### PR TITLE
test(web): clean stale MetaViewTabBar references after P2-2a/b rail migration

### DIFF
--- a/apps/web/tests/multitable-phase12.spec.ts
+++ b/apps/web/tests/multitable-phase12.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, it, expect } from 'vitest'
 
 // --- RecordDrawer field type parity ---
@@ -99,6 +101,38 @@ describe('calendar date field type recognition', () => {
 })
 
 // --- Print CSS coverage ---
+
+/**
+ * All `@media print { ... }` blocks in a source string, brace-matched so the whole block
+ * (including nested rule braces) is captured. Used by the two source-reading tests below.
+ */
+function extractPrintBlocks(source: string): string[] {
+  const blocks: string[] = []
+  const re = /@media print/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(source)) !== null) {
+    const open = source.indexOf('{', m.index)
+    if (open === -1) continue
+    let depth = 0
+    for (let i = open; i < source.length; i++) {
+      if (source[i] === '{') depth++
+      else if (source[i] === '}' && --depth === 0) {
+        blocks.push(source.slice(open, i + 1))
+        break
+      }
+    }
+  }
+  return blocks
+}
+
+const WEB_ROOT = join(__dirname, '..')
+
+// NOTE (2026-07-14, follow-up #57): 'toolbar hides in print', 'workbench base-bar and actions hide
+// in print' and 'grid interactive elements hide in print' below are self-referential placeholders
+// from the original Phase-12 verification pass — each asserts on a locally-declared string/array
+// and never reads component source, so they cannot go red if the real print CSS drifts. Rewriting
+// them is a docketed follow-up; this pass only re-pinned the two tests that referenced the retired
+// MetaViewTabBar, as real source-reading assertions.
 describe('print CSS coverage', () => {
   it('toolbar hides in print', () => {
     const rule = '@media print { .meta-toolbar { display: none !important; } }'
@@ -106,10 +140,14 @@ describe('print CSS coverage', () => {
   })
 
   it('sheet/view rail hides in print', () => {
-    // Rail print CSS lives in MetaSheetViewRail.vue (post-P2-2a/2b; retired MetaViewTabBar.vue's
-    // .meta-tab-bar rule no longer exists anywhere in the tree).
-    const rule = '@media print { .meta-view-rail { display: none !important; } }'
-    expect(rule).toContain('display: none')
+    // Reads the ACTUAL SFC: post-P2-2a/2b (#4237/#4264) the rail print rule lives in
+    // MetaSheetViewRail.vue (the retired MetaViewTabBar.vue / .meta-tab-bar rule no longer exists
+    // anywhere in the tree). Deleting that print rule turns this test red.
+    const source = readFileSync(join(WEB_ROOT, 'src/multitable/components/MetaSheetViewRail.vue'), 'utf-8')
+    const railPrintBlocks = extractPrintBlocks(source).filter((block) =>
+      /\.meta-view-rail[^{}]*\{[^{}]*display:\s*none/.test(block),
+    )
+    expect(railPrintBlocks.length).toBeGreaterThan(0)
   })
 
   it('workbench base-bar and actions hide in print', () => {
@@ -126,8 +164,19 @@ describe('print CSS coverage', () => {
   })
 
   it('complete print chain: sheet/view rail + toolbar + workbench chrome + grid interactives', () => {
-    const printComponents = ['MetaSheetViewRail', 'MetaToolbar', 'MultitableWorkbench', 'MetaGridTable']
-    expect(printComponents).toHaveLength(4)
+    // Every component in the print chain must exist on disk (readFileSync throws on a rename/move)
+    // and carry at least one @media print block (dropping the block turns this test red).
+    const PRINT_CHAIN: Record<string, string> = {
+      MetaSheetViewRail: 'src/multitable/components/MetaSheetViewRail.vue',
+      MetaToolbar: 'src/multitable/components/MetaToolbar.vue',
+      MultitableWorkbench: 'src/multitable/views/MultitableWorkbench.vue',
+      MetaGridTable: 'src/multitable/components/MetaGridTable.vue',
+    }
+    expect(Object.keys(PRINT_CHAIN)).toHaveLength(4)
+    for (const [name, relPath] of Object.entries(PRINT_CHAIN)) {
+      const source = readFileSync(join(WEB_ROOT, relPath), 'utf-8')
+      expect(extractPrintBlocks(source).length, `${name} (${relPath}) must contain an @media print block`).toBeGreaterThan(0)
+    }
   })
 })
 

--- a/apps/web/tests/multitable-phase12.spec.ts
+++ b/apps/web/tests/multitable-phase12.spec.ts
@@ -105,8 +105,10 @@ describe('print CSS coverage', () => {
     expect(rule).toContain('display: none')
   })
 
-  it('view tab bar hides in print', () => {
-    const rule = '@media print { .meta-tab-bar { display: none !important; } }'
+  it('sheet/view rail hides in print', () => {
+    // Rail print CSS lives in MetaSheetViewRail.vue (post-P2-2a/2b; retired MetaViewTabBar.vue's
+    // .meta-tab-bar rule no longer exists anywhere in the tree).
+    const rule = '@media print { .meta-view-rail { display: none !important; } }'
     expect(rule).toContain('display: none')
   })
 
@@ -123,8 +125,8 @@ describe('print CSS coverage', () => {
     expect(hiddenGridSelectors).toHaveLength(5)
   })
 
-  it('complete print chain: tab-bar + toolbar + workbench chrome + grid interactives', () => {
-    const printComponents = ['MetaViewTabBar', 'MetaToolbar', 'MultitableWorkbench', 'MetaGridTable']
+  it('complete print chain: sheet/view rail + toolbar + workbench chrome + grid interactives', () => {
+    const printComponents = ['MetaSheetViewRail', 'MetaToolbar', 'MultitableWorkbench', 'MetaGridTable']
     expect(printComponents).toHaveLength(4)
   })
 })


### PR DESCRIPTION
## Summary
- `apps/web/tests/multitable-phase12.spec.ts` (task's stated path `apps/web/src/multitable/__tests__/multitable-phase12.spec.ts` doesn't exist — no `__tests__` dir anywhere under `apps/web`; the real file is `apps/web/tests/multitable-phase12.spec.ts`) carried two bare references to the retired `MetaViewTabBar` component (replaced by `MetaSheetViewRail` in P2-2a/2b, #4237/#4264):
  - `'view tab bar hides in print'` asserted a fictional `.meta-tab-bar` print rule that no longer exists anywhere in the tree.
  - `'complete print chain: ...'` listed `'MetaViewTabBar'` in the print-hidden component chain.
- **Re-pinned as real source-reading assertions** (second commit, after review caught that the first commit's rename kept them vacuous — a local string asserting a substring of itself never reads the component):
  - `'sheet/view rail hides in print'` now `readFileSync`s `apps/web/src/multitable/components/MetaSheetViewRail.vue` (resolved relative to the spec) and asserts, via brace-matched `@media print` block extraction, that a print block contains a `.meta-view-rail` rule with `display: none`.
  - `'complete print chain'` maps all 4 component names (`MetaSheetViewRail`, `MetaToolbar`, `MultitableWorkbench`, `MetaGridTable`) to their real file paths, `readFileSync`s each (a rename/move throws → red), and asserts each contains at least one `@media print` block, with a per-component failure message.

## Mutation-check evidence
Each mutation was confirmed landed (`grep -c "@media print"` → 0 in the mutated file) before the red run, then restored byte-identical (`git diff --stat` shows only the spec):
- **Removed `MetaSheetViewRail.vue`'s print rule** → 2 failed: `'sheet/view rail hides in print'` (`expected 0 to be greater than 0`) AND `'complete print chain'` (`MetaSheetViewRail ... must contain an @media print block`).
- **Removed `MetaToolbar.vue`'s print rule** → 1 failed: `'complete print chain'` (`MetaToolbar (src/multitable/components/MetaToolbar.vue) must contain an @media print block: expected 0 to be greater than 0`). Notably the sibling self-referential `'toolbar hides in print'` placeholder **stayed green** through this mutation — confirming the review finding's class.
- Restored source → 20/20 pass.

## Docketed follow-up observation (out of scope here)
Three remaining tests in the `print CSS coverage` describe are self-referential placeholders that assert on locally-declared strings/arrays and never read component source (cannot go red on drift): `'toolbar hides in print'`, `'workbench base-bar and actions hide in print'`, `'grid interactive elements hide in print'`. Annotated with a NOTE comment on the describe block; rewriting them (and the similar declare-and-assert patterns elsewhere in this Phase-12 spec) is left as a follow-up.

## Other stale-reference sweep
Grepped the whole `apps/web` tree for `MetaViewTabBar`/`tab-bar` hits: the only remaining ones are in `apps/web/tests/meta-sheet-view-rail.spec.ts` (header comment + a describe title) and `apps/web/src/multitable/components/MetaSheetViewRail.vue` (header comment) — all correctly phrased in past tense documenting the P2-2a/2b retirement lineage, i.e. accurate history, not stale claims about current behavior. Left untouched. Confirmed `MetaViewTabBar.vue` and its dedicated personal-toggle spec are actually gone from the tree.

## CI wiring
`multitable-phase12` and `meta-sheet-view-rail` are both present in the hand-kept filter in `apps/web/scripts/run-required-web-tests.sh`, which is what `.github/workflows/web-tests.yml`'s required `web-tests` job runs.

## Test plan
- [x] `npx vitest run multitable-phase12` → 20/20 passed against intact source
- [x] Mutation checks above (red where required, restored, green again)
- [x] `bash apps/web/scripts/run-required-web-tests.sh` (the exact command the required `web-tests` CI job runs) → 330 files / 3869 tests passed