### PR TITLE
feat(automation): P2 durable-delivery S2-b — dispatch loop (registry + tick), flag-gated

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -536,6 +536,7 @@ jobs:
             tests/integration/multitable-tombstone-retention-realdb.test.ts \
             tests/integration/multitable-automation-outbox-schema-realdb.test.ts \
             tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts \
+            tests/integration/multitable-automation-dispatch-loop-realdb.test.ts \
             tests/integration/multitable-attachment-readgate.security.test.ts \
             tests/integration/multitable-ai-write-provenance-batch-grouping-realdb.test.ts \
             tests/integration/multitable-automation-branch-local-wait.test.ts \

--- a/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
+++ b/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
@@ -117,6 +117,10 @@ export const DEFAULT_ADAPTER_TIMEOUT_MS = 30_000
 // Explicit upper bounds for the loop's own knobs (the claim/resolve knobs are bounded inside S2-a).
 const MAX_MS_24H = 86_400_000
 const MAX_INTERVAL_MS = 3_600_000 // 1h — an interval beyond this is almost certainly a misconfiguration
+// The claim engine (S2-a) accepts leaseMs >= 1, but a HEARTBEATED dispatch needs the lease long enough that
+// the heartbeat (leaseMs/3) fires and a renew round-trip completes BEFORE the lease expires — otherwise a
+// competitor reclaims a still-running delivery (#4334 review P1-B). 1s is a conservative floor for that margin.
+const MIN_LOOP_LEASE_MS = 1_000
 
 /** Reject fractional, non-finite, out-of-safe-range, or out-of-bounds numeric params before they do anything. */
 function requireBoundedInt(name: string, value: number, min: number, max: number): void {
@@ -142,12 +146,17 @@ function validateDispatchNumericParams(
   },
 ): void {
   if (opts.batchSize !== undefined) requireBoundedInt('batchSize', opts.batchSize, 1, 10_000)
-  if (opts.leaseMs !== undefined) requireBoundedInt('leaseMs', opts.leaseMs, 1, MAX_MS_24H)
+  // leaseMs floor is the loop's, not the claim engine's: the heartbeat needs margin inside the lease (P1-B).
+  if (opts.leaseMs !== undefined) requireBoundedInt('leaseMs', opts.leaseMs, MIN_LOOP_LEASE_MS, MAX_MS_24H)
   if (opts.maxAttempts !== undefined) requireBoundedInt('maxAttempts', opts.maxAttempts, 1, 10_000)
   if (opts.retryBaseMs !== undefined) requireBoundedInt('retryBaseMs', opts.retryBaseMs, 1, MAX_MS_24H)
   if (opts.retryCapMs !== undefined) requireBoundedInt('retryCapMs', opts.retryCapMs, 1, MAX_MS_24H)
-  if (opts.retryBaseMs !== undefined && opts.retryCapMs !== undefined && opts.retryCapMs < opts.retryBaseMs) {
-    throw new RangeError(`retryCapMs (${opts.retryCapMs}) must be >= retryBaseMs (${opts.retryBaseMs})`)
+  // Inversion check on the EFFECTIVE values (defaults synthesized), so a one-sided override — e.g. a
+  // retryBaseMs above the DEFAULT cap with no explicit retryCapMs — is still rejected (#4334 review P2-D).
+  const effRetryBaseMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
+  const effRetryCapMs = opts.retryCapMs ?? DEFAULT_RETRY_CAP_MS
+  if (effRetryCapMs < effRetryBaseMs) {
+    throw new RangeError(`effective retryCapMs (${effRetryCapMs}) must be >= effective retryBaseMs (${effRetryBaseMs})`)
   }
   if (opts.adapterTimeoutMs !== undefined) requireBoundedInt('adapterTimeoutMs', opts.adapterTimeoutMs, 1, MAX_MS_24H)
   if (opts.intervalMs !== undefined) requireBoundedInt('intervalMs', opts.intervalMs, 1, MAX_INTERVAL_MS)
@@ -220,6 +229,10 @@ export interface DispatchTickOptions {
   adapterTimeoutMs?: number
   /** Rolling-deploy alert seam (#4203 §246). Best-effort — a throwing callback never fails the tick. */
   onUnknownConsumerKeys?: (keys: string[]) => void
+  /** Heartbeat-renew DB-error seam (#4334 review P2-C). A renew that ERRORS (vs. cleanly losing the row to a
+   *  competitor) is an infra signal — surfaced here, never masqueraded as a normal lost-lease. Values-free
+   *  (internal ids only). Best-effort — a throwing callback never fails the tick. */
+  onHeartbeatError?: (info: { outboxId: string; consumerKey: string }) => void
   /** Cooperative stop: the row loop breaks between rows when this returns true (keeps `stop()` responsive). */
   shouldStop?: () => boolean
   /** Aborted on loop `stop()` — folded into each row's adapter `ctx.signal` so a cooperative adapter cancels
@@ -235,6 +248,8 @@ export interface DispatchTickResult {
   poisoned: number
   /** resolves that hit 0 rows because the fence was superseded (zombie / lost lease) — informational. */
   lostLease: number
+  /** rows whose HEARTBEAT renew hit a DB error mid-flight (an infra signal, distinct from a normal lost lease). */
+  heartbeatErrors: number
   unknownKeys: string[]
 }
 
@@ -245,10 +260,11 @@ interface RowRuntimeConfig {
   retryBaseMs?: number
   retryCapMs?: number
   stopSignal?: AbortSignal
+  onHeartbeatError?: (info: { outboxId: string; consumerKey: string }) => void
   now?: () => Date
 }
 
-type RowDisposition = 'completed' | 'rescheduled' | 'poisoned' | 'lostLease'
+type RowDisposition = 'completed' | 'rescheduled' | 'poisoned' | 'lostLease' | 'heartbeatError'
 
 /**
  * Run a bounded race between the adapter promise and a timeout. Resolves to the marker on timeout (the loop
@@ -258,9 +274,13 @@ type RowDisposition = 'completed' | 'rescheduled' | 'poisoned' | 'lostLease'
 const TIMEOUT_MARKER = Symbol('adapter_timeout')
 
 /**
- * Process one claimed row end-to-end: revalidate the lease, run the adapter under timeout + heartbeat, then
- * resolve via fence-CAS. Only the ADAPTER's own failure is caught here (→ retryable); a DB error on
- * renew/resolve propagates (store-unhealthy is not a per-row condition).
+ * Process one JUST-CLAIMED row (per-slot claim, so it carries a fresh lease + our fence): run the adapter
+ * under a heartbeat + bounded timeout, then resolve via fence-CAS. The heartbeat maintains the lease for a
+ * long call and aborts on a mid-flight reclaim; the terminal fence-CAS is the final state arbiter. Only the
+ * ADAPTER's own failure is caught here (→ retryable); a DB error on renew/resolve propagates (store-unhealthy
+ * is not a per-row condition). No pre-call renew is needed: per-slot claim removes the batch-drift window it
+ * used to guard (the round-2 pre-call renew), and an adapter shorter than the heartbeat is already covered by
+ * the fresh claim lease.
  */
 async function processClaimedRow(
   db: Queryable,
@@ -268,14 +288,8 @@ async function processClaimedRow(
   row: ClaimedConsumer,
   cfg: RowRuntimeConfig,
 ): Promise<RowDisposition> {
-  // 1) Pre-call revalidate + renew: prove we STILL own this row (a serial batch may have drifted past the
-  //    lease) and reset its window. If a concurrent worker reclaimed it, the adapter is never called.
-  if (!(await renewConsumerLease(db, row.outboxId, row.consumerKey, row.fence, cfg.leaseMs, cfg))) {
-    return 'lostLease'
-  }
-
-  // 2) Guards: AbortController (cooperative cancel) + heartbeat (maintain the lease; detect a mid-flight
-  //    reclaim) + timeout (the loop's liveness guarantee).
+  // Guards: AbortController (cooperative cancel) + heartbeat (maintain the lease; detect a mid-flight
+  // reclaim) + timeout (the loop's liveness guarantee).
   const controller = new AbortController()
   // A loop-level stop aborts in-flight adapters too, so stop() returns promptly for a cooperative adapter.
   const onStop = () => controller.abort()
@@ -284,19 +298,22 @@ async function processClaimedRow(
     else cfg.stopSignal.addEventListener('abort', onStop, { once: true })
   }
   let leaseLost = false
+  let heartbeatErrored = false
   const heartbeat = setInterval(() => {
     void renewConsumerLease(db, row.outboxId, row.consumerKey, row.fence, cfg.leaseMs, cfg)
       .then((stillOwned) => {
         if (!stillOwned) {
+          // Renew matched 0 rows: a competitor cleanly reclaimed the row (NORMAL concurrency) — abort.
           leaseLost = true
           controller.abort()
         }
       })
       .catch(() => {
-        // A renew that errors mid-flight leaves ownership uncertain — stop the call conservatively; the
-        // terminal fence-CAS below is the final arbiter of persisted state.
-        leaseLost = true
+        // A renew that ERRORS is an INFRA signal, not a normal lost lease — surface it (never masquerade it
+        // as lostLease) and stop the call conservatively; the terminal fence-CAS is the final state arbiter.
+        heartbeatErrored = true
         controller.abort()
+        cfg.onHeartbeatError?.({ outboxId: row.outboxId, consumerKey: row.consumerKey })
       })
   }, cfg.heartbeatMs)
   heartbeat.unref?.()
@@ -334,8 +351,12 @@ async function processClaimedRow(
     cfg.stopSignal?.removeEventListener('abort', onStop)
   }
 
-  // 3) A mid-flight reclaim means another worker owns the row now — do NOT resolve it (that would clobber
-  //    the new owner's fence-CAS window; our write would match 0 rows anyway).
+  // 3) A heartbeat DB error leaves ownership uncertain — surface it as its own disposition (already reported
+  //    via onHeartbeatError) and do NOT resolve; a mid-flight CLEAN reclaim means another worker owns the row
+  //    now, so also do NOT resolve (our write would match 0 rows and could clobber the new owner's window).
+  if (heartbeatErrored) {
+    return 'heartbeatError'
+  }
   if (leaseLost) {
     return 'lostLease'
   }
@@ -379,8 +400,9 @@ export async function runDispatchTick(
   const knownKeys = registry.keys()
   const leaseMs = opts.leaseMs ?? DEFAULT_LEASE_MS
   const adapterTimeoutMs = opts.adapterTimeoutMs ?? DEFAULT_ADAPTER_TIMEOUT_MS
-  // Heartbeat well inside the lease window so a still-running adapter keeps its hold; floor at 1s.
-  const heartbeatMs = Math.max(1_000, Math.min(Math.floor(leaseMs / 3), leaseMs))
+  // Heartbeat strictly INSIDE the lease window (leaseMs/3, not a fixed floor that can exceed a short lease —
+  // #4334 review P1-B). leaseMs >= MIN_LOOP_LEASE_MS is enforced above, so this is always well below the lease.
+  const heartbeatMs = Math.max(1, Math.floor(leaseMs / 3))
   const cfg: RowRuntimeConfig = {
     leaseMs,
     adapterTimeoutMs,
@@ -388,9 +410,10 @@ export async function runDispatchTick(
     retryBaseMs: opts.retryBaseMs,
     retryCapMs: opts.retryCapMs,
     stopSignal: opts.stopSignal,
+    onHeartbeatError: opts.onHeartbeatError,
     now: opts.now,
   }
-  const result: DispatchTickResult = { claimed: 0, completed: 0, rescheduled: 0, poisoned: 0, lostLease: 0, unknownKeys: [] }
+  const result: DispatchTickResult = { claimed: 0, completed: 0, rescheduled: 0, poisoned: 0, lostLease: 0, heartbeatErrors: 0, unknownKeys: [] }
 
   // 1) rolling-deploy alert: reclaimable rows this worker cannot serve. Never claimed, never terminated.
   try {
@@ -403,20 +426,25 @@ export async function runDispatchTick(
     // below will fail loudly anyway.)
   }
 
-  // 2) claim a batch scoped to the keys this worker knows (ceiling-poison happens inside the claim).
-  const claimed = await claimDueConsumers(db, {
-    consumerKeys: knownKeys,
-    batchSize: opts.batchSize,
-    leaseMs,
-    maxAttempts: opts.maxAttempts,
-    now: opts.now,
-  })
-  result.claimed = claimed.length
-
-  // 3) process each row — per-row isolation, sequential (adapters may share downstream resources; concurrency
-  //    tuning is a later, measured decision). Each row revalidates its lease and runs under a bounded timeout.
-  for (const row of claimed) {
-    if (opts.shouldStop?.()) break // graceful stop: don't start new adapter work once the loop is stopping
+  // 2+3) PER-SLOT claim (#4334 review P1-A): the dispatcher is serial, and the claim increments `attempts`
+  //   AT CLAIM (crash-safe, S2-a). A BATCH claim would burn an attempt on every claimed row even if a slow
+  //   front row starves the tail — so a tail row could reach `max_attempts_exhausted` and dead-letter WITHOUT
+  //   its adapter ever running. Claiming ONE row per execution slot guarantees every claimed row is actually
+  //   attempted: attempts == adapter invocations. `batchSize` becomes the per-tick ceiling on how many slots
+  //   to run. (Cost: one claim query per row — acceptable for a delivery loop; a batched design is a later,
+  //   measured decision.)
+  const maxRowsPerTick = opts.batchSize ?? 50
+  for (let slot = 0; slot < maxRowsPerTick; slot++) {
+    if (opts.shouldStop?.()) break // graceful stop: don't claim/start new adapter work once stopping
+    const [row] = await claimDueConsumers(db, {
+      consumerKeys: knownKeys,
+      batchSize: 1,
+      leaseMs,
+      maxAttempts: opts.maxAttempts,
+      now: opts.now,
+    })
+    if (!row) break // nothing reclaimable this tick
+    result.claimed += 1
     const adapter = registry.get(row.consumerKey)
     if (!adapter) {
       // Cannot happen (claim is scoped to registry keys) unless the registry mutated mid-tick; leave the
@@ -427,6 +455,7 @@ export async function runDispatchTick(
     if (disposition === 'completed') result.completed += 1
     else if (disposition === 'rescheduled') result.rescheduled += 1
     else if (disposition === 'poisoned') result.poisoned += 1
+    else if (disposition === 'heartbeatError') result.heartbeatErrors += 1
     else result.lostLease += 1
   }
   return result
@@ -446,7 +475,10 @@ export interface DispatchLoopObserver {
   onUnknownConsumerKeys(keys: string[]): void
   /** A tick that threw (a DB/claim error) — never swallowed silently. */
   onTickError(err: unknown): void
-  /** Optional per-tick metrics for observability (completed/rescheduled/poisoned/lostLease counts). */
+  /** A heartbeat renew hit a DB error mid-flight (an infra signal, NOT a normal lost lease). Required so a
+   *  degrading store surfaces here instead of hiding inside the lostLease count (#4334 review P2-C). */
+  onHeartbeatError(info: { outboxId: string; consumerKey: string }): void
+  /** Optional per-tick metrics for observability (completed/rescheduled/poisoned/lostLease/heartbeatErrors). */
   onTick?(result: DispatchTickResult): void
 }
 
@@ -483,8 +515,13 @@ export function startDurableDispatchLoop(
   observer: DispatchLoopObserver,
   opts: DispatchTickOptions & { intervalMs?: number; env?: NodeJS.ProcessEnv } = {},
 ): DispatchLoopHandle {
-  if (!observer || typeof observer.onUnknownConsumerKeys !== 'function' || typeof observer.onTickError !== 'function') {
-    throw new TypeError('durable dispatch loop requires a telemetry sink (observer.onUnknownConsumerKeys + observer.onTickError)')
+  if (
+    !observer ||
+    typeof observer.onUnknownConsumerKeys !== 'function' ||
+    typeof observer.onTickError !== 'function' ||
+    typeof observer.onHeartbeatError !== 'function'
+  ) {
+    throw new TypeError('durable dispatch loop requires a telemetry sink (observer.onUnknownConsumerKeys + onTickError + onHeartbeatError)')
   }
   if (!isDurableDeliveryEnabled(opts.env ?? process.env)) {
     throw new Error('durable dispatch loop must not start while AUTOMATION_DURABLE_DELIVERY_ENABLED is off')
@@ -502,9 +539,10 @@ export function startDurableDispatchLoop(
     running = true
     inFlight = runDispatchTick(db, registry, {
       ...opts,
-      // route the alert through the exception-safe sink; break the row loop promptly once stopping;
+      // route the alerts through the exception-safe sink; break the row loop promptly once stopping;
       // fold the loop-stop signal into each adapter's ctx.signal so stop() cancels in-flight work.
       onUnknownConsumerKeys: (keys) => safeInvoke(observer.onUnknownConsumerKeys, keys),
+      onHeartbeatError: (info) => safeInvoke(observer.onHeartbeatError, info),
       shouldStop: () => stopped,
       stopSignal: stopController.signal,
     })

--- a/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
+++ b/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
@@ -1,0 +1,234 @@
+/**
+ * P2 durable-delivery — slice S2-b: the dispatch loop (registry + tick).
+ *
+ * Drives the S2-a claim engine end-to-end: alert on unknown keys → claim a batch for the keys THIS worker
+ * knows → `await` each row's consumer adapter directly → resolve via fence-CAS (complete / reschedule with
+ * backoff / poison). Consumer adapters themselves are S5 — this module defines their contract and the loop.
+ *
+ * Contract (FWB-0 lock #4203 Layer 1):
+ *   - **Registry asserts uniqueness at registration**: a duplicate consumer_key is a STARTUP ERROR, never a
+ *     silent double-run. The registry is the single enumeration source for this worker's known keys — the
+ *     claim scope, the unknown-key alert, and (S3) the manifest completeness assertion all read from it.
+ *   - **Unknown keys are alerted, never claimed**: rows whose consumer_key this worker doesn't know are
+ *     surfaced through `onUnknownConsumerKeys` and left `pending` for a worker that knows them (#4203 §246
+ *     rolling-deploy). The alert callback must never throw the tick over (best-effort).
+ *   - **The dispatcher directly `await`s the adapter** (no eventemitter3 in the durable path). An adapter
+ *     THROW is a transient `adapter_error` (rescheduled with backoff); only an explicit
+ *     `permanent_failure` verdict poisons. Attempt-exhaustion poison is claim-driven (S2-a) — the loop
+ *     never has to be alive for the ceiling to hold.
+ *   - **Per-row isolation**: one adapter failing/throwing never blocks the rest of the batch.
+ *   - **Backoff is deterministic exponential with a cap** (no Math.random — reproducible in tests; jitter
+ *     can be layered later without changing the persisted contract).
+ *
+ * Nothing here runs while `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF: `startDurableDispatchLoop` refuses
+ * to start when the flag is off, and no production code calls it yet (that wiring is S5/S4 activation).
+ */
+import type { ClaimedConsumer, DeliveryFailureReason, Queryable } from './automation-durable-dispatcher'
+import {
+  claimDueConsumers,
+  completeConsumer,
+  DEFAULT_MAX_DELIVERY_ATTEMPTS,
+  findUnknownConsumerKeys,
+  poisonConsumer,
+  rescheduleConsumer,
+  resolveDisposition,
+} from './automation-durable-dispatcher'
+import { isDurableDeliveryEnabled } from './automation-durable-delivery'
+
+/** The verdict an adapter returns for one delivered event. A THROW is treated as retryable `adapter_error`. */
+export type AdapterOutcome =
+  | { outcome: 'success' }
+  | { outcome: 'retryable_failure'; reason: Extract<DeliveryFailureReason, 'adapter_error' | 'adapter_timeout' | 'unknown'> }
+  | { outcome: 'permanent_failure'; reason: Extract<DeliveryFailureReason, 'permanent_rejection'> }
+
+/** A named consumer adapter — the durable path's delivery target (implementations land in S5). */
+export interface ConsumerAdapter {
+  /** The consumer_key this adapter serves (must be unique across the registry). */
+  readonly key: string
+  /** Handle one claimed event. Idempotency is the SINK's job (per-rule event_fires / business UNIQUE keys). */
+  handle(event: ClaimedConsumer): Promise<AdapterOutcome>
+}
+
+/**
+ * Startup-time adapter registry. Registration asserts key uniqueness — a duplicate is a configuration bug
+ * that would double-run deliveries, so it throws instead of silently overwriting (#4203 §manifest).
+ */
+export class ConsumerAdapterRegistry {
+  private readonly adapters = new Map<string, ConsumerAdapter>()
+
+  register(adapter: ConsumerAdapter): void {
+    const key = adapter?.key
+    if (typeof key !== 'string' || key.trim() === '') {
+      throw new RangeError('ConsumerAdapter.key must be a non-empty string')
+    }
+    if (this.adapters.has(key)) {
+      throw new Error(`duplicate consumer adapter registration for key "${key}" — this would double-run deliveries`)
+    }
+    this.adapters.set(key, adapter)
+  }
+
+  get(key: string): ConsumerAdapter | undefined {
+    return this.adapters.get(key)
+  }
+
+  /** The single enumeration source for this worker's known consumer_keys. */
+  keys(): string[] {
+    return [...this.adapters.keys()]
+  }
+
+  get size(): number {
+    return this.adapters.size
+  }
+}
+
+// Deterministic exponential backoff: base·2^(attempts-1), capped. attempts is the POST-claim count (>=1).
+export const DEFAULT_RETRY_BASE_MS = 5_000
+export const DEFAULT_RETRY_CAP_MS = 15 * 60_000 // 15 min
+
+export function computeRetryDelayMs(
+  attempts: number,
+  baseMs: number = DEFAULT_RETRY_BASE_MS,
+  capMs: number = DEFAULT_RETRY_CAP_MS,
+): number {
+  const n = Number.isSafeInteger(attempts) && attempts >= 1 ? attempts : 1
+  // 2^(n-1) can overflow quickly — clamp the exponent so the multiply stays in safe-integer range.
+  const exp = Math.min(n - 1, 30)
+  return Math.min(baseMs * 2 ** exp, capMs)
+}
+
+export interface DispatchTickOptions {
+  batchSize?: number
+  leaseMs?: number
+  maxAttempts?: number
+  retryBaseMs?: number
+  retryCapMs?: number
+  /** Rolling-deploy alert seam (#4203 §246). Best-effort — a throwing callback never fails the tick. */
+  onUnknownConsumerKeys?: (keys: string[]) => void
+  now?: () => Date
+}
+
+export interface DispatchTickResult {
+  claimed: number
+  completed: number
+  rescheduled: number
+  poisoned: number
+  /** resolves that hit 0 rows because the fence was superseded mid-flight (zombie writes) — informational. */
+  lostLease: number
+  unknownKeys: string[]
+}
+
+/**
+ * One dispatch tick: alert unknown keys, claim a batch for the registry's keys, await each adapter, resolve
+ * each row via fence-CAS. Never throws for a single adapter's failure; a DB error on claim does propagate
+ * (the caller's loop handles/schedules the next tick).
+ */
+export async function runDispatchTick(
+  db: Queryable,
+  registry: ConsumerAdapterRegistry,
+  opts: DispatchTickOptions = {},
+): Promise<DispatchTickResult> {
+  if (registry.size === 0) {
+    throw new RangeError('runDispatchTick requires a registry with at least one adapter (empty known-keys would claim nothing and hide misconfiguration)')
+  }
+  const knownKeys = registry.keys()
+  const result: DispatchTickResult = { claimed: 0, completed: 0, rescheduled: 0, poisoned: 0, lostLease: 0, unknownKeys: [] }
+
+  // 1) rolling-deploy alert: reclaimable rows this worker cannot serve. Never claimed, never terminated.
+  try {
+    result.unknownKeys = await findUnknownConsumerKeys(db, knownKeys, opts)
+    if (result.unknownKeys.length > 0) {
+      opts.onUnknownConsumerKeys?.(result.unknownKeys)
+    }
+  } catch {
+    // best-effort alert probe; the delivery tick itself must not die on it. (If the DB is down, the claim
+    // below will fail loudly anyway.)
+  }
+
+  // 2) claim a batch scoped to the keys this worker knows (ceiling-poison happens inside the claim).
+  const claimed = await claimDueConsumers(db, {
+    consumerKeys: knownKeys,
+    batchSize: opts.batchSize,
+    leaseMs: opts.leaseMs,
+    maxAttempts: opts.maxAttempts,
+    now: opts.now,
+  })
+  result.claimed = claimed.length
+
+  // 3) await each adapter and resolve — per-row isolation, sequential (adapters may share downstream
+  //    resources; concurrency tuning is a later, measured decision, not a default).
+  for (const row of claimed) {
+    const adapter = registry.get(row.consumerKey)
+    if (!adapter) {
+      // Cannot happen (claim is scoped to registry keys) unless the registry mutated mid-tick; leave the
+      // row alone — its lease expires and a correctly-configured worker reclaims it.
+      continue
+    }
+    let verdict: AdapterOutcome
+    try {
+      verdict = await adapter.handle(row)
+    } catch {
+      verdict = { outcome: 'retryable_failure', reason: 'adapter_error' }
+    }
+    const action = resolveDisposition(verdict.outcome)
+    let applied = false
+    if (action === 'complete') {
+      applied = await completeConsumer(db, row.outboxId, row.consumerKey, row.fence, opts)
+      if (applied) result.completed += 1
+    } else if (action === 'reschedule') {
+      const reason = verdict.outcome === 'retryable_failure' ? verdict.reason : 'unknown'
+      const delay = computeRetryDelayMs(row.attempts, opts.retryBaseMs, opts.retryCapMs)
+      applied = await rescheduleConsumer(db, row.outboxId, row.consumerKey, row.fence, delay, reason, opts)
+      if (applied) result.rescheduled += 1
+    } else {
+      const reason = verdict.outcome === 'permanent_failure' ? verdict.reason : 'permanent_rejection'
+      applied = await poisonConsumer(db, row.outboxId, row.consumerKey, row.fence, reason, opts)
+      if (applied) result.poisoned += 1
+    }
+    if (!applied) result.lostLease += 1
+  }
+  return result
+}
+
+export interface DispatchLoopHandle {
+  stop(): Promise<void>
+}
+
+/**
+ * The long-running loop: one tick every `intervalMs`, with an overlap guard (a slow tick never runs
+ * concurrently with the next). REFUSES to start while the master flag is OFF — the flag is the only
+ * activation switch, and S1..S4 all land with it off.
+ */
+export function startDurableDispatchLoop(
+  db: Queryable,
+  registry: ConsumerAdapterRegistry,
+  opts: DispatchTickOptions & { intervalMs?: number; env?: NodeJS.ProcessEnv; onTickError?: (err: unknown) => void } = {},
+): DispatchLoopHandle {
+  if (!isDurableDeliveryEnabled(opts.env ?? process.env)) {
+    throw new Error('durable dispatch loop must not start while AUTOMATION_DURABLE_DELIVERY_ENABLED is off')
+  }
+  const intervalMs = opts.intervalMs ?? 1_000
+  let running = false
+  let stopped = false
+  let inFlight: Promise<void> = Promise.resolve()
+  const timer = setInterval(() => {
+    if (running || stopped) return
+    running = true
+    inFlight = runDispatchTick(db, registry, opts)
+      .then(() => undefined)
+      .catch((err) => {
+        opts.onTickError?.(err)
+      })
+      .finally(() => {
+        running = false
+      })
+  }, intervalMs)
+  // do not keep the process alive just for the loop
+  timer.unref?.()
+  return {
+    async stop() {
+      stopped = true
+      clearInterval(timer)
+      await inFlight
+    },
+  }
+}

--- a/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
+++ b/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
@@ -14,9 +14,12 @@
  *     surfaced through `observer.onUnknownConsumerKeys` and left `pending` for a worker that knows them
  *     (#4203 §246 rolling-deploy). Observer calls are best-effort — a throwing sink never fails the tick.
  *   - **PER-SLOT claim**: the tick claims ONE reclaimable row at a time (up to `batchSize` slots) and processes
- *     it immediately — never a batch. The claim increments `attempts` AT CLAIM (crash-safe, S2-a), so a batch
- *     claim would let a slow front row starve a tail row into `max_attempts` exhaustion WITHOUT its adapter
- *     ever running; per-slot claim guarantees `attempts == adapter invocations`.
+ *     it immediately — never a batch. The claim increments `attempts` AT CLAIM (crash-safe, S2-a: a
+ *     crash-after-claim still counts toward the ceiling, which is intended). A batch claim would additionally
+ *     let a slow front row starve a tail row into `max_attempts` exhaustion WITHOUT its adapter running; per-slot
+ *     claim removes that — in NORMAL operation a row is only attempted when it is about to be processed, so it is
+ *     never poisoned-by-exhaustion without having run. (A row poisoned AT CLAIM because it was ALREADY at the
+ *     ceiling is not dispatched; the loop scans past it and counts it — it does not stop the poll.)
  *   - **The lease is maintained by a heartbeat while the adapter runs** (a fence-CAS renew, leaseMs/3 period,
  *     which does NOT bump the fence). A row lost to a concurrent reclaim mid-flight is detected — the renew
  *     matches 0 rows → the in-flight call is aborted and the row is left to its new owner. This is defense in
@@ -33,9 +36,11 @@
  *     (S5) and may misbehave. A malformed verdict (unknown outcome, missing/invalid reason, non-object, null)
  *     is a retryable `adapter_error`, NEVER a poison: a bad verdict must not silently drop the event. Only an
  *     exact `{ outcome: 'permanent_failure', reason: 'permanent_rejection' }` dead-letters.
- *   - **Per-row isolation**: one adapter failing/throwing/timing-out never blocks the next row. (A DB error on
- *     claim/renew/resolve is NOT isolated — it means the store is unhealthy, so it propagates and the caller's
- *     loop surfaces it via `onTickError` and retries next tick.)
+ *   - **Per-row isolation**: one adapter failing/throwing/timing-out never blocks the next row. A DB error on
+ *     the CLAIM or a terminal RESOLVE is NOT isolated — it means the store is unhealthy, so it propagates and
+ *     the caller's loop surfaces it via `onTickError` and retries next tick. A DB error on the HEARTBEAT renew
+ *     is caught per-row and surfaced via `onHeartbeatError` (the row is left for reclaim), so a transient blip
+ *     mid-delivery does not fail the whole tick.
  *   - **Backoff is deterministic exponential with a cap** (no Math.random — reproducible in tests; jitter can
  *     be layered later without changing the persisted contract), floored so a rescheduled row cannot be
  *     re-claimed within the same tick (retry stays a future-tick event, not an intra-tick spin).
@@ -246,6 +251,9 @@ export interface DispatchTickOptions {
    *  competitor) is an infra signal — surfaced here, never masqueraded as a normal lost-lease. Values-free
    *  (internal ids only). Best-effort — a throwing callback never fails the tick. */
   onHeartbeatError?: (info: { outboxId: string; consumerKey: string }) => void
+  /** Claim-time poison seam (#4334 review: head-of-line). A row already at the attempt ceiling is dead-lettered
+   *  AT CLAIM (not dispatched); surfaced here so the terminal transition is observable. Best-effort. */
+  onClaimTimePoison?: (info: { outboxId: string; consumerKey: string; attempts: number }) => void
   /** Cooperative stop: the row loop breaks between rows when this returns true (keeps `stop()` responsive). */
   shouldStop?: () => boolean
   /** Aborted on loop `stop()` — folded into each row's adapter `ctx.signal` so a cooperative adapter cancels
@@ -263,6 +271,8 @@ export interface DispatchTickResult {
   lostLease: number
   /** rows whose HEARTBEAT renew hit a DB error mid-flight (an infra signal, distinct from a normal lost lease). */
   heartbeatErrors: number
+  /** rows poisoned AT CLAIM (attempts already >= ceiling → dead_letter, never dispatched) this tick. */
+  claimTimePoisoned: number
   unknownKeys: string[]
 }
 
@@ -432,7 +442,7 @@ export async function runDispatchTick(
     onHeartbeatError: opts.onHeartbeatError,
     now: opts.now,
   }
-  const result: DispatchTickResult = { claimed: 0, completed: 0, rescheduled: 0, poisoned: 0, lostLease: 0, heartbeatErrors: 0, unknownKeys: [] }
+  const result: DispatchTickResult = { claimed: 0, completed: 0, rescheduled: 0, poisoned: 0, lostLease: 0, heartbeatErrors: 0, claimTimePoisoned: 0, unknownKeys: [] }
 
   // 1) rolling-deploy alert: reclaimable rows this worker cannot serve. Never claimed, never terminated.
   try {
@@ -448,21 +458,40 @@ export async function runDispatchTick(
   // 2+3) PER-SLOT claim (#4334 review P1-A): the dispatcher is serial, and the claim increments `attempts`
   //   AT CLAIM (crash-safe, S2-a). A BATCH claim would burn an attempt on every claimed row even if a slow
   //   front row starves the tail — so a tail row could reach `max_attempts_exhausted` and dead-letter WITHOUT
-  //   its adapter ever running. Claiming ONE row per execution slot guarantees every claimed row is actually
-  //   attempted: attempts == adapter invocations. `batchSize` becomes the per-tick ceiling on how many slots
-  //   to run. (Cost: one claim query per row — acceptable for a delivery loop; a batched design is a later,
-  //   measured decision.)
+  //   its adapter ever running. Claiming ONE row per execution slot means a row is only attempted when it is
+  //   about to be processed (a crash-after-claim still counts an attempt — that is the intended crash-safe
+  //   ceiling, S2-a — but normal operation never poisons a row it did not run). `batchSize` = the per-tick
+  //   ceiling on slots. (Cost: one claim query per row; a batched design is a later, measured decision.)
+  //
+  //   A claim can POISON the oldest row at claim-time (attempts already >= ceiling) and return NO dispatchable
+  //   row. That is NOT "no work" — healthy rows may be queued behind it — so an empty result with a claim-time
+  //   poison CONTINUES to the next slot (bounded by the budget) instead of breaking (#4334 review: head-of-line
+  //   block). The poison is counted + surfaced so the terminal transition is observable.
   const maxRowsPerTick = opts.batchSize ?? 50
   for (let slot = 0; slot < maxRowsPerTick; slot++) {
     if (opts.shouldStop?.()) break // graceful stop: don't claim/start new adapter work once stopping
+    let poisonedThisSlot = 0
     const [row] = await claimDueConsumers(db, {
       consumerKeys: knownKeys,
       batchSize: 1,
       leaseMs,
       maxAttempts: opts.maxAttempts,
       now: opts.now,
+      onClaimTimePoison: (info) => {
+        poisonedThisSlot += 1
+        result.claimTimePoisoned += 1
+        try {
+          opts.onClaimTimePoison?.(info)
+        } catch {
+          /* best-effort telemetry */
+        }
+      },
     })
-    if (!row) break // nothing reclaimable this tick
+    if (!row) {
+      // Distinguish "the candidate was terminated at claim" (scan past it) from "truly nothing reclaimable".
+      if (poisonedThisSlot > 0) continue
+      break
+    }
     result.claimed += 1
     const adapter = registry.get(row.consumerKey)
     if (!adapter) {

--- a/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
+++ b/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
@@ -185,23 +185,28 @@ const RETRYABLE_REASONS: ReadonlySet<string> = new Set<DeliveryFailureReason>(['
  * dropped on a single bad verdict.
  */
 export function normalizeAdapterVerdict(raw: unknown): NormalizedVerdict {
-  if (typeof raw === 'object' && raw !== null) {
-    const outcome = (raw as { outcome?: unknown }).outcome
-    if (outcome === 'success') {
-      return { action: 'complete' }
-    }
-    if (outcome === 'permanent_failure' && (raw as { reason?: unknown }).reason === 'permanent_rejection') {
-      return { action: 'poison', reason: 'permanent_rejection' }
-    }
-    if (outcome === 'retryable_failure') {
-      const reason = (raw as { reason?: unknown }).reason
-      return {
-        action: 'reschedule',
-        reason: typeof reason === 'string' && RETRYABLE_REASONS.has(reason) ? (reason as DeliveryFailureReason) : 'unknown',
+  try {
+    if (typeof raw === 'object' && raw !== null) {
+      const outcome = (raw as { outcome?: unknown }).outcome
+      if (outcome === 'success') {
+        return { action: 'complete' }
+      }
+      if (outcome === 'permanent_failure' && (raw as { reason?: unknown }).reason === 'permanent_rejection') {
+        return { action: 'poison', reason: 'permanent_rejection' }
+      }
+      if (outcome === 'retryable_failure') {
+        const reason = (raw as { reason?: unknown }).reason
+        return {
+          action: 'reschedule',
+          reason: typeof reason === 'string' && RETRYABLE_REASONS.has(reason) ? (reason as DeliveryFailureReason) : 'unknown',
+        }
       }
     }
+  } catch {
+    // A hostile/throwing getter (or prototype-polluted object) on the adapter's return value must NOT throw
+    // here — the doctrine is "the loop never throws for one adapter, and never drops". Treat it as malformed.
   }
-  // null / non-object / unknown outcome / malformed permanent → RETRY, never drop, never poison.
+  // null / non-object / unknown outcome / malformed permanent / a throwing getter → RETRY, never drop, never poison.
   return { action: 'reschedule', reason: 'adapter_error' }
 }
 
@@ -217,6 +222,9 @@ export interface DispatchTickOptions {
   onUnknownConsumerKeys?: (keys: string[]) => void
   /** Cooperative stop: the row loop breaks between rows when this returns true (keeps `stop()` responsive). */
   shouldStop?: () => boolean
+  /** Aborted on loop `stop()` — folded into each row's adapter `ctx.signal` so a cooperative adapter cancels
+   *  its in-flight work immediately (a non-cooperative one is still bounded by `adapterTimeoutMs`). */
+  stopSignal?: AbortSignal
   now?: () => Date
 }
 
@@ -236,6 +244,7 @@ interface RowRuntimeConfig {
   heartbeatMs: number
   retryBaseMs?: number
   retryCapMs?: number
+  stopSignal?: AbortSignal
   now?: () => Date
 }
 
@@ -268,6 +277,12 @@ async function processClaimedRow(
   // 2) Guards: AbortController (cooperative cancel) + heartbeat (maintain the lease; detect a mid-flight
   //    reclaim) + timeout (the loop's liveness guarantee).
   const controller = new AbortController()
+  // A loop-level stop aborts in-flight adapters too, so stop() returns promptly for a cooperative adapter.
+  const onStop = () => controller.abort()
+  if (cfg.stopSignal) {
+    if (cfg.stopSignal.aborted) controller.abort()
+    else cfg.stopSignal.addEventListener('abort', onStop, { once: true })
+  }
   let leaseLost = false
   const heartbeat = setInterval(() => {
     void renewConsumerLease(db, row.outboxId, row.consumerKey, row.fence, cfg.leaseMs, cfg)
@@ -316,6 +331,7 @@ async function processClaimedRow(
   } finally {
     clearInterval(heartbeat)
     if (timeoutTimer) clearTimeout(timeoutTimer)
+    cfg.stopSignal?.removeEventListener('abort', onStop)
   }
 
   // 3) A mid-flight reclaim means another worker owns the row now — do NOT resolve it (that would clobber
@@ -371,6 +387,7 @@ export async function runDispatchTick(
     heartbeatMs,
     retryBaseMs: opts.retryBaseMs,
     retryCapMs: opts.retryCapMs,
+    stopSignal: opts.stopSignal,
     now: opts.now,
   }
   const result: DispatchTickResult = { claimed: 0, completed: 0, rescheduled: 0, poisoned: 0, lostLease: 0, unknownKeys: [] }
@@ -450,6 +467,15 @@ function safeInvoke<A>(fn: ((arg: A) => unknown) | undefined, arg: A): void {
  * The long-running loop: one tick every `intervalMs`, with an overlap guard (a slow tick never runs
  * concurrently with the next). REQUIRES a telemetry sink and REFUSES to start while the master flag is OFF —
  * the flag is the only activation switch, and S1..S4 all land with it off.
+ *
+ * PRECONDITION (S4/S5 wiring): `db` MUST be a concurrency-capable Queryable — a pg `Pool` (or equivalent that
+ * runs queries on independent connections), NOT a single checked-out client. A row's heartbeat renew runs
+ * CONCURRENTLY with that row's adapter and its terminal resolve; on one serialized connection those queries
+ * would block each other (or deadlock). Pass the pool, never `pool.connect()`'s client.
+ *
+ * `stop()` is prompt for cooperative adapters (the loop-stop signal is folded into each adapter's
+ * `ctx.signal`); a non-cooperative adapter that ignores its signal still bounds `stop()` to at most one
+ * `adapterTimeoutMs`.
  */
 export function startDurableDispatchLoop(
   db: Queryable,
@@ -470,14 +496,17 @@ export function startDurableDispatchLoop(
   let running = false
   let stopped = false
   let inFlight: Promise<void> = Promise.resolve()
+  const stopController = new AbortController()
   const timer = setInterval(() => {
     if (running || stopped) return
     running = true
     inFlight = runDispatchTick(db, registry, {
       ...opts,
-      // route the alert through the exception-safe sink; break the row loop promptly once stopping.
+      // route the alert through the exception-safe sink; break the row loop promptly once stopping;
+      // fold the loop-stop signal into each adapter's ctx.signal so stop() cancels in-flight work.
       onUnknownConsumerKeys: (keys) => safeInvoke(observer.onUnknownConsumerKeys, keys),
       shouldStop: () => stopped,
+      stopSignal: stopController.signal,
     })
       .then((result) => {
         safeInvoke(observer.onTick, result)
@@ -494,6 +523,7 @@ export function startDurableDispatchLoop(
   return {
     async stop() {
       stopped = true
+      stopController.abort()
       clearInterval(timer)
       await inFlight
     },

--- a/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
+++ b/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
@@ -2,23 +2,45 @@
  * P2 durable-delivery — slice S2-b: the dispatch loop (registry + tick).
  *
  * Drives the S2-a claim engine end-to-end: alert on unknown keys → claim a batch for the keys THIS worker
- * knows → `await` each row's consumer adapter directly → resolve via fence-CAS (complete / reschedule with
- * backoff / poison). Consumer adapters themselves are S5 — this module defines their contract and the loop.
+ * knows → for each row **revalidate the lease, run the adapter under a bounded timeout + heartbeat, then
+ * resolve via fence-CAS** (complete / reschedule with backoff / poison). Consumer adapters themselves are S5 —
+ * this module defines their contract and the loop.
  *
  * Contract (FWB-0 lock #4203 Layer 1):
  *   - **Registry asserts uniqueness at registration**: a duplicate consumer_key is a STARTUP ERROR, never a
  *     silent double-run. The registry is the single enumeration source for this worker's known keys — the
  *     claim scope, the unknown-key alert, and (S3) the manifest completeness assertion all read from it.
  *   - **Unknown keys are alerted, never claimed**: rows whose consumer_key this worker doesn't know are
- *     surfaced through `onUnknownConsumerKeys` and left `pending` for a worker that knows them (#4203 §246
- *     rolling-deploy). The alert callback must never throw the tick over (best-effort).
- *   - **The dispatcher directly `await`s the adapter** (no eventemitter3 in the durable path). An adapter
- *     THROW is a transient `adapter_error` (rescheduled with backoff); only an explicit
- *     `permanent_failure` verdict poisons. Attempt-exhaustion poison is claim-driven (S2-a) — the loop
- *     never has to be alive for the ceiling to hold.
- *   - **Per-row isolation**: one adapter failing/throwing never blocks the rest of the batch.
- *   - **Backoff is deterministic exponential with a cap** (no Math.random — reproducible in tests; jitter
- *     can be layered later without changing the persisted contract).
+ *     surfaced through `observer.onUnknownConsumerKeys` and left `pending` for a worker that knows them
+ *     (#4203 §246 rolling-deploy). Observer calls are best-effort — a throwing sink never fails the tick.
+ *   - **A claimed row's lease is re-validated immediately before the adapter runs, and maintained by a
+ *     heartbeat while it runs** (both are fence-CAS renews that do NOT bump the fence). A worker that drifted
+ *     past its lease during a serial batch — or lost the row to a concurrent reclaim mid-flight — never
+ *     produces (or keeps producing) the external side effect: the pre-call renew fails → the adapter is not
+ *     called; the heartbeat renew fails → the in-flight call is aborted and the row is left to its new owner.
+ *     This is defense in depth over the terminal fence-CAS (which only protects persisted STATE); the
+ *     irreducible residue — an adapter mid-emit at the exact instant its lease is lost — is at-least-once and
+ *     absorbed by SINK idempotency, per the durable-delivery doctrine.
+ *   - **The adapter runs under a bounded `adapterTimeoutMs`**: one hung Promise can never freeze the tick,
+ *     later rows, or `stop()`. A timeout maps to a retryable `adapter_timeout` (rescheduled with backoff) and
+ *     the loop moves on; the dangling promise is neutralized (its later settle can no longer touch the row —
+ *     the reschedule bumped the fence). `Promise.race` alone is not the guarantee — it is paired with the
+ *     fence-CAS + idempotency above.
+ *   - **The adapter's return value is parsed against a closed verdict set at runtime** — adapters are external
+ *     (S5) and may misbehave. A malformed verdict (unknown outcome, missing/invalid reason, non-object, null)
+ *     is a retryable `adapter_error`, NEVER a poison: a bad verdict must not silently drop the event. Only an
+ *     exact `{ outcome: 'permanent_failure', reason: 'permanent_rejection' }` dead-letters.
+ *   - **Per-row isolation**: one adapter failing/throwing/timing-out never blocks the rest of the batch. (A DB
+ *     error on claim/renew/resolve is NOT isolated — it means the store is unhealthy, so it propagates and the
+ *     caller's loop surfaces it via `onTickError` and retries next tick.)
+ *   - **Backoff is deterministic exponential with a cap** (no Math.random — reproducible in tests; jitter can
+ *     be layered later without changing the persisted contract).
+ *   - **Every numeric knob is a validated safe-integer within an explicit range, checked BEFORE any work** —
+ *     at tick entry (before the claim) and at loop start (before the timer). `intervalMs=0` (hot loop) and a
+ *     fractional/huge backoff are rejected up front, never after the adapter already ran.
+ *   - **The long-running loop requires a telemetry sink**: `onUnknownConsumerKeys` + `onTickError` are
+ *     mandatory (a silent stuck-row or a swallowed tick error is an operational blind spot), and every
+ *     observer call is exception-safe — a broken sink can neither kill the process nor stop delivery.
  *
  * Nothing here runs while `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF: `startDurableDispatchLoop` refuses
  * to start when the flag is off, and no production code calls it yet (that wiring is S5/S4 activation).
@@ -27,11 +49,10 @@ import type { ClaimedConsumer, DeliveryFailureReason, Queryable } from './automa
 import {
   claimDueConsumers,
   completeConsumer,
-  DEFAULT_MAX_DELIVERY_ATTEMPTS,
   findUnknownConsumerKeys,
   poisonConsumer,
+  renewConsumerLease,
   rescheduleConsumer,
-  resolveDisposition,
 } from './automation-durable-dispatcher'
 import { isDurableDeliveryEnabled } from './automation-durable-delivery'
 
@@ -45,8 +66,13 @@ export type AdapterOutcome =
 export interface ConsumerAdapter {
   /** The consumer_key this adapter serves (must be unique across the registry). */
   readonly key: string
-  /** Handle one claimed event. Idempotency is the SINK's job (per-rule event_fires / business UNIQUE keys). */
-  handle(event: ClaimedConsumer): Promise<AdapterOutcome>
+  /**
+   * Handle one claimed event. Idempotency is the SINK's job (per-rule event_fires / business UNIQUE keys).
+   * `ctx.signal` is aborted on timeout or on a mid-flight lease loss — a cooperative adapter should stop its
+   * in-flight work when it fires (a non-cooperative adapter still can't freeze the loop: the timeout wins the
+   * race regardless).
+   */
+  handle(event: ClaimedConsumer, ctx?: { signal: AbortSignal }): Promise<AdapterOutcome>
 }
 
 /**
@@ -84,6 +110,48 @@ export class ConsumerAdapterRegistry {
 // Deterministic exponential backoff: base·2^(attempts-1), capped. attempts is the POST-claim count (>=1).
 export const DEFAULT_RETRY_BASE_MS = 5_000
 export const DEFAULT_RETRY_CAP_MS = 15 * 60_000 // 15 min
+export const DEFAULT_LEASE_MS = 30_000
+/** Default per-adapter execution ceiling. A call that outruns this is a retryable `adapter_timeout`. */
+export const DEFAULT_ADAPTER_TIMEOUT_MS = 30_000
+
+// Explicit upper bounds for the loop's own knobs (the claim/resolve knobs are bounded inside S2-a).
+const MAX_MS_24H = 86_400_000
+const MAX_INTERVAL_MS = 3_600_000 // 1h — an interval beyond this is almost certainly a misconfiguration
+
+/** Reject fractional, non-finite, out-of-safe-range, or out-of-bounds numeric params before they do anything. */
+function requireBoundedInt(name: string, value: number, min: number, max: number): void {
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new RangeError(`${name} must be a safe integer in [${min}, ${max}] (got ${value})`)
+  }
+}
+
+/**
+ * Validate every numeric knob a tick / loop may use, BEFORE any side effect. Called at tick entry (before the
+ * claim) and at loop start (before the timer) so a misconfiguration fails fast rather than after the adapter
+ * already ran (#4203 review P2: "应在 claim 和 timer 启动前统一校验").
+ */
+function validateDispatchNumericParams(
+  opts: {
+    batchSize?: number
+    leaseMs?: number
+    maxAttempts?: number
+    retryBaseMs?: number
+    retryCapMs?: number
+    adapterTimeoutMs?: number
+    intervalMs?: number
+  },
+): void {
+  if (opts.batchSize !== undefined) requireBoundedInt('batchSize', opts.batchSize, 1, 10_000)
+  if (opts.leaseMs !== undefined) requireBoundedInt('leaseMs', opts.leaseMs, 1, MAX_MS_24H)
+  if (opts.maxAttempts !== undefined) requireBoundedInt('maxAttempts', opts.maxAttempts, 1, 10_000)
+  if (opts.retryBaseMs !== undefined) requireBoundedInt('retryBaseMs', opts.retryBaseMs, 1, MAX_MS_24H)
+  if (opts.retryCapMs !== undefined) requireBoundedInt('retryCapMs', opts.retryCapMs, 1, MAX_MS_24H)
+  if (opts.retryBaseMs !== undefined && opts.retryCapMs !== undefined && opts.retryCapMs < opts.retryBaseMs) {
+    throw new RangeError(`retryCapMs (${opts.retryCapMs}) must be >= retryBaseMs (${opts.retryBaseMs})`)
+  }
+  if (opts.adapterTimeoutMs !== undefined) requireBoundedInt('adapterTimeoutMs', opts.adapterTimeoutMs, 1, MAX_MS_24H)
+  if (opts.intervalMs !== undefined) requireBoundedInt('intervalMs', opts.intervalMs, 1, MAX_INTERVAL_MS)
+}
 
 export function computeRetryDelayMs(
   attempts: number,
@@ -96,14 +164,59 @@ export function computeRetryDelayMs(
   return Math.min(baseMs * 2 ** exp, capMs)
 }
 
+/** A resolve action derived from a (possibly malformed) adapter return value. */
+export type NormalizedVerdict =
+  | { action: 'complete' }
+  | { action: 'reschedule'; reason: DeliveryFailureReason }
+  | { action: 'poison'; reason: DeliveryFailureReason }
+
+const RETRYABLE_REASONS: ReadonlySet<string> = new Set<DeliveryFailureReason>(['adapter_error', 'adapter_timeout', 'unknown'])
+
+/**
+ * Parse an adapter's return value against the closed verdict set at RUNTIME. Adapters are external (S5) and
+ * may return anything; a malformed verdict must NEVER poison (that silently drops the event) and must never
+ * throw. The fail-safe direction is retry:
+ *   - exact `{ outcome: 'success' }`                                            → complete
+ *   - `{ outcome: 'permanent_failure', reason: 'permanent_rejection' }` (exact) → poison (the only drop path)
+ *   - `{ outcome: 'retryable_failure', reason: <valid> }`                       → reschedule with that reason
+ *   - `{ outcome: 'retryable_failure', reason: <invalid/absent> }`              → reschedule, values-free `unknown`
+ *   - anything else (unknown outcome, non-object, null, malformed permanent)    → reschedule `adapter_error`
+ * A malformed permanent still terminates eventually — via the claim-time attempt ceiling — but is never
+ * dropped on a single bad verdict.
+ */
+export function normalizeAdapterVerdict(raw: unknown): NormalizedVerdict {
+  if (typeof raw === 'object' && raw !== null) {
+    const outcome = (raw as { outcome?: unknown }).outcome
+    if (outcome === 'success') {
+      return { action: 'complete' }
+    }
+    if (outcome === 'permanent_failure' && (raw as { reason?: unknown }).reason === 'permanent_rejection') {
+      return { action: 'poison', reason: 'permanent_rejection' }
+    }
+    if (outcome === 'retryable_failure') {
+      const reason = (raw as { reason?: unknown }).reason
+      return {
+        action: 'reschedule',
+        reason: typeof reason === 'string' && RETRYABLE_REASONS.has(reason) ? (reason as DeliveryFailureReason) : 'unknown',
+      }
+    }
+  }
+  // null / non-object / unknown outcome / malformed permanent → RETRY, never drop, never poison.
+  return { action: 'reschedule', reason: 'adapter_error' }
+}
+
 export interface DispatchTickOptions {
   batchSize?: number
   leaseMs?: number
   maxAttempts?: number
   retryBaseMs?: number
   retryCapMs?: number
+  /** per-adapter execution ceiling (default 30s; 1..86_400_000). A call that outruns it is `adapter_timeout`. */
+  adapterTimeoutMs?: number
   /** Rolling-deploy alert seam (#4203 §246). Best-effort — a throwing callback never fails the tick. */
   onUnknownConsumerKeys?: (keys: string[]) => void
+  /** Cooperative stop: the row loop breaks between rows when this returns true (keeps `stop()` responsive). */
+  shouldStop?: () => boolean
   now?: () => Date
 }
 
@@ -112,15 +225,129 @@ export interface DispatchTickResult {
   completed: number
   rescheduled: number
   poisoned: number
-  /** resolves that hit 0 rows because the fence was superseded mid-flight (zombie writes) — informational. */
+  /** resolves that hit 0 rows because the fence was superseded (zombie / lost lease) — informational. */
   lostLease: number
   unknownKeys: string[]
 }
 
+interface RowRuntimeConfig {
+  leaseMs: number
+  adapterTimeoutMs: number
+  heartbeatMs: number
+  retryBaseMs?: number
+  retryCapMs?: number
+  now?: () => Date
+}
+
+type RowDisposition = 'completed' | 'rescheduled' | 'poisoned' | 'lostLease'
+
 /**
- * One dispatch tick: alert unknown keys, claim a batch for the registry's keys, await each adapter, resolve
- * each row via fence-CAS. Never throws for a single adapter's failure; a DB error on claim does propagate
- * (the caller's loop handles/schedules the next tick).
+ * Run a bounded race between the adapter promise and a timeout. Resolves to the marker on timeout (the loop
+ * proceeds even if the adapter never settles); a synchronous throw or async rejection of the adapter
+ * propagates so the caller can map it to `adapter_error`.
+ */
+const TIMEOUT_MARKER = Symbol('adapter_timeout')
+
+/**
+ * Process one claimed row end-to-end: revalidate the lease, run the adapter under timeout + heartbeat, then
+ * resolve via fence-CAS. Only the ADAPTER's own failure is caught here (→ retryable); a DB error on
+ * renew/resolve propagates (store-unhealthy is not a per-row condition).
+ */
+async function processClaimedRow(
+  db: Queryable,
+  adapter: ConsumerAdapter,
+  row: ClaimedConsumer,
+  cfg: RowRuntimeConfig,
+): Promise<RowDisposition> {
+  // 1) Pre-call revalidate + renew: prove we STILL own this row (a serial batch may have drifted past the
+  //    lease) and reset its window. If a concurrent worker reclaimed it, the adapter is never called.
+  if (!(await renewConsumerLease(db, row.outboxId, row.consumerKey, row.fence, cfg.leaseMs, cfg))) {
+    return 'lostLease'
+  }
+
+  // 2) Guards: AbortController (cooperative cancel) + heartbeat (maintain the lease; detect a mid-flight
+  //    reclaim) + timeout (the loop's liveness guarantee).
+  const controller = new AbortController()
+  let leaseLost = false
+  const heartbeat = setInterval(() => {
+    void renewConsumerLease(db, row.outboxId, row.consumerKey, row.fence, cfg.leaseMs, cfg)
+      .then((stillOwned) => {
+        if (!stillOwned) {
+          leaseLost = true
+          controller.abort()
+        }
+      })
+      .catch(() => {
+        // A renew that errors mid-flight leaves ownership uncertain — stop the call conservatively; the
+        // terminal fence-CAS below is the final arbiter of persisted state.
+        leaseLost = true
+        controller.abort()
+      })
+  }, cfg.heartbeatMs)
+  heartbeat.unref?.()
+
+  let raw: unknown
+  let timedOut = false
+  let threw = false
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined
+  try {
+    const handlePromise = Promise.resolve().then(() => adapter.handle(row, { signal: controller.signal }))
+    // Neutralize the dangling promise: after a timeout its later rejection must not become an unhandledRejection.
+    handlePromise.catch(() => undefined)
+    const timeoutPromise = new Promise<typeof TIMEOUT_MARKER>((resolve) => {
+      timeoutTimer = setTimeout(() => {
+        try {
+          controller.abort()
+        } catch {
+          /* ignore */
+        }
+        resolve(TIMEOUT_MARKER)
+      }, cfg.adapterTimeoutMs)
+      timeoutTimer.unref?.()
+    })
+    const outcome = await Promise.race([handlePromise, timeoutPromise])
+    if (outcome === TIMEOUT_MARKER) {
+      timedOut = true
+    } else {
+      raw = outcome
+    }
+  } catch {
+    threw = true
+  } finally {
+    clearInterval(heartbeat)
+    if (timeoutTimer) clearTimeout(timeoutTimer)
+  }
+
+  // 3) A mid-flight reclaim means another worker owns the row now — do NOT resolve it (that would clobber
+  //    the new owner's fence-CAS window; our write would match 0 rows anyway).
+  if (leaseLost) {
+    return 'lostLease'
+  }
+
+  // 4) Derive the resolve action: timeout → adapter_timeout; a throw → adapter_error; else parse the verdict.
+  const verdict: NormalizedVerdict = timedOut
+    ? { action: 'reschedule', reason: 'adapter_timeout' }
+    : threw
+      ? { action: 'reschedule', reason: 'adapter_error' }
+      : normalizeAdapterVerdict(raw)
+
+  // 5) Terminal fence-CAS resolve — false means the token was superseded between renew and resolve (lost lease).
+  if (verdict.action === 'complete') {
+    return (await completeConsumer(db, row.outboxId, row.consumerKey, row.fence, cfg)) ? 'completed' : 'lostLease'
+  }
+  if (verdict.action === 'reschedule') {
+    const delay = computeRetryDelayMs(row.attempts, cfg.retryBaseMs, cfg.retryCapMs)
+    return (await rescheduleConsumer(db, row.outboxId, row.consumerKey, row.fence, delay, verdict.reason, cfg))
+      ? 'rescheduled'
+      : 'lostLease'
+  }
+  return (await poisonConsumer(db, row.outboxId, row.consumerKey, row.fence, verdict.reason, cfg)) ? 'poisoned' : 'lostLease'
+}
+
+/**
+ * One dispatch tick: validate knobs, alert unknown keys, claim a batch for the registry's keys, process each
+ * row (revalidate → run under timeout+heartbeat → fence-CAS resolve). Never throws for a single adapter's
+ * failure; a DB error on claim/renew/resolve does propagate (the caller's loop handles/schedules the next tick).
  */
 export async function runDispatchTick(
   db: Queryable,
@@ -130,7 +357,22 @@ export async function runDispatchTick(
   if (registry.size === 0) {
     throw new RangeError('runDispatchTick requires a registry with at least one adapter (empty known-keys would claim nothing and hide misconfiguration)')
   }
+  // Validate BEFORE any find/claim/side effect (#4203 review P2#5).
+  validateDispatchNumericParams(opts)
+
   const knownKeys = registry.keys()
+  const leaseMs = opts.leaseMs ?? DEFAULT_LEASE_MS
+  const adapterTimeoutMs = opts.adapterTimeoutMs ?? DEFAULT_ADAPTER_TIMEOUT_MS
+  // Heartbeat well inside the lease window so a still-running adapter keeps its hold; floor at 1s.
+  const heartbeatMs = Math.max(1_000, Math.min(Math.floor(leaseMs / 3), leaseMs))
+  const cfg: RowRuntimeConfig = {
+    leaseMs,
+    adapterTimeoutMs,
+    heartbeatMs,
+    retryBaseMs: opts.retryBaseMs,
+    retryCapMs: opts.retryCapMs,
+    now: opts.now,
+  }
   const result: DispatchTickResult = { claimed: 0, completed: 0, rescheduled: 0, poisoned: 0, lostLease: 0, unknownKeys: [] }
 
   // 1) rolling-deploy alert: reclaimable rows this worker cannot serve. Never claimed, never terminated.
@@ -148,43 +390,27 @@ export async function runDispatchTick(
   const claimed = await claimDueConsumers(db, {
     consumerKeys: knownKeys,
     batchSize: opts.batchSize,
-    leaseMs: opts.leaseMs,
+    leaseMs,
     maxAttempts: opts.maxAttempts,
     now: opts.now,
   })
   result.claimed = claimed.length
 
-  // 3) await each adapter and resolve — per-row isolation, sequential (adapters may share downstream
-  //    resources; concurrency tuning is a later, measured decision, not a default).
+  // 3) process each row — per-row isolation, sequential (adapters may share downstream resources; concurrency
+  //    tuning is a later, measured decision). Each row revalidates its lease and runs under a bounded timeout.
   for (const row of claimed) {
+    if (opts.shouldStop?.()) break // graceful stop: don't start new adapter work once the loop is stopping
     const adapter = registry.get(row.consumerKey)
     if (!adapter) {
       // Cannot happen (claim is scoped to registry keys) unless the registry mutated mid-tick; leave the
       // row alone — its lease expires and a correctly-configured worker reclaims it.
       continue
     }
-    let verdict: AdapterOutcome
-    try {
-      verdict = await adapter.handle(row)
-    } catch {
-      verdict = { outcome: 'retryable_failure', reason: 'adapter_error' }
-    }
-    const action = resolveDisposition(verdict.outcome)
-    let applied = false
-    if (action === 'complete') {
-      applied = await completeConsumer(db, row.outboxId, row.consumerKey, row.fence, opts)
-      if (applied) result.completed += 1
-    } else if (action === 'reschedule') {
-      const reason = verdict.outcome === 'retryable_failure' ? verdict.reason : 'unknown'
-      const delay = computeRetryDelayMs(row.attempts, opts.retryBaseMs, opts.retryCapMs)
-      applied = await rescheduleConsumer(db, row.outboxId, row.consumerKey, row.fence, delay, reason, opts)
-      if (applied) result.rescheduled += 1
-    } else {
-      const reason = verdict.outcome === 'permanent_failure' ? verdict.reason : 'permanent_rejection'
-      applied = await poisonConsumer(db, row.outboxId, row.consumerKey, row.fence, reason, opts)
-      if (applied) result.poisoned += 1
-    }
-    if (!applied) result.lostLease += 1
+    const disposition = await processClaimedRow(db, adapter, row, cfg)
+    if (disposition === 'completed') result.completed += 1
+    else if (disposition === 'rescheduled') result.rescheduled += 1
+    else if (disposition === 'poisoned') result.poisoned += 1
+    else result.lostLease += 1
   }
   return result
 }
@@ -194,29 +420,70 @@ export interface DispatchLoopHandle {
 }
 
 /**
+ * Mandatory telemetry sink for the long-running loop. Unknown keys and tick errors are operational signals
+ * that must be observable — leaving them optional lets a stuck row or a swallowed error go unseen. Every call
+ * is exception-safe inside the loop, so a broken sink can neither kill the process nor stop delivery.
+ */
+export interface DispatchLoopObserver {
+  /** Reclaimable rows carrying a consumer_key this worker doesn't know (rolling-deploy alert). */
+  onUnknownConsumerKeys(keys: string[]): void
+  /** A tick that threw (a DB/claim error) — never swallowed silently. */
+  onTickError(err: unknown): void
+  /** Optional per-tick metrics for observability (completed/rescheduled/poisoned/lostLease counts). */
+  onTick?(result: DispatchTickResult): void
+}
+
+/** Invoke an observer callback without ever letting its throw/rejection escape into the loop. */
+function safeInvoke<A>(fn: ((arg: A) => unknown) | undefined, arg: A): void {
+  if (typeof fn !== 'function') return
+  try {
+    const r = fn(arg)
+    if (r && typeof (r as { then?: unknown }).then === 'function') {
+      void (r as Promise<unknown>).catch(() => undefined)
+    }
+  } catch {
+    // a broken telemetry sink must never kill delivery or the process
+  }
+}
+
+/**
  * The long-running loop: one tick every `intervalMs`, with an overlap guard (a slow tick never runs
- * concurrently with the next). REFUSES to start while the master flag is OFF — the flag is the only
- * activation switch, and S1..S4 all land with it off.
+ * concurrently with the next). REQUIRES a telemetry sink and REFUSES to start while the master flag is OFF —
+ * the flag is the only activation switch, and S1..S4 all land with it off.
  */
 export function startDurableDispatchLoop(
   db: Queryable,
   registry: ConsumerAdapterRegistry,
-  opts: DispatchTickOptions & { intervalMs?: number; env?: NodeJS.ProcessEnv; onTickError?: (err: unknown) => void } = {},
+  observer: DispatchLoopObserver,
+  opts: DispatchTickOptions & { intervalMs?: number; env?: NodeJS.ProcessEnv } = {},
 ): DispatchLoopHandle {
+  if (!observer || typeof observer.onUnknownConsumerKeys !== 'function' || typeof observer.onTickError !== 'function') {
+    throw new TypeError('durable dispatch loop requires a telemetry sink (observer.onUnknownConsumerKeys + observer.onTickError)')
+  }
   if (!isDurableDeliveryEnabled(opts.env ?? process.env)) {
     throw new Error('durable dispatch loop must not start while AUTOMATION_DURABLE_DELIVERY_ENABLED is off')
   }
+  // Validate every knob (incl. intervalMs) BEFORE the timer exists — no hot loop, no fractional backoff (P2#5).
+  validateDispatchNumericParams(opts)
   const intervalMs = opts.intervalMs ?? 1_000
+
   let running = false
   let stopped = false
   let inFlight: Promise<void> = Promise.resolve()
   const timer = setInterval(() => {
     if (running || stopped) return
     running = true
-    inFlight = runDispatchTick(db, registry, opts)
-      .then(() => undefined)
+    inFlight = runDispatchTick(db, registry, {
+      ...opts,
+      // route the alert through the exception-safe sink; break the row loop promptly once stopping.
+      onUnknownConsumerKeys: (keys) => safeInvoke(observer.onUnknownConsumerKeys, keys),
+      shouldStop: () => stopped,
+    })
+      .then((result) => {
+        safeInvoke(observer.onTick, result)
+      })
       .catch((err) => {
-        opts.onTickError?.(err)
+        safeInvoke(observer.onTickError, err)
       })
       .finally(() => {
         running = false

--- a/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
+++ b/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
@@ -1,10 +1,10 @@
 /**
  * P2 durable-delivery — slice S2-b: the dispatch loop (registry + tick).
  *
- * Drives the S2-a claim engine end-to-end: alert on unknown keys → claim a batch for the keys THIS worker
- * knows → for each row **revalidate the lease, run the adapter under a bounded timeout + heartbeat, then
- * resolve via fence-CAS** (complete / reschedule with backoff / poison). Consumer adapters themselves are S5 —
- * this module defines their contract and the loop.
+ * Drives the S2-a claim engine end-to-end: alert on unknown keys → claim ONE row per execution slot for the
+ * keys THIS worker knows → run its adapter under a bounded timeout + heartbeat → resolve via fence-CAS
+ * (complete / reschedule with backoff / poison). Consumer adapters themselves are S5 — this module defines
+ * their contract and the loop.
  *
  * Contract (FWB-0 lock #4203 Layer 1):
  *   - **Registry asserts uniqueness at registration**: a duplicate consumer_key is a STARTUP ERROR, never a
@@ -13,14 +13,17 @@
  *   - **Unknown keys are alerted, never claimed**: rows whose consumer_key this worker doesn't know are
  *     surfaced through `observer.onUnknownConsumerKeys` and left `pending` for a worker that knows them
  *     (#4203 §246 rolling-deploy). Observer calls are best-effort — a throwing sink never fails the tick.
- *   - **A claimed row's lease is re-validated immediately before the adapter runs, and maintained by a
- *     heartbeat while it runs** (both are fence-CAS renews that do NOT bump the fence). A worker that drifted
- *     past its lease during a serial batch — or lost the row to a concurrent reclaim mid-flight — never
- *     produces (or keeps producing) the external side effect: the pre-call renew fails → the adapter is not
- *     called; the heartbeat renew fails → the in-flight call is aborted and the row is left to its new owner.
- *     This is defense in depth over the terminal fence-CAS (which only protects persisted STATE); the
- *     irreducible residue — an adapter mid-emit at the exact instant its lease is lost — is at-least-once and
- *     absorbed by SINK idempotency, per the durable-delivery doctrine.
+ *   - **PER-SLOT claim**: the tick claims ONE reclaimable row at a time (up to `batchSize` slots) and processes
+ *     it immediately — never a batch. The claim increments `attempts` AT CLAIM (crash-safe, S2-a), so a batch
+ *     claim would let a slow front row starve a tail row into `max_attempts` exhaustion WITHOUT its adapter
+ *     ever running; per-slot claim guarantees `attempts == adapter invocations`.
+ *   - **The lease is maintained by a heartbeat while the adapter runs** (a fence-CAS renew, leaseMs/3 period,
+ *     which does NOT bump the fence). A row lost to a concurrent reclaim mid-flight is detected — the renew
+ *     matches 0 rows → the in-flight call is aborted and the row is left to its new owner. This is defense in
+ *     depth over the terminal fence-CAS (which only protects persisted STATE); the irreducible residue — an
+ *     adapter mid-emit at the exact instant its lease is lost — is at-least-once and absorbed by SINK
+ *     idempotency, per the durable-delivery doctrine. (No pre-call renew: per-slot claim gives every row a
+ *     fresh lease at the moment it is processed, so there is no batch-drift window to guard.)
  *   - **The adapter runs under a bounded `adapterTimeoutMs`**: one hung Promise can never freeze the tick,
  *     later rows, or `stop()`. A timeout maps to a retryable `adapter_timeout` (rescheduled with backoff) and
  *     the loop moves on; the dangling promise is neutralized (its later settle can no longer touch the row —
@@ -30,17 +33,19 @@
  *     (S5) and may misbehave. A malformed verdict (unknown outcome, missing/invalid reason, non-object, null)
  *     is a retryable `adapter_error`, NEVER a poison: a bad verdict must not silently drop the event. Only an
  *     exact `{ outcome: 'permanent_failure', reason: 'permanent_rejection' }` dead-letters.
- *   - **Per-row isolation**: one adapter failing/throwing/timing-out never blocks the rest of the batch. (A DB
- *     error on claim/renew/resolve is NOT isolated — it means the store is unhealthy, so it propagates and the
- *     caller's loop surfaces it via `onTickError` and retries next tick.)
+ *   - **Per-row isolation**: one adapter failing/throwing/timing-out never blocks the next row. (A DB error on
+ *     claim/renew/resolve is NOT isolated — it means the store is unhealthy, so it propagates and the caller's
+ *     loop surfaces it via `onTickError` and retries next tick.)
  *   - **Backoff is deterministic exponential with a cap** (no Math.random — reproducible in tests; jitter can
- *     be layered later without changing the persisted contract).
+ *     be layered later without changing the persisted contract), floored so a rescheduled row cannot be
+ *     re-claimed within the same tick (retry stays a future-tick event, not an intra-tick spin).
  *   - **Every numeric knob is a validated safe-integer within an explicit range, checked BEFORE any work** —
- *     at tick entry (before the claim) and at loop start (before the timer). `intervalMs=0` (hot loop) and a
- *     fractional/huge backoff are rejected up front, never after the adapter already ran.
- *   - **The long-running loop requires a telemetry sink**: `onUnknownConsumerKeys` + `onTickError` are
- *     mandatory (a silent stuck-row or a swallowed tick error is an operational blind spot), and every
- *     observer call is exception-safe — a broken sink can neither kill the process nor stop delivery.
+ *     at tick entry (before the claim) and at loop start (before the timer). `intervalMs=0` (hot loop), a
+ *     fractional/huge backoff, a sub-minimum lease, and an effective backoff inversion are rejected up front.
+ *   - **The long-running loop requires a telemetry sink**: `onUnknownConsumerKeys` + `onTickError` +
+ *     `onHeartbeatError` are mandatory (a silent stuck row, a swallowed tick error, or a hidden heartbeat DB
+ *     error is an operational blind spot), and every observer call is exception-safe — a broken sink can
+ *     neither kill the process nor stop delivery.
  *
  * Nothing here runs while `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF: `startDurableDispatchLoop` refuses
  * to start when the flag is off, and no production code calls it yet (that wiring is S5/S4 activation).
@@ -121,6 +126,13 @@ const MAX_INTERVAL_MS = 3_600_000 // 1h — an interval beyond this is almost ce
 // the heartbeat (leaseMs/3) fires and a renew round-trip completes BEFORE the lease expires — otherwise a
 // competitor reclaims a still-running delivery (#4334 review P1-B). 1s is a conservative floor for that margin.
 const MIN_LOOP_LEASE_MS = 1_000
+// Per-slot claim re-claims within one tick if a rescheduled row becomes reclaimable again immediately. A
+// pathological sub-tick backoff (e.g. 1ms) turns retry into a same-tick busy-spin that burns attempts
+// back-to-back and defeats the point of backoff (spreading retries over time). Flooring the backoff base at 1s
+// means a rescheduled row can only be re-claimed after ≥1s of REAL elapsed time — a legitimate retry, not an
+// intra-tick spin (#4334 round-3 adversarial P3). Correctness held either way (attempts == adapter calls), but
+// this keeps the retry schedule honest.
+const MIN_RETRY_BASE_MS = 1_000
 
 /** Reject fractional, non-finite, out-of-safe-range, or out-of-bounds numeric params before they do anything. */
 function requireBoundedInt(name: string, value: number, min: number, max: number): void {
@@ -149,8 +161,9 @@ function validateDispatchNumericParams(
   // leaseMs floor is the loop's, not the claim engine's: the heartbeat needs margin inside the lease (P1-B).
   if (opts.leaseMs !== undefined) requireBoundedInt('leaseMs', opts.leaseMs, MIN_LOOP_LEASE_MS, MAX_MS_24H)
   if (opts.maxAttempts !== undefined) requireBoundedInt('maxAttempts', opts.maxAttempts, 1, 10_000)
-  if (opts.retryBaseMs !== undefined) requireBoundedInt('retryBaseMs', opts.retryBaseMs, 1, MAX_MS_24H)
-  if (opts.retryCapMs !== undefined) requireBoundedInt('retryCapMs', opts.retryCapMs, 1, MAX_MS_24H)
+  // retryBaseMs floor prevents a sub-tick backoff from busy-spinning a rescheduled row (adversarial P3).
+  if (opts.retryBaseMs !== undefined) requireBoundedInt('retryBaseMs', opts.retryBaseMs, MIN_RETRY_BASE_MS, MAX_MS_24H)
+  if (opts.retryCapMs !== undefined) requireBoundedInt('retryCapMs', opts.retryCapMs, MIN_RETRY_BASE_MS, MAX_MS_24H)
   // Inversion check on the EFFECTIVE values (defaults synthesized), so a one-sided override — e.g. a
   // retryBaseMs above the DEFAULT cap with no explicit retryCapMs — is still rejected (#4334 review P2-D).
   const effRetryBaseMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
@@ -313,7 +326,13 @@ async function processClaimedRow(
         // as lostLease) and stop the call conservatively; the terminal fence-CAS is the final state arbiter.
         heartbeatErrored = true
         controller.abort()
-        cfg.onHeartbeatError?.({ outboxId: row.outboxId, consumerKey: row.consumerKey })
+        // This runs inside a voided promise chain — a THROWING seam here would be an unhandled rejection, so
+        // the tick-level callback is self-protected too (the loop already wraps it in safeInvoke).
+        try {
+          cfg.onHeartbeatError?.({ outboxId: row.outboxId, consumerKey: row.consumerKey })
+        } catch {
+          /* best-effort telemetry — never let it escape the heartbeat */
+        }
       })
   }, cfg.heartbeatMs)
   heartbeat.unref?.()

--- a/packages/core-backend/src/multitable/automation-durable-dispatcher.ts
+++ b/packages/core-backend/src/multitable/automation-durable-dispatcher.ts
@@ -112,6 +112,14 @@ export interface ClaimOptions {
   leaseMs?: number
   /** attempt ceiling; a row already attempted this many times is poisoned at claim (default 8; 1..10000). */
   maxAttempts?: number
+  /**
+   * Called for each row that was POISONED at claim (attempts already >= ceiling → dead_letter). Such rows are
+   * NOT returned in the dispatchable list, so without this the caller cannot tell "no reclaimable candidate"
+   * from "the candidate(s) were terminated" — the latter must NOT stop a per-slot poll loop (healthy rows may
+   * be behind them) and the terminal transition must reach telemetry (#4334 review: claim-time poison
+   * head-of-line block). Best-effort — a throwing callback never fails the claim.
+   */
+  onClaimTimePoison?: (info: { outboxId: string; consumerKey: string; attempts: number }) => void
   /** injectable clock for tests. */
   now?: () => Date
 }
@@ -121,7 +129,9 @@ const nowIso = (opts: { now?: () => Date }): string => (opts.now?.() ?? new Date
 /**
  * Atomically claim reclaimable rows FOR THE GIVEN known keys, and poison any that have hit the attempt
  * ceiling. Rows whose key is not in `consumerKeys` are left untouched (they stay `pending`). Returns the
- * rows handed out for dispatch (in_progress) with their claim token + joined outbox event.
+ * rows handed out for dispatch (in_progress) with their claim token + joined outbox event; rows poisoned at
+ * claim (dead_letter) are NOT returned but are reported via `opts.onClaimTimePoison` so a caller can scan
+ * past them (they must not stop a poll loop) and record the terminal transition.
  */
 export async function claimDueConsumers(db: Queryable, opts: ClaimOptions): Promise<ClaimedConsumer[]> {
   const keys = requireKnownKeys(opts?.consumerKeys)
@@ -163,6 +173,7 @@ export async function claimDueConsumers(db: Queryable, opts: ClaimOptions): Prom
             r.consumer_key    AS consumer_key,
             r.fence           AS fence,
             r.attempts        AS attempts,
+            r.status          AS status,
             o.event_type      AS event_type,
             o.event_id        AS event_id,
             o.payload         AS payload,
@@ -170,21 +181,35 @@ export async function claimDueConsumers(db: Queryable, opts: ClaimOptions): Prom
             o.manifest_version AS manifest_version
        FROM resolved r
        JOIN meta_automation_outbox o ON o.id = r.outbox_id
-      WHERE r.status = 'in_progress'   -- poisoned rows are terminated, not dispatched
+      WHERE r.status IN ('in_progress', 'dead_letter')   -- dead_letter = poisoned at claim, reported not dispatched
       ORDER BY o.created_at ASC`,
     [asOf, batchSize, leaseMs, keys, maxAttempts],
   )
-  return rows.map((r) => ({
-    outboxId: String(r.outbox_id),
-    consumerKey: String(r.consumer_key),
-    fence: String(r.fence),
-    attempts: Number(r.attempts),
-    eventType: String(r.event_type),
-    eventId: String(r.event_id),
-    payload: r.payload,
-    automationDepth: Number(r.automation_depth),
-    manifestVersion: Number(r.manifest_version),
-  }))
+  const claimed: ClaimedConsumer[] = []
+  for (const r of rows) {
+    if (String(r.status) === 'dead_letter') {
+      // Poisoned at claim (attempts already >= ceiling). Not dispatchable — report it so the caller keeps
+      // scanning past it and the terminal transition is observable. Best-effort: never let it fail the claim.
+      try {
+        opts.onClaimTimePoison?.({ outboxId: String(r.outbox_id), consumerKey: String(r.consumer_key), attempts: Number(r.attempts) })
+      } catch {
+        /* best-effort telemetry */
+      }
+      continue
+    }
+    claimed.push({
+      outboxId: String(r.outbox_id),
+      consumerKey: String(r.consumer_key),
+      fence: String(r.fence),
+      attempts: Number(r.attempts),
+      eventType: String(r.event_type),
+      eventId: String(r.event_id),
+      payload: r.payload,
+      automationDepth: Number(r.automation_depth),
+      manifestVersion: Number(r.manifest_version),
+    })
+  }
+  return claimed
 }
 
 /**
@@ -284,14 +309,13 @@ export async function rescheduleConsumer(
 }
 
 /**
- * Revalidate-and-renew the lease on a claimed row (S2-b pre-call guard + heartbeat). A **fence-CAS that does
- * NOT bump the fence**: it pushes `lease_expires_at` out by `leaseMs` only while THIS worker still holds the
- * claim token and the row is still `in_progress`. Returns false the instant the worker has lost the row — a
- * concurrent reclaim bumped the fence, or the row already reached a terminal status. The S2-b loop calls this
- * immediately before each adapter invocation (so a worker that drifted past its lease during a serial batch
- * never calls the adapter for a row another worker now owns) and periodically DURING a long adapter call (so a
- * mid-flight reclaim aborts the in-flight work). Unlike `rescheduleConsumer`, renewing keeps the same fence:
- * the worker is extending its own hold, not handing the row off.
+ * Renew the lease on a claimed row (the S2-b heartbeat). A **fence-CAS that does NOT bump the fence**: it
+ * pushes `lease_expires_at` out by `leaseMs` only while THIS worker still holds the claim token and the row is
+ * still `in_progress`. Returns false the instant the worker has lost the row — a concurrent reclaim bumped the
+ * fence, or the row already reached a terminal status. The S2-b loop calls this PERIODICALLY while a long
+ * adapter runs (a heartbeat), so a still-running delivery keeps its hold and a mid-flight reclaim aborts the
+ * in-flight work. Unlike `rescheduleConsumer`, renewing keeps the same fence: the worker is extending its own
+ * hold, not handing the row off.
  */
 export async function renewConsumerLease(
   db: Queryable,

--- a/packages/core-backend/src/multitable/automation-durable-dispatcher.ts
+++ b/packages/core-backend/src/multitable/automation-durable-dispatcher.ts
@@ -284,6 +284,36 @@ export async function rescheduleConsumer(
 }
 
 /**
+ * Revalidate-and-renew the lease on a claimed row (S2-b pre-call guard + heartbeat). A **fence-CAS that does
+ * NOT bump the fence**: it pushes `lease_expires_at` out by `leaseMs` only while THIS worker still holds the
+ * claim token and the row is still `in_progress`. Returns false the instant the worker has lost the row — a
+ * concurrent reclaim bumped the fence, or the row already reached a terminal status. The S2-b loop calls this
+ * immediately before each adapter invocation (so a worker that drifted past its lease during a serial batch
+ * never calls the adapter for a row another worker now owns) and periodically DURING a long adapter call (so a
+ * mid-flight reclaim aborts the in-flight work). Unlike `rescheduleConsumer`, renewing keeps the same fence:
+ * the worker is extending its own hold, not handing the row off.
+ */
+export async function renewConsumerLease(
+  db: Queryable,
+  outboxId: string,
+  consumerKey: string,
+  fence: string,
+  leaseMs: number,
+  opts: { now?: () => Date } = {},
+): Promise<boolean> {
+  requireBoundedInt('leaseMs', leaseMs, 1, MAX_LEASE_MS)
+  const asOf = nowIso(opts)
+  const res = await db.query(
+    `UPDATE meta_automation_outbox_consumer
+        SET lease_expires_at = $4::timestamptz + ($5::int * interval '1 millisecond'),
+            updated_at = $4::timestamptz
+      WHERE outbox_id = $1 AND consumer_key = $2 AND fence = $3::bigint AND status = 'in_progress'`,
+    [outboxId, consumerKey, fence, asOf, leaseMs],
+  )
+  return Number(res.rowCount ?? 0) === 1
+}
+
+/**
  * Map an adapter outcome to a resolve action. Attempt-exhaustion is NOT an outcome here — it is enforced at
  * claim (crash-safe), so a plain `retryable_failure` at the ceiling is still `reschedule` and the next claim
  * poisons it. Kept pure so the S2-b loop's branching is unit-testable without a DB.

--- a/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
@@ -331,6 +331,37 @@ describeIfDatabase('P2 durable-delivery S2-b — dispatch loop (real DB)', () =>
     expect(await readRow(id, k)).toMatchObject({ status: 'dead_letter', last_error: 'max_attempts_exhausted' })
   })
 
+  // [#4334 review P2 head-of-line] When the OLDEST reclaimable row is already at the attempt ceiling it is
+  // poisoned AT CLAIM and not dispatched — the per-slot loop must SCAN PAST it (a healthy row is queued behind
+  // it), not mistake the empty claim for "no work" and break. The claim-time poison is counted + surfaced.
+  test('P2: a claim-time-poisoned oldest row does not block a healthy row behind it', async () => {
+    const kOld = `ck_${RUN}_holOld`
+    const kNew = `ck_${RUN}_holNew`
+    const idOld = await seedRow(kOld)
+    const idNew = await seedRow(kNew)
+    await db().query(`UPDATE meta_automation_outbox SET created_at = now() - interval '2 seconds' WHERE id=$1`, [idOld])
+    await db().query(`UPDATE meta_automation_outbox SET created_at = now() - interval '1 second'  WHERE id=$1`, [idNew])
+    // the old row is ALREADY at the ceiling (attempts=2, maxAttempts=2) → poisoned at claim, returns no row.
+    await db().query(`UPDATE meta_automation_outbox_consumer SET attempts = 2 WHERE outbox_id=$1`, [idOld])
+    let newCalled = 0
+    const claimPoisons: string[] = []
+    const r = new ConsumerAdapterRegistry()
+    r.register(adapter(kOld, ok)) // never actually invoked (poisoned at claim, before any adapter call)
+    r.register(
+      adapter(kNew, async () => {
+        newCalled += 1
+        return { outcome: 'success' }
+      }),
+    )
+    const res = await runDispatchTick(db(), r, { batchSize: 2, maxAttempts: 2, onClaimTimePoison: (i) => claimPoisons.push(i.consumerKey) })
+    expect(newCalled).toBe(1) // the healthy row behind the poisoned one WAS delivered — no head-of-line block
+    expect(res.completed).toBe(1)
+    expect(res.claimTimePoisoned).toBe(1) // the terminal transition is counted...
+    expect(claimPoisons).toContain(kOld) // ...and surfaced to telemetry
+    expect((await readRow(idOld, kOld)).status).toBe('dead_letter')
+    expect((await readRow(idNew, kNew)).status).toBe('done')
+  })
+
   // [#4334 review P1#2] A malformed adapter verdict must RETRY (values-free adapter_error), never poison —
   // poisoning drops the event. Only an exact permanent verdict dead-letters.
   test('P1#2: malformed adapter verdicts reschedule as adapter_error (never dead_letter)', async () => {

--- a/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
@@ -33,7 +33,7 @@ import {
 import type { ClaimedConsumer, Queryable } from '../../src/multitable/automation-durable-dispatcher'
 
 /** A minimal always-valid telemetry sink for tests that don't assert on it. */
-const noopObserver: DispatchLoopObserver = { onUnknownConsumerKeys: () => {}, onTickError: () => {} }
+const noopObserver: DispatchLoopObserver = { onUnknownConsumerKeys: () => {}, onTickError: () => {}, onHeartbeatError: () => {} }
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const db = () => poolManager.get()
@@ -252,48 +252,83 @@ describeIfDatabase('P2 durable-delivery S2-b — dispatch loop (real DB)', () =>
     }
   }, 15_000)
 
-  // [#4334 review P1#1] Batch-claim + serial execution: a worker that LOSES its lease mid-batch must not go
-  // on to call the next row's adapter (double external emit). The pre-call fence-CAS renew is the guard.
-  test('P1#1: a stale worker does NOT invoke the adapter for a row a concurrent worker reclaimed mid-batch', async () => {
-    const k1 = `ck_${RUN}_slotA`
-    const k2 = `ck_${RUN}_slotB`
-    const id1 = await seedRow(k1)
-    const id2 = await seedRow(k2)
-    // Deterministic dispatch order: row1 before row2 (claim dispatches ORDER BY outbox.created_at ASC).
+  // [#4334 review P1-A] Per-slot claim: the dispatcher claims ONE row per execution slot, so a row it never
+  // reaches never has its attempt burned (a BATCH claim would bump attempts for every claimed row up front,
+  // letting a starved tail row exhaust attempts and dead-letter WITHOUT its adapter ever running).
+  test('P1-A: per-slot claim never burns an attempt on a row it does not reach', async () => {
+    const k = `ck_${RUN}_slot`
+    const id0 = await seedRow(k)
+    const id1 = await seedRow(k)
+    const id2 = await seedRow(k)
+    // deterministic order id0 < id1 < id2 (claim dispatches oldest-first).
+    await db().query(`UPDATE meta_automation_outbox SET created_at = now() - interval '3 seconds' WHERE id=$1`, [id0])
     await db().query(`UPDATE meta_automation_outbox SET created_at = now() - interval '2 seconds' WHERE id=$1`, [id1])
     await db().query(`UPDATE meta_automation_outbox SET created_at = now() - interval '1 second'  WHERE id=$1`, [id2])
-
-    const callOrder: string[] = []
-    let k2Called = false
+    let processed = 0
     const r = new ConsumerAdapterRegistry()
-    // Row1's adapter simulates a CONCURRENT RECLAIM of row2 (exactly what another worker's claim does: bump
-    // the fence) while THIS worker is mid-batch. When the loop reaches row2, its pre-call renew must fail.
     r.register(
-      adapter(k1, async () => {
-        callOrder.push('k1')
-        await db().query(
-          `UPDATE meta_automation_outbox_consumer SET fence = fence + 1 WHERE outbox_id=$1 AND consumer_key=$2`,
-          [id2, k2],
-        )
+      adapter(k, async () => {
+        processed += 1
         return { outcome: 'success' }
       }),
     )
-    r.register(
-      adapter(k2, async () => {
-        k2Called = true
-        callOrder.push('k2')
-        return { outcome: 'success' }
-      }),
-    )
+    // stop the loop right after the first row: with per-slot claim, the rest are NEVER claimed.
+    const res = await runDispatchTick(db(), r, { shouldStop: () => processed >= 1 })
+    expect(res.claimed).toBe(1)
+    expect(res.completed).toBe(1)
+    expect((await readRow(id0, k)).status).toBe('done')
+    // the unreached rows are untouched — still pending, attempts NOT burned (a batch claim would show attempts=1).
+    expect(await readRow(id1, k)).toMatchObject({ status: 'pending', attempts: 0 })
+    expect(await readRow(id2, k)).toMatchObject({ status: 'pending', attempts: 0 })
+  })
 
-    const res = await runDispatchTick(db(), r)
-    expect(res.claimed).toBe(2)
-    expect(k2Called).toBe(false) // the guard held: the stale row's adapter was never called
-    expect(callOrder).toEqual(['k1']) // only the still-owned row ran
-    expect(res.completed).toBe(1) // row1
-    expect(res.lostLease).toBe(1) // row2 skipped at the pre-call renew
-    expect((await readRow(id1, k1)).status).toBe('done')
-    expect((await readRow(id2, k2)).status).toBe('in_progress') // left to its new owner, untouched by us
+  // [#4334 review P1-A] Three concurrent dispatchers over the same rows: each row is delivered EXACTLY once
+  // (per-slot claim + FOR UPDATE SKIP LOCKED distributes disjoint rows; no double delivery, no starvation).
+  test('P1-A: three concurrent dispatchers deliver each row exactly once', async () => {
+    const k = `ck_${RUN}_3w`
+    const ids = [await seedRow(k), await seedRow(k), await seedRow(k)]
+    let calls = 0
+    const mkReg = () => {
+      const r = new ConsumerAdapterRegistry()
+      r.register(
+        adapter(k, async () => {
+          calls += 1
+          return { outcome: 'success' }
+        }),
+      )
+      return r
+    }
+    const results = await Promise.all([runDispatchTick(db(), mkReg()), runDispatchTick(db(), mkReg()), runDispatchTick(db(), mkReg())])
+    expect(calls).toBe(3) // each row attempted exactly once — no double delivery
+    expect(results.reduce((a, r) => a + r.completed, 0)).toBe(3)
+    expect(results.reduce((a, r) => a + r.claimed, 0)).toBe(3) // three rows claimed across three workers, no double-claim
+    for (const id of ids) expect((await readRow(id, k)).status).toBe('done')
+  })
+
+  // [#4334 review P1-A] A row is dead-lettered by attempt-exhaustion ONLY after its adapter was ACTUALLY
+  // attempted maxAttempts times — never poisoned-without-execution.
+  test('P1-A: dead_letter by exhaustion happens only after maxAttempts real adapter calls', async () => {
+    const k = `ck_${RUN}_exhaust`
+    const id = await seedRow(k)
+    let calls = 0
+    const r = new ConsumerAdapterRegistry()
+    r.register(
+      adapter(k, async () => {
+        calls += 1
+        return { outcome: 'retryable_failure', reason: 'adapter_error' }
+      }),
+    )
+    const forceExpiry = () =>
+      db().query(`UPDATE meta_automation_outbox_consumer SET lease_expires_at = now() - interval '1 second' WHERE outbox_id=$1`, [id])
+    await runDispatchTick(db(), r, { maxAttempts: 2, retryBaseMs: 1_000, retryCapMs: 2_000 })
+    expect(calls).toBe(1)
+    await forceExpiry()
+    await runDispatchTick(db(), r, { maxAttempts: 2, retryBaseMs: 1_000, retryCapMs: 2_000 })
+    expect(calls).toBe(2)
+    await forceExpiry()
+    await runDispatchTick(db(), r, { maxAttempts: 2 }) // this claim poisons (attempts>=max) — no new adapter call
+    expect(calls).toBe(2) // attempted exactly maxAttempts times; NOT poisoned with calls=0
+    expect(await readRow(id, k)).toMatchObject({ status: 'dead_letter', last_error: 'max_attempts_exhausted' })
   })
 
   // [#4334 review P1#2] A malformed adapter verdict must RETRY (values-free adapter_error), never poison —
@@ -356,6 +391,7 @@ describeIfDatabase('P2 durable-delivery S2-b — dispatch loop (real DB)', () =>
         throw new Error('telemetry sink down')
       },
       onTickError: () => {},
+      onHeartbeatError: () => {},
     }
     const handle = startDurableDispatchLoop(db(), r, throwingObserver, {
       env: { AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv,
@@ -453,6 +489,102 @@ describeIfDatabase('P2 durable-delivery S2-b — dispatch loop (real DB)', () =>
     expect(await readRow(idBad, badKey)).toMatchObject({ status: 'in_progress', last_error: 'adapter_error' })
     expect((await readRow(idOk, okKey)).status).toBe('done')
   })
+
+  // [#4334 review P1-B] The heartbeat period must be strictly INSIDE the lease (leaseMs/3), not a fixed 1s
+  // floor that can equal/exceed a short lease. At the loop minimum lease (1000ms) the heartbeat fires at
+  // ~333ms and renews BEFORE the old 1s floor would have — provable by the lease still having ample margin.
+  test('P1-B: at the minimum lease the heartbeat renews well before the old 1s floor', async () => {
+    const key = `ck_${RUN}_hbmin`
+    const id = await seedRow(key)
+    const r = new ConsumerAdapterRegistry()
+    r.register(
+      adapter(key, async () => {
+        await new Promise((res2) => setTimeout(res2, 1_200))
+        return { outcome: 'success' }
+      }),
+    )
+    const tick = runDispatchTick(db(), r, { leaseMs: 1_000, adapterTimeoutMs: 9_000 })
+    await new Promise((res2) => setTimeout(res2, 600)) // t≈600ms: after the ~333ms heartbeat, before 1000ms
+    const mid = await readRow(id, key)
+    expect(mid.status).toBe('in_progress')
+    // renewed at ~333ms → lease≈1333 → remaining≈733; a fixed-1s-floor heartbeat would NOT have fired yet (≈400).
+    expect(Number(mid.lease_remaining_ms)).toBeGreaterThan(500)
+    const res = await tick
+    expect(res.completed).toBe(1)
+  }, 15_000)
+
+  // [#4334 review P1-B] Two REAL dispatchers (not manual fence++): while A runs a long adapter under a legal
+  // lease, its heartbeat keeps the lease alive so a second dispatcher B cannot reclaim it — no double call.
+  test('P1-B: two real dispatchers — the heartbeat blocks a concurrent reclaim (no double call)', async () => {
+    const key = `ck_${RUN}_2disp`
+    const id = await seedRow(key)
+    let callsA = 0
+    let callsB = 0
+    const regA = new ConsumerAdapterRegistry()
+    regA.register(
+      adapter(key, async () => {
+        callsA += 1
+        await new Promise((res2) => setTimeout(res2, 1_500))
+        return { outcome: 'success' }
+      }),
+    )
+    const regB = new ConsumerAdapterRegistry()
+    regB.register(
+      adapter(key, async () => {
+        callsB += 1
+        return { outcome: 'success' }
+      }),
+    )
+    const tickA = runDispatchTick(db(), regA, { leaseMs: 1_000, adapterTimeoutMs: 9_000 })
+    await new Promise((res2) => setTimeout(res2, 1_200)) // past the ORIGINAL 1s lease — only the heartbeat keeps it
+    const tickB = await runDispatchTick(db(), regB, { leaseMs: 1_000 })
+    expect(tickB.claimed).toBe(0) // B could not reclaim — A's heartbeat held the lease
+    expect(callsB).toBe(0) // ...so B never called the adapter (no A,B double delivery)
+    const resA = await tickA
+    expect(callsA).toBe(1)
+    expect(resA.completed).toBe(1)
+    expect((await readRow(id, key)).status).toBe('done')
+  }, 20_000)
+
+  // [#4334 review P2-C] A heartbeat renew that hits a DB ERROR is an infra signal — surfaced via a dedicated
+  // telemetry seam and counted distinctly, NEVER masqueraded as a normal (competitor-won) lost lease.
+  test('P2-C: a heartbeat renew DB error is surfaced (onHeartbeatError), not folded into lostLease', async () => {
+    const key = `ck_${RUN}_hbdberr`
+    const id = await seedRow(key)
+    const real = db()
+    let renewCalls = 0
+    // Wrap the pool: let everything through EXCEPT the heartbeat renew (its UPDATE is the only `SET
+    // lease_expires_at` with no `last_error`), which throws to simulate a mid-flight store blip.
+    const failingDb: Queryable = {
+      query: async (sql, params) => {
+        if (/SET\s+lease_expires_at/.test(sql) && !/last_error/.test(sql)) {
+          renewCalls += 1
+          throw new Error('heartbeat db down')
+        }
+        return real.query(sql, params)
+      },
+    }
+    const r = new ConsumerAdapterRegistry()
+    r.register(
+      adapter(key, async () => {
+        await new Promise((res2) => setTimeout(res2, 800)) // long enough for a heartbeat (leaseMs/3 ≈ 333ms)
+        return { outcome: 'success' }
+      }),
+    )
+    let heartbeatErrorsSeen = 0
+    const res = await runDispatchTick(failingDb, r, {
+      leaseMs: 1_000,
+      adapterTimeoutMs: 9_000,
+      onHeartbeatError: () => {
+        heartbeatErrorsSeen += 1
+      },
+    })
+    expect(renewCalls).toBeGreaterThan(0) // the heartbeat renew was attempted and threw
+    expect(heartbeatErrorsSeen).toBeGreaterThan(0) // surfaced via the dedicated seam...
+    expect(res.heartbeatErrors).toBe(1) // ...and counted distinctly
+    expect(res.lostLease).toBe(0) // NOT masqueraded as a normal lost lease
+    expect((await readRow(id, key)).status).toBe('in_progress') // left unresolved for reclaim
+  }, 15_000)
 })
 
 /**
@@ -523,6 +655,26 @@ describe('P2 durable-delivery S2-b — pure guards (no DB)', () => {
     await expect(runDispatchTick(unreachableDb, oneAdapterRegistry(), { batchSize: 2.5 })).rejects.toThrow(/batchSize/)
   })
 
+  test('P1-B: a lease below the loop minimum is rejected (the heartbeat needs margin inside the lease)', async () => {
+    await expect(runDispatchTick(unreachableDb, oneAdapterRegistry(), { leaseMs: 300 })).rejects.toThrow(/leaseMs/)
+    expect(() => startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), noopObserver, { env: flagOn, leaseMs: 300 })).toThrow(/leaseMs/)
+  })
+
+  test('P2-D: a one-sided backoff override is validated against effective defaults', async () => {
+    // retryBaseMs above the DEFAULT cap (15min), with NO explicit retryCapMs, is still an inversion — reject it.
+    const aboveDefaultCap = 20 * 60_000
+    expect(() => startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), noopObserver, { env: flagOn, retryBaseMs: aboveDefaultCap })).toThrow(/retryCapMs/)
+    await expect(runDispatchTick(unreachableDb, oneAdapterRegistry(), { retryBaseMs: aboveDefaultCap })).rejects.toThrow(/retryCapMs/)
+  })
+
+  test('P2#4: onHeartbeatError is also a required sink (a degrading store must be observable)', () => {
+    expect(() =>
+      startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), { onUnknownConsumerKeys: () => {}, onTickError: () => {} } as unknown as DispatchLoopObserver, {
+        env: flagOn,
+      }),
+    ).toThrow(/telemetry sink/)
+  })
+
   test('P2#4: a throwing observer.onTickError never becomes an unhandled rejection (loop survives a DB error)', async () => {
     const rejectingDb: Queryable = {
       query: async () => {
@@ -532,6 +684,7 @@ describe('P2 durable-delivery S2-b — pure guards (no DB)', () => {
     let tickErrorSeen = 0
     const observer: DispatchLoopObserver = {
       onUnknownConsumerKeys: () => {},
+      onHeartbeatError: () => {},
       onTickError: () => {
         tickErrorSeen += 1
         throw new Error('and the error sink is down too')

--- a/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
@@ -1,0 +1,249 @@
+/**
+ * P2 durable-delivery — slice S2-b: dispatch loop (registry + tick) against real Postgres.
+ *
+ * Proves the loop's guarantees end-to-end on the real outbox tables:
+ *   - registry uniqueness is a startup error (duplicate key throws — never a silent double-run);
+ *   - a success adapter's row completes; a retryable failure reschedules with a GROWING backoff lease and a
+ *     values-free reason; a permanent failure dead-letters;
+ *   - an adapter THROW maps to retryable `adapter_error` (never poison, never verbatim message);
+ *   - per-row isolation: one adapter failing never blocks another row in the same tick;
+ *   - rolling-deploy: a row with a consumer_key outside the registry is alerted via the seam and left
+ *     `pending` untouched;
+ *   - the long-running loop REFUSES to start with the master flag OFF, and with the flag ON (injected env)
+ *     actually drains a row, then stop() halts it.
+ *
+ * Consumer keys are randomUUID()-scoped for shared-DB isolation. Two-point wired (plugin-tests.yml +
+ * vitest.config.ts exclude) so it cannot skip-green.
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import {
+  computeRetryDelayMs,
+  ConsumerAdapterRegistry,
+  runDispatchTick,
+  startDurableDispatchLoop,
+  type AdapterOutcome,
+  type ConsumerAdapter,
+} from '../../src/multitable/automation-durable-dispatch-loop'
+import type { ClaimedConsumer } from '../../src/multitable/automation-durable-dispatcher'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const db = () => poolManager.get()
+const RUN = randomUUID()
+const outboxIds: string[] = []
+let seq = 0
+
+async function seedRow(consumerKey: string) {
+  const id = `ob_s2b_${RUN}_${seq}`
+  seq += 1
+  outboxIds.push(id)
+  await db().query(
+    `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
+     VALUES ($1,'approval.approved',$2::jsonb,0,1,$3)`,
+    [id, JSON.stringify({ ob: id }), `evt_${id}`],
+  )
+  await db().query(
+    `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key) VALUES ($1,$2)`,
+    [id, consumerKey],
+  )
+  return id
+}
+
+async function readRow(outboxId: string, consumerKey: string) {
+  const { rows } = await db().query(
+    `SELECT status, fence::text AS fence, attempts, last_error,
+            (lease_expires_at IS NULL) AS lease_null,
+            GREATEST(0, ceil(extract(epoch FROM (lease_expires_at - now())) * 1000))::bigint::text AS lease_remaining_ms
+       FROM meta_automation_outbox_consumer WHERE outbox_id=$1 AND consumer_key=$2`,
+    [outboxId, consumerKey],
+  )
+  return rows[0] as {
+    status: string
+    fence: string
+    attempts: number
+    last_error: string | null
+    lease_null: boolean
+    lease_remaining_ms: string
+  }
+}
+
+function adapter(key: string, handle: (e: ClaimedConsumer) => Promise<AdapterOutcome>): ConsumerAdapter {
+  return { key, handle }
+}
+
+const ok = async (): Promise<AdapterOutcome> => ({ outcome: 'success' })
+
+describeIfDatabase('P2 durable-delivery S2-b — dispatch loop (real DB)', () => {
+  afterAll(async () => {
+    if (outboxIds.length) {
+      await db().query('DELETE FROM meta_automation_outbox WHERE id = ANY($1)', [outboxIds]).catch(() => {})
+    }
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('registry: duplicate consumer_key registration throws (startup error, never silent double-run)', () => {
+    const r = new ConsumerAdapterRegistry()
+    r.register(adapter('dup-key', ok))
+    expect(() => r.register(adapter('dup-key', ok))).toThrow(/duplicate consumer adapter/)
+    expect(() => r.register(adapter('', ok))).toThrow(/non-empty/)
+    expect(r.keys()).toEqual(['dup-key'])
+  })
+
+  test('tick with an empty registry throws (empty known-keys would hide misconfiguration)', async () => {
+    await expect(runDispatchTick(db(), new ConsumerAdapterRegistry())).rejects.toThrow(/at least one adapter/)
+  })
+
+  test('success adapter: the row is claimed and completed in one tick; the adapter saw the joined event', async () => {
+    const key = `ck_${RUN}_ok`
+    const id = await seedRow(key)
+    const seen: ClaimedConsumer[] = []
+    const r = new ConsumerAdapterRegistry()
+    r.register(adapter(key, async (e) => (seen.push(e), { outcome: 'success' })))
+    const res = await runDispatchTick(db(), r)
+    expect(res).toMatchObject({ claimed: 1, completed: 1, rescheduled: 0, poisoned: 0, lostLease: 0 })
+    expect(seen[0]).toMatchObject({ outboxId: id, consumerKey: key, eventType: 'approval.approved', eventId: `evt_${id}` })
+    expect(await readRow(id, key)).toMatchObject({ status: 'done', lease_null: true })
+  })
+
+  test('retryable failure: rescheduled with a values-free reason and a backoff lease that GROWS with attempts', async () => {
+    const key = `ck_${RUN}_retry`
+    const id = await seedRow(key)
+    const r = new ConsumerAdapterRegistry()
+    r.register(adapter(key, async () => ({ outcome: 'retryable_failure', reason: 'adapter_timeout' })))
+    // attempt 1 → backoff base (5s default here: use explicit base for determinism)
+    const t1 = await runDispatchTick(db(), r, { retryBaseMs: 60_000, retryCapMs: 600_000 })
+    expect(t1).toMatchObject({ claimed: 1, rescheduled: 1, completed: 0, poisoned: 0 })
+    const after1 = await readRow(id, key)
+    expect(after1).toMatchObject({ status: 'in_progress', attempts: 1, last_error: 'adapter_timeout', lease_null: false })
+    const remaining1 = Number(after1.lease_remaining_ms)
+    expect(remaining1).toBeGreaterThan(30_000) // ~60s backoff, not the tiny claim lease
+    // not reclaimable inside the backoff window
+    expect((await runDispatchTick(db(), r, { retryBaseMs: 60_000 })).claimed).toBe(0)
+    // force expiry → attempt 2 → backoff doubles (120s)
+    await db().query(
+      `UPDATE meta_automation_outbox_consumer SET lease_expires_at = now() - interval '1 second' WHERE outbox_id=$1`,
+      [id],
+    )
+    const t2 = await runDispatchTick(db(), r, { retryBaseMs: 60_000, retryCapMs: 600_000 })
+    expect(t2).toMatchObject({ claimed: 1, rescheduled: 1 })
+    const after2 = await readRow(id, key)
+    expect(after2.attempts).toBe(2)
+    expect(Number(after2.lease_remaining_ms)).toBeGreaterThan(remaining1) // grew: 120s > 60s
+  })
+
+  test('permanent failure: dead_letter with permanent_rejection', async () => {
+    const key = `ck_${RUN}_perm`
+    const id = await seedRow(key)
+    const r = new ConsumerAdapterRegistry()
+    r.register(adapter(key, async () => ({ outcome: 'permanent_failure', reason: 'permanent_rejection' })))
+    const res = await runDispatchTick(db(), r)
+    expect(res).toMatchObject({ claimed: 1, poisoned: 1 })
+    expect(await readRow(id, key)).toMatchObject({ status: 'dead_letter', last_error: 'permanent_rejection', lease_null: true })
+  })
+
+  test('adapter THROW (with a secret-shaped message) → retryable adapter_error; message never persisted', async () => {
+    const key = `ck_${RUN}_throw`
+    const id = await seedRow(key)
+    const r = new ConsumerAdapterRegistry()
+    r.register(
+      adapter(key, async () => {
+        throw new Error('https://internal.example/hook?token=SECRET-VALUE')
+      }),
+    )
+    const res = await runDispatchTick(db(), r)
+    expect(res).toMatchObject({ claimed: 1, rescheduled: 1, poisoned: 0 })
+    const row = await readRow(id, key)
+    expect(row).toMatchObject({ status: 'in_progress', last_error: 'adapter_error' })
+    expect(row.last_error).not.toContain('SECRET') // the raw message never reaches the DB
+  })
+
+  test('per-row isolation: a throwing adapter for row A does not block row B completing in the same tick', async () => {
+    const keyA = `ck_${RUN}_isoA`
+    const keyB = `ck_${RUN}_isoB`
+    const idA = await seedRow(keyA)
+    const idB = await seedRow(keyB)
+    const r = new ConsumerAdapterRegistry()
+    r.register(
+      adapter(keyA, async () => {
+        throw new Error('boom')
+      }),
+    )
+    r.register(adapter(keyB, ok))
+    const res = await runDispatchTick(db(), r)
+    expect(res.claimed).toBe(2)
+    expect(res.completed).toBe(1)
+    expect(res.rescheduled).toBe(1)
+    expect((await readRow(idA, keyA)).status).toBe('in_progress')
+    expect((await readRow(idB, keyB)).status).toBe('done')
+  })
+
+  test('rolling deploy: an unknown consumer_key is alerted through the seam and left pending untouched', async () => {
+    const unknownKey = `ck_${RUN}_unknown`
+    const knownKey = `ck_${RUN}_known`
+    const idU = await seedRow(unknownKey)
+    await seedRow(knownKey)
+    const alerted: string[][] = []
+    const r = new ConsumerAdapterRegistry()
+    r.register(adapter(knownKey, ok))
+    const res = await runDispatchTick(db(), r, { onUnknownConsumerKeys: (k) => alerted.push(k) })
+    expect(alerted.flat()).toContain(unknownKey) // surfaced for alerting
+    expect(res.unknownKeys).toContain(unknownKey)
+    expect(await readRow(idU, unknownKey)).toMatchObject({ status: 'pending', attempts: 0 }) // untouched
+  })
+
+  test('a THROWING alert callback never fails the tick (best-effort seam)', async () => {
+    const unknownKey = `ck_${RUN}_alertthrow_u`
+    const knownKey = `ck_${RUN}_alertthrow_k`
+    await seedRow(unknownKey)
+    const idK = await seedRow(knownKey)
+    const r = new ConsumerAdapterRegistry()
+    r.register(adapter(knownKey, ok))
+    const res = await runDispatchTick(db(), r, {
+      onUnknownConsumerKeys: () => {
+        throw new Error('alert sink down')
+      },
+    })
+    expect(res.completed).toBe(1) // delivery still happened
+    expect((await readRow(idK, knownKey)).status).toBe('done')
+  })
+
+  test('computeRetryDelayMs (pure): exponential from base, capped, clamped inputs', () => {
+    expect(computeRetryDelayMs(1, 5_000, 900_000)).toBe(5_000)
+    expect(computeRetryDelayMs(2, 5_000, 900_000)).toBe(10_000)
+    expect(computeRetryDelayMs(5, 5_000, 900_000)).toBe(80_000)
+    expect(computeRetryDelayMs(10, 5_000, 900_000)).toBe(900_000) // capped
+    expect(computeRetryDelayMs(0)).toBe(computeRetryDelayMs(1)) // clamped
+    expect(computeRetryDelayMs(1_000_000, 5_000, 900_000)).toBe(900_000) // huge attempts: capped, no overflow
+  })
+
+  test('loop: refuses to start with the flag OFF; with flag ON drains a row and stop() halts', async () => {
+    const key = `ck_${RUN}_loop`
+    const id = await seedRow(key)
+    const r = new ConsumerAdapterRegistry()
+    r.register(adapter(key, ok))
+    // flag OFF (empty env) → must refuse
+    expect(() => startDurableDispatchLoop(db(), r, { env: {} as NodeJS.ProcessEnv })).toThrow(/must not start/)
+    // flag ON via injected env → drains the seeded row, then stops cleanly
+    const handle = startDurableDispatchLoop(db(), r, {
+      env: { AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv,
+      intervalMs: 100,
+    })
+    try {
+      const deadline = Date.now() + 8_000
+      // eslint-disable-next-line no-unmodified-loop-condition
+      while (Date.now() < deadline) {
+        if ((await readRow(id, key)).status === 'done') break
+        await new Promise((res2) => setTimeout(res2, 100))
+      }
+      expect((await readRow(id, key)).status).toBe('done')
+    } finally {
+      await handle.stop()
+    }
+  }, 15_000)
+})

--- a/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
@@ -373,6 +373,86 @@ describeIfDatabase('P2 durable-delivery S2-b — dispatch loop (real DB)', () =>
       await handle.stop()
     }
   }, 15_000)
+
+  // [#4334 adversarial P3-1 leg 1] The heartbeat must DETECT a mid-flight reclaim and ABORT the in-flight
+  // adapter (so a cooperative adapter stops emitting the instant it loses the row).
+  test('P3-1a: heartbeat aborts the in-flight adapter when the row is reclaimed mid-flight', async () => {
+    const key = `ck_${RUN}_hb_abort`
+    const id = await seedRow(key)
+    let abortedObserved = false
+    const r = new ConsumerAdapterRegistry()
+    r.register({
+      key,
+      handle: async (_e, ctx) => {
+        // simulate a CONCURRENT worker reclaiming THIS row mid-flight (a reclaim bumps the fence).
+        await db().query(
+          `UPDATE meta_automation_outbox_consumer SET fence = fence + 1 WHERE outbox_id=$1 AND consumer_key=$2`,
+          [id, key],
+        )
+        // wait for the heartbeat to notice the lost fence and abort us (bounded so a broken guard can't hang).
+        const start = Date.now()
+        while (!ctx?.signal.aborted && Date.now() - start < 6_000) {
+          await new Promise((res2) => setTimeout(res2, 50))
+        }
+        abortedObserved = ctx?.signal.aborted ?? false
+        return { outcome: 'success' }
+      },
+    })
+    // small lease → heartbeat at ~1s; generous adapterTimeout so the TIMEOUT doesn't preempt the heartbeat.
+    const res = await runDispatchTick(db(), r, { leaseMs: 1_500, adapterTimeoutMs: 9_000 })
+    expect(abortedObserved).toBe(true) // the heartbeat detected the reclaim and aborted the call
+    expect(res.lostLease).toBe(1) // we did not resolve a row we no longer own
+    expect(res.completed).toBe(0)
+  }, 15_000)
+
+  // [#4334 adversarial P3-1 leg 2] The heartbeat must RENEW the lease of a long adapter so it outlives the
+  // original claim window (otherwise a competitor could reclaim a still-running delivery).
+  test('P3-1b: heartbeat renews a long adapter\'s lease past the original claim window', async () => {
+    const key = `ck_${RUN}_hb_renew`
+    const id = await seedRow(key)
+    const r = new ConsumerAdapterRegistry()
+    r.register({
+      key,
+      handle: async () => {
+        await new Promise((res2) => setTimeout(res2, 2_600)) // runs well past the 1500ms claim lease
+        return { outcome: 'success' }
+      },
+    })
+    const tick = runDispatchTick(db(), r, { leaseMs: 1_500, adapterTimeoutMs: 9_000 })
+    await new Promise((res2) => setTimeout(res2, 1_900)) // t≈1.9s: the ORIGINAL 1.5s lease would be expired now
+    const mid = await readRow(id, key)
+    expect(mid.status).toBe('in_progress')
+    expect(Number(mid.lease_remaining_ms)).toBeGreaterThan(300) // the heartbeat (t≈1s) pushed the lease out
+    const res = await tick
+    expect(res.completed).toBe(1) // the long adapter still resolved cleanly (never lost its lease)
+    expect((await readRow(id, key)).status).toBe('done')
+  }, 15_000)
+
+  // [#4334 adversarial P3-2] A hostile/throwing-getter return value must NOT throw the batch — it is a
+  // malformed verdict → retryable adapter_error, and a sibling row still completes (per-row isolation).
+  test('P3-2: a throwing-getter adapter return → adapter_error (not a thrown batch); sibling still completes', async () => {
+    const badKey = `ck_${RUN}_getterthrow`
+    const okKey = `ck_${RUN}_getterthrow_ok`
+    const idBad = await seedRow(badKey)
+    const idOk = await seedRow(okKey)
+    const r = new ConsumerAdapterRegistry()
+    r.register({
+      key: badKey,
+      handle: async () =>
+        ({
+          get outcome() {
+            throw new Error('hostile getter')
+          },
+        }) as unknown as AdapterOutcome,
+    })
+    r.register(adapter(okKey, ok))
+    const res = await runDispatchTick(db(), r)
+    expect(res.claimed).toBe(2)
+    expect(res.rescheduled).toBe(1) // the hostile row retried, not dropped, not a thrown batch
+    expect(res.completed).toBe(1) // the sibling completed — per-row isolation held
+    expect(await readRow(idBad, badKey)).toMatchObject({ status: 'in_progress', last_error: 'adapter_error' })
+    expect((await readRow(idOk, okKey)).status).toBe('done')
+  })
 })
 
 /**
@@ -410,6 +490,16 @@ describe('P2 durable-delivery S2-b — pure guards (no DB)', () => {
     }
     expect(normalizeAdapterVerdict({ outcome: 'bogus' })).toEqual({ action: 'reschedule', reason: 'adapter_error' })
     expect(normalizeAdapterVerdict({ outcome: 'retryable_failure', reason: 'garbage' })).toEqual({ action: 'reschedule', reason: 'unknown' })
+  })
+
+  test('P3-2: normalizeAdapterVerdict never throws on a hostile/throwing getter (never drops the batch)', () => {
+    const hostile = {
+      get outcome(): string {
+        throw new Error('boom')
+      },
+    }
+    expect(() => normalizeAdapterVerdict(hostile)).not.toThrow()
+    expect(normalizeAdapterVerdict(hostile)).toEqual({ action: 'reschedule', reason: 'adapter_error' })
   })
 
   test('P2#4: startDurableDispatchLoop requires a telemetry sink', () => {

--- a/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
@@ -648,11 +648,19 @@ describe('P2 durable-delivery S2-b — pure guards (no DB)', () => {
     expect(() => startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), noopObserver, { env: flagOn, intervalMs: 0 })).toThrow(/intervalMs/)
     // fractional / inverted backoff — rejected at loop start and at tick entry, before claim/side effects.
     expect(() => startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), noopObserver, { env: flagOn, retryBaseMs: 1.5 })).toThrow(/retryBaseMs/)
-    expect(() => startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), noopObserver, { env: flagOn, retryBaseMs: 10, retryCapMs: 5 })).toThrow(
+    expect(() => startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), noopObserver, { env: flagOn, retryBaseMs: 2000, retryCapMs: 1000 })).toThrow(
       /retryCapMs/,
     )
     await expect(runDispatchTick(unreachableDb, oneAdapterRegistry(), { adapterTimeoutMs: -1 })).rejects.toThrow(/adapterTimeoutMs/)
     await expect(runDispatchTick(unreachableDb, oneAdapterRegistry(), { batchSize: 2.5 })).rejects.toThrow(/batchSize/)
+  })
+
+  // [#4334 round-3 adversarial P3] A sub-tick backoff would busy-spin a rescheduled row within one tick under
+  // per-slot claim (burning attempts back-to-back). The retryBaseMs floor makes that config unrepresentable.
+  test('P3-busyspin: a sub-second retry backoff is rejected (no same-tick re-claim spin)', async () => {
+    await expect(runDispatchTick(unreachableDb, oneAdapterRegistry(), { retryBaseMs: 1 })).rejects.toThrow(/retryBaseMs/)
+    await expect(runDispatchTick(unreachableDb, oneAdapterRegistry(), { retryBaseMs: 999 })).rejects.toThrow(/retryBaseMs/)
+    expect(() => startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), noopObserver, { env: flagOn, retryBaseMs: 1 })).toThrow(/retryBaseMs/)
   })
 
   test('P1-B: a lease below the loop minimum is rejected (the heartbeat needs margin inside the lease)', async () => {

--- a/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
@@ -23,12 +23,17 @@ import { poolManager } from '../../src/integration/db/connection-pool'
 import {
   computeRetryDelayMs,
   ConsumerAdapterRegistry,
+  normalizeAdapterVerdict,
   runDispatchTick,
   startDurableDispatchLoop,
   type AdapterOutcome,
   type ConsumerAdapter,
+  type DispatchLoopObserver,
 } from '../../src/multitable/automation-durable-dispatch-loop'
-import type { ClaimedConsumer } from '../../src/multitable/automation-durable-dispatcher'
+import type { ClaimedConsumer, Queryable } from '../../src/multitable/automation-durable-dispatcher'
+
+/** A minimal always-valid telemetry sink for tests that don't assert on it. */
+const noopObserver: DispatchLoopObserver = { onUnknownConsumerKeys: () => {}, onTickError: () => {} }
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const db = () => poolManager.get()
@@ -228,9 +233,9 @@ describeIfDatabase('P2 durable-delivery S2-b — dispatch loop (real DB)', () =>
     const r = new ConsumerAdapterRegistry()
     r.register(adapter(key, ok))
     // flag OFF (empty env) → must refuse
-    expect(() => startDurableDispatchLoop(db(), r, { env: {} as NodeJS.ProcessEnv })).toThrow(/must not start/)
+    expect(() => startDurableDispatchLoop(db(), r, noopObserver, { env: {} as NodeJS.ProcessEnv })).toThrow(/must not start/)
     // flag ON via injected env → drains the seeded row, then stops cleanly
-    const handle = startDurableDispatchLoop(db(), r, {
+    const handle = startDurableDispatchLoop(db(), r, noopObserver, {
       env: { AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv,
       intervalMs: 100,
     })
@@ -246,4 +251,212 @@ describeIfDatabase('P2 durable-delivery S2-b — dispatch loop (real DB)', () =>
       await handle.stop()
     }
   }, 15_000)
+
+  // [#4334 review P1#1] Batch-claim + serial execution: a worker that LOSES its lease mid-batch must not go
+  // on to call the next row's adapter (double external emit). The pre-call fence-CAS renew is the guard.
+  test('P1#1: a stale worker does NOT invoke the adapter for a row a concurrent worker reclaimed mid-batch', async () => {
+    const k1 = `ck_${RUN}_slotA`
+    const k2 = `ck_${RUN}_slotB`
+    const id1 = await seedRow(k1)
+    const id2 = await seedRow(k2)
+    // Deterministic dispatch order: row1 before row2 (claim dispatches ORDER BY outbox.created_at ASC).
+    await db().query(`UPDATE meta_automation_outbox SET created_at = now() - interval '2 seconds' WHERE id=$1`, [id1])
+    await db().query(`UPDATE meta_automation_outbox SET created_at = now() - interval '1 second'  WHERE id=$1`, [id2])
+
+    const callOrder: string[] = []
+    let k2Called = false
+    const r = new ConsumerAdapterRegistry()
+    // Row1's adapter simulates a CONCURRENT RECLAIM of row2 (exactly what another worker's claim does: bump
+    // the fence) while THIS worker is mid-batch. When the loop reaches row2, its pre-call renew must fail.
+    r.register(
+      adapter(k1, async () => {
+        callOrder.push('k1')
+        await db().query(
+          `UPDATE meta_automation_outbox_consumer SET fence = fence + 1 WHERE outbox_id=$1 AND consumer_key=$2`,
+          [id2, k2],
+        )
+        return { outcome: 'success' }
+      }),
+    )
+    r.register(
+      adapter(k2, async () => {
+        k2Called = true
+        callOrder.push('k2')
+        return { outcome: 'success' }
+      }),
+    )
+
+    const res = await runDispatchTick(db(), r)
+    expect(res.claimed).toBe(2)
+    expect(k2Called).toBe(false) // the guard held: the stale row's adapter was never called
+    expect(callOrder).toEqual(['k1']) // only the still-owned row ran
+    expect(res.completed).toBe(1) // row1
+    expect(res.lostLease).toBe(1) // row2 skipped at the pre-call renew
+    expect((await readRow(id1, k1)).status).toBe('done')
+    expect((await readRow(id2, k2)).status).toBe('in_progress') // left to its new owner, untouched by us
+  })
+
+  // [#4334 review P1#2] A malformed adapter verdict must RETRY (values-free adapter_error), never poison —
+  // poisoning drops the event. Only an exact permanent verdict dead-letters.
+  test('P1#2: malformed adapter verdicts reschedule as adapter_error (never dead_letter)', async () => {
+    const cases: Array<{ label: string; ret: unknown }> = [
+      { label: 'unknown outcome', ret: { outcome: 'bogus' } },
+      { label: 'permanent w/o reason', ret: { outcome: 'permanent_failure' } },
+      { label: 'permanent w/ bad reason', ret: { outcome: 'permanent_failure', reason: 'nope' } },
+      { label: 'null', ret: null },
+      { label: 'non-object', ret: 42 },
+      { label: 'retryable w/ bad reason', ret: { outcome: 'retryable_failure', reason: 'not_in_vocab' } },
+    ]
+    for (const c of cases) {
+      const key = `ck_${RUN}_bad_${cases.indexOf(c)}`
+      const id = await seedRow(key)
+      const r = new ConsumerAdapterRegistry()
+      r.register(adapter(key, async () => c.ret as unknown as AdapterOutcome))
+      const res = await runDispatchTick(db(), r)
+      expect(res, c.label).toMatchObject({ claimed: 1, rescheduled: 1, poisoned: 0 })
+      const row = await readRow(id, key)
+      expect(row.status, c.label).toBe('in_progress') // retried, NOT dead_letter — the event is not dropped
+      // retryable-with-bad-reason normalizes to values-free `unknown`; every other malformed shape → adapter_error.
+      const expected = (c.ret as { outcome?: string })?.outcome === 'retryable_failure' ? 'unknown' : 'adapter_error'
+      expect(row.last_error, c.label).toBe(expected)
+    }
+  })
+
+  // [#4334 review P1#3] A hung adapter must not freeze the tick — it times out to adapter_timeout and the
+  // dispatcher moves on; a sibling row still completes in the same tick.
+  test('P1#3: a hung adapter times out (adapter_timeout) and never blocks the tick or sibling rows', async () => {
+    const hangKey = `ck_${RUN}_hang`
+    const okKey = `ck_${RUN}_hang_ok`
+    const idHang = await seedRow(hangKey)
+    const idOk = await seedRow(okKey)
+    const r = new ConsumerAdapterRegistry()
+    r.register(adapter(hangKey, () => new Promise<AdapterOutcome>(() => {}))) // never settles
+    r.register(adapter(okKey, ok))
+    const started = Date.now()
+    const res = await runDispatchTick(db(), r, { adapterTimeoutMs: 300 })
+    const elapsed = Date.now() - started
+    expect(elapsed).toBeLessThan(8_000) // the tick returned — it did NOT hang on the dangling promise
+    expect(res.claimed).toBe(2)
+    expect(res.completed).toBe(1) // the ok row
+    expect(res.rescheduled).toBe(1) // the hung row
+    expect(await readRow(idHang, hangKey)).toMatchObject({ status: 'in_progress', last_error: 'adapter_timeout' })
+    expect((await readRow(idOk, okKey)).status).toBe('done')
+  })
+
+  // [#4334 review P2#4] A throwing telemetry sink must not stop delivery: the known row still drains.
+  test('P2#4: a throwing observer.onUnknownConsumerKeys never stops the loop draining a known row', async () => {
+    const unknownKey = `ck_${RUN}_obsthrow_u`
+    const knownKey = `ck_${RUN}_obsthrow_k`
+    await seedRow(unknownKey)
+    const idK = await seedRow(knownKey)
+    const r = new ConsumerAdapterRegistry()
+    r.register(adapter(knownKey, ok))
+    const throwingObserver: DispatchLoopObserver = {
+      onUnknownConsumerKeys: () => {
+        throw new Error('telemetry sink down')
+      },
+      onTickError: () => {},
+    }
+    const handle = startDurableDispatchLoop(db(), r, throwingObserver, {
+      env: { AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv,
+      intervalMs: 100,
+    })
+    try {
+      const deadline = Date.now() + 8_000
+      // eslint-disable-next-line no-unmodified-loop-condition
+      while (Date.now() < deadline) {
+        if ((await readRow(idK, knownKey)).status === 'done') break
+        await new Promise((res2) => setTimeout(res2, 100))
+      }
+      expect((await readRow(idK, knownKey)).status).toBe('done') // delivery survived the broken sink
+    } finally {
+      await handle.stop()
+    }
+  }, 15_000)
+})
+
+/**
+ * Pure guards — run without a database (fake Queryable / no DB touched). These cover the runtime verdict
+ * parser and the startup-time validation added for the #4334 review (P1#2 shape, P2#4 required sink /
+ * exception-safety, P2#5 numeric bounds).
+ */
+describe('P2 durable-delivery S2-b — pure guards (no DB)', () => {
+  const flagOn = { AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv
+  const oneAdapterRegistry = () => {
+    const r = new ConsumerAdapterRegistry()
+    r.register(adapter('k', ok))
+    return r
+  }
+  // a Queryable that MUST NOT be reached (validation/guards throw first).
+  const unreachableDb: Queryable = {
+    query: async () => {
+      throw new Error('db must not be queried in this test')
+    },
+  }
+
+  test('P1#2: normalizeAdapterVerdict maps the closed set; everything malformed → retry, never poison', () => {
+    expect(normalizeAdapterVerdict({ outcome: 'success' })).toEqual({ action: 'complete' })
+    expect(normalizeAdapterVerdict({ outcome: 'permanent_failure', reason: 'permanent_rejection' })).toEqual({
+      action: 'poison',
+      reason: 'permanent_rejection',
+    })
+    expect(normalizeAdapterVerdict({ outcome: 'retryable_failure', reason: 'adapter_timeout' })).toEqual({
+      action: 'reschedule',
+      reason: 'adapter_timeout',
+    })
+    // malformed shapes never poison:
+    for (const bad of [{ outcome: 'bogus' }, { outcome: 'permanent_failure' }, { outcome: 'permanent_failure', reason: 'x' }, null, 42, 'success', undefined, {}]) {
+      expect(normalizeAdapterVerdict(bad).action, JSON.stringify(bad)).not.toBe('poison')
+    }
+    expect(normalizeAdapterVerdict({ outcome: 'bogus' })).toEqual({ action: 'reschedule', reason: 'adapter_error' })
+    expect(normalizeAdapterVerdict({ outcome: 'retryable_failure', reason: 'garbage' })).toEqual({ action: 'reschedule', reason: 'unknown' })
+  })
+
+  test('P2#4: startDurableDispatchLoop requires a telemetry sink', () => {
+    expect(() => startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), undefined as unknown as DispatchLoopObserver, { env: flagOn })).toThrow(
+      /telemetry sink/,
+    )
+    expect(() =>
+      startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), { onUnknownConsumerKeys: () => {} } as unknown as DispatchLoopObserver, { env: flagOn }),
+    ).toThrow(/telemetry sink/)
+  })
+
+  test('P2#5: illegal numeric knobs are rejected BEFORE any work (loop start + tick entry)', async () => {
+    // intervalMs=0 would be a hot loop — rejected before the timer exists.
+    expect(() => startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), noopObserver, { env: flagOn, intervalMs: 0 })).toThrow(/intervalMs/)
+    // fractional / inverted backoff — rejected at loop start and at tick entry, before claim/side effects.
+    expect(() => startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), noopObserver, { env: flagOn, retryBaseMs: 1.5 })).toThrow(/retryBaseMs/)
+    expect(() => startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), noopObserver, { env: flagOn, retryBaseMs: 10, retryCapMs: 5 })).toThrow(
+      /retryCapMs/,
+    )
+    await expect(runDispatchTick(unreachableDb, oneAdapterRegistry(), { adapterTimeoutMs: -1 })).rejects.toThrow(/adapterTimeoutMs/)
+    await expect(runDispatchTick(unreachableDb, oneAdapterRegistry(), { batchSize: 2.5 })).rejects.toThrow(/batchSize/)
+  })
+
+  test('P2#4: a throwing observer.onTickError never becomes an unhandled rejection (loop survives a DB error)', async () => {
+    const rejectingDb: Queryable = {
+      query: async () => {
+        throw new Error('db down')
+      },
+    }
+    let tickErrorSeen = 0
+    const observer: DispatchLoopObserver = {
+      onUnknownConsumerKeys: () => {},
+      onTickError: () => {
+        tickErrorSeen += 1
+        throw new Error('and the error sink is down too')
+      },
+    }
+    const handle = startDurableDispatchLoop(rejectingDb, oneAdapterRegistry(), observer, { env: flagOn, intervalMs: 10 })
+    try {
+      const deadline = Date.now() + 2_000
+      // eslint-disable-next-line no-unmodified-loop-condition
+      while (Date.now() < deadline && tickErrorSeen === 0) {
+        await new Promise((res2) => setTimeout(res2, 20))
+      }
+      expect(tickErrorSeen).toBeGreaterThan(0) // the error WAS surfaced to the sink...
+    } finally {
+      await handle.stop() // ...and the loop is still healthy enough to stop cleanly (no crash / unhandled rejection)
+    }
+  }, 10_000)
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -321,6 +321,9 @@ export default defineConfig({
       // LOCKED). Excluded HERE so it cannot skip-green in the no-DB lane; whole-file wired into
       // plugin-tests.yml. Two-point wiring.
       'tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts',
+      // P2 durable-delivery S2-b dispatch loop (registry + tick) — real-DB. Excluded HERE so it cannot
+      // skip-green in the no-DB lane; whole-file wired into plugin-tests.yml. Two-point wiring.
+      'tests/integration/multitable-automation-dispatch-loop-realdb.test.ts',
       // W0 tail (#4279, owner MUST-WRITE OD-6, design-lock §0.5 2026-07-13): field-undelete rehydration
       // revision goldens — proves `recreateFieldFromConfig`'s tombstone-value rehydration UPDATE bumps
       // `version` and emits a `recordRecordRevision` AT THE NEW version, same transaction, for every


### PR DESCRIPTION
**Base: `main`** (S2-a #4322 landed as `336732b5f`). **Additive, flag-gated, zero behavior** — `startDurableDispatchLoop` refuses to start while `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF, nothing calls it yet. Head `279c5edc9`.

## Design (current)
Per-slot claim → adapter under heartbeat + bounded timeout → fence-CAS resolve. The tick claims ONE reclaimable row per execution slot and processes it immediately (never a batch), so a row is only attempted when it is about to run. A row already at the ceiling is poisoned at claim, counted, and scanned past (not dispatched).

## Owner reviews — all findings fixed
- **Round-2 (3 P1 + 2 P2):** malformed verdict dead-lettered → `normalizeAdapterVerdict` (retry, never poison, hostile-getter safe); hung adapter froze the tick → bounded `adapterTimeoutMs` + `AbortSignal`; optional/unsafe telemetry → required exception-safe sink; unvalidated numeric knobs → bounded safe-int validation before any work.
- **Round-3 (2 P1 + 2 P2):** tail-row poison-without-execution → **per-slot claim** (subsumes the round-2 pre-call renew, removed); heartbeat later than a short lease → `heartbeatMs = leaseMs/3` + min `leaseMs ≥ 1000`; heartbeat DB error masked as lostLease → required `onHeartbeatError` + distinct count; one-sided backoff override → **effective**-defaults inversion check.
- **Round-3 adversarial P3:** sub-tick backoff busy-spun a rescheduled row within a tick → `retryBaseMs` floored at 1s.
- **Round-4 (P2 + P3):** **claim-time-poison head-of-line block** — an exhausted oldest row was poisoned at claim, `claimDueConsumers` returned empty, and the loop mistook that for "no work" and broke, starving healthy rows behind it (and hiding the terminal transition from telemetry). Fixed: `claimDueConsumers` reports claim-time poisons via a new `onClaimTimePoison`; the loop scans past a poisoned head to the next slot (within budget), counts them (`result.claimTimePoisoned`), and surfaces them. Plus P3 doc-drift corrections (removed pre-call renew reference; heartbeat renew error → `onHeartbeatError`, not `onTickError`; the `attempts == adapter invocations` overclaim reworded for the crash-safe claim-time attempt bump).

## Verification (fresh Postgres 15)
- **61/61** across the P2 cluster (outbox schema 14 + S2-a claim 13 + **S2-b loop 34**). `tsc --noEmit` 0 errors.
- Every guard **mutation-proven load-bearing** — reverting per-slot claim kills 5 tests; the head-of-line fix has two mutations (loop scan-past + claim poison-reporting). Two-point CI wired.
- `renewConsumerLease` and `onClaimTimePoison` added to the S2-a claim engine additively (return type unchanged); its 13 claim tests still pass.
- Independent adversarial pass on the round-3 head confirmed correctness under a 3-worker / pathological-backoff probe and surfaced the busy-spin P3 (since fixed); it was cut short by a session limit, re-runnable after reset. The owner's re-review is the authoritative gate.

## Not in this slice
S3 (#4335), S4-a (#4336), S4-b/S5/S7 (#4337), S6, ledger/FWB/attachments. Flags stay OFF until the 8-scenario acceptance.

**For review — not self-merging runtime. S2-b HOLD stays until owner re-review; #4335 not retargeted.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)