### PR TITLE
feat(automation): P2 durable-delivery S4-a — producer-side atomic enqueue (helper)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -548,6 +548,7 @@ jobs:
             tests/integration/multitable-automation-outbox-schema-realdb.test.ts \
             tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts \
             tests/integration/multitable-automation-dispatch-loop-realdb.test.ts \
+            tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts \
             tests/integration/multitable-attachment-readgate.security.test.ts \
             tests/integration/multitable-ai-write-provenance-batch-grouping-realdb.test.ts \
             tests/integration/multitable-automation-branch-local-wait.test.ts \

--- a/packages/core-backend/src/multitable/automation-outbox-enqueue.ts
+++ b/packages/core-backend/src/multitable/automation-outbox-enqueue.ts
@@ -10,11 +10,11 @@
  * construction. This applies to EVERY manifest event family, not only approval-completion (§328-333).
  *
  * Hard rules:
- *   - `trx` MUST be the transaction the source change is being written in. This is MACHINE-ENFORCED: the param
- *     is a `TransactionalQueryable` and a runtime guard rejects anything without the `isTransaction` marker, so
- *     a pool can never reach the INSERTs (passing one would break atomicity — the outbox row would commit
- *     before a failing consumer INSERT could roll it back). The S4-b call sites pass the same txn as the
- *     source write.
+ *   - `trx` MUST be the transaction the source change is being written in. This is MACHINE-ENFORCED against
+ *     the DATABASE's own transaction state (pg-transaction-guard: two `pg_current_xact_id()` probes must
+ *     observe the SAME transaction) — a pool, an autocommit client, and a FORGED `isTransaction` marker all
+ *     fail the probe, so a half-committed enqueue (outbox row without its consumer fan-out) is
+ *     unrepresentable. The S4-b call sites pass the same txn as the source write.
  *   - An event type the manifest does not route is a HARD ERROR — silently enqueueing zero rows would be a
  *     silent miss, exactly what the lock forbids.
  *   - `eventId` is the stable ORIGINAL-event identity (dedup basis + outbound-idempotency seed). Validated
@@ -27,20 +27,10 @@
  */
 import { randomUUID } from 'node:crypto'
 
-import type { Queryable } from './automation-durable-dispatcher'
 import { CURRENT_ROUTING_MANIFEST, expandConsumerKeysForEvent, type RoutingManifest } from './automation-routing-manifest'
+import { assertInTransaction, type TransactionalQueryable } from './pg-transaction-guard'
 
-/**
- * A Queryable that is a TRANSACTION handle, not a connection pool. Enqueue writes TWO statements that must be
- * atomic; a pg `Pool` runs each on its own auto-committed connection, so a failure on the second INSERT would
- * leave the first (the outbox row) durably committed and ORPHANED (outbox=1, consumer=0). The `isTransaction`
- * marker is set ONLY by a real transaction wrapper (the caller writing the source change), and is runtime-
- * asserted below — a pool can never satisfy it (#4336 review P1: atomicity must not rest on a calling
- * convention).
- */
-export interface TransactionalQueryable extends Queryable {
-  readonly isTransaction: true
-}
+export type { TransactionalQueryable } from './pg-transaction-guard'
 
 export interface OutboxEventInput {
   /** Manifest event family, e.g. 'approval.approved' | 'multitable.record.created' | 'form.submitted'. */
@@ -74,13 +64,6 @@ export async function enqueueOutboxEvent(
   event: OutboxEventInput,
   manifest: RoutingManifest = CURRENT_ROUTING_MANIFEST,
 ): Promise<EnqueuedOutboxEvent> {
-  // Atomicity is machine-enforced, not conventional: reject anything that is not a real transaction handle
-  // (a Pool would commit the outbox row before a failing consumer INSERT could roll it back — #4336 review P1).
-  if (!trx || (trx as { isTransaction?: unknown }).isTransaction !== true) {
-    throw new TypeError(
-      'enqueueOutboxEvent must run inside a TRANSACTION (a TransactionalQueryable with isTransaction:true), not a pool — the outbox row + consumer fan-out have to commit or roll back together',
-    )
-  }
   const { eventType, eventId } = event
   if (typeof eventType !== 'string' || eventType.trim() === '') {
     throw new RangeError('enqueueOutboxEvent: eventType must be a non-empty string')
@@ -98,6 +81,9 @@ export async function enqueueOutboxEvent(
       `enqueueOutboxEvent: event type "${eventType}" is not routed by manifest v${manifest.version} — refusing a zero-row enqueue (silent miss)`,
     )
   }
+  // Atomicity is enforced against the DATABASE's own transaction state (pg_current_xact_id probe) — a pool,
+  // an autocommit client, or a FORGED isTransaction marker all fail here, BEFORE any write (#4336 review P1).
+  await assertInTransaction(trx, 'enqueueOutboxEvent')
   const outboxId = `obx_${randomUUID()}`
   await trx.query(
     `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)

--- a/packages/core-backend/src/multitable/automation-outbox-enqueue.ts
+++ b/packages/core-backend/src/multitable/automation-outbox-enqueue.ts
@@ -10,9 +10,11 @@
  * construction. This applies to EVERY manifest event family, not only approval-completion (§328-333).
  *
  * Hard rules:
- *   - `trx` MUST be the transaction the source change is being written in. Passing a pool here would break
- *     atomicity silently, so the call sites (S4-b wiring) pass the same client/trx they use for the source
- *     write. (Not machine-enforceable at this seam; the crash-injection V-series (S7) proves it per site.)
+ *   - `trx` MUST be the transaction the source change is being written in. This is MACHINE-ENFORCED: the param
+ *     is a `TransactionalQueryable` and a runtime guard rejects anything without the `isTransaction` marker, so
+ *     a pool can never reach the INSERTs (passing one would break atomicity — the outbox row would commit
+ *     before a failing consumer INSERT could roll it back). The S4-b call sites pass the same txn as the
+ *     source write.
  *   - An event type the manifest does not route is a HARD ERROR — silently enqueueing zero rows would be a
  *     silent miss, exactly what the lock forbids.
  *   - `eventId` is the stable ORIGINAL-event identity (dedup basis + outbound-idempotency seed). Validated
@@ -27,6 +29,18 @@ import { randomUUID } from 'node:crypto'
 
 import type { Queryable } from './automation-durable-dispatcher'
 import { CURRENT_ROUTING_MANIFEST, expandConsumerKeysForEvent, type RoutingManifest } from './automation-routing-manifest'
+
+/**
+ * A Queryable that is a TRANSACTION handle, not a connection pool. Enqueue writes TWO statements that must be
+ * atomic; a pg `Pool` runs each on its own auto-committed connection, so a failure on the second INSERT would
+ * leave the first (the outbox row) durably committed and ORPHANED (outbox=1, consumer=0). The `isTransaction`
+ * marker is set ONLY by a real transaction wrapper (the caller writing the source change), and is runtime-
+ * asserted below — a pool can never satisfy it (#4336 review P1: atomicity must not rest on a calling
+ * convention).
+ */
+export interface TransactionalQueryable extends Queryable {
+  readonly isTransaction: true
+}
 
 export interface OutboxEventInput {
   /** Manifest event family, e.g. 'approval.approved' | 'multitable.record.created' | 'form.submitted'. */
@@ -56,10 +70,17 @@ const NON_BLANK_ASCII = /[!-~]/
  * loudly, never half-enqueue.
  */
 export async function enqueueOutboxEvent(
-  trx: Queryable,
+  trx: TransactionalQueryable,
   event: OutboxEventInput,
   manifest: RoutingManifest = CURRENT_ROUTING_MANIFEST,
 ): Promise<EnqueuedOutboxEvent> {
+  // Atomicity is machine-enforced, not conventional: reject anything that is not a real transaction handle
+  // (a Pool would commit the outbox row before a failing consumer INSERT could roll it back — #4336 review P1).
+  if (!trx || (trx as { isTransaction?: unknown }).isTransaction !== true) {
+    throw new TypeError(
+      'enqueueOutboxEvent must run inside a TRANSACTION (a TransactionalQueryable with isTransaction:true), not a pool — the outbox row + consumer fan-out have to commit or roll back together',
+    )
+  }
   const { eventType, eventId } = event
   if (typeof eventType !== 'string' || eventType.trim() === '') {
     throw new RangeError('enqueueOutboxEvent: eventType must be a non-empty string')

--- a/packages/core-backend/src/multitable/automation-outbox-enqueue.ts
+++ b/packages/core-backend/src/multitable/automation-outbox-enqueue.ts
@@ -1,0 +1,93 @@
+/**
+ * P2 durable-delivery — slice S4-a: producer-side atomic enqueue.
+ *
+ * `enqueueOutboxEvent(trx, event)` writes ONE `meta_automation_outbox` row plus one
+ * `meta_automation_outbox_consumer` row per manifest-expanded consumer_key — **inside the caller's
+ * transaction**. That is the whole at-least-once foundation (#4203 §producer/identity): the outbox rows
+ * commit or roll back WITH the source state change (approval status write / record write / form submit), so
+ * a crash before commit loses nothing (the write never happened) and a crash after commit loses nothing
+ * (the rows are durable and the dispatcher drains them). REJECT/ROLLBACK paths therefore enqueue nothing by
+ * construction. This applies to EVERY manifest event family, not only approval-completion (§328-333).
+ *
+ * Hard rules:
+ *   - `trx` MUST be the transaction the source change is being written in. Passing a pool here would break
+ *     atomicity silently, so the call sites (S4-b wiring) pass the same client/trx they use for the source
+ *     write. (Not machine-enforceable at this seam; the crash-injection V-series (S7) proves it per site.)
+ *   - An event type the manifest does not route is a HARD ERROR — silently enqueueing zero rows would be a
+ *     silent miss, exactly what the lock forbids.
+ *   - `eventId` is the stable ORIGINAL-event identity (dedup basis + outbound-idempotency seed). Validated
+ *     non-blank (printable ASCII) here so the failure is a clear producer bug at the boundary, not a DB
+ *     constraint unwind.
+ *   - `automationDepth` carries the produce-side automation depth; downstream consumers inherit +1.
+ *
+ * Flag note: this helper has NO callers until S4-b wires the produce sites (dual-path behind
+ * `AUTOMATION_DURABLE_DELIVERY_ENABLED`). Landing it is behavior-neutral.
+ */
+import { randomUUID } from 'node:crypto'
+
+import type { Queryable } from './automation-durable-dispatcher'
+import { CURRENT_ROUTING_MANIFEST, expandConsumerKeysForEvent, type RoutingManifest } from './automation-routing-manifest'
+
+export interface OutboxEventInput {
+  /** Manifest event family, e.g. 'approval.approved' | 'multitable.record.created' | 'form.submitted'. */
+  eventType: string
+  /** Stable original-event identity (#4203): forwarded downstream as the per-rule dedup key. Non-blank ASCII. */
+  eventId: string
+  /** JSON-serializable event payload (stored as jsonb). */
+  payload: unknown
+  /** Producer-side automation depth (>= 0); consumers inherit +1. */
+  automationDepth?: number
+}
+
+export interface EnqueuedOutboxEvent {
+  outboxId: string
+  eventType: string
+  eventId: string
+  manifestVersion: number
+  consumerKeys: readonly string[]
+}
+
+const NON_BLANK_ASCII = /[!-~]/
+
+/**
+ * Atomically enqueue one producer event: the outbox row + a pending consumer row per manifest key, in the
+ * caller's transaction. Returns the ids so the caller can log/correlate. Throws (aborting the caller's
+ * transaction) on an unrouted event type or an invalid identity — a producer bug must fail the source write
+ * loudly, never half-enqueue.
+ */
+export async function enqueueOutboxEvent(
+  trx: Queryable,
+  event: OutboxEventInput,
+  manifest: RoutingManifest = CURRENT_ROUTING_MANIFEST,
+): Promise<EnqueuedOutboxEvent> {
+  const { eventType, eventId } = event
+  if (typeof eventType !== 'string' || eventType.trim() === '') {
+    throw new RangeError('enqueueOutboxEvent: eventType must be a non-empty string')
+  }
+  if (typeof eventId !== 'string' || !NON_BLANK_ASCII.test(eventId)) {
+    throw new RangeError('enqueueOutboxEvent: eventId must be a stable non-blank identity (printable ASCII) — a blank id is un-dedupable downstream')
+  }
+  const depth = event.automationDepth ?? 0
+  if (!Number.isSafeInteger(depth) || depth < 0) {
+    throw new RangeError(`enqueueOutboxEvent: automationDepth must be a non-negative safe integer (got ${depth})`)
+  }
+  const consumerKeys = expandConsumerKeysForEvent(eventType, manifest)
+  if (!consumerKeys || consumerKeys.length === 0) {
+    throw new Error(
+      `enqueueOutboxEvent: event type "${eventType}" is not routed by manifest v${manifest.version} — refusing a zero-row enqueue (silent miss)`,
+    )
+  }
+  const outboxId = `obx_${randomUUID()}`
+  await trx.query(
+    `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
+     VALUES ($1,$2,$3::jsonb,$4,$5,$6)`,
+    [outboxId, eventType, JSON.stringify(event.payload ?? null), depth, manifest.version, eventId],
+  )
+  // one pending delivery row per consumer, same transaction — UNNEST keeps it a single statement.
+  await trx.query(
+    `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key)
+     SELECT $1, k FROM unnest($2::text[]) AS k`,
+    [outboxId, [...consumerKeys]],
+  )
+  return { outboxId, eventType, eventId, manifestVersion: manifest.version, consumerKeys }
+}

--- a/packages/core-backend/src/multitable/pg-transaction-guard.ts
+++ b/packages/core-backend/src/multitable/pg-transaction-guard.ts
@@ -15,6 +15,13 @@
  * Cost: two trivial SELECTs per guarded call, before any write. Acceptable for the low-volume approval /
  * automation write paths this protects; the failure it prevents (a permanently half-committed outbox / ledger
  * state) is unrecoverable without manual repair.
+ *
+ * THREAT-MODEL BOUNDARY: the guard targets ACCIDENTAL misuse — every honest-but-wrong handle (pool, autocommit
+ * client, forged boolean marker over either) is caught, because the probe asks Postgres itself. A handle that
+ * actively FABRICATES query results (recognizes the probe SQL and answers a fake constant xid while routing
+ * writes elsewhere) can defeat any client-side probe in principle; that class is indistinguishable from a
+ * hostile database driver and is out of scope — no calling-convention or probe can defend against a layer
+ * that lies about what the database said.
  */
 import type { Queryable } from './automation-durable-dispatcher'
 

--- a/packages/core-backend/src/multitable/pg-transaction-guard.ts
+++ b/packages/core-backend/src/multitable/pg-transaction-guard.ts
@@ -1,0 +1,46 @@
+/**
+ * Runtime transaction-boundary guard for multi-statement atomic writes (#4336 / #4340 review P1).
+ *
+ * A compile-time marker alone is FORGEABLE — any caller can slap `isTransaction: true` onto a pg Pool, and the
+ * two INSERTs of an "atomic" write then run on separate auto-committed connections (half-state on failure: the
+ * first row durably committed, the second missing). The only trustworthy signal is the DATABASE's own
+ * transaction state, so `assertInTransaction` probes it: `pg_current_xact_id()` assigns-and-returns the
+ * CURRENT transaction's id; called twice through the same handle it returns the SAME id iff both statements
+ * ran inside one ongoing transaction. Every non-transactional handle fails the probe:
+ *   - a Pool: statements land on arbitrary connections, each its own implicit transaction → different xids;
+ *   - a single client in AUTOCOMMIT (no BEGIN): each statement is its own implicit transaction → different xids;
+ *   - withTransaction's non-transactional queryFn fallback (deps.transaction absent) → different xids;
+ *   - a FORGED `isTransaction` marker over any of the above → unchanged: the probe asks Postgres, not the caller.
+ *
+ * Cost: two trivial SELECTs per guarded call, before any write. Acceptable for the low-volume approval /
+ * automation write paths this protects; the failure it prevents (a permanently half-committed outbox / ledger
+ * state) is unrecoverable without manual repair.
+ */
+import type { Queryable } from './automation-durable-dispatcher'
+
+/**
+ * Call-site documentation type: signals at compile time that a real transaction handle is expected. The
+ * marker itself proves NOTHING (it is forgeable) — `assertInTransaction` below is the enforcement.
+ */
+export interface TransactionalQueryable extends Queryable {
+  readonly isTransaction: true
+}
+
+/** Throws unless `trx` is a handle onto one ONGOING database transaction (probed via pg_current_xact_id). */
+export async function assertInTransaction(trx: Queryable, context: string): Promise<void> {
+  const probe = async (): Promise<string> => {
+    const res = await trx.query(`SELECT pg_current_xact_id()::text AS xid`)
+    const xid = res?.rows?.[0]?.xid
+    if (typeof xid !== 'string' || xid === '') {
+      throw new TypeError(`${context}: transaction probe returned no xid — the handle is not a usable database connection`)
+    }
+    return xid
+  }
+  const first = await probe()
+  const second = await probe()
+  if (first !== second) {
+    throw new TypeError(
+      `${context} must run inside a real database TRANSACTION: the two probe statements ran in different transactions (xid ${first} then ${second}). A pool, an autocommit client, or a forged isTransaction marker cannot provide the atomicity this write requires — BEGIN a transaction and pass that handle.`,
+    )
+  }
+}

--- a/packages/core-backend/tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts
@@ -3,8 +3,9 @@
  *
  * The load-bearing proof is ATOMICITY: enqueue happens inside the caller's transaction, so ROLLBACK leaves
  * ZERO outbox/consumer rows (a crash before commit loses nothing), and COMMIT persists the outbox row plus
- * the manifest-expanded consumer fan-out. Atomicity is MACHINE-ENFORCED: enqueue rejects a pool (isTransaction
- * guard), so the outbox-committed / consumer-failed orphan is impossible by construction (#4336 review P1).
+ * the manifest-expanded consumer fan-out. Atomicity is MACHINE-ENFORCED against the DATABASE's own transaction
+ * state (pg_current_xact_id probe — a pool, an autocommit client, and a FORGED isTransaction marker all fail),
+ * so the outbox-committed / consumer-failed orphan is impossible by construction (#4336 review P1).
  * Also proves: unrouted event type / blank identity / bad depth are hard errors; manifest_version is stamped;
  * and the enqueued fan-out flows through the S2-b dispatch tick with PER-CONSUMER independence — over a
  * RUN-UNIQUE manifest so it claims only THIS test's rows on the shared CI DB (#4336 review P2).
@@ -94,13 +95,25 @@ describeIfDatabase('P2 durable-delivery S4-a — producer atomic enqueue (real D
     expect(consumers).toHaveLength(0)
   })
 
-  test('P1 pool NEGATIVE: enqueue with a pool is REJECTED before any write (no orphan possible)', async () => {
+  test('P1 pool NEGATIVE: a pool — even with a FORGED isTransaction marker — is REJECTED by the xid probe before any write', async () => {
     const eid = `evt_${RUN}_poolneg`
-    // db() is the Pool — not a transaction. The guard must reject it (a bare Queryable would have half-written).
+    // 1) the Pool itself (cast past the compile-time brand): the DB probe rejects it — the marker proves nothing.
     await expect(enqueueOutboxEvent(db() as unknown as TransactionalQueryable, { eventType: 'approval.approved', eventId: eid, payload: {} })).rejects.toThrow(
-      /must run inside a TRANSACTION/,
+      /real database TRANSACTION/,
     )
-    // and NOTHING was written — not even the outbox row (contrast the pre-fix pool path: outbox=1, consumer=0)
+    // 2) a FORGED marker wrapping the pool (the owner's counter-example): still rejected — the probe asks
+    //    Postgres, not the caller (two statements on a pool land in different transactions).
+    const forged: TransactionalQueryable = { isTransaction: true, query: (sql, params) => db().query(sql, params) }
+    await expect(enqueueOutboxEvent(forged, { eventType: 'approval.approved', eventId: eid, payload: {} })).rejects.toThrow(/real database TRANSACTION/)
+    // 3) a single client in AUTOCOMMIT (no BEGIN): each statement is its own implicit txn — rejected too.
+    const bare = await db().getInternalPool().connect()
+    try {
+      const bareTxn: TransactionalQueryable = { isTransaction: true, query: (sql, params) => bare.query(sql, params) }
+      await expect(enqueueOutboxEvent(bareTxn, { eventType: 'approval.approved', eventId: eid, payload: {} })).rejects.toThrow(/real database TRANSACTION/)
+    } finally {
+      bare.release()
+    }
+    // and NOTHING was written in any case — not even the outbox row (pre-fix pool path: outbox=1, consumer=0)
     const { rows } = await db().query('SELECT count(*)::int AS c FROM meta_automation_outbox WHERE event_id=$1', [eid])
     expect(Number(rows[0].c)).toBe(0)
   })
@@ -108,13 +121,11 @@ describeIfDatabase('P2 durable-delivery S4-a — producer atomic enqueue (real D
   test('P1 transaction POSITIVE control: a failure on the 2nd (consumer) INSERT rolls the outbox row back too', async () => {
     const client = await db().getInternalPool().connect()
     const eid = `evt_${RUN}_txnpc`
-    let calls = 0
-    // a transaction handle whose SECOND query (the consumer fan-out) fails, as a mid-enqueue DB error would
+    // a transaction handle whose consumer-fan-out INSERT fails, as a mid-enqueue DB error would
     const failingTxn: TransactionalQueryable = {
       isTransaction: true,
       query: async (sql, params) => {
-        calls += 1
-        if (calls === 2) throw new Error('simulated DB failure on the consumer INSERT')
+        if (/meta_automation_outbox_consumer/.test(sql)) throw new Error('simulated DB failure on the consumer INSERT')
         return client.query(sql, params)
       },
     }

--- a/packages/core-backend/tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts
@@ -1,0 +1,147 @@
+/**
+ * P2 durable-delivery — slice S4-a: producer-side atomic enqueue (real DB).
+ *
+ * The load-bearing proof is ATOMICITY: enqueue happens inside the caller's transaction, so ROLLBACK leaves
+ * ZERO outbox/consumer rows (a crash before commit loses nothing), and COMMIT persists the outbox row plus
+ * the manifest-expanded consumer fan-out. Also proves: unrouted event type / blank identity / bad depth are
+ * hard errors; manifest_version is stamped; and the enqueued fan-out flows through the S2-b dispatch tick
+ * with PER-CONSUMER independence (one consumer's failure never blocks the siblings' `done`).
+ *
+ * Two-point wired (plugin-tests.yml + vitest.config.ts exclude) so it cannot skip-green.
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { enqueueOutboxEvent } from '../../src/multitable/automation-outbox-enqueue'
+import { ConsumerAdapterRegistry, runDispatchTick, type AdapterOutcome } from '../../src/multitable/automation-durable-dispatch-loop'
+import { APPROVAL_COMPLETION_CONSUMERS } from '../../src/multitable/automation-routing-manifest'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const db = () => poolManager.get()
+const RUN = randomUUID()
+const enqueued: string[] = []
+
+async function rowsFor(outboxId: string) {
+  const outbox = await db().query('SELECT event_type, event_id, manifest_version, automation_depth FROM meta_automation_outbox WHERE id=$1', [outboxId])
+  const consumers = await db().query(
+    'SELECT consumer_key, status FROM meta_automation_outbox_consumer WHERE outbox_id=$1 ORDER BY consumer_key',
+    [outboxId],
+  )
+  return { outbox: outbox.rows, consumers: consumers.rows as Array<{ consumer_key: string; status: string }> }
+}
+
+describeIfDatabase('P2 durable-delivery S4-a — producer atomic enqueue (real DB)', () => {
+  afterAll(async () => {
+    if (enqueued.length) {
+      await db().query('DELETE FROM meta_automation_outbox WHERE id = ANY($1)', [enqueued]).catch(() => {})
+    }
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('COMMIT persists the outbox row + the exact manifest fan-out (approval family → 3 consumers)', async () => {
+    const raw = db().getInternalPool()
+    const client = await raw.connect()
+    let outboxId = ''
+    try {
+      await client.query('BEGIN')
+      const res = await enqueueOutboxEvent(client, {
+        eventType: 'approval.approved',
+        eventId: `evt_${RUN}_commit`,
+        payload: { instanceId: 'apr_1' },
+        automationDepth: 2,
+      })
+      outboxId = res.outboxId
+      enqueued.push(outboxId)
+      await client.query('COMMIT')
+      expect(res.consumerKeys).toEqual([...APPROVAL_COMPLETION_CONSUMERS])
+      expect(res.manifestVersion).toBe(1)
+    } finally {
+      client.release()
+    }
+    const { outbox, consumers } = await rowsFor(outboxId)
+    expect(outbox[0]).toMatchObject({ event_type: 'approval.approved', event_id: `evt_${RUN}_commit`, manifest_version: 1, automation_depth: 2 })
+    expect(consumers.map((c) => c.consumer_key).sort()).toEqual([...APPROVAL_COMPLETION_CONSUMERS].sort())
+    expect(consumers.every((c) => c.status === 'pending')).toBe(true)
+  })
+
+  test('ATOMICITY: ROLLBACK leaves zero outbox and zero consumer rows (crash-before-commit loses nothing)', async () => {
+    const raw = db().getInternalPool()
+    const client = await raw.connect()
+    let outboxId = ''
+    try {
+      await client.query('BEGIN')
+      const res = await enqueueOutboxEvent(client, {
+        eventType: 'form.submitted',
+        eventId: `evt_${RUN}_rollback`,
+        payload: {},
+      })
+      outboxId = res.outboxId
+      // rows are visible INSIDE the txn (same client)...
+      const inside = await client.query('SELECT count(*)::int AS c FROM meta_automation_outbox WHERE id=$1', [outboxId])
+      expect(Number(inside.rows[0].c)).toBe(1)
+      await client.query('ROLLBACK')
+    } finally {
+      client.release()
+    }
+    // ...and completely gone after ROLLBACK — both tables.
+    const { outbox, consumers } = await rowsFor(outboxId)
+    expect(outbox).toHaveLength(0)
+    expect(consumers).toHaveLength(0)
+  })
+
+  test('an unrouted event type is a HARD error and aborts the enclosing work (no half-enqueue)', async () => {
+    await expect(
+      enqueueOutboxEvent(db(), { eventType: 'not.a.real.family', eventId: `evt_${RUN}_x`, payload: {} }),
+    ).rejects.toThrow(/not routed by manifest v1/)
+  })
+
+  test('identity/depth validation is a boundary error: blank eventId and bad depth throw before any SQL', async () => {
+    await expect(enqueueOutboxEvent(db(), { eventType: 'form.submitted', eventId: '   ', payload: {} })).rejects.toThrow(/non-blank identity/)
+    await expect(enqueueOutboxEvent(db(), { eventType: 'form.submitted', eventId: ' ﻿', payload: {} })).rejects.toThrow(/non-blank identity/)
+    await expect(
+      enqueueOutboxEvent(db(), { eventType: 'form.submitted', eventId: `evt_${RUN}_d`, payload: {}, automationDepth: -1 }),
+    ).rejects.toThrow(/automationDepth/)
+    await expect(
+      enqueueOutboxEvent(db(), { eventType: 'form.submitted', eventId: `evt_${RUN}_d2`, payload: {}, automationDepth: 1.5 }),
+    ).rejects.toThrow(/automationDepth/)
+  })
+
+  test('end-to-end: enqueued fan-out drains through the dispatch tick with PER-CONSUMER independence', async () => {
+    // Real manifest keys collide with parallel suites on the shared CI DB, so claim via a snapshot of
+    // this event's rows only: seed → tick with a registry serving the three approval consumers where
+    // approval-bridge fails transiently — its siblings still complete independently.
+    const res = await enqueueOutboxEvent(db(), {
+      eventType: 'approval.rejected',
+      eventId: `evt_${RUN}_e2e`,
+      payload: { instanceId: 'apr_e2e' },
+    })
+    enqueued.push(res.outboxId)
+    const registry = new ConsumerAdapterRegistry()
+    const handled: string[] = []
+    for (const key of APPROVAL_COMPLETION_CONSUMERS) {
+      registry.register({
+        key,
+        async handle(e): Promise<AdapterOutcome> {
+          if (e.outboxId !== res.outboxId) return { outcome: 'retryable_failure', reason: 'unknown' } // not ours: leave for the owning suite
+          handled.push(key)
+          return key === 'approval-bridge'
+            ? { outcome: 'retryable_failure', reason: 'adapter_error' }
+            : { outcome: 'success' }
+        },
+      })
+    }
+    // ticks: batch big enough to include our three rows even if siblings' rows are pending on the shared DB
+    await runDispatchTick(db(), registry, { batchSize: 500 })
+    const { consumers } = await rowsFor(res.outboxId)
+    const byKey = Object.fromEntries(consumers.map((c) => [c.consumer_key, c.status]))
+    expect(byKey['approval-trigger']).toBe('done')
+    expect(byKey['approval-projection']).toBe('done')
+    expect(byKey['approval-bridge']).toBe('in_progress') // rescheduled with backoff — independent of siblings
+    expect(handled.sort()).toEqual([...APPROVAL_COMPLETION_CONSUMERS].sort())
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts
@@ -3,9 +3,11 @@
  *
  * The load-bearing proof is ATOMICITY: enqueue happens inside the caller's transaction, so ROLLBACK leaves
  * ZERO outbox/consumer rows (a crash before commit loses nothing), and COMMIT persists the outbox row plus
- * the manifest-expanded consumer fan-out. Also proves: unrouted event type / blank identity / bad depth are
- * hard errors; manifest_version is stamped; and the enqueued fan-out flows through the S2-b dispatch tick
- * with PER-CONSUMER independence (one consumer's failure never blocks the siblings' `done`).
+ * the manifest-expanded consumer fan-out. Atomicity is MACHINE-ENFORCED: enqueue rejects a pool (isTransaction
+ * guard), so the outbox-committed / consumer-failed orphan is impossible by construction (#4336 review P1).
+ * Also proves: unrouted event type / blank identity / bad depth are hard errors; manifest_version is stamped;
+ * and the enqueued fan-out flows through the S2-b dispatch tick with PER-CONSUMER independence — over a
+ * RUN-UNIQUE manifest so it claims only THIS test's rows on the shared CI DB (#4336 review P2).
  *
  * Two-point wired (plugin-tests.yml + vitest.config.ts exclude) so it cannot skip-green.
  */
@@ -14,14 +16,20 @@ import { randomUUID } from 'node:crypto'
 import { afterAll, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
-import { enqueueOutboxEvent } from '../../src/multitable/automation-outbox-enqueue'
+import { enqueueOutboxEvent, type TransactionalQueryable } from '../../src/multitable/automation-outbox-enqueue'
 import { ConsumerAdapterRegistry, runDispatchTick, type AdapterOutcome } from '../../src/multitable/automation-durable-dispatch-loop'
-import { APPROVAL_COMPLETION_CONSUMERS } from '../../src/multitable/automation-routing-manifest'
+import { APPROVAL_COMPLETION_CONSUMERS, type RoutingManifest } from '../../src/multitable/automation-routing-manifest'
+import type { PoolClient } from 'pg'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const db = () => poolManager.get()
 const RUN = randomUUID()
 const enqueued: string[] = []
+
+/** Wrap a checked-out client as a real transaction handle (the isTransaction marker the enqueue guard requires). */
+const txn = (client: PoolClient): TransactionalQueryable => ({ isTransaction: true, query: (sql, params) => client.query(sql, params) })
+/** A transaction handle whose query must NOT be reached (validation throws first). */
+const txnStub = (): TransactionalQueryable => ({ isTransaction: true, query: async () => { throw new Error('query should not be reached') } })
 
 async function rowsFor(outboxId: string) {
   const outbox = await db().query('SELECT event_type, event_id, manifest_version, automation_depth FROM meta_automation_outbox WHERE id=$1', [outboxId])
@@ -44,12 +52,11 @@ describeIfDatabase('P2 durable-delivery S4-a — producer atomic enqueue (real D
   })
 
   test('COMMIT persists the outbox row + the exact manifest fan-out (approval family → 3 consumers)', async () => {
-    const raw = db().getInternalPool()
-    const client = await raw.connect()
+    const client = await db().getInternalPool().connect()
     let outboxId = ''
     try {
       await client.query('BEGIN')
-      const res = await enqueueOutboxEvent(client, {
+      const res = await enqueueOutboxEvent(txn(client), {
         eventType: 'approval.approved',
         eventId: `evt_${RUN}_commit`,
         payload: { instanceId: 'apr_1' },
@@ -70,78 +77,111 @@ describeIfDatabase('P2 durable-delivery S4-a — producer atomic enqueue (real D
   })
 
   test('ATOMICITY: ROLLBACK leaves zero outbox and zero consumer rows (crash-before-commit loses nothing)', async () => {
-    const raw = db().getInternalPool()
-    const client = await raw.connect()
+    const client = await db().getInternalPool().connect()
     let outboxId = ''
     try {
       await client.query('BEGIN')
-      const res = await enqueueOutboxEvent(client, {
-        eventType: 'form.submitted',
-        eventId: `evt_${RUN}_rollback`,
-        payload: {},
-      })
+      const res = await enqueueOutboxEvent(txn(client), { eventType: 'form.submitted', eventId: `evt_${RUN}_rollback`, payload: {} })
       outboxId = res.outboxId
-      // rows are visible INSIDE the txn (same client)...
       const inside = await client.query('SELECT count(*)::int AS c FROM meta_automation_outbox WHERE id=$1', [outboxId])
-      expect(Number(inside.rows[0].c)).toBe(1)
+      expect(Number(inside.rows[0].c)).toBe(1) // visible INSIDE the txn (same client)...
       await client.query('ROLLBACK')
     } finally {
       client.release()
     }
-    // ...and completely gone after ROLLBACK — both tables.
-    const { outbox, consumers } = await rowsFor(outboxId)
+    const { outbox, consumers } = await rowsFor(outboxId) // ...and completely gone after ROLLBACK — both tables
     expect(outbox).toHaveLength(0)
     expect(consumers).toHaveLength(0)
   })
 
+  test('P1 pool NEGATIVE: enqueue with a pool is REJECTED before any write (no orphan possible)', async () => {
+    const eid = `evt_${RUN}_poolneg`
+    // db() is the Pool — not a transaction. The guard must reject it (a bare Queryable would have half-written).
+    await expect(enqueueOutboxEvent(db() as unknown as TransactionalQueryable, { eventType: 'approval.approved', eventId: eid, payload: {} })).rejects.toThrow(
+      /must run inside a TRANSACTION/,
+    )
+    // and NOTHING was written — not even the outbox row (contrast the pre-fix pool path: outbox=1, consumer=0)
+    const { rows } = await db().query('SELECT count(*)::int AS c FROM meta_automation_outbox WHERE event_id=$1', [eid])
+    expect(Number(rows[0].c)).toBe(0)
+  })
+
+  test('P1 transaction POSITIVE control: a failure on the 2nd (consumer) INSERT rolls the outbox row back too', async () => {
+    const client = await db().getInternalPool().connect()
+    const eid = `evt_${RUN}_txnpc`
+    let calls = 0
+    // a transaction handle whose SECOND query (the consumer fan-out) fails, as a mid-enqueue DB error would
+    const failingTxn: TransactionalQueryable = {
+      isTransaction: true,
+      query: async (sql, params) => {
+        calls += 1
+        if (calls === 2) throw new Error('simulated DB failure on the consumer INSERT')
+        return client.query(sql, params)
+      },
+    }
+    try {
+      await client.query('BEGIN')
+      await expect(enqueueOutboxEvent(failingTxn, { eventType: 'form.submitted', eventId: eid, payload: {} })).rejects.toThrow(/simulated DB failure/)
+      // the outbox INSERT (1st query) ran but is UNCOMMITTED — visible only inside this txn
+      const inside = await client.query('SELECT count(*)::int AS c FROM meta_automation_outbox WHERE event_id=$1', [eid])
+      expect(Number(inside.rows[0].c)).toBe(1)
+      await client.query('ROLLBACK') // the source write fails → the whole enqueue vanishes, no orphan
+    } finally {
+      client.release()
+    }
+    const { rows } = await db().query('SELECT count(*)::int AS c FROM meta_automation_outbox WHERE event_id=$1', [eid])
+    expect(Number(rows[0].c)).toBe(0)
+  })
+
   test('an unrouted event type is a HARD error and aborts the enclosing work (no half-enqueue)', async () => {
     await expect(
-      enqueueOutboxEvent(db(), { eventType: 'not.a.real.family', eventId: `evt_${RUN}_x`, payload: {} }),
+      enqueueOutboxEvent(txnStub(), { eventType: 'not.a.real.family', eventId: `evt_${RUN}_x`, payload: {} }),
     ).rejects.toThrow(/not routed by manifest v1/)
   })
 
   test('identity/depth validation is a boundary error: blank eventId and bad depth throw before any SQL', async () => {
-    await expect(enqueueOutboxEvent(db(), { eventType: 'form.submitted', eventId: '   ', payload: {} })).rejects.toThrow(/non-blank identity/)
-    await expect(enqueueOutboxEvent(db(), { eventType: 'form.submitted', eventId: ' ﻿', payload: {} })).rejects.toThrow(/non-blank identity/)
+    await expect(enqueueOutboxEvent(txnStub(), { eventType: 'form.submitted', eventId: '   ', payload: {} })).rejects.toThrow(/non-blank identity/)
+    await expect(enqueueOutboxEvent(txnStub(), { eventType: 'form.submitted', eventId: ' ﻿', payload: {} })).rejects.toThrow(/non-blank identity/)
     await expect(
-      enqueueOutboxEvent(db(), { eventType: 'form.submitted', eventId: `evt_${RUN}_d`, payload: {}, automationDepth: -1 }),
+      enqueueOutboxEvent(txnStub(), { eventType: 'form.submitted', eventId: `evt_${RUN}_d`, payload: {}, automationDepth: -1 }),
     ).rejects.toThrow(/automationDepth/)
     await expect(
-      enqueueOutboxEvent(db(), { eventType: 'form.submitted', eventId: `evt_${RUN}_d2`, payload: {}, automationDepth: 1.5 }),
+      enqueueOutboxEvent(txnStub(), { eventType: 'form.submitted', eventId: `evt_${RUN}_d2`, payload: {}, automationDepth: 1.5 }),
     ).rejects.toThrow(/automationDepth/)
   })
 
   test('end-to-end: enqueued fan-out drains through the dispatch tick with PER-CONSUMER independence', async () => {
-    // Real manifest keys collide with parallel suites on the shared CI DB, so claim via a snapshot of
-    // this event's rows only: seed → tick with a registry serving the three approval consumers where
-    // approval-bridge fails transiently — its siblings still complete independently.
-    const res = await enqueueOutboxEvent(db(), {
-      eventType: 'approval.rejected',
-      eventId: `evt_${RUN}_e2e`,
-      payload: { instanceId: 'apr_e2e' },
-    })
-    enqueued.push(res.outboxId)
+    // RUN-UNIQUE consumer keys via a test-local manifest, so the dispatch tick claims ONLY this test's rows on
+    // the shared CI DB (real manifest keys + a big batchSize would claim sibling suites' rows — #4336 review P2).
+    const keys = [`ubridge_${RUN}`, `utrigger_${RUN}`, `uproj_${RUN}`] as const
+    const testManifest: RoutingManifest = { version: 1, routes: { 'approval.rejected': keys } }
+    const client = await db().getInternalPool().connect()
+    let outboxId = ''
+    try {
+      await client.query('BEGIN')
+      const res = await enqueueOutboxEvent(txn(client), { eventType: 'approval.rejected', eventId: `evt_${RUN}_e2e`, payload: { instanceId: 'apr_e2e' } }, testManifest)
+      outboxId = res.outboxId
+      enqueued.push(outboxId)
+      await client.query('COMMIT')
+    } finally {
+      client.release()
+    }
     const registry = new ConsumerAdapterRegistry()
     const handled: string[] = []
-    for (const key of APPROVAL_COMPLETION_CONSUMERS) {
+    for (const key of keys) {
       registry.register({
         key,
-        async handle(e): Promise<AdapterOutcome> {
-          if (e.outboxId !== res.outboxId) return { outcome: 'retryable_failure', reason: 'unknown' } // not ours: leave for the owning suite
+        async handle(): Promise<AdapterOutcome> {
           handled.push(key)
-          return key === 'approval-bridge'
-            ? { outcome: 'retryable_failure', reason: 'adapter_error' }
-            : { outcome: 'success' }
+          return key === keys[0] ? { outcome: 'retryable_failure', reason: 'adapter_error' } : { outcome: 'success' }
         },
       })
     }
-    // ticks: batch big enough to include our three rows even if siblings' rows are pending on the shared DB
-    await runDispatchTick(db(), registry, { batchSize: 500 })
-    const { consumers } = await rowsFor(res.outboxId)
+    await runDispatchTick(db(), registry) // default batch — only this test's 3 unique-key rows are reclaimable by it
+    const { consumers } = await rowsFor(outboxId)
     const byKey = Object.fromEntries(consumers.map((c) => [c.consumer_key, c.status]))
-    expect(byKey['approval-trigger']).toBe('done')
-    expect(byKey['approval-projection']).toBe('done')
-    expect(byKey['approval-bridge']).toBe('in_progress') // rescheduled with backoff — independent of siblings
-    expect(handled.sort()).toEqual([...APPROVAL_COMPLETION_CONSUMERS].sort())
+    expect(byKey[keys[1]]).toBe('done')
+    expect(byKey[keys[2]]).toBe('done')
+    expect(byKey[keys[0]]).toBe('in_progress') // rescheduled with backoff — independent of siblings
+    expect(handled.sort()).toEqual([...keys].sort())
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -332,6 +332,9 @@ export default defineConfig({
       // P2 durable-delivery S2-b dispatch loop (registry + tick) — real-DB. Excluded HERE so it cannot
       // skip-green in the no-DB lane; whole-file wired into plugin-tests.yml. Two-point wiring.
       'tests/integration/multitable-automation-dispatch-loop-realdb.test.ts',
+      // P2 durable-delivery S4-a producer atomic enqueue — real-DB (txn atomicity + fan-out + e2e tick).
+      // Excluded HERE so it cannot skip-green in the no-DB lane; whole-file wired into plugin-tests.yml.
+      'tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts',
       // W0 tail (#4279, owner MUST-WRITE OD-6, design-lock §0.5 2026-07-13): field-undelete rehydration
       // revision goldens — proves `recreateFieldFromConfig`'s tombstone-value rehydration UPDATE bumps
       // `version` and emits a `recordRecordRevision` AT THE NEW version, same transaction, for every


### PR DESCRIPTION
**Base: `main`. Additive, flag-neutral** — S4-a producer-side atomic enqueue helper; no callers until S4-b wires the produce sites behind `AUTOMATION_DURABLE_DELIVERY_ENABLED`. Head `f4e81a57b`.

## What lands
`enqueueOutboxEvent(trx, event)` — one `meta_automation_outbox` row + one pending `meta_automation_outbox_consumer` row per manifest-expanded key, inside the caller's transaction; unrouted family / blank identity / bad depth are hard errors; `manifest_version` stamped. Plus the shared **`pg-transaction-guard.ts`** (also ships byte-identical on #4340; second-lander rebases to a no-op).

## Review fixes
- **P1 round-1 (atomicity by calling convention)** → **round-2 (marker forgeable)**: the `isTransaction: true` marker was a public boolean any caller could forge onto a Pool — the half-state repro (outbox=1/consumer=0) still worked. Now the guard asserts the **database's own transaction state**: two `pg_current_xact_id()` probes through the handle must observe the SAME transaction. A Pool (statements on arbitrary connections), a bare AUTOCOMMIT client, `withTransaction`'s non-transactional fallback, and a **forged marker over any of those** all fail the probe **before any write**. The brand remains compile-time documentation only.
- **P2 (shared-DB test pollution)**: the e2e drains a **run-unique** test manifest (`ubridge/utrigger/uproj_<run>`), default batch — it can only claim its own rows.

## Verification (fresh Postgres 15)
- **8/8**: commit fan-out; ROLLBACK-zero-rows; **pool + forged-marker + bare-autocommit negatives** (each rejected, zero rows); **transaction positive control** (consumer-INSERT failure rolls the outbox row back — no orphan); unrouted/blank/depth hard errors; e2e per-consumer independence. `tsc --noEmit` 0.
- The probe is **mutation-proven** (neutering `assertInTransaction` reds the negatives). Two-point CI wired.

**For review — not self-merging runtime.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)