### PR TITLE
feat(metrics): DingTalk OAuth state-operation counters — real producer for the stability check

### DIFF
--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -18,6 +18,7 @@ import {
   readDingTalkAllowedCorpIds,
 } from '../integrations/dingtalk/runtime-policy'
 import { getBcryptSaltRounds } from '../security/auth-runtime-config'
+import { recordDingTalkOAuthStateFallback, recordDingTalkOAuthStateOperation } from '../metrics/metrics'
 
 const logger = new Logger('DingTalkOAuth')
 
@@ -849,9 +850,14 @@ export async function generateState(options: {
     // per process. Deployments that require a shared store fail closed instead of
     // silently degrading to memory.
     if (isDingTalkOAuthSharedStateStoreRequired()) {
+      recordDingTalkOAuthStateOperation('write', 'error')
       throw new DingTalkOAuthStateStoreUnavailableError()
     }
     writeStateToMemory(state, record)
+    recordDingTalkOAuthStateFallback('write')
+    recordDingTalkOAuthStateOperation('write', 'ok')
+  } else {
+    recordDingTalkOAuthStateOperation('write', 'ok')
   }
 
   return state
@@ -861,21 +867,45 @@ export async function validateState(state: string): Promise<StateValidationResul
   if (!state) return { valid: false, error: 'Missing required parameter: state' }
 
   const redisResult = await validateStateFromRedis(state)
+  // `null` means the shared store was unavailable (no client / a failed exec / a thrown
+  // error) — a real Redis answer (valid, invalid/miss, or expired) is always non-null. This
+  // distinction drives both the ok/error split and whether falling through to memory counts
+  // as fallback degradation below.
+  const redisStoreUnavailable = redisResult === null
 
   // DT-OPS-05: when a shared store is required, NEVER consult the per-process Map — a
   // transient Redis outage must fail the login rather than quietly fall through to a
   // store the other replicas cannot see. `null` here means the store was unavailable
   // (a real miss returns an explicit invalid result).
   if (isDingTalkOAuthSharedStateStoreRequired()) {
-    if (redisResult) return redisResult
+    if (redisResult) {
+      recordDingTalkOAuthStateOperation('validate', 'ok')
+      return redisResult
+    }
+    recordDingTalkOAuthStateOperation('validate', 'error')
     logger.error('DingTalk OAuth state store is unavailable and a shared store is required; refusing the login')
     return { valid: false, error: 'DingTalk login is temporarily unavailable. Please try again.' }
   }
 
-  if (redisResult?.valid) return redisResult
-  if (redisResult?.error === 'State parameter has expired') return redisResult
+  if (redisResult?.valid) {
+    recordDingTalkOAuthStateOperation('validate', 'ok')
+    return redisResult
+  }
+  if (redisResult?.error === 'State parameter has expired') {
+    recordDingTalkOAuthStateOperation('validate', 'ok')
+    return redisResult
+  }
 
-  return validateStateFromMemory(state)
+  // Either Redis was unavailable (redisStoreUnavailable) or it gave a clean miss that still
+  // falls through to the defensive memory check (normal single-replica flow). Only the
+  // unavailable case is a fallback signal — a clean miss falling through here is expected
+  // behavior, not degradation.
+  if (redisStoreUnavailable) {
+    recordDingTalkOAuthStateFallback('validate')
+  }
+  const memoryResult = validateStateFromMemory(state)
+  recordDingTalkOAuthStateOperation('validate', 'ok')
+  return memoryResult
 }
 
 export async function __resetDingTalkOAuthStateStoreForTests(): Promise<void> {

--- a/packages/core-backend/src/metrics/__tests__/dingtalk-oauth-state-metrics.test.ts
+++ b/packages/core-backend/src/metrics/__tests__/dingtalk-oauth-state-metrics.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Real registry + real /metrics/prom endpoint test for the DingTalk OAuth state-operations
+ * metrics producer (metasheet_dingtalk_oauth_state_operations_total /
+ * metasheet_dingtalk_oauth_state_fallback_total).
+ *
+ * This intentionally does NOT mock prom-client, express, or the metrics registry — it boots
+ * a real express app, mounts the real installMetrics() route, and scrapes it with supertest,
+ * because scripts/ops/dingtalk-oauth-stability-check.sh gates its verdict on a real scrape of
+ * a real deployed instance ever containing a SAMPLE line (not '# HELP'/'# TYPE') that
+ * startswith('metasheet_dingtalk_oauth_state_operations_total'). A test against mocked metrics
+ * text would not prove the producer is wired end-to-end.
+ *
+ * Test order is deliberate and load-bearing: the presence-at-zero assertion MUST run before
+ * any OAuth state operation executes in this file, because the counters are module-level
+ * singletons and vitest runs `it` blocks within a file sequentially by default.
+ */
+import express from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { installMetrics } from '../metrics'
+import {
+  __resetDingTalkOAuthStateStoreForTests,
+  generateState,
+  validateState,
+} from '../../auth/dingtalk-oauth'
+
+const OPERATIONS_METRIC = 'metasheet_dingtalk_oauth_state_operations_total'
+const FALLBACK_METRIC = 'metasheet_dingtalk_oauth_state_fallback_total'
+
+// Mirrors the check script's `matching()` helper (scripts/ops/dingtalk-oauth-stability-check.sh):
+// a plain `line.startswith(prefix)` over the raw scrape text — '# HELP' / '# TYPE' comment
+// lines never match a metric-name prefix, only SAMPLE lines do.
+function sampleLinesStartingWith(body: string, prefix: string): string[] {
+  return body.split('\n').filter((line) => line.startsWith(prefix))
+}
+
+function buildApp() {
+  const app = express()
+  installMetrics(app)
+  return app
+}
+
+describe('DingTalk OAuth state metrics (real registry + real endpoint)', () => {
+  beforeEach(() => {
+    delete process.env.METRICS_SCRAPE_TOKEN
+    delete process.env.REDIS_URL
+    delete process.env.REDIS_HOST
+    delete process.env.DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE
+  })
+
+  it('reports the operations metric as present at zero before any OAuth state operation runs', async () => {
+    const res = await request(buildApp()).get('/metrics/prom')
+
+    expect(res.status).toBe(200)
+
+    const operationLines = sampleLinesStartingWith(res.text, OPERATIONS_METRIC)
+    // 2 operations (write/validate) x 2 results (ok/error) = 4 zero-initialized combinations.
+    expect(operationLines).toHaveLength(4)
+
+    const writeOk = operationLines.find((line) =>
+      line.startsWith(`${OPERATIONS_METRIC}{operation="write",result="ok"}`))
+    const writeError = operationLines.find((line) =>
+      line.startsWith(`${OPERATIONS_METRIC}{operation="write",result="error"}`))
+    const validateOk = operationLines.find((line) =>
+      line.startsWith(`${OPERATIONS_METRIC}{operation="validate",result="ok"}`))
+    const validateError = operationLines.find((line) =>
+      line.startsWith(`${OPERATIONS_METRIC}{operation="validate",result="error"}`))
+
+    for (const line of [writeOk, writeError, validateOk, validateError]) {
+      expect(line).toBeDefined()
+      // The SAMPLE line's trailing token is the value; zero-init means it must read exactly 0,
+      // proving liveness (the producer emitted the series) rather than traffic.
+      expect(line?.trim().endsWith(' 0')).toBe(true)
+    }
+
+    const fallbackLines = sampleLinesStartingWith(res.text, FALLBACK_METRIC)
+    expect(fallbackLines).toHaveLength(2)
+    for (const line of fallbackLines) {
+      expect(line.trim().endsWith(' 0')).toBe(true)
+    }
+  })
+
+  it('increments write/ok, fallback{write}, and validate/ok after a real memory-path OAuth round trip', async () => {
+    // No REDIS_URL/REDIS_HOST configured in this test env, so getRedisStateClient() short-
+    // circuits to null and both calls take the in-process memory fallback path for real —
+    // this is not a mocked Redis outage, it is simply no shared store being configured.
+    await __resetDingTalkOAuthStateStoreForTests()
+
+    const state = await generateState({ redirectPath: '/attendance' })
+    const validation = await validateState(state)
+    expect(validation).toEqual({ valid: true, redirectPath: '/attendance' })
+
+    const res = await request(buildApp()).get('/metrics/prom')
+    expect(res.status).toBe(200)
+
+    const operationLines = sampleLinesStartingWith(res.text, OPERATIONS_METRIC)
+    const writeOkLine = operationLines.find((line) =>
+      line.startsWith(`${OPERATIONS_METRIC}{operation="write",result="ok"}`))
+    const validateOkLine = operationLines.find((line) =>
+      line.startsWith(`${OPERATIONS_METRIC}{operation="validate",result="ok"}`))
+    expect(writeOkLine).toBeDefined()
+    expect(validateOkLine).toBeDefined()
+    expect(Number(writeOkLine?.trim().split(' ').pop())).toBeGreaterThanOrEqual(1)
+    expect(Number(validateOkLine?.trim().split(' ').pop())).toBeGreaterThanOrEqual(1)
+
+    const fallbackLines = sampleLinesStartingWith(res.text, FALLBACK_METRIC)
+    const fallbackWriteLine = fallbackLines.find((line) =>
+      line.startsWith(`${FALLBACK_METRIC}{operation="write"}`))
+    expect(fallbackWriteLine).toBeDefined()
+    expect(Number(fallbackWriteLine?.trim().split(' ').pop())).toBeGreaterThanOrEqual(1)
+
+    // Negative control: the scraped metrics body must never contain the raw state UUID —
+    // labels are the fixed 'operation'/'result' enums only, never state values or user data.
+    expect(res.text).not.toContain(state)
+  })
+})

--- a/packages/core-backend/src/metrics/__tests__/dingtalk-oauth-state-metrics.test.ts
+++ b/packages/core-backend/src/metrics/__tests__/dingtalk-oauth-state-metrics.test.ts
@@ -21,6 +21,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { installMetrics } from '../metrics'
 import {
   __resetDingTalkOAuthStateStoreForTests,
+  DingTalkOAuthStateStoreUnavailableError,
   generateState,
   validateState,
 } from '../../auth/dingtalk-oauth'
@@ -109,9 +110,39 @@ describe('DingTalk OAuth state metrics (real registry + real endpoint)', () => {
       line.startsWith(`${FALLBACK_METRIC}{operation="write"}`))
     expect(fallbackWriteLine).toBeDefined()
     expect(Number(fallbackWriteLine?.trim().split(' ').pop())).toBeGreaterThanOrEqual(1)
+    // The validate side consulted memory for the same reason (no shared store) — the
+    // degradation signal must cover both directions, not just the write.
+    const fallbackValidateLine = fallbackLines.find((line) =>
+      line.startsWith(`${FALLBACK_METRIC}{operation="validate"}`))
+    expect(fallbackValidateLine).toBeDefined()
+    expect(Number(fallbackValidateLine?.trim().split(' ').pop())).toBeGreaterThanOrEqual(1)
 
     // Negative control: the scraped metrics body must never contain the raw state UUID —
     // labels are the fixed 'operation'/'result' enums only, never state values or user data.
     expect(res.text).not.toContain(state)
+  })
+
+  it('increments write/error and validate/error when a shared state store is required but unavailable', async () => {
+    // Shared-required mode with no Redis configured: generateState() must fail closed
+    // (throw) and validateState() must refuse — and BOTH must leave an error sample
+    // behind, so a real multi-replica store outage is visible in /metrics/prom instead
+    // of only in logs. These are the branches the stability gate cannot exercise live.
+    await __resetDingTalkOAuthStateStoreForTests()
+    process.env.DINGTALK_OAUTH_REQUIRE_SHARED_STATE_STORE = 'true'
+
+    await expect(generateState()).rejects.toThrow(DingTalkOAuthStateStoreUnavailableError)
+    const refusal = await validateState('not-a-real-state')
+    expect(refusal.valid).toBe(false)
+
+    const res = await request(buildApp()).get('/metrics/prom')
+    expect(res.status).toBe(200)
+
+    const operationLines = sampleLinesStartingWith(res.text, OPERATIONS_METRIC)
+    const writeErrorLine = operationLines.find((line) =>
+      line.startsWith(`${OPERATIONS_METRIC}{operation="write",result="error"}`))
+    const validateErrorLine = operationLines.find((line) =>
+      line.startsWith(`${OPERATIONS_METRIC}{operation="validate",result="error"}`))
+    expect(Number(writeErrorLine?.trim().split(' ').pop())).toBeGreaterThanOrEqual(1)
+    expect(Number(validateErrorLine?.trim().split(' ').pop())).toBeGreaterThanOrEqual(1)
   })
 })

--- a/packages/core-backend/src/metrics/metrics.ts
+++ b/packages/core-backend/src/metrics/metrics.ts
@@ -483,6 +483,25 @@ const approvalSlaSchedulerLeaderGauge = gauge({
   labelNames: ['state'] as const
 })
 
+// DingTalk OAuth state-store operations (packages/core-backend/src/auth/dingtalk-oauth.ts).
+// `operation` is the state-store action ('write' from generateState, 'validate' from
+// validateState); `result` is the outcome ('ok' | 'error'). Cardinality is fixed at 2x2 —
+// state values / user data must never appear in labels.
+const dingtalkOAuthStateOperationsTotal = counter({
+  name: 'metasheet_dingtalk_oauth_state_operations_total',
+  help: 'DingTalk OAuth state store operations (write/validate) by result (ok/error)',
+  labelNames: ['operation', 'result'] as const
+})
+
+// Counts operations that fell back to the in-process memory store because the shared
+// (Redis) state store was unavailable — a normal Redis miss/expiry falling through to
+// memory in single-replica mode does NOT count here, only store-unavailable degradation.
+const dingtalkOAuthStateFallbackTotal = counter({
+  name: 'metasheet_dingtalk_oauth_state_fallback_total',
+  help: 'DingTalk OAuth state operations that used the in-process memory fallback because the shared (Redis) state store was unavailable',
+  labelNames: ['operation'] as const
+})
+
 registry.registerMetric(httpHistogram)
 registry.registerMetric(httpSummary)
 registry.registerMetric(httpRequestsTotal)
@@ -554,6 +573,23 @@ registry.registerMetric(apigwCbStoreUsedTotal)
 registry.registerMetric(apigwCbInitTotal)
 registry.registerMetric(automationSchedulerLeaderGauge)
 registry.registerMetric(approvalSlaSchedulerLeaderGauge)
+registry.registerMetric(dingtalkOAuthStateOperationsTotal)
+registry.registerMetric(dingtalkOAuthStateFallbackTotal)
+
+// Zero-initialize every DingTalk OAuth state label combination at module registration.
+// prom-client emits NO sample line for a labeled counter until its first .inc() call —
+// the DingTalk OAuth-stability check (scripts/ops/dingtalk-oauth-stability-check.sh)
+// matches SAMPLE lines only (`line.startswith('metasheet_dingtalk_oauth_state_operations_total')`;
+// '# HELP'/'# TYPE' comment lines do not count), so a zero-traffic window must still show
+// the metric as PRESENT — this line exists to prove the producer is wired, not that traffic
+// happened. Without this, a freshly-deployed or idle instance would read as "no OAuth
+// metrics" even though generateState/validateState are correctly instrumented.
+for (const dingtalkOAuthStateOperation of ['write', 'validate'] as const) {
+  for (const dingtalkOAuthStateResult of ['ok', 'error'] as const) {
+    dingtalkOAuthStateOperationsTotal.inc({ operation: dingtalkOAuthStateOperation, result: dingtalkOAuthStateResult }, 0)
+  }
+  dingtalkOAuthStateFallbackTotal.inc({ operation: dingtalkOAuthStateOperation }, 0)
+}
 
 function trimConfiguredMetricsToken(raw: string | undefined): string | null {
   const token = typeof raw === 'string' ? raw.trim() : ''
@@ -702,7 +738,10 @@ export const metrics = {
   apigwCbStoreUsedTotal,
   apigwCbInitTotal,
   automationSchedulerLeaderGauge,
-  approvalSlaSchedulerLeaderGauge
+  approvalSlaSchedulerLeaderGauge,
+  // DingTalk OAuth state-store operations
+  dingtalkOAuthStateOperationsTotal,
+  dingtalkOAuthStateFallbackTotal
 }
 
 /**
@@ -719,4 +758,29 @@ export function observeRpcLatency(
   durationSeconds: number
 ): void {
   rpcLatencySeconds.labels(method, plugin, status).observe(durationSeconds)
+}
+
+export type DingTalkOAuthStateOperation = 'write' | 'validate'
+export type DingTalkOAuthStateOperationResult = 'ok' | 'error'
+
+/**
+ * Record a DingTalk OAuth state-store operation outcome (write from generateState,
+ * validate from validateState). Never pass the state value or any user data — only
+ * the fixed 'operation'/'result' enums, to keep label cardinality bounded.
+ */
+export function recordDingTalkOAuthStateOperation(
+  operation: DingTalkOAuthStateOperation,
+  result: DingTalkOAuthStateOperationResult
+): void {
+  dingtalkOAuthStateOperationsTotal.labels(operation, result).inc()
+}
+
+/**
+ * Record that a DingTalk OAuth state operation fell back to the in-process memory store
+ * because the shared (Redis) state store was unavailable. Do NOT call this for a normal
+ * Redis miss/expiry falling through to memory in single-replica mode — only for genuine
+ * store-unavailable degradation.
+ */
+export function recordDingTalkOAuthStateFallback(operation: DingTalkOAuthStateOperation): void {
+  dingtalkOAuthStateFallbackTotal.labels(operation).inc()
 }


### PR DESCRIPTION
## What

The DingTalk OAuth stability check (`scripts/ops/dingtalk-oauth-stability-check.sh`, PR #4253) gates its verdict on `metasheet_dingtalk_oauth_state_operations_total` being present in `/metrics/prom` — but no producer of that metric existed anywhere on main. This PR lands the real producer:

- `metasheet_dingtalk_oauth_state_operations_total{operation=write|validate, result=ok|error}` and `metasheet_dingtalk_oauth_state_fallback_total{operation}` in `packages/core-backend/src/metrics/metrics.ts`, following the module's existing counter idiom.
- **Zero-initialized label series at registration** — prom-client emits no sample line for a labeled counter before its first `inc()\), and the stability check matches sample lines only; a zero-traffic window must still show the producer as alive.
- Instrumentation in `packages/core-backend/src/auth/dingtalk-oauth.ts`: `generateState()` / `validateState()` record ok/error per operation; the fallback counter rises only when the shared (Redis) store was **unavailable** and the in-process memory store was consulted — a clean Redis miss in single-replica mode is normal flow, not degradation. Shared-required refusals record `result=error` before failing closed. Labels are fixed enums only; state values never appear.

## Tests (real registry, real endpoint — no mocks)

`packages/core-backend/src/metrics/__tests__/dingtalk-oauth-state-metrics.test.ts` boots a real express app with the real `installMetrics()` route and scrapes `/metrics/prom` via supertest:
1. **Boot presence**: all 4+2 label series present at exactly `0` before any OAuth operation (the liveness property the stability check needs).
2. **Memory round trip**: `generateState` → `validateState` increments write/ok, validate/ok, fallback{write}, fallback{validate}.
3. **Shared-required outage**: store required + no Redis → `generateState` throws and `validateState` refuses, each leaving an `result="error"` sample ≥ 1.
4. Negative control: the scrape body never contains the raw state UUID.

Runs in the required `test (20.x)` check (`vitest run`, no path filter).

## Landing order

First rung of the DT-CLOSE-01B landing sequence: producer → #4253 (check + summary migration) → #4255 (docs/contract corrections). The live stability workflow can only go green once this producer is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)