### PR TITLE
feat(stock-prep): auto-persist approved ERP source rows (T3a)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -522,6 +522,7 @@ jobs:
             tests/integration/multitable-crossbase-realtime-fanout.test.ts \
             tests/integration/multitable-record-duplicate.test.ts \
             tests/integration/approval-record-projection.test.ts \
+            tests/integration/stock-preparation-t3a-erp-autopersist-realdb.test.ts \
             --reporter=dot
 
       - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start + A/E/B/D/G cross-lane acceptance + dept_head sync-plumbing carry-forward + continuous_managers chain walk + common template presets + DT-OPS-01 deprovision selection goldens)

--- a/packages/core-backend/tests/integration/stock-preparation-t3a-erp-autopersist-realdb.test.ts
+++ b/packages/core-backend/tests/integration/stock-preparation-t3a-erp-autopersist-realdb.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Stock-preparation T3a: approved ERP read source -> internal material cache (real DB).
+ *
+ * This suite drives the actual route handler through the real provisioning and records APIs. It
+ * deliberately discovers physical field ids from meta_fields instead of using the deterministic id
+ * helper, so a broken logical-to-physical translation cannot self-prove against the same formula.
+ */
+import { createRequire } from 'module'
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import {
+  ensureObject,
+  findObjectSheet,
+  patchObjectFieldProperty,
+  resolveObjectFieldIds,
+  type MultitableProvisioningObjectDescriptor,
+  type MultitableProvisioningQueryFn,
+} from '../../src/multitable/provisioning'
+import {
+  createRecord,
+  patchRecord,
+  queryRecords,
+  type MultitableRecordsQueryFn,
+} from '../../src/multitable/records'
+
+const require = createRequire(import.meta.url)
+const { createHandlers } = require('../../../../plugins/plugin-integration-core/lib/http-routes.cjs') as {
+  createHandlers: (
+    services: Record<string, unknown>,
+    options: { context: Record<string, unknown> },
+  ) => Record<string, (req: Record<string, unknown>, res: TestResponse) => Promise<unknown>>
+}
+const { validateReadSourceConfig } = require('../../../../plugins/plugin-integration-core/lib/read-source-config.cjs') as {
+  validateReadSourceConfig: (input: Record<string, unknown>) => {
+    valid: boolean
+    errors: unknown[]
+    normalized: Record<string, unknown>
+  }
+}
+const {
+  ensureStockPreparationMvpTargets,
+  syncStockPreparationMvpOptions,
+} = require('../../../../plugins/plugin-integration-core/lib/stock-preparation-mvp-provisioning.cjs') as {
+  ensureStockPreparationMvpTargets: (input: Record<string, unknown>) => Promise<Record<string, unknown>>
+  syncStockPreparationMvpOptions: (input: Record<string, unknown>) => Promise<Record<string, unknown>>
+}
+const {
+  MATERIAL_OBJECT_ID,
+  RUN_OBJECT_ID,
+} = require('../../../../plugins/plugin-integration-core/lib/stock-preparation-erp-material-sync-persist.cjs') as {
+  MATERIAL_OBJECT_ID: string
+  RUN_OBJECT_ID: string
+}
+const { STOCK_PREPARATION_MVP_TABLE_TEMPLATES } = require('../../../../plugins/plugin-integration-core/lib/stock-preparation-templates.cjs') as {
+  STOCK_PREPARATION_MVP_TABLE_TEMPLATES: Array<{
+    objectId: string
+    fields: Array<{ id: string; label: string; type: string }>
+  }>
+}
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TOKEN = `${process.pid}_${Date.now().toString(36)}`
+const TENANT_ID = `tenant_t3a_${TOKEN}`
+const TARGET_PROJECT_ID = `${TENANT_ID}:integration-core`
+const CONFIG_ID = `cfg_t3a_${TOKEN}`
+const SYSTEM_ID = `sys_t3a_${TOKEN}`
+const SYNC_RUN_ID = `run_t3a_${TOKEN}`
+const MATERIAL_INTERNAL_ID = `internal_t3a_${TOKEN}`
+const MATERIAL_CODE = `ERP-CODE-T3A-${TOKEN}`
+const MATERIAL_NAME = `ERP-NAME-T3A-${TOKEN}`
+const SOURCE_CREDENTIAL = `ERP-CREDENTIAL-T3A-${TOKEN}`
+const FLAG = 'MULTITABLE_STOCK_PREP_ERP_AUTOPERSIST_ENABLED'
+
+type QueryResult = { rows: unknown[]; rowCount?: number | null }
+type TestResponse = {
+  statusCode: number
+  body: unknown
+  status(code: number): TestResponse
+  json(body: unknown): unknown
+}
+
+function wrapQuery(
+  query: (sql: string, params?: unknown[]) => Promise<QueryResult>,
+): MultitableProvisioningQueryFn & MultitableRecordsQueryFn {
+  return async (sql, params) => {
+    const result = await query(sql, params)
+    return {
+      rows: Array.isArray(result.rows) ? result.rows : [],
+      rowCount: typeof result.rowCount === 'number' ? result.rowCount : undefined,
+    }
+  }
+}
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+function transaction<T>(handler: (query: MultitableRecordsQueryFn) => Promise<T>): Promise<T> {
+  return poolManager.get().transaction(async ({ query }) => handler(wrapQuery(query)))
+}
+
+function createRealMultitableFacade() {
+  const readQuery = wrapQuery(q)
+  const provisioning = {
+    findObjectSheet: ({ projectId, objectId }: { projectId: string; objectId: string }) =>
+      findObjectSheet(readQuery, projectId, objectId),
+    resolveFieldIds: ({ projectId, objectId, fieldIds }: { projectId: string; objectId: string; fieldIds: string[] }) =>
+      resolveObjectFieldIds(projectId, objectId, fieldIds),
+    ensureObject: ({ projectId, baseId, descriptor }: {
+      projectId: string
+      baseId?: string | null
+      descriptor: MultitableProvisioningObjectDescriptor
+    }) =>
+      transaction((query) => ensureObject({ query, projectId, baseId, descriptor })),
+    patchObjectFieldProperty: (input: {
+      projectId: string
+      objectId: string
+      fieldId: string
+      propertyPatch: Record<string, unknown>
+    }) => transaction((query) => patchObjectFieldProperty({ query, ...input })),
+  }
+  const records = {
+    queryRecords: (input: {
+      sheetId: string
+      filters?: Record<string, unknown>
+      search?: string
+      orderBy?: Array<Record<string, unknown>>
+      limit?: number
+      offset?: number
+    }) => queryRecords({ query: readQuery, ...input }),
+    createRecord: ({ sheetId, data }: { sheetId: string; data: Record<string, unknown> }) =>
+      transaction((query) => createRecord({ query, sheetId, data })),
+    patchRecord: ({ sheetId, recordId, changes }: {
+      sheetId: string
+      recordId: string
+      changes: Record<string, unknown>
+    }) => transaction((query) => patchRecord({ query, sheetId, recordId, changes })),
+  }
+  return { provisioning, records }
+}
+
+function readConfig(): Record<string, unknown> {
+  const result = validateReadSourceConfig({
+    version: 1,
+    systemId: SYSTEM_ID,
+    requiredKind: 'erp:k3-wise-webapi',
+    object: 'stock-preparation-source',
+    mode: 'list_page',
+    readPath: '/readonly/stock-preparation',
+    readMethod: 'POST',
+    operations: ['read'],
+    containerPaths: ['Rows'],
+    fieldMap: [
+      { source: 'FItemID', target: 'erpMaterialInternalId' },
+      { source: 'FNumber', target: 'erpMaterialCode' },
+      { source: 'FName', target: 'erpMaterialName' },
+    ],
+  })
+  if (!result.valid) throw new Error(`T3a real-DB fixture config is invalid: ${JSON.stringify(result.errors)}`)
+  return result.normalized
+}
+
+function unused(name: string): () => never {
+  return () => {
+    throw new Error(`unexpected T3a real-DB service call: ${name}`)
+  }
+}
+
+function createServices(sourceRows: Array<Record<string, unknown>>) {
+  const noopAsync = async () => ({})
+  return {
+    externalSystemRegistry: {
+      upsertExternalSystem: unused('upsertExternalSystem'),
+      getExternalSystem: unused('getExternalSystem'),
+      deleteExternalSystem: unused('deleteExternalSystem'),
+      listExternalSystems: unused('listExternalSystems'),
+      async getExternalSystemForAdapter() {
+        return {
+          id: SYSTEM_ID,
+          tenantId: TENANT_ID,
+          kind: 'erp:k3-wise-webapi',
+          credentials: { password: SOURCE_CREDENTIAL },
+          config: {},
+        }
+      },
+    },
+    adapterRegistry: {
+      listAdapterKinds: () => ['erp:k3-wise-webapi'],
+      createAdapter: () => ({
+        async read() {
+          return {
+            records: sourceRows,
+            raw: { Rows: sourceRows },
+            metadata: { dataRowCount: sourceRows.length, dataPageIndex: 1, returnedRecordCount: sourceRows.length },
+          }
+        },
+      }),
+    },
+    pipelineRegistry: {
+      upsertPipeline: unused('upsertPipeline'),
+      getPipeline: unused('getPipeline'),
+      listPipelines: unused('listPipelines'),
+      listPipelineRuns: unused('listPipelineRuns'),
+    },
+    pipelineRunner: { runPipeline: unused('runPipeline') },
+    deadLetterStore: { listDeadLetters: unused('listDeadLetters') },
+    stagingInstaller: {
+      installStaging: unused('installStaging'),
+      listStagingDescriptors: unused('listStagingDescriptors'),
+    },
+    templateRegistry: {
+      upsertTemplate: unused('upsertTemplate'),
+      getTemplate: unused('getTemplate'),
+      listTemplates: unused('listTemplates'),
+      deleteTemplate: unused('deleteTemplate'),
+      instantiateTemplate: unused('instantiateTemplate'),
+    },
+    readSourceConfigStore: {
+      saveVersion: unused('readSourceConfig.saveVersion'),
+      list: unused('readSourceConfig.list'),
+      get: unused('readSourceConfig.get'),
+      approve: unused('readSourceConfig.approve'),
+      retire: unused('readSourceConfig.retire'),
+      listAudit: unused('readSourceConfig.listAudit'),
+      async getForRuntime() {
+        return { id: CONFIG_ID, status: 'approved', systemId: SYSTEM_ID, config: readConfig() }
+      },
+    },
+    readSourceCompositionConfigStore: {
+      saveVersion: noopAsync,
+      list: noopAsync,
+      get: noopAsync,
+      approve: noopAsync,
+      retire: noopAsync,
+      listAudit: noopAsync,
+      getForRuntime: noopAsync,
+    },
+    bridgeAgentChecklistStore: {
+      saveVersion: noopAsync,
+      approve: noopAsync,
+      retire: noopAsync,
+      getForApply: noopAsync,
+    },
+  }
+}
+
+function response(): TestResponse {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(body) {
+      this.body = body
+      return body
+    },
+  }
+}
+
+function deepIncludes(value: unknown, needle: string): boolean {
+  if (typeof value === 'string') return value.includes(needle)
+  if (Array.isArray(value)) return value.some((entry) => deepIncludes(entry, needle))
+  if (value && typeof value === 'object') return Object.values(value).some((entry) => deepIncludes(entry, needle))
+  return false
+}
+
+async function discoverPhysicalFields(sheetId: string, objectId: string): Promise<Record<string, string>> {
+  const template = STOCK_PREPARATION_MVP_TABLE_TEMPLATES.find((entry) => entry.objectId === objectId)
+  if (!template) throw new Error(`missing frozen template for ${objectId}`)
+  const result = await q('SELECT id, name, type FROM meta_fields WHERE sheet_id = $1', [sheetId])
+  const rowsByName = new Map(
+    (result.rows as Array<{ id: string; name: string; type: string }>).map((row) => [row.name, row]),
+  )
+  return Object.fromEntries(template.fields.map((field) => {
+    const row = rowsByName.get(field.label)
+    if (!row) throw new Error(`real meta_fields row missing for ${objectId}.${field.id}`)
+    if (row.id === field.id) throw new Error(`expected a physical field id for ${objectId}.${field.id}`)
+    return [field.id, row.id]
+  }))
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('expected object response')
+  return value as Record<string, unknown>
+}
+
+if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+  test('T3a real-DB allowlist must provide DATABASE_URL', () => {
+    throw new Error('T3a real-DB allowlist step is missing DATABASE_URL')
+  })
+}
+
+describeIfDatabase('stock-preparation T3a ERP source auto-persist (real DB)', () => {
+  const facade = createRealMultitableFacade()
+  const context = { api: { multitable: facade }, storage: {}, config: {} }
+  const materialRows = [{ FItemID: MATERIAL_INTERNAL_ID, FNumber: MATERIAL_CODE, FName: MATERIAL_NAME }]
+  let materialSheetId = ''
+  let runSheetId = ''
+  let previousFlag: string | undefined
+
+  beforeAll(async () => {
+    previousFlag = process.env[FLAG]
+    const ensured = await ensureStockPreparationMvpTargets({
+      context,
+      projectId: TARGET_PROJECT_ID,
+      permission: 'admin',
+      objectIds: [MATERIAL_OBJECT_ID, RUN_OBJECT_ID],
+    })
+    expect(ensured).toMatchObject({ ready: true })
+    const materialSheet = await facade.provisioning.findObjectSheet({ projectId: TARGET_PROJECT_ID, objectId: MATERIAL_OBJECT_ID })
+    const runSheet = await facade.provisioning.findObjectSheet({ projectId: TARGET_PROJECT_ID, objectId: RUN_OBJECT_ID })
+    if (!materialSheet || !runSheet) throw new Error('T3a real-DB provisioning did not create both target sheets')
+    materialSheetId = materialSheet.id
+    runSheetId = runSheet.id
+    await syncStockPreparationMvpOptions({
+      context,
+      projectId: TARGET_PROJECT_ID,
+      permission: 'admin',
+      objectIds: [MATERIAL_OBJECT_ID, RUN_OBJECT_ID],
+      optionSets: {
+        stock_preparation_material_status_v1: [{ value: 'imported' }],
+        stock_preparation_run_type_v1: ['plm_sync', 'erp_material_sync', 'mapping_match', 'unit_match', 'prep_generate']
+          .map((value) => ({ value })),
+        stock_preparation_run_status_v1: ['running', 'succeeded', 'failed', 'partial']
+          .map((value) => ({ value })),
+      },
+    })
+  })
+
+  afterAll(async () => {
+    if (previousFlag === undefined) delete process.env[FLAG]
+    else process.env[FLAG] = previousFlag
+    const sheetIds = [materialSheetId, runSheetId].filter(Boolean)
+    if (sheetIds.length === 0) return
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = ANY($1::text[])', [sheetIds]).catch(() => {})
+    await q(
+      'DELETE FROM meta_links WHERE record_id IN (SELECT id FROM meta_records WHERE sheet_id = ANY($1::text[])) OR foreign_record_id IN (SELECT id FROM meta_records WHERE sheet_id = ANY($1::text[]))',
+      [sheetIds],
+    ).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [sheetIds]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = ANY($1::text[])', [sheetIds]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [sheetIds]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [sheetIds]).catch(() => {})
+  })
+
+  test('flag ON persists through physical field ids, stays values-free, and reruns idempotently', async () => {
+    process.env[FLAG] = 'true'
+    const handlers = createHandlers(createServices(materialRows), { context })
+    const handler = handlers.stockPreparationErpMaterialSourceRun
+    expect(handler).toBeTypeOf('function')
+    const req = {
+      user: { id: `admin_${TOKEN}`, tenantId: TENANT_ID, roles: ['admin'], permissions: ['integration:admin'] },
+      body: { workspaceId: `workspace_${TOKEN}`, readSourceConfigId: CONFIG_ID, syncRunId: SYNC_RUN_ID },
+      query: {},
+      params: {},
+    }
+
+    const first = response()
+    await handler(req, first)
+    const firstBody = asRecord(first.body)
+    const firstData = asRecord(firstBody.data)
+    const firstAutoPersist = asRecord(firstData.autoPersist)
+    expect(first.statusCode).toBe(201)
+    expect(firstData).toMatchObject({
+      mode: 'internal_persist',
+      evidence: {
+        internalWriteExecuted: true,
+        externalWriteExecuted: false,
+        productionWrite: false,
+        k3SaveSubmitAudit: false,
+      },
+    })
+    expect(firstAutoPersist).toMatchObject({
+      persisted: true,
+      mode: 'created',
+      created: { materials: 1, run: 1 },
+      patched: { materials: 0, run: 0 },
+      runStatus: 'succeeded',
+    })
+    expect(deepIncludes(first.body, MATERIAL_CODE)).toBe(false)
+    expect(deepIncludes(first.body, MATERIAL_NAME)).toBe(false)
+    expect(deepIncludes(first.body, SYNC_RUN_ID)).toBe(false)
+    expect(deepIncludes(first.body, SOURCE_CREDENTIAL)).toBe(false)
+
+    const materialFields = await discoverPhysicalFields(materialSheetId, MATERIAL_OBJECT_ID)
+    const runFields = await discoverPhysicalFields(runSheetId, RUN_OBJECT_ID)
+    const materialResult = await q('SELECT id, data, version FROM meta_records WHERE sheet_id = $1', [materialSheetId])
+    const runResult = await q('SELECT id, data, version FROM meta_records WHERE sheet_id = $1', [runSheetId])
+    expect(materialResult.rows).toHaveLength(1)
+    expect(runResult.rows).toHaveLength(1)
+    const materialData = asRecord((materialResult.rows[0] as { data: unknown }).data)
+    const runData = asRecord((runResult.rows[0] as { data: unknown }).data)
+    expect(materialData[materialFields.erpMaterialInternalId]).toBe(MATERIAL_INTERNAL_ID)
+    expect(materialData[materialFields.erpMaterialCode]).toBe(MATERIAL_CODE)
+    expect(materialData[materialFields.erpMaterialName]).toBe(MATERIAL_NAME)
+    expect(Object.prototype.hasOwnProperty.call(materialData, 'erpMaterialCode')).toBe(false)
+    expect(runData[runFields.runId]).toBe(SYNC_RUN_ID)
+    expect(runData[runFields.runType]).toBe('erp_material_sync')
+    expect(runData[runFields.status]).toBe('succeeded')
+
+    const second = response()
+    await handler(req, second)
+    const secondData = asRecord(asRecord(second.body).data)
+    expect(second.statusCode).toBe(201)
+    expect(secondData.autoPersist).toMatchObject({
+      persisted: true,
+      mode: 'refreshed',
+      created: { materials: 0, run: 0 },
+      patched: { materials: 1, run: 0 },
+    })
+    const counts = await q(
+      'SELECT sheet_id, COUNT(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[]) GROUP BY sheet_id',
+      [[materialSheetId, runSheetId]],
+    )
+    expect(Object.fromEntries((counts.rows as Array<{ sheet_id: string; count: number }>).map((row) => [row.sheet_id, row.count]))).toEqual({
+      [materialSheetId]: 1,
+      [runSheetId]: 1,
+    })
+  })
+
+  test('flag OFF preserves the read-only response and writes no internal rows', async () => {
+    delete process.env[FLAG]
+    const before = await q(
+      'SELECT sheet_id, COUNT(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[]) GROUP BY sheet_id',
+      [[materialSheetId, runSheetId]],
+    )
+    const handlers = createHandlers(createServices([{
+      FItemID: `off_internal_${TOKEN}`,
+      FNumber: `OFF-CODE-${TOKEN}`,
+      FName: `OFF-NAME-${TOKEN}`,
+    }]), { context })
+    const res = response()
+    await handlers.stockPreparationErpMaterialSourceRun({
+      user: { id: `admin_${TOKEN}`, tenantId: TENANT_ID, roles: ['admin'], permissions: ['integration:admin'] },
+      body: { workspaceId: `workspace_${TOKEN}`, readSourceConfigId: CONFIG_ID, syncRunId: `off_${SYNC_RUN_ID}` },
+      query: {},
+      params: {},
+    }, res)
+    expect(res.statusCode).toBe(200)
+    const data = asRecord(asRecord(res.body).data)
+    expect(data.mode).toBe('dry_run')
+    expect(Object.prototype.hasOwnProperty.call(data, 'autoPersist')).toBe(false)
+    const after = await q(
+      'SELECT sheet_id, COUNT(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[]) GROUP BY sheet_id',
+      [[materialSheetId, runSheetId]],
+    )
+    const countsBySheet = (rows: unknown[]) => Object.fromEntries(
+      (rows as Array<{ sheet_id: string; count: number }>).map((row) => [row.sheet_id, row.count]),
+    )
+    expect(countsBySheet(after.rows)).toEqual(countsBySheet(before.rows))
+  })
+
+  test('flag ON rejects an empty intake with a coarse 422 and zero writes', async () => {
+    process.env[FLAG] = 'true'
+    const before = await q(
+      'SELECT sheet_id, COUNT(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[]) GROUP BY sheet_id',
+      [[materialSheetId, runSheetId]],
+    )
+    const handlers = createHandlers(createServices([]), { context })
+    const emptyRunId = `EMPTY-RUN-SECRET-${TOKEN}`
+    let caught: unknown
+    try {
+      await handlers.stockPreparationErpMaterialSourceRun({
+        user: { id: `admin_${TOKEN}`, tenantId: TENANT_ID, roles: ['admin'], permissions: ['integration:admin'] },
+        body: { workspaceId: `workspace_${TOKEN}`, readSourceConfigId: CONFIG_ID, syncRunId: emptyRunId },
+        query: {},
+        params: {},
+      }, response())
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toMatchObject({ status: 422, code: 'SOURCE_RUN_EMPTY' })
+    const coarseError = caught as { message?: unknown; code?: unknown; details?: unknown }
+    expect(deepIncludes({
+      message: coarseError.message,
+      code: coarseError.code,
+      details: coarseError.details,
+    }, emptyRunId)).toBe(false)
+    const after = await q(
+      'SELECT sheet_id, COUNT(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[]) GROUP BY sheet_id',
+      [[materialSheetId, runSheetId]],
+    )
+    const countsBySheet = (rows: unknown[]) => Object.fromEntries(
+      (rows as Array<{ sheet_id: string; count: number }>).map((row) => [row.sheet_id, row.count]),
+    )
+    expect(countsBySheet(after.rows)).toEqual(countsBySheet(before.rows))
+  })
+})

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -7504,6 +7504,299 @@ async function testStockPreparationSourceRunRejectsUnapprovedConfig() {
   console.log('  testStockPreparationSourceRunRejectsUnapprovedConfig OK')
 }
 
+// ── T3a: ERP source-run server-side auto-persist (flag MULTITABLE_STOCK_PREP_ERP_AUTOPERSIST_ENABLED) ──
+// design-lock: docs/development/stock-preparation-t3a-erp-source-autopersist-design-lock-20260714.md
+const T3A_ERP_CONFIG_ID = 'private_erp_config_t3a_7788'
+const T3A_ERP_SYSTEM_ID = 'private_erp_system_t3a_7788'
+const T3A_ERP_CODE = 'RAW-ERP-CODE-T3A-7788' // FNumber -> erpMaterialCode (a REQUIRED field, so it reaches persist)
+const T3A_ERP_NAME = 'RAW-ERP-NAME-T3A-7788' // FName -> erpMaterialName
+const T3A_ERP_CREDENTIAL = 'PRIVATE-ERP-CRED-T3A-7788'
+const T3A_SOURCE_RUN_PATH = '/api/integration/stock-preparation/mvp/source-runs/erp-materials'
+
+// One recursive "does any string anywhere contain `needle`" scan, applied in BOTH directions of the
+// leak-bait so the positive leg (value present in the internal write sink) proves the scan works before
+// the negative leg (value absent from the HTTP response) is trusted.
+function deepStringIncludes(value, needle) {
+  if (typeof value === 'string') return value.includes(needle)
+  if (Array.isArray(value)) return value.some((entry) => deepStringIncludes(entry, needle))
+  if (value && typeof value === 'object') return Object.values(value).some((entry) => deepStringIncludes(entry, needle))
+  return false
+}
+
+// Faithful in-memory multitable records+provisioning for the internal MVP cache. `resolveFieldIds`
+// returns an IDENTITY map so the real createTargetScopedRecordsApi translation layer runs as a no-op;
+// records are a per-sheet key/value store honoring the frozen key fields. `writes` captures every
+// createRecord data / patchRecord changes — that IS the internal write sink the leak-bait scans.
+function createInMemoryMvpPersistStore() {
+  const sheets = new Map() // sheetId -> Map(recordId -> { id, sheetId, data })
+  const writes = []
+  const findObjectSheetCalls = []
+  let seq = 0
+  const sheetFor = (sheetId) => {
+    if (!sheets.has(sheetId)) sheets.set(sheetId, new Map())
+    return sheets.get(sheetId)
+  }
+  const recordsApi = {
+    async queryRecords({ sheetId, filters } = {}) {
+      const rows = [...sheetFor(sheetId).values()]
+      const predicate = filters && typeof filters === 'object' ? filters : {}
+      return rows
+        .filter((row) => Object.entries(predicate).every(([key, val]) => row.data[key] === val))
+        .map((row) => ({ id: row.id, sheetId: row.sheetId, data: { ...row.data } }))
+    },
+    async createRecord({ sheetId, data } = {}) {
+      seq += 1
+      const id = `rec_t3a_${seq}`
+      sheetFor(sheetId).set(id, { id, sheetId, data: { ...data } })
+      writes.push({ op: 'create', sheetId, data: { ...data } })
+      return { id, sheetId, data: { ...data } }
+    },
+    async patchRecord({ sheetId, recordId, changes } = {}) {
+      const existing = sheetFor(sheetId).get(recordId)
+      if (!existing) throw new Error(`patchRecord: unknown record ${recordId}`)
+      const data = { ...existing.data }
+      for (const [key, val] of Object.entries(changes || {})) {
+        if (val === null) delete data[key]
+        else data[key] = val
+      }
+      sheetFor(sheetId).set(recordId, { id: recordId, sheetId, data })
+      writes.push({ op: 'patch', sheetId, data: { ...changes } })
+      return { id: recordId, sheetId, data: { ...data } }
+    },
+  }
+  const provisioningApi = {
+    async findObjectSheet({ projectId, objectId } = {}) {
+      findObjectSheetCalls.push({ projectId, objectId })
+      return { id: `sheet_${objectId}` }
+    },
+    async resolveFieldIds({ fieldIds } = {}) {
+      return Object.fromEntries((fieldIds || []).map((fieldId) => [fieldId, fieldId]))
+    },
+  }
+  return { recordsApi, provisioningApi, writes, findObjectSheetCalls }
+}
+
+// A records+provisioning facade that COUNTS and THROWS on every call — for the guard/OFF paths, which
+// must reach NO records or provisioning I/O at all.
+function createCountingThrowMvpApis() {
+  const state = { calls: 0 }
+  const bomb = (name) => async () => {
+    state.calls += 1
+    throw new Error(`${name} must not run on this path`)
+  }
+  return {
+    state,
+    recordsApi: { queryRecords: bomb('queryRecords'), createRecord: bomb('createRecord'), patchRecord: bomb('patchRecord') },
+    provisioningApi: { findObjectSheet: bomb('findObjectSheet'), resolveFieldIds: bomb('resolveFieldIds') },
+  }
+}
+
+function t3aNormalizedErpConfig() {
+  const validation = validateReadSourceConfig({
+    version: 1,
+    systemId: T3A_ERP_SYSTEM_ID,
+    requiredKind: 'erp:k3-wise-webapi',
+    object: 'stock-preparation-source',
+    mode: 'list_page',
+    readPath: '/readonly/stock-preparation',
+    readMethod: 'POST',
+    operations: ['read'],
+    containerPaths: ['Rows'],
+    fieldMap: [
+      { source: 'FItemID', target: 'erpMaterialInternalId' },
+      { source: 'FNumber', target: 'erpMaterialCode' },
+      { source: 'FName', target: 'erpMaterialName' },
+    ],
+  })
+  assert.equal(validation.valid, true, JSON.stringify(validation.errors))
+  return validation.normalized
+}
+
+// Approved ERP read-source + a mock K3 adapter emitting ONE material row carrying sentinel business
+// values, mounted with the caller-supplied records/provisioning facade.
+function createErpAutoPersistHarness({ recordsApi, provisioningApi } = {}) {
+  const erpConfig = t3aNormalizedErpConfig()
+  const sourceReadCalls = []
+  const externalWriteCalls = []
+  const { services } = createMockServices({
+    readSourceConfigStore: {
+      async getForRuntime(input) {
+        if (input.id === T3A_ERP_CONFIG_ID) {
+          return { id: T3A_ERP_CONFIG_ID, status: 'approved', systemId: T3A_ERP_SYSTEM_ID, config: erpConfig }
+        }
+        throw new Error('unexpected config reference')
+      },
+    },
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        return { id: input.id, tenantId: input.tenantId, kind: 'erp:k3-wise-webapi', credentials: { password: T3A_ERP_CREDENTIAL }, config: {} }
+      },
+    },
+    adapterRegistry: {
+      createAdapter(system) {
+        return {
+          async read(request) {
+            sourceReadCalls.push({ kind: system.kind, request })
+            const rows = [{ FItemID: 'erp_internal_t3a_1', FNumber: T3A_ERP_CODE, FName: T3A_ERP_NAME }]
+            return { records: rows, raw: { Rows: rows }, metadata: { dataRowCount: 1, dataPageIndex: 1, returnedRecordCount: rows.length } }
+          },
+          async upsert(input) { externalWriteCalls.push(['upsert', input]) },
+          async save(input) { externalWriteCalls.push(['save', input]) },
+          async submit(input) { externalWriteCalls.push(['submit', input]) },
+          async audit(input) { externalWriteCalls.push(['audit', input]) },
+        }
+      },
+    },
+  })
+  const { routes } = mountRoutes(services, { recordsApi, provisioningApi })
+  return { routes, sourceReadCalls, externalWriteCalls }
+}
+
+function withAutoPersistFlag(value, run) {
+  const prev = process.env.MULTITABLE_STOCK_PREP_ERP_AUTOPERSIST_ENABLED
+  if (value === undefined) delete process.env.MULTITABLE_STOCK_PREP_ERP_AUTOPERSIST_ENABLED
+  else process.env.MULTITABLE_STOCK_PREP_ERP_AUTOPERSIST_ENABLED = value
+  return Promise.resolve()
+    .then(run)
+    .finally(() => {
+      if (prev === undefined) delete process.env.MULTITABLE_STOCK_PREP_ERP_AUTOPERSIST_ENABLED
+      else process.env.MULTITABLE_STOCK_PREP_ERP_AUTOPERSIST_ENABLED = prev
+    })
+}
+
+async function testStockPreparationErpSourceRunAutoPersistOn() {
+  await withAutoPersistFlag('true', async () => {
+    const store = createInMemoryMvpPersistStore()
+    const { routes, sourceReadCalls, externalWriteCalls } = createErpAutoPersistHarness({
+      recordsApi: store.recordsApi,
+      provisioningApi: store.provisioningApi,
+    })
+
+    const first = await invoke(routes, 'POST', T3A_SOURCE_RUN_PATH, {
+      user: ADMIN_USER,
+      body: { workspaceId: 'workspace_1', readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'erp_autopersist_run_1' },
+    })
+    // Flag ON: the read gains a real internal write — the read-only projector's fixed mode:'dry_run' and
+    // evidence.internalWriteExecuted:false are OVERRIDDEN, and a landed row makes it 201 (design-lock OD-4).
+    assertOkResponse(first, 201)
+    assert.equal(first.body.data.mode, 'internal_persist')
+    assert.equal(first.body.data.evidence.internalWriteExecuted, true)
+    assert.equal(first.body.data.autoPersist.persisted, true)
+    assert.equal(first.body.data.autoPersist.mode, 'created')
+    assert.equal(first.body.data.autoPersist.created.materials, 1)
+    assert.equal(first.body.data.autoPersist.evidence.valuesFree, true)
+    // externalWrite invariant stays false on the auto-persist path (internal MVP cache only).
+    assert.equal(externalWriteCalls.length, 0, 'auto-persist never calls an external write operation')
+    assert.equal(first.body.data.evidence.externalWriteExecuted, false)
+    assert.equal(first.body.data.evidence.productionWrite, false)
+    assert.equal(first.body.data.evidence.k3SaveSubmitAudit, false)
+
+    // Target derives from the AUTHENTICATED principal only (never the request): the staging project is
+    // `${authTenant}:integration-core`, and provisioning resolves under exactly that project.
+    assert.ok(store.findObjectSheetCalls.length > 0, 'the auto-persist resolves at least one MVP target sheet')
+    for (const call of store.findObjectSheetCalls) {
+      assert.equal(call.projectId, `${ADMIN_USER.tenantId}:integration-core`, 'persist target project derives from the auth tenant')
+    }
+
+    // Leak-bait, BOTH directions with the SAME scan: the sentinel reached the internal write sink (positive
+    // control) yet never appears in the values-free HTTP response.
+    assert.equal(deepStringIncludes(store.writes, T3A_ERP_CODE), true, 'positive control: the ERP code reached the internal write sink')
+    assert.equal(deepStringIncludes(first.body, T3A_ERP_CODE), false, 'values-free: the ERP code never crosses the HTTP response')
+    assert.equal(deepStringIncludes(first.body, T3A_ERP_NAME), false, 'values-free: the ERP name never crosses the HTTP response')
+    assert.equal(deepStringIncludes(first.body, T3A_ERP_CREDENTIAL), false, 'values-free: source credentials never cross the HTTP response')
+    assert.equal(Object.prototype.hasOwnProperty.call(first.body.data, 'intake'), false)
+    assert.equal(Object.prototype.hasOwnProperty.call(first.body.data, 'erpMaterials'), false)
+
+    // Re-run the SAME rows under the SAME syncRunId: upsertErpMaterials patches UNCONDITIONALLY, so the
+    // second run refreshes → still HTTP 201 (there is no "no change → 200" path) (design-lock P2-1).
+    const readsBeforeSecond = sourceReadCalls.length
+    const second = await invoke(routes, 'POST', T3A_SOURCE_RUN_PATH, {
+      user: ADMIN_USER,
+      body: { workspaceId: 'workspace_1', readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'erp_autopersist_run_1' },
+    })
+    assertOkResponse(second, 201)
+    assert.equal(second.body.data.autoPersist.mode, 'refreshed')
+    assert.equal(second.body.data.autoPersist.patched.materials, 1)
+    assert.equal(second.body.data.autoPersist.created.materials, 0)
+    assert.ok(sourceReadCalls.length > readsBeforeSecond, 'the re-run reads the source again')
+  })
+  console.log('  testStockPreparationErpSourceRunAutoPersistOn OK')
+}
+
+async function testStockPreparationErpSourceRunAutoPersistSteering() {
+  await withAutoPersistFlag('true', async () => {
+    // Every steering vector must be rejected with the DEDICATED code BEFORE any source read or records I/O
+    // (guard runs before the body allowlist AND before I/O). projectId is not in the allowlist, so if the
+    // guard ran after normalize a body projectId would 400 with the GENERIC invalid-key code instead.
+    const vectors = [
+      ['body.tenantId', { body: { readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'steer_1', tenantId: 'tenant_evil' } }],
+      ['body.projectId', { body: { readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'steer_2', projectId: 'tenant_evil:integration-core' } }],
+      ['query.tenantId', { body: { readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'steer_3' }, query: { tenantId: 'tenant_evil' } }],
+      ['query.projectId', { body: { readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'steer_4' }, query: { projectId: 'tenant_evil:integration-core' } }],
+    ]
+    for (const [label, reqExtra] of vectors) {
+      const bomb = createCountingThrowMvpApis()
+      const { routes, sourceReadCalls, externalWriteCalls } = createErpAutoPersistHarness({
+        recordsApi: bomb.recordsApi,
+        provisioningApi: bomb.provisioningApi,
+      })
+      const res = await invoke(routes, 'POST', T3A_SOURCE_RUN_PATH, { user: ADMIN_USER, ...reqExtra })
+      assert.equal(res.statusCode, 400, `${label}: steering rejected`)
+      assert.equal(res.body.error.code, 'STOCK_PREPARATION_ERP_AUTOPERSIST_STEERING_NOT_ALLOWED', `${label}: DEDICATED steering code`)
+      assert.equal(sourceReadCalls.length, 0, `${label}: guard fires before any source read`)
+      assert.equal(externalWriteCalls.length, 0, `${label}: guard fires before any external write`)
+      assert.equal(bomb.state.calls, 0, `${label}: guard fires before any records/provisioning I/O`)
+    }
+
+    // workspaceId is a SAME-TENANT scope selector, NOT a steering vector — a request carrying only
+    // workspaceId proceeds past the guard and persists (201), never 400'd.
+    const store = createInMemoryMvpPersistStore()
+    const { routes } = createErpAutoPersistHarness({ recordsApi: store.recordsApi, provisioningApi: store.provisioningApi })
+    const ok = await invoke(routes, 'POST', T3A_SOURCE_RUN_PATH, {
+      user: ADMIN_USER,
+      body: { workspaceId: 'workspace_9', readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'workspace_allowed_1' },
+    })
+    assert.equal(ok.statusCode, 201, 'workspaceId alone is allowed through the steering guard and persists')
+  })
+  console.log('  testStockPreparationErpSourceRunAutoPersistSteering OK')
+}
+
+async function testStockPreparationErpSourceRunAutoPersistOffInert() {
+  await withAutoPersistFlag(undefined, async () => {
+    const bomb = createCountingThrowMvpApis()
+    const { routes, externalWriteCalls } = createErpAutoPersistHarness({ recordsApi: bomb.recordsApi, provisioningApi: bomb.provisioningApi })
+    // Flag OFF (unset): today's read-only behavior byte-for-byte — even a body tenantId is harmless because
+    // the read has no write side effect, so the steering guard is not engaged and no autoPersist is added.
+    const res = await invoke(routes, 'POST', T3A_SOURCE_RUN_PATH, {
+      user: ADMIN_USER,
+      body: { readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'off_inert_1' },
+    })
+    assertOkResponse(res, 200)
+    assert.equal(res.body.data.mode, 'dry_run')
+    assert.equal(res.body.data.evidence.internalWriteExecuted, false)
+    assert.equal(Object.prototype.hasOwnProperty.call(res.body.data, 'autoPersist'), false, 'OFF adds no autoPersist field')
+    assert.equal(bomb.state.calls, 0, 'OFF never touches records/provisioning')
+    assert.equal(externalWriteCalls.length, 0)
+  })
+  console.log('  testStockPreparationErpSourceRunAutoPersistOffInert OK')
+}
+
+async function testStockPreparationErpAutoPersistTenantResolversDiffer() {
+  // Defense-in-depth for OD-2: the auto-persist route derives its tenant from the AUTHENTICATED principal
+  // (resolveAuthUserTenantId), never resolveTenantId — which for an admin honors a request-supplied tenantId.
+  // The steering guard already blocks a request tenantId at the route, so this difference is not route-
+  // observable; this DIRECT unit test proves the two helpers genuinely differ, so choosing the write-safe
+  // one is load-bearing (changing resolveAuthUserTenantId to read the request would red here).
+  const { resolveTenantId, resolveAuthUserTenantId } = httpRoutes.__internals
+  // A request that carries a steering tenantId (query vector) so the difference is observable: an admin's
+  // resolveTenantId READS it; the write-safe resolveAuthUserTenantId must IGNORE it. If the write-safe
+  // helper were changed to consult the request, this assertion would red.
+  const req = { user: { id: 'user_admin', tenantId: 'tenant_1', roles: ['admin'], permissions: ['integration:admin'] }, query: { tenantId: 'tenant_evil' }, params: {} }
+  assert.equal(resolveTenantId(req), 'tenant_evil', 'resolveTenantId honors an admin request tenantId (the steering vector)')
+  assert.equal(resolveAuthUserTenantId(req), 'tenant_1', 'resolveAuthUserTenantId ignores the request and returns the authenticated tenant')
+  console.log('  testStockPreparationErpAutoPersistTenantResolversDiffer OK')
+}
+
 async function main() {
   await testTemplatesCrudRoutes()
   await testUnauthenticatedWriteRequestIsRejected()
@@ -7535,6 +7828,10 @@ async function main() {
   await testStockPreparationReadonlySourceRunRoutes()
   await testStockPreparationSourceRunRejectsUnapprovedConfig()
   await testStockPreparationSourceRunRejectsSystemKindMismatch()
+  await testStockPreparationErpSourceRunAutoPersistOn()
+  await testStockPreparationErpSourceRunAutoPersistSteering()
+  await testStockPreparationErpSourceRunAutoPersistOffInert()
+  await testStockPreparationErpAutoPersistTenantResolversDiffer()
   await testExternalSystemUpsertPreservesObjectSchema()
   await testExternalSystemTestPersistsFailureAndPreservesInactive()
   await testExternalSystemTestClearsErrorToActiveOnSuccess()

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -7733,6 +7733,8 @@ async function testStockPreparationErpSourceRunAutoPersistSteering() {
       ['body.projectId', { body: { readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'steer_2', projectId: 'tenant_evil:integration-core' } }],
       ['query.tenantId', { body: { readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'steer_3' }, query: { tenantId: 'tenant_evil' } }],
       ['query.projectId', { body: { readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'steer_4' }, query: { projectId: 'tenant_evil:integration-core' } }],
+      ['params.tenantId', { body: { readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'steer_5' }, params: { tenantId: 'tenant_evil' } }],
+      ['params.projectId', { body: { readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'steer_6' }, params: { projectId: 'tenant_evil:integration-core' } }],
     ]
     for (const [label, reqExtra] of vectors) {
       const bomb = createCountingThrowMvpApis()
@@ -7769,7 +7771,7 @@ async function testStockPreparationErpSourceRunAutoPersistOffInert() {
     // the read has no write side effect, so the steering guard is not engaged and no autoPersist is added.
     const res = await invoke(routes, 'POST', T3A_SOURCE_RUN_PATH, {
       user: ADMIN_USER,
-      body: { readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'off_inert_1' },
+      body: { tenantId: 'tenant_evil', readSourceConfigId: T3A_ERP_CONFIG_ID, syncRunId: 'off_inert_1' },
     })
     assertOkResponse(res, 200)
     assert.equal(res.body.data.mode, 'dry_run')

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -563,6 +563,13 @@ function resolveIntegrationStagingProjectId(tenantId, requestedProjectId) {
   return `${tenantId}:integration-core`
 }
 
+// T3a (OD-1): the ERP source-run auto-persist gate. Default OFF (staged) — a truthy value only when the
+// env var is EXACTLY 'true' (trimmed, case-insensitive), same idiom as the other MULTITABLE_ gates. Off
+// keeps the source-run read-only; on wires its intake into T2 persist within the same request.
+function stockPreparationErpAutoPersistEnabled() {
+  return String(process.env.MULTITABLE_STOCK_PREP_ERP_AUTOPERSIST_ENABLED ?? '').trim().toLowerCase() === 'true'
+}
+
 function requestBody(req) {
   return req.body && typeof req.body === 'object' ? req.body : {}
 }
@@ -3883,7 +3890,13 @@ function createHandlers(services, options = {}) {
         VALID_STOCK_PREPARATION_ERP_SOURCE_RUN_REQUEST_KEYS,
         'STOCK_PREPARATION_ERP_SOURCE_RUN_REQUEST_INVALID',
       )
-      const tenantId = resolveTenantId(req, input)
+      // T3a OD-2 (security): while this route is read-only, its request-steerable tenant resolution is a
+      // deferred GHSA step-2 question. When the T3a auto-persist flag is ON the read gains a WRITE side
+      // effect, so the tenant MUST come from the AUTHENTICATED principal (resolveTenantId would honor a
+      // request tenantId for admins) — the auto-persist cannot be steered to another tenant's cache. Flag
+      // OFF keeps today's read-only behavior byte-for-byte (RC-0 safe).
+      const autoPersistEnabled = stockPreparationErpAutoPersistEnabled()
+      const tenantId = autoPersistEnabled ? resolveAuthUserTenantId(req) : resolveTenantId(req, input)
       const sourceRuntime = await loadStockPreparationReadonlySource(
         req,
         { ...input, tenantId },
@@ -3896,7 +3909,27 @@ function createHandlers(services, options = {}) {
         actor,
         ...sourceRuntime,
       })
-      return sendOk(res, publicReadonlySourceRunResult(result))
+      // T3a OD-1 (default-OFF staged flag): feed the source-run's INTERNAL intake.erpMaterials straight
+      // into T2's persist WITHIN THIS REQUEST — the normalized business rows never cross HTTP (public
+      // result stays values-free). Boundary: internal 9 MVP tables via T2's scoped records API only;
+      // externalWrite stays false (no K3 Save / ERP auto-create); no new endpoint; targetProjectId derived
+      // from the auth tenant with NO request projectId (identical to the T2 route).
+      let autoPersist = null
+      if (autoPersistEnabled) {
+        const targetProjectId = resolveIntegrationStagingProjectId(tenantId, undefined)
+        const persisted = await persistStockPreparationErpMaterialSync({
+          context,
+          permission: 'admin',
+          recordsApi: getMultitableRecordsApi(),
+          provisioning: getMultitableProvisioning(),
+          targetProjectId,
+          syncRunId: input.syncRunId,
+          erpMaterials: result.intake.erpMaterials,
+        })
+        // persisted is already the T2 values-free evidence (counts / modes / field-key names only).
+        autoPersist = persisted
+      }
+      return sendOk(res, { ...publicReadonlySourceRunResult(result), autoPersist })
     },
 
     // T2: COMMIT already-normalized ERP/K3 material-master rows into the internal erp_material_master

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -570,6 +570,22 @@ function stockPreparationErpAutoPersistEnabled() {
   return String(process.env.MULTITABLE_STOCK_PREP_ERP_AUTOPERSIST_ENABLED ?? '').trim().toLowerCase() === 'true'
 }
 
+// T3a OD-2: with auto-persist ON the ERP source-run has a write side-effect, so an explicit request
+// tenant/projectId (a steering vector) is rejected FAIL-CLOSED before any I/O — same discipline as
+// assertNoRequestBaseId. workspaceId is a SAME-TENANT scope selector (it never changes the auth-derived
+// tenant or the write target) and is deliberately NOT rejected.
+function assertStockPreparationErpAutoPersistNoSteering(req) {
+  const steers = (src) =>
+    src && (`${src.tenantId ?? ''}`.trim() !== '' || `${src.projectId ?? ''}`.trim() !== '')
+  if (steers(requestBody(req)) || steers(requestQuery(req)) || steers(requestParams(req))) {
+    throw new HttpRouteError(
+      400,
+      'STOCK_PREPARATION_ERP_AUTOPERSIST_STEERING_NOT_ALLOWED',
+      'an explicit tenantId/projectId is not allowed on the auto-persisting ERP source-run; the tenant and cache target are derived from the authenticated principal',
+    )
+  }
+}
+
 function requestBody(req) {
   return req.body && typeof req.body === 'object' ? req.body : {}
 }
@@ -3896,6 +3912,9 @@ function createHandlers(services, options = {}) {
       // request tenantId for admins) — the auto-persist cannot be steered to another tenant's cache. Flag
       // OFF keeps today's read-only behavior byte-for-byte (RC-0 safe).
       const autoPersistEnabled = stockPreparationErpAutoPersistEnabled()
+      // T3a OD-2: when auto-persist is ON the read gains a write side-effect, so reject an explicit request
+      // tenant/projectId FAIL-CLOSED BEFORE any I/O (a steered read would write into the wrong cache).
+      if (autoPersistEnabled) assertStockPreparationErpAutoPersistNoSteering(req)
       const tenantId = autoPersistEnabled ? resolveAuthUserTenantId(req) : resolveTenantId(req, input)
       const sourceRuntime = await loadStockPreparationReadonlySource(
         req,
@@ -3903,33 +3922,43 @@ function createHandlers(services, options = {}) {
         'STOCK_PREPARATION_ERP_SOURCE_RUN_REQUEST_INVALID',
       )
       const actor = user.id || user.email
+      // An empty intake (zero mapped rows) already threw SOURCE_RUN_EMPTY (422) inside here via
+      // assertIntakeReady — so past this line there is always >= 1 mapped row.
       const result = await runErpMaterialReadonlySource({
         permission: 'admin',
         syncRunId: input.syncRunId,
         actor,
         ...sourceRuntime,
       })
-      // T3a OD-1 (default-OFF staged flag): feed the source-run's INTERNAL intake.erpMaterials straight
-      // into T2's persist WITHIN THIS REQUEST — the normalized business rows never cross HTTP (public
-      // result stays values-free). Boundary: internal 9 MVP tables via T2's scoped records API only;
-      // externalWrite stays false (no K3 Save / ERP auto-create); no new endpoint; targetProjectId derived
-      // from the auth tenant with NO request projectId (identical to the T2 route).
-      let autoPersist = null
-      if (autoPersistEnabled) {
-        const targetProjectId = resolveIntegrationStagingProjectId(tenantId, undefined)
-        const persisted = await persistStockPreparationErpMaterialSync({
-          context,
-          permission: 'admin',
-          recordsApi: getMultitableRecordsApi(),
-          provisioning: getMultitableProvisioning(),
-          targetProjectId,
-          syncRunId: input.syncRunId,
-          erpMaterials: result.intake.erpMaterials,
-        })
-        // persisted is already the T2 values-free evidence (counts / modes / field-key names only).
-        autoPersist = persisted
+      const readProjection = publicReadonlySourceRunResult(result)
+      if (!autoPersistEnabled) {
+        // Flag OFF: the response is BYTE-FOR-BYTE today's read-only projection — no autoPersist field added.
+        return sendOk(res, readProjection)
       }
-      return sendOk(res, { ...publicReadonlySourceRunResult(result), autoPersist })
+      // Flag ON (OD-1): feed the source-run's INTERNAL intake.erpMaterials straight into T2's persist WITHIN
+      // THIS REQUEST — the normalized business rows never cross HTTP. Boundary: internal MVP tables via T2's
+      // scoped records API only; externalWrite stays false; targetProjectId from the auth tenant, no request
+      // projectId (identical to the T2 route).
+      const targetProjectId = resolveIntegrationStagingProjectId(tenantId, undefined)
+      const autoPersist = await persistStockPreparationErpMaterialSync({
+        context,
+        permission: 'admin',
+        recordsApi: getMultitableRecordsApi(),
+        provisioning: getMultitableProvisioning(),
+        targetProjectId,
+        syncRunId: input.syncRunId,
+        erpMaterials: result.intake.erpMaterials,
+      })
+      // The read-only projector fixes mode:'dry_run' + evidence.internalWriteExecuted:false — BOTH false now
+      // that a real internal write happened. Override them so the response can never report "not written".
+      // `autoPersist` is T2's values-free evidence (persisted/mode/created/patched/skipped/runStatus/
+      // evidence.targets — counts/modes/statuses/objectIds only, no raw rows). 201 iff a row actually landed.
+      return sendOk(res, {
+        ...readProjection,
+        mode: 'internal_persist',
+        evidence: { ...readProjection.evidence, internalWriteExecuted: true },
+        autoPersist,
+      }, autoPersist.persisted ? 201 : 200)
     },
 
     // T2: COMMIT already-normalized ERP/K3 material-master rows into the internal erp_material_master

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -3901,20 +3901,22 @@ function createHandlers(services, options = {}) {
     // internal or external write and no K3 Save/Submit/Audit path.
     async stockPreparationErpMaterialSourceRun(req, res) {
       const user = requireAccess(req, 'admin')
-      const input = normalizeStockPreparationSourceRunBody(
-        requestBody(req),
-        VALID_STOCK_PREPARATION_ERP_SOURCE_RUN_REQUEST_KEYS,
-        'STOCK_PREPARATION_ERP_SOURCE_RUN_REQUEST_INVALID',
-      )
       // T3a OD-2 (security): while this route is read-only, its request-steerable tenant resolution is a
       // deferred GHSA step-2 question. When the T3a auto-persist flag is ON the read gains a WRITE side
       // effect, so the tenant MUST come from the AUTHENTICATED principal (resolveTenantId would honor a
       // request tenantId for admins) — the auto-persist cannot be steered to another tenant's cache. Flag
       // OFF keeps today's read-only behavior byte-for-byte (RC-0 safe).
       const autoPersistEnabled = stockPreparationErpAutoPersistEnabled()
-      // T3a OD-2: when auto-persist is ON the read gains a write side-effect, so reject an explicit request
-      // tenant/projectId FAIL-CLOSED BEFORE any I/O (a steered read would write into the wrong cache).
+      // Reject an explicit request tenant/projectId FAIL-CLOSED BEFORE the body allowlist AND any I/O, so a
+      // steering attempt always gets the DEDICATED steering code — projectId is not in the source-run
+      // allowlist, so if this ran after normalize a body projectId would 400 with the generic invalid-key
+      // code instead of the steering code.
       if (autoPersistEnabled) assertStockPreparationErpAutoPersistNoSteering(req)
+      const input = normalizeStockPreparationSourceRunBody(
+        requestBody(req),
+        VALID_STOCK_PREPARATION_ERP_SOURCE_RUN_REQUEST_KEYS,
+        'STOCK_PREPARATION_ERP_SOURCE_RUN_REQUEST_INVALID',
+      )
       const tenantId = autoPersistEnabled ? resolveAuthUserTenantId(req) : resolveTenantId(req, input)
       const sourceRuntime = await loadStockPreparationReadonlySource(
         req,

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -4868,6 +4868,7 @@ module.exports = {
     hasPermission,
     requireAccess,
     resolveTenantId,
+    resolveAuthUserTenantId,
     scopedInput,
     sendError,
     inferHttpStatus,


### PR DESCRIPTION
## Summary

- wire the existing approved ERP source-run intake directly into the existing T2 internal material-cache persist path
- keep `MULTITABLE_STOCK_PREP_ERP_AUTOPERSIST_ENABLED` default-OFF; OFF preserves the existing read-only response and performs no internal write
- when ON, derive the tenant and staging target from the authenticated principal and reject body/query/params tenant or project steering before normalization and I/O
- return only values-free persist evidence; no ERP rows, material values, source credentials, or raw sync-run id cross HTTP

## Boundary

- internal MetaSheet MVP tables only (`erp_material_master` and run ledger)
- no new endpoint and no external PLM/K3/ERP write path
- K3 Save/Submit/Audit remains false
- staged upsert-only cache semantics; this does not claim authoritative full reconciliation

Refs #4263.

## Verification

- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `DATABASE_URL=postgresql://postgres@localhost:5432/metasheet_test METASHEET_REAL_DB_TEST_STEP=1 vitest ... stock-preparation-t3a-erp-autopersist-realdb.test.ts --reporter=verbose` (3/3)
- backend `tsc --noEmit`
- real-DB suite provisions the frozen targets, seeds real select metadata, discovers physical ids from `meta_fields`, exercises the real handler/provisioning/records APIs, proves 201 create + 201 refresh with no duplicate rows, OFF zero-write, empty 422 zero-write, and values-free responses
- the new real-DB file is explicitly registered in the required `plugin-tests.yml` allowlist

## Load-bearing mutations

- bypass the ON persist branch -> real-DB ON test red
- bypass logical-to-physical field translation -> real records reject logical ids
- inject ERP rows into the response -> leak-bait red
- remove params steering from the guard -> params test red

## Review status

Draft pending fresh GitHub CI and independent security review. The feature flag remains default-OFF.