### PR TITLE
feat(stock-prep): view-2 diff row detail — values-free /diff/rows drill-down (FE consumer)

### DIFF
--- a/.github/workflows/integration-guard.yml
+++ b/.github/workflows/integration-guard.yml
@@ -103,6 +103,7 @@ on:
       - 'apps/web/tests/StockPreparationWorkspace.spec.ts'
       - 'apps/web/tests/StockPreparationProjectWorkspaceView.spec.ts'
       - 'apps/web/tests/StockPreparationSnapshotDiffView.spec.ts'
+      - 'apps/web/tests/bomSnapshotDiff.spec.ts'
       - 'apps/web/tests/StockPreparationMappingConfirmView.spec.ts'
       - 'apps/web/tests/StockPreparationUnitConfirmView.spec.ts'
       - 'apps/web/tests/StockPreparationPrepLineView.spec.ts'
@@ -194,6 +195,7 @@ on:
       - 'apps/web/tests/StockPreparationWorkspace.spec.ts'
       - 'apps/web/tests/StockPreparationProjectWorkspaceView.spec.ts'
       - 'apps/web/tests/StockPreparationSnapshotDiffView.spec.ts'
+      - 'apps/web/tests/bomSnapshotDiff.spec.ts'
       - 'apps/web/tests/StockPreparationMappingConfirmView.spec.ts'
       - 'apps/web/tests/StockPreparationUnitConfirmView.spec.ts'
       - 'apps/web/tests/StockPreparationPrepLineView.spec.ts'
@@ -253,4 +255,4 @@ jobs:
       # Consolidated here into the SINGLE unioned list (verified green on both Node 20 and this repo's
       # default Node before landing) — do not reintroduce a second `run:` key; add new specs to this one.
       - name: Run integration web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationBridgeAgentSection IntegrationK3WiseSetupView IntegrationHelpView IntegrationPipelineRunSection IntegrationStockPrepPanel IntegrationExternalWritePanel IntegrationTableActionsPanel IntegrationFieldOptionSyncPanel readSourceModePresets IntegrationReadSourceWizard JsonAssist IntegrationCompositionWizard bridgeAgentConfigCheck IntegrationOptionSetsStructuredEditor optionSetsStructured integrationWorkbench MetaIntegrationFieldRuleAuthoring readSourceTemplateCatalog IntegrationTemplateCatalogPicker StockPreparationWorkspace StockPreparationProjectWorkspaceView StockPreparationSnapshotDiffView StockPreparationMappingConfirmView StockPreparationUnitConfirmView StockPreparationPrepLineView StockPreparationExceptionQueueView StockPreparationDashboardView StockPreparationStageOverview StockPreparationStageStepper --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run composition-vocab-mirror multitable-resolver-vocab-mirror integrationErrorCodeLabels fieldHints IntegrationReadSourceConfigPanel IntegrationReadSourceCompositionPanel IntegrationReadSourceCompositionAuthoringPanel readSourceCompositions.service IntegrationWorkbenchView IntegrationWorkbenchRail IntegrationMonitoringSection IntegrationCleaningDatasetSection IntegrationMappingRulesSection IntegrationObjectTemplateSection IntegrationPayloadPreviewSection IntegrationConnectionSection IntegrationBridgeAgentSection IntegrationK3WiseSetupView IntegrationHelpView IntegrationPipelineRunSection IntegrationStockPrepPanel IntegrationExternalWritePanel IntegrationTableActionsPanel IntegrationFieldOptionSyncPanel readSourceModePresets IntegrationReadSourceWizard JsonAssist IntegrationCompositionWizard bridgeAgentConfigCheck IntegrationOptionSetsStructuredEditor optionSetsStructured integrationWorkbench MetaIntegrationFieldRuleAuthoring readSourceTemplateCatalog IntegrationTemplateCatalogPicker StockPreparationWorkspace StockPreparationProjectWorkspaceView bomSnapshotDiff StockPreparationSnapshotDiffView StockPreparationMappingConfirmView StockPreparationUnitConfirmView StockPreparationPrepLineView StockPreparationExceptionQueueView StockPreparationDashboardView StockPreparationStageOverview StockPreparationStageStepper --reporter=dot

--- a/apps/web/src/components/integration/stockPreparation/StockPreparationSnapshotDiffView.vue
+++ b/apps/web/src/components/integration/stockPreparation/StockPreparationSnapshotDiffView.vue
@@ -174,6 +174,82 @@
               <dd class="sp-snap__count-value">{{ entry.value }}</dd>
             </div>
           </dl>
+
+          <!-- View-2 per-row drill-down: lazy, values-free (handles + enums + counts + opaque SHA-16
+               fingerprints only — never a raw path key / drawing number / quantity / unit). -->
+          <div class="sp-snap__rows-wrap">
+            <button
+              type="button"
+              class="sp-snap__rows-toggle"
+              data-testid="stock-prep-snapshot-diff-rows-toggle"
+              :aria-expanded="rowDetailOpen"
+              @click="toggleRowDetail"
+            >
+              {{ rowDetailOpen ? bi('收起逐行明细', 'Hide row detail') : bi('查看逐行明细', 'View row detail') }}
+            </button>
+
+            <template v-if="rowDetailOpen">
+              <p
+                v-if="rowsLoading"
+                class="sp-snap__state sp-snap__state--muted"
+                data-testid="stock-prep-snapshot-diff-rows-loading"
+                role="status"
+              >
+                {{ bi('正在加载逐行明细…', 'Loading row detail…') }}
+              </p>
+              <p
+                v-else-if="rowsErrored"
+                class="sp-snap__state sp-snap__state--muted"
+                data-testid="stock-prep-snapshot-diff-rows-error"
+                role="status"
+              >
+                {{ bi('逐行明细暂不可用,稍后再试。', 'Row detail is not available yet — try again later.') }}
+              </p>
+              <p
+                v-else-if="diffRows && diffRows.rowCount === 0"
+                class="sp-snap__state sp-snap__state--muted"
+                data-testid="stock-prep-snapshot-diff-rows-empty"
+              >
+                {{ bi('该批次无差异行。', 'No diff rows for this batch.') }}
+              </p>
+              <div v-else-if="diffRows" data-testid="stock-prep-snapshot-diff-rows">
+                <p class="sp-snap__rows-meta" data-testid="stock-prep-snapshot-diff-rows-meta">
+                  {{ bi('差异行', 'Diff rows') }}: {{ diffRows.rowCount }} ·
+                  {{ bi('待处理', 'Held') }}: {{ diffRows.heldRowCount }}
+                </p>
+                <div class="sp-snap__rows-scroll">
+                  <table class="sp-snap__rows-table" data-testid="stock-prep-snapshot-diff-rows-table">
+                    <thead>
+                      <tr>
+                        <th>{{ bi('差异句柄', 'Diff') }}</th>
+                        <th>{{ bi('类型', 'Type') }}</th>
+                        <th>{{ bi('复核状态', 'Review') }}</th>
+                        <th>{{ bi('变更类别', 'Changes') }}</th>
+                        <th>{{ bi('行数', 'Rows') }}</th>
+                        <th>{{ bi('键指纹', 'Key fp') }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr
+                        v-for="row in diffRows.rows"
+                        :key="row.diffId"
+                        data-testid="stock-prep-snapshot-diff-row"
+                        :data-diff-type="row.diffType"
+                        :data-review-status="row.reviewStatus"
+                      >
+                        <td><code class="sp-snap__handle">{{ row.diffId }}</code></td>
+                        <td>{{ row.diffType }}</td>
+                        <td>{{ row.reviewStatus }}</td>
+                        <td>{{ row.changeTypes.length ? row.changeTypes.join(', ') : '—' }}</td>
+                        <td>{{ row.rowCount }}</td>
+                        <td><code class="sp-snap__handle">{{ shortFingerprint(row.keyFingerprint) }}</code></td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </template>
+          </div>
         </div>
       </div>
     </div>
@@ -200,9 +276,11 @@ import type { IntegrationScope } from '../../../services/integration/workbench'
 import {
   getStockPreparationSnapshotDiff,
   listStockPreparationSnapshotBatches,
+  listStockPreparationSnapshotDiffRows,
   type StockPreparationSnapshotBatchListResult,
   type StockPreparationSnapshotBatchSummary,
   type StockPreparationSnapshotDiffSummary,
+  type StockPreparationSnapshotDiffRowsResult,
 } from '../../../services/integration/stockPreparation/bomSnapshotDiff'
 
 const props = withDefaults(
@@ -236,6 +314,19 @@ const diffLoading = ref(false)
 const diffErrored = ref(false)
 const diff = ref<StockPreparationSnapshotDiffSummary | null>(null)
 
+// Per-row detail sub-state (the view-2 drill-down under the summary). Lazy: the rows GET is issued only
+// when the operator opens the detail, and re-fetched fresh per batch — never eagerly with the summary.
+const rowDetailOpen = ref(false)
+const rowsLoading = ref(false)
+const rowsErrored = ref(false)
+const diffRows = ref<StockPreparationSnapshotDiffRowsResult | null>(null)
+
+// A diff/path-key fingerprint is already an opaque SHA-16 (never the raw path key); show a short prefix
+// so the table stays scannable while remaining a values-free handle.
+function shortFingerprint(fp: string | null): string {
+  return fp ? fp.slice(0, 10) : '—'
+}
+
 // Fixed whitelist of the eight values-free change-count kinds (counts of lines, never the values).
 const changeCountEntries = computed(() => {
   const counts = diff.value?.changeCounts
@@ -252,11 +343,19 @@ const changeCountEntries = computed(() => {
   ]
 })
 
+function resetRowDetail(): void {
+  rowDetailOpen.value = false
+  rowsLoading.value = false
+  rowsErrored.value = false
+  diffRows.value = null
+}
+
 function resetDiff(): void {
   selectedBatchId.value = null
   diffLoading.value = false
   diffErrored.value = false
   diff.value = null
+  resetRowDetail()
 }
 
 async function loadBatches(): Promise<void> {
@@ -293,6 +392,7 @@ async function selectBatch(batch: StockPreparationSnapshotBatchSummary): Promise
   diffLoading.value = true
   diffErrored.value = false
   diff.value = null
+  resetRowDetail() // a new batch starts collapsed; its rows are re-fetched fresh when opened
   try {
     diff.value = await getStockPreparationSnapshotDiff(batch.snapshotBatchId, props.scope)
   } catch {
@@ -302,6 +402,31 @@ async function selectBatch(batch: StockPreparationSnapshotBatchSummary): Promise
   } finally {
     diffLoading.value = false
   }
+}
+
+async function loadRowDetail(): Promise<void> {
+  if (!selectedBatchId.value) return
+  rowsLoading.value = true
+  rowsErrored.value = false
+  diffRows.value = null
+  try {
+    diffRows.value = await listStockPreparationSnapshotDiffRows(selectedBatchId.value, {
+      ...props.scope,
+      projectId: props.projectId,
+    })
+  } catch {
+    // 404-soft, same as the batch/diff GETs: neutral state, never the raw error body.
+    rowsErrored.value = true
+    diffRows.value = null
+  } finally {
+    rowsLoading.value = false
+  }
+}
+
+function toggleRowDetail(): void {
+  rowDetailOpen.value = !rowDetailOpen.value
+  // Lazy first-open fetch; a re-open reuses what we already have (batch switch clears it via resetRowDetail).
+  if (rowDetailOpen.value && !diffRows.value && !rowsLoading.value) void loadRowDetail()
 }
 
 onMounted(loadBatches)
@@ -491,5 +616,68 @@ watch(() => props.projectId, loadBatches)
   color: var(--ms-text-1);
   font-variant-numeric: tabular-nums;
   font-weight: var(--ms-font-weight-title);
+}
+
+.sp-snap__rows-wrap {
+  margin-top: var(--ms-space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-2);
+}
+
+.sp-snap__rows-toggle {
+  align-self: flex-start;
+  border: 1px solid var(--ms-border-light);
+  border-radius: 6px;
+  background: transparent;
+  padding: 4px 12px;
+  color: var(--ms-color-primary);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.sp-snap__rows-toggle:hover {
+  background: var(--el-fill-color-light);
+}
+
+.sp-snap__rows-toggle:focus-visible {
+  outline: 2px solid var(--ms-color-primary);
+  outline-offset: 1px;
+}
+
+.sp-snap__rows-meta {
+  margin: 0;
+  color: var(--ms-text-2);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+
+.sp-snap__rows-scroll {
+  overflow-x: auto;
+}
+
+.sp-snap__rows-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.sp-snap__rows-table th,
+.sp-snap__rows-table td {
+  text-align: left;
+  padding: var(--ms-space-2) var(--ms-space-3);
+  border-bottom: 1px solid var(--ms-border-light);
+  white-space: nowrap;
+}
+
+.sp-snap__rows-table th {
+  color: var(--ms-text-2);
+  font-weight: var(--ms-font-weight-title);
+}
+
+.sp-snap__rows-table td {
+  color: var(--ms-text-1);
+  font-variant-numeric: tabular-nums;
 }
 </style>

--- a/apps/web/src/components/integration/stockPreparation/StockPreparationSnapshotDiffView.vue
+++ b/apps/web/src/components/integration/stockPreparation/StockPreparationSnapshotDiffView.vue
@@ -320,6 +320,10 @@ const rowDetailOpen = ref(false)
 const rowsLoading = ref(false)
 const rowsErrored = ref(false)
 const diffRows = ref<StockPreparationSnapshotDiffRowsResult | null>(null)
+// Monotonic guard: only the NEWEST rows load may commit. A batch switch (or re-open) bumps this, so a
+// slow response for the previous batch — arriving after the operator moved on — is discarded instead of
+// being cached under the wrong batch (A's late reply must never show up when B is open).
+let rowsSeq = 0
 
 // A diff/path-key fingerprint is already an opaque SHA-16 (never the raw path key); show a short prefix
 // so the table stays scannable while remaining a values-free handle.
@@ -344,6 +348,7 @@ const changeCountEntries = computed(() => {
 })
 
 function resetRowDetail(): void {
+  rowsSeq += 1 // invalidate any in-flight rows load for the batch we are leaving
   rowDetailOpen.value = false
   rowsLoading.value = false
   rowsErrored.value = false
@@ -405,21 +410,26 @@ async function selectBatch(batch: StockPreparationSnapshotBatchSummary): Promise
 }
 
 async function loadRowDetail(): Promise<void> {
-  if (!selectedBatchId.value) return
+  const batchId = selectedBatchId.value
+  if (!batchId) return
+  const seq = (rowsSeq += 1) // this load owns the newest ticket
   rowsLoading.value = true
   rowsErrored.value = false
   diffRows.value = null
   try {
-    diffRows.value = await listStockPreparationSnapshotDiffRows(selectedBatchId.value, {
+    const result = await listStockPreparationSnapshotDiffRows(batchId, {
       ...props.scope,
       projectId: props.projectId,
     })
+    if (seq !== rowsSeq) return // superseded (batch switched / re-opened) — drop this stale response
+    diffRows.value = result
   } catch {
+    if (seq !== rowsSeq) return
     // 404-soft, same as the batch/diff GETs: neutral state, never the raw error body.
     rowsErrored.value = true
     diffRows.value = null
   } finally {
-    rowsLoading.value = false
+    if (seq === rowsSeq) rowsLoading.value = false
   }
 }
 

--- a/apps/web/src/components/integration/stockPreparation/StockPreparationSnapshotDiffView.vue
+++ b/apps/web/src/components/integration/stockPreparation/StockPreparationSnapshotDiffView.vue
@@ -305,6 +305,9 @@ const hasProject = computed(() => Boolean(props.projectId))
 const loading = ref(Boolean(props.projectId))
 const errored = ref(false)
 const result = ref<StockPreparationSnapshotBatchListResult | null>(null)
+// Monotonic guard for the batch-LIST load: a project switch bumps it, so a slow list response for the
+// previous project (arriving after the operator moved on) is dropped, not committed over the new project.
+let batchListSeq = 0
 
 const isEmpty = computed(() => result.value !== null && result.value.batchCount === 0)
 
@@ -313,6 +316,9 @@ const selectedBatchId = ref<string | null>(null)
 const diffLoading = ref(false)
 const diffErrored = ref(false)
 const diff = ref<StockPreparationSnapshotDiffSummary | null>(null)
+// Monotonic guard for the diff-SUMMARY load: a batch switch (or project switch, via resetDiff) bumps it,
+// so batch A's late summary cannot overwrite batch B's.
+let diffSeq = 0
 
 // Per-row detail sub-state (the view-2 drill-down under the summary). Lazy: the rows GET is issued only
 // when the operator opens the detail, and re-fetched fresh per batch — never eagerly with the summary.
@@ -356,6 +362,7 @@ function resetRowDetail(): void {
 }
 
 function resetDiff(): void {
+  diffSeq += 1 // invalidate any in-flight diff-summary load for the batch/project we are leaving
   selectedBatchId.value = null
   diffLoading.value = false
   diffErrored.value = false
@@ -365,7 +372,9 @@ function resetDiff(): void {
 
 async function loadBatches(): Promise<void> {
   resetDiff()
-  if (!props.projectId) {
+  const seq = (batchListSeq += 1)
+  const projectId = props.projectId
+  if (!projectId) {
     // No project handle → neutral select-a-project state; issue no GET.
     loading.value = false
     errored.value = false
@@ -375,16 +384,16 @@ async function loadBatches(): Promise<void> {
   loading.value = true
   errored.value = false
   try {
-    result.value = await listStockPreparationSnapshotBatches({
-      ...props.scope,
-      projectId: props.projectId,
-    })
+    const listed = await listStockPreparationSnapshotBatches({ ...props.scope, projectId })
+    if (seq !== batchListSeq || projectId !== props.projectId) return // superseded by a newer project load
+    result.value = listed
   } catch {
+    if (seq !== batchListSeq || projectId !== props.projectId) return
     // 404-soft: the backend read route may not exist yet. Surface a neutral state, NEVER the raw body.
     errored.value = true
     result.value = null
   } finally {
-    loading.value = false
+    if (seq === batchListSeq) loading.value = false
   }
 }
 
@@ -393,19 +402,24 @@ async function selectBatch(batch: StockPreparationSnapshotBatchSummary): Promise
   // tested guard, and today it is the ONLY caller, so this line has no reachable second path. It
   // exists solely so any future caller also cannot issue a diff GET for an incomplete batch.
   if (batch.incomplete) return
-  selectedBatchId.value = batch.snapshotBatchId
+  const batchId = batch.snapshotBatchId
+  const seq = (diffSeq += 1)
+  selectedBatchId.value = batchId
   diffLoading.value = true
   diffErrored.value = false
   diff.value = null
   resetRowDetail() // a new batch starts collapsed; its rows are re-fetched fresh when opened
   try {
-    diff.value = await getStockPreparationSnapshotDiff(batch.snapshotBatchId, props.scope)
+    const summary = await getStockPreparationSnapshotDiff(batchId, props.scope)
+    if (seq !== diffSeq || batchId !== selectedBatchId.value) return // superseded — batch A's late summary must not overwrite B
+    diff.value = summary
   } catch {
+    if (seq !== diffSeq || batchId !== selectedBatchId.value) return
     // 404-soft for the diff GET as well.
     diffErrored.value = true
     diff.value = null
   } finally {
-    diffLoading.value = false
+    if (seq === diffSeq) diffLoading.value = false
   }
 }
 

--- a/apps/web/src/components/integration/stockPreparation/StockPreparationSnapshotDiffView.vue
+++ b/apps/web/src/components/integration/stockPreparation/StockPreparationSnapshotDiffView.vue
@@ -242,7 +242,7 @@
                         <td>{{ row.reviewStatus }}</td>
                         <td>{{ row.changeTypes.length ? row.changeTypes.join(', ') : '—' }}</td>
                         <td>{{ row.rowCount }}</td>
-                        <td><code class="sp-snap__handle">{{ shortFingerprint(row.keyFingerprint) }}</code></td>
+                        <td><code class="sp-snap__handle">{{ fingerprintLabel(row.keyFingerprint) }}</code></td>
                       </tr>
                     </tbody>
                   </table>
@@ -331,10 +331,10 @@ const diffRows = ref<StockPreparationSnapshotDiffRowsResult | null>(null)
 // being cached under the wrong batch (A's late reply must never show up when B is open).
 let rowsSeq = 0
 
-// A diff/path-key fingerprint is already an opaque SHA-16 (never the raw path key); show a short prefix
-// so the table stays scannable while remaining a values-free handle.
-function shortFingerprint(fp: string | null): string {
-  return fp ? fp.slice(0, 10) : '—'
+// The fingerprint is the full opaque `sha16:<16 hex>` handle (never the raw path key) — 22 chars, short
+// enough to show whole. (The old slice(0,10) cut the `sha16:` prefix down to 4 hex, which was misleading.)
+function fingerprintLabel(fp: string | null): string {
+  return fp ?? '—'
 }
 
 // Fixed whitelist of the eight values-free change-count kinds (counts of lines, never the values).

--- a/apps/web/src/services/integration/stockPreparation/bomSnapshotDiff.ts
+++ b/apps/web/src/services/integration/stockPreparation/bomSnapshotDiff.ts
@@ -92,11 +92,13 @@ export async function getStockPreparationSnapshotDiff(
 // The row detail is NOT values-free just because the backend projects a whitelist — the CLIENT must
 // re-validate at the boundary, because open string types would let a business value planted in a
 // whitelisted field (diffId, keyFingerprint, …) render straight into the DOM. So we parse from
-// `unknown`, validate every field against the backend's frozen shape, and DROP any row that fails.
+// `unknown`, validate every field against the backend's frozen shape, and FAIL-CLOSE the whole envelope
+// (throw → the view's unavailable state) if ANY row is invalid — never a silent per-row drop.
 //
 // These three vocabularies MUST equal the backend's frozen enums (stock-preparation-snapshot-diff.cjs
 // DIFF_TYPES / REVIEW_STATUSES / CHANGE_TYPES) — a bomSnapshotDiff.vocab tripwire pins that so a backend
-// vocab change (which would otherwise make the client silently drop every row of the new kind) fails CI.
+// vocab change (which would otherwise make EVERY row of the new kind invalid → the whole response throws
+// unavailable for real diffs) fails CI instead.
 export const STOCK_PREP_DIFF_TYPES = ['added', 'removed', 'changed', 'unchanged', 'held'] as const
 export const STOCK_PREP_REVIEW_STATUSES = ['ready', 'held'] as const
 export const STOCK_PREP_CHANGE_TYPES = [
@@ -137,9 +139,10 @@ export interface StockPreparationSnapshotDiffRowsFilters {
 }
 
 // Exact backend shapes: diffId = `stockprep_diff_<16 hex>` (stableDiffId), fingerprint = `sha16:<16 hex>`
-// (stableFingerprint). A planted business value matches neither, so it is dropped — and because every
-// retained field is one of these tight shapes / an enum / a non-negative int, there is no loose pattern
-// left for a value to survive under (owner: REASON_RE / HANDLE_RE removed — those fields are gone).
+// (stableFingerprint). A planted business value matches neither, so its row fails validation → the whole
+// response throws — and because every retained field is one of these tight shapes / an enum / a
+// non-negative int, there is no loose pattern left for a value to survive under (owner: REASON_RE /
+// HANDLE_RE removed — those fields are gone).
 const DIFF_ID_RE = /^stockprep_diff_[0-9a-f]{16}$/
 const FINGERPRINT_RE = /^sha16:[0-9a-f]{16}$/
 const INVALID = Symbol('invalid')
@@ -149,7 +152,7 @@ export const SNAPSHOT_DIFF_ROWS_MALFORMED = 'SNAPSHOT_DIFF_ROWS_MALFORMED'
 
 const asMatch = (v: unknown, re: RegExp): string | null => (typeof v === 'string' && re.test(v) ? v : null)
 const asNonNegInt = (v: unknown): number | null => (typeof v === 'number' && Number.isInteger(v) && v >= 0 ? v : null)
-// null/undefined → null (valid absence); present-but-non-matching → INVALID (drop the row).
+// null/undefined → null (valid absence); present-but-non-matching → INVALID (row invalid → envelope throws).
 function asNullableMatch(v: unknown, re: RegExp): string | null | typeof INVALID {
   if (v === null || v === undefined) return null
   const s = asMatch(v, re)
@@ -213,8 +216,8 @@ export function parseStockPreparationSnapshotDiffRowsResult(raw: unknown): Stock
  * GET /api/integration/stock-preparation/snapshot-batches/:snapshotBatchId/diff/rows
  * `projectId` rides the scope (required server-side); the two enum filters are optional and are
  * validated server-side against the frozen vocabularies. The response is re-validated HERE from
- * `unknown` (parseStockPreparationSnapshotDiffRowsResult) so a malformed / value-bearing row is dropped
- * at the client boundary rather than rendered.
+ * `unknown` (parseStockPreparationSnapshotDiffRowsResult); a malformed envelope OR any value-bearing /
+ * invalid row makes the whole call throw (→ the view's unavailable state), never a silently-dropped row.
  */
 export async function listStockPreparationSnapshotDiffRows(
   snapshotBatchId: string,

--- a/apps/web/src/services/integration/stockPreparation/bomSnapshotDiff.ts
+++ b/apps/web/src/services/integration/stockPreparation/bomSnapshotDiff.ts
@@ -184,19 +184,23 @@ function parseDiffRow(raw: unknown): StockPreparationSnapshotDiffRow | null {
 }
 
 /**
- * Parse the /diff/rows body from `unknown`. A MALFORMED envelope (not an object, or `rows` not an array)
- * THROWS a fixed coarse token — the caller must surface the view's unavailable state, never a silent
- * "no diff rows" (a valid EMPTY `rows: []` is a real no-diffs result and is allowed). Invalid rows are
- * dropped; rowCount/heldRowCount are recomputed from the RETAINED rows so the count always matches the
- * rendered table (never a non-zero count over an empty table).
+ * Parse the /diff/rows body from `unknown`. Fail-closed at the ENVELOPE level: a malformed envelope (not
+ * an object / `rows` not an array) OR **any single invalid row** THROWS a fixed coarse token — the caller
+ * surfaces the view's unavailable state. We do NOT silently drop invalid rows: dropping would turn an
+ * all-invalid response into a false "no diff rows" and a mixed response into a silently-incomplete table
+ * (owner). Only a genuinely valid EMPTY `rows: []` is a real no-diffs result (empty state). When every row
+ * is valid, all are returned and rowCount/heldRowCount are computed from them.
  */
 export function parseStockPreparationSnapshotDiffRowsResult(raw: unknown): StockPreparationSnapshotDiffRowsResult {
   if (!raw || typeof raw !== 'object' || !Array.isArray((raw as Record<string, unknown>).rows)) {
     throw new Error(SNAPSHOT_DIFF_ROWS_MALFORMED)
   }
-  const rows = ((raw as Record<string, unknown>).rows as unknown[])
-    .map(parseDiffRow)
-    .filter((x): x is StockPreparationSnapshotDiffRow => x !== null)
+  const rows: StockPreparationSnapshotDiffRow[] = []
+  for (const rawRow of (raw as Record<string, unknown>).rows as unknown[]) {
+    const parsed = parseDiffRow(rawRow)
+    if (parsed === null) throw new Error(SNAPSHOT_DIFF_ROWS_MALFORMED) // any invalid row → whole envelope unavailable
+    rows.push(parsed)
+  }
   return {
     rowCount: rows.length,
     heldRowCount: rows.filter((r) => r.reviewStatus === 'held').length,

--- a/apps/web/src/services/integration/stockPreparation/bomSnapshotDiff.ts
+++ b/apps/web/src/services/integration/stockPreparation/bomSnapshotDiff.ts
@@ -87,3 +87,69 @@ export async function getStockPreparationSnapshotDiff(
   )
   return parseIntegrationResponse<StockPreparationSnapshotDiffSummary>(response)
 }
+
+/**
+ * One values-free diff ROW (the per-row drill-down under the summary). The backend projects a FROZEN
+ * whitelist (stock-preparation-snapshot-reads.cjs `DIFF_ROW_KEYS`): opaque MetaSheet handles
+ * (diffId / snapshot-line ids), enum vocabularies (diffType / reviewStatus / changeTypes), a coarse
+ * `reason` code, a `rowCount`, and SHA-16 FINGERPRINTS. The fingerprints are one-way hashes of the
+ * key / path-key — NOT the raw path keys, drawing numbers, quantities, or units — so they stay within
+ * the values-free contract (opaque handles), unlike the raw values that never cross this boundary.
+ */
+export type StockPreparationDiffReviewStatus = 'pending' | 'held' | 'accepted' | string
+export type StockPreparationDiffType = 'added' | 'removed' | 'changed' | string
+
+export interface StockPreparationSnapshotDiffRow {
+  diffId: string
+  diffType: StockPreparationDiffType
+  reviewStatus: StockPreparationDiffReviewStatus
+  changeTypes: string[]
+  reason: string | null
+  rowCount: number
+  previousSnapshotLineId: string | null
+  currentSnapshotLineId: string | null
+  keyFingerprint: string | null
+  previousPathKeyFingerprint: string | null
+  currentPathKeyFingerprint: string | null
+}
+
+export interface StockPreparationSnapshotDiffRowsResult {
+  snapshotBatchId: string
+  baseSnapshotBatchId: string | null
+  rowCount: number
+  heldRowCount: number
+  rows: StockPreparationSnapshotDiffRow[]
+}
+
+/** Optional filters mirroring the two server-validated enum query params. */
+export interface StockPreparationSnapshotDiffRowsFilters {
+  baseSnapshotBatchId?: string | null
+  reviewStatus?: StockPreparationDiffReviewStatus | null
+  diffType?: StockPreparationDiffType | null
+}
+
+/**
+ * Values-free per-row detail for one snapshot batch's diff (view-2 drill-down under the summary).
+ * GET /api/integration/stock-preparation/snapshot-batches/:snapshotBatchId/diff/rows
+ * `projectId` rides the scope (required server-side); the two enum filters are optional and are
+ * validated server-side against the frozen vocabularies (a bad value → values-free 400 with the field
+ * name only), so the client passes them straight through.
+ */
+export async function listStockPreparationSnapshotDiffRows(
+  snapshotBatchId: string,
+  scope: IntegrationScope & { projectId?: string | null } = {},
+  filters: StockPreparationSnapshotDiffRowsFilters = {},
+): Promise<StockPreparationSnapshotDiffRowsResult> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+    projectId: scope.projectId,
+    baseSnapshotBatchId: filters.baseSnapshotBatchId,
+    reviewStatus: filters.reviewStatus,
+    diffType: filters.diffType,
+  })
+  const response = await apiFetch(
+    `/api/integration/stock-preparation/snapshot-batches/${encodeURIComponent(snapshotBatchId)}/diff/rows${query ? `?${query}` : ''}`,
+  )
+  return parseIntegrationResponse<StockPreparationSnapshotDiffRowsResult>(response)
+}

--- a/apps/web/src/services/integration/stockPreparation/bomSnapshotDiff.ts
+++ b/apps/web/src/services/integration/stockPreparation/bomSnapshotDiff.ts
@@ -109,23 +109,21 @@ export type StockPreparationDiffType = (typeof STOCK_PREP_DIFF_TYPES)[number]
 export type StockPreparationDiffReviewStatus = (typeof STOCK_PREP_REVIEW_STATUSES)[number]
 export type StockPreparationDiffChangeType = (typeof STOCK_PREP_CHANGE_TYPES)[number]
 
+// Only the fields the UI actually renders are carried, and every one has a TIGHT validator (enum, a
+// prefixed handle, a sha16 fingerprint, or a non-negative int) — no loose pattern-matched string
+// survives into the client shape. UI-unused envelope fields (reason, snapshot-line ids, path
+// fingerprints, batch ids) are dropped at the boundary rather than pattern-matched, so a business value
+// in one of them can never be "values-free by a regex" — it simply isn't part of the client contract.
 export interface StockPreparationSnapshotDiffRow {
   diffId: string
   diffType: StockPreparationDiffType
   reviewStatus: StockPreparationDiffReviewStatus
   changeTypes: StockPreparationDiffChangeType[]
-  reason: string | null
   rowCount: number
-  previousSnapshotLineId: string | null
-  currentSnapshotLineId: string | null
   keyFingerprint: string | null
-  previousPathKeyFingerprint: string | null
-  currentPathKeyFingerprint: string | null
 }
 
 export interface StockPreparationSnapshotDiffRowsResult {
-  snapshotBatchId: string
-  baseSnapshotBatchId: string | null
   rowCount: number
   heldRowCount: number
   rows: StockPreparationSnapshotDiffRow[]
@@ -138,16 +136,16 @@ export interface StockPreparationSnapshotDiffRowsFilters {
   diffType?: StockPreparationDiffType | null
 }
 
-// Exact backend handle/fingerprint shapes (stock-preparation-snapshot-diff.cjs / -expansion-snapshot-mapper.cjs):
-// diffId = `stockprep_diff_<16 hex>`, snapshot-line id = `stockprep_snapshot_line_<16 hex>`,
-// fingerprint = `sha16:<16 hex>`. A planted business value (drawing no / material code / name / qty)
-// matches none of these, so it is dropped — this is what makes the client values-free by construction.
+// Exact backend shapes: diffId = `stockprep_diff_<16 hex>` (stableDiffId), fingerprint = `sha16:<16 hex>`
+// (stableFingerprint). A planted business value matches neither, so it is dropped — and because every
+// retained field is one of these tight shapes / an enum / a non-negative int, there is no loose pattern
+// left for a value to survive under (owner: REASON_RE / HANDLE_RE removed — those fields are gone).
 const DIFF_ID_RE = /^stockprep_diff_[0-9a-f]{16}$/
-const SNAPSHOT_LINE_ID_RE = /^stockprep_snapshot_line_[0-9a-f]{16}$/
 const FINGERPRINT_RE = /^sha16:[0-9a-f]{16}$/
-const REASON_RE = /^[a-z][a-z0-9_]{0,63}$/ // coarse snake_case code (backend builds it, e.g. matched_path_changed)
-const HANDLE_RE = /^[A-Za-z0-9_:.-]{1,128}$/ // conservative bound for the result-level batch handles
 const INVALID = Symbol('invalid')
+
+/** A malformed envelope (not "zero rows") — the caller turns this into the view's unavailable state. */
+export const SNAPSHOT_DIFF_ROWS_MALFORMED = 'SNAPSHOT_DIFF_ROWS_MALFORMED'
 
 const asMatch = (v: unknown, re: RegExp): string | null => (typeof v === 'string' && re.test(v) ? v : null)
 const asNonNegInt = (v: unknown): number | null => (typeof v === 'number' && Number.isInteger(v) && v >= 0 ? v : null)
@@ -172,46 +170,36 @@ function parseDiffRow(raw: unknown): StockPreparationSnapshotDiffRow | null {
   }
   const rowCount = asNonNegInt(r.rowCount)
   if (rowCount === null) return null
-
-  const reason = asNullableMatch(r.reason, REASON_RE)
-  if (reason === INVALID) return null
-  const prevLine = asNullableMatch(r.previousSnapshotLineId, SNAPSHOT_LINE_ID_RE)
-  if (prevLine === INVALID) return null
-  const currLine = asNullableMatch(r.currentSnapshotLineId, SNAPSHOT_LINE_ID_RE)
-  if (currLine === INVALID) return null
   const keyFp = asNullableMatch(r.keyFingerprint, FINGERPRINT_RE)
   if (keyFp === INVALID) return null
-  const prevFp = asNullableMatch(r.previousPathKeyFingerprint, FINGERPRINT_RE)
-  if (prevFp === INVALID) return null
-  const currFp = asNullableMatch(r.currentPathKeyFingerprint, FINGERPRINT_RE)
-  if (currFp === INVALID) return null
 
   return {
     diffId,
     diffType: r.diffType as StockPreparationDiffType,
     reviewStatus: r.reviewStatus as StockPreparationDiffReviewStatus,
     changeTypes: (r.changeTypes as StockPreparationDiffChangeType[]).slice(),
-    reason,
     rowCount,
-    previousSnapshotLineId: prevLine,
-    currentSnapshotLineId: currLine,
     keyFingerprint: keyFp,
-    previousPathKeyFingerprint: prevFp,
-    currentPathKeyFingerprint: currFp,
   }
 }
 
-/** Parse the /diff/rows body from `unknown`, dropping any row that fails validation. */
+/**
+ * Parse the /diff/rows body from `unknown`. A MALFORMED envelope (not an object, or `rows` not an array)
+ * THROWS a fixed coarse token — the caller must surface the view's unavailable state, never a silent
+ * "no diff rows" (a valid EMPTY `rows: []` is a real no-diffs result and is allowed). Invalid rows are
+ * dropped; rowCount/heldRowCount are recomputed from the RETAINED rows so the count always matches the
+ * rendered table (never a non-zero count over an empty table).
+ */
 export function parseStockPreparationSnapshotDiffRowsResult(raw: unknown): StockPreparationSnapshotDiffRowsResult {
-  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
-  const rawRows = Array.isArray(r.rows) ? r.rows : []
-  const rows = rawRows.map(parseDiffRow).filter((x): x is StockPreparationSnapshotDiffRow => x !== null)
-  const baseId = asNullableMatch(r.baseSnapshotBatchId, HANDLE_RE)
+  if (!raw || typeof raw !== 'object' || !Array.isArray((raw as Record<string, unknown>).rows)) {
+    throw new Error(SNAPSHOT_DIFF_ROWS_MALFORMED)
+  }
+  const rows = ((raw as Record<string, unknown>).rows as unknown[])
+    .map(parseDiffRow)
+    .filter((x): x is StockPreparationSnapshotDiffRow => x !== null)
   return {
-    snapshotBatchId: asMatch(r.snapshotBatchId, HANDLE_RE) ?? '',
-    baseSnapshotBatchId: baseId === INVALID ? null : baseId,
-    rowCount: asNonNegInt(r.rowCount) ?? rows.length,
-    heldRowCount: asNonNegInt(r.heldRowCount) ?? 0,
+    rowCount: rows.length,
+    heldRowCount: rows.filter((r) => r.reviewStatus === 'held').length,
     rows,
   }
 }

--- a/apps/web/src/services/integration/stockPreparation/bomSnapshotDiff.ts
+++ b/apps/web/src/services/integration/stockPreparation/bomSnapshotDiff.ts
@@ -88,22 +88,32 @@ export async function getStockPreparationSnapshotDiff(
   return parseIntegrationResponse<StockPreparationSnapshotDiffSummary>(response)
 }
 
-/**
- * One values-free diff ROW (the per-row drill-down under the summary). The backend projects a FROZEN
- * whitelist (stock-preparation-snapshot-reads.cjs `DIFF_ROW_KEYS`): opaque MetaSheet handles
- * (diffId / snapshot-line ids), enum vocabularies (diffType / reviewStatus / changeTypes), a coarse
- * `reason` code, a `rowCount`, and SHA-16 FINGERPRINTS. The fingerprints are one-way hashes of the
- * key / path-key — NOT the raw path keys, drawing numbers, quantities, or units — so they stay within
- * the values-free contract (opaque handles), unlike the raw values that never cross this boundary.
- */
-export type StockPreparationDiffReviewStatus = 'pending' | 'held' | 'accepted' | string
-export type StockPreparationDiffType = 'added' | 'removed' | 'changed' | string
+// ── Values-free-by-construction diff rows ────────────────────────────────────────────────────────
+// The row detail is NOT values-free just because the backend projects a whitelist — the CLIENT must
+// re-validate at the boundary, because open string types would let a business value planted in a
+// whitelisted field (diffId, keyFingerprint, …) render straight into the DOM. So we parse from
+// `unknown`, validate every field against the backend's frozen shape, and DROP any row that fails.
+//
+// These three vocabularies MUST equal the backend's frozen enums (stock-preparation-snapshot-diff.cjs
+// DIFF_TYPES / REVIEW_STATUSES / CHANGE_TYPES) — a bomSnapshotDiff.vocab tripwire pins that so a backend
+// vocab change (which would otherwise make the client silently drop every row of the new kind) fails CI.
+export const STOCK_PREP_DIFF_TYPES = ['added', 'removed', 'changed', 'unchanged', 'held'] as const
+export const STOCK_PREP_REVIEW_STATUSES = ['ready', 'held'] as const
+export const STOCK_PREP_CHANGE_TYPES = [
+  'added', 'removed', 'quantity_changed', 'unit_changed', 'version_changed', 'path_changed',
+  'parent_changed', 'source_fingerprint_changed', 'invalid_qty', 'missing_child_bom',
+  'duplicate_path_key', 'missing_path_key',
+] as const
+
+export type StockPreparationDiffType = (typeof STOCK_PREP_DIFF_TYPES)[number]
+export type StockPreparationDiffReviewStatus = (typeof STOCK_PREP_REVIEW_STATUSES)[number]
+export type StockPreparationDiffChangeType = (typeof STOCK_PREP_CHANGE_TYPES)[number]
 
 export interface StockPreparationSnapshotDiffRow {
   diffId: string
   diffType: StockPreparationDiffType
   reviewStatus: StockPreparationDiffReviewStatus
-  changeTypes: string[]
+  changeTypes: StockPreparationDiffChangeType[]
   reason: string | null
   rowCount: number
   previousSnapshotLineId: string | null
@@ -128,12 +138,91 @@ export interface StockPreparationSnapshotDiffRowsFilters {
   diffType?: StockPreparationDiffType | null
 }
 
+// Exact backend handle/fingerprint shapes (stock-preparation-snapshot-diff.cjs / -expansion-snapshot-mapper.cjs):
+// diffId = `stockprep_diff_<16 hex>`, snapshot-line id = `stockprep_snapshot_line_<16 hex>`,
+// fingerprint = `sha16:<16 hex>`. A planted business value (drawing no / material code / name / qty)
+// matches none of these, so it is dropped — this is what makes the client values-free by construction.
+const DIFF_ID_RE = /^stockprep_diff_[0-9a-f]{16}$/
+const SNAPSHOT_LINE_ID_RE = /^stockprep_snapshot_line_[0-9a-f]{16}$/
+const FINGERPRINT_RE = /^sha16:[0-9a-f]{16}$/
+const REASON_RE = /^[a-z][a-z0-9_]{0,63}$/ // coarse snake_case code (backend builds it, e.g. matched_path_changed)
+const HANDLE_RE = /^[A-Za-z0-9_:.-]{1,128}$/ // conservative bound for the result-level batch handles
+const INVALID = Symbol('invalid')
+
+const asMatch = (v: unknown, re: RegExp): string | null => (typeof v === 'string' && re.test(v) ? v : null)
+const asNonNegInt = (v: unknown): number | null => (typeof v === 'number' && Number.isInteger(v) && v >= 0 ? v : null)
+// null/undefined → null (valid absence); present-but-non-matching → INVALID (drop the row).
+function asNullableMatch(v: unknown, re: RegExp): string | null | typeof INVALID {
+  if (v === null || v === undefined) return null
+  const s = asMatch(v, re)
+  return s === null ? INVALID : s
+}
+
+function parseDiffRow(raw: unknown): StockPreparationSnapshotDiffRow | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+
+  const diffId = asMatch(r.diffId, DIFF_ID_RE)
+  if (!diffId) return null
+  if (!(STOCK_PREP_DIFF_TYPES as readonly unknown[]).includes(r.diffType)) return null
+  if (!(STOCK_PREP_REVIEW_STATUSES as readonly unknown[]).includes(r.reviewStatus)) return null
+  if (!Array.isArray(r.changeTypes)) return null
+  for (const ct of r.changeTypes) {
+    if (!(STOCK_PREP_CHANGE_TYPES as readonly unknown[]).includes(ct)) return null
+  }
+  const rowCount = asNonNegInt(r.rowCount)
+  if (rowCount === null) return null
+
+  const reason = asNullableMatch(r.reason, REASON_RE)
+  if (reason === INVALID) return null
+  const prevLine = asNullableMatch(r.previousSnapshotLineId, SNAPSHOT_LINE_ID_RE)
+  if (prevLine === INVALID) return null
+  const currLine = asNullableMatch(r.currentSnapshotLineId, SNAPSHOT_LINE_ID_RE)
+  if (currLine === INVALID) return null
+  const keyFp = asNullableMatch(r.keyFingerprint, FINGERPRINT_RE)
+  if (keyFp === INVALID) return null
+  const prevFp = asNullableMatch(r.previousPathKeyFingerprint, FINGERPRINT_RE)
+  if (prevFp === INVALID) return null
+  const currFp = asNullableMatch(r.currentPathKeyFingerprint, FINGERPRINT_RE)
+  if (currFp === INVALID) return null
+
+  return {
+    diffId,
+    diffType: r.diffType as StockPreparationDiffType,
+    reviewStatus: r.reviewStatus as StockPreparationDiffReviewStatus,
+    changeTypes: (r.changeTypes as StockPreparationDiffChangeType[]).slice(),
+    reason,
+    rowCount,
+    previousSnapshotLineId: prevLine,
+    currentSnapshotLineId: currLine,
+    keyFingerprint: keyFp,
+    previousPathKeyFingerprint: prevFp,
+    currentPathKeyFingerprint: currFp,
+  }
+}
+
+/** Parse the /diff/rows body from `unknown`, dropping any row that fails validation. */
+export function parseStockPreparationSnapshotDiffRowsResult(raw: unknown): StockPreparationSnapshotDiffRowsResult {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
+  const rawRows = Array.isArray(r.rows) ? r.rows : []
+  const rows = rawRows.map(parseDiffRow).filter((x): x is StockPreparationSnapshotDiffRow => x !== null)
+  const baseId = asNullableMatch(r.baseSnapshotBatchId, HANDLE_RE)
+  return {
+    snapshotBatchId: asMatch(r.snapshotBatchId, HANDLE_RE) ?? '',
+    baseSnapshotBatchId: baseId === INVALID ? null : baseId,
+    rowCount: asNonNegInt(r.rowCount) ?? rows.length,
+    heldRowCount: asNonNegInt(r.heldRowCount) ?? 0,
+    rows,
+  }
+}
+
 /**
  * Values-free per-row detail for one snapshot batch's diff (view-2 drill-down under the summary).
  * GET /api/integration/stock-preparation/snapshot-batches/:snapshotBatchId/diff/rows
  * `projectId` rides the scope (required server-side); the two enum filters are optional and are
- * validated server-side against the frozen vocabularies (a bad value → values-free 400 with the field
- * name only), so the client passes them straight through.
+ * validated server-side against the frozen vocabularies. The response is re-validated HERE from
+ * `unknown` (parseStockPreparationSnapshotDiffRowsResult) so a malformed / value-bearing row is dropped
+ * at the client boundary rather than rendered.
  */
 export async function listStockPreparationSnapshotDiffRows(
   snapshotBatchId: string,
@@ -151,5 +240,6 @@ export async function listStockPreparationSnapshotDiffRows(
   const response = await apiFetch(
     `/api/integration/stock-preparation/snapshot-batches/${encodeURIComponent(snapshotBatchId)}/diff/rows${query ? `?${query}` : ''}`,
   )
-  return parseIntegrationResponse<StockPreparationSnapshotDiffRowsResult>(response)
+  const raw = await parseIntegrationResponse<unknown>(response)
+  return parseStockPreparationSnapshotDiffRowsResult(raw)
 }

--- a/apps/web/tests/StockPreparationSnapshotDiffView.spec.ts
+++ b/apps/web/tests/StockPreparationSnapshotDiffView.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, nextTick, ref, type App as VueApp, type Component } from 'vue'
+import { createApp, h as renderH, nextTick, ref, type App as VueApp, type Component } from 'vue'
 
 // Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md).
 // Frontend MVP view 2: the readonly BOM SNAPSHOT BATCH & DIFF view. Covers the loading → batches
@@ -92,10 +92,12 @@ function batchListTwoComplete(): StockPreparationSnapshotBatchListResult {
   } as unknown as StockPreparationSnapshotBatchListResult
 }
 
-function diffSummary(): StockPreparationSnapshotDiffSummary {
+// `baseId` distinguishes one batch's summary from another's in the DOM (it renders as a <code> handle),
+// so a stale summary is detectable — batch A's `base-of-alpha` must never show while B is selected.
+function diffSummary(baseId = 'batch-beta'): StockPreparationSnapshotDiffSummary {
   return {
     snapshotBatchId: 'batch-alpha',
-    baseSnapshotBatchId: 'batch-beta',
+    baseSnapshotBatchId: baseId,
     changeCounts: {
       added: 2,
       removed: 1,
@@ -543,5 +545,62 @@ describe('StockPreparationSnapshotDiffView (readonly, values-free)', () => {
     await flushUi()
     expect(root.textContent).toContain('diff-gamma-one')
     expect(root.textContent).not.toContain('diff-alpha-one')
+  })
+
+  // ── sibling async loaders: batch-LIST and diff-SUMMARY must drop stale responses too ─────────────
+  // Mount with a REACTIVE projectId so a project switch (the watch) can be driven within one instance.
+  function mountReactiveProject(projectIdRef: { value: string }): HTMLDivElement {
+    app = createApp({ render: () => renderH(StockPreparationSnapshotDiffView as Component, { projectId: projectIdRef.value }) })
+    app.mount(container!)
+    return container!
+  }
+
+  it('a slow batch-LIST response for project A, arriving after switching to B, is dropped (not shown under B)', async () => {
+    let releaseA!: (v: StockPreparationSnapshotBatchListResult) => void
+    h.listBatches.mockImplementation((scope: { projectId?: string }) => {
+      if (scope.projectId === 'proj-A') return new Promise((resolve) => { releaseA = resolve })
+      return Promise.resolve({ projectId: 'proj-B', batchCount: 1, batches: [
+        { snapshotBatchId: 'batch-in-B', snapshotVersion: 1, snapshotStatus: 'active', syncRunId: 'sync-B', lineCount: 2, createdAtPresent: true, incomplete: false },
+      ] } as unknown as StockPreparationSnapshotBatchListResult)
+    })
+    const projectIdRef = ref('proj-A')
+    const root = mountReactiveProject(projectIdRef)
+    await nextTick() // project A's list GET is in flight (deferred)
+
+    projectIdRef.value = 'proj-B' // switch — watch fires loadBatches(B), which resolves immediately
+    await flushUi()
+    expect(root.textContent).toContain('sync-B')
+
+    // A's slow list finally arrives — must be dropped, NOT rendered over B's list.
+    releaseA({ projectId: 'proj-A', batchCount: 1, batches: [
+      { snapshotBatchId: 'batch-in-A', snapshotVersion: 1, snapshotStatus: 'active', syncRunId: 'sync-A', lineCount: 2, createdAtPresent: true, incomplete: false },
+    ] } as unknown as StockPreparationSnapshotBatchListResult)
+    await flushUi()
+    expect(root.textContent).toContain('sync-B')
+    expect(root.textContent).not.toContain('sync-A')
+  })
+
+  it('a slow diff-SUMMARY response for batch A, arriving after selecting B, is dropped (not shown under B)', async () => {
+    let releaseA!: (v: StockPreparationSnapshotDiffSummary) => void
+    h.listBatches.mockResolvedValue(batchListTwoComplete())
+    h.getDiff.mockImplementation((batchId: string) => {
+      if (batchId === 'batch-alpha') return new Promise((resolve) => { releaseA = resolve })
+      return Promise.resolve(diffSummary('base-of-gamma'))
+    })
+    const root = mountView()
+    await flushUi()
+    ;(root.querySelectorAll('[data-testid="stock-prep-snapshot-batch-select"]')[0] as HTMLButtonElement).click() // select A → summary in flight
+    await flushUi()
+    expect(root.querySelector('[data-testid="stock-prep-diff-loading"]')).not.toBeNull()
+
+    ;(root.querySelectorAll('[data-testid="stock-prep-snapshot-batch-select"]')[1] as HTMLButtonElement).click() // select B → resolves
+    await flushUi()
+    expect(root.textContent).toContain('base-of-gamma')
+
+    // A's slow summary finally arrives — must be dropped, NOT overwrite B's summary.
+    releaseA(diffSummary('base-of-alpha'))
+    await flushUi()
+    expect(root.textContent).toContain('base-of-gamma')
+    expect(root.textContent).not.toContain('base-of-alpha')
   })
 })

--- a/apps/web/tests/StockPreparationSnapshotDiffView.spec.ts
+++ b/apps/web/tests/StockPreparationSnapshotDiffView.spec.ts
@@ -13,6 +13,7 @@ const h = vi.hoisted(() => ({
   locale: 'zh-CN' as string,
   listBatches: vi.fn(),
   getDiff: vi.fn(),
+  listRows: vi.fn(),
 }))
 
 vi.mock('../src/composables/useLocale', () => ({
@@ -26,6 +27,7 @@ vi.mock('../src/composables/useLocale', () => ({
 vi.mock('../src/services/integration/stockPreparation/bomSnapshotDiff', () => ({
   listStockPreparationSnapshotBatches: h.listBatches,
   getStockPreparationSnapshotDiff: h.getDiff,
+  listStockPreparationSnapshotDiffRows: h.listRows,
 }))
 
 import StockPreparationSnapshotDiffView from '../src/components/integration/stockPreparation/StockPreparationSnapshotDiffView.vue'
@@ -95,11 +97,60 @@ function diffSummary(): StockPreparationSnapshotDiffSummary {
   }
 }
 
+function diffRowsResult(): unknown {
+  // Planted business values as EXTRA fields on each row — the values-free table must render NONE of them.
+  return {
+    snapshotBatchId: 'batch-alpha',
+    baseSnapshotBatchId: 'batch-beta',
+    rowCount: 2,
+    heldRowCount: 1,
+    rows: [
+      {
+        diffId: 'diff-one',
+        diffType: 'changed',
+        reviewStatus: 'held',
+        changeTypes: ['quantity', 'unit'],
+        reason: 'unit_mismatch',
+        rowCount: 1,
+        previousSnapshotLineId: 'line-prev-one',
+        currentSnapshotLineId: 'line-cur-one',
+        keyFingerprint: 'abcdef0123456789',
+        previousPathKeyFingerprint: 'fedcba9876543210',
+        currentPathKeyFingerprint: '0011223344556677',
+        drawingNo: PLANTED_DRAWING_NO,
+        materialCode: PLANTED_MATERIAL_CODE,
+        projectName: PLANTED_PROJECT_NAME,
+        quantity: PLANTED_QUANTITY,
+      },
+      {
+        diffId: 'diff-two',
+        diffType: 'added',
+        reviewStatus: 'pending',
+        changeTypes: [],
+        reason: null,
+        rowCount: 4,
+        previousSnapshotLineId: null,
+        currentSnapshotLineId: 'line-cur-two',
+        keyFingerprint: '99aabbccddeeff00',
+        previousPathKeyFingerprint: null,
+        currentPathKeyFingerprint: '7788990011223344',
+      },
+    ],
+  }
+}
+
 async function flushUi(cycles = 4): Promise<void> {
   for (let i = 0; i < cycles; i += 1) {
     await Promise.resolve()
     await nextTick()
   }
+}
+
+// Open the row-detail drill-down after a batch's summary is showing.
+async function openRowDetail(root: HTMLDivElement): Promise<void> {
+  const toggle = root.querySelector('[data-testid="stock-prep-snapshot-diff-rows-toggle"]') as HTMLButtonElement
+  toggle.click()
+  await flushUi()
 }
 
 describe('StockPreparationSnapshotDiffView (readonly, values-free)', () => {
@@ -110,6 +161,7 @@ describe('StockPreparationSnapshotDiffView (readonly, values-free)', () => {
     h.locale = 'zh-CN'
     h.listBatches.mockReset()
     h.getDiff.mockReset()
+    h.listRows.mockReset()
     container = document.createElement('div')
     document.body.appendChild(container)
   })
@@ -345,5 +397,97 @@ describe('StockPreparationSnapshotDiffView (readonly, values-free)', () => {
     for (const forbidden of FORBIDDEN) {
       expect(text).not.toContain(forbidden)
     }
+  })
+
+  // ── view-2 per-row drill-down (/diff/rows) ─────────────────────────────────────────────────────
+  async function mountWithDiffShown(): Promise<HTMLDivElement> {
+    h.listBatches.mockResolvedValue(batchListWithPlantedExtras())
+    h.getDiff.mockResolvedValue(diffSummary())
+    const root = mountView()
+    await flushUi()
+    ;(root.querySelector('[data-testid="stock-prep-snapshot-batch-select"]') as HTMLButtonElement).click()
+    await flushUi()
+    return root
+  }
+
+  it('does NOT fetch the row detail until the operator opens it (lazy)', async () => {
+    h.listRows.mockResolvedValue(diffRowsResult())
+    const root = await mountWithDiffShown()
+    // Summary is shown; the rows GET has not been issued, and the table is absent.
+    expect(h.listRows).not.toHaveBeenCalled()
+    expect(root.querySelector('[data-testid="stock-prep-snapshot-diff-rows"]')).toBeNull()
+    const toggle = root.querySelector('[data-testid="stock-prep-snapshot-diff-rows-toggle"]')
+    expect(toggle).not.toBeNull()
+  })
+
+  it('opening the detail loads and renders the values-free diff rows on demand', async () => {
+    h.listRows.mockResolvedValue(diffRowsResult())
+    const root = await mountWithDiffShown()
+    await openRowDetail(root)
+
+    expect(h.listRows).toHaveBeenCalledTimes(1)
+    // Scope carries the projectId; the batch id is the first arg.
+    expect(h.listRows.mock.calls[0][0]).toBe('batch-alpha')
+    const rows = root.querySelectorAll('[data-testid="stock-prep-snapshot-diff-row"]')
+    expect(rows.length).toBe(2)
+
+    const text = root.textContent || ''
+    // Values-free fields DO render: handle, enums, counts, opaque fingerprint prefix.
+    expect(text).toContain('diff-one')
+    expect(text).toContain('held')
+    expect(text).toContain('added')
+    expect(text).toContain('abcdef0123') // the 10-char fingerprint prefix, never the full raw key
+    // The meta line surfaces the counts.
+    expect(root.querySelector('[data-testid="stock-prep-snapshot-diff-rows-meta"]')?.textContent).toContain('2')
+  })
+
+  it('never renders a planted business value in the row detail (values-free)', async () => {
+    h.listRows.mockResolvedValue(diffRowsResult())
+    const root = await mountWithDiffShown()
+    await openRowDetail(root)
+
+    const text = root.textContent || ''
+    for (const forbidden of FORBIDDEN) {
+      expect(text).not.toContain(forbidden)
+    }
+    // The full fingerprint is truncated — the untruncated hash never reaches the DOM either.
+    expect(text).not.toContain('abcdef0123456789')
+  })
+
+  it('404-softs the row detail: neutral error state, never the raw body, table absent', async () => {
+    h.listRows.mockRejectedValue(new Error('secret-backend-detail MAT-ZX9911'))
+    const root = await mountWithDiffShown()
+    await openRowDetail(root)
+
+    expect(root.querySelector('[data-testid="stock-prep-snapshot-diff-rows-error"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="stock-prep-snapshot-diff-rows-table"]')).toBeNull()
+    expect(root.textContent || '').not.toContain('secret-backend-detail')
+  })
+
+  it('renders the empty state when the batch has zero diff rows', async () => {
+    h.listRows.mockResolvedValue({ snapshotBatchId: 'batch-alpha', baseSnapshotBatchId: null, rowCount: 0, heldRowCount: 0, rows: [] })
+    const root = await mountWithDiffShown()
+    await openRowDetail(root)
+
+    expect(root.querySelector('[data-testid="stock-prep-snapshot-diff-rows-empty"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="stock-prep-snapshot-diff-rows-table"]')).toBeNull()
+  })
+
+  it('switching batches collapses the detail and re-fetches fresh when re-opened', async () => {
+    h.listRows.mockResolvedValue(diffRowsResult())
+    const root = await mountWithDiffShown()
+    await openRowDetail(root)
+    expect(h.listRows).toHaveBeenCalledTimes(1)
+    expect(root.querySelector('[data-testid="stock-prep-snapshot-diff-rows"]')).not.toBeNull()
+
+    // Select the OTHER (first) batch again — a batch switch must collapse the stale detail.
+    h.getDiff.mockResolvedValue(diffSummary())
+    ;(root.querySelector('[data-testid="stock-prep-snapshot-batch-select"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(root.querySelector('[data-testid="stock-prep-snapshot-diff-rows"]')).toBeNull()
+
+    // Re-opening issues a FRESH fetch (not the stale cached rows).
+    await openRowDetail(root)
+    expect(h.listRows).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/web/tests/StockPreparationSnapshotDiffView.spec.ts
+++ b/apps/web/tests/StockPreparationSnapshotDiffView.spec.ts
@@ -603,4 +603,59 @@ describe('StockPreparationSnapshotDiffView (readonly, values-free)', () => {
     expect(root.textContent).toContain('base-of-gamma')
     expect(root.textContent).not.toContain('base-of-alpha')
   })
+
+  // A→B→A: the id-match check alone (projectId/batchId) CANNOT catch this — after returning to A, the id
+  // is A again, so only the monotonic SEQ distinguishes the stale first-A load from the fresh third one.
+  it('batch-LIST A→B→A: the STALE first-A response is dropped even after returning to project A', async () => {
+    let releaseA1!: (v: StockPreparationSnapshotBatchListResult) => void
+    let aCall = 0
+    const listFor = (proj: string, run: string) => ({ projectId: proj, batchCount: 1, batches: [
+      { snapshotBatchId: `batch-${run}`, snapshotVersion: 1, snapshotStatus: 'active', syncRunId: run, lineCount: 2, createdAtPresent: true, incomplete: false },
+    ] } as unknown as StockPreparationSnapshotBatchListResult)
+    h.listBatches.mockImplementation((scope: { projectId?: string }) => {
+      if (scope.projectId === 'proj-A') {
+        aCall += 1
+        if (aCall === 1) return new Promise((resolve) => { releaseA1 = resolve }) // stale first-A load
+        return Promise.resolve(listFor('proj-A', 'sync-A-fresh')) // fresh third load
+      }
+      return Promise.resolve(listFor('proj-B', 'sync-B'))
+    })
+    const projectIdRef = ref('proj-A')
+    const root = mountReactiveProject(projectIdRef)
+    await nextTick() // first-A load in flight (deferred)
+    projectIdRef.value = 'proj-B'; await flushUi()
+    projectIdRef.value = 'proj-A'; await flushUi() // back to A → fresh third load resolves
+    expect(root.textContent).toContain('sync-A-fresh')
+
+    releaseA1(listFor('proj-A', 'sync-A-stale')) // stale first-A now arrives — must be dropped
+    await flushUi()
+    expect(root.textContent).toContain('sync-A-fresh')
+    expect(root.textContent).not.toContain('sync-A-stale')
+  })
+
+  it('diff-SUMMARY A→B→A: the STALE first-batch-A summary is dropped even after re-selecting batch A', async () => {
+    let releaseA1!: (v: StockPreparationSnapshotDiffSummary) => void
+    let aCall = 0
+    h.listBatches.mockResolvedValue(batchListTwoComplete())
+    h.getDiff.mockImplementation((batchId: string) => {
+      if (batchId === 'batch-alpha') {
+        aCall += 1
+        if (aCall === 1) return new Promise((resolve) => { releaseA1 = resolve }) // stale first select-A
+        return Promise.resolve(diffSummary('base-alpha-fresh')) // fresh third select-A
+      }
+      return Promise.resolve(diffSummary('base-gamma'))
+    })
+    const root = mountView()
+    await flushUi()
+    const sel = () => root.querySelectorAll('[data-testid="stock-prep-snapshot-batch-select"]')
+    ;(sel()[0] as HTMLButtonElement).click(); await flushUi() // select A → summary #1 deferred
+    ;(sel()[1] as HTMLButtonElement).click(); await flushUi() // select B → resolves
+    ;(sel()[0] as HTMLButtonElement).click(); await flushUi() // re-select A → fresh summary #3 resolves
+    expect(root.textContent).toContain('base-alpha-fresh')
+
+    releaseA1(diffSummary('base-alpha-stale')) // stale first-A summary now arrives — must be dropped
+    await flushUi()
+    expect(root.textContent).toContain('base-alpha-fresh')
+    expect(root.textContent).not.toContain('base-alpha-stale')
+  })
 })

--- a/apps/web/tests/StockPreparationSnapshotDiffView.spec.ts
+++ b/apps/web/tests/StockPreparationSnapshotDiffView.spec.ts
@@ -126,12 +126,12 @@ function diffRowsResult(idPrefix = 'diff', batchId = 'batch-alpha'): unknown {
         diffId: `${idPrefix}-one`,
         diffType: 'changed',
         reviewStatus: 'held',
-        changeTypes: ['quantity', 'unit'],
+        changeTypes: ['quantity_changed', 'unit_changed'],
         reason: 'unit_mismatch',
         rowCount: 1,
         previousSnapshotLineId: 'line-prev-one',
         currentSnapshotLineId: 'line-cur-one',
-        keyFingerprint: 'abcdef0123456789',
+        keyFingerprint: 'sha16:0123456789abcdef',
         previousPathKeyFingerprint: 'fedcba9876543210',
         currentPathKeyFingerprint: '0011223344556677',
         drawingNo: PLANTED_DRAWING_NO,
@@ -142,13 +142,13 @@ function diffRowsResult(idPrefix = 'diff', batchId = 'batch-alpha'): unknown {
       {
         diffId: `${idPrefix}-two`,
         diffType: 'added',
-        reviewStatus: 'pending',
+        reviewStatus: 'ready',
         changeTypes: [],
         reason: null,
         rowCount: 4,
         previousSnapshotLineId: null,
         currentSnapshotLineId: 'line-cur-two',
-        keyFingerprint: '99aabbccddeeff00',
+        keyFingerprint: 'sha16:99aabbccddeeff00',
         previousPathKeyFingerprint: null,
         currentPathKeyFingerprint: '7788990011223344',
       },
@@ -453,7 +453,7 @@ describe('StockPreparationSnapshotDiffView (readonly, values-free)', () => {
     expect(text).toContain('diff-one')
     expect(text).toContain('held')
     expect(text).toContain('added')
-    expect(text).toContain('abcdef0123') // the 10-char fingerprint prefix, never the full raw key
+    expect(text).toContain('sha16:0123456789abcdef') // the full opaque sha16 handle (22 chars) — was the misleading 4-hex slice
     // The meta line surfaces the counts.
     expect(root.querySelector('[data-testid="stock-prep-snapshot-diff-rows-meta"]')?.textContent).toContain('2')
   })
@@ -467,8 +467,6 @@ describe('StockPreparationSnapshotDiffView (readonly, values-free)', () => {
     for (const forbidden of FORBIDDEN) {
       expect(text).not.toContain(forbidden)
     }
-    // The full fingerprint is truncated — the untruncated hash never reaches the DOM either.
-    expect(text).not.toContain('abcdef0123456789')
   })
 
   it('404-softs the row detail: neutral error state, never the raw body, table absent', async () => {

--- a/apps/web/tests/StockPreparationSnapshotDiffView.spec.ts
+++ b/apps/web/tests/StockPreparationSnapshotDiffView.spec.ts
@@ -79,6 +79,19 @@ function batchListWithPlantedExtras(): StockPreparationSnapshotBatchListResult {
   } as unknown as StockPreparationSnapshotBatchListResult
 }
 
+// TWO selectable (complete) batches, so a real A→B switch can be driven — batch-beta above is
+// incomplete/disabled, so clicking "the batch-select button" only ever re-selects batch-alpha.
+function batchListTwoComplete(): StockPreparationSnapshotBatchListResult {
+  return {
+    projectId: 'proj-alpha',
+    batchCount: 2,
+    batches: [
+      { snapshotBatchId: 'batch-alpha', snapshotVersion: 3, snapshotStatus: 'active', syncRunId: 'sync-run-alpha', lineCount: 7, createdAtPresent: true, incomplete: false },
+      { snapshotBatchId: 'batch-gamma', snapshotVersion: 4, snapshotStatus: 'active', syncRunId: 'sync-run-gamma', lineCount: 9, createdAtPresent: true, incomplete: false },
+    ],
+  } as unknown as StockPreparationSnapshotBatchListResult
+}
+
 function diffSummary(): StockPreparationSnapshotDiffSummary {
   return {
     snapshotBatchId: 'batch-alpha',
@@ -97,16 +110,18 @@ function diffSummary(): StockPreparationSnapshotDiffSummary {
   }
 }
 
-function diffRowsResult(): unknown {
+// `idPrefix` distinguishes one batch's rows from another's, so a stale-batch response is detectable in
+// the DOM (batch A's `diff-alpha-*` must never show while batch B is open).
+function diffRowsResult(idPrefix = 'diff', batchId = 'batch-alpha'): unknown {
   // Planted business values as EXTRA fields on each row — the values-free table must render NONE of them.
   return {
-    snapshotBatchId: 'batch-alpha',
+    snapshotBatchId: batchId,
     baseSnapshotBatchId: 'batch-beta',
     rowCount: 2,
     heldRowCount: 1,
     rows: [
       {
-        diffId: 'diff-one',
+        diffId: `${idPrefix}-one`,
         diffType: 'changed',
         reviewStatus: 'held',
         changeTypes: ['quantity', 'unit'],
@@ -123,7 +138,7 @@ function diffRowsResult(): unknown {
         quantity: PLANTED_QUANTITY,
       },
       {
-        diffId: 'diff-two',
+        diffId: `${idPrefix}-two`,
         diffType: 'added',
         reviewStatus: 'pending',
         changeTypes: [],
@@ -473,21 +488,60 @@ describe('StockPreparationSnapshotDiffView (readonly, values-free)', () => {
     expect(root.querySelector('[data-testid="stock-prep-snapshot-diff-rows-table"]')).toBeNull()
   })
 
-  it('switching batches collapses the detail and re-fetches fresh when re-opened', async () => {
-    h.listRows.mockResolvedValue(diffRowsResult())
-    const root = await mountWithDiffShown()
+  // Mount with TWO complete batches; select the first (batch-alpha) and show its summary.
+  async function mountWithTwoBatches(): Promise<HTMLDivElement> {
+    h.listBatches.mockResolvedValue(batchListTwoComplete())
+    h.getDiff.mockResolvedValue(diffSummary())
+    const root = mountView()
+    await flushUi()
+    ;(root.querySelectorAll('[data-testid="stock-prep-snapshot-batch-select"]')[0] as HTMLButtonElement).click()
+    await flushUi()
+    return root
+  }
+
+  it('a REAL batch switch (A→B) collapses the detail and re-fetches B fresh — B never shows A rows', async () => {
+    h.listRows.mockImplementation((batchId: string) =>
+      Promise.resolve(batchId === 'batch-gamma' ? diffRowsResult('diff-gamma', 'batch-gamma') : diffRowsResult('diff-alpha', 'batch-alpha')),
+    )
+    const root = await mountWithTwoBatches()
     await openRowDetail(root)
     expect(h.listRows).toHaveBeenCalledTimes(1)
-    expect(root.querySelector('[data-testid="stock-prep-snapshot-diff-rows"]')).not.toBeNull()
+    expect(root.textContent).toContain('diff-alpha-one')
 
-    // Select the OTHER (first) batch again — a batch switch must collapse the stale detail.
-    h.getDiff.mockResolvedValue(diffSummary())
-    ;(root.querySelector('[data-testid="stock-prep-snapshot-batch-select"]') as HTMLButtonElement).click()
+    // Select the SECOND batch (batch-gamma) — a real switch. The detail collapses.
+    ;(root.querySelectorAll('[data-testid="stock-prep-snapshot-batch-select"]')[1] as HTMLButtonElement).click()
     await flushUi()
     expect(root.querySelector('[data-testid="stock-prep-snapshot-diff-rows"]')).toBeNull()
 
-    // Re-opening issues a FRESH fetch (not the stale cached rows).
+    // Re-open → a FRESH fetch keyed on batch-gamma; it shows gamma rows, never alpha's.
     await openRowDetail(root)
     expect(h.listRows).toHaveBeenCalledTimes(2)
+    expect(h.listRows.mock.calls[1][0]).toBe('batch-gamma')
+    expect(root.textContent).toContain('diff-gamma-one')
+    expect(root.textContent).not.toContain('diff-alpha-one')
+  })
+
+  it('a slow A response arriving AFTER switching to B is discarded (monotonic guard, not cached under B)', async () => {
+    // Batch A's rows load is DEFERRED; B's resolves immediately.
+    let releaseAlpha!: (v: unknown) => void
+    h.listRows.mockImplementation((batchId: string) => {
+      if (batchId === 'batch-alpha') return new Promise((resolve) => { releaseAlpha = resolve })
+      return Promise.resolve(diffRowsResult('diff-gamma', 'batch-gamma'))
+    })
+    const root = await mountWithTwoBatches()
+    await openRowDetail(root) // opens A → A's rows GET is in flight (deferred)
+    expect(root.querySelector('[data-testid="stock-prep-snapshot-diff-rows-loading"]')).not.toBeNull()
+
+    // Switch to B while A is still pending, and open + resolve B.
+    ;(root.querySelectorAll('[data-testid="stock-prep-snapshot-batch-select"]')[1] as HTMLButtonElement).click()
+    await flushUi()
+    await openRowDetail(root)
+    expect(root.textContent).toContain('diff-gamma-one')
+
+    // NOW A's slow response finally arrives — it must be dropped, NOT cached under B.
+    releaseAlpha(diffRowsResult('diff-alpha', 'batch-alpha'))
+    await flushUi()
+    expect(root.textContent).toContain('diff-gamma-one')
+    expect(root.textContent).not.toContain('diff-alpha-one')
   })
 })

--- a/apps/web/tests/bomSnapshotDiff.spec.ts
+++ b/apps/web/tests/bomSnapshotDiff.spec.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest'
 // exercise the parser; this file does.
 import {
   parseStockPreparationSnapshotDiffRowsResult,
+  SNAPSHOT_DIFF_ROWS_MALFORMED,
   STOCK_PREP_DIFF_TYPES,
   STOCK_PREP_REVIEW_STATUSES,
   STOCK_PREP_CHANGE_TYPES,
@@ -64,9 +65,6 @@ describe('bomSnapshotDiff values-free-by-construction parser', () => {
     ['reviewStatus is off-vocabulary', { reviewStatus: 'accepted' }],
     ['a changeType is off-vocabulary', { changeTypes: ['quantity_changed', SECRET] }],
     ['keyFingerprint is not a sha16 handle', { keyFingerprint: SECRET }],
-    ['a path fingerprint is not a sha16 handle', { previousPathKeyFingerprint: SECRET }],
-    ['a snapshot-line id is not a handle', { currentSnapshotLineId: SECRET }],
-    ['reason carries a value (not a snake_case code)', { reason: SECRET }],
     ['rowCount is negative', { rowCount: -3 }],
     ['rowCount is not an integer', { rowCount: 2.5 }],
   ]
@@ -85,10 +83,25 @@ describe('bomSnapshotDiff values-free-by-construction parser', () => {
     expect(JSON.stringify(out)).not.toContain(SECRET)
   })
 
-  it('tolerates a non-object / missing rows body without throwing', () => {
-    expect(parseStockPreparationSnapshotDiffRowsResult(null).rows).toEqual([])
-    expect(parseStockPreparationSnapshotDiffRowsResult({ rows: 'nope' }).rows).toEqual([])
+  it('THROWS a fixed coarse token on a malformed envelope (not a silent "no diff rows")', () => {
+    // null / non-object / rows-not-an-array are malformed — the caller must show "unavailable", not empty.
+    expect(() => parseStockPreparationSnapshotDiffRowsResult(null)).toThrow(SNAPSHOT_DIFF_ROWS_MALFORMED)
+    expect(() => parseStockPreparationSnapshotDiffRowsResult({ rows: 'nope' })).toThrow(SNAPSHOT_DIFF_ROWS_MALFORMED)
+    // A valid EMPTY array is a real no-diffs result — allowed, zero rows.
+    expect(parseStockPreparationSnapshotDiffRowsResult({ rows: [] }).rows).toEqual([])
+    // Junk row entries inside a valid array are individually dropped (not a malformed envelope).
     expect(parseStockPreparationSnapshotDiffRowsResult({ rows: [42, null, 'x'] }).rows).toEqual([])
+  })
+
+  it('recomputes rowCount/heldRowCount from RETAINED rows (never a phantom count over a shorter table)', () => {
+    // Server claims 9/9 but only one row survives validation → counts reflect the retained row.
+    const out = parseStockPreparationSnapshotDiffRowsResult({
+      rowCount: 9, heldRowCount: 9,
+      rows: [validRow({ reviewStatus: 'held' }), validRow({ diffId: SECRET })],
+    })
+    expect(out.rows.length).toBe(1)
+    expect(out.rowCount).toBe(1)
+    expect(out.heldRowCount).toBe(1)
   })
 })
 

--- a/apps/web/tests/bomSnapshotDiff.spec.ts
+++ b/apps/web/tests/bomSnapshotDiff.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+// Service-level test (NOT mocked — imports the real module) for the values-free-by-construction parser
+// and the client/server vocabulary tripwire. The SnapshotDiffView spec mocks this module, so it cannot
+// exercise the parser; this file does.
+import {
+  parseStockPreparationSnapshotDiffRowsResult,
+  STOCK_PREP_DIFF_TYPES,
+  STOCK_PREP_REVIEW_STATUSES,
+  STOCK_PREP_CHANGE_TYPES,
+} from '../src/services/integration/stockPreparation/bomSnapshotDiff'
+// The AUTHORITATIVE backend vocabularies (frozen). Imported live so a backend vocab change reddens this
+// tripwire instead of silently making the client drop every row of the new kind.
+import backendDiff from '../../../plugins/plugin-integration-core/lib/stock-preparation-snapshot-diff.cjs'
+
+// Real backend handle/fingerprint shapes (see stock-preparation-snapshot-diff.cjs / -mapper.cjs).
+const GOOD_DIFF_ID = 'stockprep_diff_0123456789abcdef'
+const GOOD_LINE_ID = 'stockprep_snapshot_line_0123456789abcdef'
+const GOOD_FP = 'sha16:0123456789abcdef'
+const GOOD_BATCH = 'stockprep_snapshot_0123456789abcdef'
+
+function validRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    diffId: GOOD_DIFF_ID,
+    diffType: 'changed',
+    reviewStatus: 'held',
+    changeTypes: ['quantity_changed', 'unit_changed'],
+    reason: 'matched_path_changed',
+    rowCount: 1,
+    previousSnapshotLineId: GOOD_LINE_ID,
+    currentSnapshotLineId: GOOD_LINE_ID,
+    keyFingerprint: GOOD_FP,
+    previousPathKeyFingerprint: GOOD_FP,
+    currentPathKeyFingerprint: null,
+    ...overrides,
+  }
+}
+
+function parseRows(rows: unknown[]): ReturnType<typeof parseStockPreparationSnapshotDiffRowsResult> {
+  return parseStockPreparationSnapshotDiffRowsResult({
+    snapshotBatchId: GOOD_BATCH,
+    baseSnapshotBatchId: null,
+    rowCount: rows.length,
+    heldRowCount: 0,
+    rows,
+  })
+}
+
+const SECRET = 'DWG-88472-A' // a planted business value; must never survive parsing into a field
+
+describe('bomSnapshotDiff values-free-by-construction parser', () => {
+  it('keeps a well-formed row (real backend shapes)', () => {
+    const out = parseRows([validRow()])
+    expect(out.rows.length).toBe(1)
+    expect(out.rows[0].diffId).toBe(GOOD_DIFF_ID)
+    expect(out.rows[0].keyFingerprint).toBe(GOOD_FP)
+  })
+
+  // Each whitelisted field is a distinct drop path — a business value planted in ANY of them must drop
+  // the whole row, so it can never reach the DOM.
+  const dropCases: Array<[string, Record<string, unknown>]> = [
+    ['diffId carries a business value', { diffId: SECRET }],
+    ['diffType is off-vocabulary', { diffType: SECRET }],
+    ['reviewStatus is off-vocabulary', { reviewStatus: 'accepted' }],
+    ['a changeType is off-vocabulary', { changeTypes: ['quantity_changed', SECRET] }],
+    ['keyFingerprint is not a sha16 handle', { keyFingerprint: SECRET }],
+    ['a path fingerprint is not a sha16 handle', { previousPathKeyFingerprint: SECRET }],
+    ['a snapshot-line id is not a handle', { currentSnapshotLineId: SECRET }],
+    ['reason carries a value (not a snake_case code)', { reason: SECRET }],
+    ['rowCount is negative', { rowCount: -3 }],
+    ['rowCount is not an integer', { rowCount: 2.5 }],
+  ]
+  for (const [name, override] of dropCases) {
+    it(`drops the row when ${name}`, () => {
+      const out = parseRows([validRow(override)])
+      expect(out.rows.length).toBe(0)
+      expect(JSON.stringify(out)).not.toContain(SECRET)
+    })
+  }
+
+  it('drops only the invalid row and keeps the valid one alongside it', () => {
+    const out = parseRows([validRow(), validRow({ diffId: 'stockprep_diff_ffffffffffffffff', keyFingerprint: SECRET })])
+    expect(out.rows.length).toBe(1)
+    expect(out.rows[0].diffId).toBe(GOOD_DIFF_ID)
+    expect(JSON.stringify(out)).not.toContain(SECRET)
+  })
+
+  it('tolerates a non-object / missing rows body without throwing', () => {
+    expect(parseStockPreparationSnapshotDiffRowsResult(null).rows).toEqual([])
+    expect(parseStockPreparationSnapshotDiffRowsResult({ rows: 'nope' }).rows).toEqual([])
+    expect(parseStockPreparationSnapshotDiffRowsResult({ rows: [42, null, 'x'] }).rows).toEqual([])
+  })
+})
+
+describe('client/server vocabulary tripwire (drift guard)', () => {
+  const sorted = (xs: readonly string[]) => [...xs].sort()
+
+  it('client STOCK_PREP_DIFF_TYPES equals the backend DIFF_TYPES', () => {
+    expect(sorted(STOCK_PREP_DIFF_TYPES)).toEqual(sorted(Object.values(backendDiff.DIFF_TYPES)))
+  })
+  it('client STOCK_PREP_REVIEW_STATUSES equals the backend REVIEW_STATUSES', () => {
+    expect(sorted(STOCK_PREP_REVIEW_STATUSES)).toEqual(sorted(Object.values(backendDiff.REVIEW_STATUSES)))
+  })
+  it('client STOCK_PREP_CHANGE_TYPES equals the backend CHANGE_TYPES', () => {
+    expect(sorted(STOCK_PREP_CHANGE_TYPES)).toEqual(sorted(Object.values(backendDiff.CHANGE_TYPES)))
+  })
+})

--- a/apps/web/tests/bomSnapshotDiff.spec.ts
+++ b/apps/web/tests/bomSnapshotDiff.spec.ts
@@ -57,9 +57,10 @@ describe('bomSnapshotDiff values-free-by-construction parser', () => {
     expect(out.rows[0].keyFingerprint).toBe(GOOD_FP)
   })
 
-  // Each whitelisted field is a distinct drop path — a business value planted in ANY of them must drop
-  // the whole row, so it can never reach the DOM.
-  const dropCases: Array<[string, Record<string, unknown>]> = [
+  // Fail-closed at the ENVELOPE: a business value planted in ANY whitelisted field of ANY row THROWS the
+  // whole response into the unavailable state — never a silent per-row drop (which would hide an
+  // all-invalid response as "no diff rows" and a mixed one as a silently-incomplete table).
+  const throwCases: Array<[string, Record<string, unknown>]> = [
     ['diffId carries a business value', { diffId: SECRET }],
     ['diffType is off-vocabulary', { diffType: SECRET }],
     ['reviewStatus is off-vocabulary', { reviewStatus: 'accepted' }],
@@ -68,39 +69,34 @@ describe('bomSnapshotDiff values-free-by-construction parser', () => {
     ['rowCount is negative', { rowCount: -3 }],
     ['rowCount is not an integer', { rowCount: 2.5 }],
   ]
-  for (const [name, override] of dropCases) {
-    it(`drops the row when ${name}`, () => {
-      const out = parseRows([validRow(override)])
-      expect(out.rows.length).toBe(0)
-      expect(JSON.stringify(out)).not.toContain(SECRET)
+  for (const [name, override] of throwCases) {
+    it(`THROWS the whole envelope when ${name}`, () => {
+      expect(() => parseRows([validRow(override)])).toThrow(SNAPSHOT_DIFF_ROWS_MALFORMED)
     })
   }
 
-  it('drops only the invalid row and keeps the valid one alongside it', () => {
-    const out = parseRows([validRow(), validRow({ diffId: 'stockprep_diff_ffffffffffffffff', keyFingerprint: SECRET })])
-    expect(out.rows.length).toBe(1)
-    expect(out.rows[0].diffId).toBe(GOOD_DIFF_ID)
-    expect(JSON.stringify(out)).not.toContain(SECRET)
+  it('a MIXED response (one valid + one invalid row) throws — never a silently-incomplete table', () => {
+    expect(() => parseRows([validRow(), validRow({ diffId: 'stockprep_diff_ffffffffffffffff', keyFingerprint: SECRET })]))
+      .toThrow(SNAPSHOT_DIFF_ROWS_MALFORMED)
   })
 
-  it('THROWS a fixed coarse token on a malformed envelope (not a silent "no diff rows")', () => {
-    // null / non-object / rows-not-an-array are malformed — the caller must show "unavailable", not empty.
+  it('THROWS on a malformed envelope OR any invalid row; only a valid empty [] is the empty state', () => {
+    // null / non-object / rows-not-an-array → unavailable, not empty.
     expect(() => parseStockPreparationSnapshotDiffRowsResult(null)).toThrow(SNAPSHOT_DIFF_ROWS_MALFORMED)
     expect(() => parseStockPreparationSnapshotDiffRowsResult({ rows: 'nope' })).toThrow(SNAPSHOT_DIFF_ROWS_MALFORMED)
-    // A valid EMPTY array is a real no-diffs result — allowed, zero rows.
+    // Junk row entries are invalid rows → the whole envelope is unavailable (NOT silently dropped to []).
+    expect(() => parseStockPreparationSnapshotDiffRowsResult({ rows: [42, null, 'x'] })).toThrow(SNAPSHOT_DIFF_ROWS_MALFORMED)
+    // A genuinely valid EMPTY array is the ONLY thing that yields the empty state.
     expect(parseStockPreparationSnapshotDiffRowsResult({ rows: [] }).rows).toEqual([])
-    // Junk row entries inside a valid array are individually dropped (not a malformed envelope).
-    expect(parseStockPreparationSnapshotDiffRowsResult({ rows: [42, null, 'x'] }).rows).toEqual([])
   })
 
-  it('recomputes rowCount/heldRowCount from RETAINED rows (never a phantom count over a shorter table)', () => {
-    // Server claims 9/9 but only one row survives validation → counts reflect the retained row.
+  it('when EVERY row is valid, rowCount/heldRowCount are computed from them', () => {
     const out = parseStockPreparationSnapshotDiffRowsResult({
-      rowCount: 9, heldRowCount: 9,
-      rows: [validRow({ reviewStatus: 'held' }), validRow({ diffId: SECRET })],
+      rowCount: 9, heldRowCount: 9, // server envelope counts are ignored — recomputed from the parsed rows
+      rows: [validRow({ reviewStatus: 'held' }), validRow({ diffId: 'stockprep_diff_ffffffffffffffff', reviewStatus: 'ready' })],
     })
-    expect(out.rows.length).toBe(1)
-    expect(out.rowCount).toBe(1)
+    expect(out.rows.length).toBe(2)
+    expect(out.rowCount).toBe(2)
     expect(out.heldRowCount).toBe(1)
   })
 })


### PR DESCRIPTION
## What — view-2 diff row-detail drill-down (values-free-by-construction FE consumer)

Wires the already-landed, tested backend `GET /snapshot-batches/:id/diff/rows` as the per-row drill-down under the diff summary. Read-only; independent of the tenant-scoped WRITE hardening and NOT the OD-W3-1 value-plane. **externalWrite stays false.**

## Final scope (after re-review rounds)

**Values-free BY CONSTRUCTION** (not just whitelist rendering): the service parses `/diff/rows` from `unknown` and validates every field against the backend's REAL shapes — `diffId = stockprep_diff_<16hex>`, enums against the frozen `DIFF_TYPES`/`REVIEW_STATUSES`/`CHANGE_TYPES`, `rowCount` a non-negative int, `keyFingerprint = sha16:<16hex>`. UI-unused envelope fields (reason, snapshot-line ids, path fingerprints, batch ids) are DROPPED at the boundary rather than pattern-matched, so no loose-pattern string survives for a business value to hide in. Closed union types replace the open strings.
- A malformed envelope THROWS `SNAPSHOT_DIFF_ROWS_MALFORMED` → the view's neutral unavailable state (never a silent "no diff rows"); a valid empty `[]` stays a real no-diffs result. rowCount/heldRowCount are recomputed from the RETAINED rows (never a phantom count over an empty table).
- Client/server **vocab tripwire** imports the backend cjs enums LIVE and asserts equality — a backend vocab change reddens CI instead of silently making the client drop new-kind rows.
- The full opaque 22-char `sha16:<16hex>` handle is shown (was a misleading 4-hex slice).

**View**: a lazy, collapsible "View row detail" toggle — rows GET only on first open, re-fetched fresh per batch, 404-soft. All THREE async loaders (batch list, diff summary, row detail) carry a **monotonic seq guard** so a late response for the previous project/batch is dropped (A→B→A deferred-response tests prove the seq is the load-bearing guard, not the id-match).

## Verification
Parser + vocab tests (`bomSnapshotDiff.spec.ts`, wired into integration-guard): valid kept, a value in each retained field drops that row, malformed throws, empty→zero, counts recomputed, vocab matches backend. View specs: lazy, on-demand, values-free (planted values never render), 404-soft, empty, A→B and A→B→A stale-drop. **Mutations**: vocab drift / drop-a-validator / malformed-not-thrown / server-count / drop-a-seq → each RED. 168 stock-prep + bomSnapshotDiff web specs green; vue-tsc clean; rebased on main; `git diff --check` clean. Not armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)