### PR TITLE
test(multitable): comment-inbox name projection — real-DB viewName + null-entity symmetry (P3 follow-up)

### DIFF
--- a/packages/core-backend/tests/integration/multitable-permmatrix-b4-g8-comments-visibility-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-permmatrix-b4-g8-comments-visibility-realdb.test.ts
@@ -296,6 +296,18 @@ describeIfDatabase('F1 — comments respect row-level read deny (real DB)', () =
  * a row this endpoint already serves). It intentionally does NOT ship a row-selection/exclusion
  * golden for this endpoint — that would be asserting a property of pre-existing, unmodified query
  * logic that is out of scope for this PR to characterize.
+ *
+ * P3 follow-up (docket #71, off PR #4330's gate): the original golden above only pinned
+ * baseName/sheetName/fieldName in real DB — `viewName` (the byte-twin of the already-tested `view_id`
+ * correlated subquery) was mock-only (`comment-flow.test.ts` line ~732), and so was the
+ * null/deleted-entity name path (a comment whose joined entity is absent must still return the row,
+ * with the name null — `comment-flow.test.ts` line ~762). Both gaps are closed below:
+ *   - P3-1: a real `meta_views` row on `sheetId` so `viewId`/`viewName` resolve non-null, asserted as a
+ *     twin pair (same id the pre-existing `view_id` subquery already returns, plus its `name`).
+ *   - P3-2a: a record-level comment (`field_id` NULL) on the SAME sheet — the `meta_fields` LEFT JOIN's
+ *     null-key case — proves the row is not dropped and `fieldName` is explicit `null`.
+ *   - P3-2b: a comment on a SECOND sheet that has NO `meta_views` row at all — the view correlated
+ *     subquery's zero-row case — proves the row is not dropped and `viewId`/`viewName` are both `null`.
  */
 describeIfDatabase('G-10 — comment inbox entity-name projection (real DB)', () => {
   const ts = Date.now()
@@ -310,6 +322,21 @@ describeIfDatabase('G-10 — comment inbox entity-name projection (real DB)', ()
   const sheetName = 'G10 Inbox Sheet'
   const fieldName = 'G10 Status Field'
 
+  // P3-1 (docket #71): a real view on `sheetId` so viewId/viewName resolve non-null.
+  const viewId = `view_g10_inbox_${ts}`
+  const viewName = 'G10 Inbox View'
+
+  // P3-2a (docket #71): a record-level comment (field_id NULL, not field-scoped) on the SAME sheet —
+  // proves the meta_fields LEFT JOIN is null-safe (fieldName: null) and does not drop the row.
+  const recordLevelCommentId = `cmt_g10_recordlevel_${ts}`
+
+  // P3-2b (docket #71): a second sheet with NO meta_views row at all — proves the view correlated
+  // scalar subquery is null-safe (viewId/viewName: null) and does not drop the row either.
+  const noViewSheetId = `sheet_g10_inbox_noview_${ts}`
+  const noViewFieldId = `fld_g10_noview_status_${ts}`
+  const noViewRecordId = `rec_g10_inbox_noview_${ts}`
+  const noViewCommentId = `cmt_g10_noview_${ts}`
+
   beforeAll(async () => {
     await q("INSERT INTO users (id, password_hash) VALUES ($1,'x'), ($2,'x') ON CONFLICT (id) DO NOTHING", [author, viewer])
     await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [baseId, baseName])
@@ -321,19 +348,46 @@ describeIfDatabase('G-10 — comment inbox entity-name projection (real DB)', ()
        VALUES ($1,$2,$3,$4,$2,$3,$4,$5,$6,$7::jsonb, now(), now())`,
       [viewerCommentId, sheetId, recordId, fieldId, author, 'G10_INBOX_VIEWER_COMMENT', JSON.stringify([viewer])],
     )
+
+    // P3-1: give the sheet exactly one view — the view_id/view_name subquery orders by
+    // (created_at asc, id asc) limit 1, so a single view is unambiguously "the" resolved view.
+    await q('INSERT INTO meta_views (id, sheet_id, name, type) VALUES ($1,$2,$3,$4)', [viewId, sheetId, viewName, 'grid'])
+
+    // P3-2a: record-level comment — field_id/target_field_id both NULL (both columns are nullable;
+    // only target_id/container_id are NOT NULL, and those are still populated).
+    await q(
+      `INSERT INTO meta_comments (id, spreadsheet_id, row_id, field_id, container_id, target_id, target_field_id, author_id, content, mentions, created_at, updated_at)
+       VALUES ($1,$2,$3,NULL,$2,$3,NULL,$4,$5,$6::jsonb, now(), now())`,
+      [recordLevelCommentId, sheetId, recordId, author, 'G10_INBOX_RECORD_LEVEL_COMMENT', JSON.stringify([viewer])],
+    )
+
+    // P3-2b: a wholly separate sheet, with a field-scoped comment, but zero meta_views rows.
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [noViewSheetId, baseId, 'G10 Inbox Sheet (no view)'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [noViewFieldId, noViewSheetId, 'NoView Status', 'string', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [noViewRecordId, noViewSheetId, JSON.stringify({ [noViewFieldId]: 'x' })])
+    await q(
+      `INSERT INTO meta_comments (id, spreadsheet_id, row_id, field_id, container_id, target_id, target_field_id, author_id, content, mentions, created_at, updated_at)
+       VALUES ($1,$2,$3,$4,$2,$3,$4,$5,$6,$7::jsonb, now(), now())`,
+      [noViewCommentId, noViewSheetId, noViewRecordId, noViewFieldId, author, 'G10_INBOX_NOVIEW_COMMENT', JSON.stringify([viewer])],
+    )
   })
 
   afterAll(async () => {
-    await q('DELETE FROM meta_comment_reads WHERE comment_id = $1', [viewerCommentId]).catch(() => {})
+    await q('DELETE FROM meta_comment_reads WHERE comment_id = ANY($1::text[])', [[viewerCommentId, recordLevelCommentId, noViewCommentId]]).catch(() => {})
     await q('DELETE FROM meta_comments WHERE spreadsheet_id = $1', [sheetId]).catch(() => {})
+    await q('DELETE FROM meta_comments WHERE spreadsheet_id = $1', [noViewSheetId]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [sheetId]).catch(() => {})
     await q('DELETE FROM meta_records WHERE sheet_id = $1', [sheetId]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [noViewSheetId]).catch(() => {})
     await q('DELETE FROM meta_fields WHERE sheet_id = $1', [sheetId]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [noViewSheetId]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [sheetId]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [noViewSheetId]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [baseId]).catch(() => {})
     await q('DELETE FROM users WHERE id = ANY($1::text[])', [[author, viewer]]).catch(() => {})
   })
 
-  test('inbox item for a comment authored by someone else carries the projected base/sheet/field display names, ids unchanged', async () => {
+  test('inbox item for a comment authored by someone else carries the projected base/sheet/view/field display names, ids unchanged (P3-1: viewName twin-consistent with viewId)', async () => {
     const app = buildApp(viewer, ['comments:read'])
     const res = await request(app).get('/api/comments/inbox')
     expect(res.status).toBe(200)
@@ -343,8 +397,34 @@ describeIfDatabase('G-10 — comment inbox entity-name projection (real DB)', ()
     expect(item?.baseId).toBe(baseId)
     expect(item?.sheetId).toBe(sheetId)
     expect(item?.fieldId).toBe(fieldId)
+    expect(item?.viewId).toBe(viewId)
     expect(item?.baseName).toBe(baseName)
     expect(item?.sheetName).toBe(sheetName)
     expect(item?.fieldName).toBe(fieldName)
+    // P3-1 (docket #71): viewName is the byte-twin of the already-tested view_id correlated
+    // subquery — same WHERE/ORDER BY, just the `name` column instead of `id`. Pin both together.
+    expect(item?.viewName).toBe(viewName)
+  })
+
+  test('P3-2a (docket #71): a record-level comment (field_id NULL) still appears in the inbox, with fieldName null — meta_fields LEFT JOIN null-safety, not an INNER-join row drop', async () => {
+    const app = buildApp(viewer, ['comments:read'])
+    const res = await request(app).get('/api/comments/inbox')
+    expect(res.status).toBe(200)
+    const items = res.body.data.items as Array<Record<string, unknown>>
+    const item = items.find((i) => i.id === recordLevelCommentId)
+    expect(item).toBeTruthy() // row not dropped despite the null field_id join key
+    expect(item?.fieldId).toBeUndefined() // falsy field_id serializes as absent (mapRowToComment's `|| undefined`)
+    expect(item?.fieldName).toBeNull() // explicit null, not silently omitted
+  })
+
+  test('P3-2b (docket #71): a comment on a sheet with NO views still appears in the inbox, with viewId/viewName both null — the view correlated subquery is null-safe, not a row-dropping join', async () => {
+    const app = buildApp(viewer, ['comments:read'])
+    const res = await request(app).get('/api/comments/inbox')
+    expect(res.status).toBe(200)
+    const items = res.body.data.items as Array<Record<string, unknown>>
+    const item = items.find((i) => i.id === noViewCommentId)
+    expect(item).toBeTruthy() // row not dropped despite the sheet having zero meta_views rows
+    expect(item?.viewId).toBeNull()
+    expect(item?.viewName).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

PR #4330's gate (merged `16f89918e`) added server-projected display names to
`CommentService.getInbox()` (`baseName`/`sheetName`/`fieldName`/`viewName`). The
gate found the real-DB golden pinned `baseName`/`sheetName`/`fieldName` but left
two non-blocking P3 coverage gaps, both mock-only:

- **P3-1**: `viewName` had NO real-DB assertion. It's the byte-twin of the
  already-tested `view_id` correlated subquery (same WHERE/ORDER BY, `name`
  column instead of `id`) — never pinned against a real Postgres.
- **P3-2**: the null/deleted-entity name path (a comment whose sheet/base/field/
  view is null or absent → row still returns, name null, row not dropped) was
  also mock-only.

This PR closes both gaps by extending the already-wired real-DB golden — no new
two-point wiring needed.

## What changed

`packages/core-backend/tests/integration/multitable-permmatrix-b4-g8-comments-visibility-realdb.test.ts`,
extending the existing `G-10 — comment inbox entity-name projection (real DB)`
`describeIfDatabase` block:

- **P3-1**: added a real `meta_views` row on the fixture sheet. Extended the
  existing projection test to additionally assert `item.viewId === viewId` and
  `item.viewName === viewName` — twin-consistent, same as the pre-existing
  `viewId` assertion, plus the new `viewName` one.
- **P3-2a**: added a second comment on the SAME sheet with `field_id: NULL`
  (record-level, not field-scoped). New test asserts the row is present
  (`.find()` returns truthy) and `fieldName` is explicit `null` — proving the
  `meta_fields` LEFT JOIN is null-safe, not an INNER-join row drop.
- **P3-2b**: added a second sheet with a field-scoped comment but ZERO
  `meta_views` rows. New test asserts the row is present and `viewId`/`viewName`
  are both `null` — proving the view correlated scalar subquery is null-safe
  too.

No source changes — `CommentService.ts` is untouched (confirmed via `diff`
against a pre-edit backup after mutation testing, see below).

## Mutation-proof (cp-backed, restored after each leg)

1. **P3-1 leg**: replaced the `view_name` subquery's `select v.name` with
   `select NULL::text` (grep-confirmed landed at `CommentService.ts:607` before
   running). Re-ran the G-10 block: **only** the P3-1 `viewName` assertion
   failed (`expected null to be 'G10 Inbox View'`); all 11 other tests in the
   file — including the pre-existing `viewId` assertion and both P3-2 tests —
   stayed green. Restored via `cp` from backup; `diff` confirmed byte-identical
   to the pre-mutation original.

2. **P3-2a leg**: flipped `.leftJoin('meta_fields as f', ...)` to
   `.innerJoin(...)` (grep-confirmed landed before running). Re-ran the G-10
   block: **only** the P3-2a "row still present" assertion failed (`expected
   undefined to be truthy` — the null-field-id row was silently dropped by the
   INNER JOIN); P3-1 and P3-2b stayed green. Restored via `cp`; `diff` confirmed
   byte-identical.

Each mutation reds exactly the assertion it targets and nothing else —
confirms precision, not just "something broke."

## Real-DB run (fresh Postgres 14, docker, trust auth)

Fresh `metasheet_test` DB, `db:migrate` with CI's exact `MIGRATION_EXCLUDE`
(`008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql`),
`METASHEET_REAL_DB_TEST_STEP=1`, run twice (idempotent, zero errors on replay).

- Target spec + comment-realdb neighbors (`multitable-oapi1-comments-read-realdb.test.ts`,
  `multitable-oapi2a-comments-write-realdb.test.ts`): **25/25 passed**, including
  all 3 G-10 tests (1 extended + 2 new).
- Broader neighbor sweep also including `comment-reactions.api.test.ts` and
  `comments.api.test.ts`: one pre-existing, environment-level flake
  (`comments.api.test.ts > broadcasts global inbox activity for comment create
  and resolve`, `record join timeout` on a socket.io ephemeral-port test) —
  confirmed reproducible on a **clean, unmodified `origin/main`** worktree
  against the same DB (same error, same line), so it is not caused by this PR.
  Not touched here; out of scope for this P3 follow-up.

## Verification

- `pnpm --filter @metasheet/core-backend run type-check` — clean, no errors.
- Full no-DB unit run (`CI=true pnpm exec vitest run`, no `DATABASE_URL`):
  **472 files / 6537 tests passed**, 176 files / 1493 tests skipped (expected —
  DB-gated `describeIfDatabase` blocks skip without `DATABASE_URL`). Includes
  the mock-only `comment-flow.test.ts` (47/47 passed), whose `viewName` and
  `fieldName`-null tests remain the mock-side twins of the two real-DB
  assertions added here.

## Not in scope

- No merge/arm — this is a test-hardening PR per the docket; leaving it for the
  coordinator to gate.
- The pre-existing `comments.api.test.ts` socket.io flake noted above is
  unrelated and untouched.