### PR TITLE
feat(web): UI-P2-2c — responsive workbench rail (narrow-width collapse, behavior-equivalent at desktop)

### DIFF
--- a/.github/workflows/multitable-browser-verify.yml
+++ b/.github/workflows/multitable-browser-verify.yml
@@ -18,6 +18,7 @@ on:
       - 'apps/web/src/multitable/components/cells/MetaCellRenderer.vue'
       - 'apps/web/src/multitable/components/MetaCommentReactions.vue'
       - 'apps/web/src/multitable/components/MetaCommentsDrawer.vue'
+      - 'apps/web/src/multitable/views/MultitableWorkbench.vue' # UI-P2-2c drawer CSS lives here (gate NIT-3)
       - 'apps/web/src/multitable/utils/conditional-formatting.ts'
       - 'apps/web/verification/**'
       - 'apps/web/playwright.verification.config.ts'

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -4284,7 +4284,10 @@ watch(
 
 onMounted(async () => {
   window.addEventListener('beforeunload', onBeforeUnload)
-  syncRailViewportState() // UI-P2-2c: establish narrow/wide state before first paint decision
+  syncRailViewportState() // UI-P2-2c: establish narrow/wide state at mount. Runs in onMounted (AFTER the
+  // first paint), so a narrow viewport may show the expanded rail for one frame before auto-collapse;
+  // desktop is unaffected (the wide branch never writes state). Pre-paint sync would need SSR/layout-
+  // effect machinery not used in this app — accepted as a known cosmetic limit (P2-2c gate NIT-2).
   window.addEventListener('resize', syncRailViewportState)
   void auth.getCurrentUserId().then((userId) => {
     currentUserId.value = userId

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -133,7 +133,10 @@
       @reset-to-shared="onResetToShared"
     />
     <div class="mt-workbench__content">
-      <aside class="mt-workbench__rail" :class="{ 'mt-workbench__rail--collapsed': railCollapsed }">
+      <aside
+        class="mt-workbench__rail"
+        :class="{ 'mt-workbench__rail--collapsed': railCollapsed, 'mt-workbench__rail--drawer': isRailDrawerOpen }"
+      >
         <div class="mt-workbench__rail-head">
           <div v-if="basePickerBases.length" v-show="!railCollapsed" class="mt-workbench__base-bar">
             <MetaBasePicker
@@ -146,6 +149,7 @@
             />
           </div>
           <button
+            ref="railToggleRef"
             type="button"
             data-testid="rail-collapse-toggle"
             class="mt-workbench__rail-toggle"
@@ -1002,6 +1006,32 @@ const showAutomationManager = ref(false)
 // owner decision A pending -> recommended default applied): session-local only, default expanded,
 // NOT persisted (no localStorage/server write) — component remount resets to expanded.
 const railCollapsed = ref(false)
+
+// UI-P2-2c (design docs/development/multitable-ui-p2-2c-responsive-design-20260714.md): narrow-width
+// responsive rail. `isRailNarrow` is viewport-derived (window.innerWidth), NOT user-controlled — it
+// only ever WRITES `railCollapsed` on the transition INTO narrow (auto-collapse to the existing
+// icon-strip), and never touches it while already wide or already narrow, so desktop-width behavior
+// (>= RAIL_NARROW_BREAKPOINT) is a byte-for-byte no-op versus pre-2c code (see syncRailViewportState).
+// `isRailDrawerOpen` composes that with the pre-existing `railCollapsed` toggle: narrow + user-expanded
+// = the rail becomes an absolute-positioned overlay ("drawer") instead of an in-flow column (CSS only,
+// see .mt-workbench__rail--drawer) — the SAME `rail-collapse-toggle` button that already exists closes
+// it, no new emit/prop/testid. Breakpoint is a single JS constant (tokens.css has no --ms-bp-* family,
+// per the 2b design's "no width token vocabulary" carve-out at §6) — deliberately NOT mirrored into a
+// CSS @media query, so there is exactly one source of truth for the threshold.
+const RAIL_NARROW_BREAKPOINT = 768
+const isRailNarrow = ref(false)
+const railToggleRef = ref<HTMLButtonElement | null>(null)
+const isRailDrawerOpen = computed(() => isRailNarrow.value && !railCollapsed.value)
+
+function syncRailViewportState(): void {
+  if (typeof window === 'undefined') return
+  const narrow = window.innerWidth <= RAIL_NARROW_BREAKPOINT
+  const wasNarrow = isRailNarrow.value
+  isRailNarrow.value = narrow
+  if (!narrow) return // wide viewport: never mutate railCollapsed here — desktop path is untouched by 2c
+  if (!wasNarrow) railCollapsed.value = true // just crossed into narrow: auto-collapse to the icon-strip
+}
+
 const showDashboardView = ref(false)
 const showTemplateLibrary = ref(false)
 const TemplateCenterRouteName = AppRouteNames.MULTITABLE_TEMPLATES
@@ -3709,6 +3739,15 @@ function onGlobalKeydown(e: KeyboardEvent) {
   if (mod && e.key === 'z' && !e.shiftKey) { e.preventDefault(); grid.undo() }
   else if (mod && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) { e.preventDefault(); grid.redo() }
   else if (e.key === '?' && !(e.target as HTMLElement)?.closest('input, textarea, select')) { showShortcuts.value = !showShortcuts.value }
+  // UI-P2-2c: Escape closes the narrow-width drawer — scoped to events that originate FROM WITHIN the
+  // rail (the toggle button, a tree node, the base picker) so it never steals Escape from an unrelated
+  // in-progress interaction elsewhere in the workbench (e.g. a cell editor) that isn't inside the rail
+  // and may rely on its own Escape semantics. No focus trap / no scrim in this slice (documented gap,
+  // design MD §5) — this is a non-modal overlay, so background content stays reachable throughout.
+  else if (e.key === 'Escape' && isRailDrawerOpen.value && (e.target as HTMLElement)?.closest('.mt-workbench__rail')) {
+    railCollapsed.value = true
+    void nextTick(() => railToggleRef.value?.focus())
+  }
 }
 
 // --- Record deep-link (read recordId from URL hash) ---
@@ -4245,6 +4284,8 @@ watch(
 
 onMounted(async () => {
   window.addEventListener('beforeunload', onBeforeUnload)
+  syncRailViewportState() // UI-P2-2c: establish narrow/wide state before first paint decision
+  window.addEventListener('resize', syncRailViewportState)
   void auth.getCurrentUserId().then((userId) => {
     currentUserId.value = userId
   }).catch(() => undefined)
@@ -4294,6 +4335,7 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('beforeunload', onBeforeUnload)
+  window.removeEventListener('resize', syncRailViewportState)
   stopDialogMetaRefresh()
   unsubscribeMentionRealtime?.()
   // Cancel a pending column-width persist so a late write can't fire after teardown.
@@ -4338,7 +4380,9 @@ defineExpose({
 
 <style scoped>
 .mt-workbench { display: flex; flex-direction: column; height: 100%; background: #fff; }
-.mt-workbench__content { display: flex; flex: 1; min-height: 0; }
+/* position:relative establishes the positioning context .mt-workbench__rail--drawer (UI-P2-2c) anchors
+   against — inert for every other child, which all stay in normal flow. */
+.mt-workbench__content { display: flex; flex: 1; min-height: 0; position: relative; }
 .mt-workbench__main { flex: 1; display: flex; flex-direction: column; min-width: 0; }
 .mt-workbench__conflict {
   margin: 8px 16px 0;
@@ -4436,6 +4480,22 @@ defineExpose({
   overflow: hidden;
 }
 .mt-workbench__rail--collapsed { width: 36px; }
+/* UI-P2-2c (design docs/development/multitable-ui-p2-2c-responsive-design-20260714.md §3): narrow
+   viewport (<= RAIL_NARROW_BREAKPOINT, JS-only threshold — see script) + user-expanded rail = a floating
+   overlay instead of an in-flow flex column, so it no longer steals width from .mt-workbench__main.
+   Taking the rail out of flow (position:absolute) is what frees that width — no change to __main itself.
+   `--ms-shadow-pop` + an opaque `--ms-bg-card` background are both existing UF tokens (no new hex).
+   width uses the same min(px, calc(100vw - Npx)) idiom as this file's other overlay surfaces (e.g.
+   .mt-workbench__shortcuts) so it never overflows a very narrow viewport. */
+.mt-workbench__rail--drawer {
+  position: absolute;
+  inset: 0 auto 0 0;
+  z-index: 5;
+  width: min(240px, calc(100vw - 32px));
+  background: var(--ms-bg-card);
+  box-shadow: var(--ms-shadow-pop);
+  border-radius: 0 var(--ms-radius-lg) var(--ms-radius-lg) 0;
+}
 .mt-workbench__rail-head { display: flex; align-items: center; justify-content: space-between; }
 .mt-workbench__rail-toggle {
   flex-shrink: 0;

--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -946,6 +946,19 @@ async function flushUi(cycles = 5): Promise<void> {
   }
 }
 
+// UI-P2-2c (design docs/development/multitable-ui-p2-2c-responsive-design-20260714.md §6): shape copied
+// verbatim from apps/web/tests/useAttendanceAdminRailNavigation.spec.ts's own setViewportWidth helper —
+// same jsdom idiom (redefine window.innerWidth, dispatch a real 'resize' event) for the same reason
+// (MultitableWorkbench's syncRailViewportState listens for 'resize', not a matchMedia mock).
+function setViewportWidth(width: number): void {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  })
+  window.dispatchEvent(new Event('resize'))
+}
+
 function createWorkbenchMock() {
   const activeBaseId = ref('base_ops')
   const activeSheetId = ref('sheet_orders')
@@ -2833,6 +2846,113 @@ describe('MultitableWorkbench view wiring', () => {
       expect(railStubRoot().style.display).not.toBe('none')
       const baseBar = container!.querySelector('.mt-workbench__base-bar') as HTMLElement
       expect(baseBar.style.display).not.toBe('none')
+    })
+  })
+
+  // UI-P2-2c (design docs/development/multitable-ui-p2-2c-responsive-design-20260714.md §6): the rail
+  // auto-collapses below RAIL_NARROW_BREAKPOINT (768px, window.innerWidth) and, if the user re-expands it
+  // while narrow, becomes an absolute-positioned "drawer" overlay (`.mt-workbench__rail--drawer`) instead
+  // of squeezing .mt-workbench__main. These are STATE assertions (classes/attributes/focus), not CSS/
+  // layout assertions — the actual positioning/shadow/z-index rendering is a real-browser verification
+  // gap documented in the design MD §7, not claimed as proven here.
+  describe('UI-P2-2c — responsive rail (narrow-width auto-collapse + drawer)', () => {
+    function railEl(): HTMLElement {
+      const rail = container!.querySelector('.mt-workbench__rail') as HTMLElement
+      expect(rail).toBeTruthy()
+      return rail
+    }
+
+    beforeEach(() => setViewportWidth(1280))
+    afterEach(() => setViewportWidth(1280))
+
+    it('desktop width (>= breakpoint): mounting behaves exactly like pre-2c — no auto-collapse, no drawer class', async () => {
+      setViewportWidth(1280)
+      mountWorkbench()
+      await flushUi()
+      const toggle = container!.querySelector('[data-testid="rail-collapse-toggle"]') as HTMLButtonElement
+      expect(toggle.getAttribute('aria-expanded')).toBe('true')
+      expect(railEl().classList.contains('mt-workbench__rail--collapsed')).toBe(false)
+      expect(railEl().classList.contains('mt-workbench__rail--drawer')).toBe(false)
+    })
+
+    it('narrow width at mount: auto-collapses to the icon-strip (no drawer)', async () => {
+      setViewportWidth(600)
+      mountWorkbench()
+      await flushUi()
+      const toggle = container!.querySelector('[data-testid="rail-collapse-toggle"]') as HTMLButtonElement
+      expect(toggle.getAttribute('aria-expanded')).toBe('false')
+      expect(railEl().classList.contains('mt-workbench__rail--collapsed')).toBe(true)
+      expect(railEl().classList.contains('mt-workbench__rail--drawer')).toBe(false)
+    })
+
+    it('resizing to narrow after mount auto-collapses; resizing back to wide does NOT force re-expand', async () => {
+      setViewportWidth(1280)
+      mountWorkbench()
+      await flushUi()
+      const toggle = container!.querySelector('[data-testid="rail-collapse-toggle"]') as HTMLButtonElement
+      expect(toggle.getAttribute('aria-expanded')).toBe('true')
+
+      setViewportWidth(600)
+      await flushUi()
+      expect(toggle.getAttribute('aria-expanded')).toBe('false')
+
+      setViewportWidth(1280)
+      await flushUi()
+      // Deliberate asymmetry (design MD §2): leaving narrow never force-writes railCollapsed.
+      expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    })
+
+    it('re-expanding the rail while narrow enters drawer mode; the same toggle closes it back to the icon-strip', async () => {
+      setViewportWidth(600)
+      mountWorkbench()
+      await flushUi()
+      const toggle = container!.querySelector('[data-testid="rail-collapse-toggle"]') as HTMLButtonElement
+      expect(railEl().classList.contains('mt-workbench__rail--collapsed')).toBe(true)
+
+      toggle.click()
+      await flushUi()
+      expect(toggle.getAttribute('aria-expanded')).toBe('true')
+      expect(railEl().classList.contains('mt-workbench__rail--drawer')).toBe(true)
+      expect(railEl().classList.contains('mt-workbench__rail--collapsed')).toBe(false)
+
+      toggle.click()
+      await flushUi()
+      expect(railEl().classList.contains('mt-workbench__rail--drawer')).toBe(false)
+      expect(railEl().classList.contains('mt-workbench__rail--collapsed')).toBe(true)
+    })
+
+    it('Escape from inside the rail closes the drawer and returns focus to the toggle', async () => {
+      setViewportWidth(600)
+      mountWorkbench()
+      await flushUi()
+      const toggle = container!.querySelector('[data-testid="rail-collapse-toggle"]') as HTMLButtonElement
+      toggle.click()
+      await flushUi()
+      expect(railEl().classList.contains('mt-workbench__rail--drawer')).toBe(true)
+
+      toggle.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+      await flushUi()
+
+      expect(railEl().classList.contains('mt-workbench__rail--drawer')).toBe(false)
+      expect(toggle.getAttribute('aria-expanded')).toBe('false')
+      expect(document.activeElement).toBe(toggle)
+    })
+
+    it('Escape from outside the rail (main content) does NOT close the drawer — scoped, not global', async () => {
+      setViewportWidth(600)
+      mountWorkbench()
+      await flushUi()
+      const toggle = container!.querySelector('[data-testid="rail-collapse-toggle"]') as HTMLButtonElement
+      toggle.click()
+      await flushUi()
+      expect(railEl().classList.contains('mt-workbench__rail--drawer')).toBe(true)
+
+      const main = container!.querySelector('.mt-workbench__main') as HTMLElement
+      expect(main).toBeTruthy()
+      main.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+      await flushUi()
+
+      expect(railEl().classList.contains('mt-workbench__rail--drawer')).toBe(true)
     })
   })
 })

--- a/apps/web/verification/rail-drawer-harness.html
+++ b/apps/web/verification/rail-drawer-harness.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>UI-P2-2c rail drawer — browser verification harness</title>
+    <!--
+      CSS below is copied VERBATIM from apps/web/src/multitable/views/MultitableWorkbench.vue's
+      <style scoped> block (the .mt-workbench__content / .mt-workbench__rail* rules only — this harness
+      exists solely to prove those exact declarations resolve correctly in a real browser; the
+      interactive STATE logic (which class gets applied when) is already proven in jsdom via
+      apps/web/tests/multitable-workbench-view.spec.ts's 'UI-P2-2c' describe block — this harness does
+      not re-test that, it only drives class toggles directly via harness buttons). Scoped-vs-global CSS
+      does not change the resolved computed-style values being asserted here (position/z-index/width/
+      background-color/box-shadow) — only the selector-matching mechanism, which isn't under test.
+      tokens.css is imported for real by rail-drawer-harness.ts (`import '../src/styles/tokens.css'`),
+      the same statement apps/web/src/main.ts uses — so --ms-bg-card / --ms-shadow-pop / --ms-radius-lg
+      below resolve to the SAME values the real app ships, not a harness-local copy.
+    -->
+    <style>
+      .mt-workbench__content { display: flex; flex: 1; min-height: 0; position: relative; height: 320px; border: 1px dashed #999; }
+      .mt-workbench__main { flex: 1; display: flex; flex-direction: column; min-width: 0; background: #eef; }
+      .mt-workbench__rail {
+        width: 240px;
+        flex-shrink: 0;
+        display: flex;
+        flex-direction: column;
+        border-right: 1px solid var(--ms-border-light);
+        overflow: hidden;
+      }
+      .mt-workbench__rail--collapsed { width: 36px; }
+      .mt-workbench__rail--drawer {
+        position: absolute;
+        inset: 0 auto 0 0;
+        z-index: 5;
+        width: min(240px, calc(100vw - 32px));
+        background: var(--ms-bg-card);
+        box-shadow: var(--ms-shadow-pop);
+        border-radius: 0 var(--ms-radius-lg) var(--ms-radius-lg) 0;
+      }
+    </style>
+  </head>
+  <body style="margin:16px;font-family:system-ui">
+    <h3>UI-P2-2c — narrow-width rail drawer CSS (real-browser getComputedStyle)</h3>
+    <div id="app"></div>
+    <script type="module" src="./rail-drawer-harness.ts"></script>
+  </body>
+</html>

--- a/apps/web/verification/rail-drawer-harness.ts
+++ b/apps/web/verification/rail-drawer-harness.ts
@@ -1,0 +1,36 @@
+// Browser-verification harness (dev/CI only — NOT part of the app build/typecheck; lives outside src/
+// so vue-tsc + vite build ignore it). Real UF token load (../src/styles/tokens.css — the exact statement
+// apps/web/src/main.ts uses) + the copied CSS in rail-drawer-harness.html's <style> block let a real
+// browser resolve the UI-P2-2c drawer rule's computed values (position/z-index/width/background-color/
+// box-shadow) — see design docs/development/multitable-ui-p2-2c-responsive-design-20260714.md §7.
+// This harness intentionally does NOT reproduce MultitableWorkbench.vue's viewport/resize STATE machine
+// (that's already proven in jsdom, see the 'UI-P2-2c' describe in
+// apps/web/tests/multitable-workbench-view.spec.ts) — the three buttons below just apply the class
+// combinations directly so the spec can assert each state's resolved CSS in isolation.
+import { createApp, h, ref } from 'vue'
+import '../src/styles/tokens.css'
+
+type Mode = 'default' | 'collapsed' | 'drawer'
+
+createApp({
+  setup() {
+    const mode = ref<Mode>('default')
+    const railClass = () => ({
+      'mt-workbench__rail': true,
+      'mt-workbench__rail--collapsed': mode.value === 'collapsed',
+      'mt-workbench__rail--drawer': mode.value === 'drawer',
+    })
+    return () => h('div', [
+      h('div', { style: 'margin-bottom:12px;display:flex;gap:8px' }, [
+        h('button', { 'data-test': 'mode-default', onClick: () => { mode.value = 'default' } }, 'default'),
+        h('button', { 'data-test': 'mode-collapsed', onClick: () => { mode.value = 'collapsed' } }, 'collapsed'),
+        h('button', { 'data-test': 'mode-drawer', onClick: () => { mode.value = 'drawer' } }, 'drawer'),
+      ]),
+      h('div', { 'data-test': 'current-mode', style: 'margin-bottom:12px;color:#333' }, `mode: ${mode.value}`),
+      h('div', { class: 'mt-workbench__content', 'data-test': 'content' }, [
+        h('aside', { class: railClass(), 'data-test': 'rail' }, 'rail content'),
+        h('div', { class: 'mt-workbench__main', 'data-test': 'main' }, 'main content'),
+      ]),
+    ])
+  },
+}).mount('#app')

--- a/apps/web/verification/rail-drawer.spec.ts
+++ b/apps/web/verification/rail-drawer.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+
+// Real-browser verification of the UI-P2-2c drawer CSS that jsdom can't prove — see design
+// docs/development/multitable-ui-p2-2c-responsive-design-20260714.md §7 (this is the CSS leg; the
+// interactive STATE machine — which class applies at which viewport width — is proven separately in
+// jsdom, see apps/web/tests/multitable-workbench-view.spec.ts's 'UI-P2-2c' describe block).
+//
+// Every "drawer has X" assertion below is paired with a "default/collapsed does NOT have X" positive
+// control on the SAME page, so a vacuously-true assertion (e.g. a selector matching nothing) cannot
+// pass silently — see feedback_positive_control_not_failclosed.md.
+
+const OUT = 'verification-output'
+const HARNESS = '/verification/rail-drawer-harness.html'
+
+test('UI-P2-2c rail drawer CSS resolves correctly in a real browser', async ({ page }) => {
+  mkdirSync(OUT, { recursive: true })
+  const errs: string[] = []
+  page.on('console', (m) => { if (m.type() === 'error') errs.push(`console: ${m.text()}`) })
+  page.on('pageerror', (e) => errs.push(`pageerror: ${String(e)}`))
+
+  await page.setViewportSize({ width: 1280, height: 720 })
+  await page.goto(HARNESS, { waitUntil: 'domcontentloaded' })
+  const rail = page.locator('[data-test="rail"]')
+  await expect(rail).toBeVisible()
+
+  // --- default state (positive control: NOT collapsed, NOT drawer) ---
+  await expect(page.locator('[data-test="current-mode"]')).toHaveText('mode: default')
+  let box = await rail.evaluate((el) => getComputedStyle(el).position)
+  expect(box, 'default: position must be static, not absolute').toBe('static')
+  let width = await rail.evaluate((el) => getComputedStyle(el).width)
+  expect(width, 'default: full 240px width').toBe('240px')
+  let shadow = await rail.evaluate((el) => getComputedStyle(el).boxShadow)
+  expect(shadow, 'default: no drawer shadow').toBe('none')
+  await page.screenshot({ path: `${OUT}/rail-drawer-default.png` })
+
+  // --- collapsed state (positive control: the pre-existing P2-2b icon-strip, still NOT a drawer) ---
+  await page.locator('[data-test="mode-collapsed"]').click()
+  await expect(page.locator('[data-test="current-mode"]')).toHaveText('mode: collapsed')
+  box = await rail.evaluate((el) => getComputedStyle(el).position)
+  expect(box, 'collapsed: still static (P2-2b icon-strip is in-flow, not absolute)').toBe('static')
+  width = await rail.evaluate((el) => getComputedStyle(el).width)
+  expect(width, 'collapsed: 36px icon-strip width').toBe('36px')
+  await page.screenshot({ path: `${OUT}/rail-drawer-collapsed.png` })
+
+  // --- drawer state: the actual UI-P2-2c claims ---
+  await page.locator('[data-test="mode-drawer"]').click()
+  await expect(page.locator('[data-test="current-mode"]')).toHaveText('mode: drawer')
+  box = await rail.evaluate((el) => getComputedStyle(el).position)
+  expect(box, 'drawer: position:absolute (overlay, not in-flow)').toBe('absolute')
+  const zIndex = await rail.evaluate((el) => getComputedStyle(el).zIndex)
+  expect(zIndex, 'drawer: z-index:5 (paints over .mt-workbench__main)').toBe('5')
+  width = await rail.evaluate((el) => getComputedStyle(el).width)
+  expect(width, 'drawer at 1280px viewport: min(240px, calc(100vw-32px)) resolves to 240px').toBe('240px')
+  shadow = await rail.evaluate((el) => getComputedStyle(el).boxShadow)
+  expect(shadow, 'drawer: --ms-shadow-pop resolves to a real (non-none) box-shadow').not.toBe('none')
+  const bg = await rail.evaluate((el) => getComputedStyle(el).backgroundColor)
+  expect(bg, 'drawer: --ms-bg-card resolves to an OPAQUE background (not transparent) so it truly occludes .mt-workbench__main behind it').not.toBe('rgba(0, 0, 0, 0)')
+  // --ms-bg-card is #ffffff in tokens.css (light mode, no dark override defined yet — see design MD §7).
+  expect(bg, '--ms-bg-card resolves to its documented #ffffff value').toBe('rgb(255, 255, 255)')
+  await page.screenshot({ path: `${OUT}/rail-drawer-open.png` })
+
+  // --- narrow viewport: the calc(100vw - 32px) clamp actually engages (not just the 240px branch) ---
+  await page.setViewportSize({ width: 200, height: 600 })
+  await page.waitForTimeout(50) // let layout settle after resize
+  width = await rail.evaluate((el) => getComputedStyle(el).width)
+  expect(width, 'drawer at 200px viewport: calc(100vw-32px)=168px < 240px, min() picks the clamp').toBe('168px')
+  await page.screenshot({ path: `${OUT}/rail-drawer-narrow-viewport.png` })
+
+  expect(errs, `console/page errors:\n${errs.join('\n')}`).toEqual([])
+})

--- a/docs/development/multitable-ui-p2-2c-responsive-design-20260714.md
+++ b/docs/development/multitable-ui-p2-2c-responsive-design-20260714.md
@@ -1,0 +1,214 @@
+# 多维表 UI-P2-2c · 响应式工作台左侧栏（窄屏折叠 + 抽屉）· 设计（PROPOSED）
+
+> 状态：**PROPOSED**（implementer-authored, not owner-ratified). Parent lock
+> `multitable-ui-p2-2-left-rail-detail-designlock-20260707.md` §5 lists `🔒 P2-2c 响应式折叠（窄屏抽屉/图标条）—
+> P2-2b 后` as a pending gate with no further detail; the P2-2b design MD (§8.4) explicitly defers all
+> viewport/media-query behavior to this slice ("2b 不加任何视口 media query"). Neither doc specifies a
+> breakpoint, a collapse pattern, or keyboard/ARIA behavior for the narrow case — this document fills
+> that gap so the implementation has a written contract, per this task's fallback instruction ("if NO or
+> partial: write a short design section first"). Recommend Opus/adversarial review before merge, same as
+> P2-2b (§4.6 of the parent lock frames the rail as structural), since the drawer overlay is new runtime
+> behavior even though its net diff is small.
+> Baseline: `origin/main` @ `6a10d08c7` (P2-2b #4264 landed: `MetaSheetViewRail.vue` vertical tree +
+> `MultitableWorkbench.vue`'s collapsible `<aside>` rail, `railCollapsed` ref, T7 collapse tests).
+
+## 0. One-liner
+
+At viewport widths above the breakpoint, nothing changes (pinned by tests). Below it, the rail
+auto-collapses to the *same* 36px icon-strip P2-2b already built (no new DOM there — it was already an
+escape hatch, now it also self-triggers). If the user re-expands the rail while narrow, it becomes a
+floating overlay ("drawer") over the main content instead of squeezing it — one new CSS class, driven by
+one new JS boolean, closed by the *same* `rail-collapse-toggle` button that already exists, plus Escape.
+Zero new props/emits/testids on `MetaSheetViewRail.vue`; zero new i18n strings; all state lives in
+`MultitableWorkbench.vue` (consistent with where P2-2b already put `railCollapsed`, and for the same
+reason it gave: the rail-level chrome is a workbench concern, not the tree component's).
+
+## 1. Breakpoint
+
+`apps/web/src/styles/tokens.css` has no `--ms-bp-*` / width-breakpoint family (confirmed by reading the
+full 143-line file — only color/spacing/radius/typography/container-width/shadow tokens exist). P2-2b hit
+the same gap for the rail's own 240px/36px widths and explicitly carved out "raw px, don't invent a new
+token vocabulary" (§6 of its design MD). This slice follows the same carve-out for the breakpoint:
+
+```ts
+const RAIL_NARROW_BREAKPOINT = 768 // px, window.innerWidth
+```
+
+768px is not arbitrary — it is the single most common threshold already used across `apps/web/src`
+(`App.vue`, `PageShell.vue`, `CalendarView.vue`, `SpreadsheetsView.vue`, `FormView.vue`,
+`AttendanceView.vue`, `AttendanceImportWorkflowSection.vue`, `AttendanceRequestCenterSection.vue`,
+`TemplateDetailView.vue`, `GalleryView.vue`, `PlmProductView.vue`, and — most relevantly —
+`AttendanceAdminRail.vue`'s own `useAttendanceAdminRailNavigation.ts`, a structurally analogous
+"persistent left nav for a big workbench" that already does exactly this pattern: a
+`window.innerWidth <= 768` check on mount + `resize`, driving a `isCompactAdminNav` boolean). That
+component is this slice's closest precedent and its logic shape is deliberately mirrored below.
+
+The threshold is a **JS-only constant** — deliberately **not** duplicated into a CSS `@media` query, so
+there is exactly one source of truth and no risk of the two drifting apart over time. The narrow/wide
+CSS states are entirely driven by the JS-computed class bindings (same idiom P2-2b already used for
+`.mt-workbench__rail--collapsed`, which also isn't behind a media query).
+
+## 2. State model
+
+Three refs/computed, all in `MultitableWorkbench.vue` (`<script setup>`, near the existing
+`railCollapsed`):
+
+| name | kind | meaning |
+|---|---|---|
+| `railCollapsed` | `ref<boolean>` (pre-existing, P2-2b) | user-togglable; unchanged semantics |
+| `isRailNarrow` | `ref<boolean>` (new) | viewport-derived, **not** user-writable; `window.innerWidth <= 768` |
+| `isRailDrawerOpen` | `computed<boolean>` (new) | `isRailNarrow && !railCollapsed` |
+
+`syncRailViewportState()` (called on mount + on every `resize`, mirroring
+`syncAdminNavViewportState` in `useAttendanceAdminRailNavigation.ts`):
+
+```ts
+function syncRailViewportState(): void {
+  if (typeof window === 'undefined') return
+  const narrow = window.innerWidth <= RAIL_NARROW_BREAKPOINT
+  const wasNarrow = isRailNarrow.value
+  isRailNarrow.value = narrow
+  if (!narrow) return                     // wide: NEVER touches railCollapsed — see §4 desktop-invariance
+  if (!wasNarrow) railCollapsed.value = true // just crossed into narrow: auto-collapse once
+}
+```
+
+Two deliberate asymmetries, both testable:
+
+1. **Entering narrow auto-collapses; staying narrow never re-collapses.** A user who manually re-expands
+   the rail (opens the drawer) at, say, 600px and then resizes to 500px does not get slammed shut by a
+   second `resize` tick — `wasNarrow` is already `true` so the `if (!wasNarrow)` branch is skipped. This
+   matches `useAttendanceAdminRailNavigation.ts`'s own asymmetry (it only forces the flyout shut on
+   *actions* like `scrollToAdminSection`, not on every resize tick while already compact).
+2. **Leaving narrow does not force-expand.** Crossing back over the breakpoint does not reset
+   `railCollapsed` — the user's manual toggle state (set at any width, before or during the narrow visit)
+   is left alone. This is a scope-minimizing choice: it keeps `syncRailViewportState`'s wide branch a true
+   no-op (see §4), and avoids a surprise "the sidebar reopens itself" resize side effect. A user who wants
+   it back just clicks the (always-visible) toggle — unchanged control surface.
+
+Neither the auto-collapse nor `isRailNarrow` is persisted (no localStorage/server write) — consistent
+with P2-2b's §3.1 owner-decision-A default ("not persisted") and P2-2b's design lock language ("component
+remount resets"); a fresh mount always re-runs `syncRailViewportState()` from the real viewport.
+
+## 3. Narrow-width behavior (the two states below the breakpoint)
+
+| state | condition | visual | in-flow or overlay | new DOM/CSS |
+|---|---|---|---|---|
+| **icon-strip** (already existed) | `isRailNarrow && railCollapsed` | 36px strip, only the toggle button visible (rail content `v-show`-hidden) | in-flow (same as P2-2b's desktop-collapsed state) | none — this is literally P2-2b's `.mt-workbench__rail--collapsed`, just auto-entered instead of requiring a click |
+| **drawer** (new) | `isRailNarrow && !railCollapsed` (= `isRailDrawerOpen`) | full rail (base-bar + tree) floats over `.mt-workbench__main` instead of squeezing it | `position: absolute` overlay, `z-index: 5`, `box-shadow: var(--ms-shadow-pop)`, opaque `background: var(--ms-bg-card)`, `width: min(240px, calc(100vw - 32px))` | one new CSS class `.mt-workbench__rail--drawer` on the existing `<aside>` |
+
+At width **>= 768px**: neither state can be entered (`isRailNarrow` is `false`, so `isRailDrawerOpen` is
+always `false` and the auto-collapse branch never runs) — behavior is **exactly** the pre-2c P2-2b rail,
+unconditionally.
+
+Taking the rail out of flow via `position: absolute` is what frees the width for `.mt-workbench__main`
+(which is `flex: 1` and therefore expands to fill the space the rail no longer reserves) — no separate
+CSS change to `.mt-workbench__main` was needed. `.mt-workbench__content` gains `position: relative`
+(inert for every other child) purely to give the drawer a local positioning anchor instead of the
+viewport, so it respects the toolbar/actions bar above it rather than floating over them too.
+
+The drawer's own close affordance is the **same** `rail-collapse-toggle` button, no new testid: clicking
+it still just flips `railCollapsed`, which (since `isRailNarrow` is still `true`) lands back in the
+icon-strip state. `MetaSheetViewRail.vue` itself is untouched — 0 lines changed, 0 new props/emits, per
+the parent lock's emit/consumer-parity constraints (§4.1/§4.2), which this slice doesn't need to touch at
+all since all the new logic is chrome around the existing component, not inside it.
+
+## 4. Desktop-width invariance (the thing tests must pin)
+
+Claim: at any point in time where `window.innerWidth > RAIL_NARROW_BREAKPOINT`, the rail's behavior is
+identical to the pre-2c P2-2b build.
+
+This isn't just "looks the same" — it's structurally true from the code: `syncRailViewportState`'s wide
+branch is `isRailNarrow.value = narrow; if (!narrow) return` — a pure read-then-return with **zero**
+writes to `railCollapsed`. The only other new code that reads `railCollapsed` is the `isRailDrawerOpen`
+computed and the `Escape` branch in `onGlobalKeydown`, both of which are gated on `isRailNarrow` (false at
+desktop) before touching anything, so they're no-ops too. The pre-existing `rail-collapse-toggle` click
+handler (`railCollapsed = !railCollapsed`) is untouched — same line, same behavior.
+
+Test evidence for this claim: (a) all of P2-2b's existing T7 tests
+(`apps/web/tests/multitable-workbench-view.spec.ts`, `describe('UI-P2-2b — rail collapse (T7)')`) continue
+to pass **unmodified** — jsdom's default `window.innerWidth` (1024) is already above 768, so those tests
+were unknowingly already exercising the "wide" path; their continuing to pass with the 2c code present is
+itself a desktop-regression check. (b) A new explicit test sets the viewport to 1280px and re-asserts the
+same invariants defensively (see §6).
+
+## 5. Keyboard / ARIA
+
+- **Toggle button**: unchanged — same `data-testid="rail-collapse-toggle"`, same `aria-expanded`/
+  `aria-label`/`title` bindings (`rail.collapse`/`rail.expand`, already-existing i18n keys in
+  `workbench-labels.ts` — no new strings needed since the button's role, whether it's opening the
+  icon-strip or the drawer, is still accurately described as "expand/collapse sidebar").
+- **Escape closes the drawer**, scoped: only fires when `isRailDrawerOpen` is true AND the event's
+  `target` is inside `.mt-workbench__rail` (`(e.target as HTMLElement)?.closest('.mt-workbench__rail')`).
+  This reuses the workbench's existing single `@keydown="onGlobalKeydown"` root listener (bubbling — no
+  new `addEventListener`) and mirrors the scoping style already used by that function's `?` shortcut
+  branch (`!(e.target as HTMLElement)?.closest('input, textarea, select')`). The scoping is a deliberate,
+  documented choice: an unscoped global Escape would risk stealing the key from an unrelated in-progress
+  interaction elsewhere in the workbench (e.g. a cell editor's own Escape-to-cancel) that happens to be
+  open at the same time the drawer is open. Pressing Escape closes the drawer (`railCollapsed = true`)
+  and returns focus to the toggle button (`railToggleRef`).
+- **What is explicitly NOT implemented** (honesty section, same spirit as P2-2b's §5.3/§10): no focus
+  trap, no backdrop/scrim, no outside-click-to-dismiss. The drawer is a **non-modal** overlay — background
+  content (`.mt-workbench__main`) stays fully focusable and readable by assistive tech throughout, which
+  is why no `aria-hidden`/`inert` is applied to it either. This is a scope-minimizing choice for a first
+  slice, not an oversight; a follow-up could add a proper modal treatment if narrow-width usage in
+  practice shows it's needed, but that would be its own small design decision (new interaction surface),
+  not a hidden default the way P2-2b's §5.3 already treats "don't claim behavior you didn't build."
+- The rail's internal tree keyboard nav (`role="tree"`/`treeitem`/roving tabindex, P2-2b §5) is completely
+  untouched — the drawer only changes the *outer* `<aside>`'s CSS positioning, not anything inside
+  `MetaSheetViewRail.vue`.
+
+## 6. Test plan
+
+All new tests are **state** assertions (refs/classes/attributes), not CSS/layout assertions — per this
+task's constraint that jsdom cannot be trusted for real style/layout claims. They extend the existing
+`describe('MultitableWorkbench view wiring', ...)` suite in
+`apps/web/tests/multitable-workbench-view.spec.ts` (already in `multitable-web-guard.yml`'s path-filter
+and run-token list — no CI wiring changes needed, avoiding the "skip-shaped green" trap of adding a new
+spec file and forgetting to wire it in). A `setViewportWidth(width)` helper is added, copied verbatim in
+shape from `apps/web/tests/useAttendanceAdminRailNavigation.spec.ts`'s own helper
+(`Object.defineProperty(window, 'innerWidth', ...)` + `window.dispatchEvent(new Event('resize'))`).
+
+New `describe('UI-P2-2c — responsive rail (narrow-width auto-collapse + drawer)', ...)`:
+
+1. **Desktop invariance**: mount at 1280px — default expanded, no `--collapsed`/`--drawer` class, toggle
+   `aria-expanded="true"` (defensive re-statement of §4's claim; the unmodified T7 block already covers
+   this at jsdom's default width).
+2. **Narrow at mount**: mount at 600px — auto-collapses (`aria-expanded="false"`, `--collapsed` class
+   present, `--drawer` absent).
+3. **Resize after mount, round trip**: mount at 1280px, resize to 600px (auto-collapses), resize back to
+   1280px (stays collapsed — pins the "leaving narrow does not force-expand" asymmetry from §2).
+4. **Drawer open/close**: mount at 600px (auto-collapsed), click toggle → `--drawer` class present,
+   `aria-expanded="true"`; click toggle again → `--drawer` gone, `--collapsed` back (pins the toggle
+   double-duty as both icon-strip-opener and drawer-closer).
+5. **Escape scoped-in**: open the drawer, dispatch `Escape` from the toggle button (inside
+   `.mt-workbench__rail`) — drawer closes, `document.activeElement` is the toggle button.
+6. **Escape scoped-out**: open the drawer, dispatch `Escape` from `.mt-workbench__main` — drawer stays
+   open (pins the scoping decision in §5, not just that Escape "works").
+
+Diff whitelist for this slice: `apps/web/src/multitable/views/MultitableWorkbench.vue` (script: 3 new
+refs/computed + 1 function + 2 event-listener lines + 1 `onGlobalKeydown` branch; template: 1 class
+binding + 1 template ref; style: 1 property added to an existing rule + 1 new rule) and
+`apps/web/tests/multitable-workbench-view.spec.ts` (1 new helper + 1 new `describe`). Nothing else —
+`MetaSheetViewRail.vue`, `meta-sheet-view-rail-labels.ts`, `workbench-labels.ts`, and
+`multitable-web-guard.yml` are all untouched (no new i18n strings, no CI path-filter/run-list changes
+needed since both changed files are already covered).
+
+## 7. Verification honesty (read before trusting a "done")
+
+- **State logic**: verified by the vitest suite above, run for real in this environment (see PR body for
+  the actual command + output).
+- **CSS positioning / shadow / z-index / actual visual overlay-vs-push behavior**: **not** verified in a
+  real browser in this environment. Per this task's instructions and this repo's standing rule that
+  jsdom cannot be trusted for style claims (`feedback_css_verify_in_real_browser_not_jsdom.md`), no claim
+  is made here that the drawer visually renders correctly, that `--ms-shadow-pop`/`--ms-bg-card` resolve
+  to the expected computed values, or that it looks correct in dark mode. This is flagged explicitly as a
+  **coordinator verification gap** — the P2-2b PR (#4264) used a vite-harness + Playwright
+  `getComputedStyle` pattern for exactly this kind of claim; the same pattern should be applied here
+  before treating the CSS leg as proven, not just the state-machine leg.
+- **No new hardcoded hex**: every new/changed CSS declaration in this slice uses an existing `--ms-*`
+  token (`--ms-bg-card`, `--ms-shadow-pop`, `--ms-radius-lg`) or a unitless/px layout value in the same
+  "raw px for sizing, not color" carve-out P2-2b already used (§6 of the 2b MD) — grep-checkable:
+  `rg '#[0-9a-fA-F]{3,8}' apps/web/src/multitable/views/MultitableWorkbench.vue` on just the diff hunk
+  shows zero new matches (pre-existing hex elsewhere in this large file is out of this slice's scope to
+  fix).


### PR DESCRIPTION
## Design reference

`docs/development/multitable-ui-p2-2b-vertical-tree-design-20260713.md` §8.4 explicitly defers ALL viewport/media-query behavior to this slice ("2b adds no media query — responsive = P2-2c, an independent gate"). The parent lock `docs/development/multitable-ui-p2-2-left-rail-detail-designlock-20260707.md` §5 lists `🔒 P2-2c 响应式折叠（窄屏抽屉/图标条）` as a pending gate with no breakpoint/pattern/keyboard spec.

Per this task's fallback instruction, I wrote a short **PROPOSED** design doc first — **`docs/development/multitable-ui-p2-2c-responsive-design-20260714.md`** — then implemented exactly that. It is implementer-authored, not owner-ratified; I recommend the same Opus/adversarial-review gate P2-2b used before merge, since this introduces new runtime behavior (an overlay) even though the diff is small.

## Behavior table

| viewport | rail state | in-flow or overlay | new vs. pre-2c |
|---|---|---|---|
| `>= 768px` (desktop) | unchanged: expanded (240px) or manually-collapsed (36px), per the existing `railCollapsed` toggle | in-flow | **none** — `syncRailViewportState`'s wide branch never writes `railCollapsed`; it's a provable no-op |
| `< 768px`, collapsed | 36px icon-strip (same DOM/CSS P2-2b already built) | in-flow | only new is that it now **auto-triggers** on entering narrow, instead of requiring a click |
| `< 768px`, user re-expanded | full rail (base-bar + tree), unchanged content | **overlay** (`position:absolute`, `z-index:5`, `--ms-shadow-pop`, opaque `--ms-bg-card`, `width:min(240px, calc(100vw-32px))`) over `.mt-workbench__main` instead of squeezing it | new: `.mt-workbench__rail--drawer` |

Closing the drawer: the **same** `rail-collapse-toggle` button (no new testid) + **Escape**, scoped to events originating inside `.mt-workbench__rail` (so it never steals Escape from something else open elsewhere in the workbench, e.g. a cell editor).

`MetaSheetViewRail.vue` is untouched — 0 lines, 0 new props/emits/testids/i18n strings. All new state (`isRailNarrow`, `isRailDrawerOpen`, `syncRailViewportState`) lives in `MultitableWorkbench.vue`, same place P2-2b already put `railCollapsed`, for the same reason it gave (rail-level chrome is a workbench concern, not the tree component's).

## What's tested, and how

**State logic (jsdom, real component + mocked composables)** — extended the existing `describe('MultitableWorkbench view wiring', ...)` in `apps/web/tests/multitable-workbench-view.spec.ts` (already in `multitable-web-guard.yml`'s path-filter + run-token list — **no CI wiring changes needed**) with a new `describe('UI-P2-2c — responsive rail ...')`, 6 tests:
- desktop-width invariance (no class/behavior change)
- narrow-at-mount auto-collapse
- resize round-trip (narrow auto-collapses; back-to-wide does NOT force re-expand — a deliberate documented asymmetry)
- drawer open/close via the existing toggle
- Escape-from-inside closes + refocuses the toggle
- Escape-from-outside (main content) does **not** close it (proves the scoping, not just that Escape "works")

Ran for real:
```
pnpm --filter @metasheet/web exec vitest run meta-sheet-view-rail multitable-workbench-view --reporter=dot
# Test Files  2 passed (2) / Tests  109 passed (109)
```
Also ran the wider workbench-wiring neighbor set (148 tests) and `vue-tsc -b` (0 errors) — both clean.

**Mutation self-check** (commit → mutate → confirm red → revert, before pushing):
1. Disabled the auto-collapse write → 5/6 new tests went red (only the desktop-invariance test, correctly, stayed green).
2. Removed the Escape rail-scoping condition → exactly the "Escape from outside" test went red, the other 5 stayed green.

**CSS (real browser, not jsdom)** — per this repo's standing rule that jsdom style assertions are worthless, I built a minimal Playwright verification harness (`apps/web/verification/rail-drawer-harness.{html,ts}` + `rail-drawer.spec.ts`, same pattern as the existing `cf-reactions-harness`/`grouped-windowing-harness`) that loads the **real** `tokens.css` and the CSS rules copied verbatim from `MultitableWorkbench.vue`, and asserts `getComputedStyle` in real Chromium, **with positive controls** (default/collapsed states assert `position: static` / no shadow, alongside the drawer state asserting `position: absolute` / real shadow / opaque `--ms-bg-card` background):
```
pnpm exec playwright test --config playwright.verification.config.ts rail-drawer.spec.ts
# 1 passed (2.4s)
```
This also exercises the `min(240px, calc(100vw - 32px))` clamp at a 200px viewport (asserts it resolves to 168px, not 240px) and screenshots each state (`apps/web/verification-output/`, gitignored, not committed).

## Honest verification gaps

- The Playwright harness proves the **CSS declarations** resolve correctly in a real browser, and jsdom proves the **state machine** on the real component. What I did **not** do is drive the *fully integrated* `MultitableWorkbench.vue` (real auth/backend, real resize event, real browser) in one single test — that needs a running backend and is out of scope for this environment. If a higher-fidelity end-to-end confirmation is wanted, that's a coordinator follow-up.
- Dark-mode: `tokens.css` has no dark-theme overrides for `--ms-bg-card`/`--ms-shadow-pop` yet (confirmed by reading the full file — dark theme is described there as "its own independent line"), so there's nothing dark-specific to verify; I only confirm no new hardcoded hex was introduced (`git diff` hunk has zero `#`-hex matches).
- No focus trap / no scrim / no outside-click-to-dismiss on the drawer — documented as a deliberate, non-hidden scope decision in the design MD §5 (non-modal overlay, background stays reachable), not an oversight.

## Constraints checklist

- Desktop-width behavior-equivalence: pinned by test + structurally provable (the wide-viewport code path never writes `railCollapsed`).
- All existing testids/events preserved (0 changes to `MetaSheetViewRail.vue`).
- tokens.css vars only, no hardcoded values (`--ms-bg-card`, `--ms-shadow-pop`, `--ms-radius-lg`; layout sizing follows P2-2b's existing raw-px carve-out).
- No new dependencies — `pnpm-lock.yaml` diff is empty (`git diff HEAD~1 -- pnpm-lock.yaml` = no output).

Branch: `claude/w1-p2-2c-responsive-20260714`. Not merged/armed — coordinator gates.


> **CI coverage correction (gate NIT-1):** the 6 new `multitable-workbench-view` tests are executed by the **required** `web-tests` job (`run-required-web-tests.sh` filter token `multitable-workbench-view`, unchanged by this PR). `multitable-web-guard.yml` only path-triggers on the changed files — the spec is NOT in that guard's vitest run-list; an earlier revision of this body misattributed the coverage.