### PR TITLE
fix(ops): harden corrective-3 smoke capture

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -129,8 +129,8 @@ jobs:
       - name: Prod health probe monitor contract
         run: node --test scripts/ops/prod-health-probe-state.test.mjs
 
-      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (49
-      # checks = 17 contract + 32 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
+      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (53
+      # checks = 17 contract + 36 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
       # pm2/health/smoke stages are unit-tested via dot-sourced pure helpers). Run inside the REQUIRED
       # `test` gate, but only ONCE (on 20.x — no need across the 18/20 matrix), early (no pnpm install
       # needed: pwsh/tar ship on ubuntu, node is already set up) so a regression fails the required check

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -129,8 +129,8 @@ jobs:
       - name: Prod health probe monitor contract
         run: node --test scripts/ops/prod-health-probe-state.test.mjs
 
-      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (53
-      # checks = 17 contract + 36 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
+      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (56
+      # checks = 18 contract + 38 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
       # pm2/health/smoke stages are unit-tested via dot-sourced pure helpers). Run inside the REQUIRED
       # `test` gate, but only ONCE (on 20.x — no need across the 18/20 matrix), early (no pnpm install
       # needed: pwsh/tar ship on ubuntu, node is already set up) so a regression fails the required check

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -230,9 +230,12 @@ try {
   # that writes noise to stderr AND a valid values-free summary to stdout must NOT abort the capture (the
   # RC-0 POWERSHELL_NATIVE_STDERR_PROMOTION failure — where 2>&1 promoted native stderr to a terminating
   # error and the smoke's summary was never read), must NOT let the stderr text contaminate the parsed
-  # summary, and must still parse PASS. Mutation guard: flip 2>$null back to 2>&1 in Invoke-SmokeCapture and
-  # the "sentinel is NOT captured" check reds (version-independent: 2>&1 merges stderr into the captured text).
-  $fakeSmoke = Join-Path ([System.IO.Path]::GetTempPath()) ("t9accept_fakesmoke_" + [guid]::NewGuid().ToString('N').Substring(0, 12) + '.mjs')
+  # summary, and must still parse PASS. Mutation guards: flip 2>$null back to 2>&1 and the sentinel check reds;
+  # hard-code the captured exit to zero and the non-zero preservation + stage fail-closed checks red.
+  $fakeSmokeRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("t9accept_fakesmoke_" + [guid]::NewGuid().ToString('N').Substring(0, 12))
+  $fakeSmokeOps = Join-Path $fakeSmokeRoot 'scripts/ops'
+  New-Item -ItemType Directory -Path $fakeSmokeOps -Force | Out-Null
+  $fakeSmoke = Join-Path $fakeSmokeOps 'stock-preparation-mvp-postdeploy-smoke.mjs'
   $sentinel = 'STDERR-LEAK-SENTINEL-7788'
   $fakeLines = @(
     "process.stderr.write('$sentinel\n')",
@@ -252,7 +255,45 @@ try {
   $capOutcome = Test-SmokeOutcome "$($cap.stdout)"
   Check "corrective-3: the stdout values-free summary still parses to PASS (8/8, clean)" ($capOutcome.ok -and $capOutcome.pass -and $capOutcome.audit -eq '8/8' -and $capOutcome.selfScan)
   Check "corrective-3: exit code preserved (0) and the token env var is cleared after capture" ($null -ne $cap -and $cap.exit -eq 0 -and -not (Test-Path Env:METASHEET_AUTH_TOKEN))
-  Remove-Item -LiteralPath $fakeSmoke -Force -ErrorAction SilentlyContinue
+
+  $nonzeroLines = @(
+    "process.stdout.write('mvpSmoke.pass=true\n')",
+    "process.stdout.write('auditActionsCovered=8/8\n')",
+    "process.stdout.write('selfScanClean=true\n')",
+    'process.exit(7)'
+  )
+  Set-Content -LiteralPath $fakeSmoke -Encoding utf8 -Value ($nonzeroLines -join "`n")
+  $nonzeroCap = Invoke-SmokeCapture -NodeArgs @($fakeSmoke) -Token $dummyToken
+  Check "corrective-3: non-zero native exit code is preserved exactly (7), never normalized to success" (
+    $nonzeroCap.exit -eq 7 -and -not (Test-Path Env:METASHEET_AUTH_TOKEN)
+  )
+
+  # Exercise the real stage boundary in a child pwsh process because Stop-WithFailure intentionally exits.
+  # A valid-looking summary with native exit 7 must still fail the stage and retain only the coarse exit code.
+  $stageHarness = Join-Path $fakeSmokeRoot 'invoke-smoke-stage.ps1'
+  $stageSummary = Join-Path $fakeSmokeRoot 'stage-summary.txt'
+  Set-Content -LiteralPath $stageHarness -Encoding utf8 -Value @'
+param(
+  [Parameter(Mandatory = $true)][string]$AcceptanceScript,
+  [Parameter(Mandatory = $true)][string]$DeployRoot,
+  [Parameter(Mandatory = $true)][string]$SummaryPath
+)
+$ErrorActionPreference = 'Stop'
+. $AcceptanceScript -PackagePath $DeployRoot -DeployRoot $DeployRoot -SummaryPath $SummaryPath *> $null
+$token = ConvertTo-SecureString 'dummy-not-a-real-token' -AsPlainText -Force
+Invoke-SmokeStage -Token $token
+'@
+  $stageOutput = & pwsh -NoProfile -File $stageHarness -AcceptanceScript $scriptPath -DeployRoot $fakeSmokeRoot -SummaryPath $stageSummary 2>&1
+  $stageExit = $LASTEXITCODE
+  $stageSummaryJsonPath = [System.IO.Path]::ChangeExtension($stageSummary, '.json')
+  $stageSummaryJson = if (Test-Path $stageSummaryJsonPath) { Get-Content $stageSummaryJsonPath -Raw | ConvertFrom-Json } else { $null }
+  Check "corrective-3: the real smoke stage fails closed on exit 7 and records only the coarse exit" (
+    $stageExit -eq 1 -and
+    $null -ne $stageSummaryJson -and
+    $stageSummaryJson.failedStage -eq 'smoke' -and
+    $stageSummaryJson.failDetail.smokeExit -eq 7 -and
+    "$stageOutput" -notmatch 'dummy-not-a-real-token'
+  )
 
   $base = [pscustomobject]@{ state = 'online'; restartTime = 3; uptime = 1000 }
 

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -226,6 +226,34 @@ try {
   $o = Test-SmokeOutcome "mvpSmoke.pass=true`nauditActionsCovered=8/8"
   Check "smoke: selfScanClean ABSENT -> FAIL (fail-closed)" ((-not $o.ok) -and $o.reason -eq 'self_scan_not_clean')
 
+  # ── D5 (corrective-3): the stage-6 smoke capture is stdout-ONLY (2>$null), never merged (2>&1). A child
+  # that writes noise to stderr AND a valid values-free summary to stdout must NOT abort the capture (the
+  # RC-0 POWERSHELL_NATIVE_STDERR_PROMOTION failure — where 2>&1 promoted native stderr to a terminating
+  # error and the smoke's summary was never read), must NOT let the stderr text contaminate the parsed
+  # summary, and must still parse PASS. Mutation guard: flip 2>$null back to 2>&1 in Invoke-SmokeCapture and
+  # the "sentinel is NOT captured" check reds (version-independent: 2>&1 merges stderr into the captured text).
+  $fakeSmoke = Join-Path ([System.IO.Path]::GetTempPath()) ("t9accept_fakesmoke_" + [guid]::NewGuid().ToString('N').Substring(0, 12) + '.mjs')
+  $sentinel = 'STDERR-LEAK-SENTINEL-7788'
+  $fakeLines = @(
+    "process.stderr.write('$sentinel\n')",
+    "process.stderr.write('(node:1) ExperimentalWarning: stderr noise the runner must not capture\n')",
+    "process.stdout.write('mvpSmoke.pass=true\n')",
+    "process.stdout.write('auditActionsCovered=8/8\n')",
+    "process.stdout.write('selfScanClean=true\n')",
+    "process.exit(0)"
+  )
+  Set-Content -LiteralPath $fakeSmoke -Encoding utf8 -Value ($fakeLines -join "`n")
+  $dummyToken = ConvertTo-SecureString 'dummy-not-a-real-token' -AsPlainText -Force
+  $smokeThrew = $false
+  $cap = $null
+  try { $cap = Invoke-SmokeCapture -NodeArgs @($fakeSmoke) -Token $dummyToken } catch { $smokeThrew = $true }
+  Check "corrective-3: a stderr-writing child does NOT abort the capture (no native stderr promotion)" ((-not $smokeThrew) -and $null -ne $cap)
+  Check "corrective-3: the stderr sentinel is NOT captured into the parsed summary (2>`$null, not 2>&1)" ($null -ne $cap -and -not ("$($cap.stdout)" -match [regex]::Escape($sentinel)))
+  $capOutcome = Test-SmokeOutcome "$($cap.stdout)"
+  Check "corrective-3: the stdout values-free summary still parses to PASS (8/8, clean)" ($capOutcome.ok -and $capOutcome.pass -and $capOutcome.audit -eq '8/8' -and $capOutcome.selfScan)
+  Check "corrective-3: exit code preserved (0) and the token env var is cleared after capture" ($null -ne $cap -and $cap.exit -eq 0 -and -not (Test-Path Env:METASHEET_AUTH_TOKEN))
+  Remove-Item -LiteralPath $fakeSmoke -Force -ErrorAction SilentlyContinue
+
   $base = [pscustomobject]@{ state = 'online'; restartTime = 3; uptime = 1000 }
 
   # Entity corrective-1 reproduction: PM2 includes process.env in jlist; on Windows it commonly carries

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
@@ -40,6 +40,30 @@ $bootstrapCallParams = if ($bootstrapCalls.Count -eq 1) {
     Where-Object { $_ -is [System.Management.Automation.Language.CommandParameterAst] } |
     ForEach-Object { $_.ParameterName })
 } else { @() }
+$smokeStages = @($acceptanceAst.FindAll({
+  param($node)
+  $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+    $node.Name -eq 'Invoke-SmokeStage'
+}, $true))
+$smokeCaptureCalls = if ($smokeStages.Count -eq 1) {
+  @($smokeStages[0].Body.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+      $node.GetCommandName() -eq 'Invoke-SmokeCapture'
+  }, $true))
+} else { @() }
+$smokeCaptureParams = if ($smokeCaptureCalls.Count -eq 1) {
+  @($smokeCaptureCalls[0].CommandElements |
+    Where-Object { $_ -is [System.Management.Automation.Language.CommandParameterAst] } |
+    ForEach-Object { $_.ParameterName })
+} else { @() }
+$directSmokeNodeCalls = if ($smokeStages.Count -eq 1) {
+  @($smokeStages[0].Body.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+      $node.GetCommandName() -eq 'node'
+  }, $true))
+} else { @() }
 
 Check "acceptance and launcher scripts parse without errors" (
   $acceptanceErrors.Count -eq 0 -and $launcherErrors.Count -eq 0
@@ -54,6 +78,14 @@ Check "acceptance calls the release launcher with its canonical parameter names"
   'RootDir' -in $bootstrapCallParams -and
   'PackagePath' -notin $bootstrapCallParams -and
   'DeployRoot' -notin $bootstrapCallParams
+)
+Check "smoke stage delegates native execution to the summary-only capture boundary" (
+  $smokeStages.Count -eq 1 -and
+  $smokeCaptureCalls.Count -eq 1 -and
+  $smokeCaptureParams.Count -eq 2 -and
+  'NodeArgs' -in $smokeCaptureParams -and
+  'Token' -in $smokeCaptureParams -and
+  $directSmokeNodeCalls.Count -eq 0
 )
 
 # The package template and acceptance runner are one operator contract. A stale default makes a healthy

--- a/scripts/ops/stock-preparation-onprem-acceptance.ps1
+++ b/scripts/ops/stock-preparation-onprem-acceptance.ps1
@@ -367,34 +367,47 @@ function Invoke-HealthStage {
   Write-Stage 'stage 5: PASS'
 }
 
+# ── Summary-only smoke capture (pure, unit-testable). Runs the child smoke and returns ONLY its stdout
+# summary text + exit code. stderr is redirected to $null (2>$null), NEVER merged into the success stream
+# (2>&1). Two reasons: (1) Node warnings / any stderr noise must never contaminate the parsed values-free
+# summary; (2) under PowerShell 7.3+ native-command error handling, a child that writes to stderr while
+# its stream is merged (2>&1) can be PROMOTED to a terminating error that ABORTS the capture before the
+# smoke's summary is ever read — the RC-0 acceptance-runner compatibility failure the entity machine hit
+# (POWERSHELL_NATIVE_STDERR_PROMOTION): the smoke ran, but the runner threw instead of parsing its output.
+# The admin token crosses to the child ONLY as a scoped env var, cleared (with its BSTR) in a finally.
+function Invoke-SmokeCapture {
+  param([string[]]$NodeArgs, [SecureString]$Token)
+  $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Token)
+  try {
+    # Token crosses to the child ONLY as a scoped env var — never on the command line / ArgumentList.
+    $env:METASHEET_AUTH_TOKEN = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+    $out = & node @NodeArgs 2>$null  # stdout ONLY; stderr discarded (see function header)
+    $exit = $LASTEXITCODE
+  } finally {
+    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+    Remove-Item Env:METASHEET_AUTH_TOKEN -ErrorAction SilentlyContinue
+  }
+  return @{ stdout = ($out | Out-String); exit = $exit }
+}
+
 # ── Stage 6: in-package stock-preparation smoke (token via scoped env, cleared in finally) ───────
 function Invoke-SmokeStage {
   param([SecureString]$Token)
   Write-Stage 'stage 6: stock-preparation smoke'
   $smoke = Join-Path $DeployRoot 'scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs'
   if (-not (Test-Path $smoke)) { Stop-WithFailure 'smoke' @{ reason = 'smoke_script_missing' } }
-  $args = @($smoke, '--base-url', "http://localhost:$Port")
-  if ($TenantId) { $args += @('--tenant-id', $TenantId) }
-  $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Token)
-  try {
-    # Token crosses to the child ONLY as a scoped env var — never on the command line / ArgumentList.
-    $env:METASHEET_AUTH_TOKEN = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
-    $out = & node @args 2>&1
-    $exit = $LASTEXITCODE
-  } finally {
-    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
-    Remove-Item Env:METASHEET_AUTH_TOKEN -ErrorAction SilentlyContinue
-  }
-  # Parse ONLY the values-free summary fields the smoke prints; never echo the raw $out.
-  $joined = ($out | Out-String)
-  $outcome = Test-SmokeOutcome $joined
+  $nodeArgs = @($smoke, '--base-url', "http://localhost:$Port")
+  if ($TenantId) { $nodeArgs += @('--tenant-id', $TenantId) }
+  # Summary-only capture: stdout is parsed for the values-free fields; stderr is discarded (never echoed).
+  $captured = Invoke-SmokeCapture -NodeArgs $nodeArgs -Token $Token
+  $outcome = Test-SmokeOutcome $captured.stdout
   $Summary['mvpSmoke.pass'] = if ($outcome.pass) { 'true' } else { 'false' }
   $Summary.auditActionsCovered = $outcome.audit
   $Summary.selfScanClean = if ($outcome.selfScan) { 'true' } else { 'false' }
   # Fail-closed: a green exit is NOT a steady state unless the audit surface is fully covered (8/8) and
   # the self-scan is clean. An absent/unparseable field records 'N/8'/'false' and FAILS here — it never
   # passes silently (owner P2).
-  if ($exit -ne 0) { Stop-WithFailure 'smoke' @{ smokeExit = $exit } }
+  if ($captured.exit -ne 0) { Stop-WithFailure 'smoke' @{ smokeExit = $captured.exit } }
   if (-not $outcome.ok) { Stop-WithFailure 'smoke' @{ reason = $outcome.reason } }
   Write-Stage 'stage 6: PASS'
 }


### PR DESCRIPTION
## What changed

- ports the corrective-3 stdout-only smoke capture from #4349 onto current `main`
- preserves the production health-monitor workflow step added after #4349 branched
- locks `Invoke-SmokeStage` to the `Invoke-SmokeCapture` boundary with a PowerShell AST contract
- verifies native exit code `7` is preserved and makes the real smoke stage fail closed with a coarse `smokeExit`
- updates the required `test (20.x)` contract count to 18 static + 38 behavioural checks

## Why

The entity-machine smoke wrote a valid summary to stdout and routine noise to stderr. Merging stderr with stdout under newer PowerShell native-command handling could abort the runner before it parsed the summary. The original fix addressed that runtime issue, but its tests did not prove the production stage used the helper and only exercised exit code zero.

This PR supersedes #4349, whose branch is now conflicting with `main`.

## Verification

- `pwsh -NoProfile -File scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1` — 18/18
- `pwsh -NoProfile -File scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1` — 38/38
- mutation: bypass `Invoke-SmokeCapture` inside `Invoke-SmokeStage` — AST contract red
- mutation: hard-code capture exit to zero — nonzero preservation and stage fail-closed checks red
- mutation: change `2>$null` back to `2>&1` — stderr sentinel check red
- `git diff --check`

No corrective-3 release package is cut by this PR. Package provenance must bind to the merged `main` SHA; #4101 remains the operator evidence anchor.
