### PR TITLE
fix(multitable): W0 step-1 — default-off gate on destructive revert-execute (emergency stop-loss)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -365,6 +365,7 @@ jobs:
             tests/integration/multitable-permission-revert-realdb.test.ts \
             tests/integration/multitable-legacy-permission-route-lock-realdb.test.ts \
             tests/integration/multitable-revert-pit-realdb.test.ts \
+            tests/integration/multitable-w0-revert-gate-realdb.test.ts \
             tests/integration/multitable-undelete-pit-realdb.test.ts \
             tests/integration/multitable-reset-pit-realdb.test.ts \
             tests/integration/multitable-history-incomplete-precheck-realdb.test.ts \

--- a/docs/development/multitable-global-history-o2-operator-flag-ladder-20260709.md
+++ b/docs/development/multitable-global-history-o2-operator-flag-ladder-20260709.md
@@ -17,6 +17,7 @@
 | `MULTITABLE_ENABLE_FIELD_RETYPE_REVERT` | `'true'` | 4c-1 field retype revert **BASE** flag（**仅**无损/结构性 revert；base OFF ⇒ 整面 403。**旧表把它写成「lossy」= 错**，有损另需下一行的 `_LOSSY`） | 4c-1 锁 |
 | `MULTITABLE_ENABLE_FIELD_RETYPE_REVERT_LOSSY` | `'true'`（**且** base 也须 `'true'`） | 4c-1 **有损** retype revert（双门：`isLossyRetypeRevertEnabled = _LOSSY==='true' && base==='true'`，`lossy-retype-oracle.ts`；base 未开时 helper `--strict` 拒绝） | 4c-1 锁 |
 | `MULTITABLE_ENABLE_PIT_UNDELETE` | `'true'` | T8-1 PIT undelete-execute（resurrect 面；4c-3 的第二重放面挂在它之下） | T8-1 锁 |
+| `MULTITABLE_ENABLE_PIT_REVERT` | `'true'`（规范化字面 `'true'`） | **W0 step-1 紧急止损总闸**：destructive `revert-execute` 默认 **OFF**（入口第一道判断即 403 `REVERT_DISABLED`，早于 parse/auth/DB/写）。**生产保持 OFF，直到完整 W0 完整性工作落地**（连续链/时间单调/删除记录 healed-gap/phantom insert 未修前，Revert 仍可能据错误 T-state 覆写）。只读 `revert-preview` 不受影响。**undelete 成功路径需同时开本闸 + `MULTITABLE_ENABLE_PIT_UNDELETE`**（总闸在最前，任何 resurrect 路径已先过本闸）。 | W0 step-1 |
 | `MULTITABLE_META_REVISION_RETENTION_ENABLED` | **`'1'`**（⚠ 非 `'true'`） | retention janitor：revisions/config-revisions/tombstones 老化 | T9/4c-2 |
 | `MULTITABLE_META_REVISION_RETENTION_POLICY / _KEEP_N / _DAYS / _BATCH / _INTERVAL_MS` | 见代码默认 | retention 细节旋钮 | 同上 |
 

--- a/docs/development/multitable-global-history-o2-operator-flag-ladder-20260709.md
+++ b/docs/development/multitable-global-history-o2-operator-flag-ladder-20260709.md
@@ -66,7 +66,7 @@
 |---|---|---|
 | L1 | staging 开 `TOMBSTONE_CAPTURE_ENABLED='true'` | 删一条被引用记录 → `meta_link_tombstones` 出现 `reason='record_delete'` 组；trash 行带 `delete_revision_id` |
 | L2 | staging 开 `RECORD_UNDELETE_INBOUND='true'` | 回收站恢复该记录 → 响应带 `inbound.replayed≥1`；邻居单元格重新显示该记录；trash 列表出现 `inboundEdgesRecoverable:true` |
-| L3 | staging 开 `ENABLE_PIT_UNDELETE='true'`（若走 PIT 面） | revert-execute confirm:'undelete' → 响应带 `undeleteInbound`；真库金测同形状（P3-2a/b/c） |
+| L3 | staging 开 **两把闸**：`ENABLE_PIT_REVERT='true'` **且** `ENABLE_PIT_UNDELETE='true'`（若走 PIT 面）。**W0 step-1**：undelete-revert 在 revert-execute 内,总闸 `PIT_REVERT` 先判,单开 UNDELETE 无效(preview `undeleteSupported=false`,execute 403 `REVERT_DISABLED`)。 | revert-execute confirm:'undelete' → 响应带 `undeleteInbound`；真库金测同形状（P3-2a/b/c） |
 | **L3.5** | **（D-2，产品语义变更——需 owner 单独确认再上 prod）staging 开 `SIDE_DOOR_DELETE_TRASH_ENABLED='true'`**（前置：L1 已开，否则只有 trash 无捕获） | 用 automation `delete_record` 删一条被引用记录 → 该记录**出现在回收站**、`inboundEdgesRecoverable:true`；restore 后邻居单元格重新显示；plugin-SDK 删除同形状（`deleted_by` 为 NULL）。**并确认可接受**：机器删除自此可被任何有 `canDeleteRecord` 的人恢复，restore 会重放事件（可能再次触发自动化）；超 cap 的机器删除会开始失败（§2.4） |
 | L4 | （可选）staging 开 retention（值=**'1'**）并设 `_DAYS` | 观察 janitor 日志；确认地板：有存活 trash 引用的组不被清（RB10 / D-2 G8 同形状——侧门锚同样受地板保护） |
 | L5 | prod 逐级重复 L1→L3（retention 与 **L3.5/D-2** 是否上 prod 各自独立决定） | 同上 + 观察 cap 拒绝率（若出现 422 / step-failed 频发→调 cap 或审视扇入）+ trash 行数增长（§2.7） |

--- a/docs/development/multitable-global-history-o2-operator-flag-ladder-20260709.md
+++ b/docs/development/multitable-global-history-o2-operator-flag-ladder-20260709.md
@@ -6,7 +6,7 @@
 
 ## 1. Flag 清单（本线相关，全部默认 OFF）
 
-> **单一真源（R12-C，2026-07-12）**：本表是人读摘要、**并不完整**（本线共 **19** 个 flag）。**权威、完整、机器校验的清单 = `scripts/ops/global-history-flag-manifest.mjs`**；开关前请跑 `node scripts/ops/multitable-global-history-flag-status.mjs --strict`（展示全部 flag + 拒绝非法组合：lossy 无 base / side-door 无 capture / PIT-reset 撞 retention）。**本表若与 manifest 冲突，以 manifest 为准。**
+> **单一真源（R12-C，2026-07-12；2026-07-14 W0 step-1 +1）**：本表是人读摘要、**并不完整**（本线共 **20** 个 flag，W0 step-1 加入 `MULTITABLE_ENABLE_PIT_REVERT`）。**权威、完整、机器校验的清单 = `scripts/ops/global-history-flag-manifest.mjs`**；开关前请跑 `node scripts/ops/multitable-global-history-flag-status.mjs --strict`（展示全部 flag + 拒绝非法组合：lossy 无 base / side-door 无 capture / PIT-reset 撞 retention / **undelete 无 revert 总闸**）。**本表若与 manifest 冲突，以 manifest 为准。**
 
 | Flag | 激活值 | 作用 | 出处 |
 |---|---|---|---|

--- a/packages/core-backend/scripts/pit-undelete-acceptance.mjs
+++ b/packages/core-backend/scripts/pit-undelete-acceptance.mjs
@@ -17,9 +17,10 @@
  *   PIT_UNDELETE_API_MOUNT=/api/multitable
  *   PIT_UNDELETE_OUTPUT_FILE=/tmp/pit-undelete-acceptance.json
  *
- * Flag handling:
- *   - flag OFF: proves execute is inert (403 UNDELETE_DISABLED), then exits successfully.
- *   - flag ON: proves happy resurrection and an id-collision/drift 409 without overwriting the occupied record id.
+ * Flag handling (W0 step-1: undelete-revert needs BOTH MULTITABLE_ENABLE_PIT_REVERT and _PIT_UNDELETE):
+ *   - either gate OFF: undeleteSupported=false and execute is inert (403 REVERT_DISABLED when the revert
+ *     master gate is off — checked first; else 403 UNDELETE_DISABLED). Exits successfully.
+ *   - both gates ON: proves happy resurrection and an id-collision/drift 409 without overwriting the occupied record id.
  *
  * Exit:
  *   0 = all run scenarios passed
@@ -232,13 +233,17 @@ async function latestRestoreRevisionSource(ctx, recordId) {
 }
 
 async function runFlagOff(ctx, pv) {
-  log('Flag state: OFF (MULTITABLE_ENABLE_PIT_UNDELETE not true). Running inert scenario only.\n')
+  // W0 step-1: undelete-revert requires BOTH gates. undeleteSupported=false covers three states — both off,
+  // PIT_REVERT-on/PIT_UNDELETE-off, and PIT_REVERT-off/PIT_UNDELETE-on. So execute is refused with EITHER
+  // REVERT_DISABLED (the W0 master gate, checked FIRST when PIT_REVERT is off) OR UNDELETE_DISABLED (the
+  // sub-gate, when PIT_REVERT is on but PIT_UNDELETE is off). Either proves the inert state.
+  log('Flag state: undelete not supported (needs BOTH MULTITABLE_ENABLE_PIT_REVERT and _PIT_UNDELETE). Running inert scenario only.\n')
   recordCheck('flag-off preview still classifies one undelete candidate', data(pv)?.summary?.visibleUndeleteCount === 1, JSON.stringify(data(pv)?.summary || {}))
   recordCheck('flag-off preview reports undeleteSupported=false', data(pv)?.undeleteSupported === false, `got ${String(data(pv)?.undeleteSupported)}`)
   const ex = await execute(ctx, data(pv)?.previewIdentity, 'undelete')
-  recordCheck('flag-off execute → 403 UNDELETE_DISABLED', ex.status === 403 && code(ex) === 'UNDELETE_DISABLED', `got ${ex.status}/${code(ex)}`)
+  recordCheck('flag-off execute → 403 REVERT_DISABLED or UNDELETE_DISABLED', ex.status === 403 && (code(ex) === 'REVERT_DISABLED' || code(ex) === 'UNDELETE_DISABLED'), `got ${ex.status}/${code(ex)}`)
   recordCheck('flag-off execute writes no live U row', !(await liveRow(ctx, ctx.u)), 'U unexpectedly exists')
-  log('\n→ Flag-off inert state is proven. Enable MULTITABLE_ENABLE_PIT_UNDELETE=true and re-run for the flag-on live smoke.')
+  log('\n→ Inert state is proven. Enable BOTH MULTITABLE_ENABLE_PIT_REVERT=true and MULTITABLE_ENABLE_PIT_UNDELETE=true and re-run for the flag-on live smoke.')
 }
 
 async function runHappy(ctx, pv) {

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -10143,7 +10143,10 @@ export function univerMetaRouter(): Router {
         summary: { visibleRevertCount: reverts.length, visibleUndeleteCount: undeleteCount, keptCreatedAfterTCount: keptCreatedAfterT, conflictCount: driftCount },
         records: reverts.map((r) => ({ recordId: r.recordId, fieldIds: r.diff.map((dd) => dd.fieldId) })),
         undeleteRecordIds: resurrects.map((r) => r.recordId),
-        undeleteSupported: PIT_UNDELETE_ENABLED(), previewIdentity,
+        // W0 step-1: undelete-revert rides INSIDE revert-execute, so it is only actually supported when BOTH the
+        // revert master gate AND the undelete gate are on — reporting PIT_UNDELETE alone would promise an undelete
+        // that revert-execute then refuses with REVERT_DISABLED.
+        undeleteSupported: PIT_UNDELETE_ENABLED() && PIT_REVERT_ENABLED(), previewIdentity,
       } })
     } catch (err) {
       if (isUndefinedTableError(err, 'meta_record_revisions')) return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: 'No revision history available' } })

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -10109,6 +10109,10 @@ export function univerMetaRouter(): Router {
   // resurrects run in ONE transaction (all-or-nothing) while field-reverts stay best-effort per-record. Inbound links
   // are NOT rebuilt (design-lock L4 A) — they re-appear when the linking record is next saved.
   const PIT_UNDELETE_ENABLED = () => String(process.env.MULTITABLE_ENABLE_PIT_UNDELETE ?? '').trim().toLowerCase() === 'true'
+  // W0 step-1 emergency stop-loss (default OFF; only a normalized literal "true" enables). Gates the
+  // DESTRUCTIVE revert-execute path only — read-only revert-preview is unaffected. See the gate at the
+  // top of revert-execute for the data-safety rationale.
+  const PIT_REVERT_ENABLED = () => String(process.env.MULTITABLE_ENABLE_PIT_REVERT ?? '').trim().toLowerCase() === 'true'
 
   router.post('/sheets/:sheetId/revert-preview', async (req: Request, res: Response) => {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
@@ -10151,6 +10155,15 @@ export function univerMetaRouter(): Router {
   })
 
   router.post('/sheets/:sheetId/revert-execute', async (req: Request, res: Response) => {
+    // W0 step-1 (emergency stop-loss, data-safety): the destructive point-in-time revert reconstructs record
+    // state at T and OVERWRITES live data, but its trustworthiness precheck only enumerates LIVE rows and
+    // trusts created_at (= transaction-start via now()) for T-ordering — so a mid-history healed gap, a
+    // deleted record's broken chain, or a concurrent version-vs-time inversion can still overwrite with a
+    // WRONG T-state. Until the full W0 integrity work lands, revert-execute is DEFAULT-OFF behind
+    // MULTITABLE_ENABLE_PIT_REVERT and refused HERE — before parse / auth / any DB read or write. The
+    // read-only revert-preview is intentionally NOT gated. (This is the isolated stop-loss only; it does not
+    // touch contiguity / watermark / marker / time semantics / transaction isolation.)
+    if (!PIT_REVERT_ENABLED()) return res.status(403).json({ ok: false, error: { code: 'REVERT_DISABLED', message: 'Point-in-time revert is disabled (MULTITABLE_ENABLE_PIT_REVERT is off).' } })
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
     const parsed = z.object({ asOf: z.string().min(1), previewIdentity: z.string().min(1), confirm: z.string().optional() }).safeParse(req.body)
     if (!sheetId || !parsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId, asOf, previewIdentity required' } })

--- a/packages/core-backend/tests/integration/multitable-d2-sidedoor-delete-recoverability-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-d2-sidedoor-delete-recoverability-realdb.test.ts
@@ -256,6 +256,7 @@ const RETENTION: MetaRevisionRetentionConfig = {
 
 describeIfDatabase('D-2 — side-door delete recoverability (plugin + automation, real DB)', () => {
   beforeAll(async () => {
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => {
@@ -296,6 +297,7 @@ describeIfDatabase('D-2 — side-door delete recoverability (plugin + automation
   })
 
   afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_PIT_REVERT // W0 step-1: restore — never leak the revert gate into sibling files' negative controls.
     for (const flag of [SIDE_DOOR_FLAG, CAPTURE_FLAG, CAP_ROWS, INBOUND_FLAG, PIT_UNDELETE_FLAG]) delete process.env[flag]
     delete process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS
     await q('DELETE FROM users WHERE id = $1', [OWNER]).catch(() => {})

--- a/packages/core-backend/tests/integration/multitable-d2-sidedoor-delete-recoverability-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-d2-sidedoor-delete-recoverability-realdb.test.ts
@@ -256,7 +256,7 @@ const RETENTION: MetaRevisionRetentionConfig = {
 
 describeIfDatabase('D-2 — side-door delete recoverability (plugin + automation, real DB)', () => {
   beforeAll(async () => {
-    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and FORCED BACK to the default OFF (delete) in afterAll — never a saved/original value, and NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => {

--- a/packages/core-backend/tests/integration/multitable-history-incomplete-precheck-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-incomplete-precheck-realdb.test.ts
@@ -120,6 +120,7 @@ async function expectAllFourRefuseWithZeroWrites(sheet: string): Promise<void> {
 
 describeIfDatabase('multitable D-1c §0.6 HISTORY_INCOMPLETE precheck (real DB)', () => {
   beforeAll(async () => {
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })
@@ -136,6 +137,7 @@ describeIfDatabase('multitable D-1c §0.6 HISTORY_INCOMPLETE precheck (real DB)'
     await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
   })
   afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_PIT_REVERT // W0 step-1: restore — never leak the revert gate into sibling files' negative controls.
     delete process.env.MULTITABLE_ENABLE_PIT_RESET
     for (const sheet of [SHEET, SHEET_F, SHEET_S]) {
       for (const t of ['meta_records_trash', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [sheet]).catch(() => {})

--- a/packages/core-backend/tests/integration/multitable-history-incomplete-precheck-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-incomplete-precheck-realdb.test.ts
@@ -120,7 +120,7 @@ async function expectAllFourRefuseWithZeroWrites(sheet: string): Promise<void> {
 
 describeIfDatabase('multitable D-1c §0.6 HISTORY_INCOMPLETE precheck (real DB)', () => {
   beforeAll(async () => {
-    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and FORCED BACK to the default OFF (delete) in afterAll — never a saved/original value, and NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })

--- a/packages/core-backend/tests/integration/multitable-mirror-readonly-enumeration-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-mirror-readonly-enumeration-realdb.test.ts
@@ -49,7 +49,7 @@ const mirrorRows = async (): Promise<number> =>
 
 describeIfDatabase('multitable mirror-read-only hardening — C2/I-1 enumeration (real DB)', () => {
   beforeAll(async () => {
-    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and FORCED BACK to the default OFF (delete) in afterAll — never a saved/original value, and NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as express.Request & { user?: unknown }).user = currentUser; next() })

--- a/packages/core-backend/tests/integration/multitable-mirror-readonly-enumeration-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-mirror-readonly-enumeration-realdb.test.ts
@@ -49,6 +49,7 @@ const mirrorRows = async (): Promise<number> =>
 
 describeIfDatabase('multitable mirror-read-only hardening — C2/I-1 enumeration (real DB)', () => {
   beforeAll(async () => {
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as express.Request & { user?: unknown }).user = currentUser; next() })
@@ -75,6 +76,7 @@ describeIfDatabase('multitable mirror-read-only hardening — C2/I-1 enumeration
   })
 
   afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_PIT_REVERT // W0 step-1: restore — never leak the revert gate into sibling files' negative controls.
     await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[FLD_A_LINK, FLD_B_MIRROR]]).catch(() => {})
     for (const t of ['meta_records_trash', 'meta_record_revisions', 'meta_records']) await q(`DELETE FROM ${t} WHERE sheet_id = ANY($1::text[])`, [[SA, SB]]).catch(() => {})
     await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SA, SB]]).catch(() => {})

--- a/packages/core-backend/tests/integration/multitable-revert-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-revert-pit-realdb.test.ts
@@ -46,6 +46,7 @@ async function seed(): Promise<void> {
 
 describeIfDatabase('multitable T8-1 Revert-to-T (real DB)', () => {
   beforeAll(async () => {
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: curRoles, perms: curPerms }; next() })
@@ -58,6 +59,7 @@ describeIfDatabase('multitable T8-1 Revert-to-T (real DB)', () => {
     await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
   })
   afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_PIT_REVERT // W0 step-1: restore — never leak the revert gate into sibling files' negative controls.
     for (const t of ['meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})

--- a/packages/core-backend/tests/integration/multitable-revert-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-revert-pit-realdb.test.ts
@@ -46,7 +46,7 @@ async function seed(): Promise<void> {
 
 describeIfDatabase('multitable T8-1 Revert-to-T (real DB)', () => {
   beforeAll(async () => {
-    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and FORCED BACK to the default OFF (delete) in afterAll — never a saved/original value, and NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: curRoles, perms: curPerms }; next() })

--- a/packages/core-backend/tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts
@@ -94,7 +94,7 @@ async function insertTombstone(sheetId: string, fieldId: string, neighborId: str
 
 describeIfDatabase('4c-3 §7 — PIT-resurrect inbound-edge replay heuristic anchor (real DB)', () => {
   beforeAll(async () => {
-    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and FORCED BACK to the default OFF (delete) in afterAll — never a saved/original value, and NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })

--- a/packages/core-backend/tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts
@@ -94,6 +94,7 @@ async function insertTombstone(sheetId: string, fieldId: string, neighborId: str
 
 describeIfDatabase('4c-3 §7 — PIT-resurrect inbound-edge replay heuristic anchor (real DB)', () => {
   beforeAll(async () => {
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })
@@ -108,6 +109,7 @@ describeIfDatabase('4c-3 §7 — PIT-resurrect inbound-edge replay heuristic anc
   })
 
   afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_PIT_REVERT // W0 step-1: restore — never leak the revert gate into sibling files' negative controls.
     delete process.env[UNDELETE_FLAG]
     delete process.env[INBOUND_FLAG]
     delete process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS

--- a/packages/core-backend/tests/integration/multitable-undelete-pit-inbound-replay-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-pit-inbound-replay-realdb.test.ts
@@ -87,6 +87,7 @@ async function seed(): Promise<void> {
 
 describeIfDatabase('4c-3 §7 — PIT-resurrect inbound replay (real DB, P3-2 goldens)', () => {
   beforeAll(async () => {
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })
@@ -98,6 +99,7 @@ describeIfDatabase('4c-3 §7 — PIT-resurrect inbound replay (real DB, P3-2 gol
     await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
   })
   afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_PIT_REVERT // W0 step-1: restore — never leak the revert gate into sibling files' negative controls.
     await q('DELETE FROM meta_link_tombstones WHERE sheet_id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_links WHERE field_id IN (SELECT id FROM meta_fields WHERE sheet_id = $1)', [SHEET]).catch(() => {})
     for (const t of ['meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})

--- a/packages/core-backend/tests/integration/multitable-undelete-pit-inbound-replay-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-pit-inbound-replay-realdb.test.ts
@@ -87,7 +87,7 @@ async function seed(): Promise<void> {
 
 describeIfDatabase('4c-3 §7 — PIT-resurrect inbound replay (real DB, P3-2 goldens)', () => {
   beforeAll(async () => {
-    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and FORCED BACK to the default OFF (delete) in afterAll — never a saved/original value, and NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })

--- a/packages/core-backend/tests/integration/multitable-undelete-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-pit-realdb.test.ts
@@ -55,7 +55,7 @@ async function seed(): Promise<void> {
 
 describeIfDatabase('multitable T8-1 PIT undelete-execute (real DB)', () => {
   beforeAll(async () => {
-    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and FORCED BACK to the default OFF (delete) in afterAll — never a saved/original value, and NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: curPerms }; next() })

--- a/packages/core-backend/tests/integration/multitable-undelete-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-pit-realdb.test.ts
@@ -55,6 +55,7 @@ async function seed(): Promise<void> {
 
 describeIfDatabase('multitable T8-1 PIT undelete-execute (real DB)', () => {
   beforeAll(async () => {
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: curPerms }; next() })
@@ -67,6 +68,7 @@ describeIfDatabase('multitable T8-1 PIT undelete-execute (real DB)', () => {
     await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
   })
   afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_PIT_REVERT // W0 step-1: restore — never leak the revert gate into sibling files' negative controls.
     await q('DELETE FROM meta_links WHERE field_id IN (SELECT id FROM meta_fields WHERE sheet_id = $1)', [SHEET]).catch(() => {}) // meta_links has no sheet_id col
     for (const t of ['meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})

--- a/packages/core-backend/tests/integration/multitable-w0-revert-gate-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-w0-revert-gate-realdb.test.ts
@@ -31,6 +31,7 @@ let priorRevert: string | undefined
 let priorUndelete: string | undefined
 const restoreEnv = (key: string, prior: string | undefined) => { if (prior === undefined) delete process.env[key]; else process.env[key] = prior }
 const revertExecute = (body: unknown) => request(app).post(`/api/multitable/sheets/${SHEET}/revert-execute`).send(body)
+const revertPreview = (body: unknown) => request(app).post(`/api/multitable/sheets/${SHEET}/revert-preview`).send(body)
 const countWhere = async (table: string) => Number((await q(`SELECT count(*)::int AS n FROM ${table} WHERE sheet_id = $1`, [SHEET])).rows[0].n)
 
 async function seed(): Promise<void> {
@@ -104,5 +105,29 @@ describeIfDatabase('multitable W0 step-1 revert-execute default-off gate (real D
     const res = await revertExecute({ garbage: true }) // no valid body → should now reach parse → 400 VALIDATION_ERROR
     expect(res.body?.error?.code).not.toBe('REVERT_DISABLED') // proves the gate is what refused above, not an always-403
     expect(res.status).toBe(400)
+  })
+
+  // W0 step-1 review P2: revert-preview's `undeleteSupported` must be the TWO-GATE conjunction, and this
+  // must be LOAD-BEARING. The existing undelete real-DB tests set PIT_REVERT on in beforeAll, so deleting
+  // `&& PIT_REVERT_ENABLED()` from the preview leaves them green. This four-state matrix exercises all
+  // combinations against the LIVE preview route (which is NOT gated, so it runs in every state); the
+  // revert-OFF/undelete-ON row is the discriminator — it MUST report false, so the mutation flips it to
+  // true and this test goes red.
+  test('revert-preview undeleteSupported is the two-gate conjunction (four-state matrix, mutation-catching)', async () => {
+    const cases = [
+      { revert: false, undelete: false, expected: false },
+      { revert: true, undelete: false, expected: false },
+      { revert: false, undelete: true, expected: false }, // discriminator: remove `&& PIT_REVERT_ENABLED()` → this flips to true
+      { revert: true, undelete: true, expected: true },
+    ]
+    for (const c of cases) {
+      if (c.revert) process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true'
+      else delete process.env.MULTITABLE_ENABLE_PIT_REVERT
+      if (c.undelete) process.env.MULTITABLE_ENABLE_PIT_UNDELETE = 'true'
+      else delete process.env.MULTITABLE_ENABLE_PIT_UNDELETE
+      const res = await revertPreview({ asOf: T0 })
+      expect(res.status).toBe(200)
+      expect(res.body?.data?.undeleteSupported).toBe(c.expected)
+    }
   })
 })

--- a/packages/core-backend/tests/integration/multitable-w0-revert-gate-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-w0-revert-gate-realdb.test.ts
@@ -1,12 +1,15 @@
 /**
  * W0 step-1 (emergency stop-loss): the DESTRUCTIVE point-in-time revert-execute is DEFAULT-OFF behind
  * MULTITABLE_ENABLE_PIT_REVERT. This is the NEGATIVE CONTROL — with the flag OFF the route must refuse
- * with 403 REVERT_DISABLED BEFORE any parse / auth / DB read / write, and leave ZERO records / revisions
- * / links written. Positive control: with the flag ON the same call gets PAST the gate (a different,
- * non-REVERT_DISABLED response), proving the gate is load-bearing rather than always-403.
+ * with 403 REVERT_DISABLED BEFORE any parse / auth / DB read / write, leaving the record + revision rows
+ * unchanged. (The gate is the handler's FIRST statement, so nothing downstream runs at all — including
+ * link writes; this test directly checks records + revisions, from which no-op is proven.) Positive
+ * control: with the flag ON the same call gets PAST the gate (a different, non-REVERT_DISABLED response),
+ * proving the gate is load-bearing rather than always-403.
  *
- * This file NEVER leaves the flag enabled — it deletes it in beforeEach so it is immune to a sibling
- * file that set it, and restores nothing global. Runs only with DATABASE_URL.
+ * Env discipline: this file SAVES the incoming MULTITABLE_ENABLE_PIT_REVERT / _PIT_UNDELETE in beforeAll
+ * and RESTORES them in afterAll (never a blind delete), and forces them OFF in beforeEach so the negative
+ * control is immune to a sibling file that set them. Runs only with DATABASE_URL.
  */
 import express, { type Express } from 'express'
 import request from 'supertest'
@@ -24,6 +27,9 @@ const T0 = '2026-01-01T00:00:00.000Z', T2 = '2026-01-03T00:00:00.000Z'
 
 const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
 let app: Express
+let priorRevert: string | undefined
+let priorUndelete: string | undefined
+const restoreEnv = (key: string, prior: string | undefined) => { if (prior === undefined) delete process.env[key]; else process.env[key] = prior }
 const revertExecute = (body: unknown) => request(app).post(`/api/multitable/sheets/${SHEET}/revert-execute`).send(body)
 const countWhere = async (table: string) => Number((await q(`SELECT count(*)::int AS n FROM ${table} WHERE sheet_id = $1`, [SHEET])).rows[0].n)
 
@@ -39,6 +45,8 @@ async function seed(): Promise<void> {
 
 describeIfDatabase('multitable W0 step-1 revert-execute default-off gate (real DB)', () => {
   beforeAll(async () => {
+    priorRevert = process.env.MULTITABLE_ENABLE_PIT_REVERT
+    priorUndelete = process.env.MULTITABLE_ENABLE_PIT_UNDELETE
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })
@@ -55,8 +63,8 @@ describeIfDatabase('multitable W0 step-1 revert-execute default-off gate (real D
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
     await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
-    delete process.env.MULTITABLE_ENABLE_PIT_REVERT
-    delete process.env.MULTITABLE_ENABLE_PIT_UNDELETE
+    restoreEnv('MULTITABLE_ENABLE_PIT_REVERT', priorRevert)
+    restoreEnv('MULTITABLE_ENABLE_PIT_UNDELETE', priorUndelete)
   })
   beforeEach(() => {
     // Immune to a sibling file that set the flag: this negative control ALWAYS runs with the gate OFF.

--- a/packages/core-backend/tests/integration/multitable-w0-revert-gate-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-w0-revert-gate-realdb.test.ts
@@ -1,0 +1,100 @@
+/**
+ * W0 step-1 (emergency stop-loss): the DESTRUCTIVE point-in-time revert-execute is DEFAULT-OFF behind
+ * MULTITABLE_ENABLE_PIT_REVERT. This is the NEGATIVE CONTROL — with the flag OFF the route must refuse
+ * with 403 REVERT_DISABLED BEFORE any parse / auth / DB read / write, and leave ZERO records / revisions
+ * / links written. Positive control: with the flag ON the same call gets PAST the gate (a different,
+ * non-REVERT_DISABLED response), proving the gate is load-bearing rather than always-403.
+ *
+ * This file NEVER leaves the flag enabled — it deletes it in beforeEach so it is immune to a sibling
+ * file that set it, and restores nothing global. Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_w0rg_${TS}`, SHEET = `sheet_w0rg_${TS}`
+const NAME = `fld_w0rg_name_${TS}`, SALARY = `fld_w0rg_salary_${TS}`
+const A = `rec_w0rg_a_${TS}`, ACTOR = `user_w0rg_${TS}`
+const T0 = '2026-01-01T00:00:00.000Z', T2 = '2026-01-03T00:00:00.000Z'
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+const revertExecute = (body: unknown) => request(app).post(`/api/multitable/sheets/${SHEET}/revert-execute`).send(body)
+const countWhere = async (table: string) => Number((await q(`SELECT count(*)::int AS n FROM ${table} WHERE sheet_id = $1`, [SHEET])).rows[0].n)
+
+async function seed(): Promise<void> {
+  // A: existed at T0 with old values, edited at T2 → live = new. A revert-to-T0 WOULD overwrite it back to
+  // 'old' AND append a forward revision — so if the gate leaked, these counts/data would change.
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [A, SHEET, JSON.stringify({ [NAME]: 'new', [SALARY]: 200 })])
+  await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+     VALUES (gen_random_uuid(),$1,$2,1,'create','rest',ARRAY[$3,$4]::text[],'{}'::jsonb,$5::jsonb,$6)`, [SHEET, A, NAME, SALARY, JSON.stringify({ [NAME]: 'old', [SALARY]: 100 }), T0])
+  await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+     VALUES (gen_random_uuid(),$1,$2,2,'update','rest',ARRAY[$3,$4]::text[],'{}'::jsonb,$5::jsonb,$6)`, [SHEET, A, NAME, SALARY, JSON.stringify({ [NAME]: 'new', [SALARY]: 200 }), T2])
+}
+
+describeIfDatabase('multitable W0 step-1 revert-execute default-off gate (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'W0RG Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'W0RG Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [NAME, SHEET, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [SALARY, SHEET, 'Salary', 'number', '{}', 2])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+    await seed()
+  })
+  afterAll(async () => {
+    for (const t of ['meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+    delete process.env.MULTITABLE_ENABLE_PIT_REVERT
+    delete process.env.MULTITABLE_ENABLE_PIT_UNDELETE
+  })
+  beforeEach(() => {
+    // Immune to a sibling file that set the flag: this negative control ALWAYS runs with the gate OFF.
+    delete process.env.MULTITABLE_ENABLE_PIT_REVERT
+    delete process.env.MULTITABLE_ENABLE_PIT_UNDELETE
+  })
+
+  test('flag OFF → 403 REVERT_DISABLED with ZERO record / revision writes', async () => {
+    const before = { records: await countWhere('meta_records'), revisions: await countWhere('meta_record_revisions') }
+    const res = await revertExecute({ asOf: T0, previewIdentity: 'irrelevant-because-gate-is-first' })
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('REVERT_DISABLED')
+    // Zero writes: counts unchanged AND the live record still holds its post-T2 value (never reverted to 'old').
+    expect(await countWhere('meta_records')).toBe(before.records)
+    expect(await countWhere('meta_record_revisions')).toBe(before.revisions)
+    const live = (await q('SELECT data, version FROM meta_records WHERE id = $1', [A])).rows[0] as { data: Record<string, unknown>; version: number }
+    expect(live.version).toBe(2)
+    expect(live.data[NAME]).toBe('new')
+  })
+
+  test('the gate precedes PARSE: even a body with no asOf/previewIdentity gets 403 REVERT_DISABLED (not 400)', async () => {
+    const res = await revertExecute({ garbage: true })
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('REVERT_DISABLED') // NOT VALIDATION_ERROR — the gate is the very first statement
+  })
+
+  test('undelete needs BOTH flags: PIT_UNDELETE on but PIT_REVERT off → still 403 REVERT_DISABLED', async () => {
+    process.env.MULTITABLE_ENABLE_PIT_UNDELETE = 'true' // undelete enabled...
+    // ...but the revert gate (checked FIRST) is still off, so an undelete-shaped revert is refused outright.
+    const res = await revertExecute({ asOf: T0, previewIdentity: 'x', confirm: 'undelete' })
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('REVERT_DISABLED')
+  })
+
+  test('positive control — flag ON → the SAME call gets PAST the gate (not REVERT_DISABLED)', async () => {
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true'
+    const res = await revertExecute({ garbage: true }) // no valid body → should now reach parse → 400 VALIDATION_ERROR
+    expect(res.body?.error?.code).not.toBe('REVERT_DISABLED') // proves the gate is what refused above, not an always-403
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-w13-fieldperm-writegate-singlerecord-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-w13-fieldperm-writegate-singlerecord-realdb.test.ts
@@ -82,7 +82,7 @@ const storedRecord = async (recordId: string): Promise<{ data: Record<string, un
 
 describeIfDatabase('W1-3 GW4/GW5/GW6 — layer-3 per-subject field-write gate on single-record PATCH (real DB)', () => {
   beforeAll(async () => {
-    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and FORCED BACK to the default OFF (delete) in afterAll — never a saved/original value, and NEVER enabled globally.
     app = express()
     app.use(express.json())
     // Fake "always-on" session-auth middleware — mirrors production ordering: session auth runs first

--- a/packages/core-backend/tests/integration/multitable-w13-fieldperm-writegate-singlerecord-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-w13-fieldperm-writegate-singlerecord-realdb.test.ts
@@ -82,6 +82,7 @@ const storedRecord = async (recordId: string): Promise<{ data: Record<string, un
 
 describeIfDatabase('W1-3 GW4/GW5/GW6 — layer-3 per-subject field-write gate on single-record PATCH (real DB)', () => {
   beforeAll(async () => {
+    process.env.MULTITABLE_ENABLE_PIT_REVERT = 'true' // W0 step-1: this file drives revert-execute; the gate is default-OFF, set per-file here and restored in afterAll — NEVER enabled globally.
     app = express()
     app.use(express.json())
     // Fake "always-on" session-auth middleware — mirrors production ordering: session auth runs first
@@ -125,6 +126,7 @@ describeIfDatabase('W1-3 GW4/GW5/GW6 — layer-3 per-subject field-write gate on
   })
 
   afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_PIT_REVERT // W0 step-1: restore — never leak the revert gate into sibling files' negative controls.
     await db.deleteFrom('multitable_api_tokens').where('created_by', '=', TOKEN_CREATOR_ID).execute().catch(() => {})
     await q('DELETE FROM oapi_write_audit WHERE token_id = $1', [tokWriteId]).catch(() => {})
     await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})

--- a/scripts/ops/global-history-flag-manifest.mjs
+++ b/scripts/ops/global-history-flag-manifest.mjs
@@ -140,11 +140,9 @@ export const GLOBAL_HISTORY_FLAG_MANIFEST = Object.freeze([
     danger: 'high',
     purpose:
       'R3 — PIT-reset vs retention STOP-SHIP. T8-2 Reset-to-T (destructive whole-sheet PIT restore). Gated by PIT_RESET_ENABLED() (`.trim().toLowerCase() === \'true\'`, so \'TRUE\'/\' true \' also activate it — unlike most other flags in this manifest). BOTH reset-preview and reset-execute additionally call PIT_RESET_RETENTION_BLOCKED() and refuse with 409 RESET_RETENTION_CONFLICT whenever meta-revision retention is active. An operator who intends to use PIT reset MUST NOT also have retention active.',
-    // source: packages/core-backend/src/routes/univer-meta.ts:10275 (PIT_RESET_ENABLED),
-    //         :10276 (PIT_RESET_RETENTION_BLOCKED — compares MULTITABLE_META_REVISION_RETENTION_ENABLED === '1'),
-    //         :10287,:10328 (both preview and execute call the blocked-check)
-    // NOTE: the task brief cited univer-meta.ts:10264 for this; the verified line in this checkout is 10276
-    // (small file drift since the brief was written) — same function, same rule, confirmed by symbol name.
+    // Anchored by SYMBOL NAME (drift-proof): PIT_RESET_ENABLED gates reset-preview + reset-execute;
+    // PIT_RESET_RETENTION_BLOCKED compares MULTITABLE_META_REVISION_RETENTION_ENABLED === '1' and both
+    // routes call it (409 RESET_RETENTION_CONFLICT). No line numbers — they drift across rebases.
     source: 'packages/core-backend/src/routes/univer-meta.ts (symbol refs, drift-proof: PIT_RESET_ENABLED + PIT_RESET_RETENTION_BLOCKED helpers; reset-preview + reset-execute both gate on them)',
     rules: [
       {
@@ -165,8 +163,8 @@ export const GLOBAL_HISTORY_FLAG_MANIFEST = Object.freeze([
     danger: 'high',
     purpose:
       'W0 step-1 — emergency master gate on the DESTRUCTIVE point-in-time revert-execute (whole-sheet rollback to T; OVERWRITES live data). Gated by PIT_REVERT_ENABLED() (`.trim().toLowerCase() === \'true\'`) as the FIRST statement of revert-execute — before parse/auth/DB — returning 403 REVERT_DISABLED. Read-only revert-preview is intentionally NOT gated. Default OFF until the full W0 integrity work lands: the trustworthiness precheck enumerates LIVE rows only and the reconstructor orders by created_at (= transaction-start via now()), so a mid-history healed gap / a deleted record\'s broken chain / a concurrent version-vs-time inversion can still overwrite with a WRONG T-state.',
-    // source: packages/core-backend/src/routes/univer-meta.ts (PIT_REVERT_ENABLED helper :10115; the gate as
-    //   revert-execute's first statement :10169; the two-gate undeleteSupported conjunction in revert-preview :10149)
+    // Anchored by SYMBOL NAME (drift-proof, no line numbers): PIT_REVERT_ENABLED helper; the gate is
+    // revert-execute's first statement; the two-gate undeleteSupported conjunction lives in revert-preview.
     source: 'packages/core-backend/src/routes/univer-meta.ts (symbol refs, drift-proof: PIT_REVERT_ENABLED helper; revert-execute gate = its first statement; revert-preview undeleteSupported two-gate conjunction)',
   },
   {
@@ -179,7 +177,8 @@ export const GLOBAL_HISTORY_FLAG_MANIFEST = Object.freeze([
     danger: 'medium',
     purpose:
       'T8-1 PIT undelete-execute (resurrect face). Gated by `.trim().toLowerCase() === \'true\'` — same case-insensitive family as PIT_RESET. Requires canDeleteRecord (never canEditRecord) at execute plus a typed confirm:\'undelete\'. Inbound links are NOT rebuilt by this flag alone (design-lock L4 A) — see MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND for that layer. The undelete face rides INSIDE revert-execute, whose W0 master gate (MULTITABLE_ENABLE_PIT_REVERT) is checked FIRST — so undelete requires BOTH gates.',
-    // source: packages/core-backend/src/routes/univer-meta.ts:10071 (PIT_UNDELETE gate; the PIT_REVERT master gate precedes it at the top of revert-execute)
+    // Anchored by SYMBOL NAME (drift-proof, no line numbers): PIT_UNDELETE_ENABLED helper + the undelete
+    // sub-gate inside revert-execute; the PIT_REVERT master gate precedes it at the top of revert-execute.
     source: 'packages/core-backend/src/routes/univer-meta.ts (symbol refs, drift-proof: PIT_UNDELETE_ENABLED helper + the undelete sub-gate inside revert-execute; the PIT_REVERT master gate precedes it at the top of revert-execute)',
     rules: [
       {

--- a/scripts/ops/global-history-flag-manifest.mjs
+++ b/scripts/ops/global-history-flag-manifest.mjs
@@ -17,7 +17,7 @@
  * `activationValue` is the EXACT string the flag must equal (after `.trim()`, and after `.toLowerCase()`
  * only when `caseInsensitive: true`) for the gated code path to treat it as ON. Two families exist:
  *   - capture/replay/revert flags compare with `=== 'true'` (case-SENSITIVE, no trim in most call sites,
- *     except PIT_RESET/PIT_UNDELETE which use `.trim().toLowerCase() === 'true'`)
+ *     except PIT_RESET/PIT_UNDELETE/PIT_REVERT which use `.trim().toLowerCase() === 'true'`)
  *   - the retention flag compares with `=== '1'` (NOT `'true'`) — `meta-revision-retention.ts:60`
  * Setting the wrong string for a given flag is silent: the gated code path stays OFF and nothing errors.
  */
@@ -34,7 +34,7 @@
  * @property {string} key
  * @property {'boolean'|'numeric'|'enum'} type
  * @property {string} activationValue - exact string that activates a boolean flag (ignored for numeric/enum)
- * @property {boolean} [caseInsensitive] - true only for the two flags whose source call site lowercases+trims
+ * @property {boolean} [caseInsensitive] - true only for the three flags (PIT_RESET/PIT_UNDELETE/PIT_REVERT) whose source call site lowercases+trims
  * @property {string[]} dependsOn - other flag keys that MUST also be active for this flag's gated effect to be safe/whole
  * @property {string[]} conflictsWith - other flag keys that MUST NOT be active at the same time as this one
  * @property {'low'|'medium'|'high'} danger
@@ -165,8 +165,9 @@ export const GLOBAL_HISTORY_FLAG_MANIFEST = Object.freeze([
     danger: 'high',
     purpose:
       'W0 step-1 — emergency master gate on the DESTRUCTIVE point-in-time revert-execute (whole-sheet rollback to T; OVERWRITES live data). Gated by PIT_REVERT_ENABLED() (`.trim().toLowerCase() === \'true\'`) as the FIRST statement of revert-execute — before parse/auth/DB — returning 403 REVERT_DISABLED. Read-only revert-preview is intentionally NOT gated. Default OFF until the full W0 integrity work lands: the trustworthiness precheck enumerates LIVE rows only and the reconstructor orders by created_at (= transaction-start via now()), so a mid-history healed gap / a deleted record\'s broken chain / a concurrent version-vs-time inversion can still overwrite with a WRONG T-state.',
-    // source: packages/core-backend/src/routes/univer-meta.ts (PIT_REVERT_ENABLED helper + the gate as revert-execute's first statement)
-    source: 'packages/core-backend/src/routes/univer-meta.ts:10100,10151',
+    // source: packages/core-backend/src/routes/univer-meta.ts (PIT_REVERT_ENABLED helper :10115; the gate as
+    //   revert-execute's first statement :10169; the two-gate undeleteSupported conjunction in revert-preview :10149)
+    source: 'packages/core-backend/src/routes/univer-meta.ts:10115,10149,10169',
   },
   {
     key: 'MULTITABLE_ENABLE_PIT_UNDELETE',

--- a/scripts/ops/global-history-flag-manifest.mjs
+++ b/scripts/ops/global-history-flag-manifest.mjs
@@ -156,17 +156,38 @@ export const GLOBAL_HISTORY_FLAG_MANIFEST = Object.freeze([
     ],
   },
   {
-    key: 'MULTITABLE_ENABLE_PIT_UNDELETE',
+    key: 'MULTITABLE_ENABLE_PIT_REVERT',
     type: 'boolean',
     activationValue: 'true',
     caseInsensitive: true,
     dependsOn: [],
     conflictsWith: [],
+    danger: 'high',
+    purpose:
+      'W0 step-1 — emergency master gate on the DESTRUCTIVE point-in-time revert-execute (whole-sheet rollback to T; OVERWRITES live data). Gated by PIT_REVERT_ENABLED() (`.trim().toLowerCase() === \'true\'`) as the FIRST statement of revert-execute — before parse/auth/DB — returning 403 REVERT_DISABLED. Read-only revert-preview is intentionally NOT gated. Default OFF until the full W0 integrity work lands: the trustworthiness precheck enumerates LIVE rows only and the reconstructor orders by created_at (= transaction-start via now()), so a mid-history healed gap / a deleted record\'s broken chain / a concurrent version-vs-time inversion can still overwrite with a WRONG T-state.',
+    // source: packages/core-backend/src/routes/univer-meta.ts (PIT_REVERT_ENABLED helper + the gate as revert-execute's first statement)
+    source: 'packages/core-backend/src/routes/univer-meta.ts:10100,10151',
+  },
+  {
+    key: 'MULTITABLE_ENABLE_PIT_UNDELETE',
+    type: 'boolean',
+    activationValue: 'true',
+    caseInsensitive: true,
+    dependsOn: ['MULTITABLE_ENABLE_PIT_REVERT'],
+    conflictsWith: [],
     danger: 'medium',
     purpose:
-      'T8-1 PIT undelete-execute (resurrect face). Gated by `.trim().toLowerCase() === \'true\'` — same case-insensitive family as PIT_RESET. Requires canDeleteRecord (never canEditRecord) at execute plus a typed confirm:\'undelete\'. Inbound links are NOT rebuilt by this flag alone (design-lock L4 A) — see MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND for that layer.',
-    // source: packages/core-backend/src/routes/univer-meta.ts:10071
+      'T8-1 PIT undelete-execute (resurrect face). Gated by `.trim().toLowerCase() === \'true\'` — same case-insensitive family as PIT_RESET. Requires canDeleteRecord (never canEditRecord) at execute plus a typed confirm:\'undelete\'. Inbound links are NOT rebuilt by this flag alone (design-lock L4 A) — see MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND for that layer. The undelete face rides INSIDE revert-execute, whose W0 master gate (MULTITABLE_ENABLE_PIT_REVERT) is checked FIRST — so undelete requires BOTH gates.',
+    // source: packages/core-backend/src/routes/univer-meta.ts:10071 (PIT_UNDELETE gate; the PIT_REVERT master gate precedes it at the top of revert-execute)
     source: 'packages/core-backend/src/routes/univer-meta.ts:10071',
+    rules: [
+      {
+        kind: 'requires',
+        id: 'undelete-without-revert-gate',
+        description:
+          "MULTITABLE_ENABLE_PIT_UNDELETE is active but MULTITABLE_ENABLE_PIT_REVERT is not — the undelete face rides inside revert-execute, whose W0 master gate (checked FIRST) returns 403 REVERT_DISABLED before the undelete gate is reached. So undelete has no effect without PIT_REVERT: dead configuration, not a working feature. Enable BOTH to make undelete-revert live.",
+      },
+    ],
   },
   {
     key: 'MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND',

--- a/scripts/ops/global-history-flag-manifest.mjs
+++ b/scripts/ops/global-history-flag-manifest.mjs
@@ -145,7 +145,7 @@ export const GLOBAL_HISTORY_FLAG_MANIFEST = Object.freeze([
     //         :10287,:10328 (both preview and execute call the blocked-check)
     // NOTE: the task brief cited univer-meta.ts:10264 for this; the verified line in this checkout is 10276
     // (small file drift since the brief was written) — same function, same rule, confirmed by symbol name.
-    source: 'packages/core-backend/src/routes/univer-meta.ts:10275-10276,10287,10328',
+    source: 'packages/core-backend/src/routes/univer-meta.ts (symbol refs, drift-proof: PIT_RESET_ENABLED + PIT_RESET_RETENTION_BLOCKED helpers; reset-preview + reset-execute both gate on them)',
     rules: [
       {
         kind: 'conflicts',
@@ -167,7 +167,7 @@ export const GLOBAL_HISTORY_FLAG_MANIFEST = Object.freeze([
       'W0 step-1 — emergency master gate on the DESTRUCTIVE point-in-time revert-execute (whole-sheet rollback to T; OVERWRITES live data). Gated by PIT_REVERT_ENABLED() (`.trim().toLowerCase() === \'true\'`) as the FIRST statement of revert-execute — before parse/auth/DB — returning 403 REVERT_DISABLED. Read-only revert-preview is intentionally NOT gated. Default OFF until the full W0 integrity work lands: the trustworthiness precheck enumerates LIVE rows only and the reconstructor orders by created_at (= transaction-start via now()), so a mid-history healed gap / a deleted record\'s broken chain / a concurrent version-vs-time inversion can still overwrite with a WRONG T-state.',
     // source: packages/core-backend/src/routes/univer-meta.ts (PIT_REVERT_ENABLED helper :10115; the gate as
     //   revert-execute's first statement :10169; the two-gate undeleteSupported conjunction in revert-preview :10149)
-    source: 'packages/core-backend/src/routes/univer-meta.ts:10115,10149,10169',
+    source: 'packages/core-backend/src/routes/univer-meta.ts (symbol refs, drift-proof: PIT_REVERT_ENABLED helper; revert-execute gate = its first statement; revert-preview undeleteSupported two-gate conjunction)',
   },
   {
     key: 'MULTITABLE_ENABLE_PIT_UNDELETE',
@@ -180,7 +180,7 @@ export const GLOBAL_HISTORY_FLAG_MANIFEST = Object.freeze([
     purpose:
       'T8-1 PIT undelete-execute (resurrect face). Gated by `.trim().toLowerCase() === \'true\'` — same case-insensitive family as PIT_RESET. Requires canDeleteRecord (never canEditRecord) at execute plus a typed confirm:\'undelete\'. Inbound links are NOT rebuilt by this flag alone (design-lock L4 A) — see MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND for that layer. The undelete face rides INSIDE revert-execute, whose W0 master gate (MULTITABLE_ENABLE_PIT_REVERT) is checked FIRST — so undelete requires BOTH gates.',
     // source: packages/core-backend/src/routes/univer-meta.ts:10071 (PIT_UNDELETE gate; the PIT_REVERT master gate precedes it at the top of revert-execute)
-    source: 'packages/core-backend/src/routes/univer-meta.ts:10071',
+    source: 'packages/core-backend/src/routes/univer-meta.ts (symbol refs, drift-proof: PIT_UNDELETE_ENABLED helper + the undelete sub-gate inside revert-execute; the PIT_REVERT master gate precedes it at the top of revert-execute)',
     rules: [
       {
         kind: 'requires',

--- a/scripts/ops/global-history-flag-manifest.test.mjs
+++ b/scripts/ops/global-history-flag-manifest.test.mjs
@@ -81,8 +81,8 @@ function globalHistoryFlagsInSource() {
 test('completeness (source-derived, non-tautological): manifest covers every Global-History flag read in packages/core-backend/src', () => {
   const sourceGH = globalHistoryFlagsInSource()
   assert.ok(
-    sourceGH.length >= 19,
-    `expected >=19 Global-History flags derived from source, got ${sourceGH.length} — the denylist is too broad or grep broke`,
+    sourceGH.length >= 20,
+    `expected >=20 Global-History flags derived from source, got ${sourceGH.length} — the denylist is too broad or grep broke`,
   )
   const manifestKeys = new Set(GLOBAL_HISTORY_FLAG_KEYS)
   const missing = sourceGH.filter((f) => !manifestKeys.has(f))
@@ -132,6 +132,30 @@ test('R1 positive control: LOSSY off never fires regardless of base', () => {
     violationIds({ MULTITABLE_ENABLE_FIELD_RETYPE_REVERT_LOSSY: 'false', MULTITABLE_ENABLE_FIELD_RETYPE_REVERT: 'false' }).includes(
       'lossy-without-base',
     ),
+    false,
+  )
+})
+
+// ── W0 step-1: PIT undelete rides on the revert master gate ──────────────────────────────────────────
+
+test('W0 undelete-without-revert-gate: PIT_UNDELETE on + PIT_REVERT off fires the named violation (STOP)', () => {
+  const ids = violationIds({ MULTITABLE_ENABLE_PIT_UNDELETE: 'true', MULTITABLE_ENABLE_PIT_REVERT: 'false' })
+  assert.ok(ids.includes('undelete-without-revert-gate'), `expected undelete-without-revert-gate, got ${ids.join(',')}`)
+})
+
+test('W0 undelete-without-revert-gate: PIT_UNDELETE on + PIT_REVERT UNSET also fires (unset is not activated)', () => {
+  const ids = violationIds({ MULTITABLE_ENABLE_PIT_UNDELETE: 'true' })
+  assert.ok(ids.includes('undelete-without-revert-gate'))
+})
+
+test('W0 positive control: PIT_UNDELETE on + PIT_REVERT on does NOT fire (both gates → PASS)', () => {
+  const ids = violationIds({ MULTITABLE_ENABLE_PIT_UNDELETE: 'true', MULTITABLE_ENABLE_PIT_REVERT: 'true' })
+  assert.ok(!ids.includes('undelete-without-revert-gate'), `unexpected violation: ${ids.join(',')}`)
+})
+
+test('W0 positive control: PIT_UNDELETE off never fires regardless of PIT_REVERT', () => {
+  assert.equal(
+    violationIds({ MULTITABLE_ENABLE_PIT_UNDELETE: 'false', MULTITABLE_ENABLE_PIT_REVERT: 'false' }).includes('undelete-without-revert-gate'),
     false,
   )
 })
@@ -239,6 +263,7 @@ test('positive control: a full valid L1->L3.5 ladder rung (exact activation valu
   const flags = {
     MULTITABLE_TOMBSTONE_CAPTURE_ENABLED: 'true', // L1
     MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND: 'true', // L2
+    MULTITABLE_ENABLE_PIT_REVERT: 'true', // W0 master gate — undelete rides on revert-execute, so both go together
     MULTITABLE_ENABLE_PIT_UNDELETE: 'true', // L3
     MULTITABLE_SIDE_DOOR_DELETE_TRASH_ENABLED: 'true', // L3.5 (D-2), capture already on above
     MULTITABLE_ENABLE_FIELD_RETYPE_REVERT: 'true',
@@ -258,7 +283,7 @@ test('positive control: retention-only rung (L4, no PIT_RESET) has zero violatio
   assert.deepEqual(violations, [])
 })
 
-test('a rung that stacks ALL THREE illegal combinations fires all three named violations at once', () => {
+test('a rung that stacks ALL FOUR illegal combinations fires all four named violations at once', () => {
   const ids = violationIds({
     MULTITABLE_ENABLE_FIELD_RETYPE_REVERT_LOSSY: 'true',
     MULTITABLE_ENABLE_FIELD_RETYPE_REVERT: 'false',
@@ -266,10 +291,11 @@ test('a rung that stacks ALL THREE illegal combinations fires all three named vi
     MULTITABLE_TOMBSTONE_CAPTURE_ENABLED: 'false',
     MULTITABLE_ENABLE_PIT_RESET: 'true',
     MULTITABLE_META_REVISION_RETENTION_ENABLED: '1',
+    MULTITABLE_ENABLE_PIT_UNDELETE: 'true', // PIT_REVERT unset → undelete-without-revert-gate fires
   })
   assert.deepEqual(
     [...ids].sort(),
-    ['lossy-without-base', 'pit-reset-intent-with-retention-on', 'side-door-without-capture'].sort(),
+    ['lossy-without-base', 'pit-reset-intent-with-retention-on', 'side-door-without-capture', 'undelete-without-revert-gate'].sort(),
   )
 })
 
@@ -282,7 +308,7 @@ test('mutation guard: every FlagSpec.rules[] entry is reachable by evaluateFlagR
   const allRuleIds = GLOBAL_HISTORY_FLAG_MANIFEST.flatMap((spec) => (spec.rules || []).map((r) => r.id))
   assert.deepEqual(
     [...allRuleIds].sort(),
-    ['lossy-without-base', 'pit-reset-intent-with-retention-on', 'side-door-without-capture'].sort(),
+    ['lossy-without-base', 'pit-reset-intent-with-retention-on', 'side-door-without-capture', 'undelete-without-revert-gate'].sort(),
     'manifest rule set changed — update this test deliberately if a rule was intentionally added/removed',
   )
 })

--- a/scripts/ops/multitable-global-history-flag-status.mjs
+++ b/scripts/ops/multitable-global-history-flag-status.mjs
@@ -9,8 +9,9 @@
  *
  * `--strict` additionally runs the manifest's dependency/conflict rules (`evaluateFlagRules`) against
  * the observed flags and turns any violation into a hard STOP (non-zero exit), in addition to its
- * existing job of promoting the image-tag-mismatch WARN into a STOP. The three illegal-combination
- * checks (lossy-without-base, side-door-without-capture, pit-reset-intent-with-retention-on) are ALSO
+ * existing job of promoting the image-tag-mismatch WARN into a STOP. The four illegal-combination
+ * checks (lossy-without-base, side-door-without-capture, pit-reset-intent-with-retention-on,
+ * undelete-without-revert-gate) are ALSO
  * evaluated and reported as STOPs in the default (non-strict) mode — this preserves the pre-existing
  * unconditional PIT_RESET-vs-retention stop (do not regress that to strict-only) and is the safer
  * default for an operator-facing safety helper: a plain run cannot miss a genuinely illegal config.
@@ -69,8 +70,8 @@ Global History line's flags, their exact activation string, and illegal-combinat
 
 --strict additionally promotes advisory warnings (image-tag mismatch, a flag value that looks truthy
 but does not match its exact activation string) into hard stops. Illegal flag combinations
-(lossy-without-base, side-door-without-capture, pit-reset-intent-with-retention-on) are ALWAYS hard
-stops, in both modes.
+(lossy-without-base, side-door-without-capture, pit-reset-intent-with-retention-on,
+undelete-without-revert-gate) are ALWAYS hard stops, in both modes.
 
 Examples:
   METASHEET_STATUS_SSH_HOST=mainuser@staging-host \\
@@ -180,7 +181,8 @@ function buildAssessment(input, { strict = false } = {}) {
   }
 
   // R12-C: manifest-driven illegal-combination rules (lossy-without-base, side-door-without-capture,
-  // pit-reset-intent-with-retention-on). These are UNCONDITIONAL stops in both modes — an illegal
+  // pit-reset-intent-with-retention-on, undelete-without-revert-gate). These are UNCONDITIONAL stops in
+  // both modes — an illegal
   // combination is illegal regardless of whether the operator remembered --strict; this also preserves
   // the pre-existing behavior where PIT_RESET-vs-retention already stopped without --strict.
   const violations = evaluateFlagRules(input.flags)

--- a/scripts/ops/multitable-global-history-flag-status.test.mjs
+++ b/scripts/ops/multitable-global-history-flag-status.test.mjs
@@ -155,7 +155,21 @@ test('buildAssessment stops (without --strict) on side-door-without-capture', ()
   assert.match(assessment.stops.join('\n'), /side-door-without-capture/)
 })
 
-test('buildAssessment passes for a legal rung with all three illegal-combo flag pairs satisfied', () => {
+test('buildAssessment stops (without --strict) on undelete-without-revert-gate (W0 step-1)', () => {
+  const assessment = buildAssessment({
+    backend: { image: 'backend:abc', status: 'running' },
+    web: { image: 'web:abc', status: 'running' },
+    flags: collectFlagMapFromEnvText([
+      'MULTITABLE_ENABLE_PIT_UNDELETE=true',
+      'MULTITABLE_ENABLE_PIT_REVERT=false',
+    ].join('\n')),
+    health: null,
+  })
+  assert.equal(assessment.ok, false)
+  assert.match(assessment.stops.join('\n'), /undelete-without-revert-gate/)
+})
+
+test('buildAssessment passes for a legal rung with all four illegal-combo flag pairs satisfied', () => {
   const assessment = buildAssessment({
     backend: { image: 'ghcr.io/zensgit/metasheet2-backend:abc', status: 'running' },
     web: { image: 'ghcr.io/zensgit/metasheet2-web:abc', status: 'running' },
@@ -166,6 +180,8 @@ test('buildAssessment passes for a legal rung with all three illegal-combo flag 
       'MULTITABLE_SIDE_DOOR_DELETE_TRASH_ENABLED=true',
       'MULTITABLE_ENABLE_PIT_RESET=false',
       'MULTITABLE_META_REVISION_RETENTION_ENABLED=0',
+      'MULTITABLE_ENABLE_PIT_REVERT=true', // W0: undelete rides on the revert master gate — both on = legal
+      'MULTITABLE_ENABLE_PIT_UNDELETE=true',
     ].join('\n')),
     health: { ok: true, status: 200, body: {} },
   })


### PR DESCRIPTION
## What — W0 step-1 emergency stop-loss (isolated)

Owner-authorized isolated stop-loss for the Global History W0 line. **#4250 stays REQUEST_CHANGES / not RATIFIED** — this PR does NOT implement W0 (no contiguity / watermark / marker / time-semantics / transaction-isolation changes; `src/multitable/` unchanged). It only adds the missing master default-off gate to the destructive `revert-execute`.

### Why (verified P1s on main)
- `revert-execute` reconstructs record state at T and OVERWRITES live data, but the trustworthiness precheck enumerates **LIVE rows only** (`history-integrity-precheck.ts:115`) and the reconstructor trusts `created_at` (= tx-start via `now()`) for T-ordering (`record-reconstructor.ts ORDER BY created_at DESC`). So a mid-history healed gap / a deleted record's broken chain / a concurrent version-vs-time inversion can still overwrite with a **WRONG T-state**.
- Unlike `reset-execute` (gated by `MULTITABLE_ENABLE_PIT_RESET`), `revert-execute` had **no master default-off gate**.

### Locked scope (exactly as authorized)
- New `MULTITABLE_ENABLE_PIT_REVERT`, **default OFF** (only a normalized literal `"true"` enables).
- `revert-execute`'s **first statement** returns `403 REVERT_DISABLED` — before parse / auth / any DB read or write.
- Read-only `revert-preview` is **NOT** gated.
- **Undelete needs BOTH** gates (revert gate checked first ⇒ a resurrect-shaped revert needs `PIT_REVERT` *and* `PIT_UNDELETE`).
- The 8 real-DB test files that drive `revert-execute` set the flag **per-file** (beforeAll) + restore (afterAll) — never globally.
- **Negative control** (`multitable-w0-revert-gate-realdb.test.ts`, added to the `plugin-tests.yml` whitelist so it runs): flag OFF → `403 REVERT_DISABLED` + **zero** record/revision writes + live row unchanged; gate precedes parse (garbage body still 403); PIT_UNDELETE-on/PIT_REVERT-off still 403; positive control — flag ON reaches past the gate (400, not REVERT_DISABLED).
- O-2 operator flag ladder documents the flag, **production default OFF**.

### Verification
- TypeScript syntax-checked (transpileModule) + insertion placement verified on all files.
- The real-DB integration suite needs Postgres and **only runs in CI** (plugin-tests.yml) — not run locally.
- **Not armed** — awaiting independent security review + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)