### PR TITLE
test(core-backend): retry:2 to absorb the proven supertest ephemeral-port cross-talk flake (#4154)

### DIFF
--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -7,6 +7,17 @@ export default defineConfig({
     environment: 'node',
     // Fix vite SSR transformation issues - use forks pool to avoid __vite_ssr_exportName__ errors
     pool: 'forks',
+    // #4154: supertest specs call `request(app)`, which spins up a fresh `app.listen(0)` ephemeral
+    // listener PER REQUEST (~495 call sites across 42 files). Under full-suite event-loop load the OS
+    // recycles ephemeral ports fast enough that a request occasionally lands on a DIFFERENT test's app
+    // that just rebound the same port — proven by a `GET /api/approvals` returning 405 (a server that
+    // knows the path but not the method = someone else's app), and by the FAILING SPEC being random
+    // across runs (dashboard / ai-suggest / approval-rbac) rather than fixed. The collision is purely
+    // transient: a retry gets a fresh port and hits the right server. A DETERMINISTIC product failure
+    // still fails all attempts, so this absorbs the infra flake without hiding real bugs. (Tradeoff,
+    // stated plainly: a genuinely NON-deterministic PRODUCT race would also be absorbed — acceptable
+    // here because these are mock-dep unit tests, but flagged for review.)
+    retry: 2,
     deps: {
       interopDefault: true
     },

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -17,7 +17,11 @@ export default defineConfig({
     // still fails all attempts, so this absorbs the infra flake without hiding real bugs. (Tradeoff,
     // stated plainly: a genuinely NON-deterministic PRODUCT race would also be absorbed — acceptable
     // here because these are mock-dep unit tests, but flagged for review.)
-    retry: 2,
+    // CI-only (review of #4169): the required `test (20.x)` check runs in CI, so retry absorbs the
+    // flake exactly where it reds a gate; locally retry is 0 so a developer sees a genuine failure
+    // immediately instead of waiting through re-runs — and the masking tradeoff never touches local
+    // debugging. GitHub Actions sets CI=true for every run.
+    retry: process.env.CI ? 2 : 0,
     deps: {
       interopDefault: true
     },


### PR DESCRIPTION
Fixes #4154.

## 机制(证出来的,不是猜的)

`test (20.x)`(**required** 检查)约 **1/10** 被 core-backend 单测里 supertest spec 的 `socket hang up`/ECONNRESET 或错误状态码无故打红。三条决定性证据:

1. **失败的 spec 每轮都不同**(dashboard-routes-wiring / ai-suggest-formula / approval-rbac-boundary)→ 不是某个 handler 的 bug。
2. **`GET /api/approvals` 返回 405** —— 一个"认识这个路径但方法不对"的服务器,**即别的测试的 app**。请求打到了错误的临时服务器。
3. **逐个证伪**:非并发(`maxForks=1` 仍复现)· 非端口耗尽(TIME_WAIT 峰值 650/16384)· 非假时钟 · **非通用 listener churn**(3000 次相同 app churn = 0 reset —— 恰恰因为相同 app 串台也返回 200,所以隐形)。

**根因**:`request(app)` 每个请求都 `app.listen(0)` 起一个临时 listener(~495 处调用 / 42 文件)。满套件事件循环压力下,OS 回收临时端口够快,以至一个请求偶尔连到刚被**另一个测试**重绑同端口的 app → 错状态或 reset。

## 修法与为什么它不掩盖真 bug

串台是**纯瞬态**的:重试会拿到新端口、打到正确服务器。而**确定性的产品失败重试仍然全红**——所以 `retry:2` 吸收基础设施 flake,不掩盖真 bug。

**受控 A/B(同一 harness、同一会话)**:

| 配置 | 25 轮结果 |
|---|---|
| `retry:0`(对照) | **2/25 红**(flake 确认在此环境存在) |
| `retry:2`(修复) | **0/25 红** |

全量单测绿:**375 文件 / 5196 测试**。

## 取舍(明写,不藏)

`retry:2` 是全局配置,一个假设中的**非确定性产品竞态**也会被吸收。这里可接受(都是 mock 依赖的单测,产品逻辑本身没有真并发),**但明确标出交给你判断**。

**根因根除**(把每请求 churn 改成每文件 pin 一个 listening server,涉及 ~495 处调用)是更大的 follow-up,本 PR 不做。

🤖 Generated with [Claude Code](https://claude.com/claude-code)