### PR TITLE
test(multitable): OD-6 revision-disposition guard — every meta_records write site must declare a disposition

### DIFF
--- a/packages/core-backend/src/multitable/approval-record-projection-service.ts
+++ b/packages/core-backend/src/multitable/approval-record-projection-service.ts
@@ -219,6 +219,8 @@ export class ApprovalRecordProjectionService {
       await this.ensureSystemBase(client)
       await this.ensureFamilySheet(client, sheetId, instance.templateId, instance.templateName)
 
+      // revision-exempt: derived projection into the system approval base; regenerable by sweep/reconcile;
+      // authoritative history lives in the approval domain (approval_instances), not here (audit §2/§4).
       await client.query(
         `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)
          VALUES ($1, $2, $3::jsonb, 1, $4, $4)

--- a/packages/core-backend/src/multitable/auto-number-service.ts
+++ b/packages/core-backend/src/multitable/auto-number-service.ts
@@ -97,6 +97,7 @@ export async function backfillAutoNumberField(
   // SELECT ... FOR UPDATE is required.
   const overwrite = opts?.overwrite === true
   // lock-exempt: system auto-number backfill — system-derived sequence value, no user actor.
+  // revision-exempt: auto-number backfill; jsonb_set of ROW_NUMBER() seq under advisory lock; no version bump.
   const updated = await query(
     `UPDATE meta_records mr
      SET data = jsonb_set(

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -2213,6 +2213,7 @@ export class AutomationExecutor {
       // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
       // update is rejected before this UPDATE unless claim==truth + trigger-actor base-write.
       // lock-guarded: automation update_record (B1) — ensureRecordNotLocked enforced just above.
+      // revision-pending: audit A3/OD-6 lane C — automation update_record writes no revision; fix in #4220.
       await this.deps.queryFn(
         `UPDATE meta_records
          SET data = COALESCE(data, '{}'::jsonb) || $1::jsonb,
@@ -2406,6 +2407,7 @@ export class AutomationExecutor {
         // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
         // delete is rejected before this DELETE unless claim==truth + trigger-actor base-write.
         // lock-guarded: automation delete_record (C2a) — ensureRecordNotLocked enforced just above.
+        // revision-emitted: delete — recordRecordRevision written above in the same txn (rev@2365).
         await query(
           'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2',
           [effectiveRecordId, effectiveSheetId],
@@ -2471,6 +2473,7 @@ export class AutomationExecutor {
       // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
       // create is rejected before this INSERT unless claim==truth + trigger-actor base-write. This is
       // the §1.3 create-to-another-base vector the gate closes.
+      // revision-pending: audit A4/OD-6 lane C — automation create_record writes no revision; fix in #4220.
       await this.deps.queryFn(
         `INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1, $2, $3::jsonb, 1)`,
         [recordId, targetSheetId, JSON.stringify(data)],
@@ -3408,6 +3411,7 @@ export class AutomationExecutor {
         // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — same-base uses the gate's
         // fast-path (byte-identical to pre-C2); a cross-base lock is rejected unless claim==truth + base-write.
         // lock-mgmt: LOCK action — sets the lock columns themselves (not a data edit of a locked row).
+        // revision-exempt: metadata-only lock columns; `data` untouched — not a user-content edit.
         await this.deps.queryFn(
           `UPDATE meta_records
            SET locked = true, locked_by = $1, locked_at = NOW(), version = version + 1, updated_at = NOW()
@@ -3418,6 +3422,7 @@ export class AutomationExecutor {
         // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — same-base fast-path keeps
         // this byte-identical to pre-C2; a cross-base unlock is rejected unless claim==truth + base-write.
         // lock-mgmt: UNLOCK action — clears the lock columns (decision f: automation may unlock).
+        // revision-exempt: metadata-only unlock columns; `data` untouched — not a user-content edit.
         await this.deps.queryFn(
           `UPDATE meta_records
            SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -2812,8 +2812,8 @@ export class AutomationService {
       return false // record gone — the caller's missing-record path already handled it
     }
     ensureRecordNotLocked(opts.lockActorId, lockRow, () => new Error(opts.lockedMessage))
-    // lock-guarded: resultWriteback patch — ensureRecordNotLocked (opts.lockActorId = the trigger actor for a
-    // cross-base target) is enforced immediately above, so a locked target record throws → backwriteSkipped.
+    // lock-guarded: resultWriteback patch — ensureRecordNotLocked (opts.lockActorId = the trigger actor for a cross-base target) is enforced immediately above, so a locked target record throws → backwriteSkipped.
+    // revision-pending: audit A7/OD-6 lane C — resultWriteback writes no revision; fix tracked in #4220.
     await this.queryFn(
       `UPDATE meta_records
        SET data = COALESCE(data, '{}'::jsonb) || $1::jsonb, version = version + 1, updated_at = NOW()

--- a/packages/core-backend/src/multitable/formula-engine.ts
+++ b/packages/core-backend/src/multitable/formula-engine.ts
@@ -341,6 +341,7 @@ export class MultitableFormulaEngine {
       // write to other fields between this SELECT and UPDATE is not clobbered. No
       // version bump: formula values are derived, not an authoritative user edit.
       // lock-exempt: system formula materialization — derived value, no user actor (lock = read-only to USERS).
+      // revision-exempt: derived formula materialization; no version bump; recompute-on-read (audit §2).
       await query(
         `UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3`,
         [JSON.stringify(updates), recordId, sheetId],

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -675,6 +675,7 @@ export class RecordService {
         type: field.type,
         property: field.property,
       }))))
+      // revision-emitted: create — recordRecordRevision below in the same txn (rev@706).
       const inserted = await query(
         `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)
          VALUES ($1, $2, $3::jsonb, 1, $4, $4)
@@ -889,6 +890,7 @@ export class RecordService {
       }
 
       // lock-guarded: single DELETE — ensureRecordNotLocked enforced above (rejects before this txn).
+      // revision-emitted: delete — recordRecordRevision written above in the same txn (rev@845).
       await query('DELETE FROM meta_records WHERE id = $1', [recordId])
 
       // OAPI-2b §6: committed token-delete audit INSIDE the (soft-)delete txn (fail-closed). No-op for session.
@@ -1083,6 +1085,7 @@ export class RecordService {
       }
       let inserted: { rows: Array<{ version?: number }> }
       try {
+        // revision-emitted: create (trash restore) — recordRecordRevision below in the same txn (rev@1125).
         inserted = await query(
           `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by, created_at, updated_at)
            VALUES ($1, $2, $3::jsonb, 1, $4, $5, COALESCE($6, now()), COALESCE($7, now()))
@@ -1381,6 +1384,7 @@ export class RecordService {
 
       if (Object.keys(patch).length > 0) {
         // lock-guarded: single PATCH — ensureRecordNotLocked enforced above in this txn.
+        // revision-emitted: update — recordRecordRevision below in the same txn (rev@1392).
         const updateRes = await query(
           `UPDATE meta_records
            SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -967,6 +967,7 @@ export class RecordWriteService {
         // template below carries its own adjacent lock-guarded marker for the RANK-8 structural scanner.
         const updateRes = unsetIds.length > 0
           // lock-guarded: ensureRecordNotLocked enforced per record above (unset+set path)
+          // revision-emitted: update (unset+set) — recordRecordRevision below in the same txn (rev@998).
           ? await query(
               `UPDATE meta_records
                SET data = (data - $5::text[]) || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
@@ -975,6 +976,7 @@ export class RecordWriteService {
               [JSON.stringify(patch), sheetId, recordId, actorId, unsetIds],
             )
           // lock-guarded: ensureRecordNotLocked enforced per record above (set-only path)
+          // revision-emitted: update (set-only) — recordRecordRevision below in the same txn (rev@998).
           : await query(
               `UPDATE meta_records
                SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4

--- a/packages/core-backend/src/multitable/records.ts
+++ b/packages/core-backend/src/multitable/records.ts
@@ -503,6 +503,7 @@ export async function patchRecord(
   }
 
   // lock-guarded: plugin-SDK patchRecord (M1) — guardRecordNotLockedForPlugin(actor=null) rejected above.
+  // revision-pending: audit A2/OD-6 lane B — writes no revision (PIT-poisoning, reproduced); fix in #4216.
   const updated = await query(
     `UPDATE meta_records
      SET data = $1::jsonb, version = version + 1, updated_at = now()
@@ -542,6 +543,7 @@ export async function createRecord(
   }))))
 
   const recordId = `rec_${randomUUID()}`
+  // revision-pending: audit A5/OD-6 lane B — plugin-SDK createRecord writes no revision; fix in #4216.
   const inserted = await query(
     `INSERT INTO meta_records (id, sheet_id, data, version)
      VALUES ($1, $2, $3::jsonb, 1)
@@ -680,6 +682,7 @@ async function deleteRecordWithRecoverability(
   // before EITHER branch is dispatched, so this DELETE carries the identical lock disposition as the
   // flag-off one below.
   // lock-guarded: plugin-SDK deleteRecord, D-2 flag-on path (M1) — guarded in `deleteRecord` above.
+  // revision-emitted: delete (D-2 flag-on) — recordRecordRevision written above in the same txn (rev@650).
   const deleted = await query(
     `DELETE FROM meta_records
      WHERE id = $1 AND sheet_id = $2
@@ -751,6 +754,7 @@ export async function deleteRecord(
   await query('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1', [input.recordId])
 
   // lock-guarded: plugin-SDK deleteRecord (M1) — guardRecordNotLockedForPlugin(actor=null) rejected above.
+  // revision-emitted: delete (D-1 flag-off) — recordRecordRevision written below, after the DELETE (rev@771).
   const deleted = await query(
     `DELETE FROM meta_records
      WHERE id = $1 AND sheet_id = $2

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2956,6 +2956,7 @@ async function recalculateFormulaFields(
         }
         if (Object.keys(updates).length > 0) {
           // lock-exempt: system relation-aggregation materialization — derived value, no user actor (same posture as recalculateRecordFromData; a record lock is read-only to users, not system recompute).
+          // revision-exempt: relation-aggregation same-record materialization; no version bump; taint-skip.
           await query(
             'UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3',
             [JSON.stringify(updates), recordId, sheetId],
@@ -3852,6 +3853,7 @@ async function computeDependentLookupRollupRecords(
         }
         if (Object.keys(updates).length > 0) {
           // lock-exempt: system relation-aggregation fan-out materialization — derived value, no user actor (same posture as the same-record recompute write).
+          // revision-exempt: relation-aggregation fan-out materialization; no version bump; taint-skip.
           await query('UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3', [JSON.stringify(updates), recordId, sheetId])
           formulaDataByRecord.set(recordId, { ...(formulaDataByRecord.get(recordId) ?? {}), ...updates })
         }
@@ -5169,6 +5171,7 @@ async function ensurePeopleSheetPreset(query: QueryFn, baseId: string): Promise<
       }
       const existing = recordByUserId.get(user.id)
       if (!existing) {
+        // revision-exempt: system People-directory sync; mirror of `users`; regenerable, not user content.
         await query(
           `INSERT INTO meta_records (id, sheet_id, data, version)
            VALUES ($1, $2, $3::jsonb, 1)`,
@@ -5185,6 +5188,7 @@ async function ensurePeopleSheetPreset(query: QueryFn, baseId: string): Promise<
 
       if (changed) {
         // lock-exempt: internal people-directory sync — system sheet, not a user-facing record edit path.
+        // revision-exempt: system People-sheet sync; not a user-content edit (audit §2).
         await query(
           `UPDATE meta_records
            SET data = $1::jsonb, version = version + 1, updated_at = now()
@@ -5803,6 +5807,7 @@ async function createSeededSheet(args: { sheetId: string; name: string; descript
     }
 
     for (const record of records) {
+      // revision-exempt: seed/demo bootstrap; ON CONFLICT DO NOTHING; hard-coded, not user-authored.
       await query(
         `INSERT INTO meta_records (id, sheet_id, data, version)
          VALUES ($1, $2, $3::jsonb, $4)
@@ -6148,6 +6153,7 @@ async function dropFieldCascade(query: TxnQuery, opts: {
     if (!isUndefinedTableError(err, 'meta_links')) throw err
   }
   // lock-exempt: field-delete schema op — drops the deleted field's key sheet-wide; not a per-record user edit.
+  // revision-exempt: field-delete column strip; captured on the config channel (recordConfigRevision) + value/link tombstones; no per-record bump.
   await query('UPDATE meta_records SET data = data - $1 WHERE sheet_id = $2', [fieldId, sheetId])
   const shiftedDel = ((await query('UPDATE meta_fields SET "order" = "order" - 1 WHERE sheet_id = $1 AND "order" > $2 RETURNING id, "order"', [sheetId, order])) as any).rows as Array<{ id: string; order: number }>
   await recordFieldOrderShifts(query, sheetId, shiftedDel.map((r) => ({ id: String(r.id), newOrder: Number(r.order) })), -1, configBatchId, actorId)
@@ -6423,8 +6429,8 @@ async function applyLossyRetypeCellRewrite(query: TxnQuery, opts: {
   // and `jsonb_set(data, path, NULL)` returns NULL for the WHOLE `data` column — a dropped cell would wipe the record.
   // A single batched statement (never a per-row round trip), matching the tombstone-capture module's discipline.
   const payload = changed.map((c) => ({ record_id: c.recordId, value: c.after ?? null }))
-  // lock-exempt: 4c-1 lossy retype revert — schema op rewriting the reverted field's key sheet-wide under the
-  // config-restore canManageFields gate (mirrors the field-delete column strip / field-undelete rehydration);
+  // lock-exempt: 4c-1 lossy retype revert — schema op rewriting the reverted field's key sheet-wide under the config-restore canManageFields gate (mirrors the field-delete column strip / field-undelete rehydration);
+  // revision-emitted: one recordRecordRevision per changed cell, below in the same txn (rev@6454) — C5 history completeness.
   const rewritten = (await query(
     `UPDATE meta_records AS m
      SET data = jsonb_set(m.data, ARRAY[$2::text], COALESCE(item.value, 'null'::jsonb), true),
@@ -6515,8 +6521,8 @@ async function recreateFieldFromConfig(query: TxnQuery, opts: {
     // Values: only into records that do NOT already carry this key (never overwrite a value written after
     // this recreate — the recreate above just happened in THIS same transaction, so the only way a record
     // could already have the key is a value legitimately written since — this WHERE clause is the guard).
-    // lock-exempt: field-undelete schema op — rehydrates the recreated field's key sheet-wide (mirror of
-    // the field-delete drop at ~6116); not a per-record user edit, and NOT(data?key) never clobbers.
+    // lock-exempt: field-undelete schema op — rehydrates the recreated field's key sheet-wide (mirror of the field-delete drop at ~6116); not a per-record user edit, and NOT(data?key) never clobbers.
+    // revision-pending: owner-ruled MUST-WRITE (design-lock §0.5, not exempt); no lane PR yet — follow-up.
     await query(
       `UPDATE meta_records m
        SET data = data || jsonb_build_object($3::text, t.value)
@@ -10165,6 +10171,7 @@ export function univerMetaRouter(): Router {
               const occupied = await query('SELECT 1 FROM meta_records WHERE id = $1 FOR UPDATE', [r.recordId])
               if ((occupied.rows as unknown[]).length > 0) throw new RecordServiceRestoreConflictError(`Record id is occupied, cannot undelete: ${r.recordId}`)
               try {
+                // revision-emitted: create (PIT resurrect) — recordRecordRevision below in the same txn (rev@10178).
                 await query('INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by, created_at, updated_at) VALUES ($1, $2, $3::jsonb, 1, $4, $4, now(), now())', [r.recordId, sheetId, JSON.stringify(r.snapshot), undeleteActorId])
               } catch (e) {
                 if ((e as { code?: string })?.code === '23505') throw new RecordServiceRestoreConflictError(`Record id is occupied, cannot undelete: ${r.recordId}`)
@@ -10391,6 +10398,7 @@ export function univerMetaRouter(): Router {
             }
             const updateRes = unsetIds.length > 0
               // lock-guarded: PIT Reset reverts in one transaction after ensureRecordNotLocked above.
+              // revision-emitted: update (unset+set) — recordRecordRevision below in the same txn (rev@10416).
               ? await query(
                   `UPDATE meta_records
                      SET data = (data - $5::text[]) || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
@@ -10399,6 +10407,7 @@ export function univerMetaRouter(): Router {
                   [JSON.stringify(patch), sheetId, candidate.recordId, actorId, unsetIds],
                 )
               // lock-guarded: PIT Reset reverts in one transaction after ensureRecordNotLocked above.
+              // revision-emitted: update (set-only) — recordRecordRevision below in the same txn (rev@10416).
               : await query(
                   `UPDATE meta_records
                      SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
@@ -10525,6 +10534,7 @@ export function univerMetaRouter(): Router {
               )
             }
             // lock-guarded: PIT Reset deletes in the same transaction after ensureRecordNotLocked above.
+            // revision-emitted: delete — recordRecordRevision written above in the same txn (rev@10498).
             await query('DELETE FROM meta_records WHERE sheet_id = $1 AND id = $2', [sheetId, candidate.recordId])
             deletedRecordIds.push(candidate.recordId)
           }
@@ -12516,6 +12526,11 @@ export function univerMetaRouter(): Router {
       // OTHER sheets pointing to these records would DANGLE. Clean those inbound edges FIRST, in the SAME
       // transaction, before the records vanish (else the subquery can't find them) — atomic delete-edges+sheet.
       const del = await pool.transaction(async ({ query }) => {
+        // revision-exempt: records die via meta_sheets→meta_records ON DELETE CASCADE, tracked as
+        // config-channel #9 (OD-6 audit §1 row 9 / §4) — this record-revision guard does not reach it
+        // (there is no literal `DELETE FROM meta_records` here, the row loss is a DB-level FK cascade);
+        // it is a known structural residual routed to a future config-revision guard, not this one. See
+        // "known structural residual (out of scanner reach)" in multitable-revision-disposition-guard.guard.test.ts.
         await query('DELETE FROM meta_links WHERE foreign_record_id IN (SELECT id FROM meta_records WHERE sheet_id = $1)', [sheetId])
         return query('DELETE FROM meta_sheets WHERE id = $1', [sheetId])
       })
@@ -14419,6 +14434,7 @@ export function univerMetaRouter(): Router {
 
           if (Object.keys(patch).length > 0) {
             // lock-guarded: form-submit EDIT (B2) — ensureRecordNotLocked enforced just above.
+            // revision-pending: audit A1/OD-6 lane A (this is D-1c's own defect) — writes no revision; fix in #4219.
             const updateRes = await query(
               `UPDATE meta_records
                SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
@@ -14466,6 +14482,7 @@ export function univerMetaRouter(): Router {
         const latestFields = await loadFieldsForSheet(query, view.sheetId)
         Object.assign(patch, await allocateAutoNumberValues(query, view.sheetId, latestFields))
 
+        // revision-pending: audit A6/OD-6 lane A — form-submit CREATE writes no revision; fix in #4219.
         const insertRes = await query(
           `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)
            VALUES ($1, $2, $3::jsonb, 1, $4, $4)
@@ -15689,6 +15706,7 @@ export function univerMetaRouter(): Router {
             const nextIds = currentIds.filter((id) => id !== attachmentId)
             if (nextIds.length !== currentIds.length) {
               // lock-guarded: attachment-delete record edit (B3) — ensureRecordNotLocked enforced before this txn.
+              // revision-pending: audit A8/OD-6 lane A — attachment-delete record edit writes no revision; fix in #4219.
               const updateRes = await query(
                 `UPDATE meta_records
                  SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
@@ -16257,6 +16275,7 @@ export function univerMetaRouter(): Router {
         }
         const lockedBy = actorId ?? access.userId
         // lock-mgmt: LOCK action — sets the lock columns (own canEditRecord authority above).
+        // revision-exempt: record lock — metadata-only (locked/locked_by/locked_at); no data column touched.
         await pool.query(
           `UPDATE meta_records SET locked = true, locked_by = $2, locked_at = NOW(), version = version + 1, updated_at = NOW()
            WHERE id = $1 AND sheet_id = $3`,
@@ -16271,6 +16290,7 @@ export function univerMetaRouter(): Router {
           return sendForbidden(res, 'Not allowed to unlock this record')
         }
         // lock-mgmt: UNLOCK action — clears the lock columns (own canUnlock authority above).
+        // revision-exempt: record unlock — metadata-only (locked/locked_by/locked_at); no data column touched.
         await pool.query(
           `UPDATE meta_records SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()
            WHERE id = $1 AND sheet_id = $2`,

--- a/packages/core-backend/tests/unit/multitable-revision-disposition-guard.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-revision-disposition-guard.guard.test.ts
@@ -163,10 +163,6 @@ const PENDING_REVISION_SITES: ReadonlyArray<{ file: string; line: number; lane: 
   { file: 'routes/univer-meta.ts', line: 6527, lane: 'follow-up (field-undelete rehydration, owner-ruled MUST-WRITE, no PR yet)' },
 ]
 
-function findPendingEntry(file: string, line: number): { file: string; line: number; lane: string } | undefined {
-  return PENDING_REVISION_SITES.find((p) => p.file === file && p.line === line)
-}
-
 /**
  * The acceptance predicate every site is judged by. Exported as a plain function (not a class/closure
  * over module state) so the self-tests below can call it directly against synthetic sites and a

--- a/packages/core-backend/tests/unit/multitable-revision-disposition-guard.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-revision-disposition-guard.guard.test.ts
@@ -1,0 +1,348 @@
+/**
+ * OD-6 REVISION-DISPOSITION GUARD — "every `meta_records` write site must declare a revision
+ * disposition, or CI goes red" — the direct analogue of the rank-8 record-lock guard
+ * (`multitable-record-lock-guard.guard.test.ts`), but for revisions instead of locks.
+ *
+ * WHY THIS EXISTS (design-lock `docs/development/multitable-global-history-d1c-form-submit-edit-
+ * uncaptured-revision-design-lock-20260712.md` §0.5 OD-6, audit `/tmp/r13-revision-disposition-audit-
+ * 20260713.md` §2/§7a). The revision system was in the exact PRE-GUARD state the rank-8 lock guard was
+ * built to end: eight `meta_records` mutation sites (three independent human audits — rank-8, D-1, D-1c
+ * — each fixing only the sinks it happened to look at) write NO `recordRecordRevision(...)`, so
+ * `reconstructRecordsAtT` (the PIT/revert/reset read primitive) silently lies about those records
+ * forever. A structural guard prevents a NEW sink from joining that class silently.
+ *
+ * KEY DIFFERENCE FROM THE RANK-8 LOCK GUARD: that guard's `MUTATION_RE` deliberately does NOT match
+ * `INSERT INTO meta_records` (you cannot lock a record that does not exist yet). A *revision* guard MUST
+ * cover INSERT, because a create with no `action:'create'` revision is invisible to `reconstructRecordsAtT`
+ * forever — half of the 8-site bug class (audit A4/A5/A6) is exactly this. This guard's `MUTATION_RE`
+ * therefore adds `INSERT INTO meta_records` (+ the Kysely builder equivalent) on top of the lock guard's
+ * UPDATE/DELETE forms.
+ *
+ * HOW IT WORKS: enumerates EVERY `meta_records` mutation statement across the WHOLE runtime tree
+ * (`src/**`, migrations/tests/dist excluded — identical SCAN policy to the rank-8 guard) and requires
+ * each site to carry, within `MARKER_WINDOW` lines above the SQL, exactly one explicit marker comment:
+ *
+ *   • `// revision-emitted:<why>` → EMITTED  — `recordRecordRevision(...)` is called in the SAME
+ *                                              transaction as this mutation (cross-checked below: the
+ *                                              enclosing FILE must contain a real call, not just the label).
+ *   • `// revision-exempt:<why>`  → EXEMPT   — derived/system/config-captured write with no authoritative
+ *                                              user-data history obligation (formula recompute, auto-number
+ *                                              backfill, People-directory sync, lock/unlock metadata, the
+ *                                              derived approval projection, seed bootstrap, field-delete's
+ *                                              config-channel capture).
+ *   • `// revision-pending:<why>` → PENDING  — an OWNER-RULED MUST-WRITE site whose fix has NOT landed on
+ *                                              main yet (in-flight lane). A PENDING site is accepted ONLY
+ *                                              if its exact (file, line) also appears in
+ *                                              `PENDING_REVISION_SITES` below — the marker alone is not
+ *                                              enough, proving the allowlist is load-bearing (self-tests).
+ *
+ * A NEW or MOVED mutation site with NO marker FAILS this test until classified. A `revision-pending`
+ * marker whose (file, line) is missing from `PENDING_REVISION_SITES` ALSO fails — this is what makes the
+ * allowlist load-bearing rather than decorative (a developer cannot self-declare "pending" to dodge the
+ * guard; the allowlist entry, keyed to a real in-flight lane, is the actual permission slip). A malformed
+ * marker (recognizable prefix, missing the required `:reason`) fails with its own diagnostic, distinct
+ * from "no marker at all".
+ *
+ * PENDING_REVISION_SITES is the temporary bridge for the 8 uncaptured sites (audit §1/§2, R13-A lanes
+ * A/B/C, in-flight as #4219/#4216/#4220) plus `univer-meta.ts:6521` (field-undelete rehydration — audit
+ * flagged it debatable-EXEMPT, but the design-lock owner ruling (§0.5 OD-6) directs MUST-WRITE, so it is
+ * pending, not exempt; no lane PR assigned yet). Each entry is removed — and its site gains a
+ * `revision-emitted` marker — when that entry's lane lands. An entry with no corresponding
+ * `revision-pending`-marked site (lane landed, allowlist not cleaned up) fails a dedicated hygiene test
+ * below, closing the loop from the other direction.
+ *
+ * OUT OF THIS GUARD'S REACH (documented, not enforced here): `routes/univer-meta.ts` — the whole-sheet
+ * DELETE route runs `DELETE FROM meta_links WHERE foreign_record_id IN (SELECT id FROM meta_records …)`
+ * before `DELETE FROM meta_sheets`; the actual record loss is a DB-level `meta_sheets→meta_records ON
+ * DELETE CASCADE`, never a literal `DELETE FROM meta_records` statement — so it does not (and cannot)
+ * trip `MUTATION_RE`. This is audit §1 row 9 / §4's "9th site": a config/schema-lane structural residual,
+ * routed to a future *config*-revision guard, not this one. It carries an explanatory `// revision-exempt:`
+ * comment in source for human readers, but is a documented known-residual, not a scanner-covered site.
+ *
+ * SCAN policy (identical to the rank-8 lock guard): recursively walks the whole backend `src` tree, every
+ * runtime `.ts` file. Excluded by design: `db/migrations` (one-shot schema ops, no live user/plugin
+ * mutation surface — SYSTEM-exempt wholesale, same rationale as the lock guard); `.test.ts` / `.spec.ts` /
+ * `.d.ts`, `node_modules`, `dist`.
+ */
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+import { describe, expect, test } from 'vitest'
+
+const SRC = join(__dirname, '../../src')
+const read = (rel: string) => readFileSync(join(SRC, rel), 'utf8')
+
+/** Recursively list every runtime `.ts` file under `src/`, relative to `src/`, `/`-separated. */
+function listRuntimeTsFiles(): string[] {
+  const out: string[] = []
+  const walk = (absDir: string): void => {
+    for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+      const abs = join(absDir, entry.name)
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'migrations') continue
+        walk(abs)
+        continue
+      }
+      if (!entry.name.endsWith('.ts')) continue
+      if (entry.name.endsWith('.d.ts') || entry.name.endsWith('.test.ts') || entry.name.endsWith('.spec.ts')) continue
+      out.push(relative(SRC, abs).split(sep).join('/'))
+    }
+  }
+  walk(SRC)
+  return out.sort()
+}
+
+/** How many physical lines ABOVE the SQL line a disposition marker may sit (allow a blank/ternary/`SET` line). */
+const MARKER_WINDOW = 3
+
+type Disposition = 'EMITTED' | 'EXEMPT' | 'PENDING' | 'MALFORMED'
+
+interface Site {
+  file: string
+  line: number // 1-based
+  sql: string
+  disposition: Disposition | null
+}
+
+/**
+ * Every form a `meta_records` row-mutation can take in this codebase today (raw SQL `INSERT INTO` /
+ * `UPDATE` / `DELETE FROM`), plus the Kysely query-builder forms pre-emptively (mirroring the rank-8
+ * guard's own forward-compatibility precedent) so a future builder-style mutation is also caught.
+ * Unlike the rank-8 lock guard, `INSERT INTO meta_records` IS matched here (see file header).
+ */
+const MUTATION_RE =
+  /\b(?:INSERT INTO meta_records|UPDATE meta_records|DELETE FROM meta_records)\b|(?:insertInto|updateTable|deleteFrom)\(\s*['"`]meta_records['"`]/
+
+/** A marker keyword was attempted but is missing its required `:reason` — distinct diagnostic from "no marker". */
+const MALFORMED_ATTEMPT_RE = /\/\/\s*revision-(?:emitted|exempt|pending)\b(?!:)/
+
+function classify(window: string): Disposition | null {
+  if (/\/\/\s*revision-emitted:/.test(window)) return 'EMITTED'
+  if (/\/\/\s*revision-exempt:/.test(window)) return 'EXEMPT'
+  if (/\/\/\s*revision-pending:/.test(window)) return 'PENDING'
+  if (MALFORMED_ATTEMPT_RE.test(window)) return 'MALFORMED'
+  return null
+}
+
+function enumerateSites(file: string, src: string): Site[] {
+  const lines = src.split('\n')
+  const sites: Site[] = []
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]
+    if (!MUTATION_RE.test(line)) continue
+    // skip comments / JSDoc that merely mention the statement (identical guard to the rank-8 scanner)
+    const trimmed = line.trimStart()
+    if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue
+    const windowStart = Math.max(0, i - MARKER_WINDOW)
+    const window = lines.slice(windowStart, i + 1).join('\n')
+    sites.push({ file, line: i + 1, sql: line.trim(), disposition: classify(window) })
+  }
+  return sites
+}
+
+/**
+ * The temporary bridge for the 9 sites that are OWNER-RULED must-write-a-revision but NOT fixed on main
+ * yet (design-lock §0.5 OD-6, audit §1/§2). Keyed to the in-flight lane PR that closes each. When a lane
+ * lands: (a) the site gains a `// revision-emitted:` marker + a same-txn `recordRecordRevision` call, and
+ * (b) its entry here is DELETED — enforced by the "no stale allowlist entries" hygiene test below.
+ */
+const PENDING_REVISION_SITES: ReadonlyArray<{ file: string; line: number; lane: string }> = [
+  // Lane A (audit A1/A6/A8) — form-submit CREATE/EDIT + attachment-delete. Tracked: #4219.
+  { file: 'routes/univer-meta.ts', line: 14439, lane: '#4219 (form-submit EDIT, audit A1 — D-1c\'s own defect)' },
+  { file: 'routes/univer-meta.ts', line: 14487, lane: '#4219 (form-submit CREATE, audit A6)' },
+  { file: 'routes/univer-meta.ts', line: 15711, lane: '#4219 (attachment-delete record edit, audit A8)' },
+  // Lane B (audit A2/A5) — plugin-SDK create/update. Tracked: #4216.
+  { file: 'multitable/records.ts', line: 508, lane: '#4216 (plugin-SDK patchRecord, audit A2)' },
+  { file: 'multitable/records.ts', line: 548, lane: '#4216 (plugin-SDK createRecord, audit A5)' },
+  // Lane C (audit A3/A4/A7) — automation create/update + resultWriteback. Tracked: #4220.
+  { file: 'multitable/automation-executor.ts', line: 2218, lane: '#4220 (automation update_record, audit A3)' },
+  { file: 'multitable/automation-executor.ts', line: 2478, lane: '#4220 (automation create_record, audit A4)' },
+  { file: 'multitable/automation-service.ts', line: 2818, lane: '#4220 (automation resultWriteback, audit A7)' },
+  // Owner-ruled MUST-WRITE (design-lock §0.5 OD-6), NOT one of the audit's 8 — debatable-EXEMPT per the
+  // audit, overruled to MUST-WRITE by the owner. No lane PR assigned yet.
+  { file: 'routes/univer-meta.ts', line: 6527, lane: 'follow-up (field-undelete rehydration, owner-ruled MUST-WRITE, no PR yet)' },
+]
+
+function findPendingEntry(file: string, line: number): { file: string; line: number; lane: string } | undefined {
+  return PENDING_REVISION_SITES.find((p) => p.file === file && p.line === line)
+}
+
+/**
+ * The acceptance predicate every site is judged by. Exported as a plain function (not a class/closure
+ * over module state) so the self-tests below can call it directly against synthetic sites and a
+ * deliberately-shrunk copy of the allowlist, proving the allowlist is load-bearing without ever mutating
+ * a real source file on disk.
+ */
+function isAccepted(site: Pick<Site, 'file' | 'line' | 'disposition'>, pending: ReadonlyArray<{ file: string; line: number }>): boolean {
+  if (site.disposition === 'EMITTED') return true
+  if (site.disposition === 'EXEMPT') return true
+  if (site.disposition === 'PENDING') return pending.some((p) => p.file === site.file && p.line === site.line)
+  // no marker at all is accepted ONLY if the allowlist independently covers it (defense in depth — in
+  // practice every pending site today also carries an explicit `revision-pending:` marker in source).
+  if (site.disposition === null) return pending.some((p) => p.file === site.file && p.line === site.line)
+  return false // MALFORMED never passes
+}
+
+describe('OD-6 revision-disposition mutation-path guard — durable structural guard', () => {
+  const allSites = listRuntimeTsFiles().flatMap((file) => enumerateSites(file, read(file)))
+
+  test('the enumeration finds the expected mutation surface (smoke — not zero, not exploded)', () => {
+    // 36 known sites at authoring time (9 INSERT + 22 UPDATE + 5 DELETE — audit §2, cross-checked against
+    // a live grep of origin/main). The scan is whole-`src`, so a count change is FINE by itself — it means
+    // a mutation site was added/removed/moved; the per-site disposition test below is the real gate. This
+    // bound only flags an extractor that matched nothing (walk broke) or exploded (regex over-matched).
+    expect(allSites.length).toBeGreaterThanOrEqual(30)
+    expect(allSites.length).toBeLessThanOrEqual(60)
+  })
+
+  test('INSERT is actually covered by the live scan (the rank-8 lock guard deliberately excludes it)', () => {
+    const insertSites = allSites.filter((s) => /INSERT INTO meta_records/.test(s.sql))
+    // audit: 9 real INSERT sites (record-service.ts×2, records.ts, automation-executor.ts, univer-meta.ts×4,
+    // approval-record-projection-service.ts).
+    expect(insertSites.length).toBeGreaterThanOrEqual(8)
+  })
+
+  test('EVERY meta_records INSERT/UPDATE/DELETE site carries an accepted revision disposition', () => {
+    const violations = allSites.filter((s) => !isAccepted(s, PENDING_REVISION_SITES))
+    expect(
+      violations,
+      `OD-6 REVISION-DISPOSITION GUARD: ${violations.length} meta_records mutation site(s) with NO accepted ` +
+        `revision disposition:\n` +
+        violations
+          .map((s) => `  - ${s.file}:${s.line}  [${s.disposition ?? 'UNMARKED'}]  ${s.sql}`)
+          .join('\n') +
+        `\n\nYou added or moved a record mutation site. Within ${MARKER_WINDOW} lines above the SQL, add ONE of:\n` +
+        `  // revision-emitted:<why>  — recordRecordRevision(...) is called in the SAME transaction\n` +
+        `  // revision-exempt:<why>   — derived/system/config-captured write, no user-data history obligation\n` +
+        `  // revision-pending:<why>  — owner-ruled MUST-WRITE but not fixed yet; ALSO add an entry to ` +
+        `PENDING_REVISION_SITES in this file, keyed to the lane PR that will close it.\n` +
+        `A silent new create/update/delete that emits no revision is exactly the D-1c/OD-6 bug class this ` +
+        `guard exists to prevent.`,
+    ).toEqual([])
+  })
+
+  test('every EMITTED-labelled file actually calls recordRecordRevision( (a label cannot fake emission)', () => {
+    const emittedFiles = new Set(allSites.filter((s) => s.disposition === 'EMITTED').map((s) => s.file))
+    // the known-compliant files (audit §2's 14 sites) must be present
+    for (const f of [
+      'multitable/record-service.ts',
+      'multitable/record-write-service.ts',
+      'multitable/records.ts',
+      'multitable/automation-executor.ts',
+      'routes/univer-meta.ts',
+    ]) {
+      expect(emittedFiles.has(f), `${f} should have at least one EMITTED mutation site`).toBe(true)
+    }
+    for (const f of emittedFiles) {
+      expect(
+        read(f).includes('recordRecordRevision('),
+        `${f} is labelled revision-emitted but never calls recordRecordRevision(`,
+      ).toBe(true)
+    }
+  })
+
+  test('every PENDING_REVISION_SITES entry corresponds to a site CURRENTLY marked revision-pending (no stale entries)', () => {
+    // Symmetric hygiene check: when a lane lands, the site's marker flips to revision-emitted — this test
+    // then fails until the now-stale allowlist entry is deleted, closing the loop from the landing side
+    // (the "guard fails if unmarked and not pending" test closes it from the marking side).
+    const pendingSites = new Set(allSites.filter((s) => s.disposition === 'PENDING').map((s) => `${s.file}:${s.line}`))
+    const stale = PENDING_REVISION_SITES.filter((p) => !pendingSites.has(`${p.file}:${p.line}`))
+    expect(
+      stale,
+      `PENDING_REVISION_SITES has ${stale.length} entr(y/ies) whose site is no longer marked revision-pending ` +
+        `(the lane likely landed) — delete the stale entry:\n` +
+        stale.map((p) => `  - ${p.file}:${p.line}  (${p.lane})`).join('\n'),
+    ).toEqual([])
+  })
+
+  test('PENDING_REVISION_SITES has no duplicate (file,line) keys and every entry names a real lane', () => {
+    const keys = PENDING_REVISION_SITES.map((p) => `${p.file}:${p.line}`)
+    expect(new Set(keys).size).toBe(keys.length)
+    for (const p of PENDING_REVISION_SITES) {
+      expect(p.lane.length, `${p.file}:${p.line} allowlist entry must name a tracking lane`).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('OD-6 guard self-test — mutation proof (the guard must go red when neutered)', () => {
+  test('synthetic unmarked INSERT INTO meta_records is flagged (proves INSERT coverage, not inferred)', () => {
+    const synthetic = [
+      'export async function sneakyCreate(query: unknown, sheetId: string, data: unknown) {',
+      '  const recordId = `rec_${Math.random()}`',
+      '  const inserted = await query(',
+      '    `INSERT INTO meta_records (id, sheet_id, data, version)',
+      '     VALUES ($1, $2, $3::jsonb, 1)',
+      '     RETURNING version`,',
+      '    [recordId, sheetId, JSON.stringify(data)],',
+      '  )',
+      '  return inserted',
+      '}',
+    ].join('\n')
+    const sites = enumerateSites('synthetic/sneaky-create.ts', synthetic)
+    expect(sites.length).toBe(1)
+    expect(sites[0].disposition).toBeNull()
+    expect(isAccepted(sites[0], PENDING_REVISION_SITES)).toBe(false)
+  })
+
+  test('a malformed marker (missing colon) does not classify as any accepted disposition', () => {
+    const synthetic = [
+      'export async function halfMarked(query: unknown, sheetId: string, recordId: string, patch: unknown) {',
+      '  // revision-emitted oops forgot the colon',
+      '  await query(',
+      '    `UPDATE meta_records SET data = data || $1::jsonb WHERE id = $2 AND sheet_id = $3`,',
+      '    [JSON.stringify(patch), recordId, sheetId],',
+      '  )',
+      '}',
+    ].join('\n')
+    const sites = enumerateSites('synthetic/half-marked.ts', synthetic)
+    expect(sites.length).toBe(1)
+    expect(sites[0].disposition).toBe('MALFORMED')
+    expect(isAccepted(sites[0], PENDING_REVISION_SITES)).toBe(false)
+  })
+
+  test('removing the revision-emitted marker from a REAL compliant site (record-service.ts create) goes red', () => {
+    // Mutate real file content IN MEMORY ONLY (never written to disk) — strips exactly the marker line
+    // this PR added above the create INSERT, proving the guard is not vacuously green.
+    const real = read('multitable/record-service.ts')
+    expect(real).toContain('// revision-emitted: create — recordRecordRevision below in the same txn (rev@706).\n')
+    const mutated = real.replace(
+      '// revision-emitted: create — recordRecordRevision below in the same txn (rev@706).\n',
+      '',
+    )
+    expect(mutated).not.toEqual(real)
+    const before = enumerateSites('multitable/record-service.ts', real).find((s) => /INSERT INTO meta_records/.test(s.sql))
+    const after = enumerateSites('multitable/record-service.ts', mutated).find((s) => /INSERT INTO meta_records/.test(s.sql))
+    expect(before?.disposition).toBe('EMITTED')
+    expect(isAccepted(before!, PENDING_REVISION_SITES)).toBe(true)
+    expect(after?.disposition).toBeNull()
+    expect(isAccepted(after!, PENDING_REVISION_SITES)).toBe(false)
+  })
+
+  test('removing an entry from PENDING_REVISION_SITES makes its still-pending-marked site fail (allowlist is load-bearing)', () => {
+    const target = { file: 'multitable/records.ts', line: 548 }
+    const shrunk = PENDING_REVISION_SITES.filter((p) => !(p.file === target.file && p.line === target.line))
+    expect(shrunk.length).toBe(PENDING_REVISION_SITES.length - 1)
+    const site: Site = { file: target.file, line: target.line, sql: '`INSERT INTO meta_records (id, sheet_id, data, version)', disposition: 'PENDING' }
+    // with the full allowlist, the site is accepted (marker + entry both present)
+    expect(isAccepted(site, PENDING_REVISION_SITES)).toBe(true)
+    // with the entry removed, the SAME marked-pending site is now rejected — the allowlist, not the
+    // marker alone, is what makes a pending site pass.
+    expect(isAccepted(site, shrunk)).toBe(false)
+  })
+
+  test('a revision-pending marker with NO allowlist entry at all is rejected (cannot self-declare pending)', () => {
+    const synthetic = [
+      'export async function selfDeclaredPending(query: unknown, sheetId: string, recordId: string, patch: unknown) {',
+      '  // revision-pending: I promise I will fix this later, please let me merge',
+      '  await query(',
+      '    `UPDATE meta_records SET data = data || $1::jsonb WHERE id = $2 AND sheet_id = $3`,',
+      '    [JSON.stringify(patch), recordId, sheetId],',
+      '  )',
+      '}',
+    ].join('\n')
+    const sites = enumerateSites('synthetic/self-declared-pending.ts', synthetic)
+    expect(sites.length).toBe(1)
+    expect(sites[0].disposition).toBe('PENDING')
+    expect(isAccepted(sites[0], PENDING_REVISION_SITES)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Implements the **OD-6 revision-disposition guard** ratified in the design-lock `docs/development/multitable-global-history-d1c-form-submit-edit-uncaptured-revision-design-lock-20260712.md` §0.5, per the consolidated audit `/tmp/r13-revision-disposition-audit-20260713.md` §2.

The revision system was in the exact pre-guard state the rank-8 record-lock guard was built to end: **8 `meta_records` mutation sites** (found across 3 independent human audits — rank-8, D-1, D-1c — each fixing only the sinks it happened to look at) write **no** `recordRecordRevision(...)`, so `reconstructRecordsAtT` (the PIT/revert/reset read primitive) silently and permanently lies about those records. This PR adds a static structural guard so a **new** uncaptured sink can never be added silently again.

## What changed

- **New file**: `packages/core-backend/tests/unit/multitable-revision-disposition-guard.guard.test.ts` — modelled on `multitable-record-lock-guard.guard.test.ts`, but **also covers `INSERT INTO meta_records`** (the lock guard deliberately excludes INSERT — you cannot lock a record that doesn't exist yet; a revision guard cannot skip it, since an uncaptured CREATE is invisible to the reconstructor forever).
- **Source changes are comment-only markers, zero runtime behavior change**, added to all 36 real `meta_records` write sites in `packages/core-backend/src` (9 INSERT + 22 UPDATE + 5 DELETE):
  - **14 `// revision-emitted:`** on the currently-compliant sites (record-service.ts, record-write-service.ts, records.ts, automation-executor.ts, univer-meta.ts).
  - **13 `// revision-exempt:`** on derived/system/config-captured sites (formula recompute, auto-number backfill, People-directory/sheet sync, seed bootstrap, field-delete config-channel strip, record lock/unlock metadata, the derived approval projection).
  - **9 `// revision-pending:`**, each cross-referenced in an explicit `PENDING_REVISION_SITES` allowlist keyed to the in-flight lane PR that fixes it: `univer-meta.ts:14439/14487/15711` → #4219 (lane A), `records.ts:508/548` → #4216 (lane B), `automation-executor.ts:2218/2478` + `automation-service.ts:2818` → #4220 (lane C), and `univer-meta.ts:6527` (field-undelete rehydration) → follow-up, no lane PR assigned yet. This is the owner's OD-6 ruling override: the audit flagged `:6527` as debatable-EXEMPT, the design-lock owner ruling directs MUST-WRITE instead.
  - `univer-meta.ts:12519` (whole-sheet delete): the actual record loss is a `meta_sheets→meta_records` FK CASCADE, not a literal `DELETE FROM meta_records` statement, so it structurally cannot trip this guard's regex. Documented in source as the audit's "9th site" / config-lane residual, routed to a future config-revision guard rather than force-matched here.

### Discrepancy vs. the audit doc (reported, not silently resolved)

Both the audit and the task brief say **"15 exempt"**, but the audit's own enumerated EXEMPT table (and the task's own explicit list) total **14** rows (3 INSERT + 11 UPDATE). My independent `grep` of every `meta_records` INSERT/UPDATE/DELETE in `src` on `origin/main` found exactly **36** real sites (9+22+5), which equals `14 emitted + 14 exempt(audit) + 8 violating`. Moving `univer-meta.ts:6521` from exempt → pending per the owner's ruling nets **14 emitted + 13 exempt + 9 pending = 36**, matching the live scan exactly. The audit intro's "37 sites... 6 DELETE" appears to fold in the `:12519` FK-cascade residual (which is not a literal `meta_records` DELETE), off by one from the literal-grep total. Guard docstring states this reconciliation explicitly.

## Self-test / mutation proof (guard is load-bearing, not vacuous)

- Synthetic unmarked `INSERT INTO meta_records` → flagged (proves INSERT coverage, the key delta from the lock guard).
- Malformed marker (`// revision-emitted` missing the colon) → rejected, not silently accepted.
- Removing the `revision-emitted` marker from a **real** compliant site (record-service.ts, in-memory only, never written to disk) → goes red.
- Removing an entry from `PENDING_REVISION_SITES` → its still-`revision-pending`-marked site now fails, proving the allowlist — not just the marker — gates acceptance (a developer cannot self-declare "pending" to dodge the guard).
- Also empirically verified by temporarily mutating the real `record-service.ts` on disk (stripping the marker), confirming the main guard test reds against a genuinely unmarked real site, then reverting before commit.

### Symmetric hygiene

A dedicated test asserts every `PENDING_REVISION_SITES` entry still corresponds to a site currently marked `revision-pending` — when a lane lands and the marker flips to `revision-emitted`, this test goes red until the now-stale allowlist entry is deleted, closing the loop from the landing side.

### Fixed a self-inflicted regression before committing

Adding marker lines next to two multi-line `lock-guarded`/`lock-exempt` comments (`automation-service.ts:2818`, `univer-meta.ts:6429`/`6521`) pushed the pre-existing lock marker outside the rank-8 lock guard's own 3-line window, breaking that guard. Collapsed those two-line comments to one physical line each; both guards now pass together (verified).

### Known limitation, as-specified

`PENDING_REVISION_SITES` is keyed by absolute `(file, line)`. An unrelated PR that adds lines above one of the 9 pending sites will drift its line number and red this guard until the allowlist entry is updated — the "no stale entries" hygiene test only catches the lane-landed case, not pure line drift. This is the design the task specified (mirrors the lock guard's own line-oriented approach); flagging it here so the next maintainer isn't surprised by a guard failure that just needs a line-number bump.

## Test plan

- [x] `npx vitest run tests/unit/multitable-revision-disposition-guard.guard.test.ts` — 11/11 passed.
- [x] `npx vitest run tests/unit/multitable-record-lock-guard.guard.test.ts` — 4/4 passed (confirmed not broken).
- [x] `npx vitest run tests/unit` (full core-backend unit suite) — 388 files / 5328 tests passed.
- [x] `npx tsc --noEmit` — clean, no new type errors.
- [x] Empirical mutation proof: temporarily stripped a real marker from `record-service.ts` on disk, confirmed the guard reds, reverted (clean `git diff`).
- [x] CI `test (20.x)` (the actual `pnpm --filter @metasheet/core-backend test` required gate) — **PASS** (13m50s). `test (18.x)` and `web-tests` also PASS.

All required checks green (contracts ×3, pr-validate, test (20.x), web-tests).

Pure unit test, no env flag, no DB — collected automatically by the default vitest glob in the same `test (20.x)` step as the rank-8 lock guard.

**Draft — not requesting merge.** Per instructions, this PR is not marked ready/armed/merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>