### PR TITLE
docs(canonical-org): progress ledger + plan status correction + T2.5 decision branch

### DIFF
--- a/docs/development/canonical-org-mvp-progress-ledger-20260716.md
+++ b/docs/development/canonical-org-mvp-progress-ledger-20260716.md
@@ -1,0 +1,46 @@
+# Canonical Org MVP · 实施进度台账（2026-07-16）
+
+> Owner 指令产物：修正实施计划（`canonical-org-provider-transfer-v1-mvp-implementation-plan-20260713.md`）
+> 的状态失真——该计划原写 "Not started"，而 B1/B2/B3 已真实落地。本台账记录**真实 PR、merge SHA、
+> 遗留限制**；后续每落一步就地更新本文件，计划文件本身不再承载滚动状态。
+
+## 1. 已落地（真实 merge SHA）
+
+| 步 | PR | Merge SHA | 内容 | Owner 复审轮数 |
+|---|---|---|---|---|
+| **B1** | #4304 | `849f1d53d` | local provider bootstrap：get-or-create（普通 INSERT + 捕 23505 `isUniqueViolation` + re-select winner）；`one_active_local_integration_per_org` partial unique index；`local_integration_corp_id_shape` CHECK；创建审计 | 2（并发唯一性构造证明；CHECK 语义精确措辞）|
+| **B2** | #4317 | `bf52b9513` | 部门/账号/成员关系 CRUD + 8 条 admin 路由（`/api/admin/directory/local`）；fail-closed 字段白名单 + 严格类型校验（int4 有界；错误类型→400 且原值不变）；archive-not-delete；显式 primary 切换 | 2（类型强校验轮）|
+| **B3** | #4318 | `65dec7b36` | `is_manager` 一等主管关系（迁移 `zzzz20260715100000`）；双源 resolver precedence（`a.integration_id`+`d.integration_id` 双侧、DingTalk legacy 路径逐字不变）；membership PATCH 单请求单操作（isPrimary XOR isManager）+ `directory.local_membership.set_manager` 审计；writer 11 谓词守卫（org/integration 双侧/provider 三处/status='active'/account/department）| 3（可达性；双侧边界；三谓词轮）|
+
+## 2. 遗留限制（诚实清单，按归属批次）
+
+### pre-B4 hardening 小批次（不阻塞 B4 启动，**阻塞 Canonical Org MVP DONE**）
+- 非 UUID `membershipId` 进 `::uuid` cast → 500（应 400/404；B2/B3 同形）。
+- archive 不冻结后续写入（向已归档部门加成员、归档账号切 primary 均 200）。
+- 间接部门环可达（A→B→A；实测递归 CTE 无害终止，仍应规范化）。
+- B1 停用后同名重建撞 `UNIQUE(org_id, provider, name)`（B1 不宣称停用后自动重建）。
+- primary-switch 存在性检查移入事务并合成单 UPDATE（owner 判 P3 加固，非阻塞）。
+
+### routing 加固批（B5/B6 期间处理）
+- resolver **读侧**不过滤 integration `status`：active 期间设置的 `is_manager` 在 integration
+  停用后仍参与解析（写侧门已在 B3 关闭；读侧为既有设计属性，B3 未宣称覆盖）。
+- 主管**链**（chain hop）与**部门负责人**（dept head）仍走 legacy 源（B3 只泛化 direct-manager 步）。
+
+## 3. 未开发（顺序 owner 已裁：串行）
+
+- **B4** department binding 表（双侧 composite FK、provider-role 约束）→ **B5** 显式 `(org, purpose)`
+  routing policy + 只读切换预览 → **B6** local/DingTalk 审批路由真库等价证明（首个真实消费者）→
+  **B7** 外部部门 suggest-only 对账（消失只标 `stale`，不得停用本地部门）。B5/B6 同碰 routing core，
+  **不并行**。
+- Canonical Org **单独收官门**：真库 done-gate、迁移 replay、mutation 表、真实 merge SHA 全入库后，
+  才解锁 Transfer。
+- **Transfer**：T1 → T2 → T2-Gate → **条件式 T2.5** → T3 → T4 → T5。**T2.5 为显式决策分支**（owner
+  裁定）：两 corp 实证若确认 `(provider, external_key)` 冲突，必须先落 tenant-scoped key migration
+  （`(provider, tenant_key, external_key)`），**不得直接进入 T3**。
+- 排除项（本轮不做）：Feishu/WeCom driver、全消费者迁移、per-org quiet-hours、共享限流。
+
+## 4. 并行的 owner/ops 线（生产发布前必须闭合，与 B4-B7 并行）
+
+- DingTalk Hardening v1 运行态：OAuth live monitor 已闭环（连续三次 scheduled success），但
+  **真实 UAT evidence pack 仍为空模板、开关台账负责人仍全 `_TBD_`**——模拟验收不能替代
+  U1–U13 与真实 callback corp-anchor。

--- a/docs/development/canonical-org-provider-transfer-v1-mvp-implementation-plan-20260713.md
+++ b/docs/development/canonical-org-provider-transfer-v1-mvp-implementation-plan-20260713.md
@@ -4,8 +4,9 @@ Date: 2026-07-13
 Milestone: **Canonical Org & Provider Transfer v1** (the SECOND milestone — distinct from DingTalk
 Sync Hardening v1, which is a runtime-closeout milestone tracked by the DT-CLOSE tickets).
 Baseline: `origin/main` (post-#4215 / #3944).
-Status: **implementation-sequencing plan. Not started. Starts only after Hardening v1 is closed
-(DT-CLOSE-01…05 done + owner go).**
+Status: **IN PROGRESS** (owner go given 2026-07-15). B1 merged `849f1d53d` (#4304), B2 merged
+`bf52b9513` (#4317), B3 merged `65dec7b36` (#4318). Rolling status lives in
+`canonical-org-mvp-progress-ledger-20260716.md` — this file stays the sequencing/design reference.
 
 This plan does NOT re-design anything — the design is already ratified-by-merge:
 
@@ -18,9 +19,11 @@ lands incrementally (approval-routing parity first) instead of as a big-bang mig
 
 ## 0. Two non-negotiable ordering constraints
 
-1. **Hardening v1 must close first.** The org line depends on a healthy, observable directory sync
-   (DT-CLOSE-01 restored that) and on the switch ledger (DT-CLOSE-04) being resolved — don't start
-   org-substrate impl on an unclosed hardening milestone.
+1. **Hardening v1 dev-side runtime-closeout + owner go unlocks DEVELOPMENT** (owner ruling
+   2026-07-15/16, supersedes the original "must close first" wording): B1-B3 started on that go.
+   The still-open owner/ops items — real UAT (U1-U13 + callback corp-anchor), switch-ledger owners,
+   switch rulings — run in PARALLEL with B4-B7 and block **Canonical Org production release /
+   MVP DONE**, not development.
 2. **Canonical Org MVP before Transfer MVP.** The transfer engine (Wave 4) rebinds provider handles
    *under* a stable local anchor; that anchor (the `provider='local'` substrate) must exist and have
    at least one real consumer (approval routing) proven at real-DB parity before any transfer code.
@@ -37,7 +40,7 @@ departments only produce reconciliation *suggestions*, and when they disappear o
 | --- | --- | --- | --- | --- |
 | **B1** | **Local provider bootstrap** — get-or-create one `provider='local'` integration per org; `corp_id = local:<org_id>` (immutable); the **at-most-one-active-local** partial unique index; no external creds, no scheduler | §5.1 | DB has exactly-cap-one enforced; two concurrent bootstraps can't both create; audit event on create | migration + service — Sonnet, Opus gate |
 | **B2** | **Local departments + accounts + memberships** — CRUD on `directory_departments`/`directory_accounts`/`directory_account_departments` under the local integration; archive-not-delete; explicit primary department | §5.2–5.4 | membership idempotency; archive keeps history; NO manager in `raw` | Sonnet |
-| **B3** | **Normalized manager relation** — the owner-ruled first-class `is_manager`/head relation (NOT `raw.leader_in_dept`); `ApprovalDirectoryOrg` reads it | §5.4 | approval routing resolves manager from the normalized relation; a real-DB test proves it | **Opus** (routing-core) |
+| **B3** | **Normalized direct-manager relation** — the owner-ruled first-class `is_manager` relation (NOT `raw.leader_in_dept`); `ApprovalDirectoryOrg`'s direct-manager step reads it. Manager CHAIN and department-HEAD stay on their legacy sources — explicitly left to B5/B6 | §5.4 | approval routing resolves manager from the normalized relation; a real-DB test proves it | **Opus** (routing-core) |
 | **B4** | **Department binding table** — `directory_department_bindings` with the **buildable FK chain** (binding carries both integration ids; `(dept,integration)`→`departments(id,integration)` + `(integration,org)`→`integrations(id,org)`, both sides; provider-role via trigger/redundant FK) | §5.5 | a cross-org binding is **impossible to insert** (FK rejects); real-DB test | **Opus** (data-integrity) |
 | **B5** | **`(org, purpose)` routing policy + read-only preview** — stored policy; resolver picks canonical integration per purpose fail-closed; **preview shows before/after impacted approval/permission/attendance surfaces before any switch** | §6 | resolver never "array[0]"; fail-closed on unset; preview is read-only | **Opus** (governance) |
 | **B6** | **Approval-routing local/DingTalk real-DB equivalence** (the FIRST consumer, not all) | §10.1 | seeded equivalent data → `provider='local'` produces the SAME requester dept/title/manager outputs as DingTalk; in-flight approvals keep baked routing; new ones follow the selected policy | **Opus** (parity proof) |
@@ -57,7 +60,8 @@ guard already forbids it). Feishu/WeCom drivers deferred until a named customer 
 | --- | --- | --- | --- | --- |
 | **T1** | **Schema + API skeleton** — `provider_org_transfers` + `provider_org_transfer_decisions` migrations; admin-only create/read/scan/dry-run/apply/cancel; **no-op adapter** + contract tests | §7, §6.3 | new tables + admin API; no real writes yet; audit on lifecycle | Sonnet, **Opus** gate |
 | **T2** | **Source freeze** — freeze the source integration's sync while a transfer is active (the §12.2 deferral this unblocks) | §12.2 | an active transfer blocks the destructive absence sweep; real-DB test | **Opus** (sync-core) |
-| **T2-Gate** | **Two-corp coexistence proof** — stage two DingTalk corps, one overlapping person; prove whether `directory_accounts(provider, external_key)` collides (unionId is union-scoped ⇒ expected to collide ⇒ tenant-scoped key `(provider, tenant_key, external_key)` almost certainly required) | §3.4 | **owner/ops + staging** — sandbox cannot create real corps; DB-level collision mechanism can be shown, the production proof cannot | — (gated) |
+| **T2-Gate** | **Two-corp coexistence proof** — stage two DingTalk corps, one overlapping person; prove whether `directory_accounts(provider, external_key)` collides (NOT yet proven either way — the source audit's conclusion is that only a staging two-corp proof can decide; the T2.5 row below carries the conditional consequence) | §3.4 | **owner/ops + staging** — sandbox cannot create real corps; DB-level collision mechanism can be shown, the production proof cannot | — (gated) |
+| **T2.5** | **Conditional — tenant-scoped key migration** (owner ruling 2026-07-16, explicit decision branch): if T2-Gate CONFIRMS the `(provider, external_key)` collision, a tenant-scoped key migration to `(provider, tenant_key, external_key)` MUST land BEFORE any T3 work — T3 may not start directly off a confirmed collision. If T2-Gate disproves the collision, T2.5 is skipped and T3 proceeds. | §3.4 | migration + backfill + uniqueness proof on staging data | **Opus** (identity-key) |
 | **T3** | **Single-transaction user rebind** — clear source link WITHOUT deleting the identity, upsert the one `user_external_identities` row in place source→target, enable grant, link target — NOT public unbind+bind | §9.3 | real-DB atomic-rewrite mutation test; a target identity row exists after rebind (no next-login wait) | **Opus** (identity-core) |
 | **T4** | **Group-destination rebind/drop** — rebind webhook+secret keeping `destinationId` stable; drop = disable | §10 | automation rule keeps `destinationId`; drop disables without touching the form | Sonnet |
 | **T5** | **Admin workbench** — transfer list/detail, source/target selector, decision worklist, dry-run, apply progress | §13 | UI over the backend; dry-run required before apply | Sonnet + FE |
@@ -83,5 +87,5 @@ direct `corp_id` edit; the two-corp key strategy is proven in staging; identity 
 ## 5. How this runs (the goal loop, repeatable)
 
 Each increment: recon → parallel model-by-difficulty lanes → adversarial Opus gate (refute-first,
-load-bearing mutation) → land behind a done-gate → update this plan's status. Nothing lands without a
+load-bearing mutation) → land behind a done-gate → update the rolling ledger (`canonical-org-mvp-progress-ledger-20260716.md`). Nothing lands without a
 gate; nothing is claimed verified without a real-DB proof; the two milestones stay named separately.


### PR DESCRIPTION
Docs-only, per owner's round-4 findings on #4318's review:

- **New rolling ledger** `canonical-org-mvp-progress-ledger-20260716.md`: real merge SHAs (B1 `849f1d53d` / B2 `bf52b9513` / B3 `65dec7b36`), honest leftover-limitation lists split by owning batch (pre-B4 hardening batch — blocks Canonical Org MVP DONE, not B4 start; routing-hardening items for B5/B6), the serial B4→B7 order, Transfer T1→T5 with the conditional T2.5, and the parallel owner/ops track (UAT evidence pack still empty template; switch ledger owners still \_TBD\_ — simulated acceptance does not substitute).
- **Plan Status line corrected** (was 'Not started' — stale): now IN PROGRESS with the three merge SHAs, pointing rolling status at the ledger so the plan file stops rotting.
- **T2.5 explicit decision branch added to the plan** (owner ruling): if T2-Gate confirms the `(provider, external_key)` collision, the tenant-scoped key migration MUST land before any T3 work — no direct entry into T3 off a confirmed collision.

Landing discipline: unarmed — awaiting owner verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)