### PR TITLE
ci(snapshots): wire snapshot-protection E2E into the Node 20 real-DB lane (close false-green)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -248,6 +248,25 @@ jobs:
             tests/integration/router-isolation.smoke.test.ts \
             --reporter=verbose
 
+      # Snapshot Protection System E2E (GHSA-h8mf). Boots the real MetaSheetServer and asserts the
+      # platform-admin gate + restore-scope invariant on every snapshot mutation surface (create /
+      # delete / label / restore). Excluded from the no-DB default job (vitest.config.ts) because it
+      # needs a real DB + server — so before this it ran in NO CI job at all (excluded but never
+      # wired into a real-DB step): a silent false-green. Wired here as a WHOLE FILE (this repo's
+      # two-point wiring). Its beforeAll HARD-FAILS (throws) on any setup failure rather than
+      # `return`ing empty, and --reporter=verbose prints the collected file+tests so an empty run
+      # shows in the log instead of reading as green. This suite has caught an app-level middleware
+      # leak; keeping it out of CI is not an acceptable long-term state.
+      - name: Run snapshot-protection E2E (GHSA-h8mf authz)
+        if: matrix.node-version == '20.x'
+        env:
+          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
+        run: |
+          : "${DATABASE_URL:?DATABASE_URL is required for the snapshot-protection E2E}"
+          pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+            tests/integration/snapshot-protection.test.ts \
+            --reporter=verbose
+
       - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated + cross-base relation-agg authorized-reader read gate + dangling-link repair-on-read + sheet-delete cascade + oapi-4a per-base/sheet scope guard + oapi-4a REST token-create scope + mirror-read-only enumeration hardening + cross-base editable-mirror write-through op + cross-base mirror write-through Decision-F concurrency + personal-views slice-1 actor-scoped isolation + W1-2 permission-matrix B1 side-door goldens (Yjs bridge flush actor-tier/lock/row-deny/rule-deny, OAPI token write re-gate parity, base-write/sheet-write non-intersection) + W1-2 permission-matrix B2 oracle/no-leak goldens (G-5 row-level-read-deny zero-presence on export + history, G-4 OAPI token-vs-interactive read-mask parity across the 5 records:read routes) + W1-2 permission-matrix B3 management-surface 403 matrix (field/view CRUD, sheet-permission grant, sheet_config flag + conditional-rules, across A3/A4/A5/A6 actor tiers) + W1-2 permission-matrix B4 G-7 export⊆read differential (field-mask/row-deny/taint modifier combinations, same actor) + W1-1 formula freshness goldens (Yjs-bridge formula recompute GF1-GF4/GF9 + expression-change bulk recompute GF5-GF8/GF12) + W1-3 per-subject field-write gate goldens (Yjs bridge flush GW1-GW3 headline/positive-control/atomic-mixed, single-record PATCH GW4-GW6 mst_-token/session-JWT dual-caller + regression spot-check) + W3-5 batchId===null default (record-service.ts single-record self-referential batch_id vs record-write-service.ts bulk fresh-id control) + W1-2 permission-matrix B4 G-8 comments sheet-visibility gate (comments:read/write actor 403'd on a no-read sheet across list/summary/presence read + create write + no identifier/content leak) + LOCK-12 partial-success bulk PATCH shared-batch grouping + 4c-2 forward tombstone-capture flag-off/on/cap goldens (field-delete value+link+auto-number capture, record-delete inbound-only capture, R1 undelete rehydration + masking parity, retention keep-days sweep) + D-6 config-restore-execute metaFieldCache invalidation golden + F2 attachment-download read-gate row-deny/field-mask security regression guard + AI-fields S1 write-provenance/batch-grouping goldens + A6-3-3a automation branch-local-wait suspend/resume goldens + Phase C2 cross-base automation governed DELETE/LOCK goldens + C1 automation real-time fan-out goldens + duplicate/clone record route security goldens + T3-6 approval-record multitable projection goldens — six previously skip-green DB-gated specs now actually executing)
         if: matrix.node-version == '20.x'
         env:


### PR DESCRIPTION
## Wire the snapshot-protection E2E into CI (close a false-green)

Pure CI wiring. **Its migration prerequisite has landed**: PR #4228 (merge `4157205ce`, refs #4162) re-enabled `create_views_view_states` + the three snapshot-cluster migrations across **all 5** workflow `MIGRATION_EXCLUDE` lists — so the CI test-DB now has `snapshots.tags`, `protection_rules`, the change-management tables, and `views`/`view_states` that `SnapshotService` queries.

**History (verification note):** the first CI run of this PR failed exactly as predicted without the prerequisite — `column "tags" of relation "snapshots" does not exist` — which is the false-green this wiring closes: `snapshot-protection.test.ts` ("Snapshot Protection System E2E", carrying the GHSA-h8mf authz assertions) was excluded from the no-DB job (needs real server+DB) but never added to any real-DB whitelist step, so it ran in **no CI job**. This PR (rebased onto post-#4228 main) adds a dedicated Node-20 real-DB step (whole file, `--reporter=verbose` so an empty collection can't read green), modeled on the router-isolation step. **Two-point wiring complete**: excluded from no-DB + present in the real-DB lane.

**Fail-loud:** the test's `beforeAll` already hard-fails (throws) on any setup failure (port bind / listen address / dev-token) — landed with #4212; verified no silent-return or skip-green guard remains.

**Local proof** (from the #4228 line): fresh DB migrated with the exact new CI exclude list → `snapshot-protection.test.ts` **21/21**. This PR's own test (20.x) run is the in-CI proof that the newly wired step executes and passes.
