### PR TITLE
docs(multitable): retract an overclaimed security impact + 2 stale comments (owner review of #4147/#4148)

### DIFF
--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -4,10 +4,15 @@
 # specs. Web specs otherwise run only in the NON-required, path-filtered approval-web-guard /
 # multitable-web-guard — so a green PR did not mean any apps/web test passed.
 #
-# This job runs the curated, verified-stable union of those two guards' filters (104 files / 1537
-# tests, all green on main 2026-07-08) UNCONDITIONALLY — no path filter — so it can be added to
-# branch-protection required contexts WITHOUT the path-filtered-required footgun (a required check
-# that never triggers leaves PRs hanging forever). Job name is stable: `web-tests`.
+# This job runs the curated, verified-stable union of those two guards' filters UNCONDITIONALLY — no
+# path filter — so it can be added to branch-protection required contexts WITHOUT the
+# path-filtered-required footgun (a required check that never triggers leaves PRs hanging forever).
+# Job name is stable: `web-tests`.
+#
+# The file/test COUNT is deliberately NOT recorded here. It was once pinned as "104 files / 1537 tests"
+# and silently drifted as the list grew (#4147 took it to 166 files / 1958 tests) — a hardcoded count in
+# a comment becomes a false ledger on every expansion. The run log is the source of truth; grow the
+# filter list in run-required-web-tests.sh and let CI report the number.
 #
 # Adding it to required contexts is done via APPEND, never PUT — a PUT to
 # .../required_status_checks/contexts REPLACES the whole array, so `PUT ... ["web-tests"]` would

--- a/docs/development/multitable-time-machine-remaining-dev-and-verification-20260712.md
+++ b/docs/development/multitable-time-machine-remaining-dev-and-verification-20260712.md
@@ -28,19 +28,28 @@ R11（2026-07-11）落地后：#4117 vintage-exact PIT-resurrect 锚 · #4119 ma
 
 ## 3. 本轮实质发现（全部已修，#4147）
 
-### 3.1 四个前端 spec 跑在**零个** workflow 里 —— 其中一个是**唯一的**字段掩码渲染守卫
+### 3.1 四个前端 spec 跑在**零个** workflow 里 —— 其中一个是**纵深防御的前端那一层**
 
-- **实证**：全文 grep `.github/workflows/` 无命中；`multitable-web-guard.yml` 的 `vitest run` 过滤器无这些 token；
+> **⚠️ 严重性更正（owner 复审 P2，2026-07-12）**：本节初版称「这个泄漏会**全绿上线**」——**那是过度声称，已撤回**。
+> 见下方「真实严重性」。测试本身的价值不变，接线仍然正确；被更正的是我对其**安全影响**的表述。
+
+- **实证（不变）**：全文 grep `.github/workflows/` 无命中；`multitable-web-guard.yml` 的 `vitest run` 过滤器无这些 token；
   **required** 的 `run-required-web-tests.sh`（backing required `web-tests` 检查）也没有。且 required `test (20.x)`
   对 apps/web **只 build 不跑 vitest**。⇒ 这 4 个 spec（30 测，全绿、无 DB 依赖）**在任何 CI 里都没跑过**。
-- **最要紧的那个 = `meta-record-drawer-history-diff.spec.ts` 的 LEAK-LOCK**：它是 `MetaRecordDrawer` History 页
-  **掩码渲染属性的唯一前端守卫**。后端对照测（`multitable-record-history-field-mask.test.ts`，在 CI 里）只证明
-  **服务端响应**被掩码——**从不触碰渲染器**。而 `historyFieldDiffs()`（`MetaRecordDrawer.vue:791`）**必须**遍历
-  `item.changedFieldIds`，**绝不能**遍历原始 snapshot。
-- **突变实证（本轮最硬的一条证据）**：把 `item.changedFieldIds.map(...)` 换成 `Object.keys(item.snapshot ?? {}).map(...)`
-  ⇒ LEAK-LOCK **变红**，且**渲染出的 DOM 里真的出现了 `TOP_SECRET`**——一个在 snapshot 里、但不在 `changedFieldIds` 里的字段，
-  正是 actor 绝不该看到的被掩码字段。**在本 PR 之前，这个泄漏会「全绿上线」**，因为唯一能抓到它的测试跑在零个 workflow 里。
-  基线恢复后 6/6 绿。
+- **它守的是什么**：`historyFieldDiffs()`（`MetaRecordDrawer.vue:791`）**必须**遍历 `item.changedFieldIds`，
+  **不能**遍历原始 snapshot。LEAK-LOCK 钉住这条**渲染侧**属性。
+- **突变实证（结论仍成立，但只在其正确的作用域内）**：把遍历源换成 `Object.keys(item.snapshot ?? {})`
+  ⇒ LEAK-LOCK **变红**，DOM 渲染出 `TOP_SECRET`。⇒ **这个守卫是承重的、不是装饰性的**（它确实会因该回归而红）。基线恢复后 6/6 绿。
+- **真实严重性 = 纵深防御的前端那一层，不是「单靠 FE 突变就能造成线上泄漏」**：
+  - 该 spec 的 fixture **刻意构造了一个服务端契约不会产生的 payload**（snapshot 里有秘密字段、而 `changedFieldIds` 不含它）。
+    spec 自己的 docstring（`meta-record-drawer-history-diff.spec.ts:4-8`）就写明：`patch` / `snapshot` / `changedFieldIds`
+    **三者服务端都已掩码**，本测只钉「该属性的 **FE 那一半**」。
+  - 后端金测（`multitable-record-history-field-mask.test.ts`，**在 required CI 里**）R1 明确钉住
+    「被拒的 layer-3 字段值**不出现在 patch 与 snapshot 里**」。**故服务端根本不会下发那种形状。**
+  - ⇒ 正确表述：LEAK-LOCK 证明的是「**万一后端掩码发生部分回归**，FE 仍不会渲染出未在 `changedFieldIds` 里的字段」。
+    **单独一个 FE 突变不足以造成真实线上泄漏**——后端那层仍然拦着。
+  - ⇒ 接线的正当性依然充分：**一个两层安全属性的前端那层此前没有任何 CI**（纵深防御的一层是哑的）。但严重性应记为
+    **「补回纵深防御的一层」**，而**不是**「一个 live 泄漏差一次编辑就上线」。
 - **修**：4 个 spec 全部接入 **required** `web-tests` 门（`run-required-web-tests.sh`）。
 
 ### 3.2 一个真库测试**自诞生起从未执行过它的断言**
@@ -67,7 +76,8 @@ R11（2026-07-11）落地后：#4117 vintage-exact PIT-resurrect 锚 · #4119 ma
 | 断言 | 证据 |
 |---|---|
 | 4 个 FE spec 此前跑在零 workflow | grep `.github/workflows/` 无命中；`run-required-web-tests.sh` 无 token；`test (20.x)` 对 apps/web 只 build |
-| **LEAK-LOCK 真的会抓到泄漏（非装饰性守卫）** | **突变实证**：改遍历源为 `Object.keys(snapshot)` ⇒ spec 红，且 DOM 渲染出 `TOP_SECRET`；还原后 6/6 绿 |
+| **LEAK-LOCK 是承重守卫（非装饰性）** | **突变实证**：改遍历源为 `Object.keys(snapshot)` ⇒ spec 红，且 DOM 渲染出 `TOP_SECRET`；还原后 6/6 绿 |
+| **但它证明的是纵深防御的 FE 那一层，不是「FE 突变即造成线上泄漏」**（owner 复审 P2 更正） | fixture 刻意构造服务端契约**不会下发**的形状（snapshot 有秘密、`changedFieldIds` 无）；spec docstring `:4-8` 自陈三者服务端均已掩码；后端金测 `multitable-record-history-field-mask.test.ts` **R1** 钉住「被拒字段不出现在 patch 与 snapshot」⇒ **后端那层仍然拦着**。见 §3.1「真实严重性」 |
 | 真库测试从未执行过断言 | 不在 plugin-tests 白名单；`describeIfDatabase` 在 DATABASE_URL 未设处 skip-green；哨兵嵌套在同一 describe 内故一并跳过 |
 | 该真库测试并未损坏 | **真跑**：全新 pg + 全量迁移 ⇒ **9/9 通过** |
 | capture-point-3 的 cap-check 义务已履行 | `assertWithinCaptureCap` 在 `univer-meta.ts:6407` 调用前、同一 `isTombstoneCaptureEnabled()` 门内 ⇒ **无 bug** |
@@ -79,7 +89,7 @@ R11（2026-07-11）落地后：#4117 vintage-exact PIT-resurrect 锚 · #4119 ma
 | 项 | 门 | 谁解锁 |
 |---|---|---|
 | **#4004 D-2**（side-door delete recoverability 设计锁，PROPOSED） | owner-gated，watch-only（R11 directive 明列不随轮次开） | **owner ratify** |
-| **O-2 运维启用**（`MULTITABLE_TOMBSTONE_CAPTURE_ENABLED` → `..._RECORD_UNDELETE_INBOUND` → `..._PIT_UNDELETE`；retention） | 部署 host 的 env，**非 CI 可设**；production 保持 OFF | **owner/operator**（runbook 见 o2-ladder + R11 收官 MD） |
+| **O-2 运维启用**（`MULTITABLE_TOMBSTONE_CAPTURE_ENABLED` → `..._RECORD_UNDELETE_INBOUND` → `..._PIT_UNDELETE`；retention） | 部署 host 的 env，**非 CI 可设**。**代码默认 OFF**（flag 缺省即关）；**但「production 当前是否为 OFF」是外部环境状态，本次代码审阅/本文均未独立核验**（owner 复审指出，2026-07-12）——不要把「代码默认 OFF」当作「线上已 OFF」的证据 | **owner/operator**（runbook 见 o2-ladder + R11 收官 MD） |
 | **person diff before 侧名称解析** | 设计锁 PROPOSED（随 #4127 上 main），OD-P1/P2/P3 待裁 | **owner ratify** → 之后可建（S/M） |
 | **4d**：已删字段列的**值级**恢复 | **红线，永不承诺** | — |
 

--- a/packages/core-backend/src/multitable/tombstone-capture.ts
+++ b/packages/core-backend/src/multitable/tombstone-capture.ts
@@ -183,10 +183,13 @@ export async function countInboundLinkCaptureRows(query: TombstoneQueryFn, recor
  * `DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1` in `deleteRecord`. Outbound
  * edges (`record_id = $1`) are intentionally NOT captured here (see module doc-comment); a self-link
  * (`record_id = foreign_record_id`) is double-covered by both the outbound trash-replay and this inbound
- * capture, which is harmless. The reason no duplicate row can result is that inbound captures are never
- * auto-replayed (4c-3 out of scope) — NOT the outbound `ON CONFLICT DO NOTHING`, which only guards the
- * random PK `id` (meta_links has no unique on the edge triple). When 4c-3 wires inbound replay, it must
- * carry its own NOT-EXISTS guard (as the field-undelete link rehydration already does).
+ * capture, which is harmless. **4c-3 has since landed and DOES auto-replay inbound captures** (this
+ * comment previously said they were "never auto-replayed / 4c-3 out of scope" — stale). What keeps the
+ * self-link double from producing a duplicate edge is the replay's OWN `NOT EXISTS` guard
+ * (`inbound-link-replay.ts:154`, "NOT EXISTS an identical meta_links row" — it explicitly kills the
+ * self-link overlap), exactly as this comment once predicted 4c-3 would have to add. It is NOT the
+ * outbound `ON CONFLICT DO NOTHING`, which only guards the random PK `id` (meta_links has no unique
+ * constraint on the edge triple).
  */
 export async function insertInboundLinkTombstones(
   query: TombstoneQueryFn,


### PR DESCRIPTION
Owner review of #4147/#4148 raised three points. **All three are correct.** Comments/docs-only fix-forward; **#4147's CI hardening stands and is not rolled back.**

## [P2] Retracting an overclaim — the important one

The verification MD claimed the FE mutation meant a field-mask leak **"would have shipped green"**. **That is wrong and I'm withdrawing it.**

The LEAK-LOCK fixture deliberately constructs a payload **the server contract does not emit**: a `snapshot` carrying a denied field while `changedFieldIds` omits it.
- The spec's **own docstring** (`meta-record-drawer-history-diff.spec.ts:4-8`) says `patch`/`snapshot`/`changedFieldIds` are **all masked server-side**, and that it pins only the **FE half**.
- The backend golden (`multitable-record-history-field-mask.test.ts` **R1**, in required CI) pins that denied layer-3 values are **absent from patch AND snapshot**.

So the mutation proves the guard is **load-bearing for the FE layer** (it genuinely goes red) — but **not** that an FE-only regression is reachable in production, because the backend layer still stops it.

**Correct severity:** this restores the **FE half of a defense-in-depth property that had no CI at all**. That still fully justifies wiring it — but it is *not* "a live leak was one edit away."

**Generalized lesson (banked to memory):** a guard's mutation going red proves it is load-bearing *for that layer*. To claim a **reachable** production vulnerability you must additionally show the **upstream contract can actually produce the fixture's input shape**. **Mutation-red ≠ reachability.**

## [P3] Stale 4c-3 comment
`tombstone-capture.ts` still said duplicates are impossible because inbound captures are *"never auto-replayed (4c-3 out of scope)"*. **4c-3 has landed and does replay them.** What actually prevents the duplicate is the replay's own `NOT EXISTS` guard (`inbound-link-replay.ts:154`) — precisely what that comment predicted 4c-3 would have to add. Rewritten to current reality.

## [P3] Drifted count in the required-gate comment
`web-tests.yml` pinned *"104 files / 1537 tests"*; #4147 made it 166/1958. **Removed the hardcoded count** rather than bumping it — a count in a comment becomes a false ledger on every expansion. CI's run log is the source of truth.

## Also corrected
**"production OFF" is external environment state.** The code defaults the flags off, but neither the doc nor a code review verifies the live environment. Do not read "default OFF" as "prod is OFF".

## Verification
backend `tsc` **0 errors** (real compile — my first attempt hit a **decoy `tsc`** in a worktree with no `node_modules` and produced a *vacuous* "0 errors"; installed deps and reran, fittingly for this round); `tombstone-capture` unit **5/5**; `web-tests.yml` YAML parses; **no residual overclaim** left in `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)