### PR TITLE
test(dingtalk): close the send_status race in 3 approval-card waits (flake blocking unrelated PRs)

### DIFF
--- a/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
+++ b/packages/core-backend/tests/integration/automation-dingtalk-approval-card-action.test.ts
@@ -385,7 +385,7 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
     interactiveBodies.length = 0
     const dto = await approvals.createApproval({ templateId, formData: { summary: 'SECRET-FORM-VALUE' } }, { userId: REQUESTER, userName: REQUESTER })
     const instanceId = (dto as { id: string }).id
-    const rows = await waitFor(() => cardRows(instanceId))
+    const rows = await waitFor(async () => (await cardRows(instanceId)).filter((r) => r.send_status !== 'pending'))
     expect(rows).toHaveLength(1)
     const row = rows[0]
     expect(row.delivery_kind).toBe('work_notice_action_card')
@@ -777,7 +777,7 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
     try {
       const dto = await approvals.createApproval({ templateId, formData: { summary: 'r2 anchor run' } }, { userId: REQUESTER, userName: REQUESTER })
       const instanceId = (dto as { id: string }).id
-      const rows = await waitFor(() => cardRows(instanceId))
+      const rows = await waitFor(async () => (await cardRows(instanceId)).filter((r) => r.send_status !== 'pending'))
       expect(rows).toHaveLength(1)
       // The callback credential anchor: the row is pinned to the corp the card went through.
       expect(rows[0].integration_id).toBe(DD_INTEGRATION)
@@ -816,7 +816,7 @@ describeIfDatabase('A-2b send_dingtalk_approval_card action (real DB)', () => {
       sentBodies.length = 0
       const dto = await approvals.createApproval({ templateId, formData: { summary: 'r2 corp secret run' } }, { userId: REQUESTER, userName: REQUESTER })
       const instanceId = (dto as { id: string }).id
-      const rows = await waitFor(() => cardRows(instanceId))
+      const rows = await waitFor(async () => (await cardRows(instanceId)).filter((r) => r.send_status !== 'pending'))
       expect(rows).toHaveLength(1)
       const row = rows[0]
       expect(row.integration_id).toBe(DD_INTEGRATION)


### PR DESCRIPTION
## 根因(测试侧 race,零产品 bug)

`waitFor()` **行一出现就返回**。而投递行是 **INSERT 成 `pending` → 异步发送 → UPDATE 成 `sent`**,所以只等「行存在」就会撞上那个 UPDATE:

```js
const rows = await waitFor(() => cardRows(instanceId))   // 还是 pending 就返回了
expect(row.send_status).toBe('sent')                     // → expected 'pending' to be 'sent'
```

**这个文件自己早就知道**:它 10 个 `cardRows` 等待里有 **7 个**都先滤掉 `pending` 再返回。**只有 3 个漏了**(DT-A1 / DT-R1 / **DT-R2**)。本 PR 就是把该文件**自己已确立的惯用法**补到这 3 处——**零产品改动、零新 helper、零发明语义**。

## 确定性证明(隔离 PG,全文件跑)
- **main 原样在本地不复现**(5/5 绿)——race 只在 CI 的慢速/高负载/共享库下咬人。
- **撑开窗口**(临时给 mock 的 asyncsend 加 250ms)→ 变确定性:
  - **裸写法** ❌ 报出与 CI **逐字一致**的 `expected 'pending' to be 'sent'`(DT-R2 站点)
  - **修复版** ✅ 同一撑开窗口下 **15/15 全绿**
- 临时 widener 已撤;**对 main 的净 diff 恰好是那 3 行 waitFor**(3+/3−)。

## 影响面
在**两个互不相干的 PR** 上撞到:**#4156**(前端按钮变体)和 **#4168**(D-2 删除恢复)——**都不碰 DingTalk**。这正是 DingTalk 线一直在等的**第二次复现**。

## 附带好处
真实发送失败过去也报 `expected 'pending' to be 'sent'`(与 race 无法区分)。现在会等到 settled 行、报 `expected 'failed' to be 'sent'` —— **真失败不再伪装成 flake**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)