### PR TITLE
test(multitable): OD-6 revision-disposition guard — every meta_records write declares its disposition (D-1c final rung; scanner hardened)

### DIFF
--- a/packages/core-backend/src/multitable/approval-record-projection-service.ts
+++ b/packages/core-backend/src/multitable/approval-record-projection-service.ts
@@ -219,6 +219,8 @@ export class ApprovalRecordProjectionService {
       await this.ensureSystemBase(client)
       await this.ensureFamilySheet(client, sheetId, instance.templateId, instance.templateName)
 
+      // revision-exempt: derived read-model projection into the system approval base, regenerable by
+      // sweep()/reconcile(); authoritative history lives in the approval domain (OD-6 owner ruling).
       await client.query(
         `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)
          VALUES ($1, $2, $3::jsonb, 1, $4, $4)

--- a/packages/core-backend/src/multitable/auto-number-service.ts
+++ b/packages/core-backend/src/multitable/auto-number-service.ts
@@ -97,6 +97,7 @@ export async function backfillAutoNumberField(
   // SELECT ... FOR UPDATE is required.
   const overwrite = opts?.overwrite === true
   // lock-exempt: system auto-number backfill — system-derived sequence value, no user actor.
+  // revision-exempt: auto-number backfill, no version bump — system-derived sequence value under advisory lock.
   const updated = await query(
     `UPDATE meta_records mr
      SET data = jsonb_set(

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -2226,6 +2226,7 @@ export class AutomationExecutor {
         // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
         // update is rejected before this UPDATE unless claim==truth + trigger-actor base-write.
         // lock-guarded: automation update_record (B1) — ensureRecordNotLocked enforced just above.
+        // revision-emitted: D-1c slice ③ (A3) — recordRecordRevision(action:'update') @2258.
         const updateRes = await query(
           `UPDATE meta_records
            SET data = COALESCE(data, '{}'::jsonb) || $1::jsonb,
@@ -2455,6 +2456,7 @@ export class AutomationExecutor {
         // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
         // delete is rejected before this DELETE unless claim==truth + trigger-actor base-write.
         // lock-guarded: automation delete_record (C2a) — ensureRecordNotLocked enforced just above.
+        // revision-emitted: automation delete_record, D-1 — recordRecordRevision(action:'delete') @2365.
         await query(
           'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2',
           [effectiveRecordId, effectiveSheetId],
@@ -2530,7 +2532,7 @@ export class AutomationExecutor {
       // neither of which added one).
       // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
       // create is rejected before this INSERT unless claim==truth + trigger-actor base-write. This is
-      // the §1.3 create-to-another-base vector the gate closes.
+      // the §1.3 create-to-another-base vector the gate closes. revision-emitted: D-1c slice ③ (A4) — recordRecordRevision(action:'create') below, same txn.
       await this.withTransaction(async (query) => {
         await query(
           `INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1, $2, $3::jsonb, 1)`,
@@ -3485,6 +3487,7 @@ export class AutomationExecutor {
         // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — same-base uses the gate's
         // fast-path (byte-identical to pre-C2); a cross-base lock is rejected unless claim==truth + base-write.
         // lock-mgmt: LOCK action — sets the lock columns themselves (not a data edit of a locked row).
+        // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
         await this.deps.queryFn(
           `UPDATE meta_records
            SET locked = true, locked_by = $1, locked_at = NOW(), version = version + 1, updated_at = NOW()
@@ -3495,6 +3498,7 @@ export class AutomationExecutor {
         // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — same-base fast-path keeps
         // this byte-identical to pre-C2; a cross-base unlock is rejected unless claim==truth + base-write.
         // lock-mgmt: UNLOCK action — clears the lock columns (decision f: automation may unlock).
+        // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
         await this.deps.queryFn(
           `UPDATE meta_records
            SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -2860,8 +2860,8 @@ export class AutomationService {
         return false // record gone — the caller's missing-record path already handled it
       }
       ensureRecordNotLocked(opts.lockActorId, lockRow, () => new Error(opts.lockedMessage))
-      // lock-guarded: resultWriteback patch — ensureRecordNotLocked (opts.lockActorId = the trigger actor
-      // for a cross-base target) is enforced immediately above; a locked target throws → rolls back (§ note).
+      // lock-guarded: resultWriteback patch — ensureRecordNotLocked (opts.lockActorId, the trigger actor for a cross-base target) enforced immediately above; a locked target throws and rolls back.
+      // revision-emitted: D-1c slice ④ (A7 approval resultWriteback) — recordRecordRevision below, same txn.
       const updateRes = await query(
         `UPDATE meta_records
          SET data = COALESCE(data, '{}'::jsonb) || $1::jsonb, version = version + 1, updated_at = NOW()

--- a/packages/core-backend/src/multitable/formula-engine.ts
+++ b/packages/core-backend/src/multitable/formula-engine.ts
@@ -341,6 +341,7 @@ export class MultitableFormulaEngine {
       // write to other fields between this SELECT and UPDATE is not clobbered. No
       // version bump: formula values are derived, not an authoritative user edit.
       // lock-exempt: system formula materialization — derived value, no user actor (lock = read-only to USERS).
+      // revision-exempt: derived formula materialization, no version bump — pure fn of inputs, recompute-on-read.
       await query(
         `UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3`,
         [JSON.stringify(updates), recordId, sheetId],

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -675,6 +675,7 @@ export class RecordService {
         type: field.type,
         property: field.property,
       }))))
+      // revision-emitted: REST createRecord — recordRecordRevision(action:'create') below, same txn.
       const inserted = await query(
         `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)
          VALUES ($1, $2, $3::jsonb, 1, $4, $4)
@@ -889,6 +890,7 @@ export class RecordService {
       }
 
       // lock-guarded: single DELETE — ensureRecordNotLocked enforced above (rejects before this txn).
+      // revision-emitted: REST deleteRecord — recordRecordRevision(action:'delete') below, same txn.
       await query('DELETE FROM meta_records WHERE id = $1', [recordId])
 
       // OAPI-2b §6: committed token-delete audit INSIDE the (soft-)delete txn (fail-closed). No-op for session.
@@ -1083,6 +1085,7 @@ export class RecordService {
       }
       let inserted: { rows: Array<{ version?: number }> }
       try {
+        // revision-emitted: trash restore — recordRecordRevision(action:'create', source:'restore') below.
         inserted = await query(
           `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by, created_at, updated_at)
            VALUES ($1, $2, $3::jsonb, 1, $4, $5, COALESCE($6, now()), COALESCE($7, now()))
@@ -1381,6 +1384,7 @@ export class RecordService {
 
       if (Object.keys(patch).length > 0) {
         // lock-guarded: single PATCH — ensureRecordNotLocked enforced above in this txn.
+        // revision-emitted: REST patchRecord — recordRecordRevision(action:'update') below, same txn.
         const updateRes = await query(
           `UPDATE meta_records
            SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -967,6 +967,7 @@ export class RecordWriteService {
         // template below carries its own adjacent lock-guarded marker for the RANK-8 structural scanner.
         const updateRes = unsetIds.length > 0
           // lock-guarded: ensureRecordNotLocked enforced per record above (unset+set path)
+          // revision-emitted: bulk PATCH unset+set — recordRecordRevision(action:'update') @998.
           ? await query(
               `UPDATE meta_records
                SET data = (data - $5::text[]) || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
@@ -975,6 +976,7 @@ export class RecordWriteService {
               [JSON.stringify(patch), sheetId, recordId, actorId, unsetIds],
             )
           // lock-guarded: ensureRecordNotLocked enforced per record above (set-only path)
+          // revision-emitted: bulk PATCH set-only — recordRecordRevision(action:'update') @998.
           : await query(
               `UPDATE meta_records
                SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4

--- a/packages/core-backend/src/multitable/records.ts
+++ b/packages/core-backend/src/multitable/records.ts
@@ -503,6 +503,7 @@ export async function patchRecord(
   }
 
   // lock-guarded: plugin-SDK patchRecord (M1) — guardRecordNotLockedForPlugin(actor=null) rejected above.
+  // revision-emitted: D-1c slice ② (A2) — recordRecordRevision(action:'update', source:'plugin') @559.
   const updated = await query(
     `UPDATE meta_records
      SET data = $1::jsonb, version = version + 1, updated_at = now()
@@ -594,6 +595,7 @@ export async function createRecord(
   }))))
 
   const recordId = `rec_${randomUUID()}`
+  // revision-emitted: D-1c slice ② (A5) — recordRecordRevision(action:'create', source:'plugin') @628.
   const inserted = await query(
     `INSERT INTO meta_records (id, sheet_id, data, version)
      VALUES ($1, $2, $3::jsonb, 1)
@@ -763,6 +765,7 @@ async function deleteRecordWithRecoverability(
   // before EITHER branch is dispatched, so this DELETE carries the identical lock disposition as the
   // flag-off one below.
   // lock-guarded: plugin-SDK deleteRecord, D-2 flag-on path (M1) — guarded in `deleteRecord` above.
+  // revision-emitted: plugin delete, D-2 flag-on — recordRecordRevision(action:'delete') @650.
   const deleted = await query(
     `DELETE FROM meta_records
      WHERE id = $1 AND sheet_id = $2
@@ -834,6 +837,7 @@ export async function deleteRecord(
   await query('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1', [input.recordId])
 
   // lock-guarded: plugin-SDK deleteRecord (M1) — guardRecordNotLockedForPlugin(actor=null) rejected above.
+  // revision-emitted: plugin delete, D-1 flag-off — recordRecordRevision(action:'delete') @771.
   const deleted = await query(
     `DELETE FROM meta_records
      WHERE id = $1 AND sheet_id = $2

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2957,6 +2957,7 @@ async function recalculateFormulaFields(
         }
         if (Object.keys(updates).length > 0) {
           // lock-exempt: system relation-aggregation materialization — derived value, no user actor (same posture as recalculateRecordFromData; a record lock is read-only to users, not system recompute).
+          // revision-exempt: relation-aggregation same-record materialization, no version bump — derived value.
           await query(
             'UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3',
             [JSON.stringify(updates), recordId, sheetId],
@@ -3853,6 +3854,7 @@ async function computeDependentLookupRollupRecords(
         }
         if (Object.keys(updates).length > 0) {
           // lock-exempt: system relation-aggregation fan-out materialization — derived value, no user actor (same posture as the same-record recompute write).
+          // revision-exempt: relation-aggregation fan-out materialization, no version bump — derived value.
           await query('UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3', [JSON.stringify(updates), recordId, sheetId])
           formulaDataByRecord.set(recordId, { ...(formulaDataByRecord.get(recordId) ?? {}), ...updates })
         }
@@ -5170,6 +5172,7 @@ async function ensurePeopleSheetPreset(query: QueryFn, baseId: string): Promise<
       }
       const existing = recordByUserId.get(user.id)
       if (!existing) {
+        // revision-exempt: internal people-directory sync (INSERT) — system sheet, mirror of `users`, regenerable.
         await query(
           `INSERT INTO meta_records (id, sheet_id, data, version)
            VALUES ($1, $2, $3::jsonb, 1)`,
@@ -5186,6 +5189,7 @@ async function ensurePeopleSheetPreset(query: QueryFn, baseId: string): Promise<
 
       if (changed) {
         // lock-exempt: internal people-directory sync — system sheet, not a user-facing record edit path.
+        // revision-exempt: internal people-directory sync (UPDATE) — system sheet, not a user-content edit.
         await query(
           `UPDATE meta_records
            SET data = $1::jsonb, version = version + 1, updated_at = now()
@@ -5804,6 +5808,8 @@ async function createSeededSheet(args: { sheetId: string; name: string; descript
     }
 
     for (const record of records) {
+      // revision-exempt: createSeededSheet template scaffold — hardcoded demo preset at sheet birth, not
+      // caller/user content (OD-6 §7a Bucket C).
       await query(
         `INSERT INTO meta_records (id, sheet_id, data, version)
          VALUES ($1, $2, $3::jsonb, $4)
@@ -6149,6 +6155,8 @@ async function dropFieldCascade(query: TxnQuery, opts: {
     if (!isUndefinedTableError(err, 'meta_links')) throw err
   }
   // lock-exempt: field-delete schema op — drops the deleted field's key sheet-wide; not a per-record user edit.
+  // revision-exempt: field-delete column strip — captured on the config channel (recordConfigRevision
+  // field/delete) + value/link tombstones, no per-record version bump (OD-6 §7a Bucket C).
   await query('UPDATE meta_records SET data = data - $1 WHERE sheet_id = $2', [fieldId, sheetId])
   const shiftedDel = ((await query('UPDATE meta_fields SET "order" = "order" - 1 WHERE sheet_id = $1 AND "order" > $2 RETURNING id, "order"', [sheetId, order])) as any).rows as Array<{ id: string; order: number }>
   await recordFieldOrderShifts(query, sheetId, shiftedDel.map((r) => ({ id: String(r.id), newOrder: Number(r.order) })), -1, configBatchId, actorId)
@@ -6424,8 +6432,8 @@ async function applyLossyRetypeCellRewrite(query: TxnQuery, opts: {
   // and `jsonb_set(data, path, NULL)` returns NULL for the WHOLE `data` column — a dropped cell would wipe the record.
   // A single batched statement (never a per-row round trip), matching the tombstone-capture module's discipline.
   const payload = changed.map((c) => ({ record_id: c.recordId, value: c.after ?? null }))
-  // lock-exempt: 4c-1 lossy retype revert — schema op rewriting the reverted field's key sheet-wide under the
-  // config-restore canManageFields gate (mirrors the field-delete column strip / field-undelete rehydration);
+  // lock-exempt: 4c-1 lossy retype revert — schema op rewriting the reverted field's key sheet-wide under the config-restore canManageFields gate (mirrors the field-delete column strip / field-undelete rehydration).
+  // revision-emitted: C5 history completeness — recordRecordRevision (one per changed cell) below, same txn.
   const rewritten = (await query(
     `UPDATE meta_records AS m
      SET data = jsonb_set(m.data, ARRAY[$2::text], COALESCE(item.value, 'null'::jsonb), true),
@@ -6516,8 +6524,15 @@ async function recreateFieldFromConfig(query: TxnQuery, opts: {
     // Values: only into records that do NOT already carry this key (never overwrite a value written after
     // this recreate — the recreate above just happened in THIS same transaction, so the only way a record
     // could already have the key is a value legitimately written since — this WHERE clause is the guard).
-    // lock-exempt: field-undelete schema op — rehydrates the recreated field's key sheet-wide (mirror of
-    // the field-delete drop at ~6116); not a per-record user edit, and NOT(data?key) never clobbers.
+    // OD-6 owner ruling (design-lock §0.5 row OD-6, 2026-07-13): this site MUST WRITE REVISION — the audit
+    // had flagged it debatable-EXEMPT (Bucket D), owner overrode to MUST-WRITE. NOT YET IMPLEMENTED: this
+    // UPDATE rehydrates real user cell values from tombstones (`data = data || jsonb_build_object(...)`)
+    // but bumps no `version` and calls no `recordRecordRevision` — the exact fingerprint of the bug class
+    // this guard exists to catch. Out of scope for D-1c's five slices (A1-A8 — this is a field-op, not one
+    // of the eight); tracked as an explicit, named, non-silent gap, NOT a silent exemption — see
+    // KNOWN_REVISION_GAPS in multitable-revision-disposition-guard.guard.test.ts, pending its own rung.
+    // lock-exempt: field-undelete schema op — rehydrates the recreated field's key sheet-wide (mirror of the field-delete drop at ~6116); not a per-record user edit, and NOT(data?key) never clobbers (lock disposition only — see revision-pending below for the SEPARATE, still-open revision disposition).
+    // revision-pending: OD-6 owner-ruled MUST-WRITE, not yet implemented — tracked in KNOWN_REVISION_GAPS.
     await query(
       `UPDATE meta_records m
        SET data = data || jsonb_build_object($3::text, t.value)
@@ -10195,6 +10210,7 @@ export function univerMetaRouter(): Router {
               const occupied = await query('SELECT 1 FROM meta_records WHERE id = $1 FOR UPDATE', [r.recordId])
               if ((occupied.rows as unknown[]).length > 0) throw new RecordServiceRestoreConflictError(`Record id is occupied, cannot undelete: ${r.recordId}`)
               try {
+                // revision-emitted: PIT resurrect — recordRecordRevision(action:'create') below, same txn.
                 await query('INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by, created_at, updated_at) VALUES ($1, $2, $3::jsonb, 1, $4, $4, now(), now())', [r.recordId, sheetId, JSON.stringify(r.snapshot), undeleteActorId])
               } catch (e) {
                 if ((e as { code?: string })?.code === '23505') throw new RecordServiceRestoreConflictError(`Record id is occupied, cannot undelete: ${r.recordId}`)
@@ -10425,6 +10441,7 @@ export function univerMetaRouter(): Router {
             }
             const updateRes = unsetIds.length > 0
               // lock-guarded: PIT Reset reverts in one transaction after ensureRecordNotLocked above.
+              // revision-emitted: PIT reset revert unset+set — recordRecordRevision below, same txn.
               ? await query(
                   `UPDATE meta_records
                      SET data = (data - $5::text[]) || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
@@ -10433,6 +10450,7 @@ export function univerMetaRouter(): Router {
                   [JSON.stringify(patch), sheetId, candidate.recordId, actorId, unsetIds],
                 )
               // lock-guarded: PIT Reset reverts in one transaction after ensureRecordNotLocked above.
+              // revision-emitted: PIT reset revert set-only — recordRecordRevision below, same txn.
               : await query(
                   `UPDATE meta_records
                      SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
@@ -10559,6 +10577,7 @@ export function univerMetaRouter(): Router {
               )
             }
             // lock-guarded: PIT Reset deletes in the same transaction after ensureRecordNotLocked above.
+            // revision-emitted: PIT reset delete — recordRecordRevision(action:'delete') below, same txn.
             await query('DELETE FROM meta_records WHERE sheet_id = $1 AND id = $2', [sheetId, candidate.recordId])
             deletedRecordIds.push(candidate.recordId)
           }
@@ -14453,6 +14472,7 @@ export function univerMetaRouter(): Router {
 
           if (Object.keys(patch).length > 0) {
             // lock-guarded: form-submit EDIT (B2) — ensureRecordNotLocked enforced just above.
+            // revision-emitted: D-1c slice ① (A1) — recordRecordRevision(action:'update', source:'public-form') below.
             const updateRes = await query(
               `UPDATE meta_records
                SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
@@ -14540,6 +14560,7 @@ export function univerMetaRouter(): Router {
         Object.assign(patch, await allocateAutoNumberValues(query, view.sheetId, latestFields))
 
         const createActorId = effectivePublicAccessAllowed && !access.userId ? null : getRequestActorId(req)
+        // revision-emitted: D-1c slice ① (A6) — recordRecordRevision(action:'create', source:'public-form') below.
         const insertRes = await query(
           `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)
            VALUES ($1, $2, $3::jsonb, 1, $4, $4)
@@ -15787,6 +15808,7 @@ export function univerMetaRouter(): Router {
             const nextIds = currentIds.filter((id) => id !== attachmentId)
             if (nextIds.length !== currentIds.length) {
               // lock-guarded: attachment-delete record edit (B3) — ensureRecordNotLocked enforced before this txn.
+              // revision-emitted: D-1c slice ⑤ (A8) — recordRecordRevision(action:'update', source:'attachment') below.
               const updateRes = await query(
                 `UPDATE meta_records
                  SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
@@ -16399,6 +16421,7 @@ export function univerMetaRouter(): Router {
         }
         const lockedBy = actorId ?? access.userId
         // lock-mgmt: LOCK action — sets the lock columns (own canEditRecord authority above).
+        // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
         await pool.query(
           `UPDATE meta_records SET locked = true, locked_by = $2, locked_at = NOW(), version = version + 1, updated_at = NOW()
            WHERE id = $1 AND sheet_id = $3`,
@@ -16413,6 +16436,7 @@ export function univerMetaRouter(): Router {
           return sendForbidden(res, 'Not allowed to unlock this record')
         }
         // lock-mgmt: UNLOCK action — clears the lock columns (own canUnlock authority above).
+        // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
         await pool.query(
           `UPDATE meta_records SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()
            WHERE id = $1 AND sheet_id = $2`,

--- a/packages/core-backend/tests/unit/lib/multitable-revision-disposition-scanner.ts
+++ b/packages/core-backend/tests/unit/lib/multitable-revision-disposition-scanner.ts
@@ -1,0 +1,280 @@
+/**
+ * OD-6 revision-disposition guard — scanner core.
+ *
+ * Pure, file-I/O-free functions so the defeat-then-fix proofs (see
+ * `multitable-revision-disposition-scanner.test.ts`) can feed synthetic source strings directly,
+ * without ever touching a real tracked file on disk.
+ *
+ * Supersedes the #4227 draft's line-by-line, case-sensitive scanner. Two proven blockers fixed here:
+ *
+ *   1. CASE-INSENSITIVE + MULTILINE. The #4227 scanner tested `MUTATION_RE` against ONE LINE AT A TIME
+ *      with no `i` flag. A live-guard mutation proved: an unmarked UPPERCASE `UPDATE meta_records` reds
+ *      the guard, but the LOWERCASE twin passes undetected, and a verb/table split across two lines
+ *      (`UPDATE\n  meta_records`) is invisible to a per-line test. This scanner instead comment-strips
+ *      the WHOLE FILE (preserving every character's line position — see `stripComments`), then runs one
+ *      case-insensitive, `\s+`-tolerant regex over the whole text with `matchAll`. `\s` already matches
+ *      `\n`, so a verb and `meta_records` on separate lines still match one statement.
+ *
+ *   2. STABLE SITE IDS, NOT LINE NUMBERS. The #4227 scanner keyed its `PENDING_REVISION_SITES` allowlist
+ *      by literal `(file, line)`, so ANY edit above a pending site silently drifted its line number and
+ *      broke the allowlist. This scanner instead hashes `(file, enclosing-anchor, statement fingerprint,
+ *      occurrence-index)` — content the edit doesn't touch — into a `siteId` that survives unrelated
+ *      edits above it (proven by `scanner.stability.test.ts`'s "insert 3 lines above, siteId unchanged").
+ */
+import { createHash } from 'node:crypto'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+export type Disposition = 'EMITTED' | 'EXEMPT' | 'PENDING'
+
+export interface Site {
+  file: string
+  /** 1-based line where the mutation VERB (INSERT/UPDATE/DELETE) starts. */
+  line: number
+  /** The matched line's trimmed text, for readable failure messages. */
+  sql: string
+  disposition: Disposition | null
+  /** Nearest enclosing function/route name — see `findEnclosingAnchor`. Debug/readability aid only. */
+  anchor: string
+  /** Stable content hash — see module docstring point 2. */
+  siteId: string
+}
+
+/** How many physical lines ABOVE (through) the statement's start line a marker may sit. Mirrors the
+ *  rank-8 lock guard's own `MARKER_WINDOW` exactly (`multitable-record-lock-guard.guard.test.ts:74`),
+ *  so a marker legal for one guard is legal for the other and a contributor learns one convention. */
+export const MARKER_WINDOW = 3
+
+/**
+ * Every form a `meta_records` row-mutation can take in this codebase: raw SQL (case-insensitive, verb
+ * and table name may be split across lines by `\s+`) and the Kysely query-builder forms, added
+ * pre-emptively exactly as the rank-8 guard does for its own MUTATION_RE.
+ */
+export const MUTATION_RE =
+  /\b(?:INSERT\s+INTO\s+meta_records|UPDATE\s+meta_records|DELETE\s+FROM\s+meta_records)\b|(?:updateTable|deleteFrom|insertInto)\(\s*['"`]meta_records['"`]/gi
+
+/**
+ * Replace every `//...` and `/* ... *\/` comment with equal-length whitespace (newlines preserved, so
+ * line numbers computed on the result exactly match the original source) while leaving string/template
+ * literal CONTENTS untouched byte-for-byte — the SQL text the guard needs to see lives inside backtick
+ * template literals, so stripping comments must never touch quoted content. A single left-to-right state
+ * machine (not two independent regex passes) so a `//` inside a string is never mistaken for a comment
+ * start, and a comment-only mention of `UPDATE meta_records` (e.g. in a docstring) can never register as
+ * a mutation site.
+ */
+export function stripComments(src: string): string {
+  let out = ''
+  let i = 0
+  const n = src.length
+  while (i < n) {
+    const c = src[i]
+    const c2 = i + 1 < n ? src[i + 1] : ''
+    if (c === '/' && c2 === '/') {
+      while (i < n && src[i] !== '\n') {
+        out += ' '
+        i += 1
+      }
+      continue
+    }
+    if (c === '/' && c2 === '*') {
+      out += '  '
+      i += 2
+      while (i < n && !(src[i] === '*' && src[i + 1] === '/')) {
+        out += src[i] === '\n' ? '\n' : ' '
+        i += 1
+      }
+      if (i < n) {
+        out += '  '
+        i += 2
+      }
+      continue
+    }
+    if (c === "'" || c === '"' || c === '`') {
+      const quote = c
+      out += c
+      i += 1
+      while (i < n && src[i] !== quote) {
+        if (src[i] === '\\' && i + 1 < n) {
+          out += src[i] + src[i + 1]
+          i += 2
+          continue
+        }
+        out += src[i]
+        i += 1
+      }
+      if (i < n) {
+        out += src[i]
+        i += 1
+      }
+      continue
+    }
+    out += c
+    i += 1
+  }
+  return out
+}
+
+function computeLineStarts(text: string): number[] {
+  const starts = [0]
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === '\n') starts.push(i + 1)
+  }
+  return starts
+}
+
+/** 0-based line index containing character offset `offset`, via binary search over line-start offsets. */
+function lineIndexForOffset(lineStarts: number[], offset: number): number {
+  let lo = 0
+  let hi = lineStarts.length - 1
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2)
+    if (lineStarts[mid] <= offset) lo = mid
+    else hi = mid - 1
+  }
+  return lo
+}
+
+/**
+ * `window` is always a slice of RAW source lines (never comment-stripped), so a marker mid-sentence
+ * inside an existing `//` comment block still counts — this deliberately does NOT require `revision-
+ * emitted:` to be the first token after `//`. That flexibility is load-bearing in this codebase: several
+ * mutation sites already carry an adjacent marker from ANOTHER structural guard (rank-8's `lock-guarded:`
+ * / the cross-base write guard's `xbase-write-gated:`) sitting at or near that guard's own window
+ * boundary — adding a brand-new physical line here would push THAT marker outside ITS window and
+ * regress a different guard (this exact collision, and its fix, is documented at
+ * `automation-executor.ts` around the `executeCreateRecord` INSERT: the revision-emitted marker is
+ * appended to the end of the existing `xbase-write-gated:` comment's last physical line rather than
+ * added as a new line). Requiring the marker to start a comment would forbid that safe co-location.
+ */
+function classify(window: string): Disposition | null {
+  if (/revision-emitted:/.test(window)) return 'EMITTED'
+  if (/revision-exempt:/.test(window)) return 'EXEMPT'
+  if (/revision-pending:/.test(window)) return 'PENDING'
+  return null
+}
+
+/**
+ * Nearest enclosing anchor for a mutation site, scanning UPWARD from its own line over the
+ * comment-stripped text. Not a real parser (no brace-depth tracking) — a heuristic "nearest declaration
+ * line above" — but that is enough for the stability property this scanner needs: the anchor only
+ * changes when a contributor edits content genuinely between the site and its true enclosing
+ * declaration, which is a categorically rarer event than "any edit anywhere above the file" (the failure
+ * mode `siteId` exists to survive). Route handlers (`router.post('/path', async (req,res) => {...})`)
+ * are anonymous, so they fall back to a `route:<method>:<path>` anchor instead of a function name.
+ */
+const ANCHOR_PATTERNS: RegExp[] = [
+  /^\s*(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(/,
+  /^\s*(?:export\s+)?const\s+(\w+)\s*=\s*async\s+function\b/,
+  // Arrow-function assignment ONLY — requires a `=>` on the same line, so a plain parenthesized
+  // non-function expression (`const targetSheetId = (a ?? b)`) is not mistaken for a function anchor.
+  /^\s*(?:export\s+)?const\s+(\w+)\s*=\s*(?:async\s*)?\([^)]*\)\s*(?::\s*[^=]+)?=>/,
+  /router\.(get|post|put|patch|delete)\(\s*['"`]([^'"`]+)['"`]/,
+  // Class/object method `name(args) {` — excludes JS/TS control-flow keywords that share this shape
+  // (`if (...) {`, `for (...) {`, `while (...) {`, `switch (...) {`, `catch (...) {`) so a mutation
+  // inside a conditional does not get anchored to the meaningless literal name "if"/"for".
+  /^\s*(?:private\s+|public\s+|protected\s+|static\s+|async\s+)*(?!if\b|for\b|while\b|switch\b|catch\b|function\b|else\b|return\b|do\b)(\w+)\s*\([^()]*\)\s*(?::\s*[^{]+)?\{\s*$/,
+]
+
+export function findEnclosingAnchor(strippedLines: string[], matchLineIdx: number): string {
+  for (let i = matchLineIdx; i >= 0; i -= 1) {
+    const line = strippedLines[i]
+    for (const re of ANCHOR_PATTERNS) {
+      re.lastIndex = 0
+      const m = re.exec(line)
+      if (!m) continue
+      if (m.length >= 3 && m[2]) return `route:${m[1]}:${m[2]}`
+      if (m[1]) return m[1]
+    }
+  }
+  return '<module-scope>'
+}
+
+function normalizeStatement(text: string): string {
+  return text.replace(/\s+/g, ' ').trim().toLowerCase()
+}
+
+/** Stable content hash: (file, anchor, statement fingerprint, occurrence-index) — never a line number. */
+export function hashSite(file: string, anchor: string, fingerprint: string, occurrence: number): string {
+  return createHash('sha1').update(`${file}::${anchor}::${fingerprint}::${occurrence}`).digest('hex').slice(0, 16)
+}
+
+/**
+ * Enumerate every `meta_records` mutation site in `src` (whole-file, case-insensitive, multiline-aware —
+ * see module docstring). Pure function: takes source text directly, never touches disk. This is what the
+ * defeat-then-fix proofs and the stability proofs call directly with synthetic fixtures.
+ */
+interface Draft {
+  file: string
+  line: number
+  sql: string
+  disposition: Disposition | null
+  anchor: string
+  fingerprint: string
+}
+
+export function enumerateSites(file: string, src: string): Site[] {
+  const stripped = stripComments(src)
+  const rawLines = src.split('\n')
+  const strippedLines = stripped.split('\n')
+  const lineStarts = computeLineStarts(stripped)
+
+  const drafts: Draft[] = []
+  for (const match of stripped.matchAll(MUTATION_RE)) {
+    const idx = match.index ?? 0
+    const lineIdx = lineIndexForOffset(lineStarts, idx)
+    const windowStart = Math.max(0, lineIdx - MARKER_WINDOW)
+    const window = rawLines.slice(windowStart, lineIdx + 1).join('\n')
+    const anchor = findEnclosingAnchor(strippedLines, lineIdx)
+    const fingerprint = normalizeStatement(strippedLines.slice(lineIdx, lineIdx + 6).join(' '))
+    drafts.push({
+      file,
+      line: lineIdx + 1,
+      sql: rawLines[lineIdx].trim(),
+      disposition: classify(window),
+      anchor,
+      fingerprint,
+    })
+  }
+
+  // Assign an occurrence index to disambiguate byte-identical (file, anchor, fingerprint) siblings, in
+  // file-appearance order, THEN hash — this is what makes two identical UPDATEs in the same function
+  // (e.g. LOCK / UNLOCK twins that happened to normalize the same, which none of ours do, but a future
+  // one might) still get distinct, stable ids instead of colliding silently.
+  const seen = new Map<string, number>()
+  return drafts.map(({ fingerprint, ...rest }): Site => {
+    const key = `${rest.file}::${rest.anchor}::${fingerprint}`
+    const occurrence = seen.get(key) ?? 0
+    seen.set(key, occurrence + 1)
+    const siteId = hashSite(rest.file, rest.anchor, fingerprint, occurrence)
+    return { ...rest, siteId }
+  })
+}
+
+/**
+ * Recursively list every runtime `.ts` file under `src/`, relative to `src/` with `/` separators.
+ * Mirrors `multitable-record-lock-guard.guard.test.ts`'s `listRuntimeTsFiles` exactly (same exclusions:
+ * `node_modules`, `dist`, `migrations`, `.d.ts`/`.test.ts`/`.spec.ts`) so the two guards see the same
+ * mutation surface and neither can be evaded by hiding a new sink where the other guard already scans.
+ */
+export function listRuntimeTsFiles(srcRoot: string): string[] {
+  const out: string[] = []
+  const walk = (absDir: string): void => {
+    for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+      const abs = join(absDir, entry.name)
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'migrations') continue
+        walk(abs)
+        continue
+      }
+      if (!entry.name.endsWith('.ts')) continue
+      if (entry.name.endsWith('.d.ts') || entry.name.endsWith('.test.ts') || entry.name.endsWith('.spec.ts')) continue
+      out.push(relative(srcRoot, abs).split(sep).join('/'))
+    }
+  }
+  walk(srcRoot)
+  return out
+}
+
+export function readSrcFile(srcRoot: string, relFile: string): string {
+  return readFileSync(join(srcRoot, relFile), 'utf8')
+}

--- a/packages/core-backend/tests/unit/multitable-revision-disposition-guard.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-revision-disposition-guard.guard.test.ts
@@ -1,0 +1,147 @@
+/**
+ * OD-6 REVISION-DISPOSITION GUARD — "every `meta_records` mutation site must declare a revision
+ * disposition, or CI goes red."
+ *
+ * D-1c (design-lock `docs/development/multitable-global-history-d1c-form-submit-edit-uncaptured-
+ * revision-design-lock-20260712.md`) found EIGHT live `meta_records` mutation sites (A1-A8, §7a) that
+ * wrote no `recordRecordRevision(...)` — each found by a DIFFERENT human audit (rank-8, D-1, this one),
+ * years apart, each fixing only the sinks it happened to be looking at. `reconstructRecordsAtT` (the PIT
+ * view / revert / reset primitive) derives record existence AND data purely from `meta_record_revisions`
+ * — a mutation that skips it is invisible forever, and a sheet revert/reset can silently and
+ * irrecoverably destroy or resurrect real data (§0/§1/§2 of the lock). Five runtime slices (①-⑤, landed
+ * as #4245/#4246/#4247/#4248/#4249) fixed all eight. This guard is the OD-6 "separate rung" that lands
+ * LAST (§10 of the lock): it prevents a NINTH uncaptured sink from EVER being added silently again, by
+ * forcing every `meta_records` INSERT/UPDATE/DELETE site — anywhere in the runtime tree — to carry an
+ * explicit disposition marker within `MARKER_WINDOW` lines:
+ *
+ *   • `// revision-emitted:<why>`  — this site calls `recordRecordRevision(...)` in the same transaction.
+ *   • `// revision-exempt:<why>`   — a trusted derived/system/config-channel write with no user actor, OR
+ *                                    (field-delete/field-undelete) captured on the CONFIG revision channel
+ *                                    instead, per the design-lock's §7a Bucket C classification.
+ *   • `// revision-pending:<why>`  — an OWNER-RULED must-write site that does NOT yet emit a revision.
+ *                                    Reserved EXCLUSIVELY for `KNOWN_REVISION_GAPS` entries (see below) —
+ *                                    a contributor cannot self-declare "pending" to dodge the guard.
+ *
+ * Recycled from the #4227 draft PR, with its adversarial review's two proven blockers fixed (see
+ * `lib/multitable-revision-disposition-scanner.ts`'s docstring for the defeat-then-fix detail):
+ *   1. the #4227 scanner was line-by-line and case-sensitive — an unmarked UPPERCASE `UPDATE meta_records`
+ *      reddened it, but the lowercase twin passed 11/11 undetected, and a verb/table split across lines
+ *      was invisible. This guard's scanner is whole-file, case-insensitive, and multiline-aware.
+ *   2. the #4227 scanner keyed its pending-site allowlist by literal `(file, line)` — any edit above a
+ *      pending site silently drifted its line number. This guard keys every site by a stable content hash
+ *      (`siteId` — file + enclosing anchor + statement fingerprint + occurrence index), immune to edits
+ *      elsewhere in the file.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, test } from 'vitest'
+
+import { enumerateSites, listRuntimeTsFiles, readSrcFile, type Site } from './lib/multitable-revision-disposition-scanner'
+
+const SRC = join(__dirname, '../../src')
+
+/**
+ * The SOLE currently-known MUST-WRITE-but-not-yet-emitting site: `univer-meta.ts` `recreateFieldFromConfig`
+ * (field-undelete rehydration). The design-lock's audit (§7a Bucket D) had flagged it debatable-EXEMPT;
+ * the owner's OD-6 ruling (§0.5, 2026-07-13) directs MUST-WRITE instead — it rehydrates real captured user
+ * cell values from tombstones (`data = data || jsonb_build_object(...)`), which is exactly the fingerprint
+ * of the bug class this guard exists to catch. It is OUT of scope for D-1c's five slices (those are A1-A8,
+ * the bucket-A user-write-entry-point sweep; this is a field-op, not one of the eight) and is NOT silently
+ * exempted — it is a loud, named, pinned, tracked gap. A site may use `revision-pending:` ONLY if its
+ * `siteId` is listed here; see the hygiene test below for both directions of that check.
+ *
+ * To regenerate a siteId after a legitimate edit to this exact statement/anchor: run the scanner against
+ * `src/routes/univer-meta.ts` and read the `recreateFieldFromConfig` UPDATE's `siteId` — see
+ * `multitable-revision-disposition-scanner.test.ts` for how to call `enumerateSites` directly.
+ */
+const KNOWN_REVISION_GAPS: ReadonlySet<string> = new Set([
+  '456ec0c986a1b1af', // routes/univer-meta.ts recreateFieldFromConfig — field-undelete rehydration (OD-6 owner ruling: MUST-WRITE, not yet implemented)
+])
+
+describe('OD-6 revision-disposition guard — durable structural guard (D-1c final rung)', () => {
+  const allSites: Site[] = listRuntimeTsFiles(SRC).flatMap((file) => enumerateSites(file, readSrcFile(SRC, file)))
+
+  test('the enumeration finds the expected mutation surface (smoke — not zero, not exploded)', () => {
+    // 36 known sites at authoring time (9 INSERT + 22 UPDATE + 5 DELETE, literal grep on origin/main —
+    // see PR body for the full reconciliation against the design-lock's audit). Loose bound, mirroring
+    // the rank-8 guard's own philosophy: a count change is FINE (you added/removed a mutation site); the
+    // per-site disposition assertion below is the real gate.
+    expect(allSites.length).toBeGreaterThanOrEqual(30)
+    expect(allSites.length).toBeLessThanOrEqual(50)
+  })
+
+  test('EVERY meta_records INSERT/UPDATE/DELETE site carries a revision disposition (EMITTED / EXEMPT / PENDING)', () => {
+    const undeclared = allSites.filter((s) => s.disposition === null)
+    expect(
+      undeclared,
+      `OD-6 REVISION-DISPOSITION GUARD: ${undeclared.length} meta_records mutation site(s) with NO ` +
+        `revision disposition:\n` +
+        undeclared.map((s) => `  - ${s.file}:${s.line}  [${s.siteId}]  ${s.sql}`).join('\n') +
+        `\n\nYou added or moved a meta_records mutation. Within 3 lines above it, add EITHER a ` +
+        `"// revision-emitted:<why>" marker (a recordRecordRevision(...) call executes in the SAME ` +
+        `transaction) OR a "// revision-exempt:<why>" marker (trusted derived/system/config-channel write, ` +
+        `no user actor — see the design-lock's §7a Bucket C for precedent). Do NOT self-declare ` +
+        `"revision-pending" — that marker is reserved for KNOWN_REVISION_GAPS entries only (see hygiene ` +
+        `test below). A silently uncaptured meta_records write is exactly the bug class D-1c's five ` +
+        `runtime slices (①-⑤, #4245-#4249) closed — this guard exists so a NINTH one can never regress.`,
+    ).toEqual([])
+  })
+
+  test('every PENDING-labelled site is a KNOWN, TRACKED gap — no self-declared "pending" (both directions)', () => {
+    const pendingSites = allSites.filter((s) => s.disposition === 'PENDING')
+    const pendingIds = new Set(pendingSites.map((s) => s.siteId))
+
+    // direction 1: every site actually marked revision-pending must be in the allowlist — a contributor
+    // cannot dodge the "declare EMITTED or EXEMPT" requirement by writing "pending" on a brand-new site.
+    const undeclaredPending = pendingSites.filter((s) => !KNOWN_REVISION_GAPS.has(s.siteId))
+    expect(
+      undeclaredPending,
+      `A site is marked "revision-pending" but is NOT in KNOWN_REVISION_GAPS — pending is reserved for ` +
+        `owner-ruled, explicitly tracked gaps, not a way to dodge the guard:\n` +
+        undeclaredPending.map((s) => `  - ${s.file}:${s.line}  [${s.siteId}]  ${s.sql}`).join('\n'),
+    ).toEqual([])
+
+    // direction 2: every allowlist entry must correspond to a site CURRENTLY marked pending — when the
+    // follow-up rung lands and the site flips to revision-emitted, this fails until the stale entry is
+    // deleted, closing the loop from the landing side (mirrors the rank-8/#4227 hygiene convention).
+    const staleAllowlistEntries = [...KNOWN_REVISION_GAPS].filter((id) => !pendingIds.has(id))
+    expect(
+      staleAllowlistEntries,
+      `KNOWN_REVISION_GAPS lists a siteId with no corresponding revision-pending site — either the gap ` +
+        `was fixed (delete the entry) or the site's content changed and its stable id drifted ` +
+        `(regenerate it): ${staleAllowlistEntries.join(', ')}`,
+    ).toEqual([])
+
+    // exactly one known gap today (field-undelete rehydration) — a bound, not a hardcode of WHICH, so a
+    // second legitimate gap can be added without this test needing surgery, but a silent explosion trips it.
+    expect(pendingSites.length).toBe(1)
+  })
+
+  test('every EMITTED-labelled FILE actually calls recordRecordRevision( somewhere in it (a label cannot fake a call)', () => {
+    // Per-FILE cross-check (not per-site — a full call-graph proof is what the real-DB goldens in each of
+    // the five landed slices already provide; see their PRs). Mirrors the rank-8 lock guard's own
+    // `multitable-record-lock-guard.guard.test.ts` "a label cannot fake a guard" test exactly.
+    const emittedFiles = new Set(allSites.filter((s) => s.disposition === 'EMITTED').map((s) => s.file))
+    for (const f of [
+      'multitable/record-service.ts',
+      'multitable/record-write-service.ts',
+      'multitable/records.ts',
+      'multitable/automation-executor.ts',
+      'multitable/automation-service.ts',
+      'routes/univer-meta.ts',
+    ]) {
+      expect(emittedFiles.has(f), `${f} should have at least one EMITTED mutation site`).toBe(true)
+    }
+    for (const f of emittedFiles) {
+      const src = readFileSync(join(SRC, f), 'utf8')
+      expect(src.includes('recordRecordRevision('), `${f} is labelled revision-emitted but never calls recordRecordRevision(`).toBe(true)
+    }
+  })
+
+  test('recordRecordRevision is the single write helper, defined once', () => {
+    const src = readFileSync(join(SRC, 'multitable/record-history-service.ts'), 'utf8')
+    expect(src).toContain('export async function recordRecordRevision(')
+    expect([...src.matchAll(/function recordRecordRevision\(/g)].length).toBe(1)
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-revision-disposition-scanner.test.ts
+++ b/packages/core-backend/tests/unit/multitable-revision-disposition-scanner.test.ts
@@ -1,0 +1,242 @@
+/**
+ * OD-6 scanner self-tests — the defeat-then-fix proof.
+ *
+ * The #4227 draft's scanner (line-by-line, case-sensitive `MUTATION_RE`) was proven defeatable on the
+ * LIVE guard: an unmarked UPPERCASE `UPDATE meta_records` reds it, but the lowercase twin passes 11/11
+ * undetected, and a verb/table split across lines is invisible to a per-line test. Every fixture below
+ * is fed straight to `enumerateSites` — no disk writes — and each "evasion" fixture is asserted RED
+ * (site found, `disposition: null`), proving the NEW scanner catches exactly what the old one missed.
+ */
+import { describe, expect, test } from 'vitest'
+
+import { enumerateSites, findEnclosingAnchor, hashSite, stripComments } from './lib/multitable-revision-disposition-scanner'
+
+describe('OD-6 scanner — case-insensitive + multiline mutation detection (blocker #1 fix)', () => {
+  test('uppercase unmarked multiline UPDATE is detected (positive control — proves the harness works)', () => {
+    const src = [
+      'async function doThing(query: any) {',
+      '  const x = await query(',
+      '    `UPDATE meta_records',
+      '     SET data = $1',
+      '     WHERE id = $2`,',
+      '    [a, b],',
+      '  )',
+      '}',
+    ].join('\n')
+    const sites = enumerateSites('fixture.ts', src)
+    expect(sites).toHaveLength(1)
+    expect(sites[0].disposition).toBeNull()
+  })
+
+  test('DEFEAT PROOF: lowercase unmarked multiline update — the #4227 evasion — is now detected', () => {
+    const src = [
+      'async function doThing(query: any) {',
+      '  const x = await query(',
+      '    `update meta_records',
+      '     set data = $1',
+      '     where id = $2`,',
+      '    [a, b],',
+      '  )',
+      '}',
+    ].join('\n')
+    const sites = enumerateSites('fixture.ts', src)
+    expect(sites).toHaveLength(1)
+    expect(sites[0].disposition).toBeNull()
+  })
+
+  test('DEFEAT PROOF: mixed-case unmarked single-line DELETE is detected', () => {
+    const src = "async function drop(query: any) {\n  await query('Delete From meta_records WHERE id = $1', [id])\n}\n"
+    const sites = enumerateSites('fixture.ts', src)
+    expect(sites).toHaveLength(1)
+    expect(sites[0].disposition).toBeNull()
+  })
+
+  test('DEFEAT PROOF: verb and table name split across separate lines (multiline INSERT) is detected', () => {
+    const src = [
+      'async function create(query: any) {',
+      '  await query(',
+      '    `INSERT',
+      '     INTO',
+      '     meta_records (id, sheet_id, data, version)',
+      '     VALUES ($1, $2, $3::jsonb, 1)`,',
+      '  )',
+      '}',
+    ].join('\n')
+    const sites = enumerateSites('fixture.ts', src)
+    expect(sites).toHaveLength(1)
+    expect(sites[0].disposition).toBeNull()
+  })
+
+  test('a comment-only mention of the SQL text is NOT flagged as a mutation site (no over-match)', () => {
+    const src = [
+      '// Historical note: this handler used to run UPDATE meta_records directly before D-1c.',
+      '/* Multi-line block comment mentioning DELETE FROM meta_records for context. */',
+      'function unrelated() { return 1 }',
+    ].join('\n')
+    const sites = enumerateSites('fixture.ts', src)
+    expect(sites).toHaveLength(0)
+  })
+
+  test('Kysely builder forms (updateTable/deleteFrom/insertInto) are also matched, case-insensitively', () => {
+    const src = "async function k(db: any) {\n  await db.UPDATETABLE('meta_records').set({ x: 1 }).execute()\n}\n"
+    const sites = enumerateSites('fixture.ts', src)
+    expect(sites).toHaveLength(1)
+  })
+
+  test('meta_records_trash is NOT matched (word-boundary check on the table name)', () => {
+    const src = "async function t(query: any) {\n  await query('DELETE FROM meta_records_trash WHERE id = $1', [id])\n}\n"
+    const sites = enumerateSites('fixture.ts', src)
+    expect(sites).toHaveLength(0)
+  })
+})
+
+describe('OD-6 scanner — marker window discipline (mirrors rank-8 MARKER_WINDOW=3)', () => {
+  test('a revision-emitted marker within the 3-line window is recognized', () => {
+    const src = [
+      'function doThing(query: any) {',
+      '  // revision-emitted: test fixture',
+      "  const x = query('UPDATE meta_records SET data = $1 WHERE id = $2', [a, b])",
+      '}',
+    ].join('\n')
+    const sites = enumerateSites('fixture.ts', src)
+    expect(sites[0].disposition).toBe('EMITTED')
+  })
+
+  test('a revision-exempt marker within the window is recognized', () => {
+    const src = [
+      'function doThing(query: any) {',
+      '  // revision-exempt: system recompute, no user actor',
+      "  const x = query('UPDATE meta_records SET data = $1 WHERE id = $2', [a, b])",
+      '}',
+    ].join('\n')
+    const sites = enumerateSites('fixture.ts', src)
+    expect(sites[0].disposition).toBe('EXEMPT')
+  })
+
+  test('a revision-pending marker within the window is recognized', () => {
+    const src = [
+      'function doThing(query: any) {',
+      '  // revision-pending: owner-ruled MUST-WRITE, not yet implemented — see KNOWN_REVISION_GAPS',
+      "  const x = query('UPDATE meta_records SET data = $1 WHERE id = $2', [a, b])",
+      '}',
+    ].join('\n')
+    const sites = enumerateSites('fixture.ts', src)
+    expect(sites[0].disposition).toBe('PENDING')
+  })
+
+  test('a marker 4 lines above (outside the 3-line window) does NOT count — guard stays red', () => {
+    const src = [
+      'function doThing(query: any) {',
+      '  // revision-emitted: too far away to count',
+      '  const pad1 = 1',
+      '  const pad2 = 2',
+      '  const pad3 = 3',
+      "  const x = query('UPDATE meta_records SET data = $1 WHERE id = $2', [a, b])",
+      '}',
+    ].join('\n')
+    const sites = enumerateSites('fixture.ts', src)
+    expect(sites[0].disposition).toBeNull()
+  })
+
+  test('a malformed marker (missing the colon) is not accepted', () => {
+    const src = [
+      'function doThing(query: any) {',
+      '  // revision-emitted no colon here',
+      "  const x = query('UPDATE meta_records SET data = $1 WHERE id = $2', [a, b])",
+      '}',
+    ].join('\n')
+    const sites = enumerateSites('fixture.ts', src)
+    expect(sites[0].disposition).toBeNull()
+  })
+})
+
+describe('OD-6 scanner — stable site IDs (blocker #2 fix)', () => {
+  const markedSite = (padding: string[]) =>
+    [
+      ...padding,
+      'function foo(query: any) {',
+      '  // revision-emitted: x',
+      "  const r = query('UPDATE meta_records SET data = $1 WHERE id = $2', [a, b])",
+      '}',
+    ].join('\n')
+
+  test('siteId is UNCHANGED when unrelated lines are inserted ABOVE the site (the #4227 failure mode)', () => {
+    const before = enumerateSites('fixture.ts', markedSite([]))
+    const after = enumerateSites(
+      'fixture.ts',
+      markedSite(['// unrelated new comment line 1', '// unrelated new comment line 2', '// unrelated new comment line 3']),
+    )
+    expect(before).toHaveLength(1)
+    expect(after).toHaveLength(1)
+    // line number DID shift...
+    expect(after[0].line).toBe(before[0].line + 3)
+    // ...but the stable id did NOT.
+    expect(after[0].siteId).toBe(before[0].siteId)
+  })
+
+  test('two byte-identical statements in the SAME function get DIFFERENT stable ids (occurrence index)', () => {
+    const src = [
+      'function foo(query: any) {',
+      '  // revision-emitted: a',
+      "  query('UPDATE meta_records SET data = $1 WHERE id = $2', [a, b])",
+      '  // revision-emitted: b',
+      "  query('UPDATE meta_records SET data = $1 WHERE id = $2', [a, b])",
+      '}',
+    ].join('\n')
+    const sites = enumerateSites('fixture.ts', src)
+    expect(sites).toHaveLength(2)
+    expect(sites[0].siteId).not.toBe(sites[1].siteId)
+  })
+
+  test('the SAME statement in a DIFFERENT enclosing function gets a DIFFERENT stable id', () => {
+    const a = enumerateSites(
+      'fixture.ts',
+      "function foo(query: any) {\n  // revision-emitted: x\n  query('UPDATE meta_records SET data = $1 WHERE id = $2', [a, b])\n}\n",
+    )
+    const b = enumerateSites(
+      'fixture.ts',
+      "function bar(query: any) {\n  // revision-emitted: x\n  query('UPDATE meta_records SET data = $1 WHERE id = $2', [a, b])\n}\n",
+    )
+    expect(a[0].siteId).not.toBe(b[0].siteId)
+  })
+
+  test('hashSite is a pure function of its inputs (deterministic, not time/random based)', () => {
+    expect(hashSite('f.ts', 'anchor', 'fp', 0)).toBe(hashSite('f.ts', 'anchor', 'fp', 0))
+    expect(hashSite('f.ts', 'anchor', 'fp', 0)).not.toBe(hashSite('f.ts', 'anchor', 'fp', 1))
+  })
+})
+
+describe('OD-6 scanner — anchor detection', () => {
+  test('finds the nearest named function above the site', () => {
+    const src = 'async function patchRecord(query: any) {\n  // revision-emitted: x\n  query(\'UPDATE meta_records SET data=$1 WHERE id=$2\', [a,b])\n}\n'
+    const lines = stripComments(src).split('\n')
+    expect(findEnclosingAnchor(lines, 2)).toBe('patchRecord')
+  })
+
+  test('falls back to a route: anchor for an anonymous route handler', () => {
+    const src = [
+      "router.post('/views/:viewId/submit', async (req, res) => {",
+      '  // revision-emitted: x',
+      "  query('UPDATE meta_records SET data=$1 WHERE id=$2', [a,b])",
+      '})',
+    ].join('\n')
+    const lines = stripComments(src).split('\n')
+    expect(findEnclosingAnchor(lines, 2)).toBe('route:post:/views/:viewId/submit')
+  })
+})
+
+describe('OD-6 scanner — comment stripping preserves line structure', () => {
+  test('stripped text has the same length and the same number of lines as the input', () => {
+    const src = "// a comment\n/* block\n   comment */\nconst x = 'a string // not a comment /* also not */'\n"
+    const stripped = stripComments(src)
+    expect(stripped.length).toBe(src.length)
+    expect(stripped.split('\n').length).toBe(src.split('\n').length)
+  })
+
+  test('string/template literal content survives verbatim (SQL text is never stripped)', () => {
+    const src = "const q = `UPDATE meta_records SET data = $1` // trailing comment\n"
+    const stripped = stripComments(src)
+    expect(stripped).toContain('UPDATE meta_records SET data = $1')
+    expect(stripped).not.toContain('trailing comment')
+  })
+})


### PR DESCRIPTION
## Summary

Implements the **OD-6 revision-disposition guard**, ratified in the design-lock (`docs/development/multitable-global-history-d1c-form-submit-edit-uncaptured-revision-design-lock-20260712.md` §0.5 row OD-6 / §7). This is the **last rung of W0/D-1c**, landing after all five write-site slices (①#4245, ②#4246, ③#4247, ④#4248, ⑤#4249). It forces every `meta_records` INSERT/UPDATE/DELETE site — anywhere in the runtime tree — to declare an explicit revision disposition, so a **new** uncaptured write can never regress the class of bug D-1c fixed.

This supersedes Draft #4227 (`claude/od-6-revision-disposition-guard`, head `b99c44fbf`), which the owner's adversarial re-review (2026-07-13) found NEEDS-WORK on two blockers. Both are fixed here (recycled structure, new scanner). #4227 stays open as a draft; I'll close it referencing this PR — not with a closing keyword (see PR discipline below), since it documents real review history worth keeping.

## Scanner hardening — the two proven blockers, fixed

**Blocker 1 — case-insensitive + multiline SQL scan.** The #4227 scanner tested `MUTATION_RE` (no `i` flag) against source **one line at a time**. The live-guard mutation proved: an unmarked UPPERCASE `UPDATE meta_records` reds the guard, but the **lowercase** twin passes 11/11 undetected, and a verb/table split across lines is invisible to a per-line test.

Fix (`tests/unit/lib/multitable-revision-disposition-scanner.ts`): the whole file is comment-stripped (state machine — preserves every string/template literal byte-for-byte and every newline's position, so a comment-only mention of the SQL text can never register as a mutation site), then scanned with **one** `matchAll` over the case-insensitive regex `/\b(?:INSERT\s+INTO\s+meta_records|UPDATE\s+meta_records|DELETE\s+FROM\s+meta_records)\b|(?:updateTable|deleteFrom|insertInto)\(\s*['"`]meta_records['"`]/gi`. `\s+` already matches `\n`, so a verb and `meta_records` on separate lines still match one statement.

**Defeat-then-fix proof** (`tests/unit/multitable-revision-disposition-scanner.test.ts`, in-memory fixtures, no disk mutation):
- uppercase unmarked multiline `UPDATE` → detected (positive control)
- **lowercase unmarked multiline `update`** (the exact #4227 evasion) → detected
- verb and `meta_records` split across separate lines (multiline `INSERT`) → detected
- comment-only mention of the SQL text → **not** flagged (no over-match)
- `meta_records_trash` → **not** matched (word-boundary check)

Then reproduced against the **real, tracked source tree** (not a fixture) — see "Bite proof" below.

**Blocker 2 — stable site IDs, not line numbers.** #4227 keyed its `PENDING_REVISION_SITES` allowlist by literal `(file, line)`, so any edit above a pending site silently drifted its line number. Fix: every site gets a `siteId` = `sha1(file :: enclosing-anchor :: statement-fingerprint :: occurrence-index)`. The anchor is the nearest enclosing named function / `const foo = (...) =>` / class method / `router.METHOD('path', ...)` scanning upward over the comment-stripped text (heuristic, not a full parser — documented as such; good enough because the anchor only changes when a contributor edits content genuinely between the site and its declaration, categorically rarer than "any edit anywhere above the file"). Proof: inserting 3 unrelated comment lines above a marked site shifts its `line` but leaves its `siteId` byte-identical; two byte-identical statements in the same function get different ids via the occurrence index; the same statement in a different function gets a different id.

## Guard mechanics

`tests/unit/multitable-revision-disposition-guard.guard.test.ts` walks the whole `packages/core-backend/src` tree (same file-list / exclusions as the rank-8 lock guard: `node_modules`, `dist`, `migrations`, `.d.ts`/`.test.ts`/`.spec.ts` excluded) and requires, within `MARKER_WINDOW = 3` lines above each site (same convention as the rank-8 lock guard), one of:

- `// revision-emitted:<why>` — a `recordRecordRevision(...)` call executes in the same transaction.
- `// revision-exempt:<why>` — a trusted derived/system/config-channel write with no user actor.
- `// revision-pending:<why>` — reserved **exclusively** for `KNOWN_REVISION_GAPS` entries (see below); a contributor cannot self-declare "pending" to dodge the guard — a hygiene test asserts both directions (every `revision-pending` site is in the allowlist, and every allowlist entry is currently `revision-pending`; a stale entry after a follow-up fix reds until deleted).

An additional per-file cross-check (mirroring the rank-8 guard's "a label cannot fake a guard" test) asserts every file with an `EMITTED` site actually contains a `recordRecordRevision(` call somewhere in it.

## The disposition matrix (36 literal `meta_records` INSERT/UPDATE/DELETE sites, `packages/core-backend/src`, non-migration)

**Count reconciliation vs. the design-lock's audit** (`§7a`, and the standalone consolidated audit it draws on): the audit table header says "22 must-write / 15 exempt" (=37), but its own enumerated EXEMPT table folds two rows into one line each (`univer-meta.ts:16261/:16275`, `automation-executor.ts:3412/:3422` each list TWO sites on one markdown row) — the real distinct count is **14 exempt**, not 15. `22 + 14 = 36`, matching this PR's literal `grep`/scanner count exactly. (#4227 found and reported the same typo independently.) Post owner-ruling reclassification of `univer-meta.ts:6522` (EXEMPT → MUST-WRITE, see below): **22 EMITTED + 13 EXEMPT + 1 PENDING = 36.**

### EMITTED (22) — compliant, real `recordRecordRevision(...)` call in the same transaction

**14 pre-existing (rank-8 / D-1 / D-2 eras):**
| Site | recordRecordRevision |
|---|---|
| `record-service.ts` `createRecord` (INSERT) | @706 |
| `record-service.ts` `deleteRecord` (DELETE) | @845 |
| `record-service.ts` restore (INSERT) | @1125 |
| `record-service.ts` `patchRecord` (UPDATE) | @1392 |
| `record-write-service.ts` bulk PATCH ×2 (UPDATE) | @998 |
| `records.ts` plugin delete D-2 flag-on (DELETE) | @650 |
| `records.ts` plugin delete D-1 flag-off (DELETE) | @771 |
| `automation-executor.ts` `executeDeleteRecord` (DELETE) | @2365 |
| `univer-meta.ts` lossy-retype revert (UPDATE) | @6455 |
| `univer-meta.ts` PIT resurrect (INSERT) | @10178 |
| `univer-meta.ts` PIT reset revert ×2 (UPDATE) | @10416 |
| `univer-meta.ts` PIT reset delete (DELETE) | @10498 |

**8 newly-fixed by the five D-1c slices (A1-A8):**
| Slice | Site | Source |
|---|---|---|
| ① form (#4245) | `univer-meta.ts` form-submit EDIT (A1, UPDATE) | `'public-form'` |
| ① form (#4245) | `univer-meta.ts` form-submit CREATE (A6, INSERT) | `'public-form'` |
| ② plugin (#4246) | `records.ts` `patchRecord` (A2, UPDATE) | `'plugin'` |
| ② plugin (#4246) | `records.ts` `createRecord` (A5, INSERT) | `'plugin'` |
| ③ automation (#4247) | `automation-executor.ts` `update_record` (A3, UPDATE) | `'automation'` |
| ③ automation (#4247) | `automation-executor.ts` `create_record` (A4, INSERT) | `'automation'` |
| ④ approval (#4248) | `automation-service.ts` `resultWriteback` (A7, UPDATE) | `'approval'` |
| ⑤ attachment (#4249) | `univer-meta.ts` attachment-delete cell-strip (A8, UPDATE) | `'attachment'` |

### EXEMPT (13) — derived/system/config-channel, no user actor

`approval-record-projection-service.ts` (INSERT, derived approval projection) · `univer-meta.ts` People-sync ×2 (INSERT+UPDATE) · `univer-meta.ts` `createSeededSheet` template scaffold (INSERT, hardcoded demo preset) · `formula-engine.ts` formula materialization (UPDATE, no version bump) · `univer-meta.ts` relation-aggregation same-record + fan-out (UPDATE ×2, no version bump) · `auto-number-service.ts` backfill (UPDATE, no version bump) · `univer-meta.ts` field-delete column strip (UPDATE, captured on config channel) · `univer-meta.ts` record lock/unlock ×2 (UPDATE, metadata-only) · `automation-executor.ts` automation lock/unlock ×2 (UPDATE, metadata-only).

### PENDING (1) — owner-ruled MUST-WRITE, not yet implemented — see field-undelete finding below

## The field-undelete `univer-meta.ts` `recreateFieldFromConfig` finding (owner-flagged, per the brief)

The design-lock's OD-6 row is explicit: *"`univer-meta.ts:6521` field-undelete rehydration: owner ruling = SHOULD WRITE REVISION (audit flagged it debatable-EXEMPT, owner directs it MUST-WRITE)."* I verified the current state on `origin/main` (post all five slices): the site (now at line ~6537, inside `recreateFieldFromConfig`'s tombstone-rehydration branch) does `SET data = data || jsonb_build_object($3::text, t.value)` — real captured user cell values written back from tombstones — with **no `version` bump and no `recordRecordRevision` call**. It is the exact fingerprint of the bug class this whole guard exists to catch, and it is **still open**.

This is **not** one of D-1c's five slices (those are the A1-A8 bucket-A user-write-entry-point sweep; this is a field-op) — implementing the fix here would be unauthorized scope creep on a guard PR that is otherwise comment-only/zero-runtime-change, and would need its own `source` decision, real-DB golden, and adversarial review, exactly like each of the five landed slices got.

Per the brief's explicit instruction ("if it currently doesn't emit, that's a finding — report it, don't silently exempt it"), I did **not** mark it `revision-exempt` (would contradict the owner's ruling) and did **not** fabricate a `revision-emitted` marker (would be a lie, on the exact site three separate human audits already flagged). Instead: a third disposition, `revision-pending`, reserved exclusively for a `KNOWN_REVISION_GAPS` allowlist in the guard test, containing exactly this one site's stable `siteId`. The guard is GREEN because the gap is **declared, named, and pinned** — not silently passed. A hygiene test asserts nothing else can claim `pending` status and that this entry stays live only as long as the site is actually still pending.

**Reported finding, not fixed here: `univer-meta.ts` `recreateFieldFromConfig` field-undelete rehydration needs its own follow-up rung (own `source`, real-DB golden, adversarial review) to close this gap and let `KNOWN_REVISION_GAPS` go to zero.**

## Bite proof — the guard fires both ways

**(a) GREEN on current main** — all 36 sites declared (22 EMITTED / 13 EXEMPT / 1 tracked PENDING):
```
✓ EVERY meta_records INSERT/UPDATE/DELETE site carries a revision disposition
✓ every PENDING-labelled site is a KNOWN, TRACKED gap (both directions)
✓ every EMITTED-labelled FILE actually calls recordRecordRevision(
```

**(b) Planting an unmarked write reds it** — each variant proven against the REAL scanned source tree (`record-service.ts`), reverted after (via `git checkout --` on a committed checkpoint, never against uncommitted work):
- uppercase unmarked single-line `UPDATE meta_records` → **guard RED**, names the exact site
- **lowercase** unmarked single-line `update meta_records` (the #4227 evasion) → **guard RED**
- multiline, verb+table split across lines, lowercase → **guard RED**

**(c) Removing a real marker reds it** — stripped the `revision-emitted` comment from the real, landed form-submit EDIT site (`univer-meta.ts`, slice ①/A1) → **guard RED**, naming that exact site; reverted.

**Collateral regression found and fixed during this work**: adding the new marker at `automation-executor.ts`'s `executeCreateRecord` INSERT (A4) initially pushed the pre-existing `xbase-write-gated:` marker outside the **cross-base write guard**'s own 5-line window (`multitable-cross-base-write-guard.guard.test.ts`, a third structural guard scanning the same file), redding it. Fixed by appending the revision marker to the end of the existing comment's last physical line instead of adding a new line (no new line added = no window disturbed), which required loosening `classify()`'s regex to not require the marker to be the first token after `//` (documented in the scanner's docstring). Verified: full `pnpm exec vitest run` (468 files / 6434 tests) green, plus rank-8 lock guard and cross-base write guard both green alongside this one.

## Test plan

- [x] `pnpm exec vitest run tests/unit/multitable-revision-disposition-guard.guard.test.ts` — 5/5 passed
- [x] `pnpm exec vitest run tests/unit/multitable-revision-disposition-scanner.test.ts` — 20/20 passed (defeat-then-fix + stability proofs)
- [x] `pnpm exec vitest run tests/unit/multitable-record-lock-guard.guard.test.ts` — 4/4 passed (rank-8, not broken)
- [x] `pnpm exec vitest run tests/unit/multitable-cross-base-write-guard.guard.test.ts` — 5/5 passed (not broken, after the fix above)
- [x] `pnpm exec vitest run` (full core-backend unit suite) — 468 files / 6434 tests passed, 1523 pre-existing skips
- [x] `pnpm exec tsc --noEmit` — clean
- [x] Bite proof (b) and (c) above, executed against the real tracked source tree, reverted after each

No DB flag, no env gate — pure fs-scan unit test, collected automatically by the default vitest glob in the same `test (20.x)` step as the rank-8 lock guard (confirmed: not present in `vitest.config.ts`'s `exclude` list).

## This completes W0 D-1c

§0.6 `HISTORY_INCOMPLETE` (#4234, lands first) + five write-site slices (①-⑤, #4245/#4246/#4247/#4248/#4249) + this guard (lands last, per the design-lock's §10 routing) = the full ratified D-1c scope. One reported, tracked, non-silent residual: `univer-meta.ts` field-undelete rehydration needs its own follow-up rung (see finding above) — everything else in the ratified scope is closed.

**Draft — not requesting merge/arm.** Supersedes #4227 (draft, pre-slices, unfixed scanner) — I'll close that PR referencing this one, not with a closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
