### PR TITLE
fix(attendance): AE-4 harness — commitToken via import/prepare (refs #3317)

### DIFF
--- a/scripts/ops/staging-attendance-ae4-result-edit-smoke.mjs
+++ b/scripts/ops/staging-attendance-ae4-result-edit-smoke.mjs
@@ -334,6 +334,17 @@ async function postEdit(body, token = adminToken) {
 }
 
 async function postImport(userId, workDate, fields, key) {
+  // Staging enforces ATTENDANCE_IMPORT_REQUIRE_TOKEN=1: every import commit (incl. the
+  // legacy /api/attendance/import route) requires a single-use commitToken issued by
+  // POST /api/attendance/import/prepare (run 29380129251: COMMIT_TOKEN_REQUIRED without it).
+  const prepare = await api(adminToken, '/api/attendance/import/prepare', {
+    method: 'POST',
+    body: { orgId: ORG_ID },
+  })
+  const commitToken = prepare.body?.data?.commitToken
+  if (prepare.status !== 200 || !commitToken) {
+    return prepare
+  }
   const res = await api(adminToken, '/api/attendance/import', {
     method: 'POST',
     body: {
@@ -341,6 +352,7 @@ async function postImport(userId, workDate, fields, key) {
       userId,
       source: 'manual',
       idempotencyKey: key,
+      commitToken,
       batchMeta: { smokeStamp: STAMP, ae4: true },
       rows: [{ workDate, fields }],
       mode: 'override',


### PR DESCRIPTION
First live AE-4 window run (29380129251) failed 3 of ~33 assertions, all one root cause: staging enforces `ATTENDANCE_IMPORT_REQUIRE_TOKEN=1`, so every import commit (incl. the legacy `/api/attendance/import` the harness uses for recompute) requires a single-use `commitToken` from `POST /api/attendance/import/prepare` — the harness (2026-07-01) predates that hardening. `postImport` now issues a token per commit and fails through the prepare response on issuance failure. Everything else already passed live: settings snapshot/restore verified, closed-cycle guard, notify legs, non-admin 403, **residue=0**. `node --check` clean, companion test 5/5. Refs #3317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)