### PR TITLE
fix(attendance): migrate rehearsal — replica-role trigger suppression (--disable-triggers inert in full restores) (refs #3317)

### DIFF
--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -625,14 +625,21 @@ action_migrate_rehearse() {
   docker cp "$MIGRATE_BACKUP_PATH" "${POSTGRES_CONTAINER}:${container_dump_path}"
 
   log "rehearsal: restoring into ${REHEARSAL_DB}"
-  # --disable-triggers: the audit-log partitions inherit a row trigger from their
-  # partitioned parent (set_retention_period), which lives in the PRE-data section and
-  # fires during COPY, querying audit_retention_policies before it is restored (run
-  # 29340321213). We restore as the container superuser, so wrapping the data load in
-  # DISABLE/ENABLE TRIGGER ALL is safe and yields a byte-faithful clone (trigger
-  # recomputation during restore is not desired anyway).
-  docker exec "$POSTGRES_CONTAINER" pg_restore -j 2 --disable-triggers -U "$pg_user" -d "$REHEARSAL_DB" "$container_dump_path" \
+  # The audit-log partitions inherit a row trigger from their partitioned parent
+  # (set_retention_period), which lives in the PRE-data section and fires during COPY,
+  # querying audit_retention_policies before it is restored (run 29340321213).
+  # pg_restore --disable-triggers is only honored in DATA-ONLY restores and is silently
+  # inert in a full restore (empirically falsified in run 29347058494). The mechanism
+  # that actually holds for a full parallel restore: DB-level
+  # session_replication_role=replica (normal triggers do not fire in replica mode; the
+  # DB-level GUC binds every -j worker connection). RESET before the rehearsal migrate
+  # so migrations run under normal trigger semantics (faithful rehearsal).
+  docker exec "$POSTGRES_CONTAINER" psql -U "$pg_user" -d postgres -v ON_ERROR_STOP=1 \
+    -c "ALTER DATABASE ${REHEARSAL_DB} SET session_replication_role = 'replica';"
+  docker exec "$POSTGRES_CONTAINER" pg_restore -j 2 -U "$pg_user" -d "$REHEARSAL_DB" "$container_dump_path" \
     2>&1 | tee "${OUTPUT_DIR}/rehearsal-restore.log"
+  docker exec "$POSTGRES_CONTAINER" psql -U "$pg_user" -d postgres -v ON_ERROR_STOP=1 \
+    -c "ALTER DATABASE ${REHEARSAL_DB} RESET session_replication_role;"
 
   local backend_dsn rehearsal_dsn
   backend_dsn="$(resolve_backend_database_url)"

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -182,12 +182,14 @@ test('staging-only contract: the remote script names only staging containers', (
   )
 })
 
-test('rehearsal pg_restore keeps --disable-triggers (load-bearing: partition-inherited row triggers fire during COPY without it — run 29340321213)', () => {
+test('rehearsal restore keeps the replica-role trigger suppression (load-bearing: partition-inherited row triggers fire during COPY without it — runs 29340321213/29347058494; --disable-triggers is inert in full restores)', () => {
   const remote = readFileSync(REMOTE_SH, 'utf8')
-  const restoreLines = remote.split('\n').filter((l) => l.includes('pg_restore') && l.includes('$REHEARSAL_DB'))
-  assert.ok(restoreLines.length >= 1, 'expected the rehearsal pg_restore invocation to exist')
-  for (const line of restoreLines) {
-    assert.ok(line.includes('--disable-triggers'),
-      `rehearsal pg_restore lost --disable-triggers: ${line.trim()}`)
-  }
+  const restoreIdx = remote.indexOf('pg_restore -j 2 -U')
+  assert.notEqual(restoreIdx, -1, 'expected the rehearsal pg_restore invocation to exist')
+  const setIdx = remote.indexOf("SET session_replication_role = 'replica'")
+  const resetIdx = remote.indexOf('RESET session_replication_role')
+  assert.notEqual(setIdx, -1, 'rehearsal lost the DB-level replica-role SET before restore')
+  assert.notEqual(resetIdx, -1, 'rehearsal lost the RESET after restore (rehearsal migrate must run under normal trigger semantics)')
+  assert.ok(setIdx < restoreIdx, 'replica-role SET must come BEFORE the pg_restore invocation')
+  assert.ok(restoreIdx < resetIdx, 'RESET must come AFTER the pg_restore invocation')
 })


### PR DESCRIPTION
Run 29347058494 **empirically falsified** the #4284 fix — the same partition-inherited trigger fired during COPY again: `pg_restore --disable-triggers` is only honored in **data-only** restores and is silently inert in a full restore (the owner's "real acceptance = rerun the rehearsal" principle catching a plausible-but-wrong fix).

Replacement mechanism that actually holds for a full parallel restore: `ALTER DATABASE <rehearsal> SET session_replication_role = 'replica'` before the restore (normal triggers do not fire in replica mode; the DB-level GUC binds every `-j` worker connection), `RESET` after so the rehearsal migrate runs under normal trigger semantics (faithful rehearsal). The source-contract guard now pins SET-before-restore + RESET-after ordering — mutation-proven (dropping either line reds the suite; 10/10 clean). Real staging DB untouched in both failed attempts (backup taken, isolation guard intact, trap cleanup fired). `bash -n` clean. Refs #3317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)