### PR TITLE
feat(multitable): W0-1 v3.7 — Lane L3 chain-integrity core, rebuilt per #4331 §9 (causal seq + all-generations contiguity + C3)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -428,6 +428,7 @@ jobs:
             tests/integration/multitable-reset-pit-realdb.test.ts \
             tests/integration/multitable-history-incomplete-precheck-realdb.test.ts \
             tests/integration/multitable-history-contiguity-realdb.test.ts \
+            tests/integration/multitable-history-contiguity-strict-seq-realdb.test.ts \
             tests/integration/multitable-d1c-form-submit-revision-realdb.test.ts \
             tests/integration/multitable-d1c-plugin-revision-realdb.test.ts \
             tests/integration/multitable-d1c-automation-revision-realdb.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260715160000_add_meta_record_chain_seq.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260715160000_add_meta_record_chain_seq.ts
@@ -1,0 +1,140 @@
+import { sql, type Kysely } from 'kysely'
+
+/**
+ * W0-1 (v3.7 correction, owner-ratified #4331 §9 — see
+ * docs/development/multitable-w0-1-v37-exact-anchor-trust-design-lock-20260715.md §1.1/§9.7) — the
+ * chain-integrity core's shared causal `seq` domain.
+ *
+ * WHY: the landed #4269 chain-order comparator (`chainOrderAfter` in `history-integrity-precheck.ts`)
+ * orders events by `(created_at epoch-ms, version, delete-last)` — `created_at` is txn-start so same-ms
+ * events collide, and neither `version` (resets per generation) nor row `id` (random uuid) can disambiguate
+ * true causal order across the two tables. A single monotonic sequence, allocated at write time and shared
+ * by both `meta_record_revisions` and `meta_record_version_markers`, gives an exact total order for the
+ * generation-aware precheck behind `MULTITABLE_HISTORY_CONTIGUITY_STRICT` (default OFF — this migration
+ * changes schema only, no runtime behavior; see §9.7 "Ratification authorizes default-off implementation
+ * slices only").
+ *
+ * ALSO (v3.7 §9.3 / owner-ruled "loud marker"): drops the cross-generation
+ * `UNIQUE (sheet_id, record_id, version)` on `meta_record_version_markers`. A resurrected record resets
+ * `version` to 1; a new generation's lock/unlock at a version the FIRST generation also marked would
+ * otherwise collide against that constraint, and the marker INSERT's (pre-existing) `ON CONFLICT ... DO
+ * NOTHING` would silently SWALLOW the new marker — the lock/unlock itself succeeds while its marker
+ * vanishes, and the strict contiguity walk then sees an unexplained hole in the new generation (a false
+ * refusal of a healthy record). Dup-detection moves into the per-generation (seq-ordered) occupancy walk
+ * instead (`chain_corrupt` — a TRUE within-generation duplicate, distinct from the legacy
+ * `duplicate_version_event`, which stays on the byte-identical flag-off path). `record-history-service.ts`
+ * `recordVersionMarker` removes the `ON CONFLICT DO NOTHING` in the SAME PR so a genuine write conflict now
+ * fails the enclosing lock/unlock transaction loudly instead of swallowing silently.
+ *
+ * Migration shape (safe on a populated table): add the column NULLABLE first, backfill deterministically,
+ * THEN attach the `nextval` default + `NOT NULL` — never add a column with a volatile (`nextval()`) default
+ * directly, which would force an uncontrolled full-table rewrite ordered by physical row order instead of
+ * the intended `(created_at, version, id)` backfill order.
+ *
+ * Backfill semantics (v3.7 §9.3 scope item 1 — verbatim): `row_number() OVER (ORDER BY created_at, version,
+ * id)` PER TABLE — revisions and markers each get their own dense 1..N run. This is DISPLAY/ORDER
+ * ASSISTANCE ONLY for legacy (pre-this-migration) rows, NEVER A TRUST SIGNAL: the two tables' backfilled seq
+ * ranges legitimately overlap (both start at 1), so a legacy revision and a legacy marker can share a seq
+ * value, and backfilled order is only as reliable as the `created_at`/`version` it derives from. Any
+ * "prospectively causal on landing" claim from the superseded v3.5 draft (#4309) is WITHDRAWN here per the
+ * v3.7 P2-A/P2-B correction: real causality requires L4 (all-writer fence, so seq is allocated
+ * post-fence-acquisition on every writer) and an L5 trusted-since checkpoint that cuts off pre-fence/
+ * backfilled history — BOTH deferred, later lanes. Going FORWARD (every row inserted after this migration),
+ * `seq` is allocated from the ONE shared `meta_record_chain_seq` sequence at INSERT time via each table's
+ * `DEFAULT nextval(...)`, so new revisions and new markers interleave in one exact total order — necessary,
+ * but on its own (pre-L4/L5) NOT SUFFICIENT for destructive trust; see the design lock.
+ *
+ * The one-time `setval` below is a MIGRATION-TIME bootstrap sync (advancing the shared sequence past every
+ * backfilled value so no future `nextval()` collides with a legacy row's backfilled number) — NOT a test
+ * mutating a shared real-DB sequence. Goldens must NEVER call `setval` on this sequence (v3.7 P2-C); they
+ * insert explicit synthetic seq literals into isolated fixture rows instead (see
+ * `multitable-history-contiguity-strict-seq-realdb.test.ts`).
+ *
+ * zzzz-timestamped ([[feedback_migration_zzzz_ordering]]): touches `meta_record_revisions` /
+ * `meta_record_version_markers`, both created in zzzz migrations. Proven on a FRESH-DB full migrate.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE SEQUENCE IF NOT EXISTS meta_record_chain_seq`.execute(db)
+
+  // ---- meta_record_revisions: add nullable, backfill, then attach default + NOT NULL --------------------
+  await sql`ALTER TABLE meta_record_revisions ADD COLUMN IF NOT EXISTS seq bigint`.execute(db)
+  await sql`
+    UPDATE meta_record_revisions r
+    SET seq = backfill.rn
+    FROM (
+      SELECT id, row_number() OVER (ORDER BY created_at, version, id) AS rn
+      FROM meta_record_revisions
+    ) AS backfill
+    WHERE r.id = backfill.id AND r.seq IS NULL
+  `.execute(db)
+
+  // ---- meta_record_version_markers: same shape ------------------------------------------------------------
+  await sql`ALTER TABLE meta_record_version_markers ADD COLUMN IF NOT EXISTS seq bigint`.execute(db)
+  await sql`
+    UPDATE meta_record_version_markers m
+    SET seq = backfill.rn
+    FROM (
+      SELECT id, row_number() OVER (ORDER BY created_at, version, id) AS rn
+      FROM meta_record_version_markers
+    ) AS backfill
+    WHERE m.id = backfill.id AND m.seq IS NULL
+  `.execute(db)
+
+  // Advance the shared sequence PAST every backfilled value (both tables) so every FUTURE nextval() (used
+  // by both tables' DEFAULT below) is guaranteed greater than any legacy backfilled seq — new writes always
+  // causally sort after all pre-migration history. Skipped on a fresh/empty DB (nothing backfilled, GREATEST
+  // is 0, and 0 is below the sequence's own MINVALUE for an is_called=true setval).
+  await sql`
+    DO $$
+    DECLARE max_seq bigint;
+    BEGIN
+      SELECT GREATEST(
+        COALESCE((SELECT MAX(seq) FROM meta_record_revisions), 0),
+        COALESCE((SELECT MAX(seq) FROM meta_record_version_markers), 0)
+      ) INTO max_seq;
+      IF max_seq > 0 THEN
+        PERFORM setval('meta_record_chain_seq', max_seq, true);
+      END IF;
+    END $$;
+  `.execute(db)
+
+  await sql`ALTER TABLE meta_record_revisions ALTER COLUMN seq SET DEFAULT nextval('meta_record_chain_seq')`.execute(db)
+  await sql`ALTER TABLE meta_record_revisions ALTER COLUMN seq SET NOT NULL`.execute(db)
+  await sql`ALTER TABLE meta_record_version_markers ALTER COLUMN seq SET DEFAULT nextval('meta_record_chain_seq')`.execute(db)
+  await sql`ALTER TABLE meta_record_version_markers ALTER COLUMN seq SET NOT NULL`.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_record_revisions_sheet_record_seq
+    ON meta_record_revisions(sheet_id, record_id, seq)
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_record_version_markers_sheet_record_seq
+    ON meta_record_version_markers(sheet_id, record_id, seq)
+  `.execute(db)
+
+  // v3.7 §9.3 scope item 1 / owner "loud marker": drop the cross-generation UNIQUE that silently swallowed
+  // a resurrected generation's marker (see the module doc comment above).
+  await sql`
+    ALTER TABLE meta_record_version_markers
+    DROP CONSTRAINT IF EXISTS uq_meta_record_version_markers_sheet_record_version
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Best-effort restore of the dropped constraint — will fail if any cross-generation duplicate marker was
+  // written while it was absent (expected: this migration's whole point is to allow that shape going
+  // forward). Not wrapped in a guard: a failing `down()` here is a correct signal that forward-only data
+  // now exists and this migration cannot be cleanly reversed.
+  await sql`
+    ALTER TABLE meta_record_version_markers
+    ADD CONSTRAINT uq_meta_record_version_markers_sheet_record_version UNIQUE (sheet_id, record_id, version)
+  `.execute(db)
+
+  await sql`DROP INDEX IF EXISTS idx_meta_record_version_markers_sheet_record_seq`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_meta_record_revisions_sheet_record_seq`.execute(db)
+
+  await sql`ALTER TABLE meta_record_version_markers DROP COLUMN IF EXISTS seq`.execute(db)
+  await sql`ALTER TABLE meta_record_revisions DROP COLUMN IF EXISTS seq`.execute(db)
+
+  await sql`DROP SEQUENCE IF EXISTS meta_record_chain_seq`.execute(db)
+}

--- a/packages/core-backend/src/multitable/history-integrity-precheck.ts
+++ b/packages/core-backend/src/multitable/history-integrity-precheck.ts
@@ -327,7 +327,10 @@ const SEQ_FORMAT = /^[1-9][0-9]*$/
  *     over the (already seq-ordered) timeline; it only inspects `action`, never `seq` magnitude.
  *  3. EVERY generation is validated, not just the terminal one — "terminal-generation-only validation is
  *     forbidden" (§4, verbatim). A hole in an OLDER generation refuses even when the terminal generation is
- *     completely clean (the High-2 regression this lane exists to fix).
+ *     completely clean (the High-2 regression this lane exists to fix). This INCLUDES generation 0: any event
+ *     or marker that precedes the record's FIRST create (owner counterexample, #4339) means an older
+ *     generation's create was never captured — a provably incomplete chain — so it refuses `chain_hole`
+ *     rather than being skipped by a `1..creates` walk that never visits generation 0.
  *  4. Illegal/missing/out-of-range seq fails closed (`comparator_error`), never coerced to zero or dropped.
  *     A within-generation duplicate occupant is `chain_corrupt` (replaces the DROPPED cross-generation marker
  *     UNIQUE, which used to reject this shape at write time).
@@ -368,6 +371,20 @@ export function checkAllGenerationsContiguity(
     generation[i] = creates
   }
   if (creates === 0) return { ok: false, reason: 'chain_hole' } // no create ever captured (updates/markers only)
+
+  // GENERATION 0 (owner High-2 counterexample, #4339 REQUEST-CHANGES). The running `creates` counter starts
+  // at 0 and increments only at a 'create', so `generation[i] === 0` for EVERY item that precedes the record's
+  // FIRST captured create. The `g = 1..creates` walk below never visits generation 0, so without this guard
+  // those items are silently unchecked. A well-formed chain's first item is ALWAYS its create (v1): a marker
+  // happens on a live row, an update/delete presupposes a prior create — so any event or marker before the
+  // first create means an OLDER generation's create was never captured (retention-swept or an uncaptured
+  // hole). That older generation is provably incomplete and cannot be reconstructed. This is exactly the shape
+  // the owner's live counterexample hits — an older generation missing its create + a clean terminal
+  // generation — which returned {ok:true} before this fix. Fail CLOSED (chain_hole); a generation-0 event is
+  // never skipped. `generation[0]` exists (timeline.length > 0 guaranteed by the early return above) and, since
+  // the timeline is seq-ascending and `generation` is monotonic non-decreasing, `generation[0] === 0` iff at
+  // least one generation-0 item exists — one check covers the whole prefix-before-first-create.
+  if (generation[0] === 0) return { ok: false, reason: 'chain_hole' }
 
   // CONSERVATIVE: validate EVERY generation (not terminal-only — v3.7 §4/§9.3 owner High-2 correction).
   for (let g = 1; g <= creates; g++) {

--- a/packages/core-backend/src/multitable/history-integrity-precheck.ts
+++ b/packages/core-backend/src/multitable/history-integrity-precheck.ts
@@ -1,7 +1,7 @@
 import { mapFieldType, isSystemFieldType } from './field-codecs'
 import type { QueryFn } from './permission-service'
 import { isSystemSheet } from './system-sheet-predicate'
-import { hasVersionMarkerTable } from './record-history-service'
+import { hasVersionMarkerTable, hasChainSeqColumn } from './record-history-service'
 
 /**
  * Global History — W0-1: `HISTORY_INCOMPLETE`, the fail-closed integrity PRECHECK for the destructive
@@ -46,7 +46,59 @@ import { hasVersionMarkerTable } from './record-history-service'
  *  - C3 deleted/tombstoned + resurrected (multi-generation) chains — live-only enumeration here; a resurrected
  *    record refuses fail-closed (duplicate create at v1), full handling is C3.
  *  - C6 durable trusted-since watermark + rollout protocol (grandfathers pre-marker lock holes).
+ *
+ * ============================================================================================================
+ * W0-1 v3.7 (owner-ratified #4331 §9, docs/development/multitable-w0-1-v37-exact-anchor-trust-design-lock-
+ * 20260715.md) — STRICT MODE, `MULTITABLE_HISTORY_CONTIGUITY_STRICT` (default OFF; flag-off is BYTE-IDENTICAL
+ * to the #4269 behavior documented above — unchanged code path, unchanged exports, unchanged early-return
+ * shortcuts). When the flag is on, `precheckSheetHistoryIntegrity` delegates ENTIRELY to
+ * `precheckSheetHistoryIntegrityStrict` (a separate function — the non-strict function body above is never
+ * touched by this addition), which differs in four ways:
+ *
+ *  1. EXACT CAUSAL ORDER (§1.1): events and markers are ordered by the real `seq` column — one shared PG
+ *     sequence across BOTH tables (migration `zzzz20260715160000_add_meta_record_chain_seq`) — never
+ *     `created_at`/`version`. Ordering is done by native SQL `ORDER BY` on the `bigint` column; `seq` is kept
+ *     as a decimal STRING end-to-end in TypeScript (the pg driver returns int8 as a string, never a `number`,
+ *     by default). `Number(seq)`, `parseInt`, unary `+`, subtraction comparators, and JSON-number seq fields
+ *     are FORBIDDEN (§9.7) — every seq-vs-seq comparison in this module uses exact `BigInt(...)` compare or
+ *     exact string equality, never float arithmetic. See `checkAllGenerationsContiguity`'s seq-ascending scan.
+ *  2. GENERATION BY COUNT (§4): `generation = COUNT(*) FILTER (WHERE action='create') OVER (PARTITION BY
+ *     sheet_id, record_id ORDER BY seq)` — computed here as a simple running counter over the seq-ordered
+ *     per-record timeline (the counter only depends on which items are 'create' events, never on seq
+ *     magnitude, so it carries no float-precision risk).
+ *  3. ALL GENERATIONS, NOT TERMINAL-ONLY (§4/§9.3 owner High-2 — corrects the superseded v3.5 draft #4309,
+ *     which validated only the current/terminal generation): `checkAllGenerationsContiguity` walks EVERY
+ *     generation in a record's timeline and refuses on the FIRST hole/duplicate found anywhere, not only in
+ *     the newest one. A record with a hole in an OLDER generation and a clean terminal generation still
+ *     refuses — "terminal-generation-only validation is forbidden" (§4, verbatim). This lane implements the
+ *     conservative "all generations reconstructable in scope" option v3.7 §9.3 explicitly permits in place of
+ *     resolving an exact target/asOf generation (§1.3's exact anchor resolution is L6, DEFERRED); checking
+ *     every generation is strictly stronger than checking only the one the recovery target would fall in.
+ *  4. C3 DELETED-CHAIN ENUMERATION (§4/§9.3 scope item 5): records that are not live (chain-only, or present
+ *     in `meta_records_trash`) are ALSO enumerated and validated (their scope requires the timeline's last
+ *     item to be a delete; a trash row surviving with its ENTIRE revision chain retention-swept is
+ *     unverifiable and fails closed, `chain_hole`).
+ *
+ * `chain_corrupt` is a NEW reason (strict-only, never returned when the flag is off) for a within-generation
+ * duplicate occupant — it replaces the DROPPED cross-generation marker `UNIQUE` constraint's job, which used
+ * to reject this shape at write time; now the seq-ordered occupancy walk rejects it at read time instead.
+ * `comparator_error` also covers illegal seq (non-positive, malformed, or a duplicate seq value shared by two
+ * items — a shared-sequence-domain violation) — fail-closed, never coerced to zero (§9.3 scope item 6).
+ *
+ * STILL DEFERRED beyond this lane (unchanged from the list above, plus the v3.7-specific items): §1.2 sealed
+ * operation-endpoint ledger (L6), §1.3 exact recovery anchor / resolving a target generation from a real
+ * commit boundary (L6), the L4 all-writer canonical fence, the L5 trust checkpoint. C2 time-monotonicity
+ * (seq-vs-version agreement within a generation) is NOT added by this lane either — it remains on the
+ * pre-existing DEFERRED docket above; this lane's scope is the exact-bigint + all-generations + C3 + dup/
+ * illegal-seq fail-close set (v3.7 §9.3), not the full W0 trust correction.
+ * ============================================================================================================
  */
+
+/** W0-1 v3.7 §9.3 — the STRICT MODE gate. Default OFF (unset/any non-'true' value): flag-off behavior is the
+ *  byte-identical #4269 code path. See the module doc comment's STRICT MODE section for the full contract. */
+export function isContiguityStrictMode(): boolean {
+  return String(process.env.MULTITABLE_HISTORY_CONTIGUITY_STRICT ?? '').trim().toLowerCase() === 'true'
+}
 
 /** The unified refusal code (rule 1). Routes surface it as HTTP 409 with a values-free body. */
 export const HISTORY_INCOMPLETE = 'HISTORY_INCOMPLETE' as const
@@ -89,6 +141,8 @@ export type HistoryIntegrityReason =
   // content projection (retained §1.3 second layer)
   | 'content_mismatch'
   | 'comparator_error'
+  // STRICT MODE ONLY (v3.7 §9.3) — never returned when MULTITABLE_HISTORY_CONTIGUITY_STRICT is off.
+  | 'chain_corrupt' // within-generation duplicate occupant (replaces the dropped marker UNIQUE constraint)
 
 export type HistoryIntegrityVerdict = { ok: true } | { ok: false; reason: HistoryIntegrityReason }
 
@@ -236,6 +290,133 @@ export function checkRecordChainContiguity(
 }
 
 // ==============================================================================================================
+// STRICT MODE (W0-1 v3.7 §9.3) — seq-ordered, ALL-generations contiguity. PURE, unit-testable core, gated
+// behind MULTITABLE_HISTORY_CONTIGUITY_STRICT at the caller (`precheckSheetHistoryIntegrityStrict` below).
+// Does NOT share code with `checkRecordChainContiguity` above — that function and its exports are completely
+// untouched by this addition (flag-off byte-identical guarantee).
+// ==============================================================================================================
+
+/** One item of a record's seq-ordered timeline (a revision event OR a lock/unlock marker). `seq` is the
+ *  EXACT decimal-string value of the shared `meta_record_chain_seq` bigint column — never a `number`. The
+ *  caller (`precheckSheetHistoryIntegrityStrict`) fetches this array already ordered by native SQL
+ *  `ORDER BY record_id, seq` (bigint compare) — this function does not re-sort, it only DEFENSIVELY verifies
+ *  the given order is truly seq-ascending (BigInt compare — never Number()/subtraction) before trusting it. */
+export type StrictTimelineItem =
+  | { kind: 'event'; version: number; action: ChainEventAction; seq: string }
+  | { kind: 'marker'; version: number; seq: string }
+
+/** Scope of the record being validated: a LIVE record's terminal generation ends at its current `version`;
+ *  a DELETED record (chain-only or `meta_records_trash`, C3 §4) has no live version — its terminal generation
+ *  must end in a delete event, whose own (reused) version closes it. */
+export type StrictScope = { kind: 'live'; liveVersion: number } | { kind: 'deleted' }
+
+/** Positive-integer decimal string, no leading zeros — the only legal `seq` shape. Exact regardless of
+ *  magnitude (string format check, never a numeric parse). */
+const SEQ_FORMAT = /^[1-9][0-9]*$/
+
+/**
+ * Generation-aware contiguity, TRUE CAUSAL ORDER, ALL GENERATIONS (v3.7 §4/§9.3 owner High-2). Differs from
+ * `checkRecordChainContiguity` above in exactly these ways:
+ *
+ *  1. Order comes from the real `seq` column (one shared sequence across revisions AND markers), never
+ *     `created_at`/`version` structural comparison. Every seq comparison here is exact `BigInt(...)` compare
+ *     or exact string equality — never `Number(seq)`, `parseInt`, unary `+`, or a subtraction comparator
+ *     (§9.7; those silently collapse distinct seq values once they exceed 2^53, see the exact-bigint
+ *     goldens in `multitable-history-contiguity-strict-seq-realdb.test.ts`).
+ *  2. Generation = `COUNT(*) FILTER (WHERE action='create') OVER (ORDER BY seq)` — a plain running counter
+ *     over the (already seq-ordered) timeline; it only inspects `action`, never `seq` magnitude.
+ *  3. EVERY generation is validated, not just the terminal one — "terminal-generation-only validation is
+ *     forbidden" (§4, verbatim). A hole in an OLDER generation refuses even when the terminal generation is
+ *     completely clean (the High-2 regression this lane exists to fix).
+ *  4. Illegal/missing/out-of-range seq fails closed (`comparator_error`), never coerced to zero or dropped.
+ *     A within-generation duplicate occupant is `chain_corrupt` (replaces the DROPPED cross-generation marker
+ *     UNIQUE, which used to reject this shape at write time).
+ *
+ * C2 time-monotonicity (seq order vs. version order agreement) is explicitly NOT checked here — it remains
+ * on the pre-existing DEFERRED docket (module doc comment); this lane's contract is exact-bigint ordering +
+ * all-generations occupancy + C3 enumeration + dup/illegal-seq fail-close, not the full v3.7 W0 correction.
+ */
+export function checkAllGenerationsContiguity(
+  scope: StrictScope,
+  timeline: ReadonlyArray<StrictTimelineItem>,
+): ContiguityResult {
+  if (timeline.length === 0) return { ok: false, reason: 'zero_revision_live_row' }
+  const anyCreateOrUpdate = timeline.some((it) => it.kind === 'event' && it.action !== 'delete')
+  const anyMarker = timeline.some((it) => it.kind === 'marker')
+  if (!anyCreateOrUpdate && !anyMarker) return { ok: false, reason: 'zero_revision_live_row' }
+
+  // Fail-closed seq validation: format, then strict ascending + no duplicates (exact BigInt compare — the
+  // shared sequence domain must never repeat a value; a repeat or a regression is corruption, not coercible).
+  let prevSeq: bigint | null = null
+  for (const it of timeline) {
+    if (!SEQ_FORMAT.test(it.seq)) return { ok: false, reason: 'comparator_error' }
+    const cur = BigInt(it.seq)
+    if (prevSeq !== null) {
+      if (cur === prevSeq) return { ok: false, reason: 'comparator_error' } // shared-domain seq collision
+      if (cur < prevSeq) return { ok: false, reason: 'comparator_error' } // caller must pass seq-ascending
+    }
+    prevSeq = cur
+  }
+
+  // Generation index per item: cumulative count of 'create' events at-or-before this position (seq order).
+  // A plain integer counter — never reads seq magnitude, so it carries no float-precision risk.
+  let creates = 0
+  const generation: number[] = new Array(timeline.length)
+  for (let i = 0; i < timeline.length; i++) {
+    const it = timeline[i]
+    if (it.kind === 'event' && it.action === 'create') creates += 1
+    generation[i] = creates
+  }
+  if (creates === 0) return { ok: false, reason: 'chain_hole' } // no create ever captured (updates/markers only)
+
+  // CONSERVATIVE: validate EVERY generation (not terminal-only — v3.7 §4/§9.3 owner High-2 correction).
+  for (let g = 1; g <= creates; g++) {
+    const bucket: StrictTimelineItem[] = []
+    for (let i = 0; i < timeline.length; i++) if (generation[i] === g) bucket.push(timeline[i])
+
+    const first = bucket[0]
+    if (!first || first.kind !== 'event' || first.action !== 'create') return { ok: false, reason: 'chain_hole' }
+    const genStart = first.version
+    const isTerminalGen = g === creates
+    const last = bucket[bucket.length - 1]
+    const lastIsDelete = last.kind === 'event' && last.action === 'delete'
+
+    let genEnd: number
+    if (!isTerminalGen) {
+      // A non-terminal generation can only have been closed by a delete (a subsequent create implies the
+      // prior generation ended) — anything else here is an anomaly: a live record double-created in place.
+      if (!lastIsDelete) return { ok: false, reason: 'chain_hole' }
+      genEnd = last.version // delete-reuse: the delete's own version closes the generation
+    } else if (scope.kind === 'live') {
+      if (lastIsDelete) return { ok: false, reason: 'live_row_after_delete_revision' } // uncaptured resurrection
+      genEnd = scope.liveVersion
+    } else {
+      if (!lastIsDelete) return { ok: false, reason: 'chain_hole' } // deleted scope must end in a delete
+      genEnd = last.version
+    }
+
+    if (!Number.isInteger(genStart) || genStart < 1) return { ok: false, reason: 'out_of_range_version' }
+    if (!Number.isInteger(genEnd) || genEnd < genStart) return { ok: false, reason: 'out_of_range_version' }
+
+    // Occupancy (exact set, C5): exactly one non-delete occupant per version in [genStart..genEnd]. Delete
+    // events are excluded (delete-reuse — they close the generation, they never occupy a data version).
+    const occupant = new Map<number, number>()
+    for (const it of bucket) {
+      if (it.kind === 'event' && it.action === 'delete') continue
+      if (!Number.isInteger(it.version) || it.version < genStart || it.version > genEnd) return { ok: false, reason: 'out_of_range_version' }
+      occupant.set(it.version, (occupant.get(it.version) ?? 0) + 1)
+    }
+    for (let k = genStart; k <= genEnd; k++) {
+      const c = occupant.get(k) ?? 0
+      if (c === 0) return { ok: false, reason: 'chain_hole' }
+      if (c > 1) return { ok: false, reason: 'chain_corrupt' } // within-generation duplicate (strict-only code)
+    }
+  }
+
+  return { ok: true }
+}
+
+// ==============================================================================================================
 
 const toNumber = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : Number(v) || 0)
 /** Raw created_at epoch-ms — exact in float64. NEVER pack version into this (see chainOrderAfter). */
@@ -248,11 +429,18 @@ const epochOf = (createdAt: unknown): number => {
  * The shared precheck. Scope = the sheet (revert/reset are whole-sheet operations). Preview and execute both
  * call this; the execute path ALSO re-runs it inside the destructive transaction (C8) via
  * `HistoryIncompleteInTxnError`.
+ *
+ * W0-1 v3.7 §9.3: when `MULTITABLE_HISTORY_CONTIGUITY_STRICT` is on, this delegates ENTIRELY to
+ * `precheckSheetHistoryIntegrityStrict` below — a completely separate function. Everything from this line
+ * down (through the end of the non-strict function body) is UNTOUCHED by the v3.7 addition, so flag-off
+ * behavior stays byte-identical to #4269.
  */
 export async function precheckSheetHistoryIntegrity(
   query: QueryFn,
   sheetId: string,
 ): Promise<HistoryIntegrityVerdict> {
+  if (isContiguityStrictMode()) return precheckSheetHistoryIntegrityStrict(query, sheetId)
+
   // System sheets (approval projection / people directory) are server-regenerated read models — excluded.
   const sheetRes = await query('SELECT base_id, description FROM meta_sheets WHERE id = $1', [sheetId])
   const sheetRow = sheetRes.rows[0] as { base_id?: unknown; description?: unknown } | undefined
@@ -333,6 +521,134 @@ export async function precheckSheetHistoryIntegrity(
         }
       }
     }
+    return { ok: true }
+  } catch {
+    return { ok: false, reason: 'comparator_error' } // rule 4 fail-closed
+  }
+}
+
+// ==============================================================================================================
+// STRICT MODE entry point (W0-1 v3.7 §9.3). Independent of the non-strict function above — no shared state,
+// no shared query shape, so the flag-off path above is provably unaffected by anything below this line.
+// ==============================================================================================================
+
+type StrictRawTimelineRow = {
+  record_id: unknown
+  version: unknown
+  action: unknown
+  snapshot: unknown
+  seq: unknown
+  kind: unknown
+}
+
+/**
+ * STRICT MODE precheck (v3.7 §9.3). Same UNIFIED REFUSAL / FAIL-CLOSED doctrine as the non-strict function
+ * (rules 1 and 4 in the module doc comment) — the differences are entirely in HOW contiguity is proven (see
+ * `checkAllGenerationsContiguity`'s doc comment) and WHAT is enumerated (C3 deleted/trashed records too).
+ */
+async function precheckSheetHistoryIntegrityStrict(query: QueryFn, sheetId: string): Promise<HistoryIntegrityVerdict> {
+  // System sheets excluded — identical predicate/semantics to the non-strict path.
+  const sheetRes = await query('SELECT base_id, description FROM meta_sheets WHERE id = $1', [sheetId])
+  const sheetRow = sheetRes.rows[0] as { base_id?: unknown; description?: unknown } | undefined
+  if (sheetRow && isSystemSheet({ baseId: typeof sheetRow.base_id === 'string' ? sheetRow.base_id : null, description: sheetRow.description })) {
+    return { ok: true }
+  }
+
+  const fieldsRes = await query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])
+  const userFieldIds: string[] = []
+  for (const row of fieldsRes.rows as Array<{ id: unknown; type: unknown }>) {
+    if (!isDerivedFieldType(String(row.type ?? ''))) userFieldIds.push(String(row.id))
+  }
+
+  const liveRes = await query('SELECT id, data, version FROM meta_records WHERE sheet_id = $1', [sheetId])
+  const liveRows = liveRes.rows as Array<{ id: unknown; data: unknown; version: unknown }>
+  const liveById = new Map<string, { data: unknown; version: number }>()
+  for (const r of liveRows) liveById.set(String(r.id), { data: r.data, version: toNumber(r.version) })
+  // NOTE: unlike the non-strict path, strict mode does NOT early-return on zero live rows — C3 (§4) must
+  // still enumerate and validate deleted/trashed records even when a sheet currently has no live rows at all.
+
+  try {
+    // Strict mode requires the real seq column; a pre-migration deploy window (column absent) fails CLOSED,
+    // never crashes with an undefined-column error (42703).
+    if (!(await hasChainSeqColumn(query))) return { ok: false, reason: 'comparator_error' }
+
+    // Illegal-seq fail-close (§9.3 scope item 6): any non-positive seq in scope refuses immediately, native
+    // SQL `<= 0` comparison — exact regardless of magnitude, never coerced to zero.
+    const illegalRev = await query('SELECT count(*)::int AS c FROM meta_record_revisions WHERE sheet_id = $1 AND seq <= 0', [sheetId])
+    if (Number((illegalRev.rows[0] as { c: number }).c) > 0) return { ok: false, reason: 'comparator_error' }
+
+    const hasMarkers = await hasVersionMarkerTable(query)
+    if (hasMarkers) {
+      const illegalMarker = await query('SELECT count(*)::int AS c FROM meta_record_version_markers WHERE sheet_id = $1 AND seq <= 0', [sheetId])
+      if (Number((illegalMarker.rows[0] as { c: number }).c) > 0) return { ok: false, reason: 'comparator_error' }
+    }
+
+    // The full seq-ordered timeline (revisions ∪ markers), one native SQL `ORDER BY` on the `bigint` column
+    // (never a JS-side sort/comparison of seq) — grouped by `record_id` while preserving that order, which
+    // is exactly what `checkAllGenerationsContiguity` requires as input.
+    const timelineSql = hasMarkers
+      ? `SELECT record_id, version, action, snapshot, seq, 'event' AS kind FROM meta_record_revisions WHERE sheet_id = $1
+         UNION ALL
+         SELECT record_id, version, NULL AS action, NULL::jsonb AS snapshot, seq, 'marker' AS kind FROM meta_record_version_markers WHERE sheet_id = $1
+         ORDER BY record_id, seq`
+      : `SELECT record_id, version, action, snapshot, seq, 'event' AS kind FROM meta_record_revisions WHERE sheet_id = $1 ORDER BY record_id, seq`
+    const timelineRes = await query(timelineSql, [sheetId]) // `$1` is reused by BOTH UNION ALL branches — one value
+
+    const timelineByRecord = new Map<string, StrictTimelineItem[]>()
+    const latestSnapshotByRecord = new Map<string, { action: ChainEventAction; snapshot: unknown }>()
+    for (const row of timelineRes.rows as StrictRawTimelineRow[]) {
+      const rid = String(row.record_id)
+      const seq = String(row.seq ?? '')
+      const version = toNumber(row.version)
+      const list = timelineByRecord.get(rid) ?? []
+      if (row.kind === 'marker') {
+        list.push({ kind: 'marker', version, seq })
+      } else {
+        const action: ChainEventAction = (row.action === 'create' || row.action === 'delete') ? row.action : 'update'
+        list.push({ kind: 'event', version, action, seq })
+        latestSnapshotByRecord.set(rid, { action, snapshot: row.snapshot }) // rows arrive seq-ascending ⇒ last write wins = latest
+      }
+      timelineByRecord.set(rid, list)
+    }
+
+    // C3 (§4/§9.3 scope item 5): deleted/trashed records — chain-only (not live) ∪ `meta_records_trash`,
+    // minus live ids. Revert/Reset can resurrect them, so their chain must ALSO be provably contiguous.
+    const deletedIds = new Set<string>()
+    for (const rid of timelineByRecord.keys()) if (!liveById.has(rid)) deletedIds.add(rid)
+    const trashRes = await query('SELECT DISTINCT record_id FROM meta_records_trash WHERE sheet_id = $1', [sheetId])
+    for (const r of trashRes.rows as Array<{ record_id: unknown }>) {
+      const rid = String(r.record_id)
+      if (!liveById.has(rid)) deletedIds.add(rid)
+    }
+
+    // LIVE records.
+    for (const [rid, live] of liveById) {
+      const timeline = timelineByRecord.get(rid) ?? []
+      const result = checkAllGenerationsContiguity({ kind: 'live', liveVersion: live.version }, timeline)
+      if (!result.ok) return result
+
+      // SECOND LAYER (retained §1.3, unchanged semantics): live user-field content must equal the latest
+      // captured snapshot. Formula/rollup/lookup/autoNumber fields are excluded (userFieldIds) — they
+      // materialize live without a revision by design, so their live-vs-snapshot drift is never a refusal.
+      const latest = latestSnapshotByRecord.get(rid)
+      if (latest && latest.action !== 'delete') {
+        const liveData = isPlainRecord(live.data) ? live.data : {}
+        const snap = isPlainRecord(latest.snapshot) ? latest.snapshot : {}
+        for (const fid of userFieldIds) {
+          if (canonicalize(liveData[fid]) !== canonicalize(snap[fid])) return { ok: false, reason: 'content_mismatch' }
+        }
+      }
+    }
+
+    // DELETED/TRASHED records (C3). A trash row surviving with its entire revision chain retention-swept has
+    // nothing left to verify — fail-closed, never assumed healthy.
+    for (const rid of deletedIds) {
+      const timeline = timelineByRecord.get(rid) ?? []
+      if (timeline.length === 0) return { ok: false, reason: 'chain_hole' }
+      const result = checkAllGenerationsContiguity({ kind: 'deleted' }, timeline)
+      if (!result.ok) return result
+    }
+
     return { ok: true }
   } catch {
     return { ok: false, reason: 'comparator_error' } // rule 4 fail-closed

--- a/packages/core-backend/src/multitable/record-history-service.ts
+++ b/packages/core-backend/src/multitable/record-history-service.ts
@@ -236,8 +236,16 @@ export async function recordRecordRevisionsBatch(query: QueryFn, inputs: RecordR
 /**
  * W0-1 (OD-W0-1 mechanism (b)) — record a lock/unlock version bump as a chain marker in the independent
  * `meta_record_version_markers` table, so the generation-aware contiguity precheck does not read the bump
- * as an uncaptured-data-write HOLE. `kind` is 'lock' | 'unlock'. Idempotent (ON CONFLICT DO NOTHING against
- * the UNIQUE(sheet_id, record_id, version) constraint), so a retry never duplicates.
+ * as an uncaptured-data-write HOLE. `kind` is 'lock' | 'unlock'.
+ *
+ * W0-1 v3.7 (owner-ratified #4331 §9.3 — "loud marker"): this INSERT no longer carries
+ * `ON CONFLICT ... DO NOTHING`. Migration `zzzz20260715160000_add_meta_record_chain_seq` DROPPED the
+ * cross-generation `UNIQUE (sheet_id, record_id, version)` this used to target — that constraint silently
+ * SWALLOWED a resurrected generation's marker (a new generation legally reuses version numbers the FIRST
+ * generation also marked), which left the lock/unlock version bump committed while its marker vanished, and
+ * the strict contiguity walk then saw an unexplained hole in the new generation (false refusal of a healthy
+ * record). A genuine write conflict (there is no longer any unique key to violate under normal operation)
+ * now propagates and fails the enclosing lock/unlock transaction loudly instead of swallowing silently.
  *
  * Deploy-window safe (mirrors `hasRestoredFromVersionColumn`): the marker table may not exist yet in a
  * rolling deploy (the zzzz migration lands mid-process). A missing table is probed via a txn-safe
@@ -267,6 +275,26 @@ export async function hasVersionMarkerTable(query: QueryFn): Promise<boolean> {
   return false
 }
 
+let chainSeqColumnPresent = false
+/**
+ * W0-1 v3.7 (owner-ratified #4331 §9.3 / §1.1) — existence probe for the `seq` column shared by
+ * `meta_record_revisions` and `meta_record_version_markers` (migration
+ * `zzzz20260715160000_add_meta_record_chain_seq`). Mirrors `hasVersionMarkerTable`'s txn-safe
+ * information_schema pattern so the STRICT (`MULTITABLE_HISTORY_CONTIGUITY_STRICT`) precheck path can fail
+ * CLOSED during a rolling deploy window instead of crashing on an undefined column (42703).
+ */
+export async function hasChainSeqColumn(query: QueryFn): Promise<boolean> {
+  if (chainSeqColumnPresent) return true
+  const res = await query(
+    `SELECT 1 FROM information_schema.columns WHERE table_name = 'meta_record_revisions' AND column_name = 'seq' AND table_schema = ANY(current_schemas(false)) LIMIT 1`,
+  )
+  if ((res.rows as unknown[]).length > 0) {
+    chainSeqColumnPresent = true
+    return true
+  }
+  return false
+}
+
 export async function recordVersionMarker(
   query: QueryFn,
   input: { sheetId: string; recordId: string; version: number; kind: 'lock' | 'unlock'; actorId?: string | null },
@@ -274,8 +302,7 @@ export async function recordVersionMarker(
   if (!(await hasVersionMarkerTable(query))) return
   await query(
     `INSERT INTO meta_record_version_markers (id, sheet_id, record_id, version, kind, actor_id)
-     VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)
-     ON CONFLICT ON CONSTRAINT uq_meta_record_version_markers_sheet_record_version DO NOTHING`,
+     VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)`,
     [input.sheetId, input.recordId, input.version, input.kind, input.actorId ?? null],
   )
 }

--- a/packages/core-backend/tests/integration/multitable-history-contiguity-strict-seq-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-contiguity-strict-seq-realdb.test.ts
@@ -1,0 +1,290 @@
+/**
+ * W0-1 v3.7 (owner-ratified #4331 §9, docs/development/multitable-w0-1-v37-exact-anchor-trust-design-lock-
+ * 20260715.md) — the STRICT (seq-ordered, ALL-generations) chain-integrity precheck, behind
+ * `MULTITABLE_HISTORY_CONTIGUITY_STRICT` (default OFF). This is a DEFAULT-OFF implementation slice: no
+ * recovery flag is enabled by default, this file only toggles env vars inside its OWN test process to
+ * exercise the code paths (identical convention to the pre-existing
+ * `multitable-history-contiguity-realdb.test.ts`), and nothing here arms strict mode, Revert, or Reset in
+ * any real environment.
+ *
+ * Goldens (owner rubric — v3.7 §9.3/§6, this lane's required set):
+ *   FLAG-OFF PARITY                strict unset behaves BYTE-IDENTICAL to the pre-existing #4269 comparator
+ *       on the exact same data (proven directly against `precheckSheetHistoryIntegrity`).
+ *   GENERATION-2-LOCK-SURVIVES     a record's SECOND generation has a lock marker (via the REAL HTTP lock
+ *       endpoint — exercising the "loud marker" `ON CONFLICT` removal) filling what would be a hole →
+ *       passes. Proves marker attribution is per-generation, not just "current chain", and that removing the
+ *       cross-generation UNIQUE constraint did not break the ordinary lock/unlock write path.
+ *   TARGET-GENERATION HOLE, CLEAN TERMINAL ⇒ 409  (the owner High-2 regression this lane exists to fix): an
+ *       OLDER generation has an uncaptured hole; the TERMINAL generation is completely clean. A
+ *       terminal-only comparator (the superseded v3.5 shape) PASSES this; the v3.7 all-generations walk
+ *       refuses. Mutation: revert `checkAllGenerationsContiguity` to only walk the terminal generation ⇒ this
+ *       test reds (200 instead of 409).
+ *   DUP-WITHIN-GENERATION ⇒ chain_corrupt   two content events at the same version, same generation.
+ *   DELETED-GAP (C3)               a record with NO live row (chain-only + trash) whose only generation has
+ *       an uncaptured hole → refuses. Positive control: a clean deleted chain does not refuse.
+ *   EXACT-BIGINT > 2^53            two explicit SYNTHETIC seq values (inserted directly, NEVER via `setval`
+ *       on the shared `meta_record_chain_seq` — v3.7 P2-C) that Number() collapses to the same float64 must
+ *       be treated as distinct, non-colliding, correctly ordered — the chain passes. Mutation: compare seq
+ *       via `Number(a) === Number(b)` (or `Number(a) - Number(b)`) instead of exact string/BigInt ⇒ reds
+ *       (falsely refuses a healthy chain as `comparator_error`).
+ *   ILLEGAL-SEQ FAIL-CLOSE          a directly-inserted revision with a non-positive seq (bypassing every
+ *       app-level writer) refuses, never coerced to zero.
+ *   FORMULA-NOT-REFUSED            a live formula-field value that differs from its stored snapshot (formula
+ *       fields recompute live, never captured in a revision) does not trigger the content-projection layer.
+ *   POSITIVE CONTROL               a full healthy chain reverts and executes under strict mode.
+ *
+ * Two-point wiring: plugin-tests.yml real-DB run list + vitest.integration.config.ts. Runs only with
+ * DATABASE_URL. Fixture hygiene (P2-C): every seq value here is either the natural `DEFAULT nextval(...)`
+ * (ordinary app-shaped inserts) or an EXPLICIT literal on an isolated fixture row; this file never calls
+ * `setval` on the shared sequence, and `afterAll` cleans up only its own sheet/base/user rows.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { precheckSheetHistoryIntegrity } from '../../src/multitable/history-integrity-precheck'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_hcss_${TS}`
+const SHEET = `sheet_hcss_${TS}`
+const NAME = `fld_hcss_name_${TS}`
+const FORMULA_FIELD = `fld_hcss_formula_${TS}`
+const ACTOR = `user_hcss_${TS}`
+// H (the shared healthy record) uses explicit, well-separated timestamps: T0=create('old'), T2=update('new').
+// T1 (between them) is the default `asOf` — reverting to T1 must reconstruct H's T0 ('old') state, exactly
+// like the pre-existing `multitable-history-contiguity-realdb.test.ts`'s T0/T1/T2 convention.
+const T0 = '2026-02-01T00:00:00.000Z', T1 = '2026-02-02T00:00:00.000Z', T2 = '2026-02-03T00:00:00.000Z'
+
+const HISTORY_INCOMPLETE_BODY = {
+  ok: false,
+  error: {
+    code: 'HISTORY_INCOMPLETE',
+    message: 'Record history for this sheet is incomplete or inconsistent with its live data; destructive recovery is refused and nothing was written. History must be trustworthy before revert/reset can run.',
+  },
+}
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+const revertPreview = (sheet: string, asOf = T1) => request(app).post(`/api/multitable/sheets/${sheet}/revert-preview`).send({ asOf })
+const revertExecute = (sheet: string, previewIdentity: string, asOf = T1) => request(app).post(`/api/multitable/sheets/${sheet}/revert-execute`).send({ asOf, previewIdentity })
+const lockRecord = (id: string, locked: boolean) => request(app).post(`/api/multitable/records/${id}/lock`).send({ locked })
+
+// Ordinary insert — seq comes from the shared sequence's DEFAULT nextval(), exactly like a real app write.
+// Sequential `await`s preserve true causal (seq-ascending) order among a test's own inserts. `at` is an
+// OPTIONAL explicit `created_at` — irrelevant to strict (seq-ordered) verdicts, but the FLAG-OFF PARITY test
+// also exercises the LEGACY (epoch/version-ordered) comparator, which needs distinct, well-separated
+// timestamps (same-millisecond inserts would collapse its ordering) — mirrors the pre-existing
+// `multitable-history-contiguity-realdb.test.ts`'s fixed T0/T1/T2 convention.
+const rev = (sheet: string, id: string, version: number, action: string, snap: Record<string, unknown>, at?: string) =>
+  q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[]::text[],'{}'::jsonb,$5::jsonb,COALESCE($6::timestamptz, now()))`,
+    [sheet, id, version, action, JSON.stringify(snap), at ?? null])
+// Explicit-seq insert (P2-C: isolated fixture row, NEVER a `setval` on the shared sequence) — for the
+// production-magnitude (>2^53) and illegal-seq goldens, which need EXACT control over the literal seq value.
+const revExplicitSeq = (sheet: string, id: string, version: number, action: string, snap: Record<string, unknown>, seq: string) =>
+  q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[]::text[],'{}'::jsonb,$5::jsonb,$6::bigint)`, [sheet, id, version, action, JSON.stringify(snap), seq])
+const insertLive = (sheet: string, id: string, data: Record<string, unknown>, version: number) =>
+  q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,$4)', [id, sheet, JSON.stringify(data), version])
+const insertTrash = (sheet: string, id: string, data: Record<string, unknown>, originalVersion: number) =>
+  q('INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)', [id, sheet, JSON.stringify(data), originalVersion])
+const recordRow = async (id: string) => (await q('SELECT data, version FROM meta_records WHERE id = $1', [id])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+
+async function sheetWriteState(sheet: string) {
+  const records = (await q('SELECT id, data, version FROM meta_records WHERE sheet_id = $1 ORDER BY id', [sheet])).rows
+  const revisionCount = Number(((await q('SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1', [sheet])).rows[0] as { c: number }).c)
+  return { records, revisionCount }
+}
+
+async function expectRevertRefusesWithZeroWrites(sheet: string): Promise<void> {
+  const before = await sheetWriteState(sheet)
+  const pv = await revertPreview(sheet)
+  expect(pv.status).toBe(409)
+  expect(pv.body).toEqual(HISTORY_INCOMPLETE_BODY)
+  const ex = await revertExecute(sheet, 'dummy-never-minted')
+  expect(ex.status).toBe(409)
+  expect(ex.body).toEqual(HISTORY_INCOMPLETE_BODY)
+  expect(await sheetWriteState(sheet)).toEqual(before)
+}
+
+describeIfDatabase('W0-1 v3.7 STRICT history contiguity — seq-ordered, ALL generations (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'HCSS Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'HCSS'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [NAME, SHEET, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FORMULA_FIELD, SHEET, 'Formula', 'formula', '{}', 2])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+  })
+  afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_PIT_RESET
+    delete process.env.MULTITABLE_ENABLE_SHEET_REVERT
+    delete process.env.MULTITABLE_HISTORY_CONTIGUITY_STRICT
+    for (const t of ['meta_record_version_markers', 'meta_records_trash', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+  beforeEach(async () => {
+    process.env.MULTITABLE_ENABLE_PIT_RESET = 'true'
+    process.env.MULTITABLE_ENABLE_SHEET_REVERT = 'true'
+    process.env.MULTITABLE_HISTORY_CONTIGUITY_STRICT = 'true' // default OFF in real deployments; this test process only
+    await q('DELETE FROM meta_record_version_markers WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET])
+    // H — the healthy shared record (single-generation, live v2), reused by the POSITIVE CONTROL test.
+    await insertLive(SHEET, `rec_h_${TS}`, { [NAME]: 'new' }, 2)
+    await rev(SHEET, `rec_h_${TS}`, 1, 'create', { [NAME]: 'old' }, T0)
+    await rev(SHEET, `rec_h_${TS}`, 2, 'update', { [NAME]: 'new' }, T2)
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  // ── FLAG-OFF PARITY ──────────────────────────────────────────────────────────────────────────────────────
+  test('FLAG-OFF PARITY: an older-generation hole with a clean terminal generation PASSES with strict OFF (byte-identical #4269), REFUSES with strict ON', async () => {
+    const R = `rec_hcss_parity_${TS}`
+    // gen1 (older): create@1, update@3 (v2 MISSING — hole), delete@3 (reuse). gen2 (terminal, live=2): create@1, update@2 (clean).
+    // Explicit, well-separated timestamps: the LEGACY comparator orders by created_at — same-millisecond
+    // inserts would collapse its ordering, which is not what this test is exercising.
+    await rev(SHEET, R, 1, 'create', { [NAME]: 'g1-v1' }, '2026-01-01T00:00:00.000Z')
+    await rev(SHEET, R, 3, 'update', { [NAME]: 'g1-v3' }, '2026-01-01T00:00:01.000Z')
+    await rev(SHEET, R, 3, 'delete', { [NAME]: 'g1-v3' }, '2026-01-01T00:00:02.000Z')
+    await rev(SHEET, R, 1, 'create', { [NAME]: 'g2-v1' }, '2026-01-01T00:00:03.000Z')
+    await rev(SHEET, R, 2, 'update', { [NAME]: 'g2-v2' }, '2026-01-01T00:00:04.000Z')
+    await insertLive(SHEET, R, { [NAME]: 'g2-v2' }, 2)
+
+    delete process.env.MULTITABLE_HISTORY_CONTIGUITY_STRICT
+    const pool = poolManager.get()
+    expect(await precheckSheetHistoryIntegrity(pool.query.bind(pool), SHEET)).toEqual({ ok: true }) // legacy: terminal generation only, clean
+
+    process.env.MULTITABLE_HISTORY_CONTIGUITY_STRICT = 'true'
+    expect(await precheckSheetHistoryIntegrity(pool.query.bind(pool), SHEET)).toEqual({ ok: false, reason: 'chain_hole' }) // strict: all generations
+  })
+
+  // ── GENERATION-2-LOCK-SURVIVES ───────────────────────────────────────────────────────────────────────────
+  test('GENERATION-2-LOCK-SURVIVES: a lock marker in the SECOND generation (via the real HTTP lock endpoint) fills the hole → passes', async () => {
+    const R = `rec_hcss_gen2lock_${TS}`
+    // gen1: create@1, delete@1 (reuse). gen2 (terminal, live starts at 1): create@1.
+    await rev(SHEET, R, 1, 'create', { [NAME]: 'gen1' })
+    await rev(SHEET, R, 1, 'delete', { [NAME]: 'gen1' })
+    await rev(SHEET, R, 1, 'create', { [NAME]: 'gen2' })
+    await insertLive(SHEET, R, { [NAME]: 'gen2' }, 1)
+    // Real HTTP lock: version 1→2, marker written at v2 via the (ON-CONFLICT-free) recordVersionMarker path.
+    const lockRes = await lockRecord(R, true)
+    expect(lockRes.status).toBe(200)
+    expect((await recordRow(R))?.version).toBe(2)
+
+    const pv = await revertPreview(SHEET)
+    expect(pv.status).toBe(200)
+  })
+
+  // ── TARGET-GENERATION HOLE, CLEAN TERMINAL (owner High-2) ────────────────────────────────────────────────
+  test('TARGET-GENERATION HOLE, CLEAN TERMINAL ⇒ 409: an older-generation hole refuses even though the terminal generation is completely healthy', async () => {
+    const R = `rec_hcss_targetgen_${TS}`
+    await rev(SHEET, R, 1, 'create', { [NAME]: 'g1-v1' })
+    await rev(SHEET, R, 3, 'update', { [NAME]: 'g1-v3' }) // v2 uncaptured — the hole
+    await rev(SHEET, R, 3, 'delete', { [NAME]: 'g1-v3' })
+    await rev(SHEET, R, 1, 'create', { [NAME]: 'g2-v1' })
+    await rev(SHEET, R, 2, 'update', { [NAME]: 'g2-v2' }) // terminal generation — clean
+    await insertLive(SHEET, R, { [NAME]: 'g2-v2' }, 2)
+
+    await expectRevertRefusesWithZeroWrites(SHEET)
+  })
+
+  // ── DUP-WITHIN-GENERATION ────────────────────────────────────────────────────────────────────────────────
+  test('DUP-WITHIN-GENERATION ⇒ chain_corrupt: two content events at the same version, same generation, refuses', async () => {
+    const R = `rec_hcss_dupgen_${TS}`
+    await rev(SHEET, R, 1, 'create', { [NAME]: 'v1' })
+    await rev(SHEET, R, 2, 'update', { [NAME]: 'v2-a' })
+    await rev(SHEET, R, 2, 'update', { [NAME]: 'v2-b' }) // duplicate occupant at v2
+    await insertLive(SHEET, R, { [NAME]: 'v2-b' }, 2)
+
+    const pool = poolManager.get()
+    expect(await precheckSheetHistoryIntegrity(pool.query.bind(pool), SHEET)).toEqual({ ok: false, reason: 'chain_corrupt' })
+    await expectRevertRefusesWithZeroWrites(SHEET)
+  })
+
+  // ── DELETED-GAP (C3) ─────────────────────────────────────────────────────────────────────────────────────
+  test('DELETED-GAP (C3): a record with NO live row whose only generation has an uncaptured hole refuses; a clean deleted chain does not', async () => {
+    const BAD = `rec_hcss_delgap_${TS}`
+    await rev(SHEET, BAD, 1, 'create', { [NAME]: 'd1' })
+    await rev(SHEET, BAD, 3, 'update', { [NAME]: 'd3' }) // v2 uncaptured — the hole
+    await rev(SHEET, BAD, 3, 'delete', { [NAME]: 'd3' })
+    await insertTrash(SHEET, BAD, { [NAME]: 'd3' }, 3)
+    // BAD is not live (never inserted into meta_records) — enumerated via chain ∪ trash.
+    await expectRevertRefusesWithZeroWrites(SHEET)
+
+    // Positive control: replace BAD with a CLEAN deleted chain — the sheet must pass again.
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2', [SHEET, BAD])
+    await q('DELETE FROM meta_records_trash WHERE sheet_id = $1 AND record_id = $2', [SHEET, BAD])
+    const GOOD = `rec_hcss_delclean_${TS}`
+    await rev(SHEET, GOOD, 1, 'create', { [NAME]: 'g1' })
+    await rev(SHEET, GOOD, 2, 'update', { [NAME]: 'g2' })
+    await rev(SHEET, GOOD, 2, 'delete', { [NAME]: 'g2' }) // clean, delete-reuse
+    await insertTrash(SHEET, GOOD, { [NAME]: 'g2' }, 2)
+    const pv = await revertPreview(SHEET)
+    expect(pv.status).toBe(200)
+  })
+
+  // ── EXACT BIGINT > 2^53 (v3.7 §9.7 / P2-C: explicit synthetic seq, NEVER setval) ─────────────────────────
+  test('EXACT-BIGINT: two synthetic seqs straddling 2^53 (Number() collapses them) remain distinct — healthy chain passes', async () => {
+    const R = `rec_hcss_bigseq_${TS}`
+    // 2^53 = 9007199254740992 (exact in float64); 2^53+1 = 9007199254740993 collapses to the SAME float64
+    // via Number() — a naive Number()-based duplicate/order check would wrongly see these as one value.
+    const TWO_POW_53 = '9007199254740992'
+    const TWO_POW_53_PLUS_1 = '9007199254740993'
+    expect(Number(TWO_POW_53) === Number(TWO_POW_53_PLUS_1)).toBe(true) // sanity: the collapse is real in JS
+    await revExplicitSeq(SHEET, R, 1, 'create', { [NAME]: 'v1' }, TWO_POW_53)
+    await revExplicitSeq(SHEET, R, 2, 'update', { [NAME]: 'v2' }, TWO_POW_53_PLUS_1)
+    await insertLive(SHEET, R, { [NAME]: 'v2' }, 2)
+
+    const pool = poolManager.get()
+    expect(await precheckSheetHistoryIntegrity(pool.query.bind(pool), SHEET)).toEqual({ ok: true })
+    const pv = await revertPreview(SHEET)
+    expect(pv.status).toBe(200)
+  })
+
+  // ── ILLEGAL-SEQ FAIL-CLOSE ───────────────────────────────────────────────────────────────────────────────
+  test('ILLEGAL-SEQ FAIL-CLOSE: a directly-inserted revision with a non-positive seq refuses, never coerced to zero', async () => {
+    const R = `rec_hcss_illegalseq_${TS}`
+    await revExplicitSeq(SHEET, R, 1, 'create', { [NAME]: 'v1' }, '0') // illegal: non-positive
+    await insertLive(SHEET, R, { [NAME]: 'v1' }, 1)
+
+    const pool = poolManager.get()
+    expect(await precheckSheetHistoryIntegrity(pool.query.bind(pool), SHEET)).toEqual({ ok: false, reason: 'comparator_error' })
+    await expectRevertRefusesWithZeroWrites(SHEET)
+  })
+
+  // ── FORMULA-NOT-REFUSED ──────────────────────────────────────────────────────────────────────────────────
+  test('FORMULA-NOT-REFUSED: a live formula-field value that differs from its stored snapshot does not trigger content_mismatch', async () => {
+    const R = `rec_hcss_formula_${TS}`
+    await rev(SHEET, R, 1, 'create', { [NAME]: 'x', [FORMULA_FIELD]: 100 })
+    // Live data has a DIFFERENT (recomputed) formula value — formula fields are excluded from the
+    // content-projection layer's userFieldIds, so this must NOT refuse.
+    await insertLive(SHEET, R, { [NAME]: 'x', [FORMULA_FIELD]: 999 }, 1)
+
+    const pool = poolManager.get()
+    expect(await precheckSheetHistoryIntegrity(pool.query.bind(pool), SHEET)).toEqual({ ok: true })
+    const pv = await revertPreview(SHEET)
+    expect(pv.status).toBe(200)
+  })
+
+  // ── POSITIVE CONTROL ─────────────────────────────────────────────────────────────────────────────────────
+  test('POSITIVE CONTROL: a full healthy chain reverts and executes under strict mode', async () => {
+    const pv = await revertPreview(SHEET)
+    expect(pv.status).toBe(200)
+    expect(pv.body?.data?.summary?.visibleRevertCount).toBe(1)
+    const ex = await revertExecute(SHEET, pv.body?.data?.previewIdentity)
+    expect(ex.status).toBe(200)
+    const h = await recordRow(`rec_h_${TS}`)
+    expect(h?.data?.[NAME]).toBe('old')
+    expect(h?.version).toBe(3)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-history-contiguity-strict-seq-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-contiguity-strict-seq-realdb.test.ts
@@ -89,6 +89,11 @@ const revExplicitSeq = (sheet: string, id: string, version: number, action: stri
      VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[]::text[],'{}'::jsonb,$5::jsonb,$6::bigint)`, [sheet, id, version, action, JSON.stringify(snap), seq])
 const insertLive = (sheet: string, id: string, data: Record<string, unknown>, version: number) =>
   q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,$4)', [id, sheet, JSON.stringify(data), version])
+// Ordinary marker insert — seq comes from the shared sequence's DEFAULT nextval() (same as `rev`), so a marker
+// inserted BEFORE a create (sequential await) causally precedes it (lower seq) — used by the generation-0
+// marker golden below. NEVER a `setval` (P2-C).
+const marker = (sheet: string, id: string, version: number, kind: 'lock' | 'unlock') =>
+  q('INSERT INTO meta_record_version_markers (id, sheet_id, record_id, version, kind) VALUES (gen_random_uuid(),$1,$2,$3,$4)', [sheet, id, version, kind])
 const insertTrash = (sheet: string, id: string, data: Record<string, unknown>, originalVersion: number) =>
   q('INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)', [id, sheet, JSON.stringify(data), originalVersion])
 const recordRow = async (id: string) => (await q('SELECT data, version FROM meta_records WHERE id = $1', [id])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
@@ -194,6 +199,54 @@ describeIfDatabase('W0-1 v3.7 STRICT history contiguity — seq-ordered, ALL gen
     await rev(SHEET, R, 1, 'create', { [NAME]: 'g2-v1' })
     await rev(SHEET, R, 2, 'update', { [NAME]: 'g2-v2' }) // terminal generation — clean
     await insertLive(SHEET, R, { [NAME]: 'g2-v2' }, 2)
+
+    await expectRevertRefusesWithZeroWrites(SHEET)
+  })
+
+  // ── GENERATION-0 HOLE (owner High-2 counterexample, #4339) ───────────────────────────────────────────────
+  // Events/markers that PRECEDE the record's first captured create sit in generation 0 — which the strict
+  // all-generations walk (g=1..creates) never visited before the fix, so an older generation missing its
+  // create + a clean terminal generation wrongly returned {ok:true}. Live data matches the terminal
+  // generation's latest snapshot in each case, so the content-projection layer does NOT fire — the ONLY reason
+  // to refuse is the generation-0 hole. Mutation proof: delete `if (generation[0] === 0) return … chain_hole`
+  // from checkAllGenerationsContiguity ⇒ each of these reds (revert-preview returns 200 instead of 409).
+  test('GENERATION-0 (owner counterexample) ⇒ 409: an OLDER generation missing its create + a clean terminal generation refuses even though the terminal walk is healthy', async () => {
+    const R = `rec_hcss_gen0_${TS}`
+    // gen0 (create swept — retention/uncaptured): update@2, delete@2. gen1 (terminal, live=2): create@1, update@2 (clean).
+    await rev(SHEET, R, 2, 'update', { [NAME]: 'gA-v2' })
+    await rev(SHEET, R, 2, 'delete', { [NAME]: 'gA-v2' })
+    await rev(SHEET, R, 1, 'create', { [NAME]: 'gB-v1' })
+    await rev(SHEET, R, 2, 'update', { [NAME]: 'gB-v2' })
+    await insertLive(SHEET, R, { [NAME]: 'gB-v2' }, 2) // live == terminal latest snapshot ⇒ content layer clean
+
+    await expectRevertRefusesWithZeroWrites(SHEET)
+  })
+
+  test('GENERATION-0 (b) ⇒ 409: an UPDATE before any create refuses (chain_hole)', async () => {
+    const R = `rec_hcss_gen0_update_${TS}`
+    await rev(SHEET, R, 2, 'update', { [NAME]: 'orphan-v2' }) // generation 0 — no create captured yet
+    await rev(SHEET, R, 1, 'create', { [NAME]: 'v1' })
+    await rev(SHEET, R, 2, 'update', { [NAME]: 'v2' })
+    await insertLive(SHEET, R, { [NAME]: 'v2' }, 2)
+
+    await expectRevertRefusesWithZeroWrites(SHEET)
+  })
+
+  test('GENERATION-0 (c) ⇒ 409: a VERSION MARKER before any create refuses (chain_hole)', async () => {
+    const R = `rec_hcss_gen0_marker_${TS}`
+    await marker(SHEET, R, 2, 'lock') // generation 0 — a lock marker before any captured create
+    await rev(SHEET, R, 1, 'create', { [NAME]: 'v1' })
+    await rev(SHEET, R, 2, 'update', { [NAME]: 'v2' })
+    await insertLive(SHEET, R, { [NAME]: 'v2' }, 2)
+
+    await expectRevertRefusesWithZeroWrites(SHEET)
+  })
+
+  test('GENERATION-0 (d) ⇒ 409: a DELETE before any create refuses (chain_hole)', async () => {
+    const R = `rec_hcss_gen0_delete_${TS}`
+    await rev(SHEET, R, 1, 'delete', { [NAME]: 'orphan' }) // generation 0 — a delete of a swept-create generation
+    await rev(SHEET, R, 1, 'create', { [NAME]: 'v1' })
+    await insertLive(SHEET, R, { [NAME]: 'v1' }, 1)
 
     await expectRevertRefusesWithZeroWrites(SHEET)
   })

--- a/packages/core-backend/tests/integration/multitable-history-incomplete-precheck-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-incomplete-precheck-realdb.test.ts
@@ -139,7 +139,7 @@ describeIfDatabase('multitable D-1c §0.6 HISTORY_INCOMPLETE precheck (real DB)'
     delete process.env.MULTITABLE_ENABLE_PIT_RESET
     delete process.env.MULTITABLE_ENABLE_SHEET_REVERT
     for (const sheet of [SHEET, SHEET_F, SHEET_S]) {
-      for (const t of ['meta_records_trash', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [sheet]).catch(() => {})
+      for (const t of ['meta_record_version_markers', 'meta_records_trash', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [sheet]).catch(() => {})
       await q('DELETE FROM meta_sheets WHERE id = $1', [sheet]).catch(() => {})
     }
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
@@ -152,6 +152,13 @@ describeIfDatabase('multitable D-1c §0.6 HISTORY_INCOMPLETE precheck (real DB)'
     // the dedicated flag-off/on gate goldens.
     process.env.MULTITABLE_ENABLE_SHEET_REVERT = 'true'
     for (const sheet of [SHEET, SHEET_F, SHEET_S]) {
+      // W0-1 v3.7: `recordVersionMarker` no longer has `ON CONFLICT ... DO NOTHING` (the cross-generation
+      // UNIQUE it targeted was dropped — "loud marker", see history-integrity-precheck.ts's module doc).
+      // G-HI-2 reuses record id X across two tests in this file; a leftover marker from a PRIOR test at the
+      // same (sheet, record, version) — previously silently swallowed by the now-removed ON CONFLICT — would
+      // otherwise coexist with the marker THIS test's real lock/unlock writes, creating a genuine duplicate
+      // occupant. Clear markers every test, exactly like multitable-history-contiguity-realdb.test.ts already does.
+      await q('DELETE FROM meta_record_version_markers WHERE sheet_id = $1', [sheet]).catch(() => {})
       await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [sheet]).catch(() => {})
       await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [sheet])
       await q('DELETE FROM meta_records WHERE sheet_id = $1', [sheet])

--- a/packages/core-backend/tests/unit/multitable-history-contiguity-strict-seq.test.ts
+++ b/packages/core-backend/tests/unit/multitable-history-contiguity-strict-seq.test.ts
@@ -1,0 +1,186 @@
+/**
+ * W0-1 v3.7 (owner-ratified #4331 §9, docs/development/multitable-w0-1-v37-exact-anchor-trust-design-lock-
+ * 20260715.md) — `checkAllGenerationsContiguity`, the PURE, seq-ordered, ALL-GENERATIONS core behind
+ * `MULTITABLE_HISTORY_CONTIGUITY_STRICT`. Unit-level, no DB, mirrors `multitable-history-contiguity.test.ts`
+ * (the legacy epoch-ordered comparator's own pure-core suite) so both comparators are pinned
+ * deterministically. The DB goldens (`multitable-history-contiguity-strict-seq-realdb.test.ts`) exercise the
+ * same logic end-to-end + C3 + the HTTP surface.
+ *
+ * `seq` is the EXACT decimal-string value of the shared `meta_record_chain_seq` bigint column — NEVER a
+ * `number`. Small integer strings ('1', '2', ...) stand in for real sequence values in most tests below; the
+ * EXACT-BIGINT section proves the comparator stays exact at real int8 magnitudes too (values > 2^53, where
+ * `Number(...)` silently collapses distinct decimal strings to the same float64 — see that section for the
+ * JS-native proof).
+ */
+import { describe, expect, test } from 'vitest'
+
+import {
+  checkAllGenerationsContiguity,
+  type StrictScope,
+  type StrictTimelineItem,
+} from '../../src/multitable/history-integrity-precheck'
+
+const ev = (version: number, action: 'create' | 'update' | 'delete', seq: string): StrictTimelineItem => ({ kind: 'event', version, action, seq })
+const mk = (version: number, seq: string): StrictTimelineItem => ({ kind: 'marker', version, seq })
+const live = (liveVersion: number): StrictScope => ({ kind: 'live', liveVersion })
+const deleted: StrictScope = { kind: 'deleted' }
+
+describe('W0-1 v3.7 checkAllGenerationsContiguity — seq-ordered, ALL generations (not terminal-only)', () => {
+  test('healthy single-generation chain passes (positive control)', () => {
+    expect(checkAllGenerationsContiguity(live(2), [ev(1, 'create', '1'), ev(2, 'update', '2')])).toEqual({ ok: true })
+  })
+
+  test('HEALED-GAP: v3 record with revisions {v1, v3} (v2 uncaptured) → chain_hole', () => {
+    expect(checkAllGenerationsContiguity(live(3), [ev(1, 'create', '1'), ev(3, 'update', '2')])).toEqual({ ok: false, reason: 'chain_hole' })
+  })
+
+  test('the v2 hole HEALED by a lock marker → passes', () => {
+    expect(checkAllGenerationsContiguity(live(3), [ev(1, 'create', '1'), mk(2, '2'), ev(3, 'update', '3')])).toEqual({ ok: true })
+  })
+
+  test('healthy record locked then unlocked (two markers fill v2 + v3) → passes', () => {
+    expect(checkAllGenerationsContiguity(live(3), [ev(1, 'create', '1'), mk(2, '2'), mk(3, '3')])).toEqual({ ok: true })
+  })
+
+  test('zero-revision live row (uncaptured CREATE fingerprint) → zero_revision_live_row', () => {
+    expect(checkAllGenerationsContiguity(live(1), [])).toEqual({ ok: false, reason: 'zero_revision_live_row' })
+  })
+
+  test('WITHIN-GENERATION DUPLICATE occupant (two updates at one version) → chain_corrupt', () => {
+    expect(checkAllGenerationsContiguity(live(2), [ev(1, 'create', '1'), ev(2, 'update', '2'), ev(2, 'update', '3')]))
+      .toEqual({ ok: false, reason: 'chain_corrupt' })
+  })
+
+  test('a duplicate MARKER at the same version as another marker (same generation) → chain_corrupt', () => {
+    expect(checkAllGenerationsContiguity(live(2), [ev(1, 'create', '1'), mk(2, '2'), mk(2, '3')]))
+      .toEqual({ ok: false, reason: 'chain_corrupt' })
+  })
+
+  test('an event beyond the live version → out_of_range_version', () => {
+    expect(checkAllGenerationsContiguity(live(2), [ev(1, 'create', '1'), ev(2, 'update', '2'), ev(3, 'update', '3')]))
+      .toEqual({ ok: false, reason: 'out_of_range_version' })
+  })
+
+  test('a marker beyond the live version → out_of_range_version', () => {
+    expect(checkAllGenerationsContiguity(live(1), [ev(1, 'create', '1'), mk(2, '2')])).toEqual({ ok: false, reason: 'out_of_range_version' })
+  })
+
+  test('live row whose latest event is a DELETE (uncaptured resurrection) → live_row_after_delete_revision', () => {
+    expect(checkAllGenerationsContiguity(live(1), [ev(1, 'create', '1'), ev(1, 'delete', '2')]))
+      .toEqual({ ok: false, reason: 'live_row_after_delete_revision' })
+  })
+
+  // ── GENERATION-2-LOCK-SURVIVES (multi-generation, marker in a NON-first generation) ─────────────────────
+  test('GENERATION-2-LOCK-SURVIVES: gen1 clean (create+delete), gen2 = create + lock marker filling v2 → passes', () => {
+    // gen1: create@1(seq1), delete@1 reuse(seq2). gen2 (terminal, live=2): create@1(seq3), lock-marker@2(seq4).
+    expect(checkAllGenerationsContiguity(live(2), [
+      ev(1, 'create', '1'), ev(1, 'delete', '2'), ev(1, 'create', '3'), mk(2, '4'),
+    ])).toEqual({ ok: true })
+  })
+
+  // ── THE v3.7 CORRECTION: ALL generations validated, not terminal-only ────────────────────────────────────
+  test('TARGET-GENERATION HOLE, CLEAN TERMINAL: a hole in an OLDER generation refuses even though the terminal generation is completely clean (owner High-2 — "terminal-generation-only validation is forbidden")', () => {
+    // gen1 (older): create@1(seq1), update@3(seq2) [v2 MISSING], delete@3 reuse(seq3).
+    // gen2 (terminal, live=2): create@1(seq4), update@2(seq5) — clean.
+    // A terminal-only comparator (the superseded v3.5 shape) would PASS this (gen2 alone is healthy); the
+    // v3.7 all-generations walk refuses on gen1's hole regardless.
+    expect(checkAllGenerationsContiguity(live(2), [
+      ev(1, 'create', '1'), ev(3, 'update', '2'), ev(3, 'delete', '3'),
+      ev(1, 'create', '4'), ev(2, 'update', '5'),
+    ])).toEqual({ ok: false, reason: 'chain_hole' })
+  })
+
+  test('a hole in the CURRENT (terminal) generation is still caught after a restore', () => {
+    // gen2 (terminal) = create@1(seq3) then update@3(seq4) — v2 missing ⇒ hole, live version 3.
+    expect(checkAllGenerationsContiguity(live(3), [
+      ev(1, 'create', '1'), ev(1, 'delete', '2'), ev(1, 'create', '3'), ev(3, 'update', '4'),
+    ])).toEqual({ ok: false, reason: 'chain_hole' })
+  })
+
+  test('a live version < 1 is refused defensively', () => {
+    expect(checkAllGenerationsContiguity(live(0), [ev(1, 'create', '1')])).toEqual({ ok: false, reason: 'out_of_range_version' })
+  })
+
+  // ── ILLEGAL/MALFORMED SEQ FAIL-CLOSE (§9.3 scope item 6) ─────────────────────────────────────────────────
+  test('illegal seq "0" (non-positive) → comparator_error, fail-closed', () => {
+    expect(checkAllGenerationsContiguity(live(1), [ev(1, 'create', '0')])).toEqual({ ok: false, reason: 'comparator_error' })
+  })
+
+  test('illegal seq "-5" (negative) → comparator_error, fail-closed', () => {
+    expect(checkAllGenerationsContiguity(live(1), [ev(1, 'create', '-5')])).toEqual({ ok: false, reason: 'comparator_error' })
+  })
+
+  test('illegal seq "abc" (non-numeric) → comparator_error, fail-closed', () => {
+    expect(checkAllGenerationsContiguity(live(1), [ev(1, 'create', 'abc')])).toEqual({ ok: false, reason: 'comparator_error' })
+  })
+
+  test('illegal seq "01" (leading zero) → comparator_error, fail-closed', () => {
+    expect(checkAllGenerationsContiguity(live(1), [ev(1, 'create', '01')])).toEqual({ ok: false, reason: 'comparator_error' })
+  })
+
+  test('a duplicate seq value shared by two items (shared-sequence-domain violation) → comparator_error', () => {
+    expect(checkAllGenerationsContiguity(live(2), [ev(1, 'create', '1'), ev(2, 'update', '2'), mk(2, '2')]))
+      .toEqual({ ok: false, reason: 'comparator_error' })
+  })
+
+  test('seq regression (caller passed items out of ascending order) → comparator_error, fail-closed', () => {
+    expect(checkAllGenerationsContiguity(live(2), [ev(1, 'create', '2'), ev(2, 'update', '1')]))
+      .toEqual({ ok: false, reason: 'comparator_error' })
+  })
+
+  // ── DELETED-RECORD SCOPE (C3) ─────────────────────────────────────────────────────────────────────────────
+  test('DELETED SCOPE: a clean single-generation deleted chain passes (positive control for C3)', () => {
+    expect(checkAllGenerationsContiguity(deleted, [ev(1, 'create', '1'), ev(2, 'update', '2'), ev(2, 'delete', '3')])).toEqual({ ok: true })
+  })
+
+  test('DELETED SCOPE: a mid-generation gap in the deleted chain → chain_hole (C3 negative control)', () => {
+    // create@1(seq1) ... update@3(seq2, v2 missing) ... delete@3 reuse(seq3).
+    expect(checkAllGenerationsContiguity(deleted, [ev(1, 'create', '1'), ev(3, 'update', '2'), ev(3, 'delete', '3')]))
+      .toEqual({ ok: false, reason: 'chain_hole' })
+  })
+
+  test('DELETED SCOPE + v3.7 correction: an OLDER generation gap refuses even though the TERMINAL (most recent) generation is clean', () => {
+    // gen1 (older, has a gap): create@1(seq1), update@3(seq2) [v2 missing], delete@3(seq3).
+    // gen2 (terminal, clean): create@1(seq4), update@2(seq5), delete@2 reuse(seq6).
+    // The superseded v3.5 draft checked ONLY the terminal generation here and would PASS; v3.7 refuses.
+    expect(checkAllGenerationsContiguity(deleted, [
+      ev(1, 'create', '1'), ev(3, 'update', '2'), ev(3, 'delete', '3'),
+      ev(1, 'create', '4'), ev(2, 'update', '5'), ev(2, 'delete', '6'),
+    ])).toEqual({ ok: false, reason: 'chain_hole' })
+  })
+
+  test('DELETED SCOPE: a live record (scope=deleted called in error) whose chain does not end in a delete → chain_hole', () => {
+    expect(checkAllGenerationsContiguity(deleted, [ev(1, 'create', '1'), ev(2, 'update', '2')])).toEqual({ ok: false, reason: 'chain_hole' })
+  })
+
+  // ── EXACT BIGINT (§9.7 — 2^53 boundary; production-magnitude, never Number()/subtraction) ────────────────
+  describe('EXACT BIGINT: values above 2^53 (float64 loses precision at this magnitude)', () => {
+    const TWO_POW_53 = '9007199254740992' // 2^53 — exactly representable in float64
+    const TWO_POW_53_PLUS_1 = '9007199254740993' // 2^53 + 1 — NOT exactly representable
+
+    test('sanity: JS Number() actually collapses these two distinct decimal strings to the same float64', () => {
+      // This is the well-known float64 precision-loss gotcha the whole exact-bigint requirement guards
+      // against: two DIFFERENT bigint values become INDISTINGUISHABLE once coerced through Number().
+      expect(Number(TWO_POW_53) === Number(TWO_POW_53_PLUS_1)).toBe(true)
+      // BigInt is exact — the same two strings are NOT equal as arbitrary-precision integers.
+      expect(BigInt(TWO_POW_53) === BigInt(TWO_POW_53_PLUS_1)).toBe(false)
+    })
+
+    test('two distinct occupant seqs straddling 2^53 are NOT treated as a duplicate/collision — healthy chain passes', () => {
+      // create@1 (low seq) → update@2 (seq = 2^53) → update@3 (seq = 2^53+1). A Number()-based duplicate/
+      // ordering check would see the last two seqs as EQUAL and wrongly refuse this healthy chain
+      // (comparator_error) — the exact BigInt-based implementation must NOT.
+      expect(checkAllGenerationsContiguity(live(3), [
+        ev(1, 'create', '1000'), ev(2, 'update', TWO_POW_53), ev(3, 'update', TWO_POW_53_PLUS_1),
+      ])).toEqual({ ok: true })
+    })
+
+    test('near int8 max: two adjacent seqs at the extreme end of bigint range remain distinct and correctly ordered', () => {
+      const NEAR_INT8_MAX_A = '9223372036854775806' // int8 max (9223372036854775807) minus 1
+      const NEAR_INT8_MAX_B = '9223372036854775807' // int8 max
+      expect(checkAllGenerationsContiguity(live(2), [
+        ev(1, 'create', NEAR_INT8_MAX_A), ev(2, 'update', NEAR_INT8_MAX_B),
+      ])).toEqual({ ok: true })
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-history-contiguity-strict-seq.test.ts
+++ b/packages/core-backend/tests/unit/multitable-history-contiguity-strict-seq.test.ts
@@ -101,6 +101,39 @@ describe('W0-1 v3.7 checkAllGenerationsContiguity — seq-ordered, ALL generatio
     expect(checkAllGenerationsContiguity(live(0), [ev(1, 'create', '1')])).toEqual({ ok: false, reason: 'out_of_range_version' })
   })
 
+  // ── GENERATION-0 HOLE: events/markers BEFORE the first create (owner High-2 counterexample, #4339) ────────
+  // The running generation counter starts at 0 and increments only at a 'create', so anything preceding the
+  // record's first create sits in generation 0 — which the g=1..creates walk never visits. A well-formed
+  // chain's first item is always its create; an event/marker before it means an OLDER generation's create was
+  // never captured (a provably incomplete chain). Each of these returned {ok:true} before the fix (the gen-0
+  // items were silently skipped) — the mutation proof: delete `if (generation[0] === 0) return … chain_hole`
+  // and all four reds.
+  test('OWNER COUNTEREXAMPLE: an OLDER generation missing its create (its events precede the first create) + a CLEAN terminal generation ⇒ chain_hole (generation-0 hole, not skipped)', () => {
+    // gen0 (create swept): update@2(seq1), delete@2(seq2). gen1 (terminal, live=2): create@1(seq3), update@2(seq4) — clean.
+    expect(checkAllGenerationsContiguity(live(2), [
+      ev(2, 'update', '1'), ev(2, 'delete', '2'), ev(1, 'create', '3'), ev(2, 'update', '4'),
+    ])).toEqual({ ok: false, reason: 'chain_hole' })
+  })
+
+  test('an UPDATE before any create (generation 0) ⇒ chain_hole', () => {
+    expect(checkAllGenerationsContiguity(live(2), [ev(2, 'update', '1'), ev(1, 'create', '2'), ev(2, 'update', '3')]))
+      .toEqual({ ok: false, reason: 'chain_hole' })
+  })
+
+  test('a VERSION MARKER before any create (generation 0) ⇒ chain_hole', () => {
+    expect(checkAllGenerationsContiguity(live(2), [mk(2, '1'), ev(1, 'create', '2'), ev(2, 'update', '3')]))
+      .toEqual({ ok: false, reason: 'chain_hole' })
+  })
+
+  test('a DELETE before any create (generation 0) ⇒ chain_hole', () => {
+    expect(checkAllGenerationsContiguity(live(1), [ev(1, 'delete', '1'), ev(1, 'create', '2')]))
+      .toEqual({ ok: false, reason: 'chain_hole' })
+  })
+
+  test('positive control: the FIRST item being the create (generation starts at 1) is NOT refused by the gen-0 guard', () => {
+    expect(checkAllGenerationsContiguity(live(2), [ev(1, 'create', '1'), ev(2, 'update', '2')])).toEqual({ ok: true })
+  })
+
   // ── ILLEGAL/MALFORMED SEQ FAIL-CLOSE (§9.3 scope item 6) ─────────────────────────────────────────────────
   test('illegal seq "0" (non-positive) → comparator_error, fail-closed', () => {
     expect(checkAllGenerationsContiguity(live(1), [ev(1, 'create', '0')])).toEqual({ ok: false, reason: 'comparator_error' })

--- a/packages/core-backend/tests/unit/multitable-raw-record-data-projection.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-raw-record-data-projection.guard.test.ts
@@ -142,6 +142,12 @@ const ALLOWLIST: Record<string, Record<string, { disposition: Disposition; reaso
       reason: 'plugin-SDK patchRecord builds nextData = { ...existing.data, ...patch } to WRITE to meta_records; not a response echo',
     },
   },
+  'multitable/history-integrity-precheck.ts': {
+    'data: r.data': {
+      disposition: 'INTERNAL',
+      reason: 'W0-1 v3.7 STRICT precheck (precheckSheetHistoryIntegrityStrict): liveById internal hydration map used ONLY for the content-projection layer\'s live-vs-latest-snapshot equality check; the function returns only {ok, reason} — never echoes record data to any response',
+    },
+  },
 }
 
 describe('n2 raw record-data projection guard — egress-guard blind-spot closure', () => {

--- a/scripts/ops/global-history-flag-manifest.mjs
+++ b/scripts/ops/global-history-flag-manifest.mjs
@@ -192,6 +192,20 @@ export const GLOBAL_HISTORY_FLAG_MANIFEST = Object.freeze([
     ],
   },
   {
+    key: 'MULTITABLE_HISTORY_CONTIGUITY_STRICT',
+    type: 'boolean',
+    activationValue: 'true',
+    caseInsensitive: true,
+    dependsOn: [],
+    conflictsWith: [],
+    danger: 'low',
+    purpose:
+      "W0-1 v3.7 (#4331 §9) STRICT history-integrity precheck. Default OFF ⇒ BYTE-IDENTICAL to the #4269 live-vs-latest + generation-aware-contiguity comparator (unchanged code path/exports). When ON (`String(env).trim().toLowerCase() === 'true'`, so 'TRUE'/' true ' also activate it — same case-insensitive family as PIT_RESET/SHEET_REVERT/PIT_UNDELETE), precheckSheetHistoryIntegrity delegates ENTIRELY to precheckSheetHistoryIntegrityStrict: seq-ordered (exact bigint) causal order, ALL generations validated (incl. generation 0 — events before the first create refuse chain_hole), C3 deleted/trashed-chain enumeration, and dup/illegal-seq fail-close. This is a PURE-READ refusal gate: it only makes revert/reset preview+execute refuse MORE (fail-closed HISTORY_INCOMPLETE), never enables any destructive write, so danger=low. It does NOT itself unlock Revert or Reset — those stay behind MULTITABLE_ENABLE_SHEET_REVERT / MULTITABLE_ENABLE_PIT_RESET; this flag only changes HOW their shared precheck proves the chain is trustworthy (and it also runs read-only inside the UNGATED revert-preview), so it is deliberately left out of dependsOn/conflictsWith — the strict precheck is well-defined regardless of whether either destructive gate is on.",
+    // source: packages/core-backend/src/multitable/history-integrity-precheck.ts:100 (isContiguityStrictMode,
+    //         `.trim().toLowerCase() === 'true'`), :459 (precheckSheetHistoryIntegrity delegates to the strict path)
+    source: 'packages/core-backend/src/multitable/history-integrity-precheck.ts:100,459',
+  },
+  {
     key: 'MULTITABLE_ENABLE_RECORD_UNDELETE_INBOUND',
     type: 'boolean',
     activationValue: 'true',


### PR DESCRIPTION
## Summary

Rebuilds the W0-1 Lane L3 chain-integrity core per the owner-ratified **#4331 v3.7 §9** design lock, correcting the superseded v3.5 draft (#4309). This is a **default-off implementation slice** — no recovery flag is enabled, nothing here arms strict mode, Revert/Reset, or touches any host.

Implements (§9.3, §9.7 + owner v3.6 Highs):
1. **Migration** (`zzzz20260715160000_add_meta_record_chain_seq`): one shared `meta_record_chain_seq` BIGINT sequence backing a `NOT NULL seq` column on **both** `meta_record_revisions` and `meta_record_version_markers`; legacy backfill via `row_number() OVER (ORDER BY created_at,version,id)` **per table** (display/order assistance only — explicitly **never** a trust signal, per §9.3); drops the cross-generation `UNIQUE(sheet_id,record_id,version)` on the markers table (it silently swallowed a resurrected generation's marker). Proven on a fresh-DB full migrate **and** against a populated-DB backfill scenario.
2. **Exact bigint end-to-end** (§9.7): every seq comparison uses native SQL `ORDER BY` (bigint) or exact `BigInt(...)`/string-equality in TS — `Number(seq)`, `parseInt`, unary `+`, subtraction comparators, and JSON-number seq fields are never used. Production-magnitude tests (values > 2^53, where `Number()` collapses distinct decimal strings) are mutation-proven both as pure unit tests and real-DB goldens.
3. **Generation-aware contiguity, seq-ordered**, behind `MULTITABLE_HISTORY_CONTIGUITY_STRICT` (default OFF): `precheckSheetHistoryIntegrityStrict` + `checkAllGenerationsContiguity`, generation = count(create) over seq order.
4. **Target-generation check, not terminal-only** (owner High-2): the conservative "all generations reconstructable in scope" option v3.7 §9.3 explicitly permits — every generation is validated, so a hole in an *older* generation refuses even when the terminal generation is completely clean.
5. **Deleted/trash chain enumeration (C3)**: records not live (chain-only or in `meta_records_trash`) are also enumerated and validated.
6. **Dup/illegal-seq fail-close**: a within-generation duplicate ⇒ `chain_corrupt` (new, strict-only reason); illegal/missing/out-of-range seq ⇒ fail-closed `comparator_error`, never coerced to zero.

`record-history-service.ts`'s `recordVersionMarker` drops its `ON CONFLICT DO NOTHING` — the constraint it targeted no longer exists, so a genuine write conflict now fails the enclosing lock/unlock transaction loudly instead of swallowing silently ("loud marker").

## Deferred (later lanes, not built here)

- §1.2 sealed operation-endpoint ledger (L6)
- §1.3 exact recovery anchor / API (L6)
- L4 all-writer canonical fence
- L5 trust checkpoint
- C2 time-monotonicity (remains on the pre-existing deferred docket; not required by this lane's scope)

## Verification

- Fresh-DB full migrate: proven (all migrations apply cleanly, including this one) + a separate populated-DB run proving the per-table backfill + sequence bootstrap-sync is correct and collision-free for subsequent writes.
- All new goldens pass: 27/27 pure unit tests (`tests/unit/multitable-history-contiguity-strict-seq.test.ts`) + 10/10 real-DB goldens (`tests/integration/multitable-history-contiguity-strict-seq-realdb.test.ts`, wired into `plugin-tests.yml`).
- **Mutation-proven** (performed locally, not shipped): reverting the all-generations walk to terminal-only reds both the target-generation unit tests and the real-DB golden; replacing the exact `BigInt` seq comparator with `Number()`+subtraction reds both exact-bigint goldens; weakening the duplicate-occupant threshold reds the dup-within-generation goldens.
- Full existing history/revert/reset/lock/restore real-DB regression swath (34 files, 354 tests) + full unit suite (393 files, 5463 tests) + `pnpm --filter @metasheet/core-backend type-check` all green — flag-off byte-identical to #4269 is confirmed by the untouched non-strict function body and this pre-existing suite passing unchanged.
- One pre-existing real-DB test (`multitable-history-incomplete-precheck-realdb.test.ts`) needed a hygiene fix: it reused a record id across two tests without clearing `meta_record_version_markers`, previously masked by the now-removed `ON CONFLICT DO NOTHING`. Fixed by clearing markers every test (matching the sibling contiguity test file's existing convention).
- Confirmed no `Number(seq)`/`parseInt(seq)` and no test-time `setval` on the shared production sequence anywhere (grep-verified); the migration's one-time `setval` is a bootstrap sync distinct from the forbidden test-time pattern (P2-C).

## Flags

`MULTITABLE_HISTORY_CONTIGUITY_STRICT` — default OFF, not armed. `MULTITABLE_ENABLE_PIT_RESET` / `MULTITABLE_ENABLE_SHEET_REVERT` — unchanged, still default OFF; this PR does not touch their defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)