### PR TITLE
W0-1 L4cov — univer-meta/records/auto-number writer fence coverage (DRAFT)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -561,6 +561,7 @@ jobs:
             tests/integration/stock-preparation-t3b-replay-hardening-realdb.test.ts \
             tests/integration/stock-preparation-t3b-plm-autopersist-realdb.test.ts \
             tests/integration/multitable-l4-canonical-fence-realdb.test.ts \
+            tests/integration/multitable-l4cov-univer-meta-writers-realdb.test.ts \
             --reporter=dot
 
       - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start + A/E/B/D/G cross-lane acceptance + dept_head sync-plumbing carry-forward + continuous_managers chain walk + common template presets + DT-OPS-01 deprovision selection goldens)

--- a/packages/core-backend/src/multitable/auto-number-service.ts
+++ b/packages/core-backend/src/multitable/auto-number-service.ts
@@ -1,5 +1,9 @@
 import { normalizeAutoNumberProperty } from './auto-number-property'
-import { acquireCanonicalSheetFence } from './canonical-sheet-fence'
+import {
+  acquireCanonicalSheetFence,
+  assertNoActiveWriterBlock,
+  isWriterFenceEnabled,
+} from './canonical-sheet-fence'
 import type { MultitableField } from './field-codecs'
 
 export type AutoNumberQuery = (
@@ -81,7 +85,16 @@ export async function backfillAutoNumberField(
   opts?: { overwrite?: boolean },
 ): Promise<BackfillAutoNumberFieldResult> {
   const config = normalizeAutoNumberProperty(property)
+  // W0-1 L4cov (close the auto-number-backfill PARTIAL gap — L4 map's auto-number-service.ts:84). The canonical
+  // sheet fence stays UNCONDITIONAL: it is the CREATE-FIELD-backfill-vs-record-create serialization lock (see
+  // the concurrency-safety note below), so gating it behind the L4 flag would regress that guarantee when the
+  // flag is off; the module's flag-off-parity contract also keeps backfill an unconditional fence caller. The
+  // durable recovery-block check is then flag-gated (flag-off ⇒ byte-identical: fence taken, block ignored) —
+  // with the flag ON this is exactly `fenceWriterEntry`'s fence-then-check, so a backfill that begins while a
+  // recovery holds an `applying`/`fencing`/`paused_retryable` block on this sheet refuses instead of slipping
+  // past it (the gap GX2 exposed).
   await acquireCanonicalSheetFence(query, sheetId)
+  if (isWriterFenceEnabled()) await assertNoActiveWriterBlock(query, sheetId)
   await acquireFieldLock(query, sheetId, fieldId)
 
   // Single UPDATE assigns sequential values to all eligible records via

--- a/packages/core-backend/src/multitable/records.ts
+++ b/packages/core-backend/src/multitable/records.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from 'crypto'
 import { recordRecordRevision } from './record-history-service'
-import { fenceWriterEntry } from './canonical-sheet-fence'
+import {
+  assertNoActiveWriterBlock,
+  fenceWriterEntry,
+  isWriterFenceEnabled,
+} from './canonical-sheet-fence'
 
 import {
   acquireAutoNumberSheetWriteLock,
@@ -589,7 +593,18 @@ export async function createRecord(
   input: CreateMultitableRecordInput,
 ): Promise<CreatedMultitableRecord> {
   const query = input.query
+  // W0-1 L4cov (close the plugin-create PARTIAL gap — L4 map's records.ts:592). The sheet-write fence is
+  // acquired UNCONDITIONALLY: it predates L4 as the auto-number allocation-serialization lock (it serialises
+  // record-create against CREATE-FIELD auto-number backfill — see auto-number-service.ts), so gating it behind
+  // the L4 flag would REGRESS auto-number correctness when the flag is off, and the module's flag-off-parity
+  // contract explicitly keeps plugin-create as an unconditional `acquireCanonicalSheetFence` caller. We then add
+  // — flag-gated, so flag-off stays byte-identical — the durable recovery-block check `fenceWriterEntry` runs:
+  // if a recovery holds a durable `{fencing,applying,paused_retryable}` block on this sheet, refuse with
+  // `SheetWriterBlockedError`. Net effect with the flag ON is exactly `fenceWriterEntry` (fence-then-check); the
+  // split (vs. the sibling plugin patchRecord above, which uses `fenceWriterEntry` directly) exists ONLY to
+  // preserve the pre-existing unconditional fence.
   await acquireAutoNumberSheetWriteLock(query, input.sheetId)
+  if (isWriterFenceEnabled()) await assertNoActiveWriterBlock(query, input.sheetId)
   const { fields } = await loadSheetAndFields(query, input.sheetId)
 
   const { patch, linkUpdates } = await buildNormalizedPatch(query, fields, input.data)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -8881,9 +8881,10 @@ export function univerMetaRouter(): Router {
         if (confirm.trim() !== 'uncreate') return res.status(400).json({ ok: false, error: { code: 'CONFIRM_REQUIRED', message: 'Type "uncreate" to confirm dropping the created entity.' } })
         const failure = await pool.transaction(async ({ query }): Promise<{ status: number; code: string; message: string } | null> => {
           // W0-1 L4cov (fence the config-restore-execute record writes — un-create branch). `dropFieldCascade`
-          // below strips the dropped field's key from EVERY record of this sheet (`UPDATE meta_records SET
-          // data = data - $1`), so this txn is a `meta_records` writer and must converge onto the canonical
-          // fence: acquire it first, then refuse (409 in the outer catch) if a recovery holds a durable block.
+          // below strips the dropped field's key from EVERY record of this sheet's `data` (a whole-sheet
+          // record-data write via the shared field-drop cascade helper), so this txn is a record writer and
+          // must converge onto the canonical fence: acquire it first, then refuse (409 in the outer catch) if
+          // a recovery holds a durable block. (dropFieldCascade carries its own revision disposition.)
           // Flag-off ⇒ no-op / byte-identical.
           await fenceWriterEntry(query, sheetId)
           let fieldRow: any = null

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -232,6 +232,7 @@ import {
 } from '../multitable/auto-number-service'
 import {
   acquireCanonicalSheetFence,
+  assertNoActiveWriterBlock,
   claimDurableWriterBlock,
   fenceWriterEntry,
   isWriterFenceEnabled,
@@ -8879,6 +8880,12 @@ export function univerMetaRouter(): Router {
         const confirm = typeof req.body?.confirm === 'string' ? req.body.confirm : ''
         if (confirm.trim() !== 'uncreate') return res.status(400).json({ ok: false, error: { code: 'CONFIRM_REQUIRED', message: 'Type "uncreate" to confirm dropping the created entity.' } })
         const failure = await pool.transaction(async ({ query }): Promise<{ status: number; code: string; message: string } | null> => {
+          // W0-1 L4cov (fence the config-restore-execute record writes — un-create branch). `dropFieldCascade`
+          // below strips the dropped field's key from EVERY record of this sheet (`UPDATE meta_records SET
+          // data = data - $1`), so this txn is a `meta_records` writer and must converge onto the canonical
+          // fence: acquire it first, then refuse (409 in the outer catch) if a recovery holds a durable block.
+          // Flag-off ⇒ no-op / byte-identical.
+          await fenceWriterEntry(query, sheetId)
           let fieldRow: any = null
           let viewRow: any = null
           if (rev.entity_type === 'field') {
@@ -8937,6 +8944,11 @@ export function univerMetaRouter(): Router {
         let failure: { status: number; code: string; message: string } | null = null
         try {
           failure = await pool.transaction(async ({ query }): Promise<{ status: number; code: string; message: string } | null> => {
+            // W0-1 L4cov (fence the config-restore-execute record writes — undelete branch). For a field
+            // undelete, `recreateFieldFromConfig` below re-materializes the field's cells across this sheet's
+            // `meta_records`, so this txn is a record writer: take the canonical fence first, then refuse (409
+            // in the outer catch) under an active recovery block. Flag-off ⇒ no-op / byte-identical.
+            await fenceWriterEntry(query, sheetId)
             // U4-L5 id-occupied check (FOR UPDATE) — also the idempotency guard: undelete when the entity already exists → reject.
             const table = rev.entity_type === 'field' ? 'meta_fields' : 'meta_views'
             const occ = (await query(`SELECT 1 FROM ${table} WHERE id = $1 FOR UPDATE`, [rev.entity_id])) as any
@@ -9034,6 +9046,14 @@ export function univerMetaRouter(): Router {
           const lossyRevisionId = randomUUID() // pre-generated: the 4c-2 pre-image anchors to THIS revert's revision
           let lossyExecuteSummary: LossSummary = { unchanged: 0, coerced: 0, dropped: 0 }
           const failure = await pool.transaction(async ({ query }): Promise<{ status: number; code: string; message: string } | null> => {
+            // W0-1 L4cov (fence the config-restore-execute record writes — lossy retype-revert branch). This is
+            // the highest-value config-restore fence: `applyLossyRetypeCellRewrite` below rewrites the coerced/
+            // dropped cells AND emits one `recordRecordRevision` per changed cell (C5 history completeness), so
+            // it ALLOCATES `seq` on `meta_record_revisions`. Without the canonical fence that seq allocation
+            // could interleave with a concurrent recovery's, breaking the allocation-order == commit-order
+            // guarantee this lane exists to protect. Fence first, then refuse (409 in the outer catch) under an
+            // active recovery block. Flag-off ⇒ no-op / byte-identical.
+            await fenceWriterEntry(query, sheetId)
             const fieldRow = await loadLossyRetypeFieldRow(query, rev.entity_id, true)
             if (!fieldRow) return { status: 409, code: 'ENTITY_GONE', message: 'The field no longer exists; cannot restore.' }
             if (fieldRow.sheetId !== sheetId) return { status: 400, code: 'INVALID_REVISION', message: 'field revision entity does not belong to this sheet.' }
@@ -9142,6 +9162,11 @@ export function univerMetaRouter(): Router {
       if (rev.entity_type === 'field') invalidateFieldCache(sheetId)
       return res.json({ ok: true, data: { restored: { revisionId, entityType: rev.entity_type, entityId: rev.entity_id, changedKeys: rev.changed_keys } } })
     } catch (err: unknown) {
+      // W0-1 L4cov: a fenced config-restore branch (uncreate / undelete / lossy retype-revert) observed a
+      // durable recovery writer-block → refuse with the same 409 RECOVERY_IN_PROGRESS shape as reset/revert.
+      if (err instanceof SheetWriterBlockedError) {
+        return res.status(409).json({ ok: false, error: { code: 'RECOVERY_IN_PROGRESS', message: 'Another recovery operation is in progress on this sheet; retry shortly.' } })
+      }
       if (err instanceof TombstoneCaptureCapExceededError) {
         return res.status(422).json({ ok: false, error: { code: 'TOMBSTONE_CAPTURE_CAP_EXCEEDED', message: err.message } })
       }
@@ -11218,6 +11243,11 @@ export function univerMetaRouter(): Router {
       invalidateFieldCache(sheetId)
       return res.status(201).json({ ok: true, data: { field: serializeFieldRow((fieldRes as any).rows[0]) } })
     } catch (err: any) {
+      // W0-1 L4cov: creating an auto-number field runs `backfillAutoNumberField`, now fence-then-block-checked;
+      // a durable recovery block surfaces here → 409 RECOVERY_IN_PROGRESS (same shape as reset/revert).
+      if (err instanceof SheetWriterBlockedError) {
+        return res.status(409).json({ ok: false, error: { code: 'RECOVERY_IN_PROGRESS', message: 'Another recovery operation is in progress on this sheet; retry shortly.' } })
+      }
       if (err instanceof NotFoundError) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: err.message } })
       }
@@ -11736,6 +11766,11 @@ export function univerMetaRouter(): Router {
 
       return res.json({ ok: true, data: { field: updated, ...(bulkRecompute ? { bulkRecompute } : {}) } })
     } catch (err: any) {
+      // W0-1 L4cov: changing an auto-number field property runs `backfillAutoNumberField` (overwrite), now
+      // fence-then-block-checked; a durable recovery block surfaces here → 409 RECOVERY_IN_PROGRESS.
+      if (err instanceof SheetWriterBlockedError) {
+        return res.status(409).json({ ok: false, error: { code: 'RECOVERY_IN_PROGRESS', message: 'Another recovery operation is in progress on this sheet; retry shortly.' } })
+      }
       if (err instanceof NotFoundError) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: err.message } })
       }
@@ -14614,7 +14649,14 @@ export function univerMetaRouter(): Router {
       let nextVersion = 1
 
       await pool.transaction(async ({ query }) => {
+        // W0-1 L4cov (close the form-submit create/edit PARTIAL gap — L4 map's univer-meta.ts:14585). The
+        // canonical sheet fence stays UNCONDITIONAL (the pre-existing auto-number serialization lock — the
+        // form-submit CREATE branch allocates auto-numbers below; byte-identical when the L4 flag is off), then
+        // a flag-gated durable recovery-block refusal covers BOTH the EDIT (UPDATE @14655) and CREATE (INSERT
+        // @14743) branches of this handler in one place. A block observed here throws `SheetWriterBlockedError`,
+        // caught in this handler's catch and mapped to 409 RECOVERY_IN_PROGRESS (same shape as reset/revert).
         await acquireAutoNumberSheetWriteLock(query, view.sheetId)
+        if (isWriterFenceEnabled()) await assertNoActiveWriterBlock(query, view.sheetId)
 
         if (recordId) {
           const currentRes = await query(
@@ -14923,6 +14965,10 @@ export function univerMetaRouter(): Router {
         },
       })
     } catch (err) {
+      // W0-1 L4cov: the fence's durable-block refusal (added at this handler's txn entry) surfaces here.
+      if (err instanceof SheetWriterBlockedError) {
+        return res.status(409).json({ ok: false, error: { code: 'RECOVERY_IN_PROGRESS', message: 'Another recovery operation is in progress on this sheet; retry shortly.' } })
+      }
       if (err instanceof VersionConflictError) {
         return res.status(409).json({
           ok: false,

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -11813,10 +11813,15 @@ export function univerMetaRouter(): Router {
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageFields) return sendForbidden(res)
       const result = await pool.transaction(async ({ query }) => {
+        // W0-1 L4cov: dropFieldCascade below strips the dropped field's key from every record of this sheet's
+        // `data` (a whole-sheet record-data write via the shared field-drop cascade helper — the SAME cascade
+        // the config-restore un-create branch fences at ~8888), so the FORWARD field-delete txn is a record
+        // writer too and must take the canonical fence FIRST, then refuse (409 RECOVERY_IN_PROGRESS in the
+        // catch) if a recovery holds a durable block. Flag-off ⇒ no-op / byte-identical.
+        await fenceWriterEntry(query, sheetId)
         const existing = await query('SELECT id, sheet_id, name, type, property, "order" FROM meta_fields WHERE id = $1', [fieldId])
         if ((existing as any).rows.length === 0) throw new NotFoundError(`Field not found: ${fieldId}`)
         const row = (existing as any).rows[0]
-        const sheetId = String(row.sheet_id)
         // U3-L2: the field-delete cascade is the shared dropFieldCascade (also used by the un-create execute).
         await dropFieldCascade(query, {
           sheetId, fieldId,
@@ -11838,6 +11843,11 @@ export function univerMetaRouter(): Router {
       }
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      // W0-1 L4cov: fence-then-block-checked forward field-delete → a durable recovery block surfaces here as
+      // 409 RECOVERY_IN_PROGRESS (same shape as reset/revert and the un-create sibling).
+      if (err instanceof SheetWriterBlockedError) {
+        return res.status(409).json({ ok: false, error: { code: 'RECOVERY_IN_PROGRESS', message: 'Another recovery operation is in progress on this sheet; retry shortly.' } })
+      }
       console.error('[univer-meta] delete field failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete field' } })
     }

--- a/packages/core-backend/tests/integration/multitable-l4-canonical-fence-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-l4-canonical-fence-realdb.test.ts
@@ -44,7 +44,8 @@
  *   UNFENCED entirely → L4-cov-services follow-up (no canonical fence at all — the residual bug class):
  *       automation update/create/delete/lock (automation-executor.ts), approval resultWriteback
  *       (automation-service.ts), formula-engine recompute (formula-engine.ts), approval-record projection
- *       (approval-record-projection-service.ts), field-undelete rehydration (flag HOLD), plugin delete's
+ *       (approval-record-projection-service.ts), field-undelete tombstone inbound-replay rehydration (4c-3, flag
+ *       HOLD — distinct from the config-restore config-undelete branch, which IS fenced: see l4cov B7), plugin delete's
  *       NON-transactional flag-off branch (records.ts, disclosed in-code as an "L4-SEAM" —
  *       `deleteRecordWithRecoverability` right above it IS fenced via `fenceWriterEntry`, but the D-1 flag-off
  *       `deleteRecord` branch cannot hold a txn-scoped advisory lock without the transaction wrap that path

--- a/packages/core-backend/tests/integration/multitable-l4-canonical-fence-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-l4-canonical-fence-realdb.test.ts
@@ -16,28 +16,40 @@
  * every writer onto ONE canonical fence and, for multi-transaction recoveries, a DURABLE block committed
  * under that fence. The goldens below are FENCE-BEFORE-CHECK behavioral proofs, not source-text assertions.
  *
- * FENCED vs PARTIAL vs UNFENCED (verified against the impl on this branch — see the lane report):
+ * FENCED vs DEFERRED vs UNFENCED (verified against the impl on this branch + the stacked L4-coverage lane —
+ * see the lane report). The three formerly-PARTIAL families and the in-txn config-restore record writers are
+ * now FULLY FENCED by the L4-coverage lane (`multitable-l4cov-univer-meta-writers-realdb.test.ts`):
  *   FULLY FENCED (advisory fence + durable-block refusal): REST create/patch/delete/restore, bulk/AI/OAPI
  *       patch (RecordWriteService), plugin patch, plugin recoverable delete, attachment cell-strip, HTTP
  *       lock/unlock, revert-execute (durable block, now also the recovery-only PIT lock — P2 follow-up),
  *       reset-execute (fence + durable-block refusal via `fenceWriterEntry` — P2 follow-up; previously
  *       fence-first only, with NO block-check, so a reset begun during revert's released-fence apply window
- *       slipped past its committed `applying` block — see RXR1/RXR2 below).
- *   PARTIAL (advisory canonical fence for seq-ordering, but NO durable-block check ⇒ slips past a
- *       multi-txn `applying` recovery): plugin create (records.ts:592), auto-number backfill
- *       (auto-number-service.ts:84), form-submit create/edit (univer-meta.ts:14585). GX1/GX2 EXPOSE this.
- *   UNFENCED entirely (no canonical fence at all — the residual bug class): automation
- *       update/create/delete/lock (automation-executor.ts), approval resultWriteback
+ *       slipped past its committed `applying` block — see RXR1/RXR2 below);
+ *       — added by L4-coverage — plugin create (records.ts::createRecord), auto-number backfill
+ *       (auto-number-service.ts::backfillAutoNumberField), form-submit create/edit (univer-meta.ts submit),
+ *       and config-restore-execute record writes: un-create (dropFieldCascade column strip), undelete
+ *       (recreateFieldFromConfig), lossy retype-revert (applyLossyRetypeCellRewrite — the seq-ALLOCATING one,
+ *       one recordRecordRevision per cell). The three formerly-PARTIAL families keep their pre-existing
+ *       UNCONDITIONAL canonical fence (the auto-number allocation-serialization lock) and gained a FLAG-GATED
+ *       block-check, so flag-off is byte-identical (fence taken, block ignored). GX1/GX2 below, which used to
+ *       assert those families PROCEED under a block, are flipped to assert REFUSAL.
+ *   ANALYZED → DEFERRED (documented, NOT force-fenced): the POST-COMMIT derived-value recompute
+ *       (univer-meta.ts relation-agg materialization @≈2973 / fan-out @≈3869 + formula-engine.ts
+ *       recalculateRecordFromData) runs on a fresh pool connection AFTER the fenced write txn commits, but every
+ *       one of those writes is an in-place `UPDATE meta_records SET data` with NO revision and NO `seq`
+ *       allocation — so it does NOT breach the non-causal-`seq` hole this fence protects; a fence there would be
+ *       behavior-changing (see the L4-cov §C write-up). Also deferred: people/seed presets
+ *       (ensurePeopleSheetPreset / createSeededSheet) — revision-exempt system/scaffold writes, no `seq`, sheet
+ *       resolved mid-txn / created at sheet-birth (no possible active recovery to observe).
+ *   UNFENCED entirely → L4-cov-services follow-up (no canonical fence at all — the residual bug class):
+ *       automation update/create/delete/lock (automation-executor.ts), approval resultWriteback
  *       (automation-service.ts), formula-engine recompute (formula-engine.ts), approval-record projection
- *       (approval-record-projection-service.ts), post-commit derived-value recompute (univer-meta.ts:2973 /
- *       :3869), config-restore-execute record writes (univer-meta.ts:6171 / :6449 / :6555), people/seed
- *       presets (:5188 / :5825), field-undelete rehydration (flag HOLD), plugin delete's NON-transactional
- *       flag-off branch (records.ts:852, disclosed in-code as an "L4-SEAM" — `deleteRecordWithRecoverability`
- *       right above it in the same file IS fenced via `fenceWriterEntry`, but the D-1 flag-off `deleteRecord`
- *       branch cannot hold a txn-scoped advisory lock without the transaction wrap that path deliberately
- *       lacks — §1.9 byte-identity keeps it as the D-1 code verbatim). Enumerated in the report; behavioral
- *       exposure of these is deferred (their end-to-end harnesses are heavy) — see GX3 for the design of the
- *       exposure, driven for the two cheap, high-signal PARTIAL families here.
+ *       (approval-record-projection-service.ts), field-undelete rehydration (flag HOLD), plugin delete's
+ *       NON-transactional flag-off branch (records.ts, disclosed in-code as an "L4-SEAM" —
+ *       `deleteRecordWithRecoverability` right above it IS fenced via `fenceWriterEntry`, but the D-1 flag-off
+ *       `deleteRecord` branch cannot hold a txn-scoped advisory lock without the transaction wrap that path
+ *       deliberately lacks — §1.9 byte-identity keeps it as the D-1 code verbatim). Enumerated in the report;
+ *       these service-file families are left untouched here to avoid cross-lane collision.
  *
  * P2-C hygiene (v3.7): every seq comparison uses EXACT bigint (BigInt(), never Number()/parseInt/+/-); this
  * file NEVER calls `setval` on the shared `meta_record_chain_seq`; all fixtures are isolated synthetic rows
@@ -339,36 +351,38 @@ describeIfDatabase('W0-1 L4 — all-writer canonical fence (real DB)', () => {
     expect(await recordExists(R)).toBe(true)
   })
 
-  // ── §X — GAP EXPOSURE. These families take the canonical advisory fence (for seq-ordering) but do NOT
-  //         perform the durable-block check, so with the flag ON and an `applying` block they PROCEED —
-  //         slipping past a multi-txn recovery. The positive control (F1: REST create) REFUSES the same
-  //         block, so this is a genuine ASYMMETRY, not a flag/plumbing artifact. When the impl closes the
-  //         gap (adds `assertNoActiveWriterBlock` to these entries), these two goldens flip RED — convert
-  //         them to `rejects.toBeInstanceOf(SheetWriterBlockedError)` at that point.
-  test('GX1 [plugin create — PARTIAL] records.createRecord PROCEEDS under an applying block (no durable-block check) — asymmetric with F1', async () => {
+  // ── §X — the former GAP, now CLOSED by the L4-coverage lane. These families took the canonical advisory
+  //         fence (for seq-ordering) but omitted the durable-block check, so with the flag ON and an
+  //         `applying` block they PROCEEDED — slipping past a multi-txn recovery (the ASYMMETRY vs F1 REST
+  //         create, which always refused). L4-cov added the flag-gated `assertNoActiveWriterBlock` AFTER the
+  //         (still-UNCONDITIONAL, byte-identical-when-off) canonical fence, so they now REFUSE symmetrically
+  //         with F1. These goldens were flipped from "PROCEEDS" to "refuses" exactly as this header foretold.
+  //         (Fuller per-writer wiring/flag-off/race goldens live in
+  //         `multitable-l4cov-univer-meta-writers-realdb.test.ts`.)
+  test('GX1 [plugin create] records.createRecord REFUSES under an applying block (fence + flag-gated block-check) — now symmetric with F1', async () => {
     process.env[FLAG] = 'true'
     await setBlock('applying')
-    const created = await poolManager.get().transaction(async ({ query }) =>
-      pluginCreateRecord({ query: query as never, sheetId: SHEET, data: { [F_STR]: 'plugin-created-during-recovery' } }),
-    )
-    // The gap: an insert landed on a sheet a recovery has durably blocked. (F1 proves REST create refuses.)
-    expect((created as { id: string }).id).toBeTruthy()
-    expect(await recordExists((created as { id: string }).id)).toBe(true)
-    // The block itself is untouched — the writer neither observed nor cleared it.
-    expect(await readBlock()).toBe('applying')
-    await q('DELETE FROM meta_records WHERE id = $1', [(created as { id: string }).id]).catch(() => {})
+    const before = (await q('SELECT count(*)::int AS n FROM meta_records WHERE sheet_id=$1', [SHEET])).rows[0] as { n: number }
+    await expect(
+      poolManager.get().transaction(async ({ query }) =>
+        pluginCreateRecord({ query: query as never, sheetId: SHEET, data: { [F_STR]: 'plugin-created-during-recovery' } }),
+      ),
+    ).rejects.toBeInstanceOf(SheetWriterBlockedError)
+    const after = (await q('SELECT count(*)::int AS n FROM meta_records WHERE sheet_id=$1', [SHEET])).rows[0] as { n: number }
+    expect(after.n).toBe(before.n) // refused BEFORE any insert
+    expect(await readBlock()).toBe('applying') // block untouched
   })
 
-  test('GX2 [auto-number backfill — PARTIAL] backfillAutoNumberField PROCEEDS under an applying block (advisory fence only, no durable-block check)', async () => {
+  test('GX2 [auto-number backfill] backfillAutoNumberField REFUSES under an applying block (fence + flag-gated block-check)', async () => {
     const R = mkRecord('gx2')
     await seedRecord(R)
     process.env[FLAG] = 'true'
     await setBlock('applying')
     const property = { prefix: '', digits: 3 }
-    // Fence acquired (advisory) but no block-check ⇒ backfill runs its UPDATE despite the recovery block.
-    const res = await backfillAutoNumberField(q as never, SHEET, F_AN, property as never, { overwrite: true })
-    expect(res).toBeTruthy()
-    expect(await readBlock()).toBe('applying') // block untouched — writer slipped past it
+    await expect(
+      backfillAutoNumberField(q as never, SHEET, F_AN, property as never, { overwrite: true }),
+    ).rejects.toBeInstanceOf(SheetWriterBlockedError)
+    expect(await readBlock()).toBe('applying') // block untouched — writer refused, never ran its UPDATE
   })
 
   // ── §P — flag-off PARITY: with the fence flag OFF, a durable block is inert; every writer behaves

--- a/packages/core-backend/tests/integration/multitable-l4cov-univer-meta-writers-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-l4cov-univer-meta-writers-realdb.test.ts
@@ -20,10 +20,17 @@
  *                        records.ts::createRecord     ⇒ A1 (block still proceeds) RED.
  *   - auto-number backfill  same removal in auto-number-service.ts::backfillAutoNumberField ⇒ A2 RED.
  *   - form-submit        remove the block-check after `acquireAutoNumberSheetWriteLock` in the submit txn
- *                        ⇒ B1c/B2c (409 becomes 200) RED.
+ *                        ⇒ B1 (409 becomes 200) RED (B1c is the flag-off parity leg).
  *   - create-field backfill  (shares the backfill mutation) ⇒ B3 RED.
  *   - config-restore un-create / lossy-retype  remove `await fenceWriterEntry(query, sheetId)` from the branch's
  *                        txn entry ⇒ B4c / B5 (409 becomes the downstream status) RED.
+ *   - FORWARD field-delete route (`DELETE /fields/:fieldId`)  remove `await fenceWriterEntry(query, sheetId)`
+ *                        from the delete-field txn ⇒ B6 (409 becomes 200) RED. [re-gate P1: this route shared
+ *                        dropFieldCascade with un-create but was the ONE unfenced sibling — hole now closed + tested.]
+ *   - config-restore UNDELETE branch  remove `await fenceWriterEntry(query, sheetId)` from the undelete txn
+ *                        ⇒ B7 (409 becomes the downstream status) RED. [re-gate P2: the undelete fence was
+ *                        present but untested; B7 covers it. config-undelete stays flag-HOLD — this golden is
+ *                        the precondition to un-holding it.]
  *
  * P2-C hygiene (v3.7): all fixtures are isolated synthetic rows with unique ids; this file NEVER calls `setval`
  * on the shared `meta_record_chain_seq`; `afterAll` cleans up ONLY this suite's own rows. Locally the whole
@@ -55,6 +62,7 @@ const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, para
 
 const FLAG = 'MULTITABLE_ENABLE_WRITER_FENCE'
 const UNCREATE_FLAG = 'MULTITABLE_ENABLE_CONFIG_UNCREATE'
+const UNDELETE_FLAG = 'MULTITABLE_ENABLE_CONFIG_UNDELETE'
 const RETYPE_FLAG = 'MULTITABLE_ENABLE_FIELD_RETYPE_REVERT'
 const RETYPE_LOSSY_FLAG = 'MULTITABLE_ENABLE_FIELD_RETYPE_REVERT_LOSSY'
 
@@ -115,6 +123,10 @@ const restoreExecute = (body: Record<string, unknown>) => {
   actor = MEMBER
   return request(app).post(`/api/multitable/sheets/${SHEET}/config-restore-execute`).send(body)
 }
+const deleteField = (fieldId: string) => {
+  actor = MEMBER
+  return request(app).delete(`/api/multitable/fields/${fieldId}`)
+}
 
 /** Seed a field `create` config revision (un-create eligible: isSupportedUncreate). */
 const insertFieldCreateRev = async (fieldId: string, name: string): Promise<string> => {
@@ -123,6 +135,16 @@ const insertFieldCreateRev = async (fieldId: string, name: string): Promise<stri
     `INSERT INTO meta_config_revisions (sheet_id, entity_type, entity_id, action, before, after, changed_keys, batch_id, actor_id, source)
      VALUES ($1,'field',$2,'create',NULL,$3::jsonb,$4::text[],gen_random_uuid(),$5,'mutation') RETURNING id`,
     [SHEET, fieldId, after, ['name', 'type', 'property', 'order'], ACTOR],
+  )
+  return (r.rows[0] as { id: string }).id
+}
+/** Seed a field `delete` config revision (undelete eligible: isSupportedUndelete = action 'delete' + field). */
+const insertFieldDeleteRev = async (fieldId: string, name: string): Promise<string> => {
+  const before = JSON.stringify({ name, type: 'string', property: {}, order: 9 })
+  const r = await q(
+    `INSERT INTO meta_config_revisions (sheet_id, entity_type, entity_id, action, before, after, changed_keys, batch_id, actor_id, source)
+     VALUES ($1,'field',$2,'delete',$3::jsonb,NULL,$4::text[],gen_random_uuid(),$5,'mutation') RETURNING id`,
+    [SHEET, fieldId, before, ['name', 'type', 'property', 'order'], ACTOR],
   )
   return (r.rows[0] as { id: string }).id
 }
@@ -157,12 +179,12 @@ describeIfDatabase('W0-1 L4cov — univer-meta/records/auto-number writer fence 
   })
 
   afterEach(async () => {
-    for (const f of [FLAG, UNCREATE_FLAG, RETYPE_FLAG, RETYPE_LOSSY_FLAG]) delete process.env[f]
+    for (const f of [FLAG, UNCREATE_FLAG, UNDELETE_FLAG, RETYPE_FLAG, RETYPE_LOSSY_FLAG]) delete process.env[f]
     await setBlock(null).catch(() => {})
   })
 
   afterAll(async () => {
-    for (const f of [FLAG, UNCREATE_FLAG, RETYPE_FLAG, RETYPE_LOSSY_FLAG]) delete process.env[f]
+    for (const f of [FLAG, UNCREATE_FLAG, UNDELETE_FLAG, RETYPE_FLAG, RETYPE_LOSSY_FLAG]) delete process.env[f]
     await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_field_auto_number_sequences WHERE sheet_id = $1', [SHEET]).catch(() => {})
@@ -459,6 +481,81 @@ describeIfDatabase('W0-1 L4cov — univer-meta/records/auto-number writer fence 
     await setBlock(null)
     await q('DELETE FROM meta_config_revisions WHERE entity_id = $1', [F]).catch(() => {})
     await q('DELETE FROM meta_fields WHERE id = $1', [F]).catch(() => {})
+  })
+
+  // ── §B6 — the FORWARD field-delete route (`DELETE /fields/:fieldId`). Its txn calls the SAME dropFieldCascade
+  // as the un-create sibling (B4) but was UNFENCED (the P1 coverage hole this rung's re-gate found: 200 under an
+  // applying block where the sibling 409s). Now fenced-first. Same three legs as B4: block⇒409, no-block⇒200
+  // (positive control it isn't just always-refusing), flag-off⇒block inert. MUTATION: remove
+  // `await fenceWriterEntry(query, sheetId)` from the delete-field route txn ⇒ B6 (409 becomes 200) RED.
+  test('B6 [forward field-delete route] applying block ⇒ 409 RECOVERY_IN_PROGRESS, field survives (flag ON)', async () => {
+    const F = mkField('b6')
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F, SHEET, 'B6F', 'string', '{}', 9])
+    process.env[FLAG] = 'true'
+    await setBlock('applying')
+    const res = await deleteField(F)
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('RECOVERY_IN_PROGRESS')
+    expect(await fieldExists(F)).toBe(true) // NOT dropped — the forward route now fences like its un-create sibling
+    expect(await readBlock()).toBe('applying') // block untouched
+    await q('DELETE FROM meta_fields WHERE id = $1', [F]).catch(() => {})
+  })
+
+  test('B6b [forward field-delete route] POSITIVE CONTROL: NO block ⇒ 200 drops the field + strips its key from records (flag ON)', async () => {
+    const F = mkField('b6b')
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F, SHEET, 'B6bF', 'string', '{}', 9])
+    const R = mkRecord('b6b')
+    await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [R, SHEET, JSON.stringify({ [F]: 'carried' }), ACTOR])
+    process.env[FLAG] = 'true'
+    await setBlock(null)
+    const res = await deleteField(F)
+    expect(res.status).toBe(200)
+    expect(await fieldExists(F)).toBe(false) // dropped — no active recovery blocked it
+    const rowAfter = await q('SELECT data FROM meta_records WHERE id = $1', [R])
+    expect(((rowAfter.rows[0] as { data: Record<string, unknown> }).data)[F]).toBeUndefined() // the cascade stripped the key
+    await q('DELETE FROM meta_records WHERE id = $1', [R]).catch(() => {})
+  })
+
+  test('B6c [forward field-delete route] FLAG OFF: an applying block is INERT ⇒ the delete PROCEEDS (byte-identical pre-L4cov)', async () => {
+    const F = mkField('b6c')
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F, SHEET, 'B6cF', 'string', '{}', 9])
+    delete process.env[FLAG] // fence OFF
+    await setBlock('applying')
+    const res = await deleteField(F)
+    expect(res.status).toBe(200) // fence no-op ⇒ delete proceeds despite the block — the refusal is flag-gated
+    expect(await fieldExists(F)).toBe(false)
+  })
+
+  // ── §B7 — the config-restore UNDELETE branch (re-gate P2: the fence was present but untested). A field DELETE
+  // config revision is undelete-eligible (isSupportedUndelete); the undelete txn fences as its FIRST statement
+  // (before the id-occupied FOR UPDATE + preview-token verify), so a dummy token still 409s at the fence under a
+  // block — exactly like un-create (B4). MUTATION: remove `await fenceWriterEntry(query, sheetId)` from the
+  // undelete txn ⇒ B7 (409 becomes the downstream PREVIEW_IDENTITY_INVALID) RED. config-undelete stays flag-HOLD.
+  test('B7 [config-restore undelete] applying block ⇒ 409 RECOVERY_IN_PROGRESS (fence FIRST), field stays deleted (flag ON)', async () => {
+    const F = mkField('b7')
+    const rev = await insertFieldDeleteRev(F, 'B7F')
+    process.env[FLAG] = 'true'
+    process.env[UNDELETE_FLAG] = 'true'
+    await setBlock('applying')
+    const res = await restoreExecute({ revisionId: rev, previewToken: 'dummy-token', confirm: 'undelete' })
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('RECOVERY_IN_PROGRESS')
+    expect(await fieldExists(F)).toBe(false) // NOT recreated — the fence refused before the undelete plan ran
+    expect(await readBlock()).toBe('applying') // block untouched
+    await q('DELETE FROM meta_config_revisions WHERE entity_id = $1', [F]).catch(() => {})
+  })
+
+  test('B7c [config-restore undelete] FLAG OFF: an applying block is INERT ⇒ NOT 409 RECOVERY (fence no-op)', async () => {
+    const F = mkField('b7c')
+    const rev = await insertFieldDeleteRev(F, 'B7cF')
+    delete process.env[FLAG] // fence OFF
+    process.env[UNDELETE_FLAG] = 'true'
+    await setBlock('applying')
+    // Fence no-op ⇒ the request proceeds PAST the fence into the (dummy) token verify → a NON-fence status,
+    // NOT the fence's 409 RECOVERY_IN_PROGRESS. Proves the block-refusal is flag-gated.
+    const res = await restoreExecute({ revisionId: rev, previewToken: 'dummy-token', confirm: 'undelete' })
+    expect(res.body?.error?.code).not.toBe('RECOVERY_IN_PROGRESS')
+    await q('DELETE FROM meta_config_revisions WHERE entity_id = $1', [F]).catch(() => {})
   })
 
   // ── §R — CONSTRUCTED RACE on a NEWLY-fenced writer (plugin-create). Two raw pg clients + pg_blocking_pids.

--- a/packages/core-backend/tests/integration/multitable-l4cov-univer-meta-writers-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-l4cov-univer-meta-writers-realdb.test.ts
@@ -1,0 +1,530 @@
+/**
+ * W0-1 Lane L4-coverage — univer-meta / records / auto-number writer families. Real-DB goldens.
+ *
+ * Stacked on L4 (`multitable-l4-canonical-fence-realdb.test.ts`). L4 converged the core writers onto the
+ * canonical per-sheet fence and left three PARTIAL families (canonical advisory fence for seq-ordering, but NO
+ * durable-block check) plus several in-txn config-restore writers unfenced. This lane closes those holes; this
+ * file is the behavioral proof.
+ *
+ * WHAT THIS PROVES (per newly-fenced writer): (1) a BLOCK-REFUSAL golden — with the L4 flag ON and a durable
+ * `applying` block, the writer REFUSES (409 `RECOVERY_IN_PROGRESS` at the HTTP boundary, or throws
+ * `SheetWriterBlockedError` at the library boundary) instead of proceeding; (2) a POSITIVE CONTROL — the SAME
+ * request with NO block proceeds (200/created/throws-a-different-error), so the refusal is a genuine block
+ * effect, not a plumbing artifact; (3) FLAG-OFF PARITY — with the fence flag OFF the durable block is inert and
+ * the writer behaves byte-identically to pre-L4 (the PARTIAL families KEEP their pre-existing UNCONDITIONAL
+ * canonical fence — it is the auto-number allocation-serialization lock — so flag-off is "fence still taken,
+ * block ignored", NOT "no fence at all"; §AF proves the unconditional fence survives via a constructed park).
+ *
+ * MUTATION LOG (each asserted in the lane report; every one was run RED→restore→green):
+ *   - plugin-create      remove `if (isWriterFenceEnabled()) await assertNoActiveWriterBlock(...)` from
+ *                        records.ts::createRecord     ⇒ A1 (block still proceeds) RED.
+ *   - auto-number backfill  same removal in auto-number-service.ts::backfillAutoNumberField ⇒ A2 RED.
+ *   - form-submit        remove the block-check after `acquireAutoNumberSheetWriteLock` in the submit txn
+ *                        ⇒ B1c/B2c (409 becomes 200) RED.
+ *   - create-field backfill  (shares the backfill mutation) ⇒ B3 RED.
+ *   - config-restore un-create / lossy-retype  remove `await fenceWriterEntry(query, sheetId)` from the branch's
+ *                        txn entry ⇒ B4c / B5 (409 becomes the downstream status) RED.
+ *
+ * P2-C hygiene (v3.7): all fixtures are isolated synthetic rows with unique ids; this file NEVER calls `setval`
+ * on the shared `meta_record_chain_seq`; `afterAll` cleans up ONLY this suite's own rows. Locally the whole
+ * suite is run against a throwaway database `metasheet_l4cov_gate` (created, migrated, dropped) so the shared
+ * chain sequence is never touched — see the lane report. Two-point wiring: plugin-tests.yml real-DB run list +
+ * vitest.integration.config.ts default include glob. Runs only with DATABASE_URL; the sentinel fails-not-skips.
+ */
+import { EventEmitter } from 'events'
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import type { EventBus } from '../../src/integration/events/event-bus'
+import { RecordService } from '../../src/multitable/record-service'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { deriveCapabilities } from '../../src/multitable/sheet-capabilities'
+import { createRecord as pluginCreateRecord } from '../../src/multitable/records'
+import { backfillAutoNumberField } from '../../src/multitable/auto-number-service'
+import {
+  SheetWriterBlockedError,
+  canonicalSheetFenceKey,
+  __resetRecoveryWriterStateColumnProbe,
+  type WriterBlockState,
+} from '../../src/multitable/canonical-sheet-fence'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const FLAG = 'MULTITABLE_ENABLE_WRITER_FENCE'
+const UNCREATE_FLAG = 'MULTITABLE_ENABLE_CONFIG_UNCREATE'
+const RETYPE_FLAG = 'MULTITABLE_ENABLE_FIELD_RETYPE_REVERT'
+const RETYPE_LOSSY_FLAG = 'MULTITABLE_ENABLE_FIELD_RETYPE_REVERT_LOSSY'
+
+const TS = Date.now()
+const BASE = `base_l4cov_${TS}`
+const SHEET = `sheet_l4cov_${TS}`
+const VIEW = `view_l4cov_${TS}`
+const F_STR = `fld_l4cov_str_${TS}`
+const ACTOR = `u_l4cov_actor_${TS}`
+
+let seq = 0
+const mkRecord = (tag: string) => `rec_l4cov_${tag}_${TS}_${seq++}`
+const mkField = (tag: string) => `fld_l4cov_${tag}_${TS}_${seq++}`
+
+const eventBus = new EventEmitter() as unknown as EventBus
+const capabilities = deriveCapabilities(['multitable:read', 'multitable:write'], false)
+const mkRecordService = () =>
+  new RecordService(
+    poolManager.get() as unknown as ConstructorParameters<typeof RecordService>[0],
+    eventBus,
+  )
+
+const setBlock = async (state: WriterBlockState | null) =>
+  q('UPDATE meta_sheets SET recovery_writer_state = $2 WHERE id = $1', [SHEET, state])
+const readBlock = async (): Promise<unknown> =>
+  ((await q('SELECT recovery_writer_state FROM meta_sheets WHERE id = $1', [SHEET])).rows[0] as
+    | { recovery_writer_state: unknown }
+    | undefined)?.recovery_writer_state ?? null
+const recordData = async (id: string): Promise<Record<string, unknown> | undefined> =>
+  ((await q('SELECT data FROM meta_records WHERE id = $1', [id])).rows[0] as { data: Record<string, unknown> } | undefined)?.data
+const recordExists = async (id: string): Promise<boolean> =>
+  (await q('SELECT 1 FROM meta_records WHERE id = $1', [id])).rows.length > 0
+const fieldExists = async (id: string): Promise<boolean> =>
+  (await q('SELECT 1 FROM meta_fields WHERE id = $1', [id])).rows.length > 0
+const seedRecord = async (id: string, data: Record<string, unknown> = { [F_STR]: 'orig' }): Promise<void> => {
+  await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [
+    id, SHEET, JSON.stringify(data), ACTOR,
+  ])
+}
+
+// ── HTTP harness (real univerMetaRouter). A mutable actor + middleware, per the sibling config-restore suites.
+let app: Express
+let actor: { id: string; roles: string[]; perms: string[] }
+const MEMBER = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }
+const submit = (body: Record<string, unknown>) => {
+  actor = MEMBER
+  return request(app).post(`/api/multitable/views/${VIEW}/submit`).send(body)
+}
+const createField = (body: Record<string, unknown>) => {
+  actor = MEMBER
+  return request(app).post('/api/multitable/fields').send(body)
+}
+const restorePreview = (revisionId: string) => {
+  actor = MEMBER
+  return request(app).post(`/api/multitable/sheets/${SHEET}/config-restore-preview`).send({ revisionId })
+}
+const restoreExecute = (body: Record<string, unknown>) => {
+  actor = MEMBER
+  return request(app).post(`/api/multitable/sheets/${SHEET}/config-restore-execute`).send(body)
+}
+
+/** Seed a field `create` config revision (un-create eligible: isSupportedUncreate). */
+const insertFieldCreateRev = async (fieldId: string, name: string): Promise<string> => {
+  const after = JSON.stringify({ name, type: 'string', property: {}, order: 9 })
+  const r = await q(
+    `INSERT INTO meta_config_revisions (sheet_id, entity_type, entity_id, action, before, after, changed_keys, batch_id, actor_id, source)
+     VALUES ($1,'field',$2,'create',NULL,$3::jsonb,$4::text[],gen_random_uuid(),$5,'mutation') RETURNING id`,
+    [SHEET, fieldId, after, ['name', 'type', 'property', 'order'], ACTOR],
+  )
+  return (r.rows[0] as { id: string }).id
+}
+/** Seed a property-only field `update` config revision (lossy-retype eligible: isLossyPropertyRetypeRevertShape). */
+const insertLossyPropertyRev = async (fieldId: string): Promise<string> => {
+  const r = await q(
+    `INSERT INTO meta_config_revisions (sheet_id, entity_type, entity_id, action, before, after, changed_keys, batch_id, actor_id, source)
+     VALUES ($1,'field',$2,'update',$3::jsonb,$4::jsonb,$5::text[],gen_random_uuid(),$6,'mutation') RETURNING id`,
+    [SHEET, fieldId, JSON.stringify({ property: { max: 5 } }), JSON.stringify({ property: { max: 3 } }), ['property'], ACTOR],
+  )
+  return (r.rows[0] as { id: string }).id
+}
+
+describeIfDatabase('W0-1 L4cov — univer-meta/records/auto-number writer fence coverage (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as { user?: typeof actor }).user = actor; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'L4cov Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'L4cov Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [
+      F_STR, SHEET, 'Note', 'string', '{}', 1,
+    ])
+    await q(
+      `INSERT INTO meta_views (id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config)
+       VALUES ($1,$2,$3,'grid','{}'::jsonb,'{}'::jsonb,'{}'::jsonb,'[]'::jsonb,'{}'::jsonb)`,
+      [VIEW, SHEET, 'L4cov View'],
+    )
+  })
+
+  afterEach(async () => {
+    for (const f of [FLAG, UNCREATE_FLAG, RETYPE_FLAG, RETYPE_LOSSY_FLAG]) delete process.env[f]
+    await setBlock(null).catch(() => {})
+  })
+
+  afterAll(async () => {
+    for (const f of [FLAG, UNCREATE_FLAG, RETYPE_FLAG, RETYPE_LOSSY_FLAG]) delete process.env[f]
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_field_auto_number_sequences WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id IN (SELECT id FROM meta_fields WHERE sheet_id = $1)', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+
+  beforeEach(() => {
+    __resetRecoveryWriterStateColumnProbe()
+  })
+
+  test('sentinel: DATABASE_URL is set (this suite must RUN, never skip-green)', () => {
+    if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+      throw new Error('real-DB allowlist step is missing DATABASE_URL')
+    }
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ── §A — PARTIAL families (plugin-create + auto-number backfill) at the LIBRARY boundary ────────────────
+  // These hold the canonical fence UNCONDITIONALLY (the auto-number allocation-serialization lock). L4cov adds
+  // a FLAG-GATED durable-block check. Under an `applying` block with the flag ON they now THROW instead of
+  // slipping past (the gap L4's GX1/GX2 exposed, now flipped to refusal in the L4 file).
+
+  test('A1 [plugin-create] createRecord under an applying block THROWS SheetWriterBlockedError; no insert (flag ON)', async () => {
+    process.env[FLAG] = 'true'
+    await setBlock('applying')
+    const before = (await q('SELECT count(*)::int AS n FROM meta_records WHERE sheet_id=$1', [SHEET])).rows[0] as { n: number }
+    const err = await poolManager
+      .get()
+      .transaction(async ({ query }) =>
+        pluginCreateRecord({ query: query as never, sheetId: SHEET, data: { [F_STR]: 'blocked-create' } }),
+      )
+      .catch((e) => e)
+    expect(err).toBeInstanceOf(SheetWriterBlockedError)
+    const after = (await q('SELECT count(*)::int AS n FROM meta_records WHERE sheet_id=$1', [SHEET])).rows[0] as { n: number }
+    expect(after.n).toBe(before.n) // refused BEFORE the INSERT
+    expect(await readBlock()).toBe('applying') // block untouched
+  })
+
+  test('A1-off [plugin-create] FLAG OFF: an applying block is INERT — create PROCEEDS (byte-identical pre-L4)', async () => {
+    delete process.env[FLAG] // OFF
+    await setBlock('applying')
+    const created = await poolManager
+      .get()
+      .transaction(async ({ query }) =>
+        pluginCreateRecord({ query: query as never, sheetId: SHEET, data: { [F_STR]: 'flag-off-create' } }),
+      )
+    expect((created as { id: string }).id).toBeTruthy()
+    expect(await recordExists((created as { id: string }).id)).toBe(true) // committed despite the block
+    await q('DELETE FROM meta_records WHERE id = $1', [(created as { id: string }).id]).catch(() => {})
+    await setBlock(null)
+  })
+
+  test('A2 [auto-number backfill] backfillAutoNumberField under an applying block THROWS (flag ON); block untouched', async () => {
+    const F_AN = mkField('a2an')
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [
+      F_AN, SHEET, 'Seq', 'autoNumber', JSON.stringify({ prefix: '', digits: 3 }), 2,
+    ])
+    process.env[FLAG] = 'true'
+    await setBlock('applying')
+    const err = await backfillAutoNumberField(q as never, SHEET, F_AN, { prefix: '', digits: 3 } as never, { overwrite: true }).catch((e) => e)
+    expect(err).toBeInstanceOf(SheetWriterBlockedError)
+    expect(await readBlock()).toBe('applying')
+    await q('DELETE FROM meta_fields WHERE id = $1', [F_AN]).catch(() => {})
+  })
+
+  test('A2-off [auto-number backfill] FLAG OFF: backfill IGNORES an applying block and runs (byte-identical)', async () => {
+    const F_AN = mkField('a2offan')
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [
+      F_AN, SHEET, 'Seq2', 'autoNumber', JSON.stringify({ prefix: '', digits: 3 }), 3,
+    ])
+    delete process.env[FLAG] // OFF
+    await setBlock('applying')
+    const res = await backfillAutoNumberField(q as never, SHEET, F_AN, { prefix: '', digits: 3 } as never, { overwrite: true })
+    expect(res).toBeTruthy() // ran despite the block
+    expect(await readBlock()).toBe('applying')
+    await q('DELETE FROM meta_field_auto_number_sequences WHERE field_id = $1', [F_AN]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE id = $1', [F_AN]).catch(() => {})
+  })
+
+  // ── §AF — the UNCONDITIONAL fence is PRESERVED even with the flag off. A constructed park proves plugin-create
+  // still parks on a concurrently-held canonical fence regardless of the flag (so flag-off did NOT drop the
+  // auto-number serialization lock — the correctness reason we split fence-acquire from block-check). Throw-if-
+  // never-parked keeps this non-vacuous.
+  async function waitUntilBlockedOnFence(blockerPid: number, timeoutMs = 5000): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      const r = await q(
+        `SELECT COUNT(*)::int AS c FROM pg_stat_activity
+          WHERE datname = current_database()
+            AND wait_event_type = 'Lock'
+            AND $1 = ANY(pg_blocking_pids(pid))
+            AND query ILIKE '%pg_advisory_xact_lock%'`,
+        [blockerPid],
+      )
+      if ((r.rows[0] as { c: number }).c >= 1) return
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+    throw new Error('plugin-create never parked on the held canonical fence — the unconditional fence is gone')
+  }
+
+  test('AF [flag OFF] plugin-create STILL parks on a held canonical fence (the unconditional auto-number lock survives)', async () => {
+    delete process.env[FLAG] // OFF — block-check disabled, but the fence acquire must remain
+    await setBlock(null)
+    const b = await poolManager.get().getInternalPool().connect()
+    const a = await poolManager.get().getInternalPool().connect()
+    let parked = false
+    try {
+      await b.query('BEGIN')
+      const bPid = Number((await b.query('SELECT pg_backend_pid() AS pid')).rows[0]!.pid)
+      await b.query('SELECT pg_advisory_xact_lock(hashtext($1))', [canonicalSheetFenceKey(SHEET)]) // hold the fence
+
+      await a.query('BEGIN')
+      const aQuery = (sql: string, params?: unknown[]) => a.query(sql, params) as unknown as Promise<{ rows: unknown[]; rowCount?: number | null }>
+      let createdId: string | undefined
+      const aRun = (async () => {
+        const rec = await pluginCreateRecord({ query: aQuery as never, sheetId: SHEET, data: { [F_STR]: 'af-parks' } })
+        createdId = (rec as { id: string }).id
+      })()
+      await waitUntilBlockedOnFence(bPid) // THROWS if A did not park ⇒ the unconditional fence was removed
+      parked = true
+      await b.query('COMMIT') // release the fence
+      await aRun // A now proceeds (flag off ⇒ no block-check) and creates
+      await a.query('COMMIT')
+      expect(createdId).toBeTruthy()
+      await q('DELETE FROM meta_records WHERE id = $1', [createdId!]).catch(() => {})
+    } finally {
+      await a.query('ROLLBACK').catch(() => {})
+      a.release()
+      b.release()
+    }
+    expect(parked).toBe(true)
+  })
+
+  // ── §B — HTTP writers via the real univerMetaRouter (production wiring + 409 mapping) ────────────────────
+
+  test('B1 [form-submit CREATE] applying block ⇒ 409 RECOVERY_IN_PROGRESS, no record inserted (flag ON)', async () => {
+    process.env[FLAG] = 'true'
+    await setBlock('applying')
+    const before = (await q('SELECT count(*)::int AS n FROM meta_records WHERE sheet_id=$1', [SHEET])).rows[0] as { n: number }
+    const res = await submit({ data: { [F_STR]: 'form-blocked' } })
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('RECOVERY_IN_PROGRESS')
+    const after = (await q('SELECT count(*)::int AS n FROM meta_records WHERE sheet_id=$1', [SHEET])).rows[0] as { n: number }
+    expect(after.n).toBe(before.n) // zero writes
+  })
+
+  test('B1b [form-submit CREATE] POSITIVE CONTROL: NO block ⇒ 200 create (proves 409 is the block, not plumbing)', async () => {
+    process.env[FLAG] = 'true'
+    await setBlock(null)
+    const res = await submit({ data: { [F_STR]: 'form-ok' } })
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.mode).toBe('create')
+    const id = res.body?.data?.record?.id as string
+    expect(id).toBeTruthy()
+    await q('DELETE FROM meta_record_revisions WHERE record_id = $1', [id]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE id = $1', [id]).catch(() => {})
+  })
+
+  test('B1c [form-submit CREATE] FLAG OFF: an applying block is INERT ⇒ 200 create (byte-identical pre-L4)', async () => {
+    delete process.env[FLAG] // OFF
+    await setBlock('applying')
+    const res = await submit({ data: { [F_STR]: 'form-flag-off' } })
+    expect(res.status).toBe(200) // committed despite the block
+    const id = res.body?.data?.record?.id as string
+    await q('DELETE FROM meta_record_revisions WHERE record_id = $1', [id]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE id = $1', [id]).catch(() => {})
+    await setBlock(null)
+  })
+
+  test('B2 [form-submit EDIT] applying block ⇒ 409, record data unchanged (flag ON)', async () => {
+    const R = mkRecord('b2')
+    await seedRecord(R)
+    process.env[FLAG] = 'true'
+    await setBlock('applying')
+    const res = await submit({ recordId: R, data: { [F_STR]: 'edit-blocked' } })
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('RECOVERY_IN_PROGRESS')
+    expect(await recordData(R)).toMatchObject({ [F_STR]: 'orig' }) // unchanged
+  })
+
+  test('B2b [form-submit EDIT] POSITIVE CONTROL: NO block ⇒ 200 edit applied', async () => {
+    const R = mkRecord('b2b')
+    await seedRecord(R)
+    process.env[FLAG] = 'true'
+    await setBlock(null)
+    const res = await submit({ recordId: R, data: { [F_STR]: 'edit-ok' } })
+    expect(res.status).toBe(200)
+    expect(await recordData(R)).toMatchObject({ [F_STR]: 'edit-ok' })
+  })
+
+  test('B3 [create-field autoNumber → backfill] applying block ⇒ 409, field NOT created (flag ON)', async () => {
+    await seedRecord(mkRecord('b3seed')) // an existing record so backfill has scan rows (not required, but realistic)
+    const F_NEW = mkField('b3an')
+    process.env[FLAG] = 'true'
+    await setBlock('applying')
+    const res = await createField({ id: F_NEW, sheetId: SHEET, name: 'B3 Seq', type: 'autoNumber', order: 7 })
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('RECOVERY_IN_PROGRESS')
+    expect(await fieldExists(F_NEW)).toBe(false) // whole txn rolled back
+  })
+
+  test('B3b [create-field autoNumber] POSITIVE CONTROL: NO block ⇒ 201 field created', async () => {
+    const F_NEW = mkField('b3ban')
+    process.env[FLAG] = 'true'
+    await setBlock(null)
+    const res = await createField({ id: F_NEW, sheetId: SHEET, name: 'B3b Seq', type: 'autoNumber', order: 8 })
+    expect(res.status).toBe(201)
+    expect(await fieldExists(F_NEW)).toBe(true)
+    await q('DELETE FROM meta_config_revisions WHERE entity_id = $1', [F_NEW]).catch(() => {})
+    await q('DELETE FROM meta_field_auto_number_sequences WHERE field_id = $1', [F_NEW]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE id = $1', [F_NEW]).catch(() => {})
+  })
+
+  // ── config-restore-execute record writers (B) ──────────────────────────────────────────────────────────
+
+  test('B4 [config-restore un-create] applying block ⇒ 409, field survives (flag ON)', async () => {
+    const F = mkField('b4')
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F, SHEET, 'B4F', 'string', '{}', 9])
+    const rev = await insertFieldCreateRev(F, 'B4F')
+    process.env[FLAG] = 'true'
+    process.env[UNCREATE_FLAG] = 'true'
+    // The fence is the FIRST statement of the un-create txn (before the preview-token verify), so a dummy token
+    // still 409s at the fence under a block — no valid token needed on the refusal path.
+    await setBlock('applying')
+    const res = await restoreExecute({ revisionId: rev, previewToken: 'dummy-token', confirm: 'uncreate' })
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('RECOVERY_IN_PROGRESS')
+    expect(await fieldExists(F)).toBe(true) // NOT dropped
+    await q('DELETE FROM meta_config_revisions WHERE entity_id = $1', [F]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE id = $1', [F]).catch(() => {})
+  })
+
+  test('B4b [config-restore un-create] POSITIVE CONTROL: NO block ⇒ 200 drops the field (with a real preview token)', async () => {
+    const F = mkField('b4b')
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F, SHEET, 'B4bF', 'string', '{}', 9])
+    const rev = await insertFieldCreateRev(F, 'B4bF')
+    process.env[FLAG] = 'true'
+    process.env[UNCREATE_FLAG] = 'true'
+    await setBlock(null)
+    const pv = await restorePreview(rev)
+    expect(pv.status).toBe(200)
+    const res = await restoreExecute({ revisionId: rev, previewToken: pv.body.data.previewToken, confirm: 'uncreate' })
+    expect(res.status).toBe(200)
+    expect(await fieldExists(F)).toBe(false) // dropped — the fence did NOT block (no active recovery)
+    await q('DELETE FROM meta_config_revisions WHERE entity_id = $1', [F]).catch(() => {})
+  })
+
+  test('B4c [config-restore un-create] FLAG OFF: an applying block is INERT ⇒ NOT 409 RECOVERY (fence no-op)', async () => {
+    const F = mkField('b4c')
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F, SHEET, 'B4cF', 'string', '{}', 9])
+    const rev = await insertFieldCreateRev(F, 'B4cF')
+    delete process.env[FLAG] // fence OFF
+    process.env[UNCREATE_FLAG] = 'true'
+    await setBlock('applying')
+    // Fence no-op ⇒ the request proceeds PAST the fence into the (dummy) token verify → PREVIEW_IDENTITY_INVALID,
+    // NOT the fence's 409 RECOVERY_IN_PROGRESS. Proves the block-refusal is flag-gated.
+    const res = await restoreExecute({ revisionId: rev, previewToken: 'dummy-token', confirm: 'uncreate' })
+    expect(res.body?.error?.code).not.toBe('RECOVERY_IN_PROGRESS')
+    await q('DELETE FROM meta_config_revisions WHERE entity_id = $1', [F]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE id = $1', [F]).catch(() => {})
+    await setBlock(null)
+  })
+
+  test('B5 [config-restore lossy retype-revert — the SEQ-allocating writer] applying block ⇒ 409; flag-off ⇒ not 409 RECOVERY', async () => {
+    // Highest-value config-restore fence: applyLossyRetypeCellRewrite emits one recordRecordRevision per changed
+    // cell (allocates seq). The fence is the FIRST statement of its txn, so with a dummy token a block 409s at the
+    // fence; with the fence flag OFF the request slips past into the downstream lossy machinery (≠ 409 RECOVERY).
+    const F = mkField('b5rating')
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [
+      F, SHEET, 'B5Rating', 'rating', JSON.stringify({ max: 3 }), 10,
+    ])
+    const rev = await insertLossyPropertyRev(F)
+    process.env[RETYPE_FLAG] = 'true'
+    process.env[RETYPE_LOSSY_FLAG] = 'true'
+
+    process.env[FLAG] = 'true' // fence ON
+    await setBlock('applying')
+    const blocked = await restoreExecute({ revisionId: rev, previewToken: 'dummy-token', confirm: 'revert-retype-lossy' })
+    expect(blocked.status).toBe(409)
+    expect(blocked.body?.error?.code).toBe('RECOVERY_IN_PROGRESS')
+
+    delete process.env[FLAG] // fence OFF — positive control: block is inert, the fence's 409 must NOT appear
+    __resetRecoveryWriterStateColumnProbe()
+    await setBlock('applying')
+    const passed = await restoreExecute({ revisionId: rev, previewToken: 'dummy-token', confirm: 'revert-retype-lossy' })
+    expect(passed.body?.error?.code).not.toBe('RECOVERY_IN_PROGRESS')
+
+    await setBlock(null)
+    await q('DELETE FROM meta_config_revisions WHERE entity_id = $1', [F]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE id = $1', [F]).catch(() => {})
+  })
+
+  // ── §R — CONSTRUCTED RACE on a NEWLY-fenced writer (plugin-create). Two raw pg clients + pg_blocking_pids.
+  // A (plugin-create) races recovery B claiming the durable block under the canonical fence. plugin-create takes
+  // the SAME fence key, so A parks behind B (proven via pg_blocking_pids — never a timer), then once A proceeds
+  // it OBSERVES B's committed block (its flag-gated fence-before-check) and throws. throw-if-never-parked keeps
+  // it non-vacuous; removing the block-check (or the durable block) makes A miss B's block ⇒ this reds.
+  test('R1 [plugin-create] fence serialises the writer against a recovery claim; A observes B\'s durable block', async () => {
+    process.env[FLAG] = 'true'
+    await setBlock(null)
+    const b = await poolManager.get().getInternalPool().connect()
+    const a = await poolManager.get().getInternalPool().connect()
+    let aOutcome: 'blocked' | 'proceeded' = 'proceeded'
+    let aErr: unknown
+    let createdId: string | undefined
+    try {
+      await b.query('BEGIN')
+      const bPid = Number((await b.query('SELECT pg_backend_pid() AS pid')).rows[0]!.pid)
+      await b.query('SELECT pg_advisory_xact_lock(hashtext($1))', [canonicalSheetFenceKey(SHEET)])
+      await b.query("UPDATE meta_sheets SET recovery_writer_state = 'applying' WHERE id = $1", [SHEET])
+
+      await a.query('BEGIN')
+      const aQuery = (sql: string, params?: unknown[]) => a.query(sql, params) as unknown as Promise<{ rows: unknown[]; rowCount?: number | null }>
+      const aRun = (async () => {
+        try {
+          const rec = await pluginCreateRecord({ query: aQuery as never, sheetId: SHEET, data: { [F_STR]: 'race-create' } })
+          createdId = (rec as { id: string }).id
+          aOutcome = 'proceeded'
+        } catch (e) {
+          aErr = e
+          aOutcome = 'blocked'
+        }
+      })()
+
+      await waitUntilBlockedOnFence(bPid) // deterministic proof A is parked on B's fence, not racing free
+      await b.query('COMMIT') // B releases the fence AND commits `applying`
+      await aRun
+      await a.query('ROLLBACK').catch(() => {})
+    } finally {
+      a.release()
+      b.release()
+    }
+    expect(aOutcome).toBe('blocked')
+    expect(aErr).toBeInstanceOf(SheetWriterBlockedError)
+    expect((aErr as SheetWriterBlockedError).state).toBe('applying')
+    expect(createdId).toBeUndefined() // never inserted
+    expect(await readBlock()).toBe('applying')
+    await setBlock(null)
+  })
+
+  // ── §C — POST-COMMIT derived-value recompute — ANALYZED, DEFERRED (documented). ─────────────────────────
+  // The relation-aggregation materialization (univer-meta.ts recalculateFormulaFields @≈2973 /
+  // computeDependentLookupRollupRecords @≈3869) and the pure-formula path (formula-engine.ts
+  // recalculateRecordFromData) run POST-COMMIT on a fresh pool connection: record-write-service.ts Step 4/4c
+  // call them with `this.pool.query.bind(this.pool)` AFTER the fenced write txn (line ≈776) has committed. BUT
+  // every one of those writes is an in-place `UPDATE meta_records SET data = data || …` — they emit NO
+  // meta_record_revisions row and allocate NO `seq` (verified: `revision-exempt` in-code + no INSERT into
+  // meta_record_revisions / nextval / chain_seq in formula-engine.ts). So the specific trust hole this lane
+  // targets (non-causal `seq`) is NOT present. A fence here would be behavior-changing (extend the fence-hold
+  // window across heavy recompute; the cross-sheet fan-out touches RELATED sheets and would need multi-sheet
+  // fences; and coupling the user write's durability to recompute success — today a recompute failure is logged
+  // and tolerated). Correct call: DEFER. This placeholder is skipped, not silently absent.
+  test.skip('C [post-commit recompute] DEFERRED — no seq allocated post-commit (in-place data only); see lane report', () => {
+    // Intentionally skipped. The analysis + decision live in the PR body / lane report (§C). If a future slice
+    // moves the recompute into the fenced txn, replace this with a golden proving the recompute\'s seq is
+    // allocated under the fence (causal). Until then, fencing it would be a wrong fence, not a fix.
+    expect(true).toBe(true)
+  })
+})


### PR DESCRIPTION
## W0-1 L4-coverage — univer-meta / records / auto-number writer families

Stacked on **L4** (`claude/w0-l4-all-writer-canonical-fence-20260715`, base of this PR). Closes fence-coverage holes so the PG `seq` allocation order equals the per-sheet commit order for more `meta_records` writers. Everything is behind `MULTITABLE_ENABLE_WRITER_FENCE` (default **OFF**). **DRAFT — do not merge/arm/enable.**

### (A) Close the 3 PARTIAL gaps
These writers already hold the canonical fence **unconditionally** — it is the pre-existing auto-number allocation-serialization lock (`acquireCanonicalSheetFence` = the old `acquireAutoNumberSheetWriteLock`), which predates L4. Replacing it with the flag-gated `fenceWriterEntry` would REMOVE that lock when the flag is off = an auto-number correctness regression, and would violate the fence module's own flag-off-parity contract ("the ONLY callers of `acquireCanonicalSheetFence` with the flag off are … plugin create, form submit, auto-number backfill"). Correct realization: **keep the unconditional fence + add a flag-gated `assertNoActiveWriterBlock`** — semantically identical to `fenceWriterEntry` when the flag is ON, byte-identical when OFF.

- **plugin-create** — `records.ts` `createRecord`
- **auto-number backfill** — `auto-number-service.ts` `backfillAutoNumberField`
- **form-submit create/edit** — `univer-meta.ts` (covers both EDIT + CREATE branches) + `SheetWriterBlockedError` → 409 `RECOVERY_IN_PROGRESS`
- 409 mapping also added to the two `/fields` handlers (POST create-field, PATCH field-property) that run the backfill.

The L4 gap goldens **GX1/GX2** (which asserted these PROCEED under an `applying` block) are converted to assert refusal, exactly as the L4 test header anticipated.

### (B) Fence the in-txn config-restore-execute record writes
Fenced the three record-writing branches at txn entry (fence-before-check) + 409 in the outer catch:
- **un-create** — `dropFieldCascade` strips the dropped field's key from every record (`UPDATE meta_records SET data = data - key`).
- **undelete** — `recreateFieldFromConfig` re-materializes the field's cells.
- **lossy retype-revert** — `applyLossyRetypeCellRewrite` rewrites cells AND emits one `recordRecordRevision` per changed cell, i.e. it **allocates `seq`** — the highest-value target here.

### (C) POST-COMMIT derived-value recompute — ANALYZED, DEFERRED (documented)
The two recompute sites the L4 map flagged (`univer-meta.ts` relation-aggregation materialization + fan-out) and the pure-formula path (`formula-engine.ts`) run **post-commit on a fresh pool connection** (`record-write-service.ts` Step 4/4c call the helpers with `this.pool.query.bind(this.pool)`, after the fenced txn closes). BUT every one of these writes is an in-place `UPDATE meta_records SET data = data || …` — **no `meta_record_revisions` write, no `seq` allocation**. So the specific trust hole this lane targets (non-causal `seq`) is **NOT present** here. Forcing the recompute into the fenced txn would be a behavioral change (extends the fence-hold window across heavy recompute; the cross-sheet fan-out touches RELATED sheets and would need multi-sheet fences; and it would couple the user write's durability to recompute success — today a recompute failure is logged and tolerated). Correct call: **defer**, documented with a skipped placeholder test.

### (D) Out of scope — deferred to `L4-cov-services`
The service-file unfenced families remain unfenced (untouched to avoid collision): `automation-executor.ts`, `automation-service.ts` (approval writeback), `formula-engine.ts`, `approval-record-projection-service.ts`. Also deferred (documented in the honest unfenced map): people/seed presets (`ensurePeopleSheetPreset`, `createSeededSheet`) — revision-exempt system/scaffold writes, no `seq`, sheetId resolved mid-txn / at sheet-birth (no possible active recovery on a just-created or system-mirror sheet).

### Verification
See the real-DB goldens (per-writer production-wiring + block-refusal + a constructed race) and the mutation log in the PR description / lane report. `pnpm --filter @metasheet/core-backend type-check` clean.
