### PR TITLE
fix(ci): restore Observability Strict contract gate

### DIFF
--- a/.github/workflows/observability-strict.yml
+++ b/.github/workflows/observability-strict.yml
@@ -17,6 +17,8 @@ on:
       - 'packages/core-backend/**'
       - 'apps/web/**'
       - 'packages/openapi/**'
+      - 'scripts/contract-smoke.js'
+      - 'scripts/contract-smoke.test.mjs'
       - '.github/workflows/observability-strict.yml'
 
 concurrency:
@@ -50,6 +52,7 @@ jobs:
     env:
       P99_THRESHOLD: 0.1
       RBAC_SOFT_THRESHOLD: 60
+      JWT_SECRET: 'test-secret-for-ci'
 
     steps:
       - name: Checkout code
@@ -92,6 +95,9 @@ jobs:
         with:
           name: observability-install-log
           path: install.log
+
+      - name: Test contract smoke harness
+        run: node --test scripts/contract-smoke.test.mjs
 
       - name: Build OpenAPI spec
         run: |
@@ -143,7 +149,6 @@ jobs:
           KANBAN_AUTH_REQUIRED: 'true'
           APPROVAL_AUTH_REQUIRED: 'false'
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/metasheet
-          JWT_SECRET: 'test-secret-for-ci'
           NODE_ENV: 'development'
         run: |
           echo "Starting backend server directly with tsx..."

--- a/scripts/contract-smoke.js
+++ b/scripts/contract-smoke.js
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const DEFAULT_BASE_URL = 'http://127.0.0.1:8900'
+const DEFAULT_OUTPUT_PATH = 'contract-smoke.json'
+const DEFAULT_TIMEOUT_MS = 5_000
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function assertContract(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function expectStatus(response, expected) {
+  assertContract(
+    response.status === expected,
+    `expected HTTP ${expected}, received ${response.status}`,
+  )
+}
+
+function normalizeBaseUrl(rawValue) {
+  const value = String(rawValue || DEFAULT_BASE_URL).trim()
+  const url = new URL(value)
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error('BASE_URL must use http or https')
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(
+      'BASE_URL must not contain credentials, query parameters, or fragments',
+    )
+  }
+  return url.toString().replace(/\/$/, '')
+}
+
+function parseTimeoutMs(rawValue) {
+  if (rawValue === undefined || rawValue === '') return DEFAULT_TIMEOUT_MS
+  const timeoutMs = Number.parseInt(String(rawValue), 10)
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 100 || timeoutMs > 60_000) {
+    throw new Error(
+      'CONTRACT_SMOKE_TIMEOUT_MS must be an integer from 100 to 60000',
+    )
+  }
+  return timeoutMs
+}
+
+async function readResponseBody(response) {
+  const text = await response.text()
+  if (!text) return null
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+function summarizeBody(body) {
+  const serialized = typeof body === 'string' ? body : JSON.stringify(body)
+  if (!serialized) return null
+  return serialized.length <= 1_000
+    ? serialized
+    : `${serialized.slice(0, 1_000)}...`
+}
+
+function contractChecks() {
+  return [
+    {
+      name: 'health:get',
+      method: 'GET',
+      path: '/health',
+      authenticated: false,
+      assert(response, body) {
+        expectStatus(response, 200)
+        assertContract(isRecord(body), 'expected a JSON object')
+        assertContract(body.status === 'ok', 'expected status=ok')
+        assertContract(body.ok === true, 'expected ok=true')
+      },
+    },
+    {
+      name: 'auth:missing-token',
+      method: 'GET',
+      path: '/api/permissions',
+      authenticated: false,
+      assert(response, body) {
+        expectStatus(response, 401)
+        assertContract(isRecord(body), 'expected a JSON object')
+        assertContract(body.ok === false, 'expected ok=false')
+        assertContract(
+          body.error?.code === 'UNAUTHORIZED',
+          'expected error.code=UNAUTHORIZED',
+        )
+      },
+    },
+    {
+      name: 'permissions:health',
+      method: 'GET',
+      path: '/api/permissions/health',
+      authenticated: false,
+      assert(response, body) {
+        expectStatus(response, 200)
+        assertContract(isRecord(body), 'expected a JSON object')
+        assertContract(body.status === 'ok', 'expected status=ok')
+        assertContract(
+          typeof body.degraded === 'boolean',
+          'expected a boolean degraded field',
+        )
+      },
+    },
+    {
+      name: 'permissions:list',
+      method: 'GET',
+      path: '/api/permissions',
+      assert(response, body) {
+        expectStatus(response, 200)
+        assertContract(isRecord(body), 'expected a JSON object')
+        assertContract(Array.isArray(body.data), 'expected data to be an array')
+        assertContract(
+          Number.isInteger(body.total),
+          'expected total to be an integer',
+        )
+      },
+    },
+    {
+      name: 'permissions:me',
+      method: 'GET',
+      path: '/api/permissions/me',
+      assert(response, body) {
+        expectStatus(response, 200)
+        assertContract(isRecord(body), 'expected a JSON object')
+        assertContract(
+          typeof body.userId === 'string' && body.userId.length > 0,
+          'expected a userId',
+        )
+        assertContract(
+          Array.isArray(body.permissions),
+          'expected permissions to be an array',
+        )
+        assertContract(
+          typeof body.isAdmin === 'boolean',
+          'expected isAdmin to be a boolean',
+        )
+      },
+    },
+    {
+      name: 'permissions:check-validation',
+      method: 'POST',
+      path: '/api/permissions/check',
+      body: {},
+      assert(response, body) {
+        expectStatus(response, 400)
+        assertContract(isRecord(body), 'expected a JSON object')
+        assertContract(
+          body.error === 'permission is required',
+          'expected the permission validation error',
+        )
+      },
+    },
+    {
+      name: 'approvals:not-found',
+      method: 'GET',
+      path: '/api/approvals/__observability_contract_missing__',
+      assert(response, body) {
+        expectStatus(response, 404)
+        assertContract(isRecord(body), 'expected a JSON object')
+        assertContract(body.ok === false, 'expected ok=false')
+        assertContract(
+          body.error?.code === 'APPROVAL_NOT_FOUND',
+          'expected error.code=APPROVAL_NOT_FOUND',
+        )
+      },
+    },
+    {
+      name: 'audit-logs:list',
+      method: 'GET',
+      path: '/api/audit-logs?page=1&pageSize=1',
+      assert(response, body) {
+        expectStatus(response, 200)
+        assertContract(isRecord(body), 'expected a JSON object')
+        assertContract(body.ok === true, 'expected ok=true')
+        assertContract(isRecord(body.data), 'expected data to be an object')
+        assertContract(
+          Array.isArray(body.data.items),
+          'expected data.items to be an array',
+        )
+        assertContract(body.data.page === 1, 'expected page=1')
+        assertContract(body.data.pageSize === 1, 'expected pageSize=1')
+        assertContract(
+          Number.isInteger(body.data.total),
+          'expected total to be an integer',
+        )
+      },
+    },
+  ]
+}
+
+async function executeCheck(check, { baseUrl, token, timeoutMs, fetchImpl }) {
+  const startedAt = Date.now()
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    const headers = { Accept: 'application/json' }
+    if (check.authenticated !== false) headers.Authorization = `Bearer ${token}`
+    if (check.body !== undefined) headers['Content-Type'] = 'application/json'
+
+    const response = await fetchImpl(`${baseUrl}${check.path}`, {
+      method: check.method,
+      headers,
+      signal: controller.signal,
+      ...(check.body === undefined ? {} : { body: JSON.stringify(check.body) }),
+    })
+    const body = await readResponseBody(response)
+    check.assert(response, body)
+    return {
+      name: check.name,
+      ok: true,
+      method: check.method,
+      path: check.path,
+      status: response.status,
+      durationMs: Date.now() - startedAt,
+    }
+  } catch (error) {
+    return {
+      name: check.name,
+      ok: false,
+      method: check.method,
+      path: check.path,
+      durationMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export async function runContractSmoke(options = {}) {
+  const baseUrl = normalizeBaseUrl(options.baseUrl)
+  const token = String(options.token || '').trim()
+  if (!token) throw new Error('TOKEN is required')
+
+  const timeoutMs = parseTimeoutMs(options.timeoutMs)
+  const fetchImpl = options.fetchImpl || globalThis.fetch
+  if (typeof fetchImpl !== 'function') throw new Error('fetch is not available')
+
+  const startedAt = new Date().toISOString()
+  const checks = []
+  for (const check of contractChecks()) {
+    checks.push(
+      await executeCheck(check, { baseUrl, token, timeoutMs, fetchImpl }),
+    )
+  }
+
+  return {
+    ok: checks.every((check) => check.ok),
+    baseUrl,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    checks,
+  }
+}
+
+export async function writeContractReport(outputPath, report) {
+  const resolvedPath = path.resolve(outputPath || DEFAULT_OUTPUT_PATH)
+  await mkdir(path.dirname(resolvedPath), { recursive: true })
+  await writeFile(resolvedPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+  return resolvedPath
+}
+
+export async function runCli(options = {}) {
+  const env = options.env || process.env
+  const stdout = options.stdout || process.stdout
+  const stderr = options.stderr || process.stderr
+  const outputPath = env.CONTRACT_SMOKE_OUTPUT || DEFAULT_OUTPUT_PATH
+
+  try {
+    const report = await runContractSmoke({
+      baseUrl: env.BASE_URL,
+      token: env.TOKEN,
+      timeoutMs: env.CONTRACT_SMOKE_TIMEOUT_MS,
+      fetchImpl: options.fetchImpl,
+    })
+    const writtenPath = await writeContractReport(outputPath, report)
+    stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+    stdout.write(`Contract smoke report: ${writtenPath}\n`)
+    return report.ok ? 0 : 1
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    const report = {
+      ok: false,
+      baseUrl: (() => {
+        try {
+          return normalizeBaseUrl(env.BASE_URL)
+        } catch {
+          return null
+        }
+      })(),
+      startedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+      checks: [],
+      error: summarizeBody(message),
+    }
+    try {
+      await writeContractReport(outputPath, report)
+    } catch (writeError) {
+      stderr.write(
+        `Failed to write contract smoke report: ${writeError instanceof Error ? writeError.message : String(writeError)}\n`,
+      )
+    }
+    stderr.write(`Contract smoke failed: ${message}\n`)
+    return 1
+  }
+}
+
+const entrypoint = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : ''
+if (import.meta.url === entrypoint) {
+  process.exitCode = await runCli()
+}

--- a/scripts/contract-smoke.test.mjs
+++ b/scripts/contract-smoke.test.mjs
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { runCli, runContractSmoke } from './contract-smoke.js'
+
+const token = 'test-token-not-a-secret'
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function passingFetch(requests = []) {
+  return async (rawUrl, options = {}) => {
+    const url = new URL(rawUrl)
+    requests.push({
+      method: options.method,
+      path: `${url.pathname}${url.search}`,
+      authorization: options.headers?.Authorization,
+      body: options.body,
+    })
+
+    const key = `${options.method} ${url.pathname}${url.search}`
+    const responses = {
+      'GET /health': jsonResponse({ status: 'ok', ok: true }),
+      'GET /api/permissions/health': jsonResponse({
+        status: 'ok',
+        degraded: false,
+      }),
+      'GET /api/permissions': options.headers?.Authorization
+        ? jsonResponse({ data: [{ code: 'spreadsheet:read' }], total: 1 })
+        : jsonResponse(
+            {
+              ok: false,
+              error: { code: 'UNAUTHORIZED', message: 'Missing Bearer token' },
+            },
+            401,
+          ),
+      'GET /api/permissions/me': jsonResponse({
+        userId: 'dev-user',
+        permissions: ['*:*'],
+        isAdmin: true,
+      }),
+      'POST /api/permissions/check': jsonResponse(
+        { error: 'permission is required' },
+        400,
+      ),
+      'GET /api/approvals/__observability_contract_missing__': jsonResponse(
+        {
+          ok: false,
+          error: {
+            code: 'APPROVAL_NOT_FOUND',
+            message: 'Approval instance not found',
+          },
+        },
+        404,
+      ),
+      'GET /api/audit-logs?page=1&pageSize=1': jsonResponse({
+        ok: true,
+        data: { items: [], page: 1, pageSize: 1, total: 0 },
+      }),
+    }
+    const response = responses[key]
+    if (!response) throw new Error(`unexpected request: ${key}`)
+    return response
+  }
+}
+
+test('runContractSmoke validates the current read-only API contract', async () => {
+  const requests = []
+  const report = await runContractSmoke({
+    baseUrl: 'http://127.0.0.1:8900/',
+    token,
+    fetchImpl: passingFetch(requests),
+  })
+
+  assert.equal(report.ok, true)
+  assert.equal(report.baseUrl, 'http://127.0.0.1:8900')
+  assert.equal(report.checks.length, 8)
+  assert.equal(
+    report.checks.every((check) => check.ok),
+    true,
+  )
+  assert.deepEqual(
+    requests
+      .filter((request) => request.authorization)
+      .map((request) => request.authorization),
+    Array(5).fill(`Bearer ${token}`),
+  )
+  assert.equal(
+    requests.find((request) => request.path === '/health').authorization,
+    undefined,
+  )
+  assert.equal(
+    requests.find((request) => request.path === '/api/permissions/health')
+      .authorization,
+    undefined,
+  )
+  assert.equal(
+    requests.find(
+      (request) =>
+        request.path === '/api/permissions' && !request.authorization,
+    ).authorization,
+    undefined,
+  )
+  assert.equal(
+    requests.find((request) => request.path === '/api/permissions/check').body,
+    '{}',
+  )
+})
+
+test('runContractSmoke records a failed contract and continues the remaining checks', async () => {
+  const fetchImpl = passingFetch()
+  let requestCount = 0
+  const report = await runContractSmoke({
+    baseUrl: 'http://example.test',
+    token,
+    fetchImpl: async (url, options) => {
+      requestCount += 1
+      if (new URL(url).pathname === '/api/permissions/me') {
+        return jsonResponse({ error: 'unexpected failure' }, 500)
+      }
+      return fetchImpl(url, options)
+    },
+  })
+
+  assert.equal(report.ok, false)
+  assert.equal(requestCount, 8)
+  assert.equal(report.checks.length, 8)
+  assert.deepEqual(
+    report.checks.filter((check) => !check.ok).map((check) => check.name),
+    ['permissions:me'],
+  )
+  assert.match(
+    report.checks.find((check) => check.name === 'permissions:me').error,
+    /expected HTTP 200, received 500/,
+  )
+  assert.equal(report.checks.at(-1).name, 'audit-logs:list')
+  assert.equal(report.checks.at(-1).ok, true)
+})
+
+test('runCli writes a deterministic failure artifact and returns a non-zero code', async () => {
+  const outputDir = await mkdtemp(path.join(tmpdir(), 'contract-smoke-'))
+  const outputPath = path.join(outputDir, 'result.json')
+  let stdout = ''
+  let stderr = ''
+
+  try {
+    const exitCode = await runCli({
+      env: {
+        BASE_URL: 'http://127.0.0.1:8900',
+        CONTRACT_SMOKE_OUTPUT: outputPath,
+      },
+      fetchImpl: passingFetch(),
+      stdout: {
+        write: (chunk) => {
+          stdout += chunk
+        },
+      },
+      stderr: {
+        write: (chunk) => {
+          stderr += chunk
+        },
+      },
+    })
+
+    assert.equal(exitCode, 1)
+    assert.equal(stdout, '')
+    assert.match(stderr, /TOKEN is required/)
+    const report = JSON.parse(await readFile(outputPath, 'utf8'))
+    assert.equal(report.ok, false)
+    assert.equal(report.error, 'TOKEN is required')
+    assert.deepEqual(report.checks, [])
+  } finally {
+    await rm(outputDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

Restore the executable contract gate referenced by Observability Strict since the repository import.

- add `scripts/contract-smoke.js` with eight current, non-mutating HTTP contracts covering health, auth rejection, permission health/list/current-user/validation, approval not-found shape, and audit-log pagination;
- always write the machine-readable `contract-smoke.json` artifact, collect all check results, enforce per-request timeouts, and exit non-zero on any failed contract;
- add focused Node tests for the passing surface, failure collection, and deterministic CLI failure artifact;
- make script/test changes trigger the Strict workflow and run the harness tests before the live E2E;
- move the non-secret CI-only JWT signing key to job scope so the backend and token generator cannot silently use different defaults.

The repository's missing `v2-strict` label has also been restored in GitHub with the existing documented trigger name.

## Why

The workflow invoked `node scripts/contract-smoke.js`, parsed `contract-smoke.json`, and uploaded that artifact, but the executable never existed in this repository's reachable history. Manual run 29297815998 therefore failed with `MODULE_NOT_FOUND` immediately after a successful migration.

Recovering the old documented mock-server script would have been incorrect: the current Strict job starts the real Express assembly, whose approval and permission contracts have changed. The restored gate validates the current runtime without seeding or mutating business data.

The missing executable also masked a second workflow defect: the server used `JWT_SECRET=test-secret-for-ci` while the later token generator fell back to `dev-secret-key`. A single job-level value now feeds both steps.

## Verification

- `node --test scripts/contract-smoke.test.mjs`: 3/3 PASS on Node 24;
- `npx --yes node@20 --test scripts/contract-smoke.test.mjs`: 3/3 PASS on Node 20;
- fresh PostgreSQL database migrated with the exact current Strict exclusion list: PASS;
- real `MetaSheetServer` on that database plus CI-signed token: 8/8 contract checks PASS;
- workflow YAML parse: PASS;
- Prettier with repository JS style flags and `git diff --check`: PASS;
- current-main rebase integrity: `range-diff` is `=` from the previous reviewed patch; post-rebase local harness tests 3/3 PASS;
- exact-head PR CI at `b50ca858799d67be0e5daede11bf061792f28f78`: 12/12 SUCCESS; GitHub reports `MERGEABLE / CLEAN`;
- exact-head Observability Strict run https://github.com/zensgit/metasheet2/actions/runs/29351026343: harness tests PASS, all eight live contract checks PASS, `contract-smoke.json` accepted, and all downstream strict thresholds completed successfully.

Refs #4259
