### PR TITLE
fix(attendance): make rehearsal trigger suppression effective

### DIFF
--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -624,15 +624,28 @@ action_migrate_rehearse() {
   docker exec "$POSTGRES_CONTAINER" mkdir -p "$CONTAINER_RUNNER_DIR"
   docker cp "$MIGRATE_BACKUP_PATH" "${POSTGRES_CONTAINER}:${container_dump_path}"
 
-  log "rehearsal: restoring into ${REHEARSAL_DB}"
-  # --disable-triggers: the audit-log partitions inherit a row trigger from their
-  # partitioned parent (set_retention_period), which lives in the PRE-data section and
-  # fires during COPY, querying audit_retention_policies before it is restored (run
-  # 29340321213). We restore as the container superuser, so wrapping the data load in
-  # DISABLE/ENABLE TRIGGER ALL is safe and yields a byte-faithful clone (trigger
-  # recomputation during restore is not desired anyway).
-  docker exec "$POSTGRES_CONTAINER" pg_restore -j 2 --disable-triggers -U "$pg_user" -d "$REHEARSAL_DB" "$container_dump_path" \
-    2>&1 | tee "${OUTPUT_DIR}/rehearsal-restore.log"
+  local restore_log="${OUTPUT_DIR}/rehearsal-restore.log"
+  : > "$restore_log"
+
+  # pg_restore only emits DISABLE/ENABLE TRIGGER statements for an explicit data-only
+  # restore. Passing --disable-triggers to a full restore is a no-op (run 29347058494),
+  # so a partition trigger can still fire during COPY before its pending dependency is
+  # migrated. Restore the archive in section order and suppress triggers only around the
+  # data phase; post-data objects are installed after every table payload is present.
+  log "rehearsal: restoring pre-data into ${REHEARSAL_DB}"
+  docker exec "$POSTGRES_CONTAINER" pg_restore --exit-on-error --section=pre-data \
+    -U "$pg_user" -d "$REHEARSAL_DB" "$container_dump_path" \
+    2>&1 | tee -a "$restore_log"
+
+  log "rehearsal: restoring data with triggers disabled into ${REHEARSAL_DB}"
+  docker exec "$POSTGRES_CONTAINER" pg_restore --exit-on-error -j 2 --data-only \
+    --disable-triggers --superuser="$pg_user" -U "$pg_user" -d "$REHEARSAL_DB" "$container_dump_path" \
+    2>&1 | tee -a "$restore_log"
+
+  log "rehearsal: restoring post-data into ${REHEARSAL_DB}"
+  docker exec "$POSTGRES_CONTAINER" pg_restore --exit-on-error -j 2 --section=post-data \
+    -U "$pg_user" -d "$REHEARSAL_DB" "$container_dump_path" \
+    2>&1 | tee -a "$restore_log"
 
   local backend_dsn rehearsal_dsn
   backend_dsn="$(resolve_backend_database_url)"

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -182,12 +182,41 @@ test('staging-only contract: the remote script names only staging containers', (
   )
 })
 
-test('rehearsal pg_restore keeps --disable-triggers (load-bearing: partition-inherited row triggers fire during COPY without it — run 29340321213)', () => {
+test('rehearsal pg_restore uses ordered phases so data-only trigger suppression is effective', () => {
   const remote = readFileSync(REMOTE_SH, 'utf8')
-  const restoreLines = remote.split('\n').filter((l) => l.includes('pg_restore') && l.includes('$REHEARSAL_DB'))
-  assert.ok(restoreLines.length >= 1, 'expected the rehearsal pg_restore invocation to exist')
-  for (const line of restoreLines) {
-    assert.ok(line.includes('--disable-triggers'),
-      `rehearsal pg_restore lost --disable-triggers: ${line.trim()}`)
-  }
+  const logical = remote.replace(/\\\n\s*/g, ' ').replace(/\s+/g, ' ')
+  const preData = logical.indexOf(
+    'pg_restore --exit-on-error --section=pre-data',
+  )
+  const data = logical.indexOf(
+    'pg_restore --exit-on-error -j 2 --data-only --disable-triggers',
+  )
+  const postData = logical.indexOf(
+    'pg_restore --exit-on-error -j 2 --section=post-data',
+  )
+  const restoreCommands =
+    logical.match(/docker exec "\$POSTGRES_CONTAINER" pg_restore [^|]+/g) || []
+
+  assert.ok(preData >= 0, 'expected an explicit pre-data rehearsal restore')
+  assert.ok(data > preData, 'expected the data-only restore after pre-data')
+  assert.ok(
+    postData > data,
+    'expected the post-data restore after the trigger-suppressed data phase',
+  )
+  assert.equal(
+    restoreCommands.length,
+    3,
+    'expected exactly pre-data, data-only, and post-data restore commands',
+  )
+  assert.match(
+    logical.slice(data, postData),
+    /--disable-triggers --superuser="\$pg_user"/,
+    'data-only restore must disable triggers through the restore superuser',
+  )
+  assert.equal(
+    restoreCommands.filter((command) => command.includes('--disable-triggers'))
+      .length,
+    1,
+    '--disable-triggers must appear only on the explicit data-only restore',
+  )
 })


### PR DESCRIPTION
## Summary

Make the staging migration rehearsal's trigger suppression effective.

- split the custom-archive restore into ordered pre-data, data-only, and post-data phases;
- use `-j 2 --data-only --disable-triggers --superuser=<restore user>` only for the data phase, which is the mode where `pg_restore` actually emits trigger controls;
- fail each phase immediately with `--exit-on-error` while preserving one append-only rehearsal restore log;
- replace the old flag-presence assertion with an executable contract for phase order, trigger-suppression scope, restore-user wiring, and command count.

The real staging database remains untouched until the rehearsal and its existing isolation checks pass.

## Why

Staging Window Runner run https://github.com/zensgit/metasheet2/actions/runs/29347058494 reached the deploy host, completed a fresh backup, created the synthetic rehearsal database, and then failed while copying an audit-log partition because `set_retention_period` queried the still-missing `audit_retention_policies` relation.

The previous fix passed `--disable-triggers` to a full restore. PostgreSQL documents and implements that option for data-only restores: a local custom-archive inspection produced zero `DISABLE/ENABLE TRIGGER` statements for the full restore, but emitted both controls for the explicit data-only restore.

## Verification

- exact head: `9e36c31404b7d5c7f99a6029776c6c36e300a934`;
- exact-head GitHub CI: 11/11 SUCCESS, 0 failure, 0 skipped, 0 pending;
- live GitHub state: `MERGEABLE / CLEAN` against `main` `b6b7dc85a30d95b309535646f53be3a125509fe3`;
- unresolved review threads: 0;
- `node --test scripts/ops/attendance-window-runner-pipeline.test.mjs`: 10/10 PASS;
- full required strict contract case: PASS;
- `bash -n scripts/ops/attendance-staging-window-runner-remote.sh`: PASS;
- `git diff --check`: PASS;
- local PostgreSQL 15.17 option-compatibility control: the exact `-j 2 --data-only --disable-triggers --superuser=...` restore returned 0, restored the expected row, and re-enabled the target trigger afterward (`tgenabled=O`);
- local PostgreSQL control with the same missing-dependency trigger shape:
  - data-only restore without suppression: expected failure at trigger execution;
  - data-only restore with the new suppression arguments: PASS;
  - post-data restore: PASS;
  - final restored data row and trigger: present;
- generated SQL control count: full restore 0; explicit data-only restore 2.

No staging workflow dispatch, deploy, real-database migration, smoke, restart, GC, or application-data cleanup was performed.

Refs #3317
