### PR TITLE
feat(ops): DT-CLOSE-02 DingTalk env contract — closeout switches reproducible in deploy templates

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -81,6 +81,10 @@ jobs:
         run: |
           node --test scripts/ops/dingtalk-oauth-stability-metrics-auth-contract.test.mjs
 
+      - name: Run DingTalk closeout env-contract test (DT-CLOSE-02)
+        run: |
+          node --test scripts/ops/dingtalk-closeout-env-contract.test.mjs
+
   test:
     runs-on: ubuntu-latest
 

--- a/docker/app.env.example
+++ b/docker/app.env.example
@@ -35,3 +35,87 @@ ATTENDANCE_IMPORT_HEAVY_QUERY_TIMEOUT_MS=180000
 POSTGRES_USER=metasheet
 POSTGRES_PASSWORD=change-me
 POSTGRES_DB=metasheet
+
+# --- DingTalk directory-sync & interactive-card closeout switches ---
+# DT-CLOSE-02: every value below is the SAME default the code falls back to when the var is
+# absent, so applying this file byte-identical to what is already running changes nothing.
+# See docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md and the
+# design-lock for the owner rulings behind each DANGER note.
+
+# DANGER: stays OFF until an audited reactivation/rollback path + a real-data preview + a
+# small canary have run. ON makes the NEXT sync's absence-sweep actually deprovision (mass
+# login revocation) instead of just stranding accounts.
+# (directory-sync.ts isDirectoryDeprovisionEnabled)
+DIRECTORY_DEPROVISION_ENABLED=false
+# DANGER: circuit breaker — a deprovision batch larger than this ABORTS instead of running.
+# 25 is the code default; do not raise without re-validating absence-sweep signal quality.
+# (directory-sync.ts DIRECTORY_DEPROVISION_MAX_BATCH)
+DIRECTORY_DEPROVISION_MAX_BATCH=25
+
+# DANGER: stays OFF until dept_order_list has been verified against a real tenant AND a
+# dry run has been reviewed. ON flips how the PRIMARY department is inferred for EVERY
+# synced account — changes live approval routing. Prefer a per-integration override over
+# flipping this global switch. (directory-sync.ts isDirectoryPrimaryDepartmentFromOrderEnabled)
+DIRECTORY_PRIMARY_DEPT_FROM_ORDER=false
+
+# DANGER: MUST be true + Redis-verified on any multi-replica deployment. False on
+# multi-replica means the OAuth `state` (CSRF nonce) is not shared across replicas ->
+# login failures and a state-forgery window. Single-replica deploys may leave this false.
+# (dingtalk-oauth.ts isDingTalkOAuthSharedStateStoreRequired)
+DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE=false
+
+# DANGER: stays OFF until U1-U13 UAT is all-green AND the real-callback anchor proof (#4171)
+# lands. ON starts the interactive-card Stream client (dingtalk-stream SDK) BEFORE
+# real-callback validation. (interactive-card-stream.ts resolveDingTalkInteractiveCardStreamConfig)
+DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=false
+
+# DANGER: retention window MUST stay LONGER than the longest approval SLA, and MUST be set
+# before DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED above is ever turned on. Too short deletes
+# delivery-ledger rows a still-in-flight approval card needs to resolve. Code default 90
+# days, floored at 7 (DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS / _MIN_DAYS in
+# dingtalk-group-delivery-retention.ts are COMPILED-IN CONSTANTS, not env vars — there is no
+# process.env read for either name; do not add them here, the code would ignore them).
+DINGTALK_GROUP_DELIVERY_RETENTION_DAYS=90
+# DANGER: '1' disables the retention sweep entirely (rows accumulate unbounded). Code
+# default is enabled (any value other than exactly '1').
+DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED=0
+# DANGER: how often the sweep tick runs. Invalid/absent falls back to 21600000ms (6h). Too
+# long lets the table grow between passes; too short adds needless DB load.
+DINGTALK_GROUP_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS=21600000
+# Master switch for the two leader-lock settings below — OFF (the default) means
+# single-process leader with no Redis lock, and TTL/RETRY below have no effect until this
+# is 'true'. Documented here because it directly gates them.
+# ENABLE_DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK=false
+# DANGER: leader-lock TTL, used only when the leader lock above is enabled. Too short can
+# cause lock thrash (double-run) under a slow renew. Code default 30000ms.
+DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK_TTL_MS=30000
+# DANGER: leader-lock acquire-retry interval, used only when the leader lock above is
+# enabled. Invalid/absent falls back to max(1000, ttl/3) = 10000ms at the default TTL above.
+DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK_RETRY_MS=10000
+
+# DANGER: alert threshold (days) for accounts that are still linked but have gone inactive.
+# Unset = off (this signal never alerts). A non-positive/non-integer value is treated as
+# unset and logs a warning once — it never silently clamps to a bogus threshold.
+DIRECTORY_INACTIVE_LINKED_ALERT_DAYS=
+# DANGER: directory-sync failure/alert channel (DingTalk group-robot webhook, SSRF-pinned).
+# MUST be configured for production, or sync failures accumulate silently with nobody
+# notified. Blank = channel disabled (best-effort; never fails the sync itself).
+DIRECTORY_SYNC_ALERT_WEBHOOK=
+# DANGER: HMAC secret for the webhook above. Leave blank unless the webhook above is set;
+# never commit a real value to this file.
+DIRECTORY_SYNC_ALERT_WEBHOOK_SECRET=
+# DANGER: how often a running sync proves liveness via a heartbeat write. Invalid or
+# <5000ms is ignored entirely (falls back to 60000ms) so a misconfiguration cannot hammer
+# the pool.
+DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS=60000
+# DANGER: minutes a run may go without a heartbeat before another caller reclaims its
+# lease. Code default 10, clamped to at least 5x the heartbeat interval above so a GC
+# pause cannot cause a false reclaim.
+DIRECTORY_SYNC_LEASE_STALE_MINUTES=10
+
+# DANGER: corp-id allowlist for DingTalk login (web OAuth + container/免登). Empty = allow
+# ANY corp. Set this before enabling auto-provision or container login in a shared deploy.
+DINGTALK_ALLOWED_CORP_IDS=
+# DANGER: enables POST /api/auth/login/dingtalk/container (in-container 免登, bypasses the
+# JWT gate pre-auth). Default OFF (404). Only enable inside the DingTalk container context.
+DINGTALK_CONTAINER_LOGIN_ENABLED=false

--- a/docker/app.staging.env.example
+++ b/docker/app.staging.env.example
@@ -63,3 +63,82 @@ DINGTALK_NOTIFY_AGENT_ID=replace-me
 # (integrations/dingtalk/approval-card-config.ts). Falls back to a stored
 # per-directory secret if unset; required for signed approval decision links.
 APPROVAL_CARD_LINK_SECRET=replace-me
+
+# --- DingTalk directory-sync & interactive-card closeout switches ---
+# DT-CLOSE-02: every value below is the SAME default the code falls back to when the var is
+# absent, so applying this file byte-identical to what is already running changes nothing.
+# See docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md and the
+# design-lock for the owner rulings behind each DANGER note.
+# NOTE: DINGTALK_ALLOWED_CORP_IDS and DINGTALK_CONTAINER_LOGIN_ENABLED are already
+# configured above (lines 43/54) — not repeated here to avoid a duplicate key in this file.
+
+# DANGER: stays OFF until an audited reactivation/rollback path + a real-data preview + a
+# small canary have run. ON makes the NEXT sync's absence-sweep actually deprovision (mass
+# login revocation) instead of just stranding accounts.
+# (directory-sync.ts isDirectoryDeprovisionEnabled)
+DIRECTORY_DEPROVISION_ENABLED=false
+# DANGER: circuit breaker — a deprovision batch larger than this ABORTS instead of running.
+# 25 is the code default; do not raise without re-validating absence-sweep signal quality.
+# (directory-sync.ts DIRECTORY_DEPROVISION_MAX_BATCH)
+DIRECTORY_DEPROVISION_MAX_BATCH=25
+
+# DANGER: stays OFF until dept_order_list has been verified against a real tenant AND a
+# dry run has been reviewed. ON flips how the PRIMARY department is inferred for EVERY
+# synced account — changes live approval routing. Prefer a per-integration override over
+# flipping this global switch. (directory-sync.ts isDirectoryPrimaryDepartmentFromOrderEnabled)
+DIRECTORY_PRIMARY_DEPT_FROM_ORDER=false
+
+# DANGER: MUST be true + Redis-verified on any multi-replica deployment. False on
+# multi-replica means the OAuth `state` (CSRF nonce) is not shared across replicas ->
+# login failures and a state-forgery window. Single-replica deploys may leave this false.
+# (dingtalk-oauth.ts isDingTalkOAuthSharedStateStoreRequired)
+DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE=false
+
+# DANGER: stays OFF until U1-U13 UAT is all-green AND the real-callback anchor proof (#4171)
+# lands. ON starts the interactive-card Stream client (dingtalk-stream SDK) BEFORE
+# real-callback validation. (interactive-card-stream.ts resolveDingTalkInteractiveCardStreamConfig)
+DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=false
+
+# DANGER: retention window MUST stay LONGER than the longest approval SLA, and MUST be set
+# before DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED above is ever turned on. Too short deletes
+# delivery-ledger rows a still-in-flight approval card needs to resolve. Code default 90
+# days, floored at 7 (DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS / _MIN_DAYS in
+# dingtalk-group-delivery-retention.ts are COMPILED-IN CONSTANTS, not env vars — there is no
+# process.env read for either name; do not add them here, the code would ignore them).
+DINGTALK_GROUP_DELIVERY_RETENTION_DAYS=90
+# DANGER: '1' disables the retention sweep entirely (rows accumulate unbounded). Code
+# default is enabled (any value other than exactly '1').
+DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED=0
+# DANGER: how often the sweep tick runs. Invalid/absent falls back to 21600000ms (6h). Too
+# long lets the table grow between passes; too short adds needless DB load.
+DINGTALK_GROUP_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS=21600000
+# Master switch for the two leader-lock settings below — OFF (the default) means
+# single-process leader with no Redis lock, and TTL/RETRY below have no effect until this
+# is 'true'. Documented here because it directly gates them.
+# ENABLE_DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK=false
+# DANGER: leader-lock TTL, used only when the leader lock above is enabled. Too short can
+# cause lock thrash (double-run) under a slow renew. Code default 30000ms.
+DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK_TTL_MS=30000
+# DANGER: leader-lock acquire-retry interval, used only when the leader lock above is
+# enabled. Invalid/absent falls back to max(1000, ttl/3) = 10000ms at the default TTL above.
+DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK_RETRY_MS=10000
+
+# DANGER: alert threshold (days) for accounts that are still linked but have gone inactive.
+# Unset = off (this signal never alerts). A non-positive/non-integer value is treated as
+# unset and logs a warning once — it never silently clamps to a bogus threshold.
+DIRECTORY_INACTIVE_LINKED_ALERT_DAYS=
+# DANGER: directory-sync failure/alert channel (DingTalk group-robot webhook, SSRF-pinned).
+# MUST be configured for production, or sync failures accumulate silently with nobody
+# notified. Blank = channel disabled (best-effort; never fails the sync itself).
+DIRECTORY_SYNC_ALERT_WEBHOOK=
+# DANGER: HMAC secret for the webhook above. Leave blank unless the webhook above is set;
+# never commit a real value to this file.
+DIRECTORY_SYNC_ALERT_WEBHOOK_SECRET=
+# DANGER: how often a running sync proves liveness via a heartbeat write. Invalid or
+# <5000ms is ignored entirely (falls back to 60000ms) so a misconfiguration cannot hammer
+# the pool.
+DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS=60000
+# DANGER: minutes a run may go without a heartbeat before another caller reclaims its
+# lease. Code default 10, clamped to at least 5x the heartbeat interval above so a GC
+# pause cannot cause a false reclaim.
+DIRECTORY_SYNC_LEASE_STALE_MINUTES=10

--- a/scripts/ops/dingtalk-closeout-env-contract.test.mjs
+++ b/scripts/ops/dingtalk-closeout-env-contract.test.mjs
@@ -1,0 +1,136 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// DT-CLOSE-02 contract guard.
+//
+// The DingTalk directory-sync / interactive-card closeout switches (deprovision, primary-dept
+// inference, OAuth shared-state store, interactive-card Stream, group-delivery retention,
+// directory-sync alerting/heartbeat/lease, corp allowlist, container login) are read straight
+// from process.env with NO other reproducible record of what a production/staging deploy is
+// running. If a deploy template silently drops one of these, the next redeploy resets it to
+// the code default with no operator warning — exactly the failure mode DT-CLOSE-01 hit for
+// the OAuth-stability metrics scrape.
+//
+// This test pins that every key below appears in BOTH docker/app.env.example (production) and
+// docker/app.staging.env.example (staging), each preceded by an explanatory comment line, so a
+// deployment stays reproducible. It intentionally does NOT require a specific value — templates
+// are allowed to ship the safe/conservative default (commented or live `KEY=value`); the point
+// is that the key + its guidance exist at all.
+//
+// CANONICAL KEY LIST — keep this in sync with packages/core-backend/src (grep for
+// `process.env.DIRECTORY_*` / `process.env.DINGTALK_*` under directory/ and
+// integrations/dingtalk/ + auth/dingtalk-oauth.ts + services/dingtalk-group-delivery-retention*).
+//
+// NOT included here on purpose: DINGTALK_GROUP_DELIVERY_RETENTION_MIN_DAYS (=7) and
+// DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS (=90) are exported `const` values in
+// dingtalk-group-delivery-retention.ts, never read via `process.env` — adding them as `KEY=`
+// template lines would be a template an operator could "set" that the code silently ignores.
+// They are documented as prose in the DINGTALK_GROUP_DELIVERY_RETENTION_DAYS comment block
+// instead (see the second test below), not enforced as settable keys.
+const CLOSEOUT_ENV_KEYS = [
+  'DIRECTORY_DEPROVISION_ENABLED',
+  'DIRECTORY_DEPROVISION_MAX_BATCH',
+  'DIRECTORY_PRIMARY_DEPT_FROM_ORDER',
+  'DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE',
+  'DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
+  'DINGTALK_GROUP_DELIVERY_RETENTION_DAYS',
+  'DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED',
+  'DINGTALK_GROUP_DELIVERY_RETENTION_SCHEDULER_INTERVAL_MS',
+  'DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK_TTL_MS',
+  'DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK_RETRY_MS',
+  'DIRECTORY_INACTIVE_LINKED_ALERT_DAYS',
+  'DIRECTORY_SYNC_ALERT_WEBHOOK',
+  'DIRECTORY_SYNC_ALERT_WEBHOOK_SECRET',
+  'DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS',
+  'DIRECTORY_SYNC_LEASE_STALE_MINUTES',
+  'DINGTALK_ALLOWED_CORP_IDS',
+  'DINGTALK_CONTAINER_LOGIN_ENABLED',
+]
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, '..', '..')
+
+const TEMPLATES = [
+  { label: 'production', path: join(REPO_ROOT, 'docker', 'app.env.example') },
+  { label: 'staging', path: join(REPO_ROOT, 'docker', 'app.staging.env.example') },
+]
+
+/**
+ * Locate the (possibly commented-out) assignment line for `key` and return its 0-based line
+ * index, or -1 if absent. Anchored so `DIRECTORY_SYNC_ALERT_WEBHOOK=` never matches the
+ * `DIRECTORY_SYNC_ALERT_WEBHOOK_SECRET=` line: the literal `=` must follow the key immediately.
+ */
+function findAssignmentLineIndex(lines, key) {
+  const re = new RegExp(`^#?\\s*${key}=`)
+  return lines.findIndex((line) => re.test(line))
+}
+
+/** The nearest non-blank line above `index`, or null if none / file start. */
+function nearestPrecedingNonBlankLine(lines, index) {
+  for (let i = index - 1; i >= 0; i -= 1) {
+    const trimmed = lines[i].trim()
+    if (trimmed.length > 0) return trimmed
+  }
+  return null
+}
+
+for (const { label, path } of TEMPLATES) {
+  test(`${label} deploy template documents every DingTalk closeout env key`, () => {
+    const text = readFileSync(path, 'utf8')
+    const lines = text.split('\n')
+
+    for (const key of CLOSEOUT_ENV_KEYS) {
+      const lineIndex = findAssignmentLineIndex(lines, key)
+      assert.notEqual(
+        lineIndex,
+        -1,
+        `${key} is missing from ${path} — every DingTalk directory-sync/interactive-card ` +
+          'closeout switch must appear in the deploy template so a deployment is reproducible.',
+      )
+
+      const precedingLine = nearestPrecedingNonBlankLine(lines, lineIndex)
+      assert.ok(
+        precedingLine !== null && precedingLine.startsWith('#'),
+        `${key} in ${path} has no preceding comment line explaining what it does / the ` +
+          'danger of mis-setting it.',
+      )
+    }
+  })
+}
+
+test('production and staging templates both carry the closeout switches header', () => {
+  for (const { path } of TEMPLATES) {
+    const text = readFileSync(path, 'utf8')
+    assert.match(
+      text,
+      /# --- DingTalk directory-sync & interactive-card closeout switches ---/,
+      `${path} is missing the DT-CLOSE-02 closeout switches section header`,
+    )
+  }
+})
+
+test('the RETENTION_DAYS entry documents that MIN_DAYS/DEFAULT_DAYS are NOT env-settable', () => {
+  // Guards against someone "helpfully" turning the disclaimer into a fake env line, or
+  // deleting it and letting an operator believe MIN_DAYS/DEFAULT_DAYS do something.
+  for (const { path } of TEMPLATES) {
+    const text = readFileSync(path, 'utf8')
+    assert.match(
+      text,
+      /DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS.*_MIN_DAYS.*COMPILED-IN CONSTANTS|DEFAULT_DAYS \/ _MIN_DAYS[\s\S]{0,200}COMPILED-IN CONSTANTS/,
+      `${path} must document that RETENTION_MIN_DAYS/DEFAULT_DAYS are compiled-in constants, not env vars`,
+    )
+    assert.doesNotMatch(
+      text,
+      /^#?\s*DINGTALK_GROUP_DELIVERY_RETENTION_MIN_DAYS=/m,
+      `${path} must NOT define DINGTALK_GROUP_DELIVERY_RETENTION_MIN_DAYS as a settable env line — it is a compiled-in constant the code never reads from process.env`,
+    )
+    assert.doesNotMatch(
+      text,
+      /^#?\s*DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS=/m,
+      `${path} must NOT define DINGTALK_GROUP_DELIVERY_RETENTION_DEFAULT_DAYS as a settable env line — it is a compiled-in constant the code never reads from process.env`,
+    )
+  }
+})

--- a/scripts/ops/dingtalk-closeout-env-contract.test.mjs
+++ b/scripts/ops/dingtalk-closeout-env-contract.test.mjs
@@ -101,6 +101,43 @@ for (const { label, path } of TEMPLATES) {
   })
 }
 
+// The three switches that are DANGEROUS if a template ships them turned ON: the deploy would
+// enable mass-deprovision / re-infer every primary department / start the Stream client on the
+// next redeploy. Presence alone is not enough for these — a live `KEY=true` in a template is a
+// footgun. If the key is present as a LIVE (non-commented) assignment, it MUST be an off value.
+// (Numeric defaults like MAX_BATCH=25 are intentionally NOT pinned to the code value here: the
+// code defaults are computed IIFE/Math expressions, not extractable literals, so a source-vs-
+// template numeric equality check would be brittle. Numeric-value drift is covered by the
+// DT-CLOSE-04 switch-ruling ledger + review, not this contract — this test locks the one class
+// that is both cheap to check and genuinely dangerous: a dangerous switch shipped ON.)
+const MUST_BE_OFF_IF_LIVE = [
+  'DIRECTORY_DEPROVISION_ENABLED',
+  'DIRECTORY_PRIMARY_DEPT_FROM_ORDER',
+  'DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED',
+]
+const OFF_VALUES = new Set(['false', '0', 'no', 'off', ''])
+
+for (const { label, path } of TEMPLATES) {
+  test(`${label} template never ships a dangerous closeout switch turned ON`, () => {
+    const lines = readFileSync(path, 'utf8').split('\n')
+    for (const key of MUST_BE_OFF_IF_LIVE) {
+      // A LIVE assignment = the line is NOT commented out.
+      const liveRe = new RegExp(`^\\s*${key}=(.*)$`)
+      for (const line of lines) {
+        const m = line.match(liveRe)
+        if (!m) continue
+        const value = m[1].trim().toLowerCase()
+        assert.ok(
+          OFF_VALUES.has(value),
+          `${key} is shipped LIVE as '${m[1].trim()}' in ${path} — this switch must stay OFF ` +
+            'by default (a deploy applying this template would enable a dangerous behavior). ' +
+            'Ship it commented-out or =false.',
+        )
+      }
+    }
+  })
+}
+
 test('production and staging templates both carry the closeout switches header', () => {
   for (const { path } of TEMPLATES) {
     const text = readFileSync(path, 'utf8')


### PR DESCRIPTION
## DT-CLOSE-02 — DingTalk env contract (reproducible deploys)

The DingTalk directory-sync / interactive-card closeout switches are read straight from `process.env` but were **absent from the deploy templates** — so a redeploy silently reset each to the code default with no operator record (the same reproducibility hole DT-CLOSE-01 hit for the metrics scrape).

**Change:** every closeout key (deprovision, primary-dept inference, OAuth shared-state, interactive-card Stream, group-delivery retention family, directory-sync alert/heartbeat/lease, corp allowlist, container login) is now in **both** `docker/app.env.example` (production) and `docker/app.staging.env.example` (staging) — each with the code-accurate safe default + a **DANGER comment** stating what enabling/mis-setting does (per the owner's switch rulings). Secrets stay blank.

**Contract test** `scripts/ops/dingtalk-closeout-env-contract.test.mjs` (wired into plugin-tests.yml, alongside DT-CLOSE-01):
- every canonical closeout key must appear in both templates, each with a preceding comment — **missing key → red** (verified by mutation);
- the three dangerous OFF-by-default switches (`DEPROVISION_ENABLED` / `PRIMARY_DEPT_FROM_ORDER` / `INTERACTIVE_CARD_STREAM_ENABLED`), if shipped LIVE, must be off — **shipping `=true` → red** (verified by mutation), so a template can never carry a footgun;
- guards that the compiled-in `RETENTION_MIN_DAYS/DEFAULT_DAYS` are documented as NOT env-settable (an operator can't "set" a value the code ignores).

Numeric-value drift (e.g. a future `MAX_BATCH` default change) is left to the DT-CLOSE-04 switch-ruling ledger — the code defaults are computed IIFE/`Math` expressions, not cleanly source-extractable; documented in the test.

Adversarially gated (Opus): APPROVE, one P3 (value-drift) which this revision addresses for the dangerous class.
