### PR TITLE
fix(approval): P1-1 review P3s — precise lock-waiter correlation + strict-binding contract comments

### DIFF
--- a/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
+++ b/packages/core-backend/src/integrations/dingtalk/approval-card-deliveries.ts
@@ -244,10 +244,16 @@ export async function markDingTalkApprovalCardDeliverySendOutcomeUnknown(
  * delivery that triggered the transition (it is claimed `acted` separately). Returns the swept ids.
  *
  * Review P2-1: a card whose (node_key, recipient) STILL has an active `approval_assignments` seat
- * MUST NOT be superseded — otherwise approving branch A of a `joinMode:'all'` parallel fork would
- * false-stale branch B's legitimately-live card. The `NOT EXISTS` clause keeps this sweep in exact
- * agreement with the wrapper's read-time active-assignment binding: a card is superseded iff no
- * live seat matches it.
+ * MUST NOT be superseded. The `NOT EXISTS` clause keeps this sweep in exact agreement with the
+ * STRICT card→round binding (the wrapper pre-read AND the engine's authoritative in-txn guard): a
+ * card is superseded iff no live seat matches it — the sweep never retires a card the binding would
+ * still honour, and never revives one it would not.
+ *
+ * (The original motivation was a `joinMode:'all'` parallel fork false-stale'ing a sibling branch's
+ * live card. That exact topology is in fact foreclosed twice over — template validation rejects the
+ * same user on two branches, and the per-instance active-seat unique index forbids a second live
+ * seat for one assignee — so a recipient is live on at most one branch. The clause stays regardless:
+ * it is the invariant, not the workaround.)
  */
 export async function supersedeDingTalkApprovalCardDeliveriesForInstance(
   query: QueryFn,

--- a/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
+++ b/packages/core-backend/src/services/ApprovalCardDeliveryAction.ts
@@ -16,12 +16,21 @@
  *   delivered, and a valid HMAC deep-link token is itself proof of delivery, so the ledger's
  *   send-time uncertainty must not make a delivered card inoperable. pending/failed stay stale.)
  * - P1-1 stale-card binding: actionability ADDITIONALLY requires a LIVE active `approval_assignments`
- *   row still matching the delivery's node_key + recipient (+ entry_epoch when the delivery carries
- *   one). A card issued for node-1 must NOT approve node-2 after the instance advances (node-1's
- *   assignment is deactivated → no match), nor re-approve the SAME node after a loop-back (a fresh
- *   epoch on the new active assignment fails the old card's epoch match). The read-time binding is the
- *   authoritative guard and stands alone even if the supersede sweep never runs; a NULL delivery
- *   epoch (legacy) skips only the epoch clause and stays closed on the node/assignee match.
+ *   row still matching the delivery's node_key + recipient + entry_epoch. A card issued for node-1
+ *   must NOT approve node-2 after the instance advances (node-1's assignment is deactivated → no
+ *   match), nor re-approve the SAME node after a loop-back (a fresh epoch on the new active
+ *   assignment fails the old card's epoch match).
+ *
+ *   STRICT, fail-closed (P1-1 re-review): the delivery MUST carry a NON-NULL entry_epoch equal to a
+ *   NON-NULL live-seat epoch. There is NO null-pass arm — a NULL delivery epoch is never actionable,
+ *   and pre-column legacy cards are SUPERSEDED outright at migrate time (their original round cannot
+ *   be proven, so it is never inferred).
+ *
+ *   The binding below is a read-time PRE-READ (fast-fail + honest UI state); it is NOT the authority.
+ *   The authoritative guard is re-validated inside `ApprovalProductService.dispatchAction`'s instance
+ *   `FOR UPDATE` transaction, because this pre-read runs OUTSIDE that lock and a concurrent advance
+ *   can slip a stale card past it (the TOCTOU the re-review closed). Never weaken the in-txn guard on
+ *   the strength of this one.
  */
 import { createHmac, timingSafeEqual } from 'crypto'
 
@@ -110,9 +119,13 @@ interface InstanceSummaryRow {
   policy_snapshot: unknown
   /**
    * P1-1: TRUE iff an ACTIVE `approval_assignments` row still matches the delivery's node +
-   * recipient (+ epoch when the delivery carries one). This is the authoritative stale-card guard —
-   * see `buildSummary`. Computed in the same round-trip as the instance read so `actionable`
-   * reflects live assignment state, never just the instance status.
+   * recipient + epoch (STRICT: a NON-NULL delivery epoch equal to a NON-NULL live-seat epoch; a
+   * NULL-epoch delivery never matches). Computed in the same round-trip as the instance read so
+   * `actionable` reflects live assignment state, never just the instance status.
+   *
+   * This is the read-time PRE-READ, NOT the authoritative guard — it runs outside the engine's
+   * instance lock, so a concurrent advance can race it. The authority is the in-txn card→round
+   * binding inside `ApprovalProductService.dispatchAction`'s `FOR UPDATE` txn. See `buildSummary`.
    */
   has_active_assignment: boolean
 }

--- a/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-card-delivery-wrapper.db.test.ts
@@ -45,25 +45,32 @@ const q = (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlTe
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
 /**
- * Block until a backend is genuinely WAITING on the instance row lock (wait_event_type='Lock' on the
- * `approval_instances … FOR UPDATE`) — the deterministic proof that the concurrent dispatchAction is
- * parked behind the held lock, NOT a timer. Throws if it never blocks so the interleaving golden can
- * never silently degrade into the sequential case (a vacuous green).
+ * Block until a backend is genuinely WAITING on the instance row lock held by THIS test — the
+ * deterministic proof that the concurrent dispatchAction is parked behind our lock, NOT a timer.
+ * Throws if it never blocks, so the interleaving golden can never silently degrade into the
+ * sequential case (a vacuous green).
+ *
+ * Review P3: correlate the waiter to OUR holder via `pg_blocking_pids(pid)` rather than merely
+ * matching "some backend is blocked on some approval_instances FOR UPDATE". The integration suite
+ * shares one database, so an unrelated test's lock waiter could otherwise satisfy a text-match-only
+ * probe and let this golden pass without our interleaving ever happening.
  */
-async function waitUntilBlockedOnInstanceLock(timeoutMs = 5000): Promise<void> {
+async function waitUntilBlockedOnInstanceLock(blockerPid: number, timeoutMs = 5000): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     const r = await q(
       `SELECT COUNT(*)::int AS c FROM pg_stat_activity
         WHERE datname = current_database()
           AND wait_event_type = 'Lock'
+          AND $1 = ANY(pg_blocking_pids(pid))
           AND query ILIKE '%approval_instances%'
           AND query ILIKE '%for update%'`,
+      [blockerPid],
     )
     if ((r.rows[0] as { c: number }).c >= 1) return
     await sleep(25)
   }
-  throw new Error('concurrent dispatchAction never blocked on the instance row lock — interleaving did not occur')
+  throw new Error('concurrent dispatchAction never blocked on the instance row lock HELD BY THIS TEST — interleaving did not occur')
 }
 
 let approvals: ApprovalProductService
@@ -727,6 +734,9 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
       // A: take and HOLD the instance row lock (same row dispatchAction locks FOR UPDATE).
       await hold.query('BEGIN')
       await hold.query(`SELECT id FROM approval_instances WHERE id = $1 AND COALESCE(source_system, 'platform') = 'platform' FOR UPDATE`, [instanceId])
+      // Our holder's backend pid — the waiter probe correlates against THIS pid (review P3), so a
+      // foreign lock waiter in the shared test DB can never satisfy the interleaving proof for us.
+      const holdPid = Number((await hold.query('SELECT pg_backend_pid() AS pid')).rows[0].pid)
 
       // B: the stale node1 card driven directly into dispatchAction — it must block on B's own FOR UPDATE.
       let bSettled = false
@@ -739,8 +749,9 @@ describeIfDatabase('A-4 card-delivery wrapper (real DB)', () => {
         .then((v) => { bSettled = true; return v }, (e) => { bSettled = true; throw e })
       bStarted = true
 
-      // Deterministic proof B is parked behind the lock (not a timer): wait for wait_event_type='Lock'.
-      await waitUntilBlockedOnInstanceLock()
+      // Deterministic proof B is parked behind OUR lock (not a timer, not a foreign waiter):
+      // wait_event_type='Lock' AND our holder's pid is among B's pg_blocking_pids.
+      await waitUntilBlockedOnInstanceLock(holdPid)
       expect(bSettled).toBe(false) // B cannot have resolved while A holds the lock
 
       // A advances N1→N2 IN-TXN (deactivate node1 seat, mint the node2 seat at a fresh epoch, move the


### PR DESCRIPTION
Closes the two **non-blocking P3s** the owner raised in the #4112 APPROVE/GO review.

## P3-a — lock-waiter probe was too loose (test precision)
`waitUntilBlockedOnInstanceLock` matched *any* backend blocked on *any* `approval_instances … FOR UPDATE`. The integration suite shares one database, so an unrelated test's lock waiter could satisfy the probe and let the TOCTOU interleaving golden pass **without our interleaving ever happening** — a vacuous green.

Now correlates the waiter to **our** holder: `$1 = ANY(pg_blocking_pids(pid))`, using the holding connection's `pg_backend_pid()`.

**Mutation-verified:** correlating against a non-holder pid turns the golden **RED** (`never blocked … HELD BY THIS TEST`) — the pid clause is load-bearing, not decorative.

## P3-b — three stale contract comments
They still described the deleted permissive NULL dual-read, and mis-named the read-time pre-read as *the authority*:
- `ApprovalCardDeliveryAction.ts` top-of-file contract
- `InstanceSummaryRow.has_active_assignment`
- `supersedeDingTalkApprovalCardDeliveriesForInstance`

All now state the truth: **STRICT non-null epoch equality** (no null-pass arm; a NULL-epoch card is never actionable, and legacy pre-column cards are *superseded* at migrate time), and the read-time binding is a **PRE-READ** — the authority is the in-txn card→round guard inside `dispatchAction`'s `FOR UPDATE` txn, because the pre-read runs outside that lock and a concurrent advance can race it.

The supersede helper's parallel-fork rationale is corrected too: that topology is foreclosed twice over (template validation rejects the same user on two branches; the per-instance active-seat unique index forbids a second live seat), so a recipient is live on at most one branch. The `NOT EXISTS` clause stays — it is the invariant, not the workaround.

## Verification
- wrapper real-DB suite **21/21** (incl. the interleaving golden with the tightened probe)
- `tsc --noEmit` clean
- **Zero runtime behaviour change** — comments + one test probe.

Stream flag stays OFF; U1–U13 UAT and production enablement unchanged.