### PR TITLE
fix(ops): DT-CLOSE-01B downgrade OAuth-stability check to metrics-only (unblock the monitor; alert topology deferred)

### DIFF
--- a/.github/workflows/dingtalk-oauth-stability-recording-lite.yml
+++ b/.github/workflows/dingtalk-oauth-stability-recording-lite.yml
@@ -1,4 +1,9 @@
 name: DingTalk OAuth Stability Recording (Lite)
+# DT-CLOSE-01B: this is a METRICS-ONLY OAuth-stability recording. Its verdict is the OAuth
+# state-machine signal (/metrics/prom, authenticated) + /health + root-disk headroom. The
+# Alertmanager + webhook alert-DELIVERY topology is NOT deployable from current main and is
+# DEFERRED (the check soft-reports it, the verdict does not depend on it). This workflow does
+# NOT claim alert-delivery observability is restored — only OAuth-stability metrics observability.
 
 on:
   schedule:

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -93,6 +93,12 @@ jobs:
         run: |
           node --test scripts/ops/dingtalk-oauth-stability-metrics-only-fullscript.test.mjs
 
+      - name: Run DingTalk OAuth-stability summary + workflow contract tests (DT-CLOSE-01B)
+        run: |
+          node --test \
+            scripts/ops/github-dingtalk-oauth-stability-summary.test.mjs \
+            scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -85,6 +85,10 @@ jobs:
         run: |
           node --test scripts/ops/dingtalk-closeout-env-contract.test.mjs
 
+      - name: Run DingTalk OAuth-stability metrics-only contract test (DT-CLOSE-01B)
+        run: |
+          node --test scripts/ops/dingtalk-oauth-stability-metrics-only-contract.test.mjs
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -89,6 +89,10 @@ jobs:
         run: |
           node --test scripts/ops/dingtalk-oauth-stability-metrics-only-contract.test.mjs
 
+      - name: Run DingTalk OAuth-stability metrics-only full-script test (DT-CLOSE-01B)
+        run: |
+          node --test scripts/ops/dingtalk-oauth-stability-metrics-only-fullscript.test.mjs
+
   test:
     runs-on: ubuntu-latest
 

--- a/scripts/ops/dingtalk-oauth-stability-check.sh
+++ b/scripts/ops/dingtalk-oauth-stability-check.sh
@@ -44,14 +44,25 @@ fi
 REMOTE
 }
 
-WEBHOOK_STATUS="$(bash "${ROOT_DIR}/scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh" --print-status)"
+# DT-CLOSE-01B: this recording is a METRICS-ONLY OAuth-stability check. Its job is the OAuth
+# state-machine signal (/metrics/prom, authenticated per DT-CLOSE-01), /health, and root-disk
+# headroom. The Alertmanager (:9093) + metasheet-alert-webhook alert-DELIVERY topology is a
+# SEPARATE concern that is NOT deployable from current main (docker/observability/ has only
+# Prometheus+Grafana; the alertmanager service + webhook bridge + OAuth alert rules were never
+# landed). Hard-depending on it made every scheduled run fail with `curl (7) :9093` — the OAuth
+# monitor going blind because of an unrelated, undeployed topology. So the alert-topology probes
+# below are SOFT (best-effort; a failure yields a "deferred" marker, not an abort) and, critically,
+# the verdict (report['healthy']) does NOT depend on them. Alert-delivery observability is DEFERRED
+# to a follow-up that actually deploys the topology; this check no longer claims it is "restored".
+ALERT_TOPOLOGY_DEFERRED="false"
+WEBHOOK_STATUS="$(bash "${ROOT_DIR}/scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh" --print-status 2>/dev/null || { ALERT_TOPOLOGY_DEFERRED="true"; printf 'configured=false\n'; })"
 HEALTH_JSON="$(ssh_cmd "curl -fsS http://127.0.0.1:8900/health")"
 METRICS_TEXT="$(remote_authed_curl "http://127.0.0.1:8900/metrics/prom")"
-ALERTMANAGER_STATUS_JSON="$(ssh_cmd "curl -fsS http://127.0.0.1:9093/api/v2/status")"
-ALERTS_JSON="$(ssh_cmd "curl -fsS http://127.0.0.1:9093/api/v2/alerts")"
-ALERTMANAGER_ERROR_COUNT="$(ssh_cmd "docker logs --since ${LOG_WINDOW} metasheet-alertmanager 2>&1 | grep -E 'Notify for alerts failed|no_text' | wc -l | tr -d ' '")"
-BRIDGE_NOTIFY_COUNT="$(ssh_cmd "docker logs --since ${LOG_WINDOW} metasheet-alert-webhook 2>&1 | grep '\"path\": \"/notify\"' | wc -l | tr -d ' '")"
-BRIDGE_RESOLVED_COUNT="$(ssh_cmd "docker logs --since ${LOG_WINDOW} metasheet-alert-webhook 2>&1 | grep '\"path\": \"/notify\"' | grep '\"status\": \"resolved\"' | wc -l | tr -d ' '")"
+ALERTMANAGER_STATUS_JSON="$(ssh_cmd "curl -fsS http://127.0.0.1:9093/api/v2/status" 2>/dev/null || { ALERT_TOPOLOGY_DEFERRED="true"; printf '{}'; })"
+ALERTS_JSON="$(ssh_cmd "curl -fsS http://127.0.0.1:9093/api/v2/alerts" 2>/dev/null || { ALERT_TOPOLOGY_DEFERRED="true"; printf '[]'; })"
+ALERTMANAGER_ERROR_COUNT="$(ssh_cmd "docker logs --since ${LOG_WINDOW} metasheet-alertmanager 2>&1 | grep -E 'Notify for alerts failed|no_text' | wc -l | tr -d ' '" 2>/dev/null || printf '0')"
+BRIDGE_NOTIFY_COUNT="$(ssh_cmd "docker logs --since ${LOG_WINDOW} metasheet-alert-webhook 2>&1 | grep '\"path\": \"/notify\"' | wc -l | tr -d ' '" 2>/dev/null || printf '0')"
+BRIDGE_RESOLVED_COUNT="$(ssh_cmd "docker logs --since ${LOG_WINDOW} metasheet-alert-webhook 2>&1 | grep '\"path\": \"/notify\"' | grep '\"status\": \"resolved\"' | wc -l | tr -d ' '" 2>/dev/null || printf '0')"
 ROOT_DF_LINE="$(ssh_cmd "df -P / | awk 'NR==2 {print \$2\" \"\$3\" \"\$4\" \"\$5}'")"
 
 WEBHOOK_STATUS_INPUT="${WEBHOOK_STATUS}" \
@@ -67,6 +78,7 @@ SSH_USER_HOST_INPUT="${SSH_USER_HOST}" \
 LOG_WINDOW_INPUT="${LOG_WINDOW}" \
 MAX_ROOT_USE_PERCENT_INPUT="${MAX_ROOT_USE_PERCENT}" \
 JSON_OUTPUT_INPUT="${JSON_OUTPUT}" \
+ALERT_TOPOLOGY_DEFERRED_INPUT="${ALERT_TOPOLOGY_DEFERRED}" \
 python3 - <<'EOF'
 import json
 import os
@@ -147,11 +159,19 @@ health_ok = (
     report['health']['ok'] is True
     or report['health']['status'] == 'ok'
 )
+# DT-CLOSE-01B: metrics-only OAuth-stability verdict. The OAuth signal is present when the state
+# machine is emitting its operation metrics (an authenticated /metrics/prom scrape returned the
+# metasheet_dingtalk_oauth_state_operations_total series). The verdict deliberately does NOT depend
+# on the alert-delivery topology (webhook configured / Slack host / alertmanager notify errors) —
+# that is a separate, currently-DEFERRED concern (docker/observability has no alertmanager service
+# or webhook bridge on main), and coupling it in is what made the OAuth monitor go blind.
+alert_topology_deferred = os.environ.get('ALERT_TOPOLOGY_DEFERRED_INPUT', 'false') == 'true'
+report['alertDeliveryObservability'] = 'deferred' if alert_topology_deferred else 'observed'
+oauth_metrics_present = len(report['metrics']['operationsSamples']) > 0
+report['oauthMetricsPresent'] = oauth_metrics_present
 report['healthy'] = (
     health_ok
-    and report['webhookConfig']['configured'] is True
-    and report['webhookConfig']['host'] == 'hooks.slack.com'
-    and report['alertmanager']['notifyErrorsLastWindow'] == 0
+    and oauth_metrics_present
     and report['storage']['root']['usePercent'] < report['storage']['root']['maxUsePercent']
 )
 
@@ -161,10 +181,9 @@ else:
     print(f"[oauth-stability] checkedAt={report['checkedAt']}")
     print(f"[oauth-stability] host={report['host']}")
     print(f"[oauth-stability] health.status={report['health']['status']} plugins={report['health']['plugins']} ok={report['health']['ok']}")
-    print(f"[oauth-stability] webhook.configured={report['webhookConfig']['configured']} host={report['webhookConfig']['host']}")
-    print(f"[oauth-stability] alertmanager.activeAlerts={report['alertmanager']['activeAlertsCount']} notifyErrors={report['alertmanager']['notifyErrorsLastWindow']}")
     print(f"[oauth-stability] storage.rootUse={report['storage']['root']['usePercent']}% availKBlocks={report['storage']['root']['availableKBlocks']} maxUse={report['storage']['root']['maxUsePercent']}%")
-    print(f"[oauth-stability] bridge.notifyEvents={report['bridge']['notifyEventsLastWindow']} resolvedEvents={report['bridge']['resolvedEventsLastWindow']}")
-    print(f"[oauth-stability] metrics.operations={len(report['metrics']['operationsSamples'])} fallback={len(report['metrics']['fallbackSamples'])} redis={len(report['metrics']['redisSamples'])}")
+    print(f"[oauth-stability] metrics.operations={len(report['metrics']['operationsSamples'])} fallback={len(report['metrics']['fallbackSamples'])} redis={len(report['metrics']['redisSamples'])} oauthMetricsPresent={str(report['oauthMetricsPresent']).lower()}")
+    print(f"[oauth-stability] alertDeliveryObservability={report['alertDeliveryObservability']} (DEFERRED means the Alertmanager+webhook topology is not deployed — NOT part of the OAuth verdict)")
+    print(f"[oauth-stability] webhook.configured={report['webhookConfig']['configured']} alertmanager.notifyErrors={report['alertmanager']['notifyErrorsLastWindow']} bridge.notifyEvents={report['bridge']['notifyEventsLastWindow']} (informational only)")
     print(f"[oauth-stability] healthy={str(report['healthy']).lower()}")
 EOF

--- a/scripts/ops/dingtalk-oauth-stability-check.sh
+++ b/scripts/ops/dingtalk-oauth-stability-check.sh
@@ -17,6 +17,11 @@ MAX_ROOT_USE_PERCENT="${MAX_ROOT_USE_PERCENT:-95}"
 DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
 DEPLOY_COMPOSE_FILE="${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}"
 
+# Fail-honest docker-logs match-count pipeline builders (alertmanager_error_count_cmd,
+# bridge_notify_count_cmd, bridge_resolved_count_cmd) — see the file for the contract.
+# shellcheck source=./dingtalk-oauth-stability-log-probe-cmds.sh
+source "${ROOT_DIR}/scripts/ops/dingtalk-oauth-stability-log-probe-cmds.sh"
+
 ssh_cmd() {
   ssh -i "${SSH_KEY}" -o BatchMode=yes -o StrictHostKeyChecking=no "${SSH_USER_HOST}" "$@"
 }
@@ -55,12 +60,14 @@ REMOTE
 # the verdict (report['healthy']) does NOT depend on them. Alert-delivery observability is DEFERRED
 # to a follow-up that actually deploys the topology; this check no longer claims it is "restored".
 ALERT_TOPOLOGY_DEFERRED="false"
-# NOTE: each of these three probes must set ALERT_TOPOLOGY_DEFERRED from the PARENT shell on failure.
-# `WEBHOOK_STATUS="$(cmd || { ALERT_TOPOLOGY_DEFERRED=true; ... })"` is a bug: the `|| { ... }` runs
-# INSIDE the `$( ... )` command substitution, which is a SUBSHELL — the assignment never propagates
-# to the parent shell and ALERT_TOPOLOGY_DEFERRED silently stays "false" even when the probe failed.
-# Repro: `X=false; Y=$(false || { X=true; echo z; }); echo $X` prints `false`. Use a parent-shell
-# if/else instead so the assignment sticks; the `if` consumes the non-zero exit so `set -e` does not abort.
+# NOTE: each of these SIX probes (webhook-status, alertmanager-status, alerts, and the three
+# docker-logs match-count probes below) must set ALERT_TOPOLOGY_DEFERRED from the PARENT shell on
+# failure. `WEBHOOK_STATUS="$(cmd || { ALERT_TOPOLOGY_DEFERRED=true; ... })"` is a bug: the `|| { ... }`
+# runs INSIDE the `$( ... )` command substitution, which is a SUBSHELL — the assignment never
+# propagates to the parent shell and ALERT_TOPOLOGY_DEFERRED silently stays "false" even when the
+# probe failed. Repro: `X=false; Y=$(false || { X=true; echo z; }); echo $X` prints `false`. Use a
+# parent-shell if/else instead so the assignment sticks; the `if` consumes the non-zero exit so
+# `set -e` does not abort.
 if WEBHOOK_STATUS="$(bash "${ROOT_DIR}/scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh" --print-status 2>/dev/null)"; then
   :
 else
@@ -81,9 +88,33 @@ else
   ALERT_TOPOLOGY_DEFERRED="true"
   ALERTS_JSON='[]'
 fi
-ALERTMANAGER_ERROR_COUNT="$(ssh_cmd "docker logs --since ${LOG_WINDOW} metasheet-alertmanager 2>&1 | grep -E 'Notify for alerts failed|no_text' | wc -l | tr -d ' '" 2>/dev/null || printf '0')"
-BRIDGE_NOTIFY_COUNT="$(ssh_cmd "docker logs --since ${LOG_WINDOW} metasheet-alert-webhook 2>&1 | grep '\"path\": \"/notify\"' | wc -l | tr -d ' '" 2>/dev/null || printf '0')"
-BRIDGE_RESOLVED_COUNT="$(ssh_cmd "docker logs --since ${LOG_WINDOW} metasheet-alert-webhook 2>&1 | grep '\"path\": \"/notify\"' | grep '\"status\": \"resolved\"' | wc -l | tr -d ' '" 2>/dev/null || printf '0')"
+# SECOND bug class (distinct from the subshell-assignment one above): these three probes pipe
+# `docker logs | grep | wc -l` over ssh. `wc -l` ALWAYS exits 0 no matter what fed it, so a `docker
+# logs` failure (container missing, daemon down) used to be silently reported as a successful "0"
+# count — the `|| printf 0` local fallback never even ran, because the remote pipeline itself never
+# failed. The pipeline strings below (built by the sourced dingtalk-oauth-stability-log-probe-cmds.sh)
+# enable `pipefail` on the remote shell so a `docker logs` failure propagates as a non-zero exit while
+# a genuine zero-match read still exits 0 — see that file for the full contract. Combined with the
+# parent-shell if/else here, a probe failure now correctly sets ALERT_TOPOLOGY_DEFERRED instead of
+# being read as "0 events, alert delivery topology fine".
+if ALERTMANAGER_ERROR_COUNT="$(ssh_cmd "$(alertmanager_error_count_cmd)" 2>/dev/null)"; then
+  :
+else
+  ALERT_TOPOLOGY_DEFERRED="true"
+  ALERTMANAGER_ERROR_COUNT="0"
+fi
+if BRIDGE_NOTIFY_COUNT="$(ssh_cmd "$(bridge_notify_count_cmd)" 2>/dev/null)"; then
+  :
+else
+  ALERT_TOPOLOGY_DEFERRED="true"
+  BRIDGE_NOTIFY_COUNT="0"
+fi
+if BRIDGE_RESOLVED_COUNT="$(ssh_cmd "$(bridge_resolved_count_cmd)" 2>/dev/null)"; then
+  :
+else
+  ALERT_TOPOLOGY_DEFERRED="true"
+  BRIDGE_RESOLVED_COUNT="0"
+fi
 ROOT_DF_LINE="$(ssh_cmd "df -P / | awk 'NR==2 {print \$2\" \"\$3\" \"\$4\" \"\$5}'")"
 
 WEBHOOK_STATUS_INPUT="${WEBHOOK_STATUS}" \

--- a/scripts/ops/dingtalk-oauth-stability-check.sh
+++ b/scripts/ops/dingtalk-oauth-stability-check.sh
@@ -97,19 +97,25 @@ fi
 # a genuine zero-match read still exits 0 — see that file for the full contract. Combined with the
 # parent-shell if/else here, a probe failure now correctly sets ALERT_TOPOLOGY_DEFERRED instead of
 # being read as "0 events, alert delivery topology fine".
-if ALERTMANAGER_ERROR_COUNT="$(ssh_cmd "$(alertmanager_error_count_cmd)" 2>/dev/null)"; then
+# `set -o pipefail` is bash-only, so the pipeline is run under an EXPLICIT `bash -c` on the remote
+# (parity with remote_authed_curl's `bash -s` above) instead of trusting the remote login shell to be
+# bash. A non-bash login shell would have aborted on `set -o pipefail` (fail-safe → deferred), but
+# forcing bash makes the probe work — not just fail safely — regardless of the login-shell config.
+# `printf '%q'` re-quotes the pipeline as backslash-escaped words (no control chars in these strings,
+# so no $'…' forms), which any POSIX login shell can hand to bash unmangled.
+if ALERTMANAGER_ERROR_COUNT="$(ssh_cmd "bash -c $(printf '%q' "$(alertmanager_error_count_cmd)")" 2>/dev/null)"; then
   :
 else
   ALERT_TOPOLOGY_DEFERRED="true"
   ALERTMANAGER_ERROR_COUNT="0"
 fi
-if BRIDGE_NOTIFY_COUNT="$(ssh_cmd "$(bridge_notify_count_cmd)" 2>/dev/null)"; then
+if BRIDGE_NOTIFY_COUNT="$(ssh_cmd "bash -c $(printf '%q' "$(bridge_notify_count_cmd)")" 2>/dev/null)"; then
   :
 else
   ALERT_TOPOLOGY_DEFERRED="true"
   BRIDGE_NOTIFY_COUNT="0"
 fi
-if BRIDGE_RESOLVED_COUNT="$(ssh_cmd "$(bridge_resolved_count_cmd)" 2>/dev/null)"; then
+if BRIDGE_RESOLVED_COUNT="$(ssh_cmd "bash -c $(printf '%q' "$(bridge_resolved_count_cmd)")" 2>/dev/null)"; then
   :
 else
   ALERT_TOPOLOGY_DEFERRED="true"

--- a/scripts/ops/dingtalk-oauth-stability-check.sh
+++ b/scripts/ops/dingtalk-oauth-stability-check.sh
@@ -55,11 +55,32 @@ REMOTE
 # the verdict (report['healthy']) does NOT depend on them. Alert-delivery observability is DEFERRED
 # to a follow-up that actually deploys the topology; this check no longer claims it is "restored".
 ALERT_TOPOLOGY_DEFERRED="false"
-WEBHOOK_STATUS="$(bash "${ROOT_DIR}/scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh" --print-status 2>/dev/null || { ALERT_TOPOLOGY_DEFERRED="true"; printf 'configured=false\n'; })"
+# NOTE: each of these three probes must set ALERT_TOPOLOGY_DEFERRED from the PARENT shell on failure.
+# `WEBHOOK_STATUS="$(cmd || { ALERT_TOPOLOGY_DEFERRED=true; ... })"` is a bug: the `|| { ... }` runs
+# INSIDE the `$( ... )` command substitution, which is a SUBSHELL — the assignment never propagates
+# to the parent shell and ALERT_TOPOLOGY_DEFERRED silently stays "false" even when the probe failed.
+# Repro: `X=false; Y=$(false || { X=true; echo z; }); echo $X` prints `false`. Use a parent-shell
+# if/else instead so the assignment sticks; the `if` consumes the non-zero exit so `set -e` does not abort.
+if WEBHOOK_STATUS="$(bash "${ROOT_DIR}/scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh" --print-status 2>/dev/null)"; then
+  :
+else
+  ALERT_TOPOLOGY_DEFERRED="true"
+  WEBHOOK_STATUS="configured=false"
+fi
 HEALTH_JSON="$(ssh_cmd "curl -fsS http://127.0.0.1:8900/health")"
 METRICS_TEXT="$(remote_authed_curl "http://127.0.0.1:8900/metrics/prom")"
-ALERTMANAGER_STATUS_JSON="$(ssh_cmd "curl -fsS http://127.0.0.1:9093/api/v2/status" 2>/dev/null || { ALERT_TOPOLOGY_DEFERRED="true"; printf '{}'; })"
-ALERTS_JSON="$(ssh_cmd "curl -fsS http://127.0.0.1:9093/api/v2/alerts" 2>/dev/null || { ALERT_TOPOLOGY_DEFERRED="true"; printf '[]'; })"
+if ALERTMANAGER_STATUS_JSON="$(ssh_cmd "curl -fsS http://127.0.0.1:9093/api/v2/status" 2>/dev/null)"; then
+  :
+else
+  ALERT_TOPOLOGY_DEFERRED="true"
+  ALERTMANAGER_STATUS_JSON='{}'
+fi
+if ALERTS_JSON="$(ssh_cmd "curl -fsS http://127.0.0.1:9093/api/v2/alerts" 2>/dev/null)"; then
+  :
+else
+  ALERT_TOPOLOGY_DEFERRED="true"
+  ALERTS_JSON='[]'
+fi
 ALERTMANAGER_ERROR_COUNT="$(ssh_cmd "docker logs --since ${LOG_WINDOW} metasheet-alertmanager 2>&1 | grep -E 'Notify for alerts failed|no_text' | wc -l | tr -d ' '" 2>/dev/null || printf '0')"
 BRIDGE_NOTIFY_COUNT="$(ssh_cmd "docker logs --since ${LOG_WINDOW} metasheet-alert-webhook 2>&1 | grep '\"path\": \"/notify\"' | wc -l | tr -d ' '" 2>/dev/null || printf '0')"
 BRIDGE_RESOLVED_COUNT="$(ssh_cmd "docker logs --since ${LOG_WINDOW} metasheet-alert-webhook 2>&1 | grep '\"path\": \"/notify\"' | grep '\"status\": \"resolved\"' | wc -l | tr -d ' '" 2>/dev/null || printf '0')"
@@ -166,7 +187,12 @@ health_ok = (
 # that is a separate, currently-DEFERRED concern (docker/observability has no alertmanager service
 # or webhook bridge on main), and coupling it in is what made the OAuth monitor go blind.
 alert_topology_deferred = os.environ.get('ALERT_TOPOLOGY_DEFERRED_INPUT', 'false') == 'true'
-report['alertDeliveryObservability'] = 'deferred' if alert_topology_deferred else 'observed'
+# THREE-STATE: 'observed' requires BOTH (i) none of the alert-topology probes failed AND (ii) the
+# webhook is actually configured. A reachable-but-UNCONFIGURED webhook (the config script can exit 0
+# and print `configured=false` — Alertmanager up, nothing to notify) must also read as deferred, not
+# observed: printing a success exit code is not the same as having delivery observability.
+alert_topology_observed = (not alert_topology_deferred) and report['webhookConfig']['configured'] is True
+report['alertDeliveryObservability'] = 'observed' if alert_topology_observed else 'deferred'
 oauth_metrics_present = len(report['metrics']['operationsSamples']) > 0
 report['oauthMetricsPresent'] = oauth_metrics_present
 report['healthy'] = (

--- a/scripts/ops/dingtalk-oauth-stability-log-probe-cmds.sh
+++ b/scripts/ops/dingtalk-oauth-stability-log-probe-cmds.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# DT-CLOSE-01B log-probe remote-pipeline builders.
+#
+# Extracted out of dingtalk-oauth-stability-check.sh (rather than left inline) so a test can execute
+# the EXACT string these functions produce, locally, under `bash -c` with a stubbed `docker` on PATH —
+# proving the FAIL-HONEST contract for real, not just through the ssh-shim layer (the ssh shim only
+# ever returns a canned exit code/output for the whole remote command; it never actually runs the
+# pipeline, so it cannot by itself prove the pipeline is fail-honest). See
+# dingtalk-oauth-stability-metrics-only-fullscript.test.mjs for both the ssh-shim marker tests and the
+# real-pipeline-with-stubbed-docker tests.
+#
+# BUG THIS FIXES: the previous inline form was
+#   `VAR="$(ssh_cmd '... | wc -l | tr -d '\'' '\''' 2>/dev/null || printf '0')"`
+# which has two independent defects: (1) the `|| printf 0` fallback sits OUTSIDE the ssh command
+# substitution and never sets the ALERT_TOPOLOGY_DEFERRED marker even when it fires (same
+# subshell-assignment class as the status probes above it); (2) worse, it never fires at all in the
+# case that matters most — `docker logs ... 2>&1 | grep ... | wc -l` masks a `docker logs` failure
+# (e.g. "Error: No such container") as a successful zero count, because `wc -l` always exits 0
+# regardless of what fed it, and `2>&1` even risks the error TEXT itself being grep-matched.
+#
+# FAIL-HONEST CONTRACT (each function's stdout, run under `bash -c "$(fn)"` with LOG_WINDOW set):
+#   - `docker logs` fails (container missing, daemon unreachable, ...) => NON-ZERO exit
+#   - `docker logs` succeeds, nothing matches                          => exit 0, prints "0"
+#   - `docker logs` succeeds, N lines match                            => exit 0, prints "N"
+#
+# HOW: `set -o pipefail` is enabled INSIDE the remote command (a fresh non-interactive remote shell
+# does not inherit this script's own top-level `set -o pipefail`), so docker's non-zero exit
+# propagates through the pipe even though `wc -l` itself always exits 0. `2>/dev/null` (NOT `2>&1`)
+# keeps docker's stderr error text out of the piped byte stream entirely, so it can never be
+# miscounted as a grep match. Each grep's own "no lines matched" exit status (1) is neutralized with
+# `|| test $? = 1` so a genuine zero-match read still reports pipeline success; any OTHER grep exit
+# status (a real grep error, e.g. 2 for a malformed pattern) is left unneutralized and fails the
+# pipeline honestly. The grep patterns themselves are byte-identical to the pre-fix ones.
+#
+# Callers must have LOG_WINDOW set before invoking these functions (they read it at call time, not at
+# source time).
+
+alertmanager_error_count_cmd() {
+  printf '%s' "set -o pipefail; docker logs --since ${LOG_WINDOW} metasheet-alertmanager 2>/dev/null | { grep -E 'Notify for alerts failed|no_text' || test \$? = 1; } | wc -l | tr -d ' '"
+}
+
+bridge_notify_count_cmd() {
+  printf '%s' "set -o pipefail; docker logs --since ${LOG_WINDOW} metasheet-alert-webhook 2>/dev/null | { grep '\"path\": \"/notify\"' || test \$? = 1; } | wc -l | tr -d ' '"
+}
+
+bridge_resolved_count_cmd() {
+  printf '%s' "set -o pipefail; docker logs --since ${LOG_WINDOW} metasheet-alert-webhook 2>/dev/null | { grep '\"path\": \"/notify\"' || test \$? = 1; } | { grep '\"status\": \"resolved\"' || test \$? = 1; } | wc -l | tr -d ' '"
+}

--- a/scripts/ops/dingtalk-oauth-stability-metrics-only-contract.test.mjs
+++ b/scripts/ops/dingtalk-oauth-stability-metrics-only-contract.test.mjs
@@ -1,0 +1,91 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// DT-CLOSE-01B contract guard — the OAuth-stability recording is METRICS-ONLY.
+//
+// The verdict (`report['healthy']`) previously required the alert-DELIVERY topology (webhook
+// configured, Slack host, alertmanager notify errors == 0). That topology is not deployable from
+// main, so every scheduled run failed with `curl (7) :9093` — the OAuth monitor going blind on an
+// unrelated, undeployed concern. This test pins the decoupling BEHAVIORALLY (it runs the embedded
+// verdict Python), so re-coupling the verdict to the alert topology, or removing the OAuth-metrics
+// signal from it, turns red.
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const scriptPath = join(__dirname, 'dingtalk-oauth-stability-check.sh')
+const script = readFileSync(scriptPath, 'utf8')
+
+function extractVerdictPython() {
+  const m = script.match(/python3 - <<'EOF'\n([\s\S]*?)\nEOF/)
+  assert.ok(m, 'could not find the embedded verdict python block')
+  return m[1]
+}
+
+function runVerdict(env) {
+  const base = {
+    WEBHOOK_STATUS_INPUT: 'configured=false',
+    HEALTH_JSON_INPUT: '{"status":"ok","ok":true,"plugins":5,"dbPool":{}}',
+    METRICS_TEXT_INPUT: 'metasheet_dingtalk_oauth_state_operations_total{result="ok"} 42',
+    ALERTMANAGER_STATUS_JSON_INPUT: '{}',
+    ALERTS_JSON_INPUT: '[]',
+    ALERTMANAGER_ERROR_COUNT_INPUT: '0',
+    BRIDGE_NOTIFY_COUNT_INPUT: '0',
+    BRIDGE_RESOLVED_COUNT_INPUT: '0',
+    ROOT_DF_LINE_INPUT: '100 39 61 39%',
+    SSH_USER_HOST_INPUT: 'test@host',
+    LOG_WINDOW_INPUT: '24h',
+    MAX_ROOT_USE_PERCENT_INPUT: '95',
+    JSON_OUTPUT_INPUT: 'true',
+    ALERT_TOPOLOGY_DEFERRED_INPUT: 'false',
+  }
+  const r = spawnSync('python3', ['-c', extractVerdictPython()], {
+    env: { ...base, ...env },
+    encoding: 'utf8',
+  })
+  assert.equal(r.status, 0, `verdict python aborted: ${r.stderr}`)
+  return JSON.parse(r.stdout)
+}
+
+test('healthy OAuth + DEFERRED alert topology => healthy=true (verdict does not require the topology)', () => {
+  const report = runVerdict({ ALERT_TOPOLOGY_DEFERRED_INPUT: 'true', WEBHOOK_STATUS_INPUT: 'configured=false' })
+  assert.equal(report.healthy, true, 'a healthy OAuth signal must pass even when the alert topology is absent')
+  assert.equal(report.alertDeliveryObservability, 'deferred')
+  assert.equal(report.oauthMetricsPresent, true)
+})
+
+test('positive control: NO OAuth operation metrics => healthy=false', () => {
+  const report = runVerdict({ METRICS_TEXT_INPUT: 'some_other_metric 1' })
+  assert.equal(report.oauthMetricsPresent, false)
+  assert.equal(report.healthy, false, 'the verdict must actually depend on the OAuth metrics being present')
+})
+
+test('storage over max => healthy=false (storage headroom still gates)', () => {
+  const report = runVerdict({ ROOT_DF_LINE_INPUT: '100 97 3 97%' })
+  assert.equal(report.healthy, false)
+})
+
+test('a broken/absent Slack webhook does NOT fail the verdict (decoupled)', () => {
+  // Explicitly the regression this fixes: no webhook, notify errors present -> still healthy if OAuth is.
+  const report = runVerdict({
+    ALERT_TOPOLOGY_DEFERRED_INPUT: 'true',
+    WEBHOOK_STATUS_INPUT: 'configured=false',
+    ALERTMANAGER_ERROR_COUNT_INPUT: '99',
+  })
+  assert.equal(report.healthy, true, 'alert-delivery failures must NOT drag down the OAuth-stability verdict')
+})
+
+test('source guard: the verdict expression references OAuth metrics, not the alert topology', () => {
+  const verdict = script.match(/report\['healthy'\] = \(([\s\S]*?)\)/)
+  assert.ok(verdict, 'could not find the report[healthy] assignment')
+  const expr = verdict[1]
+  assert.match(expr, /oauth_metrics_present/, 'verdict must gate on the OAuth metrics signal')
+  assert.doesNotMatch(expr, /webhookConfig|alertmanager|hooks\.slack\.com/, 'verdict must NOT re-couple to the alert-delivery topology')
+})
+
+test('the alert-topology probes are soft (a failure marks deferred, never aborts under set -e)', () => {
+  assert.match(script, /ALERT_TOPOLOGY_DEFERRED="true"; printf '\{\}'/, 'the :9093 status probe must soft-fail to a deferred marker')
+  assert.match(script, /curl -fsS http:\/\/127\.0\.0\.1:9093\/api\/v2\/status" 2>\/dev\/null \|\|/, 'the alertmanager status curl must have a `|| fallback` so set -e does not abort')
+})

--- a/scripts/ops/dingtalk-oauth-stability-metrics-only-contract.test.mjs
+++ b/scripts/ops/dingtalk-oauth-stability-metrics-only-contract.test.mjs
@@ -100,6 +100,12 @@ test('the alert-topology probes are soft (a failure marks deferred via a PARENT-
     'ALERTMANAGER_STATUS_JSON',
     'ALERTS_JSON',
     'WEBHOOK_STATUS',
+    // The three docker-logs match-count probes are held to the same parent-shell if/else shape —
+    // they were the second instance of the subshell-assignment bug (plus wc -l masking the docker
+    // failure entirely; see dingtalk-oauth-stability-log-probe-cmds.sh for that half of the fix).
+    'ALERTMANAGER_ERROR_COUNT',
+    'BRIDGE_NOTIFY_COUNT',
+    'BRIDGE_RESOLVED_COUNT',
   ]) {
     const re = new RegExp(
       `if ${probe}="\\$\\([^\\n]*"; then\\n\\s*:\\n\\s*else\\n\\s*ALERT_TOPOLOGY_DEFERRED="true"\\n\\s*${probe}=`,

--- a/scripts/ops/dingtalk-oauth-stability-metrics-only-contract.test.mjs
+++ b/scripts/ops/dingtalk-oauth-stability-metrics-only-contract.test.mjs
@@ -85,7 +85,53 @@ test('source guard: the verdict expression references OAuth metrics, not the ale
   assert.doesNotMatch(expr, /webhookConfig|alertmanager|hooks\.slack\.com/, 'verdict must NOT re-couple to the alert-delivery topology')
 })
 
-test('the alert-topology probes are soft (a failure marks deferred, never aborts under set -e)', () => {
-  assert.match(script, /ALERT_TOPOLOGY_DEFERRED="true"; printf '\{\}'/, 'the :9093 status probe must soft-fail to a deferred marker')
-  assert.match(script, /curl -fsS http:\/\/127\.0\.0\.1:9093\/api\/v2\/status" 2>\/dev\/null \|\|/, 'the alertmanager status curl must have a `|| fallback` so set -e does not abort')
+test('the alert-topology probes are soft (a failure marks deferred via a PARENT-SHELL if/else, never aborts under set -e)', () => {
+  // Regression guard for the subshell bug: `WEBHOOK_STATUS="$(cmd || { ALERT_TOPOLOGY_DEFERRED=true; ... })"`
+  // sets the marker INSIDE the `$( ... )` command substitution (a subshell), so the assignment is lost and
+  // the parent-shell ALERT_TOPOLOGY_DEFERRED silently stays "false" even when the probe failed. The fix
+  // must use a parent-shell `if <probe>; then :; else ALERT_TOPOLOGY_DEFERRED="true"; ... fi` for every
+  // probe that marks deferred, so the assignment actually propagates.
+  assert.doesNotMatch(
+    script,
+    /\$\([^)]*ALERT_TOPOLOGY_DEFERRED="true"[^)]*\)/,
+    'ALERT_TOPOLOGY_DEFERRED must never be assigned inside a $( ... ) command substitution (subshell) — the assignment would be lost',
+  )
+  for (const probe of [
+    'ALERTMANAGER_STATUS_JSON',
+    'ALERTS_JSON',
+    'WEBHOOK_STATUS',
+  ]) {
+    const re = new RegExp(
+      `if ${probe}="\\$\\([^\\n]*"; then\\n\\s*:\\n\\s*else\\n\\s*ALERT_TOPOLOGY_DEFERRED="true"\\n\\s*${probe}=`,
+    )
+    assert.match(script, re, `${probe} must set ALERT_TOPOLOGY_DEFERRED from a parent-shell if/else on failure`)
+  }
+})
+
+test('three-state alertDeliveryObservability: observed requires BOTH no probe failure AND webhook configured', () => {
+  // (1) probe failure alone (webhook happens to report configured=true) => deferred.
+  const probeFailed = runVerdict({
+    ALERT_TOPOLOGY_DEFERRED_INPUT: 'true',
+    WEBHOOK_STATUS_INPUT: 'configured=true\nscheme=https\nhost=hooks.slack.com\npath_length=10',
+  })
+  assert.equal(probeFailed.webhookConfig.configured, true)
+  assert.equal(probeFailed.alertDeliveryObservability, 'deferred', 'a failed alert-topology probe must defer even if the webhook is configured')
+
+  // (2) probes all succeeded, but the webhook is reachable-and-UNCONFIGURED (config script exits 0,
+  // prints configured=false) => deferred. This is the owner-required three-state case: a successful
+  // exit code from the config probe is NOT the same as having delivery observability.
+  const unconfigured = runVerdict({
+    ALERT_TOPOLOGY_DEFERRED_INPUT: 'false',
+    WEBHOOK_STATUS_INPUT: 'configured=false',
+  })
+  assert.equal(unconfigured.webhookConfig.configured, false)
+  assert.equal(unconfigured.alertDeliveryObservability, 'deferred', 'a reachable-but-unconfigured webhook must NOT read as observed')
+
+  // (3) full topology: no probe failure AND webhook configured => observed.
+  const full = runVerdict({
+    ALERT_TOPOLOGY_DEFERRED_INPUT: 'false',
+    WEBHOOK_STATUS_INPUT: 'configured=true\nscheme=https\nhost=hooks.slack.com\npath_length=10',
+  })
+  assert.equal(full.webhookConfig.configured, true)
+  assert.equal(full.alertDeliveryObservability, 'observed', 'observed requires BOTH no probe failure and a configured webhook')
 })

--- a/scripts/ops/dingtalk-oauth-stability-metrics-only-fullscript.test.mjs
+++ b/scripts/ops/dingtalk-oauth-stability-metrics-only-fullscript.test.mjs
@@ -28,16 +28,34 @@ import { fileURLToPath } from 'node:url'
 // A closing MUTATION test removes the `ALERT_TOPOLOGY_DEFERRED="true"` assignment lines from a copy
 // of the script and re-runs scenario (1); if the marker is not load-bearing, the mutated script would
 // still (wrongly) report the same 'deferred' result the assignment is supposed to produce.
+//
+// OWNER P2 FOLLOW-UP: the three docker-logs match-count probes (ALERTMANAGER_ERROR_COUNT,
+// BRIDGE_NOTIFY_COUNT, BRIDGE_RESOLVED_COUNT) had the SAME subshell-assignment bug PLUS a second,
+// worse one: `docker logs ... 2>&1 | grep ... | wc -l` masks a `docker logs` failure (container
+// missing) as a successful zero count, because `wc -l` always exits 0 regardless of what fed it — so
+// even a correctly-placed parent-shell fallback would never fire. State 4 below pins the fix: a
+// metasheet-alert-webhook docker-logs probe failure must still defer, even with :9093 reachable and
+// the webhook configured. The pipeline strings themselves are built by the sourced
+// dingtalk-oauth-stability-log-probe-cmds.sh; a dedicated block further down runs those EXACT strings
+// under bash with a stubbed `docker` on PATH (no ssh layer at all) to prove the fail-honest contract
+// for real, since the ssh-shim states below only ever see a canned exit code, never the actual pipe.
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(__dirname, '../..')
 const realCheckScriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-oauth-stability-check.sh')
 const realCheckScriptSource = readFileSync(realCheckScriptPath, 'utf8')
+const logProbeCmdsLibPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-oauth-stability-log-probe-cmds.sh')
+const logProbeCmdsLibSource = readFileSync(logProbeCmdsLibPath, 'utf8')
 
 const SSH_SHIM = `#!/usr/bin/env bash
 # Mock ssh for the DT-CLOSE-01B full-script test. Ignores connection flags (-i/-o/host); dispatches
 # on the trailing remote-command argument, which is where dingtalk-oauth-stability-check.sh's ssh_cmd()
-# puts the actual remote command string.
+# puts the actual remote command string. MOCK_BRIDGE_LOGS_UP (default true) controls whether the
+# metasheet-alert-webhook docker-logs probes (BRIDGE_NOTIFY_COUNT / BRIDGE_RESOLVED_COUNT) succeed;
+# 'false' simulates a "No such container" docker failure for BOTH (they target the same container).
+# This shim only ever returns a canned exit code/output for the whole remote command — it does not
+# actually execute the pipeline, so it cannot by itself prove the pipeline is fail-honest; that is
+# proven separately, below, by running the real pipeline strings under bash with a stubbed docker.
 args=("$@")
 last_idx=$(( \${#args[@]} - 1 ))
 cmd="\${args[$last_idx]}"
@@ -71,9 +89,24 @@ case "$cmd" in
     printf '%s\\n' '0'
     exit 0
     ;;
+  *resolved*)
+    # BRIDGE_RESOLVED_COUNT's pipeline (the two-grep chain) is the only one whose remote command
+    # string contains "resolved" — must be matched BEFORE the generic metasheet-alert-webhook case
+    # below, since both target that same container name.
+    if [ "\${MOCK_BRIDGE_LOGS_UP:-true}" = "true" ]; then
+      printf '%s\\n' '1'
+      exit 0
+    fi
+    echo "Error: No such container: metasheet-alert-webhook" >&2
+    exit 1
+    ;;
   *metasheet-alert-webhook*)
-    printf '%s\\n' '0'
-    exit 0
+    if [ "\${MOCK_BRIDGE_LOGS_UP:-true}" = "true" ]; then
+      printf '%s\\n' '2'
+      exit 0
+    fi
+    echo "Error: No such container: metasheet-alert-webhook" >&2
+    exit 1
     ;;
   *"df -P /"*)
     printf '%s\\n' '100 39 61 39%'
@@ -106,7 +139,7 @@ echo "unsupported mode: \${1:-}" >&2
 exit 1
 `
 
-function makeSandbox({ checkScriptSource = realCheckScriptSource } = {}) {
+function makeSandbox({ checkScriptSource = realCheckScriptSource, logProbeCmdsSource = logProbeCmdsLibSource } = {}) {
   const tmp = mkdtempSync(path.join(tmpdir(), 'dingtalk-oauth-stability-fullscript-'))
   const opsDir = path.join(tmp, 'scripts', 'ops')
   const binDir = path.join(tmp, 'bin')
@@ -116,6 +149,14 @@ function makeSandbox({ checkScriptSource = realCheckScriptSource } = {}) {
   const checkScriptDest = path.join(opsDir, 'dingtalk-oauth-stability-check.sh')
   writeFileSync(checkScriptDest, checkScriptSource)
   chmodSync(checkScriptDest, 0o755)
+
+  // dingtalk-oauth-stability-check.sh `source`s this lib (via ROOT_DIR, which resolves to `tmp` in
+  // the sandbox) to build the log-probe pipeline strings — without a sandbox copy, `set -euo pipefail`
+  // would abort the whole script on the failed `source`, killing every test in this file, not just the
+  // log-probe ones.
+  const logProbeCmdsDest = path.join(opsDir, 'dingtalk-oauth-stability-log-probe-cmds.sh')
+  writeFileSync(logProbeCmdsDest, logProbeCmdsSource)
+  chmodSync(logProbeCmdsDest, 0o755)
 
   const webhookStubDest = path.join(opsDir, 'set-dingtalk-onprem-alertmanager-webhook-config.sh')
   writeFileSync(webhookStubDest, WEBHOOK_CONFIG_STUB)
@@ -196,7 +237,7 @@ test('state 2: :9093 reachable, webhook UNCONFIGURED (probe succeeds, configured
   }
 })
 
-test('state 3: full topology (:9093 reachable AND webhook configured) => observed', () => {
+test('state 3: full topology (:9093 reachable AND webhook configured) => observed, log-probe counts reflect successful reads', () => {
   const sandbox = makeSandbox()
   try {
     const result = runScript(sandbox, { MOCK_9093_UP: 'true', STUB_WEBHOOK_CONFIGURED: 'true' })
@@ -206,12 +247,52 @@ test('state 3: full topology (:9093 reachable AND webhook configured) => observe
     assert.equal(report.alertDeliveryObservability, 'observed', 'only the full topology may report observed')
     assert.equal(report.oauthMetricsPresent, true)
     assert.equal(report.healthy, true)
+    // 'observed' must mean the docker-logs probes actually succeeded, not just that :9093 answered and
+    // the webhook is configured — pin the shim's distinct, non-zero counts through to the report so a
+    // regression that stops threading these counts through (e.g. reverting to the old `|| printf 0`
+    // fallback path) would surface here even though it wouldn't flip alertDeliveryObservability itself.
+    assert.equal(report.alertmanager.notifyErrorsLastWindow, 0)
+    assert.equal(report.bridge.notifyEventsLastWindow, 2)
+    assert.equal(report.bridge.resolvedEventsLastWindow, 1)
+  } finally {
+    cleanupSandbox(sandbox)
+  }
+})
+
+test('state 4: :9093 reachable + webhook configured, but the metasheet-alert-webhook docker-logs probe FAILS => deferred, healthy stays true', () => {
+  const sandbox = makeSandbox()
+  try {
+    const result = runScript(sandbox, {
+      MOCK_9093_UP: 'true',
+      STUB_WEBHOOK_CONFIGURED: 'true',
+      MOCK_BRIDGE_LOGS_UP: 'false',
+    })
+    const report = parseReport(result)
+    assert.equal(report.webhookConfig.configured, true, ':9093 and the webhook config are both fine — only the log probe itself failed')
+    assert.equal(
+      report.alertDeliveryObservability,
+      'deferred',
+      'a docker-logs probe failure ("No such container") for the alert-webhook bridge must defer, not read as observed',
+    )
+    assert.equal(report.bridge.notifyEventsLastWindow, 0, 'a failed probe must fall back to 0, not report a fabricated count')
+    assert.equal(report.bridge.resolvedEventsLastWindow, 0)
+    assert.equal(report.oauthMetricsPresent, true)
+    assert.equal(report.healthy, true, 'the metrics-only verdict must stay healthy when only the bridge log probe is down')
   } finally {
     cleanupSandbox(sandbox)
   }
 })
 
 test('mutation: removing the ALERT_TOPOLOGY_DEFERRED="true" assignments desensitizes the :9093-refused case', () => {
+  // There are now SIX such assignment lines (the 3 original status/alerts/webhook probes plus the 3
+  // log-probe else-branches added for the docker-logs masking fix). This test's SCENARIO (:9093
+  // refused, webhook configured=true, log probes left succeeding via the ssh-shim defaults) only ever
+  // exercises the two :9093 branches — it does NOT, by itself, prove the three NEW log-probe branches
+  // are load-bearing; that is what the dedicated "state 4" bridge-down test above guards permanently,
+  // and what the one-time OWNER P2 mutation proof (see PR description) demonstrated directly on the
+  // live script. This test only asserts that blanket-removing every occurrence of the marker
+  // assignment (all 6) still desensitizes the :9093-refused path, as a regression tripwire on the
+  // marker text itself.
   const assignmentLine = /^[ \t]*ALERT_TOPOLOGY_DEFERRED="true"[ \t]*\n/m
   assert.match(realCheckScriptSource, assignmentLine, 'sanity: the assignment line must exist in the real script before mutating')
 
@@ -221,14 +302,18 @@ test('mutation: removing the ALERT_TOPOLOGY_DEFERRED="true" assignments desensit
     mutated = mutated.replace(assignmentLine, '')
     removedCount += 1
   }
-  assert.equal(removedCount, 3, 'expected exactly the 3 known ALERT_TOPOLOGY_DEFERRED="true" assignment lines to be removed')
+  assert.equal(removedCount, 6, 'expected exactly the 6 known ALERT_TOPOLOGY_DEFERRED="true" assignment lines to be removed')
   assert.doesNotMatch(mutated, /ALERT_TOPOLOGY_DEFERRED="true"/, 'mutation must fully remove the marker assignment')
-  // The JSON/text fallbacks (ALERTMANAGER_STATUS_JSON='{}' etc.) and WEBHOOK_STATUS="configured=false"
-  // must survive the mutation untouched — this proves the redness below comes from the missing MARKER,
-  // not from a downstream JSON parse crash on an empty/garbage fallback value.
+  // The JSON/text fallbacks (ALERTMANAGER_STATUS_JSON='{}' etc.), WEBHOOK_STATUS="configured=false",
+  // and the three log-probe count fallbacks must survive the mutation untouched — this proves the
+  // redness below comes from the missing MARKER, not from a downstream JSON parse crash or a missing
+  // fallback value.
   assert.match(mutated, /ALERTMANAGER_STATUS_JSON='\{\}'/)
   assert.match(mutated, /ALERTS_JSON='\[\]'/)
   assert.match(mutated, /WEBHOOK_STATUS="configured=false"/)
+  assert.match(mutated, /ALERTMANAGER_ERROR_COUNT="0"/)
+  assert.match(mutated, /BRIDGE_NOTIFY_COUNT="0"/)
+  assert.match(mutated, /BRIDGE_RESOLVED_COUNT="0"/)
 
   const sandbox = makeSandbox({ checkScriptSource: mutated })
   try {
@@ -245,3 +330,97 @@ test('mutation: removing the ALERT_TOPOLOGY_DEFERRED="true" assignments desensit
     cleanupSandbox(sandbox)
   }
 })
+
+// ---------------------------------------------------------------------------------------------
+// Raw pipeline-string tests: no ssh layer at all. These run the EXACT string
+// dingtalk-oauth-stability-log-probe-cmds.sh's builder functions produce, under real bash, against a
+// stubbed `docker` on PATH. This is what actually proves the FAIL-HONEST contract closes the masking
+// gap for real — the ssh-shim states above only ever see a canned exit code for the whole remote
+// command (set by this test file), so they cannot by themselves distinguish "the pipeline is
+// fail-honest" from "the shim happened to hard-code the right exit code".
+// ---------------------------------------------------------------------------------------------
+
+const DOCKER_STUB = `#!/usr/bin/env bash
+# Stub docker for the raw pipeline-string tests. Purely env-var driven so one stub script can serve
+# every fixture without per-probe variants.
+if [ "\${MOCK_DOCKER_EXIT:-0}" != "0" ]; then
+  echo "Error: No such container" >&2
+  exit "\${MOCK_DOCKER_EXIT}"
+fi
+printf '%s' "\${MOCK_DOCKER_STDOUT:-}"
+exit 0
+`
+
+function generateLogProbeCmd(fnName) {
+  const result = spawnSync('bash', ['-c', `source ${JSON.stringify(logProbeCmdsLibPath)}; LOG_WINDOW=24h ${fnName}`], {
+    encoding: 'utf8',
+  })
+  assert.equal(result.status, 0, `failed to generate ${fnName}: ${result.stderr}`)
+  assert.ok(result.stdout.length > 0, `${fnName} produced an empty command string`)
+  return result.stdout
+}
+
+function runLogProbeCmd(cmd, { dockerExit = '0', dockerStdout = '' } = {}) {
+  const binDir = mkdtempSync(path.join(tmpdir(), 'dingtalk-oauth-stability-docker-stub-'))
+  const dockerDest = path.join(binDir, 'docker')
+  writeFileSync(dockerDest, DOCKER_STUB)
+  chmodSync(dockerDest, 0o755)
+  try {
+    return spawnSync('bash', ['-c', cmd], {
+      env: {
+        PATH: `${binDir}:${process.env.PATH || ''}`,
+        MOCK_DOCKER_EXIT: dockerExit,
+        MOCK_DOCKER_STDOUT: dockerStdout,
+      },
+      encoding: 'utf8',
+      timeout: 15000,
+    })
+  } finally {
+    rmSync(binDir, { recursive: true, force: true })
+  }
+}
+
+const LOG_PROBE_CMD_CASES = [
+  {
+    fn: 'alertmanager_error_count_cmd',
+    matchingLine: '2026-07-13T00:00:00Z ERROR Notify for alerts failed: dial tcp timeout',
+    nonMatchingLine: '2026-07-13T00:00:00Z INFO heartbeat ok',
+  },
+  {
+    fn: 'bridge_notify_count_cmd',
+    matchingLine: '{"path": "/notify", "status": "ok"}',
+    nonMatchingLine: '{"path": "/health", "status": "ok"}',
+  },
+  {
+    fn: 'bridge_resolved_count_cmd',
+    matchingLine: '{"path": "/notify", "status": "resolved"}',
+    nonMatchingLine: '{"path": "/notify", "status": "ok"}',
+  },
+]
+
+for (const { fn, matchingLine, nonMatchingLine } of LOG_PROBE_CMD_CASES) {
+  test(`log-probe pipeline string (${fn}): docker logs failure => NON-ZERO pipeline exit (the masking gap, closed)`, () => {
+    const cmd = generateLogProbeCmd(fn)
+    const result = runLogProbeCmd(cmd, { dockerExit: '1' })
+    assert.notEqual(
+      result.status,
+      0,
+      `a docker-logs failure must make the pipeline exit non-zero; got status=${result.status} stdout=${JSON.stringify(result.stdout)} stderr=${result.stderr}`,
+    )
+  })
+
+  test(`log-probe pipeline string (${fn}): docker ok + zero matches => exit 0, prints "0"`, () => {
+    const cmd = generateLogProbeCmd(fn)
+    const result = runLogProbeCmd(cmd, { dockerExit: '0', dockerStdout: `${nonMatchingLine}\n` })
+    assert.equal(result.status, 0, `stderr=${result.stderr}`)
+    assert.equal(result.stdout.trim(), '0')
+  })
+
+  test(`log-probe pipeline string (${fn}): docker ok + N matching lines => exit 0, prints "N"`, () => {
+    const cmd = generateLogProbeCmd(fn)
+    const dockerStdout = `${matchingLine}\n${nonMatchingLine}\n${matchingLine}\n`
+    const result = runLogProbeCmd(cmd, { dockerExit: '0', dockerStdout })
+    assert.equal(result.status, 0, `stderr=${result.stderr}`)
+    assert.equal(result.stdout.trim(), '2')
+  })
+}

--- a/scripts/ops/dingtalk-oauth-stability-metrics-only-fullscript.test.mjs
+++ b/scripts/ops/dingtalk-oauth-stability-metrics-only-fullscript.test.mjs
@@ -1,0 +1,247 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+// DT-CLOSE-01B full-script regression guard.
+//
+// The metrics-only contract test (dingtalk-oauth-stability-metrics-only-contract.test.mjs) only
+// exercises the EMBEDDED VERDICT PYTHON by injecting *_INPUT env vars directly — it never runs the
+// shell probes that are supposed to *produce* ALERT_TOPOLOGY_DEFERRED. That left a real subshell bug
+// invisible: `WEBHOOK_STATUS="$(cmd || { ALERT_TOPOLOGY_DEFERRED="true"; ... })"` sets the marker
+// INSIDE the `$( ... )` command substitution — a SUBSHELL — so the assignment never reaches the
+// parent shell and ALERT_TOPOLOGY_DEFERRED silently stayed "false" even when :9093 was unreachable.
+// Repro: `X=false; Y=$(false || { X=true; echo z; }); echo $X` prints `false`.
+//
+// This test runs the WHOLE script (real bash, real embedded python) against a mocked `ssh` (PATH
+// shim) and a stubbed `set-dingtalk-onprem-alertmanager-webhook-config.sh`, pinning all three states
+// of the owner-required THREE-STATE contract:
+//   (1) :9093 refused (probe failure)                         => alertDeliveryObservability=deferred
+//   (2) :9093 reachable, webhook UNCONFIGURED (probe succeeds,
+//       script exits 0 and prints configured=false)           => alertDeliveryObservability=deferred
+//   (3) full topology: :9093 reachable AND webhook configured => alertDeliveryObservability=observed
+// In every state `healthy` stays true — the metrics-only verdict must never depend on the topology.
+//
+// A closing MUTATION test removes the `ALERT_TOPOLOGY_DEFERRED="true"` assignment lines from a copy
+// of the script and re-runs scenario (1); if the marker is not load-bearing, the mutated script would
+// still (wrongly) report the same 'deferred' result the assignment is supposed to produce.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, '../..')
+const realCheckScriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-oauth-stability-check.sh')
+const realCheckScriptSource = readFileSync(realCheckScriptPath, 'utf8')
+
+const SSH_SHIM = `#!/usr/bin/env bash
+# Mock ssh for the DT-CLOSE-01B full-script test. Ignores connection flags (-i/-o/host); dispatches
+# on the trailing remote-command argument, which is where dingtalk-oauth-stability-check.sh's ssh_cmd()
+# puts the actual remote command string.
+args=("$@")
+last_idx=$(( \${#args[@]} - 1 ))
+cmd="\${args[$last_idx]}"
+
+case "$cmd" in
+  *127.0.0.1:8900/health*)
+    printf '%s\\n' '{"status":"ok","ok":true,"plugins":5,"dbPool":{}}'
+    exit 0
+    ;;
+  *127.0.0.1:8900/metrics/prom*)
+    printf '%s\\n' 'metasheet_dingtalk_oauth_state_operations_total{result="ok"} 42'
+    exit 0
+    ;;
+  *127.0.0.1:9093/api/v2/status*)
+    if [ "\${MOCK_9093_UP:-true}" = "true" ]; then
+      printf '%s\\n' '{"uptime":"1h2m"}'
+      exit 0
+    fi
+    echo "ssh: connect to host 127.0.0.1 port 9093: Connection refused" >&2
+    exit 7
+    ;;
+  *127.0.0.1:9093/api/v2/alerts*)
+    if [ "\${MOCK_9093_UP:-true}" = "true" ]; then
+      printf '%s\\n' '[]'
+      exit 0
+    fi
+    echo "ssh: connect to host 127.0.0.1 port 9093: Connection refused" >&2
+    exit 7
+    ;;
+  *metasheet-alertmanager*)
+    printf '%s\\n' '0'
+    exit 0
+    ;;
+  *metasheet-alert-webhook*)
+    printf '%s\\n' '0'
+    exit 0
+    ;;
+  *"df -P /"*)
+    printf '%s\\n' '100 39 61 39%'
+    exit 0
+    ;;
+  *)
+    echo "mock-ssh: unrecognized remote command: $cmd" >&2
+    exit 99
+    ;;
+esac
+`
+
+const WEBHOOK_CONFIG_STUB = `#!/usr/bin/env bash
+# Stub for set-dingtalk-onprem-alertmanager-webhook-config.sh --print-status, controlled per-scenario
+# by STUB_WEBHOOK_CONFIGURED. Mirrors the real script's contract: it exits 0 in BOTH the configured and
+# the reachable-but-unconfigured cases (only a missing/unreadable config *file* is "not configured" —
+# that is still a clean, successful probe, not a probe failure).
+if [ "\${1:-}" = "--print-status" ]; then
+  if [ "\${STUB_WEBHOOK_CONFIGURED:-false}" = "true" ]; then
+    printf '%s\\n' 'configured=true'
+    printf '%s\\n' 'scheme=https'
+    printf '%s\\n' 'host=hooks.slack.com'
+    printf '%s\\n' 'path_length=10'
+  else
+    printf '%s\\n' 'configured=false'
+  fi
+  exit 0
+fi
+echo "unsupported mode: \${1:-}" >&2
+exit 1
+`
+
+function makeSandbox({ checkScriptSource = realCheckScriptSource } = {}) {
+  const tmp = mkdtempSync(path.join(tmpdir(), 'dingtalk-oauth-stability-fullscript-'))
+  const opsDir = path.join(tmp, 'scripts', 'ops')
+  const binDir = path.join(tmp, 'bin')
+  mkdirSync(opsDir, { recursive: true })
+  mkdirSync(binDir, { recursive: true })
+
+  const checkScriptDest = path.join(opsDir, 'dingtalk-oauth-stability-check.sh')
+  writeFileSync(checkScriptDest, checkScriptSource)
+  chmodSync(checkScriptDest, 0o755)
+
+  const webhookStubDest = path.join(opsDir, 'set-dingtalk-onprem-alertmanager-webhook-config.sh')
+  writeFileSync(webhookStubDest, WEBHOOK_CONFIG_STUB)
+  chmodSync(webhookStubDest, 0o755)
+
+  const sshShimDest = path.join(binDir, 'ssh')
+  writeFileSync(sshShimDest, SSH_SHIM)
+  chmodSync(sshShimDest, 0o755)
+
+  return { tmp, checkScriptDest, binDir }
+}
+
+function cleanupSandbox(sandbox) {
+  rmSync(sandbox.tmp, { recursive: true, force: true })
+}
+
+function runScript(sandbox, scenarioEnv) {
+  const result = spawnSync('bash', [sandbox.checkScriptDest], {
+    env: {
+      PATH: `${sandbox.binDir}:${process.env.PATH || ''}`,
+      HOME: sandbox.tmp,
+      SSH_USER_HOST: 'mock@example.test',
+      SSH_KEY: path.join(sandbox.tmp, 'fake-deploy-key'),
+      JSON_OUTPUT: 'true',
+      LOG_WINDOW: '24h',
+      MAX_ROOT_USE_PERCENT: '95',
+      DEPLOY_PATH: 'metasheet2',
+      DEPLOY_COMPOSE_FILE: 'docker-compose.app.yml',
+      ...scenarioEnv,
+    },
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 15000,
+  })
+  return result
+}
+
+function parseReport(result) {
+  assert.equal(result.status, 0, `script exited non-zero: status=${result.status} stderr=${result.stderr}`)
+  let report
+  try {
+    report = JSON.parse(result.stdout)
+  } catch (err) {
+    throw new Error(`could not parse JSON stdout: ${err.message}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`)
+  }
+  return report
+}
+
+test('state 1: :9093 refused (alert-topology probe failure) => deferred, healthy stays true', () => {
+  const sandbox = makeSandbox()
+  try {
+    const result = runScript(sandbox, { MOCK_9093_UP: 'false', STUB_WEBHOOK_CONFIGURED: 'true' })
+    const report = parseReport(result)
+    assert.equal(report.alertDeliveryObservability, 'deferred', 'a refused :9093 probe must defer, even with a configured webhook')
+    assert.equal(report.webhookConfig.configured, true)
+    assert.equal(report.oauthMetricsPresent, true)
+    assert.equal(report.healthy, true, 'the metrics-only verdict must stay healthy when only the alert topology is down')
+  } finally {
+    cleanupSandbox(sandbox)
+  }
+})
+
+test('state 2: :9093 reachable, webhook UNCONFIGURED (probe succeeds, configured=false) => deferred, healthy stays true', () => {
+  const sandbox = makeSandbox()
+  try {
+    const result = runScript(sandbox, { MOCK_9093_UP: 'true', STUB_WEBHOOK_CONFIGURED: 'false' })
+    const report = parseReport(result)
+    assert.equal(report.webhookConfig.configured, false)
+    assert.equal(
+      report.alertDeliveryObservability,
+      'deferred',
+      'a successful-but-unconfigured webhook probe must NOT read as observed',
+    )
+    assert.equal(report.oauthMetricsPresent, true)
+    assert.equal(report.healthy, true)
+  } finally {
+    cleanupSandbox(sandbox)
+  }
+})
+
+test('state 3: full topology (:9093 reachable AND webhook configured) => observed', () => {
+  const sandbox = makeSandbox()
+  try {
+    const result = runScript(sandbox, { MOCK_9093_UP: 'true', STUB_WEBHOOK_CONFIGURED: 'true' })
+    const report = parseReport(result)
+    assert.equal(report.webhookConfig.configured, true)
+    assert.equal(report.webhookConfig.host, 'hooks.slack.com')
+    assert.equal(report.alertDeliveryObservability, 'observed', 'only the full topology may report observed')
+    assert.equal(report.oauthMetricsPresent, true)
+    assert.equal(report.healthy, true)
+  } finally {
+    cleanupSandbox(sandbox)
+  }
+})
+
+test('mutation: removing the ALERT_TOPOLOGY_DEFERRED="true" assignments desensitizes the :9093-refused case', () => {
+  const assignmentLine = /^[ \t]*ALERT_TOPOLOGY_DEFERRED="true"[ \t]*\n/m
+  assert.match(realCheckScriptSource, assignmentLine, 'sanity: the assignment line must exist in the real script before mutating')
+
+  let mutated = realCheckScriptSource
+  let removedCount = 0
+  while (assignmentLine.test(mutated)) {
+    mutated = mutated.replace(assignmentLine, '')
+    removedCount += 1
+  }
+  assert.equal(removedCount, 3, 'expected exactly the 3 known ALERT_TOPOLOGY_DEFERRED="true" assignment lines to be removed')
+  assert.doesNotMatch(mutated, /ALERT_TOPOLOGY_DEFERRED="true"/, 'mutation must fully remove the marker assignment')
+  // The JSON/text fallbacks (ALERTMANAGER_STATUS_JSON='{}' etc.) and WEBHOOK_STATUS="configured=false"
+  // must survive the mutation untouched — this proves the redness below comes from the missing MARKER,
+  // not from a downstream JSON parse crash on an empty/garbage fallback value.
+  assert.match(mutated, /ALERTMANAGER_STATUS_JSON='\{\}'/)
+  assert.match(mutated, /ALERTS_JSON='\[\]'/)
+  assert.match(mutated, /WEBHOOK_STATUS="configured=false"/)
+
+  const sandbox = makeSandbox({ checkScriptSource: mutated })
+  try {
+    // Same scenario as "state 1" above: :9093 refused, webhook configured=true.
+    const result = runScript(sandbox, { MOCK_9093_UP: 'false', STUB_WEBHOOK_CONFIGURED: 'true' })
+    const report = parseReport(result)
+    assert.notEqual(
+      report.alertDeliveryObservability,
+      'deferred',
+      'with the marker assignment removed, a refused :9093 probe must NOT be caught anymore — proving the assignment is load-bearing',
+    )
+    assert.equal(report.alertDeliveryObservability, 'observed', 'without the marker, the script wrongly reports observed despite the refused probe')
+  } finally {
+    cleanupSandbox(sandbox)
+  }
+})

--- a/scripts/ops/dingtalk-oauth-stability-metrics-only-fullscript.test.mjs
+++ b/scripts/ops/dingtalk-oauth-stability-metrics-only-fullscript.test.mjs
@@ -123,7 +123,12 @@ const WEBHOOK_CONFIG_STUB = `#!/usr/bin/env bash
 # Stub for set-dingtalk-onprem-alertmanager-webhook-config.sh --print-status, controlled per-scenario
 # by STUB_WEBHOOK_CONFIGURED. Mirrors the real script's contract: it exits 0 in BOTH the configured and
 # the reachable-but-unconfigured cases (only a missing/unreadable config *file* is "not configured" —
-# that is still a clean, successful probe, not a probe failure).
+# that is still a clean, successful probe, not a probe failure). STUB_WEBHOOK_FAIL=true simulates the
+# probe itself failing (script error, non-zero exit) — that MUST take the deferred path.
+if [ "\${STUB_WEBHOOK_FAIL:-false}" = "true" ]; then
+  echo "stub: simulated webhook-config probe failure" >&2
+  exit 1
+fi
 if [ "\${1:-}" = "--print-status" ]; then
   if [ "\${STUB_WEBHOOK_CONFIGURED:-false}" = "true" ]; then
     printf '%s\\n' 'configured=true'
@@ -278,6 +283,31 @@ test('state 4: :9093 reachable + webhook configured, but the metasheet-alert-web
     assert.equal(report.bridge.resolvedEventsLastWindow, 0)
     assert.equal(report.oauthMetricsPresent, true)
     assert.equal(report.healthy, true, 'the metrics-only verdict must stay healthy when only the bridge log probe is down')
+  } finally {
+    cleanupSandbox(sandbox)
+  }
+})
+
+test('state 5: the webhook-config probe ITSELF fails (non-zero exit, not configured=false) => deferred, healthy stays true', () => {
+  // Distinct from state 2: there the probe SUCCEEDS and reports configured=false; here the probe
+  // script errors out. The check.sh else-branch must mark deferred (and fall back to
+  // configured=false), never abort under set -e or read as observed.
+  const sandbox = makeSandbox()
+  try {
+    const result = runScript(sandbox, {
+      MOCK_9093_UP: 'true',
+      STUB_WEBHOOK_CONFIGURED: 'true',
+      STUB_WEBHOOK_FAIL: 'true',
+    })
+    const report = parseReport(result)
+    assert.equal(report.webhookConfig.configured, false, 'a failed webhook-config probe must fall back to configured=false')
+    assert.equal(
+      report.alertDeliveryObservability,
+      'deferred',
+      'a crashed webhook-config probe must defer, not read as observed',
+    )
+    assert.equal(report.oauthMetricsPresent, true)
+    assert.equal(report.healthy, true, 'the metrics-only verdict must stay healthy when only the webhook-config probe crashed')
   } finally {
     cleanupSandbox(sandbox)
   }

--- a/scripts/ops/github-dingtalk-oauth-stability-summary.py
+++ b/scripts/ops/github-dingtalk-oauth-stability-summary.py
@@ -29,8 +29,12 @@ def infer_failure_reasons(
     payload: Optional[dict[str, Any]],
     stability_rc: str,
     healthy: str,
-    webhook_secret_available: str,
 ) -> list[str]:
+    # DT-CLOSE-01B: the health verdict is metrics-only — health_ok AND oauthMetricsPresent AND
+    # storage-headroom (see dingtalk-oauth-stability-check.sh). Alert-DELIVERY topology (webhook
+    # configured / host / Alertmanager notify errors) is a separate, currently-DEFERRED concern and
+    # must NEVER appear here: gating narration on it is what let a real OAuth-metrics outage get
+    # misattributed to "webhook not configured" while the actual failing signal went unreported.
     reasons: list[str] = []
     if stability_rc != '0':
         reasons.append(f'stability-check command failed (rc={stability_rc or "missing"})')
@@ -39,25 +43,17 @@ def infer_failure_reasons(
         return reasons
     if healthy != 'true':
         health = payload.get('health', {}) or {}
-        webhook = payload.get('webhookConfig', {}) or {}
-        alertmanager = payload.get('alertmanager', {}) or {}
         storage = ((payload.get('storage') or {}).get('root') or {})
+        oauth_metrics_present = payload.get('oauthMetricsPresent')
 
         if not (health.get('ok') is True or health.get('status') == 'ok'):
             reasons.append(
                 f'backend health is not ok (status={health.get("status")} ok={health.get("ok")})'
             )
-        if webhook.get('configured') is not True:
-            reasons.append('Alertmanager webhook is not configured')
-            if webhook_secret_available != 'true':
-                reasons.append(
-                    'No supported GitHub webhook secret was available for Alertmanager self-heal'
-                )
-        elif webhook.get('host') != 'hooks.slack.com':
-            reasons.append(f'Alertmanager webhook host drifted to {webhook.get("host")}')
-        if int(alertmanager.get('notifyErrorsLastWindow') or 0) > 0:
+        if oauth_metrics_present is not True:
             reasons.append(
-                f'Alertmanager reported notify errors in the current log window ({alertmanager.get("notifyErrorsLastWindow")})'
+                'OAuth state-operation metrics are absent from /metrics/prom (producer not '
+                'running/not deployed, or the scrape is broken)'
             )
         if int(storage.get('usePercent') or 0) >= int(storage.get('maxUsePercent') or 0):
             reasons.append(
@@ -80,26 +76,31 @@ def infer_next_actions(
                 actions.append(
                     f'Plan a remote Docker image/cache cleanup soon because root usage is approaching the gate ({use_percent}% / {max_use_percent}%).'
                 )
-        return actions
+    else:
+        actions = []
+        for reason in failure_reasons:
+            if 'stability-check command failed' in reason:
+                actions.append('Re-run the workflow log tail and remote SSH stability check to isolate the failing command.')
+            elif 'backend health is not ok' in reason:
+                actions.append('Check the on-prem backend container health and `/health` response before retrying the workflow.')
+            elif 'OAuth state-operation metrics are absent' in reason:
+                actions.append(
+                    'Verify the backend container is up, confirm the METRICS_SCRAPE_TOKEN handshake succeeds '
+                    'against /metrics/prom, and confirm the deployed image actually contains the OAuth '
+                    'state-metrics producer.'
+                )
+            elif 'root filesystem is at or above gate' in reason:
+                actions.append('Run the on-prem Docker GC flow or free disk space on the remote host, then retry the stability workflow.')
+            elif 'JSON missing or unreadable' in reason:
+                actions.append('Check the uploaded log artifact first; the workflow did not produce a readable stability JSON payload.')
 
-    actions: list[str] = []
-    for reason in failure_reasons:
-        if 'stability-check command failed' in reason:
-            actions.append('Re-run the workflow log tail and remote SSH stability check to isolate the failing command.')
-        elif 'backend health is not ok' in reason:
-            actions.append('Check the on-prem backend container health and `/health` response before retrying the workflow.')
-        elif 'webhook is not configured' in reason or 'host drifted' in reason:
-            actions.append('Reapply the persisted Alertmanager webhook configuration on the on-prem host.')
-        elif 'No supported GitHub webhook secret' in reason:
-            actions.append(
-                'Configure one supported GitHub Actions secret: ALERTMANAGER_WEBHOOK_URL, ALERT_WEBHOOK_URL, SLACK_WEBHOOK_URL, or ATTENDANCE_ALERT_SLACK_WEBHOOK_URL.'
-            )
-        elif 'notify errors' in reason:
-            actions.append('Inspect Alertmanager and webhook bridge logs, then confirm Slack delivery still resolves firing and resolved notifications.')
-        elif 'root filesystem is at or above gate' in reason:
-            actions.append('Run the on-prem Docker GC flow or free disk space on the remote host, then retry the stability workflow.')
-        elif 'JSON missing or unreadable' in reason:
-            actions.append('Check the uploaded log artifact first; the workflow did not produce a readable stability JSON payload.')
+    # Alert-delivery topology is deferred by design and is never a failure reason, but it is
+    # always worth surfacing as context — independent of whether the run passed or failed.
+    if payload and payload.get('alertDeliveryObservability') == 'deferred':
+        actions.append(
+            'Alert-delivery observability reading as deferred is expected until the '
+            'Alertmanager+bridge topology ships; see the switch ledger.'
+        )
 
     deduped: list[str] = []
     for action in actions:
@@ -119,7 +120,7 @@ def make_summary_payload(
     status = 'PASS' if stability_rc == '0' and healthy == 'true' else 'FAIL'
     run_url = github_run_url()
     webhook_secret_available = os.environ.get('WEBHOOK_SECRET_AVAILABLE', 'false')
-    failure_reasons = infer_failure_reasons(payload, stability_rc, healthy, webhook_secret_available)
+    failure_reasons = infer_failure_reasons(payload, stability_rc, healthy)
     next_actions = infer_next_actions(payload, failure_reasons)
     summary_json_path = summary_path.with_suffix('.json')
 
@@ -152,6 +153,47 @@ def make_summary_payload(
     }
 
 
+def alert_delivery_observability_lines(
+    payload: Optional[dict[str, Any]],
+    webhook_secret_available: bool,
+) -> list[str]:
+    # Always emitted — this is context, never a gate. The verdict (see infer_failure_reasons)
+    # does not depend on any of this; it exists so a human can see why the topology reads the
+    # way it does without mistaking it for a health failure.
+    lines = ['## Alert Delivery Observability', '']
+    if not payload:
+        lines.append('- Stability JSON missing or unreadable; alert-delivery observability unknown.')
+        lines.append('')
+        return lines
+
+    observability = payload.get('alertDeliveryObservability')
+    webhook = payload.get('webhookConfig', {}) or {}
+    alertmanager = payload.get('alertmanager', {}) or {}
+
+    if observability == 'observed':
+        lines.append(
+            '- State: `observed` — the Alertmanager + webhook bridge topology is deployed and the webhook is configured.'
+        )
+        notify_errors = int(alertmanager.get('notifyErrorsLastWindow') or 0)
+        if notify_errors > 0:
+            lines.append(
+                f'- WARNING: Alertmanager reported {notify_errors} delivery error(s) in the current log window. '
+                'This is informational only and is NOT a failure reason for the OAuth-stability health verdict.'
+            )
+    else:
+        lines.append(
+            '- State: `deferred` — the alert-delivery topology (Alertmanager :9093 / webhook bridge) is deferred '
+            'by design and is NOT part of the OAuth-stability health verdict.'
+        )
+        lines.append(f'- Webhook configured (context only): `{webhook.get("configured")}`')
+
+    lines.append(
+        f'- Webhook self-heal secret available: `{str(bool(webhook_secret_available)).lower()}` (informational only).'
+    )
+    lines.append('')
+    return lines
+
+
 def markdown_lines(summary: dict[str, Any]) -> list[str]:
     payload = summary.get('snapshot') or {}
     lines = ['# DingTalk OAuth Stability Recording (Lite)', '']
@@ -163,9 +205,6 @@ def markdown_lines(summary: dict[str, Any]) -> list[str]:
     run_url = workflow.get('runUrl')
     if run_url:
         lines.append(f'- Run URL: `{run_url}`')
-    lines.append(
-        f'- Webhook self-heal secret available: `{str(bool(self_heal.get("webhookSecretAvailable"))).lower()}`'
-    )
     lines.append('')
 
     if payload:
@@ -214,6 +253,10 @@ def markdown_lines(summary: dict[str, Any]) -> list[str]:
     else:
         lines.append('- No blocking failure reasons detected.')
     lines.append('')
+
+    lines.extend(
+        alert_delivery_observability_lines(payload, bool(self_heal.get('webhookSecretAvailable')))
+    )
 
     lines.append('## Next Actions')
     lines.append('')

--- a/scripts/ops/github-dingtalk-oauth-stability-summary.test.mjs
+++ b/scripts/ops/github-dingtalk-oauth-stability-summary.test.mjs
@@ -48,43 +48,276 @@ function runSummary(args, env = {}) {
   })
 }
 
-test('summary calls out missing GitHub webhook secret when self-heal was skipped', async () => {
+// Extracts the raw text between a `## <heading>` line and the next `## ` heading (or EOF), so
+// assertions can be scoped to the section they claim to be about instead of matching anywhere
+// in the document.
+function extractSection(markdown, heading) {
+  const lines = markdown.split('\n')
+  const startIndex = lines.findIndex((line) => line.trim() === `## ${heading}`)
+  if (startIndex === -1) {
+    return null
+  }
+  const rest = lines.slice(startIndex + 1)
+  const endOffset = rest.findIndex((line) => line.startsWith('## '))
+  const body = endOffset === -1 ? rest : rest.slice(0, endOffset)
+  return body.join('\n')
+}
+
+async function runWithPayload(outDir, payload, env) {
+  const jsonPath = path.join(outDir, 'stability.json')
+  const logPath = path.join(outDir, 'stability.log')
+  const summaryPath = path.join(outDir, 'summary.md')
+  writeFileSync(jsonPath, `${JSON.stringify(payload)}\n`)
+  writeFileSync(logPath, 'log tail\n')
+  const result = await runSummary([jsonPath, logPath, summaryPath], env)
+  const summary = result.status === 0 ? JSON.parse(readFileSync(path.join(outDir, 'summary.json'), 'utf8')) : null
+  return { result, summary }
+}
+
+// PIN (a) — the owner's masking case. A real OAuth-metrics outage (oauthMetricsPresent=false)
+// must be reported as the failure reason. An unconfigured webhook (a separate, DEFERRED,
+// by-design concern) must never appear as a failure reason again — that coupling is exactly
+// what let the real outage go unreported while the summary blamed webhook config instead.
+test('DT-CLOSE-01B pin (a): metrics-absent is reported; webhook/notify wording never appears as a failure reason', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const { result, summary } = await runWithPayload(
+      outDir,
+      {
+        checkedAt: '2026-04-29T12:50:55Z',
+        host: 'mainuser@23.254.236.11',
+        health: { status: 'ok', plugins: 13, ok: true },
+        webhookConfig: { configured: false, host: '', pathLength: 0 },
+        alertmanager: { activeAlertsCount: 0, notifyErrorsLastWindow: 0 },
+        storage: { root: { usePercent: 40, availableKBlocks: 4941512, maxUsePercent: 95 } },
+        bridge: { notifyEventsLastWindow: 0, resolvedEventsLastWindow: 0 },
+        metrics: { operationsSamples: [], fallbackSamples: [], redisSamples: [] },
+        oauthMetricsPresent: false,
+        alertDeliveryObservability: 'deferred',
+        healthy: false,
+      },
+      { STABILITY_RC: '0', HEALTHY: 'false', WEBHOOK_SECRET_AVAILABLE: 'false' },
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+
+    // Authoritative pin: the failure-reasons array is exactly the metrics-absent reason — no
+    // webhook/notify/host-drift reason survives, no matter how the JSON payload is shaped.
+    assert.deepEqual(summary.failureReasons, [
+      'OAuth state-operation metrics are absent from /metrics/prom (producer not running/not deployed, or the scrape is broken)',
+    ])
+
+    const outcomeSection = extractSection(result.stdout, 'Outcome')
+    assert.match(outcomeSection, /OAuth state-operation metrics are absent/)
+    assert.doesNotMatch(outcomeSection, /webhook/i)
+    assert.doesNotMatch(outcomeSection, /notify/i)
+    assert.doesNotMatch(outcomeSection, /host drifted/i)
+
+    // The next action for the metrics-absent reason points at the actual thing to check.
+    assert.ok(
+      summary.nextActions.some((action) => action.includes('METRICS_SCRAPE_TOKEN') && action.includes('OAuth state-metrics producer')),
+      `expected a METRICS_SCRAPE_TOKEN next action, got: ${JSON.stringify(summary.nextActions)}`,
+    )
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+// PIN (b) — deferred alert-delivery topology never produces a failure reason, even though the
+// summary must still surface it as context so a human knows why it reads that way.
+test("DT-CLOSE-01B pin (b): healthy=true + alertDeliveryObservability='deferred' yields zero failure reasons and a deferred info line", async () => {
+  const outDir = makeTmpDir()
+  try {
+    const { result, summary } = await runWithPayload(
+      outDir,
+      {
+        checkedAt: '2026-07-14T03:00:00Z',
+        host: 'mainuser@23.254.236.11',
+        health: { status: 'ok', plugins: 13, ok: true },
+        webhookConfig: { configured: false, host: '', pathLength: 0 },
+        alertmanager: { activeAlertsCount: 0, notifyErrorsLastWindow: 0 },
+        storage: { root: { usePercent: 40, availableKBlocks: 4941512, maxUsePercent: 95 } },
+        bridge: { notifyEventsLastWindow: 0, resolvedEventsLastWindow: 0 },
+        metrics: { operationsSamples: ['metasheet_dingtalk_oauth_state_operations_total{result="ok"} 3'], fallbackSamples: [], redisSamples: [] },
+        oauthMetricsPresent: true,
+        alertDeliveryObservability: 'deferred',
+        healthy: true,
+      },
+      { STABILITY_RC: '0', HEALTHY: 'true', WEBHOOK_SECRET_AVAILABLE: 'false' },
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(summary.status, 'PASS')
+    assert.deepEqual(summary.failureReasons, [])
+
+    const infoSection = extractSection(result.stdout, 'Alert Delivery Observability')
+    assert.ok(infoSection, 'expected an Alert Delivery Observability section in the markdown')
+    assert.match(infoSection, /`deferred`/)
+    assert.match(infoSection, /deferred by design/)
+    assert.match(infoSection, /NOT part of the OAuth-stability health verdict/)
+    assert.match(infoSection, /Webhook configured \(context only\): `False`/)
+
+    assert.ok(
+      summary.nextActions.some((action) => action.includes('deferred') && action.includes('switch ledger')),
+      `expected a deferred-topology next action, got: ${JSON.stringify(summary.nextActions)}`,
+    )
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+// PIN (c) — an observed topology with delivery errors gets a WARNING line, explicitly marked as
+// not a failure reason, and the failure-reasons array stays empty.
+test('DT-CLOSE-01B pin (c): observed + notifyErrors>0 emits a warning line but zero failure reasons', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const { result, summary } = await runWithPayload(
+      outDir,
+      {
+        checkedAt: '2026-07-14T03:05:00Z',
+        host: 'mainuser@23.254.236.11',
+        health: { status: 'ok', plugins: 13, ok: true },
+        webhookConfig: { configured: true, host: 'hooks.slack.com', pathLength: 40 },
+        alertmanager: { activeAlertsCount: 0, notifyErrorsLastWindow: 3 },
+        storage: { root: { usePercent: 40, availableKBlocks: 4941512, maxUsePercent: 95 } },
+        bridge: { notifyEventsLastWindow: 2, resolvedEventsLastWindow: 2 },
+        metrics: { operationsSamples: ['metasheet_dingtalk_oauth_state_operations_total{result="ok"} 3'], fallbackSamples: [], redisSamples: [] },
+        oauthMetricsPresent: true,
+        alertDeliveryObservability: 'observed',
+        healthy: true,
+      },
+      { STABILITY_RC: '0', HEALTHY: 'true', WEBHOOK_SECRET_AVAILABLE: 'true' },
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(summary.status, 'PASS')
+    assert.deepEqual(summary.failureReasons, [])
+
+    const infoSection = extractSection(result.stdout, 'Alert Delivery Observability')
+    assert.ok(infoSection, 'expected an Alert Delivery Observability section in the markdown')
+    assert.match(infoSection, /`observed`/)
+    assert.match(infoSection, /WARNING: Alertmanager reported 3 delivery error\(s\)/)
+    assert.match(infoSection, /NOT a failure reason/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('backend health not ok still reports as a failure reason', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const { result, summary } = await runWithPayload(
+      outDir,
+      {
+        checkedAt: '2026-07-14T03:10:00Z',
+        host: 'mainuser@23.254.236.11',
+        health: { status: 'degraded', plugins: 13, ok: false },
+        webhookConfig: { configured: true, host: 'hooks.slack.com', pathLength: 40 },
+        alertmanager: { activeAlertsCount: 0, notifyErrorsLastWindow: 0 },
+        storage: { root: { usePercent: 40, availableKBlocks: 4941512, maxUsePercent: 95 } },
+        bridge: { notifyEventsLastWindow: 0, resolvedEventsLastWindow: 0 },
+        metrics: { operationsSamples: ['metasheet_dingtalk_oauth_state_operations_total{result="ok"} 3'], fallbackSamples: [], redisSamples: [] },
+        oauthMetricsPresent: true,
+        alertDeliveryObservability: 'observed',
+        healthy: false,
+      },
+      { STABILITY_RC: '0', HEALTHY: 'false', WEBHOOK_SECRET_AVAILABLE: 'true' },
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.deepEqual(summary.failureReasons, ['backend health is not ok (status=degraded ok=False)'])
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('root filesystem at/over gate still reports as a failure reason', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const { result, summary } = await runWithPayload(
+      outDir,
+      {
+        checkedAt: '2026-07-14T03:15:00Z',
+        host: 'mainuser@23.254.236.11',
+        health: { status: 'ok', plugins: 13, ok: true },
+        webhookConfig: { configured: true, host: 'hooks.slack.com', pathLength: 40 },
+        alertmanager: { activeAlertsCount: 0, notifyErrorsLastWindow: 0 },
+        storage: { root: { usePercent: 96, availableKBlocks: 100, maxUsePercent: 95 } },
+        bridge: { notifyEventsLastWindow: 0, resolvedEventsLastWindow: 0 },
+        metrics: { operationsSamples: ['metasheet_dingtalk_oauth_state_operations_total{result="ok"} 3'], fallbackSamples: [], redisSamples: [] },
+        oauthMetricsPresent: true,
+        alertDeliveryObservability: 'observed',
+        healthy: false,
+      },
+      { STABILITY_RC: '0', HEALTHY: 'false', WEBHOOK_SECRET_AVAILABLE: 'true' },
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.deepEqual(summary.failureReasons, ['root filesystem is at or above gate (96% / 95% max)'])
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('stability-check command failure and missing JSON keep their existing behavior', async () => {
   const outDir = makeTmpDir()
   const jsonPath = path.join(outDir, 'stability.json')
   const logPath = path.join(outDir, 'stability.log')
   const summaryPath = path.join(outDir, 'summary.md')
   try {
-    writeFileSync(jsonPath, `${JSON.stringify({
-      checkedAt: '2026-04-29T12:50:55Z',
-      host: 'mainuser@23.254.236.11',
-      health: { status: 'ok', plugins: 13, ok: true },
-      webhookConfig: { configured: false, host: '', pathLength: 0 },
-      alertmanager: { activeAlertsCount: 0, notifyErrorsLastWindow: 0 },
-      storage: { root: { usePercent: 94, availableKBlocks: 4941512, maxUsePercent: 95 } },
-      bridge: { notifyEventsLastWindow: 0, resolvedEventsLastWindow: 0 },
-      metrics: { operationsSamples: [], fallbackSamples: [], redisSamples: [] },
-      healthy: false,
-    })}\n`)
-    writeFileSync(logPath, 'self-heal skipped\n')
-
+    writeFileSync(logPath, 'ssh connection refused\n')
     const result = await runSummary([jsonPath, logPath, summaryPath], {
-      STABILITY_RC: '0',
+      STABILITY_RC: '255',
       HEALTHY: 'false',
       WEBHOOK_SECRET_AVAILABLE: 'false',
     })
 
     assert.equal(result.status, 0, result.stderr)
-    assert.match(result.stdout, /Webhook self-heal secret available: `false`/)
-    assert.match(result.stdout, /Alertmanager webhook is not configured/)
-    assert.match(result.stdout, /No supported GitHub webhook secret was available/)
-    assert.match(result.stdout, /Configure one supported GitHub Actions secret/)
-
     const summary = JSON.parse(readFileSync(path.join(outDir, 'summary.json'), 'utf8'))
-    assert.equal(summary.selfHeal.webhookSecretAvailable, false)
     assert.deepEqual(summary.failureReasons, [
-      'Alertmanager webhook is not configured',
-      'No supported GitHub webhook secret was available for Alertmanager self-heal',
+      'stability-check command failed (rc=255)',
+      'stability JSON missing or unreadable',
     ])
+    assert.equal(summary.status, 'FAIL')
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+// Instruction 4: the summary must never crash on partial JSON — missing storage / alertmanager /
+// alertDeliveryObservability / oauthMetricsPresent keys should degrade gracefully, not throw.
+test('partial JSON with missing keys does not crash and still surfaces the metrics-absent reason', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const { result, summary } = await runWithPayload(
+      outDir,
+      {
+        checkedAt: '2026-07-14T03:20:00Z',
+        host: 'mainuser@23.254.236.11',
+        health: { status: 'ok', plugins: 13, ok: true },
+        // storage, alertmanager, webhookConfig, alertDeliveryObservability, oauthMetricsPresent
+        // are all intentionally absent.
+        healthy: false,
+      },
+      { STABILITY_RC: '0', HEALTHY: 'false', WEBHOOK_SECRET_AVAILABLE: 'false' },
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.ok(
+      summary.failureReasons.includes(
+        'OAuth state-operation metrics are absent from /metrics/prom (producer not running/not deployed, or the scrape is broken)',
+      ),
+      `expected the metrics-absent reason, got: ${JSON.stringify(summary.failureReasons)}`,
+    )
+    // Absent storage defaults both usePercent and maxUsePercent to 0, so 0 >= 0 also fires —
+    // this is documented fail-closed behavior, not a bug, and must not crash.
+    assert.ok(
+      summary.failureReasons.some((reason) => reason.startsWith('root filesystem is at or above gate')),
+      `expected a storage-gate reason from the 0/0 default, got: ${JSON.stringify(summary.failureReasons)}`,
+    )
+
+    const infoSection = extractSection(result.stdout, 'Alert Delivery Observability')
+    assert.ok(infoSection, 'expected the info section to render even with missing keys')
   } finally {
     rmSync(outDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
**BLOCKER follow-up to #4236.** #4236 authenticated the scrape, but all 4 scheduled runs still failed (`stabilityRc=7`, `curl (7) :9093`). Root cause: the check **hard-depends on an Alertmanager + metasheet-alert-webhook topology that isn't deployable from current main** (`docker/observability/` has only Prometheus+Grafana), and its **verdict falsely required** that topology (webhook configured / Slack host / alertmanager notify errors). The OAuth monitor was blind on an unrelated, undeployed concern.

**Fix (per your metrics-only-downgrade option, honestly scoped):**
- Alert-topology probes (`:9093`, webhook-container logs, config self-heal) are now **SOFT** — a failure yields an `alertDeliveryObservability: deferred` marker instead of aborting under `set -e`.
- The **verdict is decoupled**: `healthy` now depends only on the OAuth signal (`metasheet_dingtalk_oauth_state_operations_total` present) + `/health` + root-disk headroom.
- Workflow + script explicitly marked metrics-only; **this does NOT claim alert-delivery observability is restored** — that topology is deferred to a follow-up that actually deploys it.

**Verification:** behavioral contract test (runs the embedded verdict python) — healthy OAuth + deferred topology ⇒ healthy ✅; **no OAuth metrics ⇒ unhealthy** (positive control) ✅; a broken/absent webhook does NOT fail the verdict ✅; **re-coupling the verdict to the topology reddens** ✅ (verified by mutation). 10/10 across both OAuth contract suites; CI-wired.

**Remaining (ops):** the immediate + next scheduled run should now succeed on the live host (OAuth metrics present there). Alert-delivery topology rebuild is a separate deferred ticket.