### PR TITLE
fix(ops): corrective-3 — acceptance smoke capture stdout-only (2>$null) + wiring/exit guards

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -129,8 +129,8 @@ jobs:
       - name: Prod health probe monitor contract
         run: node --test scripts/ops/prod-health-probe-state.test.mjs
 
-      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (53
-      # checks = 17 contract + 36 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
+      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (56
+      # checks = 19 contract + 37 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
       # pm2/health/smoke stages are unit-tested via dot-sourced pure helpers). Run inside the REQUIRED
       # `test` gate, but only ONCE (on 20.x — no need across the 18/20 matrix), early (no pnpm install
       # needed: pwsh/tar ship on ubuntu, node is already set up) so a regression fails the required check

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -129,8 +129,8 @@ jobs:
       - name: Prod health probe monitor contract
         run: node --test scripts/ops/prod-health-probe-state.test.mjs
 
-      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (49
-      # checks = 17 contract + 32 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
+      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (53
+      # checks = 17 contract + 36 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
       # pm2/health/smoke stages are unit-tested via dot-sourced pure helpers). Run inside the REQUIRED
       # `test` gate, but only ONCE (on 20.x — no need across the 18/20 matrix), early (no pnpm install
       # needed: pwsh/tar ship on ubuntu, node is already set up) so a regression fails the required check

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -254,6 +254,38 @@ try {
   Check "corrective-3: exit code preserved (0) and the token env var is cleared after capture" ($null -ne $cap -and $cap.exit -eq 0 -and -not (Test-Path Env:METASHEET_AUTH_TOKEN))
   Remove-Item -LiteralPath $fakeSmoke -Force -ErrorAction SilentlyContinue
 
+  # ── D6 (corrective-3): the REAL stage-6 must FAIL CLOSED on a non-zero smoke exit even when the stdout
+  # summary parses PASS — a green summary is not a green process. Driven as a SUBPROCESS because
+  # Stop-WithFailure exits the runspace, and D5 alone (the helper in isolation) only ever exercised exit 0,
+  # so a helper hardcoded to return 0 would slip through. The subprocess mirrors the runner's own orchestrator
+  # try/catch, so it is robust whether or not this pwsh promotes a native non-zero exit to a terminating error.
+  $fcRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("t9accept_failclosed_" + [guid]::NewGuid().ToString('N').Substring(0, 12))
+  $fcSmokeDir = Join-Path $fcRoot 'scripts/ops'
+  New-Item -ItemType Directory -Path $fcSmokeDir -Force | Out-Null
+  Set-Content -LiteralPath (Join-Path $fcSmokeDir 'stock-preparation-mvp-postdeploy-smoke.mjs') -Encoding utf8 -Value (@(
+    "process.stdout.write('mvpSmoke.pass=true\n')",
+    "process.stdout.write('auditActionsCovered=8/8\n')",
+    "process.stdout.write('selfScanClean=true\n')",
+    "process.exit(7)"
+  ) -join "`n")
+  $fcSummary = Join-Path $fcRoot 'acceptance-summary.txt'
+  $fcDriver = Join-Path $fcRoot 'drive.ps1'
+  Set-Content -LiteralPath $fcDriver -Encoding utf8 -Value (@(
+    'param($ScriptPath, $DeployRoot, $SummaryPath)',
+    '. $ScriptPath -PackagePath $DeployRoot -DeployRoot $DeployRoot -SummaryPath $SummaryPath *> $null',
+    '$tok = ConvertTo-SecureString ''drive-dummy'' -AsPlainText -Force',
+    'try { Invoke-SmokeStage -Token $tok } catch { if ($Summary.failedStage -eq ''none'') { $Summary.failedStage = ''smoke'' }; Emit-Summary; exit 1 }',
+    'exit 0'
+  ) -join "`n")
+  & pwsh -NoProfile -File $fcDriver -ScriptPath $scriptPath -DeployRoot $fcRoot -SummaryPath $fcSummary *> $null
+  $fcExit = $LASTEXITCODE
+  $fcJson = [System.IO.Path]::ChangeExtension($fcSummary, '.json')
+  $fcObj = if (Test-Path $fcJson) { Get-Content $fcJson -Raw | ConvertFrom-Json } else { $null }
+  Check "corrective-3: stage-6 FAILS CLOSED on a non-zero smoke exit (7) despite a PASS stdout summary" (
+    $fcExit -eq 1 -and $null -ne $fcObj -and $fcObj.failedStage -eq 'smoke'
+  )
+  Remove-Item -LiteralPath $fcRoot -Recurse -Force -ErrorAction SilentlyContinue
+
   $base = [pscustomobject]@{ state = 'online'; restartTime = 3; uptime = 1000 }
 
   # Entity corrective-1 reproduction: PM2 includes process.env in jlist; on Windows it commonly carries

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -226,6 +226,34 @@ try {
   $o = Test-SmokeOutcome "mvpSmoke.pass=true`nauditActionsCovered=8/8"
   Check "smoke: selfScanClean ABSENT -> FAIL (fail-closed)" ((-not $o.ok) -and $o.reason -eq 'self_scan_not_clean')
 
+  # ── D5 (corrective-3): the stage-6 smoke capture is stdout-ONLY (2>$null), never merged (2>&1). A child
+  # that writes noise to stderr AND a valid values-free summary to stdout must NOT abort the capture (the
+  # RC-0 POWERSHELL_NATIVE_STDERR_PROMOTION failure — where 2>&1 promoted native stderr to a terminating
+  # error and the smoke's summary was never read), must NOT let the stderr text contaminate the parsed
+  # summary, and must still parse PASS. Mutation guard: flip 2>$null back to 2>&1 in Invoke-SmokeCapture and
+  # the "sentinel is NOT captured" check reds (version-independent: 2>&1 merges stderr into the captured text).
+  $fakeSmoke = Join-Path ([System.IO.Path]::GetTempPath()) ("t9accept_fakesmoke_" + [guid]::NewGuid().ToString('N').Substring(0, 12) + '.mjs')
+  $sentinel = 'STDERR-LEAK-SENTINEL-7788'
+  $fakeLines = @(
+    "process.stderr.write('$sentinel\n')",
+    "process.stderr.write('(node:1) ExperimentalWarning: stderr noise the runner must not capture\n')",
+    "process.stdout.write('mvpSmoke.pass=true\n')",
+    "process.stdout.write('auditActionsCovered=8/8\n')",
+    "process.stdout.write('selfScanClean=true\n')",
+    "process.exit(0)"
+  )
+  Set-Content -LiteralPath $fakeSmoke -Encoding utf8 -Value ($fakeLines -join "`n")
+  $dummyToken = ConvertTo-SecureString 'dummy-not-a-real-token' -AsPlainText -Force
+  $smokeThrew = $false
+  $cap = $null
+  try { $cap = Invoke-SmokeCapture -NodeArgs @($fakeSmoke) -Token $dummyToken } catch { $smokeThrew = $true }
+  Check "corrective-3: a stderr-writing child does NOT abort the capture (no native stderr promotion)" ((-not $smokeThrew) -and $null -ne $cap)
+  Check "corrective-3: the stderr sentinel is NOT captured into the parsed summary (2>`$null, not 2>&1)" ($null -ne $cap -and -not ("$($cap.stdout)" -match [regex]::Escape($sentinel)))
+  $capOutcome = Test-SmokeOutcome "$($cap.stdout)"
+  Check "corrective-3: the stdout values-free summary still parses to PASS (8/8, clean)" ($capOutcome.ok -and $capOutcome.pass -and $capOutcome.audit -eq '8/8' -and $capOutcome.selfScan)
+  Check "corrective-3: exit code preserved (0) and the token env var is cleared after capture" ($null -ne $cap -and $cap.exit -eq 0 -and -not (Test-Path Env:METASHEET_AUTH_TOKEN))
+  Remove-Item -LiteralPath $fakeSmoke -Force -ErrorAction SilentlyContinue
+
   $base = [pscustomobject]@{ state = 'online'; restartTime = 3; uptime = 1000 }
 
   # Entity corrective-1 reproduction: PM2 includes process.env in jlist; on Windows it commonly carries

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
@@ -66,6 +66,25 @@ Check "acceptance default port matches the packaged on-prem environment template
   $portParam[0].DefaultValue.Extent.Text -eq $templatePortMatch.Groups[1].Value
 )
 
+# ── corrective-3: stage-6 must DELEGATE the smoke run to the summary-only helper (stdout-only, 2>$null),
+# never invoke node directly or MERGE stderr (2>&1). The behaviour test exercises the helper in isolation,
+# so it cannot catch a revert of the STAGE wiring back to `& node ... 2>&1`; pin that wiring in the AST here
+# (the RC-0 POWERSHELL_NATIVE_STDERR_PROMOTION regression, where merged native stderr aborted the capture).
+$smokeStageAst = @($acceptanceAst.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq 'Invoke-SmokeStage' }, $true))[0]
+$smokeCaptureAst = @($acceptanceAst.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq 'Invoke-SmokeCapture' }, $true))[0]
+$stageCallsCapture = $null -ne $smokeStageAst -and @($smokeStageAst.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] -and $n.GetCommandName() -eq 'Invoke-SmokeCapture' }, $true)).Count -ge 1
+$stageInvokesNode = $null -ne $smokeStageAst -and @($smokeStageAst.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] -and $n.GetCommandName() -eq 'node' }, $true)).Count -gt 0
+Check "corrective-3: stage-6 delegates the smoke run to Invoke-SmokeCapture and never invokes node directly" (
+  $stageCallsCapture -and -not $stageInvokesNode
+)
+$captureNode = if ($null -ne $smokeCaptureAst) { @($smokeCaptureAst.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] -and $n.GetCommandName() -eq 'node' }, $true)) } else { @() }
+$captureRedirs = if ($captureNode.Count -ge 1) { $captureNode[0].Redirections } else { @() }
+$hasErrToFile = @($captureRedirs | Where-Object { $_ -is [System.Management.Automation.Language.FileRedirectionAst] -and $_.FromStream -eq [System.Management.Automation.Language.RedirectionStream]::Error }).Count -ge 1
+$hasErrMerged = @($captureRedirs | Where-Object { $_ -is [System.Management.Automation.Language.MergingRedirectionAst] }).Count -ge 1
+Check "corrective-3: the smoke capture redirects stderr away (2>`$null), never merges it (2>&1)" (
+  $captureNode.Count -ge 1 -and $hasErrToFile -and -not $hasErrMerged
+)
+
 # Windows PowerShell rejects ordinary PM2 payloads containing case-variant environment keys such as
 # Path/PATH. The raw document must cross a Node projection boundary before PowerShell deserializes it,
 # and that projection helper must be a required package asset.

--- a/scripts/ops/stock-preparation-onprem-acceptance.ps1
+++ b/scripts/ops/stock-preparation-onprem-acceptance.ps1
@@ -367,34 +367,47 @@ function Invoke-HealthStage {
   Write-Stage 'stage 5: PASS'
 }
 
+# ── Summary-only smoke capture (pure, unit-testable). Runs the child smoke and returns ONLY its stdout
+# summary text + exit code. stderr is redirected to $null (2>$null), NEVER merged into the success stream
+# (2>&1). Two reasons: (1) Node warnings / any stderr noise must never contaminate the parsed values-free
+# summary; (2) under PowerShell 7.3+ native-command error handling, a child that writes to stderr while
+# its stream is merged (2>&1) can be PROMOTED to a terminating error that ABORTS the capture before the
+# smoke's summary is ever read — the RC-0 acceptance-runner compatibility failure the entity machine hit
+# (POWERSHELL_NATIVE_STDERR_PROMOTION): the smoke ran, but the runner threw instead of parsing its output.
+# The admin token crosses to the child ONLY as a scoped env var, cleared (with its BSTR) in a finally.
+function Invoke-SmokeCapture {
+  param([string[]]$NodeArgs, [SecureString]$Token)
+  $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Token)
+  try {
+    # Token crosses to the child ONLY as a scoped env var — never on the command line / ArgumentList.
+    $env:METASHEET_AUTH_TOKEN = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+    $out = & node @NodeArgs 2>$null  # stdout ONLY; stderr discarded (see function header)
+    $exit = $LASTEXITCODE
+  } finally {
+    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+    Remove-Item Env:METASHEET_AUTH_TOKEN -ErrorAction SilentlyContinue
+  }
+  return @{ stdout = ($out | Out-String); exit = $exit }
+}
+
 # ── Stage 6: in-package stock-preparation smoke (token via scoped env, cleared in finally) ───────
 function Invoke-SmokeStage {
   param([SecureString]$Token)
   Write-Stage 'stage 6: stock-preparation smoke'
   $smoke = Join-Path $DeployRoot 'scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs'
   if (-not (Test-Path $smoke)) { Stop-WithFailure 'smoke' @{ reason = 'smoke_script_missing' } }
-  $args = @($smoke, '--base-url', "http://localhost:$Port")
-  if ($TenantId) { $args += @('--tenant-id', $TenantId) }
-  $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Token)
-  try {
-    # Token crosses to the child ONLY as a scoped env var — never on the command line / ArgumentList.
-    $env:METASHEET_AUTH_TOKEN = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
-    $out = & node @args 2>&1
-    $exit = $LASTEXITCODE
-  } finally {
-    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
-    Remove-Item Env:METASHEET_AUTH_TOKEN -ErrorAction SilentlyContinue
-  }
-  # Parse ONLY the values-free summary fields the smoke prints; never echo the raw $out.
-  $joined = ($out | Out-String)
-  $outcome = Test-SmokeOutcome $joined
+  $nodeArgs = @($smoke, '--base-url', "http://localhost:$Port")
+  if ($TenantId) { $nodeArgs += @('--tenant-id', $TenantId) }
+  # Summary-only capture: stdout is parsed for the values-free fields; stderr is discarded (never echoed).
+  $captured = Invoke-SmokeCapture -NodeArgs $nodeArgs -Token $Token
+  $outcome = Test-SmokeOutcome $captured.stdout
   $Summary['mvpSmoke.pass'] = if ($outcome.pass) { 'true' } else { 'false' }
   $Summary.auditActionsCovered = $outcome.audit
   $Summary.selfScanClean = if ($outcome.selfScan) { 'true' } else { 'false' }
   # Fail-closed: a green exit is NOT a steady state unless the audit surface is fully covered (8/8) and
   # the self-scan is clean. An absent/unparseable field records 'N/8'/'false' and FAILS here — it never
   # passes silently (owner P2).
-  if ($exit -ne 0) { Stop-WithFailure 'smoke' @{ smokeExit = $exit } }
+  if ($captured.exit -ne 0) { Stop-WithFailure 'smoke' @{ smokeExit = $captured.exit } }
   if (-not $outcome.ok) { Stop-WithFailure 'smoke' @{ reason = $outcome.reason } }
   Write-Stage 'stage 6: PASS'
 }


### PR DESCRIPTION
## corrective-3 — acceptance-runner smoke capture is stdout-only, not stderr-merged

**Refs #4101** (on-prem acceptance tracker). This PR must NOT change that tracker's status — it stays OPEN until the corrective-3 entity-machine run PASSes. Supersedes #4349 (closed after a rebase onto hot main orphaned its head commit); this branch carries the same work plus the re-review fixes below.

### What the entity machine hit
The RC-0 run reported `POWERSHELL_NATIVE_STDERR_PROMOTION`. Root cause: stage-6's smoke capture used `& node @args 2>&1`. Under PowerShell 7.3+ native-command error handling, a child that writes to **stderr** while its stream is **merged** (`2>&1`) can be promoted to a *terminating error* that aborts the capture **before the smoke's summary is parsed**. The smoke process ran; the **acceptance runner** threw. A runner-compatibility failure, **not** a smoke FAIL — app / migration / PM2 / health were fine; RC-0 is **not** a PASS.

### Fix (`afde2fd67`)
Extract a summary-only helper `Invoke-SmokeCapture`: captures **only stdout** (`2>$null`), preserves `$LASTEXITCODE`, keeps the admin-token BSTR + scoped-env `finally` cleanup (token discipline unchanged; static-invariant tests still pass). `Invoke-SmokeStage` parses the helper's stdout.

### Re-review fixes (`b2ed0bdc7`) — closing the two P2 test gaps you found
Your exact-head review flagged that the first test (D5) exercised `Invoke-SmokeCapture` in isolation, so a revert of the **stage** to direct `2>&1` stayed 36/36 green, and it only tested exit 0, so a helper hardcoded to return 0 stayed green. Both closed:

1. **AST wiring guard (static, +2 contract).** stage-6 must call `Invoke-SmokeCapture` and **never invoke node directly**; the helper's node command must carry a `FileRedirectionAst` on stderr (`2>$null`) and **no** `MergingRedirectionAst` (`2>&1`). Mutation-proven: reverting the stage to `& node ... 2>&1` reds the delegation check; flipping the helper to `2>&1` reds the redirect check.
2. **Fail-closed behaviour test (D6, +1 behavioural).** Drives the **real** `Invoke-SmokeStage` in a subprocess (mirrors the orchestrator try/catch, robust to native-exit promotion) against a child that prints a valid PASS summary but **exits 7** — the stage must `Stop-WithFailure` (exit 1, `failedStage=smoke`). Mutation-proven: a helper hardcoded to return 0 lets the stage PASS → reds.

Plus the original D5 (behaviour, +4): a fake smoke writes a sentinel to stderr + valid summary to stdout → no abort, sentinel not captured, summary parses PASS, exit/token cleared; mutation `2>$null`→`2>&1` reds the "sentinel not captured" check.

**Counts 49 → 56 (17 → 19 contract, 32 → 37 behavioural).** All in the required `test (20.x)` pwsh gate. Rebased onto hot main (`d64f0a6d8`).

### Sequencing
Fix + tests only. **Do not re-run corrective-2.** After a short exact-head re-review + merge, cut the exact-SHA **corrective-3** package from the merged main SHA and re-run acceptance from stage 1 on the entity machine; RC-A stays gated on that PASS. `externalWrite=false` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
