### PR TITLE
fix(multitable): treat layer-2 visibility keys as cross-cutting in both field-property sanitizers

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -263,6 +263,7 @@ jobs:
             tests/integration/multitable-history-events-realdb.test.ts \
             tests/integration/multitable-history-before-hydration-realdb.test.ts \
             tests/integration/multitable-history-alltables-fieldnames-realdb.test.ts \
+            tests/integration/multitable-layer2-hidden-person-button-realdb.test.ts \
             tests/integration/multitable-history-events-hasmore-realdb.test.ts \
             tests/integration/multitable-history-audit-grant-realdb.test.ts \
             tests/integration/multitable-history-audit-reveal-realdb.test.ts \

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -2559,6 +2559,19 @@ function saveConfig() {
   const property = currentDraftProperty(fieldType)
   if (!property && fieldConfigError.value) return
   if (!property) return
+  // Layer-2 visibility keys (`hidden` / `visible`) are CARRIED OPAQUELY — exactly like `actionConfig`
+  // above, and for exactly the same reason: this form does not edit them, but `update-field` REPLACES
+  // `property` wholesale, and several `currentDraftProperty` branches (person, button, …) rebuild it as a
+  // closed literal. Without this, an unrelated Save (rename a button, flip person single/multi, edit a
+  // validation rule) would silently drop a stored `hidden: true` and UN-HIDE the field for everyone.
+  //
+  // Safe by construction: the FE has no writer of these keys anywhere (grep — the only FE reference is the
+  // reader in utils/field-permissions.ts), so re-emitting them can never block an un-hide; whatever
+  // authored the hide is also what clears it. Mirrors the server-side cross-cutting carrier.
+  const carried = { ...property }
+  const storedProperty = (configTarget.value.property ?? {}) as Record<string, unknown>
+  if (storedProperty.hidden === true) carried.hidden = true
+  if (storedProperty.visible === false) carried.visible = false
   // Skip no-op saves for types that only expose validation + aiShortcut: if
   // the user touched neither surface there is nothing to persist, and
   // emitting an empty `property: {}` would otherwise clobber existing values
@@ -2569,7 +2582,7 @@ function saveConfig() {
     closeConfig()
     return
   }
-  emit('update-field', configTarget.value.id, { property })
+  emit('update-field', configTarget.value.id, { property: carried })
   closeConfig()
 }
 

--- a/apps/web/tests/multitable-field-manager.spec.ts
+++ b/apps/web/tests/multitable-field-manager.spec.ts
@@ -1093,3 +1093,78 @@ describe('MetaFieldManager — foreign-field picker (3c)', () => {
     app.unmount(); container.remove()
   })
 })
+
+// Layer-2 visibility keys are CARRIED OPAQUELY through a field-config Save.
+//
+// `update-field` REPLACES `property` wholesale, and `currentDraftProperty` rebuilds it as a closed literal
+// for several types (the person branch is literally `{ limitSingleRecord }`). So without an explicit carry,
+// any unrelated Save — flip person single/multi, rename a button, edit a validation rule — silently DROPPED
+// a stored `hidden: true` and UN-HID the field for everyone. This is the same hazard the component already
+// guards for `actionConfig` ("the form doesn't edit it, so re-emit it intact").
+//
+// The form has no hide/un-hide control anywhere (the FE has no writer of these keys at all — only the
+// reader in utils/field-permissions.ts), so re-emitting them cannot block an un-hide.
+describe('MetaFieldManager — layer-2 visibility keys survive a config Save', () => {
+  function saveConfigFor(field: Record<string, unknown>) {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true, sheetId: 'sheet_1', sheets: [], fields: [field], onUpdateField: updateSpy,
+        })
+      },
+    })
+    app.mount(container)
+    return { container, updateSpy, app }
+  }
+
+  async function openAndSave(container: HTMLElement) {
+    await nextTick()
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((b) => b.textContent?.includes('Save field settings'))
+      ?.click()
+    await nextTick()
+  }
+
+  it('a HIDDEN person field stays hidden after an unrelated config Save', async () => {
+    const { container, updateSpy, app } = saveConfigFor({
+      id: 'fld_p', name: 'People', type: 'person', property: { hidden: true, limitSingleRecord: true },
+    })
+    try {
+      await openAndSave(container)
+      expect(updateSpy).toHaveBeenCalled()
+      const [, payload] = updateSpy.mock.calls[updateSpy.mock.calls.length - 1]
+      // the hide SURVIVES the wholesale property replacement…
+      expect(payload.property.hidden).toBe(true)
+      // …alongside the type-specific key the form actually edits
+      expect(payload.property.limitSingleRecord).toBe(true)
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('`visible: false` (the other half of the predicate) survives too', async () => {
+    const { container, updateSpy, app } = saveConfigFor({
+      id: 'fld_p2', name: 'People', type: 'person', property: { visible: false },
+    })
+    try {
+      await openAndSave(container)
+      const [, payload] = updateSpy.mock.calls[updateSpy.mock.calls.length - 1]
+      expect(payload.property.visible).toBe(false)
+    } finally { app.unmount(); container.remove() }
+  })
+
+  it('NON-VACUOUS: a field with no visibility keys does not gain them', async () => {
+    const { container, updateSpy, app } = saveConfigFor({
+      id: 'fld_p3', name: 'People', type: 'person', property: { limitSingleRecord: false },
+    })
+    try {
+      await openAndSave(container)
+      const [, payload] = updateSpy.mock.calls[updateSpy.mock.calls.length - 1]
+      expect(payload.property.hidden).toBeUndefined()
+      expect(payload.property.visible).toBeUndefined()
+    } finally { app.unmount(); container.remove() }
+  })
+})

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -260,8 +260,12 @@ export function sanitizeFieldProperty(
  * branch's incidental `...obj` passthrough"). Fixing only the two guilty branches would leave the next
  * closed-allowlist branch (or new field type) free to reintroduce it; a branch only has to forget once.
  *
- * Only the HIDING signals are carried (`hidden: true` / `visible: false`); the permissive values are not
- * load-bearing for the predicate and preserving them would churn existing property shapes for no benefit.
+ * SCOPE, precisely (review P3): this helper only ever SYNTHESIZES the DENY values — it adds `hidden: true`
+ * / `visible: false` when the source carries them, and adds nothing otherwise. It does NOT strip anything:
+ * a passthrough branch that already spreads `...obj` still carries an existing `hidden: false` /
+ * `visible: true` through, exactly as before. Those permissive values are inert for the predicate, and
+ * deliberately NOT removed here — stripping them would churn existing wire shapes for no security benefit.
+ * So: deny values are guaranteed present; permissive values keep whatever shape the type already had.
  *
  * SINGLE DEFINITION — `univer-meta.ts`'s sibling sanitizer imports and applies this same function, so the
  * two cannot silently drift apart again.

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -233,10 +233,47 @@ export function sanitizeFieldProperty(
   // per-type normalization rather than relying on each branch's incidental
   // `...obj` passthrough (which would also let a *malformed* rule leak through).
   // See field-visibility-rule.ts.
-  return withFieldRequiredWhenRule(
-    withFieldVisibilityRule(sanitizeFieldPropertyByType(type, property), property),
+  //
+  // The layer-2 visibility keys (`hidden` / `visible`) belong to that SAME cross-cutting set and were
+  // simply never added to it — see withLayer2VisibilityKeys. That omission is the bug it fixes.
+  return withLayer2VisibilityKeys(
+    withFieldRequiredWhenRule(
+      withFieldVisibilityRule(sanitizeFieldPropertyByType(type, property), property),
+      property,
+    ),
     property,
   )
+}
+
+/**
+ * Layer-2 field visibility (`property.hidden === true` / `property.visible === false`) is CROSS-CUTTING:
+ * `isFieldPermissionHidden` (permission-derivation.ts) reads these two keys for EVERY field type.
+ *
+ * Most per-type branches spread the source (`...obj`, or link's `...cleanObj`) and so carried the keys
+ * through incidentally. Exactly TWO branches rebuild `property` from scratch as a closed allowlist and
+ * therefore DROPPED them — **`person` and `button`** (measured, not assumed: reverting this rule reds only
+ * the person and button rows of the type-by-type test). A custom `fieldTypeRegistry` codec can do the same.
+ * So whether a field could be hidden at all depended on which branch its type happened to fall into.
+ *
+ * This applies the rule ONCE, in the cross-cutting composition chain — exactly where `visibilityRule` and
+ * `requiredWhen` already live, and for exactly the same stated reason ("rather than relying on each
+ * branch's incidental `...obj` passthrough"). Fixing only the two guilty branches would leave the next
+ * closed-allowlist branch (or new field type) free to reintroduce it; a branch only has to forget once.
+ *
+ * Only the HIDING signals are carried (`hidden: true` / `visible: false`); the permissive values are not
+ * load-bearing for the predicate and preserving them would churn existing property shapes for no benefit.
+ *
+ * SINGLE DEFINITION — `univer-meta.ts`'s sibling sanitizer imports and applies this same function, so the
+ * two cannot silently drift apart again.
+ */
+export function withLayer2VisibilityKeys(
+  sanitized: Record<string, unknown>,
+  property: unknown,
+): Record<string, unknown> {
+  const source = normalizeJson(property)
+  if (source.hidden === true) sanitized.hidden = true
+  if (source.visible === false) sanitized.visible = false
+  return sanitized
 }
 
 function sanitizeFieldPropertyByType(

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2246,11 +2246,14 @@ function sanitizeFieldProperty(type: UniverMetaField['type'], property: unknown)
   // rule via `...obj` passthrough. Mirrors field-codecs.ts's sanitizeFieldProperty
   // (shared helpers).
   //
-  // The layer-2 visibility keys (`hidden` / `visible`) belong to that SAME cross-cutting set. This
-  // sanitizer has the same closed-allowlist branches as its field-codecs sibling — `person` and `button`
-  // rebuild `property` from scratch and so dropped them (the other branches spread `...obj` and kept them
-  // incidentally). It applies the SAME SHARED function — imported, never re-implemented: two independent
-  // copies of this rule is precisely how the inconsistency survived in the first place.
+  // The layer-2 visibility keys (`hidden` / `visible`) belong to that SAME cross-cutting set.
+  //
+  // In THIS sanitizer the closed-allowlist branch is `person` ONLY — there is no `button` branch here at
+  // all (button falls through to the passthrough default), so button was never dropped on this path. Its
+  // field-codecs sibling has BOTH person and button. The two sanitizers do not even agree on which types
+  // they special-case — which is exactly why the rule must live OUTSIDE the per-type switch and be SHARED.
+  // It applies the same imported function, never a second copy: two independent copies of this rule is
+  // precisely how the inconsistency survived in the first place.
   return withLayer2VisibilityKeys(
     withFieldRequiredWhenRule(
       withFieldVisibilityRule(sanitizeFieldPropertyByType(type, property), property),

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -177,7 +177,7 @@ import { MultitableFormulaEngine } from '../multitable/formula-engine'
 import { FormulaEngine } from '../formula/engine'
 import { validateRecord, getDefaultValidationRules } from '../multitable/field-validation-engine'
 import type { FieldValidationConfig } from '../multitable/field-validation'
-import { assertRichLongTextToggleAllowed, BATCH1_FIELD_TYPES, coerceBatch1Value, isPersonSingleRecord, isRichLongTextProperty, normalizeMultiSelectValue, richLongTextToPlainText, validateLongTextValue, validatePersonValue } from '../multitable/field-codecs'
+import { assertRichLongTextToggleAllowed, BATCH1_FIELD_TYPES, coerceBatch1Value, withLayer2VisibilityKeys, isPersonSingleRecord, isRichLongTextProperty, normalizeMultiSelectValue, richLongTextToPlainText, validateLongTextValue, validatePersonValue } from '../multitable/field-codecs'
 import { apiTokenWriteRateLimit, conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
 import { buildOapiAuditContext, oapiWriteAuditBoundary } from '../multitable/oapi-write-audit'
 import { apiTokenAuth, requireScope } from '../middleware/api-token-auth'
@@ -2245,8 +2245,17 @@ function sanitizeFieldProperty(type: UniverMetaField['type'], property: unknown)
   // sanitize + merge them uniformly so the write path can never leak a malformed
   // rule via `...obj` passthrough. Mirrors field-codecs.ts's sanitizeFieldProperty
   // (shared helpers).
-  return withFieldRequiredWhenRule(
-    withFieldVisibilityRule(sanitizeFieldPropertyByType(type, property), property),
+  //
+  // The layer-2 visibility keys (`hidden` / `visible`) belong to that SAME cross-cutting set. This
+  // sanitizer has the same closed-allowlist branches as its field-codecs sibling — `person` and `button`
+  // rebuild `property` from scratch and so dropped them (the other branches spread `...obj` and kept them
+  // incidentally). It applies the SAME SHARED function — imported, never re-implemented: two independent
+  // copies of this rule is precisely how the inconsistency survived in the first place.
+  return withLayer2VisibilityKeys(
+    withFieldRequiredWhenRule(
+      withFieldVisibilityRule(sanitizeFieldPropertyByType(type, property), property),
+      property,
+    ),
     property,
   )
 }

--- a/packages/core-backend/tests/integration/multitable-layer2-hidden-person-button-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-layer2-hidden-person-button-realdb.test.ts
@@ -19,6 +19,27 @@
  *   - STRING_HIDDEN  (string, property.hidden=true)   → value MUST be masked (control: always worked, so a
  *                                                       green here proves the harness detects masking)
  *
+ * MUTATION MATRIX (measured — and the reason the ROUTE goldens exist rather than inference):
+ * the two record routes go through DIFFERENT sanitizers, which is only visible by mutating each half:
+ *   - `GET /records` (list)        → univer-meta's `loadSheetFields` → **univer-meta's** sanitizer
+ *   - `GET /records/:id` (single)  → `loaders.ts`                    → **field-codecs'** sanitizer
+ *
+ *   | mutation                      | list | single |
+ *   |-------------------------------|------|--------|
+ *   | remove univer-meta half only  | RED  | green  |
+ *   | remove field-codecs half only | green| RED    |
+ *   | remove BOTH                   | RED  | RED    |
+ *
+ * So each route golden pins a DIFFERENT half of the fix, and a single-module mutation would have missed
+ * one. This is exactly why a permission-layer fix cannot be argued "platform-wide" from the fact that the
+ * surfaces share a sanitizer — they don't all share the SAME one.
+ *
+ * KNOWN, ACCEPTED CONSEQUENCE (owner-decided, not changed here): making person/button genuinely hideable
+ * also makes them able to trigger the pre-existing Yjs gate — `canReadEveryYjsFieldForUser` refuses the
+ * whole Y.Doc if ANY field on the sheet is unreadable, so the client falls back to REST. That fail-closed is
+ * the correct security boundary (a record-level Y.Doc cannot be field-masked); this change only widens the
+ * set of field types that can trip it. A field-scoped Yjs design is a separate piece of work.
+ *
  * Runs only with DATABASE_URL. (plugin-tests.yml whitelist — two-point wiring.)
  */
 import express, { type Express } from 'express'
@@ -47,6 +68,10 @@ const STRING_CANARY = 'string-hidden-canary'
 const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
 let app: Express
 const detail = (batchId: string) => request(app).get(`/api/multitable/bases/${BASE_ID}/history/events/${batchId}`)
+// The RECORD read routes — the surface on which the leak was originally confirmed. A permission fix must be
+// pinned HERE, not inferred from a shared sanitizer across modules.
+const recordsList = () => request(app).get('/api/multitable/records').query({ sheetId: SHEET_ID })
+const singleRecord = () => request(app).get(`/api/multitable/records/${REC}`).query({ sheetId: SHEET_ID })
 
 describeIfDatabase('layer-2 property.hidden masks person + button values (real DB)', () => {
   beforeAll(async () => {
@@ -67,6 +92,18 @@ describeIfDatabase('layer-2 property.hidden masks person + button values (real D
     await addField(PERSON_VISIBLE, 'OpenPeople', 'person', '{}', 3)
     await addField(STRING_HIDDEN, 'HiddenString', 'string', '{"hidden":true}', 4)
 
+    // a LIVE record row — GET /records and GET /records/:id read meta_records (the revisions below drive the
+    // History surface). Same four fields, so one fixture proves both surfaces.
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [
+      REC, SHEET_ID,
+      JSON.stringify({
+        [PERSON_HIDDEN]: [P_SECRET],
+        [BUTTON_HIDDEN]: BUTTON_CANARY,
+        [PERSON_VISIBLE]: [P_OPEN],
+        [STRING_HIDDEN]: STRING_CANARY,
+      }),
+    ])
+
     await q(
       `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot, batch_id)
        VALUES (gen_random_uuid(), $1, $2, 1, 'update', 'rest', $3, $4::text[], '{}'::jsonb, $5::jsonb, $6)`,
@@ -85,6 +122,7 @@ describeIfDatabase('layer-2 property.hidden masks person + button values (real D
   })
 
   afterAll(async () => {
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
@@ -119,6 +157,53 @@ describeIfDatabase('layer-2 property.hidden masks person + button values (real D
     const change = (res.body?.data?.changes ?? []).find((c: any) => c.recordId === REC)
     expect(change.after?.[PERSON_VISIBLE]).toEqual([P_OPEN])
     expect(change.changedFieldIds).toContain(PERSON_VISIBLE)
+  })
+
+  /**
+   * THE ROUTES THE LEAK WAS ORIGINALLY CONFIRMED ON.
+   *
+   * The History batch-detail tests above prove the two-layer mask chain. They are NOT a substitute for these:
+   * the originally-observed fact was that **`GET /records` returned the hidden person field's userId**. A
+   * permission-layer fix must be pinned on the actual read routes, not inferred "platform-wide" from the fact
+   * that both surfaces happen to share a sanitizer. Cross-module deduction is an argument, not a test.
+   *
+   * Asserted on BOTH the list and the single-record route: the hidden person's and hidden button's FIELD ID,
+   * VALUE, and (for person) MEMBER ID are all absent; the visible person is still returned.
+   */
+  test('GET /records (list): a hidden person/button field is absent — field id, value, and member id', async () => {
+    const res = await recordsList()
+    expect(res.status).toBe(200)
+    const rows = (res.body?.data?.records ?? res.body?.data ?? res.body?.records ?? []) as Array<Record<string, any>>
+    const rec = rows.find((r) => r.id === REC)
+    expect(rec).toBeTruthy()
+    const data = (rec!.data ?? rec!.fields ?? rec) as Record<string, unknown>
+
+    expect(data[PERSON_HIDDEN]).toBeUndefined()          // hidden PERSON: value gone
+    expect(Object.keys(data)).not.toContain(PERSON_HIDDEN) // …and its field id gone
+    expect(data[BUTTON_HIDDEN]).toBeUndefined()          // hidden BUTTON: same
+    expect(data[PERSON_VISIBLE]).toEqual([P_OPEN])       // NON-VACUOUS: visible person still returned
+
+    const body = JSON.stringify(res.body)
+    expect(body).not.toContain(P_SECRET)      // the hidden member's user id, nowhere in the body
+    expect(body).not.toContain(BUTTON_CANARY)
+    expect(body).not.toContain(STRING_CANARY)
+    expect(body).toContain(P_OPEN)            // control: the VISIBLE member does appear
+  })
+
+  test('GET /records/:recordId (single): same — hidden person/button absent, visible person returned', async () => {
+    const res = await singleRecord()
+    expect(res.status).toBe(200)
+    const rec = (res.body?.data?.record ?? res.body?.data ?? res.body?.record ?? {}) as Record<string, any>
+    const data = (rec.data ?? rec.fields ?? rec) as Record<string, unknown>
+
+    expect(data[PERSON_HIDDEN]).toBeUndefined()
+    expect(data[BUTTON_HIDDEN]).toBeUndefined()
+    expect(data[PERSON_VISIBLE]).toEqual([P_OPEN])
+
+    const body = JSON.stringify(res.body)
+    expect(body).not.toContain(P_SECRET)
+    expect(body).not.toContain(BUTTON_CANARY)
+    expect(body).toContain(P_OPEN)
   })
 
   /**

--- a/packages/core-backend/tests/integration/multitable-layer2-hidden-person-button-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-layer2-hidden-person-button-realdb.test.ts
@@ -121,6 +121,30 @@ describeIfDatabase('layer-2 property.hidden masks person + button values (real D
     expect(change.changedFieldIds).toContain(PERSON_VISIBLE)
   })
 
+  /**
+   * The OTHER sanitizer. The tests above seed `property` via raw SQL, so they exercise only the READ-path
+   * codec (field-codecs.ts). The HTTP field-WRITE path has its own sanitizer (`univer-meta.ts`'s
+   * `sanitizeFieldProperty`, reached via `normalizeFieldWriteInput` from `PATCH /fields/:fieldId`), and it
+   * had the SAME closed-allowlist person branch. Neutering ONLY that call site left every other test in this
+   * PR green — an untested guard (review P2-2). This drives the real route so the write half is covered.
+   */
+  test('WRITE PATH (the univer-meta sanitizer): PATCH /fields persists property.hidden on a person field', async () => {
+    const fid = `fld_l2_wp_${TS}`
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [fid, SHEET_ID, 'WritePathPerson', 'person', '{}', 5])
+
+    const res = await request(app).patch(`/api/multitable/fields/${fid}`).send({ property: { hidden: true, limitSingleRecord: false } })
+    expect(res.status).toBe(200)
+
+    // It PERSISTED — this is exactly what the univer-meta half of the fix is responsible for. Without it,
+    // the closed-allowlist person branch rebuilds `property` and the hide is dropped on the way in.
+    const row = (await q('SELECT property FROM meta_fields WHERE id = $1', [fid])).rows[0] as { property: Record<string, unknown> }
+    expect(row.property.hidden).toBe(true)
+    // …and the type-specific sanitization still ran (the cross-cutting rule did not replace it)
+    expect(row.property.limitSingleRecord).toBe(false)
+
+    await q('DELETE FROM meta_fields WHERE id = $1', [fid]).catch(() => {})
+  })
+
   test('CONTROL: a hidden STRING field was always masked — proves the harness detects masking at all', async () => {
     const res = await detail(BATCH)
     const change = (res.body?.data?.changes ?? []).find((c: any) => c.recordId === REC)

--- a/packages/core-backend/tests/integration/multitable-layer2-hidden-person-button-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-layer2-hidden-person-button-realdb.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Layer-2 field hiding must actually MASK the value — end-to-end — for `person` and `button`.
+ *
+ * The unit test (tests/unit/field-property-layer2-visibility.test.ts) proves the sanitizer now preserves
+ * `hidden`/`visible` for these two types. This proves the consequence that actually matters: with the key
+ * preserved, `isFieldPermissionHidden` sees it, the field leaves the two-layer allow-set, and the read
+ * surface stops emitting the value.
+ *
+ * Read surface used: the History batch-detail projection, because it applies the canonical two-layer mask
+ * (layer-2 property-hidden ∩ layer-3 field_permissions) via `allowedFieldsBySheet` — the same chain the
+ * record read paths use. A field outside that set has its VALUES dropped by `filterDataByAllowedFields`
+ * AND its id dropped from `changedFieldIds`.
+ *
+ * Structure (differential — the controls are what make it non-vacuous):
+ *   - PERSON_HIDDEN  (person, property.hidden=true)   → value MUST be masked      ← was leaking
+ *   - BUTTON_HIDDEN  (button, property.hidden=true)   → value MUST be masked      ← was leaking
+ *   - PERSON_VISIBLE (person, no hidden)              → value MUST still be returned (non-vacuous control:
+ *                                                       proves we did not just mask everything)
+ *   - STRING_HIDDEN  (string, property.hidden=true)   → value MUST be masked (control: always worked, so a
+ *                                                       green here proves the harness detects masking)
+ *
+ * Runs only with DATABASE_URL. (plugin-tests.yml whitelist — two-point wiring.)
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_l2_${TS}`
+const SHEET_ID = `sheet_l2_${TS}`
+const PERSON_HIDDEN = `fld_l2_ph_${TS}`
+const BUTTON_HIDDEN = `fld_l2_bh_${TS}`
+const PERSON_VISIBLE = `fld_l2_pv_${TS}`
+const STRING_HIDDEN = `fld_l2_sh_${TS}`
+const REC = `rec_l2_${TS}`
+const BATCH = `batch_l2_${TS}`
+const VIEWER = `user_l2_viewer_${TS}`
+const P_SECRET = `user_l2_secret_${TS}` // only inside the HIDDEN person field
+const P_OPEN = `user_l2_open_${TS}` // inside the VISIBLE person field
+const BUTTON_CANARY = 'button-hidden-canary'
+const STRING_CANARY = 'string-hidden-canary'
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+const detail = (batchId: string) => request(app).get(`/api/multitable/bases/${BASE_ID}/history/events/${batchId}`)
+
+describeIfDatabase('layer-2 property.hidden masks person + button values (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: VIEWER, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    for (const u of [VIEWER, P_SECRET, P_OPEN]) {
+      await q("INSERT INTO users (id, password_hash, name) VALUES ($1,'x',$2) ON CONFLICT (id) DO NOTHING", [u, `N_${u}`])
+    }
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'L2 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'L2 Sheet'])
+    const addField = (id: string, name: string, type: string, property: string, order: number) =>
+      q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [id, SHEET_ID, name, type, property, order])
+    await addField(PERSON_HIDDEN, 'HiddenPeople', 'person', '{"hidden":true}', 1)
+    await addField(BUTTON_HIDDEN, 'HiddenButton', 'button', '{"hidden":true}', 2)
+    await addField(PERSON_VISIBLE, 'OpenPeople', 'person', '{}', 3)
+    await addField(STRING_HIDDEN, 'HiddenString', 'string', '{"hidden":true}', 4)
+
+    await q(
+      `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot, batch_id)
+       VALUES (gen_random_uuid(), $1, $2, 1, 'update', 'rest', $3, $4::text[], '{}'::jsonb, $5::jsonb, $6)`,
+      [
+        SHEET_ID, REC, VIEWER,
+        [PERSON_HIDDEN, BUTTON_HIDDEN, PERSON_VISIBLE, STRING_HIDDEN],
+        JSON.stringify({
+          [PERSON_HIDDEN]: [P_SECRET],
+          [BUTTON_HIDDEN]: BUTTON_CANARY,
+          [PERSON_VISIBLE]: [P_OPEN],
+          [STRING_HIDDEN]: STRING_CANARY,
+        }),
+        BATCH,
+      ],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    for (const u of [VIEWER, P_SECRET, P_OPEN]) await q('DELETE FROM users WHERE id = $1', [u]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('a layer-2 hidden PERSON field is masked — its value, its member, and its field id all absent', async () => {
+    const res = await detail(BATCH)
+    expect(res.status).toBe(200)
+    const change = (res.body?.data?.changes ?? []).find((c: any) => c.recordId === REC)
+    expect(change).toBeTruthy()
+
+    expect(change.after?.[PERSON_HIDDEN]).toBeUndefined() // value dropped
+    expect(change.changedFieldIds).not.toContain(PERSON_HIDDEN) // field id dropped (no "it changed" oracle)
+    // whole-body: the hidden member's id must not surface anywhere (incl. via personNames-style maps)
+    expect(JSON.stringify(res.body)).not.toContain(P_SECRET)
+  })
+
+  test('a layer-2 hidden BUTTON field is masked (same rule, second affected type)', async () => {
+    const res = await detail(BATCH)
+    const change = (res.body?.data?.changes ?? []).find((c: any) => c.recordId === REC)
+    expect(change.after?.[BUTTON_HIDDEN]).toBeUndefined()
+    expect(change.changedFieldIds).not.toContain(BUTTON_HIDDEN)
+    expect(JSON.stringify(res.body)).not.toContain(BUTTON_CANARY)
+  })
+
+  test('NON-VACUOUS: a VISIBLE person field is still returned (we did not simply mask everything)', async () => {
+    const res = await detail(BATCH)
+    const change = (res.body?.data?.changes ?? []).find((c: any) => c.recordId === REC)
+    expect(change.after?.[PERSON_VISIBLE]).toEqual([P_OPEN])
+    expect(change.changedFieldIds).toContain(PERSON_VISIBLE)
+  })
+
+  test('CONTROL: a hidden STRING field was always masked — proves the harness detects masking at all', async () => {
+    const res = await detail(BATCH)
+    const change = (res.body?.data?.changes ?? []).find((c: any) => c.recordId === REC)
+    expect(change.after?.[STRING_HIDDEN]).toBeUndefined()
+    expect(JSON.stringify(res.body)).not.toContain(STRING_CANARY)
+  })
+})

--- a/packages/core-backend/tests/unit/field-property-layer2-visibility.test.ts
+++ b/packages/core-backend/tests/unit/field-property-layer2-visibility.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Layer-2 field visibility keys are CROSS-CUTTING — they must survive EVERY field type's sanitizer.
+ *
+ * `isFieldPermissionHidden` (permission-derivation.ts) decides layer-2 hiding by reading exactly two keys:
+ *   property.hidden === true   ||   property.visible === false
+ *
+ * The per-type sanitizer has two shapes of branch:
+ *   - PASSTHROUGH (`return { ...obj, … }` / link's `...cleanObj`) — select, link, lookup, rollup, formula,
+ *     attachment, currency, dateTime, … — these carried the keys through incidentally.
+ *   - CLOSED ALLOWLIST (`return { …only these keys }`) — **exactly `person` and `button`** (plus any custom
+ *     `fieldTypeRegistry` codec that does the same). These rebuilt `property` from scratch and DROPPED the
+ *     two keys, so the predicate never saw them.
+ *
+ * MEASURED, NOT ASSUMED: reverting the cross-cutting rule reds ONLY the `person` and `button` rows below.
+ * The other types already preserved the keys — they are kept in the table as CONTROLS, so that converting
+ * any of them to a closed allowlist later (or adding a new type) is caught immediately.
+ *
+ * So: whether a field could be hidden at all depended on which branch its type happened to fall into.
+ * `sanitizeFieldProperty` already applied `visibilityRule` / `requiredWhen` as cross-cutting rules for
+ * exactly this reason — `hidden`/`visible` were simply never added to that set. The fix adds them there
+ * rather than patching the two guilty branches, because a branch only has to forget once.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeFieldProperty } from '../../src/multitable/field-codecs'
+import { isFieldPermissionHidden } from '../../src/multitable/permission-derivation'
+
+// The two types that ACTUALLY dropped the keys (measured: reverting the fix reds only these).
+const AFFECTED_TYPES = ['person', 'button'] as const
+// Types that already preserved them (passthrough branches). Kept as controls: they prove the assertion is
+// not vacuous, and they catch a future conversion of any of them into a closed allowlist.
+const CONTROL_TYPES = ['select', 'link', 'lookup', 'rollup', 'formula', 'attachment'] as const
+
+describe('layer-2 visibility keys survive every field type sanitizer', () => {
+  describe.each([...AFFECTED_TYPES, ...CONTROL_TYPES])('type=%s', (type) => {
+    it('preserves `hidden: true` — so isFieldPermissionHidden() can see it', () => {
+      const property = sanitizeFieldProperty(type, { hidden: true })
+      expect(property.hidden).toBe(true)
+      expect(isFieldPermissionHidden({ property })).toBe(true)
+    })
+
+    it('preserves `visible: false` — the other half of the same predicate', () => {
+      const property = sanitizeFieldProperty(type, { visible: false })
+      expect(property.visible).toBe(false)
+      expect(isFieldPermissionHidden({ property })).toBe(true)
+    })
+
+    it('NON-VACUOUS control: a field with neither key is NOT hidden', () => {
+      const property = sanitizeFieldProperty(type, {})
+      expect(isFieldPermissionHidden({ property })).toBe(false)
+    })
+  })
+
+  it('does not invent the keys: permissive values are not carried (only the HIDING signals are)', () => {
+    // `hidden: false` / `visible: true` are not load-bearing for the predicate; carrying them would churn
+    // existing property shapes for no benefit. What matters is that neither makes the field hidden.
+    const p1 = sanitizeFieldProperty('person', { hidden: false })
+    const p2 = sanitizeFieldProperty('person', { visible: true })
+    expect(isFieldPermissionHidden({ property: p1 })).toBe(false)
+    expect(isFieldPermissionHidden({ property: p2 })).toBe(false)
+  })
+
+  it('the type-specific sanitization still happens (the cross-cutting rule does not replace it)', () => {
+    // person's own key survives alongside the carried layer-2 key…
+    const person = sanitizeFieldProperty('person', { hidden: true, limitSingleRecord: false })
+    expect(person.hidden).toBe(true)
+    expect(person.limitSingleRecord).toBe(false)
+    // …and button still gets its enforced readOnly, plus its own allowlisted keys.
+    const button = sanitizeFieldProperty('button', { hidden: true, label: 'Go', variant: 'primary' })
+    expect(button.hidden).toBe(true)
+    expect(button.readOnly).toBe(true)
+    expect(button.label).toBe('Go')
+  })
+
+  it('a junk property value cannot smuggle a truthy-but-not-true hidden', () => {
+    // the predicate is strict (=== true / === false); the carrier must be equally strict, so a truthy
+    // non-boolean must NOT become a hiding signal (it would be an unpredictable, type-dependent mask).
+    for (const junk of ['true', 1, {}, []]) {
+      const property = sanitizeFieldProperty('person', { hidden: junk })
+      expect(isFieldPermissionHidden({ property })).toBe(false)
+    }
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -57,6 +57,11 @@ export default defineConfig({
       // no-DB job cannot skip-green it, and wired as a WHOLE FILE into the directory real-DB
       // step in plugin-tests.yml.
       'tests/integration/directory-sync-schedule-timezone.db.test.ts',
+      // Layer-2 hidden person/button masking (real DB): proves the cross-cutting visibility-key fix actually
+      // masks the VALUE end-to-end, with non-vacuous controls. DATABASE_URL-gated; excluded here so the no-DB
+      // job cannot skip-green it, and wired as a WHOLE FILE into the multitable real-DB step in
+      // plugin-tests.yml. Two-point wiring — both points, deliberately.
+      'tests/integration/multitable-layer2-hidden-person-button-realdb.test.ts',
       'tests/integration/approval-manager-chain.db.test.ts',
       'tests/integration/approval-requester-department.db.test.ts',
       'tests/integration/approval-requester-title.db.test.ts',


### PR DESCRIPTION
## What

`isFieldPermissionHidden` decides layer-2 field hiding from exactly two property keys — `hidden === true` / `visible === false`. They're **cross-cutting**: any field type may carry them.

The per-type sanitizer has two branch shapes:
- **passthrough** (`...obj`, or link's `...cleanObj`) — carried the keys through incidentally
- **closed allowlist** (rebuilds `property` from scratch) — **`person` and `button`** — **dropped** them

So for those two types, marking a field hidden **did not make it hidden**. Which behavior you got depended on which branch your type happened to fall into.

**Measured, not assumed:** reverting this rule reds **only** the `person` and `button` rows of the type-by-type test. `link`/`lookup`/`rollup`/`formula`/`attachment` already preserved the keys — they stay in the table as **controls**, so converting any of them to a closed allowlist later (or adding a new type) is caught immediately.

## Where the fix goes, and why not per-branch

`sanitizeFieldProperty` **already** composes `visibilityRule` + `requiredWhen` as cross-cutting rules, with a comment giving exactly this rationale — *"rather than relying on each branch's incidental `...obj` passthrough."* `hidden`/`visible` were simply **never added to that set**.

Adding them **there** (not patching the two guilty branches) is what stops the *next* closed-allowlist branch from reintroducing it — a branch only has to forget once. It also covers the custom `fieldTypeRegistry` codec escape hatch, which a per-branch fix would miss.

There are **two** sanitizers with this same structure (`field-codecs.ts`, `univer-meta.ts`). Both now apply the **same shared function**, imported rather than re-implemented — two independent copies of the rule is how the inconsistency survived.

Only the **hiding** signals are carried; permissive values aren't load-bearing, and the carrier is strict (a truthy non-boolean can't smuggle a mask).

## Verification
- **unit 27/27** type-by-type (incl. non-vacuous + junk-value rows). **Mutation reds only person+button.**
- **New real-DB e2e**: a hidden person/button field's **value**, its **member id**, and its **field id** are all absent from the read surface; a **visible** person is still returned (non-vacuous control); a hidden **string** is masked (harness control). **Mutation reds exactly the person+button rows.**
- **Two-point wiring** on the new real-DB file — no-DB lane reports `No test files found`, not a skip-green.
- **Regression:** full backend unit suite **376 files / 5223 tests** pass; **7 masking/permission integration suites (43 tests)** pass, incl. button routes.
- backend `tsc` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Adversarial review: **APPROVE-with-hardening** (0 P1, 2 P2) — both P2s fixed

Both P2s made the fix **hollow**, so they mattered:

- **P2-1 — the FE was silently wiping the mask I'd just restored.** `update-field` replaces `property` wholesale, and `MetaFieldManager.currentDraftProperty` rebuilds it as a **closed literal** per type (the person branch is literally `{ limitSingleRecord }`). So any unrelated Save — rename a button, flip person single/multi, edit a validation rule — **dropped a stored `hidden: true` and un-hid the field.** Carried the keys **opaquely**, exactly as this component already carries `actionConfig` (*"the form doesn't edit it, so re-emit it intact"*). Safe: the FE has **no writer** of these keys anywhere (only the reader in `utils/field-permissions.ts`), so re-emitting can't block an un-hide. Fixed in the **FE, not the server** — a server-side merge-forward would collide with the strict carrier and make un-hiding impossible.
- **P2-2 — the univer-meta half had zero coverage.** Neutering *only* that call site left every test green. That half is the HTTP **write** path (`PATCH /fields` → `normalizeFieldWriteInput` → univer-meta's sanitizer); without it, `PATCH /fields {property:{hidden:true}}` on a person field **never persists**. Added a real write-path test.
- **P3-1 — a claim of mine was wrong.** `univer-meta`'s sanitizer has **no `button` branch at all** (button falls to its passthrough default), so it was **`person` only** there; `field-codecs` has both. The two sanitizers don't even agree on which types they special-case — which is exactly why the rule must live outside the per-type switch and be **shared**.

**Every new guard is mutation-proven** (drop the FE carry → reds exactly the 2 hide-preservation tests; neuter only the univer-meta half → reds exactly the write-path test).

Verified: backend tsc 0 · web type-check clean · unit **27/27** · e2e **6/6** · FE field-manager **26/26**.
