### PR TITLE
fix(ops): corrective-3 — acceptance smoke capture stdout-only (2>$null), not stderr-merged

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -123,8 +123,8 @@ jobs:
       - name: Global History flag manifest contract (R12-C)
         run: node --test scripts/ops/global-history-flag-manifest.test.mjs scripts/ops/multitable-global-history-flag-status.test.mjs
 
-      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (49
-      # checks = 17 contract + 32 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
+      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (53
+      # checks = 17 contract + 36 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
       # pm2/health/smoke stages are unit-tested via dot-sourced pure helpers). Run inside the REQUIRED
       # `test` gate, but only ONCE (on 20.x — no need across the 18/20 matrix), early (no pnpm install
       # needed: pwsh/tar ship on ubuntu, node is already set up) so a regression fails the required check

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -226,6 +226,34 @@ try {
   $o = Test-SmokeOutcome "mvpSmoke.pass=true`nauditActionsCovered=8/8"
   Check "smoke: selfScanClean ABSENT -> FAIL (fail-closed)" ((-not $o.ok) -and $o.reason -eq 'self_scan_not_clean')
 
+  # ── D5 (corrective-3): the stage-6 smoke capture is stdout-ONLY (2>$null), never merged (2>&1). A child
+  # that writes noise to stderr AND a valid values-free summary to stdout must NOT abort the capture (the
+  # RC-0 POWERSHELL_NATIVE_STDERR_PROMOTION failure — where 2>&1 promoted native stderr to a terminating
+  # error and the smoke's summary was never read), must NOT let the stderr text contaminate the parsed
+  # summary, and must still parse PASS. Mutation guard: flip 2>$null back to 2>&1 in Invoke-SmokeCapture and
+  # the "sentinel is NOT captured" check reds (version-independent: 2>&1 merges stderr into the captured text).
+  $fakeSmoke = Join-Path ([System.IO.Path]::GetTempPath()) ("t9accept_fakesmoke_" + [guid]::NewGuid().ToString('N').Substring(0, 12) + '.mjs')
+  $sentinel = 'STDERR-LEAK-SENTINEL-7788'
+  $fakeLines = @(
+    "process.stderr.write('$sentinel\n')",
+    "process.stderr.write('(node:1) ExperimentalWarning: stderr noise the runner must not capture\n')",
+    "process.stdout.write('mvpSmoke.pass=true\n')",
+    "process.stdout.write('auditActionsCovered=8/8\n')",
+    "process.stdout.write('selfScanClean=true\n')",
+    "process.exit(0)"
+  )
+  Set-Content -LiteralPath $fakeSmoke -Encoding utf8 -Value ($fakeLines -join "`n")
+  $dummyToken = ConvertTo-SecureString 'dummy-not-a-real-token' -AsPlainText -Force
+  $smokeThrew = $false
+  $cap = $null
+  try { $cap = Invoke-SmokeCapture -NodeArgs @($fakeSmoke) -Token $dummyToken } catch { $smokeThrew = $true }
+  Check "corrective-3: a stderr-writing child does NOT abort the capture (no native stderr promotion)" ((-not $smokeThrew) -and $null -ne $cap)
+  Check "corrective-3: the stderr sentinel is NOT captured into the parsed summary (2>`$null, not 2>&1)" ($null -ne $cap -and -not ("$($cap.stdout)" -match [regex]::Escape($sentinel)))
+  $capOutcome = Test-SmokeOutcome "$($cap.stdout)"
+  Check "corrective-3: the stdout values-free summary still parses to PASS (8/8, clean)" ($capOutcome.ok -and $capOutcome.pass -and $capOutcome.audit -eq '8/8' -and $capOutcome.selfScan)
+  Check "corrective-3: exit code preserved (0) and the token env var is cleared after capture" ($null -ne $cap -and $cap.exit -eq 0 -and -not (Test-Path Env:METASHEET_AUTH_TOKEN))
+  Remove-Item -LiteralPath $fakeSmoke -Force -ErrorAction SilentlyContinue
+
   $base = [pscustomobject]@{ state = 'online'; restartTime = 3; uptime = 1000 }
 
   # Entity corrective-1 reproduction: PM2 includes process.env in jlist; on Windows it commonly carries

--- a/scripts/ops/stock-preparation-onprem-acceptance.ps1
+++ b/scripts/ops/stock-preparation-onprem-acceptance.ps1
@@ -367,34 +367,47 @@ function Invoke-HealthStage {
   Write-Stage 'stage 5: PASS'
 }
 
+# ── Summary-only smoke capture (pure, unit-testable). Runs the child smoke and returns ONLY its stdout
+# summary text + exit code. stderr is redirected to $null (2>$null), NEVER merged into the success stream
+# (2>&1). Two reasons: (1) Node warnings / any stderr noise must never contaminate the parsed values-free
+# summary; (2) under PowerShell 7.3+ native-command error handling, a child that writes to stderr while
+# its stream is merged (2>&1) can be PROMOTED to a terminating error that ABORTS the capture before the
+# smoke's summary is ever read — the RC-0 acceptance-runner compatibility failure the entity machine hit
+# (POWERSHELL_NATIVE_STDERR_PROMOTION): the smoke ran, but the runner threw instead of parsing its output.
+# The admin token crosses to the child ONLY as a scoped env var, cleared (with its BSTR) in a finally.
+function Invoke-SmokeCapture {
+  param([string[]]$NodeArgs, [SecureString]$Token)
+  $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Token)
+  try {
+    # Token crosses to the child ONLY as a scoped env var — never on the command line / ArgumentList.
+    $env:METASHEET_AUTH_TOKEN = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+    $out = & node @NodeArgs 2>$null  # stdout ONLY; stderr discarded (see function header)
+    $exit = $LASTEXITCODE
+  } finally {
+    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+    Remove-Item Env:METASHEET_AUTH_TOKEN -ErrorAction SilentlyContinue
+  }
+  return @{ stdout = ($out | Out-String); exit = $exit }
+}
+
 # ── Stage 6: in-package stock-preparation smoke (token via scoped env, cleared in finally) ───────
 function Invoke-SmokeStage {
   param([SecureString]$Token)
   Write-Stage 'stage 6: stock-preparation smoke'
   $smoke = Join-Path $DeployRoot 'scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs'
   if (-not (Test-Path $smoke)) { Stop-WithFailure 'smoke' @{ reason = 'smoke_script_missing' } }
-  $args = @($smoke, '--base-url', "http://localhost:$Port")
-  if ($TenantId) { $args += @('--tenant-id', $TenantId) }
-  $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Token)
-  try {
-    # Token crosses to the child ONLY as a scoped env var — never on the command line / ArgumentList.
-    $env:METASHEET_AUTH_TOKEN = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
-    $out = & node @args 2>&1
-    $exit = $LASTEXITCODE
-  } finally {
-    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
-    Remove-Item Env:METASHEET_AUTH_TOKEN -ErrorAction SilentlyContinue
-  }
-  # Parse ONLY the values-free summary fields the smoke prints; never echo the raw $out.
-  $joined = ($out | Out-String)
-  $outcome = Test-SmokeOutcome $joined
+  $nodeArgs = @($smoke, '--base-url', "http://localhost:$Port")
+  if ($TenantId) { $nodeArgs += @('--tenant-id', $TenantId) }
+  # Summary-only capture: stdout is parsed for the values-free fields; stderr is discarded (never echoed).
+  $captured = Invoke-SmokeCapture -NodeArgs $nodeArgs -Token $Token
+  $outcome = Test-SmokeOutcome $captured.stdout
   $Summary['mvpSmoke.pass'] = if ($outcome.pass) { 'true' } else { 'false' }
   $Summary.auditActionsCovered = $outcome.audit
   $Summary.selfScanClean = if ($outcome.selfScan) { 'true' } else { 'false' }
   # Fail-closed: a green exit is NOT a steady state unless the audit surface is fully covered (8/8) and
   # the self-scan is clean. An absent/unparseable field records 'N/8'/'false' and FAILS here — it never
   # passes silently (owner P2).
-  if ($exit -ne 0) { Stop-WithFailure 'smoke' @{ smokeExit = $exit } }
+  if ($captured.exit -ne 0) { Stop-WithFailure 'smoke' @{ smokeExit = $captured.exit } }
   if (-not $outcome.ok) { Stop-WithFailure 'smoke' @{ reason = $outcome.reason } }
   Write-Stage 'stage 6: PASS'
 }


### PR DESCRIPTION
## corrective-3 — acceptance-runner smoke capture is stdout-only, not stderr-merged

**Refs #4101** (on-prem acceptance tracker). This PR must NOT change that tracker's status — it stays OPEN until the corrective-3 entity-machine run PASSes.

### What the entity machine actually hit
The RC-0 run reported `POWERSHELL_NATIVE_STDERR_PROMOTION`. Root cause: stage-6's smoke capture in `stock-preparation-onprem-acceptance.ps1` used

```powershell
$out = & node @args 2>&1
```

Under PowerShell 7.3+ native-command error handling, a child that writes to **stderr** while its stream is **merged** (`2>&1`) can be promoted to a *terminating error* that aborts the capture **before the smoke's values-free summary is ever parsed**. The smoke process ran; the **acceptance runner** threw. This is a runner-compatibility failure, **not** a smoke FAIL — app / migration / PM2 / health were all fine, and RC-0 is **not** a PASS.

### Fix
Extract a summary-only helper `Invoke-SmokeCapture` that:
- captures **only stdout** (`& node @NodeArgs 2>$null` — stderr discarded, never merged),
- preserves `$LASTEXITCODE`,
- keeps the admin-token BSTR zero-free + scoped-env `finally` cleanup (token discipline unchanged; the static-invariant tests still pass).

`Invoke-SmokeStage` now parses the helper's stdout. Values-free guarantee unchanged (only whitelisted summary fields are ever emitted).

### Load-bearing test (runs in the required `test (20.x)` pwsh gate)
New behaviour check D5: a fake smoke writes a **sentinel to stderr** and a valid summary to **stdout**, then asserts the capture (1) does not throw / abort, (2) does **not** capture the stderr sentinel, (3) still parses PASS (8/8, clean), (4) preserves exit 0 + clears the token env.

**Mutation-verified:** flipping `2>$null` back to `2>&1` reds the "sentinel is NOT captured" check (35 pass / 1 fail) — version-independent, because `2>&1` merges stderr into the captured text regardless of whether promotion fires. Behavioural count 32 → 36; the CI comment count is updated (49 → 53).

### Scope / sequencing
- Fix + load-bearing test only. **Do not re-run corrective-2.** After this merges, cut the exact-SHA **corrective-3** package and re-run the acceptance from stage 1 on the entity machine; RC-A stays gated on that PASS.
- `externalWrite=false` invariant untouched; no runtime behavior outside the acceptance runner changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
