### PR TITLE
fix(ops): align stock-prep acceptance bootstrap contract

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -123,8 +123,8 @@ jobs:
       - name: Global History flag manifest contract (R12-C)
         run: node --test scripts/ops/global-history-flag-manifest.test.mjs scripts/ops/multitable-global-history-flag-status.test.mjs
 
-      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (36
-      # checks = 11 contract + 25 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
+      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (40
+      # checks = 14 contract + 26 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
       # pm2/health/smoke stages are unit-tested via dot-sourced pure helpers). Run inside the REQUIRED
       # `test` gate, but only ONCE (on 20.x — no need across the 18/20 matrix), early (no pnpm install
       # needed: pwsh/tar ship on ubuntu, node is already set up) so a regression fails the required check

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -74,7 +74,20 @@ function New-Fixture {
   if ($WithBootstrap) {
     $bootName = if ($BootstrapName) { $BootstrapName } else { "$pkgBase-deploy-bootstrap.ps1" }
     $bootPath = Join-Path $pkgDir $bootName
-    Set-Content -Path $bootPath -Value 'param($PackagePath,$DeployRoot) exit 0'
+    # Mirror the REAL release sidecar contract (multitable-onprem-deploy-launcher.ps1),
+    # not the acceptance caller. Requiring both named arguments prevents caller and
+    # fixture from drifting together while the packaged sidecar rejects the call.
+    $bootstrapSource = @'
+param(
+  [Parameter(Mandatory = $true)][string]$PackageArchive,
+  [Parameter(Mandatory = $true)][string]$RootDir
+)
+if (-not (Test-Path -LiteralPath $PackageArchive -PathType Leaf)) { exit 81 }
+if (-not (Test-Path -LiteralPath $RootDir -PathType Container)) { exit 82 }
+Set-Content -Path (Join-Path $RootDir 'bootstrap-contract.marker') -Value (Split-Path -Leaf $PackageArchive) -NoNewline
+exit 0
+'@
+    Set-Content -Path $bootPath -Value $bootstrapSource
     $bootHash = if ($BootstrapBadChecksum) { '0' * 64 } else { (Get-FileHash -Path $bootPath -Algorithm SHA256).Hash.ToLower() }
     $shaLines += "$bootHash  $bootName"
   }
@@ -91,7 +104,13 @@ function New-Fixture {
     $js = "const a=process.argv.slice(2); if(a.includes('--confirm')){process.exit($confirmExit)} process.exit(0)"
     Set-Content -Path (Join-Path $migrateDir 'migrate.js') -Value $js
   }
-  [pscustomobject]@{ Root = $root; Package = $pkg; DeployRoot = $deployRoot; Summary = (Join-Path $root 'acceptance-summary.txt') }
+  [pscustomobject]@{
+    Root = $root
+    Package = $pkg
+    DeployRoot = $deployRoot
+    Summary = (Join-Path $root 'acceptance-summary.txt')
+    BootstrapMarker = (Join-Path $deployRoot 'bootstrap-contract.marker')
+  }
 }
 
 function Invoke-Acceptance {
@@ -154,8 +173,13 @@ try {
 
   # ── D2: bootstrap selected by EXACT bound name + verified against SHA256SUMS (owner P1). ─────────────
   # Correctly-named bootstrap with a valid checksum: stage 2 PASSES, stops later at migrate (absent).
-  $r = Invoke-Acceptance (New-Fixture -ProvenanceGitCommit $GOOD_SHA -WithBootstrap $true) $GOOD_SHA
+  $fx = New-Fixture -ProvenanceGitCommit $GOOD_SHA -WithBootstrap $true
+  $r = Invoke-Acceptance $fx $GOOD_SHA
   Check "correct bootstrap name + checksum -> install PASS, stops later at migrate" ($r.Summary.packageShaMatch -eq 'PASS' -and $r.Summary.failedStage -eq 'migrate')
+  Check "bootstrap receives the archive file and deploy root through the release-sidecar contract" (
+    (Test-Path $fx.BootstrapMarker -PathType Leaf) -and
+    (Get-Content $fx.BootstrapMarker -Raw) -eq (Split-Path -Leaf $fx.Package)
+  )
 
   # A DIFFERENT package's bootstrap in the same dir (wrong name) is NOT run — the derived name is absent.
   $r = Invoke-Acceptance (New-Fixture -ProvenanceGitCommit $GOOD_SHA -WithBootstrap $true -BootstrapName 'some-other-pkg-deploy-bootstrap.ps1') $GOOD_SHA

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
@@ -7,8 +7,49 @@
 $ErrorActionPreference = 'Stop'
 $script = Join-Path $PSScriptRoot '..' 'stock-preparation-onprem-acceptance.ps1'
 $src = Get-Content $script -Raw
+$launcher = Join-Path $PSScriptRoot '..' 'multitable-onprem-deploy-launcher.ps1'
 $fail = 0
 function Check { param([string]$Name, [bool]$Ok) if ($Ok) { Write-Host "  PASS  $Name" } else { Write-Host "  FAIL  $Name"; $script:fail++ } }
+
+# Parse both sides of the bootstrap boundary. A fixture that copies the caller's
+# parameter names can let caller and test drift together while the release sidecar
+# has a different contract, which is exactly what the RC-0 entity-machine run found.
+$acceptanceTokens = $null; $acceptanceErrors = $null
+$acceptanceAst = [System.Management.Automation.Language.Parser]::ParseFile(
+  $script, [ref]$acceptanceTokens, [ref]$acceptanceErrors
+)
+$launcherTokens = $null; $launcherErrors = $null
+$launcherAst = [System.Management.Automation.Language.Parser]::ParseFile(
+  $launcher, [ref]$launcherTokens, [ref]$launcherErrors
+)
+$launcherParams = @($launcherAst.ParamBlock.Parameters | ForEach-Object { $_.Name.VariablePath.UserPath })
+$bootstrapCalls = @($acceptanceAst.FindAll({
+  param($node)
+  $node -is [System.Management.Automation.Language.CommandAst] -and
+    $node.InvocationOperator -eq [System.Management.Automation.Language.TokenKind]::Ampersand -and
+    $node.CommandElements.Count -gt 0 -and
+    $node.CommandElements[0].Extent.Text -eq '$bootstrapPath'
+}, $true))
+$bootstrapCallParams = if ($bootstrapCalls.Count -eq 1) {
+  @($bootstrapCalls[0].CommandElements |
+    Where-Object { $_ -is [System.Management.Automation.Language.CommandParameterAst] } |
+    ForEach-Object { $_.ParameterName })
+} else { @() }
+
+Check "acceptance and launcher scripts parse without errors" (
+  $acceptanceErrors.Count -eq 0 -and $launcherErrors.Count -eq 0
+)
+Check "release launcher exposes PackageArchive and RootDir" (
+  'PackageArchive' -in $launcherParams -and 'RootDir' -in $launcherParams
+)
+Check "acceptance calls the release launcher with its canonical parameter names" (
+  $bootstrapCalls.Count -eq 1 -and
+  $bootstrapCallParams.Count -eq 2 -and
+  'PackageArchive' -in $bootstrapCallParams -and
+  'RootDir' -in $bootstrapCallParams -and
+  'PackagePath' -notin $bootstrapCallParams -and
+  'DeployRoot' -notin $bootstrapCallParams
+)
 
 # ── 1. Summary is values-free by construction: exactly the 9 whitelisted keys, nothing else. ─────
 $expected9 = @(

--- a/scripts/ops/stock-preparation-onprem-acceptance.ps1
+++ b/scripts/ops/stock-preparation-onprem-acceptance.ps1
@@ -278,7 +278,9 @@ function Invoke-BootstrapStage {
   $verdict = Test-Sha256SumsEntry $bootstrapPath $shaPath $bootstrapName
   if (-not $verdict.ok) { Stop-WithFailure 'install' @{ reason = "bootstrap_$($verdict.reason)" } }
 
-  & $bootstrapPath -PackagePath $PackagePath -DeployRoot $DeployRoot
+  # The release sidecar is a copy of multitable-onprem-deploy-launcher.ps1. Map this
+  # runner's operator-facing names onto that launcher's canonical parameter contract.
+  & $bootstrapPath -PackageArchive $PackagePath -RootDir $DeployRoot
   if ($LASTEXITCODE -ne 0) { Stop-WithFailure 'install' @{ exitCode = $LASTEXITCODE } }
   Write-Stage 'stage 2: PASS'
 }


### PR DESCRIPTION
## Summary

- map the stock-preparation acceptance runner's operator-facing `PackagePath` / `DeployRoot` inputs to the packaged bootstrap launcher's canonical `PackageArchive` / `RootDir` parameters
- replace the self-confirming fake bootstrap with a release-contract fixture that requires the real parameter names and verifies archive-file/root-directory semantics
- add an AST cross-contract guard between the acceptance runner and `multitable-onprem-deploy-launcher.ps1`
- update the required-gate check-count ledger from 36 to 40

## Why

The RC-0 entity-machine run in #4101 passed release checksum, remote staging checksum, and embedded provenance, then failed before installation with a PowerShell `ParameterBindingException`. The acceptance runner called the exact packaged sidecar with parameter names that the sidecar does not expose.

The prior behavior fixture declared the same incorrect names as the caller, so caller and test drifted together while CI stayed green.

## Verification

- `stock-preparation-onprem-acceptance.tests.ps1`: 14/14 PASS
- `stock-preparation-onprem-acceptance.behavior.tests.ps1`: 26/26 PASS
- old-call mutation (`-PackagePath/-DeployRoot`): static guard RED 1/14 and behavior guard RED 3/26
- on-prem package/system hardening tests: 24/24 PASS
- PowerShell parser: 3 files PASS
- workflow YAML parse: PASS
- `git diff --check`: PASS

## Boundary

- no database/runtime business logic change
- no T3a/T3b/T4 scope
- no external write or K3 Save/Submit/Audit path
- the published RC-0 archive remains invalid for the one-click acceptance path; a fresh exact-SHA package is required after this PR lands
