### PR TITLE
feat(automation): P2 durable-delivery S1 — outbox schema + default-OFF flag (additive, zero behavior)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -507,6 +507,7 @@ jobs:
             tests/integration/multitable-tombstone-field-rehydrate-revision-realdb.test.ts \
             tests/integration/multitable-tombstone-record-capture-realdb.test.ts \
             tests/integration/multitable-tombstone-retention-realdb.test.ts \
+            tests/integration/multitable-automation-outbox-schema-realdb.test.ts \
             tests/integration/multitable-attachment-readgate.security.test.ts \
             tests/integration/multitable-ai-write-provenance-batch-grouping-realdb.test.ts \
             tests/integration/multitable-automation-branch-local-wait.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260715120000_create_automation_outbox.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260715120000_create_automation_outbox.ts
@@ -10,11 +10,14 @@
  *                                        the source state change (approval status write / record write).
  *                                        `manifest_version` stamps the routing manifest that expanded it
  *                                        (a v1 row is dispatched per v1 forever — never re-interpreted).
- *                                        `event_id` is NOT NULL — the stable ORIGINAL-event identity the
- *                                        dispatcher forwards downstream as the per-rule dedup key and the
- *                                        outbound-idempotency seed (#4203 §producer/identity). It is NOT
- *                                        unique: #4203 §cutover tolerates transient double-emit and dedups
- *                                        at the sink, so a second contract-legal enqueue must be allowed.
+ *                                        `event_id` is NOT NULL AND non-blank — the stable ORIGINAL-event
+ *                                        identity the dispatcher forwards downstream as the per-rule dedup
+ *                                        key and the outbound-idempotency seed (#4203 §producer/identity). A
+ *                                        CHECK rejects empty/all-whitespace ids, mirroring the dedup helper
+ *                                        (`automation-event-dedup.ts`: `_eventId.trim()` → no-identity), so a
+ *                                        blank id can't sit in the outbox looking like an identity it isn't.
+ *                                        It is NOT unique: #4203 §cutover tolerates transient double-emit and
+ *                                        dedups at the sink, so a second contract-legal enqueue is allowed.
  *   - `meta_automation_outbox_consumer`— per-(outbox_id, consumer_key) delivery state. `status` is the
  *                                        four-state machine `pending|in_progress|done|dead_letter` — there is
  *                                        NO persistent `failed` state: a transient failure only bumps
@@ -30,8 +33,13 @@
  *                                        lease is EXACTLY the in_progress marker — a BICONDITIONAL CHECK ties
  *                                        `lease IS NOT NULL` to `status='in_progress'` in BOTH directions:
  *                                        in_progress ⇒ leased (else unreclaimable), and non-in_progress ⇒
- *                                        NO lease (a stale lease on a done/pending row would be spuriously
- *                                        reclaimed). Fence/attempts/depth carry non-negative CHECKs.
+ *                                        NO lease. The reverse half is NOT about the reclaim scan (that scan
+ *                                        is status-scoped, so it would never pick up a leftover lease on a
+ *                                        settled row) — it keeps a lease meaning EXACTLY "owned by a live
+ *                                        in_progress worker", so every terminal/reclaim transition must clear
+ *                                        the lease atomically and a settled row can never carry stale
+ *                                        ownership. Fence/attempts/depth carry non-negative CHECKs; `event_id`
+ *                                        is non-blank (mirrors the dedup helper's `.trim()` → no-identity).
  *
  * NOTHING reads or writes these tables yet — the durable dispatcher (S2), the producer-side atomic enqueue
  * (S4), and the consumer adapters (S5) are separate, flag-gated slices. This migration is byte-for-byte
@@ -56,7 +64,13 @@ export async function up(db: Kysely<unknown>): Promise<void> {
                          CONSTRAINT automation_outbox_depth_nonneg CHECK (automation_depth >= 0),
       manifest_version int  NOT NULL
                          CONSTRAINT automation_outbox_manifest_version_positive CHECK (manifest_version >= 1),
-      event_id         text NOT NULL,
+      event_id         text NOT NULL
+                         -- reject empty / all-whitespace ids: the dedup helper (automation-event-dedup.ts)
+                         -- does _eventId.trim() and treats a blank result as NO identity, so a blank id in
+                         -- the outbox would be un-dedupable. [^[:space:]] = at least one non-whitespace char
+                         -- (POSIX class covers space/tab/newline/CR/VT/FF, mirroring JS .trim() over ASCII;
+                         -- a regex, not btrim(), so no backslash escapes leak into this template literal).
+                         CONSTRAINT automation_outbox_event_id_nonblank CHECK (event_id ~ '[^[:space:]]'),
       created_at       timestamptz NOT NULL DEFAULT now()
     )
   `.execute(db)
@@ -85,8 +99,12 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       -- The lease is EXACTLY the in_progress marker — a BICONDITIONAL, not a one-directional guard:
       --   in_progress  => lease present  (else the reclaim scan status=in_progress AND lease < now()
       --                                   could never recover it — a permanently stuck row); AND
-      --   NOT in_progress => lease absent (a stale lease left on a pending/done/dead_letter row would be
-      --                                    spuriously matched by the same reclaim scan).
+      --   NOT in_progress => lease absent. The reason is NOT that the scan would reclaim it — that scan is
+      --                                    status-scoped and would never pick up a leftover lease on a
+      --                                    pending/done/dead_letter row. It is to keep a lease meaning
+      --                                    EXACTLY "owned by a live in_progress worker": every terminal /
+      --                                    reclaim transition must clear the lease atomically, so a settled
+      --                                    row can never carry stale, ambiguous ownership.
       -- Every state transition (claim/complete/reclaim/poison) sets or clears the lease in the SAME
       -- single-row UPDATE that changes the status, so the biconditional holds at every commit boundary.
       CONSTRAINT automation_outbox_consumer_lease_iff_in_progress

--- a/packages/core-backend/src/db/migrations/zzzz20260715120000_create_automation_outbox.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260715120000_create_automation_outbox.ts
@@ -1,0 +1,72 @@
+/**
+ * Migration: `meta_automation_outbox` + `meta_automation_outbox_consumer` — P2 durable-delivery substrate.
+ *
+ * FWB-0 design lock (#4203, Layer 1) + approval-line plan (#4239): the automation completion→delivery
+ * chain today has two crash-loss windows (commit-then-emit to an in-memory `eventemitter3` bus; a
+ * terminal claim-before-execute tombstone). This migration lands the **additive, unused-until-wired**
+ * substrate for the durable fix:
+ *
+ *   - `meta_automation_outbox`         — one row per producer event, written in the SAME transaction as
+ *                                        the source state change (approval status write / record write).
+ *                                        `manifest_version` stamps the routing manifest that expanded it
+ *                                        (a v1 row is dispatched per v1 forever — never re-interpreted).
+ *   - `meta_automation_outbox_consumer`— per-(outbox_id, consumer_key) delivery state. `status` is the
+ *                                        four-state machine `pending|in_progress|done|dead_letter` plus a
+ *                                        `failed` transient; `fence` is the monotonic epoch bumped on every
+ *                                        claim/reclaim (a stale-fence "zombie" write hits 0 rows, §Layer-1
+ *                                        fencing); `attempts` is incremented AT CLAIM (so an always-crash-
+ *                                        after-claim poison still reaches `dead_letter`); `lease_expires_at`
+ *                                        is the reclaim lease.
+ *
+ * NOTHING reads or writes these tables yet — the durable dispatcher (S2), the producer-side atomic enqueue
+ * (S4), and the consumer adapters (S5) are separate, flag-gated slices. This migration is byte-for-byte
+ * behavior-neutral: no existing table is altered, no code path touches these tables while
+ * `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF (the default). Additive `CREATE TABLE IF NOT EXISTS` only.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Producer event rows — co-committed with the source state change.
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_automation_outbox (
+      id               text PRIMARY KEY,
+      event_type       text NOT NULL,
+      payload          jsonb NOT NULL,
+      automation_depth int  NOT NULL DEFAULT 0,
+      manifest_version int  NOT NULL,
+      event_id         text,
+      created_at       timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+  // Dispatcher polls pending rows oldest-first.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_automation_outbox_created_at
+    ON meta_automation_outbox (created_at)
+  `.execute(db)
+
+  // Per-(outbox_id, consumer_key) delivery state — the reclaimable lease row (fence-bearing).
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_automation_outbox_consumer (
+      outbox_id        text NOT NULL REFERENCES meta_automation_outbox(id) ON DELETE CASCADE,
+      consumer_key     text NOT NULL,
+      status           text NOT NULL DEFAULT 'pending'
+                         CHECK (status IN ('pending','in_progress','done','failed','dead_letter')),
+      lease_expires_at timestamptz,
+      fence            bigint NOT NULL DEFAULT 0,
+      attempts         int    NOT NULL DEFAULT 0,
+      last_error       text,
+      updated_at       timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (outbox_id, consumer_key)
+    )
+  `.execute(db)
+  // Dispatcher claim scan: reclaimable rows are pending, or in_progress past a stale lease.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_automation_outbox_consumer_claim
+    ON meta_automation_outbox_consumer (status, lease_expires_at)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS meta_automation_outbox_consumer`.execute(db)
+  await sql`DROP TABLE IF EXISTS meta_automation_outbox`.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260715120000_create_automation_outbox.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260715120000_create_automation_outbox.ts
@@ -10,6 +10,11 @@
  *                                        the source state change (approval status write / record write).
  *                                        `manifest_version` stamps the routing manifest that expanded it
  *                                        (a v1 row is dispatched per v1 forever — never re-interpreted).
+ *                                        `event_id` is NOT NULL — the stable ORIGINAL-event identity the
+ *                                        dispatcher forwards downstream as the per-rule dedup key and the
+ *                                        outbound-idempotency seed (#4203 §producer/identity). It is NOT
+ *                                        unique: #4203 §cutover tolerates transient double-emit and dedups
+ *                                        at the sink, so a second contract-legal enqueue must be allowed.
  *   - `meta_automation_outbox_consumer`— per-(outbox_id, consumer_key) delivery state. `status` is the
  *                                        four-state machine `pending|in_progress|done|dead_letter` — there is
  *                                        NO persistent `failed` state: a transient failure only bumps
@@ -21,9 +26,12 @@
  *                                        `fence` is the monotonic epoch bumped on every claim/reclaim (a
  *                                        stale-fence "zombie" write hits 0 rows); `attempts` is incremented AT
  *                                        CLAIM (so an always-crash-after-claim poison still reaches
- *                                        `dead_letter`); `lease_expires_at` is the reclaim lease and is
- *                                        REQUIRED whenever `status='in_progress'` (a CHECK enforces it — an
- *                                        in_progress row with a NULL lease could never be reclaimed).
+ *                                        `dead_letter`); `lease_expires_at` is the reclaim lease, and the
+ *                                        lease is EXACTLY the in_progress marker — a BICONDITIONAL CHECK ties
+ *                                        `lease IS NOT NULL` to `status='in_progress'` in BOTH directions:
+ *                                        in_progress ⇒ leased (else unreclaimable), and non-in_progress ⇒
+ *                                        NO lease (a stale lease on a done/pending row would be spuriously
+ *                                        reclaimed). Fence/attempts/depth carry non-negative CHECKs.
  *
  * NOTHING reads or writes these tables yet — the durable dispatcher (S2), the producer-side atomic enqueue
  * (S4), and the consumer adapters (S5) are separate, flag-gated slices. This migration is byte-for-byte
@@ -34,14 +42,21 @@ import { sql, type Kysely } from 'kysely'
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   // Producer event rows — co-committed with the source state change.
+  //   event_id is NOT NULL: it is the stable ORIGINAL-event identity (#4203 §producer/identity contract) the
+  //   dispatcher forwards downstream as the per-rule `event_fires` dedup_key and the outbound-idempotency-key
+  //   seed. A NULL identity would break cutover-window dedup and outbound idempotency, so it is required.
+  //   (Deliberately NOT unique: #4203 §cutover tolerates transient double-emit and dedups at the sink, not
+  //   at the outbox — a UNIQUE(event_id) here would reject the second, contract-legal enqueue.)
   await sql`
     CREATE TABLE IF NOT EXISTS meta_automation_outbox (
       id               text PRIMARY KEY,
       event_type       text NOT NULL,
       payload          jsonb NOT NULL,
-      automation_depth int  NOT NULL DEFAULT 0 CHECK (automation_depth >= 0),
-      manifest_version int  NOT NULL CHECK (manifest_version >= 1),
-      event_id         text,
+      automation_depth int  NOT NULL DEFAULT 0
+                         CONSTRAINT automation_outbox_depth_nonneg CHECK (automation_depth >= 0),
+      manifest_version int  NOT NULL
+                         CONSTRAINT automation_outbox_manifest_version_positive CHECK (manifest_version >= 1),
+      event_id         text NOT NULL,
       created_at       timestamptz NOT NULL DEFAULT now()
     )
   `.execute(db)
@@ -57,17 +72,25 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       outbox_id        text NOT NULL REFERENCES meta_automation_outbox(id) ON DELETE CASCADE,
       consumer_key     text NOT NULL,
       status           text NOT NULL DEFAULT 'pending'
+                         CONSTRAINT automation_outbox_consumer_status_valid
                          CHECK (status IN ('pending','in_progress','done','dead_letter')),
       lease_expires_at timestamptz,
-      fence            bigint NOT NULL DEFAULT 0 CHECK (fence >= 0),
-      attempts         int    NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+      fence            bigint NOT NULL DEFAULT 0
+                         CONSTRAINT automation_outbox_consumer_fence_nonneg CHECK (fence >= 0),
+      attempts         int    NOT NULL DEFAULT 0
+                         CONSTRAINT automation_outbox_consumer_attempts_nonneg CHECK (attempts >= 0),
       last_error       text,
       updated_at       timestamptz NOT NULL DEFAULT now(),
       PRIMARY KEY (outbox_id, consumer_key),
-      -- an in_progress row MUST carry a lease, or the reclaim scan (status='in_progress' AND
-      -- lease_expires_at < now()) could never recover it — it would be a permanently stuck row.
-      CONSTRAINT outbox_consumer_in_progress_needs_lease
-        CHECK (status <> 'in_progress' OR lease_expires_at IS NOT NULL)
+      -- The lease is EXACTLY the in_progress marker — a BICONDITIONAL, not a one-directional guard:
+      --   in_progress  => lease present  (else the reclaim scan status=in_progress AND lease < now()
+      --                                   could never recover it — a permanently stuck row); AND
+      --   NOT in_progress => lease absent (a stale lease left on a pending/done/dead_letter row would be
+      --                                    spuriously matched by the same reclaim scan).
+      -- Every state transition (claim/complete/reclaim/poison) sets or clears the lease in the SAME
+      -- single-row UPDATE that changes the status, so the biconditional holds at every commit boundary.
+      CONSTRAINT automation_outbox_consumer_lease_iff_in_progress
+        CHECK ((lease_expires_at IS NOT NULL) = (status = 'in_progress'))
     )
   `.execute(db)
   // Dispatcher claim scan: reclaimable rows are pending, or in_progress past a stale lease.

--- a/packages/core-backend/src/db/migrations/zzzz20260715120000_create_automation_outbox.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260715120000_create_automation_outbox.ts
@@ -11,12 +11,19 @@
  *                                        `manifest_version` stamps the routing manifest that expanded it
  *                                        (a v1 row is dispatched per v1 forever — never re-interpreted).
  *   - `meta_automation_outbox_consumer`— per-(outbox_id, consumer_key) delivery state. `status` is the
- *                                        four-state machine `pending|in_progress|done|dead_letter` plus a
- *                                        `failed` transient; `fence` is the monotonic epoch bumped on every
- *                                        claim/reclaim (a stale-fence "zombie" write hits 0 rows, §Layer-1
- *                                        fencing); `attempts` is incremented AT CLAIM (so an always-crash-
- *                                        after-claim poison still reaches `dead_letter`); `lease_expires_at`
- *                                        is the reclaim lease.
+ *                                        four-state machine `pending|in_progress|done|dead_letter` — there is
+ *                                        NO persistent `failed` state: a transient failure only bumps
+ *                                        `attempts` and leaves the row reclaimable (the lease expires → the
+ *                                        next claimer reclaims it), and bounded-attempts-exhausted transitions
+ *                                        straight to the terminal `dead_letter`. The two terminals `done` and
+ *                                        `dead_letter` are exactly the resolve-permitting set (§Layer-1); a
+ *                                        row can never get stuck in a non-reclaimable non-terminal state.
+ *                                        `fence` is the monotonic epoch bumped on every claim/reclaim (a
+ *                                        stale-fence "zombie" write hits 0 rows); `attempts` is incremented AT
+ *                                        CLAIM (so an always-crash-after-claim poison still reaches
+ *                                        `dead_letter`); `lease_expires_at` is the reclaim lease and is
+ *                                        REQUIRED whenever `status='in_progress'` (a CHECK enforces it — an
+ *                                        in_progress row with a NULL lease could never be reclaimed).
  *
  * NOTHING reads or writes these tables yet — the durable dispatcher (S2), the producer-side atomic enqueue
  * (S4), and the consumer adapters (S5) are separate, flag-gated slices. This migration is byte-for-byte
@@ -32,8 +39,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       id               text PRIMARY KEY,
       event_type       text NOT NULL,
       payload          jsonb NOT NULL,
-      automation_depth int  NOT NULL DEFAULT 0,
-      manifest_version int  NOT NULL,
+      automation_depth int  NOT NULL DEFAULT 0 CHECK (automation_depth >= 0),
+      manifest_version int  NOT NULL CHECK (manifest_version >= 1),
       event_id         text,
       created_at       timestamptz NOT NULL DEFAULT now()
     )
@@ -50,13 +57,17 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       outbox_id        text NOT NULL REFERENCES meta_automation_outbox(id) ON DELETE CASCADE,
       consumer_key     text NOT NULL,
       status           text NOT NULL DEFAULT 'pending'
-                         CHECK (status IN ('pending','in_progress','done','failed','dead_letter')),
+                         CHECK (status IN ('pending','in_progress','done','dead_letter')),
       lease_expires_at timestamptz,
-      fence            bigint NOT NULL DEFAULT 0,
-      attempts         int    NOT NULL DEFAULT 0,
+      fence            bigint NOT NULL DEFAULT 0 CHECK (fence >= 0),
+      attempts         int    NOT NULL DEFAULT 0 CHECK (attempts >= 0),
       last_error       text,
       updated_at       timestamptz NOT NULL DEFAULT now(),
-      PRIMARY KEY (outbox_id, consumer_key)
+      PRIMARY KEY (outbox_id, consumer_key),
+      -- an in_progress row MUST carry a lease, or the reclaim scan (status='in_progress' AND
+      -- lease_expires_at < now()) could never recover it — it would be a permanently stuck row.
+      CONSTRAINT outbox_consumer_in_progress_needs_lease
+        CHECK (status <> 'in_progress' OR lease_expires_at IS NOT NULL)
     )
   `.execute(db)
   // Dispatcher claim scan: reclaimable rows are pending, or in_progress past a stale lease.

--- a/packages/core-backend/src/db/migrations/zzzz20260715120000_create_automation_outbox.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260715120000_create_automation_outbox.ts
@@ -13,9 +13,11 @@
  *                                        `event_id` is NOT NULL AND non-blank — the stable ORIGINAL-event
  *                                        identity the dispatcher forwards downstream as the per-rule dedup
  *                                        key and the outbound-idempotency seed (#4203 §producer/identity). A
- *                                        CHECK rejects empty/all-whitespace ids, mirroring the dedup helper
- *                                        (`automation-event-dedup.ts`: `_eventId.trim()` → no-identity), so a
- *                                        blank id can't sit in the outbox looking like an identity it isn't.
+ *                                        CHECK requires a printable-ASCII non-space char (`[!-~]`), so any id
+ *                                        the dedup helper (`automation-event-dedup.ts`: `_eventId.trim()`)
+ *                                        would collapse to no-identity — empty, ASCII whitespace, OR Unicode
+ *                                        whitespace (NBSP/EM/narrow-NBSP/BOM, which PostgreSQL's ASCII-only
+ *                                        `[:space:]` misses) — is rejected before it can masquerade as one.
  *                                        It is NOT unique: #4203 §cutover tolerates transient double-emit and
  *                                        dedups at the sink, so a second contract-legal enqueue is allowed.
  *   - `meta_automation_outbox_consumer`— per-(outbox_id, consumer_key) delivery state. `status` is the
@@ -65,12 +67,15 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       manifest_version int  NOT NULL
                          CONSTRAINT automation_outbox_manifest_version_positive CHECK (manifest_version >= 1),
       event_id         text NOT NULL
-                         -- reject empty / all-whitespace ids: the dedup helper (automation-event-dedup.ts)
-                         -- does _eventId.trim() and treats a blank result as NO identity, so a blank id in
-                         -- the outbox would be un-dedupable. [^[:space:]] = at least one non-whitespace char
-                         -- (POSIX class covers space/tab/newline/CR/VT/FF, mirroring JS .trim() over ASCII;
-                         -- a regex, not btrim(), so no backslash escapes leak into this template literal).
-                         CONSTRAINT automation_outbox_event_id_nonblank CHECK (event_id ~ '[^[:space:]]'),
+                         -- reject blank ids: the dedup helper (automation-event-dedup.ts) does _eventId.trim()
+                         -- and treats a blank result as NO identity, so a blank id in the outbox is un-dedupable.
+                         -- event_id is an ASCII identity by contract, so require at least one PRINTABLE-ASCII
+                         -- non-space char: [!-~] = 0x21..0x7E. This is stronger than [^[:space:]] on purpose —
+                         -- PostgreSQL's [:space:] is ASCII-only, so [^[:space:]] would ACCEPT an id made solely
+                         -- of Unicode whitespace (NBSP U+00A0, EM SPACE U+2003, narrow-NBSP U+202F, BOM U+FEFF),
+                         -- all of which JS .trim() strips to '' → no identity. [!-~] rejects those too.
+                         -- (A regex, not btrim(); no backslash escapes leak into this template literal.)
+                         CONSTRAINT automation_outbox_event_id_nonblank CHECK (event_id ~ '[!-~]'),
       created_at       timestamptz NOT NULL DEFAULT now()
     )
   `.execute(db)

--- a/packages/core-backend/src/multitable/automation-durable-delivery.ts
+++ b/packages/core-backend/src/multitable/automation-durable-delivery.ts
@@ -1,0 +1,54 @@
+/**
+ * P2 durable-delivery — flag + shared types (slice S1, foundational).
+ *
+ * The automation completion→delivery chain is moving from the crash-lossy `commit-then-emit` +
+ * terminal-claim design onto a transactional outbox (`meta_automation_outbox`) drained by a durable
+ * dispatcher that directly `await`s named consumer adapters, per FWB-0 lock #4203 Layer 1 and the
+ * approval-line plan #4239.
+ *
+ * This module is the **flag gate + row shapes** only. The dispatcher (S2), the versioned routing manifest
+ * (S3), the producer-side atomic enqueue (S4), and the consumer adapters (S5) are separate slices. Nothing
+ * here has any side effect; while `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF (the default) the outbox
+ * tables are never read or written, so behavior is byte-for-byte unchanged from today.
+ */
+
+/**
+ * Master gate for the whole P2 durable-delivery runtime. **Default OFF.** Enabled only when the env var is
+ * exactly the string `true` after trim + lowercase — matching the repo's other default-OFF runtime flags
+ * (e.g. `MULTITABLE_ENABLE_PIT_RESET`). No slice of the durable path may run while this is OFF.
+ */
+export function isDurableDeliveryEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return String(env.AUTOMATION_DURABLE_DELIVERY_ENABLED ?? '').trim().toLowerCase() === 'true'
+}
+
+/** Terminal + transient states of a `meta_automation_outbox_consumer` row (the per-consumer lease). */
+export type OutboxConsumerStatus = 'pending' | 'in_progress' | 'done' | 'failed' | 'dead_letter'
+
+/** The set of statuses that let a consumer's adapter resolve (event terminally handled for that consumer). */
+export const RESOLVE_PERMITTING_STATUSES: ReadonlySet<OutboxConsumerStatus> = new Set([
+  'done',
+  'dead_letter',
+])
+
+/** A producer event row (`meta_automation_outbox`), co-committed with its source state change. */
+export interface OutboxRow {
+  id: string
+  eventType: string
+  payload: unknown
+  automationDepth: number
+  manifestVersion: number
+  eventId: string | null
+  createdAt: Date
+}
+
+/** A per-(outbox_id, consumer_key) delivery-state row (`meta_automation_outbox_consumer`). */
+export interface OutboxConsumerRow {
+  outboxId: string
+  consumerKey: string
+  status: OutboxConsumerStatus
+  leaseExpiresAt: Date | null
+  fence: number
+  attempts: number
+  lastError: string | null
+  updatedAt: Date
+}

--- a/packages/core-backend/src/multitable/automation-durable-delivery.ts
+++ b/packages/core-backend/src/multitable/automation-durable-delivery.ts
@@ -36,14 +36,21 @@ export const RESOLVE_PERMITTING_STATUSES: ReadonlySet<OutboxConsumerStatus> = ne
   'dead_letter',
 ])
 
-/** A producer event row (`meta_automation_outbox`), co-committed with its source state change. */
+/**
+ * A producer event row (`meta_automation_outbox`), co-committed with its source state change.
+ *
+ * `eventId` is **non-nullable** (`string`): it is the stable ORIGINAL-event identity (#4203 §producer/identity)
+ * the dispatcher forwards downstream as the per-rule `event_fires` dedup key and the seed for outbound
+ * idempotency keys — a NULL identity would break cutover-window dedup and outbound idempotency. It is NOT
+ * unique (the outbox tolerates the cutover's transient double-emit; dedup happens at the sink, not here).
+ */
 export interface OutboxRow {
   id: string
   eventType: string
   payload: unknown
   automationDepth: number
   manifestVersion: number
-  eventId: string | null
+  eventId: string
   createdAt: Date
 }
 

--- a/packages/core-backend/src/multitable/automation-durable-delivery.ts
+++ b/packages/core-backend/src/multitable/automation-durable-delivery.ts
@@ -21,10 +21,16 @@ export function isDurableDeliveryEnabled(env: NodeJS.ProcessEnv = process.env): 
   return String(env.AUTOMATION_DURABLE_DELIVERY_ENABLED ?? '').trim().toLowerCase() === 'true'
 }
 
-/** Terminal + transient states of a `meta_automation_outbox_consumer` row (the per-consumer lease). */
-export type OutboxConsumerStatus = 'pending' | 'in_progress' | 'done' | 'failed' | 'dead_letter'
+/**
+ * States of a `meta_automation_outbox_consumer` row (the per-consumer lease). There is deliberately NO
+ * persistent `failed` state: a transient failure only bumps `attempts` and leaves the row reclaimable (its
+ * lease expires and the next claimer reclaims it); bounded-attempts-exhausted goes straight to the terminal
+ * `dead_letter`. So every non-terminal state (`pending`, `in_progress`) is reclaimable and every terminal
+ * state is resolve-permitting — a row can never get stuck.
+ */
+export type OutboxConsumerStatus = 'pending' | 'in_progress' | 'done' | 'dead_letter'
 
-/** The set of statuses that let a consumer's adapter resolve (event terminally handled for that consumer). */
+/** The two terminal statuses that let a consumer's adapter resolve (event terminally handled for it). */
 export const RESOLVE_PERMITTING_STATUSES: ReadonlySet<OutboxConsumerStatus> = new Set([
   'done',
   'dead_letter',
@@ -41,13 +47,20 @@ export interface OutboxRow {
   createdAt: Date
 }
 
-/** A per-(outbox_id, consumer_key) delivery-state row (`meta_automation_outbox_consumer`). */
+/**
+ * A per-(outbox_id, consumer_key) delivery-state row (`meta_automation_outbox_consumer`).
+ *
+ * `fence` is a **`string`, not a `number`**: the column is `bigint`, and node-postgres returns bigint as a
+ * string to avoid the JS-number 2^53 precision cliff (the S1 real-DB golden asserts `fence: '0'`). S2's
+ * increment/CAS must treat it as a decimal string (`fence = fence + 1` server-side; compare with the claimed
+ * string), never coerce it through a JS `number`.
+ */
 export interface OutboxConsumerRow {
   outboxId: string
   consumerKey: string
   status: OutboxConsumerStatus
   leaseExpiresAt: Date | null
-  fence: number
+  fence: string
   attempts: number
   lastError: string | null
   updatedAt: Date

--- a/packages/core-backend/tests/integration/multitable-automation-outbox-schema-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-outbox-schema-realdb.test.ts
@@ -21,6 +21,8 @@
  * Runs only with DATABASE_URL (sentinel fails-not-skips in CI's real-DB lane; two-point wired into
  * plugin-tests.yml + excluded from the no-DB default job in vitest.config.ts so it cannot skip-green).
  */
+import { randomUUID } from 'node:crypto'
+
 import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
@@ -29,13 +31,15 @@ import { isDurableDeliveryEnabled, RESOLVE_PERMITTING_STATUSES } from '../../src
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 
-// Synthetic outbox ids for this run (Date.now()-scoped so parallel files/runs never collide); cleaned up after.
-const RUN = Math.floor(Date.now() % 1e9)
+// Synthetic outbox ids for this run — randomUUID()-scoped so parallel files/runs never collide (Date.now()
+// modulo could, on a fast/parallel runner); cleaned up after.
+const RUN = randomUUID()
 const OB1 = `ob_s1_${RUN}_a`
 const OB2 = `ob_s1_${RUN}_b`
 const OB_MV = `ob_s1_${RUN}_mv` // manifest_version=0 negative control (insert must fail → no row persists)
 const OB_DEPTH = `ob_s1_${RUN}_depth` // automation_depth=-1 negative control (insert must fail → no row persists)
-const ALL_OB = [OB1, OB2, OB_MV, OB_DEPTH]
+const OB_EID = `ob_s1_${RUN}_eid` // event_id non-blank test (negatives fail; the positive persists a row)
+const ALL_OB = [OB1, OB2, OB_MV, OB_DEPTH, OB_EID]
 
 // A fully-valid outbox row — every NOT NULL column supplied, INCLUDING the now-required event_id.
 const insertOutbox = (id: string) =>
@@ -82,6 +86,34 @@ describeIfDatabase('P2 durable-delivery S1 — automation outbox schema + flag (
         [OB_MV],
       ),
     ).rejects.toThrow(/event_id|not-null/i)
+  })
+
+  test('event_id CHECK rejects empty AND all-whitespace ids (mirrors the dedup helper .trim()); non-blank accepted', async () => {
+    // negative: empty string — a blank id the dedup helper would treat as no-identity.
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
+         VALUES ($1,'approval.approved','{}'::jsonb,0,1,'')`,
+        [OB_EID],
+      ),
+    ).rejects.toThrow(/automation_outbox_event_id_nonblank/)
+    // negative: all-whitespace (space + tab + newline) — the point of [^[:space:]] over a spaces-only btrim:
+    // the helper's JS .trim() strips tab/newline too, so the CHECK must reject them to mirror it.
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
+         VALUES ($1,'approval.approved','{}'::jsonb,0,1,$2)`,
+        [OB_EID, ' \t\n '],
+      ),
+    ).rejects.toThrow(/automation_outbox_event_id_nonblank/)
+    // positive control: a normal non-blank id inserts (proves the CHECK gates on blankness, not on event_id itself).
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
+         VALUES ($1,'approval.approved','{}'::jsonb,0,1,'evt_ok')`,
+        [OB_EID],
+      ),
+    ).resolves.toBeTruthy()
   })
 
   test('manifest_version CHECK rejects 0 (must be >= 1) — by constraint name', async () => {

--- a/packages/core-backend/tests/integration/multitable-automation-outbox-schema-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-outbox-schema-realdb.test.ts
@@ -18,8 +18,7 @@ import { isDurableDeliveryEnabled, RESOLVE_PERMITTING_STATUSES } from '../../src
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 
-// A real automation_rules row is required as the outbox rows carry no rule FK, but a consumer-lease test
-// needs a genuine outbox row; we keep everything inside two synthetic ids and clean them up.
+// Outbox rows carry no rule FK, so the schema goldens need only two synthetic outbox ids, cleaned up after.
 const OB1 = `ob_s1_${Math.floor(Date.now() % 1e9)}_a`
 const OB2 = `ob_s1_${Math.floor(Date.now() % 1e9)}_b`
 
@@ -55,12 +54,15 @@ describeIfDatabase('P2 durable-delivery S1 — automation outbox schema + flag (
       `INSERT INTO meta_automation_outbox (id, event_type, payload, manifest_version) VALUES ($1,$2,$3::jsonb,1)`,
       [OB1, 'approval.approved', JSON.stringify({ any: 'payload' })],
     )
-    // positive control: every valid status inserts.
-    for (const s of ['pending', 'in_progress', 'done', 'failed', 'dead_letter'] as const) {
+    // positive control: every valid status inserts. There are exactly four — NO persistent `failed`
+    // (a transient failure only bumps attempts and stays reclaimable; exhaustion → dead_letter). `in_progress`
+    // must carry a lease (the in_progress-needs-lease CHECK), so give it one; the others take a NULL lease.
+    for (const s of ['pending', 'in_progress', 'done', 'dead_letter'] as const) {
+      const lease = s === 'in_progress' ? "now() + interval '5 minutes'" : 'NULL'
       await q(
-        `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status)
-         VALUES ($1,$2,$3)
-         ON CONFLICT (outbox_id, consumer_key) DO UPDATE SET status = EXCLUDED.status`,
+        `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at)
+         VALUES ($1,$2,$3,${lease})
+         ON CONFLICT (outbox_id, consumer_key) DO UPDATE SET status = EXCLUDED.status, lease_expires_at = EXCLUDED.lease_expires_at`,
         [OB1, `ck_${s}`, s],
       )
     }
@@ -73,14 +75,52 @@ describeIfDatabase('P2 durable-delivery S1 — automation outbox schema + flag (
     ).rejects.toThrow()
   })
 
+  test('in_progress REQUIRES a lease: NULL-lease in_progress is rejected, leased in_progress is accepted', async () => {
+    await q(
+      `INSERT INTO meta_automation_outbox (id, event_type, payload, manifest_version) VALUES ($1,'approval.approved','{}'::jsonb,1)
+       ON CONFLICT (id) DO NOTHING`,
+      [OB1],
+    )
+    // negative control: an in_progress row with NULL lease is unreclaimable — the CHECK must reject it.
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at)
+         VALUES ($1,'ck_inprog_nolease','in_progress',NULL)`,
+        [OB1],
+      ),
+    ).rejects.toThrow()
+    // positive control: the SAME row with a lease is accepted (proves the CHECK gates on the lease, not the status).
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at)
+         VALUES ($1,'ck_inprog_leased','in_progress',now() + interval '5 minutes')`,
+        [OB1],
+      ),
+    ).resolves.toBeTruthy()
+  })
+
+  test('fence/attempts non-negative CHECKs reject a negative fence', async () => {
+    await q(
+      `INSERT INTO meta_automation_outbox (id, event_type, payload, manifest_version) VALUES ($1,'approval.approved','{}'::jsonb,1)
+       ON CONFLICT (id) DO NOTHING`,
+      [OB1],
+    )
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, fence) VALUES ($1,'ck_negfence','pending',-1)`,
+        [OB1],
+      ),
+    ).rejects.toThrow()
+  })
+
   test('FK cascade: deleting an outbox event removes its per-consumer lease rows', async () => {
     await q(
       `INSERT INTO meta_automation_outbox (id, event_type, payload, manifest_version) VALUES ($1,'approval.approved','{}'::jsonb,1)`,
       [OB2],
     )
     await q(
-      `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, fence, attempts)
-       VALUES ($1,'approval-trigger','in_progress',3,2)`,
+      `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at, fence, attempts)
+       VALUES ($1,'approval-trigger','in_progress',now() + interval '5 minutes',3,2)`,
       [OB2],
     )
     const before = await q('SELECT count(*)::int AS c FROM meta_automation_outbox_consumer WHERE outbox_id = $1', [OB2])

--- a/packages/core-backend/tests/integration/multitable-automation-outbox-schema-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-outbox-schema-realdb.test.ts
@@ -2,10 +2,21 @@
  * P2 durable-delivery — slice S1 schema + flag golden (real DB).
  *
  * Verifies the additive migration `zzzz20260715120000_create_automation_outbox` landed the two new tables
- * with the shape the later slices depend on, that the `status` CHECK enforces the four-state machine, that
- * the FK cascade deletes per-consumer rows with their outbox event, and that the master flag is OFF by
- * default (so S1 changes byte-for-byte nothing at runtime). No behavior of the existing automation path is
- * exercised — these tables are unused until the dispatcher (S2) wires them behind the flag.
+ * with the shape the later slices depend on:
+ *   - `status` CHECK enforces the FOUR-state machine `pending|in_progress|done|dead_letter` (no persistent
+ *     `failed` — a stuck absorbing state);
+ *   - the lease is a BICONDITIONAL of `status='in_progress'` (in_progress ⇒ leased; NOT in_progress ⇒ no
+ *     lease) — all four corners are exercised;
+ *   - `event_id` is NOT NULL (the stable original-event identity the dispatcher forwards downstream, #4203);
+ *   - fence/attempts/manifest_version/automation_depth carry the documented non-negative / positive CHECKs;
+ *   - `fence` is `bigint` and round-trips as a STRING past 2^53 (no JS-number precision loss — S2's CAS
+ *     depends on this);
+ *   - the FK cascade deletes per-consumer rows with their outbox event; and the master flag is OFF by
+ *     default (so S1 changes byte-for-byte nothing at runtime).
+ *
+ * Each named CHECK has a negative control that asserts the SPECIFIC constraint name in the rejection, so
+ * deleting/loosening that one constraint turns exactly its test red (mutation-resistant, not a blanket
+ * `.rejects.toThrow()` that any error would satisfy).
  *
  * Runs only with DATABASE_URL (sentinel fails-not-skips in CI's real-DB lane; two-point wired into
  * plugin-tests.yml + excluded from the no-DB default job in vitest.config.ts so it cannot skip-green).
@@ -18,16 +29,29 @@ import { isDurableDeliveryEnabled, RESOLVE_PERMITTING_STATUSES } from '../../src
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 
-// Outbox rows carry no rule FK, so the schema goldens need only two synthetic outbox ids, cleaned up after.
-const OB1 = `ob_s1_${Math.floor(Date.now() % 1e9)}_a`
-const OB2 = `ob_s1_${Math.floor(Date.now() % 1e9)}_b`
+// Synthetic outbox ids for this run (Date.now()-scoped so parallel files/runs never collide); cleaned up after.
+const RUN = Math.floor(Date.now() % 1e9)
+const OB1 = `ob_s1_${RUN}_a`
+const OB2 = `ob_s1_${RUN}_b`
+const OB_MV = `ob_s1_${RUN}_mv` // manifest_version=0 negative control (insert must fail → no row persists)
+const OB_DEPTH = `ob_s1_${RUN}_depth` // automation_depth=-1 negative control (insert must fail → no row persists)
+const ALL_OB = [OB1, OB2, OB_MV, OB_DEPTH]
+
+// A fully-valid outbox row — every NOT NULL column supplied, INCLUDING the now-required event_id.
+const insertOutbox = (id: string) =>
+  q(
+    `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
+     VALUES ($1,'approval.approved','{}'::jsonb,0,1,$2)
+     ON CONFLICT (id) DO NOTHING`,
+    [id, `evt_${id}`],
+  )
 
 describeIfDatabase('P2 durable-delivery S1 — automation outbox schema + flag (real DB)', () => {
   beforeAll(async () => {
-    await q('DELETE FROM meta_automation_outbox WHERE id = ANY($1)', [[OB1, OB2]]).catch(() => {})
+    await q('DELETE FROM meta_automation_outbox WHERE id = ANY($1)', [ALL_OB]).catch(() => {})
   })
   afterAll(async () => {
-    await q('DELETE FROM meta_automation_outbox WHERE id = ANY($1)', [[OB1, OB2]]).catch(() => {})
+    await q('DELETE FROM meta_automation_outbox WHERE id = ANY($1)', [ALL_OB]).catch(() => {})
   })
 
   test('sentinel: DATABASE_URL set', () => {
@@ -49,14 +73,41 @@ describeIfDatabase('P2 durable-delivery S1 — automation outbox schema + flag (
     }
   })
 
+  test('event_id is NOT NULL (stable original-event identity forwarded as the downstream dedup key)', async () => {
+    // Otherwise-valid row; the ONLY violation is a NULL event_id → the not-null constraint must reject it.
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
+         VALUES ($1,'approval.approved','{}'::jsonb,0,1,NULL)`,
+        [OB_MV],
+      ),
+    ).rejects.toThrow(/event_id|not-null/i)
+  })
+
+  test('manifest_version CHECK rejects 0 (must be >= 1) — by constraint name', async () => {
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
+         VALUES ($1,'approval.approved','{}'::jsonb,0,0,$2)`,
+        [OB_MV, `evt_${OB_MV}`],
+      ),
+    ).rejects.toThrow(/automation_outbox_manifest_version_positive/)
+  })
+
+  test('automation_depth CHECK rejects a negative depth — by constraint name', async () => {
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
+         VALUES ($1,'approval.approved','{}'::jsonb,-1,1,$2)`,
+        [OB_DEPTH, `evt_${OB_DEPTH}`],
+      ),
+    ).rejects.toThrow(/automation_outbox_depth_nonneg/)
+  })
+
   test('status CHECK enforces the four-state machine (rejects an unknown status; accepts each valid one)', async () => {
-    await q(
-      `INSERT INTO meta_automation_outbox (id, event_type, payload, manifest_version) VALUES ($1,$2,$3::jsonb,1)`,
-      [OB1, 'approval.approved', JSON.stringify({ any: 'payload' })],
-    )
-    // positive control: every valid status inserts. There are exactly four — NO persistent `failed`
-    // (a transient failure only bumps attempts and stays reclaimable; exhaustion → dead_letter). `in_progress`
-    // must carry a lease (the in_progress-needs-lease CHECK), so give it one; the others take a NULL lease.
+    await insertOutbox(OB1)
+    // positive control: exactly FOUR valid statuses — NO persistent `failed`. `in_progress` MUST carry a lease
+    // (the lease-iff-in_progress biconditional); the other three MUST NOT — so give in_progress a lease, others NULL.
     for (const s of ['pending', 'in_progress', 'done', 'dead_letter'] as const) {
       const lease = s === 'in_progress' ? "now() + interval '5 minutes'" : 'NULL'
       await q(
@@ -66,58 +117,98 @@ describeIfDatabase('P2 durable-delivery S1 — automation outbox schema + flag (
         [OB1, `ck_${s}`, s],
       )
     }
-    // negative: a bogus status is rejected by the CHECK.
+    // negative: a bogus status (valid lease shape) → only the status CHECK can fire.
     await expect(
       q(
-        `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status) VALUES ($1,'ck_bad','bogus')`,
+        `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at) VALUES ($1,'ck_bad','bogus',NULL)`,
         [OB1],
       ),
-    ).rejects.toThrow()
+    ).rejects.toThrow(/automation_outbox_consumer_status_valid/)
   })
 
-  test('in_progress REQUIRES a lease: NULL-lease in_progress is rejected, leased in_progress is accepted', async () => {
-    await q(
-      `INSERT INTO meta_automation_outbox (id, event_type, payload, manifest_version) VALUES ($1,'approval.approved','{}'::jsonb,1)
-       ON CONFLICT (id) DO NOTHING`,
-      [OB1],
-    )
-    // negative control: an in_progress row with NULL lease is unreclaimable — the CHECK must reject it.
+  test('lease is a BICONDITIONAL of in_progress — all four corners enforced', async () => {
+    await insertOutbox(OB1)
+    // (a) in_progress + NULL lease → rejected (would be unreclaimable).
     await expect(
       q(
         `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at)
-         VALUES ($1,'ck_inprog_nolease','in_progress',NULL)`,
+         VALUES ($1,'ck_ip_nolease','in_progress',NULL)`,
         [OB1],
       ),
-    ).rejects.toThrow()
-    // positive control: the SAME row with a lease is accepted (proves the CHECK gates on the lease, not the status).
+    ).rejects.toThrow(/automation_outbox_consumer_lease_iff_in_progress/)
+    // (b) in_progress + lease → accepted.
     await expect(
       q(
         `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at)
-         VALUES ($1,'ck_inprog_leased','in_progress',now() + interval '5 minutes')`,
+         VALUES ($1,'ck_ip_leased','in_progress',now() + interval '5 minutes')`,
+        [OB1],
+      ),
+    ).resolves.toBeTruthy()
+    // (c) NOT-in_progress + lease → rejected (the OTHER half the review flagged: a stale lease on done/pending
+    //     would be spuriously matched by the reclaim scan).
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at)
+         VALUES ($1,'ck_done_leased','done',now() + interval '5 minutes')`,
+        [OB1],
+      ),
+    ).rejects.toThrow(/automation_outbox_consumer_lease_iff_in_progress/)
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at)
+         VALUES ($1,'ck_pending_leased','pending',now() + interval '5 minutes')`,
+        [OB1],
+      ),
+    ).rejects.toThrow(/automation_outbox_consumer_lease_iff_in_progress/)
+    // (d) NOT-in_progress + NULL lease → accepted.
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at)
+         VALUES ($1,'ck_pending_nolease','pending',NULL)`,
         [OB1],
       ),
     ).resolves.toBeTruthy()
   })
 
-  test('fence/attempts non-negative CHECKs reject a negative fence', async () => {
-    await q(
-      `INSERT INTO meta_automation_outbox (id, event_type, payload, manifest_version) VALUES ($1,'approval.approved','{}'::jsonb,1)
-       ON CONFLICT (id) DO NOTHING`,
-      [OB1],
-    )
+  test('fence/attempts non-negative CHECKs reject negatives — each by its own constraint name', async () => {
+    await insertOutbox(OB1)
     await expect(
       q(
         `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, fence) VALUES ($1,'ck_negfence','pending',-1)`,
         [OB1],
       ),
-    ).rejects.toThrow()
+    ).rejects.toThrow(/automation_outbox_consumer_fence_nonneg/)
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, attempts) VALUES ($1,'ck_negattempts','pending',-1)`,
+        [OB1],
+      ),
+    ).rejects.toThrow(/automation_outbox_consumer_attempts_nonneg/)
+  })
+
+  test('fence is bigint and round-trips as a STRING beyond 2^53 (no JS-number precision loss)', async () => {
+    await insertOutbox(OB1)
+    const big = '9007199254740993' // 2^53 + 1 — the first integer a JS number cannot represent exactly.
+    expect(BigInt(big) > 2n ** 53n).toBe(true) // it is genuinely past the JS-number safe-integer boundary.
+    // Pass as a text param (never a JS number, which would corrupt it before it reached pg).
+    await q(
+      `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at, fence)
+       VALUES ($1,'ck_bigfence','pending',NULL,$2)
+       ON CONFLICT (outbox_id, consumer_key) DO UPDATE SET fence = EXCLUDED.fence`,
+      [OB1, big],
+    )
+    const r = await q(
+      `SELECT fence FROM meta_automation_outbox_consumer WHERE outbox_id=$1 AND consumer_key='ck_bigfence'`,
+      [OB1],
+    )
+    // The node-postgres driver returns bigint as a string; the exact value survives (a JS number would
+    // have collapsed 9007199254740993 → 9007199254740992). This is why OutboxConsumerRow.fence is `string`.
+    expect(typeof r.rows[0].fence).toBe('string')
+    expect(r.rows[0].fence).toBe(big)
   })
 
   test('FK cascade: deleting an outbox event removes its per-consumer lease rows', async () => {
-    await q(
-      `INSERT INTO meta_automation_outbox (id, event_type, payload, manifest_version) VALUES ($1,'approval.approved','{}'::jsonb,1)`,
-      [OB2],
-    )
+    await insertOutbox(OB2)
     await q(
       `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at, fence, attempts)
        VALUES ($1,'approval-trigger','in_progress',now() + interval '5 minutes',3,2)`,
@@ -130,22 +221,18 @@ describeIfDatabase('P2 durable-delivery S1 — automation outbox schema + flag (
     expect(Number(after.rows[0].c)).toBe(0) // cascaded
   })
 
-  test('column defaults: a fresh consumer row is pending, fence 0, attempts 0', async () => {
-    await q(
-      `INSERT INTO meta_automation_outbox (id, event_type, payload, manifest_version) VALUES ($1,'approval.approved','{}'::jsonb,1)
-       ON CONFLICT (id) DO NOTHING`,
-      [OB1],
-    )
+  test('column defaults: a fresh consumer row is pending, fence 0 (string), attempts 0, no lease', async () => {
+    await insertOutbox(OB1)
     await q(
       `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key) VALUES ($1,'ck_defaults')
        ON CONFLICT (outbox_id, consumer_key) DO NOTHING`,
       [OB1],
     )
     const r = await q(
-      `SELECT status, fence, attempts FROM meta_automation_outbox_consumer WHERE outbox_id=$1 AND consumer_key='ck_defaults'`,
+      `SELECT status, fence, attempts, lease_expires_at FROM meta_automation_outbox_consumer WHERE outbox_id=$1 AND consumer_key='ck_defaults'`,
       [OB1],
     )
-    expect(r.rows[0]).toMatchObject({ status: 'pending', fence: '0', attempts: 0 })
+    expect(r.rows[0]).toMatchObject({ status: 'pending', fence: '0', attempts: 0, lease_expires_at: null })
   })
 
   test('master flag is OFF by default and robust to whitespace/case (no S1 behavior while OFF)', () => {

--- a/packages/core-backend/tests/integration/multitable-automation-outbox-schema-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-outbox-schema-realdb.test.ts
@@ -1,0 +1,123 @@
+/**
+ * P2 durable-delivery — slice S1 schema + flag golden (real DB).
+ *
+ * Verifies the additive migration `zzzz20260715120000_create_automation_outbox` landed the two new tables
+ * with the shape the later slices depend on, that the `status` CHECK enforces the four-state machine, that
+ * the FK cascade deletes per-consumer rows with their outbox event, and that the master flag is OFF by
+ * default (so S1 changes byte-for-byte nothing at runtime). No behavior of the existing automation path is
+ * exercised — these tables are unused until the dispatcher (S2) wires them behind the flag.
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI's real-DB lane; two-point wired into
+ * plugin-tests.yml + excluded from the no-DB default job in vitest.config.ts so it cannot skip-green).
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { isDurableDeliveryEnabled, RESOLVE_PERMITTING_STATUSES } from '../../src/multitable/automation-durable-delivery'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+// A real automation_rules row is required as the outbox rows carry no rule FK, but a consumer-lease test
+// needs a genuine outbox row; we keep everything inside two synthetic ids and clean them up.
+const OB1 = `ob_s1_${Math.floor(Date.now() % 1e9)}_a`
+const OB2 = `ob_s1_${Math.floor(Date.now() % 1e9)}_b`
+
+describeIfDatabase('P2 durable-delivery S1 — automation outbox schema + flag (real DB)', () => {
+  beforeAll(async () => {
+    await q('DELETE FROM meta_automation_outbox WHERE id = ANY($1)', [[OB1, OB2]]).catch(() => {})
+  })
+  afterAll(async () => {
+    await q('DELETE FROM meta_automation_outbox WHERE id = ANY($1)', [[OB1, OB2]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('both tables exist with the expected columns', async () => {
+    const cols = async (table: string) =>
+      (await q('SELECT column_name FROM information_schema.columns WHERE table_name = $1', [table])).rows.map(
+        (r) => (r as { column_name: string }).column_name,
+      )
+    const outbox = await cols('meta_automation_outbox')
+    for (const c of ['id', 'event_type', 'payload', 'automation_depth', 'manifest_version', 'event_id', 'created_at']) {
+      expect(outbox).toContain(c)
+    }
+    const consumer = await cols('meta_automation_outbox_consumer')
+    for (const c of ['outbox_id', 'consumer_key', 'status', 'lease_expires_at', 'fence', 'attempts', 'last_error', 'updated_at']) {
+      expect(consumer).toContain(c)
+    }
+  })
+
+  test('status CHECK enforces the four-state machine (rejects an unknown status; accepts each valid one)', async () => {
+    await q(
+      `INSERT INTO meta_automation_outbox (id, event_type, payload, manifest_version) VALUES ($1,$2,$3::jsonb,1)`,
+      [OB1, 'approval.approved', JSON.stringify({ any: 'payload' })],
+    )
+    // positive control: every valid status inserts.
+    for (const s of ['pending', 'in_progress', 'done', 'failed', 'dead_letter'] as const) {
+      await q(
+        `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status)
+         VALUES ($1,$2,$3)
+         ON CONFLICT (outbox_id, consumer_key) DO UPDATE SET status = EXCLUDED.status`,
+        [OB1, `ck_${s}`, s],
+      )
+    }
+    // negative: a bogus status is rejected by the CHECK.
+    await expect(
+      q(
+        `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status) VALUES ($1,'ck_bad','bogus')`,
+        [OB1],
+      ),
+    ).rejects.toThrow()
+  })
+
+  test('FK cascade: deleting an outbox event removes its per-consumer lease rows', async () => {
+    await q(
+      `INSERT INTO meta_automation_outbox (id, event_type, payload, manifest_version) VALUES ($1,'approval.approved','{}'::jsonb,1)`,
+      [OB2],
+    )
+    await q(
+      `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, fence, attempts)
+       VALUES ($1,'approval-trigger','in_progress',3,2)`,
+      [OB2],
+    )
+    const before = await q('SELECT count(*)::int AS c FROM meta_automation_outbox_consumer WHERE outbox_id = $1', [OB2])
+    expect(Number(before.rows[0].c)).toBe(1)
+    await q('DELETE FROM meta_automation_outbox WHERE id = $1', [OB2])
+    const after = await q('SELECT count(*)::int AS c FROM meta_automation_outbox_consumer WHERE outbox_id = $1', [OB2])
+    expect(Number(after.rows[0].c)).toBe(0) // cascaded
+  })
+
+  test('column defaults: a fresh consumer row is pending, fence 0, attempts 0', async () => {
+    await q(
+      `INSERT INTO meta_automation_outbox (id, event_type, payload, manifest_version) VALUES ($1,'approval.approved','{}'::jsonb,1)
+       ON CONFLICT (id) DO NOTHING`,
+      [OB1],
+    )
+    await q(
+      `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key) VALUES ($1,'ck_defaults')
+       ON CONFLICT (outbox_id, consumer_key) DO NOTHING`,
+      [OB1],
+    )
+    const r = await q(
+      `SELECT status, fence, attempts FROM meta_automation_outbox_consumer WHERE outbox_id=$1 AND consumer_key='ck_defaults'`,
+      [OB1],
+    )
+    expect(r.rows[0]).toMatchObject({ status: 'pending', fence: '0', attempts: 0 })
+  })
+
+  test('master flag is OFF by default and robust to whitespace/case (no S1 behavior while OFF)', () => {
+    expect(isDurableDeliveryEnabled({} as NodeJS.ProcessEnv)).toBe(false)
+    expect(isDurableDeliveryEnabled({ AUTOMATION_DURABLE_DELIVERY_ENABLED: 'false' } as unknown as NodeJS.ProcessEnv)).toBe(false)
+    expect(isDurableDeliveryEnabled({ AUTOMATION_DURABLE_DELIVERY_ENABLED: '1' } as unknown as NodeJS.ProcessEnv)).toBe(false)
+    // positive control: only exactly-true (trim/case-insensitive) enables.
+    expect(isDurableDeliveryEnabled({ AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv)).toBe(true)
+    expect(isDurableDeliveryEnabled({ AUTOMATION_DURABLE_DELIVERY_ENABLED: '  TRUE ' } as unknown as NodeJS.ProcessEnv)).toBe(true)
+  })
+
+  test('RESOLVE_PERMITTING_STATUSES = {done, dead_letter} (a poisoned rule does not block adapter resolve forever)', () => {
+    expect([...RESOLVE_PERMITTING_STATUSES].sort()).toEqual(['dead_letter', 'done'])
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-automation-outbox-schema-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-outbox-schema-realdb.test.ts
@@ -88,24 +88,29 @@ describeIfDatabase('P2 durable-delivery S1 — automation outbox schema + flag (
     ).rejects.toThrow(/event_id|not-null/i)
   })
 
-  test('event_id CHECK rejects empty AND all-whitespace ids (mirrors the dedup helper .trim()); non-blank accepted', async () => {
-    // negative: empty string — a blank id the dedup helper would treat as no-identity.
-    await expect(
-      q(
-        `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
-         VALUES ($1,'approval.approved','{}'::jsonb,0,1,'')`,
-        [OB_EID],
-      ),
-    ).rejects.toThrow(/automation_outbox_event_id_nonblank/)
-    // negative: all-whitespace (space + tab + newline) — the point of [^[:space:]] over a spaces-only btrim:
-    // the helper's JS .trim() strips tab/newline too, so the CHECK must reject them to mirror it.
-    await expect(
-      q(
-        `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
-         VALUES ($1,'approval.approved','{}'::jsonb,0,1,$2)`,
-        [OB_EID, ' \t\n '],
-      ),
-    ).rejects.toThrow(/automation_outbox_event_id_nonblank/)
+  test('event_id CHECK requires a printable-ASCII non-space char — rejects empty, ASCII- AND Unicode-whitespace; accepts a real id', async () => {
+    // Every value here is one the dedup helper's `_eventId.trim()` collapses to '' (→ no identity). The
+    // Unicode-whitespace cases are the whole point of `[!-~]` over `[^[:space:]]`: PostgreSQL's `[:space:]`
+    // is ASCII-only, so `[^[:space:]]` would ACCEPT these — while JS `.trim()` strips them — leaving the DB
+    // holding an id the helper treats as blank. `[!-~]` (printable ASCII, no space) rejects them all.
+    const blanks: Array<readonly [string, string]> = [
+      ['empty', ''],
+      ['ascii space+tab+newline', ' \t\n '],
+      ['NBSP U+00A0', '\u00A0'],
+      ['EM SPACE U+2003', '\u2003'],
+      ['narrow NBSP U+202F', '\u202F'],
+      ['BOM / ZWNBSP U+FEFF', '\uFEFF'],
+    ]
+    for (const [label, value] of blanks) {
+      await expect(
+        q(
+          `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
+           VALUES ($1,'approval.approved','{}'::jsonb,0,1,$2)`,
+          [OB_EID, value],
+        ),
+        `blank event_id [${label}] must be rejected`,
+      ).rejects.toThrow(/automation_outbox_event_id_nonblank/)
+    }
     // positive control: a normal non-blank id inserts (proves the CHECK gates on blankness, not on event_id itself).
     await expect(
       q(
@@ -176,8 +181,9 @@ describeIfDatabase('P2 durable-delivery S1 — automation outbox schema + flag (
         [OB1],
       ),
     ).resolves.toBeTruthy()
-    // (c) NOT-in_progress + lease → rejected (the OTHER half the review flagged: a stale lease on done/pending
-    //     would be spuriously matched by the reclaim scan).
+    // (c) NOT-in_progress + lease → rejected. The reason is NOT that the reclaim scan would pick it up — that
+    //     scan is status-scoped and never looks at done/pending rows — but to keep a lease meaning EXACTLY
+    //     "owned by a live in_progress worker" (terminal/reclaim transitions must clear it atomically).
     await expect(
       q(
         `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at)

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -292,6 +292,10 @@ export default defineConfig({
       // C6/G8 tombstone-table retention sweep (bounded batch, keep-days floor at
       // META_REVISION_RETENTION_MIN_DAYS, disabled-by-default zero rows touched).
       'tests/integration/multitable-tombstone-retention-realdb.test.ts',
+      // P2 durable-delivery S1 (#4203 Layer 1 / #4239): additive outbox-schema + flag golden — real Postgres
+      // only (checks the migration landed both tables, the status CHECK, FK cascade, defaults). Excluded HERE
+      // so it cannot skip-green in the no-DB lane, whole-file wired into plugin-tests.yml. Two-point wiring.
+      'tests/integration/multitable-automation-outbox-schema-realdb.test.ts',
       // W0 tail (#4279, owner MUST-WRITE OD-6, design-lock §0.5 2026-07-13): field-undelete rehydration
       // revision goldens — proves `recreateFieldFromConfig`'s tombstone-value rehydration UPDATE bumps
       // `version` and emits a `recordRecordRevision` AT THE NEW version, same transaction, for every


### PR DESCRIPTION
**First runtime slice of the RATIFIED durable-delivery design** (FWB-0 lock #4203 Layer 1 + approval-line plan #4239), authorized after all four design locks landed on main. **Additive only — zero behavior change.** No existing table is altered; no code path reads or writes the new tables while `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF (the default).

## What lands
- **Migration** `zzzz20260715120000_create_automation_outbox`:
  - `meta_automation_outbox` — producer event rows, to be co-committed with the source state change (approval status / record write) by S4. `manifest_version` stamps the routing manifest that expanded the row (a v1 row is dispatched per v1 forever). `event_id` is **NOT NULL and non-blank** — the stable original-event identity the dispatcher forwards downstream as the per-rule dedup key and the outbound-idempotency seed (#4203 §producer/identity). A CHECK `event_id ~ '[!-~]'` requires a printable-ASCII non-space char, so any id the dedup helper (`automation-event-dedup.ts`: `_eventId.trim()`) would collapse to no-identity is rejected — including Unicode whitespace (NBSP/EM/narrow-NBSP/BOM), which PostgreSQL's ASCII-only `[:space:]` would have let through. Deliberately **not unique** (cutover tolerates transient double-emit and dedups at the sink, not at the outbox).
  - `meta_automation_outbox_consumer` — per-`(outbox_id, consumer_key)` delivery state: `status` is the **four**-state machine `pending|in_progress|done|dead_letter` via a named CHECK — there is **no persistent `failed`** state (a transient failure only bumps `attempts` and leaves the row reclaimable via lease expiry; bounded-attempts-exhausted → terminal `dead_letter`, so no state can stick). `lease_expires_at` is tied to `status='in_progress'` by a **biconditional** CHECK (in_progress ⇒ leased, else unreclaimable; NOT in_progress ⇒ no lease — not because the reclaim scan would pick it up, that scan is status-scoped, but to keep a lease meaning exactly "owned by a live in_progress worker", so terminal/reclaim transitions must clear it atomically). `fence` is `bigint` (zombie fencing); `attempts` incremented at claim; `fence`/`attempts`/`automation_depth`/`manifest_version` carry named non-negative / positive CHECKs. FK cascade from the outbox event.
- **`automation-durable-delivery.ts`** — `isDurableDeliveryEnabled` (default OFF, robust trim/case read mirroring `MULTITABLE_ENABLE_PIT_RESET`), the row types (`fence` is a **`string`** — node-postgres returns bigint as a string; S2's CAS stays in decimal-string space), and `RESOLVE_PERMITTING_STATUSES = {done, dead_letter}`.
- **Real-DB golden** — the migration landed both tables + columns; the status CHECK enforces the **four**-state machine (four valid inserts + a bogus status rejected); the lease **biconditional** is exercised on all four corners; `event_id` NOT NULL and the `manifest_version`/`automation_depth`/`fence`/`attempts` CHECKs each have a negative control that asserts the **specific constraint name** in the rejection (so deleting exactly one constraint reddens exactly its test); `fence` round-trips as a **string past 2^53** (no JS-number precision loss); plus FK cascade, column defaults, and the flag OFF by default with a positive control that only exactly-`true` enables. **Two-point wired** (plugin-tests.yml real-DB run + vitest.config.ts exclude) so it cannot skip-green.

## Not in this slice (subsequent P2 slices)
S2 durable dispatcher (awaited-adapter + fence-CAS claim), S3 versioned routing manifest + startup completeness assertion + rolling-deploy, S4 producer-side atomic enqueue replacing the commit-then-emit points, S5 consumer adapters + poison-terminal, S6 upgrade-migration backfill, S7 crash-injection V-series. Each behind the same default-OFF flag.

**FWB, attachment, and every related flag stay OFF** — this slice ships no behavior. **For review — not self-merging runtime.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
