### PR TITLE
docs(multitable): T5 owner decision record (2026-07-13) + comment-affordance token design-lock (PROPOSED)

### DIFF
--- a/docs/development/multitable-comment-affordance-token-design-lock-20260713.md
+++ b/docs/development/multitable-comment-affordance-token-design-lock-20260713.md
@@ -1,0 +1,45 @@
+# Multitable · comment-affordance 专用 token + 9 组件一致性 — 短设计锁（PROPOSED）
+
+- **Status**: **PROPOSED — owner ratify 前零实现授权。** 本锁由 owner 2026-07-13 对 T5 的 OD-T5b=A 裁决**委托创建**（「Comment-affordance：独立短设计锁，定义专用 comment-active token 和 9 组件一致性测试」），但 token **值**与 OD-CA-1..3 仍待 owner 拍板。
+- **上游裁决（已定，不在本锁重议）**：comment 按钮从 T5 剥离；**不得拿 `--ms-color-warning` 代替 comment-active 色彩**（owner 明令）。
+- **范围**：仅 comment-affordance 的**颜色语义与一致性**。不碰 affordance 的行为逻辑（`comment-affordance.ts` 的 active/idle 判定不变）、不碰权限、不碰计数逻辑。
+
+## §1 面（origin/main `8bc7bbfe4` 逐组件核验）
+
+`resolveCommentAffordanceStateClass`（`utils/comment-affordance.ts:38`）被 **10 个文件**消费：Grid / Kanban / Gallery / Calendar / Timeline / Hierarchy / Form / RecordDrawer + 两个专用组件（`MetaCommentActionChip`、`MetaCommentAffordance`）。每处传自己的 base class ⇒ active 态样式**由各组件自备**——这正是漂移的结构性根源。
+
+## §2 实证发现：系统**已经**漂移（核验过的,不是推测）
+
+| 组件 | comment-active 实际颜色 | 备注 |
+|---|---|---|
+| MetaRecordDrawer / MetaKanbanView / MetaCalendarView / MetaFormView 等多数 | **琥珀三元组** `border #f59e0b · bg #fff7ed · text #b45309` | 事实上的主流约定 |
+| **MetaGridTable**（`meta-grid__comment-action--active`） | **蓝 `color: #1d4ed8`**,无琥珀 | **与主流不一致** —— 同一「有评论」语义在网格里是蓝、在看板/抽屉里是琥珀 |
+| MetaCommentActionChip | active/idle **均只有 `opacity: 1`** | 自身无视觉区分,靠**父按钮**的 class 上色（如 drawer 的 `--comment--active`）|
+
+⚠ 注意琥珀三元组与唯一的警告 token `--ms-color-warning: #d97706` **三个都不相等**——这就是 owner 禁止「拿 warning token 代替」的事实基础:那不是 token 化,是**变色**。
+
+## §3 提案
+
+1. **新增专用 token 三元组**（`tokens.css`,全站单一真源 §UF 口径）:
+   ```css
+   --ms-color-comment-active-border: #f59e0b;
+   --ms-color-comment-active-bg:     #fff7ed;
+   --ms-color-comment-active-text:   #b45309;
+   ```
+   **值 = 现行主流琥珀**（采纳时零视觉变）——值本身是 OD-CA-1,owner 可改。
+2. **9 组件全部改引 token**,删除各自硬编码琥珀。
+3. **一致性守卫测试**:一个 spec 遍历 9 个消费组件的 `--active` 规则,断言:(a) 颜色只来自上述 token(源码扫描:组件内不得再出现裸琥珀 hex);(b) `resolveCommentAffordanceStateClass` 仍是唯一的态派生入口(防止有组件另起炉灶)。**必须带正控**:故意在一个组件里塞回裸 hex → 守卫必红(否则守卫空转)。
+
+## §4 OWNER 决策点
+
+| # | 决策 | 选项 |
+|---|---|---|
+| **OD-CA-1** | token **值** | (a 荐) 现行琥珀三元组原值(零视觉变) · (b) 归一到别的色阶(变色,须设计确认) |
+| **OD-CA-2** | **MetaGridTable 的蓝 `#1d4ed8`** 是 bug 还是有意的场景差异? | (a 荐) **是漂移,收敛到 token**(网格 active 变琥珀=可见变化,需 owner 知情) · (b) 网格有意用蓝,记为**显式豁免**并注释,守卫放行该例外 |
+| **OD-CA-3** | drawer 的 comment 按钮此时是否顺带迁 `MtButton`? | (a) 迁,active 用新 token(T5 补完) · (b 荐) 本锁只管颜色/一致性,按钮迁移等 token 落地后单独小 slice(避免一票两事) |
+
+## §5 本文不主张什么
+
+- 不主张任何 token 已存在或任何组件已改——**零 runtime,PROPOSED**。
+- 不主张 §2 表覆盖了全部 10 文件的每一条规则——主流琥珀 + Grid 蓝 + Chip 无自样式是**核验过的**;逐组件全量清单在实施 slice 里做。
+- 不主张 OD-CA-2 的「(a 荐)」已被采纳——网格变色是**可见变化**,必须 owner 知情后拍。

--- a/docs/development/multitable-ui-p2-1c-t5-recorddrawer-decision-brief-20260712.md
+++ b/docs/development/multitable-ui-p2-1c-t5-recorddrawer-decision-brief-20260712.md
@@ -57,7 +57,22 @@ border-color: #f59e0b;  background: #fff7ed;  color: #b45309;
 
 ---
 
-## §3 OWNER 决策点
+## §3 OWNER 决策点 — ✅ 全部已裁（owner 2026-07-13，见 §3.5）
+
+## §3.5 OWNER 裁决记录（2026-07-13，逐字采纳）
+
+| 决策点 | 裁决 | 实施边界（owner 原话要点） |
+|---|---|---|
+| **OD-T5a** | **= A** | watch 迁 `MtButton`，**保留 `--watching` 状态类**，**新增 `aria-pressed`**；原有 loading / disabled / click 行为**不变**。 |
+| **OD-T5b** | **= A** | comment **从 T5 剥离**，**单独治理整个 comment-affordance 系统**（独立短设计锁：专用 comment-active token + 9 组件一致性测试）。**不得拿 warning token 代替 comment-active 色彩**（§2.1 的 C 选项被明确否决）。 |
+| **OD-T5c** | **= A** | workflow / permissions 迁 `MtButton`，**现有 glyph 保留在 slot**，**暂不引入新图标契约**。 |
+| **OD-T5d** | **= 放行** | duplicate / delete / unlock 可迁；**`@click`、`v-if`、`:disabled`、`data-*` 必须逐字节保留**；delete 用 **`variant="danger"`**。 |
+
+**实施拆分（owner 指定，可并行）**：
+- **T5-safe** = watch + workflow + permissions + duplicate/delete/unlock（一个 runtime slice，实施中）。
+- **Comment-affordance** = 独立短设计锁（`multitable-comment-affordance-token-design-lock-20260713.md`，PROPOSED——token 值是新样式语义，仍需 owner ratify），定义专用 comment-active token + 9 组件一致性测试。
+
+> 下方 §3 原选项表与 §4 推荐保留为**提案历史**;裁决以本节为准。
 
 ### 🔴 OD-T5a — watch toggle 的 active 态怎么表达？
 
@@ -102,6 +117,7 @@ border-color: #f59e0b;  background: #fff7ed;  color: #b45309;
 
 ## §5 本文不主张什么
 
-- 不主张 T5 已完成，也不主张 MetaRecordDrawer 已迁。
-- 不主张上面任何一个「（荐）」已被采纳——**全部待 owner 拍板**。
+- 不主张 T5 已完成——T5-safe slice 实施中（未合），comment-affordance 锁是 PROPOSED。
+- ~~不主张上面任何一个「（荐）」已被采纳~~ → **2026-07-13 起 §3.5 记录 owner 裁决**：OD-T5a/b/c 均裁 A、OD-T5d 放行（凑巧与推荐一致，但**以裁决为准,不以推荐为据**）。
 - 不主张碰过任何权限 / 删除 / 锁定逻辑：**本文零 runtime**。
+- 不主张 comment-affordance 的 token **值**已定——那在独立锁里,仍待 owner ratify。


### PR DESCRIPTION
Two docs, one ruling batch:

1. T5 brief updated with §3.5 — the owner's verbatim rulings: OD-T5a=A (watch → MtButton, keep
   --watching, ADD aria-pressed, behavior unchanged) · OD-T5b=A (comment split out of T5; the entire
   comment-affordance system governed separately; warning-token substitution explicitly FORBIDDEN) ·
   OD-T5c=A (workflow/permissions → MtButton, glyph stays in slot, no new icon contract) · OD-T5d=放行
   (duplicate/delete/unlock migratable, byte-preserved handlers, delete=danger). The original §3
   options and §4 recommendation are preserved as proposal history; §3.5 is authoritative. T5-safe
   implementation slice is running in parallel per the owner's split.

2. NEW comment-affordance short design-lock (PROPOSED — token values still need owner ratify). It
   encodes the OD-T5b=A delegation: a dedicated --ms-color-comment-active-{border,bg,text} token trio
   (proposed values = the current majority amber, so adoption is zero-visual-change) + a 9-component
   consistency guard with a positive control.

   The lock also records a VERIFIED drift the consistency test exists to catch: the system has already
   diverged on main — most surfaces use the amber trio (#f59e0b/#fff7ed/#b45309), but MetaGridTable's
   comment-active is BLUE (#1d4ed8), and MetaCommentActionChip has no visual active state of its own
   (opacity:1 in both states; the parent button colors it). Whether grid's blue is a bug to converge or
   an intentional per-surface distinction is OD-CA-2 — the owner rules, because either answer changes
   a visible surface. Also verified: the amber trio matches NONE of --ms-color-warning (#d97706), which
   is the factual basis for the owner's "no warning-token substitution" prohibition — that swap would
   be a recolor, not a tokenization.

Docs-only, zero runtime. Nothing ratified by me: §3.5 records the owner's words; the new lock is
PROPOSED with OD-CA-1..3 left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)