### PR TITLE
feat(web): G-10 follow-up — normal-user surfaces render display names over bare entity IDs (owner ruling 2026-07-15)

### DIFF
--- a/apps/web/src/multitable/import/xlsx-mapping.ts
+++ b/apps/web/src/multitable/import/xlsx-mapping.ts
@@ -116,9 +116,36 @@ export function parseXlsxBuffer(
 }
 
 /**
+ * Sanitize an arbitrary display string into a workbook tab name SheetJS will accept.
+ *
+ * G-10 follow-up (owner ruling 2026-07-15): exports name the xlsx tab after the sheet's DISPLAY
+ * name, so this boundary must tolerate hostile user-authored names. SheetJS 0.20.3's
+ * `check_ws_name` (called by `book_append_sheet`) THROWS on: names longer than 31 chars, the
+ * chars []:*?/\, a leading or trailing apostrophe, and the reserved name 'History'
+ * (case-insensitive — empirically verified against the pinned dependency). Rules applied in
+ * order: forbidden chars → spaces; trim; cap at 31; strip edge apostrophes (re-trim — the strip
+ * can expose new edge whitespace); reserved 'History' → 'History_' suffix (7 chars, so the
+ * suffix can never overflow the cap); empty → 'Sheet1'.
+ */
+export function safeXlsxSheetName(name: string | undefined): string {
+  const cleaned = (name ?? '')
+    .replace(/[\\/\[\]:*?]/g, ' ')
+    .trim()
+    .slice(0, 31)
+    .replace(/^'+|'+$/g, '')
+    .trim()
+  if (!cleaned) return 'Sheet1'
+  if (/^history$/i.test(cleaned)) return `${cleaned}_`
+  return cleaned
+}
+
+/**
  * Build an `.xlsx` Uint8Array (browser-safe) from a tabular dataset.
  * Headers row first, then string-coerced data rows. Caller is responsible
  * for typing/formatting via the `serialize` callback.
+ *
+ * The tab name is sanitized via `safeXlsxSheetName`, so this function never throws on a
+ * hostile `sheetName` (defense in depth: callers may pre-sanitize, but the boundary holds).
  */
 export function buildXlsxBuffer(
   xlsx: XlsxModule,
@@ -128,7 +155,7 @@ export function buildXlsxBuffer(
     rows: Array<Array<string | number | boolean | null | undefined>>
   },
 ): Uint8Array {
-  const sheetName = (params.sheetName?.trim() || 'Sheet1').slice(0, 31)
+  const sheetName = safeXlsxSheetName(params.sheetName)
   const aoa: unknown[][] = [params.headers.slice()]
   for (const row of params.rows) {
     aoa.push(row.map((cell) => (cell === undefined || cell === null ? '' : cell)))

--- a/apps/web/src/multitable/utils/meta-bulk-edit-labels.ts
+++ b/apps/web/src/multitable/utils/meta-bulk-edit-labels.ts
@@ -88,6 +88,21 @@ export function bulkFailure(failed: number, requested: number, sampleFailures: s
     : `${failed} of ${requested} ${recordWord(requested)} failed${detail}`
 }
 
+// G-10 follow-up (owner ruling 2026-07-15): the bulk-edit failure sample is a normal-user
+// dialog/toast surface, so each sampled failure leads with the record's display NAME. The caller
+// supplies the resolver over rows it ALREADY has loaded (zero new data paths, HI-1) — that
+// resolver's own fallback keeps the raw record id only when the row is no longer in scope.
+// Failure `reason` strings stay raw per this module's scope note above.
+export function bulkFailureSamples(
+  failures: ReadonlyArray<{ recordId: string; reason: string }>,
+  recordLabelOf: (recordId: string) => string,
+): string {
+  return failures
+    .slice(0, 3)
+    .map((failure) => `${recordLabelOf(failure.recordId)}: ${failure.reason}`)
+    .join('; ')
+}
+
 export function bulkVersionConflict(message: string, isZh: boolean): string {
   const detail = message ? (isZh ? `（${message}）` : ` (${message})`) : ''
   return isZh

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -610,6 +610,7 @@ import { recordLabel } from '../utils/meta-record-labels'
 import { resolveButtonFieldProperty } from '../utils/field-config'
 import {
   bulkFailure as fmtBulkFailure,
+  bulkFailureSamples as fmtBulkFailureSamples,
   bulkPartialSuccess as fmtBulkPartialSuccess,
   bulkSuccess as fmtBulkSuccess,
   bulkVersionConflict as fmtBulkVersionConflict,
@@ -3618,6 +3619,17 @@ function onGridSelectionChange(recordIds: string[]) {
 type GridExportField = (typeof scopedGridFields)['value'][number]
 type GridExportRow = (typeof grid.rows)['value'][number]
 
+// G-10 follow-up (owner ruling 2026-07-15): exports are a normal-user surface — the download
+// filename and the xlsx tab use the active sheet's display NAME (already in workbench.sheets
+// scope), never the bare sheetId. When no name resolves, the generic 'export' fallback is used
+// rather than the raw id (HI-1: zero new data paths). The server route path still wins when it
+// supplies a Content-Disposition filename (itself sheet-name based).
+const activeSheetExportName = computed(() => {
+  const id = workbench.activeSheetId.value
+  const name = id ? workbench.sheets.value.find((sheet) => sheet.id === id)?.name : undefined
+  return typeof name === 'string' && name.trim().length > 0 ? name.trim() : ''
+})
+
 function onExportCsv() { openExportDialog('csv') }
 async function onExportXlsx() { openExportDialog('xlsx') }
 
@@ -3654,14 +3666,14 @@ async function exportAllRowsViaRoute(fieldIds: string[], format: 'csv' | 'xlsx')
       fieldIds,
       format,
     })
-    triggerDownloadNamed(blob, filename || `${sheetId}.${format}`)
+    triggerDownloadNamed(blob, filename || `${activeSheetExportName.value || 'export'}.${format}`)
   } catch (err: any) {
     showError(err?.message ?? wb(format === 'csv' ? 'toast.csvExportFailed' : 'toast.excelExportFailed', isZh.value))
   }
 }
 
 function triggerDownload(blob: Blob, extension: string) {
-  triggerDownloadNamed(blob, `${workbench.activeSheetId.value || 'export'}.${extension}`)
+  triggerDownloadNamed(blob, `${activeSheetExportName.value || 'export'}.${extension}`)
 }
 
 // Download a blob under an exact filename (the server's Content-Disposition for the route path).
@@ -3709,7 +3721,10 @@ async function doExportXlsx(fields: GridExportField[], rowList: GridExportRow[])
         return String(v)
       }),
     )
-    const sheetName = (workbench.activeSheetId.value || 'export').slice(0, 31)
+    // Sheet display name for the xlsx tab (G-10 follow-up, same ruling as the filename above).
+    // Excel rejects []:*?/\ in tab names, so replace them; buildXlsxBuffer trims, slices to 31
+    // chars, and falls back to 'Sheet1' if the sanitized name comes out empty.
+    const sheetName = (activeSheetExportName.value || 'export').replace(/[\\/\[\]:*?]/g, ' ')
     const buffer = buildXlsxBuffer(xlsxModule, { sheetName, headers, rows })
     triggerDownload(new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }), 'xlsx')
   } catch (err: any) {
@@ -3877,10 +3892,10 @@ async function onBulkEditApply(payload: { mode: 'set' | 'clear'; fieldId: string
     const updatedCount = result.updated.length
     const requestedCount = payload.recordIds.length
     if (result.failed.length > 0) {
-      const sampleFailures = result.failed
-        .slice(0, 3)
-        .map((failure) => `${failure.recordId}: ${failure.reason}`)
-        .join('; ')
+      // G-10 follow-up (owner ruling 2026-07-15): normal-user surface — each sampled failure leads
+      // with the record's display name (bulkFillRecordName over the already-loaded rows; its own
+      // fallback keeps the raw id only when the row is no longer loaded). Zero new fetches.
+      const sampleFailures = fmtBulkFailureSamples(result.failed, bulkFillRecordName)
       bulkEditDialog.error = fmtBulkFailure(result.failed.length, requestedCount, sampleFailures, isZh.value)
       if (updatedCount > 0) {
         bulkEditDialog.resultMessage = fmtBulkPartialSuccess(updatedCount, requestedCount, payload.mode, isZh.value)

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -3722,10 +3722,9 @@ async function doExportXlsx(fields: GridExportField[], rowList: GridExportRow[])
       }),
     )
     // Sheet display name for the xlsx tab (G-10 follow-up, same ruling as the filename above).
-    // Excel rejects []:*?/\ in tab names, so replace them; buildXlsxBuffer trims, slices to 31
-    // chars, and falls back to 'Sheet1' if the sanitized name comes out empty.
-    const sheetName = (activeSheetExportName.value || 'export').replace(/[\\/\[\]:*?]/g, ' ')
-    const buffer = buildXlsxBuffer(xlsxModule, { sheetName, headers, rows })
+    // buildXlsxBuffer's safeXlsxSheetName owns ALL SheetJS tab-name rules (forbidden chars,
+    // 31-char cap, edge apostrophes, reserved 'History') — a hostile display name can't throw.
+    const buffer = buildXlsxBuffer(xlsxModule, { sheetName: activeSheetExportName.value || 'export', headers, rows })
     triggerDownload(new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }), 'xlsx')
   } catch (err: any) {
     showError(err?.message ?? wb('toast.excelExportFailed', isZh.value))

--- a/apps/web/tests/meta-bulk-edit-labels.spec.ts
+++ b/apps/web/tests/meta-bulk-edit-labels.spec.ts
@@ -5,6 +5,7 @@ import {
   bulkClearHintSuffix,
   bulkEditLabel,
   bulkFailure,
+  bulkFailureSamples,
   bulkPartialSuccess,
   bulkSuccess,
   bulkSummary,
@@ -45,6 +46,31 @@ describe('meta-bulk-edit-labels', () => {
     expect(bulkFailure(1, 3, '', false)).toBe('1 of 3 records failed')
     expect(bulkFailure(1, 3, 'rec_1: conflict', true)).toBe('3 条记录中有 1 条失败（rec_1: conflict）')
     expect(bulkFailure(1, 3, '', true)).toBe('3 条记录中有 1 条失败')
+  })
+
+  // G-10 follow-up (owner ruling 2026-07-15): the failure sample is a normal-user surface — each
+  // sampled failure leads with the record's display NAME (resolved by the caller from rows already
+  // in scope); the raw record id appears only when the caller's resolver itself falls back to it.
+  it('bulkFailureSamples leads each sample with the resolved record name', () => {
+    const labels: Record<string, string> = { rec_1: 'Alpha', rec_2: 'Beta' }
+    const resolve = (id: string) => labels[id] ?? id
+    expect(bulkFailureSamples([{ recordId: 'rec_1', reason: 'locked' }], resolve)).toBe('Alpha: locked')
+    expect(bulkFailureSamples(
+      [
+        { recordId: 'rec_1', reason: 'locked' },
+        { recordId: 'rec_2', reason: 'conflict' },
+      ],
+      resolve,
+    )).toBe('Alpha: locked; Beta: conflict')
+    // Resolver fallback (row no longer loaded) keeps the raw id — honest, not fabricated.
+    expect(bulkFailureSamples([{ recordId: 'rec_gone', reason: 'missing' }], resolve)).toBe('rec_gone: missing')
+  })
+
+  it('bulkFailureSamples caps the sample at 3 failures', () => {
+    const failures = ['rec_1', 'rec_2', 'rec_3', 'rec_4'].map((id) => ({ recordId: id, reason: 'x' }))
+    const sample = bulkFailureSamples(failures, (id) => id.toUpperCase())
+    expect(sample).toBe('REC_1: x; REC_2: x; REC_3: x')
+    expect(sample).not.toContain('REC_4')
   })
 
   it('formats version conflicts without empty parentheses', () => {

--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -3,6 +3,15 @@ import { computed, createApp, defineComponent, h, nextTick, reactive, ref, type 
 
 const showErrorSpy = vi.fn()
 const showSuccessSpy = vi.fn()
+// G-10 follow-up: captures the xlsx tab name the export path passes down, without writing a real
+// workbook (buildXlsxBuffer's own trim/slice/default behavior is covered by multitable/xlsx-mapping.test.ts).
+// vi.hoisted: the mocked module is imported synchronously by MultitableWorkbench.vue, so a plain
+// top-level const would still be in its TDZ when the factory runs.
+const { buildXlsxBufferMock } = vi.hoisted(() => ({ buildXlsxBufferMock: vi.fn(() => new Uint8Array([1, 2, 3])) }))
+vi.mock('../src/multitable/import/xlsx-mapping', async () => {
+  const actual = await vi.importActual<any>('../src/multitable/import/xlsx-mapping')
+  return { ...actual, buildXlsxBuffer: buildXlsxBufferMock }
+})
 const pushSpy = vi.fn().mockResolvedValue(undefined)
 const useMultitableSheetRealtimeMock = vi.fn()
 // The workflow-designer manager button is gated on caps.canManageAutomation AND
@@ -296,7 +305,7 @@ vi.mock('../src/multitable/components/MetaGridTable.vue', () => ({
       collapsedGroupKeys: { type: Array, default: () => [] },
       rowDensity: { type: String, default: undefined },
     },
-    emits: ['select-record', 'open-comments', 'open-field-comments', 'resize-column', 'toggle-group'],
+    emits: ['select-record', 'open-comments', 'open-field-comments', 'resize-column', 'toggle-group', 'bulk-edit', 'selection-change'],
     render() {
       return h('div', {
         'data-grid-column-widths': JSON.stringify(this.$props.columnWidths ?? {}),
@@ -350,6 +359,22 @@ vi.mock('../src/multitable/components/MetaGridTable.vue', () => ({
             onClick: () => this.$emit('toggle-group', 'todo'),
           },
           'toggle-group',
+        ),
+        h(
+          'button',
+          {
+            'data-bulk-edit': 'true',
+            onClick: () => this.$emit('bulk-edit', { mode: 'clear', recordIds: ['rec_1'] }),
+          },
+          'bulk-edit',
+        ),
+        h(
+          'button',
+          {
+            'data-select-rows': 'rec_1',
+            onClick: () => this.$emit('selection-change', ['rec_1']),
+          },
+          'selection-change',
         ),
       ])
     },
@@ -1093,6 +1118,7 @@ function createGridMock() {
     setGroupField: vi.fn(), setGroupFields: vi.fn(),
     goToPage: vi.fn(),
     patchCell: vi.fn(),
+    bulkPatch: vi.fn(),
     createRecord: vi.fn(),
     deleteRecord: vi.fn(),
     mergeRemoteRecord: vi.fn().mockReturnValue(true),
@@ -1559,6 +1585,114 @@ describe('MultitableWorkbench view wiring', () => {
       Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
       Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
     }
+  })
+
+  // G-10 follow-up (owner ruling 2026-07-15, 普通用户面优先显示名称): the export download filename is a
+  // normal-user surface. When the backend route returns no Content-Disposition filename, the fallback
+  // must be the active sheet's display NAME ('Orders', already in workbench.sheets scope) — never the
+  // raw sheet id ('sheet_orders').
+  it('export filename fallback uses the sheet display name, not the raw sheet id', async () => {
+    workbenchMock.client.exportSheet.mockResolvedValue({
+      blob: new Blob(['Title\nAlpha'], { type: 'text/csv' }),
+      filename: '',
+    })
+    const downloads: string[] = []
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: vi.fn(() => 'blob:multitable-export') })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: vi.fn() })
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+      downloads.push(this.download)
+    })
+    try {
+      mountWorkbench()
+      await flushUi()
+
+      container!.querySelector<HTMLButtonElement>('[data-export-csv="true"]')!.click()
+      await flushUi()
+      document.body.querySelector<HTMLButtonElement>('.meta-export__btn--primary')!.click()
+      await flushUi()
+
+      expect(downloads).toEqual(['Orders.csv'])
+    } finally {
+      clickSpy.mockRestore()
+      Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
+      Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
+    }
+  })
+
+  // G-10 follow-up: the selected-rows client-side export path names BOTH the downloaded file and the
+  // xlsx workbook tab after the sheet's display name (previously both were the raw sheet id).
+  it('selected-rows xlsx export names the file and the workbook tab after the sheet display name', async () => {
+    const downloads: string[] = []
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: vi.fn(() => 'blob:multitable-export') })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: vi.fn() })
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+      downloads.push(this.download)
+    })
+    buildXlsxBufferMock.mockClear()
+    try {
+      mountWorkbench()
+      await flushUi()
+
+      // Select a row (grid multi-select), then open the export dialog and switch to selected+xlsx.
+      container!.querySelector<HTMLButtonElement>('[data-select-rows="rec_1"]')!.click()
+      await flushUi()
+      container!.querySelector<HTMLButtonElement>('[data-export-csv="true"]')!.click()
+      await flushUi()
+      const selectedRadio = document.body.querySelector<HTMLInputElement>('.meta-export__opt input[value="selected"]')
+      expect(selectedRadio).not.toBeNull()
+      expect(selectedRadio!.disabled).toBe(false)
+      selectedRadio!.click()
+      document.body.querySelector<HTMLInputElement>('.meta-export__opt input[value="xlsx"]')!.click()
+      await flushUi()
+      document.body.querySelector<HTMLButtonElement>('.meta-export__btn--primary')!.click()
+      // The xlsx path lazily `import('xlsx')` before building — module loading can take macrotask
+      // time, so poll (bounded) rather than relying on microtask flushes alone.
+      for (let i = 0; i < 100 && downloads.length === 0; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        await flushUi()
+      }
+
+      expect(downloads).toEqual(['Orders.xlsx'])
+      expect(buildXlsxBufferMock).toHaveBeenCalledTimes(1)
+      expect(buildXlsxBufferMock.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ sheetName: 'Orders' }))
+    } finally {
+      clickSpy.mockRestore()
+      Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
+      Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
+    }
+  })
+
+  // G-10 follow-up: bulk-edit failure samples (dialog error + toast, normal-user surfaces) lead with
+  // the record's display name resolved from the already-loaded rows ('rec_1' → its Title value
+  // 'Alpha'), never the bare record id. The reason string stays raw.
+  it('bulk-edit failure samples lead with the record display name, not the raw record id', async () => {
+    gridMock.bulkPatch.mockResolvedValue({
+      updated: [],
+      failed: [{ recordId: 'rec_1', reason: 'locked' }],
+    })
+    mountWorkbench()
+    await flushUi()
+
+    container!.querySelector<HTMLButtonElement>('[data-bulk-edit="true"]')!.click()
+    await flushUi()
+    // Real MetaBulkEditDialog (teleported): clear mode only needs a field selection to submit.
+    const fieldSelect = document.body.querySelector<HTMLSelectElement>('.meta-bulk-edit__select')
+    expect(fieldSelect).not.toBeNull()
+    fieldSelect!.value = 'fld_title'
+    fieldSelect!.dispatchEvent(new Event('change'))
+    await flushUi()
+    document.body.querySelector<HTMLButtonElement>('.meta-bulk-edit__btn--primary')!.click()
+    await flushUi()
+
+    expect(gridMock.bulkPatch).toHaveBeenCalledWith({ fieldId: 'fld_title', value: null, recordIds: ['rec_1'] })
+    const errorEl = document.body.querySelector('.meta-bulk-edit__error')
+    expect(errorEl?.textContent).toContain('Alpha: locked')
+    expect(errorEl?.textContent).not.toContain('rec_1')
+    expect(showErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Alpha: locked'))
   })
 
   it('syncs external base/sheet/view props after mount', async () => {

--- a/apps/web/tests/multitable/xlsx-mapping.test.ts
+++ b/apps/web/tests/multitable/xlsx-mapping.test.ts
@@ -7,6 +7,7 @@ import {
   buildXlsxBuffer,
   mapXlsxColumnsToFields,
   parseXlsxBuffer,
+  safeXlsxSheetName,
 } from '../../src/multitable/import/xlsx-mapping'
 
 const xlsxModule = XLSX as unknown as Parameters<typeof parseXlsxBuffer>[0]
@@ -137,6 +138,57 @@ describe('xlsx-mapping helpers', () => {
       })
       const parsed = parseXlsxBuffer(xlsxModule, buffer)
       expect(parsed.sheetName.length).toBeLessThanOrEqual(31)
+    })
+
+    // G-10 follow-up hardening: exports now name the tab after the sheet's user-authored DISPLAY
+    // name, and SheetJS's check_ws_name (real module, no mocks here) THROWS on the reserved name
+    // 'History' (case-insensitive), on leading/trailing apostrophes, and on []:*?/\ chars. These
+    // goldens drive the REAL write path end-to-end: build must not throw and the tab must be valid.
+    it.each([
+      ['History', 'History_'],
+      ['history', 'history_'],
+      ['HISTORY', 'HISTORY_'],
+      ["'Plan", 'Plan'],
+      ["Plan'", 'Plan'],
+      ["'History'", 'History_'], // edge-apostrophe strip must happen BEFORE the reserved check
+      ['Q1/Q2: [draft]?*', 'Q1 Q2   draft'],
+      ["''", 'Sheet1'], // nothing left after stripping ⇒ default
+    ])('writes a real workbook for hostile sheet name %j (tab %j)', (hostile, expectedTab) => {
+      const buffer = buildXlsxBuffer(xlsxModule, {
+        sheetName: hostile,
+        headers: ['x'],
+        rows: [['1']],
+      })
+      const parsed = parseXlsxBuffer(xlsxModule, buffer)
+      expect(parsed.sheetName).toBe(expectedTab)
+      expect(parsed.rows).toEqual([['1']])
+    })
+
+    it('keeps interior apostrophes and ordinary names untouched', () => {
+      const buffer = buildXlsxBuffer(xlsxModule, {
+        sheetName: "Bob's Orders",
+        headers: ['x'],
+        rows: [['1']],
+      })
+      expect(parseXlsxBuffer(xlsxModule, buffer).sheetName).toBe("Bob's Orders")
+    })
+  })
+
+  describe('safeXlsxSheetName', () => {
+    it('applies rules in order: chars → trim → cap → edge apostrophes → reserved → default', () => {
+      expect(safeXlsxSheetName('Orders')).toBe('Orders')
+      expect(safeXlsxSheetName(undefined)).toBe('Sheet1')
+      expect(safeXlsxSheetName('   ')).toBe('Sheet1')
+      expect(safeXlsxSheetName('History')).toBe('History_')
+      expect(safeXlsxSheetName('hIsToRy')).toBe('hIsToRy_')
+      expect(safeXlsxSheetName("'Plan'")).toBe('Plan')
+      expect(safeXlsxSheetName("' History '")).toBe('History_')
+      expect(safeXlsxSheetName('a/b\\c[d]e:f*g?h')).toBe('a b c d e f g h')
+      // The cap applies before the apostrophe strip, so a cut exposing an edge apostrophe is
+      // still stripped; the result stays within 31 chars.
+      const cut = safeXlsxSheetName(`${'a'.repeat(30)}'x`)
+      expect(cut).toBe('a'.repeat(30))
+      expect(cut.length).toBeLessThanOrEqual(31)
     })
   })
 


### PR DESCRIPTION
Owner ruling (G-10 定稿 2026-07-15): rule-editor / admin technical surfaces keep `数据表 ID` labels with raw IDs (already correct); **normal-user surfaces show display NAMES, not bare sheetId/baseId/viewId/recordId values**.

Full audit sweep of `apps/web/src/multitable/**` (plus the multitable views under `apps/web/src/views/`) for raw entity-ID values interpolated into visible text. Non-display usages (`:key` bindings, API paths, postMessage plumbing, map keys) were excluded as non-surfaces.

## Fixed — 4 surfaces (names already in component scope; zero new data paths)

| # | Surface | Before | After |
|---|---|---|---|
| F1 | Export (all rows) download filename fallback — `MultitableWorkbench.vue` `exportAllRowsViaRoute` | `filename \|\| \`${sheetId}.${format}\`` → e.g. `sheet_orders.csv` when the route omits Content-Disposition | Sheet display name via new `activeSheetExportName` computed (from `workbench.sheets`, already loaded) → `Orders.csv`; generic `export` when no name resolves — never the raw id |
| F2 | Export (selected rows) download filename — `triggerDownload` | `\`${activeSheetId \|\| 'export'}.${ext}\`` — **always** the raw sheetId | `\`${activeSheetExportName \|\| 'export'}.${ext}\`` |
| F3 | xlsx workbook tab name — `doExportXlsx` | `activeSheetId.slice(0, 31)` — **always** the raw sheetId | Sheet display name, sanitized by the new `safeXlsxSheetName` boundary in `buildXlsxBuffer` (see hardening below) |
| F4 | Bulk-edit failure samples (dialog error + toast) — `onBulkEditApply` | `\`${failure.recordId}: ${failure.reason}\`` | New `bulkFailureSamples(failures, recordLabelOf)` helper (`meta-bulk-edit-labels.ts`) called with the existing `bulkFillRecordName` resolver over the already-loaded rows; the raw id appears only when the row is no longer loaded (honest fallback). Reason strings stay raw. |

### Gate P2 hardening (second commit)

The gate confirmed SheetJS 0.20.3's `check_ws_name` ALSO throws on the reserved tab name `History` (case-insensitive) and on leading/trailing apostrophes — a display name like `History` or `'Plan` would have made `buildXlsxBuffer` throw (export fails with the excelExportFailed toast). The pre-G-10 raw `sheet_…` ids could never hit this; the display-name change introduced the surface. Fixed with both gate-suggested legs:

- `safeXlsxSheetName()` (`xlsx-mapping.ts`) owns ALL tab-name rules, in order: forbidden chars → trim → 31-char cap → edge-apostrophe strip (re-trim) → reserved `History` → `History_` suffix → empty → `Sheet1`.
- `buildXlsxBuffer` sanitizes at the boundary itself (defense in depth — no caller can make it throw on a hostile name); the workbench's local partial regex was removed in favor of the single boundary owner.
- Goldens with the REAL xlsx module (no `buildXlsxBuffer` mock): `History`/`history`/`HISTORY`, edge apostrophes, `'History'` (strip-before-reserved ordering), forbidden chars, all-apostrophes → all write a real workbook with a valid tab; interior apostrophes preserved; plus direct `safeXlsxSheetName` units. The SheetJS rejection surface was empirically reproduced against the pinned dependency before fixing, and dropping either the reserved-name branch or the apostrophe strip reddens 5 tests each (mutation landing grep-confirmed).

Spec pins (all in the required `web-tests` lane):
- `meta-bulk-edit-labels.spec.ts` +2: `bulkFailureSamples` name-leading rendering, resolver fallback, 3-sample cap.
- `multitable-workbench-view.spec.ts` +3 integration: filename fallback = `Orders.csv` (not `sheet_orders.csv`); selected-rows xlsx = `Orders.xlsx` download + `sheetName: 'Orders'` into `buildXlsxBuffer`; bulk-failure sample = `Alpha: locked` (record title), not `rec_1: locked`, in both dialog error and toast.
- All three integration pins are mutation-verified: reverting each fix independently reddens exactly its test (mutation landing confirmed by grep before each run).

## Left — name genuinely not in scope (HI-1: zero new data paths — listed, not fetched)

| Surface | Renders today | Why left |
|---|---|---|
| `apps/web/src/views/MultitableCommentInboxView.vue:37-41` — comment-inbox card meta line (normal-user) | `Base {baseId}` · `Sheet {sheetId}` · `Row {recordId}` · `View {viewId}` · `Field {fieldId}` — five raw ids | The inbox payload carries **no names**: `CommentService.getInbox` already joins `meta_sheets as s` but projects only ids. Rendering names needs a server projection change (or a per-sheet client fetch) = a new data path. **Top follow-up candidate** — projecting `s.name` server-side is small. |
| `MultitableWorkbench.vue` `recordNotFound` toast (deep-link open-record failure) | `未找到记录：rec_xxx` | Record is genuinely gone (404) — no name exists anywhere; recordId in deep-link display is an accepted technical context. Existing pin `multitable-workbench-i18n.spec.ts` ("keeps record id raw") intentionally unchanged. |

## Left — already name-first (raw id only as last-resort fallback; no change)

- `HistoryBatchChangesList.vue` / `TrashModal.vue` — record title via `pickRecordTitle`, `#shortid` fallback, full id only in the tooltip/title attr (technical affordance).
- Workbench `bulkFillRecordName` / `batchRecordLabel` (+ `gridSelectionLabels` capture) / `configHistoryLabelOf` — resolve names from loaded rows/fields/views first; bare id only for off-page rows (a name would require a fetch).
- `MetaLinkPicker.vue` `{{ item.display || item.id }}` — display server-resolved from the foreign sheet's display field; raw id only when the record has no readable display value (empty display); it is the only differentiator between such rows.

## Intentionally left — admin/technical surfaces (owner ruled these stay technical)

- `meta-automation-labels.ts` rule-editor config labels (`目标数据表 ID` / `数据表 ID` / field-ID placeholders) and the manual sheet-ID entry escape hatch.
- Automation Runs admin panel (`runs.sheetFilter` 表 ID + `AutomationExecutionsView.vue`, admin-gated).
- `meta-api-token-labels.ts` `apiDingTalkScopeLabel` sheet-scope chip (`…: {sheetId}`) — API Tokens & Webhooks manager, identifiers surface.
- Public-form URL construction/display (`MetaFormShareManager` / `MetaAutomationManager`) — deep-link display; URLs carry ids by design.

Out of the ruling's entity set (userIds, noted for completeness): `historyActor` `由 {actorId}` (record history / trash deletedBy), `HistoryCenterModal` `actorLabel` (name-first already), `MetaPersonPicker` `display || id` — no client-side user directory; would need a fetch.

## Cleared (no raw entity-ID visible text found)

Automation log/delivery viewers; AutomationManager/RuleEditor/ConditionalRuleBuilder templates; NotificationBell; LinkedRecordPopover; FormView; cell renderer/editor; Calendar/Gantt/Timeline/Hierarchy/Dashboard/Gallery/Kanban views; ImportModal; HistoryCenterModal chrome; Field/View managers; BasePicker; SheetViewRail; Reset dialogs; Record/Sheet permission managers; CommentsDrawer; AI bulk-fill dialog and RestoreBatchDialog (name-first via props); automationActionSummary; test-run messages; EmbedHost (plumbing only); Home/TemplateCenter/TemplateDetail/PublicForm views.

## Verification

- Rebased onto current main; `bash apps/web/scripts/run-required-web-tests.sh` — 336 files / 3934 tests, exit 0 (includes all new tests).
- `vue-tsc -b` — clean.
- Positive controls: each of the three workbench-level fixes AND both legs of the tab-name sanitizer (reserved-name branch, apostrophe strip) were individually reverted and their tests confirmed red before restoring.

EN locale, admin advanced settings, rule-editor config, and API/key/identifier surfaces untouched per the ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
