### PR TITLE
fix(attendance): residue_check log to stderr (false-FAIL on clean sweep) (refs #3317)

### DIFF
--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -557,7 +557,10 @@ residue_check() {
   [[ "$value" =~ ^[0-9]+$ ]] \
     || fail "residue-sweep query '${name}' did not return a bare integer (got '${value}'); sql: ${sql}"
   echo "${name}=${value}" >> "$RESIDUE_RESULTS_FILE"
-  log "residue-sweep ${name}=${value}"
+  # stderr, NOT stdout: callers capture this function's stdout as the numeric count, and a
+  # stdout log line contaminates the comparison (run 29395824577: all 29 counts were 0 yet
+  # the sweep false-FAILED because the captured value was "log-line\n0").
+  log "residue-sweep ${name}=${value}" >&2
   printf '%s' "$value"
 }
 


### PR DESCRIPTION
Run 29395824577: **all 29 §7 counts = 0** (the artifact's residue-sweep.txt is clean) yet the sweep FAILED — `residue_check` logged to stdout, so the caller's `$(…)` capture held `log-line\n0` and the numeric comparisons all failed, producing a garbage nonzero list. One-line fix: redirect that log call to stderr. `bash -n` clean, self-test 16/16. Refs #3317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)