### PR TITLE
feat(multitable): OD-W2-5a — record-history read passes through restored_from_version (R11 inspector badge; fixes History-Center normalizer half-wire)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -757,6 +757,10 @@ function normalizeHistoryChange(raw: unknown): HistoryChange {
     changedFieldIds: Array.isArray(p.changedFieldIds) ? p.changedFieldIds.map(String) : [],
     before: p.before && typeof p.before === 'object' ? (p.before as Record<string, unknown>) : null,
     after: p.after && typeof p.after === 'object' ? (p.after as Record<string, unknown>) : null,
+    // OD-W2-5a half-wire fix: the HistoryChange type + backend payload carry restoredFromVersion but this
+    // normalizer dropped it, so the base History Center badge worked in component tests (which inject objects
+    // directly) yet went blank on the real client wire. Pass it through (badge keys on non-null).
+    restoredFromVersion: typeof p.restoredFromVersion === 'number' ? p.restoredFromVersion : null,
   }
 }
 
@@ -798,6 +802,8 @@ function normalizeRecordHistoryEntry(payload: Partial<MetaRecordRevision> | null
       ? null
       : isPlainObject(payload.snapshot) ? payload.snapshot : {},
     createdAt: typeof payload?.createdAt === 'string' ? payload.createdAt : '',
+    // OD-W2-5a: pass through the R11 restore back-reference so the inspector history badge can render it.
+    restoredFromVersion: typeof payload?.restoredFromVersion === 'number' ? payload.restoredFromVersion : null,
   }
 }
 

--- a/apps/web/src/multitable/components/MetaRecordHistoryPanel.vue
+++ b/apps/web/src/multitable/components/MetaRecordHistoryPanel.vue
@@ -41,6 +41,11 @@
         <div class="meta-record-drawer__history-main">
           <span class="meta-record-drawer__history-action">{{ historyActionLabel(item.action) }}</span>
           <span class="meta-record-drawer__history-version">v{{ item.version }}</span>
+          <span
+            v-if="item.restoredFromVersion != null"
+            class="meta-record-drawer__history-restored"
+            data-test="record-history-restored-from"
+          >{{ restoredFromVersionBadge(item.restoredFromVersion, isZh) }}</span>
         </div>
         <div class="meta-record-drawer__history-meta">
           <span>{{ formatHistoryTime(item.createdAt) }}</span>
@@ -105,6 +110,7 @@ import { useLocale } from '../../composables/useLocale'
 import {
   recordLabel,
   historyActor,
+  restoredFromVersionBadge,
   type MetaRecordLabelKey,
 } from '../utils/meta-record-labels'
 import { formatRecordFieldValue, textControlValue as textControlValueShared } from '../utils/recordDisplay'
@@ -282,6 +288,8 @@ function textControlValue(value: unknown): string {
 .meta-record-drawer__history-main { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 5px; }
 .meta-record-drawer__history-action { font-size: 13px; font-weight: 700; color: #111827; }
 .meta-record-drawer__history-version { font-size: 11px; font-weight: 700; color: #2563eb; background: #eff6ff; border-radius: 999px; padding: 2px 7px; }
+/* OD-W2-5a R11 restore badge — muted, reuses the panel's existing meta color (#64748b), no new hex. */
+.meta-record-drawer__history-restored { font-size: 11px; color: #64748b; font-style: italic; }
 .meta-record-drawer__history-meta { display: flex; flex-wrap: wrap; gap: 6px; font-size: 11px; color: #64748b; }
 .meta-record-drawer__history-fields { margin-top: 8px; font-size: 12px; color: #374151; word-break: break-word; }
 .meta-record-drawer__history-diff { display: flex; align-items: baseline; gap: 8px; padding: 2px 0; }

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -364,6 +364,9 @@ export interface MetaRecordRevision {
   patch: Record<string, unknown>
   snapshot: Record<string, unknown> | null
   createdAt: string
+  /** R11 back-reference (OD-W2-5a): the source record-version this `source='restore'` change restored from, else
+   *  null/absent. Optional so a pre-R11 backend payload still typechecks. The badge renders only when non-null. */
+  restoredFromVersion?: number | null
 }
 
 /** Global History & Point-in-Time Restore — base-level read-only history center (T2/T3). */

--- a/apps/web/tests/multitable-client.spec.ts
+++ b/apps/web/tests/multitable-client.spec.ts
@@ -801,6 +801,9 @@ describe('MultitableApiClient', () => {
             patch: { fld_title: 'Edited again' },
             snapshot: { fld_title: 'Edited again' },
             createdAt: '2026-04-30T10:00:00.000Z',
+            // OD-W2-5a POSITIVE control: this row carries the R11 restore back-reference; it must pass
+            // through. rev_1 (no field) pins the null direction. Guards the required-gate normalizer.
+            restoredFromVersion: 2,
           },
           { id: 'bad' },
         ],
@@ -825,6 +828,7 @@ describe('MultitableApiClient', () => {
         patch: { fld_title: 'Updated' },
         snapshot: { fld_title: 'Updated' },
         createdAt: '2026-04-30T09:00:00.000Z',
+        restoredFromVersion: null,
       },
       {
         id: 'rev_2',
@@ -839,6 +843,7 @@ describe('MultitableApiClient', () => {
         patch: { fld_title: 'Edited again' },
         snapshot: { fld_title: 'Edited again' },
         createdAt: '2026-04-30T10:00:00.000Z',
+        restoredFromVersion: 2,
       },
     ])
     expect(fetchFn).toHaveBeenCalledWith('/api/multitable/sheets/sheet%20history/records/rec%20history/history?limit=25')

--- a/apps/web/tests/multitable-record-history-client-restored-from.spec.ts
+++ b/apps/web/tests/multitable-record-history-client-restored-from.spec.ts
@@ -1,0 +1,78 @@
+// OD-W2-5a client golden: the two history read-path fetchers must pass the R11 restore
+// back-reference (restoredFromVersion) through their normalizers.
+//
+// This is the CLIENT tier of the owner-mandated API/client/component golden triple, and it
+// specifically pins the half-wire that component tests could not catch: MetaRecordHistoryPanel /
+// HistoryCenterModal specs inject already-shaped objects, so a normalizer that DROPPED the field
+// still rendered a badge in-component while the real wire went blank. Here we feed a RAW server
+// payload through the public fetcher and assert the normalized value survives.
+//
+// Positive: a numeric restoredFromVersion on the wire → preserved.
+// Negative: absent / non-number restoredFromVersion → coerced to null (badge keys on non-null).
+import { describe, expect, it, vi } from 'vitest'
+import { MultitableApiClient } from '../src/multitable/api/client'
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+describe('OD-W2-5a — record-history read fetchers pass restoredFromVersion through the client normalizers', () => {
+  describe('listRecordHistory → normalizeRecordHistoryEntry (inspector history tab)', () => {
+    it('preserves a numeric restoredFromVersion from the raw wire payload', async () => {
+      const fetchFn = vi.fn().mockResolvedValue(
+        json({
+          ok: true,
+          data: {
+            items: [
+              { id: 'rev_2', sheetId: 's1', recordId: 'r1', version: 2, action: 'update', restoredFromVersion: 1 },
+              { id: 'rev_1', sheetId: 's1', recordId: 'r1', version: 1, action: 'create' },
+            ],
+          },
+        }),
+      )
+      const client = new MultitableApiClient({ fetchFn })
+      const rows = await client.listRecordHistory('s1', 'r1')
+      expect(rows.find((r) => r.version === 2)?.restoredFromVersion).toBe(1)
+      // NEG in the same wire: an entry with no restoredFromVersion → null, not undefined.
+      expect(rows.find((r) => r.version === 1)?.restoredFromVersion).toBeNull()
+    })
+
+    it('coerces a non-number restoredFromVersion (e.g. a stringified value) to null', async () => {
+      const fetchFn = vi.fn().mockResolvedValue(
+        json({
+          ok: true,
+          data: {
+            items: [
+              { id: 'rev_9', sheetId: 's1', recordId: 'r1', version: 9, action: 'update', restoredFromVersion: '3' },
+            ],
+          },
+        }),
+      )
+      const client = new MultitableApiClient({ fetchFn })
+      const rows = await client.listRecordHistory('s1', 'r1')
+      expect(rows[0]?.restoredFromVersion).toBeNull()
+    })
+  })
+
+  describe('getHistoryBatch → normalizeHistoryChange (base History Center)', () => {
+    it('preserves a numeric restoredFromVersion on a change, and nulls an absent one', async () => {
+      const fetchFn = vi.fn().mockResolvedValue(
+        json({
+          ok: true,
+          data: {
+            batchId: 'bat_1',
+            source: 'rest',
+            createdAt: '2026-07-16T00:00:00.000Z',
+            changes: [
+              { sheetId: 's1', recordId: 'r1', action: 'update', version: 5, restoredFromVersion: 2 },
+              { sheetId: 's1', recordId: 'r1', action: 'update', version: 4 },
+            ],
+          },
+        }),
+      )
+      const client = new MultitableApiClient({ fetchFn })
+      const detail = await client.getHistoryBatch('b1', 'bat_1')
+      expect(detail?.changes.find((c) => c.version === 5)?.restoredFromVersion).toBe(2)
+      expect(detail?.changes.find((c) => c.version === 4)?.restoredFromVersion).toBeNull()
+    })
+  })
+})

--- a/apps/web/tests/multitable-record-history-panel.spec.ts
+++ b/apps/web/tests/multitable-record-history-panel.spec.ts
@@ -296,4 +296,28 @@ describe('MetaRecordHistoryPanel (W2 S2 extraction)', () => {
       app.unmount()
     })
   })
+
+  describe('OD-W2-5a R11 restored-from badge', () => {
+    it('renders the badge for a revision carrying restoredFromVersion (keyed on the version, not source)', async () => {
+      const { container, app } = mountPanel({
+        revisions: [rev(4, 'update', { source: 'restore', restoredFromVersion: 2 }), rev(1, 'create')],
+      })
+      await flushUi()
+      const badge = container.querySelector('[data-test="record-history-restored-from"]')
+      expect(badge).not.toBeNull()
+      expect(badge!.textContent).toContain('v2')
+      app.unmount()
+    })
+
+    it('NEG (owner Medium): source=restore but restoredFromVersion=null → NO badge (badge never keys on source)', async () => {
+      const { container, app } = mountPanel({
+        // A `source='restore'` write with a NULL back-reference (PIT-resurrect / reset / lossy-retype-revert
+        // shape). The badge must key on `restoredFromVersion != null`, NEVER on `source === 'restore'`.
+        revisions: [rev(4, 'update', { source: 'restore', restoredFromVersion: null }), rev(1, 'create')],
+      })
+      await flushUi()
+      expect(container.querySelector('[data-test="record-history-restored-from"]')).toBeNull()
+      app.unmount()
+    })
+  })
 })

--- a/packages/core-backend/src/multitable/record-history-service.ts
+++ b/packages/core-backend/src/multitable/record-history-service.ts
@@ -65,6 +65,11 @@ export interface RecordRevisionEntry {
   snapshot: Record<string, unknown> | null
   batchId?: string | null
   createdAt: string
+  /** OD-W2-5a read-through: the R11 SOURCE record-version this `source='restore'` row restored from, else
+   *  null (only the three record-version restore routes populate `restored_from_version`; every other
+   *  emitter leaves it NULL). The inspector history badge keys on NON-NULL, never on `source='restore'`.
+   *  Null in a pre-migration read window (the SELECT omits the column when the 42703 probe says it's absent). */
+  restoredFromVersion?: number | null
 }
 
 // R11 deploy-window guard for restored_from_version (migration zzzz20260711000000_add_meta_record_revisions_restored_from_version). recordRecordRevision runs INSIDE
@@ -281,6 +286,12 @@ export async function listRecordRevisions(
 ): Promise<RecordRevisionEntry[]> {
   const limit = Math.min(Math.max(Number(input.limit ?? 50), 1), 100)
   const offset = Math.max(Number(input.offset ?? 0), 0)
+  // OD-W2-5a read-through: project `restored_from_version` for the R11 inspector badge. Mirrors the WRITE
+  // side's deploy-window discipline — reuse the same txn-safe 42703 probe; when the column is absent (a
+  // rolling deploy before the migration lands) omit it from the SELECT so the read degrades to the base
+  // shape (serializeRecordRevision then sees undefined ⇒ restoredFromVersion: null) rather than erroring.
+  // The column name is a fixed literal, not user input — no injection surface.
+  const restoredCol = (await hasRestoredFromVersionColumn(query)) ? 'restored_from_version,\n       ' : ''
   const result = await query(
     `SELECT
        id,
@@ -294,7 +305,7 @@ export async function listRecordRevisions(
        patch,
        snapshot,
        batch_id,
-       created_at
+       ${restoredCol}created_at
      FROM meta_record_revisions
      WHERE sheet_id = $1 AND record_id = $2
      ORDER BY version DESC, created_at DESC
@@ -318,6 +329,8 @@ function serializeRecordRevision(row: Record<string, unknown>): RecordRevisionEn
     snapshot: row.snapshot === null || row.snapshot === undefined ? null : normalizeJsonObject(row.snapshot),
     batchId: typeof row.batch_id === 'string' ? row.batch_id : null,
     createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at ?? ''),
+    // OD-W2-5a: undefined when the SELECT omitted the column (pre-migration deploy window) ⇒ null.
+    restoredFromVersion: row.restored_from_version == null ? null : Number(row.restored_from_version),
   }
 }
 

--- a/packages/core-backend/tests/integration/multitable-restore-backreference-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-restore-backreference-realdb.test.ts
@@ -27,7 +27,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { univerMetaRouter } from '../../src/routes/univer-meta'
-import { recordRecordRevision } from '../../src/multitable/record-history-service'
+import { recordRecordRevision, listRecordRevisions } from '../../src/multitable/record-history-service'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
@@ -108,6 +108,23 @@ describeIfDatabase('R11 restore back-reference — restored_from_version (real D
     // the pre-existing non-restore revisions stay NULL
     expect(await restoredFromOf(rid, 1)).toBeNull()
     expect(await restoredFromOf(rid, 2)).toBeNull()
+  })
+
+  test('G4 (OD-W2-5a): the record-history READ (listRecordRevisions) surfaces restoredFromVersion — not just the DB column', async () => {
+    const rid = `rec_rbr_g4_${TS}`
+    await seedRestorable(rid)
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(200)
+    const newVersion = res.body?.data?.newVersion as number
+
+    // This is what the inspector history panel consumes. Before OD-W2-5a the SELECT omitted the column so the
+    // read returned undefined here even though the DB column was populated (proven by G1). Now it passes through.
+    const entries = await listRecordRevisions(q, { sheetId: SHEET_ID, recordId: rid, limit: 50 })
+    const restoreEntry = entries.find((e) => e.version === newVersion)
+    expect(restoreEntry?.restoredFromVersion).toBe(1)
+    // non-restore revisions read back as null (never source-inferred)
+    expect(entries.find((e) => e.version === 1)?.restoredFromVersion ?? null).toBeNull()
+    expect(entries.find((e) => e.version === 2)?.restoredFromVersion ?? null).toBeNull()
   })
 
   test('G1b recordRecordRevision seam: restoredFromVersion=N writes the column; the three routes all share this primitive', async () => {


### PR DESCRIPTION
## OD-W2-5a — record-history READ passes through `restored_from_version`

Owner ruling (直接 GO, a-read-through, no further owner decision, no #4339 dependency): the R11 restore
back-reference column already exists on `origin/main` (landed via #4124, 7月11日) with the write seam and
version-restore wiring. The remaining gap was the **read** path — it stopped at the DB column and never
surfaced `restoredFromVersion` to the inspector history tab, and there was a real half-wire in the base
History Center normalizer.

### What this does
- **Backend read** (`record-history-service.ts`): `listRecordRevisions` now projects `restored_from_version`
  into `RecordRevisionEntry.restoredFromVersion`, guarded by the existing `hasRestoredFromVersionColumn`
  probe so a pre-migration deploy window degrades to `null` (no 42703 / 500) instead of erroring.
- **FE types + normalizers** (`types.ts`, `api/client.ts`): `MetaRecordRevision` carries the field;
  `normalizeRecordHistoryEntry` passes it through. **Fixes the half-wire**: `normalizeHistoryChange`
  previously **dropped** `restoredFromVersion`, so the base History Center badge worked in component
  tests (which inject objects directly) yet went blank on the real client wire.
- **Component** (`MetaRecordHistoryPanel.vue`): renders the existing `restoredFromVersionBadge` **only when
  the field is non-null** — an entry with `source='restore'` but a NULL back-reference shows no badge.

### Verification (API / client / component golden triple, owner-mandated)
- **API (real DB)**: new G4 in `multitable-restore-backreference-realdb.test.ts` — the *read* surfaces
  `restoredFromVersion=1` after a restore; versions 1 & 2 stay null. Ran on fresh PG (9/9). Mutation:
  neutering the read projection reds G4; **dropping the column degrades to null with no 500** (42703 fallback proven).
- **Client**: new `multitable-record-history-client-restored-from.spec.ts` — drives `listRecordHistory` /
  `getHistoryBatch` with a raw wire payload; positive preserves a numeric value, negative coerces
  absent/non-number to null. Mutation-proven (stripping both pass-throughs reds the 2 positive assertions).
  The required-gate `multitable-client.spec.ts` golden is also extended (rev_2 positive, rev_1 null).
- **Component**: `multitable-record-history-panel.spec.ts` — positive (badge with `v2`) + owner-mandated
  **negative** (`source='restore'` + NULL → **no badge**; mutation confirms the `v-if` keys on the field,
  not on `source`).
- Both type-checks clean; the field is additive (no shape rename).

Closes the last authorized W2 runtime slice; the W2 design+verification MD (#4358) §附录 A is updated to
declare W2 complete once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
