### PR TITLE
feat(automation): P2 durable-delivery S4-b/S5 activation seam + S7 crash-injection V-series

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -734,6 +734,7 @@ jobs:
             tests/integration/multitable-automation-event-fires-lease-migration.db.test.ts \
             tests/integration/multitable-automation-event-fires-lease-realdb.db.test.ts \
             tests/integration/multitable-automation-approval-bridge-lease-migration.db.test.ts \
+            tests/integration/multitable-automation-approval-bridge-lease-realdb.test.ts \
             tests/integration/multitable-attachment-blob-purge.db.test.ts \
             tests/integration/multitable-attachment-root-escape.db.test.ts \
             tests/integration/stock-prep-audit-immutable-trigger.db.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -735,6 +735,7 @@ jobs:
             tests/integration/multitable-automation-event-fires-lease-realdb.db.test.ts \
             tests/integration/multitable-automation-approval-bridge-lease-migration.db.test.ts \
             tests/integration/multitable-automation-approval-bridge-lease-realdb.test.ts \
+            tests/integration/multitable-automation-producer-emit-realdb.test.ts \
             tests/integration/multitable-attachment-blob-purge.db.test.ts \
             tests/integration/multitable-attachment-root-escape.db.test.ts \
             tests/integration/stock-prep-audit-immutable-trigger.db.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -737,6 +737,7 @@ jobs:
             tests/integration/multitable-automation-approval-bridge-lease-realdb.test.ts \
             tests/integration/multitable-automation-producer-emit-realdb.test.ts \
             tests/integration/multitable-automation-producer-family2-realdb.test.ts \
+            tests/integration/multitable-automation-producer-family5-realdb.test.ts \
             tests/integration/multitable-attachment-blob-purge.db.test.ts \
             tests/integration/multitable-attachment-root-escape.db.test.ts \
             tests/integration/stock-prep-audit-immutable-trigger.db.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -573,6 +573,7 @@ jobs:
             tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts \
             tests/integration/multitable-automation-dispatch-loop-realdb.test.ts \
             tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts \
+            tests/integration/multitable-automation-durable-activation-realdb.test.ts \
             tests/integration/multitable-attachment-readgate.security.test.ts \
             tests/integration/multitable-ai-write-provenance-batch-grouping-realdb.test.ts \
             tests/integration/multitable-automation-branch-local-wait.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -545,6 +545,7 @@ jobs:
             tests/integration/multitable-date-reminder-trigger.test.ts \
             tests/integration/multitable-webhook-event-bridge.test.ts \
             tests/integration/multitable-webhook-retry-tick.test.ts \
+            tests/integration/multitable-webhook-durable-dedup.test.ts \
             tests/integration/multitable-ai-shortcut-run.test.ts \
             tests/integration/multitable-ai-bulk-preview.test.ts \
             tests/integration/multitable-ai-bulk-commit.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -738,6 +738,7 @@ jobs:
             tests/integration/multitable-automation-approval-bridge-lease-realdb.test.ts \
             tests/integration/multitable-automation-producer-emit-realdb.test.ts \
             tests/integration/multitable-automation-producer-family2-realdb.test.ts \
+            tests/integration/multitable-durable-startup-failclosed.db.test.ts \
             tests/integration/multitable-automation-producer-family5-realdb.test.ts \
             tests/integration/multitable-automation-producer-family4-realdb.test.ts \
             tests/integration/multitable-automation-producer-family1-realdb.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -733,6 +733,7 @@ jobs:
             tests/integration/files-orphan-blob-retention.db.test.ts \
             tests/integration/multitable-automation-event-fires-lease-migration.db.test.ts \
             tests/integration/multitable-automation-event-fires-lease-realdb.db.test.ts \
+            tests/integration/multitable-automation-approval-bridge-lease-migration.db.test.ts \
             tests/integration/multitable-attachment-blob-purge.db.test.ts \
             tests/integration/multitable-attachment-root-escape.db.test.ts \
             tests/integration/stock-prep-audit-immutable-trigger.db.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -736,6 +736,7 @@ jobs:
             tests/integration/multitable-automation-approval-bridge-lease-migration.db.test.ts \
             tests/integration/multitable-automation-approval-bridge-lease-realdb.test.ts \
             tests/integration/multitable-automation-producer-emit-realdb.test.ts \
+            tests/integration/multitable-automation-producer-family2-realdb.test.ts \
             tests/integration/multitable-attachment-blob-purge.db.test.ts \
             tests/integration/multitable-attachment-root-escape.db.test.ts \
             tests/integration/stock-prep-audit-immutable-trigger.db.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -739,6 +739,7 @@ jobs:
             tests/integration/multitable-automation-producer-family2-realdb.test.ts \
             tests/integration/multitable-automation-producer-family5-realdb.test.ts \
             tests/integration/multitable-automation-producer-family4-realdb.test.ts \
+            tests/integration/multitable-automation-producer-family1-realdb.test.ts \
             tests/integration/multitable-attachment-blob-purge.db.test.ts \
             tests/integration/multitable-attachment-root-escape.db.test.ts \
             tests/integration/stock-prep-audit-immutable-trigger.db.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -738,6 +738,7 @@ jobs:
             tests/integration/multitable-automation-producer-emit-realdb.test.ts \
             tests/integration/multitable-automation-producer-family2-realdb.test.ts \
             tests/integration/multitable-automation-producer-family5-realdb.test.ts \
+            tests/integration/multitable-automation-producer-family4-realdb.test.ts \
             tests/integration/multitable-attachment-blob-purge.db.test.ts \
             tests/integration/multitable-attachment-root-escape.db.test.ts \
             tests/integration/stock-prep-audit-immutable-trigger.db.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260717120000_approval_bridge_lease.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260717120000_approval_bridge_lease.ts
@@ -1,0 +1,101 @@
+/**
+ * Migration: `multitable_automation_approval_bridges` — P2 durable-delivery P1 #1: upgrade the terminal-EARLY
+ * completion claim into a reclaimable LEASE (mirrors the S6 `meta_automation_event_fires` lease).
+ *
+ * Problem (owner P1 #1): `claimCompletion` flips a bridge `pending → resumed` (TERMINAL) BEFORE the resume
+ * continuation runs. A crash between that terminal write and the continuation finishing is permanently lost —
+ * a redelivery finds the row not-`pending` and skips, so the tail (the automation's remaining actions) never
+ * runs. This adds a reclaimable lease so a crash mid-continuation leaves the row RECLAIMABLE (lease expires →
+ * the redelivered completion event reclaims it) and moves the terminal write to AFTER the continuation.
+ *
+ * KEY DIFFERENCE FROM S6 (verify, don't assume — the S6 `DEFAULT 'done'` backfill does NOT apply here):
+ * `meta_automation_event_fires` rows were historical COMPLETED deliveries, so S6 backfilled them to `done`.
+ * This table's `status` column already exists with LIVE semantics — a `pending` row is an IN-FLIGHT bridge
+ * still waiting for its (external) approval-completion event. Those rows MUST stay `pending`. So this migration
+ * does NOT touch any existing status value: it only ADDS the lease columns (`lease_expires_at` NULL,
+ * `fence`/`attempts` DEFAULT 0) and WIDENS the CHECKs. Every pre-existing row is therefore never `in_progress`
+ * and always lease-NULL, so the biconditional CHECK holds at ALTER time.
+ *
+ * New states (owner's state-machine laws — no stuck absorbing state; every terminal resolve-permitting):
+ *   - `in_progress` — the completion event is claimed and the continuation is running; holds a lease + fence.
+ *     Reclaimable: an EXPIRED in_progress lease (crashed worker) is reclaimed by the next redelivery (fence+1).
+ *   - `dead_letter` — a continuation that crashed past the attempt ceiling; terminal (no infinite reclaim).
+ * Terminals stay lease-NULL: `resumed` (continuation done — success OR deterministic failure, preserving the
+ * legacy meaning "completion consumed"), `failed` (start_approval CREATION failure — unchanged), `dead_letter`.
+ *
+ * FENCE (universal rule for every reclaimable lease row): monotonic, self-incremented on claim/reclaim;
+ * persistent-state writes are fence-CAS (`WHERE fence = <claimed>`), so a reclaimed zombie with a stale fence
+ * hits 0 rows → single-writer. `bigint` (values can exceed 2^31) round-tripped as a STRING at the driver seam.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Lease column: NULL for every existing row (no lease held). Added BEFORE the biconditional CHECK so that
+  // CHECK validates against lease-NULL existing rows.
+  await sql`ALTER TABLE multitable_automation_approval_bridges ADD COLUMN IF NOT EXISTS lease_expires_at timestamptz`.execute(db)
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+      ADD COLUMN IF NOT EXISTS attempts int NOT NULL DEFAULT 0
+        CONSTRAINT chk_mt_auto_approval_bridge_attempts_nonneg CHECK (attempts >= 0)
+  `.execute(db)
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+      ADD COLUMN IF NOT EXISTS fence bigint NOT NULL DEFAULT 0
+        CONSTRAINT chk_mt_auto_approval_bridge_fence_nonneg CHECK (fence >= 0)
+  `.execute(db)
+
+  // Widen the status set to include the two new lease states. DROP+ADD (replay-safe) — the original CHECK
+  // name is reused so there is exactly one status CHECK.
+  await sql`ALTER TABLE multitable_automation_approval_bridges DROP CONSTRAINT IF EXISTS chk_mt_auto_approval_bridge_status`.execute(db)
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+      ADD CONSTRAINT chk_mt_auto_approval_bridge_status
+      CHECK (status IN ('creating', 'pending', 'in_progress', 'resumed', 'failed', 'dead_letter'))
+  `.execute(db)
+
+  // BICONDITIONAL: a lease exists IFF the row is in_progress (mirrors event_fires / outbox_consumer). Every
+  // pre-existing row is creating/pending/resumed/failed with lease=NULL ⇒ (false)=(false) ⇒ holds at ALTER.
+  await sql`ALTER TABLE multitable_automation_approval_bridges DROP CONSTRAINT IF EXISTS chk_mt_auto_approval_bridge_lease_iff_in_progress`.execute(db)
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+      ADD CONSTRAINT chk_mt_auto_approval_bridge_lease_iff_in_progress
+      CHECK ((status = 'in_progress') = (lease_expires_at IS NOT NULL))
+  `.execute(db)
+
+  // Widen "claimable states must carry an approval_instance_id" to the new post-completion states (in_progress
+  // and dead_letter are only reached via a completion event, which requires an instance). creating/failed can
+  // still have a NULL instance (creation-time states), so they stay outside the IN-list.
+  await sql`ALTER TABLE multitable_automation_approval_bridges DROP CONSTRAINT IF EXISTS chk_mt_auto_approval_bridge_claimable_has_approval`.execute(db)
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+      ADD CONSTRAINT chk_mt_auto_approval_bridge_claimable_has_approval
+      CHECK (status NOT IN ('pending', 'in_progress', 'resumed', 'dead_letter') OR approval_instance_id IS NOT NULL)
+  `.execute(db)
+
+  // The reclaim scan reads (status='in_progress' AND lease_expires_at < now()); index it (mirrors S6).
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_mt_auto_approval_bridges_reclaim
+    ON multitable_automation_approval_bridges (status, lease_expires_at)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_mt_auto_approval_bridges_reclaim`.execute(db)
+  await sql`ALTER TABLE multitable_automation_approval_bridges DROP CONSTRAINT IF EXISTS chk_mt_auto_approval_bridge_lease_iff_in_progress`.execute(db)
+  await sql`ALTER TABLE multitable_automation_approval_bridges DROP COLUMN IF EXISTS fence`.execute(db)
+  await sql`ALTER TABLE multitable_automation_approval_bridges DROP COLUMN IF EXISTS attempts`.execute(db)
+  await sql`ALTER TABLE multitable_automation_approval_bridges DROP COLUMN IF EXISTS lease_expires_at`.execute(db)
+  // restore the pre-lease status set + claimable CHECK
+  await sql`ALTER TABLE multitable_automation_approval_bridges DROP CONSTRAINT IF EXISTS chk_mt_auto_approval_bridge_status`.execute(db)
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+      ADD CONSTRAINT chk_mt_auto_approval_bridge_status
+      CHECK (status IN ('creating', 'pending', 'resumed', 'failed'))
+  `.execute(db)
+  await sql`ALTER TABLE multitable_automation_approval_bridges DROP CONSTRAINT IF EXISTS chk_mt_auto_approval_bridge_claimable_has_approval`.execute(db)
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+      ADD CONSTRAINT chk_mt_auto_approval_bridge_claimable_has_approval
+      CHECK (status NOT IN ('pending', 'resumed') OR approval_instance_id IS NOT NULL)
+  `.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260717130000_webhook_delivery_event_id.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260717130000_webhook_delivery_event_id.ts
@@ -1,0 +1,41 @@
+/**
+ * Migration: `multitable_webhook_deliveries` — P2 durable-delivery closure item 3 (owner 2026-07-17).
+ *
+ * Problem: the DURABLE webhook consumer (`webhook-event-bridge`) discarded the outbox `eventId`, so an
+ * at-least-once redelivery (a crash between the fire-and-forget send and the consumer-row done-CAS, or a
+ * `busy` retry) called `createDeliveryRecord` again → a SECOND delivery row + a SECOND HTTP send. This adds a
+ * per-(webhook, event) identity so the durable path can CLAIM instead of blindly INSERT.
+ *
+ * `event_id` is NULLABLE and defaults to NULL. Every LEGACY path (the bus bridge's fire-and-forget deliver,
+ * the retry tick) passes no event_id → NULL → byte-identical behavior (no dedup there, unchanged; the
+ * partial index below does not constrain NULL rows). ONLY the durable consumer passes the outbox eventId.
+ *
+ * The claim is a PARTIAL UNIQUE index on `(webhook_id, event_id) WHERE event_id IS NOT NULL`: the durable
+ * insert becomes `INSERT ... ON CONFLICT DO NOTHING RETURNING id`; zero rows ⇒ this (webhook, event) was
+ * already claimed ⇒ the redelivery skips the send. The partial predicate keeps NULL (legacy) rows entirely
+ * unconstrained, so many legacy deliveries for the same webhook coexist exactly as today.
+ *
+ * `multitable_webhook_deliveries` is a `zzzz`-prefixed table (created in
+ * `zzzz20260414100002_create_multitable_api_tokens_and_webhooks`); a new column on it must ALSO be a `zzzz`
+ * migration so it sorts AFTER the create (migration zzzz-ordering trap).
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // NULL for every existing row and every legacy path — the durable consumer is the only writer of a non-NULL
+  // value. Additive + nullable, so no backfill and no behavior change for existing rows.
+  await sql`ALTER TABLE multitable_webhook_deliveries ADD COLUMN IF NOT EXISTS event_id text`.execute(db)
+  // Per-(webhook, event) claim. PARTIAL so NULL (legacy) rows are unconstrained — the durable path's identity
+  // dedup never touches legacy fan-out. This is the arbiter under concurrency: two racing durable delivers of
+  // the same (webhook, event) → exactly one INSERT wins, the loser's ON CONFLICT DO NOTHING returns 0 rows.
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_webhook_delivery_event_claim
+      ON multitable_webhook_deliveries (webhook_id, event_id)
+      WHERE event_id IS NOT NULL
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS uq_webhook_delivery_event_claim`.execute(db)
+  await sql`ALTER TABLE multitable_webhook_deliveries DROP COLUMN IF EXISTS event_id`.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1403,6 +1403,11 @@ export interface MultitableAutomationApprovalBridgesTable {
   created_at: CreatedAt
   completed_at: Date | string | null
   resumed_at: Date | string | null
+  // P2 durable-delivery P1#1 — reclaimable lease (zzzz20260717120000_approval_bridge_lease). NULL/0 for every
+  // row written before the upgrade and on the flag-OFF legacy path.
+  lease_expires_at: Date | string | null
+  attempts: number
+  fence: string | number
 }
 
 export interface MultitableAutomationExecutionsTable {

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1507,6 +1507,9 @@ export interface MultitableWebhookDeliveriesTable {
   created_at: CreatedAt
   delivered_at: NullableTimestamp
   next_retry_at: NullableTimestamp
+  /** Outbox event identity for the DURABLE delivery leg's per-(webhook, event) idempotent claim
+   *  (partial-unique `uq_webhook_delivery_event_claim`). NULL on every legacy path. */
+  event_id: string | null
 }
 
 export interface DingTalkGroupDestinationsTable {

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2340,6 +2340,13 @@ export class MetaSheetServer {
           onTickError: (err) => this.logger.error('Durable delivery dispatch tick error', err instanceof Error ? err : new Error(String(err))),
           onHeartbeatError: (info) => this.logger.warn(`Durable delivery heartbeat renew DB error for ${info.consumerKey} (outbox ${info.outboxId}); row left for reclaim`),
           onClaimTimePoison: (info) => this.logger.warn(`Durable delivery dead-lettered ${info.consumerKey} (outbox ${info.outboxId}) after ${info.attempts} attempts`),
+        }, {
+          // Clock alignment (sink audit 2026-07-17): the OUTBOX consumer lease must outlive the SINK leases
+          // (EVENT_DELIVERY_LEASE_MS / BRIDGE_COMPLETION_LEASE_MS, both 60s) — with the 30s default, a crash
+          // redelivers while the dead worker's sink lease is still live, burning retries on 'busy'. 90s means
+          // the first post-crash redelivery already finds the sink lease expired and reclaims. The busy→
+          // retryable mapping in the sinks is the structural guard; this alignment just avoids wasted spins.
+          leaseMs: 90_000,
         })
         if (this.durableDeliveryLoop) this.logger.info('Durable delivery dispatch loop started (AUTOMATION_DURABLE_DELIVERY_ENABLED)')
       }

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2352,7 +2352,15 @@ export class MetaSheetServer {
         if (this.durableDeliveryLoop) this.logger.info('Durable delivery dispatch loop started (AUTOMATION_DURABLE_DELIVERY_ENABLED)')
       }
     } catch (e) {
-      this.logger.error('Durable delivery dispatch loop initialization failed; continuing in degraded mode', e as Error)
+      // Owner closure item 4 — startup fail-closed. With the flag ON the producer families suppress their
+      // legacy emits, so continuing without a dispatch loop is not "degraded": it silently strands every
+      // outbox row (total delivery outage). The disposition helper (unit-tested) decides per flag.
+      const { durableBootFailureDisposition } = await import('./multitable/automation-durable-activation')
+      if (durableBootFailureDisposition() === 'fail-closed') {
+        this.logger.error('Durable delivery boot FAILED with AUTOMATION_DURABLE_DELIVERY_ENABLED=true — aborting startup (fail-closed: legacy emits are suppressed, a loop-less process would strand all outbox rows)', e as Error)
+        throw e
+      }
+      this.logger.error('Durable delivery dispatch loop initialization failed (flag OFF — nothing suppressed, legacy path delivers); continuing', e as Error)
     }
 
     try {

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2325,11 +2325,16 @@ export class MetaSheetServer {
     // families' producers enqueue same-txn and SUPPRESS their legacy emit, the P1#2 REPLACE contract), and
     // with the flag OFF they are the delivery path exactly as before. stop() is registered in this.stop().
     try {
-      const { bootDurableDelivery } = await import('./multitable/automation-durable-activation')
+      const { bootDurableDelivery, assertDurableRuntimeDependency } = await import('./multitable/automation-durable-activation')
       const { buildDurableConsumerHandlers } = await import('./multitable/automation-durable-consumer-handlers')
       const { getApprovalRecordProjectionService } = await import('./multitable/approval-record-projection-service')
       const { WebhookService } = await import('./multitable/webhook-service')
       const { db: kyselyDbDurable } = await import('./db/db')
+      // Owner P1 (head 5afe30f26): an earlier degraded AutomationService init must not silently SKIP durable
+      // boot — with the flag ON, skipping is the same outage as a boot crash (no dispatcher, outbox stranded)
+      // but with no exception to catch. The assert throws flag-ON (→ the disposition catch below aborts
+      // startup) and no-ops flag-OFF (the `if` skip below keeps the legacy degrade behavior).
+      assertDurableRuntimeDependency('AutomationService (durable consumer handlers delegate)', Boolean(this.automationService))
       if (this.automationService) {
         const handlers = buildDurableConsumerHandlers({
           automationService: this.automationService,
@@ -2374,7 +2379,18 @@ export class MetaSheetServer {
           ? 'Webhook retry scheduler initialized'
           : 'Webhook retry scheduler disabled (WEBHOOK_RETRY_SCHEDULER_DISABLED=1)',
       )
+      // Owner P1 (head 5afe30f26): with durable delivery ON the retry scheduler is LOAD-BEARING — the durable
+      // webhook leg persists a pending row and fire-and-forgets the send; crash recovery (incl. the
+      // first-attempt stray-grace leg) IS this scheduler. Disabled (env) ⇒ throw here; init failure ⇒ the
+      // catch below. Both abort startup flag-ON; flag-OFF keeps the legacy degrade-and-continue.
+      const { assertDurableRuntimeDependency } = await import('./multitable/automation-durable-activation')
+      assertDurableRuntimeDependency('webhook retry scheduler (durable webhook crash recovery)', webhookRetryScheduler != null)
     } catch (e) {
+      const { durableBootFailureDisposition } = await import('./multitable/automation-durable-activation')
+      if (durableBootFailureDisposition() === 'fail-closed') {
+        this.logger.error('Webhook retry scheduler unavailable with AUTOMATION_DURABLE_DELIVERY_ENABLED=true — aborting startup (fail-closed: the durable webhook leg depends on it for crash recovery)', e as Error)
+        throw e
+      }
       this.logger.error('Webhook retry scheduler initialization failed; continuing in degraded mode', e as Error)
     }
 

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -269,6 +269,13 @@ export class MetaSheetServer {
   private stopFilesOrphanBlobRetention?: () => void
   private stopMultitableAttachmentBlobPurge?: () => void
   private automationService?: AutomationService
+  // Owner P1 (head 1d3854c7a): explicit readiness bit for the durable fail-closed chain. TRUE only after
+  // the FULL AutomationService init sequence (constructor + init() + loadAndRegisterAllScheduled()) has
+  // succeeded — `Boolean(this.automationService)` alone was bypassable, because the field used to be
+  // assigned right after construction and never cleared when init()/load threw. The init block below is
+  // publish-last (field + this bit + singleton set only on full success), so the two can never disagree;
+  // the durable boot asserts THIS bit.
+  private automationServiceReady = false
   private apiGateway?: APIGateway
   private yjsCleanupTimer?: NodeJS.Timeout
   private yjsSyncMetricsSource?: { getMetrics(): { activeDocCount: number; docIds: string[] } }
@@ -1889,6 +1896,7 @@ export class MetaSheetServer {
     shutdownTasks.push(Promise.resolve().then(() => {
       try {
         this.automationService?.shutdown()
+        this.automationServiceReady = false
         setAutomationServiceInstance(null)
       } catch (err) {
         this.logger.warn(`AutomationService shutdown error: ${err instanceof Error ? err.message : String(err)}`)
@@ -2169,7 +2177,15 @@ export class MetaSheetServer {
       )
     }
 
-    // Initialize AutomationService
+    // Initialize AutomationService — PUBLISH-LAST (owner P1, head 1d3854c7a). The field, the readiness
+    // bit, and the module singleton are set ONLY after the FULL init chain (constructor + init() +
+    // loadAndRegisterAllScheduled()) has succeeded. Previously `this.automationService` was assigned right
+    // after construction and never cleared on failure, so an init()/load throw left a half-initialized
+    // service that `Boolean(this.automationService)` happily accepted — bypassing the durable fail-closed
+    // assert. Now a mid-chain failure rolls the instance back (best-effort shutdown: unsubscribe bus
+    // handlers, destroy scheduler timers) and publishes NOTHING: flag-OFF this is the legacy
+    // degrade-and-continue, flag-ON the durable boot below fail-closes on automationServiceReady=false.
+    let pendingAutomationService: AutomationService | undefined
     try {
       const pool = poolManager.get()
       const { db: kyselyDb } = await import('./db/db')
@@ -2180,7 +2196,7 @@ export class MetaSheetServer {
       // behaviour) when the flag is off or Redis is unavailable, so this
       // call is safe in every deployment.
       const schedulerLeaderOptions = await resolveAutomationSchedulerLeaderOptions()
-      this.automationService = new AutomationService(
+      pendingAutomationService = new AutomationService(
         eventBus,
         kyselyDb,
         pool.query.bind(pool),
@@ -2189,11 +2205,23 @@ export class MetaSheetServer {
         { leaderStateGauge: promMetrics.automationSchedulerLeaderGauge },
         notificationService,
       )
-      this.automationService.init()
-      setAutomationServiceInstance(this.automationService)
-      await this.automationService.loadAndRegisterAllScheduled()
+      pendingAutomationService.init()
+      await pendingAutomationService.loadAndRegisterAllScheduled()
+      // Full chain succeeded — publish atomically (nothing downstream can ever observe a partial init).
+      this.automationService = pendingAutomationService
+      this.automationServiceReady = true
+      setAutomationServiceInstance(pendingAutomationService)
       this.logger.info('AutomationService initialized')
     } catch (e) {
+      // Roll back the half-built instance. It was never published (no field, no singleton, routes see
+      // undefined), so this only reaps whatever the partial init managed to start.
+      try {
+        pendingAutomationService?.shutdown()
+      } catch {
+        // best-effort rollback — the instance is unpublished either way
+      }
+      this.automationService = undefined
+      this.automationServiceReady = false
       this.logger.error('AutomationService initialization failed; continuing in degraded mode', e as Error)
     }
 
@@ -2315,6 +2343,44 @@ export class MetaSheetServer {
       this.logger.error('Webhook event bridge initialization failed; continuing in degraded mode', e as Error)
     }
 
+    // Webhook retry scheduler — started BEFORE the durable dispatch loop ON PURPOSE (owner P2, head
+    // 1d3854c7a): flag-ON it is a load-bearing durable runtime dependency (the durable webhook leg persists
+    // a `pending` row and fire-and-forgets the send; crash recovery — incl. the first-attempt stray-grace
+    // leg — IS this scheduler), and the activation sequence must validate EVERY dependency before the loop
+    // starts, so a fail-closed abort can never leave a live loop handle ticking the pool. Flag-OFF the order
+    // swap is behavior-neutral: the two blocks are independent (the scheduler is webhook_deliveries
+    // row-driven and never reads the loop), only the log-line order changes.
+    try {
+      const webhookRetryLeaderOptions = await resolveWebhookRetrySchedulerLeaderOptions()
+      const webhookRetryScheduler = startWebhookRetryScheduler({
+        leaderOptions: webhookRetryLeaderOptions,
+        intervalMs: resolveWebhookRetrySchedulerIntervalMs(),
+      })
+      this.logger.info(
+        webhookRetryScheduler
+          ? 'Webhook retry scheduler initialized'
+          : 'Webhook retry scheduler disabled (WEBHOOK_RETRY_SCHEDULER_DISABLED=1)',
+      )
+      // Owner P1 (head 5afe30f26): with durable delivery ON the retry scheduler is LOAD-BEARING (see the
+      // ordering note above). Disabled (env) ⇒ throw here; init failure ⇒ the catch below. Both abort
+      // startup flag-ON; flag-OFF keeps the legacy degrade-and-continue.
+      const { assertDurableRuntimeDependency } = await import('./multitable/automation-durable-activation')
+      assertDurableRuntimeDependency('webhook retry scheduler (durable webhook crash recovery)', webhookRetryScheduler != null)
+    } catch (e) {
+      const { durableBootFailureDisposition } = await import('./multitable/automation-durable-activation')
+      if (durableBootFailureDisposition() === 'fail-closed') {
+        // Roll back anything this block managed to start — an aborted startup must leave no ticking DB timer.
+        try {
+          stopWebhookRetryScheduler()
+        } catch {
+          // best-effort rollback; the abort below is the authoritative outcome
+        }
+        this.logger.error('Webhook retry scheduler unavailable with AUTOMATION_DURABLE_DELIVERY_ENABLED=true — aborting startup (fail-closed: the durable webhook leg depends on it for crash recovery)', e as Error)
+        throw e
+      }
+      this.logger.error('Webhook retry scheduler initialization failed; continuing in degraded mode', e as Error)
+    }
+
     // P2 durable-delivery S5: start the transactional-outbox dispatch loop. Gated by
     // AUTOMATION_DURABLE_DELIVERY_ENABLED — bootDurableDelivery returns null when the flag is OFF, so this
     // block registers no loop, opens no poll, and reads no rows (byte-identical startup). When ON, it builds
@@ -2324,6 +2390,12 @@ export class MetaSheetServer {
     // bus subscriptions above stay wired — with the flag ON they serve only UN-routed event types (routed
     // families' producers enqueue same-txn and SUPPRESS their legacy emit, the P1#2 REPLACE contract), and
     // with the flag OFF they are the delivery path exactly as before. stop() is registered in this.stop().
+    //
+    // ACTIVATION IS A ROLLBACK-ABLE SEQUENCE (owner P2, head 1d3854c7a): every durable dependency is
+    // validated BEFORE the loop starts — the retry scheduler in the block above, AutomationService readiness
+    // and manifest completeness below — and the loop start is the LAST fallible step, so a fail-closed abort
+    // structurally cannot leave a live loop. The catch still stops+nulls any started handle (defense in
+    // depth) and tears down the retry scheduler on abort.
     try {
       const { bootDurableDelivery, assertDurableRuntimeDependency } = await import('./multitable/automation-durable-activation')
       const { buildDurableConsumerHandlers } = await import('./multitable/automation-durable-consumer-handlers')
@@ -2334,8 +2406,14 @@ export class MetaSheetServer {
       // boot — with the flag ON, skipping is the same outage as a boot crash (no dispatcher, outbox stranded)
       // but with no exception to catch. The assert throws flag-ON (→ the disposition catch below aborts
       // startup) and no-ops flag-OFF (the `if` skip below keeps the legacy degrade behavior).
-      assertDurableRuntimeDependency('AutomationService (durable consumer handlers delegate)', Boolean(this.automationService))
-      if (this.automationService) {
+      // Owner P1 (head 1d3854c7a): the assert consumes the explicit READINESS bit, not the object's mere
+      // existence — publish-last (above) guarantees the bit is true only after constructor+init()+load ALL
+      // succeeded, so a half-initialized service can no longer slip past `Boolean(this.automationService)`.
+      assertDurableRuntimeDependency(
+        'AutomationService (durable consumer handlers delegate; requires the FULL init chain: constructor + init() + loadAndRegisterAllScheduled())',
+        this.automationServiceReady && Boolean(this.automationService),
+      )
+      if (this.automationServiceReady && this.automationService) {
         const handlers = buildDurableConsumerHandlers({
           automationService: this.automationService,
           projectionService: getApprovalRecordProjectionService(),
@@ -2360,38 +2438,30 @@ export class MetaSheetServer {
       // Owner closure item 4 — startup fail-closed. With the flag ON the producer families suppress their
       // legacy emits, so continuing without a dispatch loop is not "degraded": it silently strands every
       // outbox row (total delivery outage). The disposition helper (unit-tested) decides per flag.
+      //
+      // ROLLBACK FIRST (owner P2, head 1d3854c7a): if a loop handle was started before the throw, stop it
+      // and null the field NOW — the prior shape left the S1 rejection with a live loop whose next tick hit
+      // "Cannot use a pool after calling end on the pool" in the green Node20 CI log. With the reordered
+      // sequence above nothing fallible remains after the loop starts, so this is defense in depth.
+      if (this.durableDeliveryLoop) {
+        const startedLoop = this.durableDeliveryLoop
+        this.durableDeliveryLoop = null
+        await startedLoop.stop().catch((stopErr: unknown) => {
+          this.logger.warn(`Durable delivery dispatch loop rollback stop error: ${stopErr instanceof Error ? stopErr.message : String(stopErr)}`)
+        })
+      }
       const { durableBootFailureDisposition } = await import('./multitable/automation-durable-activation')
       if (durableBootFailureDisposition() === 'fail-closed') {
+        // The retry scheduler (started in the block above) must not outlive the aborted startup either.
+        try {
+          stopWebhookRetryScheduler()
+        } catch {
+          // best-effort rollback; the abort below is the authoritative outcome
+        }
         this.logger.error('Durable delivery boot FAILED with AUTOMATION_DURABLE_DELIVERY_ENABLED=true — aborting startup (fail-closed: legacy emits are suppressed, a loop-less process would strand all outbox rows)', e as Error)
         throw e
       }
       this.logger.error('Durable delivery dispatch loop initialization failed (flag OFF — nothing suppressed, legacy path delivers); continuing', e as Error)
-    }
-
-    try {
-      const webhookRetryLeaderOptions = await resolveWebhookRetrySchedulerLeaderOptions()
-      const webhookRetryScheduler = startWebhookRetryScheduler({
-        leaderOptions: webhookRetryLeaderOptions,
-        intervalMs: resolveWebhookRetrySchedulerIntervalMs(),
-      })
-      this.logger.info(
-        webhookRetryScheduler
-          ? 'Webhook retry scheduler initialized'
-          : 'Webhook retry scheduler disabled (WEBHOOK_RETRY_SCHEDULER_DISABLED=1)',
-      )
-      // Owner P1 (head 5afe30f26): with durable delivery ON the retry scheduler is LOAD-BEARING — the durable
-      // webhook leg persists a pending row and fire-and-forgets the send; crash recovery (incl. the
-      // first-attempt stray-grace leg) IS this scheduler. Disabled (env) ⇒ throw here; init failure ⇒ the
-      // catch below. Both abort startup flag-ON; flag-OFF keeps the legacy degrade-and-continue.
-      const { assertDurableRuntimeDependency } = await import('./multitable/automation-durable-activation')
-      assertDurableRuntimeDependency('webhook retry scheduler (durable webhook crash recovery)', webhookRetryScheduler != null)
-    } catch (e) {
-      const { durableBootFailureDisposition } = await import('./multitable/automation-durable-activation')
-      if (durableBootFailureDisposition() === 'fail-closed') {
-        this.logger.error('Webhook retry scheduler unavailable with AUTOMATION_DURABLE_DELIVERY_ENABLED=true — aborting startup (fail-closed: the durable webhook leg depends on it for crash recovery)', e as Error)
-        throw e
-      }
-      this.logger.error('Webhook retry scheduler initialization failed; continuing in degraded mode', e as Error)
     }
 
     // AI usage ledger retention sweep (ladder #9): a periodic bounded DELETE of

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -281,7 +281,10 @@ export class MetaSheetServer {
   private disableEventBus = process.env.DISABLE_EVENT_BUS === 'true'
   private metricsStreamService?: MetricsStreamService
   private dingtalkInteractiveCardStreamWorker?: DingTalkInteractiveCardStreamWorker
-  
+  // P2 durable-delivery S5: the outbox dispatch loop handle. null unless AUTOMATION_DURABLE_DELIVERY_ENABLED
+  // is ON (bootDurableDelivery returns null when the flag is off → no loop, no reads, byte-identical startup).
+  private durableDeliveryLoop: import('./multitable/automation-durable-dispatch-loop').DispatchLoopHandle | null = null
+
   // IoC Container
   private injector: Injector
 
@@ -1891,6 +1894,17 @@ export class MetaSheetServer {
         this.logger.warn(`AutomationService shutdown error: ${err instanceof Error ? err.message : String(err)}`)
       }
     }))
+    // P2 durable-delivery S5: stop the outbox dispatch loop (no-op when the flag was OFF — the handle is null).
+    // A clean stop lets in-flight adapters finish/abort and prevents a claimed row from being abandoned mid-lease.
+    if (this.durableDeliveryLoop) {
+      const loop = this.durableDeliveryLoop
+      this.durableDeliveryLoop = null
+      shutdownTasks.push(
+        loop.stop().catch((err) => {
+          this.logger.warn(`Durable delivery dispatch loop stop error: ${err instanceof Error ? err.message : String(err)}`)
+        }) as Promise<void>,
+      )
+    }
     shutdownTasks.push(Promise.resolve().then(() => {
       try {
         this.stopMetaRevisionRetention?.()
@@ -2299,6 +2313,38 @@ export class MetaSheetServer {
       this.logger.info('Webhook event bridge initialized')
     } catch (e) {
       this.logger.error('Webhook event bridge initialization failed; continuing in degraded mode', e as Error)
+    }
+
+    // P2 durable-delivery S5: start the transactional-outbox dispatch loop. Gated by
+    // AUTOMATION_DURABLE_DELIVERY_ENABLED — bootDurableDelivery returns null when the flag is OFF, so this
+    // block registers no loop, opens no poll, and reads no rows (byte-identical startup). When ON, it builds
+    // the six REAL consumer adapters (delegating to the SAME service methods the legacy bus subscribers call —
+    // handleApprovalCompletionEvent / ...Trigger / projection reconcile / handleEvent / webhook deliverEvent),
+    // asserts manifest completeness before any claim, and drains meta_automation_outbox_consumer. The legacy
+    // bus subscriptions above stay wired during the cutover; double delivery is collapsed by the sinks'
+    // idempotency (per the #4203 §316-325 migration-safety contract). stop() is registered in this.stop().
+    try {
+      const { bootDurableDelivery } = await import('./multitable/automation-durable-activation')
+      const { buildDurableConsumerHandlers } = await import('./multitable/automation-durable-consumer-handlers')
+      const { getApprovalRecordProjectionService } = await import('./multitable/approval-record-projection-service')
+      const { WebhookService } = await import('./multitable/webhook-service')
+      const { db: kyselyDbDurable } = await import('./db/db')
+      if (this.automationService) {
+        const handlers = buildDurableConsumerHandlers({
+          automationService: this.automationService,
+          projectionService: getApprovalRecordProjectionService(),
+          webhookService: new WebhookService(kyselyDbDurable),
+        })
+        this.durableDeliveryLoop = bootDurableDelivery(poolManager.get(), handlers, {
+          onUnknownConsumerKeys: (keys) => this.logger.warn(`Durable delivery: unknown consumer keys parked pending: ${keys.join(', ')}`),
+          onTickError: (err) => this.logger.error('Durable delivery dispatch tick error', err instanceof Error ? err : new Error(String(err))),
+          onHeartbeatError: (info) => this.logger.warn(`Durable delivery heartbeat renew DB error for ${info.consumerKey} (outbox ${info.outboxId}); row left for reclaim`),
+          onClaimTimePoison: (info) => this.logger.warn(`Durable delivery dead-lettered ${info.consumerKey} (outbox ${info.outboxId}) after ${info.attempts} attempts`),
+        })
+        if (this.durableDeliveryLoop) this.logger.info('Durable delivery dispatch loop started (AUTOMATION_DURABLE_DELIVERY_ENABLED)')
+      }
+    } catch (e) {
+      this.logger.error('Durable delivery dispatch loop initialization failed; continuing in degraded mode', e as Error)
     }
 
     try {

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2321,8 +2321,9 @@ export class MetaSheetServer {
     // the six REAL consumer adapters (delegating to the SAME service methods the legacy bus subscribers call —
     // handleApprovalCompletionEvent / ...Trigger / projection reconcile / handleEvent / webhook deliverEvent),
     // asserts manifest completeness before any claim, and drains meta_automation_outbox_consumer. The legacy
-    // bus subscriptions above stay wired during the cutover; double delivery is collapsed by the sinks'
-    // idempotency (per the #4203 §316-325 migration-safety contract). stop() is registered in this.stop().
+    // bus subscriptions above stay wired — with the flag ON they serve only UN-routed event types (routed
+    // families' producers enqueue same-txn and SUPPRESS their legacy emit, the P1#2 REPLACE contract), and
+    // with the flag OFF they are the delivery path exactly as before. stop() is registered in this.stop().
     try {
       const { bootDurableDelivery } = await import('./multitable/automation-durable-activation')
       const { buildDurableConsumerHandlers } = await import('./multitable/automation-durable-consumer-handlers')

--- a/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
+++ b/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
@@ -61,6 +61,18 @@ export interface AutomationApprovalBridgeRow {
   triggerEvent: unknown
 }
 
+/**
+ * Discriminated completion-claim result (done/busy split — sink-recoverability audit 2026-07-17).
+ * `claimed` = THIS caller owns the bridge (fresh or reclaimed; legacy terminal-early also maps here);
+ * `none` = nothing to do (no bridge for the approval / already terminal / just poisoned) — skip is correct;
+ * `busy` = ANOTHER worker holds a LIVE lease — the caller must fail retryably, NEVER resolve `done` (a
+ * crashed holder's continuation would be dropped forever) and NEVER run (a live holder would double-drive).
+ */
+export type ApprovalBridgeClaimResult =
+  | { kind: 'claimed'; row: AutomationApprovalBridgeRow }
+  | { kind: 'none' }
+  | { kind: 'busy' }
+
 export interface StartApprovalBridgeResult {
   suspended: boolean
   result?: AutomationStepResult
@@ -337,11 +349,11 @@ export class AutomationApprovalBridgeService {
   async claimCompletion(
     event: ApprovalCompletionEventV1,
     env: NodeJS.ProcessEnv = process.env,
-  ): Promise<AutomationApprovalBridgeRow | null> {
+  ): Promise<ApprovalBridgeClaimResult> {
     const approvalId = event.approval.instanceId
 
     if (!isDurableDeliveryEnabled(env)) {
-      // LEGACY terminal-early path — byte-identical to the pre-P1#1 behavior.
+      // LEGACY terminal-early path — byte-identical to the pre-P1#1 behavior (never 'busy').
       const claimed = await db
         .updateTable('multitable_automation_approval_bridges')
         .set({
@@ -354,7 +366,7 @@ export class AutomationApprovalBridgeService {
         .where('status', '=', 'pending')
         .returningAll()
         .executeTakeFirst()
-      return claimed ? this.mapRow(claimed as Record<string, unknown>) : null
+      return claimed ? { kind: 'claimed', row: this.mapRow(claimed as Record<string, unknown>) } : { kind: 'none' }
     }
 
     // FLAG-ON reclaimable-lease path. Raw SQL for the fence-CAS + lease arithmetic (mirrors S6 event_fires).
@@ -369,7 +381,7 @@ export class AutomationApprovalBridgeService {
       WHERE approval_instance_id = ${approvalId} AND status = 'pending'
       RETURNING *
     `.execute(db)
-    if (fresh.rows.length > 0) return this.mapRow(fresh.rows[0])
+    if (fresh.rows.length > 0) return { kind: 'claimed', row: this.mapRow(fresh.rows[0]) }
 
     // 2) POISON at reclaim: an EXPIRED in_progress that has already exhausted its attempts → dead_letter
     //    (terminal, lease cleared). Returns null (skip) — the work will not be retried again.
@@ -380,7 +392,7 @@ export class AutomationApprovalBridgeService {
         AND lease_expires_at < now() AND attempts >= ${BRIDGE_COMPLETION_MAX_ATTEMPTS}
       RETURNING id
     `.execute(db)
-    if (poisoned.rows.length > 0) return null
+    if (poisoned.rows.length > 0) return { kind: 'none' }
 
     // 3) RECLAIM an EXPIRED in_progress lease (crashed worker): fence+1, attempts+1, new lease. Concurrent
     //    reclaimers race — exactly one matches (the winner's new future lease makes the loser's `< now()`
@@ -392,7 +404,21 @@ export class AutomationApprovalBridgeService {
         AND lease_expires_at < now() AND attempts < ${BRIDGE_COMPLETION_MAX_ATTEMPTS}
       RETURNING *
     `.execute(db)
-    return reclaim.rows.length > 0 ? this.mapRow(reclaim.rows[0]) : null
+    if (reclaim.rows.length > 0) return { kind: 'claimed', row: this.mapRow(reclaim.rows[0]) }
+    // Neither claimed, poisoned, nor reclaimed: classify (done/busy split — sink audit 2026-07-17). NO row
+    // for this approval (the dominant case — most approvals have no automation bridge) or a TERMINAL row
+    // (resumed / failed / dead_letter — the completion is consumed) → 'none' (skip is correct). A LIVE
+    // in_progress lease → 'busy' (the caller fails retryably rather than resolving the delivery `done` and
+    // dropping a crashed holder's continuation). A racing `pending` (appeared between the fresh UPDATE and
+    // this SELECT) is also 'busy' — fail-closed toward retry; the redelivery claims it.
+    const row = await sql<{ status: string }>`
+      SELECT status FROM multitable_automation_approval_bridges WHERE approval_instance_id = ${approvalId}
+    `.execute(db)
+    const status = row.rows[0]?.status
+    if (status === undefined || status === 'resumed' || status === 'failed' || status === 'dead_letter') {
+      return { kind: 'none' }
+    }
+    return { kind: 'busy' }
   }
 
   /**

--- a/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
+++ b/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
@@ -7,8 +7,10 @@
  */
 
 import { randomUUID } from 'crypto'
+import { sql } from 'kysely'
 import { db } from '../db/db'
 import { query } from '../db/pg'
+import { isDurableDeliveryEnabled } from './automation-durable-delivery'
 import { toJsonValue } from '../db/type-helpers'
 import { ServiceError } from '../services/ApprovalBridgeService'
 import { ApprovalProductService } from '../services/ApprovalProductService'
@@ -28,7 +30,14 @@ import {
 } from './automation-executor'
 import type { AutomationAction, StartApprovalConfig } from './automation-actions'
 
-type BridgeStatus = 'creating' | 'pending' | 'resumed' | 'failed'
+// P2 durable-delivery P1#1: `in_progress` (completion claimed, continuation running — holds a lease + fence)
+// and `dead_letter` (continuation crashed past the attempt ceiling — terminal) are the reclaimable-lease
+// additions. They exist ONLY on the flag-ON path; flag OFF still flips pending→resumed terminally.
+type BridgeStatus = 'creating' | 'pending' | 'in_progress' | 'resumed' | 'failed' | 'dead_letter'
+
+/** Reclaimable-lease knobs for the flag-ON completion claim (mirror S6 EVENT_DELIVERY_LEASE_MS + dispatcher). */
+const BRIDGE_COMPLETION_LEASE_MS = 60_000
+const BRIDGE_COMPLETION_MAX_ATTEMPTS = 8
 
 export interface AutomationApprovalBridgeRow {
   id: string
@@ -45,6 +54,9 @@ export interface AutomationApprovalBridgeRow {
   idempotencyKey: string
   status: BridgeStatus
   outcome: string | null
+  /** P1#1 lease token (bigint as string; '0' on the flag-OFF path). The completion handler passes it to
+   *  `markBridgeResumed` for the fence-CAS terminal write so a reclaimed zombie can never overwrite it. */
+  fence: string
   actionFingerprint: ActionFingerprint
   triggerEvent: unknown
 }
@@ -309,21 +321,93 @@ export class AutomationApprovalBridgeService {
     }
   }
 
-  async claimCompletion(event: ApprovalCompletionEventV1): Promise<AutomationApprovalBridgeRow | null> {
+  /**
+   * Claim the completion of a suspended bridge so exactly one worker resumes it.
+   *
+   * Flag OFF (legacy, byte-identical): atomically flip `pending → resumed` (TERMINAL) and return the row. The
+   * caller runs the continuation AFTER this terminal write — the window the P1 finding is about.
+   *
+   * Flag ON (P1#1 recoverable lease): flip `pending → in_progress` with a lease + `fence`+1 (a FRESH claim), or
+   * RECLAIM an EXPIRED `in_progress` lease left by a crashed worker (`fence`+1, `attempts`+1). A row still under
+   * a LIVE lease, or already terminal, returns null (skip — another worker owns it / it is done). A crashed
+   * worker whose reclaim would exceed `BRIDGE_COMPLETION_MAX_ATTEMPTS` is DEAD-LETTERED at claim (bounded — no
+   * infinite reclaim of a continuation that always crashes) and returns null. The caller runs the continuation
+   * and then calls `markBridgeResumed(id, fence)` (fence-CAS) — NO terminal-early write.
+   */
+  async claimCompletion(
+    event: ApprovalCompletionEventV1,
+    env: NodeJS.ProcessEnv = process.env,
+  ): Promise<AutomationApprovalBridgeRow | null> {
     const approvalId = event.approval.instanceId
-    const claimed = await db
-      .updateTable('multitable_automation_approval_bridges')
-      .set({
-        status: 'resumed',
-        outcome: event.transition.toStatus,
-        completed_at: event.occurredAt,
-        resumed_at: new Date().toISOString(),
-      } as never)
-      .where('approval_instance_id', '=', approvalId)
-      .where('status', '=', 'pending')
-      .returningAll()
-      .executeTakeFirst()
-    return claimed ? this.mapRow(claimed as Record<string, unknown>) : null
+
+    if (!isDurableDeliveryEnabled(env)) {
+      // LEGACY terminal-early path — byte-identical to the pre-P1#1 behavior.
+      const claimed = await db
+        .updateTable('multitable_automation_approval_bridges')
+        .set({
+          status: 'resumed',
+          outcome: event.transition.toStatus,
+          completed_at: event.occurredAt,
+          resumed_at: new Date().toISOString(),
+        } as never)
+        .where('approval_instance_id', '=', approvalId)
+        .where('status', '=', 'pending')
+        .returningAll()
+        .executeTakeFirst()
+      return claimed ? this.mapRow(claimed as Record<string, unknown>) : null
+    }
+
+    // FLAG-ON reclaimable-lease path. Raw SQL for the fence-CAS + lease arithmetic (mirrors S6 event_fires).
+    const leaseMs = BRIDGE_COMPLETION_LEASE_MS
+    // 1) FRESH claim: pending → in_progress, lease + fence 1 + attempts 1. Records outcome/completed_at now
+    //    (idempotent — the same completion event carries the same outcome on any redelivery).
+    const fresh = await sql<Record<string, unknown>>`
+      UPDATE multitable_automation_approval_bridges
+      SET status = 'in_progress', lease_expires_at = now() + ${leaseMs} * interval '1 millisecond',
+          fence = fence + 1, attempts = attempts + 1,
+          outcome = ${event.transition.toStatus}, completed_at = ${event.occurredAt}
+      WHERE approval_instance_id = ${approvalId} AND status = 'pending'
+      RETURNING *
+    `.execute(db)
+    if (fresh.rows.length > 0) return this.mapRow(fresh.rows[0])
+
+    // 2) POISON at reclaim: an EXPIRED in_progress that has already exhausted its attempts → dead_letter
+    //    (terminal, lease cleared). Returns null (skip) — the work will not be retried again.
+    const poisoned = await sql<{ id: string }>`
+      UPDATE multitable_automation_approval_bridges
+      SET status = 'dead_letter', lease_expires_at = NULL
+      WHERE approval_instance_id = ${approvalId} AND status = 'in_progress'
+        AND lease_expires_at < now() AND attempts >= ${BRIDGE_COMPLETION_MAX_ATTEMPTS}
+      RETURNING id
+    `.execute(db)
+    if (poisoned.rows.length > 0) return null
+
+    // 3) RECLAIM an EXPIRED in_progress lease (crashed worker): fence+1, attempts+1, new lease. Concurrent
+    //    reclaimers race — exactly one matches (the winner's new future lease makes the loser's `< now()`
+    //    predicate false → 0 rows). A LIVE lease or an already-terminal row matches nothing → null (skip).
+    const reclaim = await sql<Record<string, unknown>>`
+      UPDATE multitable_automation_approval_bridges
+      SET fence = fence + 1, attempts = attempts + 1, lease_expires_at = now() + ${leaseMs} * interval '1 millisecond'
+      WHERE approval_instance_id = ${approvalId} AND status = 'in_progress'
+        AND lease_expires_at < now() AND attempts < ${BRIDGE_COMPLETION_MAX_ATTEMPTS}
+      RETURNING *
+    `.execute(db)
+    return reclaim.rows.length > 0 ? this.mapRow(reclaim.rows[0]) : null
+  }
+
+  /**
+   * P1#1: the TERMINAL write, done AFTER the continuation completes (success OR a deterministic failure —
+   * both "consumed the completion", mirroring the legacy `resumed` meaning). fence-CAS: a reclaimed zombie
+   * whose fence is stale matches 0 rows, so it can never overwrite the live owner's terminal state
+   * (single-writer). Returns true when THIS caller (holding `fence`) won the terminal write.
+   */
+  async markBridgeResumed(id: string, fence: string): Promise<boolean> {
+    const res = await sql`
+      UPDATE multitable_automation_approval_bridges
+      SET status = 'resumed', lease_expires_at = NULL, resumed_at = now()
+      WHERE id = ${id} AND fence = ${fence}::bigint AND status = 'in_progress'
+    `.execute(db)
+    return Number(res.numAffectedRows ?? 0) === 1
   }
 
   private async markBridgeFailed(id: string): Promise<void> {
@@ -428,6 +512,7 @@ export class AutomationApprovalBridgeService {
       idempotencyKey: row.idempotency_key as string,
       status: row.status as BridgeStatus,
       outcome: (row.outcome as string) ?? null,
+      fence: String(row.fence ?? '0'),
       actionFingerprint: { count: Number(fp.count ?? 0), hash: String(fp.hash ?? '') },
       triggerEvent: typeof row.trigger_event === 'string' ? JSON.parse(row.trigger_event) : (row.trigger_event ?? null),
     }

--- a/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
+++ b/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
@@ -37,7 +37,7 @@ type BridgeStatus = 'creating' | 'pending' | 'in_progress' | 'resumed' | 'failed
 
 /** Reclaimable-lease knobs for the flag-ON completion claim (mirror S6 EVENT_DELIVERY_LEASE_MS + dispatcher). */
 const BRIDGE_COMPLETION_LEASE_MS = 60_000
-const BRIDGE_COMPLETION_MAX_ATTEMPTS = 8
+export const BRIDGE_COMPLETION_MAX_ATTEMPTS = 8
 
 export interface AutomationApprovalBridgeRow {
   id: string

--- a/packages/core-backend/src/multitable/automation-durable-activation.ts
+++ b/packages/core-backend/src/multitable/automation-durable-activation.ts
@@ -33,9 +33,11 @@ import {
   startDurableDispatchLoop,
   type AdapterOutcome,
   type DispatchLoopHandle,
+  type DispatchLoopObserver,
   type DispatchTickOptions,
 } from './automation-durable-dispatch-loop'
 import { isDurableDeliveryEnabled } from './automation-durable-delivery'
+import type { TransactionalQueryable } from './pg-transaction-guard'
 
 /** Throw this from a handler to mark a DETERMINISTIC permanent failure (→ dead_letter, not retried). */
 export class PermanentDeliveryFailure extends Error {}
@@ -61,10 +63,12 @@ export const DURABLE_CONSUMER_KEYS = [
 
 /**
  * Produce-site seam: durable enqueue when the flag is ON, no-op when OFF. MUST be called on the SAME
- * transaction client as the source state change — atomicity is the whole point (#4203 §producer/identity).
+ * transaction client as the source state change — atomicity is the whole point (#4203 §producer/identity),
+ * and it is MACHINE-ENFORCED downstream: `enqueueOutboxEvent` probes the database's own transaction state
+ * (pg-transaction-guard), so a pool / autocommit client / forged marker is rejected before any write.
  */
 export async function produceAutomationEvent(
-  trx: Queryable,
+  trx: TransactionalQueryable,
   input: OutboxEventInput,
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<EnqueuedOutboxEvent | null> {
@@ -100,21 +104,26 @@ export function buildConsumerAdapterRegistry(handlers: DurableConsumerHandlers):
 export interface BootOptions extends DispatchTickOptions {
   intervalMs?: number
   env?: NodeJS.ProcessEnv
-  onTickError?: (err: unknown) => void
 }
 
 /**
  * Startup entry: flag OFF → null (byte-for-byte no-op); flag ON → registry + BIDIRECTIONAL manifest
  * completeness assertion (a boot misconfiguration fails loudly before any claim) + dispatch loop.
+ *
+ * `observer` is REQUIRED (the loop's telemetry doctrine): unknown consumer keys, tick errors, heartbeat DB
+ * errors, and claim-time poisons must all be observable — the boot site wires them to real logging/metrics.
+ * `db` MUST be a pg Pool (or equivalent running queries on independent connections), never a single
+ * checked-out client — the loop's heartbeat renews run concurrently with adapters and resolves.
  */
 export function bootDurableDelivery(
   db: Queryable,
   handlers: DurableConsumerHandlers,
+  observer: DispatchLoopObserver,
   opts: BootOptions = {},
 ): DispatchLoopHandle | null {
   const env = opts.env ?? process.env
   if (!isDurableDeliveryEnabled(env)) return null
   const registry = buildConsumerAdapterRegistry(handlers)
   assertManifestCompleteness(registry, CURRENT_ROUTING_MANIFEST)
-  return startDurableDispatchLoop(db, registry, { ...opts, env })
+  return startDurableDispatchLoop(db, registry, observer, { ...opts, env })
 }

--- a/packages/core-backend/src/multitable/automation-durable-activation.ts
+++ b/packages/core-backend/src/multitable/automation-durable-activation.ts
@@ -119,6 +119,32 @@ export function durableBootFailureDisposition(env: NodeJS.ProcessEnv = process.e
 }
 
 /**
+ * Owner REQUEST-CHANGES (head 5afe30f26) P1s: fail-closed must cover the whole durable DEPENDENCY CHAIN,
+ * not only an exception raised inside the boot block. Two runtime dependencies are load-bearing flag-ON:
+ *   - **AutomationService** — the durable consumer handlers delegate to it. Its own init runs earlier under
+ *     a swallow-and-degrade catch, so it can be absent (or half-initialized) here; the boot site's
+ *     `if (automationService)` would then silently SKIP durable boot entirely — flag ON + skip = no
+ *     dispatcher = every outbox row stranded, with no exception for the disposition catch to see.
+ *   - **the webhook retry scheduler** — the durable webhook leg persists a `pending` delivery row and
+ *     fire-and-forgets the HTTP attempt; its crash recovery (including the first-attempt stray-grace leg)
+ *     IS the retry scheduler. `WEBHOOK_RETRY_SCHEDULER_DISABLED=1` returns null and an init exception was
+ *     swallowed — either one silently loses crashed webhook deliveries with the flag ON.
+ * Throws when the flag is ON and the named dependency is unavailable (the boot site's disposition catch
+ * rethrows → startup aborts). No-op flag-OFF: the legacy degrade-and-continue behavior is preserved
+ * byte-identically (nothing durable depends on these then).
+ */
+export function assertDurableRuntimeDependency(
+  dependency: string,
+  available: boolean,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (!isDurableDeliveryEnabled(env) || available) return
+  throw new Error(
+    `durable-delivery fail-closed: required runtime dependency unavailable with AUTOMATION_DURABLE_DELIVERY_ENABLED=true — ${dependency}`,
+  )
+}
+
+/**
  * Startup entry: flag OFF → null (byte-for-byte no-op); flag ON → registry + BIDIRECTIONAL manifest
  * completeness assertion (a boot misconfiguration fails loudly before any claim) + dispatch loop.
  *

--- a/packages/core-backend/src/multitable/automation-durable-activation.ts
+++ b/packages/core-backend/src/multitable/automation-durable-activation.ts
@@ -8,11 +8,12 @@
  *   - `produceAutomationEvent(trx, input)` — the produce-site seam. Call it INSIDE the same transaction as
  *     the source state change (approval status write / record write / form submit / comment). Flag ON →
  *     durable enqueue (outbox + fan-out, atomic with the source change); flag OFF → no-op returning null.
- *     Cutover contract (#4203 §316-325): call sites KEEP their legacy post-commit `eventBus.emit` in both
- *     modes for now — during the window where both paths fire, double delivery is collapsed by the SINKS'
- *     idempotency (per-rule `event_fires` dedup on the forwarded ORIGINAL `eventId`, business UNIQUE keys),
- *     which is exactly the lock's migration-safety argument. The legacy emit is demoted to non-load-bearing
- *     and removed per-site only after the 8-scenario acceptance.
+ *     Cutover contract — RESOLVED to REPLACE (P1#2, per FWB0 lock §Layer-1 L318-324: flag ON ⇒ the old bus
+ *     is "降级为非承重" and "稳态下双跑……都不允许存活"): every wired producer family enqueues same-txn via
+ *     `automation-producer-emit.ts` and SUPPRESSES its legacy post-commit emit when the flag is ON (flag
+ *     OFF ⇒ legacy emit, byte-identical). REPLACE is necessary, not stylistic — the webhook sink has no
+ *     event-id dedup, so keep-both would double-deliver every webhook. An earlier draft of this header
+ *     described a transitional keep-both window; that described only the pre-P1#2 state and is superseded.
  *   - `buildConsumerAdapterRegistry(handlers)` — the six ratified consumers (manifest v1 universe), each a
  *     thin adapter delegating to an injected handler (S5 wiring passes the REAL service methods —
  *     `handleApprovalCompletionResume` / `...Trigger` / projection / task / record / webhook-bridge — which

--- a/packages/core-backend/src/multitable/automation-durable-activation.ts
+++ b/packages/core-backend/src/multitable/automation-durable-activation.ts
@@ -1,0 +1,120 @@
+/**
+ * P2 durable-delivery — slices S4-b + S5: the activation seam (producer facade + consumer adapters + boot).
+ *
+ * This is the ONE module production code touches; everything below it (enqueue, manifest, loop, claim
+ * engine) stays flag-agnostic. All three entry points are no-ops / refusals while
+ * `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF, so landing this is byte-for-byte behavior-neutral.
+ *
+ *   - `produceAutomationEvent(trx, input)` — the produce-site seam. Call it INSIDE the same transaction as
+ *     the source state change (approval status write / record write / form submit / comment). Flag ON →
+ *     durable enqueue (outbox + fan-out, atomic with the source change); flag OFF → no-op returning null.
+ *     Cutover contract (#4203 §316-325): call sites KEEP their legacy post-commit `eventBus.emit` in both
+ *     modes for now — during the window where both paths fire, double delivery is collapsed by the SINKS'
+ *     idempotency (per-rule `event_fires` dedup on the forwarded ORIGINAL `eventId`, business UNIQUE keys),
+ *     which is exactly the lock's migration-safety argument. The legacy emit is demoted to non-load-bearing
+ *     and removed per-site only after the 8-scenario acceptance.
+ *   - `buildConsumerAdapterRegistry(handlers)` — the six ratified consumers (manifest v1 universe), each a
+ *     thin adapter delegating to an injected handler (S5 wiring passes the REAL service methods —
+ *     `handleApprovalCompletionResume` / `...Trigger` / projection / task / record / webhook-bridge — which
+ *     structurally REPLACES the anonymous bus closures and closes the manifest's un-enumerable direction).
+ *     Outcome mapping: handler resolves → success; throws `PermanentDeliveryFailure` → poison; any other
+ *     throw → retryable `adapter_error` (raw message never persisted). Sink idempotency is the handlers'
+ *     contract (they receive the stable original `eventId`, fence-free — the outbound-idempotency seed).
+ *   - `bootDurableDelivery(db, handlers, opts)` — startup: flag OFF → returns null (nothing registered, no
+ *     loop, no reads); flag ON → build registry, `assertManifestCompleteness` (bidirectional, throws on
+ *     boot misconfiguration BEFORE any claim), start the dispatch loop. Returns the loop handle.
+ */
+import type { Queryable } from './automation-durable-dispatcher'
+import type { ClaimedConsumer } from './automation-durable-dispatcher'
+import { enqueueOutboxEvent, type EnqueuedOutboxEvent, type OutboxEventInput } from './automation-outbox-enqueue'
+import { assertManifestCompleteness, CURRENT_ROUTING_MANIFEST } from './automation-routing-manifest'
+import {
+  ConsumerAdapterRegistry,
+  startDurableDispatchLoop,
+  type AdapterOutcome,
+  type DispatchLoopHandle,
+  type DispatchTickOptions,
+} from './automation-durable-dispatch-loop'
+import { isDurableDeliveryEnabled } from './automation-durable-delivery'
+
+/** Throw this from a handler to mark a DETERMINISTIC permanent failure (→ dead_letter, not retried). */
+export class PermanentDeliveryFailure extends Error {}
+
+/** One handler per ratified consumer_key (manifest v1 universe). S5 wiring passes the real service methods. */
+export interface DurableConsumerHandlers {
+  'approval-bridge': (event: ClaimedConsumer) => Promise<void>
+  'approval-trigger': (event: ClaimedConsumer) => Promise<void>
+  'approval-projection': (event: ClaimedConsumer) => Promise<void>
+  'approval-task-trigger': (event: ClaimedConsumer) => Promise<void>
+  'automation-record-trigger': (event: ClaimedConsumer) => Promise<void>
+  'webhook-event-bridge': (event: ClaimedConsumer) => Promise<void>
+}
+
+export const DURABLE_CONSUMER_KEYS = [
+  'approval-bridge',
+  'approval-trigger',
+  'approval-projection',
+  'approval-task-trigger',
+  'automation-record-trigger',
+  'webhook-event-bridge',
+] as const satisfies readonly (keyof DurableConsumerHandlers)[]
+
+/**
+ * Produce-site seam: durable enqueue when the flag is ON, no-op when OFF. MUST be called on the SAME
+ * transaction client as the source state change — atomicity is the whole point (#4203 §producer/identity).
+ */
+export async function produceAutomationEvent(
+  trx: Queryable,
+  input: OutboxEventInput,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<EnqueuedOutboxEvent | null> {
+  if (!isDurableDeliveryEnabled(env)) return null
+  return enqueueOutboxEvent(trx, input)
+}
+
+/** Build the six-adapter registry from injected handlers, with the ratified outcome mapping. */
+export function buildConsumerAdapterRegistry(handlers: DurableConsumerHandlers): ConsumerAdapterRegistry {
+  const registry = new ConsumerAdapterRegistry()
+  for (const key of DURABLE_CONSUMER_KEYS) {
+    const handler = handlers[key]
+    if (typeof handler !== 'function') {
+      throw new RangeError(`bootDurableDelivery: missing handler for consumer_key "${key}"`)
+    }
+    registry.register({
+      key,
+      async handle(event): Promise<AdapterOutcome> {
+        try {
+          await handler(event)
+          return { outcome: 'success' }
+        } catch (err) {
+          return err instanceof PermanentDeliveryFailure
+            ? { outcome: 'permanent_failure', reason: 'permanent_rejection' }
+            : { outcome: 'retryable_failure', reason: 'adapter_error' }
+        }
+      },
+    })
+  }
+  return registry
+}
+
+export interface BootOptions extends DispatchTickOptions {
+  intervalMs?: number
+  env?: NodeJS.ProcessEnv
+  onTickError?: (err: unknown) => void
+}
+
+/**
+ * Startup entry: flag OFF → null (byte-for-byte no-op); flag ON → registry + BIDIRECTIONAL manifest
+ * completeness assertion (a boot misconfiguration fails loudly before any claim) + dispatch loop.
+ */
+export function bootDurableDelivery(
+  db: Queryable,
+  handlers: DurableConsumerHandlers,
+  opts: BootOptions = {},
+): DispatchLoopHandle | null {
+  const env = opts.env ?? process.env
+  if (!isDurableDeliveryEnabled(env)) return null
+  const registry = buildConsumerAdapterRegistry(handlers)
+  assertManifestCompleteness(registry, CURRENT_ROUTING_MANIFEST)
+  return startDurableDispatchLoop(db, registry, { ...opts, env })
+}

--- a/packages/core-backend/src/multitable/automation-durable-activation.ts
+++ b/packages/core-backend/src/multitable/automation-durable-activation.ts
@@ -108,6 +108,17 @@ export interface BootOptions extends DispatchTickOptions {
 }
 
 /**
+ * Startup FAIL-CLOSED policy for a durable-delivery boot failure (owner closure item 4). With the flag ON,
+ * the wired producer families SUPPRESS their legacy post-commit emits — so a swallowed boot failure does not
+ * "degrade" to the legacy path, it strands EVERY outbox row with no dispatcher draining them: a silent,
+ * total delivery outage strictly worse than a crash. Flag ON ⇒ 'fail-closed' (the boot site MUST rethrow /
+ * abort startup). Flag OFF ⇒ 'degraded-ok' (nothing is suppressed; legacy delivers; log and continue).
+ */
+export function durableBootFailureDisposition(env: NodeJS.ProcessEnv = process.env): 'fail-closed' | 'degraded-ok' {
+  return isDurableDeliveryEnabled(env) ? 'fail-closed' : 'degraded-ok'
+}
+
+/**
  * Startup entry: flag OFF → null (byte-for-byte no-op); flag ON → registry + BIDIRECTIONAL manifest
  * completeness assertion (a boot misconfiguration fails loudly before any claim) + dispatch loop.
  *

--- a/packages/core-backend/src/multitable/automation-durable-consumer-handlers.ts
+++ b/packages/core-backend/src/multitable/automation-durable-consumer-handlers.ts
@@ -1,0 +1,107 @@
+/**
+ * P2 durable-delivery — slice S5: the REAL consumer handlers (production wiring).
+ *
+ * `automation-durable-activation.ts` defines the six-key `DurableConsumerHandlers` shape and the adapter
+ * outcome mapping; this module builds the CONCRETE handlers that delegate to the exact same production
+ * methods the legacy `eventBus.subscribe(...)` closures call. It is the structural close of the manifest's
+ * un-enumerable direction (#4203 §293-300): every anonymous bus closure gets a named consumer_key adapter
+ * whose body IS the closure's body.
+ *
+ * The mapping (durable consumer_key → the legacy bus subscriber it replaces):
+ *   - approval-bridge          → AutomationService.handleApprovalCompletionEvent   (automation-service.ts:935)
+ *   - approval-trigger         → AutomationService.handleApprovalCompletionTrigger (automation-service.ts:940)
+ *   - approval-projection      → ApprovalRecordProjectionService.reconcile         (approval-record-projection-service.ts:174)
+ *   - approval-task-trigger    → AutomationService.handleApprovalTaskCreatedTrigger (automation-service.ts:954)
+ *   - automation-record-trigger→ AutomationService.handleEvent                     (automation-service.ts:923)
+ *   - webhook-event-bridge     → WebhookService.deliverEvent (via WEBHOOK_BRIDGE_EVENT_MAP) (webhook-event-bridge.ts:78)
+ *
+ * A handler throwing is mapped by the activation registry to a retryable `adapter_error` (the dispatcher
+ * reschedules with backoff, bounded → dead_letter) — EXCEPT a `PermanentDeliveryFailure`, which dead-letters.
+ * This is intentional and matches the legacy `.catch(log)` fire-and-forget only in that both survive a bad
+ * event; the durable path additionally RETRIES, so a transient failure is no longer lost. Idempotency on the
+ * re-delivery is the sink's own contract (per-rule `event_fires` lease / business UNIQUE keys / idempotent
+ * upsert) — the same contract the legacy path already relied on.
+ *
+ * Payload reconstruction: the outbox row stores the ORIGINAL event payload as jsonb, so each adapter casts
+ * `event.payload` to the typed event the handler expects — the SAME object the bus delivered. For the record
+ * trigger we overlay the durable row's authoritative `_eventId` / `_automationDepth` (the outbox identity is
+ * the dedup + depth source of truth), so a durable re-delivery dedups on the stable original id.
+ *
+ * This module has NO side effects at import and touches NO flag: it is a pure builder over injected service
+ * references. `bootDurableDelivery` (flag-gated) is the only thing that constructs and runs these handlers.
+ */
+import type { ClaimedConsumer } from './automation-durable-dispatcher'
+import type { DurableConsumerHandlers } from './automation-durable-activation'
+import type { AutomationEventPayload } from './automation-service'
+import type { ApprovalCompletionEventV1 } from '../services/ApprovalCompletionEvent'
+import type { ApprovalTaskCreatedEventV1 } from '../services/ApprovalTaskCreatedEvent'
+import type { WebhookEventType } from './webhooks'
+import { WEBHOOK_BRIDGE_EVENT_MAP } from './webhook-event-bridge'
+
+/**
+ * The production service surface the durable handlers delegate to — a STRUCTURAL interface (not the concrete
+ * classes) so this module stays unit-testable with spies and free of the services' heavy constructor graphs.
+ * The boot site (`index.ts`) passes the live singletons.
+ */
+export interface DurableDeliveryServices {
+  automationService: {
+    handleApprovalCompletionEvent(event: ApprovalCompletionEventV1): Promise<void>
+    handleApprovalCompletionTrigger(event: ApprovalCompletionEventV1): Promise<void>
+    handleApprovalTaskCreatedTrigger(event: ApprovalTaskCreatedEventV1): Promise<void>
+    handleEvent(eventType: string, payload: AutomationEventPayload): Promise<void>
+  }
+  projectionService: {
+    reconcile(instanceId: string): Promise<unknown>
+  }
+  webhookService: {
+    deliverEvent(event: WebhookEventType, payload: unknown): Promise<unknown>
+  }
+}
+
+/** Reconstruct the record-trigger payload, overlaying the durable row's authoritative identity + depth. */
+function recordTriggerPayload(event: ClaimedConsumer): AutomationEventPayload {
+  const base = (event.payload && typeof event.payload === 'object' ? event.payload : {}) as AutomationEventPayload
+  return { ...base, _eventId: event.eventId, _automationDepth: event.automationDepth }
+}
+
+/**
+ * Build the six concrete durable consumer handlers over the live services. The result is handed to
+ * `buildConsumerAdapterRegistry` / `bootDurableDelivery`, which wrap each in the ratified outcome mapping.
+ */
+export function buildDurableConsumerHandlers(services: DurableDeliveryServices): DurableConsumerHandlers {
+  const { automationService, projectionService, webhookService } = services
+  return {
+    'approval-bridge': async (event: ClaimedConsumer) => {
+      await automationService.handleApprovalCompletionEvent(event.payload as ApprovalCompletionEventV1)
+    },
+    'approval-trigger': async (event: ClaimedConsumer) => {
+      await automationService.handleApprovalCompletionTrigger(event.payload as ApprovalCompletionEventV1)
+    },
+    'approval-projection': async (event: ClaimedConsumer) => {
+      const instanceId = (event.payload as ApprovalCompletionEventV1)?.approval?.instanceId
+      if (typeof instanceId !== 'string' || instanceId.length === 0) {
+        // A durable approval.* row with no instanceId is a malformed producer payload — nothing to project.
+        // Return (success): the projection is an idempotent upsert keyed by instanceId; there is no work to do
+        // and retrying would never find one. (The legacy subscriber `return`s on the same guard.)
+        return
+      }
+      await projectionService.reconcile(instanceId)
+    },
+    'approval-task-trigger': async (event: ClaimedConsumer) => {
+      await automationService.handleApprovalTaskCreatedTrigger(event.payload as ApprovalTaskCreatedEventV1)
+    },
+    'automation-record-trigger': async (event: ClaimedConsumer) => {
+      await automationService.handleEvent(event.eventType, recordTriggerPayload(event))
+    },
+    'webhook-event-bridge': async (event: ClaimedConsumer) => {
+      const webhookEvent: WebhookEventType | undefined = WEBHOOK_BRIDGE_EVENT_MAP[event.eventType]
+      if (!webhookEvent) {
+        // The manifest only routes webhook-event-bridge for the four mapped families, so an unmapped type here
+        // means a producer enqueued a row the manifest shouldn't have. Throw → retryable adapter_error (never a
+        // silent drop): an operator sees it via the dead-letter ceiling rather than losing the delivery.
+        throw new Error(`webhook-event-bridge: no webhook mapping for event type "${event.eventType}"`)
+      }
+      await webhookService.deliverEvent(webhookEvent, event.payload)
+    },
+  }
+}

--- a/packages/core-backend/src/multitable/automation-durable-consumer-handlers.ts
+++ b/packages/core-backend/src/multitable/automation-durable-consumer-handlers.ts
@@ -54,7 +54,9 @@ export interface DurableDeliveryServices {
     reconcile(instanceId: string): Promise<unknown>
   }
   webhookService: {
-    deliverEvent(event: WebhookEventType, payload: unknown): Promise<unknown>
+    // The durable leg passes the outbox `eventId` (3rd arg) so redelivery is idempotent per (webhook, event);
+    // the legacy bus bridge omits it. Optional so a spy/legacy caller need not supply it.
+    deliverEvent(event: WebhookEventType, payload: unknown, eventId?: string): Promise<unknown>
   }
 }
 
@@ -101,7 +103,9 @@ export function buildDurableConsumerHandlers(services: DurableDeliveryServices):
         // silent drop): an operator sees it via the dead-letter ceiling rather than losing the delivery.
         throw new Error(`webhook-event-bridge: no webhook mapping for event type "${event.eventType}"`)
       }
-      await webhookService.deliverEvent(webhookEvent, event.payload)
+      // Thread the outbox row's authoritative `eventId` so a redelivery of THIS durable row is idempotent per
+      // (webhook, event) — no duplicate delivery row, no duplicate send. (The legacy bus bridge omits it.)
+      await webhookService.deliverEvent(webhookEvent, event.payload, event.eventId)
     },
   }
 }

--- a/packages/core-backend/src/multitable/automation-durable-delivery.ts
+++ b/packages/core-backend/src/multitable/automation-durable-delivery.ts
@@ -22,6 +22,21 @@ export function isDurableDeliveryEnabled(env: NodeJS.ProcessEnv = process.env): 
 }
 
 /**
+ * Thrown by a durable sink when ANOTHER worker holds a LIVE lease on the work this delivery names (the
+ * outbox-lease-vs-sink-lease composed-timing hole, sink-recoverability audit 2026-07-17): the delivery must
+ * NOT resolve `done` (that would permanently drop the crashed holder's work) and must NOT run (that would
+ * double-run a live holder). The consumer adapter maps any handler throw to a retryable `adapter_error`, so
+ * the dispatch loop redelivers with backoff — by which time the sink lease has expired (reclaim) or been
+ * resolved (`done`). Values-free by construction: carries key identities only.
+ */
+export class DurableSinkBusyError extends Error {
+  constructor(sink: string, key: string) {
+    super(`durable sink busy (live lease held elsewhere): ${sink} ${key}`)
+    this.name = 'DurableSinkBusyError'
+  }
+}
+
+/**
  * States of a `meta_automation_outbox_consumer` row (the per-consumer lease). There is deliberately NO
  * persistent `failed` state: a transient failure only bumps `attempts` and leaves the row reclaimable (its
  * lease expires and the next claimer reclaims it); bounded-attempts-exhausted goes straight to the terminal

--- a/packages/core-backend/src/multitable/automation-event-fires-lease.ts
+++ b/packages/core-backend/src/multitable/automation-event-fires-lease.ts
@@ -12,7 +12,15 @@
  */
 import { sql, type Kysely } from 'kysely'
 
-/** `{ fence }` when THIS caller owns the (rule, dedup) claim; `'skip'` when it is already done or live-leased. */
+/**
+ * `{ fence }` when THIS caller owns the (rule, dedup) claim; `'done'` when the delivery is already terminal
+ * (done / outcome_unknown / failed / dead_letter — nothing left to run); `'busy'` when ANOTHER worker holds a
+ * LIVE lease. The done/busy split is load-bearing (sink-recoverability audit 2026-07-17): the outbox lease
+ * (30s default) can expire before this sink lease (60s), so a crashed worker's redelivery arrives while the
+ * dead worker's lease is still live — mapping that to a silent skip would mark the consumer row `done` and
+ * PERMANENTLY lose the work. `'busy'` lets the caller fail retryably so the outbox redelivers after the sink
+ * lease has expired, when the reclaim path takes over.
+ */
 // schema-agnostic query helper: Kysely<T> is invariant so we accept any schema (repo precedent:
 // record-subscription-service.ts, several migrations). Only raw `sql` is used, never typed query builders.
 export async function claimEventFiresLease(
@@ -21,7 +29,7 @@ export async function claimEventFiresLease(
   ruleId: string,
   dedupKey: string,
   leaseMs: number,
-): Promise<{ fence: string } | 'skip'> {
+): Promise<{ fence: string } | 'done' | 'busy'> {
   const ms = Math.max(1, Math.floor(leaseMs))
   // Fresh claim: in_progress + lease + fence 1. ON CONFLICT DO NOTHING → an existing row falls through.
   const fresh = await sql<{ fence: string }>`
@@ -41,7 +49,19 @@ export async function claimEventFiresLease(
       AND status = 'in_progress' AND lease_expires_at < now()
     RETURNING fence::text AS fence
   `.execute(db)
-  return reclaim.rows.length > 0 ? { fence: reclaim.rows[0].fence } : 'skip'
+  if (reclaim.rows.length > 0) return { fence: reclaim.rows[0].fence }
+  // Neither claimed nor reclaimed: classify. Resolve-permitting terminals → 'done' (delivered / permanently
+  // poisoned — never re-run). ANYTHING else → 'busy' (fail-closed toward retry): an in_progress LIVE lease is
+  // the composed-timing hole above; a row that VANISHED between the INSERT conflict and this SELECT (TTL
+  // sweep / races) also maps to 'busy' — the next redelivery simply fresh-claims, bounded by the outbox
+  // attempts cap, whereas a false 'done' would silently drop work.
+  const row = await sql<{ status: string }>`
+    SELECT status FROM meta_automation_event_fires WHERE rule_id = ${ruleId} AND dedup_key = ${dedupKey}
+  `.execute(db)
+  const status = row.rows[0]?.status
+  return status === 'done' || status === 'outcome_unknown' || status === 'failed' || status === 'dead_letter'
+    ? 'done'
+    : 'busy'
 }
 
 /** fence-CAS the leased row to terminal `done` (clears the lease atomically). A stale-fence zombie hits 0 rows. */

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -23,6 +23,7 @@ import {
 import type { TransactionalQueryable } from './pg-transaction-guard'
 import { Logger } from '../core/logger'
 import { withAutomationEventId } from './automation-event-dedup'
+import { enqueueRecordEventIfDurable, emitRecordEventIfLegacy } from './automation-producer-emit'
 import { redactString } from './automation-log-redact'
 import { computeActionFingerprint } from './automation-suspension-service'
 import type { ConditionBranchResumeCursor } from './automation-resume-cursor'
@@ -2270,6 +2271,16 @@ export class AutomationExecutor {
       // transaction below (same placement as before this slice).
       await this.sanitizeRichLongTextInWritePayload(effectiveSheetId, patch)
 
+      // P1#2c REPLACE — build the chaining-event payload ONCE (stable `_eventId`) so the same-txn durable
+      // enqueue (flag ON, inside the txn below) and the legacy post-commit emit (flag OFF) share one identity.
+      const chainEventPayload = withAutomationEventId({
+        sheetId: effectiveSheetId,
+        recordId: effectiveRecordId,
+        changes: fields,
+        actorId: context.actorId,
+        _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
+      })
+
       // W0 slice ③ (D-1c design-lock, RATIFIED 2026-07-13, §0.5 OD-1..OD-3, §0/§7a site A3): the
       // lock-check, the UPDATE, and the revision INSERT now all run inside ONE transaction — mirrors
       // D-1's `executeDeleteRecord` fix just above (`withTransaction` is the SAME helper; its
@@ -2364,18 +2375,22 @@ export class AutomationExecutor {
             snapshot: normalizeJson(updatedRow.data),
           })
         }
+        // P1#2c REPLACE: same-transaction durable enqueue on the SUCCESS path (flag ON) — atomic with the
+        // UPDATE + revision (any throw above rolls it back; the duplicate-claim early-return above skips it,
+        // exactly as it skips the legacy emit). Unconditional on `updatedRow` to mirror the legacy emit
+        // 1:1 (the 0-row same-base leniency still emitted). Flag OFF ⇒ no-op (legacy emit below fires).
+        await enqueueRecordEventIfDurable(
+          { query, isTransaction: true } as unknown as TransactionalQueryable,
+          'multitable.record.updated',
+          chainEventPayload,
+        )
         return null
       })
       if (txResult) return txResult
 
-      // Emit event for chaining
-      this.deps.eventBus.emit('multitable.record.updated', withAutomationEventId({
-        sheetId: effectiveSheetId,
-        recordId: effectiveRecordId,
-        changes: fields,
-        actorId: context.actorId,
-        _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
-      }))
+      // P1#2c REPLACE: flag OFF ⇒ legacy post-commit emit (byte-identical); flag ON ⇒ SUPPRESSED (the
+      // same-txn enqueue above is the delivery path — keep-both would double-deliver the webhook sink).
+      emitRecordEventIfLegacy(this.deps.eventBus, 'multitable.record.updated', chainEventPayload)
 
       // C1 real-time fan-out: invalidate the EFFECTIVE sheet's room (target for cross-base, trigger for
       // same-base) so its gated subscribers see the change live — automation writes were previously
@@ -2425,6 +2440,15 @@ export class AutomationExecutor {
         effectiveSheetId = targetSheetId
         effectiveRecordId = targetRecordId
       }
+
+      // P1#2c REPLACE — build the chaining-event payload ONCE (stable `_eventId`) so the same-txn durable
+      // enqueue (flag ON, inside the txn below) and the legacy post-commit emit (flag OFF) share one identity.
+      const chainEventPayload = withAutomationEventId({
+        sheetId: effectiveSheetId,
+        recordId: effectiveRecordId,
+        actorId: context.actorId,
+        _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
+      })
 
       const step = await this.withTransaction(effectiveSheetId, async (query) => {
         // #4196 Class-A claim — FIRST statement, SAME transaction as the delete+revision below. A
@@ -2568,19 +2592,24 @@ export class AutomationExecutor {
           [effectiveRecordId, effectiveSheetId],
         )
 
+        // P1#2c REPLACE: same-transaction durable enqueue on the SUCCESS path (flag ON) — atomic with the
+        // link cleanup + revision + DELETE (any throw above rolls it back; the duplicate-claim early-return
+        // above skips it, exactly as it skips the legacy emit). Unconditional on `lockRow` to mirror the
+        // legacy emit 1:1 (the 0-row same-base leniency still emitted). Flag OFF ⇒ no-op.
+        await enqueueRecordEventIfDurable(
+          { query, isTransaction: true } as unknown as TransactionalQueryable,
+          'multitable.record.deleted',
+          chainEventPayload,
+        )
         return null
       })
       if (step) return step
 
-      // Emit event for chaining (mirrors the updated/created emits + the same-base delete sink's
-      // `multitable.record.deleted` shape). C1 real-time invalidation fan-out to the target base's room
-      // is OUT of this lock — this only emits the domain event; no cross-room publish is wired here.
-      this.deps.eventBus.emit('multitable.record.deleted', withAutomationEventId({
-        sheetId: effectiveSheetId,
-        recordId: effectiveRecordId,
-        actorId: context.actorId,
-        _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
-      }))
+      // P1#2c REPLACE (mirrors the updated/created sites + the same-base delete sink's event shape): flag
+      // OFF ⇒ legacy post-commit emit (byte-identical); flag ON ⇒ SUPPRESSED (the same-txn enqueue above is
+      // the delivery path). C1 real-time invalidation fan-out to the target base's room stays OUT of this
+      // lock — this only carries the domain event; no cross-room publish is wired here.
+      emitRecordEventIfLegacy(this.deps.eventBus, 'multitable.record.deleted', chainEventPayload)
 
       // C1 real-time fan-out (see executeUpdateRecord) — invalidate the effective sheet's room.
       this.publishRecordRealtime('record-deleted', effectiveSheetId, effectiveRecordId, gate.crossBase, context)
@@ -2698,6 +2727,16 @@ export class AutomationExecutor {
       // field config before it reaches the DB (inert-by-construction at every writer).
       await this.sanitizeRichLongTextInWritePayload(targetSheetId, data)
 
+      // P1#2c REPLACE — build the chaining-event payload ONCE (stable `_eventId`) so the same-txn durable
+      // enqueue (flag ON, inside the txn below) and the legacy post-commit emit (flag OFF) share one identity.
+      const chainEventPayload = withAutomationEventId({
+        sheetId: targetSheetId,
+        recordId,
+        data,
+        actorId: context.actorId,
+        _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
+      })
+
       // W0 slice ③ (D-1c design-lock, RATIFIED 2026-07-13, §0.5 OD-1..OD-3, §0/§7a site A4): the
       // INSERT and its birth revision now run inside ONE transaction — mirrors `executeUpdateRecord`
       // above / D-1's `executeDeleteRecord`. A failed revision INSERT rolls back the record INSERT: the
@@ -2741,19 +2780,23 @@ export class AutomationExecutor {
           patch: data,
           snapshot: data,
         })
+        // P1#2c REPLACE: same-transaction durable enqueue on the SUCCESS path (flag ON) — atomic with the
+        // INSERT + birth revision (a revision throw rolls it back; the duplicate-claim early-return above
+        // skips it, exactly as the caller below skips the legacy emit). Flag OFF ⇒ no-op.
+        await enqueueRecordEventIfDurable(
+          { query, isTransaction: true } as unknown as TransactionalQueryable,
+          'multitable.record.created',
+          chainEventPayload,
+        )
         return null
       })
       // #4196: a duplicate claim skipped the INSERT/revision — report the already-applied success and
       // emit NO create event and NO real-time fan-out (a replay must produce zero downstream effect).
       if (skipped === 'duplicate') return this.alreadyAppliedResult('create_record')
 
-      this.deps.eventBus.emit('multitable.record.created', withAutomationEventId({
-        sheetId: targetSheetId,
-        recordId,
-        data,
-        actorId: context.actorId,
-        _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
-      }))
+      // P1#2c REPLACE: flag OFF ⇒ legacy post-commit emit (byte-identical); flag ON ⇒ SUPPRESSED (the
+      // same-txn enqueue above is the delivery path — keep-both would double-deliver the webhook sink).
+      emitRecordEventIfLegacy(this.deps.eventBus, 'multitable.record.created', chainEventPayload)
 
       // C1 real-time fan-out (see executeUpdateRecord) — invalidate the target sheet's room.
       this.publishRecordRealtime('record-created', targetSheetId, recordId, gate.crossBase, context)

--- a/packages/core-backend/src/multitable/automation-outbox-enqueue.ts
+++ b/packages/core-backend/src/multitable/automation-outbox-enqueue.ts
@@ -33,7 +33,7 @@ import { assertInTransaction, type TransactionalQueryable } from './pg-transacti
 export type { TransactionalQueryable } from './pg-transaction-guard'
 
 export interface OutboxEventInput {
-  /** Manifest event family, e.g. 'approval.approved' | 'multitable.record.created' | 'form.submitted'. */
+  /** Manifest event family, e.g. 'approval.approved' | 'multitable.record.created' | 'multitable.form.submitted'. */
   eventType: string
   /** Stable original-event identity (#4203): forwarded downstream as the per-rule dedup key. Non-blank ASCII. */
   eventId: string

--- a/packages/core-backend/src/multitable/automation-producer-emit.ts
+++ b/packages/core-backend/src/multitable/automation-producer-emit.ts
@@ -70,3 +70,45 @@ export function emitRecordEventIfLegacy(
   bus.emit(eventType, payload)
   return true
 }
+
+/**
+ * The identity shape of an approval-domain event as built by `buildApprovalCompletionEvent` /
+ * `buildApprovalTaskCreatedEvent` (`src/services/Approval*Event.ts`). Unlike record events (family 2/3), an
+ * approval event carries its stable identity in a top-level `eventId` (NOT the record-event `_eventId`) and its
+ * family in `eventType`. Only these two identity fields are read here; the caller passes the FULL event object,
+ * which is forwarded verbatim as the durable payload (all its properties serialize at runtime). Deliberately
+ * NOT an index-signature type, so a concrete `Approval*EventV1` (no index signature) is assignable.
+ */
+export interface ApprovalEventLike {
+  eventType: string
+  eventId: string
+}
+
+/**
+ * P1#2e producer family 1 seam (approval completion + task_created). Flag ON ⇒ enqueue the approval `event`
+ * on the SAME transaction as the terminal-transition / assignment write that produced it (REPLACE — the
+ * legacy `emitApproval*Event` post-commit bus emit is then SUPPRESSED at its choke, so keep-both cannot
+ * double-deliver the non-idempotent webhook sink). Flag OFF ⇒ no-op (the legacy emit is the delivery path).
+ *
+ * Two identity notes, both load-bearing:
+ *   - approval events carry `eventId` (the dedup basis + outbound-idempotency seed) at the TOP LEVEL, NOT the
+ *     record-event `_eventId` — so this reads `event.eventId`, and forwards the WHOLE event as `payload`.
+ *   - `automationDepth: 0` — an approval completion / task_created event is an ORIGINAL producer event, never
+ *     a link in an automation chain, so it seeds depth 0 (downstream consumers inherit +1).
+ *
+ * `trx` MUST be the source-write transaction handle — `produceAutomationEvent`'s xid probe rejects a pool /
+ * autocommit client / forged marker, so a half-committed enqueue is unrepresentable. Returns true iff enqueued.
+ */
+export async function enqueueApprovalEventIfDurable(
+  trx: TransactionalQueryable,
+  event: ApprovalEventLike,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  if (!isDurableDeliveryEnabled(env)) return false
+  const res = await produceAutomationEvent(
+    trx,
+    { eventType: event.eventType, eventId: event.eventId, payload: event, automationDepth: 0 },
+    env,
+  )
+  return res !== null
+}

--- a/packages/core-backend/src/multitable/automation-producer-emit.ts
+++ b/packages/core-backend/src/multitable/automation-producer-emit.ts
@@ -1,0 +1,72 @@
+/**
+ * P2 durable-delivery P1 #2 — the producer REPLACE seam (shared by every commit-then-emit site).
+ *
+ * Ratified semantics — FWB0 design lock (`approval-form-writeback-fwb0-designlock-20260712.md`) §Layer-1
+ * lines 318-324: when the durable path is active the old `eventemitter3` path is "降级为非承重"; the design
+ * "替换掉生产侧全部「提交后 emit」调用点 …… 切换后旧总线对这些事件族静音", and "稳态下双跑（两条都投）……
+ * 都不允许存活". So flag ON ⇒ the durable outbox path REPLACES the legacy post-commit `eventBus.emit`. This is
+ * REPLACE, not keep-both: keep-both is only the transitional cutover window, safe "仅仅因为 sink 是幂等的" —
+ * and the webhook sink is NOT idempotent across paths (`WebhookService.deliverEvent` → `createDeliveryRecord`
+ * persists a fresh delivery row per call with no event-id dedup), so keep-both would DOUBLE-deliver webhooks.
+ *
+ * Each producer site has TWO phases, because the emit is architecturally decoupled from the source
+ * transaction (it fires POST-commit, after the `withTransaction`/service txn closes):
+ *   1. `enqueueRecordEventIfDurable(trx, ...)` — INSIDE the source txn, on the SUCCESS path: flag ON ⇒ a
+ *      same-transaction outbox enqueue (atomic with the source write; the xid probe rejects a non-txn handle);
+ *      flag OFF ⇒ no-op.
+ *   2. `emitRecordEventIfLegacy(bus, ...)` — AFTER commit: flag OFF ⇒ the legacy emit (byte-identical);
+ *      flag ON ⇒ SUPPRESSED (the same-txn enqueue in phase 1 is the delivery path — emitting too would
+ *      double-deliver).
+ * The caller builds the payload ONCE (via `withAutomationEventId`, which stamps a stable `_eventId`) so both
+ * phases carry the same event identity (the dedup + outbound-idempotency seed).
+ */
+import { produceAutomationEvent } from './automation-durable-activation'
+import { isDurableDeliveryEnabled } from './automation-durable-delivery'
+import type { TransactionalQueryable } from './pg-transaction-guard'
+
+/** A record-event payload as built by `withAutomationEventId` — carries `_eventId` (+ optional depth). */
+export interface RecordEventLike {
+  _eventId?: unknown
+  _automationDepth?: unknown
+  [k: string]: unknown
+}
+
+interface EventBusLike {
+  emit(eventType: string, payload: unknown): void
+}
+
+/**
+ * Flag ON: enqueue `eventType`/`payload` on the SAME transaction as the source write (REPLACE — the legacy
+ * emit is then suppressed). Flag OFF: no-op (the caller emits legacy post-commit). Returns true iff enqueued.
+ * `trx` MUST be the source-write transaction handle — `produceAutomationEvent`'s xid probe rejects a pool /
+ * autocommit client, so a half-committed enqueue is unrepresentable.
+ */
+export async function enqueueRecordEventIfDurable(
+  trx: TransactionalQueryable,
+  eventType: string,
+  payload: RecordEventLike,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  if (!isDurableDeliveryEnabled(env)) return false
+  const eventId = typeof payload._eventId === 'string' ? payload._eventId : ''
+  const automationDepth = typeof payload._automationDepth === 'number' ? payload._automationDepth : 0
+  const res = await produceAutomationEvent(trx, { eventType, eventId, payload, automationDepth }, env)
+  return res !== null
+}
+
+/**
+ * Flag OFF: emit the legacy post-commit event (byte-identical to before P1#2). Flag ON: SUPPRESSED — the
+ * same-transaction enqueue is the delivery path; emitting here too would double-deliver (the durable
+ * consumers call the SAME handlers, and the webhook sink is not cross-path idempotent). Returns true iff
+ * it emitted. This suppression is the load-bearing REPLACE guard.
+ */
+export function emitRecordEventIfLegacy(
+  bus: EventBusLike,
+  eventType: string,
+  payload: RecordEventLike,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (isDurableDeliveryEnabled(env)) return false
+  bus.emit(eventType, payload)
+  return true
+}

--- a/packages/core-backend/src/multitable/automation-routing-manifest.ts
+++ b/packages/core-backend/src/multitable/automation-routing-manifest.ts
@@ -11,8 +11,15 @@
  *   approval.{approved,rejected,revoked,cancelled} → approval-bridge, approval-trigger, approval-projection
  *   approval.task_created                          → approval-task-trigger
  *   multitable.record.{created,updated,deleted}    → automation-record-trigger, webhook-event-bridge
- *   multitable.comment.created                     → webhook-event-bridge
  *   multitable.form.submitted                      → automation-record-trigger
+ *
+ * REMOVED from v1 (owner closure item 2, 2026-07-17): `multitable.comment.created` → webhook-event-bridge.
+ * NOTHING in the codebase emits that event type (repo-wide census; the comment feature writes rows but has
+ * never emitted a bus event, so even the LEGACY webhook bridge's subscription to it has been inert since it
+ * shipped). A manifest route nobody produces is dead configuration masquerading as coverage. Wiring a real
+ * comment producer is a deliberate FEATURE enable (it would create webhook deliveries that have never fired
+ * = a flag-OFF behavior change), so it ships as its own family-6 slice with a manifest v2 — not as a v1
+ * literal. The legacy bridge's inert subscription is left untouched (removing it is that slice's business).
  *
  * NOTE on the form-submission literal: the lock's §283-291 prose names the family by its TRIGGER TYPE
  * (`form.submitted`), but the manifest keys on BUS EVENT TYPES — and the lock's own grounding citation
@@ -78,7 +85,6 @@ export const ROUTING_MANIFEST_V1: RoutingManifest = deepFreezeManifest({
     'multitable.record.created': ['automation-record-trigger', 'webhook-event-bridge'],
     'multitable.record.updated': ['automation-record-trigger', 'webhook-event-bridge'],
     'multitable.record.deleted': ['automation-record-trigger', 'webhook-event-bridge'],
-    'multitable.comment.created': ['webhook-event-bridge'],
     'multitable.form.submitted': ['automation-record-trigger'],
   },
 })

--- a/packages/core-backend/src/multitable/automation-routing-manifest.ts
+++ b/packages/core-backend/src/multitable/automation-routing-manifest.ts
@@ -12,7 +12,16 @@
  *   approval.task_created                          → approval-task-trigger
  *   multitable.record.{created,updated,deleted}    → automation-record-trigger, webhook-event-bridge
  *   multitable.comment.created                     → webhook-event-bridge
- *   form.submitted                                 → automation-record-trigger
+ *   multitable.form.submitted                      → automation-record-trigger
+ *
+ * NOTE on the form-submission literal: the lock's §283-291 prose names the family by its TRIGGER TYPE
+ * (`form.submitted`), but the manifest keys on BUS EVENT TYPES — and the lock's own grounding citation
+ * (`automation-service.ts:892-936`) subscribes to `multitable.form.submitted` (the trigger-type mapping
+ * `multitable.form.submitted → form.submitted` lives in `automation-triggers.ts`). The v1 literal
+ * originally transcribed the lock's shorthand (`form.submitted`) — an event type NOTHING ever emits, so
+ * the durable path could never route a form submission (the producer's fail-closed expand would throw).
+ * Corrected to the real bus event type; flagged for owner review in PR #4337 (ratified-set transcription
+ * fix, not a routing change — same family, same consumer set).
  *
  * Completeness is asserted BIDIRECTIONALLY at startup with the adapter registry as the single enumeration
  * source (#4203 §293-300): (a) every consumer_key the manifest routes to has a registered adapter — a
@@ -70,7 +79,7 @@ export const ROUTING_MANIFEST_V1: RoutingManifest = deepFreezeManifest({
     'multitable.record.updated': ['automation-record-trigger', 'webhook-event-bridge'],
     'multitable.record.deleted': ['automation-record-trigger', 'webhook-event-bridge'],
     'multitable.comment.created': ['webhook-event-bridge'],
-    'form.submitted': ['automation-record-trigger'],
+    'multitable.form.submitted': ['automation-record-trigger'],
   },
 })
 

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -33,6 +33,7 @@ import {
 } from './automation-inbound-webhook'
 import { isValidIanaTimeZone } from './automation-timezone'
 import { isDurableDeliveryEnabled } from './automation-durable-delivery'
+import { enqueueRecordEventIfDurable, emitRecordEventIfLegacy } from './automation-producer-emit'
 import { claimEventFiresLease, markEventFiresDone } from './automation-event-fires-lease'
 
 /** S6 event-delivery lease window: long enough to cover a normal executeRule, short enough that a crashed
@@ -2955,6 +2956,15 @@ export class AutomationService {
       missingMessage?: string
     },
   ): Promise<boolean> {
+    // P1#2 REPLACE — build the chaining-event payload ONCE (stable `_eventId`) so the same-txn durable enqueue
+    // (inside the txn, flag ON) and the legacy post-commit emit (flag OFF) carry the same event identity.
+    const chainEventPayload = withAutomationEventId({
+      sheetId,
+      recordId,
+      changes: patch,
+      actorId: opts.chainActorId,
+      _automationDepth: opts.automationDepth,
+    })
     const wrote = await this.withTransaction(sheetId, async (query) => {
       const lockRes = await query(
         'SELECT locked, locked_by, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2',
@@ -2990,17 +3000,27 @@ export class AutomationService {
           snapshot: normalizeJson(updatedRow.data),
         })
       }
+      // P1#2 REPLACE: same-transaction durable enqueue on the SUCCESS path (flag ON) — atomic with the
+      // writeback UPDATE + revision. A rollback (locked / gone target throws or returns false above) enqueues
+      // nothing by construction. Flag OFF ⇒ no-op (the legacy emit below fires instead).
+      await enqueueRecordEventIfDurable(
+        {
+          isTransaction: true,
+          query: async (sql, params) => {
+            const r = await query(sql, params)
+            return { rows: (r.rows ?? []) as Array<Record<string, unknown>>, rowCount: r.rowCount ?? null }
+          },
+        },
+        'multitable.record.updated',
+        chainEventPayload,
+      )
       return true
     })
     if (!wrote) return false
 
-    this.eventBus.emit('multitable.record.updated', withAutomationEventId({
-      sheetId,
-      recordId,
-      changes: patch,
-      actorId: opts.chainActorId,
-      _automationDepth: opts.automationDepth,
-    }))
+    // P1#2 REPLACE: flag OFF ⇒ legacy post-commit emit (byte-identical); flag ON ⇒ SUPPRESSED (the same-txn
+    // enqueue above is the delivery path — keep-both would double-deliver the non-idempotent webhook sink).
+    emitRecordEventIfLegacy(this.eventBus, 'multitable.record.updated', chainEventPayload)
     try {
       publishMultitableSheetRealtime({
         spreadsheetId: sheetId,

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -2437,13 +2437,50 @@ export class AutomationService {
     return { execution: continued }
   }
 
-  async handleApprovalCompletionEvent(event: ApprovalCompletionEventV1): Promise<void> {
+  async handleApprovalCompletionEvent(event: ApprovalCompletionEventV1, env: NodeJS.ProcessEnv = process.env): Promise<void> {
     if (event.version !== 1 || event.source !== 'approval-product') return
     if (!['approval.approved', 'approval.rejected', 'approval.revoked', 'approval.cancelled'].includes(event.eventType)) return
 
-    const bridge = await this.approvalBridgeService.claimCompletion(event)
+    const leased = isDurableDeliveryEnabled(env)
+    const bridge = await this.approvalBridgeService.claimCompletion(event, env)
     if (!bridge) return
 
+    if (!leased) {
+      // LEGACY (flag OFF): claimCompletion already flipped the bridge to the terminal `resumed` BEFORE the
+      // continuation — byte-identical to the pre-P1#1 behavior (the window the P1 finding is about).
+      await this.resumeApprovalBridgeContinuation(bridge, event)
+      return
+    }
+    // P1#1 (flag ON): the bridge holds a RECLAIMABLE lease (in_progress). Run the continuation, THEN write the
+    // terminal `resumed` via fence-CAS — NO terminal-early write. A crash before markBridgeResumed leaves the
+    // lease to expire; the redelivered completion event reclaims it (bounded → dead_letter). The tail's own
+    // idempotency (Class-A same-txn claim / Class-B intent) makes the reclaim redelivery exactly-once at the
+    // effect level (at-least-once delivery + sink idempotency — the durable-delivery doctrine).
+    try {
+      await this.resumeApprovalBridgeContinuation(bridge, event)
+    } catch (err) {
+      // an UNEXPECTED throw (NOT a handled deterministic failure — those `return` inside the continuation):
+      // do NOT mark terminal. Let the lease expire so the work is reclaimed and retried; rethrow so a durable
+      // dispatcher driving this records a retryable failure.
+      logger.error(`Approval bridge continuation crashed for ${bridge.id}; leaving lease to expire for reclaim`, err instanceof Error ? err : undefined)
+      throw err
+    }
+    const won = await this.approvalBridgeService.markBridgeResumed(bridge.id, bridge.fence)
+    if (!won) {
+      // our lease expired mid-continuation and a reclaimer took the row (fence advanced); the continuation's
+      // effects are idempotent and the reclaimer writes the terminal state — nothing to do here.
+      logger.warn(`Approval bridge ${bridge.id} terminal write lost the fence-CAS (reclaimed mid-flight); reclaimer owns it`)
+    }
+  }
+
+  /**
+   * The bridge resume continuation — extracted VERBATIM so the legacy (terminal-early) path and the P1#1 lease
+   * path share ONE body. Its early `return`s are the DETERMINISTIC failures (missing execution, missing/disabled
+   * rule, changed fingerprint, non-approved outcome, record gone); each settles the execution and returns
+   * normally (no throw), so the caller then writes the terminal bridge state (legacy: already done by
+   * claimCompletion; lease: markBridgeResumed). Only an UNEXPECTED throw escapes to the caller's reclaim path.
+   */
+  private async resumeApprovalBridgeContinuation(bridge: AutomationApprovalBridgeRow, event: ApprovalCompletionEventV1): Promise<void> {
     const execution = await this.logService.getById(bridge.executionId)
     if (!execution) {
       logger.error(`start_approval bridge ${bridge.id} references missing execution ${bridge.executionId}`)

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -32,7 +32,7 @@ import {
   type InboundWebhookRejectReason,
 } from './automation-inbound-webhook'
 import { isValidIanaTimeZone } from './automation-timezone'
-import { isDurableDeliveryEnabled } from './automation-durable-delivery'
+import { DurableSinkBusyError, isDurableDeliveryEnabled } from './automation-durable-delivery'
 import { enqueueRecordEventIfDurable, emitRecordEventIfLegacy } from './automation-producer-emit'
 import { claimEventFiresLease, markEventFiresDone } from './automation-event-fires-lease'
 
@@ -1596,7 +1596,15 @@ export class AutomationService {
       return
     }
     const lease = await claimEventFiresLease(this.db, ruleId, dedupKey, EVENT_DELIVERY_LEASE_MS)
-    if (lease === 'skip') return
+    if (lease === 'done') return
+    if (lease === 'busy') {
+      // Composed-timing hole (sink audit 2026-07-17): the outbox lease can expire before this sink lease, so
+      // a crashed worker's redelivery lands while the dead worker's sink lease is still LIVE. Returning here
+      // would resolve the delivery `done` and PERMANENTLY drop the work; running would double-run a live
+      // holder. Throw retryably instead — the dispatch loop's backoff outlives the sink lease, and the next
+      // redelivery reclaims (crashed holder) or reads `done` (live holder finished).
+      throw new DurableSinkBusyError('event_fires', `${ruleId}:${dedupKey}`)
+    }
     await run()
     await markEventFiresDone(this.db, ruleId, dedupKey, lease.fence)
   }
@@ -2443,8 +2451,16 @@ export class AutomationService {
     if (!['approval.approved', 'approval.rejected', 'approval.revoked', 'approval.cancelled'].includes(event.eventType)) return
 
     const leased = isDurableDeliveryEnabled(env)
-    const bridge = await this.approvalBridgeService.claimCompletion(event, env)
-    if (!bridge) return
+    const claim = await this.approvalBridgeService.claimCompletion(event, env)
+    if (claim.kind === 'none') return
+    if (claim.kind === 'busy') {
+      // Same composed-timing hole as runWithEventDedup (sink audit 2026-07-17): another worker's LIVE bridge
+      // lease. Resolving `done` here would drop a crashed holder's continuation forever; running would
+      // double-drive a live holder. Fail retryably — the redelivery after backoff reclaims an expired lease
+      // or reads the terminal row. (The legacy flag-OFF path never returns 'busy'.)
+      throw new DurableSinkBusyError('approval_bridge', event.approval.instanceId)
+    }
+    const bridge = claim.row
 
     if (!leased) {
       // LEGACY (flag OFF): claimCompletion already flipped the bridge to the terminal `resumed` BEFORE the

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -2,6 +2,8 @@ import { randomUUID } from 'crypto'
 
 import type { EventBus } from '../integration/events/event-bus'
 import { withAutomationEventId } from './automation-event-dedup'
+import { enqueueRecordEventIfDurable, emitRecordEventIfLegacy } from './automation-producer-emit'
+import type { TransactionalQueryable } from './pg-transaction-guard'
 import type { MultitableCapabilities } from './access'
 import {
   ensureAttachmentIdsExist as ensureAttachmentIdsExistShared,
@@ -75,6 +77,19 @@ export interface ConnectionPool {
   query: QueryFn
   transaction: <T>(handler: TransactionHandler<T>) => Promise<T>
 }
+
+/**
+ * P1#2 REPLACE — adapt this service's `pool.transaction` query handle to the shared produce-seam's
+ * TransactionalQueryable. Only ever built from a handle INSIDE `this.pool.transaction(...)`; the seam's
+ * xid probe (pg-transaction-guard) rejects a pool/autocommit handle at runtime, so the marker cannot lie.
+ */
+const asProducerTrx = (query: QueryFn): TransactionalQueryable => ({
+  isTransaction: true,
+  query: async (sql, params) => {
+    const r = await query(sql, params)
+    return { rows: (r.rows ?? []) as Array<Record<string, unknown>>, rowCount: r.rowCount ?? null }
+  },
+})
 
 export type UniverMetaField = MultitableField
 
@@ -520,6 +535,16 @@ export class RecordService {
 
     const patch: Record<string, unknown> = {}
     const recordId = `rec_${randomUUID()}`
+    // P1#2 REPLACE — build the created-event payload ONCE (stable `_eventId`) so the same-txn durable enqueue
+    // (flag ON, inside the txn) and the legacy post-commit emit (flag OFF) carry the same event identity.
+    // `data` holds the SAME `patch` reference the legacy emit passed; it is fully populated inside the txn
+    // before either phase serializes/emits it.
+    const createdEventPayload = withAutomationEventId({
+      sheetId,
+      recordId,
+      data: patch,
+      actorId,
+    })
     const recordRes = await this.pool.transaction(async ({ query }) => {
       // W0-1 L4 (canonical fence): create ALREADY takes this fence unconditionally (the auto-number key,
       // now renamed to `acquireCanonicalSheetFence` — same key). Byte-identical when the flag is off. The
@@ -737,6 +762,10 @@ export class RecordService {
 
       // W0-1 L6-a: seal the operation LAST (endpoint row = the exact committed boundary). No-op when inert.
       await sealOperation(query, op)
+      // P1#2 REPLACE: same-transaction durable enqueue on the SUCCESS path (flag ON) — atomic with the INSERT +
+      // revision above (any validation/permission throw rolls back and enqueues nothing by construction).
+      // Flag OFF ⇒ no-op (the legacy emit below fires instead). `patch` is fully populated by this point.
+      await enqueueRecordEventIfDurable(asProducerTrx(query), 'multitable.record.created', createdEventPayload)
       return inserted
     })
 
@@ -774,12 +803,9 @@ export class RecordService {
         patch,
       }],
     })
-    this.eventBus.emit('multitable.record.created', withAutomationEventId({
-      sheetId,
-      recordId,
-      data: patch,
-      actorId,
-    }))
+    // P1#2 REPLACE: flag OFF ⇒ legacy post-commit emit (byte-identical); flag ON ⇒ SUPPRESSED (the same-txn
+    // enqueue above is the delivery path — keep-both would double-deliver the non-idempotent webhook sink).
+    emitRecordEventIfLegacy(this.eventBus, 'multitable.record.created', createdEventPayload)
 
     return {
       recordId,
@@ -820,6 +846,13 @@ export class RecordService {
     // the ONE shared rule (`ensureRecordNotLocked`) so every mutation path enforces it identically.
     ensureRecordNotLocked(actorId, recordRow, () => new RecordPermissionError('Record is locked'))
 
+    // P1#2 REPLACE — build the deleted-event payload ONCE (stable `_eventId`) so the same-txn durable enqueue
+    // (flag ON, inside the txn) and the legacy post-commit emit (flag OFF) carry the same event identity.
+    const deletedEventPayload = withAutomationEventId({
+      sheetId,
+      recordId,
+      actorId,
+    })
     await this.pool.transaction(async ({ query }) => {
       // W0-1 L4 (canonical fence): fence FIRST (before any read/check), then refuse if a recovery holds a
       // durable block. No-op & byte-identical when MULTITABLE_ENABLE_WRITER_FENCE is off.
@@ -922,6 +955,10 @@ export class RecordService {
 
       // W0-1 L6-a: seal the operation LAST. No-op when inert.
       await sealOperation(query, op)
+      // P1#2 REPLACE: same-transaction durable enqueue on the SUCCESS path (flag ON) — atomic with the DELETE +
+      // revision + trash copy above (a version-conflict/permission throw rolls back and enqueues nothing).
+      // Flag OFF ⇒ no-op (the legacy emit below fires instead).
+      await enqueueRecordEventIfDurable(asProducerTrx(query), 'multitable.record.deleted', deletedEventPayload)
     })
 
     publishMultitableSheetRealtime({
@@ -932,11 +969,9 @@ export class RecordService {
       recordId,
       recordIds: [recordId],
     })
-    this.eventBus.emit('multitable.record.deleted', withAutomationEventId({
-      sheetId,
-      recordId,
-      actorId,
-    }))
+    // P1#2 REPLACE: flag OFF ⇒ legacy post-commit emit (byte-identical); flag ON ⇒ SUPPRESSED (the same-txn
+    // enqueue above is the delivery path).
+    emitRecordEventIfLegacy(this.eventBus, 'multitable.record.deleted', deletedEventPayload)
 
     return {
       recordId,
@@ -1094,6 +1129,9 @@ export class RecordService {
 
     let inboundOut: (InboundReplayResult & { recoverable: boolean }) | undefined
     const inboundEnabled = isRecordUndeleteInboundEnabled()
+    // P1#2 REPLACE — build the restored(created)-event payload ONCE (stable `_eventId`) so the same-txn durable
+    // enqueue (flag ON, inside the txn) and the legacy post-commit emit (flag OFF) carry the same identity.
+    const restoredEventPayload = withAutomationEventId({ sheetId, recordId, actorId })
     await this.pool.transaction(async ({ query }) => {
       // W0-1 L4 (canonical fence): fence FIRST, then refuse if a recovery holds a durable block. No-op &
       // byte-identical when MULTITABLE_ENABLE_WRITER_FENCE is off.
@@ -1170,6 +1208,10 @@ export class RecordService {
       await query('DELETE FROM meta_records_trash WHERE id = $1', [trashPk])
       // W0-1 L6-a: seal the operation LAST. No-op when inert.
       await sealOperation(query, op)
+      // P1#2 REPLACE: same-transaction durable enqueue on the SUCCESS path (flag ON) — atomic with the restore
+      // INSERT + revision + trash-row delete above (a restore-conflict throw rolls back and enqueues nothing).
+      // Flag OFF ⇒ no-op (the legacy emit below fires instead).
+      await enqueueRecordEventIfDurable(asProducerTrx(query), 'multitable.record.created', restoredEventPayload)
     })
 
     publishMultitableSheetRealtime({
@@ -1180,7 +1222,9 @@ export class RecordService {
       recordId,
       recordIds: [recordId],
     })
-    this.eventBus.emit('multitable.record.created', withAutomationEventId({ sheetId, recordId, actorId }))
+    // P1#2 REPLACE: flag OFF ⇒ legacy post-commit emit (byte-identical); flag ON ⇒ SUPPRESSED (the same-txn
+    // enqueue above is the delivery path).
+    emitRecordEventIfLegacy(this.eventBus, 'multitable.record.created', restoredEventPayload)
 
     return { recordId, sheetId, ...(inboundOut ? { inbound: inboundOut } : {}) }
   }
@@ -1364,6 +1408,16 @@ export class RecordService {
 
     let nextVersion = 1
     let pendingSubscriberNotification: NotifyRecordSubscribersInput | null = null
+    // P1#2 REPLACE — build the updated-event payload ONCE (stable `_eventId`) so the same-txn durable enqueue
+    // (flag ON, inside the txn) and the legacy post-commit emit (flag OFF) carry the same event identity.
+    // `data` holds the SAME `patch` reference the legacy emit passed (fully populated above, pre-txn);
+    // `actorId` is the same `access.userId ?? 'system'` expression the legacy emit used.
+    const updatedEventPayload = withAutomationEventId({
+      sheetId,
+      recordId,
+      data: patch,
+      actorId: access.userId ?? 'system',
+    })
     await this.pool.transaction(async ({ query }) => {
       // W0-1 L4 (canonical fence): fence FIRST, then refuse if a recovery holds a durable block. No-op &
       // byte-identical when MULTITABLE_ENABLE_WRITER_FENCE is off.
@@ -1496,6 +1550,10 @@ export class RecordService {
       // W0-1 L6-a: seal the operation LAST. No-op when inert OR when the patch had no field change (a
       // no-op patch emits no revision ⇒ zero-event operation ⇒ not an executable anchor, so no endpoint).
       await sealOperation(query, op)
+      // P1#2 REPLACE: same-transaction durable enqueue on the SUCCESS path (flag ON) — atomic with the UPDATE +
+      // revision above (a version-conflict/permission throw rolls back and enqueues nothing). Fires even for a
+      // zero-field patch, mirroring the legacy emit (which fired unconditionally post-commit). Flag OFF ⇒ no-op.
+      await enqueueRecordEventIfDurable(asProducerTrx(query), 'multitable.record.updated', updatedEventPayload)
     })
 
     if (pendingSubscriberNotification) {
@@ -1540,12 +1598,9 @@ export class RecordService {
         patch,
       }],
     })
-    this.eventBus.emit('multitable.record.updated', withAutomationEventId({
-      sheetId,
-      recordId,
-      data: patch,
-      actorId,
-    }))
+    // P1#2 REPLACE: flag OFF ⇒ legacy post-commit emit (byte-identical — the payload's actorId is the same
+    // `access.userId ?? 'system'` value); flag ON ⇒ SUPPRESSED (the same-txn enqueue above is the delivery path).
+    emitRecordEventIfLegacy(this.eventBus, 'multitable.record.updated', updatedEventPayload)
 
     return {
       recordId,

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -17,6 +17,8 @@
 import { randomUUID } from 'crypto'
 import type { EventBus } from '../integration/events/event-bus'
 import { withAutomationEventId } from './automation-event-dedup'
+import { enqueueRecordEventIfDurable, emitRecordEventIfLegacy } from './automation-producer-emit'
+import type { TransactionalQueryable } from './pg-transaction-guard'
 import { publishMultitableSheetRealtime } from './realtime-publish'
 import {
   createYjsInvalidationPostCommitHook,
@@ -56,6 +58,19 @@ export interface ConnectionPool {
   query: QueryFn
   transaction: <T>(handler: TransactionHandler<T>) => Promise<T>
 }
+
+/**
+ * P1#2 REPLACE — adapt this service's `pool.transaction` query handle to the shared produce-seam's
+ * TransactionalQueryable. Only ever built from a handle INSIDE `this.pool.transaction(...)`; the seam's
+ * xid probe (pg-transaction-guard) rejects a pool/autocommit handle at runtime, so the marker cannot lie.
+ */
+const asProducerTrx = (query: QueryFn): TransactionalQueryable => ({
+  isTransaction: true,
+  query: async (sql, params) => {
+    const r = await query(sql, params)
+    return { rows: (r.rows ?? []) as Array<Record<string, unknown>>, rowCount: r.rowCount ?? null }
+  },
+})
 
 export type UniverMetaField = {
   id: string
@@ -777,6 +792,22 @@ export class RecordWriteService {
     // W0-1 L6-a: hoisted so the post-txn response echo can use the operation id as batch_id (below). Inert
     // unless the L4 fence flag is on and the L6 migration is deployed.
     let ledger: OperationLedger = new OperationLedger(sheetId, null)
+    // P1#2 REPLACE — build each record's updated-event payload ONCE, BEFORE the transaction (stable `_eventId`
+    // per record), so the same-txn durable enqueue (flag ON, inside the txn) and the legacy post-commit Step-7
+    // emit (flag OFF) carry the same event identity. The `changes` object is the SAME construction Step 7
+    // used (`changesByRecord` is never mutated by the txn). A record skipped in-txn (`applied === 0` → not in
+    // `updated`) simply never uses its payload — building one is pure (a uuid stamp, no side effects).
+    const updatedEventPayloadByRecord = new Map(
+      Array.from(changesByRecord.entries(), ([recordId, changes]) => [
+        recordId,
+        withAutomationEventId({
+          sheetId,
+          recordId,
+          changes: Object.fromEntries(changes.map((change) => [change.fieldId, change.value])),
+          actorId,
+        }),
+      ] as const),
+    )
     const updates = await this.pool.transaction(async ({ query }) => {
       // W0-1 L4 (canonical fence): fence FIRST — before the preWriteGuard check and every mutation — then
       // refuse if a recovery holds a durable block. Covers the bulk / AI / OAPI patch family in one place.
@@ -1123,6 +1154,16 @@ export class RecordWriteService {
       // wrote, event_count = the number written. No-op when inert or zero-event. This is THE multi-event
       // anchor case (G-BATCH-ENDPOINT): the endpoint sits after ALL rows, never at an intermediate seq.
       await sealOperation(query, ledger)
+      // P1#2 REPLACE: same-transaction durable enqueue on the SUCCESS path (flag ON) — one event per record
+      // ACTUALLY written (mirrors Step 7's per-update legacy emit: skipped records emit nothing), atomic with
+      // every UPDATE + revision this bulk txn wrote. A throw anywhere above rolls back and enqueues nothing.
+      // Flag OFF ⇒ no-op (Step 7 emits legacy post-commit instead).
+      for (const update of updated) {
+        const payload = updatedEventPayloadByRecord.get(update.recordId)
+        if (payload) {
+          await enqueueRecordEventIfDurable(asProducerTrx(query), 'multitable.record.updated', payload)
+        }
+      }
       return updated
     })
 
@@ -1442,16 +1483,15 @@ export class RecordWriteService {
       // -------------------------------------------------------------------
       // Step 7: EventBus emit
       // -------------------------------------------------------------------
+      // P1#2 REPLACE: flag OFF ⇒ legacy post-commit emit per written record (byte-identical — same payload
+      // objects built pre-txn from the same `changesByRecord` construction); flag ON ⇒ SUPPRESSED (the
+      // same-txn enqueue inside the Step-1 transaction is the delivery path — keep-both would double-deliver
+      // the non-idempotent webhook sink).
       for (const update of updates) {
-        const changes = Object.fromEntries(
-          (changesByRecord.get(update.recordId) ?? []).map((change) => [change.fieldId, change.value]),
-        )
-        this.eventBus.emit('multitable.record.updated', withAutomationEventId({
-          sheetId,
-          recordId: update.recordId,
-          changes,
-          actorId,
-        }))
+        const payload = updatedEventPayloadByRecord.get(update.recordId)
+        if (payload) {
+          emitRecordEventIfLegacy(this.eventBus, 'multitable.record.updated', payload)
+        }
       }
     }
 

--- a/packages/core-backend/src/multitable/webhook-event-bridge.ts
+++ b/packages/core-backend/src/multitable/webhook-event-bridge.ts
@@ -31,13 +31,18 @@ const logger = new Logger('WebhookEventBridge')
 
 /**
  * Map internal event names (as published on the EventBus) to webhook event types.
+ *
+ * Exported so the P2 durable-delivery `webhook-event-bridge` consumer adapter forwards on the SAME mapping as
+ * the legacy bus subscription below (a single source of truth — the durable path must never diverge from the
+ * bus path it replaces).
  */
-const EVENT_MAP: Record<string, WebhookEventType> = {
+export const WEBHOOK_BRIDGE_EVENT_MAP: Record<string, WebhookEventType> = {
   'multitable.record.created': 'record.created',
   'multitable.record.updated': 'record.updated',
   'multitable.record.deleted': 'record.deleted',
   'multitable.comment.created': 'comment.created',
 }
+const EVENT_MAP = WEBHOOK_BRIDGE_EVENT_MAP
 
 export interface WebhookEventBridgeOptions {
   /**

--- a/packages/core-backend/src/multitable/webhook-event-bridge.ts
+++ b/packages/core-backend/src/multitable/webhook-event-bridge.ts
@@ -15,7 +15,10 @@
  * Posture (at-least-once, fire-and-forget): `deliverEvent` persists a durable
  * delivery row BEFORE the HTTP attempt and only then fires the request without
  * awaiting it, so a crash mid-flight leaves a `pending` row the retry tick picks
- * up. The bridge subscription itself is fire-and-forget (errors are logged, never
+ * up — including a FIRST attempt that died before its outcome handler stamped
+ * `next_retry_at` (the stray-grace leg of `retryFailedDeliveries`; before that
+ * leg existed such rows were a stuck absorbing state this header wrongly claimed
+ * were retried). The bridge subscription itself is fire-and-forget (errors are logged, never
  * propagated back to the emitting write). A full transactional outbox (emit inside
  * the write transaction) is out of scope — see the rank-5 wiring deliverable.
  */

--- a/packages/core-backend/src/multitable/webhook-service.ts
+++ b/packages/core-backend/src/multitable/webhook-service.ts
@@ -31,6 +31,10 @@ const BASE_RETRY_DELAY_MS = WEBHOOK_DEFAULT_BASE_RETRY_DELAY_MS
 // long enough to out-live the HTTP attempt + backoff recompute so a concurrent
 // replica's tick skips it; short enough that a crashed tick's row is retried soon.
 const RETRY_CLAIM_LEASE_MS = DELIVERY_TIMEOUT_MS * 4
+/** How long a pending row may sit with next_retry_at NULL (a first attempt whose outcome never landed)
+ *  before the retry tick claims it as a crashed-process stray. Must exceed DELIVERY_TIMEOUT_MS by a wide
+ *  margin so a live in-flight first attempt is never double-fired. */
+const FIRST_ATTEMPT_STRAY_GRACE_MS = Math.max(5 * 60_000, DELIVERY_TIMEOUT_MS * 10)
 
 function generateId(): string {
   return randomBytes(16).toString('hex')
@@ -442,8 +446,23 @@ export class WebhookService {
         .selectFrom('multitable_webhook_deliveries')
         .selectAll()
         .where('status', '=', 'pending')
-        .where('next_retry_at', 'is not', null)
-        .where('next_retry_at', '<=', new Date(now))
+        .where((eb) =>
+          eb.or([
+            // scheduled retries whose backoff has elapsed
+            eb.and([eb('next_retry_at', 'is not', null), eb('next_retry_at', '<=', new Date(now))]),
+            // FIRST-ATTEMPT strays (sink audit 2026-07-17): deliverEvent persists the row and fires the HTTP
+            // attempt WITHOUT awaiting; the outcome handler is what stamps status/next_retry_at. A process
+            // crash between the INSERT and that handler leaves pending + next_retry_at NULL — which the
+            // scheduled-retry leg above can never select, a stuck absorbing state (the module header's
+            // "the retry tick picks it up" was false for first attempts). Claim them after a grace period
+            // long enough that a LIVE in-flight first attempt (outcome lands within DELIVERY_TIMEOUT_MS)
+            // is never double-fired.
+            eb.and([
+              eb('next_retry_at', 'is', null),
+              eb('created_at', '<=', new Date(now - FIRST_ATTEMPT_STRAY_GRACE_MS)),
+            ]),
+          ]),
+        )
         .forUpdate()
         .skipLocked()
         .execute()

--- a/packages/core-backend/src/multitable/webhook-service.ts
+++ b/packages/core-backend/src/multitable/webhook-service.ts
@@ -5,7 +5,7 @@
  */
 
 import { createHmac, randomBytes } from 'crypto'
-import type { Kysely } from 'kysely'
+import { sql, type Kysely } from 'kysely'
 import { Logger } from '../core/logger'
 import type { Database } from '../db/types'
 import { nowTimestamp, toJsonValue } from '../db/type-helpers'
@@ -317,6 +317,12 @@ export class WebhookService {
   async deliverEvent(
     event: WebhookEventType,
     payload: unknown,
+    // P2 durable-delivery closure item 3: the DURABLE consumer passes the outbox `eventId` so the per-webhook
+    // delivery row becomes an idempotent CLAIM keyed by (webhook_id, event_id). An at-least-once redelivery
+    // (crash between send and the consumer-row done-CAS, or a `busy` retry) then re-enters here with the SAME
+    // eventId → the claim finds the row already present → NO second row, NO second send. LEGACY callers (the
+    // bus bridge, the retry tick) pass nothing → NULL event_id → byte-identical fan-out (no dedup, unchanged).
+    eventId?: string,
   ): Promise<WebhookDelivery[]> {
     const rows = await this.db
       .selectFrom('multitable_webhooks')
@@ -330,7 +336,11 @@ export class WebhookService {
 
     const deliveries: WebhookDelivery[] = []
     for (const wh of matching) {
-      const delivery = await this.createDeliveryRecord(wh.id, event, payload)
+      const delivery = await this.createDeliveryRecord(wh.id, event, payload, eventId)
+      // A null claim (durable path only) = this (webhook, event) was already delivered/claimed by a prior
+      // attempt → skip the HTTP send entirely (the redelivery is terminally handled; the caller/adapter maps
+      // an error-free return to success). Never reachable on the legacy path (eventId undefined → always a row).
+      if (!delivery) continue
       deliveries.push(delivery)
       // Fire-and-forget — do not await per delivery to avoid blocking the caller
       this.executeDelivery(delivery).catch((err) => {
@@ -533,26 +543,46 @@ export class WebhookService {
 
   // ─── Helpers ─────────────────────────────────────────────────────────
 
+  /**
+   * Create the pending delivery row. When `eventId` is supplied (durable path) this is an idempotent CLAIM on
+   * the partial-unique `(webhook_id, event_id)` index: `ON CONFLICT DO NOTHING RETURNING id` returns 0 rows
+   * when a prior attempt already claimed this (webhook, event) → returns `null`, and the caller skips the
+   * send. When `eventId` is absent (legacy path) it is an unconditional INSERT with NULL event_id, exactly as
+   * before — the partial index does not constrain NULL, so legacy fan-out is byte-identical.
+   */
   private async createDeliveryRecord(
     webhookId: string,
     event: WebhookEventType,
     payload: unknown,
-  ): Promise<WebhookDelivery> {
+    eventId?: string,
+  ): Promise<WebhookDelivery | null> {
     const id = generateId()
     const now = new Date().toISOString()
 
-    await this.db
-      .insertInto('multitable_webhook_deliveries')
-      .values({
-        id,
-        webhook_id: webhookId,
-        event,
-        payload: toJsonValue(payload),
-        status: 'pending',
-        attempt_count: 0,
-        created_at: now,
-      })
-      .execute()
+    if (typeof eventId === 'string' && eventId.length > 0) {
+      // Durable claim — raw SQL so the ON CONFLICT targets the partial index precisely. Zero rows ⇒ a prior
+      // attempt owns this (webhook, event) ⇒ null (skip the send; the redelivery is terminally handled).
+      const claimed = await sql<{ id: string }>`
+        INSERT INTO multitable_webhook_deliveries (id, webhook_id, event, payload, status, attempt_count, created_at, event_id)
+        VALUES (${id}, ${webhookId}, ${event}, ${toJsonValue(payload)}, 'pending', 0, ${now}, ${eventId})
+        ON CONFLICT (webhook_id, event_id) WHERE event_id IS NOT NULL DO NOTHING
+        RETURNING id
+      `.execute(this.db)
+      if (claimed.rows.length === 0) return null
+    } else {
+      await this.db
+        .insertInto('multitable_webhook_deliveries')
+        .values({
+          id,
+          webhook_id: webhookId,
+          event,
+          payload: toJsonValue(payload),
+          status: 'pending',
+          attempt_count: 0,
+          created_at: now,
+        })
+        .execute()
+    }
 
     return {
       id,

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -196,6 +196,8 @@ import {
   serializeAutomationRule,
 } from '../multitable/automation-service'
 import { withAutomationEventId } from '../multitable/automation-event-dedup'
+import { enqueueRecordEventIfDurable, emitRecordEventIfLegacy } from '../multitable/automation-producer-emit'
+import type { TransactionalQueryable } from '../multitable/pg-transaction-guard'
 import { listAutomationDingTalkGroupDeliveries } from '../multitable/dingtalk-group-delivery-service'
 import { listAutomationDingTalkPersonDeliveries } from '../multitable/dingtalk-person-delivery-service'
 import {
@@ -4976,6 +4978,25 @@ function getAttachmentStorageService(): StorageServiceImpl {
 function getRequestActorId(req: Request): string | null {
   const actorId = req.user?.id
   return typeof actorId === 'string' && actorId.trim().length > 0 ? actorId.trim() : null
+}
+
+/**
+ * P2 durable-delivery P1#2d (producer family 5) — wrap the live in-transaction `query` of a
+ * `pool.transaction` as the produce-seam's `TransactionalQueryable`. Call it ONLY with the query handle of
+ * the SAME transaction the source write runs in: the seam's xid probe (`assertInTransaction`) rejects a
+ * pool / autocommit handle at runtime, so a mis-wired call fails loud instead of half-committing an outbox
+ * row.
+ */
+function asProducerTxnQueryable(
+  query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>>; rowCount: number | null }>,
+): TransactionalQueryable {
+  return {
+    isTransaction: true,
+    query: async (sql, params) => {
+      const r = await query(sql, params)
+      return { rows: r.rows, rowCount: r.rowCount ?? null }
+    },
+  }
 }
 
 const VIEW_CONFIG_HISTORY_KEYS = ['name', 'type', 'filterInfo', 'sortInfo', 'groupInfo', 'hiddenFieldIds', 'config'] as const
@@ -10395,6 +10416,13 @@ export function univerMetaRouter(): Router {
         // the spine invariant (mirror never owns a meta_links row) is structural, not snapshot-hygiene-reliant.
         const linkFieldIds = fields.filter((f) => f.type === 'link' && fieldById.get(f.id)?.readOnly !== true).map((f) => f.id)
         const undeleteActorId = getRequestActorId(req)
+        // P1#2d REPLACE — build each resurrect's event payload ONCE before the txn (stable `_eventId`) so the
+        // same-txn durable enqueue (flag ON, inside the txn below) and the legacy post-commit emit (flag OFF)
+        // carry the same event identity. Keyed by recordId; total over `resurrects` by construction — the txn is
+        // all-or-nothing, so on success `resurrectedIds` is exactly the ids of `resurrects`.
+        const undeleteEventPayloads = new Map(
+          resurrects.map((r) => [r.recordId, withAutomationEventId({ sheetId, recordId: r.recordId, actorId: undeleteActorId })]),
+        )
         try {
           await pool.transaction(async ({ query }) => {
             // W0-1 L4: the recovery's OWN resurrect writes take the canonical fence (for seq-ordering) but
@@ -10460,6 +10488,14 @@ export function univerMetaRouter(): Router {
                   undeleteInboundTotals.total += replay.total
                 }
               }
+              // P1#2d REPLACE: same-transaction durable enqueue on the SUCCESS path (flag ON) — atomic with THIS
+              // record's resurrect INSERT + links + 'restore' create-revision (any conflict throw in this loop
+              // rolls the WHOLE txn — and every enqueue — back; nothing half-delivered). One enqueue per
+              // resurrected record, mirroring the legacy per-record post-commit emit 1:1. Flag OFF ⇒ no-op.
+              const undeleteDurablePayload = undeleteEventPayloads.get(r.recordId)
+              if (undeleteDurablePayload) {
+                await enqueueRecordEventIfDurable(asProducerTxnQueryable(query), 'multitable.record.created', undeleteDurablePayload)
+              }
               resurrectedIds.push(r.recordId)
             }
           })
@@ -10469,7 +10505,10 @@ export function univerMetaRouter(): Router {
         }
         for (const recordId of resurrectedIds) { // post-commit realtime, mirrors restoreRecord
           publishMultitableSheetRealtime({ spreadsheetId: sheetId, actorId: undeleteActorId, source: 'multitable', kind: 'record-created', recordId, recordIds: [recordId] })
-          eventBus.emit('multitable.record.created', withAutomationEventId({ sheetId, recordId, actorId: undeleteActorId }))
+          // P1#2d REPLACE: flag OFF ⇒ legacy post-commit emit (the SAME prebuilt payload object — byte-identical
+          // fields); flag ON ⇒ SUPPRESSED (the same-txn enqueue inside the txn above is the delivery path).
+          const undeleteLegacyPayload = undeleteEventPayloads.get(recordId)
+          if (undeleteLegacyPayload) emitRecordEventIfLegacy(eventBus, 'multitable.record.created', undeleteLegacyPayload)
         }
       }
       const writeHelpers: RecordWriteHelpers = createRecordWriteHelpers(req, pool)
@@ -10623,6 +10662,12 @@ export function univerMetaRouter(): Router {
       const batchId = randomUUID()
       const updatedRows: Array<{ recordId: string; version: number; fieldIds: string[]; patch: Record<string, unknown> }> = []
       const deletedRecordIds: string[] = []
+      // P1#2d REPLACE — per-row event payloads, built ONCE (stable `_eventId`) INSIDE the txn at the point each
+      // row's write completes (the update payload's `changes` = the in-txn-computed revisionPatch, so it CANNOT
+      // be prebuilt before the txn), shared verbatim by the same-txn durable enqueue (flag ON) and the legacy
+      // post-commit emit loops below (flag OFF). A txn abort discards them with the response (409/422/…).
+      const updatedEventPayloads: Array<Record<string, unknown> & { _eventId: string }> = []
+      const deletedEventPayloads: Array<Record<string, unknown> & { _eventId: string }> = []
 
       try {
         await pool.transaction(async ({ query }) => {
@@ -10776,6 +10821,13 @@ export function univerMetaRouter(): Router {
               }
               if (ids.length === 0) await query('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2', [change.fieldId, candidate.recordId])
             }
+            // P1#2d REPLACE: build this row's payload ONCE, then same-transaction durable enqueue on the SUCCESS
+            // path (flag ON) — atomic with the row's UPDATE + revision + link replay (any later candidate's
+            // conflict throw rolls the WHOLE reset — and every enqueue — back). One enqueue per updated row,
+            // mirroring the legacy per-row post-commit emit 1:1. Flag OFF ⇒ no-op (legacy loop below fires).
+            const updatedEventPayload = withAutomationEventId({ sheetId, recordId: candidate.recordId, changes: revisionPatch, actorId })
+            updatedEventPayloads.push(updatedEventPayload)
+            await enqueueRecordEventIfDurable(asProducerTxnQueryable(query), 'multitable.record.updated', updatedEventPayload)
             updatedRows.push({ recordId: candidate.recordId, version: nextVersion, fieldIds: [...Object.keys(patch), ...unsetIds], patch: revisionPatch })
           }
 
@@ -10835,6 +10887,12 @@ export function univerMetaRouter(): Router {
             // lock-guarded: PIT Reset deletes in the same transaction after ensureRecordNotLocked above.
             // revision-emitted: PIT reset delete — recordRecordRevision(action:'delete') below, same txn.
             await query('DELETE FROM meta_records WHERE sheet_id = $1 AND id = $2', [sheetId, candidate.recordId])
+            // P1#2d REPLACE: build this row's payload ONCE, then same-transaction durable enqueue on the SUCCESS
+            // path (flag ON) — atomic with the row's tombstone capture + trash + delete revision + DELETE. One
+            // enqueue per deleted record, mirroring the legacy per-record post-commit emit 1:1. Flag OFF ⇒ no-op.
+            const deletedEventPayload = withAutomationEventId({ sheetId, recordId: candidate.recordId, actorId })
+            deletedEventPayloads.push(deletedEventPayload)
+            await enqueueRecordEventIfDurable(asProducerTxnQueryable(query), 'multitable.record.deleted', deletedEventPayload)
             deletedRecordIds.push(candidate.recordId)
           }
         })
@@ -10869,8 +10927,11 @@ export function univerMetaRouter(): Router {
           fieldIds: [...new Set(updatedRows.flatMap((r) => r.fieldIds))],
           recordPatches: updatedRows.map((r) => ({ recordId: r.recordId, version: r.version, patch: r.patch })),
         })
-        for (const row of updatedRows) {
-          eventBus.emit('multitable.record.updated', withAutomationEventId({ sheetId, recordId: row.recordId, changes: row.patch, actorId }))
+        // P1#2d REPLACE: flag OFF ⇒ legacy post-commit emits (the SAME prebuilt per-row payload objects —
+        // byte-identical fields: recordId/changes are the very candidate.recordId/revisionPatch the legacy
+        // literal read back off updatedRows); flag ON ⇒ SUPPRESSED (the same-txn enqueues are the delivery path).
+        for (const updatedLegacyPayload of updatedEventPayloads) {
+          emitRecordEventIfLegacy(eventBus, 'multitable.record.updated', updatedLegacyPayload)
         }
       }
       if (deletedRecordIds.length > 0) {
@@ -10881,8 +10942,9 @@ export function univerMetaRouter(): Router {
           kind: 'record-deleted',
           recordIds: deletedRecordIds,
         })
-        for (const recordId of deletedRecordIds) {
-          eventBus.emit('multitable.record.deleted', withAutomationEventId({ sheetId, recordId, actorId }))
+        // P1#2d REPLACE: flag OFF ⇒ legacy post-commit emits (same prebuilt objects); flag ON ⇒ SUPPRESSED.
+        for (const deletedLegacyPayload of deletedEventPayloads) {
+          emitRecordEventIfLegacy(eventBus, 'multitable.record.deleted', deletedLegacyPayload)
         }
       }
       return res.json({ ok: true, data: { asOf: asOfIso, strategy: 'reset', revertedCount: updatedRows.length, deletedCount: deletedRecordIds.length, deletedRecordIds } })
@@ -14730,6 +14792,18 @@ export function univerMetaRouter(): Router {
       let resultRecordId = recordId ?? buildId('rec')
       let nextVersion = 1
 
+      // P1#2d REPLACE — build the form.submitted payload ONCE before the txn (stable `_eventId`) so the
+      // same-txn durable enqueue (flag ON, at the end of BOTH the EDIT and CREATE branches below) and the
+      // legacy post-commit emit (flag OFF) carry the same event identity. `recordId: resultRecordId` is the
+      // value the legacy literal read back post-commit as `record.id`: EDIT ⇒ the request's recordId; CREATE ⇒
+      // the pre-generated id the INSERT writes verbatim ($1) and RETURNING echoes unchanged.
+      const formSubmittedPayload = withAutomationEventId({
+        sheetId: view.sheetId,
+        recordId: resultRecordId,
+        actorId: getRequestActorId(req),
+        mode: recordId ? 'update' : 'create',
+      })
+
       await pool.transaction(async ({ query }) => {
         // W0-1 L4cov (close the form-submit create/edit PARTIAL gap — L4 map's univer-meta.ts:14585). The
         // canonical sheet fence stays UNCONDITIONAL (the pre-existing auto-number serialization lock — the
@@ -14849,6 +14923,11 @@ export function univerMetaRouter(): Router {
           }
           // W0-1 L6-a: seal the operation LAST for the EDIT branch (no-op when inert or a no-field-change edit).
           await sealOperation(query, op)
+          // P1#2d REPLACE: same-transaction durable enqueue on the EDIT branch's SUCCESS path (flag ON) —
+          // atomic with the UPDATE + revision + link replay (a version-conflict/lock/not-found throw above
+          // rolls the enqueue back with the txn). After the seal: the outbox row is not a record-history event,
+          // so it never enters the operation's event count. Flag OFF ⇒ no-op (legacy post-commit emit fires).
+          await enqueueRecordEventIfDurable(asProducerTxnQueryable(query), 'multitable.form.submitted', formSubmittedPayload)
           return
         }
 
@@ -14908,6 +14987,10 @@ export function univerMetaRouter(): Router {
         })
         // W0-1 L6-a: seal the operation LAST for the CREATE branch. No-op when inert.
         await sealOperation(query, op)
+        // P1#2d REPLACE: same-transaction durable enqueue on the CREATE branch's SUCCESS path (flag ON) —
+        // atomic with the INSERT + links + create revision. After the seal for the same reason as the EDIT
+        // branch (the outbox row is not a record-history event). Flag OFF ⇒ no-op.
+        await enqueueRecordEventIfDurable(asProducerTxnQueryable(query), 'multitable.form.submitted', formSubmittedPayload)
       })
 
       const recordRes = await pool.query(
@@ -15030,12 +15113,10 @@ export function univerMetaRouter(): Router {
       // unchanged.) Payload is sheetId/recordId only (matchesTrigger + handleEvent key off those, and
       // actions re-read the record) — no raw record.data egress. `mode` distinguishes a new submission
       // ('create') from a form-link edit ('update').
-      eventBus.emit('multitable.form.submitted', withAutomationEventId({
-        sheetId: view.sheetId,
-        recordId: record.id,
-        actorId: getRequestActorId(req),
-        mode: recordId ? 'update' : 'create',
-      }))
+      // P1#2d REPLACE: flag OFF ⇒ legacy post-commit emit (the SAME prebuilt payload object — byte-identical
+      // fields; `recordId: resultRecordId` === the `record.id` the old literal read here, see the payload's
+      // construction above the txn); flag ON ⇒ SUPPRESSED (the same-txn enqueue is the delivery path).
+      emitRecordEventIfLegacy(eventBus, 'multitable.form.submitted', formSubmittedPayload)
 
       return res.json({
         ok: true,

--- a/packages/core-backend/src/services/ApprovalCompletionEvent.ts
+++ b/packages/core-backend/src/services/ApprovalCompletionEvent.ts
@@ -1,5 +1,6 @@
 import { Logger } from '../core/logger'
 import { eventBus } from '../integration/events/event-bus'
+import { isDurableDeliveryEnabled } from '../multitable/automation-durable-delivery'
 
 const logger = new Logger('ApprovalCompletionEvent')
 
@@ -121,6 +122,12 @@ export function buildApprovalCompletionEvent(input: {
 }
 
 export function emitApprovalCompletionEvent(event: ApprovalCompletionEventV1): void {
+  // P1#2e producer family 1 — REPLACE guard (the load-bearing suppression). When durable delivery is ON, the
+  // SAME-transaction outbox enqueue at every completion build site (ApprovalProductService completion sites ×6,
+  // via `enqueueApprovalEventIfDurable`) is the delivery path; the family-1 invariant is that EVERY build site
+  // enqueues in-txn, so this legacy post-commit emit would DOUBLE-deliver (the durable consumers call the same
+  // handlers, and the webhook sink is not cross-path idempotent). Flag OFF ⇒ legacy emit (byte-identical).
+  if (isDurableDeliveryEnabled()) return
   try {
     eventBus.emit(event.eventType, event)
   } catch (error) {

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -77,10 +77,14 @@ import {
 } from './ApprovalCompletionEvent'
 import {
   buildApprovalTaskCreatedEvent,
+  collectLiveApprovalTaskCreatedEvents,
   emitApprovalTaskCreatedEvent,
   type ApprovalTaskCreatedInstanceSnapshot,
   type ApprovalTaskCreatedTaskSnapshot,
 } from './ApprovalTaskCreatedEvent'
+import { enqueueApprovalEventIfDurable } from '../multitable/automation-producer-emit'
+import { isDurableDeliveryEnabled } from '../multitable/automation-durable-delivery'
+import type { TransactionalQueryable } from '../multitable/pg-transaction-guard'
 import { getApprovalRecordProjectionService } from '../multitable/approval-record-projection-service'
 import { supersedeDingTalkApprovalCardDeliveriesForInstance } from '../integrations/dingtalk/approval-card-deliveries'
 import { Logger } from '../core/logger'
@@ -291,6 +295,23 @@ type AdminJumpEventPayload = {
 type ApprovalDbClient = {
   query: typeof pool.query
   release: () => void
+}
+
+/**
+ * P1#2e producer family 1 — wrap an in-transaction pg client (the connection that has BEGUN and not yet
+ * COMMITted) as the durable seam's `TransactionalQueryable`. The `isTransaction: true` marker documents intent
+ * but proves nothing on its own; `produceAutomationEvent`'s `pg_current_xact_id()` probe (pg-transaction-guard)
+ * is the real guard and THROWS at runtime on a pool / autocommit client / forged marker, so a half-committed
+ * approval-event enqueue is unrepresentable. Only ever hand this the same `client` the source write ran on.
+ */
+function approvalTxnHandle(client: ApprovalDbClient): TransactionalQueryable {
+  return {
+    isTransaction: true,
+    query: async (sql: string, params?: unknown[]) => {
+      const r = await client.query(sql, params)
+      return { rows: (r.rows ?? []) as Array<Record<string, unknown>>, rowCount: r.rowCount ?? null }
+    },
+  }
 }
 
 type ValidationContext = {
@@ -3973,8 +3994,14 @@ export class ApprovalProductService {
           },
           actor: null,
         })
+        // P1#2e REPLACE (family 1) — same-txn durable enqueue of the completion event, atomic with the
+        // terminal transition written above. Flag OFF ⇒ no-op (the post-commit emit is the delivery path).
+        await enqueueApprovalEventIfDurable(approvalTxnHandle(client), completionEvent)
       }
 
+      // P1#2e REPLACE (family 1) — flag-ON in-txn task_created enqueue at the END of the txn (after every
+      // assignment write + same-txn cascade). Flag OFF ⇒ no-op. Legacy post-commit emit stays below.
+      await this.enqueueApprovalTaskCreatedEventsInTxn(client, instanceId, createdTaskEvents)
       await client.query('COMMIT')
     } catch (error) {
       await rollbackQuietly(client)
@@ -4252,7 +4279,11 @@ export class ApprovalProductService {
           },
           { id: actor.userId, name: actor.userName || actor.userId },
         )
+        // P1#2e REPLACE (family 1) — same-txn durable enqueue, atomic with the jump→approved transition.
+        await enqueueApprovalEventIfDurable(approvalTxnHandle(client), completionEvent)
       }
+      // P1#2e REPLACE (family 1) — flag-ON in-txn task_created enqueue at the END of the txn (flag OFF no-op).
+      await this.enqueueApprovalTaskCreatedEventsInTxn(client, id, createdTaskEvents)
       await client.query('COMMIT')
       await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
 
@@ -4488,6 +4519,8 @@ export class ApprovalProductService {
           }, actor)
         }
 
+        // P1#2e REPLACE (family 1) — flag-ON in-txn task_created enqueue at the END of this instance's txn.
+        await this.enqueueApprovalTaskCreatedEventsInTxn(client, instanceId, createdTaskEvents)
         await client.query('COMMIT')
         await this.emitApprovalTaskCreatedEventsPostCommit(instanceId, createdTaskEvents) // A-2a
         result.succeeded.push(instanceId)
@@ -4660,6 +4693,8 @@ export class ApprovalProductService {
           targetUserId,
         })
         await consumeTimeout()
+        // P1#2e REPLACE (family 1) — flag-ON in-txn task_created enqueue at the END of the transfer txn.
+        await this.enqueueApprovalTaskCreatedEventsInTxn(client, id, createdTaskEvents)
         await client.query('COMMIT')
         await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
         return 'applied'
@@ -4754,8 +4789,12 @@ export class ApprovalProductService {
           },
           { id: APPROVAL_TIMEOUT_SYSTEM_ACTOR, name: APPROVAL_TIMEOUT_SYSTEM_ACTOR },
         )
+        // P1#2e REPLACE (family 1) — same-txn durable enqueue, atomic with the timeout jump→approved transition.
+        await enqueueApprovalEventIfDurable(approvalTxnHandle(client), completionEvent)
       }
       await consumeTimeout()
+      // P1#2e REPLACE (family 1) — flag-ON in-txn task_created enqueue at the END of the timeout-jump txn.
+      await this.enqueueApprovalTaskCreatedEventsInTxn(client, id, createdTaskEvents)
       await client.query('COMMIT')
       await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
 
@@ -5027,6 +5066,8 @@ export class ApprovalProductService {
           metadata: { nodeKey: currentNodeKey },
           targetUserId: request.targetUserId,
         }, actor)
+        // P1#2e REPLACE (family 1) — flag-ON in-txn task_created enqueue at the END of the transfer txn.
+        await this.enqueueApprovalTaskCreatedEventsInTxn(client, id, createdTaskEvents)
         await client.query('COMMIT')
         await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
         return (await this.getApproval(id))!
@@ -5085,6 +5126,8 @@ export class ApprovalProductService {
           metadata: { nodeKey: currentNodeKey, addSignMode, addedUserIds: targetUserIds },
           targetUserId: targetUserIds[0],
         }, actor)
+        // P1#2e REPLACE (family 1) — flag-ON in-txn task_created enqueue at the END of the add_sign txn.
+        await this.enqueueApprovalTaskCreatedEventsInTxn(client, id, createdTaskEvents)
         await client.query('COMMIT')
         await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
         return (await this.getApproval(id))!
@@ -5224,6 +5267,8 @@ export class ApprovalProductService {
           },
           { id: actor.userId, name: actorName },
         )
+        // P1#2e REPLACE (family 1) — same-txn durable enqueue, atomic with the revoke transition above.
+        await enqueueApprovalEventIfDurable(approvalTxnHandle(client), completionEvent)
         await client.query('COMMIT')
         emitApprovalCompletionEvent(completionEvent)
         this.emitTerminalMetric(id, 'revoked')
@@ -5323,6 +5368,8 @@ export class ApprovalProductService {
         }, actor)
         await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents, returnEntryEpoch)
         await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
+        // P1#2e REPLACE (family 1) — flag-ON in-txn task_created enqueue at the END of the return txn.
+        await this.enqueueApprovalTaskCreatedEventsInTxn(client, id, createdTaskEvents)
         await client.query('COMMIT')
         await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
         this.emitNodeDecisionMetric(id, currentNodeKey, actor.userId)
@@ -5372,6 +5419,8 @@ export class ApprovalProductService {
           },
           { id: actor.userId, name: actorName },
         )
+        // P1#2e REPLACE (family 1) — same-txn durable enqueue, atomic with the reject transition above.
+        await enqueueApprovalEventIfDurable(approvalTxnHandle(client), completionEvent)
         await client.query('COMMIT')
         this.emitNodeDecisionMetric(id, currentNodeKey, actor.userId)
         emitApprovalCompletionEvent(completionEvent)
@@ -5817,6 +5866,14 @@ export class ApprovalProductService {
           )
         : null
 
+      // P1#2e REPLACE (family 1) — same-txn durable enqueue of the completion event (only when this advance is
+      // terminal), atomic with the approve→approved transition above. Flag OFF ⇒ no-op.
+      if (completionEvent) {
+        await enqueueApprovalEventIfDurable(approvalTxnHandle(client), completionEvent)
+      }
+      // P1#2e REPLACE (family 1) — flag-ON in-txn task_created enqueue at the END of the advance txn (after
+      // every assignment write + same-txn auto-approval / parallel-cancel cascade). Flag OFF ⇒ no-op.
+      await this.enqueueApprovalTaskCreatedEventsInTxn(client, id, createdTaskEvents)
       await client.query('COMMIT')
       await this.emitApprovalTaskCreatedEventsPostCommit(id, createdTaskEvents) // A-2a
       // P1-1 defense-in-depth: the node just advanced past `currentNodeKey`, so sweep every still-`sent`
@@ -6136,6 +6193,12 @@ export class ApprovalProductService {
    * created by the just-committed operation. Best-effort by contract: a lookup/emit failure NEVER
    * fails the approval flow (the T2-6 dedupe ledger also absorbs any later re-emission), and the
    * instance snapshot is re-read AFTER commit so the event reflects durable state.
+   *
+   * P1#2e producer family 1 — flag-OFF delivery leg. The recheck+dedup+instance-read+build logic is now the
+   * SHARED `collectLiveApprovalTaskCreatedEvents` core (parameterized on the query fn); this leg passes
+   * `pool.query`, so it is BYTE-IDENTICAL to the pre-P1#2e inline logic. When the flag is ON, the individual
+   * `emitApprovalTaskCreatedEvent` is choke-suppressed (the in-txn `enqueueApprovalTaskCreatedEventsInTxn` leg
+   * is the delivery path); the post-commit collector read here is then harmless (read-only, values-free).
    */
   private async emitApprovalTaskCreatedEventsPostCommit(
     instanceId: string,
@@ -6143,42 +6206,48 @@ export class ApprovalProductService {
   ): Promise<void> {
     if (tasks.length === 0) return
     try {
-      // Same-transaction cascades (auto-approve at entry, immediate handover) can deactivate a row
-      // BEFORE commit — only still-active assignments are real pending items, so re-check against
-      // durable state and drop the rest (values-free: key fields only).
-      const activeResult = await pool.query(
-        `SELECT node_key, assignee_id, entry_epoch FROM approval_assignments
-          WHERE instance_id = $1 AND is_active = TRUE AND assignment_type = 'user'`,
-        [instanceId],
+      const events = await collectLiveApprovalTaskCreatedEvents(
+        (sql, params) => pool.query(sql, params),
+        instanceId,
+        tasks,
       )
-      const activeKeys = new Set(
-        (activeResult.rows as Array<{ node_key: string; assignee_id: string; entry_epoch: number | string | null }>).map(
-          (row) => `${row.node_key}:${row.entry_epoch === null ? 'null' : String(Number(row.entry_epoch))}:${row.assignee_id}`,
-        ),
-      )
-      const seen = new Set<string>()
-      const liveTasks = tasks.filter((task) => {
-        const key = `${task.nodeKey}:${task.entryEpoch === null ? 'null' : String(task.entryEpoch)}:${task.assigneeUserId}`
-        if (seen.has(key) || !activeKeys.has(key)) return false
-        seen.add(key)
-        return true
-      })
-      if (liveTasks.length === 0) return
-      const result = await pool.query(
-        `SELECT id, request_no, template_id, template_version_id, published_definition_id,
-                business_key, workflow_key, requester_snapshot
-           FROM approval_instances WHERE id = $1`,
-        [instanceId],
-      )
-      const instance = result.rows[0] as ApprovalTaskCreatedInstanceSnapshot | undefined
-      if (!instance) return
-      for (const task of liveTasks) {
-        emitApprovalTaskCreatedEvent(buildApprovalTaskCreatedEvent({ instance, task }))
+      for (const event of events) {
+        emitApprovalTaskCreatedEvent(event)
       }
     } catch (error) {
       approvalProductLogger.warn(
         `approval.task_created post-commit emission failed for ${instanceId}: ${error instanceof Error ? error.message : String(error)}`,
       )
+    }
+  }
+
+  /**
+   * P1#2e producer family 1 — flag-ON delivery leg for approval.task_created. Runs at the END of a source txn
+   * (after every assignment write AND same-transaction cascade deactivation in that txn) with the SOURCE-TXN
+   * query fn, so the SHARED collector's `is_active` recheck observes the txn's own pre-commit view — identical
+   * filtering to the post-commit read of committed state (design §4a). Each surviving event is enqueued on the
+   * SAME transaction as the source writes, so the outbox rows commit or roll back atomically with them.
+   *
+   * NOT best-effort (unlike the post-commit leg): a failed enqueue THROWS and rolls back the whole transition —
+   * that atomicity is the entire point of durable delivery. Flag OFF ⇒ pure no-op (no extra txn reads), which
+   * keeps the flag-OFF path byte-identical. `client` MUST be the same in-transaction connection as the writes.
+   */
+  private async enqueueApprovalTaskCreatedEventsInTxn(
+    client: ApprovalDbClient,
+    instanceId: string,
+    tasks: ApprovalTaskCreatedTaskSnapshot[],
+  ): Promise<void> {
+    if (!isDurableDeliveryEnabled()) return
+    if (tasks.length === 0) return
+    const events = await collectLiveApprovalTaskCreatedEvents(
+      (sql, params) => client.query(sql, params),
+      instanceId,
+      tasks,
+    )
+    if (events.length === 0) return
+    const trx = approvalTxnHandle(client)
+    for (const event of events) {
+      await enqueueApprovalEventIfDurable(trx, event)
     }
   }
 

--- a/packages/core-backend/src/services/ApprovalTaskCreatedEvent.ts
+++ b/packages/core-backend/src/services/ApprovalTaskCreatedEvent.ts
@@ -1,5 +1,6 @@
 import { Logger } from '../core/logger'
 import { eventBus } from '../integration/events/event-bus'
+import { isDurableDeliveryEnabled } from '../multitable/automation-durable-delivery'
 
 const logger = new Logger('ApprovalTaskCreatedEvent')
 
@@ -100,6 +101,12 @@ export function buildApprovalTaskCreatedEvent(input: {
 }
 
 export function emitApprovalTaskCreatedEvent(event: ApprovalTaskCreatedEventV1): void {
+  // P1#2e producer family 1 — REPLACE guard (the load-bearing suppression). When durable delivery is ON, the
+  // SAME-transaction outbox enqueue at the END of every source txn (ApprovalProductService task_created sites
+  // ×9, via the shared collector + `enqueueApprovalEventIfDurable`) is the delivery path. The only caller of
+  // this legacy emit is `emitApprovalTaskCreatedEventsPostCommit`, and its full set of build sites all enqueue
+  // in-txn, so a flag-ON legacy emit would DOUBLE-deliver (non-idempotent webhook sink). Flag OFF ⇒ legacy emit.
+  if (isDurableDeliveryEnabled()) return
   try {
     eventBus.emit(event.eventType, event)
   } catch (error) {
@@ -107,4 +114,61 @@ export function emitApprovalTaskCreatedEvent(event: ApprovalTaskCreatedEventV1):
       `approval task_created event ${event.eventId} failed: ${error instanceof Error ? error.message : String(error)}`,
     )
   }
+}
+
+/**
+ * P1#2e producer family 1 — the SHARED task_created recheck+dedup+instance-read+build core, parameterized on
+ * the query fn so BOTH delivery legs run IDENTICAL filtering (semantics cannot drift):
+ *   - flag-OFF post-commit leg (`emitApprovalTaskCreatedEventsPostCommit`) passes `pool.query` and emits each
+ *     returned event — byte-identical to the pre-P1#2e inline logic;
+ *   - flag-ON in-txn leg (`enqueueApprovalTaskCreatedEventsInTxn`) passes the SOURCE-TXN query fn and enqueues
+ *     each returned event same-txn — so a same-transaction cascade deactivation (a row created THEN deactivated
+ *     before COMMIT) is already reflected in `is_active`, exactly as the post-commit read sees committed state.
+ *
+ * Filtering (unchanged from the original recheck): keep only tasks whose `(nodeKey:entryEpoch:assigneeUserId)`
+ * is BOTH still `is_active` (durable/txn state) AND not a duplicate within this batch (`seen`), then re-read the
+ * instance snapshot ONCE and build a per-recipient event whose `eventId` is byte-identical to the legacy quad
+ * (`approval-task:instanceId:nodeKey:entryEpoch:assigneeUserId`) so the T2-6 dedup ledger keys line up.
+ */
+export type ApprovalTaskCreatedQueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: Array<Record<string, unknown>> }>
+
+export async function collectLiveApprovalTaskCreatedEvents(
+  query: ApprovalTaskCreatedQueryFn,
+  instanceId: string,
+  tasks: ApprovalTaskCreatedTaskSnapshot[],
+): Promise<ApprovalTaskCreatedEventV1[]> {
+  if (tasks.length === 0) return []
+  // Same-transaction cascades (auto-approve at entry, immediate handover) can deactivate a row BEFORE commit —
+  // only still-active assignments are real pending items, so re-check against the query's view and drop the
+  // rest (values-free: key fields only).
+  const activeResult = await query(
+    `SELECT node_key, assignee_id, entry_epoch FROM approval_assignments
+      WHERE instance_id = $1 AND is_active = TRUE AND assignment_type = 'user'`,
+    [instanceId],
+  )
+  const activeKeys = new Set(
+    (activeResult.rows as Array<{ node_key: string; assignee_id: string; entry_epoch: number | string | null }>).map(
+      (row) => `${row.node_key}:${row.entry_epoch === null ? 'null' : String(Number(row.entry_epoch))}:${row.assignee_id}`,
+    ),
+  )
+  const seen = new Set<string>()
+  const liveTasks = tasks.filter((task) => {
+    const key = `${task.nodeKey}:${task.entryEpoch === null ? 'null' : String(task.entryEpoch)}:${task.assigneeUserId}`
+    if (seen.has(key) || !activeKeys.has(key)) return false
+    seen.add(key)
+    return true
+  })
+  if (liveTasks.length === 0) return []
+  const result = await query(
+    `SELECT id, request_no, template_id, template_version_id, published_definition_id,
+            business_key, workflow_key, requester_snapshot
+       FROM approval_instances WHERE id = $1`,
+    [instanceId],
+  )
+  const instance = result.rows[0] as unknown as ApprovalTaskCreatedInstanceSnapshot | undefined
+  if (!instance) return []
+  return liveTasks.map((task) => buildApprovalTaskCreatedEvent({ instance, task }))
 }

--- a/packages/core-backend/tests/integration/multitable-automation-approval-bridge-lease-migration.db.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-approval-bridge-lease-migration.db.test.ts
@@ -1,0 +1,181 @@
+/**
+ * P2 durable-delivery P1 #1 — `multitable_automation_approval_bridges` terminal-early → LEASE upgrade
+ * migration (real DB, ISOLATED SCHEMA), via the REAL UPGRADE PATH (not fresh-DB).
+ *
+ * The load-bearing difference from the S6 event_fires migration: event_fires rows were historical COMPLETED
+ * deliveries (backfilled to `done`); a bridge `pending` row is a LIVE in-flight approval still awaiting its
+ * completion event. So this migration must NOT touch existing status values — it only ADDS lease columns and
+ * WIDENS the CHECKs. The first test proves exactly that: a pre-existing `pending`/`resumed` row keeps its
+ * status after the ALTER (a backfill would corrupt live state), and gets lease=NULL / fence=0 / attempts=0.
+ *
+ * Isolated schema + search_path (house rule for shared-DB integration) — no shared-table pollution.
+ */
+import { randomUUID } from 'node:crypto'
+
+import { Pool } from 'pg'
+import { Kysely, PostgresDialect, sql } from 'kysely'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { up as migrateUp } from '../../src/db/migrations/zzzz20260717120000_approval_bridge_lease'
+
+const dbUrl = process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+
+describeDb('P1#1 approval-bridge terminal→lease upgrade migration (real DB, isolated schema)', () => {
+  let adminPool: Pool
+  let schema: string
+  let testPool: Pool
+  let testDb: Kysely<unknown>
+
+  beforeEach(async () => {
+    adminPool = new Pool({ connectionString: dbUrl })
+    schema = `p1b_${randomUUID().replace(/-/g, '')}`
+    await adminPool.query(`CREATE SCHEMA "${schema}"`)
+    testPool = new Pool({ connectionString: dbUrl, options: `-c search_path=${schema}` })
+    testDb = new Kysely<unknown>({ dialect: new PostgresDialect({ pool: testPool }) })
+    // OLD schema exactly as zzzz20260610150000_create_automation_approval_bridges (the columns + the two CHECKs
+    // this migration touches). No FK/index noise — irrelevant to the ALTER under test.
+    await sql`
+      CREATE TABLE multitable_automation_approval_bridges (
+        id TEXT PRIMARY KEY,
+        execution_id TEXT NOT NULL,
+        root_execution_id TEXT NOT NULL,
+        rule_id TEXT NOT NULL,
+        sheet_id TEXT,
+        record_id TEXT,
+        step_index INTEGER NOT NULL,
+        approval_instance_id TEXT,
+        approval_request_no TEXT,
+        approval_template_id TEXT NOT NULL,
+        approval_published_definition_id TEXT,
+        idempotency_key TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending'
+          CONSTRAINT chk_mt_auto_approval_bridge_status CHECK (status IN ('creating', 'pending', 'resumed', 'failed')),
+        outcome TEXT,
+        action_fingerprint JSONB NOT NULL,
+        trigger_event JSONB,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        completed_at TIMESTAMPTZ,
+        resumed_at TIMESTAMPTZ,
+        CONSTRAINT chk_mt_auto_approval_bridge_claimable_has_approval
+          CHECK (status NOT IN ('pending', 'resumed') OR approval_instance_id IS NOT NULL)
+      )
+    `.execute(testDb)
+  })
+
+  afterEach(async () => {
+    await testDb.destroy()
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await adminPool.end()
+  })
+
+  const insertOld = (id: string, status: string, approvalInstanceId: string | null) =>
+    sql`
+      INSERT INTO multitable_automation_approval_bridges
+        (id, execution_id, root_execution_id, rule_id, step_index, approval_instance_id, approval_template_id,
+         idempotency_key, status, action_fingerprint)
+      VALUES (${id}, 'exec_1', 'exec_1', 'rule_1', 0, ${approvalInstanceId}, 'tpl_1', ${'idem_' + id}, ${status}, '{"count":0,"hash":""}'::jsonb)
+    `.execute(testDb)
+
+  const rowOf = async (id: string) =>
+    (
+      await sql<{ status: string; lease: string | null; attempts: number; fence: string }>`
+        SELECT status, lease_expires_at::text AS lease, attempts, fence
+        FROM multitable_automation_approval_bridges WHERE id = ${id}
+      `.execute(testDb)
+    ).rows[0]
+
+  it('UPGRADE PATH: pre-existing rows KEEP their status (a pending row stays pending — NOT backfilled) + new columns land NULL/0', async () => {
+    // live in-flight + terminal + creation-time deploy data
+    await insertOld('b_pending', 'pending', 'appr_1')
+    await insertOld('b_resumed', 'resumed', 'appr_2')
+    await insertOld('b_creating', 'creating', null)
+    await insertOld('b_failed', 'failed', null)
+
+    await expect(migrateUp(testDb)).resolves.toBeUndefined()
+
+    // status UNCHANGED for every row (the S6 done-backfill trick does NOT apply — pending is live work)
+    expect((await rowOf('b_pending')).status).toBe('pending')
+    expect((await rowOf('b_resumed')).status).toBe('resumed')
+    expect((await rowOf('b_creating')).status).toBe('creating')
+    expect((await rowOf('b_failed')).status).toBe('failed')
+    // new lease columns default to lease-free / fence 0 / attempts 0 for every existing row
+    for (const id of ['b_pending', 'b_resumed', 'b_creating', 'b_failed']) {
+      const r = await rowOf(id)
+      expect(r.lease).toBeNull()
+      expect(r.attempts).toBe(0)
+      expect(r.fence).toBe('0')
+    }
+  })
+
+  it('new lease states land: in_progress requires a lease (biconditional), terminals reject one, bogus rejected', async () => {
+    await insertOld('b_x', 'pending', 'appr_x')
+    await migrateUp(testDb)
+    // pending → in_progress WITHOUT a lease is rejected (unreclaimable)
+    await expect(
+      sql`UPDATE multitable_automation_approval_bridges SET status='in_progress' WHERE id='b_x'`.execute(testDb),
+    ).rejects.toThrow(/chk_mt_auto_approval_bridge_lease_iff_in_progress/)
+    // pending → in_progress WITH a lease is accepted (a live, reclaimable claim)
+    await expect(
+      sql`UPDATE multitable_automation_approval_bridges SET status='in_progress', lease_expires_at = now() + interval '60 s' WHERE id='b_x'`.execute(testDb),
+    ).resolves.toBeTruthy()
+    // an in_progress row can't drop its lease without leaving in_progress
+    await expect(
+      sql`UPDATE multitable_automation_approval_bridges SET lease_expires_at = NULL WHERE id='b_x'`.execute(testDb),
+    ).rejects.toThrow(/chk_mt_auto_approval_bridge_lease_iff_in_progress/)
+    // terminal dead_letter is accepted (with an instance) and is lease-NULL
+    await sql`UPDATE multitable_automation_approval_bridges SET status='dead_letter', lease_expires_at = NULL WHERE id='b_x'`.execute(testDb)
+    expect((await rowOf('b_x')).status).toBe('dead_letter')
+    // a bogus status → closed-set CHECK
+    await expect(
+      insertOld('b_bogus', 'zombie_state', 'appr_z'),
+    ).rejects.toThrow(/chk_mt_auto_approval_bridge_status/)
+  })
+
+  it('claimable-has-approval widened: in_progress/dead_letter require an approval_instance_id', async () => {
+    await migrateUp(testDb)
+    // an in_progress row with NO instance is rejected by the widened claimable CHECK
+    await expect(
+      sql`
+        INSERT INTO multitable_automation_approval_bridges
+          (id, execution_id, root_execution_id, rule_id, step_index, approval_instance_id, approval_template_id,
+           idempotency_key, status, lease_expires_at, action_fingerprint)
+        VALUES ('b_noappr','e','e','r',0, NULL, 't','idem_noappr','in_progress', now() + interval '60 s', '{}'::jsonb)
+      `.execute(testDb),
+    ).rejects.toThrow(/chk_mt_auto_approval_bridge_claimable_has_approval/)
+  })
+
+  it('fence is a monotonic single-writer token: claim/reclaim increment, stale-fence CAS writes 0 rows, bigint round-trips as string past 2^53; attempts/fence CHECKs named', async () => {
+    await insertOld('b_f', 'pending', 'appr_f')
+    await migrateUp(testDb)
+    // claim: fence 0 → 1 via fence-CAS
+    const claim = await sql<{ fence: string }>`
+      UPDATE multitable_automation_approval_bridges SET fence = fence + 1, status='in_progress', lease_expires_at = now() + interval '60 s'
+      WHERE id='b_f' AND fence = 0 RETURNING fence
+    `.execute(testDb)
+    expect(claim.rows[0].fence).toBe('1')
+    // reclaim: fence 1 → 2
+    const reclaim = await sql<{ fence: string }>`
+      UPDATE multitable_automation_approval_bridges SET fence = fence + 1 WHERE id='b_f' AND fence = 1 RETURNING fence
+    `.execute(testDb)
+    expect(reclaim.rows[0].fence).toBe('2')
+    // zombie holding stale fence 1 tries to write terminal → 0 rows (single-writer)
+    const zombie = await sql`
+      UPDATE multitable_automation_approval_bridges SET status='resumed', lease_expires_at = NULL WHERE id='b_f' AND fence = 1 AND status='in_progress'
+    `.execute(testDb)
+    expect(Number(zombie.numAffectedRows ?? 0)).toBe(0)
+    // bigint driver boundary: 2^53+1 survives a RAW SELECT (no ::text) as an exact STRING
+    const big = '9007199254740993'
+    await sql`UPDATE multitable_automation_approval_bridges SET fence = ${big}::bigint WHERE id='b_f' AND fence = 2`.execute(testDb)
+    const back = await sql<{ fence: string }>`SELECT fence FROM multitable_automation_approval_bridges WHERE id='b_f'`.execute(testDb)
+    expect(typeof back.rows[0].fence).toBe('string')
+    expect(back.rows[0].fence).toBe(big)
+    // named CHECKs reject negatives
+    await expect(
+      sql`UPDATE multitable_automation_approval_bridges SET fence = -1 WHERE id='b_f'`.execute(testDb),
+    ).rejects.toThrow(/chk_mt_auto_approval_bridge_fence_nonneg/)
+    await expect(
+      sql`UPDATE multitable_automation_approval_bridges SET attempts = -1 WHERE id='b_f'`.execute(testDb),
+    ).rejects.toThrow(/chk_mt_auto_approval_bridge_attempts_nonneg/)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-automation-approval-bridge-lease-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-approval-bridge-lease-realdb.test.ts
@@ -23,9 +23,14 @@
  */
 import { randomUUID } from 'node:crypto'
 
-import { afterAll, describe, expect, test } from 'vitest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
+import { EventBus } from '../../src/integration/events/event-bus'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { DurableSinkBusyError } from '../../src/multitable/automation-durable-delivery'
+import { claimEventFiresLease, markEventFiresDone } from '../../src/multitable/automation-event-fires-lease'
+import { db as kyselyDb } from '../../src/db/db'
 import {
   AutomationApprovalBridgeService,
   BRIDGE_COMPLETION_MAX_ATTEMPTS,
@@ -96,60 +101,66 @@ describeIfDatabase('P1#1 approval-bridge lease runtime crash matrix (real DB)', 
   test('fresh claim → in_progress (fence 1, attempts 1, lease + outcome set); markBridgeResumed → resumed; redelivery skips', async () => {
     const inst = `inst_fresh_${RUN}`
     const id = await seedBridge('pending', { instanceId: inst })
-    const claimed = await service.claimCompletion(eventFor(inst, 'approved'), FLAG_ON)
-    expect(claimed?.id).toBe(id)
-    expect(claimed?.status).toBe('in_progress')
-    expect(claimed?.fence).toBe('1')
+    const claim = await service.claimCompletion(eventFor(inst, 'approved'), FLAG_ON)
+    expect(claim.kind).toBe('claimed')
+    const claimed = claim.kind === 'claimed' ? claim.row : (undefined as never)
+    expect(claimed.id).toBe(id)
+    expect(claimed.status).toBe('in_progress')
+    expect(claimed.fence).toBe('1')
     const afterClaim = await rowById(id)
     expect(afterClaim).toMatchObject({ status: 'in_progress', attempts: 1, fence: '1', outcome: 'approved' })
     expect(afterClaim.lease).not.toBe('') // lease held
 
     // terminal write AFTER the continuation
-    expect(await service.markBridgeResumed(id, claimed!.fence)).toBe(true)
+    expect(await service.markBridgeResumed(id, claimed.fence)).toBe(true)
     expect(await rowById(id)).toMatchObject({ status: 'resumed', lease: '' })
 
-    // a redelivery finds a terminal row → null (skip, no double-run)
-    expect(await service.claimCompletion(eventFor(inst, 'approved'), FLAG_ON)).toBeNull()
+    // a redelivery finds a terminal row → 'none' (skip, no double-run — and NOT 'busy': terminal ≠ live lease)
+    expect(await service.claimCompletion(eventFor(inst, 'approved'), FLAG_ON)).toEqual({ kind: 'none' })
   })
 
   test('crash-after-claim → lease expires → the redelivered event RECLAIMS the same row (at-least-once, fence 2)', async () => {
     const inst = `inst_reclaim_${RUN}`
     const id = await seedBridge('pending', { instanceId: inst })
     const first = await service.claimCompletion(eventFor(inst), FLAG_ON)
-    expect(first?.fence).toBe('1')
+    expect(first.kind === 'claimed' && first.row.fence).toBe('1')
     // "crash": no markBridgeResumed; force the lease to expire
     await db().query(`UPDATE multitable_automation_approval_bridges SET lease_expires_at = now() - interval '1 min' WHERE id=$1`, [id])
     // redelivery reclaims the SAME row: fence 2, attempts 2
     const second = await service.claimCompletion(eventFor(inst), FLAG_ON)
-    expect(second?.id).toBe(id)
-    expect(second?.status).toBe('in_progress')
-    expect(second?.fence).toBe('2')
+    expect(second.kind).toBe('claimed')
+    const secondRow = second.kind === 'claimed' ? second.row : (undefined as never)
+    expect(secondRow.id).toBe(id)
+    expect(secondRow.status).toBe('in_progress')
+    expect(secondRow.fence).toBe('2')
     expect((await rowById(id)).attempts).toBe(2)
   })
 
   test('zombie fence-CAS: after a reclaim (fence 2), the zombie markBridgeResumed(fence 1) writes 0 rows; only the reclaimer wins', async () => {
     const inst = `inst_zombie_${RUN}`
     const id = await seedBridge('pending', { instanceId: inst })
-    const zombie = await service.claimCompletion(eventFor(inst), FLAG_ON) // fence 1
-    expect(zombie?.fence).toBe('1')
+    const zombieClaim = await service.claimCompletion(eventFor(inst), FLAG_ON) // fence 1
+    const zombie = zombieClaim.kind === 'claimed' ? zombieClaim.row : (undefined as never)
+    expect(zombie.fence).toBe('1')
     await db().query(`UPDATE multitable_automation_approval_bridges SET lease_expires_at = now() - interval '1 min' WHERE id=$1`, [id])
-    const reclaimer = await service.claimCompletion(eventFor(inst), FLAG_ON) // fence 2
-    expect(reclaimer?.fence).toBe('2')
+    const reclaimerClaim = await service.claimCompletion(eventFor(inst), FLAG_ON) // fence 2
+    const reclaimer = reclaimerClaim.kind === 'claimed' ? reclaimerClaim.row : (undefined as never)
+    expect(reclaimer.fence).toBe('2')
     // zombie (stale fence 1) tries to write terminal → fence-CAS 0 rows (single-writer)
-    expect(await service.markBridgeResumed(id, zombie!.fence)).toBe(false)
+    expect(await service.markBridgeResumed(id, zombie.fence)).toBe(false)
     expect((await rowById(id)).status).toBe('in_progress') // still owned by the reclaimer
     // reclaimer (fence 2) wins
-    expect(await service.markBridgeResumed(id, reclaimer!.fence)).toBe(true)
+    expect(await service.markBridgeResumed(id, reclaimer.fence)).toBe(true)
     expect(await rowById(id)).toMatchObject({ status: 'resumed', lease: '' })
   })
 
-  test('a redelivery under a LIVE lease returns null (another worker owns it — no double delivery)', async () => {
+  test("a redelivery under a LIVE lease returns 'busy' (another worker owns it — neither double-run NOR a silent done-resolve that would drop a crashed holder's work)", async () => {
     const inst = `inst_live_${RUN}`
     await seedBridge('pending', { instanceId: inst })
     const claimed = await service.claimCompletion(eventFor(inst), FLAG_ON) // fence 1, LIVE 60s lease
-    expect(claimed?.fence).toBe('1')
-    // no lease expiry → a concurrent redelivery must skip
-    expect(await service.claimCompletion(eventFor(inst), FLAG_ON)).toBeNull()
+    expect(claimed.kind === 'claimed' && claimed.row.fence).toBe('1')
+    // no lease expiry → a concurrent redelivery must fail retryably, not skip
+    expect(await service.claimCompletion(eventFor(inst), FLAG_ON)).toEqual({ kind: 'busy' })
   })
 
   test('bounded attempts: an EXPIRED in_progress at the ceiling is DEAD-LETTERED at claim (null, terminal — no infinite reclaim)', async () => {
@@ -157,29 +168,105 @@ describeIfDatabase('P1#1 approval-bridge lease runtime crash matrix (real DB)', 
     // seed an in_progress row at the attempt ceiling with an already-expired lease (the crashed-N-times state)
     const id = await seedBridge('in_progress', { instanceId: inst, attempts: BRIDGE_COMPLETION_MAX_ATTEMPTS })
     const res = await service.claimCompletion(eventFor(inst), FLAG_ON)
-    expect(res).toBeNull() // not reclaimed
+    expect(res).toEqual({ kind: 'none' }) // not reclaimed — poisoned terminally
     expect(await rowById(id)).toMatchObject({ status: 'dead_letter', lease: '' }) // terminal, lease cleared
-    // a further redelivery still skips (terminal)
-    expect(await service.claimCompletion(eventFor(inst), FLAG_ON)).toBeNull()
+    // a further redelivery still skips (terminal → 'none', not 'busy')
+    expect(await service.claimCompletion(eventFor(inst), FLAG_ON)).toEqual({ kind: 'none' })
   })
 
   test('one below the ceiling is RECLAIMED, not dead-lettered (boundary is >=, not >)', async () => {
     const inst = `inst_boundary_${RUN}`
     const id = await seedBridge('in_progress', { instanceId: inst, attempts: BRIDGE_COMPLETION_MAX_ATTEMPTS - 1 })
     const res = await service.claimCompletion(eventFor(inst), FLAG_ON)
-    expect(res?.id).toBe(id)
-    expect(res?.status).toBe('in_progress')
+    expect(res.kind).toBe('claimed')
+    const resRow = res.kind === 'claimed' ? res.row : (undefined as never)
+    expect(resRow.id).toBe(id)
+    expect(resRow.status).toBe('in_progress')
     expect((await rowById(id)).attempts).toBe(BRIDGE_COMPLETION_MAX_ATTEMPTS) // reclaimed → attempts bumped to the ceiling
   })
 
   test('flag OFF is byte-identical legacy: pending → resumed TERMINALLY at claim, fence stays 0 (no lease)', async () => {
     const inst = `inst_off_${RUN}`
     const id = await seedBridge('pending', { instanceId: inst })
-    const claimed = await service.claimCompletion(eventFor(inst, 'approved'), FLAG_OFF)
-    expect(claimed?.id).toBe(id)
-    expect(claimed?.status).toBe('resumed') // terminal-early, exactly as before P1#1
+    const claim = await service.claimCompletion(eventFor(inst, 'approved'), FLAG_OFF)
+    const claimed = claim.kind === 'claimed' ? claim.row : (undefined as never)
+    expect(claimed.id).toBe(id)
+    expect(claimed.status).toBe('resumed') // terminal-early, exactly as before P1#1
     expect(await rowById(id)).toMatchObject({ status: 'resumed', fence: '0', lease: '', outcome: 'approved' })
-    // legacy claim is single-shot: a second flag-OFF claim finds no pending row → null
-    expect(await service.claimCompletion(eventFor(inst, 'approved'), FLAG_OFF)).toBeNull()
+    // legacy claim is single-shot: a second flag-OFF claim finds no pending row → 'none' (legacy never 'busy')
+    expect(await service.claimCompletion(eventFor(inst, 'approved'), FLAG_OFF)).toEqual({ kind: 'none' })
+  })
+})
+
+/**
+ * Busy-mapping WIRE goldens (sink audit 2026-07-17): the done/busy split is only load-bearing if the REAL
+ * service maps 'busy' to a retryable throw — a silent return would resolve the outbox delivery `done` and
+ * permanently drop a crashed holder's work. These drive the real AutomationService entry points.
+ */
+describeIfDatabase('busy mapping — wire level (real AutomationService)', () => {
+  const pool = () => poolManager.get()
+  const svc = () => new AutomationService(new EventBus(), kyselyDb as never, pool().query.bind(pool()))
+  // event_fires carries an FK to automation_rules(id) — seed a real base/sheet/rule for the (rule, dedup) keys.
+  const WIRE_BASE = `base_wire_${RUN}`
+  const WIRE_SHEET = `sheet_wire_${RUN}`
+  const WIRE_RULE = `rule_wire_${RUN}`
+
+  beforeAll(async () => {
+    await pool().query('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [WIRE_BASE, 'Wire Base', `u_wire_${RUN}`])
+    await pool().query('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [WIRE_SHEET, WIRE_BASE, 'Wire Sheet'])
+    await pool().query(
+      `INSERT INTO automation_rules (id, sheet_id, trigger_type, action_type) VALUES ($1,$2,'record.created','send_notification')`,
+      [WIRE_RULE, WIRE_SHEET],
+    )
+  })
+
+  afterAll(async () => {
+    await pool().query('DELETE FROM automation_rules WHERE id = $1', [WIRE_RULE]).catch(() => {})
+    await pool().query('DELETE FROM meta_sheets WHERE id = $1', [WIRE_SHEET]).catch(() => {})
+    await pool().query('DELETE FROM meta_bases WHERE id = $1', [WIRE_BASE]).catch(() => {})
+  })
+
+  test("W1 handleApprovalCompletionEvent under a LIVE foreign bridge lease → DurableSinkBusyError, row byte-untouched", async () => {
+    const inst = `inst_wire_busy_${RUN}`
+    const id = await seedBridge('pending', { instanceId: inst })
+    // a "foreign worker" takes the live lease
+    const held = await service.claimCompletion(eventFor(inst), FLAG_ON)
+    expect(held.kind).toBe('claimed')
+    const before = await rowById(id)
+    // the redelivered event on ANOTHER worker must fail retryably — never resolve, never run the continuation
+    await expect(svc().handleApprovalCompletionEvent(eventFor(inst), FLAG_ON)).rejects.toThrow(DurableSinkBusyError)
+    expect(await rowById(id)).toEqual(before) // fence/attempts/status all untouched by the busy loser
+  })
+
+  test("W2 runWithEventDedup under a LIVE foreign event_fires lease → retryable throw, handler NOT run; after done → silent skip", async () => {
+    const rule = WIRE_RULE
+    const dedup = `wire_dedup_${RUN}`
+    const held = await claimEventFiresLease(kyselyDb, rule, dedup, 60_000)
+    expect(typeof held).toBe('object')
+    let runs = 0
+    const call = () =>
+      (svc() as unknown as { runWithEventDedup: (r: string, d: string, run: () => Promise<unknown>, env: NodeJS.ProcessEnv) => Promise<void> })
+        .runWithEventDedup(rule, dedup, async () => { runs += 1 }, FLAG_ON)
+    // live foreign lease → busy throw, handler NOT run (running would double-run the live holder)
+    await expect(call()).rejects.toThrow(DurableSinkBusyError)
+    expect(runs).toBe(0)
+    // the holder finishes → 'done' → silent skip (NOT busy, NOT a re-run)
+    await markEventFiresDone(kyselyDb, rule, dedup, (held as { fence: string }).fence)
+    await call()
+    expect(runs).toBe(0)
+    await kyselyDb.deleteFrom('meta_automation_event_fires' as never).where('dedup_key' as never, '=', dedup as never).execute()
+  })
+
+  test('W3 runWithEventDedup over an EXPIRED foreign lease → RECLAIMS and RUNS (crash recovery, not busy)', async () => {
+    const rule = WIRE_RULE
+    const dedup = `wire_dedup_exp_${RUN}`
+    const held = await claimEventFiresLease(kyselyDb, rule, dedup, 1) // 1ms — expires immediately
+    expect(typeof held).toBe('object')
+    await new Promise((r) => setTimeout(r, 20))
+    let runs = 0
+    await (svc() as unknown as { runWithEventDedup: (r: string, d: string, run: () => Promise<unknown>, env: NodeJS.ProcessEnv) => Promise<void> })
+      .runWithEventDedup(rule, dedup, async () => { runs += 1 }, FLAG_ON)
+    expect(runs).toBe(1) // reclaimed the crashed holder's work and ran it
+    await kyselyDb.deleteFrom('meta_automation_event_fires' as never).where('dedup_key' as never, '=', dedup as never).execute()
   })
 })

--- a/packages/core-backend/tests/integration/multitable-automation-approval-bridge-lease-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-approval-bridge-lease-realdb.test.ts
@@ -1,0 +1,185 @@
+/**
+ * P2 durable-delivery P1 #1 — approval-bridge reclaimable-LEASE runtime crash matrix (real DB).
+ *
+ * Exercises the REAL `AutomationApprovalBridgeService.claimCompletion` / `markBridgeResumed` against Postgres.
+ * These methods use only the module `db` + the event (not jobService/approvalProductService), so the service
+ * is constructed with dummy deps. Each test uses a RUN-UNIQUE `approval_instance_id`; claimCompletion targets
+ * a specific instance (never a scan), so this suite can never touch a sibling suite's bridge row on the shared
+ * CI DB. Seeded rows are cleaned up in afterAll.
+ *
+ * Crash = "no markBridgeResumed from that worker" + lease expiry — the same observable a killed process leaves:
+ *   - fresh claim:            pending → in_progress (fence 1, attempts 1, lease + outcome set); markBridgeResumed
+ *                             (fence-CAS) → resumed, and a redelivery then skips (terminal).
+ *   - crash-after-claim:      claim (fence 1) → lease expires → the redelivered event RECLAIMS (fence 2,
+ *                             attempts 2) the SAME row → the continuation is redelivered (at-least-once).
+ *   - zombie fence-CAS:       after a reclaim (fence 2), the zombie's markBridgeResumed(fence 1) writes 0 rows
+ *                             (false); only the reclaimer (fence 2) wins — persisted state is single-writer.
+ *   - live lease:             a redelivery under a LIVE lease returns null (another worker owns it — no double).
+ *   - bounded attempts:       an expired in_progress at the attempt ceiling is DEAD-LETTERED at claim (null,
+ *                             terminal) — no infinite reclaim, no stuck absorbing state.
+ *   - flag OFF byte-identical: claimCompletion flips pending → resumed TERMINALLY, fence stays 0 (legacy).
+ *
+ * Two-point wired (plugin-tests.yml run-list + vitest.config exclude).
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import {
+  AutomationApprovalBridgeService,
+  BRIDGE_COMPLETION_MAX_ATTEMPTS,
+} from '../../src/multitable/automation-approval-bridge-service'
+import type { ApprovalCompletionEventV1, ApprovalCompletionOutcome } from '../../src/services/ApprovalCompletionEvent'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const db = () => poolManager.get()
+const RUN = randomUUID().replace(/-/g, '')
+const FLAG_ON = { AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv
+const FLAG_OFF = {} as NodeJS.ProcessEnv
+
+// claimCompletion / markBridgeResumed use only the module `db` — dummy the constructor deps.
+const service = new AutomationApprovalBridgeService({} as never, {} as never)
+const seededIds: string[] = []
+
+function eventFor(instanceId: string, toStatus: ApprovalCompletionOutcome = 'approved'): ApprovalCompletionEventV1 {
+  return {
+    version: 1,
+    eventId: `evt_${instanceId}`,
+    eventType: `approval.${toStatus}` as ApprovalCompletionEventV1['eventType'],
+    occurredAt: new Date().toISOString(),
+    source: 'approval-product',
+    approval: { instanceId, requestNo: null, templateId: 'tpl', templateVersionId: null, publishedDefinitionId: null, businessKey: null, workflowKey: null },
+    transition: { action: 'approve', fromStatus: null, toStatus, fromVersion: null, toVersion: 1, nodeKey: null },
+    actor: null,
+    requester: { id: null },
+  }
+}
+
+/** Seed one bridge row directly. `status`/`attempts`/`lease` let the ceiling + reclaim cases set up state. */
+async function seedBridge(status: string, opts: { instanceId: string; attempts?: number; leasePastMs?: number } ): Promise<string> {
+  const id = `aab_${RUN}_${randomUUID().replace(/-/g, '')}`
+  const lease = status === 'in_progress'
+    ? `now() - interval '${opts.leasePastMs ?? 60_000} milliseconds'` // in_progress requires a lease (biconditional); seed it EXPIRED
+    : 'NULL'
+  await db().query(
+    `INSERT INTO multitable_automation_approval_bridges
+       (id, execution_id, root_execution_id, rule_id, step_index, approval_instance_id, approval_template_id,
+        idempotency_key, status, attempts, lease_expires_at, action_fingerprint)
+     VALUES ($1,$2,$2,'rule_1',0,$3,'tpl',$4,$5,$6, ${lease}, '{"count":0,"hash":""}'::jsonb)`,
+    [id, `exec_${id}`, opts.instanceId, `idem_${id}`, status, opts.attempts ?? 0],
+  )
+  seededIds.push(id)
+  return id
+}
+
+async function rowById(id: string) {
+  const { rows } = await db().query(
+    `SELECT status, attempts, fence::text AS fence, coalesce(lease_expires_at::text,'') AS lease, outcome
+       FROM multitable_automation_approval_bridges WHERE id=$1`,
+    [id],
+  )
+  return rows[0] as { status: string; attempts: number; fence: string; lease: string; outcome: string | null }
+}
+
+describeIfDatabase('P1#1 approval-bridge lease runtime crash matrix (real DB)', () => {
+  afterAll(async () => {
+    if (seededIds.length) {
+      await db().query('DELETE FROM multitable_automation_approval_bridges WHERE id = ANY($1)', [seededIds]).catch(() => {})
+    }
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('fresh claim → in_progress (fence 1, attempts 1, lease + outcome set); markBridgeResumed → resumed; redelivery skips', async () => {
+    const inst = `inst_fresh_${RUN}`
+    const id = await seedBridge('pending', { instanceId: inst })
+    const claimed = await service.claimCompletion(eventFor(inst, 'approved'), FLAG_ON)
+    expect(claimed?.id).toBe(id)
+    expect(claimed?.status).toBe('in_progress')
+    expect(claimed?.fence).toBe('1')
+    const afterClaim = await rowById(id)
+    expect(afterClaim).toMatchObject({ status: 'in_progress', attempts: 1, fence: '1', outcome: 'approved' })
+    expect(afterClaim.lease).not.toBe('') // lease held
+
+    // terminal write AFTER the continuation
+    expect(await service.markBridgeResumed(id, claimed!.fence)).toBe(true)
+    expect(await rowById(id)).toMatchObject({ status: 'resumed', lease: '' })
+
+    // a redelivery finds a terminal row → null (skip, no double-run)
+    expect(await service.claimCompletion(eventFor(inst, 'approved'), FLAG_ON)).toBeNull()
+  })
+
+  test('crash-after-claim → lease expires → the redelivered event RECLAIMS the same row (at-least-once, fence 2)', async () => {
+    const inst = `inst_reclaim_${RUN}`
+    const id = await seedBridge('pending', { instanceId: inst })
+    const first = await service.claimCompletion(eventFor(inst), FLAG_ON)
+    expect(first?.fence).toBe('1')
+    // "crash": no markBridgeResumed; force the lease to expire
+    await db().query(`UPDATE multitable_automation_approval_bridges SET lease_expires_at = now() - interval '1 min' WHERE id=$1`, [id])
+    // redelivery reclaims the SAME row: fence 2, attempts 2
+    const second = await service.claimCompletion(eventFor(inst), FLAG_ON)
+    expect(second?.id).toBe(id)
+    expect(second?.status).toBe('in_progress')
+    expect(second?.fence).toBe('2')
+    expect((await rowById(id)).attempts).toBe(2)
+  })
+
+  test('zombie fence-CAS: after a reclaim (fence 2), the zombie markBridgeResumed(fence 1) writes 0 rows; only the reclaimer wins', async () => {
+    const inst = `inst_zombie_${RUN}`
+    const id = await seedBridge('pending', { instanceId: inst })
+    const zombie = await service.claimCompletion(eventFor(inst), FLAG_ON) // fence 1
+    expect(zombie?.fence).toBe('1')
+    await db().query(`UPDATE multitable_automation_approval_bridges SET lease_expires_at = now() - interval '1 min' WHERE id=$1`, [id])
+    const reclaimer = await service.claimCompletion(eventFor(inst), FLAG_ON) // fence 2
+    expect(reclaimer?.fence).toBe('2')
+    // zombie (stale fence 1) tries to write terminal → fence-CAS 0 rows (single-writer)
+    expect(await service.markBridgeResumed(id, zombie!.fence)).toBe(false)
+    expect((await rowById(id)).status).toBe('in_progress') // still owned by the reclaimer
+    // reclaimer (fence 2) wins
+    expect(await service.markBridgeResumed(id, reclaimer!.fence)).toBe(true)
+    expect(await rowById(id)).toMatchObject({ status: 'resumed', lease: '' })
+  })
+
+  test('a redelivery under a LIVE lease returns null (another worker owns it — no double delivery)', async () => {
+    const inst = `inst_live_${RUN}`
+    await seedBridge('pending', { instanceId: inst })
+    const claimed = await service.claimCompletion(eventFor(inst), FLAG_ON) // fence 1, LIVE 60s lease
+    expect(claimed?.fence).toBe('1')
+    // no lease expiry → a concurrent redelivery must skip
+    expect(await service.claimCompletion(eventFor(inst), FLAG_ON)).toBeNull()
+  })
+
+  test('bounded attempts: an EXPIRED in_progress at the ceiling is DEAD-LETTERED at claim (null, terminal — no infinite reclaim)', async () => {
+    const inst = `inst_dead_${RUN}`
+    // seed an in_progress row at the attempt ceiling with an already-expired lease (the crashed-N-times state)
+    const id = await seedBridge('in_progress', { instanceId: inst, attempts: BRIDGE_COMPLETION_MAX_ATTEMPTS })
+    const res = await service.claimCompletion(eventFor(inst), FLAG_ON)
+    expect(res).toBeNull() // not reclaimed
+    expect(await rowById(id)).toMatchObject({ status: 'dead_letter', lease: '' }) // terminal, lease cleared
+    // a further redelivery still skips (terminal)
+    expect(await service.claimCompletion(eventFor(inst), FLAG_ON)).toBeNull()
+  })
+
+  test('one below the ceiling is RECLAIMED, not dead-lettered (boundary is >=, not >)', async () => {
+    const inst = `inst_boundary_${RUN}`
+    const id = await seedBridge('in_progress', { instanceId: inst, attempts: BRIDGE_COMPLETION_MAX_ATTEMPTS - 1 })
+    const res = await service.claimCompletion(eventFor(inst), FLAG_ON)
+    expect(res?.id).toBe(id)
+    expect(res?.status).toBe('in_progress')
+    expect((await rowById(id)).attempts).toBe(BRIDGE_COMPLETION_MAX_ATTEMPTS) // reclaimed → attempts bumped to the ceiling
+  })
+
+  test('flag OFF is byte-identical legacy: pending → resumed TERMINALLY at claim, fence stays 0 (no lease)', async () => {
+    const inst = `inst_off_${RUN}`
+    const id = await seedBridge('pending', { instanceId: inst })
+    const claimed = await service.claimCompletion(eventFor(inst, 'approved'), FLAG_OFF)
+    expect(claimed?.id).toBe(id)
+    expect(claimed?.status).toBe('resumed') // terminal-early, exactly as before P1#1
+    expect(await rowById(id)).toMatchObject({ status: 'resumed', fence: '0', lease: '', outcome: 'approved' })
+    // legacy claim is single-shot: a second flag-OFF claim finds no pending row → null
+    expect(await service.claimCompletion(eventFor(inst, 'approved'), FLAG_OFF)).toBeNull()
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
@@ -4,19 +4,30 @@
  * Activation (flag semantics — the byte-neutral proof):
  *   - flag OFF: produceAutomationEvent → null + ZERO rows; bootDurableDelivery → null (no registry, no loop);
  *   - missing handler → boot throws before any claim; incomplete registry → completeness assertion throws;
- *   - flag ON: produce inside a txn → boot → loop drains the fan-out; PermanentDeliveryFailure → dead_letter.
+ *   - flag ON: produce inside a txn via the REAL seam enqueues the exact manifest fan-out (approval → 3
+ *     consumers, pending — asserted WITHOUT draining, so no shared-row claim); poison → dead_letter is proven
+ *     separately on a run-unique key.
+ *
+ * SCOPE: this file covers the activation seam + the S7 crash-injection tests ONLY. The S5/S6 PRODUCTION work
+ * — meta_automation_event_fires lease-ification + upgrade backfill; recoverable bridge/trigger/projection
+ * sinks; real producer/consumer/boot wiring — is NOT implemented here and ships as separate slices (the
+ * review's open P1). Nothing below claims S6 is done or exempt.
  *
  * Crash-injection V-series (crash = "no further calls from that worker" + lease expiry — the same observable
- * a killed process leaves):
+ * a killed process leaves). To avoid mutating sibling suites' due rows on the shared CI DB, every V-test that
+ * claims/reclaims does so over a RUN-UNIQUE single-consumer manifest and claims only its own key (proven by
+ * the ISOLATION golden below, which seeds a real-key foreign due row and asserts it byte-identical after):
  *   V1 produce-then-crash-BEFORE-commit  → ROLLBACK: zero rows, zero deliveries (nothing phantom).
- *   V2 commit-then-crash-before-dispatch → rows durable; a later tick ("restarted worker") delivers.
+ *   V2 commit-then-crash-before-dispatch → rows durable; a later run-unique tick ("restarted worker") delivers.
  *   V3 crash-after-claim                 → lease expiry → reclaim redelivers: at-least-once, and the handler
  *                                          sees the SAME stable eventId on every delivery (fence-free identity).
- *   V4 zombie + reclaimer both live      → both sides can reach "send"; the outbound idempotency SEED
- *                                          (eventId + consumer_key) is IDENTICAL across fences (#4203 §340 —
- *                                          the endpoint dedups), and the zombie's terminal write hits 0 rows.
+ *   V4 zombie + reclaimer both live      → BOTH actually call a real idempotent endpoint; the outbound seed is
+ *                                          the EVENT+ACTION identity via deriveOutboundIdempotencyKey (NOT
+ *                                          consumer_key, which can't distinguish two actions in one consumer),
+ *                                          so 2 sends collapse to 1 effect (#4203 §340); a different-event
+ *                                          positive control proves that is non-vacuous; zombie terminal write
+ *                                          hits 0 rows.
  *
- * Uses the real manifest consumer keys; adapters defensively skip rows not seeded by this file (shared CI DB).
  * Two-point wired (plugin-tests.yml + vitest.config.ts exclude).
  */
 import { randomUUID } from 'node:crypto'
@@ -35,7 +46,7 @@ import {
 import { claimDueConsumers, completeConsumer, type ClaimedConsumer } from '../../src/multitable/automation-durable-dispatcher'
 import { runDispatchTick, ConsumerAdapterRegistry, type AdapterOutcome, type DispatchLoopObserver } from '../../src/multitable/automation-durable-dispatch-loop'
 import type { TransactionalQueryable } from '../../src/multitable/pg-transaction-guard'
-import { enqueueOutboxEvent, type OutboxEventInput } from '../../src/multitable/automation-outbox-enqueue'
+import { enqueueOutboxEvent } from '../../src/multitable/automation-outbox-enqueue'
 import { deriveOutboundIdempotencyKey } from '../../src/multitable/automation-action-idempotency'
 import { APPROVAL_COMPLETION_CONSUMERS, type RoutingManifest } from '../../src/multitable/automation-routing-manifest'
 import type { PoolClient } from 'pg'
@@ -76,22 +87,6 @@ const noopObserver: DispatchLoopObserver = {
   onTickError: () => {},
   onHeartbeatError: () => {},
   onClaimTimePoison: () => {},
-}
-/** Produce inside a REAL committed transaction (the enqueue txn probe requires one) and return the result. */
-async function produceCommitted(input: OutboxEventInput, env: NodeJS.ProcessEnv) {
-  const client = await db().getInternalPool().connect()
-  try {
-    await client.query('BEGIN')
-    const trx: TransactionalQueryable = { isTransaction: true, query: (sql, params) => client.query(sql, params) }
-    const res = await produceAutomationEvent(trx, input, env)
-    await client.query('COMMIT')
-    return res
-  } catch (e) {
-    await client.query('ROLLBACK').catch(() => {})
-    throw e
-  } finally {
-    client.release()
-  }
 }
 
 /**
@@ -149,6 +144,16 @@ async function consumerStatuses(outboxId: string) {
   return Object.fromEntries((rows as Array<{ consumer_key: string; status: string }>).map((r) => [r.consumer_key, r.status]))
 }
 
+/** The four mutable fields a stray claim would disturb — for the foreign-row isolation golden. */
+async function consumerSnapshot(outboxId: string) {
+  const { rows } = await db().query(
+    `SELECT status, attempts, coalesce(lease_expires_at::text,'') AS lease, coalesce(last_error,'') AS last_error
+       FROM meta_automation_outbox_consumer WHERE outbox_id=$1`,
+    [outboxId],
+  )
+  return rows[0] as { status: string; attempts: number; lease: string; last_error: string }
+}
+
 describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection (real DB)', () => {
   afterAll(async () => {
     if (enqueued.length) {
@@ -158,6 +163,34 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
 
   test('sentinel: DATABASE_URL set', () => {
     expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('ISOLATION golden: a foreign DUE row (real manifest key) is byte-identical after this suite drains a run-unique row', async () => {
+    // seed a foreign row exactly as a sibling suite would leave one: a REAL manifest key, fresh `pending`
+    // (no lease — the schema's lease_iff_in_progress CHECK forbids a lease on a pending row). A fresh pending
+    // row IS claimable/due. If this suite ever claimed by real keys + a big batch (the pre-fix hazard), THIS
+    // row's status/attempts/lease/last_error would move.
+    const fid = `obx_foreign_${RUN}`
+    await db().query(
+      `INSERT INTO meta_automation_outbox (id, event_type, payload, automation_depth, manifest_version, event_id)
+       VALUES ($1,'multitable.record.updated','{}'::jsonb,0,1,$2)`,
+      [fid, `evt_foreign_${RUN}`],
+    )
+    await db().query(
+      `INSERT INTO meta_automation_outbox_consumer (outbox_id, consumer_key, status)
+       VALUES ($1,'automation-record-trigger','pending')`,
+      [fid],
+    )
+    enqueued.push(fid)
+    const before = await consumerSnapshot(fid)
+    // run THIS suite's isolation pattern: enqueue a run-unique row and drain it via a run-unique tick
+    const keyF = `uiso_${RUN}`
+    const r = await enqueueUnique('multitable.record.updated', `evt_${RUN}_iso`, keyF)
+    await runDispatchTick(db(), uniqueRegistry(keyF, () => {}))
+    expect(await consumerStatuses(r.outboxId)).toEqual({ [keyF]: 'done' }) // our own row DID drain
+    // the foreign row is UNTOUCHED — a run-unique claim can never reach a real-key row
+    expect(await consumerSnapshot(fid)).toEqual(before) // status + attempts + lease + last_error all identical
+    expect(before).toMatchObject({ status: 'pending', attempts: 0, last_error: '' })
   })
 
   test('flag OFF is byte-neutral: produce → null + zero rows; boot → null (no loop, no reads)', async () => {
@@ -233,7 +266,6 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
   })
 
   test('V2: commit-then-crash-before-dispatch → rows are durable; a later tick (restart) delivers', async () => {
-    const res = await produceCommitted({ eventType: 'multitable.comment.created', eventId: `evt_${RUN}_v2`, payload: {} }, FLAG_ON)
     // "crash": no dispatcher runs. Rows sit durable & pending (run-unique key — only ours):
     const key2 = `uv2_${RUN}`
     const r2 = await enqueueUnique('multitable.comment.created', `evt_${RUN}_v2`, key2)

--- a/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
@@ -232,6 +232,20 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
     expect(Object.values(s).every((v) => v === 'pending')).toBe(true)
   })
 
+  test('boot lifecycle (flag ON): bootDurableDelivery returns a LIVE handle and stop() resolves cleanly — no rows touched', async () => {
+    // The index.ts wiring calls exactly this. A large interval means the first tick never fires before stop(),
+    // so booting the REAL six-key registry is safe on the shared CI DB (it claims nothing). This proves the
+    // start/stop lifecycle + shutdown hook path; per-row DELIVERY through the loop is proven by V2/V3 (tick)
+    // and the handler MAPPING by the unit suite. A `count(*)` before/after guards against a stray claim.
+    const before = await db().query('SELECT count(*)::int AS c FROM meta_automation_outbox_consumer WHERE status <> \'pending\'')
+    const handle = bootDurableDelivery(db(), recordingHandlers([]), noopObserver, { env: FLAG_ON, intervalMs: 3_600_000 })
+    expect(handle).not.toBeNull()
+    await handle!.stop() // resolves promptly (no in-flight adapter) — the shutdown path
+    await handle!.stop() // idempotent second stop must not throw
+    const after = await db().query('SELECT count(*)::int AS c FROM meta_automation_outbox_consumer WHERE status <> \'pending\'')
+    expect(Number(after.rows[0].c)).toBe(Number(before.rows[0].c)) // no tick fired → no claim → no foreign-row mutation
+  })
+
   test('flag ON: a PermanentDeliveryFailure handler poisons its row to dead_letter (run-unique key — no shared-row pollution)', async () => {
     const keyP = `upoison_${RUN}`
     const res = await enqueueUnique('multitable.record.updated', `evt_${RUN}_poison`, keyP)

--- a/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
@@ -47,6 +47,7 @@ import { claimDueConsumers, completeConsumer, type ClaimedConsumer } from '../..
 import { runDispatchTick, ConsumerAdapterRegistry, type AdapterOutcome, type DispatchLoopObserver } from '../../src/multitable/automation-durable-dispatch-loop'
 import type { TransactionalQueryable } from '../../src/multitable/pg-transaction-guard'
 import { enqueueOutboxEvent } from '../../src/multitable/automation-outbox-enqueue'
+import { buildDurableConsumerHandlers, type DurableDeliveryServices } from '../../src/multitable/automation-durable-consumer-handlers'
 import { deriveOutboundIdempotencyKey } from '../../src/multitable/automation-action-idempotency'
 import { APPROVAL_COMPLETION_CONSUMERS, type RoutingManifest } from '../../src/multitable/automation-routing-manifest'
 import type { PoolClient } from 'pg'
@@ -353,5 +354,46 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
 
     // the zombie finally tries to write its terminal state: fence-CAS → 0 rows (single-writer persisted state)
     expect(await completeConsumer(db(), res.outboxId, keyZ, z!.fence)).toBe(false)
+  })
+
+  test('S7-composed: producer seam → real dispatch CLAIM → the REAL record-trigger handler delegates to handleEvent → row done', async () => {
+    // Composes the S5 wiring end-to-end on a run-unique key (no foreign-row claim): the outbox row is claimed
+    // by the ACTUAL dispatch tick, the claimed row flows into the REAL `automation-record-trigger` handler from
+    // buildDurableConsumerHandlers (not a synthetic recorder), and that handler delegates to the SAME
+    // AutomationService.handleEvent the legacy bus subscriber calls — proving the ClaimedConsumer shape → real
+    // handler → real method path holds under a live claim. Idempotency of the real handler is the sink's own
+    // event_fires lease (S6/#4426), exercised by the automation-service suites; here the handler is a spy so the
+    // composition stays hermetic and shared-DB-safe.
+    const calls: Array<{ eventType: string; payload: unknown }> = []
+    const spyServices = {
+      automationService: {
+        handleApprovalCompletionEvent: async () => {},
+        handleApprovalCompletionTrigger: async () => {},
+        handleApprovalTaskCreatedTrigger: async () => {},
+        handleEvent: async (eventType: string, payload: unknown) => { calls.push({ eventType, payload }) },
+      },
+      projectionService: { reconcile: async () => undefined },
+      webhookService: { deliverEvent: async () => [] },
+    } as unknown as DurableDeliveryServices
+    const realHandlers = buildDurableConsumerHandlers(spyServices)
+
+    const keyC = `ucomposed_${RUN}`
+    const res = await enqueueUnique('multitable.record.created', `evt_${RUN}_composed`, keyC)
+    // route the run-unique key to the REAL record-trigger handler (invoked with the live ClaimedConsumer)
+    const registry = new ConsumerAdapterRegistry()
+    registry.register({
+      key: keyC,
+      async handle(event): Promise<AdapterOutcome> {
+        await realHandlers['automation-record-trigger'](event)
+        return { outcome: 'success' }
+      },
+    })
+    await runDispatchTick(db(), registry)
+
+    expect(await consumerStatuses(res.outboxId)).toEqual({ [keyC]: 'done' })
+    // the REAL handler forwarded to handleEvent with the durable identity overlaid (fence-free stable eventId)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].eventType).toBe('multitable.record.created')
+    expect((calls[0].payload as { _eventId?: string })._eventId).toBe(`evt_${RUN}_composed`)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
@@ -270,7 +270,7 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
     let outboxId = ''
     try {
       await client.query('BEGIN')
-      const res = await produceAutomationEvent({ isTransaction: true, query: (s, p) => client.query(s, p) }, { eventType: 'form.submitted', eventId: `evt_${RUN}_v1`, payload: {} }, FLAG_ON)
+      const res = await produceAutomationEvent({ isTransaction: true, query: (s, p) => client.query(s, p) }, { eventType: 'multitable.form.submitted', eventId: `evt_${RUN}_v1`, payload: {} }, FLAG_ON)
       outboxId = res!.outboxId
       await client.query('ROLLBACK') // crash before commit
     } finally {
@@ -294,7 +294,7 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
 
   test('V3: crash-after-claim → reclaim redelivers (at-least-once) with the SAME stable eventId across fences', async () => {
     const key3 = `uv3_${RUN}`
-    const res = await enqueueUnique('form.submitted', `evt_${RUN}_v3`, key3)
+    const res = await enqueueUnique('multitable.form.submitted', `evt_${RUN}_v3`, key3)
     // worker A claims its OWN run-unique row and "crashes" (never resolves)
     const claimed = await claimDueConsumers(db(), { consumerKeys: [key3], batchSize: 50 })
     const mine = claimed.find((c) => c.outboxId === res.outboxId)

--- a/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
@@ -1,0 +1,200 @@
+/**
+ * P2 durable-delivery — S4-b/S5 activation seam + S7 crash-injection V-series (real DB).
+ *
+ * Activation (flag semantics — the byte-neutral proof):
+ *   - flag OFF: produceAutomationEvent → null + ZERO rows; bootDurableDelivery → null (no registry, no loop);
+ *   - missing handler → boot throws before any claim; incomplete registry → completeness assertion throws;
+ *   - flag ON: produce inside a txn → boot → loop drains the fan-out; PermanentDeliveryFailure → dead_letter.
+ *
+ * Crash-injection V-series (crash = "no further calls from that worker" + lease expiry — the same observable
+ * a killed process leaves):
+ *   V1 produce-then-crash-BEFORE-commit  → ROLLBACK: zero rows, zero deliveries (nothing phantom).
+ *   V2 commit-then-crash-before-dispatch → rows durable; a later tick ("restarted worker") delivers.
+ *   V3 crash-after-claim                 → lease expiry → reclaim redelivers: at-least-once, and the handler
+ *                                          sees the SAME stable eventId on every delivery (fence-free identity).
+ *   V4 zombie + reclaimer both live      → both sides can reach "send"; the outbound idempotency SEED
+ *                                          (eventId + consumer_key) is IDENTICAL across fences (#4203 §340 —
+ *                                          the endpoint dedups), and the zombie's terminal write hits 0 rows.
+ *
+ * Uses the real manifest consumer keys; adapters defensively skip rows not seeded by this file (shared CI DB).
+ * Two-point wired (plugin-tests.yml + vitest.config.ts exclude).
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import {
+  bootDurableDelivery,
+  buildConsumerAdapterRegistry,
+  DURABLE_CONSUMER_KEYS,
+  PermanentDeliveryFailure,
+  produceAutomationEvent,
+  type DurableConsumerHandlers,
+} from '../../src/multitable/automation-durable-activation'
+import { claimDueConsumers, completeConsumer, type ClaimedConsumer } from '../../src/multitable/automation-durable-dispatcher'
+import { runDispatchTick } from '../../src/multitable/automation-durable-dispatch-loop'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const db = () => poolManager.get()
+const RUN = randomUUID()
+const FLAG_ON = { AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv
+const FLAG_OFF = {} as NodeJS.ProcessEnv
+const enqueued: string[] = []
+
+// Handlers that record deliveries for OUR rows and defensively re-throw for foreign rows (retryable → left
+// reclaimable for whichever suite owns them; never terminated by us).
+function recordingHandlers(seen: Array<{ key: string; eventId: string; fence: string }>, opts: { failBridgePermanently?: boolean } = {}): DurableConsumerHandlers {
+  const make = (key: string) => async (e: ClaimedConsumer) => {
+    if (!e.eventId.includes(RUN)) throw new Error('foreign row — not ours, stay reclaimable')
+    seen.push({ key, eventId: e.eventId, fence: e.fence })
+    if (opts.failBridgePermanently && key === 'approval-bridge') throw new PermanentDeliveryFailure('ratified permanent rejection')
+  }
+  return Object.fromEntries(DURABLE_CONSUMER_KEYS.map((k) => [k, make(k)])) as unknown as DurableConsumerHandlers
+}
+
+async function consumerStatuses(outboxId: string) {
+  const { rows } = await db().query(
+    'SELECT consumer_key, status FROM meta_automation_outbox_consumer WHERE outbox_id=$1',
+    [outboxId],
+  )
+  return Object.fromEntries((rows as Array<{ consumer_key: string; status: string }>).map((r) => [r.consumer_key, r.status]))
+}
+
+describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection (real DB)', () => {
+  afterAll(async () => {
+    if (enqueued.length) {
+      await db().query('DELETE FROM meta_automation_outbox WHERE id = ANY($1)', [enqueued]).catch(() => {})
+    }
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('flag OFF is byte-neutral: produce → null + zero rows; boot → null (no loop, no reads)', async () => {
+    const before = await db().query('SELECT count(*)::int AS c FROM meta_automation_outbox')
+    const res = await produceAutomationEvent(db(), { eventType: 'approval.approved', eventId: `evt_${RUN}_off`, payload: {} }, FLAG_OFF)
+    expect(res).toBeNull()
+    const after = await db().query('SELECT count(*)::int AS c FROM meta_automation_outbox')
+    expect(Number(after.rows[0].c)).toBe(Number(before.rows[0].c)) // nothing written
+    expect(bootDurableDelivery(db(), recordingHandlers([]), { env: FLAG_OFF })).toBeNull()
+  })
+
+  test('boot fails loudly on a missing handler (before any claim)', () => {
+    const handlers = recordingHandlers([]) as Record<string, unknown>
+    delete handlers['approval-projection']
+    expect(() => bootDurableDelivery(db(), handlers as unknown as DurableConsumerHandlers, { env: FLAG_ON })).toThrow(/missing handler.*approval-projection/)
+  })
+
+  test('registry from handlers passes the bidirectional manifest completeness assertion', () => {
+    const registry = buildConsumerAdapterRegistry(recordingHandlers([]))
+    expect(registry.keys().sort()).toEqual([...DURABLE_CONSUMER_KEYS].sort())
+  })
+
+  test('flag ON end-to-end: produce (in txn) → boot → loop drains the fan-out; permanent failure → dead_letter', async () => {
+    const raw = db().getInternalPool()
+    const client = await raw.connect()
+    let outboxId = ''
+    try {
+      await client.query('BEGIN')
+      const res = await produceAutomationEvent(client, { eventType: 'approval.approved', eventId: `evt_${RUN}_e2e`, payload: { i: 1 } }, FLAG_ON)
+      outboxId = res!.outboxId
+      enqueued.push(outboxId)
+      await client.query('COMMIT')
+    } finally {
+      client.release()
+    }
+    const seen: Array<{ key: string; eventId: string; fence: string }> = []
+    const handle = bootDurableDelivery(db(), recordingHandlers(seen, { failBridgePermanently: true }), {
+      env: FLAG_ON,
+      intervalMs: 100,
+      batchSize: 500,
+    })
+    expect(handle).toBeTruthy()
+    try {
+      const deadline = Date.now() + 8_000
+      while (Date.now() < deadline) {
+        const s = await consumerStatuses(outboxId)
+        if (s['approval-trigger'] === 'done' && s['approval-projection'] === 'done' && s['approval-bridge'] === 'dead_letter') break
+        await new Promise((r) => setTimeout(r, 100))
+      }
+    } finally {
+      await handle!.stop()
+    }
+    const s = await consumerStatuses(outboxId)
+    expect(s['approval-trigger']).toBe('done')
+    expect(s['approval-projection']).toBe('done')
+    expect(s['approval-bridge']).toBe('dead_letter') // PermanentDeliveryFailure → poison
+    expect(seen.every((x) => x.eventId === `evt_${RUN}_e2e`)).toBe(true) // stable original identity delivered
+  }, 15_000)
+
+  test('V1: produce-then-crash-BEFORE-commit → zero rows, zero deliveries', async () => {
+    const raw = db().getInternalPool()
+    const client = await raw.connect()
+    let outboxId = ''
+    try {
+      await client.query('BEGIN')
+      const res = await produceAutomationEvent(client, { eventType: 'form.submitted', eventId: `evt_${RUN}_v1`, payload: {} }, FLAG_ON)
+      outboxId = res!.outboxId
+      await client.query('ROLLBACK') // crash before commit
+    } finally {
+      client.release()
+    }
+    const { rows } = await db().query('SELECT count(*)::int AS c FROM meta_automation_outbox WHERE id=$1', [outboxId])
+    expect(Number(rows[0].c)).toBe(0)
+  })
+
+  test('V2: commit-then-crash-before-dispatch → rows are durable; a later tick (restart) delivers', async () => {
+    const res = await produceAutomationEvent(db(), { eventType: 'multitable.comment.created', eventId: `evt_${RUN}_v2`, payload: {} }, FLAG_ON)
+    enqueued.push(res!.outboxId)
+    // "crash": no dispatcher runs. Rows sit durable & pending:
+    expect(await consumerStatuses(res!.outboxId)).toEqual({ 'webhook-event-bridge': 'pending' })
+    // "restart": a fresh tick delivers.
+    const seen: Array<{ key: string; eventId: string; fence: string }> = []
+    await runDispatchTick(db(), buildConsumerAdapterRegistry(recordingHandlers(seen)), { batchSize: 500 })
+    expect(await consumerStatuses(res!.outboxId)).toEqual({ 'webhook-event-bridge': 'done' })
+    expect(seen.some((x) => x.eventId === `evt_${RUN}_v2`)).toBe(true)
+  })
+
+  test('V3: crash-after-claim → reclaim redelivers (at-least-once) with the SAME stable eventId across fences', async () => {
+    const res = await produceAutomationEvent(db(), { eventType: 'form.submitted', eventId: `evt_${RUN}_v3`, payload: {} }, FLAG_ON)
+    enqueued.push(res!.outboxId)
+    // worker A claims and "crashes" (never resolves)
+    const [a] = await claimDueConsumers(db(), { consumerKeys: ['automation-record-trigger'], batchSize: 500 })
+    const mine = a && a.outboxId === res!.outboxId ? a : (await claimDueConsumers(db(), { consumerKeys: ['automation-record-trigger'], batchSize: 500 })).find((c) => c.outboxId === res!.outboxId)
+    expect(mine?.eventId).toBe(`evt_${RUN}_v3`)
+    await db().query(`UPDATE meta_automation_outbox_consumer SET lease_expires_at = now() - interval '1 min' WHERE outbox_id=$1`, [res!.outboxId])
+    // worker B (restart) redelivers through the loop
+    const seen: Array<{ key: string; eventId: string; fence: string }> = []
+    await runDispatchTick(db(), buildConsumerAdapterRegistry(recordingHandlers(seen)), { batchSize: 500 })
+    const delivered = seen.find((x) => x.eventId === `evt_${RUN}_v3`)
+    expect(delivered).toBeTruthy() // at-least-once survived the crash
+    expect(delivered!.eventId).toBe(mine!.eventId) // identity is fence-free — same dedup/idempotency seed
+    expect(Number(delivered!.fence)).toBeGreaterThan(Number(mine!.fence)) // genuinely a different claim epoch
+  })
+
+  test('V4: zombie + reclaimer both reach send → identical idempotency SEED across fences; zombie terminal write = 0 rows', async () => {
+    const res = await produceAutomationEvent(db(), { eventType: 'multitable.record.updated', eventId: `evt_${RUN}_v4`, payload: {} }, FLAG_ON)
+    enqueued.push(res!.outboxId)
+    // zombie Z claims (fence F1) and stalls past its lease — but stays alive
+    const zAll = await claimDueConsumers(db(), { consumerKeys: ['automation-record-trigger', 'webhook-event-bridge'], batchSize: 500 })
+    const z = zAll.find((c) => c.outboxId === res!.outboxId && c.consumerKey === 'automation-record-trigger')
+    expect(z).toBeTruthy()
+    const zombieSendKeySeed = `${z!.eventId}::${z!.consumerKey}` // the lock's outbound key basis: stable event+action identity, NO fence/attempt
+    await db().query(
+      `UPDATE meta_automation_outbox_consumer SET lease_expires_at = now() - interval '1 min' WHERE outbox_id=$1 AND consumer_key='automation-record-trigger'`,
+      [res!.outboxId],
+    )
+    // reclaimer R delivers (fence F2) — R's send uses ITS row's identity
+    const seen: Array<{ key: string; eventId: string; fence: string }> = []
+    await runDispatchTick(db(), buildConsumerAdapterRegistry(recordingHandlers(seen)), { batchSize: 500 })
+    const r = seen.find((x) => x.eventId === `evt_${RUN}_v4` && x.key === 'automation-record-trigger')
+    expect(r).toBeTruthy()
+    const reclaimerSendKeySeed = `${r!.eventId}::${r!.key}`
+    expect(reclaimerSendKeySeed).toBe(zombieSendKeySeed) // SAME key at the endpoint → double send collapses to one effect
+    expect(Number(r!.fence)).toBeGreaterThan(Number(z!.fence)) // and they really were different claim epochs
+    // the zombie finally tries to write its terminal state: fence-CAS → 0 rows (single-writer persisted state)
+    expect(await completeConsumer(db(), res!.outboxId, 'automation-record-trigger', z!.fence)).toBe(false)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
@@ -283,7 +283,7 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
   test('V2: commit-then-crash-before-dispatch → rows are durable; a later tick (restart) delivers', async () => {
     // "crash": no dispatcher runs. Rows sit durable & pending (run-unique key — only ours):
     const key2 = `uv2_${RUN}`
-    const r2 = await enqueueUnique('multitable.comment.created', `evt_${RUN}_v2`, key2)
+    const r2 = await enqueueUnique('multitable.record.deleted', `evt_${RUN}_v2`, key2)
     expect(await consumerStatuses(r2.outboxId)).toEqual({ [key2]: 'pending' })
     // "restart": a fresh tick delivers.
     const seen: string[] = []

--- a/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
@@ -33,7 +33,9 @@ import {
   type DurableConsumerHandlers,
 } from '../../src/multitable/automation-durable-activation'
 import { claimDueConsumers, completeConsumer, type ClaimedConsumer } from '../../src/multitable/automation-durable-dispatcher'
-import { runDispatchTick } from '../../src/multitable/automation-durable-dispatch-loop'
+import { runDispatchTick, type DispatchLoopObserver } from '../../src/multitable/automation-durable-dispatch-loop'
+import type { TransactionalQueryable } from '../../src/multitable/pg-transaction-guard'
+import type { OutboxEventInput } from '../../src/multitable/automation-outbox-enqueue'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const db = () => poolManager.get()
@@ -41,6 +43,29 @@ const RUN = randomUUID()
 const FLAG_ON = { AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv
 const FLAG_OFF = {} as NodeJS.ProcessEnv
 const enqueued: string[] = []
+/** Required telemetry sink (boot now demands one, per the loop's observability doctrine). */
+const noopObserver: DispatchLoopObserver = {
+  onUnknownConsumerKeys: () => {},
+  onTickError: () => {},
+  onHeartbeatError: () => {},
+  onClaimTimePoison: () => {},
+}
+/** Produce inside a REAL committed transaction (the enqueue txn probe requires one) and return the result. */
+async function produceCommitted(input: OutboxEventInput, env: NodeJS.ProcessEnv) {
+  const client = await db().getInternalPool().connect()
+  try {
+    await client.query('BEGIN')
+    const trx: TransactionalQueryable = { isTransaction: true, query: (sql, params) => client.query(sql, params) }
+    const res = await produceAutomationEvent(trx, input, env)
+    await client.query('COMMIT')
+    return res
+  } catch (e) {
+    await client.query('ROLLBACK').catch(() => {})
+    throw e
+  } finally {
+    client.release()
+  }
+}
 
 // Handlers that record deliveries for OUR rows and defensively re-throw for foreign rows (retryable → left
 // reclaimable for whichever suite owns them; never terminated by us).
@@ -74,17 +99,17 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
 
   test('flag OFF is byte-neutral: produce → null + zero rows; boot → null (no loop, no reads)', async () => {
     const before = await db().query('SELECT count(*)::int AS c FROM meta_automation_outbox')
-    const res = await produceAutomationEvent(db(), { eventType: 'approval.approved', eventId: `evt_${RUN}_off`, payload: {} }, FLAG_OFF)
+    const res = await produceAutomationEvent(db() as unknown as TransactionalQueryable, { eventType: 'approval.approved', eventId: `evt_${RUN}_off`, payload: {} }, FLAG_OFF)
     expect(res).toBeNull()
     const after = await db().query('SELECT count(*)::int AS c FROM meta_automation_outbox')
     expect(Number(after.rows[0].c)).toBe(Number(before.rows[0].c)) // nothing written
-    expect(bootDurableDelivery(db(), recordingHandlers([]), { env: FLAG_OFF })).toBeNull()
+    expect(bootDurableDelivery(db(), recordingHandlers([]), noopObserver, { env: FLAG_OFF })).toBeNull()
   })
 
   test('boot fails loudly on a missing handler (before any claim)', () => {
     const handlers = recordingHandlers([]) as Record<string, unknown>
     delete handlers['approval-projection']
-    expect(() => bootDurableDelivery(db(), handlers as unknown as DurableConsumerHandlers, { env: FLAG_ON })).toThrow(/missing handler.*approval-projection/)
+    expect(() => bootDurableDelivery(db(), handlers as unknown as DurableConsumerHandlers, noopObserver, { env: FLAG_ON })).toThrow(/missing handler.*approval-projection/)
   })
 
   test('registry from handlers passes the bidirectional manifest completeness assertion', () => {
@@ -98,7 +123,7 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
     let outboxId = ''
     try {
       await client.query('BEGIN')
-      const res = await produceAutomationEvent(client, { eventType: 'approval.approved', eventId: `evt_${RUN}_e2e`, payload: { i: 1 } }, FLAG_ON)
+      const res = await produceAutomationEvent({ isTransaction: true, query: (s, p) => client.query(s, p) }, { eventType: 'approval.approved', eventId: `evt_${RUN}_e2e`, payload: { i: 1 } }, FLAG_ON)
       outboxId = res!.outboxId
       enqueued.push(outboxId)
       await client.query('COMMIT')
@@ -106,7 +131,7 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
       client.release()
     }
     const seen: Array<{ key: string; eventId: string; fence: string }> = []
-    const handle = bootDurableDelivery(db(), recordingHandlers(seen, { failBridgePermanently: true }), {
+    const handle = bootDurableDelivery(db(), recordingHandlers(seen, { failBridgePermanently: true }), noopObserver, {
       env: FLAG_ON,
       intervalMs: 100,
       batchSize: 500,
@@ -135,7 +160,7 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
     let outboxId = ''
     try {
       await client.query('BEGIN')
-      const res = await produceAutomationEvent(client, { eventType: 'form.submitted', eventId: `evt_${RUN}_v1`, payload: {} }, FLAG_ON)
+      const res = await produceAutomationEvent({ isTransaction: true, query: (s, p) => client.query(s, p) }, { eventType: 'form.submitted', eventId: `evt_${RUN}_v1`, payload: {} }, FLAG_ON)
       outboxId = res!.outboxId
       await client.query('ROLLBACK') // crash before commit
     } finally {
@@ -146,7 +171,7 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
   })
 
   test('V2: commit-then-crash-before-dispatch → rows are durable; a later tick (restart) delivers', async () => {
-    const res = await produceAutomationEvent(db(), { eventType: 'multitable.comment.created', eventId: `evt_${RUN}_v2`, payload: {} }, FLAG_ON)
+    const res = await produceCommitted({ eventType: 'multitable.comment.created', eventId: `evt_${RUN}_v2`, payload: {} }, FLAG_ON)
     enqueued.push(res!.outboxId)
     // "crash": no dispatcher runs. Rows sit durable & pending:
     expect(await consumerStatuses(res!.outboxId)).toEqual({ 'webhook-event-bridge': 'pending' })
@@ -158,7 +183,7 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
   })
 
   test('V3: crash-after-claim → reclaim redelivers (at-least-once) with the SAME stable eventId across fences', async () => {
-    const res = await produceAutomationEvent(db(), { eventType: 'form.submitted', eventId: `evt_${RUN}_v3`, payload: {} }, FLAG_ON)
+    const res = await produceCommitted({ eventType: 'form.submitted', eventId: `evt_${RUN}_v3`, payload: {} }, FLAG_ON)
     enqueued.push(res!.outboxId)
     // worker A claims and "crashes" (never resolves)
     const [a] = await claimDueConsumers(db(), { consumerKeys: ['automation-record-trigger'], batchSize: 500 })
@@ -175,7 +200,7 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
   })
 
   test('V4: zombie + reclaimer both reach send → identical idempotency SEED across fences; zombie terminal write = 0 rows', async () => {
-    const res = await produceAutomationEvent(db(), { eventType: 'multitable.record.updated', eventId: `evt_${RUN}_v4`, payload: {} }, FLAG_ON)
+    const res = await produceCommitted({ eventType: 'multitable.record.updated', eventId: `evt_${RUN}_v4`, payload: {} }, FLAG_ON)
     enqueued.push(res!.outboxId)
     // zombie Z claims (fence F1) and stalls past its lease — but stays alive
     const zAll = await claimDueConsumers(db(), { consumerKeys: ['automation-record-trigger', 'webhook-event-bridge'], batchSize: 500 })

--- a/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-durable-activation-realdb.test.ts
@@ -33,9 +33,36 @@ import {
   type DurableConsumerHandlers,
 } from '../../src/multitable/automation-durable-activation'
 import { claimDueConsumers, completeConsumer, type ClaimedConsumer } from '../../src/multitable/automation-durable-dispatcher'
-import { runDispatchTick, type DispatchLoopObserver } from '../../src/multitable/automation-durable-dispatch-loop'
+import { runDispatchTick, ConsumerAdapterRegistry, type AdapterOutcome, type DispatchLoopObserver } from '../../src/multitable/automation-durable-dispatch-loop'
 import type { TransactionalQueryable } from '../../src/multitable/pg-transaction-guard'
-import type { OutboxEventInput } from '../../src/multitable/automation-outbox-enqueue'
+import { enqueueOutboxEvent, type OutboxEventInput } from '../../src/multitable/automation-outbox-enqueue'
+import { deriveOutboundIdempotencyKey } from '../../src/multitable/automation-action-idempotency'
+import { APPROVAL_COMPLETION_CONSUMERS, type RoutingManifest } from '../../src/multitable/automation-routing-manifest'
+import type { PoolClient } from 'pg'
+
+/**
+ * A REAL idempotent outbound endpoint model: it records ONE effect per distinct idempotency key and
+ * DEDUPS repeats. `send(key)` returns 'delivered' the first time a key is seen and 'deduped' after —
+ * the endpoint the lock's Class-B semantics assume (§340). `effects` counts distinct real-world effects.
+ */
+class IdempotentEndpoint {
+  private readonly seen = new Set<string>()
+  readonly sends: string[] = []
+  send(idempotencyKey: string): 'delivered' | 'deduped' {
+    this.sends.push(idempotencyKey)
+    if (this.seen.has(idempotencyKey)) return 'deduped'
+    this.seen.add(idempotencyKey)
+    return 'delivered'
+  }
+  get effects(): number {
+    return this.seen.size
+  }
+}
+
+/** A run-unique single-consumer manifest so a tick claims ONLY this test's rows on the shared CI DB. */
+function uniqueManifest(consumerKey: string, eventType: string): RoutingManifest {
+  return { version: 1, routes: { [eventType]: [consumerKey] } }
+}
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const db = () => poolManager.get()
@@ -65,6 +92,42 @@ async function produceCommitted(input: OutboxEventInput, env: NodeJS.ProcessEnv)
   } finally {
     client.release()
   }
+}
+
+/**
+ * Enqueue a durable event over a RUN-UNIQUE single-consumer manifest, committed. Used by the crash-injection
+ * V-series so their claim/reclaim ticks touch ONLY this test's rows — never a sibling suite's due rows on the
+ * shared CI DB (#4337 review P2: the prior version claimed foreign rows with real keys + batchSize:500,
+ * mutating their attempts/lease/last_error and risking dead-letter).
+ */
+async function enqueueUnique(eventType: string, eventId: string, consumerKey: string) {
+  const client = await db().getInternalPool().connect()
+  try {
+    await client.query('BEGIN')
+    const trx: TransactionalQueryable = { isTransaction: true, query: (sql, params) => client.query(sql, params) }
+    const res = await enqueueOutboxEvent(trx, { eventType, eventId, payload: {} }, uniqueManifest(consumerKey, eventType))
+    await client.query('COMMIT')
+    enqueued.push(res.outboxId)
+    return res
+  } catch (e) {
+    await client.query('ROLLBACK').catch(() => {})
+    throw e
+  } finally {
+    client.release()
+  }
+}
+
+/** A registry with a single run-unique consumer whose adapter calls `onDeliver(event)` then succeeds. */
+function uniqueRegistry(consumerKey: string, onDeliver: (e: ClaimedConsumer) => void): ConsumerAdapterRegistry {
+  const reg = new ConsumerAdapterRegistry()
+  reg.register({
+    key: consumerKey,
+    async handle(e): Promise<AdapterOutcome> {
+      onDeliver(e)
+      return { outcome: 'success' }
+    },
+  })
+  return reg
 }
 
 // Handlers that record deliveries for OUR rows and defensively re-throw for foreign rows (retryable → left
@@ -117,9 +180,10 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
     expect(registry.keys().sort()).toEqual([...DURABLE_CONSUMER_KEYS].sort())
   })
 
-  test('flag ON end-to-end: produce (in txn) → boot → loop drains the fan-out; permanent failure → dead_letter', async () => {
-    const raw = db().getInternalPool()
-    const client = await raw.connect()
+  test('flag ON: produce (in txn) via the REAL seam enqueues the exact manifest fan-out (approval → 3 consumers, pending)', async () => {
+    // Proves the real produce→manifest fan-out WITHOUT draining (no tick → cannot claim a sibling suite's
+    // rows on the shared CI DB — the drain/poison behavior is proven separately on run-unique keys below).
+    const client = await db().getInternalPool().connect()
     let outboxId = ''
     try {
       await client.query('BEGIN')
@@ -130,29 +194,27 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
     } finally {
       client.release()
     }
-    const seen: Array<{ key: string; eventId: string; fence: string }> = []
-    const handle = bootDurableDelivery(db(), recordingHandlers(seen, { failBridgePermanently: true }), noopObserver, {
-      env: FLAG_ON,
-      intervalMs: 100,
-      batchSize: 500,
-    })
-    expect(handle).toBeTruthy()
-    try {
-      const deadline = Date.now() + 8_000
-      while (Date.now() < deadline) {
-        const s = await consumerStatuses(outboxId)
-        if (s['approval-trigger'] === 'done' && s['approval-projection'] === 'done' && s['approval-bridge'] === 'dead_letter') break
-        await new Promise((r) => setTimeout(r, 100))
-      }
-    } finally {
-      await handle!.stop()
-    }
     const s = await consumerStatuses(outboxId)
-    expect(s['approval-trigger']).toBe('done')
-    expect(s['approval-projection']).toBe('done')
-    expect(s['approval-bridge']).toBe('dead_letter') // PermanentDeliveryFailure → poison
-    expect(seen.every((x) => x.eventId === `evt_${RUN}_e2e`)).toBe(true) // stable original identity delivered
-  }, 15_000)
+    expect(Object.keys(s).sort()).toEqual([...APPROVAL_COMPLETION_CONSUMERS].sort())
+    expect(Object.values(s).every((v) => v === 'pending')).toBe(true)
+  })
+
+  test('flag ON: a PermanentDeliveryFailure handler poisons its row to dead_letter (run-unique key — no shared-row pollution)', async () => {
+    const keyP = `upoison_${RUN}`
+    const res = await enqueueUnique('multitable.record.updated', `evt_${RUN}_poison`, keyP)
+    const registry = new ConsumerAdapterRegistry()
+    let handled = false
+    registry.register({
+      key: keyP,
+      async handle(): Promise<AdapterOutcome> {
+        handled = true
+        return { outcome: 'permanent_failure', reason: 'permanent_rejection' } // the mapped PermanentDeliveryFailure
+      },
+    })
+    await runDispatchTick(db(), registry)
+    expect(handled).toBe(true)
+    expect(await consumerStatuses(res.outboxId)).toEqual({ [keyP]: 'dead_letter' })
+  })
 
   test('V1: produce-then-crash-BEFORE-commit → zero rows, zero deliveries', async () => {
     const raw = db().getInternalPool()
@@ -172,54 +234,78 @@ describeIfDatabase('P2 durable-delivery S4-b/S5 activation + S7 crash-injection 
 
   test('V2: commit-then-crash-before-dispatch → rows are durable; a later tick (restart) delivers', async () => {
     const res = await produceCommitted({ eventType: 'multitable.comment.created', eventId: `evt_${RUN}_v2`, payload: {} }, FLAG_ON)
-    enqueued.push(res!.outboxId)
-    // "crash": no dispatcher runs. Rows sit durable & pending:
-    expect(await consumerStatuses(res!.outboxId)).toEqual({ 'webhook-event-bridge': 'pending' })
+    // "crash": no dispatcher runs. Rows sit durable & pending (run-unique key — only ours):
+    const key2 = `uv2_${RUN}`
+    const r2 = await enqueueUnique('multitable.comment.created', `evt_${RUN}_v2`, key2)
+    expect(await consumerStatuses(r2.outboxId)).toEqual({ [key2]: 'pending' })
     // "restart": a fresh tick delivers.
-    const seen: Array<{ key: string; eventId: string; fence: string }> = []
-    await runDispatchTick(db(), buildConsumerAdapterRegistry(recordingHandlers(seen)), { batchSize: 500 })
-    expect(await consumerStatuses(res!.outboxId)).toEqual({ 'webhook-event-bridge': 'done' })
-    expect(seen.some((x) => x.eventId === `evt_${RUN}_v2`)).toBe(true)
+    const seen: string[] = []
+    await runDispatchTick(db(), uniqueRegistry(key2, (e) => seen.push(e.eventId)))
+    expect(await consumerStatuses(r2.outboxId)).toEqual({ [key2]: 'done' })
+    expect(seen).toContain(`evt_${RUN}_v2`)
   })
 
   test('V3: crash-after-claim → reclaim redelivers (at-least-once) with the SAME stable eventId across fences', async () => {
-    const res = await produceCommitted({ eventType: 'form.submitted', eventId: `evt_${RUN}_v3`, payload: {} }, FLAG_ON)
-    enqueued.push(res!.outboxId)
-    // worker A claims and "crashes" (never resolves)
-    const [a] = await claimDueConsumers(db(), { consumerKeys: ['automation-record-trigger'], batchSize: 500 })
-    const mine = a && a.outboxId === res!.outboxId ? a : (await claimDueConsumers(db(), { consumerKeys: ['automation-record-trigger'], batchSize: 500 })).find((c) => c.outboxId === res!.outboxId)
+    const key3 = `uv3_${RUN}`
+    const res = await enqueueUnique('form.submitted', `evt_${RUN}_v3`, key3)
+    // worker A claims its OWN run-unique row and "crashes" (never resolves)
+    const claimed = await claimDueConsumers(db(), { consumerKeys: [key3], batchSize: 50 })
+    const mine = claimed.find((c) => c.outboxId === res.outboxId)
     expect(mine?.eventId).toBe(`evt_${RUN}_v3`)
-    await db().query(`UPDATE meta_automation_outbox_consumer SET lease_expires_at = now() - interval '1 min' WHERE outbox_id=$1`, [res!.outboxId])
+    await db().query(`UPDATE meta_automation_outbox_consumer SET lease_expires_at = now() - interval '1 min' WHERE outbox_id=$1`, [res.outboxId])
     // worker B (restart) redelivers through the loop
-    const seen: Array<{ key: string; eventId: string; fence: string }> = []
-    await runDispatchTick(db(), buildConsumerAdapterRegistry(recordingHandlers(seen)), { batchSize: 500 })
+    const seen: Array<{ eventId: string; fence: string }> = []
+    await runDispatchTick(db(), uniqueRegistry(key3, (e) => seen.push({ eventId: e.eventId, fence: e.fence })))
     const delivered = seen.find((x) => x.eventId === `evt_${RUN}_v3`)
     expect(delivered).toBeTruthy() // at-least-once survived the crash
     expect(delivered!.eventId).toBe(mine!.eventId) // identity is fence-free — same dedup/idempotency seed
     expect(Number(delivered!.fence)).toBeGreaterThan(Number(mine!.fence)) // genuinely a different claim epoch
   })
 
-  test('V4: zombie + reclaimer both reach send → identical idempotency SEED across fences; zombie terminal write = 0 rows', async () => {
-    const res = await produceCommitted({ eventType: 'multitable.record.updated', eventId: `evt_${RUN}_v4`, payload: {} }, FLAG_ON)
-    enqueued.push(res!.outboxId)
-    // zombie Z claims (fence F1) and stalls past its lease — but stays alive
-    const zAll = await claimDueConsumers(db(), { consumerKeys: ['automation-record-trigger', 'webhook-event-bridge'], batchSize: 500 })
-    const z = zAll.find((c) => c.outboxId === res!.outboxId && c.consumerKey === 'automation-record-trigger')
+  test('V4: zombie AND reclaimer BOTH reach send → a real idempotent endpoint collapses the double-send to ONE effect; zombie terminal write = 0 rows', async () => {
+    const keyZ = `uv4_${RUN}`
+    const res = await enqueueUnique('multitable.record.updated', `evt_${RUN}_v4`, keyZ)
+    const endpoint = new IdempotentEndpoint()
+    // the Class-B outbound identity is EVENT + ACTION (not consumer_key, which can't distinguish two actions
+    // in one consumer). We use the ledger's deriveOutboundIdempotencyKey(eventId, actionKey) as the seed.
+    const seedFor = (eventId: string) => deriveOutboundIdempotencyKey(eventId, `action:${keyZ}`)
+
+    // 1) zombie Z claims (fence F1) and ACTUALLY reaches send — then stalls past its lease but stays alive.
+    const zClaim = await claimDueConsumers(db(), { consumerKeys: [keyZ], batchSize: 50 })
+    const z = zClaim.find((c) => c.outboxId === res.outboxId)
     expect(z).toBeTruthy()
-    const zombieSendKeySeed = `${z!.eventId}::${z!.consumerKey}` // the lock's outbound key basis: stable event+action identity, NO fence/attempt
+    const zSend = endpoint.send(seedFor(z!.eventId)) // Z reaches the endpoint
+    expect(zSend).toBe('delivered')
     await db().query(
-      `UPDATE meta_automation_outbox_consumer SET lease_expires_at = now() - interval '1 min' WHERE outbox_id=$1 AND consumer_key='automation-record-trigger'`,
-      [res!.outboxId],
+      `UPDATE meta_automation_outbox_consumer SET lease_expires_at = now() - interval '1 min' WHERE outbox_id=$1 AND consumer_key=$2`,
+      [res.outboxId, keyZ],
     )
-    // reclaimer R delivers (fence F2) — R's send uses ITS row's identity
-    const seen: Array<{ key: string; eventId: string; fence: string }> = []
-    await runDispatchTick(db(), buildConsumerAdapterRegistry(recordingHandlers(seen)), { batchSize: 500 })
-    const r = seen.find((x) => x.eventId === `evt_${RUN}_v4` && x.key === 'automation-record-trigger')
-    expect(r).toBeTruthy()
-    const reclaimerSendKeySeed = `${r!.eventId}::${r!.key}`
-    expect(reclaimerSendKeySeed).toBe(zombieSendKeySeed) // SAME key at the endpoint → double send collapses to one effect
-    expect(Number(r!.fence)).toBeGreaterThan(Number(z!.fence)) // and they really were different claim epochs
+
+    // 2) reclaimer R claims (fence F2) and ALSO reaches send — through the real loop.
+    let rEventId = ''
+    let rFence = ''
+    await runDispatchTick(
+      db(),
+      uniqueRegistry(keyZ, (e) => {
+        rEventId = e.eventId
+        rFence = e.fence
+        endpoint.send(seedFor(e.eventId)) // R reaches the endpoint too — the double send
+      }),
+    )
+    expect(rEventId).toBe(`evt_${RUN}_v4`)
+    expect(Number(rFence)).toBeGreaterThan(Number(z!.fence)) // genuinely different claim epochs (F2 > F1)
+
+    // BOTH reached send (2 sends), but the idempotent endpoint recorded exactly ONE effect — the double
+    // send collapsed because Z and R derived the IDENTICAL seed (event+action identity, fence-free).
+    expect(endpoint.sends).toHaveLength(2)
+    expect(endpoint.effects).toBe(1)
+
+    // POSITIVE CONTROL: a send with a DIFFERENT event identity is a distinct effect — the endpoint is not
+    // trivially collapsing everything (so the effects===1 above is meaningful, not vacuous).
+    expect(endpoint.send(seedFor('some-other-event'))).toBe('delivered')
+    expect(endpoint.effects).toBe(2)
+
     // the zombie finally tries to write its terminal state: fence-CAS → 0 rows (single-writer persisted state)
-    expect(await completeConsumer(db(), res!.outboxId, 'automation-record-trigger', z!.fence)).toBe(false)
+    expect(await completeConsumer(db(), res.outboxId, keyZ, z!.fence)).toBe(false)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-automation-event-fires-lease-realdb.db.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-event-fires-lease-realdb.db.test.ts
@@ -59,7 +59,7 @@ describeDb('S6 event_fires lease claim/reclaim (real DB, isolated schema)', () =
 
   it('fresh claim leases the row (in_progress, fence 1); markDone fence-CAS → done, lease cleared', async () => {
     const c = await claimEventFiresLease(db, RULE, 'e1', 60_000)
-    expect(c).not.toBe('skip')
+    expect(typeof c).toBe('object')
     const r = await row('e1')
     expect(r).toMatchObject({ status: 'in_progress', fence: '1', attempts: 1 })
     expect(r.lease).not.toBeNull()
@@ -67,24 +67,24 @@ describeDb('S6 event_fires lease claim/reclaim (real DB, isolated schema)', () =
     expect(await row('e1')).toMatchObject({ status: 'done', lease: null })
   })
 
-  it('a DONE delivery is skipped on re-claim (at-most-once for a completed event)', async () => {
+  it("a DONE delivery re-claims as 'done' (at-most-once for a completed event — resolve-permitting skip)", async () => {
     const c = await claimEventFiresLease(db, RULE, 'e2', 60_000)
     await markEventFiresDone(db, RULE, 'e2', (c as { fence: string }).fence)
-    expect(await claimEventFiresLease(db, RULE, 'e2', 60_000)).toBe('skip')
+    expect(await claimEventFiresLease(db, RULE, 'e2', 60_000)).toBe('done')
   })
 
-  it('a LIVE (unexpired) lease is skipped — a second worker does NOT double-run', async () => {
+  it("a LIVE (unexpired) lease claims as 'busy' — a second worker neither double-runs NOR resolves done (the composed-timing hole: a silent skip here would let an early outbox redelivery mark the crashed holder's work done forever)", async () => {
     await claimEventFiresLease(db, RULE, 'e3', 60_000) // long lease, still live
-    expect(await claimEventFiresLease(db, RULE, 'e3', 60_000)).toBe('skip')
+    expect(await claimEventFiresLease(db, RULE, 'e3', 60_000)).toBe('busy')
   })
 
   it('WINDOW-2: a crash (claim but no markDone) leaves an EXPIRED lease the next claim RECLAIMS (redelivers)', async () => {
     const first = await claimEventFiresLease(db, RULE, 'e4', 1) // 1ms lease → expires immediately
-    expect(first).not.toBe('skip')
+    expect(typeof first).toBe('object')
     // "crash": executeRule never finished, markEventFiresDone never called → the row is in_progress + expired.
     await new Promise((r) => setTimeout(r, 20))
     const reclaim = await claimEventFiresLease(db, RULE, 'e4', 60_000)
-    expect(reclaim).not.toBe('skip') // the work is RECLAIMED, not dropped (legacy tombstone would have skipped)
+    expect(typeof reclaim).toBe('object') // the work is RECLAIMED, not dropped (legacy tombstone would have skipped)
     expect(Number((reclaim as { fence: string }).fence)).toBe(2) // fence bumped on reclaim
     expect(await row('e4')).toMatchObject({ status: 'in_progress', attempts: 2 })
   })
@@ -106,6 +106,6 @@ describeDb('S6 event_fires lease claim/reclaim (real DB, isolated schema)', () =
     // legacy path: bare INSERT (status defaults to done)
     await sql`INSERT INTO meta_automation_event_fires (rule_id, dedup_key) VALUES (${RULE}, 'e6')`.execute(db)
     expect(await row('e6')).toMatchObject({ status: 'done', fence: '0' })
-    expect(await claimEventFiresLease(db, RULE, 'e6', 60_000)).toBe('skip') // already delivered under the old path
+    expect(await claimEventFiresLease(db, RULE, 'e6', 60_000)).toBe('done') // already delivered under the old path
   })
 })

--- a/packages/core-backend/tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts
@@ -82,7 +82,7 @@ describeIfDatabase('P2 durable-delivery S4-a — producer atomic enqueue (real D
     let outboxId = ''
     try {
       await client.query('BEGIN')
-      const res = await enqueueOutboxEvent(txn(client), { eventType: 'form.submitted', eventId: `evt_${RUN}_rollback`, payload: {} })
+      const res = await enqueueOutboxEvent(txn(client), { eventType: 'multitable.form.submitted', eventId: `evt_${RUN}_rollback`, payload: {} })
       outboxId = res.outboxId
       const inside = await client.query('SELECT count(*)::int AS c FROM meta_automation_outbox WHERE id=$1', [outboxId])
       expect(Number(inside.rows[0].c)).toBe(1) // visible INSIDE the txn (same client)...
@@ -131,7 +131,7 @@ describeIfDatabase('P2 durable-delivery S4-a — producer atomic enqueue (real D
     }
     try {
       await client.query('BEGIN')
-      await expect(enqueueOutboxEvent(failingTxn, { eventType: 'form.submitted', eventId: eid, payload: {} })).rejects.toThrow(/simulated DB failure/)
+      await expect(enqueueOutboxEvent(failingTxn, { eventType: 'multitable.form.submitted', eventId: eid, payload: {} })).rejects.toThrow(/simulated DB failure/)
       // the outbox INSERT (1st query) ran but is UNCOMMITTED — visible only inside this txn
       const inside = await client.query('SELECT count(*)::int AS c FROM meta_automation_outbox WHERE event_id=$1', [eid])
       expect(Number(inside.rows[0].c)).toBe(1)
@@ -150,13 +150,13 @@ describeIfDatabase('P2 durable-delivery S4-a — producer atomic enqueue (real D
   })
 
   test('identity/depth validation is a boundary error: blank eventId and bad depth throw before any SQL', async () => {
-    await expect(enqueueOutboxEvent(txnStub(), { eventType: 'form.submitted', eventId: '   ', payload: {} })).rejects.toThrow(/non-blank identity/)
-    await expect(enqueueOutboxEvent(txnStub(), { eventType: 'form.submitted', eventId: ' ﻿', payload: {} })).rejects.toThrow(/non-blank identity/)
+    await expect(enqueueOutboxEvent(txnStub(), { eventType: 'multitable.form.submitted', eventId: '   ', payload: {} })).rejects.toThrow(/non-blank identity/)
+    await expect(enqueueOutboxEvent(txnStub(), { eventType: 'multitable.form.submitted', eventId: ' ﻿', payload: {} })).rejects.toThrow(/non-blank identity/)
     await expect(
-      enqueueOutboxEvent(txnStub(), { eventType: 'form.submitted', eventId: `evt_${RUN}_d`, payload: {}, automationDepth: -1 }),
+      enqueueOutboxEvent(txnStub(), { eventType: 'multitable.form.submitted', eventId: `evt_${RUN}_d`, payload: {}, automationDepth: -1 }),
     ).rejects.toThrow(/automationDepth/)
     await expect(
-      enqueueOutboxEvent(txnStub(), { eventType: 'form.submitted', eventId: `evt_${RUN}_d2`, payload: {}, automationDepth: 1.5 }),
+      enqueueOutboxEvent(txnStub(), { eventType: 'multitable.form.submitted', eventId: `evt_${RUN}_d2`, payload: {}, automationDepth: 1.5 }),
     ).rejects.toThrow(/automationDepth/)
   })
 

--- a/packages/core-backend/tests/integration/multitable-automation-producer-emit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-producer-emit-realdb.test.ts
@@ -1,0 +1,104 @@
+/**
+ * P2 durable-delivery P1 #2 — producer REPLACE seam same-transaction goldens (real DB).
+ *
+ * The shared `enqueueRecordEventIfDurable` is what EVERY wired producer family calls, so one set of goldens
+ * here covers the produce-seam behavior for all of them:
+ *   - flag ON + COMMIT  → the outbox row + its manifest-expanded consumer rows are durable (pending).
+ *   - flag ON + ROLLBACK → zero rows (atomic with the source txn — a crash/abort before commit loses nothing).
+ *   - flag OFF          → no-op (no rows); the caller emits legacy post-commit instead.
+ * Rows are asserted by their own outbox id and cleaned up — never drained — so this never claims a sibling
+ * suite's row on the shared CI DB.
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { enqueueRecordEventIfDurable } from '../../src/multitable/automation-producer-emit'
+import type { TransactionalQueryable } from '../../src/multitable/pg-transaction-guard'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const db = () => poolManager.get()
+const RUN = randomUUID()
+const FLAG_ON = { AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv
+const FLAG_OFF = {} as NodeJS.ProcessEnv
+const seededOutboxIds: string[] = []
+
+/** Run `fn` with a real transaction handle wrapped as a TransactionalQueryable; commit or rollback per `commit`. */
+async function inTxn<T>(commit: boolean, fn: (trx: TransactionalQueryable) => Promise<T>): Promise<T> {
+  const client = await db().getInternalPool().connect()
+  try {
+    await client.query('BEGIN')
+    const trx: TransactionalQueryable = {
+      isTransaction: true,
+      query: async (sql, params) => {
+        const r = await client.query(sql, params)
+        return { rows: r.rows as Array<Record<string, unknown>>, rowCount: r.rowCount ?? null }
+      },
+    }
+    const out = await fn(trx)
+    await client.query(commit ? 'COMMIT' : 'ROLLBACK')
+    return out
+  } catch (e) {
+    await client.query('ROLLBACK').catch(() => {})
+    throw e
+  } finally {
+    client.release()
+  }
+}
+
+async function outboxCount(eventId: string): Promise<number> {
+  const { rows } = await db().query('SELECT count(*)::int AS c FROM meta_automation_outbox WHERE event_id=$1', [eventId])
+  return Number((rows[0] as { c: number }).c)
+}
+async function consumerKeys(eventId: string): Promise<string[]> {
+  const { rows } = await db().query(
+    `SELECT c.consumer_key FROM meta_automation_outbox_consumer c
+       JOIN meta_automation_outbox o ON o.id = c.outbox_id WHERE o.event_id=$1 ORDER BY 1`,
+    [eventId],
+  )
+  return (rows as Array<{ consumer_key: string }>).map((r) => r.consumer_key)
+}
+
+describeIfDatabase('P1#2 producer REPLACE seam same-txn goldens (real DB)', () => {
+  afterAll(async () => {
+    if (seededOutboxIds.length) {
+      await db().query('DELETE FROM meta_automation_outbox WHERE id = ANY($1)', [seededOutboxIds]).catch(() => {})
+    }
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('flag ON + COMMIT: the outbox row + its manifest consumer fan-out are durable', async () => {
+    const eventId = `evt_${RUN}_commit`
+    const enqueued = await inTxn(true, (trx) =>
+      enqueueRecordEventIfDurable(trx, 'multitable.record.updated', { sheetId: 's', recordId: 'r', _eventId: eventId, _automationDepth: 0 }, FLAG_ON),
+    )
+    expect(enqueued).toBe(true)
+    const { rows } = await db().query('SELECT id FROM meta_automation_outbox WHERE event_id=$1', [eventId])
+    if (rows[0]) seededOutboxIds.push((rows[0] as { id: string }).id)
+    expect(await outboxCount(eventId)).toBe(1)
+    // manifest v1: multitable.record.updated → automation-record-trigger + webhook-event-bridge
+    expect(await consumerKeys(eventId)).toEqual(['automation-record-trigger', 'webhook-event-bridge'])
+  })
+
+  test('flag ON + ROLLBACK: zero rows — the enqueue is atomic with the source transaction', async () => {
+    const eventId = `evt_${RUN}_rollback`
+    const enqueued = await inTxn(false, (trx) =>
+      enqueueRecordEventIfDurable(trx, 'multitable.record.updated', { sheetId: 's', recordId: 'r', _eventId: eventId, _automationDepth: 0 }, FLAG_ON),
+    )
+    expect(enqueued).toBe(true) // it ran inside the txn…
+    expect(await outboxCount(eventId)).toBe(0) // …but the rollback took the outbox row with it
+  })
+
+  test('flag OFF: no-op — zero rows (the caller emits legacy post-commit instead)', async () => {
+    const eventId = `evt_${RUN}_off`
+    const enqueued = await inTxn(true, (trx) =>
+      enqueueRecordEventIfDurable(trx, 'multitable.record.updated', { sheetId: 's', recordId: 'r', _eventId: eventId, _automationDepth: 0 }, FLAG_OFF),
+    )
+    expect(enqueued).toBe(false)
+    expect(await outboxCount(eventId)).toBe(0)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-automation-producer-family1-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-producer-family1-realdb.test.ts
@@ -1,0 +1,289 @@
+/**
+ * P2 durable-delivery P1#2e — producer family 1 (approval completion + approval.task_created) REPLACE goldens
+ * (real DB, through the REAL `ApprovalProductService` methods — createApproval / dispatchAction).
+ *
+ * Family 3's goldens covered the shared seam; family 2's the executor sites; THESE prove the approval SITE
+ * wiring end-to-end over real Postgres, for BOTH event families in family 1:
+ *
+ *   F1-G1  flag ON + approve-to-terminal (dispatchAction approve on a single-node template) → ONE
+ *          `approval.approved` outbox row fanned to EXACTLY [approval-bridge, approval-projection,
+ *          approval-trigger] (sorted, all pending), committed WITH the terminal transition; the legacy
+ *          `emitApprovalCompletionEvent` bus emit is SUPPRESSED (shared-bus spy sees nothing).
+ *   F1-G2  flag ON + createApproval with a pending assignment → per-recipient `approval.task_created` outbox
+ *          row to EXACTLY [approval-task-trigger], `event_id` BYTE-EQUAL to the legacy quad formula
+ *          (`approval-task:instanceId:nodeKey:entryEpoch:assigneeUserId`); legacy emit SUPPRESSED (spy silent).
+ *   F1-G3  flag ON + auto-approve-at-entry (requester-merge terminal at create) → ONE `approval.approved`
+ *          outbox row (fanned to the 3 completion consumers) and ZERO `approval.task_created` rows; spy silent.
+ *          NOTE (honest scope): in the current pure-cascade architecture the entry assignment is removed from
+ *          the resolution BEFORE `insertAssignments`, so `createdTaskEvents` is EMPTY here (verified) — this
+ *          golden proves the terminal fan-out + that no spurious task event is enqueued, but it does NOT
+ *          exercise a row that is inserted THEN deactivated in-txn. That live-then-deactivated recheck parity
+ *          is proven precisely by the shared-collector unit test (`approval-task-created-collector.test.ts`),
+ *          which is also the load-bearing catch for the "skip is_active recheck" mutation.
+ *   F1-G4  flag OFF → the legacy emits fire exactly as before (spy sees `approval.task_created` at create and
+ *          `approval.approved` at approve) and ZERO outbox rows exist — the REPLACE guard's other leg.
+ *   F1-G5  ATOMICITY: a Postgres-level failure injected into the completion outbox INSERT (a BEFORE-INSERT
+ *          trigger scoped to this instance's approval event_id) aborts the whole transaction — the terminal
+ *          transition AND the enqueue roll back together (instance stays pending, zero outbox rows). Mirrors
+ *          multitable-4196-classa-claim-realdb.test.ts's injectTrigger.
+ *
+ * Rows are asserted by this run's own instance ids (`payload->'approval'->>'instanceId'`) — never drained — so
+ * this suite cannot claim a sibling suite's rows on the shared CI DB. Two-point wired (vitest.config exclude +
+ * plugin-tests.yml run-list).
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { eventBus as integrationEventBus } from '../../src/integration/events/event-bus'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const DURABLE_FLAG = 'AUTOMATION_DURABLE_DELIVERY_ENABLED'
+
+const TS = Date.now()
+const BASE = `base_f1_${TS}`
+const SHEET = `sheet_f1_${TS}`
+const REQUESTER = `u_f1_req_${TS}`
+const APPROVER = `u_f1_appr_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+let approvals: ApprovalProductService
+let manualTemplateId = ''
+let autoTemplateId = ''
+
+/** Spy on the SHARED bus the approval emitters use (ApprovalCompletionEvent / ApprovalTaskCreatedEvent import
+ * the module-singleton `eventBus`; ApprovalProductService injects no bus). This observes exactly what a real
+ * post-commit subscriber would receive — so a SUPPRESSED (flag-ON) emit shows up as an empty spy. */
+const spy: Array<{ type: string; payload: Record<string, unknown> }> = []
+function resetSpy(): void { spy.length = 0 }
+
+/** This run's outbox rows for an instance id — joined to their consumer fan-out, never drained. */
+interface OutboxRow { id: string; event_type: string; event_id: string; payload: Record<string, unknown>; consumers: string[] }
+const outboxRowsForInstance = async (instanceId: string): Promise<OutboxRow[]> =>
+  (
+    await q(
+      `SELECT o.id, o.event_type, o.event_id, o.payload,
+              ARRAY(SELECT c.consumer_key FROM meta_automation_outbox_consumer c
+                     WHERE c.outbox_id = o.id ORDER BY c.consumer_key) AS consumers
+         FROM meta_automation_outbox o
+        WHERE o.payload->'approval'->>'instanceId' = $1
+        ORDER BY o.event_type, o.created_at`,
+      [instanceId],
+    )
+  ).rows as unknown as OutboxRow[]
+
+const consumerStatuses = async (outboxId: string): Promise<string[]> =>
+  ((await q('SELECT status FROM meta_automation_outbox_consumer WHERE outbox_id = $1 ORDER BY consumer_key', [outboxId])).rows as Array<{ status: string }>).map((r) => r.status)
+
+const instanceStatus = async (id: string): Promise<string> =>
+  ((await q('SELECT status FROM approval_instances WHERE id = $1', [id])).rows[0] as { status: string }).status
+
+function manualTemplateRequest() {
+  return {
+    key: `f1-manual-${TS}`,
+    name: 'F1 Manual Single Node',
+    formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: 'Start', config: {} },
+        { key: 'approval_1', type: 'approval', name: 'Only', config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }] } },
+        { key: 'end', type: 'end', name: 'End', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'e-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+  }
+}
+
+function autoTemplateRequest() {
+  return {
+    key: `f1-auto-${TS}`,
+    name: 'F1 Auto Approve At Entry',
+    formSchema: { fields: [{ id: 'summary', type: 'text', label: 'Summary', required: true }] },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: 'Start', config: {} },
+        { key: 'approval_1', type: 'approval', name: 'Auto', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: 'End', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'e-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+  }
+}
+
+const requesterActor = () => ({ userId: REQUESTER, userName: REQUESTER })
+const approverActor = () => ({ userId: APPROVER, userName: APPROVER })
+
+async function createManualInstance(): Promise<string> {
+  const dto = await approvals.createApproval({ templateId: manualTemplateId, formData: { summary: 'f1' } }, requesterActor())
+  return (dto as { id: string }).id
+}
+
+async function injectOutboxFailure(name: string, instanceId: string): Promise<void> {
+  await q(`CREATE OR REPLACE FUNCTION ${name}() RETURNS trigger AS $fn$
+           BEGIN
+             RAISE EXCEPTION 'F1 injected completion outbox failure' USING ERRCODE = 'P0001';
+           END $fn$ LANGUAGE plpgsql`)
+  await q(`CREATE TRIGGER ${name}_trg BEFORE INSERT ON meta_automation_outbox
+           FOR EACH ROW WHEN (NEW.event_id LIKE 'approval:${instanceId}:%') EXECUTE FUNCTION ${name}()`)
+}
+async function dropOutboxFailure(name: string): Promise<void> {
+  await q(`DROP TRIGGER IF EXISTS ${name}_trg ON meta_automation_outbox`).catch(() => {})
+  await q(`DROP FUNCTION IF EXISTS ${name}()`).catch(() => {})
+}
+
+describeIfDatabase('P1#2e — producer family 1: approval completion + task_created REPLACE (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'F1 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'F1 Sheet'])
+    await q(
+      `INSERT INTO permissions (code, name, description)
+       VALUES ('approvals:read','Approvals Read','F1'),('approvals:write','Approvals Write','F1'),('approvals:act','Approvals Act','F1')
+       ON CONFLICT (code) DO NOTHING`,
+    )
+    for (const uid of [REQUESTER, APPROVER]) {
+      await q(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+         VALUES ($1,$2,$1,'x','user','[]'::jsonb,TRUE,FALSE) ON CONFLICT (id) DO UPDATE SET is_active = TRUE`,
+        [uid, `${uid}@f1.test`],
+      )
+    }
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:write') ON CONFLICT DO NOTHING`, [REQUESTER])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'approvals:act') ON CONFLICT DO NOTHING`, [APPROVER])
+
+    approvals = new ApprovalProductService()
+    const manual = await approvals.createTemplate(manualTemplateRequest() as never)
+    manualTemplateId = (manual as { id: string }).id
+    await approvals.publishTemplate(manualTemplateId, { policy: { allowRevoke: true } } as never)
+    const auto = await approvals.createTemplate(autoTemplateRequest() as never)
+    autoTemplateId = (auto as { id: string }).id
+    await approvals.publishTemplate(autoTemplateId, { policy: { allowRevoke: true, autoApproval: { mergeWithRequester: true } } } as never)
+
+    for (const t of ['approval.approved', 'approval.rejected', 'approval.revoked', 'approval.cancelled', 'approval.task_created']) {
+      integrationEventBus.subscribe(t, (payload) => { spy.push({ type: t, payload: payload as Record<string, unknown> }) })
+    }
+  })
+
+  afterEach(() => {
+    delete process.env[DURABLE_FLAG]
+    resetSpy()
+  })
+
+  afterAll(async () => {
+    for (const tid of [manualTemplateId, autoTemplateId]) {
+      const instances = await q('SELECT id FROM approval_instances WHERE template_id = $1', [tid]).catch(() => ({ rows: [] as unknown[] }))
+      for (const row of instances.rows as Array<{ id: string }>) {
+        await q(`DELETE FROM meta_automation_outbox_consumer WHERE outbox_id IN (SELECT id FROM meta_automation_outbox WHERE payload->'approval'->>'instanceId' = $1)`, [row.id]).catch(() => {})
+        await q(`DELETE FROM meta_automation_outbox WHERE payload->'approval'->>'instanceId' = $1`, [row.id]).catch(() => {})
+        await q('DELETE FROM approval_assignments WHERE instance_id = $1', [row.id]).catch(() => {})
+        await q('DELETE FROM approval_records WHERE instance_id = $1', [row.id]).catch(() => {})
+        await q('DELETE FROM approval_instances WHERE id = $1', [row.id]).catch(() => {})
+      }
+      await q('DELETE FROM approval_templates WHERE id = $1', [tid]).catch(() => {})
+    }
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[REQUESTER, APPROVER]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[REQUESTER, APPROVER]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL is set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  // F1-G1 — approve to terminal ────────────────────────────────────────────────────────────────────────
+  test('F1-G1 flag ON approve-to-terminal: one approval.approved outbox row fanned to 3; legacy emit SUPPRESSED', async () => {
+    const id = await createManualInstance() // create runs flag-OFF: no outbox rows, spy sees the task event
+    resetSpy()
+    process.env[DURABLE_FLAG] = 'true'
+    await approvals.dispatchAction(id, { action: 'approve', comment: 'ok' } as never, approverActor())
+
+    expect(await instanceStatus(id)).toBe('approved')
+    const rows = await outboxRowsForInstance(id)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].event_type).toBe('approval.approved')
+    expect(rows[0].consumers).toEqual(['approval-bridge', 'approval-projection', 'approval-trigger'])
+    expect(await consumerStatuses(rows[0].id)).toEqual(['pending', 'pending', 'pending'])
+    expect(rows[0].event_id).toBe(rows[0].payload.eventId)
+    expect((rows[0].payload.transition as { toStatus: string }).toStatus).toBe('approved')
+    // REPLACE leg: the durable enqueue is the ONLY path — the legacy post-commit completion emit stayed silent.
+    expect(spy).toHaveLength(0)
+  })
+
+  // F1-G2 — task_created at create ─────────────────────────────────────────────────────────────────────
+  test('F1-G2 flag ON create: per-recipient approval.task_created outbox row, eventId byte-equal to legacy quad', async () => {
+    process.env[DURABLE_FLAG] = 'true'
+    const id = await createManualInstance()
+
+    expect(await instanceStatus(id)).toBe('pending')
+    const rows = await outboxRowsForInstance(id)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].event_type).toBe('approval.task_created')
+    expect(rows[0].consumers).toEqual(['approval-task-trigger'])
+    expect(await consumerStatuses(rows[0].id)).toEqual(['pending'])
+    // Byte-equality to the legacy quad formula, reconstructed from the durable assignment row itself.
+    const asg = (await q(
+      `SELECT node_key, entry_epoch, assignee_id FROM approval_assignments WHERE instance_id = $1 AND assignment_type = 'user' AND is_active = TRUE`,
+      [id],
+    )).rows[0] as { node_key: string; entry_epoch: number | string | null; assignee_id: string }
+    const expectedEventId = `approval-task:${id}:${asg.node_key}:${asg.entry_epoch === null ? 'null' : String(Number(asg.entry_epoch))}:${asg.assignee_id}`
+    expect(rows[0].event_id).toBe(expectedEventId)
+    expect(rows[0].payload.eventId).toBe(expectedEventId)
+    expect(asg.assignee_id).toBe(APPROVER)
+    // Legacy emit SUPPRESSED (flag ON) — the in-txn enqueue is the only delivery path.
+    expect(spy).toHaveLength(0)
+  })
+
+  // F1-G3 — auto-approve-at-entry (same-txn terminal) ──────────────────────────────────────────────────
+  test('F1-G3 flag ON auto-approve-at-entry: one approval.approved row, ZERO task_created rows; spy silent', async () => {
+    process.env[DURABLE_FLAG] = 'true'
+    const dto = await approvals.createApproval({ templateId: autoTemplateId, formData: { summary: 'auto' } }, requesterActor())
+    const id = (dto as { id: string }).id
+
+    expect(await instanceStatus(id)).toBe('approved')
+    const rows = await outboxRowsForInstance(id)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].event_type).toBe('approval.approved')
+    expect(rows[0].consumers).toEqual(['approval-bridge', 'approval-projection', 'approval-trigger'])
+    // No pending assignment survived the cascade → NO task_created row was enqueued (the recheck's intent).
+    expect(rows.filter((r) => r.event_type === 'approval.task_created')).toHaveLength(0)
+    expect(spy).toHaveLength(0)
+  })
+
+  // F1-G4 — flag OFF: legacy fires, zero outbox ────────────────────────────────────────────────────────
+  test('F1-G4 flag OFF: legacy emits fire (task_created at create, approval.approved at approve); ZERO outbox rows', async () => {
+    const id = await createManualInstance() // flag OFF
+    expect(spy.filter((e) => e.type === 'approval.task_created')).toHaveLength(1)
+    await approvals.dispatchAction(id, { action: 'approve', comment: 'ok' } as never, approverActor())
+    expect(spy.filter((e) => e.type === 'approval.approved')).toHaveLength(1)
+    expect(await outboxRowsForInstance(id)).toHaveLength(0)
+  })
+
+  // F1-G5 — atomicity: transition + enqueue roll back together ──────────────────────────────────────────
+  test('F1-G5 atomicity: injected completion-outbox failure rolls back the transition AND the enqueue', async () => {
+    const id = await createManualInstance() // flag OFF setup: pending, APPROVER assigned
+    process.env[DURABLE_FLAG] = 'true'
+    const trg = `f1g5_${TS}`
+    await injectOutboxFailure(trg, id)
+    try {
+      await expect(
+        approvals.dispatchAction(id, { action: 'approve', comment: 'ok' } as never, approverActor()),
+      ).rejects.toThrow(/injected completion outbox failure/)
+    } finally {
+      await dropOutboxFailure(trg)
+    }
+    // The WHOLE transaction rolled back: the terminal transition did NOT persist and NO outbox row survives.
+    expect(await instanceStatus(id)).toBe('pending')
+    expect(await outboxRowsForInstance(id)).toHaveLength(0)
+    // A clean retry (trigger gone) now commits both the transition and the enqueue atomically.
+    await approvals.dispatchAction(id, { action: 'approve', comment: 'ok' } as never, approverActor())
+    expect(await instanceStatus(id)).toBe('approved')
+    const rows = await outboxRowsForInstance(id)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].event_type).toBe('approval.approved')
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-automation-producer-family1-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-producer-family1-realdb.test.ts
@@ -286,4 +286,45 @@ describeIfDatabase('P1#2e — producer family 1: approval completion + task_crea
     expect(rows).toHaveLength(1)
     expect(rows[0].event_type).toBe('approval.approved')
   })
+
+  // F1-G6 — atomicity for the task_created IN-TXN leg (owner closure item 1): the per-recipient enqueue at
+  // the end of createApproval's manual BEGIN..COMMIT must be atomic with the instance + assignment writes —
+  // an enqueue failure rolls back EVERYTHING (no instance, no assignments, no rows), proving the leg shares
+  // the SOURCE transaction rather than re-writing post-commit.
+  test('F1-G6 atomicity: injected task_created-outbox failure rolls back instance + assignments + enqueue together', async () => {
+    process.env[DURABLE_FLAG] = 'true'
+    const trg = `f1g6_${TS}`
+    const before = Number(
+      (await q('SELECT count(*)::int AS n FROM approval_instances WHERE template_id = $1', [manualTemplateId])).rows[0].n,
+    )
+    await q(`CREATE OR REPLACE FUNCTION ${trg}() RETURNS trigger AS $fn$
+             BEGIN
+               RAISE EXCEPTION 'injected task_created outbox failure' USING ERRCODE = 'P0001';
+             END $fn$ LANGUAGE plpgsql`)
+    await q(`CREATE TRIGGER ${trg}_trg BEFORE INSERT ON meta_automation_outbox
+             FOR EACH ROW WHEN (NEW.event_type = 'approval.task_created' AND NEW.payload->'approval'->>'templateId' = '${manualTemplateId}')
+             EXECUTE FUNCTION ${trg}()`)
+    try {
+      await expect(
+        approvals.createApproval({ templateId: manualTemplateId, formData: { summary: 'f1g6' } }, requesterActor()),
+      ).rejects.toThrow(/injected task_created outbox failure/)
+    } finally {
+      await q(`DROP TRIGGER IF EXISTS ${trg}_trg ON meta_automation_outbox`).catch(() => {})
+      await q(`DROP FUNCTION IF EXISTS ${trg}()`).catch(() => {})
+    }
+    // The WHOLE source transaction rolled back: no new instance, no assignments, no outbox rows.
+    const after = Number(
+      (await q('SELECT count(*)::int AS n FROM approval_instances WHERE template_id = $1', [manualTemplateId])).rows[0].n,
+    )
+    expect(after).toBe(before)
+    const orphanAssignments = await q(
+      `SELECT a.id FROM approval_assignments a
+        WHERE a.instance_id NOT IN (SELECT id FROM approval_instances)`,
+    )
+    expect(orphanAssignments.rows).toHaveLength(0)
+    // A clean retry (trigger gone) commits instance + assignments + the task_created enqueue atomically.
+    const dto = await approvals.createApproval({ templateId: manualTemplateId, formData: { summary: 'f1g6b' } }, requesterActor())
+    const rows = (await outboxRowsForInstance(dto.id)).filter((r) => r.event_type === 'approval.task_created')
+    expect(rows.length).toBeGreaterThanOrEqual(1)
+  })
 })

--- a/packages/core-backend/tests/integration/multitable-automation-producer-family2-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-producer-family2-realdb.test.ts
@@ -1,0 +1,272 @@
+/**
+ * P2 durable-delivery P1#2c — producer family 2 (executor Class-A record actions) REPLACE goldens (real DB).
+ *
+ * Family 3's goldens covered the shared seam (`enqueueRecordEventIfDurable`); THESE goldens prove the
+ * executor SITE wiring through the REAL production path — `AutomationService.executeRule(...)` with the
+ * constructor's real `deps.transaction` — for all three Class-A record events:
+ *
+ *   F2-G1  flag ON  + create_record  → ONE outbox row (`multitable.record.created`) fanned out to exactly
+ *          [automation-record-trigger, webhook-event-bridge] (pending), committed WITH the record; the
+ *          legacy bus emit is SUPPRESSED (spy sees nothing).
+ *   F2-G2  flag ON  + update_record  → same for `multitable.record.updated`.
+ *   F2-G3  flag ON  + delete_record  → same for `multitable.record.deleted`.
+ *   F2-G4  flag OFF → the legacy post-commit emit fires with the same payload shape (byte-identical legacy
+ *          path) and ZERO outbox rows exist — the REPLACE guard's other leg.
+ *   F2-G5  ATOMICITY: a Postgres-level failure injected into the revision INSERT rolls back the WHOLE
+ *          transaction — the record write AND the outbox enqueue vanish together (no half-delivery).
+ *   F2-G6  REPLAY: with the Class-A claim flag also ON, a replay on the same lineage root short-circuits as
+ *          `alreadyApplied` — and enqueues NO second outbox row (a replayed action must produce zero
+ *          downstream deliveries, mirroring how the legacy emit is skipped).
+ *
+ * Rows are asserted by this run's own record ids (payload->>'recordId') — never drained — so this suite
+ * cannot claim a sibling suite's rows on the shared CI DB. Two-point wired (vitest.config exclude +
+ * plugin-tests.yml run-list).
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { EventBus } from '../../src/integration/events/event-bus'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { db } from '../../src/db/db'
+import type { AutomationExecution, AutomationRule } from '../../src/multitable/automation-executor'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const DURABLE_FLAG = 'AUTOMATION_DURABLE_DELIVERY_ENABLED'
+const CLASSA_FLAG = 'AUTOMATION_CLASSA_CLAIM_ENABLED'
+const TS = Date.now()
+const OWNER = `u_f2_owner_${TS}`
+const BASE = `base_f2_${TS}`
+const SHEET = `sheet_f2_${TS}`
+const FLD = `fld_f2_title_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+/** Real production wiring — mirrors index.ts (real queryFn; constructor hard-wires deps.transaction). The
+ * bus is OURS so the suppression spy observes exactly what production subscribers would receive. */
+function realService(bus: EventBus): AutomationService {
+  const pool = poolManager.get()
+  return new AutomationService(bus, db as never, pool.query.bind(pool))
+}
+
+function ruleFor(
+  sheetId: string,
+  action: { type: 'create_record' | 'update_record' | 'delete_record'; config: Record<string, unknown> },
+): AutomationRule {
+  return {
+    id: `atr_f2_${TS}_${Math.random().toString(36).slice(2, 8)}`,
+    name: 'Family-2 rule',
+    sheetId,
+    trigger: { type: 'record.created', config: {} },
+    actions: [action as never],
+    enabled: true,
+    createdBy: OWNER,
+    createdAt: new Date().toISOString(),
+  } as unknown as AutomationRule
+}
+
+interface OutboxRow {
+  id: string
+  event_type: string
+  payload: Record<string, unknown>
+  consumers: string[]
+}
+
+/** This run's outbox rows for a record id — joined to their consumer fan-out, never drained. */
+const outboxRowsForRecord = async (recordId: string): Promise<OutboxRow[]> =>
+  (
+    await q(
+      `SELECT o.id, o.event_type, o.payload,
+              ARRAY(SELECT c.consumer_key FROM meta_automation_outbox_consumer c
+                     WHERE c.outbox_id = o.id ORDER BY c.consumer_key) AS consumers
+         FROM meta_automation_outbox o
+        WHERE o.payload->>'recordId' = $1
+        ORDER BY o.created_at`,
+      [recordId],
+    )
+  ).rows as unknown as OutboxRow[]
+
+const consumerStatuses = async (outboxId: string): Promise<string[]> =>
+  (
+    (await q('SELECT status FROM meta_automation_outbox_consumer WHERE outbox_id = $1', [outboxId])).rows as Array<{
+      status: string
+    }>
+  ).map((r) => r.status)
+
+/** Record-event spy on the REAL bus the service emits into. */
+function spyRecordEvents(bus: EventBus): Array<{ type: string; payload: Record<string, unknown> }> {
+  const seen: Array<{ type: string; payload: Record<string, unknown> }> = []
+  for (const t of ['multitable.record.created', 'multitable.record.updated', 'multitable.record.deleted']) {
+    bus.subscribe(t, (p: unknown) => {
+      seen.push({ type: t, payload: p as Record<string, unknown> })
+    })
+  }
+  return seen
+}
+
+async function createViaRule(svc: AutomationService, title: string): Promise<{ recordId: string; execution: AutomationExecution }> {
+  const execution = await svc.executeRule(
+    ruleFor(SHEET, { type: 'create_record', config: { sheetId: SHEET, data: { [FLD]: title } } }),
+    { actorId: OWNER, data: {} },
+  )
+  expect(execution.status).toBe('success')
+  return { recordId: (execution.steps[0]?.output as { recordId: string }).recordId, execution }
+}
+
+describeIfDatabase('P1#2c — producer family 2: executor Class-A record events REPLACE (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [BASE, 'F2 Base', OWNER])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'F2 Sheet'])
+    await q(`INSERT INTO meta_fields (id, sheet_id, name, type, "order") VALUES ($1,$2,'Title','string',0)`, [FLD, SHEET])
+  })
+
+  afterEach(() => {
+    delete process.env[DURABLE_FLAG]
+    delete process.env[CLASSA_FLAG]
+  })
+
+  afterAll(async () => {
+    await q(
+      `DELETE FROM meta_automation_outbox
+        WHERE payload->>'recordId' IN (SELECT id FROM meta_records WHERE sheet_id = $1)
+           OR payload->>'sheetId' = $1`,
+      [SHEET],
+    ).catch(() => {})
+    await q(
+      'DELETE FROM meta_record_revisions WHERE record_id IN (SELECT id FROM meta_records WHERE sheet_id = $1)',
+      [SHEET],
+    ).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL is set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // F2-G1 — create_record ──────────────────────────────────────────────────────────────────────────────
+  test('F2-G1 flag ON create_record: same-txn outbox row + exact fan-out; legacy emit SUPPRESSED', async () => {
+    process.env[DURABLE_FLAG] = 'true'
+    const bus = new EventBus()
+    const seen = spyRecordEvents(bus)
+    const { recordId } = await createViaRule(realService(bus), 'g1')
+
+    const rows = await outboxRowsForRecord(recordId)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].event_type).toBe('multitable.record.created')
+    expect(rows[0].consumers).toEqual(['automation-record-trigger', 'webhook-event-bridge'])
+    expect(await consumerStatuses(rows[0].id)).toEqual(['pending', 'pending'])
+    expect(rows[0].payload).toMatchObject({ sheetId: SHEET, recordId, actorId: OWNER })
+    expect(typeof rows[0].payload._eventId).toBe('string')
+    // REPLACE leg: the durable enqueue is the ONLY path — the legacy post-commit emit stayed silent.
+    expect(seen).toHaveLength(0)
+  })
+
+  // F2-G2 — update_record ──────────────────────────────────────────────────────────────────────────────
+  test('F2-G2 flag ON update_record: same-txn outbox row + exact fan-out; legacy emit SUPPRESSED', async () => {
+    const { recordId } = await createViaRule(realService(new EventBus()), 'g2-v1') // setup create runs flag-OFF
+    process.env[DURABLE_FLAG] = 'true'
+    const bus = new EventBus()
+    const seen = spyRecordEvents(bus)
+    const exec = await realService(bus).executeRule(
+      ruleFor(SHEET, { type: 'update_record', config: { fields: { [FLD]: 'g2-v2' } } }),
+      { recordId, actorId: OWNER, data: {} },
+    )
+    expect(exec.status).toBe('success')
+
+    const rows = (await outboxRowsForRecord(recordId)).filter((r) => r.event_type === 'multitable.record.updated')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].consumers).toEqual(['automation-record-trigger', 'webhook-event-bridge'])
+    expect(rows[0].payload).toMatchObject({ sheetId: SHEET, recordId, changes: { [FLD]: 'g2-v2' } })
+    expect(seen).toHaveLength(0)
+  })
+
+  // F2-G3 — delete_record ──────────────────────────────────────────────────────────────────────────────
+  test('F2-G3 flag ON delete_record: same-txn outbox row + exact fan-out; legacy emit SUPPRESSED', async () => {
+    const { recordId } = await createViaRule(realService(new EventBus()), 'g3')
+    process.env[DURABLE_FLAG] = 'true'
+    const bus = new EventBus()
+    const seen = spyRecordEvents(bus)
+    const exec = await realService(bus).executeRule(
+      ruleFor(SHEET, { type: 'delete_record', config: {} }),
+      { recordId, actorId: OWNER, data: {} },
+    )
+    expect(exec.status).toBe('success')
+
+    const rows = (await outboxRowsForRecord(recordId)).filter((r) => r.event_type === 'multitable.record.deleted')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].consumers).toEqual(['automation-record-trigger', 'webhook-event-bridge'])
+    expect(seen).toHaveLength(0)
+  })
+
+  // F2-G4 — flag OFF: byte-identical legacy path ───────────────────────────────────────────────────────
+  test('F2-G4 flag OFF: legacy post-commit emit fires (same shape) and ZERO outbox rows exist', async () => {
+    const bus = new EventBus()
+    const seen = spyRecordEvents(bus)
+    const { recordId } = await createViaRule(realService(bus), 'g4')
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0].type).toBe('multitable.record.created')
+    expect(seen[0].payload).toMatchObject({ sheetId: SHEET, recordId, actorId: OWNER })
+    expect(typeof seen[0].payload._eventId).toBe('string')
+    expect(seen[0].payload._automationDepth).toBe(1)
+    expect(await outboxRowsForRecord(recordId)).toHaveLength(0)
+  })
+
+  // F2-G5 — atomicity under genuine Postgres failure ───────────────────────────────────────────────────
+  test('F2-G5 flag ON: a revision-INSERT failure rolls back record AND outbox together (no half-delivery)', async () => {
+    process.env[DURABLE_FLAG] = 'true'
+    const marker = `g5-crash-${TS}`
+    await q(`CREATE OR REPLACE FUNCTION f2_g5_fail() RETURNS trigger AS $fn$
+             BEGIN
+               RAISE EXCEPTION 'f2 g5 injected revision failure' USING ERRCODE = 'P0001';
+             END $fn$ LANGUAGE plpgsql`)
+    await q(`CREATE TRIGGER f2_g5_fail_trg BEFORE INSERT ON meta_record_revisions
+             FOR EACH ROW WHEN (NEW.snapshot->>'${FLD}' = '${marker}') EXECUTE FUNCTION f2_g5_fail()`)
+    try {
+      const exec = await realService(new EventBus()).executeRule(
+        ruleFor(SHEET, { type: 'create_record', config: { sheetId: SHEET, data: { [FLD]: marker } } }),
+        { actorId: OWNER, data: {} },
+      )
+      expect(exec.steps[0]?.status).toBe('failed')
+      // The whole transaction — record, revision, AND the durable enqueue — rolled back together. Scoped
+      // to THIS test's marker (earlier goldens in this suite legitimately committed sheet-scoped rows).
+      const orphaned = await q(
+        `SELECT o.id FROM meta_automation_outbox o WHERE o.payload->'data'->>'${FLD}' = $1`,
+        [marker],
+      )
+      const half = await q(`SELECT id FROM meta_records WHERE sheet_id = $1 AND data->>'${FLD}' = $2`, [SHEET, marker])
+      expect(orphaned.rows.length + half.rows.length).toBe(0)
+    } finally {
+      await q('DROP TRIGGER IF EXISTS f2_g5_fail_trg ON meta_record_revisions').catch(() => {})
+      await q('DROP FUNCTION IF EXISTS f2_g5_fail()').catch(() => {})
+    }
+  })
+
+  // F2-G6 — replay produces zero second delivery ───────────────────────────────────────────────────────
+  test('F2-G6 flag ON + Class-A claim ON: a replay on the same root enqueues NO second outbox row', async () => {
+    process.env[DURABLE_FLAG] = 'true'
+    process.env[CLASSA_FLAG] = 'true'
+    const svc = realService(new EventBus())
+    const rule = ruleFor(SHEET, { type: 'create_record', config: { sheetId: SHEET, data: { [FLD]: 'g6' } } })
+    const first = await svc.executeRule(rule, { actorId: OWNER, data: {} })
+    expect(first.status).toBe('success')
+    const recordId = (first.steps[0]?.output as { recordId: string }).recordId
+    expect(await outboxRowsForRecord(recordId)).toHaveLength(1)
+
+    const second = await svc.executeRule(rule, {
+      actorId: OWNER,
+      data: {},
+    }, {
+      rerunOfExecutionId: first.id,
+      initiatedBy: OWNER,
+      rootExecutionId: first.id,
+    })
+    expect(second.status).toBe('success')
+    expect(second.steps[0]?.alreadyApplied).toBe(true)
+    // The duplicate-claim early-return skipped the enqueue exactly as it skips the legacy emit.
+    expect(await outboxRowsForRecord(recordId)).toHaveLength(1)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-automation-producer-family4-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-producer-family4-realdb.test.ts
@@ -1,0 +1,269 @@
+/**
+ * P2 durable-delivery P1 #2b — producer family 4 SITE-WIRING goldens (real DB).
+ *
+ * Family 4 = the record CRUD emit sites: `record-service.ts` createRecord / patchRecord / deleteRecord /
+ * restoreRecord + `record-write-service.ts` patchRecords (bulk). The REPLACE seam ITSELF
+ * (`enqueueRecordEventIfDurable` commit/rollback/off atomicity) is already golden-covered by the family-3
+ * suite (`multitable-automation-producer-emit-realdb.test.ts`); what THIS suite proves is the SITE wiring —
+ * driving the REAL services end to end:
+ *   - flag ON  → each CRUD write leaves exactly one outbox row (right event_type, payload = the legacy
+ *                payload shape, event_id = the payload's `_eventId`) fanned out to exactly
+ *                [automation-record-trigger, webhook-event-bridge] (pending), AND the legacy bus is
+ *                SUPPRESSED at the real site (REPLACE, not keep-both — the webhook sink is not idempotent).
+ *   - flag ON + a failing write (version conflict) → zero outbox rows AND zero emits (success-path only).
+ *   - flag OFF → the legacy bus fires with the byte-identical payload shape and ZERO outbox rows.
+ *
+ * Rows are asserted by THIS suite's own unique record/sheet ids and cleaned up — never drained/claimed — so
+ * it never touches a sibling suite's rows on the shared CI DB. Runs only with DATABASE_URL (sentinel
+ * fails-not-skips inside the real-DB allowlist step). Two-point wiring: vitest.config.ts exclude +
+ * plugin-tests.yml real-DB run list.
+ */
+import type { Request } from 'express'
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import type { EventBus } from '../../src/integration/events/event-bus'
+import { RecordService, VersionConflictError } from '../../src/multitable/record-service'
+import { RecordWriteService, type RecordPatchInput as WriteRecordPatchInput } from '../../src/multitable/record-write-service'
+import { createRecordWriteHelpers } from '../../src/routes/univer-meta'
+import { deriveCapabilities, type AccessInfo } from '../../src/multitable/sheet-capabilities'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const FLAG = 'AUTOMATION_DURABLE_DELIVERY_ENABLED'
+const TS = Date.now()
+const BASE = `base_f4_${TS}`
+const SHEET = `sheet_f4_${TS}`
+const F_STR = `fld_f4_str_${TS}`
+const ACTOR = `u_f4_actor_${TS}`
+const MANIFEST_FANOUT = ['automation-record-trigger', 'webhook-event-bridge']
+
+let seq = 0
+const mkRecord = (tag: string) => `rec_f4_${tag}_${TS}_${seq++}`
+
+// The suppression probe: the REAL services are constructed over this spy bus, so "flag ON ⇒ not called"
+// is asserted at the actual production emit site, not at the seam helper.
+const busEmit = vi.fn()
+const eventBus = { emit: busEmit } as unknown as EventBus
+
+const access: AccessInfo = { userId: ACTOR, permissions: ['multitable:read', 'multitable:write'], isAdminRole: false }
+const capabilities = deriveCapabilities(['multitable:read', 'multitable:write'], false)
+const resolveSheetAccess = async () => ({ capabilities })
+
+const mkRecordService = () =>
+  new RecordService(poolManager.get() as unknown as ConstructorParameters<typeof RecordService>[0], eventBus)
+const mkWriteService = () => {
+  const fakeReq = { user: { id: ACTOR, roles: [], perms: ['multitable:read', 'multitable:write'] } } as unknown as Request
+  const helpers = createRecordWriteHelpers(
+    fakeReq,
+    poolManager.get() as unknown as { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }> },
+  )
+  return new RecordWriteService(
+    poolManager.get() as unknown as ConstructorParameters<typeof RecordWriteService>[0],
+    eventBus,
+    helpers,
+  )
+}
+
+const seedRecord = async (id: string, data: Record<string, unknown> = { [F_STR]: 'orig' }): Promise<void> => {
+  await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [id, SHEET, JSON.stringify(data), ACTOR])
+}
+
+const mkBulkInput = (changesByRecord: Map<string, Array<{ fieldId: string; value: unknown; expectedVersion?: number }>>): WriteRecordPatchInput => ({
+  sheetId: SHEET,
+  changesByRecord,
+  actorId: ACTOR,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fields: [{ id: F_STR, name: 'Note', type: 'string', property: {}, order: 1 }] as any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  visiblePropertyFields: [{ id: F_STR, name: 'Note', type: 'string', property: {}, order: 1 }] as any,
+  visiblePropertyFieldIds: new Set([F_STR]),
+  attachmentFields: [],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fieldById: new Map([[F_STR, { type: 'string', readOnly: false, hidden: false } as Record<string, unknown>]]) as any,
+  capabilities,
+  access,
+})
+
+type OutboxRow = { id: string; event_id: string; automation_depth: number; manifest_version: number; payload: Record<string, unknown> }
+/** This suite's own rows ONLY: keyed by our unique per-run record id + event type. Never drains anything. */
+const outboxRowsFor = async (recordId: string, eventType: string): Promise<OutboxRow[]> => {
+  const { rows } = await q(
+    `SELECT id, event_id, automation_depth, manifest_version, payload FROM meta_automation_outbox
+      WHERE event_type = $1 AND payload->>'recordId' = $2 ORDER BY created_at`,
+    [eventType, recordId],
+  )
+  return rows as OutboxRow[]
+}
+const consumersOf = async (outboxId: string): Promise<Array<{ consumer_key: string; status: string }>> => {
+  const { rows } = await q(
+    'SELECT consumer_key, status FROM meta_automation_outbox_consumer WHERE outbox_id = $1 ORDER BY consumer_key',
+    [outboxId],
+  )
+  return rows as Array<{ consumer_key: string; status: string }>
+}
+/** Full site golden for one flag-ON write: exactly one outbox row, legacy-shaped payload, manifest fan-out. */
+const expectDurableRow = async (recordId: string, eventType: string, payloadShape: Record<string, unknown>): Promise<void> => {
+  const rows = await outboxRowsFor(recordId, eventType)
+  expect(rows).toHaveLength(1)
+  const row = rows[0]!
+  expect(row.payload).toEqual({ ...payloadShape, _eventId: expect.any(String) })
+  expect(row.event_id).toBe(row.payload._eventId) // stable identity shared by both phases
+  expect(row.automation_depth).toBe(0)
+  expect(row.manifest_version).toBe(1)
+  expect(await consumersOf(row.id)).toEqual(MANIFEST_FANOUT.map((consumer_key) => ({ consumer_key, status: 'pending' })))
+}
+
+describeIfDatabase('P1#2b producer family 4 — record CRUD site wiring (real DB)', () => {
+  beforeAll(async () => {
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'F4 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'F4 Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_STR, SHEET, 'Note', 'string', '{}', 1])
+  })
+
+  afterEach(() => {
+    delete process.env[FLAG]
+    busEmit.mockClear()
+  })
+
+  afterAll(async () => {
+    delete process.env[FLAG]
+    // ONLY this suite's rows: every outbox row we produced carries our unique sheet id in its payload
+    // (consumer rows cascade), and every fixture id is TS-suffixed.
+    await q("DELETE FROM meta_automation_outbox WHERE payload->>'sheetId' = $1", [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL is set (this suite must RUN, never skip-green)', () => {
+    if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+      throw new Error('real-DB allowlist step is missing DATABASE_URL')
+    }
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ── flag ON: durable outbox row + manifest fan-out, legacy bus SUPPRESSED at the real site ──────────
+
+  test('ON create: createRecord → one record.created outbox row (legacy payload shape) + fan-out; bus suppressed', async () => {
+    process.env[FLAG] = 'true'
+    const res = await mkRecordService().createRecord({ sheetId: SHEET, data: { [F_STR]: 'created' }, actorId: ACTOR, capabilities })
+    await expectDurableRow(res.recordId, 'multitable.record.created', {
+      sheetId: SHEET,
+      recordId: res.recordId,
+      data: { [F_STR]: 'created' },
+      actorId: ACTOR,
+    })
+    expect(busEmit).not.toHaveBeenCalled() // REPLACE: the same-txn enqueue IS the delivery path
+  })
+
+  test('ON update (single): patchRecord → one record.updated outbox row + fan-out; bus suppressed', async () => {
+    const R = mkRecord('patch')
+    await seedRecord(R)
+    process.env[FLAG] = 'true'
+    await mkRecordService().patchRecord({ recordId: R, sheetId: SHEET, data: { [F_STR]: 'patched' }, actorId: ACTOR, access, capabilities })
+    await expectDurableRow(R, 'multitable.record.updated', {
+      sheetId: SHEET,
+      recordId: R,
+      data: { [F_STR]: 'patched' },
+      actorId: ACTOR, // patchRecord's legacy emit used access.userId ?? 'system'
+    })
+    expect(busEmit).not.toHaveBeenCalled()
+  })
+
+  test('ON delete: deleteRecord → one record.deleted outbox row + fan-out; bus suppressed', async () => {
+    const R = mkRecord('del')
+    await seedRecord(R)
+    process.env[FLAG] = 'true'
+    await mkRecordService().deleteRecord({ recordId: R, actorId: ACTOR, access, resolveSheetAccess })
+    await expectDurableRow(R, 'multitable.record.deleted', { sheetId: SHEET, recordId: R, actorId: ACTOR })
+    expect(busEmit).not.toHaveBeenCalled()
+  })
+
+  test('ON restore: restoreRecord → one record.created outbox row (restore payload has NO data key); bus suppressed', async () => {
+    const R = mkRecord('restore')
+    await seedRecord(R)
+    process.env[FLAG] = 'true'
+    await mkRecordService().deleteRecord({ recordId: R, actorId: ACTOR, access, resolveSheetAccess })
+    await mkRecordService().restoreRecord({ recordId: R, actorId: ACTOR, access, resolveSheetAccess })
+    // the restore site's legacy payload was { sheetId, recordId, actorId } — no `data` key (unlike create)
+    await expectDurableRow(R, 'multitable.record.created', { sheetId: SHEET, recordId: R, actorId: ACTOR })
+    expect(busEmit).not.toHaveBeenCalled()
+  })
+
+  test('ON bulk: patchRecords (record-write-service) → one record.updated outbox row PER written record; bus suppressed', async () => {
+    const R1 = mkRecord('bulk1')
+    const R2 = mkRecord('bulk2')
+    await seedRecord(R1)
+    await seedRecord(R2)
+    process.env[FLAG] = 'true'
+    await mkWriteService().patchRecords(mkBulkInput(new Map([
+      [R1, [{ fieldId: F_STR, value: 'bulk-one' }]],
+      [R2, [{ fieldId: F_STR, value: 'bulk-two' }]],
+    ])))
+    await expectDurableRow(R1, 'multitable.record.updated', { sheetId: SHEET, recordId: R1, changes: { [F_STR]: 'bulk-one' }, actorId: ACTOR })
+    await expectDurableRow(R2, 'multitable.record.updated', { sheetId: SHEET, recordId: R2, changes: { [F_STR]: 'bulk-two' }, actorId: ACTOR })
+    expect(busEmit).not.toHaveBeenCalled()
+  })
+
+  test('ON + failing write: a version-conflict patch rolls back → ZERO outbox rows AND zero emits (success-path only)', async () => {
+    const R = mkRecord('conflict')
+    await seedRecord(R) // version 1
+    process.env[FLAG] = 'true'
+    await expect(
+      mkRecordService().patchRecord({ recordId: R, sheetId: SHEET, data: { [F_STR]: 'nope' }, expectedVersion: 99, actorId: ACTOR, access, capabilities }),
+    ).rejects.toBeInstanceOf(VersionConflictError)
+    expect(await outboxRowsFor(R, 'multitable.record.updated')).toHaveLength(0)
+    expect(busEmit).not.toHaveBeenCalled()
+  })
+
+  // ── flag OFF: legacy bus fires byte-identically, ZERO outbox rows ───────────────────────────────────
+
+  test('OFF create: legacy bus fires with the byte-identical payload shape; zero outbox rows', async () => {
+    const res = await mkRecordService().createRecord({ sheetId: SHEET, data: { [F_STR]: 'off-created' }, actorId: ACTOR, capabilities })
+    expect(busEmit).toHaveBeenCalledTimes(1)
+    expect(busEmit).toHaveBeenCalledWith('multitable.record.created', {
+      sheetId: SHEET,
+      recordId: res.recordId,
+      data: { [F_STR]: 'off-created' },
+      actorId: ACTOR,
+      _eventId: expect.any(String),
+    })
+    expect(await outboxRowsFor(res.recordId, 'multitable.record.created')).toHaveLength(0)
+  })
+
+  test('OFF delete: legacy bus fires with the byte-identical payload shape; zero outbox rows', async () => {
+    const R = mkRecord('offdel')
+    await seedRecord(R)
+    await mkRecordService().deleteRecord({ recordId: R, actorId: ACTOR, access, resolveSheetAccess })
+    expect(busEmit).toHaveBeenCalledTimes(1)
+    expect(busEmit).toHaveBeenCalledWith('multitable.record.deleted', {
+      sheetId: SHEET,
+      recordId: R,
+      actorId: ACTOR,
+      _eventId: expect.any(String),
+    })
+    expect(await outboxRowsFor(R, 'multitable.record.deleted')).toHaveLength(0)
+  })
+
+  test('OFF bulk: legacy bus fires per written record with the byte-identical changes payload; zero outbox rows', async () => {
+    const R = mkRecord('offbulk')
+    await seedRecord(R)
+    await mkWriteService().patchRecords(mkBulkInput(new Map([[R, [{ fieldId: F_STR, value: 'off-bulk' }]]])))
+    expect(busEmit).toHaveBeenCalledTimes(1)
+    expect(busEmit).toHaveBeenCalledWith('multitable.record.updated', {
+      sheetId: SHEET,
+      recordId: R,
+      changes: { [F_STR]: 'off-bulk' },
+      actorId: ACTOR,
+      _eventId: expect.any(String),
+    })
+    expect(await outboxRowsFor(R, 'multitable.record.updated')).toHaveLength(0)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-automation-producer-family5-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-producer-family5-realdb.test.ts
@@ -1,0 +1,269 @@
+/**
+ * P2 durable-delivery P1#2d — producer family 5 (univer-meta routes ×4) goldens, real DB.
+ *
+ * Every mutation is driven through the REAL Express routes (`univerMetaRouter()` on a real app, real
+ * `poolManager` pool — same harness as the sibling undelete/reset/d1c suites), so these goldens exercise the
+ * actual route-layer txn + enqueue wiring, not a re-implementation:
+ *
+ *   site 1  `multitable.record.created`  — revert-execute UNDELETE (resurrect) path
+ *   site 2  `multitable.record.updated`  — reset-execute bulk per-row revert path (N rows ⇒ N events)
+ *   site 3  `multitable.record.deleted`  — reset-execute delete path
+ *   site 4  `multitable.form.submitted`  — form submit (CREATE and EDIT branches; its flag-ON golden's
+ *            consumer-key assertion is the END-TO-END proof of the manifest fix that routes this event —
+ *            an unrouted event would make the fail-closed expand THROW inside the txn, 500ing the route)
+ *
+ * Per family-wired site: flag ON ⇒ same-txn outbox row + exact manifest v1 consumer fan-out, legacy bus
+ * SUPPRESSED (REPLACE); flag OFF ⇒ legacy post-commit emit with the byte-identical payload shape + ZERO
+ * outbox rows. Rows are asserted by this suite's own record ids / outbox ids and cleaned up — never drained —
+ * so it never claims a sibling suite's rows on the shared CI DB. Three ISOLATED sheets (form/undelete/reset)
+ * keep each scenario's PIT integrity precheck and delete-set blind to the others' records.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { eventBus } from '../../src/integration/events/event-bus'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_f5_${TS}`
+const FORM_SHEET = `sheet_f5_form_${TS}`, UNDEL_SHEET = `sheet_f5_undel_${TS}`, RESET_SHEET = `sheet_f5_reset_${TS}`
+const FORM_VIEW = `view_f5_form_${TS}`
+const FLD_FORM = `fld_f5_form_${TS}`, FLD_UNDEL = `fld_f5_undel_${TS}`, FLD_RESET = `fld_f5_reset_${TS}`
+const MEMBER = `u_f5_member_${TS}`, ADMIN = `u_f5_admin_${TS}`
+// Seeded record ids are PER-TEST unique (seedSeq) — outboxRowsFor keys on payload.recordId, so reusing an id
+// across the flag-ON and flag-OFF tests would let one test see the other's (intentionally durable) rows.
+let seedSeq = 0
+const T0 = '2026-01-01T00:00:00.000Z', T1 = '2026-01-02T00:00:00.000Z', T2 = '2026-01-03T00:00:00.000Z'
+const DURABLE_FLAG = 'AUTOMATION_DURABLE_DELIVERY_ENABLED'
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let currentUser: { id: string; roles: string[]; perms: string[] } | undefined
+const asMember = (): void => { currentUser = { id: MEMBER, roles: ['member'], perms: ['multitable:read', 'multitable:write'] } }
+const asAdmin = (): void => { currentUser = { id: ADMIN, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] } }
+
+const seededOutboxIds: string[] = []
+
+/** All outbox rows for (eventType, payload.recordId) — this suite's record ids are unique, so this is
+ *  assert-by-own-row, never a drain. Ids are tracked for cleanup. */
+async function outboxRowsFor(eventType: string, recordId: string): Promise<Array<{ id: string; event_id: string; payload: Record<string, unknown> }>> {
+  const { rows } = await q(
+    `SELECT id, event_id, payload FROM meta_automation_outbox WHERE event_type = $1 AND payload->>'recordId' = $2 ORDER BY id`,
+    [eventType, recordId],
+  )
+  const typed = rows as Array<{ id: string; event_id: string; payload: Record<string, unknown> }>
+  for (const r of typed) if (!seededOutboxIds.includes(r.id)) seededOutboxIds.push(r.id)
+  return typed
+}
+async function consumersOf(outboxId: string): Promise<string[]> {
+  const { rows } = await q('SELECT consumer_key FROM meta_automation_outbox_consumer WHERE outbox_id = $1 ORDER BY 1', [outboxId])
+  return (rows as Array<{ consumer_key: string }>).map((r) => r.consumer_key)
+}
+/** The legacy-bus calls of one event type observed by the spy (realtime uses `publish`, so `emit` is clean). */
+function emitsOf(spy: ReturnType<typeof vi.spyOn>, eventType: string): Array<Record<string, unknown>> {
+  return (spy.mock.calls as Array<[string, unknown]>).filter((c) => c[0] === eventType).map((c) => c[1] as Record<string, unknown>)
+}
+
+const rev = (sheetId: string, fld: string, id: string, version: number, action: string, snap: Record<string, unknown>, at: string) =>
+  q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[$5]::text[],'{}'::jsonb,$6::jsonb,$7)`, [sheetId, id, version, action, fld, JSON.stringify(snap), at])
+
+async function cleanSheet(sheetId: string): Promise<void> {
+  await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [sheetId]).catch(() => {})
+  await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [sheetId])
+  await q('DELETE FROM meta_records WHERE sheet_id = $1', [sheetId])
+}
+/** U: created at T0, deleted at T2, NO live row → revert-to-T1 resurrects it (same shape as the undelete suite). */
+async function seedUndelete(): Promise<string> {
+  await cleanSheet(UNDEL_SHEET)
+  const u = `rec_f5_u_${TS}_${++seedSeq}`
+  await rev(UNDEL_SHEET, FLD_UNDEL, u, 1, 'create', { [FLD_UNDEL]: 'u-at-T1' }, T0)
+  await rev(UNDEL_SHEET, FLD_UNDEL, u, 2, 'delete', { [FLD_UNDEL]: 'u-at-T1' }, T2)
+  return u
+}
+/** a/b: old@T0 → new@T2 (reset-to-T1 reverts both — the per-row N=2 case); d: created@T2 (reset deletes it). */
+async function seedReset(): Promise<{ a: string; b: string; d: string }> {
+  await cleanSheet(RESET_SHEET)
+  const a = `rec_f5_a_${TS}_${++seedSeq}`, b = `rec_f5_b_${TS}_${++seedSeq}`, d = `rec_f5_d_${TS}_${++seedSeq}`
+  for (const id of [a, b]) {
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [id, RESET_SHEET, JSON.stringify({ [FLD_RESET]: 'new' })])
+    await rev(RESET_SHEET, FLD_RESET, id, 1, 'create', { [FLD_RESET]: 'old' }, T0)
+    await rev(RESET_SHEET, FLD_RESET, id, 2, 'update', { [FLD_RESET]: 'new' }, T2)
+  }
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [d, RESET_SHEET, JSON.stringify({ [FLD_RESET]: 'newbie' })])
+  await rev(RESET_SHEET, FLD_RESET, d, 1, 'create', { [FLD_RESET]: 'newbie' }, T2)
+  return { a, b, d }
+}
+
+async function undeleteExecute(u: string): Promise<void> {
+  asAdmin()
+  const pv = await request(app).post(`/api/multitable/sheets/${UNDEL_SHEET}/revert-preview`).send({ asOf: T1 })
+  expect(pv.status).toBe(200)
+  const x = await request(app).post(`/api/multitable/sheets/${UNDEL_SHEET}/revert-execute`)
+    .send({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'undelete' })
+  expect(x.status).toBe(200)
+  expect(x.body?.data?.undeleteRecordIds).toEqual([u])
+}
+async function resetExecute(d: string): Promise<void> {
+  asAdmin()
+  const pv = await request(app).post(`/api/multitable/sheets/${RESET_SHEET}/reset-preview`).send({ asOf: T1 })
+  expect(pv.status).toBe(200)
+  const x = await request(app).post(`/api/multitable/sheets/${RESET_SHEET}/reset-execute`)
+    .send({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'reset' })
+  expect(x.status).toBe(200)
+  expect(x.body?.data?.revertedCount).toBe(2)
+  expect(x.body?.data?.deletedRecordIds).toEqual([d])
+}
+async function formSubmitCreate(name: string): Promise<string> {
+  asMember()
+  const res = await request(app).post(`/api/multitable/views/${FORM_VIEW}/submit`).send({ data: { [FLD_FORM]: name } })
+  expect(res.status).toBe(200)
+  expect(res.body?.data?.mode).toBe('create')
+  return String(res.body?.data?.record?.id)
+}
+
+describeIfDatabase('P1#2d producer family 5 (univer-meta routes) — durable REPLACE goldens (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { if (currentUser) (req as unknown as { user?: unknown }).user = currentUser; next() })
+    process.env.MULTITABLE_ENABLE_SHEET_REVERT = 'true'
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'F5 Base'])
+    for (const [sheet, fld] of [[FORM_SHEET, FLD_FORM], [UNDEL_SHEET, FLD_UNDEL], [RESET_SHEET, FLD_RESET]] as const) {
+      await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [sheet, BASE, sheet])
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [fld, sheet, 'Name', 'string', '{}', 1])
+    }
+    await q('INSERT INTO meta_views (id, sheet_id, name, type, config) VALUES ($1,$2,$3,$4,$5::jsonb)', [FORM_VIEW, FORM_SHEET, 'Form', 'form', '{}'])
+    for (const u of [MEMBER, ADMIN]) await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [u])
+  })
+  afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_SHEET_REVERT
+    if (seededOutboxIds.length) {
+      await q('DELETE FROM meta_automation_outbox WHERE id = ANY($1)', [seededOutboxIds]).catch(() => {}) // consumer rows CASCADE
+    }
+    for (const sheet of [FORM_SHEET, UNDEL_SHEET, RESET_SHEET]) {
+      await cleanSheet(sheet).catch(() => {})
+      await q('DELETE FROM meta_views WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_fields WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_sheets WHERE id = $1', [sheet]).catch(() => {})
+    }
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[MEMBER, ADMIN]]).catch(() => {})
+  })
+  afterEach(() => {
+    delete process.env[DURABLE_FLAG]
+    delete process.env.MULTITABLE_ENABLE_PIT_UNDELETE
+    delete process.env.MULTITABLE_ENABLE_PIT_RESET
+    vi.restoreAllMocks()
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('site 4 CREATE, flag ON: form submit → same-txn outbox row routed [automation-record-trigger] (manifest-fix E2E) + legacy bus SUPPRESSED', async () => {
+    process.env[DURABLE_FLAG] = 'true'
+    const emitSpy = vi.spyOn(eventBus, 'emit')
+    const recId = await formSubmitCreate('f5-on-create')
+    const rows = await outboxRowsFor('multitable.form.submitted', recId)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.event_id).toBe(rows[0]!.payload._eventId) // event identity = the payload's own _eventId
+    expect(rows[0]!.payload).toEqual({ sheetId: FORM_SHEET, recordId: recId, actorId: MEMBER, mode: 'create', _eventId: rows[0]!.event_id })
+    // THE manifest-fix expansion assertion: multitable.form.submitted routes (post-fix) → exactly this set.
+    expect(await consumersOf(rows[0]!.id)).toEqual(['automation-record-trigger'])
+    expect(emitsOf(emitSpy, 'multitable.form.submitted')).toHaveLength(0) // REPLACE: legacy emit suppressed
+  })
+
+  test('site 4 EDIT, flag ON: form-submit EDIT branch → its own outbox row (mode=update) + suppressed legacy', async () => {
+    const recId = await formSubmitCreate('f5-edit-base') // created with flag OFF → no outbox row for the create
+    expect(await outboxRowsFor('multitable.form.submitted', recId)).toHaveLength(0)
+    process.env[DURABLE_FLAG] = 'true'
+    const emitSpy = vi.spyOn(eventBus, 'emit')
+    asMember()
+    const res = await request(app).post(`/api/multitable/views/${FORM_VIEW}/submit`)
+      .send({ recordId: recId, expectedVersion: 1, data: { [FLD_FORM]: 'f5-edit-v2' } })
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.mode).toBe('update')
+    const rows = await outboxRowsFor('multitable.form.submitted', recId)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.payload).toEqual({ sheetId: FORM_SHEET, recordId: recId, actorId: MEMBER, mode: 'update', _eventId: rows[0]!.event_id })
+    expect(await consumersOf(rows[0]!.id)).toEqual(['automation-record-trigger'])
+    expect(emitsOf(emitSpy, 'multitable.form.submitted')).toHaveLength(0)
+  })
+
+  test('site 4, flag OFF: legacy emit fires with the byte-identical payload shape + ZERO outbox rows', async () => {
+    const emitSpy = vi.spyOn(eventBus, 'emit')
+    const recId = await formSubmitCreate('f5-off-create')
+    const emits = emitsOf(emitSpy, 'multitable.form.submitted')
+    expect(emits).toHaveLength(1)
+    expect(emits[0]).toEqual({ sheetId: FORM_SHEET, recordId: recId, actorId: MEMBER, mode: 'create', _eventId: expect.any(String) })
+    expect(await outboxRowsFor('multitable.form.submitted', recId)).toHaveLength(0)
+  })
+
+  test('site 1, flag ON: undelete resurrect → same-txn outbox row [automation-record-trigger, webhook-event-bridge] + suppressed legacy', async () => {
+    const u = await seedUndelete()
+    process.env.MULTITABLE_ENABLE_PIT_UNDELETE = 'true'
+    process.env[DURABLE_FLAG] = 'true'
+    const emitSpy = vi.spyOn(eventBus, 'emit')
+    await undeleteExecute(u)
+    const rows = await outboxRowsFor('multitable.record.created', u)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.payload).toEqual({ sheetId: UNDEL_SHEET, recordId: u, actorId: ADMIN, _eventId: rows[0]!.event_id })
+    expect(await consumersOf(rows[0]!.id)).toEqual(['automation-record-trigger', 'webhook-event-bridge'])
+    expect(emitsOf(emitSpy, 'multitable.record.created')).toHaveLength(0)
+  })
+
+  test('site 1, flag OFF: undelete → legacy record.created emit (byte-identical shape) + ZERO outbox rows', async () => {
+    const u = await seedUndelete()
+    process.env.MULTITABLE_ENABLE_PIT_UNDELETE = 'true'
+    const emitSpy = vi.spyOn(eventBus, 'emit')
+    await undeleteExecute(u)
+    const emits = emitsOf(emitSpy, 'multitable.record.created')
+    expect(emits).toHaveLength(1)
+    expect(emits[0]).toEqual({ sheetId: UNDEL_SHEET, recordId: u, actorId: ADMIN, _eventId: expect.any(String) })
+    expect(await outboxRowsFor('multitable.record.created', u)).toHaveLength(0)
+  })
+
+  test('sites 2+3, flag ON: reset → PER-ROW outbox rows (2× record.updated for 2 rows, distinct _eventIds) + 1× record.deleted, full fan-out, suppressed legacy', async () => {
+    const { a, b, d } = await seedReset()
+    process.env.MULTITABLE_ENABLE_PIT_RESET = 'true'
+    process.env[DURABLE_FLAG] = 'true'
+    const emitSpy = vi.spyOn(eventBus, 'emit')
+    await resetExecute(d)
+    const rowsA = await outboxRowsFor('multitable.record.updated', a)
+    const rowsB = await outboxRowsFor('multitable.record.updated', b)
+    expect(rowsA).toHaveLength(1) // per-row, 1:1 with the legacy per-row emits — N rows ⇒ N events
+    expect(rowsB).toHaveLength(1)
+    expect(rowsA[0]!.event_id).not.toBe(rowsB[0]!.event_id) // each row carries its OWN event identity
+    expect(rowsA[0]!.payload).toEqual({ sheetId: RESET_SHEET, recordId: a, changes: { [FLD_RESET]: 'old' }, actorId: ADMIN, _eventId: rowsA[0]!.event_id })
+    expect(rowsB[0]!.payload).toEqual({ sheetId: RESET_SHEET, recordId: b, changes: { [FLD_RESET]: 'old' }, actorId: ADMIN, _eventId: rowsB[0]!.event_id })
+    expect(await consumersOf(rowsA[0]!.id)).toEqual(['automation-record-trigger', 'webhook-event-bridge'])
+    expect(await consumersOf(rowsB[0]!.id)).toEqual(['automation-record-trigger', 'webhook-event-bridge'])
+    const rowsD = await outboxRowsFor('multitable.record.deleted', d)
+    expect(rowsD).toHaveLength(1)
+    expect(rowsD[0]!.payload).toEqual({ sheetId: RESET_SHEET, recordId: d, actorId: ADMIN, _eventId: rowsD[0]!.event_id })
+    expect(await consumersOf(rowsD[0]!.id)).toEqual(['automation-record-trigger', 'webhook-event-bridge'])
+    expect(emitsOf(emitSpy, 'multitable.record.updated')).toHaveLength(0)
+    expect(emitsOf(emitSpy, 'multitable.record.deleted')).toHaveLength(0)
+  })
+
+  test('sites 2+3, flag OFF: reset → per-row legacy emits (2 updated + 1 deleted, byte-identical shapes) + ZERO outbox rows', async () => {
+    const { a, b, d } = await seedReset()
+    process.env.MULTITABLE_ENABLE_PIT_RESET = 'true'
+    const emitSpy = vi.spyOn(eventBus, 'emit')
+    await resetExecute(d)
+    const updated = emitsOf(emitSpy, 'multitable.record.updated')
+    expect(updated).toHaveLength(2)
+    expect(updated.map((p) => p.recordId).sort()).toEqual([a, b].sort())
+    for (const p of updated) {
+      expect(p).toEqual({ sheetId: RESET_SHEET, recordId: p.recordId, changes: { [FLD_RESET]: 'old' }, actorId: ADMIN, _eventId: expect.any(String) })
+    }
+    const deleted = emitsOf(emitSpy, 'multitable.record.deleted')
+    expect(deleted).toHaveLength(1)
+    expect(deleted[0]).toEqual({ sheetId: RESET_SHEET, recordId: d, actorId: ADMIN, _eventId: expect.any(String) })
+    for (const id of [a, b]) expect(await outboxRowsFor('multitable.record.updated', id)).toHaveLength(0)
+    expect(await outboxRowsFor('multitable.record.deleted', d)).toHaveLength(0)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-durable-startup-failclosed.db.test.ts
+++ b/packages/core-backend/tests/integration/multitable-durable-startup-failclosed.db.test.ts
@@ -1,24 +1,38 @@
 /**
- * Owner REQUEST-CHANGES (head 5afe30f26) — REAL startup-level fail-closed regression (not just the pure
- * disposition/assert helpers): drives the actual `MetaSheetServer.start()` lifecycle against Postgres.
+ * Owner REQUEST-CHANGES (heads 5afe30f26 → 1d3854c7a) — REAL startup-level fail-closed regression (not just
+ * the pure disposition/assert helpers): drives the actual `MetaSheetServer.start()` lifecycle against
+ * Postgres.
  *
- * The two P1s: with AUTOMATION_DURABLE_DELIVERY_ENABLED=true, the wired producer families SUPPRESS their
- * legacy post-commit emits, so a process that starts without the full durable chain does not "degrade" — it
- * silently strands work:
- *   - AutomationService init failure was swallowed → `if (this.automationService)` SKIPPED durable boot →
- *     no dispatcher, every outbox row stranded, no exception anywhere.
- *   - the webhook retry scheduler could be disabled (WEBHOOK_RETRY_SCHEDULER_DISABLED=1) or fail init and
- *     startup continued — but the DURABLE webhook leg fire-and-forgets its send and relies on that
- *     scheduler (pending rows + first-attempt stray grace) for crash recovery.
+ * Round 1 (head 5afe30f26) P1s: with AUTOMATION_DURABLE_DELIVERY_ENABLED=true, the wired producer families
+ * SUPPRESS their legacy post-commit emits, so a process that starts without the full durable chain does not
+ * "degrade" — it silently strands work (no dispatcher / no webhook crash recovery).
+ *
+ * Round 2 (head 1d3854c7a) findings, both covered here:
+ *   - P1: `this.automationService` used to be assigned right after construction and never cleared, so a REAL
+ *     `init()` or `loadAndRegisterAllScheduled()` failure (object exists!) slipped past
+ *     `Boolean(this.automationService)` and the server kept listening. Fixed by publish-last + an explicit
+ *     `automationServiceReady` bit; regressed by S2-init / S2-load below (injected into the REAL init path).
+ *   - P2: the boot used to START the dispatch loop before validating the retry scheduler, so the S1
+ *     rejection left a LIVE loop handle whose next tick hit "Cannot use a pool after calling end on the
+ *     pool" (visible in a green Node20 CI log). Fixed by reordering activation (validate every dependency,
+ *     start the loop LAST) + a stop-and-null rollback in the catch. Regressed below by asserting, after a
+ *     rejected start(): loop handle is null, the shared retry scheduler is torn down, and ZERO dispatcher DB
+ *     calls occur while waiting longer than one loop interval (the probe wraps the REAL dispatcher functions
+ *     pass-through; S5 is the positive control proving the probe observes real ticks).
  *
  * Matrix (each case = a REAL server lifecycle):
- *   S1 flag ON + retry scheduler disabled            → start() REJECTS (fail-closed names the scheduler)
- *   S2 flag ON + AutomationService init failure      → start() REJECTS (fail-closed names AutomationService;
- *      the failure is injected into the REAL init path via a module mock whose constructor throws on demand
- *      — everything else in the boot is real)
- *   S3 flag OFF + retry scheduler disabled           → starts (legacy degrade preserved)
- *   S4 flag OFF + AutomationService init failure     → starts (legacy degrade preserved)
- *   S5 flag ON + healthy                             → starts (fail-closed never over-fires; positive control)
+ *   S1      flag ON + retry scheduler disabled     → start() REJECTS naming the scheduler; loop handle null;
+ *           zero dispatcher DB calls past one interval; no shared scheduler
+ *   S2      flag ON + AutomationService CONSTRUCTOR throws → start() REJECTS naming AutomationService
+ *   S2-init flag ON + AutomationService init() throws (object constructed) → start() REJECTS; nothing published
+ *   S2-load flag ON + loadAndRegisterAllScheduled() rejects (constructor + init() succeeded) → start()
+ *           REJECTS; loop handle null; zero dispatcher DB calls past one interval; nothing published
+ *   S3      flag OFF + retry scheduler disabled    → starts (legacy degrade preserved)
+ *   S4      flag OFF + constructor throws          → starts (legacy degrade preserved)
+ *   S4-load flag OFF + load failure                → starts (publish-last never over-fires flag-OFF;
+ *           automationServiceReady stays false)
+ *   S5      flag ON + healthy                      → starts; loop handle live; dispatcher DB calls observed
+ *           (positive control for the zero-tick assertions)
  *
  * Failure cases run FIRST (they abort mid-boot, pre-listen, and are never stopped); success lifecycles are
  * stopped together in afterAll — see the HARNESS CONSTRAINT note below for why (one shared pool per
@@ -26,33 +40,92 @@
  */
 import { afterAll, afterEach, describe, expect, test, vi } from 'vitest'
 
-// Injected fault switch — hoisted so the module-mock factory (which vitest hoists above imports) can see it.
-const fault = vi.hoisted(() => ({ automationCtorThrows: false }))
+// Injected fault switches — hoisted so the module-mock factory (which vitest hoists above imports) can see
+// them. ctor / init / load cover the three rungs of the REAL init chain: the round-2 P1 was precisely that
+// only the ctor rung was regressed while init()/load failures (object already exists) bypassed fail-closed.
+const fault = vi.hoisted(() => ({
+  automationCtorThrows: false,
+  automationInitThrows: false,
+  automationLoadThrows: false,
+}))
 
-// Mock ONLY the AutomationService class inside the otherwise-real module: the subclass throws at construction
-// when the switch is on, else behaves byte-identically (calls through to the real constructor). This injects
-// the "AutomationService initialization failed" path into the REAL server boot, which is otherwise untouched.
+// Behavioral DB-tick probe — pass-through wrappers around the REAL dispatcher functions the loop calls on
+// every tick (findUnknownConsumerKeys + claimDueConsumers). Any durable loop tick MUST increment this
+// counter before touching the DB, so "counter unchanged across > one interval" is a real zero-DB-tick
+// assertion (and S5 proves the counter moves when a loop IS live — the positive control).
+const dispatcherProbe = vi.hoisted(() => ({ dbCalls: 0 }))
+
+// Mock ONLY the AutomationService class inside the otherwise-real module: the subclass throws at the
+// requested rung when its switch is on, else behaves byte-identically (calls through to the real
+// implementation). This injects the failure into the REAL server boot, which is otherwise untouched.
 vi.mock('../../src/multitable/automation-service', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/multitable/automation-service')>()
   class FaultInjectedAutomationService extends actual.AutomationService {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructor(...args: any[]) {
       if (fault.automationCtorThrows) {
-        throw new Error('injected automation-service init failure (startup fail-closed regression)')
+        throw new Error('injected automation-service constructor failure (startup fail-closed regression)')
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       super(...(args as [any, any, any, any, any, any, any]))
+    }
+
+    init(): void {
+      if (fault.automationInitThrows) {
+        throw new Error('injected automation-service init() failure (startup fail-closed regression)')
+      }
+      super.init()
+    }
+
+    async loadAndRegisterAllScheduled(): Promise<void> {
+      if (fault.automationLoadThrows) {
+        throw new Error('injected automation-service loadAndRegisterAllScheduled failure (startup fail-closed regression)')
+      }
+      return super.loadAndRegisterAllScheduled()
     }
   }
   return { ...actual, AutomationService: FaultInjectedAutomationService }
 })
 
+vi.mock('../../src/multitable/automation-durable-dispatcher', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/multitable/automation-durable-dispatcher')>()
+  return {
+    ...actual,
+    findUnknownConsumerKeys: (...args: Parameters<typeof actual.findUnknownConsumerKeys>) => {
+      dispatcherProbe.dbCalls += 1
+      return actual.findUnknownConsumerKeys(...args)
+    },
+    claimDueConsumers: (...args: Parameters<typeof actual.claimDueConsumers>) => {
+      dispatcherProbe.dbCalls += 1
+      return actual.claimDueConsumers(...args)
+    },
+  }
+})
+
 import { MetaSheetServer } from '../../src/index'
+import { getAutomationServiceInstance } from '../../src/multitable/automation-service'
+import { getSharedWebhookRetryScheduler } from '../../src/services/WebhookRetryScheduler'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
 const DURABLE_FLAG = 'AUTOMATION_DURABLE_DELIVERY_ENABLED'
 const SCHED_DISABLE = 'WEBHOOK_RETRY_SCHEDULER_DISABLED'
+
+// The boot site does not override intervalMs → the loop's default (1_000ms). The zero-tick windows below
+// wait LONGER than two intervals, so a live (leaked) loop could not hide between polls.
+const LOOP_INTERVAL_MS = 1_000
+const PAST_ONE_INTERVAL_MS = 2_200
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Peek the server's private durable loop handle — the round-2 P2 asserts it is NULL after a rejection. */
+function durableLoopHandle(server: MetaSheetServer): unknown {
+  return (server as unknown as { durableDeliveryLoop: unknown }).durableDeliveryLoop
+}
+
+function automationReadyBit(server: MetaSheetServer): boolean {
+  return (server as unknown as { automationServiceReady: boolean }).automationServiceReady
+}
 
 async function startServer(): Promise<{ server: MetaSheetServer; error: unknown }> {
   const server = new MetaSheetServer({ port: 0, host: '127.0.0.1' })
@@ -69,8 +142,9 @@ async function startServer(): Promise<{ server: MetaSheetServer; error: unknown 
  * ENDS the shared poolManager pool, so any lifecycle started after a stop() sees "Cannot use a pool after
  * calling end on the pool" everywhere. Therefore:
  *   - FAILURE lifecycles (start() rejects) are NEVER stopped: the fail-closed throw fires in the boot blocks,
- *     which all run BEFORE `httpServer.listen` (index.ts ~2909), so no socket exists; leaked timers from the
- *     earlier init blocks are reaped when the vitest fork exits.
+ *     which all run BEFORE `httpServer.listen`, so no socket exists. The activation rollback is what
+ *     guarantees no durable loop/scheduler timer survives the rejection — and the failure tests ASSERT that
+ *     (handle null + zero dispatcher DB calls past an interval), instead of relying on fork-exit reaping.
  *   - SUCCESS lifecycles are collected and stopped ONLY in afterAll, in reverse order, catch-wrapped: the
  *     first stop() ends the pool; later stops' pool-dependent cleanup errors are swallowed (their listeners
  *     still close; the fork exits right after).
@@ -90,6 +164,8 @@ describeIfDatabase('durable-delivery startup fail-closed (REAL MetaSheetServer.s
     delete process.env[DURABLE_FLAG]
     delete process.env[SCHED_DISABLE]
     fault.automationCtorThrows = false
+    fault.automationInitThrows = false
+    fault.automationLoadThrows = false
   })
 
   afterAll(async () => {
@@ -98,21 +174,60 @@ describeIfDatabase('durable-delivery startup fail-closed (REAL MetaSheetServer.s
     }
   })
 
-  test('S1 flag ON + retry scheduler disabled → startup REJECTS naming the scheduler (fail-closed)', async () => {
+  test('S1 flag ON + retry scheduler disabled → REJECTS naming the scheduler; loop handle null; zero DB ticks past one interval', async () => {
     process.env[DURABLE_FLAG] = 'true'
     process.env[SCHED_DISABLE] = '1'
-    const { error } = await startServer()
+    const { server, error } = await startServer()
     // start() rejected in the pre-listen boot blocks — nothing to stop (see harness constraint above).
     expect(error).toBeTruthy()
     expect(String(error)).toMatch(/fail-closed.*webhook retry scheduler/)
+    // Round-2 P2: the rejection must leave NO live durable machinery — a null handle AND behavioral silence.
+    expect(durableLoopHandle(server)).toBeNull()
+    expect(getSharedWebhookRetryScheduler()).toBeNull()
+    const before = dispatcherProbe.dbCalls
+    await sleep(PAST_ONE_INTERVAL_MS)
+    expect(PAST_ONE_INTERVAL_MS).toBeGreaterThan(LOOP_INTERVAL_MS)
+    expect(dispatcherProbe.dbCalls).toBe(before)
   })
 
-  test('S2 flag ON + AutomationService init failure → startup REJECTS naming AutomationService (fail-closed)', async () => {
+  test('S2 flag ON + AutomationService constructor throws → REJECTS naming AutomationService (fail-closed)', async () => {
     process.env[DURABLE_FLAG] = 'true'
     fault.automationCtorThrows = true
-    const { error } = await startServer()
+    const { server, error } = await startServer()
     expect(error).toBeTruthy()
     expect(String(error)).toMatch(/fail-closed.*AutomationService/)
+    expect(durableLoopHandle(server)).toBeNull()
+    // The retry scheduler had already started (it boots before the durable block) — the fail-closed
+    // rollback must tear it down so the aborted process leaves no ticking DB timer.
+    expect(getSharedWebhookRetryScheduler()).toBeNull()
+  })
+
+  test('S2-init flag ON + AutomationService init() throws (object constructed) → REJECTS (publish-last, fail-closed)', async () => {
+    process.env[DURABLE_FLAG] = 'true'
+    fault.automationInitThrows = true
+    const { server, error } = await startServer()
+    // Round-2 P1: the object EXISTS (constructor succeeded) — readiness, not existence, must gate the boot.
+    expect(error).toBeTruthy()
+    expect(String(error)).toMatch(/fail-closed.*AutomationService/)
+    expect(automationReadyBit(server)).toBe(false)
+    expect(getAutomationServiceInstance()).toBeNull()
+    expect(durableLoopHandle(server)).toBeNull()
+    expect(getSharedWebhookRetryScheduler()).toBeNull()
+  })
+
+  test('S2-load flag ON + loadAndRegisterAllScheduled rejects (ctor+init succeeded) → REJECTS; loop null; zero DB ticks past one interval', async () => {
+    process.env[DURABLE_FLAG] = 'true'
+    fault.automationLoadThrows = true
+    const { server, error } = await startServer()
+    expect(error).toBeTruthy()
+    expect(String(error)).toMatch(/fail-closed.*AutomationService/)
+    expect(automationReadyBit(server)).toBe(false)
+    expect(getAutomationServiceInstance()).toBeNull()
+    expect(durableLoopHandle(server)).toBeNull()
+    expect(getSharedWebhookRetryScheduler()).toBeNull()
+    const before = dispatcherProbe.dbCalls
+    await sleep(PAST_ONE_INTERVAL_MS)
+    expect(dispatcherProbe.dbCalls).toBe(before)
   })
 
   test('S3 flag OFF + retry scheduler disabled → starts (legacy degrade-and-continue preserved)', async () => {
@@ -123,7 +238,7 @@ describeIfDatabase('durable-delivery startup fail-closed (REAL MetaSheetServer.s
     expect((server.getAddress() as { port?: number } | null)?.port).toBeTruthy()
   })
 
-  test('S4 flag OFF + AutomationService init failure → starts (legacy degrade-and-continue preserved)', async () => {
+  test('S4 flag OFF + AutomationService constructor throws → starts (legacy degrade-and-continue preserved)', async () => {
     fault.automationCtorThrows = true
     const { server, error } = await startServer()
     startedServers.push(server)
@@ -131,11 +246,31 @@ describeIfDatabase('durable-delivery startup fail-closed (REAL MetaSheetServer.s
     expect((server.getAddress() as { port?: number } | null)?.port).toBeTruthy()
   })
 
-  test('S5 flag ON + healthy chain → starts (fail-closed never over-fires; durable loop boots for real)', async () => {
+  test('S4-load flag OFF + load failure → starts degraded (publish-last never over-fires; readiness stays false)', async () => {
+    fault.automationLoadThrows = true
+    const { server, error } = await startServer()
+    startedServers.push(server)
+    expect(error).toBeNull()
+    expect((server.getAddress() as { port?: number } | null)?.port).toBeTruthy()
+    expect(automationReadyBit(server)).toBe(false)
+    expect(durableLoopHandle(server)).toBeNull()
+  })
+
+  test('S5 flag ON + healthy chain → starts; loop handle live; dispatcher DB calls observed (positive control)', async () => {
     process.env[DURABLE_FLAG] = 'true'
     const { server, error } = await startServer()
     startedServers.push(server)
     expect(error).toBeNull()
     expect((server.getAddress() as { port?: number } | null)?.port).toBeTruthy()
+    expect(automationReadyBit(server)).toBe(true)
+    expect(durableLoopHandle(server)).not.toBeNull()
+    // Positive control for the S1/S2-load zero-tick assertions: with a REAL loop running, the probe MUST
+    // move within a few intervals — proving the counter actually observes dispatcher DB activity.
+    const before = dispatcherProbe.dbCalls
+    const deadline = Date.now() + 10_000
+    while (dispatcherProbe.dbCalls === before && Date.now() < deadline) {
+      await sleep(200)
+    }
+    expect(dispatcherProbe.dbCalls).toBeGreaterThan(before)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-durable-startup-failclosed.db.test.ts
+++ b/packages/core-backend/tests/integration/multitable-durable-startup-failclosed.db.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Owner REQUEST-CHANGES (head 5afe30f26) — REAL startup-level fail-closed regression (not just the pure
+ * disposition/assert helpers): drives the actual `MetaSheetServer.start()` lifecycle against Postgres.
+ *
+ * The two P1s: with AUTOMATION_DURABLE_DELIVERY_ENABLED=true, the wired producer families SUPPRESS their
+ * legacy post-commit emits, so a process that starts without the full durable chain does not "degrade" — it
+ * silently strands work:
+ *   - AutomationService init failure was swallowed → `if (this.automationService)` SKIPPED durable boot →
+ *     no dispatcher, every outbox row stranded, no exception anywhere.
+ *   - the webhook retry scheduler could be disabled (WEBHOOK_RETRY_SCHEDULER_DISABLED=1) or fail init and
+ *     startup continued — but the DURABLE webhook leg fire-and-forgets its send and relies on that
+ *     scheduler (pending rows + first-attempt stray grace) for crash recovery.
+ *
+ * Matrix (each case = a REAL server lifecycle):
+ *   S1 flag ON + retry scheduler disabled            → start() REJECTS (fail-closed names the scheduler)
+ *   S2 flag ON + AutomationService init failure      → start() REJECTS (fail-closed names AutomationService;
+ *      the failure is injected into the REAL init path via a module mock whose constructor throws on demand
+ *      — everything else in the boot is real)
+ *   S3 flag OFF + retry scheduler disabled           → starts (legacy degrade preserved)
+ *   S4 flag OFF + AutomationService init failure     → starts (legacy degrade preserved)
+ *   S5 flag ON + healthy                             → starts (fail-closed never over-fires; positive control)
+ *
+ * Failure cases run FIRST (they abort mid-boot, pre-listen, and are never stopped); success lifecycles are
+ * stopped together in afterAll — see the HARNESS CONSTRAINT note below for why (one shared pool per
+ * process). DATABASE_URL-gated; two-point wired (vitest.config exclude + plugin-tests.yml run-list).
+ */
+import { afterAll, afterEach, describe, expect, test, vi } from 'vitest'
+
+// Injected fault switch — hoisted so the module-mock factory (which vitest hoists above imports) can see it.
+const fault = vi.hoisted(() => ({ automationCtorThrows: false }))
+
+// Mock ONLY the AutomationService class inside the otherwise-real module: the subclass throws at construction
+// when the switch is on, else behaves byte-identically (calls through to the real constructor). This injects
+// the "AutomationService initialization failed" path into the REAL server boot, which is otherwise untouched.
+vi.mock('../../src/multitable/automation-service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/multitable/automation-service')>()
+  class FaultInjectedAutomationService extends actual.AutomationService {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(...args: any[]) {
+      if (fault.automationCtorThrows) {
+        throw new Error('injected automation-service init failure (startup fail-closed regression)')
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      super(...(args as [any, any, any, any, any, any, any]))
+    }
+  }
+  return { ...actual, AutomationService: FaultInjectedAutomationService }
+})
+
+import { MetaSheetServer } from '../../src/index'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const DURABLE_FLAG = 'AUTOMATION_DURABLE_DELIVERY_ENABLED'
+const SCHED_DISABLE = 'WEBHOOK_RETRY_SCHEDULER_DISABLED'
+
+async function startServer(): Promise<{ server: MetaSheetServer; error: unknown }> {
+  const server = new MetaSheetServer({ port: 0, host: '127.0.0.1' })
+  try {
+    await server.start()
+    return { server, error: null }
+  } catch (e) {
+    return { server, error: e }
+  }
+}
+
+/**
+ * HARNESS CONSTRAINT — one shared global pool per process: `server.stop()` is a FULL graceful shutdown that
+ * ENDS the shared poolManager pool, so any lifecycle started after a stop() sees "Cannot use a pool after
+ * calling end on the pool" everywhere. Therefore:
+ *   - FAILURE lifecycles (start() rejects) are NEVER stopped: the fail-closed throw fires in the boot blocks,
+ *     which all run BEFORE `httpServer.listen` (index.ts ~2909), so no socket exists; leaked timers from the
+ *     earlier init blocks are reaped when the vitest fork exits.
+ *   - SUCCESS lifecycles are collected and stopped ONLY in afterAll, in reverse order, catch-wrapped: the
+ *     first stop() ends the pool; later stops' pool-dependent cleanup errors are swallowed (their listeners
+ *     still close; the fork exits right after).
+ */
+const startedServers: MetaSheetServer[] = []
+
+async function stopQuietly(server: MetaSheetServer): Promise<void> {
+  try {
+    await (server as unknown as { stop: () => Promise<void> }).stop()
+  } catch {
+    // pool already ended by an earlier stop — remaining cleanup is reaped at fork exit
+  }
+}
+
+describeIfDatabase('durable-delivery startup fail-closed (REAL MetaSheetServer.start lifecycle)', () => {
+  afterEach(() => {
+    delete process.env[DURABLE_FLAG]
+    delete process.env[SCHED_DISABLE]
+    fault.automationCtorThrows = false
+  })
+
+  afterAll(async () => {
+    for (const server of startedServers.reverse()) {
+      await stopQuietly(server)
+    }
+  })
+
+  test('S1 flag ON + retry scheduler disabled → startup REJECTS naming the scheduler (fail-closed)', async () => {
+    process.env[DURABLE_FLAG] = 'true'
+    process.env[SCHED_DISABLE] = '1'
+    const { error } = await startServer()
+    // start() rejected in the pre-listen boot blocks — nothing to stop (see harness constraint above).
+    expect(error).toBeTruthy()
+    expect(String(error)).toMatch(/fail-closed.*webhook retry scheduler/)
+  })
+
+  test('S2 flag ON + AutomationService init failure → startup REJECTS naming AutomationService (fail-closed)', async () => {
+    process.env[DURABLE_FLAG] = 'true'
+    fault.automationCtorThrows = true
+    const { error } = await startServer()
+    expect(error).toBeTruthy()
+    expect(String(error)).toMatch(/fail-closed.*AutomationService/)
+  })
+
+  test('S3 flag OFF + retry scheduler disabled → starts (legacy degrade-and-continue preserved)', async () => {
+    process.env[SCHED_DISABLE] = '1'
+    const { server, error } = await startServer()
+    startedServers.push(server)
+    expect(error).toBeNull()
+    expect((server.getAddress() as { port?: number } | null)?.port).toBeTruthy()
+  })
+
+  test('S4 flag OFF + AutomationService init failure → starts (legacy degrade-and-continue preserved)', async () => {
+    fault.automationCtorThrows = true
+    const { server, error } = await startServer()
+    startedServers.push(server)
+    expect(error).toBeNull()
+    expect((server.getAddress() as { port?: number } | null)?.port).toBeTruthy()
+  })
+
+  test('S5 flag ON + healthy chain → starts (fail-closed never over-fires; durable loop boots for real)', async () => {
+    process.env[DURABLE_FLAG] = 'true'
+    const { server, error } = await startServer()
+    startedServers.push(server)
+    expect(error).toBeNull()
+    expect((server.getAddress() as { port?: number } | null)?.port).toBeTruthy()
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-durable-startup-failclosed.db.test.ts
+++ b/packages/core-backend/tests/integration/multitable-durable-startup-failclosed.db.test.ts
@@ -205,12 +205,16 @@ describeIfDatabase('durable-delivery startup fail-closed (REAL MetaSheetServer.s
   test('S2-init flag ON + AutomationService init() throws (object constructed) → REJECTS (publish-last, fail-closed)', async () => {
     process.env[DURABLE_FLAG] = 'true'
     fault.automationInitThrows = true
+    // NOTE: an EARLIER failing lifecycle (S1) legitimately published its fully-inited service before its
+    // scheduler assert aborted, and failure lifecycles never run stop() — so the singleton observable is
+    // "THIS lifecycle published nothing NEW", not "the singleton is null".
+    const publishedBefore = getAutomationServiceInstance()
     const { server, error } = await startServer()
     // Round-2 P1: the object EXISTS (constructor succeeded) — readiness, not existence, must gate the boot.
     expect(error).toBeTruthy()
     expect(String(error)).toMatch(/fail-closed.*AutomationService/)
     expect(automationReadyBit(server)).toBe(false)
-    expect(getAutomationServiceInstance()).toBeNull()
+    expect(getAutomationServiceInstance()).toBe(publishedBefore)
     expect(durableLoopHandle(server)).toBeNull()
     expect(getSharedWebhookRetryScheduler()).toBeNull()
   })
@@ -218,11 +222,12 @@ describeIfDatabase('durable-delivery startup fail-closed (REAL MetaSheetServer.s
   test('S2-load flag ON + loadAndRegisterAllScheduled rejects (ctor+init succeeded) → REJECTS; loop null; zero DB ticks past one interval', async () => {
     process.env[DURABLE_FLAG] = 'true'
     fault.automationLoadThrows = true
+    const publishedBefore = getAutomationServiceInstance()
     const { server, error } = await startServer()
     expect(error).toBeTruthy()
     expect(String(error)).toMatch(/fail-closed.*AutomationService/)
     expect(automationReadyBit(server)).toBe(false)
-    expect(getAutomationServiceInstance()).toBeNull()
+    expect(getAutomationServiceInstance()).toBe(publishedBefore)
     expect(durableLoopHandle(server)).toBeNull()
     expect(getSharedWebhookRetryScheduler()).toBeNull()
     const before = dispatcherProbe.dbCalls

--- a/packages/core-backend/tests/integration/multitable-webhook-durable-dedup.test.ts
+++ b/packages/core-backend/tests/integration/multitable-webhook-durable-dedup.test.ts
@@ -1,0 +1,118 @@
+/**
+ * P2 durable-delivery closure item 3 (owner 2026-07-17) — idempotent DURABLE webhook delivery per
+ * (webhook_id, event_id).
+ *
+ * Before this: the durable `webhook-event-bridge` consumer called `WebhookService.deliverEvent` with no event
+ * identity, so an at-least-once redelivery (crash between the fire-and-forget send and the consumer-row
+ * done-CAS, or a `busy` retry) created a SECOND delivery row and re-sent the webhook. Now `deliverEvent`
+ * accepts the outbox `eventId` and the per-webhook row is an idempotent CLAIM on the partial-unique
+ * `(webhook_id, event_id)` index.
+ *
+ * Drives the REAL `WebhookService.deliverEvent` against Postgres with a loopback fetch (send count = spy).
+ * Each test uses a DISTINCT event type so its webhook set is isolated (no cross-test send bleed). Runs only
+ * with DATABASE_URL (plugin-tests.yml multitable real-DB job). Asserts its own webhook ids only.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { db } from '../../src/db/db'
+import { WebhookService } from '../../src/multitable/webhook-service'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const USER_ID = `u_whk_dd_${TS}`
+const WH_UPD = `whk_dd_upd_${TS}` // record.updated  — G1, G4 (single subscriber → isolated send count)
+const WH_CRE1 = `whk_dd_cre1_${TS}` // record.created — G2 (two subscribers → per-webhook dedup)
+const WH_CRE2 = `whk_dd_cre2_${TS}` // record.created — G2
+const WH_DEL = `whk_dd_del_${TS}` // record.deleted  — G3 (legacy)
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+let sends: string[] = []
+const loopbackFetch = (async (url: unknown) => {
+  sends.push(String(url))
+  return { ok: true, status: 200, text: async () => 'ok' } as Response
+}) as unknown as typeof fetch
+
+const svc = () => new WebhookService(db, loopbackFetch)
+
+/** deliverEvent fires the HTTP attempt fire-and-forget; wait until the loopback has recorded `atLeast` sends,
+ * then settle a little longer so a spurious extra send would land and be caught. Returns the observed count. */
+async function settleSends(atLeast: number, timeoutMs = 3000): Promise<number> {
+  const deadline = Date.now() + timeoutMs
+  while (sends.length < atLeast && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 25))
+  }
+  await new Promise((r) => setTimeout(r, 150))
+  return sends.length
+}
+
+const rowsFor = async (webhookId: string): Promise<Array<{ id: string; event_id: string | null }>> =>
+  (
+    await q('SELECT id, event_id FROM multitable_webhook_deliveries WHERE webhook_id = $1 ORDER BY created_at', [webhookId])
+  ).rows as Array<{ id: string; event_id: string | null }>
+
+async function seedWebhook(id: string, event: string): Promise<void> {
+  await q(
+    'INSERT INTO multitable_webhooks (id, name, url, secret, events, active, created_by, created_at, failure_count, max_retries) VALUES ($1,$2,$3,$4,$5::jsonb,$6,$7,$8,$9,$10)',
+    [id, `DD ${id}`, `https://sink.test/${id}`, null, JSON.stringify([event]), true, USER_ID, new Date().toISOString(), 0, 3],
+  )
+}
+
+describeIfDatabase('durable webhook delivery — idempotent per (webhook, event_id)', () => {
+  beforeAll(async () => {
+    await seedWebhook(WH_UPD, 'record.updated')
+    await seedWebhook(WH_CRE1, 'record.created')
+    await seedWebhook(WH_CRE2, 'record.created')
+    await seedWebhook(WH_DEL, 'record.deleted')
+  })
+
+  afterAll(async () => {
+    const ids = [WH_UPD, WH_CRE1, WH_CRE2, WH_DEL]
+    await q('DELETE FROM multitable_webhook_deliveries WHERE webhook_id = ANY($1)', [ids]).catch(() => {})
+    await q('DELETE FROM multitable_webhooks WHERE id = ANY($1)', [ids]).catch(() => {})
+  })
+
+  test('G1 durable redelivery with the SAME eventId → still 1 row + 1 send (claim dedups)', async () => {
+    sends = []
+    const E = `evt_dd_g1_${TS}`
+    await svc().deliverEvent('record.updated', { recordId: 'r1' }, E)
+    expect(await settleSends(1)).toBe(1)
+    // the redelivery (crash/busy retry re-enters here with the same identity)
+    await svc().deliverEvent('record.updated', { recordId: 'r1' }, E)
+    expect(await settleSends(1)).toBe(1) // NO second send
+    expect((await rowsFor(WH_UPD)).filter((r) => r.event_id === E)).toHaveLength(1)
+  })
+
+  test('G2 dedup is PER-WEBHOOK: two webhooks on the same event → each gets its own row + send; redeliver dedups both', async () => {
+    sends = []
+    const E = `evt_dd_g2_${TS}`
+    await svc().deliverEvent('record.created', { recordId: 'r2' }, E)
+    expect(await settleSends(2)).toBe(2)
+    expect((await rowsFor(WH_CRE1)).filter((r) => r.event_id === E)).toHaveLength(1)
+    expect((await rowsFor(WH_CRE2)).filter((r) => r.event_id === E)).toHaveLength(1)
+    await svc().deliverEvent('record.created', { recordId: 'r2' }, E)
+    expect(await settleSends(2)).toBe(2) // neither re-sends
+  })
+
+  test('G3 LEGACY path (no eventId) → NULL event_id rows; repeated calls create rows exactly as today', async () => {
+    sends = []
+    await svc().deliverEvent('record.deleted', { recordId: 'r3' }) // no eventId
+    await svc().deliverEvent('record.deleted', { recordId: 'r3' }) // again — legacy has no dedup
+    expect(await settleSends(2)).toBeGreaterThanOrEqual(2)
+    const nullRows = (await rowsFor(WH_DEL)).filter((r) => r.event_id === null)
+    expect(nullRows.length).toBeGreaterThanOrEqual(2) // two legacy rows coexist (partial index does not constrain NULL)
+  })
+
+  test('G4 CONCURRENCY: two genuinely concurrent durable delivers, same (webhook, event) → exactly 1 row + 1 send', async () => {
+    sends = []
+    const E = `evt_dd_g4_${TS}`
+    await Promise.all([
+      svc().deliverEvent('record.updated', { recordId: 'r4' }, E),
+      svc().deliverEvent('record.updated', { recordId: 'r4' }, E),
+    ])
+    expect(await settleSends(1)).toBe(1)
+    expect((await rowsFor(WH_UPD)).filter((r) => r.event_id === E)).toHaveLength(1)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-webhook-retry-tick.test.ts
+++ b/packages/core-backend/tests/integration/multitable-webhook-retry-tick.test.ts
@@ -94,6 +94,35 @@ describeIfDatabase('webhook retry tick (real DB)', () => {
     scheduler.stop()
   })
 
+  test('FIRST-ATTEMPT stray recovery: pending + next_retry_at NULL past the grace is claimed; a fresh in-flight first attempt is NOT', async () => {
+    // deliverEvent fire-and-forgets the first HTTP attempt; a crash before the outcome handler stamps
+    // status/next_retry_at leaves pending + next_retry_at NULL — formerly a stuck absorbing state the
+    // scheduled-retry leg could never select (sink audit 2026-07-17).
+    captured = []
+    const strayId = `del_retry_stray_${TS}`
+    const freshId = `del_retry_fresh_${TS}`
+    const oldCreated = new Date(Date.now() - 10 * 60_000).toISOString() // well past the 5-min stray grace
+    await q(
+      'INSERT INTO multitable_webhook_deliveries (id, webhook_id, event, payload, status, attempt_count, created_at, next_retry_at) VALUES ($1,$2,$3,$4::jsonb,$5,$6,$7,$8)',
+      [strayId, WH_ID, 'record.updated', JSON.stringify({ recordId: 'r-stray' }), 'pending', 0, oldCreated, null],
+    )
+    await q(
+      'INSERT INTO multitable_webhook_deliveries (id, webhook_id, event, payload, status, attempt_count, created_at, next_retry_at) VALUES ($1,$2,$3,$4::jsonb,$5,$6,$7,$8)',
+      [freshId, WH_ID, 'record.updated', JSON.stringify({ recordId: 'r-fresh' }), 'pending', 0, new Date().toISOString(), null],
+    )
+    const scheduler = new WebhookRetryScheduler({
+      service: new WebhookService(db, loopbackFetch),
+    })
+    const retried = await scheduler.tick()
+    expect(retried).toBe(1) // the stray only — the fresh row's first attempt may still be in flight
+    const stray = await q('SELECT status FROM multitable_webhook_deliveries WHERE id = $1', [strayId])
+    expect(stray.rows[0].status).toBe('success') // recovered and delivered (loopback 200)
+    const fresh = await q('SELECT status, next_retry_at FROM multitable_webhook_deliveries WHERE id = $1', [freshId])
+    expect(fresh.rows[0].status).toBe('pending')
+    expect(fresh.rows[0].next_retry_at).toBeNull() // untouched — no double-fire of a live first attempt
+    scheduler.stop()
+  })
+
   test('a second tick does no work once the due delivery is resolved', async () => {
     captured = []
     const scheduler = new WebhookRetryScheduler({

--- a/packages/core-backend/tests/unit/approval-task-created-collector.test.ts
+++ b/packages/core-backend/tests/unit/approval-task-created-collector.test.ts
@@ -1,0 +1,105 @@
+/**
+ * P2 durable-delivery P1#2e — the SHARED `collectLiveApprovalTaskCreatedEvents` core.
+ *
+ * This collector is used by BOTH task_created delivery legs (flag-OFF post-commit `pool.query` + flag-ON in-txn
+ * client), so its filtering CANNOT drift between them. These no-DB unit tests pin the load-bearing filters with
+ * a fake query fn:
+ *   - the `is_active` RECHECK: a task whose assignment row is NOT returned by the active-assignments SELECT
+ *     (i.e. deactivated / never durably active) is DROPPED. This is the precise catch for the "skip the
+ *     is_active recheck" mutation — passing all tasks through would leak the deactivated one and redden here.
+ *     (The real-DB auto-approve golden cannot exercise this, because the current pure cascade removes the
+ *     entry assignment BEFORE it is ever inserted, so `createdTaskEvents` is empty there — see F1-G3.)
+ *   - within-batch DEDUP: a duplicate `(nodeKey:entryEpoch:assigneeUserId)` fires once.
+ *   - eventId BYTE-EQUALITY to the legacy quad formula (the T2-6 dedup ledger key).
+ */
+import { describe, expect, test } from 'vitest'
+
+import {
+  collectLiveApprovalTaskCreatedEvents,
+  type ApprovalTaskCreatedQueryFn,
+  type ApprovalTaskCreatedTaskSnapshot,
+} from '../../src/services/ApprovalTaskCreatedEvent'
+
+const INSTANCE_ID = 'inst_9'
+const NODE = 'approval_1'
+
+/** A fake query fn: the active-assignments SELECT returns `activeRows`; the instance SELECT returns one row. */
+function fakeQuery(activeRows: Array<{ node_key: string; assignee_id: string; entry_epoch: number | null }>): ApprovalTaskCreatedQueryFn {
+  return async (sql: string) => {
+    if (sql.includes('approval_assignments')) return { rows: activeRows as unknown as Array<Record<string, unknown>> }
+    if (sql.includes('approval_instances')) {
+      return {
+        rows: [
+          {
+            id: INSTANCE_ID,
+            request_no: 'RQ-9',
+            template_id: 'tpl_9',
+            template_version_id: 'ver_9',
+            published_definition_id: 'def_9',
+            business_key: 'bk_9',
+            workflow_key: 'wf_9',
+            requester_snapshot: { id: 'req_9' },
+          },
+        ] as Array<Record<string, unknown>>,
+      }
+    }
+    return { rows: [] }
+  }
+}
+
+const task = (assignee: string, entryEpoch: number | null): ApprovalTaskCreatedTaskSnapshot => ({
+  nodeKey: NODE,
+  entryEpoch,
+  assigneeUserId: assignee,
+  sourceStep: 0,
+})
+
+describe('collectLiveApprovalTaskCreatedEvents — the shared recheck+dedup+build core', () => {
+  test('is_active RECHECK: a task whose assignment is NOT active is dropped (mutation catch)', async () => {
+    // Two tasks entered the txn, but only uX survives as an active assignment; uY was deactivated.
+    const tasks = [task('uX', 1), task('uY', 1)]
+    const events = await collectLiveApprovalTaskCreatedEvents(
+      fakeQuery([{ node_key: NODE, assignee_id: 'uX', entry_epoch: 1 }]),
+      INSTANCE_ID,
+      tasks,
+    )
+    expect(events.map((e) => e.task.assigneeUserId)).toEqual(['uX'])
+    // Skipping the is_active filter (passing all tasks) would yield ['uX','uY'] here — the mutation reddens.
+  })
+
+  test('within-batch DEDUP: an identical (node:epoch:assignee) task fires exactly once', async () => {
+    const tasks = [task('uX', 1), task('uX', 1)]
+    const events = await collectLiveApprovalTaskCreatedEvents(
+      fakeQuery([{ node_key: NODE, assignee_id: 'uX', entry_epoch: 1 }]),
+      INSTANCE_ID,
+      tasks,
+    )
+    expect(events).toHaveLength(1)
+  })
+
+  test('eventId is BYTE-EQUAL to the legacy quad formula', async () => {
+    const events = await collectLiveApprovalTaskCreatedEvents(
+      fakeQuery([{ node_key: NODE, assignee_id: 'uX', entry_epoch: 5 }]),
+      INSTANCE_ID,
+      [task('uX', 5)],
+    )
+    expect(events[0].eventId).toBe(`approval-task:${INSTANCE_ID}:${NODE}:5:uX`)
+    expect(events[0].eventType).toBe('approval.task_created')
+    expect(events[0].approval.instanceId).toBe(INSTANCE_ID)
+  })
+
+  test('legacy NULL epoch serializes as the literal "null" segment (dedupe-stable)', async () => {
+    const events = await collectLiveApprovalTaskCreatedEvents(
+      fakeQuery([{ node_key: NODE, assignee_id: 'uX', entry_epoch: null }]),
+      INSTANCE_ID,
+      [task('uX', null)],
+    )
+    expect(events[0].eventId).toBe(`approval-task:${INSTANCE_ID}:${NODE}:null:uX`)
+  })
+
+  test('empty inputs short-circuit: no tasks, or no surviving tasks, returns []', async () => {
+    expect(await collectLiveApprovalTaskCreatedEvents(fakeQuery([]), INSTANCE_ID, [])).toEqual([])
+    // tasks present but NONE active → [] (and the instance SELECT is never reached)
+    expect(await collectLiveApprovalTaskCreatedEvents(fakeQuery([]), INSTANCE_ID, [task('uX', 1)])).toEqual([])
+  })
+})

--- a/packages/core-backend/tests/unit/automation-durable-boot-disposition.test.ts
+++ b/packages/core-backend/tests/unit/automation-durable-boot-disposition.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Owner closure item 4 — startup FAIL-CLOSED policy for a durable-delivery boot failure.
+ *
+ * With the flag ON the wired producer families SUPPRESS their legacy post-commit emits, so a swallowed boot
+ * failure does not "degrade" to the legacy path — it strands every outbox row with no dispatcher (a silent,
+ * total delivery outage strictly worse than a crash). index.ts's boot catch consults this disposition and
+ * RETHROWS on 'fail-closed'; these tests pin the policy so a future edit cannot silently soften it.
+ */
+import { describe, expect, test } from 'vitest'
+
+import { durableBootFailureDisposition } from '../../src/multitable/automation-durable-activation'
+
+describe('durableBootFailureDisposition — flag-ON boot failures abort startup', () => {
+  test('flag ON → fail-closed (the boot site must rethrow; legacy emits are suppressed, degraded mode = outage)', () => {
+    expect(durableBootFailureDisposition({ AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv)).toBe('fail-closed')
+    expect(durableBootFailureDisposition({ AUTOMATION_DURABLE_DELIVERY_ENABLED: ' TRUE ' } as unknown as NodeJS.ProcessEnv)).toBe('fail-closed')
+  })
+
+  test('flag OFF / absent / garbage → degraded-ok (nothing suppressed; legacy path delivers)', () => {
+    expect(durableBootFailureDisposition({} as NodeJS.ProcessEnv)).toBe('degraded-ok')
+    expect(durableBootFailureDisposition({ AUTOMATION_DURABLE_DELIVERY_ENABLED: 'false' } as unknown as NodeJS.ProcessEnv)).toBe('degraded-ok')
+    expect(durableBootFailureDisposition({ AUTOMATION_DURABLE_DELIVERY_ENABLED: '1' } as unknown as NodeJS.ProcessEnv)).toBe('degraded-ok')
+  })
+})

--- a/packages/core-backend/tests/unit/automation-durable-boot-disposition.test.ts
+++ b/packages/core-backend/tests/unit/automation-durable-boot-disposition.test.ts
@@ -8,7 +8,10 @@
  */
 import { describe, expect, test } from 'vitest'
 
-import { durableBootFailureDisposition } from '../../src/multitable/automation-durable-activation'
+import {
+  assertDurableRuntimeDependency,
+  durableBootFailureDisposition,
+} from '../../src/multitable/automation-durable-activation'
 
 describe('durableBootFailureDisposition — flag-ON boot failures abort startup', () => {
   test('flag ON → fail-closed (the boot site must rethrow; legacy emits are suppressed, degraded mode = outage)', () => {
@@ -20,5 +23,27 @@ describe('durableBootFailureDisposition — flag-ON boot failures abort startup'
     expect(durableBootFailureDisposition({} as NodeJS.ProcessEnv)).toBe('degraded-ok')
     expect(durableBootFailureDisposition({ AUTOMATION_DURABLE_DELIVERY_ENABLED: 'false' } as unknown as NodeJS.ProcessEnv)).toBe('degraded-ok')
     expect(durableBootFailureDisposition({ AUTOMATION_DURABLE_DELIVERY_ENABLED: '1' } as unknown as NodeJS.ProcessEnv)).toBe('degraded-ok')
+  })
+})
+
+describe('assertDurableRuntimeDependency — flag-ON load-bearing dependencies abort startup (owner P1s, head 5afe30f26)', () => {
+  const ON = { AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv
+  const OFF = {} as NodeJS.ProcessEnv
+
+  test('flag ON + dependency unavailable → THROWS naming the dependency (AutomationService absent / scheduler disabled)', () => {
+    expect(() => assertDurableRuntimeDependency('AutomationService (durable consumer handlers delegate)', false, ON))
+      .toThrow(/fail-closed.*AutomationService/)
+    expect(() => assertDurableRuntimeDependency('webhook retry scheduler (durable webhook crash recovery)', false, ON))
+      .toThrow(/fail-closed.*webhook retry scheduler/)
+  })
+
+  test('flag ON + dependency available → passes (fail-closed never over-fires on a healthy boot)', () => {
+    expect(() => assertDurableRuntimeDependency('AutomationService (durable consumer handlers delegate)', true, ON)).not.toThrow()
+    expect(() => assertDurableRuntimeDependency('webhook retry scheduler (durable webhook crash recovery)', true, ON)).not.toThrow()
+  })
+
+  test('flag OFF → no-op even when unavailable (legacy degrade-and-continue preserved byte-identically)', () => {
+    expect(() => assertDurableRuntimeDependency('AutomationService (durable consumer handlers delegate)', false, OFF)).not.toThrow()
+    expect(() => assertDurableRuntimeDependency('webhook retry scheduler (durable webhook crash recovery)', false, OFF)).not.toThrow()
   })
 })

--- a/packages/core-backend/tests/unit/automation-durable-consumer-handlers.test.ts
+++ b/packages/core-backend/tests/unit/automation-durable-consumer-handlers.test.ts
@@ -1,0 +1,132 @@
+/**
+ * P2 durable-delivery — S5 real consumer handlers: the mapping proof.
+ *
+ * Each durable consumer_key adapter MUST delegate to the SAME production method the legacy `eventBus.subscribe`
+ * closure calls (structurally closing the manifest's un-enumerable direction). This proves the routing +
+ * payload reconstruction with spy services — no DB, no flag (the builder is a pure delegation over injected
+ * services; `bootDurableDelivery` is the only flag gate and is proven in the real-DB activation suite).
+ */
+import { describe, expect, test } from 'vitest'
+
+import { buildDurableConsumerHandlers, type DurableDeliveryServices } from '../../src/multitable/automation-durable-consumer-handlers'
+import { buildConsumerAdapterRegistry } from '../../src/multitable/automation-durable-activation'
+import { assertManifestCompleteness, manifestConsumerKeys } from '../../src/multitable/automation-routing-manifest'
+import type { ClaimedConsumer } from '../../src/multitable/automation-durable-dispatcher'
+
+type Call = { method: string; args: unknown[] }
+
+function spyServices(): { services: DurableDeliveryServices; calls: Call[] } {
+  const calls: Call[] = []
+  const rec = (method: string) => async (...args: unknown[]) => {
+    calls.push({ method, args })
+  }
+  const services: DurableDeliveryServices = {
+    automationService: {
+      handleApprovalCompletionEvent: rec('handleApprovalCompletionEvent'),
+      handleApprovalCompletionTrigger: rec('handleApprovalCompletionTrigger'),
+      handleApprovalTaskCreatedTrigger: rec('handleApprovalTaskCreatedTrigger'),
+      handleEvent: rec('handleEvent'),
+    },
+    projectionService: { reconcile: rec('reconcile') as unknown as (id: string) => Promise<unknown> },
+    webhookService: { deliverEvent: rec('deliverEvent') as unknown as (e: never, p: unknown) => Promise<unknown> },
+  }
+  return { services, calls }
+}
+
+function claimed(over: Partial<ClaimedConsumer> & Pick<ClaimedConsumer, 'consumerKey' | 'eventType'>): ClaimedConsumer {
+  return {
+    outboxId: 'obx_1',
+    fence: '1',
+    attempts: 1,
+    eventId: 'evt_stable_1',
+    payload: {},
+    automationDepth: 0,
+    manifestVersion: 1,
+    ...over,
+  }
+}
+
+const approvalPayload = {
+  version: 1,
+  eventId: 'evt_stable_1',
+  eventType: 'approval.approved',
+  source: 'approval-product',
+  approval: { instanceId: 'appr_inst_9' },
+  transition: { toStatus: 'approved' },
+}
+
+describe('buildDurableConsumerHandlers — durable consumer_key → real production method', () => {
+  test('approval-bridge delegates to handleApprovalCompletionEvent with the reconstructed event payload', async () => {
+    const { services, calls } = spyServices()
+    const handlers = buildDurableConsumerHandlers(services)
+    await handlers['approval-bridge'](claimed({ consumerKey: 'approval-bridge', eventType: 'approval.approved', payload: approvalPayload }))
+    expect(calls).toEqual([{ method: 'handleApprovalCompletionEvent', args: [approvalPayload] }])
+  })
+
+  test('approval-trigger delegates to handleApprovalCompletionTrigger (NOT the bridge)', async () => {
+    const { services, calls } = spyServices()
+    const handlers = buildDurableConsumerHandlers(services)
+    await handlers['approval-trigger'](claimed({ consumerKey: 'approval-trigger', eventType: 'approval.rejected', payload: approvalPayload }))
+    expect(calls).toEqual([{ method: 'handleApprovalCompletionTrigger', args: [approvalPayload] }])
+  })
+
+  test('approval-projection delegates to reconcile(instanceId) taken from the payload', async () => {
+    const { services, calls } = spyServices()
+    const handlers = buildDurableConsumerHandlers(services)
+    await handlers['approval-projection'](claimed({ consumerKey: 'approval-projection', eventType: 'approval.approved', payload: approvalPayload }))
+    expect(calls).toEqual([{ method: 'reconcile', args: ['appr_inst_9'] }])
+  })
+
+  test('approval-projection with NO instanceId is a no-op success (no reconcile, no throw)', async () => {
+    const { services, calls } = spyServices()
+    const handlers = buildDurableConsumerHandlers(services)
+    await expect(
+      handlers['approval-projection'](claimed({ consumerKey: 'approval-projection', eventType: 'approval.approved', payload: { approval: {} } })),
+    ).resolves.toBeUndefined()
+    expect(calls).toEqual([])
+  })
+
+  test('approval-task-trigger delegates to handleApprovalTaskCreatedTrigger with the payload', async () => {
+    const { services, calls } = spyServices()
+    const handlers = buildDurableConsumerHandlers(services)
+    const taskPayload = { version: 1, eventId: 'evt_task', templateId: 't1' }
+    await handlers['approval-task-trigger'](claimed({ consumerKey: 'approval-task-trigger', eventType: 'approval.task_created', payload: taskPayload }))
+    expect(calls).toEqual([{ method: 'handleApprovalTaskCreatedTrigger', args: [taskPayload] }])
+  })
+
+  test('automation-record-trigger delegates to handleEvent(eventType, payload) overlaying the durable _eventId + _automationDepth', async () => {
+    const { services, calls } = spyServices()
+    const handlers = buildDurableConsumerHandlers(services)
+    await handlers['automation-record-trigger'](
+      claimed({ consumerKey: 'automation-record-trigger', eventType: 'multitable.record.created', eventId: 'evt_durable_id', automationDepth: 2, payload: { sheetId: 's1', recordId: 'r1', _eventId: 'STALE', _automationDepth: 99 } }),
+    )
+    // the DURABLE row's identity + depth win — a re-delivery dedups on the stable original id, not a stale copy
+    expect(calls).toEqual([
+      { method: 'handleEvent', args: ['multitable.record.created', { sheetId: 's1', recordId: 'r1', _eventId: 'evt_durable_id', _automationDepth: 2 }] },
+    ])
+  })
+
+  test('webhook-event-bridge maps the event type via the SAME table the bus bridge uses, then deliverEvent', async () => {
+    const { services, calls } = spyServices()
+    const handlers = buildDurableConsumerHandlers(services)
+    const payload = { some: 'record-event' }
+    await handlers['webhook-event-bridge'](claimed({ consumerKey: 'webhook-event-bridge', eventType: 'multitable.comment.created', payload }))
+    expect(calls).toEqual([{ method: 'deliverEvent', args: ['comment.created', payload] }])
+  })
+
+  test('webhook-event-bridge THROWS on an unmapped event type (retryable adapter_error, never a silent drop)', async () => {
+    const { services } = spyServices()
+    const handlers = buildDurableConsumerHandlers(services)
+    await expect(
+      handlers['webhook-event-bridge'](claimed({ consumerKey: 'webhook-event-bridge', eventType: 'multitable.record.moved', payload: {} })),
+    ).rejects.toThrow(/no webhook mapping/)
+  })
+
+  test('the REAL handler set is manifest-complete (registry keys === every routed consumer_key, bidirectional)', () => {
+    const { services } = spyServices()
+    const registry = buildConsumerAdapterRegistry(buildDurableConsumerHandlers(services))
+    // bidirectional: no routed key without an adapter, no adapter without a route (throws otherwise)
+    expect(() => assertManifestCompleteness(registry)).not.toThrow()
+    expect(registry.keys().sort()).toEqual(manifestConsumerKeys().sort())
+  })
+})

--- a/packages/core-backend/tests/unit/automation-durable-consumer-handlers.test.ts
+++ b/packages/core-backend/tests/unit/automation-durable-consumer-handlers.test.ts
@@ -110,8 +110,10 @@ describe('buildDurableConsumerHandlers — durable consumer_key → real product
     const { services, calls } = spyServices()
     const handlers = buildDurableConsumerHandlers(services)
     const payload = { some: 'record-event' }
-    await handlers['webhook-event-bridge'](claimed({ consumerKey: 'webhook-event-bridge', eventType: 'multitable.record.updated', payload }))
-    expect(calls).toEqual([{ method: 'deliverEvent', args: ['record.updated', payload] }])
+    await handlers['webhook-event-bridge'](claimed({ consumerKey: 'webhook-event-bridge', eventType: 'multitable.record.updated', payload, eventId: 'evt_whk_id' }))
+    // The outbox eventId is threaded as the 3rd arg (closure item 3 — per-(webhook, event) dedup); a mutant
+    // that drops it reds here.
+    expect(calls).toEqual([{ method: 'deliverEvent', args: ['record.updated', payload, 'evt_whk_id'] }])
   })
 
   test('webhook-event-bridge THROWS on an unmapped event type (retryable adapter_error, never a silent drop)', async () => {

--- a/packages/core-backend/tests/unit/automation-durable-consumer-handlers.test.ts
+++ b/packages/core-backend/tests/unit/automation-durable-consumer-handlers.test.ts
@@ -110,8 +110,8 @@ describe('buildDurableConsumerHandlers — durable consumer_key → real product
     const { services, calls } = spyServices()
     const handlers = buildDurableConsumerHandlers(services)
     const payload = { some: 'record-event' }
-    await handlers['webhook-event-bridge'](claimed({ consumerKey: 'webhook-event-bridge', eventType: 'multitable.comment.created', payload }))
-    expect(calls).toEqual([{ method: 'deliverEvent', args: ['comment.created', payload] }])
+    await handlers['webhook-event-bridge'](claimed({ consumerKey: 'webhook-event-bridge', eventType: 'multitable.record.updated', payload }))
+    expect(calls).toEqual([{ method: 'deliverEvent', args: ['record.updated', payload] }])
   })
 
   test('webhook-event-bridge THROWS on an unmapped event type (retryable adapter_error, never a silent drop)', async () => {

--- a/packages/core-backend/tests/unit/automation-producer-emit-approval.test.ts
+++ b/packages/core-backend/tests/unit/automation-producer-emit-approval.test.ts
@@ -1,0 +1,92 @@
+/**
+ * P2 durable-delivery P1#2e — producer family 1 seam (`enqueueApprovalEventIfDurable`).
+ *
+ * Pins the two load-bearing decisions of the approval seam entry WITHOUT a DB (the real-DB enqueue is proven by
+ * the family-1 goldens): (1) flag OFF ⇒ a pure no-op that never touches the transaction handle; (2) flag ON ⇒
+ * it forwards the WHOLE approval event as the durable `payload`, keys the outbox on the event's TOP-LEVEL
+ * `eventId` (NOT a record-event `_eventId`), and stamps `automation_depth = 0` (an approval event is an
+ * ORIGINAL producer event, never an automation-chain link). A fake in-transaction handle answers the
+ * `pg_current_xact_id()` probe with a stable xid and records the INSERTs.
+ */
+import { describe, expect, test, vi } from 'vitest'
+
+import { enqueueApprovalEventIfDurable } from '../../src/multitable/automation-producer-emit'
+import type { TransactionalQueryable } from '../../src/multitable/pg-transaction-guard'
+
+const FLAG_ON = { AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv
+const FLAG_OFF = {} as NodeJS.ProcessEnv
+
+const completionEvent = {
+  version: 1,
+  eventId: 'approval:inst_1:3:approval.approved',
+  eventType: 'approval.approved',
+  occurredAt: '2026-07-17T00:00:00.000Z',
+  source: 'approval-product',
+  approval: { instanceId: 'inst_1', requestNo: 'RQ-1' },
+  transition: { action: 'approve', toStatus: 'approved', toVersion: 3 },
+  actor: { id: 'u1', name: 'U1' },
+  requester: { id: 'u0' },
+}
+
+/** A fake handle that PASSES the xid probe (stable id) and records every non-probe statement's [sql, params]. */
+function fakeTxn(): { trx: TransactionalQueryable; writes: Array<{ sql: string; params?: unknown[] }> } {
+  const writes: Array<{ sql: string; params?: unknown[] }> = []
+  const trx = {
+    isTransaction: true as const,
+    query: async (sql: string, params?: unknown[]) => {
+      if (sql.includes('pg_current_xact_id')) return { rows: [{ xid: '777' }], rowCount: 1 }
+      writes.push({ sql, params })
+      return { rows: [] as Array<Record<string, unknown>>, rowCount: 1 }
+    },
+  }
+  return { trx, writes }
+}
+
+describe('enqueueApprovalEventIfDurable — flag OFF is a pure no-op', () => {
+  test('returns false and never touches the transaction handle', async () => {
+    const query = vi.fn()
+    const trx = { isTransaction: true as const, query } as unknown as TransactionalQueryable
+    expect(await enqueueApprovalEventIfDurable(trx, completionEvent, FLAG_OFF)).toBe(false)
+    expect(query).not.toHaveBeenCalled()
+  })
+})
+
+describe('enqueueApprovalEventIfDurable — flag ON enqueues the FULL event, keyed on top-level eventId, depth 0', () => {
+  test('outbox INSERT carries the whole event payload + eventId + automation_depth 0; consumers = completion fan-out', async () => {
+    const { trx, writes } = fakeTxn()
+    expect(await enqueueApprovalEventIfDurable(trx, completionEvent, FLAG_ON)).toBe(true)
+
+    const outboxInsert = writes.find((w) => w.sql.includes('INSERT INTO meta_automation_outbox '))
+    expect(outboxInsert).toBeDefined()
+    // params: [id, event_type, payload::jsonb, automation_depth, manifest_version, event_id]
+    const p = outboxInsert!.params as unknown[]
+    expect(p[1]).toBe('approval.approved')
+    expect(JSON.parse(p[2] as string)).toEqual(completionEvent) // WHOLE event forwarded verbatim as payload
+    expect(p[3]).toBe(0) // automation_depth: an approval event is an ORIGINAL producer event
+    expect(p[5]).toBe(completionEvent.eventId) // keyed on the TOP-LEVEL eventId, not a record `_eventId`
+
+    const consumerInsert = writes.find((w) => w.sql.includes('meta_automation_outbox_consumer'))
+    expect(consumerInsert).toBeDefined()
+    // approval.approved fans out to the three completion consumers (manifest v1).
+    expect(consumerInsert!.params?.[1]).toEqual(['approval-bridge', 'approval-trigger', 'approval-projection'])
+  })
+
+  test('task_created event routes to exactly [approval-task-trigger]', async () => {
+    const { trx, writes } = fakeTxn()
+    const taskEvent = {
+      version: 1,
+      eventId: 'approval-task:inst_1:approval_1:1:u5',
+      eventType: 'approval.task_created',
+      occurredAt: '2026-07-17T00:00:00.000Z',
+      source: 'approval-product',
+      approval: { instanceId: 'inst_1' },
+      task: { nodeKey: 'approval_1', entryEpoch: 1, assigneeUserId: 'u5', sourceStep: 0 },
+      requester: { id: 'u0' },
+    }
+    expect(await enqueueApprovalEventIfDurable(trx, taskEvent, FLAG_ON)).toBe(true)
+    const consumerInsert = writes.find((w) => w.sql.includes('meta_automation_outbox_consumer'))
+    expect(consumerInsert!.params?.[1]).toEqual(['approval-task-trigger'])
+    const outboxInsert = writes.find((w) => w.sql.includes('INSERT INTO meta_automation_outbox '))
+    expect((outboxInsert!.params as unknown[])[5]).toBe(taskEvent.eventId)
+  })
+})

--- a/packages/core-backend/tests/unit/automation-producer-emit.test.ts
+++ b/packages/core-backend/tests/unit/automation-producer-emit.test.ts
@@ -1,0 +1,39 @@
+/**
+ * P2 durable-delivery P1 #2 — producer REPLACE seam (the flag-ON suppression is the load-bearing guard).
+ *
+ * The design decision (FWB0 lock §Layer-1 lines 318-324): flag ON ⇒ the durable same-txn enqueue REPLACES the
+ * legacy post-commit emit. These unit tests pin the two phases' flag gating with spies (no DB): flag OFF emits
+ * / does not enqueue; flag ON suppresses the emit (the enqueue happened same-txn). If the suppression is ever
+ * neutralized, the "flag ON suppresses" test reddens (double-delivery).
+ */
+import { describe, expect, test, vi } from 'vitest'
+
+import { emitRecordEventIfLegacy, enqueueRecordEventIfDurable } from '../../src/multitable/automation-producer-emit'
+import type { TransactionalQueryable } from '../../src/multitable/pg-transaction-guard'
+
+const FLAG_ON = { AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv
+const FLAG_OFF = {} as NodeJS.ProcessEnv
+const payload = { sheetId: 's1', recordId: 'r1', _eventId: 'evt_1', _automationDepth: 2 }
+
+describe('emitRecordEventIfLegacy — legacy emit fires ONLY when durable delivery is OFF', () => {
+  test('flag OFF: emits the legacy event (byte-identical) and returns true', () => {
+    const bus = { emit: vi.fn() }
+    expect(emitRecordEventIfLegacy(bus, 'multitable.record.updated', payload, FLAG_OFF)).toBe(true)
+    expect(bus.emit).toHaveBeenCalledTimes(1)
+    expect(bus.emit).toHaveBeenCalledWith('multitable.record.updated', payload)
+  })
+
+  test('flag ON: SUPPRESSED — does NOT emit (the same-txn enqueue is the delivery path); returns false', () => {
+    const bus = { emit: vi.fn() }
+    expect(emitRecordEventIfLegacy(bus, 'multitable.record.updated', payload, FLAG_ON)).toBe(false)
+    expect(bus.emit).not.toHaveBeenCalled() // keep-both would double-deliver the non-idempotent webhook sink
+  })
+})
+
+describe('enqueueRecordEventIfDurable — same-txn enqueue ONLY when durable delivery is ON', () => {
+  test('flag OFF: no-op — never touches the transaction handle, returns false', async () => {
+    const trx = { isTransaction: true as const, query: vi.fn() } as unknown as TransactionalQueryable & { query: ReturnType<typeof vi.fn> }
+    expect(await enqueueRecordEventIfDurable(trx, 'multitable.record.updated', payload, FLAG_OFF)).toBe(false)
+    expect((trx as unknown as { query: ReturnType<typeof vi.fn> }).query).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core-backend/tests/unit/automation-routing-manifest.test.ts
+++ b/packages/core-backend/tests/unit/automation-routing-manifest.test.ts
@@ -37,7 +37,10 @@ describe('P2 S3 — routing manifest v1 (lock #4203 §283-291 full set)', () => 
       expect(expandConsumerKeysForEvent(t)).toEqual(['automation-record-trigger', 'webhook-event-bridge'])
     }
     expect(expandConsumerKeysForEvent('multitable.comment.created')).toEqual(['webhook-event-bridge'])
-    expect(expandConsumerKeysForEvent('form.submitted')).toEqual(['automation-record-trigger'])
+    // BUS event type (what univer-meta emits + automation-service subscribes) — NOT the trigger type
+    // 'form.submitted' the lock's prose shorthand used; the bare trigger-type literal routes nothing.
+    expect(expandConsumerKeysForEvent('multitable.form.submitted')).toEqual(['automation-record-trigger'])
+    expect(expandConsumerKeysForEvent('form.submitted')).toBeUndefined()
     // the distinct key universe is exactly the six ratified consumers — no stragglers, none missing
     expect([...manifestConsumerKeys()].sort()).toEqual([...FULL_V1_KEYS].sort())
     // EXACT event-family set — a route ADDED/removed/renamed reds even if it reuses an existing consumer
@@ -48,8 +51,8 @@ describe('P2 S3 — routing manifest v1 (lock #4203 §283-291 full set)', () => 
       'approval.rejected',
       'approval.revoked',
       'approval.task_created',
-      'form.submitted',
       'multitable.comment.created',
+      'multitable.form.submitted',
       'multitable.record.created',
       'multitable.record.deleted',
       'multitable.record.updated',

--- a/packages/core-backend/tests/unit/automation-routing-manifest.test.ts
+++ b/packages/core-backend/tests/unit/automation-routing-manifest.test.ts
@@ -36,7 +36,9 @@ describe('P2 S3 — routing manifest v1 (lock #4203 §283-291 full set)', () => 
     for (const t of ['multitable.record.created', 'multitable.record.updated', 'multitable.record.deleted']) {
       expect(expandConsumerKeysForEvent(t)).toEqual(['automation-record-trigger', 'webhook-event-bridge'])
     }
-    expect(expandConsumerKeysForEvent('multitable.comment.created')).toEqual(['webhook-event-bridge'])
+    // REMOVED from v1 (owner closure item 2): no producer exists anywhere for this event type — a route
+    // nobody produces is dead configuration; family-6 (real comment producer) re-adds it as manifest v2.
+    expect(expandConsumerKeysForEvent('multitable.comment.created')).toBeUndefined()
     // BUS event type (what univer-meta emits + automation-service subscribes) — NOT the trigger type
     // 'form.submitted' the lock's prose shorthand used; the bare trigger-type literal routes nothing.
     expect(expandConsumerKeysForEvent('multitable.form.submitted')).toEqual(['automation-record-trigger'])
@@ -51,7 +53,6 @@ describe('P2 S3 — routing manifest v1 (lock #4203 §283-291 full set)', () => 
       'approval.rejected',
       'approval.revoked',
       'approval.task_created',
-      'multitable.comment.created',
       'multitable.form.submitted',
       'multitable.record.created',
       'multitable.record.deleted',

--- a/packages/core-backend/tests/unit/record-service-producer-replace.test.ts
+++ b/packages/core-backend/tests/unit/record-service-producer-replace.test.ts
@@ -1,0 +1,209 @@
+/**
+ * P2 durable-delivery P1 #2b — family 4 (record-service CRUD) REPLACE wiring, pure-unit (no DB).
+ *
+ * The real-DB family-4 suite (`multitable-automation-producer-family4-realdb.test.ts`) is the site golden;
+ * it only runs inside the DATABASE_URL-gated CI step. THIS file keeps the load-bearing suppression guard in
+ * the default no-DB unit job: with `AUTOMATION_DURABLE_DELIVERY_ENABLED=true`, the REAL createRecord /
+ * patchRecord / deleteRecord must (a) NOT emit on the legacy bus (REPLACE, not keep-both) and (b) attempt
+ * the same-transaction outbox enqueue (positive control — "no emit" alone could be faked by a dead site).
+ * With the flag OFF (default), the legacy emit fires byte-identically and the outbox is never touched.
+ *
+ * The mock pool answers the seam's runtime xid probe (`pg_current_xact_id`) with a constant xid, which is
+ * exactly what a REAL in-transaction handle looks like to the probe — the services hand the seam their
+ * `pool.transaction` handle, so both probe statements go through one "connection".
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { RecordService, type ConnectionPool, type QueryFn } from '../../src/multitable/record-service'
+
+vi.mock('../../src/multitable/realtime-publish', () => ({
+  publishMultitableSheetRealtime: vi.fn(),
+}))
+
+const FLAG = 'AUTOMATION_DURABLE_DELIVERY_ENABLED'
+
+const fullCapabilities = {
+  canRead: true,
+  canCreateRecord: true,
+  canEditRecord: true,
+  canDeleteRecord: true,
+  canManageFields: true,
+  canManageSheetAccess: true,
+  canManageViews: true,
+  canComment: true,
+  canManageAutomation: true,
+  canExport: true,
+}
+const access = { userId: 'user_1', permissions: ['multitable:write'], isAdminRole: false }
+
+function createMockEventBus() {
+  return { emit: vi.fn(), publish: vi.fn(), subscribe: vi.fn().mockReturnValue('sub_1'), unsubscribe: vi.fn() }
+}
+
+type QueryResponse = { rows: unknown[]; rowCount?: number | null }
+
+function createMockPool(): ConnectionPool & { queryMock: ReturnType<typeof vi.fn> } {
+  const queryMock = vi.fn(async (sql: string, _params?: unknown[]): Promise<QueryResponse> => {
+    // P1#2 seam: the pg-transaction-guard probe — a constant xid means "one ongoing transaction".
+    if (sql.includes('pg_current_xact_id')) {
+      return { rows: [{ xid: '4242' }] }
+    }
+    if (sql.includes('INSERT INTO meta_automation_outbox_consumer')) {
+      return { rows: [], rowCount: 2 }
+    }
+    if (sql.includes('INSERT INTO meta_automation_outbox')) {
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes('SELECT id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL')) {
+      return { rows: [{ id: 'sheet_ops' }] }
+    }
+    if (sql.includes('FROM meta_fields WHERE sheet_id = $1')) {
+      return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {} }] }
+    }
+    if (sql.includes('SELECT pg_advisory_xact_lock')) {
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes('INSERT INTO meta_records') && sql.includes('RETURNING version')) {
+      return { rows: [{ version: 1 }] }
+    }
+    if (sql.includes('INSERT INTO meta_record_revisions')) {
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes('FROM meta_record_subscriptions')) {
+      return { rows: [] }
+    }
+    if (sql.includes('SELECT id, sheet_id, created_by, locked, locked_by') && sql.includes('FROM meta_records WHERE id = $1')) {
+      return {
+        rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', created_by: 'user_1', locked: false, locked_by: null, created_at: null, updated_at: null }],
+      }
+    }
+    if (sql.includes('SELECT id, sheet_id, version, data FROM meta_records WHERE id = $1 FOR UPDATE')) {
+      return { rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', version: 4, data: { fld_title: 'Before' } }] }
+    }
+    if (sql.includes('SELECT id, version, data, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+      return { rows: [{ id: 'rec_existing', version: 4, data: { fld_title: 'Before' }, created_by: 'user_1', locked: false, locked_by: null }] }
+    }
+    if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {
+      return { rows: [{ version: 5 }], rowCount: 1 }
+    }
+    if (sql.includes('SELECT id, config FROM meta_views WHERE sheet_id = $1 AND type = $2')) {
+      return { rows: [] }
+    }
+    if (sql.includes('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1')) {
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes('DELETE FROM meta_records WHERE id = $1')) {
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes('SELECT base_id FROM meta_sheets WHERE id = $1')) {
+      return { rows: [{ base_id: 'base_ops' }] }
+    }
+    if (sql.includes('INSERT INTO meta_records_trash')) {
+      return { rows: [], rowCount: 1 }
+    }
+    throw new Error(`Unhandled SQL in test: ${sql}`)
+  })
+  return {
+    query: queryMock as unknown as QueryFn,
+    queryMock,
+    transaction: async <T>(handler: (client: { query: QueryFn }) => Promise<T>) =>
+      handler({ query: queryMock as unknown as QueryFn }),
+  }
+}
+
+const outboxInsertsOf = (pool: ReturnType<typeof createMockPool>) =>
+  pool.queryMock.mock.calls.filter(
+    ([sql]) => String(sql).includes('INSERT INTO meta_automation_outbox') && !String(sql).includes('outbox_consumer'),
+  )
+
+describe('P1#2b family 4 — record-service REPLACE wiring (unit, no DB)', () => {
+  let pool: ReturnType<typeof createMockPool>
+  let eventBus: ReturnType<typeof createMockEventBus>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    pool = createMockPool()
+    eventBus = createMockEventBus()
+  })
+
+  afterEach(() => {
+    delete process.env[FLAG]
+  })
+
+  const svc = () => new RecordService(pool, eventBus as never)
+
+  describe('flag ON — durable enqueue REPLACES the legacy emit at the real site', () => {
+    beforeEach(() => {
+      process.env[FLAG] = 'true'
+    })
+
+    it('createRecord: legacy bus SUPPRESSED; same-txn outbox enqueue attempted (positive control)', async () => {
+      await svc().createRecord({ sheetId: 'sheet_ops', data: { fld_title: 'Alpha' }, actorId: 'user_1', capabilities: { ...fullCapabilities } })
+      expect(eventBus.emit).not.toHaveBeenCalled()
+      expect(outboxInsertsOf(pool).length).toBeGreaterThan(0)
+      expect(pool.queryMock).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO meta_automation_outbox_consumer'), expect.anything())
+    })
+
+    it('patchRecord: legacy bus SUPPRESSED; same-txn outbox enqueue attempted', async () => {
+      await svc().patchRecord({ recordId: 'rec_existing', sheetId: 'sheet_ops', data: { fld_title: 'After' }, actorId: 'user_1', access, capabilities: { ...fullCapabilities } })
+      expect(eventBus.emit).not.toHaveBeenCalled()
+      expect(outboxInsertsOf(pool).length).toBeGreaterThan(0)
+    })
+
+    it('deleteRecord: legacy bus SUPPRESSED; same-txn outbox enqueue attempted', async () => {
+      await svc().deleteRecord({
+        recordId: 'rec_existing',
+        actorId: 'user_1',
+        access,
+        resolveSheetAccess: async () => ({ capabilities: { ...fullCapabilities } }),
+      })
+      expect(eventBus.emit).not.toHaveBeenCalled()
+      expect(outboxInsertsOf(pool).length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('flag OFF (default) — legacy emit byte-identical, outbox never touched', () => {
+    it('createRecord: emits the legacy created event; no outbox statement', async () => {
+      const result = await svc().createRecord({ sheetId: 'sheet_ops', data: { fld_title: 'Alpha' }, actorId: 'user_1', capabilities: { ...fullCapabilities } })
+      expect(eventBus.emit).toHaveBeenCalledTimes(1)
+      expect(eventBus.emit).toHaveBeenCalledWith('multitable.record.created', {
+        sheetId: 'sheet_ops',
+        recordId: result.recordId,
+        data: { fld_title: 'Alpha' },
+        actorId: 'user_1',
+        _eventId: expect.any(String),
+      })
+      expect(outboxInsertsOf(pool)).toHaveLength(0)
+    })
+
+    it('patchRecord: emits the legacy updated event; no outbox statement', async () => {
+      await svc().patchRecord({ recordId: 'rec_existing', sheetId: 'sheet_ops', data: { fld_title: 'After' }, actorId: 'user_1', access, capabilities: { ...fullCapabilities } })
+      expect(eventBus.emit).toHaveBeenCalledTimes(1)
+      expect(eventBus.emit).toHaveBeenCalledWith('multitable.record.updated', {
+        sheetId: 'sheet_ops',
+        recordId: 'rec_existing',
+        data: { fld_title: 'After' },
+        actorId: 'user_1',
+        _eventId: expect.any(String),
+      })
+      expect(outboxInsertsOf(pool)).toHaveLength(0)
+    })
+
+    it('deleteRecord: emits the legacy deleted event; no outbox statement', async () => {
+      await svc().deleteRecord({
+        recordId: 'rec_existing',
+        actorId: 'user_1',
+        access,
+        resolveSheetAccess: async () => ({ capabilities: { ...fullCapabilities } }),
+      })
+      expect(eventBus.emit).toHaveBeenCalledTimes(1)
+      expect(eventBus.emit).toHaveBeenCalledWith('multitable.record.deleted', {
+        sheetId: 'sheet_ops',
+        recordId: 'rec_existing',
+        actorId: 'user_1',
+        _eventId: expect.any(String),
+      })
+      expect(outboxInsertsOf(pool)).toHaveLength(0)
+    })
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -272,6 +272,9 @@ export default defineConfig({
       'tests/integration/multitable-automation-producer-emit-realdb.test.ts',
       // P1#2c producer family 2 (executor Class-A record events) REPLACE site goldens: real DB, same shape.
       'tests/integration/multitable-automation-producer-family2-realdb.test.ts',
+      // P1#2d producer family 5 (univer-meta routes ×4) durable REPLACE goldens (route-driven): real DB.
+      // Excluded here so it cannot skip-green, whole-file wired into plugin-tests.yml's attendance real-DB step.
+      'tests/integration/multitable-automation-producer-family5-realdb.test.ts',
       // F9 owner CHANGES-REQUESTED (GF9-1/GF9-2): multitable_attachments blob_purged_at migration +
       // deleteAttachmentBinary index-free delete + sweepMultitableAttachmentBlobPurge compensating-sweep
       // matrix, same shape/rationale as the F5 entry immediately above (DATABASE_URL-gated describeDb,

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -270,6 +270,8 @@ export default defineConfig({
       // P1#2 producer REPLACE seam same-txn goldens (enqueueRecordEventIfDurable commit/rollback/off): real DB.
       // Excluded here so it cannot skip-green, whole-file wired into plugin-tests.yml's attendance real-DB step.
       'tests/integration/multitable-automation-producer-emit-realdb.test.ts',
+      // P1#2c producer family 2 (executor Class-A record events) REPLACE site goldens: real DB, same shape.
+      'tests/integration/multitable-automation-producer-family2-realdb.test.ts',
       // F9 owner CHANGES-REQUESTED (GF9-1/GF9-2): multitable_attachments blob_purged_at migration +
       // deleteAttachmentBinary index-free delete + sweepMultitableAttachmentBlobPurge compensating-sweep
       // matrix, same shape/rationale as the F5 entry immediately above (DATABASE_URL-gated describeDb,

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -385,6 +385,9 @@ export default defineConfig({
       // P2 durable-delivery S4-a producer atomic enqueue — real-DB (txn atomicity + fan-out + e2e tick).
       // Excluded HERE so it cannot skip-green in the no-DB lane; whole-file wired into plugin-tests.yml.
       'tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts',
+      // P2 durable-delivery S4-b/S5 activation seam + S7 crash-injection V-series — real-DB. Excluded
+      // HERE so it cannot skip-green in the no-DB lane; whole-file wired into plugin-tests.yml.
+      'tests/integration/multitable-automation-durable-activation-realdb.test.ts',
       // W0 tail (#4279, owner MUST-WRITE OD-6, design-lock §0.5 2026-07-13): field-undelete rehydration
       // revision goldens — proves `recreateFieldFromConfig`'s tombstone-value rehydration UPDATE bumps
       // `version` and emits a `recordRecordRevision` AT THE NEW version, same transaction, for every

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -267,6 +267,9 @@ export default defineConfig({
       // P1#1 approval-bridge LEASE claim/reclaim runtime crash matrix (terminal-early removal): real DB.
       // Excluded here so it cannot skip-green, whole-file wired into plugin-tests.yml's attendance real-DB step.
       'tests/integration/multitable-automation-approval-bridge-lease-realdb.test.ts',
+      // P1#2 producer REPLACE seam same-txn goldens (enqueueRecordEventIfDurable commit/rollback/off): real DB.
+      // Excluded here so it cannot skip-green, whole-file wired into plugin-tests.yml's attendance real-DB step.
+      'tests/integration/multitable-automation-producer-emit-realdb.test.ts',
       // F9 owner CHANGES-REQUESTED (GF9-1/GF9-2): multitable_attachments blob_purged_at migration +
       // deleteAttachmentBinary index-free delete + sweepMultitableAttachmentBlobPurge compensating-sweep
       // matrix, same shape/rationale as the F5 entry immediately above (DATABASE_URL-gated describeDb,

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -275,6 +275,9 @@ export default defineConfig({
       // P1#2d producer family 5 (univer-meta routes ×4) durable REPLACE goldens (route-driven): real DB.
       // Excluded here so it cannot skip-green, whole-file wired into plugin-tests.yml's attendance real-DB step.
       'tests/integration/multitable-automation-producer-family5-realdb.test.ts',
+      // P1#2b producer family 4 (record-service CRUD + record-write bulk) site-wiring goldens: real DB.
+      // Excluded here so it cannot skip-green, whole-file wired into plugin-tests.yml's attendance real-DB step.
+      'tests/integration/multitable-automation-producer-family4-realdb.test.ts',
       // F9 owner CHANGES-REQUESTED (GF9-1/GF9-2): multitable_attachments blob_purged_at migration +
       // deleteAttachmentBinary index-free delete + sweepMultitableAttachmentBlobPurge compensating-sweep
       // matrix, same shape/rationale as the F5 entry immediately above (DATABASE_URL-gated describeDb,

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -264,6 +264,9 @@ export default defineConfig({
       // isolated-schema real UPGRADE path. Excluded here so it cannot skip-green, whole-file wired into
       // plugin-tests.yml's attendance real-DB step.
       'tests/integration/multitable-automation-approval-bridge-lease-migration.db.test.ts',
+      // P1#1 approval-bridge LEASE claim/reclaim runtime crash matrix (terminal-early removal): real DB.
+      // Excluded here so it cannot skip-green, whole-file wired into plugin-tests.yml's attendance real-DB step.
+      'tests/integration/multitable-automation-approval-bridge-lease-realdb.test.ts',
       // F9 owner CHANGES-REQUESTED (GF9-1/GF9-2): multitable_attachments blob_purged_at migration +
       // deleteAttachmentBinary index-free delete + sweepMultitableAttachmentBlobPurge compensating-sweep
       // matrix, same shape/rationale as the F5 entry immediately above (DATABASE_URL-gated describeDb,

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -272,6 +272,9 @@ export default defineConfig({
       'tests/integration/multitable-automation-producer-emit-realdb.test.ts',
       // P1#2c producer family 2 (executor Class-A record events) REPLACE site goldens: real DB, same shape.
       'tests/integration/multitable-automation-producer-family2-realdb.test.ts',
+      // Owner P1s (head 5afe30f26): REAL MetaSheetServer.start() fail-closed matrix — flag ON + missing
+      // AutomationService / disabled retry scheduler must ABORT startup; flag OFF keeps legacy degrade.
+      'tests/integration/multitable-durable-startup-failclosed.db.test.ts',
       // P1#2d producer family 5 (univer-meta routes ×4) durable REPLACE goldens (route-driven): real DB.
       // Excluded here so it cannot skip-green, whole-file wired into plugin-tests.yml's attendance real-DB step.
       'tests/integration/multitable-automation-producer-family5-realdb.test.ts',

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -278,6 +278,9 @@ export default defineConfig({
       // P1#2b producer family 4 (record-service CRUD + record-write bulk) site-wiring goldens: real DB.
       // Excluded here so it cannot skip-green, whole-file wired into plugin-tests.yml's attendance real-DB step.
       'tests/integration/multitable-automation-producer-family4-realdb.test.ts',
+      // P1#2e producer family 1 (approval completion + task_created) REPLACE site goldens: real DB, same shape.
+      // Excluded here so it cannot skip-green, whole-file wired into plugin-tests.yml's attendance real-DB step.
+      'tests/integration/multitable-automation-producer-family1-realdb.test.ts',
       // F9 owner CHANGES-REQUESTED (GF9-1/GF9-2): multitable_attachments blob_purged_at migration +
       // deleteAttachmentBinary index-free delete + sweepMultitableAttachmentBlobPurge compensating-sweep
       // matrix, same shape/rationale as the F5 entry immediately above (DATABASE_URL-gated describeDb,

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -260,6 +260,10 @@ export default defineConfig({
       // S6 event_fires LEASE claim/reclaim (window-2 fix): isolated-schema real DB. Excluded here so it cannot
       // skip-green, whole-file wired into the attendance real-DB step in plugin-tests.yml.
       'tests/integration/multitable-automation-event-fires-lease-realdb.db.test.ts',
+      // P1#1 approval-bridge terminal→lease UPGRADE migration (existing rows keep status; new lease columns):
+      // isolated-schema real UPGRADE path. Excluded here so it cannot skip-green, whole-file wired into
+      // plugin-tests.yml's attendance real-DB step.
+      'tests/integration/multitable-automation-approval-bridge-lease-migration.db.test.ts',
       // F9 owner CHANGES-REQUESTED (GF9-1/GF9-2): multitable_attachments blob_purged_at migration +
       // deleteAttachmentBinary index-free delete + sweepMultitableAttachmentBlobPurge compensating-sweep
       // matrix, same shape/rationale as the F5 entry immediately above (DATABASE_URL-gated describeDb,


### PR DESCRIPTION
**Base: `main`. Flag-gated (`AUTOMATION_DURABLE_DELIVERY_ENABLED`, default OFF), flag-OFF byte-identical.** Head `1d3854c7a`, rebased onto current `main` (0 behind at push). This PR now carries the COMPLETE owner-named P1 boundary: recoverable bridge/trigger/projection sinks + real producer/consumer/boot wiring, with every manifest-routed producer family on the REPLACE seam.

## Contents (19 commits, grouped)

### A. S4-b/S5 activation + consumers + boot (pre-checkpoint scope)
Activation seam (`produceAutomationEvent` / registry / `bootDurableDelivery`), six REAL consumer adapters delegating to the same service methods the legacy bus subscribers call, index.ts boot/stop wiring, S7 composed producer→claim→REAL-handler goldens.

### B. Recoverable sinks (owner P1 ①)
- **approval-bridge** P1#1a-d: reclaimable lease schema (upgrade-path tested, biconditional lease-iff-in_progress, fence, bounded attempts→dead_letter), claim/reclaim, terminal `resumed` moved AFTER the continuation (fence-CAS single-writer), crash matrix.
- **P1#1e done/busy split** (sink-audit finding): outbox lease (30s) < sink leases (60s) meant a post-crash redelivery arrived during the dead worker's LIVE sink lease and was silently resolved `done` → work permanently lost. `claimEventFiresLease` → `{fence}|'done'|'busy'`; `claimCompletion` → `claimed|none|busy`; `busy` → retryable `DurableSinkBusyError`; boot outbox lease aligned to 90s. Wire goldens W1–W3 drive the real `AutomationService`; both busy→silent-skip mutations are killed by named tests.
- **approval-projection**: audited RECOVERABLE-AS-BUILT (advisory xact lock, monotonic projected_version, rollback-rethrow, leader sweep) — no code change needed.
- **webhook-event-bridge**: first-attempt stray recovery — a crash before the outcome handler left `pending` + `next_retry_at NULL`, unselectable by the retry scan (stuck absorbing state; the module header wrongly claimed recovery). Stray-grace claim leg (max(5min, timeout×10)) + golden + mutation kill. Crash-duplicates stay ratified at-least-once.

### C. Producer REPLACE — all five manifest-routed families (owner P1 ①)
Steady state per FWB0 §Layer-1 L318-324: flag ON ⇒ same-txn enqueue REPLACES the legacy post-commit emit (suppressed); flag OFF ⇒ legacy emit byte-identical. REPLACE is necessary: the webhook sink has no event-id dedup, keep-both double-delivers.
| family | sites | goldens |
|---|---|---|
| 3 result-writeback | automation-service ×1 | seam realdb 4 |
| 2 executor Class-A | automation-executor ×3 | F2-G1..G6 (7) incl. PG-level failure-injection atomicity + replay-zero-second-delivery |
| 4 record CRUD | record-service ×4 + record-write ×1 | 10 realdb + 6 unit |
| 5 univer-meta | routes ×4 incl. form-submit | 8 route-driven (supertest) |
| 1 approval | completion ×6 + task_created ×9 | F1-G1..G5 (6) + collector 5 unit |
Family 1 uses a SHARED `collectLiveApprovalTaskCreatedEvents` core so the in-txn (flag-ON) and post-commit (flag-OFF) legs cannot drift; per-recipient quad `eventId`s stay byte-identical to legacy (T2-6 dedup alignment). Duplicate Class-A claims skip the enqueue exactly as they skip the legacy emit.

**⚠️ Ratified-literal correction (flagged for owner):** manifest v1 `'form.submitted'` → `'multitable.form.submitted'`. The lock's prose shorthand named the trigger TYPE; no code emits that literal — as written the durable path could never route a form submission (fail-closed expand throws). Resolved by the lock's own grounding citation (`automation-service.ts:892-936`). Same family, same consumer set.

Un-routed events (approval.admin_jumped / bulk_reassigned / automation.notification) intentionally stay legacy. `multitable.comment.created` is routed but has no emitter anywhere (pre-existing; inert on both paths).

## Activation closure (owner review 2026-07-17 — 4 items)
The producer families being wired did not by itself close activation; the owner named four gaps, all now closed on this branch:
1. **task_created same-txn atomicity** — the in-txn leg gained a discriminating rollback golden (F1-G6): an injected Postgres failure on the `approval.task_created` outbox INSERT rolls back instance + assignments + enqueue together; mutation-proven (post-commit enqueue → RED).
2. **`multitable.comment.created` removed from manifest v1** — repo-wide census: no producer exists (even the legacy bridge subscription is inert). A route nobody produces is dead config; a real comment producer ships as family-6 + manifest v2 (would be a flag-OFF behavior change otherwise). Second flagged ratified-literal edit.
3. **durable webhook idempotency** — the durable consumer dropped the outbox eventId, so a busy-retry re-created a delivery row + re-sent (unforced duplicate). Migration adds `event_id` + partial-unique `(webhook_id, event_id)`; durable leg threads the eventId → claim (`ON CONFLICT DO NOTHING`); legacy NULL path byte-identical. Goldens G1-G4 + 2 mutations.
4. **flag-ON boot fail-closed** — a durable boot failure with the flag ON now aborts startup (rethrow) instead of silently degrading (legacy emits are suppressed → a loop-less process strands every outbox row). Unit-tested disposition; flag OFF logs-and-continues.

### Activation closure round 2 (owner REQUEST-CHANGES at `5afe30f26` — 2P1+1P2)
Startup fail-closed now covers the WHOLE durable dependency chain, proven at the REAL `MetaSheetServer.start()` level:
- AutomationService absence (a degraded earlier init) can no longer silently skip durable boot — asserted before the `if`-skip, flag-ON throw aborts startup.
- The webhook retry scheduler (load-bearing for durable webhook crash recovery) disabled via env OR failing init aborts startup flag-ON; flag OFF keeps legacy degrade byte-identically.
- Kysely `MultitableWebhookDeliveriesTable.event_id` drift fixed.
- REAL startup regression `multitable-durable-startup-failclosed.db.test.ts` (5 real server lifecycles: 2 fail-closed rejections incl. a constructor-fault injection into the real init path, 2 flag-OFF degrades, 1 healthy flag-ON positive control) — mutation-proven (removing both asserts reds exactly the two fail-closed cases). Battery at `1d3854c7a`: 109/109 (16 files) + tsc 0.

## Verification at exact head `5afe30f26`
Fresh DB (createdb + full `db:migrate`, incl. the new webhook migration): **durable + webhook battery 104/104 (15 files)** · **full unit suite 6782 passed / 0 failed** · tsc 0. Two flagged ratified-literal edits (form.submitted event-type fix + comment.created removal) called out for owner review. Per-item + per-family mutation proofs in the commit messages. Flags stay OFF; no self-merge.

## Verification at exact head `8c95bec48`
Fresh DB (createdb + full `db:migrate`): **durable/lease/producer battery 96/96 (13 files)** · **full unit suite 6742 passed / 0 failed** (flag-OFF byte-identical at scale) · tsc 0. Per-family + per-fix mutation proofs recorded in the commit messages (every load-bearing guard has a named RED witness). Two-point wiring (vitest.config exclude + plugin-tests.yml run-list) for every real-DB spec.

## Out of scope / follow-ups
8-scenario acceptance matrix runs as formal acceptance after this lands (now all-families-scoped). Flags stay OFF; UAT + flag-ON are owner gates. Fan-out per-target intent lock = #4450 (PROPOSED rev 2).


