### PR TITLE
fix(multitable): interim revert-execute default-off master gate (current-risk mitigation)

### DIFF
--- a/apps/web/src/multitable/composables/useMultitableWorkbench.ts
+++ b/apps/web/src/multitable/composables/useMultitableWorkbench.ts
@@ -21,6 +21,7 @@ const EMPTY_CAPABILITIES: MetaCapabilities = {
   canManageFields: false,
   canManageSheetAccess: false,
   pitResetEnabled: false,
+  sheetRevertEnabled: false,
   personalViewsEnabled: false,
   canManageViews: false,
   canComment: false,

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -490,6 +490,11 @@ export interface MetaCapabilities {
   /** T8-2 Reset flag-visibility signal (#3239): flag-derived (MULTITABLE_ENABLE_PIT_RESET ∧ sheet-admin), set by
    *  /context. Optional — absent/false ⇒ the Reset entry is HIDDEN (the FE half of "inert until enabled"). */
   pitResetEnabled?: boolean
+  /** Interim revert-execute master-gate flag-visibility signal (current-risk mitigation): flag-derived
+   *  (MULTITABLE_ENABLE_SHEET_REVERT ∧ sheet-admin), set by /context — SAME pattern as pitResetEnabled. Optional —
+   *  absent/false ⇒ any Revert entry the FE builds MUST be HIDDEN (fail-closed, same discipline as Reset). No
+   *  consuming component exists yet in this PR; this is the type-contract half only. */
+  sheetRevertEnabled?: boolean
   /** Slice 3 personal-views "My view" toggle flag-visibility signal (design-lock
    *  multitable-personal-views-slice3-fe-toggle-design-lock-20260706.md §7 Q1): flag-derived
    *  (MULTITABLE_ENABLE_PERSONAL_VIEWS), set by /context. Optional — absent/false ⇒ the toggle + reset-to-shared

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7147,6 +7147,10 @@ export function univerMetaRouter(): Router {
           capabilities: {
             ...capabilities,
             pitResetEnabled: (String(process.env.MULTITABLE_ENABLE_PIT_RESET ?? '').trim().toLowerCase() === 'true') && capabilities.canManageSheetAccess === true,
+            // Interim revert-execute master-gate visibility (current-risk mitigation): SAME flag-derived-capability
+            // pattern as pitResetEnabled — true iff MULTITABLE_ENABLE_SHEET_REVERT is on AND the actor is a
+            // sheet-admin, mirroring revert-preview/-execute's own canManageSheetAccess (D2) floor exactly.
+            sheetRevertEnabled: (String(process.env.MULTITABLE_ENABLE_SHEET_REVERT ?? '').trim().toLowerCase() === 'true') && capabilities.canManageSheetAccess === true,
             personalViewsEnabled: isPersonalViewsEnabled(),
           },
           capabilityOrigin,
@@ -10109,6 +10113,12 @@ export function univerMetaRouter(): Router {
   // resurrects run in ONE transaction (all-or-nothing) while field-reverts stay best-effort per-record. Inbound links
   // are NOT rebuilt (design-lock L4 A) — they re-appear when the linking record is next saved.
   const PIT_UNDELETE_ENABLED = () => String(process.env.MULTITABLE_ENABLE_PIT_UNDELETE ?? '').trim().toLowerCase() === 'true'
+  // Interim revert-execute master gate (current-risk mitigation, owner-directed): the merged §0.6 precheck (#4234)
+  // is live-vs-latest and still blind to the healed-gap + check→write race; until the full W0-1 correctness fix
+  // lands, revert-execute is closed by DEFAULT — mirrors reset-execute's PIT_RESET_ENABLED() gate exactly (same
+  // String(env).trim().toLowerCase()==='true' resolution). revert-preview stays UNGATED (read-only, no writes to
+  // protect, and the FE preview UI still needs to render even while the button that would call execute is hidden).
+  const SHEET_REVERT_ENABLED = () => String(process.env.MULTITABLE_ENABLE_SHEET_REVERT ?? '').trim().toLowerCase() === 'true'
 
   router.post('/sheets/:sheetId/revert-preview', async (req: Request, res: Response) => {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
@@ -10151,6 +10161,7 @@ export function univerMetaRouter(): Router {
   })
 
   router.post('/sheets/:sheetId/revert-execute', async (req: Request, res: Response) => {
+    if (!SHEET_REVERT_ENABLED()) return res.status(403).json({ ok: false, error: { code: 'REVERT_DISABLED', message: 'Sheet revert is disabled (MULTITABLE_ENABLE_SHEET_REVERT is off).' } })
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
     const parsed = z.object({ asOf: z.string().min(1), previewIdentity: z.string().min(1), confirm: z.string().optional() }).safeParse(req.body)
     if (!sheetId || !parsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId, asOf, previewIdentity required' } })

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -181,6 +181,7 @@ describe('Multitable context API', () => {
       canExport: true,
       canSendNotification: false,
       pitResetEnabled: false,
+      sheetRevertEnabled: false,
       personalViewsEnabled: false,
     })
     expect(response.body.data.capabilityOrigin).toEqual({
@@ -378,6 +379,7 @@ describe('Multitable context API', () => {
       canExport: true,
       canSendNotification: true,
       pitResetEnabled: false,
+      sheetRevertEnabled: false,
       personalViewsEnabled: false,
     })
     // Route-level contract lock for the new FE signal: flag ON + sheet-admin → pitResetEnabled true (its only true source).
@@ -387,6 +389,13 @@ describe('Multitable context API', () => {
       const onResp = await request(app).get('/api/multitable/context').query({ sheetId: 'sheet_ops' }).expect(200)
       expect(onResp.body.data.capabilities.pitResetEnabled).toBe(true)
     } finally { delete process.env.MULTITABLE_ENABLE_PIT_RESET }
+    // Interim revert-execute master-gate contract lock (current-risk mitigation): SAME pattern as pitResetEnabled —
+    // flag ON + sheet-admin → sheetRevertEnabled true (its only true source). Flag-off (false) locked above.
+    process.env.MULTITABLE_ENABLE_SHEET_REVERT = 'true'
+    try {
+      const onResp = await request(app).get('/api/multitable/context').query({ sheetId: 'sheet_ops' }).expect(200)
+      expect(onResp.body.data.capabilities.sheetRevertEnabled).toBe(true)
+    } finally { delete process.env.MULTITABLE_ENABLE_SHEET_REVERT }
     // Slice 3 contract lock: flag ON → personalViewsEnabled true (available to every reader, presentation-only —
     // NOT ANDed with a management capability, unlike pitResetEnabled). Flag-off (false) locked by the exact-matches above.
     process.env.MULTITABLE_ENABLE_PERSONAL_VIEWS = 'true'

--- a/packages/core-backend/tests/integration/multitable-d2-sidedoor-delete-recoverability-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-d2-sidedoor-delete-recoverability-realdb.test.ts
@@ -263,6 +263,9 @@ describeIfDatabase('D-2 — side-door delete recoverability (plugin + automation
       next()
     })
     process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS = '50' // G5 drives the PIT revert route
+    // Interim revert-execute master gate (current-risk mitigation): default-OFF now — keep it on for this
+    // suite's G5 golden (which drives revert-execute), unchanged behavior.
+    process.env.MULTITABLE_ENABLE_SHEET_REVERT = 'true'
     app.use('/api/multitable', univerMetaRouter())
 
     await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [OWNER])
@@ -298,6 +301,7 @@ describeIfDatabase('D-2 — side-door delete recoverability (plugin + automation
   afterAll(async () => {
     for (const flag of [SIDE_DOOR_FLAG, CAPTURE_FLAG, CAP_ROWS, INBOUND_FLAG, PIT_UNDELETE_FLAG]) delete process.env[flag]
     delete process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS
+    delete process.env.MULTITABLE_ENABLE_SHEET_REVERT
     await q('DELETE FROM users WHERE id = $1', [OWNER]).catch(() => {})
     for (const sheet of [SHEET_A, SHEET_B, SHEET_X, SHEET_G5]) {
       await q('DELETE FROM meta_link_tombstones WHERE sheet_id = $1', [sheet]).catch(() => {})

--- a/packages/core-backend/tests/integration/multitable-history-incomplete-precheck-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-incomplete-precheck-realdb.test.ts
@@ -137,6 +137,7 @@ describeIfDatabase('multitable D-1c §0.6 HISTORY_INCOMPLETE precheck (real DB)'
   })
   afterAll(async () => {
     delete process.env.MULTITABLE_ENABLE_PIT_RESET
+    delete process.env.MULTITABLE_ENABLE_SHEET_REVERT
     for (const sheet of [SHEET, SHEET_F, SHEET_S]) {
       for (const t of ['meta_records_trash', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [sheet]).catch(() => {})
       await q('DELETE FROM meta_sheets WHERE id = $1', [sheet]).catch(() => {})
@@ -146,6 +147,10 @@ describeIfDatabase('multitable D-1c §0.6 HISTORY_INCOMPLETE precheck (real DB)'
   })
   beforeEach(async () => {
     process.env.MULTITABLE_ENABLE_PIT_RESET = 'true'
+    // Interim revert-execute master gate (current-risk mitigation): the route is default-OFF now, so keep it
+    // on for this suite's pre-existing goldens — unchanged behavior. See multitable-revert-pit-realdb.test.ts for
+    // the dedicated flag-off/on gate goldens.
+    process.env.MULTITABLE_ENABLE_SHEET_REVERT = 'true'
     for (const sheet of [SHEET, SHEET_F, SHEET_S]) {
       await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [sheet]).catch(() => {})
       await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [sheet])

--- a/packages/core-backend/tests/integration/multitable-mirror-readonly-enumeration-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-mirror-readonly-enumeration-realdb.test.ts
@@ -52,9 +52,12 @@ describeIfDatabase('multitable mirror-read-only hardening — C2/I-1 enumeration
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as express.Request & { user?: unknown }).user = currentUser; next() })
-    // PIT flags read per-request; SHEET_REVERT_MAX_RECORDS captured at ROUTER CREATION → set all three BEFORE univerMetaRouter().
+    // PIT flags read per-request; SHEET_REVERT_MAX_RECORDS captured at ROUTER CREATION → set all four BEFORE univerMetaRouter().
     process.env.MULTITABLE_ENABLE_PIT_UNDELETE = 'true'
     process.env.MULTITABLE_ENABLE_PIT_RESET = 'true'
+    // Interim revert-execute master gate (current-risk mitigation): default-OFF now — keep it on for this
+    // suite's SD-2/G5-style revert-route enumeration goldens, unchanged behavior.
+    process.env.MULTITABLE_ENABLE_SHEET_REVERT = 'true'
     process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS = '50'
     app.use('/api/multitable', univerMetaRouter())
 
@@ -81,7 +84,7 @@ describeIfDatabase('multitable mirror-read-only hardening — C2/I-1 enumeration
     await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SA, SB]]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
     await q('DELETE FROM users WHERE id = $1', [USER]).catch(() => {})
-    delete process.env.MULTITABLE_ENABLE_PIT_UNDELETE; delete process.env.MULTITABLE_ENABLE_PIT_RESET; delete process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS
+    delete process.env.MULTITABLE_ENABLE_PIT_UNDELETE; delete process.env.MULTITABLE_ENABLE_PIT_RESET; delete process.env.MULTITABLE_ENABLE_SHEET_REVERT; delete process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS
   })
 
   test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })

--- a/packages/core-backend/tests/integration/multitable-revert-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-revert-pit-realdb.test.ts
@@ -29,6 +29,12 @@ let curPerms = ['multitable:read', 'multitable:write', 'multitable:share'] // sh
 const revertPreview = (asOf: string) => request(app).post(`/api/multitable/sheets/${SHEET}/revert-preview`).send({ asOf })
 const revertExecute = (asOf: string, previewIdentity: string) => request(app).post(`/api/multitable/sheets/${SHEET}/revert-execute`).send({ asOf, previewIdentity })
 const recordRow = async (id: string) => (await q('SELECT data, version FROM meta_records WHERE id = $1', [id])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+// GATE golden helper: sheet-scoped row counts, to prove the flag-off 403 performs literally ZERO writes (no new
+// record row, no new revision row) — not just "the response the client sees looks unwritten".
+const sheetRowCounts = async (): Promise<{ records: number; revisions: number }> => ({
+  records: Number(((await q('SELECT count(*)::int AS n FROM meta_records WHERE sheet_id = $1', [SHEET])).rows[0] as { n: number }).n),
+  revisions: Number(((await q('SELECT count(*)::int AS n FROM meta_record_revisions WHERE sheet_id = $1', [SHEET])).rows[0] as { n: number }).n),
+})
 const rev = (id: string, version: number, action: string, snap: Record<string, unknown>, at: string) =>
   q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
      VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[$5,$6]::text[],'{}'::jsonb,$7::jsonb,$8)`, [SHEET, id, version, action, NAME, SALARY, JSON.stringify(snap), at])
@@ -50,6 +56,10 @@ describeIfDatabase('multitable T8-1 Revert-to-T (real DB)', () => {
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: curRoles, perms: curPerms }; next() })
     process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS = '10' // test ceiling: seed = 3 records; the ceiling golden adds 8 → 11 > 10
+    // Interim revert-execute master gate (current-risk mitigation, owner-directed): default-OFF now — ON for
+    // every pre-existing golden in this suite (unchanged behavior); the dedicated flag-off/on gate golden below
+    // toggles it locally and restores this value in a finally block.
+    process.env.MULTITABLE_ENABLE_SHEET_REVERT = 'true'
     app.use('/api/multitable', univerMetaRouter())
     await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'RV Base'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'RV Sheet'])
@@ -58,6 +68,7 @@ describeIfDatabase('multitable T8-1 Revert-to-T (real DB)', () => {
     await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
   })
   afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_SHEET_REVERT
     for (const t of ['meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
@@ -142,5 +153,44 @@ describeIfDatabase('multitable T8-1 Revert-to-T (real DB)', () => {
     const res = await revertPreview(T1)
     expect(res.status).toBe(413)
     expect(res.body?.error?.code).toBe('SHEET_TOO_LARGE')
+  })
+
+  // ── Interim revert-execute master gate (current-risk mitigation, owner-directed) ──────────────────────────────
+  // The merged §0.6 precheck (#4234) is live-vs-latest and still blind to the healed-gap + check→write race; until
+  // the full W0-1 correctness fix lands, revert-execute is closed by DEFAULT via MULTITABLE_ENABLE_SHEET_REVERT
+  // (mirrors reset-execute's PIT_RESET_ENABLED gate exactly). This suite runs with the flag ON throughout (set in
+  // beforeAll) so every OTHER golden above is unaffected; this golden toggles the flag OFF locally and restores
+  // it in a finally block so it never leaks into a later test in this file.
+  test('[GATE] flag UNSET → revert-execute is 403 REVERT_DISABLED with ZERO writes; revert-preview stays ungated', async () => {
+    const savedFlag = process.env.MULTITABLE_ENABLE_SHEET_REVERT
+    try {
+      delete process.env.MULTITABLE_ENABLE_SHEET_REVERT
+      // revert-preview is read-only and MUST remain reachable while execute is gated off — the FE preview
+      // screen still needs to render even when the Revert button itself is hidden.
+      const pv = await revertPreview(T1)
+      expect(pv.status).toBe(200)
+      expect(pv.body?.data?.previewIdentity).toBeTruthy()
+
+      const beforeA = await recordRow(A)
+      const beforeCounts = await sheetRowCounts()
+      const res = await revertExecute(T1, pv.body.data.previewIdentity)
+      expect(res.status).toBe(403)
+      expect(res.body).toEqual({ ok: false, error: { code: 'REVERT_DISABLED', message: 'Sheet revert is disabled (MULTITABLE_ENABLE_SHEET_REVERT is off).' } })
+      // ZERO WRITES — assert the DB, not just the response shape: identical record row, identical
+      // sheet-scoped record/revision counts (no new revision of any source, no partial per-record apply).
+      expect(await recordRow(A)).toEqual(beforeA)
+      expect(await sheetRowCounts()).toEqual(beforeCounts)
+    } finally {
+      if (savedFlag === undefined) delete process.env.MULTITABLE_ENABLE_SHEET_REVERT
+      else process.env.MULTITABLE_ENABLE_SHEET_REVERT = savedFlag
+    }
+  })
+
+  test('[GATE] flag SET → revert-execute runs the normal path (unchanged from the pre-existing goldens above)', async () => {
+    expect(process.env.MULTITABLE_ENABLE_SHEET_REVERT).toBe('true') // suite default, set in beforeAll
+    const pv = await revertPreview(T1)
+    const res = await revertExecute(T1, pv.body?.data?.previewIdentity)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.revertedCount).toBe(2)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -217,6 +217,7 @@ describe('Multitable sheet-scoped permissions API', () => {
       canExport: true,
       canSendNotification: false,
       pitResetEnabled: false, // T8-2: flag-off default ⇒ false (this actor is also not a sheet-admin, so false regardless)
+      sheetRevertEnabled: false, // interim revert-execute master gate: flag-off default ⇒ false (also not a sheet-admin, so false regardless)
       personalViewsEnabled: false, // Slice 3: flag-off default ⇒ false (available to all readers when the flag is on)
     })
     expect(contextResponse.body.data.viewPermissions).toEqual({

--- a/packages/core-backend/tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts
@@ -50,6 +50,7 @@ const NAME = `fld_rvi_name_${TS}`
 const ACTOR = `user_rvi_${TS}`
 const UNDELETE_FLAG = 'MULTITABLE_ENABLE_PIT_UNDELETE'
 const INBOUND_FLAG = 'MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND'
+const SHEET_REVERT_FLAG = 'MULTITABLE_ENABLE_SHEET_REVERT'
 const T0 = '2026-01-01T00:00:00.000Z'
 const T0_5 = '2026-01-01T12:00:00.000Z'
 const T1 = '2026-01-02T00:00:00.000Z'
@@ -105,11 +106,15 @@ describeIfDatabase('4c-3 §7 — PIT-resurrect inbound-edge replay heuristic anc
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [NAME, SHEET_A, 'Name', 'string', '{}', 0])
     await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
     process.env[UNDELETE_FLAG] = 'true'
+    // Interim revert-execute master gate (current-risk mitigation): default-OFF now — keep it on for this
+    // suite's resurrect-via-revert-execute goldens, unchanged behavior.
+    process.env[SHEET_REVERT_FLAG] = 'true'
   })
 
   afterAll(async () => {
     delete process.env[UNDELETE_FLAG]
     delete process.env[INBOUND_FLAG]
+    delete process.env[SHEET_REVERT_FLAG]
     delete process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS
     for (const sheet of [SHEET_A, SHEET_B]) {
       await q('DELETE FROM meta_link_tombstones WHERE sheet_id = $1', [sheet]).catch(() => {})

--- a/packages/core-backend/tests/integration/multitable-undelete-pit-inbound-replay-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-pit-inbound-replay-realdb.test.ts
@@ -31,6 +31,7 @@ const L = `rec_uir_l_${TS}` // LIVE neighbour whose data still declares U (inbou
 const ACTOR = `user_uir_${TS}`
 const UNDELETE_FLAG = 'MULTITABLE_ENABLE_PIT_UNDELETE'
 const INBOUND_FLAG = 'MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND'
+const SHEET_REVERT_FLAG = 'MULTITABLE_ENABLE_SHEET_REVERT'
 const T0 = '2026-01-01T00:00:00.000Z', T1 = '2026-01-02T00:00:00.000Z', T2 = '2026-01-03T00:00:00.000Z'
 const SNAP = { [NAME]: 'u-at-T1' } // no outbound links — this suite is about INBOUND only
 
@@ -107,6 +108,9 @@ describeIfDatabase('4c-3 §7 — PIT-resurrect inbound replay (real DB, P3-2 gol
   })
   beforeEach(async () => {
     process.env[UNDELETE_FLAG] = 'true'
+    // Interim revert-execute master gate (current-risk mitigation): default-OFF now — keep it on for this
+    // suite's revert-execute-driven inbound-replay goldens, unchanged behavior.
+    process.env[SHEET_REVERT_FLAG] = 'true'
     await q('DELETE FROM meta_link_tombstones WHERE sheet_id = $1', [SHEET])
     await q('DELETE FROM meta_links WHERE field_id IN (SELECT id FROM meta_fields WHERE sheet_id = $1)', [SHEET])
     for (const t of ['meta_record_revisions', 'meta_records']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET])
@@ -115,6 +119,7 @@ describeIfDatabase('4c-3 §7 — PIT-resurrect inbound replay (real DB, P3-2 gol
   afterEach(() => {
     delete process.env[UNDELETE_FLAG]
     delete process.env[INBOUND_FLAG]
+    delete process.env[SHEET_REVERT_FLAG]
   })
 
   test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })

--- a/packages/core-backend/tests/integration/multitable-undelete-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-undelete-pit-realdb.test.ts
@@ -59,6 +59,10 @@ describeIfDatabase('multitable T8-1 PIT undelete-execute (real DB)', () => {
     app.use(express.json())
     app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: curPerms }; next() })
     process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS = '2' // captured at router creation; (k) exceeds it via the resurrect set
+    // Interim revert-execute master gate (current-risk mitigation): default-OFF now — keep it on for the WHOLE
+    // suite (independent of this file's own FLAG=PIT_UNDELETE on/off toggling, which this suite tests directly),
+    // so every existing revert-execute call here is unchanged.
+    process.env.MULTITABLE_ENABLE_SHEET_REVERT = 'true'
     app.use('/api/multitable', univerMetaRouter())
     await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'UN Base'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'UN Sheet'])
@@ -67,6 +71,7 @@ describeIfDatabase('multitable T8-1 PIT undelete-execute (real DB)', () => {
     await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
   })
   afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_SHEET_REVERT
     await q('DELETE FROM meta_links WHERE field_id IN (SELECT id FROM meta_fields WHERE sheet_id = $1)', [SHEET]).catch(() => {}) // meta_links has no sheet_id col
     for (const t of ['meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})

--- a/packages/openapi/dist-sdk/index.d.ts
+++ b/packages/openapi/dist-sdk/index.d.ts
@@ -15555,6 +15555,8 @@ export interface components {
             canExport: boolean;
             /** @description True only when MULTITABLE_ENABLE_PIT_RESET is on AND the actor has canManageSheetAccess; populated by GET /context (absent on other capability responses). Drives the FE Reset entry visibility. */
             pitResetEnabled?: boolean;
+            /** @description True only when MULTITABLE_ENABLE_SHEET_REVERT is on AND the actor has canManageSheetAccess; populated by GET /context (absent on other capability responses). Drives the FE Revert entry visibility (interim revert-execute master gate, current-risk mitigation). */
+            sheetRevertEnabled?: boolean;
         };
         /** @enum {string} */
         MultitableSheetPermissionAccessLevel: "read" | "write" | "write-own" | "admin";

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -2792,6 +2792,13 @@ components:
             True only when MULTITABLE_ENABLE_PIT_RESET is on AND the actor has
             canManageSheetAccess; populated by GET /context (absent on other
             capability responses). Drives the FE Reset entry visibility.
+        sheetRevertEnabled:
+          type: boolean
+          description: >-
+            True only when MULTITABLE_ENABLE_SHEET_REVERT is on AND the actor
+            has canManageSheetAccess; populated by GET /context (absent on other
+            capability responses). Drives the FE Revert entry visibility
+            (interim revert-execute master gate, current-risk mitigation).
       required:
         - canRead
         - canCreateRecord

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -3821,6 +3821,10 @@
           "pitResetEnabled": {
             "type": "boolean",
             "description": "True only when MULTITABLE_ENABLE_PIT_RESET is on AND the actor has canManageSheetAccess; populated by GET /context (absent on other capability responses). Drives the FE Reset entry visibility."
+          },
+          "sheetRevertEnabled": {
+            "type": "boolean",
+            "description": "True only when MULTITABLE_ENABLE_SHEET_REVERT is on AND the actor has canManageSheetAccess; populated by GET /context (absent on other capability responses). Drives the FE Revert entry visibility (interim revert-execute master gate, current-risk mitigation)."
           }
         },
         "required": [

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -2792,6 +2792,13 @@ components:
             True only when MULTITABLE_ENABLE_PIT_RESET is on AND the actor has
             canManageSheetAccess; populated by GET /context (absent on other
             capability responses). Drives the FE Reset entry visibility.
+        sheetRevertEnabled:
+          type: boolean
+          description: >-
+            True only when MULTITABLE_ENABLE_SHEET_REVERT is on AND the actor
+            has canManageSheetAccess; populated by GET /context (absent on other
+            capability responses). Drives the FE Revert entry visibility
+            (interim revert-execute master gate, current-risk mitigation).
       required:
         - canRead
         - canCreateRecord

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -2574,6 +2574,9 @@ components:
         pitResetEnabled:
           type: boolean
           description: True only when MULTITABLE_ENABLE_PIT_RESET is on AND the actor has canManageSheetAccess; populated by GET /context (absent on other capability responses). Drives the FE Reset entry visibility.
+        sheetRevertEnabled:
+          type: boolean
+          description: True only when MULTITABLE_ENABLE_SHEET_REVERT is on AND the actor has canManageSheetAccess; populated by GET /context (absent on other capability responses). Drives the FE Revert entry visibility (interim revert-execute master gate, current-risk mitigation).
       required:
         - canRead
         - canCreateRecord

--- a/scripts/ops/global-history-flag-manifest.mjs
+++ b/scripts/ops/global-history-flag-manifest.mjs
@@ -17,7 +17,7 @@
  * `activationValue` is the EXACT string the flag must equal (after `.trim()`, and after `.toLowerCase()`
  * only when `caseInsensitive: true`) for the gated code path to treat it as ON. Two families exist:
  *   - capture/replay/revert flags compare with `=== 'true'` (case-SENSITIVE, no trim in most call sites,
- *     except PIT_RESET/PIT_UNDELETE which use `.trim().toLowerCase() === 'true'`)
+ *     except PIT_RESET/PIT_UNDELETE/SHEET_REVERT which use `.trim().toLowerCase() === 'true'`)
  *   - the retention flag compares with `=== '1'` (NOT `'true'`) — `meta-revision-retention.ts:60`
  * Setting the wrong string for a given flag is silent: the gated code path stays OFF and nothing errors.
  */
@@ -129,6 +129,21 @@ export const GLOBAL_HISTORY_FLAG_MANIFEST = Object.freeze([
           "MULTITABLE_ENABLE_FIELD_RETYPE_REVERT_LOSSY is active ('true') but MULTITABLE_ENABLE_FIELD_RETYPE_REVERT is not active — the lossy gate has no effect (isLossyRetypeRevertEnabled requires both), so this flag combination is dead configuration, not a working feature.",
       },
     ],
+  },
+  {
+    key: 'MULTITABLE_ENABLE_SHEET_REVERT',
+    type: 'boolean',
+    activationValue: 'true',
+    caseInsensitive: true,
+    dependsOn: [],
+    conflictsWith: [],
+    danger: 'high',
+    purpose:
+      'Interim revert-execute master gate (current-risk mitigation, owner-directed): the merged §0.6 history-integrity precheck (#4234) is live-vs-latest and still blind to the healed-gap + check→write race, so revert-execute (bulk-overwrites live record field values back to T across up to MULTITABLE_SHEET_REVERT_MAX_RECORDS records, and resurrects records deleted after T — that resurrect sub-path additionally requires MULTITABLE_ENABLE_PIT_UNDELETE) is closed by DEFAULT until the full W0-1 correctness fix lands. Mirrors MULTITABLE_ENABLE_PIT_RESET\'s gate exactly: SAME `String(env).trim().toLowerCase() === \'true\'` resolution (hence caseInsensitive here too, unlike the config-revert family above which compares case-sensitively), same canManageSheetAccess (D2) floor. danger=high for the same reason as PIT_RESET, not the medium config-revert flags above: a whole-sheet-scale destructive bulk write over live record data with no undo, gated off specifically because a known correctness gap (TOCTOU-shaped) is unmitigated. revert-preview stays UNGATED (read-only; the FE preview UI still needs to render even while the button that would call execute is hidden — capabilities.sheetRevertEnabled controls that visibility, same flag-derived-capability pattern as pitResetEnabled).',
+    // source: packages/core-backend/src/routes/univer-meta.ts:10121 (SHEET_REVERT_ENABLED, `.trim().toLowerCase() === 'true'` guard),
+    //         :10164 (revert-execute gate call site — 403 REVERT_DISABLED when off),
+    //         :7153 (capabilities.sheetRevertEnabled — SAME flag-derived-capability pattern as pitResetEnabled, ANDed with canManageSheetAccess)
+    source: 'packages/core-backend/src/routes/univer-meta.ts:10121,10164,7153',
   },
   {
     key: 'MULTITABLE_ENABLE_PIT_RESET',


### PR DESCRIPTION
## Summary

Interim, owner-directed current-risk mitigation — done FIRST, independent of the broader W0-1 correctness-fix line.

The merged §0.6 precheck (#4234) is live-vs-latest and blind to the healed-gap + check→write race. Base record-data `revert-execute` currently has **no master enable-flag** (unlike `reset-execute`, gated by `PIT_RESET_ENABLED()` / `MULTITABLE_ENABLE_PIT_RESET`). Until the full W0-1 correctness fix lands, this closes the risky path by default.

## Changes

- **New default-off flag** `MULTITABLE_ENABLE_SHEET_REVERT`, resolved exactly like `PIT_RESET_ENABLED()` (`String(env).trim().toLowerCase()==='true'`). Gates the very top of `POST /sheets/:sheetId/revert-execute` in `packages/core-backend/src/routes/univer-meta.ts` — off ⇒ `403 { code: 'REVERT_DISABLED' }`, mirroring the existing `RESET_DISABLED` shape exactly. `revert-preview` is intentionally left **ungated** (read-only, no writes to protect).
- **FE capability hint** `sheetRevertEnabled` added to the `GET /context` `capabilities` blob (same flag ∧ `canManageSheetAccess` pattern as `pitResetEnabled`), plus matching OpenAPI schema (`packages/openapi/src/base.yml` + regenerated `dist/*` + hand-synced `dist-sdk/index.d.ts`, since `openapi-typescript` couldn't be fetched in this sandbox) and FE `MetaCapabilities` type (`apps/web/src/multitable/types.ts`, `useMultitableWorkbench.ts`). No consuming FE component is added in this PR — type-contract only.
- **Every pre-existing real-DB suite that exercises `revert-execute`** now sets the new flag in its own setup, matching that file's existing env-setup convention, so behavior is unchanged:
  - `multitable-revert-pit-realdb.test.ts`
  - `multitable-history-incomplete-precheck-realdb.test.ts`
  - `multitable-d2-sidedoor-delete-recoverability-realdb.test.ts`
  - `multitable-mirror-readonly-enumeration-realdb.test.ts`
  - `multitable-undelete-inbound-resurrect-realdb.test.ts`
  - `multitable-undelete-pit-inbound-replay-realdb.test.ts`
  - `multitable-undelete-pit-realdb.test.ts`
  - `multitable-context.api.test.ts` / `multitable-sheet-permissions.api.test.ts` — capability-shape exact-matches updated for the new `sheetRevertEnabled: false` field (ripple from the FE hint, not from the gate itself)
  - `multitable-w13-fieldperm-writegate-singlerecord-realdb.test.ts` and the unit guard `multitable-w13-write-path-layer3-gate.guard.test.ts` were checked and need **no change** — the former only mentions `revert-execute` in a comment (calls `/patch` only), and the gate adds no `.patchRecords(`/`.patchRecord(` call site so the guard's frozen count is untouched.
- **New gate golden** in `multitable-revert-pit-realdb.test.ts`: flag UNSET → `revert-execute` returns 403 `REVERT_DISABLED` with **zero writes** (record row + sheet-scoped record/revision counts asserted unchanged), `revert-preview` still reachable; flag SET → normal path runs unchanged. Added to an already plugin-tests.yml-wired file, so no new two-point CI wiring was needed.

## Why draft

This flips a currently-default-on route to default-off — intentional (fail-closed), but a behavior change, so it stays a **DRAFT** for owner review. Not marked ready, not armed, not merged.

## Test plan

- [x] `multitable-revert-pit-realdb.test.ts` — 10/10 green (incl. the 2 new gate goldens)
- [x] The other 6 real-DB suites that call `revert-execute` — 88/88 green, run together in one process (no cross-file env leakage)
- [x] `multitable-context.api.test.ts` — 22/22 green (incl. new `sheetRevertEnabled` flag-ON contract lock)
- [x] `multitable-sheet-permissions.api.test.ts` — capability-shape assertion for the touched test passes; file has 17 pre-existing unrelated 500-error failures, confirmed identical on `origin/main` baseline (stash-compared) before ever reaching the `sheetRevertEnabled` assertion — not caused by this change
- [x] `multitable-w13-fieldperm-writegate-singlerecord-realdb.test.ts` + the unit guard — green, confirmed no code change needed
- [x] Mutation: commented out the gate line → the flag-off golden reds (`200` instead of `403`); restored → green again
- [x] `tsc --noEmit` (core-backend) and `vue-tsc -b` (web) both clean
- [x] `scripts/ops/multitable-openapi-parity.test.mjs` — pre-existing unrelated failure (missing `duration` field type in the test's own expected list), confirmed identical on `origin/main` baseline

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>