### PR TITLE
fix(security): combined landing — GHSA-q7hj + GHSA-h8mf + SafetyGuard double-confirm

### DIFF
--- a/packages/core-backend/src/guards/SafetyGuard.ts
+++ b/packages/core-backend/src/guards/SafetyGuard.ts
@@ -139,10 +139,16 @@ export class SafetyGuard {
       };
     }
 
-    // If has confirmation token, verify it
+    // If has confirmation token, verify it. BINDING (GHSA): the retried operation must match the token's
+    // original operation, initiator, and resource, and the token must already be confirmed. The retry
+    // deliberately does NOT forward a typed phrase / acknowledgment — a token is accepted here only via
+    // the RETRY-phase branch in verifyConfirmation (pending.confirmed), never by re-confirming inline.
     if (context.confirmationToken) {
       const verification = this.verifyConfirmation({
-        token: context.confirmationToken
+        token: context.confirmationToken,
+        operation: context.operation,
+        initiator: context.initiator,
+        resourceKey: this.resourceKey(context.details)
       });
 
       if (verification.valid) {
@@ -254,7 +260,37 @@ export class SafetyGuard {
       return { valid: false, reason: 'Confirmation token has expired' };
     }
 
-    // Check double-confirm requirement
+    // BINDING (GHSA): a confirmation token is bound to the operation, initiator, and resource of the
+    // request that minted it. Reject any presentation that does not match — this prevents a confirmed
+    // token from being replayed against a different operation, by a different admin, or on a different
+    // resource. The route/retry path (checkOperation) supplies all three; /safety/confirm supplies the
+    // authenticated initiator. A field left undefined by the caller is not checked, but the security
+    // paths always supply the fields their threat requires (retry: all three; confirm: initiator).
+    if (request.operation !== undefined && request.operation !== pending.context.operation) {
+      return { valid: false, reason: 'Confirmation token does not match this operation' };
+    }
+    if (request.initiator !== undefined && request.initiator !== pending.context.initiator) {
+      return { valid: false, reason: 'Confirmation token was issued to a different user' };
+    }
+    if (
+      request.resourceKey !== undefined &&
+      request.resourceKey !== this.resourceKey(pending.context.details)
+    ) {
+      return { valid: false, reason: 'Confirmation token does not match this resource' };
+    }
+
+    // RETRY phase (GHSA): once a token is confirmed (via /safety/confirm), the retried operation
+    // request — which carries ONLY the token, never the typed phrase or acknowledgment — is accepted on
+    // the strength of pending.confirmed alone. This is the fix for the double-confirm deadlock: the
+    // typed-phrase re-check below must NOT fire on the retry. Binding was already enforced above.
+    if (pending.confirmed) {
+      return { valid: true };
+    }
+
+    // CONFIRM phase (GHSA): the token is not yet confirmed — this is the /safety/confirm step. A
+    // double-confirm operation requires the typed phrase; a HIGH/CRITICAL operation requires an explicit
+    // acknowledgment. A route retry that reaches here (token present but never confirmed) fails these
+    // checks — confirmation cannot be skipped by going straight to the retry.
     if (pending.assessment.requiresDoubleConfirm) {
       if (!request.typedConfirmation) {
         return {
@@ -275,11 +311,9 @@ export class SafetyGuard {
       }
     }
 
-    // Check acknowledgment for high-risk operations (only if not already confirmed)
     if (
-      !pending.confirmed &&
-      (pending.assessment.riskLevel === RiskLevel.HIGH ||
-        pending.assessment.riskLevel === RiskLevel.CRITICAL)
+      pending.assessment.riskLevel === RiskLevel.HIGH ||
+      pending.assessment.riskLevel === RiskLevel.CRITICAL
     ) {
       if (!request.acknowledged) {
         return {
@@ -289,17 +323,58 @@ export class SafetyGuard {
       }
     }
 
-    // Mark as confirmed after successful verification
-    if (!pending.confirmed) {
-      pending.confirmed = true;
-      logger.info('Operation confirmed by user', {
-        context: 'SafetyGuard',
-        operation: pending.context.operation,
-        token: request.token.substring(0, 20) + '...'
-      });
-    }
+    // All confirm-phase checks passed: mark the token confirmed. The subsequent route retry (token only)
+    // will be accepted by the RETRY-phase branch above.
+    pending.confirmed = true;
+    logger.info('Operation confirmed by user', {
+      context: 'SafetyGuard',
+      operation: pending.context.operation,
+      token: request.token.substring(0, 20) + '...'
+    });
 
     return { valid: true };
+  }
+
+  /**
+   * Canonical fingerprint of the resource-identifying details of an operation, used to bind a
+   * confirmation token to its resource (GHSA). assessRisk() adds its own bookkeeping keys to
+   * context.details (ruleApplied / ruleInfo / ruleBlocked / ruleBlockReason) on both the issuing and
+   * the retried request; those top-level keys are excluded so the fingerprint reflects only the
+   * caller-supplied resource identity.
+   *
+   * Callers may pass NESTED resource details — e.g. the admin bulk-data routes pass
+   * { table, filters: { ... } } and { table, updates: { ... } } — so the fingerprint RECURSIVELY sorts
+   * object keys at every depth. Array order is PRESERVED (a reordered array is a different resource).
+   * The effect: two requests that differ only in object key ordering bind to the SAME token (a
+   * legitimate confirmation is not rejected), while any value change or array reordering binds to a
+   * DIFFERENT token.
+   */
+  private resourceKey(details: Record<string, unknown> | undefined): string {
+    if (!details) return '';
+    const OMIT = new Set(['ruleApplied', 'ruleInfo', 'ruleBlocked', 'ruleBlockReason']);
+    const stable: Record<string, unknown> = {};
+    for (const key of Object.keys(details)) {
+      if (!OMIT.has(key)) stable[key] = details[key];
+    }
+    return JSON.stringify(this.canonicalize(stable));
+  }
+
+  /**
+   * Recursively normalize a value for stable fingerprinting: object keys sorted at any depth, array
+   * order preserved, primitives returned as-is.
+   */
+  private canonicalize(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map((v) => this.canonicalize(v));
+    }
+    if (value !== null && typeof value === 'object') {
+      const sorted: Record<string, unknown> = {};
+      for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+        sorted[key] = this.canonicalize((value as Record<string, unknown>)[key]);
+      }
+      return sorted;
+    }
+    return value;
   }
 
   /**

--- a/packages/core-backend/src/guards/middleware.ts
+++ b/packages/core-backend/src/guards/middleware.ts
@@ -6,8 +6,36 @@
 
 import type { Request, Response, NextFunction } from 'express';
 import { getSafetyGuard } from './SafetyGuard';
-import type { OperationType} from './types';
-import { type OperationContext } from './types';
+import type { OperationType, RiskAssessment } from './types';
+import { type OperationContext, RiskLevel } from './types';
+
+/**
+ * Build accurate client instructions for completing a blocked operation.
+ *
+ * The confirmation flow is TWO steps for anything needing a typed phrase or an acknowledgment: first
+ * POST /api/admin/safety/confirm with the token (plus the typed phrase for double-confirm ops and/or
+ * `acknowledged: true` for HIGH/CRITICAL ops), THEN retry the ORIGINAL operation with the same token in
+ * the X-Safety-Token header — the retry never carries the typed phrase/acknowledgment. A MEDIUM op needs
+ * neither, so a single retry with the token suffices.
+ */
+function buildConfirmInstructions(operation: OperationType, assessment: RiskAssessment): string {
+  const needsConfirmStep =
+    assessment.requiresDoubleConfirm ||
+    assessment.riskLevel === RiskLevel.HIGH ||
+    assessment.riskLevel === RiskLevel.CRITICAL;
+
+  if (!needsConfirmStep) {
+    return 'Retry this operation with the same token in the X-Safety-Token header.';
+  }
+
+  const confirmBody = assessment.requiresDoubleConfirm
+    ? `{ token, typedConfirmation: "${operation}", acknowledged: true }`
+    : '{ token, acknowledged: true }';
+  return (
+    `First POST /api/admin/safety/confirm with ${confirmBody}, then retry this operation with the same ` +
+    'token in the X-Safety-Token header.'
+  );
+}
 
 // Extend Express Request type
 interface SafetyRequest extends Request {
@@ -86,9 +114,7 @@ export function requireSafetyCheck(options: SafetyMiddlewareOptions) {
           ? {
               token: result.confirmationToken,
               expiresAt: result.tokenExpiry,
-              instructions: result.assessment.requiresDoubleConfirm
-                ? `To confirm, send another request with the token and type "${options.operation}" as confirmation`
-                : 'To confirm, send another request with the token and acknowledged: true'
+              instructions: buildConfirmInstructions(options.operation, result.assessment)
             }
           : undefined
       });
@@ -97,9 +123,11 @@ export function requireSafetyCheck(options: SafetyMiddlewareOptions) {
 }
 
 /**
- * API endpoint for confirming dangerous operations
+ * API endpoint for confirming dangerous operations. This is step ONE of the two-step flow: it validates
+ * the typed phrase / acknowledgment and marks the token confirmed, but does NOT execute the operation —
+ * the caller then retries the original operation with the same token in the X-Safety-Token header.
  *
- * POST /api/safety/confirm
+ * POST /api/admin/safety/confirm
  * Body: { token: string, typedConfirmation?: string, acknowledged?: boolean }
  */
 export function createSafetyConfirmEndpoint() {
@@ -116,10 +144,18 @@ export function createSafetyConfirmEndpoint() {
       return;
     }
 
+    // BINDING (GHSA): confirm on behalf of the AUTHENTICATED principal only. verifyConfirmation rejects
+    // the token if this initiator does not match the one that minted it, so an admin cannot confirm
+    // another admin's pending operation. The route mounting this handler is platform-admin gated, so
+    // req.user.id is present.
+    const initiator =
+      (req as SafetyRequest).user?.id || (req as SafetyRequest).user?.email;
+
     const verification = safetyGuard.verifyConfirmation({
       token,
       typedConfirmation,
-      acknowledged
+      acknowledged,
+      initiator
     });
 
     if (verification.valid) {

--- a/packages/core-backend/src/guards/types.ts
+++ b/packages/core-backend/src/guards/types.ts
@@ -106,6 +106,16 @@ export interface ConfirmationRequest {
 
   /** Additional acknowledgment */
   acknowledged?: boolean;
+
+  /**
+   * Binding fields (GHSA): a confirmation token is bound to the operation, initiator, and resource of
+   * the request that minted it. verifyConfirmation rejects a token presented for a different operation,
+   * by a different initiator, or against a different resource. The route/retry path (checkOperation)
+   * always supplies all three; the /safety/confirm endpoint supplies the authenticated initiator.
+   */
+  operation?: OperationType;
+  initiator?: string;
+  resourceKey?: string;
 }
 
 export interface SafetyGuardConfig {

--- a/packages/core-backend/src/routes/admin-routes.ts
+++ b/packages/core-backend/src/routes/admin-routes.ts
@@ -945,6 +945,10 @@ router.post(
  */
 router.delete(
   '/snapshots/:id',
+  // SECURITY (GHSA-h8mf): match the restore/cleanup siblings — a snapshot delete must be platform-admin,
+  // not merely safety-confirmed. protectAdminOperation = [requireAdminRole (fail-closed 403/503), audit].
+  // Without this a non-admin could reach delete with only a safety token (delete is a bypass-inventory path).
+  ...protectAdminOperation(OperationType.DELETE_SNAPSHOT),
   requireSafetyCheck({
     operation: OperationType.DELETE_SNAPSHOT,
     getDetails: (req) => ({ snapshotId: req.params.id })

--- a/packages/core-backend/src/routes/admin-routes.ts
+++ b/packages/core-backend/src/routes/admin-routes.ts
@@ -85,6 +85,11 @@ router.get('/safety/status', createSafetyStatusEndpoint());
  */
 router.post(
   '/safety/confirm',
+  // SECURITY (GHSA): confirming a dangerous operation is itself a privileged step — platform-admin only,
+  // fail-closed. Without this the endpoint was reachable by any authenticated caller (rate-limit +
+  // idempotency are throughput controls, not authorization), letting a non-admin confirm a pending
+  // token. requireAdminRole also guarantees req.user.id for the initiator binding in the confirm handler.
+  requireAdminRole(),
   ...protectConfirmationEndpoint(),
   async (req: AuthenticatedRequest, res: Response) => {
     const confirmHandler = createSafetyConfirmEndpoint();

--- a/packages/core-backend/src/routes/change-management.ts
+++ b/packages/core-backend/src/routes/change-management.ts
@@ -3,15 +3,35 @@ import type { Request, Response } from 'express'
 import { changeManagementService } from '../services/ChangeManagementService'
 import { schemaSnapshotService } from '../services/SchemaSnapshotService'
 import { Logger } from '../core/logger'
+import { requireAdminRole } from '../guards/audit-integration'
 
 const logger = new Logger('ChangeManagementRoutes')
 const router = Router()
 
-// Middleware to extract user (mock for now if not present)
+// SECURITY (GHSA-q7hj): the entire change-management surface — change create/approve/deploy/rollback
+// AND schema snapshot/diff — performs privileged, side-effecting operations (a deploy can drive a full
+// snapshot restore). Gate it on platform-admin. requireAdminRole() reads the authenticated principal
+// (req.user, set by jwtAuthMiddleware), calls isAdmin(user.id), returns 403 for a non-admin, and FAILS
+// CLOSED (503, never next()) if the permission check itself throws.
+//
+// The guard is bound to this router's OWN namespaces (/changes, /schemas) rather than added path-less.
+// This router is mounted at `app.use('/api', changeManagementRouter)` (index.ts), so a path-less
+// `router.use(guard)` would execute for EVERY /api/* request that reaches this router in the chain —
+// 403'ing unrelated endpoints mounted after it (e.g. /api/admin/*) for any non-admin. Every route below
+// lives under /changes or /schemas, so these two mounts cover the whole surface (and any future route in
+// those namespaces) without leaking the gate to sibling routers.
+router.use('/changes', requireAdminRole())
+router.use('/schemas', requireAdminRole())
+
+// Identity comes ONLY from the authenticated principal. requireAdminRole() above guarantees req.user
+// is present; we never trust an `x-user-id` header and never fall back to a spoofable `anonymous`
+// identity (GHSA-q7hj). If req.user.id is somehow absent, fail rather than impersonate.
 const getUser = (req: Request): string => {
-  const headerUserId = req.headers['x-user-id']
-  const userId = Array.isArray(headerUserId) ? headerUserId[0] : headerUserId
-  return req.user?.id?.toString() || userId || 'anonymous'
+  const id = req.user?.id
+  if (id === undefined || id === null || String(id).length === 0) {
+    throw new Error('unauthenticated: change-management requires an authenticated req.user.id')
+  }
+  return String(id)
 }
 
 /**
@@ -58,10 +78,17 @@ router.post('/changes/:id/approve', async (req: Request, res: Response) => {
 router.post('/changes/:id/deploy', async (req: Request, res: Response) => {
   try {
     const userId = getUser(req)
+    // SECURITY (GHSA-q7hj): a caller-supplied `force` would drive a real full snapshot restore with no
+    // break-glass controls. Reject ANY truthy force outright — forced restore is not permitted via this
+    // endpoint (a genuine forced restore is a separate named, reason-logged, strongly-audited scheme).
+    // Never forward a caller-supplied force to the service.
+    if (req.body.force) {
+      return res.status(400).json({ success: false, error: 'force restore is not permitted via this endpoint' })
+    }
     const result = await changeManagementService.deployChange(
       req.params.id,
       userId,
-      { dryRun: req.body.dry_run, force: req.body.force }
+      { dryRun: req.body.dry_run, force: false }
     )
     res.json({ success: true, data: result })
   } catch (error) {

--- a/packages/core-backend/src/routes/snapshot-labels.ts
+++ b/packages/core-backend/src/routes/snapshot-labels.ts
@@ -5,8 +5,10 @@
  * Provides REST API for snapshot labeling operations
  */
 
+import type { Request } from 'express';
 import { Router } from 'express';
 import { snapshotService } from '../services/SnapshotService';
+import { requireAdminRole } from '../guards/audit-integration';
 import { Logger } from '../core/logger';
 
 const router = Router();
@@ -18,15 +20,28 @@ type ProtectionLevel = 'normal' | 'protected' | 'critical';
 // Type for release channels
 type ReleaseChannel = 'stable' | 'canary' | 'beta' | 'experimental';
 
+// SECURITY (GHSA-h8mf): this router is a SECOND surface for snapshot label mutations, mounted under
+// /api/admin/snapshots (admin-routes.ts). Like the /api/snapshots router, its mutations are raised to
+// platform-admin (requireAdminRole) and identity is taken ONLY from req.user.id — never the spoofable
+// `x-user-id` header, never a `system` fallback. requireAdminRole() guarantees req.user is present, so
+// getUserId only throws if reached without a principal (it never should be).
+const getUserId = (req: Request): string => {
+  const id = req.user?.id;
+  if (id === undefined || id === null || String(id).length === 0) {
+    throw new Error('unauthenticated: snapshot label mutation requires an authenticated req.user.id');
+  }
+  return String(id);
+};
+
 /**
  * PUT /api/snapshots/:id/tags
  * Add or remove tags from a snapshot
  */
-router.put('/:id/tags', async (req, res) => {
+router.put('/:id/tags', requireAdminRole(), async (req, res) => {
   try {
     const { id } = req.params;
     const { add, remove } = req.body;
-    const userId = req.headers['x-user-id'] as string || 'system';
+    const userId = getUserId(req);
 
     if (add && Array.isArray(add) && add.length > 0) {
       await snapshotService.addTags(id, add, userId);
@@ -56,11 +71,11 @@ router.put('/:id/tags', async (req, res) => {
  * PATCH /api/snapshots/:id/protection
  * Set protection level for a snapshot
  */
-router.patch('/:id/protection', async (req, res) => {
+router.patch('/:id/protection', requireAdminRole(), async (req, res) => {
   try {
     const { id } = req.params;
     const { level } = req.body;
-    const userId = req.headers['x-user-id'] as string || 'system';
+    const userId = getUserId(req);
 
     if (!level || !['normal', 'protected', 'critical'].includes(level)) {
       return res.status(400).json({
@@ -91,11 +106,11 @@ router.patch('/:id/protection', async (req, res) => {
  * PATCH /api/snapshots/:id/release-channel
  * Set release channel for a snapshot
  */
-router.patch('/:id/release-channel', async (req, res) => {
+router.patch('/:id/release-channel', requireAdminRole(), async (req, res) => {
   try {
     const { id } = req.params;
     const { channel } = req.body;
-    const userId = req.headers['x-user-id'] as string || 'system';
+    const userId = getUserId(req);
 
     if (channel && !['stable', 'canary', 'beta', 'experimental'].includes(channel)) {
       return res.status(400).json({

--- a/packages/core-backend/src/routes/snapshots.ts
+++ b/packages/core-backend/src/routes/snapshots.ts
@@ -6,7 +6,8 @@
 import type { Request, Response } from 'express';
 import { Router } from 'express'
 import { rbacGuard } from '../rbac/rbac'
-import { snapshotService } from '../services/SnapshotService'
+import { requireAdminRole, protectAdminOperation, requireSafetyCheck, OperationType } from '../guards'
+import { snapshotService, RESTORABLE_ITEM_TYPES, type RestorableItemType } from '../services/SnapshotService'
 import { Logger } from '../core/logger'
 
 const logger = new Logger('SnapshotsRouter')
@@ -14,11 +15,33 @@ const logger = new Logger('SnapshotsRouter')
 type ProtectionLevel = 'normal' | 'protected' | 'critical'
 type ReleaseChannel = 'stable' | 'canary' | 'beta' | 'experimental'
 
-const getUserId = (req: Request) =>
-  req.user?.id?.toString() || (req.headers['x-user-id'] as string) || 'system'
+// SECURITY (GHSA-h8mf): identity comes ONLY from the authenticated principal. Every snapshot
+// MUTATION below is gated by requireAdminRole(), which guarantees req.user is present; we never
+// trust an `x-user-id` header and never fall back to a spoofable `system` identity. If req.user.id
+// is somehow absent we fail rather than impersonate. (Defensive hardening: on the normal JWT chain
+// req.user.id is always set on a successful auth, so the old fallback was largely unreachable — but
+// removing it removes the ambiguity entirely.)
+const getUserId = (req: Request): string => {
+  const id = req.user?.id
+  if (id === undefined || id === null || String(id).length === 0) {
+    throw new Error('unauthenticated: snapshot mutation requires an authenticated req.user.id')
+  }
+  return String(id)
+}
 
 export function snapshotsRouter(): Router {
   const r = Router()
+
+  // SECURITY (GHSA-h8mf): every snapshot MUTATION (create/restore/delete/lock-unlock/protection/
+  // release-channel/tags/cleanup) is a privileged, side-effecting operation — a restore drives a
+  // real write-back, and lock/protection changes gate whether a restore/delete is even possible.
+  // The prior `rbacGuard('permissions','write')` granted any non-admin holding the `permissions:write`
+  // code, so a low-privilege user could unlock-then-restore or trigger a destructive full restore.
+  // We therefore raise ALL mutations to platform-admin via requireAdminRole() (the existing admin
+  // safety guard: 403 for non-admin / 403 for no principal / 503 fail-closed if the RBAC check
+  // itself throws — it never falls through). READ routes keep `permissions:read` (scope not widened).
+  // org/view-scoped snapshot permissions are deferred to the later RBAC line; this is the
+  // conservative platform-admin boundary.
 
   // List snapshots for a view or filtered query
   r.get('/api/snapshots', rbacGuard('permissions', 'read'), async (req: Request, res: Response) => {
@@ -81,7 +104,7 @@ export function snapshotsRouter(): Router {
   })
 
   // Add/remove snapshot tags
-  r.put('/api/snapshots/:id/tags', rbacGuard('permissions', 'write'), async (req: Request, res: Response) => {
+  r.put('/api/snapshots/:id/tags', requireAdminRole(), async (req: Request, res: Response) => {
     try {
       const { id } = req.params
       const { add, remove } = req.body
@@ -113,7 +136,7 @@ export function snapshotsRouter(): Router {
   })
 
   // Set protection level
-  r.patch('/api/snapshots/:id/protection', rbacGuard('permissions', 'write'), async (req: Request, res: Response) => {
+  r.patch('/api/snapshots/:id/protection', requireAdminRole(), async (req: Request, res: Response) => {
     try {
       const { id } = req.params
       const { level } = req.body
@@ -147,7 +170,7 @@ export function snapshotsRouter(): Router {
   })
 
   // Set release channel
-  r.patch('/api/snapshots/:id/release-channel', rbacGuard('permissions', 'write'), async (req: Request, res: Response) => {
+  r.patch('/api/snapshots/:id/release-channel', requireAdminRole(), async (req: Request, res: Response) => {
     try {
       const { id } = req.params
       const { channel } = req.body
@@ -203,7 +226,7 @@ export function snapshotsRouter(): Router {
   })
 
   // Create a new snapshot
-  r.post('/api/snapshots', rbacGuard('permissions', 'write'), async (req: Request, res: Response) => {
+  r.post('/api/snapshots', requireAdminRole(), async (req: Request, res: Response) => {
     const userId = getUserId(req)
     const { view_id, name, description, snapshot_type, metadata, expires_at } = req.body
 
@@ -235,18 +258,78 @@ export function snapshotsRouter(): Router {
     }
   })
 
+  // SECURITY (GHSA-h8mf) SCOPE: the three legacy DESTRUCTIVE snapshot endpoints in this router —
+  // restore (POST /api/snapshots/:id/restore, CRITICAL), delete (DELETE /api/snapshots/:id, MEDIUM),
+  // and cleanup (POST /api/snapshots/cleanup, HIGH) — are ALL raised to the canonical admin safety stack
+  // (protectAdminOperation + requireSafetyCheck). cleanup is included deliberately: it is a batch delete
+  // whose canonical twin already uses the same stack, so leaving it on the old guard would keep a weaker
+  // door open. Each of the three is annotated at its route below.
+
   // Restore a snapshot
-  r.post('/api/snapshots/:id/restore', rbacGuard('permissions', 'write'), async (req: Request, res: Response) => {
+  // SECURITY (GHSA-h8mf): this legacy endpoint reaches the SAME destructive primitive as the canonical
+  // admin route (admin-routes.ts POST /api/admin/snapshots/:id/restore), so it must carry the SAME
+  // security stack — platform-admin + audit (protectAdminOperation) AND the SafetyGuard confirmation
+  // (requireSafetyCheck). RESTORE_SNAPSHOT is RiskLevel.CRITICAL. `confirm_full` below is an ordinary
+  // request field for restore-SCOPE validation; it is NOT a safety token and cannot substitute for one.
+  r.post(
+    '/api/snapshots/:id/restore',
+    ...protectAdminOperation(OperationType.RESTORE_SNAPSHOT),
+    requireSafetyCheck({
+      operation: OperationType.RESTORE_SNAPSHOT,
+      getDetails: (req: Request) => ({ snapshotId: req.params.id })
+    }),
+    async (req: Request, res: Response) => {
     const snapshotId = req.params.id
     const userId = getUserId(req)
-    const { restore_type, item_types } = req.body
+    const { restore_type, item_types, confirm_full } = req.body
+
+    // SECURITY (GHSA-h8mf): validate the restore scope at the edge (defense-in-depth; SnapshotService
+    // re-validates the same invariant authoritatively so other callers cannot bypass this). restore_type
+    // is not a mere label — with no item_types the restore covers EVERYTHING — so bind the two:
+    //   - restore_type must be explicitly 'full' | 'partial' | 'selective';
+    //   - a 'full' restore must be explicitly confirmed (confirm_full === true) and must NOT narrow via item_types;
+    //   - 'partial'/'selective' must carry a non-empty item_types drawn from RESTORABLE_ITEM_TYPES.
+    if (restore_type !== 'full' && restore_type !== 'partial' && restore_type !== 'selective') {
+      return res.status(400).json({
+        ok: false,
+        error: { code: 'BAD_REQUEST', message: "restore_type must be 'full', 'partial', or 'selective'" }
+      })
+    }
+    if (restore_type === 'full') {
+      if (confirm_full !== true) {
+        return res.status(400).json({
+          ok: false,
+          error: { code: 'BAD_REQUEST', message: 'a full restore must be explicitly confirmed with confirm_full:true' }
+        })
+      }
+      if (item_types !== undefined && !(Array.isArray(item_types) && item_types.length === 0)) {
+        return res.status(400).json({
+          ok: false,
+          error: { code: 'BAD_REQUEST', message: "restore_type 'full' must not specify item_types" }
+        })
+      }
+    } else {
+      if (!Array.isArray(item_types) || item_types.length === 0) {
+        return res.status(400).json({
+          ok: false,
+          error: { code: 'BAD_REQUEST', message: `restore_type '${restore_type}' requires a non-empty item_types array` }
+        })
+      }
+      const invalid = item_types.filter((t: unknown) => !RESTORABLE_ITEM_TYPES.includes(t as RestorableItemType))
+      if (invalid.length > 0) {
+        return res.status(400).json({
+          ok: false,
+          error: { code: 'BAD_REQUEST', message: `item_types outside allowlist [${RESTORABLE_ITEM_TYPES.join(', ')}]: ${invalid.join(', ')}` }
+        })
+      }
+    }
 
     try {
       const result = await snapshotService.restoreSnapshot({
         snapshotId,
         restoredBy: userId,
         restoreType: restore_type,
-        itemTypes: item_types
+        itemTypes: restore_type === 'full' ? undefined : item_types
       })
 
       return res.json({ ok: true, data: result })
@@ -260,7 +343,17 @@ export function snapshotsRouter(): Router {
   })
 
   // Delete a snapshot
-  r.delete('/api/snapshots/:id', rbacGuard('permissions', 'write'), async (req: Request, res: Response) => {
+  // SECURITY (GHSA-h8mf): same reasoning as restore above — this legacy endpoint must carry the same
+  // stack as its canonical twin (admin-routes.ts DELETE /api/admin/snapshots/:id): platform-admin +
+  // audit AND the SafetyGuard confirmation. DELETE_SNAPSHOT is RiskLevel.MEDIUM.
+  r.delete(
+    '/api/snapshots/:id',
+    ...protectAdminOperation(OperationType.DELETE_SNAPSHOT),
+    requireSafetyCheck({
+      operation: OperationType.DELETE_SNAPSHOT,
+      getDetails: (req: Request) => ({ snapshotId: req.params.id })
+    }),
+    async (req: Request, res: Response) => {
     const snapshotId = req.params.id
     const userId = getUserId(req)
 
@@ -289,7 +382,7 @@ export function snapshotsRouter(): Router {
   })
 
   // Lock/unlock a snapshot
-  r.patch('/api/snapshots/:id/lock', rbacGuard('permissions', 'write'), async (req: Request, res: Response) => {
+  r.patch('/api/snapshots/:id/lock', requireAdminRole(), async (req: Request, res: Response) => {
     const snapshotId = req.params.id
     const userId = getUserId(req)
     const { locked } = req.body
@@ -349,7 +442,14 @@ export function snapshotsRouter(): Router {
   })
 
   // Cleanup expired snapshots
-  r.post('/api/snapshots/cleanup', rbacGuard('permissions', 'write'), async (_req: Request, res: Response) => {
+  // SECURITY (GHSA-h8mf): cleanup deletes snapshots (RiskLevel.HIGH) and its canonical twin
+  // (admin-routes.ts POST /api/admin/snapshots/cleanup) carries protectAdminOperation +
+  // requireSafetyCheck — this legacy endpoint reuses the same stack rather than being the weak door.
+  r.post(
+    '/api/snapshots/cleanup',
+    ...protectAdminOperation(OperationType.CLEANUP_SNAPSHOTS),
+    requireSafetyCheck({ operation: OperationType.CLEANUP_SNAPSHOTS }),
+    async (_req: Request, res: Response) => {
     try {
       const result = await snapshotService.cleanupExpired()
       return res.json({

--- a/packages/core-backend/src/services/SnapshotService.ts
+++ b/packages/core-backend/src/services/SnapshotService.ts
@@ -14,6 +14,16 @@ import crypto from 'crypto'
 import type { Database } from '../db/types'
 import { protectionRuleService } from './ProtectionRuleService'
 
+/**
+ * SECURITY (GHSA-h8mf): the only item types a snapshot restore can act on. restoreItem() handles
+ * exactly these three (view / view_state / table_row); any other type is a no-op warning. A
+ * partial/selective restore MUST draw every itemType from this allowlist, and a full restore MUST
+ * NOT narrow to a subset. This is the single source of truth for both the route validation
+ * (defense-in-depth) and the authoritative service-layer invariant in restoreSnapshot().
+ */
+export const RESTORABLE_ITEM_TYPES = ['view', 'view_state', 'table_row'] as const
+export type RestorableItemType = (typeof RESTORABLE_ITEM_TYPES)[number]
+
 export interface SnapshotCreateOptions {
   viewId: string
   name: string
@@ -304,6 +314,38 @@ export class SnapshotService {
 
     if (!db) {
       throw new Error('Database not available')
+    }
+
+    // SECURITY (GHSA-h8mf): authoritative restore-scope invariant, enforced HERE (not only at the
+    // HTTP route) so that no caller — internal service, a future route, or a test harness — can
+    // trigger a full restore while labeling it partial, or a partial restore over an item type
+    // outside the allowlist. `restore_type` alone is only a log label; the real determinant of
+    // scope is `itemTypes` (missing/empty itemTypes = restore EVERYTHING). We therefore bind the
+    // two together and reject any contradiction, before touching the database:
+    //   - restoreType MUST be explicitly one of 'full' | 'partial' | 'selective' (no silent default).
+    //   - 'full' MUST NOT carry itemTypes (a full restore covers every item type).
+    //   - 'partial' | 'selective' MUST carry a non-empty itemTypes, every value in RESTORABLE_ITEM_TYPES.
+    const restoreType = options.restoreType
+    if (restoreType !== 'full' && restoreType !== 'partial' && restoreType !== 'selective') {
+      throw new Error(
+        `Invalid restoreType: must be explicitly 'full', 'partial', or 'selective' (received: ${String(restoreType)})`
+      )
+    }
+    if (restoreType === 'full') {
+      if (options.itemTypes && options.itemTypes.length > 0) {
+        throw new Error("restoreType 'full' must not specify itemTypes; a full restore covers all item types")
+      }
+    } else {
+      const itemTypes = options.itemTypes
+      if (!Array.isArray(itemTypes) || itemTypes.length === 0) {
+        throw new Error(`restoreType '${restoreType}' requires a non-empty itemTypes allowlist`)
+      }
+      const invalid = itemTypes.filter((t) => !RESTORABLE_ITEM_TYPES.includes(t as RestorableItemType))
+      if (invalid.length > 0) {
+        throw new Error(
+          `itemTypes contains values outside the allowlist [${RESTORABLE_ITEM_TYPES.join(', ')}]: ${invalid.join(', ')}`
+        )
+      }
     }
 
     this.logger.info(`Restoring snapshot: ${options.snapshotId}`)

--- a/packages/core-backend/tests/integration/snapshot-protection.test.ts
+++ b/packages/core-backend/tests/integration/snapshot-protection.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { MetaSheetServer } from '../../src/index'
 import { snapshotService } from '../../src/services/SnapshotService'
 import { protectionRuleService } from '../../src/services/ProtectionRuleService'
+import { pool } from '../../src/db/pg'
 import net from 'net'
 import crypto from 'crypto'
 import type { ProtectionRule } from '../../src/services/ProtectionRuleService'
@@ -43,6 +44,17 @@ describe('Snapshot Protection System E2E', () => {
     }
     baseUrl = `http://127.0.0.1:${address.port}`
 
+    // SECURITY (GHSA-h8mf): snapshot MUTATIONS (tags / protection level / release channel) are now
+    // platform-admin only — protection_level gates deletion and restore, so it is not a
+    // `permissions:write` operation. This E2E drives those operator routes, so its actor must be a
+    // platform admin. isAdmin() (rbac/service.ts) = a user_roles row with role_id 'admin'.
+    if (pool) {
+      await pool.query(
+        `INSERT INTO user_roles (user_id, role_id) VALUES ($1, 'admin') ON CONFLICT DO NOTHING`,
+        [testUserId]
+      )
+    }
+
     const tokenRes = await authFetch(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(testUserId)}`)
     if (tokenRes.status !== 200) {
       throw new Error(`snapshot-protection: dev-token request failed (${tokenRes.status})`)
@@ -66,6 +78,15 @@ describe('Snapshot Protection System E2E', () => {
     if (testRuleId) {
       try {
         await protectionRuleService.deleteRule(testRuleId)
+      } catch (e) {
+        // Ignore cleanup errors
+      }
+    }
+
+    // Drop the platform-admin grant seeded in beforeAll (GHSA-h8mf) so it cannot leak to other suites.
+    if (pool) {
+      try {
+        await pool.query(`DELETE FROM user_roles WHERE user_id = $1 AND role_id = 'admin'`, [testUserId])
       } catch (e) {
         // Ignore cleanup errors
       }

--- a/packages/core-backend/tests/unit/SnapshotService.test.ts
+++ b/packages/core-backend/tests/unit/SnapshotService.test.ts
@@ -116,7 +116,9 @@ describe('SnapshotService - Protection Integration', () => {
       execution_time_ms: 10
     })
 
-    await expect(service.restoreSnapshot({ snapshotId: 'snap-1', restoredBy: 'user-1' }))
+    // restoreType is now required (GHSA-h8mf explicit-scope invariant); 'full' keeps this test's
+    // intent (a full restore that the protection rule then blocks).
+    await expect(service.restoreSnapshot({ snapshotId: 'snap-1', restoredBy: 'user-1', restoreType: 'full' }))
       .rejects.toThrow('Snapshot restore blocked by rule: Block Restore')
   })
 })

--- a/packages/core-backend/tests/unit/admin-safety-confirm-authz.test.ts
+++ b/packages/core-backend/tests/unit/admin-safety-confirm-authz.test.ts
@@ -1,0 +1,85 @@
+/**
+ * GHSA (AC5) — POST /api/admin/safety/confirm must be platform-admin gated. Confirming a dangerous
+ * operation is itself privileged; the rate-limit + idempotency guards it previously carried are
+ * throughput controls, not authorization. This asserts requireAdminRole is the FIRST guard on the route.
+ *
+ * Mirrors admin-snapshot-delete-authz.test.ts (direct guard-handler invocation via initAdminRoutes).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Router } from 'express'
+import { isAdmin } from '../../src/rbac/service'
+
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: vi.fn().mockResolvedValue(true),
+}))
+vi.mock('../../src/db/pg', () => ({ pool: null }))
+vi.mock('../../src/services/SnapshotService', () => ({}))
+vi.mock('../../src/audit/audit', () => ({}))
+
+import { initAdminRoutes } from '../../src/routes/admin-routes'
+
+function firstGuardOf(router: Router, method: 'post', routePath: string) {
+  const layer = (router as unknown as {
+    stack?: Array<{
+      route?: {
+        path?: string
+        methods?: Record<string, boolean>
+        stack?: Array<{ handle: (req: any, res: any, next?: any) => Promise<void> | void }>
+      }
+    }>
+  }).stack?.find((item) => item.route?.path === routePath && item.route?.methods?.[method])
+  const stack = layer?.route?.stack ?? []
+  if (stack.length === 0) throw new Error(`Route handler not found for ${method.toUpperCase()} ${routePath}`)
+  return stack[0]
+}
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(payload: unknown) {
+      this.body = payload
+      return this
+    },
+  }
+}
+
+describe('POST /safety/confirm — platform-admin guard first (GHSA AC5)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(isAdmin).mockResolvedValue(true)
+  })
+
+  it('first guard denies a non-admin with 403 and does not call next', async () => {
+    vi.mocked(isAdmin).mockResolvedValue(false)
+    const guard = firstGuardOf(initAdminRoutes(), 'post', '/safety/confirm')
+    const res = mockRes()
+    const next = vi.fn()
+    await guard.handle({ user: { id: 'u-nonadmin' }, ip: '127.0.0.1', path: '/safety/confirm' }, res, next)
+    expect(res.statusCode).toBe(403)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('first guard fails closed with 503 when the RBAC check throws', async () => {
+    vi.mocked(isAdmin).mockRejectedValue(new Error('rbac down'))
+    const guard = firstGuardOf(initAdminRoutes(), 'post', '/safety/confirm')
+    const res = mockRes()
+    const next = vi.fn()
+    await guard.handle({ user: { id: 'u-x' }, ip: '127.0.0.1', path: '/safety/confirm' }, res, next)
+    expect(res.statusCode).toBe(503)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('first guard passes a platform-admin through to the next handler', async () => {
+    const guard = firstGuardOf(initAdminRoutes(), 'post', '/safety/confirm')
+    const res = mockRes()
+    const next = vi.fn()
+    await guard.handle({ user: { id: 'u-admin' }, ip: '127.0.0.1', path: '/safety/confirm' }, res, next)
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(res.statusCode).toBe(200)
+  })
+})

--- a/packages/core-backend/tests/unit/admin-snapshot-delete-authz.test.ts
+++ b/packages/core-backend/tests/unit/admin-snapshot-delete-authz.test.ts
@@ -1,0 +1,89 @@
+/**
+ * GHSA-h8mf (F3) — admin-routes DELETE /api/admin/snapshots/:id must be platform-admin, not merely
+ * safety-confirmed. Before the fix it was guarded only by requireSafetyCheck (a confirmation token,
+ * not a role), unlike its restore/cleanup siblings which use protectAdminOperation. This asserts the
+ * FIRST guard on the route is the fail-closed admin guard.
+ *
+ * Mirrors admin-yjs-status-routes.test.ts (direct guard-handler invocation via initAdminRoutes).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Router } from 'express'
+import { isAdmin } from '../../src/rbac/service'
+
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: vi.fn().mockResolvedValue(true),
+}))
+vi.mock('../../src/db/pg', () => ({ pool: null }))
+vi.mock('../../src/services/SnapshotService', () => ({}))
+vi.mock('../../src/audit/audit', () => ({}))
+
+import { initAdminRoutes } from '../../src/routes/admin-routes'
+
+function getRouteStack(router: Router, method: 'delete' | 'post', routePath: string) {
+  const layer = (router as unknown as {
+    stack?: Array<{
+      route?: {
+        path?: string
+        methods?: Record<string, boolean>
+        stack?: Array<{ handle: (req: any, res: any, next?: any) => Promise<void> | void }>
+      }
+    }>
+  }).stack?.find((item) => item.route?.path === routePath && item.route?.methods?.[method])
+  const stack = layer?.route?.stack ?? []
+  if (stack.length === 0) throw new Error(`Route handler not found for ${method.toUpperCase()} ${routePath}`)
+  return stack
+}
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(payload: unknown) {
+      this.body = payload
+      return this
+    },
+  }
+}
+
+describe('admin DELETE /snapshots/:id — platform-admin guard first (GHSA-h8mf F3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(isAdmin).mockResolvedValue(true)
+  })
+
+  it('first guard denies a non-admin with 403 and does not call next', async () => {
+    vi.mocked(isAdmin).mockResolvedValue(false)
+    const router = initAdminRoutes()
+    const stack = getRouteStack(router, 'delete', '/snapshots/:id')
+    const res = mockRes()
+    const next = vi.fn()
+    await stack[0]?.handle({ user: { id: 'u-nonadmin' }, ip: '127.0.0.1', path: '/snapshots/s1' }, res, next)
+    expect(res.statusCode).toBe(403)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('first guard fails closed with 503 when the RBAC check throws', async () => {
+    vi.mocked(isAdmin).mockRejectedValue(new Error('rbac down'))
+    const router = initAdminRoutes()
+    const stack = getRouteStack(router, 'delete', '/snapshots/:id')
+    const res = mockRes()
+    const next = vi.fn()
+    await stack[0]?.handle({ user: { id: 'u-x' }, ip: '127.0.0.1', path: '/snapshots/s1' }, res, next)
+    expect(res.statusCode).toBe(503)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('first guard passes a platform-admin through to the next handler', async () => {
+    const router = initAdminRoutes()
+    const stack = getRouteStack(router, 'delete', '/snapshots/:id')
+    const res = mockRes()
+    const next = vi.fn()
+    await stack[0]?.handle({ user: { id: 'u-admin' }, ip: '127.0.0.1', path: '/snapshots/s1' }, res, next)
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(res.statusCode).toBe(200)
+  })
+})

--- a/packages/core-backend/tests/unit/change-management-authz.test.ts
+++ b/packages/core-backend/tests/unit/change-management-authz.test.ts
@@ -1,0 +1,191 @@
+/**
+ * GHSA-q7hj — change-management router: platform-admin gate + identity hardening + force rejection.
+ *
+ * Owner ruling (5 required proofs):
+ *   (a) non-admin -> 403;
+ *   (b) service methods called ZERO times on denial;
+ *   (c) RBAC-check failure -> ZERO side effects (fail-closed 503, no service call);
+ *   (d) platform-admin normal path no regression;
+ *   (e) force=true rejected.
+ * Plus: unauthenticated -> 403; truthy non-boolean force rejected (bypass prevention);
+ * identity comes ONLY from req.user.id (x-user-id header ignored).
+ *
+ * Mount pattern mirrors tests/unit/multitable-ai-usage-summary-route.test.ts:
+ * rbac/service + db/pg mocked; the two change-management services mocked to spy call counts.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { isAdmin } from '../../src/rbac/service'
+
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: vi.fn().mockResolvedValue(true),
+}))
+
+// pool=null makes requireAdminRole's best-effort logSafetyOperation a no-op (no throw on denial),
+// so denials return a clean 403/503 rather than being swallowed into the catch.
+vi.mock('../../src/db/pg', () => ({
+  pool: null,
+}))
+
+vi.mock('../../src/services/ChangeManagementService', () => ({
+  changeManagementService: {
+    createChangeRequest: vi.fn().mockResolvedValue({ id: 'cr-created' }),
+    approveChangeRequest: vi.fn().mockResolvedValue({ approved: true }),
+    deployChange: vi.fn().mockResolvedValue({ deployed: true }),
+    rollbackChange: vi.fn().mockResolvedValue({ rolledBack: true }),
+  },
+}))
+
+vi.mock('../../src/services/SchemaSnapshotService', () => ({
+  schemaSnapshotService: {
+    createSchemaSnapshot: vi.fn().mockResolvedValue({ id: 'snap-created' }),
+    diffSchemas: vi.fn().mockResolvedValue({ diff: [] }),
+  },
+}))
+
+import changeManagementRouter from '../../src/routes/change-management'
+import { changeManagementService } from '../../src/services/ChangeManagementService'
+import { schemaSnapshotService } from '../../src/services/SchemaSnapshotService'
+
+function buildApp(user?: { id: string }): Express {
+  const app = express()
+  app.use(express.json())
+  if (user) {
+    app.use((req, _res, next) => {
+      ;(req as express.Request & { user?: { id: string } }).user = user
+      next()
+    })
+  }
+  app.use('/api', changeManagementRouter)
+  return app
+}
+
+function expectNoServiceCalls(): void {
+  expect(changeManagementService.createChangeRequest).toHaveBeenCalledTimes(0)
+  expect(changeManagementService.approveChangeRequest).toHaveBeenCalledTimes(0)
+  expect(changeManagementService.deployChange).toHaveBeenCalledTimes(0)
+  expect(changeManagementService.rollbackChange).toHaveBeenCalledTimes(0)
+  expect(schemaSnapshotService.createSchemaSnapshot).toHaveBeenCalledTimes(0)
+  expect(schemaSnapshotService.diffSchemas).toHaveBeenCalledTimes(0)
+}
+
+describe('change-management router — platform-admin gate + identity + force rejection (GHSA-q7hj)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(isAdmin).mockResolvedValue(true)
+  })
+
+  it('(a)+(b) non-admin principal -> 403 on every route, and NO service method is called', async () => {
+    vi.mocked(isAdmin).mockResolvedValue(false)
+    const app = buildApp({ id: 'u-nonadmin' })
+
+    await request(app).post('/api/changes').send({ title: 'x' }).expect(403)
+    await request(app).post('/api/changes/cr1/approve').send({}).expect(403)
+    await request(app).post('/api/changes/cr1/deploy').send({}).expect(403)
+    await request(app).post('/api/changes/cr1/rollback').send({}).expect(403)
+    await request(app).post('/api/schemas/v1/snapshot').send({}).expect(403)
+    await request(app).get('/api/schemas/diff?schema1=a&schema2=b').expect(403)
+
+    expectNoServiceCalls()
+  })
+
+  it('unauthenticated (no req.user) -> 403, no service call', async () => {
+    const app = buildApp(undefined)
+    await request(app).post('/api/changes/cr1/deploy').send({}).expect(403)
+    expectNoServiceCalls()
+  })
+
+  it('(c) RBAC check failure (isAdmin throws) -> 503 fail-closed, NO service call (zero side effects)', async () => {
+    vi.mocked(isAdmin).mockRejectedValue(new Error('rbac db down'))
+    const app = buildApp({ id: 'u-someone' })
+    await request(app).post('/api/changes/cr1/deploy').send({}).expect(503)
+    await request(app).post('/api/schemas/v1/snapshot').send({}).expect(503)
+    expectNoServiceCalls()
+  })
+
+  it('(d) platform-admin normal path: create/approve/rollback/snapshot/diff succeed (no regression)', async () => {
+    const app = buildApp({ id: 'u-admin' })
+
+    await request(app).post('/api/changes').send({ title: 'x' }).expect(201)
+    expect(changeManagementService.createChangeRequest).toHaveBeenCalledTimes(1)
+
+    await request(app).post('/api/changes/cr1/approve').send({ comment: 'ok' }).expect(200)
+    expect(changeManagementService.approveChangeRequest).toHaveBeenCalledTimes(1)
+
+    await request(app).post('/api/changes/cr1/rollback').send({ reason: 'r' }).expect(200)
+    expect(changeManagementService.rollbackChange).toHaveBeenCalledTimes(1)
+
+    await request(app).post('/api/schemas/v1/snapshot').send({}).expect(201)
+    expect(schemaSnapshotService.createSchemaSnapshot).toHaveBeenCalledTimes(1)
+
+    await request(app).get('/api/schemas/diff?schema1=a&schema2=b').expect(200)
+    expect(schemaSnapshotService.diffSchemas).toHaveBeenCalledTimes(1)
+  })
+
+  it('(d) platform-admin non-force deploy: succeeds and forwards force:false to the service', async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app).post('/api/changes/cr1/deploy').send({ dry_run: false }).expect(200)
+    expect(changeManagementService.deployChange).toHaveBeenCalledTimes(1)
+    expect(changeManagementService.deployChange).toHaveBeenCalledWith('cr1', 'u-admin', {
+      dryRun: false,
+      force: false,
+    })
+  })
+
+  it('(e) platform-admin deploy with force=true -> 400, deployChange NOT called', async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app).post('/api/changes/cr1/deploy').send({ force: true }).expect(400)
+    expect(changeManagementService.deployChange).toHaveBeenCalledTimes(0)
+  })
+
+  it('(e) truthy non-boolean force ("true", 1) is also rejected -> 400, deployChange NOT called (bypass prevention)', async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app).post('/api/changes/cr1/deploy').send({ force: 'true' }).expect(400)
+    await request(app).post('/api/changes/cr1/deploy').send({ force: 1 }).expect(400)
+    expect(changeManagementService.deployChange).toHaveBeenCalledTimes(0)
+  })
+
+  it('identity comes ONLY from req.user.id — a spoofed x-user-id header is ignored', async () => {
+    const app = buildApp({ id: 'u-realadmin' })
+    await request(app)
+      .post('/api/changes')
+      .set('x-user-id', 'u-spoofed')
+      .send({ title: 'x' })
+      .expect(201)
+    expect(changeManagementService.createChangeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ requestedBy: 'u-realadmin' }),
+    )
+    expect(changeManagementService.createChangeRequest).not.toHaveBeenCalledWith(
+      expect.objectContaining({ requestedBy: 'u-spoofed' }),
+    )
+  })
+
+  // REGRESSION (GHSA-q7hj): this router is mounted at app.use('/api', changeManagementRouter), so a
+  // PATH-LESS router.use(requireAdminRole()) executes for EVERY /api/* request that reaches it and
+  // 403s unrelated endpoints mounted AFTER it (e.g. /api/admin/*) for any non-admin — which would
+  // brick the app for non-admins. The guard must be bound to this router's own namespaces only.
+  // Mounting the router in isolation (as the tests above do) cannot see this; we must reproduce the
+  // real wiring: the router at '/api' with a sibling /api route registered after it.
+  it('the admin gate does NOT leak to sibling /api routes mounted after this router', async () => {
+    vi.mocked(isAdmin).mockResolvedValue(false)
+    const app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as express.Request & { user?: { id: string } }).user = { id: 'u-nonadmin' }
+      next()
+    })
+    app.use('/api', changeManagementRouter)
+    // A sibling router/route mounted AFTER the change-management router, exactly like /api/admin/* is.
+    app.get('/api/admin/safety/rules', (_req, res) => {
+      res.status(200).json({ ok: true })
+    })
+
+    // change-management surface stays gated for a non-admin...
+    await request(app).post('/api/changes/cr1/deploy').send({}).expect(403)
+    await request(app).get('/api/schemas/diff?schema1=a&schema2=b').expect(403)
+    // ...but an unrelated /api endpoint mounted after it MUST remain reachable.
+    await request(app).get('/api/admin/safety/rules').expect(200)
+    expectNoServiceCalls()
+  })
+})

--- a/packages/core-backend/tests/unit/safety-guard-confirm-flow.test.ts
+++ b/packages/core-backend/tests/unit/safety-guard-confirm-flow.test.ts
@@ -1,0 +1,236 @@
+/**
+ * GHSA — SafetyGuard double-confirm flow + token binding.
+ *
+ * Fixes the deadlock where a double-confirm operation (RESTORE_SNAPSHOT, DROP_TABLE, TRUNCATE_TABLE,
+ * SHUTDOWN_SERVICE, RELOAD_ALL_PLUGINS) could NEVER complete over HTTP: the route retry carries only the
+ * token, but verifyConfirmation re-checked the typed phrase unconditionally, so a confirmed token still
+ * 403'd forever. And it hardens the token: a confirmation is now bound to the operation, initiator, and
+ * resource of the request that minted it, so a confirmed token cannot be replayed cross-operation,
+ * cross-user, or cross-resource, and is one-time-use.
+ *
+ * These tests use the REAL SafetyGuard (nothing mocked) against a minimal app that wires requireSafetyCheck
+ * + the /safety/confirm handler exactly as production does — this is the 403→confirm→retry→200 proof the
+ * gate found missing, plus a failure-mode matrix, each row a mutation target.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import express, { type Express } from 'express'
+import request from 'supertest'
+import {
+  initSafetyGuard,
+  getSafetyGuard,
+  requireSafetyCheck,
+  createSafetyConfirmEndpoint,
+  OperationType,
+} from '../../src/guards'
+
+function buildApp(): Express {
+  const app = express()
+  app.use(express.json())
+  // Identity is taken from x-test-user so a single app can act as different admins.
+  app.use((req, _res, next) => {
+    const u = req.headers['x-test-user']
+    if (u) (req as express.Request & { user?: { id: string } }).user = { id: String(u) }
+    next()
+  })
+  app.post(
+    '/op/restore/:id',
+    requireSafetyCheck({ operation: OperationType.RESTORE_SNAPSHOT, getDetails: (req) => ({ snapshotId: req.params.id }) }),
+    (_req, res) => res.json({ ok: true, did: 'restore' }),
+  )
+  app.post(
+    '/op/delete/:id',
+    requireSafetyCheck({ operation: OperationType.DELETE_SNAPSHOT, getDetails: (req) => ({ snapshotId: req.params.id }) }),
+    (_req, res) => res.json({ ok: true, did: 'delete' }),
+  )
+  app.post(
+    '/op/cleanup',
+    requireSafetyCheck({ operation: OperationType.CLEANUP_SNAPSHOTS }),
+    (_req, res) => res.json({ ok: true, did: 'cleanup' }),
+  )
+  // A route whose resource details are NESTED (like the admin bulk-data routes' filters/updates), used
+  // to exercise resourceKey's recursive canonicalization. MEDIUM op so a single token-retry completes.
+  app.post(
+    '/op/bulk/:id',
+    requireSafetyCheck({
+      operation: OperationType.DELETE_SNAPSHOT,
+      getDetails: (req) => ({ id: req.params.id, filters: req.body.filters }),
+    }),
+    (_req, res) => res.json({ ok: true, did: 'bulk' }),
+  )
+  // The confirm handler derives the initiator from req.user (mirrors the admin-routes mount, which also
+  // adds requireAdminRole — that gate is proven separately in admin-safety-confirm-authz.test.ts).
+  app.post('/safety/confirm', createSafetyConfirmEndpoint())
+  return app
+}
+
+const M = 'admin-M'
+const N = 'admin-N'
+
+describe('SafetyGuard double-confirm flow + token binding (GHSA)', () => {
+  let app: Express
+
+  beforeEach(() => {
+    initSafetyGuard() // fresh guard: empty pending map, default 300s expiry
+    app = buildApp()
+  })
+  afterEach(() => {
+    getSafetyGuard().destroy() // clear the cleanup interval + pending map
+  })
+
+  async function mintToken(path: string, user = M): Promise<string> {
+    const res = await request(app).post(path).set('x-test-user', user).send({}).expect(403)
+    expect(res.body.code).toBe('SAFETY_CHECK_REQUIRED')
+    const token = res.body.confirmation?.token
+    expect(token).toBeTruthy()
+    return token as string
+  }
+
+  it('RESTORE (double-confirm CRITICAL): 403 → confirm(typed+ack) → retry(token) → 200 COMPLETES', async () => {
+    const token = await mintToken('/op/restore/s1')
+    // Confirm with the typed phrase + acknowledgment.
+    await request(app)
+      .post('/safety/confirm')
+      .set('x-test-user', M)
+      .send({ token, typedConfirmation: 'restore_snapshot', acknowledged: true })
+      .expect(200)
+    // Retry the operation with ONLY the token — this is the path that was permanently 403 before.
+    const done = await request(app).post('/op/restore/s1').set('x-test-user', M).set('x-safety-token', token).expect(200)
+    expect(done.body).toEqual({ ok: true, did: 'restore' })
+  })
+
+  it('DELETE (MEDIUM): 403 → single retry with token → 200 (no double-confirm, no ack needed)', async () => {
+    const token = await mintToken('/op/delete/s1')
+    const done = await request(app).post('/op/delete/s1').set('x-test-user', M).set('x-safety-token', token).expect(200)
+    expect(done.body.did).toBe('delete')
+  })
+
+  it('CLEANUP (HIGH): retry-without-ack 403; confirm(ack) → retry → 200', async () => {
+    const token = await mintToken('/op/cleanup')
+    // A HIGH op needs acknowledgment; the token-only retry cannot supply it → still 403.
+    await request(app).post('/op/cleanup').set('x-test-user', M).set('x-safety-token', token).expect(403)
+    await request(app).post('/safety/confirm').set('x-test-user', M).send({ token, acknowledged: true }).expect(200)
+    const done = await request(app).post('/op/cleanup').set('x-test-user', M).set('x-safety-token', token).expect(200)
+    expect(done.body.did).toBe('cleanup')
+  })
+
+  // ---- failure-mode matrix (each row is a mutation target) ----
+
+  it('UNCONFIRMED: retry with a token that was never confirmed → 403, operation NOT performed', async () => {
+    const token = await mintToken('/op/restore/s1')
+    const res = await request(app).post('/op/restore/s1').set('x-test-user', M).set('x-safety-token', token).expect(403)
+    expect(res.body.code).toBe('SAFETY_CHECK_REQUIRED')
+  })
+
+  it('EXPIRED: an expired token cannot be confirmed', async () => {
+    initSafetyGuard({ tokenExpirationSeconds: -1 }) // tokens are born expired → deterministic, no sleep
+    app = buildApp()
+    const token = await mintToken('/op/restore/s1')
+    await request(app)
+      .post('/safety/confirm')
+      .set('x-test-user', M)
+      .send({ token, typedConfirmation: 'restore_snapshot', acknowledged: true })
+      .expect(400) // "Confirmation token has expired"
+  })
+
+  it('WRONG USER: token confirmed by M cannot be consumed by N → 403', async () => {
+    const token = await mintToken('/op/restore/s1', M)
+    await request(app)
+      .post('/safety/confirm')
+      .set('x-test-user', M)
+      .send({ token, typedConfirmation: 'restore_snapshot', acknowledged: true })
+      .expect(200)
+    await request(app).post('/op/restore/s1').set('x-test-user', N).set('x-safety-token', token).expect(403)
+  })
+
+  it('WRONG OPERATION: a confirmed RESTORE token presented on the DELETE route → 403', async () => {
+    const token = await mintToken('/op/restore/s1', M)
+    await request(app)
+      .post('/safety/confirm')
+      .set('x-test-user', M)
+      .send({ token, typedConfirmation: 'restore_snapshot', acknowledged: true })
+      .expect(200)
+    await request(app).post('/op/delete/s1').set('x-test-user', M).set('x-safety-token', token).expect(403)
+  })
+
+  it('WRONG RESOURCE: a confirmed token for s1 presented against s2 → 403', async () => {
+    const token = await mintToken('/op/restore/s1', M)
+    await request(app)
+      .post('/safety/confirm')
+      .set('x-test-user', M)
+      .send({ token, typedConfirmation: 'restore_snapshot', acknowledged: true })
+      .expect(200)
+    await request(app).post('/op/restore/s2').set('x-test-user', M).set('x-safety-token', token).expect(403)
+  })
+
+  it('DOUBLE USE: a token is one-time — the second retry with the same token → 403', async () => {
+    const token = await mintToken('/op/restore/s1', M)
+    await request(app)
+      .post('/safety/confirm')
+      .set('x-test-user', M)
+      .send({ token, typedConfirmation: 'restore_snapshot', acknowledged: true })
+      .expect(200)
+    await request(app).post('/op/restore/s1').set('x-test-user', M).set('x-safety-token', token).expect(200)
+    await request(app).post('/op/restore/s1').set('x-test-user', M).set('x-safety-token', token).expect(403)
+  })
+
+  it('WRONG TYPED PHRASE: confirm with an incorrect typed phrase → 400, and the op stays blocked', async () => {
+    const token = await mintToken('/op/restore/s1', M)
+    await request(app).post('/safety/confirm').set('x-test-user', M).send({ token, typedConfirmation: 'nope', acknowledged: true }).expect(400)
+    await request(app).post('/op/restore/s1').set('x-test-user', M).set('x-safety-token', token).expect(403)
+  })
+
+  // ---- resourceKey recursive canonicalization (nested details) ----
+
+  async function mintBulk(filters: unknown): Promise<string> {
+    const res = await request(app).post('/op/bulk/x1').set('x-test-user', M).send({ filters }).expect(403)
+    return res.body.confirmation.token as string
+  }
+
+  it('NESTED KEY REORDER: a token minted for {filters:{a,b}} is accepted on a retry sending {filters:{b,a}} → 200', async () => {
+    const token = await mintBulk({ a: 1, b: 2 })
+    const done = await request(app)
+      .post('/op/bulk/x1')
+      .set('x-test-user', M)
+      .set('x-safety-token', token)
+      .send({ filters: { b: 2, a: 1 } }) // same resource, keys reordered
+      .expect(200)
+    expect(done.body.did).toBe('bulk')
+  })
+
+  it('NESTED VALUE CHANGE: a changed nested value is a different resource → 403', async () => {
+    const token = await mintBulk({ a: 1, b: 2 })
+    await request(app)
+      .post('/op/bulk/x1')
+      .set('x-test-user', M)
+      .set('x-safety-token', token)
+      .send({ filters: { a: 9, b: 2 } }) // value changed
+      .expect(403)
+  })
+
+  it('ARRAY REORDER: array order is significant — [1,2] vs [2,1] is a different resource → 403', async () => {
+    const token = await mintBulk({ items: [1, 2] })
+    await request(app)
+      .post('/op/bulk/x1')
+      .set('x-test-user', M)
+      .set('x-safety-token', token)
+      .send({ filters: { items: [2, 1] } }) // array reordered
+      .expect(403)
+  })
+
+  // ---- response contract: the 403 confirmation.instructions describe the ACTUAL flow ----
+
+  it('INSTRUCTIONS (double-confirm): the 403 tells the client to POST /api/admin/safety/confirm then retry with X-Safety-Token', async () => {
+    const res = await request(app).post('/op/restore/s1').set('x-test-user', M).send({}).expect(403)
+    const instructions = res.body.confirmation.instructions as string
+    expect(instructions).toContain('/api/admin/safety/confirm')
+    expect(instructions).toContain('X-Safety-Token')
+    expect(instructions).toContain('restore_snapshot') // the typed phrase for a double-confirm op
+  })
+
+  it('INSTRUCTIONS (single-confirm MEDIUM): a single token retry, no /safety/confirm step', async () => {
+    const res = await request(app).post('/op/delete/s1').set('x-test-user', M).send({}).expect(403)
+    const instructions = res.body.confirmation.instructions as string
+    expect(instructions).toContain('X-Safety-Token')
+    expect(instructions).not.toContain('/api/admin/safety/confirm')
+  })
+})

--- a/packages/core-backend/tests/unit/snapshot-labels-authz.test.ts
+++ b/packages/core-backend/tests/unit/snapshot-labels-authz.test.ts
@@ -1,0 +1,106 @@
+/**
+ * GHSA-h8mf (F2) — the SECOND snapshot mutation surface: snapshot-labels router, mounted under
+ * /api/admin/snapshots. Its tags/protection/release-channel mutations were unguarded and used a
+ * spoofable `x-user-id`/`system` identity. They are now platform-admin + identity from req.user.id.
+ *
+ * Mirrors snapshots-authz.test.ts (GHSA-h8mf) and change-management-authz.test.ts (GHSA-q7hj).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { isAdmin } from '../../src/rbac/service'
+
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  pool: null,
+}))
+
+vi.mock('../../src/services/SnapshotService', () => ({
+  snapshotService: {
+    addTags: vi.fn().mockResolvedValue(true),
+    removeTags: vi.fn().mockResolvedValue(true),
+    setProtectionLevel: vi.fn().mockResolvedValue(true),
+    setReleaseChannel: vi.fn().mockResolvedValue(true),
+    getSnapshot: vi.fn().mockResolvedValue({ id: 's1' }),
+    getByTags: vi.fn().mockResolvedValue([]),
+    getByProtectionLevel: vi.fn().mockResolvedValue([]),
+    getByReleaseChannel: vi.fn().mockResolvedValue([]),
+  },
+}))
+
+import snapshotLabelsRouter from '../../src/routes/snapshot-labels'
+import { snapshotService } from '../../src/services/SnapshotService'
+
+function buildApp(user?: { id: string }): Express {
+  const app = express()
+  app.use(express.json())
+  if (user) {
+    app.use((req, _res, next) => {
+      ;(req as express.Request & { user?: { id: string } }).user = user
+      next()
+    })
+  }
+  // Same mount base as admin-routes.ts (router.use('/snapshots', ...) under /api/admin).
+  app.use('/api/admin/snapshots', snapshotLabelsRouter)
+  return app
+}
+
+function mutationServiceCalls(): number {
+  const s = snapshotService as unknown as Record<string, { mock?: { calls: unknown[] } }>
+  return (
+    (s.addTags?.mock?.calls.length ?? 0) +
+    (s.removeTags?.mock?.calls.length ?? 0) +
+    (s.setProtectionLevel?.mock?.calls.length ?? 0) +
+    (s.setReleaseChannel?.mock?.calls.length ?? 0)
+  )
+}
+
+describe('snapshot-labels router — platform-admin gate + identity (GHSA-h8mf F2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(isAdmin).mockResolvedValue(true)
+  })
+
+  it('non-admin -> 403 on tags/protection/release-channel, NO service mutation called', async () => {
+    vi.mocked(isAdmin).mockResolvedValue(false)
+    const app = buildApp({ id: 'u-nonadmin' })
+    await request(app).put('/api/admin/snapshots/s1/tags').send({ add: ['x'] }).expect(403)
+    await request(app).patch('/api/admin/snapshots/s1/protection').send({ level: 'critical' }).expect(403)
+    await request(app).patch('/api/admin/snapshots/s1/release-channel').send({ channel: 'stable' }).expect(403)
+    expect(mutationServiceCalls()).toBe(0)
+  })
+
+  it('unauthenticated (no req.user) -> 403, no service mutation', async () => {
+    const app = buildApp(undefined)
+    await request(app).patch('/api/admin/snapshots/s1/protection').send({ level: 'critical' }).expect(403)
+    expect(mutationServiceCalls()).toBe(0)
+  })
+
+  it('RBAC check failure (isAdmin throws) -> 503 fail-closed, no service mutation', async () => {
+    vi.mocked(isAdmin).mockRejectedValue(new Error('rbac db down'))
+    const app = buildApp({ id: 'u-x' })
+    await request(app).patch('/api/admin/snapshots/s1/protection').send({ level: 'critical' }).expect(503)
+    expect(mutationServiceCalls()).toBe(0)
+  })
+
+  it('platform-admin -> protection mutation succeeds and reaches the service', async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app).patch('/api/admin/snapshots/s1/protection').send({ level: 'critical' }).expect(200)
+    expect(snapshotService.setProtectionLevel).toHaveBeenCalledTimes(1)
+  })
+
+  it('identity comes ONLY from req.user.id — a spoofed x-user-id header is ignored', async () => {
+    const app = buildApp({ id: 'u-realadmin' })
+    await request(app)
+      .patch('/api/admin/snapshots/s1/protection')
+      .set('x-user-id', 'u-spoofed')
+      .send({ level: 'critical' })
+      .expect(200)
+    expect(snapshotService.setProtectionLevel).toHaveBeenCalledWith('s1', 'critical', 'u-realadmin')
+    expect(snapshotService.setProtectionLevel).not.toHaveBeenCalledWith('s1', 'critical', 'u-spoofed')
+    expect(snapshotService.setProtectionLevel).not.toHaveBeenCalledWith('s1', 'critical', 'system')
+  })
+})

--- a/packages/core-backend/tests/unit/snapshot-restore-invariant.test.ts
+++ b/packages/core-backend/tests/unit/snapshot-restore-invariant.test.ts
@@ -1,0 +1,80 @@
+/**
+ * GHSA-h8mf — SnapshotService.restoreSnapshot() authoritative restore-scope invariant.
+ *
+ * The route validates the same rules (defense-in-depth), but the SERVICE must re-validate so no
+ * other caller (internal service, a future route, a test harness) can bypass the route and trigger
+ * a full restore labeled 'partial', or a partial restore over an item type outside the allowlist.
+ *
+ * db is mocked to a SENTINEL: any real query throws DB_REACHED_SENTINEL. So a rejection carrying the
+ * sentinel proves the invariant PASSED the input through to the DB; a rejection carrying an invariant
+ * message proves the invariant BLOCKED it before any DB access. This distinguishes the two and makes
+ * the invariant load-bearing: delete it and the "blocked" cases would fall through to the sentinel.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/db/db', () => ({
+  db: {
+    selectFrom: () => {
+      throw new Error('DB_REACHED_SENTINEL')
+    },
+  },
+}))
+
+import { snapshotService } from '../../src/services/SnapshotService'
+
+describe('SnapshotService.restoreSnapshot — restore-scope invariant (GHSA-h8mf)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('rejects a missing/unknown restoreType before touching the DB', async () => {
+    await expect(
+      snapshotService.restoreSnapshot({ snapshotId: 's1', restoredBy: 'u1' }),
+    ).rejects.toThrow('Invalid restoreType')
+    await expect(
+      // @ts-expect-error deliberately invalid at the type level to prove the runtime guard
+      snapshotService.restoreSnapshot({ snapshotId: 's1', restoredBy: 'u1', restoreType: 'everything' }),
+    ).rejects.toThrow('Invalid restoreType')
+  })
+
+  it("rejects restoreType 'full' that also narrows via itemTypes", async () => {
+    await expect(
+      snapshotService.restoreSnapshot({ snapshotId: 's1', restoredBy: 'u1', restoreType: 'full', itemTypes: ['view'] }),
+    ).rejects.toThrow('must not specify itemTypes')
+  })
+
+  it("rejects partial/selective with missing or empty itemTypes", async () => {
+    await expect(
+      snapshotService.restoreSnapshot({ snapshotId: 's1', restoredBy: 'u1', restoreType: 'partial' }),
+    ).rejects.toThrow('requires a non-empty itemTypes')
+    await expect(
+      snapshotService.restoreSnapshot({ snapshotId: 's1', restoredBy: 'u1', restoreType: 'selective', itemTypes: [] }),
+    ).rejects.toThrow('requires a non-empty itemTypes')
+  })
+
+  it('rejects an itemType outside the allowlist', async () => {
+    await expect(
+      snapshotService.restoreSnapshot({
+        snapshotId: 's1',
+        restoredBy: 'u1',
+        restoreType: 'partial',
+        itemTypes: ['view', 'secrets'],
+      }),
+    ).rejects.toThrow('outside the allowlist')
+  })
+
+  it('PASSES a confirmed-shape full restore through to the DB (sentinel), i.e. not over-restricted', async () => {
+    await expect(
+      snapshotService.restoreSnapshot({ snapshotId: 's1', restoredBy: 'u1', restoreType: 'full' }),
+    ).rejects.toThrow('DB_REACHED_SENTINEL')
+  })
+
+  it('PASSES a valid partial restore (allowlisted itemTypes) through to the DB (sentinel)', async () => {
+    await expect(
+      snapshotService.restoreSnapshot({
+        snapshotId: 's1',
+        restoredBy: 'u1',
+        restoreType: 'partial',
+        itemTypes: ['view', 'table_row'],
+      }),
+    ).rejects.toThrow('DB_REACHED_SENTINEL')
+  })
+})

--- a/packages/core-backend/tests/unit/snapshots-authz.test.ts
+++ b/packages/core-backend/tests/unit/snapshots-authz.test.ts
@@ -1,0 +1,231 @@
+/**
+ * GHSA-h8mf — snapshots router: platform-admin gate on ALL mutations + identity hardening +
+ * restore-scope validation (full must be confirmed & unscoped; partial/selective need a non-empty
+ * allowlisted item_types). Reads stay at permissions:read (scope NOT widened).
+ *
+ * Owner temporary boundary (2026-07-11):
+ *   - every snapshot mutation -> platform-admin via the existing admin safety guard (requireAdminRole);
+ *   - RBAC/safety-check exception -> fail closed (503);
+ *   - identity ONLY from req.user.id (x-user-id ignored);
+ *   - full explicit + confirmed; partial/selective require non-empty allowlisted item_types.
+ *
+ * Mount pattern mirrors tests/unit/change-management-authz.test.ts (GHSA-q7hj).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { isAdmin } from '../../src/rbac/service'
+
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: vi.fn().mockResolvedValue(true),
+}))
+
+// pool=null makes requireAdminRole's best-effort logSafetyOperation a no-op (no throw on denial).
+vi.mock('../../src/db/pg', () => ({
+  pool: null,
+}))
+
+// rbacGuard is used by the READ routes only; pass-through so we can prove reads are NOT admin-gated.
+vi.mock('../../src/rbac/rbac', () => ({
+  rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}))
+
+// The destructive endpoints (restore/delete/cleanup) now also sit behind the SafetyGuard confirmation
+// (requireSafetyCheck), which 403s until a safety token is presented. That layer is proven engaged, and
+// proven load-bearing, in tests/unit/snapshots-safety-guard.test.ts. Here we pass it through so THIS file
+// can isolate the two layers it is about: the platform-admin gate and the restore-scope validation.
+// requireAdminRole / protectAdminOperation stay REAL — the admin gate is what this file tests.
+vi.mock('../../src/guards', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/guards')>()
+  return {
+    ...actual,
+    requireSafetyCheck: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+      next(),
+  }
+})
+
+// Mock the service AND re-export the item-type allowlist the router imports at module load.
+vi.mock('../../src/services/SnapshotService', () => ({
+  RESTORABLE_ITEM_TYPES: ['view', 'view_state', 'table_row'],
+  snapshotService: {
+    restoreSnapshot: vi.fn().mockResolvedValue({ success: true, itemsRestored: 3, duration: 0.1 }),
+    deleteSnapshot: vi.fn().mockResolvedValue(true),
+    setSnapshotLock: vi.fn().mockResolvedValue(true),
+    setProtectionLevel: vi.fn().mockResolvedValue(true),
+    setReleaseChannel: vi.fn().mockResolvedValue(true),
+    addTags: vi.fn().mockResolvedValue(true),
+    removeTags: vi.fn().mockResolvedValue(true),
+    createSnapshot: vi.fn().mockResolvedValue({ id: 'snap1' }),
+    cleanupExpired: vi.fn().mockResolvedValue({ deleted: 0, freed: 0, skipped: 0 }),
+    getSnapshot: vi.fn().mockResolvedValue({ id: 'snap1' }),
+    listSnapshots: vi.fn().mockResolvedValue([]),
+  },
+}))
+
+import { snapshotsRouter } from '../../src/routes/snapshots'
+import { snapshotService } from '../../src/services/SnapshotService'
+
+function buildApp(user?: { id: string }): Express {
+  const app = express()
+  app.use(express.json())
+  if (user) {
+    app.use((req, _res, next) => {
+      ;(req as express.Request & { user?: { id: string } }).user = user
+      next()
+    })
+  }
+  app.use(snapshotsRouter())
+  return app
+}
+
+// Every mutation route + a minimal valid body (admin path).
+const MUTATIONS: Array<{ name: string; method: 'post' | 'put' | 'patch' | 'delete'; path: string; body?: unknown }> = [
+  { name: 'create', method: 'post', path: '/api/snapshots', body: { view_id: 'v1', name: 'n' } },
+  { name: 'restore', method: 'post', path: '/api/snapshots/s1/restore', body: { restore_type: 'full', confirm_full: true } },
+  { name: 'delete', method: 'delete', path: '/api/snapshots/s1' },
+  { name: 'lock', method: 'patch', path: '/api/snapshots/s1/lock', body: { locked: true } },
+  { name: 'protection', method: 'patch', path: '/api/snapshots/s1/protection', body: { level: 'critical' } },
+  { name: 'release-channel', method: 'patch', path: '/api/snapshots/s1/release-channel', body: { channel: 'stable' } },
+  { name: 'tags', method: 'put', path: '/api/snapshots/s1/tags', body: { add: ['x'] } },
+  { name: 'cleanup', method: 'post', path: '/api/snapshots/cleanup', body: {} },
+]
+
+function serviceCallCount(): number {
+  const s = snapshotService as unknown as Record<string, { mock?: { calls: unknown[] } }>
+  return Object.values(s).reduce((n, fn) => n + (fn?.mock?.calls.length ?? 0), 0)
+}
+
+describe('snapshots router — platform-admin gate on all mutations (GHSA-h8mf)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(isAdmin).mockResolvedValue(true)
+  })
+
+  it('non-admin principal -> 403 on EVERY mutation route, and NO service method is called', async () => {
+    vi.mocked(isAdmin).mockResolvedValue(false)
+    const app = buildApp({ id: 'u-nonadmin' })
+    for (const m of MUTATIONS) {
+      const req = request(app)[m.method](m.path)
+      await (m.body !== undefined ? req.send(m.body as object) : req).expect(403)
+    }
+    expect(serviceCallCount()).toBe(0)
+  })
+
+  it('unauthenticated (no req.user) -> 403 on a mutation, no service call', async () => {
+    const app = buildApp(undefined)
+    await request(app).post('/api/snapshots/s1/restore').send({ restore_type: 'full', confirm_full: true }).expect(403)
+    expect(serviceCallCount()).toBe(0)
+  })
+
+  it('RBAC check failure (isAdmin throws) -> 503 fail-closed on a mutation, NO service call', async () => {
+    vi.mocked(isAdmin).mockRejectedValue(new Error('rbac db down'))
+    const app = buildApp({ id: 'u-someone' })
+    await request(app).post('/api/snapshots/s1/restore').send({ restore_type: 'full', confirm_full: true }).expect(503)
+    await request(app).delete('/api/snapshots/s1').expect(503)
+    expect(serviceCallCount()).toBe(0)
+  })
+
+  it('platform-admin normal path: each mutation reaches its service method', async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app).post('/api/snapshots').send({ view_id: 'v1', name: 'n' }).expect(201)
+    expect(snapshotService.createSnapshot).toHaveBeenCalledTimes(1)
+    await request(app).delete('/api/snapshots/s1').expect(200)
+    expect(snapshotService.deleteSnapshot).toHaveBeenCalledTimes(1)
+    await request(app).patch('/api/snapshots/s1/lock').send({ locked: false }).expect(200)
+    expect(snapshotService.setSnapshotLock).toHaveBeenCalledTimes(1)
+    await request(app).patch('/api/snapshots/s1/protection').send({ level: 'critical' }).expect(200)
+    expect(snapshotService.setProtectionLevel).toHaveBeenCalledTimes(1)
+  })
+
+  it('reads are NOT elevated: a non-admin can still list/get/diff (permissions:read, scope unchanged)', async () => {
+    vi.mocked(isAdmin).mockResolvedValue(false)
+    const app = buildApp({ id: 'u-reader' })
+    await request(app).get('/api/snapshots?view_id=v1').expect(200)
+    await request(app).get('/api/snapshots/s1').expect(200)
+  })
+})
+
+describe('snapshots restore route — scope validation (GHSA-h8mf)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(isAdmin).mockResolvedValue(true)
+  })
+
+  it('missing restore_type -> 400, restoreSnapshot NOT called', async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app).post('/api/snapshots/s1/restore').send({}).expect(400)
+    expect(snapshotService.restoreSnapshot).toHaveBeenCalledTimes(0)
+  })
+
+  it('invalid restore_type -> 400, restoreSnapshot NOT called', async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app).post('/api/snapshots/s1/restore').send({ restore_type: 'everything' }).expect(400)
+    expect(snapshotService.restoreSnapshot).toHaveBeenCalledTimes(0)
+  })
+
+  it("full WITHOUT confirm_full -> 400 (must be explicitly confirmed), restoreSnapshot NOT called", async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app).post('/api/snapshots/s1/restore').send({ restore_type: 'full' }).expect(400)
+    await request(app).post('/api/snapshots/s1/restore').send({ restore_type: 'full', confirm_full: 'yes' }).expect(400)
+    expect(snapshotService.restoreSnapshot).toHaveBeenCalledTimes(0)
+  })
+
+  it("full WITH item_types -> 400 (a full restore must not narrow), restoreSnapshot NOT called", async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app)
+      .post('/api/snapshots/s1/restore')
+      .send({ restore_type: 'full', confirm_full: true, item_types: ['view'] })
+      .expect(400)
+    expect(snapshotService.restoreSnapshot).toHaveBeenCalledTimes(0)
+  })
+
+  it('full confirmed + no item_types -> 200, restoreSnapshot called with itemTypes undefined', async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app).post('/api/snapshots/s1/restore').send({ restore_type: 'full', confirm_full: true }).expect(200)
+    expect(snapshotService.restoreSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshotId: 's1', restoreType: 'full', itemTypes: undefined }),
+    )
+  })
+
+  it('partial WITHOUT item_types (and empty array) -> 400, restoreSnapshot NOT called', async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app).post('/api/snapshots/s1/restore').send({ restore_type: 'partial' }).expect(400)
+    await request(app).post('/api/snapshots/s1/restore').send({ restore_type: 'partial', item_types: [] }).expect(400)
+    expect(snapshotService.restoreSnapshot).toHaveBeenCalledTimes(0)
+  })
+
+  it('partial with an out-of-allowlist item_type -> 400, restoreSnapshot NOT called', async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app)
+      .post('/api/snapshots/s1/restore')
+      .send({ restore_type: 'selective', item_types: ['view', 'secrets'] })
+      .expect(400)
+    expect(snapshotService.restoreSnapshot).toHaveBeenCalledTimes(0)
+  })
+
+  it('partial with allowlisted item_types -> 200, forwarded to the service', async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app)
+      .post('/api/snapshots/s1/restore')
+      .send({ restore_type: 'partial', item_types: ['view', 'table_row'] })
+      .expect(200)
+    expect(snapshotService.restoreSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ restoreType: 'partial', itemTypes: ['view', 'table_row'] }),
+    )
+  })
+
+  it('identity comes ONLY from req.user.id — a spoofed x-user-id header is ignored', async () => {
+    const app = buildApp({ id: 'u-realadmin' })
+    await request(app)
+      .post('/api/snapshots/s1/restore')
+      .set('x-user-id', 'u-spoofed')
+      .send({ restore_type: 'full', confirm_full: true })
+      .expect(200)
+    expect(snapshotService.restoreSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ restoredBy: 'u-realadmin' }),
+    )
+    expect(snapshotService.restoreSnapshot).not.toHaveBeenCalledWith(
+      expect.objectContaining({ restoredBy: 'u-spoofed' }),
+    )
+  })
+})

--- a/packages/core-backend/tests/unit/snapshots-safety-guard.test.ts
+++ b/packages/core-backend/tests/unit/snapshots-safety-guard.test.ts
@@ -1,0 +1,119 @@
+/**
+ * GHSA-h8mf — the legacy destructive snapshot endpoints must carry the SAME security stack as their
+ * canonical admin twins in admin-routes.ts: platform-admin + audit (protectAdminOperation) AND the
+ * SafetyGuard confirmation (requireSafetyCheck).
+ *
+ * Being a platform admin is NOT sufficient for a destructive operation here. RESTORE_SNAPSHOT is
+ * RiskLevel.CRITICAL, CLEANUP_SNAPSHOTS is HIGH, DELETE_SNAPSHOT is MEDIUM — all require a safety
+ * confirmation token (x-safety-token / body._safetyToken). The route's `confirm_full` field is ordinary
+ * request data used for restore-SCOPE validation; it is NOT a safety token and cannot stand in for one.
+ *
+ * NOTHING is mocked here except the RBAC lookup, the audit pool and the snapshot service: the SafetyGuard
+ * is the REAL one, so this proves the stack is actually wired, not merely present in the source.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { isAdmin } from '../../src/rbac/service'
+
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('../../src/db/pg', () => ({ pool: null }))
+
+vi.mock('../../src/rbac/rbac', () => ({
+  rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}))
+
+vi.mock('../../src/services/SnapshotService', () => ({
+  RESTORABLE_ITEM_TYPES: ['view', 'view_state', 'table_row'],
+  snapshotService: {
+    restoreSnapshot: vi.fn().mockResolvedValue({ success: true, itemsRestored: 1, duration: 0.1 }),
+    deleteSnapshot: vi.fn().mockResolvedValue(true),
+    cleanupExpired: vi.fn().mockResolvedValue({ deleted: 0, freed: 0, skipped: 0 }),
+    getSnapshot: vi.fn().mockResolvedValue({ id: 's1' }),
+    listSnapshots: vi.fn().mockResolvedValue([]),
+    createSnapshot: vi.fn().mockResolvedValue({ id: 's1' }),
+    setSnapshotLock: vi.fn().mockResolvedValue(true),
+    setProtectionLevel: vi.fn().mockResolvedValue(true),
+    setReleaseChannel: vi.fn().mockResolvedValue(true),
+    addTags: vi.fn().mockResolvedValue(true),
+    removeTags: vi.fn().mockResolvedValue(true),
+  },
+}))
+
+import { snapshotsRouter } from '../../src/routes/snapshots'
+import { snapshotService } from '../../src/services/SnapshotService'
+
+function buildApp(user: { id: string }): Express {
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    ;(req as express.Request & { user?: { id: string } }).user = user
+    next()
+  })
+  app.use(snapshotsRouter())
+  return app
+}
+
+// Every destructive legacy endpoint + a body that is otherwise completely valid, so the ONLY thing
+// standing between the caller and the destructive service call is the SafetyGuard confirmation.
+const DESTRUCTIVE: Array<{
+  name: string
+  method: 'post' | 'delete'
+  path: string
+  body?: unknown
+  service: keyof typeof snapshotService
+}> = [
+  {
+    name: 'restore (CRITICAL)',
+    method: 'post',
+    path: '/api/snapshots/s1/restore',
+    body: { restore_type: 'full', confirm_full: true },
+    service: 'restoreSnapshot',
+  },
+  { name: 'delete (MEDIUM)', method: 'delete', path: '/api/snapshots/s1', service: 'deleteSnapshot' },
+  { name: 'cleanup (HIGH)', method: 'post', path: '/api/snapshots/cleanup', body: {}, service: 'cleanupExpired' },
+]
+
+describe('snapshots router — legacy destructive endpoints sit behind the SafetyGuard (GHSA-h8mf)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(isAdmin).mockResolvedValue(true)
+  })
+
+  it.each(DESTRUCTIVE)(
+    'platform-admin WITHOUT a safety token cannot $name — 403 SAFETY_CHECK_REQUIRED and the service is NOT called',
+    async ({ method, path, body, service }) => {
+      const app = buildApp({ id: 'u-admin' })
+      const req = request(app)[method](path)
+      const res = await (body !== undefined ? req.send(body as object) : req)
+
+      // Admin alone is not enough: the SafetyGuard demands a confirmation token.
+      expect(res.status).toBe(403)
+      expect(res.body?.code).toBe('SAFETY_CHECK_REQUIRED')
+      // The destructive work must not have happened.
+      expect(snapshotService[service]).toHaveBeenCalledTimes(0)
+    },
+  )
+
+  it('the SafetyGuard 403 hands back a confirmation token (the real second factor, not confirm_full)', async () => {
+    const app = buildApp({ id: 'u-admin' })
+    const res = await request(app)
+      .post('/api/snapshots/s1/restore')
+      .send({ restore_type: 'full', confirm_full: true })
+      .expect(403)
+
+    // confirm_full:true was supplied and is irrelevant to the safety layer — a token is what is required.
+    expect(res.body?.confirmation?.token).toBeTruthy()
+    expect(res.body?.assessment?.riskLevel).toBeTruthy()
+    expect(snapshotService.restoreSnapshot).toHaveBeenCalledTimes(0)
+  })
+
+  it('a NON-destructive mutation (create) is not gated by the SafetyGuard — the gate is scoped, not blanket', async () => {
+    const app = buildApp({ id: 'u-admin' })
+    await request(app).post('/api/snapshots').send({ view_id: 'v1', name: 'n' }).expect(201)
+    expect(snapshotService.createSnapshot).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Combined landing — GHSA-q7hj + GHSA-h8mf + SafetyGuard double-confirm

Owner-approved public landing of the reviewed security stack (private GHSA fork PR #1). Three commits, all authorization/safety hardening on admin-only surfaces; no behavior change for non-admin users.

**Commits**
1. `fix(change-management)` (GHSA-q7hj) — platform-admin gate + identity hardening on the change-management endpoints; reject force-restore.
2. `fix(snapshots)` (GHSA-h8mf) — platform-admin + SafetyGuard on **all** snapshot mutation surfaces (create/delete/label/restore); restore-scope invariant so a restore cannot cross its snapshot's scope. `resourceKey` is recursively canonicalized (object keys sorted at any depth, array order preserved) so the SafetyGuard confirm token binds to the true operation payload.
3. `fix(safety-guard)` — complete + bind the double-confirm flow: the confirm token is bound to operation + initiator + resourceKey, one-time-use, `requireAdminRole` on `/api/admin/safety/confirm`; the confirm instructions describe the real two-step flow (POST confirm → retry with `X-Safety-Token`) and the response contract is pinned.

**Scope ruling (owner):** restore/delete/cleanup are all in scope and explicitly covered; no other security surface was widened.

**Verification**
- Rebased onto current `main` with **no semantic change** (combined diff byte-identical to the reviewed version modulo hunk offsets).
- `tsc --noEmit`: exit 0.
- Security unit suites: **63/63** pass (change-management-authz, snapshots-authz, snapshots-safety-guard, safety-guard-confirm-flow, snapshot-restore-invariant, snapshot-labels-authz, admin-safety-confirm-authz, admin-snapshot-delete-authz, SnapshotService).
- Real-DB `snapshot-protection` integration + router-isolation + app-assembly run in CI required checks.

Advisories (GHSA-q7hj, GHSA-h8mf) are published **after deploy confirmation**, per the coordinated-disclosure sequence.
