### PR TITLE
fix(ops): harden stock-prep RC acceptance PM2 sampling

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -123,8 +123,8 @@ jobs:
       - name: Global History flag manifest contract (R12-C)
         run: node --test scripts/ops/global-history-flag-manifest.test.mjs scripts/ops/multitable-global-history-flag-status.test.mjs
 
-      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (40
-      # checks = 14 contract + 26 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
+      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (49
+      # checks = 17 contract + 32 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
       # pm2/health/smoke stages are unit-tested via dot-sourced pure helpers). Run inside the REQUIRED
       # `test` gate, but only ONCE (on 20.x — no need across the 18/20 matrix), early (no pnpm install
       # needed: pwsh/tar ship on ubuntu, node is already set up) so a regression fails the required check

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -9,8 +9,17 @@
 # need a live server, so their fail-closed logic is unit-tested by DOT-SOURCING the pure helpers.
 $ErrorActionPreference = 'Stop'
 $scriptPath = Join-Path $PSScriptRoot '..' 'stock-preparation-onprem-acceptance.ps1'
+$pm2SampleHelper = Join-Path $PSScriptRoot '..' 'stock-preparation-pm2-sample.mjs'
 $pass = 0; $fail = 0
 function Check { param([string]$Name, [bool]$Ok) if ($Ok) { $script:pass++; Write-Host "  PASS  $Name" } else { $script:fail++; Write-Host "  FAIL  $Name" } }
+
+function Invoke-Pm2Projection {
+  param([string]$Json)
+  $raw = $Json | & node $pm2SampleHelper 2>$null
+  $exit = $LASTEXITCODE
+  $sample = if ($exit -eq 0 -and $raw) { $raw | ConvertFrom-Json } else { $null }
+  [pscustomobject]@{ Exit = $exit; Raw = "$raw"; Sample = $sample }
+}
 
 # A valid 40-hex commit the package claims to be built from (BUILD_PROVENANCE.json.gitCommit is enforced
 # to be a full 40-hex by package-verify.sh, and the acceptance script now requires the same).
@@ -218,6 +227,75 @@ try {
   Check "smoke: selfScanClean ABSENT -> FAIL (fail-closed)" ((-not $o.ok) -and $o.reason -eq 'self_scan_not_clean')
 
   $base = [pscustomobject]@{ state = 'online'; restartTime = 3; uptime = 1000 }
+
+  # Entity corrective-1 reproduction: PM2 includes process.env in jlist; on Windows it commonly carries
+  # both Path and PATH. PowerShell ConvertFrom-Json rejects those case-variant keys, so the Node boundary
+  # must consume the raw payload and return only a fixed coarse projection.
+  $pm2Secret = 'MAT-001-SECRET'
+  $pm2WithDuplicateCaseKeys = '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":3,"pm_uptime":1000,"env":{"Path":"first","PATH":"second","MATERIAL":"' + $pm2Secret + '"}}}]'
+  $projected = Invoke-Pm2Projection $pm2WithDuplicateCaseKeys
+  Check "pm2 projection: Path/PATH duplicate-case payload parses into the three-field sample" (
+    $projected.Exit -eq 0 -and
+    $projected.Sample.state -eq 'online' -and
+    $projected.Sample.restartTime -eq 3 -and
+    $projected.Sample.uptime -eq 1000
+  )
+  Check "pm2 projection: environment and sentinel values never cross the projection" (
+    $projected.Raw -notmatch $pm2Secret -and
+    @($projected.Sample.PSObject.Properties.Name).Count -eq 3
+  )
+
+  # Exercise the actual Get-Pm2Sample native-command pipeline, not only the helper in isolation. This
+  # catches regressions in `$LASTEXITCODE handling or accidentally moving ConvertFrom-Json before Node.
+  $fakePm2Dir = Join-Path ([System.IO.Path]::GetTempPath()) ("t9accept_pm2_" + [guid]::NewGuid().ToString('N').Substring(0, 12))
+  New-Item -ItemType Directory -Path $fakePm2Dir | Out-Null
+  $fakePm2Js = Join-Path $fakePm2Dir 'pm2-fixture.mjs'
+  Set-Content -Path $fakePm2Js -Value @'
+#!/usr/bin/env node
+if (process.argv[2] !== 'jlist') process.exit(2)
+process.stdout.write(process.env.T9_PM2_JLIST || '')
+'@ -NoNewline
+  if ($IsWindows) {
+    Set-Content -Path (Join-Path $fakePm2Dir 'pm2.cmd') -Value @'
+@echo off
+node "%~dp0pm2-fixture.mjs" %*
+'@ -NoNewline
+  } else {
+    $fakePm2 = Join-Path $fakePm2Dir 'pm2'
+    Set-Content -Path $fakePm2 -Value @'
+#!/bin/sh
+exec node "$(dirname "$0")/pm2-fixture.mjs" "$@"
+'@ -NoNewline
+    & chmod +x $fakePm2
+  }
+  $oldPath = $env:PATH
+  try {
+    $env:PATH = "$fakePm2Dir$([IO.Path]::PathSeparator)$oldPath"
+    $env:T9_PM2_JLIST = $pm2WithDuplicateCaseKeys
+    $actualSample = Get-Pm2Sample
+    Check "pm2 projection: Get-Pm2Sample survives duplicate-case keys through the native pipeline" (
+      $actualSample.state -eq 'online' -and $actualSample.restartTime -eq 3 -and $actualSample.uptime -eq 1000
+    )
+  } finally {
+    $env:PATH = $oldPath
+    Remove-Item Env:T9_PM2_JLIST -ErrorAction SilentlyContinue
+  }
+
+  $unknownState = Invoke-Pm2Projection '[{"name":"metasheet-backend","pm2_env":{"status":"MAT-001-SECRET","restart_time":0,"pm_uptime":1}}]'
+  Check "pm2 projection: unknown free-form state is clamped to a coarse token" (
+    $unknownState.Exit -eq 0 -and $unknownState.Sample.state -eq 'unknown' -and $unknownState.Raw -notmatch 'MAT-001-SECRET'
+  )
+
+  $duplicateTarget = Invoke-Pm2Projection '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":0,"pm_uptime":1}},{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":0,"pm_uptime":1}}]'
+  Check "pm2 projection: duplicate target processes fail closed with no output" (
+    $duplicateTarget.Exit -ne 0 -and -not $duplicateTarget.Raw
+  )
+
+  $invalidCounters = Invoke-Pm2Projection '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":"3","pm_uptime":1000}}]'
+  Check "pm2 projection: malformed counters fail closed with no output" (
+    $invalidCounters.Exit -ne 0 -and -not $invalidCounters.Raw
+  )
+
   Check "pm2: same restart_time + same uptime -> stable" ((Test-Pm2StableSample $base ([pscustomobject]@{ state='online'; restartTime=3; uptime=1000 })).ok)
   Check "pm2: restart_time incremented (crash-loop) -> FAIL (restart_loop)" ((Test-Pm2StableSample $base ([pscustomobject]@{ state='online'; restartTime=4; uptime=1000 })).reason -eq 'restart_loop')
   Check "pm2: pm_uptime moved forward (self-restart) -> FAIL (uptime_reset)" ((Test-Pm2StableSample $base ([pscustomobject]@{ state='online'; restartTime=3; uptime=2000 })).reason -eq 'uptime_reset')

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
@@ -8,6 +8,11 @@ $ErrorActionPreference = 'Stop'
 $script = Join-Path $PSScriptRoot '..' 'stock-preparation-onprem-acceptance.ps1'
 $src = Get-Content $script -Raw
 $launcher = Join-Path $PSScriptRoot '..' 'multitable-onprem-deploy-launcher.ps1'
+$pm2SampleHelper = Join-Path $PSScriptRoot '..' 'stock-preparation-pm2-sample.mjs'
+$opsDir = Resolve-Path (Join-Path $PSScriptRoot '..')
+$repoRoot = Resolve-Path (Join-Path $opsDir '../..')
+$packageBuild = Join-Path $opsDir 'multitable-onprem-package-build.sh'
+$onPremEnvTemplate = Join-Path $repoRoot 'docker/app.env.multitable-onprem.template'
 $fail = 0
 function Check { param([string]$Name, [bool]$Ok) if ($Ok) { Write-Host "  PASS  $Name" } else { Write-Host "  FAIL  $Name"; $script:fail++ } }
 
@@ -49,6 +54,29 @@ Check "acceptance calls the release launcher with its canonical parameter names"
   'RootDir' -in $bootstrapCallParams -and
   'PackagePath' -notin $bootstrapCallParams -and
   'DeployRoot' -notin $bootstrapCallParams
+)
+
+# The package template and acceptance runner are one operator contract. A stale default makes a healthy
+# service look down, as the corrective-1 entity run proved (configured 8900 vs runner default 8081).
+$portParam = @($acceptanceAst.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'Port' })
+$templatePortMatch = [regex]::Match((Get-Content $onPremEnvTemplate -Raw), '(?m)^PORT=([0-9]+)\s*$')
+Check "acceptance default port matches the packaged on-prem environment template" (
+  $portParam.Count -eq 1 -and
+  $templatePortMatch.Success -and
+  $portParam[0].DefaultValue.Extent.Text -eq $templatePortMatch.Groups[1].Value
+)
+
+# Windows PowerShell rejects ordinary PM2 payloads containing case-variant environment keys such as
+# Path/PATH. The raw document must cross a Node projection boundary before PowerShell deserializes it,
+# and that projection helper must be a required package asset.
+$packageBuildSrc = Get-Content $packageBuild -Raw
+Check "PM2 jlist is projected by the packaged Node helper before ConvertFrom-Json" (
+  (Test-Path -LiteralPath $pm2SampleHelper -PathType Leaf) -and
+  $src -match '&\s+node\s+\$pm2SampleHelper' -and
+  -not ($src -match 'pm2\s+jlist[^\r\n]*ConvertFrom-Json')
+)
+Check "PM2 projection helper is required by the on-prem package build" (
+  $packageBuildSrc -match '"scripts/ops/stock-preparation-pm2-sample\.mjs"'
 )
 
 # ── 1. Summary is values-free by construction: exactly the 9 whitelisted keys, nothing else. ─────

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -86,6 +86,7 @@ REQUIRED_PATHS=(
   "scripts/ops/integration-k3wise-gate-contract-check.mjs"
   "scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs"
   "scripts/ops/stock-preparation-onprem-acceptance.ps1"
+  "scripts/ops/stock-preparation-pm2-sample.mjs"
   "scripts/ops/multitable-permission-lists-postdeploy-smoke.mjs"
   "scripts/ops/fixtures/integration-k3wise"
   # Legacy SQL readonly Bridge Agent tooling. BA-M0.5 proves the approved

--- a/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
+++ b/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
@@ -370,11 +370,12 @@ test('on-prem release and workflow artifacts publish both first-hop bootstrap si
   )
 })
 
-test('on-prem verifier rejects packages missing the stock-preparation acceptance contract', () => {
+test('on-prem verifier rejects packages missing the stock-preparation acceptance runtime contract', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-stock-prep-package-'))
   const migrationPath = path.join(root, 'packages/core-backend/migrations/066_create_integration_stock_prep_audit.sql')
   const smokePath = path.join(root, 'scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs')
   const acceptancePath = path.join(root, 'scripts/ops/stock-preparation-onprem-acceptance.ps1')
+  const pm2SamplePath = path.join(root, 'scripts/ops/stock-preparation-pm2-sample.mjs')
   fs.mkdirSync(path.dirname(migrationPath), { recursive: true })
   fs.mkdirSync(path.dirname(smokePath), { recursive: true })
   fs.writeFileSync(migrationPath, 'CREATE TABLE integration_stock_prep_audit ();\n')
@@ -387,12 +388,20 @@ test('on-prem verifier rejects packages missing the stock-preparation acceptance
       '$Summary.auditActionsCovered = "8/8"',
       '$Summary.selfScanClean = "true"',
       '$Summary.externalPlmK3ErpWrite = "false"',
+      'stock-preparation-pm2-sample.mjs',
     ].join('\n'),
   )
+  fs.writeFileSync(pm2SamplePath, "const APP_NAME = 'metasheet-backend'\n")
 
   try {
     const clean = runStockPreparationVerifier(root)
     assert.equal(clean.status, 0, clean.stderr)
+
+    fs.rmSync(pm2SamplePath)
+    const missingPm2Sample = runStockPreparationVerifier(root)
+    assert.notEqual(missingPm2Sample.status, 0)
+    assert.match(missingPm2Sample.stderr, /PM2 safe projection helper/)
+    fs.writeFileSync(pm2SamplePath, "const APP_NAME = 'metasheet-backend'\n")
 
     fs.rmSync(acceptancePath)
     const missingAcceptance = runStockPreparationVerifier(root)
@@ -412,6 +421,7 @@ test('on-prem verifier rejects packages missing the stock-preparation acceptance
         '$Summary.auditActionsCovered = "8/8"',
         '$Summary.selfScanClean = "true"',
         '$Summary.externalPlmK3ErpWrite = "false"',
+        'stock-preparation-pm2-sample.mjs',
       ].join('\n'),
     )
     fs.rmSync(smokePath)

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -358,6 +358,7 @@ function verify_stock_preparation_mvp_contract() {
   local migration="${root}/packages/core-backend/migrations/066_create_integration_stock_prep_audit.sql"
   local smoke="${root}/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs"
   local acceptance="${root}/scripts/ops/stock-preparation-onprem-acceptance.ps1"
+  local pm2_sample="${root}/scripts/ops/stock-preparation-pm2-sample.mjs"
 
   search_fixed_string 'integration_stock_prep_audit' "$migration" || die "migration 066 must create the stock-preparation audit surface"
   search_fixed_string 'auditActionsCovered' "$smoke" || die "stock-preparation MVP postdeploy smoke must report audit action coverage"
@@ -368,6 +369,8 @@ function verify_stock_preparation_mvp_contract() {
   search_fixed_string 'auditActionsCovered' "$acceptance" || die "stock-preparation one-click acceptance must require complete audit action coverage"
   search_fixed_string 'selfScanClean' "$acceptance" || die "stock-preparation one-click acceptance must require its values-free self scan"
   search_fixed_string 'externalPlmK3ErpWrite' "$acceptance" || die "stock-preparation one-click acceptance must report the external-write invariant"
+  search_fixed_string 'stock-preparation-pm2-sample.mjs' "$acceptance" || die "stock-preparation one-click acceptance must use the PM2 safe projection helper"
+  search_fixed_string 'metasheet-backend' "$pm2_sample" || die "stock-preparation PM2 safe projection helper must be packaged"
 }
 
 function verify_generic_integration_workbench_contract() {
@@ -897,6 +900,7 @@ required=(
   "scripts/ops/integration-k3wise-gate-contract-check.mjs"
   "scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs"
   "scripts/ops/stock-preparation-onprem-acceptance.ps1"
+  "scripts/ops/stock-preparation-pm2-sample.mjs"
   "scripts/ops/multitable-permission-lists-postdeploy-smoke.mjs"
   "scripts/ops/bridge-agent-driver-smoke.ps1"
   "scripts/ops/fixtures/bridge-agent-driver-smoke/evidence.template.json"

--- a/scripts/ops/stock-preparation-onprem-acceptance.ps1
+++ b/scripts/ops/stock-preparation-onprem-acceptance.ps1
@@ -42,7 +42,7 @@
 .PARAMETER PackagePath        Path to the .zip or .tgz on-prem package.
 .PARAMETER Sha256SumsPath     Path to the SHA256SUMS sidecar (default: alongside the package).
 .PARAMETER DeployRoot         Existing deploy root the bootstrap installs into.
-.PARAMETER Port               Backend port for health + smoke (default 8081).
+.PARAMETER Port               Backend port for health + smoke (default 8900, matching the on-prem template).
 .PARAMETER TenantId           Optional tenant id passed to the smoke (--tenant-id) when the admin
                               token carries no tenant claim.
 .PARAMETER TargetMigration    Migration name that MUST be applied after migrate (idempotent confirm).
@@ -56,7 +56,7 @@ param(
   [Parameter(Mandatory = $true)][string]$PackagePath,
   [string]$Sha256SumsPath,
   [Parameter(Mandatory = $true)][string]$DeployRoot,
-  [int]$Port = 8081,
+  [int]$Port = 8900,
   [string]$TenantId,
   [string]$TargetMigration = '066_create_integration_stock_prep_audit',
   [string]$ExpectedGitSha,
@@ -307,12 +307,25 @@ function Invoke-MigrationStage {
 # ── Stage 4: pm2 restart + POLL stable-online (command success != stable service) ────────────────
 # Normalize one `pm2 jlist` entry to @{ state; restartTime; uptime } (values-free: no raw jlist echoed).
 function Get-Pm2Sample {
-  $entry = (& pm2 jlist 2>$null | ConvertFrom-Json | Where-Object { $_.name -eq 'metasheet-backend' } | Select-Object -First 1)
-  if (-not $entry) { return $null }
-  [pscustomobject]@{
-    state       = "$($entry.pm2_env.status)"
-    restartTime = [int]($entry.pm2_env.restart_time)
-    uptime      = [long]($entry.pm2_env.pm_uptime)
+  # Do not feed the full PM2 payload to PowerShell's ConvertFrom-Json. PM2 includes the process
+  # environment, where Windows commonly has both `Path` and `PATH`; Windows PowerShell 5.1 treats
+  # those as duplicate keys and rejects the whole document. Node parses the raw payload and emits a
+  # fixed three-field projection. Any missing helper, parse failure, duplicate target, or invalid
+  # number returns $null and the stable-online stage fails closed.
+  $pm2SampleHelper = Join-Path $PSScriptRoot 'stock-preparation-pm2-sample.mjs'
+  if (-not (Test-Path -LiteralPath $pm2SampleHelper -PathType Leaf)) { return $null }
+  $safeJson = (& pm2 jlist 2>$null | & node $pm2SampleHelper 2>$null)
+  $sampleExit = $LASTEXITCODE
+  if ($sampleExit -ne 0 -or -not $safeJson) { return $null }
+  try {
+    $entry = $safeJson | ConvertFrom-Json
+    [pscustomobject]@{
+      state       = "$($entry.state)"
+      restartTime = [int]($entry.restartTime)
+      uptime      = [long]($entry.uptime)
+    }
+  } catch {
+    return $null
   }
 }
 

--- a/scripts/ops/stock-preparation-pm2-sample.mjs
+++ b/scripts/ops/stock-preparation-pm2-sample.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+// Normalize `pm2 jlist` before PowerShell sees it. Windows PowerShell treats
+// object keys case-insensitively, so ordinary environment pairs such as
+// `Path`/`PATH` make ConvertFrom-Json reject the otherwise valid PM2 payload.
+// This helper emits only the three coarse fields needed by the acceptance
+// runner and never echoes input or parse errors.
+
+const APP_NAME = 'metasheet-backend'
+const ALLOWED_STATES = new Set([
+  'online',
+  'stopping',
+  'stopped',
+  'launching',
+  'errored',
+  'one-launch-status',
+  'waiting restart',
+])
+
+let raw = ''
+for await (const chunk of process.stdin) raw += chunk
+
+try {
+  const processes = JSON.parse(raw)
+  if (!Array.isArray(processes)) throw new Error('invalid_shape')
+
+  const matches = processes.filter((entry) => entry?.name === APP_NAME)
+  if (matches.length !== 1) throw new Error('target_count')
+
+  const pm2Env = matches[0]?.pm2_env
+  const rawState = typeof pm2Env?.status === 'string' ? pm2Env.status : ''
+  const restartTime = pm2Env?.restart_time
+  const uptime = pm2Env?.pm_uptime
+  if (!Number.isSafeInteger(restartTime) || restartTime < 0) throw new Error('restart_time')
+  if (!Number.isSafeInteger(uptime) || uptime < 0) throw new Error('uptime')
+
+  process.stdout.write(JSON.stringify({
+    state: ALLOWED_STATES.has(rawState) ? rawState : 'unknown',
+    restartTime,
+    uptime,
+  }))
+} catch {
+  process.exitCode = 1
+}


### PR DESCRIPTION
## Summary

- normalize `pm2 jlist` through a packaged Node helper before PowerShell deserialization
- emit only a closed PM2 state token plus non-negative integer restart/uptime counters
- align the acceptance runner default port with `docker/app.env.multitable-onprem.template` (`8900`)
- require and verify the projection helper in on-prem packages

## Why

The corrective-1 Windows entity run in #4101 completed install and migration, then failed inside the acceptance harness:

- PowerShell rejected ordinary PM2 JSON containing case-variant environment keys such as `Path` / `PATH`
- the runner defaulted to `8081` while the packaged on-prem environment defaults to `8900`

The post-failure read-only probe showed PM2 stable and the configured-port health endpoint green. This PR changes only the acceptance/package contract; it does not change application runtime or external-write behavior.

## Verification

- acceptance static contract: 17/17 PASS
- acceptance behavior: 32/32 PASS
- package verifier tests: 10/10 PASS
- shell syntax, workflow YAML, Node syntax, and diff checks: PASS
- mutation: restoring default `8081` makes the template-port guard RED
- mutation: restoring direct `pm2 jlist | ConvertFrom-Json` makes the static guard RED and the behavior harness reproduce `Path/PATH` duplicate-key failure

Safety boundary remains `externalPlmK3ErpWrite=false`; no `MIGRATION_EXCLUDE`, external writer, application route, or database behavior is changed.