### PR TITLE
feat(multitable): person before-side name resolution in History diffs (OD-P1=A, OD-P2, OD-P3)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -264,6 +264,7 @@ jobs:
             tests/integration/multitable-history-before-hydration-realdb.test.ts \
             tests/integration/multitable-history-alltables-fieldnames-realdb.test.ts \
             tests/integration/multitable-layer2-hidden-person-button-realdb.test.ts \
+            tests/integration/multitable-history-person-names-realdb.test.ts \
             tests/integration/multitable-history-events-hasmore-realdb.test.ts \
             tests/integration/multitable-history-audit-grant-realdb.test.ts \
             tests/integration/multitable-history-audit-reveal-realdb.test.ts \

--- a/apps/web/src/multitable/components/HistoryBatchChangesList.vue
+++ b/apps/web/src/multitable/components/HistoryBatchChangesList.vue
@@ -202,11 +202,21 @@ function personSummariesForSide(c: HistoryChange, fieldId: string, v: unknown): 
 // Resolve the field for rendering. `props.fields` is the ACTIVE sheet only, so in all-tables mode a row on
 // another sheet found nothing and fell back to raw JSON. Fall back to the server's masked fieldTypes/
 // fieldNames maps, which describe exactly the fields whose values the projection already emitted.
+//
+// The synthesized field carries NO `property` — we only have the masked id→name/type maps, not the
+// per-field config. `formatFieldDisplay`'s property-dependent branches then silently take their DEFAULTS,
+// which FABRICATES values on an audit surface: a USD `currency` (property.code='USD') renders as
+// "¥1,000.00", and a `rating` with property.max=10 renders 8 as "★★★★★" (capped at the default max of 5).
+// So the cross-sheet fallback is restricted to `person`, the ONE type the D-2-era lock authorizes
+// `fieldTypes` for (…person-before-side-name-resolution… §0.1: fieldNames fixes the LABEL, fieldTypes
+// fixes the VALUE — for person). Every other cross-sheet type falls through to `formatDiffValue`, i.e.
+// the honest raw value. Rendering a value we cannot faithfully format is worse than not formatting it.
 function fieldForDiff(c: HistoryChange, fieldId: string): { id: string; name: string; type: string } | null {
   const active = props.fields?.find((x) => x.id === fieldId)
   if (active && typeof active.type === 'string') return active as { id: string; name: string; type: string }
   const type = props.fieldTypes?.[c.sheetId]?.[fieldId]
   if (!type) return null // no masked type ⇒ cannot render type-aware; caller falls back to plain text
+  if (type !== 'person') return null // property-less ⇒ would fabricate; see the note above
   return { id: fieldId, name: props.fieldNames?.[c.sheetId]?.[fieldId] ?? fieldId, type }
 }
 function formatDiffValueFor(c: HistoryChange, fieldId: string, v: unknown): string {

--- a/apps/web/src/multitable/components/HistoryBatchChangesList.vue
+++ b/apps/web/src/multitable/components/HistoryBatchChangesList.vue
@@ -84,6 +84,11 @@ const props = defineProps<{
    * in it and used to render as a raw userId. This server-resolved directory map covers BOTH sides.
    */
   personNames?: Record<string, { display: string; inactive?: boolean }>
+  /**
+   * all-tables: server-masked field TYPES for sheets other than the active one (`props.fields` only carries
+   * the active sheet). Without this a cross-table person diff rendered as raw `["u_123"]` JSON.
+   */
+  fieldTypes?: Record<string, Record<string, string>>
   /** Reuses the caller's own action-label map (kept as a single source of truth in HistoryCenterModal.vue —
    *  this is prop-drilling, not a shared-module extraction, per the AI-fields S1 design-lock's constraint
    *  on `sourceLabel` NOT applying here since this is a distinct map (per-change action, not source)). */
@@ -175,7 +180,11 @@ function personSummariesForSide(c: HistoryChange, fieldId: string, v: unknown): 
   const cached = props.personSummaries?.[c.recordId]?.[fieldId] ?? null
   const dir = props.personNames
   if (!dir) return cached // no server map (older payload) → legacy behavior exactly
-  const ids = Array.isArray(v) ? v.map(String).filter((id) => id.trim()) : v ? [String(v)] : []
+  // Dirty-value filtering: a person value is `userId[]`. A stored value can be dirty (a legacy object, a
+  // number, null). `v.map(String)` would render an object as the literal "[object Object]" — so accept ONLY
+  // non-empty strings and drop the rest, rather than stringifying garbage into the UI.
+  const ids = (Array.isArray(v) ? v : v === null || v === undefined ? [] : [v])
+    .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
   if (ids.length === 0) return cached
   const byIdCached = new Map((cached ?? []).map((s) => [s.id, s]))
   return ids.map((id) => {
@@ -190,8 +199,18 @@ function personSummariesForSide(c: HistoryChange, fieldId: string, v: unknown): 
     return byIdCached.get(id) ?? { id, display: id }
   })
 }
+// Resolve the field for rendering. `props.fields` is the ACTIVE sheet only, so in all-tables mode a row on
+// another sheet found nothing and fell back to raw JSON. Fall back to the server's masked fieldTypes/
+// fieldNames maps, which describe exactly the fields whose values the projection already emitted.
+function fieldForDiff(c: HistoryChange, fieldId: string): { id: string; name: string; type: string } | null {
+  const active = props.fields?.find((x) => x.id === fieldId)
+  if (active && typeof active.type === 'string') return active as { id: string; name: string; type: string }
+  const type = props.fieldTypes?.[c.sheetId]?.[fieldId]
+  if (!type) return null // no masked type ⇒ cannot render type-aware; caller falls back to plain text
+  return { id: fieldId, name: props.fieldNames?.[c.sheetId]?.[fieldId] ?? fieldId, type }
+}
 function formatDiffValueFor(c: HistoryChange, fieldId: string, v: unknown): string {
-  const f = props.fields?.find((x) => x.id === fieldId)
+  const f = fieldForDiff(c, fieldId)
   if (!f || typeof f.type !== 'string') return formatDiffValue(v)
   return formatFieldDisplay({
     field: f as MetaField,

--- a/apps/web/src/multitable/components/HistoryBatchChangesList.vue
+++ b/apps/web/src/multitable/components/HistoryBatchChangesList.vue
@@ -57,7 +57,7 @@
 
 <script setup lang="ts">
 import { useLocale } from '../../composables/useLocale'
-import { recordLabel, restoredFromVersionBadge } from '../utils/meta-record-labels'
+import { inactivePersonDisplay, recordLabel, restoredFromVersionBadge } from '../utils/meta-record-labels'
 import { formatFieldDisplay, pickRecordTitle } from '../utils/field-display'
 import type { HistoryChange, LinkedRecordSummary, MetaField, PersonSummary } from '../types'
 
@@ -78,6 +78,12 @@ const props = defineProps<{
    *  layer-3 field_permissions), so it carries only names the actor may see — the FE never re-derives the
    *  mask (the #4007 footgun). Active-table rows still resolve via `fields`; both sources are masked. */
   fieldNames?: Record<string, Record<string, string>>
+  /**
+   * Person before-side name resolution (batch-detail payload `HistoryBatchDetail.personNames`). The grid's
+   * `personSummaries` cache describes the record's CURRENT cell, so a person REMOVED by this change is not
+   * in it and used to render as a raw userId. This server-resolved directory map covers BOTH sides.
+   */
+  personNames?: Record<string, { display: string; inactive?: boolean }>
   /** Reuses the caller's own action-label map (kept as a single source of truth in HistoryCenterModal.vue —
    *  this is prop-drilling, not a shared-module extraction, per the AI-fields S1 design-lock's constraint
    *  on `sourceLabel` NOT applying here since this is a distinct map (per-change action, not source)). */
@@ -157,6 +163,33 @@ function linkSummariesForSide(c: HistoryChange, fieldId: string, v: unknown): Li
   const matched = v.map((id) => byId.get(String(id)))
   return matched.every((s): s is LinkedRecordSummary => s !== undefined) ? matched : null
 }
+// Person sides. UNLIKE link (above), formatFieldDisplay maps person summaries PER ID (`byId.get(id) || id`)
+// rather than rendering them verbatim — so person has no "both sides show the same name list" bug and needs
+// no value-order filtering. The real gap is different: the grid's `personSummaries` cache describes the
+// record's CURRENT cell, so a person REMOVED by this change (in `before`, gone from `after`) is NOT cached
+// and rendered as a raw userId — "who was removed" was unreadable.
+//
+// Priority per id: server `personNames` (covers BOTH sides, incl. removed people) → grid cell cache →
+// raw id (formatFieldDisplay's own final fallback). Built from THIS side's ids, so each side resolves its own.
+function personSummariesForSide(c: HistoryChange, fieldId: string, v: unknown): PersonSummary[] | null {
+  const cached = props.personSummaries?.[c.recordId]?.[fieldId] ?? null
+  const dir = props.personNames
+  if (!dir) return cached // no server map (older payload) → legacy behavior exactly
+  const ids = Array.isArray(v) ? v.map(String).filter((id) => id.trim()) : v ? [String(v)] : []
+  if (ids.length === 0) return cached
+  const byIdCached = new Map((cached ?? []).map((s) => [s.id, s]))
+  return ids.map((id) => {
+    const entry = dir[id]
+    if (entry) {
+      // OD-P2: a deactivated person stays visible and MARKED. formatFieldDisplay renders person summaries
+      // as bare `display` strings (it ignores `inactive`), so the marker is applied here — in the diff's own
+      // summaries — rather than by changing that shared formatter for the grid/drawer too.
+      const display = entry.inactive ? inactivePersonDisplay(entry.display, isZh.value) : entry.display
+      return { id, display, ...(entry.inactive ? { inactive: true } : {}) }
+    }
+    return byIdCached.get(id) ?? { id, display: id }
+  })
+}
 function formatDiffValueFor(c: HistoryChange, fieldId: string, v: unknown): string {
   const f = props.fields?.find((x) => x.id === fieldId)
   if (!f || typeof f.type !== 'string') return formatDiffValue(v)
@@ -164,7 +197,7 @@ function formatDiffValueFor(c: HistoryChange, fieldId: string, v: unknown): stri
     field: f as MetaField,
     value: v,
     linkSummaries: f.type === 'link' ? linkSummariesForSide(c, fieldId, v) : null,
-    personSummaries: props.personSummaries?.[c.recordId]?.[fieldId] ?? null,
+    personSummaries: f.type === 'person' ? personSummariesForSide(c, fieldId, v) : (props.personSummaries?.[c.recordId]?.[fieldId] ?? null),
     isZh: isZh.value,
   })
 }

--- a/apps/web/src/multitable/components/HistoryCenterModal.vue
+++ b/apps/web/src/multitable/components/HistoryCenterModal.vue
@@ -26,7 +26,7 @@
             <span class="meta-hist__when">{{ formatTime(pinnedDetail.createdAt) }}</span>
             <span class="meta-hist__counts" data-test="hist-pinned-counts">{{ countLabel(pinnedDetail) }}</span>
           </div>
-          <HistoryBatchChangesList :changes="pinnedDetail.changes" :fields="fields" :field-names="pinnedDetail.fieldNames" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
+          <HistoryBatchChangesList :changes="pinnedDetail.changes" :fields="fields" :field-names="pinnedDetail.fieldNames" :person-names="pinnedDetail.personNames" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
         </template>
       </div>
 
@@ -68,7 +68,7 @@
           <div v-if="expandedId === b.batchId" class="meta-hist__detail" data-test="hist-detail">
             <p v-if="detailLoading" class="meta-hist__hint">{{ t('加载中…', 'Loading…') }}</p>
             <p v-else-if="!detail" class="meta-hist__hint">{{ t('无法打开该批次', 'This batch is unavailable') }}</p>
-            <HistoryBatchChangesList v-else :changes="detail.changes" :fields="fields" :field-names="detail.fieldNames" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
+            <HistoryBatchChangesList v-else :changes="detail.changes" :fields="fields" :field-names="detail.fieldNames" :person-names="detail.personNames" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
           </div>
         </li>
       </ul>

--- a/apps/web/src/multitable/components/HistoryCenterModal.vue
+++ b/apps/web/src/multitable/components/HistoryCenterModal.vue
@@ -26,7 +26,7 @@
             <span class="meta-hist__when">{{ formatTime(pinnedDetail.createdAt) }}</span>
             <span class="meta-hist__counts" data-test="hist-pinned-counts">{{ countLabel(pinnedDetail) }}</span>
           </div>
-          <HistoryBatchChangesList :changes="pinnedDetail.changes" :fields="fields" :field-names="pinnedDetail.fieldNames" :person-names="pinnedDetail.personNames" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
+          <HistoryBatchChangesList :changes="pinnedDetail.changes" :fields="fields" :field-names="pinnedDetail.fieldNames" :person-names="pinnedDetail.personNames" :field-types="pinnedDetail.fieldTypes" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
         </template>
       </div>
 
@@ -68,7 +68,7 @@
           <div v-if="expandedId === b.batchId" class="meta-hist__detail" data-test="hist-detail">
             <p v-if="detailLoading" class="meta-hist__hint">{{ t('加载中…', 'Loading…') }}</p>
             <p v-else-if="!detail" class="meta-hist__hint">{{ t('无法打开该批次', 'This batch is unavailable') }}</p>
-            <HistoryBatchChangesList v-else :changes="detail.changes" :fields="fields" :field-names="detail.fieldNames" :person-names="detail.personNames" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
+            <HistoryBatchChangesList v-else :changes="detail.changes" :fields="fields" :field-names="detail.fieldNames" :person-names="detail.personNames" :field-types="detail.fieldTypes" :link-summaries="linkSummaries" :person-summaries="personSummaries" :action-label="actionLabel" @open-record="emit('open-record', $event)" />
           </div>
         </li>
       </ul>

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -407,6 +407,14 @@ export interface HistoryBatchDetail {
    *  appear in this batch's (post-mask) changes across ALL involved sheets. Optional so a pre-R11 backend
    *  payload still typechecks; the FE degrades to raw ids / active-table names when absent. */
   fieldNames?: Record<string, Record<string, string>>
+  /**
+   * Person before-side name resolution: flat `userId → { display, inactive? }` for every userId in this
+   * batch's (post-mask) person values, BOTH sides. The grid's person cache only knows the CURRENT cell, so
+   * a person REMOVED by this change has no cached summary and would render as a raw id — this map is what
+   * makes "who was removed" readable. Server-resolved from the same directory as `actorName`; denied person
+   * fields' values (and thus their userIds) never reach it.
+   */
+  personNames?: Record<string, { display: string; inactive?: boolean }>
 }
 
 export interface MetaRecordSubscription {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -415,6 +415,12 @@ export interface HistoryBatchDetail {
    * fields' values (and thus their userIds) never reach it.
    */
   personNames?: Record<string, { display: string; inactive?: boolean }>
+  /**
+   * all-tables: masked field-id → TYPE map, per sheet. Companion to `fieldNames`: that one gives a
+   * non-active sheet's field its NAME, this one gives its VALUE a type-aware renderer (person/link/date/…)
+   * instead of raw JSON. Same masked source; hidden/denied field types never appear.
+   */
+  fieldTypes?: Record<string, Record<string, string>>
 }
 
 export interface MetaRecordSubscription {

--- a/apps/web/src/multitable/utils/field-display.ts
+++ b/apps/web/src/multitable/utils/field-display.ts
@@ -117,7 +117,14 @@ export function formatFieldDisplay(params: {
   // Native person (人员): value = userId[]; resolve display from personSummaries (userId →
   // display), falling back to the raw userId. (Legacy link-backed person is type='link' below.)
   if (field.type === 'person') {
-    const ids = Array.isArray(value) ? value.map(String).filter((id) => id.trim().length > 0) : value ? [String(value)] : []
+    // DIRTY-VALUE FILTERING. A person value is `userId[]`, but a stored value can be dirty — a legacy
+    // object, a number, a null — from an old import, a retype, or a hand-seeded row. The previous
+    // `value.map(String)` stringified those, so an object rendered as the literal "[object Object]" and a
+    // number as "42", straight into the UI (and, in a History diff, into an audit surface). Accept ONLY
+    // non-empty strings and DROP the rest: an id we cannot trust is not an id. A cell of nothing but dirt
+    // renders as '—', which is honest, rather than as fabricated garbage.
+    const ids = (Array.isArray(value) ? value : value === null || value === undefined ? [] : [value])
+      .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
     if (ids.length === 0) return '—'
     const byId = new Map((personSummaries ?? []).map((s) => [s.id, s.display]))
     return ids.map((id) => byId.get(id) || id).join(', ')

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -373,6 +373,16 @@ export function restoredFromVersionBadge(version: number, isZh: boolean): string
   return isZh ? `从版本 ${version} 恢复` : `Restored from v${version}`
 }
 
+/**
+ * Person before-side name resolution (OD-P2): mark a DEACTIVATED person in a History diff.
+ * Scoped to the History Center diff on purpose — the shared `formatFieldDisplay` renders person summaries
+ * as bare `display` strings and is also used by the grid/record-drawer, so the marker is applied where the
+ * diff builds its own summaries rather than by changing the shared formatter for every surface.
+ */
+export function inactivePersonDisplay(display: string, isZh: boolean): string {
+  return isZh ? `${display}（已停用）` : `${display} (deactivated)`
+}
+
 // --- ResetConfirmDialog.vue interpolation helpers (R5c) ---
 // `asOf` is the wire point-in-time value (display + API `asOf`) and record counts are wire summary
 // numbers — both always interpolated raw, never translated. Each helper below reconstructs one

--- a/apps/web/tests/multitable-history-center-inline-diff.spec.ts
+++ b/apps/web/tests/multitable-history-center-inline-diff.spec.ts
@@ -617,3 +617,71 @@ describe('HistoryCenterModal — person before-side name resolution', () => {
     } finally { app.unmount(); container.remove() }
   })
 })
+
+// all-tables: a change row on a NON-ACTIVE sheet. `props.fields` carries only the active sheet, so before
+// `fieldTypes` such a row had no type and fell back to raw JSON — a cross-table person diff rendered as
+// `["user_x"]`. The server's masked fieldTypes/fieldNames maps close that, and dirty values must never be
+// stringified into the UI as "[object Object]".
+describe('HistoryCenterModal — all-tables cross-sheet type-aware diffs + dirty-value filtering', () => {
+  async function openWith(detail: Record<string, unknown>, props: Record<string, unknown>) {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    mockGetHistoryBatch.mockResolvedValue(detail)
+    const { app, container } = mountModalWithProps({ fields: TYPED_FIELDS, ...props })
+    await flushPromises()
+    container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+    await flushPromises()
+    return { app, container }
+  }
+
+  const otherSheetChange = [{
+    sheetId: 'sheet_other', recordId: 'rec_9', action: 'update', version: 2,
+    changedFieldIds: ['fld_other_person'],
+    before: { fld_other_person: ['user_kept', 'user_removed'] },
+    after: { fld_other_person: ['user_kept'] },
+  }] as unknown as HistoryBatchDetail['changes']
+
+  it('a PERSON diff on a NON-ACTIVE sheet renders names (not raw JSON) via the masked fieldTypes map', async () => {
+    const { app, container } = await openWith({
+      ...detailWith(otherSheetChange),
+      fieldNames: { sheet_other: { fld_other_person: 'Owners' } },
+      fieldTypes: { sheet_other: { fld_other_person: 'person' } },
+      personNames: { user_kept: { display: 'Kept Person' }, user_removed: { display: 'Removed Person' } },
+    }, {})
+    try {
+      const before = container.querySelector('.meta-hist__diff-before')?.textContent ?? ''
+      expect(before).toContain('Removed Person') // resolved, cross-sheet
+      expect(before).toContain('Kept Person')
+      expect(before).not.toContain('[') // NOT raw JSON
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('without a masked type for that sheet, it degrades to plain text (never crashes)', async () => {
+    const { app, container } = await openWith({
+      ...detailWith(otherSheetChange),
+      fieldNames: { sheet_other: { fld_other_person: 'Owners' } },
+      // no fieldTypes → cannot render type-aware
+    }, {})
+    try {
+      expect(container.querySelector('.meta-hist__diff-before')).toBeTruthy()
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('DIRTY VALUES: a person value holding an object/number/null never renders as "[object Object]"', async () => {
+    const dirty = [{
+      sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,
+      changedFieldIds: ['fld_person'],
+      before: { fld_person: [{ id: 'user_kept' }, 42, null, 'user_kept'] },
+      after: { fld_person: ['user_kept'] },
+    }] as unknown as HistoryBatchDetail['changes']
+    const { app, container } = await openWith({
+      ...detailWith(dirty),
+      personNames: { user_kept: { display: 'Kept Person' } },
+    }, {})
+    try {
+      const before = container.querySelector('.meta-hist__diff-before')?.textContent ?? ''
+      expect(before).not.toContain('[object Object]') // ← the whole point
+      expect(before).not.toContain('42')
+      expect(before).toContain('Kept Person') // the one clean id still resolves
+    } finally { app.unmount(); container.remove() }
+  })
+})

--- a/apps/web/tests/multitable-history-center-inline-diff.spec.ts
+++ b/apps/web/tests/multitable-history-center-inline-diff.spec.ts
@@ -666,6 +666,55 @@ describe('HistoryCenterModal — all-tables cross-sheet type-aware diffs + dirty
     } finally { app.unmount(); container.remove() }
   })
 
+  // NO-FABRICATION (review P2-1). `fieldTypes` gives us a cross-sheet field's id→name/type, but NOT its
+  // `property`. Formatting a property-dependent type from a property-LESS field makes formatFieldDisplay
+  // fall back to its defaults and INVENT a value: a USD currency renders with a ¥ symbol, and a rating with
+  // max=10 renders 8 as five full stars. History is an AUDIT surface — a wrong value is worse than an
+  // unformatted one. So the cross-sheet fallback is person-only; every other type shows the raw value.
+  const otherSheetCurrency = [{
+    sheetId: 'sheet_other', recordId: 'rec_9', action: 'update', version: 2,
+    changedFieldIds: ['fld_other_money'],
+    before: { fld_other_money: 1000 },
+    after: { fld_other_money: 2000 },
+  }] as unknown as HistoryBatchDetail['changes']
+
+  it('NO-FABRICATION: a cross-sheet CURRENCY diff shows the raw value, never a guessed currency symbol', async () => {
+    const { app, container } = await openWith({
+      ...detailWith(otherSheetCurrency),
+      fieldNames: { sheet_other: { fld_other_money: 'Amount' } },
+      fieldTypes: { sheet_other: { fld_other_money: 'currency' } }, // type known, property NOT
+    }, {})
+    try {
+      const before = container.querySelector('.meta-hist__diff-before')?.textContent ?? ''
+      const after = container.querySelector('.meta-hist__diff-after')?.textContent ?? ''
+      expect(before).toContain('1000')
+      expect(after).toContain('2000')
+      // the field is USD on its own sheet; we have no property here, so we must NOT stamp a symbol on it
+      expect(before).not.toContain('¥')
+      expect(before).not.toContain('$')
+      expect(after).not.toContain('¥')
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('NO-FABRICATION: a cross-sheet RATING diff shows the raw number, never stars against a guessed max', async () => {
+    const ratingChange = [{
+      sheetId: 'sheet_other', recordId: 'rec_9', action: 'update', version: 2,
+      changedFieldIds: ['fld_other_rating'],
+      before: { fld_other_rating: 8 }, // max=10 on its own sheet → 8/10, NOT full marks
+      after: { fld_other_rating: 9 },
+    }] as unknown as HistoryBatchDetail['changes']
+    const { app, container } = await openWith({
+      ...detailWith(ratingChange),
+      fieldNames: { sheet_other: { fld_other_rating: 'Score' } },
+      fieldTypes: { sheet_other: { fld_other_rating: 'rating' } }, // type known, property (max) NOT
+    }, {})
+    try {
+      const before = container.querySelector('.meta-hist__diff-before')?.textContent ?? ''
+      expect(before).toContain('8')
+      expect(before).not.toContain('★') // default max=5 would cap 8 to five stars ⇒ reads as full marks
+    } finally { app.unmount(); container.remove() }
+  })
+
   it('DIRTY VALUES: a person value holding an object/number/null never renders as "[object Object]"', async () => {
     const dirty = [{
       sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,

--- a/apps/web/tests/multitable-history-center-inline-diff.spec.ts
+++ b/apps/web/tests/multitable-history-center-inline-diff.spec.ts
@@ -545,3 +545,75 @@ describe('HistoryCenterModal — restore back-reference badge', () => {
     } finally { app.unmount(); container.remove() }
   })
 })
+
+// Person before-side name resolution. The grid's `personSummaries` cache describes the record's CURRENT
+// cell, so a person REMOVED by the very change you're looking at is NOT in it and used to render as a raw
+// userId — "who was removed" was unreadable. The server's `personNames` map covers BOTH sides.
+// Priority per id: personNames → grid cell cache → raw id.
+describe('HistoryCenterModal — person before-side name resolution', () => {
+  const removedChange = [{
+    sheetId: 'sheet_1', recordId: 'rec_1', action: 'update', version: 2,
+    changedFieldIds: ['fld_person'],
+    before: { fld_person: ['user_kept', 'user_removed'] },
+    after: { fld_person: ['user_kept'] },
+  }] as unknown as HistoryBatchDetail['changes']
+
+  async function openWith(personNames: Record<string, { display: string; inactive?: boolean }> | undefined, personSummaries: unknown) {
+    mockListHistoryEvents.mockResolvedValue({ batches: [batch()], total: 1, nextCursor: null, searchTruncated: false })
+    mockGetHistoryBatch.mockResolvedValue({ ...detailWith(removedChange), ...(personNames ? { personNames } : {}) })
+    const { app, container } = mountModalWithProps({ fields: TYPED_FIELDS, personSummaries })
+    await flushPromises()
+    container.querySelector<HTMLButtonElement>('[data-test="hist-batch"]')!.click()
+    await flushPromises()
+    return { app, container }
+  }
+
+  it('BEFORE side resolves the REMOVED person from personNames — the grid cache cannot know them', async () => {
+    // the cache holds ONLY the current cell (user_kept); user_removed is gone from it by definition
+    const { app, container } = await openWith(
+      { user_kept: { display: 'Kept Person' }, user_removed: { display: 'Removed Person' } },
+      { rec_1: { fld_person: [{ id: 'user_kept', display: 'Kept Person' }] } },
+    )
+    try {
+      const before = container.querySelector('.meta-hist__diff-before')?.textContent ?? ''
+      expect(before).toContain('Removed Person') // ← the whole point of the feature
+      expect(before).not.toContain('user_removed') // not the raw id
+      expect(before).toContain('Kept Person')
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('marks a DEACTIVATED person and still renders them (OD-P2)', async () => {
+    const { app, container } = await openWith(
+      { user_kept: { display: 'Kept Person' }, user_removed: { display: 'Removed Person', inactive: true } },
+      { rec_1: { fld_person: [{ id: 'user_kept', display: 'Kept Person' }] } },
+    )
+    try {
+      const before = container.querySelector('.meta-hist__diff-before')?.textContent ?? ''
+      expect(before).toContain('Removed Person') // still visible…
+      expect(before).toContain('deactivated') // …and marked
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('falls back to the grid cache, then to the raw id, when personNames lacks the id', async () => {
+    // personNames covers neither id → cache supplies user_kept; user_removed has no source → raw id
+    const { app, container } = await openWith(
+      {},
+      { rec_1: { fld_person: [{ id: 'user_kept', display: 'Kept Person' }] } },
+    )
+    try {
+      const before = container.querySelector('.meta-hist__diff-before')?.textContent ?? ''
+      expect(before).toContain('Kept Person') // cache fallback
+      expect(before).toContain('user_removed') // raw-id fallback, not JSON
+      expect(before).not.toContain('[')
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('no personNames at all (older payload) → legacy behavior exactly (cache, then raw id)', async () => {
+    const { app, container } = await openWith(undefined, { rec_1: { fld_person: [{ id: 'user_kept', display: 'Kept Person' }] } })
+    try {
+      const before = container.querySelector('.meta-hist__diff-before')?.textContent ?? ''
+      expect(before).toContain('Kept Person')
+      expect(before).toContain('user_removed')
+    } finally { app.unmount(); container.remove() }
+  })
+})

--- a/packages/core-backend/src/multitable/history-projection.ts
+++ b/packages/core-backend/src/multitable/history-projection.ts
@@ -551,6 +551,17 @@ export interface HistoryBatchDetail {
    * name is directory-level info (the same name renders wherever that user appears), not a new disclosure.
    */
   personNames: Record<string, PersonDirectoryEntry>
+  /**
+   * all-tables: masked field-id → TYPE map, per sheet — the companion to `fieldNames`.
+   *
+   * WHY: in all-tables mode the FE's `fields` prop carries only the ACTIVE sheet's fields, so a change row on
+   * a NON-active sheet had no type and fell back to raw JSON text — a person diff on another table rendered
+   * as `["u_123"]` instead of names, and a link/date/select diff rendered raw. `fieldNames` fixed the LABEL;
+   * this fixes the VALUE. Same masked source (`allowedFieldsBySheet`), same query (the join already selects
+   * `f.type`), so it costs nothing extra and can only describe a field whose value the projection already
+   * emits. Hidden/denied field types NEVER appear, exactly as their names never do.
+   */
+  fieldTypes: Record<string, Record<string, string>>
 }
 
 /**
@@ -728,6 +739,7 @@ export async function loadHistoryBatchDetail(
   // subset of the two-layer allow-set, so the query cannot return a hidden/denied field; the re-check below
   // is defense-in-depth (LOCK-3: a field name is as sensitive as its value, evaluated PER the field's sheet).
   const fieldNames: Record<string, Record<string, string>> = {}
+  const fieldTypes: Record<string, Record<string, string>> = {}
   // Person before-side resolution: the SAME meta_fields join also tells us which of those already-visible
   // fields are `type='person'` (no extra query), so we can harvest their userIds below.
   const personFieldsBySheet = new Map<string, Set<string>>()
@@ -746,7 +758,9 @@ export async function loadHistoryBatchDetail(
       if (!allowedFieldsFor(allowedFieldsBySheet, sheetId).has(fieldId)) continue // defense-in-depth LOCK-3
       const name = typeof row.name === 'string' ? row.name : ''
       ;(fieldNames[sheetId] ??= {})[fieldId] = name
-      if (String(row.type ?? '').trim().toLowerCase() === 'person') {
+      const fieldType = String(row.type ?? '').trim()
+      if (fieldType) (fieldTypes[sheetId] ??= {})[fieldId] = fieldType
+      if (fieldType.toLowerCase() === 'person') {
         ;(personFieldsBySheet.get(sheetId) ?? personFieldsBySheet.set(sheetId, new Set()).get(sheetId)!).add(fieldId)
       }
     }
@@ -783,6 +797,7 @@ export async function loadHistoryBatchDetail(
     visibleAffectedFieldCount: visibleFields.size,
     changes,
     fieldNames,
+    fieldTypes,
     personNames,
   }
 }

--- a/packages/core-backend/src/multitable/history-projection.ts
+++ b/packages/core-backend/src/multitable/history-projection.ts
@@ -23,6 +23,8 @@
  */
 import type { QueryFn } from './permission-service'
 import { loadDeniedRecordIds, loadRowLevelReadDenyEnabled } from './permission-service'
+import type { PersonDirectoryEntry } from './user-display'
+import { resolvePersonDirectoryEntries } from './user-display'
 
 export interface HistoryAccess {
   userId: string
@@ -533,6 +535,22 @@ export interface HistoryBatchDetail {
    * re-deriving the two-layer mask client-side (the #4007 footgun). Hidden/denied field names NEVER appear.
    */
   fieldNames: Record<string, Record<string, string>>
+  /**
+   * Person before-side name resolution (OD-P1 = Option A, OD-P2 = carry `inactive`): a flat
+   * `userId → { display, inactive? }` directory map for every userId that appears in this batch's
+   * (post-mask) PERSON field values — before AND after sides.
+   *
+   * WHY IT EXISTS: the grid's person cache only knows the record's CURRENT cell, so a person REMOVED by
+   * this very change (present in `before`, absent from `after`) has no cached summary and used to render
+   * as a raw userId — "who was removed" was unreadable. This map is resolved server-side from the SAME
+   * directory as `actorName` (`resolvePersonDirectoryEntries`, one query for the whole batch, never N+1).
+   *
+   * LOCK-3: the ids are harvested ONLY from `changes` — which is already value-masked — and only for
+   * fields in the per-sheet allow-set. A person field the actor cannot read has had its values dropped
+   * before this runs, so its userIds never appear here. Resolving an ALREADY-VISIBLE userId to its display
+   * name is directory-level info (the same name renders wherever that user appears), not a new disclosure.
+   */
+  personNames: Record<string, PersonDirectoryEntry>
 }
 
 /**
@@ -710,12 +728,15 @@ export async function loadHistoryBatchDetail(
   // subset of the two-layer allow-set, so the query cannot return a hidden/denied field; the re-check below
   // is defense-in-depth (LOCK-3: a field name is as sensitive as its value, evaluated PER the field's sheet).
   const fieldNames: Record<string, Record<string, string>> = {}
+  // Person before-side resolution: the SAME meta_fields join also tells us which of those already-visible
+  // fields are `type='person'` (no extra query), so we can harvest their userIds below.
+  const personFieldsBySheet = new Map<string, Set<string>>()
   const nameSheetIds: string[] = []
   const nameFieldIds: string[] = []
   for (const [sheetId, ids] of involvedFieldsBySheet) for (const fieldId of ids) { nameSheetIds.push(sheetId); nameFieldIds.push(fieldId) }
   if (nameFieldIds.length > 0) {
     const nameRes = await query(
-      `SELECT f.id, f.sheet_id, f.name FROM meta_fields f
+      `SELECT f.id, f.sheet_id, f.name, f.type FROM meta_fields f
        JOIN unnest($1::text[], $2::text[]) AS t(sheet_id, field_id) ON f.sheet_id = t.sheet_id AND f.id = t.field_id`,
       [nameSheetIds, nameFieldIds],
     )
@@ -725,7 +746,32 @@ export async function loadHistoryBatchDetail(
       if (!allowedFieldsFor(allowedFieldsBySheet, sheetId).has(fieldId)) continue // defense-in-depth LOCK-3
       const name = typeof row.name === 'string' ? row.name : ''
       ;(fieldNames[sheetId] ??= {})[fieldId] = name
+      if (String(row.type ?? '').trim().toLowerCase() === 'person') {
+        ;(personFieldsBySheet.get(sheetId) ?? personFieldsBySheet.set(sheetId, new Set()).get(sheetId)!).add(fieldId)
+      }
     }
+  }
+
+  // Harvest the userIds to resolve. ONLY from `changes` (already value-masked) and ONLY for person fields
+  // in the per-sheet allow-set ⇒ a denied person field's values were dropped upstream and can never land
+  // here (LOCK-3 — see the `personNames` doc on HistoryBatchDetail). Both sides: the whole point is the
+  // BEFORE side, where a just-removed person has no grid-cache summary.
+  const personIds: string[] = []
+  const collect = (v: unknown): void => {
+    if (Array.isArray(v)) { for (const id of v) if (typeof id === 'string' && id.trim()) personIds.push(id) }
+    else if (typeof v === 'string' && v.trim()) personIds.push(v)
+  }
+  for (const c of changes) {
+    const personFields = personFieldsBySheet.get(c.sheetId)
+    if (!personFields?.size) continue
+    for (const fieldId of personFields) {
+      if (c.before && Object.prototype.hasOwnProperty.call(c.before, fieldId)) collect(c.before[fieldId])
+      if (c.after && Object.prototype.hasOwnProperty.call(c.after, fieldId)) collect(c.after[fieldId])
+    }
+  }
+  const personNames: Record<string, PersonDirectoryEntry> = {}
+  if (personIds.length > 0) {
+    for (const [id, entry] of await resolvePersonDirectoryEntries(query, personIds)) personNames[id] = entry
   }
 
   return {
@@ -737,5 +783,6 @@ export async function loadHistoryBatchDetail(
     visibleAffectedFieldCount: visibleFields.size,
     changes,
     fieldNames,
+    personNames,
   }
 }

--- a/packages/core-backend/src/multitable/user-display.ts
+++ b/packages/core-backend/src/multitable/user-display.ts
@@ -72,8 +72,13 @@ export async function resolvePersonDirectoryEntries(
       const display = name || email || id // raw-id fallback, matching the grid's person summaries
       out.set(id, u.is_active === false ? { display, inactive: true } : { display })
     }
-  } catch {
-    // users table absent (minimal harness) — return empty; callers fall back to the raw id.
+  } catch (err) {
+    // ONLY "users table absent" (42P01, minimal harness) degrades to an empty map → callers fall back to the
+    // raw id. Anything else RETHROWS, matching the sibling this claims parity with (`buildPersonSummaries`,
+    // univer-meta.ts:5435-5438). A bare `catch {}` here would swallow a transient connection error or a
+    // genuinely broken query and silently render EVERY person as a raw userId, with no signal at all —
+    // fail-safe in direction, but indistinguishable from "no directory exists" (review P3-1).
+    if (!(typeof (err as { code?: unknown })?.code === 'string' && (err as { code?: string }).code === '42P01')) throw err
   }
   return out
 }

--- a/packages/core-backend/src/multitable/user-display.ts
+++ b/packages/core-backend/src/multitable/user-display.ts
@@ -32,3 +32,48 @@ export async function resolveUserDisplayNames(
   }
   return out
 }
+
+/** A person-field directory entry: the same shape the grid's PersonSummary carries (minus `id`). */
+export type PersonDirectoryEntry = { display: string; inactive?: boolean }
+
+/**
+ * Person before-side name resolution (OD-P1 = Option A, OD-P2 = carry `inactive`).
+ *
+ * Resolve `userId → { display, inactive }` for user ids that appear in person-field VALUES. Same
+ * directory + same rules as `resolveUserDisplayNames` / `buildPersonSummaries`, so there is ONE source
+ * of truth for both:
+ *   - display preference `name → email`, falling back to the RAW userId when the user row exists but
+ *     carries neither (parity with the grid's person summaries, univer-meta.ts:5449);
+ *   - `inactive: true` iff `users.is_active === false` (2c-S4, univer-meta.ts:5433) — a deactivated
+ *     assignee still renders, marked, and stays non-re-assignable.
+ * Graceful empty map if the `users` table is absent (minimal harness) → caller falls back to the raw id.
+ *
+ * WHY THIS IS NOT A DISCLOSURE (LOCK-3): the caller resolves ONLY the userIds that are already present
+ * in the POST-MASK payload. A person field the actor cannot read has had its values dropped by
+ * `filterDataByAllowedFields` before this runs, so its userIds never reach here. Turning an ALREADY-VISIBLE
+ * userId into its display name is directory-level information (the same name already renders wherever
+ * that user appears, and `actorName` resolves it from this very table) — it is not a new disclosure of the
+ * field's value. Never call this with ids harvested from an unmasked snapshot.
+ */
+export async function resolvePersonDirectoryEntries(
+  query: QueryFn,
+  userIds: Array<string | null | undefined>,
+): Promise<Map<string, PersonDirectoryEntry>> {
+  const ids = [...new Set(userIds.filter((id): id is string => typeof id === 'string' && id.length > 0))]
+  const out = new Map<string, PersonDirectoryEntry>()
+  if (ids.length === 0) return out
+  try {
+    const res = await query('SELECT id, email, name, is_active FROM users WHERE id = ANY($1::text[])', [ids])
+    for (const u of res.rows as Array<{ id?: unknown; email?: unknown; name?: unknown; is_active?: unknown }>) {
+      const id = typeof u.id === 'string' ? u.id : String(u.id ?? '')
+      if (!id) continue
+      const name = typeof u.name === 'string' ? u.name.trim() : ''
+      const email = typeof u.email === 'string' ? u.email.trim() : ''
+      const display = name || email || id // raw-id fallback, matching the grid's person summaries
+      out.set(id, u.is_active === false ? { display, inactive: true } : { display })
+    }
+  } catch {
+    // users table absent (minimal harness) — return empty; callers fall back to the raw id.
+  }
+  return out
+}

--- a/packages/core-backend/tests/integration/multitable-history-alltables-fieldnames-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-alltables-fieldnames-realdb.test.ts
@@ -137,4 +137,28 @@ describeIfDatabase('all-tables-B — batch-detail fieldNames masked cross-table 
     expect(body).toContain(OK_A_NAME)
     expect(body).toContain(OK_B_NAME)
   })
+
+  test('fieldTypes mirrors fieldNames — same masked set; a hidden/denied field TYPE never leaks either', async () => {
+    const res = await detail(BATCH)
+    expect(res.status).toBe(200)
+    const fieldNames = res.body?.data?.fieldNames
+    const fieldTypes = res.body?.data?.fieldTypes
+    expect(fieldTypes && typeof fieldTypes === 'object').toBe(true)
+
+    // fieldTypes covers EXACTLY the same (sheet, field) pairs fieldNames does — same masked allow-set.
+    // If it could describe a field fieldNames cannot name, it would be a second, weaker mask.
+    expect(Object.keys(fieldTypes).sort()).toEqual(Object.keys(fieldNames).sort())
+    for (const sheetId of Object.keys(fieldNames)) {
+      expect(Object.keys(fieldTypes[sheetId]).sort()).toEqual(Object.keys(fieldNames[sheetId]).sort())
+    }
+
+    // the readable fields DO carry a type (non-vacuous)
+    expect(fieldTypes[SHEET_A]?.[OK_A]).toBeTruthy()
+    expect(fieldTypes[SHEET_B]?.[OK_B]).toBeTruthy()
+
+    // LOCK-3: the layer-2 property-hidden and layer-3 denied fields have NO type entry — the same
+    // exclusion their NAMES get. A type is metadata about a field the actor cannot read.
+    expect(fieldTypes[SHEET_A]?.[HIDDEN_A]).toBeUndefined()
+    expect(fieldTypes[SHEET_B]?.[DENIED_B]).toBeUndefined()
+  })
 })

--- a/packages/core-backend/tests/integration/multitable-history-person-names-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-person-names-realdb.test.ts
@@ -16,10 +16,9 @@
  *   G2 a deactivated user carries `inactive: true` (OD-P2; same `users.is_active === false` rule as the grid).
  *   G3 LOCK-3: a person in a field_permissions-DENIED person field appears NOWHERE — not in personNames,
  *      not anywhere in the response body (whole-body assertion).
- *   G4 TRIPWIRE (current reality, not an endorsement): a layer-2 `property.hidden` PERSON field is NOT
- *      excluded — because layer-2 hiding is a PLATFORM NO-OP on person fields (pre-existing; the sanitizer
- *      drops `hidden`). Such a field is one the actor CAN read, so it is outside this feature's precondition.
- *      Pinned so the gap is visible; flip it when the platform bug is fixed. See the test's own docstring.
+ *   G4 LOCK-3 (layer-2): a person inside a property-HIDDEN person field appears NOWHERE. Authored as a
+ *      tripwire when layer-2 hiding was a platform no-op on person fields; FLIPPED to this deny assertion
+ *      once #4165 fixed it. Layer-2 is now a SECOND independent exclusion, alongside G3's layer-3.
  *
  * MUTATION MATRIX (12 combinations, measured — independently re-run by the #4161 adversarial review).
  * The leak is guarded three times: (i) the `changed_field_ids` filter (`allowed.has`) → a denied person field
@@ -172,33 +171,43 @@ describeIfDatabase('person before-side name resolution — batch-detail personNa
   })
 
   /**
-   * G4 — CURRENT-REALITY TRIPWIRE, not an endorsement. Documents a PRE-EXISTING PLATFORM GAP that this
-   * feature neither causes nor relies on (found by the #4161 adversarial review):
+   * G4 — DENY ASSERTION (flipped 2026-07-12, once the platform fix landed).
    *
-   *   layer-2 `property.hidden` is a NO-OP on native PERSON fields, platform-wide.
-   *   `sanitizeFieldPropertyByType`'s `person` branch (field-codecs.ts) is a CLOSED ALLOWLIST that silently
-   *   drops `hidden`/`visible` — unlike `select`, which passes them through. So `isFieldPermissionHidden`
-   *   never sees the flag, and a "hidden" person field is readable at EVERY surface: `GET /records` already
-   *   returns its userIds today, with or without this PR.
+   * This test was authored as a CURRENT-REALITY TRIPWIRE: layer-2 `property.hidden` used to be a NO-OP on
+   * native person fields (the `person` branch of `sanitizeFieldPropertyByType` was a closed allowlist that
+   * silently dropped `hidden`/`visible`), so a "hidden" person field was readable at every surface. The
+   * tripwire pinned that reality and said, in as many words, "flip this when the platform bug is fixed".
    *
-   * ⇒ Such a field is one the actor CAN read, so it is outside this feature's masking precondition (which is
-   *   scoped to layer-3 `field_permissions`-DENIED — see G3). Marginal disclosure of this PR is ZERO: the raw
-   *   ids are already on the same payload pre-PR; `personNames` only turns an ALREADY-VISIBLE id into a name.
+   * It is fixed (#4165 `30d2acb17`): `withLayer2VisibilityKeys` now carries the layer-2 keys across EVERY
+   * type's sanitizer, in BOTH sanitizers. The tripwire duly went red — `expected undefined to be
+   * 'Layer2HiddenPerson'` — which is the tripwire working, not a regression. It is now flipped to the
+   * assertion it always wanted to be:
    *
-   * This test pins that reality so the gap is VISIBLE rather than silently absent. **When the platform bug is
-   * fixed** (person's sanitizer stops dropping `hidden`), this test WILL go red — that is the point: flip it
-   * to `toBeUndefined()` then. Deliberately NOT written as a failing test, which would make an out-of-scope
-   * permission-layer fix a merge gate for this feature.
+   *   a layer-2 property-hidden PERSON field is masked, so its member NEVER reaches the directory resolver
+   *   and their display NAME can never surface.
+   *
+   * This makes layer-2 a SECOND independent exclusion for `personNames`, alongside the layer-3
+   * field_permissions exclusion G3 pins. Both layers now hold.
    */
-  test('G4 tripwire: a layer-2 property-hidden PERSON field is NOT excluded — because layer-2 hiding is a platform no-op on person fields (pre-existing; flip this when fixed)', async () => {
+  test('G4 LOCK-3 (layer-2): a person inside a property-HIDDEN person field appears NOWHERE', async () => {
     const res = await detail(BATCH)
     expect(res.status).toBe(200)
     const personNames = res.body?.data?.personNames
-    // Current reality: the "hidden" person field is readable, so its member resolves like any visible person.
-    expect(personNames[P_HIDDEN]?.display).toBe(HIDDEN_NAME)
-    // …and, decisively, its raw id is ALREADY on the payload pre-PR — so personNames adds no disclosure here.
+
+    // the hidden field's member is NOT resolved — not even to a raw id
+    expect(personNames[P_HIDDEN]).toBeUndefined()
+
+    // precondition (proves the layer-2 mask is actually on, so this is not vacuous):
+    // the hidden field's VALUES are dropped upstream, exactly like the layer-3 denied field in G3
     const change = (res.body?.data?.changes ?? []).find((c: any) => c.recordId === REC)
-    expect(change?.before?.[PERSON_HIDDEN]).toEqual([P_HIDDEN])
+    expect(change?.before?.[PERSON_HIDDEN]).toBeUndefined()
+    expect(change?.after?.[PERSON_HIDDEN]).toBeUndefined()
+    expect(change?.changedFieldIds).not.toContain(PERSON_HIDDEN)
+
+    // WHOLE-BODY: neither the hidden member's id nor their display name may appear anywhere.
+    const body = JSON.stringify(res.body)
+    expect(body).not.toContain(HIDDEN_NAME)
+    expect(body).not.toContain(P_HIDDEN)
   })
 
   test('G3 LOCK-3: a person inside a field_permissions-DENIED person field appears NOWHERE', async () => {

--- a/packages/core-backend/tests/integration/multitable-history-person-names-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-person-names-realdb.test.ts
@@ -16,20 +16,38 @@
  *   G2 a deactivated user carries `inactive: true` (OD-P2; same `users.is_active === false` rule as the grid).
  *   G3 LOCK-3: a person in a field_permissions-DENIED person field appears NOWHERE — not in personNames,
  *      not anywhere in the response body (whole-body assertion).
+ *   G4 TRIPWIRE (current reality, not an endorsement): a layer-2 `property.hidden` PERSON field is NOT
+ *      excluded — because layer-2 hiding is a PLATFORM NO-OP on person fields (pre-existing; the sanitizer
+ *      drops `hidden`). Such a field is one the actor CAN read, so it is outside this feature's precondition.
+ *      Pinned so the gap is visible; flip it when the platform bug is fixed. See the test's own docstring.
  *
- * MUTATION MATRIX (measured, not asserted — stating exactly what each golden is load-bearing FOR):
- *   The leak is guarded THREE independent times: (i) `involvedFieldsBySheet` accumulates from the POST-MASK
- *   `fields`, so a denied person field never even becomes a person-field candidate; (ii) the name loop
- *   re-checks `allowed.has`; (iii) the id harvest reads the POST-MASK `changes`, never a raw snapshot.
- *     - break (ii) alone              → 4/4 still GREEN (no leak — (i)+(iii) hold)
- *     - break (iii) alone             → G1+G2 RED (the removed/inactive people live only on the HYDRATED
- *                                       `before` side, absent from this batch's raw rows), but NO leak
- *     - break (ii)+(iii)              → G1+G2 RED, still NO leak (guard (i) alone suffices)
- *     - break ALL THREE               → G3 RED: the denied person's display NAME surfaces in the body
- *   So: **G1/G2 are load-bearing for correctness** (they red on a real refactor). **G3 is non-vacuous but
- *   triply-redundant** — it is the last line, not the only line. Do not read a green G3 as "the mask works";
- *   read it as "all three guards would have to fail together." (Mutation-red proves load-bearing for a layer;
- *   it does not by itself prove a reachable vulnerability.)
+ * MUTATION MATRIX (12 combinations, measured — independently re-run by the #4161 adversarial review).
+ * The leak is guarded three times: (i) the `changed_field_ids` filter (`allowed.has`) → a denied person field
+ * never becomes a person-field candidate; (ii) the name loop's `allowed.has` re-check; (iii) the id harvest
+ * reads the POST-MASK `changes`, never a raw snapshot.
+ *   NOTE (review NIT-2): (i) and (ii) are the SAME predicate applied twice — defense-in-depth, not two
+ *   independent properties. The genuinely independent guard is (iii).
+ *
+ * Two flavors of breaking (iii) matter, and they say OPPOSITE things about G3:
+ *   - (iii-a) harvest this batch's RAW rows → also loses the hydrated before-image
+ *   - (iii-b) harvest raw snapshots AND the raw, UNMASKED hydrated prev-snapshot → before-image still works
+ *             (this is the MORE REALISTIC refactor: "just read the snapshots directly")
+ *
+ *   | breaks            | G1    | G2    | G3    | leak? |
+ *   |-------------------|-------|-------|-------|-------|
+ *   | none (as-is)      | GREEN | GREEN | GREEN |  –    |
+ *   | any ONE           | see below, but NEVER a leak                   |
+ *   | any TWO           | never a leak                                  |
+ *   | i + ii + iii-a    | RED   | RED   | RED   | LEAK  |
+ *   | i + ii + iii-b    | GREEN | GREEN | **RED** | LEAK |
+ *
+ * So, precisely:
+ *   - The leak needs ALL THREE broken — no single or double break reds G3 (upheld).
+ *   - G1/G2 are load-bearing for CORRECTNESS (they red under iii-a).
+ *   - **G3 is NOT merely a redundant last line.** Under (iii-b) — the refactor someone would actually write —
+ *     **G1 and G2 stay GREEN and G3 is the SOLE detector of the leak.** An earlier version of this header
+ *     called G3 "triply-redundant"; that undersold it and is corrected here.
+ *   (Mutation-red proves a guard is load-bearing for its layer; it is not by itself a reachability claim.)
  *
  * Runs only with DATABASE_URL. (plugin-tests.yml whitelist — two-point wiring.)
  */
@@ -46,6 +64,7 @@ const BASE_ID = `base_pn_${TS}`
 const SHEET_ID = `sheet_pn_${TS}`
 const PERSON_OK = `fld_pn_ok_${TS}` // readable person field
 const PERSON_DENIED = `fld_pn_den_${TS}` // layer-3 field_permissions-denied person field
+const PERSON_HIDDEN = `fld_pn_hid_${TS}` // layer-2 property.hidden person field (a NO-OP on person — see G4)
 const REC = `rec_pn_${TS}`
 const BATCH_PRIOR = `batch_pn_prior_${TS}`
 const BATCH = `batch_pn_${TS}`
@@ -55,11 +74,13 @@ const P_KEPT = `user_pn_kept_${TS}` // still in the cell after the change
 const P_REMOVED = `user_pn_removed_${TS}` // REMOVED by this change — the whole point
 const P_INACTIVE = `user_pn_inactive_${TS}` // deactivated (is_active = false)
 const P_SECRET = `user_pn_secret_${TS}` // ONLY in the DENIED field — must never surface
+const P_HIDDEN = `user_pn_hidden_${TS}` // ONLY in the layer-2 property-hidden field (G4 tripwire)
 
 const KEPT_NAME = 'Kept Person'
 const REMOVED_NAME = 'Removed Person'
 const INACTIVE_NAME = 'Inactive Person'
 const SECRET_NAME = 'SecretPersonMustNeverAppear'
+const HIDDEN_NAME = 'Layer2HiddenPerson'
 
 const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
 let app: Express
@@ -91,11 +112,14 @@ describeIfDatabase('person before-side name resolution — batch-detail personNa
     await addUser(P_REMOVED, REMOVED_NAME)
     await addUser(P_INACTIVE, INACTIVE_NAME, false) // 2c-S4: is_active = false ⇒ inactive
     await addUser(P_SECRET, SECRET_NAME)
+    await addUser(P_HIDDEN, HIDDEN_NAME)
 
     await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'PersonNames Base'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'PN Sheet'])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [PERSON_OK, SHEET_ID, 'Assignees', 'person', '{}', 1])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [PERSON_DENIED, SHEET_ID, 'SecretAssignees', 'person', '{}', 2])
+    // layer-2 property-hidden person field — which the platform does NOT actually hide (G4 tripwire).
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [PERSON_HIDDEN, SHEET_ID, 'HiddenAssignees', 'person', '{"hidden":true}', 3])
     // layer-3: VIEWER cannot read PERSON_DENIED ⇒ its VALUES (and thus its userIds) are dropped post-mask.
     await q(
       `INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,false,false)`,
@@ -103,10 +127,10 @@ describeIfDatabase('person before-side name resolution — batch-detail personNa
     )
 
     // v1 (prior batch): the person cell holds THREE people; the denied field holds the secret person.
-    await insertRevision(1, BATCH_PRIOR, { [PERSON_OK]: [P_KEPT, P_REMOVED, P_INACTIVE], [PERSON_DENIED]: [P_SECRET] }, [PERSON_OK, PERSON_DENIED])
+    await insertRevision(1, BATCH_PRIOR, { [PERSON_OK]: [P_KEPT, P_REMOVED, P_INACTIVE], [PERSON_DENIED]: [P_SECRET], [PERSON_HIDDEN]: [P_HIDDEN] }, [PERSON_OK, PERSON_DENIED, PERSON_HIDDEN])
     // v2 (BATCH under test): P_REMOVED and P_INACTIVE are removed — only P_KEPT survives in the current cell.
     // The denied field is listed as changed too, so its ids are in the RAW snapshot the projection reads.
-    await insertRevision(2, BATCH, { [PERSON_OK]: [P_KEPT], [PERSON_DENIED]: [P_SECRET] }, [PERSON_OK, PERSON_DENIED])
+    await insertRevision(2, BATCH, { [PERSON_OK]: [P_KEPT], [PERSON_DENIED]: [P_SECRET], [PERSON_HIDDEN]: [P_HIDDEN] }, [PERSON_OK, PERSON_DENIED, PERSON_HIDDEN])
   })
 
   afterAll(async () => {
@@ -115,7 +139,7 @@ describeIfDatabase('person before-side name resolution — batch-detail personNa
     await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
-    for (const u of [VIEWER, P_KEPT, P_REMOVED, P_INACTIVE, P_SECRET]) await q('DELETE FROM users WHERE id = $1', [u]).catch(() => {})
+    for (const u of [VIEWER, P_KEPT, P_REMOVED, P_INACTIVE, P_SECRET, P_HIDDEN]) await q('DELETE FROM users WHERE id = $1', [u]).catch(() => {})
   })
 
   test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
@@ -145,6 +169,36 @@ describeIfDatabase('person before-side name resolution — batch-detail personNa
     expect(personNames[P_INACTIVE]?.inactive).toBe(true)
     // an ACTIVE user must NOT be marked (otherwise the marker is meaningless)
     expect(personNames[P_KEPT]?.inactive).toBeUndefined()
+  })
+
+  /**
+   * G4 — CURRENT-REALITY TRIPWIRE, not an endorsement. Documents a PRE-EXISTING PLATFORM GAP that this
+   * feature neither causes nor relies on (found by the #4161 adversarial review):
+   *
+   *   layer-2 `property.hidden` is a NO-OP on native PERSON fields, platform-wide.
+   *   `sanitizeFieldPropertyByType`'s `person` branch (field-codecs.ts) is a CLOSED ALLOWLIST that silently
+   *   drops `hidden`/`visible` — unlike `select`, which passes them through. So `isFieldPermissionHidden`
+   *   never sees the flag, and a "hidden" person field is readable at EVERY surface: `GET /records` already
+   *   returns its userIds today, with or without this PR.
+   *
+   * ⇒ Such a field is one the actor CAN read, so it is outside this feature's masking precondition (which is
+   *   scoped to layer-3 `field_permissions`-DENIED — see G3). Marginal disclosure of this PR is ZERO: the raw
+   *   ids are already on the same payload pre-PR; `personNames` only turns an ALREADY-VISIBLE id into a name.
+   *
+   * This test pins that reality so the gap is VISIBLE rather than silently absent. **When the platform bug is
+   * fixed** (person's sanitizer stops dropping `hidden`), this test WILL go red — that is the point: flip it
+   * to `toBeUndefined()` then. Deliberately NOT written as a failing test, which would make an out-of-scope
+   * permission-layer fix a merge gate for this feature.
+   */
+  test('G4 tripwire: a layer-2 property-hidden PERSON field is NOT excluded — because layer-2 hiding is a platform no-op on person fields (pre-existing; flip this when fixed)', async () => {
+    const res = await detail(BATCH)
+    expect(res.status).toBe(200)
+    const personNames = res.body?.data?.personNames
+    // Current reality: the "hidden" person field is readable, so its member resolves like any visible person.
+    expect(personNames[P_HIDDEN]?.display).toBe(HIDDEN_NAME)
+    // …and, decisively, its raw id is ALREADY on the payload pre-PR — so personNames adds no disclosure here.
+    const change = (res.body?.data?.changes ?? []).find((c: any) => c.recordId === REC)
+    expect(change?.before?.[PERSON_HIDDEN]).toEqual([P_HIDDEN])
   })
 
   test('G3 LOCK-3: a person inside a field_permissions-DENIED person field appears NOWHERE', async () => {

--- a/packages/core-backend/tests/integration/multitable-history-person-names-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-person-names-realdb.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Person before-side name resolution — batch-detail `personNames` directory map (real DB).
+ *
+ * THE PROBLEM: the grid's `personSummaries` cache only knows a record's CURRENT cell. A person REMOVED by
+ * the very change you are looking at is, by definition, no longer in the current cell — so the History diff
+ * rendered them as a raw `userId`. "Who was removed" was unreadable. `loadHistoryBatchDetail` now emits
+ * `personNames: { [userId]: { display, inactive? } }` covering every userId in the batch's (post-mask)
+ * person values, BOTH sides, resolved from the SAME directory as `actorName`.
+ *
+ * THE LOCK-3 PROPERTY: a person inside a field_permissions-DENIED person field must never surface — and
+ * leaking their display NAME would be strictly worse than leaking the raw id. G3 pins that with a
+ * whole-body assertion.
+ *
+ * Goldens:
+ *   G1 the REMOVED person (present in `before`, gone from `after`) resolves to a display name — the point.
+ *   G2 a deactivated user carries `inactive: true` (OD-P2; same `users.is_active === false` rule as the grid).
+ *   G3 LOCK-3: a person in a field_permissions-DENIED person field appears NOWHERE — not in personNames,
+ *      not anywhere in the response body (whole-body assertion).
+ *
+ * MUTATION MATRIX (measured, not asserted — stating exactly what each golden is load-bearing FOR):
+ *   The leak is guarded THREE independent times: (i) `involvedFieldsBySheet` accumulates from the POST-MASK
+ *   `fields`, so a denied person field never even becomes a person-field candidate; (ii) the name loop
+ *   re-checks `allowed.has`; (iii) the id harvest reads the POST-MASK `changes`, never a raw snapshot.
+ *     - break (ii) alone              → 4/4 still GREEN (no leak — (i)+(iii) hold)
+ *     - break (iii) alone             → G1+G2 RED (the removed/inactive people live only on the HYDRATED
+ *                                       `before` side, absent from this batch's raw rows), but NO leak
+ *     - break (ii)+(iii)              → G1+G2 RED, still NO leak (guard (i) alone suffices)
+ *     - break ALL THREE               → G3 RED: the denied person's display NAME surfaces in the body
+ *   So: **G1/G2 are load-bearing for correctness** (they red on a real refactor). **G3 is non-vacuous but
+ *   triply-redundant** — it is the last line, not the only line. Do not read a green G3 as "the mask works";
+ *   read it as "all three guards would have to fail together." (Mutation-red proves load-bearing for a layer;
+ *   it does not by itself prove a reachable vulnerability.)
+ *
+ * Runs only with DATABASE_URL. (plugin-tests.yml whitelist — two-point wiring.)
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_pn_${TS}`
+const SHEET_ID = `sheet_pn_${TS}`
+const PERSON_OK = `fld_pn_ok_${TS}` // readable person field
+const PERSON_DENIED = `fld_pn_den_${TS}` // layer-3 field_permissions-denied person field
+const REC = `rec_pn_${TS}`
+const BATCH_PRIOR = `batch_pn_prior_${TS}`
+const BATCH = `batch_pn_${TS}`
+
+const VIEWER = `user_pn_viewer_${TS}` // the actor
+const P_KEPT = `user_pn_kept_${TS}` // still in the cell after the change
+const P_REMOVED = `user_pn_removed_${TS}` // REMOVED by this change — the whole point
+const P_INACTIVE = `user_pn_inactive_${TS}` // deactivated (is_active = false)
+const P_SECRET = `user_pn_secret_${TS}` // ONLY in the DENIED field — must never surface
+
+const KEPT_NAME = 'Kept Person'
+const REMOVED_NAME = 'Removed Person'
+const INACTIVE_NAME = 'Inactive Person'
+const SECRET_NAME = 'SecretPersonMustNeverAppear'
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+
+const detail = (batchId: string) => request(app).get(`/api/multitable/bases/${BASE_ID}/history/events/${batchId}`)
+
+const addUser = (id: string, name: string, isActive = true) =>
+  q(
+    "INSERT INTO users (id, password_hash, name, is_active) VALUES ($1,'x',$2,$3) ON CONFLICT (id) DO NOTHING",
+    [id, name, isActive],
+  )
+
+const insertRevision = (version: number, batchId: string, snapshot: Record<string, unknown>, changed: string[]) =>
+  q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot, batch_id)
+     VALUES (gen_random_uuid(), $1, $2, $3, 'update', 'rest', $4, $5::text[], '{}'::jsonb, $6::jsonb, $7)`,
+    [SHEET_ID, REC, version, VIEWER, changed, JSON.stringify(snapshot), batchId],
+  )
+
+describeIfDatabase('person before-side name resolution — batch-detail personNames (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: VIEWER, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await addUser(VIEWER, 'Viewer')
+    await addUser(P_KEPT, KEPT_NAME)
+    await addUser(P_REMOVED, REMOVED_NAME)
+    await addUser(P_INACTIVE, INACTIVE_NAME, false) // 2c-S4: is_active = false ⇒ inactive
+    await addUser(P_SECRET, SECRET_NAME)
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'PersonNames Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'PN Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [PERSON_OK, SHEET_ID, 'Assignees', 'person', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [PERSON_DENIED, SHEET_ID, 'SecretAssignees', 'person', '{}', 2])
+    // layer-3: VIEWER cannot read PERSON_DENIED ⇒ its VALUES (and thus its userIds) are dropped post-mask.
+    await q(
+      `INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,false,false)`,
+      [SHEET_ID, PERSON_DENIED, VIEWER],
+    )
+
+    // v1 (prior batch): the person cell holds THREE people; the denied field holds the secret person.
+    await insertRevision(1, BATCH_PRIOR, { [PERSON_OK]: [P_KEPT, P_REMOVED, P_INACTIVE], [PERSON_DENIED]: [P_SECRET] }, [PERSON_OK, PERSON_DENIED])
+    // v2 (BATCH under test): P_REMOVED and P_INACTIVE are removed — only P_KEPT survives in the current cell.
+    // The denied field is listed as changed too, so its ids are in the RAW snapshot the projection reads.
+    await insertRevision(2, BATCH, { [PERSON_OK]: [P_KEPT], [PERSON_DENIED]: [P_SECRET] }, [PERSON_OK, PERSON_DENIED])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    for (const u of [VIEWER, P_KEPT, P_REMOVED, P_INACTIVE, P_SECRET]) await q('DELETE FROM users WHERE id = $1', [u]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('G1 the REMOVED person (in before, gone from after) resolves to a display name — the whole point', async () => {
+    const res = await detail(BATCH)
+    expect(res.status).toBe(200)
+    const personNames = res.body?.data?.personNames
+    expect(personNames && typeof personNames === 'object').toBe(true)
+
+    // The removed person is NOT in the record's current cell, so the grid cache could never supply this.
+    expect(personNames[P_REMOVED]).toBeTruthy()
+    expect(personNames[P_REMOVED].display).toBe(REMOVED_NAME)
+    // the surviving person resolves too (both sides are covered)
+    expect(personNames[P_KEPT]?.display).toBe(KEPT_NAME)
+
+    // and the before side genuinely still carries the removed id (i.e. this isn't vacuous)
+    const change = (res.body?.data?.changes ?? []).find((c: any) => c.recordId === REC)
+    expect(change?.before?.[PERSON_OK]).toEqual([P_KEPT, P_REMOVED, P_INACTIVE])
+    expect(change?.after?.[PERSON_OK]).toEqual([P_KEPT])
+  })
+
+  test('G2 a deactivated user carries inactive:true (OD-P2, same users.is_active rule as the grid)', async () => {
+    const res = await detail(BATCH)
+    const personNames = res.body?.data?.personNames
+    expect(personNames[P_INACTIVE]?.display).toBe(INACTIVE_NAME)
+    expect(personNames[P_INACTIVE]?.inactive).toBe(true)
+    // an ACTIVE user must NOT be marked (otherwise the marker is meaningless)
+    expect(personNames[P_KEPT]?.inactive).toBeUndefined()
+  })
+
+  test('G3 LOCK-3: a person inside a field_permissions-DENIED person field appears NOWHERE', async () => {
+    const res = await detail(BATCH)
+    expect(res.status).toBe(200)
+    const personNames = res.body?.data?.personNames
+
+    // not in the directory map — neither the id nor the name
+    expect(personNames[P_SECRET]).toBeUndefined()
+
+    // the denied field's VALUES are dropped upstream (precondition — proves the mask is actually on)
+    const change = (res.body?.data?.changes ?? []).find((c: any) => c.recordId === REC)
+    expect(change?.before?.[PERSON_DENIED]).toBeUndefined()
+    expect(change?.after?.[PERSON_DENIED]).toBeUndefined()
+
+    // WHOLE-BODY: neither the secret user's id nor their display name may appear anywhere in the response.
+    // (Harvesting ids from the RAW snapshot instead of post-mask `changes` would leak the NAME here.)
+    const body = JSON.stringify(res.body)
+    expect(body).not.toContain(SECRET_NAME)
+    expect(body).not.toContain(P_SECRET)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -62,6 +62,13 @@ export default defineConfig({
       // job cannot skip-green it, and wired as a WHOLE FILE into the multitable real-DB step in
       // plugin-tests.yml. Two-point wiring — both points, deliberately.
       'tests/integration/multitable-layer2-hidden-person-button-realdb.test.ts',
+      // Person before-side name resolution (real DB): its reason to exist is the LOCK-3 property — a
+      // field_permissions-DENIED person field's members must never reach the directory resolver, so their
+      // display NAMES can never surface. DATABASE_URL-gated; excluded here so the no-DB job cannot
+      // skip-green it (a `describeIfDatabase` alone still gets COLLECTED and reported as skipped =
+      // silently never run), and wired as a WHOLE FILE into the multitable real-DB step in plugin-tests.yml.
+      // Two-point wiring — both points, deliberately.
+      'tests/integration/multitable-history-person-names-realdb.test.ts',
       'tests/integration/approval-manager-chain.db.test.ts',
       'tests/integration/approval-requester-department.db.test.ts',
       'tests/integration/approval-requester-title.db.test.ts',


### PR DESCRIPTION
Implements the **person before-side name-resolution** design-lock (landed PROPOSED in #4127).

## The problem
The grid's `personSummaries` cache only knows a record's **current** cell. A person **removed by the very change you're looking at** is, by definition, no longer in it — so the History diff rendered them as a **raw userId**. *"Who was removed"* was unreadable.

## The fix
`loadHistoryBatchDetail` now emits `personNames: { [userId]: { display, inactive? } }` covering every userId in the batch's **post-mask** person values, **both sides**, resolved from the same directory as `actorName` (one query, never N+1). FE priority per id: **`personNames` → grid cell cache → raw id**.

## Decisions taken (per the lock's recommendations — name different ones and I'll follow)
- **OD-P1 = Option A** — server-side map on the existing batch-detail payload; no new endpoint, no extra round-trip.
- **OD-P2 = carry `inactive`, and actually RENDER the marker.** `formatFieldDisplay` **ignores** `inactive`, so carrying it on the wire alone would have been a half-delivery. I mark it in the History diff's **own** summaries via a typed label — *not* by changing the shared formatter, which the grid and record-drawer also use.
- **OD-P3 = no flag** — read-only directory metadata, same tier as `actorName` / `fieldNames`.

## LOCK-3
Ids are harvested **only** from the post-mask `changes`, and only for person fields in the per-sheet allow-set. A denied person field's values are dropped upstream, so its members never reach the resolver — leaking a display **name** would be strictly worse than leaking the id.

### Mutation matrix (measured — I state what each golden is load-bearing *for*, not more)
The leak is guarded **three** times: (i) `involvedFieldsBySheet` accumulates post-mask; (ii) the name loop re-checks `allowed.has`; (iii) the harvest reads post-mask `changes`.

> **CORRECTED after adversarial review — I had UNDERSOLD G3.** I tested only one flavor of breaking the harvest: **(iii-a)** read this batch's raw rows, which *also* loses the hydrated before-image, so G1/G2 red alongside G3. The reviewer ran **(iii-b)** — harvest raw snapshots **and** the raw *unmasked* hydrated prev-snapshot, i.e. keep the before-image working. **That is the refactor someone would actually write.**

| breaks | G1 | G2 | G3 | leak? |
|---|---|---|---|---|
| none (as-is) | GREEN | GREEN | GREEN | – |
| any ONE | — | — | GREEN | **never** |
| any TWO | — | — | GREEN | **never** |
| i + ii + **iii-a** | RED | RED | RED | **LEAK** |
| i + ii + **iii-b** | **GREEN** | **GREEN** | **RED** | **LEAK** |

**Upheld:** the leak needs **all three** broken — no single or double break reds G3.
**Corrected:** under **(iii-b)** — the realistic refactor — **G1/G2 stay GREEN and G3 is the SOLE detector.** So G3 is *not* merely a redundant last line; calling it "triply-redundant" understated it. (Mutation-red proves load-bearing for a layer; it is not by itself a reachability claim.)

**NIT-2:** guards (i) and (ii) are the *same predicate twice* (defense-in-depth), not two independent properties. The genuinely independent guard is (iii).

FE: ignoring `personNames` reds exactly the 2 tests that rely on it.

## Wiring
The real-DB golden is wired with **both** points (`vitest.config` exclude **+** `plugin-tests.yml` whitelist) — verified the no-DB lane reports **"No test files found"**, not a skip-green.

## Verification
backend `tsc` 0 errors · web type-check clean · **26/26** realdb (my golden + LOCK-3 neighbors: all-tables-B, field-mask, before-hydration) · FE spec **21/21** in the **required** gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Adversarial review: **APPROVE** (0 P1, no PR-side security defect)
Fixes pushed:
- **Accuracy:** corrected the G3 claim above (I undersold it).
- **P3-1:** `resolvePersonDirectoryEntries` had a bare `catch {}` swallowing *every* error (the sibling `buildPersonSummaries` rethrows non-`42P01`) — a transient DB error would silently render every person as a raw userId. **Narrowed to `42P01`.**
- **P3-4:** added **G4**, a *current-reality tripwire* for a **pre-existing platform gap** the review surfaced: layer-2 `property.hidden` is a **no-op on native person fields**. Such a field is one the actor **can** read, so it is *outside* this feature's precondition — this PR neither causes it nor relies on it, and its **marginal disclosure is zero** (the raw ids are already on the same payload pre-PR). Pinned so the gap is visible; deliberately **not** a failing test, which would make an out-of-scope permission-layer fix a merge gate.

Verified: backend tsc 0 · golden 5/5 · 18/18 with LOCK-3 neighbors · 5196/5196 unit · FE 21/21.
