### PR TITLE
test(core-backend): harden optional startup dependency exemptions

### DIFF
--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -65,6 +65,7 @@
     "sanitize-html": "^2.13.0",
     "semver": "^7.7.3",
     "socket.io": "^4.6.1",
+    "uuid": "^9.0.1",
     "winston": "^3.17.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "xml2js": "^0.6.2",
@@ -88,7 +89,6 @@
     "supertest": "^7.2.2",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
-    "uuid": "^9.0.1",
     "vitest": "^1.1.0"
   }
 }

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -44,6 +44,7 @@
     "dingtalk-stream": "^2.1.5",
     "eventemitter3": "^5.0.1",
     "express": "^4.18.2",
+    "express-validator": "^7.2.1",
     "geoip-lite": "^1.4.10",
     "glob": "^10.3.10",
     "ioredis": "^5.3.0",

--- a/packages/core-backend/src/middleware/validation.ts
+++ b/packages/core-backend/src/middleware/validation.ts
@@ -19,27 +19,30 @@ interface Result {
   array(): ValidationError[]
 }
 
-// Dynamic import for optional express-validator
-let validationResult: ((req: Request) => Result) | null = null
-
+// express-validator is a declared PRODUCTION dependency and request validation is a security
+// control — load it FAIL-CLOSED (#4126 review). The previous try/catch fallback left
+// `validationResult` null when the module was absent and `validate` then called next() unchecked,
+// so every declarative chain on the workflow / workflow-designer / PLM routes was silently
+// disabled. A missing module is now a loud boot failure, never a silent open door.
+let validationResult: (req: Request) => Result
 try {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
   const expressValidator = require('express-validator')
   validationResult = expressValidator.validationResult
-} catch {
-  // express-validator not installed - validation will be skipped
+  if (typeof validationResult !== 'function') {
+    throw new Error('express-validator did not expose validationResult')
+  }
+} catch (error) {
+  throw new Error(
+    'express-validator is a required production dependency (request validation must never silently ' +
+      `degrade to pass-through). Install dependencies and retry. Underlying: ${(error as Error)?.message ?? 'unknown'}`
+  )
 }
 
 /**
  * Validation middleware that checks for express-validator errors
  */
 export const validate = (req: Request, res: Response, next: NextFunction) => {
-  if (!validationResult) {
-    // express-validator not installed, skip validation
-    next()
-    return
-  }
-
   const errors = validationResult(req)
   if (!errors.isEmpty()) {
     return res.status(400).json({

--- a/packages/core-backend/src/types/validator.ts
+++ b/packages/core-backend/src/types/validator.ts
@@ -49,31 +49,45 @@ export function createNoOpValidator(): ValidatorChain {
 }
 
 /**
- * Load express-validator or return no-op validators
+ * Load express-validator. FAIL-CLOSED (#4126 review): express-validator is a declared PRODUCTION
+ * dependency, and the declarative validation chains on the workflow / workflow-designer / PLM
+ * routes are a security control. The previous no-op fallback silently disabled every one of those
+ * chains when the module was absent — and the module was never declared anywhere, so validation was
+ * fail-OPEN in every environment. A missing module is now a loud boot failure, never a silent
+ * downgrade to "no validation".
  */
 export function loadValidators(): {
   body: ValidatorFunction
   param: ValidatorFunction
   query: ValidatorFunction
 } {
+  let validator: {
+    body: ValidatorFunction
+    param: ValidatorFunction
+    query: ValidatorFunction
+  }
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-    const validator = require('express-validator') as {
-      body: ValidatorFunction
-      param: ValidatorFunction
-      query: ValidatorFunction
-    }
-    return {
-      body: validator.body,
-      param: validator.param,
-      query: validator.query
-    }
-  } catch {
-    // express-validator not installed, use no-op validators
-    return {
-      body: () => createNoOpValidator(),
-      param: () => createNoOpValidator(),
-      query: () => createNoOpValidator()
-    }
+    validator = require('express-validator')
+  } catch (error) {
+    throw new Error(
+      'express-validator is a required production dependency (declarative request validation is a ' +
+        'security control and must never silently degrade to no-op). Install dependencies and retry. ' +
+        `Underlying: ${(error as Error)?.message ?? 'unknown'}`
+    )
+  }
+  if (
+    typeof validator?.body !== 'function' ||
+    typeof validator?.param !== 'function' ||
+    typeof validator?.query !== 'function'
+  ) {
+    throw new Error(
+      'express-validator did not expose body/param/query — refusing to start with unvalidated routes'
+    )
+  }
+  return {
+    body: validator.body,
+    param: validator.param,
+    query: validator.query
   }
 }

--- a/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
+++ b/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
@@ -11,11 +11,14 @@ import { describe, expect, it } from 'vitest'
 // crashes on boot (uuid was declared only in core-backend devDependencies while WorkflowDesigner /
 // BPMNWorkflowEngine / DelayService import it at module load).
 //
-// This guard statically BFS-walks the real startup graph from `src/index.ts`, following relative
-// imports, and asserts every external top-level import resolves to a prod dependency of either
-// core-backend or the workspace root (hoisting reality). Lazy `require()` / `await import()` inside
-// functions (the optional adapters: mongodb, aws-sdk, @opentelemetry, …) are NOT eager, are NOT in
-// the startup graph, and are correctly not flagged — so the check is precise, not a blanket sweep.
+// This guard statically BFS-walks the startup graph from `src/index.ts`, following every STATIC
+// edge — `import … from`, side-effect `import '…'`, and `export … from` barrel re-exports, each
+// single- or multi-line, with comments stripped — and asserts every external eager import resolves
+// to a prod dependency of either core-backend or the workspace root (hoisting reality). Lazy
+// `require()` / `await import()` inside functions (the optional adapters: mongodb, aws-sdk,
+// @opentelemetry, …) are NOT eager, are NOT in the graph, and are correctly not flagged — so the
+// check is precise, not a blanket sweep. A file-count floor guards against a parser regression
+// silently shrinking the walk.
 
 const CORE_BACKEND = path.resolve(__dirname, '..', '..')
 const REPO_ROOT = path.resolve(CORE_BACKEND, '..', '..')
@@ -58,8 +61,34 @@ function rootModule(spec: string): string {
   return spec.startsWith('@') ? spec.split('/').slice(0, 2).join('/') : spec.split('/')[0]
 }
 
+// Strip block + line comments so commented-out imports never match. (String literals containing
+// import-like text are vanishingly rare for module specifiers and not a real false-source here.)
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1')
+}
+
+// Every static module specifier that makes a file part of the EAGER graph:
+//   - `import … from '…'`      (default / named / namespace, single- or multi-line)
+//   - `import '…'`             (side-effect)
+//   - `export … from '…'`      (barrel re-export — pulls the target in at load)
+// excluding the type-only forms (`import type …` / `export type …`, erased at compile time) and the
+// lazy forms (`import('…')` / `require('…')` — those live inside functions and are NOT eager).
+function* staticSpecifiers(source: string): Generator<string> {
+  const clean = stripComments(source)
+  // `s` flag: the clause may span newlines (multi-line import/export blocks).
+  const importFrom = /\bimport\s+(?!type[\s{])[^;'"]*?\bfrom\s*['"]([^'"]+)['"]/gs
+  const exportFrom = /\bexport\s+(?!type[\s{])[^;'"]*?\bfrom\s*['"]([^'"]+)['"]/gs
+  const sideEffect = /\bimport\s+['"]([^'"]+)['"]/g
+  for (const re of [importFrom, exportFrom, sideEffect]) {
+    let m: RegExpExecArray | null
+    while ((m = re.exec(clean)) !== null) yield m[1]
+  }
+}
+
 // BFS the eager startup import graph; return external top-level modules mapped to an example file.
-function collectStartupExternals(): Map<string, string> {
+function collectStartupExternals(): { externals: Map<string, string>; filesVisited: number } {
   const seen = new Set<string>()
   const externals = new Map<string, string>()
   const queue: string[] = [ENTRY]
@@ -67,11 +96,7 @@ function collectStartupExternals(): Map<string, string> {
     const file = queue.shift()!
     if (seen.has(file) || !existsSync(file)) continue
     seen.add(file)
-    for (const line of readFileSync(file, 'utf8').split('\n')) {
-      // Top-level static import only (column 0), excluding `import type …`.
-      const match = line.match(/^import\s+(?!type[\s{])(?:[^'"]*\sfrom\s+)?['"]([^'"]+)['"]/)
-      if (!match) continue
-      const spec = match[1]
+    for (const spec of staticSpecifiers(readFileSync(file, 'utf8'))) {
       if (spec.startsWith('.')) {
         const resolved = resolveRelative(file, spec)
         if (resolved) queue.push(resolved)
@@ -83,13 +108,16 @@ function collectStartupExternals(): Map<string, string> {
       if (!externals.has(mod)) externals.set(mod, path.relative(CORE_BACKEND, file))
     }
   }
-  return externals
+  return { externals, filesVisited: seen.size }
 }
 
 describe('runtime dependency classification (production-install startup contract)', () => {
   it('every eagerly-imported external module in the startup graph is a production dependency', () => {
     const prod = prodDependencyNames()
-    const externals = collectStartupExternals()
+    const { externals, filesVisited } = collectStartupExternals()
+    // Guard against silent coverage collapse: the eager startup graph is a few hundred files; if a
+    // parser regression makes the walk visit almost nothing the "0 missing" result is meaningless.
+    expect(filesVisited).toBeGreaterThan(150)
     const missing = [...externals.entries()]
       .filter(([mod]) => !prod.has(mod))
       .map(([mod, file]) => `${mod} (eager import e.g. ${file})`)

--- a/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
+++ b/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync } from 'fs'
 import path from 'path'
+import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 
 // Production-install startup contract (#3751 corrective-6, entity-machine failureClass=
@@ -11,14 +12,16 @@ import { describe, expect, it } from 'vitest'
 // crashes on boot (uuid was declared only in core-backend devDependencies while WorkflowDesigner /
 // BPMNWorkflowEngine / DelayService import it at module load).
 //
-// This guard statically BFS-walks the startup graph from `src/index.ts`, following every STATIC
-// edge — `import … from`, side-effect `import '…'`, and `export … from` barrel re-exports, each
-// single- or multi-line, with comments stripped — and asserts every external eager import resolves
-// to a prod dependency of either core-backend or the workspace root (hoisting reality). Lazy
-// `require()` / `await import()` inside functions (the optional adapters: mongodb, aws-sdk,
-// @opentelemetry, …) are NOT eager, are NOT in the graph, and are correctly not flagged — so the
-// check is precise, not a blanket sweep. A file-count floor guards against a parser regression
-// silently shrinking the walk.
+// This guard BFS-walks the startup graph from `src/index.ts` using the TypeScript AST (not regex):
+// each file is parsed and its top-level `ImportDeclaration` / `ExportDeclaration` (re-export) nodes
+// are read, skipping the type-only forms (`import type` / `export type`, erased at compile time).
+// Every external eager import must resolve to a prod dependency of core-backend or the workspace
+// root (hoisting reality). Lazy `require()` / `await import()` inside functions (the optional
+// adapters: mongodb, aws-sdk, @opentelemetry, …) are call expressions, NOT declarations, so the AST
+// never treats them as eager — the check is precise, not a blanket sweep. The AST handles
+// single-line, multi-line, default/named/namespace, side-effect, and barrel re-export forms
+// uniformly, so there is no line-based blind spot. A file-count floor + an explicit
+// multi-line-edge regression test guard against a traversal regression.
 
 const CORE_BACKEND = path.resolve(__dirname, '..', '..')
 const REPO_ROOT = path.resolve(CORE_BACKEND, '..', '..')
@@ -61,42 +64,48 @@ function rootModule(spec: string): string {
   return spec.startsWith('@') ? spec.split('/').slice(0, 2).join('/') : spec.split('/')[0]
 }
 
-// Strip block + line comments so commented-out imports never match. (String literals containing
-// import-like text are vanishingly rare for module specifiers and not a real false-source here.)
-function stripComments(source: string): string {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/(^|[^:])\/\/[^\n]*/g, '$1')
-}
-
-// Every static module specifier that makes a file part of the EAGER graph:
-//   - `import … from '…'`      (default / named / namespace, single- or multi-line)
-//   - `import '…'`             (side-effect)
-//   - `export … from '…'`      (barrel re-export — pulls the target in at load)
-// excluding the type-only forms (`import type …` / `export type …`, erased at compile time) and the
-// lazy forms (`import('…')` / `require('…')` — those live inside functions and are NOT eager).
-function* staticSpecifiers(source: string): Generator<string> {
-  const clean = stripComments(source)
-  // `s` flag: the clause may span newlines (multi-line import/export blocks).
-  const importFrom = /\bimport\s+(?!type[\s{])[^;'"]*?\bfrom\s*['"]([^'"]+)['"]/gs
-  const exportFrom = /\bexport\s+(?!type[\s{])[^;'"]*?\bfrom\s*['"]([^'"]+)['"]/gs
-  const sideEffect = /\bimport\s+['"]([^'"]+)['"]/g
-  for (const re of [importFrom, exportFrom, sideEffect]) {
-    let m: RegExpExecArray | null
-    while ((m = re.exec(clean)) !== null) yield m[1]
+// Every static module specifier that makes a file part of the EAGER graph, read from the AST:
+//   - `import … from '…'`   ImportDeclaration (default / named / namespace / side-effect)
+//   - `export … from '…'`   ExportDeclaration with a moduleSpecifier (barrel re-export)
+// skipping the type-only forms. `import(…)` / `require(…)` are CallExpressions, never Import/Export
+// Declarations, so they are structurally excluded — no eager/lazy heuristic needed.
+function staticSpecifiersOf(file: string): string[] {
+  const source = ts.createSourceFile(
+    file,
+    readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ false,
+    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  )
+  const specs: string[] = []
+  for (const stmt of source.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      if (stmt.importClause?.isTypeOnly) continue // `import type …`
+      if (ts.isStringLiteral(stmt.moduleSpecifier)) specs.push(stmt.moduleSpecifier.text)
+    } else if (ts.isExportDeclaration(stmt)) {
+      if (stmt.isTypeOnly) continue // `export type … from …`
+      if (stmt.moduleSpecifier && ts.isStringLiteral(stmt.moduleSpecifier)) {
+        specs.push(stmt.moduleSpecifier.text)
+      }
+    }
   }
+  return specs
 }
 
-// BFS the eager startup import graph; return external top-level modules mapped to an example file.
-function collectStartupExternals(): { externals: Map<string, string>; filesVisited: number } {
-  const seen = new Set<string>()
+// BFS the eager startup import graph; return external top-level modules mapped to an example file,
+// plus the full set of visited (resolved) files.
+function walkStartupGraph(): {
+  externals: Map<string, string>
+  visited: Set<string>
+} {
+  const visited = new Set<string>()
   const externals = new Map<string, string>()
   const queue: string[] = [ENTRY]
   while (queue.length > 0) {
     const file = queue.shift()!
-    if (seen.has(file) || !existsSync(file)) continue
-    seen.add(file)
-    for (const spec of staticSpecifiers(readFileSync(file, 'utf8'))) {
+    if (visited.has(file) || !existsSync(file)) continue
+    visited.add(file)
+    for (const spec of staticSpecifiersOf(file)) {
       if (spec.startsWith('.')) {
         const resolved = resolveRelative(file, spec)
         if (resolved) queue.push(resolved)
@@ -108,16 +117,16 @@ function collectStartupExternals(): { externals: Map<string, string>; filesVisit
       if (!externals.has(mod)) externals.set(mod, path.relative(CORE_BACKEND, file))
     }
   }
-  return { externals, filesVisited: seen.size }
+  return { externals, visited }
 }
 
 describe('runtime dependency classification (production-install startup contract)', () => {
   it('every eagerly-imported external module in the startup graph is a production dependency', () => {
     const prod = prodDependencyNames()
-    const { externals, filesVisited } = collectStartupExternals()
+    const { externals, visited } = walkStartupGraph()
     // Guard against silent coverage collapse: the eager startup graph is a few hundred files; if a
-    // parser regression makes the walk visit almost nothing the "0 missing" result is meaningless.
-    expect(filesVisited).toBeGreaterThan(150)
+    // parser/traversal regression makes the walk visit almost nothing the "0 missing" is meaningless.
+    expect(visited.size).toBeGreaterThan(150)
     const missing = [...externals.entries()]
       .filter(([mod]) => !prod.has(mod))
       .map(([mod, file]) => `${mod} (eager import e.g. ${file})`)
@@ -126,6 +135,19 @@ describe('runtime dependency classification (production-install startup contract
       `these modules are imported at startup but are not production dependencies — a --prod install ` +
         `would omit them and crash the backend on boot:\n  ${missing.join('\n  ')}`,
     ).toEqual([])
+  })
+
+  it('traverses modules reachable only through a MULTI-LINE import edge (regression: #4126)', () => {
+    // src/index.ts:19 imports ./core/workday-calendar-port via a multi-line `import { … } from`.
+    // A line-based matcher missed multi-line edges, so a dev-only import hidden behind one passed
+    // silently. The AST walk must visit this target — proving multi-line edges are followed.
+    const { visited } = walkStartupGraph()
+    const target = resolveRelative(ENTRY, './core/workday-calendar-port')
+    expect(target, 'the multi-line-imported target must resolve').toBeTruthy()
+    expect(
+      visited.has(target as string),
+      'a module reachable only via a multi-line import edge must be traversed',
+    ).toBe(true)
   })
 
   it('uuid specifically is a production dependency (corrective-6 regression lock)', () => {

--- a/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
+++ b/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from 'vitest'
 // For each file it collects the HARD-eager module specifiers — the ones whose absence crashes
 // module evaluation under a `--prod` install:
 //   - `import … from`  /  side-effect `import '…'`  /  `export … from`  (declarations)
-//   - a TOP-LEVEL `require('…')` / `import('…')` NOT inside a `try` block
+//   - every TOP-LEVEL `require('…')` / `import('…')`, including calls inside `try`
 // and skips only the genuinely non-eager forms: type-only declarations, and require()/import()
 // inside a function/class body (lazy). A top-level require()/import() in ANY position — including
 // inside try / catch / finally — is treated as hard, because only a `try { require } catch` that
@@ -24,11 +24,12 @@ import { describe, expect, it } from 'vitest'
 // structurally (try-finally with no catch propagates; a require in catch/finally is unguarded; a
 // rethrowing catch does not swallow). The intentionally-optional soft dependencies are therefore
 // exempted by the explicit, auditable OPTIONAL_SOFT_DEPENDENCIES allowlist at the check site, whose
-// entries are asserted to stay live-and-non-prod. Every other hard external must resolve to a prod
-// dependency of core-backend or the workspace root (hoisting reality). Multi-line, default/named/
-// namespace, and barrel re-export forms are handled uniformly by the AST (no line-based blind spot).
-// A file-count floor, a multi-line-edge regression test, a synthetic classification test covering
-// every try/catch/finally shape, and an allowlist-hygiene test guard against regressions.
+// entries are asserted to stay live-and-non-prod, occur exactly once, and remain protected by a
+// swallowing top-level try/catch. Every other hard external must resolve to a prod dependency of
+// core-backend or the workspace root (hoisting reality). Multi-line, default/named/namespace, and
+// barrel re-export forms are handled uniformly by the AST (no line-based blind spot). A file-count
+// floor, multi-line-edge regression, synthetic eager/lazy classification, guarded-loader shape
+// matrix, and allowlist-hygiene test guard against regressions.
 
 const CORE_BACKEND = path.resolve(__dirname, '..', '..')
 const REPO_ROOT = path.resolve(CORE_BACKEND, '..', '..')
@@ -107,12 +108,10 @@ function rootModule(spec: string): string {
 // The HARD-eager module specifiers of a file — the ones whose absence crashes module evaluation:
 //   - `import … from '…'`   ImportDeclaration (default / named / namespace / side-effect)
 //   - `export … from '…'`   ExportDeclaration with a moduleSpecifier (barrel re-export)
-//   - a TOP-LEVEL `require('…')` / `import('…')` call NOT inside a try block — executed at module
-//     load, unguarded, so a missing module throws and the backend fails to boot.
-// Skipped (not hard): type-only forms; require()/import() inside a function/class body (lazy); a
-// top-level require()/import() INSIDE a try block (the "captured optional dependency" pattern — the
-// catch tolerates absence, e.g. @opentelemetry/api, js-yaml, express-validator). These distinctions
-// are read structurally from the AST (function boundaries, try blocks), not by heuristic.
+//   - every TOP-LEVEL `require('…')` / `import('…')` call — including calls inside try/catch/finally.
+// Skipped (not hard): type-only forms and require()/import() inside a function/class body (lazy).
+// Intentionally optional top-level loaders are still collected here, then exempted only when their
+// exact allowlisted occurrence retains a structurally verified swallowing try/catch.
 function isFunctionLikeBoundary(node: ts.Node): boolean {
   return (
     ts.isFunctionDeclaration(node) ||
@@ -180,9 +179,75 @@ function hardSpecifiersOf(file: string): string[] {
   return specs
 }
 
-// One eager external import site. EVERY occurrence is recorded (#4126 review: keeping only the
-// first site per module let a module-name allowlist mask a new hard import of the same module in
-// another file).
+function isDescendantOf(node: ts.Node, ancestor: ts.Node): boolean {
+  let current: ts.Node | undefined = node
+  while (current) {
+    if (current === ancestor) return true
+    current = current.parent
+  }
+  return false
+}
+
+function containsEagerThrow(node: ts.Node): boolean {
+  let found = false
+  const walk = (current: ts.Node): void => {
+    if (found) return
+    if (current !== node && isFunctionLikeBoundary(current)) return
+    if (ts.isThrowStatement(current)) {
+      found = true
+      return
+    }
+    current.forEachChild(walk)
+  }
+  walk(node)
+  return found
+}
+
+function isProtectedBySwallowingTry(call: ts.CallExpression): boolean {
+  let current: ts.Node | undefined = call.parent
+  while (current) {
+    if (isFunctionLikeBoundary(current)) return false
+    if (
+      ts.isTryStatement(current) &&
+      isDescendantOf(call, current.tryBlock) &&
+      current.catchClause &&
+      !containsEagerThrow(current.catchClause.block) &&
+      (!current.finallyBlock || !containsEagerThrow(current.finallyBlock))
+    ) {
+      return true
+    }
+    current = current.parent
+  }
+  return false
+}
+
+function inspectOptionalLoader(file: string, module: string): {
+  topLevelCalls: number
+  guardedCalls: number
+} {
+  const source = ts.createSourceFile(
+    file,
+    readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ true,
+    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  )
+  const calls: ts.CallExpression[] = []
+  const walkTopLevel = (node: ts.Node): void => {
+    if (isFunctionLikeBoundary(node)) return
+    const spec = dynamicRequireSpecifier(node)
+    if (spec !== null && rootModule(spec) === module && ts.isCallExpression(node)) calls.push(node)
+    node.forEachChild(walkTopLevel)
+  }
+  for (const stmt of source.statements) walkTopLevel(stmt)
+  return {
+    topLevelCalls: calls.length,
+    guardedCalls: calls.filter(isProtectedBySwallowingTry).length,
+  }
+}
+
+// One eager external import occurrence. EVERY occurrence is recorded (#4126 review: deduplicating
+// by module+file let an exemption mask a second, unguarded import in the same file).
 interface EagerOccurrence {
   module: string
   file: string // repo-relative to packages/core-backend
@@ -195,7 +260,6 @@ function walkStartupGraph(): {
 } {
   const visited = new Set<string>()
   const occurrences: EagerOccurrence[] = []
-  const seenSites = new Set<string>()
   const queue: string[] = [ENTRY]
   while (queue.length > 0) {
     const file = queue.shift()!
@@ -211,9 +275,6 @@ function walkStartupGraph(): {
       if (spec.startsWith('node:')) continue
       const mod = rootModule(spec)
       if (NODE_BUILTINS.has(mod)) continue
-      const site = `${mod}@@${relFile}`
-      if (seenSites.has(site)) continue // one occurrence per (module, file) — repeats in a file are the same site
-      seenSites.add(site)
       occurrences.push({ module: mod, file: relFile })
     }
   }
@@ -303,7 +364,45 @@ describe('runtime dependency classification (production-install startup contract
     fs.rmSync(dir, { recursive: true, force: true })
   })
 
-  it('the soft-dependency exemptions are site-exact, live, non-prod, and occurrence-count-locked', () => {
+  it('only exempts one top-level loader protected by a swallowing try/catch', () => {
+    const os = require('os') as typeof import('os')
+    const fs = require('fs') as typeof import('fs')
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'metasheet2-soft-loader-'))
+    const file = path.join(dir, 'sample.ts')
+    const inspect = (source: string) => {
+      fs.writeFileSync(file, source)
+      return inspectOptionalLoader(file, 'optional-soft')
+    }
+
+    expect(inspect(`try { require('optional-soft') } catch { /* degrade */ }`)).toEqual({
+      topLevelCalls: 1,
+      guardedCalls: 1,
+    })
+    expect(inspect(`require('optional-soft')`)).toEqual({ topLevelCalls: 1, guardedCalls: 0 })
+    expect(inspect(`try { require('optional-soft') } finally { /* propagates */ }`)).toEqual({
+      topLevelCalls: 1,
+      guardedCalls: 0,
+    })
+    expect(inspect(`try {} catch { require('optional-soft') }`)).toEqual({
+      topLevelCalls: 1,
+      guardedCalls: 0,
+    })
+    expect(inspect(`try { require('optional-soft') } catch (error) { throw error }`)).toEqual({
+      topLevelCalls: 1,
+      guardedCalls: 0,
+    })
+    expect(
+      inspect(`try { require('optional-soft') } catch {}\nrequire('optional-soft')`),
+    ).toEqual({ topLevelCalls: 2, guardedCalls: 1 })
+    expect(inspect(`function later() { require('optional-soft') }`)).toEqual({
+      topLevelCalls: 0,
+      guardedCalls: 0,
+    })
+
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('the soft-dependency exemptions are exact, guarded, live, non-prod, and occurrence-count-locked', () => {
     const prod = prodDependencyNames()
     const { occurrences } = walkStartupGraph()
     for (const entry of OPTIONAL_SOFT_DEPENDENCIES) {
@@ -318,9 +417,16 @@ describe('runtime dependency classification (production-install startup contract
       // file adds an occurrence and fails here (and in the main check, which is site-keyed).
       expect(
         sites.map((o) => o.file).sort(),
-        `${entry.module} is eagerly imported at unexempted site(s) — a module-name exemption must not ` +
-          `cover a new hard import elsewhere. Sites: ${sites.map((o) => o.file).join(', ')}`,
+        `${entry.module} has extra eager occurrences — an exemption must not cover a new hard import ` +
+          `in the same file or elsewhere. Sites: ${sites.map((o) => o.file).join(', ')}`,
       ).toEqual([entry.file])
+      // Shape lock: the sole occurrence must remain inside the try block of a swallowing catch.
+      // Moving it outside the try, into catch/finally, or adding a second call fails closed.
+      expect(
+        inspectOptionalLoader(path.join(CORE_BACKEND, entry.file), entry.module),
+        `${entry.module} at ${entry.file} is exempt only while exactly one top-level loader is ` +
+          `protected by a swallowing try/catch`,
+      ).toEqual({ topLevelCalls: 1, guardedCalls: 1 })
       // Not a prod dep — otherwise the exemption hides a real classification.
       expect(
         prod.has(entry.module),

--- a/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
+++ b/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
@@ -42,17 +42,38 @@ const NODE_BUILTINS = new Set([
   'stream/promises', 'timers/promises', 'crypto/promises',
 ])
 
-// Explicit allowlist of intentionally-OPTIONAL soft dependencies: modules a startup file requires at
-// module load INSIDE a try/catch that swallows the missing-module error and degrades gracefully, so
-// their absence under a --prod install does NOT crash the backend. Each entry below was verified to
-// be a `try { require(x) } catch { …fallback… }` (never rethrown) with a functioning degraded path.
-// Adding a new optional soft dependency is a deliberate, auditable edit here — anything NOT declared
-// prod and NOT on this list is treated as a hard eager dependency and fails the guard.
-const OPTIONAL_SOFT_DEPENDENCIES = new Set([
-  '@opentelemetry/api', // src/core/logger.ts — try{require}catch{otelApi=null}; trace-id enrichment off
-  'js-yaml', // src/services/ConfigService.ts — try{require}catch{}; JSON-only config fallback
-  'express-validator', // src/middleware/validation.ts — try{require}catch{}; validation skipped
-])
+// Explicit, OCCURRENCE-PRECISE allowlist of intentionally-OPTIONAL soft dependencies (#4126 review):
+// a module-name-only allowlist would mask a NEW hard import of the same module elsewhere (an
+// unguarded `import 'js-yaml'` in another startup file would sail through). So each exemption pins
+// the module to its exact source file AND requires the total occurrence count across the startup
+// graph to match — any additional site, or a change of site, fails the guard.
+//
+// Each entry is a verified `try { require(x) } catch { …working degraded path… }` (never rethrown)
+// whose absence does NOT crash the backend and does NOT disable a security control.
+// (express-validator was previously listed here and is NOT eligible: request validation is a
+// security control that fail-OPENed when the module was absent — it is now a declared production
+// dependency loaded fail-closed.)
+interface SoftDependencyExemption {
+  module: string
+  file: string // repo-relative to packages/core-backend
+  reason: string
+}
+const OPTIONAL_SOFT_DEPENDENCIES: SoftDependencyExemption[] = [
+  {
+    module: '@opentelemetry/api',
+    file: 'src/core/logger.ts',
+    reason: 'try{require}catch{otelApi=null} — trace-id enrichment degrades off; no security control',
+  },
+  {
+    module: 'js-yaml',
+    file: 'src/services/ConfigService.ts',
+    reason: 'try{require}catch{} — JSON-only config fallback; no security control',
+  },
+]
+const SOFT_EXEMPTION_KEY = (module: string, file: string): string => `${module}@@${file}`
+const SOFT_EXEMPTION_KEYS = new Set(
+  OPTIONAL_SOFT_DEPENDENCIES.map((entry) => SOFT_EXEMPTION_KEY(entry.module, entry.file)),
+)
 
 function readJson(file: string): Record<string, unknown> {
   return JSON.parse(readFileSync(file, 'utf8'))
@@ -159,19 +180,28 @@ function hardSpecifiersOf(file: string): string[] {
   return specs
 }
 
-// BFS the eager startup import graph; return external top-level modules mapped to an example file,
-// plus the full set of visited (resolved) files.
+// One eager external import site. EVERY occurrence is recorded (#4126 review: keeping only the
+// first site per module let a module-name allowlist mask a new hard import of the same module in
+// another file).
+interface EagerOccurrence {
+  module: string
+  file: string // repo-relative to packages/core-backend
+}
+
+// BFS the eager startup import graph; return every eager external occurrence plus the visited files.
 function walkStartupGraph(): {
-  externals: Map<string, string>
+  occurrences: EagerOccurrence[]
   visited: Set<string>
 } {
   const visited = new Set<string>()
-  const externals = new Map<string, string>()
+  const occurrences: EagerOccurrence[] = []
+  const seenSites = new Set<string>()
   const queue: string[] = [ENTRY]
   while (queue.length > 0) {
     const file = queue.shift()!
     if (visited.has(file) || !existsSync(file)) continue
     visited.add(file)
+    const relFile = path.relative(CORE_BACKEND, file)
     for (const spec of hardSpecifiersOf(file)) {
       if (spec.startsWith('.')) {
         const resolved = resolveRelative(file, spec)
@@ -181,26 +211,35 @@ function walkStartupGraph(): {
       if (spec.startsWith('node:')) continue
       const mod = rootModule(spec)
       if (NODE_BUILTINS.has(mod)) continue
-      if (!externals.has(mod)) externals.set(mod, path.relative(CORE_BACKEND, file))
+      const site = `${mod}@@${relFile}`
+      if (seenSites.has(site)) continue // one occurrence per (module, file) — repeats in a file are the same site
+      seenSites.add(site)
+      occurrences.push({ module: mod, file: relFile })
     }
   }
-  return { externals, visited }
+  return { occurrences, visited }
 }
 
 describe('runtime dependency classification (production-install startup contract)', () => {
-  it('every eagerly-imported external module in the startup graph is a production dependency', () => {
+  it('every eager external import site in the startup graph is a production dependency', () => {
     const prod = prodDependencyNames()
-    const { externals, visited } = walkStartupGraph()
+    const { occurrences, visited } = walkStartupGraph()
     // Guard against silent coverage collapse: the eager startup graph is a few hundred files; if a
     // parser/traversal regression makes the walk visit almost nothing the "0 missing" is meaningless.
     expect(visited.size).toBeGreaterThan(150)
-    const missing = [...externals.entries()]
-      .filter(([mod]) => !prod.has(mod) && !OPTIONAL_SOFT_DEPENDENCIES.has(mod))
-      .map(([mod, file]) => `${mod} (eager import e.g. ${file})`)
+    // Checked PER OCCURRENCE (module + source file), not per module name: a soft-dependency
+    // exemption is bound to its exact site, so an unguarded import of the SAME module in another
+    // startup file is still a hard dependency and still fails.
+    const missing = occurrences
+      .filter(
+        ({ module, file }) =>
+          !prod.has(module) && !SOFT_EXEMPTION_KEYS.has(SOFT_EXEMPTION_KEY(module, file)),
+      )
+      .map(({ module, file }) => `${module} (eager import at ${file})`)
     expect(
       missing,
-      `these modules are imported at startup but are neither a production dependency nor an ` +
-        `allowlisted optional soft dependency — a --prod install would omit them and crash the ` +
+      `these import sites are eager at startup but are neither a production dependency nor an ` +
+        `allowlisted optional soft-dependency SITE — a --prod install would omit them and crash the ` +
         `backend on boot:\n  ${missing.join('\n  ')}`,
     ).toEqual([])
   })
@@ -264,18 +303,51 @@ describe('runtime dependency classification (production-install startup contract
     fs.rmSync(dir, { recursive: true, force: true })
   })
 
-  it('the optional-soft-dependency allowlist is not stale — every entry is still a startup require and not a prod dep', () => {
+  it('the soft-dependency exemptions are site-exact, live, non-prod, and occurrence-count-locked', () => {
     const prod = prodDependencyNames()
-    const { externals } = walkStartupGraph()
-    for (const soft of OPTIONAL_SOFT_DEPENDENCIES) {
+    const { occurrences } = walkStartupGraph()
+    for (const entry of OPTIONAL_SOFT_DEPENDENCIES) {
+      const sites = occurrences.filter((o) => o.module === entry.module)
+      // Live: the exempted site still exists.
       expect(
-        externals.has(soft),
-        `${soft} is allowlisted as optional but is no longer eagerly required in the startup graph — remove the stale entry`,
+        sites.some((o) => o.file === entry.file),
+        `${entry.module} is exempted at ${entry.file} but is no longer eagerly required there — fix or remove the stale exemption`,
       ).toBe(true)
+      // Occurrence-count lock (#4126 review): the module must be eagerly imported at EXACTLY the
+      // exempted site and nowhere else. A new unguarded import of the same module in another startup
+      // file adds an occurrence and fails here (and in the main check, which is site-keyed).
       expect(
-        prod.has(soft),
-        `${soft} is now a production dependency — drop it from the optional allowlist so a real regression can be seen`,
+        sites.map((o) => o.file).sort(),
+        `${entry.module} is eagerly imported at unexempted site(s) — a module-name exemption must not ` +
+          `cover a new hard import elsewhere. Sites: ${sites.map((o) => o.file).join(', ')}`,
+      ).toEqual([entry.file])
+      // Not a prod dep — otherwise the exemption hides a real classification.
+      expect(
+        prod.has(entry.module),
+        `${entry.module} is now a production dependency — drop the exemption so a real regression can be seen`,
       ).toBe(false)
+    }
+  })
+
+  it('express-validator is a production dependency and its loaders are fail-closed (#4126 review security fix)', () => {
+    const cb = readJson(path.join(CORE_BACKEND, 'package.json'))
+    const deps = (cb.dependencies as Record<string, string>) ?? {}
+    expect(
+      deps['express-validator'],
+      'express-validator backs declarative request validation (a security control) and must be a production dependency, never an optional soft dependency',
+    ).toBeTruthy()
+    expect(
+      OPTIONAL_SOFT_DEPENDENCIES.some((entry) => entry.module === 'express-validator'),
+      'express-validator must not be allowlisted as an optional soft dependency — its absence fail-OPENed validation',
+    ).toBe(false)
+    // The loaders must throw (fail-closed), never fall back to no-op validators / next().
+    const loaderSources = [
+      readFileSync(path.join(CORE_BACKEND, 'src/types/validator.ts'), 'utf8'),
+      readFileSync(path.join(CORE_BACKEND, 'src/middleware/validation.ts'), 'utf8'),
+    ]
+    for (const source of loaderSources) {
+      expect(source).toMatch(/throw new Error\(/)
+      expect(source).not.toMatch(/validation will be skipped|skip validation|use no-op validators/)
     }
   })
 

--- a/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
+++ b/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
@@ -17,13 +17,18 @@ import { describe, expect, it } from 'vitest'
 // module evaluation under a `--prod` install:
 //   - `import … from`  /  side-effect `import '…'`  /  `export … from`  (declarations)
 //   - a TOP-LEVEL `require('…')` / `import('…')` NOT inside a `try` block
-// and skips the non-crashing forms structurally: type-only declarations; require()/import() inside a
-// function/class body (lazy); and a top-level require()/import() INSIDE a try block (the captured
-// optional-dependency pattern — @opentelemetry/api, js-yaml, express-validator each `try { require }
-// catch {}`). Every hard external must resolve to a prod dependency of core-backend or the workspace
-// root (hoisting reality). Multi-line, default/named/namespace, and barrel re-export forms are
-// handled uniformly by the AST (no line-based blind spot). A file-count floor, a multi-line-edge
-// regression test, and a synthetic eager-vs-lazy classification test guard against regressions.
+// and skips only the genuinely non-eager forms: type-only declarations, and require()/import()
+// inside a function/class body (lazy). A top-level require()/import() in ANY position — including
+// inside try / catch / finally — is treated as hard, because only a `try { require } catch` that
+// actually SWALLOWS the missing-module error is safe, and that judgement is fragile to reason about
+// structurally (try-finally with no catch propagates; a require in catch/finally is unguarded; a
+// rethrowing catch does not swallow). The intentionally-optional soft dependencies are therefore
+// exempted by the explicit, auditable OPTIONAL_SOFT_DEPENDENCIES allowlist at the check site, whose
+// entries are asserted to stay live-and-non-prod. Every other hard external must resolve to a prod
+// dependency of core-backend or the workspace root (hoisting reality). Multi-line, default/named/
+// namespace, and barrel re-export forms are handled uniformly by the AST (no line-based blind spot).
+// A file-count floor, a multi-line-edge regression test, a synthetic classification test covering
+// every try/catch/finally shape, and an allowlist-hygiene test guard against regressions.
 
 const CORE_BACKEND = path.resolve(__dirname, '..', '..')
 const REPO_ROOT = path.resolve(CORE_BACKEND, '..', '..')
@@ -35,6 +40,18 @@ const NODE_BUILTINS = new Set([
   'perf_hooks', 'timers', 'string_decoder', 'readline', 'cluster', 'v8', 'vm', 'module', 'process',
   'async_hooks', 'http2', 'dgram', 'tty', 'constants', 'punycode', 'fs/promises',
   'stream/promises', 'timers/promises', 'crypto/promises',
+])
+
+// Explicit allowlist of intentionally-OPTIONAL soft dependencies: modules a startup file requires at
+// module load INSIDE a try/catch that swallows the missing-module error and degrades gracefully, so
+// their absence under a --prod install does NOT crash the backend. Each entry below was verified to
+// be a `try { require(x) } catch { …fallback… }` (never rethrown) with a functioning degraded path.
+// Adding a new optional soft dependency is a deliberate, auditable edit here — anything NOT declared
+// prod and NOT on this list is treated as a hard eager dependency and fails the guard.
+const OPTIONAL_SOFT_DEPENDENCIES = new Set([
+  '@opentelemetry/api', // src/core/logger.ts — try{require}catch{otelApi=null}; trace-id enrichment off
+  'js-yaml', // src/services/ConfigService.ts — try{require}catch{}; JSON-only config fallback
+  'express-validator', // src/middleware/validation.ts — try{require}catch{}; validation skipped
 ])
 
 function readJson(file: string): Record<string, unknown> {
@@ -107,19 +124,21 @@ function hardSpecifiersOf(file: string): string[] {
   )
   const specs: string[] = []
 
-  // Top-level executable walk: descend through control flow, STOP at function/class boundaries
-  // (lazy), and treat requires inside a `try` block as captured-optional (skipped).
-  const walkTopLevel = (node: ts.Node, inTry: boolean): void => {
+  // Top-level executable walk: descend through ALL control flow — including try / catch / finally —
+  // and STOP only at function/class boundaries (those bodies are lazy). Every top-level
+  // require('…') / import('…') is collected as hard, regardless of try structure. We deliberately do
+  // NOT try to reason about whether a surrounding try/catch "swallows" a missing-module error:
+  //   - `try { require(x) } finally {}`   — no catch → the error propagates (crash)
+  //   - `try {} catch { require(x) }`      — the require is in the handler, not guarded
+  //   - `try { require(x) } catch (e) { throw e }` — catch rethrows → not swallowed
+  // are all real boot crashes, so require() anywhere at top level is hard. The intentionally-optional
+  // soft dependencies are exempted by the explicit OPTIONAL_SOFT_DEPENDENCIES allowlist at the check
+  // site, not by a fragile try-shape heuristic here.
+  const walkTopLevel = (node: ts.Node): void => {
     if (isFunctionLikeBoundary(node)) return
-    if (ts.isTryStatement(node)) {
-      // The try/catch/finally bodies are all the optional context — a require anywhere in them is
-      // gracefully guarded. (Anything in the enclosing scope stays hard.)
-      node.forEachChild((child) => walkTopLevel(child, true))
-      return
-    }
     const spec = dynamicRequireSpecifier(node)
-    if (spec !== null && !inTry) specs.push(spec)
-    node.forEachChild((child) => walkTopLevel(child, inTry))
+    if (spec !== null) specs.push(spec)
+    node.forEachChild(walkTopLevel)
   }
 
   for (const stmt of source.statements) {
@@ -135,7 +154,7 @@ function hardSpecifiersOf(file: string): string[] {
       }
       continue
     }
-    walkTopLevel(stmt, false)
+    walkTopLevel(stmt)
   }
   return specs
 }
@@ -176,12 +195,13 @@ describe('runtime dependency classification (production-install startup contract
     // parser/traversal regression makes the walk visit almost nothing the "0 missing" is meaningless.
     expect(visited.size).toBeGreaterThan(150)
     const missing = [...externals.entries()]
-      .filter(([mod]) => !prod.has(mod))
+      .filter(([mod]) => !prod.has(mod) && !OPTIONAL_SOFT_DEPENDENCIES.has(mod))
       .map(([mod, file]) => `${mod} (eager import e.g. ${file})`)
     expect(
       missing,
-      `these modules are imported at startup but are not production dependencies — a --prod install ` +
-        `would omit them and crash the backend on boot:\n  ${missing.join('\n  ')}`,
+      `these modules are imported at startup but are neither a production dependency nor an ` +
+        `allowlisted optional soft dependency — a --prod install would omit them and crash the ` +
+        `backend on boot:\n  ${missing.join('\n  ')}`,
     ).toEqual([])
   })
 
@@ -198,7 +218,7 @@ describe('runtime dependency classification (production-install startup contract
     ).toBe(true)
   })
 
-  it('classifies eager vs lazy specifiers structurally (#4126 review: top-level require/import gap)', () => {
+  it('classifies eager vs lazy specifiers structurally, incl. every try/catch/finally shape (#4126 review)', () => {
     const os = require('os') as typeof import('os')
     const fs = require('fs') as typeof import('fs')
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'metasheet2-hardspec-'))
@@ -211,20 +231,52 @@ describe('runtime dependency classification (production-install startup contract
         `export { x } from 'eager-reexport'`,
         `const a = require('eager-toplevel-require')`,
         `void import('eager-toplevel-import')`,
-        `let opt; try { opt = require('optional-in-try') } catch { opt = null }`,
+        // ── every top-level require is HARD regardless of try shape (only a swallowing catch would
+        //    make it optional, and that judgement is delegated to the explicit allowlist, not here) ──
+        `try { require('hard-try-finally') } finally { /* no catch → propagates */ }`,
+        `try { /* body */ } catch { require('hard-in-catch') }`,
+        `try { /* body */ } finally { require('hard-in-finally') }`,
+        `try { require('hard-rethrow') } catch (e) { throw e }`,
+        `try { require('hard-try-catch-swallow') } catch { /* swallow */ }`,
+        // ── lazy: inside function / method bodies (never eager) ──
         `function later() { const b = require('lazy-in-function'); return b }`,
         `class C { m() { return require('lazy-in-method') } }`,
       ].join('\n'),
     )
     const specs = hardSpecifiersOf(file)
     expect(specs.sort()).toEqual(
-      ['eager-static', 'eager-reexport', 'eager-toplevel-require', 'eager-toplevel-import'].sort(),
+      [
+        'eager-static',
+        'eager-reexport',
+        'eager-toplevel-require',
+        'eager-toplevel-import',
+        'hard-try-finally',
+        'hard-in-catch',
+        'hard-in-finally',
+        'hard-rethrow',
+        'hard-try-catch-swallow',
+      ].sort(),
     )
-    // Explicitly: the type-only, try-captured, and in-function forms are NOT hard.
-    for (const notHard of ['type-only-erased', 'optional-in-try', 'lazy-in-function', 'lazy-in-method']) {
+    // The type-only and in-function/method forms are the only NON-hard specifiers.
+    for (const notHard of ['type-only-erased', 'lazy-in-function', 'lazy-in-method']) {
       expect(specs).not.toContain(notHard)
     }
     fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('the optional-soft-dependency allowlist is not stale — every entry is still a startup require and not a prod dep', () => {
+    const prod = prodDependencyNames()
+    const { externals } = walkStartupGraph()
+    for (const soft of OPTIONAL_SOFT_DEPENDENCIES) {
+      expect(
+        externals.has(soft),
+        `${soft} is allowlisted as optional but is no longer eagerly required in the startup graph — remove the stale entry`,
+      ).toBe(true)
+      expect(
+        prod.has(soft),
+        `${soft} is now a production dependency — drop it from the optional allowlist so a real regression can be seen`,
+      ).toBe(false)
+    }
   })
 
   it('uuid specifically is a production dependency (corrective-6 regression lock)', () => {

--- a/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
+++ b/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync, existsSync } from 'fs'
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+// Production-install startup contract (#3751 corrective-6, entity-machine failureClass=
+// RUNTIME_DEPENDENCY_DECLARED_AS_DEV_ONLY / missingRuntimeModule=uuid).
+//
+// A production install (`pnpm install --prod`) skips devDependencies. Any EXTERNAL module that is
+// EAGERLY imported (top-level `import … from 'x'`, non-type) somewhere in the server's startup
+// import graph must therefore be declared in a PRODUCTION dependency set — otherwise the backend
+// crashes on boot (uuid was declared only in core-backend devDependencies while WorkflowDesigner /
+// BPMNWorkflowEngine / DelayService import it at module load).
+//
+// This guard statically BFS-walks the real startup graph from `src/index.ts`, following relative
+// imports, and asserts every external top-level import resolves to a prod dependency of either
+// core-backend or the workspace root (hoisting reality). Lazy `require()` / `await import()` inside
+// functions (the optional adapters: mongodb, aws-sdk, @opentelemetry, …) are NOT eager, are NOT in
+// the startup graph, and are correctly not flagged — so the check is precise, not a blanket sweep.
+
+const CORE_BACKEND = path.resolve(__dirname, '..', '..')
+const REPO_ROOT = path.resolve(CORE_BACKEND, '..', '..')
+const ENTRY = path.join(CORE_BACKEND, 'src', 'index.ts')
+
+const NODE_BUILTINS = new Set([
+  'fs', 'path', 'crypto', 'os', 'http', 'https', 'stream', 'util', 'events', 'url', 'zlib',
+  'child_process', 'net', 'tls', 'dns', 'buffer', 'querystring', 'assert', 'worker_threads',
+  'perf_hooks', 'timers', 'string_decoder', 'readline', 'cluster', 'v8', 'vm', 'module', 'process',
+  'async_hooks', 'http2', 'dgram', 'tty', 'constants', 'punycode', 'fs/promises',
+  'stream/promises', 'timers/promises', 'crypto/promises',
+])
+
+function readJson(file: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+function prodDependencyNames(): Set<string> {
+  const cb = readJson(path.join(CORE_BACKEND, 'package.json'))
+  const root = readJson(path.join(REPO_ROOT, 'package.json'))
+  const names = new Set<string>()
+  for (const pkg of [cb, root]) {
+    for (const field of ['dependencies', 'optionalDependencies', 'peerDependencies']) {
+      for (const name of Object.keys((pkg[field] as Record<string, string>) ?? {})) names.add(name)
+    }
+  }
+  return names
+}
+
+function resolveRelative(fromFile: string, spec: string): string | null {
+  const base = path.resolve(path.dirname(fromFile), spec)
+  for (const ext of ['.ts', '.tsx', '.js', '.mjs', '.cts', '/index.ts', '/index.js']) {
+    if (existsSync(base + ext)) return base + ext
+  }
+  if (existsSync(base) && /\.(ts|tsx|js|mjs|cts)$/.test(base)) return base
+  return null
+}
+
+function rootModule(spec: string): string {
+  return spec.startsWith('@') ? spec.split('/').slice(0, 2).join('/') : spec.split('/')[0]
+}
+
+// BFS the eager startup import graph; return external top-level modules mapped to an example file.
+function collectStartupExternals(): Map<string, string> {
+  const seen = new Set<string>()
+  const externals = new Map<string, string>()
+  const queue: string[] = [ENTRY]
+  while (queue.length > 0) {
+    const file = queue.shift()!
+    if (seen.has(file) || !existsSync(file)) continue
+    seen.add(file)
+    for (const line of readFileSync(file, 'utf8').split('\n')) {
+      // Top-level static import only (column 0), excluding `import type …`.
+      const match = line.match(/^import\s+(?!type[\s{])(?:[^'"]*\sfrom\s+)?['"]([^'"]+)['"]/)
+      if (!match) continue
+      const spec = match[1]
+      if (spec.startsWith('.')) {
+        const resolved = resolveRelative(file, spec)
+        if (resolved) queue.push(resolved)
+        continue
+      }
+      if (spec.startsWith('node:')) continue
+      const mod = rootModule(spec)
+      if (NODE_BUILTINS.has(mod)) continue
+      if (!externals.has(mod)) externals.set(mod, path.relative(CORE_BACKEND, file))
+    }
+  }
+  return externals
+}
+
+describe('runtime dependency classification (production-install startup contract)', () => {
+  it('every eagerly-imported external module in the startup graph is a production dependency', () => {
+    const prod = prodDependencyNames()
+    const externals = collectStartupExternals()
+    const missing = [...externals.entries()]
+      .filter(([mod]) => !prod.has(mod))
+      .map(([mod, file]) => `${mod} (eager import e.g. ${file})`)
+    expect(
+      missing,
+      `these modules are imported at startup but are not production dependencies — a --prod install ` +
+        `would omit them and crash the backend on boot:\n  ${missing.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('uuid specifically is a production dependency (corrective-6 regression lock)', () => {
+    const cb = readJson(path.join(CORE_BACKEND, 'package.json'))
+    const deps = (cb.dependencies as Record<string, string>) ?? {}
+    const dev = (cb.devDependencies as Record<string, string>) ?? {}
+    expect(deps.uuid, 'uuid must be a runtime dependency').toBeTruthy()
+    expect(dev.uuid, 'uuid must not remain in devDependencies').toBeUndefined()
+  })
+})

--- a/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
+++ b/packages/core-backend/tests/unit/runtime-dependency-classification.test.ts
@@ -12,16 +12,18 @@ import { describe, expect, it } from 'vitest'
 // crashes on boot (uuid was declared only in core-backend devDependencies while WorkflowDesigner /
 // BPMNWorkflowEngine / DelayService import it at module load).
 //
-// This guard BFS-walks the startup graph from `src/index.ts` using the TypeScript AST (not regex):
-// each file is parsed and its top-level `ImportDeclaration` / `ExportDeclaration` (re-export) nodes
-// are read, skipping the type-only forms (`import type` / `export type`, erased at compile time).
-// Every external eager import must resolve to a prod dependency of core-backend or the workspace
-// root (hoisting reality). Lazy `require()` / `await import()` inside functions (the optional
-// adapters: mongodb, aws-sdk, @opentelemetry, …) are call expressions, NOT declarations, so the AST
-// never treats them as eager — the check is precise, not a blanket sweep. The AST handles
-// single-line, multi-line, default/named/namespace, side-effect, and barrel re-export forms
-// uniformly, so there is no line-based blind spot. A file-count floor + an explicit
-// multi-line-edge regression test guard against a traversal regression.
+// This guard BFS-walks the startup graph from `src/index.ts` using the TypeScript AST (not regex).
+// For each file it collects the HARD-eager module specifiers — the ones whose absence crashes
+// module evaluation under a `--prod` install:
+//   - `import … from`  /  side-effect `import '…'`  /  `export … from`  (declarations)
+//   - a TOP-LEVEL `require('…')` / `import('…')` NOT inside a `try` block
+// and skips the non-crashing forms structurally: type-only declarations; require()/import() inside a
+// function/class body (lazy); and a top-level require()/import() INSIDE a try block (the captured
+// optional-dependency pattern — @opentelemetry/api, js-yaml, express-validator each `try { require }
+// catch {}`). Every hard external must resolve to a prod dependency of core-backend or the workspace
+// root (hoisting reality). Multi-line, default/named/namespace, and barrel re-export forms are
+// handled uniformly by the AST (no line-based blind spot). A file-count floor, a multi-line-edge
+// regression test, and a synthetic eager-vs-lazy classification test guard against regressions.
 
 const CORE_BACKEND = path.resolve(__dirname, '..', '..')
 const REPO_ROOT = path.resolve(CORE_BACKEND, '..', '..')
@@ -64,12 +66,38 @@ function rootModule(spec: string): string {
   return spec.startsWith('@') ? spec.split('/').slice(0, 2).join('/') : spec.split('/')[0]
 }
 
-// Every static module specifier that makes a file part of the EAGER graph, read from the AST:
+// The HARD-eager module specifiers of a file — the ones whose absence crashes module evaluation:
 //   - `import … from '…'`   ImportDeclaration (default / named / namespace / side-effect)
 //   - `export … from '…'`   ExportDeclaration with a moduleSpecifier (barrel re-export)
-// skipping the type-only forms. `import(…)` / `require(…)` are CallExpressions, never Import/Export
-// Declarations, so they are structurally excluded — no eager/lazy heuristic needed.
-function staticSpecifiersOf(file: string): string[] {
+//   - a TOP-LEVEL `require('…')` / `import('…')` call NOT inside a try block — executed at module
+//     load, unguarded, so a missing module throws and the backend fails to boot.
+// Skipped (not hard): type-only forms; require()/import() inside a function/class body (lazy); a
+// top-level require()/import() INSIDE a try block (the "captured optional dependency" pattern — the
+// catch tolerates absence, e.g. @opentelemetry/api, js-yaml, express-validator). These distinctions
+// are read structurally from the AST (function boundaries, try blocks), not by heuristic.
+function isFunctionLikeBoundary(node: ts.Node): boolean {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isConstructorDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node)
+  )
+}
+
+function dynamicRequireSpecifier(node: ts.Node): string | null {
+  if (!ts.isCallExpression(node) || node.arguments.length === 0) return null
+  const callee = node.expression
+  const isRequire = ts.isIdentifier(callee) && callee.text === 'require'
+  const isDynamicImport = callee.kind === ts.SyntaxKind.ImportKeyword
+  if (!isRequire && !isDynamicImport) return null
+  const arg = node.arguments[0]
+  return ts.isStringLiteral(arg) ? arg.text : null
+}
+
+function hardSpecifiersOf(file: string): string[] {
   const source = ts.createSourceFile(
     file,
     readFileSync(file, 'utf8'),
@@ -78,16 +106,36 @@ function staticSpecifiersOf(file: string): string[] {
     file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
   )
   const specs: string[] = []
+
+  // Top-level executable walk: descend through control flow, STOP at function/class boundaries
+  // (lazy), and treat requires inside a `try` block as captured-optional (skipped).
+  const walkTopLevel = (node: ts.Node, inTry: boolean): void => {
+    if (isFunctionLikeBoundary(node)) return
+    if (ts.isTryStatement(node)) {
+      // The try/catch/finally bodies are all the optional context — a require anywhere in them is
+      // gracefully guarded. (Anything in the enclosing scope stays hard.)
+      node.forEachChild((child) => walkTopLevel(child, true))
+      return
+    }
+    const spec = dynamicRequireSpecifier(node)
+    if (spec !== null && !inTry) specs.push(spec)
+    node.forEachChild((child) => walkTopLevel(child, inTry))
+  }
+
   for (const stmt of source.statements) {
     if (ts.isImportDeclaration(stmt)) {
       if (stmt.importClause?.isTypeOnly) continue // `import type …`
       if (ts.isStringLiteral(stmt.moduleSpecifier)) specs.push(stmt.moduleSpecifier.text)
-    } else if (ts.isExportDeclaration(stmt)) {
+      continue
+    }
+    if (ts.isExportDeclaration(stmt)) {
       if (stmt.isTypeOnly) continue // `export type … from …`
       if (stmt.moduleSpecifier && ts.isStringLiteral(stmt.moduleSpecifier)) {
         specs.push(stmt.moduleSpecifier.text)
       }
+      continue
     }
+    walkTopLevel(stmt, false)
   }
   return specs
 }
@@ -105,7 +153,7 @@ function walkStartupGraph(): {
     const file = queue.shift()!
     if (visited.has(file) || !existsSync(file)) continue
     visited.add(file)
-    for (const spec of staticSpecifiersOf(file)) {
+    for (const spec of hardSpecifiersOf(file)) {
       if (spec.startsWith('.')) {
         const resolved = resolveRelative(file, spec)
         if (resolved) queue.push(resolved)
@@ -148,6 +196,35 @@ describe('runtime dependency classification (production-install startup contract
       visited.has(target as string),
       'a module reachable only via a multi-line import edge must be traversed',
     ).toBe(true)
+  })
+
+  it('classifies eager vs lazy specifiers structurally (#4126 review: top-level require/import gap)', () => {
+    const os = require('os') as typeof import('os')
+    const fs = require('fs') as typeof import('fs')
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'metasheet2-hardspec-'))
+    const file = path.join(dir, 'sample.ts')
+    fs.writeFileSync(
+      file,
+      [
+        `import staticDefault from 'eager-static'`,
+        `import type { T } from 'type-only-erased'`,
+        `export { x } from 'eager-reexport'`,
+        `const a = require('eager-toplevel-require')`,
+        `void import('eager-toplevel-import')`,
+        `let opt; try { opt = require('optional-in-try') } catch { opt = null }`,
+        `function later() { const b = require('lazy-in-function'); return b }`,
+        `class C { m() { return require('lazy-in-method') } }`,
+      ].join('\n'),
+    )
+    const specs = hardSpecifiersOf(file)
+    expect(specs.sort()).toEqual(
+      ['eager-static', 'eager-reexport', 'eager-toplevel-require', 'eager-toplevel-import'].sort(),
+    )
+    // Explicitly: the type-only, try-captured, and in-function forms are NOT hard.
+    for (const notHard of ['type-only-erased', 'optional-in-try', 'lazy-in-function', 'lazy-in-method']) {
+      expect(specs).not.toContain(notHard)
+    }
+    fs.rmSync(dir, { recursive: true, force: true })
   })
 
   it('uuid specifically is a production dependency (corrective-6 regression lock)', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       socket.io:
         specifier: ^4.6.1
         version: 4.8.1
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
       winston:
         specifier: ^3.17.0
         version: 3.18.3
@@ -305,9 +308,6 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
-      uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
       vitest:
         specifier: ^1.1.0
         version: 1.6.1(@types/node@20.19.25)(jsdom@27.2.0)(less@4.4.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.21.2
+      express-validator:
+        specifier: ^7.2.1
+        version: 7.3.2
       geoip-lite:
         specifier: ^1.4.10
         version: 1.4.10
@@ -2526,6 +2529,10 @@ packages:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
+  express-validator@7.3.2:
+    resolution: {integrity: sha512-ctLw1Vl6dXVH62dIQMDdTAQkrh480mkFuG6/SGXOaVlwPNukhRAe7EgJIMJ2TSAni8iwHBRp530zAZE5ZPF2IA==}
+    engines: {node: '>= 8.0.0'}
+
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
@@ -3174,6 +3181,9 @@ packages:
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@5.1.0:
     resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
@@ -4229,6 +4239,10 @@ packages:
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
+
+  validator@13.15.35:
+    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
+    engines: {node: '>= 0.10'}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -6785,6 +6799,11 @@ snapshots:
 
   expect-type@1.2.2: {}
 
+  express-validator@7.3.2:
+    dependencies:
+      lodash: 4.18.1
+      validator: 13.15.35
+
   express@4.21.2:
     dependencies:
       accepts: 1.3.8
@@ -7526,6 +7545,8 @@ snapshots:
   lodash.once@4.1.1: {}
 
   lodash@4.17.21: {}
+
+  lodash@4.18.1: {}
 
   log-symbols@5.1.0:
     dependencies:
@@ -8650,6 +8671,8 @@ snapshots:
   uuid@8.3.2: {}
 
   uuid@9.0.1: {}
+
+  validator@13.15.35: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## What

Stacked corrective follow-up for parent PR #4126 at exact base 27b4d4e292998b448a2ce87c50d2e23d28c9d9eb.

- retain every eager external occurrence instead of deduplicating by module+file
- require each optional-loader exemption to have exactly one top-level dynamic loader
- structurally verify that loader remains inside a swallowing try/catch
- reject loaders moved outside try, placed in catch/finally, rethrown, duplicated in the same file, or added elsewhere
- correct stale guard comments and add a synthetic guarded-loader shape matrix

Only the parent PR's startup-contract test changes. No runtime/package code is modified.

## Why

The parent guard's claimed occurrence lock still collapsed imports to module@@file. Adding an unguarded import 'js-yaml' in ConfigService.ts beside the existing guarded require therefore remained 6/6 green. Moving the existing require outside try also remained exempt by file.

## Verification

Clean tree:
- focused runtime dependency guard: 7/7 PASS
- core-backend tsc --noEmit: PASS
- full core-backend unit suite: 372/372 files, 5097/5097 tests PASS
- git diff --check: PASS

Mutation teeth:
- same-file unguarded import beside the guarded require: RED on duplicate occurrence
- existing js-yaml require moved outside try/catch: RED on guardedCalls=0
- both mutations were restored before commit

## Integration boundary

This PR targets the parent feature branch, not main. Parent #4126 remains the merge/package unit for #4101. The parent owner may merge or cherry-pick this one commit, then request exact-head re-review. No package build, entity-machine action, deploy, or self-merge is performed here.
