### PR TITLE
test(multitable): W0 remediation — two-point wiring for 2 realdb specs + field-undelete atomicity golden (owner review follow-up)

### DIFF
--- a/packages/core-backend/tests/integration/multitable-tombstone-field-rehydrate-revision-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-tombstone-field-rehydrate-revision-realdb.test.ts
@@ -105,6 +105,20 @@ async function revisionsFor(recordId: string): Promise<RevisionRow[]> {
   const r = await q('SELECT version, action, source, actor_id, changed_field_ids, patch, snapshot, batch_id FROM meta_record_revisions WHERE record_id = $1 ORDER BY version', [recordId])
   return r.rows as RevisionRow[]
 }
+/** meta_fields uses HARD delete (no `deleted_at` column) — "still deleted" for a field means "still absent". */
+async function fieldExists(fieldId: string): Promise<boolean> {
+  const r = await q('SELECT 1 FROM meta_fields WHERE id = $1', [fieldId])
+  return r.rows.length > 0
+}
+async function fieldOrder(fieldId: string): Promise<number | undefined> {
+  const r = await q('SELECT "order" FROM meta_fields WHERE id = $1', [fieldId])
+  const row = r.rows[0] as { order: number } | undefined
+  return row ? Number(row.order) : undefined
+}
+async function fieldCreateRevisionCount(sheetId: string, fieldId: string): Promise<number> {
+  const r = await q(`SELECT COUNT(*)::int AS n FROM meta_config_revisions WHERE sheet_id = $1 AND entity_type = 'field' AND entity_id = $2 AND action = 'create'`, [sheetId, fieldId])
+  return Number((r.rows[0] as { n: number }).n)
+}
 
 describeIfDatabase('W0 tail — field-undelete rehydration emits revisions (real DB)', () => {
   beforeAll(async () => {
@@ -249,5 +263,76 @@ describeIfDatabase('W0 tail — field-undelete rehydration emits revisions (real
     const diesRevs = await revisionsFor(R_DIES)
     expect(diesRevs).toHaveLength(1)
     expect(diesRevs[0]?.action).toBe('create')
+  })
+
+  // Owner post-merge review of #4279 (Medium finding #2): the two tests above prove the success path and
+  // the zero-row leg, but neither forces a `meta_record_revisions` INSERT failure AFTER the row data/version
+  // updates — so neither actually pins that the WHOLE field-undelete (field re-creation + its order-shift +
+  // its create-revision + the per-record rehydration UPDATE + the per-record revision emit) is ONE atomic
+  // transaction. This golden does, following the same scoped-trigger shape as the D-1c slice ⑤ atomicity
+  // golden (`multitable-d1c-attachment-revision-realdb.test.ts`).
+  test('atomicity golden: if the meta_record_revisions INSERT throws mid-rehydration, the WHOLE field-undelete transaction rolls back — field re-creation, its order-shift, AND the record data/version all undo, no half-write', async () => {
+    const s = await freshSheet('atomic')
+    const F = mkFieldId('atomic')
+    const TRAIL = mkFieldId('atomicTrail') // a trailing field — proves the recreate's own order-shift undoes too
+    await insertField(s, F, 'AtomicVal', 'string', 1)
+    await insertField(s, TRAIL, 'Trailing', 'string', 2)
+
+    const R = mkRecordId('atomic')
+    const T0 = new Date(Date.now() - 60_000).toISOString()
+    await insertRecord(s, R, { [F]: 'atomic-orig', other: 'x1' })
+    await seedCreateRevision(s, R, { other: 'x1' }, T0)
+
+    expect((await deleteField(F)).status).toBe(200)
+    // The forward delete already shifted TRAIL's order 2 -> 1 (the -1 shift dropFieldCascade applies).
+    expect(await fieldOrder(TRAIL)).toBe(1)
+    const revF = await lastFieldDeleteRevisionId(s, F)
+
+    const p = await preview(s, revF)
+    expect(p.status).toBe(200)
+    expect(p.body?.data?.undelete?.tombstoneAvailable).toBe(true)
+    const previewToken = p.body.data.previewToken
+
+    // Scoped, self-cleaning failure injection: fires ONLY for R's own rehydration-revision INSERT — the
+    // AND clause (record_id match AND source='restore') is the exact discriminator recreateFieldFromConfig
+    // uses for this write (see univer-meta.ts ~6569), so this cannot fire for any other concurrently-seeded
+    // record or test file sharing this database. Dropped in `finally`, always, win or lose.
+    await q(`CREATE OR REPLACE FUNCTION _tfrr_atomic_fail_revision() RETURNS trigger AS $f$
+      BEGIN IF NEW.record_id = '${R}' AND NEW.source = 'restore' THEN RAISE EXCEPTION 'tfrr atomic injected revision failure'; END IF; RETURN NEW; END;
+    $f$ LANGUAGE plpgsql`, [])
+    await q('CREATE TRIGGER _tfrr_atomic_fail_revision_trg BEFORE INSERT ON meta_record_revisions FOR EACH ROW EXECUTE FUNCTION _tfrr_atomic_fail_revision()', [])
+    try {
+      const failed = await execute(s, { revisionId: revF, previewToken, confirm: 'undelete' })
+      expect(failed.status).toBe(500) // not a RecordServiceRestoreConflictError -> falls through to the outer catch's generic 500
+    } finally {
+      await q('DROP TRIGGER IF EXISTS _tfrr_atomic_fail_revision_trg ON meta_record_revisions', [])
+      await q('DROP FUNCTION IF EXISTS _tfrr_atomic_fail_revision()', [])
+    }
+
+    // ---- everything in the SAME transaction rolled back: field re-creation, its order-shift, config
+    // revision, record data + version, and the (never-committed) revision emit itself. ----
+    expect(await fieldExists(F)).toBe(false) // field: still absent (hard-delete; "still deleted" == still no row)
+    expect(await fieldOrder(TRAIL)).toBe(1) // the recreate's own +1 shift did NOT stick (would be 2 if it had)
+    expect(await fieldCreateRevisionCount(s, F)).toBe(0) // the field-create config revision never committed
+
+    const row = await recordRow(R)
+    expect(row?.data).toEqual({ other: 'x1' }) // rehydrated value NOT present
+    expect(row?.version).toBe(1) // unchanged — the version bump did not survive the rollback
+    expect(await revisionsFor(R)).toHaveLength(1) // only the seeded create@1 — no ghost rehydration revision
+
+    // ---- positive control: identical fixture, trigger gone -> the SAME undelete now succeeds fully. Proves
+    // the failure above was caused BY the trigger (not a broken previewToken / stale-revision fixture) — the
+    // revision id and preview flow are still valid; the DB state is byte-for-byte back where the delete left it. ----
+    const p2 = await preview(s, revF)
+    expect(p2.status).toBe(200)
+    const ok = await execute(s, { revisionId: revF, previewToken: p2.body.data.previewToken, confirm: 'undelete' })
+    expect(ok.status).toBe(200)
+
+    expect(await fieldExists(F)).toBe(true)
+    expect(await fieldOrder(TRAIL)).toBe(2) // this time the shift DOES stick
+    const row2 = await recordRow(R)
+    expect(row2?.data).toEqual({ [F]: 'atomic-orig', other: 'x1' })
+    expect(row2?.version).toBe(2)
+    expect(await revisionsFor(R)).toHaveLength(2)
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -218,6 +218,15 @@ export default defineConfig({
       // `Run multitable real-DB integration` in plugin-tests.yml. Two-point wiring: BOTH points
       // or the file silently never runs.
       'tests/integration/multitable-history-incomplete-precheck-realdb.test.ts',
+      // W0-1 (#4269, design-lock §6 owner ruling 2026-07-14; corrected in-place by the doc-only 8d65a2a35
+      // follow-up): generation-aware history contiguity goldens — replaces the live-vs-latest §0.6
+      // comparator above with a per-generation occupancy proof (every version in [genStart..liveVersion] is
+      // occupied by exactly one canonical chain event: a create/update revision OR a lock/unlock marker;
+      // delete revisions reuse the last live version and are excluded from the count). Real Postgres only
+      // (describeIfDatabase would skip-green in the no-DB lane) — excluded HERE so the no-DB job cannot
+      // skip-green it, and whole-file wired into `Run multitable real-DB integration` in plugin-tests.yml.
+      // Two-point wiring: BOTH points or the file silently never runs.
+      'tests/integration/multitable-history-contiguity-realdb.test.ts',
       // D-1c W0 slice ① (form-submit CREATE/EDIT public-form revision goldens): real Postgres only
       // (installs scoped failure/suppression triggers per site and drives the real submit route
       // end-to-end) — excluded HERE so it cannot skip-green in the no-DB lane, whole-file wired into
@@ -250,6 +259,17 @@ export default defineConfig({
       // Postgres only — excluded HERE so it cannot skip-green in the no-DB lane, whole-file wired into
       // `Run multitable real-DB integration` in plugin-tests.yml.
       'tests/integration/multitable-d1c-attachment-revision-realdb.test.ts',
+      // W0 tail (#4279, owner MUST-WRITE OD-6, design-lock §0.5 2026-07-13): field-undelete rehydration
+      // revision goldens — proves `recreateFieldFromConfig`'s tombstone-value rehydration UPDATE bumps
+      // `version` and emits a `recordRecordRevision` AT THE NEW version, same transaction, for every
+      // rehydrated record (full post-write snapshot, shared batchId); a zero-row concurrent-delete emits no
+      // ghost revision; and the real revert-preview route 200s afterward (the W0-1 contiguity + retained
+      // content-projection positive control — this site was `history-integrity-precheck.ts`'s own DEFERRED
+      // content-integrity gap before this fix). Real Postgres only (describeIfDatabase would skip-green in
+      // the no-DB lane) — excluded HERE so the no-DB job cannot skip-green it, and whole-file wired into
+      // `Run multitable real-DB integration` in plugin-tests.yml. Two-point wiring: BOTH points or the file
+      // silently never runs.
+      'tests/integration/multitable-tombstone-field-rehydrate-revision-realdb.test.ts',
       // D-2 side-door delete recoverability (#4004): real Postgres only (it installs scoped failure-
       // injection triggers and drives both side doors end-to-end) — excluded HERE so it cannot skip-green
       // in the no-DB lane, and whole-file wired into `Run multitable real-DB integration` in

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -259,6 +259,24 @@ export default defineConfig({
       // Postgres only — excluded HERE so it cannot skip-green in the no-DB lane, whole-file wired into
       // `Run multitable real-DB integration` in plugin-tests.yml.
       'tests/integration/multitable-d1c-attachment-revision-realdb.test.ts',
+      // 4c-2 forward tombstone-capture cluster (design-lock #3809+#3830, owner-ratified 2026-07-08) — four
+      // sibling realdb specs swept into the exclude list as the same remediation class as the two W0 entries
+      // below/above (post-merge review of #4279): all four are describeIfDatabase-gated and were ALREADY
+      // whole-file wired into `Run multitable real-DB integration` in plugin-tests.yml, but missing from
+      // this list — so the no-DB job silently COLLECTED and skip-greened them. Two-point wiring: BOTH
+      // points or the no-DB lane reports them as green-with-zero-assertions.
+      // Field-delete capture point (G1 values/links/auto-number captured + causal anchor, G2 flag-off
+      // byte-identical `before`, G3 over-cap 422 atomic refusal), driving dropFieldCascade end-to-end.
+      'tests/integration/multitable-tombstone-field-capture-realdb.test.ts',
+      // R1 rehydration on field UNDELETE (G4 values/links/auto-number rehydrate + field_permissions masking
+      // unchanged, G5 no-tombstone stays definition-only), driving config-restore-execute end-to-end.
+      'tests/integration/multitable-tombstone-field-rehydrate-realdb.test.ts',
+      // Record-delete capture point (G2 record half flag-off zero rows, G7 inbound-only edge capture,
+      // G10 version-conflict refusal before any capture), driving deleteRecord end-to-end.
+      'tests/integration/multitable-tombstone-record-capture-realdb.test.ts',
+      // C6/G8 tombstone-table retention sweep (bounded batch, keep-days floor at
+      // META_REVISION_RETENTION_MIN_DAYS, disabled-by-default zero rows touched).
+      'tests/integration/multitable-tombstone-retention-realdb.test.ts',
       // W0 tail (#4279, owner MUST-WRITE OD-6, design-lock §0.5 2026-07-13): field-undelete rehydration
       // revision goldens — proves `recreateFieldFromConfig`'s tombstone-value rehydration UPDATE bumps
       // `version` and emits a `recordRecordRevision` AT THE NEW version, same transaction, for every


### PR DESCRIPTION
## Owner findings (verbatim-summarized)

Post-merge review of #4279 (field-undelete rehydration revision emit, `8b483b7f5`) found two Medium test-contract gaps:

1. **Two-point wiring gap.** Every D-1c-era real-DB spec is supposed to appear in `packages/core-backend/vitest.config.ts`'s no-DB `exclude` list (so the no-DB job cannot collect-and-skip-green a `describeIfDatabase`-gated file) AND in `plugin-tests.yml`'s multitable real-DB step (so it actually runs against Postgres in CI). Two specs were only wired on the CI side: `multitable-history-contiguity-realdb.test.ts` (from #4269) and `multitable-tombstone-field-rehydrate-revision-realdb.test.ts` (from #4279) — both missing from the `vitest.config.ts` exclude list.
2. **Missing atomicity golden.** The `multitable-tombstone-field-rehydrate-revision-realdb.test.ts` spec proves the happy path and the zero-row/concurrent-delete leg, but nothing forces a `meta_record_revisions` INSERT failure *after* the record data/version updates — so "the whole field-undelete is one atomic transaction" was asserted in prose (the file's own docstring) but never actually pinned by a test.

This PR is test-contract work only — zero runtime changes. The core implementations (#4269's generation-aware contiguity precheck, #4279's rehydration revision emit) are owner-confirmed correct.

**Scope extension (coordinator-directed, same remediation class):** while fixing the two named specs, four sibling `multitable-tombstone-*-realdb.test.ts` specs turned out to be in exactly the same half-wired state. Since the owner finding is a class ("D-1c two-point wiring applies to all realdb specs"), the sweep now covers all six.

## Fix 1 — two-point wiring: per-spec disposition (all six)

| Spec | plugin-tests.yml DB step | vitest.config.ts exclude (before) | Disposition |
|---|---|---|---|
| `multitable-history-contiguity-realdb.test.ts` (#4269) | ✅ already wired (L386) | ❌ missing | **owner finding #1 — excluded now** |
| `multitable-tombstone-field-rehydrate-revision-realdb.test.ts` (#4279) | ✅ already wired (L494) | ❌ missing | **owner finding #1 — excluded now** |
| `multitable-tombstone-field-capture-realdb.test.ts` (4c-2) | ✅ already wired (L492) | ❌ missing | **same-class sweep — was half-wired, excluded now** |
| `multitable-tombstone-field-rehydrate-realdb.test.ts` (4c-2) | ✅ already wired (L493) | ❌ missing | **same-class sweep — was half-wired, excluded now** |
| `multitable-tombstone-record-capture-realdb.test.ts` (4c-2) | ✅ already wired (L495) | ❌ missing | **same-class sweep — was half-wired, excluded now** |
| `multitable-tombstone-retention-realdb.test.ts` (4c-2) | ✅ already wired (L496) | ❌ missing | **same-class sweep — was half-wired, excluded now** |

None of the six was in the worse "never runs anywhere" state — all were already in the CI DB-step whitelist (confirmed, not edited), so no blind-wiring decision arose. All four sweep siblings were run against a fresh migrated real Postgres **before** being excluded (see counts below) — none is failing/flaky in its real lane; excluding them from the no-DB lane removes only the skip-green shadow, not any live coverage.

**Both-direction proof:**

**(a) no-DB lane — before vs. after, collect-count deltas.**
- Owner-finding pair, before: `Test Files 2 skipped (2)` / `Tests 12 skipped (12)` (collected + skip-greened). After: `No test files found, exiting with code 1`.
- Sweep quartet, before: `Test Files 4 skipped (4)` / `Tests 23 skipped (23)` (collected + skip-greened). After: `No test files found, exiting with code 1`.
- FULL no-DB suite, final state: `Test Files 471 passed | 177 skipped (648)` / `Tests 6518 passed | 1503 skipped (8021)` — zero failures. Delta vs. the run with only the first two exclusions (`471 passed | 181 skipped (652)` / `6518 passed | 1526 skipped (8044)`): skipped files −4 and skipped tests −23, exactly the sweep quartet; **passed counts unchanged** (6518/471), i.e. nothing that was actually executing was lost.

**(b) DB lane reality.** All six files appear in `.github/workflows/plugin-tests.yml`'s node-20.x "Run multitable real-DB integration" step (`DATABASE_URL` + `METASHEET_REAL_DB_TEST_STEP: '1'`). Ran all six for real against a fresh `postgres:14` migrated with CI's exact `MIGRATION_EXCLUDE`:
```
Test Files  6 passed (6)
     Tests  36 passed (36)
```
(Earlier verification of the first commit also ran the exclusion-list neighbor `multitable-d1c-form-submit-revision-realdb.test.ts` as a sanity control: 3 files / 25 tests passing.)

## Fix 2 — the field-undelete atomicity golden

Added `atomicity golden: if the meta_record_revisions INSERT throws mid-rehydration, the WHOLE field-undelete transaction rolls back` to `multitable-tombstone-field-rehydrate-revision-realdb.test.ts`, following the same scoped-trigger shape as the D-1c slice ⑤ atomicity golden in `multitable-d1c-attachment-revision-realdb.test.ts`:

- **Scoped trigger:** `BEFORE INSERT ON meta_record_revisions`, `RAISE EXCEPTION` only when `NEW.record_id = '<this test's own record id>' AND NEW.source = 'restore'` — the exact discriminator `recreateFieldFromConfig` uses for the rehydration-revision INSERT, so it cannot fire for any other concurrently-seeded record or test file sharing the database. Created inside the test, dropped in a `finally` (always, win or lose) — confirmed no orphaned trigger/function survives after the run (`pg_trigger`/`pg_proc` queried post-suite, zero rows).
- **Drives the real route:** field-delete → preview → arm trigger → `config-restore-execute` (undelete) → asserts `500` (falls through the route's outer catch to the generic `INTERNAL` mapping, since it's not a `RecordServiceRestoreConflictError`).
- **DB-state rollback assertions (all in one transaction, all proven rolled back):**
  - field still absent from `meta_fields` (hard-delete, no `deleted_at` column on that table — "still deleted" == still no row)
  - the trailing field's order-shift did NOT stick (still `1`, not re-shifted to `2` by the recreate's own +1 shift)
  - no new `meta_config_revisions` `create` row for the field (the config-revision channel rolled back too)
  - the record's `data` does NOT contain the rehydrated value; `version` is unchanged (no bump survived)
  - `meta_record_revisions` for the record has exactly 1 row (only the seeded baseline — no ghost rehydration revision)
- **Positive control:** same fixture, trigger dropped → re-run preview + execute → `200`, full success (field recreated, order-shift applied, data+version bumped, one new revision row). Proves the failure leg failed *because of* the trigger, not a broken/stale `previewToken` or fixture.

**Mutation awareness (empirically verified, not just narrated):** identified "the revision emit escapes the transaction and its failure gets swallowed" (e.g. an accidental `try/catch` around the emit, or issuing it on a separate connection/promise that isn't awaited into the transaction's own error path) as the mutation this golden exists to catch — a naive "move the emit outside the txn" mutation alone still gets caught, because Postgres poisons the whole session on the trigger's `RAISE EXCEPTION` and the *next* statement in the same transaction throws too, still triggering `pool.transaction`'s rollback. It takes the **combined** mutation — emit on a separate connection *and* swallow its own failure — to actually break atomicity. I applied that exact combined mutation locally (temporary, reverted before committing — `git diff` on `univer-meta.ts` is clean in this PR) and reran only the new golden test: it went **red** (`expected 200 to be 500`), confirming the golden is discriminating, not a tautology. It would equally catch "moving the revision emit outside the transaction" as a standalone code change, since that mutation's whole point is that the data write commits independently of whether the revision emit succeeds — exactly the state this golden's rollback assertions are built to detect.

## Verification bar

- Type-check: `tsc --noEmit` clean at final head (and after all mutation-test scratch work; `univer-meta.ts` itself is untouched by this PR).
- Full no-DB unit run (all six exclusions in place): `471 passed | 177 skipped` files, `6518 passed | 1503 skipped` tests — zero failures, passed counts identical to the pre-sweep baseline, and none of the six target files collected.
- Real-DB: fresh `postgres:14` container, full `db:migrate` with CI's exact `MIGRATION_EXCLUDE` (`008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql`), clean run. All six swept/fixed specs pass with `METASHEET_REAL_DB_TEST_STEP=1` (**6 files / 36 tests**); the first-commit verification additionally covered the `multitable-d1c-form-submit-revision-realdb.test.ts` neighbor (3 files / 25 tests).

## Scope note (not attempted here)

The scale/batch-helper item mentioned in the task brief is a separate enablement gate and was **not** attempted here, per instruction — docketed separately.

Not merging/arming — coordinator gates.
