### PR TITLE
fix(attendance): confirm override-import modal in prod/full verify flows (#189 Gate-4 timeout)

### DIFF
--- a/docs/development/attendance-189-prod-flow-import-override-modal-fix-20260713.md
+++ b/docs/development/attendance-189-prod-flow-import-override-modal-fix-20260713.md
@@ -1,0 +1,58 @@
+# #189 Strict-Gate Gate-4 (Playwright Prod) timeout — diagnosis + fix (2026-07-13)
+
+> **Status: fix landed in verify tooling; Gate-4 root cause = a verify-script gap, NOT a deploy/auth issue.**
+> Fixes the 8-consecutive strict-gate failures where Gate 4 (Playwright Prod) timed out 60s at the import commit.
+
+## 1. Symptom
+`#189` strict gate: **Gate 4 (Playwright Prod) = FAIL**, all others (API smoke, provisioning, desktop, mobile) PASS.
+Exact error (`gate-playwright-production-flow.log`): `page.waitForResponse: Timeout 60000ms exceeded while waiting for
+event "response"` at `clickImportAndWaitForCommitResponse (verify-attendance-production-flow.mjs:329)`. Flow log:
+`17 Preview import / 18 Preview API ok: items=1 / 19 Commit import / 20 Failed: waitForResponse timeout`.
+
+## 2. Hypotheses ruled out (with evidence)
+- **NOT auth.** The stale CI-secret token failed, but the workflow's deploy-host fallback minted a fresh valid
+  token (AUTH_SOURCE=token, HTTP 200); the SAME token/API_BASE was reused by all gates and 4/5 downstream gates
+  (incl. admin-only) PASSED with it → token conclusively valid.
+- **NOT stale/unhealthy deploy.** Prod runs `f0ce863ea` (#4218), only **1 commit behind main**, 41 ahead of #4096;
+  deploy pipeline healthy (7/8 recent deploys success, host 35.8 GB free / 52%). Same import flow, same target.
+- **NOT the old advanced-panel bug** (#4096 fixed that; the script already expands the panel — screenshot
+  `04-import-preview.png` shows the Import button rendered, enabled, clickable).
+- **NOT an env/target difference.** `attendance-strict-gates-prod.yml` has no local build; Gates 4/5/6 all hit the
+  same deployed target. The asymmetry is a **script coverage difference** (below).
+
+## 3. Root cause
+The app added a **"确认覆盖导入" (Confirm override import) modal** as a safety guard (AttendanceView §2/§4
+design-lock). `requestRunImport()` (`AttendanceView.vue:19585`) does **not** commit directly when the import mode
+requires confirmation — it opens the modal (`[data-import-override-confirm]`); the commit POST fires only after the
+acknowledgement checkbox is checked and **确认** (`[data-import-override-confirm-submit]`, disabled until checked) is
+clicked (`importOverrideConfirm.onConfirm → runImport()`).
+
+The prod-flow verify script clicks "Import" and immediately `waitForResponse` for `/api/attendance/import/commit`
+(or legacy `/api/attendance/import`) — but the modal intercepts, **no POST ever fires**, so it hits the full 60s
+timeout. Only **Gate 4** exercises the live UI commit: the API smoke commits via direct API (no modal, `elapsedMs=83`),
+and desktop/mobile don't drive the real commit (their commit-click path is gated off by `REQUIRE_IMPORT_JOB_RECOVERY=false`).
+→ The backend is fine; the verify script never learned to confirm the modal.
+
+## 4. Fix (verify tooling only — no product runtime change)
+- `scripts/verify-attendance-production-flow.mjs`: new `confirmImportOverrideModalIfPresent(page)` — after clicking
+  "Import", if `[data-import-override-confirm]` becomes visible, check the ack checkbox and click confirm-submit,
+  THEN await the commit response (armed before the click, so it catches the POST whenever it fires). No-op when no
+  modal appears (non-override direct-commit path).
+- `scripts/verify-attendance-full-flow.mjs`: same helper on the override recovery path (`assertImportJobRecoveryFlow`,
+  `mode:'override'`) — gated off by default but future-proofed for when `REQUIRE_IMPORT_JOB_RECOVERY=true`.
+- **Contract test** `scripts/ops/attendance-import-override-confirm-contract.test.mjs`: cross-checks the app renders
+  the modal hooks AND both scripts target them in the right order — so the fix can't silently drift from the app.
+- Wired into the strict-gate contract case (`attendance-run-gate-contract-case.sh`, strict) alongside #4096's.
+
+## 5. Verification
+- `node --check` on all three files: OK.
+- Contract test: **5/5 pass** (app renders modal + ack checkbox + confirm-submit; both scripts define the helper with
+  the app's exact selectors; production-flow confirms the modal *between* the Import click and the response await;
+  full-flow confirms after the import click).
+- **Next real proof**: a fresh `#189` strict-gate run against current prod should flip **Gate 4 → PASS** (the commit
+  POST now dispatches after the modal is confirmed). That rerun is the acceptance evidence.
+
+## 6. Where this sits in the attendance closeout
+This unblocks closeout step 2 ("fix #189, get prod/desktop/mobile/API green"). Remaining (sequenced, some owner/ops-gated):
+pick a release SHA → five-window smokes (AE-4 incl. **manual AE-3 modal**, RD-4/5, OT-bank v1-8, MP-6, HMR-5) on the
+same SHA → backfill stamps + residue=0 + close #3317 → close #189 + final four-column closeout MD + release tag.

--- a/scripts/ops/attendance-import-override-confirm-contract.test.mjs
+++ b/scripts/ops/attendance-import-override-confirm-contract.test.mjs
@@ -1,0 +1,66 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+// Contract: the acceptance verify flows must confirm the "override import" modal (确认覆盖导入) that the app
+// opens before the commit POST fires, and the selectors they use must match the app's actual modal. Without
+// this, clicking "Import" opens the modal, no POST /api/attendance/import/commit ever fires, and the flow
+// hits the 60s waitForResponse timeout (the #189 Gate-4 "Playwright Prod" failure, 2026-07-13).
+
+const repoRoot = process.cwd()
+const read = (file) => readFileSync(path.join(repoRoot, file), 'utf8')
+
+const productionFlow = read('scripts/verify-attendance-production-flow.mjs')
+const fullFlow = read('scripts/verify-attendance-full-flow.mjs')
+const attendanceView = read('apps/web/src/views/AttendanceView.vue')
+
+// The three modal hooks the verify scripts drive.
+const MODAL = '[data-import-override-confirm]'
+const CHECKBOX_WRAP = '[data-import-override-extra-confirm]'
+const CONFIRM_SUBMIT = '[data-import-override-confirm-submit]'
+
+test('the app renders the override-confirm modal + its acknowledgement checkbox + confirm-submit control', () => {
+  // App side: requestRunImport opens the modal instead of committing when the mode requires confirmation.
+  assert.match(attendanceView, /requestRunImport/)
+  assert.match(attendanceView, /importOverrideConfirm\.open\s*=\s*true/)
+  // The DOM hooks the scripts target must exist on the app modal (cross-check app <-> script).
+  assert.ok(attendanceView.includes('data-import-override-confirm'), 'app must mark the modal')
+  assert.ok(attendanceView.includes('data-import-override-extra-confirm'), 'app must mark the ack checkbox')
+  assert.ok(attendanceView.includes('data-import-override-confirm-submit'), 'app must mark the confirm-submit')
+})
+
+for (const [name, raw] of [
+  ['production flow', productionFlow],
+  ['full flow', fullFlow],
+]) {
+  test(`${name} defines confirmImportOverrideModalIfPresent using the app's modal hooks`, () => {
+    assert.match(raw, /async function confirmImportOverrideModalIfPresent\s*\(/, `${name} must define the helper`)
+    const start = raw.indexOf('async function confirmImportOverrideModalIfPresent')
+    const body = raw.slice(start, start + 800)
+    assert.ok(body.includes(MODAL), `${name} helper must locate ${MODAL}`)
+    assert.ok(body.includes(CHECKBOX_WRAP), `${name} helper must check the ack checkbox under ${CHECKBOX_WRAP}`)
+    assert.ok(body.includes(CONFIRM_SUBMIT), `${name} helper must click ${CONFIRM_SUBMIT}`)
+    assert.match(body, /waitFor\(\{\s*state:\s*'visible'/, `${name} helper must gate on the modal being visible (no-op otherwise)`)
+  })
+}
+
+test('production flow confirms the override modal between clicking Import and awaiting the commit response', () => {
+  const start = productionFlow.indexOf('async function clickImportAndWaitForCommitResponse')
+  assert.notEqual(start, -1)
+  const end = productionFlow.indexOf('\nasync function', start + 1)
+  const body = productionFlow.slice(start, end > start ? end : start + 900)
+  const clickIdx = body.indexOf(".click()")
+  const confirmIdx = body.indexOf('confirmImportOverrideModalIfPresent(page)')
+  const awaitIdx = body.indexOf('await responsePromise')
+  assert.ok(clickIdx !== -1 && confirmIdx !== -1 && awaitIdx !== -1, 'all three steps present')
+  assert.ok(clickIdx < confirmIdx, 'confirm the modal AFTER clicking Import')
+  assert.ok(confirmIdx < awaitIdx, 'confirm the modal BEFORE awaiting the commit response')
+})
+
+test('full flow confirms the override modal after clicking the import button (override recovery path)', () => {
+  const clickIdx = fullFlow.indexOf('await importButton.click()')
+  const confirmIdx = fullFlow.indexOf('confirmImportOverrideModalIfPresent(page)', clickIdx)
+  assert.ok(clickIdx !== -1 && confirmIdx !== -1)
+  assert.ok(clickIdx < confirmIdx, 'confirm the modal after the import click')
+})

--- a/scripts/ops/attendance-run-gate-contract-case.sh
+++ b/scripts/ops/attendance-run-gate-contract-case.sh
@@ -92,6 +92,9 @@ if [[ "$CASE_ID" == "strict" ]]; then
   info "running strict import advanced-panel contract"
   node --test ./scripts/ops/attendance-strict-import-advanced-contract.test.mjs
 
+  info "running strict import override-confirm modal contract"
+  node --test ./scripts/ops/attendance-import-override-confirm-contract.test.mjs
+
   cp "$valid_summary" "${strict_dir}/gate-summary.json"
   ./scripts/ops/attendance-validate-gate-summary.sh "$strict_dir" 1
   node ./scripts/ops/attendance-validate-gate-summary-schema.mjs \

--- a/scripts/verify-attendance-full-flow.mjs
+++ b/scripts/verify-attendance-full-flow.mjs
@@ -772,6 +772,23 @@ async function resolveRecoveryUserId(apiBase) {
   return ''
 }
 
+// When the import mode requires confirmation (override), requestRunImport() opens the "confirm override
+// import" modal (确认覆盖导入, AttendanceView §2/§4) before the commit fires; the commit only dispatches after
+// the acknowledgement checkbox is checked and Confirm is clicked. No-op when no modal appears.
+async function confirmImportOverrideModalIfPresent(page) {
+  const modal = page.locator('[data-import-override-confirm]').first()
+  try {
+    await modal.waitFor({ state: 'visible', timeout: 5000 })
+  } catch {
+    return
+  }
+  const checkbox = modal.locator('[data-import-override-extra-confirm] input[type="checkbox"]').first()
+  if (await checkbox.count()) {
+    await checkbox.check().catch(() => {})
+  }
+  await modal.locator('[data-import-override-confirm-submit]').first().click()
+}
+
 async function assertImportJobRecoveryFlow(page, importSection, apiBase) {
   logInfo('Admin import recovery assertion started')
   const payloadInput = await ensureImportAdvancedOptionsVisible(importSection)
@@ -845,6 +862,7 @@ async function assertImportJobRecoveryFlow(page, importSection, apiBase) {
     }
 
     await importButton.click()
+    await confirmImportOverrideModalIfPresent(page)
     const asyncCard = importSection.locator('div.attendance__status').filter({ hasText: labels.asyncJobCard }).first()
     const timeoutMessage = page.getByText(labels.asyncStillRunning).first()
     await Promise.any([

--- a/scripts/verify-attendance-production-flow.mjs
+++ b/scripts/verify-attendance-production-flow.mjs
@@ -325,12 +325,32 @@ function isImportCommitUrl(url) {
   }
 }
 
+// When the import mode requires confirmation, requestRunImport() opens the "confirm override import"
+// modal (确认覆盖导入, AttendanceView §2/§4 design-lock) instead of committing directly; the commit POST
+// only fires after the acknowledgement checkbox is checked and Confirm is clicked. Handle it so the commit
+// actually dispatches. No-op (returns fast) when no modal appears (non-override direct-commit path).
+async function confirmImportOverrideModalIfPresent(page) {
+  const modal = page.locator('[data-import-override-confirm]').first()
+  try {
+    await modal.waitFor({ state: 'visible', timeout: 5000 })
+  } catch {
+    return // no override-confirm modal — direct-commit path
+  }
+  const checkbox = modal.locator('[data-import-override-extra-confirm] input[type="checkbox"]').first()
+  if (await checkbox.count()) {
+    await checkbox.check().catch(() => {})
+  }
+  await modal.locator('[data-import-override-confirm-submit]').first().click()
+}
+
 async function clickImportAndWaitForCommitResponse(page, importSection) {
   const responsePromise = page.waitForResponse((resp) => {
     if (resp.request().method() !== 'POST') return false
     return isImportCommitUrl(resp.url())
   }, { timeout: timeoutMs })
   await importSection.getByRole('button', { name: exactNamePattern(uiText.import) }).click()
+  // A confirm-override modal may intercept before the commit POST fires (design-lock §2/§4); confirm it.
+  await confirmImportOverrideModalIfPresent(page)
   const response = await responsePromise
   const raw = await response.text()
   let body = null

--- a/scripts/verify-attendance-production-flow.mjs
+++ b/scripts/verify-attendance-production-flow.mjs
@@ -319,6 +319,10 @@ async function waitForJsonResponse(page, predicate, { label }) {
 function isImportCommitUrl(url) {
   try {
     const pathname = new URL(url).pathname
+    // Sync commit + legacy alias. NOT '/import/commit-async': the prod-gate fixture is 1 row
+    // (< commitAsyncThreshold=1000), so the commit is always sync. If that fixture ever grows
+    // to >=1000 rows the commit goes async and this matcher misses it — producing the SAME 60s
+    // waitForResponse timeout from a DIFFERENT cause (routing, not the override-confirm modal).
     return pathname === '/api/attendance/import/commit' || pathname === '/api/attendance/import'
   } catch {
     return false


### PR DESCRIPTION
## Problem
`#189` strict gate failed **8 consecutive runs**: **Gate 4 (Playwright Prod) timed out 60s at the import commit**, while every other gate (API smoke, provisioning, desktop, mobile) passed. Owner explicitly ruled out "just wait for deploy" and "the old advanced-panel issue" and asked to re-diagnose the UI submit / validator / runtime-env contract.

## Root cause — a verify-script gap, not deploy/auth
The app added a **"确认覆盖导入 / Confirm override import" safety modal**. `requestRunImport()` (`AttendanceView.vue`) does **not** commit directly when the import mode requires confirmation — it opens the modal (`[data-import-override-confirm]`); the commit POST fires only after the ack checkbox (`[data-import-override-extra-confirm]`) is checked and confirm-submit (`[data-import-override-confirm-submit]`, disabled until checked) is clicked.

The prod-flow verify script clicked "Import" then `waitForResponse`'d for `/api/attendance/import/commit` — but the modal intercepted, **no POST ever fired**, so it hit the full 60s timeout. Only **Gate 4** drives the live UI commit (API smoke commits via direct API, no modal; desktop/mobile commit path is gated off by `REQUIRE_IMPORT_JOB_RECOVERY=false`) → only Gate 4 failed.

Ruled out with evidence: **NOT auth** (deploy-host fallback minted a valid token; same token passed 4/5 gates incl. admin-only), **NOT a stale/unhealthy deploy** (prod on `f0ce863ea`, 1 commit behind main, pipeline healthy), **NOT the advanced-panel bug** (#4096 fixed; script already expands the panel and the Import button renders enabled).

## Fix (verify tooling only — no product runtime change)
- `scripts/verify-attendance-production-flow.mjs`: new `confirmImportOverrideModalIfPresent(page)` — after clicking Import, if the override modal is visible, check the ack box and click confirm-submit, then await the commit response (armed pre-click so it catches the POST whenever it fires). No-op on the non-override direct-commit path.
- `scripts/verify-attendance-full-flow.mjs`: same helper on the override recovery path.
- `scripts/ops/attendance-import-override-confirm-contract.test.mjs`: **new contract test (5/5)** cross-checking app↔script selectors + click/confirm/await ordering, so the fix can't silently drift from the app.
- `scripts/ops/attendance-run-gate-contract-case.sh`: wire the contract test into the strict case (alongside #4096's).
- docs: diagnosis + fix + verification MD.

## Verification
- `node --check` on both verify scripts: OK.
- Contract test: **5/5 pass**.
- `bash -n` on the gate contract-case script: OK.
- **Real acceptance proof** = a fresh `#189` strict-gate run flipping **Gate 4 → PASS**. Left `#189` open until that run confirms.

Refs #189, #3317. No closing keyword — close issue-189 only after a real Gate-4-green strict run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


> ⚠️ 2026-07-14 errata: the original body contained the literal prose "close issue-189" in keyword form, which GitHub parsed and auto-closed issue-189 at merge time (15:59:57Z) — one second after merge, ~13 min BEFORE the proving strict-gate run 29265492036 started. The evidence subsequently landed green (both run-twice artifacts: apiSmoke/provisioning/playwrightProd/playwrightDesktop/playwrightMobile all PASS, owner-verified), so #189 stays closed on merit; the closure TIMING was a keyword mis-trigger. Keywords defused.
