### PR TITLE
fix(attendance): output-side containment for import upload paths (defense-in-depth, refs #3925)

### DIFF
--- a/packages/core-backend/tests/unit/attendance-import-upload-path-containment.test.ts
+++ b/packages/core-backend/tests/unit/attendance-import-upload-path-containment.test.ts
@@ -1,0 +1,64 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Post-closeout P3 defense-in-depth (2026-07-11): the attendance import upload path builder now applies
+// output-side containment (resolveImportUploadWithinBase) behind the existing isUuidLike/org-sanitizer
+// input gates. These tests exercise the REAL production getImportUploadPaths via the plugin's test seam
+// (not a reimplementation) — an interpolated key that resolves outside the base must throw, never escape.
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const { getImportUploadPaths, resolveImportUploadWithinBase, sanitizeImportUploadOrgId } =
+  attendancePlugin.__attendanceImportPathForTests
+
+const VALID_UUID = '11111111-1111-4111-8111-111111111111'
+
+describe('attendance import upload path containment (output-side backstop)', () => {
+  describe('resolveImportUploadWithinBase (the containment primitive)', () => {
+    it('rejects traversal / absolute / empty keys', () => {
+      expect(() => resolveImportUploadWithinBase('/srv/base', '../evil.csv')).toThrow(/outside the base/)
+      expect(() => resolveImportUploadWithinBase('/srv/base', '../../etc/passwd')).toThrow(/outside the base/)
+      expect(() => resolveImportUploadWithinBase('/srv/base', '/etc/passwd')).toThrow(/outside the base/)
+      // resolves to the base itself → rejected (never operate on the base dir as if it were a file)
+      expect(() => resolveImportUploadWithinBase('/srv/base', '')).toThrow(/outside the base/)
+    })
+
+    it('allows keys contained within the base', () => {
+      expect(resolveImportUploadWithinBase('/srv/base', 'file.csv')).toBe(path.resolve('/srv/base', 'file.csv'))
+      expect(resolveImportUploadWithinBase('/srv/base', 'sub/file.csv')).toBe(path.resolve('/srv/base', 'sub/file.csv'))
+    })
+  })
+
+  describe('getImportUploadPaths (the real production path builder)', () => {
+    it('throws on a traversal fileId — backstop if a future caller skips the uuid gate', () => {
+      expect(() => getImportUploadPaths({ orgId: 'org1', fileId: '../../../../etc/passwd' })).toThrow(
+        /outside the base/,
+      )
+      expect(() => getImportUploadPaths({ orgId: 'org1', fileId: '../secret' })).toThrow(/outside the base/)
+    })
+
+    it('sanitizes a traversal orgId so the path cannot escape', () => {
+      const { csvPath, dir } = getImportUploadPaths({ orgId: '../../evil', fileId: VALID_UUID })
+      expect(csvPath).not.toContain('..')
+      expect(dir).not.toContain('..')
+      // org sanitizer collapses non-[A-Za-z0-9_-] to '_', so the traversal becomes a plain child dir name
+      expect(csvPath.startsWith(dir + path.sep)).toBe(true)
+    })
+
+    it('builds the expected contained path for a valid uuid (no regression)', () => {
+      const { csvPath, metaPath, dir } = getImportUploadPaths({ orgId: 'org1', fileId: VALID_UUID })
+      expect(csvPath).toBe(path.join(dir, `${VALID_UUID}.csv`))
+      expect(metaPath).toBe(path.join(dir, `${VALID_UUID}.json`))
+      expect(csvPath.startsWith(dir + path.sep)).toBe(true)
+    })
+  })
+
+  describe('sanitizeImportUploadOrgId', () => {
+    it('collapses traversal / separators and falls back to default', () => {
+      expect(sanitizeImportUploadOrgId('../../evil')).not.toContain('.')
+      expect(sanitizeImportUploadOrgId('a/b')).toBe('a_b')
+      expect(sanitizeImportUploadOrgId('')).toBe('default')
+      expect(sanitizeImportUploadOrgId(null)).toBe('default')
+    })
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -5932,6 +5932,40 @@ class HttpError extends Error {
   }
 }
 
+// Attendance import upload path containment (post-closeout P3 defense-in-depth, 2026-07-11).
+// Output-side containment mirroring core StorageService.resolveWithinBase, layered behind the existing
+// isUuidLike(fileId) + sanitizeImportUploadOrgId(orgId) input gates: even if a future caller builds a path
+// without the uuid gate, an interpolated key that resolves outside the base throws instead of escaping the
+// upload root. Hardens both the upload endpoints and the cleanupExpiredImportUploads sweep (both delegate
+// to getImportUploadPaths). Module-scope + hoisted so the deletion/read call sites and the test seam share
+// one implementation.
+function resolveImportUploadWithinBase(baseDir, relativeKey) {
+  const base = path.resolve(baseDir)
+  const resolved = path.resolve(base, relativeKey)
+  if (resolved !== base && resolved.startsWith(base + path.sep)) return resolved
+  throw new HttpError(400, 'VALIDATION_ERROR', 'Import upload path resolves outside the base directory')
+}
+
+function getImportUploadBaseDir() {
+  return String(process.env.ATTENDANCE_IMPORT_UPLOAD_DIR || path.join(process.cwd(), 'uploads', 'attendance-import'))
+}
+
+function sanitizeImportUploadOrgId(orgId) {
+  const raw = typeof orgId === 'string' && orgId.trim() ? orgId.trim() : DEFAULT_ORG_ID
+  const safe = raw.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64)
+  return safe || DEFAULT_ORG_ID
+}
+
+function getImportUploadPaths({ orgId, fileId }) {
+  const safeOrgId = sanitizeImportUploadOrgId(orgId)
+  const dir = resolveImportUploadWithinBase(getImportUploadBaseDir(), safeOrgId)
+  return {
+    dir,
+    csvPath: resolveImportUploadWithinBase(dir, `${fileId}.csv`),
+    metaPath: resolveImportUploadWithinBase(dir, `${fileId}.json`),
+  }
+}
+
 function formatZodValidationDetails(error) {
   const issues = Array.isArray(error?.issues) ? error.issues : []
   return issues.map((issue) => ({
@@ -20754,6 +20788,11 @@ module.exports = {
     collectRowUserIdentityValues,
     resolveRowUserId,
   },
+  __attendanceImportPathForTests: {
+    getImportUploadPaths,
+    resolveImportUploadWithinBase,
+    sanitizeImportUploadOrgId,
+  },
   __attendanceImportCsvHeaderForTests: {
     detectCsvHeaderIndex,
     detectCsvHeaderRowIndexFromFile,
@@ -22651,21 +22690,9 @@ module.exports = {
 		      return Math.max(1, Math.floor(raw))
 		    })()
 
-		    const sanitizeImportUploadOrgId = (orgId) => {
-		      const raw = typeof orgId === 'string' && orgId.trim() ? orgId.trim() : DEFAULT_ORG_ID
-		      const safe = raw.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64)
-		      return safe || DEFAULT_ORG_ID
-		    }
-
-		    const getImportUploadPaths = ({ orgId, fileId }) => {
-		      const safeOrgId = sanitizeImportUploadOrgId(orgId)
-		      const dir = path.join(ATTENDANCE_IMPORT_UPLOAD_DIR, safeOrgId)
-		      return {
-		        dir,
-		        csvPath: path.join(dir, `${fileId}.csv`),
-		        metaPath: path.join(dir, `${fileId}.json`),
-		      }
-		    }
+		    // sanitizeImportUploadOrgId + getImportUploadPaths moved to module scope (import-path containment,
+		    // 2026-07-11): the module-scope getImportUploadPaths now routes every path through
+		    // resolveImportUploadWithinBase, so these call sites (and the test seam) share one contained impl.
 
 		    const isUuidLike = (value) => {
 		      if (typeof value !== 'string') return false


### PR DESCRIPTION
存储完整性线收官后 security-class sweep 的**唯一 P3**（owner 同意修）。**非权限层、防呆、非 live vuln。**

## 根因（防呆缺口）
`getImportUploadPaths` 用 `path.join(dir, ${fileId}.csv/.json)` 拼路径——**当前安全**（每个调用点前置 `isUuidLike(fileId)` + `sanitizeImportUploadOrgId(orgId)`），但**无输出侧兜底**：若未来新增调用点忘了 uuid gate，`../` fileId 会逃逸 upload root。（F3/F10 是输出侧 `resolveWithinBase`；本刀把考勤 import 也拉到同一底座。）

## 修法
- module scope 新增 `resolveImportUploadWithinBase(base,key)`（逐字 mirror 核心 `StorageService.resolveWithinBase`：解析后 startsWith(base+sep) 否则 throw）。
- `getImportUploadPaths` 的 dir/csvPath/metaPath 全过它。
- **把 path builder + sanitizer 上提到 module scope**，让**生产函数与测试 seam 共用同一 contained 实现**（避免 test/prod 分叉 = F10 教训）。
- 同时硬化 **upload endpoints 与 cleanup sweep 两条**删除/读路径（都经 getImportUploadPaths）。

## 测试（测真实 production getImportUploadPaths，非 reimpl）
新增 `attendance-import-upload-path-containment.test.ts`：经 `__attendanceImportPathForTests` 调**真实** getImportUploadPaths，traversal fileId/orgId → throw / sanitized；正路径不回归；helper 直测。
本地：`node --check` 通过；算法 + mutation smoke 11/11（mutation 还原 path.join → traversal 不再 throw = 守卫 load-bearing）。**真实 .test.ts 由 opus 闸 + CI 跑**（worktree 无独立 pnpm deps，本地 vitest 受阻，非代码问题）。

## 边界
只改 `plugins/plugin-attendance/index.cjs` + 新测。不碰鉴权/core/F4/tracker。无迁移。refs #3925，**不合并前过 opus 安全闸 + owner 复核**。