### PR TITLE
fix(multitable): B5 — route rich-text editor aria labels through typed label module (i18n strict-zero)

### DIFF
--- a/apps/web/src/multitable/components/cells/MetaRichLongTextEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaRichLongTextEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="meta-rich-editor">
-    <div class="meta-rich-editor__toolbar" role="toolbar" :aria-label="ariaToolbar">
+    <div class="meta-rich-editor__toolbar" role="toolbar" :aria-label="l('richText.toolbarAria')">
       <button
         v-for="cmd in inlineCommands"
         :key="cmd.command"
@@ -64,7 +64,7 @@
         contenteditable="true"
         role="textbox"
         aria-multiline="true"
-        :aria-label="ariaContent"
+        :aria-label="l('richText.contentAria')"
         data-test="rich-longtext-editor"
         @focus="onFocus"
         @input="onInput"
@@ -154,12 +154,10 @@ const editableRef = ref<HTMLDivElement | null>(null)
 const focused = ref(false)
 
 const zh = () => props.isZh !== false
-// Reuse the cell-editor family's typed label module (B5 mention.* keys). The
-// existing toolbar ternaries stay as-is (out of B5 scope, per the map).
+// Reuse the cell-editor family's typed label module (B5 mention.* keys +
+// richText.* toolbar/content aria — previously unconditional Chinese consts).
+// The existing toolbar ternaries stay as-is (out of B5 scope, per the map).
 const l = (key: MetaCoreLabelKey) => metaCoreLabel(key, zh())
-
-const ariaToolbar = '富文本格式工具栏'
-const ariaContent = '富文本内容编辑区'
 
 // --- B5 people-mention popover state ---
 // True only when a host actually fed candidates → the popover is structurally

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -92,6 +92,8 @@ export type MetaCoreLabelKey =
   | 'linkedRecord.empty'
   // --- Rich-longText in-cell @mention (B5) ---
   | 'mention.suggestionsAria'
+  // --- Rich-longText editor chrome aria (B5 i18n fix — was unconditional zh) ---
+  | 'richText.toolbarAria' | 'richText.contentAria'
   // --- Auth chrome (file-location closure tightening per #1803) ---
   | 'auth.notAuthenticated'
 
@@ -277,6 +279,11 @@ const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   'linkedRecord.close': { en: 'Close', zh: '关闭' },
   'linkedRecord.empty': { en: 'No fields to show', zh: '没有可显示的字段' },
   'mention.suggestionsAria': { en: 'Mention people', zh: '提及成员' },
+  // MetaRichLongTextEditor toolbar/content-surface aria labels. zh keeps the
+  // exact pre-fix strings; en was previously missing (the consts were
+  // unconditional Chinese — a screen reader in an English UI read Chinese).
+  'richText.toolbarAria': { en: 'Rich text formatting toolbar', zh: '富文本格式工具栏' },
+  'richText.contentAria': { en: 'Rich text content editor', zh: '富文本内容编辑区' },
 }
 
 export function metaCoreLabel(key: MetaCoreLabelKey, isZh: boolean): string {

--- a/apps/web/tests/multitable-core-i18n.spec.ts
+++ b/apps/web/tests/multitable-core-i18n.spec.ts
@@ -59,6 +59,22 @@ describe('meta-core-labels static keys', () => {
     expect(metaCoreLabel('toolbar.checkedTrue', true)).toBe('已勾选 / true')
     expect(metaCoreLabel('toolbar.uncheckedFalse', true)).toBe('未勾选 / false')
   })
+
+  it('B5: rich-text editor chrome aria labels exist and are non-empty in BOTH locales', () => {
+    // zh keeps the exact pre-fix strings (the consts hardcoded in
+    // MetaRichLongTextEditor.vue before B5); en must exist and must not
+    // contain CJK (the original bug: English screen readers read Chinese).
+    expect(metaCoreLabel('richText.toolbarAria', true)).toBe('富文本格式工具栏')
+    expect(metaCoreLabel('richText.contentAria', true)).toBe('富文本内容编辑区')
+    expect(metaCoreLabel('richText.toolbarAria', false)).toBe('Rich text formatting toolbar')
+    expect(metaCoreLabel('richText.contentAria', false)).toBe('Rich text content editor')
+    for (const key of ['richText.toolbarAria', 'richText.contentAria'] as const) {
+      for (const isZh of [true, false]) {
+        expect(metaCoreLabel(key, isZh).trim().length).toBeGreaterThan(0)
+      }
+      expect(metaCoreLabel(key, false)).not.toMatch(/[一-鿿]/)
+    }
+  })
 })
 
 describe('meta-core-labels helpers', () => {

--- a/apps/web/tests/multitable-richtext-editor-mention.spec.ts
+++ b/apps/web/tests/multitable-richtext-editor-mention.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, h, nextTick, ref } from 'vue'
 import MetaRichLongTextEditor from '../src/multitable/components/cells/MetaRichLongTextEditor.vue'
 import type { MetaCommentMentionSuggestion } from '../src/multitable/types'
+import { metaCoreLabel } from '../src/multitable/utils/meta-core-labels'
 
 // B5 — MetaRichLongTextEditor mention behaviour at the COMPONENT level.
 //
@@ -114,4 +115,49 @@ describe('MetaRichLongTextEditor — B5 mention popover + host gate', () => {
     await nextTick()
     expect(container!.querySelector('[data-test="rich-longtext-mention-popover"]')).toBeNull()
   })
+})
+
+describe('MetaRichLongTextEditor — B5 aria labels come from the typed label module (i18n strict-zero)', () => {
+  // Before this fix the toolbar/content aria labels were unconditional Chinese
+  // consts (`const ariaToolbar = '富文本格式工具栏'`) — an English-locale screen
+  // reader read Chinese. They must now come from meta-core-labels (richText.*)
+  // in BOTH locales; equality with the module output per locale pins that (a
+  // hardcoded string in the component would fail one of the two locales).
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    container?.remove()
+    container = null
+  })
+
+  function mount(props: Record<string, unknown>) {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    const app = createApp({ setup: () => () => h(MetaRichLongTextEditor, props) })
+    app.mount(container)
+  }
+
+  for (const isZh of [true, false]) {
+    it(`renders module-sourced, non-empty toolbar + content aria labels (isZh=${isZh})`, async () => {
+      mount({ modelValue: '', isZh })
+      await nextTick()
+
+      const toolbar = container!.querySelector('.meta-rich-editor__toolbar[role="toolbar"]')
+      const editable = container!.querySelector('[data-test="rich-longtext-editor"]')
+      expect(toolbar).not.toBeNull()
+      expect(editable).not.toBeNull()
+
+      const toolbarAria = toolbar!.getAttribute('aria-label')
+      const contentAria = editable!.getAttribute('aria-label')
+      expect(toolbarAria).toBe(metaCoreLabel('richText.toolbarAria', isZh))
+      expect(contentAria).toBe(metaCoreLabel('richText.contentAria', isZh))
+      expect((toolbarAria ?? '').trim().length).toBeGreaterThan(0)
+      expect((contentAria ?? '').trim().length).toBeGreaterThan(0)
+      if (!isZh) {
+        // The original B5 bug: unconditional Chinese in an English locale.
+        expect(toolbarAria).not.toMatch(/[一-鿿]/)
+        expect(contentAria).not.toMatch(/[一-鿿]/)
+      }
+    })
+  }
 })


### PR DESCRIPTION
## Root cause (inventory §5 B5)

`MetaRichLongTextEditor.vue:161-162` hardcoded the toolbar/content aria labels as **unconditional Chinese consts**:

```ts
const ariaToolbar = '富文本格式工具栏'
const ariaContent = '富文本内容编辑区'
```

An English-locale screen reader therefore read Chinese for the rich-text editor chrome — a real i18n bug and a violation of the multitable i18n strict-zero discipline, whose only extension point is the typed label modules.

## Fix — idiom followed (no new pattern)

The component **already consumes `meta-core-labels`** via `const l = (key: MetaCoreLabelKey) => metaCoreLabel(key, zh())` (used for `mention.suggestionsAria` in the same template). This PR:

- adds two keys to `meta-core-labels.ts` following its exact idiom (typed key union + explicit en/zh pairs): `richText.toolbarAria` / `richText.contentAria`. **zh keeps the exact pre-fix strings** (zero behavior change for Chinese users); en is new.
- deletes the two consts and binds `:aria-label="l('richText.toolbarAria')"` / `:aria-label="l('richText.contentAria')"` — byte-for-byte the same template pattern as the existing `l('mention.suggestionsAria')` binding.

The editor's toolbar-button ternaries (`zh() ? '加粗' : 'Bold'` etc.) are bilingual and stay as-is, per the component's own scope note — they are not the B5 bug class (no wrong-locale output).

## Specs (both matched by the existing CI filter)

1. `multitable-core-i18n.spec.ts` — exact en/zh values for both keys, non-empty in both locales, and **no CJK in the en variant** (the exact original failure mode).
2. `multitable-richtext-editor-mention.spec.ts` — mounts the real component with `isZh: true` and `isZh: false` and asserts the rendered `aria-label`s **equal the label-module output for that locale** and are non-empty. Equality per locale means a hardcoded string in the component fails one of the two legs.

### Red-proof (被触发≠被验证)

Temporarily restoring the pre-fix consts makes the `isZh=false` leg fail while `isZh=true` still passes (zh strings identical) — exactly the bug shape:

```
Tests  1 failed | 5 passed (6)   # with `const ariaToolbar = '富文本格式工具栏'` restored
```

### CI wiring proof

apps/web specs do NOT run in the required `test (20.x)` check; they run in the non-required **Multitable Web Guard** (`.github/workflows/multitable-web-guard.yml`) with a hand-kept `vitest run` filter. Both extended spec files are **already** in that filter (line 766 tokens `multitable-core-i18n`, `multitable-richtext-editor-mention`) and are **already path triggers** in both the `pull_request` and `push` blocks — so this PR fires the guard and the new assertions run in CI. No filter extension needed.

### Local output

```
✓ tests/multitable-core-i18n.spec.ts  (25 tests)
✓ tests/multitable-richtext-editor-mention.spec.ts  (6 tests)
  ✓ B5 aria labels come from the typed label module … (isZh=true)
  ✓ B5 aria labels come from the typed label module … (isZh=false)
Test Files  2 passed (2) / Tests  30 passed (30)
```

Full family re-run after the mutation check: `multitable-richtext-{editor-mention,longtext,mention,wiring}` + `multitable-core-i18n` + `meta-cell-editor-i18n` → **6 files / 118 tests passed**. `vue-tsc -b` clean.

## Sibling sweep (same-class hardcoded Chinese aria)

Swept the whole `apps/web/src/multitable` tree for unconditional-Chinese aria strings (attribute literals, bound consts, `ariaLabel:` props, template literals): **the two B5 lines were the only hits**. Not the same class, listed as follow-ups:

- **HistoryCenterModal.vue / TrashModal.vue** use a *local* bilingual `t('中文', 'English')` helper for aria labels — output is locale-correct (not the B5 bug), but the strings live outside the typed label modules. Migrating them is a non-trivial T3-style slice, not done here.
- **B3 (separate inventory item)**: `MetaRichLongTextEditor.vue` and `meta-core-labels.ts` are themselves not path triggers in multitable-web-guard.yml (this PR triggers the guard via the spec files, which are). That path-trigger hole is B3's scope.
- Editor toolbar ternaries + `prompt`/`alert` strings in the same component: bilingual, could fold into `richText.*` keys in a later label-module slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
