### PR TITLE
refactor(multitable): UI-P2-1c T1 batch-4 — drawer/viewer header close-× → MtIconButton

### DIFF
--- a/apps/web/src/multitable/components/HistoryCenterModal.vue
+++ b/apps/web/src/multitable/components/HistoryCenterModal.vue
@@ -10,7 +10,7 @@
     <div class="meta-hist__modal" role="dialog" aria-modal="true" :aria-label="t('历史记录', 'History')">
       <header class="meta-hist__header">
         <h3 class="meta-hist__title">{{ t('历史记录', 'History') }}</h3>
-        <button class="meta-hist__close" type="button" :aria-label="t('关闭', 'Close')" @click="emit('close')">×</button>
+        <MtIconButton class="meta-hist__close" :aria-label="t('关闭', 'Close')" @click="emit('close')">×</MtIconButton>
       </header>
 
       <div v-if="initialBatchId && !pinnedDismissed" class="meta-hist__pinned" data-test="hist-pinned-batch">
@@ -90,7 +90,7 @@ import { useLocale } from '../../composables/useLocale'
 import { useHistoryCenter } from '../composables/useHistoryCenter'
 import { historyActor } from '../utils/meta-record-labels'
 import HistoryBatchChangesList from './HistoryBatchChangesList.vue'
-import { MtButton } from '../ui'
+import { MtButton, MtIconButton } from '../ui'
 import type { LinkedRecordSummary, PersonSummary } from '../types'
 
 const props = defineProps<{
@@ -224,7 +224,9 @@ function formatTime(iso: string): string {
 .meta-hist__modal { background: var(--meta-surface, #fff); color: var(--meta-text, #1f2329); border-radius: 8px; min-width: 420px; max-width: 640px; max-height: 76vh; overflow: auto; padding: 16px; box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18); }
 .meta-hist__header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
 .meta-hist__title { margin: 0; font-size: 15px; }
-.meta-hist__close { background: none; border: none; font-size: 20px; line-height: 1; cursor: pointer; color: inherit; }
+/* .meta-hist__close: now <MtIconButton> (ghost, token-styled; the × glyph char passes through its
+   default-slot icon fallback (size token-normalized to the icon control)). Bespoke hardcoded CSS removed
+   (UI-P2-1c T1 batch-4). Class kept on the element only for selector stability. */
 .meta-hist__filters { display: flex; gap: 8px; margin-bottom: 12px; flex-wrap: wrap; }
 .meta-hist__filter { font-size: 12px; padding: 4px 6px; border: 1px solid var(--meta-border, #ddd); border-radius: 4px; }
 /* .meta-hist__apply / .meta-hist__more (below): the Filter and Load-more controls are now <MtButton>

--- a/apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue
@@ -3,7 +3,7 @@
     <div class="meta-group-delivery">
       <div class="meta-group-delivery__header">
         <h4 class="meta-group-delivery__title">{{ automationLabel('delivery.groupTitle', isZh) }}</h4>
-        <button class="meta-group-delivery__close" type="button" @click="$emit('close')">&times;</button>
+        <MtIconButton class="meta-group-delivery__close" @click="$emit('close')">&times;</MtIconButton>
       </div>
 
       <div class="meta-group-delivery__body">
@@ -55,7 +55,7 @@ import { useLocale } from '../../composables/useLocale'
 import type { DingTalkGroupDelivery } from '../types'
 import type { MultitableApiClient } from '../api/client'
 import { automationLabel, automationStatusLabel } from '../utils/meta-automation-labels'
-import { MtButton } from '../ui'
+import { MtButton, MtIconButton } from '../ui'
 
 const props = defineProps<{
   visible: boolean
@@ -157,15 +157,9 @@ watch(
   color: #0f172a;
 }
 
-.meta-group-delivery__close {
-  border: none;
-  background: none;
-  font-size: 22px;
-  cursor: pointer;
-  color: #64748b;
-  line-height: 1;
-  padding: 0 4px;
-}
+/* .meta-group-delivery__close: now <MtIconButton> (ghost, token-styled; the &times; glyph char passes
+   through its default-slot icon fallback (size token-normalized to the icon control)). Bespoke hardcoded
+   CSS removed (UI-P2-1c T1 batch-4). Class kept on the element only for selector stability. */
 
 .meta-group-delivery__body {
   padding: 16px 20px 20px;

--- a/apps/web/src/multitable/components/MetaAutomationLogViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationLogViewer.vue
@@ -3,7 +3,7 @@
     <div class="meta-log-viewer">
       <div class="meta-log-viewer__header">
         <h4 class="meta-log-viewer__title">{{ automationLabel('log.title', isZh) }}</h4>
-        <button class="meta-log-viewer__close" type="button" @click="$emit('close')">&times;</button>
+        <MtIconButton class="meta-log-viewer__close" @click="$emit('close')">&times;</MtIconButton>
       </div>
 
       <div class="meta-log-viewer__body">
@@ -144,7 +144,7 @@ import {
   renderAutomationLogSupportPacketJson,
   renderAutomationLogSupportPacketMarkdown,
 } from '../utils/automation-log-support-packet'
-import { MtButton } from '../ui'
+import { MtButton, MtIconButton } from '../ui'
 
 const props = defineProps<{
   sheetId: string
@@ -293,7 +293,9 @@ watch(
 }
 
 .meta-log-viewer__title { margin: 0; font-size: 16px; font-weight: 700; color: #0f172a; }
-.meta-log-viewer__close { border: none; background: none; font-size: 22px; cursor: pointer; color: #64748b; line-height: 1; padding: 0 4px; }
+/* .meta-log-viewer__close: now <MtIconButton> (ghost, token-styled; the &times; glyph char passes
+   through its default-slot icon fallback (size token-normalized to the icon control)). Bespoke hardcoded CSS
+   removed (UI-P2-1c T1 batch-4). Class kept on the element only for selector stability. */
 
 .meta-log-viewer__body {
   padding: 16px 20px 20px;

--- a/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
@@ -3,7 +3,7 @@
     <div class="meta-person-delivery">
       <div class="meta-person-delivery__header">
         <h4 class="meta-person-delivery__title">{{ automationLabel('delivery.personTitle', isZh) }}</h4>
-        <button class="meta-person-delivery__close" type="button" @click="$emit('close')">&times;</button>
+        <MtIconButton class="meta-person-delivery__close" @click="$emit('close')">&times;</MtIconButton>
       </div>
 
       <div class="meta-person-delivery__body">
@@ -66,7 +66,7 @@ import { useLocale } from '../../composables/useLocale'
 import type { DingTalkPersonDelivery } from '../types'
 import type { MultitableApiClient } from '../api/client'
 import { automationLabel, automationStatusLabel } from '../utils/meta-automation-labels'
-import { MtButton } from '../ui'
+import { MtButton, MtIconButton } from '../ui'
 
 const props = defineProps<{
   visible: boolean
@@ -195,15 +195,9 @@ watch(
   color: #0f172a;
 }
 
-.meta-person-delivery__close {
-  border: none;
-  background: none;
-  font-size: 22px;
-  cursor: pointer;
-  color: #64748b;
-  line-height: 1;
-  padding: 0 4px;
-}
+/* .meta-person-delivery__close: now <MtIconButton> (ghost, token-styled; the &times; glyph char passes
+   through its default-slot icon fallback (size token-normalized to the icon control)). Bespoke hardcoded
+   CSS removed (UI-P2-1c T1 batch-4). Class kept on the element only for selector stability. */
 
 .meta-person-delivery__body {
   padding: 16px 20px 20px;

--- a/apps/web/src/multitable/components/MetaCommentsDrawer.vue
+++ b/apps/web/src/multitable/components/MetaCommentsDrawer.vue
@@ -10,7 +10,7 @@
           {{ l('comment.inbox') }}
           <span v-if="unreadCount > 0" class="meta-comments-drawer__inbox-badge">{{ unreadCount }}</span>
         </RouterLink>
-        <button class="meta-comments-drawer__close" @click="emit('close')">&times;</button>
+        <MtIconButton class="meta-comments-drawer__close" @click="emit('close')">&times;</MtIconButton>
       </div>
     </div>
     <div class="meta-comments-drawer__body">
@@ -147,6 +147,7 @@ import { RouterLink } from 'vue-router'
 import { useLocale } from '../../composables/useLocale'
 import type { MetaCommentMentionSuggestion, MultitableComment } from '../types'
 import { normalizeMultitableComment } from '../api/client'
+import { MtIconButton } from '../ui'
 import {
   commentLabel,
   editingBanner,
@@ -416,7 +417,9 @@ function formatCommentPreview(content: string): string {
 .meta-comments-drawer__inbox-link { color: #409eff; font-size: 12px; text-decoration: none; }
 .meta-comments-drawer__inbox-link:hover { text-decoration: underline; }
 .meta-comments-drawer__inbox-badge { margin-left: 6px; padding: 2px 6px; border-radius: 999px; background: #eff6ff; color: #2563eb; font-size: 11px; }
-.meta-comments-drawer__close { border: none; background: none; font-size: 18px; cursor: pointer; color: #999; }
+/* .meta-comments-drawer__close: now <MtIconButton> (ghost, token-styled; the &times; glyph char passes
+   through its default-slot icon fallback (size token-normalized to the icon control)). Bespoke hardcoded CSS
+   removed (UI-P2-1c T1 batch-4). Class kept on the element only for selector stability. */
 .meta-comments-drawer__body { flex: 1; overflow-y: auto; padding: 10px 14px; }
 .meta-comments-drawer__loading, .meta-comments-drawer__empty { text-align: center; padding: 20px; color: #999; font-size: 13px; }
 .meta-comments-drawer__thread { margin-bottom: 12px; }

--- a/apps/web/tests/history-center-modal-migration.spec.ts
+++ b/apps/web/tests/history-center-modal-migration.spec.ts
@@ -3,8 +3,18 @@
 // danger accent; `.meta-hist__apply` / `.meta-hist__more` were unstyled, `.meta-hist__pinned-dismiss` was
 // already a neutral --ms-* bordered secondary action). Behavior-preservation proof: each control stays a
 // native <button>, keeps its :disabled binding (Load-more) and data-test attribute, and clicking it still
-// runs the SAME composable method with the SAME arguments. The header close-× glyph and the per-row
-// __summary batch toggle (a domain row control) stay bespoke — out of scope for this migration.
+// runs the SAME composable method with the SAME arguments. The per-row __summary batch toggle (a domain
+// row control) stays bespoke — out of scope for this migration.
+//
+// UI-P2-1c T1 batch-4 (multitable-ui-p2-1c-tail-resolution-designlock-20260707.md §2-T1, RATIFIED,
+// "各 manager header" remainder): the header close-× (`.meta-hist__close`) was additionally migrated
+// from a bespoke <button>×</button> to the shared MtIconButton primitive — the × glyph char passes
+// through MtIconButton's default-slot icon fallback (glyph char preserved, size token-normalized to the
+// icon control). Behavior-preservation proof: it stays a native, keyboard-operable <button>, keeps the
+// SAME aria-label (`t('关闭', 'Close')`), and clicking it still fires the SAME `emit('close')`. This is
+// the only sharer of `.meta-hist__close` — its bespoke CSS was removed outright, no double-styling risk.
+// The bespoke `type="button"` attribute was dropped (redundant — MtButton's own template already
+// hardcodes `type="button"` on its root native <button>).
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, type App } from 'vue'
 import HistoryCenterModal from '../src/multitable/components/HistoryCenterModal.vue'
@@ -126,5 +136,29 @@ describe('HistoryCenterModal — MtButton migration (UI-P2-1c batch4)', () => {
     expect(container.querySelectorAll('[data-test="hist-batch"]').length).toBe(2) // b1 + appended b2
     // v-if="nextCursor && !loading" — the control disappears once the cursor is exhausted.
     expect(container.querySelector('[data-test="hist-load-more"]')).toBeNull()
+  })
+})
+
+describe('HistoryCenterModal — close-× MtIconButton migration (UI-P2-1c T1 batch-4)', () => {
+  it('renders the header close-× as a native <button> (MtIconButton) keeping the class + aria-label + glyph', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [], total: 0, nextCursor: null, searchTruncated: false })
+    const container = mount({ open: true, baseId: 'base_1' })
+    await flush()
+    const btn = container.querySelector('.meta-hist__close') as HTMLButtonElement
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('meta-hist__close')).toBe(true)
+    expect(btn.getAttribute('aria-label')).toBe('Close')
+    expect(btn.textContent?.trim()).toBe('×') // × glyph char preserved (size token-normalized)
+  })
+
+  it('clicking the header close-× emits `close` (unchanged — same emit(\'close\'))', async () => {
+    mockListHistoryEvents.mockResolvedValue({ batches: [], total: 0, nextCursor: null, searchTruncated: false })
+    const onClose = vi.fn()
+    const container = mount({ open: true, baseId: 'base_1', onClose })
+    await flush()
+    const btn = container.querySelector('.meta-hist__close') as HTMLButtonElement
+    btn.click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
   })
 })

--- a/apps/web/tests/meta-automation-log-viewer-migration.spec.ts
+++ b/apps/web/tests/meta-automation-log-viewer-migration.spec.ts
@@ -6,7 +6,18 @@
 // MetaChartLoadError's retry control #3823). Behavior-preservation proof: each stays a native <button>,
 // keeps its data-action attribute, and clicking it still runs the SAME handler (loadData /
 // copySupportPacket / downloadSupportPacket) — including the copy/download buttons' `.stop` modifier, which
-// still works because MtButton re-emits the real native MouseEvent. The header close-× glyph stays bespoke.
+// still works because MtButton re-emits the real native MouseEvent.
+//
+// UI-P2-1c T1 batch-4 (multitable-ui-p2-1c-tail-resolution-designlock-20260707.md §2-T1, RATIFIED,
+// "各 manager header" remainder): the header close-× (`.meta-log-viewer__close`) was additionally
+// migrated from a bespoke <button>&times;</button> to the shared MtIconButton primitive — the &times;
+// glyph passes through MtIconButton's default-slot icon fallback (glyph char preserved, size
+// token-normalized to the icon control). Behavior-preservation proof: it stays a native, keyboard-
+// operable <button>, and clicking it still fires the SAME `$emit('close')` (no aria-label existed
+// pre-migration — none was invented). This is the only sharer of `.meta-log-viewer__close` — its
+// bespoke CSS was removed outright, no double-styling risk. The bespoke `type="button"` attribute
+// was dropped (redundant — MtButton's own template already hardcodes `type="button"` on its root
+// native <button>, so the DOM type stays "button" either way).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 
@@ -148,5 +159,28 @@ describe('MetaAutomationLogViewer — MtButton migration (UI-P2-1c batch4)', () 
     expect(item.querySelector('[data-detail="true"]')).not.toBeNull()
 
     clickSpy.mockRestore()
+  })
+})
+
+describe('MetaAutomationLogViewer — close-× MtIconButton migration (UI-P2-1c T1 batch-4)', () => {
+  it('renders the header close-× as a native <button> (MtIconButton) keeping the class + glyph', async () => {
+    const client = makeMockClient()
+    mounted = mount({ visible: true, sheetId: 's', ruleId: 'rule-1', client })
+    await flushPromises()
+    const btn = mounted.container.querySelector('.meta-log-viewer__close') as HTMLButtonElement
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('meta-log-viewer__close')).toBe(true)
+    expect(btn.textContent?.trim()).toBe('×') // × glyph char preserved (size token-normalized)
+  })
+
+  it('clicking the header close-× emits `close` (unchanged — same $emit(\'close\'))', async () => {
+    const client = makeMockClient()
+    const onClose = vi.fn()
+    mounted = mount({ visible: true, sheetId: 's', ruleId: 'rule-1', client, onClose })
+    await flushPromises()
+    const btn = mounted.container.querySelector('.meta-log-viewer__close') as HTMLButtonElement
+    btn.click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
   })
 })

--- a/apps/web/tests/meta-comments-drawer-migration.spec.ts
+++ b/apps/web/tests/meta-comments-drawer-migration.spec.ts
@@ -1,0 +1,107 @@
+// UI-P2-1c T1 batch-4 (multitable-ui-p2-1c-tail-resolution-designlock-20260707.md §2-T1, RATIFIED,
+// "各 manager header" remainder): MetaCommentsDrawer's header close-× (`.meta-comments-drawer__close`)
+// was migrated from a bespoke <button>&times;</button> to the shared MtIconButton primitive — the
+// &times; glyph passes through MtIconButton's default-slot icon fallback (glyph char preserved, size
+// token-normalized to the icon control). Behavior-preservation proof: it stays a native, keyboard-
+// operable <button>, and clicking it still fires the SAME `emit('close')` (no aria-label existed
+// pre-migration — none was invented). This is the only sharer of `.meta-comments-drawer__close` — its
+// bespoke CSS was removed outright, no double-styling risk.
+//
+// Scope discipline: MetaCommentsDrawer has ~10 buttons total (reply / edit / delete / resolve / retry /
+// reply-cancel / edit-cancel / reactions / composer-submit / the inbox RouterLink / the header close-×).
+// Only the header close-× is a true dismiss (`emit('close')`, closes the whole drawer) — every other
+// control mutates/navigates a specific comment or the composer and was NOT touched. This spec mounts
+// with a real vue-router (MetaCommentsDrawer renders a <RouterLink> in its header) — same setup as the
+// pre-existing `multitable-comments-drawer.spec.ts`.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+import { createMemoryHistory, createRouter, type Router } from 'vue-router'
+import MetaCommentsDrawer from '../src/multitable/components/MetaCommentsDrawer.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function makeRouter(): Router {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'home', component: defineComponent({ render: () => h('div') }) },
+      {
+        path: '/multitable/comments/inbox',
+        name: 'multitable-comment-inbox',
+        component: defineComponent({ render: () => h('div') }),
+      },
+    ],
+  })
+}
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+afterEach(() => {
+  while (mounts.length) { const m = mounts.pop()!; m.app.unmount(); m.container.remove() }
+  useLocale().setLocale('en')
+})
+
+async function mount(props: Record<string, unknown>): Promise<HTMLDivElement> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const router = makeRouter()
+  const app = createApp({ render: () => h(MetaCommentsDrawer, props) })
+  app.use(router)
+  await router.push('/')
+  await router.isReady()
+  app.mount(container)
+  mounts.push({ app, container })
+  await flushUi()
+  return container
+}
+
+const baseProps = () => ({
+  visible: true,
+  comments: [],
+  loading: false,
+  canComment: true,
+  canResolve: true,
+  draft: '',
+})
+
+describe('MetaCommentsDrawer — close-× MtIconButton migration (UI-P2-1c T1 batch-4)', () => {
+  it('renders the header close-× as a native <button> (MtIconButton) keeping the class + glyph', async () => {
+    const container = await mount(baseProps())
+    const btn = container.querySelector('.meta-comments-drawer__close') as HTMLButtonElement
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('meta-comments-drawer__close')).toBe(true)
+    expect(btn.textContent?.trim()).toBe('×') // × glyph char preserved (size token-normalized)
+  })
+
+  it('clicking the header close-× emits `close` (unchanged — same emit(\'close\'))', async () => {
+    const onClose = vi.fn()
+    const container = await mount({ ...baseProps(), onClose })
+    const btn = container.querySelector('.meta-comments-drawer__close') as HTMLButtonElement
+    btn.click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
+  })
+
+  it('does not touch the inbox RouterLink or any per-comment action button (scope discipline)', async () => {
+    const container = await mount({
+      ...baseProps(),
+      comments: [
+        {
+          id: 'c1', spreadsheetId: 'sheet_1', rowId: 'row_1', targetFieldId: null, mentions: [],
+          authorId: 'user_1', authorName: 'Amy Wong', content: 'hello', resolved: false,
+          createdAt: '2026-04-01T09:00:00.000Z',
+        } as any,
+      ],
+      currentUserId: 'user_1',
+    })
+    // The inbox link stays a real <a> (RouterLink), not migrated to MtButton/MtIconButton.
+    expect(container.querySelector('.meta-comments-drawer__inbox-link')?.tagName).toBe('A')
+    // Reply/edit/delete/resolve stay bespoke <button class="meta-comments-drawer__reply|__resolve">.
+    expect(container.querySelector('.meta-comments-drawer__reply')).not.toBeNull()
+  })
+})

--- a/apps/web/tests/meta-group-delivery-viewer-migration.spec.ts
+++ b/apps/web/tests/meta-group-delivery-viewer-migration.spec.ts
@@ -7,7 +7,17 @@ import { useLocale } from '../src/composables/useLocale'
 // to the shared MtButton primitive (ghost — it was a neutral bordered-white secondary action). Its class is
 // unique, so the bespoke hex CSS was removed. Behavior-preservation proof: it stays a native <button>; the
 // :disabled binding survives; clicking it still runs loadData → props.client.getAutomationDingTalkGroupDeliveries.
-// The header close-× glyph stays bespoke.
+//
+// UI-P2-1c T1 batch-4 (multitable-ui-p2-1c-tail-resolution-designlock-20260707.md §2-T1, RATIFIED,
+// "各 manager header" remainder): the header close-× (`.meta-group-delivery__close`) was additionally
+// migrated from a bespoke <button>&times;</button> to the shared MtIconButton primitive — the &times;
+// glyph passes through MtIconButton's default-slot icon fallback (glyph char preserved, size
+// token-normalized to the icon control). Behavior-preservation proof: it stays a native, keyboard-
+// operable <button>, and clicking it still fires the SAME `$emit('close')` (no aria-label existed
+// pre-migration — none was invented). This is the only sharer of `.meta-group-delivery__close` — its
+// bespoke CSS was removed outright, no double-styling risk. The bespoke `type="button"` attribute was
+// dropped (redundant — MtButton's own template already hardcodes `type="button"` on its root native
+// <button>).
 
 const flush = () => new Promise((r) => setTimeout(r, 0))
 let app: App | null = null; let container: HTMLDivElement | null = null
@@ -17,9 +27,9 @@ afterEach(() => {
   useLocale().setLocale('en')
 })
 
-function mount(client: Record<string, unknown>) {
+function mount(client: Record<string, unknown>, extraProps: Record<string, unknown> = {}) {
   container = document.createElement('div'); document.body.appendChild(container)
-  app = createApp({ render: () => h(MetaAutomationGroupDeliveryViewer, { visible: true, sheetId: 's1', ruleId: 'r1', client }) })
+  app = createApp({ render: () => h(MetaAutomationGroupDeliveryViewer, { visible: true, sheetId: 's1', ruleId: 'r1', client, ...extraProps }) })
   app.mount(container)
 }
 const refreshBtn = () => container!.querySelector('[data-action="refresh"]') as HTMLButtonElement
@@ -40,5 +50,26 @@ describe('MetaAutomationGroupDeliveryViewer — MtButton migration (UI-P2-1c)', 
     await flush()
     expect(get).toHaveBeenCalledTimes(1) // the click, post-clear
     expect(get).toHaveBeenCalledWith('s1', 'r1', 50)
+  })
+})
+
+describe('MetaAutomationGroupDeliveryViewer — close-× MtIconButton migration (UI-P2-1c T1 batch-4)', () => {
+  it('renders the header close-× as a native <button> (MtIconButton) keeping the class + glyph', async () => {
+    mount({ getAutomationDingTalkGroupDeliveries: vi.fn().mockResolvedValue([]) })
+    await flush()
+    const btn = container!.querySelector('.meta-group-delivery__close') as HTMLButtonElement
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('meta-group-delivery__close')).toBe(true)
+    expect(btn.textContent?.trim()).toBe('×') // × glyph char preserved (size token-normalized)
+  })
+
+  it('clicking the header close-× emits `close` (unchanged — same $emit(\'close\'))', async () => {
+    const onClose = vi.fn()
+    mount({ getAutomationDingTalkGroupDeliveries: vi.fn().mockResolvedValue([]) }, { onClose })
+    await flush()
+    const btn = container!.querySelector('.meta-group-delivery__close') as HTMLButtonElement
+    btn.click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
   })
 })

--- a/apps/web/tests/meta-person-delivery-viewer-migration.spec.ts
+++ b/apps/web/tests/meta-person-delivery-viewer-migration.spec.ts
@@ -6,7 +6,18 @@ import { useLocale } from '../src/composables/useLocale'
 // UI-P2-1c: MetaAutomationPersonDeliveryViewer's toolbar Refresh control was migrated from a bespoke <button>
 // to the shared MtButton primitive (ghost — neutral bordered-white secondary). Unique class → bespoke hex CSS
 // removed. Behavior-preservation proof: native <button>; :disabled survives; clicking still runs loadData →
-// props.client.getAutomationDingTalkPersonDeliveries. The header close-× glyph stays bespoke.
+// props.client.getAutomationDingTalkPersonDeliveries.
+//
+// UI-P2-1c T1 batch-4 (multitable-ui-p2-1c-tail-resolution-designlock-20260707.md §2-T1, RATIFIED,
+// "各 manager header" remainder): the header close-× (`.meta-person-delivery__close`) was additionally
+// migrated from a bespoke <button>&times;</button> to the shared MtIconButton primitive — the &times;
+// glyph passes through MtIconButton's default-slot icon fallback (glyph char preserved, size
+// token-normalized to the icon control). Behavior-preservation proof: it stays a native, keyboard-
+// operable <button>, and clicking it still fires the SAME `$emit('close')` (no aria-label existed
+// pre-migration — none was invented). This is the only sharer of `.meta-person-delivery__close` — its
+// bespoke CSS was removed outright, no double-styling risk. The bespoke `type="button"` attribute was
+// dropped (redundant — MtButton's own template already hardcodes `type="button"` on its root native
+// <button>).
 
 const flush = () => new Promise((r) => setTimeout(r, 0))
 let app: App | null = null; let container: HTMLDivElement | null = null
@@ -16,9 +27,9 @@ afterEach(() => {
   useLocale().setLocale('en')
 })
 
-function mount(client: Record<string, unknown>) {
+function mount(client: Record<string, unknown>, extraProps: Record<string, unknown> = {}) {
   container = document.createElement('div'); document.body.appendChild(container)
-  app = createApp({ render: () => h(MetaAutomationPersonDeliveryViewer, { visible: true, sheetId: 's1', ruleId: 'r1', client }) })
+  app = createApp({ render: () => h(MetaAutomationPersonDeliveryViewer, { visible: true, sheetId: 's1', ruleId: 'r1', client, ...extraProps }) })
   app.mount(container)
 }
 const refreshBtn = () => container!.querySelector('[data-action="refresh"]') as HTMLButtonElement
@@ -65,5 +76,26 @@ describe('MetaAutomationPersonDeliveryViewer — MtButton migration (UI-P2-1c)',
     // admin-side list filter: the new state is selectable, not silently excluded by the IN-list
     const options = Array.from(container!.querySelectorAll('[data-field="statusFilter"] option')).map((o) => (o as HTMLOptionElement).value)
     expect(options).toContain('outcome_unknown')
+  })
+})
+
+describe('MetaAutomationPersonDeliveryViewer — close-× MtIconButton migration (UI-P2-1c T1 batch-4)', () => {
+  it('renders the header close-× as a native <button> (MtIconButton) keeping the class + glyph', async () => {
+    mount({ getAutomationDingTalkPersonDeliveries: vi.fn().mockResolvedValue([]) })
+    await flush()
+    const btn = container!.querySelector('.meta-person-delivery__close') as HTMLButtonElement
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn.classList.contains('meta-person-delivery__close')).toBe(true)
+    expect(btn.textContent?.trim()).toBe('×') // × glyph char preserved (size token-normalized)
+  })
+
+  it('clicking the header close-× emits `close` (unchanged — same $emit(\'close\'))', async () => {
+    const onClose = vi.fn()
+    mount({ getAutomationDingTalkPersonDeliveries: vi.fn().mockResolvedValue([]) }, { onClose })
+    await flush()
+    const btn = container!.querySelector('.meta-person-delivery__close') as HTMLButtonElement
+    btn.click()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
   })
 })


### PR DESCRIPTION
## What changed

T1 batch-4 of `docs/development/multitable-ui-p2-1c-tail-resolution-designlock-20260707.md` §2-T1 (RATIFIED — owner directive 2026-07-11), covering the lock's **"各 manager header" remainder** — the 5 components explicitly assigned to this lane. Migrates each header close-× glyph button from a bespoke `<button>&times;</button>` to the shared `MtIconButton` primitive (`apps/web/src/multitable/ui`, same barrel import idiom as #4130/#4133):

| File | Class | Handler | aria-label pre-migration |
|---|---|---|---|
| `MetaCommentsDrawer.vue` | `.meta-comments-drawer__close` | `@click="emit('close')"` | none (none invented) |
| `MetaAutomationLogViewer.vue` | `.meta-log-viewer__close` | `@click="$emit('close')"` | none (none invented) |
| `MetaAutomationGroupDeliveryViewer.vue` | `.meta-group-delivery__close` | `@click="$emit('close')"` | none (none invented) |
| `MetaAutomationPersonDeliveryViewer.vue` | `.meta-person-delivery__close` | `@click="$emit('close')"` | none (none invented) |
| `HistoryCenterModal.vue` | `.meta-hist__close` | `@click="emit('close')"` | `t('关闭','Close')` — preserved verbatim |

Each source file also dropped the bespoke `type="button"` attribute where present (4 of 5) — redundant, not a behavior change: `MtButton`'s own template already hardcodes `type="button"` on its root native `<button>`, so the DOM type stays `"button"` either way regardless of whether the caller passes it through.

## Scope discipline — what was left untouched

**Only the header close-×.** Per-component button inventory, verified by handler before touching anything:

- **`MetaCommentsDrawer.vue`** has ~10 buttons total. Left untouched: reply / edit / delete / resolve (all mutate a specific comment thread), retry (re-fetches on error), reply-cancel / edit-cancel (dismiss a composer banner, not the drawer), the composer submit button, and the inbox `<RouterLink>` (navigation, not a button at all). None of these are a "close the whole drawer" dismiss — only `.meta-comments-drawer__close` is.
- **The 3 automation viewers** (log/group-delivery/person-delivery) each have Refresh (+ Retry/copy/download support-packet buttons on the log viewer) already migrated to `MtButton` in earlier, unrelated PRs (#3869/#3870/#4089) — those stay byte-identical; only the header close-× (previously untouched, "stays bespoke" per those PRs' own doc comments) moved in this PR.
- **`HistoryCenterModal.vue`**: Filter/Clear/Load-more were already `MtButton` (#4089); the per-row `.meta-hist__summary` batch-toggle button is a domain row control, not a dismiss — untouched.

No permission, deletion, or AI business logic was touched anywhere — buttons + CSS only, exactly as scoped.

## Byte-preservation

`@click` / `v-if` / `:disabled` / `aria-label` / `data-*` copied verbatim per file (diffed against `origin/main`: only the tag name, the `../ui` import line, and the CSS block for each `__close` class changed — nothing else in any of the 5 `.vue` files moved). 2 of 5 close-× buttons had no `aria-label` before migration (`MetaCommentsDrawer`, the 3 automation viewers) — none was invented, matching the "byte-preserve, don't improve" rule.

## Classes: kept, CSS removed

Each of the 5 `__close` classes is the **sole sharer** in its file (repo-wide grep confirmed no other `.vue`/`.ts` reference). Per file:
- class kept on `<MtIconButton class="...">` (Vue attr-fallthrough merges it onto the underlying native `<button>`) — for selector stability, matching existing behavior specs that query these classes directly (e.g. `multitable-comments-drawer.spec.ts`, `multitable-history-fe.spec.ts`).
- the bespoke hardcoded CSS rule was **deleted outright** and replaced with a one-line comment (same convention as #4130/#4133) — no orphaned rule, no double-styling risk.

No new hardcoded hex introduced (diff-grepped against the full component set — 0 hits). No new primitive variants/props/sizes — `MtIconButton` used with only `class` / `aria-label` / `@click` / default slot, all pre-existing on the barrel.

## Honest visual delta (token-normalized, NOT "zero visual change")

Same normalization already landed on `main` via #4099/#4130/#4133: `MtIconButton` renders the `×`/`&times;` glyph inside a fixed 32px (`--ms-control-height`) square control, flex-centered, with `--ms-*` token-driven hover/focus-visible states (a visible focus ring now appears on keyboard focus, which none of these 5 bespoke buttons had). Font-size (previously 18–22px, independently set per file) is no longer independently set — it inherits the shared icon-button sizing. Headers grow by a few px accordingly — expected, not a regression, per this repo's standing discipline against overclaiming pixel-identical migrations.

## Test evidence

A mount spec per component, anchored on the component's own `.X__close` class (never fuzzy `textContent`/optional-chained `querySelector(...)?.click()`), asserting: (1) it renders as a native `<button>` keeping the class + preserved glyph text, and (2) clicking it fires the exact same emit with the exact same (empty) payload. `MetaAutomationLogViewer` / `MetaAutomationGroupDeliveryViewer` / `MetaAutomationPersonDeliveryViewer` / `HistoryCenterModal` specs were extended (new `describe` blocks alongside their existing, unmodified button-migration coverage); `MetaCommentsDrawer` got a new file (none existed) using a real `vue-router` instance, matching the pre-existing `multitable-comments-drawer.spec.ts` mount convention (the drawer renders a `<RouterLink>` in its header) plus a 3rd test pinning that the inbox link and a per-comment reply button are NOT migrated (scope-discipline regression guard).

```
pnpm --filter @metasheet/web exec vitest run meta-comments-drawer-migration meta-automation-log-viewer-migration meta-group-delivery-viewer-migration meta-person-delivery-viewer-migration history-center-modal-migration --reporter=dot

 Test Files  5 passed (5)
      Tests  25 passed (25)
```

Also ran the broader pre-existing regression net around these 5 files (multitable-comments-drawer, meta-comments-drawer-i18n, multitable-history-fe, multitable-history-center-{ai-shortcut-label,inline-diff,pinned-batch-deeplink}, multitable-workbench-restore-wiring, multitable-config-history-modal, multitable-restore-{batch,preview}-dialog) — 15 files / 122 tests, all green.

`vue-tsc -b` (repo `type-check` script): clean, no errors.

**Pre-existing flake noted, not caused by this PR**: `multitable-workbench-history-field-scope-wiring.spec.ts` is flaky when run in the SAME vitest worker alongside several other spec files (2–4 of its 6 tests intermittently fail with timeouts/null-chip assertions) — reproduced identically on an unmodified `origin/main` checkout (stashed this branch's diff, same failure signature). In isolation it passes 6/6 reliably, both on `origin/main` and with this PR's diff applied (ran twice each way). Out of scope for this PR; flagging per this line's standing discipline against silently absorbing pre-existing flakes into an unrelated diff's blast radius.

## Mutation-red evidence (per component, done serially: mutate → red → `git checkout -- <file>` restore from the committed baseline)

1. **MetaCommentsDrawer** — dropped `@click="emit('close')"` → `clicking the header close-× emits 'close'` failed: `expected "spy" to be called 1 times, but got 0 times`. Restored.
2. **MetaAutomationLogViewer** — dropped `@click="$emit('close')"` → same failure shape. Restored.
3. **MetaAutomationGroupDeliveryViewer** — dropped `@click="$emit('close')"` → same failure shape. Restored.
4. **MetaAutomationPersonDeliveryViewer** — dropped `@click="$emit('close')"` → same failure shape. Restored.
5. **HistoryCenterModal** — dropped `@click="emit('close')"` (kept the aria-label binding, mutated ONLY the click handler) → same failure shape. Restored.

Each mutation was applied against the already-committed baseline (this branch's own commit) and restored via `git checkout -- <file>`; `git status --short` was clean after every restore. Full 5-spec / 25-test suite re-ran green after all 5 restores.

## CI wiring (two-point, verified — no edits needed)

- `.github/workflows/multitable-web-guard.yml`: the wildcard `apps/web/tests/*-migration.spec.ts` path trigger (present at both the `pull_request` and `push` blocks, pre-existing on `origin/main`) fires on all 5 touched/new spec files.
- `apps/web/scripts/run-required-web-tests.sh` (backs the REQUIRED `web-tests` check): the bare `migration` token (pre-existing) substring-matches every `*-migration.spec.ts` file, including the new `meta-comments-drawer-migration.spec.ts`.

Both were re-verified on the current `origin/main` tip after rebasing this branch (`grep` confirmed present at the expected lines). Same precedent as #4130/#4133 — neither touched these files either.

## Coordination note (dedup-check finding, for the record)

At the start of this lane I found `#4174` already open, self-titled "T1 batch-4," touching `ResetConfirmDialog.vue` / `RestoreBatchDialog.vue` / `RestorePreviewDialog.vue` — a disjoint file set from this PR's assignment (the "各 manager header" remainder). I did not author #4174 (read-only `gh pr view` during the dedup check only) and never touched any of its 3 files. This PR is branched fresh off `origin/main` and only touches the 5 files listed above.

refs docs/development/multitable-ui-p2-1c-tail-resolution-designlock-20260707.md §2-T1

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
