### PR TITLE
fix(attendance): guard empty regression worker queue

### DIFF
--- a/scripts/ops/attendance-fast-parallel-regression.sh
+++ b/scripts/ops/attendance-fast-parallel-regression.sh
@@ -133,11 +133,14 @@ for index in "${!CHECK_NAMES[@]}"; do
   fi
 done
 
-for pid in "${ACTIVE_PIDS[@]}"; do
-  if [[ -n "$pid" ]]; then
-    wait "$pid" || true
-  fi
-done
+# Bash 3.2 treats an empty array expansion as unbound under `set -u`.
+if (( ${#ACTIVE_PIDS[@]} > 0 )); then
+  for pid in "${ACTIVE_PIDS[@]}"; do
+    if [[ -n "$pid" ]]; then
+      wait "$pid" || true
+    fi
+  done
+fi
 
 for index in "${!CHECK_RESULT_FILES[@]}"; do
   result_file="${CHECK_RESULT_FILES[$index]}"


### PR DESCRIPTION
## What

- guard the final active-worker array expansion when the queue has drained completely
- preserve the existing wait behavior whenever worker PIDs remain

## Why

macOS Bash 3.2 treats an empty array expansion as an unbound variable under set -u. With PROFILE=contracts and MAX_PARALLEL=1, each worker is drained inside the launch loop, so the final wait loop expanded an empty ACTIVE_PIDS array and exited before writing summary.json.

The same focused test failed 3/4 on current main before this patch.

## Verification

- attendance-fast-parallel-regression.test.mjs: 4/4 PASS (baseline was 3/4)
- all scripts/ops/attendance-*.test.mjs: 122/122 PASS
- bash -n: PASS
- git diff --check: PASS

No runtime deployment or workflow dispatch was performed.
