### PR TITLE
fix(multitable): W0-1 — generation-aware history contiguity replaces live-vs-latest §0.6 comparator (healed-gap closed; C2/C3/C6 deferred)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -368,6 +368,7 @@ jobs:
             tests/integration/multitable-undelete-pit-realdb.test.ts \
             tests/integration/multitable-reset-pit-realdb.test.ts \
             tests/integration/multitable-history-incomplete-precheck-realdb.test.ts \
+            tests/integration/multitable-history-contiguity-realdb.test.ts \
             tests/integration/multitable-d1c-form-submit-revision-realdb.test.ts \
             tests/integration/multitable-d1c-plugin-revision-realdb.test.ts \
             tests/integration/multitable-d1c-automation-revision-realdb.test.ts \

--- a/docs/development/multitable-global-history-w0-1-history-incomplete-contiguity-trusted-since-design-lock-20260713.md
+++ b/docs/development/multitable-global-history-w0-1-history-incomplete-contiguity-trusted-since-design-lock-20260713.md
@@ -1,0 +1,88 @@
+# W0-1 — `HISTORY_INCOMPLETE` 可信性纠错：连续性 + trusted-since + 同锁事务 — DESIGN LOCK (PROPOSED)
+
+- **Status**: **PROPOSED — 2026-07-13. NOT ratified. Design-first, ZERO 运行时改动。** owner 复审判 §0.6 现草案(#4235)「**不能安全落地**」——本锁把 §0.6 从 live-vs-latest 升级为**连续性证明**。**破坏性恢复路径 + 需 schema/行为变更**,故按 owner 一贯纪律(D-1c/D-2/4c-*/R13-C)**design-lock first,ratify 后才动**。W0 顺序门的第一刀,gate 一切 revision 5 刀之前。
+- **Provenance**: primary-source @ origin/main;healed-gap flaw **已实证**(golden `/tmp/r13-w0-healed-gap-golden.txt`,对当前 #4235 **红**)。#4235 impl **faithful to §0.6**(其 gate=APPROVE-with-hardening 0P1/0P2),缺陷在 **§0.6 设计**本身。
+
+## §0 已证缺陷(owner P1,实证)
+- **healed-gap**:#4235 comparator = `LEFT JOIN LATERAL … ORDER BY created_at DESC LIMIT 1` = **live vs LATEST**。构造:记录 version=3,revisions 仅 {v1,v3}(v2 是无 revision 的 uncaptured 写),live==v3 snapshot ⇒ 预检**通过**。但 revert/reset 到 T∈[v2,v3) 用 latest≤T=**v1** 重建=错(记录当时是 v2)。**实证**:revert-preview(T1) 返回 **200 非 409**(golden 红)。tail 健康、**中段有洞**,live-vs-latest 结构性看不见。
+- **check→write 竞态**(owner P1 + #4235 gate P3-1):execute 预检是破坏性事务**前**的池化 READ COMMITTED 查询 ⇒ check→write 间可落无 revision 写。
+
+## §1 设计:连续性证明(替换 live-vs-latest)
+重建到 T 可信 **iff** 该记录 revision 链在 ≤T 范围**连续无洞**。判据不是「live==latest」,而是「**每个 version 都有链上条目**」。
+
+### 1.1 版本连续性 = 完整性的可观测代理
+每次写(捕获或否)`version+1`。捕获写另写 revision(该 version)。故:一条记录 version=N,若其 revisions 的 version 集**缺某 k**(1≤k≤N),则 version k 是一次**无 revision 的写** = 潜在 uncaptured 数据写(= 洞)。`count(distinct revision.version) < live.version` ⇒ 有洞。
+
+### 1.2 ⚠️ 关键难点:lock/unlock 合法地跳 version(假阳源)
+`univer-meta.ts:16403/16417` lock/unlock `SET locked=…, version = version + 1`,**不写 revision**(设计如此)。故一条**健康**记录经 lock/unlock 也会造 version 洞——**version-contiguity 单独会误拒 lock/unlock**(违反 G-HI-2)。**必须区分「lock/unlock 跳版」与「uncaptured 数据写跳版」**——retroactively 不可区分,故:
+- **lock/unlock(及一切合法的无 revision version-bump)必须留链上标记**。三选一(**OD-W0-1**):
+  - **(a) 轻量 revision**:lock/unlock 写一条 `action='lock'/'unlock'` 的 revision(snapshot=当前 data,不算数据变更)。链变密:每 version 有 data-revision 或 lock-revision。**简单,复用 revision 表**;代价=History Center 会看到 lock 事件(可过滤)。
+  - **(b) 独立 marker 表**:`meta_record_version_markers(record_id, version, kind)`。链外记「此 version 是 lock」。**不污染 revision 表**;代价=新表+双读。
+  - **(c) lock/unlock 停止 bump version**:metadata-only,version 只跟数据变更 ⇒ 连续性==数据完整性,无需 marker。**最干净但改并发语义**(lock 的 CAS 依赖 version?须核 `:16403` 的 CAS 用途)——**风险最高,须证不破 lock 并发**。
+- **推荐 (a)**(复用现有表 + 密链,History Center 过滤 lock 事件即可);(c) 若能证 lock 不依赖 version-bump 做 CAS 则更优,但须独立证。
+
+### 1.3 派生字段不 bump version ⇒ 自动无洞(G-HI-3 免费绿)
+formula/rollup/lookup/auto-number 物化写 `data` **不** bump version(`formula-engine.ts:345` 等)⇒ 不造 version 洞 ⇒ 连续性检查天然不误拒它们。§0.6 item 2 的「投影排派生」仍保留作**内容**比较的第二层(密链证连续 + 投影证内容一致,双层)。
+
+### 1.4 持久化 trusted-since(历史过渡,owner「持久化 trusted-since」)
+历史记录(本修复前)的 lock/unlock **无 marker** ⇒ 有真实旧洞,无法 retroactively 补。故:
+- durable **`revision_trusted_since_version`**(每记录;或 per-sheet 水位)= 密链 regime 起点。重建到 T 可信 iff latest-rev-≤T 的 version ≥ trusted_since **且** [trusted_since, 该 version] 连续。
+- **T 低于 trusted_since ⇒ fail-closed 拒绝**(不可证,宁拒)。**owner 决策 OD-W0-2**:历史区间 (a) 一律拒(最保守) (b) 对**全链连续**(从 v1 起无任何洞)的记录允许(那些从没 lock/uncaptured 过的记录可全程重建)。推荐 (b)——全链连续的记录可信,不必被水位一刀切拒。
+- 迁移设置初值:上线时 `trusted_since = current version`(声明「从此密链」);**不追溯信任旧洞**。⚠️ 迁移排序 [[feedback_migration_zzzz_ordering]]:新列/水位迁移须 zzzz TS,fresh-DB 全量 migrate 验。
+
+## §2 同锁事务 execute 复检(owner P1-B + #4235 gate P3-1)
+execute 的复检 + 恢复写入须**同一事务 + `FOR UPDATE` scope 行**:进恢复事务 → `SELECT … FOR UPDATE` scope 记录 → **在锁内**跑连续性预检 → 若 incomplete 则 `HISTORY_INCOMPLETE` 回滚 → 否则恢复写。杜绝 check→write 窗口(现 #4235 的 FOR UPDATE + version-mismatch 只**部分**挡,gate P3-1 已指)。
+
+## §3 验证义务(实现阶段,mutation-proven,对齐最终验收 #3)
+- **healed-gap golden**(`/tmp/r13-w0-healed-gap-golden.txt`,现红):修后 revert+reset preview+execute 到 gap 窗 T ⇒ 409 + 零写;突变(去连续性检查)→ 红。
+- **G-HI-2 lock/unlock 不误拒**(密链后:lock/unlock 有 marker ⇒ 无洞 ⇒ 通过);突变(去 lock-marker)→ G-HI-2 红。
+- **G-HI-3 formula 不误拒**(不 bump version);保留。
+- **并发竞态 golden**:check→execute-write 间落一次 uncaptured 写 ⇒ 同锁事务复检抓(真并发构造,非顺序论证 [[feedback_toctou_needs_constructed_race]])。
+- **trusted-since golden**:T<水位 ⇒ 拒;全链连续记录 T<水位 ⇒(若 OD-W0-2=b)允许。
+- 全链健康记录任意 T ⇒ 通过(正控,防 refuse-everything)。
+
+## §4 OD 决策(owner ratify)
+- **OD-W0-1**:lock-marker 方案 (a) 轻量 revision / (b) 独立表 / (c) lock 停 bump version。推荐 (a)。
+- **OD-W0-2**:trusted-since 历史区间 (a) 一律拒 / (b) 全链连续者允许。推荐 (b)。
+- **OD-W0-3**:trusted-since 粒度 per-record 还是 per-sheet 水位。推荐 per-record(精确;per-sheet 会因一条脏记录拒全表)。
+- **OD-W0-4**:HISTORY_INCOMPLETE 是否**整操作拒**(现 §0.6 = 是)还是**逐记录跳过脏的**。§0.6/owner=整操作拒(最安全,不产半状态)——保持。
+
+## §5 边界
+- **零运行时改动**;破坏性路径 + schema/行为变更 ⇒ **ratify + 迁移排序纪律**后才实现。**#4235 在本纠错落地前不合**(现 comparator 漏 healed-gap;owner「不能安全落地」)。
+- 本锁是 W0 第一刀;5 刀 revision 写入(form/plugin/automation/approval/attachment)+ OD-6 guard(#4227)排其后。**W0 未成可信闭环前不启用更多恢复 flag。**
+
+**收官口径**:design-only;§0.6 升级为连续性证明的设计已锁,healed-gap 已实证;实现待 owner ratify OD-W0-1..4 + 迁移排序验。这是 owner「先把 W0 做成可信闭环」的第一刀设计。
+
+---
+
+## §6 OWNER 裁决(2026-07-14)— 方向校准 + 首刀 scope + 延迟尾
+
+owner 复审本锁 + #4252(C1–C8 验证)后裁决:**「不要做 global version-unique,要做 generation-aware contiguity + site disposition。同意改道。」** 逐字要点:
+
+### §6.1 已裁的设计口径
+- **OD-W0-1 = 显式 marker,覆盖 4 个 lock/unlock 站点**(非只 HTTP pair):HTTP `univer-meta.ts:16426`(lock)/`:16441`(unlock)+ **automation** `automation-executor.ts:3493`(lock)/`:3504`(unlock)。四者都是「版本递增但不写 revision」的**合法例外**,**必须显式 marker**——否则守卫会给未来维护者留下「已捕获」的错觉。
+- **系统 sheet 排除走统一 predicate**,不散写站点豁免:`isSystemSheet(sheet) = isApprovalProjectionBaseId(base_id) || isSystemPeopleSheetDescription(description)`。**people directory sync 与 approval projection reprojection 是系统再生读模型**,不进用户历史完整性模型(它们合法地非连续)。
+- **generation / vintage 模型(必进 spec + golden)**:`generation = count(create revisions at-or-before)`;**但 delete revision 可复用 last live version**,所以**不能用单调 version 唯一性推历史完整性**(C5 的实质)。这点后续实现极易写错,须钉死。
+- **`recreateFieldFromConfig`(`:6522`)不得被吞成合法豁免**:它是**内容完整性**缺口,不是 version-contiguity 缺口。保留为 **flagged tail / OD-6 MUST-WRITE**(见 OD-6 守卫 #4251 的 `revision-pending` 具名追踪)。**本轮守卫绿不得掩盖它。**
+- **trash-restore `source='rest'` vs 注释写 "restore"**:作**注释/测试口径修正**,勿让 spec 引用错事实。
+
+### §6.2 首刀 scope(owner:「让实现只做这四件事」)
+1. **generation-aware contiguity**(替换 #4234 的 live-vs-latest;精确集非 count,C1/C5)。
+2. **4 个 lock/unlock markers**(§6.1,HTTP + automation)。
+3. **统一 `isSystemSheet` 排除**(§6.1)。
+4. **C8 same-txn + C4 fence**(execute 复检移入破坏性事务内、在 fence 后;C4 机制 SERIALIZABLE / sheet-lock / advisory 三选一,实现择安全者并证,若视为真 fork 回报 owner)。
+
+### §6.3 延迟尾(**明标、不得被守卫绿掩盖**,与 recreateFieldFromConfig 同纪律)
+owner「只做这四件」⇒ #4252 的以下条件**本刀不做,但显式 docket 为后续**,须在 OD-6/W0-1 报告里钉死:
+- **C2 时间单调性**(`created_at`=txn-start,版本升序/时间降序可选错 T-snapshot)——本刀不解,报告标「已知残余:PIT 时间锚未证单调」。
+- **C3 已删记录链的 healed-gap**(live-only 枚举漏 tombstoned resurrect)——本刀不解,标后续。
+- **C6 trusted-since 锚 + 滚动上线协议**(checkpoint / 水位持久化 / 跨 regime 边界的旧实例写)——本刀不解,标后续。
+- **C7 marker 词汇迁移**(`action CHECK` 只收 create/update/delete;若 marker 走轻量 revision 须迁 CHECK + 闭类型 + 同步 History UI/retention/reconstructor)——随本刀 marker 方案定,若采独立 marker 表则规避 C7。
+
+### §6.4 验收锚(fail-first)
+#4252 §6.1 的 **healed-gap 反例**(record v3、revisions 仅 {v1,v3}、live==v3 ⇒ revert-preview(T∈(v1,v3)) 必 **409**)= 本刀首个 fail-first golden。live-vs-latest 使其绿=证伪;contiguity 使其红→绿=证成。突变(去 contiguity)必红。
+
+### §6.5 状态与授权
+- **本锁仍非全 RATIFIED**——owner 裁的是**方向 + 首刀 4 项 scope 授权**;C2/C3/C6 延迟、其各自设计/机制未裁。
+- **首刀实现:AUTHORIZED**(HOT-CORE + schema/txn ⇒ Opus 设计/门禁 + zzzz 迁移排序 fresh-DB 验 + mutation-proven goldens)。
+- **#4234(已合的 live-vs-latest §0.6)= 部分守卫**,首刀落地后被 contiguity 取代/升级;在此之前它对 healed-gap **欠检**(如实,不掩盖)。**并行的 #4235(同款 live-vs-latest)按 #4252 建议关闭**(port 其 golden)。

--- a/packages/core-backend/src/db/migrations/zzzz20260713150000_create_meta_record_version_markers.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260713150000_create_meta_record_version_markers.ts
@@ -1,0 +1,53 @@
+import { sql, type Kysely } from 'kysely'
+
+/**
+ * W0-1 (OD-W0-1 = marker mechanism (b), owner §6.1) — the independent version-marker table.
+ *
+ * The four lock/unlock sites (HTTP `univer-meta.ts` lock/unlock, automation `automation-executor.ts`
+ * lock/unlock) legally do `version = version + 1` WITHOUT writing a revision: they are metadata-only
+ * bumps, not data writes. The generation-aware contiguity precheck (`history-integrity-precheck.ts`)
+ * would otherwise read that version as a HOLE (an uncaptured data write) and false-refuse a healthy
+ * locked record. This table records "this version bump was a lock/unlock, not a data write" OUT of the
+ * revision chain.
+ *
+ * Mechanism (b) is chosen over (a) lightweight lock/unlock revisions precisely to AVOID the C7 ripple:
+ * `meta_record_revisions.action CHECK (action IN ('create','update','delete'))` stays closed, and the
+ * History UI / retention / reconstructor never see a new action vocabulary. This table is read ONLY by
+ * the contiguity precheck.
+ *
+ * `UNIQUE (sheet_id, record_id, version)` is the C5 fail-closed constraint FOR MARKERS: exactly one
+ * marker per version, so a conflicting/duplicate marker cannot be forged. (The revisions table itself
+ * CANNOT carry `UNIQUE (sheet_id, record_id, version)` — a delete revision legally REUSES the last live
+ * version — so the create/update exact-set is enforced in application code; markers, being a brand-new
+ * table with no reuse semantics, get the DB constraint for free.)
+ *
+ * zzzz-timestamped ([[feedback_migration_zzzz_ordering]]): this table shares the version-space of
+ * `meta_records` / `meta_record_revisions`, both of which are created in zzzz migrations. Proven on a
+ * FRESH-DB full migrate (not a preloaded DB) per the migration discipline.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_record_version_markers (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      sheet_id text NOT NULL,
+      record_id text NOT NULL,
+      version integer NOT NULL,
+      kind text NOT NULL CHECK (kind IN ('lock', 'unlock')),
+      actor_id text,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT uq_meta_record_version_markers_sheet_record_version UNIQUE (sheet_id, record_id, version)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_record_version_markers_sheet_record
+    ON meta_record_version_markers(sheet_id, record_id, version)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_meta_record_version_markers_sheet_record`.execute(db)
+  await sql`DROP TABLE IF EXISTS meta_record_version_markers`.execute(db)
+}

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -4,7 +4,7 @@
  */
 
 import { randomUUID } from 'crypto'
-import { recordRecordRevision } from './record-history-service'
+import { recordRecordRevision, recordVersionMarker } from './record-history-service'
 import { Logger } from '../core/logger'
 import { withAutomationEventId } from './automation-event-dedup'
 import { redactString } from './automation-log-redact'
@@ -3486,25 +3486,32 @@ export class AutomationExecutor {
         const lockedBy = typeof context.actorId === 'string' && context.actorId.trim() ? context.actorId : 'system'
         // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — same-base uses the gate's
         // fast-path (byte-identical to pre-C2); a cross-base lock is rejected unless claim==truth + base-write.
+        // W0-1: write a lock marker at the new version so the contiguity precheck reads this legitimate
+        // non-data version bump as a marker, not an uncaptured-write hole.
         // lock-mgmt: LOCK action — sets the lock columns themselves (not a data edit of a locked row).
         // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
-        await this.deps.queryFn(
+        const upd = await this.deps.queryFn(
           `UPDATE meta_records
            SET locked = true, locked_by = $1, locked_at = NOW(), version = version + 1, updated_at = NOW()
-           WHERE id = $2 AND sheet_id = $3`,
+           WHERE id = $2 AND sheet_id = $3 RETURNING version`,
           [lockedBy, effectiveRecordId, effectiveSheetId],
         )
+        const newVersion = Number((upd.rows[0] as { version?: unknown } | undefined)?.version)
+        if (Number.isFinite(newVersion)) await recordVersionMarker(this.deps.queryFn, { sheetId: effectiveSheetId, recordId: effectiveRecordId, version: newVersion, kind: 'lock', actorId: typeof context.actorId === 'string' ? context.actorId : null })
       } else {
         // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — same-base fast-path keeps
         // this byte-identical to pre-C2; a cross-base unlock is rejected unless claim==truth + base-write.
+        // W0-1: write an unlock marker at the new version — legitimate non-data bump, not a hole.
         // lock-mgmt: UNLOCK action — clears the lock columns (decision f: automation may unlock).
         // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
-        await this.deps.queryFn(
+        const upd = await this.deps.queryFn(
           `UPDATE meta_records
            SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()
-           WHERE id = $1 AND sheet_id = $2`,
+           WHERE id = $1 AND sheet_id = $2 RETURNING version`,
           [effectiveRecordId, effectiveSheetId],
         )
+        const newVersion = Number((upd.rows[0] as { version?: unknown } | undefined)?.version)
+        if (Number.isFinite(newVersion)) await recordVersionMarker(this.deps.queryFn, { sheetId: effectiveSheetId, recordId: effectiveRecordId, version: newVersion, kind: 'unlock', actorId: typeof context.actorId === 'string' ? context.actorId : null })
       }
 
       return {

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -3484,15 +3484,15 @@ export class AutomationExecutor {
 
       if (locked) {
         const lockedBy = typeof context.actorId === 'string' && context.actorId.trim() ? context.actorId : 'system'
-        // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — same-base uses the gate's
-        // fast-path (byte-identical to pre-C2); a cross-base lock is rejected unless claim==truth + base-write.
         // W0-1: write a lock marker at the new version so the contiguity precheck reads this legitimate
-        // non-data version bump as a marker, not an uncaptured-write hole.
-        // lock-mgmt: LOCK action — sets the lock columns themselves (not a data edit of a locked row).
-        // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
-        // W0-1 NIT-2: version bump + marker are atomic (mirrors the HTTP lock path). A transient error between
-        // the two must not leave a durable version hole that fail-closed-refuses revert/reset until C6.
+        // non-data version bump as a marker, not an uncaptured-write hole. Bump + marker are atomic inside
+        // withTransaction (mirrors the HTTP lock path) — a transient error between the two must not leave
+        // a durable version hole that fail-closed-refuses revert/reset until C6. The three disposition
+        // markers live INSIDE the callback: each structural guard scans a fixed window above the SQL line.
         await this.withTransaction(async (query) => {
+          // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — cross-base lock rejected unless claim==truth + base-write.
+          // lock-mgmt: LOCK action — sets the lock columns themselves (not a data edit of a locked row).
+          // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
           const upd = await query(
             `UPDATE meta_records
              SET locked = true, locked_by = $1, locked_at = NOW(), version = version + 1, updated_at = NOW()
@@ -3503,13 +3503,13 @@ export class AutomationExecutor {
           if (Number.isFinite(newVersion)) await recordVersionMarker(query, { sheetId: effectiveSheetId, recordId: effectiveRecordId, version: newVersion, kind: 'lock', actorId: typeof context.actorId === 'string' ? context.actorId : null })
         })
       } else {
-        // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — same-base fast-path keeps
-        // this byte-identical to pre-C2; a cross-base unlock is rejected unless claim==truth + base-write.
-        // W0-1: write an unlock marker at the new version — legitimate non-data bump, not a hole.
-        // lock-mgmt: UNLOCK action — clears the lock columns (decision f: automation may unlock).
-        // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
-        // W0-1 NIT-2: version bump + marker are atomic (mirrors the HTTP unlock path) — no durable version hole.
+        // W0-1: write an unlock marker at the new version — legitimate non-data bump, not a hole. Bump +
+        // marker are atomic inside withTransaction (mirrors the HTTP unlock path) — no durable version hole.
+        // Disposition markers live INSIDE the callback (fixed guard scan windows above the SQL line).
         await this.withTransaction(async (query) => {
+          // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — cross-base unlock rejected unless claim==truth + base-write.
+          // lock-mgmt: UNLOCK action — clears the lock columns (decision f: automation may unlock).
+          // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
           const upd = await query(
             `UPDATE meta_records
              SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -3490,28 +3490,35 @@ export class AutomationExecutor {
         // non-data version bump as a marker, not an uncaptured-write hole.
         // lock-mgmt: LOCK action — sets the lock columns themselves (not a data edit of a locked row).
         // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
-        const upd = await this.deps.queryFn(
-          `UPDATE meta_records
-           SET locked = true, locked_by = $1, locked_at = NOW(), version = version + 1, updated_at = NOW()
-           WHERE id = $2 AND sheet_id = $3 RETURNING version`,
-          [lockedBy, effectiveRecordId, effectiveSheetId],
-        )
-        const newVersion = Number((upd.rows[0] as { version?: unknown } | undefined)?.version)
-        if (Number.isFinite(newVersion)) await recordVersionMarker(this.deps.queryFn, { sheetId: effectiveSheetId, recordId: effectiveRecordId, version: newVersion, kind: 'lock', actorId: typeof context.actorId === 'string' ? context.actorId : null })
+        // W0-1 NIT-2: version bump + marker are atomic (mirrors the HTTP lock path). A transient error between
+        // the two must not leave a durable version hole that fail-closed-refuses revert/reset until C6.
+        await this.withTransaction(async (query) => {
+          const upd = await query(
+            `UPDATE meta_records
+             SET locked = true, locked_by = $1, locked_at = NOW(), version = version + 1, updated_at = NOW()
+             WHERE id = $2 AND sheet_id = $3 RETURNING version`,
+            [lockedBy, effectiveRecordId, effectiveSheetId],
+          )
+          const newVersion = Number((upd.rows[0] as { version?: unknown } | undefined)?.version)
+          if (Number.isFinite(newVersion)) await recordVersionMarker(query, { sheetId: effectiveSheetId, recordId: effectiveRecordId, version: newVersion, kind: 'lock', actorId: typeof context.actorId === 'string' ? context.actorId : null })
+        })
       } else {
         // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — same-base fast-path keeps
         // this byte-identical to pre-C2; a cross-base unlock is rejected unless claim==truth + base-write.
         // W0-1: write an unlock marker at the new version — legitimate non-data bump, not a hole.
         // lock-mgmt: UNLOCK action — clears the lock columns (decision f: automation may unlock).
         // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
-        const upd = await this.deps.queryFn(
-          `UPDATE meta_records
-           SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()
-           WHERE id = $1 AND sheet_id = $2 RETURNING version`,
-          [effectiveRecordId, effectiveSheetId],
-        )
-        const newVersion = Number((upd.rows[0] as { version?: unknown } | undefined)?.version)
-        if (Number.isFinite(newVersion)) await recordVersionMarker(this.deps.queryFn, { sheetId: effectiveSheetId, recordId: effectiveRecordId, version: newVersion, kind: 'unlock', actorId: typeof context.actorId === 'string' ? context.actorId : null })
+        // W0-1 NIT-2: version bump + marker are atomic (mirrors the HTTP unlock path) — no durable version hole.
+        await this.withTransaction(async (query) => {
+          const upd = await query(
+            `UPDATE meta_records
+             SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()
+             WHERE id = $1 AND sheet_id = $2 RETURNING version`,
+            [effectiveRecordId, effectiveSheetId],
+          )
+          const newVersion = Number((upd.rows[0] as { version?: unknown } | undefined)?.version)
+          if (Number.isFinite(newVersion)) await recordVersionMarker(query, { sheetId: effectiveSheetId, recordId: effectiveRecordId, version: newVersion, kind: 'unlock', actorId: typeof context.actorId === 'string' ? context.actorId : null })
+        })
       }
 
       return {

--- a/packages/core-backend/src/multitable/history-integrity-precheck.ts
+++ b/packages/core-backend/src/multitable/history-integrity-precheck.ts
@@ -1,6 +1,7 @@
 import { mapFieldType, isSystemFieldType } from './field-codecs'
 import type { QueryFn } from './permission-service'
 import { isSystemSheet } from './system-sheet-predicate'
+import { hasVersionMarkerTable } from './record-history-service'
 
 /**
  * Global History — W0-1: `HISTORY_INCOMPLETE`, the fail-closed integrity PRECHECK for the destructive
@@ -261,8 +262,11 @@ export async function precheckSheetHistoryIntegrity(
 
     // Lock/unlock markers (deploy-window safe: a missing table pre-migration ⇒ no markers ⇒ locked records
     // fail CLOSED via a hole, never a crash — the C6 trusted-since watermark that grandfathers them is deferred).
+    // The existence probe (information_schema, never 42P01) MUST run before the direct SELECT: this precheck is
+    // re-run INSIDE the reset-execute destructive transaction, and a swallowed 42P01 there still aborts the txn
+    // (25P02 on the next statement → 500 instead of clean 409). Mirrors the WRITE path's txn-safe probe.
     const markersByRecord = new Map<string, VersionMarker[]>()
-    try {
+    if (await hasVersionMarkerTable(query)) {
       const markerRes = await query(
         `SELECT record_id, version, kind, created_at FROM meta_record_version_markers WHERE sheet_id = $1`,
         [sheetId],
@@ -274,8 +278,6 @@ export async function precheckSheetHistoryIntegrity(
         list.push({ version, kind: m.kind === 'unlock' ? 'unlock' : 'lock', orderKey: orderKeyOf(m.created_at, version) })
         markersByRecord.set(rid, list)
       }
-    } catch (err) {
-      if (!isMissingMarkerTable(err)) throw err // real errors → fail-closed via outer catch
     }
 
     for (const row of liveRows) {
@@ -302,11 +304,4 @@ export async function precheckSheetHistoryIntegrity(
   } catch {
     return { ok: false, reason: 'comparator_error' } // rule 4 fail-closed
   }
-}
-
-/** 42P01 = undefined_table — the marker table has not been migrated yet (rolling-deploy window). */
-function isMissingMarkerTable(err: unknown): boolean {
-  const code = (err as { code?: unknown })?.code
-  const message = String((err as { message?: unknown })?.message ?? '')
-  return code === '42P01' || /meta_record_version_markers/.test(message) && /does not exist|undefined table/i.test(message)
 }

--- a/packages/core-backend/src/multitable/history-integrity-precheck.ts
+++ b/packages/core-backend/src/multitable/history-integrity-precheck.ts
@@ -1,91 +1,100 @@
 import { mapFieldType, isSystemFieldType } from './field-codecs'
 import type { QueryFn } from './permission-service'
+import { isSystemSheet } from './system-sheet-predicate'
 
 /**
- * Global History — D-1c §0.6: `HISTORY_INCOMPLETE`, the fail-closed integrity PRECHECK for the destructive
- * recovery surfaces (PIT sheet Revert-to-T + Reset-to-T, preview AND execute). RATIFIED 2026-07-13 (owner);
- * design-lock: docs/development/multitable-global-history-d1c-form-submit-edit-uncaptured-revision-design-lock-20260712.md.
+ * Global History — W0-1: `HISTORY_INCOMPLETE`, the fail-closed integrity PRECHECK for the destructive
+ * recovery surfaces (PIT sheet Revert-to-T + Reset-to-T, preview AND execute). The owner-directed
+ * correction of D-1c §0.6 (design lock:
+ * docs/development/multitable-global-history-w0-1-history-incomplete-contiguity-trusted-since-design-lock-20260713.md,
+ * §6 owner ruling 2026-07-14).
  *
- * Doctrine (owner hard-lock, verbatim rules 1–4):
+ * WHAT CHANGED vs #4234 (the superseded live-vs-latest comparator): the PRIMARY integrity proof is now a
+ * GENERATION-AWARE CONTIGUITY proof, not a live-vs-latest content diff. #4234 compared the live `data`
+ * against the LATEST revision snapshot; a record at version 3 with revisions only {v1, v3} (v2 an
+ * uncaptured mid-chain write) has live == v3, so #4234 PASSED it — but revert/reset to a T inside (v1, v3)
+ * reconstructs the wrong (v1) snapshot. Contiguity proves that EVERY version in [1..liveVersion] is
+ * accounted for by exactly one chain event (a create/update revision OR a legitimate lock/unlock marker);
+ * a version with no chain event = an uncaptured data write = a HOLE = HISTORY_INCOMPLETE.
+ *
+ * The pre-existing live-vs-latest content-projection is RETAINED as the design-lock §1.3 SECOND layer
+ * (contiguity proves the chain is complete; the content projection proves live == the latest captured
+ * content), so no coverage from #4234 is lost. Contiguity is the load-bearing new proof.
+ *
+ * Doctrine (owner hard-lock, verbatim rules 1–4, unchanged):
  *  1. UNIFIED REFUSAL — while any live record's history in the affected scope is untrustworthy, preview and
- *     execute BOTH return `HISTORY_INCOMPLETE`; no execute token is minted and zero rows are written. Preview
- *     and execute consume the SAME function (this one), so execute re-checks by construction (rule 4 / TOCTOU —
- *     the revision-derived `previewIdentity` scopeHash is structurally blind to uncaptured writes and is NOT
- *     relied on for this).
- *  2. CONTENT, NOT VERSION — the comparator diffs the live `meta_records.data` against the latest revision's
- *     `snapshot`, projected onto the sheet's USER-AUTHORED field ids only. Version-only mutations (record
- *     lock/unlock bump `version` without touching `data`) therefore never trip it, and neither does derived-field
- *     materialization: formula / rollup / lookup / auto-number engines write computed keys into `data` with no
- *     revision BY DESIGN (`formula-engine.ts` recompute, `univer-meta.ts` relation-aggregation fan-out,
- *     `auto-number-service.ts` backfill), so a full-`data` diff would refuse every healthy record on every
- *     formula sheet. The exact excluded type list is pinned below (`DERIVED_FIELD_TYPES`).
- *  3. ZERO-REVISION LIVE ROWS REFUSE — a live record with no revision at all (the uncaptured-CREATE
- *     fingerprint) is trivially inconsistent with its non-existent latest snapshot. The precheck enumerates the
- *     LIVE row set of the scope — NOT the reconstruction — because `computeSheetReset` pushes live rows absent
- *     from the reconstructed state into its delete-set, so iterating the reconstruction misses exactly the rows
- *     the reset would silently destroy.
- *  4. FAIL-CLOSED — any comparator failure refuses; there is no proceed-on-error branch. (Database errors
- *     propagate to the routes' existing non-write error mapping instead of being folded into a false
- *     `HISTORY_INCOMPLETE`; every one of those paths is also a zero-write refusal.)
+ *     execute BOTH return `HISTORY_INCOMPLETE`; no execute token is minted and zero rows are written.
+ *  2. GENERATION-AWARE, NOT COUNT — the criterion is an EXACT SET (C5): exactly one canonical chain event
+ *     per expected version. It is NOT `count(distinct version) < live.version` and NOT `count(*) == version`,
+ *     because a DELETE revision legally REUSES the last live version (so both counts are ambiguous). Delete
+ *     revisions are excluded from the per-version occupant count; a delete that is the latest event on a
+ *     LIVE row, or beyond the live version, refuses.
+ *  3. SYSTEM SHEETS EXCLUDED — approval-projection / people-directory sheets are server-regenerated read
+ *     models (`isSystemSheet`); they legitimately carry non-contiguous history and are skipped entirely.
+ *  4. FAIL-CLOSED — any comparator failure refuses; there is no proceed-on-error branch.
  *
- * PURE READ — writes nothing. NOT a backfill (OD-5 forbids fabricating history); it refuses to act on
- * untrustworthy history, it does not repair it.
+ * C8 (same-txn) + C4 (fence): the EXECUTE path re-runs this precheck INSIDE the destructive transaction,
+ * after a per-sheet `pg_advisory_xact_lock` fence (see `routes/univer-meta.ts` reset-execute), so check and
+ * write are atomic against a phantom insert landing between the preview/compute check and the write.
+ *
+ * PURE READ — writes nothing. NOT a backfill; it refuses to act on untrustworthy history.
+ *
+ * DEFERRED (docketed, must not be masked by this guard going green — design lock §6.3):
+ *  - `recreateFieldFromConfig` (univer-meta.ts) content-integrity gap — owner-ruled MUST-WRITE, own rung.
+ *  - C2 time-monotonicity (version-ascending/time-descending under concurrency can pick the wrong T-snapshot).
+ *  - C3 deleted/tombstoned + resurrected (multi-generation) chains — live-only enumeration here; a resurrected
+ *    record refuses fail-closed (duplicate create at v1), full handling is C3.
+ *  - C6 durable trusted-since watermark + rollout protocol (grandfathers pre-marker lock holes).
  */
 
 /** The unified refusal code (rule 1). Routes surface it as HTTP 409 with a values-free body. */
 export const HISTORY_INCOMPLETE = 'HISTORY_INCOMPLETE' as const
 
+/** C8 in-txn sentinel: thrown by the execute-path re-check inside the destructive transaction so the route
+ *  catch can map it to the same values-free 409 and roll the whole transaction back (zero writes). */
+export const HISTORY_INCOMPLETE_INTXN = 'HISTORY_INCOMPLETE_INTXN' as const
+export class HistoryIncompleteInTxnError extends Error {
+  readonly code = HISTORY_INCOMPLETE_INTXN
+  constructor(readonly reason: HistoryIntegrityReason) {
+    super('History is incomplete — destructive recovery refused inside the transaction (zero writes).')
+    this.name = 'HistoryIncompleteInTxnError'
+  }
+}
+
 /**
- * D-1c §0.6 item 2 — the EXACT derived-type exclusion list, pinned from how `field-codecs` classifies value
- * types (`mapFieldType` canonical names). These four are the value engines that materialize computed keys into
- * `meta_records.data` without a revision by design; every other type (including `link` ids, which live in
- * `data` and are snapshot-captured like any cell per OD-4) is user-authored and IS compared.
+ * The EXACT derived-type exclusion list (retained §1.3 content layer) — value engines that materialize
+ * computed keys into `meta_records.data` WITHOUT a revision by design. Derived materialization does NOT
+ * bump `version` either, so it never creates a contiguity hole; this set only governs the content layer.
  */
 export const DERIVED_FIELD_TYPES: ReadonlySet<string> = new Set(['formula', 'rollup', 'lookup', 'autoNumber'])
 
-/**
- * P3-1 hardening (post-ratification, same doctrine — not a live false-positive today, but the security path
- * must be closed on its own terms, not on the accident that no writer currently exercises the gap). Rule 2's
- * text is "the sheet's user-authored/writable field ids" — the four value-derivation engines above are one
- * instance of "not user-authored", not the whole class. The four SYSTEM field types (`createdTime` /
- * `modifiedTime` / `createdBy` / `modifiedBy`, `field-codecs`'s canonical `SYSTEM_FIELD_TYPES`) are equally
- * server-maintained: `isFieldAlwaysReadOnly` (`permission-derivation.ts`) already places them in the SAME
- * always-read-only bucket as formula/lookup/rollup. In today's write paths a system field's value is derived
- * purely at READ time (`query-service.ts`'s `injectSystemFieldValues`, from `created_at`/`updated_at`/
- * `created_by`/`modified_by`) and is never written into the `data` column at all — so this exclusion has no
- * observable effect on any current writer. It hardens the precheck against a FUTURE or LEGACY/imported record
- * that happens to carry a stray value under a system field id in `data`: such a value must never be able to
- * pollute-refuse a healthy record, any more than a materialized formula value can. `autoNumber` is a member of
- * both sets; the union simply dedupes it.
- */
+/** The four SYSTEM field types are server-maintained (derived at read time), excluded like derived types. */
 export function isNonUserAuthoredFieldType(canonicalType: string): boolean {
   return DERIVED_FIELD_TYPES.has(canonicalType) || isSystemFieldType(canonicalType)
 }
 
-/** Raw DB `meta_fields.type` → excluded from the user-authored-field projection? Routed through the canonical
- * `mapFieldType` so raw spellings (`auto_number`, `AUTO-NUMBER`, `modified_time`, …) classify identically to
- * their canonical forms. Covers both the derived-value engines (rule 2) and the system-computed types
- * (P3-1 hardening, above). */
+/** Raw DB `meta_fields.type` → excluded from the user-authored-field projection? */
 export function isDerivedFieldType(rawType: string): boolean {
   return isNonUserAuthoredFieldType(String(mapFieldType(String(rawType ?? ''))))
 }
 
-export type HistoryIntegrityVerdict =
-  | { ok: true }
-  /** Reasons are internal/log-only enums — the HTTP surface is a flat, values-free `HISTORY_INCOMPLETE`
-   *  (no record ids, no counts: the refusal must not become a denied-record existence oracle). */
-  | { ok: false; reason: 'zero_revision_live_row' | 'live_row_after_delete_revision' | 'content_mismatch' | 'comparator_error' }
+export type HistoryIntegrityReason =
+  // contiguity (primary, W0-1)
+  | 'zero_revision_live_row'
+  | 'chain_hole'
+  | 'duplicate_version_event'
+  | 'out_of_range_version'
+  | 'live_row_after_delete_revision'
+  // content projection (retained §1.3 second layer)
+  | 'content_mismatch'
+  | 'comparator_error'
+
+export type HistoryIntegrityVerdict = { ok: true } | { ok: false; reason: HistoryIntegrityReason }
 
 const isPlainRecord = (v: unknown): v is Record<string, unknown> =>
   !!v && typeof v === 'object' && !Array.isArray(v)
 
-/**
- * Canonical value equality for the projection: key-order-insensitive for nested objects, order-SENSITIVE for
- * arrays (healthy captured writers snapshot the very object they write, so ordering matches), and `null` ≡
- * absent — the same `?? null` fold the canonical restore diff (`record-restore-diff.ts` `sameValue`) already
- * uses for restorable-value equality, so the precheck cannot be stricter about emptiness than the restore
- * machinery it guards.
- */
+/** Canonical value equality for the content projection (key-order-insensitive objects, `null` ≡ absent). */
 const canonicalize = (v: unknown): string => {
   if (v === undefined || v === null) return 'null'
   if (Array.isArray(v)) return `[${v.map(canonicalize).join(',')}]`
@@ -96,60 +105,208 @@ const canonicalize = (v: unknown): string => {
   return JSON.stringify(v) ?? 'null'
 }
 
+// ==============================================================================================================
+// Generation-aware contiguity — the PURE, unit-testable core (mutation-proven in isolation of the DB).
+// ==============================================================================================================
+
+export type ChainEventAction = 'create' | 'update' | 'delete'
+/** A revision chain event. `orderKey` is a monotone tiebreaker (created_at epoch, then version, then id) used
+ *  ONLY to decide which event is "latest" for the live-row-after-delete check. */
+export interface ChainEvent {
+  version: number
+  action: ChainEventAction
+  orderKey?: number
+}
+/** A legitimate non-data version bump (lock/unlock) recorded out-of-chain in `meta_record_version_markers`.
+ *  `orderKey` (created_at epoch, then version) places the marker in its generation, exactly like a ChainEvent. */
+export interface VersionMarker {
+  version: number
+  kind: 'lock' | 'unlock'
+  orderKey?: number
+}
+
+export type ContiguityResult = { ok: true } | { ok: false; reason: HistoryIntegrityReason }
+
 /**
- * The shared §0.6 precheck. Scope = the sheet (revert/reset are whole-sheet operations, T8 D5).
+ * Generation-aware contiguity for ONE live record (owner §6.1 — "generation = count(create revisions
+ * at-or-before)"; delete revisions REUSE the last live version, so NO count/version-uniqueness criterion works).
  *
- * Both compute paths (`computeSheetRevert`, `computeSheetReset`) call this AFTER their cheap record-count
- * ceiling (a too-large sheet is refused 413 before any scan, precheck included) and BEFORE any diff/scope
- * work — so preview mints no token and execute writes no row once this refuses.
+ * A record's chain is a sequence of GENERATIONS separated by delete revisions (a record can be created,
+ * deleted, then trash-restored / PIT-resurrected — a fresh `create` revision at version 1 starts a NEW
+ * generation). Only the CURRENT generation (the suffix strictly after the LAST delete, by orderKey) governs
+ * a LIVE record's trustworthiness for revert/reset to a T in that generation. Reconstruction across a prior
+ * generation boundary is C3 (deleted-record chains) — explicitly DEFERRED — so this proof scopes to the
+ * current generation, which is why a common trash-restore is NOT false-refused.
+ *
+ * The current generation is contiguous iff every version k ∈ [genStart..liveVersion] (genStart = the version
+ * of the generation's `create`) is occupied by EXACTLY ONE canonical occupant:
+ *   - a create/update revision at version k in the current generation, OR
+ *   - a lock/unlock marker at version k in the current generation.
+ * Fail-closed:
+ *   - a version with no occupant = an uncaptured data write = a HOLE (this is the healed-gap the whole slice
+ *     exists to catch: v3 record with revisions {v1, v3} ⇒ v2 hole);
+ *   - two occupants at one version = duplicate/conflicting event (C5);
+ *   - an occupant version > liveVersion (or < genStart) = out-of-range (C5);
+ *   - the last chain event is a delete but the row is LIVE (current generation empty) = uncaptured
+ *     resurrection;
+ *   - no create/update revision anywhere = the zero-revision uncaptured-CREATE fingerprint.
+ */
+export function checkRecordChainContiguity(
+  liveVersion: number,
+  events: ReadonlyArray<ChainEvent>,
+  markers: ReadonlyArray<VersionMarker>,
+): ContiguityResult {
+  const V = Number.isFinite(liveVersion) ? Math.trunc(liveVersion) : 0
+  if (V < 1) return { ok: false, reason: 'chain_hole' } // a live record must have version >= 1
+
+  const anyCreateOrUpdate = events.some((e) => e.action !== 'delete')
+  if (!anyCreateOrUpdate && markers.length === 0) return { ok: false, reason: 'zero_revision_live_row' }
+
+  // Generation boundary: the LAST delete (by orderKey) terminates the prior generation; the current
+  // generation is everything strictly after it.
+  let lastDeleteOrderKey = Number.NEGATIVE_INFINITY
+  for (const e of events) {
+    if (e.action === 'delete') lastDeleteOrderKey = Math.max(lastDeleteOrderKey, e.orderKey ?? 0)
+  }
+  const inCurrentGen = (orderKey?: number): boolean => (orderKey ?? 0) > lastDeleteOrderKey
+
+  const currentGenEvents = events.filter((e) => e.action !== 'delete' && inCurrentGen(e.orderKey))
+  const currentGenMarkers = markers.filter((m) => inCurrentGen(m.orderKey))
+
+  // Current generation empty while the row is LIVE ⇒ the latest chain event is a delete (uncaptured
+  // resurrection: history claims dead but the row exists).
+  if (currentGenEvents.length === 0 && anyCreateOrUpdate) return { ok: false, reason: 'live_row_after_delete_revision' }
+  if (currentGenEvents.length === 0) return { ok: false, reason: 'zero_revision_live_row' }
+
+  // A generation must START with a create. genStart = the create's version (v1 for original + resurrect).
+  const createVersions = currentGenEvents.filter((e) => e.action === 'create').map((e) => e.version)
+  if (createVersions.length === 0) return { ok: false, reason: 'chain_hole' } // updates with no create = broken generation
+  const genStart = Math.min(...createVersions)
+  if (genStart < 1 || genStart > V) return { ok: false, reason: 'out_of_range_version' }
+
+  const occupant = new Map<number, number>()
+  for (const e of currentGenEvents) {
+    if (!Number.isInteger(e.version) || e.version < genStart || e.version > V) return { ok: false, reason: 'out_of_range_version' }
+    occupant.set(e.version, (occupant.get(e.version) ?? 0) + 1)
+  }
+  for (const m of currentGenMarkers) {
+    if (!Number.isInteger(m.version) || m.version < genStart || m.version > V) return { ok: false, reason: 'out_of_range_version' }
+    occupant.set(m.version, (occupant.get(m.version) ?? 0) + 1)
+  }
+
+  for (let k = genStart; k <= V; k++) {
+    const c = occupant.get(k) ?? 0
+    if (c === 0) return { ok: false, reason: 'chain_hole' }
+    if (c > 1) return { ok: false, reason: 'duplicate_version_event' }
+  }
+  return { ok: true }
+}
+
+// ==============================================================================================================
+
+const toNumber = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : Number(v) || 0)
+const orderKeyOf = (createdAt: unknown, version: number): number => {
+  const t = createdAt instanceof Date ? createdAt.getTime() : Date.parse(String(createdAt ?? ''))
+  // epoch-ms dominates; version is a sub-ms tiebreaker (max ~1e6 versions before it would collide a ms).
+  return (Number.isFinite(t) ? t : 0) * 1e6 + version
+}
+
+/**
+ * The shared precheck. Scope = the sheet (revert/reset are whole-sheet operations). Preview and execute both
+ * call this; the execute path ALSO re-runs it inside the destructive transaction (C8) via
+ * `HistoryIncompleteInTxnError`.
  */
 export async function precheckSheetHistoryIntegrity(
   query: QueryFn,
   sheetId: string,
 ): Promise<HistoryIntegrityVerdict> {
+  // System sheets (approval projection / people directory) are server-regenerated read models — excluded.
+  const sheetRes = await query('SELECT base_id, description FROM meta_sheets WHERE id = $1', [sheetId])
+  const sheetRow = sheetRes.rows[0] as { base_id?: unknown; description?: unknown } | undefined
+  if (sheetRow && isSystemSheet({ baseId: typeof sheetRow.base_id === 'string' ? sheetRow.base_id : null, description: sheetRow.description })) {
+    return { ok: true }
+  }
+
   const fieldsRes = await query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])
   const userFieldIds: string[] = []
   for (const row of fieldsRes.rows as Array<{ id: unknown; type: unknown }>) {
     if (!isDerivedFieldType(String(row.type ?? ''))) userFieldIds.push(String(row.id))
   }
-  const liveRes = await query('SELECT id, data FROM meta_records WHERE sheet_id = $1', [sheetId])
-  const liveRows = liveRes.rows as Array<{ id: unknown; data: unknown }>
+  const liveRes = await query('SELECT id, data, version FROM meta_records WHERE sheet_id = $1', [sheetId])
+  const liveRows = liveRes.rows as Array<{ id: unknown; data: unknown; version: unknown }>
   if (liveRows.length === 0) return { ok: true }
-  // Latest revision per record — LOCK-11 deterministic order (`created_at DESC, version DESC, id DESC`),
-  // parity with `reconstructRecordsAtT` but WITHOUT the `<= T` cut: rule 2 compares live data against
-  // history's most recent claim, which is T-independent.
-  const revRes = await query(
-    `SELECT DISTINCT ON (record_id) record_id, action, snapshot
-     FROM meta_record_revisions
-     WHERE sheet_id = $1
-     ORDER BY record_id, created_at DESC, version DESC, id DESC`,
-    [sheetId],
-  )
-  const latestByRecord = new Map<string, { action: string; snapshot: unknown }>()
-  for (const row of revRes.rows as Array<{ record_id: unknown; action: unknown; snapshot: unknown }>) {
-    latestByRecord.set(String(row.record_id), { action: String(row.action ?? ''), snapshot: row.snapshot })
-  }
+
   try {
-    // Rule 3: iterate the LIVE rows (never the reconstruction — that misses exactly the delete-set-at-risk rows).
+    // FULL chain per record (contiguity needs every event, not just the latest) — all versions/actions.
+    const revRes = await query(
+      `SELECT record_id, version, action, snapshot, created_at, id
+       FROM meta_record_revisions
+       WHERE sheet_id = $1`,
+      [sheetId],
+    )
+    type RevRow = { record_id: unknown; version: unknown; action: unknown; snapshot: unknown; created_at: unknown; id: unknown }
+    const eventsByRecord = new Map<string, ChainEvent[]>()
+    const latestSnapByRecord = new Map<string, { action: string; snapshot: unknown; orderKey: number }>()
+    for (const r of revRes.rows as RevRow[]) {
+      const rid = String(r.record_id)
+      const version = toNumber(r.version)
+      const action = (r.action === 'create' || r.action === 'delete') ? r.action : 'update'
+      const orderKey = orderKeyOf(r.created_at, version)
+      const list = eventsByRecord.get(rid) ?? []
+      list.push({ version, action, orderKey })
+      eventsByRecord.set(rid, list)
+      const prev = latestSnapByRecord.get(rid)
+      if (!prev || orderKey > prev.orderKey) latestSnapByRecord.set(rid, { action, snapshot: r.snapshot, orderKey })
+    }
+
+    // Lock/unlock markers (deploy-window safe: a missing table pre-migration ⇒ no markers ⇒ locked records
+    // fail CLOSED via a hole, never a crash — the C6 trusted-since watermark that grandfathers them is deferred).
+    const markersByRecord = new Map<string, VersionMarker[]>()
+    try {
+      const markerRes = await query(
+        `SELECT record_id, version, kind, created_at FROM meta_record_version_markers WHERE sheet_id = $1`,
+        [sheetId],
+      )
+      for (const m of markerRes.rows as Array<{ record_id: unknown; version: unknown; kind: unknown; created_at: unknown }>) {
+        const rid = String(m.record_id)
+        const version = toNumber(m.version)
+        const list = markersByRecord.get(rid) ?? []
+        list.push({ version, kind: m.kind === 'unlock' ? 'unlock' : 'lock', orderKey: orderKeyOf(m.created_at, version) })
+        markersByRecord.set(rid, list)
+      }
+    } catch (err) {
+      if (!isMissingMarkerTable(err)) throw err // real errors → fail-closed via outer catch
+    }
+
     for (const row of liveRows) {
-      const latest = latestByRecord.get(String(row.id))
-      // Zero revisions at all → the uncaptured-CREATE fingerprint → refuse.
-      if (!latest) return { ok: false, reason: 'zero_revision_live_row' }
-      // A LIVE row whose latest revision is a DELETE: history claims the record is dead, so
-      // `reconstructRecordsAtT(now)` reports it non-existent and a Reset would push it into the delete-set
-      // even when the content projection matches (a delete revision stores the PRE-delete snapshot). That is
-      // the same silent-destruction class rule 3 exists for → refuse. (No captured path produces this state:
-      // trash-restore and PIT-resurrect both write a fresh 'create' revision in the same transaction.)
-      if (latest.action === 'delete') return { ok: false, reason: 'live_row_after_delete_revision' }
-      const live = isPlainRecord(row.data) ? row.data : {}
-      const snap = isPlainRecord(latest.snapshot) ? latest.snapshot : {}
-      for (const fid of userFieldIds) {
-        if (canonicalize(live[fid]) !== canonicalize(snap[fid])) return { ok: false, reason: 'content_mismatch' }
+      const rid = String(row.id)
+      const liveVersion = toNumber(row.version)
+      const events = eventsByRecord.get(rid) ?? []
+      const markers = markersByRecord.get(rid) ?? []
+
+      // PRIMARY: generation-aware contiguity.
+      const contiguity = checkRecordChainContiguity(liveVersion, events, markers)
+      if (!contiguity.ok) return contiguity
+
+      // SECOND LAYER (retained §1.3): live user-field content must equal the latest captured snapshot.
+      const latest = latestSnapByRecord.get(rid)
+      if (latest && latest.action !== 'delete') {
+        const live = isPlainRecord(row.data) ? row.data : {}
+        const snap = isPlainRecord(latest.snapshot) ? latest.snapshot : {}
+        for (const fid of userFieldIds) {
+          if (canonicalize(live[fid]) !== canonicalize(snap[fid])) return { ok: false, reason: 'content_mismatch' }
+        }
       }
     }
     return { ok: true }
   } catch {
-    // Rule 4 fail-closed: a comparator error is a refusal, never a proceed.
-    return { ok: false, reason: 'comparator_error' }
+    return { ok: false, reason: 'comparator_error' } // rule 4 fail-closed
   }
+}
+
+/** 42P01 = undefined_table — the marker table has not been migrated yet (rolling-deploy window). */
+function isMissingMarkerTable(err: unknown): boolean {
+  const code = (err as { code?: unknown })?.code
+  const message = String((err as { message?: unknown })?.message ?? '')
+  return code === '42P01' || /meta_record_version_markers/.test(message) && /does not exist|undefined table/i.test(message)
 }

--- a/packages/core-backend/src/multitable/history-integrity-precheck.ts
+++ b/packages/core-backend/src/multitable/history-integrity-precheck.ts
@@ -111,19 +111,50 @@ const canonicalize = (v: unknown): string => {
 // ==============================================================================================================
 
 export type ChainEventAction = 'create' | 'update' | 'delete'
-/** A revision chain event. `orderKey` is a monotone tiebreaker (created_at epoch, then version, then id) used
- *  ONLY to decide which event is "latest" for the live-row-after-delete check. */
+/** A revision chain event. `orderKey` is the RAW `created_at` epoch-ms (exact in float64 — never packed with
+ *  the version; see `chainOrderAfter`). Rank + version tiebreaks are compared structurally off the event. */
 export interface ChainEvent {
   version: number
   action: ChainEventAction
   orderKey?: number
 }
 /** A legitimate non-data version bump (lock/unlock) recorded out-of-chain in `meta_record_version_markers`.
- *  `orderKey` (created_at epoch, then version) places the marker in its generation, exactly like a ChainEvent. */
+ *  `orderKey` = raw `created_at` epoch-ms; a marker ranks with updates (it happens on a LIVE row). */
 export interface VersionMarker {
   version: number
   kind: 'lock' | 'unlock'
   orderKey?: number
+}
+
+/**
+ * Total chain order = (created_at epoch-ms, version, non-delete-before-delete), compared STRUCTURALLY.
+ *
+ * Why not a packed numeric key: the previous encoding (`epoch*1e6 + version`) silently LOST the version
+ * tiebreak to float64 precision — at 2026 epochs the scaled value is ~1.7e18 where the ULP is ~256, so
+ * same-millisecond events collapsed to one float and the generation boundary was mis-drawn (CI catch:
+ * undelete-pit scenario (g), a same-ms delete + occupying create). Comments asserting "version is a sub-ms
+ * tiebreaker" were an unverified invariant; this comparator is pinned by same-epoch unit goldens instead.
+ *
+ * Within one millisecond, VERSION is the primary tiebreak: same-epoch multi-vintage churn writes ascending
+ * versions (…delete@2, create@3, delete@4… — 4c-3 §7 realdb goldens construct exactly this at one T), so
+ * ordering by version keeps each create with ITS vintage. A static action rank (e.g. "create after delete")
+ * cannot linearize that shape — it would hoist create@3 past delete@4 into the live generation and refuse
+ * out_of_range. The final leg breaks the delete-REUSE tie only: a delete that reuses version k happens
+ * after the content event at k, so at equal (epoch, version) the delete sorts LAST.
+ *
+ * Known fail-closed residue (C2 docket, NOT solved here): a restore/resurrect create@v1 landing in the SAME
+ * millisecond as the delete it follows is version-below the delete and thus sorts before it — the row
+ * refuses (live_row_after_delete_revision), it is never mis-reconstructed. The packed-float ordering refused
+ * that shape too (collapsed keys), so this is no regression; disambiguating same-ms cross-generation order
+ * needs the C2 time anchor.
+ */
+type ChainOrdered = { version: number; action?: ChainEventAction; orderKey?: number }
+const chainOrderAfter = (a: ChainOrdered, b: ChainOrdered): boolean => {
+  const ta = a.orderKey ?? 0
+  const tb = b.orderKey ?? 0
+  if (ta !== tb) return ta > tb
+  if (a.version !== b.version) return a.version > b.version
+  return a.action === 'delete' && b.action !== 'delete'
 }
 
 export type ContiguityResult = { ok: true } | { ok: false; reason: HistoryIntegrityReason }
@@ -163,16 +194,17 @@ export function checkRecordChainContiguity(
   const anyCreateOrUpdate = events.some((e) => e.action !== 'delete')
   if (!anyCreateOrUpdate && markers.length === 0) return { ok: false, reason: 'zero_revision_live_row' }
 
-  // Generation boundary: the LAST delete (by orderKey) terminates the prior generation; the current
-  // generation is everything strictly after it.
-  let lastDeleteOrderKey = Number.NEGATIVE_INFINITY
+  // Generation boundary: the LAST delete (by chain order) terminates the prior generation; the current
+  // generation is everything strictly after it (structural comparator — see chainOrderAfter).
+  let lastDelete: ChainEvent | null = null
   for (const e of events) {
-    if (e.action === 'delete') lastDeleteOrderKey = Math.max(lastDeleteOrderKey, e.orderKey ?? 0)
+    if (e.action === 'delete' && (lastDelete === null || chainOrderAfter(e, lastDelete))) lastDelete = e
   }
-  const inCurrentGen = (orderKey?: number): boolean => (orderKey ?? 0) > lastDeleteOrderKey
+  const boundary = lastDelete
+  const inCurrentGen = (x: ChainOrdered): boolean => boundary === null || chainOrderAfter(x, boundary)
 
-  const currentGenEvents = events.filter((e) => e.action !== 'delete' && inCurrentGen(e.orderKey))
-  const currentGenMarkers = markers.filter((m) => inCurrentGen(m.orderKey))
+  const currentGenEvents = events.filter((e) => e.action !== 'delete' && inCurrentGen(e))
+  const currentGenMarkers = markers.filter((m) => inCurrentGen(m))
 
   // Current generation empty while the row is LIVE ⇒ the latest chain event is a delete (uncaptured
   // resurrection: history claims dead but the row exists).
@@ -206,10 +238,10 @@ export function checkRecordChainContiguity(
 // ==============================================================================================================
 
 const toNumber = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : Number(v) || 0)
-const orderKeyOf = (createdAt: unknown, version: number): number => {
+/** Raw created_at epoch-ms — exact in float64. NEVER pack version into this (see chainOrderAfter). */
+const epochOf = (createdAt: unknown): number => {
   const t = createdAt instanceof Date ? createdAt.getTime() : Date.parse(String(createdAt ?? ''))
-  // epoch-ms dominates; version is a sub-ms tiebreaker (max ~1e6 versions before it would collide a ms).
-  return (Number.isFinite(t) ? t : 0) * 1e6 + version
+  return Number.isFinite(t) ? t : 0
 }
 
 /**
@@ -247,17 +279,18 @@ export async function precheckSheetHistoryIntegrity(
     )
     type RevRow = { record_id: unknown; version: unknown; action: unknown; snapshot: unknown; created_at: unknown; id: unknown }
     const eventsByRecord = new Map<string, ChainEvent[]>()
-    const latestSnapByRecord = new Map<string, { action: string; snapshot: unknown; orderKey: number }>()
+    const latestSnapByRecord = new Map<string, { action: ChainEventAction; snapshot: unknown; version: number; orderKey: number }>()
     for (const r of revRes.rows as RevRow[]) {
       const rid = String(r.record_id)
       const version = toNumber(r.version)
-      const action = (r.action === 'create' || r.action === 'delete') ? r.action : 'update'
-      const orderKey = orderKeyOf(r.created_at, version)
+      const action: ChainEventAction = (r.action === 'create' || r.action === 'delete') ? r.action : 'update'
+      const orderKey = epochOf(r.created_at)
       const list = eventsByRecord.get(rid) ?? []
       list.push({ version, action, orderKey })
       eventsByRecord.set(rid, list)
       const prev = latestSnapByRecord.get(rid)
-      if (!prev || orderKey > prev.orderKey) latestSnapByRecord.set(rid, { action, snapshot: r.snapshot, orderKey })
+      const cand = { action, snapshot: r.snapshot, version, orderKey }
+      if (!prev || chainOrderAfter(cand, prev)) latestSnapByRecord.set(rid, cand)
     }
 
     // Lock/unlock markers (deploy-window safe: a missing table pre-migration ⇒ no markers ⇒ locked records
@@ -275,7 +308,7 @@ export async function precheckSheetHistoryIntegrity(
         const rid = String(m.record_id)
         const version = toNumber(m.version)
         const list = markersByRecord.get(rid) ?? []
-        list.push({ version, kind: m.kind === 'unlock' ? 'unlock' : 'lock', orderKey: orderKeyOf(m.created_at, version) })
+        list.push({ version, kind: m.kind === 'unlock' ? 'unlock' : 'lock', orderKey: epochOf(m.created_at) })
         markersByRecord.set(rid, list)
       }
     }

--- a/packages/core-backend/src/multitable/record-history-service.ts
+++ b/packages/core-backend/src/multitable/record-history-service.ts
@@ -134,6 +134,46 @@ export async function recordRecordRevision(query: QueryFn, input: RecordRevision
   return id
 }
 
+/**
+ * W0-1 (OD-W0-1 mechanism (b)) — record a lock/unlock version bump as a chain marker in the independent
+ * `meta_record_version_markers` table, so the generation-aware contiguity precheck does not read the bump
+ * as an uncaptured-data-write HOLE. `kind` is 'lock' | 'unlock'. Idempotent (ON CONFLICT DO NOTHING against
+ * the UNIQUE(sheet_id, record_id, version) constraint), so a retry never duplicates.
+ *
+ * Deploy-window safe (mirrors `hasRestoredFromVersionColumn`): the marker table may not exist yet in a
+ * rolling deploy (the zzzz migration lands mid-process). A missing table is probed via a txn-safe
+ * information_schema SELECT (never poisons the enclosing transaction with a 42P01) — if absent, the marker
+ * write is SKIPPED and the lock/unlock version bump still commits. That leaves a transient pre-migration
+ * hole for that record; per the design lock (§1.4) the durable trusted-since watermark that grandfathers
+ * pre-marker holes is C6, explicitly DEFERRED — until then such a record fails CLOSED (refused), never a
+ * silent destructive write.
+ */
+let versionMarkerTablePresent = false
+async function hasVersionMarkerTable(query: QueryFn): Promise<boolean> {
+  if (versionMarkerTablePresent) return true
+  const res = await query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = 'meta_record_version_markers' AND table_schema = ANY(current_schemas(false)) LIMIT 1`,
+  )
+  if ((res.rows as unknown[]).length > 0) {
+    versionMarkerTablePresent = true
+    return true
+  }
+  return false
+}
+
+export async function recordVersionMarker(
+  query: QueryFn,
+  input: { sheetId: string; recordId: string; version: number; kind: 'lock' | 'unlock'; actorId?: string | null },
+): Promise<void> {
+  if (!(await hasVersionMarkerTable(query))) return
+  await query(
+    `INSERT INTO meta_record_version_markers (id, sheet_id, record_id, version, kind, actor_id)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)
+     ON CONFLICT ON CONSTRAINT uq_meta_record_version_markers_sheet_record_version DO NOTHING`,
+    [input.sheetId, input.recordId, input.version, input.kind, input.actorId ?? null],
+  )
+}
+
 export async function listRecordRevisions(
   query: QueryFn,
   input: { sheetId: string; recordId: string; limit?: number; offset?: number },

--- a/packages/core-backend/src/multitable/record-history-service.ts
+++ b/packages/core-backend/src/multitable/record-history-service.ts
@@ -149,7 +149,14 @@ export async function recordRecordRevision(query: QueryFn, input: RecordRevision
  * silent destructive write.
  */
 let versionMarkerTablePresent = false
-async function hasVersionMarkerTable(query: QueryFn): Promise<boolean> {
+/**
+ * Txn-safe existence probe for `meta_record_version_markers`. Uses `information_schema.tables`, which
+ * returns zero rows (never throws `42P01`) when the table is absent — so callers inside a transaction
+ * can gate a direct marker SELECT/INSERT without poisoning the enclosing txn during the pre-migration
+ * rolling-deploy window. Shared by the WRITE path (recordVersionMarker) and the READ path
+ * (history-integrity-precheck) so both avoid the 42P01-abort trap identically.
+ */
+export async function hasVersionMarkerTable(query: QueryFn): Promise<boolean> {
   if (versionMarkerTablePresent) return true
   const res = await query(
     `SELECT 1 FROM information_schema.tables WHERE table_name = 'meta_record_version_markers' AND table_schema = ANY(current_schemas(false)) LIMIT 1`,

--- a/packages/core-backend/src/multitable/system-sheet-predicate.ts
+++ b/packages/core-backend/src/multitable/system-sheet-predicate.ts
@@ -1,0 +1,34 @@
+import { isApprovalProjectionBaseId } from './approval-projection-constants'
+
+/**
+ * W0-1 (owner §6.1) — the ONE `isSystemSheet` predicate. System-regenerated read-models are excluded from
+ * the user-history contiguity model as a SINGLE predicate, not scattered per-site exemptions:
+ *
+ *   isSystemSheet(sheet) = isApprovalProjectionBaseId(base_id) || isSystemPeopleSheetDescription(description)
+ *
+ * The approval-projection base and the system People directory sheet are both server-regenerated read
+ * models (approval reprojection / people-directory sync). They legitimately carry NON-contiguous version
+ * history — a reprojection can rewrite a row's `data` and bump `version` without a user-authored revision —
+ * so the generation-aware contiguity precheck MUST NOT read that as a hole and refuse. They are not part of
+ * the user's Time-Machine history model, so the precheck skips contiguity for them entirely.
+ *
+ * `SYSTEM_PEOPLE_SHEET_DESCRIPTION` + `isSystemPeopleSheetDescription` live HERE (the single source of
+ * truth); `routes/univer-meta.ts` re-imports them so both the People-sheet list-filtering and this
+ * history-exclusion key off the exact same sentinel.
+ */
+
+/** The sentinel `description` the system People directory sheet carries (system read-model). */
+export const SYSTEM_PEOPLE_SHEET_DESCRIPTION = '__metasheet_system:people__'
+
+/** True iff `description` marks the system People directory sheet. */
+export function isSystemPeopleSheetDescription(value: unknown): boolean {
+  return typeof value === 'string' && value.trim() === SYSTEM_PEOPLE_SHEET_DESCRIPTION
+}
+
+/**
+ * True iff the sheet is a system-regenerated read-model excluded from the user-history contiguity model.
+ * Pure — the caller supplies the sheet's `baseId` + `description` (both nullable to tolerate legacy rows).
+ */
+export function isSystemSheet(sheet: { baseId?: string | null; description?: unknown }): boolean {
+  return isApprovalProjectionBaseId(sheet.baseId ?? null) || isSystemPeopleSheetDescription(sheet.description)
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -74,7 +74,8 @@ import { createPersonMemberResolver, personRestrictGroupIds, resolvePersonAssign
 import { resolveUserDisplayNames } from '../multitable/user-display'
 import { loadHistoryBatchSummaries, loadHistoryBatchDetail, estimateHistoryHasMore } from '../multitable/history-projection'
 import { reconstructRecordsAtT } from '../multitable/record-reconstructor'
-import { precheckSheetHistoryIntegrity } from '../multitable/history-integrity-precheck'
+import { precheckSheetHistoryIntegrity, HistoryIncompleteInTxnError } from '../multitable/history-integrity-precheck'
+import { SYSTEM_PEOPLE_SHEET_DESCRIPTION, isSystemPeopleSheetDescription } from '../multitable/system-sheet-predicate'
 import { hashPreviewChanges, hashScope, hashResurrectSet, hashDeleteSet, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity, mintPitRevertPreviewIdentity, verifyPitRevertPreviewIdentity, mintPitResetPreviewIdentity, verifyPitResetPreviewIdentity, mintConfigRestorePreviewIdentity, verifyConfigRestorePreviewIdentity, hashLossSummary, type UncreatePlan, hashUncreatePlan, mintConfigUncreatePreviewIdentity, verifyConfigUncreatePreviewIdentity, type UndeletePlan, hashUndeletePlan, mintConfigUndeletePreviewIdentity, verifyConfigUndeletePreviewIdentity, hashPermissionGrant, mintConfigPermissionRevertPreviewIdentity, verifyConfigPermissionRevertPreviewIdentity } from '../multitable/restore-preview-identity'
 import {
   recordConfigRevision,
@@ -234,7 +235,7 @@ import {
   createYjsInvalidationPostCommitHook,
   type YjsInvalidator,
 } from '../multitable/post-commit-hooks'
-import { listRecordRevisions, recordRecordRevision, type RecordRevisionEntry } from '../multitable/record-history-service'
+import { listRecordRevisions, recordRecordRevision, recordVersionMarker, type RecordRevisionEntry } from '../multitable/record-history-service'
 import { replayInboundLinks, isRecordUndeleteInboundEnabled } from '../multitable/inbound-link-replay'
 import { countInboundLinkCaptureRows, insertInboundLinkTombstones } from '../multitable/tombstone-capture'
 
@@ -462,8 +463,14 @@ type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; r
 
 const DEFAULT_BASE_ID = 'base_legacy'
 const DEFAULT_BASE_NAME = 'Migrated Base'
+// W0-1 C4 fence: fixed namespace int for the per-sheet `pg_advisory_xact_lock` guarding destructive PIT
+// recovery (reset-execute). Paired with `hashtext(sheetId)` as the per-sheet key; two-int advisory lock form
+// keeps this namespace disjoint from any other advisory lock in the codebase.
+const PIT_RECOVERY_LOCK_NS = 0x77303104 // 'w0' + marker; arbitrary fixed int4 namespace
 const SYSTEM_PEOPLE_SHEET_NAME = 'People'
-const SYSTEM_PEOPLE_SHEET_DESCRIPTION = '__metasheet_system:people__'
+// SYSTEM_PEOPLE_SHEET_DESCRIPTION + isSystemPeopleSheetDescription moved to
+// ../multitable/system-sheet-predicate (single source of truth, shared with the W0-1 isSystemSheet
+// history-exclusion predicate); imported at the top of this file.
 const ATTACHMENT_PATH = process.env.ATTACHMENT_PATH || path.join(process.cwd(), 'data', 'attachments')
 const ATTACHMENT_UPLOAD_MAX_SIZE = Number.parseInt(process.env.ATTACHMENT_MAX_SIZE ?? '', 10) || 100 * 1024 * 1024
 const multitableMulter = loadMulter()
@@ -981,10 +988,6 @@ function normalizeJsonArray(value: unknown): string[] {
     }
   }
   return []
-}
-
-function isSystemPeopleSheetDescription(value: unknown): boolean {
-  return typeof value === 'string' && value.trim() === SYSTEM_PEOPLE_SHEET_DESCRIPTION
 }
 
 function filterVisibleSheetRows<T extends { description?: unknown }>(rows: T[]): T[] {
@@ -10424,6 +10427,20 @@ export function univerMetaRouter(): Router {
 
       try {
         await pool.transaction(async ({ query }) => {
+          // W0-1 C4 FENCE (owner §6.2.4): a per-sheet advisory transaction lock, acquired as the FIRST
+          // statement of the destructive transaction. `FOR UPDATE` on scope rows alone does NOT stop a
+          // concurrent NEW-record insert (phantom) landing between the outer/preview check and this write;
+          // the advisory lock serializes recovery operations on the sheet, and combined with the in-txn
+          // re-check below closes the check→write window. Chosen over SERIALIZABLE (lowest blast radius,
+          // does not change global isolation, no serialization-failure retry loop). Namespace int is a fixed
+          // W0-1 constant; `hashtext(sheetId)` is the per-sheet key.
+          await query('SELECT pg_advisory_xact_lock($1::int, hashtext($2)::int)', [PIT_RECOVERY_LOCK_NS, sheetId])
+          // W0-1 C8 (same-txn re-check): re-run the integrity precheck INSIDE the fenced transaction. A
+          // phantom uncaptured write that committed after the outer computeSheetReset precheck (which runs
+          // BEFORE this transaction) is caught HERE — the check and the destructive write are now atomic.
+          // Refusal throws → the whole reset rolls back (zero writes) → mapped to the 409 below.
+          const inTxnIntegrity = await precheckSheetHistoryIntegrity(query, sheetId)
+          if (inTxnIntegrity.ok === false) throw new HistoryIncompleteInTxnError(inTxnIntegrity.reason)
           const baseRow = (await query('SELECT base_id FROM meta_sheets WHERE id = $1', [sheetId])).rows[0] as Record<string, unknown> | undefined
           const baseId = typeof baseRow?.base_id === 'string' ? baseRow.base_id : null
           const lockedRows = affectedIds.length > 0
@@ -10594,6 +10611,9 @@ export function univerMetaRouter(): Router {
           }
         })
       } catch (err) {
+        // W0-1 C8: the in-txn integrity re-check refused — the whole reset rolled back (zero writes). Map to
+        // the same values-free 409 as the outer precheck (no denied-record oracle, no token).
+        if (err instanceof HistoryIncompleteInTxnError) return sendHistoryIncomplete(res)
         if (err instanceof ServiceVersionConflictError || err instanceof RecordServiceVersionConflictError) {
           return res.status(409).json({ ok: false, error: { code: 'PREVIEW_IDENTITY_INVALID', message: 'Reset target changed since preview; nothing written — re-preview.' } })
         }
@@ -16431,13 +16451,19 @@ export function univerMetaRouter(): Router {
           return sendForbidden(res, 'Record editing is not allowed for this row')
         }
         const lockedBy = actorId ?? access.userId
-        // lock-mgmt: LOCK action — sets the lock columns (own canEditRecord authority above).
-        // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
-        await pool.query(
-          `UPDATE meta_records SET locked = true, locked_by = $2, locked_at = NOW(), version = version + 1, updated_at = NOW()
-           WHERE id = $1 AND sheet_id = $3`,
-          [recordId, lockedBy, sheetId],
-        )
+        // W0-1: the version bump is a legitimate NON-data event; write a lock marker at the new version (same
+        // txn) so the generation-aware contiguity precheck reads it as a marker, not an uncaptured-write hole.
+        await pool.transaction(async ({ query }) => {
+          // lock-mgmt: LOCK action — sets the lock columns (own canEditRecord authority above).
+          // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
+          const upd = await query(
+            `UPDATE meta_records SET locked = true, locked_by = $2, locked_at = NOW(), version = version + 1, updated_at = NOW()
+             WHERE id = $1 AND sheet_id = $3 RETURNING version`,
+            [recordId, lockedBy, sheetId],
+          )
+          const newVersion = Number((upd.rows[0] as { version?: unknown } | undefined)?.version)
+          if (Number.isFinite(newVersion)) await recordVersionMarker(query, { sheetId, recordId, version: newVersion, kind: 'lock', actorId: actorId ?? access.userId ?? null })
+        })
       } else {
         // UNLOCK: must pass canUnlock (locker ∨ owner ∨ sheet-admin).
         if (!canUnlock(actorId ?? access.userId ?? null, {
@@ -16446,13 +16472,19 @@ export function univerMetaRouter(): Router {
         }, capabilities)) {
           return sendForbidden(res, 'Not allowed to unlock this record')
         }
-        // lock-mgmt: UNLOCK action — clears the lock columns (own canUnlock authority above).
-        // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
-        await pool.query(
-          `UPDATE meta_records SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()
-           WHERE id = $1 AND sheet_id = $2`,
-          [recordId, sheetId],
-        )
+        // W0-1: write an unlock marker at the new version (same txn) — the version bump is a legitimate
+        // non-data event, not an uncaptured-write hole for the contiguity precheck.
+        await pool.transaction(async ({ query }) => {
+          // lock-mgmt: UNLOCK action — clears the lock columns (own canUnlock authority above).
+          // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
+          const upd = await query(
+            `UPDATE meta_records SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()
+             WHERE id = $1 AND sheet_id = $2 RETURNING version`,
+            [recordId, sheetId],
+          )
+          const newVersion = Number((upd.rows[0] as { version?: unknown } | undefined)?.version)
+          if (Number.isFinite(newVersion)) await recordVersionMarker(query, { sheetId, recordId, version: newVersion, kind: 'unlock', actorId: actorId ?? access.userId ?? null })
+        })
       }
 
       const after = await pool.query('SELECT locked, locked_by, locked_at FROM meta_records WHERE id = $1', [recordId])

--- a/packages/core-backend/tests/integration/multitable-history-contiguity-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-contiguity-realdb.test.ts
@@ -1,0 +1,303 @@
+/**
+ * W0-1 — generation-aware history contiguity (real DB, real routes). The owner-directed correction of §0.6:
+ * the precheck's PRIMARY integrity proof is now CONTIGUITY (every version in the current generation is
+ * accounted for by exactly one chain event or a lock/unlock marker), replacing #4234's live-vs-latest
+ * comparator. Design lock: multitable-global-history-w0-1-...-design-lock-20260713.md (§6 owner ruling).
+ *
+ * Goldens (owner rubric; each mutation-proven — see the PR for the mutation matrix):
+ *   HEALED-GAP (fail-first, #4252 §6.1)  v3 record, revisions {v1,v3}, live==v3 → revert/reset preview AND
+ *       execute ALL 409, zero writes. A live-vs-latest comparator PASSES this; contiguity refuses it.
+ *   LOCK-MARKERS (positive control)      a healthy record version-bumped by EACH of the FOUR lock/unlock
+ *       sites (HTTP lock, HTTP unlock, automation lock, automation unlock) writes a marker → precheck PASSES.
+ *       Without this leg a refuse-everything impl would pass HEALED-GAP.
+ *   SYSTEM-SHEET EXCLUDED                a non-contiguous record on an approval-projection base sheet AND on a
+ *       people-directory sheet is NOT refused (isSystemSheet skip).
+ *   DELETE-REUSE                         a record created→updated→deleted (delete revision REUSES the last live
+ *       version) leaves a healthy sibling revert/reset-able (delete-reuse is not a false hole).
+ *   PHANTOM-INSERT RACE (C4/C8)          a constructed two-connection race: a phantom uncaptured record inserted
+ *       while reset-execute is blocked on the per-sheet advisory fence is caught by the in-txn re-check → 409,
+ *       zero destructive writes. Proves the advisory lock is on the destructive path AND the check/write are atomic.
+ *   POSITIVE CONTROL                     a full healthy chain reverts/executes at any T.
+ *
+ * Two-point wiring: plugin-tests.yml real-DB run list + vitest.integration.config.ts. Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { AutomationExecutor, type AutomationDeps, type AutomationRule } from '../../src/multitable/automation-executor'
+import { EventBus } from '../../src/integration/events/event-bus'
+import { APPROVAL_PROJECTION_BASE_ID } from '../../src/multitable/approval-projection-constants'
+import { SYSTEM_PEOPLE_SHEET_DESCRIPTION } from '../../src/multitable/system-sheet-predicate'
+import { precheckSheetHistoryIntegrity } from '../../src/multitable/history-integrity-precheck'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_hc_${TS}`
+const SHEET = `sheet_hc_${TS}`
+const SHEET_PROJ = `sheet_hc_proj_${TS}`   // system sheet: base_id = approval projection base
+const SHEET_PEOPLE = `sheet_hc_people_${TS}` // system sheet: description = people sentinel
+const NAME = `fld_hc_name_${TS}`, SALARY = `fld_hc_salary_${TS}`
+const PNAME = `fld_hc_pname_${TS}`
+const ACTOR = `user_hc_${TS}`
+const T0 = '2026-01-01T00:00:00.000Z', T1 = '2026-01-02T00:00:00.000Z', T2 = '2026-01-03T00:00:00.000Z'
+const NS = 0x77303104 // PIT_RECOVERY_LOCK_NS (must match univer-meta.ts)
+
+const HISTORY_INCOMPLETE_BODY = {
+  ok: false,
+  error: {
+    code: 'HISTORY_INCOMPLETE',
+    message: 'Record history for this sheet is incomplete or inconsistent with its live data; destructive recovery is refused and nothing was written. History must be trustworthy before revert/reset can run.',
+  },
+}
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+const revertPreview = (sheet: string, asOf = T1) => request(app).post(`/api/multitable/sheets/${sheet}/revert-preview`).send({ asOf })
+const revertExecute = (sheet: string, previewIdentity: string, asOf = T1) => request(app).post(`/api/multitable/sheets/${sheet}/revert-execute`).send({ asOf, previewIdentity })
+const resetPreview = (sheet: string, asOf = T1) => request(app).post(`/api/multitable/sheets/${sheet}/reset-preview`).send({ asOf })
+const resetExecute = (sheet: string, previewIdentity: string, asOf = T1) => request(app).post(`/api/multitable/sheets/${sheet}/reset-execute`).send({ asOf, previewIdentity, confirm: 'reset' })
+const lockRecord = (id: string, locked: boolean) => request(app).post(`/api/multitable/records/${id}/lock`).send({ locked })
+
+const rev = (sheet: string, id: string, version: number, action: string, snap: Record<string, unknown>, at: string) =>
+  q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[]::text[],'{}'::jsonb,$5::jsonb,$6)`, [sheet, id, version, action, JSON.stringify(snap), at])
+const insertLive = (sheet: string, id: string, data: Record<string, unknown>, version: number) =>
+  q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,$4)', [id, sheet, JSON.stringify(data), version])
+const markerCount = async (sheet: string, id: string, version: number): Promise<number> =>
+  Number(((await q('SELECT count(*)::int c FROM meta_record_version_markers WHERE sheet_id=$1 AND record_id=$2 AND version=$3', [sheet, id, version])).rows[0] as { c: number }).c)
+const recordRow = async (id: string) => (await q('SELECT data, version FROM meta_records WHERE id = $1', [id])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function sheetWriteState(sheet: string) {
+  const records = (await q('SELECT id, data, version FROM meta_records WHERE sheet_id = $1 ORDER BY id', [sheet])).rows
+  const revisionCount = Number(((await q('SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1', [sheet])).rows[0] as { c: number }).c)
+  const trashCount = Number(((await q('SELECT count(*)::int c FROM meta_records_trash WHERE sheet_id = $1', [sheet])).rows[0] as { c: number }).c)
+  return { records, revisionCount, trashCount }
+}
+
+async function expectAllFourRefuseWithZeroWrites(sheet: string): Promise<void> {
+  const before = await sheetWriteState(sheet)
+  const pvRevert = await revertPreview(sheet)
+  expect(pvRevert.status).toBe(409); expect(pvRevert.body).toEqual(HISTORY_INCOMPLETE_BODY)
+  const exRevert = await revertExecute(sheet, 'dummy-never-minted')
+  expect(exRevert.status).toBe(409); expect(exRevert.body).toEqual(HISTORY_INCOMPLETE_BODY)
+  const pvReset = await resetPreview(sheet)
+  expect(pvReset.status).toBe(409); expect(pvReset.body).toEqual(HISTORY_INCOMPLETE_BODY)
+  const exReset = await resetExecute(sheet, 'dummy-never-minted')
+  expect(exReset.status).toBe(409); expect(exReset.body).toEqual(HISTORY_INCOMPLETE_BODY)
+  expect(await sheetWriteState(sheet)).toEqual(before)
+}
+
+function makeAutomationExecutor(): AutomationExecutor {
+  const deps: AutomationDeps = { eventBus: new EventBus(), queryFn: (sql: string, params?: unknown[]) => q(sql, params ?? []) }
+  return new AutomationExecutor(deps)
+}
+const lockRule = (locked: boolean): AutomationRule => ({
+  id: `axr_hc_${TS}_${Math.random().toString(36).slice(2, 8)}`,
+  name: 'hc-lock', sheetId: SHEET, enabled: true, trigger: { type: 'record.updated', config: {} },
+  actions: [{ type: 'lock_record', config: { locked } } as never],
+  createdBy: ACTOR, createdAt: new Date().toISOString(),
+} as unknown as AutomationRule)
+
+describeIfDatabase('W0-1 generation-aware history contiguity (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'HC Base'])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2) ON CONFLICT (id) DO NOTHING', [APPROVAL_PROJECTION_BASE_ID, 'Approval Projection']) // shared system base
+    // plain sheet + a projection-base sheet + a people-sentinel sheet
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3),($4,$5,$6)', [SHEET, BASE, 'HC', SHEET_PROJ, APPROVAL_PROJECTION_BASE_ID, 'HC Proj'])
+    await q('INSERT INTO meta_sheets (id, base_id, name, description) VALUES ($1,$2,$3,$4)', [SHEET_PEOPLE, BASE, 'People', SYSTEM_PEOPLE_SHEET_DESCRIPTION])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [NAME, SHEET, 'Name', 'string', '{}', 1])
+    for (const s of [SHEET_PROJ, SHEET_PEOPLE]) {
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [`${NAME}_${s}`, s, 'Name', 'string', '{}', 1])
+    }
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [SALARY, SHEET, 'Salary', 'number', '{}', 2])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+  })
+  afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_PIT_RESET
+    for (const sheet of [SHEET, SHEET_PROJ, SHEET_PEOPLE]) {
+      for (const t of ['meta_record_version_markers', 'meta_records_trash', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [sheet]).catch(() => {})
+      await q('DELETE FROM meta_sheets WHERE id = $1', [sheet]).catch(() => {})
+    }
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+  beforeEach(async () => {
+    process.env.MULTITABLE_ENABLE_PIT_RESET = 'true'
+    for (const sheet of [SHEET, SHEET_PROJ, SHEET_PEOPLE]) {
+      await q('DELETE FROM meta_record_version_markers WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [sheet])
+      await q('DELETE FROM meta_records WHERE sheet_id = $1', [sheet])
+    }
+    // H — the healthy captured record shared by scenarios (old@T0 → new@T2), contiguous chain.
+    await insertLive(SHEET, `rec_h_${TS}`, { [NAME]: 'new', [SALARY]: 200 }, 2)
+    await rev(SHEET, `rec_h_${TS}`, 1, 'create', { [NAME]: 'old', [SALARY]: 100 }, T0)
+    await rev(SHEET, `rec_h_${TS}`, 2, 'update', { [NAME]: 'new', [SALARY]: 200 }, T2)
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  // ── HEALED-GAP (fail-first, ported verbatim from #4252 §6.1) ──────────────────────────────────────────────
+  test('HEALED-GAP: v3 record with revisions {v1,v3} (v2 uncaptured) → all four surfaces refuse, zero writes', async () => {
+    const HG = `rec_hi_healedgap_${TS}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,3)', [HG, SHEET, JSON.stringify({ [NAME]: 'hg-v3-healed', [SALARY]: 300 })])
+    await rev(SHEET, HG, 1, 'create', { [NAME]: 'hg-v1', [SALARY]: 100 }, T0)
+    await rev(SHEET, HG, 3, 'update', { [NAME]: 'hg-v3-healed', [SALARY]: 300 }, T2) // NO v2 — uncaptured mid-chain write
+    expect((await recordRow(HG))?.version).toBe(3)
+    expect(Number(((await q('SELECT count(*)::int c FROM meta_record_revisions WHERE record_id=$1', [HG])).rows[0] as { c: number }).c)).toBe(2)
+    // T1 ∈ (v1@T0, v3@T2) — the gap window. Contiguity refuses; a live-vs-latest comparator alone does not.
+    await expectAllFourRefuseWithZeroWrites(SHEET)
+  })
+
+  // ── LOCK-MARKERS positive control (all FOUR lock/unlock sites) ────────────────────────────────────────────
+  test('LOCK-MARKERS: a healthy record bumped by ALL FOUR lock/unlock sites writes markers → precheck PASSES', async () => {
+    const L = `rec_hc_lock_${TS}`
+    await insertLive(SHEET, L, { [NAME]: 'lk' }, 1)
+    await rev(SHEET, L, 1, 'create', { [NAME]: 'lk' }, T0)
+    // HTTP lock (1→2) + HTTP unlock (2→3)
+    expect((await lockRecord(L, true)).status).toBe(200)
+    expect((await lockRecord(L, false)).status).toBe(200)
+    // automation lock (3→4) + automation unlock (4→5) — REAL AutomationExecutor, same-base lock_record.
+    const exec = makeAutomationExecutor()
+    expect((await exec.execute(lockRule(true), { recordId: L, sheetId: SHEET, actorId: ACTOR, data: {} })).steps[0]?.status).toBe('success')
+    expect((await exec.execute(lockRule(false), { recordId: L, sheetId: SHEET, actorId: ACTOR, data: {} })).steps[0]?.status).toBe('success')
+    const after = await recordRow(L)
+    expect(after?.version).toBe(5) // four legitimate non-data version bumps
+    // Each bump wrote its marker (2,3 = HTTP; 4,5 = automation). This is what makes them not-a-hole.
+    for (const v of [2, 3, 4, 5]) expect(await markerCount(SHEET, L, v)).toBe(1)
+    // precheck PASSES: markers fill v2..v5, create fills v1 → contiguous. Revert previews + executes.
+    const pv = await revertPreview(SHEET)
+    expect(pv.status).toBe(200)
+    expect(pv.body?.data?.previewIdentity).toBeTruthy()
+    const ex = await revertExecute(SHEET, pv.body?.data?.previewIdentity)
+    expect(ex.status).toBe(200)
+    const l = await recordRow(L)
+    expect(l?.data?.[NAME]).toBe('lk') // L untouched by the revert (already at its T1 state)
+  })
+
+  test('LOCK-MARKERS mutation surface: a lock bump with the marker DELETED becomes a hole → refused', async () => {
+    // Simulates the mutation "remove the lock-marker write": the version bumped but no marker exists ⇒ hole.
+    const L = `rec_hc_lockmut_${TS}`
+    await insertLive(SHEET, L, { [NAME]: 'lk' }, 1)
+    await rev(SHEET, L, 1, 'create', { [NAME]: 'lk' }, T0)
+    expect((await lockRecord(L, true)).status).toBe(200) // 1→2, marker@2 written
+    await q('DELETE FROM meta_record_version_markers WHERE sheet_id=$1 AND record_id=$2', [SHEET, L]) // neuter the marker
+    await expectAllFourRefuseWithZeroWrites(SHEET) // v2 is now an unexplained hole
+  })
+
+  // ── SYSTEM-SHEET EXCLUSION ───────────────────────────────────────────────────────────────────────────────
+  test('SYSTEM-SHEET (approval projection base): a non-contiguous record is EXCLUDED by the precheck (direct call — the base ALSO capability-fences non-admins at the route)', async () => {
+    // The approval-projection base denies canManageSheetAccess to non-admins (403 at the route BEFORE the
+    // precheck), so the isSystemSheet SKIP is proven at the precheck itself: the same non-contiguous shape
+    // that refuses on a plain sheet passes on the projection-base sheet.
+    const R = `rec_hc_proj_${TS}`
+    const f = `${NAME}_${SHEET_PROJ}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,3)', [R, SHEET_PROJ, JSON.stringify({ [f]: 'v3' })])
+    await rev(SHEET_PROJ, R, 1, 'create', { [f]: 'v1' }, T0)
+    await rev(SHEET_PROJ, R, 3, 'update', { [f]: 'v3' }, T2) // hole at v2
+    const pool = poolManager.get()
+    expect(await precheckSheetHistoryIntegrity(pool.query.bind(pool), SHEET_PROJ)).toEqual({ ok: true }) // excluded
+    // Discriminator: the SAME non-contiguous shape on the plain (non-system) SHEET refuses.
+    const R2 = `rec_hc_proj_ctrl_${TS}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,3)', [R2, SHEET, JSON.stringify({ [NAME]: 'v3' })])
+    await rev(SHEET, R2, 1, 'create', { [NAME]: 'v1' }, T0)
+    await rev(SHEET, R2, 3, 'update', { [NAME]: 'v3' }, T2)
+    expect(await precheckSheetHistoryIntegrity(pool.query.bind(pool), SHEET)).toEqual({ ok: false, reason: 'chain_hole' })
+  })
+
+  test('SYSTEM-SHEET (people directory): a non-contiguous record is NOT refused (isSystemSheet skip)', async () => {
+    const R = `rec_hc_people_${TS}`
+    const f = `${NAME}_${SHEET_PEOPLE}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,3)', [R, SHEET_PEOPLE, JSON.stringify({ [f]: 'v3' })])
+    await rev(SHEET_PEOPLE, R, 1, 'create', { [f]: 'v1' }, T0)
+    await rev(SHEET_PEOPLE, R, 3, 'update', { [f]: 'v3' }, T2)
+    const pv = await revertPreview(SHEET_PEOPLE)
+    expect(pv.status).toBe(200)
+  })
+
+  // ── DELETE-REUSE ─────────────────────────────────────────────────────────────────────────────────────────
+  test('DELETE-REUSE: a deleted record whose delete revision REUSES the last live version is not a false hole', async () => {
+    // DR: create@1, update@2, then a DELETE that reuses v2 (the record-service delete shape). DR is gone
+    // (in trash), NOT live — its delete-reuse revision must not false-refuse the healthy live sibling H.
+    const DR = `rec_hc_delreuse_${TS}`
+    await rev(SHEET, DR, 1, 'create', { [NAME]: 'dr1', [SALARY]: 1 }, T0)
+    await rev(SHEET, DR, 2, 'update', { [NAME]: 'dr2', [SALARY]: 2 }, T2)
+    await rev(SHEET, DR, 2, 'delete', { [NAME]: 'dr2', [SALARY]: 2 }, T2) // delete REUSES version 2 (not v3)
+    // DR is deleted (no live row); only the healthy H is live. Contiguity is per-record + live-only.
+    const pv = await revertPreview(SHEET)
+    expect(pv.status).toBe(200) // H is contiguous; DR's delete-reuse revision is not enumerated (not live)
+    expect(pv.body?.data?.summary?.visibleRevertCount).toBe(1) // H → old
+  })
+
+  // ── PHANTOM-INSERT RACE (C4/C8, constructed two-connection race) ─────────────────────────────────────────
+  test('PHANTOM-INSERT RACE: a phantom uncaptured record landing while reset-execute holds the fence is caught in-txn → 409, zero destructive writes', async () => {
+    // A healthy delete-candidate D (created AFTER T1 ⇒ reset-to-T1 would DELETE it). History complete at preview.
+    const D = `rec_hc_delcand_${TS}`
+    await insertLive(SHEET, D, { [NAME]: 'delme' }, 1)
+    await rev(SHEET, D, 1, 'create', { [NAME]: 'delme' }, T2) // created after T1
+    const pv = await resetPreview(SHEET)
+    expect(pv.status).toBe(200)
+    const identity = pv.body?.data?.previewIdentity as string
+    expect(identity).toBeTruthy()
+    expect(pv.body?.data?.deleteRecordIds).toContain(D)
+
+    // Connection B holds the sheet's advisory fence open until we release it.
+    let release: () => void = () => {}
+    const held = new Promise<void>((r) => { release = r })
+    const bDone = poolManager.get().transaction(async ({ query }) => {
+      await query('SELECT pg_advisory_xact_lock($1::int, hashtext($2)::int)', [NS, SHEET])
+      await held
+    })
+    const advisory = async (granted: boolean): Promise<number> =>
+      Number(((await q(`SELECT count(*)::int c FROM pg_locks WHERE locktype='advisory' AND classid=$1 AND granted=$2`, [NS, granted])).rows[0] as { c: number }).c)
+    const waitFor = async (pred: () => Promise<boolean>, label: string) => {
+      for (let i = 0; i < 300; i++) { if (await pred()) return; await sleep(15) }
+      throw new Error(`timeout waiting for ${label}`)
+    }
+    let res: request.Response | undefined
+    try {
+      await waitFor(async () => (await advisory(true)) >= 1, 'B holds the advisory lock')
+      // Fire reset-execute: it passes the OUTER precheck (history complete, no phantom yet), enters the
+      // destructive txn, and BLOCKS acquiring the advisory fence B holds. `.then((r) => r)` DISPATCHES the
+      // (lazy) supertest request immediately and returns a real Promise we can race/await.
+      const resetP: Promise<request.Response> = resetExecute(SHEET, identity).then((r) => r)
+      await waitFor(async () => (await advisory(false)) >= 1, 'reset-execute blocked on the fence')
+      // PROVE the fence is on the destructive path: reset has NOT completed while B holds the lock.
+      const pending = await Promise.race([resetP.then(() => 'done'), sleep(150).then(() => 'pending')])
+      expect(pending).toBe('pending')
+      // The phantom uncaptured write lands NOW (after the outer precheck already passed) and commits.
+      const PH = `rec_hc_phantom_${TS}`
+      await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,3)', [PH, SHEET, JSON.stringify({ [NAME]: 'phantom' })])
+      await rev(SHEET, PH, 1, 'create', { [NAME]: 'ph1' }, T0)
+      await rev(SHEET, PH, 3, 'update', { [NAME]: 'phantom' }, T2) // hole at v2
+      release() // reset acquires the fence → runs the in-txn re-check → sees the phantom → refuses
+      res = await resetP
+    } finally {
+      release()
+      await bDone.catch(() => {})
+    }
+    expect(res!.status).toBe(409)
+    expect(res!.body).toEqual(HISTORY_INCOMPLETE_BODY)
+    expect(await recordRow(D)).toBeTruthy() // D was NOT deleted — the in-txn re-check rolled the whole reset back
+  })
+
+  // ── GLOBAL POSITIVE CONTROL ──────────────────────────────────────────────────────────────────────────────
+  test('POSITIVE CONTROL: a full healthy chain reverts and executes at T (guards against refuse-everything)', async () => {
+    const pv = await revertPreview(SHEET)
+    expect(pv.status).toBe(200)
+    expect(pv.body?.data?.summary?.visibleRevertCount).toBe(1)
+    const ex = await revertExecute(SHEET, pv.body?.data?.previewIdentity)
+    expect(ex.status).toBe(200)
+    const h = await recordRow(`rec_h_${TS}`)
+    expect(h?.data?.[NAME]).toBe('old')
+    expect(h?.version).toBe(3)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-history-contiguity-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-contiguity-realdb.test.ts
@@ -122,6 +122,7 @@ describeIfDatabase('W0-1 generation-aware history contiguity (real DB)', () => {
   })
   afterAll(async () => {
     delete process.env.MULTITABLE_ENABLE_PIT_RESET
+    delete process.env.MULTITABLE_ENABLE_SHEET_REVERT
     for (const sheet of [SHEET, SHEET_PROJ, SHEET_PEOPLE]) {
       for (const t of ['meta_record_version_markers', 'meta_records_trash', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [sheet]).catch(() => {})
       await q('DELETE FROM meta_sheets WHERE id = $1', [sheet]).catch(() => {})
@@ -131,6 +132,9 @@ describeIfDatabase('W0-1 generation-aware history contiguity (real DB)', () => {
   })
   beforeEach(async () => {
     process.env.MULTITABLE_ENABLE_PIT_RESET = 'true'
+    // #4261 (landed mid-flight on main) closes revert-execute by default behind this master gate;
+    // these goldens assert the CONTIGUITY precheck's verdicts, so the interim gate must be open.
+    process.env.MULTITABLE_ENABLE_SHEET_REVERT = 'true'
     for (const sheet of [SHEET, SHEET_PROJ, SHEET_PEOPLE]) {
       await q('DELETE FROM meta_record_version_markers WHERE sheet_id = $1', [sheet]).catch(() => {})
       await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [sheet]).catch(() => {})

--- a/packages/core-backend/tests/unit/multitable-history-contiguity.test.ts
+++ b/packages/core-backend/tests/unit/multitable-history-contiguity.test.ts
@@ -80,4 +80,59 @@ describe('W0-1 checkRecordChainContiguity — generation-aware exact-set', () =>
   test('a live version < 1 is refused defensively', () => {
     expect(checkRecordChainContiguity(0, [ev(1, 'create', 0)], [])).toEqual({ ok: false, reason: 'chain_hole' })
   })
+
+  // ============================================================================================================
+  // SAME-EPOCH ordering goldens — REAL-magnitude epochs on purpose. The first implementation packed the order
+  // key as `epoch*1e6 + version` in a float64: at 2026 epochs that is ~1.7e18 where the float ULP is ~256, so
+  // the version tiebreak was silently annihilated and same-millisecond delete+create pairs collapsed to ONE
+  // order position → the generation boundary was mis-drawn → false HISTORY_INCOMPLETE (caught by CI in
+  // undelete-pit scenario (g), invisible to small-integer orderKeys). These goldens pin the structural
+  // comparator (epoch, version, non-delete-before-delete) at realistic magnitudes.
+  // ============================================================================================================
+  const T2026 = Date.parse('2026-01-03T00:00:00.000Z') // 1767398400000 — the magnitude that broke the packed key
+
+  test('SAME-EPOCH: delete@2 + occupying create@7 in one ms → the create IS the current generation (CI catch)', () => {
+    expect(checkRecordChainContiguity(7, [
+      ev(1, 'create', Date.parse('2026-01-01T00:00:00.000Z')), ev(2, 'delete', T2026), ev(7, 'create', T2026),
+    ], [])).toEqual({ ok: true })
+  })
+
+  test('SAME-EPOCH multi-vintage churn: delete@2, create@3, delete@4 all in one ms + later resurrect → passes', () => {
+    // 4c-3 §7 realdb goldens construct exactly this (a re-create at exactly T between two same-T deletes).
+    // Version order (2→3→4) keeps create@3 with ITS (closed) vintage; a static "create after delete" action
+    // rank would hoist create@3 past delete@4 into the live generation and refuse out_of_range_version —
+    // that mis-ordering shipped briefly and red-flagged the 4c-3 suite; this golden pins the compat shape.
+    expect(checkRecordChainContiguity(1, [
+      ev(1, 'create', T2026 + 86_400_000), // the live resurrect create@v1, a day later
+      ev(1, 'create', T2026 - 86_400_000), ev(2, 'delete', T2026), ev(3, 'create', T2026), ev(4, 'delete', T2026),
+    ], [])).toEqual({ ok: true })
+  })
+
+  test('SAME-EPOCH: update@2 then delete@2 (version REUSE) in one ms → the delete sorts last; update stays prior-gen', () => {
+    // At equal (epoch, version) the delete comes after the content event whose version it reuses. If the
+    // same-ms update leaked into the current generation, genStart=1 with an occupant@2 > liveVersion 1
+    // would refuse out_of_range_version.
+    expect(checkRecordChainContiguity(1, [
+      ev(1, 'create', T2026 - 1000), ev(2, 'update', T2026), ev(2, 'delete', T2026), ev(1, 'create', T2026 + 1000),
+    ], [])).toEqual({ ok: true })
+  })
+
+  test('SAME-EPOCH fail-closed residue (C2 docket): restore create@1 in the SAME ms as the delete@5 it follows → refused', () => {
+    // Version order puts create@1 before delete@5, so the live row's generation looks empty — the comparator
+    // CANNOT disambiguate same-ms cross-generation order without the C2 time anchor (deferred). Fail-closed
+    // (refusal, zero writes) is the pinned interim behavior; the packed-float ordering refused this shape too,
+    // so this is not a regression. If C2 later solves it, flip this golden to ok:true deliberately.
+    expect(checkRecordChainContiguity(1, [
+      ev(1, 'create', T2026 - 1000), ev(5, 'update', T2026 - 500), ev(5, 'delete', T2026), ev(1, 'create', T2026),
+    ], [])).toEqual({ ok: false, reason: 'live_row_after_delete_revision' })
+  })
+
+  test('SAME-EPOCH negative control: the boundary is not blind — a hole in the live generation is still caught', () => {
+    // Same-ms churn (delete@2/create@3/delete@4), then the live generation opens create@1 and jumps to
+    // update@3 (v2 missing) ⇒ hole.
+    expect(checkRecordChainContiguity(3, [
+      ev(1, 'create', T2026 - 86_400_000), ev(2, 'delete', T2026), ev(3, 'create', T2026), ev(4, 'delete', T2026),
+      ev(1, 'create', T2026 + 1000), ev(3, 'update', T2026 + 2000),
+    ], [])).toEqual({ ok: false, reason: 'chain_hole' })
+  })
 })

--- a/packages/core-backend/tests/unit/multitable-history-contiguity.test.ts
+++ b/packages/core-backend/tests/unit/multitable-history-contiguity.test.ts
@@ -1,0 +1,83 @@
+/**
+ * W0-1 — generation-aware contiguity, the PURE core (`checkRecordChainContiguity`). Unit-level, no DB, so the
+ * exact-set / generation / delete-reuse semantics are pinned deterministically and are mutation-friendly:
+ * the DB goldens (multitable-history-contiguity-realdb.test.ts) exercise the same logic end-to-end.
+ *
+ * `orderKey` is a monotone temporal position (created_at epoch, then version). Here we pass small integers to
+ * express the temporal order of events within a record's lifetime.
+ */
+import { describe, expect, test } from 'vitest'
+
+import { checkRecordChainContiguity, type ChainEvent, type VersionMarker } from '../../src/multitable/history-integrity-precheck'
+
+const ev = (version: number, action: ChainEvent['action'], orderKey: number): ChainEvent => ({ version, action, orderKey })
+const mk = (version: number, kind: VersionMarker['kind'], orderKey: number): VersionMarker => ({ version, kind, orderKey })
+
+describe('W0-1 checkRecordChainContiguity — generation-aware exact-set', () => {
+  test('healthy single-generation chain passes (positive control)', () => {
+    expect(checkRecordChainContiguity(2, [ev(1, 'create', 0), ev(2, 'update', 1)], [])).toEqual({ ok: true })
+  })
+
+  test('THE HEALED-GAP: v3 record with revisions {v1, v3} (v2 uncaptured) → chain_hole', () => {
+    // The exact design-flaw the whole slice exists to catch. A live-vs-latest comparator PASSES this (live == v3).
+    expect(checkRecordChainContiguity(3, [ev(1, 'create', 0), ev(3, 'update', 2)], [])).toEqual({ ok: false, reason: 'chain_hole' })
+  })
+
+  test('the same v2 hole HEALED by a lock marker → passes (marker is a legitimate non-data bump)', () => {
+    expect(checkRecordChainContiguity(3, [ev(1, 'create', 0), ev(3, 'update', 2)], [mk(2, 'lock', 1)])).toEqual({ ok: true })
+  })
+
+  test('healthy record locked then unlocked (two markers fill v2 + v3) → passes', () => {
+    expect(checkRecordChainContiguity(3, [ev(1, 'create', 0)], [mk(2, 'lock', 1), mk(3, 'unlock', 2)])).toEqual({ ok: true })
+  })
+
+  test('zero-revision live row (uncaptured CREATE fingerprint) → zero_revision_live_row', () => {
+    expect(checkRecordChainContiguity(1, [], [])).toEqual({ ok: false, reason: 'zero_revision_live_row' })
+  })
+
+  test('duplicate create/update at one version → duplicate_version_event (C5, count-based would miss)', () => {
+    expect(checkRecordChainContiguity(2, [ev(1, 'create', 0), ev(2, 'update', 1), ev(2, 'update', 2)], []))
+      .toEqual({ ok: false, reason: 'duplicate_version_event' })
+  })
+
+  test('an event beyond the live version → out_of_range_version (C5)', () => {
+    expect(checkRecordChainContiguity(2, [ev(1, 'create', 0), ev(2, 'update', 1), ev(3, 'update', 2)], []))
+      .toEqual({ ok: false, reason: 'out_of_range_version' })
+  })
+
+  test('a marker beyond the live version → out_of_range_version', () => {
+    expect(checkRecordChainContiguity(1, [ev(1, 'create', 0)], [mk(2, 'lock', 1)]))
+      .toEqual({ ok: false, reason: 'out_of_range_version' })
+  })
+
+  test('live row whose latest event is a DELETE (uncaptured resurrection) → live_row_after_delete_revision', () => {
+    expect(checkRecordChainContiguity(1, [ev(1, 'create', 0), ev(1, 'delete', 1)], []))
+      .toEqual({ ok: false, reason: 'live_row_after_delete_revision' })
+  })
+
+  test('GENERATION: a trash-restored record (create/delete/create) → passes on its CURRENT generation', () => {
+    // create@1 (gen1) → delete@1 (gen1 terminates, reuses v1) → create@1 (gen2 = current, restore at v1).
+    // A non-generation-aware "duplicate create at v1" criterion would FALSELY refuse this common case.
+    expect(checkRecordChainContiguity(1, [ev(1, 'create', 0), ev(1, 'delete', 1), ev(1, 'create', 2)], []))
+      .toEqual({ ok: true })
+  })
+
+  test('GENERATION + DELETE-REUSE: prior generation update@2+delete@2 (reuse), restored then updated → passes', () => {
+    // gen1: create@1, update@2, delete@2 (delete REUSES v2). gen2 (current): create@1 (restore), update@2.
+    // Proves delete-reuse in the prior generation does not become a false hole/duplicate for the current one.
+    expect(checkRecordChainContiguity(2, [
+      ev(1, 'create', 0), ev(2, 'update', 1), ev(2, 'delete', 2), ev(1, 'create', 3), ev(2, 'update', 4),
+    ], [])).toEqual({ ok: true })
+  })
+
+  test('a hole in the CURRENT generation is still caught after a restore', () => {
+    // gen2 (current) = create@1 (restore, ok3) then update@3 (ok4) — v2 missing ⇒ hole, live version 3.
+    expect(checkRecordChainContiguity(3, [
+      ev(1, 'create', 0), ev(1, 'delete', 1), ev(1, 'create', 2), ev(3, 'update', 3),
+    ], [])).toEqual({ ok: false, reason: 'chain_hole' })
+  })
+
+  test('a live version < 1 is refused defensively', () => {
+    expect(checkRecordChainContiguity(0, [ev(1, 'create', 0)], [])).toEqual({ ok: false, reason: 'chain_hole' })
+  })
+})


### PR DESCRIPTION
## W0-1 — generation-aware history contiguity (owner-directed §0.6 correction)

Replaces #4234's **live-vs-latest** comparator in `history-integrity-precheck.ts` with a **generation-aware contiguity** proof. Authority: `docs/development/multitable-global-history-w0-1-history-incomplete-contiguity-trusted-since-design-lock-20260713.md` §6 (owner ruling 2026-07-14, PROPOSED lock **folded into this PR**) + the C1–C8 conditions in #4252. Scope is exactly the owner's four items; nothing else is wired.

**Base:** `origin/main` @ `86fa1d85c` (rebased twice for mid-flight main movement). HOT-CORE + schema/txn on the destructive-recovery path — landed via the sync-then-gate-then-arm-fast discipline: verdicts are head-scoped, every rebase paid a re-gate. The governing design lock is folded into this PR and remains **PROPOSED** — merging this implementation does NOT ratify the W0-1 lock; C2/C3/C6 and `recreateFieldFromConfig` stay owner-gated (see docket below).

### Gate ledger (adversarial Opus, refute-first, head-scoped)
- **Round 1 @ `075fdfe5e`** — MERGE_WITH_NITS: owner's 4 items all pass; 7 constructed scenarios all bite under mutation; fresh-DB migrate + CI-lane wiring proven. Findings: P3-1 (in-txn marker SELECT poisons the reset-execute txn in the pre-migration deploy window → 25P02 → 500 instead of clean 409), NIT-1 (design-lock citation dangling), NIT-2 (automation marker writes non-atomic).
- **Hardening `7a5372f99`** — all three addressed: marker READ path now gated behind the WRITE path's txn-safe `information_schema` probe (`hasVersionMarkerTable`, exported); automation lock/unlock bump+marker wrapped in `withTransaction` (prod supplies `deps.transaction` — verified at `automation-service.ts:841`); PROPOSED lock folded in from the #4250 branch.
- **Round 2 @ `7a5372f99`** — MERGE_CLEAN: P3-1 repro flips (clean verdict, no txn poisoning); probe proven load-bearing under mutation; memoization hazard checked (positive-only cache, no suite pollution in combined single-pg run).
- **CI truth catch `91d14b3a6`** — Plugin System Tests (required test 18.x/20.x) was RED at every prior head incl. the original delivery: the three source-scanning guard specs (cross-base / rank-8 lock / OD-6 revision-disposition) accept markers only within fixed windows (5/3/3 lines) above the SQL anchor, and the W0-1 comments + withTransaction wrapper pushed the automation-site markers out of window. Fix is comment-placement-only; full CI-mirror no-DB run 6480 passed / 0 failed.
- **Rebase onto `86fa1d85c`** — composes with **#4261** (interim revert-execute master gate, explicitly scoped "until the full W0-1 correctness fix lands" = this PR): flag OFF → 403 before the precheck; flag ON → contiguity verdicts as gated. The new contiguity realdb spec opens `MULTITABLE_ENABLE_SHEET_REVERT` in its test env (`7de0093a9`, test-only), mirroring its PIT_RESET handling; #4261 had already adapted all pre-existing revert-execute specs on main.
- **Round 3 @ `7de0093a9`** — MERGE_CLEAN on the rebase composition; then CI's DB whitelist step ran for the FIRST time at this head (every earlier run had died at the unit step, masking it) and caught a REAL predicate bug none of the gates saw: `undelete-pit` scenario (g) got `HISTORY_INCOMPLETE` instead of `PREVIEW_IDENTITY_INVALID`.
- **Comparator fix `a1cbd9639`** — the generation-boundary order key was packed as `epoch*1e6 + version` in a float64; at 2026 epochs (~1.7e18, ULP ~256) the version tiebreak was silently annihilated, so same-millisecond delete+create pairs collapsed and the current generation was mis-drawn. Replaced with a structural comparator: **(created_at epoch-ms, version, non-delete-before-delete)**. Version is the same-ms primary tiebreak (same-epoch multi-vintage churn — delete@2/create@3/delete@4 at one T, constructed by the 4c-3 §7 goldens — requires it; a static "create after delete" action rank was tried first and false-refused that suite). Pinned by 5 same-epoch unit goldens at real magnitudes. Verified against the FULL 202-file CI DB whitelist on a fresh PG (202/202, 1797 passed) + full no-DB suite (6515 passed).
- **Round 4 @ `a1cbd9639`** — final gate at the arm head: per-leg comparator mutations, adversarial hunt for reachable false-accepts, independent full-realdb re-run; plus required CI at the same SHA.

### The contiguity predicate (exact-set + generation + delete-reuse)
A LIVE record at `liveVersion = V` is trustworthy **iff** every version `k ∈ [genStart..V]` of its **current generation** is occupied by **exactly one** canonical event:
- a `create`/`update` revision at version `k`, **OR**
- a `lock`/`unlock` marker at version `k`.

`generation = count(create revisions at-or-before)`. A record's chain is a sequence of generations separated by `delete` revisions; the **current generation** is the suffix strictly after the last delete (a trash-restore / PIT-resurrect writes a fresh `create` at v1, starting a new generation). Fail-closed on: a version with **no** occupant (a hole = uncaptured data write — **the healed-gap**); **two** occupants at one version (duplicate/conflict, C5); an occupant version `> V` or `< genStart` (out-of-range, C5); the latest event being a `delete` on a live row (uncaptured resurrection); or no create/update revision at all (zero-revision fingerprint).

**Delete-reuse (C5):** a `delete` revision **reuses** the last live version, so it is **excluded** from the per-version occupant count. Neither `count(distinct version)` nor `count(*)` can be the criterion — pinned in the design and in `checkRecordChainContiguity` unit tests.

The pre-existing live-vs-latest content projection is **retained** as the §1.3 second layer (contiguity proves the chain is complete; the projection proves live == latest captured content). No #4234 coverage is lost; the existing 9-golden precheck suite still passes.

### Marker mechanism (OD-W0-1) + why (C7 avoidance)
**Mechanism (b): independent `meta_record_version_markers` table** (`zzzz20260713150000_...`), `UNIQUE(sheet_id, record_id, version)` for C5-fail-closed markers. Chosen over (a) lightweight revisions **specifically to avoid the C7 ripple**: `meta_record_revisions.action CHECK (create/update/delete)` stays closed, and History UI / retention / reconstructor are untouched. Markers are written at **all four** lock/unlock sites — HTTP `univer-meta.ts` lock/unlock (atomic in `pool.transaction`) and automation `automation-executor.ts` lock/unlock — via `recordVersionMarker` (idempotent `ON CONFLICT DO NOTHING`, deploy-window safe: a missing table pre-migration ⇒ fail-closed, never a crash). The 4 sites keep their `revision-exempt` + `lock-mgmt` disposition markers (OD-6 guard #4258 and the rank-8 lock guard both stay green).

### isSystemSheet predicate (single source of truth)
`isSystemSheet(sheet) = isApprovalProjectionBaseId(base_id) || isSystemPeopleSheetDescription(description)` in the new `multitable/system-sheet-predicate.ts`. `SYSTEM_PEOPLE_SHEET_DESCRIPTION` + `isSystemPeopleSheetDescription` moved there (re-imported by `univer-meta.ts`), so both People-sheet filtering and the history exclusion key off the same sentinel. The precheck skips contiguity for system sheets (server-regenerated read models).

### C4 fence + C8 same-txn
`reset-execute` (the destructive delete path) now acquires a **per-sheet `pg_advisory_xact_lock`** as the first statement of its destructive transaction, then **re-runs the precheck inside that transaction** (`HistoryIncompleteInTxnError` → rollback → the same values-free 409). Chosen over SERIALIZABLE: lowest blast radius, no global-isolation change, no serialization-failure retry loop. `revert-execute` is non-destructive (per-record CAS field-reverts + id-collision-guarded resurrects) so its precheck stays at the compute layer; the healed-gap refusal for revert fires there. **Proven with a constructed two-connection race** (not a sequential argument) — see goldens.

### Goldens (real-DB, mutation-proven) — all green locally
`tests/integration/multitable-history-contiguity-realdb.test.ts` (wired into `plugin-tests.yml`) + `tests/unit/multitable-history-contiguity.test.ts`:

| Golden | Asserts | Mutation → red (verified) |
|---|---|---|
| **HEALED-GAP** (fail-first, #4252 §6.1) | v3 record, revisions {v1,v3}, live==v3 → revert+reset preview+execute ALL 409, zero writes | neuter contiguity → **200** |
| **LOCK-MARKERS** (positive control) | record bumped by all 4 lock/unlock sites writes markers → precheck PASSES | neuter marker write → markerCount **0** |
| **SYSTEM-SHEET** (projection + people) | non-contiguous record NOT refused (excluded); plain-sheet discriminator IS refused | neuter isSystemSheet → **falsely refused** |
| **DELETE-REUSE** | delete revision reusing last live version is not a false hole (healthy sibling reverts) | (unit) delete counted as occupant → wrong reason |
| **PHANTOM-INSERT RACE** (C4/C8) | phantom uncaptured insert while reset holds the fence → 409, D not deleted | neuter in-txn recheck → **200**; neuter advisory fence → **can't block** |
| **POSITIVE CONTROL** | full healthy chain reverts+executes at T | (guards refuse-everything) |

Plus 13 `checkRecordChainContiguity` unit cases (healed-gap, marker-heal, generation/resurrect, delete-reuse, duplicate, out-of-range, zombie, zero-revision). All prior suites stay green: `multitable-history-incomplete-precheck-realdb` (9), `multitable-reset-pit-realdb` (13), `multitable-reset-pit-inbound-capture-realdb` (3), disposition scanner + rank-8 lock guard (42), + neighbor batch (76).

### Migration proof (zzzz, fresh-DB)
`zzzz20260713150000_create_meta_record_version_markers` sorts **last** on a fresh-DB full migrate; table + UNIQUE constraint + CHECK verified; re-migrate is a no-op (idempotent); `down()` verified. Not in any `MIGRATION_EXCLUDE` list (independent table, no FK/view deps) — runs in the CI test DB.

### EXPLICIT DOCKET — open residuals (this green does NOT mean "history fully trustworthy")
This slice closes the **live-record mid-chain healed-gap (C1/C5)** + **lock-marker false-refusal (C7-partial)** + **check/write race (C4/C8)**. Still open, deferred by the owner, **must not be masked**:
- **`recreateFieldFromConfig` (`univer-meta.ts:~6522`)** — content-integrity gap, owner-ruled **MUST-WRITE**, its own follow-up rung (OD-6 `revision-pending`).
- **C2 time-monotonicity** — reconstruction sorts by `created_at` (= txn-start); version-ascending/time-descending under concurrency can still select the wrong T-snapshot. Two pinned manifestations, in OPPOSITE directions (round-4 gate): (fail-closed, same-ms) a restore `create@v1` in the same millisecond as its preceding delete sorts version-below it and refuses — annoying, never corrupting; (fail-OPEN, cross-ms) a time-reversed event (e.g. a v2 event timestamped after its generation's delete via clock skew / txn-start inversion) can land in the wrong generation and MASK a real same-version hole → `ok:true`. The pre-fix packed-float encoding accepts the identical fail-open shape (proven by the gate), so neither is a regression of this PR — but the eventual C2 time-anchor must close the fail-open direction specifically, not just the false-refusals.
- **C3 deleted/tombstoned + resurrected (cross-generation) chains** — enumeration is live-only; reconstruction across a prior-generation boundary is not validated.
- **C6 durable trusted-since watermark + rollout protocol** — pre-marker lock bumps (historic or rolling-deploy window) have no marker and fail **closed** (refused), not grandfathered.

### #4235
Should be **closed** (parallel same-shape live-vs-latest §0.6 draft, superseded); its real-DB goldens are folded into this branch's suite per #4252's recommendation.

