### PR TITLE
feat(attendance): window-runner migrate action — backup + clone-rehearsal + apply per alignment runbook (refs #3317)

### DIFF
--- a/.github/workflows/attendance-staging-window-runner.yml
+++ b/.github/workflows/attendance-staging-window-runner.yml
@@ -4,9 +4,16 @@ run-name: "Attendance Staging Window Runner: ${{ inputs.action }}${{ inputs.acti
 
 # One dispatch = ONE action of the attendance five-window staging acceptance
 # (docs/development/attendance-staging-window-bundle-20260702.md):
-#   deploy — pin staging backend+web to a full-SHA GHCR tag, migrate, verify build+auth
-#   smoke  — run one window smoke (ae4 / rd45 / otbank-v18 / mp6 / hmr5) in-container
-#   status — read-only staging snapshot
+#   deploy  — pin staging backend+web to a full-SHA GHCR tag, migrate, verify build+auth
+#   smoke   — run one window smoke (ae4 / rd45 / otbank-v18 / mp6 / hmr5) in-container
+#   status  — read-only staging snapshot
+#   migrate — backup + clone-rehearsal + apply, per docs/operations/staging-migration-
+#             alignment-runbook.md. The only path forward from action=deploy's migration-
+#             alignment gate reporting `do_not_run_full_migrate`: pg_dump the real staging
+#             DB to a host file (metadata-only in the artifact — never the dump itself),
+#             restore it into a throwaway rehearsal DB inside the same postgres container,
+#             run migrate.js against ONLY the rehearsal DB, and only touch the real staging
+#             DB once that rehearsal is fully green.
 #
 # Modeled on attendance-remote-log-snapshot-prod.yml (SSH via deploy secrets, artifact
 # upload, 15-minute timeout, single concurrency group). Remote logic lives in the
@@ -26,7 +33,7 @@ on:
         description: 'What to run against the STAGING stack'
         required: true
         type: choice
-        options: [deploy, smoke, status]
+        options: [deploy, smoke, status, migrate]
         default: status
       deploy_sha:
         description: 'FULL 40-char commit SHA (GHCR tags are full-SHA). Required for deploy and smoke.'
@@ -71,7 +78,7 @@ jobs:
           SET_WINDOW_ENV: ${{ inputs.set_window_env }}
         run: |
           set -euo pipefail
-          case "$ACTION" in deploy|smoke|status) ;; *) echo "invalid action: $ACTION" >&2; exit 2 ;; esac
+          case "$ACTION" in deploy|smoke|status|migrate) ;; *) echo "invalid action: $ACTION" >&2; exit 2 ;; esac
           if [[ "$ACTION" == "deploy" || "$ACTION" == "smoke" ]]; then
             if [[ ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
               echo "deploy_sha must be the FULL 40-char lowercase commit SHA for action=$ACTION (GHCR tags are full-SHA; short prefixes fail with manifest unknown), got: '$DEPLOY_SHA'" >&2

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -598,13 +598,18 @@ action_migrate_rehearse() {
   # real staging DB is never touched by this function. The rehearsal DB (and the
   # container-local copy of the dump used to restore it) are ALWAYS removed on exit —
   # trap-guarded so an abort mid-rehearsal still cleans up.
-  local pg_user="$MIGRATE_BACKUP_PG_USER"
-  local container_dump_path="${CONTAINER_RUNNER_DIR}/rehearsal-${RUN_STAMP}.dump"
+  # Globals (NOT locals): the EXIT trap must see these under every bash invocation mode
+  # (function locals are not reliably visible to traps under `bash -c`). Review P3, round 6.
+  REHEARSAL_PG_USER="$MIGRATE_BACKUP_PG_USER"
+  REHEARSAL_CONTAINER_DUMP_PATH="${CONTAINER_RUNNER_DIR}/rehearsal-${RUN_STAMP}.dump"
+  local pg_user="$REHEARSAL_PG_USER"
+  local container_dump_path="$REHEARSAL_CONTAINER_DUMP_PATH"
 
   cleanup_rehearsal() {
-    docker exec "$POSTGRES_CONTAINER" psql -U "$pg_user" -d postgres -v ON_ERROR_STOP=0 \
+    # Fixed synthetic name only — this can never name the real staging DB.
+    docker exec "$POSTGRES_CONTAINER" psql -U "$REHEARSAL_PG_USER" -d postgres -v ON_ERROR_STOP=0 \
       -c "DROP DATABASE IF EXISTS ${REHEARSAL_DB};" >/dev/null 2>&1 || true
-    docker exec "$POSTGRES_CONTAINER" rm -f "$container_dump_path" >/dev/null 2>&1 || true
+    docker exec "$POSTGRES_CONTAINER" rm -f "$REHEARSAL_CONTAINER_DUMP_PATH" >/dev/null 2>&1 || true
   }
 
   log "rehearsal: dropping any prior ${REHEARSAL_DB} left by an aborted run"
@@ -627,9 +632,41 @@ action_migrate_rehearse() {
   backend_dsn="$(resolve_backend_database_url)"
   rehearsal_dsn="$(dsn_replace_database "$backend_dsn" "$REHEARSAL_DB")"
 
+  # Channel-independent isolation guard (review P2, round 6): the -e DATABASE_URL override
+  # only isolates if migrate.js resolves its DSN from process.env (SECRET_PROVIDER=env).
+  # Under file/vault providers the override is SILENTLY IGNORED and the "rehearsal" would
+  # migrate the REAL staging DB. Defend independently of that channel: count applied
+  # migrations in BOTH DBs via direct psql before and after the rehearsal run, and require
+  # the real DB's count to be UNCHANGED and the rehearsal DB's to have ADVANCED.
+  count_applied() { # count_applied <db-name>
+    docker exec "$POSTGRES_CONTAINER" psql -U "$REHEARSAL_PG_USER" -d "$1" -tA \
+      -c "SELECT COALESCE((SELECT count(*) FROM kysely_migration), 0);" 2>/dev/null | tr -d '[:space:]'
+  }
+  local real_db real_before rehearsal_before real_after rehearsal_after
+  real_db="$(dsn_database_name "$backend_dsn")"
+  [[ -n "$real_db" && "$real_db" != "$REHEARSAL_DB" ]] \
+    || fail "could not resolve the real staging DB name distinct from the rehearsal DB (got '${real_db:-<empty>}')"
+  real_before="$(count_applied "$real_db")"
+  rehearsal_before="$(count_applied "$REHEARSAL_DB")"
+  [[ "$real_before" =~ ^[0-9]+$ && "$rehearsal_before" =~ ^[0-9]+$ ]] \
+    || fail "pre-rehearsal applied-migration counts unreadable (real='${real_before}' rehearsal='${rehearsal_before}')"
+  log "rehearsal isolation baseline: applied(real ${real_db})=${real_before} applied(${REHEARSAL_DB})=${rehearsal_before}"
+
   log "rehearsal: running migrate.js against the REHEARSAL DB only (staging DB untouched so far)"
   staging_exec_env "DATABASE_URL=${rehearsal_dsn}" -- node "$MIGRATE_JS" < /dev/null 2>&1 \
     | tee "${OUTPUT_DIR}/rehearsal-migrate-run.log"
+
+  real_after="$(count_applied "$real_db")"
+  rehearsal_after="$(count_applied "$REHEARSAL_DB")"
+  log "rehearsal isolation check: applied(real ${real_db}) ${real_before}->${real_after}; applied(${REHEARSAL_DB}) ${rehearsal_before}->${rehearsal_after}"
+  {
+    echo "real_db=${real_db} real_before=${real_before} real_after=${real_after}"
+    echo "rehearsal_before=${rehearsal_before} rehearsal_after=${rehearsal_after}"
+  } > "${OUTPUT_DIR}/rehearsal-isolation-check.txt"
+  [[ "$real_after" == "$real_before" ]] \
+    || fail "ISOLATION BREACH: real staging DB applied-migration count changed ${real_before}->${real_after} during the rehearsal run — the DATABASE_URL override was ignored (non-env secret provider?). STOP; restore from ${MIGRATE_BACKUP_PATH} per runbook before ANY further action"
+  [[ "$rehearsal_after" -gt "$rehearsal_before" || "$rehearsal_after" -ge "$real_before" ]] \
+    || fail "rehearsal DB applied count did not advance (${rehearsal_before}->${rehearsal_after}) — the rehearsal migrate did not actually run against ${REHEARSAL_DB}; refusing to treat rehearsal as green"
 
   log "rehearsal: confirming pending=0 against the rehearsal DB"
   staging_exec_env "DATABASE_URL=${rehearsal_dsn}" -- node "$MIGRATE_JS" --list < /dev/null 2>&1 \

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -3,10 +3,20 @@
 #
 # Remote (deploy-host) half of .github/workflows/attendance-staging-window-runner.yml.
 # Executes ONE action per invocation against the STAGING stack only:
-#   deploy — pin staging backend+web to a full-SHA image tag, migrate, verify build+auth
-#   smoke  — run one of the five window smokes in-container (bundle doc:
-#            docs/development/attendance-staging-window-bundle-20260702.md)
-#   status — read-only snapshot (containers, health, settings, pending migrations)
+#   deploy  — pin staging backend+web to a full-SHA image tag, migrate, verify build+auth
+#   smoke   — run one of the five window smokes in-container (bundle doc:
+#             docs/development/attendance-staging-window-bundle-20260702.md)
+#   status  — read-only snapshot (containers, health, settings, pending migrations)
+#   migrate — backup + clone-rehearsal + apply, per
+#             docs/operations/staging-migration-alignment-runbook.md and
+#             docs/development/staging-migration-alignment-runbook-verification-20260519.md.
+#             Only reachable path from a `do_not_run_full_migrate` decision surfaced by
+#             action=deploy's migration-alignment gate: pg_dump the real staging DB to a
+#             HOST file (never uploaded — business data), clone-restore it into a
+#             throwaway `window_runner_rehearsal` DB inside the SAME postgres container,
+#             run migrate.js against ONLY the rehearsal DB, and require it to fully
+#             succeed (pending=0) before ever touching the real staging DB. The rehearsal
+#             DB is always dropped (trap-guarded), including on failure.
 #
 # HARD SAFETY RAILS:
 #   * Operates exclusively on the staging compose file docker-compose.app.staging.yml
@@ -25,6 +35,18 @@ source "${HERE}/attendance-window-runner-pipeline.lib.sh"
 
 log() { echo "[window-runner] $*"; }
 fail() { echo "[window-runner][error] $*" >&2; exit 1; }
+
+hash_value() {
+  # sha256 of a file, tool-portable (GNU sha256sum on the deploy host; shasum fallback).
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+  else
+    fail "no sha256 tool available (need sha256sum or shasum) to hash ${file}"
+  fi
+}
 
 ACTION="${ACTION:?ACTION is required (deploy|smoke|status)}"
 DEPLOY_SHA="${DEPLOY_SHA:-}"
@@ -46,6 +68,13 @@ STAGING_WEB_HEALTH_URL="http://127.0.0.1:8082/api/health"
 STAGING_BACKEND_HEALTH_URL="http://127.0.0.1:18900/health"
 IN_CONTAINER_BASE_URL="http://127.0.0.1:8900"
 MIGRATE_JS="packages/core-backend/dist/src/db/migrate.js"
+# Fixed, clearly-synthetic rehearsal DB name for action=migrate. Lives inside the SAME
+# postgres container/server as staging, never on a different host, and is always dropped
+# (created fresh each run — never assumed to persist).
+REHEARSAL_DB="window_runner_rehearsal"
+# Host-side backup dir for action=migrate (HOME is writable; the staging repo dir is not
+# — proven by run 29313154282, same reason OVERRIDE_FILE above lives under OUTPUT_DIR).
+BACKUP_DIR="${HOME}/window-runner-backups"
 
 resolve_home_path() {
   local raw="$1"
@@ -116,6 +145,26 @@ staging_exec_env() {
 require_sha() {
   [[ "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]] \
     || fail "deploy_sha must be the FULL 40-char lowercase commit SHA (GHCR tags are full-SHA; a 9-char prefix fails with manifest unknown — 2026-04-26 postmortem), got: '${DEPLOY_SHA}'"
+}
+
+resolve_backend_database_url() {
+  # stdout: the RUNNING staging backend container's own DATABASE_URL (never hardcoded —
+  # read from the container's actual env, sourced from docker/app.staging.env on the host).
+  local dsn
+  dsn="$(docker exec "$BACKEND_CONTAINER" printenv DATABASE_URL 2>/dev/null || true)"
+  [[ -n "$dsn" ]] || fail "could not resolve DATABASE_URL from ${BACKEND_CONTAINER}'s own env"
+  printf '%s' "$dsn"
+}
+
+resolve_postgres_creds() {
+  # stdout: "<POSTGRES_USER> <POSTGRES_DB>" resolved from the RUNNING postgres container's
+  # own env (never hardcoded — same docker/app.staging.env source as the backend's DSN).
+  local pg_user pg_db
+  pg_user="$(docker exec "$POSTGRES_CONTAINER" printenv POSTGRES_USER 2>/dev/null || true)"
+  pg_db="$(docker exec "$POSTGRES_CONTAINER" printenv POSTGRES_DB 2>/dev/null || true)"
+  [[ -n "$pg_user" ]] || fail "could not resolve POSTGRES_USER from ${POSTGRES_CONTAINER}'s own env"
+  [[ -n "$pg_db" ]] || fail "could not resolve POSTGRES_DB from ${POSTGRES_CONTAINER}'s own env"
+  printf '%s %s' "$pg_user" "$pg_db"
 }
 
 fetch_health_commit() {
@@ -506,6 +555,136 @@ action_status() {
   return "$status_rc"
 }
 
+action_migrate_backup() {
+  # Step 2 of the runbook-compliant sequence: pg_dump the REAL staging DB to a HOST file
+  # (never the staging repo dir — not writable by this SSH user; never uploaded as a CI
+  # artifact — it contains business data). Records sha256 + byte size + path only.
+  # Here-string (not `< <(...)` process substitution): bash appends a trailing newline
+  # when feeding a here-string, so `read` sees a complete line and exits 0 even though
+  # resolve_postgres_creds's printf has no trailing \n. With process substitution instead,
+  # `read` would hit EOF before a newline and return 1, tripping `set -e`.
+  local pg_user pg_db
+  read -r pg_user pg_db <<< "$(resolve_postgres_creds)"
+
+  mkdir -p "$BACKUP_DIR"
+  local ts
+  ts="$(date -u +%Y%m%dT%H%M%SZ)"
+  MIGRATE_BACKUP_PATH="${BACKUP_DIR}/staging-${ts}-pre-migrate.dump"
+
+  log "backup: pg_dump -Fc -U ${pg_user} ${pg_db} -> ${MIGRATE_BACKUP_PATH}"
+  docker exec "$POSTGRES_CONTAINER" pg_dump -Fc -U "$pg_user" "$pg_db" > "$MIGRATE_BACKUP_PATH"
+  [[ -s "$MIGRATE_BACKUP_PATH" ]] \
+    || fail "backup file is empty: ${MIGRATE_BACKUP_PATH}; refusing to proceed without a working backup (runbook: pg_dump first is non-negotiable)"
+
+  MIGRATE_BACKUP_SHA256="$(hash_value "$MIGRATE_BACKUP_PATH")"
+  MIGRATE_BACKUP_BYTES="$(wc -c < "$MIGRATE_BACKUP_PATH" | tr -d '[:space:]')"
+  MIGRATE_BACKUP_PG_USER="$pg_user"
+  MIGRATE_BACKUP_PG_DB="$pg_db"
+
+  {
+    echo "path=${MIGRATE_BACKUP_PATH}"
+    echo "sha256=${MIGRATE_BACKUP_SHA256}"
+    echo "bytes=${MIGRATE_BACKUP_BYTES}"
+    echo "pg_user=${pg_user}"
+    echo "pg_db=${pg_db}"
+    echo "note=dump stays on the deploy host at the path above; NOT uploaded (business data, public-repo artifacts are world-downloadable); retention is an operator decision"
+  } > "${OUTPUT_DIR}/backup-metadata.txt"
+  log "backup OK: ${MIGRATE_BACKUP_BYTES} bytes, sha256=${MIGRATE_BACKUP_SHA256} (dump stays on host, not uploaded)"
+}
+
+action_migrate_rehearse() {
+  # Step 3: clone-rehearsal. Restores the just-taken backup into a throwaway DB inside
+  # the SAME postgres container/server, then runs migrate.js against ONLY that DB. The
+  # real staging DB is never touched by this function. The rehearsal DB (and the
+  # container-local copy of the dump used to restore it) are ALWAYS removed on exit —
+  # trap-guarded so an abort mid-rehearsal still cleans up.
+  local pg_user="$MIGRATE_BACKUP_PG_USER"
+  local container_dump_path="${CONTAINER_RUNNER_DIR}/rehearsal-${RUN_STAMP}.dump"
+
+  cleanup_rehearsal() {
+    docker exec "$POSTGRES_CONTAINER" psql -U "$pg_user" -d postgres -v ON_ERROR_STOP=0 \
+      -c "DROP DATABASE IF EXISTS ${REHEARSAL_DB};" >/dev/null 2>&1 || true
+    docker exec "$POSTGRES_CONTAINER" rm -f "$container_dump_path" >/dev/null 2>&1 || true
+  }
+
+  log "rehearsal: dropping any prior ${REHEARSAL_DB} left by an aborted run"
+  cleanup_rehearsal
+  trap cleanup_rehearsal EXIT
+
+  log "rehearsal: creating ${REHEARSAL_DB} (clearly-synthetic fixed name; same postgres server as staging)"
+  docker exec "$POSTGRES_CONTAINER" psql -U "$pg_user" -d postgres -v ON_ERROR_STOP=1 \
+    -c "CREATE DATABASE ${REHEARSAL_DB};" 2>&1 | tee "${OUTPUT_DIR}/rehearsal-create-db.log"
+
+  log "rehearsal: copying the backup into the postgres container (pg_restore -j needs a seekable file, not stdin)"
+  docker exec "$POSTGRES_CONTAINER" mkdir -p "$CONTAINER_RUNNER_DIR"
+  docker cp "$MIGRATE_BACKUP_PATH" "${POSTGRES_CONTAINER}:${container_dump_path}"
+
+  log "rehearsal: restoring into ${REHEARSAL_DB}"
+  docker exec "$POSTGRES_CONTAINER" pg_restore -j 2 -U "$pg_user" -d "$REHEARSAL_DB" "$container_dump_path" \
+    2>&1 | tee "${OUTPUT_DIR}/rehearsal-restore.log"
+
+  local backend_dsn rehearsal_dsn
+  backend_dsn="$(resolve_backend_database_url)"
+  rehearsal_dsn="$(dsn_replace_database "$backend_dsn" "$REHEARSAL_DB")"
+
+  log "rehearsal: running migrate.js against the REHEARSAL DB only (staging DB untouched so far)"
+  staging_exec_env "DATABASE_URL=${rehearsal_dsn}" -- node "$MIGRATE_JS" < /dev/null 2>&1 \
+    | tee "${OUTPUT_DIR}/rehearsal-migrate-run.log"
+
+  log "rehearsal: confirming pending=0 against the rehearsal DB"
+  staging_exec_env "DATABASE_URL=${rehearsal_dsn}" -- node "$MIGRATE_JS" --list < /dev/null 2>&1 \
+    | tee "${OUTPUT_DIR}/rehearsal-migrate-list-after.txt"
+  grep -q '^Pending: 0$' "${OUTPUT_DIR}/rehearsal-migrate-list-after.txt" \
+    || fail "rehearsal migrate run did not leave the rehearsal DB at pending=0 (see rehearsal-migrate-list-after.txt); staging DB was NOT touched, stopping per the runbook"
+
+  log "rehearsal: green — dropping ${REHEARSAL_DB} and the in-container dump copy"
+  cleanup_rehearsal
+  trap - EXIT
+  log "rehearsal OK"
+}
+
+action_migrate_apply() {
+  # Step 4: only reached if action_migrate_rehearse fully succeeded. Same before/after
+  # pending-list discipline as action_deploy's migration step, against the REAL staging DB.
+  log "apply: migrate-list BEFORE (real staging DB)"
+  staging_exec node "$MIGRATE_JS" --list < /dev/null 2>&1 | tee "${OUTPUT_DIR}/apply-migrate-list-before.txt"
+
+  log "apply: running migrate.js against the REAL staging DB (rehearsal was green)"
+  staging_exec node "$MIGRATE_JS" < /dev/null 2>&1 | tee "${OUTPUT_DIR}/apply-migrate-run.log"
+
+  staging_exec node "$MIGRATE_JS" --list < /dev/null 2>&1 | tee "${OUTPUT_DIR}/apply-migrate-list-after.txt"
+  grep -q '^Pending: 0$' "${OUTPUT_DIR}/apply-migrate-list-after.txt" \
+    || fail "staging migrate did not end at pending=0 after apply (see apply-migrate-list-after.txt); restore from ${MIGRATE_BACKUP_PATH} if needed (runbook §Failure modes)"
+  log "apply OK: staging migrate ended at pending=0"
+}
+
+action_migrate() {
+  prepare_container_runner
+  action_migrate_backup
+  action_migrate_rehearse
+  action_migrate_apply
+
+  # Step 5: post-checks.
+  curl -fsS --max-time 10 "$STAGING_WEB_HEALTH_URL" > "${OUTPUT_DIR}/health-web.json" \
+    || fail "post-apply health check failed: ${STAGING_WEB_HEALTH_URL} unreachable"
+  grep -q '"ok":true' "${OUTPUT_DIR}/health-web.json" \
+    || fail "post-apply health check did not report ok:true (see health-web.json)"
+  auth_round_trip
+  snapshot_staging_ps
+
+  {
+    echo "action=migrate"
+    echo "backup_path=${MIGRATE_BACKUP_PATH}"
+    echo "backup_sha256=${MIGRATE_BACKUP_SHA256}"
+    echo "backup_bytes=${MIGRATE_BACKUP_BYTES}"
+    echo "rehearsal_db=${REHEARSAL_DB}"
+    echo "rehearsal_result=ok"
+    echo "apply_result=ok"
+    echo "result=ok"
+  } > "${OUTPUT_DIR}/summary.txt"
+  log "migrate OK: backup=${MIGRATE_BACKUP_PATH} rehearsal=ok apply=ok"
+}
+
 # --- main ------------------------------------------------------------------------------
 
 mkdir -p "$OUTPUT_DIR"
@@ -515,5 +694,6 @@ case "$ACTION" in
   deploy) action_deploy ;;
   smoke) action_smoke ;;
   status) action_status ;;
-  *) fail "unknown action: ${ACTION} (expected deploy|smoke|status)" ;;
+  migrate) action_migrate ;;
+  *) fail "unknown action: ${ACTION} (expected deploy|smoke|status|migrate)" ;;
 esac

--- a/scripts/ops/attendance-window-runner-pipeline.lib.sh
+++ b/scripts/ops/attendance-window-runner-pipeline.lib.sh
@@ -74,3 +74,14 @@ dsn_replace_database() {
   fi
   printf '%s/%s%s' "${base%/*}" "$new_db" "$query"
 }
+
+# dsn_database_name <dsn>
+# Extracts the db-name path segment (query string stripped) — the inverse read of
+# dsn_replace_database, used by the rehearsal isolation guard to psql the real DB directly.
+dsn_database_name() {
+  local dsn="$1" base="$1"
+  if [[ "$dsn" == *'?'* ]]; then
+    base="${dsn%%\?*}"
+  fi
+  printf '%s' "${base##*/}"
+}

--- a/scripts/ops/attendance-window-runner-pipeline.lib.sh
+++ b/scripts/ops/attendance-window-runner-pipeline.lib.sh
@@ -6,6 +6,8 @@
 # Contract (proven by scripts/ops/attendance-window-runner-pipeline.test.mjs, which runs
 # this exact file under `bash -o pipefail -c`):
 #   filtered_pipe <output_file> <grep_ere_pattern> -- <producer command...>
+#   dsn_replace_database <dsn> <new_db_name>
+#     Pure string transform (no I/O, no env reads) — see below.
 #     Runs `<producer> 2>&1 | grep -E <pattern> > <output_file>` and returns:
 #       0        when the producer succeeded — INCLUDING when grep matched ZERO lines
 #                (an empty filter result is a normal outcome, e.g. quiet logs);
@@ -49,4 +51,26 @@ filtered_pipe() {
   fi
   # grep rc 0 (matches) or 1 (zero matches) with a healthy producer -> success.
   return 0
+}
+
+# dsn_replace_database <dsn> <new_db_name>
+#
+# Swaps the database-name path segment of a postgres/postgresql connection string,
+# preserving scheme, userinfo, host, and port, and passing any query string through
+# unchanged (e.g. `?sslmode=disable`). Used by the `migrate` action (action_migrate in
+# attendance-staging-window-runner-remote.sh) to derive a rehearsal-DB DATABASE_URL from
+# the staging backend container's own DATABASE_URL — same host/creds, different db name —
+# without hardcoding host/port/credentials anywhere in this repo.
+#
+# Pure string transform: no I/O, no env reads, no external commands. Proven against
+# representative DSNs (including the query-string form) by
+# scripts/ops/attendance-window-runner-pipeline.test.mjs.
+dsn_replace_database() {
+  local dsn="$1" new_db="$2"
+  local base="$dsn" query=""
+  if [[ "$dsn" == *'?'* ]]; then
+    base="${dsn%%\?*}"
+    query="?${dsn#*\?}"
+  fi
+  printf '%s/%s%s' "${base%/*}" "$new_db" "$query"
 }

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -108,6 +108,19 @@ test('workflow shape contract: remote commands run under explicit `bash -o pipef
   assert.doesNotMatch(yaml, /bash\s+-s\b/, 'the workflow must not fall back to `ssh ... bash -s` (login-shell pipefail is not guaranteed)')
 })
 
+test('dsn_database_name: extracts the db-name path segment, stripping the query string', () => {
+  const cases = [
+    ['postgresql://u:p@staging-postgres:5432/metasheet', 'metasheet'],
+    ['postgresql://u:p@staging-postgres:5432/metasheet?sslmode=disable', 'metasheet'],
+    ['postgres://u@h/window_runner_rehearsal?a=1&b=2', 'window_runner_rehearsal'],
+  ]
+  for (const [dsn, expected] of cases) {
+    const result = runPipefailBash(`source '${LIB}'\ndsn_database_name '${dsn}'`)
+    assert.equal(result.status, 0, `expected exit 0 for dsn=${dsn}; stderr: ${result.stderr}`)
+    assert.equal(result.stdout.trim(), expected, `dsn=${dsn}`)
+  }
+})
+
 test('dsn_replace_database: swaps the db-name path segment, preserving host/port/query', () => {
   const cases = [
     // [input DSN, new db name, expected output]

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -108,6 +108,41 @@ test('workflow shape contract: remote commands run under explicit `bash -o pipef
   assert.doesNotMatch(yaml, /bash\s+-s\b/, 'the workflow must not fall back to `ssh ... bash -s` (login-shell pipefail is not guaranteed)')
 })
 
+test('dsn_replace_database: swaps the db-name path segment, preserving host/port/query', () => {
+  const cases = [
+    // [input DSN, new db name, expected output]
+    [
+      'postgres://metasheet:change-me@postgres:5432/metasheet',
+      'window_runner_rehearsal',
+      'postgres://metasheet:change-me@postgres:5432/window_runner_rehearsal',
+    ],
+    [
+      // The exact runbook / app.staging.env.example shape, with the ?sslmode=disable
+      // suffix the docker/app.staging.env.example comment calls out — must survive.
+      'postgres://metasheet:change-me@postgres:5432/metasheet?sslmode=disable',
+      'window_runner_rehearsal',
+      'postgres://metasheet:change-me@postgres:5432/window_runner_rehearsal?sslmode=disable',
+    ],
+    [
+      // postgresql:// scheme + multiple query params.
+      'postgresql://appuser:secret@db-host:5433/dbname?sslmode=require&connect_timeout=10',
+      'window_runner_rehearsal',
+      'postgresql://appuser:secret@db-host:5433/window_runner_rehearsal?sslmode=require&connect_timeout=10',
+    ],
+    [
+      // No explicit port, no query string.
+      'postgres://metasheet@postgres/metasheet',
+      'window_runner_rehearsal',
+      'postgres://metasheet@postgres/window_runner_rehearsal',
+    ],
+  ]
+  for (const [dsn, newDb, expected] of cases) {
+    const result = runPipefailBash(`source '${LIB}'\ndsn_replace_database '${dsn}' '${newDb}'`)
+    assert.equal(result.status, 0, `expected exit 0 for dsn=${dsn}; stderr: ${result.stderr}`)
+    assert.equal(result.stdout, expected, `dsn rewrite mismatch for input: ${dsn}`)
+  }
+})
+
 test('staging-only contract: the remote script names only staging containers', () => {
   const source = readFileSync(REMOTE_SH, 'utf8')
   for (const name of [


### PR DESCRIPTION
## Why

The attendance staging window-runner's `deploy` action correctly **stopped**
at the migration-alignment gate: `applied=240 pending=24`,
`decision=do_not_run_full_migrate` (3 migrations flagged high replay-risk by
the heuristic scanner). Per
`docs/development/staging-migration-alignment-runbook-verification-20260519.md`
and `docs/operations/staging-migration-alignment-runbook.md`, the only
sanctioned next step from that decision is to **rehearse on a cloned/backed-up
DB before applying to staging**. This PR adds `action=migrate` implementing
that sequence end-to-end, so the rehearsal is a repeatable, fail-closed tool
run instead of a manual SSH session.

## Step map to the runbook

| Runbook step | This PR |
| --- | --- |
| Staging-only guard | Unchanged — `assert_staging_only()` already runs unconditionally before any action dispatch (`attendance-staging-window-runner-remote.sh`, `main`); `migrate` gets it for free. |
| §Pre-flight "pg_dump first — non-negotiable" | `action_migrate_backup()`: `docker exec metasheet-staging-postgres pg_dump -Fc -U <user> <db>` → host file `${HOME}/window-runner-backups/staging-<utc-timestamp>-pre-migrate.dump`. Empty-file check fails closed. |
| "rehearse against a DB clone or backup" (verification-20260519 doc, final line) | `action_migrate_rehearse()`: creates `window_runner_rehearsal` inside the **same** postgres container, restores the just-taken dump into it, runs `migrate.js` against **only** that DB, requires `Pending: 0`. |
| §Option B "drop and recreate" pattern (adapted to a throwaway clone, not staging itself) | Same `CREATE DATABASE` / `pg_restore` mechanics, scoped to the synthetic rehearsal DB, never the real `metasheet` DB. |
| "If any fails, stop and investigate" (§A.5) | Any rehearsal failure aborts the whole job (`set -euo pipefail`) before the real staging DB is ever touched; the rehearsal DB is dropped via an EXIT trap regardless of how it failed. |
| §Post-alignment verification (auth round-trip, schema checks) | `action_migrate()` post-checks: `/api/health` `ok:true`, then the existing `auth_round_trip()` helper (`/api/auth/me` + `/api/attendance/settings`, same as `deploy`). |

## Sequence implemented (`action_migrate` in `attendance-staging-window-runner-remote.sh`)

1. Existing staging-only guard (unchanged, already global).
2. **Backup** — `pg_dump -Fc` to a host file under `${HOME}/window-runner-backups/`
   (HOME is writable; the staging repo checkout dir is not — same constraint
   `OVERRIDE_FILE` already works around). Records `sha256` + byte size + path
   in `backup-metadata.txt`. **The dump itself is never uploaded** as a CI
   artifact — it contains business data, and artifacts on this public repo
   are world-downloadable. Retention of the on-host dump is an operator
   decision; the path format is `staging-<UTC-timestamp>-pre-migrate.dump`,
   easy to `find -mtime` for cleanup later.
3. **Clone rehearsal** — creates a fixed, obviously-synthetic
   `window_runner_rehearsal` DB inside the *same* postgres container (dropped
   first if a prior aborted run left it behind), copies the dump into the
   container (`pg_restore -j 2` needs a seekable file — **not** stdin, which
   is why the dump is `docker cp`'d in rather than piped), restores it, then
   execs `migrate.js` in the backend container with `DATABASE_URL` rewritten
   to point at the rehearsal DB (same host/creds, different db name).
   Requires the migrate run to succeed **and** a follow-up `--list` to read
   `Pending: 0`. The rehearsal DB and the in-container dump copy are **always**
   removed — a `cleanup_rehearsal` function is both called explicitly on the
   success path and registered via `trap ... EXIT` so an abort mid-rehearsal
   still cleans up.
4. **Apply** — only reached if step 3 fully succeeded. Runs `migrate.js`
   against the **real** staging DB with the same before/after `migrate.js
   --list` discipline (and the same `^Pending: 0$` format check) the `deploy`
   action already uses.
5. **Post-checks** — `/api/health` must report `"ok":true`; then the existing
   `auth_round_trip()` helper (unchanged, reused as-is) proves `/api/auth/me`
   and `/api/attendance/settings` both return 200, writing the settings
   snapshot to the artifact.
6. **Artifact** — backup metadata (path/sha256/bytes, *not* the dump),
   rehearsal create/restore/migrate-run/migrate-list logs, apply
   before/after pending lists, and the post-check outputs. The job fails if
   any step fails (no swallowed errors — everything relies on the script's
   `set -euo pipefail` plus explicit `fail()` calls, same as the other three
   actions).

## DSN rewrite semantics

Step 3 needs a `DATABASE_URL` that points at the rehearsal DB using the
backend container's own real host/port/credentials — never hardcoded. Added
`dsn_replace_database <dsn> <new_db_name>` to
`attendance-window-runner-pipeline.lib.sh` (the same file that already hosts
`filtered_pipe`, and is already sourced + unit-tested by
`attendance-window-runner-pipeline.test.mjs`). It's a pure
parameter-expansion string transform — no I/O:

```bash
dsn_replace_database() {
  local dsn="$1" new_db="$2"
  local base="$dsn" query=""
  if [[ "$dsn" == *'?'* ]]; then
    base="${dsn%%\?*}"
    query="?${dsn#*\?}"
  fi
  printf '%s/%s%s' "${base%/*}" "$new_db" "$query"
}
```

It swaps the last path segment (the db name), preserving scheme, userinfo,
host, port, and any query string verbatim (e.g. the `?sslmode=disable` suffix
called out in `docker/app.staging.env.example`). `resolve_backend_database_url()`
reads the backend container's actual `DATABASE_URL` via `docker exec ...
printenv` (never hardcoded); `resolve_postgres_creds()` does the same for
`POSTGRES_USER`/`POSTGRES_DB` from the postgres container's own env.

## Test evidence

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/attendance-staging-window-runner.yml'))"` — parses; `action` choice list is `[deploy, smoke, status, migrate]`.
- `bash -n scripts/ops/attendance-staging-window-runner-remote.sh` — OK.
- `bash -n scripts/ops/attendance-window-runner-pipeline.lib.sh` — OK.
- `node --test scripts/ops/attendance-window-runner-pipeline.test.mjs` — **8/8 pass** (the existing 7, plus one new test):

  ```
  ✔ leg (a): zero grep matches in the pipeline still exits 0 (normal outcome)
  ✔ leg (b): producer failure propagates as a NONZERO overall exit, even when grep matches
  ✔ leg (b) variant: producer failure with ZERO grep matches is still NONZERO (not misread as leg a)
  ✔ positive control: the -o pipefail wrapper is load-bearing for raw pipelines
  ✔ embedded scripts parse (bash -n) — remote runner + pipeline lib
  ✔ workflow shape contract: remote commands run under explicit `bash -o pipefail -c`
  ✔ dsn_replace_database: swaps the db-name path segment, preserving host/port/query
  ✔ staging-only contract: the remote script names only staging containers
  tests 8, pass 8, fail 0
  ```

  The new `dsn_replace_database` test runs the exact committed helper (same
  sourcing pattern as the existing `filtered_pipe` tests) against four
  representative DSNs: with/without a query string, `postgres://` vs
  `postgresql://` scheme, and with/without an explicit port — including the
  `?sslmode=disable` shape from `docker/app.staging.env.example`.

## Decisions worth flagging

- **`pg_restore -j 2` requires a seekable file, not stdin.** A naive
  `docker exec -i pg_restore ... < dump` would silently drop parallelism (or
  error) since custom-format parallel restore needs random access. Fixed by
  `docker cp`-ing the dump into the postgres container's own `/tmp` first,
  then restoring from that path; the in-container copy is removed by the
  same cleanup trap as the rehearsal DB.
- **`action=migrate` does not require `deploy_sha`** — like `status`, it
  operates on whatever is currently deployed to staging rather than pinning a
  new image; only `deploy` and `smoke` need a SHA.
- **pg user/db resolution** uses `docker exec <container> printenv <VAR>`
  rather than parsing full `docker exec ... env` output — same source of
  truth (`docker/app.staging.env` via `env_file:`), simpler to make fail
  closed per-variable.
- The on-host backup dump path/retention is **not** managed by this PR —
  documented above as an explicit operator decision (owner's call), same as
  the runbook's own pre-existing `<artifact-dir>/metasheet-staging-pgdump-$TS.dump`
  convention.

## Not in scope

- No change to `action=deploy`'s existing halt-on-`do_not_run_full_migrate`
  behavior — this PR only adds the tool the runbook already told operators to
  reach for next.
- Live execution against the actual staging stack (this PR is code +
  local/offline validation only, per the model-split policy for this line —
  a real dispatch is an operator action, not something exercised here).

refs #3317
