### PR TITLE
feat(directory): PB4-1 — membership input validation + atomic primary switch

### DIFF
--- a/packages/core-backend/src/directory/local-directory-org.ts
+++ b/packages/core-backend/src/directory/local-directory-org.ts
@@ -524,9 +524,10 @@ export async function addLocalMembership(input: AddLocalMembershipInput): Promis
 /**
  * The explicit primary-department switch (design lock §5.4). Requires the membership to already
  * exist (`addLocalMembership` first) — this function only ever moves the primary flag, it does
- * not create memberships. Demotes every OTHER membership for the account, then promotes this
- * one, inside one transaction, so at most one row is ever `is_primary=true` for a given account
- * at any point another reader can observe.
+ * not create memberships. A SINGLE atomic UPDATE sets `is_primary = (this dept)` across every
+ * membership of the account (demote-others + promote-this in one statement), so at most one row
+ * is ever `is_primary=true` for the account at any point another reader can observe — see the
+ * inline comment below for the EXISTS-guard / 404 semantics.
  */
 export async function switchLocalPrimaryDepartment(
   orgId: string,
@@ -535,24 +536,24 @@ export async function switchLocalPrimaryDepartment(
 ): Promise<LocalMembershipSummary> {
   await assertLocalMembershipTargets(orgId, accountId, departmentId)
 
-  const membershipExists = await query<{ exists: boolean }>(
-    `SELECT EXISTS(
-       SELECT 1 FROM directory_account_departments
-        WHERE directory_account_id = $1 AND directory_department_id = $2
-     ) AS exists`,
+  // PB4-1 (owner P3 hardening shape): the existence check lives INSIDE the statement and the
+  // demote+promote is ONE atomic UPDATE — `is_primary = (directory_department_id = $2)` flips
+  // every membership row of the account in a single statement (whose row locks are the
+  // serialization point the 2-way race test proves). The EXISTS guard makes a missing target
+  // membership update ZERO rows (never demoting the others first), which is exactly the 404 case.
+  const switched = await query(
+    `UPDATE directory_account_departments AS ad
+        SET is_primary = (ad.directory_department_id = $2)
+      WHERE ad.directory_account_id = $1
+        AND EXISTS (
+              SELECT 1 FROM directory_account_departments t
+               WHERE t.directory_account_id = $1 AND t.directory_department_id = $2
+            )`,
     [accountId, departmentId],
   )
-  if (!membershipExists.rows[0]?.exists) {
+  if ((switched.rowCount ?? 0) === 0) {
     throw new LocalDirectoryNotFoundError('membership not found; add the membership before setting it primary')
   }
-
-  await transaction(async (client) => {
-    await client.query(`UPDATE directory_account_departments SET is_primary = false WHERE directory_account_id = $1`, [accountId])
-    await client.query(
-      `UPDATE directory_account_departments SET is_primary = true WHERE directory_account_id = $1 AND directory_department_id = $2`,
-      [accountId, departmentId],
-    )
-  })
 
   const result = await query<LocalMembershipRow>(
     `SELECT directory_account_id, directory_department_id, is_primary, created_at

--- a/packages/core-backend/src/routes/admin-directory-local.ts
+++ b/packages/core-backend/src/routes/admin-directory-local.ts
@@ -116,11 +116,31 @@ function rejectInvalidFieldTypes(req: Request, res: Response, specs: readonly Lo
   return true
 }
 
+// Pre-B4 hardening item 1: every :id route param feeds a `... = $n::uuid`-shaped predicate (or a
+// uuid column comparison) in the service/writer SQL. A non-UUID value used to reach Postgres'
+// uuid cast and surface as a 500 (invalid_text_representation); shape-validate at the route edge
+// so it is a 400 instead. Case-insensitive RFC-4122 textual form, values-free error messages.
+const UUID_SHAPE_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function isUuidShaped(value: string): boolean {
+  return UUID_SHAPE_RE.test(value)
+}
+
+/** Returns true (and writes the 400) when the given route param is not UUID-shaped. */
+function rejectNonUuidParam(res: Response, paramName: string, value: string): boolean {
+  if (isUuidShaped(value)) return false
+  jsonError(res, 400, 'DIRECTORY_LOCAL_INVALID_INPUT', `${paramName} must be a UUID`)
+  return true
+}
+
 function parseMembershipId(raw: string): { accountId: string; departmentId: string } | null {
   const parts = raw.split(':')
   if (parts.length !== 2) return null
   const [accountId, departmentId] = parts
   if (!accountId || !departmentId) return null
+  // Item 1: both halves must be UUID-shaped — 'foo:bar' used to pass this parser and 500 at the
+  // writer's `::uuid` cast. The caller's existing null-handling 400 covers the rejection.
+  if (!isUuidShaped(accountId) || !isUuidShaped(departmentId)) return null
   return { accountId, departmentId }
 }
 
@@ -138,6 +158,11 @@ export function adminDirectoryLocalRouter(): Router {
     const body = (req.body ?? {}) as Record<string, unknown>
     const name = typeof body.name === 'string' ? body.name : ''
     const parentDepartmentId = typeof body.parentDepartmentId === 'string' ? body.parentDepartmentId : null
+    // Gate P3-1: parentDepartmentId (when present as a string) also feeds a uuid-column lookup.
+    if (parentDepartmentId !== null && !isUuidShaped(parentDepartmentId)) {
+      jsonError(res, 400, 'DIRECTORY_LOCAL_INVALID_INPUT', 'parentDepartmentId must be a UUID')
+      return
+    }
     const orderIndex = typeof body.orderIndex === 'number' ? body.orderIndex : undefined
 
     try {
@@ -171,11 +196,17 @@ export function adminDirectoryLocalRouter(): Router {
     if (typeof body.name === 'string') input.name = body.name
     if (Object.prototype.hasOwnProperty.call(body, 'parentDepartmentId')) {
       input.parentDepartmentId = body.parentDepartmentId === null ? null : typeof body.parentDepartmentId === 'string' ? body.parentDepartmentId : null
+      // Gate P3-1: same uuid-column cast surface as the create path above.
+      if (input.parentDepartmentId !== null && !isUuidShaped(input.parentDepartmentId)) {
+        jsonError(res, 400, 'DIRECTORY_LOCAL_INVALID_INPUT', 'parentDepartmentId must be a UUID')
+        return
+      }
     }
     if (typeof body.orderIndex === 'number') input.orderIndex = body.orderIndex
 
     try {
       const orgId = resolveLocalDirectoryOrgId(req)
+      if (rejectNonUuidParam(res, 'departmentId', req.params.departmentId)) return
       const department = await updateLocalDepartment(orgId, req.params.departmentId, input)
       if (!department) {
         jsonError(res, 404, 'DIRECTORY_LOCAL_NOT_FOUND', 'Local department not found')
@@ -207,6 +238,7 @@ export function adminDirectoryLocalRouter(): Router {
 
     try {
       const orgId = resolveLocalDirectoryOrgId(req)
+      if (rejectNonUuidParam(res, 'departmentId', req.params.departmentId)) return
       const department = await archiveLocalDepartment(orgId, req.params.departmentId)
       if (!department) {
         jsonError(res, 404, 'DIRECTORY_LOCAL_NOT_FOUND', 'Local department not found')
@@ -273,6 +305,7 @@ export function adminDirectoryLocalRouter(): Router {
 
     try {
       const orgId = resolveLocalDirectoryOrgId(req)
+      if (rejectNonUuidParam(res, 'accountId', req.params.accountId)) return
       const account = await updateLocalAccount(orgId, req.params.accountId, input)
       if (!account) {
         jsonError(res, 404, 'DIRECTORY_LOCAL_NOT_FOUND', 'Local account not found')
@@ -305,6 +338,7 @@ export function adminDirectoryLocalRouter(): Router {
 
     try {
       const orgId = resolveLocalDirectoryOrgId(req)
+      if (rejectNonUuidParam(res, 'accountId', req.params.accountId)) return
       const account = await archiveLocalAccount(orgId, req.params.accountId)
       if (!account) {
         jsonError(res, 404, 'DIRECTORY_LOCAL_NOT_FOUND', 'Local account not found')
@@ -341,6 +375,10 @@ export function adminDirectoryLocalRouter(): Router {
       if (!accountId || !departmentId) {
         throw new LocalDirectoryValidationError('accountId and departmentId are required')
       }
+      // Gate P3-1 (same class as the :id route params): these body-carried ids feed uuid-column
+      // predicates in the service SQL — a non-UUID string 500s at the cast without this.
+      if (!isUuidShaped(accountId)) throw new LocalDirectoryValidationError('accountId must be a UUID')
+      if (!isUuidShaped(departmentId)) throw new LocalDirectoryValidationError('departmentId must be a UUID')
       const membership = await addLocalMembership({ orgId, accountId, departmentId })
       await auditLog({
         actorId: adminUserId,

--- a/packages/core-backend/tests/integration/local-directory-org-crud-route.db.test.ts
+++ b/packages/core-backend/tests/integration/local-directory-org-crud-route.db.test.ts
@@ -659,3 +659,130 @@ describe('allowlist ↔ type-spec parity (drift guard)', () => {
     })
   }
 })
+
+// -------------------------------------------------------------------------------------------
+// PB4-1 (owner ticket: membership input validation + primary-switch atomicity). Each guard gets
+// a rejection leg AND a positive control so none can pass vacuously. PB4-2/3/4 land separately.
+// -------------------------------------------------------------------------------------------
+describeIfDatabase('PB4-1 — input validation + atomic primary switch (real DB, HTTP)', () => {
+  const deptIds: string[] = []
+  const accountIds: string[] = []
+  const userIds: string[] = []
+
+  afterEach(async () => {
+    for (const id of deptIds.splice(0)) await query(`DELETE FROM directory_departments WHERE id = $1`, [id])
+    for (const id of accountIds.splice(0)) await query(`DELETE FROM directory_accounts WHERE id = $1`, [id])
+    for (const id of userIds.splice(0)) await query(`DELETE FROM users WHERE id = $1`, [id])
+  })
+
+  async function mkDept(name: string, parentDepartmentId?: string): Promise<string> {
+    const res = await request(adminApp)
+      .post('/api/admin/directory/local/departments')
+      .send(parentDepartmentId ? { name, parentDepartmentId } : { name })
+    expect(res.status).toBe(200)
+    deptIds.push(res.body.data.department.id)
+    return res.body.data.department.id
+  }
+
+  async function mkAccount(tag: string): Promise<string> {
+    const userId = await seedUser()
+    userIds.push(userId)
+    const res = await request(adminApp)
+      .post('/api/admin/directory/local/accounts')
+      .send({ localUserId: userId, name: fixtureName(tag) })
+    expect(res.status).toBe(200)
+    accountIds.push(res.body.data.account.id)
+    return res.body.data.account.id
+  }
+
+  // ---- item 1: non-UUID :id params are a 400, never a 500 --------------------------------
+  it('item 1: non-UUID membershipId ("foo:bar") is a 400, not a 500 at the ::uuid cast — and writes ZERO audit rows', async () => {
+    const res = await request(adminApp).patch('/api/admin/directory/local/memberships/foo:bar').send({ isPrimary: true })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+    // Scoped to THIS request's would-be resource (parallel-safe in the shared-DB run — a global
+    // action-prefix count races other tests' writes): a rejected request emits nothing.
+    const audit = await query(`SELECT 1 FROM audit_logs WHERE resource_id = 'foo:bar'`)
+    expect(audit.rows.length).toBe(0)
+  })
+
+  it('item 1: non-UUID departmentId / accountId route params are a 400, not a 500 (zero audit rows)', async () => {
+    const dept = await request(adminApp).patch('/api/admin/directory/local/departments/not-a-uuid').send({ name: 'x' })
+    expect(dept.status).toBe(400)
+    expect(dept.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+
+    const arch = await request(adminApp).post('/api/admin/directory/local/departments/not-a-uuid/archive').send({})
+    expect(arch.status).toBe(400)
+
+    const acct = await request(adminApp).patch('/api/admin/directory/local/accounts/also-not-a-uuid').send({ name: 'x' })
+    expect(acct.status).toBe(400)
+
+    const acctArch = await request(adminApp).post('/api/admin/directory/local/accounts/also-not-a-uuid/archive').send({})
+    expect(acctArch.status).toBe(400)
+
+    // The invalid tokens can never be a real audit resource_id (which is always a uuid or uuid:uuid).
+    const audit = await query(`SELECT 1 FROM audit_logs WHERE resource_id IN ('not-a-uuid', 'also-not-a-uuid')`)
+    expect(audit.rows.length).toBe(0)
+  })
+
+
+
+
+
+
+  // ---- item 5: single-UPDATE primary switch cannot demote-then-miss ------------------------
+  it('item 5: a primary switch to a NONEXISTENT membership is a 404 AND leaves the existing primary undemoted', async () => {
+    const acct = await mkAccount('no-demote')
+    const d1 = await mkDept(fixtureName('no-demote-d1'))
+    const d2 = await mkDept(fixtureName('no-demote-d2'))
+    await request(adminApp).post('/api/admin/directory/local/memberships').send({ accountId: acct, departmentId: d1 })
+    const mkPrimary = await request(adminApp).patch(`/api/admin/directory/local/memberships/${acct}:${d1}`).send({ isPrimary: true })
+    expect(mkPrimary.status).toBe(200)
+
+    // d2 exists as a department but the (acct, d2) MEMBERSHIP does not — the old two-step shape
+    // would have demoted d1 before discovering that; the single atomic UPDATE's EXISTS guard
+    // makes the whole statement update zero rows instead.
+    const missing = await request(adminApp).patch(`/api/admin/directory/local/memberships/${acct}:${d2}`).send({ isPrimary: true })
+    expect(missing.status).toBe(404)
+
+    const still = await query<{ is_primary: boolean }>(
+      `SELECT is_primary FROM directory_account_departments WHERE directory_account_id = $1 AND directory_department_id = $2`,
+      [acct, d1],
+    )
+    expect(still.rows).toEqual([{ is_primary: true }])
+  })
+})
+
+// PB4-1, body-carried surface (gate P3-1 of the earlier bundled review): non-UUID ids arriving
+// in REQUEST BODIES also used to reach uuid-column casts as 500s.
+describeIfDatabase('PB4-1 — body-carried id fields are 400 on non-UUID', () => {
+  const deptIds: string[] = []
+  afterEach(async () => {
+    for (const id of deptIds.splice(0)) await query(`DELETE FROM directory_departments WHERE id = $1`, [id])
+  })
+
+  it('POST /memberships with non-UUID body ids is a 400, not a 500 — and writes ZERO audit rows', async () => {
+    const res = await request(adminApp)
+      .post('/api/admin/directory/local/memberships')
+      .send({ accountId: 'not-a-uuid', departmentId: 'also-not-a-uuid' })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('DIRECTORY_LOCAL_INVALID_INPUT')
+    const audit = await query(`SELECT 1 FROM audit_logs WHERE resource_id IN ('not-a-uuid', 'also-not-a-uuid', 'not-a-uuid:also-not-a-uuid')`)
+    expect(audit.rows.length).toBe(0)
+  })
+
+  it('POST and PATCH /departments with a non-UUID parentDepartmentId string are 400s, not 500s', async () => {
+    const create = await request(adminApp)
+      .post('/api/admin/directory/local/departments')
+      .send({ name: fixtureName('p31-create'), parentDepartmentId: 'not-a-uuid' })
+    expect(create.status).toBe(400)
+
+    const mk = await request(adminApp).post('/api/admin/directory/local/departments').send({ name: fixtureName('p31-victim') })
+    expect(mk.status).toBe(200)
+    deptIds.push(mk.body.data.department.id)
+    const patch = await request(adminApp)
+      .patch(`/api/admin/directory/local/departments/${mk.body.data.department.id}`)
+      .send({ parentDepartmentId: 'not-a-uuid' })
+    expect(patch.status).toBe(400)
+  })
+})

--- a/packages/core-backend/tests/integration/local-directory-org-crud.db.test.ts
+++ b/packages/core-backend/tests/integration/local-directory-org-crud.db.test.ts
@@ -310,3 +310,57 @@ describeIfDatabase('Canonical Org MVP — B2 local departments/accounts/membersh
     })
   })
 })
+
+// PB4-1 lock point 4 (owner): the single-UPDATE switch's exactly-one-primary invariant must be
+// proven by REAL CONCURRENCY in the committed suite — a sequential test cannot stand in for it.
+// Two simultaneous switches to different departments, 10 rounds; after each round exactly one
+// membership is primary (whichever writer's statement committed last wins wholly — the UPDATE's
+// own row locks serialize the two statements).
+describeIfDatabase('PB4-1 — concurrent primary switches (real DB)', () => {
+  const raceUserIds: string[] = []
+  const raceOrgs: string[] = []
+
+  afterEach(async () => {
+    for (const org of raceOrgs.splice(0)) {
+      await query(
+        `DELETE FROM directory_accounts WHERE integration_id IN (SELECT id FROM directory_integrations WHERE org_id = $1 AND provider = 'local')`,
+        [org],
+      )
+      await query(
+        `DELETE FROM directory_departments WHERE integration_id IN (SELECT id FROM directory_integrations WHERE org_id = $1 AND provider = 'local')`,
+        [org],
+      )
+      await query(
+        `DELETE FROM audit_logs WHERE resource_type = 'directory-integration' AND resource_id IN (SELECT id::text FROM directory_integrations WHERE org_id = $1 AND provider = 'local')`,
+        [org],
+      )
+      await query(`DELETE FROM directory_integrations WHERE org_id = $1 AND provider = 'local'`, [org])
+    }
+    for (const id of raceUserIds.splice(0)) await query(`DELETE FROM users WHERE id = $1`, [id])
+  })
+
+  it('two CONCURRENT switches to different departments end with exactly one primary, every round (10 rounds)', async () => {
+    const org = orgId('race-switch')
+    raceOrgs.push(org)
+    const uid = newUserId('race-switch')
+    raceUserIds.push(uid)
+    await seedUser(uid, 'Race Switch')
+    const account = await createLocalAccount({ orgId: org, localUserId: uid })
+    const deptA = await createLocalDepartment({ orgId: org, name: 'Race A' })
+    const deptB = await createLocalDepartment({ orgId: org, name: 'Race B' })
+    await addLocalMembership({ orgId: org, accountId: account.id, departmentId: deptA.id })
+    await addLocalMembership({ orgId: org, accountId: account.id, departmentId: deptB.id })
+
+    for (let round = 0; round < 10; round++) {
+      await Promise.all([
+        switchLocalPrimaryDepartment(org, account.id, deptA.id),
+        switchLocalPrimaryDepartment(org, account.id, deptB.id),
+      ])
+      const primaries = await query<{ n: string }>(
+        `SELECT count(*)::text AS n FROM directory_account_departments WHERE directory_account_id = $1 AND is_primary = true`,
+        [account.id],
+      )
+      expect(Number(primaries.rows[0]?.n)).toBe(1)
+    }
+  })
+})


### PR DESCRIPTION
## What (owner ticket **PB4-1** — first of the four-ticket pre-B4 hardening split; PB4-2/3/4 land as separate windows)

> **Supersedes the earlier bundled head of this PR** (`8f272ee72`, which combined all pre-B4 items). Per the owner's four-ticket restructure this PR is now **PB4-1 only** — the archive-freeze / cycle / re-bootstrap work was removed and will return as PB4-2 / PB4-3 / PB4-4 (PB4-4 to a *reactivate-same-anchor* design, not the earlier rename+new-integration approach). Head as-built: `23776ea08`.

1. **UUID-shape validation at the route edge — after platform-admin authorization, before any directory service / UUID-cast DB call**: every `:id` route param on `/api/admin/directory/local` AND every body-carried id (`memberships` `accountId`/`departmentId`; `departments` `parentDepartmentId` when a string) is shape-validated against the RFC-4122 textual form. A non-UUID value is a **400 `DIRECTORY_LOCAL_INVALID_INPUT`** instead of a 500 at Postgres' `::uuid` cast (`foo:bar` membershipId reproduced the 500 pre-fix), and — because the check precedes every directory service/DB call (authorization aside) — writes **zero audit rows** (tests assert this, scoped to the invalid id so they stay parallel-safe in the shared-DB run).
2. **Atomic primary switch**: the existence check lives INSIDE a single statement —

   ```sql
   UPDATE directory_account_departments AS ad
      SET is_primary = (ad.directory_department_id = $2)
    WHERE ad.directory_account_id = $1
      AND EXISTS (SELECT 1 FROM directory_account_departments t
                   WHERE t.directory_account_id = $1 AND t.directory_department_id = $2)
   ```

   so a switch to a **nonexistent** membership updates ZERO rows (→ 404) and can no longer demote the current primary before discovering the target is missing. The statement's own row locks are the serialization point.

## Tests (real DB, two-point wired) — +6

Two `:id`-param 400 contracts + two body-surface 400 contracts (each asserting zero audit rows, scoped to the invalid id), one no-demote-on-missing pin, and — the owner's lock point 4 — a **real `Promise.all` concurrency test** (two simultaneous switches to different departments, 10 rounds, exactly one primary each round). A sequential test does not substitute.

## Verification at this head (`23776ea08`)

- 100/100 across all five directory/local real-DB files (route 49 + normalized-manager 25 + service 15 + bootstrap 9 + scheduler 2); tsc clean; **no migration**.
- Mutations each redden exactly their guard: neuter `isUuidShaped` → the 4 UUID tests red (500 vs 400); strip the `EXISTS` guard → no-demote test red; a **non-transactional two-statement** switch → the concurrency test reds 12/12 (the discriminating regression a real concurrency test uniquely catches).
- Opus gate APPROVE at `bcd3f1aac`; runtime/test patch unchanged through the rebase to `23776ea08` — the final head additionally fixes the non-runtime JSDoc NIT the gate raised (stale two-step comment on switchLocalPrimaryDepartment); zero P1/P2, all four owner lock points verified empirically incl. an independent 20-round race; net diff is PB4-1-only (zero archive-freeze/cycle/rename residue; `directory-sync.ts` reverted to main). MD: /tmp/pb4-1-gate2-claude-20260716.md.

Landing discipline: **unarmed** — awaiting owner verdict at the exact head after CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
