### PR TITLE
ci(migrations): re-enable final #4162 exclusion tail

### DIFF
--- a/.github/workflows/migration-replay.yml
+++ b/.github/workflows/migration-replay.yml
@@ -76,39 +76,32 @@ jobs:
           # in packages/core-backend/src/db/migration-provider.ts (that one no-ops a migration's
           # body but keeps its name; this one drops the name+body entirely). This job's purpose
           # (run db:migrate TWICE against a fresh db, assert idempotency) is narrower than the
-          # per-PR gate's, so its list has independently evolved: it already dropped
-          # 20250925_create_view_tables.sql once #3627 fixed the underlying owner_id FK bug
-          # (see #3632) — the four CI per-PR gate occurrences still exclude that file and have
-          # NOT been re-verified against the same fix, which may mean they are stale rather than
-          # intentionally divergent. See docs/development/superseded-legacy-migrations-gap-audit-20260710.md
+          # per-PR gate's, so its list has independently evolved. It first dropped
+          # 20250925_create_view_tables.sql after #3627 fixed the owner_id FK bug (#3632), and
+          # #4162 has now removed that stale exclusion from the other lanes too. See
+          # docs/development/superseded-legacy-migrations-gap-audit-20260710.md
           # and packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md for the full cross-list
-          # picture. #4162's follow-up is now PARTIALLY executed (2026-07-13): the
-          # views/view_states migration and the three snapshot-cluster migrations are
-          # re-enabled in ALL five workflow lists simultaneously (this file, plugin-tests,
-          # observability-e2e/strict, safety-guard-e2e) — see the Re-enabled note below.
-          # Still excluded everywhere: 008/048/049, 042a, gantt (and 20250925 outside this
-          # file). The two lists solve different problems and are not required to converge.
+          # picture. #4162 is now fully executed: views/view_states + the snapshot cluster
+          # were re-enabled on 2026-07-13, and 042a/gantt/20250925 were removed from every
+          # occurrence on 2026-07-14. 042a reaches the provider's superseded no-op marker;
+          # gantt and 20250925 execute their real bodies. Remaining exclusions are 008/048/049
+          # plus user_orgs in the non-plugin lanes.
           # Exclude 008_plugin_infrastructure.sql - has idempotency issue with scope column
           # TODO: Fix migration to be fully idempotent or split into separate migrations
           # Exclude 048-049 - Phase 2 Event Bus/BPMN migrations with complex SQL syntax issues
           # TODO: Rewrite these migrations with correct PostgreSQL syntax
-          # Re-enabled per #4162 (2026-07-13): 20250924120000_create_views_view_states.ts and the three
-          # snapshot-cluster migrations (20251117000001_add_snapshot_labels, 20251117000002_create_protection_rules,
-          # 20251201000001_create_change_management_tables) now RUN here. Their old per-item exclusion reasons were
-          # re-tested and are stale (same class as the 20250925 one #3627 fixed): fresh-DB migrate, second-pass
-          # replay, and the snapshot-protection E2E (21/21) all pass with them applied.
-          # Exclude 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
+          # Re-enabled per #4162: views/view_states + snapshot cluster (2026-07-13), then
+          # 042a/gantt/20250925 (2026-07-14). Fresh and old-list upgrade migrations, tracked-skip
+          # replay, schema assertions, and the snapshot-protection E2E all pass with this shape.
           # Exclude zzzz20260114110000_create_user_orgs_table.ts - replay paths hit legacy user_orgs is_active reference incompatibility
-          # Exclude 042a_core_model_views.sql - References non-existent last_accessed column
-          # TODO: Fix last_accessed column reference in 042a_core_model_views.sql
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm -F @metasheet/core-backend db:migrate
           pnpm -F @metasheet/core-backend db:migrate
       - name: List migrations
         env:
           DATABASE_URL: postgresql://127.0.0.1/metasheet
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
         run: pnpm -F @metasheet/core-backend db:list
 
       - name: Upload install logs on failure

--- a/.github/workflows/observability-e2e.yml
+++ b/.github/workflows/observability-e2e.yml
@@ -76,31 +76,21 @@ jobs:
           # (no-ops a migration's body but keeps its name; this drops name+body entirely). See
           # packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md and
           # docs/development/superseded-legacy-migrations-gap-audit-20260710.md for the full
-          # cross-list picture. #4162 follow-up (2026-07-13): the views/view_states migration
-          # and the three snapshot-cluster migrations are re-enabled below (in all five
-          # workflow lists at once), so their up() bodies now DO get per-PR green CI runs.
-          # Remaining asymmetry: production/on-prem db:migrate runs with no exclude at all,
-          # so the STILL-excluded items (008/048/049, 042a, gantt, 20250925) keep that gap.
+          # cross-list picture. #4162 is now fully executed: views/view_states + the snapshot
+          # cluster landed first, then 042a/gantt/20250925 were removed from every occurrence.
+          # 042a reaches the provider's superseded no-op marker; gantt and 20250925 execute
+          # their real bodies. Remaining asymmetry is limited to 008/048/049 and user_orgs.
           # Exclude problematic migrations (see migration-replay.yml for the per-item detail
           # this workflow shares):
           # 008_plugin_infrastructure.sql - has idempotency issue with scope column
           # 048/049 (event bus / BPMN) - Phase 2 migrations with complex SQL syntax issues
-          # 042a_core_model_views.sql - References non-existent last_accessed column
-          # Re-enabled per #4162 (2026-07-13): 20250924120000_create_views_view_states.ts and the three
-          # snapshot-cluster migrations (20251117000001_add_snapshot_labels, 20251117000002_create_protection_rules,
-          # 20251201000001_create_change_management_tables) now RUN here. Their old per-item exclusion reasons were
-          # re-tested and are stale (same class as the 20250925 one #3627 fixed): fresh-DB migrate, second-pass
-          # replay, and the snapshot-protection E2E (21/21) all pass with them applied.
-          # 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
-          # 20250925_create_view_tables.sql - legacy owner_id FK assumes pre-text user ids during replay.
-          #   NOTE: this exact bug was fixed by #3627, and migration-replay.yml already dropped
-          #   this exclusion in #3632 (verified passing there); this workflow was never
-          #   re-verified/updated to match, so this exclusion may now be stale rather than still
-          #   required — needs re-verification before removal, not a piecemeal drop (see #4162).
+          # Re-enabled per #4162: views/view_states + snapshot cluster (2026-07-13), then
+          # 042a/gantt/20250925 (2026-07-14). Fresh and old-list upgrade migrations, tracked-skip
+          # replay, schema assertions, and the snapshot-protection E2E all pass with this shape.
           # zzzz20260114110000_create_user_orgs_table.ts - replay paths hit legacy user_orgs is_active reference incompatibility.
           #   NOTE: plugin-tests.yml intentionally does NOT exclude this one — attendance
           #   auto-absence depends on the user_orgs table in that job (see b1fc1e19d1).
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm -F @metasheet/core-backend db:list || true
           pnpm -F @metasheet/core-backend db:migrate

--- a/.github/workflows/observability-strict.yml
+++ b/.github/workflows/observability-strict.yml
@@ -108,30 +108,20 @@ jobs:
           # (no-ops a migration's body but keeps its name; this drops name+body entirely). See
           # packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md and
           # docs/development/superseded-legacy-migrations-gap-audit-20260710.md for the full
-          # cross-list picture. #4162 follow-up (2026-07-13): the views/view_states migration
-          # and the three snapshot-cluster migrations are re-enabled below (in all five
-          # workflow lists at once), so their up() bodies now DO get per-PR green CI runs.
-          # Remaining asymmetry: production/on-prem db:migrate runs with no exclude at all,
-          # so the STILL-excluded items (008/048/049, 042a, gantt, 20250925) keep that gap.
+          # cross-list picture. #4162 is now fully executed: views/view_states + the snapshot
+          # cluster landed first, then 042a/gantt/20250925 were removed from every occurrence.
+          # 042a reaches the provider's superseded no-op marker; gantt and 20250925 execute
+          # their real bodies. Remaining asymmetry is limited to 008/048/049 and user_orgs.
           # Exclude problematic migrations (see migration-replay.yml for details)
           # 008_plugin_infrastructure.sql - has idempotency issue with scope column
           # 048/049 (event bus / BPMN) - Phase 2 migrations with complex SQL syntax issues
-          # 042a_core_model_views.sql - References non-existent last_accessed column
-          # Re-enabled per #4162 (2026-07-13): 20250924120000_create_views_view_states.ts and the three
-          # snapshot-cluster migrations (20251117000001_add_snapshot_labels, 20251117000002_create_protection_rules,
-          # 20251201000001_create_change_management_tables) now RUN here. Their old per-item exclusion reasons were
-          # re-tested and are stale (same class as the 20250925 one #3627 fixed): fresh-DB migrate, second-pass
-          # replay, and the snapshot-protection E2E (21/21) all pass with them applied.
-          # 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
-          # 20250925_create_view_tables.sql - legacy owner_id FK assumes pre-text user ids during replay.
-          #   NOTE: this exact bug was fixed by #3627, and migration-replay.yml already dropped
-          #   this exclusion in #3632 (verified passing there); this workflow was never
-          #   re-verified/updated to match, so this exclusion may now be stale rather than still
-          #   required — needs re-verification before removal, not a piecemeal drop (see #4162).
+          # Re-enabled per #4162: views/view_states + snapshot cluster (2026-07-13), then
+          # 042a/gantt/20250925 (2026-07-14). Fresh and old-list upgrade migrations, tracked-skip
+          # replay, schema assertions, and the snapshot-protection E2E all pass with this shape.
           # zzzz20260114110000_create_user_orgs_table.ts - replay paths hit legacy user_orgs is_active reference incompatibility.
           #   NOTE: plugin-tests.yml intentionally does NOT exclude this one — attendance
           #   auto-absence depends on the user_orgs table in that job (see b1fc1e19d1).
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm -F @metasheet/core-backend db:list || true
           pnpm -F @metasheet/core-backend db:migrate

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -280,27 +280,18 @@ jobs:
           # (no-ops a migration's body but keeps its name; this drops name+body entirely). See
           # packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md and
           # docs/development/superseded-legacy-migrations-gap-audit-20260710.md for the full
-          # cross-list picture. #4162 follow-up (2026-07-13): the views/view_states migration
-          # and the three snapshot-cluster migrations are re-enabled below (in all five
-          # workflow lists at once), so their up() bodies now DO get per-PR green CI runs.
-          # Remaining asymmetry: production/on-prem db:migrate runs with no exclude at all,
-          # so the STILL-excluded items (008/048/049, 042a, gantt, 20250925) keep that gap.
+          # cross-list picture. #4162 is now fully executed: the 2026-07-13 tranche re-enabled
+          # views/view_states plus the snapshot cluster, and the 2026-07-14 tail removed 042a,
+          # gantt, and 20250925 from every occurrence. 042a now reaches the provider's audited
+          # superseded no-op marker; gantt and 20250925 execute their real bodies in this lane.
+          # Remaining asymmetry is limited to 008/048/049 (and user_orgs outside plugin-tests).
           # Exclude problematic migrations (see migration-replay.yml for the per-item detail
           # this workflow shares):
           # 008_plugin_infrastructure.sql - has idempotency issue with scope column
           # 048/049 (event bus / BPMN) - Phase 2 migrations with complex SQL syntax issues
-          # 042a_core_model_views.sql - References non-existent last_accessed column
-          # Re-enabled per #4162 (2026-07-13): 20250924120000_create_views_view_states.ts and the three
-          # snapshot-cluster migrations (20251117000001_add_snapshot_labels, 20251117000002_create_protection_rules,
-          # 20251201000001_create_change_management_tables) now RUN here. Their old per-item exclusion reasons were
-          # re-tested and are stale (same class as the 20250925 one #3627 fixed): fresh-DB migrate, second-pass
-          # replay, and the snapshot-protection E2E (21/21) all pass with them applied.
-          # 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
-          # 20250925_create_view_tables.sql - legacy owner_id FK assumes pre-text user ids during replay.
-          #   NOTE: this exact bug was fixed by #3627, and migration-replay.yml already dropped
-          #   this exclusion in #3632 (verified passing there); this workflow was never
-          #   re-verified/updated to match, so this exclusion may now be stale rather than still
-          #   required — needs re-verification before removal, not a piecemeal drop (see #4162).
+          # Re-enabled per #4162: views/view_states + snapshot cluster (2026-07-13), then
+          # 042a/gantt/20250925 (2026-07-14). Fresh and old-list upgrade migrations, tracked-skip
+          # replay, schema assertions, and the snapshot-protection E2E all pass with this shape.
           # NOTE: zzzz20260114110000_create_user_orgs_table.ts is intentionally NOT in this
           #   list (unlike observability-*.yml/safety-guard-e2e.yml/migration-replay.yml, which
           #   all exclude it because it hits a legacy user_orgs is_active replay incompatibility
@@ -309,7 +300,7 @@ jobs:
           #   ("ci(attendance): run integration gate against postgres") — "Include the user_orgs
           #   migration in plugin-test database setup because attendance auto-absence now
           #   depends on that table."
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql
         run: |
           pnpm --filter @metasheet/core-backend db:migrate
 
@@ -817,27 +808,18 @@ jobs:
           # (no-ops a migration's body but keeps its name; this drops name+body entirely). See
           # packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md and
           # docs/development/superseded-legacy-migrations-gap-audit-20260710.md for the full
-          # cross-list picture. #4162 follow-up (2026-07-13): the views/view_states migration
-          # and the three snapshot-cluster migrations are re-enabled below (in all five
-          # workflow lists at once), so their up() bodies now DO get per-PR green CI runs.
-          # Remaining asymmetry: production/on-prem db:migrate runs with no exclude at all,
-          # so the STILL-excluded items (008/048/049, 042a, gantt, 20250925) keep that gap.
+          # cross-list picture. #4162 is now fully executed: the 2026-07-13 tranche re-enabled
+          # views/view_states plus the snapshot cluster, and the 2026-07-14 tail removed 042a,
+          # gantt, and 20250925 from every occurrence. 042a now reaches the provider's audited
+          # superseded no-op marker; gantt and 20250925 execute their real bodies in this lane.
+          # Remaining asymmetry is limited to 008/048/049 (and user_orgs outside plugin-tests).
           # Exclude problematic migrations (see migration-replay.yml for the per-item detail
           # this workflow shares):
           # 008_plugin_infrastructure.sql - has idempotency issue with scope column
           # 048/049 (event bus / BPMN) - Phase 2 migrations with complex SQL syntax issues
-          # 042a_core_model_views.sql - References non-existent last_accessed column
-          # Re-enabled per #4162 (2026-07-13): 20250924120000_create_views_view_states.ts and the three
-          # snapshot-cluster migrations (20251117000001_add_snapshot_labels, 20251117000002_create_protection_rules,
-          # 20251201000001_create_change_management_tables) now RUN here. Their old per-item exclusion reasons were
-          # re-tested and are stale (same class as the 20250925 one #3627 fixed): fresh-DB migrate, second-pass
-          # replay, and the snapshot-protection E2E (21/21) all pass with them applied.
-          # 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
-          # 20250925_create_view_tables.sql - legacy owner_id FK assumes pre-text user ids during replay.
-          #   NOTE: this exact bug was fixed by #3627, and migration-replay.yml already dropped
-          #   this exclusion in #3632 (verified passing there); this workflow was never
-          #   re-verified/updated to match, so this exclusion may now be stale rather than still
-          #   required — needs re-verification before removal, not a piecemeal drop (see #4162).
+          # Re-enabled per #4162: views/view_states + snapshot cluster (2026-07-13), then
+          # 042a/gantt/20250925 (2026-07-14). Fresh and old-list upgrade migrations, tracked-skip
+          # replay, schema assertions, and the snapshot-protection E2E all pass with this shape.
           # NOTE: zzzz20260114110000_create_user_orgs_table.ts is also absent from this job's
           #   list (unlike observability-*.yml/safety-guard-e2e.yml/migration-replay.yml). It was
           #   removed here in the SAME commit as the `test` job above (b1fc1e19d1), whose message
@@ -846,7 +828,7 @@ jobs:
           #   not obviously touch user_orgs/attendance. Left as-is (not this T8 slice's job to
           #   resolve), but flagged: this specific occurrence's omission may be an unverified
           #   side-effect of a file-wide edit rather than a decision made for this job.
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql
         run: |
           pnpm --filter @metasheet/core-backend db:migrate
 

--- a/.github/workflows/safety-guard-e2e.yml
+++ b/.github/workflows/safety-guard-e2e.yml
@@ -71,31 +71,21 @@ jobs:
           # (no-ops a migration's body but keeps its name; this drops name+body entirely). See
           # packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md and
           # docs/development/superseded-legacy-migrations-gap-audit-20260710.md for the full
-          # cross-list picture. #4162 follow-up (2026-07-13): the views/view_states migration
-          # and the three snapshot-cluster migrations are re-enabled below (in all five
-          # workflow lists at once), so their up() bodies now DO get per-PR green CI runs.
-          # Remaining asymmetry: production/on-prem db:migrate runs with no exclude at all,
-          # so the STILL-excluded items (008/048/049, 042a, gantt, 20250925) keep that gap.
+          # cross-list picture. #4162 is now fully executed: views/view_states + the snapshot
+          # cluster landed first, then 042a/gantt/20250925 were removed from every occurrence.
+          # 042a reaches the provider's superseded no-op marker; gantt and 20250925 execute
+          # their real bodies. Remaining asymmetry is limited to 008/048/049 and user_orgs.
           # Exclude problematic migrations (see migration-replay.yml for the per-item detail
           # this workflow shares):
           # 008_plugin_infrastructure.sql - has idempotency issue with scope column
           # 048/049 (event bus / BPMN) - Phase 2 migrations with complex SQL syntax issues
-          # 042a_core_model_views.sql - References non-existent last_accessed column
-          # Re-enabled per #4162 (2026-07-13): 20250924120000_create_views_view_states.ts and the three
-          # snapshot-cluster migrations (20251117000001_add_snapshot_labels, 20251117000002_create_protection_rules,
-          # 20251201000001_create_change_management_tables) now RUN here. Their old per-item exclusion reasons were
-          # re-tested and are stale (same class as the 20250925 one #3627 fixed): fresh-DB migrate, second-pass
-          # replay, and the snapshot-protection E2E (21/21) all pass with them applied.
-          # 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
-          # 20250925_create_view_tables.sql - legacy owner_id FK assumes pre-text user ids during replay.
-          #   NOTE: this exact bug was fixed by #3627, and migration-replay.yml already dropped
-          #   this exclusion in #3632 (verified passing there); this workflow was never
-          #   re-verified/updated to match, so this exclusion may now be stale rather than still
-          #   required — needs re-verification before removal, not a piecemeal drop (see #4162).
+          # Re-enabled per #4162: views/view_states + snapshot cluster (2026-07-13), then
+          # 042a/gantt/20250925 (2026-07-14). Fresh and old-list upgrade migrations, tracked-skip
+          # replay, schema assertions, and the snapshot-protection E2E all pass with this shape.
           # zzzz20260114110000_create_user_orgs_table.ts - replay paths hit legacy user_orgs is_active reference incompatibility.
           #   NOTE: plugin-tests.yml intentionally does NOT exclude this one — attendance
           #   auto-absence depends on the user_orgs table in that job (see b1fc1e19d1).
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm -F @metasheet/core-backend db:list || true
           pnpm -F @metasheet/core-backend db:migrate

--- a/packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
+++ b/packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
@@ -4,12 +4,32 @@
 
 This document tracks database migrations that are currently excluded from automated replay testing. These migrations require manual review and fixing before they can be re-enabled.
 
-**Current Exclude Count**: 7 files (union across occurrences)
+**Current Exclude Count**: 4 files (union across occurrences)
 
-**Default Exclude in CI**: `008_plugin_infrastructure.sql, 048_create_event_bus_tables.sql, 049_create_bpmn_workflow_tables.sql, 042a_core_model_views.sql, 20250924140000_create_gantt_tables.ts, 20250925_create_view_tables.sql, zzzz20260114110000_create_user_orgs_table.ts`
+**Default Exclude in CI**: `008_plugin_infrastructure.sql, 048_create_event_bus_tables.sql, 049_create_bpmn_workflow_tables.sql`; observability/safety/replay also exclude `zzzz20260114110000_create_user_orgs_table.ts`
 
-**Last Updated**: 2026-07-13 (#4162 follow-up — see the re-enable section below; T8 docs-only pass
-2026-07-12 added the cross-list context without changing any exclude value)
+**Last Updated**: 2026-07-14 (#4162 closure — see both re-enable sections below; T8 docs-only
+pass 2026-07-12 added the cross-list context without changing any exclude value)
+
+---
+
+## #4162 closure (2026-07-14): final 3 items RE-ENABLED across all workflow lists
+
+The remaining view-table cluster tail is no longer excluded:
+
+- `042a_core_model_views.sql` now reaches `SUPERSEDED_LEGACY_SQL_MIGRATIONS` and records its
+  audited no-op history marker. Its redundant CI-level drop was not protecting any live body.
+- `20250924140000_create_gantt_tables.ts` now executes after the UUID `views` migration and
+  creates all four Gantt tables, indexes, triggers, and constraints.
+- `20250925_create_view_tables.sql` now executes in the five per-PR gate occurrences that still
+  excluded it. Its owner-id FK type guard was fixed by #3627 and had already run green in
+  `migration-replay.yml` since #3632.
+
+Proofs on current `main`: a fresh no-exclude migration, an exact old-plugin-list database upgraded
+to the new list, and a second tracked-skip migrate all exited 0. The upgrade applied all three
+previously absent names; the four `gantt_*` tables plus `chk_no_self_dependency` and
+`chk_valid_date_range` were present. The workflow lists, guard baseline/fixtures, provider comments,
+and this ledger were updated together so a removed item cannot remain silently documented as live.
 
 ---
 
@@ -27,7 +47,7 @@ Why: `snapshot-protection.test.ts` (the GHSA-h8mf "Snapshot Protection System E2
 queries `views` / `view_states` — so a CI test-DB without these migrations cannot run that suite at
 all (it failed with `column "tags" of relation "snapshots" does not exist` when first wired in
 PR #4218). The old per-item exclusion reasons were re-tested and found stale — the same class of
-staleness as the `20250925` row below. Proof carried by the re-enable PR: fresh-DB full migrate,
+staleness later closed for `20250925`. Proof carried by the re-enable PR: fresh-DB full migrate,
 second-pass **tracked-skip replay** (a second `migrateToLatest()` skips already-applied items via
 the migration history — it does NOT re-run the four `up()` bodies), a **separate upgrade proof**
 (old-list DB → new-list migrate, which is what actually re-executes the newly-enabled `up()`
@@ -51,28 +71,27 @@ workflows/jobs that depend on each one's specific shape. Full detail:
    marker) so CI's schema-build order can succeed despite that migration's known conflicts.
 2. **`migration-replay.yml`'s own `MIGRATION_EXCLUDE` subset** — a narrower, independently
    evolving list for a different job (run `db:migrate` twice against a fresh db, assert the
-   second pass is a clean tracked-skip replay). Its list is not identical to #1's (7-item
-   union as of 2026-07-13) today.
+   second pass is a clean tracked-skip replay). Its list is not identical to #1's (4-item
+   union as of 2026-07-14) today.
 3. **`SUPERSEDED_LEGACY_SQL_MIGRATIONS`** in `packages/core-backend/src/db/migration-provider.ts`
    — a disjoint-purpose list of ~29 legacy numeric SQL migrations turned into no-op history
-   markers (name stays, body doesn't run) rather than dropped. Overlaps #1 on exactly three
-   items (`042a_core_model_views`, `048_create_event_bus_tables`,
-   `049_create_bpmn_workflow_tables`) — confirmed intentional/harmless double-listing by the
-   2026-07-10 audit.
+   markers (name stays, body doesn't run) rather than dropped. Overlaps #1 on exactly two
+   items (`048_create_event_bus_tables`, `049_create_bpmn_workflow_tables`) — confirmed
+   intentional/harmless double-listing. `042a_core_model_views` remains a superseded no-op but
+   is no longer redundantly dropped by CI.
 
 **Known, verified divergences between the 7 occurrences of #1/#2** (git-blame-checked, not
 guessed):
 
 | Item | Present in | Absent from | Why |
 |---|---|---|---|
-| `20250925_create_view_tables.sql` | plugin-tests.yml (both jobs), observability-strict/e2e.yml, safety-guard-e2e.yml | migration-replay.yml | The owner_id FK bug this item guards against was fixed by #3627; migration-replay.yml dropped the exclusion in #3632 (verified passing). The other 4 occurrences were never re-verified/updated to match — **possibly stale**, not resolved here (still open for `20250925` specifically). The snapshot-protection-blocking part of #4162 was executed 2026-07-13 (see the re-enable section above); `20250925` itself remains excluded outside migration-replay.yml. |
 | `zzzz20260114110000_create_user_orgs_table.ts` | observability-strict/e2e.yml, safety-guard-e2e.yml, migration-replay.yml | plugin-tests.yml (both jobs) | Removed from plugin-tests.yml's `test` job in commit `b1fc1e19d1` ("ci(attendance): run integration gate against postgres") because attendance auto-absence needs the `user_orgs` table applied in that job. The **same commit** also removed it from the `after-sales-integration` job in the same file, which does not obviously touch attendance/user_orgs — that second removal may be an unverified side-effect of a file-wide edit rather than a deliberate per-job decision. Flagged, not resolved here. |
 
 **Known asymmetry this doc does not close**: production and on-prem `db:migrate` runs use **no**
 `MIGRATION_EXCLUDE` at all — every migration listed above runs in a real deploy. Only CI's per-PR
-gate trims the list. **Since the 2026-07-13 #4162 follow-up, the views/view_states + snapshot/
-protection-rule/change-management migrations DO get per-PR green CI runs**; the asymmetry now
-covers only the still-excluded remainder (008/048/049, 042a, gantt, 20250925).
+gate trims the list. **Since the two #4162 re-enable tranches, views/view_states, gantt, 20250925,
+and the snapshot/protection/change-management cluster get per-PR CI runs.** The asymmetry now covers
+only 008/048/049 and `user_orgs` outside plugin-tests.
 
 **Guard**: `scripts/ci/validate-migration-exclude.sh` cross-checks all of the above for
 undocumented drift (warn-only; see that script's header for what it covers and does not cover).
@@ -103,20 +122,23 @@ without re-reading that design doc first.
 ### Current CI Exclusions
 
 #### `042a_core_model_views.sql`
-**Status**: ❌ Excluded
-**Issue**: References non-existent `last_accessed` column during replay paths.
+**Status**: ✅ RE-ENABLED 2026-07-14 (#4162 closure)
+**Disposition**: Still an audited `SUPERSEDED_LEGACY_SQL_MIGRATIONS` no-op history marker; the
+redundant CI-level exclusion was removed.
 
 #### `20250924120000_create_views_view_states.ts`
 **Status**: ✅ RE-ENABLED 2026-07-13 (#4162 follow-up — see section above)
 **Issue**: Creates view-state foreign keys against pre-fix `text` view ids, which fails once replay paths rebuild the newer UUID-based schema.
 
 #### `20250924140000_create_gantt_tables.ts`
-**Status**: ❌ Excluded
-**Issue**: Creates gantt foreign keys against the same pre-fix `text` view ids and fails with `uuid` vs `text` FK incompatibility during replay paths.
+**Status**: ✅ RE-ENABLED 2026-07-14 (#4162 closure)
+**Disposition**: Current `views.id` is UUID. Fresh and old-list upgrade migrations create all four
+Gantt tables and their constraints successfully.
 
 #### `20250925_create_view_tables.sql`
-**Status**: ❌ Excluded
-**Issue**: Applies `tables_owner_id_fkey` against a legacy `owner_id` shape that no longer exists in replay-built schemas, causing `owner_id` foreign-key failures.
+**Status**: ✅ RE-ENABLED 2026-07-14 (#4162 closure)
+**Disposition**: #3627 added the owner-id FK type guard; #3632 proved replay, and #4162 aligned the
+remaining workflow occurrences after fresh/upgrade verification.
 
 #### `20251117000001_add_snapshot_labels.ts`
 **Status**: ✅ RE-ENABLED 2026-07-13 (#4162 follow-up — see section above)

--- a/packages/core-backend/src/db/migration-provider.ts
+++ b/packages/core-backend/src/db/migration-provider.ts
@@ -39,24 +39,22 @@ interface CreateCoreBackendMigrationProviderOptions {
 //      order cannot yet satisfy a migration's FK/constraint assumptions.
 //   3. migration-replay.yml's OWN MIGRATION_EXCLUDE subset — a different, narrower list for
 //      a different job (run db:migrate twice against a fresh db, assert idempotency), which
-//      has independently dropped some entries (e.g. 20250925_create_view_tables.sql, fixed by
-//      #3627/#3632) that the CI per-PR gate lists above have not yet re-verified and dropped.
+//      independently dropped 20250925_create_view_tables.sql after #3627/#3632; #4162 later
+//      re-verified that fix and aligned the per-PR gate lists.
 //      See the comments on that env var in each workflow file for the per-item and
 //      per-occurrence detail.
 //
-// Known, deliberate overlap between this list and mechanism #2: 042a_core_model_views,
-// 048_create_event_bus_tables, and 049_create_bpmn_workflow_tables appear in BOTH — no-op
-// AND CI-excluded is redundant but harmless (belt-and-suspenders), confirmed as the full
-// overlap (no others) by the 2026-07-10 audit above.
+// Known, deliberate overlap between this list and mechanism #2:
+// 048_create_event_bus_tables and 049_create_bpmn_workflow_tables appear in BOTH — no-op AND
+// CI-excluded is redundant but harmless (belt-and-suspenders). 042a_core_model_views was the
+// third overlap until #4162 removed its stale CI exclusion; it remains an audited no-op marker.
 //
 // Known asymmetry that this list does NOT close (tracked, not a bug in this file): production
-// and on-prem `db:migrate` runs use NEITHER this list NOR MIGRATION_EXCLUDE — they run every
-// migration including the modern view_states/gantt/snapshot/protection-rule/change-management
-// migrations that CI's MIGRATION_EXCLUDE (mechanism #2) skips. That means those modern
-// migrations' up() bodies have never had a per-PR green CI run; untangling that gap so the
-// full snapshot-protection integration suite can run in CI is gated planning work — see #4162.
-// Do not "fix" that gap by deleting entries from this list; the two mechanisms serve different
-// failure modes and this file is not the one that needs to change for it.
+// and on-prem `db:migrate` runs use no MIGRATION_EXCLUDE. #4162 closed the modern migration
+// coverage gap for views/view_states, gantt, 20250925, and the snapshot/protection/change-
+// management cluster. The remaining CI exclusions are 008/048/049 plus user_orgs outside
+// plugin-tests; do not "fix" those by deleting entries from this list because the mechanisms
+// serve different failure modes.
 //
 // Per-item disposition below (grouped; full object-level mapping is in the 2026-07-10 audit
 // doc's §1/§2 tables). Everything is a verified zombie (no live reader depends on the legacy

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -489,11 +489,9 @@ export default defineConfig({
       'tests/integration/router-isolation.smoke.test.ts',
       // snapshot-protection boots a real server too, and its silent-return skips are gone (setup now
       // hard-fails and every test must assert), so it can no longer report green without doing its work.
-      // It is still NOT wired into CI: the CI test database is migrated with MIGRATION_EXCLUDE, which omits
-      // the view-table migrations (20250924120000_create_views_view_states, 20250925_create_view_tables,
-      // 042a_core_model_views) — so `views` does not exist there and createSnapshot's captureViewState
-      // cannot run. Wiring it requires untangling that excluded migration cluster, which is its own change;
-      // until then this is DECLARED debt, not invisible debt. Run it locally against a fully-migrated DB.
+      // It is wired as a WHOLE FILE into plugin-tests.yml's Node 20 real-DB lane. #4162 re-enabled
+      // its views/snapshot dependencies and then removed the remaining 042a/gantt/20250925 tail,
+      // so this exclusion only keeps the no-DB default job from skip-green duplication.
       'tests/integration/snapshot-protection.test.ts',
       'tests/integration/spreadsheet-integration.test.ts',
       // Playwright E2E suites run through their own harness, not Vitest.

--- a/scripts/ci/__fixtures__/migration-exclude/drift/workflows/migration-replay.yml
+++ b/scripts/ci/__fixtures__/migration-exclude/drift/workflows/migration-replay.yml
@@ -5,8 +5,7 @@ jobs:
       - name: Run migrations twice (replay)
         env:
           DATABASE_URL: postgresql://127.0.0.1/metasheet
-          # 20250925_create_view_tables.sql intentionally absent here - fixed by #3627/#3632.
-          # 042a_core_model_views.sql ALSO undocumented-ly dropped here (no reason given) - this
-          # is the drift this fixture exists to trigger.
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,20250924140000_create_gantt_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          # 048_create_event_bus_tables.sql is undocumented-ly dropped here (no reason given) -
+          # this is the drift this fixture exists to trigger.
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,049_create_bpmn_workflow_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
         run: echo fixture

--- a/scripts/ci/__fixtures__/migration-exclude/drift/workflows/observability-strict.yml
+++ b/scripts/ci/__fixtures__/migration-exclude/drift/workflows/observability-strict.yml
@@ -5,5 +5,5 @@ jobs:
       - name: Run DB migrations
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/metasheet
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,zzzz20260114110000_create_user_orgs_table.ts,999_bogus_undocumented_migration.sql
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,zzzz20260114110000_create_user_orgs_table.ts,999_bogus_undocumented_migration.sql
         run: echo fixture

--- a/scripts/ci/__fixtures__/migration-exclude/drift/workflows/plugin-tests.yml
+++ b/scripts/ci/__fixtures__/migration-exclude/drift/workflows/plugin-tests.yml
@@ -7,5 +7,5 @@ jobs:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
           # zzzz20260114110000_create_user_orgs_table.ts intentionally absent here - attendance
           # needs the user_orgs table applied in this job (see b1fc1e19d1).
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql
         run: echo fixture

--- a/scripts/ci/__fixtures__/migration-exclude/good/workflows/migration-replay.yml
+++ b/scripts/ci/__fixtures__/migration-exclude/good/workflows/migration-replay.yml
@@ -5,6 +5,5 @@ jobs:
       - name: Run migrations twice (replay)
         env:
           DATABASE_URL: postgresql://127.0.0.1/metasheet
-          # 20250925_create_view_tables.sql intentionally absent here - fixed by #3627/#3632.
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
         run: echo fixture

--- a/scripts/ci/__fixtures__/migration-exclude/good/workflows/observability-strict.yml
+++ b/scripts/ci/__fixtures__/migration-exclude/good/workflows/observability-strict.yml
@@ -5,5 +5,5 @@ jobs:
       - name: Run DB migrations
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/metasheet
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,zzzz20260114110000_create_user_orgs_table.ts
         run: echo fixture

--- a/scripts/ci/__fixtures__/migration-exclude/good/workflows/plugin-tests.yml
+++ b/scripts/ci/__fixtures__/migration-exclude/good/workflows/plugin-tests.yml
@@ -7,5 +7,5 @@ jobs:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
           # zzzz20260114110000_create_user_orgs_table.ts intentionally absent here - attendance
           # needs the user_orgs table applied in this job (see b1fc1e19d1).
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql
         run: echo fixture

--- a/scripts/ci/__tests__/validate-migration-exclude.test.sh
+++ b/scripts/ci/__tests__/validate-migration-exclude.test.sh
@@ -3,8 +3,8 @@
 # testable part. Does NOT scan the real repo (that would make the test hostage to future,
 # legitimate edits to the workflows/migration-provider.ts); instead it points the guard at
 # small fixture files via the WORKFLOWS_DIR/PROVIDER_FILE overrides and asserts:
-#   - a "good" fixture set (mirrors the real, currently-documented baseline + the two known
-#     divergences) produces ZERO warnings;
+#   - a "good" fixture set (mirrors the real, currently-documented baseline + the known
+#     divergence) produces ZERO warnings;
 #   - a "drift" fixture set (an undocumented new exclusion, an undocumented divergence, a
 #     missing expected overlap item, an undocumented new overlap item, and a missing doc
 #     pointer) produces warnings for every one of those distinct cases.
@@ -73,7 +73,7 @@ else
 fi
 
 assert_contains "undocumented new exclusion (check A)" "999_bogus_undocumented_migration.sql"
-assert_contains "undocumented divergence (check B)" "Undocumented divergence: '042a_core_model_views.sql'"
+assert_contains "undocumented divergence (check B)" "Undocumented divergence: '048_create_event_bus_tables.sql'"
 assert_contains "undocumented overlap (check C)" "999_bogus_undocumented_migration' appears in BOTH"
 assert_contains "missing expected overlap item (check C reverse)" "'049_create_bpmn_workflow_tables' is no longer in SUPERSEDED_LEGACY_SQL_MIGRATIONS"
 assert_contains "missing doc pointer (check D)" "no longer references docs/development/migration-legacy-sql-skip-design-20260512.md"

--- a/scripts/ci/validate-migration-exclude.sh
+++ b/scripts/ci/validate-migration-exclude.sh
@@ -23,14 +23,14 @@
 # (a single env var, as inherited by this process) contained 3 hardcoded filenames. It now
 # reads the actual workflow files and migration-provider.ts directly and checks:
 #   A. every item in every CI-gate/replay MIGRATION_EXCLUDE occurrence against the full known
-#      baseline (7 items since the 2026-07-13 #4162 re-enable; was 11, originally 3) — anything extra is reported as a possibly-undocumented new
+#      baseline (4 items since the 2026-07-14 #4162 tail re-enable; was 7, then 11) — anything extra is reported as a possibly-undocumented new
 #      exclusion;
 #   B. every occurrence-to-occurrence divergence within those seven occurrences (5 files:
 #      plugin-tests x2, migration-replay x2, observability-e2e/strict, safety-guard-e2e) against a table
 #      of KNOWN, already-reviewed divergences (see MIGRATION_EXCLUDE_TRACKING.md) — anything
 #      not in that table is reported as new/undocumented drift;
 #   C. the overlap between MIGRATION_EXCLUDE and SUPERSEDED_LEGACY_SQL_MIGRATIONS against the
-#      known 3-item overlap (042a/048/049) — a new overlap item, or a missing expected one, is
+#      known 2-item overlap (048/049) — a new overlap item, or a missing expected one, is
 #      reported;
 #   D. a size canary + doc-pointer presence check on SUPERSEDED_LEGACY_SQL_MIGRATIONS itself.
 #
@@ -48,33 +48,30 @@ REPO_ROOT="$(cd "$HERE/../.." && pwd)"
 WORKFLOWS_DIR="${WORKFLOWS_DIR:-$REPO_ROOT/.github/workflows}"
 PROVIDER_FILE="${PROVIDER_FILE:-$REPO_ROOT/packages/core-backend/src/db/migration-provider.ts}"
 
-# Known baseline: the union of every item that has appeared, with review, in any CI
-# per-PR-gate / migration-replay MIGRATION_EXCLUDE occurrence as of 2026-07-13.
+# Known baseline: the union of every item that remains, with review, in any CI
+# per-PR-gate / migration-replay MIGRATION_EXCLUDE occurrence as of 2026-07-14.
 # (#4162 follow-up, 2026-07-13: 20250924120000_create_views_view_states.ts and the three
 # snapshot-cluster migrations — 20251117000001_add_snapshot_labels.ts,
 # 20251117000002_create_protection_rules.ts, 20251201000001_create_change_management_tables.ts —
 # were RE-ENABLED across all five workflow lists at once and removed from this baseline; if one
-# of them reappears in a list, this guard now reports it as a possibly-undocumented NEW exclusion.)
+# of them reappears in a list, this guard now reports it as a possibly-undocumented NEW exclusion.
+# The 2026-07-14 tail also re-enabled 042a_core_model_views.sql,
+# 20250924140000_create_gantt_tables.ts, and 20250925_create_view_tables.sql everywhere.)
 KNOWN_BASELINE_ITEMS='008_plugin_infrastructure.sql
 048_create_event_bus_tables.sql
 049_create_bpmn_workflow_tables.sql
-042a_core_model_views.sql
-20250924140000_create_gantt_tables.ts
-20250925_create_view_tables.sql
 zzzz20260114110000_create_user_orgs_table.ts'
 
 # Known, reviewed occurrence-to-occurrence divergences: "<item>|<workflow-file-basename that
 # is known to OMIT it, while the rest of the baseline occurrences include it>". See
 # packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md for the full per-row explanation
 # (git-blame-verified commits/PRs, not guessed).
-KNOWN_DIVERGENCES='20250925_create_view_tables.sql|migration-replay.yml
-zzzz20260114110000_create_user_orgs_table.ts|plugin-tests.yml'
+KNOWN_DIVERGENCES='zzzz20260114110000_create_user_orgs_table.ts|plugin-tests.yml'
 
 # Known, reviewed overlap between MIGRATION_EXCLUDE (mechanisms #1/#2) and
 # SUPERSEDED_LEGACY_SQL_MIGRATIONS (mechanism #3) — confirmed intentional/harmless by the
 # 2026-07-10 audit (docs/development/superseded-legacy-migrations-gap-audit-20260710.md §0).
-KNOWN_SUPERSEDED_OVERLAP='042a_core_model_views
-048_create_event_bus_tables
+KNOWN_SUPERSEDED_OVERLAP='048_create_event_bus_tables
 049_create_bpmn_workflow_tables'
 
 # The array has 30 entries as of 2026-07-12 (counted directly from migration-provider.ts, not
@@ -264,7 +261,7 @@ $stripped"
         overlap_found="$overlap_found
 $stripped"
         if ! item_in_list "$stripped" "$KNOWN_SUPERSEDED_OVERLAP"; then
-          warn "'$stripped' appears in BOTH MIGRATION_EXCLUDE (CI-gate/replay) AND SUPERSEDED_LEGACY_SQL_MIGRATIONS, which is not in this guard's KNOWN_SUPERSEDED_OVERLAP table (042a/048/049 only). Double-listing is usually harmless (belt-and-suspenders) but should be a reviewed, cited decision, not a silent accident."
+          warn "'$stripped' appears in BOTH MIGRATION_EXCLUDE (CI-gate/replay) AND SUPERSEDED_LEGACY_SQL_MIGRATIONS, which is not in this guard's KNOWN_SUPERSEDED_OVERLAP table (048/049 only). Double-listing is usually harmless (belt-and-suspenders) but should be a reviewed, cited decision, not a silent accident."
         fi
       fi
     done <<< "$uniq_baseline_stripped"
@@ -274,9 +271,9 @@ $stripped"
       expected_overlap_item="$(trim "$expected_overlap_item")"
       [[ -z "$expected_overlap_item" ]] && continue
       if ! item_in_list "$expected_overlap_item" "$superseded_list"; then
-        warn "Expected overlap item '$expected_overlap_item' is no longer in SUPERSEDED_LEGACY_SQL_MIGRATIONS — the known 3-item overlap with MIGRATION_EXCLUDE (042a/048/049) has changed; re-verify against docs/development/superseded-legacy-migrations-gap-audit-20260710.md."
+        warn "Expected overlap item '$expected_overlap_item' is no longer in SUPERSEDED_LEGACY_SQL_MIGRATIONS — the known 2-item overlap with MIGRATION_EXCLUDE (048/049) has changed; re-verify against docs/development/superseded-legacy-migrations-gap-audit-20260710.md."
       elif ! item_in_list "$expected_overlap_item" "$uniq_baseline_stripped"; then
-        warn "Expected overlap item '$expected_overlap_item' is no longer excluded by any CI-gate/replay MIGRATION_EXCLUDE occurrence — the known 3-item overlap has changed; re-verify."
+        warn "Expected overlap item '$expected_overlap_item' is no longer excluded by any CI-gate/replay MIGRATION_EXCLUDE occurrence — the known 2-item overlap has changed; re-verify."
       fi
     done <<< "$KNOWN_SUPERSEDED_OVERLAP"
 
@@ -293,10 +290,10 @@ $stripped"
   # --- Always-on informational note: the asymmetry this guard does not, and cannot, close --
   info "Known asymmetry (not a bug this guard can catch): production/on-prem 'db:migrate' runs"
   info "with NO MIGRATION_EXCLUDE at all. Only CI's per-PR gate trims the list above. #4162"
-  info "follow-up (2026-07-13): views/view_states + the snapshot/protection-rule/change-management"
-  info "migrations are re-enabled in CI and now DO get per-PR green runs; the still-excluded"
-  info "remainder (008/048/049, 042a, gantt, 20250925) keeps this gap. Do not close it by"
-  info "editing this script."
+  info "follow-up (2026-07-14): views/view_states, the snapshot cluster, 042a, gantt, and"
+  info "20250925 are re-enabled in CI. The still-excluded remainder (008/048/049, plus"
+  info "user_orgs outside plugin-tests) keeps this narrower gap. Do not close it by editing"
+  info "this script."
 }
 
 # main() is the only thing in this file that calls exit. It is intentionally NOT wired into any


### PR DESCRIPTION
## Summary

Complete the remaining migration-exclusion scope tracked by #4162.

- remove `042a_core_model_views.sql`, `20250924140000_create_gantt_tables.ts`, and `20250925_create_view_tables.sql` from all seven `MIGRATION_EXCLUDE` occurrences across five workflows;
- keep `042a` as the audited `SUPERSEDED_LEGACY_SQL_MIGRATIONS` no-op history marker while allowing Gantt and `20250925` to execute their real bodies in CI;
- update the drift guard baseline (7 -> 4 items), known divergence table (2 -> 1), superseded overlap (3 -> 2), fixtures, workflow comments, tracking ledger, provider comments, and the stale snapshot-protection Vitest note together.

No migration body or application runtime behavior changes in this PR.

## Why

The three remaining exclusions are stale on current `main`:

- `042a` is already converted to a no-op by the migration provider, so the CI-level drop is redundant;
- the current `views.id` is UUID, so the Gantt foreign keys now migrate cleanly;
- #3627 added the owner-id type guard for `20250925`, and #3632 already proved it in migration replay. The other workflow lists had never been aligned.

## Verification

- fresh PostgreSQL database, no `MIGRATION_EXCLUDE`: full migrate PASS; second tracked-skip migrate PASS;
- exact old plugin-list database -> new plugin list: PASS; all three names applied, four `gantt_*` tables and both Gantt constraints present;
- strict new list (still excludes `user_orgs`): fresh migrate PASS; second tracked-skip migrate PASS; `db:list` reports `Applied: 260`, `Pending: 0`;
- `snapshot-protection.test.ts`: 21/21 PASS on Node 24 and Node 20.20.2 with pnpm 10.33.0;
- `migration-provider.test.ts`: 6/6 PASS on Node 24 and Node 20.20.2;
- `validate-migration-exclude.test.sh`: PASS; real-repo guard reports zero undocumented drift;
- core-backend type-check: PASS;
- five workflow YAML files parse successfully;
- `bash -n` and `git diff --check`: PASS;
- current-main rebase integrity: `range-diff` is `=` from the previous reviewed patch; post-rebase exclusion drift guard PASS and `migration-provider.test.ts` 6/6 PASS;
- exact-head PR CI at `53e2e4cc98138a505e597c58be1478f5d455c4c2`: 16 successful, 0 failing, 0 pending, with the label-gated Strict job expectedly skipped. Migration Replay passed in run https://github.com/zensgit/metasheet2/actions/runs/29351036953. GitHub reports `MERGEABLE / CLEAN`.

An earlier manual Observability Strict dispatch on code-identical head `c2ec231823b12e7b3f7636dd039cd4c90983a0a4` also passed setup, OpenAPI build, and the reduced-list database migration. It then exposed the repository's pre-existing missing `scripts/contract-smoke.js` reference; that independent CI defect is isolated in #4259 with run evidence: https://github.com/zensgit/metasheet2/actions/runs/29297815998.

`prettier --check` still reports the touched parent workflow/docs/TS files as nonconforming; this PR intentionally avoids a broad formatting-only rewrite.

Refs #4162
