### PR TITLE
feat(automation): P2 durable-delivery S3 — versioned routing manifest + bidirectional completeness assertion

### DIFF
--- a/packages/core-backend/src/multitable/automation-routing-manifest.ts
+++ b/packages/core-backend/src/multitable/automation-routing-manifest.ts
@@ -1,0 +1,107 @@
+/**
+ * P2 durable-delivery — slice S3: the versioned routing manifest + startup completeness assertion.
+ *
+ * The manifest maps each event family to the FULL set of consumer_keys that must receive a durable delivery
+ * row. The producer (S4) expands an event into its `(outbox_id, consumer_key)` rows AT ENQUEUE, stamping
+ * `manifest_version` — a row enqueued under v1 is dispatched per v1 forever and never re-interpreted against
+ * a live manifest (#4203 §manifest). Content is the lock's ratified v1 full set (§283-291), grounded in the
+ * actual subscription surfaces (`automation-service.ts:892-936`, `index.ts:2119` projection,
+ * `webhook-event-bridge.ts:36-39`):
+ *
+ *   approval.{approved,rejected,revoked,cancelled} → approval-bridge, approval-trigger, approval-projection
+ *   approval.task_created                          → approval-task-trigger
+ *   multitable.record.{created,updated,deleted}    → automation-record-trigger, webhook-event-bridge
+ *   multitable.comment.created                     → webhook-event-bridge
+ *   form.submitted                                 → automation-record-trigger
+ *
+ * Completeness is asserted BIDIRECTIONALLY at startup with the adapter registry as the single enumeration
+ * source (#4203 §293-300): (a) every consumer_key the manifest routes to has a registered adapter — a
+ * manifest entry nobody serves would park rows forever; (b) every registered adapter is routed by the
+ * manifest — an adapter no event reaches is dead configuration (and, worse, a sign the manifest lost an
+ * entry). NOTE the lock's third direction — an ANONYMOUS bare `eventBus.subscribe(...)` closure carries no
+ * consumer_key and cannot be enumerated from the bus side — is NOT enforceable here at runtime; it is closed
+ * structurally in S5 by replacing those subscription sites with registered adapters (the cutover makes the
+ * old bus non-load-bearing).
+ *
+ * Rolling deploy (#4203 §234-255): expanding an event family to a NEW consumer_key K is activation-gated —
+ * (1) ship workers that know K (adapter registered), (2) only then ship producers whose manifest expands K.
+ * The worker side is protected at runtime (unknown key → pending + alert, S2-a/S2-b); the PRODUCER side
+ * CANNOT be (an N-1 producer simply never writes the K row — nothing exists to park or alert on), so K
+ * expansion must wait until all producers are N-aware. `SUPPORTED_MANIFEST_VERSIONS` is the deploy gate's
+ * anchor: a dispatcher refuses rows stamped with a version it does not know.
+ *
+ * Pure data + assertions — no DB, no side effects, flag-independent (nothing reads it until S4 enqueues).
+ */
+import type { ConsumerAdapterRegistry } from './automation-durable-dispatch-loop'
+
+export interface RoutingManifest {
+  readonly version: number
+  /** event_type → the FULL set of consumer_keys that must each get a durable delivery row. */
+  readonly routes: Readonly<Record<string, readonly string[]>>
+}
+
+export const APPROVAL_COMPLETION_CONSUMERS = ['approval-bridge', 'approval-trigger', 'approval-projection'] as const
+
+/** v1 — the lock's ratified full set (#4203 §283-291). Frozen: never mutate; new needs = new version. */
+export const ROUTING_MANIFEST_V1: RoutingManifest = Object.freeze({
+  version: 1,
+  routes: Object.freeze({
+    'approval.approved': APPROVAL_COMPLETION_CONSUMERS,
+    'approval.rejected': APPROVAL_COMPLETION_CONSUMERS,
+    'approval.revoked': APPROVAL_COMPLETION_CONSUMERS,
+    'approval.cancelled': APPROVAL_COMPLETION_CONSUMERS,
+    'approval.task_created': ['approval-task-trigger'] as const,
+    'multitable.record.created': ['automation-record-trigger', 'webhook-event-bridge'] as const,
+    'multitable.record.updated': ['automation-record-trigger', 'webhook-event-bridge'] as const,
+    'multitable.record.deleted': ['automation-record-trigger', 'webhook-event-bridge'] as const,
+    'multitable.comment.created': ['webhook-event-bridge'] as const,
+    'form.submitted': ['automation-record-trigger'] as const,
+  }),
+})
+
+export const CURRENT_ROUTING_MANIFEST: RoutingManifest = ROUTING_MANIFEST_V1
+
+/** Versions this build can dispatch. A row stamped with an unknown version must be left alone (older/newer
+ *  worker's job), mirroring the unknown-consumer_key rule. */
+export const SUPPORTED_MANIFEST_VERSIONS: ReadonlySet<number> = new Set([1])
+
+/**
+ * Expand an event type to its consumer_keys under the given manifest. Returns undefined for an event type
+ * the manifest does not route — the PRODUCER (S4) treats that as a hard error (it must know its families;
+ * silently enqueueing zero rows would be a silent miss).
+ */
+export function expandConsumerKeysForEvent(
+  eventType: string,
+  manifest: RoutingManifest = CURRENT_ROUTING_MANIFEST,
+): readonly string[] | undefined {
+  return manifest.routes[eventType]
+}
+
+/** Every distinct consumer_key the manifest routes to. */
+export function manifestConsumerKeys(manifest: RoutingManifest = CURRENT_ROUTING_MANIFEST): string[] {
+  return [...new Set(Object.values(manifest.routes).flat())]
+}
+
+/**
+ * Startup completeness assertion — BIDIRECTIONAL, registry as the single enumeration source (#4203 §296).
+ * Throws with the exact missing keys; callers run this once at boot BEFORE starting the dispatch loop.
+ */
+export function assertManifestCompleteness(
+  registry: Pick<ConsumerAdapterRegistry, 'keys'>,
+  manifest: RoutingManifest = CURRENT_ROUTING_MANIFEST,
+): void {
+  const registered = new Set(registry.keys())
+  const routed = new Set(manifestConsumerKeys(manifest))
+  const unserved = [...routed].filter((k) => !registered.has(k))
+  const unrouted = [...registered].filter((k) => !routed.has(k))
+  if (unserved.length > 0 || unrouted.length > 0) {
+    const parts: string[] = []
+    if (unserved.length > 0) {
+      parts.push(`manifest routes to consumer_key(s) with NO registered adapter (rows would park forever): ${unserved.join(', ')}`)
+    }
+    if (unrouted.length > 0) {
+      parts.push(`registered adapter(s) NOT routed by the manifest (dead configuration / lost manifest entry): ${unrouted.join(', ')}`)
+    }
+    throw new Error(`routing manifest v${manifest.version} completeness violated — ${parts.join(' ; ')}`)
+  }
+}

--- a/packages/core-backend/src/multitable/automation-routing-manifest.ts
+++ b/packages/core-backend/src/multitable/automation-routing-manifest.ts
@@ -40,23 +40,38 @@ export interface RoutingManifest {
   readonly routes: Readonly<Record<string, readonly string[]>>
 }
 
-export const APPROVAL_COMPLETION_CONSUMERS = ['approval-bridge', 'approval-trigger', 'approval-projection'] as const
+/**
+ * DEEP-freeze a manifest so v1 routing is immutable at RUNTIME. `as const` / a bare outer `Object.freeze` are
+ * NOT enough: the CONSUMER ARRAYS inside `routes` stay mutable, so `manifest.routes[e].pop()` (or a pop on the
+ * shared APPROVAL_COMPLETION_CONSUMERS array) would silently rewrite v1's routing (#4335 review P2). Freeze
+ * every route array, the routes record, and the object itself.
+ */
+function deepFreezeManifest(m: RoutingManifest): RoutingManifest {
+  for (const keys of Object.values(m.routes)) {
+    Object.freeze(keys)
+  }
+  Object.freeze(m.routes)
+  return Object.freeze(m)
+}
 
-/** v1 — the lock's ratified full set (#4203 §283-291). Frozen: never mutate; new needs = new version. */
-export const ROUTING_MANIFEST_V1: RoutingManifest = Object.freeze({
+/** Shared across the four approval-completion routes — frozen so no route can mutate it out from under the others. */
+export const APPROVAL_COMPLETION_CONSUMERS: readonly string[] = Object.freeze(['approval-bridge', 'approval-trigger', 'approval-projection'])
+
+/** v1 — the lock's ratified full set (#4203 §283-291). Deep-frozen: never mutate at runtime; new needs = new version. */
+export const ROUTING_MANIFEST_V1: RoutingManifest = deepFreezeManifest({
   version: 1,
-  routes: Object.freeze({
+  routes: {
     'approval.approved': APPROVAL_COMPLETION_CONSUMERS,
     'approval.rejected': APPROVAL_COMPLETION_CONSUMERS,
     'approval.revoked': APPROVAL_COMPLETION_CONSUMERS,
     'approval.cancelled': APPROVAL_COMPLETION_CONSUMERS,
-    'approval.task_created': ['approval-task-trigger'] as const,
-    'multitable.record.created': ['automation-record-trigger', 'webhook-event-bridge'] as const,
-    'multitable.record.updated': ['automation-record-trigger', 'webhook-event-bridge'] as const,
-    'multitable.record.deleted': ['automation-record-trigger', 'webhook-event-bridge'] as const,
-    'multitable.comment.created': ['webhook-event-bridge'] as const,
-    'form.submitted': ['automation-record-trigger'] as const,
-  }),
+    'approval.task_created': ['approval-task-trigger'],
+    'multitable.record.created': ['automation-record-trigger', 'webhook-event-bridge'],
+    'multitable.record.updated': ['automation-record-trigger', 'webhook-event-bridge'],
+    'multitable.record.deleted': ['automation-record-trigger', 'webhook-event-bridge'],
+    'multitable.comment.created': ['webhook-event-bridge'],
+    'form.submitted': ['automation-record-trigger'],
+  },
 })
 
 export const CURRENT_ROUTING_MANIFEST: RoutingManifest = ROUTING_MANIFEST_V1

--- a/packages/core-backend/tests/unit/automation-routing-manifest.test.ts
+++ b/packages/core-backend/tests/unit/automation-routing-manifest.test.ts
@@ -1,0 +1,73 @@
+/**
+ * P2 durable-delivery S3 — versioned routing manifest + bidirectional completeness assertion (pure, no DB).
+ *
+ * Pins the lock's ratified v1 full set (#4203 §283-291) so a silent manifest edit is a red test, and proves
+ * the startup assertion catches BOTH failure directions with the exact offending keys named.
+ */
+import { describe, expect, test } from 'vitest'
+
+import {
+  assertManifestCompleteness,
+  CURRENT_ROUTING_MANIFEST,
+  expandConsumerKeysForEvent,
+  manifestConsumerKeys,
+  ROUTING_MANIFEST_V1,
+  SUPPORTED_MANIFEST_VERSIONS,
+} from '../../src/multitable/automation-routing-manifest'
+
+const registryOf = (...keys: string[]) => ({ keys: () => [...keys] })
+const FULL_V1_KEYS = [
+  'approval-bridge',
+  'approval-trigger',
+  'approval-projection',
+  'approval-task-trigger',
+  'automation-record-trigger',
+  'webhook-event-bridge',
+]
+
+describe('P2 S3 — routing manifest v1 (lock #4203 §283-291 full set)', () => {
+  test('v1 routes exactly the ratified event families to their FULL consumer sets', () => {
+    expect(ROUTING_MANIFEST_V1.version).toBe(1)
+    for (const t of ['approval.approved', 'approval.rejected', 'approval.revoked', 'approval.cancelled']) {
+      expect(expandConsumerKeysForEvent(t)).toEqual(['approval-bridge', 'approval-trigger', 'approval-projection'])
+    }
+    expect(expandConsumerKeysForEvent('approval.task_created')).toEqual(['approval-task-trigger'])
+    for (const t of ['multitable.record.created', 'multitable.record.updated', 'multitable.record.deleted']) {
+      expect(expandConsumerKeysForEvent(t)).toEqual(['automation-record-trigger', 'webhook-event-bridge'])
+    }
+    expect(expandConsumerKeysForEvent('multitable.comment.created')).toEqual(['webhook-event-bridge'])
+    expect(expandConsumerKeysForEvent('form.submitted')).toEqual(['automation-record-trigger'])
+    // the distinct key universe is exactly the six ratified consumers — no stragglers, none missing
+    expect([...manifestConsumerKeys()].sort()).toEqual([...FULL_V1_KEYS].sort())
+  })
+
+  test('an unrouted event type expands to undefined (the producer must treat that as a hard error)', () => {
+    expect(expandConsumerKeysForEvent('some.unknown.event')).toBeUndefined()
+    expect(expandConsumerKeysForEvent('')).toBeUndefined()
+  })
+
+  test('the manifest object is frozen (a v1 row is dispatched per v1 forever — no in-place edits)', () => {
+    expect(Object.isFrozen(ROUTING_MANIFEST_V1)).toBe(true)
+    expect(Object.isFrozen(ROUTING_MANIFEST_V1.routes)).toBe(true)
+    expect(CURRENT_ROUTING_MANIFEST).toBe(ROUTING_MANIFEST_V1)
+    expect(SUPPORTED_MANIFEST_VERSIONS.has(1)).toBe(true)
+  })
+
+  test('completeness: a registry serving exactly the manifest keys passes', () => {
+    expect(() => assertManifestCompleteness(registryOf(...FULL_V1_KEYS))).not.toThrow()
+  })
+
+  test('completeness direction 1: a manifest key with NO adapter throws naming that key (rows would park forever)', () => {
+    const missingProjection = FULL_V1_KEYS.filter((k) => k !== 'approval-projection')
+    expect(() => assertManifestCompleteness(registryOf(...missingProjection))).toThrow(/NO registered adapter.*approval-projection/)
+  })
+
+  test('completeness direction 2: an adapter NOT routed by the manifest throws naming that key (dead configuration)', () => {
+    expect(() => assertManifestCompleteness(registryOf(...FULL_V1_KEYS, 'ghost-consumer'))).toThrow(/NOT routed by the manifest.*ghost-consumer/)
+  })
+
+  test('completeness: both directions violated at once reports BOTH keys', () => {
+    const swapped = [...FULL_V1_KEYS.filter((k) => k !== 'approval-bridge'), 'ghost-consumer']
+    expect(() => assertManifestCompleteness(registryOf(...swapped))).toThrow(/approval-bridge[\s\S]*ghost-consumer/)
+  })
+})

--- a/packages/core-backend/tests/unit/automation-routing-manifest.test.ts
+++ b/packages/core-backend/tests/unit/automation-routing-manifest.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, test } from 'vitest'
 
 import {
+  APPROVAL_COMPLETION_CONSUMERS,
   assertManifestCompleteness,
   CURRENT_ROUTING_MANIFEST,
   expandConsumerKeysForEvent,
@@ -39,6 +40,20 @@ describe('P2 S3 — routing manifest v1 (lock #4203 §283-291 full set)', () => 
     expect(expandConsumerKeysForEvent('form.submitted')).toEqual(['automation-record-trigger'])
     // the distinct key universe is exactly the six ratified consumers — no stragglers, none missing
     expect([...manifestConsumerKeys()].sort()).toEqual([...FULL_V1_KEYS].sort())
+    // EXACT event-family set — a route ADDED/removed/renamed reds even if it reuses an existing consumer
+    // (the per-key checks + the distinct-key universe would otherwise stay green) (#4335 review P2).
+    expect(Object.keys(ROUTING_MANIFEST_V1.routes).sort()).toEqual([
+      'approval.approved',
+      'approval.cancelled',
+      'approval.rejected',
+      'approval.revoked',
+      'approval.task_created',
+      'form.submitted',
+      'multitable.comment.created',
+      'multitable.record.created',
+      'multitable.record.deleted',
+      'multitable.record.updated',
+    ])
   })
 
   test('an unrouted event type expands to undefined (the producer must treat that as a hard error)', () => {
@@ -46,9 +61,19 @@ describe('P2 S3 — routing manifest v1 (lock #4203 §283-291 full set)', () => 
     expect(expandConsumerKeysForEvent('')).toBeUndefined()
   })
 
-  test('the manifest object is frozen (a v1 row is dispatched per v1 forever — no in-place edits)', () => {
+  test('the manifest is DEEP-frozen (a v1 row is dispatched per v1 forever — no in-place edits, incl. arrays)', () => {
     expect(Object.isFrozen(ROUTING_MANIFEST_V1)).toBe(true)
     expect(Object.isFrozen(ROUTING_MANIFEST_V1.routes)).toBe(true)
+    // the CONSUMER ARRAYS must be frozen too — `as const` is compile-time only; a bare outer freeze leaves
+    // `routes[e].pop()` / a pop on the shared approval array able to silently rewrite v1 (#4335 review P2).
+    for (const arr of Object.values(ROUTING_MANIFEST_V1.routes)) {
+      expect(Object.isFrozen(arr)).toBe(true)
+    }
+    expect(Object.isFrozen(APPROVAL_COMPLETION_CONSUMERS)).toBe(true)
+    expect(() => (ROUTING_MANIFEST_V1.routes['approval.approved'] as string[]).pop()).toThrow(TypeError)
+    expect(() => (APPROVAL_COMPLETION_CONSUMERS as string[]).push('x')).toThrow(TypeError)
+    // the mutation attempts changed nothing
+    expect(expandConsumerKeysForEvent('approval.approved')).toEqual(['approval-bridge', 'approval-trigger', 'approval-projection'])
     expect(CURRENT_ROUTING_MANIFEST).toBe(ROUTING_MANIFEST_V1)
     expect(SUPPORTED_MANIFEST_VERSIONS.has(1)).toBe(true)
   })


### PR DESCRIPTION
**Stacked on #4334 (S2-b)** — retarget after parents land. Pure data + assertions; nothing reads it until S4 enqueues. Zero behavior.

- **`ROUTING_MANIFEST_V1`** — the lock's ratified full set (#4203 §283-291) grounded in the real subscription surfaces (`automation-service.ts:892-936`, `index.ts:2119`, `webhook-event-bridge.ts:36-39`); frozen (a v1 row is dispatched per v1 forever).
- **`assertManifestCompleteness`** — bidirectional, registry as the single enumeration source: manifest-key-without-adapter (rows park forever) AND adapter-not-routed (dead config) both throw naming exact keys. The un-enumerable third direction (anonymous bus closures) is closed structurally in S5.
- **`SUPPORTED_MANIFEST_VERSIONS`** — the rolling-deploy anchor; K-expansion stays activation-gated because the producer side cannot be defended at runtime (#4203 §240-243).

**Verification:** unit spec runs in the required no-DB `test` lane (7/7): pins the exact v1 routes/universe, frozen-ness, unknown→undefined, both directions with exact-key messages. Mutation: dropping direction 2 reds exactly its tests.

Flag OFF; **for review — not self-merging runtime.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)