### PR TITLE
feat(directory): Milestone-2 B1 — local provider bootstrap (get-or-create, at-most-one-active index, creation audit)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -564,6 +564,8 @@ jobs:
             tests/integration/directory-tenant-change-immutable.db.test.ts \
             tests/integration/directory-sync-orchestration.db.test.ts \
             tests/integration/directory-sync-schedule-timezone.db.test.ts \
+            tests/integration/directory-local-provider-bootstrap.db.test.ts \
+            tests/integration/directory-local-provider-scheduler-exclusion.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             tests/integration/attendance-notification-redelivery.db.test.ts \
             tests/integration/attendance-notification-redelivery-route.db.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260715090000_add_one_active_local_integration_per_org.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260715090000_add_one_active_local_integration_per_org.ts
@@ -1,0 +1,69 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * Canonical Org MVP — B1 (local-provider bootstrap), #4215 §5.1.
+ *
+ * Enforce "at most one ACTIVE local directory integration per org" in the DB, not by service
+ * convention: a partial unique index on `directory_integrations(org_id)` scoped to
+ * `provider = 'local' AND status = 'active'`. Two concurrent `getOrCreateLocalIntegration`
+ * calls for the same org can therefore never both create a row — the loser gets a
+ * unique-violation (23505) and re-reads the winner (see directory-sync.ts).
+ *
+ * "At least one" is deliberately NOT enforced here — that is the bootstrap service's
+ * responsibility (create-on-first-use); a partial unique index can only cap the upper bound.
+ *
+ * `directory_integrations` was created by a zzzz migration
+ * (`zzzz20260324150000_create_directory_sync_tables.ts`), so this index addition MUST also be a
+ * zzzz-prefixed TS migration — a plain 0xx SQL migration would run before the table exists and
+ * silently no-op (same rule as the sibling `schedule_timezone` / run-lease additions).
+ *
+ * IF NOT EXISTS keeps it idempotent on replay. Existing rows are unaffected: no production org
+ * has a `provider='local'` integration yet (this milestone introduces the concept), so the
+ * partial predicate matches nothing at creation time and the index cannot conflict with any
+ * current data.
+ *
+ * Owner round P2-1: `local_integration_corp_id_shape` — a CHECK constraint proving the
+ * `corp_id = 'local:' || org_id` CONSISTENCY RELATION for every `provider = 'local'` row. This is
+ * NOT full corp_id immutability by itself (a single UPDATE that rewrites BOTH `org_id` and
+ * `corp_id` together, keeping the relation, still passes the CHECK) — see the corrected comment
+ * on `getOrCreateLocalIntegration` in directory-sync.ts for the full two-half guarantee. Postgres
+ * has no `ADD CONSTRAINT IF NOT EXISTS`, so idempotency is a `pg_constraint` existence probe
+ * (mirrors `zzzz20260422225000_add_dingtalk_person_delivery_status.ts`).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS one_active_local_integration_per_org
+    ON directory_integrations (org_id)
+    WHERE provider = 'local' AND status = 'active'
+  `.execute(db)
+
+  await sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conname = 'local_integration_corp_id_shape'
+           -- conname is NOT database-unique: a same-named constraint on ANY other table would
+           -- make a bare-conname probe falsely report "already installed" and silently skip
+           -- adding the CHECK here. Pin the probe to this table and to CHECK constraints.
+           AND conrelid = 'directory_integrations'::regclass
+           AND contype = 'c'
+      ) THEN
+        ALTER TABLE directory_integrations
+        ADD CONSTRAINT local_integration_corp_id_shape
+        CHECK (provider <> 'local' OR corp_id = 'local:' || org_id);
+      END IF;
+    END $$;
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE directory_integrations
+    DROP CONSTRAINT IF EXISTS local_integration_corp_id_shape
+  `.execute(db)
+
+  await sql`DROP INDEX IF EXISTS one_active_local_integration_per_org`.execute(db)
+}

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -2139,6 +2139,112 @@ export async function createDirectoryIntegration(input: DirectoryIntegrationInpu
 }
 
 /**
+ * Canonical Org MVP — B1 (local-provider bootstrap), #4215 §5.1.
+ *
+ * Get-or-create the ONE editable `provider='local'` directory integration that is this org's
+ * canonical organization anchor. Unlike `createDirectoryIntegration` (which is DingTalk-shaped:
+ * it requires appKey/appSecret and runs `assertDingTalkCorpAllowed`), a local integration has
+ * no external credentials and no real corp — its `corp_id` is a deterministic `local:<org_id>`
+ * that satisfies the NOT NULL column and is compatible with a future tenant-scoped directory key.
+ * It is `sync_enabled = false` and, because the DingTalk sync scheduler selects
+ * `WHERE provider = 'dingtalk'` (directory-sync-scheduler.ts), it is NEVER scheduled — proven by
+ * directory-local-provider-scheduler-exclusion.db.test.ts. The absence-sweep path is likewise
+ * unreachable for a local id (every sync entry loads the integration via `getIntegrationRow`'s
+ * `provider = 'dingtalk'` filter and throws "Directory integration not found" first, :3073) —
+ * stated as mechanism, not as a separately-tested invariant.
+ *
+ * Owner round P2-1: `corp_id` immutability for a `provider='local'` row is NOT inherited from the
+ * #4181 `updateDirectoryIntegration` guard — that guard's precursor, `getIntegrationRow`, hard-
+ * filters `WHERE provider = 'dingtalk'`, so a local row's id never reaches it and the guard never
+ * runs for one. The actual guarantee here has two independent halves, both required:
+ *   1. DB — the `local_integration_corp_id_shape` CHECK constraint (this migration's sibling,
+ *      zzzz20260715090000) proves only the CONSISTENCY RELATION `corp_id = 'local:' || org_id`
+ *      for every `provider='local'` row; it does NOT by itself block a rewrite, because a single
+ *      UPDATE that changes BOTH `org_id` and `corp_id` together, keeping that relation, still
+ *      satisfies the CHECK.
+ *   2. API — the B2 write surface must never accept client-submitted `org_id` or `corp_id` on a
+ *      local integration, closing exactly the gap half 1 leaves open.
+ * Neither half alone is "immutable"; only together do they prevent a local row's tenant anchor
+ * from being silently re-tagged.
+ *
+ * Idempotent + concurrency-safe: returns the existing active local integration if present;
+ * otherwise inserts one. Two concurrent callers for the same org cannot both create a row — the
+ * partial unique index `one_active_local_integration_per_org` makes the loser's INSERT raise a
+ * unique_violation (23505), which we catch and resolve by re-reading the winner.
+ */
+export async function getOrCreateLocalIntegration(
+  orgId: string = DEFAULT_ORG_ID,
+): Promise<DirectoryIntegrationSummary> {
+  const normalizedOrgId = normalizeText(orgId) || DEFAULT_ORG_ID
+
+  const existing = await selectActiveLocalIntegration(normalizedOrgId)
+  if (existing) return summarizeIntegration(existing)
+
+  const localCorpId = `local:${normalizedOrgId}`
+  try {
+    const result = await query<DirectoryIntegrationRow>(
+      `INSERT INTO directory_integrations (
+         org_id, provider, name, status, corp_id, config, sync_enabled, schedule_cron, schedule_timezone,
+         default_deprovision_policy, created_at, updated_at
+       )
+       VALUES ($1, 'local', $2, 'active', $3, $4::jsonb, false, NULL, NULL, 'mark_inactive', NOW(), NOW())
+       RETURNING id, org_id, provider, name, status, corp_id, config, sync_enabled, schedule_cron, schedule_timezone,
+                 default_deprovision_policy, last_sync_at, last_success_at, last_error, created_at, updated_at`,
+      [
+        normalizedOrgId,
+        'Local organization',
+        localCorpId,
+        JSON.stringify({ mode: 'editable', source: 'local' }),
+      ],
+    )
+    const created = summarizeIntegration(result.rows[0])
+    try {
+      const { auditLog } = await import('../audit/audit')
+      await auditLog({
+        actorId: 'system',
+        actorType: 'system',
+        action: 'directory.local_integration.bootstrap',
+        resourceType: 'directory-integration',
+        resourceId: created.id,
+        meta: { orgId: normalizedOrgId, provider: 'local', corpId: localCorpId },
+      })
+    } catch (error) {
+      // Owner round P3: `auditLog` itself never rejects (by contract) — the only failure this
+      // catch can see is the dynamic `import('../audit/audit')` itself (e.g. a broken module
+      // graph). That must not be silently swallowed, but it also must not fail row creation:
+      // the row is already committed, so this stays best-effort and the function still returns
+      // normally below. Values-free: integrationId + orgId + an error summary only — no config,
+      // no corp values beyond the already-derived id fields.
+      logger.warn(`Failed to import audit module after local integration bootstrap: ${readErrorMessage(error, 'unknown error')}`, {
+        integrationId: created.id,
+        orgId: normalizedOrgId,
+      })
+    }
+    return created
+  } catch (error) {
+    // Concurrency: another caller won the race and created the one active local integration
+    // (Postgres unique_violation on `one_active_local_integration_per_org`). Re-read the winner.
+    if (isUniqueViolation(error)) {
+      const winner = await selectActiveLocalIntegration(normalizedOrgId)
+      if (winner) return summarizeIntegration(winner)
+    }
+    throw error
+  }
+}
+
+async function selectActiveLocalIntegration(orgId: string): Promise<DirectoryIntegrationRow | null> {
+  const result = await query<DirectoryIntegrationRow>(
+    `SELECT id, org_id, provider, name, status, corp_id, config, sync_enabled, schedule_cron, schedule_timezone,
+            default_deprovision_policy, last_sync_at, last_success_at, last_error, created_at, updated_at
+     FROM directory_integrations
+     WHERE org_id = $1 AND provider = 'local' AND status = 'active'
+     LIMIT 1`,
+    [orgId],
+  )
+  return result.rows[0] ?? null
+}
+
+/**
  * Thrown by `updateDirectoryIntegration` when a generic integration-form save tries to change
  * `corp_id` once it is already set — see the guard's comment there (org-transfer Phase 1 §12.1)
  * for why this is blocked. The rule is absolute (no synced-records probe): once set, corp_id is

--- a/packages/core-backend/tests/integration/directory-local-provider-bootstrap.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-local-provider-bootstrap.db.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { getOrCreateLocalIntegration } from '../../src/directory/directory-sync'
+
+/**
+ * Canonical Org MVP — B1 (local-provider bootstrap), #4215 §5.1, real DB.
+ *
+ * `getOrCreateLocalIntegration` is the get-or-create for the ONE editable `provider='local'`
+ * directory integration that anchors an org's canonical organization data. This proves, against
+ * real Postgres:
+ *   (a) constructed concurrency — two simultaneous bootstraps for the same org converge to the
+ *       SAME row and emit exactly ONE creation audit event (the partial unique index
+ *       `one_active_local_integration_per_org` makes the loser's INSERT raise unique_violation,
+ *       which the service catches and resolves by re-reading the winner — the loser never audits);
+ *   (b) the DB itself enforces the cap — two raw INSERTs with DIFFERENT names (so the pre-existing
+ *       UNIQUE(org_id, provider, name) cannot be what rejects the second one) still collide on the
+ *       new partial index;
+ *   (c) idempotent re-call returns the same row and does not audit a second time;
+ *   (d) the created row's shape: corp_id = 'local:<org_id>', status='active', sync_enabled=false,
+ *       config.source='local', config.mode='editable';
+ *   (e) the index is ACTIVE-only: marking the row inactive lets a fresh bootstrap create a new
+ *       active row (inactive history is preserved, not blocked);
+ *   (f) the index is provider-scoped: an org with an active 'dingtalk' integration can still get
+ *       an active 'local' one;
+ *   (g)/(h) owner round P2-1 — the `local_integration_corp_id_shape` CHECK constraint (not the
+ *       #4181 `updateDirectoryIntegration` guard, which never sees a local row's id — see the
+ *       comment on `getOrCreateLocalIntegration`) rejects a raw INSERT/UPDATE that gives a
+ *       'local' row a corp_id other than 'local:<org_id>'.
+ *
+ * Audit is asserted directly against `audit_logs` (the table `auditLog()` in
+ * `../audit/audit` -> `AuditService.logEvent` -> `AuditRepository.createAuditLog` writes to).
+ * That table is a partitioned table that lazily creates its own current-month partition on first
+ * insert (`AuditRepository.ensureCurrentMonthPartition`), so no extra fixture setup is needed here.
+ *
+ * Fixture IDs are namespaced with this file's own STAMP + a per-test suffix — integration specs
+ * share one real Postgres in CI (plugin-tests.yml), so a bare `Date.now()` can collide with
+ * another file's fixtures in the same run.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+const AUDIT_ACTION = 'directory.local_integration.bootstrap'
+
+function orgId(suffix: string): string {
+  return `b1-local-${STAMP}-${suffix}`
+}
+
+interface LocalIntegrationRow {
+  id: string
+  org_id: string
+  provider: string
+  name: string
+  status: string
+  corp_id: string
+  config: unknown
+  sync_enabled: boolean
+}
+
+async function readIntegrations(orgId: string, provider?: string): Promise<LocalIntegrationRow[]> {
+  const result = provider
+    ? await query<LocalIntegrationRow>(
+        `SELECT id, org_id, provider, name, status, corp_id, config, sync_enabled
+         FROM directory_integrations WHERE org_id = $1 AND provider = $2 ORDER BY created_at`,
+        [orgId, provider],
+      )
+    : await query<LocalIntegrationRow>(
+        `SELECT id, org_id, provider, name, status, corp_id, config, sync_enabled
+         FROM directory_integrations WHERE org_id = $1 ORDER BY created_at`,
+        [orgId],
+      )
+  return result.rows
+}
+
+async function readActiveLocalRows(orgId: string): Promise<LocalIntegrationRow[]> {
+  return (await readIntegrations(orgId, 'local')).filter((row) => row.status === 'active')
+}
+
+async function insertLocalRow(orgId: string, name: string, status: 'active' | 'inactive' = 'active'): Promise<string> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config, sync_enabled)
+     VALUES ($1, 'local', $2, $3, $4, $5::jsonb, false)
+     RETURNING id`,
+    [orgId, name, status, `local:${orgId}`, JSON.stringify({ mode: 'editable', source: 'local' })],
+  )
+  return result.rows[0].id
+}
+
+async function insertDingTalkRow(orgId: string, name: string): Promise<string> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config)
+     VALUES ($1, 'dingtalk', $2, 'active', $3, '{}'::jsonb)
+     RETURNING id`,
+    [orgId, name, `corp-${STAMP}`],
+  )
+  return result.rows[0].id
+}
+
+async function readBootstrapAuditRows(resourceId: string): Promise<Array<{ action: string; resource_type: string; resource_id: string }>> {
+  const result = await query<{ action: string; resource_type: string; resource_id: string }>(
+    `SELECT action, resource_type, resource_id FROM audit_logs
+     WHERE action = $1 AND resource_type = 'directory-integration' AND resource_id = $2`,
+    [AUDIT_ACTION, resourceId],
+  )
+  return result.rows
+}
+
+describeIfDatabase('Canonical Org MVP — B1 local provider bootstrap (real DB)', () => {
+  const seededOrgIds: string[] = []
+
+  afterEach(async () => {
+    const ids = seededOrgIds.splice(0)
+    for (const id of ids) {
+      await query(
+        `DELETE FROM audit_logs WHERE resource_type = 'directory-integration'
+           AND resource_id IN (SELECT id::text FROM directory_integrations WHERE org_id = $1)`,
+        [id],
+      )
+      await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [id])
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('(a) two concurrent bootstraps for the same org converge to one row and exactly one audit event', async () => {
+    const org = orgId('concurrent')
+    seededOrgIds.push(org)
+
+    const [first, second] = await Promise.all([getOrCreateLocalIntegration(org), getOrCreateLocalIntegration(org)])
+
+    expect(first.id).toBe(second.id)
+
+    const activeRows = await readActiveLocalRows(org)
+    expect(activeRows.length).toBe(1)
+    expect(activeRows[0].id).toBe(first.id)
+
+    const auditRows = await readBootstrapAuditRows(first.id)
+    expect(auditRows.length).toBe(1)
+  })
+
+  it('(b) DB-level cap: two raw INSERTs with different names — the second is rejected by the partial index, not the (org,provider,name) constraint', async () => {
+    const org = orgId('db-cap')
+    seededOrgIds.push(org)
+
+    await insertLocalRow(org, 'Local organization A')
+    await expect(insertLocalRow(org, 'Local organization B')).rejects.toMatchObject({
+      code: '23505',
+      constraint: 'one_active_local_integration_per_org',
+    })
+
+    const activeRows = await readActiveLocalRows(org)
+    expect(activeRows.length).toBe(1)
+    expect(activeRows[0].name).toBe('Local organization A')
+  })
+
+  it('(c) idempotent re-call returns the same row and does not audit a second time', async () => {
+    const org = orgId('idempotent')
+    seededOrgIds.push(org)
+
+    const first = await getOrCreateLocalIntegration(org)
+    const second = await getOrCreateLocalIntegration(org)
+
+    expect(second.id).toBe(first.id)
+
+    const activeRows = await readActiveLocalRows(org)
+    expect(activeRows.length).toBe(1)
+
+    const auditRows = await readBootstrapAuditRows(first.id)
+    expect(auditRows.length).toBe(1)
+  })
+
+  it('(d) created row shape: corp_id, status, sync_enabled, config.mode/source', async () => {
+    const org = orgId('shape')
+    seededOrgIds.push(org)
+
+    const created = await getOrCreateLocalIntegration(org)
+
+    const rows = await readIntegrations(org, 'local')
+    expect(rows.length).toBe(1)
+    const row = rows[0]
+    expect(row.id).toBe(created.id)
+    expect(row.corp_id).toBe(`local:${org}`)
+    expect(row.status).toBe('active')
+    expect(row.sync_enabled).toBe(false)
+    const config = row.config as { mode?: string; source?: string }
+    expect(config.mode).toBe('editable')
+    expect(config.source).toBe('local')
+  })
+
+  it('(e) active-only cap: the index permits inactive history — an inactive local row does not block a new active one, but a second ACTIVE one is still rejected', async () => {
+    // Raw inserts (not getOrCreateLocalIntegration): getOrCreateLocalIntegration always writes
+    // the constant name 'Local organization', so driving this through the service would collide
+    // on the pre-existing UNIQUE(org_id, provider, name) index — the SAME confound test (b) is
+    // written to dodge — and prove nothing about `one_active_local_integration_per_org` itself.
+    // Whether/how the service should ever re-bootstrap after a local row goes inactive (today no
+    // code path sets one inactive — scheduler/deprovision both exclude provider='local') is a
+    // service-layer naming question, not this index's job; this test isolates the index alone.
+    const org = orgId('active-only')
+    seededOrgIds.push(org)
+
+    const inactiveId = await insertLocalRow(org, 'Local organization (archived)', 'inactive')
+    // A new ACTIVE row with a different name succeeds — the partial index ignores inactive rows.
+    const activeId = await insertLocalRow(org, 'Local organization (current)', 'active')
+    expect(activeId).not.toBe(inactiveId)
+
+    const rows = await readIntegrations(org, 'local')
+    expect(rows.length).toBe(2)
+    expect(rows.find((r) => r.id === inactiveId)?.status).toBe('inactive')
+    expect(rows.find((r) => r.id === activeId)?.status).toBe('active')
+
+    // But a SECOND active row (yet another different name) is still rejected — the cap is
+    // active-only, not a one-time allowance.
+    await expect(insertLocalRow(org, 'Local organization (second-active)', 'active')).rejects.toMatchObject({
+      code: '23505',
+      constraint: 'one_active_local_integration_per_org',
+    })
+
+    const activeRows = await readActiveLocalRows(org)
+    expect(activeRows.length).toBe(1)
+    expect(activeRows[0].id).toBe(activeId)
+  })
+
+  it('(f) provider-scoped: an org with an active dingtalk integration can still get an active local one', async () => {
+    const org = orgId('coexist')
+    seededOrgIds.push(org)
+
+    const dingtalkId = await insertDingTalkRow(org, `DingTalk org ${STAMP}`)
+
+    const local = await getOrCreateLocalIntegration(org)
+
+    expect(local.id).not.toBe(dingtalkId)
+
+    const allRows = await readIntegrations(org)
+    expect(allRows.length).toBe(2)
+    expect(allRows.every((r) => r.status === 'active')).toBe(true)
+    expect(allRows.map((r) => r.provider).sort()).toEqual(['dingtalk', 'local'])
+  })
+
+  // Owner round P2-1: `getIntegrationRow` (the precursor to `updateDirectoryIntegration`'s
+  // corp_id-immutable guard) hard-filters `provider = 'dingtalk'`, so a `provider='local'` row's
+  // id never reaches that guard — it cannot be what protects a local row's corp_id shape. These
+  // two tests prove the REAL backstop is the `local_integration_corp_id_shape` DB CHECK
+  // constraint, independent of any application-layer guard, via raw INSERT/UPDATE that never go
+  // through `updateDirectoryIntegration` at all.
+  it('(g) DB CHECK: a raw INSERT of a local row whose corp_id does not equal local:<org_id> is rejected', async () => {
+    const org = orgId('check-insert')
+    seededOrgIds.push(org)
+
+    await expect(
+      query(
+        `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config, sync_enabled)
+         VALUES ($1, 'local', $2, 'active', $3, $4::jsonb, false)`,
+        [org, 'Local organization', `local:${org}-wrong`, JSON.stringify({ mode: 'editable', source: 'local' })],
+      ),
+    ).rejects.toMatchObject({
+      code: '23514',
+      constraint: 'local_integration_corp_id_shape',
+    })
+
+    const rows = await readIntegrations(org, 'local')
+    expect(rows.length).toBe(0)
+  })
+
+  it('(h) DB CHECK: a raw UPDATE that rewrites an existing local row\'s corp_id alone is rejected', async () => {
+    const org = orgId('check-update')
+    seededOrgIds.push(org)
+
+    const id = await insertLocalRow(org, 'Local organization')
+
+    await expect(
+      query(`UPDATE directory_integrations SET corp_id = $1 WHERE id = $2`, [`local:${org}-retagged`, id]),
+    ).rejects.toMatchObject({
+      code: '23514',
+      constraint: 'local_integration_corp_id_shape',
+    })
+
+    const rows = await readIntegrations(org, 'local')
+    expect(rows.length).toBe(1)
+    expect(rows[0].corp_id).toBe(`local:${org}`)
+  })
+})

--- a/packages/core-backend/tests/integration/directory-local-provider-scheduler-exclusion.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-local-provider-scheduler-exclusion.db.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { SchedulerServiceImpl } from '../../src/services/SchedulerService'
+import {
+  resetDirectorySyncSchedulerForTests,
+  startDirectorySyncScheduler,
+} from '../../src/directory/directory-sync-scheduler'
+
+/**
+ * Canonical Org MVP — B1 owner round P2-2 (local-provider bootstrap), #4215 §5.1, real DB.
+ *
+ * `getOrCreateLocalIntegration`'s doc comment claims a `provider='local'` row is "NEVER
+ * scheduled or swept" because `directory-sync-scheduler.ts`'s `listScheduleRows()` selects
+ * `WHERE provider = 'dingtalk'`. That was a code-facts-only claim with no test pinning it. This
+ * proves it against the scheduler's REAL startup-scan path (`startDirectorySyncScheduler`,
+ * which calls `listScheduleRows()` against real Postgres), not a mocked one:
+ *
+ *   - a `provider='local'` row is inserted FORCED to `status='active'`, `sync_enabled=true`, and
+ *     a valid `schedule_cron` — i.e. every condition `shouldSchedule()` checks is satisfied,
+ *     so if the scheduler's provider filter were ever dropped this row WOULD schedule;
+ *   - an identically-configured `provider='dingtalk'` row is inserted alongside it as a
+ *     POSITIVE CONTROL: after the same startup scan, ITS job must be registered, proving the
+ *     test is actually observing real scheduling and not just an inert no-op scan;
+ *   - after `startDirectorySyncScheduler` runs, the local row's job (exact
+ *     `directory-sync:<id>` format built by the scheduler module's private `buildJobName`,
+ *     replicated inline here since it isn't exported) must be absent, while the dingtalk row's
+ *     job must be present.
+ *
+ * Uses a real `SchedulerServiceImpl` (not a mock) so `getJob()` reflects genuine
+ * registration/absence. The forced schedule_cron is a once-a-year expression so no scheduled
+ * fire can occur during the test's lifetime; the scheduler instance is destroyed in `afterEach`
+ * regardless.
+ *
+ * Fixture IDs are namespaced with this file's own STAMP + a per-test suffix — integration specs
+ * share one real Postgres in CI (plugin-tests.yml), so a bare `Date.now()` can collide with
+ * another file's fixtures in the same run.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+// Mirrors directory-sync-scheduler.ts's private `JOB_PREFIX` + `buildJobName` — not exported,
+// so the format is replicated here (same convention the unit test suite for this module uses).
+const JOB_PREFIX = 'directory-sync'
+// Once a year (Jan 1, 00:00 UTC): a valid cron expression that cannot fire during this test.
+const FAR_FUTURE_CRON = '0 0 1 1 *'
+
+function orgId(suffix: string): string {
+  return `b1-sched-excl-${STAMP}-${suffix}`
+}
+
+function jobName(integrationId: string): string {
+  return `${JOB_PREFIX}:${integrationId}`
+}
+
+async function insertForcedScheduleRow(params: {
+  org: string
+  provider: 'local' | 'dingtalk'
+  corpId: string
+}): Promise<string> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config, sync_enabled, schedule_cron, schedule_timezone)
+     VALUES ($1, $2, $3, 'active', $4, '{}'::jsonb, true, $5, 'UTC')
+     RETURNING id`,
+    [params.org, params.provider, `Scheduler exclusion ${params.provider} ${STAMP}`, params.corpId, FAR_FUTURE_CRON],
+  )
+  return result.rows[0].id
+}
+
+describeIfDatabase('Canonical Org MVP — B1 owner round P2-2: scheduler excludes provider=local (real DB)', () => {
+  const seededOrgIds: string[] = []
+  let scheduler: SchedulerServiceImpl | null = null
+
+  afterEach(async () => {
+    scheduler?.destroy()
+    scheduler = null
+    resetDirectorySyncSchedulerForTests()
+
+    const ids = seededOrgIds.splice(0)
+    for (const id of ids) {
+      await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [id])
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('startup scan never registers a job for a forced-active/enabled/valid-cron local row, while an identically-configured dingtalk row (positive control) IS registered', async () => {
+    const org = orgId('exclusion')
+    seededOrgIds.push(org)
+
+    const localId = await insertForcedScheduleRow({ org, provider: 'local', corpId: `local:${org}` })
+    const dingtalkId = await insertForcedScheduleRow({ org, provider: 'dingtalk', corpId: `corp-${STAMP}` })
+
+    resetDirectorySyncSchedulerForTests()
+    scheduler = new SchedulerServiceImpl()
+    await startDirectorySyncScheduler({ scheduler })
+
+    const localJob = await scheduler.getJob(jobName(localId))
+    expect(localJob).toBeNull()
+
+    const dingtalkJob = await scheduler.getJob(jobName(dingtalkId))
+    expect(dingtalkJob).not.toBeNull()
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -76,6 +76,21 @@ export default defineConfig({
       // no-DB job cannot skip-green it, and wired as a WHOLE FILE into the directory real-DB
       // step in plugin-tests.yml.
       'tests/integration/directory-sync-schedule-timezone.db.test.ts',
+      // Canonical Org MVP B1 (#4215 §5.1) local-provider bootstrap (real DB): proves
+      // getOrCreateLocalIntegration's concurrency-safe get-or-create, the
+      // one_active_local_integration_per_org partial index (both halves: caps active rows,
+      // permits inactive history), the creation audit event, and provider-scoped coexistence
+      // with a dingtalk integration. DATABASE_URL-gated; excluded here so the no-DB job cannot
+      // skip-green it, and wired as a WHOLE FILE into the directory real-DB step in
+      // plugin-tests.yml.
+      'tests/integration/directory-local-provider-bootstrap.db.test.ts',
+      // Canonical Org MVP B1 owner round P2-2 (#4215 §5.1): proves, against the scheduler's REAL
+      // startup-scan path (not a mock), that a `provider='local'` row forced to every
+      // schedule-eligible condition is never registered as a cron job, with an identically
+      // configured dingtalk row as a positive control. DATABASE_URL-gated; excluded here so the
+      // no-DB job cannot skip-green it, and wired as a WHOLE FILE into the directory real-DB
+      // step in plugin-tests.yml.
+      'tests/integration/directory-local-provider-scheduler-exclusion.db.test.ts',
       // Layer-2 hidden person/button masking (real DB): proves the cross-cutting visibility-key fix actually
       // masks the VALUE end-to-end, with non-vacuous controls. DATABASE_URL-gated; excluded here so the no-DB
       // job cannot skip-green it, and wired as a WHOLE FILE into the multitable real-DB step in


### PR DESCRIPTION
## What (Canonical Org MVP · B1, per #4242 plan row B1 + #4215 §5.1 ratified design)

- **Migration** `zzzz20260715090000_add_one_active_local_integration_per_org`: the §5.1 partial unique index `ON directory_integrations(org_id) WHERE provider='local' AND status='active'` (DB caps at-MOST-one active local integration per org) **plus** the owner-prescribed shape constraint `CHECK (provider <> 'local' OR corp_id = 'local:' || org_id)` — both idempotent; the pg_constraint existence probe is pinned to `conrelid='directory_integrations'::regclass AND contype='c'` (conname alone is not database-unique — a same-named constraint on another table must not make the probe falsely skip; verified with a constructed name-collision positive control).
- **Service** `getOrCreateLocalIntegration(orgId)` (directory-sync.ts, additive): race-safe get-or-create via a plain INSERT whose **unique-violation (23505) is caught by `isUniqueViolation` and recovered by re-selecting the winner** — the loser returns the winner's row; `corp_id = local:<org_id>` derived, never client-supplied; `sync_enabled=false`, `config={mode:editable, source:local}`; creation audit event (post-commit lazy `auditLog`, values-free warn if the audit import fails) fired ONLY by the actual creator. No runtime callers yet — B2 wires CRUD.
- **corp_id guarantee wording (owner-precise)**: the CHECK proves only the `corp_id ↔ org_id` consistency relation (it does NOT block a simultaneous rewrite of both fields); the full guarantee is the pair **DB constraint relation + B2 API forbidding client-submitted org_id/corp_id**. The #4181 guard does NOT cover local rows (its precursor `getIntegrationRow` filters `provider='dingtalk'`) — comment corrected accordingly.

## Tests (real DB, two-point wired: vitest.config exclude + plugin-tests.yml whole-file step)

- `directory-local-provider-bootstrap.db.test.ts` (9): constructed 2-way race (same id / one row / one audit), raw double-INSERT rejected by the partial index, idempotent re-call (no 2nd audit), row shape, active-only cap (inactive history allowed), dingtalk+local coexistence, bad-INSERT + bad-UPDATE rejected by the CHECK (`23514`).
- `directory-local-provider-scheduler-exclusion.db.test.ts` (2): via the REAL `startDirectorySyncScheduler` startup scan — a local row forced `active + sync_enabled=true + valid cron` is NEVER registered. The test **replicates the job-name contract inline** (`buildJobName` is module-private); the identically-configured DingTalk positive control — asserted through the same replicated contract — guards the exclusion assertion against going vacuously green if the job-name format drifts.

## Verification (at this head)

- Fresh-DB full migration chain ×2 (idempotent); tsc clean; 11/11 green under `vitest.integration.config.ts` (CI-same invocation); independent 5-way race → 1 id / 1 row / 1 audit; probe name-collision positive control (same-named CHECK on another table does not skip installation).
- Load-bearing mutations (each reddens exactly its guard, then restored): drop partial index → 2 red; drop CHECK → 2 red; remove scheduler `provider='dingtalk'` predicate → exclusion test red (real path, not copied SQL); **neuter the `isUniqueViolation`/re-select recovery branch** → race test red 3/3; broaden audit to every call → idempotence test red.
- Known limitation (honest, deferred): re-bootstrap after deactivation can collide with the pre-existing `UNIQUE(org_id, provider, name)` on the same default name — B1 does not claim automatic re-creation after deactivation.

Adversarial gate: APPROVE, no P1/P2 (one comment-precision P3 folded in). Owner round-2: PR-body mechanism descriptions corrected to as-built (catch-23505+re-select, replicated job-name contract), pg_constraint probe pinned to table+type. Landing discipline: **unarmed** — awaiting owner review at the exact head after CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)