### PR TITLE
test(multitable): W0 docket follow-ups — reset-pit deleteScopeHash drift golden + create-path autoNumber snapshot pin

### DIFF
--- a/packages/core-backend/tests/integration/multitable-d1c-plugin-revision-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-d1c-plugin-revision-realdb.test.ts
@@ -54,13 +54,25 @@
  * hand-rolled `query: txQuery` calling `patchRecord`/`createRecord` directly could never detect (it would
  * silently supply its own transaction and stay green regardless of production wiring).
  *
+ * ALSO IN THIS FILE — docket #51 (a W0 test follow-up, unrelated to slice ②'s A2/A5 sites but colocated
+ * here because it needs the SAME real plugin-SDK `createRecord` entry point): slices ②/③ argued
+ * STRUCTURALLY, but never PINNED, what the create-path revision snapshot does with an `autoNumber`
+ * field. `records.ts`'s `createRecord` calls `allocateAutoNumberValues` (`auto-number-service.ts`) and
+ * folds the result into the SAME `patch` object written to both `meta_records.data` and the revision
+ * `snapshot` (`records.ts:591,639` — `snapshot: patch`), so the golden below pins MATERIALIZED-and-
+ * matching, not absent — see the "AutoNumber snapshot pin" describe block near the end of this file for
+ * the reality pin and the §1.3 content-projection cross-check.
+ *
  * Runs only with DATABASE_URL (plugin-tests.yml multitable real-DB job).
  */
+import express, { type Express } from 'express'
+import request from 'supertest'
 import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { MetaSheetServer } from '../../src/index'
 import { reconstructRecordsAtT } from '../../src/multitable/record-reconstructor'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -73,6 +85,10 @@ const SHEET_LINK_TARGET = `sheet_d1c2_linktgt_${TS}`
 const SHEET_FAIL_CREATE = `sheet_d1c2_failcreate_${TS}`
 const SHEET_FAIL_PATCH = `sheet_d1c2_failpatch_${TS}`
 const SHEET_RACE = `sheet_d1c2_race_${TS}`
+// Docket #51 — dedicated sheet (NOT SHEET_MAIN): an autoNumber field on SHEET_MAIN would silently join
+// every create's `patch`/snapshot and break the exact-key assertions above (e.g. Site A2's
+// `expect(Object.keys(updateRev.snapshot ?? {})).toEqual([FLD_TITLE])`), so this pin gets its own sheet.
+const SHEET_AUTONUM = `sheet_d1c2_autonum_${TS}`
 
 const FLD_TITLE = `fld_d1c2_title_${TS}`
 const FLD_NOTES = `fld_d1c2_notes_${TS}`
@@ -82,8 +98,12 @@ const FLD_RACE_TITLE = `fld_d1c2_rtitle_${TS}`
 const FLD_LINK_TITLE = `fld_d1c2_ltitle_${TS}`
 const FLD_LINK = `fld_d1c2_link_${TS}`
 const FLD_LINK_TARGET_NAME = `fld_d1c2_tgtname_${TS}`
+const FLD_AUTONUM_TITLE = `fld_d1c2_antitle_${TS}`
+const FLD_AUTONUM_SERIAL = `fld_d1c2_anserial_${TS}`
+const ACTOR = `user_d1c2_${TS}` // docket #51 only — the express app's req.user for the revert-preview cross-check
 
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+let app: Express // docket #51 only — the other goldens in this file drive the plugin SDK directly, no HTTP
 
 /** The slice of the real core API this golden drives (index.ts builds it; we do not re-declare it). */
 type CoreApiShape = {
@@ -228,6 +248,7 @@ describeIfDatabase('D-1c slice ② — plugin-SDK createRecord/patchRecord write
     await makeSheet(SHEET_FAIL_CREATE, 'D1C2 Fail Create')
     await makeSheet(SHEET_FAIL_PATCH, 'D1C2 Fail Patch')
     await makeSheet(SHEET_RACE, 'D1C2 Race')
+    await makeSheet(SHEET_AUTONUM, 'D1C2 AutoNumber') // docket #51
 
     await makeField(FLD_TITLE, SHEET_MAIN, 'Title', 'string', {}, 1)
     await makeField(FLD_NOTES, SHEET_MAIN, 'Notes', 'string', {}, 2) // 2nd field on SHEET_MAIN — G4 merge-trap golden
@@ -237,6 +258,8 @@ describeIfDatabase('D-1c slice ② — plugin-SDK createRecord/patchRecord write
     await makeField(FLD_LINK_TARGET_NAME, SHEET_LINK_TARGET, 'Name', 'string')
     await makeField(FLD_LINK_TITLE, SHEET_LINK, 'Title', 'string')
     await makeField(FLD_LINK, SHEET_LINK, 'Linked', 'link', { foreignSheetId: SHEET_LINK_TARGET })
+    await makeField(FLD_AUTONUM_TITLE, SHEET_AUTONUM, 'Title', 'string', {}, 1) // docket #51
+    await makeField(FLD_AUTONUM_SERIAL, SHEET_AUTONUM, 'Serial', 'autoNumber', {}, 2) // docket #51 — default start=1
 
     // Seed one target record for the link-edge golden (not itself under test — plain SQL insert is fine,
     // this sheet is never scanned by any §0.6/revert/reset precheck in this file).
@@ -246,10 +269,22 @@ describeIfDatabase('D-1c slice ② — plugin-SDK createRecord/patchRecord write
       SHEET_LINK_TARGET,
       JSON.stringify({ [FLD_LINK_TARGET_NAME]: 'target' }),
     ])
+
+    // Docket #51 only: a minimal express app mounting the REAL univer-meta router, so the §1.3
+    // content-projection cross-check can hit the actual `revert-preview` HTTP route (not just the
+    // internal `precheckSheetHistoryIntegrity` function) — same auth-stub pattern as
+    // `multitable-reset-pit-realdb.test.ts` / `multitable-history-incomplete-precheck-realdb.test.ts`.
+    // 'multitable:share' → canManageSheetAccess, the D2 gate revert-preview's route enforces.
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
   })
 
   afterAll(async () => {
-    for (const sheet of [SHEET_MAIN, SHEET_LINK, SHEET_LINK_TARGET, SHEET_FAIL_CREATE, SHEET_FAIL_PATCH, SHEET_RACE]) {
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {}) // docket #51
+    for (const sheet of [SHEET_MAIN, SHEET_LINK, SHEET_LINK_TARGET, SHEET_FAIL_CREATE, SHEET_FAIL_PATCH, SHEET_RACE, SHEET_AUTONUM]) {
       await q(
         'DELETE FROM meta_record_revisions WHERE record_id IN (SELECT id FROM meta_records WHERE sheet_id = $1)',
         [sheet],
@@ -547,5 +582,56 @@ describeIfDatabase('D-1c slice ② — plugin-SDK createRecord/patchRecord write
       // proxy), so there is no live row left to compare a "did it change" assertion against.
       expect(await recordRow(created.id)).toBeUndefined()
     }, 15000)
+  })
+
+  // ── Docket #51 — create-path auto-number snapshot pin ─────────────────────────────────────────────────
+  // Unrelated to sites A2/A5's REVISION-EMISSION fix above (this file's main subject) — a separate,
+  // previously-deferred NIT: slices ②/③ argued STRUCTURALLY, but never PINNED, what the create-path
+  // revision snapshot does with an autoNumber field's value. Picked THIS file (plugin creates) over the
+  // sibling `multitable-d1c-automation-revision-realdb.test.ts` (automation creates) because the plugin
+  // path's `createRecord` (`records.ts:583`) actually calls `allocateAutoNumberValues` before building
+  // its `patch` — the "cleaner", more informative fixture (a real MATERIALIZED value to pin); the
+  // automation path's `executeCreateRecord` (`automation-executor.ts:2497`) does a BARE INSERT of
+  // `config.data` with NO auto-number allocation call at all, so it would only pin an absent-field
+  // no-op, less useful as a drift trip-wire.
+  describe('AutoNumber snapshot pin (docket #51, real DB)', () => {
+    test('createRecord MATERIALIZES the auto-number value into BOTH meta_records.data AND the create revision snapshot (matching, not absent)', async () => {
+      const created = await sdk.createRecord({
+        sheetId: SHEET_AUTONUM,
+        data: { [FLD_AUTONUM_TITLE]: 'row-1' }, // autoNumber is server-readonly — never supplied by the caller
+      })
+      expect(created.version).toBe(1)
+
+      // THE REALITY PIN: allocateAutoNumberValues (auto-number-service.ts) runs BEFORE the INSERT and its
+      // result is folded into the SAME `patch` object written to meta_records.data (records.ts:591-603) —
+      // MATERIALIZED, not absent. This is the OPPOSITE shape from a formula/lookup field, which the
+      // sibling `multitable-history-incomplete-precheck-realdb.test.ts` G-HI-3 golden pins as
+      // materializing POST-commit and staying absent from the create revision (a stray write, not a
+      // fixture — that file's SHEET_F/AUTON record is raw-SQL-seeded to construct an adversarial state,
+      // never claiming to be what a real create produces).
+      expect(created.data[FLD_AUTONUM_SERIAL]).toBe(1)
+      const row = await recordRow(created.id)
+      expect(row?.data?.[FLD_AUTONUM_SERIAL]).toBe(1)
+
+      const revs = await revisionsOf(created.id)
+      expect(revs).toHaveLength(1)
+      expect(revs[0]!.action).toBe('create')
+      expect(revs[0]!.source).toBe('plugin')
+      // THE PIN: the emitted revision snapshot carries the SAME materialized value as meta_records.data —
+      // not absent, not a different value. `snapshot: patch` at records.ts:639 writes the identical
+      // object as the INSERT, so a fresh create can never independently drift the two.
+      expect(revs[0]!.snapshot?.[FLD_AUTONUM_SERIAL]).toBe(1)
+      expect(revs[0]!.snapshot?.[FLD_AUTONUM_SERIAL]).toBe(row?.data?.[FLD_AUTONUM_SERIAL])
+
+      // §1.3 content projection agrees: revert-preview must NOT content_mismatch-refuse this record even
+      // though the auto-number key sits in `data` — DERIVED_FIELD_TYPES (history-integrity-precheck.ts)
+      // excludes 'autoNumber' from the user-authored-field projection entirely (line 70:
+      // `Set(['formula', 'rollup', 'lookup', 'autoNumber'])`), so the projection's per-field loop
+      // (history-integrity-precheck.ts's `for (const fid of userFieldIds)`) never even inspects this key.
+      const asOf = await cutoffAfter(created.id, 1) // strictly after this create — nothing to revert to "now"
+      const pv = await request(app).post(`/api/multitable/sheets/${SHEET_AUTONUM}/revert-preview`).send({ asOf })
+      expect(pv.status).toBe(200) // NOT 409 content_mismatch — the exclusion holds even though the values match here
+      expect(pv.body?.data?.summary?.visibleRevertCount).toBe(0) // live == the T-state at `asOf` — nothing to revert
+    })
   })
 })

--- a/packages/core-backend/tests/integration/multitable-reset-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-reset-pit-realdb.test.ts
@@ -5,9 +5,15 @@
  * while meta revision retention is enabled; (c) PIT-2 all-or-nothing — a LOCKED
  * delete-target → 409 RESET_BLOCKED with ZERO writes (mutation-proven: drop the not-locked preflight check → D is
  * deleted → this golden fails); (d) row-deny added after preview → 409 RESET_BLOCKED with ZERO writes and no blocker
- * details; (e) ceiling → 413; (f) typed confirm:'reset' required → 400; (g) delete-set divergence — a record created
- * or edited between preview/execute → 409, NOTHING deleted; (h) single-transaction atomicity — a forced DELETE-revision
- * failure rolls back the already-started A/B reverts too; (i) PIT-7 reveal-non-composition; (j) D2 sheet-admin gate.
+ * details; (e) ceiling → 413; (f) typed confirm:'reset' required → 400; (g1/g2) delete-set divergence via an
+ * UNCAPTURED write (a record inserted/edited by raw SQL, no revision) between preview/execute → 409
+ * HISTORY_INCOMPLETE (the §0.6 precheck refuses on incomplete history BEFORE the identity check ever runs);
+ * (g3) delete-set HASH divergence via a CAPTURE-COMPLETE write (a record created through the REAL plugin-SDK
+ * entry point — history stays complete) → 409 PREVIEW_IDENTITY_INVALID, the deleteScopeHash re-comparison
+ * catching it instead (docket #46 — deferred during the §0.6 precheck work because the pre-capture-complete
+ * world could not construct this scenario without HISTORY_INCOMPLETE masking it first); (h) single-transaction
+ * atomicity — a forced DELETE-revision failure rolls back the already-started A/B reverts too; (i) PIT-7
+ * reveal-non-composition; (j) D2 sheet-admin gate.
  * Runs only with DATABASE_URL.
  */
 import express, { type Express } from 'express'
@@ -18,6 +24,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { MetaSheetServer } from '../../src/index'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
@@ -37,6 +44,35 @@ const inTrash = async (id: string) => (await q('SELECT record_id FROM meta_recor
 const rev = (id: string, version: number, action: string, snap: Record<string, unknown>, at: string) =>
   q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
      VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[$5,$6]::text[],'{}'::jsonb,$7::jsonb,$8)`, [SHEET, id, version, action, NAME, SALARY, JSON.stringify(snap), at])
+
+/** Docket #46 (g3): the REAL plugin-SDK `createRecord` entry point — same technique as
+ *  `multitable-d1c-plugin-revision-realdb.test.ts` — used to inject a NORMAL, capture-complete write between
+ *  preview and execute (records BOTH the `meta_records` row and its version-1 `create` revision in one
+ *  transaction), as opposed to this file's raw-SQL `rev()` helper which the (g1)/(g2) goldens use on purpose
+ *  to construct the UNCAPTURED case. A hand-rolled `INSERT` + `rev()` pair could accidentally diverge from
+ *  what a real write path produces; driving the actual production SDK entry point cannot.
+ */
+type PluginRecordsApi = {
+  createRecord: (input: { sheetId: string; data: Record<string, unknown> }) => Promise<{ id: string; sheetId: string; version: number; data: Record<string, unknown> }>
+}
+function realSdk(): PluginRecordsApi {
+  const server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+  const coreApi = (server as unknown as { createCoreAPI: () => { multitable: { records: PluginRecordsApi } } }).createCoreAPI()
+  return coreApi.multitable.records
+}
+
+/** ZERO-WRITES post-assertion for (g3): the full observable write-state of SHEET — records (id/data/version),
+ *  revision count, and trash count — compared before/after the refused execute (deepEqual). */
+async function sheetSnapshot(): Promise<{
+  records: Array<{ id: string; data: Record<string, unknown>; version: number }>
+  revisionCount: number
+  trashCount: number
+}> {
+  const records = (await q('SELECT id, data, version FROM meta_records WHERE sheet_id = $1 ORDER BY id', [SHEET])).rows as Array<{ id: string; data: Record<string, unknown>; version: number }>
+  const revisionCount = Number(((await q('SELECT count(*)::int AS c FROM meta_record_revisions WHERE sheet_id = $1', [SHEET])).rows[0] as { c: number }).c)
+  const trashCount = Number(((await q('SELECT count(*)::int AS c FROM meta_records_trash WHERE sheet_id = $1', [SHEET])).rows[0] as { c: number }).c)
+  return { records, revisionCount, trashCount }
+}
 
 async function seed(): Promise<void> {
   for (const id of [A, B]) { // existed at T1 (old), changed at T2 (new) → reset-to-T1 reverts them to old.
@@ -169,7 +205,9 @@ describeIfDatabase('multitable T8-2 Reset-to-T (DESTRUCTIVE, real DB)', () => {
     const E = `rec_rs_e_${TS}`
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [E, SHEET, JSON.stringify({ [NAME]: 'sneaked-in' })]) // now post-T-created too
     const ex = await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'reset' })
-    // §0.6 restore-marker: original PREVIEW_IDENTITY_INVALID assertion restores after the corresponding revision-slice lands
+    // §0.6 restore-marker RESOLVED: the PREVIEW_IDENTITY_INVALID shape this scenario would hit if E were
+    // captured is now pinned directly by (g3) below (docket #46), which swaps this raw-SQL uncaptured insert
+    // for a real capture-complete create so the deleteScopeHash divergence is what actually fires.
     // E is a live row with ZERO revisions (an uncaptured create injected between preview and execute) — the
     // D-1c §0.6 precheck refuses it FIRST. This is a real TOCTOU and §0.6 refusing is CORRECT: still 409,
     // still zero writes; only the pinned error code changed from the identity-drift shape to the
@@ -183,13 +221,41 @@ describeIfDatabase('multitable T8-2 Reset-to-T (DESTRUCTIVE, real DB)', () => {
     const pv = await resetPreview() // D bound at version 1
     await q('UPDATE meta_records SET data = $2::jsonb, version = version + 1 WHERE id = $1', [D, JSON.stringify({ [NAME]: 'edited-after-preview', [SALARY]: 501 })])
     const ex = await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'reset' })
-    // §0.6 restore-marker: original PREVIEW_IDENTITY_INVALID assertion restores after the corresponding revision-slice lands
+    // §0.6 restore-marker RESOLVED: see (g3) below for the capture-complete sibling of this scenario, where
+    // history stays complete and the deleteScopeHash re-comparison is what actually refuses.
     // The raw UPDATE left D's live data disagreeing with its latest (only) revision snapshot — an uncaptured
     // edit injected between preview and execute. The D-1c §0.6 precheck refuses it FIRST: real TOCTOU, §0.6
     // refusing is CORRECT; still 409, still zero writes; only the pinned error code changed.
     expect(ex.status).toBe(409); expect(ex.body?.error?.code).toBe('HISTORY_INCOMPLETE')
     expect((await recordRow(D))?.data?.[NAME]).toBe('edited-after-preview')
     for (const id of [A, B]) { const r = await recordRow(id); expect(r?.data?.[NAME]).toBe('new'); expect(r?.version).toBe(2) }
+  })
+
+  test('(g3) docket #46 — delete-set HASH divergence via a CAPTURE-COMPLETE write: a NORMAL create between preview/execute is NOT caught by §0.6 (history stays complete) — refused via PREVIEW_IDENTITY_INVALID identity mismatch instead, ZERO writes', async () => {
+    const pv = await resetPreview() // delete-set bound = {D at v1}; deleteScopeHash computed over just D
+    // A NORMAL capture-complete write — the REAL plugin-SDK createRecord entry point (source='plugin'),
+    // NOT raw SQL: it writes the meta_records row AND a matching version-1 'create' revision in ONE
+    // transaction (same production wiring `multitable-d1c-plugin-revision-realdb.test.ts` pins), so §0.6's
+    // generation-aware contiguity + content-projection precheck (history-integrity-precheck.ts) passes
+    // clean on this sheet — this scenario is deliberately NOT the (g1)/(g2) HISTORY_INCOMPLETE case.
+    const sdk = realSdk()
+    const created = await sdk.createRecord({ sheetId: SHEET, data: { [NAME]: 'captured-after-preview' } })
+    const before = await sheetSnapshot() // captured AFTER the create so this is a true zero-writes-from-execute check
+    const ex = await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'reset' })
+    // The RE-ENUMERATED delete-set at execute now includes `created.id` (absent from the T1 reconstruction,
+    // live now) — its deleteScopeHash (hashDeleteSet, restore-preview-identity.ts) diverges from what is
+    // bound inside previewIdentity, so verifyPitResetPreviewIdentity fails with reason='mismatch_deleteScopeHash'
+    // (never 'expired') → the route maps that to 409 PREVIEW_IDENTITY_INVALID (univer-meta.ts reset-execute,
+    // ~:10454-10457) — never HISTORY_INCOMPLETE, because history really is complete here. This is THE
+    // deferred W0 golden (docket #46): the delete-scope-divergence refusal path, reachable now that a
+    // capture-complete write no longer gets pre-empted by §0.6.
+    expect(ex.status).toBe(409)
+    expect(ex.body?.error?.code).toBe('PREVIEW_IDENTITY_INVALID')
+    // ZERO WRITES — assert the DB, not just the response: identical records/versions, no new revision, no
+    // trash row, for the WHOLE sheet (not just D/created individually).
+    expect(await sheetSnapshot()).toEqual(before)
+    expect(await recordRow(D)).toBeTruthy() // D NOT deleted
+    expect(await recordRow(created.id)).toBeTruthy() // the newly-created record NOT deleted either
   })
 
   test('(h) single-transaction atomicity: DELETE-revision failure rolls back prior A/B reverts AND D delete', async () => {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -302,6 +302,13 @@ export default defineConfig({
       // whole-file wired into `Run multitable real-DB integration` in plugin-tests.yml.
       'tests/integration/multitable-undelete-inbound-resurrect-realdb.test.ts',
       'tests/integration/multitable-reset-pit-inbound-capture-realdb.test.ts',
+      // T8-2 Reset-to-T goldens (flag-off/on, PIT-2 all-or-nothing, delete-set divergence including the
+      // docket #46 capture-complete deleteScopeHash-mismatch golden, single-txn atomicity, D2 gate): real
+      // Postgres only. Was ALREADY whole-file wired into `Run multitable real-DB integration` in
+      // plugin-tests.yml but MISSING from this list (same pre-existing-gap class the 4c-2 tombstone
+      // cluster comment above documents) — so the no-DB job silently COLLECTED and skip-greened it.
+      // Two-point wiring: BOTH points or the no-DB lane reports it green-with-zero-assertions.
+      'tests/integration/multitable-reset-pit-realdb.test.ts',
       // W6 full-HTTP-path approve->resume seam: mounts authRouter + approvalsRouter on an
       // ephemeral port against real Postgres, so it is excluded from the default run and wired
       // into the dedicated `Run multitable real-DB integration` job in plugin-tests.yml.


### PR DESCRIPTION
Two docketed W0 test follow-ups (docket items 46 and 51), one PR. Tests + one wiring line only — zero runtime source changes.

## (A) Reset-pit deleteScopeHash divergence golden — docket item 46

**File**: `packages/core-backend/tests/integration/multitable-reset-pit-realdb.test.ts` (existing, already two-point wired on the plugin-tests.yml side) — new golden `(g3)`.

**What it pins**: the reset-execute preview-identity's `deleteScopeHash` re-comparison is the refusal that fires when the DELETE SCOPE diverges between preview and execute via a **capture-complete** write. The golden takes a reset preview (delete-set = {D}), then creates a new record through the REAL plugin-SDK `createRecord` entry point (`MetaSheetServer.createCoreAPI()` — row + version-1 create revision in one transaction, same production wiring `multitable-d1c-plugin-revision-realdb.test.ts` pins), then executes with the stale previewIdentity. The re-enumerated delete-set now includes the new record, `hashDeleteSet` diverges from the token's bound hash, and `verifyPitResetPreviewIdentity` fails with `mismatch_deleteScopeHash` → **409 `PREVIEW_IDENTITY_INVALID`, zero writes** (whole-sheet records/revision-count/trash-count deepEqual before/after).

**Why it was deferred**: during the §0.6 precheck work, any construction of "delete set diverged" used raw-SQL inserts — an *uncaptured* write — which the D-1c §0.6 `HISTORY_INCOMPLETE` precheck refuses FIRST (that shape is pinned by the pre-existing `(g1)`/`(g2)` goldens, whose stale "restore-marker" comments this PR also resolves). Only the capture-complete W0 world (all 9 write paths emit revisions) makes the *identity-mismatch* refusal reachable without `HISTORY_INCOMPLETE` masking it.

**Mutation evidence (landing-verified)**: commented out the `deleteScopeHash` mismatch check in `verifyPitResetPreviewIdentity` (`restore-preview-identity.ts:529`) → `(g3)` went red with `expected 200 to be 409` — i.e. with the guard neutralized the destructive reset **actually executes** against the stale scope. Restored the file byte-identical (diff-verified) → full file green again (14/14). The mutation never left the working tree — the committed source is untouched.

## (B) Create-path autoNumber snapshot pin — docket item 51

**File**: `packages/core-backend/tests/integration/multitable-d1c-plugin-revision-realdb.test.ts` (existing, already two-point wired) — new "AutoNumber snapshot pin" describe block, on a dedicated sheet (an autoNumber field on the shared fixture sheet would break the existing exact-snapshot-key assertions).

**The reality-pin decision — MATERIALIZED, not absent**: the plugin create path (`records.ts` `createRecord`) calls `allocateAutoNumberValues` (`auto-number-service.ts`) BEFORE the INSERT and folds the allocated value into the same `patch` object written to both `meta_records.data` and the create revision (`snapshot: patch`, records.ts:639). The golden creates a record via the real SDK with an autoNumber field on the sheet and asserts the revision snapshot carries the SAME materialized value as `meta_records.data` (value `1`, matching, not absent). This is the opposite shape from formula/lookup (which materialize post-commit and stay absent from the create snapshot — the adversarial raw-SQL state G-HI-3 pins in `multitable-history-incomplete-precheck-realdb.test.ts`); drift in either direction now reds a golden. Chose the plugin-create fixture over the automation one because automation `executeCreateRecord` does a bare INSERT of `config.data` with **no** auto-number allocation call at all — it would only pin an absent-field no-op.

**§1.3 content-projection cross-check**: after the create, the real `revert-preview` HTTP route returns 200 with `visibleRevertCount: 0` — no `content_mismatch` from the autoNumber field, because `autoNumber` is in `DERIVED_FIELD_TYPES` (`history-integrity-precheck.ts:70`) and thus excluded from the user-authored-field projection.

## Also: pre-existing two-point-wiring gap fixed

`multitable-reset-pit-realdb.test.ts` was whitelisted in `plugin-tests.yml`'s multitable real-DB step but **missing from `vitest.config.ts`'s no-DB exclude list** — the same gap class the 4c-2 tombstone-cluster sweep documented. Proven both ways: with the parent commit's config and no `DATABASE_URL`, the file is collected and reports `1 skipped (14 tests)` exit 0 (silent skip-green); with this PR's config it is not collected at all, while non-excluded files still are (positive control). Added the exclude entry with the house comment.

## Verification

- `pnpm type-check` — green (core-backend + apps/web).
- Real-DB: fresh Postgres, CI `MIGRATION_EXCLUDE` list applied via `db:migrate`, `METASHEET_REAL_DB_TEST_STEP=1`, `vitest.integration.config.ts` — the two touched files + `multitable-history-contiguity-realdb.test.ts`: **35/35 passed**. (Local deviation: Postgres 15.17 Homebrew, not the CI postgres:14 image — Docker daemon unreachable in this sandbox; nothing version-specific is exercised, and the CI run on this PR is the authoritative 14.x leg.)
- Full no-DB unit run (`vitest run`, no `DATABASE_URL`): **471 files passed / 176 skipped, 6518 tests passed / 1490 skipped, 0 failed**.
- Mutation check for (A): red under mutation, green restored (details above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
