### PR TITLE
docs(dev-plan): DT-CLOSE-03/04/05 — Hardening v1 closeout docs (UAT scaffold + switch ledger + status errata)

### DIFF
--- a/docs/development/dingtalk-hardening-real-uat-evidence-pack-20260713.md
+++ b/docs/development/dingtalk-hardening-real-uat-evidence-pack-20260713.md
@@ -1,0 +1,171 @@
+# DingTalk Hardening — Real UAT Evidence Pack (DT-CLOSE-03)
+
+Date: 2026-07-13
+Status: **BLANK SCAFFOLD.** Nothing in this document, as shipped, is evidence of anything.
+It is a template for **owner/ops to execute against the deployed SHA** and fill in. Until
+every checkbox below is ticked with a captured result, **DingTalk Sync Hardening v1
+Wave 1 is not done** — do not read a filled-in copy of this template as complete unless
+every section's "Executed by / date / SHA" line is filled and every row has a captured
+result, not a projection.
+
+> **Sandbox cannot execute any part of this document.** It cannot reach the deploy host
+> (`23.254.236.11`) or a real DingTalk corp. Every row here requires either a live deployed
+> backend, a real DingTalk tenant with Stream credentials, or both. This is why it is a
+> scaffold, not a report.
+
+## 0. Scope and cross-references
+
+This is Wave 1 of **DingTalk Sync Hardening v1** (Waves 0–2) — a separate milestone from
+**Canonical Org & Provider Transfer v1** (Waves 3–4, design-only). Completing this pack does
+not close the Transfer milestone and does not by itself close Hardening v1 either — Wave 2
+(`dingtalk-hardening-switch-ruling-ledger-20260713.md`, DT-CLOSE-04) is the sibling
+blocker.
+
+- Roll-up: `dingtalk-sync-org-transfer-line-design-and-verification-20260712.md` §5.2/§8.
+- Canonical interactive-card UAT script (source of truth for U1–U13 procedure detail, in
+  Chinese, with exact click sequences): `approval-dingtalk-slice-b-uat-checklist-20260710.md`.
+  Section A below is an English enumeration of **what each U-item proves**, for evidence-pack
+  bookkeeping — execute against the canonical script, not a re-derivation of it.
+- Switch ledger (what "default-off" means per switch, evidence-to-flip criteria):
+  `dingtalk-hardening-switch-ruling-ledger-20260713.md` (DT-CLOSE-04).
+- Corp-anchor real-callback tooling this pack exercises: #4171 (merged `663511527`),
+  `interactive-card-callback.ts` `readCallbackCorpAnchor`.
+
+## 1. Preconditions (must all be true before starting)
+
+| # | Precondition | Status |
+| --- | --- | --- |
+| P1 | Deploy-host disk resolved (#159 — **CLOSED** 2026-07-13, storage-health recovery confirmed) | done (infra only — does not itself satisfy P2/P3) |
+| P2 | The exact target SHA is deployed and its identity is confirmable (`git rev-parse HEAD` on the deploy host, or the image tag) | ⬜ record SHA: `______` |
+| P3 | Access to a real DingTalk corp (staging tenant or an authorized customer sandbox) with: an admin account, Stream app credentials, an interactive-card template, and **at least two** local accounts bound to DingTalk (one designated approval assignee "A", one non-assignee "B") | ⬜ |
+| P4 | `LOG_LEVEL=info` (or `debug`) on the deployed instance — **not** `warn`/`error`. `scripts/dev-optimized-start.sh` defaults to `warn`, which silently swallows the corp-anchor probe log line and makes "no log line" ambiguous between "prod-safe default silence" and "the probe never fired." Confirm before Section C. | ⬜ |
+
+**Executed by:** ______  **Date:** ______  **Target SHA:** ______
+
+## 2. Values-free evidence rules (apply to every section below)
+
+- **No PII.** No real names, phone numbers, emails, DingTalk `userid`/`unionId` values, or
+  form field contents may be written into this pack or attached screenshots. If a screenshot
+  would show any of these, redact before attaching or describe the result in words instead.
+- Corp id / integration id (uuid) are **not** PII and may be recorded — they identify a
+  tenant/config, not a person.
+- Capture **counts, booleans, HTTP status codes, and enum reason-codes** (e.g.
+  `corp_anchor_absent`, `container_login_disabled`, `env_disabled`) — never the underlying
+  values that produced them.
+- If a step's "expected result" in the canonical UAT script already specifies a values-free
+  log shape (e.g. U11-a's `headerEventCorpIdPresent`/`bodyCorpIdPresent` booleans), capture
+  exactly that shape and nothing more.
+- Any evidence file (log excerpt, screenshot, env dump) attached to this pack's execution
+  record must be reviewed against this section **before** attaching, not after.
+
+## 3. Section A — Default-off smoke test
+
+Confirm every switch in the DT-CLOSE-04 ledger is at its documented default on the deployed
+SHA, **before** touching Section B/C (which deliberately flips switch #3 in a controlled
+window). Evidence = the observed behavior when the gated action is attempted, not just "the
+env var is unset" (a wrong assumption about default-parsing is exactly the kind of bug this
+smoke test exists to catch).
+
+| # | Switch | Expected (default) | How to observe | Result |
+| --- | --- | --- | --- | --- |
+| S1 | `DIRECTORY_DEPROVISION_ENABLED` | off — a sync run's absence sweep reports candidates but writes nothing | Run one directory sync; confirm the run report shows `applied: false` and no account transitioned to inactive by the deprovision path (existing absence-marking behavior, if any, is unaffected) | ⬜ |
+| S2 | `DIRECTORY_PRIMARY_DEPT_FROM_ORDER` | off — primary department still resolves via legacy `departmentIds[0]` | Inspect one multi-department account's resolved primary department before/after; unchanged | ⬜ |
+| S3 | `DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED` | off — worker never starts, no client created | Deploy logs show no "Stream worker started" line; `resolveDingTalkInteractiveCardStreamConfig` would report `reason: 'env_disabled'` if queried | ⬜ |
+| S4 | `DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE` | off — OAuth login works via in-process state (single replica) or is known-risky (multi-replica, tracked separately in DT-CLOSE-04) | One OAuth login round-trip succeeds | ⬜ |
+| S5 | `DINGTALK_GROUP_DELIVERY_RETENTION_DAYS` family | sweep **enabled** at 90-day default (this one is on-by-default, not off — confirm the *value*, not that it's disabled) | Confirm scheduler log shows a sweep tick; confirm no `_DISABLED=1` set | ⬜ |
+| S6 | `DIRECTORY_SYNC_ALERT_WEBHOOK` | off (unset) — no alert channel configured, sync failures do not page anyone yet | Confirm var is unset in the deployed env (redacted dump, presence/absence only — never print the value) | ⬜ |
+| S7 | `DINGTALK_CONTAINER_LOGIN_ENABLED` | off — `POST /login/dingtalk/container` returns 404 `container_login_disabled` | One curl/Postman call to that path, capture status code + `code` field only | ⬜ |
+| S8 | `DINGTALK_ALLOWED_CORP_IDS` | deployment-specific — confirm it matches the ledger's row for this env (staging template ships `replace-me`, must be a real corp id list before use) | Confirm the deployed value is a real corp id set, not the placeholder | ⬜ |
+
+**Executed by:** ______  **Date:** ______
+
+## 4. Section B — Interactive-card U1–U13 (execute via the canonical script)
+
+Execute `approval-dingtalk-slice-b-uat-checklist-20260710.md` in full — including its own §0
+(env prep) and §0-a (the hard precondition, folded into Section C below) — with
+`DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED=1` set **only** in this controlled UAT window, per
+that script's own instruction. What each item proves, for this pack's bookkeeping:
+
+| # | Proves | Expected result | Evidence to capture | Pass/Fail |
+| --- | --- | --- | --- | --- |
+| U1 | Full-config send path delivers a real interactive card | Card reaches assignee A; ledger row `delivery_kind='interactive_card'`, `send_status='sent'` | ledger row snapshot (ids/status/kind only) | ⬜ |
+| U2 | Incomplete config fails closed to the OA fallback, not an error | OA ActionCard sent instead; no exception | ledger row `work_notice_action_card` | ⬜ |
+| U3 | Card body carries no form data | Only title/ticket-no/node/status visible | screenshot (redacted of any PII) | ⬜ |
+| U3-a | `cardTypeId`/spaceType casing (`IM_ROBOT`, #4118) is accepted by the real API | Card delivered using the uppercase form; report if the real API instead only accepts lowercase | pass/fail + note if casing assumption was wrong | ⬜ |
+| U4 | Approve-click reaches the approval engine correctly attributed | Engine records approve; audit actor = A's local account; ledger callback result `executed` | audit log actor-id + result enum only | ⬜ |
+| U5 | Duplicate callback is idempotent | No second engine write; card shows the real terminal state | count of engine writes (must be 1) | ⬜ |
+| U6 | Non-assignee click on a forwarded card is rejected | Engine 403 `APPROVAL_ASSIGNMENT_REQUIRED`; **zero** approval writes | status code + error code | ⬜ |
+| U7 | An operator with no DingTalk binding cannot act via the card | No engine call; card shows "bind DingTalk first" message | pass/fail | ⬜ |
+| U8 | Reject routes to the structured decision page (deep link), not an inline reject | Deep link opens; comment required before reject succeeds | pass/fail | ⬜ |
+| U9 | Terminal-state display uses the server's local display name, not an echoed DingTalk payload value | Card shows "approved by \<A's server-side local display name\> · \<time\>" | pass/fail (do not record the name itself) | ⬜ |
+| U10 | A card-update-API failure does not roll back an already-submitted approval | Approval stands; error logged values-free; a later click converges to the true terminal state via stale-summary handling | pass/fail | ⬜ |
+| U11 | Forged/expired `outTrackId` callback is indistinguishable (byte-for-byte) from an unresolved-operator case — no existence oracle | Neutral card-face message, same as the unresolved case | pass/fail | ⬜ |
+| U11-a | **The real-callback corp-anchor test** — a real approve-click carries an actual corp identifier the cross-corp gate can read | A real click **passes** the gate (not rejected as `corp_mismatch`); worker log shows the gate read an anchor matching the ledger's `integration_id`'s corp | see Section C — this is the load-bearing row of the whole pack | ⬜ |
+| U11-b | Retention-swept ("expired") cards are inert (only relevant if `DINGTALK_GROUP_DELIVERY_RETENTION_DAYS` sweep already ran on that card) | Clicking an expired card: no engine write, stale terminal-state message | pass/fail (n/a if not exercised) | ⬜ |
+| U12 | Clean shutdown, including a shutdown mid-`initialize()` | No half-open connection left; worker status reaches a consistent terminal state | worker status enum before/after | ⬜ |
+| U13 | Turning the flag back off actually stops the worker | After flag off + restart, worker never reconnects; all sends fall back to OA; this matches the intended prod-default-safe posture | pass/fail | ⬜ |
+
+**Pass standard (per the canonical script's own §5):** U1–U13 all green = the Slice-B design
+lock's UAT gate is met. **That still does not itself flip
+`DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED` to on in prod** — per DT-CLOSE-04, that is a
+separate, explicit owner/ops decision made *after* this evidence exists. Any red item: record
+the values-free symptom, assign it to its owning layer (B-2 send / B-3 callback / B-4 card
+lifecycle / SDK), and leave the flag off.
+
+**Executed by:** ______  **Date:** ______
+
+## 5. Section C — The real-callback corp-anchor test (U11-a, detailed)
+
+This is the thing #4171's probe can **observe**, not prove alone — it only becomes proof once
+a real click is captured and read. Do not skip straight to U11-a without the self-check below;
+"no log line" is ambiguous between "the real frame has no corp anchor" (⇒ close the flag) and
+"the log level ate it" (⇒ fix config, nothing else) unless the self-check has already ruled
+the second one out.
+
+1. ⬜ Confirm `LOG_LEVEL=info` on the UAT instance (Precondition P4). If not set, fix and
+   redeploy/restart before continuing — do not interpret silence yet.
+2. ⬜ Perform **one known-good click** that is expected to reach the cross-corp gate (e.g. a
+   normal approve by assignee A on a freshly delivered card). Confirm the log line
+   `DingTalk interactive-card callback corp anchor` appears, with fields `deliveryId`,
+   `headerEventCorpIdPresent`, `bodyCorpIdPresent`. **If this line does not appear, the probe
+   itself is not firing (config/deploy problem) — stop and fix that before drawing any
+   conclusion about real frame shape.**
+3. ⬜ From that captured line, record (booleans only, never the corp id value itself):
+   - `headerEventCorpIdPresent` = ⬜ true / ⬜ false
+   - `bodyCorpIdPresent` = ⬜ true / ⬜ false
+4. ⬜ Record the gate's refusal/success outcome for that same click:
+   - ⬜ succeeded (gate passed — U11-a proof condition met)
+   - ⬜ `corp_mismatch` (a genuine cross-corp click — should not happen on a same-corp
+     known-good click; if it does, treat as a configuration bug, not proof either way)
+   - ⬜ `corp_anchor_absent` — **both fields false. STOP. Do not enable the flag in prod.**
+     The real frame carries no corp identifier the gate can read; enabling
+     `DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED` on this basis would make every real click
+     dead-on-arrival.
+   - ⬜ `corp_anchor_conflict` — both present but disagree; investigate the adapter/gateway,
+     do not treat as "absent."
+   - ⬜ `delivery_corp_unresolved` — this deployment's own `directory_integrations.corp_id`
+     configuration is the problem, not the real frame's shape; fix that config and repeat.
+5. ⬜ **Verdict**: real frames DO / DO NOT (circle one) carry a usable corp anchor. If DO
+   NOT, this is a hard blocker on Wave 2's switch #3 flip (DT-CLOSE-04) regardless of how
+   many other U-items pass — record that explicitly here, do not let it get lost in a
+   green-looking U1–U13 table.
+6. ⬜ If DO: update `interactive-card-callback.ts`'s `readCallbackCorpAnchor` doc comment
+   from "unverified assumption" to "verified against a real frame on \<date\>," per the
+   canonical script's own instruction — this pack's result is the source for that doc update,
+   not a duplicate of it.
+
+**Executed by:** ______  **Date:** ______  **Verdict:** ______
+
+## 6. Sign-off
+
+This pack is complete only when every section above has an "Executed by / Date" filled in,
+every row has a captured (not projected) result, and Section C has an explicit DO/DO-NOT
+verdict. Completion of this pack satisfies the Wave-1 half of DingTalk Sync Hardening v1's
+运行态收官 (operational-closeout) requirement; it does **not** by itself authorize flipping
+any switch — that is DT-CLOSE-04's ledger, ruled by the owner, using this pack's evidence
+where required.
+
+| Role | Name / 负责人 | Date | Verdict |
+| --- | --- | --- | --- |
+| Executor (ops) | ______ | ______ | ______ |
+| Reviewer (owner) | ______ | ______ | ______ |

--- a/docs/development/dingtalk-hardening-real-uat-evidence-pack-20260713.md
+++ b/docs/development/dingtalk-hardening-real-uat-evidence-pack-20260713.md
@@ -35,7 +35,7 @@ blocker.
 
 | # | Precondition | Status |
 | --- | --- | --- |
-| P1 | Deploy-host disk resolved (#159 — **CLOSED** 2026-07-13, storage-health recovery confirmed) | done (infra only — does not itself satisfy P2/P3) |
+| P1 | Deploy-host disk resolved (#159 — **CLOSED** 2026-07-12, storage-health recovery confirmed) | done (infra only — does not itself satisfy P2/P3) |
 | P2 | The exact target SHA is deployed and its identity is confirmable (`git rev-parse HEAD` on the deploy host, or the image tag) | ⬜ record SHA: `______` |
 | P3 | Access to a real DingTalk corp (staging tenant or an authorized customer sandbox) with: an admin account, Stream app credentials, an interactive-card template, and **at least two** local accounts bound to DingTalk (one designated approval assignee "A", one non-assignee "B") | ⬜ |
 | P4 | `LOG_LEVEL=info` (or `debug`) on the deployed instance — **not** `warn`/`error`. `scripts/dev-optimized-start.sh` defaults to `warn`, which silently swallows the corp-anchor probe log line and makes "no log line" ambiguous between "prod-safe default silence" and "the probe never fired." Confirm before Section C. | ⬜ |

--- a/docs/development/dingtalk-hardening-switch-ruling-ledger-20260713.md
+++ b/docs/development/dingtalk-hardening-switch-ruling-ledger-20260713.md
@@ -1,0 +1,108 @@
+# DingTalk Hardening — Switch Ruling Ledger (DT-CLOSE-04)
+
+Date: 2026-07-13
+Status: **Wave 2 tracking document** for `dingtalk-sync-org-transfer-line-design-and-verification-20260712.md`
+§6/§8. **DingTalk Sync Hardening v1** (Waves 0–2) is code-complete but NOT 运行态收官
+(operationally closed) — this ledger is one of the two blockers to that closeout (the other
+is the Wave-1 UAT evidence pack, DT-CLOSE-03). This is a **separate milestone** from
+**Canonical Org & Provider Transfer v1** (Waves 3–4, design-only, core impl not started) —
+never conflate the two.
+
+## Purpose
+
+Every env-gated switch this line ships must land on one of two ruled states, never on an
+unowned default:
+
+- **explicitly-deferred** — stays at its shipped default (off, in every case on this line)
+  until a named precondition is met. The precondition is the flip criterion, not a date.
+- **must-verify-enabled** — the mechanism is already on by default (or must be turned on
+  before another switch is safe to flip), but its *correctness* for this deployment has not
+  been demonstrated. "Verified-enabled" requires evidence, not just "it's set."
+
+No row in this ledger may read "default off, no ruling" — that is the exact failure mode
+this ledger exists to close out.
+
+All defaults below were read from the code at `origin/main` (post-#4228/#4218,
+`4157205ce`/`f0ce863ea`) on 2026-07-13, not copied from an earlier doc — cited by file and
+symbol so they can be re-checked at any later SHA.
+
+## 1. Primary safety switches (the six owner-named)
+
+| # | Switch(es) | Bucket | Current default (code) | Shipped in a config template? | Owner ruling (verbatim) |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `DIRECTORY_DEPROVISION_ENABLED` + `DIRECTORY_DEPROVISION_MAX_BATCH` | **explicitly-deferred** | `DEPROVISION_ENABLED`: **off** (`isDirectoryDeprovisionEnabled()`, `directory-sync.ts` ~L1186 — only `'true'/'1'/'yes'` enable it, unset ⇒ false). `MAX_BATCH`: **25** (`DIRECTORY_DEPROVISION_MAX_BATCH`, ~L1246 — any non-finite/non-positive input falls back to 25; this is the circuit-breaker's safe value). | Neither is in `.env.example`, `docker/app.env.example`, or `docker/app.staging.env.example`. | "stays OFF until audited reactivation/rollback + real-data preview + small canary. DANGER: enabling makes the next sync's absence sweep actually deprovision (mass login revocation) instead of just stranding." |
+| 2 | `DIRECTORY_PRIMARY_DEPT_FROM_ORDER` | **explicitly-deferred** | **off** (`isDirectoryPrimaryDepartmentFromOrderEnabled()`, `directory-sync.ts` ~L881 — same true/1/yes gate; unset ⇒ legacy `departmentIds[0]` inference). | Not in any template. | "OFF; verify real dept_order_list + dry-run first; prefer PER-INTEGRATION over a global env. DANGER: flips how the primary department is inferred for every synced account." |
+| 3 | `DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED` | **explicitly-deferred** | **off** (`resolveDingTalkInteractiveCardStreamConfig()`, `interactive-card-stream.ts` ~L119-136 — `enabled` requires the literal string `'1'`/`'true'`; unset ⇒ `{ enabled: false, reason: 'env_disabled' }`, and the client factory is never invoked). | Not in any template (client id/secret/template id/integration id are also unset). | "stays OFF until U1-U13 all green + #4171 real-callback anchor proof. DANGER: turns on the interactive-card Stream client before real-callback validation." |
+| 4 | `DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE` | **must-verify-enabled** | **off** (`isDingTalkOAuthSharedStateStoreRequired()`, `dingtalk-oauth.ts` ~L119 — unset ⇒ single-replica in-process `Map` fallback is silently accepted). | Not in any template. | "MUST be ON + Redis-verified for multi-replica deploys; single-replica may defer. DANGER if OFF on multi-replica: OAuth state (CSRF nonce) not shared across replicas → login failures/state-forgery window." |
+| 5 | `DINGTALK_GROUP_DELIVERY_RETENTION_DAYS` family (`_DISABLED`, `_MIN_DAYS`\*, `_DEFAULT_DAYS`\*, `_SCHEDULER_INTERVAL_MS`, `_LEADER_LOCK_TTL_MS`, `_LEADER_LOCK_RETRY_MS`) | **must-verify-enabled** | Sweep is **enabled by default** (`dingtalk-group-delivery-retention-scheduler.ts` ~L43 — only `DINGTALK_GROUP_DELIVERY_RETENTION_DISABLED=1` turns it off). `_DAYS` defaults to **90**, floored at `_MIN_DAYS`=**7** (`dingtalk-group-delivery-retention.ts` ~L44-74, both `\*` are code constants, not envs). `_SCHEDULER_INTERVAL_MS` defaults to **21,600,000 ms** (6h), floored at 60,000 ms (`LedgerRetentionScheduler.ts` ~L38-39). Leader lock is **opt-in** via `ENABLE_DINGTALK_GROUP_DELIVERY_RETENTION_LEADER_LOCK=true` (default off — single instance sweeps unlocked, which is safe: the sweep is idempotent); when enabled, `_LEADER_LOCK_TTL_MS` defaults **30,000 ms** and `_LEADER_LOCK_RETRY_MS` defaults **max(1000, ttl/3) = 10,000 ms**. | `.env.example` ~L43-47 has `_DAYS=90`, `_DISABLED=0`, `_SCHEDULER_INTERVAL_MS=21600000`, `ENABLE_..._LEADER_LOCK=false` (all commented-out samples). Neither `docker/app.env.example` nor `docker/app.staging.env.example` has any of this family. | "retention window MUST be LONGER than the longest approval SLA, set BEFORE enabling interactive cards. DANGER if too short: deletes delivery ledger rows still needed to resolve an in-flight approval card." |
+| 6 | `DIRECTORY_SYNC_ALERT_WEBHOOK` + `DIRECTORY_SYNC_ALERT_WEBHOOK_SECRET` | **must-verify-enabled** | **unset = off** (`directory-sync-alert-delivery.ts` ~L37 — no channel exists until a valid DingTalk robot URL is configured; an invalid URL throws rather than silently degrading). | Not in any template. | (No literal "owner:" sentence on file for this one; framed by the closeout brief as must-verify-enabled alongside OAuth shared-state and retention.) "must be configured for prod or sync failures go unnoticed (this is the egress-guarded channel)." |
+
+\* `_MIN_DAYS` (7) and `_DEFAULT_DAYS` (90) are **not themselves env vars** — they are the
+code-level floor/default that `_DAYS` resolves against. Listed here because the ENV-KEYS
+inventory that scoped this ledger named them as part of "the family."
+
+### 1.1 Evidence required to flip, and rollback action
+
+| # | Switch | Evidence required to flip | Rollback action |
+| --- | --- | --- | --- |
+| 1 | `DIRECTORY_DEPROVISION_ENABLED` | (a) An audited reactivation/rollback path exists and is tested — there is currently **no product path to reverse a deprovision** once it fires (this is why it gates the flip, not just documents it). (b) A real-data **preview** run (`DIRECTORY_DEPROVISION_ENABLED` left off, sync run inspected) shows the exact *count* and *policy* (`manual_review`/`disable_grant_only`/`mark_inactive`) of who WOULD be deprovisioned, values-free. (c) A small **canary**: enable for one low-risk integration only, run one full sync cycle, confirm only the previewed candidates were affected. `DIRECTORY_DEPROVISION_MAX_BATCH` (default 25) is not itself a flip decision — raise it only after (a)-(c) pass and the org's genuine daily-leaver count routinely exceeds 25 (i.e. the circuit breaker is aborting legitimate runs); lower it for a smaller blast radius. | Unset (or set to any non-`true/1/yes` value) — takes effect on the **next sync run**, stops future deprovisioning immediately. Does **not** undo accounts already deprovisioned in a prior run; that requires the (currently nonexistent) reactivation path from evidence item (a) — which is exactly why (a) is a precondition, not an afterthought. |
+| 2 | `DIRECTORY_PRIMARY_DEPT_FROM_ORDER` | A real `topapi/v2/user/get` response from a real tenant showing `dept_order_list` is populated, and its lowest-`order` entry cross-checked against that tenant's own understanding of the employee's primary department (DingTalk does not contractually document `order`'s semantics). A dry-run diff against the current `departmentIds[0]` inference, reviewed for how many accounts' primary department (and therefore `direct_manager`/`continuous_managers` routing) would change. Per-integration override implemented (owner preference) before a global flip — this is a design gap, not just an ops step. | Unset — reverts to the legacy `departmentIds[0]` inference on the **next sync read**; stateless flag, no data migration, no residual state. |
+| 3 | `DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED` | **Both**, jointly: (a) the full U1-U13 checklist green (canonical script: `approval-dingtalk-slice-b-uat-checklist-20260710.md`; execution scaffold: DT-CLOSE-03 `dingtalk-hardening-real-uat-evidence-pack-20260713.md`), and (b) the #4171 real-callback corp-anchor probe observing an actual captured frame with `headerEventCorpIdPresent`/`bodyCorpIdPresent` — not merely that the probe code exists. | Unset — `resolveDingTalkInteractiveCardStreamConfig()` returns `{ enabled: false }` on the next read, so the client factory is never invoked. **Caveat**: the Stream worker's `initialize()` (`interactive-card-stream.ts` ~L234) resolves this config **once** at call time and does not appear to be re-polled while `active`; an already-running worker needs an explicit `shutdown()`/process restart to actually stop, not just the env flip. |
+| 4 | `DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE` | Confirm deployment topology has >1 replica. Confirm Redis is reachable from **every** replica (`getRedisClient()` resolves non-null on each). Run a login round-trip where the OAuth callback is deliberately routed to a **different** replica than the one that issued the launch `state`, and confirm success. Separately confirm `DingTalkOAuthStateStoreUnavailableError` (503) fires when Redis is down (proves fail-closed, not fail-open, once the flag is on). | Unset — falls back to the in-process `Map`. This is a **fail-open** rollback: on a single-replica deployment it is inert, but reverting it on a still-multi-replica deployment **reintroduces** the state-not-shared risk it exists to close, it does not just "undo a change." |
+| 5 | `DINGTALK_GROUP_DELIVERY_RETENTION_DAYS` family | Determine the longest approval SLA actually configured/observed for this deployment. Confirm `_DAYS` ≥ that SLA with margin. Confirm the sweep is not `_DISABLED=1` (i.e. actually running). Do this **before** flipping switch #3 (interactive cards) on — a short window deletes delivery ledger rows an in-flight card still needs (this is U11-b in the UAT script). | Raise `_DAYS` back above the SLA, or set `_DISABLED=1` to pause the sweep entirely if rows are being deleted prematurely. `_MIN_DAYS`=7 is a hard floor regardless of misconfiguration, so a bad value cannot go to zero/negative. |
+| 6 | `DIRECTORY_SYNC_ALERT_WEBHOOK` (+`_SECRET`) | Configure a valid DingTalk robot URL (an invalid one throws at read time rather than silently no-op'ing) + secret if the robot requires signing. Trigger a deliberate sync failure in a non-prod environment and confirm the alert is delivered to the target DingTalk group. Confirm the send path goes through the existing egress-guarded channel (pinned-egress guard on `send_webhook`/`webhook-service.ts`), not a bypass. | Unset both — the channel silently goes back to "no channel configured" (`unset = off`, matching the code's own documented convention); the sync continues unaffected, only the notification is lost. Inert rollback. |
+
+## 2. Supporting env keys (not one of the six; included so nothing is left unowned)
+
+These were in the same ENV-KEYS inventory that scoped this ledger but are tuning knobs or
+already-adopted allowlists rather than independent safety gates. Listed here — each with an
+owner placeholder — specifically so none of them silently reads as "an unowned default-off."
+
+| Key(s) | Current default (code) | Shipped in a config template? | Ruling |
+| --- | --- | --- | --- |
+| `DIRECTORY_INACTIVE_LINKED_ALERT_DAYS` | **unset = off** (`readDirectoryInactiveLinkedAlertThresholdDays()`, `directory-sync-alert-delivery.ts` ~L349 — a non-positive/non-integer value is treated as unset and logged once, not silently clamped). Gates a best-effort, never-throws informational alert; also requires switch #6 (`DIRECTORY_SYNC_ALERT_WEBHOOK`) to actually deliver. | Not in any template. | **must-verify-enabled** (paired with #6): configure a threshold once #6's delivery channel is verified; until then this is inert (no channel to send through) rather than dangerous. |
+| `DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS`, `DIRECTORY_SYNC_LEASE_STALE_MINUTES` | Heartbeat defaults **60,000 ms**; any value `< 5,000 ms` or non-finite is ignored entirely, not floored (`directory-sync.ts` ~L2795). Lease-stale defaults **10 min**, clamped to at least `5 × heartbeat / 60,000` minutes so a slow beat cannot cause a false reclaim (~L2809). | Not in any template. | **tuning-only** — the defaults are self-protecting (non-clampable to unsafe values) and were not called out by name in the owner's switch rulings. No flip decision needed; keep at code defaults unless a specific multi-replica lease-contention symptom is observed. |
+| `DINGTALK_ALLOWED_CORP_IDS` | **unset = unscoped allowlist** (`readDingTalkAllowedCorpIds()`, `runtime-policy.ts` ~L18 — empty list makes `isDingTalkCorpAllowed` permissive; `isCorpAllowlistConfigured()` gates auto-provisioning specifically on this being non-empty, DT-HARDEN-09). | **In `docker/app.staging.env.example`** (`DINGTALK_ALLOWED_CORP_IDS=replace-me`, ~L43) — **not** in `docker/app.env.example` (the prod template has no DingTalk block at all) or root `.env.example`. | **must-verify-enabled** for any deployment that turns on `DINGTALK_AUTH_AUTO_PROVISION` — an unscoped allowlist + auto-provision is refused by the code itself (DT-HARDEN-09), so this is close to self-enforcing, but the allowlist's *contents* (which corp ids) still need an explicit owner confirmation per deployment. |
+| `DINGTALK_CONTAINER_LOGIN_ENABLED` | **off** (`routes/auth.ts` ~L1329 — unset ⇒ `POST /login/dingtalk/container` 404s with `container_login_disabled`). | **In `docker/app.staging.env.example`** (`DINGTALK_CONTAINER_LOGIN_ENABLED=false`, ~L54) — **not** in `docker/app.env.example` or root `.env.example`. | **explicitly-deferred**, same posture as E1 elsewhere on this line: default off, enable only for a deployment that actually ships the in-container 免登 frontend flow. |
+
+**Correction to the closeout brief's gap analysis**: `DINGTALK_ALLOWED_CORP_IDS` and
+`DINGTALK_CONTAINER_LOGIN_ENABLED` are in `docker/app.staging.env.example`, **not**
+`docker/app.env.example` — verified by direct grep on 2026-07-13; `docker/app.env.example`
+(the prod template, 37 lines) currently has **no** `DINGTALK_*`/`DIRECTORY_*` entries at all.
+That gap (prod template has zero DingTalk config, staging template has partial) is itself
+worth a follow-up, tracked here rather than silently corrected without a note.
+
+## 3. Owner / 负责人 assignment
+
+Every row above needs a named owner before Wave 2 can be called closed. **Placeholder —
+not yet assigned:**
+
+| Switch / family | Owner / 负责人 | Assigned date |
+| --- | --- | --- |
+| `DIRECTORY_DEPROVISION_ENABLED` + `_MAX_BATCH` | _TBD_ | _TBD_ |
+| `DIRECTORY_PRIMARY_DEPT_FROM_ORDER` | _TBD_ | _TBD_ |
+| `DINGTALK_INTERACTIVE_CARD_STREAM_ENABLED` | _TBD_ | _TBD_ |
+| `DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE` | _TBD_ | _TBD_ |
+| `DINGTALK_GROUP_DELIVERY_RETENTION_DAYS` family | _TBD_ | _TBD_ |
+| `DIRECTORY_SYNC_ALERT_WEBHOOK` (+`_SECRET`) | _TBD_ | _TBD_ |
+| `DIRECTORY_INACTIVE_LINKED_ALERT_DAYS` | _TBD_ | _TBD_ |
+| `DIRECTORY_SYNC_HEARTBEAT_INTERVAL_MS` / `_LEASE_STALE_MINUTES` | _TBD_ | _TBD_ |
+| `DINGTALK_ALLOWED_CORP_IDS` | _TBD_ | _TBD_ |
+| `DINGTALK_CONTAINER_LOGIN_ENABLED` | _TBD_ | _TBD_ |
+
+This ledger does not itself close Wave 2 — it makes the decision **shape** explicit
+(default / precondition / evidence / rollback / owner) so the owner ruling, once given per
+row, is a one-line fill-in rather than a re-derivation. No row here is closed until its
+Owner/负责人 cell is filled and, for the must-verify-enabled rows, its evidence has actually
+been captured (see DT-CLOSE-03 for the UAT evidence-pack mechanics that produce that
+evidence for switch #3, and analogous ad hoc capture for #4/#5/#6).
+
+## 4. Cross-references
+
+- Roll-up: `dingtalk-sync-org-transfer-line-design-and-verification-20260712.md` §6/§8
+  (DT-CLOSE-05 errata, 2026-07-13).
+- UAT execution scaffold: `dingtalk-hardening-real-uat-evidence-pack-20260713.md`
+  (DT-CLOSE-03) — produces the evidence switch #3 needs.
+- Corp-anchor real-callback proof tooling: #4171 (merged `663511527`),
+  `interactive-card-callback.ts` `readCallbackCorpAnchor`.
+- DingTalk hardening ticket set (17/17 landed): `attendance-dingtalk-benchmark-tracker.md`.

--- a/docs/development/dingtalk-hardening-v1-runtime-closeout-design-and-verification-20260713.md
+++ b/docs/development/dingtalk-hardening-v1-runtime-closeout-design-and-verification-20260713.md
@@ -1,0 +1,77 @@
+# DingTalk Sync Hardening v1 — Runtime-Closeout Design & Verification
+
+Date: 2026-07-13
+Scope: the closeout of **DingTalk Sync Hardening v1** to a *runtime-closed* state (DT-CLOSE-01…05),
+and the forward plan for the SECOND, separate milestone (Canonical Org & Provider Transfer v1).
+
+## 0. Two milestones — do NOT conflate
+
+Per the owner's judgment, the DingTalk line is **two milestones**, never one "钉钉线收官":
+
+1. **DingTalk Sync Hardening v1** — code basically complete; this document takes it to **运行态收官**
+   (runtime-closeout): observability restored, deploy reproducible, switches owned, UAT scaffolded.
+2. **Canonical Org & Provider Transfer v1** — **design done** (#4215 / #3944 landed), core impl **not
+   started**; its MVP sequencing is a separate plan (see §4). It starts only after milestone 1 closes.
+
+## 1. What runtime-closeout means (why code-complete ≠ closed)
+
+Hardening v1's *code* is on main, but three runtime facts kept it from being closed: the OAuth-stability
+**monitor was blind** (401 on a now-token-gated metrics scrape), the deploy was **not reproducible**
+from templates (the switches the code reads weren't in any `.env` template), and the **switch decisions
++ real UAT** weren't recorded. DT-CLOSE-01…05 close exactly those.
+
+## 2. Deliverables (DT-CLOSE-01…05)
+
+| Ticket | What | PR | State | Model |
+| --- | --- | --- | --- | --- |
+| **DT-CLOSE-01** | Authenticate the OAuth-stability `/metrics/prom` scrape — token resolved on the deploy host (backend-container runtime, secret-safe), `x-metrics-token` header, unauth fallback; contract test that reddens if auth is removed | **#4236** | ✅ **MERGED** `cd1a36428` | me (Opus care — auth) |
+| **DT-CLOSE-02** | DingTalk env contract — every closeout key in `docker/app.env.example` + staging with code-accurate default + DANGER comment; contract test: missing-key → red, dangerous switch shipped ON → red | **#4240** | armed (squash) | Sonnet + Opus gate |
+| **DT-CLOSE-03** | Real-enterprise UAT evidence-pack scaffold — default-off smoke, U1–U13, real-callback corp-anchor, values-free rules | **#4241** | armed (owner/ops executes) | Sonnet |
+| **DT-CLOSE-04** | Switch-ruling ledger — every switch = explicitly-deferred or must-verify-enabled + rollback + owner; no unowned default-off | **#4241** | armed | Sonnet |
+| **DT-CLOSE-05** | Consolidated-MD status errata — #159 CLOSED, #4218/#4228 MERGED, #4176 superseded; reaffirm two-milestone split | **#4241** | armed | Sonnet |
+
+## 3. Verification — VERIFIED vs OWNER/OPS-GATED (kept separate)
+
+### 3.1 VERIFIED (code, this session)
+
+- **DT-CLOSE-01**: `bash -n` clean; contract test 4/4; **auth-mutation reddens** (reverting to the bare
+  scrape fails the test); CI-wired.
+- **DT-CLOSE-02**: contract test 6/6; **two mutations redden** (missing key; dangerous switch shipped
+  `=true`); CI-wired alongside DT-CLOSE-01. Every template default was checked against the code default
+  by the Opus gate.
+- Both lanes passed an independent **Opus adversarial gate** — overall APPROVE, no P1/P2; the one P3
+  (value-drift) is addressed for the dangerous-switch class.
+
+### 3.2 OWNER/OPS-GATED (this environment cannot produce)
+
+| Item | Why not here | Ticket |
+| --- | --- | --- |
+| OAuth-stability "immediate + next scheduled run consecutive success" | needs the live deploy host + secrets | DT-CLOSE-01 (ops step) |
+| Real-enterprise UAT U1–U13 + real-callback corp-anchor (does the callback carry `eventCorpId`/`corpId`?) | needs a deployed SHA + a real DingTalk corp + real people | DT-CLOSE-03 |
+| Each switch flipped to "verified-enabled" | needs the UAT evidence above | DT-CLOSE-04 |
+
+**Switch posture (encoded conservatively, per owner):** deprovision + primary-dept inference + Stream
+stay **OFF** (each with its exact flip-precondition in the ledger); OAuth shared-state **must be ON** on
+multi-replica; retention window **> longest approval SLA**; interactive-card Stream only after U1–U13 all
+green + the #4171 real-callback anchor proof.
+
+## 4. Forward: milestone 2 (design landed, impl gated)
+
+`docs/development/canonical-org-provider-transfer-v1-mvp-implementation-plan-20260713.md` (#4242)
+sequences the landed #4215 / #3944 designs into gated MVP increments — Canonical Org MVP (bootstrap →
+CRUD → normalized manager → binding FK chain → `(org,purpose)` routing → **approval-routing real-DB
+parity first** → suggest-only reconciliation), then Transfer MVP (schema/API → source freeze → two-corp
+proof → single-tx atomic rebind → group rebind/drop → workbench). Feishu/WeCom + full consumer migration
+deferred. **Starts only after Hardening v1 closes.**
+
+## 5. Definition of runtime-closeout DONE (Hardening v1)
+
+- DT-CLOSE-01 merged + the live monitor shows consecutive successful runs (ops).
+- DT-CLOSE-02 merged; a deploy is reproducible from the templates (contract-guarded).
+- DT-CLOSE-03 evidence pack executed against the deployed SHA with U1–U13 + real-callback anchor (owner/ops).
+- DT-CLOSE-04 ledger: every switch owned (verified-enabled or explicitly-deferred), never an unowned default-off.
+- DT-CLOSE-05 docs accurate.
+
+Items 1–2 + the docs are delivered here; items requiring the live host / a real corp are handed to
+owner/ops with the scaffolding to execute them. **Hardening v1 is at runtime-closeout stage — not "all
+done", and explicitly separate from milestone 2.**

--- a/docs/development/dingtalk-sync-org-transfer-line-design-and-verification-20260712.md
+++ b/docs/development/dingtalk-sync-org-transfer-line-design-and-verification-20260712.md
@@ -225,7 +225,7 @@ atomic single-transaction rebind, etc.). Those are acceptance criteria, not resu
 
 ## 8. What remains + who owns it (Wave 0 closed; everything below is Waves 1–5)
 
-- **Wave 1** — ops: deploy-host disk (**#159, CLOSED 2026-07-13** — storage-health recovery
+- **Wave 1** — ops: deploy-host disk (**#159, CLOSED 2026-07-12** — storage-health recovery
   confirmed, the infra blocker is cleared) + a real deploy of the exact main SHA + the
   U1–U13 evidence pack (scaffold ready: DT-CLOSE-03). **The deploy + UAT execution itself is
   still not done** — only its precondition is.

--- a/docs/development/dingtalk-sync-org-transfer-line-design-and-verification-20260712.md
+++ b/docs/development/dingtalk-sync-org-transfer-line-design-and-verification-20260712.md
@@ -18,6 +18,32 @@ lives in (all now **on `main`**):
 - `docs/research/dingtalk-corp-switch-assessment-20260708.md` **(Rev 5)** — the assessment
   (#3941 + post-#4181 errata #4221).
 
+> **Erratum (2026-07-13 — DT-CLOSE-05).** This MD went stale within the same day it landed.
+> Corrections, no history rewrite (pattern per #4221):
+> - **#159** (deploy-host disk) — **CLOSED**. Storage-health recovery confirmed
+>   (`df_used_pct=39`, run `29206256980`). The Wave-1 UAT deploy-host blocker is cleared;
+>   the deploy + U1–U13 evidence-pack execution itself is **still not done** — only its
+>   infra precondition is.
+> - **#4218** (snapshot-protection CI wiring) — **MERGED** `f0ce863ea`. No longer "disarmed,
+>   awaiting an owner decision."
+> - **#4228** (re-enable `views`/`view_states` + snapshot-cluster migrations in all 5 CI
+>   exclude lists — the owner's `MIGRATION_EXCLUDE` ruling, executed as its own PR first,
+>   per this doc's own §3 recommendation) — **MERGED** `4157205ce`.
+> - **#4176** (planning-only investigation of the exclusion cluster) — superseded by
+>   #4228's execution; **recommend close**, no residual action on this line.
+> - Reaffirmed: this line is **two separate milestones** (§1), never described together as
+>   "钉钉线收官" (whole-line done). **DingTalk Sync Hardening v1** (Waves 0–2) has landed
+>   code for every hardening ticket and is now at the **运行态收官** (operational-closeout)
+>   stage — tracked by the **DT-CLOSE-0x** ticket set (this errata is DT-CLOSE-05; see also
+>   DT-CLOSE-03 `dingtalk-hardening-real-uat-evidence-pack-20260713.md` and DT-CLOSE-04
+>   `dingtalk-hardening-switch-ruling-ledger-20260713.md`) — it is **NOT done**.
+>   **Canonical Org & Provider Transfer v1** (Waves 3–4) remains a **separate** milestone:
+>   its design is committed (#4215, #3944 Rev 3) but **core implementation has not
+>   started**. Do not conflate the two.
+>
+> The inline text in §1, §3, and §8 below is also corrected in place, so a partial read does
+> not land on a stale claim either.
+
 ## 0. Honest headline
 
 The DingTalk hardening tickets (17/17 H/OPS/PERF) and their follow-ups are already on
@@ -29,6 +55,13 @@ from real-env UAT onward is owner/ops-gated or depends on a staging proof this e
 cannot produce — it is sequenced here, not force-built. **The product line itself (Waves
 1–5) is NOT done; what is done is Wave 0.**
 
+This still holds after the 2026-07-13 errata above: **DingTalk Sync Hardening v1** (Waves
+0–2) and **Canonical Org & Provider Transfer v1** (Waves 3–4) are tracked and reported as
+**two separate milestones**, and neither is complete. Hardening v1 is code-complete but at
+the **运行态收官** (operational-closeout) stage — Wave 1 real-env UAT and Wave 2 switch
+closeout, tracked as the **DT-CLOSE-0x** ticket set — not "done." Transfer v1 remains
+design-only; core implementation has not started. Never collapse this into "钉钉线收官."
+
 ## 1. Two milestones, six waves
 
 Per owner review (2026-07-12), the line splits into two formal milestones:
@@ -39,7 +72,7 @@ Per owner review (2026-07-12), the line splits into two formal milestones:
 | Wave | Work | Done-gate | State |
 | --- | --- | --- | --- |
 | **0 — stop the bleeding** | fix/disarm **#4181** (corp_id immutable); rebase+merge **#4171** (corp-anchor UAT probe); refresh **#3941** to as-built; revise **#3944 → Rev 3**; commit the local-org plan | no OPEN P1/P2; docs have no dead refs / stale status | ✅ **CLOSED** — all landed with owner APPROVE at each step; real merge SHAs in §3 |
-| 1 — real-env UAT | resolve deploy-host disk (#159); deploy the exact main SHA; run default-off smoke + interactive-card **U1–U13** | a real deploy of current main + evidence pack (time, SHA, result, rollback point) | **owner/ops** — sandbox cannot reach the deploy host |
+| 1 — real-env UAT | ~~resolve deploy-host disk~~ (**#159, CLOSED** — done); deploy the exact main SHA; run default-off smoke + interactive-card **U1–U13** | a real deploy of current main + evidence pack (time, SHA, result, rollback point) | **owner/ops** — sandbox cannot reach the deploy host |
 | 2 — switch closeout | per-switch ruling for deprovision / primary-department / OAuth shared-state / retention / alert-webhook | each switch "verified-enabled" or "explicitly-deferred", never an unowned default-off | **owner** — see §6 |
 | 3 — local org substrate | `provider='local'` integration; editable departments/memberships; external-department binding; explicit routing policy (by org+purpose, not array[0]); normalized manager relation | local department IDs are the stable anchor; DingTalk disappearing does not delete the local org | **design committed** this session; impl gated |
 | 4 — org transfer | transfer/decision tables; source freeze; dry-run; two-corp proof; atomic user rebind; group rebind/drop; admin UI; never a direct corp_id edit | resumable, idempotent, auditable, reversible | **design Rev 3**; impl gated on design merge + staging proof |
@@ -84,11 +117,15 @@ verdict (APPROVE / best-of-both ruling / CHANGES_REQUESTED→fix→land):
 
 **Process note (for the record):** two Claude sessions worked this line in parallel and
 collided on #3941/#3944. Neither clobbered the other; the owner ruled best-of-both, which is
-what merged. The one Wave-0-adjacent item still open is the **snapshot-protection CI wiring
-(#4218)** — disarmed, blocked on an owner decision about the CI test-DB's
-`MIGRATION_EXCLUDE` (the suite needs `snapshots.tags` / `protection_rules` /
-`change_management` tables whose migrations that DB skips); it belongs to the security line,
-not this one.
+what merged. The one Wave-0-adjacent item that was still open, **snapshot-protection CI
+wiring (#4218)**, is now resolved (2026-07-13 errata, DT-CLOSE-05): the owner's
+`MIGRATION_EXCLUDE` decision landed as its own verified PR first — **#4228** (`4157205ce`)
+re-enabled the `views` / `view_states` + snapshot-cluster migrations in all 5 CI exclude
+lists — and then **#4218** (`f0ce863ea`) merged, wiring the snapshot-protection E2E into the
+Node 20 real-DB lane and closing the false-green (21/21 positive control). **#4176** (the
+planning-only investigation issue for the exclusion cluster) is superseded by #4228's
+execution and is recommended for closure. This item belonged to the security line, not this
+one, and is recorded here only because it was Wave-0-adjacent.
 
 ## 4. Design — the three-layer model
 
@@ -146,7 +183,7 @@ set and same-corp resend pass; a genuine org change must go through the Wave 4 t
 
 | Item | Why not verified now |
 | --- | --- |
-| Real-env UAT U1–U13 (Wave 1) | needs a real deploy of the exact main SHA on the deploy host; sandbox cannot reach it |
+| Real-env UAT U1–U13 (Wave 1) | needs a real deploy of the exact main SHA on the deploy host; sandbox cannot reach it — execution scaffold: `dingtalk-hardening-real-uat-evidence-pack-20260713.md` (DT-CLOSE-03, blank until owner/ops fills it in) |
 | Two-corp coexistence proof (Wave 4 gate) | needs a staging env + two real DingTalk corps; the DB-level collision *mechanism* can be shown, the production proof cannot |
 | Local-org substrate tests (Wave 3) | substrate not built; test matrix specified in the local-org plan §13 |
 | Transfer engine tests (Wave 4) | engine not built; test outlines in the transfer plan §9.4/§10.4 |
@@ -157,6 +194,10 @@ increment must produce (real-DB parity, archive-not-delete, stale-binding-not-in
 atomic single-transaction rebind, etc.). Those are acceptance criteria, not results.
 
 ## 6. Switch decisions (owner guidance — all still owner-gated)
+
+> Full ledger with current default, evidence-required-to-flip, rollback action and an
+> owner/负责人 placeholder per switch: `dingtalk-hardening-switch-ruling-ledger-20260713.md`
+> (DT-CLOSE-04). The summary below is unchanged; the ledger is the executable version.
 
 - `DIRECTORY_DEPROVISION_ENABLED` — stays **off** until audited reactivation/rollback +
   real-data preview + a small canary.
@@ -184,16 +225,20 @@ atomic single-transaction rebind, etc.). Those are acceptance criteria, not resu
 
 ## 8. What remains + who owns it (Wave 0 closed; everything below is Waves 1–5)
 
-- **Wave 1** — ops: deploy-host disk (#159) + a real deploy of the exact main SHA + the
-  U1–U13 evidence pack.
+- **Wave 1** — ops: deploy-host disk (**#159, CLOSED 2026-07-13** — storage-health recovery
+  confirmed, the infra blocker is cleared) + a real deploy of the exact main SHA + the
+  U1–U13 evidence pack (scaffold ready: DT-CLOSE-03). **The deploy + UAT execution itself is
+  still not done** — only its precondition is.
 - **Wave 2** — owner: resolve each switch in §6 to "verified-enabled" or
-  "explicitly-deferred".
+  "explicitly-deferred" (ledger ready: DT-CLOSE-04).
 - **Wave 3** — a per-phase go to start the local-org substrate impl; the design (#4215) is
   landed and its three schema questions are resolved.
 - **Wave 4** — gated on the Wave 3 substrate + the staging two-corp coexistence proof; the
   design (#3944 Rev 3) is landed.
 - **Wave 5** — only on a named second-provider customer case.
-- **#4218 (snapshot-protection CI wiring; security line)** — disarmed, awaiting the owner's
-  ruling on the CI test-DB `MIGRATION_EXCLUDE` (un-exclude the 3 snapshot/protection/
-  change-management migrations inside #4218, or land the un-exclusion as its own verified
-  PR first).
+- **#4218 (snapshot-protection CI wiring; security line) — MERGED** `f0ce863ea`. **#4228**
+  (the owner's `MIGRATION_EXCLUDE` ruling — re-enable `views`/`view_states` +
+  snapshot-cluster migrations in all 5 CI exclude lists) — **MERGED** `4157205ce`, landed as
+  its own verified PR first, exactly as this doc originally recommended. False-green closed,
+  21/21 positive control. **#4176** (the planning-only version of the same investigation) is
+  superseded and **recommended for closure** — no residual action on this line.


### PR DESCRIPTION
## DT-CLOSE-03/04/05 — DingTalk Hardening v1 closeout docs

Docs-only. Three deliverables closing the paperwork side of **DingTalk Sync Hardening v1** (kept distinct from the second milestone, Canonical Org & Provider Transfer v1).

- **DT-CLOSE-05 (errata)** — `dingtalk-sync-org-transfer-line-design-and-verification-20260712.md`: fixes stale status — #159 CLOSED (2026-07-12), #4218 + #4228 MERGED (snapshot false-green closed, 21/21 positive control), #4176 superseded by #4228; reaffirms the **two-milestone split** and that Hardening v1 is at 运行态收官 stage (DT-CLOSE tickets), **not done**.
- **DT-CLOSE-04 (switch ledger)** — `dingtalk-hardening-switch-ruling-ledger-20260713.md`: every switch = *explicitly-deferred* (deprovision, primary-dept, Stream — with the exact precondition to flip) or *must-verify-enabled* (OAuth shared-state on multi-replica, retention > SLA, directory alert webhook), each with current default, owner ruling, evidence-to-flip, rollback, and owner placeholder. **No unowned default-off.**
- **DT-CLOSE-03 (UAT scaffold)** — `dingtalk-hardening-real-uat-evidence-pack-20260713.md`: an owner/ops-executed checklist against the deployed SHA — default-off smoke, U1–U13, the real-callback corp-anchor test (does the real DingTalk callback carry `eventCorpId`/`corpId`? — what #4171's probe can observe but not prove alone), values-free evidence rules. **Execution is owner/ops** (sandbox can't reach a real corp).

Honesty rules held: no doc claims UAT is done or a switch is verified-enabled without evidence; the two milestones stay separate. Adversarially gated (Opus): APPROVE, NITs (date, cosmetic) addressed.
