### PR TITLE
feat(web): multitable UI P2-1c T1 batch-5 — close-× to MtIconButton

### DIFF
--- a/apps/web/src/multitable/components/MetaLinkPicker.vue
+++ b/apps/web/src/multitable/components/MetaLinkPicker.vue
@@ -3,7 +3,7 @@
     <div class="meta-link-picker" @keydown.esc.stop.prevent="emit('close')" @keydown.enter.stop.prevent="onConfirm">
       <div class="meta-link-picker__header">
         <h4 class="meta-link-picker__title">{{ titleText }}</h4>
-        <button class="meta-link-picker__close" :aria-label="lp('linkPicker.close')" @click="emit('close')">&times;</button>
+        <MtIconButton class="meta-link-picker__close" :aria-label="lp('linkPicker.close')" @click="emit('close')">&times;</MtIconButton>
       </div>
       <div class="meta-link-picker__search">
         <input v-model="search" class="meta-link-picker__input" :placeholder="searchPlaceholder" @input="onSearch" />
@@ -46,7 +46,7 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
-import { MtButton } from '../ui'
+import { MtButton, MtIconButton } from '../ui'
 import type { LinkedRecordSummary, MetaField } from '../types'
 import { multitableClient } from '../api/client'
 import { linkPickerSearchPlaceholder, linkPickerTitle } from '../utils/link-fields'
@@ -172,7 +172,9 @@ function onConfirm() {
 .meta-link-picker { width: 480px; max-height: 70vh; background: #fff; border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,.15); display: flex; flex-direction: column; }
 .meta-link-picker__header { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; border-bottom: 1px solid #eee; }
 .meta-link-picker__title { font-size: 14px; font-weight: 600; margin: 0; }
-.meta-link-picker__close { border: none; background: none; font-size: 20px; cursor: pointer; color: #999; }
+/* .meta-link-picker__close: now <MtIconButton> (ghost, token-styled; the &times; glyph char passes
+   through its default-slot icon fallback (size token-normalized to the icon control)). Bespoke hardcoded CSS removed
+   (UI-P2-1c T1 batch-5). Class kept on the element only for selector stability. */
 .meta-link-picker__search { padding: 8px 16px; }
 .meta-link-picker__input { width: 100%; padding: 6px 10px; border: 1px solid #ddd; border-radius: 4px; font-size: 13px; }
 .meta-link-picker__selected { padding: 0 16px 8px; border-bottom: 1px solid #f0f0f0; }

--- a/apps/web/src/multitable/components/MetaPersonPicker.vue
+++ b/apps/web/src/multitable/components/MetaPersonPicker.vue
@@ -3,7 +3,7 @@
     <div class="meta-person-picker" @keydown.esc.stop.prevent="emit('close')" @keydown.enter.stop.prevent="onConfirm">
       <div class="meta-person-picker__header">
         <h4 class="meta-person-picker__title">{{ titleText }}</h4>
-        <button class="meta-person-picker__close" :aria-label="pp('personPicker.close')" @click="emit('close')">&times;</button>
+        <MtIconButton class="meta-person-picker__close" :aria-label="pp('personPicker.close')" @click="emit('close')">&times;</MtIconButton>
       </div>
       <div class="meta-person-picker__search">
         <input v-model="search" class="meta-person-picker__input" :placeholder="searchPlaceholder" @input="onSearch" />
@@ -44,7 +44,7 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
-import { MtButton } from '../ui'
+import { MtButton, MtIconButton } from '../ui'
 import type { MetaField, PersonSummary } from '../types'
 import { multitableClient } from '../api/client'
 import { isPersonSingleRecordField } from '../utils/person-fields'
@@ -186,7 +186,9 @@ function onConfirm() {
 .meta-person-picker { width: 480px; max-height: 70vh; background: #fff; border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,.15); display: flex; flex-direction: column; }
 .meta-person-picker__header { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; border-bottom: 1px solid #eee; }
 .meta-person-picker__title { font-size: 14px; font-weight: 600; margin: 0; }
-.meta-person-picker__close { border: none; background: none; font-size: 20px; cursor: pointer; color: #999; }
+/* .meta-person-picker__close: now <MtIconButton> (ghost, token-styled; the &times; glyph char passes
+   through its default-slot icon fallback (size token-normalized to the icon control)). Bespoke hardcoded CSS removed
+   (UI-P2-1c T1 batch-5). Class kept on the element only for selector stability. */
 .meta-person-picker__search { padding: 8px 16px; }
 .meta-person-picker__input { width: 100%; padding: 6px 10px; border: 1px solid #ddd; border-radius: 4px; font-size: 13px; }
 .meta-person-picker__selected { padding: 0 16px 8px; border-bottom: 1px solid #f0f0f0; }

--- a/apps/web/src/multitable/components/ScaleFormattingDialog.vue
+++ b/apps/web/src/multitable/components/ScaleFormattingDialog.vue
@@ -4,7 +4,7 @@
       <div class="scf-dlg__header">
         <h4 class="scf-dlg__title">{{ ml('formatting.scaleTitle') }}</h4>
         <span class="scf-dlg__count">{{ draftRules.length }} / {{ ruleLimit }}</span>
-        <button class="scf-dlg__close" :aria-label="ml('formatting.close')" @click="close">&times;</button>
+        <MtIconButton class="scf-dlg__close" :aria-label="ml('formatting.close')" @click="close">&times;</MtIconButton>
       </div>
       <div class="scf-dlg__body">
         <p v-if="!draftRules.length" class="scf-dlg__empty">{{ ml('formatting.scaleEmpty') }}</p>
@@ -282,7 +282,7 @@ import { CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT } from '../types'
 import { HEX_COLOR_RE, extractScaleRulesFromConfig, lerpHexColor } from '../utils/conditional-formatting'
 import { SCALE_ICON_GLYPHS, type ScaleIconGlyph } from '../utils/scale-icons'
 import { formattingPickColor, managerLabel } from '../utils/meta-manager-labels'
-import { MtButton } from '../ui'
+import { MtButton, MtIconButton } from '../ui'
 
 const props = defineProps<{
   visible: boolean
@@ -549,7 +549,9 @@ function save() {
 .scf-dlg__header { display: flex; align-items: center; gap: 12px; padding: 12px 16px; border-bottom: 1px solid #eee; }
 .scf-dlg__title { flex: 1; font-size: 15px; font-weight: 600; margin: 0; }
 .scf-dlg__count { font-size: 12px; color: #666; }
-.scf-dlg__close { border: none; background: none; font-size: 20px; cursor: pointer; color: #999; padding: 0 4px; }
+/* .scf-dlg__close: now <MtIconButton> (ghost, token-styled; the &times; glyph char passes through
+   its default-slot icon fallback (size token-normalized to the icon control)). Bespoke hardcoded CSS removed
+   (UI-P2-1c T1 batch-5). Class kept on the element only for selector stability. */
 .scf-dlg__body { flex: 1; overflow-y: auto; padding: 12px 16px; display: flex; flex-direction: column; gap: 12px; }
 .scf-dlg__empty { font-size: 13px; color: #777; margin: 0; }
 .scf-dlg__rule-list { display: flex; flex-direction: column; gap: 10px; }

--- a/apps/web/tests/meta-meta-link-picker-migration.spec.ts
+++ b/apps/web/tests/meta-meta-link-picker-migration.spec.ts
@@ -10,6 +10,23 @@ import { useLocale } from '../src/composables/useLocale'
 // emits `close`; and clicking confirm still invokes onConfirm and emits `confirm` with the SAME
 // { recordIds, summaries } payload as before. This picker renders its own overlay inline (no
 // Teleport), but the residue guard still queries `document` for robustness.
+//
+// UI-P2-1c T1 batch-5 (multitable-ui-p2-1c-tail-resolution-designlock-20260707.md §2-T1, RATIFIED):
+// the header close-× (`.meta-link-picker__close`) was additionally migrated from a bespoke
+// <button>&times;</button> to the shared MtIconButton primitive — the &times; glyph passes through
+// MtIconButton's default-slot icon fallback (glyph char preserved, size token-normalized to the icon
+// control, consistent with the existing glyph-MtIconButton controls already on main). Behavior-
+// preservation proof: it stays a native, keyboard-operable <button>, keeps the SAME aria-label
+// (`lp('linkPicker.close')`), and clicking it still emits the SAME `close` event with no payload
+// (identical to the footer cancel button's handler). This is the only sharer of
+// `.meta-link-picker__close` (single button, single file) — its bespoke CSS was removed outright,
+// no double-styling risk.
+//
+// NOT migrated (classifier — verified against the handler, not the label): the per-chip
+// `.meta-link-picker__chip-remove` × glyph button (`@click="removeSelected(item.id)"`) is a
+// remove-selected-item control, not a close/dismiss — it stays a bespoke native <button>, out of
+// T1 scope. The positive-control test below proves it (a) still removes just that chip, (b) does
+// NOT emit `close`, and (c) is unaffected by the close-× migration.
 
 const { mockListLinkOptions } = vi.hoisted(() => ({ mockListLinkOptions: vi.fn() }))
 vi.mock('../src/multitable/api/client', () => ({
@@ -46,6 +63,8 @@ function mount(extraProps: Record<string, unknown> = {}, handlers: Record<string
 
 const cancelBtn = () => document.querySelector('.meta-link-picker__cancel') as HTMLButtonElement
 const confirmBtn = () => document.querySelector('.meta-link-picker__confirm') as HTMLButtonElement
+const closeBtn = () => document.querySelector('.meta-link-picker__close') as HTMLButtonElement
+const chipRemoveBtns = () => Array.from(document.querySelectorAll('.meta-link-picker__chip-remove')) as HTMLButtonElement[]
 
 describe('MetaLinkPicker — MtButton migration (UI-P2-1c)', () => {
   it('renders footer cancel + confirm as native <button>s (keyboard-operable, classes preserved)', async () => {
@@ -95,5 +114,58 @@ describe('MetaLinkPicker — MtButton migration (UI-P2-1c)', () => {
       recordIds: ['vendor_1'],
       summaries: [{ id: 'vendor_1', display: 'Acme Supply' }],
     })
+  })
+
+  it('renders the header close-× as a native <button> (MtIconButton) keeping the class + aria-label + glyph', async () => {
+    mockListLinkOptions.mockResolvedValue({ selected: [], records: [], page: { offset: 0, limit: 50, total: 0, hasMore: false } })
+    const { visible } = mount()
+    visible.value = true
+    await flushPromises()
+    const btn = closeBtn()
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('meta-link-picker__close')).toBe(true)
+    expect(btn.getAttribute('aria-label')).toBe('Close link picker')
+    expect(btn.textContent?.trim()).toBe('×') // × glyph char preserved (size token-normalized)
+  })
+
+  it('clicking the header close-× emits `close` (unchanged — same emit as the footer cancel button)', async () => {
+    mockListLinkOptions.mockResolvedValue({ selected: [], records: [], page: { offset: 0, limit: 50, total: 0, hasMore: false } })
+    const onClose = vi.fn()
+    const { visible } = mount({}, { onClose })
+    visible.value = true
+    await flushPromises()
+    closeBtn().click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
+  })
+
+  it('positive control: the per-chip remove-× is NOT the close-× — it stays a bespoke <button>, removes only that chip, and does NOT emit `close`', async () => {
+    mockListLinkOptions.mockResolvedValue({
+      selected: [
+        { id: 'vendor_1', display: 'Acme Supply' },
+        { id: 'vendor_2', display: 'Beacon Labs' },
+      ],
+      records: [],
+      page: { offset: 0, limit: 50, total: 0, hasMore: false },
+    })
+    const onClose = vi.fn()
+    const { container, visible } = mount({ currentValue: ['vendor_1', 'vendor_2'] }, { onClose })
+    visible.value = true
+    await flushPromises()
+
+    const chips = chipRemoveBtns()
+    expect(chips.length).toBe(2)
+    chips.forEach((btn) => expect(btn.tagName).toBe('BUTTON'))
+
+    chips[0].click()
+    await nextTick()
+
+    // exactly one chip removed, the close handler was never invoked by this click
+    expect(chipRemoveBtns().length).toBe(1)
+    expect(onClose).not.toHaveBeenCalled()
+    // dialog itself is untouched by the removal — still mounted, close-× still present and functional
+    expect(container.querySelector('.meta-link-picker__close')).toBeTruthy()
+    closeBtn().click()
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/tests/meta-meta-person-picker-migration.spec.ts
+++ b/apps/web/tests/meta-meta-person-picker-migration.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createApp, h, type App } from 'vue'
+import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
 import MetaPersonPicker from '../src/multitable/components/MetaPersonPicker.vue'
 import { useLocale } from '../src/composables/useLocale'
 
@@ -11,7 +11,23 @@ import { useLocale } from '../src/composables/useLocale'
 // pre-migration onConfirm. The `watch(() => props.visible, …)` is non-immediate, so mounting with
 // visible:true does NOT trigger loadMembers() — no directory API to stub, selection stays empty.
 // The dialog is an inline v-if overlay (not teleported), but we query `document` for robustness.
-// Left untouched per the classifier: the close-× glyph, chip-remove × glyphs, and the Clear button.
+//
+// UI-P2-1c T1 batch-5 (multitable-ui-p2-1c-tail-resolution-designlock-20260707.md §2-T1, RATIFIED):
+// the header close-× (`.meta-person-picker__close`) was additionally migrated from a bespoke
+// <button>&times;</button> to the shared MtIconButton primitive — the &times; glyph passes through
+// MtIconButton's default-slot icon fallback (glyph char preserved, size token-normalized to the icon
+// control, consistent with the existing glyph-MtIconButton controls already on main). Behavior-
+// preservation proof: it stays a native, keyboard-operable <button>, keeps the SAME aria-label
+// (`pp('personPicker.close')`), and clicking it still emits the SAME `close` event with no payload
+// (identical to the footer cancel button's handler). This is the only sharer of
+// `.meta-person-picker__close` (single button, single file) — its bespoke CSS was removed outright,
+// no double-styling risk.
+//
+// NOT migrated (classifier — verified against the handler, not the label): the per-chip
+// `.meta-person-picker__chip-remove` × glyph button (`@click="removeSelected(item.id)"`) is a
+// remove-selected-item control, not a close/dismiss — it stays a bespoke native <button>, out of
+// T1 scope. The positive-control test below proves it (a) still removes just that chip, (b) does
+// NOT emit `close`, and (c) is unaffected by the close-× migration.
 
 const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
 afterEach(() => {
@@ -27,9 +43,26 @@ function mount(props: Record<string, unknown>, handlers: Record<string, unknown>
   mounts.push({ app, container })
 }
 
+// Reactive `visible` ref so flipping false->true fires the non-immediate `watch(() => props.visible)`,
+// which is what actually populates `selected`/`summaryById` from `currentValue` — needed to render a
+// selected chip (and its chip-remove ×) for the positive-control test below.
+function mountWithVisibleToggle(extraProps: Record<string, unknown> = {}, handlers: Record<string, unknown> = {}) {
+  const container = document.createElement('div'); document.body.appendChild(container)
+  const visible = ref(false)
+  const Harness = defineComponent({
+    setup: () => () => h(MetaPersonPicker, { visible: visible.value, sheetId: 's1', ...extraProps, ...handlers }),
+  })
+  const app = createApp(Harness)
+  app.mount(container)
+  mounts.push({ app, container })
+  return { container, visible }
+}
+
 const baseProps = () => ({ visible: true, sheetId: 's1' })
+const closeBtn = () => document.querySelector('.meta-person-picker__close') as HTMLButtonElement
 const cancelBtn = () => document.querySelector('.meta-person-picker__cancel') as HTMLButtonElement
 const confirmBtn = () => document.querySelector('.meta-person-picker__confirm') as HTMLButtonElement
+const chipRemoveBtns = () => Array.from(document.querySelectorAll('.meta-person-picker__chip-remove')) as HTMLButtonElement[]
 
 describe('MetaPersonPicker — MtButton migration (UI-P2-1c)', () => {
   it('renders cancel + confirm as native, enabled <button>s (keyboard-operable, not bare divs)', () => {
@@ -57,5 +90,50 @@ describe('MetaPersonPicker — MtButton migration (UI-P2-1c)', () => {
     expect(onConfirm).toHaveBeenCalledTimes(1)
     // selection empty (loadMembers never ran) → onConfirm emits empty arrays, exactly as before
     expect(onConfirm).toHaveBeenCalledWith({ userIds: [], summaries: [] })
+  })
+
+  it('renders the header close-× as a native <button> (MtIconButton) keeping the class + aria-label + glyph', () => {
+    mount(baseProps())
+    const btn = closeBtn()
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('meta-person-picker__close')).toBe(true)
+    expect(btn.getAttribute('aria-label')).toBe('Close people picker')
+    expect(btn.textContent?.trim()).toBe('×') // × glyph char preserved (size token-normalized)
+  })
+
+  it('renders the localized (zh) aria-label unchanged', () => {
+    useLocale().setLocale('zh')
+    mount(baseProps())
+    expect(closeBtn().getAttribute('aria-label')).toBe('关闭人员选择器')
+  })
+
+  it('clicking the header close-× emits `close` (unchanged — same emit as the footer cancel button)', () => {
+    const onClose = vi.fn()
+    mount(baseProps(), { onClose })
+    closeBtn().click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
+  })
+
+  it('positive control: the per-chip remove-× is NOT the close-× — it stays a bespoke <button>, removes only that chip, and does NOT emit `close`', async () => {
+    const onClose = vi.fn()
+    const { visible, container } = mountWithVisibleToggle({ currentValue: ['u1', 'u2'] }, { onClose })
+    visible.value = true
+    await nextTick()
+
+    const chips = chipRemoveBtns()
+    expect(chips.length).toBe(2) // both stored ids rendered as chips (populated via the visible-toggle watcher)
+    chips.forEach((btn) => expect(btn.tagName).toBe('BUTTON'))
+
+    chips[0].click()
+    await nextTick()
+
+    // exactly one chip removed, the close handler was never invoked by this click
+    expect(chipRemoveBtns().length).toBe(1)
+    expect(onClose).not.toHaveBeenCalled()
+    // dialog itself is untouched by the removal — still mounted, close-× still present and functional
+    expect(container.querySelector('.meta-person-picker__close')).toBeTruthy()
+    closeBtn().click()
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/tests/scale-formatting-dialog-migration.spec.ts
+++ b/apps/web/tests/scale-formatting-dialog-migration.spec.ts
@@ -9,6 +9,20 @@ import { useLocale } from '../src/composables/useLocale'
 // migrated at once and the bespoke hex CSS removed (no double-styling) — mirrors ConditionalFormattingDialog.
 // Behavior-preservation proof: they stay native, keyboard-operable <button>s; :disabled bindings survive;
 // clicking still runs the same handlers / emits the same events.
+//
+// UI-P2-1c T1 batch-5 (multitable-ui-p2-1c-tail-resolution-designlock-20260707.md §2-T1, RATIFIED): the
+// header close-× (`.scf-dlg__close`) was additionally migrated from a bespoke <button>&times;</button>
+// to the shared MtIconButton primitive — the &times; glyph passes through MtIconButton's default-slot
+// icon fallback (glyph char preserved, size token-normalized to the icon control, consistent with the
+// existing glyph-MtIconButton controls already on main — this is the same class/handler shape as
+// ConditionalFormattingDialog's `.cf-dlg__close`, migrated in #4133). Behavior-preservation proof: it
+// stays a native, keyboard-operable <button>, keeps the SAME aria-label (`ml('formatting.close')`), and
+// clicking it still calls the SAME close() — including the window.confirm dirty-guard (verified below;
+// this dialog has no dedicated i18n spec exercising that path the way
+// conditional-formatting-dialog-i18n.spec.ts does for the CF twin, so the guard is asserted directly
+// here). This is the only sharer of `.scf-dlg__close` (single button, single file, no chip/remove ×
+// sibling exists on this dialog — verified via repo-wide grep) — its bespoke CSS was removed outright,
+// no double-styling risk.
 
 const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
 afterEach(() => {
@@ -30,6 +44,7 @@ const footerCancel = (r: HTMLElement) =>
 const footerSave = (r: HTMLElement) => r.querySelector('.scf-dlg__footer .scf-dlg__btn--primary') as HTMLButtonElement
 const addRuleBtn = (r: HTMLElement) =>
   Array.from(r.querySelectorAll('.scf-dlg__btn--primary')).find((b) => !b.closest('.scf-dlg__footer')) as HTMLButtonElement
+const closeBtn = (r: HTMLElement) => r.querySelector('.scf-dlg__close') as HTMLButtonElement
 
 describe('ScaleFormattingDialog — MtButton migration (UI-P2-1c)', () => {
   it('renders footer cancel/save + addRule as native <button>s; save disabled until a valid dirty rule', () => {
@@ -62,5 +77,46 @@ describe('ScaleFormattingDialog — MtButton migration (UI-P2-1c)', () => {
     removeBtn.click() // @click="removeRule(index)" preserved
     await nextTick()
     expect(root.querySelector('.scf-dlg__btn--danger')).toBeNull() // rule row gone
+  })
+
+  it('renders the header close-× as a native <button> (MtIconButton) keeping the class + aria-label + glyph', () => {
+    const root = mount(baseProps())
+    const btn = closeBtn(root)
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('scf-dlg__close')).toBe(true)
+    expect(btn.getAttribute('aria-label')).toBe('Close')
+    expect(btn.textContent?.trim()).toBe('×') // × glyph char preserved (size token-normalized)
+  })
+
+  it('clicking the header close-× on a clean (non-dirty) dialog emits `close` (unchanged — same close() as footer cancel)', () => {
+    const onClose = vi.fn()
+    const root = mount(baseProps(), { onClose })
+    closeBtn(root).click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
+  })
+
+  it('clicking the header close-× on a dirty dialog still routes through the SAME window.confirm dirty-guard (declined → no close)', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const onClose = vi.fn()
+    const root = mount(baseProps(), { onClose })
+    addRuleBtn(root).click() // makes the draft dirty
+    await nextTick()
+    closeBtn(root).click()
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled() // guard declined → close() returns early, unchanged behavior
+    confirmSpy.mockRestore()
+  })
+
+  it('clicking the header close-× on a dirty dialog emits `close` once the SAME window.confirm dirty-guard is accepted', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const onClose = vi.fn()
+    const root = mount(baseProps(), { onClose })
+    addRuleBtn(root).click() // makes the draft dirty
+    await nextTick()
+    closeBtn(root).click()
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledTimes(1)
+    confirmSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## What changed

T1 batch-5 of `docs/development/multitable-ui-p2-1c-tail-resolution-designlock-20260707.md` §2-T1 (RATIFIED — owner directive 2026-07-11). Migrates the header close-× glyph button in 3 components from a bespoke `<button>&times;</button>` to the shared `MtIconButton` primitive (`apps/web/src/multitable/ui`, imported via the existing barrel idiom used by #4130/#4133/#4174):

| File | Class | Handler |
|---|---|---|
| `apps/web/src/multitable/components/MetaPersonPicker.vue` | `.meta-person-picker__close` | `@click="emit('close')"` |
| `apps/web/src/multitable/components/MetaLinkPicker.vue` | `.meta-link-picker__close` | `@click="emit('close')"` |
| `apps/web/src/multitable/components/ScaleFormattingDialog.vue` | `.scf-dlg__close` | `@click="close"` (local fn: `if (dirty.value && !window.confirm(...)) return; emit('close')`) |

Only the header close-× in each file was touched.

## × buttons NOT migrated, and why (classifier — verified against the handler, not the label)

The lock defines T1 narrowly as the close/dismiss glyph button. Two of the three files also contain a **second** `×`-glyph button that is **not** a close/dismiss control — it removes one selected chip:

| File | Class | Handler | Why out of scope |
|---|---|---|---|
| `MetaPersonPicker.vue` | `.meta-person-picker__chip-remove` | `@click="removeSelected(item.id)"` | Removes one selected person from the in-progress selection; does not close the dialog or emit `close`. Remove-item control, not dismiss. |
| `MetaLinkPicker.vue` | `.meta-link-picker__chip-remove` | `@click="removeSelected(item.id)"` | Same shape — removes one selected linked record; does not close the dialog or emit `close`. |

`ScaleFormattingDialog.vue` has only the one `×` (the close-×) — verified via repo-wide grep for `&times;`/`×` in the file; no remove-item sibling exists there (its per-rule "remove" control is a text-labeled `MtButton variant="danger"`, already migrated in #3850, unaffected here).

Both chip-remove buttons remain bespoke native `<button>`s, byte-identical to `origin/main`. The positive-control tests below prove they still remove exactly one chip, never emit `close`, and are unaffected by the close-× migration.

## Honest visual delta (not zero-visual-change — per #4133's precedent, don't claim it is)

None of the three original close-× rules had a hover or focus state:
- `.meta-person-picker__close` / `.meta-link-picker__close`: `border: none; background: none; font-size: 20px; cursor: pointer; color: #999;` — no padding rule, no hover, no focus-visible state, box sized purely by the 20px glyph + browser default button padding.
- `.scf-dlg__close`: same, plus `padding: 0 4px;`.

Post-migration, all three render as `MtIconButton` (`variant="ghost"` default, `size="md"` default):
- Fixed square control box: `width: var(--ms-control-height)`, `padding: 0 !important` (overrides `MtButton`'s own padding).
- Token-driven hover/active states and a visible `outline` on keyboard focus — none of the three bespoke buttons had any focus indicator before.
- The `×` glyph char itself is unchanged (passed through via the default slot → `MtIconButton`'s `icon` slot fallback), but its size is no longer an independent per-component `font-size: 20px` — it now inherits the shared icon-button control sizing.

## Emit-conservation argument

Byte-conserved: same event names, same payloads, same order, same guard logic.
- `MetaPersonPicker` / `MetaLinkPicker`: `@click="emit('close')"` is unchanged — the exact same inline expression, now bound on `<MtIconButton>` instead of `<button>`. No new event surface.
- `ScaleFormattingDialog`: `@click="close"` still points at the same `close()` function, including its `window.confirm` dirty-guard (`if (dirty.value && !window.confirm(ml('view.discardFormattingConfirm'))) return`) — verified directly (this dialog has no dedicated i18n spec exercising that path the way `conditional-formatting-dialog-i18n.spec.ts` does for its CF twin, so the guard is asserted in the migration spec itself; see test evidence below).

No new props, no new emits, no new primitive semantics — `MtIconButton` is used with only `class` / `aria-label` / `@click` / default slot, all pre-existing on the `ui/` barrel.

## Classes: survived vs removed

All three close-× classes are the **sole sharer** in their file (verified via repo-wide grep — no other `.vue`/`.ts` references besides the element itself and read-only test selectors):
- The class is **kept on the element** (`<MtIconButton class="...">`, Vue's attr-fallthrough merges it onto the underlying native `<button>`) — purely for selector stability (existing suites like `multitable-link-picker.spec.ts` / `meta-link-picker-i18n.spec.ts` query these classes directly and stay green unmodified).
- The bespoke hardcoded CSS rule for each class was **deleted outright** (no orphan CSS, no double-styling risk) and replaced with a one-line comment pointing at the new primitive, matching the #4130/#4133/#4174 comment convention.

No new hardcoded hex was introduced — all three CSS diffs are deletions/comment-only (`git diff` verified, token-only styling now comes from `MtIconButton`/`MtButton`'s own `--ms-*` rules).

## Test evidence

Extended the existing per-component `*-migration.spec.ts` files (same convention as #4130/#4133/#4174) with: a render-shape assertion (native `<button>`, class retained, aria-label retained incl. zh locale, `×` glyph text preserved), a real-click emit assertion, and — where applicable — a positive-control assertion for the button(s) left untouched.

```
pnpm --filter @metasheet/web exec vitest run meta-meta-person-picker-migration meta-meta-link-picker-migration scale-formatting-dialog-migration multitable-person-picker multitable-link-picker multitable-crossbase-link-picker meta-link-picker-i18n meta-link-picker-labels multitable-cf-scale multitable-view-manager-scale scale-formatting-dialog conditional-formatting-dialog-migration --reporter=dot

 Test Files  12 passed (12)
      Tests  93 passed (93)
```

`vue-tsc -b` (the repo's `type-check` script): clean, exit 0.

## Mutation-red evidence (per migrated close-×, done serially: commit baseline first → mutate → red → `git checkout -- <file>` restore from the committed baseline)

1. **MetaPersonPicker** — removed `@click="emit('close')"` from the close-× → 2 tests failed: `clicking the header close-× emits 'close'` (`expected "spy" to be called 1 times, but got 0 times`) and the positive-control test's tail assertion (same failure — proving the positive control's final "close still works" check is load-bearing, not decorative). Restored via `git checkout -- apps/web/src/multitable/components/MetaPersonPicker.vue`; `git diff --stat` empty after.
2. **MetaLinkPicker** — same mutation, same 2 failures, same restore. `git diff --stat` empty after.
3. **ScaleFormattingDialog** — removed `@click="close"` from the close-× → 3 tests failed: the clean-dialog emit test AND both dirty-guard tests (`expected "spy"/"bound " to be called 1 times, but got 0 times` — the dirty-guard tests independently prove the mutation, since `window.confirm` is never reached without the `@click` wired). Restored via `git checkout -- apps/web/src/multitable/components/ScaleFormattingDialog.vue`; `git diff --stat` empty after.

Each mutation was applied against the already-committed baseline (safe — nothing unstaged to lose) and restored precisely; full 93-test suite re-run green after all three restores.

## CI wiring — empirically confirmed, not just reasoned

`multitable-web-guard.yml`'s `on.pull_request.paths` (and `on.push.branches:[main].paths`) already has a wildcard `apps/web/tests/*-migration.spec.ts` filter that matches the 3 spec files this PR touches, and its `vitest run` filter list (the exact line the CI job runs) already includes the bare keyword `migration`, which vitest matches as a substring against spec file paths. Neither needed editing.

This was verified empirically, not just by reading the YAML: I ran the **exact** `vitest run <44-item filter list>` line from the workflow's `Run multitable web guard specs (targeted)` step against this branch and grepped the output for the three new/extended spec files — all 20 of their test cases (7 + 6 + 7) appear and pass:

```
grep -E "person-picker-migration|link-picker-migration|scale-formatting-dialog-migration" <output>
 ✓ tests/meta-meta-link-picker-migration.spec.ts > ... (6 tests, all ✓)
 ✓ tests/meta-meta-person-picker-migration.spec.ts > ... (7 tests, all ✓)
 ✓ tests/scale-formatting-dialog-migration.spec.ts > ... (7 tests, all ✓)
```

Note: that same 44-file combined local run exited non-zero overall, but the failures are in 3 unrelated spec files this PR never touches (`multitable-automation-manager.spec.ts`, `multitable-automation-rule-editor.spec.ts`, `multitable-workbench-history-field-scope-wiring.spec.ts`) — confirmed to be a local resource-contention artifact of running ~44 spec files concurrently in this sandbox, not a regression: each of those 3 files passes cleanly (206/206, then 6/6) when re-run in isolation / smaller batches on this same branch. Flagging this transparently rather than silently re-running until green.

## Scope discipline

Read design-lock §2-T1 + `gh pr diff 4130`/`4133`/`4174` before starting. Did not touch: the chip-remove × buttons (see table above), the footer cancel/confirm buttons in the two pickers (already `MtButton`, #3835/#3836), the footer/addRule/per-rule buttons in ScaleFormattingDialog (already `MtButton`, #3850), any permission/selection/business logic, and no file outside the 6 listed in `git diff --stat` (3 components + 3 test files). No new hardcoded hex (CSS diffs are deletions only). No `MtButton`/`MtIconButton` primitive extension — used exactly as it ships on `main`.

Nothing to report as "stopped on" beyond the classifier call above (both remove-× buttons were unambiguous once the handler was read — neither closes/dismisses anything).

refs docs/development/multitable-ui-p2-1c-tail-resolution-designlock-20260707.md §2-T1

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
