### PR TITLE
feat(multitable): comment inbox cards render entity display names (server projection + name-first FE) — G-10 follow-up

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -352,6 +352,11 @@ type RawInboxItem = RawComment & {
   sheetId?: string | null
   viewId?: string | null
   recordId?: string | null
+  // G-10 (docket #68): additive display names alongside the ids above.
+  baseName?: string | null
+  sheetName?: string | null
+  viewName?: string | null
+  fieldName?: string | null
 }
 
 type MultitableCommentIdentityPayload = {
@@ -515,6 +520,13 @@ function normalizeCommentInbox(payload: { items?: RawInboxItem[]; total?: number
             : typeof item.rowId === 'string'
               ? item.rowId
               : null,
+          // G-10 (docket #68): additive display names — string-or-null pass-through, same shape
+          // discipline as the id fields above; anything else (missing key, wrong type) normalizes to
+          // null so the FE's `name ?? id` fallback always has a defined id to fall back to.
+          baseName: typeof item.baseName === 'string' || item.baseName === null ? item.baseName : null,
+          sheetName: typeof item.sheetName === 'string' || item.sheetName === null ? item.sheetName : null,
+          viewName: typeof item.viewName === 'string' || item.viewName === null ? item.viewName : null,
+          fieldName: typeof item.fieldName === 'string' || item.fieldName === null ? item.fieldName : null,
         })) as MultitableCommentInboxItem[]
       : [],
     total: typeof payload.total === 'number' ? payload.total : 0,

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -659,6 +659,16 @@ export interface MultitableCommentInboxItem extends MultitableComment {
   sheetId?: string | null
   viewId?: string | null
   recordId?: string | null
+  /**
+   * G-10 (docket #68): server-projected display name for the matching id, when resolvable.
+   * Additive — the id fields above are unchanged. Render name-first with an id fallback
+   * (`baseName ?? baseId`, same pattern as the existing `authorName ?? authorId`); `recordId` has no
+   * `recordName` counterpart (no cheap server-side record-title resolver exists yet).
+   */
+  baseName?: string | null
+  sheetName?: string | null
+  viewName?: string | null
+  fieldName?: string | null
 }
 
 export type MetaCommentInboxItem = MultitableCommentInboxItem

--- a/apps/web/src/views/MultitableCommentInboxView.vue
+++ b/apps/web/src/views/MultitableCommentInboxView.vue
@@ -34,11 +34,11 @@
           <div>
             <strong>{{ item.authorName ?? item.authorId }}</strong>
             <p class="mt-comment-inbox__meta">
-              <span v-if="item.baseId">Base {{ item.baseId }}</span>
-              <span>Sheet {{ resolveItemSheetId(item) }}</span>
+              <span v-if="item.baseId" :title="item.baseId">Base {{ item.baseName ?? item.baseId }}</span>
+              <span :title="resolveItemSheetId(item)">Sheet {{ item.sheetName ?? resolveItemSheetId(item) }}</span>
               <span>Row {{ resolveItemRecordId(item) }}</span>
-              <span v-if="item.viewId">View {{ item.viewId }}</span>
-              <span v-if="resolveItemFieldId(item)">Field {{ resolveItemFieldId(item) }}</span>
+              <span v-if="item.viewId" :title="item.viewId">View {{ item.viewName ?? item.viewId }}</span>
+              <span v-if="resolveItemFieldId(item)" :title="resolveItemFieldId(item) ?? undefined">Field {{ item.fieldName ?? resolveItemFieldId(item) }}</span>
             </p>
           </div>
           <div class="mt-comment-inbox__flags">

--- a/apps/web/tests/multitable-client.spec.ts
+++ b/apps/web/tests/multitable-client.spec.ts
@@ -420,6 +420,13 @@ describe('MultitableApiClient', () => {
         sheetId: 'sheet_1',
         viewId: 'view_1',
         recordId: 'row_1',
+        // G-10 (docket #68): additive display names — absent from this fixture's raw payload, so
+        // normalizeCommentInbox falls back to null (never undefined, so the FE's `name ?? id`
+        // pattern always has a defined id to fall back to).
+        baseName: null,
+        sheetName: null,
+        viewName: null,
+        fieldName: null,
         spreadsheetId: 'sheet_1',
         rowId: 'row_1',
         parentId: undefined,
@@ -970,6 +977,11 @@ describe('MultitableApiClient', () => {
           sheetId: 'sheet_comments',
           viewId: 'view_comments',
           recordId: 'rec_1',
+          // G-10 (docket #68): raw backend payload carries display names — asserts the client
+          // normalizer passes them through unchanged (not just defaults them to null).
+          baseName: 'Comments Base',
+          sheetName: 'Comments Sheet',
+          viewName: 'Comments View',
           authorId: 'user_2',
           content: 'hello',
           resolved: false,
@@ -996,6 +1008,13 @@ describe('MultitableApiClient', () => {
         sheetId: 'sheet_comments',
         viewId: 'view_comments',
         recordId: 'rec_1',
+        // G-10 (docket #68): pass-through from the raw payload above (not defaulted, since the
+        // backend supplied real strings) — fieldName is null because this fixture is a
+        // record-level comment (no fieldId), matching the id/name null-symmetry contract.
+        baseName: 'Comments Base',
+        sheetName: 'Comments Sheet',
+        viewName: 'Comments View',
+        fieldName: null,
         spreadsheetId: 'sheet_comments',
         rowId: 'rec_1',
         parentId: undefined,

--- a/apps/web/tests/multitable-comment-inbox-view.spec.ts
+++ b/apps/web/tests/multitable-comment-inbox-view.spec.ts
@@ -91,6 +91,11 @@ describe('MultitableCommentInboxView', () => {
             sheetId: 'sheet_ops',
             viewId: 'view_grid',
             recordId: 'rec_1',
+            // G-10 (docket #68): server-projected display names alongside the ids above.
+            baseName: 'Ops Base',
+            sheetName: 'Ops Sheet',
+            viewName: 'Grid View',
+            fieldName: 'Notes',
             authorId: 'user_2',
             authorName: 'Jamie',
             content: 'Need review',
@@ -122,6 +127,10 @@ describe('MultitableCommentInboxView', () => {
             sheetId: 'sheet_ops',
             viewId: 'view_grid',
             recordId: 'rec_1',
+            baseName: 'Ops Base',
+            sheetName: 'Ops Sheet',
+            viewName: 'Grid View',
+            fieldName: 'Notes',
             authorId: 'user_2',
             authorName: 'Jamie',
             content: 'Need review',
@@ -161,8 +170,26 @@ describe('MultitableCommentInboxView', () => {
     expect(container?.textContent).toContain('Jamie')
     expect(container?.textContent).toContain('Need review')
     expect(container?.textContent).toContain('1')
-    expect(container?.textContent).toContain('View view_grid')
     expect(container?.textContent).toContain('Mention')
+
+    // G-10 (docket #68): cards render entity display names, name-first (id ?? name fallback pattern
+    // mirrored from the existing authorName ?? authorId). The raw ids are demoted to a `title`
+    // tooltip attribute rather than removed outright.
+    expect(container?.textContent).toContain('Base Ops Base')
+    expect(container?.textContent).toContain('Sheet Ops Sheet')
+    expect(container?.textContent).toContain('View Grid View')
+    expect(container?.textContent).toContain('Field Notes')
+    // the raw ids no longer appear as VISIBLE text for the named entities...
+    expect(container?.textContent).not.toContain('Sheet sheet_ops')
+    expect(container?.textContent).not.toContain('View view_grid')
+    expect(container?.textContent).not.toContain('Field fld_notes')
+    // ...but are still present, demoted to a hover tooltip (secondary, not removed).
+    expect(container?.querySelector('[title="base_ops"]')?.textContent).toContain('Ops Base')
+    expect(container?.querySelector('[title="sheet_ops"]')?.textContent).toContain('Ops Sheet')
+    expect(container?.querySelector('[title="view_grid"]')?.textContent).toContain('Grid View')
+    expect(container?.querySelector('[title="fld_notes"]')?.textContent).toContain('Notes')
+    // Row/record has NO name projection (documented server-side disposition) — raw id stays visible.
+    expect(container?.textContent).toContain('Row rec_1')
 
     const openButton = Array.from(container!.querySelectorAll('button')).find((element) => element.textContent?.includes('Open')) as HTMLButtonElement | undefined
     openButton?.click()

--- a/packages/core-backend/src/di/identifiers.ts
+++ b/packages/core-backend/src/di/identifiers.ts
@@ -314,6 +314,24 @@ export interface CommentInboxItem extends CommentRecord {
     viewId?: string | null;
     /** The record ID for deep-link navigation. */
     recordId?: string | null;
+    /**
+     * G-10 (docket #68): display name of `baseId` (`meta_bases.name`), when the base row still
+     * resolves. Additive projection alongside the existing id — never a substitute for it. Null
+     * when the base was deleted/unresolvable, NOT when absent (record-level comments with no base
+     * still carry `baseId: null` and therefore `baseName: null` too).
+     */
+    baseName?: string | null;
+    /** G-10: display name of `sheetId` (`meta_sheets.name`), same null semantics as `baseName`. */
+    sheetName?: string | null;
+    /** G-10: display name of `viewId` (`meta_views.name`), same null semantics as `baseName`. */
+    viewName?: string | null;
+    /**
+     * G-10: display name of the commented field (`meta_fields.name`), when this is a field-level
+     * comment (`targetFieldId` set) AND the field still exists. Null for record-level comments and
+     * for a deleted field. `recordId` intentionally has NO analogous `recordName` — see
+     * `CommentService.getInbox` for why a record title is not synthesized here.
+     */
+    fieldName?: string | null;
 }
 
 /** Per-row comment presence summary used by the sheet grid indicator. */

--- a/packages/core-backend/src/services/CommentService.ts
+++ b/packages/core-backend/src/services/CommentService.ts
@@ -134,6 +134,11 @@ type CommentInboxRow = CommentRow & {
   sheet_id: string | null
   view_id: string | null
   record_id: string | null
+  /** G-10 (docket #68): display names projected alongside the existing ids — see getInbox(). */
+  base_name: string | null
+  sheet_name: string | null
+  view_name: string | null
+  field_name: string | null
 }
 
 type GroupedCountRow = {
@@ -511,6 +516,27 @@ export class CommentService {
     }
   }
 
+  /**
+   * G-10 (docket #68, G-10 audit #4323) name-projection note:
+   *
+   * This method's WHERE clause is UNCHANGED by the name projection below — every predicate line is
+   * untouched, so the row set returned is identical, row for row, to what it was before this change.
+   * The new `base_name`/`sheet_name`/`view_name`/`field_name` columns are pure SELECT-list additions
+   * (LEFT JOINs / correlated scalar subqueries keyed off ids already in the row), so they cannot
+   * surface a row that wasn't already being returned, and cannot attach a name to any row this
+   * endpoint wasn't already serializing the id (and content) for.
+   *
+   * That said: unlike `getComments`/`getCommentPresenceSummary`/etc., THIS aggregate has no per-sheet
+   * `resolveSheetReadableCapabilities` gate — see the G-8 doc comment on `ensureSheetReadable` in
+   * `routes/comments.ts` ("user-scoped cross-sheet `inbox`/`unread-count` aggregates... would need
+   * result filtering by the actor's readable-sheet set") and
+   * `docs/development/multitable-g8-comments-sheet-read-gate-verification-20260706.md` ("Residual
+   * follow-up... NOT in this PR"). That gap is pre-existing, already tracked, and out of scope here —
+   * this change does not widen it (no WHERE relaxation), and the projected names carry exactly the
+   * same boundary the existing id/content fields already have on this endpoint today, no more and no
+   * less. This PR makes no independent claim, positive or negative, about this method's row-selection
+   * robustness beyond that — it is verified unchanged, not verified correct.
+   */
   async getInbox(userId: string, options?: Pick<CommentQueryOptions, 'limit' | 'offset'>): Promise<{ items: CommentInboxItem[]; total: number }> {
     const limit = Math.min(200, Math.max(1, Number(options?.limit ?? 50)))
     const offset = Math.max(0, Number(options?.offset ?? 0))
@@ -530,6 +556,9 @@ export class CommentService {
       .selectFrom('meta_comments as c')
       .leftJoin('meta_comment_reads as r', (join) => join.onRef('r.comment_id', '=', 'c.id').on('r.user_id', '=', userId))
       .leftJoin('meta_sheets as s', 's.id', 'c.spreadsheet_id')
+      // G-10: field name lookup for field-level comments; null-safe (LEFT JOIN) since c.field_id is
+      // nullable for record-level comments and a field can be deleted after a comment references it.
+      .leftJoin('meta_fields as f', 'f.id', 'c.field_id')
       .select((eb) => [
         'c.id',
         'c.spreadsheet_id',
@@ -561,6 +590,26 @@ export class CommentService {
         )`.as('view_id'),
         sql<boolean>`case when r.comment_id is null then true else false end`.as('unread'),
         sql<boolean>`case when ${mentionPredicate} then true else false end`.as('mentioned'),
+        // G-10 (docket #68) — additive display-name projection. `meta_bases` isn't in the Kysely
+        // Database type (every other call site in this codebase reaches it via raw SQL too — see
+        // permission-service.ts/univer-meta.ts), so it's a correlated scalar subquery keyed off the
+        // already-joined `s.base_id`, mirroring the existing view_id subquery's shape rather than
+        // adding a new typed table. meta_sheets/meta_fields ARE typed, so those two are plain column
+        // refs off the joins above.
+        eb.ref('s.name').as('sheet_name'),
+        sql<string | null>`(
+          select b.name
+          from meta_bases as b
+          where b.id = s.base_id
+        )`.as('base_name'),
+        eb.ref('f.name').as('field_name'),
+        sql<string | null>`(
+          select v.name
+          from meta_views as v
+          where v.sheet_id = c.spreadsheet_id
+          order by v.created_at asc, v.id asc
+          limit 1
+        )`.as('view_name'),
       ])
       .where('c.author_id', '!=', userId)
       .where(inboxPredicate)
@@ -1184,6 +1233,12 @@ export class CommentService {
       sheetId: row.sheet_id ?? row.spreadsheet_id,
       viewId: row.view_id,
       recordId: row.record_id ?? row.row_id,
+      // G-10 (docket #68): additive display names — see getInbox()'s doc comment for the
+      // no-WHERE-relaxation boundary and the pre-existing G-8 caveat these inherit.
+      baseName: row.base_name,
+      sheetName: row.sheet_name,
+      viewName: row.view_name,
+      fieldName: row.field_name,
     }
   }
 

--- a/packages/core-backend/tests/integration/comment-flow.test.ts
+++ b/packages/core-backend/tests/integration/comment-flow.test.ts
@@ -163,6 +163,11 @@ function inboxRow(overrides: Record<string, unknown> = {}) {
     sheet_id: 'sheet_a',
     view_id: 'view_1',
     record_id: 'row_1',
+    // G-10 (docket #68): display names alongside the existing ids above.
+    base_name: 'Base One',
+    sheet_name: 'Sheet A',
+    view_name: 'View One',
+    field_name: null,
     ...overrides,
   }
 }
@@ -722,6 +727,60 @@ describe('Week-1 collab semantics — comment-flow integration', () => {
       expect(item.sheetId).toBe('sheet_xyz')
       expect(item.viewId).toBe('view_xyz')
       expect(item.recordId).toBe('row_xyz')
+    })
+
+    it('G-10 (docket #68): getInbox projects baseName/sheetName/viewName alongside the existing ids (additive, ids unchanged)', async () => {
+      const metaItem = inboxRow({
+        id: 'cmt_meta_names',
+        author_id: 'user_other',
+        mentioned: true,
+        base_id: 'base_xyz',
+        sheet_id: 'sheet_xyz',
+        view_id: 'view_xyz',
+        record_id: 'row_xyz',
+        base_name: 'Base XYZ',
+        sheet_name: 'Sheet XYZ',
+        view_name: 'View XYZ',
+      })
+
+      qFirst({ c: 1 })
+      qExec([metaItem])
+
+      const result = await svc.getInbox('user_viewer')
+      const item = result.items[0]
+
+      // additive: the existing id fields are untouched by the name projection
+      expect(item.baseId).toBe('base_xyz')
+      expect(item.sheetId).toBe('sheet_xyz')
+      expect(item.viewId).toBe('view_xyz')
+      expect(item.recordId).toBe('row_xyz')
+      expect(item.baseName).toBe('Base XYZ')
+      expect(item.sheetName).toBe('Sheet XYZ')
+      expect(item.viewName).toBe('View XYZ')
+    })
+
+    it('G-10: getInbox projects fieldName for a field-level comment, null for a record-level one', async () => {
+      const fieldItem = inboxRow({
+        id: 'cmt_field_named',
+        author_id: 'user_other',
+        mentioned: true,
+        field_id: 'fld_status',
+        field_name: 'Status',
+      })
+      const recordItem = inboxRow({
+        id: 'cmt_record_level',
+        author_id: 'user_other',
+        mentioned: true,
+        field_id: null,
+        field_name: null,
+      })
+
+      qFirst({ c: 2 })
+      qExec([fieldItem, recordItem])
+
+      const result = await svc.getInbox('user_viewer')
+      expect(result.items.find((i) => i.id === 'cmt_field_named')?.fieldName).toBe('Status')
+      expect(result.items.find((i) => i.id === 'cmt_record_level')?.fieldName).toBeNull()
     })
 
     it('non-mentioned users can appear in inbox for unread activity (mentioned=false)', async () => {

--- a/packages/core-backend/tests/integration/multitable-permmatrix-b4-g8-comments-visibility-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-permmatrix-b4-g8-comments-visibility-realdb.test.ts
@@ -283,3 +283,68 @@ describeIfDatabase('F1 — comments respect row-level read deny (real DB)', () =
     expect(Number((inserted.rows[0] as { c: number }).c)).toBe(0)
   })
 })
+
+/**
+ * G-10 (docket #68, G-10 audit #4323) — comment inbox entity-name projection (real DB).
+ *
+ * `CommentService.getInbox` (`/api/comments/inbox`) now additively projects `baseName`/`sheetName`/
+ * `viewName`/`fieldName` alongside the existing `baseId`/`sheetId`/`viewId`/`fieldId` (raw ids kept,
+ * names are name-first display sugar). See `CommentService.getInbox`'s doc comment for the
+ * no-WHERE-relaxation reasoning: this endpoint has no per-sheet `resolveSheetReadableCapabilities`
+ * gate (pre-existing, tracked residual from the G-8 verification doc — NOT this PR's scope). This
+ * suite verifies the ADDITIVE projection itself (names correctly resolved alongside unchanged ids for
+ * a row this endpoint already serves). It intentionally does NOT ship a row-selection/exclusion
+ * golden for this endpoint — that would be asserting a property of pre-existing, unmodified query
+ * logic that is out of scope for this PR to characterize.
+ */
+describeIfDatabase('G-10 — comment inbox entity-name projection (real DB)', () => {
+  const ts = Date.now()
+  const baseId = `base_g10_inbox_${ts}`
+  const sheetId = `sheet_g10_inbox_${ts}`
+  const fieldId = `fld_g10_status_${ts}`
+  const recordId = `rec_g10_inbox_${ts}`
+  const viewerCommentId = `cmt_g10_viewer_${ts}` // unread, authored by someone else → appears in viewer's inbox
+  const author = `user_g10_author_${ts}`
+  const viewer = `user_g10_viewer_${ts}`
+  const baseName = 'G10 Inbox Base'
+  const sheetName = 'G10 Inbox Sheet'
+  const fieldName = 'G10 Status Field'
+
+  beforeAll(async () => {
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x'), ($2,'x') ON CONFLICT (id) DO NOTHING", [author, viewer])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [baseId, baseName])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [sheetId, baseId, sheetName])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [fieldId, sheetId, fieldName, 'string', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [recordId, sheetId, JSON.stringify({ [fieldId]: 'x' })])
+    await q(
+      `INSERT INTO meta_comments (id, spreadsheet_id, row_id, field_id, container_id, target_id, target_field_id, author_id, content, mentions, created_at, updated_at)
+       VALUES ($1,$2,$3,$4,$2,$3,$4,$5,$6,$7::jsonb, now(), now())`,
+      [viewerCommentId, sheetId, recordId, fieldId, author, 'G10_INBOX_VIEWER_COMMENT', JSON.stringify([viewer])],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_comment_reads WHERE comment_id = $1', [viewerCommentId]).catch(() => {})
+    await q('DELETE FROM meta_comments WHERE spreadsheet_id = $1', [sheetId]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [sheetId]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [sheetId]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [sheetId]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [baseId]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[author, viewer]]).catch(() => {})
+  })
+
+  test('inbox item for a comment authored by someone else carries the projected base/sheet/field display names, ids unchanged', async () => {
+    const app = buildApp(viewer, ['comments:read'])
+    const res = await request(app).get('/api/comments/inbox')
+    expect(res.status).toBe(200)
+    const item = (res.body.data.items as Array<Record<string, unknown>>).find((i) => i.id === viewerCommentId)
+    expect(item).toBeTruthy()
+    // additive: existing id fields are untouched by the name projection (backward-compat contract)
+    expect(item?.baseId).toBe(baseId)
+    expect(item?.sheetId).toBe(sheetId)
+    expect(item?.fieldId).toBe(fieldId)
+    expect(item?.baseName).toBe(baseName)
+    expect(item?.sheetName).toBe(sheetName)
+    expect(item?.fieldName).toBe(fieldName)
+  })
+})

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -184,6 +184,18 @@ components:
             recordId:
               type: string
               nullable: true
+            baseName:
+              type: string
+              nullable: true
+            sheetName:
+              type: string
+              nullable: true
+            viewName:
+              type: string
+              nullable: true
+            fieldName:
+              type: string
+              nullable: true
           required:
             - unread
             - mentioned

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -266,6 +266,22 @@
               "recordId": {
                 "type": "string",
                 "nullable": true
+              },
+              "baseName": {
+                "type": "string",
+                "nullable": true
+              },
+              "sheetName": {
+                "type": "string",
+                "nullable": true
+              },
+              "viewName": {
+                "type": "string",
+                "nullable": true
+              },
+              "fieldName": {
+                "type": "string",
+                "nullable": true
               }
             },
             "required": [

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -184,6 +184,18 @@ components:
             recordId:
               type: string
               nullable: true
+            baseName:
+              type: string
+              nullable: true
+            sheetName:
+              type: string
+              nullable: true
+            viewName:
+              type: string
+              nullable: true
+            fieldName:
+              type: string
+              nullable: true
           required:
             - unread
             - mentioned

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -182,6 +182,22 @@ components:
             recordId:
               type: string
               nullable: true
+            # G-10 (docket #68): additive display names alongside the ids above. Null when the
+            # underlying entity is unresolvable (deleted/no view yet); recordId intentionally has NO
+            # analogous name field — see CommentService.getInbox for why a record title isn't
+            # synthesized server-side.
+            baseName:
+              type: string
+              nullable: true
+            sheetName:
+              type: string
+              nullable: true
+            viewName:
+              type: string
+              nullable: true
+            fieldName:
+              type: string
+              nullable: true
           required: [unread, mentioned]
     CommentInboxResponse:
       type: object


### PR DESCRIPTION
## Summary

Docket #68 (G-10 audit #4323, owner ruling 2026-07-15): `MultitableCommentInboxView.vue` rendered five raw entity IDs (Base/Sheet/Row/View/Field) per inbox card. Owner ruling for normal-user surfaces is name-first display. This PR adds the small **new server data path** authorized for this rung: `CommentService.getInbox()` additively projects display names alongside the existing ids, and the FE renders name-first.

## Server projection

`getInbox()` gains four additive columns, each resolved from tables already in (or trivially joined to) the query:

- **`baseName`** — `meta_bases.name`, via a correlated scalar subquery keyed off the already-joined `meta_sheets.base_id` (mirrors the existing `view_id` subquery's shape; `meta_bases` isn't in the Kysely `Database` type — every other call site in this codebase reaches it via raw SQL too, so a typed JOIN isn't the established pattern here).
- **`sheetName`** — `meta_sheets.name`, a plain column ref off the join this query already had.
- **`fieldName`** — `meta_fields.name`, via a new `LEFT JOIN meta_fields ON f.id = c.field_id` (null-safe: `field_id` is nullable for record-level comments).
- **`viewName`** — `meta_views.name`, via a scalar subquery. **Checked against the CI test-DB migration-exclusion list first**: the `views`/`view_states` migrations excluded from CI (`042a_core_model_views.sql`, `20250925_create_view_tables.sql`) create an *unrelated* legacy `views`/`view_states` table pair, not `meta_views` — `meta_views` (with its `name` column) comes from `zzz20251231_create_meta_schema.ts`, which is not excluded, so this is genuinely CI-testable (proven green against a fresh-migrated Postgres below).
- **`recordId` gets no `recordName`.** I checked how other server surfaces resolve record titles (notifications, DingTalk cards, audit) — none do; the only heuristic ("first string field, else first field" over `meta_records.data`) lives inline in `routes/univer-meta.ts`'s `loadRecordSummaries`, tightly coupled to per-request machinery (row-level-deny gating, `req`) with no reusable exported form. Not a "cheap existing mechanism" per the docket's own bar, so the record chip stays raw-id, unchanged.

All four are `?? id` fallback pairs — additive, backward-compatible, existing fields unchanged.

## Permission audit (the reason this needed its own rung)

This change is **additive-only**: every WHERE predicate in `getInbox()` is byte-identical before/after — the new fields are pure `SELECT`-list additions (LEFT JOIN / correlated subqueries keyed off ids already in the row). They cannot surface a row that wasn't already returned, nor attach a name to a row whose id (and content) this endpoint wasn't already serializing. No WHERE relaxation.

The endpoint's per-sheet visibility posture is a pre-existing, separately-tracked matter (not introduced or altered here); any further robustness questions raised while scoping this rung were flagged directly to the owner out of band, not in this PR. Accordingly **no exclusion/visibility golden ships here** — asserting one would claim a property of pre-existing, unmodified query logic this additive PR neither verified nor is the right vehicle to change. What ships is a real-DB golden proving the projection itself is correct (names resolve, ids unchanged) for a comment this endpoint already returns.

## Per-entity disposition

| Entity | Disposition |
|---|---|
| Base | Named — `baseName` via `meta_bases.name` |
| Sheet | Named — `sheetName` via `meta_sheets.name` (already joined) |
| Field | Named — `fieldName` via new `meta_fields` LEFT JOIN, null for record-level comments |
| View | Named — `viewName` via `meta_views.name`, confirmed CI-testable (not on the exclusion list) |
| Row/Record | **Left raw** — no cheap existing server-side title resolver; noted for a future dedicated slice if ever pursued |

## FE

`MultitableCommentInboxView.vue` renders `item.xName ?? item.xId` (mirrors the existing `authorName ?? authorId` pattern already in this file), raw id demoted to a `title` hover tooltip rather than removed. No new i18n debt — no new label strings introduced, only the *value* shown changed.

## Verification

- Backend `tsc --noEmit`: clean.
- FE `vue-tsc -b`: clean.
- Backend no-DB suite (`vitest run`, full): **472 files / 6534 tests passed**, 0 failures (includes the OD-6 revision-disposition, rank-8 record-lock, and cross-base-write guard scanners — none trip since this change never touches `meta_records` mutation paths).
- Real-DB: fresh Postgres, migrated with the exact CI `MIGRATION_EXCLUDE` list, then ran the touched spec + its two comment-realdb neighbors: **`multitable-permmatrix-b4-g8-comments-visibility-realdb.test.ts`, `multitable-oapi1-comments-read-realdb.test.ts`, `multitable-oapi2a-comments-write-realdb.test.ts`** — 23/23 passed. Added one new real-DB test proving the additive projection (extending the existing wired file — no new real-DB spec file, no two-point wiring needed).
- Mock-DB `comment-flow.test.ts` (extended, existing wired file): 47/47 passed, including 2 new cases for the name projection + field-level vs record-level `fieldName` disposition.
- FE required web-tests script (`run-required-web-tests.sh`, full): **337 files / 3946 tests passed**, including the updated `multitable-comment-inbox-view.spec.ts` (name-first rendering + tooltip fallback assertions) and `multitable-client.spec.ts` (client-side normalization pass-through/default assertions).
- `packages/openapi`: `src/base.yml` schema extended (additive, nullable fields); `dist/*` regenerated via `packages/openapi/tools/build.ts` and validated via `tools/validate.ts` (clean). `dist-sdk/index.d.ts` intentionally left untouched — regenerating it pulled in unrelated pre-existing drift (two approval-metrics endpoints already in `src/` but never synced to `dist-sdk/`) that isn't part of this docket's scope.

## Judgment calls

1. **No `recordName`** — no cheap existing mechanism; documented above and in code comments (`CommentInboxItem.fieldName`'s doc comment cross-references this).
2. **`meta_bases` accessed via raw scalar subquery, not a typed Kysely join** — matches the codebase's own established convention (every other `meta_bases` call site uses raw SQL; it isn't in the Kysely `Database` type).
3. **No exclusion/visibility golden shipped** — pre-existing/separately-tracked, out of scope here; anything further was raised with the owner out of band.
4. **`dist-sdk/index.d.ts` left untouched** — regenerating it would fold in unrelated pre-existing drift into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
