### PR TITLE
feat(automation): action-idempotency ledger L1 — meta_automation_action_applied schema + golden

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -546,6 +546,7 @@ jobs:
             tests/integration/multitable-tombstone-record-capture-realdb.test.ts \
             tests/integration/multitable-tombstone-retention-realdb.test.ts \
             tests/integration/multitable-automation-outbox-schema-realdb.test.ts \
+            tests/integration/multitable-action-applied-ledger-realdb.test.ts \
             tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts \
             tests/integration/multitable-automation-dispatch-loop-realdb.test.ts \
             tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260715200000_create_automation_action_applied.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260715200000_create_automation_action_applied.ts
@@ -39,7 +39,12 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       application_mode text NOT NULL DEFAULT 'apply'
                          CONSTRAINT action_applied_mode_valid CHECK (application_mode IN ('apply','test_run')),
       result_ref       text,
-      applied_at       timestamptz NOT NULL DEFAULT now()
+      applied_at       timestamptz NOT NULL DEFAULT now(),
+      -- node_key and entry_epoch must move together: BOTH the non-node sentinel ('', 0) OR BOTH a real
+      -- FWB-3 node scope (non-blank node_key, epoch >= 1). Without this, ('', 7) and ('node_A', 0) are
+      -- accepted and can split one idempotency identity into two rows (#4340 review P2).
+      CONSTRAINT action_applied_node_epoch_paired
+        CHECK ((node_key = '' AND entry_epoch = 0) OR (node_key <> '' AND entry_epoch >= 1))
     )
   `.execute(db)
   // the single business-claim key: sentinels (node_key='', entry_epoch=0) cover FWB-1/2; FWB-3 uses real values.

--- a/packages/core-backend/src/db/migrations/zzzz20260715200000_create_automation_action_applied.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260715200000_create_automation_action_applied.ts
@@ -41,10 +41,12 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       result_ref       text,
       applied_at       timestamptz NOT NULL DEFAULT now(),
       -- node_key and entry_epoch must move together: BOTH the non-node sentinel ('', 0) OR BOTH a real
-      -- FWB-3 node scope (non-blank node_key, epoch >= 1). Without this, ('', 7) and ('node_A', 0) are
-      -- accepted and can split one idempotency identity into two rows (#4340 review P2).
+      -- FWB-3 node scope (node_key with a printable non-space char, epoch >= 1). The regex test [!-~]
+      -- (not merely <> the empty string) so a WHITESPACE/TAB-only node_key with a positive epoch is rejected
+      -- too — otherwise ('', 7), ('node_A', 0) AND (' ', 7) are accepted and can split one idempotency
+      -- identity into two rows (#4340 review P2).
       CONSTRAINT action_applied_node_epoch_paired
-        CHECK ((node_key = '' AND entry_epoch = 0) OR (node_key <> '' AND entry_epoch >= 1))
+        CHECK ((node_key = '' AND entry_epoch = 0) OR (node_key ~ '[!-~]' AND entry_epoch >= 1))
     )
   `.execute(db)
   // the single business-claim key: sentinels (node_key='', entry_epoch=0) cover FWB-1/2; FWB-3 uses real values.

--- a/packages/core-backend/src/db/migrations/zzzz20260715200000_create_automation_action_applied.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260715200000_create_automation_action_applied.ts
@@ -1,0 +1,54 @@
+/**
+ * Migration: `meta_automation_action_applied` — the ACTION-LEVEL idempotency ledger (FWB prerequisite).
+ *
+ * #4203 §2.3 ruling: a bare `approval_instance_id UNIQUE` would block a second rule/action forever, so the
+ * business-level claim key is the composite below. Two dedup layers stack: the EVENT level (`event_fires` /
+ * outbox per-consumer rows) stops "the same event redelivered"; THIS ledger stops "the same instance's same
+ * action re-applied" across retries/redeliveries/zombie double-sends — the Class-A same-DB write claim is
+ * INSERTed in the SAME transaction as the record write + revision + outbox row (§3 D9), so a zombie's
+ * duplicate write collides on the UNIQUE key and rolls back (natural fencing for same-DB effects).
+ *
+ *   - `action_key` = the #4196-C4 corrected triple identity {structuralPath, action.type, canonicalConfig
+ *     hash} — stable across fence tokens and attempts (the outbound-idempotency seed for Class-B).
+ *   - FWB-1/FWB-2 uniqueness = (instance_id, rule_id, action_key) with node_key='' AND entry_epoch=0
+ *     (sentinel: non-node-scoped). FWB-3 adds real (node_key, entry_epoch) — 退回/跳转 re-entry gets a new
+ *     epoch, and an old epoch's values are never reused (§6). One UNIQUE index covers both via sentinels.
+ *   - `application_mode` separates test-run/dry-run isolation from real applies ('apply' | 'test_run'):
+ *     a test run claims in mode 'test_run' and NEVER blocks (or is blocked by) a real apply.
+ *   - Class-B outbound effects don't get exactly-once from this table — they carry the derived idempotency
+ *     key to the endpoint and record `outcome_unknown` without auto-resend when the endpoint can't dedup.
+ *   - `result_ref` stores only IDENTIFIERS (record id / revision id), never business values (values-free).
+ *
+ * Additive only; nothing reads or writes this table until the FWB runtime lands behind its own gate.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_automation_action_applied (
+      id               text PRIMARY KEY,
+      instance_id      text NOT NULL
+                         CONSTRAINT action_applied_instance_nonblank CHECK (instance_id ~ '[!-~]'),
+      rule_id          text NOT NULL
+                         CONSTRAINT action_applied_rule_nonblank CHECK (rule_id ~ '[!-~]'),
+      action_key       text NOT NULL
+                         CONSTRAINT action_applied_action_key_nonblank CHECK (action_key ~ '[!-~]'),
+      node_key         text NOT NULL DEFAULT '',
+      entry_epoch      int  NOT NULL DEFAULT 0
+                         CONSTRAINT action_applied_epoch_nonneg CHECK (entry_epoch >= 0),
+      application_mode text NOT NULL DEFAULT 'apply'
+                         CONSTRAINT action_applied_mode_valid CHECK (application_mode IN ('apply','test_run')),
+      result_ref       text,
+      applied_at       timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+  // the single business-claim key: sentinels (node_key='', entry_epoch=0) cover FWB-1/2; FWB-3 uses real values.
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_action_applied_business_claim
+    ON meta_automation_action_applied (instance_id, rule_id, action_key, node_key, entry_epoch, application_mode)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS meta_automation_action_applied`.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260715200000_create_fwb_action_applied.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260715200000_create_fwb_action_applied.ts
@@ -1,5 +1,10 @@
 /**
- * Migration: `meta_automation_action_applied` — the ACTION-LEVEL idempotency ledger (FWB prerequisite).
+ * Migration: `meta_fwb_action_applied` — the FWB (approval form-writeback) ACTION-LEVEL idempotency ledger.
+ *
+ * NAME NOTE (#4340 review P1): `meta_automation_action_applied` is RESERVED by the #4196 lock (§2.2) for the
+ * EXECUTION-SCOPED retry ledger — a DIFFERENT schema keyed by `(kind, root_execution_id, action_key)`. This
+ * FWB ledger is a separate concern (approval-instance / node scoped) and MUST NOT squat that name, so it lives
+ * on `meta_fwb_action_applied`. The two tables coexist independently (see the coexistence golden in the spec).
  *
  * #4203 §2.3 ruling: a bare `approval_instance_id UNIQUE` would block a second rule/action forever, so the
  * business-level claim key is the composite below. Two dedup layers stack: the EVENT level (`event_fires` /
@@ -9,7 +14,7 @@
  * duplicate write collides on the UNIQUE key and rolls back (natural fencing for same-DB effects).
  *
  *   - `action_key` = the #4196-C4 corrected triple identity {structuralPath, action.type, canonicalConfig
- *     hash} — stable across fence tokens and attempts (the outbound-idempotency seed for Class-B).
+ *     hash}, INJECTIVELY encoded — stable across fence tokens and attempts (the outbound-idempotency seed).
  *   - FWB-1/FWB-2 uniqueness = (instance_id, rule_id, action_key) with node_key='' AND entry_epoch=0
  *     (sentinel: non-node-scoped). FWB-3 adds real (node_key, entry_epoch) — 退回/跳转 re-entry gets a new
  *     epoch, and an old epoch's values are never reused (§6). One UNIQUE index covers both via sentinels.
@@ -25,19 +30,19 @@ import { sql, type Kysely } from 'kysely'
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`
-    CREATE TABLE IF NOT EXISTS meta_automation_action_applied (
+    CREATE TABLE IF NOT EXISTS meta_fwb_action_applied (
       id               text PRIMARY KEY,
       instance_id      text NOT NULL
-                         CONSTRAINT action_applied_instance_nonblank CHECK (instance_id ~ '[!-~]'),
+                         CONSTRAINT fwb_action_applied_instance_nonblank CHECK (instance_id ~ '[!-~]'),
       rule_id          text NOT NULL
-                         CONSTRAINT action_applied_rule_nonblank CHECK (rule_id ~ '[!-~]'),
+                         CONSTRAINT fwb_action_applied_rule_nonblank CHECK (rule_id ~ '[!-~]'),
       action_key       text NOT NULL
-                         CONSTRAINT action_applied_action_key_nonblank CHECK (action_key ~ '[!-~]'),
+                         CONSTRAINT fwb_action_applied_action_key_nonblank CHECK (action_key ~ '[!-~]'),
       node_key         text NOT NULL DEFAULT '',
       entry_epoch      int  NOT NULL DEFAULT 0
-                         CONSTRAINT action_applied_epoch_nonneg CHECK (entry_epoch >= 0),
+                         CONSTRAINT fwb_action_applied_epoch_nonneg CHECK (entry_epoch >= 0),
       application_mode text NOT NULL DEFAULT 'apply'
-                         CONSTRAINT action_applied_mode_valid CHECK (application_mode IN ('apply','test_run')),
+                         CONSTRAINT fwb_action_applied_mode_valid CHECK (application_mode IN ('apply','test_run')),
       result_ref       text,
       applied_at       timestamptz NOT NULL DEFAULT now(),
       -- node_key and entry_epoch must move together: BOTH the non-node sentinel ('', 0) OR BOTH a real
@@ -45,17 +50,17 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       -- (not merely <> the empty string) so a WHITESPACE/TAB-only node_key with a positive epoch is rejected
       -- too — otherwise ('', 7), ('node_A', 0) AND (' ', 7) are accepted and can split one idempotency
       -- identity into two rows (#4340 review P2).
-      CONSTRAINT action_applied_node_epoch_paired
+      CONSTRAINT fwb_action_applied_node_epoch_paired
         CHECK ((node_key = '' AND entry_epoch = 0) OR (node_key ~ '[!-~]' AND entry_epoch >= 1))
     )
   `.execute(db)
   // the single business-claim key: sentinels (node_key='', entry_epoch=0) cover FWB-1/2; FWB-3 uses real values.
   await sql`
-    CREATE UNIQUE INDEX IF NOT EXISTS uq_action_applied_business_claim
-    ON meta_automation_action_applied (instance_id, rule_id, action_key, node_key, entry_epoch, application_mode)
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_fwb_action_applied_business_claim
+    ON meta_fwb_action_applied (instance_id, rule_id, action_key, node_key, entry_epoch, application_mode)
   `.execute(db)
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
-  await sql`DROP TABLE IF EXISTS meta_automation_action_applied`.execute(db)
+  await sql`DROP TABLE IF EXISTS meta_fwb_action_applied`.execute(db)
 }

--- a/packages/core-backend/src/multitable/automation-action-idempotency.ts
+++ b/packages/core-backend/src/multitable/automation-action-idempotency.ts
@@ -46,13 +46,19 @@ export interface ActionIdentity {
   canonicalConfig: unknown
 }
 
-/** The stable triple-identity action key: `<structuralPath>#<actionType>#sha256(canonicalConfig)[:16]`. */
+/**
+ * The stable triple-identity action key. The three components are joined with an INJECTIVE encoding —
+ * `JSON.stringify([structuralPath, actionType, sha256(canonicalConfig)[:16]])` — NOT a bare delimiter join.
+ * A delimiter like `#` collides when a component contains it: `("a", "b#c")` and `("a#b", "c")` would both
+ * become `"a#b#c#…"`, splitting/merging distinct action identities (#4340 review P2). JSON escapes each
+ * component unambiguously, so the map from the triple to the key is one-to-one.
+ */
 export function deriveActionKey(id: ActionIdentity): string {
   if (!NON_BLANK.test(id.structuralPath ?? '') || !NON_BLANK.test(id.actionType ?? '')) {
     throw new RangeError('deriveActionKey: structuralPath and actionType must be non-blank')
   }
   const cfgHash = createHash('sha256').update(canonicalizeConfig(id.canonicalConfig)).digest('hex').slice(0, 16)
-  return `${id.structuralPath}#${id.actionType}#${cfgHash}`
+  return JSON.stringify([id.structuralPath, id.actionType, cfgHash])
 }
 
 export interface ActionClaim {
@@ -86,12 +92,16 @@ export async function claimActionApplied(trx: Queryable, c: ActionClaim): Promis
   return Number(res.rowCount ?? 0) === 1 ? 'claimed' : 'duplicate'
 }
 
-/** Endpoint idempotency key = stable event+action identity. NEVER fence/attempt-derived (#4203 §340). */
+/**
+ * Endpoint idempotency key = stable event+action identity. NEVER fence/attempt-derived (#4203 §340). Uses the
+ * same INJECTIVE JSON-array encoding as `deriveActionKey` — a bare `::` join would collide if either component
+ * contained `::` (#4340 review P2).
+ */
 export function deriveOutboundIdempotencyKey(eventId: string, actionKey: string): string {
   if (!NON_BLANK.test(eventId) || !NON_BLANK.test(actionKey)) {
     throw new RangeError('deriveOutboundIdempotencyKey: eventId and actionKey must be non-blank')
   }
-  return `${eventId}::${actionKey}`
+  return JSON.stringify([eventId, actionKey])
 }
 
 /**

--- a/packages/core-backend/src/multitable/automation-action-idempotency.ts
+++ b/packages/core-backend/src/multitable/automation-action-idempotency.ts
@@ -94,7 +94,7 @@ export async function claimActionApplied(trx: Queryable, c: ActionClaim): Promis
   }
   const mode = c.applicationMode ?? 'apply'
   const res = await trx.query(
-    `INSERT INTO meta_automation_action_applied (id, instance_id, rule_id, action_key, node_key, entry_epoch, application_mode, result_ref)
+    `INSERT INTO meta_fwb_action_applied (id, instance_id, rule_id, action_key, node_key, entry_epoch, application_mode, result_ref)
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
      ON CONFLICT (instance_id, rule_id, action_key, node_key, entry_epoch, application_mode) DO NOTHING`,
     [c.id, c.instanceId, c.ruleId, c.actionKey, nodeKey, entryEpoch, mode, c.resultRef ?? null],

--- a/packages/core-backend/src/multitable/automation-action-idempotency.ts
+++ b/packages/core-backend/src/multitable/automation-action-idempotency.ts
@@ -1,0 +1,110 @@
+/**
+ * Action-idempotency ledger L2 — stable action_key derivation + Class-A same-transaction claim + Class-B
+ * outbound semantics (#4203 §2.3 / #4196 C4). FWB write-path prerequisite; no production callers yet.
+ *
+ *   - `deriveActionKey({structuralPath, actionType, canonicalConfig})` — the #4196-C4 corrected TRIPLE
+ *     identity. Deterministic: the config is canonicalized (deep key-sort) then sha256-hashed, so the key is
+ *     stable across fence tokens, attempts, retries and process restarts — the Class-B outbound-idempotency
+ *     seed. NEVER derived from fence/attempt/timestamps.
+ *   - `claimActionApplied(trx, claim)` — Class-A same-DB claim: INSERT ... ON CONFLICT DO NOTHING on the
+ *     composite business key, in the SAME transaction as the record write + revision + outbox row (§3 D9).
+ *     Returns 'claimed' (proceed to write) or 'duplicate' (a prior apply won — skip, net-once). A zombie's
+ *     duplicate write therefore collides and aborts with its transaction — natural fencing for same-DB
+ *     effects, no oracle needed.
+ *   - Class-B (outbound) effects CANNOT be fenced by this table: both a zombie and its reclaimer may reach
+ *     the send. `deriveOutboundIdempotencyKey` binds the endpoint key to the STABLE event+action identity
+ *     (never fence/attempt), so a double send carries the SAME key and the endpoint collapses it;
+ *     `classifyOutboundOutcome` encodes the ratified rule: an endpoint without idempotency support and an
+ *     ambiguous transport result → `outcome_unknown`, recorded, NEVER auto-resent (#4203 §340-346).
+ */
+import { createHash } from 'node:crypto'
+
+import type { Queryable } from './automation-durable-dispatcher'
+
+const NON_BLANK = /[!-~]/
+
+/** Deep-sort object keys so hashing is insensitive to property order (arrays keep order — it is meaning). */
+export function canonicalizeConfig(value: unknown): string {
+  const walk = (v: unknown): unknown => {
+    if (Array.isArray(v)) return v.map(walk)
+    if (v && typeof v === 'object') {
+      return Object.fromEntries(
+        Object.keys(v as Record<string, unknown>)
+          .sort()
+          .map((k) => [k, walk((v as Record<string, unknown>)[k])]),
+      )
+    }
+    return v
+  }
+  return JSON.stringify(walk(value ?? null))
+}
+
+export interface ActionIdentity {
+  /** structured step path of the action inside its rule (#4196 C4). */
+  structuralPath: string
+  actionType: string
+  canonicalConfig: unknown
+}
+
+/** The stable triple-identity action key: `<structuralPath>#<actionType>#sha256(canonicalConfig)[:16]`. */
+export function deriveActionKey(id: ActionIdentity): string {
+  if (!NON_BLANK.test(id.structuralPath ?? '') || !NON_BLANK.test(id.actionType ?? '')) {
+    throw new RangeError('deriveActionKey: structuralPath and actionType must be non-blank')
+  }
+  const cfgHash = createHash('sha256').update(canonicalizeConfig(id.canonicalConfig)).digest('hex').slice(0, 16)
+  return `${id.structuralPath}#${id.actionType}#${cfgHash}`
+}
+
+export interface ActionClaim {
+  id: string
+  instanceId: string
+  ruleId: string
+  actionKey: string
+  /** FWB-3 only; FWB-1/2 use the sentinels. */
+  nodeKey?: string
+  entryEpoch?: number
+  applicationMode?: 'apply' | 'test_run'
+  /** identifiers only (record id / revision id) — never business values. */
+  resultRef?: string | null
+}
+
+/**
+ * Class-A same-transaction business claim. Call on the SAME trx as the record write; 'duplicate' means a
+ * prior apply already holds the key (net-once satisfied) — the caller skips its write and completes.
+ */
+export async function claimActionApplied(trx: Queryable, c: ActionClaim): Promise<'claimed' | 'duplicate'> {
+  for (const [name, v] of [['instanceId', c.instanceId], ['ruleId', c.ruleId], ['actionKey', c.actionKey]] as const) {
+    if (typeof v !== 'string' || !NON_BLANK.test(v)) throw new RangeError(`claimActionApplied: ${name} must be non-blank`)
+  }
+  const mode = c.applicationMode ?? 'apply'
+  const res = await trx.query(
+    `INSERT INTO meta_automation_action_applied (id, instance_id, rule_id, action_key, node_key, entry_epoch, application_mode, result_ref)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+     ON CONFLICT (instance_id, rule_id, action_key, node_key, entry_epoch, application_mode) DO NOTHING`,
+    [c.id, c.instanceId, c.ruleId, c.actionKey, c.nodeKey ?? '', c.entryEpoch ?? 0, mode, c.resultRef ?? null],
+  )
+  return Number(res.rowCount ?? 0) === 1 ? 'claimed' : 'duplicate'
+}
+
+/** Endpoint idempotency key = stable event+action identity. NEVER fence/attempt-derived (#4203 §340). */
+export function deriveOutboundIdempotencyKey(eventId: string, actionKey: string): string {
+  if (!NON_BLANK.test(eventId) || !NON_BLANK.test(actionKey)) {
+    throw new RangeError('deriveOutboundIdempotencyKey: eventId and actionKey must be non-blank')
+  }
+  return `${eventId}::${actionKey}`
+}
+
+/**
+ * Class-B outcome classification (#4203 §344): a definite transport success/failure maps through; an
+ * AMBIGUOUS result (timeout/unknown) on an endpoint WITHOUT idempotency support is `outcome_unknown` —
+ * recorded, never auto-resent (a resend on ambiguity is a duplicate external effect). With endpoint
+ * idempotency support, a retry is safe (same key collapses), so ambiguity maps to retryable.
+ */
+export function classifyOutboundOutcome(
+  transport: 'delivered' | 'rejected' | 'ambiguous',
+  endpointSupportsIdempotency: boolean,
+): 'success' | 'permanent_failure' | 'retryable_failure' | 'outcome_unknown' {
+  if (transport === 'delivered') return 'success'
+  if (transport === 'rejected') return 'permanent_failure'
+  return endpointSupportsIdempotency ? 'retryable_failure' : 'outcome_unknown'
+}

--- a/packages/core-backend/src/multitable/automation-action-idempotency.ts
+++ b/packages/core-backend/src/multitable/automation-action-idempotency.ts
@@ -82,12 +82,22 @@ export async function claimActionApplied(trx: Queryable, c: ActionClaim): Promis
   for (const [name, v] of [['instanceId', c.instanceId], ['ruleId', c.ruleId], ['actionKey', c.actionKey]] as const) {
     if (typeof v !== 'string' || !NON_BLANK.test(v)) throw new RangeError(`claimActionApplied: ${name} must be non-blank`)
   }
+  // node_key / entry_epoch must be PAIRED — the ('', 0) non-node sentinel OR a non-BLANK node_key with epoch
+  // >= 1. Validated here (not only at the DB CHECK) so a mixed pair — incl. a whitespace/tab-only node_key
+  // with a positive epoch — fails fast with a clear error before the write (#4340 review P2).
+  const nodeKey = c.nodeKey ?? ''
+  const entryEpoch = c.entryEpoch ?? 0
+  const isSentinel = nodeKey === '' && entryEpoch === 0
+  const isNodeScope = NON_BLANK.test(nodeKey) && Number.isInteger(entryEpoch) && entryEpoch >= 1
+  if (!isSentinel && !isNodeScope) {
+    throw new RangeError('claimActionApplied: (node_key, entry_epoch) must be the ("",0) sentinel or a non-blank node_key with entry_epoch >= 1')
+  }
   const mode = c.applicationMode ?? 'apply'
   const res = await trx.query(
     `INSERT INTO meta_automation_action_applied (id, instance_id, rule_id, action_key, node_key, entry_epoch, application_mode, result_ref)
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
      ON CONFLICT (instance_id, rule_id, action_key, node_key, entry_epoch, application_mode) DO NOTHING`,
-    [c.id, c.instanceId, c.ruleId, c.actionKey, c.nodeKey ?? '', c.entryEpoch ?? 0, mode, c.resultRef ?? null],
+    [c.id, c.instanceId, c.ruleId, c.actionKey, nodeKey, entryEpoch, mode, c.resultRef ?? null],
   )
   return Number(res.rowCount ?? 0) === 1 ? 'claimed' : 'duplicate'
 }

--- a/packages/core-backend/src/multitable/automation-action-idempotency.ts
+++ b/packages/core-backend/src/multitable/automation-action-idempotency.ts
@@ -19,7 +19,9 @@
  */
 import { createHash } from 'node:crypto'
 
-import type { Queryable } from './automation-durable-dispatcher'
+import { assertInTransaction, type TransactionalQueryable } from './pg-transaction-guard'
+
+export type { TransactionalQueryable } from './pg-transaction-guard'
 
 const NON_BLANK = /[!-~]/
 
@@ -77,8 +79,14 @@ export interface ActionClaim {
 /**
  * Class-A same-transaction business claim. Call on the SAME trx as the record write; 'duplicate' means a
  * prior apply already holds the key (net-once satisfied) — the caller skips its write and completes.
+ *
+ * The same-transaction requirement is MACHINE-ENFORCED against the DATABASE's own transaction state
+ * (pg-transaction-guard xid probe): a pool / autocommit client / forged marker is rejected BEFORE the claim.
+ * Otherwise the claim would auto-commit separately from the business write — and after a failed business
+ * write, the orphaned committed claim makes every retry return 'duplicate', permanently skipping the missing
+ * write (#4340 review P1).
  */
-export async function claimActionApplied(trx: Queryable, c: ActionClaim): Promise<'claimed' | 'duplicate'> {
+export async function claimActionApplied(trx: TransactionalQueryable, c: ActionClaim): Promise<'claimed' | 'duplicate'> {
   for (const [name, v] of [['instanceId', c.instanceId], ['ruleId', c.ruleId], ['actionKey', c.actionKey]] as const) {
     if (typeof v !== 'string' || !NON_BLANK.test(v)) throw new RangeError(`claimActionApplied: ${name} must be non-blank`)
   }
@@ -92,6 +100,8 @@ export async function claimActionApplied(trx: Queryable, c: ActionClaim): Promis
   if (!isSentinel && !isNodeScope) {
     throw new RangeError('claimActionApplied: (node_key, entry_epoch) must be the ("",0) sentinel or a non-blank node_key with entry_epoch >= 1')
   }
+  // The claim must ride the SAME transaction as the business write — probed against the DB itself (#4340 P1).
+  await assertInTransaction(trx, 'claimActionApplied')
   const mode = c.applicationMode ?? 'apply'
   const res = await trx.query(
     `INSERT INTO meta_fwb_action_applied (id, instance_id, rule_id, action_key, node_key, entry_epoch, application_mode, result_ref)

--- a/packages/core-backend/tests/integration/multitable-action-applied-ledger-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-action-applied-ledger-realdb.test.ts
@@ -79,6 +79,29 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
     // mixed pairs split one idempotency identity — rejected by the paired CHECK, named
     await expect(claim({ action: `ak_${RUN}_bad_a`, node: '', epoch: 7 })).rejects.toThrow(/action_applied_node_epoch_paired/)
     await expect(claim({ action: `ak_${RUN}_bad_b`, node: 'node_C', epoch: 0 })).rejects.toThrow(/action_applied_node_epoch_paired/)
+    // a WHITESPACE/TAB-only node_key is NOT a real node — `~ '[!-~]'` (not `<> ''`) rejects it with a positive epoch
+    await expect(claim({ action: `ak_${RUN}_bad_ws`, node: ' ', epoch: 7 })).rejects.toThrow(/action_applied_node_epoch_paired/)
+    await expect(claim({ action: `ak_${RUN}_bad_tab`, node: '\t', epoch: 3 })).rejects.toThrow(/action_applied_node_epoch_paired/)
+  })
+
+  test('claimActionApplied validates the (node_key, entry_epoch) PAIR at the JS layer, before the write', async () => {
+    const base = { instanceId: INST, ruleId: `rule_${RUN}_pjs`, actionKey: `ak_${RUN}_pjs` }
+    // valid: sentinel and a real node scope both claim
+    expect(await claimActionApplied(poolManager.get(), { ...base, id: `aa_${randomUUID()}` })).toBe('claimed')
+    expect(
+      await claimActionApplied(poolManager.get(), { ...base, actionKey: `ak_${RUN}_pjs2`, nodeKey: 'node_X', entryEpoch: 1, id: `aa_${randomUUID()}` }),
+    ).toBe('claimed')
+    // mixed pairs (incl. whitespace/tab node with a positive epoch) throw at the JS layer — nothing is written
+    for (const bad of [
+      { nodeKey: '', entryEpoch: 5 },
+      { nodeKey: 'node_Y', entryEpoch: 0 },
+      { nodeKey: ' ', entryEpoch: 2 },
+      { nodeKey: '\t', entryEpoch: 1 },
+    ]) {
+      await expect(
+        claimActionApplied(poolManager.get(), { ...base, actionKey: `ak_${RUN}_pjs_bad`, ...bad, id: `aa_${randomUUID()}` }),
+      ).rejects.toThrow(/must be the.*sentinel/)
+    }
   })
 
   test('test_run isolation: a test_run claim does not block (or get blocked by) a real apply', async () => {

--- a/packages/core-backend/tests/integration/multitable-action-applied-ledger-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-action-applied-ledger-realdb.test.ts
@@ -18,6 +18,13 @@ import { randomUUID } from 'node:crypto'
 import { afterAll, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
+import {
+  canonicalizeConfig,
+  claimActionApplied,
+  classifyOutboundOutcome,
+  deriveActionKey,
+  deriveOutboundIdempotencyKey,
+} from '../../src/multitable/automation-action-idempotency'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
@@ -93,5 +100,48 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
     }
     const { rows } = await q('SELECT count(*)::int AS c FROM meta_automation_action_applied WHERE action_key=$1', [action])
     expect(Number(rows[0].c)).toBe(0)
+  })
+
+  // ---- L2: derivation + Class-A claim helper + Class-B semantics ----
+
+  test('L2 deriveActionKey: deterministic triple identity — key-order insensitive, value-sensitive, fence-free', () => {
+    const a = deriveActionKey({ structuralPath: 'steps[2].actions[0]', actionType: 'create_record', canonicalConfig: { b: 2, a: 1 } })
+    const b = deriveActionKey({ structuralPath: 'steps[2].actions[0]', actionType: 'create_record', canonicalConfig: { a: 1, b: 2 } })
+    expect(a).toBe(b) // property order does not change identity
+    const c = deriveActionKey({ structuralPath: 'steps[2].actions[0]', actionType: 'create_record', canonicalConfig: { a: 1, b: 3 } })
+    expect(c).not.toBe(a) // config change = new identity
+    expect(canonicalizeConfig({ x: [2, 1] })).toBe('{"x":[2,1]}') // array order preserved (it is meaning)
+    expect(() => deriveActionKey({ structuralPath: ' ', actionType: 'x', canonicalConfig: {} })).toThrow(/non-blank/)
+  })
+
+  test('L2 claimActionApplied: first=claimed, repeat=duplicate; CONCURRENT double-claim → exactly one claimed', async () => {
+    const key = deriveActionKey({ structuralPath: 's[0]', actionType: 'create_record', canonicalConfig: { t: RUN } })
+    const base = { instanceId: INST, ruleId: `rule_${RUN}_l2`, actionKey: key }
+    expect(await claimActionApplied(poolManager.get(), { ...base, id: `aa_${randomUUID()}` })).toBe('claimed')
+    expect(await claimActionApplied(poolManager.get(), { ...base, id: `aa_${randomUUID()}` })).toBe('duplicate')
+    // constructed race on a FRESH key: two connections claim simultaneously
+    const key2 = deriveActionKey({ structuralPath: 's[1]', actionType: 'create_record', canonicalConfig: { t: RUN } })
+    const raw = poolManager.get().getInternalPool()
+    const [ca, cb] = await Promise.all([raw.connect(), raw.connect()])
+    try {
+      const [ra, rb] = await Promise.all([
+        claimActionApplied(ca, { ...base, actionKey: key2, id: `aa_${randomUUID()}` }),
+        claimActionApplied(cb, { ...base, actionKey: key2, id: `aa_${randomUUID()}` }),
+      ])
+      expect([ra, rb].filter((r) => r === 'claimed')).toHaveLength(1) // net-once under the race
+      expect([ra, rb].filter((r) => r === 'duplicate')).toHaveLength(1)
+    } finally {
+      ca.release()
+      cb.release()
+    }
+  })
+
+  test('L2 Class-B: outbound key = stable event+action identity; ambiguity w/o endpoint idempotency = outcome_unknown', () => {
+    const k1 = deriveOutboundIdempotencyKey('evt_1', 'ak_1')
+    expect(k1).toBe('evt_1::ak_1') // no fence, no attempt — identical across zombie + reclaimer
+    expect(classifyOutboundOutcome('delivered', false)).toBe('success')
+    expect(classifyOutboundOutcome('rejected', true)).toBe('permanent_failure')
+    expect(classifyOutboundOutcome('ambiguous', true)).toBe('retryable_failure') // endpoint dedups → safe retry
+    expect(classifyOutboundOutcome('ambiguous', false)).toBe('outcome_unknown') // recorded, NEVER auto-resent
   })
 })

--- a/packages/core-backend/tests/integration/multitable-action-applied-ledger-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-action-applied-ledger-realdb.test.ts
@@ -25,6 +25,7 @@ import {
   deriveActionKey,
   deriveOutboundIdempotencyKey,
 } from '../../src/multitable/automation-action-idempotency'
+import type { Queryable } from '../../src/multitable/automation-durable-dispatcher'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
@@ -71,6 +72,15 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
     await expect(claim({ action: `ak_${RUN}_n`, node: 'node_A', epoch: 2 })).resolves.toBeTruthy() // 退回→新 epoch
   })
 
+  test('node_key/entry_epoch are PAIRED: only the empty-node sentinel or a real node with epoch>=1; mixed pairs rejected', async () => {
+    // valid pairs
+    await expect(claim({ action: `ak_${RUN}_p0`, node: '', epoch: 0 })).resolves.toBeTruthy() // non-node sentinel
+    await expect(claim({ action: `ak_${RUN}_p1`, node: 'node_B', epoch: 1 })).resolves.toBeTruthy() // real FWB-3 scope
+    // mixed pairs split one idempotency identity — rejected by the paired CHECK, named
+    await expect(claim({ action: `ak_${RUN}_bad_a`, node: '', epoch: 7 })).rejects.toThrow(/action_applied_node_epoch_paired/)
+    await expect(claim({ action: `ak_${RUN}_bad_b`, node: 'node_C', epoch: 0 })).rejects.toThrow(/action_applied_node_epoch_paired/)
+  })
+
   test('test_run isolation: a test_run claim does not block (or get blocked by) a real apply', async () => {
     await claim({ action: `ak_${RUN}_t`, mode: 'test_run' })
     await expect(claim({ action: `ak_${RUN}_t`, mode: 'apply' })).resolves.toBeTruthy()
@@ -84,17 +94,18 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
     await expect(claim({ rule: '\t' })).rejects.toThrow(/action_applied_rule_nonblank/)
   })
 
-  test('same-transaction guarantee: claim inside a rolled-back txn leaves NO ledger row', async () => {
+  test('same-transaction guarantee: the REAL claimActionApplied inside a rolled-back txn leaves NO ledger row', async () => {
     const raw = poolManager.get().getInternalPool()
     const c = await raw.connect()
     const action = `ak_${RUN}_txn`
+    // exercise the REAL helper on the checked-out connection (not a hand-written INSERT) so the test proves
+    // claimActionApplied's own write is bound to the caller's txn (#4340 review P3).
+    const trx: Queryable = { query: (sql, params) => c.query(sql, params) }
     try {
       await c.query('BEGIN')
-      await c.query(
-        `INSERT INTO meta_automation_action_applied (id, instance_id, rule_id, action_key) VALUES ($1,$2,$3,$4)`,
-        [`aa_${randomUUID()}`, INST, `rule_${RUN}_txn`, action],
-      )
-      await c.query('ROLLBACK') // the record write failed → claim must vanish with it
+      const r = await claimActionApplied(trx, { id: `aa_${randomUUID()}`, instanceId: INST, ruleId: `rule_${RUN}_txn`, actionKey: action })
+      expect(r).toBe('claimed') // the real helper claimed inside the txn...
+      await c.query('ROLLBACK') // ...but the record write failed → the claim must vanish with it
     } finally {
       c.release()
     }
@@ -112,6 +123,11 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
     expect(c).not.toBe(a) // config change = new identity
     expect(canonicalizeConfig({ x: [2, 1] })).toBe('{"x":[2,1]}') // array order preserved (it is meaning)
     expect(() => deriveActionKey({ structuralPath: ' ', actionType: 'x', canonicalConfig: {} })).toThrow(/non-blank/)
+    // INJECTIVE encoding (#4340 review P2): a delimiter inside a component must not merge two distinct
+    // identities. Under a bare `#` join, ("a","b#c") and ("a#b","c") would both be "a#b#c#…" — they must differ.
+    expect(deriveActionKey({ structuralPath: 'a', actionType: 'b#c', canonicalConfig: {} })).not.toBe(
+      deriveActionKey({ structuralPath: 'a#b', actionType: 'c', canonicalConfig: {} }),
+    )
   })
 
   test('L2 claimActionApplied: first=claimed, repeat=duplicate; CONCURRENT double-claim → exactly one claimed', async () => {
@@ -138,7 +154,9 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
 
   test('L2 Class-B: outbound key = stable event+action identity; ambiguity w/o endpoint idempotency = outcome_unknown', () => {
     const k1 = deriveOutboundIdempotencyKey('evt_1', 'ak_1')
-    expect(k1).toBe('evt_1::ak_1') // no fence, no attempt — identical across zombie + reclaimer
+    expect(k1).toBe('["evt_1","ak_1"]') // injective JSON-array encoding — no fence, no attempt
+    // a component containing the old `::` delimiter must not collide (#4340 review P2)
+    expect(deriveOutboundIdempotencyKey('a', 'b::c')).not.toBe(deriveOutboundIdempotencyKey('a::b', 'c'))
     expect(classifyOutboundOutcome('delivered', false)).toBe('success')
     expect(classifyOutboundOutcome('rejected', true)).toBe('permanent_failure')
     expect(classifyOutboundOutcome('ambiguous', true)).toBe('retryable_failure') // endpoint dedups → safe retry

--- a/packages/core-backend/tests/integration/multitable-action-applied-ledger-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-action-applied-ledger-realdb.test.ts
@@ -1,5 +1,5 @@
 /**
- * Action-idempotency ledger L1 — meta_automation_action_applied schema golden (real DB).
+ * Action-idempotency ledger L1 — meta_fwb_action_applied schema golden (real DB).
  *
  * Proves the #4203 §2.3 business-claim contract at the DB layer:
  *   - the composite UNIQUE key (instance_id, rule_id, action_key, node_key, entry_epoch, application_mode)
@@ -34,7 +34,7 @@ const INST = `apr_${RUN}`
 
 const claim = (over: Partial<Record<'id'|'instance'|'rule'|'action'|'node'|'mode', string>> & { epoch?: number } = {}) =>
   q(
-    `INSERT INTO meta_automation_action_applied (id, instance_id, rule_id, action_key, node_key, entry_epoch, application_mode, result_ref)
+    `INSERT INTO meta_fwb_action_applied (id, instance_id, rule_id, action_key, node_key, entry_epoch, application_mode, result_ref)
      VALUES ($1,$2,$3,$4,$5,$6,$7,'rec_id_only')`,
     [
       over.id ?? `aa_${randomUUID()}`,
@@ -49,7 +49,7 @@ const claim = (over: Partial<Record<'id'|'instance'|'rule'|'action'|'node'|'mode
 
 describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', () => {
   afterAll(async () => {
-    await q('DELETE FROM meta_automation_action_applied WHERE instance_id = $1', [INST]).catch(() => {})
+    await q('DELETE FROM meta_fwb_action_applied WHERE instance_id = $1', [INST]).catch(() => {})
   })
 
   test('sentinel: DATABASE_URL set', () => {
@@ -58,7 +58,7 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
 
   test('duplicate apply of the SAME (instance, rule, action) collides on the named UNIQUE index', async () => {
     await claim()
-    await expect(claim()).rejects.toThrow(/uq_action_applied_business_claim/)
+    await expect(claim()).rejects.toThrow(/uq_fwb_action_applied_business_claim/)
   })
 
   test('a SECOND rule and a SECOND action on the same instance are NOT blocked (no bare-instance UNIQUE)', async () => {
@@ -68,7 +68,7 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
 
   test('FWB-3 node scoping: same action re-entered with a NEW entry_epoch claims independently', async () => {
     await claim({ action: `ak_${RUN}_n`, node: 'node_A', epoch: 1 })
-    await expect(claim({ action: `ak_${RUN}_n`, node: 'node_A', epoch: 1 })).rejects.toThrow(/uq_action_applied_business_claim/)
+    await expect(claim({ action: `ak_${RUN}_n`, node: 'node_A', epoch: 1 })).rejects.toThrow(/uq_fwb_action_applied_business_claim/)
     await expect(claim({ action: `ak_${RUN}_n`, node: 'node_A', epoch: 2 })).resolves.toBeTruthy() // 退回→新 epoch
   })
 
@@ -77,11 +77,11 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
     await expect(claim({ action: `ak_${RUN}_p0`, node: '', epoch: 0 })).resolves.toBeTruthy() // non-node sentinel
     await expect(claim({ action: `ak_${RUN}_p1`, node: 'node_B', epoch: 1 })).resolves.toBeTruthy() // real FWB-3 scope
     // mixed pairs split one idempotency identity — rejected by the paired CHECK, named
-    await expect(claim({ action: `ak_${RUN}_bad_a`, node: '', epoch: 7 })).rejects.toThrow(/action_applied_node_epoch_paired/)
-    await expect(claim({ action: `ak_${RUN}_bad_b`, node: 'node_C', epoch: 0 })).rejects.toThrow(/action_applied_node_epoch_paired/)
+    await expect(claim({ action: `ak_${RUN}_bad_a`, node: '', epoch: 7 })).rejects.toThrow(/fwb_action_applied_node_epoch_paired/)
+    await expect(claim({ action: `ak_${RUN}_bad_b`, node: 'node_C', epoch: 0 })).rejects.toThrow(/fwb_action_applied_node_epoch_paired/)
     // a WHITESPACE/TAB-only node_key is NOT a real node — `~ '[!-~]'` (not `<> ''`) rejects it with a positive epoch
-    await expect(claim({ action: `ak_${RUN}_bad_ws`, node: ' ', epoch: 7 })).rejects.toThrow(/action_applied_node_epoch_paired/)
-    await expect(claim({ action: `ak_${RUN}_bad_tab`, node: '\t', epoch: 3 })).rejects.toThrow(/action_applied_node_epoch_paired/)
+    await expect(claim({ action: `ak_${RUN}_bad_ws`, node: ' ', epoch: 7 })).rejects.toThrow(/fwb_action_applied_node_epoch_paired/)
+    await expect(claim({ action: `ak_${RUN}_bad_tab`, node: '\t', epoch: 3 })).rejects.toThrow(/fwb_action_applied_node_epoch_paired/)
   })
 
   test('claimActionApplied validates the (node_key, entry_epoch) PAIR at the JS layer, before the write', async () => {
@@ -107,14 +107,14 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
   test('test_run isolation: a test_run claim does not block (or get blocked by) a real apply', async () => {
     await claim({ action: `ak_${RUN}_t`, mode: 'test_run' })
     await expect(claim({ action: `ak_${RUN}_t`, mode: 'apply' })).resolves.toBeTruthy()
-    await expect(claim({ action: `ak_${RUN}_t`, mode: 'test_run' })).rejects.toThrow(/uq_action_applied_business_claim/)
-    await expect(claim({ action: `ak_${RUN}_bogusmode`, mode: 'bogus' })).rejects.toThrow(/action_applied_mode_valid/)
+    await expect(claim({ action: `ak_${RUN}_t`, mode: 'test_run' })).rejects.toThrow(/uq_fwb_action_applied_business_claim/)
+    await expect(claim({ action: `ak_${RUN}_bogusmode`, mode: 'bogus' })).rejects.toThrow(/fwb_action_applied_mode_valid/)
   })
 
   test('non-blank CHECKs reject blank identity parts by constraint name', async () => {
-    await expect(claim({ action: '  ' })).rejects.toThrow(/action_applied_action_key_nonblank/)
-    await expect(claim({ instance: '' })).rejects.toThrow(/action_applied_instance_nonblank/)
-    await expect(claim({ rule: '\t' })).rejects.toThrow(/action_applied_rule_nonblank/)
+    await expect(claim({ action: '  ' })).rejects.toThrow(/fwb_action_applied_action_key_nonblank/)
+    await expect(claim({ instance: '' })).rejects.toThrow(/fwb_action_applied_instance_nonblank/)
+    await expect(claim({ rule: '\t' })).rejects.toThrow(/fwb_action_applied_rule_nonblank/)
   })
 
   test('same-transaction guarantee: the REAL claimActionApplied inside a rolled-back txn leaves NO ledger row', async () => {
@@ -132,7 +132,7 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
     } finally {
       c.release()
     }
-    const { rows } = await q('SELECT count(*)::int AS c FROM meta_automation_action_applied WHERE action_key=$1', [action])
+    const { rows } = await q('SELECT count(*)::int AS c FROM meta_fwb_action_applied WHERE action_key=$1', [action])
     expect(Number(rows[0].c)).toBe(0)
   })
 
@@ -184,5 +184,33 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
     expect(classifyOutboundOutcome('rejected', true)).toBe('permanent_failure')
     expect(classifyOutboundOutcome('ambiguous', true)).toBe('retryable_failure') // endpoint dedups → safe retry
     expect(classifyOutboundOutcome('ambiguous', false)).toBe('outcome_unknown') // recorded, NEVER auto-resent
+  })
+
+  // [#4340 review P1] Table-name coexistence: this FWB ledger lives on `meta_fwb_action_applied` and must NOT
+  // squat `meta_automation_action_applied`, which #4196 §2.2 reserves for the EXECUTION-SCOPED retry ledger
+  // (a DIFFERENT schema with a `kind` column). Prove both tables coexist and #4196's own INSERT works.
+  test('coexists with the #4196 execution-scoped meta_automation_action_applied (kind schema) — no name squat', async () => {
+    // this suite's migration created ONLY the FWB table under its FWB-specific name
+    const fwbExists = await q(`SELECT to_regclass('public.meta_fwb_action_applied') IS NOT NULL AS ok`)
+    expect(fwbExists.rows[0].ok).toBe(true)
+    // the #4196 name is FREE — stand up its LOCKED (§2.2) execution-scoped shape and run its exact claim INSERT
+    await q(`CREATE TABLE IF NOT EXISTS meta_automation_action_applied (
+               kind text NOT NULL, root_execution_id text NOT NULL, action_key text NOT NULL,
+               action_type text, applied_at timestamptz NOT NULL DEFAULT now(),
+               UNIQUE (kind, root_execution_id, action_key))`)
+    try {
+      // #4196 §2's INSERT — would have thrown `column "kind" does not exist` if the FWB table had squatted the name
+      await q(`INSERT INTO meta_automation_action_applied (kind, root_execution_id, action_key)
+               VALUES ('execution', $1, 'ak_exec') ON CONFLICT DO NOTHING`, [`root_${RUN}`])
+      const execRow = await q(`SELECT count(*)::int AS c FROM meta_automation_action_applied WHERE root_execution_id=$1`, [`root_${RUN}`])
+      expect(Number(execRow.rows[0].c)).toBe(1)
+      // and the FWB ledger claims INTO ITS OWN table, independently
+      const key = deriveActionKey({ structuralPath: 's[coexist]', actionType: 'create_record', canonicalConfig: { t: RUN } })
+      expect(await claimActionApplied(poolManager.get(), { instanceId: INST, ruleId: `rule_${RUN}_cx`, actionKey: key, id: `aa_${randomUUID()}` })).toBe('claimed')
+      const fwbRow = await q(`SELECT count(*)::int AS c FROM meta_fwb_action_applied WHERE instance_id=$1 AND action_key=$2`, [INST, key])
+      expect(Number(fwbRow.rows[0].c)).toBe(1) // the two ledgers are disjoint tables
+    } finally {
+      await q(`DROP TABLE IF EXISTS meta_automation_action_applied`).catch(() => {})
+    }
   })
 })

--- a/packages/core-backend/tests/integration/multitable-action-applied-ledger-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-action-applied-ledger-realdb.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Action-idempotency ledger L1 — meta_automation_action_applied schema golden (real DB).
+ *
+ * Proves the #4203 §2.3 business-claim contract at the DB layer:
+ *   - the composite UNIQUE key (instance_id, rule_id, action_key, node_key, entry_epoch, application_mode)
+ *     blocks a duplicate apply (the Class-A zombie-fencing collision) with the named index;
+ *   - a SECOND rule / SECOND action on the same instance is NOT blocked (the exact bare-instance_id trap the
+ *     lock ruled out);
+ *   - FWB-3 node-scoping: same action, new entry_epoch (退回/跳转 re-entry) claims independently;
+ *   - test_run isolation: a test_run claim never blocks a real apply (and vice versa);
+ *   - non-blank CHECKs on instance/rule/action_key reject ''/whitespace by constraint name;
+ *   - the same-transaction guarantee: claim + "record write" in one txn → ROLLBACK removes the claim.
+ *
+ * Two-point wired (plugin-tests.yml + vitest.config.ts exclude) so it cannot skip-green.
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const RUN = randomUUID()
+const INST = `apr_${RUN}`
+
+const claim = (over: Partial<Record<'id'|'instance'|'rule'|'action'|'node'|'mode', string>> & { epoch?: number } = {}) =>
+  q(
+    `INSERT INTO meta_automation_action_applied (id, instance_id, rule_id, action_key, node_key, entry_epoch, application_mode, result_ref)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,'rec_id_only')`,
+    [
+      over.id ?? `aa_${randomUUID()}`,
+      over.instance ?? INST,
+      over.rule ?? `rule_${RUN}_1`,
+      over.action ?? `ak_${RUN}_1`,
+      over.node ?? '',
+      over.epoch ?? 0,
+      over.mode ?? 'apply',
+    ],
+  )
+
+describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', () => {
+  afterAll(async () => {
+    await q('DELETE FROM meta_automation_action_applied WHERE instance_id = $1', [INST]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('duplicate apply of the SAME (instance, rule, action) collides on the named UNIQUE index', async () => {
+    await claim()
+    await expect(claim()).rejects.toThrow(/uq_action_applied_business_claim/)
+  })
+
+  test('a SECOND rule and a SECOND action on the same instance are NOT blocked (no bare-instance UNIQUE)', async () => {
+    await expect(claim({ rule: `rule_${RUN}_2` })).resolves.toBeTruthy()
+    await expect(claim({ action: `ak_${RUN}_2` })).resolves.toBeTruthy()
+  })
+
+  test('FWB-3 node scoping: same action re-entered with a NEW entry_epoch claims independently', async () => {
+    await claim({ action: `ak_${RUN}_n`, node: 'node_A', epoch: 1 })
+    await expect(claim({ action: `ak_${RUN}_n`, node: 'node_A', epoch: 1 })).rejects.toThrow(/uq_action_applied_business_claim/)
+    await expect(claim({ action: `ak_${RUN}_n`, node: 'node_A', epoch: 2 })).resolves.toBeTruthy() // 退回→新 epoch
+  })
+
+  test('test_run isolation: a test_run claim does not block (or get blocked by) a real apply', async () => {
+    await claim({ action: `ak_${RUN}_t`, mode: 'test_run' })
+    await expect(claim({ action: `ak_${RUN}_t`, mode: 'apply' })).resolves.toBeTruthy()
+    await expect(claim({ action: `ak_${RUN}_t`, mode: 'test_run' })).rejects.toThrow(/uq_action_applied_business_claim/)
+    await expect(claim({ action: `ak_${RUN}_bogusmode`, mode: 'bogus' })).rejects.toThrow(/action_applied_mode_valid/)
+  })
+
+  test('non-blank CHECKs reject blank identity parts by constraint name', async () => {
+    await expect(claim({ action: '  ' })).rejects.toThrow(/action_applied_action_key_nonblank/)
+    await expect(claim({ instance: '' })).rejects.toThrow(/action_applied_instance_nonblank/)
+    await expect(claim({ rule: '\t' })).rejects.toThrow(/action_applied_rule_nonblank/)
+  })
+
+  test('same-transaction guarantee: claim inside a rolled-back txn leaves NO ledger row', async () => {
+    const raw = poolManager.get().getInternalPool()
+    const c = await raw.connect()
+    const action = `ak_${RUN}_txn`
+    try {
+      await c.query('BEGIN')
+      await c.query(
+        `INSERT INTO meta_automation_action_applied (id, instance_id, rule_id, action_key) VALUES ($1,$2,$3,$4)`,
+        [`aa_${randomUUID()}`, INST, `rule_${RUN}_txn`, action],
+      )
+      await c.query('ROLLBACK') // the record write failed → claim must vanish with it
+    } finally {
+      c.release()
+    }
+    const { rows } = await q('SELECT count(*)::int AS c FROM meta_automation_action_applied WHERE action_key=$1', [action])
+    expect(Number(rows[0].c)).toBe(0)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-action-applied-ledger-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-action-applied-ledger-realdb.test.ts
@@ -24,11 +24,30 @@ import {
   classifyOutboundOutcome,
   deriveActionKey,
   deriveOutboundIdempotencyKey,
+  type TransactionalQueryable,
 } from '../../src/multitable/automation-action-idempotency'
-import type { Queryable } from '../../src/multitable/automation-durable-dispatcher'
+import type { PoolClient } from 'pg'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+/** Wrap a checked-out client (after BEGIN) as a branded transaction handle for the claim helper. */
+const txn = (client: PoolClient): TransactionalQueryable => ({ isTransaction: true, query: (sql, params) => client.query(sql, params) })
+/** Run fn inside a real committed transaction on its own client (ROLLBACK on error). */
+async function inTxn<T>(fn: (trx: TransactionalQueryable, client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await poolManager.get().getInternalPool().connect()
+  try {
+    await client.query('BEGIN')
+    const r = await fn(txn(client), client)
+    await client.query('COMMIT')
+    return r
+  } catch (e) {
+    await client.query('ROLLBACK').catch(() => {})
+    throw e
+  } finally {
+    client.release()
+  }
+}
 const RUN = randomUUID()
 const INST = `apr_${RUN}`
 
@@ -86,12 +105,13 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
 
   test('claimActionApplied validates the (node_key, entry_epoch) PAIR at the JS layer, before the write', async () => {
     const base = { instanceId: INST, ruleId: `rule_${RUN}_pjs`, actionKey: `ak_${RUN}_pjs` }
-    // valid: sentinel and a real node scope both claim
-    expect(await claimActionApplied(poolManager.get(), { ...base, id: `aa_${randomUUID()}` })).toBe('claimed')
+    // valid: sentinel and a real node scope both claim (inside real transactions — the probe requires it)
+    expect(await inTxn((t) => claimActionApplied(t, { ...base, id: `aa_${randomUUID()}` }))).toBe('claimed')
     expect(
-      await claimActionApplied(poolManager.get(), { ...base, actionKey: `ak_${RUN}_pjs2`, nodeKey: 'node_X', entryEpoch: 1, id: `aa_${randomUUID()}` }),
+      await inTxn((t) => claimActionApplied(t, { ...base, actionKey: `ak_${RUN}_pjs2`, nodeKey: 'node_X', entryEpoch: 1, id: `aa_${randomUUID()}` })),
     ).toBe('claimed')
-    // mixed pairs (incl. whitespace/tab node with a positive epoch) throw at the JS layer — nothing is written
+    // mixed pairs (incl. whitespace/tab node with a positive epoch) throw at the JS layer BEFORE the txn probe
+    // and before any SQL — a pool handle proves nothing is even queried.
     for (const bad of [
       { nodeKey: '', entryEpoch: 5 },
       { nodeKey: 'node_Y', entryEpoch: 0 },
@@ -99,7 +119,7 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
       { nodeKey: '\t', entryEpoch: 1 },
     ]) {
       await expect(
-        claimActionApplied(poolManager.get(), { ...base, actionKey: `ak_${RUN}_pjs_bad`, ...bad, id: `aa_${randomUUID()}` }),
+        claimActionApplied(poolManager.get() as unknown as TransactionalQueryable, { ...base, actionKey: `ak_${RUN}_pjs_bad`, ...bad, id: `aa_${randomUUID()}` }),
       ).rejects.toThrow(/must be the.*sentinel/)
     }
   })
@@ -117,21 +137,45 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
     await expect(claim({ rule: '\t' })).rejects.toThrow(/fwb_action_applied_rule_nonblank/)
   })
 
-  test('same-transaction guarantee: the REAL claimActionApplied inside a rolled-back txn leaves NO ledger row', async () => {
+  test('same-transaction guarantee: a failed business write rolls the claim back too — the retry CLAIMS again (never a permanent skip)', async () => {
     const raw = poolManager.get().getInternalPool()
     const c = await raw.connect()
     const action = `ak_${RUN}_txn`
     // exercise the REAL helper on the checked-out connection (not a hand-written INSERT) so the test proves
     // claimActionApplied's own write is bound to the caller's txn (#4340 review P3).
-    const trx: Queryable = { query: (sql, params) => c.query(sql, params) }
     try {
       await c.query('BEGIN')
-      const r = await claimActionApplied(trx, { id: `aa_${randomUUID()}`, instanceId: INST, ruleId: `rule_${RUN}_txn`, actionKey: action })
+      const r = await claimActionApplied(txn(c), { id: `aa_${randomUUID()}`, instanceId: INST, ruleId: `rule_${RUN}_txn`, actionKey: action })
       expect(r).toBe('claimed') // the real helper claimed inside the txn...
       await c.query('ROLLBACK') // ...but the record write failed → the claim must vanish with it
     } finally {
       c.release()
     }
+    const { rows } = await q('SELECT count(*)::int AS c FROM meta_fwb_action_applied WHERE action_key=$1', [action])
+    expect(Number(rows[0].c)).toBe(0)
+    // the owner's P1 scenario disproven: the RETRY claims again — it is NOT a permanent 'duplicate' skip
+    // (a pool-committed orphan claim would have made this 'duplicate' and silently dropped the write forever).
+    expect(await inTxn((t) => claimActionApplied(t, { id: `aa_${randomUUID()}`, instanceId: INST, ruleId: `rule_${RUN}_txn`, actionKey: action }))).toBe(
+      'claimed',
+    )
+  })
+
+  test('P1: a pool / forged marker / bare autocommit client is REJECTED by the xid probe (the claim can never auto-commit apart from the business write)', async () => {
+    const action = `ak_${RUN}_poolneg`
+    const c1 = { id: `aa_${randomUUID()}`, instanceId: INST, ruleId: `rule_${RUN}_pn`, actionKey: action }
+    // 1) the Pool itself, cast past the compile-time brand
+    await expect(claimActionApplied(poolManager.get() as unknown as TransactionalQueryable, c1)).rejects.toThrow(/real database TRANSACTION/)
+    // 2) a FORGED isTransaction marker wrapping the pool — the probe asks Postgres, not the caller
+    const forged: TransactionalQueryable = { isTransaction: true, query: (sql, params) => poolManager.get().query(sql, params) }
+    await expect(claimActionApplied(forged, { ...c1, id: `aa_${randomUUID()}` })).rejects.toThrow(/real database TRANSACTION/)
+    // 3) a bare client WITHOUT BEGIN (autocommit): each statement its own implicit txn — rejected
+    const bare = await poolManager.get().getInternalPool().connect()
+    try {
+      await expect(claimActionApplied(txn(bare), { ...c1, id: `aa_${randomUUID()}` })).rejects.toThrow(/real database TRANSACTION/)
+    } finally {
+      bare.release()
+    }
+    // nothing was written by any of the rejected attempts
     const { rows } = await q('SELECT count(*)::int AS c FROM meta_fwb_action_applied WHERE action_key=$1', [action])
     expect(Number(rows[0].c)).toBe(0)
   })
@@ -156,23 +200,18 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
   test('L2 claimActionApplied: first=claimed, repeat=duplicate; CONCURRENT double-claim → exactly one claimed', async () => {
     const key = deriveActionKey({ structuralPath: 's[0]', actionType: 'create_record', canonicalConfig: { t: RUN } })
     const base = { instanceId: INST, ruleId: `rule_${RUN}_l2`, actionKey: key }
-    expect(await claimActionApplied(poolManager.get(), { ...base, id: `aa_${randomUUID()}` })).toBe('claimed')
-    expect(await claimActionApplied(poolManager.get(), { ...base, id: `aa_${randomUUID()}` })).toBe('duplicate')
-    // constructed race on a FRESH key: two connections claim simultaneously
+    expect(await inTxn((t) => claimActionApplied(t, { ...base, id: `aa_${randomUUID()}` }))).toBe('claimed')
+    expect(await inTxn((t) => claimActionApplied(t, { ...base, id: `aa_${randomUUID()}` }))).toBe('duplicate')
+    // constructed race on a FRESH key: two CONCURRENT TRANSACTIONS claim simultaneously — the loser blocks on
+    // the winner's speculative-insert lock until it commits, then resolves 'duplicate' (each txn commits
+    // inside its own promise, so the race is between two full transactions with no orchestration deadlock).
     const key2 = deriveActionKey({ structuralPath: 's[1]', actionType: 'create_record', canonicalConfig: { t: RUN } })
-    const raw = poolManager.get().getInternalPool()
-    const [ca, cb] = await Promise.all([raw.connect(), raw.connect()])
-    try {
-      const [ra, rb] = await Promise.all([
-        claimActionApplied(ca, { ...base, actionKey: key2, id: `aa_${randomUUID()}` }),
-        claimActionApplied(cb, { ...base, actionKey: key2, id: `aa_${randomUUID()}` }),
-      ])
-      expect([ra, rb].filter((r) => r === 'claimed')).toHaveLength(1) // net-once under the race
-      expect([ra, rb].filter((r) => r === 'duplicate')).toHaveLength(1)
-    } finally {
-      ca.release()
-      cb.release()
-    }
+    const [ra, rb] = await Promise.all([
+      inTxn((t) => claimActionApplied(t, { ...base, actionKey: key2, id: `aa_${randomUUID()}` })),
+      inTxn((t) => claimActionApplied(t, { ...base, actionKey: key2, id: `aa_${randomUUID()}` })),
+    ])
+    expect([ra, rb].filter((r) => r === 'claimed')).toHaveLength(1) // net-once under the race
+    expect([ra, rb].filter((r) => r === 'duplicate')).toHaveLength(1)
   })
 
   test('L2 Class-B: outbound key = stable event+action identity; ambiguity w/o endpoint idempotency = outcome_unknown', () => {
@@ -186,31 +225,54 @@ describeIfDatabase('action-idempotency ledger L1 — schema golden (real DB)', (
     expect(classifyOutboundOutcome('ambiguous', false)).toBe('outcome_unknown') // recorded, NEVER auto-resent
   })
 
-  // [#4340 review P1] Table-name coexistence: this FWB ledger lives on `meta_fwb_action_applied` and must NOT
-  // squat `meta_automation_action_applied`, which #4196 §2.2 reserves for the EXECUTION-SCOPED retry ledger
-  // (a DIFFERENT schema with a `kind` column). Prove both tables coexist and #4196's own INSERT works.
-  test('coexists with the #4196 execution-scoped meta_automation_action_applied (kind schema) — no name squat', async () => {
+  // [#4340 review P1+P2] Table-name coexistence: this FWB ledger lives on `meta_fwb_action_applied` and must
+  // NOT squat `meta_automation_action_applied`, which #4196 §2.2 reserves for the EXECUTION-SCOPED retry
+  // ledger (a DIFFERENT schema with a `kind` column). The whole probe runs INSIDE ONE ROLLED-BACK TRANSACTION
+  // (DDL is transactional in Postgres) — the test never DROPs, creates, or pollutes anything persistent, so a
+  // FUTURE real #4196 table is reused untouched instead of being destroyed (#4340 review P2).
+  test('coexists with the #4196 execution-scoped meta_automation_action_applied (kind schema) — no squat, no destructive cleanup', async () => {
     // this suite's migration created ONLY the FWB table under its FWB-specific name
     const fwbExists = await q(`SELECT to_regclass('public.meta_fwb_action_applied') IS NOT NULL AS ok`)
     expect(fwbExists.rows[0].ok).toBe(true)
-    // the #4196 name is FREE — stand up its LOCKED (§2.2) execution-scoped shape and run its exact claim INSERT
-    await q(`CREATE TABLE IF NOT EXISTS meta_automation_action_applied (
-               kind text NOT NULL, root_execution_id text NOT NULL, action_key text NOT NULL,
-               action_type text, applied_at timestamptz NOT NULL DEFAULT now(),
-               UNIQUE (kind, root_execution_id, action_key))`)
+    const preExisting = Boolean((await q(`SELECT to_regclass('public.meta_automation_action_applied') IS NOT NULL AS ok`)).rows[0].ok)
+    const root = `root_${RUN}`
+    const key = deriveActionKey({ structuralPath: 's[coexist]', actionType: 'create_record', canonicalConfig: { t: RUN } })
+    const client = await poolManager.get().getInternalPool().connect()
     try {
-      // #4196 §2's INSERT — would have thrown `column "kind" does not exist` if the FWB table had squatted the name
-      await q(`INSERT INTO meta_automation_action_applied (kind, root_execution_id, action_key)
-               VALUES ('execution', $1, 'ak_exec') ON CONFLICT DO NOTHING`, [`root_${RUN}`])
-      const execRow = await q(`SELECT count(*)::int AS c FROM meta_automation_action_applied WHERE root_execution_id=$1`, [`root_${RUN}`])
+      await client.query('BEGIN')
+      // stand up (or, in a future where the real table exists, REUSE) the #4196 §2.2 execution-scoped shape —
+      // entirely inside this transaction, so ROLLBACK below leaves the database exactly as it was.
+      await client.query(`CREATE TABLE IF NOT EXISTS meta_automation_action_applied (
+                            kind text NOT NULL, root_execution_id text NOT NULL, action_key text NOT NULL,
+                            action_type text, applied_at timestamptz NOT NULL DEFAULT now(),
+                            UNIQUE (kind, root_execution_id, action_key))`)
+      // #4196 §2's INSERT — would have thrown `column "kind" does not exist` if the FWB table squatted the name
+      await client.query(
+        `INSERT INTO meta_automation_action_applied (kind, root_execution_id, action_key)
+         VALUES ('execution', $1, 'ak_exec') ON CONFLICT DO NOTHING`,
+        [root],
+      )
+      const execRow = await client.query(`SELECT count(*)::int AS c FROM meta_automation_action_applied WHERE root_execution_id=$1`, [root])
       expect(Number(execRow.rows[0].c)).toBe(1)
-      // and the FWB ledger claims INTO ITS OWN table, independently
-      const key = deriveActionKey({ structuralPath: 's[coexist]', actionType: 'create_record', canonicalConfig: { t: RUN } })
-      expect(await claimActionApplied(poolManager.get(), { instanceId: INST, ruleId: `rule_${RUN}_cx`, actionKey: key, id: `aa_${randomUUID()}` })).toBe('claimed')
-      const fwbRow = await q(`SELECT count(*)::int AS c FROM meta_fwb_action_applied WHERE instance_id=$1 AND action_key=$2`, [INST, key])
-      expect(Number(fwbRow.rows[0].c)).toBe(1) // the two ledgers are disjoint tables
+      // and the FWB ledger claims INTO ITS OWN table in the SAME transaction — disjoint ledgers, one atomic scope
+      expect(await claimActionApplied(txn(client), { instanceId: INST, ruleId: `rule_${RUN}_cx`, actionKey: key, id: `aa_${randomUUID()}` })).toBe('claimed')
+      const fwbRow = await client.query(`SELECT count(*)::int AS c FROM meta_fwb_action_applied WHERE instance_id=$1 AND action_key=$2`, [INST, key])
+      expect(Number(fwbRow.rows[0].c)).toBe(1)
+      await client.query('ROLLBACK') // discard EVERYTHING the probe did — never a DROP
+    } catch (e) {
+      await client.query('ROLLBACK').catch(() => {})
+      throw e
     } finally {
-      await q(`DROP TABLE IF EXISTS meta_automation_action_applied`).catch(() => {})
+      client.release()
     }
+    // the #4196 name is EXACTLY as it was before the test: absent today; untouched if a real table existed
+    const post = Boolean((await q(`SELECT to_regclass('public.meta_automation_action_applied') IS NOT NULL AS ok`)).rows[0].ok)
+    expect(post).toBe(preExisting)
+    if (post) {
+      const leftover = await q(`SELECT count(*)::int AS c FROM meta_automation_action_applied WHERE root_execution_id=$1`, [root])
+      expect(Number(leftover.rows[0].c)).toBe(0) // a pre-existing real table gained nothing from this test
+    }
+    const fwbLeft = await q('SELECT count(*)::int AS c FROM meta_fwb_action_applied WHERE action_key=$1', [key])
+    expect(Number(fwbLeft.rows[0].c)).toBe(0) // the FWB probe row rolled back too
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -325,6 +325,9 @@ export default defineConfig({
       // only (checks the migration landed both tables, the status CHECK, FK cascade, defaults). Excluded HERE
       // so it cannot skip-green in the no-DB lane, whole-file wired into plugin-tests.yml. Two-point wiring.
       'tests/integration/multitable-automation-outbox-schema-realdb.test.ts',
+      // action-idempotency ledger L1 schema golden — real-DB. Excluded HERE so it cannot skip-green
+      // in the no-DB lane; whole-file wired into plugin-tests.yml. Two-point wiring.
+      'tests/integration/multitable-action-applied-ledger-realdb.test.ts',
       // P2 durable-delivery S2-a claim engine / fence-CAS — real-DB constructed-concurrency (zombie/SKIP
       // LOCKED). Excluded HERE so it cannot skip-green in the no-DB lane; whole-file wired into
       // plugin-tests.yml. Two-point wiring.


### PR DESCRIPTION
**Base: `main`. Additive, flag-neutral** — the FWB action-idempotency ledger (write-path prerequisite); no production callers until the FWB runtime lands behind its own gate. Head `5f81c8a18`.

## What lands
- **Migration `zzzz…_create_fwb_action_applied.ts`** → **`meta_fwb_action_applied`** (renamed off the #4196-reserved name): composite business-claim key via `uq_fwb_action_applied_business_claim`; named non-blank CHECKs; `application_mode ∈ {apply, test_run}`; **paired** `fwb_action_applied_node_epoch_paired` CHECK — the `('',0)` sentinel or a node_key matching `[!-~]` with epoch ≥ 1 (whitespace/tab rejected).
- **`automation-action-idempotency.ts`**: `deriveActionKey` / `deriveOutboundIdempotencyKey` (injective JSON-array encoding), `claimActionApplied` (Class-A same-txn claim + JS pair guard + **transaction probe**), `classifyOutboundOutcome` (`outcome_unknown` never auto-resent). Shared **`pg-transaction-guard.ts`** (byte-identical with #4336).

## Review fixes (rounds 1–3)
- **P2 injective encoding**; **P2 node/epoch pairing** (incl. whitespace/tab via `[!-~]` + JS-layer guard); **P1 table rename** off `meta_automation_action_applied` (#4196 §2.2's execution-scoped ledger) + coexistence golden; **P3** real-helper rollback test + body refresh.
- **P1 round-2 (pool acceptance)**: `claimActionApplied` accepted a pool → the claim auto-committed apart from the business write → a failed write left an orphaned claim and every retry returned `'duplicate'` (permanent skip). Now the **xid probe** rejects a pool / forged marker / bare autocommit client **before the claim** (three negatives, zero rows); the rollback test proves the retry **claims again** after a failed write. Also hard-stops the `withTransaction` non-transactional-fallback hazard.
- **P2 round-2 (destructive coexistence test)**: the probe now runs **inside one rolled-back transaction** (transactional DDL) — never DROPs; a pre-existing real #4196 table is reused untouched. Verified against the exact repro: pre-created real table + sentinel row → spec passes AND `to_regclass` non-NULL, row intact.

## Verification (fresh Postgres 15)
- **14/14** real-DB (incl. concurrent double-claim as two full transactions; P1 negatives; retry-after-rollback; non-destructive coexistence). `tsc --noEmit` 0.
- Probe, paired CHECK, JS pair guard, injective encoding all **mutation-proven**. Two-point CI wired.

**For review — not self-merging runtime.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)