### PR TITLE
fix(attendance): MP-6 harness — top-level attachmentUrl (refs #3317)

### DIFF
--- a/scripts/ops/staging-attendance-makeup-punch-mp6-smoke.mjs
+++ b/scripts/ops/staging-attendance-makeup-punch-mp6-smoke.mjs
@@ -425,7 +425,11 @@ function makeupBody(workDate, requestType, { reason, attachment = true } = {}) {
     workDate,
     requestType,
     reason: reason === undefined ? `MP-6 smoke ${STAMP} ${requestType} ${workDate}` : reason,
-    metadata: attachment ? { attachmentUrl: ATTACHMENT_URL } : {},
+    // The server's draft resolver reads the attachment from the TOP-LEVEL body field
+    // (parsedData.attachmentUrl) and rebuilds metadata from scratch — a body.metadata
+    // attachment is silently dropped (run 29383604023: valid leg 422
+    // MAKEUP_PUNCH_ATTACHMENT_REQUIRED despite metadata.attachmentUrl being set).
+    ...(attachment ? { attachmentUrl: ATTACHMENT_URL } : {}),
   }
   if (requestType === 'missed_check_in') body.requestedInAt = `${workDate}T01:00:00.000Z`
   else body.requestedOutAt = `${workDate}T10:00:00.000Z`


### PR DESCRIPTION
MP-6 live window run 29383604023 failed exactly one leg: "valid missed_check_out created pending" got 422 `MAKEUP_PUNCH_ATTACHMENT_REQUIRED`. Root cause: the harness sent the attachment as `body.metadata.attachmentUrl`, but `resolveAttendanceRequestDraft` reads the **top-level** `attachmentUrl` body field (zod `z.string().optional()`) and rebuilds `metadata` from scratch — incoming metadata is silently dropped. One-line fix moving the attachment to the top-level field; the negative leg (no attachment anywhere → 422) is unchanged and passed live. All other MP-6 legs incl. residue=0 cleanup already green live. `node --check` clean, companion test green. Refs #3317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)