### PR TITLE
perf(multitable): W0 enablement gate — batch revision emit for field-undelete rehydration + real-scale benchmark

### DIFF
--- a/packages/core-backend/scripts/benchmark-field-undelete-revision-emit.ts
+++ b/packages/core-backend/scripts/benchmark-field-undelete-revision-emit.ts
@@ -1,0 +1,221 @@
+/**
+ * W0 enablement gate (owner ruling, post-merge review of #4279/#4286): real-scale benchmark for the
+ * field-undelete rehydration revision-emit mechanism — OLD (per-record serial `recordRecordRevision` loop)
+ * vs NEW (`recordRecordRevisionsBatch`, chunked multi-row INSERT).
+ *
+ * WHAT THIS MEASURES: the exact piece of `recreateFieldFromConfig` (univer-meta.ts) that changed. The
+ * rehydration UPDATE (`UPDATE meta_records ... FROM meta_field_value_tombstones ... RETURNING ...`) is
+ * copied HERE verbatim, byte-for-byte, from the production route — it is already a single set-based
+ * statement (O(1) regardless of N) both before and after this PR, so it is NOT the bottleneck the owner
+ * flagged and is run identically in both legs to keep the comparison apples-to-apples. What changed, and
+ * what this benchmark isolates, is what happens to the UPDATE's `RETURNING` rows next: OLD emitted one
+ * `recordRecordRevision` call per row (N sequential round trips); NEW emits them all via ONE
+ * `recordRecordRevisionsBatch` call (chunked at 1000 rows/statement).
+ *
+ * WHY DIRECT-SEED, NOT THE FULL DELETE-FIELD HTTP ENDPOINT: `meta_field_value_tombstones.config_revision_id`
+ * is deliberately NOT a foreign key (see `zzzz20260708090000_create_meta_tombstone_tables.ts`'s own
+ * docstring — an FK here would block/cascade the very delete that's about to remove the referenced row).
+ * That means a realistic tombstone set can be seeded directly with a manufactured revision id, without
+ * paying for (and adding unrelated noise from) the full field-delete cascade. The rehydration UPDATE this
+ * benchmark runs is unmodified production SQL either way.
+ *
+ * WHY THE SAME SEED DATA IS REUSED FOR BOTH LEGS: each leg runs inside its own `BEGIN ... ROLLBACK`
+ * transaction (mirroring the real route's `poolManager.transaction()` wrapper), so the UPDATE's effects
+ * (data merge + version bump) and every `meta_record_revisions` row it inserted are undone after each leg
+ * — the same N pristine (field-absent) records + their tombstones can be rehydrated a second time for the
+ * NEW leg. This is a fairness property, not a shortcut: it guarantees both legs race identical rows in
+ * identical order, not two independently-seeded (and therefore not-quite-comparable) datasets.
+ *
+ * Usage: DATABASE_URL=postgresql://... pnpm --filter @metasheet/core-backend exec tsx \
+ *   scripts/benchmark-field-undelete-revision-emit.ts [N]
+ * N defaults to 10000; pass a smaller value (e.g. 5000) if seeding 10k is too slow in your environment.
+ */
+import { performance } from 'node:perf_hooks'
+import { randomUUID } from 'node:crypto'
+
+import { poolManager } from '../src/integration/db/connection-pool'
+import { recordRecordRevision, recordRecordRevisionsBatch, type QueryFn, type RecordRevisionInput } from '../src/multitable/record-history-service'
+
+const N = Number(process.argv[2] ?? process.env.BENCH_N ?? 10000)
+const TS = Date.now()
+const BASE = `bench_tfrr_${TS}`
+const SHEET = `bench_sheet_tfrr_${TS}`
+const FIELD = `bench_fld_tfrr_${TS}`
+const SEED_CHUNK = 1000 // bulk-seed INSERT chunk size (separate from the thing being benchmarked)
+
+type Counted = { query: QueryFn; count: () => number }
+
+/** Wrap a raw transaction client's query into a `QueryFn` that also counts every statement issued —
+ * the "statement count" half of the benchmark's report. */
+function countedQuery(raw: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>): Counted {
+  let n = 0
+  const query: QueryFn = async (sql, params) => {
+    n += 1
+    return raw(sql, params)
+  }
+  return { query, count: () => n }
+}
+
+async function seed(): Promise<string[]> {
+  const pool = poolManager.get()
+  await pool.query('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'Bench Base'])
+  await pool.query('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, SHEET])
+  await pool.query('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FIELD, SHEET, 'BenchVal', 'string', '{}', 1])
+
+  const recordIds = Array.from({ length: N }, (_, i) => `bench_rec_${TS}_${i}`)
+  const deleteRevisionId = randomUUID()
+
+  for (let start = 0; start < N; start += SEED_CHUNK) {
+    const chunk = recordIds.slice(start, start + SEED_CHUNK)
+
+    // meta_records: id, sheet_id, data, version — 4 cols/row. Live row does NOT carry FIELD (post-field-
+    // delete state) — the UPDATE's `NOT (data ? $3)` guard requires this so the rehydration has rows to touch.
+    const recordParams: unknown[] = []
+    const recordTuples: string[] = []
+    chunk.forEach((id, i) => {
+      const idx = start + i
+      recordTuples.push(`($${i * 3 + 1}, $${i * 3 + 2}, $${i * 3 + 3}::jsonb, 1)`)
+      recordParams.push(id, SHEET, JSON.stringify({ other: `x${idx}` }))
+    })
+    await poolManager.get().query(`INSERT INTO meta_records (id, sheet_id, data, version) VALUES ${recordTuples.join(', ')}`, recordParams)
+
+    // meta_field_value_tombstones: id, sheet_id, field_id, record_id, value, reason, config_revision_id — 7 cols/row.
+    const tsTuples: string[] = []
+    const tsParams: unknown[] = []
+    chunk.forEach((id, i) => {
+      const idx = start + i
+      const b = i * 6
+      tsTuples.push(`($${b + 1}::uuid, $${b + 2}, $${b + 3}, $${b + 4}, $${b + 5}::jsonb, 'field_delete', $${b + 6}::uuid)`)
+      tsParams.push(randomUUID(), SHEET, FIELD, id, JSON.stringify(`val-${idx}`), deleteRevisionId)
+    })
+    await poolManager.get().query(
+      `INSERT INTO meta_field_value_tombstones (id, sheet_id, field_id, record_id, value, reason, config_revision_id) VALUES ${tsTuples.join(', ')}`,
+      tsParams,
+    )
+  }
+  return [deleteRevisionId]
+}
+
+/** Verbatim copy of the production rehydration UPDATE (univer-meta.ts ~6547) — see module docstring for
+ * why this is copied rather than imported (it's an inline statement inside a non-exported function). */
+const REHYDRATE_UPDATE_SQL = `UPDATE meta_records m
+   SET data = data || jsonb_build_object($3::text, t.value),
+       version = m.version + 1,
+       updated_at = now()
+   FROM meta_field_value_tombstones t
+   WHERE m.id = t.record_id
+     AND m.sheet_id = $2
+     AND t.config_revision_id = $1
+     AND t.field_id = $3
+     AND t.reason = 'field_delete'
+     AND NOT (m.data ? $3)
+   RETURNING m.id, m.version, m.data, t.value AS rehydrated_value`
+
+interface RehydratedRow { id: string; version: number; data: Record<string, unknown>; rehydrated_value: unknown }
+
+async function runLeg(deleteRevisionId: string, mode: 'old-loop' | 'new-batch'): Promise<{ wallMs: number; statements: number; rowsRehydrated: number }> {
+  const rawClient = await poolManager.get().getInternalPool().connect()
+  const { query, count } = countedQuery((sql, params) => rawClient.query(sql, params) as Promise<{ rows: unknown[]; rowCount?: number | null }>)
+  try {
+    await query('BEGIN')
+    const start = performance.now()
+    const updateResult = (await query(REHYDRATE_UPDATE_SQL, [deleteRevisionId, SHEET, FIELD])) as unknown as { rows: RehydratedRow[] }
+    const rows = updateResult.rows
+    const recordBatchId = randomUUID()
+    if (mode === 'old-loop') {
+      for (const row of rows) {
+        await recordRecordRevision(query, {
+          sheetId: SHEET,
+          recordId: String(row.id),
+          version: Number(row.version) || 0,
+          action: 'update',
+          source: 'restore',
+          actorId: 'bench-actor',
+          changedFieldIds: [FIELD],
+          patch: { [FIELD]: row.rehydrated_value },
+          snapshot: row.data,
+          batchId: recordBatchId,
+        })
+      }
+    } else {
+      const inputs: RecordRevisionInput[] = rows.map((row) => ({
+        sheetId: SHEET,
+        recordId: String(row.id),
+        version: Number(row.version) || 0,
+        action: 'update',
+        source: 'restore',
+        actorId: 'bench-actor',
+        changedFieldIds: [FIELD],
+        patch: { [FIELD]: row.rehydrated_value },
+        snapshot: row.data,
+        batchId: recordBatchId,
+      }))
+      await recordRecordRevisionsBatch(query, inputs)
+    }
+    const wallMs = performance.now() - start
+    // ROLLBACK (not COMMIT): undoes the UPDATE + the revision inserts, so the SAME pristine seed rows
+    // (still missing FIELD) are available for the next leg — see module docstring's fairness note.
+    await query('ROLLBACK')
+    return { wallMs, statements: count(), rowsRehydrated: rows.length }
+  } catch (e) {
+    await query('ROLLBACK').catch(() => {})
+    throw e
+  } finally {
+    rawClient.release()
+  }
+}
+
+async function cleanup(): Promise<void> {
+  const pool = poolManager.get()
+  await pool.query('DELETE FROM meta_field_value_tombstones WHERE sheet_id = $1', [SHEET]).catch(() => {})
+  await pool.query('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+  await pool.query('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
+  await pool.query('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+  await pool.query('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+  await pool.query('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+}
+
+async function main(): Promise<void> {
+  if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL is required.')
+    process.exit(1)
+  }
+  console.log(`W0 field-undelete revision-emit benchmark: N = ${N} tombstoned records`)
+  console.log('Seeding...')
+  const seedStart = performance.now()
+  const [deleteRevisionId] = await seed()
+  console.log(`Seed complete in ${(performance.now() - seedStart).toFixed(0)}ms`)
+
+  try {
+    console.log('\nRunning OLD leg (per-record serial recordRecordRevision loop)...')
+    const oldResult = await runLeg(deleteRevisionId, 'old-loop')
+    console.log(`  rows rehydrated: ${oldResult.rowsRehydrated}`)
+    console.log(`  statements issued (incl. BEGIN/UPDATE/ROLLBACK): ${oldResult.statements}`)
+    console.log(`  wall time: ${oldResult.wallMs.toFixed(1)}ms`)
+
+    console.log('\nRunning NEW leg (recordRecordRevisionsBatch, chunked)...')
+    const newResult = await runLeg(deleteRevisionId, 'new-batch')
+    console.log(`  rows rehydrated: ${newResult.rowsRehydrated}`)
+    console.log(`  statements issued (incl. BEGIN/UPDATE/ROLLBACK): ${newResult.statements}`)
+    console.log(`  wall time: ${newResult.wallMs.toFixed(1)}ms`)
+
+    console.log('\n=== Summary ===')
+    console.log(`N = ${N}`)
+    console.log(`OLD: ${oldResult.statements} statements, ${oldResult.wallMs.toFixed(1)}ms`)
+    console.log(`NEW: ${newResult.statements} statements, ${newResult.wallMs.toFixed(1)}ms`)
+    console.log(`statement reduction: ${(oldResult.statements / newResult.statements).toFixed(1)}x`)
+    console.log(`wall-time speedup: ${(oldResult.wallMs / newResult.wallMs).toFixed(1)}x`)
+  } finally {
+    console.log('\nCleaning up seed data...')
+    await cleanup()
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e)
+    cleanup()
+      .catch(() => {})
+      .finally(() => process.exit(1))
+  })

--- a/packages/core-backend/src/multitable/record-history-service.ts
+++ b/packages/core-backend/src/multitable/record-history-service.ts
@@ -134,6 +134,100 @@ export async function recordRecordRevision(query: QueryFn, input: RecordRevision
   return id
 }
 
+// W0 enablement gate (owner ruling, post-merge review of #4279/#4286): the field-undelete rehydration site
+// (`recreateFieldFromConfig` in univer-meta.ts) previously called `recordRecordRevision` once PER rehydrated
+// record, serially, inside the same transaction — an O(N) round-trip chain that the owner ruled must become a
+// single batch write before the field-undelete flag can ever be enabled (the tombstone cap default allows up
+// to 50,000 rows per undelete). `recordRecordRevisionsBatch` is that batch path: one multi-row INSERT per
+// chunk, with EXACTLY the same column semantics/defaults as `recordRecordRevision` above (same id generation
+// via `randomUUID()` when omitted, same `changedFieldIds` de-dup, same `source`/`batchId` defaults, same
+// `snapshot`/`patch` JSON handling, same deploy-window-safe `restoredFromVersion` column probe — reusing
+// `hasRestoredFromVersionColumn` so the two helpers can never disagree about whether the column exists).
+const BATCH_CHUNK_ROWS = 1000
+
+/**
+ * Batch counterpart to `recordRecordRevision`: inserts `inputs.length` rows with as few statements as
+ * possible instead of one `recordRecordRevision` call per row. Runs on the caller's own `QueryFn` (so it
+ * participates in the caller's transaction exactly like the single-row helper), and returns the ids in the
+ * same order as `inputs` (mirroring `recordRecordRevision`'s single-id return).
+ *
+ * Chunking math: each row binds 11 params in the base shape (12 if any row in the whole batch carries a
+ * non-null `restoredFromVersion` AND the column exists — see below), so `BATCH_CHUNK_ROWS = 1000` keeps a
+ * full chunk at ≤12,000 bound parameters, comfortably under PostgreSQL's 65,535-parameter-per-statement
+ * ceiling (drivers/pgbouncer add their own lower practical ceilings too — 1000 rows/statement stays well
+ * clear of those as well). A tombstone-cap-sized undelete (50,000 rows) becomes 50 statements instead of
+ * 50,000 — the exact O(N)→O(N/1000) shape the owner's enablement gate asked for.
+ *
+ * `restoredFromVersion` handling mirrors the single-row helper's deploy-window guard, but decided ONCE for
+ * the whole batch (not per chunk, not per row) so every chunk of a single call uses the SAME column list —
+ * required for a well-formed multi-row `INSERT ... VALUES (...), (...), ...` (every tuple must have the same
+ * arity). If ANY input in the batch sets a non-null `restoredFromVersion` AND the column exists, EVERY row
+ * in EVERY chunk is inserted with the extended (12-column) shape — rows that didn't set it get an explicit
+ * SQL `NULL` for that column, which is byte-identical in the stored row to the base shape omitting it
+ * entirely. If the column does not exist (pre-migration deploy window), every row degrades to the base shape
+ * and any `restoredFromVersion` values are silently dropped — identical to the single-row helper's own
+ * degrade behavior.
+ */
+export async function recordRecordRevisionsBatch(query: QueryFn, inputs: RecordRevisionInput[]): Promise<string[]> {
+  if (inputs.length === 0) return []
+
+  const prepared = inputs.map((input) => {
+    const id = input.id ?? randomUUID()
+    return {
+      id,
+      sheetId: input.sheetId,
+      recordId: input.recordId,
+      version: input.version,
+      action: input.action,
+      source: input.source ?? 'rest',
+      actorId: input.actorId ?? null,
+      changedFieldIds: Array.from(new Set((input.changedFieldIds ?? []).filter(Boolean))),
+      patch: JSON.stringify(input.patch ?? {}),
+      snapshot: input.snapshot === undefined ? null : JSON.stringify(input.snapshot),
+      batchId: input.batchId ?? id,
+      restoredFromVersion: input.restoredFromVersion ?? null,
+    }
+  })
+
+  const anyRestoredFromVersion = prepared.some((row) => row.restoredFromVersion !== null)
+  const useExtendedShape = anyRestoredFromVersion && (await hasRestoredFromVersionColumn(query))
+  const columns = useExtendedShape
+    ? ['id', 'sheet_id', 'record_id', 'version', 'action', 'source', 'actor_id', 'changed_field_ids', 'patch', 'snapshot', 'batch_id', 'restored_from_version']
+    : ['id', 'sheet_id', 'record_id', 'version', 'action', 'source', 'actor_id', 'changed_field_ids', 'patch', 'snapshot', 'batch_id']
+  const paramsPerRow = columns.length
+
+  for (let start = 0; start < prepared.length; start += BATCH_CHUNK_ROWS) {
+    const chunk = prepared.slice(start, start + BATCH_CHUNK_ROWS)
+    const params: unknown[] = []
+    const valueTuples: string[] = []
+    chunk.forEach((row, i) => {
+      const base = i * paramsPerRow
+      const placeholders = [
+        `$${base + 1}::uuid`,
+        `$${base + 2}`,
+        `$${base + 3}`,
+        `$${base + 4}`,
+        `$${base + 5}`,
+        `$${base + 6}`,
+        `$${base + 7}`,
+        `$${base + 8}::text[]`,
+        `$${base + 9}::jsonb`,
+        `$${base + 10}::jsonb`,
+        `$${base + 11}`,
+      ]
+      params.push(row.id, row.sheetId, row.recordId, row.version, row.action, row.source, row.actorId, row.changedFieldIds, row.patch, row.snapshot, row.batchId)
+      if (useExtendedShape) {
+        placeholders.push(`$${base + 12}`)
+        params.push(row.restoredFromVersion)
+      }
+      valueTuples.push(`(${placeholders.join(', ')})`)
+    })
+    await query(`INSERT INTO meta_record_revisions (${columns.join(', ')}) VALUES ${valueTuples.join(', ')}`, params)
+  }
+
+  return prepared.map((row) => row.id)
+}
+
 /**
  * W0-1 (OD-W0-1 mechanism (b)) — record a lock/unlock version bump as a chain marker in the independent
  * `meta_record_version_markers` table, so the generation-aware contiguity precheck does not read the bump

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -235,7 +235,7 @@ import {
   createYjsInvalidationPostCommitHook,
   type YjsInvalidator,
 } from '../multitable/post-commit-hooks'
-import { listRecordRevisions, recordRecordRevision, recordVersionMarker, type RecordRevisionEntry } from '../multitable/record-history-service'
+import { listRecordRevisions, recordRecordRevision, recordRecordRevisionsBatch, recordVersionMarker, type RecordRevisionEntry, type RecordRevisionInput } from '../multitable/record-history-service'
 import { replayInboundLinks, isRecordUndeleteInboundEnabled } from '../multitable/inbound-link-replay'
 import { countInboundLinkCaptureRows, insertInboundLinkTombstones } from '../multitable/tombstone-capture'
 
@@ -6542,7 +6542,7 @@ async function recreateFieldFromConfig(query: TxnQuery, opts: {
     // retype revert's `applyLossyRetypeCellRewrite` above) — `restoredFromVersion` stays reserved for the
     // three record-version restore routes per `RecordRevisionInput`'s own doc comment.
     // lock-exempt: field-undelete schema op — rehydrates the recreated field's key sheet-wide (mirror of the field-delete drop at ~6116); not a per-record user edit, and NOT(data?key) never clobbers.
-    // revision-emitted: field-undelete rehydration — recordRecordRevision (one per rehydrated record) below, same txn.
+    // revision-emitted: field-undelete rehydration — recordRecordRevisionsBatch (batched multi-row INSERT) below, same txn.
     const rehydrated = (await query(
       `UPDATE meta_records m
        SET data = data || jsonb_build_object($3::text, t.value),
@@ -6565,20 +6565,26 @@ async function recreateFieldFromConfig(query: TxnQuery, opts: {
       // the field-order-shift + field-create CONFIG revisions (a different history channel) — reusing it
       // here would cross-wire the two channels' batch grouping.
       const recordBatchId = randomUUID()
-      for (const row of rehydratedRows) {
-        await recordRecordRevision(query, {
-          sheetId,
-          recordId: String(row.id),
-          version: Number(row.version) || 0,
-          action: 'update',
-          source: 'restore',
-          actorId,
-          changedFieldIds: [fieldId],
-          patch: { [fieldId]: row.rehydrated_value as unknown },
-          snapshot: normalizeJson(row.data),
-          batchId: recordBatchId,
-        })
-      }
+      // W0 enablement gate (owner ruling, post-merge review of #4279/#4286): this used to be a per-record
+      // `recordRecordRevision` call in a serial loop — an O(N) round-trip chain the owner ruled must become
+      // a batch write before the field-undelete flag can ever be enabled (the tombstone cap default allows
+      // up to 50,000 rows). `recordRecordRevisionsBatch` collects every rehydrated row's revision input
+      // here and emits them as ONE call (internally chunked at 1000 rows/statement), same transaction, same
+      // per-row column semantics (id/version/patch/snapshot/batchId) as the old loop — see
+      // `record-history-service.ts` for the chunking math and the deploy-window-safe column probe reuse.
+      const revisionInputs: RecordRevisionInput[] = rehydratedRows.map((row) => ({
+        sheetId,
+        recordId: String(row.id),
+        version: Number(row.version) || 0,
+        action: 'update',
+        source: 'restore',
+        actorId,
+        changedFieldIds: [fieldId],
+        patch: { [fieldId]: row.rehydrated_value as unknown },
+        snapshot: normalizeJson(row.data),
+        batchId: recordBatchId,
+      }))
+      await recordRecordRevisionsBatch(query, revisionInputs)
     }
     // Link edges: only between two records that are BOTH currently alive (design-lock §4 R1).
     // Idempotence: meta_links has no unique on (field_id, record_id, foreign_record_id) (PK is the

--- a/packages/core-backend/tests/integration/multitable-tombstone-field-rehydrate-revision-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-tombstone-field-rehydrate-revision-realdb.test.ts
@@ -265,6 +265,68 @@ describeIfDatabase('W0 tail — field-undelete rehydration emits revisions (real
     expect(diesRevs[0]?.action).toBe('create')
   })
 
+  // W0 enablement gate (owner ruling, post-merge review of #4279/#4286): the per-record serial
+  // `recordRecordRevision` loop was replaced with `recordRecordRevisionsBatch` (one chunked multi-row
+  // INSERT). The two tests above only exercise 1-2 records — not enough to catch a chunking off-by-one
+  // (e.g. an exclusive vs inclusive slice bound dropping or duplicating the LAST row of a chunk, or a
+  // wrong `base` param-offset arithmetic scrambling rows into the wrong tuple). This test rehydrates 25
+  // records in ONE field-undelete and asserts exactly 25 revisions exist, each at the correct new version,
+  // each with its OWN correct patch/snapshot (not a neighbor's) — the per-row-correctness half of the
+  // chunking proof. The numeric chunk-boundary math itself (999/1000/1001/2500 rows, exact statement
+  // counts) is unit-tested directly against `recordRecordRevisionsBatch` in
+  // `record-history-service-batch.test.ts` (no DB needed there); this real-DB test is the end-to-end
+  // complement proving the chunked INSERT actually lands correctly through the real route + real trigger
+  // surface, not just in isolation.
+  test('multi-record rehydration (25 records) produces exactly 25 revisions, each with its OWN correct per-row snapshot (chunking off-by-one / row-scramble guard)', async () => {
+    const s = await freshSheet('multi25')
+    const F = mkFieldId('multi25')
+    await insertField(s, F, 'Multi25Val', 'string', 1)
+
+    const N = 25
+    const records = Array.from({ length: N }, (_, i) => mkRecordId(`multi25_${i}`))
+    const T0 = new Date(Date.now() - 60_000).toISOString()
+    for (let i = 0; i < N; i += 1) {
+      await insertRecord(s, records[i], { [F]: `val-${i}`, other: `x${i}` })
+      await seedCreateRevision(s, records[i], { other: `x${i}` }, T0)
+    }
+
+    expect((await deleteField(F)).status).toBe(200)
+    const revF = await lastFieldDeleteRevisionId(s, F)
+
+    const p = await preview(s, revF)
+    expect(p.status).toBe(200)
+    expect(p.body?.data?.undelete?.tombstoneAvailable).toBe(true)
+    const ok = await execute(s, { revisionId: revF, previewToken: p.body.data.previewToken, confirm: 'undelete' })
+    expect(ok.status).toBe(200)
+
+    let sharedBatchId: string | null = null
+    for (let i = 0; i < N; i += 1) {
+      const row = await recordRow(records[i])
+      expect(row?.version).toBe(2)
+      expect(row?.data).toEqual({ [F]: `val-${i}`, other: `x${i}` })
+
+      const revs = await revisionsFor(records[i])
+      expect(revs).toHaveLength(2) // seeded create@1 + the batched rehydration@2 — no dupes, no drops
+      const rehydrateRev = revs.find((r) => r.version === 2)
+      expect(rehydrateRev).toMatchObject({
+        action: 'update',
+        source: 'restore',
+        actor_id: MANAGER.id,
+        changed_field_ids: [F],
+        patch: { [F]: `val-${i}` }, // THIS record's own value, never a neighbor's (row-scramble guard)
+        snapshot: { [F]: `val-${i}`, other: `x${i}` },
+      })
+      if (sharedBatchId === null) sharedBatchId = rehydrateRev?.batch_id ?? null
+      else expect(rehydrateRev?.batch_id).toBe(sharedBatchId) // LOCK-12: one shared batch across all 25
+    }
+    expect(sharedBatchId).toBeTruthy()
+
+    // Sheet-wide total: exactly N seeded creates + N batched rehydrations, nothing extra (no ghost rows
+    // from a chunk boundary being processed twice).
+    const total = await q('SELECT COUNT(*)::int AS n FROM meta_record_revisions WHERE sheet_id = $1', [s])
+    expect(Number((total.rows[0] as { n: number }).n)).toBe(N * 2)
+  })
+
   // Owner post-merge review of #4279 (Medium finding #2): the two tests above prove the success path and
   // the zero-row leg, but neither forces a `meta_record_revisions` INSERT failure AFTER the row data/version
   // updates — so neither actually pins that the WHOLE field-undelete (field re-creation + its order-shift +

--- a/packages/core-backend/tests/unit/record-history-service-batch.test.ts
+++ b/packages/core-backend/tests/unit/record-history-service-batch.test.ts
@@ -1,0 +1,209 @@
+/**
+ * W0 enablement gate (owner ruling, post-merge review of #4279/#4286): unit coverage for
+ * `recordRecordRevisionsBatch` — the batch counterpart to `recordRecordRevision` the field-undelete
+ * rehydration site now calls instead of a per-record serial loop (see `univer-meta.ts`'s
+ * `recreateFieldFromConfig`). No DB here — a mock `QueryFn` records every statement + its params so these
+ * tests pin the CHUNKING MATH (statement count at/around the 1000-row boundary) and the COLUMN-SEMANTICS
+ * PARITY with `recordRecordRevision` (same id generation, same defaults, same JSON handling) without a real
+ * Postgres. The real-DB spec (`multitable-tombstone-field-rehydrate-revision-realdb.test.ts`) covers the
+ * end-to-end wiring and the atomicity golden; this file is the fast, deterministic complement that a real-DB
+ * run cannot cheaply exercise at N=1000+ rows.
+ */
+import { describe, expect, test, vi } from 'vitest'
+
+import { recordRecordRevision, recordRecordRevisionsBatch, type QueryFn, type RecordRevisionInput } from '../../src/multitable/record-history-service'
+
+function mockQuery(): { query: QueryFn; calls: Array<{ sql: string; params: unknown[] }> } {
+  const calls: Array<{ sql: string; params: unknown[] }> = []
+  const query: QueryFn = async (sql, params) => {
+    calls.push({ sql, params: params ?? [] })
+    // The `restored_from_version` column-existence probe (SELECT ... information_schema.columns) must
+    // return zero rows so callers that never set restoredFromVersion never trip the extended-shape path
+    // (mirrors the base fixture's schema: no such column configured in this mock).
+    if (/information_schema\.columns/.test(sql)) return { rows: [], rowCount: 0 }
+    return { rows: [], rowCount: 0 }
+  }
+  return { query, calls }
+}
+
+function input(i: number, overrides: Partial<RecordRevisionInput> = {}): RecordRevisionInput {
+  return {
+    sheetId: 'sheet_1',
+    recordId: `rec_${i}`,
+    version: 2,
+    action: 'update',
+    source: 'restore',
+    actorId: 'actor_1',
+    changedFieldIds: ['fld_1'],
+    patch: { fld_1: `v${i}` },
+    snapshot: { fld_1: `v${i}`, other: 'x' },
+    batchId: 'batch_shared',
+    ...overrides,
+  }
+}
+
+describe('recordRecordRevisionsBatch — zero-row and single-chunk shape', () => {
+  test('zero rows: no query is issued at all, returns []', async () => {
+    const { query, calls } = mockQuery()
+    const ids = await recordRecordRevisionsBatch(query, [])
+    expect(ids).toEqual([])
+    expect(calls).toHaveLength(0)
+  })
+
+  test('a handful of rows: exactly ONE INSERT statement, one VALUES tuple per row, in input order', async () => {
+    const { query, calls } = mockQuery()
+    const inputs = [input(1), input(2), input(3)]
+    const ids = await recordRecordRevisionsBatch(query, inputs)
+    expect(ids).toHaveLength(3)
+    expect(calls).toHaveLength(1)
+    const [{ sql, params }] = calls
+    expect(sql).toMatch(/^INSERT INTO meta_record_revisions/)
+    // 3 rows * 11 base columns (no restoredFromVersion anywhere in this fixture) = 33 params.
+    expect(params).toHaveLength(33)
+    // 3 VALUES tuples.
+    expect((sql.match(/\(\$/g) ?? []).length).toBe(3)
+  })
+
+  test('column semantics parity with recordRecordRevision: same defaults for id/batchId/source/changedFieldIds/snapshot', async () => {
+    const { query: singleQuery, calls: singleCalls } = mockQuery()
+    const { query: batchQuery, calls: batchCalls } = mockQuery()
+    const bareInput: RecordRevisionInput = { sheetId: 's', recordId: 'r1', version: 1, action: 'create' }
+
+    await recordRecordRevision(singleQuery, bareInput)
+    await recordRecordRevisionsBatch(batchQuery, [bareInput])
+
+    const singleParams = singleCalls[0]?.params ?? []
+    const batchParams = batchCalls[0]?.params ?? []
+    // Column order for both is (id, sheet_id, record_id, version, action, source, actor_id,
+    // changed_field_ids, patch, snapshot, batch_id) — indices 0..10.
+    expect(batchParams).toHaveLength(11)
+    expect(singleParams).toHaveLength(11)
+    // id (0) is a random uuid on both sides — just check both are non-empty strings, not equal to each other.
+    expect(typeof batchParams[0]).toBe('string')
+    expect(typeof singleParams[0]).toBe('string')
+    // sheet_id, record_id, version, action match verbatim.
+    expect(batchParams.slice(1, 5)).toEqual(singleParams.slice(1, 5))
+    // source defaults to 'rest' on both when omitted.
+    expect(batchParams[5]).toBe('rest')
+    expect(singleParams[5]).toBe('rest')
+    // actor_id defaults to null on both.
+    expect(batchParams[6]).toBeNull()
+    expect(singleParams[6]).toBeNull()
+    // changed_field_ids defaults to [] on both (de-duped/filtered).
+    expect(batchParams[7]).toEqual([])
+    expect(singleParams[7]).toEqual([])
+    // patch defaults to '{}' JSON on both.
+    expect(batchParams[8]).toBe('{}')
+    expect(singleParams[8]).toBe('{}')
+    // snapshot defaults to null (input omitted `snapshot` entirely) on both.
+    expect(batchParams[9]).toBeNull()
+    expect(singleParams[9]).toBeNull()
+    // batch_id defaults to the row's OWN id (batchId omitted) on both — i.e. batchParams[10] === batchParams[0].
+    expect(batchParams[10]).toBe(batchParams[0])
+    expect(singleParams[10]).toBe(singleParams[0])
+  })
+
+  test('changedFieldIds is de-duplicated and falsy-filtered, matching recordRecordRevision', async () => {
+    const { query, calls } = mockQuery()
+    await recordRecordRevisionsBatch(query, [input(1, { changedFieldIds: ['a', 'a', '', 'b', 'a'] })])
+    expect(calls[0]?.params[7]).toEqual(['a', 'b'])
+  })
+
+  test('an explicit id is honored (not overwritten by a random uuid), mirroring recordRecordRevision', async () => {
+    const { query, calls } = mockQuery()
+    await recordRecordRevisionsBatch(query, [input(1, { id: 'fixed-id-1' })])
+    expect(calls[0]?.params[0]).toBe('fixed-id-1')
+  })
+
+  test('a shared explicit batchId across every row is preserved verbatim (LOCK-12 grouping)', async () => {
+    const { query, calls } = mockQuery()
+    const inputs = [input(1, { batchId: 'shared-batch' }), input(2, { batchId: 'shared-batch' }), input(3, { batchId: 'shared-batch' })]
+    await recordRecordRevisionsBatch(query, inputs)
+    const params = calls[0]?.params ?? []
+    // Row i's batch_id is at offset i*11 + 10.
+    expect(params[10]).toBe('shared-batch')
+    expect(params[21]).toBe('shared-batch')
+    expect(params[32]).toBe('shared-batch')
+  })
+
+  test('returned ids are in the SAME order as the input rows', async () => {
+    const { query } = mockQuery()
+    const inputs = [input(1, { id: 'id-a' }), input(2, { id: 'id-b' }), input(3, { id: 'id-c' })]
+    const ids = await recordRecordRevisionsBatch(query, inputs)
+    expect(ids).toEqual(['id-a', 'id-b', 'id-c'])
+  })
+})
+
+describe('recordRecordRevisionsBatch — chunking math at the 1000-row boundary', () => {
+  test('exactly 1000 rows: ONE statement', async () => {
+    const { query, calls } = mockQuery()
+    const inputs = Array.from({ length: 1000 }, (_, i) => input(i))
+    await recordRecordRevisionsBatch(query, inputs)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.params).toHaveLength(1000 * 11)
+  })
+
+  test('1001 rows (one past the boundary): TWO statements, split 1000 + 1, no row dropped or duplicated', async () => {
+    const { query, calls } = mockQuery()
+    const inputs = Array.from({ length: 1001 }, (_, i) => input(i, { id: `id-${i}` }))
+    const ids = await recordRecordRevisionsBatch(query, inputs)
+    expect(calls).toHaveLength(2)
+    expect(calls[0]?.params).toHaveLength(1000 * 11)
+    expect(calls[1]?.params).toHaveLength(1 * 11)
+    expect(ids).toHaveLength(1001)
+    expect(ids).toEqual(inputs.map((i) => i.id))
+    // No id appears twice across the two statements' params (id is always param 0 of its row's tuple).
+    expect(new Set(ids).size).toBe(1001)
+  })
+
+  test('2500 rows: THREE statements (1000 + 1000 + 500), preserving row order across chunks', async () => {
+    const { query, calls } = mockQuery()
+    const inputs = Array.from({ length: 2500 }, (_, i) => input(i, { id: `id-${i}` }))
+    const ids = await recordRecordRevisionsBatch(query, inputs)
+    expect(calls).toHaveLength(3)
+    expect(calls[0]?.params).toHaveLength(1000 * 11)
+    expect(calls[1]?.params).toHaveLength(1000 * 11)
+    expect(calls[2]?.params).toHaveLength(500 * 11)
+    expect(ids).toEqual(inputs.map((i) => i.id))
+  })
+
+  test('999 rows (one short of the boundary): ONE statement, all 999 present', async () => {
+    const { query, calls } = mockQuery()
+    const inputs = Array.from({ length: 999 }, (_, i) => input(i, { id: `id-${i}` }))
+    const ids = await recordRecordRevisionsBatch(query, inputs)
+    expect(calls).toHaveLength(1)
+    expect(ids).toHaveLength(999)
+  })
+})
+
+describe('recordRecordRevisionsBatch — restoredFromVersion deploy-window parity', () => {
+  test('column absent (mock schema has no restored_from_version): every row degrades to the base 11-column shape, restoredFromVersion silently dropped — mirrors recordRecordRevision', async () => {
+    const { query, calls } = mockQuery()
+    await recordRecordRevisionsBatch(query, [input(1, { restoredFromVersion: 7 })])
+    // Base shape stays 11 params/row when the column probe returns absent.
+    expect(calls.find((c) => /^INSERT INTO meta_record_revisions/.test(c.sql))?.params).toHaveLength(11)
+  })
+
+  test('no row sets restoredFromVersion: the column-existence probe is never even issued (short-circuited)', async () => {
+    const { query, calls } = mockQuery()
+    await recordRecordRevisionsBatch(query, [input(1), input(2)])
+    expect(calls.some((c) => /information_schema\.columns/.test(c.sql))).toBe(false)
+  })
+
+  test('column present: EVERY row in the batch gets the extended 12-column shape, including rows that did not set restoredFromVersion (explicit NULL for those)', async () => {
+    const calls: Array<{ sql: string; params: unknown[] }> = []
+    const query: QueryFn = async (sql, params) => {
+      calls.push({ sql, params: params ?? [] })
+      if (/information_schema\.columns/.test(sql)) return { rows: [{ '?column?': 1 }], rowCount: 1 }
+      return { rows: [], rowCount: 0 }
+    }
+    const inputs = [input(1, { restoredFromVersion: 5 }), input(2)] // second row omits it
+    await recordRecordRevisionsBatch(query, inputs)
+    const insertCall = calls.find((c) => /^INSERT INTO meta_record_revisions/.test(c.sql))
+    expect(insertCall?.sql).toMatch(/restored_from_version/)
+    expect(insertCall?.params).toHaveLength(2 * 12)
+    // Row 0's restoredFromVersion (param index 11) is 5; row 1's (param index 23) is explicit null.
+    expect(insertCall?.params[11]).toBe(5)
+    expect(insertCall?.params[23]).toBeNull()
+  })
+})


### PR DESCRIPTION
## Owner-gate citation

Owner ruling, post-merge review of #4279 (rehydration revision-emit, `8b483b7f5`) and #4286 (two-point
wiring + atomicity golden, follow-up): **before the field-undelete flag can ever be enabled**, the
per-record serial `recordRecordRevision` loop in `recreateFieldFromConfig`'s rehydration path
(`packages/core-backend/src/routes/univer-meta.ts` ~L6546) must be replaced with a batch approach, OR the
tombstone cap must be lowered + a real-scale benchmark provided. #4286's own body explicitly docketed this
as separate, unattempted work: *"The scale/batch-helper item mentioned in the task brief is a separate
enablement gate and was **not** attempted here, per instruction — docketed separately."* This PR is that
docket, choosing the **batch path** (preferred per the task brief) over lowering the cap.

**The flag stays OFF.** This PR satisfies the enablement precondition; enablement itself remains a separate,
still-pending owner decision (unaffected by this PR — no flag, no route-gating logic touched).

## What changed

`packages/core-backend/src/multitable/record-history-service.ts` — new `recordRecordRevisionsBatch(query,
inputs)`:

- One multi-row `INSERT ... VALUES (...), (...), ...` per **1000-row chunk**, instead of one
  `recordRecordRevision` call (one round trip) per row.
- **Chunking math**: base shape binds 11 params/row (`id, sheet_id, record_id, version, action, source,
  actor_id, changed_field_ids, patch, snapshot, batch_id`); 12/row if the batch's `restoredFromVersion`
  extended shape is in play. `1000 rows × 12 params = 12,000` — comfortably under PostgreSQL's
  65,535-bound-parameter-per-statement ceiling, with headroom against any lower practical driver/pgbouncer
  ceiling too. A tombstone-cap-sized undelete (50,000 rows, the current default max) becomes **50
  statements instead of 50,000**.
- **Exactly the same column semantics as `recordRecordRevision`**: same `randomUUID()` id generation when
  `id` is omitted, same `changedFieldIds` de-dup/filter, same `source`/`batchId` defaults, same
  `patch`/`snapshot` JSON stringify handling, and it **reuses** the single-row helper's own
  `hasRestoredFromVersionColumn` deploy-window probe (decided ONCE per batch call, not per row/chunk, since
  every VALUES tuple in a multi-row INSERT must share the same column arity) — so the two helpers can never
  disagree about whether the `restored_from_version` column exists.
- Zero rows in → zero statements out, returns `[]` immediately (no BEGIN-adjacent no-op query).
- Takes the caller's own `QueryFn`, so it runs inside the caller's transaction exactly like the single-row
  helper — no new connection, no new txn boundary.

`packages/core-backend/src/routes/univer-meta.ts` — `recreateFieldFromConfig`'s rehydration site now
collects the `RETURNING` rows from the (unchanged) tombstone-rehydration `UPDATE` into a
`RecordRevisionInput[]` and calls `recordRecordRevisionsBatch` once, same transaction, after the UPDATE.
**Zero other semantics changed**: version = the post-bump version per row (unchanged), full post-write
snapshot per row (unchanged), patch = the rehydrated field only (unchanged), `source: 'restore'`
(unchanged), `actorId` unchanged, shared `batchId` across the whole rehydration (unchanged, LOCK-12), and a
zero-row UPDATE still emits nothing (unchanged — `recordRecordRevisionsBatch([])` is a no-op).

**OD-6 disposition markers**: the `lock-exempt:`/`revision-emitted:` comment pair sits immediately above the
(untouched) rehydration `UPDATE` statement; the diff only rewrites what happens to `RETURNING` rows
*after* that statement, so the marker-to-SQL line distance is **unchanged** (verified: both markers still
land inside the OD-6/rank-8 guards' 3-line scan window — see verification below).

## Semantics-preservation proof (which goldens pin it)

| Guarantee | Pinned by |
|---|---|
| version = post-bump version per row, full snapshot, patch = rehydrated field only, `source:'restore'`, `actorId` | Happy-path test (2 records, unchanged from #4279) |
| shared `batchId` across the whole rehydration (LOCK-12) | Happy-path test + the new 25-record test |
| zero-row UPDATE → zero revisions (no FK-less ghost) | Zero-row/concurrent-delete leg (unchanged from #4279) |
| W0-1 contiguity + content-projection both pass after rehydration | Happy-path positive control (`revert-preview` 200, unchanged) |
| **The batch INSERT hits the SAME atomicity guarantee as the old loop** — a `meta_record_revisions` INSERT failure mid-rehydration rolls back the WHOLE undelete (field re-creation, order-shift, config revision, record data/version) | **Atomicity golden (#4286), re-run against this PR — PASSED.** The scoped `BEFORE INSERT` trigger fires from inside `recordRecordRevisionsBatch` (confirmed in the stderr trace: `at Module.recordRecordRevisionsBatch (record-history-service.ts:225:5)`), and a multi-row `INSERT` is one atomic statement, so the trigger's `RAISE EXCEPTION` aborts the whole statement — the surrounding transaction still rolls back everything, exactly as before. |
| **No chunking off-by-one** (dropped/duplicated/row-scrambled revision at a chunk-adjacent index) | New 25-record real-DB test (per-row correctness) **+** new no-DB unit tests pinning exact statement counts at the 999/1000/1001/2500-row boundaries (numeric chunk-boundary proof — mutation-proofed: `BATCH_CHUNK_ROWS` mutated 1000→999, the three boundary tests went RED as expected, reverted) |
| Column-semantics parity with `recordRecordRevision` (id gen, defaults, JSON handling, `restoredFromVersion` deploy-window degrade) | New no-DB unit tests, side-by-side with `recordRecordRevision`'s own output |

## Benchmark (real Postgres 14, local Docker)

Isolates exactly the mechanism that changed: the (unmodified, verbatim-copied) production rehydration
`UPDATE` runs identically in both legs; what's measured is what happens to its `RETURNING` rows next — OLD
(`recordRecordRevision` × N, sequential) vs NEW (`recordRecordRevisionsBatch`, chunked). Script:
`packages/core-backend/scripts/benchmark-field-undelete-revision-emit.ts`. Both legs run inside their own
`BEGIN...ROLLBACK` (mirroring the real route's transaction wrapper) against the SAME seeded, pristine
(field-absent) records + tombstones — the rollback undoes each leg so the second leg gets an identical
starting state, a fairness property, not a shortcut.

| N | Leg | Statements | Wall time | Statement reduction | Wall-time speedup |
|---|---|---|---|---|---|
| 200 | OLD | 203 | 57.9ms | — | — |
| 200 | NEW | 4 | 11.0ms | 50.8x | 5.2x |
| **10,000** | **OLD** | **10,003** | **2315.2ms** | — | — |
| **10,000** | **NEW** | **13** | **729.1ms** | **769.5x** | **3.2x** |

N=10,000 is the headline number (exceeds the task's "N = 10,000 at least" floor). Statement count matches
the chunking math exactly: 10 chunks of 1000 rows = 10 INSERTs + BEGIN + UPDATE + ROLLBACK = 13 statements
(NEW) vs 10,000 individual INSERTs + the same 3 = 10,003 (OLD).

**N=50,000 (the actual tombstone-cap ceiling) was attempted but not completed**: local Docker Desktop
became unresponsive mid-run (`Connection terminated unexpectedly` — a network-level drop, not a Postgres
statement error; confirmed as host-level, not code-related, because `docker ps`/raw TCP to the container
port both became unreachable immediately afterward, independent of this benchmark's Node process). I did not
force-restart Docker Desktop since other sessions had unrelated containers running on the same daemon.
Extrapolating linearly from the N=10,000 measurement (statement count is exactly N/1000 + 3, confirmed
linear from the 200→10,000 data points): N=50,000 would be **50 chunks → 53 statements** (NEW) vs **50,003**
(OLD) — a ~943x statement-count reduction, consistent with the pattern already observed. This extrapolation
is not a substitute for a direct measurement; flagged as an explicit uncertainty below.

Wall-time speedup is markedly larger in a network-latency-bound production setting than shown here: this
Docker Postgres has sub-millisecond round-trip latency, so the 3.2x is a lower bound — the OLD loop's cost
is dominated by *count of round trips*, so any added per-round-trip latency (a real network hop vs a local
Unix/loopback socket) widens the gap between 10,003 round trips and 13 almost linearly.

## Verification bar

- **Type-check**: `pnpm -s run type-check` (`packages/core-backend`) — clean, no output, exit 0.
- **Full no-DB unit suite**: `pnpm -s exec vitest run` — **472 files passed / 177 skipped (649)**, **6532
  tests passed / 1503 skipped (8035)**, 0 failed. (An earlier run in the same session showed 2 unrelated
  files — `multitable-button-routes.test.ts`, `plm-workbench-bom-multitable-routes.test.ts` — fail under
  full-suite load; both pass 100% in isolation (63/63) and are byte-identical to `origin/main` (`git diff`
  empty), consistent with the documented supertest ephemeral-port collision flake noted in
  `vitest.config.ts`. Re-ran the full suite clean.)
- **Structural guard specs** (OD-6 / rank-8 / cross-base + the scanner's own self-tests) — **52/52 passed**;
  confirms the `lock-exempt:`/`revision-emitted:` markers at the rehydration site stayed inside their 3-line
  scan windows after the edit.
- **New no-DB unit tests** (`record-history-service-batch.test.ts`) — **14/14 passed**; mutation-proofed
  (chunk-size mutation 1000→999 turned 3 of them red, confirming they discriminate, not tautological;
  reverted, re-ran green).
- **Real DB**: fresh `postgres:14` container, `db:migrate` with CI's exact `MIGRATION_EXCLUDE` list — clean,
  all migrations applied.
- **Real-DB spec run** (`vitest.integration.config.ts`, `METASHEET_REAL_DB_TEST_STEP=1`) — **27/27 passed,
  0 failed**:
  - `multitable-tombstone-field-rehydrate-revision-realdb.test.ts` (5 tests: sentinel, happy path, zero-row
    leg, **new 25-record chunking test**, **atomicity golden**)
  - `multitable-history-contiguity-realdb.test.ts` (9 tests, unaffected — sanity control)
  - `multitable-reset-pit-realdb.test.ts` (13 tests, unaffected — sanity control)
- **Benchmark run**: N=200 and N=10,000 both completed with correct row/statement counts (see table above).

## Not done / owner-gated

- `MULTITABLE_ENABLE_CONFIG_UNDELETE` / `MULTITABLE_TOMBSTONE_CAPTURE_ENABLED` / the tombstone-cap default
  — all untouched, stay exactly as they are. This PR does not enable anything.
- N=50,000 direct measurement — attempted, blocked by a local Docker Desktop hiccup unrelated to this code;
  N=10,000 (measured) + linear extrapolation to N=50,000 given above.
- Not merged, not armed for auto-merge — left for the coordinator to gate.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>



> **Gate NIT-1 fact-check (coordinator):** the gate flagged `tests/unit/record-history-service-batch.test.ts` as unwired. Incorrect — core-backend's vitest config has no explicit `include`, so the default glob collects all of `tests/unit/**`, and the REQUIRED `test (18.x/20.x)` unit step runs exactly that (`pnpm test`, CI=true auto-run). The full no-DB file count going 471→472 with this PR confirms collection. The chunk-boundary coverage IS in the blocking gate; no wiring needed. NIT-2 (wall-time ordering may inflate the 3.2x figure; 769.5x statement math exact) stands as stated.