### PR TITLE
feat(automation): P2 durable-delivery S2-a — claim engine / fence-CAS (additive, flag-gated)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -508,6 +508,7 @@ jobs:
             tests/integration/multitable-tombstone-record-capture-realdb.test.ts \
             tests/integration/multitable-tombstone-retention-realdb.test.ts \
             tests/integration/multitable-automation-outbox-schema-realdb.test.ts \
+            tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts \
             tests/integration/multitable-attachment-readgate.security.test.ts \
             tests/integration/multitable-ai-write-provenance-batch-grouping-realdb.test.ts \
             tests/integration/multitable-automation-branch-local-wait.test.ts \

--- a/packages/core-backend/src/multitable/automation-durable-dispatcher.ts
+++ b/packages/core-backend/src/multitable/automation-durable-dispatcher.ts
@@ -1,30 +1,37 @@
 /**
  * P2 durable-delivery — slice S2-a: the claim engine (fence-CAS).
  *
- * The durable dispatcher drains `meta_automation_outbox_consumer` rows by CLAIMING each reclaimable row
- * (pending, or in_progress past a stale lease), invoking its consumer adapter (S5), then resolving the row
- * — `complete` (→ done), `poison` (→ dead_letter, bounded attempts exhausted), or `release` (→ pending,
- * a transient failure that stays reclaimable). This module is those four primitives only; the poll+dispatch
- * loop and the adapter wiring are S2-b / S5.
+ * The durable dispatcher drains `meta_automation_outbox_consumer` rows by CLAIMING each reclaimable row,
+ * invoking its consumer adapter (S5), then resolving it. This module is those primitives only; the
+ * poll+dispatch loop and the adapters are S2-b / S5.
  *
- * Concurrency contract (mirrors the proven AttendanceNotificationDeliveryWorker):
- *   - CLAIM is a single atomic `FOR UPDATE SKIP LOCKED` CTE: it flips the row to `in_progress`, stamps a
- *     fresh lease, **increments `fence` (the monotonic claim token)** and **increments `attempts` AT CLAIM**
- *     (so a worker that always crashes after claiming still drives the row toward `dead_letter`). Two workers
- *     never claim the same row — SKIP LOCKED hands each a disjoint set.
- *   - Every resolve is a **fence-CAS**: `WHERE ... AND fence = <claimed fence> AND status = 'in_progress'`.
- *     A "zombie" (a live worker whose lease expired and was reclaimed by another) still holds the OLD fence,
- *     so its write matches 0 rows and is a silent no-op — the reclaimer (new fence) owns the row. This is why
- *     `fence` is a bigint carried as a `string`: never coerce it through a JS number (2^53).
- *   - Terminal/reclaim writes clear the lease in the SAME UPDATE that changes status, upholding the
- *     `lease ⟺ in_progress` biconditional CHECK at every commit boundary.
+ * Correctness contract (mirrors the proven AttendanceNotificationDeliveryWorker + FWB-0 lock #4203 Layer 1):
+ *   - CLAIM is a single atomic `FOR UPDATE SKIP LOCKED` CTE that also enforces the poison ceiling. For a
+ *     reclaimable row (pending, or in_progress past a stale lease):
+ *       · attempts < maxAttempts → flip to `in_progress`, stamp a fresh lease, bump `fence` (the monotonic
+ *         claim token) and `attempts` (AT CLAIM), and hand it out for dispatch;
+ *       · attempts ≥ maxAttempts → **poison it to `dead_letter` right here** and DON'T dispatch it.
+ *     Poisoning at claim time (driven only by the persisted `attempts`) is what makes the ceiling
+ *     **crash-safe**: a worker that always crashes AFTER claiming never runs a resolve path, yet the row
+ *     still terminates — the next reclaim finds `attempts ≥ maxAttempts` and dead-letters it. "非无限
+ *     reclaim" (#4203 §poison-terminal). SKIP LOCKED hands concurrent workers disjoint rows.
+ *   - Every resolve is a **fence-CAS** (`WHERE ... AND fence = <claimed> AND status = 'in_progress'`): a
+ *     "zombie" whose lease was reclaimed holds a stale fence, so its write matches 0 rows (silent no-op)
+ *     while the reclaimer (new fence) owns the row. `fence` is a bigint carried as a `string` (never a JS
+ *     number — 2^53).
+ *   - A retryable failure does NOT flip the row back to an immediately-reclaimable state — that would spin
+ *     retries with no backoff and burn the ceiling in a tight loop. Instead `reschedule` keeps the row
+ *     `in_progress` and pushes its lease out by a backoff, so it is re-claimed only AFTER the lease expires
+ *     (#4203 §"租约过期后被 reclaim"). Terminal/lease writes preserve the `lease ⟺ in_progress` biconditional.
+ *   - Failure detail is NEVER persisted verbatim (a raw adapter error can carry a secret-shaped URL/token).
+ *     Resolves take a typed, values-free `DeliveryFailureReason` code, and only the code reaches the DB.
  *
- * Nothing here runs while `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF — these are pure primitives with no
- * caller until the S2-b loop is wired behind the flag.
+ * Nothing here runs while `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF — pure primitives with no caller
+ * until the S2-b loop is wired behind the flag.
  */
 import type { OutboxConsumerStatus } from './automation-durable-delivery'
 
-/** Minimal query surface — a pg Pool or a checked-out client both satisfy it (keeps the engine testable). */
+/** Minimal query surface — a pg Pool wrapper or a checked-out client both satisfy it (keeps the engine testable). */
 export interface Queryable {
   query(sql: string, params?: unknown[]): Promise<{ rows: Array<Record<string, unknown>>; rowCount: number | null }>
 }
@@ -32,13 +39,41 @@ export interface Queryable {
 /** Default attempt ceiling before a consumer row is poisoned to `dead_letter`. */
 export const DEFAULT_MAX_DELIVERY_ATTEMPTS = 8
 
+/**
+ * The ONLY strings that may land in `last_error` — a closed, values-free vocabulary so a raw adapter error
+ * (which can embed a secret-shaped URL/token) is never persisted verbatim. The dispatch loop maps an
+ * adapter outcome to one of these codes; the real detail belongs in redacted structured logs, not this row.
+ */
+export type DeliveryFailureReason =
+  | 'adapter_error'
+  | 'adapter_timeout'
+  | 'permanent_rejection'
+  | 'max_attempts_exhausted'
+  | 'unknown'
+
+/** The closed set of legal reason codes — enforced at RUNTIME so even an untyped caller can't persist a raw
+ *  (possibly secret-bearing) string. Values-free by construction, not just by the TS type. */
+const ALLOWED_FAILURE_REASONS: ReadonlySet<string> = new Set<DeliveryFailureReason>([
+  'adapter_error',
+  'adapter_timeout',
+  'permanent_rejection',
+  'max_attempts_exhausted',
+  'unknown',
+])
+
+function assertReason(reason: DeliveryFailureReason): void {
+  if (!ALLOWED_FAILURE_REASONS.has(reason)) {
+    throw new RangeError('last_error must be a values-free DeliveryFailureReason code, not a raw message')
+  }
+}
+
 /** A row claimed for dispatch — carries the claim `fence` (the CAS token) and the joined outbox event. */
 export interface ClaimedConsumer {
   outboxId: string
   consumerKey: string
   /** post-increment claim token (bigint as string — never a JS number). */
   fence: string
-  /** post-increment attempt count for THIS claim (>= 1). */
+  /** post-increment attempt count for THIS claim (1..maxAttempts). */
   attempts: number
   eventType: string
   eventId: string
@@ -48,10 +83,13 @@ export interface ClaimedConsumer {
 }
 
 export interface ClaimOptions {
-  /** max rows to claim in one batch (default 50). */
+  /** max rows to claim in one batch (default 50). must be > 0. */
   batchSize?: number
-  /** lease duration in ms (default 30_000). */
+  /** lease duration in ms (default 30_000). must be > 0 — a non-positive lease would be born already
+   *  expired, making the row instantly reclaimable and spinning claims with no backoff. */
   leaseMs?: number
+  /** attempt ceiling; a row that has already been attempted this many times is poisoned at claim (default 8). must be >= 1. */
+  maxAttempts?: number
   /** restrict the claim to specific consumer_keys (default: all). */
   consumerKeys?: string[]
   /** injectable clock for tests. */
@@ -60,15 +98,26 @@ export interface ClaimOptions {
 
 const nowIso = (opts: { now?: () => Date }): string => (opts.now?.() ?? new Date()).toISOString()
 
+function requirePositive(name: string, value: number, min = 1): void {
+  if (!Number.isFinite(value) || value < min) {
+    throw new RangeError(`${name} must be a finite number >= ${min} (got ${value})`)
+  }
+}
+
 /**
- * Atomically claim reclaimable consumer rows: `pending`, or `in_progress` whose lease has expired. Flips each
- * to `in_progress` with a fresh lease, bumps `fence` and `attempts`, and returns the claim token + the joined
- * outbox event. `FOR UPDATE SKIP LOCKED` guarantees disjoint claims across concurrent workers.
+ * Atomically claim reclaimable consumer rows and poison any that have hit the attempt ceiling. Returns the
+ * rows actually handed out for dispatch (in_progress) with their claim token + joined outbox event; poisoned
+ * rows are terminated in the same statement and NOT returned. `FOR UPDATE SKIP LOCKED` gives concurrent
+ * workers disjoint rows.
  */
 export async function claimDueConsumers(db: Queryable, opts: ClaimOptions = {}): Promise<ClaimedConsumer[]> {
   const asOf = nowIso(opts)
   const batchSize = opts.batchSize ?? 50
   const leaseMs = opts.leaseMs ?? 30_000
+  const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_DELIVERY_ATTEMPTS
+  requirePositive('batchSize', batchSize)
+  requirePositive('leaseMs', leaseMs)
+  requirePositive('maxAttempts', maxAttempts)
   const keys = opts.consumerKeys ?? null
   const { rows } = await db.query(
     `WITH claim AS (
@@ -83,36 +132,40 @@ export async function claimDueConsumers(db: Queryable, opts: ClaimOptions = {}):
         LIMIT $2::int
         FOR UPDATE SKIP LOCKED
      ),
-     claimed AS (
+     resolved AS (
        UPDATE meta_automation_outbox_consumer c
-          SET status = 'in_progress',
-              lease_expires_at = $1::timestamptz + ($3::int * interval '1 millisecond'),
-              fence = c.fence + 1,
-              attempts = c.attempts + 1,
+          -- attempts >= ceiling → poison to dead_letter (crash-safe, no worker needed); else claim.
+          SET status = CASE WHEN c.attempts >= $5::int THEN 'dead_letter' ELSE 'in_progress' END,
+              lease_expires_at = CASE WHEN c.attempts >= $5::int THEN NULL
+                                      ELSE $1::timestamptz + ($3::int * interval '1 millisecond') END,
+              fence = CASE WHEN c.attempts >= $5::int THEN c.fence ELSE c.fence + 1 END,
+              attempts = CASE WHEN c.attempts >= $5::int THEN c.attempts ELSE c.attempts + 1 END,
+              last_error = CASE WHEN c.attempts >= $5::int THEN 'max_attempts_exhausted' ELSE c.last_error END,
               updated_at = $1::timestamptz
          FROM claim
         WHERE c.outbox_id = claim.outbox_id AND c.consumer_key = claim.consumer_key
-       RETURNING c.outbox_id, c.consumer_key, c.fence::text AS fence, c.attempts
+       RETURNING c.outbox_id, c.consumer_key, c.fence::text AS fence, c.attempts, c.status
      )
-     SELECT cl.outbox_id       AS outbox_id,
-            cl.consumer_key    AS consumer_key,
-            cl.fence           AS fence,
-            cl.attempts        AS attempts,
-            o.event_type       AS event_type,
-            o.event_id         AS event_id,
-            o.payload          AS payload,
+     SELECT r.outbox_id       AS outbox_id,
+            r.consumer_key    AS consumer_key,
+            r.fence           AS fence,
+            r.attempts        AS attempts,
+            o.event_type      AS event_type,
+            o.event_id        AS event_id,
+            o.payload         AS payload,
             o.automation_depth AS automation_depth,
             o.manifest_version AS manifest_version
-       FROM claimed cl
-       JOIN meta_automation_outbox o ON o.id = cl.outbox_id
+       FROM resolved r
+       JOIN meta_automation_outbox o ON o.id = r.outbox_id
+      WHERE r.status = 'in_progress'   -- poisoned rows are terminated, not dispatched
       ORDER BY o.created_at ASC`,
-    [asOf, batchSize, leaseMs, keys],
+    [asOf, batchSize, leaseMs, keys, maxAttempts],
   )
   return rows.map((r) => ({
     outboxId: String(r.outbox_id),
     consumerKey: String(r.consumer_key),
-    fence: String(r.fence), // bigint text — keep as string
-    attempts: Number(r.attempts), // int — safe as number
+    fence: String(r.fence),
+    attempts: Number(r.attempts),
     eventType: String(r.event_type),
     eventId: String(r.event_id),
     payload: r.payload,
@@ -121,85 +174,94 @@ export async function claimDueConsumers(db: Queryable, opts: ClaimOptions = {}):
   }))
 }
 
-/** fence-CAS UPDATE shared by every resolve: writes only if the caller still holds the claim (fence match). */
-async function casResolve(
+/**
+ * Terminal success: → `done`, lease cleared. Returns false if the caller lost the lease (a zombie whose
+ * fence was superseded by a reclaimer) — its write matched 0 rows and did nothing.
+ */
+export async function completeConsumer(
   db: Queryable,
   outboxId: string,
   consumerKey: string,
   fence: string,
-  status: Extract<OutboxConsumerStatus, 'done' | 'dead_letter' | 'pending'>,
-  lastError: string | null,
-  asOf: string,
+  opts: { now?: () => Date } = {},
 ): Promise<boolean> {
   const res = await db.query(
     `UPDATE meta_automation_outbox_consumer
-        SET status = $4,
-            lease_expires_at = NULL,
-            last_error = $5,
-            updated_at = $6::timestamptz
-      WHERE outbox_id = $1
-        AND consumer_key = $2
-        AND fence = $3::bigint
-        AND status = 'in_progress'`,
-    [outboxId, consumerKey, fence, status, lastError, asOf],
+        SET status = 'done', lease_expires_at = NULL, last_error = NULL, updated_at = $4::timestamptz
+      WHERE outbox_id = $1 AND consumer_key = $2 AND fence = $3::bigint AND status = 'in_progress'`,
+    [outboxId, consumerKey, fence, nowIso(opts)],
   )
   return Number(res.rowCount ?? 0) === 1
 }
 
 /**
- * Terminal success: → `done`, lease cleared. Returns false if the caller lost the lease (a zombie whose
- * fence was superseded by a reclaimer) — its write matched 0 rows and did nothing.
+ * Terminal poison for a DETERMINISTIC permanent failure: → `dead_letter`, lease cleared. (Attempt-exhaustion
+ * poison is handled at claim, not here.) Returns false on a lost lease. `reason` is a values-free code.
  */
-export function completeConsumer(
+export async function poisonConsumer(
   db: Queryable,
   outboxId: string,
   consumerKey: string,
   fence: string,
+  reason: DeliveryFailureReason,
   opts: { now?: () => Date } = {},
 ): Promise<boolean> {
-  return casResolve(db, outboxId, consumerKey, fence, 'done', null, nowIso(opts))
+  assertReason(reason)
+  const res = await db.query(
+    `UPDATE meta_automation_outbox_consumer
+        SET status = 'dead_letter', lease_expires_at = NULL, last_error = $4, updated_at = $5::timestamptz
+      WHERE outbox_id = $1 AND consumer_key = $2 AND fence = $3::bigint AND status = 'in_progress'`,
+    [outboxId, consumerKey, fence, reason, nowIso(opts)],
+  )
+  return Number(res.rowCount ?? 0) === 1
 }
 
 /**
- * Terminal poison: → `dead_letter`, lease cleared (attempts exhausted). Returns false on a lost lease.
+ * Non-terminal retry after a TRANSIENT failure: the row STAYS `in_progress` and its lease is pushed out by
+ * `retryDelayMs` (a backoff), so it is re-claimed only after the lease expires — never immediately. `attempts`
+ * was already bumped at claim (so the row still marches toward the ceiling); this does not touch it. Returns
+ * false on a lost lease. `reason` is a values-free code.
  */
-export function poisonConsumer(
+export async function rescheduleConsumer(
   db: Queryable,
   outboxId: string,
   consumerKey: string,
   fence: string,
-  error: string,
+  retryDelayMs: number,
+  reason: DeliveryFailureReason,
   opts: { now?: () => Date } = {},
 ): Promise<boolean> {
-  return casResolve(db, outboxId, consumerKey, fence, 'dead_letter', error.slice(0, 1000), nowIso(opts))
+  requirePositive('retryDelayMs', retryDelayMs)
+  assertReason(reason)
+  const asOf = nowIso(opts)
+  const res = await db.query(
+    `UPDATE meta_automation_outbox_consumer
+        SET lease_expires_at = $4::timestamptz + ($5::int * interval '1 millisecond'),
+            last_error = $6,
+            updated_at = $4::timestamptz
+      WHERE outbox_id = $1 AND consumer_key = $2 AND fence = $3::bigint AND status = 'in_progress'`,
+    [outboxId, consumerKey, fence, asOf, retryDelayMs, reason],
+  )
+  return Number(res.rowCount ?? 0) === 1
 }
 
 /**
- * Non-terminal release after a transient failure: → `pending`, lease cleared, so the row is immediately
- * reclaimable by the next batch. `attempts` was already bumped at claim, so this does NOT re-increment it —
- * the row still marches toward the poison ceiling. Returns false on a lost lease.
- */
-export function releaseConsumer(
-  db: Queryable,
-  outboxId: string,
-  consumerKey: string,
-  fence: string,
-  error: string,
-  opts: { now?: () => Date } = {},
-): Promise<boolean> {
-  return casResolve(db, outboxId, consumerKey, fence, 'pending', error.slice(0, 1000), nowIso(opts))
-}
-
-/**
- * Decide how a claimed row resolves after its adapter runs, given the post-claim `attempts` and the ceiling.
- * Success → complete. Failure with attempts remaining → release (retry). Failure at/over the ceiling →
- * poison. Kept pure so the S2-b loop's branching is unit-testable without a DB.
+ * Map an adapter outcome to a resolve action. Attempt-exhaustion is NOT an outcome here — it is enforced at
+ * claim (crash-safe), so a plain `retryable_failure` at the ceiling is still `reschedule` and the next claim
+ * poisons it. Kept pure so the S2-b loop's branching is unit-testable without a DB.
  */
 export function resolveDisposition(
-  outcome: 'success' | 'failure',
-  attempts: number,
-  maxAttempts: number = DEFAULT_MAX_DELIVERY_ATTEMPTS,
-): 'complete' | 'release' | 'poison' {
-  if (outcome === 'success') return 'complete'
-  return attempts >= maxAttempts ? 'poison' : 'release'
+  outcome: 'success' | 'retryable_failure' | 'permanent_failure',
+): 'complete' | 'reschedule' | 'poison' {
+  switch (outcome) {
+    case 'success':
+      return 'complete'
+    case 'retryable_failure':
+      return 'reschedule'
+    case 'permanent_failure':
+      return 'poison'
+  }
 }
+
+// Re-exported for callers that narrow on the shared status union.
+export type { OutboxConsumerStatus }

--- a/packages/core-backend/src/multitable/automation-durable-dispatcher.ts
+++ b/packages/core-backend/src/multitable/automation-durable-dispatcher.ts
@@ -6,25 +6,29 @@
  * poll+dispatch loop and the adapters are S2-b / S5.
  *
  * Correctness contract (mirrors the proven AttendanceNotificationDeliveryWorker + FWB-0 lock #4203 Layer 1):
- *   - CLAIM is a single atomic `FOR UPDATE SKIP LOCKED` CTE that also enforces the poison ceiling. For a
- *     reclaimable row (pending, or in_progress past a stale lease):
- *       · attempts < maxAttempts → flip to `in_progress`, stamp a fresh lease, bump `fence` (the monotonic
- *         claim token) and `attempts` (AT CLAIM), and hand it out for dispatch;
- *       · attempts ≥ maxAttempts → **poison it to `dead_letter` right here** and DON'T dispatch it.
- *     Poisoning at claim time (driven only by the persisted `attempts`) is what makes the ceiling
- *     **crash-safe**: a worker that always crashes AFTER claiming never runs a resolve path, yet the row
- *     still terminates — the next reclaim finds `attempts ≥ maxAttempts` and dead-letters it. "非无限
- *     reclaim" (#4203 §poison-terminal). SKIP LOCKED hands concurrent workers disjoint rows.
+ *   - A worker claims ONLY the consumer_keys it knows — `consumerKeys` is REQUIRED and non-empty (a
+ *     registry-managed allow-list). A key it doesn't recognize is never claimed, so it stays `pending`
+ *     for a worker that does know it. This is the rolling-deploy contract (#4203 §246): an N-1 worker must
+ *     NEVER mark an unknown-key row `done`/`dead_letter` (that silently drops an event a newer worker owns),
+ *     and this "unknown → pending + alert" behavior MUST exist in the FIRST dispatcher version — a current
+ *     worker won't hit unknown keys itself, but at the next version bump it becomes N-1. `findUnknownConsumerKeys`
+ *     is the alert seam.
+ *   - CLAIM is a single atomic `FOR UPDATE SKIP LOCKED` CTE that also enforces the poison ceiling: a
+ *     reclaimable row (pending, or in_progress past a stale lease) with `attempts >= maxAttempts` is
+ *     poisoned to `dead_letter` right there — driven only by the persisted `attempts`, so the ceiling is
+ *     **crash-safe** (a worker that always crashes after claiming never resolves, yet the row still
+ *     terminates). Otherwise it flips to `in_progress`, stamps a lease, bumps `fence` (the claim token) and
+ *     `attempts` (AT CLAIM). SKIP LOCKED hands concurrent workers disjoint rows.
  *   - Every resolve is a **fence-CAS** (`WHERE ... AND fence = <claimed> AND status = 'in_progress'`): a
- *     "zombie" whose lease was reclaimed holds a stale fence, so its write matches 0 rows (silent no-op)
- *     while the reclaimer (new fence) owns the row. `fence` is a bigint carried as a `string` (never a JS
+ *     zombie holding a superseded fence writes 0 rows. **`reschedule` and `poison`/`complete` all consume
+ *     the token** — reschedule ATOMICALLY BUMPS the fence, so a late worker holding the original token can
+ *     no longer complete/poison/reschedule the row. `fence` is a bigint carried as a `string` (never a JS
  *     number — 2^53).
- *   - A retryable failure does NOT flip the row back to an immediately-reclaimable state — that would spin
- *     retries with no backoff and burn the ceiling in a tight loop. Instead `reschedule` keeps the row
- *     `in_progress` and pushes its lease out by a backoff, so it is re-claimed only AFTER the lease expires
- *     (#4203 §"租约过期后被 reclaim"). Terminal/lease writes preserve the `lease ⟺ in_progress` biconditional.
- *   - Failure detail is NEVER persisted verbatim (a raw adapter error can carry a secret-shaped URL/token).
- *     Resolves take a typed, values-free `DeliveryFailureReason` code, and only the code reaches the DB.
+ *   - A retryable failure keeps the row `in_progress` with the lease pushed out by a backoff (re-claimed
+ *     only after expiry), never an immediately-reclaimable state (#4203 §"租约过期后被 reclaim").
+ *   - Failure detail is never persisted verbatim: resolves take a typed, values-free `DeliveryFailureReason`.
+ *   - Every numeric bound is a validated SAFE INTEGER within an explicit range (no fractional/huge value
+ *     reaches Postgres as a runtime cast error).
  *
  * Nothing here runs while `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF — pure primitives with no caller
  * until the S2-b loop is wired behind the flag.
@@ -39,10 +43,15 @@ export interface Queryable {
 /** Default attempt ceiling before a consumer row is poisoned to `dead_letter`. */
 export const DEFAULT_MAX_DELIVERY_ATTEMPTS = 8
 
+// Explicit upper bounds so a caller bug can't push an out-of-range value into an int/interval cast.
+const MAX_BATCH_SIZE = 10_000
+const MAX_LEASE_MS = 86_400_000 // 24h
+const MAX_DELAY_MS = 86_400_000 // 24h
+const MAX_ATTEMPTS_CEILING = 10_000
+
 /**
  * The ONLY strings that may land in `last_error` — a closed, values-free vocabulary so a raw adapter error
- * (which can embed a secret-shaped URL/token) is never persisted verbatim. The dispatch loop maps an
- * adapter outcome to one of these codes; the real detail belongs in redacted structured logs, not this row.
+ * (which can embed a secret-shaped URL/token) is never persisted verbatim.
  */
 export type DeliveryFailureReason =
   | 'adapter_error'
@@ -51,8 +60,6 @@ export type DeliveryFailureReason =
   | 'max_attempts_exhausted'
   | 'unknown'
 
-/** The closed set of legal reason codes — enforced at RUNTIME so even an untyped caller can't persist a raw
- *  (possibly secret-bearing) string. Values-free by construction, not just by the TS type. */
 const ALLOWED_FAILURE_REASONS: ReadonlySet<string> = new Set<DeliveryFailureReason>([
   'adapter_error',
   'adapter_timeout',
@@ -65,6 +72,20 @@ function assertReason(reason: DeliveryFailureReason): void {
   if (!ALLOWED_FAILURE_REASONS.has(reason)) {
     throw new RangeError('last_error must be a values-free DeliveryFailureReason code, not a raw message')
   }
+}
+
+/** Reject fractional, non-finite, out-of-safe-range, or out-of-bounds numeric params before they hit SQL. */
+function requireBoundedInt(name: string, value: number, min: number, max: number): void {
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new RangeError(`${name} must be a safe integer in [${min}, ${max}] (got ${value})`)
+  }
+}
+
+function requireKnownKeys(consumerKeys: string[] | undefined): string[] {
+  if (!Array.isArray(consumerKeys) || consumerKeys.length === 0) {
+    throw new RangeError('consumerKeys is required and must be a non-empty allow-list of keys this worker knows')
+  }
+  return consumerKeys
 }
 
 /** A row claimed for dispatch — carries the claim `fence` (the CAS token) and the joined outbox event. */
@@ -83,42 +104,34 @@ export interface ClaimedConsumer {
 }
 
 export interface ClaimOptions {
-  /** max rows to claim in one batch (default 50). must be > 0. */
+  /** REQUIRED non-empty allow-list — the consumer_keys THIS worker knows. Unknown keys are never claimed. */
+  consumerKeys: string[]
+  /** max rows to claim in one batch (default 50; 1..10000). */
   batchSize?: number
-  /** lease duration in ms (default 30_000). must be > 0 — a non-positive lease would be born already
-   *  expired, making the row instantly reclaimable and spinning claims with no backoff. */
+  /** lease duration in ms (default 30_000; 1..86_400_000). */
   leaseMs?: number
-  /** attempt ceiling; a row that has already been attempted this many times is poisoned at claim (default 8). must be >= 1. */
+  /** attempt ceiling; a row already attempted this many times is poisoned at claim (default 8; 1..10000). */
   maxAttempts?: number
-  /** restrict the claim to specific consumer_keys (default: all). */
-  consumerKeys?: string[]
   /** injectable clock for tests. */
   now?: () => Date
 }
 
 const nowIso = (opts: { now?: () => Date }): string => (opts.now?.() ?? new Date()).toISOString()
 
-function requirePositive(name: string, value: number, min = 1): void {
-  if (!Number.isFinite(value) || value < min) {
-    throw new RangeError(`${name} must be a finite number >= ${min} (got ${value})`)
-  }
-}
-
 /**
- * Atomically claim reclaimable consumer rows and poison any that have hit the attempt ceiling. Returns the
- * rows actually handed out for dispatch (in_progress) with their claim token + joined outbox event; poisoned
- * rows are terminated in the same statement and NOT returned. `FOR UPDATE SKIP LOCKED` gives concurrent
- * workers disjoint rows.
+ * Atomically claim reclaimable rows FOR THE GIVEN known keys, and poison any that have hit the attempt
+ * ceiling. Rows whose key is not in `consumerKeys` are left untouched (they stay `pending`). Returns the
+ * rows handed out for dispatch (in_progress) with their claim token + joined outbox event.
  */
-export async function claimDueConsumers(db: Queryable, opts: ClaimOptions = {}): Promise<ClaimedConsumer[]> {
+export async function claimDueConsumers(db: Queryable, opts: ClaimOptions): Promise<ClaimedConsumer[]> {
+  const keys = requireKnownKeys(opts?.consumerKeys)
   const asOf = nowIso(opts)
   const batchSize = opts.batchSize ?? 50
   const leaseMs = opts.leaseMs ?? 30_000
   const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_DELIVERY_ATTEMPTS
-  requirePositive('batchSize', batchSize)
-  requirePositive('leaseMs', leaseMs)
-  requirePositive('maxAttempts', maxAttempts)
-  const keys = opts.consumerKeys ?? null
+  requireBoundedInt('batchSize', batchSize, 1, MAX_BATCH_SIZE)
+  requireBoundedInt('leaseMs', leaseMs, 1, MAX_LEASE_MS)
+  requireBoundedInt('maxAttempts', maxAttempts, 1, MAX_ATTEMPTS_CEILING)
   const { rows } = await db.query(
     `WITH claim AS (
        SELECT c.outbox_id, c.consumer_key
@@ -127,7 +140,7 @@ export async function claimDueConsumers(db: Queryable, opts: ClaimOptions = {}):
                 c.status = 'pending'
              OR (c.status = 'in_progress' AND c.lease_expires_at <= $1::timestamptz)
               )
-          AND ($4::text[] IS NULL OR c.consumer_key = ANY($4::text[]))
+          AND c.consumer_key = ANY($4::text[])   -- worker's known keys only; unknown keys stay pending
         ORDER BY c.updated_at ASC
         LIMIT $2::int
         FOR UPDATE SKIP LOCKED
@@ -175,8 +188,32 @@ export async function claimDueConsumers(db: Queryable, opts: ClaimOptions = {}):
 }
 
 /**
- * Terminal success: → `done`, lease cleared. Returns false if the caller lost the lease (a zombie whose
- * fence was superseded by a reclaimer) — its write matched 0 rows and did nothing.
+ * Rolling-deploy alert seam: the consumer_keys of reclaimable rows that this worker does NOT know. The
+ * dispatch loop alerts on these (they are stuck until a worker that knows them runs) but must NEVER claim or
+ * terminate them (#4203 §246). Reclaimable-only — terminal rows are not "stuck".
+ */
+export async function findUnknownConsumerKeys(
+  db: Queryable,
+  knownKeys: string[],
+  opts: { now?: () => Date } = {},
+): Promise<string[]> {
+  const keys = requireKnownKeys(knownKeys)
+  const { rows } = await db.query(
+    `SELECT DISTINCT c.consumer_key
+       FROM meta_automation_outbox_consumer c
+      WHERE (
+              c.status = 'pending'
+           OR (c.status = 'in_progress' AND c.lease_expires_at <= $1::timestamptz)
+            )
+        AND NOT (c.consumer_key = ANY($2::text[]))`,
+    [nowIso(opts), keys],
+  )
+  return rows.map((r) => String(r.consumer_key))
+}
+
+/**
+ * Terminal success: → `done`, lease cleared. Returns false if the caller lost the lease (a zombie or a stale
+ * token superseded by a reclaim/reschedule) — its write matched 0 rows and did nothing.
  */
 export async function completeConsumer(
   db: Queryable,
@@ -196,7 +233,7 @@ export async function completeConsumer(
 
 /**
  * Terminal poison for a DETERMINISTIC permanent failure: → `dead_letter`, lease cleared. (Attempt-exhaustion
- * poison is handled at claim, not here.) Returns false on a lost lease. `reason` is a values-free code.
+ * poison is handled at claim, not here.) Returns false on a lost/stale token. `reason` is a values-free code.
  */
 export async function poisonConsumer(
   db: Queryable,
@@ -217,10 +254,10 @@ export async function poisonConsumer(
 }
 
 /**
- * Non-terminal retry after a TRANSIENT failure: the row STAYS `in_progress` and its lease is pushed out by
- * `retryDelayMs` (a backoff), so it is re-claimed only after the lease expires — never immediately. `attempts`
- * was already bumped at claim (so the row still marches toward the ceiling); this does not touch it. Returns
- * false on a lost lease. `reason` is a values-free code.
+ * Non-terminal retry after a TRANSIENT failure: the row STAYS `in_progress`, its lease is pushed out by
+ * `retryDelayMs` (a backoff, re-claimed only after expiry), and **the fence is ATOMICALLY BUMPED** so the
+ * token the caller just used is dead — a late worker holding it can no longer complete/poison/reschedule.
+ * `attempts` was already bumped at claim; this does not touch it. Returns false on a lost/stale token.
  */
 export async function rescheduleConsumer(
   db: Queryable,
@@ -231,12 +268,13 @@ export async function rescheduleConsumer(
   reason: DeliveryFailureReason,
   opts: { now?: () => Date } = {},
 ): Promise<boolean> {
-  requirePositive('retryDelayMs', retryDelayMs)
+  requireBoundedInt('retryDelayMs', retryDelayMs, 1, MAX_DELAY_MS)
   assertReason(reason)
   const asOf = nowIso(opts)
   const res = await db.query(
     `UPDATE meta_automation_outbox_consumer
-        SET lease_expires_at = $4::timestamptz + ($5::int * interval '1 millisecond'),
+        SET fence = fence + 1,
+            lease_expires_at = $4::timestamptz + ($5::int * interval '1 millisecond'),
             last_error = $6,
             updated_at = $4::timestamptz
       WHERE outbox_id = $1 AND consumer_key = $2 AND fence = $3::bigint AND status = 'in_progress'`,
@@ -263,5 +301,4 @@ export function resolveDisposition(
   }
 }
 
-// Re-exported for callers that narrow on the shared status union.
 export type { OutboxConsumerStatus }

--- a/packages/core-backend/src/multitable/automation-durable-dispatcher.ts
+++ b/packages/core-backend/src/multitable/automation-durable-dispatcher.ts
@@ -1,0 +1,205 @@
+/**
+ * P2 durable-delivery — slice S2-a: the claim engine (fence-CAS).
+ *
+ * The durable dispatcher drains `meta_automation_outbox_consumer` rows by CLAIMING each reclaimable row
+ * (pending, or in_progress past a stale lease), invoking its consumer adapter (S5), then resolving the row
+ * — `complete` (→ done), `poison` (→ dead_letter, bounded attempts exhausted), or `release` (→ pending,
+ * a transient failure that stays reclaimable). This module is those four primitives only; the poll+dispatch
+ * loop and the adapter wiring are S2-b / S5.
+ *
+ * Concurrency contract (mirrors the proven AttendanceNotificationDeliveryWorker):
+ *   - CLAIM is a single atomic `FOR UPDATE SKIP LOCKED` CTE: it flips the row to `in_progress`, stamps a
+ *     fresh lease, **increments `fence` (the monotonic claim token)** and **increments `attempts` AT CLAIM**
+ *     (so a worker that always crashes after claiming still drives the row toward `dead_letter`). Two workers
+ *     never claim the same row — SKIP LOCKED hands each a disjoint set.
+ *   - Every resolve is a **fence-CAS**: `WHERE ... AND fence = <claimed fence> AND status = 'in_progress'`.
+ *     A "zombie" (a live worker whose lease expired and was reclaimed by another) still holds the OLD fence,
+ *     so its write matches 0 rows and is a silent no-op — the reclaimer (new fence) owns the row. This is why
+ *     `fence` is a bigint carried as a `string`: never coerce it through a JS number (2^53).
+ *   - Terminal/reclaim writes clear the lease in the SAME UPDATE that changes status, upholding the
+ *     `lease ⟺ in_progress` biconditional CHECK at every commit boundary.
+ *
+ * Nothing here runs while `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF — these are pure primitives with no
+ * caller until the S2-b loop is wired behind the flag.
+ */
+import type { OutboxConsumerStatus } from './automation-durable-delivery'
+
+/** Minimal query surface — a pg Pool or a checked-out client both satisfy it (keeps the engine testable). */
+export interface Queryable {
+  query(sql: string, params?: unknown[]): Promise<{ rows: Array<Record<string, unknown>>; rowCount: number | null }>
+}
+
+/** Default attempt ceiling before a consumer row is poisoned to `dead_letter`. */
+export const DEFAULT_MAX_DELIVERY_ATTEMPTS = 8
+
+/** A row claimed for dispatch — carries the claim `fence` (the CAS token) and the joined outbox event. */
+export interface ClaimedConsumer {
+  outboxId: string
+  consumerKey: string
+  /** post-increment claim token (bigint as string — never a JS number). */
+  fence: string
+  /** post-increment attempt count for THIS claim (>= 1). */
+  attempts: number
+  eventType: string
+  eventId: string
+  payload: unknown
+  automationDepth: number
+  manifestVersion: number
+}
+
+export interface ClaimOptions {
+  /** max rows to claim in one batch (default 50). */
+  batchSize?: number
+  /** lease duration in ms (default 30_000). */
+  leaseMs?: number
+  /** restrict the claim to specific consumer_keys (default: all). */
+  consumerKeys?: string[]
+  /** injectable clock for tests. */
+  now?: () => Date
+}
+
+const nowIso = (opts: { now?: () => Date }): string => (opts.now?.() ?? new Date()).toISOString()
+
+/**
+ * Atomically claim reclaimable consumer rows: `pending`, or `in_progress` whose lease has expired. Flips each
+ * to `in_progress` with a fresh lease, bumps `fence` and `attempts`, and returns the claim token + the joined
+ * outbox event. `FOR UPDATE SKIP LOCKED` guarantees disjoint claims across concurrent workers.
+ */
+export async function claimDueConsumers(db: Queryable, opts: ClaimOptions = {}): Promise<ClaimedConsumer[]> {
+  const asOf = nowIso(opts)
+  const batchSize = opts.batchSize ?? 50
+  const leaseMs = opts.leaseMs ?? 30_000
+  const keys = opts.consumerKeys ?? null
+  const { rows } = await db.query(
+    `WITH claim AS (
+       SELECT c.outbox_id, c.consumer_key
+         FROM meta_automation_outbox_consumer c
+        WHERE (
+                c.status = 'pending'
+             OR (c.status = 'in_progress' AND c.lease_expires_at <= $1::timestamptz)
+              )
+          AND ($4::text[] IS NULL OR c.consumer_key = ANY($4::text[]))
+        ORDER BY c.updated_at ASC
+        LIMIT $2::int
+        FOR UPDATE SKIP LOCKED
+     ),
+     claimed AS (
+       UPDATE meta_automation_outbox_consumer c
+          SET status = 'in_progress',
+              lease_expires_at = $1::timestamptz + ($3::int * interval '1 millisecond'),
+              fence = c.fence + 1,
+              attempts = c.attempts + 1,
+              updated_at = $1::timestamptz
+         FROM claim
+        WHERE c.outbox_id = claim.outbox_id AND c.consumer_key = claim.consumer_key
+       RETURNING c.outbox_id, c.consumer_key, c.fence::text AS fence, c.attempts
+     )
+     SELECT cl.outbox_id       AS outbox_id,
+            cl.consumer_key    AS consumer_key,
+            cl.fence           AS fence,
+            cl.attempts        AS attempts,
+            o.event_type       AS event_type,
+            o.event_id         AS event_id,
+            o.payload          AS payload,
+            o.automation_depth AS automation_depth,
+            o.manifest_version AS manifest_version
+       FROM claimed cl
+       JOIN meta_automation_outbox o ON o.id = cl.outbox_id
+      ORDER BY o.created_at ASC`,
+    [asOf, batchSize, leaseMs, keys],
+  )
+  return rows.map((r) => ({
+    outboxId: String(r.outbox_id),
+    consumerKey: String(r.consumer_key),
+    fence: String(r.fence), // bigint text — keep as string
+    attempts: Number(r.attempts), // int — safe as number
+    eventType: String(r.event_type),
+    eventId: String(r.event_id),
+    payload: r.payload,
+    automationDepth: Number(r.automation_depth),
+    manifestVersion: Number(r.manifest_version),
+  }))
+}
+
+/** fence-CAS UPDATE shared by every resolve: writes only if the caller still holds the claim (fence match). */
+async function casResolve(
+  db: Queryable,
+  outboxId: string,
+  consumerKey: string,
+  fence: string,
+  status: Extract<OutboxConsumerStatus, 'done' | 'dead_letter' | 'pending'>,
+  lastError: string | null,
+  asOf: string,
+): Promise<boolean> {
+  const res = await db.query(
+    `UPDATE meta_automation_outbox_consumer
+        SET status = $4,
+            lease_expires_at = NULL,
+            last_error = $5,
+            updated_at = $6::timestamptz
+      WHERE outbox_id = $1
+        AND consumer_key = $2
+        AND fence = $3::bigint
+        AND status = 'in_progress'`,
+    [outboxId, consumerKey, fence, status, lastError, asOf],
+  )
+  return Number(res.rowCount ?? 0) === 1
+}
+
+/**
+ * Terminal success: → `done`, lease cleared. Returns false if the caller lost the lease (a zombie whose
+ * fence was superseded by a reclaimer) — its write matched 0 rows and did nothing.
+ */
+export function completeConsumer(
+  db: Queryable,
+  outboxId: string,
+  consumerKey: string,
+  fence: string,
+  opts: { now?: () => Date } = {},
+): Promise<boolean> {
+  return casResolve(db, outboxId, consumerKey, fence, 'done', null, nowIso(opts))
+}
+
+/**
+ * Terminal poison: → `dead_letter`, lease cleared (attempts exhausted). Returns false on a lost lease.
+ */
+export function poisonConsumer(
+  db: Queryable,
+  outboxId: string,
+  consumerKey: string,
+  fence: string,
+  error: string,
+  opts: { now?: () => Date } = {},
+): Promise<boolean> {
+  return casResolve(db, outboxId, consumerKey, fence, 'dead_letter', error.slice(0, 1000), nowIso(opts))
+}
+
+/**
+ * Non-terminal release after a transient failure: → `pending`, lease cleared, so the row is immediately
+ * reclaimable by the next batch. `attempts` was already bumped at claim, so this does NOT re-increment it —
+ * the row still marches toward the poison ceiling. Returns false on a lost lease.
+ */
+export function releaseConsumer(
+  db: Queryable,
+  outboxId: string,
+  consumerKey: string,
+  fence: string,
+  error: string,
+  opts: { now?: () => Date } = {},
+): Promise<boolean> {
+  return casResolve(db, outboxId, consumerKey, fence, 'pending', error.slice(0, 1000), nowIso(opts))
+}
+
+/**
+ * Decide how a claimed row resolves after its adapter runs, given the post-claim `attempts` and the ceiling.
+ * Success → complete. Failure with attempts remaining → release (retry). Failure at/over the ceiling →
+ * poison. Kept pure so the S2-b loop's branching is unit-testable without a DB.
+ */
+export function resolveDisposition(
+  outcome: 'success' | 'failure',
+  attempts: number,
+  maxAttempts: number = DEFAULT_MAX_DELIVERY_ATTEMPTS,
+): 'complete' | 'release' | 'poison' {
+  if (outcome === 'success') return 'complete'
+  return attempts >= maxAttempts ? 'poison' : 'release'
+}

--- a/packages/core-backend/tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts
@@ -1,18 +1,21 @@
 /**
  * P2 durable-delivery — slice S2-a: claim engine / fence-CAS (real DB).
  *
- * Exercises the four claim-engine primitives against real Postgres, with CONSTRUCTED races (not sequential
- * arguments — a race guard is only proven by the interleaving it must survive):
+ * Exercises the claim-engine primitives against real Postgres with CONSTRUCTED races (a race guard is only
+ * proven by the interleaving it must survive):
  *   - claim flips pending→in_progress, bumps fence + attempts, stamps a lease, joins the outbox event;
- *   - `FOR UPDATE SKIP LOCKED` gives two concurrent claimers disjoint rows (exactly one wins a single due row);
- *   - the ZOMBIE interleaving: a worker claims (fence N), its lease expires, a reclaimer takes it (fence N+1),
- *     and the zombie's stale-fence resolve writes 0 rows while the reclaimer's wins;
- *   - complete/release/poison land the documented terminal/reclaimable states and clear the lease;
- *   - attempts increment AT CLAIM, so a crash-after-claim still marches the row to the poison ceiling.
+ *   - `FOR UPDATE SKIP LOCKED` lets a claimer SKIP a row another transaction holds locked and take a
+ *     different free row (the discriminating test — removing SKIP LOCKED makes it block → lock_timeout → red);
+ *   - the ZOMBIE interleaving: claim (fence N) → lease expires → reclaim (fence N+1) → the stale-fence
+ *     resolve writes 0 rows while the reclaimer wins;
+ *   - **crash-safe poison**: a worker that always crashes after claiming never resolves, yet the row still
+ *     dead-letters — the claim itself poisons a row at the attempt ceiling (driven only by persisted attempts);
+ *   - **backoff, not immediate retry**: reschedule keeps the row in_progress and pushes the lease out, so it
+ *     is re-claimed only after the lease expires (never instantly);
+ *   - failure detail is values-free: only a typed reason code reaches `last_error`.
  *
  * Consumer keys are randomUUID()-scoped so this file never claims rows seeded by a parallel describeIfDatabase
- * sharing the one CI Postgres. Runs only with DATABASE_URL (two-point wired: plugin-tests.yml real-DB run +
- * vitest.config.ts exclude, so it cannot skip-green).
+ * sharing the one CI Postgres. Two-point wired (plugin-tests.yml + vitest.config.ts exclude).
  */
 import { randomUUID } from 'node:crypto'
 
@@ -23,7 +26,7 @@ import {
   claimDueConsumers,
   completeConsumer,
   poisonConsumer,
-  releaseConsumer,
+  rescheduleConsumer,
   resolveDisposition,
 } from '../../src/multitable/automation-durable-dispatcher'
 
@@ -33,7 +36,6 @@ const RUN = randomUUID()
 const outboxIds: string[] = []
 let seq = 0
 
-// Seed a valid outbox event + one consumer row, with a RUN-scoped unique consumer_key (isolation).
 async function seedRow(opts: { status?: string; lease?: string | null } = {}) {
   const id = `ob_s2_${RUN}_${seq}`
   const consumerKey = `ck_${RUN}_${seq}`
@@ -54,11 +56,11 @@ async function seedRow(opts: { status?: string; lease?: string | null } = {}) {
 
 async function readRow(outboxId: string, consumerKey: string) {
   const { rows } = await db().query(
-    `SELECT status, fence::text AS fence, attempts, (lease_expires_at IS NULL) AS lease_null
+    `SELECT status, fence::text AS fence, attempts, last_error, (lease_expires_at IS NULL) AS lease_null
        FROM meta_automation_outbox_consumer WHERE outbox_id=$1 AND consumer_key=$2`,
     [outboxId, consumerKey],
   )
-  return rows[0] as { status: string; fence: string; attempts: number; lease_null: boolean }
+  return rows[0] as { status: string; fence: string; attempts: number; last_error: string | null; lease_null: boolean }
 }
 
 async function expireLease(outboxId: string, consumerKey: string) {
@@ -84,52 +86,52 @@ describeIfDatabase('P2 durable-delivery S2-a — claim engine / fence-CAS (real 
     const { outboxId, consumerKey } = await seedRow()
     const [mine] = await claimDueConsumers(db(), { consumerKeys: [consumerKey], batchSize: 10 })
     expect(mine).toBeTruthy()
-    expect(mine.fence).toBe('1') // 0 -> 1
-    expect(typeof mine.fence).toBe('string') // bigint as string, never a JS number
-    expect(mine.attempts).toBe(1) // 0 -> 1 AT CLAIM
+    expect(mine.fence).toBe('1')
+    expect(typeof mine.fence).toBe('string')
+    expect(mine.attempts).toBe(1)
     expect(mine.eventType).toBe('approval.approved')
     expect(mine.eventId).toBe(`evt_${outboxId}`)
     expect(mine.payload).toMatchObject({ ob: outboxId })
-    expect(await readRow(outboxId, consumerKey)).toMatchObject({
-      status: 'in_progress',
-      fence: '1',
-      attempts: 1,
-      lease_null: false, // in_progress MUST carry a lease (the biconditional)
-    })
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'in_progress', fence: '1', attempts: 1, lease_null: false })
   })
 
-  test('SKIP LOCKED: two concurrent claimers over one due row → exactly one wins (no double-claim)', async () => {
-    const { outboxId, consumerKey } = await seedRow()
+  test('SKIP LOCKED: a claimer skips a row another tx holds locked and takes a different FREE row', async () => {
+    const locked = await seedRow()
+    const free = await seedRow()
     const raw = db().getInternalPool()
     const a = await raw.connect()
     const b = await raw.connect()
     try {
-      const [ra, rb] = await Promise.all([
-        claimDueConsumers(a, { consumerKeys: [consumerKey], batchSize: 10 }),
-        claimDueConsumers(b, { consumerKeys: [consumerKey], batchSize: 10 }),
-      ])
-      const wins = [ra, rb].map((rs) => rs.filter((c) => c.outboxId === outboxId).length)
-      expect(wins[0] + wins[1]).toBe(1) // exactly one connection claimed the single due row
+      // B must not block indefinitely if the guard is ever removed — a lock wait then trips this timeout.
+      await b.query("SET lock_timeout = '2000ms'")
+      await a.query('BEGIN')
+      // A holds a row lock on `locked` without committing.
+      await a.query(
+        `SELECT 1 FROM meta_automation_outbox_consumer WHERE outbox_id=$1 AND consumer_key=$2 FOR UPDATE`,
+        [locked.outboxId, locked.consumerKey],
+      )
+      // B claims across both keys: SKIP LOCKED must let it skip `locked` and take `free` — NOT block on the lock.
+      const claimed = await claimDueConsumers(b, { consumerKeys: [locked.consumerKey, free.consumerKey], batchSize: 10 })
+      const keys = new Set(claimed.map((c) => c.consumerKey))
+      expect(keys.has(free.consumerKey)).toBe(true) // took the free row
+      expect(keys.has(locked.consumerKey)).toBe(false) // skipped the locked row, did not block on it
+      await a.query('ROLLBACK')
     } finally {
       a.release()
       b.release()
     }
-    // claimed exactly once → attempts incremented exactly once (not double)
-    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'in_progress', attempts: 1 })
   })
 
   test('ZOMBIE fence-CAS: a stale-fence complete writes 0 rows; the reclaimer (new fence) wins', async () => {
     const { outboxId, consumerKey } = await seedRow()
-    const [first] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] }) // fence 1
+    const [first] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
     expect(first.fence).toBe('1')
-    await expireLease(outboxId, consumerKey) // worker stalled past its lease
-    const [second] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] }) // reclaim → fence 2
+    await expireLease(outboxId, consumerKey)
+    const [second] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
     expect(second.fence).toBe('2')
-    // the zombie (still holding fence 1) tries to finish: fence-CAS mismatch → no-op
-    expect(await completeConsumer(db(), outboxId, consumerKey, first.fence)).toBe(false)
-    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'in_progress' }) // NOT done — reclaimer owns it
-    // the reclaimer (fence 2) finishes → done
-    expect(await completeConsumer(db(), outboxId, consumerKey, second.fence)).toBe(true)
+    expect(await completeConsumer(db(), outboxId, consumerKey, first.fence)).toBe(false) // zombie: 0 rows
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'in_progress' })
+    expect(await completeConsumer(db(), outboxId, consumerKey, second.fence)).toBe(true) // reclaimer wins
     expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'done', lease_null: true })
   })
 
@@ -138,37 +140,61 @@ describeIfDatabase('P2 durable-delivery S2-a — claim engine / fence-CAS (real 
     const [c] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
     expect(await completeConsumer(db(), outboxId, consumerKey, c.fence)).toBe(true)
     expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'done', lease_null: true })
-    // idempotent: the row is no longer in_progress, so the CAS matches 0 rows
     expect(await completeConsumer(db(), outboxId, consumerKey, c.fence)).toBe(false)
   })
 
-  test('release → pending (immediately reclaimable), lease cleared, attempts accumulate on reclaim', async () => {
+  test('reschedule keeps in_progress with a BACKOFF lease — NOT immediately reclaimable; reclaimed after expiry', async () => {
     const { outboxId, consumerKey } = await seedRow()
     const [c1] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
-    expect(c1.attempts).toBe(1)
-    expect(await releaseConsumer(db(), outboxId, consumerKey, c1.fence, 'transient boom')).toBe(true)
-    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'pending', lease_null: true, attempts: 1 })
-    const [c2] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] }) // reclaimable right away
-    expect(c2.fence).toBe('2') // fence bumped each claim
-    expect(c2.attempts).toBe(2) // marches toward the ceiling (release did NOT reset it)
+    expect(await rescheduleConsumer(db(), outboxId, consumerKey, c1.fence, 60_000, 'adapter_error')).toBe(true)
+    // stays in_progress (NOT flipped to a pending that would be instantly reclaimable), attempts unchanged
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'in_progress', attempts: 1, lease_null: false })
+    // within the backoff window the row is NOT reclaimable
+    expect(await claimDueConsumers(db(), { consumerKeys: [consumerKey] })).toHaveLength(0)
+    // once the backoff lease expires, it IS reclaimed (fence + attempts advance)
+    await expireLease(outboxId, consumerKey)
+    const [c2] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
+    expect(c2.fence).toBe('2')
+    expect(c2.attempts).toBe(2)
   })
 
-  test('poison → dead_letter, lease cleared, terminal (never reclaimed by a later claim)', async () => {
+  test('CRASH-SAFE poison: a worker that always crashes after claim still dead-letters at the ceiling', async () => {
+    const { outboxId, consumerKey } = await seedRow()
+    const MAX = 3
+    for (let i = 1; i <= MAX; i++) {
+      const [c] = await claimDueConsumers(db(), { consumerKeys: [consumerKey], maxAttempts: MAX })
+      expect(c.attempts).toBe(i) // dispatched
+      await expireLease(outboxId, consumerKey) // "crash" → no resolve → lease expires
+    }
+    // the next claim finds attempts === ceiling and poisons it WITHOUT dispatching (no worker needed)
+    const poisoned = await claimDueConsumers(db(), { consumerKeys: [consumerKey], maxAttempts: MAX })
+    expect(poisoned).toHaveLength(0)
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({
+      status: 'dead_letter',
+      attempts: MAX, // capped
+      last_error: 'max_attempts_exhausted',
+      lease_null: true,
+    })
+    // terminal: never reclaimed again
+    await expireLease(outboxId, consumerKey).catch(() => {})
+    expect(await claimDueConsumers(db(), { consumerKeys: [consumerKey], maxAttempts: MAX })).toHaveLength(0)
+  })
+
+  test('poison (deterministic permanent failure) → dead_letter, lease cleared, terminal', async () => {
     const { outboxId, consumerKey } = await seedRow()
     const [c] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
-    expect(await poisonConsumer(db(), outboxId, consumerKey, c.fence, 'exhausted')).toBe(true)
-    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'dead_letter', lease_null: true })
-    const again = await claimDueConsumers(db(), { consumerKeys: [consumerKey], batchSize: 10 })
-    expect(again.find((x) => x.outboxId === outboxId)).toBeFalsy() // dead_letter is terminal, not reclaimable
+    expect(await poisonConsumer(db(), outboxId, consumerKey, c.fence, 'permanent_rejection')).toBe(true)
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'dead_letter', last_error: 'permanent_rejection', lease_null: true })
+    expect(await claimDueConsumers(db(), { consumerKeys: [consumerKey], batchSize: 10 })).toHaveLength(0)
   })
 
-  test('attempts increment AT CLAIM across reclaims (crash-after-claim still marches to the ceiling)', async () => {
+  test('attempts increment AT CLAIM across reclaims (crash-after-claim marches toward the ceiling)', async () => {
     const { outboxId, consumerKey } = await seedRow()
     for (let i = 1; i <= 3; i++) {
-      const [c] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
-      expect(c.attempts).toBe(i) // bumped even though the "worker" never resolves (simulated crash)
+      const [c] = await claimDueConsumers(db(), { consumerKeys: [consumerKey], maxAttempts: 100 })
+      expect(c.attempts).toBe(i)
       expect(c.fence).toBe(String(i))
-      await expireLease(outboxId, consumerKey) // crash → lease expires → next round reclaims
+      await expireLease(outboxId, consumerKey)
     }
   })
 
@@ -181,12 +207,28 @@ describeIfDatabase('P2 durable-delivery S2-a — claim engine / fence-CAS (real 
     expect(keys.has(b.consumerKey)).toBe(false)
   })
 
-  test('resolveDisposition (pure): success→complete; failure<ceiling→release; failure≥ceiling→poison', () => {
-    expect(resolveDisposition('success', 1)).toBe('complete')
-    expect(resolveDisposition('failure', 1, 8)).toBe('release')
-    expect(resolveDisposition('failure', 7, 8)).toBe('release')
-    expect(resolveDisposition('failure', 8, 8)).toBe('poison')
-    expect(resolveDisposition('failure', 9, 8)).toBe('poison')
-    expect(resolveDisposition('success', 99, 8)).toBe('complete') // success completes even past the ceiling
+  test('input validation: non-positive leaseMs/retryDelayMs and an off-vocabulary reason all throw', async () => {
+    const { outboxId, consumerKey } = await seedRow()
+    await expect(claimDueConsumers(db(), { consumerKeys: [consumerKey], leaseMs: -1 })).rejects.toThrow(/leaseMs/)
+    await expect(claimDueConsumers(db(), { consumerKeys: [consumerKey], leaseMs: 0 })).rejects.toThrow(/leaseMs/)
+    const [c] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
+    await expect(rescheduleConsumer(db(), outboxId, consumerKey, c.fence, 0, 'adapter_error')).rejects.toThrow(/retryDelayMs/)
+    // values-free guard: a raw (secret-shaped) string is rejected before it can reach the DB
+    await expect(
+      poisonConsumer(db(), outboxId, consumerKey, c.fence, 'https://api/internal?token=SECRET' as never),
+    ).rejects.toThrow(/values-free/)
+  })
+
+  test('last_error only ever holds a values-free code (never a raw message)', async () => {
+    const { outboxId, consumerKey } = await seedRow()
+    const [c] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
+    await rescheduleConsumer(db(), outboxId, consumerKey, c.fence, 30_000, 'adapter_timeout')
+    expect((await readRow(outboxId, consumerKey)).last_error).toBe('adapter_timeout')
+  })
+
+  test('resolveDisposition (pure): success→complete; retryable→reschedule; permanent→poison', () => {
+    expect(resolveDisposition('success')).toBe('complete')
+    expect(resolveDisposition('retryable_failure')).toBe('reschedule')
+    expect(resolveDisposition('permanent_failure')).toBe('poison')
   })
 })

--- a/packages/core-backend/tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts
@@ -1,0 +1,192 @@
+/**
+ * P2 durable-delivery — slice S2-a: claim engine / fence-CAS (real DB).
+ *
+ * Exercises the four claim-engine primitives against real Postgres, with CONSTRUCTED races (not sequential
+ * arguments — a race guard is only proven by the interleaving it must survive):
+ *   - claim flips pending→in_progress, bumps fence + attempts, stamps a lease, joins the outbox event;
+ *   - `FOR UPDATE SKIP LOCKED` gives two concurrent claimers disjoint rows (exactly one wins a single due row);
+ *   - the ZOMBIE interleaving: a worker claims (fence N), its lease expires, a reclaimer takes it (fence N+1),
+ *     and the zombie's stale-fence resolve writes 0 rows while the reclaimer's wins;
+ *   - complete/release/poison land the documented terminal/reclaimable states and clear the lease;
+ *   - attempts increment AT CLAIM, so a crash-after-claim still marches the row to the poison ceiling.
+ *
+ * Consumer keys are randomUUID()-scoped so this file never claims rows seeded by a parallel describeIfDatabase
+ * sharing the one CI Postgres. Runs only with DATABASE_URL (two-point wired: plugin-tests.yml real-DB run +
+ * vitest.config.ts exclude, so it cannot skip-green).
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import {
+  claimDueConsumers,
+  completeConsumer,
+  poisonConsumer,
+  releaseConsumer,
+  resolveDisposition,
+} from '../../src/multitable/automation-durable-dispatcher'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const db = () => poolManager.get()
+const RUN = randomUUID()
+const outboxIds: string[] = []
+let seq = 0
+
+// Seed a valid outbox event + one consumer row, with a RUN-scoped unique consumer_key (isolation).
+async function seedRow(opts: { status?: string; lease?: string | null } = {}) {
+  const id = `ob_s2_${RUN}_${seq}`
+  const consumerKey = `ck_${RUN}_${seq}`
+  seq += 1
+  outboxIds.push(id)
+  await db().query(
+    `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
+     VALUES ($1,'approval.approved',$2::jsonb,0,1,$3)`,
+    [id, JSON.stringify({ ob: id }), `evt_${id}`],
+  )
+  await db().query(
+    `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status, lease_expires_at)
+     VALUES ($1,$2,$3,$4::timestamptz)`,
+    [id, consumerKey, opts.status ?? 'pending', opts.lease ?? null],
+  )
+  return { outboxId: id, consumerKey }
+}
+
+async function readRow(outboxId: string, consumerKey: string) {
+  const { rows } = await db().query(
+    `SELECT status, fence::text AS fence, attempts, (lease_expires_at IS NULL) AS lease_null
+       FROM meta_automation_outbox_consumer WHERE outbox_id=$1 AND consumer_key=$2`,
+    [outboxId, consumerKey],
+  )
+  return rows[0] as { status: string; fence: string; attempts: number; lease_null: boolean }
+}
+
+async function expireLease(outboxId: string, consumerKey: string) {
+  await db().query(
+    `UPDATE meta_automation_outbox_consumer SET lease_expires_at = now() - interval '1 minute'
+      WHERE outbox_id=$1 AND consumer_key=$2`,
+    [outboxId, consumerKey],
+  )
+}
+
+describeIfDatabase('P2 durable-delivery S2-a — claim engine / fence-CAS (real DB)', () => {
+  afterAll(async () => {
+    if (outboxIds.length) {
+      await db().query('DELETE FROM meta_automation_outbox WHERE id = ANY($1)', [outboxIds]).catch(() => {})
+    }
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('claim flips pending→in_progress, bumps fence+attempts, stamps lease, joins the event', async () => {
+    const { outboxId, consumerKey } = await seedRow()
+    const [mine] = await claimDueConsumers(db(), { consumerKeys: [consumerKey], batchSize: 10 })
+    expect(mine).toBeTruthy()
+    expect(mine.fence).toBe('1') // 0 -> 1
+    expect(typeof mine.fence).toBe('string') // bigint as string, never a JS number
+    expect(mine.attempts).toBe(1) // 0 -> 1 AT CLAIM
+    expect(mine.eventType).toBe('approval.approved')
+    expect(mine.eventId).toBe(`evt_${outboxId}`)
+    expect(mine.payload).toMatchObject({ ob: outboxId })
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({
+      status: 'in_progress',
+      fence: '1',
+      attempts: 1,
+      lease_null: false, // in_progress MUST carry a lease (the biconditional)
+    })
+  })
+
+  test('SKIP LOCKED: two concurrent claimers over one due row → exactly one wins (no double-claim)', async () => {
+    const { outboxId, consumerKey } = await seedRow()
+    const raw = db().getInternalPool()
+    const a = await raw.connect()
+    const b = await raw.connect()
+    try {
+      const [ra, rb] = await Promise.all([
+        claimDueConsumers(a, { consumerKeys: [consumerKey], batchSize: 10 }),
+        claimDueConsumers(b, { consumerKeys: [consumerKey], batchSize: 10 }),
+      ])
+      const wins = [ra, rb].map((rs) => rs.filter((c) => c.outboxId === outboxId).length)
+      expect(wins[0] + wins[1]).toBe(1) // exactly one connection claimed the single due row
+    } finally {
+      a.release()
+      b.release()
+    }
+    // claimed exactly once → attempts incremented exactly once (not double)
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'in_progress', attempts: 1 })
+  })
+
+  test('ZOMBIE fence-CAS: a stale-fence complete writes 0 rows; the reclaimer (new fence) wins', async () => {
+    const { outboxId, consumerKey } = await seedRow()
+    const [first] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] }) // fence 1
+    expect(first.fence).toBe('1')
+    await expireLease(outboxId, consumerKey) // worker stalled past its lease
+    const [second] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] }) // reclaim → fence 2
+    expect(second.fence).toBe('2')
+    // the zombie (still holding fence 1) tries to finish: fence-CAS mismatch → no-op
+    expect(await completeConsumer(db(), outboxId, consumerKey, first.fence)).toBe(false)
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'in_progress' }) // NOT done — reclaimer owns it
+    // the reclaimer (fence 2) finishes → done
+    expect(await completeConsumer(db(), outboxId, consumerKey, second.fence)).toBe(true)
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'done', lease_null: true })
+  })
+
+  test('complete happy-path → done, lease cleared; a repeat complete is a no-op', async () => {
+    const { outboxId, consumerKey } = await seedRow()
+    const [c] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
+    expect(await completeConsumer(db(), outboxId, consumerKey, c.fence)).toBe(true)
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'done', lease_null: true })
+    // idempotent: the row is no longer in_progress, so the CAS matches 0 rows
+    expect(await completeConsumer(db(), outboxId, consumerKey, c.fence)).toBe(false)
+  })
+
+  test('release → pending (immediately reclaimable), lease cleared, attempts accumulate on reclaim', async () => {
+    const { outboxId, consumerKey } = await seedRow()
+    const [c1] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
+    expect(c1.attempts).toBe(1)
+    expect(await releaseConsumer(db(), outboxId, consumerKey, c1.fence, 'transient boom')).toBe(true)
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'pending', lease_null: true, attempts: 1 })
+    const [c2] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] }) // reclaimable right away
+    expect(c2.fence).toBe('2') // fence bumped each claim
+    expect(c2.attempts).toBe(2) // marches toward the ceiling (release did NOT reset it)
+  })
+
+  test('poison → dead_letter, lease cleared, terminal (never reclaimed by a later claim)', async () => {
+    const { outboxId, consumerKey } = await seedRow()
+    const [c] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
+    expect(await poisonConsumer(db(), outboxId, consumerKey, c.fence, 'exhausted')).toBe(true)
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'dead_letter', lease_null: true })
+    const again = await claimDueConsumers(db(), { consumerKeys: [consumerKey], batchSize: 10 })
+    expect(again.find((x) => x.outboxId === outboxId)).toBeFalsy() // dead_letter is terminal, not reclaimable
+  })
+
+  test('attempts increment AT CLAIM across reclaims (crash-after-claim still marches to the ceiling)', async () => {
+    const { outboxId, consumerKey } = await seedRow()
+    for (let i = 1; i <= 3; i++) {
+      const [c] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
+      expect(c.attempts).toBe(i) // bumped even though the "worker" never resolves (simulated crash)
+      expect(c.fence).toBe(String(i))
+      await expireLease(outboxId, consumerKey) // crash → lease expires → next round reclaims
+    }
+  })
+
+  test('claim respects the consumer_keys filter (does not touch other keys)', async () => {
+    const a = await seedRow()
+    const b = await seedRow()
+    const claimed = await claimDueConsumers(db(), { consumerKeys: [a.consumerKey], batchSize: 50 })
+    const keys = new Set(claimed.map((c) => c.consumerKey))
+    expect(keys.has(a.consumerKey)).toBe(true)
+    expect(keys.has(b.consumerKey)).toBe(false)
+  })
+
+  test('resolveDisposition (pure): success→complete; failure<ceiling→release; failure≥ceiling→poison', () => {
+    expect(resolveDisposition('success', 1)).toBe('complete')
+    expect(resolveDisposition('failure', 1, 8)).toBe('release')
+    expect(resolveDisposition('failure', 7, 8)).toBe('release')
+    expect(resolveDisposition('failure', 8, 8)).toBe('poison')
+    expect(resolveDisposition('failure', 9, 8)).toBe('poison')
+    expect(resolveDisposition('success', 99, 8)).toBe('complete') // success completes even past the ceiling
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts
@@ -1,21 +1,20 @@
 /**
  * P2 durable-delivery — slice S2-a: claim engine / fence-CAS (real DB).
  *
- * Exercises the claim-engine primitives against real Postgres with CONSTRUCTED races (a race guard is only
- * proven by the interleaving it must survive):
+ * Exercises the claim-engine primitives against real Postgres with CONSTRUCTED races:
  *   - claim flips pending→in_progress, bumps fence + attempts, stamps a lease, joins the outbox event;
- *   - `FOR UPDATE SKIP LOCKED` lets a claimer SKIP a row another transaction holds locked and take a
- *     different free row (the discriminating test — removing SKIP LOCKED makes it block → lock_timeout → red);
- *   - the ZOMBIE interleaving: claim (fence N) → lease expires → reclaim (fence N+1) → the stale-fence
- *     resolve writes 0 rows while the reclaimer wins;
- *   - **crash-safe poison**: a worker that always crashes after claiming never resolves, yet the row still
- *     dead-letters — the claim itself poisons a row at the attempt ceiling (driven only by persisted attempts);
- *   - **backoff, not immediate retry**: reschedule keeps the row in_progress and pushes the lease out, so it
- *     is re-claimed only after the lease expires (never instantly);
- *   - failure detail is values-free: only a typed reason code reaches `last_error`.
+ *   - `FOR UPDATE SKIP LOCKED` lets a claimer SKIP a row another tx holds locked and take a different free
+ *     row (removing SKIP LOCKED makes it block → the tx-scoped lock_timeout trips → red);
+ *   - the ZOMBIE interleaving: a stale-fence resolve writes 0 rows while the reclaimer wins;
+ *   - crash-safe poison at the ceiling (no surviving worker needed);
+ *   - reschedule keeps the row in_progress with a backoff lease AND bumps the fence, so the token is dead
+ *     (a late complete with the old fence is a no-op);
+ *   - rolling deploy: an unknown consumer_key is left `pending` (never claimed/dead-lettered) and surfaced
+ *     for alert (#4203 §246);
+ *   - numeric params are validated safe-integers-in-bounds; failure detail is a values-free code.
  *
- * Consumer keys are randomUUID()-scoped so this file never claims rows seeded by a parallel describeIfDatabase
- * sharing the one CI Postgres. Two-point wired (plugin-tests.yml + vitest.config.ts exclude).
+ * Consumer keys are randomUUID()-scoped for shared-DB isolation. Two-point wired (plugin-tests.yml +
+ * vitest.config.ts exclude).
  */
 import { randomUUID } from 'node:crypto'
 
@@ -25,6 +24,7 @@ import { poolManager } from '../../src/integration/db/connection-pool'
 import {
   claimDueConsumers,
   completeConsumer,
+  findUnknownConsumerKeys,
   poisonConsumer,
   rescheduleConsumer,
   resolveDisposition,
@@ -102,21 +102,25 @@ describeIfDatabase('P2 durable-delivery S2-a — claim engine / fence-CAS (real 
     const a = await raw.connect()
     const b = await raw.connect()
     try {
-      // B must not block indefinitely if the guard is ever removed — a lock wait then trips this timeout.
-      await b.query("SET lock_timeout = '2000ms'")
       await a.query('BEGIN')
       // A holds a row lock on `locked` without committing.
       await a.query(
         `SELECT 1 FROM meta_automation_outbox_consumer WHERE outbox_id=$1 AND consumer_key=$2 FOR UPDATE`,
         [locked.outboxId, locked.consumerKey],
       )
-      // B claims across both keys: SKIP LOCKED must let it skip `locked` and take `free` — NOT block on the lock.
+      // B claims inside its own tx with a TX-SCOPED lock_timeout (SET LOCAL → auto-reset, no pool pollution).
+      // SKIP LOCKED must let B skip the locked row and take the free one — NOT block on the lock.
+      await b.query('BEGIN')
+      await b.query("SET LOCAL lock_timeout = '2000ms'")
       const claimed = await claimDueConsumers(b, { consumerKeys: [locked.consumerKey, free.consumerKey], batchSize: 10 })
+      await b.query('COMMIT')
       const keys = new Set(claimed.map((c) => c.consumerKey))
       expect(keys.has(free.consumerKey)).toBe(true) // took the free row
       expect(keys.has(locked.consumerKey)).toBe(false) // skipped the locked row, did not block on it
-      await a.query('ROLLBACK')
     } finally {
+      // best-effort: release A's lock, and clear B's tx whether it committed or aborted (mutation path).
+      await a.query('ROLLBACK').catch(() => {})
+      await b.query('ROLLBACK').catch(() => {})
       a.release()
       b.release()
     }
@@ -129,9 +133,9 @@ describeIfDatabase('P2 durable-delivery S2-a — claim engine / fence-CAS (real 
     await expireLease(outboxId, consumerKey)
     const [second] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
     expect(second.fence).toBe('2')
-    expect(await completeConsumer(db(), outboxId, consumerKey, first.fence)).toBe(false) // zombie: 0 rows
+    expect(await completeConsumer(db(), outboxId, consumerKey, first.fence)).toBe(false)
     expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'in_progress' })
-    expect(await completeConsumer(db(), outboxId, consumerKey, second.fence)).toBe(true) // reclaimer wins
+    expect(await completeConsumer(db(), outboxId, consumerKey, second.fence)).toBe(true)
     expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'done', lease_null: true })
   })
 
@@ -143,18 +147,22 @@ describeIfDatabase('P2 durable-delivery S2-a — claim engine / fence-CAS (real 
     expect(await completeConsumer(db(), outboxId, consumerKey, c.fence)).toBe(false)
   })
 
-  test('reschedule keeps in_progress with a BACKOFF lease — NOT immediately reclaimable; reclaimed after expiry', async () => {
+  test('reschedule: backoff lease (not instantly reclaimable) + BUMPS fence (old token dead); reclaimed after expiry', async () => {
     const { outboxId, consumerKey } = await seedRow()
     const [c1] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
+    expect(c1.fence).toBe('1')
     expect(await rescheduleConsumer(db(), outboxId, consumerKey, c1.fence, 60_000, 'adapter_error')).toBe(true)
-    // stays in_progress (NOT flipped to a pending that would be instantly reclaimable), attempts unchanged
-    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'in_progress', attempts: 1, lease_null: false })
+    // fence bumped 1→2, still in_progress, attempts unchanged
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'in_progress', fence: '2', attempts: 1, lease_null: false })
+    // the token c1.fence is now DEAD: a late worker holding it cannot complete (or poison/reschedule) the row
+    expect(await completeConsumer(db(), outboxId, consumerKey, c1.fence)).toBe(false)
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'in_progress' }) // not done
     // within the backoff window the row is NOT reclaimable
     expect(await claimDueConsumers(db(), { consumerKeys: [consumerKey] })).toHaveLength(0)
-    // once the backoff lease expires, it IS reclaimed (fence + attempts advance)
+    // after the backoff lease expires it IS reclaimed (fence + attempts advance)
     await expireLease(outboxId, consumerKey)
     const [c2] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
-    expect(c2.fence).toBe('2')
+    expect(c2.fence).toBe('3') // 1 (claim) → 2 (reschedule bump) → 3 (reclaim)
     expect(c2.attempts).toBe(2)
   })
 
@@ -163,21 +171,35 @@ describeIfDatabase('P2 durable-delivery S2-a — claim engine / fence-CAS (real 
     const MAX = 3
     for (let i = 1; i <= MAX; i++) {
       const [c] = await claimDueConsumers(db(), { consumerKeys: [consumerKey], maxAttempts: MAX })
-      expect(c.attempts).toBe(i) // dispatched
+      expect(c.attempts).toBe(i)
       await expireLease(outboxId, consumerKey) // "crash" → no resolve → lease expires
     }
-    // the next claim finds attempts === ceiling and poisons it WITHOUT dispatching (no worker needed)
     const poisoned = await claimDueConsumers(db(), { consumerKeys: [consumerKey], maxAttempts: MAX })
-    expect(poisoned).toHaveLength(0)
+    expect(poisoned).toHaveLength(0) // poisoned at claim, NOT dispatched
     expect(await readRow(outboxId, consumerKey)).toMatchObject({
       status: 'dead_letter',
-      attempts: MAX, // capped
+      attempts: MAX,
       last_error: 'max_attempts_exhausted',
       lease_null: true,
     })
-    // terminal: never reclaimed again
     await expireLease(outboxId, consumerKey).catch(() => {})
     expect(await claimDueConsumers(db(), { consumerKeys: [consumerKey], maxAttempts: MAX })).toHaveLength(0)
+  })
+
+  test('rolling deploy: an unknown consumer_key stays pending (never claimed/dead-lettered) and is surfaced for alert', async () => {
+    const { outboxId, consumerKey } = await seedRow() // only "worker N" knows consumerKey
+    const nMinus1Keys = [`ck_${RUN}_unrelated`] // "worker N-1" knows a different key
+    // N-1 claims with ITS keys → must not touch the unknown-to-it row
+    const byNminus1 = await claimDueConsumers(db(), { consumerKeys: nMinus1Keys, batchSize: 10 })
+    expect(byNminus1.find((c) => c.outboxId === outboxId)).toBeFalsy()
+    // even repeated N-1 claims never dead-letter it (it is never claimed → attempts stays 0, status pending)
+    for (let i = 0; i < 10; i++) await claimDueConsumers(db(), { consumerKeys: nMinus1Keys, maxAttempts: 3 })
+    expect(await readRow(outboxId, consumerKey)).toMatchObject({ status: 'pending', attempts: 0 })
+    // the alert seam surfaces the key as unknown to N-1
+    expect(await findUnknownConsumerKeys(db(), nMinus1Keys)).toContain(consumerKey)
+    // "worker N" (knows the key) processes it normally
+    const byN = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
+    expect(byN.find((c) => c.outboxId === outboxId)).toBeTruthy()
   })
 
   test('poison (deterministic permanent failure) → dead_letter, lease cleared, terminal', async () => {
@@ -198,25 +220,19 @@ describeIfDatabase('P2 durable-delivery S2-a — claim engine / fence-CAS (real 
     }
   })
 
-  test('claim respects the consumer_keys filter (does not touch other keys)', async () => {
-    const a = await seedRow()
-    const b = await seedRow()
-    const claimed = await claimDueConsumers(db(), { consumerKeys: [a.consumerKey], batchSize: 50 })
-    const keys = new Set(claimed.map((c) => c.consumerKey))
-    expect(keys.has(a.consumerKey)).toBe(true)
-    expect(keys.has(b.consumerKey)).toBe(false)
-  })
-
-  test('input validation: non-positive leaseMs/retryDelayMs and an off-vocabulary reason all throw', async () => {
+  test('input validation: keys required, numeric params must be safe integers in bounds, reason values-free', async () => {
     const { outboxId, consumerKey } = await seedRow()
+    await expect(claimDueConsumers(db(), { consumerKeys: [] })).rejects.toThrow(/consumerKeys/)
+    await expect(claimDueConsumers(db(), {} as never)).rejects.toThrow(/consumerKeys/)
     await expect(claimDueConsumers(db(), { consumerKeys: [consumerKey], leaseMs: -1 })).rejects.toThrow(/leaseMs/)
-    await expect(claimDueConsumers(db(), { consumerKeys: [consumerKey], leaseMs: 0 })).rejects.toThrow(/leaseMs/)
+    await expect(claimDueConsumers(db(), { consumerKeys: [consumerKey], leaseMs: 1.5 })).rejects.toThrow(/leaseMs/) // fractional
+    await expect(claimDueConsumers(db(), { consumerKeys: [consumerKey], leaseMs: 1e15 })).rejects.toThrow(/leaseMs/) // over cap
+    await expect(claimDueConsumers(db(), { consumerKeys: [consumerKey], batchSize: 0 })).rejects.toThrow(/batchSize/)
+    await expect(claimDueConsumers(db(), { consumerKeys: [consumerKey], maxAttempts: 0 })).rejects.toThrow(/maxAttempts/)
     const [c] = await claimDueConsumers(db(), { consumerKeys: [consumerKey] })
     await expect(rescheduleConsumer(db(), outboxId, consumerKey, c.fence, 0, 'adapter_error')).rejects.toThrow(/retryDelayMs/)
-    // values-free guard: a raw (secret-shaped) string is rejected before it can reach the DB
-    await expect(
-      poisonConsumer(db(), outboxId, consumerKey, c.fence, 'https://api/internal?token=SECRET' as never),
-    ).rejects.toThrow(/values-free/)
+    await expect(rescheduleConsumer(db(), outboxId, consumerKey, c.fence, 2.5, 'adapter_error')).rejects.toThrow(/retryDelayMs/)
+    await expect(poisonConsumer(db(), outboxId, consumerKey, c.fence, 'https://api/internal?token=SECRET' as never)).rejects.toThrow(/values-free/)
   })
 
   test('last_error only ever holds a values-free code (never a raw message)', async () => {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -310,6 +310,10 @@ export default defineConfig({
       // only (checks the migration landed both tables, the status CHECK, FK cascade, defaults). Excluded HERE
       // so it cannot skip-green in the no-DB lane, whole-file wired into plugin-tests.yml. Two-point wiring.
       'tests/integration/multitable-automation-outbox-schema-realdb.test.ts',
+      // P2 durable-delivery S2-a claim engine / fence-CAS — real-DB constructed-concurrency (zombie/SKIP
+      // LOCKED). Excluded HERE so it cannot skip-green in the no-DB lane; whole-file wired into
+      // plugin-tests.yml. Two-point wiring.
+      'tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts',
       // W0 tail (#4279, owner MUST-WRITE OD-6, design-lock §0.5 2026-07-13): field-undelete rehydration
       // revision goldens — proves `recreateFieldFromConfig`'s tombstone-value rehydration UPDATE bumps
       // `version` and emits a `recordRecordRevision` AT THE NEW version, same transaction, for every


### PR DESCRIPTION
**P2 durable-delivery slice S2-a — the claim engine (fence-CAS).** First runtime slice of the durable dispatcher (FWB-0 #4203 Layer 1), on top of the landed S1 outbox schema (#4303). **Additive, flag-gated, zero behavior change:** nothing calls these primitives while `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF; the poll+dispatch loop is S2-b and the consumer adapters are S5.

## What lands
- **`automation-durable-dispatcher.ts`** — the claim-engine primitives:
  - `claimDueConsumers(db, { consumerKeys, batchSize?, leaseMs?, maxAttempts?, now? })` — **`consumerKeys` is REQUIRED and non-empty** (the registry allow-list of keys this worker knows). One atomic `FOR UPDATE SKIP LOCKED` CTE: a reclaimable row (`pending`, or `in_progress` past a stale lease) **whose key is in the allow-list** is claimed (→ `in_progress`, fresh lease, `fence`++ , `attempts`++ **at claim**), OR — if `attempts >= maxAttempts` — **poisoned to `dead_letter` right there** (crash-safe, no surviving worker needed) and not dispatched. A key **not** in the allow-list is never touched, so it stays `pending` for a worker that knows it (rolling-deploy contract, #4203 §246).
  - `findUnknownConsumerKeys(db, knownKeys)` — the alert seam: reclaimable rows whose key this worker doesn't know (the loop alerts on these, never claims them).
  - `completeConsumer` / `poisonConsumer` / `rescheduleConsumer` — **fence-CAS** resolves (`WHERE fence = <claimed> AND status='in_progress'`). A zombie/stale token writes 0 rows. `rescheduleConsumer` (transient failure) keeps the row `in_progress`, pushes the lease out by a backoff (re-claimed only after expiry, never instantly), **and atomically bumps the fence** — so the token the caller used is dead and a late worker holding it can't complete/poison/reschedule. `reason` is a typed, values-free `DeliveryFailureReason`, enforced at runtime.
  - `resolveDisposition('success' | 'retryable_failure' | 'permanent_failure')` → `complete` / `reschedule` / `poison` (attempt-exhaustion poison is claim-driven, not a disposition).
  - All numeric bounds validated as **safe integers in explicit ranges** (batch 1..10000, lease/delay 1..86_400_000, attempts 1..10000) — no fractional/huge value reaches a SQL cast.
- **Real-DB spec (13 tests, real Postgres, CONSTRUCTED races)** — claim shape; discriminating SKIP-LOCKED (tx A holds a lock, B skips it and takes a free row, tx-scoped `SET LOCAL lock_timeout` + `finally` rollback so the pool isn't polluted); zombie fence-CAS; complete + idempotent; reschedule (backoff + fence-bump/token-invalidation + reclaim); crash-safe poison at the ceiling; **rolling-deploy unknown-key** (N-1 leaves it `pending`, N processes it, alert seam surfaces it); permanent poison; attempts-at-claim across reclaims; input validation; values-free `last_error`; pure `resolveDisposition`. **Two-point wired** (plugin-tests.yml run list + vitest.config.ts exclude).

## Verification
Ran locally on **real Postgres 15**: **13/13 pass**. Five guards are **mutation-proven load-bearing**: unknown-key scoping (always-true filter → N-1 claims it → red), reschedule fence-bump (drop the bump → stale token completes → red), SKIP-LOCKED (drop it → red on lock timeout), fence-CAS, and crash-safe poison. Typecheck green under CI's `tsc`.

## Not in this slice
S2-b poll+dispatch loop (drives claim → adapter → resolve, and alerts on `findUnknownConsumerKeys`), S3 routing manifest + startup completeness assertion, S4 producer atomic enqueue, S5 consumer adapters + poison-terminal. Flag stays OFF; FWB / attachment / flag-enable remain gated until full implementation + the 8-scenario acceptance.

**For review — not self-merging runtime.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
