### PR TITLE
feat(web): multitable UI P2-1c T1 batch-2 — close-× to MtIconButton

### DIFF
--- a/apps/web/src/multitable/components/ConditionalFormattingDialog.vue
+++ b/apps/web/src/multitable/components/ConditionalFormattingDialog.vue
@@ -4,7 +4,7 @@
       <div class="cf-dlg__header">
         <h4 class="cf-dlg__title">{{ ml('formatting.title') }}</h4>
         <span class="cf-dlg__count">{{ draftRules.length }} / {{ ruleLimit }}</span>
-        <button class="cf-dlg__close" :aria-label="ml('formatting.close')" @click="close">&times;</button>
+        <MtIconButton class="cf-dlg__close" :aria-label="ml('formatting.close')" @click="close">&times;</MtIconButton>
       </div>
       <div class="cf-dlg__body">
         <p v-if="!draftRules.length" class="cf-dlg__empty">
@@ -153,7 +153,7 @@ import {
   formattingPickColor,
   managerLabel,
 } from '../utils/meta-manager-labels'
-import { MtButton } from '../ui'
+import { MtButton, MtIconButton } from '../ui'
 
 const props = defineProps<{
   visible: boolean
@@ -398,7 +398,9 @@ function save() {
 .cf-dlg__header { display: flex; align-items: center; gap: 12px; padding: 12px 16px; border-bottom: 1px solid #eee; }
 .cf-dlg__title { flex: 1; font-size: 15px; font-weight: 600; margin: 0; }
 .cf-dlg__count { font-size: 12px; color: #666; }
-.cf-dlg__close { border: none; background: none; font-size: 20px; cursor: pointer; color: #999; padding: 0 4px; }
+/* .cf-dlg__close: now <MtIconButton> (ghost, token-styled; the &times; glyph char passes through
+   its default-slot icon fallback (size token-normalized to the icon control)). Bespoke hardcoded CSS removed
+   (UI-P2-1c T1 batch-2). Class kept on the element only for selector stability. */
 .cf-dlg__body { flex: 1; overflow-y: auto; padding: 12px 16px; display: flex; flex-direction: column; gap: 12px; }
 .cf-dlg__empty { font-size: 13px; color: #777; margin: 0; }
 .cf-dlg__rule-list { display: flex; flex-direction: column; gap: 10px; }

--- a/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
+++ b/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
@@ -4,7 +4,7 @@
       <div class="cfg-history-modal" role="dialog" :aria-label="l('record.configHistoryTitle')">
         <div class="cfg-history__header">
           <strong>{{ l('record.configHistoryTitle') }}</strong>
-          <button class="cfg-history__close" :aria-label="l('record.configHistoryClose')" @click="$emit('close')">&times;</button>
+          <MtIconButton class="cfg-history__close" :aria-label="l('record.configHistoryClose')" @click="$emit('close')">&times;</MtIconButton>
         </div>
 
         <!-- Entity-type filter (server still gates; this only narrows within what the server returned). -->
@@ -122,6 +122,7 @@ import { computed, ref } from 'vue'
 import type { MetaConfigRevision, ConfigRestoreExecuteConfirm, ConfigRestorePreview, ConfigRestoreUpdatePreview } from '../api/client'
 import { redactString } from '../utils/automation-log-redact'
 import { recordLabel, configRestoreTypedConfirm, type MetaRecordLabelKey } from '../utils/meta-record-labels'
+import { MtIconButton } from '../ui'
 
 const props = defineProps<{
   visible: boolean
@@ -407,7 +408,9 @@ function entitySummary(entityType: string, entityId: string, entityName?: string
 .cfg-history-overlay { position: fixed; inset: 0; background: rgba(15, 23, 42, 0.45); display: flex; align-items: center; justify-content: center; z-index: 1000; }
 .cfg-history-modal { position: relative; background: var(--surface, #fff); border-radius: 10px; width: min(560px, calc(100vw - 32px)); max-height: calc(100vh - 64px); display: flex; flex-direction: column; box-shadow: 0 12px 40px rgba(15, 23, 42, 0.2); }
 .cfg-history__header { display: flex; align-items: center; justify-content: space-between; padding: 14px 16px; border-bottom: 1px solid var(--border, #e2e8f0); }
-.cfg-history__close { border: none; background: none; font-size: 20px; line-height: 1; cursor: pointer; color: var(--text-secondary, #64748b); }
+/* .cfg-history__close: now <MtIconButton> (ghost, token-styled; the &times; glyph char passes through
+   its default-slot icon fallback (size token-normalized to the icon control)). Bespoke hardcoded CSS removed
+   (UI-P2-1c T1 batch-2). Class kept on the element only for selector stability. */
 .cfg-history__filters { display: flex; gap: 6px; flex-wrap: wrap; padding: 10px 16px 0; }
 .cfg-history__chip { padding: 3px 10px; border-radius: 999px; border: 1px solid var(--border, #cbd5e1); background: var(--surface, #fff); cursor: pointer; font-size: 12px; }
 .cfg-history__chip--active { background: var(--primary, #2563eb); color: #fff; border-color: var(--primary, #2563eb); }

--- a/apps/web/src/multitable/components/MetaExportDialog.vue
+++ b/apps/web/src/multitable/components/MetaExportDialog.vue
@@ -4,7 +4,7 @@
       <div class="meta-export-modal" role="dialog" :aria-label="l('export.title')">
         <div class="meta-export__header">
           <strong>{{ l('export.title') }}</strong>
-          <button class="meta-export__close" :aria-label="l('export.close')" @click="onCancel">&times;</button>
+          <MtIconButton class="meta-export__close" :aria-label="l('export.close')" @click="onCancel">&times;</MtIconButton>
         </div>
 
         <div class="meta-export__body">
@@ -86,7 +86,7 @@
 import { computed, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
 import { metaCoreLabel, selectedCount, type MetaCoreLabelKey } from '../utils/meta-core-labels'
-import { MtButton } from '../ui'
+import { MtButton, MtIconButton } from '../ui'
 
 export interface ExportColumn {
   id: string
@@ -168,8 +168,9 @@ function onCancel() {
 .meta-export-overlay { position: fixed; inset: 0; z-index: 110; background: rgba(0,0,0,.3); display: flex; align-items: center; justify-content: center; }
 .meta-export-modal { background: #fff; border-radius: 6px; min-width: 420px; max-width: 540px; box-shadow: 0 10px 40px rgba(0,0,0,.18); display: flex; flex-direction: column; max-height: 80vh; }
 .meta-export__header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid #ebedf0; }
-.meta-export__close { background: transparent; border: none; font-size: 22px; line-height: 1; cursor: pointer; color: #909399; }
-.meta-export__close:hover { color: #303133; }
+/* .meta-export__close: now <MtIconButton> (ghost, token-styled; the &times; glyph char passes through
+   its default-slot icon fallback (size token-normalized to the icon control)). Bespoke hardcoded CSS removed
+   (UI-P2-1c T1 batch-2). Class kept on the element only for selector stability. */
 .meta-export__body { padding: 16px; display: flex; flex-direction: column; gap: 16px; overflow-y: auto; }
 .meta-export__row { display: flex; flex-direction: column; gap: 6px; }
 .meta-export__row-head { display: flex; align-items: center; justify-content: space-between; }

--- a/apps/web/tests/conditional-formatting-dialog-migration.spec.ts
+++ b/apps/web/tests/conditional-formatting-dialog-migration.spec.ts
@@ -9,6 +9,16 @@ import { useLocale } from '../src/composables/useLocale'
 // AND would-be-left buttons, ALL sharers were migrated at once and the bespoke hex CSS removed — so the
 // token primitive is not double-styled. Behavior-preservation proof: they stay native, keyboard-operable
 // <button>s; :disabled bindings survive; clicking still runs the same handlers / emits the same events.
+//
+// UI-P2-1c T1 batch-2: the header close-× (`.cf-dlg__close`) was additionally migrated from a bespoke
+// <button>&times;</button> to the shared MtIconButton primitive — the &times; glyph passes through
+// MtIconButton's default-slot icon fallback (glyph char preserved, size token-normalized to the icon
+// control, consistent with the existing glyph-MtIconButton controls already on main). Behavior-
+// preservation proof: it stays a native, keyboard-operable <button>, keeps the SAME aria-label
+// (`ml('formatting.close')`), and clicking it still calls the SAME close() — including the
+// window.confirm dirty-guard (unchanged; see conditional-formatting-dialog-i18n.spec.ts for that
+// path). This is the only sharer of `.cf-dlg__close` (single button, single file) — its bespoke CSS
+// was removed outright, no double-styling risk.
 
 const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
 afterEach(() => {
@@ -46,6 +56,24 @@ describe('ConditionalFormattingDialog — MtButton migration (UI-P2-1c)', () => 
     const root = mount(baseProps(), { onClose })
     footerCancel(root).click()
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the header close-× as a native <button> (MtIconButton) keeping the class + aria-label', () => {
+    const root = mount(baseProps())
+    const btn = root.querySelector('.cf-dlg__close') as HTMLButtonElement
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('cf-dlg__close')).toBe(true)
+    expect(btn.getAttribute('aria-label')).toBe('Close')
+    expect(btn.textContent?.trim()).toBe('×') // × glyph char preserved (size token-normalized)
+  })
+
+  it('clicking the header close-× on a clean (non-dirty) dialog emits `close` (unchanged — same close() as footer cancel)', () => {
+    const onClose = vi.fn()
+    const root = mount(baseProps(), { onClose })
+    const btn = root.querySelector('.cf-dlg__close') as HTMLButtonElement
+    btn.click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
   })
 
   it('addRule → per-rule up/down/remove render as native buttons; save emits `save`; remove drops the rule', async () => {

--- a/apps/web/tests/meta-config-history-modal-migration.spec.ts
+++ b/apps/web/tests/meta-config-history-modal-migration.spec.ts
@@ -1,0 +1,68 @@
+// UI-P2-1c T1 batch-2: MetaConfigHistoryModal's header close-× (`.cfg-history__close`) was migrated
+// from a bespoke <button>&times;</button> to the shared MtIconButton primitive — the &times; glyph
+// passes through MtIconButton's default-slot icon fallback (glyph char preserved, size
+// token-normalized to the icon control, consistent with the existing glyph-MtIconButton controls
+// already on main). Behavior-preservation proof: it stays a native, keyboard-operable <button>,
+// keeps the SAME aria-label (`l('record.configHistoryClose')`), and clicking it still emits the SAME
+// `close` event with no payload (the template's `@click="$emit('close')"` is byte-identical pre/post
+// migration). This is the only sharer of `.cfg-history__close` (single button, single file) — its
+// bespoke CSS was removed outright, no double-styling risk. The dialog teleports to <body>, so
+// queries hit `document`, not the mount container (see also the existing regression coverage in
+// multitable-config-history-modal.spec.ts's 'close emits close' test, which stays green unchanged).
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App as VueApp } from 'vue'
+import MetaConfigHistoryModal from '../src/multitable/components/MetaConfigHistoryModal.vue'
+
+const mounts: Array<{ app: VueApp; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+})
+
+function mount(props: Record<string, unknown> = {}) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp(MetaConfigHistoryModal, {
+    visible: true,
+    items: [],
+    loading: false,
+    entityType: '',
+    recordLabelOf: (id: string) => id,
+    isZh: false,
+    ...props,
+  })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+
+const closeBtn = () => document.querySelector('.cfg-history__close') as HTMLButtonElement
+
+describe('MetaConfigHistoryModal — close-× MtIconButton migration (UI-P2-1c T1 batch-2)', () => {
+  it('renders the close control as a native <button> (MtIconButton) keeping the class + aria-label', () => {
+    mount()
+    const btn = closeBtn()
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('cfg-history__close')).toBe(true)
+    expect(btn.getAttribute('aria-label')).toBe('Close')
+  })
+
+  it('renders the localized (zh) aria-label unchanged', () => {
+    mount({ isZh: true })
+    expect(closeBtn().getAttribute('aria-label')).toBe('关闭')
+  })
+
+  it('renders the &times; glyph char (token-normalized size)', () => {
+    mount()
+    expect(closeBtn().textContent?.trim()).toBe('×')
+  })
+
+  it('clicking close emits `close` with no payload (unchanged from the pre-migration @click)', async () => {
+    const onClose = vi.fn()
+    mount({ onClose })
+    await nextTick()
+    closeBtn().click()
+    await nextTick()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
+  })
+})

--- a/apps/web/tests/meta-meta-export-dialog-migration.spec.ts
+++ b/apps/web/tests/meta-meta-export-dialog-migration.spec.ts
@@ -8,7 +8,16 @@ import { useLocale } from '../src/composables/useLocale'
 // preservation proof: they stay native, keyboard-operable <button>s; the `:disabled="!canExport"`
 // binding survives on confirm; and clicking them still emits the SAME `cancel` / `confirm` events
 // with the SAME payload. The dialog teleports to <body>, so queries hit `document`, not the mount
-// container. The close-× glyph and the select-all / clear-all link buttons stay bespoke (untouched).
+// container. The select-all / clear-all link buttons stay bespoke (untouched — a separate PR's territory).
+//
+// UI-P2-1c T1 batch-2: the header close-× (`.meta-export__close`) was additionally migrated from a
+// bespoke <button>&times;</button> to the shared MtIconButton primitive — the &times; glyph passes
+// through MtIconButton's default-slot icon fallback (glyph char preserved, size token-normalized to
+// the icon control, consistent with the existing glyph-MtIconButton controls already on main).
+// Behavior-preservation proof: it stays a native, keyboard-operable <button>, keeps the SAME
+// aria-label (`l('export.close')`), and clicking it still calls the SAME onCancel() → emits `cancel`
+// (identical to the footer cancel button's handler). This is the only sharer of `.meta-export__close`
+// (single button, single file) — its bespoke CSS was removed outright, no double-styling risk.
 
 const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
 afterEach(() => {
@@ -73,5 +82,23 @@ describe('MetaExportDialog — MtButton migration (UI-P2-1c)', () => {
     confirmBtn().click()
     expect(onConfirm).toHaveBeenCalledTimes(1)
     expect(onConfirm).toHaveBeenCalledWith({ fieldIds: ['f1', 'f2'], rowScope: 'all', format: 'csv' })
+  })
+
+  it('renders the header close-× as a native <button> (MtIconButton) keeping the class + aria-label', () => {
+    mount(baseProps())
+    const btn = document.querySelector('.meta-export__close') as HTMLButtonElement
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('meta-export__close')).toBe(true)
+    expect(btn.getAttribute('aria-label')).toBe('Close')
+    expect(btn.textContent?.trim()).toBe('×') // × glyph char preserved (size token-normalized)
+  })
+
+  it('clicking the header close-× emits `cancel` (unchanged — same onCancel as the footer cancel button)', () => {
+    const onCancel = vi.fn()
+    mount(baseProps(), { onCancel })
+    const btn = document.querySelector('.meta-export__close') as HTMLButtonElement
+    btn.click()
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onCancel).toHaveBeenCalledWith()
   })
 })


### PR DESCRIPTION
## Summary
Continues the RATIFIED T1 close-× → MtIconButton migration (docs/development/multitable-ui-p2-1c-tail-resolution-designlock-20260707.md §2-T1), following batch-1 (#4130). Migrates 3 more header close-× buttons from bespoke `<button>&times;</button>` to the shared `MtIconButton` primitive:

- `MetaExportDialog.vue` (`.meta-export__close`)
- `MetaConfigHistoryModal.vue` (`.cfg-history__close`)
- `ConditionalFormattingDialog.vue` (`.cf-dlg__close`)

**Wording note (batch-1's gate lesson):** MtIconButton normalizes the × glyph to the icon-token size (14px) inside a control-height square — growing each header ~12px. This is **token-normalized**, not "zero visual change." It matches the glyph-MtIconButton look already on main (batch-1's three close-× migrations; batch6 #4099's Calendar ‹/› nav, BasePicker +).

Each `__close` class is the sole sharer within its file, so the bespoke CSS is removed outright (no double-styling risk); the class stays on the element for selector stability. `@click`/emit/`aria-label` are byte-equivalent to pre-migration.

**Scope guard:** `MetaExportDialog`'s select-all/clear-all link buttons (`.meta-export__link`) are untouched — that's PR #4131 (T3)'s territory; no overlap with this diff.

## Test plan
- [x] `meta-meta-export-dialog-migration.spec.ts` extended (already had cancel/confirm→MtButton coverage) + `multitable-export-dialog.spec.ts` (existing regression) — both mutation-red confirmed on a neutered `@click`
- [x] `conditional-formatting-dialog-migration.spec.ts` extended (already had six-button MtButton coverage) + `conditional-formatting-dialog-i18n.spec.ts` (existing regression, including the `[aria-label]` count assertion at 50) — both mutation-red confirmed
- [x] `meta-config-history-modal-migration.spec.ts` new + existing `multitable-config-history-modal.spec.ts` "close emits close" regression — both mutation-red confirmed
- [x] `vue-tsc -b` clean
- [x] no new hardcoded hex
- [x] full-suite sweep across 245 multitable/meta/conditional-formatting spec files: identical pre-existing 95-test/12-file failure set (`multitable-workbench-view.spec.ts`, `multitable-phase11.spec.ts`, etc. — unrelated to close-× buttons, confirmed present on baseline before this change too) — zero new regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)