### PR TITLE
feat(approval): Milestone-2 B3 — normalized manager relation, dual-source resolver (local flag ⊕ legacy DingTalk raw)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -570,6 +570,7 @@ jobs:
             tests/integration/directory-local-provider-scheduler-exclusion.db.test.ts \
             tests/integration/local-directory-org-crud.db.test.ts \
             tests/integration/local-directory-org-crud-route.db.test.ts \
+            tests/integration/directory-normalized-manager.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             tests/integration/attendance-notification-redelivery.db.test.ts \
             tests/integration/attendance-notification-redelivery-route.db.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260715100000_add_is_manager_to_directory_account_departments.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260715100000_add_is_manager_to_directory_account_departments.ts
@@ -1,0 +1,55 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * Canonical Org MVP — B3 (normalized manager relation), #4215 §5.4.
+ *
+ * The manager/department-head link becomes a FIRST-CLASS, provider-neutral relation instead of
+ * living hidden inside a provider's raw JSON (`directory_accounts.raw.leader_in_dept`). Owner
+ * ruling (Wave 3, 2026-07-12): approval routing must read product truth, not parse provider raw.
+ * This adds the typed flag on the membership row — `is_manager = true` on
+ * `directory_account_departments(account = M, department = D)` means "M is a manager/leader of
+ * department D", the same per-department semantic DingTalk models as `leader_in_dept`, now lifted
+ * into a queryable column an admin can set on a LOCAL org.
+ *
+ * `directory_account_departments` was created by a zzzz migration
+ * (`zzzz20260324150000_create_directory_sync_tables.ts`), so this addition MUST also be a
+ * zzzz-prefixed TS migration — a plain 0xx SQL migration would run before the table exists and
+ * silently no-op (same ordering rule as the sibling B1 index / schedule_timezone additions).
+ *
+ * DEFAULT false is load-bearing for the DingTalk bit-identical guarantee: the DingTalk sync
+ * writer never sets this column, so every provider-synced membership row keeps `is_manager =
+ * false`, which makes `ApprovalDirectoryOrg`'s dual-source resolver fall through to the existing
+ * `raw.leader_in_dept` path for those integrations (see the resolver comment). The flag is
+ * populated for LOCAL rows only, via `setLocalMembershipManager`.
+ *
+ * IF NOT EXISTS on both the column and the index keeps replay idempotent. No backfill is needed:
+ * the column is added with `DEFAULT false`, and `false` is the correct value for every existing
+ * row regardless of provider — `is_manager` only ever becomes `true` through the new B3 writer
+ * (`setLocalMembershipManager`), which no pre-B3 row could have gone through.
+ *
+ * Index: the resolver looks up managers by department filtered to `is_manager = true`
+ * (`... WHERE d.external_department_id = $2 AND ad.is_manager = true`). A partial index keyed on
+ * `directory_department_id WHERE is_manager` keeps that lookup cheap and the index tiny — it holds
+ * only the (few) manager rows, not every membership.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE directory_account_departments
+    ADD COLUMN IF NOT EXISTS is_manager boolean NOT NULL DEFAULT false
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_directory_account_departments_manager_by_dept
+    ON directory_account_departments (directory_department_id)
+    WHERE is_manager
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_directory_account_departments_manager_by_dept`.execute(db)
+  await sql`
+    ALTER TABLE directory_account_departments
+    DROP COLUMN IF EXISTS is_manager
+  `.execute(db)
+}

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -1064,6 +1064,66 @@ export async function upsertDirectoryAccountDepartments(
 }
 
 /**
+ * Canonical Org MVP — B3 (normalized manager relation), #4215 §5.4.
+ *
+ * Set the first-class `is_manager` flag on ONE existing LOCAL membership row — the write
+ * counterpart to the normalized read path in `ApprovalDirectoryOrg` (dual-source, precedence on
+ * `is_manager`). It updates an existing membership; it does NOT create one (membership creation
+ * stays owned by the B2 local-directory CRUD surface, #4317). This writer is called by the
+ * `PATCH /api/admin/directory/local/memberships/:membershipId` route (platform-admin gated), which
+ * supplies the server-resolved `orgId`, emits the set/unset audit event, and maps a
+ * `{ updated: false }` result to a 404.
+ *
+ * SCOPE — the single UPDATE binds ALL of: the ORG (`i.org_id = $3`); the INTEGRATION
+ * (`i.id = a.integration_id`, and the department's own integration via `d.integration_id =
+ * a.integration_id`, so the account and the department must share ONE integration) AND that
+ * integration's STATUS (`i.status = 'active'` — an inactive/disabled local integration is out of
+ * scope, matching the read side's `selectActiveLocalIntegration`); the PROVIDER, checked on ALL
+ * THREE joined rows (`i.provider = 'local'` AND `a.provider = 'local'` AND `d.provider = 'local'`
+ * — an integration can be local while a child account/department row is mislabeled with a
+ * different provider, e.g. a stray `'dingtalk'` row under a local integration, so the account and
+ * department provider must each be checked independently, not inferred from the integration); and
+ * the ACCOUNT/DEPARTMENT identity (`ad.directory_account_id` / `ad.directory_department_id`).
+ * Anything malformed — an inactive local integration, a DingTalk-synced membership, a mislabeled
+ * account or department row, a local-account × foreign-integration-department pair, or a cross-org
+ * call (`orgId` naming a different org than the account's integration belongs to) — matches ZERO
+ * rows, so the result is a no-op `{ updated: false }`, never an error and never a cross-scope write.
+ *
+ * That local-only, active-only boundary is load-bearing: the resolver's DingTalk bit-identical
+ * guarantee rests on `is_manager` staying default-false for every provider-synced row, so this
+ * writer must never be able to flip it on a non-local or inactive membership.
+ *
+ * No audit here: this is the persistence primitive (it mirrors `upsertDirectoryAccountDepartments`,
+ * which likewise does not audit). The membership-change audit row is written by its caller, the
+ * local-directory membership route, next to every other B2 membership mutation's audit event.
+ */
+export async function setLocalMembershipManager(
+  orgId: string,
+  identity: { directoryAccountId: string; directoryDepartmentId: string },
+  isManager: boolean,
+): Promise<{ updated: boolean }> {
+  const normalizedOrgId = normalizeText(orgId) || DEFAULT_ORG_ID
+  const result = await query(
+    `UPDATE directory_account_departments AS ad
+        SET is_manager = $4
+       FROM directory_accounts a, directory_integrations i, directory_departments d
+      WHERE ad.directory_account_id = $1::uuid
+        AND ad.directory_department_id = $2::uuid
+        AND a.id = ad.directory_account_id
+        AND d.id = ad.directory_department_id
+        AND i.id = a.integration_id
+        AND d.integration_id = a.integration_id
+        AND i.provider = 'local'
+        AND i.status = 'active'
+        AND a.provider = 'local'
+        AND d.provider = 'local'
+        AND i.org_id = $3`,
+    [identity.directoryAccountId, identity.directoryDepartmentId, normalizedOrgId, isManager],
+  )
+  return { updated: (result.rowCount ?? 0) > 0 }
+}
+
+/**
  * DT-HARDEN-02: whether an auto-admitted account can be granted DingTalk login.
  * A grant needs a stable identity key: corp-scoped accounts key on corpId+openId,
  * so a corp account WITHOUT an openId cannot be granted (directory 通讯录's

--- a/packages/core-backend/src/directory/local-directory-org-request-schema.ts
+++ b/packages/core-backend/src/directory/local-directory-org-request-schema.ts
@@ -54,8 +54,14 @@ export const UPDATE_LOCAL_ACCOUNT_FIELDS = ['name', 'email', 'mobile', 'title'] 
 /** POST /api/admin/directory/local/memberships */
 export const ADD_LOCAL_MEMBERSHIP_FIELDS = ['accountId', 'departmentId'] as const
 
-/** PATCH /api/admin/directory/local/memberships/:membershipId — the explicit primary-department switch. */
-export const SWITCH_LOCAL_MEMBERSHIP_PRIMARY_FIELDS = ['isPrimary'] as const
+/**
+ * PATCH /api/admin/directory/local/memberships/:membershipId — a narrow membership update that
+ * performs EXACTLY ONE of two mutually-exclusive operations per request (the route enforces the
+ * XOR): the explicit primary-department switch (`isPrimary: true`) OR the normalized manager-flag
+ * set/unset (`isManager: true|false`, B3 #4215 §5.4). Both keys in one body — or an empty body —
+ * is a 400 before any write, so a combined request can never partially apply.
+ */
+export const UPDATE_LOCAL_MEMBERSHIP_FIELDS = ['isPrimary', 'isManager'] as const
 
 /**
  * Owner P2 (review on #4317): the allowlists above only ever checked field NAMES. A
@@ -89,7 +95,7 @@ export const SWITCH_LOCAL_MEMBERSHIP_PRIMARY_FIELDS = ['isPrimary'] as const
  * behavior, which silently `Math.trunc`ed any finite number the client sent (so a float or a
  * numeric string masqueraded as accepted input instead of being rejected).
  */
-export type LocalDirectoryFieldKind = 'string' | 'stringOrNull' | 'integer'
+export type LocalDirectoryFieldKind = 'string' | 'stringOrNull' | 'integer' | 'boolean'
 
 export interface LocalDirectoryFieldSpec {
   field: string
@@ -114,6 +120,8 @@ function describeFieldKind(kind: LocalDirectoryFieldKind): string {
       // int4-bounded (see matchesFieldKind) — say so, or a 3e9 rejection reads as a lie
       // ("3000000000 IS an integer"). Message precision is a review contract in this repo.
       return 'an integer within the int4 range'
+    case 'boolean':
+      return 'a boolean'
   }
 }
 
@@ -128,6 +136,8 @@ function matchesFieldKind(value: unknown, kind: LocalDirectoryFieldKind): boolea
       // Number.isInteger gate and then blow up as a 500 at INSERT time — same
       // "type gate exists but the write still fails loudly" seam, closed here as a 400.
       return typeof value === 'number' && Number.isInteger(value) && value >= -2147483648 && value <= 2147483647
+    case 'boolean':
+      return typeof value === 'boolean'
   }
 }
 
@@ -188,8 +198,17 @@ export const ADD_LOCAL_MEMBERSHIP_FIELD_TYPES: readonly LocalDirectoryFieldSpec[
   { field: 'departmentId', kind: 'string' },
 ]
 
-// Note: PATCH /memberships/:membershipId (`SWITCH_LOCAL_MEMBERSHIP_PRIMARY_FIELDS`) has no
-// corresponding *_FIELD_TYPES export — its one field, `isPrimary`, is already validated more
-// strictly than any kind here could express (`body.isPrimary !== true` in admin-directory-local.ts
-// rejects anything that isn't the literal `true`, including `false`, strings, and numbers — the
-// route's own narrow-endpoint contract, not a coercion bug).
+/**
+ * PATCH /api/admin/directory/local/memberships/:membershipId — types for `UPDATE_LOCAL_MEMBERSHIP_FIELDS`.
+ * Both fields are booleans. `isManager` (B3 #4215 §5.4) legitimately accepts BOTH `true` (set the
+ * normalized manager flag) and `false` (unset it), so this type gate is what rejects (400) an
+ * `isManager` sent as a string/number BEFORE the route ever reads it — the same coercion class the
+ * account/department endpoints close. `isPrimary` keeps its stricter route-layer contract too
+ * (`body.isPrimary !== true` in admin-directory-local.ts rejects anything but the literal `true`);
+ * it still gets a boolean spec HERE so the allowlist ↔ type-spec drift guard holds by set-equality —
+ * a field present in an allowlist with NO type spec is exactly the drift this pairing forbids.
+ */
+export const UPDATE_LOCAL_MEMBERSHIP_FIELD_TYPES: readonly LocalDirectoryFieldSpec[] = [
+  { field: 'isPrimary', kind: 'boolean' },
+  { field: 'isManager', kind: 'boolean' },
+]

--- a/packages/core-backend/src/routes/admin-directory-local.ts
+++ b/packages/core-backend/src/routes/admin-directory-local.ts
@@ -10,11 +10,12 @@ import {
   CREATE_LOCAL_ACCOUNT_FIELDS,
   CREATE_LOCAL_DEPARTMENT_FIELD_TYPES,
   CREATE_LOCAL_DEPARTMENT_FIELDS,
-  SWITCH_LOCAL_MEMBERSHIP_PRIMARY_FIELDS,
   UPDATE_LOCAL_ACCOUNT_FIELD_TYPES,
   UPDATE_LOCAL_ACCOUNT_FIELDS,
   UPDATE_LOCAL_DEPARTMENT_FIELD_TYPES,
   UPDATE_LOCAL_DEPARTMENT_FIELDS,
+  UPDATE_LOCAL_MEMBERSHIP_FIELD_TYPES,
+  UPDATE_LOCAL_MEMBERSHIP_FIELDS,
   checkFieldAllowlist,
   checkFieldTypes,
   type LocalDirectoryFieldSpec,
@@ -32,6 +33,7 @@ import {
   updateLocalAccount,
   updateLocalDepartment,
 } from '../directory/local-directory-org'
+import { setLocalMembershipManager } from '../directory/directory-sync'
 import { jsonError, jsonOk } from '../util/response'
 
 const logger = new Logger('AdminDirectoryLocalRoutes')
@@ -357,7 +359,8 @@ export function adminDirectoryLocalRouter(): Router {
   router.patch('/memberships/:membershipId', async (req: Request, res: Response) => {
     const adminUserId = await ensurePlatformAdmin(req, res)
     if (!adminUserId) return
-    if (rejectUnlistedFields(req, res, SWITCH_LOCAL_MEMBERSHIP_PRIMARY_FIELDS)) return
+    if (rejectUnlistedFields(req, res, UPDATE_LOCAL_MEMBERSHIP_FIELDS)) return
+    if (rejectInvalidFieldTypes(req, res, UPDATE_LOCAL_MEMBERSHIP_FIELD_TYPES)) return
 
     const parsed = parseMembershipId(req.params.membershipId)
     if (!parsed) {
@@ -366,16 +369,62 @@ export function adminDirectoryLocalRouter(): Router {
     }
 
     const body = (req.body ?? {}) as Record<string, unknown>
-    // This route is deliberately narrow: the ONLY supported operation is the explicit primary
-    // switch (design lock §5.4). `{isPrimary: true}` is required — anything else (missing,
-    // false, non-boolean) is rejected rather than guessed at.
+    // This endpoint performs EXACTLY ONE of two mutually-exclusive membership operations per
+    // request — the explicit primary-department switch (`isPrimary`) OR the normalized manager-flag
+    // set/unset (`isManager`, B3 §5.4). Enforcing the XOR HERE, before any service call, is what
+    // makes a combined `{isPrimary, isManager}` (or an empty `{}`) a 400 that can never partially
+    // apply: no column is touched on the rejected path.
+    const hasPrimary = Object.prototype.hasOwnProperty.call(body, 'isPrimary')
+    const hasManager = Object.prototype.hasOwnProperty.call(body, 'isManager')
+    if (hasPrimary === hasManager) {
+      jsonError(res, 400, 'DIRECTORY_LOCAL_INVALID_INPUT', 'exactly one of isPrimary | isManager is required')
+      return
+    }
+
+    const orgId = resolveLocalDirectoryOrgId(req)
+
+    if (hasManager) {
+      // `isManager` is guaranteed a boolean by rejectInvalidFieldTypes above; both `true` (set the
+      // normalized manager flag) and `false` (unset it) are valid operations. The writer is scoped
+      // to LOCAL memberships in THIS org — a no-op `{ updated: false }` (missing, non-local,
+      // cross-org, or cross-integration membership) becomes a 404, and it emits no cross-scope write.
+      const isManager = body.isManager as boolean
+      try {
+        const result = await setLocalMembershipManager(
+          orgId,
+          { directoryAccountId: parsed.accountId, directoryDepartmentId: parsed.departmentId },
+          isManager,
+        )
+        if (!result.updated) {
+          jsonError(res, 404, 'DIRECTORY_LOCAL_NOT_FOUND', 'Local membership not found')
+          return
+        }
+        await auditLog({
+          actorId: adminUserId,
+          actorType: 'user',
+          action: 'directory.local_membership.set_manager',
+          resourceType: 'directory-account-department',
+          resourceId: `${parsed.accountId}:${parsed.departmentId}`,
+          // Values-free: IDs (references) + the boolean operation flag, no names/PII.
+          meta: { accountId: parsed.accountId, departmentId: parsed.departmentId, isManager },
+        })
+        jsonOk(res, {
+          membership: { id: `${parsed.accountId}:${parsed.departmentId}`, accountId: parsed.accountId, departmentId: parsed.departmentId, isManager },
+        })
+      } catch (error) {
+        handleLocalDirectoryError(res, error, 'Failed to set local membership manager flag')
+      }
+      return
+    }
+
+    // Primary-switch branch (unchanged contract): `{isPrimary: true}` is required — `false` or any
+    // non-`true` value is rejected rather than guessed at (narrow-endpoint contract, design lock §5.4).
     if (body.isPrimary !== true) {
       jsonError(res, 400, 'DIRECTORY_LOCAL_INVALID_INPUT', 'isPrimary must be true — this endpoint only performs the explicit primary-department switch')
       return
     }
 
     try {
-      const orgId = resolveLocalDirectoryOrgId(req)
       const membership = await switchLocalPrimaryDepartment(orgId, parsed.accountId, parsed.departmentId)
       await auditLog({
         actorId: adminUserId,

--- a/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
+++ b/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
@@ -204,27 +204,55 @@ export async function resolveApprovalRequesterOrgRelations(
   const integrationId = requester.integration_id
   const requesterDeptId = normalizeExternalId(requester.primary_external_department_id)
 
-  // 2) Direct manager: the account flagged leader for the requester's primary
-  //    department in its own `leader_in_dept`. Exclude the requester themselves.
+  // 2) Direct manager — DUAL-SOURCE with precedence (B3, design-lock §5.4).
+  //    The manager relationship is now a first-class, provider-neutral flag on the
+  //    membership row (`directory_account_departments.is_manager`) — product truth an
+  //    admin sets on a LOCAL org — NOT parsed from a provider's raw JSON. Precedence:
+  //      - if the requester's primary department has ANY membership marked
+  //        `is_manager = true`, resolve the manager from that normalized relation;
+  //      - OTHERWISE fall back to the legacy DingTalk `raw.leader_in_dept` parse below,
+  //        which stays byte-for-byte unchanged.
+  //    DingTalk-synced rows never set `is_manager` (the sync writer leaves it default-false —
+  //    see `setLocalMembershipManager`'s local-only writer boundary), so the normalized gate is
+  //    always 0 rows for a DingTalk integration and its approval routing stays bit-identical.
+  //    B6 proves local/DingTalk manager parity end-to-end; B3 only opens the normalized read
+  //    seam for the DIRECT manager here. The manager CHAIN (step 4) and the department HEAD
+  //    (step 3, a distinct `dept_manager_userid_list` source) are intentionally left on their
+  //    legacy sources in this increment.
   let managerId: string | undefined
   if (requesterDeptId) {
-    const candidateRows = await query<{ account_id: string; raw: unknown }>(
-      `SELECT a.id::text AS account_id, a.raw AS raw
-         FROM directory_accounts a
-         JOIN directory_account_departments ad
-           ON ad.directory_account_id = a.id
-         JOIN directory_departments d
-           ON d.id = ad.directory_department_id
-        WHERE a.integration_id = $1::uuid
-          AND a.is_active = true
-          AND d.external_department_id = $2
-          AND a.external_user_id <> $3`,
-      [integrationId, requesterDeptId, requester.external_user_id],
+    const normalized = await resolveNormalizedDeptManager(
+      integrationId,
+      requesterDeptId,
+      requester.external_user_id,
+      query,
     )
-    const managerAccountId = candidateRows.rows.find((row) =>
-      parseLeaderDeptIds(asRecord(row.raw)).includes(requesterDeptId))?.account_id
-    if (managerAccountId) {
-      managerId = await resolveLinkedLocalUserId(managerAccountId, query)
+    if (normalized.present) {
+      // The dept is normalized-managed: the normalized relation is authoritative even when it
+      // resolves to no LINKED local user (e.g. the flagged manager is unlinked) — we never blend
+      // back into the provider raw for a dept an admin explicitly manages.
+      managerId = normalized.managerId
+    } else {
+      // LEGACY (unchanged): the account flagged leader for the requester's primary
+      // department in its own `leader_in_dept`. Exclude the requester themselves.
+      const candidateRows = await query<{ account_id: string; raw: unknown }>(
+        `SELECT a.id::text AS account_id, a.raw AS raw
+           FROM directory_accounts a
+           JOIN directory_account_departments ad
+             ON ad.directory_account_id = a.id
+           JOIN directory_departments d
+             ON d.id = ad.directory_department_id
+          WHERE a.integration_id = $1::uuid
+            AND a.is_active = true
+            AND d.external_department_id = $2
+            AND a.external_user_id <> $3`,
+        [integrationId, requesterDeptId, requester.external_user_id],
+      )
+      const managerAccountId = candidateRows.rows.find((row) =>
+        parseLeaderDeptIds(asRecord(row.raw)).includes(requesterDeptId))?.account_id
+      if (managerAccountId) {
+        managerId = await resolveLinkedLocalUserId(managerAccountId, query)
+      }
     }
   }
 
@@ -376,6 +404,56 @@ async function resolveManagerChain(
   }
 
   return chain
+}
+
+/**
+ * B3 (design-lock §5.4) — resolve the requester's direct manager from the NORMALIZED relation:
+ * the `directory_account_departments.is_manager` flag on a membership of the requester's primary
+ * department. Returns a discriminated result so the caller can honour the precedence rule:
+ *   - `present = false` — the department has NO `is_manager = true` membership, so the caller
+ *     falls back to the legacy `raw.leader_in_dept` source (this is always the case for a
+ *     DingTalk integration, whose rows never set the flag → its routing is bit-identical);
+ *   - `present = true` — the department IS normalized-managed, so this result is authoritative,
+ *     including `managerId = undefined` when the flagged manager is not linked to a local user
+ *     (we do not blend back into the provider raw for an explicitly-managed dept).
+ *
+ * The existence gate is requester-INCLUSIVE (any `is_manager` row for the dept flips to
+ * normalized), while the pick is requester-EXCLUSIVE (a person is never their own manager). The
+ * pick is deterministic — ordered by `external_user_id` then account id — since, unlike the
+ * legacy `.find` over arbitrary heap order, this is a fresh read path.
+ *
+ * The department is bound to the SAME integration as the account (`d.integration_id = $1` alongside
+ * the account's `a.integration_id = $1`): `external_department_id` is unique only WITHIN an
+ * integration, so without this a repeated external id in another integration — or a malformed
+ * cross-integration membership — could leak a foreign dept's manager into this integration's
+ * routing. Both sides bind the one requester integration scope.
+ */
+async function resolveNormalizedDeptManager(
+  integrationId: string,
+  deptExternalId: string,
+  requesterExternalId: string,
+  query: QueryFn,
+): Promise<{ present: boolean; managerId?: string }> {
+  const rows = await query<{ account_id: string; external_user_id: string }>(
+    `SELECT a.id::text        AS account_id,
+            a.external_user_id AS external_user_id
+       FROM directory_account_departments ad
+       JOIN directory_accounts a
+         ON a.id = ad.directory_account_id
+        AND a.is_active = true
+       JOIN directory_departments d
+         ON d.id = ad.directory_department_id
+      WHERE a.integration_id = $1::uuid
+        AND d.integration_id = $1::uuid
+        AND d.external_department_id = $2
+        AND ad.is_manager = true
+      ORDER BY a.external_user_id ASC, a.id ASC`,
+    [integrationId, deptExternalId],
+  )
+  if (rows.rows.length === 0) return { present: false }
+  const manager = rows.rows.find((row) => row.external_user_id !== requesterExternalId)
+  if (!manager) return { present: true }
+  return { present: true, managerId: await resolveLinkedLocalUserId(manager.account_id, query) }
 }
 
 async function resolveLinkedLocalUserId(accountId: string, query: QueryFn): Promise<string | undefined> {

--- a/packages/core-backend/tests/integration/directory-normalized-manager.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-normalized-manager.db.test.ts
@@ -1,0 +1,769 @@
+import express from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import {
+  getOrCreateLocalIntegration,
+  setLocalMembershipManager,
+} from '../../src/directory/directory-sync'
+import { adminDirectoryLocalRouter } from '../../src/routes/admin-directory-local'
+import { resolveApprovalRequesterOrgRelations } from '../../src/services/ApprovalDirectoryOrg'
+
+/**
+ * Canonical Org MVP — B3 (normalized manager relation), #4215 §5.4, real DB.
+ *
+ * Owner ruling (Wave 3, 2026-07-12): the manager/department-head link is a FIRST-CLASS,
+ * provider-neutral flag on the membership (`directory_account_departments.is_manager`), NOT parsed
+ * from a provider's raw JSON. `ApprovalDirectoryOrg`'s direct-manager resolution (step 2) is now
+ * DUAL-SOURCE with precedence:
+ *   - if the requester's primary department has ANY `is_manager = true` membership → resolve from
+ *     that normalized relation (authoritative, even when it links to no local user);
+ *   - otherwise → the legacy DingTalk `raw.leader_in_dept` parse, byte-for-byte unchanged.
+ *
+ * This proves, against real Postgres:
+ *   (a) NORMALIZED resolution — a local integration whose manager is flagged via the normalized
+ *       relation (set through `setLocalMembershipManager`) resolves that manager;
+ *   (b) DINGTALK REGRESSION PIN (load-bearing compat leg) — a DingTalk-shaped integration whose
+ *       manager is flagged the pre-existing way (`raw.leader_in_dept`, `is_manager` left
+ *       default-false) resolves the SAME manager it always did; a positive control asserts NO
+ *       membership got an `is_manager` flag, so the compat argument is non-vacuous;
+ *   (c) PRECEDENCE — when a department has BOTH a legacy `leader_in_dept` leader AND a normalized
+ *       `is_manager` manager (a different account), the normalized relation wins and the legacy
+ *       source is ignored;
+ *   (d1) `is_manager` DEFAULTS false; the writer sets it and writes NO provider raw;
+ *   (d2) the writer's LOCAL-ONLY boundary — it refuses (no-op) a DingTalk membership, keeping the
+ *       bit-identical guarantee's writer side intact.
+ *
+ * Fixture IDs are namespaced with this file's own STAMP + a per-scenario suffix — integration
+ * specs share one real Postgres in CI (plugin-tests.yml), so a bare `Date.now()` can collide with
+ * another file's fixtures in the same run.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+
+// Adapt the QueryResultRow-constrained `query` to the resolver's unconstrained QueryFn.
+const queryFn = <Row>(text: string, params?: unknown[]): Promise<{ rows: Row[] }> =>
+  query(text, params).then((r) => ({ rows: r.rows as Row[] }))
+
+function id(suffix: string): string {
+  return `b3-nm-${STAMP}-${suffix}`
+}
+
+async function seedUser(userId: string): Promise<void> {
+  await query(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x')`, [userId, `${userId}@example.test`])
+}
+
+async function seedDept(integrationId: string, provider: string, externalId: string, name: string): Promise<string> {
+  return (
+    await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, provider, external_department_id, name, is_active, raw)
+       VALUES ($1, $2, $3, $4, true, '{}'::jsonb) RETURNING id`,
+      [integrationId, provider, externalId, name],
+    )
+  ).rows[0].id
+}
+
+async function seedAccount(
+  integrationId: string,
+  provider: string,
+  externalUserId: string,
+  externalKey: string,
+  name: string,
+  raw: Record<string, unknown>,
+): Promise<string> {
+  return (
+    await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb) RETURNING id`,
+      [integrationId, provider, externalUserId, externalKey, name, JSON.stringify(raw)],
+    )
+  ).rows[0].id
+}
+
+async function link(accountId: string, userId: string): Promise<void> {
+  await query(
+    `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+     VALUES ($1, $2, 'linked', 'manual')`,
+    [accountId, userId],
+  )
+}
+
+async function membership(accountId: string, departmentId: string, isPrimary: boolean): Promise<void> {
+  await query(
+    `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary)
+     VALUES ($1, $2, $3)`,
+    [accountId, departmentId, isPrimary],
+  )
+}
+
+async function readIsManager(accountId: string, departmentId: string): Promise<boolean> {
+  return (
+    await query<{ is_manager: boolean }>(
+      `SELECT is_manager FROM directory_account_departments
+        WHERE directory_account_id = $1 AND directory_department_id = $2`,
+      [accountId, departmentId],
+    )
+  ).rows[0].is_manager
+}
+
+describeIfDatabase('B3 normalized manager relation — ApprovalDirectoryOrg dual-source (real DB)', () => {
+  const integrationIds: string[] = []
+  const userIds: string[] = []
+
+  // (a) local integration — normalized relation.
+  const U_A_REQ = id('a-req')
+  const U_A_MGR = id('a-mgr')
+  let localDeptA = ''
+  let localMgrAccountA = ''
+
+  // (b) DingTalk-shaped integration — legacy leader_in_dept.
+  const U_B_REQ = id('b-req')
+  const U_B_MGR = id('b-mgr')
+  let dtIntegrationB = ''
+
+  // (c) precedence — both sources present on one DingTalk integration.
+  const U_C_REQ = id('c-req')
+  const U_C_LEGACY = id('c-legacy')
+  const U_C_NORM = id('c-norm')
+  let dtDeptC = ''
+  let normAccountC = ''
+
+  // (d1) writer + default + no-raw.
+  let localDeptD = ''
+  let localAccountD = ''
+
+  // (d2) writer local-only boundary.
+  let dtDeptE = ''
+  let dtAccountE = ''
+
+  beforeAll(async () => {
+    // ---- (a) local integration ----
+    const localA = await getOrCreateLocalIntegration(id('a-org'))
+    integrationIds.push(localA.id)
+    localDeptA = await seedDept(localA.id, 'local', id('a-dept'), 'EngA')
+    await seedUser(U_A_REQ)
+    await seedUser(U_A_MGR)
+    const reqA = await seedAccount(localA.id, 'local', id('a-ext-req'), id('a-key-req'), 'ReqA', {})
+    localMgrAccountA = await seedAccount(localA.id, 'local', id('a-ext-mgr'), id('a-key-mgr'), 'MgrA', {})
+    userIds.push(U_A_REQ, U_A_MGR)
+    await link(reqA, U_A_REQ)
+    await link(localMgrAccountA, U_A_MGR)
+    await membership(reqA, localDeptA, true)
+    await membership(localMgrAccountA, localDeptA, false)
+
+    // ---- (b) DingTalk-shaped integration ----
+    dtIntegrationB = (
+      await query<{ id: string }>(
+        `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+        [id('b-int'), id('b-corp')],
+      )
+    ).rows[0].id
+    integrationIds.push(dtIntegrationB)
+    const deptB = await seedDept(dtIntegrationB, 'dingtalk', id('b-dept'), 'EngB')
+    await seedUser(U_B_REQ)
+    await seedUser(U_B_MGR)
+    const reqB = await seedAccount(dtIntegrationB, 'dingtalk', id('b-ext-req'), id('b-key-req'), 'ReqB', {})
+    const mgrB = await seedAccount(dtIntegrationB, 'dingtalk', id('b-ext-mgr'), id('b-key-mgr'), 'MgrB', {
+      leader_in_dept: [{ dept_id: id('b-dept'), leader: true }],
+    })
+    userIds.push(U_B_REQ, U_B_MGR)
+    await link(reqB, U_B_REQ)
+    await link(mgrB, U_B_MGR)
+    await membership(reqB, deptB, true)
+    await membership(mgrB, deptB, true) // NOTE: is_manager intentionally left default-false.
+
+    // ---- (c) precedence: legacy leader AND normalized manager on one DingTalk integration ----
+    const dtIntegrationC = (
+      await query<{ id: string }>(
+        `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+        [id('c-int'), id('c-corp')],
+      )
+    ).rows[0].id
+    integrationIds.push(dtIntegrationC)
+    dtDeptC = await seedDept(dtIntegrationC, 'dingtalk', id('c-dept'), 'EngC')
+    await seedUser(U_C_REQ)
+    await seedUser(U_C_LEGACY)
+    await seedUser(U_C_NORM)
+    const reqC = await seedAccount(dtIntegrationC, 'dingtalk', id('c-ext-req'), id('c-key-req'), 'ReqC', {})
+    const legacyC = await seedAccount(dtIntegrationC, 'dingtalk', id('c-ext-legacy'), id('c-key-legacy'), 'LegacyC', {
+      leader_in_dept: [{ dept_id: id('c-dept'), leader: true }],
+    })
+    normAccountC = await seedAccount(dtIntegrationC, 'dingtalk', id('c-ext-norm'), id('c-key-norm'), 'NormC', {})
+    userIds.push(U_C_REQ, U_C_LEGACY, U_C_NORM)
+    await link(reqC, U_C_REQ)
+    await link(legacyC, U_C_LEGACY)
+    await link(normAccountC, U_C_NORM)
+    await membership(reqC, dtDeptC, true)
+    await membership(legacyC, dtDeptC, true)
+    await membership(normAccountC, dtDeptC, true)
+
+    // ---- (d1) local writer target ----
+    const localD = await getOrCreateLocalIntegration(id('d-org'))
+    integrationIds.push(localD.id)
+    localDeptD = await seedDept(localD.id, 'local', id('d-dept'), 'EngD')
+    localAccountD = await seedAccount(localD.id, 'local', id('d-ext'), id('d-key'), 'AcctD', {})
+    await membership(localAccountD, localDeptD, true)
+
+    // ---- (d2) DingTalk writer-boundary target ----
+    const dtIntegrationE = (
+      await query<{ id: string }>(
+        `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+        [id('e-int'), id('e-corp')],
+      )
+    ).rows[0].id
+    integrationIds.push(dtIntegrationE)
+    dtDeptE = await seedDept(dtIntegrationE, 'dingtalk', id('e-dept'), 'EngE')
+    dtAccountE = await seedAccount(dtIntegrationE, 'dingtalk', id('e-ext'), id('e-key'), 'AcctE', {})
+    await membership(dtAccountE, dtDeptE, true)
+  })
+
+  afterAll(async () => {
+    try {
+      for (const integrationId of integrationIds) {
+        // account_departments + links cascade on directory_accounts delete.
+        await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+      }
+      if (userIds.length > 0) await query(`DELETE FROM users WHERE id = ANY($1)`, [userIds])
+    } catch {
+      /* best effort */
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('(a) resolves the manager from the NORMALIZED is_manager relation on a local integration', async () => {
+    // Exercise the writer as the flag source (the PATCH /memberships route calls it in production).
+    expect(
+      await setLocalMembershipManager(id('a-org'), { directoryAccountId: localMgrAccountA, directoryDepartmentId: localDeptA }, true),
+    ).toEqual({ updated: true })
+
+    const rel = await resolveApprovalRequesterOrgRelations(U_A_REQ, queryFn)
+    // Exact shape: manager from the normalized relation; department name lifted; no title/head seeded.
+    expect(rel).toEqual({ managerId: U_A_MGR, primaryDepartmentName: 'EngA' })
+  })
+
+  it('(b) DINGTALK REGRESSION PIN: legacy leader_in_dept resolution is unchanged, and no is_manager was set', async () => {
+    const rel = await resolveApprovalRequesterOrgRelations(U_B_REQ, queryFn)
+    expect(rel).toEqual({ managerId: U_B_MGR, primaryDepartmentName: 'EngB' })
+
+    // Positive control for the compat argument: NOT ONE membership on the DingTalk integration
+    // carries the normalized flag — the whole reason the legacy path still runs bit-identically.
+    const flagged = (
+      await query<{ count: number }>(
+        `SELECT COUNT(*)::int AS count
+           FROM directory_account_departments ad
+           JOIN directory_accounts a ON a.id = ad.directory_account_id
+          WHERE a.integration_id = $1 AND ad.is_manager = true`,
+        [dtIntegrationB],
+      )
+    ).rows[0].count
+    expect(flagged).toBe(0)
+  })
+
+  it('(c) PRECEDENCE: the normalized relation wins over a legacy leader_in_dept leader in the same dept', async () => {
+    // Flag the normalized manager directly (this DingTalk membership is not a writer target — the
+    // writer is local-only — so the resolver-precedence fixture sets the column directly).
+    await query(
+      `UPDATE directory_account_departments SET is_manager = true
+        WHERE directory_account_id = $1 AND directory_department_id = $2`,
+      [normAccountC, dtDeptC],
+    )
+
+    const rel = await resolveApprovalRequesterOrgRelations(U_C_REQ, queryFn)
+    expect(rel.managerId).toBe(U_C_NORM) // normalized wins
+    expect(rel.managerId).not.toBe(U_C_LEGACY) // legacy leader_in_dept is ignored once normalized is present
+  })
+
+  it('(d1) is_manager defaults false; the writer flips it and writes NO provider raw', async () => {
+    expect(await readIsManager(localAccountD, localDeptD)).toBe(false) // DEFAULT false
+
+    expect(
+      await setLocalMembershipManager(id('d-org'), { directoryAccountId: localAccountD, directoryDepartmentId: localDeptD }, true),
+    ).toEqual({ updated: true })
+    expect(await readIsManager(localAccountD, localDeptD)).toBe(true)
+
+    // No raw write: the account's provider-raw JSON is untouched by the normalized-flag write.
+    const raw = (await query<{ raw: unknown }>(`SELECT raw FROM directory_accounts WHERE id = $1`, [localAccountD])).rows[0].raw
+    expect(raw).toEqual({})
+
+    // Round-trips back to false.
+    expect(
+      await setLocalMembershipManager(id('d-org'), { directoryAccountId: localAccountD, directoryDepartmentId: localDeptD }, false),
+    ).toEqual({ updated: true })
+    expect(await readIsManager(localAccountD, localDeptD)).toBe(false)
+  })
+
+  it('(d2) writer LOCAL-ONLY boundary: it refuses (no-op) a DingTalk membership, leaving is_manager false', async () => {
+    // dtIntegrationE has org_id 'default' (schema default), so 'default' is the org that WOULD match
+    // if provider weren't the blocker — isolating the boundary to the `i.provider = 'local'` gate.
+    expect(
+      await setLocalMembershipManager('default', { directoryAccountId: dtAccountE, directoryDepartmentId: dtDeptE }, true),
+    ).toEqual({ updated: false })
+    expect(await readIsManager(dtAccountE, dtDeptE)).toBe(false)
+  })
+})
+
+// =============================================================================================
+// B3 writer scope + resolver integration binding (real DB). The writer's UPDATE binds org +
+// integration (+ active status) + provider (on all three joined rows) + account/department; the
+// resolver binds `d.integration_id` to the requester's integration. Mutation targets: m1 = drop
+// the resolver's `d.integration_id`; m2 = drop the writer's `d.integration_id = a.integration_id`
+// (isolated below with a same-provider, different-integration fixture — a DingTalk-department
+// fixture would ALSO trip the newer `d.provider = 'local'` predicate and so could not isolate m2
+// on its own); m-status/m-aprov/m-dprov = the owner round-3 predicates, isolated in the route
+// describe block below (each test flips exactly ONE of status/account-provider/dept-provider).
+// =============================================================================================
+describeIfDatabase('B3 writer four-way scope + resolver integration binding (real DB)', () => {
+  const integrationIds: string[] = []
+  const userIds: string[] = []
+
+  afterAll(async () => {
+    try {
+      for (const integrationId of integrationIds) {
+        await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+      }
+      if (userIds.length > 0) await query(`DELETE FROM users WHERE id = ANY($1)`, [userIds])
+    } catch {
+      /* best effort */
+    }
+  })
+
+  it('writer refuses a CROSS-ORG call (org mismatch) — updated:false, is_manager untouched; correct org flips it', async () => {
+    const local = await getOrCreateLocalIntegration(id('wx-org'))
+    integrationIds.push(local.id)
+    const dept = await seedDept(local.id, 'local', id('wx-dept'), 'WX')
+    const acct = await seedAccount(local.id, 'local', id('wx-ext'), id('wx-key'), 'WX', {})
+    await membership(acct, dept, true)
+
+    // Same account+dept, but a DIFFERENT org string → the `i.org_id = $3` gate fails → no match.
+    expect(
+      await setLocalMembershipManager(id('wx-OTHER-org'), { directoryAccountId: acct, directoryDepartmentId: dept }, true),
+    ).toEqual({ updated: false })
+    expect(await readIsManager(acct, dept)).toBe(false)
+
+    // Control: the CORRECT org DOES flip it (proves the fixture is otherwise writable — the org
+    // gate, not some unrelated bind, is what refused the cross-org call above).
+    expect(
+      await setLocalMembershipManager(id('wx-org'), { directoryAccountId: acct, directoryDepartmentId: dept }, true),
+    ).toEqual({ updated: true })
+    expect(await readIsManager(acct, dept)).toBe(true)
+  })
+
+  it('writer refuses a LOCAL-account × DINGTALK-department malformed membership — updated:false', async () => {
+    const local = await getOrCreateLocalIntegration(id('wf-org'))
+    integrationIds.push(local.id)
+    const localAcct = await seedAccount(local.id, 'local', id('wf-ext'), id('wf-key'), 'WF', {})
+
+    // A DingTalk integration + department; wire the LOCAL account to the DingTalk dept (malformed).
+    const dt = (
+      await query<{ id: string }>(`INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`, [id('wf-dt-int'), id('wf-dt-corp')])
+    ).rows[0].id
+    integrationIds.push(dt)
+    const dtDept = await seedDept(dt, 'dingtalk', id('wf-dt-dept'), 'WF-DT')
+    await membership(localAcct, dtDept, true)
+
+    // The account is local & in this org, but the department lives in the DingTalk integration —
+    // refused BOTH by the `d.integration_id = a.integration_id` bind AND by `d.provider = 'local'`
+    // (the DingTalk dept's own provider column). Because two independent predicates both reject
+    // this fixture, it is NOT the isolating test for either one — see the dedicated
+    // same-provider/different-integration fixture right below for the m2-isolated case, and the
+    // route describe block below for the m-dprov-isolated case.
+    expect(
+      await setLocalMembershipManager(id('wf-org'), { directoryAccountId: localAcct, directoryDepartmentId: dtDept }, true),
+    ).toEqual({ updated: false })
+    expect(await readIsManager(localAcct, dtDept)).toBe(false)
+  })
+
+  it('writer refuses a LOCAL-account × LOCAL-department pair from DIFFERENT integrations — updated:false (m2 target, isolated from provider checks)', async () => {
+    const localA = await getOrCreateLocalIntegration(id('wf2-org-a'))
+    integrationIds.push(localA.id)
+    const acctA = await seedAccount(localA.id, 'local', id('wf2-ext-a'), id('wf2-key-a'), 'WF2A', {})
+
+    const localB = await getOrCreateLocalIntegration(id('wf2-org-b'))
+    integrationIds.push(localB.id)
+    const deptB = await seedDept(localB.id, 'local', id('wf2-dept-b'), 'WF2B')
+
+    // Both rows are provider='local' (passes a.provider/d.provider AND i.provider/i.status) but
+    // belong to DIFFERENT integrations — only `d.integration_id = a.integration_id` refuses this,
+    // so this fixture isolates m2 cleanly (dropping it, and only it, flips the result to true).
+    await membership(acctA, deptB, true)
+
+    expect(
+      await setLocalMembershipManager(id('wf2-org-a'), { directoryAccountId: acctA, directoryDepartmentId: deptB }, true),
+    ).toEqual({ updated: false })
+    expect(await readIsManager(acctA, deptB)).toBe(false)
+  })
+
+  it('resolver binds d.integration_id: a same-external-id is_manager row in ANOTHER integration does NOT leak (m1 target)', async () => {
+    const U_REQ = id('rg-req')
+    const U_MGR = id('rg-mgr')
+    await seedUser(U_REQ)
+    await seedUser(U_MGR)
+    userIds.push(U_REQ, U_MGR)
+
+    const SHARED_EXT = id('rg-shared-ext')
+
+    // int-1 — the requester's integration; its primary dept carries SHARED_EXT.
+    const int1 = await getOrCreateLocalIntegration(id('rg-org1'))
+    integrationIds.push(int1.id)
+    const dept1 = await seedDept(int1.id, 'local', SHARED_EXT, 'RG1')
+    const req = await seedAccount(int1.id, 'local', id('rg-ext-req'), id('rg-key-req'), 'RGReq', {})
+    await link(req, U_REQ)
+    await membership(req, dept1, true)
+
+    // int-2 — a DIFFERENT integration with a dept sharing the SAME external_department_id. The
+    // manager account is in int-1 (so `a.integration_id = $1` passes), but its is_manager membership
+    // points at the int-2 dept, and its raw carries NO leader_in_dept (so the LEGACY path can never
+    // resolve it). Only the normalized read could — and only if `d.integration_id` were dropped.
+    const int2 = await getOrCreateLocalIntegration(id('rg-org2'))
+    integrationIds.push(int2.id)
+    const dept2 = await seedDept(int2.id, 'local', SHARED_EXT, 'RG2')
+    const mgr = await seedAccount(int1.id, 'local', id('rg-ext-mgr'), id('rg-key-mgr'), 'RGMgr', {})
+    await link(mgr, U_MGR)
+    await query(
+      `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary, is_manager)
+       VALUES ($1, $2, false, true)`,
+      [mgr, dept2],
+    )
+
+    const rel = await resolveApprovalRequesterOrgRelations(U_REQ, queryFn)
+    // With `d.integration_id` bound to the requester's integration, the int-2 dept is out of scope →
+    // no normalized manager, and the legacy scan finds no leader → managerId is absent. Dropping the
+    // bind (m1) would leak U_MGR here.
+    expect(rel.managerId).toBeUndefined()
+  })
+})
+
+// =============================================================================================
+// B3 set-manager ROUTE (real DB, HTTP) — PATCH /memberships/:id {isManager}. Drives the REAL
+// route as platform admin: end-to-end true→resolver-resolves / false→resolver-stops, the audit
+// row, platform-admin gating (401/403), field smuggling + type rejection, the XOR / no-partial
+// contract (m3 target: drop the XOR guard), the empty-body 400, and the 404 on a non-local /
+// absent membership.
+// =============================================================================================
+describeIfDatabase('B3 set-manager route — PATCH /memberships/:id {isManager} (real DB, HTTP)', () => {
+  const S = Date.now()
+  const rid = (s: string): string => `b3-route-${S}-${s}`
+  const accountIds: string[] = []
+  const otherIntegrationIds: string[] = []
+  const userIds: string[] = []
+  // Owner round-3 (P2-1/P2-2) hardening tests each seed their OWN department under `localInt` so
+  // a temporary provider/status flip never touches the shared `deptId` fixture other tests here
+  // depend on.
+  const extraDeptIds: string[] = []
+  let localInt = ''
+  let deptId = ''
+  let mgrAccountId = ''
+  let membershipId = ''
+  let uReq = ''
+  let uMgr = ''
+  let localAcctForMalformed = ''
+  let dtDeptId = ''
+
+  function appAs(user: unknown): express.Express {
+    const app = express()
+    app.use(express.json())
+    if (user !== undefined) {
+      app.use((req, _res, next) => {
+        ;(req as express.Request & { user?: unknown }).user = user
+        next()
+      })
+    }
+    app.use('/api/admin/directory/local', adminDirectoryLocalRouter())
+    return app
+  }
+  const adminApp = appAs({ id: `b3-route-admin-${S}`, role: 'admin' })
+  const nonAdminApp = appAs({ id: `b3-route-nonadmin-${S}` })
+  const noAuthApp = appAs(undefined)
+
+  beforeAll(async () => {
+    // The route resolves org 'default' server-side, so seed into the default org's local integration.
+    const local = await getOrCreateLocalIntegration('default')
+    localInt = local.id
+    uReq = rid('u-req')
+    uMgr = rid('u-mgr')
+    await seedUser(uReq)
+    await seedUser(uMgr)
+    userIds.push(uReq, uMgr)
+    deptId = await seedDept(localInt, 'local', rid('dept'), 'RouteDept')
+    const reqAccountId = await seedAccount(localInt, 'local', rid('ext-req'), rid('key-req'), 'RouteReq', {})
+    mgrAccountId = await seedAccount(localInt, 'local', rid('ext-mgr'), rid('key-mgr'), 'RouteMgr', {})
+    accountIds.push(reqAccountId, mgrAccountId)
+    await link(reqAccountId, uReq)
+    await link(mgrAccountId, uMgr)
+    await membership(reqAccountId, deptId, true)
+    await membership(mgrAccountId, deptId, false)
+    membershipId = `${mgrAccountId}:${deptId}`
+
+    // Malformed target: a LOCAL account (default int) joined to a DingTalk department.
+    localAcctForMalformed = await seedAccount(localInt, 'local', rid('ext-mal'), rid('key-mal'), 'RouteMal', {})
+    accountIds.push(localAcctForMalformed)
+    const dtInt = (
+      await query<{ id: string }>(`INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`, [rid('dt-int'), rid('dt-corp')])
+    ).rows[0].id
+    otherIntegrationIds.push(dtInt)
+    dtDeptId = await seedDept(dtInt, 'dingtalk', rid('dt-dept'), 'RouteDT')
+    await membership(localAcctForMalformed, dtDeptId, true)
+  })
+
+  afterAll(async () => {
+    try {
+      for (const accountId of accountIds) await query(`DELETE FROM directory_accounts WHERE id = $1`, [accountId])
+      if (deptId) await query(`DELETE FROM directory_departments WHERE id = $1`, [deptId])
+      for (const extraDeptId of extraDeptIds) await query(`DELETE FROM directory_departments WHERE id = $1`, [extraDeptId])
+      for (const integrationId of otherIntegrationIds) {
+        await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+        await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+      }
+      if (userIds.length > 0) await query(`DELETE FROM users WHERE id = ANY($1)`, [userIds])
+    } catch {
+      /* best effort */
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('set true over HTTP → ApprovalDirectoryOrg resolves the manager; audit row written; false → resolver stops', async () => {
+    const setTrue = await request(adminApp).patch(`/api/admin/directory/local/memberships/${membershipId}`).send({ isManager: true })
+    expect(setTrue.status).toBe(200)
+    expect(setTrue.body.data.membership.isManager).toBe(true)
+    expect(await readIsManager(mgrAccountId, deptId)).toBe(true)
+
+    const resolvedOn = await resolveApprovalRequesterOrgRelations(uReq, queryFn)
+    expect(resolvedOn.managerId).toBe(uMgr)
+
+    const audit = await query<{ action_details: Record<string, unknown> }>(
+      `SELECT action_details FROM audit_logs
+        WHERE action = 'directory.local_membership.set_manager' AND resource_id = $1
+        ORDER BY id DESC LIMIT 1`,
+      [membershipId],
+    )
+    expect(audit.rows.length).toBe(1)
+    // Values-free payload: structured IDs (references) + the boolean operation flag only — no
+    // names / emails / raw values ever reach the audit surface.
+    expect(audit.rows[0].action_details).toEqual({ accountId: mgrAccountId, departmentId: deptId, isManager: true })
+
+    const setFalse = await request(adminApp).patch(`/api/admin/directory/local/memberships/${membershipId}`).send({ isManager: false })
+    expect(setFalse.status).toBe(200)
+    expect(setFalse.body.data.membership.isManager).toBe(false)
+    expect(await readIsManager(mgrAccountId, deptId)).toBe(false)
+
+    const resolvedOff = await resolveApprovalRequesterOrgRelations(uReq, queryFn)
+    expect(resolvedOff.managerId).toBeUndefined()
+  })
+
+  it('rejects an UNAUTHENTICATED request (401), no write', async () => {
+    const res = await request(noAuthApp).patch(`/api/admin/directory/local/memberships/${membershipId}`).send({ isManager: true })
+    expect(res.status).toBe(401)
+    expect(await readIsManager(mgrAccountId, deptId)).toBe(false)
+  })
+
+  it('rejects a NON-ADMIN authenticated request (403), no write', async () => {
+    const res = await request(nonAdminApp).patch(`/api/admin/directory/local/memberships/${membershipId}`).send({ isManager: true })
+    expect(res.status).toBe(403)
+    expect(await readIsManager(mgrAccountId, deptId)).toBe(false)
+  })
+
+  it('rejects a body smuggling org_id/corp_id (400 UNKNOWN_FIELDS), no write', async () => {
+    const res = await request(adminApp)
+      .patch(`/api/admin/directory/local/memberships/${membershipId}`)
+      .send({ isManager: true, org_id: 'attacker-org', corp_id: 'evil-corp' })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_UNKNOWN_FIELDS')
+    expect(await readIsManager(mgrAccountId, deptId)).toBe(false)
+  })
+
+  it.each([
+    { name: 'isManager as a string', value: 'true' },
+    { name: 'isManager as a number', value: 1 },
+    { name: 'isManager as null', value: null },
+  ])('rejects $name — 400 INVALID_INPUT, no write', async ({ value }) => {
+    const res = await request(adminApp)
+      .patch(`/api/admin/directory/local/memberships/${membershipId}`)
+      .send({ isManager: value })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+    expect(await readIsManager(mgrAccountId, deptId)).toBe(false)
+  })
+
+  it('rejects a COMBINED {isPrimary, isManager} body — 400, and proves NO partial write (m3 target)', async () => {
+    const before = (
+      await query<{ is_primary: boolean; is_manager: boolean }>(
+        `SELECT is_primary, is_manager FROM directory_account_departments WHERE directory_account_id = $1 AND directory_department_id = $2`,
+        [mgrAccountId, deptId],
+      )
+    ).rows[0]
+
+    const res = await request(adminApp)
+      .patch(`/api/admin/directory/local/memberships/${membershipId}`)
+      .send({ isPrimary: true, isManager: true })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+
+    const after = (
+      await query<{ is_primary: boolean; is_manager: boolean }>(
+        `SELECT is_primary, is_manager FROM directory_account_departments WHERE directory_account_id = $1 AND directory_department_id = $2`,
+        [mgrAccountId, deptId],
+      )
+    ).rows[0]
+    expect(after).toEqual(before) // neither column moved — the combined request applied nothing
+  })
+
+  it('rejects an EMPTY body {} — 400 INVALID_INPUT', async () => {
+    const res = await request(adminApp).patch(`/api/admin/directory/local/memberships/${membershipId}`).send({})
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+  })
+
+  it('returns 404 for a LOCAL-account × DINGTALK-department membership (writer no-op), is_manager untouched', async () => {
+    const res = await request(adminApp)
+      .patch(`/api/admin/directory/local/memberships/${localAcctForMalformed}:${dtDeptId}`)
+      .send({ isManager: true })
+    expect(res.status).toBe(404)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_NOT_FOUND')
+    expect(await readIsManager(localAcctForMalformed, dtDeptId)).toBe(false)
+  })
+
+  it('returns 404 for an ABSENT membership (random ids)', async () => {
+    const res = await request(adminApp)
+      .patch(`/api/admin/directory/local/memberships/00000000-0000-0000-0000-000000000000:00000000-0000-0000-0000-000000000001`)
+      .send({ isManager: true })
+    expect(res.status).toBe(404)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_NOT_FOUND')
+  })
+
+  // Owner round-3 P2-1: the writer lacked `i.status = 'active'` — an INACTIVE local integration
+  // still matched the UPDATE. This flips the SHARED `localInt` row (the only integration the
+  // route can ever reach, since `resolveLocalDirectoryOrgId` is hardcoded to 'default') under a
+  // try/finally so it is guaranteed back to 'active' for every test after this one, regardless of
+  // assertion outcome. A dedicated fresh account+dept keeps the blast radius off `deptId` /
+  // `mgrAccountId`. Mutation m-status: dropping `i.status = 'active'` from the writer's UPDATE
+  // must redden this test (the `updated: false` / 404 assertions below would flip to true/200).
+  it('writer + route refuse an INACTIVE local integration — updated:false / 404 / no audit; reactivating restores the write (m-status target)', async () => {
+    const dept = await seedDept(localInt, 'local', rid('inact-dept'), 'RouteInactDept')
+    extraDeptIds.push(dept)
+    const acct = await seedAccount(localInt, 'local', rid('inact-ext'), rid('inact-key'), 'RouteInactAcct', {})
+    accountIds.push(acct)
+    await membership(acct, dept, false)
+    const mid = `${acct}:${dept}`
+
+    await query(`UPDATE directory_integrations SET status = 'inactive' WHERE id = $1`, [localInt])
+    try {
+      // (a) writer directly: updated:false, is_manager unchanged.
+      expect(await setLocalMembershipManager('default', { directoryAccountId: acct, directoryDepartmentId: dept }, true)).toEqual({
+        updated: false,
+      })
+      expect(await readIsManager(acct, dept)).toBe(false)
+
+      // (b) the route: 404, no audit row.
+      const res = await request(adminApp).patch(`/api/admin/directory/local/memberships/${mid}`).send({ isManager: true })
+      expect(res.status).toBe(404)
+      expect(res.body.error.code).toBe('DIRECTORY_LOCAL_NOT_FOUND')
+      const audit = await query(
+        `SELECT 1 FROM audit_logs WHERE action = 'directory.local_membership.set_manager' AND resource_id = $1`,
+        [mid],
+      )
+      expect(audit.rows.length).toBe(0)
+      expect(await readIsManager(acct, dept)).toBe(false)
+    } finally {
+      await query(`UPDATE directory_integrations SET status = 'active' WHERE id = $1`, [localInt])
+    }
+
+    // (c) positive control: same account/dept, integration reactivated → the writer now applies.
+    expect(await setLocalMembershipManager('default', { directoryAccountId: acct, directoryDepartmentId: dept }, true)).toEqual({
+      updated: true,
+    })
+    expect(await readIsManager(acct, dept)).toBe(true)
+  })
+
+  // Owner round-3 P2-2 (predicate 1 of 2): the writer checked `i.provider = 'local'` but never
+  // the CHILD rows — a membership whose `directory_accounts.provider` is mislabeled 'dingtalk'
+  // under an otherwise-local integration still matched. Flips ONLY the account's provider (never
+  // the department's), isolating this test to the `a.provider = 'local'` predicate. Mutation
+  // m-aprov: dropping that predicate must redden this test without affecting the department-
+  // provider test below.
+  it('writer + route refuse an ACCOUNT row mislabeled provider — updated:false / 404 / no audit; restoring re-enables the write (m-aprov target)', async () => {
+    const dept = await seedDept(localInt, 'local', rid('aprov-dept'), 'RouteAprovDept')
+    extraDeptIds.push(dept)
+    const acct = await seedAccount(localInt, 'local', rid('aprov-ext'), rid('aprov-key'), 'RouteAprovAcct', {})
+    accountIds.push(acct)
+    await membership(acct, dept, false)
+    const mid = `${acct}:${dept}`
+
+    await query(`UPDATE directory_accounts SET provider = 'dingtalk' WHERE id = $1`, [acct])
+    try {
+      expect(await setLocalMembershipManager('default', { directoryAccountId: acct, directoryDepartmentId: dept }, true)).toEqual({
+        updated: false,
+      })
+      expect(await readIsManager(acct, dept)).toBe(false)
+
+      const res = await request(adminApp).patch(`/api/admin/directory/local/memberships/${mid}`).send({ isManager: true })
+      expect(res.status).toBe(404)
+      expect(res.body.error.code).toBe('DIRECTORY_LOCAL_NOT_FOUND')
+      const audit = await query(
+        `SELECT 1 FROM audit_logs WHERE action = 'directory.local_membership.set_manager' AND resource_id = $1`,
+        [mid],
+      )
+      expect(audit.rows.length).toBe(0)
+      expect(await readIsManager(acct, dept)).toBe(false)
+    } finally {
+      await query(`UPDATE directory_accounts SET provider = 'local' WHERE id = $1`, [acct])
+    }
+
+    // Positive control: same account/dept, provider restored to 'local' → the writer now applies.
+    expect(await setLocalMembershipManager('default', { directoryAccountId: acct, directoryDepartmentId: dept }, true)).toEqual({
+      updated: true,
+    })
+    expect(await readIsManager(acct, dept)).toBe(true)
+  })
+
+  // Owner round-3 P2-2 (predicate 2 of 2): same gap on the DEPARTMENT side — a
+  // `directory_departments.provider` mislabeled 'dingtalk' under an otherwise-local integration
+  // still matched. Flips ONLY the department's provider (never the account's), isolating this
+  // test to the `d.provider = 'local'` predicate. Mutation m-dprov: dropping that predicate must
+  // redden THIS test while the account-provider test above stays green — proving the two
+  // predicates (and their tests) are independently load-bearing.
+  it('writer + route refuse a DEPARTMENT row mislabeled provider — updated:false / 404 / no audit; restoring re-enables the write (m-dprov target)', async () => {
+    const dept = await seedDept(localInt, 'local', rid('dprov-dept'), 'RouteDprovDept')
+    extraDeptIds.push(dept)
+    const acct = await seedAccount(localInt, 'local', rid('dprov-ext'), rid('dprov-key'), 'RouteDprovAcct', {})
+    accountIds.push(acct)
+    await membership(acct, dept, false)
+    const mid = `${acct}:${dept}`
+
+    await query(`UPDATE directory_departments SET provider = 'dingtalk' WHERE id = $1`, [dept])
+    try {
+      expect(await setLocalMembershipManager('default', { directoryAccountId: acct, directoryDepartmentId: dept }, true)).toEqual({
+        updated: false,
+      })
+      expect(await readIsManager(acct, dept)).toBe(false)
+
+      const res = await request(adminApp).patch(`/api/admin/directory/local/memberships/${mid}`).send({ isManager: true })
+      expect(res.status).toBe(404)
+      expect(res.body.error.code).toBe('DIRECTORY_LOCAL_NOT_FOUND')
+      const audit = await query(
+        `SELECT 1 FROM audit_logs WHERE action = 'directory.local_membership.set_manager' AND resource_id = $1`,
+        [mid],
+      )
+      expect(audit.rows.length).toBe(0)
+      expect(await readIsManager(acct, dept)).toBe(false)
+    } finally {
+      await query(`UPDATE directory_departments SET provider = 'local' WHERE id = $1`, [dept])
+    }
+
+    // Positive control: same account/dept, provider restored to 'local' → the writer now applies.
+    expect(await setLocalMembershipManager('default', { directoryAccountId: acct, directoryDepartmentId: dept }, true)).toEqual({
+      updated: true,
+    })
+    expect(await readIsManager(acct, dept)).toBe(true)
+  })
+})

--- a/packages/core-backend/tests/integration/local-directory-org-crud-route.db.test.ts
+++ b/packages/core-backend/tests/integration/local-directory-org-crud-route.db.test.ts
@@ -14,6 +14,8 @@ import {
   UPDATE_LOCAL_ACCOUNT_FIELDS,
   UPDATE_LOCAL_DEPARTMENT_FIELD_TYPES,
   UPDATE_LOCAL_DEPARTMENT_FIELDS,
+  UPDATE_LOCAL_MEMBERSHIP_FIELD_TYPES,
+  UPDATE_LOCAL_MEMBERSHIP_FIELDS,
 } from '../../src/directory/local-directory-org-request-schema'
 import { adminDirectoryLocalRouter } from '../../src/routes/admin-directory-local'
 
@@ -633,8 +635,10 @@ describeIfDatabase('Canonical Org MVP — B2 local departments/accounts/membersh
 // *_FIELD_TYPES specs are hand-maintained in parallel. A field added to an allowlist WITHOUT a
 // matching type spec would pass the type gate unchecked — the exact coercion bug class this PR
 // closes. Set-equality per endpoint makes that drift impossible to land silently.
-// SWITCH_LOCAL_MEMBERSHIP_PRIMARY_FIELDS deliberately has no *_FIELD_TYPES pair: its single
-// field `isPrimary` is validated by the route's literal `!== true` check, stricter than any kind.
+// UPDATE_LOCAL_MEMBERSHIP (B3 #4215 §5.4) now DOES carry a *_FIELD_TYPES pair: `isManager` accepts
+// both true/false and so needs a real boolean type gate, and `isPrimary` gets a boolean spec too so
+// the pair stays set-equal here (its stricter literal `!== true` check still runs in the route on
+// top of the type gate).
 // ---------------------------------------------------------------------------------------------
 
 describe('allowlist ↔ type-spec parity (drift guard)', () => {
@@ -644,6 +648,7 @@ describe('allowlist ↔ type-spec parity (drift guard)', () => {
     ['CREATE_LOCAL_ACCOUNT', CREATE_LOCAL_ACCOUNT_FIELDS, CREATE_LOCAL_ACCOUNT_FIELD_TYPES],
     ['UPDATE_LOCAL_ACCOUNT', UPDATE_LOCAL_ACCOUNT_FIELDS, UPDATE_LOCAL_ACCOUNT_FIELD_TYPES],
     ['ADD_LOCAL_MEMBERSHIP', ADD_LOCAL_MEMBERSHIP_FIELDS, ADD_LOCAL_MEMBERSHIP_FIELD_TYPES],
+    ['UPDATE_LOCAL_MEMBERSHIP', UPDATE_LOCAL_MEMBERSHIP_FIELDS, UPDATE_LOCAL_MEMBERSHIP_FIELD_TYPES],
   ]
 
   for (const [label, fields, specs] of PAIRS) {

--- a/packages/core-backend/tests/unit/approval-directory-org.test.ts
+++ b/packages/core-backend/tests/unit/approval-directory-org.test.ts
@@ -20,7 +20,10 @@ interface FakeDb {
     primary_department_raw: unknown
     primary_department_name?: string | null
   } | null
-  // candidate accounts in the requester's primary department (for manager scan)
+  // B3 normalized relation: memberships of the requester's primary dept flagged is_manager=true
+  // (requester-inclusive existence gate; the resolver excludes the requester on the pick).
+  normalizedDeptManagers?: Array<{ account_id: string; external_user_id: string }>
+  // candidate accounts in the requester's primary department (for the legacy leader_in_dept scan)
   deptCandidates?: Array<{ account_id: string; raw: unknown; external_user_id?: string }>
   // directory_account_id -> linked local user id
   localByAccountId?: Record<string, string | null>
@@ -32,6 +35,13 @@ function makeQuery(db: FakeDb) {
   return async <Row>(text: string, params?: unknown[]): Promise<{ rows: Row[] }> => {
     if (text.includes('FROM directory_account_links l') && text.includes('LEFT JOIN directory_account_departments')) {
       return { rows: (db.requester ? [db.requester] : []) as Row[] }
+    }
+    // B3 normalized-manager gate query (`ad.is_manager = true`). Default-empty means the dept has
+    // no normalized manager, so the resolver falls through to the legacy leader_in_dept scan below
+    // (this is why every pre-B3 fixture keeps its expectations unchanged). Requester-inclusive
+    // existence, requester-exclusive pick — the fake mirrors production self-exclusion via $3.
+    if (text.includes('ad.is_manager = true')) {
+      return { rows: (db.normalizedDeptManagers ?? []) as Row[] }
     }
     if (text.includes('JOIN directory_account_departments ad') && text.includes('d.external_department_id = $2')) {
       // Mirror the production self-exclusion `AND a.external_user_id <> $3` so a
@@ -76,6 +86,63 @@ describe('resolveApprovalRequesterOrgRelations', () => {
     }
     const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
     expect(result).toEqual({ managerId: 'local-mgr', deptHeadId: 'local-head' })
+  })
+
+  it('B3 precedence: the normalized is_manager relation wins over a legacy leader_in_dept leader in the same dept', async () => {
+    const db: FakeDb = {
+      requester: {
+        integration_id: 'int-1',
+        account_id: 'acc-req',
+        external_user_id: 'ext-req',
+        raw: {},
+        primary_external_department_id: 'D1',
+        primary_department_raw: {},
+      },
+      // Normalized relation present for D1 → authoritative; the legacy scan must be ignored.
+      normalizedDeptManagers: [{ account_id: 'acc-norm', external_user_id: 'ext-norm' }],
+      deptCandidates: [{ account_id: 'acc-legacy', raw: { leader_in_dept: [{ dept_id: 'D1', leader: true }] } }],
+      localByAccountId: { 'acc-norm': 'local-norm', 'acc-legacy': 'local-legacy' },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
+    expect(result).toEqual({ managerId: 'local-norm' }) // not 'local-legacy'
+  })
+
+  it('B3 authoritative-when-present: a normalized-managed dept whose flagged manager is unlinked omits managerId and does NOT fall back to legacy', async () => {
+    const db: FakeDb = {
+      requester: {
+        integration_id: 'int-1',
+        account_id: 'acc-req',
+        external_user_id: 'ext-req',
+        raw: {},
+        primary_external_department_id: 'D1',
+        primary_department_raw: {},
+      },
+      normalizedDeptManagers: [{ account_id: 'acc-norm', external_user_id: 'ext-norm' }],
+      localByAccountId: { 'acc-norm': null }, // the normalized manager is not linked to a local user
+      // A legacy leader that WOULD resolve — proving the resolver does not blend back into raw.
+      deptCandidates: [{ account_id: 'acc-legacy', raw: { leader_in_dept: [{ dept_id: 'D1', leader: true }] } }],
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
+    expect(result).toEqual({}) // managerId omitted; legacy 'acc-legacy' intentionally NOT used
+  })
+
+  it('B3 requester-exclusive pick: a normalized dept whose ONLY is_manager row is the requester omits managerId', async () => {
+    const db: FakeDb = {
+      requester: {
+        integration_id: 'int-1',
+        account_id: 'acc-req',
+        external_user_id: 'ext-req',
+        raw: {},
+        primary_external_department_id: 'D1',
+        primary_department_raw: {},
+      },
+      // Gate fires (a normalized row exists) but it is the requester's own → no other manager.
+      normalizedDeptManagers: [{ account_id: 'acc-req', external_user_id: 'ext-req' }],
+      deptCandidates: [{ account_id: 'acc-legacy', raw: { leader_in_dept: [{ dept_id: 'D1', leader: true }] } }],
+      localByAccountId: { 'acc-req': 'local-req', 'acc-legacy': 'local-legacy' },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
+    expect(result).toEqual({}) // self excluded on pick; still no fallback to legacy
   })
 
   it('RA-1a: resolves the primary department NAME into primaryDepartmentName (server-resolved source)', async () => {

--- a/packages/core-backend/tests/unit/approval-manager-chain.test.ts
+++ b/packages/core-backend/tests/unit/approval-manager-chain.test.ts
@@ -47,6 +47,13 @@ function makeOrgQuery(org: OrgModel) {
         }] as Row[],
       }
     }
+    // 1b) B3 normalized-manager gate (`ad.is_manager = true`) — empty here so the DIRECT-manager
+    //     resolution falls through to the legacy leader_in_dept scan (branch 3). The chain walk
+    //     (step 4 / branch 2) is on the legacy source and unaffected by B3; the normalized
+    //     direct-manager path is covered by approval-directory-org.test.ts.
+    if (text.includes('ad.is_manager = true')) {
+      return { rows: [] }
+    }
     // 2) chain hop query (find dept leader + their primary dept) — recognized by
     //    `primary_dept_external_id`; MUST precede the legacy scan below.
     if (text.includes('primary_dept_external_id') && text.includes('d.external_department_id = $2')) {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -105,6 +105,13 @@ export default defineConfig({
       // gated; excluded here so the no-DB job cannot skip-green it, and wired as a WHOLE FILE into
       // the directory real-DB step in plugin-tests.yml.
       'tests/integration/local-directory-org-crud-route.db.test.ts',
+      // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
+      // resolution against real Postgres — normalized `is_manager` relation for a local integration,
+      // the DingTalk `leader_in_dept` regression pin (load-bearing compat leg + is_manager=0 positive
+      // control), precedence, the writer's default/no-raw and local-only boundary. DATABASE_URL-gated;
+      // excluded here so the no-DB job cannot skip-green it, and wired as a WHOLE FILE into the
+      // approval real-DB step in plugin-tests.yml. Two-point wiring — both points, deliberately.
+      'tests/integration/directory-normalized-manager.db.test.ts',
       // Layer-2 hidden person/button masking (real DB): proves the cross-cutting visibility-key fix actually
       // masks the VALUE end-to-end, with non-vacuous controls. DATABASE_URL-gated; excluded here so the no-DB
       // job cannot skip-green it, and wired as a WHOLE FILE into the multitable real-DB step in


### PR DESCRIPTION
## What (Canonical Org MVP · B3 — owner round-3 complete at this head)

- Migration `zzzz20260715100000`: `is_manager boolean NOT NULL DEFAULT false` on `directory_account_departments` (no backfill: DEFAULT false is the correct value for every existing row — the flag only ever becomes true through the writer below).
- **Dual-source resolver with precedence**: `ApprovalDirectoryOrg`'s direct-manager step resolves from the normalized relation iff the requester's primary department has ANY `is_manager=true` membership within the same integration (`a.integration_id = $1 AND d.integration_id = $1`); otherwise the legacy `raw.leader_in_dept` parse runs byte-for-byte unchanged (DingTalk regression pin load-bearing).
- **Manager write path (production-reachable, audited)**: `PATCH /api/admin/directory/local/memberships/:membershipId` accepts exactly one of `{isPrimary: true}` / `{isManager: true|false}` per request (both/neither → 400 before any write); platform-admin guard, server-side org resolution, fail-closed allowlist + `boolean` type kind; success emits `directory.local_membership.set_manager` (post-commit best-effort `auditLog`, values-free ids+boolean payload).
- **Writer guard — the UPDATE, verbatim from `directory-sync.ts` (signature `setLocalMembershipManager(orgId, {directoryAccountId, directoryDepartmentId}, isManager)`):**

```sql
UPDATE directory_account_departments AS ad
    SET is_manager = $4
   FROM directory_accounts a, directory_integrations i, directory_departments d
  WHERE ad.directory_account_id = $1::uuid
    AND ad.directory_department_id = $2::uuid
    AND a.id = ad.directory_account_id
    AND d.id = ad.directory_department_id
    AND i.id = a.integration_id
    AND d.integration_id = a.integration_id
    AND i.provider = 'local'
    AND i.status = 'active'
    AND a.provider = 'local'
    AND d.provider = 'local'
    AND i.org_id = $3
```

  Round-3 additions per owner findings: `i.status='active'` (an INACTIVE local integration can no longer flip managers — write refused, route 404, zero audit rows), `a.provider='local'` and `d.provider='local'` (child rows mislabeled under a local integration refused — each predicate has its own malformed real-DB test and its own mutation that reddens exactly that test; the prior different-integration test was re-isolated with a same-provider fixture so every mutation stays independently load-bearing).

## Verification at this head

83/83 real-DB green across B3 + B2's two files (CI-same config); fresh-DB chain ×2; tsc clean; patch-id unchanged across the rebase onto current main. All SIX writer/resolver mutations redden exactly their own guard (3 round-2 + 3 round-3). Gate MD: /tmp/m2-b3-regate3-claude-20260716.md (APPROVE, zero P1/P2).

Known non-blocking notes: resolver READ side does not filter integration status (pre-existing design property — the new status gate governs writes; flags set while active still resolve after deactivation; documented, not claimed otherwise); non-UUID membershipId reaches the `::uuid` cast → 500 (identical pre-existing behavior in B2's primary-switch branch).

Landing discipline: **unarmed** — awaiting owner verdict at the exact head; arm only after APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
