### PR TITLE
fix(attendance): support staging Compose re-normalization

### DIFF
--- a/.github/workflows/attendance-staging-window-runner.yml
+++ b/.github/workflows/attendance-staging-window-runner.yml
@@ -62,6 +62,11 @@ on:
         type: choice
         options: [none, rd-window]
         default: none
+      force_recreate:
+        description: 'deploy only: recreate backend+web even when image/config content is unchanged (used to re-stamp persistent Compose config_files labels). Postgres/Redis remain excluded.'
+        required: false
+        type: boolean
+        default: false
       skip_host_sync:
         description: 'skip the deploy-host repo git sync before smoke (true/false)'
         required: false
@@ -87,6 +92,7 @@ jobs:
           ACTION: ${{ inputs.action }}
           DEPLOY_SHA: ${{ inputs.deploy_sha }}
           SET_WINDOW_ENV: ${{ inputs.set_window_env }}
+          FORCE_RECREATE: ${{ inputs.force_recreate }}
           STAMPS: ${{ inputs.stamps }}
         run: |
           set -euo pipefail
@@ -99,6 +105,11 @@ jobs:
           fi
           if [[ "$ACTION" != "deploy" && "$SET_WINDOW_ENV" != "none" ]]; then
             echo "set_window_env=$SET_WINDOW_ENV is only meaningful for action=deploy (env flips happen together with the deploy, never mid-smoke — bundle §3.4)" >&2
+            exit 2
+          fi
+          case "$FORCE_RECREATE" in true|false) ;; *) echo "force_recreate must be true or false, got: '$FORCE_RECREATE'" >&2; exit 2 ;; esac
+          if [[ "$ACTION" != "deploy" && "$FORCE_RECREATE" == "true" ]]; then
+            echo "force_recreate=true is only allowed for action=deploy" >&2
             exit 2
           fi
           if [[ "$ACTION" == "residue-sweep" ]]; then
@@ -157,6 +168,7 @@ jobs:
           DEPLOY_SHA: ${{ inputs.deploy_sha }}
           SMOKE_ID: ${{ inputs.smoke }}
           SET_WINDOW_ENV: ${{ inputs.set_window_env }}
+          FORCE_RECREATE: ${{ inputs.force_recreate }}
           SKIP_HOST_SYNC: ${{ inputs.skip_host_sync }}
           STAMPS: ${{ inputs.stamps }}
           RUNNER_DIR: ${{ steps.sync.outputs.runner_dir }}
@@ -183,6 +195,7 @@ jobs:
           export DEPLOY_SHA='${DEPLOY_SHA}'
           export SMOKE_ID='${SMOKE_ID}'
           export SET_WINDOW_ENV='${SET_WINDOW_ENV}'
+          export FORCE_RECREATE='${FORCE_RECREATE}'
           export STAGING_DEPLOY_PATH='${STAGING_DEPLOY_PATH}'
           export DEPLOY_PATH='${DEPLOY_PATH}'
           export SKIP_HOST_SYNC='${SKIP_HOST_SYNC}'
@@ -227,6 +240,7 @@ jobs:
           SMOKE_ID: ${{ inputs.smoke }}
           DEPLOY_SHA: ${{ inputs.deploy_sha }}
           SET_WINDOW_ENV: ${{ inputs.set_window_env }}
+          FORCE_RECREATE: ${{ inputs.force_recreate }}
           STAMPS: ${{ inputs.stamps }}
         run: |
           set -euo pipefail
@@ -238,6 +252,7 @@ jobs:
             if [[ "$ACTION" == "residue-sweep" ]]; then echo "- Stamps: \`${STAMPS:-<none>}\`"; fi
             echo "- Deploy SHA: \`${DEPLOY_SHA:-<none>}\`"
             echo "- Window env: \`${SET_WINDOW_ENV}\`"
+            echo "- Force recreate: \`${FORCE_RECREATE}\`"
             echo "- Remote rc: \`${REMOTE_RC:-missing}\`"
             echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`"
             if [[ -f output/window-runner/summary.txt ]]; then

--- a/scripts/ops/attendance-staging-window-runner-remote.sh
+++ b/scripts/ops/attendance-staging-window-runner-remote.sh
@@ -65,6 +65,7 @@ ACTION="${ACTION:?ACTION is required (deploy|smoke|status|migrate|residue-sweep)
 DEPLOY_SHA="${DEPLOY_SHA:-}"
 SMOKE_ID="${SMOKE_ID:-}"
 SET_WINDOW_ENV="${SET_WINDOW_ENV:-none}"
+FORCE_RECREATE="${FORCE_RECREATE:-false}"
 STAMPS="${STAMPS:-}"
 STAGING_DEPLOY_PATH="${STAGING_DEPLOY_PATH:-metasheet2-dingtalk-staging}"
 DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
@@ -72,6 +73,14 @@ SKIP_HOST_SYNC="${SKIP_HOST_SYNC:-false}"
 OUTPUT_DIR="${OUTPUT_DIR:?OUTPUT_DIR is required}"
 IMAGE_OWNER="${IMAGE_OWNER:-zensgit}"
 RUN_STAMP="${RUN_STAMP:?RUN_STAMP is required (workflow run id marker)}"
+
+case "$FORCE_RECREATE" in
+  true|false) ;;
+  *) fail "FORCE_RECREATE must be true or false, got: '${FORCE_RECREATE}'" ;;
+esac
+if [[ "$ACTION" != "deploy" && "$FORCE_RECREATE" == "true" ]]; then
+  fail "FORCE_RECREATE=true is only allowed for action=deploy"
+fi
 
 BACKEND_CONTAINER="metasheet-staging-backend"
 WEB_CONTAINER="metasheet-staging-web"
@@ -382,7 +391,12 @@ action_deploy() {
 
   compose_staging pull backend web 2>&1 | tee "${OUTPUT_DIR}/compose-pull.log"
   # NEVER recreate postgres/redis: only backend+web, --no-deps.
-  compose_staging up -d --no-deps backend web 2>&1 | tee "${OUTPUT_DIR}/compose-up.log"
+  local -a up_args=(up -d --no-deps)
+  if [[ "$FORCE_RECREATE" == "true" ]]; then
+    up_args+=(--force-recreate)
+  fi
+  up_args+=(backend web)
+  compose_staging "${up_args[@]}" 2>&1 | tee "${OUTPUT_DIR}/compose-up.log"
 
   local pg_id_after redis_id_after
   pg_id_after="$(docker inspect -f '{{.Id}}' "$POSTGRES_CONTAINER")"
@@ -429,6 +443,7 @@ action_deploy() {
     echo "action=deploy"
     echo "deploy_sha=${DEPLOY_SHA}"
     echo "set_window_env=${SET_WINDOW_ENV}"
+    echo "force_recreate=${FORCE_RECREATE}"
     echo "backend_image=${backend_image}"
     echo "web_image=${web_image}"
     echo "result=ok"

--- a/scripts/ops/attendance-window-runner-pipeline.test.mjs
+++ b/scripts/ops/attendance-window-runner-pipeline.test.mjs
@@ -353,3 +353,34 @@ test('persistent override: POSITIVE CONTROL — the exact mktemp template REALLY
   assert.notEqual(p1, p2, 'two mktemp calls produced the SAME path — not randomized')
   assert.ok(existsSync(p1) && existsSync(p2), 'mktemp did not actually create the candidate files')
 })
+
+test('persistent override re-normalization: force_recreate is an explicit deploy-only boolean that defaults off', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8')
+  assert.match(
+    workflow,
+    /force_recreate:\n\s+description:[^\n]+\n\s+required: false\n\s+type: boolean\n\s+default: false/,
+    'force_recreate must be a boolean workflow input and default to false',
+  )
+  assert.match(
+    workflow,
+    /if \[\[ "\$ACTION" != "deploy" && "\$FORCE_RECREATE" == "true" \]\]; then\n\s+echo "force_recreate=true is only allowed for action=deploy"/,
+    'workflow input validation must reject force_recreate on non-deploy actions',
+  )
+  assert.match(workflow, /export FORCE_RECREATE='\$\{FORCE_RECREATE\}'/, 'validated force_recreate must reach the remote script')
+})
+
+test('persistent override re-normalization: force mode adds --force-recreate while the service set stays exactly backend+web', () => {
+  const remote = readFileSync(REMOTE_SH, 'utf8')
+  const start = remote.indexOf('action_deploy() {')
+  const end = remote.indexOf('\naction_smoke() {', start)
+  assert.ok(start !== -1 && end > start, 'expected action_deploy() bounds')
+  const deploy = remote.slice(start, end)
+  assert.match(deploy, /local -a up_args=\(up -d --no-deps\)/, 'deploy must retain --no-deps')
+  assert.match(
+    deploy,
+    /if \[\[ "\$FORCE_RECREATE" == "true" \]\]; then\n\s+up_args\+=\(--force-recreate\)\n\s+fi/,
+    'force mode must add the load-bearing --force-recreate option',
+  )
+  assert.match(deploy, /up_args\+=\(backend web\)\n\s+compose_staging "\$\{up_args\[@\]\}"/, 'the only recreated services must be backend and web')
+  assert.doesNotMatch(deploy, /up_args\+=\([^\n]*(?:postgres|redis)/, 'postgres/redis must never enter the recreate service list')
+})


### PR DESCRIPTION
## What changed

- add an explicit deploy-only `force_recreate` workflow input, defaulting to `false`
- pass it through strict validation to the remote runner
- when enabled, run `docker compose up -d --no-deps --force-recreate backend web`
- preserve the existing postgres/redis container-ID assertions and record the mode in artifacts
- add source-contract goldens for default-off, deploy-only, force-recreate, and the exact backend/web service set

## Why

PR #4316 moved the Window Runner override to a persistent path, but an unchanged image and rendered configuration may leave existing staging containers untouched. Their old `com.docker.compose.project.config_files` labels would then continue to reference the deleted per-run `/tmp` override. This opt-in performs the one-time container re-normalization needed before the Time Machine containment check can verify staging next-restart state.

## Safety

- default behavior is unchanged
- the option is rejected for non-deploy actions
- only backend and web are eligible for recreation; `--no-deps` remains mandatory
- postgres and redis IDs are asserted unchanged after deploy
- no Time Machine flag is changed by this PR

## Verification

- `bash -n scripts/ops/attendance-staging-window-runner-remote.sh`
- `node --test scripts/ops/attendance-window-runner-pipeline.test.mjs` (23/23)
- Ruby YAML syntax parse
- mutation proof: replacing `up_args+=(--force-recreate)` with a no-op makes exactly the new force-mode golden fail; restoring it returns 23/23 green
