### PR TITLE
test(core-backend): close real-app CI guard gaps

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -205,6 +205,23 @@ jobs:
             tests/integration/router-isolation.smoke.test.ts \
             --reporter=verbose
 
+      - name: Run snapshot-protection real-app guard (dedicated full-migration DB)
+        if: matrix.node-version == '20.x'
+        env:
+          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_snapshot_test
+          SNAPSHOT_DATABASE_NAME: metasheet_snapshot_test
+        run: |
+          set -euo pipefail
+          : "${DATABASE_URL:?DATABASE_URL is required for the snapshot-protection guard}"
+          : "${SNAPSHOT_DATABASE_NAME:?SNAPSHOT_DATABASE_NAME is required}"
+          trap 'dropdb -U postgres --if-exists --force "${SNAPSHOT_DATABASE_NAME}"' EXIT
+          createdb -U postgres "${SNAPSHOT_DATABASE_NAME}"
+          unset MIGRATION_EXCLUDE
+          pnpm --filter @metasheet/core-backend db:migrate
+          pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+            tests/integration/snapshot-protection.test.ts \
+            --reporter=verbose
+
       - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated + cross-base relation-agg authorized-reader read gate + dangling-link repair-on-read + sheet-delete cascade + oapi-4a per-base/sheet scope guard + oapi-4a REST token-create scope + mirror-read-only enumeration hardening + cross-base editable-mirror write-through op + cross-base mirror write-through Decision-F concurrency + personal-views slice-1 actor-scoped isolation + W1-2 permission-matrix B1 side-door goldens (Yjs bridge flush actor-tier/lock/row-deny/rule-deny, OAPI token write re-gate parity, base-write/sheet-write non-intersection) + W1-2 permission-matrix B2 oracle/no-leak goldens (G-5 row-level-read-deny zero-presence on export + history, G-4 OAPI token-vs-interactive read-mask parity across the 5 records:read routes) + W1-2 permission-matrix B3 management-surface 403 matrix (field/view CRUD, sheet-permission grant, sheet_config flag + conditional-rules, across A3/A4/A5/A6 actor tiers) + W1-2 permission-matrix B4 G-7 export⊆read differential (field-mask/row-deny/taint modifier combinations, same actor) + W1-1 formula freshness goldens (Yjs-bridge formula recompute GF1-GF4/GF9 + expression-change bulk recompute GF5-GF8/GF12) + W1-3 per-subject field-write gate goldens (Yjs bridge flush GW1-GW3 headline/positive-control/atomic-mixed, single-record PATCH GW4-GW6 mst_-token/session-JWT dual-caller + regression spot-check) + W3-5 batchId===null default (record-service.ts single-record self-referential batch_id vs record-write-service.ts bulk fresh-id control) + W1-2 permission-matrix B4 G-8 comments sheet-visibility gate (comments:read/write actor 403'd on a no-read sheet across list/summary/presence read + create write + no identifier/content leak) + LOCK-12 partial-success bulk PATCH shared-batch grouping + 4c-2 forward tombstone-capture flag-off/on/cap goldens (field-delete value+link+auto-number capture, record-delete inbound-only capture, R1 undelete rehydration + masking parity, retention keep-days sweep) + D-6 config-restore-execute metaFieldCache invalidation golden + F2 attachment-download read-gate row-deny/field-mask security regression guard)
         if: matrix.node-version == '20.x'
         env:

--- a/packages/core-backend/tests/integration/router-isolation.smoke.test.ts
+++ b/packages/core-backend/tests/integration/router-isolation.smoke.test.ts
@@ -14,20 +14,157 @@
  * Route-level UNIT tests structurally cannot catch this: they mount one router in isolation, so every
  * path exercised belongs to that router and a leak is invisible. Only real app assembly shows it.
  *
- * The cheapest total check for the whole `/api` surface: an AUTHENTICATED request to an `/api` path
- * that no router owns must fall through every router and end in 404. If any router under `/api`
- * intercepts traffic it does not own, this probe comes back as that router's rejection (403/503/…)
- * instead of 404 — and this test fails, naming the interception.
- *
- * This is a generic architectural guard, not a test of any particular endpoint: it stays correct as
- * routers are added, and needs no knowledge of individual routes.
+ * The runtime check sends an AUTHENTICATED request to an `/api` path that no router owns; unconditional
+ * interception comes back as the router's rejection instead of 404. A second structural check derives
+ * every imported router mounted at the shared `/api` prefix and rejects path-less `router.use(...)`
+ * regardless of request-dependent branches inside that middleware. Together they cover both the live
+ * assembled chain and the conditional-interception shape that one probe cannot exercise exhaustively.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { MetaSheetServer } from '../../src/index'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import net from 'net'
+import ts from 'typescript'
 
 // A path deliberately owned by NO router. If any /api router intercepts foreign traffic, it answers this.
 const UNOWNED_API_PATH = '/api/__router_isolation_probe__/no-router-owns-this'
+const CORE_BACKEND_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+
+type ImportedBinding = {
+  importedName: 'default' | string
+  moduleSpecifier: string
+}
+
+type SharedPrefixRouter = ImportedBinding & {
+  localName: string
+}
+
+function walkAst(node: ts.Node, visit: (node: ts.Node) => void): void {
+  visit(node)
+  ts.forEachChild(node, (child) => walkAst(child, visit))
+}
+
+function parseSource(filePath: string): ts.SourceFile {
+  return ts.createSourceFile(
+    filePath,
+    readFileSync(filePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+}
+
+function importedBindings(sourceFile: ts.SourceFile): Map<string, ImportedBinding> {
+  const bindings = new Map<string, ImportedBinding>()
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue
+    const clause = statement.importClause
+    if (!clause) continue
+    const moduleSpecifier = statement.moduleSpecifier.text
+    if (clause.name) {
+      bindings.set(clause.name.text, { importedName: 'default', moduleSpecifier })
+    }
+    if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+      for (const element of clause.namedBindings.elements) {
+        bindings.set(element.name.text, {
+          importedName: element.propertyName?.text ?? element.name.text,
+          moduleSpecifier,
+        })
+      }
+    }
+  }
+  return bindings
+}
+
+function isThisAppUse(node: ts.CallExpression): boolean {
+  if (!ts.isPropertyAccessExpression(node.expression) || node.expression.name.text !== 'use') return false
+  const receiver = node.expression.expression
+  return ts.isPropertyAccessExpression(receiver)
+    && receiver.name.text === 'app'
+    && receiver.expression.kind === ts.SyntaxKind.ThisKeyword
+}
+
+function discoverSharedPrefixRouters(): SharedPrefixRouter[] {
+  const indexPath = resolve(CORE_BACKEND_ROOT, 'src/index.ts')
+  const sourceFile = parseSource(indexPath)
+  const imports = importedBindings(sourceFile)
+  const routers: SharedPrefixRouter[] = []
+
+  walkAst(sourceFile, (node) => {
+    if (!ts.isCallExpression(node) || !isThisAppUse(node)) return
+    const [mountPath, ...handlers] = node.arguments
+    if (!mountPath || !ts.isStringLiteralLike(mountPath) || mountPath.text !== '/api') return
+
+    for (const handler of handlers) {
+      if (ts.isIdentifier(handler)) {
+        const imported = imports.get(handler.text)
+        if (!imported || !imported.moduleSpecifier.includes('/routes/')) continue
+        routers.push({ localName: handler.text, ...imported })
+        continue
+      }
+      if (ts.isCallExpression(handler) && ts.isIdentifier(handler.expression)) {
+        const imported = imports.get(handler.expression.text)
+        if (imported?.moduleSpecifier.includes('/routes/')) {
+          throw new Error(
+            `router-isolation smoke: shared-prefix router factory ${handler.expression.text} ` +
+              'is not structurally inspected; extend the guard before using this mount shape',
+          )
+        }
+      }
+    }
+  })
+
+  return routers
+}
+
+function resolveImportedModule(moduleSpecifier: string): string {
+  const basePath = resolve(CORE_BACKEND_ROOT, 'src', moduleSpecifier)
+  const candidates = [`${basePath}.ts`, `${basePath}.tsx`, resolve(basePath, 'index.ts')]
+  const match = candidates.find((candidate) => existsSync(candidate))
+  if (!match) throw new Error(`router-isolation smoke: cannot resolve ${moduleSpecifier}`)
+  return match
+}
+
+function exportedRouterBinding(sourceFile: ts.SourceFile, importedName: string): string | null {
+  if (importedName !== 'default') return importedName
+  for (const statement of sourceFile.statements) {
+    if (ts.isExportAssignment(statement) && !statement.isExportEquals && ts.isIdentifier(statement.expression)) {
+      return statement.expression.text
+    }
+  }
+  return null
+}
+
+function isLiteralExpressPath(node: ts.Expression | undefined): boolean {
+  if (!node) return false
+  if (ts.isStringLiteralLike(node) || ts.isRegularExpressionLiteral(node)) return true
+  return ts.isArrayLiteralExpression(node)
+    && node.elements.length > 0
+    && node.elements.every((element) => ts.isExpression(element) && isLiteralExpressPath(element))
+}
+
+function pathlessUseViolations(router: SharedPrefixRouter): string[] {
+  const modulePath = resolveImportedModule(router.moduleSpecifier)
+  const sourceFile = parseSource(modulePath)
+  const routerBinding = exportedRouterBinding(sourceFile, router.importedName)
+  if (!routerBinding) {
+    return [`${router.localName} (${router.moduleSpecifier}): exported router binding could not be resolved`]
+  }
+
+  const violations: string[] = []
+  walkAst(sourceFile, (node) => {
+    if (!ts.isCallExpression(node) || !ts.isPropertyAccessExpression(node.expression)) return
+    if (node.expression.name.text !== 'use') return
+    if (!ts.isIdentifier(node.expression.expression) || node.expression.expression.text !== routerBinding) return
+    if (isLiteralExpressPath(node.arguments[0])) return
+
+    const location = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+    violations.push(`${router.localName} (${router.moduleSpecifier}:${location.line + 1}:${location.character + 1})`)
+  })
+  return violations
+}
 
 describe('router isolation — no /api router may intercept traffic it does not own', () => {
   let server: MetaSheetServer
@@ -87,5 +224,16 @@ describe('router isolation — no /api router may intercept traffic it does not 
         `intercepting foreign traffic — most likely a PATH-LESS router.use(middleware) in a router mounted ` +
         `at app.use('/api', ...). Bind that middleware to the paths the router owns instead.`,
     ).toBe(404)
+  })
+
+  it('routers mounted at the shared /api prefix bind every router.use middleware to an owned path', () => {
+    const routers = discoverSharedPrefixRouters()
+    expect(routers.length, 'Expected at least one imported router mounted at app.use(\'/api\', ...)').toBeGreaterThan(0)
+
+    const violations = routers.flatMap(pathlessUseViolations)
+    expect(
+      violations,
+      `Shared-prefix routers contain path-less router.use middleware:\n${violations.join('\n')}`,
+    ).toEqual([])
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -251,11 +251,8 @@ export default defineConfig({
       'tests/integration/router-isolation.smoke.test.ts',
       // snapshot-protection boots a real server too, and its silent-return skips are gone (setup now
       // hard-fails and every test must assert), so it can no longer report green without doing its work.
-      // It is still NOT wired into CI: the CI test database is migrated with MIGRATION_EXCLUDE, which omits
-      // the view-table migrations (20250924120000_create_views_view_states, 20250925_create_view_tables,
-      // 042a_core_model_views) — so `views` does not exist there and createSnapshot's captureViewState
-      // cannot run. Wiring it requires untangling that excluded migration cluster, which is its own change;
-      // until then this is DECLARED debt, not invisible debt. Run it locally against a fully-migrated DB.
+      // The required Node 20 real-DB job runs this whole file against a dedicated fully-migrated database;
+      // keeping it excluded here prevents the no-DB default job from running it against an incomplete schema.
       'tests/integration/snapshot-protection.test.ts',
       'tests/integration/spreadsheet-integration.test.ts',
       // Playwright E2E suites run through their own harness, not Vitest.


### PR DESCRIPTION
## What

Direct corrective on current `main` for the two P2 gaps left after #4145 merged.

- Derive every imported router mounted at the shared `app.use('/api', ...)` prefix from the TypeScript AST.
- Inspect each exported router module and reject path-less `router.use(...)`, including request-conditional interception that the single unknown-path probe cannot exercise.
- Keep literal string, regex, and array path bindings allowed.
- Run `snapshot-protection.test.ts` as a whole file in the required Node 20 real-DB job.
- Give that spec a dedicated fully-migrated database and force-drop it through an EXIT trap, preserving the broader lane's existing `MIGRATION_EXCLUDE` fixture.
- Update the default-test exclusion comment to match the now-real dedicated CI wiring.

## Provenance

- source PR: #4145, merged as `5ae49c724751aa57fcddd5135717c62e7434c4ba`
- corrective base: `main@c7fee328fa1b2b12e461ec9ab5bc3a0d41efb360`
- corrective exact head: `52fdc9450075b6bc616be19ea944310c68206cf2`
- changed files: 3 test/workflow configuration files
- runtime files changed: 0

## Verification

- real PostgreSQL, Node 24: 2 files / 24 tests PASS
- real PostgreSQL, Node 20.20.2 with pnpm 10.33: 2 files / 24 tests PASS
- dedicated empty database, full migration set with no exclusions: PASS on Node 20
- dedicated snapshot-protection run: 21/21 PASS; cleanup leaves no database
- request-conditional foreign-workflow interception mutation: RED in the structural guard
- unconditional interception mutation: RED in the runtime probe
- literal path-bound router middleware control: 3/3 PASS
- core-backend type-check: PASS
- default migration-provider suite: 6/6 PASS
- workflow YAML parse: PASS
- diff check: PASS

## GitHub verification

- exact head `52fdc9450075b6bc616be19ea944310c68206cf2`: 15 SUCCESS + 1 expected SKIPPED
- Node 20 `Run real-app assembly guard (router isolation)`: SUCCESS
- Node 20 `Run snapshot-protection real-app guard (dedicated full-migration DB)`: SUCCESS
- failed-job rerun passed the full multitable real-DB batch, approval real-DB batch, build, attendance integration, and plugin smoke
- coverage: SUCCESS
- the first Node 20 attempt exposed an independent unordered AI bulk quota-prefix bug; the exact failure was reproduced and is corrected separately in #4150, while this PR remains unchanged and runtime-free

## Integration boundary

This is a no-runtime corrective for owner review and merge. No self-merge, deploy, restart, or production action is performed here.
