### PR TITLE
docs(automation): retry/test-run/redelivery design refresh — 3-semantic split + delivered ledger + decision menu (PROPOSED)

### DIFF
--- a/docs/development/approval-automation-retry-and-sample-testrun-design-lock-20260709.md
+++ b/docs/development/approval-automation-retry-and-sample-testrun-design-lock-20260709.md
@@ -155,12 +155,19 @@ not-yet-applied tail:
   outcome `already_applied` (distinct from `success`/`skipped` so the run detail is honest).
 - **Never claim** CONTROL-FLOW / INERT actions (`condition_branch`, `parallel_branch`, `wait_for_callback`,
   `record_click`) — they are pure/repeatable and must re-run to re-derive routing.
-- **Documented residual gap (accept, do not over-engineer in v1):** the mark is written *after* a successful
-  dispatch, so a crash in the narrow window `dispatched-OK → before-mark` can let one action re-fire on a
-  later retry. This is the **at-most-once-favoured** trade (same philosophy as the T2-6 claim-then-fire
-  at-most-once note at `automation-service.ts:1554`). `confirmSideEffects` still gates the human, and the
-  window is bounded to a single action. Stronger cross-target idempotency (webhook `Idempotency-Key`, DingTalk
-  dedup) is OUT OF SCOPE v1 (§10).
+- **Documented residual gap** — **⚠ CORRECTED 2026-07-12 (see the Rev-2 refresh `…-design-refresh-20260712.md`
+  §4 C2/C4, which is the authoritative amendment):** the mark is written *after* a successful dispatch, so a
+  crash in the narrow window `dispatched-OK → before-mark` leaves the row unmarked and the next retry
+  **re-fires** that one action. That is **at-LEAST-once (a bounded single-action *duplicate* window)** — the
+  original text here wrongly called it "at-most-once-favoured" and compared it to the T2-6 *claim-then-fire*
+  idiom; claim-*before*-fire would be at-most-once and would risk a silent *skip* (the opposite failure), so
+  the comparison was also wrong. The **choice of durability trade is re-opened** (mark-after-success
+  at-least-once ∣ claim-before-fire at-most-once ∣ two-phase claim→commit) as Rev-2 **Q3** — do not treat
+  mark-after-success as settled. Also **⚠**: the `action_key = reuse computeActionFingerprint` note above is
+  insufficient — `computeActionFingerprint` hashes only the *sequence of action types* (no config, no
+  per-action position, no branch/parallel `step_key`); Rev-2 **§4 C4** replaces it with a normalized
+  structural step path + canonical config hash. `confirmSideEffects` still gates the human; stronger
+  cross-target idempotency (webhook `Idempotency-Key`, DingTalk dedup) stays OUT OF SCOPE v1 (§10).
 
 **L4.3 `confirmSideEffects` (keep).** The route keeps requiring `confirmSideEffects === true` (else `400
 CONFIRM_SIDE_EFFECTS_REQUIRED`). The confirm UX MUST state that retry re-fires only the **not-yet-applied**

--- a/docs/development/approval-automation-retry-design-refresh-20260712.md
+++ b/docs/development/approval-automation-retry-design-refresh-20260712.md
@@ -129,6 +129,7 @@ Q7 are worded to that boundary.
   (risks a silent skip); **(iii)** two-phase claim→commit + reconciliation (closest to exactly-once, most
   code). **OPEN — owner decides.** Rev-2 leans **(i)** with `confirmSideEffects` as the human gate, but flags
   that for irreversible egress (email/DingTalk) some owners prefer (ii).
+  > Q3 席位: 本节写语义/重投递权衡已由 `approval-automation-retry-action-classification-designlock-20260712.md` (#4196) 的按 action 类型分类方案取代 (PROPOSED)。
 - **Q4 — `action_key` re-fire-on-reorder (re-framed by C4).** With the corrected structural key, a reordered
   action (new step path) counts as not-applied and re-fires. **OPEN — confirm this is desired**, or pin
   identity to a stable per-action id instead of position.

--- a/docs/development/approval-automation-retry-design-refresh-20260712.md
+++ b/docs/development/approval-automation-retry-design-refresh-20260712.md
@@ -1,36 +1,39 @@
-# Automation retry / test-run / notification-redelivery — design refresh (2026-07-12)
+# Automation retry / test-run / notification-redelivery — design refresh (2026-07-12, Rev 2)
 
-**Status: PROPOSED (doc-only; no runtime).** This refreshes the open-questions + delivered-ledger of the
-2026-07-09 lock (`approval-automation-retry-and-sample-testrun-design-lock-20260709.md`, PR #4032) against
-current `origin/main` (`592be07ec`). The 07-09 lock's **LOCKED contract sections (§4 retry, §5 test-run, §6
-permission, §11 acceptance gates G1–G10)** remain the technical contract; this doc **does not re-open or
-re-lock them** — it (a) disambiguates three semantics that share verbs, (b) ledgers what has since shipped
-so nothing is rebuilt, and (c) re-casts the open questions as an owner-decision menu grounded in shipped code.
+**Status: PROPOSED (doc-only; no runtime).** Refresh of the 2026-07-09 lock
+(`approval-automation-retry-and-sample-testrun-design-lock-20260709.md`, PR #4032) against `origin/main`
+`592be07ec`.
 
+> **AMENDMENT / SUPERSEDING AUTHORITY.** This document is an **amendment** to the 07-09 lock, not a parallel
+> note. Where the two conflict, **this Rev-2 refresh is authoritative** for: the three-semantic split (§1),
+> the delivered ledger (§2), the idempotency-identity + write-semantics + retention corrections (§4 C1–C3),
+> the `action_key` definition (§4 C4), the retry-vs-resume boundary (§4 C5), and the open-question menu (§5).
+> The 07-09 lock's §4.2 "at-most-once" wording is **factually wrong and is corrected both here (§4 C2) and in
+> the 07-09 lock itself** (this PR edits that file too). The 07-09 §4.1/§4.3/§4.4/§4.5/§5/§6/§11 remain in
+> force except where §4 below explicitly overrides them.
+>
 > **Scope guard (owner-set, MS-AUTOMATION-RETRY-DESIGN-REFRESH):** docs/design-lock only; stays PROPOSED; no
-> runtime; does **not** touch the in-flight approval P1 (#4158); no permission expansion. Implementation is a
-> separately-authorized later slice per owner ratify.
+> runtime; does **not** touch the in-flight approval P1 (#4158); no permission expansion; implementation is a
+> separately-authorized later slice.
 
 ---
 
 ## 1. Three semantics that share verbs — DO NOT conflate
 
-The words "retry" / "re-send" / "test" appear across three **different** subsystems with **different**
-correctness rules. Conflating them is the failure mode this refresh exists to prevent (see the standing
-principle: *retry is graded by business semantic, not by the verb* — a network error ≠ "did not execute", and
-a side-effecting send is marked `outcome_unknown`, never blindly re-fired).
+"retry" / "resume" / "re-send" / "test" span **four** distinct behaviours across two subsystems. Conflating
+them is the failure mode this refresh prevents (standing principle: *retry is graded by business semantic, not
+by verb*; an ambiguous side-effecting send is `outcome_unknown`, never blindly re-fired).
 
-| # | Semantic | Subsystem / owner line | What it re-does | Idempotency rule | Status |
+| # | Behaviour | Subsystem / path | Re-does | Idempotency identity | Status |
 |---|---|---|---|---|---|
-| **S1** | **Automation retry / resume** (B3-10) | multitable automation (`automation-service.ts` `retryExecution` / `resume`) | Re-enters `executeRule` for a **failed/suspended rule execution** | **Per-action applied-ledger** (proposed `meta_automation_action_applied`): re-fire ONLY not-yet-applied actions | **DESIGN PROPOSED — unbuilt** (ledger table absent on main) |
-| **S2** | **Sample-record test-run** (B3-12) | same automation path, `testRun` under a side-effect **policy** | Runs a rule against a real `recordId` to validate it pre-enable | `simulate` (default) = ZERO side-effects; `real_fire` = reuse S1's ledger + confirm + capability | **PARTIAL** — G8 permission gate shipped (#4107); `simulate/real_fire` policy unbuilt |
-| **S3** | **DingTalk notification redelivery / test-send** | attendance/DingTalk delivery (`AttendanceNotificationRedelivery.ts`, `admin-directory` test-send) | Re-delivers a **failed/unknown notification**, or sends a one-off **test** notification | `redelivery_safe` column gate + `outcome_unknown` (never auto-resend an ambiguous send) | **SHIPPED** — #4085 + #4102 (**separate line**; out of this lock's build scope) |
+| **S1** | **Automation retry** (B3-10) | `automation-service.ts` `retryExecution` → re-enters `executeRule` | Re-runs a **failed/skipped** execution from step 0 | `(root_execution_id, action_key)` applied-ledger; root = the **lineage root** (stable across retries of one original) | **DESIGN PROPOSED — unbuilt** |
+| **S1′** | **Automation resume** (A6-2/A6-3-3, EXISTING) | `resumeExecution` → token claim → `continueExecution`/`continueBranchExecution` | Runs **only the remaining tail** of a suspended execution | single-use resume token + fingerprint drift guard (already shipped) | **SHIPPED; NOT in B3-10 scope — G10 must protect it from regression** |
+| **S2** | **Sample-record test-run** (B3-12) | same `executeRule` path via `testRun` under a side-effect **policy** | Runs a rule against a real `recordId` to validate pre-enable | `simulate` = zero business side-effects; `real_fire` = needs a **caller-supplied stable idempotency id** (§4 C1) — testRun does NOT get a lineage root | **PARTIAL** — G8 gate shipped (#4107); `simulate/real_fire` unbuilt |
+| **S3** | **Attendance notification redelivery / test-send** | notification-delivery subsystem (`AttendanceNotificationRedelivery.ts`, `admin-directory` test-send) — **NOT the automation path** | Redelivers **one** failed outbox row / sends one test notification | `redelivery_safe=true` + DingTalk-row gate; `outcome_unknown` is **rejected** | **SHIPPED** (#4085/#4102); narrow, single-row, operator-route |
 
-**The refresh's core assertion:** S1 and S2 share ONE backend path (`executeRule`) and ONE idempotency
-substrate (the applied-ledger) and belong to THIS lock. **S3 is a different subsystem** (notification
-delivery, not rule execution) with its own already-shipped mechanism; this lock **cross-references** S3 so
-future work does not re-implement redelivery inside the automation path, and does not fold S3's `outcome_unknown`
-semantics into S1/S2's applied-ledger.
+**Corrections vs Rev 1:** S1 is **retry only** — resume (S1′) is a *different, already-shipped* mechanism
+(tail-continuation, not whole re-run) and is explicitly **out of B3-10's build**; it appears here only so G10
+regression-guards it. S3 is **not** a general redelivery entry (see §4 C6).
 
 ---
 
@@ -38,79 +41,123 @@ semantics into S1/S2's applied-ledger.
 
 | PR | main sha | Semantic | What shipped | Effect on the 07-09 lock |
 |---|---|---|---|---|
-| **#4107** | `e129a25c4` | **S2** | `POST /sheets/:id/automations/:ruleId/test` now `403`s a caller lacking `canManageAutomation` (`automation.ts:262`); route still real-fires (no simulate policy yet) | **G8 SATISFIED** (the §0.1 "test route has no backend gate" gap is closed). The FE `confirm()` is no longer the security boundary. |
-| **#4102** | `7839b73a8` | **S3** | Operator-initiated **safe redelivery** service (`AttendanceNotificationRedelivery.ts`, +`redelivery_safe` column, task_id trace index, admin route) | Delivers S3 redelivery **outside** the automation path. Nothing in §4/§5 to rebuild. |
-| **#4085** | `434ba8d58` | **S3** | Work-notification **test-send** returns a **distinct `outcome_unknown`** response (not success/failure) | Establishes S3's "ambiguous send ⇒ outcome_unknown, do not auto-resend" rule — the semantic S1's ledger must NOT copy (S1 tracks *applied*, S3 tracks *delivery outcome*). |
-
-**Not yet built (per semantic):**
-- **S1 retry idempotency** — `meta_automation_action_applied` table does not exist on main; `retryExecution`
-  (`automation-service.ts:2179`) still re-enters `executeRule` and re-fires **all** actions (whole-rerun).
-  G1–G4, G9, G10 unmet. This is the largest remaining slice.
-- **S2 simulate/real_fire policy** — `testRun` (`automation.ts:285`) still unconditionally real-fires; no
-  `simulate` (dry-run) mode, no `real_fire` opt-in. G5, G6, G7, G9 unmet. G8 (gate) is the only S2 gate met.
+| **#4107** | `e129a25c4` | S2 | `/sheets/:id/automations/:ruleId/test` `403`s a caller lacking `canManageAutomation` (`automation.ts:262`); route still real-fires | **G8 SATISFIED**; FE `confirm()` no longer the boundary |
+| **#4102** | `7839b73a8` | S3 | Operator route redelivering **one** `attendance_notification_deliveries` row that is DingTalk + `status='failed'` + `redelivery_safe=true`; `outcome_unknown`/other channels **rejected** | S3 lives **outside** automation; nothing in §4/§5 to rebuild |
+| **#4085** | `434ba8d58` | S3 | Work-notification **test-send** returns a distinct `outcome_unknown` (not success/failure) | Establishes "ambiguous send ⇒ `outcome_unknown`, never auto-resend" — a **delivery-outcome** marker, NOT the S1 *applied* marker |
 
 ---
 
 ## 3. Current-code baseline (grounded on `592be07ec`)
 
-- **Retry route** `POST /automation-executions/:id/retry` → `requireAdminRole()` (`automation.ts:422`).
-- **Resume route** `POST /automation/resume` → `requireAdminRole()` (`automation.ts:476`).
-- **Test-run route** `POST /sheets/:id/automations/:ruleId/test` → `canManageAutomation` per-sheet capability
-  (`automation.ts:262`, shipped #4107).
-- ⇒ **Asymmetry now REAL on main:** retry/resume = platform-admin; test-run = per-sheet `canManageAutomation`.
-  This is the live fact Q1 must decide against (07-09 lock asked it hypothetically; it is now concrete).
-- `computeActionFingerprint` exists (`automation-suspension-service.ts`) and is used by resume — the primitive
-  the proposed applied-ledger `action_key` would reuse — but **no applied-ledger consumer exists**.
+- Retry `POST /automation-executions/:id/retry` → `requireAdminRole()` (`automation.ts:422`); resume
+  `POST /automation/resume` → `requireAdminRole()` (`:476`); test-run `POST …/test` → `canManageAutomation`
+  (`:262`, #4107). **Asymmetry now REAL on main** (retry/resume admin vs test-run canManageAutomation).
+- `retryExecution` (`automation-service.ts:2179`) gates ONLY on `status ∈ {failed, skipped}` — **no age cap**
+  (this is the C3 gap). Its `rootExecutionId = lineageIds.at(-1) ?? original.id` (`:2199`) is stable across
+  retries of one original.
+- `testRun` (`:2962`) `return this.executeRule(...)` with **no** `rootExecutionId` argument ⇒ each call mints a
+  fresh execution ⇒ **no stable idempotency root** (this is the C1 gap). `executeRule` **persists an execution
+  row/log** ⇒ a "simulate" run is NOT write-free (this is the Q6 correction).
+- `computeActionFingerprint` (`automation-suspension-service.ts:60`) = `sha256(actions.map(a => a.type)
+  .join('|'))` — **types-only**: no config, no position, no branch/parallel step path (this is the C4 gap).
+- `meta_automation_action_applied` table: **absent** — retry whole-reruns, re-firing already-succeeded actions.
 
 ---
 
-## 4. Owner-decision menu — Q1–Q6 re-cast against shipped code
+## 4. BLOCKING design corrections (must land before any S1/S2 implementation)
 
-Each item: the 07-09 question, what shipped since that changes it, and a grounded recommendation. **All remain
-owner decisions; nothing here is auto-locked.**
+These are the review-blockers; each is a contract fix, not just wording.
 
-- **Q1 — retry permission gate.** *07-09:* keep retry `requireAdminRole()` or unify to `canManageAutomation`?
-  *Now:* #4107 made **test-run** `canManageAutomation`, so retry (admin) and test-run (canManage) are
-  **asymmetric on main today**. Decision is now "reconcile the asymmetry": **(a)** keep retry admin-only
-  (retry replays real production side-effects on real data → stricter is defensible), **(b)** unify retry
-  down to `canManageAutomation` to match test-run. **Rec: (a) keep admin** — retry re-fires production
-  actions on the live record; test-run is author-scoped validation. If unified later, it is its own opt-in.
-- **Q2 — test-run dry-run-by-default.** *Now unchanged & more urgent:* test-run **still real-fires** on main
-  (#4107 gated *who* can call it, not *whether it simulates*). Recommend confirming **`simulate` default**;
-  `real_fire` = explicit opt-in carrying confirm + capability + S1 ledger. **Rec: dry-run default.**
-- **Q3 — applied-ledger crash-window trade** (mark-after-success). Unchanged by deliveries. **Rec: ACCEPT
-  at-most-once** (a crash between dispatch and mark re-fires that one action on the next retry — same
-  philosophy as the T2-6 claim-then-fire ledger).
-- **Q4 — `action_key` = position + type + config-hash; a reorder ⇒ re-fire.** Unchanged. Confirm desired
-  semantics (an action moved to a new position counts as "not applied" and re-fires). **Rec: confirm as-is.**
-- **Q5 — applied-ledger retention window** (propose 7 days, matching T2-6). Unchanged; only relevant once S1
-  is built. **Rec: 7 days, revisit if human retries lag days.**
-- **Q6 — `simulate` read-gate** (may simulate against a record the caller can read but not write). Unchanged.
-  **Rec: yes** — nothing is written, so a read capability suffices to preview a would-be payload.
+**C1 (P1) — `real_fire` test-run has no stable idempotency identity.** Retry inherits a lineage
+`root_execution_id`; **test-run does not** (fresh execution per call). So the 07-09 claim that real_fire "reuses
+the `(root_execution_id, action_key)` ledger" is unsatisfiable — two real-fires get different roots and
+G6/G10 dedup cannot hold. **Fix:** `real_fire` MUST carry a **caller-supplied stable
+`testRunOperationId` (Idempotency-Key)** that becomes the ledger `root_execution_id` for that test-run;
+repeat/concurrent real-fires with the same key dedupe via the applied-ledger, a new key is a new run. **Tests
+(RED-first):** two *independent HTTP requests* with the same key ⇒ second is `already_applied`; two concurrent
+requests with the same key ⇒ exactly one dispatch; different keys ⇒ independent.
 
-**New (raised by the deliveries) — Q7:** should S3 (notification redelivery / test-send) be **explicitly
-fenced off** from S1/S2 in the lock's OUT-OF-SCOPE, so a future implementer does not add a "resend notification"
-button that routes through `executeRule` (double-dispatch) instead of the shipped `AttendanceNotificationRedelivery`
-path? **Rec: yes, add to §10 OUT-OF-SCOPE** — S3 is delivered separately and must not be re-plumbed through automation.
+**C2 (P1) — write-semantics is at-LEAST-once, not at-most-once (corrected in BOTH docs).** `mark-after-success`
+(dispatch, then `INSERT … ON CONFLICT DO NOTHING`) means a crash in the `dispatched-OK → before-mark` window
+leaves the row unmarked ⇒ the next retry **re-fires** that one action ⇒ **at-least-once / duplicate window**.
+The 07-09 §4.2 called this "at-most-once-favoured" and compared it to the T2-6 *claim-then-fire* idiom — both
+wrong (claim-*before*-fire would be at-most-once, and would risk a *skip*, the opposite failure). **Fix:** the
+07-09 §4.2 is edited in this PR to state at-least-once; and the *choice of trade* is re-opened as **Q3** below
+(mark-after-success at-least-once, vs claim-before-fire at-most-once, vs two-phase claim→commit reconciliation
+for closer-to-exactly-once).
+
+**C3 (P1) — retry eligibility not bound to ledger retention.** With no age cap on `retryExecution` and a
+7-day ledger sweep, a >7-day-old failed execution retried after its ledger rows are gone re-fires **every**
+already-succeeded action. **Fix — pick ONE (owner decision, Q5):** (a) cap retry eligibility to **≤ ledger
+retention** (reject older with a distinct code); or (b) **retain the ledger until the execution is no longer
+retryable** (retention keyed to eligibility, not a fixed 7 days); or (c) **fail-closed**: if the ledger flag
+is ON and no ledger rows exist for an eligible-but-aged root, refuse the retry rather than silently
+whole-rerun. Rev-2 recommends **(a)** (simplest, bounded) with **(c)** as the safety net.
+
+**C4 (P2) — `action_key` needs a real structural identity.** `computeActionFingerprint` hashes only the
+*sequence of action types* — it cannot distinguish two same-type actions, config edits, or nested
+branch/parallel children. **Fix:** `action_key` = a **normalized full structural step path** (top-level index
+**and** branch/parallel child `step_key`, matching the A6-3-3 branch cursor's `step_key`, not a bare
+`positionIndex`) **+ a stable canonical hash of that action's `config`** (canonicalised key order). Add a
+**nested-action conflict test**: two distinct branch children that would collide under a naive top-level index
+must get distinct `action_key`s.
+
+**C5 (P2) — retry and resume are different mechanisms; B3-10 = retry only.** `resumeExecution` claims a
+single-use token then runs the **tail** via `continueExecution`/`continueBranchExecution`; `retryExecution`
+re-enters `executeRule` from step 0. B3-10's applied-ledger applies to **retry**; resume keeps its existing
+token/fingerprint guards **unchanged**, and **G10 must assert resume is not regressed** by the ledger work.
+Resume permission is explicitly **not** adjusted by this slice (owner Q1 ruling).
+
+**C6 (P2) — S3 narrowed to its delivered boundary.** #4102's `AttendanceNotificationRedelivery` is
+**operator-initiated redelivery of a single `attendance_notification_deliveries` row** that is a DingTalk row
+with `status='failed'` **and** `redelivery_safe=true`; it **rejects `outcome_unknown`** (a `markOutcomeUnknown`
+row keeps `redelivery_safe=false`), other channels, and non-failed rows; it flips exactly that one row
+`failed→pending`. It is **NOT** a general redelivery entry for automation or DingTalk messages. §1/§2 rows and
+Q7 are worded to that boundary.
 
 ---
 
-## 5. What a future implementation slice would still cover (per semantic, when authorized)
+## 5. Owner-decision menu (rulings applied; open items re-framed per §4)
 
-- **S1 (largest):** build `meta_automation_action_applied` + wire `retryExecution` to claim-then-skip per
-  action (G1–G4, G9, G10), behind `AUTOMATION_RETRY_IDEMPOTENT_LEDGER` (default OFF). RED tests #1–#6 of the
-  07-09 lock §12.
-- **S2:** add the `simulate|real_fire` policy to `testRun` (G5–G7, G9); `simulate` = spy-proven zero
-  dispatch; `real_fire` reuses S1's ledger + confirm + the already-shipped G8 capability gate. RED tests
-  #7–#9 of §12.
-- **S3:** nothing — shipped (#4085/#4102). Only a doc cross-reference so it is not rebuilt.
-
-Each slice is separately owner-authorized. This refresh authorizes **no** implementation.
+- **Q1 — retry permission.** **RULED: (a) retry stays `requireAdminRole()`** (retry replays production
+  side-effects on the live record; test-run is author-scoped validation). Resume permission **not** adjusted
+  here. The retry(admin)/test-run(canManage) asymmetry is thus **intentional**, documented.
+- **Q2 — test-run dry-run default.** **RULED: agreed — `simulate` is the default**; `real_fire` is an explicit
+  opt-in carrying confirm + capability + the C1 idempotency key + the applied-ledger.
+- **Q3 — write-semantics trade (re-framed by C2).** Choose the durability trade: **(i)** mark-after-success =
+  at-least-once (bounded single-action duplicate window; simplest); **(ii)** claim-before-fire = at-most-once
+  (risks a silent skip); **(iii)** two-phase claim→commit + reconciliation (closest to exactly-once, most
+  code). **OPEN — owner decides.** Rev-2 leans **(i)** with `confirmSideEffects` as the human gate, but flags
+  that for irreversible egress (email/DingTalk) some owners prefer (ii).
+- **Q4 — `action_key` re-fire-on-reorder (re-framed by C4).** With the corrected structural key, a reordered
+  action (new step path) counts as not-applied and re-fires. **OPEN — confirm this is desired**, or pin
+  identity to a stable per-action id instead of position.
+- **Q5 — ledger retention (bound to C3).** Not an independent number: the retention window is now **coupled to
+  retry eligibility** per C3. **OPEN — owner picks C3 (a)/(b)/(c)**, which sets retention.
+- **Q6 — simulate gate (corrected).** **RULED (corrected framing): `simulate` requires `canManageAutomation` +
+  record-READABLE (not writable)**, and it MAY write **values-free audit / execution-log** rows, but MUST
+  perform **zero business writes, egress, notifications, or approvals** (spy-proven). "Nothing is written" was
+  inaccurate — the execution-log write is expected and permitted.
+- **Q7 — fence S3 out of the automation path.** **RULED: agreed, isolate** — a future "resend notification"
+  affordance MUST route through the shipped, **narrow** `AttendanceNotificationRedelivery` (single failed
+  DingTalk `redelivery_safe` row), **not** through `executeRule`, and S3 must **not** be described as a general
+  redelivery path.
 
 ---
 
-## 6. Cross-references
-- 07-09 LOCKED contract: `approval-automation-retry-and-sample-testrun-design-lock-20260709.md` (#4032).
-- S3 delivered line: #4085 `434ba8d58`, #4102 `7839b73a8` (+ the send-trigger audit doctrine).
-- G8 delivery: #4107 `e129a25c4`.
+## 6. What a future (separately-authorized) implementation slice covers
+- **S1 retry:** `meta_automation_action_applied` + claim/skip wiring with the **C4** structural key, **C2**
+  chosen durability trade, **C3** retention/eligibility coupling; behind `AUTOMATION_RETRY_IDEMPOTENT_LEDGER`
+  (default OFF). RED tests: 07-09 §12 #1–#6 **plus** a resume-not-regressed test (C5) and a nested-action
+  conflict test (C4).
+- **S2 test-run:** `simulate|real_fire` policy on `testRun`; `simulate` = spy-proven zero business dispatch
+  (Q6 framing); `real_fire` = C1 idempotency key + S1 ledger + shipped G8 gate. RED tests: 07-09 §12 #7–#9
+  **plus** the C1 two-request / concurrent-request tests.
+- **S3:** nothing — shipped; doc cross-reference only (C6 boundary).
+
+Each slice separately owner-authorized. This refresh authorizes **no** implementation.
+
+## 7. Cross-references
+- 07-09 LOCKED contract (amended here at §4.2): `approval-automation-retry-and-sample-testrun-design-lock-20260709.md` (#4032).
+- S2 G8 delivery: #4107 `e129a25c4`. S3 deliveries: #4085 `434ba8d58`, #4102 `7839b73a8`.
 - Standing principle: retry graded by business semantic, not verb; ambiguous send ⇒ `outcome_unknown`.

--- a/docs/development/approval-automation-retry-design-refresh-20260712.md
+++ b/docs/development/approval-automation-retry-design-refresh-20260712.md
@@ -1,0 +1,116 @@
+# Automation retry / test-run / notification-redelivery — design refresh (2026-07-12)
+
+**Status: PROPOSED (doc-only; no runtime).** This refreshes the open-questions + delivered-ledger of the
+2026-07-09 lock (`approval-automation-retry-and-sample-testrun-design-lock-20260709.md`, PR #4032) against
+current `origin/main` (`592be07ec`). The 07-09 lock's **LOCKED contract sections (§4 retry, §5 test-run, §6
+permission, §11 acceptance gates G1–G10)** remain the technical contract; this doc **does not re-open or
+re-lock them** — it (a) disambiguates three semantics that share verbs, (b) ledgers what has since shipped
+so nothing is rebuilt, and (c) re-casts the open questions as an owner-decision menu grounded in shipped code.
+
+> **Scope guard (owner-set, MS-AUTOMATION-RETRY-DESIGN-REFRESH):** docs/design-lock only; stays PROPOSED; no
+> runtime; does **not** touch the in-flight approval P1 (#4158); no permission expansion. Implementation is a
+> separately-authorized later slice per owner ratify.
+
+---
+
+## 1. Three semantics that share verbs — DO NOT conflate
+
+The words "retry" / "re-send" / "test" appear across three **different** subsystems with **different**
+correctness rules. Conflating them is the failure mode this refresh exists to prevent (see the standing
+principle: *retry is graded by business semantic, not by the verb* — a network error ≠ "did not execute", and
+a side-effecting send is marked `outcome_unknown`, never blindly re-fired).
+
+| # | Semantic | Subsystem / owner line | What it re-does | Idempotency rule | Status |
+|---|---|---|---|---|---|
+| **S1** | **Automation retry / resume** (B3-10) | multitable automation (`automation-service.ts` `retryExecution` / `resume`) | Re-enters `executeRule` for a **failed/suspended rule execution** | **Per-action applied-ledger** (proposed `meta_automation_action_applied`): re-fire ONLY not-yet-applied actions | **DESIGN PROPOSED — unbuilt** (ledger table absent on main) |
+| **S2** | **Sample-record test-run** (B3-12) | same automation path, `testRun` under a side-effect **policy** | Runs a rule against a real `recordId` to validate it pre-enable | `simulate` (default) = ZERO side-effects; `real_fire` = reuse S1's ledger + confirm + capability | **PARTIAL** — G8 permission gate shipped (#4107); `simulate/real_fire` policy unbuilt |
+| **S3** | **DingTalk notification redelivery / test-send** | attendance/DingTalk delivery (`AttendanceNotificationRedelivery.ts`, `admin-directory` test-send) | Re-delivers a **failed/unknown notification**, or sends a one-off **test** notification | `redelivery_safe` column gate + `outcome_unknown` (never auto-resend an ambiguous send) | **SHIPPED** — #4085 + #4102 (**separate line**; out of this lock's build scope) |
+
+**The refresh's core assertion:** S1 and S2 share ONE backend path (`executeRule`) and ONE idempotency
+substrate (the applied-ledger) and belong to THIS lock. **S3 is a different subsystem** (notification
+delivery, not rule execution) with its own already-shipped mechanism; this lock **cross-references** S3 so
+future work does not re-implement redelivery inside the automation path, and does not fold S3's `outcome_unknown`
+semantics into S1/S2's applied-ledger.
+
+---
+
+## 2. Delivered ledger since the 07-09 lock (avoid rebuild)
+
+| PR | main sha | Semantic | What shipped | Effect on the 07-09 lock |
+|---|---|---|---|---|
+| **#4107** | `e129a25c4` | **S2** | `POST /sheets/:id/automations/:ruleId/test` now `403`s a caller lacking `canManageAutomation` (`automation.ts:262`); route still real-fires (no simulate policy yet) | **G8 SATISFIED** (the §0.1 "test route has no backend gate" gap is closed). The FE `confirm()` is no longer the security boundary. |
+| **#4102** | `7839b73a8` | **S3** | Operator-initiated **safe redelivery** service (`AttendanceNotificationRedelivery.ts`, +`redelivery_safe` column, task_id trace index, admin route) | Delivers S3 redelivery **outside** the automation path. Nothing in §4/§5 to rebuild. |
+| **#4085** | `434ba8d58` | **S3** | Work-notification **test-send** returns a **distinct `outcome_unknown`** response (not success/failure) | Establishes S3's "ambiguous send ⇒ outcome_unknown, do not auto-resend" rule — the semantic S1's ledger must NOT copy (S1 tracks *applied*, S3 tracks *delivery outcome*). |
+
+**Not yet built (per semantic):**
+- **S1 retry idempotency** — `meta_automation_action_applied` table does not exist on main; `retryExecution`
+  (`automation-service.ts:2179`) still re-enters `executeRule` and re-fires **all** actions (whole-rerun).
+  G1–G4, G9, G10 unmet. This is the largest remaining slice.
+- **S2 simulate/real_fire policy** — `testRun` (`automation.ts:285`) still unconditionally real-fires; no
+  `simulate` (dry-run) mode, no `real_fire` opt-in. G5, G6, G7, G9 unmet. G8 (gate) is the only S2 gate met.
+
+---
+
+## 3. Current-code baseline (grounded on `592be07ec`)
+
+- **Retry route** `POST /automation-executions/:id/retry` → `requireAdminRole()` (`automation.ts:422`).
+- **Resume route** `POST /automation/resume` → `requireAdminRole()` (`automation.ts:476`).
+- **Test-run route** `POST /sheets/:id/automations/:ruleId/test` → `canManageAutomation` per-sheet capability
+  (`automation.ts:262`, shipped #4107).
+- ⇒ **Asymmetry now REAL on main:** retry/resume = platform-admin; test-run = per-sheet `canManageAutomation`.
+  This is the live fact Q1 must decide against (07-09 lock asked it hypothetically; it is now concrete).
+- `computeActionFingerprint` exists (`automation-suspension-service.ts`) and is used by resume — the primitive
+  the proposed applied-ledger `action_key` would reuse — but **no applied-ledger consumer exists**.
+
+---
+
+## 4. Owner-decision menu — Q1–Q6 re-cast against shipped code
+
+Each item: the 07-09 question, what shipped since that changes it, and a grounded recommendation. **All remain
+owner decisions; nothing here is auto-locked.**
+
+- **Q1 — retry permission gate.** *07-09:* keep retry `requireAdminRole()` or unify to `canManageAutomation`?
+  *Now:* #4107 made **test-run** `canManageAutomation`, so retry (admin) and test-run (canManage) are
+  **asymmetric on main today**. Decision is now "reconcile the asymmetry": **(a)** keep retry admin-only
+  (retry replays real production side-effects on real data → stricter is defensible), **(b)** unify retry
+  down to `canManageAutomation` to match test-run. **Rec: (a) keep admin** — retry re-fires production
+  actions on the live record; test-run is author-scoped validation. If unified later, it is its own opt-in.
+- **Q2 — test-run dry-run-by-default.** *Now unchanged & more urgent:* test-run **still real-fires** on main
+  (#4107 gated *who* can call it, not *whether it simulates*). Recommend confirming **`simulate` default**;
+  `real_fire` = explicit opt-in carrying confirm + capability + S1 ledger. **Rec: dry-run default.**
+- **Q3 — applied-ledger crash-window trade** (mark-after-success). Unchanged by deliveries. **Rec: ACCEPT
+  at-most-once** (a crash between dispatch and mark re-fires that one action on the next retry — same
+  philosophy as the T2-6 claim-then-fire ledger).
+- **Q4 — `action_key` = position + type + config-hash; a reorder ⇒ re-fire.** Unchanged. Confirm desired
+  semantics (an action moved to a new position counts as "not applied" and re-fires). **Rec: confirm as-is.**
+- **Q5 — applied-ledger retention window** (propose 7 days, matching T2-6). Unchanged; only relevant once S1
+  is built. **Rec: 7 days, revisit if human retries lag days.**
+- **Q6 — `simulate` read-gate** (may simulate against a record the caller can read but not write). Unchanged.
+  **Rec: yes** — nothing is written, so a read capability suffices to preview a would-be payload.
+
+**New (raised by the deliveries) — Q7:** should S3 (notification redelivery / test-send) be **explicitly
+fenced off** from S1/S2 in the lock's OUT-OF-SCOPE, so a future implementer does not add a "resend notification"
+button that routes through `executeRule` (double-dispatch) instead of the shipped `AttendanceNotificationRedelivery`
+path? **Rec: yes, add to §10 OUT-OF-SCOPE** — S3 is delivered separately and must not be re-plumbed through automation.
+
+---
+
+## 5. What a future implementation slice would still cover (per semantic, when authorized)
+
+- **S1 (largest):** build `meta_automation_action_applied` + wire `retryExecution` to claim-then-skip per
+  action (G1–G4, G9, G10), behind `AUTOMATION_RETRY_IDEMPOTENT_LEDGER` (default OFF). RED tests #1–#6 of the
+  07-09 lock §12.
+- **S2:** add the `simulate|real_fire` policy to `testRun` (G5–G7, G9); `simulate` = spy-proven zero
+  dispatch; `real_fire` reuses S1's ledger + confirm + the already-shipped G8 capability gate. RED tests
+  #7–#9 of §12.
+- **S3:** nothing — shipped (#4085/#4102). Only a doc cross-reference so it is not rebuilt.
+
+Each slice is separately owner-authorized. This refresh authorizes **no** implementation.
+
+---
+
+## 6. Cross-references
+- 07-09 LOCKED contract: `approval-automation-retry-and-sample-testrun-design-lock-20260709.md` (#4032).
+- S3 delivered line: #4085 `434ba8d58`, #4102 `7839b73a8` (+ the send-trigger audit doctrine).
+- G8 delivery: #4107 `e129a25c4`.
+- Standing principle: retry graded by business semantic, not verb; ambiguous send ⇒ `outcome_unknown`.


### PR DESCRIPTION
**Lane MS-AUTOMATION-RETRY-DESIGN-REFRESH**（owner-designated）。刷新 #4032 的 B3-10/B3-12 设计锁 @ fresh main `592be07ec`。**docs-only、PROPOSED、零 runtime、不碰 #4158、不扩权限。实现另行授权。**

## 三套语义辨析（核心）
共用「retry/re-send/test」动词但规则不同，防止混建：
- **S1 自动化 retry/resume**（B3-10）= 重进 executeRule；per-action applied-ledger 幂等 → **未建**（`meta_automation_action_applied` 主线不存在，retryExecution 仍整体重跑）。
- **S2 sample-record test-run**（B3-12）= 按 side-effect policy 跑真实 record → **G8 权限门已交付 #4107**（route 现 canManageAutomation 门），但 testRun 仍真发、simulate/real_fire policy **未建**。
- **S3 钉钉通知 redelivery/test-send** = 通知投递子系统，**已单独交付**（#4085 test-send outcome_unknown / #4102 operator safe redelivery + redelivery_safe 列）→ 本锁**交叉引用、不在自动化路径重建**。

## 交付账（避免重复建设）
#4107 `e129a25c4`(S2 G8) · #4102 `7839b73a8`(S3 redelivery) · #4085 `434ba8d58`(S3 test-send) —— 均如实登记 + 主线 sha + 对 07-09 锁的影响。

## Q1-Q6 决策菜单（基于当前代码重整）+ Q7
Q1 的 admin vs canManageAutomation 不对称**现已在主线成真**（retry/resume=admin `automation.ts:422/476`，test-run=canManageAutomation `:262`）→ 决策变「如何调和」。Q2 test-run 仍真发使 dry-run-default 更紧迫。Q3-Q6 逐条 grounded + 建议。新增 Q7=把 S3 明确 fence 出自动化路径（防有人加「重发通知」按钮走 executeRule 双投递）。

07-09 锁的 §4/§5/§6/§11 LOCKED 契约**不重开**；本刷新只更新交付账 + 语义辨析 + 决策菜单。已在 #4022 登记 lane。**请复审 + ratify，实现再单独授权。**