### PR TITLE
fix(attendance): migrate rehearsal — pg_restore --disable-triggers (refs #3317)

### DIFF
--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -625,7 +625,13 @@ action_migrate_rehearse() {
   docker cp "$MIGRATE_BACKUP_PATH" "${POSTGRES_CONTAINER}:${container_dump_path}"
 
   log "rehearsal: restoring into ${REHEARSAL_DB}"
-  docker exec "$POSTGRES_CONTAINER" pg_restore -j 2 -U "$pg_user" -d "$REHEARSAL_DB" "$container_dump_path" \
+  # --disable-triggers: the audit-log partitions inherit a row trigger from their
+  # partitioned parent (set_retention_period), which lives in the PRE-data section and
+  # fires during COPY, querying audit_retention_policies before it is restored (run
+  # 29340321213). We restore as the container superuser, so wrapping the data load in
+  # DISABLE/ENABLE TRIGGER ALL is safe and yields a byte-faithful clone (trigger
+  # recomputation during restore is not desired anyway).
+  docker exec "$POSTGRES_CONTAINER" pg_restore -j 2 --disable-triggers -U "$pg_user" -d "$REHEARSAL_DB" "$container_dump_path" \
     2>&1 | tee "${OUTPUT_DIR}/rehearsal-restore.log"
 
   local backend_dsn rehearsal_dsn

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -181,3 +181,13 @@ test('staging-only contract: the remote script names only staging containers', (
     'remote script must never reference the prod-track compose file',
   )
 })
+
+test('rehearsal pg_restore keeps --disable-triggers (load-bearing: partition-inherited row triggers fire during COPY without it — run 29340321213)', () => {
+  const remote = readFileSync(REMOTE_SH, 'utf8')
+  const restoreLines = remote.split('\n').filter((l) => l.includes('pg_restore') && l.includes('$REHEARSAL_DB'))
+  assert.ok(restoreLines.length >= 1, 'expected the rehearsal pg_restore invocation to exist')
+  for (const line of restoreLines) {
+    assert.ok(line.includes('--disable-triggers'),
+      `rehearsal pg_restore lost --disable-triggers: ${line.trim()}`)
+  }
+})


### PR DESCRIPTION
Run 29340321213: rehearsal restore failed — the audit-log partitions inherit `set_retention_period` from their partitioned parent (pre-data section), so it fires during `COPY` and queries `audit_retention_policies` before it exists. Restore runs as the container superuser → `--disable-triggers` wraps the data load in DISABLE/ENABLE TRIGGER ALL, yielding the intended byte-faithful clone. One-line change + comment; real staging DB was untouched throughout (backup taken, isolation guard intact). `bash -n` clean, self-test 9/9. Refs #3317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)