### PR TITLE
refactor(multitable): UI-P2-1c T1 — picker + scale-dialog close-× → MtIconButton

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -145,6 +145,13 @@ on:
       # run-required-web-tests.sh) is wired separately in #4156; this is the advisory-guard half of
       # the same fix.
       - 'apps/web/src/multitable/ui/**'
+      # UI-P2-1c T1 batch-3: MetaPersonPicker/MetaLinkPicker/ScaleFormattingDialog's header close-×
+      # migrated to MtIconButton. Their `*-migration.spec.ts` files are covered by the wildcard
+      # above, but (per the R5c/T3-T4-T5 CI-residual precedent) the .vue sources themselves had NO
+      # path trigger — a PR touching only e.g. ScaleFormattingDialog.vue would run no web-guard.
+      - 'apps/web/src/multitable/components/MetaPersonPicker.vue'
+      - 'apps/web/src/multitable/components/MetaLinkPicker.vue'
+      - 'apps/web/src/multitable/components/ScaleFormattingDialog.vue'
       # Formula catalog parity (12 scalar functions): web-side intent specs (12-present /
       # COUNTIF-absent, 1a scalar-set, i18n labels, editor diagnostics incl. arity table)
       - 'apps/web/src/multitable/utils/formula-docs.ts'
@@ -277,6 +284,13 @@ on:
       # run-required-web-tests.sh) is wired separately in #4156; this is the advisory-guard half of
       # the same fix.
       - 'apps/web/src/multitable/ui/**'
+      # UI-P2-1c T1 batch-3: MetaPersonPicker/MetaLinkPicker/ScaleFormattingDialog's header close-×
+      # migrated to MtIconButton. Their `*-migration.spec.ts` files are covered by the wildcard
+      # above, but (per the R5c/T3-T4-T5 CI-residual precedent) the .vue sources themselves had NO
+      # path trigger — a PR touching only e.g. ScaleFormattingDialog.vue would run no web-guard.
+      - 'apps/web/src/multitable/components/MetaPersonPicker.vue'
+      - 'apps/web/src/multitable/components/MetaLinkPicker.vue'
+      - 'apps/web/src/multitable/components/ScaleFormattingDialog.vue'
       # Formula catalog parity (12 scalar functions): web-side intent specs (12-present /
       # COUNTIF-absent, 1a scalar-set, i18n labels, editor diagnostics incl. arity table)
       - 'apps/web/src/multitable/utils/formula-docs.ts'

--- a/apps/web/src/multitable/components/MetaLinkPicker.vue
+++ b/apps/web/src/multitable/components/MetaLinkPicker.vue
@@ -3,7 +3,7 @@
     <div class="meta-link-picker" @keydown.esc.stop.prevent="emit('close')" @keydown.enter.stop.prevent="onConfirm">
       <div class="meta-link-picker__header">
         <h4 class="meta-link-picker__title">{{ titleText }}</h4>
-        <button class="meta-link-picker__close" :aria-label="lp('linkPicker.close')" @click="emit('close')">&times;</button>
+        <MtIconButton class="meta-link-picker__close" :aria-label="lp('linkPicker.close')" @click="emit('close')">&times;</MtIconButton>
       </div>
       <div class="meta-link-picker__search">
         <input v-model="search" class="meta-link-picker__input" :placeholder="searchPlaceholder" @input="onSearch" />
@@ -46,7 +46,7 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
-import { MtButton } from '../ui'
+import { MtButton, MtIconButton } from '../ui'
 import type { LinkedRecordSummary, MetaField } from '../types'
 import { multitableClient } from '../api/client'
 import { linkPickerSearchPlaceholder, linkPickerTitle } from '../utils/link-fields'
@@ -172,7 +172,10 @@ function onConfirm() {
 .meta-link-picker { width: 480px; max-height: 70vh; background: #fff; border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,.15); display: flex; flex-direction: column; }
 .meta-link-picker__header { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; border-bottom: 1px solid #eee; }
 .meta-link-picker__title { font-size: 14px; font-weight: 600; margin: 0; }
-.meta-link-picker__close { border: none; background: none; font-size: 20px; cursor: pointer; color: #999; }
+/* .meta-link-picker__close: now <MtIconButton> (ghost, token-styled; the &times; glyph char
+   passes through its default-slot icon fallback, size token-normalized to the icon control).
+   Bespoke hardcoded CSS removed (UI-P2-1c T1 batch-3). Class kept on the element only for
+   selector stability. */
 .meta-link-picker__search { padding: 8px 16px; }
 .meta-link-picker__input { width: 100%; padding: 6px 10px; border: 1px solid #ddd; border-radius: 4px; font-size: 13px; }
 .meta-link-picker__selected { padding: 0 16px 8px; border-bottom: 1px solid #f0f0f0; }

--- a/apps/web/src/multitable/components/MetaPersonPicker.vue
+++ b/apps/web/src/multitable/components/MetaPersonPicker.vue
@@ -3,7 +3,7 @@
     <div class="meta-person-picker" @keydown.esc.stop.prevent="emit('close')" @keydown.enter.stop.prevent="onConfirm">
       <div class="meta-person-picker__header">
         <h4 class="meta-person-picker__title">{{ titleText }}</h4>
-        <button class="meta-person-picker__close" :aria-label="pp('personPicker.close')" @click="emit('close')">&times;</button>
+        <MtIconButton class="meta-person-picker__close" :aria-label="pp('personPicker.close')" @click="emit('close')">&times;</MtIconButton>
       </div>
       <div class="meta-person-picker__search">
         <input v-model="search" class="meta-person-picker__input" :placeholder="searchPlaceholder" @input="onSearch" />
@@ -44,7 +44,7 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
-import { MtButton } from '../ui'
+import { MtButton, MtIconButton } from '../ui'
 import type { MetaField, PersonSummary } from '../types'
 import { multitableClient } from '../api/client'
 import { isPersonSingleRecordField } from '../utils/person-fields'
@@ -186,7 +186,10 @@ function onConfirm() {
 .meta-person-picker { width: 480px; max-height: 70vh; background: #fff; border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,.15); display: flex; flex-direction: column; }
 .meta-person-picker__header { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; border-bottom: 1px solid #eee; }
 .meta-person-picker__title { font-size: 14px; font-weight: 600; margin: 0; }
-.meta-person-picker__close { border: none; background: none; font-size: 20px; cursor: pointer; color: #999; }
+/* .meta-person-picker__close: now <MtIconButton> (ghost, token-styled; the &times; glyph char
+   passes through its default-slot icon fallback, size token-normalized to the icon control).
+   Bespoke hardcoded CSS removed (UI-P2-1c T1 batch-3). Class kept on the element only for
+   selector stability. */
 .meta-person-picker__search { padding: 8px 16px; }
 .meta-person-picker__input { width: 100%; padding: 6px 10px; border: 1px solid #ddd; border-radius: 4px; font-size: 13px; }
 .meta-person-picker__selected { padding: 0 16px 8px; border-bottom: 1px solid #f0f0f0; }

--- a/apps/web/src/multitable/components/ScaleFormattingDialog.vue
+++ b/apps/web/src/multitable/components/ScaleFormattingDialog.vue
@@ -4,7 +4,7 @@
       <div class="scf-dlg__header">
         <h4 class="scf-dlg__title">{{ ml('formatting.scaleTitle') }}</h4>
         <span class="scf-dlg__count">{{ draftRules.length }} / {{ ruleLimit }}</span>
-        <button class="scf-dlg__close" :aria-label="ml('formatting.close')" @click="close">&times;</button>
+        <MtIconButton class="scf-dlg__close" :aria-label="ml('formatting.close')" @click="close">&times;</MtIconButton>
       </div>
       <div class="scf-dlg__body">
         <p v-if="!draftRules.length" class="scf-dlg__empty">{{ ml('formatting.scaleEmpty') }}</p>
@@ -282,7 +282,7 @@ import { CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT } from '../types'
 import { HEX_COLOR_RE, extractScaleRulesFromConfig, lerpHexColor } from '../utils/conditional-formatting'
 import { SCALE_ICON_GLYPHS, type ScaleIconGlyph } from '../utils/scale-icons'
 import { formattingPickColor, managerLabel } from '../utils/meta-manager-labels'
-import { MtButton } from '../ui'
+import { MtButton, MtIconButton } from '../ui'
 
 const props = defineProps<{
   visible: boolean
@@ -549,7 +549,9 @@ function save() {
 .scf-dlg__header { display: flex; align-items: center; gap: 12px; padding: 12px 16px; border-bottom: 1px solid #eee; }
 .scf-dlg__title { flex: 1; font-size: 15px; font-weight: 600; margin: 0; }
 .scf-dlg__count { font-size: 12px; color: #666; }
-.scf-dlg__close { border: none; background: none; font-size: 20px; cursor: pointer; color: #999; padding: 0 4px; }
+/* .scf-dlg__close: now <MtIconButton> (ghost, token-styled; the &times; glyph char passes through
+   its default-slot icon fallback, size token-normalized to the icon control). Bespoke hardcoded
+   CSS removed (UI-P2-1c T1 batch-3). Class kept on the element only for selector stability. */
 .scf-dlg__body { flex: 1; overflow-y: auto; padding: 12px 16px; display: flex; flex-direction: column; gap: 12px; }
 .scf-dlg__empty { font-size: 13px; color: #777; margin: 0; }
 .scf-dlg__rule-list { display: flex; flex-direction: column; gap: 10px; }

--- a/apps/web/tests/meta-meta-link-picker-migration.spec.ts
+++ b/apps/web/tests/meta-meta-link-picker-migration.spec.ts
@@ -10,6 +10,16 @@ import { useLocale } from '../src/composables/useLocale'
 // emits `close`; and clicking confirm still invokes onConfirm and emits `confirm` with the SAME
 // { recordIds, summaries } payload as before. This picker renders its own overlay inline (no
 // Teleport), but the residue guard still queries `document` for robustness.
+//
+// UI-P2-1c T1 batch-3: the header close-× (`.meta-link-picker__close`) was ALSO migrated, from a
+// bespoke <button>&times;</button> to the shared MtIconButton primitive (T1 design-lock recommendation:
+// keep the &times; glyph, only collapse padding/hover/focus-ring onto tokens — token-normalized, not
+// zero-visual-change; see #4130/#4133 wording precedent). It stays a native, keyboard-operable
+// <button>, keeps the SAME aria-label (`lp('linkPicker.close')`) and the SAME @click="emit('close')"
+// (no payload). `.meta-link-picker__close` is the sole sharer of that class in this file — its
+// bespoke CSS was removed outright (no double-styling risk).
+// Left untouched per the classifier: the chip-remove × glyphs (`@click="removeSelected(id)"` — a
+// "remove this chip" action, not a dismiss/close) and the Clear/Load-more buttons stay bespoke.
 
 const { mockListLinkOptions } = vi.hoisted(() => ({ mockListLinkOptions: vi.fn() }))
 vi.mock('../src/multitable/api/client', () => ({
@@ -46,6 +56,7 @@ function mount(extraProps: Record<string, unknown> = {}, handlers: Record<string
 
 const cancelBtn = () => document.querySelector('.meta-link-picker__cancel') as HTMLButtonElement
 const confirmBtn = () => document.querySelector('.meta-link-picker__confirm') as HTMLButtonElement
+const closeBtn = () => document.querySelector('.meta-link-picker__close') as HTMLButtonElement
 
 describe('MetaLinkPicker — MtButton migration (UI-P2-1c)', () => {
   it('renders footer cancel + confirm as native <button>s (keyboard-operable, classes preserved)', async () => {
@@ -95,5 +106,38 @@ describe('MetaLinkPicker — MtButton migration (UI-P2-1c)', () => {
       recordIds: ['vendor_1'],
       summaries: [{ id: 'vendor_1', display: 'Acme Supply' }],
     })
+  })
+
+  it('T1 batch-3: renders the header close-× as a native <button> (MtIconButton) keeping class + aria-label + glyph', async () => {
+    useLocale().setLocale('en')
+    mockListLinkOptions.mockResolvedValue({ selected: [], records: [], page: { offset: 0, limit: 50, total: 0, hasMore: false } })
+    const { visible } = mount()
+    visible.value = true
+    await flushPromises()
+    const btn = closeBtn()
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('meta-link-picker__close')).toBe(true)
+    expect(btn.getAttribute('aria-label')).toBe('Close link picker')
+    expect(btn.textContent?.trim()).toBe('×')
+  })
+
+  it('T1 batch-3: renders the localized (zh) aria-label unchanged on the close-×', async () => {
+    useLocale().setLocale('zh')
+    mockListLinkOptions.mockResolvedValue({ selected: [], records: [], page: { offset: 0, limit: 50, total: 0, hasMore: false } })
+    const { visible } = mount()
+    visible.value = true
+    await flushPromises()
+    expect(closeBtn().getAttribute('aria-label')).toBe('关闭关联记录选择器')
+  })
+
+  it('T1 batch-3: clicking the header close-× emits `close` with no payload (unchanged from pre-migration @click="emit(\'close\')")', async () => {
+    mockListLinkOptions.mockResolvedValue({ selected: [], records: [], page: { offset: 0, limit: 50, total: 0, hasMore: false } })
+    const onClose = vi.fn()
+    const { visible } = mount({}, { onClose })
+    visible.value = true
+    await flushPromises()
+    closeBtn().click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
   })
 })

--- a/apps/web/tests/meta-meta-person-picker-migration.spec.ts
+++ b/apps/web/tests/meta-meta-person-picker-migration.spec.ts
@@ -11,7 +11,16 @@ import { useLocale } from '../src/composables/useLocale'
 // pre-migration onConfirm. The `watch(() => props.visible, …)` is non-immediate, so mounting with
 // visible:true does NOT trigger loadMembers() — no directory API to stub, selection stays empty.
 // The dialog is an inline v-if overlay (not teleported), but we query `document` for robustness.
-// Left untouched per the classifier: the close-× glyph, chip-remove × glyphs, and the Clear button.
+//
+// UI-P2-1c T1 batch-3: the header close-× (`.meta-person-picker__close`) was ALSO migrated, from a
+// bespoke <button>&times;</button> to the shared MtIconButton primitive (T1 design-lock recommendation:
+// keep the &times; glyph, only collapse padding/hover/focus-ring onto tokens — token-normalized, not
+// zero-visual-change; see #4130/#4133 wording precedent). It stays a native, keyboard-operable
+// <button>, keeps the SAME aria-label (`pp('personPicker.close')`) and the SAME @click="emit('close')"
+// (no payload). `.meta-person-picker__close` is the sole sharer of that class in this file — its
+// bespoke CSS was removed outright (no double-styling risk).
+// Left untouched per the classifier: the chip-remove × glyphs (`@click="removeSelected(id)"` — a
+// "remove this chip" action, not a dismiss/close — and the Clear button) stay bespoke <button>s.
 
 const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
 afterEach(() => {
@@ -30,6 +39,7 @@ function mount(props: Record<string, unknown>, handlers: Record<string, unknown>
 const baseProps = () => ({ visible: true, sheetId: 's1' })
 const cancelBtn = () => document.querySelector('.meta-person-picker__cancel') as HTMLButtonElement
 const confirmBtn = () => document.querySelector('.meta-person-picker__confirm') as HTMLButtonElement
+const closeBtn = () => document.querySelector('.meta-person-picker__close') as HTMLButtonElement
 
 describe('MetaPersonPicker — MtButton migration (UI-P2-1c)', () => {
   it('renders cancel + confirm as native, enabled <button>s (keyboard-operable, not bare divs)', () => {
@@ -57,5 +67,29 @@ describe('MetaPersonPicker — MtButton migration (UI-P2-1c)', () => {
     expect(onConfirm).toHaveBeenCalledTimes(1)
     // selection empty (loadMembers never ran) → onConfirm emits empty arrays, exactly as before
     expect(onConfirm).toHaveBeenCalledWith({ userIds: [], summaries: [] })
+  })
+
+  it('T1 batch-3: renders the header close-× as a native <button> (MtIconButton) keeping class + aria-label + glyph', () => {
+    useLocale().setLocale('en')
+    mount(baseProps())
+    const btn = closeBtn()
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('meta-person-picker__close')).toBe(true)
+    expect(btn.getAttribute('aria-label')).toBe('Close people picker')
+    expect(btn.textContent?.trim()).toBe('×')
+  })
+
+  it('T1 batch-3: renders the localized (zh) aria-label unchanged on the close-×', () => {
+    useLocale().setLocale('zh')
+    mount(baseProps())
+    expect(closeBtn().getAttribute('aria-label')).toBe('关闭人员选择器')
+  })
+
+  it('T1 batch-3: clicking the header close-× emits `close` with no payload (unchanged from pre-migration @click="emit(\'close\')")', () => {
+    const onClose = vi.fn()
+    mount(baseProps(), { onClose })
+    closeBtn().click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
   })
 })

--- a/apps/web/tests/scale-formatting-dialog-migration.spec.ts
+++ b/apps/web/tests/scale-formatting-dialog-migration.spec.ts
@@ -9,6 +9,15 @@ import { useLocale } from '../src/composables/useLocale'
 // migrated at once and the bespoke hex CSS removed (no double-styling) — mirrors ConditionalFormattingDialog.
 // Behavior-preservation proof: they stay native, keyboard-operable <button>s; :disabled bindings survive;
 // clicking still runs the same handlers / emits the same events.
+//
+// UI-P2-1c T1 batch-3: the header close-× (`.scf-dlg__close`) was ALSO migrated, from a bespoke
+// <button>&times;</button> to the shared MtIconButton primitive (T1 design-lock recommendation: keep
+// the &times; glyph, only collapse padding/hover/focus-ring onto tokens — token-normalized, not
+// zero-visual-change; see #4130/#4133 wording precedent). It stays a native, keyboard-operable
+// <button>, keeps the SAME aria-label (`ml('formatting.close')`) and the SAME @click="close" — the
+// local `close()` function (unsaved-dirty confirm guard, then `emit('close')`), unchanged by this
+// migration. `.scf-dlg__close` is the sole sharer of that class in this file — its bespoke CSS was
+// removed outright (no double-styling risk).
 
 const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
 afterEach(() => {
@@ -30,6 +39,7 @@ const footerCancel = (r: HTMLElement) =>
 const footerSave = (r: HTMLElement) => r.querySelector('.scf-dlg__footer .scf-dlg__btn--primary') as HTMLButtonElement
 const addRuleBtn = (r: HTMLElement) =>
   Array.from(r.querySelectorAll('.scf-dlg__btn--primary')).find((b) => !b.closest('.scf-dlg__footer')) as HTMLButtonElement
+const headerCloseBtn = (r: HTMLElement) => r.querySelector('.scf-dlg__close') as HTMLButtonElement
 
 describe('ScaleFormattingDialog — MtButton migration (UI-P2-1c)', () => {
   it('renders footer cancel/save + addRule as native <button>s; save disabled until a valid dirty rule', () => {
@@ -62,5 +72,30 @@ describe('ScaleFormattingDialog — MtButton migration (UI-P2-1c)', () => {
     removeBtn.click() // @click="removeRule(index)" preserved
     await nextTick()
     expect(root.querySelector('.scf-dlg__btn--danger')).toBeNull() // rule row gone
+  })
+
+  it('T1 batch-3: renders the header close-× as a native <button> (MtIconButton) keeping class + aria-label + glyph', () => {
+    useLocale().setLocale('en')
+    const root = mount(baseProps())
+    const btn = headerCloseBtn(root)
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('scf-dlg__close')).toBe(true)
+    expect(btn.getAttribute('aria-label')).toBe('Close')
+    expect(btn.textContent?.trim()).toBe('×')
+  })
+
+  it('T1 batch-3: renders the localized (zh) aria-label unchanged on the close-×', () => {
+    useLocale().setLocale('zh')
+    const root = mount(baseProps())
+    expect(headerCloseBtn(root).getAttribute('aria-label')).toBe('关闭')
+  })
+
+  it('T1 batch-3: clicking the header close-× on a clean (non-dirty) dialog emits `close` with no payload (unchanged @click="close")', () => {
+    useLocale().setLocale('en')
+    const onClose = vi.fn()
+    const root = mount(baseProps(), { onClose })
+    headerCloseBtn(root).click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
   })
 })


### PR DESCRIPTION
## What changed

T1 of `docs/development/multitable-ui-p2-1c-tail-resolution-designlock-20260707.md` §2-T1 (RATIFIED — owner directive 2026-07-11). Migrates the header close-× glyph button in 3 components from a bespoke `<button>&times;</button>` to the shared `MtIconButton` primitive:

| File | Class | Handler |
|---|---|---|
| `apps/web/src/multitable/components/MetaPersonPicker.vue` | `.meta-person-picker__close` | `@click="emit('close')"` |
| `apps/web/src/multitable/components/MetaLinkPicker.vue` | `.meta-link-picker__close` | `@click="emit('close')"` |
| `apps/web/src/multitable/components/ScaleFormattingDialog.vue` | `.scf-dlg__close` | `@click="close"` (local fn: `if (dirty.value && !window.confirm(...)) return; emit('close')`) |

Only the close-× glyph button in each was touched. All three imported `MtButton`/`MtIconButton`'s barrel (`../ui`) already — only the import line and the one `<button>`→`<MtIconButton>` tag swap changed per file.

## Scope correction — 2 files dropped mid-task

This task was originally assigned 5 components (adding `RestorePreviewDialog.vue` + `RestoreBatchDialog.vue`). Before making any edit, I checked for parallel work per repo discipline and found:
- An **open** PR #4174 ("T1 batch-4") already migrates the close-× in `RestorePreviewDialog.vue` and `RestoreBatchDialog.vue` (plus `ResetConfirmDialog.vue`), with matching class names and the same T1 approach.
- `origin/main` still had the bespoke buttons in both files (confirmed unmerged), so this is live, not stale.

I never touched either file — no edits, no spec changes — to avoid duplicating #4174's work and guaranteeing a merge conflict. **This PR's real scope is the 3 remaining components above.** If #4174 is ever abandoned or reverted, `RestorePreviewDialog.vue` / `RestoreBatchDialog.vue` still need their T1 close-× migration — that work is not done anywhere else once #4174's fate is unresolved.

## Left untouched — chip-remove is NOT a close button

`MetaPersonPicker.vue` and `MetaLinkPicker.vue` each have a **second** `×` glyph, the chip-remove button (`.meta-person-picker__chip-remove` / `.meta-link-picker__chip-remove`, `@click="removeSelected(item.id)"`). This removes one selected chip, not the dialog — it is explicitly out of T1 scope per the design-lock's own "not every × is a close button" caveat, and stays bespoke, untouched.

## Byte-equivalence

Each migrated control:
- Stays a native, keyboard-operable `<button>` (`MtIconButton` → `MtButton`'s root element).
- Keeps the exact same `class` (verified sole-sharer via repo-wide grep — no other `.vue`/`.ts` references any of the 3 classes outside their own file/tests).
- Keeps the exact same `:aria-label` binding (`pp('personPicker.close')` / `lp('linkPicker.close')` / `ml('formatting.close')`) — unchanged label-lookup calls.
- Keeps the exact same `@click` handler expression — `emit('close')` ×2, `close` (unmodified local fn) for ScaleFormattingDialog.
- Renders the identical `&times;` glyph text via `MtIconButton`'s default-slot → `#icon` slot fallback.

No `@click`/emit/aria-label/`:disabled`/`data-*` touched beyond the tag swap; no business/permission/deletion/AI logic touched.

## Honest visual delta (not "zero visual change")

Per #4130/#4133 precedent: `MtIconButton` normalizes the `×` glyph to the icon-token size (14px) inside a control-height (32px) square, replacing each dialog's previously independent `font-size: 20px` glyph with token-driven sizing, and adds `--ms-*` hover/focus-visible states none of the three had before (a visible keyboard focus ring now appears). Headers grow slightly to accommodate the control-height square. This is **token-normalized**, consistent with the glyph-MtIconButton look already on main — expected, not a regression.

## Classes: kept, CSS: removed

Each of the 3 close-× classes is the **sole sharer** in its file (grep-verified), so:
- The class stays on the element (via `MtIconButton`'s `class` attr fallthrough) for selector stability — existing regression specs (`multitable-person-picker.spec.ts`, `multitable-link-picker.spec.ts`, `meta-link-picker-i18n.spec.ts`, `scale-formatting-dialog.spec.ts`) query these classes directly and stay green unmodified.
- The bespoke hardcoded CSS rule for each class was deleted outright (no orphan CSS, no double-styling) and replaced with a one-line comment, matching the #4130/#4133/#4174 comment convention.

No new hardcoded hex introduced — CSS changes are deletions only. No new `MtIconButton`/`MtButton` variant, size, or prop was added — both existing props (`class`, `:aria-label`, `@click`, default slot) covered every case; nothing to stop on.

## Tests

New tests added to the existing per-component `*-migration.spec.ts` files (extending, not duplicating — same convention as prior batches, since all 3 already had migration specs from an earlier MtButton footer-button slice):

- `apps/web/tests/meta-meta-person-picker-migration.spec.ts` (+3 tests): render shape (native `<button>`, class, aria-label, glyph), zh aria-label, click→`close` emit (no payload).
- `apps/web/tests/meta-meta-link-picker-migration.spec.ts` (+3 tests): same shape, driven through the existing `visible`-toggle harness (the component's directory-load watcher is non-immediate).
- `apps/web/tests/scale-formatting-dialog-migration.spec.ts` (+3 tests): same shape; click test runs against the clean (non-dirty) baseline so the `close()` guard's `window.confirm` branch isn't exercised.

All anchor on `data-*`-adjacent stable class selectors (`.meta-person-picker__close`, `.meta-link-picker__close`, `.scf-dlg__close`), real `createApp`/`mount` + real DOM `.click()` (no `wrapper.vm.$emit` bypass, no optional-chained `?.click()`).

```
pnpm --filter @metasheet/web exec vitest run meta-meta-person-picker-migration meta-meta-link-picker-migration \
  scale-formatting-dialog-migration multitable-person-picker multitable-link-picker meta-link-picker-i18n \
  meta-link-picker-labels scale-formatting-dialog.spec --reporter=dot

 Test Files  8 passed (8)
      Tests  46 passed (46)
```

`vue-tsc -b`: clean, no errors.

## Mutation-red evidence (per migrated close-×, baseline committed first, restored via `git checkout -- <file>`)

1. **MetaPersonPicker** — dropped `@click="emit('close')"` from the close-× → `T1 batch-3: clicking the header close-× emits \`close\`...` failed: `expected "spy" to be called 1 times, but got 0 times`. Restored, re-verified green.
2. **MetaLinkPicker** — same mutation → same test failed the same way. Restored, re-verified green.
3. **ScaleFormattingDialog** — dropped `@click="close"` from the close-× → its close-× click test failed the same way. Restored, re-verified green.

Each mutation was applied against the already-committed baseline commit and restored via `git checkout -- <file>` (safe — baseline was committed before mutating). Full 8-file/46-test suite re-confirmed green after each restore, and once more after a rebase onto latest `origin/main`.

## CI wiring (two-point, verified — not just triggered)

1. **Vitest token list** — `apps/web/tests/*-migration.spec.ts` was already a path trigger, and both `multitable-web-guard.yml`'s own `vitest run` step and the REQUIRED `run-required-web-tests.sh` already carry the bare token `migration`, which substring-matches all 3 extended spec files — **no edit needed** to either run-list; this is an already-wired file per the repo's "existing already-wired file" carve-out.
2. **Path trigger for the .vue sources** — the 3 component `.vue` files themselves had **no** explicit path trigger in `multitable-web-guard.yml` (only their spec files were covered via the wildcard). Per the repo's own R5c/T3-T4-T5 CI-residual-fix precedent (a PR touching only the `.vue` source with no spec change would otherwise run no web-guard), I added explicit path-trigger lines for all 3 files to **both** duplicated `paths:` blocks (`pull_request` and `push`) in `multitable-web-guard.yml`.
3. **Actually ran the CI steps, not an approximation**:
   - `bash apps/web/scripts/run-required-web-tests.sh` (the REQUIRED `web-tests` check, full run): **176/176 files, 2104/2104 tests passed**, including all 3 extended migration specs.
   - The advisory guard's own `vitest run <82-token filter>` line: flaked on an **unrelated** file, `multitable-workbench-history-field-scope-wiring.spec.ts` (2 different subtests failed across 2 runs of the full batch — nondeterministic), which this PR never touches (no diff to `MultitableWorkbench.vue`/`HistoryCenterModal.vue`). Re-ran that file in isolation 3× — passed 3/3, 6/6 tests every time — and it passed cleanly inside the full 176-file required-script run above. This is a pre-existing parallel-run flake, not something this PR introduced.

## Scope discipline

Read the design-lock + `gh pr diff 4130`/`4133`/`4174` before starting. Verified each `×` glyph's handler before touching anything (`MetaPersonPicker`/`MetaLinkPicker`'s chip-remove buttons are `removeSelected(id)`, not dismiss — left alone). Did not touch: selection checkboxes, search input, Clear/Load-more buttons, footer Cancel/Confirm (already `MtButton` from an earlier slice), any per-rule swatch/add/remove control in `ScaleFormattingDialog`, or `RestorePreviewDialog.vue`/`RestoreBatchDialog.vue` (see scope-correction section above). No permission, deletion, or AI logic touched anywhere.

refs docs/development/multitable-ui-p2-1c-tail-resolution-designlock-20260707.md §2-T1

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
