### PR TITLE
ci(migrations): re-enable views/view_states + snapshot-cluster migrations in all 5 CI exclude lists (#4162)

### DIFF
--- a/.github/workflows/migration-replay.yml
+++ b/.github/workflows/migration-replay.yml
@@ -78,29 +78,33 @@ jobs:
           # NOT been re-verified against the same fix, which may mean they are stale rather than
           # intentionally divergent. See docs/development/superseded-legacy-migrations-gap-audit-20260710.md
           # and packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md for the full cross-list
-          # picture, and #4162 for the gated follow-up that would re-enable the view-table
-          # cluster in CI. Do not resolve that gap by editing this file — the two lists solve
-          # different problems and are not required to converge.
+          # picture. #4162's follow-up is now PARTIALLY executed (2026-07-13): the
+          # views/view_states migration and the three snapshot-cluster migrations are
+          # re-enabled in ALL five workflow lists simultaneously (this file, plugin-tests,
+          # observability-e2e/strict, safety-guard-e2e) — see the Re-enabled note below.
+          # Still excluded everywhere: 008/048/049, 042a, gantt (and 20250925 outside this
+          # file). The two lists solve different problems and are not required to converge.
           # Exclude 008_plugin_infrastructure.sql - has idempotency issue with scope column
           # TODO: Fix migration to be fully idempotent or split into separate migrations
           # Exclude 048-049 - Phase 2 Event Bus/BPMN migrations with complex SQL syntax issues
           # TODO: Rewrite these migrations with correct PostgreSQL syntax
-          # Exclude 20250924120000_create_views_view_states.ts - View states migration with schema issues
+          # Re-enabled per #4162 (2026-07-13): 20250924120000_create_views_view_states.ts and the three
+          # snapshot-cluster migrations (20251117000001_add_snapshot_labels, 20251117000002_create_protection_rules,
+          # 20251201000001_create_change_management_tables) now RUN here. Their old per-item exclusion reasons were
+          # re-tested and are stale (same class as the 20250925 one #3627 fixed): fresh-DB migrate, second-pass
+          # replay, and the snapshot-protection E2E (21/21) all pass with them applied.
           # Exclude 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
-          # Exclude 20251117000001_add_snapshot_labels.ts - re-applies chk_protection_level after earlier snapshot schema creation during replay
-          # Exclude 20251117000002_create_protection_rules.ts - re-creates protection_rules after replay paths already created the table
-          # Exclude 20251201000001_create_change_management_tables.ts - legacy snapshot_id text FKs no longer match replay-built uuid snapshot ids
           # Exclude zzzz20260114110000_create_user_orgs_table.ts - replay paths hit legacy user_orgs is_active reference incompatibility
           # Exclude 042a_core_model_views.sql - References non-existent last_accessed column
           # TODO: Fix last_accessed column reference in 042a_core_model_views.sql
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm -F @metasheet/core-backend db:migrate
           pnpm -F @metasheet/core-backend db:migrate
       - name: List migrations
         env:
           DATABASE_URL: postgresql://127.0.0.1/metasheet
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
         run: pnpm -F @metasheet/core-backend db:list
 
       - name: Upload install logs on failure

--- a/.github/workflows/observability-e2e.yml
+++ b/.github/workflows/observability-e2e.yml
@@ -72,9 +72,11 @@ jobs:
           # (no-ops a migration's body but keeps its name; this drops name+body entirely). See
           # packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md and
           # docs/development/superseded-legacy-migrations-gap-audit-20260710.md for the full
-          # cross-list picture. Known asymmetry: production/on-prem db:migrate runs with no
-          # exclude at all, so the view-table cluster excluded below has never had a per-PR
-          # green CI run of its up() bodies — untangling that is gated planning work, #4162.
+          # cross-list picture. #4162 follow-up (2026-07-13): the views/view_states migration
+          # and the three snapshot-cluster migrations are re-enabled below (in all five
+          # workflow lists at once), so their up() bodies now DO get per-PR green CI runs.
+          # Remaining asymmetry: production/on-prem db:migrate runs with no exclude at all,
+          # so the STILL-excluded items (008/048/049, 042a, gantt, 20250925) keep that gap.
           # Exclude problematic migrations (see migration-replay.yml for the per-item detail
           # this workflow shares):
           # 008_plugin_infrastructure.sql - has idempotency issue with scope column

--- a/.github/workflows/observability-e2e.yml
+++ b/.github/workflows/observability-e2e.yml
@@ -80,20 +80,21 @@ jobs:
           # 008_plugin_infrastructure.sql - has idempotency issue with scope column
           # 048/049 (event bus / BPMN) - Phase 2 migrations with complex SQL syntax issues
           # 042a_core_model_views.sql - References non-existent last_accessed column
-          # 20250924120000_create_views_view_states.ts - View states migration with schema issues
+          # Re-enabled per #4162 (2026-07-13): 20250924120000_create_views_view_states.ts and the three
+          # snapshot-cluster migrations (20251117000001_add_snapshot_labels, 20251117000002_create_protection_rules,
+          # 20251201000001_create_change_management_tables) now RUN here. Their old per-item exclusion reasons were
+          # re-tested and are stale (same class as the 20250925 one #3627 fixed): fresh-DB migrate, second-pass
+          # replay, and the snapshot-protection E2E (21/21) all pass with them applied.
           # 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
           # 20250925_create_view_tables.sql - legacy owner_id FK assumes pre-text user ids during replay.
           #   NOTE: this exact bug was fixed by #3627, and migration-replay.yml already dropped
           #   this exclusion in #3632 (verified passing there); this workflow was never
           #   re-verified/updated to match, so this exclusion may now be stale rather than still
           #   required — needs re-verification before removal, not a piecemeal drop (see #4162).
-          # 20251117000001_add_snapshot_labels.ts - re-applies chk_protection_level after earlier snapshot schema creation during replay
-          # 20251117000002_create_protection_rules.ts - re-creates protection_rules after replay paths already created the table
-          # 20251201000001_create_change_management_tables.ts - legacy snapshot_id text FKs no longer match replay-built uuid snapshot ids
           # zzzz20260114110000_create_user_orgs_table.ts - replay paths hit legacy user_orgs is_active reference incompatibility.
           #   NOTE: plugin-tests.yml intentionally does NOT exclude this one — attendance
           #   auto-absence depends on the user_orgs table in that job (see b1fc1e19d1).
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm -F @metasheet/core-backend db:list || true
           pnpm -F @metasheet/core-backend db:migrate

--- a/.github/workflows/observability-strict.yml
+++ b/.github/workflows/observability-strict.yml
@@ -104,9 +104,11 @@ jobs:
           # (no-ops a migration's body but keeps its name; this drops name+body entirely). See
           # packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md and
           # docs/development/superseded-legacy-migrations-gap-audit-20260710.md for the full
-          # cross-list picture. Known asymmetry: production/on-prem db:migrate runs with no
-          # exclude at all, so the view-table cluster excluded below has never had a per-PR
-          # green CI run of its up() bodies — untangling that is gated planning work, #4162.
+          # cross-list picture. #4162 follow-up (2026-07-13): the views/view_states migration
+          # and the three snapshot-cluster migrations are re-enabled below (in all five
+          # workflow lists at once), so their up() bodies now DO get per-PR green CI runs.
+          # Remaining asymmetry: production/on-prem db:migrate runs with no exclude at all,
+          # so the STILL-excluded items (008/048/049, 042a, gantt, 20250925) keep that gap.
           # Exclude problematic migrations (see migration-replay.yml for details)
           # 008_plugin_infrastructure.sql - has idempotency issue with scope column
           # 048/049 (event bus / BPMN) - Phase 2 migrations with complex SQL syntax issues

--- a/.github/workflows/observability-strict.yml
+++ b/.github/workflows/observability-strict.yml
@@ -111,20 +111,21 @@ jobs:
           # 008_plugin_infrastructure.sql - has idempotency issue with scope column
           # 048/049 (event bus / BPMN) - Phase 2 migrations with complex SQL syntax issues
           # 042a_core_model_views.sql - References non-existent last_accessed column
-          # 20250924120000_create_views_view_states.ts - View states migration with schema issues
+          # Re-enabled per #4162 (2026-07-13): 20250924120000_create_views_view_states.ts and the three
+          # snapshot-cluster migrations (20251117000001_add_snapshot_labels, 20251117000002_create_protection_rules,
+          # 20251201000001_create_change_management_tables) now RUN here. Their old per-item exclusion reasons were
+          # re-tested and are stale (same class as the 20250925 one #3627 fixed): fresh-DB migrate, second-pass
+          # replay, and the snapshot-protection E2E (21/21) all pass with them applied.
           # 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
           # 20250925_create_view_tables.sql - legacy owner_id FK assumes pre-text user ids during replay.
           #   NOTE: this exact bug was fixed by #3627, and migration-replay.yml already dropped
           #   this exclusion in #3632 (verified passing there); this workflow was never
           #   re-verified/updated to match, so this exclusion may now be stale rather than still
           #   required — needs re-verification before removal, not a piecemeal drop (see #4162).
-          # 20251117000001_add_snapshot_labels.ts - re-applies chk_protection_level after earlier snapshot schema creation during replay
-          # 20251117000002_create_protection_rules.ts - re-creates protection_rules after replay paths already created the table
-          # 20251201000001_create_change_management_tables.ts - legacy snapshot_id text FKs no longer match replay-built uuid snapshot ids
           # zzzz20260114110000_create_user_orgs_table.ts - replay paths hit legacy user_orgs is_active reference incompatibility.
           #   NOTE: plugin-tests.yml intentionally does NOT exclude this one — attendance
           #   auto-absence depends on the user_orgs table in that job (see b1fc1e19d1).
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm -F @metasheet/core-backend db:list || true
           pnpm -F @metasheet/core-backend db:migrate

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -190,24 +190,27 @@ jobs:
           # (no-ops a migration's body but keeps its name; this drops name+body entirely). See
           # packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md and
           # docs/development/superseded-legacy-migrations-gap-audit-20260710.md for the full
-          # cross-list picture. Known asymmetry: production/on-prem db:migrate runs with no
-          # exclude at all, so the view-table cluster excluded below has never had a per-PR
-          # green CI run of its up() bodies — untangling that is gated planning work, #4162.
+          # cross-list picture. #4162 follow-up (2026-07-13): the views/view_states migration
+          # and the three snapshot-cluster migrations are re-enabled below (in all five
+          # workflow lists at once), so their up() bodies now DO get per-PR green CI runs.
+          # Remaining asymmetry: production/on-prem db:migrate runs with no exclude at all,
+          # so the STILL-excluded items (008/048/049, 042a, gantt, 20250925) keep that gap.
           # Exclude problematic migrations (see migration-replay.yml for the per-item detail
           # this workflow shares):
           # 008_plugin_infrastructure.sql - has idempotency issue with scope column
           # 048/049 (event bus / BPMN) - Phase 2 migrations with complex SQL syntax issues
           # 042a_core_model_views.sql - References non-existent last_accessed column
-          # 20250924120000_create_views_view_states.ts - View states migration with schema issues
+          # Re-enabled per #4162 (2026-07-13): 20250924120000_create_views_view_states.ts and the three
+          # snapshot-cluster migrations (20251117000001_add_snapshot_labels, 20251117000002_create_protection_rules,
+          # 20251201000001_create_change_management_tables) now RUN here. Their old per-item exclusion reasons were
+          # re-tested and are stale (same class as the 20250925 one #3627 fixed): fresh-DB migrate, second-pass
+          # replay, and the snapshot-protection E2E (21/21) all pass with them applied.
           # 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
           # 20250925_create_view_tables.sql - legacy owner_id FK assumes pre-text user ids during replay.
           #   NOTE: this exact bug was fixed by #3627, and migration-replay.yml already dropped
           #   this exclusion in #3632 (verified passing there); this workflow was never
           #   re-verified/updated to match, so this exclusion may now be stale rather than still
           #   required — needs re-verification before removal, not a piecemeal drop (see #4162).
-          # 20251117000001_add_snapshot_labels.ts - re-applies chk_protection_level after earlier snapshot schema creation during replay
-          # 20251117000002_create_protection_rules.ts - re-creates protection_rules after replay paths already created the table
-          # 20251201000001_create_change_management_tables.ts - legacy snapshot_id text FKs no longer match replay-built uuid snapshot ids
           # NOTE: zzzz20260114110000_create_user_orgs_table.ts is intentionally NOT in this
           #   list (unlike observability-*.yml/safety-guard-e2e.yml/migration-replay.yml, which
           #   all exclude it because it hits a legacy user_orgs is_active replay incompatibility
@@ -216,7 +219,7 @@ jobs:
           #   ("ci(attendance): run integration gate against postgres") — "Include the user_orgs
           #   migration in plugin-test database setup because attendance auto-absence now
           #   depends on that table."
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
         run: |
           pnpm --filter @metasheet/core-backend db:migrate
 
@@ -671,24 +674,27 @@ jobs:
           # (no-ops a migration's body but keeps its name; this drops name+body entirely). See
           # packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md and
           # docs/development/superseded-legacy-migrations-gap-audit-20260710.md for the full
-          # cross-list picture. Known asymmetry: production/on-prem db:migrate runs with no
-          # exclude at all, so the view-table cluster excluded below has never had a per-PR
-          # green CI run of its up() bodies — untangling that is gated planning work, #4162.
+          # cross-list picture. #4162 follow-up (2026-07-13): the views/view_states migration
+          # and the three snapshot-cluster migrations are re-enabled below (in all five
+          # workflow lists at once), so their up() bodies now DO get per-PR green CI runs.
+          # Remaining asymmetry: production/on-prem db:migrate runs with no exclude at all,
+          # so the STILL-excluded items (008/048/049, 042a, gantt, 20250925) keep that gap.
           # Exclude problematic migrations (see migration-replay.yml for the per-item detail
           # this workflow shares):
           # 008_plugin_infrastructure.sql - has idempotency issue with scope column
           # 048/049 (event bus / BPMN) - Phase 2 migrations with complex SQL syntax issues
           # 042a_core_model_views.sql - References non-existent last_accessed column
-          # 20250924120000_create_views_view_states.ts - View states migration with schema issues
+          # Re-enabled per #4162 (2026-07-13): 20250924120000_create_views_view_states.ts and the three
+          # snapshot-cluster migrations (20251117000001_add_snapshot_labels, 20251117000002_create_protection_rules,
+          # 20251201000001_create_change_management_tables) now RUN here. Their old per-item exclusion reasons were
+          # re-tested and are stale (same class as the 20250925 one #3627 fixed): fresh-DB migrate, second-pass
+          # replay, and the snapshot-protection E2E (21/21) all pass with them applied.
           # 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
           # 20250925_create_view_tables.sql - legacy owner_id FK assumes pre-text user ids during replay.
           #   NOTE: this exact bug was fixed by #3627, and migration-replay.yml already dropped
           #   this exclusion in #3632 (verified passing there); this workflow was never
           #   re-verified/updated to match, so this exclusion may now be stale rather than still
           #   required — needs re-verification before removal, not a piecemeal drop (see #4162).
-          # 20251117000001_add_snapshot_labels.ts - re-applies chk_protection_level after earlier snapshot schema creation during replay
-          # 20251117000002_create_protection_rules.ts - re-creates protection_rules after replay paths already created the table
-          # 20251201000001_create_change_management_tables.ts - legacy snapshot_id text FKs no longer match replay-built uuid snapshot ids
           # NOTE: zzzz20260114110000_create_user_orgs_table.ts is also absent from this job's
           #   list (unlike observability-*.yml/safety-guard-e2e.yml/migration-replay.yml). It was
           #   removed here in the SAME commit as the `test` job above (b1fc1e19d1), whose message
@@ -697,7 +703,7 @@ jobs:
           #   not obviously touch user_orgs/attendance. Left as-is (not this T8 slice's job to
           #   resolve), but flagged: this specific occurrence's omission may be an unverified
           #   side-effect of a file-wide edit rather than a decision made for this job.
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
         run: |
           pnpm --filter @metasheet/core-backend db:migrate
 

--- a/.github/workflows/safety-guard-e2e.yml
+++ b/.github/workflows/safety-guard-e2e.yml
@@ -79,20 +79,21 @@ jobs:
           # 008_plugin_infrastructure.sql - has idempotency issue with scope column
           # 048/049 (event bus / BPMN) - Phase 2 migrations with complex SQL syntax issues
           # 042a_core_model_views.sql - References non-existent last_accessed column
-          # 20250924120000_create_views_view_states.ts - View states migration with schema issues
+          # Re-enabled per #4162 (2026-07-13): 20250924120000_create_views_view_states.ts and the three
+          # snapshot-cluster migrations (20251117000001_add_snapshot_labels, 20251117000002_create_protection_rules,
+          # 20251201000001_create_change_management_tables) now RUN here. Their old per-item exclusion reasons were
+          # re-tested and are stale (same class as the 20250925 one #3627 fixed): fresh-DB migrate, second-pass
+          # replay, and the snapshot-protection E2E (21/21) all pass with them applied.
           # 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
           # 20250925_create_view_tables.sql - legacy owner_id FK assumes pre-text user ids during replay.
           #   NOTE: this exact bug was fixed by #3627, and migration-replay.yml already dropped
           #   this exclusion in #3632 (verified passing there); this workflow was never
           #   re-verified/updated to match, so this exclusion may now be stale rather than still
           #   required — needs re-verification before removal, not a piecemeal drop (see #4162).
-          # 20251117000001_add_snapshot_labels.ts - re-applies chk_protection_level after earlier snapshot schema creation during replay
-          # 20251117000002_create_protection_rules.ts - re-creates protection_rules after replay paths already created the table
-          # 20251201000001_create_change_management_tables.ts - legacy snapshot_id text FKs no longer match replay-built uuid snapshot ids
           # zzzz20260114110000_create_user_orgs_table.ts - replay paths hit legacy user_orgs is_active reference incompatibility.
           #   NOTE: plugin-tests.yml intentionally does NOT exclude this one — attendance
           #   auto-absence depends on the user_orgs table in that job (see b1fc1e19d1).
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm -F @metasheet/core-backend db:list || true
           pnpm -F @metasheet/core-backend db:migrate

--- a/.github/workflows/safety-guard-e2e.yml
+++ b/.github/workflows/safety-guard-e2e.yml
@@ -71,9 +71,11 @@ jobs:
           # (no-ops a migration's body but keeps its name; this drops name+body entirely). See
           # packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md and
           # docs/development/superseded-legacy-migrations-gap-audit-20260710.md for the full
-          # cross-list picture. Known asymmetry: production/on-prem db:migrate runs with no
-          # exclude at all, so the view-table cluster excluded below has never had a per-PR
-          # green CI run of its up() bodies — untangling that is gated planning work, #4162.
+          # cross-list picture. #4162 follow-up (2026-07-13): the views/view_states migration
+          # and the three snapshot-cluster migrations are re-enabled below (in all five
+          # workflow lists at once), so their up() bodies now DO get per-PR green CI runs.
+          # Remaining asymmetry: production/on-prem db:migrate runs with no exclude at all,
+          # so the STILL-excluded items (008/048/049, 042a, gantt, 20250925) keep that gap.
           # Exclude problematic migrations (see migration-replay.yml for the per-item detail
           # this workflow shares):
           # 008_plugin_infrastructure.sql - has idempotency issue with scope column

--- a/packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
+++ b/packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
@@ -4,12 +4,33 @@
 
 This document tracks database migrations that are currently excluded from automated replay testing. These migrations require manual review and fixing before they can be re-enabled.
 
-**Current Exclude Count**: 11 files
+**Current Exclude Count**: 7 files (union across occurrences)
 
-**Default Exclude in CI**: `008_plugin_infrastructure.sql, 048_create_event_bus_tables.sql, 049_create_bpmn_workflow_tables.sql, 042a_core_model_views.sql, 20250924120000_create_views_view_states.ts, 20250924140000_create_gantt_tables.ts, 20250925_create_view_tables.sql, 20251117000001_add_snapshot_labels.ts, 20251117000002_create_protection_rules.ts, 20251201000001_create_change_management_tables.ts, zzzz20260114110000_create_user_orgs_table.ts`
+**Default Exclude in CI**: `008_plugin_infrastructure.sql, 048_create_event_bus_tables.sql, 049_create_bpmn_workflow_tables.sql, 042a_core_model_views.sql, 20250924140000_create_gantt_tables.ts, 20250925_create_view_tables.sql, zzzz20260114110000_create_user_orgs_table.ts`
 
-**Last Updated**: 2026-05-12 (T8 docs-only pass 2026-07-12 added the cross-list context below without
-changing any exclude value)
+**Last Updated**: 2026-07-13 (#4162 follow-up — see the re-enable section below; T8 docs-only pass
+2026-07-12 added the cross-list context without changing any exclude value)
+
+---
+
+## #4162 follow-up (2026-07-13): 4 items RE-ENABLED across all five workflow lists
+
+`20250924120000_create_views_view_states.ts`, `20251117000001_add_snapshot_labels.ts`,
+`20251117000002_create_protection_rules.ts`, and `20251201000001_create_change_management_tables.ts`
+were removed from **every** `MIGRATION_EXCLUDE` occurrence at once (plugin-tests.yml ×2,
+observability-e2e.yml, observability-strict.yml, safety-guard-e2e.yml, migration-replay.yml ×2) —
+deliberately all-lists-at-once, to avoid recreating the #3627→#3632 single-file-sync drift this doc
+records for `20250925_create_view_tables.sql`.
+
+Why: `snapshot-protection.test.ts` (the GHSA-h8mf "Snapshot Protection System E2E") needs
+`snapshots.tags`, `protection_rules`, and the change-management tables — and `SnapshotService` also
+queries `views` / `view_states` — so a CI test-DB without these migrations cannot run that suite at
+all (it failed with `column "tags" of relation "snapshots" does not exist` when first wired in
+PR #4218). The old per-item exclusion reasons were re-tested and found stale — the same class of
+staleness as the `20250925` row below. Proof carried by the re-enable PR: fresh-DB full migrate,
+second-pass replay (idempotency), upgrade path (old-list DB → new-list migrate), the 5 target
+tables/columns present, `snapshot-protection.test.ts` 21/21, and Node 18.x/20.x real-DB CI jobs
+green with the new lists.
 
 ---
 
@@ -40,13 +61,14 @@ guessed):
 
 | Item | Present in | Absent from | Why |
 |---|---|---|---|
-| `20250925_create_view_tables.sql` | plugin-tests.yml (both jobs), observability-strict/e2e.yml, safety-guard-e2e.yml | migration-replay.yml | The owner_id FK bug this item guards against was fixed by #3627; migration-replay.yml dropped the exclusion in #3632 (verified passing). The other 4 occurrences were never re-verified/updated to match — **possibly stale**, not resolved here. Re-enabling for the full view-table cluster (so `snapshot-protection.test.ts` can run in CI) is gated planning work: **#4162**. |
+| `20250925_create_view_tables.sql` | plugin-tests.yml (both jobs), observability-strict/e2e.yml, safety-guard-e2e.yml | migration-replay.yml | The owner_id FK bug this item guards against was fixed by #3627; migration-replay.yml dropped the exclusion in #3632 (verified passing). The other 4 occurrences were never re-verified/updated to match — **possibly stale**, not resolved here (still open for `20250925` specifically). The snapshot-protection-blocking part of #4162 was executed 2026-07-13 (see the re-enable section above); `20250925` itself remains excluded outside migration-replay.yml. |
 | `zzzz20260114110000_create_user_orgs_table.ts` | observability-strict/e2e.yml, safety-guard-e2e.yml, migration-replay.yml | plugin-tests.yml (both jobs) | Removed from plugin-tests.yml's `test` job in commit `b1fc1e19d1` ("ci(attendance): run integration gate against postgres") because attendance auto-absence needs the `user_orgs` table applied in that job. The **same commit** also removed it from the `after-sales-integration` job in the same file, which does not obviously touch attendance/user_orgs — that second removal may be an unverified side-effect of a file-wide edit rather than a deliberate per-job decision. Flagged, not resolved here. |
 
 **Known asymmetry this doc does not close**: production and on-prem `db:migrate` runs use **no**
 `MIGRATION_EXCLUDE` at all — every migration listed above runs in a real deploy. Only CI's per-PR
-gate trims the list, which means the view-table/gantt/snapshot/protection-rule/change-management
-cluster has never had a per-PR green CI run of its `up()` bodies. See #4162.
+gate trims the list. **Since the 2026-07-13 #4162 follow-up, the views/view_states + snapshot/
+protection-rule/change-management migrations DO get per-PR green CI runs**; the asymmetry now
+covers only the still-excluded remainder (008/048/049, 042a, gantt, 20250925).
 
 **Guard**: `scripts/ci/validate-migration-exclude.sh` cross-checks all of the above for
 undocumented drift (warn-only; see that script's header for what it covers and does not cover).

--- a/packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
+++ b/packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
@@ -48,7 +48,7 @@ workflows/jobs that depend on each one's specific shape. Full detail:
    marker) so CI's schema-build order can succeed despite that migration's known conflicts.
 2. **`migration-replay.yml`'s own `MIGRATION_EXCLUDE` subset** — a narrower, independently
    evolving list for a different job (run `db:migrate` twice against a fresh db, assert
-   idempotency). It is not the same 11 items as #1 today.
+   idempotency). Its list is not identical to #1's (7-item union as of 2026-07-13) today.
 3. **`SUPERSEDED_LEGACY_SQL_MIGRATIONS`** in `packages/core-backend/src/db/migration-provider.ts`
    — a disjoint-purpose list of ~29 legacy numeric SQL migrations turned into no-op history
    markers (name stays, body doesn't run) rather than dropped. Overlaps #1 on exactly three
@@ -77,8 +77,8 @@ undocumented drift (warn-only; see that script's header for what it covers and d
 
 ## Pre-2026-07-12 content below is a historical snapshot
 
-The "Current CI Exclusions" section right below is still an accurate reflection of the workflow
-files as of 2026-05-12. Everything under **Pre-Existing Issues / Phase 2 Additions / Fix Strategy
+The "Current CI Exclusions" section right below reflected the workflow files as of 2026-05-12;
+the four items marked RE-ENABLED were removed from all lists on 2026-07-13 (#4162, see above). Everything under **Pre-Existing Issues / Phase 2 Additions / Fix Strategy
 / History** further down, however, refers to migration **filenames that no longer exist** in this
 repo (`008_add_indexes_to_workflows.sql`, `031_add_approval_templates.sql`,
 `036_add_workflow_execution_logs.sql`, `037_add_notification_preferences.sql`,
@@ -103,7 +103,7 @@ without re-reading that design doc first.
 **Issue**: References non-existent `last_accessed` column during replay paths.
 
 #### `20250924120000_create_views_view_states.ts`
-**Status**: ❌ Excluded
+**Status**: ✅ RE-ENABLED 2026-07-13 (#4162 follow-up — see section above)
 **Issue**: Creates view-state foreign keys against pre-fix `text` view ids, which fails once replay paths rebuild the newer UUID-based schema.
 
 #### `20250924140000_create_gantt_tables.ts`
@@ -115,15 +115,15 @@ without re-reading that design doc first.
 **Issue**: Applies `tables_owner_id_fkey` against a legacy `owner_id` shape that no longer exists in replay-built schemas, causing `owner_id` foreign-key failures.
 
 #### `20251117000001_add_snapshot_labels.ts`
-**Status**: ❌ Excluded
+**Status**: ✅ RE-ENABLED 2026-07-13 (#4162 follow-up — see section above)
 **Issue**: Re-applies the `chk_protection_level` constraint after replay paths have already created the newer snapshot schema, causing duplicate-constraint failures on `snapshots`.
 
 #### `20251117000002_create_protection_rules.ts`
-**Status**: ❌ Excluded
+**Status**: ✅ RE-ENABLED 2026-07-13 (#4162 follow-up — see section above)
 **Issue**: Re-creates the `protection_rules` table after replay paths have already applied the legacy protection-rule schema, causing duplicate-table failures.
 
 #### `20251201000001_create_change_management_tables.ts`
-**Status**: ❌ Excluded
+**Status**: ✅ RE-ENABLED 2026-07-13 (#4162 follow-up — see section above)
 **Issue**: Applies `snapshot_id` foreign keys against the newer `uuid snapshots.id` while replay paths still rebuild legacy `text` snapshot references, causing incompatible-FK failures.
 
 #### `zzzz20260114110000_create_user_orgs_table.ts`

--- a/packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
+++ b/packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
@@ -28,7 +28,10 @@ queries `views` / `view_states` — so a CI test-DB without these migrations can
 all (it failed with `column "tags" of relation "snapshots" does not exist` when first wired in
 PR #4218). The old per-item exclusion reasons were re-tested and found stale — the same class of
 staleness as the `20250925` row below. Proof carried by the re-enable PR: fresh-DB full migrate,
-second-pass replay (idempotency), upgrade path (old-list DB → new-list migrate), the 5 target
+second-pass **tracked-skip replay** (a second `migrateToLatest()` skips already-applied items via
+the migration history — it does NOT re-run the four `up()` bodies), a **separate upgrade proof**
+(old-list DB → new-list migrate, which is what actually re-executes the newly-enabled `up()`
+bodies on an existing schema), the 5 target
 tables/columns present, `snapshot-protection.test.ts` 21/21, and Node 18.x/20.x real-DB CI jobs
 green with the new lists.
 
@@ -47,8 +50,9 @@ workflows/jobs that depend on each one's specific shape. Full detail:
    `observability-e2e.yml`, `safety-guard-e2e.yml`. Drops a migration entirely (no history
    marker) so CI's schema-build order can succeed despite that migration's known conflicts.
 2. **`migration-replay.yml`'s own `MIGRATION_EXCLUDE` subset** — a narrower, independently
-   evolving list for a different job (run `db:migrate` twice against a fresh db, assert
-   idempotency). Its list is not identical to #1's (7-item union as of 2026-07-13) today.
+   evolving list for a different job (run `db:migrate` twice against a fresh db, assert the
+   second pass is a clean tracked-skip replay). Its list is not identical to #1's (7-item
+   union as of 2026-07-13) today.
 3. **`SUPERSEDED_LEGACY_SQL_MIGRATIONS`** in `packages/core-backend/src/db/migration-provider.ts`
    — a disjoint-purpose list of ~29 legacy numeric SQL migrations turned into no-op history
    markers (name stays, body doesn't run) rather than dropped. Overlaps #1 on exactly three
@@ -56,7 +60,7 @@ workflows/jobs that depend on each one's specific shape. Full detail:
    `049_create_bpmn_workflow_tables`) — confirmed intentional/harmless double-listing by the
    2026-07-10 audit.
 
-**Known, verified divergences between the 6 occurrences of #1/#2** (git-blame-checked, not
+**Known, verified divergences between the 7 occurrences of #1/#2** (git-blame-checked, not
 guessed):
 
 | Item | Present in | Absent from | Why |

--- a/scripts/ci/__fixtures__/migration-exclude/drift/workflows/migration-replay.yml
+++ b/scripts/ci/__fixtures__/migration-exclude/drift/workflows/migration-replay.yml
@@ -8,5 +8,5 @@ jobs:
           # 20250925_create_view_tables.sql intentionally absent here - fixed by #3627/#3632.
           # 042a_core_model_views.sql ALSO undocumented-ly dropped here (no reason given) - this
           # is the drift this fixture exists to trigger.
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,20250924140000_create_gantt_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
         run: echo fixture

--- a/scripts/ci/__fixtures__/migration-exclude/drift/workflows/observability-strict.yml
+++ b/scripts/ci/__fixtures__/migration-exclude/drift/workflows/observability-strict.yml
@@ -5,5 +5,5 @@ jobs:
       - name: Run DB migrations
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/metasheet
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts,999_bogus_undocumented_migration.sql
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,zzzz20260114110000_create_user_orgs_table.ts,999_bogus_undocumented_migration.sql
         run: echo fixture

--- a/scripts/ci/__fixtures__/migration-exclude/drift/workflows/plugin-tests.yml
+++ b/scripts/ci/__fixtures__/migration-exclude/drift/workflows/plugin-tests.yml
@@ -7,5 +7,5 @@ jobs:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
           # zzzz20260114110000_create_user_orgs_table.ts intentionally absent here - attendance
           # needs the user_orgs table applied in this job (see b1fc1e19d1).
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
         run: echo fixture

--- a/scripts/ci/__fixtures__/migration-exclude/good/workflows/migration-replay.yml
+++ b/scripts/ci/__fixtures__/migration-exclude/good/workflows/migration-replay.yml
@@ -6,5 +6,5 @@ jobs:
         env:
           DATABASE_URL: postgresql://127.0.0.1/metasheet
           # 20250925_create_view_tables.sql intentionally absent here - fixed by #3627/#3632.
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
         run: echo fixture

--- a/scripts/ci/__fixtures__/migration-exclude/good/workflows/observability-strict.yml
+++ b/scripts/ci/__fixtures__/migration-exclude/good/workflows/observability-strict.yml
@@ -5,5 +5,5 @@ jobs:
       - name: Run DB migrations
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/metasheet
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
         run: echo fixture

--- a/scripts/ci/__fixtures__/migration-exclude/good/workflows/plugin-tests.yml
+++ b/scripts/ci/__fixtures__/migration-exclude/good/workflows/plugin-tests.yml
@@ -7,5 +7,5 @@ jobs:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
           # zzzz20260114110000_create_user_orgs_table.ts intentionally absent here - attendance
           # needs the user_orgs table applied in this job (see b1fc1e19d1).
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
         run: echo fixture

--- a/scripts/ci/__tests__/validate-migration-exclude.test.sh
+++ b/scripts/ci/__tests__/validate-migration-exclude.test.sh
@@ -23,7 +23,10 @@ run_against() {
   (
     WORKFLOWS_DIR="$FIX/$subdir/workflows"
     PROVIDER_FILE="$FIX/$subdir/provider.ts"
-    export WORKFLOWS_DIR PROVIDER_FILE
+    # Fixture shape: 3 occurrence lines across 3 files (the guard's real-repo pin is 7/5).
+    EXPECTED_OCCURRENCE_COUNT=3
+    EXPECTED_FILE_COUNT=3
+    export WORKFLOWS_DIR PROVIDER_FILE EXPECTED_OCCURRENCE_COUNT EXPECTED_FILE_COUNT
     # shellcheck source=../validate-migration-exclude.sh
     source "$GUARD"
     run_checks

--- a/scripts/ci/validate-migration-exclude.sh
+++ b/scripts/ci/validate-migration-exclude.sh
@@ -23,7 +23,7 @@
 # (a single env var, as inherited by this process) contained 3 hardcoded filenames. It now
 # reads the actual workflow files and migration-provider.ts directly and checks:
 #   A. every item in every CI-gate/replay MIGRATION_EXCLUDE occurrence against the full known
-#      baseline (11 items, not 3) — anything extra is reported as a possibly-undocumented new
+#      baseline (7 items since the 2026-07-13 #4162 re-enable; was 11, originally 3) — anything extra is reported as a possibly-undocumented new
 #      exclusion;
 #   B. every occurrence-to-occurrence divergence within those six occurrences against a table
 #      of KNOWN, already-reviewed divergences (see MIGRATION_EXCLUDE_TRACKING.md) — anything

--- a/scripts/ci/validate-migration-exclude.sh
+++ b/scripts/ci/validate-migration-exclude.sh
@@ -48,17 +48,18 @@ WORKFLOWS_DIR="${WORKFLOWS_DIR:-$REPO_ROOT/.github/workflows}"
 PROVIDER_FILE="${PROVIDER_FILE:-$REPO_ROOT/packages/core-backend/src/db/migration-provider.ts}"
 
 # Known baseline: the union of every item that has appeared, with review, in any CI
-# per-PR-gate / migration-replay MIGRATION_EXCLUDE occurrence as of 2026-07-12.
+# per-PR-gate / migration-replay MIGRATION_EXCLUDE occurrence as of 2026-07-13.
+# (#4162 follow-up, 2026-07-13: 20250924120000_create_views_view_states.ts and the three
+# snapshot-cluster migrations — 20251117000001_add_snapshot_labels.ts,
+# 20251117000002_create_protection_rules.ts, 20251201000001_create_change_management_tables.ts —
+# were RE-ENABLED across all five workflow lists at once and removed from this baseline; if one
+# of them reappears in a list, this guard now reports it as a possibly-undocumented NEW exclusion.)
 KNOWN_BASELINE_ITEMS='008_plugin_infrastructure.sql
 048_create_event_bus_tables.sql
 049_create_bpmn_workflow_tables.sql
 042a_core_model_views.sql
-20250924120000_create_views_view_states.ts
 20250924140000_create_gantt_tables.ts
 20250925_create_view_tables.sql
-20251117000001_add_snapshot_labels.ts
-20251117000002_create_protection_rules.ts
-20251201000001_create_change_management_tables.ts
 zzzz20260114110000_create_user_orgs_table.ts'
 
 # Known, reviewed occurrence-to-occurrence divergences: "<item>|<workflow-file-basename that
@@ -282,10 +283,11 @@ $stripped"
 
   # --- Always-on informational note: the asymmetry this guard does not, and cannot, close --
   info "Known asymmetry (not a bug this guard can catch): production/on-prem 'db:migrate' runs"
-  info "with NO MIGRATION_EXCLUDE at all. Only CI's per-PR gate trims the list above, so the"
-  info "view-table/gantt/snapshot/protection-rule/change-management cluster excluded there has"
-  info "never had a per-PR green CI run of its up() bodies. Re-enabling that cluster in CI is"
-  info "gated planning work — see #4162. Do not close that gap by editing this script."
+  info "with NO MIGRATION_EXCLUDE at all. Only CI's per-PR gate trims the list above. #4162"
+  info "follow-up (2026-07-13): views/view_states + the snapshot/protection-rule/change-management"
+  info "migrations are re-enabled in CI and now DO get per-PR green runs; the still-excluded"
+  info "remainder (008/048/049, 042a, gantt, 20250925) keeps this gap. Do not close it by"
+  info "editing this script."
 }
 
 # main() is the only thing in this file that calls exit. It is intentionally NOT wired into any

--- a/scripts/ci/validate-migration-exclude.sh
+++ b/scripts/ci/validate-migration-exclude.sh
@@ -25,7 +25,8 @@
 #   A. every item in every CI-gate/replay MIGRATION_EXCLUDE occurrence against the full known
 #      baseline (7 items since the 2026-07-13 #4162 re-enable; was 11, originally 3) — anything extra is reported as a possibly-undocumented new
 #      exclusion;
-#   B. every occurrence-to-occurrence divergence within those six occurrences against a table
+#   B. every occurrence-to-occurrence divergence within those seven occurrences (5 files:
+#      plugin-tests x2, migration-replay x2, observability-e2e/strict, safety-guard-e2e) against a table
 #      of KNOWN, already-reviewed divergences (see MIGRATION_EXCLUDE_TRACKING.md) — anything
 #      not in that table is reported as new/undocumented drift;
 #   C. the overlap between MIGRATION_EXCLUDE and SUPERSEDED_LEGACY_SQL_MIGRATIONS against the
@@ -169,8 +170,16 @@ run_checks() {
   local occurrences
   occurrences="$(collect_occurrences)"
 
-  if [[ -z "$occurrences" ]]; then
-    warn "No MIGRATION_EXCLUDE occurrences found under $WORKFLOWS_DIR — expected at least 6."
+  # Exact shape pin (2026-07-13, #4228 review): 7 occurrences across 5 files in the real repo
+  # (plugin-tests x2, migration-replay x2, observability-e2e, observability-strict,
+  # safety-guard-e2e). Env-overridable so the fixture tests can pin their own shape.
+  local expected_occ expected_files occ_count file_count
+  expected_occ="${EXPECTED_OCCURRENCE_COUNT:-7}"
+  expected_files="${EXPECTED_FILE_COUNT:-5}"
+  occ_count="$(printf '%s\n' "$occurrences" | sed '/^$/d' | wc -l | tr -d ' ')"
+  file_count="$(printf '%s\n' "$occurrences" | sed '/^$/d' | cut -d: -f1 | sort -u | wc -l | tr -d ' ')"
+  if [[ "$occ_count" -ne "$expected_occ" || "$file_count" -ne "$expected_files" ]]; then
+    warn "Expected exactly $expected_occ MIGRATION_EXCLUDE occurrences across $expected_files workflow files; found $occ_count across $file_count — a new/removed occurrence must be reviewed and this pin updated."
   fi
 
   # --- A: every item in every occurrence must be a known baseline item ------------------


### PR DESCRIPTION
## Re-enable views/view_states + snapshot-cluster migrations in all 5 CI exclude lists (#4162)

Prerequisite PR for the snapshot-protection CI wiring (#4218), per owner ruling (option 2, expanded scope): the scope is **not** just the 3 snapshot migrations — after fixing `tags`, `SnapshotService` also queries `views`/`view_states`, which the CI test-DB equally lacked.

**Change:** remove `20250924120000_create_views_view_states.ts`, `20251117000001_add_snapshot_labels.ts`, `20251117000002_create_protection_rules.ts`, `20251201000001_create_change_management_tables.ts` from **every** `MIGRATION_EXCLUDE` occurrence at once — `plugin-tests.yml` (×2), `observability-e2e.yml`, `observability-strict.yml`, `safety-guard-e2e.yml`, `migration-replay.yml` (×2) — deliberately all-lists-at-once to avoid recreating the #3627→#3632 single-file-sync drift. Stale per-item comment blocks replaced; `scripts/ci/validate-migration-exclude.sh` baseline 11→7 **with an exact 7-occurrences/5-files shape pin** (env-overridable for fixtures); its good/drift fixtures updated (guard regression test PASS); `MIGRATION_EXCLUDE_TRACKING.md` updated. Still excluded everywhere: 008/048/049, 042a, gantt (+ 20250925 outside migration-replay).

**Owner-required proofs (wording per review — replay ≠ idempotent re-run):**
| Proof | Result |
|---|---|
| Fresh-DB full migrate (exact new plugin-tests list) | ✅ exit 0; `views`, `view_states`, `snapshots.tags`, `protection_rules`, change-management tables all present |
| Fresh-DB full migrate (**strictest** surface: observability/safety-guard 7-item list, excluding both `20250925` and `zzzz_user_orgs`) | ✅ exit 0; same objects present — the 4 re-enabled migrations depend on neither still-excluded item |
| **Upgrade proof** (old-list DB → new-list migrate; this is what actually executes the 4 newly-enabled `up()` bodies on an existing schema) | ✅ exit 0; objects appear |
| **Tracked-skip replay** (second `migrateToLatest()` — skips applied items via migration history; NOT a re-run of the `up()` bodies) | ✅ exit 0 on both surfaces — same semantics migration-replay.yml's own job asserts |
| views/view_states + 3 snapshot migrations complete | ✅ verified via information_schema post-migrate |
| `snapshot-protection.test.ts` | ✅ **21/21** against the fresh new-list DB |
| Node 18.x / 20.x real-DB jobs + observability ×2 (strict via `v2-strict` label) + safety-guard + migration-replay | this PR's exact-head CI |

**Adversarial gate (2 Opus lanes):** blast-radius APPROVE; consistency findings (guard fixture regression, stale counts, unaligned comments) all fixed in follow-up commits.

After this merges: rebase #4218 (pure CI wiring, currently disarmed), update its verification note, run green, arm.

Refs #4162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
