### PR TITLE
feat(attendance): staging window-runner workflow — deploy/smoke/status for the five-window acceptance (refs #3317)

### DIFF
--- a/.github/workflows/attendance-staging-window-runner.yml
+++ b/.github/workflows/attendance-staging-window-runner.yml
@@ -1,0 +1,219 @@
+name: Attendance Staging Window Runner
+
+run-name: "Attendance Staging Window Runner: ${{ inputs.action }}${{ inputs.action == 'smoke' && format(' ({0})', inputs.smoke) || '' }}"
+
+# One dispatch = ONE action of the attendance five-window staging acceptance
+# (docs/development/attendance-staging-window-bundle-20260702.md):
+#   deploy — pin staging backend+web to a full-SHA GHCR tag, migrate, verify build+auth
+#   smoke  — run one window smoke (ae4 / rd45 / otbank-v18 / mp6 / hmr5) in-container
+#   status — read-only staging snapshot
+#
+# Modeled on attendance-remote-log-snapshot-prod.yml (SSH via deploy secrets, artifact
+# upload, 15-minute timeout, single concurrency group). Remote logic lives in the
+# committed scripts/ops/attendance-staging-window-runner-remote.sh, synced per-run;
+# every remote command is wrapped in an explicit `bash -o pipefail -c '<script>'`
+# (login-shell defaults are never relied on). Pipeline semantics are proven by
+# scripts/ops/attendance-window-runner-pipeline.test.mjs (gate-contract strict case).
+#
+# STAGING ONLY: the remote script fails closed unless it finds
+# docker-compose.app.staging.yml defining the metasheet-staging-* containers, and it
+# never recreates staging postgres/redis (asserted by container-id comparison).
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'What to run against the STAGING stack'
+        required: true
+        type: choice
+        options: [deploy, smoke, status]
+        default: status
+      deploy_sha:
+        description: 'FULL 40-char commit SHA (GHCR tags are full-SHA). Required for deploy and smoke.'
+        required: false
+        default: ''
+      smoke:
+        description: 'Which window smoke to run (action=smoke only)'
+        required: false
+        type: choice
+        options: [ae4, rd45, otbank-v18, mp6, hmr5]
+        default: ae4
+      set_window_env:
+        description: 'deploy only: rd-window sets ATTENDANCE_SCHEDULER_ENABLED + ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED on the staging backend at deploy time (bundle §3.4). The digest gate always stays unset.'
+        required: false
+        type: choice
+        options: [none, rd-window]
+        default: none
+      skip_host_sync:
+        description: 'skip the deploy-host repo git sync before smoke (true/false)'
+        required: false
+        default: 'false'
+
+concurrency:
+  group: attendance-staging-window-runner
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate inputs and embedded scripts
+        env:
+          ACTION: ${{ inputs.action }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          SET_WINDOW_ENV: ${{ inputs.set_window_env }}
+        run: |
+          set -euo pipefail
+          case "$ACTION" in deploy|smoke|status) ;; *) echo "invalid action: $ACTION" >&2; exit 2 ;; esac
+          if [[ "$ACTION" == "deploy" || "$ACTION" == "smoke" ]]; then
+            if [[ ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "deploy_sha must be the FULL 40-char lowercase commit SHA for action=$ACTION (GHCR tags are full-SHA; short prefixes fail with manifest unknown), got: '$DEPLOY_SHA'" >&2
+              exit 2
+            fi
+          fi
+          if [[ "$ACTION" != "deploy" && "$SET_WINDOW_ENV" != "none" ]]; then
+            echo "set_window_env=$SET_WINDOW_ENV is only meaningful for action=deploy (env flips happen together with the deploy, never mid-smoke — bundle §3.4)" >&2
+            exit 2
+          fi
+          bash -n scripts/ops/attendance-staging-window-runner-remote.sh
+          bash -n scripts/ops/attendance-window-runner-pipeline.lib.sh
+          node --check scripts/ops/attendance-window-runner-mint-token.mjs
+          echo "inputs and embedded scripts OK"
+
+      - name: Run pipeline self-test (same shape as the remote invocation)
+        run: node --test scripts/ops/attendance-window-runner-pipeline.test.mjs
+
+      - name: Sync runner scripts to deploy host
+        id: sync
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          runner_dir="/tmp/attendance-window-runner-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "runner_dir=$runner_dir" >> "$GITHUB_OUTPUT"
+          tar -czf - \
+            scripts/ops/attendance-staging-window-runner-remote.sh \
+            scripts/ops/attendance-window-runner-pipeline.lib.sh \
+            scripts/ops/attendance-window-runner-mint-token.mjs \
+          | ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.ssh/deploy_key \
+              "$DEPLOY_USER@$DEPLOY_HOST" \
+              "bash -o pipefail -c 'set -euo pipefail; rm -rf ${runner_dir}; mkdir -p ${runner_dir}; tar -xzf - -C ${runner_dir} --strip-components=2'"
+
+      - name: Run remote action
+        id: remote
+        continue-on-error: true
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          STAGING_DEPLOY_PATH: ${{ vars.STAGING_DEPLOY_PATH || 'metasheet2-dingtalk-staging' }}
+          ACTION: ${{ inputs.action }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          SMOKE_ID: ${{ inputs.smoke }}
+          SET_WINDOW_ENV: ${{ inputs.set_window_env }}
+          SKIP_HOST_SYNC: ${{ inputs.skip_host_sync }}
+          RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
+        run: |
+          set -euo pipefail
+          ssh_opts="-o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.ssh/deploy_key"
+          DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
+          for pair in "DEPLOY_PATH=$DEPLOY_PATH" "STAGING_DEPLOY_PATH=$STAGING_DEPLOY_PATH" "SKIP_HOST_SYNC=$SKIP_HOST_SYNC"; do
+            value="${pair#*=}"
+            if [[ ! "$value" =~ ^[A-Za-z0-9._/~-]+$ ]]; then
+              echo "refusing unsafe characters in ${pair%%=*}: '$value'" >&2
+              exit 2
+            fi
+          done
+          remote_output_dir="/tmp/attendance-window-runner-out-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_name="attendance-staging-window-runner-${ACTION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+          mkdir -p output/window-runner
+
+          # Everything after this prelude is the committed remote script; the inputs are
+          # regex-validated above so the generated prelude is quoting-safe.
+          remote_script="set -euo pipefail
+          export ACTION='${ACTION}'
+          export DEPLOY_SHA='${DEPLOY_SHA}'
+          export SMOKE_ID='${SMOKE_ID}'
+          export SET_WINDOW_ENV='${SET_WINDOW_ENV}'
+          export STAGING_DEPLOY_PATH='${STAGING_DEPLOY_PATH}'
+          export DEPLOY_PATH='${DEPLOY_PATH}'
+          export SKIP_HOST_SYNC='${SKIP_HOST_SYNC}'
+          export OUTPUT_DIR='${remote_output_dir}'
+          export RUN_STAMP='gh${GITHUB_RUN_ID}a${GITHUB_RUN_ATTEMPT}'
+          rm -rf '${remote_output_dir}'
+          mkdir -p '${remote_output_dir}'
+          bash '${RUNNER_DIR}/attendance-staging-window-runner-remote.sh'"
+          escaped_script="$(printf '%s' "$remote_script" | sed "s/'/'\\\\''/g")"
+
+          set +e
+          # Owner-ruled invocation shape: the remote command is exactly
+          # `bash -o pipefail -c '<script>'` — never a login-shell default.
+          ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "bash -o pipefail -c '${escaped_script}'" 2>&1 \
+            | tee output/window-runner/ssh.log
+          rc=${PIPESTATUS[0]}
+          scp $ssh_opts -r "$DEPLOY_USER@$DEPLOY_HOST:${remote_output_dir}/." output/window-runner/ 2>&1 \
+            | tee -a output/window-runner/ssh.log
+          scp_rc=${PIPESTATUS[0]}
+          ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+            "bash -o pipefail -c 'rm -rf ${remote_output_dir} ${RUNNER_DIR}'" \
+            >> output/window-runner/ssh.log 2>&1
+          set -e
+
+          if [[ "$rc" == "0" && "$scp_rc" != "0" ]]; then
+            rc="$scp_rc"
+          fi
+          echo "remote_rc=$rc" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Write step summary
+        if: always()
+        env:
+          REMOTE_RC: ${{ steps.remote.outputs.remote_rc }}
+          ARTIFACT_NAME: ${{ steps.remote.outputs.artifact_name }}
+          ACTION: ${{ inputs.action }}
+          SMOKE_ID: ${{ inputs.smoke }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          SET_WINDOW_ENV: ${{ inputs.set_window_env }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Attendance Staging Window Runner"
+            echo ""
+            echo "- Action: \`${ACTION}\`"
+            if [[ "$ACTION" == "smoke" ]]; then echo "- Smoke: \`${SMOKE_ID}\`"; fi
+            echo "- Deploy SHA: \`${DEPLOY_SHA:-<none>}\`"
+            echo "- Window env: \`${SET_WINDOW_ENV}\`"
+            echo "- Remote rc: \`${REMOTE_RC:-missing}\`"
+            echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`"
+            if [[ -f output/window-runner/summary.txt ]]; then
+              echo ""
+              echo '```text'
+              cat output/window-runner/summary.txt
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.remote.outputs.artifact_name || format('attendance-staging-window-runner-{0}-{1}-{2}', inputs.action, github.run_id, github.run_attempt) }}
+          retention-days: 30
+          path: output/window-runner
+
+      - name: Fail on remote error
+        if: steps.remote.outputs.remote_rc != '0'
+        run: exit 1

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "verify:attendance-regression-local": "bash scripts/ops/attendance-regression-local.sh",
     "verify:attendance-regression-fast": "bash scripts/ops/attendance-fast-parallel-regression.sh",
     "verify:attendance-regression-fast:test": "node --test scripts/ops/attendance-fast-parallel-regression.test.mjs",
+    "verify:attendance-window-runner:pipeline:test": "node --test scripts/ops/attendance-window-runner-pipeline.test.mjs",
     "verify:global-history-flag-manifest:test": "node --test scripts/ops/global-history-flag-manifest.test.mjs scripts/ops/multitable-global-history-flag-status.test.mjs",
     "verify:attendance-regression-fast:ops": "PROFILE=ops MAX_PARALLEL=2 bash scripts/ops/attendance-fast-parallel-regression.sh",
     "verify:attendance-regression-fast:contracts": "PROFILE=contracts MAX_PARALLEL=1 bash scripts/ops/attendance-fast-parallel-regression.sh",

--- a/scripts/ops/attendance-run-gate-contract-case.sh
+++ b/scripts/ops/attendance-run-gate-contract-case.sh
@@ -95,6 +95,9 @@ if [[ "$CASE_ID" == "strict" ]]; then
   info "running strict import override-confirm modal contract"
   node --test ./scripts/ops/attendance-import-override-confirm-contract.test.mjs
 
+  info "running staging window-runner pipeline contract (pipefail both legs)"
+  node --test ./scripts/ops/attendance-window-runner-pipeline.test.mjs
+
   cp "$valid_summary" "${strict_dir}/gate-summary.json"
   ./scripts/ops/attendance-validate-gate-summary.sh "$strict_dir" 1
   node ./scripts/ops/attendance-validate-gate-summary-schema.mjs \

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -1,0 +1,500 @@
+#!/usr/bin/env bash
+# attendance-staging-window-runner-remote.sh
+#
+# Remote (deploy-host) half of .github/workflows/attendance-staging-window-runner.yml.
+# Executes ONE action per invocation against the STAGING stack only:
+#   deploy — pin staging backend+web to a full-SHA image tag, migrate, verify build+auth
+#   smoke  — run one of the five window smokes in-container (bundle doc:
+#            docs/development/attendance-staging-window-bundle-20260702.md)
+#   status — read-only snapshot (containers, health, settings, pending migrations)
+#
+# HARD SAFETY RAILS:
+#   * Operates exclusively on the staging compose file docker-compose.app.staging.yml
+#     and the metasheet-staging-{backend,web,postgres,redis} containers. Fails closed
+#     if the staging compose file is absent or does not define the staging containers.
+#   * NEVER runs compose against the prod-track stack, and NEVER recreates staging
+#     postgres/redis (deploy uses `up -d --no-deps backend web` and asserts the
+#     postgres/redis container ids are unchanged afterwards).
+#   * Invoked by the workflow as `bash -o pipefail -c '<script>'`; this file also sets
+#     pipefail itself so pipelines inside it stay strict when run directly.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=attendance-window-runner-pipeline.lib.sh
+source "${HERE}/attendance-window-runner-pipeline.lib.sh"
+
+log() { echo "[window-runner] $*"; }
+fail() { echo "[window-runner][error] $*" >&2; exit 1; }
+
+ACTION="${ACTION:?ACTION is required (deploy|smoke|status)}"
+DEPLOY_SHA="${DEPLOY_SHA:-}"
+SMOKE_ID="${SMOKE_ID:-}"
+SET_WINDOW_ENV="${SET_WINDOW_ENV:-none}"
+STAGING_DEPLOY_PATH="${STAGING_DEPLOY_PATH:-metasheet2-dingtalk-staging}"
+DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
+SKIP_HOST_SYNC="${SKIP_HOST_SYNC:-false}"
+OUTPUT_DIR="${OUTPUT_DIR:?OUTPUT_DIR is required}"
+IMAGE_OWNER="${IMAGE_OWNER:-zensgit}"
+RUN_STAMP="${RUN_STAMP:?RUN_STAMP is required (workflow run id marker)}"
+
+BACKEND_CONTAINER="metasheet-staging-backend"
+WEB_CONTAINER="metasheet-staging-web"
+POSTGRES_CONTAINER="metasheet-staging-postgres"
+REDIS_CONTAINER="metasheet-staging-redis"
+CONTAINER_RUNNER_DIR="/tmp/window-runner"
+STAGING_WEB_HEALTH_URL="http://127.0.0.1:8082/api/health"
+STAGING_BACKEND_HEALTH_URL="http://127.0.0.1:18900/health"
+IN_CONTAINER_BASE_URL="http://127.0.0.1:8900"
+MIGRATE_JS="packages/core-backend/dist/src/db/migrate.js"
+
+resolve_home_path() {
+  local raw="$1"
+  if [[ "$raw" == /* ]]; then
+    printf '%s' "$raw"
+  elif [[ "$raw" == ~/* ]]; then
+    printf '%s' "${HOME}/${raw#~/}"
+  else
+    printf '%s' "${HOME}/${raw}"
+  fi
+}
+
+STAGING_DIR="$(resolve_home_path "$STAGING_DEPLOY_PATH")"
+PROD_REPO_DIR="$(resolve_home_path "$DEPLOY_PATH")"
+STAGING_COMPOSE_FILE="${STAGING_DIR}/docker-compose.app.staging.yml"
+OVERRIDE_FILE="${STAGING_DIR}/docker-compose.window-runner.override.yml"
+
+# --- staging-only guard (fail closed) -------------------------------------------------
+assert_staging_only() {
+  [[ -d "$STAGING_DIR" ]] || fail "staging stack directory missing: ${STAGING_DIR} (set STAGING_DEPLOY_PATH); refusing to guess"
+  [[ -f "$STAGING_COMPOSE_FILE" ]] || fail "staging compose file missing: ${STAGING_COMPOSE_FILE}; fail closed — this runner never falls back to another compose file"
+  grep -q "container_name: ${BACKEND_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "compose file does not define ${BACKEND_CONTAINER}; refusing (wrong file?)"
+  grep -q "container_name: ${WEB_CONTAINER}" "$STAGING_COMPOSE_FILE" \
+    || fail "compose file does not define ${WEB_CONTAINER}; refusing (wrong file?)"
+  if grep -qE 'container_name: metasheet-(backend|web|postgres|redis)[[:space:]]*$' "$STAGING_COMPOSE_FILE"; then
+    fail "compose file defines PROD-track container names; refusing"
+  fi
+  if [[ "$STAGING_DIR" == "$PROD_REPO_DIR" ]]; then
+    fail "staging stack dir equals the prod-track repo dir (${STAGING_DIR}); refusing"
+  fi
+  log "staging-only guard OK: dir=${STAGING_DIR} compose=$(basename "$STAGING_COMPOSE_FILE")"
+}
+
+require_compose_v2() {
+  if docker compose version >/dev/null 2>&1; then
+    return 0
+  fi
+  fail "docker compose v2 plugin is required (legacy docker-compose v1 breaks up -d against existing containers; see docs/development/staging-deploy-d88ad587b-20260426.md)"
+}
+
+compose_staging() {
+  # The ONLY compose entry point in this script: staging compose file + runner override.
+  (cd "$STAGING_DIR" && docker compose -f "$STAGING_COMPOSE_FILE" -f "$OVERRIDE_FILE" "$@")
+}
+
+staging_exec() {
+  # The ONLY docker-exec entry point: pinned staging backend container name.
+  docker exec "$BACKEND_CONTAINER" "$@"
+}
+
+staging_exec_env() {
+  # docker exec with -e pairs: staging_exec_env "A=1" "B=2" -- cmd...
+  local -a env_flags=()
+  while [[ "$#" -gt 0 && "$1" != "--" ]]; do
+    env_flags+=(-e "$1")
+    shift
+  done
+  [[ "${1:-}" == "--" ]] && shift
+  docker exec "${env_flags[@]}" "$BACKEND_CONTAINER" "$@"
+}
+
+require_sha() {
+  [[ "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "deploy_sha must be the FULL 40-char lowercase commit SHA (GHCR tags are full-SHA; a 9-char prefix fails with manifest unknown — 2026-04-26 postmortem), got: '${DEPLOY_SHA}'"
+}
+
+fetch_health_commit() {
+  # stdout: build.commit from the staging web port (/api/health), empty on failure.
+  local body
+  if ! body="$(curl -fsS --max-time 10 "$STAGING_WEB_HEALTH_URL" 2>/dev/null)"; then
+    printf ''
+    return 0
+  fi
+  printf '%s' "$body" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("build", {}).get("commit", ""))
+except Exception:
+    print("")'
+}
+
+wait_for_health_commit() {
+  local expected="$1" attempts="${2:-30}" delay="${3:-4}" i commit
+  for ((i = 1; i <= attempts; i += 1)); do
+    commit="$(fetch_health_commit)"
+    if [[ "$commit" == "$expected" ]]; then
+      log "health build.commit matches deploy sha (attempt ${i}/${attempts})"
+      return 0
+    fi
+    log "waiting for health build.commit==${expected} (attempt ${i}/${attempts}, got '${commit:-<unreachable>}')"
+    sleep "$delay"
+  done
+  curl -sS --max-time 10 "$STAGING_WEB_HEALTH_URL" > "${OUTPUT_DIR}/health-last.json" 2>&1 || true
+  fail "staging /api/health build.commit never matched ${expected}"
+}
+
+prepare_container_runner() {
+  staging_exec mkdir -p "${CONTAINER_RUNNER_DIR}/scripts/ops"
+  # Bare ESM imports (e.g. `import('pg')`) resolve node_modules upward from the script
+  # location; a symlink makes /tmp/window-runner scripts resolve the image's node_modules.
+  staging_exec ln -sfn /app/node_modules "${CONTAINER_RUNNER_DIR}/node_modules"
+  docker cp "${HERE}/attendance-window-runner-mint-token.mjs" \
+    "${BACKEND_CONTAINER}:${CONTAINER_RUNNER_DIR}/scripts/ops/attendance-window-runner-mint-token.mjs"
+}
+
+find_admin_user() {
+  staging_exec node "${CONTAINER_RUNNER_DIR}/scripts/ops/attendance-window-runner-mint-token.mjs" --find-admin
+}
+
+mint_token() {
+  # mint_token <user_id> <roles_csv> <perms_csv>; token printed to stdout (never logged).
+  local user_id="$1" roles="$2" perms="$3"
+  [[ "$user_id" =~ ^[A-Za-z0-9._@-]+$ ]] || fail "refusing to mint token for unsafe user id: ${user_id}"
+  staging_exec node "${CONTAINER_RUNNER_DIR}/scripts/ops/attendance-window-runner-mint-token.mjs" \
+    --mint --user-id "$user_id" --roles "$roles" --perms "$perms"
+}
+
+capture_settings() {
+  # capture_settings <token> <out_file>; records HTTP code alongside the body.
+  local token="$1" out_file="$2" http_code
+  http_code="$(curl -sS --max-time 15 -o "$out_file" -w '%{http_code}' \
+    -H "Authorization: Bearer ${token}" -H 'x-org-id: default' \
+    'http://127.0.0.1:8082/api/attendance/settings?orgId=default' || echo '000')"
+  echo "$http_code" > "${out_file}.http_code"
+  log "GET /api/attendance/settings -> ${http_code} (${out_file})"
+  printf '%s' "$http_code"
+}
+
+assert_window_env_flags() {
+  # The digest gate must stay unset/false for the whole window (bundle §3.4); the two
+  # rd-window flags must be live when requested. Verified in the RUNNING container env.
+  staging_exec node -e '
+const mode = process.argv[1]
+const digest = process.env.ATTENDANCE_REPORT_DIGEST_ENABLED
+if (digest === "true") {
+  console.error("FAIL: ATTENDANCE_REPORT_DIGEST_ENABLED=true in the staging backend — the window plan requires it UNSET for the whole window (bundle §3.4)")
+  process.exit(1)
+}
+const sched = process.env.ATTENDANCE_SCHEDULER_ENABLED
+const worker = process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED
+if (mode === "rd-window") {
+  if (sched !== "true" || worker !== "true") {
+    console.error(`FAIL: rd-window requested but scheduler=${sched} worker=${worker} in the running container`)
+    process.exit(1)
+  }
+} else if (sched === "true" || worker === "true") {
+  console.warn(`WARN: set_window_env=none but scheduler=${sched} worker=${worker} are on (likely set in the host env file; this runner only manages its own override)`)
+}
+console.log(`env-flags ok: mode=${mode} scheduler=${sched||"<unset>"} worker=${worker||"<unset>"} digest=${digest||"<unset>"}`)
+' "$SET_WINDOW_ENV" | tee "${OUTPUT_DIR}/env-flags.txt"
+}
+
+snapshot_staging_ps() {
+  docker ps --filter 'name=metasheet-staging-' \
+    --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}' > "${OUTPUT_DIR}/docker-ps-staging.txt"
+}
+
+host_sync_prod_repo() {
+  # Same discipline as attendance-remote-log-snapshot-prod.yml: the smoke scripts are
+  # docker-cp'd from the host-synced repo (main), decoupled from the deployed image SHA.
+  [[ -d "$PROD_REPO_DIR" ]] || fail "host repo missing: ${PROD_REPO_DIR} (DEPLOY_PATH)"
+  if [[ "$SKIP_HOST_SYNC" == "true" ]]; then
+    log "host-sync skipped (skip_host_sync=true)"
+    return 0
+  fi
+  if git -C "$PROD_REPO_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C "$PROD_REPO_DIR" fetch origin main
+    git -C "$PROD_REPO_DIR" checkout main
+    git -C "$PROD_REPO_DIR" pull --ff-only origin main
+    log "host-sync ok: $(git -C "$PROD_REPO_DIR" rev-parse HEAD)"
+  else
+    log "host-sync: ${PROD_REPO_DIR} is not a git repo; continuing with existing files"
+  fi
+}
+
+auth_round_trip() {
+  # Bundle §3: staging-realm token must authenticate. Mint in-container (staging
+  # JWT_SECRET), then require /api/auth/me == 200 AND /api/attendance/settings == 200.
+  local admin_id admin_token me_code settings_code
+  admin_id="$(find_admin_user)"
+  log "auth round-trip subject: ${admin_id}"
+  admin_token="$(mint_token "$admin_id" 'admin' 'attendance:read,attendance:write,attendance:admin,attendance:approve')"
+  me_code="$(curl -sS --max-time 15 -o "${OUTPUT_DIR}/auth-me.json" -w '%{http_code}' \
+    -H "Authorization: Bearer ${admin_token}" 'http://127.0.0.1:8082/api/auth/me' || echo '000')"
+  echo "$me_code" > "${OUTPUT_DIR}/auth-me.http_code"
+  [[ "$me_code" == "200" ]] || fail "auth round-trip failed: GET /api/auth/me -> ${me_code} (401 = wrong-realm token / missing admin user; do not debug the route — see bundle §3)"
+  settings_code="$(capture_settings "$admin_token" "${OUTPUT_DIR}/settings-postdeploy.json")"
+  [[ "$settings_code" == "200" ]] || fail "auth round-trip failed: GET /api/attendance/settings -> ${settings_code} (503 = schema gap: STOP per bundle §3)"
+  log "auth round-trip OK (me=200, settings=200)"
+}
+
+# --- actions ---------------------------------------------------------------------------
+
+action_deploy() {
+  require_sha
+  require_compose_v2
+
+  local backend_image="ghcr.io/${IMAGE_OWNER}/metasheet2-backend:${DEPLOY_SHA}"
+  local web_image="ghcr.io/${IMAGE_OWNER}/metasheet2-web:${DEPLOY_SHA}"
+
+  local pg_id_before redis_id_before
+  pg_id_before="$(docker inspect -f '{{.Id}}' "$POSTGRES_CONTAINER")" \
+    || fail "staging postgres container not found: ${POSTGRES_CONTAINER}"
+  redis_id_before="$(docker inspect -f '{{.Id}}' "$REDIS_CONTAINER")" \
+    || fail "staging redis container not found: ${REDIS_CONTAINER}"
+
+  if [[ -f "$OVERRIDE_FILE" ]]; then
+    cp "$OVERRIDE_FILE" "${OVERRIDE_FILE}.bak-$(date +%Y%m%d%H%M%S)"
+  fi
+  {
+    echo "# Written by attendance-staging-window-runner (run ${RUN_STAMP}). Pins the staging"
+    echo "# backend/web images to one full-SHA tag; env flips happen ONLY here, together with"
+    echo "# the deploy (bundle §3.4). Redeploying with set_window_env=none removes the flags."
+    echo "services:"
+    echo "  backend:"
+    echo "    image: ${backend_image}"
+    if [[ "$SET_WINDOW_ENV" == "rd-window" ]]; then
+      echo "    environment:"
+      echo "      ATTENDANCE_SCHEDULER_ENABLED: \"true\""
+      echo "      ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED: \"true\""
+    fi
+    echo "  web:"
+    echo "    image: ${web_image}"
+  } > "$OVERRIDE_FILE"
+  cp "$OVERRIDE_FILE" "${OUTPUT_DIR}/window-runner-override.yml"
+  log "override written: ${OVERRIDE_FILE} (env mode: ${SET_WINDOW_ENV})"
+
+  compose_staging pull backend web 2>&1 | tee "${OUTPUT_DIR}/compose-pull.log"
+  # NEVER recreate postgres/redis: only backend+web, --no-deps.
+  compose_staging up -d --no-deps backend web 2>&1 | tee "${OUTPUT_DIR}/compose-up.log"
+
+  local pg_id_after redis_id_after
+  pg_id_after="$(docker inspect -f '{{.Id}}' "$POSTGRES_CONTAINER")"
+  redis_id_after="$(docker inspect -f '{{.Id}}' "$REDIS_CONTAINER")"
+  [[ "$pg_id_before" == "$pg_id_after" ]] || fail "staging postgres container was recreated — hard constraint violated"
+  [[ "$redis_id_before" == "$redis_id_after" ]] || fail "staging redis container was recreated — hard constraint violated"
+  log "postgres/redis untouched (container ids unchanged)"
+
+  local running_backend_image
+  running_backend_image="$(docker inspect -f '{{.Config.Image}}' "$BACKEND_CONTAINER")"
+  [[ "$running_backend_image" == "$backend_image" ]] \
+    || fail "backend container image is ${running_backend_image}, expected ${backend_image}"
+
+  wait_for_health_commit "$DEPLOY_SHA"
+  curl -fsS --max-time 10 "$STAGING_WEB_HEALTH_URL" > "${OUTPUT_DIR}/health-web.json"
+  curl -fsS --max-time 10 "$STAGING_BACKEND_HEALTH_URL" > "${OUTPUT_DIR}/health-backend.json" || true
+
+  assert_window_env_flags
+
+  # Migration discipline (bundle §3.2): list BEFORE, classify read-only, migrate, list
+  # AFTER (must end pending=0). The alignment report runs in-container from the deployed
+  # image's own /app/scripts copy so its file scan matches the deployed migration set.
+  prepare_container_runner
+  staging_exec node "$MIGRATE_JS" --list < /dev/null 2>&1 | tee "${OUTPUT_DIR}/migrate-list-before.txt"
+  docker cp "${OUTPUT_DIR}/migrate-list-before.txt" "${BACKEND_CONTAINER}:${CONTAINER_RUNNER_DIR}/migrate-list-before.txt"
+  staging_exec node /app/scripts/ops/staging-migration-alignment-report.mjs \
+    --migrate-list-file "${CONTAINER_RUNNER_DIR}/migrate-list-before.txt" \
+    --out-dir "${CONTAINER_RUNNER_DIR}/migration-report" < /dev/null 2>&1 \
+    | tee "${OUTPUT_DIR}/migration-alignment-stdout.txt"
+  docker cp "${BACKEND_CONTAINER}:${CONTAINER_RUNNER_DIR}/migration-report" "${OUTPUT_DIR}/migration-report" || true
+  if grep -q 'decision=do_not_run_full_migrate' "${OUTPUT_DIR}/migration-alignment-stdout.txt"; then
+    fail "migration alignment report says do_not_run_full_migrate — STOP per bundle §3.2; follow docs/development/staging-migration-alignment-runbook-verification-20260519.md"
+  fi
+
+  staging_exec node "$MIGRATE_JS" < /dev/null 2>&1 | tee "${OUTPUT_DIR}/migrate-run.log"
+  staging_exec node "$MIGRATE_JS" --list < /dev/null 2>&1 | tee "${OUTPUT_DIR}/migrate-list-after.txt"
+  grep -q '^Pending: 0$' "${OUTPUT_DIR}/migrate-list-after.txt" \
+    || fail "migrations did not end at pending=0 (see migrate-list-after.txt)"
+
+  auth_round_trip
+  snapshot_staging_ps
+
+  {
+    echo "action=deploy"
+    echo "deploy_sha=${DEPLOY_SHA}"
+    echo "set_window_env=${SET_WINDOW_ENV}"
+    echo "backend_image=${backend_image}"
+    echo "web_image=${web_image}"
+    echo "result=ok"
+  } > "${OUTPUT_DIR}/summary.txt"
+  log "deploy OK: ${DEPLOY_SHA}"
+}
+
+action_smoke() {
+  [[ -n "$DEPLOY_SHA" ]] || fail "deploy_sha is REQUIRED for action=smoke (every stamp must name the exact deployed SHA — precedent-window lesson)"
+  require_sha
+  [[ -n "$SMOKE_ID" ]] || fail "smoke input is required for action=smoke"
+
+  local smoke_script stamp_prefix
+  local -a extra_env=() extra_tokens=()
+  case "$SMOKE_ID" in
+    ae4)
+      smoke_script="staging-attendance-ae4-result-edit-smoke.mjs"
+      stamp_prefix="ae4-smoke"
+      extra_tokens=("NON_ADMIN_TOKEN:reader:user:attendance:read")
+      ;;
+    rd45)
+      smoke_script="staging-attendance-report-digest-rd45-smoke.mjs"
+      stamp_prefix="rd45-smoke"
+      extra_env=("PLUGIN_INDEX_PATH=/app/plugins/plugin-attendance/index.cjs")
+      ;;
+    otbank-v18)
+      smoke_script="staging-attendance-overtime-bank-v18-smoke.mjs"
+      stamp_prefix="otbank-v18-smoke"
+      extra_tokens=(
+        "CASE1_TOKEN:case1:user:attendance:read,attendance:write"
+        "CASE2_TOKEN:case2:user:attendance:read,attendance:write"
+        "CASE3_TOKEN:case3:user:attendance:read,attendance:write"
+        "MUSTPAY_TOKEN:mustpay:user:attendance:read,attendance:write"
+        "DORMANT_TOKEN:dormant:user:attendance:read,attendance:write"
+      )
+      ;;
+    mp6)
+      smoke_script="staging-attendance-makeup-punch-mp6-smoke.mjs"
+      stamp_prefix="mp6-smoke"
+      extra_tokens=("SUBJECT_TOKEN:subject:user:attendance:read,attendance:write")
+      ;;
+    hmr5)
+      smoke_script="staging-attendance-manual-missed-punch-reminder-hmr5-smoke.mjs"
+      stamp_prefix="hmr5-smoke"
+      extra_tokens=("SCOPED_TOKEN:scoped:user:attendance:read,attendance:write")
+      ;;
+    *)
+      fail "unknown smoke id: ${SMOKE_ID}"
+      ;;
+  esac
+  local stamp="${stamp_prefix}-${RUN_STAMP}"
+
+  host_sync_prod_repo
+  local smoke_src="${PROD_REPO_DIR}/scripts/ops/${smoke_script}"
+  [[ -f "$smoke_src" ]] || fail "smoke script missing in host-synced repo: ${smoke_src}"
+
+  # The deployed build must BE the SHA the stamps will name (bundle §2).
+  local live_commit
+  live_commit="$(fetch_health_commit)"
+  [[ "$live_commit" == "$DEPLOY_SHA" ]] \
+    || fail "staging /api/health build.commit is '${live_commit:-<unreachable>}' but deploy_sha=${DEPLOY_SHA}; refusing to smoke a mismatched build"
+
+  prepare_container_runner
+  local admin_id admin_token
+  admin_id="$(find_admin_user)"
+  admin_token="$(mint_token "$admin_id" 'admin' 'attendance:read,attendance:write,attendance:admin,attendance:approve')"
+  log "smoke admin subject: ${admin_id}; stamp: ${stamp}"
+
+  # Window-level settings-restore evidence (bundle §5): settings BEFORE and AFTER.
+  capture_settings "$admin_token" "${OUTPUT_DIR}/settings-before.json" >/dev/null
+
+  docker cp "$smoke_src" "${BACKEND_CONTAINER}:${CONTAINER_RUNNER_DIR}/scripts/ops/${smoke_script}"
+
+  local -a run_env=(
+    "BASE_URL=${IN_CONTAINER_BASE_URL}"
+    "DEPLOY_SHA=${DEPLOY_SHA}"
+    "STAMP=${stamp}"
+    "ADMIN_TOKEN=${admin_token}"
+  )
+  local spec env_name suffix roles perms
+  for spec in "${extra_tokens[@]:-}"; do
+    [[ -n "$spec" ]] || continue
+    env_name="${spec%%:*}"
+    suffix="$(printf '%s' "$spec" | cut -d: -f2)"
+    roles="$(printf '%s' "$spec" | cut -d: -f3)"
+    perms="$(printf '%s' "$spec" | cut -d: -f4-)"
+    run_env+=("${env_name}=$(mint_token "${stamp}-${suffix}" "$roles" "$perms")")
+  done
+  for spec in "${extra_env[@]:-}"; do
+    [[ -n "$spec" ]] || continue
+    run_env+=("$spec")
+  done
+
+  # DATABASE_URL intentionally NOT passed: the container's own env already carries the
+  # staging DB URL, which is exactly the API↔DB coherence the helpers assert.
+  local -a pipe_status
+  set +e
+  staging_exec_env "${run_env[@]}" -- node "${CONTAINER_RUNNER_DIR}/scripts/ops/${smoke_script}" \
+    < /dev/null 2>&1 | tee "${OUTPUT_DIR}/smoke-${SMOKE_ID}.log"
+  pipe_status=("${PIPESTATUS[@]}")
+  set -e
+  local smoke_rc="${pipe_status[0]}"
+  if [[ "${pipe_status[1]}" != "0" ]]; then
+    fail "tee failed writing the smoke log (rc=${pipe_status[1]})"
+  fi
+
+  capture_settings "$admin_token" "${OUTPUT_DIR}/settings-after.json" >/dev/null
+
+  # Filtered backend log slice for the artifact — zero matches is a normal outcome;
+  # a failing `docker logs` must still fail this step (filtered_pipe contract, proven
+  # by scripts/ops/attendance-window-runner-pipeline.test.mjs).
+  filtered_pipe "${OUTPUT_DIR}/backend-log-slice.log" \
+    'attendance|digest|delivery|reminder|overtime|makeup' \
+    -- docker logs --since 30m "$BACKEND_CONTAINER"
+
+  snapshot_staging_ps
+  {
+    echo "action=smoke"
+    echo "smoke=${SMOKE_ID}"
+    echo "deploy_sha=${DEPLOY_SHA}"
+    echo "stamp=${stamp}"
+    echo "smoke_rc=${smoke_rc}"
+  } > "${OUTPUT_DIR}/summary.txt"
+
+  if [[ "$smoke_rc" != "0" ]]; then
+    fail "smoke ${SMOKE_ID} exited rc=${smoke_rc} (full log: smoke-${SMOKE_ID}.log)"
+  fi
+  log "smoke ${SMOKE_ID} OK (stamp ${stamp})"
+}
+
+action_status() {
+  snapshot_staging_ps
+  curl -sS --max-time 10 "$STAGING_WEB_HEALTH_URL" > "${OUTPUT_DIR}/health-web.json" 2>&1 \
+    || echo "unreachable" > "${OUTPUT_DIR}/health-web.json"
+  curl -sS --max-time 10 "$STAGING_BACKEND_HEALTH_URL" > "${OUTPUT_DIR}/health-backend.json" 2>&1 \
+    || echo "unreachable" > "${OUTPUT_DIR}/health-backend.json"
+  local live_commit
+  live_commit="$(fetch_health_commit)"
+  log "live build.commit: ${live_commit:-<unreachable>}"
+
+  local status_rc=0
+  if docker inspect -f '{{.State.Running}}' "$BACKEND_CONTAINER" 2>/dev/null | grep -qx 'true'; then
+    prepare_container_runner
+    staging_exec node "$MIGRATE_JS" --list < /dev/null 2>&1 | tee "${OUTPUT_DIR}/migrate-list.txt" || status_rc=1
+    assert_window_env_flags || status_rc=1
+    local admin_id admin_token
+    if admin_id="$(find_admin_user)"; then
+      admin_token="$(mint_token "$admin_id" 'admin' 'attendance:read,attendance:admin')"
+      capture_settings "$admin_token" "${OUTPUT_DIR}/settings-current.json" >/dev/null || status_rc=1
+    else
+      echo "no active admin user found; settings snapshot skipped" > "${OUTPUT_DIR}/settings-current.json"
+    fi
+  else
+    log "backend container not running; container-side snapshots skipped"
+    status_rc=1
+  fi
+
+  {
+    echo "action=status"
+    echo "live_commit=${live_commit:-unreachable}"
+    echo "status_rc=${status_rc}"
+  } > "${OUTPUT_DIR}/summary.txt"
+  return "$status_rc"
+}
+
+# --- main ------------------------------------------------------------------------------
+
+mkdir -p "$OUTPUT_DIR"
+assert_staging_only
+
+case "$ACTION" in
+  deploy) action_deploy ;;
+  smoke) action_smoke ;;
+  status) action_status ;;
+  *) fail "unknown action: ${ACTION} (expected deploy|smoke|status)" ;;
+esac

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -170,7 +170,8 @@ capture_settings() {
     -H "Authorization: Bearer ${token}" -H 'x-org-id: default' \
     'http://127.0.0.1:8082/api/attendance/settings?orgId=default' || echo '000')"
   echo "$http_code" > "${out_file}.http_code"
-  log "GET /api/attendance/settings -> ${http_code} (${out_file})"
+  # callers capture stdout as the code — informational line goes to stderr
+  log "GET /api/attendance/settings -> ${http_code} (${out_file})" >&2
   printf '%s' "$http_code"
 }
 
@@ -447,7 +448,8 @@ action_smoke() {
   } > "${OUTPUT_DIR}/summary.txt"
 
   if [[ "$smoke_rc" != "0" ]]; then
-    fail "smoke ${SMOKE_ID} exited rc=${smoke_rc} (full log: smoke-${SMOKE_ID}.log)"
+    echo "[window-runner][error] smoke ${SMOKE_ID} exited rc=${smoke_rc} (full log: smoke-${SMOKE_ID}.log)" >&2
+    exit "$smoke_rc"
   fi
   log "smoke ${SMOKE_ID} OK (stamp ${stamp})"
 }

--- a/scripts/ops/attendance-window-runner-mint-token.mjs
+++ b/scripts/ops/attendance-window-runner-mint-token.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// attendance-window-runner-mint-token.mjs
+//
+// In-container helper for the attendance staging window-runner workflow
+// (.github/workflows/attendance-staging-window-runner.yml). Runs INSIDE the
+// staging backend container (docker exec), where JWT_SECRET and DATABASE_URL
+// are the staging realm's own values, so no secret ever leaves the host.
+//
+// Modes:
+//   --find-admin
+//       Prints the id of an existing ACTIVE users row with role='admin'
+//       (preferring id='admin'), or exits 3 if none exists. Read-only.
+//       Staging runs NODE_ENV=production, so verifyToken() loads the user from
+//       the DB and uses the DB role — a token is only useful when its subject
+//       is a real active DB user (see packages/core-backend/src/auth/AuthService.ts).
+//   --mint --user-id <id> [--roles a,b] [--perms p,q] [--expires-in 7200]
+//       Prints an HS256 JWT signed with the container's JWT_SECRET (staging
+//       realm). Zero-dependency signing (node:crypto), same shape as
+//       scripts/gen-dev-token.js. No `sid` claim is included on purpose: the
+//       session-registry check in verifyToken() only runs when `sid` is present.
+//
+// Prints ONLY the value (user id / token) on stdout so callers can capture it.
+
+import crypto from 'node:crypto'
+
+function base64url(input) {
+  return Buffer.from(input).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+}
+
+function parseArgs(argv) {
+  const opts = { mode: '', userId: '', roles: 'user', perms: '', expiresInSeconds: 7200 }
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--find-admin') opts.mode = 'find-admin'
+    else if (arg === '--mint') opts.mode = 'mint'
+    else if (arg === '--user-id') opts.userId = argv[++i] || ''
+    else if (arg === '--roles') opts.roles = argv[++i] || ''
+    else if (arg === '--perms') opts.perms = argv[++i] || ''
+    else if (arg === '--expires-in') opts.expiresInSeconds = Number.parseInt(argv[++i] || '7200', 10)
+    else {
+      console.error(`unknown argument: ${arg}`)
+      process.exit(2)
+    }
+  }
+  return opts
+}
+
+async function findAdmin() {
+  let pg
+  try {
+    pg = await import('pg')
+  } catch {
+    console.error('FAIL: package "pg" must be resolvable (run from a directory with node_modules linked, e.g. /tmp/window-runner).')
+    process.exit(2)
+  }
+  const databaseUrl = process.env.DATABASE_URL || ''
+  if (!databaseUrl) {
+    console.error('FAIL: DATABASE_URL is required (run inside the staging backend container).')
+    process.exit(2)
+  }
+  const pool = new pg.default.Pool({ connectionString: databaseUrl })
+  try {
+    const result = await pool.query(
+      `SELECT id FROM users
+       WHERE role = 'admin' AND (is_active IS DISTINCT FROM false)
+       ORDER BY (id = 'admin') DESC, created_at ASC NULLS LAST
+       LIMIT 1`,
+    )
+    if (result.rows.length === 0) {
+      console.error('FAIL: no active role=admin user exists in the staging database; the auth round-trip needs a real staging admin subject.')
+      process.exit(3)
+    }
+    console.log(String(result.rows[0].id))
+  } finally {
+    await pool.end()
+  }
+}
+
+function mint(opts) {
+  const secret = process.env.JWT_SECRET || ''
+  if (!secret) {
+    console.error('FAIL: JWT_SECRET is not set in this environment; refusing to mint with a fallback secret.')
+    process.exit(2)
+  }
+  if (!opts.userId) {
+    console.error('FAIL: --user-id is required for --mint.')
+    process.exit(2)
+  }
+  if (!Number.isFinite(opts.expiresInSeconds) || opts.expiresInSeconds <= 0 || opts.expiresInSeconds > 24 * 3600) {
+    console.error('FAIL: --expires-in must be a positive number of seconds (max 86400).')
+    process.exit(2)
+  }
+  const now = Math.floor(Date.now() / 1000)
+  const header = { alg: 'HS256', typ: 'JWT' }
+  const payload = {
+    id: opts.userId,
+    roles: opts.roles.split(',').map((v) => v.trim()).filter(Boolean),
+    perms: opts.perms.split(',').map((v) => v.trim()).filter(Boolean),
+    iat: now,
+    exp: now + opts.expiresInSeconds,
+  }
+  const data = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(data)
+    .digest('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
+  console.log(`${data}.${signature}`)
+}
+
+const opts = parseArgs(process.argv.slice(2))
+if (opts.mode === 'find-admin') {
+  await findAdmin()
+} else if (opts.mode === 'mint') {
+  mint(opts)
+} else {
+  console.error('usage: attendance-window-runner-mint-token.mjs --find-admin | --mint --user-id <id> [--roles a,b] [--perms p,q] [--expires-in <seconds>]')
+  process.exit(2)
+}

--- a/scripts/ops/attendance-window-runner-pipeline.lib.sh
+++ b/scripts/ops/attendance-window-runner-pipeline.lib.sh
@@ -1,0 +1,52 @@
+# attendance-window-runner-pipeline.lib.sh
+#
+# Shared pipeline helper for the attendance staging window-runner remote script
+# (scripts/ops/attendance-staging-window-runner-remote.sh). Sourced, not executed.
+#
+# Contract (proven by scripts/ops/attendance-window-runner-pipeline.test.mjs, which runs
+# this exact file under `bash -o pipefail -c`):
+#   filtered_pipe <output_file> <grep_ere_pattern> -- <producer command...>
+#     Runs `<producer> 2>&1 | grep -E <pattern> > <output_file>` and returns:
+#       0        when the producer succeeded — INCLUDING when grep matched ZERO lines
+#                (an empty filter result is a normal outcome, e.g. quiet logs);
+#       producer's exit code when the producer (first pipeline stage) failed,
+#                regardless of whether grep happened to match its partial output;
+#       grep's exit code when grep itself failed (rc > 1, e.g. a bad pattern).
+#
+# The caller is expected to run with pipefail enabled (`bash -o pipefail -c` or
+# `set -o pipefail`); this helper additionally reads PIPESTATUS explicitly so the
+# producer's failure is never masked by a succeeding grep, and a zero-match grep
+# (rc=1) is never misread as a failure.
+
+filtered_pipe() {
+  local out_file="$1"
+  local pattern="$2"
+  shift 2
+  if [ "${1:-}" = "--" ]; then
+    shift
+  fi
+  if [ "$#" -eq 0 ]; then
+    echo "[filtered_pipe] usage: filtered_pipe <output_file> <pattern> -- <cmd...>" >&2
+    return 64
+  fi
+
+  local -a pipe_status
+  set +e
+  "$@" 2>&1 | grep -E "$pattern" > "$out_file"
+  pipe_status=("${PIPESTATUS[@]}")
+  set -e
+
+  local producer_rc="${pipe_status[0]}"
+  local grep_rc="${pipe_status[1]}"
+
+  if [ "$producer_rc" -ne 0 ]; then
+    echo "[filtered_pipe] producer failed rc=${producer_rc} (cmd: $*)" >&2
+    return "$producer_rc"
+  fi
+  if [ "$grep_rc" -gt 1 ]; then
+    echo "[filtered_pipe] grep failed rc=${grep_rc} (pattern: ${pattern})" >&2
+    return "$grep_rc"
+  fi
+  # grep rc 0 (matches) or 1 (zero matches) with a healthy producer -> success.
+  return 0
+}

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// attendance-window-runner-pipeline.test.mjs
+//
+// Committed proof for the attendance staging window-runner's remote pipeline semantics
+// (owner-ruled acceptance for .github/workflows/attendance-staging-window-runner.yml):
+//
+//   (a) a grep with ZERO matches inside the pipeline still yields overall exit 0
+//       (zero matches is a normal outcome, e.g. filtering quiet logs), and
+//   (b) when the first pipeline stage (the `docker logs`-equivalent producer) FAILS,
+//       the overall exit is NONZERO (pipefail propagates).
+//
+// The tests run the EXACT committed helper (scripts/ops/attendance-window-runner-pipeline.lib.sh,
+// sourced by the remote script) under the EXACT invocation shape the workflow uses
+// (`bash -o pipefail -c '<script>'`), plus a raw-pipeline positive control proving the
+// `-o pipefail` flag itself is load-bearing (without it, the failure leg goes green).
+//
+// Wired into CI via scripts/ops/attendance-run-gate-contract-case.sh (strict case),
+// which the Attendance Gate Contract Matrix workflow runs on every pull request.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const LIB = join(HERE, 'attendance-window-runner-pipeline.lib.sh')
+const REMOTE_SH = join(HERE, 'attendance-staging-window-runner-remote.sh')
+const WORKFLOW = join(HERE, '..', '..', '.github', 'workflows', 'attendance-staging-window-runner.yml')
+
+function runPipefailBash(script) {
+  // Same shape as the workflow's remote invocation: bash -o pipefail -c '<script>'.
+  return spawnSync('bash', ['-o', 'pipefail', '-c', script], { encoding: 'utf8' })
+}
+
+function runPlainBash(script) {
+  return spawnSync('bash', ['-c', script], { encoding: 'utf8' })
+}
+
+test('leg (a): zero grep matches in the pipeline still exits 0 (normal outcome)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'window-runner-pipe-'))
+  const out = join(dir, 'filtered.log')
+  const result = runPipefailBash(
+    `set -euo pipefail
+source '${LIB}'
+filtered_pipe '${out}' 'PATTERN_THAT_MATCHES_NOTHING_XYZ' -- printf '%s\\n' alpha beta gamma
+echo POST_PIPE_REACHED`,
+  )
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}; stderr: ${result.stderr}`)
+  assert.match(result.stdout, /POST_PIPE_REACHED/, 'script must continue past the zero-match pipeline')
+  assert.equal(readFileSync(out, 'utf8'), '', 'zero matches must produce an empty filter file')
+})
+
+test('leg (b): producer failure propagates as a NONZERO overall exit, even when grep matches', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'window-runner-pipe-'))
+  const out = join(dir, 'filtered.log')
+  const result = runPipefailBash(
+    `set -euo pipefail
+source '${LIB}'
+filtered_pipe '${out}' 'partial' -- bash -c 'echo partial-output-before-crash; exit 7'
+echo MUST_NOT_REACH`,
+  )
+  assert.equal(result.status, 7, `expected the producer rc (7) to propagate, got ${result.status}`)
+  assert.doesNotMatch(result.stdout, /MUST_NOT_REACH/, 'a failed producer must abort the script')
+  assert.match(result.stderr, /producer failed rc=7/, 'the failure must name the producer rc')
+})
+
+test('leg (b) variant: producer failure with ZERO grep matches is still NONZERO (not misread as leg a)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'window-runner-pipe-'))
+  const out = join(dir, 'filtered.log')
+  const result = runPipefailBash(
+    `set -euo pipefail
+source '${LIB}'
+filtered_pipe '${out}' 'PATTERN_THAT_MATCHES_NOTHING_XYZ' -- bash -c 'echo noise; exit 5'`,
+  )
+  assert.equal(result.status, 5, `expected producer rc (5), got ${result.status}; stderr: ${result.stderr}`)
+})
+
+test('positive control: the -o pipefail wrapper is load-bearing for raw pipelines', () => {
+  // Raw pipeline (no helper), same shape as `docker exec ... | tee log` in the remote
+  // script: with pipefail the producer failure propagates; without it the pipe goes
+  // green — which is exactly why the workflow must wrap the remote command in
+  // `bash -o pipefail -c` instead of relying on the SSH login shell.
+  const script = `bash -c 'echo produced; exit 9' | cat > /dev/null`
+  const withPipefail = runPipefailBash(script)
+  assert.equal(withPipefail.status, 9, 'with pipefail, the raw pipeline must fail with the producer rc')
+  const withoutPipefail = runPlainBash(script)
+  assert.equal(withoutPipefail.status, 0, 'control: without pipefail the same pipeline exits 0 (masking the failure)')
+})
+
+test('embedded scripts parse (bash -n) — remote runner + pipeline lib', () => {
+  for (const file of [REMOTE_SH, LIB]) {
+    const result = spawnSync('bash', ['-n', file], { encoding: 'utf8' })
+    assert.equal(result.status, 0, `bash -n failed for ${file}: ${result.stderr}`)
+  }
+})
+
+test('workflow shape contract: remote commands run under explicit `bash -o pipefail -c`', () => {
+  assert.ok(existsSync(WORKFLOW), `workflow file missing: ${WORKFLOW}`)
+  const yaml = readFileSync(WORKFLOW, 'utf8')
+  const pipefailInvocations = yaml.match(/bash -o pipefail -c/g) || []
+  assert.ok(
+    pipefailInvocations.length >= 2,
+    `expected every remote (ssh) command to be wrapped in \`bash -o pipefail -c\` (sync + action), found ${pipefailInvocations.length}`,
+  )
+  assert.doesNotMatch(yaml, /bash\s+-s\b/, 'the workflow must not fall back to `ssh ... bash -s` (login-shell pipefail is not guaranteed)')
+})
+
+test('staging-only contract: the remote script names only staging containers', () => {
+  const source = readFileSync(REMOTE_SH, 'utf8')
+  for (const name of [
+    'metasheet-staging-backend',
+    'metasheet-staging-web',
+    'metasheet-staging-postgres',
+    'metasheet-staging-redis',
+  ]) {
+    assert.match(source, new RegExp(name), `remote script must pin ${name}`)
+  }
+  // Any literal prod-track container name (not merely the metasheet-staging- prefix)
+  // in the remote script is a regression.
+  const withoutStaging = source.replaceAll(/metasheet-staging-(backend|web|postgres|redis)/g, '')
+  assert.doesNotMatch(
+    withoutStaging,
+    /['"]metasheet-(backend|web|postgres|redis)['"]/,
+    'remote script must never reference prod-track container names',
+  )
+  assert.match(source, /docker-compose\.app\.staging\.yml/, 'remote script must pin the staging compose file')
+  assert.doesNotMatch(
+    source.replaceAll('docker-compose.app.staging.yml', ''),
+    /docker-compose\.app\.yml/,
+    'remote script must never reference the prod-track compose file',
+  )
+})


### PR DESCRIPTION
One dispatchable workflow (`attendance-staging-window-runner.yml`) that runs ONE action per dispatch of the attendance five-window staging acceptance (`docs/development/attendance-staging-window-bundle-20260702.md`), against the STAGING stack only. Refs #3317.

## What each action does

**`action=deploy`** (requires `deploy_sha` = full 40-char SHA)
- Writes a runner-owned override (`docker-compose.window-runner.override.yml` in the staging stack dir, previous copy backed up) pinning `ghcr.io/zensgit/metasheet2-{backend,web}:<full-sha>`; with `set_window_env=rd-window` it also pins `ATTENDANCE_SCHEDULER_ENABLED=true` + `ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED=true` on the backend — env flips happen together with the deploy, never mid-smoke (bundle §3.4). The digest gate is asserted NOT `true` in the running container on every deploy.
- `docker compose -f docker-compose.app.staging.yml -f <override> pull backend web` then `up -d --no-deps backend web`. Staging postgres/redis are never recreated — asserted by comparing their container ids before/after.
- Captures the pending-migration list BEFORE (`migrate.js --list`), runs the committed migration alignment report in-container and hard-stops on `decision=do_not_run_full_migrate` (bundle §3.2), runs `migrate.js`, captures AFTER and asserts `Pending: 0`.
- Verifies `curl 127.0.0.1:8082/api/health` `build.commit == deploy_sha` (with retries), then the bundle §3 auth round-trip: an in-container staging-realm token (see decisions below) must get `200` from BOTH `/api/auth/me` and `/api/attendance/settings`.
- Everything (override copy, compose logs, migrate lists, alignment report, health/auth evidence, `docker ps`) is uploaded as the run artifact.

**`action=smoke`** (requires `deploy_sha`, `smoke` = one of `ae4 | rd45 | otbank-v18 | mp6 | hmr5`)
- Refuses if `deploy_sha` is empty/short, and refuses if the live `/api/health` `build.commit` differs from it (every stamp must name the exact deployed SHA — the precedent window's lesson, bundle §2).
- `docker cp`s the selected smoke helper from the host-synced repo into the staging backend container under `/tmp/window-runner/` and runs it in-container with `BASE_URL=http://127.0.0.1:8900` (backend-direct, in-container precedent), `DATABASE_URL` from the container's own env, `DEPLOY_SHA`, a run-scoped `STAMP` (`<family>-gh<run_id>a<attempt>`), and the tokens each helper needs (mapping below). The five helper paths are exactly the bundle §1 table's `scripts/ops/staging-attendance-*-smoke.mjs`.
- Captures `GET /api/attendance/settings` BEFORE and AFTER the smoke to the artifact (window-level settings-restore evidence, bundle §5), plus the full smoke stdout/stderr and a filtered backend log slice.
- The job fails iff the smoke exits nonzero, and it propagates the helper's exact exit code.

**`action=status`** (read-only)
- `docker ps` for the staging containers, `/api/health` via 8082 and 18900, current settings document, pending-migration list, and the window env-flag snapshot → artifact. Exits nonzero if the backend container is not running (honest signal; artifacts still uploaded).

## Owner-constraint proofs

1. **Explicit `bash -o pipefail -c '<script>'` for every remote pipeline.** Both SSH invocations (script sync and action run) send the remote command exactly as `bash -o pipefail -c '<script>'` — never a login-shell default or `-s` stdin form. The `<script>` is a short regex-validated prelude that runs the committed `scripts/ops/attendance-staging-window-runner-remote.sh`, which itself re-asserts `set -euo pipefail`.
2. **Committed self-test proving BOTH legs** — `scripts/ops/attendance-window-runner-pipeline.test.mjs` (`node --test`, 7 tests) runs the exact committed pipeline helper (`attendance-window-runner-pipeline.lib.sh`, sourced by the remote script) under the exact `bash -o pipefail -c` shape:
   - leg (a): grep with ZERO matches inside the pipeline → overall exit 0, empty filter file, script continues;
   - leg (b): failing first stage (the `docker logs`-equivalent) → overall exit is the producer's nonzero rc, even when grep matched, and also when grep matched nothing;
   - a raw-pipeline positive control shows `-o pipefail` itself is load-bearing (same pipeline exits 0 without it);
   - plus `bash -n` on the extracted scripts and shape contracts (workflow uses `bash -o pipefail -c`; remote script names only `metasheet-staging-*`).
   **Mutation check (the mutation was verified applied before trusting the red):** removing the producer-rc propagation from the lib turned exactly the two failure-leg tests RED (5/7) while leg (a) stayed green; restored → 7/7.
   **Wiring:** the test is added to the `strict` case of `scripts/ops/attendance-run-gate-contract-case.sh`, which the `Attendance Gate Contract Matrix` workflow runs on every pull request (`on: pull_request` → `attendance-run-gate-contract-case.sh strict`) — this PR's own checks execute it (the "running staging window-runner pipeline contract" line in the strict-case log). The window-runner workflow additionally self-runs the same test on every dispatch before touching SSH, and a `verify:attendance-window-runner:pipeline:test` package script is registered.
3. **Never touches the prod-track stack, fail-closed.** The remote script fails closed when `<staging-dir>/docker-compose.app.staging.yml` is absent; refuses compose files that do not define `metasheet-staging-backend`/`-web` or that define prod-track container names; refuses `staging dir == prod repo dir`; the only compose entry point pins the staging file + runner override; all exec/cp/logs go through the pinned `metasheet-staging-backend` name; deploy asserts postgres/redis container ids unchanged (a positive control, not just the absence of a recreate call).
4. **Lint/sanity:** workflow parses (`python3 yaml.safe_load` OK), `bash -n` on both shell scripts and `node --check` on the mint helper pass locally AND re-run as a workflow step on every dispatch before SSH.

## Local rehearsal (stubbed docker/curl through the real escaped invocation)

All three actions were rehearsed locally through the exact prelude construction, sed quoting, and `bash -o pipefail -c` path, with stub `docker`/`curl` binaries:
- fail-closed: missing staging dir; prod-shaped compose file; 9-char SHA (the `manifest unknown` postmortem refusal message surfaced); `decision=do_not_run_full_migrate` stops BEFORE migrate ever runs;
- deploy: override content verified for both env modes (none = images only; rd-window = images + the two flags), `Pending: 0` assertion, postgres/redis id check, auth round-trip;
- smoke: per-smoke token env mapping verified for all five smokes, exact rc propagation (rc=3 helper → rc=3 job), settings before/after captured, filtered log slice keeps matches and tolerates zero matches.
The rehearsal caught and repaired one real bug (command-substitution capture polluted by a stdout log line in `capture_settings`).

## Design decisions (divergences / ambiguity resolutions — for gate review)

1. **Remote logic lives in committed scripts, synced per-run** (`attendance-staging-window-runner-remote.sh` + lib + mint helper, tar-synced to a per-run `/tmp` dir and cleaned up), instead of a giant inline `remote_cmds` array as in the log-snapshot precedent. The remote command is still exactly `bash -o pipefail -c '<prelude>'`; committed files are what `bash -n` and the self-test exercise.
2. **`/tmp` docker-cp + `node_modules` symlink + `PLUGIN_INDEX_PATH`.** The smokes are copied to `/tmp/window-runner/scripts/ops/` as specced, but bare ESM `import('pg')` cannot resolve from `/tmp`, so the runner symlinks `/app/node_modules` next to them; rd45's producer seam is pinned to the deployed image's `/app/plugins/plugin-attendance/index.cjs` (an env override the helper already supports), which is exactly "the shipped seam at the deployed SHA" its runbook requires.
3. **Token mint path (bundle §9 OQ-5 was an explicit open question).** Staging runs `NODE_ENV=production`: `/api/auth/dev-token` 404s and trusted-claims are inert, and `verifyToken` requires the subject to be an existing ACTIVE `users` row (DB role wins). The runner therefore mints in-container (HS256 with the container's own `JWT_SECRET`; no `sid` claim, so the session gate is not engaged; zero-dep, same shape as `scripts/gen-dev-token.js`): the ADMIN token's subject is an existing active `role='admin'` user discovered read-only (prefer id `admin`; fail closed if none), and the per-smoke tokens (`NON_ADMIN`, `CASE1..DORMANT`, `SUBJECT`, `SCOPED`) are minted for the helper-seeded `${STAMP}-<suffix>` synthetic users. Secrets never leave the host; tokens are never logged.
4. **Auth round-trip = both checks.** `/api/auth/me == 200` (as specced) plus `GET /api/attendance/settings == 200` (bundle §3's own round-trip; a 503 there = schema gap = STOP).
5. **Migration gate.** The committed alignment report runs in-container from the deployed image's own `/app/scripts` copy against the captured BEFORE list; only `do_not_run_full_migrate` blocks (the bundle's STOP condition); other decisions are recorded in the artifact.
6. **Staging stack location** is not derivable from the repo: `STAGING_DEPLOY_PATH` repo variable with default `metasheet2-dingtalk-staging` (the documented staging dir), fail-closed if the staging compose file is not there.
7. **Pinning via a runner-owned override file** (flag-pinning override precedent) instead of editing the staging `.env`: full-SHA image pins plus (only in rd-window mode) the two env flags. A later `set_window_env=none` deploy drops the flags — that is the bundle §7 rollback path. Any pre-existing override is backed up with a timestamp. Note: if the live stack was manually started with extra ad-hoc override files, a runner deploy recreates backend/web from base + runner override only (a clean single-SHA window posture; the backup preserves the operator's rollback).
8. **`docker exec` on pinned container names** for everything except pull/up (compose project-name drift immunity); `curl` health parsing uses `python3` (proven present on the host by the prod deploy job) rather than assuming `jq`.
9. **Timeout stays 15 min** per the log-snapshot model; a cold GHCR pull that exceeds it is re-dispatchable (the `concurrency` group serializes runs, `cancel-in-progress: false`).
10. **`status` exits nonzero when the backend is down** — read-only but not always-green, so a dispatcher gets an honest signal.

## Precedents followed

- `attendance-remote-log-snapshot-prod.yml` — SSH via `DEPLOY_HOST`/`DEPLOY_USER`/`DEPLOY_SSH_KEY_B64`, host repo sync discipline, artifact upload, 15-min timeout, concurrency group, `continue-on-error` + explicit fail step.
- `docker-build.yml` deploy job — full-40-char-SHA tag enforcement, compose-v2-only detection, `migrate.js` with stdin redirect, health polling.
- The 2026-04-26 staging deploy postmortem — 9-char tag `manifest unknown` refusal; the flag-pinning override operator checklist — override + `up -d backend web` pattern.
- The C5-5 staging evidence — smokes run from inside the deployed backend container (backend-direct `BASE_URL`).

## Not in scope / follow-ups

- The manual steps stay manual by design: AE-3 modal probe, per-runbook final `*_STAGING_SMOKE_PASS` stamps, the §7 consolidated residue sweep, and the umbrella-issue close note remain operator/runbook actions; this workflow produces the deploy/smoke/status evidence they consume.
- First real dispatch (`action=status`) against the host will confirm the `STAGING_DEPLOY_PATH` default and can happen before any deploy since it is read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
