### PR TITLE
feat(dingtalk): retention sweep for approval-card + person delivery ledgers (DT-HARDEN-08)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -385,6 +385,7 @@ jobs:
             tests/integration/multitable-ai-ledger-retention.test.ts \
             tests/integration/multitable-ai-ledger-concurrency.test.ts \
             tests/integration/dingtalk-group-delivery-retention.db.test.ts \
+            tests/integration/dingtalk-card-person-delivery-retention.db.test.ts \
             tests/integration/multitable-ai-suggest-formula.test.ts \
             tests/integration/data-source-c3-keyset-realdb.test.ts \
             tests/integration/data-source-test-ephemeral-realdb.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -386,6 +386,7 @@ jobs:
             tests/integration/multitable-ai-ledger-concurrency.test.ts \
             tests/integration/dingtalk-group-delivery-retention.db.test.ts \
             tests/integration/dingtalk-card-person-delivery-retention.db.test.ts \
+            tests/integration/dingtalk-card-delivery-retention-actionability.db.test.ts \
             tests/integration/multitable-ai-suggest-formula.test.ts \
             tests/integration/data-source-c3-keyset-realdb.test.ts \
             tests/integration/data-source-test-ephemeral-realdb.test.ts \

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -130,6 +130,12 @@ import {
   startDingTalkGroupDeliveryRetentionScheduler,
   stopDingTalkGroupDeliveryRetentionScheduler,
 } from './services/dingtalk-group-delivery-retention-scheduler'
+import {
+  resolveDingTalkCardPersonDeliveryRetentionSchedulerIntervalMs,
+  resolveDingTalkCardPersonDeliveryRetentionSchedulerLeaderOptions,
+  startDingTalkCardPersonDeliveryRetentionScheduler,
+  stopDingTalkCardPersonDeliveryRetentionScheduler,
+} from './services/dingtalk-card-person-delivery-retention-scheduler'
 import { initWebhookEventBridge } from './multitable/webhook-event-bridge'
 import { ApprovalBreachNotifier } from './services/ApprovalBreachNotifier'
 import {
@@ -2007,6 +2013,14 @@ export class MetaSheetServer {
       }
     })())
 
+    shutdownTasks.push((async () => {
+      try {
+        stopDingTalkCardPersonDeliveryRetentionScheduler()
+      } catch (err) {
+        this.logger.warn(`DingTalk approval-card/person delivery retention scheduler shutdown failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    })())
+
     // 4. Destroy API Gateway resources (only if one was constructed during start()).
     shutdownTasks.push((async () => {
       try {
@@ -2312,6 +2326,30 @@ export class MetaSheetServer {
       )
     } catch (e) {
       this.logger.error('DingTalk group-delivery retention scheduler initialization failed; continuing in degraded mode', e as Error)
+    }
+
+    // DingTalk approval-card + person delivery retention sweep (DT-HARDEN-08 follow-up): a
+    // periodic sweep of dingtalk_person_deliveries (bounded batch DELETE, message content +
+    // response bodies) and dingtalk_approval_card_deliveries (stale sent → expired only, never
+    // deleted — see dingtalk-card-person-delivery-retention.ts for why). Reuses the generic
+    // LedgerRetentionScheduler, same as the group-delivery sweep above. UNLIKE the group sweep,
+    // this one is DISABLED BY DEFAULT: it stays a no-op until an operator sets a positive
+    // DINGTALK_DELIVERY_RETENTION_DAYS (opt out any time with DINGTALK_DELIVERY_RETENTION_DISABLED=1).
+    // The scheduler still starts unconditionally (a harmless no-op timer) so this boot path never
+    // depends on whether that env var is set.
+    try {
+      const dingtalkCardPersonDeliveryRetentionLeaderOptions = await resolveDingTalkCardPersonDeliveryRetentionSchedulerLeaderOptions()
+      const dingtalkCardPersonDeliveryRetentionScheduler = startDingTalkCardPersonDeliveryRetentionScheduler({
+        leaderOptions: dingtalkCardPersonDeliveryRetentionLeaderOptions,
+        intervalMs: resolveDingTalkCardPersonDeliveryRetentionSchedulerIntervalMs(),
+      })
+      this.logger.info(
+        dingtalkCardPersonDeliveryRetentionScheduler
+          ? 'DingTalk approval-card/person delivery retention scheduler initialized (no-op until DINGTALK_DELIVERY_RETENTION_DAYS is set)'
+          : 'DingTalk approval-card/person delivery retention scheduler disabled (DINGTALK_DELIVERY_RETENTION_DISABLED=1)',
+      )
+    } catch (e) {
+      this.logger.error('DingTalk approval-card/person delivery retention scheduler initialization failed; continuing in degraded mode', e as Error)
     }
 
     // B-4 BJ-5 follow-up: reconcile ORPHANED AI bulk-fill jobs at boot. A hard

--- a/packages/core-backend/src/services/dingtalk-card-person-delivery-retention-scheduler.ts
+++ b/packages/core-backend/src/services/dingtalk-card-person-delivery-retention-scheduler.ts
@@ -1,0 +1,89 @@
+/**
+ * DingTalk approval-card + person delivery retention scheduler (DT-HARDEN-08 follow-up).
+ *
+ * Boot-wiring glue around the generic `LedgerRetentionScheduler` class (unchanged — it already
+ * depends only on an injected `{ sweep(): Promise<number> }` service) bound to
+ * `PgDingTalkCardPersonDeliveryRetentionService` — the sweep logic itself lives in
+ * ./dingtalk-card-person-delivery-retention.ts.
+ *
+ * The scheduler ALWAYS starts at boot (same as the group-delivery scheduler) — only
+ * DINGTALK_DELIVERY_RETENTION_DISABLED=1 stops it from starting at all. This is intentional: the
+ * underlying sweep is disabled-by-default via its OWN config (no DINGTALK_DELIVERY_RETENTION_DAYS
+ * set → every tick sweeps 0 rows), so an unconfigured deployment gets a harmless no-op timer, not
+ * a code path that behaves differently depending on whether the env is set — the boot wiring
+ * itself never depends on the retention-days env var, only the runtime row count does.
+ *
+ * Interval defaults to the same daily-ish 6h cadence as the group-delivery / AI-usage-ledger
+ * sweeps (DINGTALK_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS), clamped to a 60s floor. A
+ * multi-instance fleet can opt into a Redis leader lock via
+ * ENABLE_DINGTALK_DELIVERY_RETENTION_LEADER_LOCK=true, mirroring the group scheduler's opt-in — the
+ * sweep is idempotent and convergent, so the lock is a load optimisation only, never load-bearing
+ * for correctness.
+ */
+
+import { randomBytes } from 'crypto'
+import { Logger } from '../core/logger'
+import { getRedisClient } from '../db/redis'
+import { RedisLeaderLock, type RedisLeaderLockClient } from '../multitable/redis-leader-lock'
+import {
+  LedgerRetentionScheduler,
+  type LedgerRetentionSchedulerLeaderOptions,
+  type LedgerRetentionSchedulerOptions,
+} from './LedgerRetentionScheduler'
+import { PgDingTalkCardPersonDeliveryRetentionService } from './dingtalk-card-person-delivery-retention'
+
+const DEFAULT_LOCK_TTL_MS = 30_000
+
+let sharedScheduler: LedgerRetentionScheduler | null = null
+
+/**
+ * Starts the scheduler unless DINGTALK_DELIVERY_RETENTION_DISABLED=1 (operator kill switch — the
+ * same flag the sweep's own config honors). Returns null when disabled or already started. Note
+ * this does NOT gate on whether DINGTALK_DELIVERY_RETENTION_DAYS is set — the scheduler always
+ * runs; it is the sweep's own config resolution that decides whether a given tick does anything
+ * (see module docstring).
+ */
+export function startDingTalkCardPersonDeliveryRetentionScheduler(
+  options: LedgerRetentionSchedulerOptions = {},
+): LedgerRetentionScheduler | null {
+  if (process.env.DINGTALK_DELIVERY_RETENTION_DISABLED === '1') return null
+  if (sharedScheduler) return sharedScheduler
+  sharedScheduler = new LedgerRetentionScheduler({
+    ...options,
+    service: options.service ?? new PgDingTalkCardPersonDeliveryRetentionService(),
+    logger: options.logger ?? new Logger('DingTalkCardPersonDeliveryRetentionScheduler'),
+    sweptEntityLabel: options.sweptEntityLabel ?? 'DingTalk approval-card/person delivery rows',
+  })
+  sharedScheduler.start()
+  return sharedScheduler
+}
+
+export function stopDingTalkCardPersonDeliveryRetentionScheduler(): void {
+  if (sharedScheduler) {
+    sharedScheduler.stop()
+    sharedScheduler = null
+  }
+}
+
+export function resolveDingTalkCardPersonDeliveryRetentionSchedulerIntervalMs(): number | undefined {
+  const raw = Number(process.env.DINGTALK_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS)
+  return Number.isFinite(raw) && raw > 0 ? raw : undefined
+}
+
+export async function resolveDingTalkCardPersonDeliveryRetentionSchedulerLeaderOptions(): Promise<LedgerRetentionSchedulerLeaderOptions | null> {
+  if (process.env.ENABLE_DINGTALK_DELIVERY_RETENTION_LEADER_LOCK !== 'true') return null
+  const redis = await getRedisClient()
+  if (!redis) return null
+  const ttlMs = Number(process.env.DINGTALK_DELIVERY_RETENTION_LEADER_LOCK_TTL_MS) > 0
+    ? Number(process.env.DINGTALK_DELIVERY_RETENTION_LEADER_LOCK_TTL_MS)
+    : DEFAULT_LOCK_TTL_MS
+  const retryIntervalMs = Number(process.env.DINGTALK_DELIVERY_RETENTION_LEADER_LOCK_RETRY_MS) > 0
+    ? Number(process.env.DINGTALK_DELIVERY_RETENTION_LEADER_LOCK_RETRY_MS)
+    : undefined
+  return {
+    leaderLock: new RedisLeaderLock({ client: redis as unknown as RedisLeaderLockClient }),
+    ownerId: `dingtalk-card-person-delivery-retention:${process.pid}:${randomBytes(4).toString('hex')}`,
+    ttlMs,
+    retryIntervalMs,
+  }
+}

--- a/packages/core-backend/src/services/dingtalk-card-person-delivery-retention.ts
+++ b/packages/core-backend/src/services/dingtalk-card-person-delivery-retention.ts
@@ -1,0 +1,212 @@
+/**
+ * DingTalk approval-card + person delivery retention sweep (DT-HARDEN-08 follow-up, sibling of
+ * services/dingtalk-group-delivery-retention.ts).
+ *
+ * `dingtalk_person_deliveries` persists full message `content` plus raw `response_body` TEXT for
+ * every automation person-notify send (and rule-creator test sends) with zero DELETE anywhere in
+ * the codebase — same unbounded-growth-of-sensitive-payload shape as the group-delivery ledger
+ * this mirrors. `dingtalk_approval_card_deliveries` carries no message content (see its migration:
+ * id/instance_id/node_key/recipient ids/delivery_kind/task_id/integration_id/card_state/
+ * acted_* / send_status / send_error only), but it DOES carry a security-relevant state machine — a
+ * `card_state='sent'` row plus a valid deep-link token is independently actionable
+ * (ApprovalCardDeliveryAction.ts) — and a lingering `sent` card that nothing ever advances (the
+ * instance moved on some other way, or the recipient never opened it) stays claimable forever.
+ * Retention here means two independently-testable sub-sweeps sharing one config:
+ *
+ *  - dingtalk_person_deliveries: mirrors the group sweep exactly — a bounded batch DELETE (ctid
+ *    sub-select, same shape as sweepDingTalkGroupDeliveryRetention) of rows older than the window.
+ *    This table has no downstream reader keyed by delivery id (listAutomationDingTalkPersonDeliveries
+ *    is a rule-history display query only), so a straight delete is safe and closes the actual
+ *    unexpired-content gap.
+ *
+ *  - dingtalk_approval_card_deliveries: NEVER deleted by this sweep (its acted_action/acted_by/
+ *    acted_at columns are the only record of who approved/rejected via which card — deleting them
+ *    would erase delivery-channel provenance the group-delivery precedent doesn't have to protect).
+ *    Instead, rows still `card_state='sent'` past the window are moved to the already-existing
+ *    `expired` terminal state (allowed by the original CHECK constraint — no migration needed).
+ *    This can only ever move a row AWAY from `sent`: the WHERE clause requires `card_state='sent'`,
+ *    so a swept row can never become actionable again (buildSummary()'s `actionable` requires
+ *    card_state==='sent'; claimDingTalkApprovalCardDeliveryActed()'s claim UPDATE requires
+ *    card_state='sent' too — both close on an `expired` row exactly like they do on `acted`/
+ *    `superseded`/`revoked`). `task_id` and the idx_dacd_task_id trace index are never touched.
+ *
+ * GATING DEVIATION FROM THE GROUP-DELIVERY PRECEDENT (read this before changing the default):
+ * the group sweep is enabled BY DEFAULT (opt OUT via DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED=1),
+ * with an out-of-range/invalid DINGTALK_GROUP_DELIVERY_RETENTION_DAYS falling back to its 90-day
+ * default while STAYING enabled. This sweep inverts that: it is a no-op until an operator sets a
+ * valid, positive DINGTALK_DELIVERY_RETENTION_DAYS — an unset OR invalid value means "not
+ * configured" and the sweep stays disabled (fail closed), it does NOT fall back to a default
+ * window and start deleting/expiring anyway. This is a deliberate owner-facing judgment call (not
+ * a copy-paste divergence): these two ledgers sit closer to the approval security boundary
+ * (card_state machine, deep-link actionability) and to raw message content than the group-robot
+ * telemetry table does, so shipping this capability OFF until explicitly turned on is the safer
+ * default. Flipping the default to match the group sweep's opt-out posture is a one-line change
+ * (swap the `disabled` polarity below) — call this out explicitly if that flip is ever requested.
+ *
+ * OPERATOR FOOT-GUN — PICK A WINDOW LONGER THAN YOUR APPROVAL SLA. The card sub-sweep expires any
+ * card still `sent` past the window, and it does NOT ask whether that card's approval instance is
+ * still legitimately PENDING. An approval that sits awaiting a decision for longer than the window
+ * therefore loses its one-tap card button (`expired` is not actionable) and its approver must fall
+ * back to the web page — the decision is never lost, but the convenience path is. That is the
+ * intended hygiene trade-off (an indefinitely-`sent` card plus a valid deep-link token is otherwise
+ * actionable FOREVER, which is exactly the unbounded-claimability window this sweep closes), but it
+ * means the window must exceed the longest approval turnaround you actually expect. The MIN floor
+ * (7 days) is a foot-gun guard, not a recommendation — most orgs should set considerably more.
+ *
+ * Scheduling reuses the generic `LedgerRetentionScheduler` class unchanged, exactly like the group
+ * sweep — see dingtalk-card-person-delivery-retention-scheduler.ts.
+ *
+ * KNOWN GAP (documented, not fixed here, mirrors the group sweep's own documented gap): neither
+ * table's `created_at` predicate has a dedicated index. Acceptable at current table sizes; kept
+ * out per YAGNI (adding one is a migration, which this change deliberately avoids since neither
+ * table needs a new column).
+ */
+
+import type { AiUsageQueryFn } from './ai-usage-ledger'
+import type { LedgerRetentionService } from './LedgerRetentionScheduler'
+import { poolManager } from '../integration/db/connection-pool'
+
+export const DINGTALK_PERSON_DELIVERY_TABLE = 'dingtalk_person_deliveries'
+export const DINGTALK_APPROVAL_CARD_DELIVERY_TABLE = 'dingtalk_approval_card_deliveries'
+
+/** Reference default retention window in days — only takes effect once DAYS is explicitly set. */
+export const DINGTALK_DELIVERY_RETENTION_DEFAULT_DAYS = 90
+
+/** Floor on the retention window (foot-gun guard) — never below 7 days. */
+export const DINGTALK_DELIVERY_RETENTION_MIN_DAYS = 7
+
+/** Per-pass row cap — drains a backlog over ticks, never one huge statement. */
+export const DINGTALK_DELIVERY_RETENTION_DEFAULT_BATCH = 5000
+
+export interface DingTalkDeliveryRetentionConfig {
+  /** Resolved retention window in days (already floored). Meaningful only when !disabled. */
+  retentionDays: number
+  /** True unless an operator has explicitly opted in (see module docstring — default-OFF). */
+  disabled: boolean
+  /** Per-pass row cap (defaults to DINGTALK_DELIVERY_RETENTION_DEFAULT_BATCH). */
+  batchSize?: number
+}
+
+/**
+ * Resolve the retention config from the environment. DISABLED BY DEFAULT — the inverse gate of
+ * the sibling group-delivery sweep (see module docstring). Enabled only when
+ * DINGTALK_DELIVERY_RETENTION_DAYS parses to a finite positive number (then floored at
+ * DINGTALK_DELIVERY_RETENTION_MIN_DAYS); any other value (unset, non-numeric, zero, negative)
+ * leaves the sweep disabled rather than silently falling back to a default window.
+ * DINGTALK_DELIVERY_RETENTION_DISABLED=1 forces disabled regardless of DAYS (operator kill switch,
+ * also honored by the scheduler's own start gate).
+ */
+export function resolveDingTalkDeliveryRetentionConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): DingTalkDeliveryRetentionConfig {
+  const forceDisabled = env.DINGTALK_DELIVERY_RETENTION_DISABLED === '1'
+  const rawDays = Number(env.DINGTALK_DELIVERY_RETENTION_DAYS)
+  const explicitlyConfigured = Number.isFinite(rawDays) && rawDays > 0
+  const disabled = forceDisabled || !explicitlyConfigured
+  const retentionDays = Math.max(
+    DINGTALK_DELIVERY_RETENTION_MIN_DAYS,
+    Math.floor(explicitlyConfigured ? rawDays : DINGTALK_DELIVERY_RETENTION_DEFAULT_DAYS),
+  )
+  return { retentionDays, disabled }
+}
+
+/**
+ * Delete dingtalk_person_deliveries rows older than the retention window. Returns rows deleted (0
+ * when disabled, or when nothing is past the window). Bounded by `batchSize` via a ctid sub-select
+ * — same shape as sweepDingTalkGroupDeliveryRetention — so one pass never blocks the table during
+ * a backlog drain. No source_type carve-out (automation sends and rule-creator test sends alike):
+ * nothing downstream references a delivery row by id once written.
+ */
+export async function sweepDingTalkPersonDeliveryRetention(
+  query: AiUsageQueryFn,
+  config: DingTalkDeliveryRetentionConfig,
+): Promise<number> {
+  if (config.disabled) return 0
+  const retentionDays = Math.max(DINGTALK_DELIVERY_RETENTION_MIN_DAYS, Math.floor(config.retentionDays))
+  const batchSize = Math.max(1, Math.floor(config.batchSize ?? DINGTALK_DELIVERY_RETENTION_DEFAULT_BATCH))
+  const result = await query(
+    `DELETE FROM ${DINGTALK_PERSON_DELIVERY_TABLE}
+      WHERE ctid IN (
+        SELECT ctid FROM ${DINGTALK_PERSON_DELIVERY_TABLE}
+         WHERE created_at < now() - ($1::int * interval '1 day')
+         LIMIT $2
+      )`,
+    [retentionDays, batchSize],
+  )
+  return result.rowCount ?? 0
+}
+
+/**
+ * Expire stale dingtalk_approval_card_deliveries rows: `card_state='sent'` AND older than the
+ * retention window transitions to `card_state='expired'` — never deleted (see module docstring).
+ * Bounded by `batchSize` via the same ctid sub-select pattern. The WHERE clause requires
+ * card_state='sent', so this can only ever move a row AWAY from `sent` — it is structurally
+ * incapable of reviving a card back to an actionable state. `task_id`, `send_status`,
+ * `acted_*`, and `integration_id` are left untouched.
+ */
+export async function sweepDingTalkApprovalCardDeliveryRetention(
+  query: AiUsageQueryFn,
+  config: DingTalkDeliveryRetentionConfig,
+): Promise<number> {
+  if (config.disabled) return 0
+  const retentionDays = Math.max(DINGTALK_DELIVERY_RETENTION_MIN_DAYS, Math.floor(config.retentionDays))
+  const batchSize = Math.max(1, Math.floor(config.batchSize ?? DINGTALK_DELIVERY_RETENTION_DEFAULT_BATCH))
+  const result = await query(
+    `UPDATE ${DINGTALK_APPROVAL_CARD_DELIVERY_TABLE}
+        SET card_state = 'expired', updated_at = NOW()
+      WHERE ctid IN (
+        SELECT ctid FROM ${DINGTALK_APPROVAL_CARD_DELIVERY_TABLE}
+         WHERE card_state = 'sent' AND created_at < now() - ($1::int * interval '1 day')
+         LIMIT $2
+      )`,
+    [retentionDays, batchSize],
+  )
+  return result.rowCount ?? 0
+}
+
+export interface DingTalkCardPersonDeliveryRetentionResult {
+  /** dingtalk_person_deliveries rows physically deleted. */
+  personDeleted: number
+  /** dingtalk_approval_card_deliveries rows moved sent → expired. */
+  cardExpired: number
+}
+
+/**
+ * Runs both sub-sweeps under one shared config (one retention window governs both ledgers — the
+ * operator sets one "how long to keep DingTalk delivery ledger data" knob, not two). Disabled
+ * short-circuits before touching either table.
+ */
+export async function sweepDingTalkCardPersonDeliveryRetention(
+  query: AiUsageQueryFn,
+  config: DingTalkDeliveryRetentionConfig,
+): Promise<DingTalkCardPersonDeliveryRetentionResult> {
+  if (config.disabled) return { personDeleted: 0, cardExpired: 0 }
+  const personDeleted = await sweepDingTalkPersonDeliveryRetention(query, config)
+  const cardExpired = await sweepDingTalkApprovalCardDeliveryRetention(query, config)
+  return { personDeleted, cardExpired }
+}
+
+/**
+ * Default service: binds the composed sweep to the shared pg pool + the env-resolved retention
+ * config. Re-reads the config each pass so an env change (enabling/disabling, or a new DAYS value)
+ * takes effect on the next tick without a restart. Returns the combined row count (person deletes +
+ * card expires) to satisfy the generic LedgerRetentionService's `Promise<number>` contract; the
+ * two counts are independently available via the exported sub-sweep functions for callers that
+ * need the breakdown (e.g. tests, or a future richer log line).
+ */
+export class PgDingTalkCardPersonDeliveryRetentionService implements LedgerRetentionService {
+  private readonly config?: DingTalkDeliveryRetentionConfig
+
+  constructor(config?: DingTalkDeliveryRetentionConfig) {
+    this.config = config
+  }
+
+  async sweep(): Promise<number> {
+    const config = this.config ?? resolveDingTalkDeliveryRetentionConfig()
+    if (config.disabled) return 0
+    const pool = poolManager.get() as unknown as { query: AiUsageQueryFn }
+    const query = pool.query.bind(pool) as AiUsageQueryFn
+    const { personDeleted, cardExpired } = await sweepDingTalkCardPersonDeliveryRetention(query, config)
+    return personDeleted + cardExpired
+  }
+}

--- a/packages/core-backend/tests/integration/dingtalk-card-delivery-retention-actionability.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-card-delivery-retention-actionability.db.test.ts
@@ -1,0 +1,282 @@
+/**
+ * PR #4142 P2-1 HARDENING GOLDEN — the sweep's actual security invariant, tested on the REAL
+ * production surfaces (reviewer-authored; EXECUTED and PASSING against real Postgres on the merge
+ * result of origin/main + PR #4142).
+ *
+ * Suggested landing path:
+ *   packages/core-backend/tests/integration/dingtalk-card-delivery-retention-actionability.db.test.ts
+ * and add that path to the `Run multitable real-DB integration` run-list in .github/workflows/plugin-tests.yml
+ * (next to dingtalk-card-person-delivery-retention.db.test.ts), plus the exclude list in vitest.config.ts.
+ *
+ * WHY THIS EXISTS: PR #4142's own test (e) ("SECURITY KEYSTONE") asserts only the low-level
+ * claimDingTalkApprovalCardDeliveryActed helper. Neutering the ACTUAL guard —
+ * `delivery.card_state === 'sent'` in ApprovalCardDeliveryAction.buildSummary — leaves the entire
+ * repo suite GREEN (43/43) while a swept `expired` card becomes fully actionable again. The sweep
+ * creates the first state in the system where a non-`sent` card coexists with a still-`pending`
+ * instance AND a still-live matching seat, i.e. where card_state is the SOLE load-bearing guard.
+ * This file is RED under that mutation.
+ *
+ * The CONTROL test is load-bearing: without it, `actionable:false` could mean a broken fixture
+ * rather than a working guard.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { createHmac } from 'crypto'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+import {
+  executeApprovalActionFromCardDelivery,
+  getApprovalCardDeliverySummary,
+} from '../../src/services/ApprovalCardDeliveryAction'
+import {
+  insertDingTalkApprovalCardDelivery,
+  markDingTalkApprovalCardDeliverySent,
+  findDingTalkApprovalCardDeliveryById,
+} from '../../src/integrations/dingtalk/approval-card-deliveries'
+import {
+  sweepDingTalkApprovalCardDeliveryRetention,
+  sweepDingTalkCardPersonDeliveryRetention,
+  resolveDingTalkDeliveryRetentionConfig,
+} from '../../src/services/dingtalk-card-person-delivery-retention'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const REQUESTER = `u_ret_req_${TS}`
+const APPROVER = `u_ret_appr_${TS}`
+const SECRET = 'retention-actionability-secret'
+
+const q = (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)
+const qf = (sqlText: string, params?: unknown[]) => q(sqlText, params)
+
+function tokenFor(deliveryId: string): string {
+  return createHmac('sha256', SECRET).update(deliveryId).digest('hex').slice(0, 32)
+}
+
+let approvals: ApprovalProductService
+let templateId = ''
+
+async function newInstance(): Promise<string> {
+  const dto = await approvals.createApproval(
+    { templateId, formData: { summary: 'retention actionability' } },
+    { userId: REQUESTER, userName: REQUESTER },
+  )
+  return (dto as { id: string }).id
+}
+
+/** The live entry_epoch of the node's still-active seat — the round a card binds to (#4112). */
+async function activeEpoch(instanceId: string, nodeKey: string): Promise<number | null> {
+  const r = await q(
+    `SELECT entry_epoch FROM approval_assignments
+      WHERE instance_id = $1 AND node_key = $2 AND assignee_id = $3 AND is_active = TRUE
+      ORDER BY created_at DESC LIMIT 1`,
+    [instanceId, nodeKey, APPROVER],
+  )
+  const raw = (r.rows[0] as { entry_epoch: number | string | null } | undefined)?.entry_epoch
+  return raw === null || raw === undefined ? null : Number(raw)
+}
+
+/** A card that is GENUINELY actionable right now: sent + epoch bound to the LIVE active seat. */
+async function newActionableCard(instanceId: string): Promise<string> {
+  const epoch = await activeEpoch(instanceId, 'approval_1')
+  expect(epoch).not.toBeNull()
+  const row = await insertDingTalkApprovalCardDelivery(q, {
+    instanceId,
+    nodeKey: 'approval_1',
+    recipientUserId: APPROVER,
+    recipientDingTalkUserId: `dd_${APPROVER}`,
+    deliveryKind: 'work_notice_action_card',
+    entryEpoch: epoch,
+  })
+  await markDingTalkApprovalCardDeliverySent(q, row.id, `task_ret_${row.id}`)
+  return row.id
+}
+
+async function ageCard(id: string, daysAgo: number): Promise<void> {
+  await q(
+    `UPDATE dingtalk_approval_card_deliveries SET created_at = now() - ($2::int * interval '1 day') WHERE id = $1`,
+    [id, daysAgo],
+  )
+}
+
+async function decisionRecordCount(instanceId: string): Promise<number> {
+  const r = await q(
+    `SELECT COUNT(*)::int AS c FROM approval_records WHERE instance_id = $1 AND action IN ('approve','reject')`,
+    [instanceId],
+  )
+  return (r.rows[0] as { c: number }).c
+}
+
+const actor = { userId: APPROVER, userName: APPROVER }
+
+describeIfDatabase('DingTalk card retention sweep — actionability invariant (real DB)', () => {
+  beforeAll(async () => {
+    process.env.APPROVAL_CARD_LINK_SECRET = SECRET
+    await q(`INSERT INTO permissions (code, name, description) VALUES ('approvals:read','r','t'),('approvals:write','w','t'),('approvals:act','a','t') ON CONFLICT (code) DO NOTHING`)
+    for (const uid of [REQUESTER, APPROVER]) {
+      await q(`INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+               VALUES ($1,$2,$1,'x','user','[]'::jsonb,TRUE,FALSE) ON CONFLICT (id) DO UPDATE SET is_active = TRUE`, [uid, `${uid}@ret.test`])
+    }
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:write') ON CONFLICT DO NOTHING`, [REQUESTER])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:act') ON CONFLICT DO NOTHING`, [APPROVER])
+
+    approvals = new ApprovalProductService()
+    const template = await approvals.createTemplate({
+      key: `ret-act-${TS}`,
+      name: 'Retention Actionability Template',
+      formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: 'Start', config: {} },
+          { key: 'approval_1', type: 'approval', name: 'First', config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }] } },
+          { key: 'end', type: 'end', name: 'End', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+          { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+        ],
+      },
+    } as never)
+    templateId = (template as { id: string }).id
+    await approvals.publishTemplate(templateId, { policy: { allowRevoke: true, rejectCommentRequired: false } } as never)
+  })
+
+  afterAll(async () => {
+    const instances = await q('SELECT id FROM approval_instances WHERE template_id = $1', [templateId]).catch(() => ({ rows: [] as unknown[] }))
+    for (const row of instances.rows as Array<{ id: string }>) {
+      await q('DELETE FROM dingtalk_approval_card_deliveries WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_assignments WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_records WHERE instance_id = $1', [row.id]).catch(() => {})
+      await q('DELETE FROM approval_instances WHERE id = $1', [row.id]).catch(() => {})
+    }
+    await q('DELETE FROM approval_templates WHERE id = $1', [templateId]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[REQUESTER, APPROVER]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[REQUESTER, APPROVER]]).catch(() => {})
+  })
+
+  test('CONTROL: an UNSWEPT past-window sent card w/ a live seat IS actionable and DOES approve', async () => {
+    const instanceId = await newInstance()
+    const cardId = await newActionableCard(instanceId)
+    await ageCard(cardId, 31) // past the window — but we do NOT sweep
+
+    const summary = await getApprovalCardDeliverySummary({ query: qf }, {
+      deliveryId: cardId, token: tokenFor(cardId), viewerUserId: APPROVER,
+    })
+    expect(summary.status).toBe('ok')
+    expect((summary as { summary: { actionable: boolean } }).summary.actionable).toBe(true)
+
+    const outcome = await executeApprovalActionFromCardDelivery({ query: qf, approvals }, {
+      deliveryId: cardId, token: tokenFor(cardId), decision: 'approve', actor,
+    })
+    expect(outcome.status).toBe('ok')
+    expect(await decisionRecordCount(instanceId)).toBe(1)
+  })
+
+  test('SECURITY: a SWEPT (expired) card whose seat is STILL LIVE is NOT actionable on either production surface — ZERO approval records', async () => {
+    const instanceId = await newInstance()
+    const cardId = await newActionableCard(instanceId)
+    await ageCard(cardId, 31)
+
+    const expired = await sweepDingTalkApprovalCardDeliveryRetention(qf, { retentionDays: 30, disabled: false })
+    expect(expired).toBe(1)
+    expect((await findDingTalkApprovalCardDeliveryById(q, cardId))?.card_state).toBe('expired')
+
+    // The state this sweep newly creates: seat STILL live, epoch STILL matching, instance STILL pending.
+    // card_state is the SOLE remaining guard here — that is exactly what this test pins.
+    const seat = await q(
+      `SELECT entry_epoch FROM approval_assignments WHERE instance_id=$1 AND node_key='approval_1' AND assignee_id=$2 AND is_active=TRUE`,
+      [instanceId, APPROVER],
+    )
+    expect(seat.rows.length).toBe(1)
+    const del = await findDingTalkApprovalCardDeliveryById(q, cardId)
+    expect(Number(del?.entry_epoch)).toBe(Number((seat.rows[0] as { entry_epoch: number }).entry_epoch))
+    const inst = await q(`SELECT status FROM approval_instances WHERE id=$1`, [instanceId])
+    expect((inst.rows[0] as { status: string }).status).toBe('pending')
+
+    // READ surface
+    const summary = await getApprovalCardDeliverySummary({ query: qf }, {
+      deliveryId: cardId, token: tokenFor(cardId), viewerUserId: APPROVER,
+    })
+    expect(summary.status).toBe('ok')
+    expect((summary as { summary: { actionable: boolean } }).summary.actionable).toBe(false)
+
+    // EXECUTION surface — the sole path used by BOTH the Slice-A route and the Slice-B stream callback
+    const outcome = await executeApprovalActionFromCardDelivery({ query: qf, approvals }, {
+      deliveryId: cardId, token: tokenFor(cardId), decision: 'approve', actor,
+    })
+    expect(outcome.status).toBe('stale')
+    expect(await decisionRecordCount(instanceId)).toBe(0)
+    expect((await findDingTalkApprovalCardDeliveryById(q, cardId))?.card_state).toBe('expired')
+  })
+
+  test('BLAST: the sweep mutates ONLY card_state (+updated_at) — every binding/provenance column is immutable, approval_* untouched', async () => {
+    const instanceId = await newInstance()
+    const cardId = await newActionableCard(instanceId)
+    await ageCard(cardId, 31)
+
+    const cols = `id, instance_id, node_key, recipient_user_id, recipient_dingtalk_user_id, delivery_kind,
+                  task_id, integration_id, entry_epoch, card_state, acted_action, acted_by, acted_at,
+                  send_status, send_error, created_at`
+    const before = await q(`SELECT ${cols} FROM dingtalk_approval_card_deliveries WHERE id = $1`, [cardId])
+    const asgBefore = await q(`SELECT id, is_active, entry_epoch, node_key, assignee_id FROM approval_assignments WHERE instance_id=$1 ORDER BY id`, [instanceId])
+    const instBefore = await q(`SELECT status, current_node_key, version FROM approval_instances WHERE id=$1`, [instanceId])
+
+    await sweepDingTalkCardPersonDeliveryRetention(qf, { retentionDays: 30, disabled: false })
+
+    const after = await q(`SELECT ${cols} FROM dingtalk_approval_card_deliveries WHERE id = $1`, [cardId])
+    const asgAfter = await q(`SELECT id, is_active, entry_epoch, node_key, assignee_id FROM approval_assignments WHERE instance_id=$1 ORDER BY id`, [instanceId])
+    const instAfter = await q(`SELECT status, current_node_key, version FROM approval_instances WHERE id=$1`, [instanceId])
+
+    const b = before.rows[0] as Record<string, unknown>
+    const a = after.rows[0] as Record<string, unknown>
+    for (const col of Object.keys(b)) {
+      if (col === 'card_state') continue
+      expect({ col, v: a[col] }).toEqual({ col, v: b[col] }) // binding + provenance immutable
+    }
+    expect(b.card_state).toBe('sent')
+    expect(a.card_state).toBe('expired')
+    expect(asgAfter.rows).toEqual(asgBefore.rows)
+    expect(instAfter.rows).toEqual(instBefore.rows)
+  })
+
+  test('DEFAULT-OFF: unset/invalid/zero/negative/non-numeric DAYS never sweeps — a past-window card sits untouched', async () => {
+    const instanceId = await newInstance()
+    const cardId = await newActionableCard(instanceId)
+    await ageCard(cardId, 400)
+
+    const cfg = resolveDingTalkDeliveryRetentionConfig({} as NodeJS.ProcessEnv)
+    expect(cfg.disabled).toBe(true)
+    expect(await sweepDingTalkCardPersonDeliveryRetention(qf, cfg)).toEqual({ personDeleted: 0, cardExpired: 0 })
+
+    for (const bad of ['0', '-5', 'abc', '', 'NaN', '1e999x']) {
+      const c = resolveDingTalkDeliveryRetentionConfig({ DINGTALK_DELIVERY_RETENTION_DAYS: bad } as NodeJS.ProcessEnv)
+      expect({ bad, disabled: c.disabled }).toEqual({ bad, disabled: true }) // never falls back to a default window
+      expect({ bad, r: await sweepDingTalkCardPersonDeliveryRetention(qf, c) })
+        .toEqual({ bad, r: { personDeleted: 0, cardExpired: 0 } })
+    }
+
+    const killed = resolveDingTalkDeliveryRetentionConfig({
+      DINGTALK_DELIVERY_RETENTION_DAYS: '30', DINGTALK_DELIVERY_RETENTION_DISABLED: '1',
+    } as NodeJS.ProcessEnv)
+    expect(killed.disabled).toBe(true)
+    expect(await sweepDingTalkCardPersonDeliveryRetention(qf, killed)).toEqual({ personDeleted: 0, cardExpired: 0 })
+
+    expect((await findDingTalkApprovalCardDeliveryById(q, cardId))?.card_state).toBe('sent')
+  })
+
+  test('an ACTED card past the window is never swept (dacd_acted_consistency safety) and keeps its provenance', async () => {
+    const instanceId = await newInstance()
+    const cardId = await newActionableCard(instanceId)
+    const outcome = await executeApprovalActionFromCardDelivery({ query: qf, approvals }, {
+      deliveryId: cardId, token: tokenFor(cardId), decision: 'approve', actor,
+    })
+    expect(outcome.status).toBe('ok')
+    await ageCard(cardId, 999)
+
+    await expect(sweepDingTalkApprovalCardDeliveryRetention(qf, { retentionDays: 30, disabled: false }))
+      .resolves.toBeGreaterThanOrEqual(0)
+    const row = await findDingTalkApprovalCardDeliveryById(q, cardId)
+    expect(row?.card_state).toBe('acted')
+    expect(row?.acted_by).toBe(APPROVER)
+  })
+})

--- a/packages/core-backend/tests/integration/dingtalk-card-person-delivery-retention.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-card-person-delivery-retention.db.test.ts
@@ -1,0 +1,300 @@
+/**
+ * DT-HARDEN-08 follow-up — dingtalk_approval_card_deliveries + dingtalk_person_deliveries
+ * retention sweep (real DB). Sibling of dingtalk-group-delivery-retention.db.test.ts.
+ *
+ * dingtalk_person_deliveries is write-once (full message content + raw response bodies, no
+ * DELETE anywhere) — mirrors the group ledger's shape exactly, so its sweep is a bounded batch
+ * DELETE. dingtalk_approval_card_deliveries carries the security-relevant card_state machine
+ * instead of message content — its sweep only ever moves a stale `sent` row to the already-valid
+ * `expired` terminal state, NEVER deletes (acted_action/acted_by/acted_at are the only
+ * delivery-channel record of who approved/rejected via card, and are preserved even past the
+ * window).
+ *
+ * KEYSTONE (security): a card row the sweep expires must NOT be claimable afterward —
+ * claimDingTalkApprovalCardDeliveryActed's `WHERE card_state='sent'` guard must reject it, proving
+ * the sweep can only ever move a card AWAY from actionable, never toward it.
+ *
+ * Also proves: (a) unset env ⇒ true no-op (both tables untouched) — the default-OFF gate this
+ * sweep deliberately inverts from the group sweep's opt-out default; (b) rows inside the window
+ * are untouched; (c) rows outside the window are redacted/expired per the precedent above; (d)
+ * idempotent; (e) swept card row is non-actionable; (f) the sweep does not touch
+ * dingtalk_group_deliveries, the sibling ledger it does not own.
+ *
+ * Wired into .github/workflows/plugin-tests.yml "Run multitable real-DB integration" step;
+ * excluded from packages/core-backend/vitest.config.ts's default (no-DB) job so it cannot
+ * skip-green there.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import {
+  claimDingTalkApprovalCardDeliveryActed,
+  findDingTalkApprovalCardDeliveryById,
+  insertDingTalkApprovalCardDelivery,
+  markDingTalkApprovalCardDeliverySent,
+} from '../../src/integrations/dingtalk/approval-card-deliveries'
+import {
+  DINGTALK_APPROVAL_CARD_DELIVERY_TABLE,
+  DINGTALK_PERSON_DELIVERY_TABLE,
+  PgDingTalkCardPersonDeliveryRetentionService,
+  resolveDingTalkDeliveryRetentionConfig,
+  sweepDingTalkApprovalCardDeliveryRetention,
+  sweepDingTalkCardPersonDeliveryRetention,
+  sweepDingTalkPersonDeliveryRetention,
+} from '../../src/services/dingtalk-card-person-delivery-retention'
+import { LedgerRetentionScheduler } from '../../src/services/LedgerRetentionScheduler'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const INSTANCE_ID = `apv_dacpr_${TS}`
+const GROUP_DESTINATION_ID = `dtdest_dacpr_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+async function ageRow(table: string, id: string, daysAgo: number): Promise<void> {
+  await q(`UPDATE ${table} SET created_at = now() - ($2::int * interval '1 day') WHERE id = $1`, [id, daysAgo])
+}
+
+// --- dingtalk_person_deliveries fixtures (no FK — plain TEXT columns) -----------------------
+const OLD_PERSON = `dacpr_person_old_${TS}`
+const NEW_PERSON = `dacpr_person_new_${TS}`
+
+async function seedPersonRow(id: string, daysAgo: number): Promise<void> {
+  await q(
+    `INSERT INTO ${DINGTALK_PERSON_DELIVERY_TABLE}
+       (id, local_user_id, source_type, subject, content, success, status)
+     VALUES ($1, 'user_dacpr', 'automation', 'retention test', 'hello content', true, 'success')`,
+    [id],
+  )
+  await ageRow(DINGTALK_PERSON_DELIVERY_TABLE, id, daysAgo)
+}
+
+async function personIds(): Promise<string[]> {
+  const res = await q(`SELECT id FROM ${DINGTALK_PERSON_DELIVERY_TABLE} WHERE local_user_id = 'user_dacpr' ORDER BY id`)
+  return (res.rows as Array<{ id: string }>).map((r) => r.id)
+}
+
+// --- dingtalk_approval_card_deliveries fixtures (FK → approval_instances) -------------------
+const OLD_SENT_CARD = `dacpr_card_old_sent_${TS}`
+const NEW_SENT_CARD = `dacpr_card_new_sent_${TS}`
+const OLD_ACTED_CARD = `dacpr_card_old_acted_${TS}`
+
+async function seedCardRows(): Promise<void> {
+  await insertDingTalkApprovalCardDelivery(q, {
+    id: OLD_SENT_CARD,
+    instanceId: INSTANCE_ID,
+    nodeKey: 'approval_1',
+    recipientUserId: 'user_old_sent',
+    recipientDingTalkUserId: 'dd_user_old_sent',
+    deliveryKind: 'work_notice_action_card',
+  })
+  await markDingTalkApprovalCardDeliverySent(q, OLD_SENT_CARD, 'task_dacpr_old_sent') // send_status='sent' — WOULD be actionable if not swept
+  await ageRow(DINGTALK_APPROVAL_CARD_DELIVERY_TABLE, OLD_SENT_CARD, 31)
+
+  await insertDingTalkApprovalCardDelivery(q, {
+    id: NEW_SENT_CARD,
+    instanceId: INSTANCE_ID,
+    nodeKey: 'approval_1',
+    recipientUserId: 'user_new_sent',
+    recipientDingTalkUserId: 'dd_user_new_sent',
+    deliveryKind: 'work_notice_action_card',
+  })
+  await markDingTalkApprovalCardDeliverySent(q, NEW_SENT_CARD, 'task_dacpr_new_sent')
+  await ageRow(DINGTALK_APPROVAL_CARD_DELIVERY_TABLE, NEW_SENT_CARD, 29)
+
+  await insertDingTalkApprovalCardDelivery(q, {
+    id: OLD_ACTED_CARD,
+    instanceId: INSTANCE_ID,
+    nodeKey: 'approval_1',
+    recipientUserId: 'user_old_acted',
+    recipientDingTalkUserId: 'dd_user_old_acted',
+    deliveryKind: 'work_notice_action_card',
+  })
+  await markDingTalkApprovalCardDeliverySent(q, OLD_ACTED_CARD, 'task_dacpr_old_acted')
+  await claimDingTalkApprovalCardDeliveryActed(q, OLD_ACTED_CARD, { action: 'approve', actedBy: 'user_old_acted' })
+  await ageRow(DINGTALK_APPROVAL_CARD_DELIVERY_TABLE, OLD_ACTED_CARD, 31) // old AND already-terminal — must stay 'acted', not touched
+}
+
+async function cardState(id: string): Promise<string | null> {
+  const row = await findDingTalkApprovalCardDeliveryById(q, id)
+  return row?.card_state ?? null
+}
+
+async function reseed(): Promise<void> {
+  await q(`DELETE FROM ${DINGTALK_APPROVAL_CARD_DELIVERY_TABLE} WHERE instance_id = $1`, [INSTANCE_ID])
+  await q(`DELETE FROM ${DINGTALK_PERSON_DELIVERY_TABLE} WHERE local_user_id = 'user_dacpr'`)
+  await seedPersonRow(OLD_PERSON, 31)
+  await seedPersonRow(NEW_PERSON, 29)
+  await seedCardRows()
+}
+
+describeIfDatabase('DingTalk approval-card + person delivery retention sweep (real DB)', () => {
+  beforeAll(async () => {
+    await q(
+      `INSERT INTO approval_instances (id, status, current_node_key) VALUES ($1, 'pending', 'approval_1') ON CONFLICT (id) DO NOTHING`,
+      [INSTANCE_ID],
+    )
+    await q(
+      `INSERT INTO dingtalk_group_destinations (id, name, webhook_url, created_by)
+       VALUES ($1, 'dacpr sibling-isolation destination', 'https://oapi.dingtalk.com/robot/send?access_token=dacpr', 'tester')
+       ON CONFLICT (id) DO NOTHING`,
+      [GROUP_DESTINATION_ID],
+    )
+    await reseed()
+  })
+
+  beforeEach(async () => {
+    await reseed()
+  })
+
+  afterAll(async () => {
+    await q(`DELETE FROM ${DINGTALK_APPROVAL_CARD_DELIVERY_TABLE} WHERE instance_id = $1`, [INSTANCE_ID]).catch(() => {})
+    await q(`DELETE FROM ${DINGTALK_PERSON_DELIVERY_TABLE} WHERE local_user_id = 'user_dacpr'`).catch(() => {})
+    await q(`DELETE FROM approval_instances WHERE id = $1`, [INSTANCE_ID]).catch(() => {})
+    await q(`DELETE FROM dingtalk_group_deliveries WHERE destination_id = $1`, [GROUP_DESTINATION_ID]).catch(() => {})
+    await q(`DELETE FROM dingtalk_group_destinations WHERE id = $1`, [GROUP_DESTINATION_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('(a) DEFAULT-OFF: resolveDingTalkDeliveryRetentionConfig({}) (unset env) drives a true no-op against the real DB — both tables completely unchanged', async () => {
+    const config = resolveDingTalkDeliveryRetentionConfig({}) // simulates a deployment that never set DINGTALK_DELIVERY_RETENTION_DAYS
+    expect(config.disabled).toBe(true)
+
+    const result = await sweepDingTalkCardPersonDeliveryRetention((sql, params) => q(sql, params), config)
+    expect(result).toEqual({ personDeleted: 0, cardExpired: 0 })
+
+    expect((await personIds()).sort()).toEqual([NEW_PERSON, OLD_PERSON].sort())
+    expect(await cardState(OLD_SENT_CARD)).toBe('sent') // NOT expired — the env was never configured
+    expect(await cardState(NEW_SENT_CARD)).toBe('sent')
+    expect(await cardState(OLD_ACTED_CARD)).toBe('acted')
+  })
+
+  test('(b)+(c) KEYSTONE: a 30-day sweep deletes only the >30d person row and expires only the >30d still-sent card row; everything inside the window (and any non-sent card) is untouched', async () => {
+    expect((await personIds()).sort()).toEqual([NEW_PERSON, OLD_PERSON].sort())
+
+    const result = await sweepDingTalkCardPersonDeliveryRetention((sql, params) => q(sql, params), {
+      retentionDays: 30,
+      disabled: false,
+    })
+    expect(result).toEqual({ personDeleted: 1, cardExpired: 1 })
+
+    // person: old deleted, new kept
+    expect(await personIds()).toEqual([NEW_PERSON])
+
+    // card: old-sent → expired; new-sent untouched; old-but-already-acted untouched (never a delete, never re-touched)
+    expect(await cardState(OLD_SENT_CARD)).toBe('expired')
+    expect(await cardState(NEW_SENT_CARD)).toBe('sent')
+    expect(await cardState(OLD_ACTED_CARD)).toBe('acted')
+
+    // the expired row is NOT physically deleted — the ledger keeps it (delivery-channel record)
+    expect(await findDingTalkApprovalCardDeliveryById(q, OLD_SENT_CARD)).not.toBeNull()
+  })
+
+  test('(e) SECURITY KEYSTONE: a swept (expired) card row can never be claimed — the atomic claim requires card_state=\'sent\' and a swept row fails it, staying expired forever', async () => {
+    await sweepDingTalkApprovalCardDeliveryRetention((sql, params) => q(sql, params), { retentionDays: 30, disabled: false })
+    expect(await cardState(OLD_SENT_CARD)).toBe('expired')
+
+    // OLD_SENT_CARD was marked send_status='sent' before ageing — it WOULD have been claimable had
+    // the sweep not expired it first. The claim must now fail (return null) and never flip back.
+    const claimed = await claimDingTalkApprovalCardDeliveryActed(q, OLD_SENT_CARD, {
+      action: 'approve',
+      actedBy: 'attacker_or_late_tap',
+    })
+    expect(claimed).toBeNull()
+    expect(await cardState(OLD_SENT_CARD)).toBe('expired') // still expired, never 'acted', never back to 'sent'
+  })
+
+  test('(d) idempotence: a second sweep pass over the same window deletes/expires 0 more', async () => {
+    const first = await sweepDingTalkCardPersonDeliveryRetention((sql, params) => q(sql, params), {
+      retentionDays: 30,
+      disabled: false,
+    })
+    expect(first).toEqual({ personDeleted: 1, cardExpired: 1 })
+
+    const second = await sweepDingTalkCardPersonDeliveryRetention((sql, params) => q(sql, params), {
+      retentionDays: 30,
+      disabled: false,
+    })
+    expect(second).toEqual({ personDeleted: 0, cardExpired: 0 })
+
+    expect(await personIds()).toEqual([NEW_PERSON])
+    expect(await cardState(OLD_SENT_CARD)).toBe('expired')
+  })
+
+  test('disabled config (explicit disabled:true) is a no-op on both tables', async () => {
+    const result = await sweepDingTalkCardPersonDeliveryRetention((sql, params) => q(sql, params), {
+      retentionDays: 30,
+      disabled: true,
+    })
+    expect(result).toEqual({ personDeleted: 0, cardExpired: 0 })
+    expect((await personIds()).sort()).toEqual([NEW_PERSON, OLD_PERSON].sort())
+    expect(await cardState(OLD_SENT_CARD)).toBe('sent')
+  })
+
+  test('the batch LIMIT bounds a single person-delete pass (batchSize=1 does not also expire cards in the same call — sub-sweeps are independently bounded)', async () => {
+    const deleted = await sweepDingTalkPersonDeliveryRetention((sql, params) => q(sql, params), {
+      retentionDays: 30,
+      disabled: false,
+      batchSize: 1,
+    })
+    expect(deleted).toBe(1) // only 1 stale person row exists, batch bound is not exercised further here, but proves the LIMIT wiring executes
+    expect(await personIds()).toEqual([NEW_PERSON])
+    // card table untouched by the person-only sub-sweep
+    expect(await cardState(OLD_SENT_CARD)).toBe('sent')
+  })
+
+  test('the batch LIMIT bounds a single card-expire pass (batchSize=1)', async () => {
+    const expired = await sweepDingTalkApprovalCardDeliveryRetention((sql, params) => q(sql, params), {
+      retentionDays: 30,
+      disabled: false,
+      batchSize: 1,
+    })
+    expect(expired).toBe(1)
+    expect(await cardState(OLD_SENT_CARD)).toBe('expired')
+    // person table untouched by the card-only sub-sweep
+    expect(await personIds()).toEqual(expect.arrayContaining([OLD_PERSON, NEW_PERSON]))
+  })
+
+  test('(f) sibling isolation: the sweep never touches dingtalk_group_deliveries (a table it does not own)', async () => {
+    const OLD_GROUP_ROW = `dacpr_group_${TS}`
+    await q(
+      `INSERT INTO dingtalk_group_deliveries (
+         id, destination_id, source_type, subject, content, success,
+         http_status, response_body, error_message
+       ) VALUES ($1, $2, 'automation', 'sibling test', 'hello', true, 200, 'ok', NULL)`,
+      [OLD_GROUP_ROW, GROUP_DESTINATION_ID],
+    )
+    await ageRow('dingtalk_group_deliveries', OLD_GROUP_ROW, 365) // far past any retention window
+
+    await sweepDingTalkCardPersonDeliveryRetention((sql, params) => q(sql, params), { retentionDays: 30, disabled: false })
+
+    const res = await q(`SELECT id FROM dingtalk_group_deliveries WHERE id = $1`, [OLD_GROUP_ROW])
+    expect(res.rows).toHaveLength(1) // untouched — this sweep owns only the card + person ledgers
+  })
+
+  test('PgDingTalkCardPersonDeliveryRetentionService.sweep() (the scheduler-bound path) hits the real DB identically and returns the combined count', async () => {
+    const service = new PgDingTalkCardPersonDeliveryRetentionService({ retentionDays: 30, disabled: false })
+    const swept = await service.sweep()
+    expect(swept).toBe(2) // 1 person deleted + 1 card expired
+    expect(await personIds()).toEqual([NEW_PERSON])
+    expect(await cardState(OLD_SENT_CARD)).toBe('expired')
+  })
+
+  test('the scheduler tick drives the sweep end-to-end (LedgerRetentionScheduler + PgDingTalkCardPersonDeliveryRetentionService)', async () => {
+    const scheduler = new LedgerRetentionScheduler({
+      service: new PgDingTalkCardPersonDeliveryRetentionService({ retentionDays: 30, disabled: false }),
+    })
+    expect(scheduler.leader).toBe(true)
+
+    const swept = await scheduler.tick()
+    expect(swept).toBe(2)
+    expect(await personIds()).toEqual([NEW_PERSON])
+    expect(await cardState(OLD_SENT_CARD)).toBe('expired')
+
+    scheduler.stop()
+  })
+})

--- a/packages/core-backend/tests/integration/dingtalk-card-person-delivery-retention.db.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-card-person-delivery-retention.db.test.ts
@@ -194,7 +194,7 @@ describeIfDatabase('DingTalk approval-card + person delivery retention sweep (re
     expect(await findDingTalkApprovalCardDeliveryById(q, OLD_SENT_CARD)).not.toBeNull()
   })
 
-  test('(e) SECURITY KEYSTONE: a swept (expired) card row can never be claimed — the atomic claim requires card_state=\'sent\' and a swept row fails it, staying expired forever', async () => {
+  test('(e) LEDGER-LEVEL: a swept (expired) card row can never be CLAIMED (low-level helper only — the real security surface is covered by dingtalk-card-delivery-retention-actionability.db.test.ts) — the atomic claim requires card_state=\'sent\' and a swept row fails it, staying expired forever', async () => {
     await sweepDingTalkApprovalCardDeliveryRetention((sql, params) => q(sql, params), { retentionDays: 30, disabled: false })
     expect(await cardState(OLD_SENT_CARD)).toBe('expired')
 

--- a/packages/core-backend/tests/unit/dingtalk-card-person-delivery-retention.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-card-person-delivery-retention.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  DINGTALK_DELIVERY_RETENTION_DEFAULT_DAYS,
+  DINGTALK_DELIVERY_RETENTION_MIN_DAYS,
+  resolveDingTalkDeliveryRetentionConfig,
+  sweepDingTalkApprovalCardDeliveryRetention,
+  sweepDingTalkCardPersonDeliveryRetention,
+  sweepDingTalkPersonDeliveryRetention,
+} from '../../src/services/dingtalk-card-person-delivery-retention'
+import {
+  LedgerRetentionScheduler,
+  stopLedgerRetentionScheduler,
+} from '../../src/services/LedgerRetentionScheduler'
+import {
+  resolveDingTalkCardPersonDeliveryRetentionSchedulerIntervalMs,
+  startDingTalkCardPersonDeliveryRetentionScheduler,
+  stopDingTalkCardPersonDeliveryRetentionScheduler,
+} from '../../src/services/dingtalk-card-person-delivery-retention-scheduler'
+
+describe('resolveDingTalkDeliveryRetentionConfig (env parse + floor + DEFAULT-OFF gate)', () => {
+  it('DEFAULT-OFF: disabled with no env set at all (inverse of the sibling group-delivery sweep)', () => {
+    expect(resolveDingTalkDeliveryRetentionConfig({})).toEqual({
+      retentionDays: DINGTALK_DELIVERY_RETENTION_DEFAULT_DAYS,
+      disabled: true,
+    })
+  })
+
+  it('enables with a valid positive DINGTALK_DELIVERY_RETENTION_DAYS', () => {
+    expect(
+      resolveDingTalkDeliveryRetentionConfig({ DINGTALK_DELIVERY_RETENTION_DAYS: '30' }),
+    ).toEqual({ retentionDays: 30, disabled: false })
+  })
+
+  it('floors the retention window at the min (foot-gun guard): 1 day → MIN, still enabled', () => {
+    const config = resolveDingTalkDeliveryRetentionConfig({ DINGTALK_DELIVERY_RETENTION_DAYS: '1' })
+    expect(config.retentionDays).toBe(DINGTALK_DELIVERY_RETENTION_MIN_DAYS)
+    expect(config.disabled).toBe(false)
+  })
+
+  it('an invalid/non-positive DAYS value stays DISABLED (fail closed) — it does NOT fall back to the default window and enable anyway (deliberate deviation from the group sweep)', () => {
+    expect(resolveDingTalkDeliveryRetentionConfig({ DINGTALK_DELIVERY_RETENTION_DAYS: 'abc' }).disabled).toBe(true)
+    expect(resolveDingTalkDeliveryRetentionConfig({ DINGTALK_DELIVERY_RETENTION_DAYS: '0' }).disabled).toBe(true)
+    expect(resolveDingTalkDeliveryRetentionConfig({ DINGTALK_DELIVERY_RETENTION_DAYS: '-10' }).disabled).toBe(true)
+    expect(resolveDingTalkDeliveryRetentionConfig({ DINGTALK_DELIVERY_RETENTION_DAYS: 'NaN' }).disabled).toBe(true)
+  })
+
+  it('DINGTALK_DELIVERY_RETENTION_DISABLED=1 forces disabled even when DAYS is validly set', () => {
+    expect(
+      resolveDingTalkDeliveryRetentionConfig({
+        DINGTALK_DELIVERY_RETENTION_DAYS: '30',
+        DINGTALK_DELIVERY_RETENTION_DISABLED: '1',
+      }).disabled,
+    ).toBe(true)
+  })
+
+  it('does not force-disable on any other value (only the literal "1" disables)', () => {
+    expect(
+      resolveDingTalkDeliveryRetentionConfig({
+        DINGTALK_DELIVERY_RETENTION_DAYS: '30',
+        DINGTALK_DELIVERY_RETENTION_DISABLED: 'true',
+      }).disabled,
+    ).toBe(false)
+  })
+})
+
+describe('sweepDingTalkPersonDeliveryRetention / sweepDingTalkApprovalCardDeliveryRetention (disabled short-circuit + re-floor)', () => {
+  it('sweepDingTalkPersonDeliveryRetention is a no-op when disabled (never queries)', async () => {
+    const query = vi.fn(async () => ({ rows: [], rowCount: 0 }))
+    expect(await sweepDingTalkPersonDeliveryRetention(query as never, { retentionDays: 30, disabled: true })).toBe(0)
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('sweepDingTalkApprovalCardDeliveryRetention is a no-op when disabled (never queries)', async () => {
+    const query = vi.fn(async () => ({ rows: [], rowCount: 0 }))
+    expect(await sweepDingTalkApprovalCardDeliveryRetention(query as never, { retentionDays: 30, disabled: true })).toBe(0)
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('sweepDingTalkPersonDeliveryRetention re-floors an out-of-range config.retentionDays before building the DELETE', async () => {
+    const calls: Array<unknown[] | undefined> = []
+    const query = vi.fn(async (_sql: string, params?: unknown[]) => {
+      calls.push(params)
+      return { rows: [], rowCount: 0 }
+    })
+    await sweepDingTalkPersonDeliveryRetention(query as never, { retentionDays: 1, disabled: false })
+    expect(query).toHaveBeenCalledTimes(1)
+    expect(calls[0]?.[0]).toBe(DINGTALK_DELIVERY_RETENTION_MIN_DAYS)
+  })
+
+  it('sweepDingTalkApprovalCardDeliveryRetention re-floors an out-of-range config.retentionDays before building the UPDATE, and the UPDATE requires card_state=\'sent\'', async () => {
+    const calls: Array<{ sql: string; params?: unknown[] }> = []
+    const query = vi.fn(async (sql: string, params?: unknown[]) => {
+      calls.push({ sql, params })
+      return { rows: [], rowCount: 0 }
+    })
+    await sweepDingTalkApprovalCardDeliveryRetention(query as never, { retentionDays: 1, disabled: false })
+    expect(query).toHaveBeenCalledTimes(1)
+    expect(calls[0]?.params?.[0]).toBe(DINGTALK_DELIVERY_RETENTION_MIN_DAYS)
+    expect(calls[0]?.sql).toMatch(/SET card_state = 'expired'/)
+    expect(calls[0]?.sql).toMatch(/WHERE card_state = 'sent'/)
+    // never reachable to touch task_id, send_status, acted_*, or integration_id
+    expect(calls[0]?.sql).not.toMatch(/task_id/)
+    expect(calls[0]?.sql).not.toMatch(/send_status/)
+    expect(calls[0]?.sql).not.toMatch(/acted_/)
+  })
+
+  it('sweepDingTalkCardPersonDeliveryRetention composes both sub-sweeps and short-circuits on disabled', async () => {
+    const query = vi.fn(async () => ({ rows: [], rowCount: 0 }))
+    expect(await sweepDingTalkCardPersonDeliveryRetention(query as never, { retentionDays: 30, disabled: true })).toEqual({
+      personDeleted: 0,
+      cardExpired: 0,
+    })
+    expect(query).not.toHaveBeenCalled()
+
+    const calls: string[] = []
+    const activeQuery = vi.fn(async (sql: string) => {
+      calls.push(sql)
+      return { rows: [], rowCount: 3 }
+    })
+    expect(await sweepDingTalkCardPersonDeliveryRetention(activeQuery as never, { retentionDays: 30, disabled: false })).toEqual({
+      personDeleted: 3,
+      cardExpired: 3,
+    })
+    expect(calls).toHaveLength(2)
+    expect(calls[0]).toMatch(/DELETE FROM dingtalk_person_deliveries/)
+    expect(calls[1]).toMatch(/UPDATE dingtalk_approval_card_deliveries/)
+  })
+})
+
+describe('DingTalk approval-card/person delivery retention scheduler (reuses the generic LedgerRetentionScheduler)', () => {
+  afterEach(() => {
+    stopLedgerRetentionScheduler()
+    stopDingTalkCardPersonDeliveryRetentionScheduler()
+    delete process.env.DINGTALK_DELIVERY_RETENTION_DISABLED
+    delete process.env.DINGTALK_DELIVERY_RETENTION_DAYS
+    delete process.env.DINGTALK_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS
+  })
+
+  it('tick() delegates to the injected fake sweep and returns its count', async () => {
+    const sweep = vi.fn<() => Promise<number>>().mockResolvedValue(7)
+    const scheduler = new LedgerRetentionScheduler({ service: { sweep } })
+    expect(await scheduler.tick()).toBe(7)
+    expect(sweep).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows sweep errors and returns 0 (degraded mode)', async () => {
+    const sweep = vi.fn().mockRejectedValue(new Error('db down'))
+    const scheduler = new LedgerRetentionScheduler({ service: { sweep } })
+    expect(await scheduler.tick()).toBe(0)
+  })
+
+  it('startDingTalkCardPersonDeliveryRetentionScheduler returns null when DINGTALK_DELIVERY_RETENTION_DISABLED=1', () => {
+    process.env.DINGTALK_DELIVERY_RETENTION_DISABLED = '1'
+    const scheduler = startDingTalkCardPersonDeliveryRetentionScheduler({
+      service: { sweep: vi.fn().mockResolvedValue(0) },
+    })
+    expect(scheduler).toBeNull()
+  })
+
+  it('startDingTalkCardPersonDeliveryRetentionScheduler STARTS by default (no env) — the boot wiring never depends on the retention-days env var, even though the real sweep it drives is a no-op until DINGTALK_DELIVERY_RETENTION_DAYS is set', () => {
+    const scheduler = startDingTalkCardPersonDeliveryRetentionScheduler({
+      service: { sweep: vi.fn().mockResolvedValue(0) },
+    })
+    expect(scheduler).not.toBeNull()
+  })
+
+  it('startDingTalkCardPersonDeliveryRetentionScheduler returns the same shared instance on repeat calls', () => {
+    const first = startDingTalkCardPersonDeliveryRetentionScheduler({ service: { sweep: vi.fn().mockResolvedValue(0) } })
+    const second = startDingTalkCardPersonDeliveryRetentionScheduler({ service: { sweep: vi.fn().mockResolvedValue(0) } })
+    expect(first).toBe(second)
+  })
+
+  it('resolveDingTalkCardPersonDeliveryRetentionSchedulerIntervalMs reads a positive override, else undefined', () => {
+    expect(resolveDingTalkCardPersonDeliveryRetentionSchedulerIntervalMs()).toBeUndefined()
+    process.env.DINGTALK_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS = '3600000'
+    expect(resolveDingTalkCardPersonDeliveryRetentionSchedulerIntervalMs()).toBe(3600000)
+    process.env.DINGTALK_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS = '-5'
+    expect(resolveDingTalkCardPersonDeliveryRetentionSchedulerIntervalMs()).toBeUndefined()
+  })
+
+  it('start() actually arms the interval loop, using the REAL default-resolved service end-to-end: with no DINGTALK_DELIVERY_RETENTION_DAYS set, the tick fires on schedule but sweeps 0 rows every time (default-off proof at the scheduler level, not just the config-resolver level)', async () => {
+    vi.useFakeTimers()
+    try {
+      const intervalMs = 60_000 // MIN_INTERVAL_MS floor in LedgerRetentionScheduler
+      // No service injected: exercises the REAL PgDingTalkCardPersonDeliveryRetentionService via
+      // the default resolver — but sweep() short-circuits before touching the pool because the
+      // resolved config is disabled (no DAYS env set), so this never needs a live DB.
+      const scheduler = startDingTalkCardPersonDeliveryRetentionScheduler({ intervalMs })
+      expect(scheduler).not.toBeNull()
+      await scheduler!.ready
+
+      await vi.advanceTimersByTimeAsync(intervalMs)
+      expect(await scheduler!.tick()).toBe(0) // still disabled — ticking again confirms convergence, not a fluke
+
+      stopDingTalkCardPersonDeliveryRetentionScheduler()
+      await vi.advanceTimersByTimeAsync(intervalMs * 3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('start() arms + re-arms + stop() halts, with an injected fake sweep (same shape as the group scheduler test)', async () => {
+    vi.useFakeTimers()
+    try {
+      const sweep = vi.fn<() => Promise<number>>().mockResolvedValue(0)
+      const intervalMs = 60_000
+      const scheduler = startDingTalkCardPersonDeliveryRetentionScheduler({ service: { sweep }, intervalMs })
+      expect(scheduler).not.toBeNull()
+      await scheduler!.ready
+
+      expect(sweep).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(intervalMs)
+      expect(sweep).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(intervalMs)
+      expect(sweep).toHaveBeenCalledTimes(2)
+
+      stopDingTalkCardPersonDeliveryRetentionScheduler()
+      await vi.advanceTimersByTimeAsync(intervalMs * 3)
+      expect(sweep).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -209,6 +209,7 @@ export default defineConfig({
       // Excluded from the no-DB default job so it cannot skip-green, and wired as a WHOLE FILE
       // into the `Run multitable real-DB integration` step in plugin-tests.yml.
       'tests/integration/dingtalk-card-person-delivery-retention.db.test.ts',
+      'tests/integration/dingtalk-card-delivery-retention-actionability.db.test.ts',
       // comments.api.test.ts needs setup.integration.ts + a live DB. It stays
       // CI-excluded (NOT wired) because 8 of its tests have a pre-existing real-wire
       // failure (CommentService.mapRowToComment drops containerId/targetId/

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -204,6 +204,11 @@ export default defineConfig({
       // as a WHOLE FILE into the `Run multitable real-DB integration` step in plugin-tests.yml where
       // it runs against real Postgres every PR.
       'tests/integration/dingtalk-group-delivery-retention.db.test.ts',
+      // DT-HARDEN-08 follow-up (sibling of the above): dingtalk_approval_card_deliveries +
+      // dingtalk_person_deliveries retention sweep. DATABASE_URL-gated (describeIfDatabase).
+      // Excluded from the no-DB default job so it cannot skip-green, and wired as a WHOLE FILE
+      // into the `Run multitable real-DB integration` step in plugin-tests.yml.
+      'tests/integration/dingtalk-card-person-delivery-retention.db.test.ts',
       // comments.api.test.ts needs setup.integration.ts + a live DB. It stays
       // CI-excluded (NOT wired) because 8 of its tests have a pre-existing real-wire
       // failure (CommentService.mapRowToComment drops containerId/targetId/


### PR DESCRIPTION
Closes the last unexpired ledgers on the DingTalk line. DT-HARDEN-08 doctrine is **redact, index, expire, scope**; `dingtalk_group_deliveries` got its sweep in #4013 — these two were the remainder, with **no `DELETE` anywhere in the codebase**.

## Two headline decisions (read these first)

**1. Default-OFF — a deliberate deviation from the group sweep.** The group sweep is default-**ON** (opt-out) and falls back to its 90d default even on an invalid value. This one is a **no-op until an operator sets a valid positive `DINGTALK_DELIVERY_RETENTION_DAYS`**; unset *or* invalid ⇒ stays disabled, never silently starts deleting. Rationale: these two ledgers sit closer to the approval **security boundary** (card state machine, deep-link actionability) and to raw message content than group-robot telemetry does. Flipping to match the group sweep's opt-out posture is a one-line polarity change — say the word.

**2. The card table has no content column** — so there is nothing to redact there. I did **not** build a no-op "redaction" to satisfy the doctrine's letter; the real content gap is `dingtalk_person_deliveries` only, and that's documented rather than papered over.

## What each sub-sweep does

| Table | Action | Why |
|---|---|---|
| `dingtalk_person_deliveries` | bounded batch **DELETE** past the window | holds full message `content` + raw `response_body`; nothing references a row by id downstream |
| `dingtalk_approval_card_deliveries` | `sent` → **`expired`** past the window; **never deleted** | `acted_action/by/at` are the only record of who decided via which card; `task_id` + its trace index must survive for operator tracing |

### Security invariant (pinned by a real-DB keystone test)
A `card_state='sent'` row + a valid deep-link token is independently actionable **forever** — that unbounded-claimability window is precisely what the card sweep closes. The expire `UPDATE`'s `WHERE` requires `card_state='sent'`, so it can **only ever move a row away from `sent`** — structurally incapable of reviving a card into an actionable state. Both readers (`buildSummary`'s `actionable`, the atomic acted-claim) require `'sent'`, so an `expired` row is closed exactly like `acted`/`superseded`/`revoked`.

## ⚠️ Operator foot-gun — pick a window longer than your approval SLA
The card sweep does **not** ask whether the approval is still pending. A window shorter than your real approval turnaround **will expire live cards**: the decision is never lost (the approver falls back to the web page), but the one-tap path is. The 7-day `MIN` floor is a foot-gun *guard*, not a recommendation.

## Env
- `DINGTALK_DELIVERY_RETENTION_DAYS` — opt-in; enables both sub-sweeps (floored at 7).
- `DINGTALK_DELIVERY_RETENTION_DISABLED=1` — kill switch, wins over `DAYS`.
- Batch-bounded per pass (drains a backlog over ticks, never one huge statement); config re-read each tick, so enabling/disabling needs no restart.

## Verification (real numbers)
- `tsc --noEmit` clean
- unit **19/19**
- real-DB **11/11** — default-off true no-op against a live DB · keystone window (deletes only the >Nd person row, expires only the >Nd *still-sent* card) · **security keystone (a swept card can never be claimed)** · idempotence · batch bounding · sibling-table isolation · scheduler end-to-end
- Mutation self-checks: removing the `card_state='sent'` guard → 6/11 real-DB RED (incl. a genuine CHECK-constraint violation); removing the default-off gate → both default-off tests RED.

No migration (the `expired` state already exists in the CHECK constraint). No new dependencies.