### PR TITLE
fix(ops): package stock-prep acceptance runner

### DIFF
--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -85,6 +85,7 @@ REQUIRED_PATHS=(
   "scripts/ops/integration-k3wise-postdeploy-summary.mjs"
   "scripts/ops/integration-k3wise-gate-contract-check.mjs"
   "scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs"
+  "scripts/ops/stock-preparation-onprem-acceptance.ps1"
   "scripts/ops/multitable-permission-lists-postdeploy-smoke.mjs"
   "scripts/ops/fixtures/integration-k3wise"
   # Legacy SQL readonly Bridge Agent tooling. BA-M0.5 proves the approved

--- a/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
+++ b/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
@@ -370,19 +370,50 @@ test('on-prem release and workflow artifacts publish both first-hop bootstrap si
   )
 })
 
-test('on-prem verifier rejects packages missing the stock-preparation smoke contract', () => {
+test('on-prem verifier rejects packages missing the stock-preparation acceptance contract', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-stock-prep-package-'))
   const migrationPath = path.join(root, 'packages/core-backend/migrations/066_create_integration_stock_prep_audit.sql')
   const smokePath = path.join(root, 'scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs')
+  const acceptancePath = path.join(root, 'scripts/ops/stock-preparation-onprem-acceptance.ps1')
   fs.mkdirSync(path.dirname(migrationPath), { recursive: true })
   fs.mkdirSync(path.dirname(smokePath), { recursive: true })
   fs.writeFileSync(migrationPath, 'CREATE TABLE integration_stock_prep_audit ();\n')
   fs.writeFileSync(smokePath, 'S.auditActionsCovered = "8/8"\nS.selfScanClean = true\nS.pass = true\n')
+  fs.writeFileSync(
+    acceptancePath,
+    [
+      'function Get-ArchiveProvenanceGitCommit {}',
+      '$Summary.pm2StableOnline = "PASS"',
+      '$Summary.auditActionsCovered = "8/8"',
+      '$Summary.selfScanClean = "true"',
+      '$Summary.externalPlmK3ErpWrite = "false"',
+    ].join('\n'),
+  )
 
   try {
     const clean = runStockPreparationVerifier(root)
     assert.equal(clean.status, 0, clean.stderr)
 
+    fs.rmSync(acceptancePath)
+    const missingAcceptance = runStockPreparationVerifier(root)
+    assert.notEqual(missingAcceptance.status, 0)
+    assert.match(missingAcceptance.stderr, /stock-preparation one-click acceptance/)
+
+    fs.writeFileSync(acceptancePath, '$Summary.pm2StableOnline = "PASS"\n')
+    const incompleteAcceptance = runStockPreparationVerifier(root)
+    assert.notEqual(incompleteAcceptance.status, 0)
+    assert.match(incompleteAcceptance.stderr, /in-archive provenance/)
+
+    fs.writeFileSync(
+      acceptancePath,
+      [
+        'function Get-ArchiveProvenanceGitCommit {}',
+        '$Summary.pm2StableOnline = "PASS"',
+        '$Summary.auditActionsCovered = "8/8"',
+        '$Summary.selfScanClean = "true"',
+        '$Summary.externalPlmK3ErpWrite = "false"',
+      ].join('\n'),
+    )
     fs.rmSync(smokePath)
     const missing = runStockPreparationVerifier(root)
     assert.notEqual(missing.status, 0)

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -357,11 +357,17 @@ function verify_stock_preparation_mvp_contract() {
   local root="$1"
   local migration="${root}/packages/core-backend/migrations/066_create_integration_stock_prep_audit.sql"
   local smoke="${root}/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs"
+  local acceptance="${root}/scripts/ops/stock-preparation-onprem-acceptance.ps1"
 
   search_fixed_string 'integration_stock_prep_audit' "$migration" || die "migration 066 must create the stock-preparation audit surface"
   search_fixed_string 'auditActionsCovered' "$smoke" || die "stock-preparation MVP postdeploy smoke must report audit action coverage"
   search_fixed_string 'selfScanClean' "$smoke" || die "stock-preparation MVP postdeploy smoke must report its values-free self scan"
   search_fixed_string 'S.pass =' "$smoke" || die "stock-preparation MVP postdeploy smoke must emit the final pass flag"
+  search_fixed_string 'Get-ArchiveProvenanceGitCommit' "$acceptance" || die "stock-preparation one-click acceptance must bind ExpectedGitSha to in-archive provenance"
+  search_fixed_string 'pm2StableOnline' "$acceptance" || die "stock-preparation one-click acceptance must verify stable PM2 online state"
+  search_fixed_string 'auditActionsCovered' "$acceptance" || die "stock-preparation one-click acceptance must require complete audit action coverage"
+  search_fixed_string 'selfScanClean' "$acceptance" || die "stock-preparation one-click acceptance must require its values-free self scan"
+  search_fixed_string 'externalPlmK3ErpWrite' "$acceptance" || die "stock-preparation one-click acceptance must report the external-write invariant"
 }
 
 function verify_generic_integration_workbench_contract() {
@@ -890,6 +896,7 @@ required=(
   "scripts/ops/integration-k3wise-postdeploy-summary.mjs"
   "scripts/ops/integration-k3wise-gate-contract-check.mjs"
   "scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs"
+  "scripts/ops/stock-preparation-onprem-acceptance.ps1"
   "scripts/ops/multitable-permission-lists-postdeploy-smoke.mjs"
   "scripts/ops/bridge-agent-driver-smoke.ps1"
   "scripts/ops/fixtures/bridge-agent-driver-smoke/evidence.template.json"

--- a/scripts/ops/onprem-windows-system-hardening.test.mjs
+++ b/scripts/ops/onprem-windows-system-hardening.test.mjs
@@ -283,12 +283,17 @@ test('on-prem archive contract includes migration 066 and the documented postdep
     'build must package the stock-preparation smoke',
   )
   assert.ok(
+    buildScript.includes('"scripts/ops/stock-preparation-onprem-acceptance.ps1"'),
+    'build must package the stock-preparation one-click acceptance script',
+  )
+  assert.ok(
     buildScript.includes('"scripts/ops/multitable-permission-lists-postdeploy-smoke.mjs"'),
     'build must package the permission-list closeout smoke',
   )
   for (const relativePath of [
     'packages/core-backend/migrations/066_create_integration_stock_prep_audit.sql',
     'scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs',
+    'scripts/ops/stock-preparation-onprem-acceptance.ps1',
     'scripts/ops/multitable-permission-lists-postdeploy-smoke.mjs',
   ]) {
     assert.ok(verifyScript.includes(`"${relativePath}"`), `verifier must require ${relativePath}`)
@@ -297,6 +302,8 @@ test('on-prem archive contract includes migration 066 and the documented postdep
   assert.match(verifyScript, /function verify_stock_preparation_mvp_contract/)
   assert.match(verifyScript, /auditActionsCovered/)
   assert.match(verifyScript, /selfScanClean/)
+  assert.match(verifyScript, /Get-ArchiveProvenanceGitCommit/)
+  assert.match(verifyScript, /externalPlmK3ErpWrite/)
 })
 
 test('Windows apply helper retries post-PM2 healthcheck during warmup and remains fail-closed', () => {


### PR DESCRIPTION
## What changed

- include `scripts/ops/stock-preparation-onprem-acceptance.ps1` in the on-prem package
- require the script in the package verifier
- verify the acceptance runner's provenance, PM2 stability, smoke completeness, values-free, and external-write markers
- add package-contract regressions for missing and incomplete acceptance runners

## Why

The first RC-0 artifact built successfully from `05b5d16682f01a5f1a014aea334be3aaff2b9ed4`, but the archive omitted the one-click acceptance runner delivered by #4210. The existing verifier also did not require it, so the build could report green while the documented entity-machine acceptance command was unavailable.

The incomplete artifact was not published.

## Verification

- `bash -n scripts/ops/multitable-onprem-package-build.sh`
- `bash -n scripts/ops/multitable-onprem-package-verify.sh`
- `node --test scripts/ops/multitable-onprem-package-no-node-modules.test.mjs scripts/ops/onprem-windows-system-hardening.test.mjs` (24/24)
- `scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1` (11/11)
- `scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1` (25/25)
- fail-first proof: the prior RC-0 archive is rejected with `Required package content missing: scripts/ops/stock-preparation-onprem-acceptance.ps1`

After merge, RC-0 will be rebuilt from an exact `main` SHA and verified before the GitHub prerelease is published.
