### PR TITLE
feat(directory): Milestone-2 B2 — local departments/accounts/memberships CRUD

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -567,6 +567,8 @@ jobs:
             tests/integration/directory-sync-schedule-timezone.db.test.ts \
             tests/integration/directory-local-provider-bootstrap.db.test.ts \
             tests/integration/directory-local-provider-scheduler-exclusion.db.test.ts \
+            tests/integration/local-directory-org-crud.db.test.ts \
+            tests/integration/local-directory-org-crud-route.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             tests/integration/attendance-notification-redelivery.db.test.ts \
             tests/integration/attendance-notification-redelivery-route.db.test.ts \

--- a/packages/core-backend/src/directory/local-directory-org-request-schema.ts
+++ b/packages/core-backend/src/directory/local-directory-org-request-schema.ts
@@ -1,0 +1,195 @@
+/**
+ * Canonical Org MVP — B2 (local departments/accounts/memberships CRUD), #4304-plan §5.2-5.4.
+ *
+ * Fail-closed field allowlists for every B2 write endpoint (owner hard requirement — the second
+ * half of the `corp_id` guarantee B1 left open, see `getOrCreateLocalIntegration`'s doc comment
+ * in `directory-sync.ts`): a B2 request body may ONLY contain keys this module explicitly
+ * allows for that operation. `org_id` / `orgId` / `corp_id` / `corpId` are never in any
+ * allowlist below, so a request that smuggles them is rejected the same way any other unknown
+ * field is — not by a special-cased denylist that could miss a spelling variant, but because
+ * the allowlist is closed by construction. Org identity is resolved server-side from the
+ * request's authenticated context (`resolveLocalDirectoryOrgId` in `admin-directory-local.ts`),
+ * which never reads the request body at all — the allowlist is defense in depth on top of that,
+ * not the only thing standing between a client and the org anchor.
+ *
+ * Pure and dependency-free by design: no DB, no Express types. Testable in the fast unit lane;
+ * the route layer is the only caller.
+ */
+
+export interface FieldAllowlistResult {
+  ok: boolean
+  /** Present only when `ok` is false — the caller decides whether/how to log this (values-free: it's a set of JSON key NAMES, never a value). */
+  rejectedFields: string[]
+}
+
+const EMPTY_RESULT: FieldAllowlistResult = { ok: true, rejectedFields: [] }
+
+/**
+ * Fail-closed: any key in `body` that is not in `allowedFields` fails the check. A non-object
+ * body (null, array, primitive, undefined) has no keys to reject, so it passes here — callers
+ * still separately validate that required fields are present and well-typed.
+ */
+export function checkFieldAllowlist(body: unknown, allowedFields: readonly string[]): FieldAllowlistResult {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return EMPTY_RESULT
+  }
+  const allowed = new Set(allowedFields)
+  const rejected = Object.keys(body as Record<string, unknown>).filter((key) => !allowed.has(key))
+  if (rejected.length === 0) return EMPTY_RESULT
+  return { ok: false, rejectedFields: rejected }
+}
+
+/** POST /api/admin/directory/local/departments */
+export const CREATE_LOCAL_DEPARTMENT_FIELDS = ['name', 'parentDepartmentId', 'orderIndex'] as const
+
+/** PATCH /api/admin/directory/local/departments/:departmentId */
+export const UPDATE_LOCAL_DEPARTMENT_FIELDS = ['name', 'parentDepartmentId', 'orderIndex'] as const
+
+/** POST /api/admin/directory/local/accounts */
+export const CREATE_LOCAL_ACCOUNT_FIELDS = ['localUserId', 'name', 'email', 'mobile', 'title'] as const
+
+/** PATCH /api/admin/directory/local/accounts/:accountId */
+export const UPDATE_LOCAL_ACCOUNT_FIELDS = ['name', 'email', 'mobile', 'title'] as const
+
+/** POST /api/admin/directory/local/memberships */
+export const ADD_LOCAL_MEMBERSHIP_FIELDS = ['accountId', 'departmentId'] as const
+
+/** PATCH /api/admin/directory/local/memberships/:membershipId — the explicit primary-department switch. */
+export const SWITCH_LOCAL_MEMBERSHIP_PRIMARY_FIELDS = ['isPrimary'] as const
+
+/**
+ * Owner P2 (review on #4317): the allowlists above only ever checked field NAMES. A
+ * present field with the WRONG TYPE (e.g. `parentDepartmentId: 123`, `email: {}`, `title: []`)
+ * fell through the route layer's `typeof x === 'string' ? x : null`-shaped extraction and was
+ * silently coerced to `null` — which, for these fields, is the DESTRUCTIVE "clear this value"
+ * signal. A malformed request body could therefore CLEAR a department's parent or an account's
+ * email/mobile/title instead of being rejected.
+ *
+ * `checkFieldTypes` closes that gap: every field an endpoint accepts also gets a declared type
+ * kind, checked BEFORE the route layer ever extracts/coerces a value. A key that is ABSENT from
+ * the body is never checked here — `undefined` continues to mean "leave this field alone"
+ * everywhere in B2. A key that IS present must match its kind exactly, or the whole request is
+ * rejected (400) before anything is read into the update input, let alone written.
+ *
+ * Nullable-by-design (kind `'stringOrNull'`, explicit `null` is a legitimate value, not a type
+ * error) vs non-nullable (kind `'string'`/`'integer'`, explicit `null` IS a type error) is decided
+ * per field from `local-directory-org.ts`'s own input types, not invented here:
+ *   - `parentDepartmentId` (department create/update): `string | null` in both
+ *     `CreateLocalDepartmentInput` and `UpdateLocalDepartmentInput` — `null` means "no parent /
+ *     make root", an explicit, designed operation.
+ *   - `email` / `mobile` / `title` (account create/update): `string | null` in both
+ *     `CreateLocalAccountInput` and `UpdateLocalAccountInput` — `null` means "no value", likewise
+ *     designed.
+ *   - `name` (department, account), `orderIndex` (department), `localUserId` (account),
+ *     `accountId` / `departmentId` (membership) are all plain `string`/`number` in those same
+ *     interfaces — none of them has a "clear to null" operation, so `null` is a type error for
+ *     every one of them, exactly like any other wrong type.
+ *
+ * `'integer'` (only `orderIndex`) requires `Number.isInteger` — this tightens the previous
+ * behavior, which silently `Math.trunc`ed any finite number the client sent (so a float or a
+ * numeric string masqueraded as accepted input instead of being rejected).
+ */
+export type LocalDirectoryFieldKind = 'string' | 'stringOrNull' | 'integer'
+
+export interface LocalDirectoryFieldSpec {
+  field: string
+  kind: LocalDirectoryFieldKind
+}
+
+export interface FieldTypeCheckResult {
+  ok: boolean
+  /** Present only when `ok` is false — the field NAME that failed (never its value — values-free). */
+  field?: string
+  /** Present only when `ok` is false — a static, field-name-only message (never echoes the received value). */
+  message?: string
+}
+
+function describeFieldKind(kind: LocalDirectoryFieldKind): string {
+  switch (kind) {
+    case 'string':
+      return 'a string'
+    case 'stringOrNull':
+      return 'a string or null'
+    case 'integer':
+      // int4-bounded (see matchesFieldKind) — say so, or a 3e9 rejection reads as a lie
+      // ("3000000000 IS an integer"). Message precision is a review contract in this repo.
+      return 'an integer within the int4 range'
+  }
+}
+
+function matchesFieldKind(value: unknown, kind: LocalDirectoryFieldKind): boolean {
+  switch (kind) {
+    case 'string':
+      return typeof value === 'string'
+    case 'stringOrNull':
+      return value === null || typeof value === 'string'
+    case 'integer':
+      // int4 bounds included: an integer beyond the column's range would pass a bare
+      // Number.isInteger gate and then blow up as a 500 at INSERT time — same
+      // "type gate exists but the write still fails loudly" seam, closed here as a 400.
+      return typeof value === 'number' && Number.isInteger(value) && value >= -2147483648 && value <= 2147483647
+  }
+}
+
+/**
+ * Strict per-field type validation, run AFTER `checkFieldAllowlist` has already confirmed every
+ * key in `body` is one this endpoint accepts. Checks only the keys `body` actually contains
+ * (`undefined`/absent fields are never touched — see module doc comment); stops at the first
+ * mismatch and reports that field's name (never its value).
+ */
+export function checkFieldTypes(body: unknown, specs: readonly LocalDirectoryFieldSpec[]): FieldTypeCheckResult {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return { ok: true }
+  }
+  const record = body as Record<string, unknown>
+  for (const spec of specs) {
+    if (!Object.prototype.hasOwnProperty.call(record, spec.field)) continue
+    if (!matchesFieldKind(record[spec.field], spec.kind)) {
+      return { ok: false, field: spec.field, message: `${spec.field} must be ${describeFieldKind(spec.kind)}` }
+    }
+  }
+  return { ok: true }
+}
+
+/** POST /api/admin/directory/local/departments — types for `CREATE_LOCAL_DEPARTMENT_FIELDS`. */
+export const CREATE_LOCAL_DEPARTMENT_FIELD_TYPES: readonly LocalDirectoryFieldSpec[] = [
+  { field: 'name', kind: 'string' },
+  { field: 'parentDepartmentId', kind: 'stringOrNull' },
+  { field: 'orderIndex', kind: 'integer' },
+]
+
+/** PATCH /api/admin/directory/local/departments/:departmentId — types for `UPDATE_LOCAL_DEPARTMENT_FIELDS`. */
+export const UPDATE_LOCAL_DEPARTMENT_FIELD_TYPES: readonly LocalDirectoryFieldSpec[] = [
+  { field: 'name', kind: 'string' },
+  { field: 'parentDepartmentId', kind: 'stringOrNull' },
+  { field: 'orderIndex', kind: 'integer' },
+]
+
+/** POST /api/admin/directory/local/accounts — types for `CREATE_LOCAL_ACCOUNT_FIELDS`. */
+export const CREATE_LOCAL_ACCOUNT_FIELD_TYPES: readonly LocalDirectoryFieldSpec[] = [
+  { field: 'localUserId', kind: 'string' },
+  { field: 'name', kind: 'string' },
+  { field: 'email', kind: 'stringOrNull' },
+  { field: 'mobile', kind: 'stringOrNull' },
+  { field: 'title', kind: 'stringOrNull' },
+]
+
+/** PATCH /api/admin/directory/local/accounts/:accountId — types for `UPDATE_LOCAL_ACCOUNT_FIELDS`. */
+export const UPDATE_LOCAL_ACCOUNT_FIELD_TYPES: readonly LocalDirectoryFieldSpec[] = [
+  { field: 'name', kind: 'string' },
+  { field: 'email', kind: 'stringOrNull' },
+  { field: 'mobile', kind: 'stringOrNull' },
+  { field: 'title', kind: 'stringOrNull' },
+]
+
+/** POST /api/admin/directory/local/memberships — types for `ADD_LOCAL_MEMBERSHIP_FIELDS`. */
+export const ADD_LOCAL_MEMBERSHIP_FIELD_TYPES: readonly LocalDirectoryFieldSpec[] = [
+  { field: 'accountId', kind: 'string' },
+  { field: 'departmentId', kind: 'string' },
+]
+
+// Note: PATCH /memberships/:membershipId (`SWITCH_LOCAL_MEMBERSHIP_PRIMARY_FIELDS`) has no
+// corresponding *_FIELD_TYPES export — its one field, `isPrimary`, is already validated more
+// strictly than any kind here could express (`body.isPrimary !== true` in admin-directory-local.ts
+// rejects anything that isn't the literal `true`, including `false`, strings, and numbers — the
+// route's own narrow-endpoint contract, not a coercion bug).

--- a/packages/core-backend/src/directory/local-directory-org.ts
+++ b/packages/core-backend/src/directory/local-directory-org.ts
@@ -1,0 +1,565 @@
+/**
+ * Canonical Org MVP — B2 (local departments/accounts/memberships CRUD), MVP sequencing plan §1
+ * row B2, design lock §5.2-5.4 (`local-directory-provider-canonical-org-anchor-development-plan-
+ * 20260709.md`).
+ *
+ * CRUD for `directory_departments` / `directory_accounts` / `directory_account_departments` rows
+ * under the ONE `provider='local'` integration a B1 `getOrCreateLocalIntegration(orgId)` call
+ * anchors (imported, not reimplemented — `directory-sync.ts` is edited nowhere by this file).
+ *
+ * Owner design fixes this module honors (do NOT reintroduce what they ruled out):
+ *   - a local department's manager/head is NEVER written into `raw` here — `raw` on a local
+ *     department/account carries provenance only (`{source:'local', ...}`); the normalized
+ *     manager relation is B3's scope, not this file's.
+ *   - archive-not-delete: departments and accounts are deactivated (`is_active=false`), never
+ *     `DELETE`d, so history is preserved. Archiving an already-archived row is a no-op success.
+ *   - `is_primary` on a membership is always an EXPLICIT write (`addLocalMembership` /
+ *     `switchLocalPrimaryDepartment`), never inferred from array order.
+ *   - a local account is linked to its platform user via `directory_account_links` only — no
+ *     `user_external_identities` row is ever written for `provider='local'` (local users
+ *     authenticate through the normal local login/session path).
+ *
+ * Every exported function takes `orgId` as an explicit, required parameter supplied by the
+ * caller (the route layer resolves it from server-side context, never from a request body) —
+ * this module does not default it, so a caller cannot accidentally fall through to some
+ * ambient org.
+ */
+
+import * as crypto from 'crypto'
+import { query, transaction } from '../db/pg'
+import { getOrCreateLocalIntegration } from './directory-sync'
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { code?: unknown }).code === '23505'
+}
+
+export class LocalDirectoryValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'LocalDirectoryValidationError'
+  }
+}
+
+export class LocalDirectoryNotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'LocalDirectoryNotFoundError'
+  }
+}
+
+export class LocalDirectoryConflictError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'LocalDirectoryConflictError'
+  }
+}
+
+const MAX_NAME_LENGTH = 200
+
+// ---------------------------------------------------------------------------------------------
+// Departments
+// ---------------------------------------------------------------------------------------------
+
+export interface LocalDepartmentSummary {
+  id: string
+  integrationId: string
+  externalDepartmentId: string
+  /** The PARENT department's `directory_departments.id` (resolved from its external key), or null for a root department. */
+  parentDepartmentId: string | null
+  name: string
+  orderIndex: number
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+interface LocalDepartmentRow {
+  id: string
+  integration_id: string
+  external_department_id: string
+  external_parent_department_id: string | null
+  name: string
+  order_index: number
+  is_active: boolean
+  created_at: string
+  updated_at: string
+  parent_id: string | null
+}
+
+// Resolves the parent's `id` (not just its key) via a self-join on the department's own key
+// space — `directory_departments` stores `external_parent_department_id` as the PARENT's
+// `external_department_id`, matching the DingTalk-sync convention (see directory-sync.ts /
+// admin-users.ts department-tree queries), not the parent row's uuid PK.
+const LOCAL_DEPARTMENT_SELECT = `
+  SELECT d.id, d.integration_id, d.external_department_id, d.external_parent_department_id,
+         d.name, d.order_index, d.is_active, d.created_at, d.updated_at, p.id AS parent_id
+    FROM directory_departments d
+    LEFT JOIN directory_departments p
+      ON p.integration_id = d.integration_id AND p.external_department_id = d.external_parent_department_id
+`
+
+async function loadLocalDepartmentForOrg(orgId: string, departmentId: string): Promise<LocalDepartmentRow | null> {
+  const integration = await getOrCreateLocalIntegration(orgId)
+  const result = await query<LocalDepartmentRow>(
+    `${LOCAL_DEPARTMENT_SELECT} WHERE d.id = $1 AND d.integration_id = $2 AND d.provider = 'local'`,
+    [departmentId, integration.id],
+  )
+  return result.rows[0] ?? null
+}
+
+function summarizeLocalDepartment(row: LocalDepartmentRow): LocalDepartmentSummary {
+  return {
+    id: row.id,
+    integrationId: row.integration_id,
+    externalDepartmentId: row.external_department_id,
+    parentDepartmentId: row.parent_id ?? null,
+    name: row.name,
+    orderIndex: row.order_index,
+    isActive: row.is_active,
+    createdAt: new Date(row.created_at).toISOString(),
+    updatedAt: new Date(row.updated_at).toISOString(),
+  }
+}
+
+export interface CreateLocalDepartmentInput {
+  orgId: string
+  name: string
+  parentDepartmentId?: string | null
+  orderIndex?: number
+}
+
+export async function createLocalDepartment(input: CreateLocalDepartmentInput): Promise<LocalDepartmentSummary> {
+  const name = normalizeText(input.name)
+  if (!name) throw new LocalDirectoryValidationError('name is required')
+  if (name.length > MAX_NAME_LENGTH) throw new LocalDirectoryValidationError(`name must be at most ${MAX_NAME_LENGTH} characters`)
+
+  const integration = await getOrCreateLocalIntegration(input.orgId)
+
+  let parentExternalDepartmentId: string | null = null
+  if (input.parentDepartmentId) {
+    const parent = await loadLocalDepartmentForOrg(input.orgId, input.parentDepartmentId)
+    if (!parent) throw new LocalDirectoryNotFoundError('parent department not found')
+    parentExternalDepartmentId = parent.external_department_id
+  }
+
+  const orderIndex = Number.isFinite(input.orderIndex) ? Math.trunc(input.orderIndex as number) : 0
+  // App-generated, immutable key — design lock §5.2: "the value should be immutable and
+  // generated by the app, for example local:<uuid>".
+  const externalDepartmentId = `local:${crypto.randomUUID()}`
+
+  const inserted = await query<{ id: string }>(
+    `INSERT INTO directory_departments (
+       integration_id, provider, external_department_id, external_parent_department_id,
+       name, order_index, is_active, raw, last_seen_at, created_at, updated_at
+     )
+     VALUES ($1, 'local', $2, $3, $4, $5, true, $6::jsonb, NOW(), NOW(), NOW())
+     RETURNING id`,
+    [
+      integration.id,
+      externalDepartmentId,
+      parentExternalDepartmentId,
+      name,
+      orderIndex,
+      // Provenance ONLY — manager is NEVER stored here (design lock §5.2 owner fix).
+      JSON.stringify({ source: 'local', metadata: {} }),
+    ],
+  )
+
+  const created = await loadLocalDepartmentForOrg(input.orgId, inserted.rows[0].id)
+  if (!created) throw new Error('local department created but reload failed')
+  return summarizeLocalDepartment(created)
+}
+
+export interface UpdateLocalDepartmentInput {
+  name?: string
+  /** `undefined` = leave unchanged; `null` = clear (make root); a string = reparent. */
+  parentDepartmentId?: string | null
+  orderIndex?: number
+}
+
+export async function updateLocalDepartment(
+  orgId: string,
+  departmentId: string,
+  input: UpdateLocalDepartmentInput,
+): Promise<LocalDepartmentSummary | null> {
+  const current = await loadLocalDepartmentForOrg(orgId, departmentId)
+  if (!current) return null
+
+  const nextName = input.name !== undefined ? normalizeText(input.name) : current.name
+  if (input.name !== undefined && !nextName) throw new LocalDirectoryValidationError('name is required')
+  if (nextName.length > MAX_NAME_LENGTH) throw new LocalDirectoryValidationError(`name must be at most ${MAX_NAME_LENGTH} characters`)
+
+  let nextParentExternalId = current.external_parent_department_id
+  if (input.parentDepartmentId !== undefined) {
+    if (input.parentDepartmentId === null) {
+      nextParentExternalId = null
+    } else {
+      if (input.parentDepartmentId === departmentId) {
+        throw new LocalDirectoryValidationError('a department cannot be its own parent')
+      }
+      const parent = await loadLocalDepartmentForOrg(orgId, input.parentDepartmentId)
+      if (!parent) throw new LocalDirectoryNotFoundError('parent department not found')
+      nextParentExternalId = parent.external_department_id
+    }
+  }
+
+  const nextOrderIndex = Number.isFinite(input.orderIndex) ? Math.trunc(input.orderIndex as number) : current.order_index
+
+  await query(
+    `UPDATE directory_departments
+        SET name = $1, external_parent_department_id = $2, order_index = $3, updated_at = NOW()
+      WHERE id = $4`,
+    [nextName, nextParentExternalId, nextOrderIndex, departmentId],
+  )
+
+  const updated = await loadLocalDepartmentForOrg(orgId, departmentId)
+  if (!updated) throw new Error('local department updated but reload failed')
+  return summarizeLocalDepartment(updated)
+}
+
+/**
+ * Archive-not-delete (design lock §12 safety invariant / this plan's SCOPE): flips `is_active`
+ * to false and returns the row unchanged otherwise. Never issues a `DELETE`. Idempotent — an
+ * already-archived department archives again as a no-op success (there is no "already deleted"
+ * failure mode to guard against).
+ */
+export async function archiveLocalDepartment(orgId: string, departmentId: string): Promise<LocalDepartmentSummary | null> {
+  const current = await loadLocalDepartmentForOrg(orgId, departmentId)
+  if (!current) return null
+
+  if (current.is_active) {
+    await query(`UPDATE directory_departments SET is_active = false, updated_at = NOW() WHERE id = $1`, [departmentId])
+  }
+
+  const updated = await loadLocalDepartmentForOrg(orgId, departmentId)
+  if (!updated) throw new Error('local department archived but reload failed')
+  return summarizeLocalDepartment(updated)
+}
+
+// ---------------------------------------------------------------------------------------------
+// Accounts
+// ---------------------------------------------------------------------------------------------
+
+export interface LocalAccountSummary {
+  id: string
+  integrationId: string
+  externalUserId: string
+  externalKey: string
+  name: string
+  email: string | null
+  mobile: string | null
+  title: string | null
+  isActive: boolean
+  localUserId: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+interface LocalAccountRow {
+  id: string
+  integration_id: string
+  external_user_id: string
+  external_key: string
+  name: string
+  email: string | null
+  mobile: string | null
+  title: string | null
+  is_active: boolean
+  created_at: string
+  updated_at: string
+  local_user_id: string | null
+}
+
+const LOCAL_ACCOUNT_SELECT = `
+  SELECT a.id, a.integration_id, a.external_user_id, a.external_key, a.name, a.email, a.mobile,
+         a.title, a.is_active, a.created_at, a.updated_at, l.local_user_id
+    FROM directory_accounts a
+    LEFT JOIN directory_account_links l ON l.directory_account_id = a.id
+`
+
+async function loadLocalAccountForOrg(orgId: string, accountId: string): Promise<LocalAccountRow | null> {
+  const integration = await getOrCreateLocalIntegration(orgId)
+  const result = await query<LocalAccountRow>(
+    `${LOCAL_ACCOUNT_SELECT} WHERE a.id = $1 AND a.integration_id = $2 AND a.provider = 'local'`,
+    [accountId, integration.id],
+  )
+  return result.rows[0] ?? null
+}
+
+function summarizeLocalAccount(row: LocalAccountRow): LocalAccountSummary {
+  return {
+    id: row.id,
+    integrationId: row.integration_id,
+    externalUserId: row.external_user_id,
+    externalKey: row.external_key,
+    name: row.name,
+    email: row.email,
+    mobile: row.mobile,
+    title: row.title,
+    isActive: row.is_active,
+    localUserId: row.local_user_id ?? null,
+    createdAt: new Date(row.created_at).toISOString(),
+    updatedAt: new Date(row.updated_at).toISOString(),
+  }
+}
+
+export interface CreateLocalAccountInput {
+  orgId: string
+  /** An EXISTING platform `users.id` — a local account always links to a real platform user. */
+  localUserId: string
+  name?: string
+  email?: string | null
+  mobile?: string | null
+  title?: string | null
+}
+
+/**
+ * Creates a `provider='local'` account row bound to an existing platform user, and links it via
+ * `directory_account_links` — never `user_external_identities` (design lock §5.3: local users
+ * authenticate through the normal local login/session path, not an external-identity bind).
+ *
+ * `external_key = '<org_id>:<local_user_id>'` (design lock §5.3), so the same platform user can
+ * hold one local directory account per org without colliding on the `(provider, external_key)`
+ * unique index.
+ */
+export async function createLocalAccount(input: CreateLocalAccountInput): Promise<LocalAccountSummary> {
+  const localUserId = normalizeText(input.localUserId)
+  if (!localUserId) throw new LocalDirectoryValidationError('localUserId is required')
+
+  const integration = await getOrCreateLocalIntegration(input.orgId)
+
+  const userRow = await query<{ id: string; name: string | null; email: string | null }>(
+    `SELECT id, name, email FROM users WHERE id = $1`,
+    [localUserId],
+  )
+  const user = userRow.rows[0]
+  if (!user) throw new LocalDirectoryNotFoundError('local user not found')
+
+  const name = normalizeText(input.name) || normalizeText(user.name) || normalizeText(user.email) || localUserId
+  if (name.length > MAX_NAME_LENGTH) throw new LocalDirectoryValidationError(`name must be at most ${MAX_NAME_LENGTH} characters`)
+  const email = input.email !== undefined ? normalizeText(input.email) || null : user.email ?? null
+  const mobile = input.mobile !== undefined ? normalizeText(input.mobile) || null : null
+  const title = input.title !== undefined ? normalizeText(input.title) || null : null
+
+  const externalUserId = localUserId
+  const externalKey = `${input.orgId}:${localUserId}`
+
+  let accountId = ''
+  try {
+    await transaction(async (client) => {
+      const inserted = await client.query(
+        `INSERT INTO directory_accounts (
+           integration_id, provider, corp_id, external_user_id, external_key, name, email, mobile,
+           title, is_active, raw, last_seen_at, created_at, updated_at
+         )
+         VALUES ($1, 'local', NULL, $2, $3, $4, $5, $6, $7, true, $8::jsonb, NOW(), NOW(), NOW())
+         RETURNING id`,
+        [
+          integration.id,
+          externalUserId,
+          externalKey,
+          name,
+          email,
+          mobile,
+          title,
+          // Provenance ONLY — NO leader_in_dept here (design lock §5.3 owner fix).
+          JSON.stringify({ source: 'local', localUserId }),
+        ],
+      )
+      accountId = (inserted.rows[0] as { id: string }).id
+
+      // Same ON CONFLICT (directory_account_id) DO UPDATE shape directory-sync.ts's own
+      // admission/link paths use (see e.g. syncDirectoryIntegration's link upsert).
+      await client.query(
+        `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy, created_at, updated_at)
+         VALUES ($1, $2, 'linked', 'local_explicit', NOW(), NOW())
+         ON CONFLICT (directory_account_id) DO UPDATE SET
+           local_user_id = EXCLUDED.local_user_id,
+           link_status = EXCLUDED.link_status,
+           match_strategy = EXCLUDED.match_strategy,
+           updated_at = NOW()`,
+        [accountId, localUserId],
+      )
+    })
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new LocalDirectoryConflictError('a local directory account already exists for this user in this org')
+    }
+    throw error
+  }
+
+  const created = await loadLocalAccountForOrg(input.orgId, accountId)
+  if (!created) throw new Error('local account created but reload failed')
+  return summarizeLocalAccount(created)
+}
+
+export interface UpdateLocalAccountInput {
+  name?: string
+  email?: string | null
+  mobile?: string | null
+  title?: string | null
+}
+
+export async function updateLocalAccount(
+  orgId: string,
+  accountId: string,
+  input: UpdateLocalAccountInput,
+): Promise<LocalAccountSummary | null> {
+  const current = await loadLocalAccountForOrg(orgId, accountId)
+  if (!current) return null
+
+  const nextName = input.name !== undefined ? normalizeText(input.name) : current.name
+  if (input.name !== undefined && !nextName) throw new LocalDirectoryValidationError('name is required')
+  if (nextName.length > MAX_NAME_LENGTH) throw new LocalDirectoryValidationError(`name must be at most ${MAX_NAME_LENGTH} characters`)
+  const nextEmail = input.email !== undefined ? normalizeText(input.email) || null : current.email
+  const nextMobile = input.mobile !== undefined ? normalizeText(input.mobile) || null : current.mobile
+  const nextTitle = input.title !== undefined ? normalizeText(input.title) || null : current.title
+
+  await query(
+    `UPDATE directory_accounts SET name = $1, email = $2, mobile = $3, title = $4, updated_at = NOW() WHERE id = $5`,
+    [nextName, nextEmail, nextMobile, nextTitle, accountId],
+  )
+
+  const updated = await loadLocalAccountForOrg(orgId, accountId)
+  if (!updated) throw new Error('local account updated but reload failed')
+  return summarizeLocalAccount(updated)
+}
+
+/** Archive-not-delete, same semantics as `archiveLocalDepartment`. Keeps `directory_account_links` intact. */
+export async function archiveLocalAccount(orgId: string, accountId: string): Promise<LocalAccountSummary | null> {
+  const current = await loadLocalAccountForOrg(orgId, accountId)
+  if (!current) return null
+
+  if (current.is_active) {
+    await query(`UPDATE directory_accounts SET is_active = false, updated_at = NOW() WHERE id = $1`, [accountId])
+  }
+
+  const updated = await loadLocalAccountForOrg(orgId, accountId)
+  if (!updated) throw new Error('local account archived but reload failed')
+  return summarizeLocalAccount(updated)
+}
+
+// ---------------------------------------------------------------------------------------------
+// Memberships
+// ---------------------------------------------------------------------------------------------
+
+export interface LocalMembershipSummary {
+  accountId: string
+  departmentId: string
+  isPrimary: boolean
+  createdAt: string
+}
+
+interface LocalMembershipRow {
+  directory_account_id: string
+  directory_department_id: string
+  is_primary: boolean
+  created_at: string
+}
+
+function summarizeLocalMembership(row: LocalMembershipRow): LocalMembershipSummary {
+  return {
+    accountId: row.directory_account_id,
+    departmentId: row.directory_department_id,
+    isPrimary: row.is_primary,
+    createdAt: new Date(row.created_at).toISOString(),
+  }
+}
+
+/** Both the account and the department must belong to THIS org's local integration — no cross-org or cross-provider membership can be created. */
+async function assertLocalMembershipTargets(orgId: string, accountId: string, departmentId: string): Promise<void> {
+  const integration = await getOrCreateLocalIntegration(orgId)
+  const check = await query<{ account_ok: boolean; department_ok: boolean }>(
+    `SELECT
+       EXISTS(SELECT 1 FROM directory_accounts WHERE id = $1 AND integration_id = $2 AND provider = 'local') AS account_ok,
+       EXISTS(SELECT 1 FROM directory_departments WHERE id = $3 AND integration_id = $2 AND provider = 'local') AS department_ok`,
+    [accountId, integration.id, departmentId],
+  )
+  const row = check.rows[0]
+  if (!row?.account_ok) throw new LocalDirectoryNotFoundError('local account not found')
+  if (!row?.department_ok) throw new LocalDirectoryNotFoundError('local department not found')
+}
+
+export interface AddLocalMembershipInput {
+  orgId: string
+  accountId: string
+  departmentId: string
+}
+
+/**
+ * Idempotent add: the SAME (account, department) pair inserted twice yields exactly one row
+ * (`ON CONFLICT (directory_account_id, directory_department_id) DO NOTHING` — the table's
+ * existing composite PK). A new row starts `is_primary=false`; use
+ * `switchLocalPrimaryDepartment` to make a membership primary — that is a SEPARATE, explicit
+ * operation on purpose (design lock §5.4: "primary department must be explicit, not inferred").
+ */
+export async function addLocalMembership(input: AddLocalMembershipInput): Promise<LocalMembershipSummary> {
+  await assertLocalMembershipTargets(input.orgId, input.accountId, input.departmentId)
+
+  const inserted = await query<LocalMembershipRow>(
+    `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary, created_at)
+     VALUES ($1, $2, false, NOW())
+     ON CONFLICT (directory_account_id, directory_department_id) DO NOTHING
+     RETURNING directory_account_id, directory_department_id, is_primary, created_at`,
+    [input.accountId, input.departmentId],
+  )
+
+  if (inserted.rows[0]) return summarizeLocalMembership(inserted.rows[0])
+
+  // Already existed — idempotent re-add reads back the existing row unchanged.
+  const existing = await query<LocalMembershipRow>(
+    `SELECT directory_account_id, directory_department_id, is_primary, created_at
+       FROM directory_account_departments
+      WHERE directory_account_id = $1 AND directory_department_id = $2`,
+    [input.accountId, input.departmentId],
+  )
+  if (!existing.rows[0]) throw new Error('membership add: row neither inserted nor found')
+  return summarizeLocalMembership(existing.rows[0])
+}
+
+/**
+ * The explicit primary-department switch (design lock §5.4). Requires the membership to already
+ * exist (`addLocalMembership` first) — this function only ever moves the primary flag, it does
+ * not create memberships. Demotes every OTHER membership for the account, then promotes this
+ * one, inside one transaction, so at most one row is ever `is_primary=true` for a given account
+ * at any point another reader can observe.
+ */
+export async function switchLocalPrimaryDepartment(
+  orgId: string,
+  accountId: string,
+  departmentId: string,
+): Promise<LocalMembershipSummary> {
+  await assertLocalMembershipTargets(orgId, accountId, departmentId)
+
+  const membershipExists = await query<{ exists: boolean }>(
+    `SELECT EXISTS(
+       SELECT 1 FROM directory_account_departments
+        WHERE directory_account_id = $1 AND directory_department_id = $2
+     ) AS exists`,
+    [accountId, departmentId],
+  )
+  if (!membershipExists.rows[0]?.exists) {
+    throw new LocalDirectoryNotFoundError('membership not found; add the membership before setting it primary')
+  }
+
+  await transaction(async (client) => {
+    await client.query(`UPDATE directory_account_departments SET is_primary = false WHERE directory_account_id = $1`, [accountId])
+    await client.query(
+      `UPDATE directory_account_departments SET is_primary = true WHERE directory_account_id = $1 AND directory_department_id = $2`,
+      [accountId, departmentId],
+    )
+  })
+
+  const result = await query<LocalMembershipRow>(
+    `SELECT directory_account_id, directory_department_id, is_primary, created_at
+       FROM directory_account_departments
+      WHERE directory_account_id = $1 AND directory_department_id = $2`,
+    [accountId, departmentId],
+  )
+  if (!result.rows[0]) throw new Error('membership primary switch: row not found after update')
+  return summarizeLocalMembership(result.rows[0])
+}

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -162,6 +162,7 @@ import { viewsRouter } from './routes/views'
 import { initAdminRoutes } from './routes/admin-routes'
 import { adminUsersRouter } from './routes/admin-users'
 import { adminDirectoryRouter } from './routes/admin-directory'
+import { adminDirectoryLocalRouter } from './routes/admin-directory-local'
 import { startDirectorySyncScheduler, stopDirectorySyncScheduler } from './directory/directory-sync-scheduler'
 import { canaryRoutes } from './routes/canary-routes'
 import { CanaryRouter } from './canary/CanaryRouter'
@@ -1255,6 +1256,9 @@ export class MetaSheetServer {
     }))
     this.app.use(adminUsersRouter())
     this.app.use('/api/admin/directory', adminDirectoryRouter())
+    // Canonical Org MVP B2 (local departments/accounts/memberships CRUD) — mounted alongside
+    // adminDirectoryRouter under the same base path, sharing its `ensurePlatformAdmin` RBAC gate.
+    this.app.use('/api/admin/directory/local', adminDirectoryLocalRouter())
 
     // Canary routing (behind ENABLE_CANARY_ROUTING feature flag)
     const canaryEnabled = process.env.ENABLE_CANARY_ROUTING === 'true'

--- a/packages/core-backend/src/routes/admin-directory-local.ts
+++ b/packages/core-backend/src/routes/admin-directory-local.ts
@@ -1,0 +1,395 @@
+import type { Request, Response } from 'express'
+import { Router } from 'express'
+import { auditLog } from '../audit/audit'
+import { Logger } from '../core/logger'
+import { ensurePlatformAdmin } from './admin-directory'
+import {
+  ADD_LOCAL_MEMBERSHIP_FIELD_TYPES,
+  ADD_LOCAL_MEMBERSHIP_FIELDS,
+  CREATE_LOCAL_ACCOUNT_FIELD_TYPES,
+  CREATE_LOCAL_ACCOUNT_FIELDS,
+  CREATE_LOCAL_DEPARTMENT_FIELD_TYPES,
+  CREATE_LOCAL_DEPARTMENT_FIELDS,
+  SWITCH_LOCAL_MEMBERSHIP_PRIMARY_FIELDS,
+  UPDATE_LOCAL_ACCOUNT_FIELD_TYPES,
+  UPDATE_LOCAL_ACCOUNT_FIELDS,
+  UPDATE_LOCAL_DEPARTMENT_FIELD_TYPES,
+  UPDATE_LOCAL_DEPARTMENT_FIELDS,
+  checkFieldAllowlist,
+  checkFieldTypes,
+  type LocalDirectoryFieldSpec,
+} from '../directory/local-directory-org-request-schema'
+import {
+  LocalDirectoryConflictError,
+  LocalDirectoryNotFoundError,
+  LocalDirectoryValidationError,
+  addLocalMembership,
+  archiveLocalAccount,
+  archiveLocalDepartment,
+  createLocalAccount,
+  createLocalDepartment,
+  switchLocalPrimaryDepartment,
+  updateLocalAccount,
+  updateLocalDepartment,
+} from '../directory/local-directory-org'
+import { jsonError, jsonOk } from '../util/response'
+
+const logger = new Logger('AdminDirectoryLocalRoutes')
+
+// Must match `directory-sync.ts`'s own (unexported) `DEFAULT_ORG_ID`. Not imported/re-exported
+// from there on purpose — keeping this file's only coupling to directory-sync.ts limited to the
+// `getOrCreateLocalIntegration` import (via local-directory-org.ts) means this route file never
+// needs to change if directory-sync.ts's internals move, and vice versa (clean parallel-lane
+// rebase with B3, which also touches directory-sync.ts).
+const DEFAULT_ORG_ID = 'default'
+
+/**
+ * The SOLE origin of org identity for every B2 write below. This codebase's directory subsystem
+ * is single-tenant today: `admin-directory.ts`'s routes don't reference an org constant at the
+ * route layer at all — they call the directory-sync services with no `orgId` argument and let
+ * those services default it (`directory-sync.ts`'s own unexported `DEFAULT_ORG_ID = 'default'`).
+ * This route resolves the SAME effective org ('default') explicitly instead, because
+ * `local-directory-org.ts`'s functions require `orgId` (no default — see that module's header
+ * comment on why). There is no per-request org/tenant context wired into the directory subsystem
+ * yet for either style to read. Request bodies are never read for org identity here: this is the
+ * actual mechanism that makes `org_id`/`corp_id` unspoofable, independent of (and in addition to)
+ * the field allowlists below, which separately reject a request that even TRIES to send them.
+ */
+function resolveLocalDirectoryOrgId(_req: Request): string {
+  return DEFAULT_ORG_ID
+}
+
+function readErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message.trim().length > 0 ? error.message : fallback
+}
+
+/**
+ * Maps the three typed local-directory-org.ts errors to their HTTP status; anything else is an
+ * unexpected 500. Error `.message` on all three thrown types is a static, developer-authored
+ * string (never a client-supplied value), so surfacing it stays values-free.
+ */
+function handleLocalDirectoryError(res: Response, error: unknown, fallbackMessage: string): void {
+  if (error instanceof LocalDirectoryValidationError) {
+    jsonError(res, 400, 'DIRECTORY_LOCAL_INVALID_INPUT', error.message)
+    return
+  }
+  if (error instanceof LocalDirectoryNotFoundError) {
+    jsonError(res, 404, 'DIRECTORY_LOCAL_NOT_FOUND', error.message)
+    return
+  }
+  if (error instanceof LocalDirectoryConflictError) {
+    jsonError(res, 409, 'DIRECTORY_LOCAL_CONFLICT', error.message)
+    return
+  }
+  logger.warn(fallbackMessage, { error: readErrorMessage(error, 'unknown error') })
+  jsonError(res, 500, 'DIRECTORY_LOCAL_INTERNAL_ERROR', fallbackMessage)
+}
+
+/**
+ * Owner hard requirement: every B2 write endpoint validates its body against a fail-closed field
+ * allowlist BEFORE touching any field — `org_id`/`corp_id` (and any other key not in that
+ * endpoint's allowlist) make the whole request 400, rather than being silently dropped. Returns
+ * true and writes the 400 response if the request should stop here.
+ */
+function rejectUnlistedFields(req: Request, res: Response, allowedFields: readonly string[]): boolean {
+  const allowlist = checkFieldAllowlist(req.body, allowedFields)
+  if (allowlist.ok) return false
+  jsonError(res, 400, 'DIRECTORY_LOCAL_UNKNOWN_FIELDS', 'Request body contains fields not accepted by this endpoint')
+  return true
+}
+
+/**
+ * Owner P2 (review on #4317): a field allowed BY NAME (past `rejectUnlistedFields` above)
+ * must still match its declared TYPE, or the whole request 400s here — before ANY field is read
+ * out of `req.body` into a service-layer input. This is what stops e.g.
+ * `PATCH /departments/:id {parentDepartmentId: 123}` from ever reaching the `typeof x === 'string'
+ * ? x : null`-shaped extraction below it, which is what silently coerced a wrong-typed value into
+ * the destructive `null` ("clear this field") signal. See `checkFieldTypes`'s doc comment in
+ * `local-directory-org-request-schema.ts` for the full nullable-by-design rationale per field.
+ */
+function rejectInvalidFieldTypes(req: Request, res: Response, specs: readonly LocalDirectoryFieldSpec[]): boolean {
+  const result = checkFieldTypes(req.body, specs)
+  if (result.ok) return false
+  jsonError(res, 400, 'DIRECTORY_LOCAL_INVALID_INPUT', result.message)
+  return true
+}
+
+function parseMembershipId(raw: string): { accountId: string; departmentId: string } | null {
+  const parts = raw.split(':')
+  if (parts.length !== 2) return null
+  const [accountId, departmentId] = parts
+  if (!accountId || !departmentId) return null
+  return { accountId, departmentId }
+}
+
+export function adminDirectoryLocalRouter(): Router {
+  const router = Router()
+
+  // ---- Departments ------------------------------------------------------------------------
+
+  router.post('/departments', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectUnlistedFields(req, res, CREATE_LOCAL_DEPARTMENT_FIELDS)) return
+    if (rejectInvalidFieldTypes(req, res, CREATE_LOCAL_DEPARTMENT_FIELD_TYPES)) return
+
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const name = typeof body.name === 'string' ? body.name : ''
+    const parentDepartmentId = typeof body.parentDepartmentId === 'string' ? body.parentDepartmentId : null
+    const orderIndex = typeof body.orderIndex === 'number' ? body.orderIndex : undefined
+
+    try {
+      const orgId = resolveLocalDirectoryOrgId(req)
+      const department = await createLocalDepartment({ orgId, name, parentDepartmentId, orderIndex })
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'directory.local_department.create',
+        resourceType: 'directory-department',
+        resourceId: department.id,
+        meta: {
+          integrationId: department.integrationId,
+          hasParent: department.parentDepartmentId !== null,
+        },
+      })
+      jsonOk(res, { department })
+    } catch (error) {
+      handleLocalDirectoryError(res, error, 'Failed to create local department')
+    }
+  })
+
+  router.patch('/departments/:departmentId', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectUnlistedFields(req, res, UPDATE_LOCAL_DEPARTMENT_FIELDS)) return
+    if (rejectInvalidFieldTypes(req, res, UPDATE_LOCAL_DEPARTMENT_FIELD_TYPES)) return
+
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const input: { name?: string; parentDepartmentId?: string | null; orderIndex?: number } = {}
+    if (typeof body.name === 'string') input.name = body.name
+    if (Object.prototype.hasOwnProperty.call(body, 'parentDepartmentId')) {
+      input.parentDepartmentId = body.parentDepartmentId === null ? null : typeof body.parentDepartmentId === 'string' ? body.parentDepartmentId : null
+    }
+    if (typeof body.orderIndex === 'number') input.orderIndex = body.orderIndex
+
+    try {
+      const orgId = resolveLocalDirectoryOrgId(req)
+      const department = await updateLocalDepartment(orgId, req.params.departmentId, input)
+      if (!department) {
+        jsonError(res, 404, 'DIRECTORY_LOCAL_NOT_FOUND', 'Local department not found')
+        return
+      }
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'directory.local_department.update',
+        resourceType: 'directory-department',
+        resourceId: department.id,
+        meta: {
+          integrationId: department.integrationId,
+          nameChanged: typeof body.name === 'string',
+          parentChanged: Object.prototype.hasOwnProperty.call(body, 'parentDepartmentId'),
+          orderChanged: typeof body.orderIndex === 'number',
+        },
+      })
+      jsonOk(res, { department })
+    } catch (error) {
+      handleLocalDirectoryError(res, error, 'Failed to update local department')
+    }
+  })
+
+  router.post('/departments/:departmentId/archive', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectUnlistedFields(req, res, [])) return
+
+    try {
+      const orgId = resolveLocalDirectoryOrgId(req)
+      const department = await archiveLocalDepartment(orgId, req.params.departmentId)
+      if (!department) {
+        jsonError(res, 404, 'DIRECTORY_LOCAL_NOT_FOUND', 'Local department not found')
+        return
+      }
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'directory.local_department.archive',
+        resourceType: 'directory-department',
+        resourceId: department.id,
+        meta: { integrationId: department.integrationId },
+      })
+      jsonOk(res, { department })
+    } catch (error) {
+      handleLocalDirectoryError(res, error, 'Failed to archive local department')
+    }
+  })
+
+  // ---- Accounts -----------------------------------------------------------------------------
+
+  router.post('/accounts', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectUnlistedFields(req, res, CREATE_LOCAL_ACCOUNT_FIELDS)) return
+    if (rejectInvalidFieldTypes(req, res, CREATE_LOCAL_ACCOUNT_FIELD_TYPES)) return
+
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const localUserId = typeof body.localUserId === 'string' ? body.localUserId : ''
+    const name = typeof body.name === 'string' ? body.name : undefined
+    const email = typeof body.email === 'string' ? body.email : body.email === null ? null : undefined
+    const mobile = typeof body.mobile === 'string' ? body.mobile : body.mobile === null ? null : undefined
+    const title = typeof body.title === 'string' ? body.title : body.title === null ? null : undefined
+
+    try {
+      const orgId = resolveLocalDirectoryOrgId(req)
+      const account = await createLocalAccount({ orgId, localUserId, name, email, mobile, title })
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'directory.local_account.create',
+        resourceType: 'directory-account',
+        resourceId: account.id,
+        meta: { integrationId: account.integrationId, localUserId: account.localUserId },
+      })
+      jsonOk(res, { account })
+    } catch (error) {
+      handleLocalDirectoryError(res, error, 'Failed to create local account')
+    }
+  })
+
+  router.patch('/accounts/:accountId', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectUnlistedFields(req, res, UPDATE_LOCAL_ACCOUNT_FIELDS)) return
+    if (rejectInvalidFieldTypes(req, res, UPDATE_LOCAL_ACCOUNT_FIELD_TYPES)) return
+
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const input: { name?: string; email?: string | null; mobile?: string | null; title?: string | null } = {}
+    if (typeof body.name === 'string') input.name = body.name
+    if (Object.prototype.hasOwnProperty.call(body, 'email')) input.email = typeof body.email === 'string' ? body.email : null
+    if (Object.prototype.hasOwnProperty.call(body, 'mobile')) input.mobile = typeof body.mobile === 'string' ? body.mobile : null
+    if (Object.prototype.hasOwnProperty.call(body, 'title')) input.title = typeof body.title === 'string' ? body.title : null
+
+    try {
+      const orgId = resolveLocalDirectoryOrgId(req)
+      const account = await updateLocalAccount(orgId, req.params.accountId, input)
+      if (!account) {
+        jsonError(res, 404, 'DIRECTORY_LOCAL_NOT_FOUND', 'Local account not found')
+        return
+      }
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'directory.local_account.update',
+        resourceType: 'directory-account',
+        resourceId: account.id,
+        meta: {
+          integrationId: account.integrationId,
+          nameChanged: typeof body.name === 'string',
+          emailChanged: Object.prototype.hasOwnProperty.call(body, 'email'),
+          mobileChanged: Object.prototype.hasOwnProperty.call(body, 'mobile'),
+          titleChanged: Object.prototype.hasOwnProperty.call(body, 'title'),
+        },
+      })
+      jsonOk(res, { account })
+    } catch (error) {
+      handleLocalDirectoryError(res, error, 'Failed to update local account')
+    }
+  })
+
+  router.post('/accounts/:accountId/archive', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectUnlistedFields(req, res, [])) return
+
+    try {
+      const orgId = resolveLocalDirectoryOrgId(req)
+      const account = await archiveLocalAccount(orgId, req.params.accountId)
+      if (!account) {
+        jsonError(res, 404, 'DIRECTORY_LOCAL_NOT_FOUND', 'Local account not found')
+        return
+      }
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'directory.local_account.archive',
+        resourceType: 'directory-account',
+        resourceId: account.id,
+        meta: { integrationId: account.integrationId },
+      })
+      jsonOk(res, { account })
+    } catch (error) {
+      handleLocalDirectoryError(res, error, 'Failed to archive local account')
+    }
+  })
+
+  // ---- Memberships --------------------------------------------------------------------------
+
+  router.post('/memberships', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectUnlistedFields(req, res, ADD_LOCAL_MEMBERSHIP_FIELDS)) return
+    if (rejectInvalidFieldTypes(req, res, ADD_LOCAL_MEMBERSHIP_FIELD_TYPES)) return
+
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const accountId = typeof body.accountId === 'string' ? body.accountId : ''
+    const departmentId = typeof body.departmentId === 'string' ? body.departmentId : ''
+
+    try {
+      const orgId = resolveLocalDirectoryOrgId(req)
+      if (!accountId || !departmentId) {
+        throw new LocalDirectoryValidationError('accountId and departmentId are required')
+      }
+      const membership = await addLocalMembership({ orgId, accountId, departmentId })
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'directory.local_membership.add',
+        resourceType: 'directory-account-department',
+        resourceId: `${membership.accountId}:${membership.departmentId}`,
+        meta: { accountId: membership.accountId, departmentId: membership.departmentId },
+      })
+      jsonOk(res, { membership: { id: `${membership.accountId}:${membership.departmentId}`, ...membership } })
+    } catch (error) {
+      handleLocalDirectoryError(res, error, 'Failed to add local membership')
+    }
+  })
+
+  router.patch('/memberships/:membershipId', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectUnlistedFields(req, res, SWITCH_LOCAL_MEMBERSHIP_PRIMARY_FIELDS)) return
+
+    const parsed = parseMembershipId(req.params.membershipId)
+    if (!parsed) {
+      jsonError(res, 400, 'DIRECTORY_LOCAL_INVALID_INPUT', 'membershipId must be "<accountId>:<departmentId>"')
+      return
+    }
+
+    const body = (req.body ?? {}) as Record<string, unknown>
+    // This route is deliberately narrow: the ONLY supported operation is the explicit primary
+    // switch (design lock §5.4). `{isPrimary: true}` is required — anything else (missing,
+    // false, non-boolean) is rejected rather than guessed at.
+    if (body.isPrimary !== true) {
+      jsonError(res, 400, 'DIRECTORY_LOCAL_INVALID_INPUT', 'isPrimary must be true — this endpoint only performs the explicit primary-department switch')
+      return
+    }
+
+    try {
+      const orgId = resolveLocalDirectoryOrgId(req)
+      const membership = await switchLocalPrimaryDepartment(orgId, parsed.accountId, parsed.departmentId)
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'directory.local_membership.switch_primary',
+        resourceType: 'directory-account-department',
+        resourceId: `${membership.accountId}:${membership.departmentId}`,
+        meta: { accountId: membership.accountId, departmentId: membership.departmentId },
+      })
+      jsonOk(res, { membership: { id: `${membership.accountId}:${membership.departmentId}`, ...membership } })
+    } catch (error) {
+      handleLocalDirectoryError(res, error, 'Failed to switch local primary department')
+    }
+  })
+
+  return router
+}

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -201,7 +201,12 @@ function hasLegacyAdminClaim(req: Request): boolean {
   return false
 }
 
-async function ensurePlatformAdmin(req: Request, res: Response): Promise<string | null> {
+/**
+ * Exported so sibling directory admin route modules (e.g. `admin-directory-local.ts`, Canonical
+ * Org MVP B2) share the SAME platform-admin gate rather than re-implementing the legacy-claim /
+ * RBAC check — duplicated auth guards drift, which is a security-relevant divergence.
+ */
+export async function ensurePlatformAdmin(req: Request, res: Response): Promise<string | null> {
   const userId = getRequestUserId(req)
   if (!userId) {
     jsonError(res, 401, 'UNAUTHENTICATED', 'Authentication required')

--- a/packages/core-backend/tests/integration/local-directory-org-crud-route.db.test.ts
+++ b/packages/core-backend/tests/integration/local-directory-org-crud-route.db.test.ts
@@ -1,0 +1,656 @@
+import { randomUUID } from 'crypto'
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import {
+  ADD_LOCAL_MEMBERSHIP_FIELD_TYPES,
+  ADD_LOCAL_MEMBERSHIP_FIELDS,
+  CREATE_LOCAL_ACCOUNT_FIELD_TYPES,
+  CREATE_LOCAL_ACCOUNT_FIELDS,
+  CREATE_LOCAL_DEPARTMENT_FIELD_TYPES,
+  CREATE_LOCAL_DEPARTMENT_FIELDS,
+  UPDATE_LOCAL_ACCOUNT_FIELD_TYPES,
+  UPDATE_LOCAL_ACCOUNT_FIELDS,
+  UPDATE_LOCAL_DEPARTMENT_FIELD_TYPES,
+  UPDATE_LOCAL_DEPARTMENT_FIELDS,
+} from '../../src/directory/local-directory-org-request-schema'
+import { adminDirectoryLocalRouter } from '../../src/routes/admin-directory-local'
+
+/**
+ * Canonical Org MVP — B2 (local departments/accounts/memberships CRUD), HTTP route layer, real
+ * DB. Pairs with `local-directory-org-crud.db.test.ts` (service layer) the same way
+ * `attendance-notification-redelivery-route.db.test.ts` pairs with
+ * `attendance-notification-redelivery.db.test.ts` — the service file proves persistence
+ * semantics; THIS file proves the actual HTTP write surface: platform-admin gating, per-mutation
+ * audit rows, and — the owner hard requirement this line exists for — that `org_id`/`corp_id`
+ * (and their camelCase spellings) smuggled into a request body are REJECTED (400), not silently
+ * dropped, on every mutating B2 endpoint. Org identity is resolved server-side
+ * (`resolveLocalDirectoryOrgId` in admin-directory-local.ts) to `'default'` — the same effective
+ * single-tenant org every other directory admin route reaches too (by omitting `orgId` and
+ * letting directory-sync.ts's services default it); there is no per-request org/tenant context in
+ * this codebase for directory routes to read yet, so every request below shares that one org's
+ * local integration. Fixtures are cleaned up by their own returned ids in `afterEach` (never by
+ * deleting the shared integration row, which other B2 test runs may still be using).
+ *
+ * `req.user` is set by a trivial pass-through auth middleware (`role: 'admin'` satisfies
+ * `hasLegacyAdminClaim` directly, the same shortcut `attendance-notification-redelivery-
+ * route.db.test.ts` uses) — no RBAC fixture rows are needed for the admin-path tests. The
+ * non-admin test below deliberately does NOT set that claim, so it exercises the real
+ * `isRbacAdmin` query against Postgres.
+ *
+ * DATABASE_URL-gated (describeIfDatabase): excluded from the no-DB vitest job so it cannot
+ * skip-green, and wired as a WHOLE FILE into the `Run approval real-DB integration` step in
+ * plugin-tests.yml.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+
+function fixtureName(tag: string): string {
+  return `b2-route-${STAMP}-${tag}-${randomUUID().slice(0, 8)}`
+}
+
+const adminApp = express()
+adminApp.use(express.json())
+adminApp.use((req, _res, next) => {
+  ;(req as express.Request & { user?: unknown }).user = { id: `b2-route-admin-${STAMP}`, role: 'admin' }
+  next()
+})
+adminApp.use('/api/admin/directory/local', adminDirectoryLocalRouter())
+
+const nonAdminApp = express()
+nonAdminApp.use(express.json())
+nonAdminApp.use((req, _res, next) => {
+  ;(req as express.Request & { user?: unknown }).user = { id: `b2-route-nonadmin-${STAMP}` }
+  next()
+})
+nonAdminApp.use('/api/admin/directory/local', adminDirectoryLocalRouter())
+
+async function seedUser(): Promise<string> {
+  const id = `b2-route-user-${STAMP}-${randomUUID().slice(0, 8)}`
+  await query(`INSERT INTO users (id, email, name, password_hash) VALUES ($1, $2, $3, 'x')`, [id, `${id}@example.test`, 'Route Test User'])
+  return id
+}
+
+describeIfDatabase('Canonical Org MVP — B2 local departments/accounts/memberships CRUD (real DB, HTTP route layer)', () => {
+  const createdDepartmentIds: string[] = []
+  const createdAccountIds: string[] = []
+  const createdUserIds: string[] = []
+
+  afterEach(async () => {
+    const depts = createdDepartmentIds.splice(0)
+    for (const id of depts) await query(`DELETE FROM directory_departments WHERE id = $1`, [id])
+    const accounts = createdAccountIds.splice(0)
+    for (const id of accounts) await query(`DELETE FROM directory_accounts WHERE id = $1`, [id]) // cascades links + memberships
+    const users = createdUserIds.splice(0)
+    for (const id of users) await query(`DELETE FROM users WHERE id = $1`, [id])
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('creates a department over real HTTP, persists it, and writes one audit row', async () => {
+    const deptName = fixtureName('create-dept')
+    const res = await request(adminApp).post('/api/admin/directory/local/departments').send({ name: deptName })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.data.department.name).toBe(deptName)
+    expect(res.body.data.department.isActive).toBe(true)
+    createdDepartmentIds.push(res.body.data.department.id)
+
+    const row = await query<{ name: string; is_active: boolean }>(`SELECT name, is_active FROM directory_departments WHERE id = $1`, [
+      res.body.data.department.id,
+    ])
+    expect(row.rows).toEqual([{ name: deptName, is_active: true }])
+
+    const audit = await query(`SELECT 1 FROM audit_logs WHERE action = 'directory.local_department.create' AND resource_id = $1`, [
+      res.body.data.department.id,
+    ])
+    expect(audit.rows.length).toBe(1)
+  })
+
+  it('rejects a create-department request smuggling org_id/corp_id (400, no row written, no audit row)', async () => {
+    const deptName = fixtureName('smuggle-dept-snake')
+    const res = await request(adminApp)
+      .post('/api/admin/directory/local/departments')
+      .send({ name: deptName, org_id: 'attacker-org', corp_id: 'evil-corp' })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'DIRECTORY_LOCAL_UNKNOWN_FIELDS',
+        message: 'Request body contains fields not accepted by this endpoint',
+        details: undefined,
+      },
+    })
+
+    const rows = await query(`SELECT 1 FROM directory_departments WHERE name = $1`, [deptName])
+    expect(rows.rows.length).toBe(0)
+  })
+
+  it('rejects a create-department request smuggling the camelCase orgId/corpId spelling too', async () => {
+    const deptName = fixtureName('smuggle-dept-camel')
+    const res = await request(adminApp)
+      .post('/api/admin/directory/local/departments')
+      .send({ name: deptName, orgId: 'attacker-org', corpId: 'evil-corp' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_UNKNOWN_FIELDS')
+
+    const rows = await query(`SELECT 1 FROM directory_departments WHERE name = $1`, [deptName])
+    expect(rows.rows.length).toBe(0)
+  })
+
+  it('rejects an update-department request smuggling org_id (the target row is left unchanged)', async () => {
+    const created = await request(adminApp).post('/api/admin/directory/local/departments').send({ name: fixtureName('update-target') })
+    expect(created.status).toBe(200)
+    createdDepartmentIds.push(created.body.data.department.id)
+    const originalName = created.body.data.department.name
+
+    const res = await request(adminApp)
+      .patch(`/api/admin/directory/local/departments/${created.body.data.department.id}`)
+      .send({ name: 'should-not-apply', org_id: 'attacker-org' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_UNKNOWN_FIELDS')
+
+    const row = await query<{ name: string }>(`SELECT name FROM directory_departments WHERE id = $1`, [created.body.data.department.id])
+    expect(row.rows[0].name).toBe(originalName)
+  })
+
+  // ---- Department field TYPE validation (owner P2 on #4317: allowlist checked NAMES only, not
+  // TYPES — a wrong-typed value fell through `typeof x === 'string' ? x : null`-shaped extraction
+  // and silently coerced to the destructive `null` ("clear") signal). ---------------------------
+
+  it('rejects a PATCH department parentDepartmentId given as a number — 400, parent left unchanged (owner-reported case, verbatim)', async () => {
+    const parent = await request(adminApp).post('/api/admin/directory/local/departments').send({ name: fixtureName('parent-num-case') })
+    expect(parent.status).toBe(200)
+    createdDepartmentIds.push(parent.body.data.department.id)
+    const child = await request(adminApp)
+      .post('/api/admin/directory/local/departments')
+      .send({ name: fixtureName('child-num-case'), parentDepartmentId: parent.body.data.department.id })
+    expect(child.status).toBe(200)
+    createdDepartmentIds.push(child.body.data.department.id)
+    expect(child.body.data.department.parentDepartmentId).toBe(parent.body.data.department.id)
+
+    const res = await request(adminApp)
+      .patch(`/api/admin/directory/local/departments/${child.body.data.department.id}`)
+      .send({ parentDepartmentId: 123 })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      ok: false,
+      error: { code: 'DIRECTORY_LOCAL_INVALID_INPUT', message: 'parentDepartmentId must be a string or null', details: undefined },
+    })
+
+    const row = await query<{ external_parent_department_id: string | null }>(
+      `SELECT external_parent_department_id FROM directory_departments WHERE id = $1`,
+      [child.body.data.department.id],
+    )
+    expect(row.rows[0].external_parent_department_id).toBe(parent.body.data.department.externalDepartmentId)
+  })
+
+  it.each([
+    { name: 'parentDepartmentId as an array', field: 'parentDepartmentId', badValue: [], expectedMessage: 'parentDepartmentId must be a string or null' },
+    { name: 'parentDepartmentId as a boolean', field: 'parentDepartmentId', badValue: true, expectedMessage: 'parentDepartmentId must be a string or null' },
+    { name: 'name as a number', field: 'name', badValue: 42, expectedMessage: 'name must be a string' },
+    { name: 'name as explicit null (not nullable-by-design)', field: 'name', badValue: null, expectedMessage: 'name must be a string' },
+    { name: 'orderIndex as a numeric string', field: 'orderIndex', badValue: '5', expectedMessage: 'orderIndex must be an integer within the int4 range' },
+    { name: 'orderIndex as a float', field: 'orderIndex', badValue: 3.7, expectedMessage: 'orderIndex must be an integer within the int4 range' },
+    // int4 bound (gate NIT-1): an integer beyond the column range used to pass Number.isInteger
+    // and blow up as a 500 at INSERT time; the type gate now bounds it to int4 => 400, no write.
+    { name: 'orderIndex beyond int4 range', field: 'orderIndex', badValue: 3_000_000_000, expectedMessage: 'orderIndex must be an integer within the int4 range' },
+  ])('rejects a PATCH department with $name — 400, department left byte-identical', async ({ field, badValue, expectedMessage }) => {
+    const created = await request(adminApp).post('/api/admin/directory/local/departments').send({ name: fixtureName(`dept-type-${field}`) })
+    expect(created.status).toBe(200)
+    const id = created.body.data.department.id as string
+    createdDepartmentIds.push(id)
+
+    const before = await query<{ name: string; order_index: number; external_parent_department_id: string | null }>(
+      `SELECT name, order_index, external_parent_department_id FROM directory_departments WHERE id = $1`,
+      [id],
+    )
+
+    const res = await request(adminApp).patch(`/api/admin/directory/local/departments/${id}`).send({ [field]: badValue })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+    expect(res.body.error.message).toBe(expectedMessage)
+
+    const after = await query<{ name: string; order_index: number; external_parent_department_id: string | null }>(
+      `SELECT name, order_index, external_parent_department_id FROM directory_departments WHERE id = $1`,
+      [id],
+    )
+    expect(after.rows[0]).toEqual(before.rows[0])
+  })
+
+  it.each([
+    { name: 'name as a number', field: 'name', badValue: 42, expectedMessage: 'name must be a string' },
+    { name: 'parentDepartmentId as a number', field: 'parentDepartmentId', badValue: 123, expectedMessage: 'parentDepartmentId must be a string or null' },
+    { name: 'orderIndex as a numeric string', field: 'orderIndex', badValue: '5', expectedMessage: 'orderIndex must be an integer within the int4 range' },
+    { name: 'orderIndex as a float', field: 'orderIndex', badValue: 1.5, expectedMessage: 'orderIndex must be an integer within the int4 range' },
+  ])('rejects a create-department request with $name — 400, no row written', async ({ field, badValue, expectedMessage }) => {
+    const deptName = fixtureName('create-type-bad')
+    const body: Record<string, unknown> = field === 'name' ? { [field]: badValue } : { name: deptName, [field]: badValue }
+
+    const before = await query<{ count: string }>(`SELECT COUNT(*)::text AS count FROM directory_departments`)
+
+    const res = await request(adminApp).post('/api/admin/directory/local/departments').send(body)
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+    expect(res.body.error.message).toBe(expectedMessage)
+
+    const after = await query<{ count: string }>(`SELECT COUNT(*)::text AS count FROM directory_departments`)
+    expect(after.rows[0].count).toBe(before.rows[0].count)
+
+    if (field !== 'name') {
+      const rows = await query(`SELECT 1 FROM directory_departments WHERE name = $1`, [deptName])
+      expect(rows.rows.length).toBe(0)
+    }
+  })
+
+  it('PATCH department parentDepartmentId: null clears the parent (nullable-by-design, positive control)', async () => {
+    const parent = await request(adminApp).post('/api/admin/directory/local/departments').send({ name: fixtureName('parent-null-clear') })
+    expect(parent.status).toBe(200)
+    createdDepartmentIds.push(parent.body.data.department.id)
+    const child = await request(adminApp)
+      .post('/api/admin/directory/local/departments')
+      .send({ name: fixtureName('child-null-clear'), parentDepartmentId: parent.body.data.department.id })
+    expect(child.status).toBe(200)
+    createdDepartmentIds.push(child.body.data.department.id)
+    expect(child.body.data.department.parentDepartmentId).toBe(parent.body.data.department.id)
+
+    const res = await request(adminApp)
+      .patch(`/api/admin/directory/local/departments/${child.body.data.department.id}`)
+      .send({ parentDepartmentId: null })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.department.parentDepartmentId).toBeNull()
+
+    const row = await query<{ external_parent_department_id: string | null }>(
+      `SELECT external_parent_department_id FROM directory_departments WHERE id = $1`,
+      [child.body.data.department.id],
+    )
+    expect(row.rows[0].external_parent_department_id).toBeNull()
+  })
+
+  it('rejects a PATCH department with one valid field and one wrong-typed field — 400, NEITHER field is applied (no partial write)', async () => {
+    const created = await request(adminApp).post('/api/admin/directory/local/departments').send({ name: fixtureName('no-partial-write-dept') })
+    expect(created.status).toBe(200)
+    const id = created.body.data.department.id as string
+    createdDepartmentIds.push(id)
+    const originalName = created.body.data.department.name as string
+
+    const res = await request(adminApp)
+      .patch(`/api/admin/directory/local/departments/${id}`)
+      .send({ name: 'should-not-apply-either', parentDepartmentId: 123 })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+
+    const row = await query<{ name: string; external_parent_department_id: string | null }>(
+      `SELECT name, external_parent_department_id FROM directory_departments WHERE id = $1`,
+      [id],
+    )
+    // The valid `name` change was NOT partially applied even though it appeared before the
+    // wrong-typed `parentDepartmentId` in the same request body — the type gate rejects the
+    // WHOLE request before either field is read into the update input.
+    expect(row.rows[0]).toEqual({ name: originalName, external_parent_department_id: null })
+  })
+
+  it('rejects a create-account request smuggling corp_id (400, no row written)', async () => {
+    const uid = await seedUser()
+    createdUserIds.push(uid)
+
+    const res = await request(adminApp).post('/api/admin/directory/local/accounts').send({ localUserId: uid, corp_id: 'evil-corp' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_UNKNOWN_FIELDS')
+
+    const rows = await query(`SELECT 1 FROM directory_accounts WHERE external_user_id = $1`, [uid])
+    expect(rows.rows.length).toBe(0)
+  })
+
+  it('creates an account over real HTTP, links it to the platform user, and writes one audit row', async () => {
+    const uid = await seedUser()
+    createdUserIds.push(uid)
+
+    const res = await request(adminApp).post('/api/admin/directory/local/accounts').send({ localUserId: uid })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.account.localUserId).toBe(uid)
+    expect(res.body.data.account.isActive).toBe(true)
+    createdAccountIds.push(res.body.data.account.id)
+
+    const audit = await query(`SELECT 1 FROM audit_logs WHERE action = 'directory.local_account.create' AND resource_id = $1`, [
+      res.body.data.account.id,
+    ])
+    expect(audit.rows.length).toBe(1)
+  })
+
+  // ---- Account field TYPE validation (owner P2 on #4317, same class of bug as departments above:
+  // email/mobile/title given a non-string, non-null value silently coerced to `null` and CLEARED
+  // the stored value). ------------------------------------------------------------------------
+
+  it('rejects a PATCH account email given as an object — 400, account left unchanged (owner-reported case, verbatim)', async () => {
+    const uid = await seedUser()
+    createdUserIds.push(uid)
+    const created = await request(adminApp)
+      .post('/api/admin/directory/local/accounts')
+      .send({ localUserId: uid, email: 'keep@example.test', mobile: '10000000000', title: 'Keep Title' })
+    expect(created.status).toBe(200)
+    const id = created.body.data.account.id as string
+    createdAccountIds.push(id)
+
+    const res = await request(adminApp).patch(`/api/admin/directory/local/accounts/${id}`).send({ email: {} })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      ok: false,
+      error: { code: 'DIRECTORY_LOCAL_INVALID_INPUT', message: 'email must be a string or null', details: undefined },
+    })
+
+    const row = await query<{ email: string | null; mobile: string | null; title: string | null }>(
+      `SELECT email, mobile, title FROM directory_accounts WHERE id = $1`,
+      [id],
+    )
+    expect(row.rows[0]).toEqual({ email: 'keep@example.test', mobile: '10000000000', title: 'Keep Title' })
+  })
+
+  it('rejects a PATCH account title given as an array — 400, account left unchanged (owner-reported case, verbatim)', async () => {
+    const uid = await seedUser()
+    createdUserIds.push(uid)
+    const created = await request(adminApp)
+      .post('/api/admin/directory/local/accounts')
+      .send({ localUserId: uid, email: 'keep2@example.test', mobile: '20000000000', title: 'Keep Title 2' })
+    expect(created.status).toBe(200)
+    const id = created.body.data.account.id as string
+    createdAccountIds.push(id)
+
+    const res = await request(adminApp).patch(`/api/admin/directory/local/accounts/${id}`).send({ title: [] })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      ok: false,
+      error: { code: 'DIRECTORY_LOCAL_INVALID_INPUT', message: 'title must be a string or null', details: undefined },
+    })
+
+    const row = await query<{ email: string | null; mobile: string | null; title: string | null }>(
+      `SELECT email, mobile, title FROM directory_accounts WHERE id = $1`,
+      [id],
+    )
+    expect(row.rows[0]).toEqual({ email: 'keep2@example.test', mobile: '20000000000', title: 'Keep Title 2' })
+  })
+
+  it.each([
+    { name: 'mobile as a number', field: 'mobile', badValue: 42, expectedMessage: 'mobile must be a string or null' },
+    { name: 'name as a number', field: 'name', badValue: 42, expectedMessage: 'name must be a string' },
+    { name: 'name as explicit null (not nullable-by-design)', field: 'name', badValue: null, expectedMessage: 'name must be a string' },
+  ])('rejects a PATCH account with $name — 400, account left unchanged', async ({ field, badValue, expectedMessage }) => {
+    const uid = await seedUser()
+    createdUserIds.push(uid)
+    const created = await request(adminApp)
+      .post('/api/admin/directory/local/accounts')
+      .send({ localUserId: uid, email: 'stable@example.test', mobile: '30000000000', title: 'Stable Title' })
+    const id = created.body.data.account.id as string
+    createdAccountIds.push(id)
+
+    const before = await query<{ name: string; email: string | null; mobile: string | null; title: string | null }>(
+      `SELECT name, email, mobile, title FROM directory_accounts WHERE id = $1`,
+      [id],
+    )
+
+    const res = await request(adminApp).patch(`/api/admin/directory/local/accounts/${id}`).send({ [field]: badValue })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+    expect(res.body.error.message).toBe(expectedMessage)
+
+    const after = await query<{ name: string; email: string | null; mobile: string | null; title: string | null }>(
+      `SELECT name, email, mobile, title FROM directory_accounts WHERE id = $1`,
+      [id],
+    )
+    expect(after.rows[0]).toEqual(before.rows[0])
+  })
+
+  it.each([
+    { name: 'localUserId as a number', field: 'localUserId', badValue: 42, expectedMessage: 'localUserId must be a string' },
+    { name: 'name as a number', field: 'name', badValue: 42, expectedMessage: 'name must be a string' },
+    { name: 'email as an object', field: 'email', badValue: {}, expectedMessage: 'email must be a string or null' },
+    { name: 'title as an array', field: 'title', badValue: [], expectedMessage: 'title must be a string or null' },
+  ])('rejects a create-account request with $name — 400, no row written', async ({ field, badValue, expectedMessage }) => {
+    const uid = await seedUser()
+    createdUserIds.push(uid)
+    const body: Record<string, unknown> = field === 'localUserId' ? { localUserId: badValue } : { localUserId: uid, [field]: badValue }
+
+    const before = await query<{ count: string }>(`SELECT COUNT(*)::text AS count FROM directory_accounts`)
+
+    const res = await request(adminApp).post('/api/admin/directory/local/accounts').send(body)
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+    expect(res.body.error.message).toBe(expectedMessage)
+
+    const after = await query<{ count: string }>(`SELECT COUNT(*)::text AS count FROM directory_accounts`)
+    expect(after.rows[0].count).toBe(before.rows[0].count)
+
+    if (field !== 'localUserId') {
+      const rows = await query(`SELECT 1 FROM directory_accounts WHERE external_user_id = $1`, [uid])
+      expect(rows.rows.length).toBe(0)
+    }
+  })
+
+  it('PATCH account email/mobile/title: null clears all three (nullable-by-design, positive control)', async () => {
+    const uid = await seedUser()
+    createdUserIds.push(uid)
+    const created = await request(adminApp)
+      .post('/api/admin/directory/local/accounts')
+      .send({ localUserId: uid, email: 'clear-me@example.test', mobile: '999', title: 'Clear Me' })
+    expect(created.status).toBe(200)
+    const id = created.body.data.account.id as string
+    createdAccountIds.push(id)
+
+    const res = await request(adminApp).patch(`/api/admin/directory/local/accounts/${id}`).send({ email: null, mobile: null, title: null })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.account.email).toBeNull()
+    expect(res.body.data.account.mobile).toBeNull()
+    expect(res.body.data.account.title).toBeNull()
+
+    const row = await query<{ email: string | null; mobile: string | null; title: string | null }>(
+      `SELECT email, mobile, title FROM directory_accounts WHERE id = $1`,
+      [id],
+    )
+    expect(row.rows[0]).toEqual({ email: null, mobile: null, title: null })
+  })
+
+  it('rejects a PATCH account with one valid field and one wrong-typed field — 400, NEITHER field is applied (no partial write)', async () => {
+    const uid = await seedUser()
+    createdUserIds.push(uid)
+    const created = await request(adminApp)
+      .post('/api/admin/directory/local/accounts')
+      .send({ localUserId: uid, email: 'no-partial@example.test', mobile: '40000000000', title: 'No Partial' })
+    expect(created.status).toBe(200)
+    const id = created.body.data.account.id as string
+    createdAccountIds.push(id)
+
+    const res = await request(adminApp)
+      .patch(`/api/admin/directory/local/accounts/${id}`)
+      .send({ mobile: '50000000000', title: [] })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+
+    const row = await query<{ email: string | null; mobile: string | null; title: string | null }>(
+      `SELECT email, mobile, title FROM directory_accounts WHERE id = $1`,
+      [id],
+    )
+    // The valid `mobile` change was NOT partially applied even though it appeared before the
+    // wrong-typed `title` in the same request body.
+    expect(row.rows[0]).toEqual({ email: 'no-partial@example.test', mobile: '40000000000', title: 'No Partial' })
+  })
+
+  it('adds and switches a membership over real HTTP; rejects a primary-switch body smuggling org_id/corp_id', async () => {
+    const uid = await seedUser()
+    createdUserIds.push(uid)
+    const acctRes = await request(adminApp).post('/api/admin/directory/local/accounts').send({ localUserId: uid })
+    expect(acctRes.status).toBe(200)
+    createdAccountIds.push(acctRes.body.data.account.id)
+    const deptRes = await request(adminApp).post('/api/admin/directory/local/departments').send({ name: fixtureName('member-dept') })
+    expect(deptRes.status).toBe(200)
+    createdDepartmentIds.push(deptRes.body.data.department.id)
+
+    const accountId = acctRes.body.data.account.id as string
+    const departmentId = deptRes.body.data.department.id as string
+    const membershipId = `${accountId}:${departmentId}`
+
+    const addRes = await request(adminApp).post('/api/admin/directory/local/memberships').send({ accountId, departmentId })
+    expect(addRes.status).toBe(200)
+    expect(addRes.body.data.membership).toEqual({ id: membershipId, accountId, departmentId, isPrimary: false, createdAt: addRes.body.data.membership.createdAt })
+
+    const smuggled = await request(adminApp)
+      .patch(`/api/admin/directory/local/memberships/${membershipId}`)
+      .send({ isPrimary: true, org_id: 'attacker-org', corp_id: 'evil-corp' })
+    expect(smuggled.status).toBe(400)
+    expect(smuggled.body.error.code).toBe('DIRECTORY_LOCAL_UNKNOWN_FIELDS')
+
+    const stillNotPrimary = await query<{ is_primary: boolean }>(
+      `SELECT is_primary FROM directory_account_departments WHERE directory_account_id = $1 AND directory_department_id = $2`,
+      [accountId, departmentId],
+    )
+    expect(stillNotPrimary.rows[0].is_primary).toBe(false)
+
+    const switchRes = await request(adminApp).patch(`/api/admin/directory/local/memberships/${membershipId}`).send({ isPrimary: true })
+    expect(switchRes.status).toBe(200)
+    expect(switchRes.body.data.membership.isPrimary).toBe(true)
+
+    const row = await query<{ is_primary: boolean }>(
+      `SELECT is_primary FROM directory_account_departments WHERE directory_account_id = $1 AND directory_department_id = $2`,
+      [accountId, departmentId],
+    )
+    expect(row.rows[0].is_primary).toBe(true)
+
+    const audit = await query(`SELECT 1 FROM audit_logs WHERE action = 'directory.local_membership.switch_primary' AND resource_id = $1`, [
+      membershipId,
+    ])
+    expect(audit.rows.length).toBe(1)
+  })
+
+  it('rejects a primary-switch body that omits isPrimary:true, even with no smuggled fields (narrow-endpoint contract)', async () => {
+    const uid = await seedUser()
+    createdUserIds.push(uid)
+    const acctRes = await request(adminApp).post('/api/admin/directory/local/accounts').send({ localUserId: uid })
+    createdAccountIds.push(acctRes.body.data.account.id)
+    const deptRes = await request(adminApp).post('/api/admin/directory/local/departments').send({ name: fixtureName('member-dept-narrow') })
+    createdDepartmentIds.push(deptRes.body.data.department.id)
+
+    const accountId = acctRes.body.data.account.id as string
+    const departmentId = deptRes.body.data.department.id as string
+    await request(adminApp).post('/api/admin/directory/local/memberships').send({ accountId, departmentId })
+
+    const res = await request(adminApp)
+      .patch(`/api/admin/directory/local/memberships/${accountId}:${departmentId}`)
+      .send({ isPrimary: false })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+  })
+
+  // ---- Membership field TYPE validation (owner P2 on #4317, same allowlist-checks-names-only
+  // gap; accountId/departmentId already 400'd via the required-field check before this fix, but
+  // now get the same explicit type gate as every other endpoint for consistency). ---------------
+
+  it.each([
+    { name: 'accountId as a number', field: 'accountId', expectedMessage: 'accountId must be a string' },
+    { name: 'departmentId as a number', field: 'departmentId', expectedMessage: 'departmentId must be a string' },
+  ])('rejects an add-membership request with $name — 400, no row written', async ({ field, expectedMessage }) => {
+    const uid = await seedUser()
+    createdUserIds.push(uid)
+    const acctRes = await request(adminApp).post('/api/admin/directory/local/accounts').send({ localUserId: uid })
+    createdAccountIds.push(acctRes.body.data.account.id)
+    const deptRes = await request(adminApp).post('/api/admin/directory/local/departments').send({ name: fixtureName('member-type-dept') })
+    createdDepartmentIds.push(deptRes.body.data.department.id)
+
+    const accountId = acctRes.body.data.account.id as string
+    const departmentId = deptRes.body.data.department.id as string
+    const body: Record<string, unknown> = { accountId, departmentId, [field]: 42 }
+
+    const res = await request(adminApp).post('/api/admin/directory/local/memberships').send(body)
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+    expect(res.body.error.message).toBe(expectedMessage)
+
+    const rows = await query(
+      `SELECT 1 FROM directory_account_departments WHERE directory_account_id = $1 AND directory_department_id = $2`,
+      [accountId, departmentId],
+    )
+    expect(rows.rows.length).toBe(0)
+  })
+
+  it('rejects a primary-switch body where isPrimary is a string, not the boolean literal true — 400 (boolean-type coverage, no state change)', async () => {
+    const uid = await seedUser()
+    createdUserIds.push(uid)
+    const acctRes = await request(adminApp).post('/api/admin/directory/local/accounts').send({ localUserId: uid })
+    createdAccountIds.push(acctRes.body.data.account.id)
+    const deptRes = await request(adminApp).post('/api/admin/directory/local/departments').send({ name: fixtureName('member-bool-dept') })
+    createdDepartmentIds.push(deptRes.body.data.department.id)
+    const accountId = acctRes.body.data.account.id as string
+    const departmentId = deptRes.body.data.department.id as string
+    await request(adminApp).post('/api/admin/directory/local/memberships').send({ accountId, departmentId })
+
+    const res = await request(adminApp)
+      .patch(`/api/admin/directory/local/memberships/${accountId}:${departmentId}`)
+      .send({ isPrimary: 'true' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+
+    const row = await query<{ is_primary: boolean }>(
+      `SELECT is_primary FROM directory_account_departments WHERE directory_account_id = $1 AND directory_department_id = $2`,
+      [accountId, departmentId],
+    )
+    expect(row.rows[0].is_primary).toBe(false)
+  })
+
+  it('rejects requests from an authenticated non-admin user (403, no row written)', async () => {
+    const deptName = fixtureName('forbidden-dept')
+    const res = await request(nonAdminApp).post('/api/admin/directory/local/departments').send({ name: deptName })
+
+    expect(res.status).toBe(403)
+
+    const rows = await query(`SELECT 1 FROM directory_departments WHERE name = $1`, [deptName])
+    expect(rows.rows.length).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------------------------
+// Allowlist ↔ type-spec drift guard (gate NIT-2): the *_FIELDS name allowlists and the
+// *_FIELD_TYPES specs are hand-maintained in parallel. A field added to an allowlist WITHOUT a
+// matching type spec would pass the type gate unchecked — the exact coercion bug class this PR
+// closes. Set-equality per endpoint makes that drift impossible to land silently.
+// SWITCH_LOCAL_MEMBERSHIP_PRIMARY_FIELDS deliberately has no *_FIELD_TYPES pair: its single
+// field `isPrimary` is validated by the route's literal `!== true` check, stricter than any kind.
+// ---------------------------------------------------------------------------------------------
+
+describe('allowlist ↔ type-spec parity (drift guard)', () => {
+  const PAIRS: Array<[string, readonly string[], readonly { field: string }[]]> = [
+    ['CREATE_LOCAL_DEPARTMENT', CREATE_LOCAL_DEPARTMENT_FIELDS, CREATE_LOCAL_DEPARTMENT_FIELD_TYPES],
+    ['UPDATE_LOCAL_DEPARTMENT', UPDATE_LOCAL_DEPARTMENT_FIELDS, UPDATE_LOCAL_DEPARTMENT_FIELD_TYPES],
+    ['CREATE_LOCAL_ACCOUNT', CREATE_LOCAL_ACCOUNT_FIELDS, CREATE_LOCAL_ACCOUNT_FIELD_TYPES],
+    ['UPDATE_LOCAL_ACCOUNT', UPDATE_LOCAL_ACCOUNT_FIELDS, UPDATE_LOCAL_ACCOUNT_FIELD_TYPES],
+    ['ADD_LOCAL_MEMBERSHIP', ADD_LOCAL_MEMBERSHIP_FIELDS, ADD_LOCAL_MEMBERSHIP_FIELD_TYPES],
+  ]
+
+  for (const [label, fields, specs] of PAIRS) {
+    it(`${label}: every allowed field has exactly one type spec`, () => {
+      const allow = [...fields].sort()
+      const typed = specs.map((s) => s.field).sort()
+      expect(typed).toEqual(allow)
+    })
+  }
+})

--- a/packages/core-backend/tests/integration/local-directory-org-crud.db.test.ts
+++ b/packages/core-backend/tests/integration/local-directory-org-crud.db.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import {
+  LocalDirectoryConflictError,
+  LocalDirectoryNotFoundError,
+  LocalDirectoryValidationError,
+  addLocalMembership,
+  archiveLocalAccount,
+  archiveLocalDepartment,
+  createLocalAccount,
+  createLocalDepartment,
+  switchLocalPrimaryDepartment,
+  updateLocalAccount,
+  updateLocalDepartment,
+} from '../../src/directory/local-directory-org'
+
+/**
+ * Canonical Org MVP — B2 (local departments/accounts/memberships CRUD), MVP sequencing plan §1
+ * row B2, design lock §5.2-5.4, real DB, SERVICE layer.
+ *
+ * Proves, against real Postgres:
+ *   - departments: create / rename / archive-keeps-history (row remains, `is_active=false`,
+ *     idempotent re-archive); parent resolves to the parent's `id` via its external key; `raw`
+ *     never carries a manager (design lock owner fix).
+ *   - accounts: create + link (`directory_account_departments` is untouched here — the LINK is
+ *     `directory_account_links`) + deactivate keeps history; a local account NEVER produces a
+ *     `user_external_identities` row (with a positive control proving the query mechanism itself
+ *     works: `directory_account_links` DOES have a row for the same account); duplicate creation
+ *     for the same (org, user) is a 409, not a silent second row; `raw` never carries
+ *     `leader_in_dept`.
+ *   - memberships: `addLocalMembership` is idempotent (same pair twice → one row, PK-backed);
+ *     `switchLocalPrimaryDepartment` demotes the old primary — exactly one `is_primary=true` row
+ *     per account at any point; a membership cannot straddle two orgs' local integrations.
+ *
+ * The HTTP write surface (route-level field allowlist, `org_id`/`corp_id` smuggling rejection,
+ * audit-on-mutation) is proved separately in the paired
+ * `local-directory-org-crud-route.db.test.ts` — this file exercises the service functions
+ * directly, mirroring B1's `directory-local-provider-bootstrap.db.test.ts` convention.
+ *
+ * Fixture IDs are namespaced with this file's own STAMP + a per-test suffix — integration specs
+ * share one real Postgres in CI (plugin-tests.yml), so a bare `Date.now()` can collide with
+ * another file's fixtures in the same run.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+
+function orgId(suffix: string): string {
+  return `b2-local-${STAMP}-${suffix}`
+}
+
+function newUserId(suffix: string): string {
+  return `b2-local-user-${STAMP}-${suffix}`
+}
+
+async function seedUser(id: string, name: string): Promise<void> {
+  await query(`INSERT INTO users (id, email, name, password_hash) VALUES ($1, $2, $3, 'x')`, [id, `${id}@example.test`, name])
+}
+
+describeIfDatabase('Canonical Org MVP — B2 local departments/accounts/memberships CRUD (real DB, service layer)', () => {
+  const seededOrgIds: string[] = []
+  const seededUserIds: string[] = []
+
+  afterEach(async () => {
+    const orgs = seededOrgIds.splice(0)
+    for (const org of orgs) {
+      // directory_departments/directory_accounts (integration_id FK, ON DELETE CASCADE) and
+      // their dependents (directory_account_departments, directory_account_links, both also
+      // ON DELETE CASCADE) all fall out of deleting the integration row.
+      await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [org])
+    }
+    const users = seededUserIds.splice(0)
+    for (const uid of users) {
+      await query(`DELETE FROM users WHERE id = $1`, [uid])
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  describe('departments', () => {
+    it('create + rename + archive keeps history (row remains, is_active=false); re-archive is idempotent', async () => {
+      const org = orgId('dept-lifecycle')
+      seededOrgIds.push(org)
+
+      const created = await createLocalDepartment({ orgId: org, name: 'Engineering' })
+      expect(created.name).toBe('Engineering')
+      expect(created.isActive).toBe(true)
+      expect(created.parentDepartmentId).toBeNull()
+      expect(created.externalDepartmentId.startsWith('local:')).toBe(true)
+
+      const renamed = await updateLocalDepartment(org, created.id, { name: 'Platform Engineering' })
+      expect(renamed?.name).toBe('Platform Engineering')
+      expect(renamed?.isActive).toBe(true)
+
+      const archived = await archiveLocalDepartment(org, created.id)
+      expect(archived?.isActive).toBe(false)
+      expect(archived?.name).toBe('Platform Engineering')
+
+      const row = await query<{ id: string; is_active: boolean; name: string }>(
+        `SELECT id, is_active, name FROM directory_departments WHERE id = $1`,
+        [created.id],
+      )
+      expect(row.rows.length).toBe(1)
+      expect(row.rows[0].is_active).toBe(false)
+      expect(row.rows[0].name).toBe('Platform Engineering')
+
+      const archivedAgain = await archiveLocalDepartment(org, created.id)
+      expect(archivedAgain?.isActive).toBe(false)
+    })
+
+    it('parent department resolves to the PARENT id, and the stored key is the parent\'s external_department_id', async () => {
+      const org = orgId('dept-parent')
+      seededOrgIds.push(org)
+
+      const parent = await createLocalDepartment({ orgId: org, name: 'Sales' })
+      const child = await createLocalDepartment({ orgId: org, name: 'Sales APAC', parentDepartmentId: parent.id })
+
+      expect(child.parentDepartmentId).toBe(parent.id)
+
+      const row = await query<{ external_parent_department_id: string | null }>(
+        `SELECT external_parent_department_id FROM directory_departments WHERE id = $1`,
+        [child.id],
+      )
+      expect(row.rows[0].external_parent_department_id).toBe(parent.externalDepartmentId)
+    })
+
+    it('rejects an empty/whitespace-only name', async () => {
+      const org = orgId('dept-empty-name')
+      seededOrgIds.push(org)
+      await expect(createLocalDepartment({ orgId: org, name: '   ' })).rejects.toBeInstanceOf(LocalDirectoryValidationError)
+    })
+
+    it('rejects a non-existent parent department id', async () => {
+      const org = orgId('dept-bad-parent')
+      seededOrgIds.push(org)
+      await expect(
+        createLocalDepartment({ orgId: org, name: 'Orphan', parentDepartmentId: '00000000-0000-0000-0000-000000000000' }),
+      ).rejects.toBeInstanceOf(LocalDirectoryNotFoundError)
+    })
+
+    it('raw carries provenance ONLY — no manager field', async () => {
+      const org = orgId('dept-raw')
+      seededOrgIds.push(org)
+      const created = await createLocalDepartment({ orgId: org, name: 'Legal' })
+      const row = await query<{ raw: Record<string, unknown> }>(`SELECT raw FROM directory_departments WHERE id = $1`, [created.id])
+      expect(row.rows[0].raw).toEqual({ source: 'local', metadata: {} })
+    })
+  })
+
+  describe('accounts', () => {
+    it('create + link + deactivate keeps history; NEVER touches user_external_identities (with a positive control)', async () => {
+      const org = orgId('acct-lifecycle')
+      seededOrgIds.push(org)
+      const uid = newUserId('acct-lifecycle')
+      seededUserIds.push(uid)
+      await seedUser(uid, 'Ada Lovelace')
+
+      const created = await createLocalAccount({ orgId: org, localUserId: uid, title: 'Engineer' })
+      expect(created.externalUserId).toBe(uid)
+      expect(created.externalKey).toBe(`${org}:${uid}`)
+      expect(created.name).toBe('Ada Lovelace')
+      expect(created.title).toBe('Engineer')
+      expect(created.isActive).toBe(true)
+      expect(created.localUserId).toBe(uid)
+
+      const linkRow = await query<{ local_user_id: string; link_status: string }>(
+        `SELECT local_user_id, link_status FROM directory_account_links WHERE directory_account_id = $1`,
+        [created.id],
+      )
+      expect(linkRow.rows.length).toBe(1)
+      expect(linkRow.rows[0].local_user_id).toBe(uid)
+      expect(linkRow.rows[0].link_status).toBe('linked')
+
+      const updated = await updateLocalAccount(org, created.id, { mobile: '13800000000' })
+      expect(updated?.mobile).toBe('13800000000')
+      expect(updated?.name).toBe('Ada Lovelace')
+
+      const archived = await archiveLocalAccount(org, created.id)
+      expect(archived?.isActive).toBe(false)
+
+      const row = await query<{ is_active: boolean }>(`SELECT is_active FROM directory_accounts WHERE id = $1`, [created.id])
+      expect(row.rows.length).toBe(1)
+      expect(row.rows[0].is_active).toBe(false)
+
+      // Positive control: directory_account_links DOES have a row for this account, proving the
+      // zero-rows assertion below isn't vacuously true because of a broken query/table name.
+      const linkStillThere = await query(`SELECT 1 FROM directory_account_links WHERE directory_account_id = $1`, [created.id])
+      expect(linkStillThere.rows.length).toBe(1)
+
+      const identityRows = await query(`SELECT 1 FROM user_external_identities WHERE provider = 'local'`)
+      expect(identityRows.rows.length).toBe(0)
+    })
+
+    it('rejects a non-existent local user id', async () => {
+      const org = orgId('acct-no-user')
+      seededOrgIds.push(org)
+      await expect(createLocalAccount({ orgId: org, localUserId: 'no-such-user' })).rejects.toBeInstanceOf(LocalDirectoryNotFoundError)
+    })
+
+    it('rejects a second local account for the same (org, user) pair — 409-shaped, not a silent duplicate', async () => {
+      const org = orgId('acct-dup')
+      seededOrgIds.push(org)
+      const uid = newUserId('acct-dup')
+      seededUserIds.push(uid)
+      await seedUser(uid, 'Dup User')
+
+      await createLocalAccount({ orgId: org, localUserId: uid })
+      await expect(createLocalAccount({ orgId: org, localUserId: uid })).rejects.toBeInstanceOf(LocalDirectoryConflictError)
+
+      const rows = await query(`SELECT 1 FROM directory_accounts WHERE external_user_id = $1`, [uid])
+      expect(rows.rows.length).toBe(1)
+    })
+
+    it('raw carries provenance ONLY — no leader_in_dept field', async () => {
+      const org = orgId('acct-raw')
+      seededOrgIds.push(org)
+      const uid = newUserId('acct-raw')
+      seededUserIds.push(uid)
+      await seedUser(uid, 'Raw Check')
+
+      const created = await createLocalAccount({ orgId: org, localUserId: uid })
+      const row = await query<{ raw: Record<string, unknown> }>(`SELECT raw FROM directory_accounts WHERE id = $1`, [created.id])
+      expect(row.rows[0].raw).toEqual({ source: 'local', localUserId: uid })
+    })
+  })
+
+  describe('memberships', () => {
+    async function seedAccountAndDepartments(org: string, tag: string) {
+      const uid = newUserId(tag)
+      seededUserIds.push(uid)
+      await seedUser(uid, `Member ${tag}`)
+      const account = await createLocalAccount({ orgId: org, localUserId: uid })
+      const deptA = await createLocalDepartment({ orgId: org, name: `Dept A ${tag}` })
+      const deptB = await createLocalDepartment({ orgId: org, name: `Dept B ${tag}` })
+      return { account, deptA, deptB }
+    }
+
+    it('add is idempotent — the same (account, department) pair twice yields exactly one row', async () => {
+      const org = orgId('member-idempotent')
+      seededOrgIds.push(org)
+      const { account, deptA } = await seedAccountAndDepartments(org, 'idempotent')
+
+      const first = await addLocalMembership({ orgId: org, accountId: account.id, departmentId: deptA.id })
+      const second = await addLocalMembership({ orgId: org, accountId: account.id, departmentId: deptA.id })
+
+      expect(first.isPrimary).toBe(false)
+      expect(second.isPrimary).toBe(false)
+      expect(second.accountId).toBe(first.accountId)
+      expect(second.departmentId).toBe(first.departmentId)
+
+      const rows = await query(
+        `SELECT 1 FROM directory_account_departments WHERE directory_account_id = $1 AND directory_department_id = $2`,
+        [account.id, deptA.id],
+      )
+      expect(rows.rows.length).toBe(1)
+    })
+
+    it('primary switch demotes the old primary — exactly one is_primary=true row per account, both directions', async () => {
+      const org = orgId('member-primary-switch')
+      seededOrgIds.push(org)
+      const { account, deptA, deptB } = await seedAccountAndDepartments(org, 'primary-switch')
+
+      await addLocalMembership({ orgId: org, accountId: account.id, departmentId: deptA.id })
+      await addLocalMembership({ orgId: org, accountId: account.id, departmentId: deptB.id })
+
+      const firstSwitch = await switchLocalPrimaryDepartment(org, account.id, deptA.id)
+      expect(firstSwitch.isPrimary).toBe(true)
+
+      const afterFirst = await query<{ directory_department_id: string; is_primary: boolean }>(
+        `SELECT directory_department_id, is_primary FROM directory_account_departments WHERE directory_account_id = $1 ORDER BY directory_department_id`,
+        [account.id],
+      )
+      expect(afterFirst.rows.filter((r) => r.is_primary).length).toBe(1)
+      expect(afterFirst.rows.find((r) => r.directory_department_id === deptA.id)?.is_primary).toBe(true)
+      expect(afterFirst.rows.find((r) => r.directory_department_id === deptB.id)?.is_primary).toBe(false)
+
+      const secondSwitch = await switchLocalPrimaryDepartment(org, account.id, deptB.id)
+      expect(secondSwitch.isPrimary).toBe(true)
+
+      const afterSecond = await query<{ directory_department_id: string; is_primary: boolean }>(
+        `SELECT directory_department_id, is_primary FROM directory_account_departments WHERE directory_account_id = $1 ORDER BY directory_department_id`,
+        [account.id],
+      )
+      expect(afterSecond.rows.filter((r) => r.is_primary).length).toBe(1)
+      expect(afterSecond.rows.find((r) => r.directory_department_id === deptA.id)?.is_primary).toBe(false)
+      expect(afterSecond.rows.find((r) => r.directory_department_id === deptB.id)?.is_primary).toBe(true)
+    })
+
+    it('rejects switching primary to a department the account has no membership row for', async () => {
+      const org = orgId('member-primary-missing')
+      seededOrgIds.push(org)
+      const { account, deptA } = await seedAccountAndDepartments(org, 'primary-missing')
+
+      await expect(switchLocalPrimaryDepartment(org, account.id, deptA.id)).rejects.toBeInstanceOf(LocalDirectoryNotFoundError)
+    })
+
+    it('rejects a membership whose account and department belong to different orgs\' local integrations', async () => {
+      const orgOne = orgId('member-cross-org-1')
+      const orgTwo = orgId('member-cross-org-2')
+      seededOrgIds.push(orgOne, orgTwo)
+
+      const { account } = await seedAccountAndDepartments(orgOne, 'cross-org-account')
+      const other = await seedAccountAndDepartments(orgTwo, 'cross-org-dept')
+
+      await expect(
+        addLocalMembership({ orgId: orgOne, accountId: account.id, departmentId: other.deptA.id }),
+      ).rejects.toBeInstanceOf(LocalDirectoryNotFoundError)
+    })
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -91,6 +91,20 @@ export default defineConfig({
       // no-DB job cannot skip-green it, and wired as a WHOLE FILE into the directory real-DB
       // step in plugin-tests.yml.
       'tests/integration/directory-local-provider-scheduler-exclusion.db.test.ts',
+      // Canonical Org MVP B2 (local departments/accounts/memberships CRUD), design lock §5.2-5.4,
+      // service layer (real DB): department create/rename/archive-keeps-history, account
+      // create+link+deactivate (with a positive control proving the local account never touches
+      // user_external_identities), membership add idempotency, and the explicit primary-department
+      // switch (old primary demoted, exactly one is_primary per account). DATABASE_URL-gated;
+      // excluded here so the no-DB job cannot skip-green it, and wired as a WHOLE FILE into the
+      // directory real-DB step in plugin-tests.yml.
+      'tests/integration/local-directory-org-crud.db.test.ts',
+      // Canonical Org MVP B2, HTTP route layer (real DB): platform-admin gating, per-mutation
+      // audit rows, and the owner hard requirement — an org_id/corp_id (snake_case AND camelCase)
+      // smuggled into a B2 request body is REJECTED (400), never silently dropped. DATABASE_URL-
+      // gated; excluded here so the no-DB job cannot skip-green it, and wired as a WHOLE FILE into
+      // the directory real-DB step in plugin-tests.yml.
+      'tests/integration/local-directory-org-crud-route.db.test.ts',
       // Layer-2 hidden person/button masking (real DB): proves the cross-cutting visibility-key fix actually
       // masks the VALUE end-to-end, with non-vacuous controls. DATABASE_URL-gated; excluded here so the no-DB
       // job cannot skip-green it, and wired as a WHOLE FILE into the multitable real-DB step in


### PR DESCRIPTION
## What (Canonical Org MVP · B2, per #4242 plan row B2 + #4215 §5.2-5.4)

- New service module `local-directory-org.ts`: department/account/membership CRUD under an org's local integration (B1's `getOrCreateLocalIntegration`, merged `849f1d53d`). Departments use app-generated immutable `local:<uuid>` keys; accounts use `external_key='<org_id>:<local_user_id>'` (multi-org-safe) and link via `directory_account_links` — **no `user_external_identities` for provider='local'** (asserted with a positive control). `raw` carries provenance only; **manager data never enters raw** (that is B3's normalized relation; B2 code has zero `is_manager` references).
- **Archive-not-delete** for departments and accounts (`is_active=false`, history preserved); membership add is idempotent (same pair twice → one row); **explicit primary switch** (`PATCH /memberships/:id` body exactly `{isPrimary:true}`; all-rows demote inside a row-locked transaction is the serialization point).
- 8 admin routes at `/api/admin/directory/local` behind the same `ensurePlatformAdmin` guard as neighboring directory admin routes (export made shareable, additive-only).
- **Owner hard requirement (second half of B1's corp_id guarantee): every endpoint runs a fail-closed field allowlist — unknown fields reject 400; `org_id`/`orgId`/`corp_id`/`corpId` (and `is_manager`/`isManager`) are in no allowlist; org identity comes only from the session context.**

## Tests (real DB, two-point wired) — 14 service + 10 route = 24

Idempotency, archive-keeps-history, primary-switch invariant, org/corp smuggling rejection, no-identities assertion, raw provenance, cross-integration rejection.

## Verification at this head

- 24/24 green (CI-same `vitest.integration.config.ts`), fresh-DB chain, tsc clean; **no migration** (existing columns suffice).
- Load-bearing mutations (reddened then restored): non-idempotent upsert → red; archive→DELETE → red (1); neutered allowlist → red (5).
- Adversarial gate APPROVE, zero P1/P2: **all 8 routes** probed for smuggling incl. the 3 without suite coverage (uniform 400); unauth→401/non-admin→403 on all 8; cross-integration escapes (local↔dingtalk membership both directions, parent-under-dingtalk) all blocked 404 with no rows written; **is_primary invariant under real 2-way concurrency 80/80** with two positive controls proving the harness non-vacuous.
- Known P3 follow-ups (deliberate-to-confirm, non-blocking): archive does not fence subsequent writes (membership-to-archived-dept returns 200 — B3/B4 consumers must not assume archived==write-frozen); indirect department cycles reachable (verified harmless on the live recursive CTE; B4 owns tree normalization).

Landing discipline: **unarmed** — awaiting owner review at the exact head after CI. Note: gate reviewed `918404be5`; this head is the same tree with a commit-message count fix only (14+10, was miswritten 15+9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)