### PR TITLE
fix(ops): DT-CLOSE-01 authenticate OAuth-stability /metrics/prom scrape (unblock monitoring)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -77,6 +77,10 @@ jobs:
             scripts/ops/onprem-windows-system-hardening.test.mjs \
             scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
 
+      - name: Run DingTalk OAuth-stability metrics-auth contract test (DT-CLOSE-01)
+        run: |
+          node --test scripts/ops/dingtalk-oauth-stability-metrics-auth-contract.test.mjs
+
   test:
     runs-on: ubuntu-latest
 

--- a/scripts/ops/dingtalk-oauth-stability-check.sh
+++ b/scripts/ops/dingtalk-oauth-stability-check.sh
@@ -8,14 +8,45 @@ SSH_KEY="${SSH_KEY:-${HOME}/.ssh/metasheet2_deploy}"
 JSON_OUTPUT="${JSON_OUTPUT:-false}"
 LOG_WINDOW="${LOG_WINDOW:-24h}"
 MAX_ROOT_USE_PERCENT="${MAX_ROOT_USE_PERCENT:-95}"
+# DT-CLOSE-01: /metrics/prom now requires METRICS_SCRAPE_TOKEN (metrics.ts createMetricsAuthMiddleware),
+# so an unauthenticated scrape 401s and the whole OAuth-stability recording goes blind. Resolve the
+# token on the deploy host itself (same source of truth as scripts/ops/resolve-metrics-scrape-token.sh:
+# the backend container's runtime env) and attach it as the x-metrics-token header IN THE SAME remote
+# shell — the secret never transits the CI runner, this script's env, or a runner-side process arg list.
+# Falls back to an unauthenticated scrape only when the backend has no token configured (auth disabled).
+DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
+DEPLOY_COMPOSE_FILE="${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}"
 
 ssh_cmd() {
   ssh -i "${SSH_KEY}" -o BatchMode=yes -o StrictHostKeyChecking=no "${SSH_USER_HOST}" "$@"
 }
 
+# Scrape a token-gated endpoint on the deploy host. The token is read from the backend container's
+# runtime env on the remote and used within the same remote shell (never printed, never returned to
+# the runner). Args: <url>. Any remaining args after the url are appended to curl verbatim.
+remote_authed_curl() {
+  local url="$1"; shift || true
+  ssh_cmd "DEPLOY_PATH=$(printf '%q' "${DEPLOY_PATH}") DEPLOY_COMPOSE_FILE=$(printf '%q' "${DEPLOY_COMPOSE_FILE}") URL=$(printf '%q' "${url}") bash -s" <<'REMOTE'
+set -euo pipefail
+if [ "${DEPLOY_PATH}" != "${DEPLOY_PATH#/}" ]; then repo="${DEPLOY_PATH}"; else repo="${HOME}/${DEPLOY_PATH}"; fi
+compose=(docker compose)
+docker compose version >/dev/null 2>&1 || compose=(docker-compose)
+token=""
+if [ -d "${repo}" ]; then
+  token="$(cd "${repo}" && "${compose[@]}" -f "${DEPLOY_COMPOSE_FILE}" exec -T backend sh -lc 'printf "%s" "${METRICS_SCRAPE_TOKEN:-}"' </dev/null 2>/dev/null || true)"
+fi
+if [ -n "${token}" ]; then
+  curl -fsS -H "x-metrics-token: ${token}" "${URL}"
+else
+  # No token configured on the backend => metrics auth is disabled; an unauthenticated scrape is correct.
+  curl -fsS "${URL}"
+fi
+REMOTE
+}
+
 WEBHOOK_STATUS="$(bash "${ROOT_DIR}/scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh" --print-status)"
 HEALTH_JSON="$(ssh_cmd "curl -fsS http://127.0.0.1:8900/health")"
-METRICS_TEXT="$(ssh_cmd "curl -fsS http://127.0.0.1:8900/metrics/prom")"
+METRICS_TEXT="$(remote_authed_curl "http://127.0.0.1:8900/metrics/prom")"
 ALERTMANAGER_STATUS_JSON="$(ssh_cmd "curl -fsS http://127.0.0.1:9093/api/v2/status")"
 ALERTS_JSON="$(ssh_cmd "curl -fsS http://127.0.0.1:9093/api/v2/alerts")"
 ALERTMANAGER_ERROR_COUNT="$(ssh_cmd "docker logs --since ${LOG_WINDOW} metasheet-alertmanager 2>&1 | grep -E 'Notify for alerts failed|no_text' | wc -l | tr -d ' '")"

--- a/scripts/ops/dingtalk-oauth-stability-metrics-auth-contract.test.mjs
+++ b/scripts/ops/dingtalk-oauth-stability-metrics-auth-contract.test.mjs
@@ -1,0 +1,62 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// DT-CLOSE-01 contract guard. `/metrics/prom` is token-gated (metrics.ts
+// createMetricsAuthMiddleware requires METRICS_SCRAPE_TOKEN), so the OAuth-stability
+// recording must scrape it WITH the token or go blind on HTTP 401. This test pins the
+// authenticated-scrape shape so that removing the auth (the exact regression that broke
+// the recording) turns this test red — a load-bearing mutation guard, not decoration.
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const script = readFileSync(join(__dirname, 'dingtalk-oauth-stability-check.sh'), 'utf8')
+
+test('the /metrics/prom scrape goes through the authed helper, not a bare unauthenticated curl', () => {
+  // The metrics scrape must use the token-resolving helper.
+  assert.match(
+    script,
+    /METRICS_TEXT="\$\(remote_authed_curl "http:\/\/127\.0\.0\.1:8900\/metrics\/prom"\)"/,
+    'metrics scrape must call remote_authed_curl (regression: a bare ssh_cmd curl 401s)',
+  )
+  // And it must NOT be the old unauthenticated form.
+  assert.doesNotMatch(
+    script,
+    /METRICS_TEXT="\$\(ssh_cmd "curl -fsS http:\/\/127\.0\.0\.1:8900\/metrics\/prom"\)"/,
+    'metrics scrape must not revert to the unauthenticated ssh_cmd curl',
+  )
+})
+
+test('the authed helper attaches the x-metrics-token header from the backend runtime token', () => {
+  assert.match(script, /remote_authed_curl\(\)/, 'remote_authed_curl helper must exist')
+  // Token is read from the backend container runtime env (same source as resolve-metrics-scrape-token.sh).
+  assert.match(
+    script,
+    /exec -T backend sh -lc 'printf "%s" "\$\{METRICS_SCRAPE_TOKEN:-\}"'/,
+    'token must be read from the backend container runtime METRICS_SCRAPE_TOKEN',
+  )
+  // The header must be applied when a token exists.
+  assert.match(
+    script,
+    /curl -fsS -H "x-metrics-token: \$\{token\}" "\$\{URL\}"/,
+    'a resolved token must be sent as the x-metrics-token header',
+  )
+})
+
+test('secret-safe: the token is resolved on the remote and never printed or echoed', () => {
+  // The token is only ever used inside the remote heredoc; it must not be echoed anywhere.
+  assert.doesNotMatch(script, /echo[^\n]*\$\{?token\}?/i, 'token must never be echoed')
+  assert.doesNotMatch(script, /printf[^\n]*token[^\n]*>&2/i, 'token must never be printed to stderr')
+  // The remote heredoc quoting must be single-quoted so the token stays remote (not interpolated
+  // by the runner-side shell into the ssh argv).
+  assert.match(script, /bash -s" <<'REMOTE'/, 'remote token resolution must run in a quoted heredoc (token stays on the host)')
+})
+
+test('unauthenticated fallback only when the backend has no token (auth disabled)', () => {
+  assert.match(
+    script,
+    /else\s*\n\s*# No token configured on the backend[^\n]*\n\s*curl -fsS "\$\{URL\}"/,
+    'the bare curl must be reachable ONLY in the no-token branch',
+  )
+})


### PR DESCRIPTION
## DT-CLOSE-01 — authenticate the OAuth-stability `/metrics/prom` scrape (unblock monitoring)

**BLOCKER fix.** The OAuth-stability recording went blind: `dingtalk-oauth-stability-check.sh:18` scraped `/metrics/prom` **unauthenticated**, but `/metrics/prom` is token-gated (`metrics.ts` `createMetricsAuthMiddleware` requires `METRICS_SCRAPE_TOKEN`) → HTTP 401 → the last ~100 records failed. **DingTalk OAuth is not broken — the monitor could no longer see it.**

**Fix (reuses the existing token-resolution mechanism, secret-safe):** the token is resolved **on the deploy host** — from the backend container's runtime env, the same source as `resolve-metrics-scrape-token.sh` — inside one remote heredoc, and attached as the `x-metrics-token` header there. The secret never transits the CI runner, this script's env, or a runner-side process-arg list. Unauthenticated fallback only when the backend has no token (auth disabled).

**Verification:**
- `bash -n` clean; contract test **4/4** (`dingtalk-oauth-stability-metrics-auth-contract.test.mjs`).
- **Auth-mutation reddens** (the owner's gate): reverting the metrics line to the bare unauthenticated `ssh_cmd curl` → the contract test fails. Wired into plugin-tests.yml so it's CI-gated.
- Secret-safe assertions: token never echoed/printed; resolved inside a single-quoted remote heredoc.

**Remaining (ops):** the "immediate run + next scheduled run consecutive success" gate needs the live deploy host + secrets — that is the ops verification step (this PR makes the script correct + guards the regression).
