### PR TITLE
fix(ops): make stock-prep smoke capture PowerShell 5.1-safe

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -99,6 +99,29 @@ jobs:
             scripts/ops/github-dingtalk-oauth-stability-summary.test.mjs \
             scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
 
+  stock-prep-powershell51:
+    name: stock-prep PowerShell 5.1 acceptance
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      # The release package runs this acceptance boundary under Windows PowerShell 5.1. pwsh 7 has
+      # different native-stderr semantics and cannot stand in for the target shell contract.
+      - name: Run target-shell smoke capture regression
+        shell: powershell
+        run: |
+          $powershell51 = "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe"
+          & $powershell51 -NoProfile -ExecutionPolicy Bypass -File `
+            scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
   test:
     runs-on: ubuntu-latest
 
@@ -129,12 +152,10 @@ jobs:
       - name: Prod health probe monitor contract
         run: node --test scripts/ops/prod-health-probe-state.test.mjs
 
-      # #4210 T9: the stock-preparation one-click acceptance script's contract + behavioural tests (56
-      # checks = 18 contract + 38 behavioural) are pure pwsh 7 + tar + node (no DB, no live server — the
-      # pm2/health/smoke stages are unit-tested via dot-sourced pure helpers). Run inside the REQUIRED
-      # `test` gate, but only ONCE (on 20.x — no need across the 18/20 matrix), early (no pnpm install
-      # needed: pwsh/tar ship on ubuntu, node is already set up) so a regression fails the required check
-      # fast. This is the only CI that executes these checks.
+      # #4210 T9: the stock-preparation one-click acceptance script's cross-platform contract + behavioural
+      # tests are pure pwsh 7 + tar + node. Run once in the required 20.x arm. The package's target-shell
+      # semantics are covered separately by the Windows PowerShell 5.1 job above; neither shell substitutes
+      # for the other.
       - name: Run stock-preparation on-prem acceptance tests (T9, pwsh)
         if: matrix.node-version == '20.x'
         shell: pwsh

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -226,12 +226,10 @@ try {
   $o = Test-SmokeOutcome "mvpSmoke.pass=true`nauditActionsCovered=8/8"
   Check "smoke: selfScanClean ABSENT -> FAIL (fail-closed)" ((-not $o.ok) -and $o.reason -eq 'self_scan_not_clean')
 
-  # ── D5 (corrective-3): the stage-6 smoke capture is stdout-ONLY (2>$null), never merged (2>&1). A child
-  # that writes noise to stderr AND a valid values-free summary to stdout must NOT abort the capture (the
-  # RC-0 POWERSHELL_NATIVE_STDERR_PROMOTION failure — where 2>&1 promoted native stderr to a terminating
-  # error and the smoke's summary was never read), must NOT let the stderr text contaminate the parsed
-  # summary, and must still parse PASS. Mutation guards: flip 2>$null back to 2>&1 and the sentinel check reds;
-  # hard-code the captured exit to zero and the non-zero preservation + stage fail-closed checks red.
+  # ── D5 (corrective-3/4): the stage-6 smoke capture is stdout-ONLY (2>$null), never merged (2>&1).
+  # Corrective-4 also scopes ErrorActionPreference=Continue around only the native invocation so Windows
+  # PowerShell 5.1 does not promote discarded stderr to a terminating error. The dedicated powershell.exe
+  # 5.1 CI test is the load-bearing target-shell proof; this pwsh 7 leg keeps cross-version coverage.
   $fakeSmokeRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("t9accept_fakesmoke_" + [guid]::NewGuid().ToString('N').Substring(0, 12))
   $fakeSmokeOps = Join-Path $fakeSmokeRoot 'scripts/ops'
   New-Item -ItemType Directory -Path $fakeSmokeOps -Force | Out-Null
@@ -254,9 +252,15 @@ try {
   Check "corrective-3: the stderr sentinel is NOT captured into the parsed summary (2>`$null, not 2>&1)" ($null -ne $cap -and -not ("$($cap.stdout)" -match [regex]::Escape($sentinel)))
   $capOutcome = Test-SmokeOutcome "$($cap.stdout)"
   Check "corrective-3: the stdout values-free summary still parses to PASS (8/8, clean)" ($capOutcome.ok -and $capOutcome.pass -and $capOutcome.audit -eq '8/8' -and $capOutcome.selfScan)
-  Check "corrective-3: exit code preserved (0) and the token env var is cleared after capture" ($null -ne $cap -and $cap.exit -eq 0 -and -not (Test-Path Env:METASHEET_AUTH_TOKEN))
+  Check "corrective-4: exit 0 preserves code, restores error policy, and clears token env" (
+    $null -ne $cap -and
+    $cap.exit -eq 0 -and
+    $ErrorActionPreference -eq 'Stop' -and
+    -not (Test-Path Env:METASHEET_AUTH_TOKEN)
+  )
 
   $nonzeroLines = @(
+    "process.stderr.write('$sentinel\n')",
     "process.stdout.write('mvpSmoke.pass=true\n')",
     "process.stdout.write('auditActionsCovered=8/8\n')",
     "process.stdout.write('selfScanClean=true\n')",
@@ -264,8 +268,11 @@ try {
   )
   Set-Content -LiteralPath $fakeSmoke -Encoding utf8 -Value ($nonzeroLines -join "`n")
   $nonzeroCap = Invoke-SmokeCapture -NodeArgs @($fakeSmoke) -Token $dummyToken
-  Check "corrective-3: non-zero native exit code is preserved exactly (7), never normalized to success" (
-    $nonzeroCap.exit -eq 7 -and -not (Test-Path Env:METASHEET_AUTH_TOKEN)
+  Check "corrective-4: stderr-writing exit 7 preserves code, policy, and token cleanup" (
+    $nonzeroCap.exit -eq 7 -and
+    $nonzeroCap.stdout -notmatch [regex]::Escape($sentinel) -and
+    $ErrorActionPreference -eq 'Stop' -and
+    -not (Test-Path Env:METASHEET_AUTH_TOKEN)
   )
 
   # Exercise the real stage boundary in a child pwsh process because Stop-WithFailure intentionally exits.

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
@@ -1,0 +1,105 @@
+#requires -Version 5.1
+# Target-shell regression tests for stock-preparation-onprem-acceptance.ps1.
+#
+# The packaged Windows path runs under Windows PowerShell 5.1, whose native stderr handling differs
+# from pwsh 7. These tests must run with powershell.exe on windows-latest. A child that writes both
+# stdout and stderr must still return its stdout and exact exit code while the runner's global
+# ErrorActionPreference remains Stop.
+$ErrorActionPreference = 'Stop'
+$scriptPath = Join-Path $PSScriptRoot '..' 'stock-preparation-onprem-acceptance.ps1'
+$pass = 0
+$fail = 0
+
+function Check {
+  param([string]$Name, [bool]$Ok)
+  if ($Ok) {
+    $script:pass++
+    Write-Host "  PASS  $Name"
+  } else {
+    $script:fail++
+    Write-Host "  FAIL  $Name"
+  }
+}
+
+Check 'host is Windows PowerShell 5.1 Desktop' (
+  $PSVersionTable.PSEdition -eq 'Desktop' -and
+  $PSVersionTable.PSVersion.Major -eq 5 -and
+  $PSVersionTable.PSVersion.Minor -eq 1
+)
+
+$root = Join-Path ([System.IO.Path]::GetTempPath()) ("t9accept_ps51_" + [guid]::NewGuid().ToString('N').Substring(0, 12))
+$fakeSmoke = Join-Path $root 'fake-smoke.mjs'
+$sentinel = 'PS51-STDERR-SENTINEL-4210'
+
+try {
+  New-Item -ItemType Directory -Path $root -Force | Out-Null
+  . $scriptPath -PackagePath $root -DeployRoot $root *> $null
+  $dummyToken = ConvertTo-SecureString 'dummy-not-a-real-token' -AsPlainText -Force
+
+  Set-Content -LiteralPath $fakeSmoke -Encoding ASCII -Value @(
+    "process.stderr.write('$sentinel\\n')"
+    "process.stdout.write('mvpSmoke.pass=true\\n')"
+    "process.stdout.write('auditActionsCovered=8/8\\n')"
+    "process.stdout.write('selfScanClean=true\\n')"
+    'process.exit(0)'
+  )
+
+  $zeroCapture = $null
+  $zeroThrew = $false
+  try {
+    $zeroCapture = Invoke-SmokeCapture -NodeArgs @($fakeSmoke) -Token $dummyToken
+  } catch {
+    $zeroThrew = $true
+  }
+
+  Check 'stderr-writing exit-0 child does not abort capture' (-not $zeroThrew -and $null -ne $zeroCapture)
+  Check 'exit-0 stdout summary is captured' (
+    $null -ne $zeroCapture -and
+    $zeroCapture.stdout -match 'mvpSmoke\.pass=true' -and
+    $zeroCapture.stdout -match 'auditActionsCovered=8/8' -and
+    $zeroCapture.stdout -match 'selfScanClean=true'
+  )
+  Check 'exit-0 stderr is excluded from stdout' ($null -ne $zeroCapture -and $zeroCapture.stdout -notmatch $sentinel)
+  Check 'exit-0 code is preserved exactly' ($null -ne $zeroCapture -and $zeroCapture.exit -eq 0)
+  Check 'exit-0 restores error policy and clears token env' (
+    $ErrorActionPreference -eq 'Stop' -and -not (Test-Path Env:METASHEET_AUTH_TOKEN)
+  )
+
+  Set-Content -LiteralPath $fakeSmoke -Encoding ASCII -Value @(
+    "process.stderr.write('$sentinel\\n')"
+    "process.stdout.write('mvpSmoke.pass=true\\n')"
+    "process.stdout.write('auditActionsCovered=8/8\\n')"
+    "process.stdout.write('selfScanClean=true\\n')"
+    'process.exit(7)'
+  )
+
+  $sevenCapture = $null
+  $sevenThrew = $false
+  try {
+    $sevenCapture = Invoke-SmokeCapture -NodeArgs @($fakeSmoke) -Token $dummyToken
+  } catch {
+    $sevenThrew = $true
+  }
+
+  Check 'stderr-writing exit-7 child does not abort capture' (-not $sevenThrew -and $null -ne $sevenCapture)
+  Check 'exit-7 stdout is captured and stderr remains excluded' (
+    $null -ne $sevenCapture -and
+    $sevenCapture.stdout -match 'mvpSmoke\.pass=true' -and
+    $sevenCapture.stdout -notmatch $sentinel
+  )
+  Check 'exit-7 code is preserved exactly' ($null -ne $sevenCapture -and $sevenCapture.exit -eq 7)
+  Check 'exit-7 restores error policy and clears token env' (
+    $ErrorActionPreference -eq 'Stop' -and -not (Test-Path Env:METASHEET_AUTH_TOKEN)
+  )
+} finally {
+  Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+  Remove-Item Env:METASHEET_AUTH_TOKEN -ErrorAction SilentlyContinue
+}
+
+if ($fail -gt 0) {
+  Write-Host "FAILED: $fail check(s); $pass passed"
+  exit 1
+}
+
+Write-Host "ALL POWERSHELL 5.1 CHECKS PASS ($pass/10)"
+exit 0

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
@@ -6,7 +6,8 @@
 # stdout and stderr must still return its stdout and exact exit code while the runner's global
 # ErrorActionPreference remains Stop.
 $ErrorActionPreference = 'Stop'
-$scriptPath = Join-Path $PSScriptRoot '..' 'stock-preparation-onprem-acceptance.ps1'
+$opsDir = Join-Path $PSScriptRoot '..'
+$scriptPath = Join-Path $opsDir 'stock-preparation-onprem-acceptance.ps1'
 $pass = 0
 $fail = 0
 

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
@@ -45,6 +45,11 @@ $smokeStages = @($acceptanceAst.FindAll({
   $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
     $node.Name -eq 'Invoke-SmokeStage'
 }, $true))
+$smokeCaptureFunctions = @($acceptanceAst.FindAll({
+  param($node)
+  $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+    $node.Name -eq 'Invoke-SmokeCapture'
+}, $true))
 $smokeCaptureCalls = if ($smokeStages.Count -eq 1) {
   @($smokeStages[0].Body.FindAll({
     param($node)
@@ -86,6 +91,20 @@ Check "smoke stage delegates native execution to the summary-only capture bounda
   'NodeArgs' -in $smokeCaptureParams -and
   'Token' -in $smokeCaptureParams -and
   $directSmokeNodeCalls.Count -eq 0
+)
+$scopedPolicyTry = if ($smokeCaptureFunctions.Count -eq 1) {
+  @($smokeCaptureFunctions[0].Body.FindAll({
+    param($node)
+    $node -is [System.Management.Automation.Language.TryStatementAst] -and
+      $null -ne $node.Finally -and
+      $node.Body.Extent.Text -match '\$ErrorActionPreference\s*=\s*["'']Continue["'']' -and
+      $node.Finally.Extent.Text -match '\$ErrorActionPreference\s*=\s*\$previousErrorActionPreference'
+  }, $true))
+} else { @() }
+Check "native smoke invocation scopes and restores ErrorActionPreference" (
+  $smokeCaptureFunctions.Count -eq 1 -and
+  $smokeCaptureFunctions[0].Extent.Text -match '\$previousErrorActionPreference\s*=\s*\$ErrorActionPreference' -and
+  $scopedPolicyTry.Count -eq 1
 )
 
 # The package template and acceptance runner are one operator contract. A stale default makes a healthy

--- a/scripts/ops/stock-preparation-onprem-acceptance.ps1
+++ b/scripts/ops/stock-preparation-onprem-acceptance.ps1
@@ -369,20 +369,25 @@ function Invoke-HealthStage {
 
 # ── Summary-only smoke capture (pure, unit-testable). Runs the child smoke and returns ONLY its stdout
 # summary text + exit code. stderr is redirected to $null (2>$null), NEVER merged into the success stream
-# (2>&1). Two reasons: (1) Node warnings / any stderr noise must never contaminate the parsed values-free
-# summary; (2) under PowerShell 7.3+ native-command error handling, a child that writes to stderr while
-# its stream is merged (2>&1) can be PROMOTED to a terminating error that ABORTS the capture before the
-# smoke's summary is ever read — the RC-0 acceptance-runner compatibility failure the entity machine hit
-# (POWERSHELL_NATIVE_STDERR_PROMOTION): the smoke ran, but the runner threw instead of parsing its output.
-# The admin token crosses to the child ONLY as a scoped env var, cleared (with its BSTR) in a finally.
+# (2>&1). Windows PowerShell 5.1 still promotes native stderr under a global ErrorActionPreference=Stop,
+# even with null redirection. Scope Continue to this one native invocation, capture $LASTEXITCODE, and
+# restore the caller's policy in finally. The surrounding runner remains fail-closed. Node warnings / any
+# stderr noise never enter the parsed values-free summary. The admin token crosses to the child ONLY as a
+# scoped env var, cleared (with its BSTR) in the outer finally.
 function Invoke-SmokeCapture {
   param([string[]]$NodeArgs, [SecureString]$Token)
   $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Token)
+  $previousErrorActionPreference = $ErrorActionPreference
   try {
     # Token crosses to the child ONLY as a scoped env var — never on the command line / ArgumentList.
     $env:METASHEET_AUTH_TOKEN = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
-    $out = & node @NodeArgs 2>$null  # stdout ONLY; stderr discarded (see function header)
-    $exit = $LASTEXITCODE
+    try {
+      $ErrorActionPreference = 'Continue'
+      $out = & node @NodeArgs 2>$null  # stdout ONLY; stderr discarded (see function header)
+      $exit = $LASTEXITCODE
+    } finally {
+      $ErrorActionPreference = $previousErrorActionPreference
+    }
   } finally {
     [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
     Remove-Item Env:METASHEET_AUTH_TOKEN -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Root cause

The corrective-3 package runs the acceptance boundary under Windows PowerShell 5.1, but its required behavioral gate only exercised Ubuntu `pwsh 7`. With global `ErrorActionPreference=Stop`, Windows PowerShell 5.1 promotes native stderr to a terminating `RemoteException` even when the command uses `2>$null`, so stdout and the smoke summary are never captured.

## Scoped correction

- save the caller's `ErrorActionPreference`
- set `Continue` only around the native Node invocation
- capture stdout and `$LASTEXITCODE`
- restore the prior policy in an inner `finally`
- retain the outer SecureString/BSTR and token-env cleanup
- keep stderr excluded from the values-free summary
- keep all surrounding runner stages fail-closed

## Target-shell gate

Adds a stable `stock-prep PowerShell 5.1 acceptance` job on `windows-latest` that explicitly invokes `powershell.exe` 5.1. Its child writes both stdout and stderr at exit 0 and exit 7. The gate asserts stdout capture, stderr exclusion, exact exit-code preservation, error-policy restoration, and token-env cleanup.

### Red-first evidence

The first harness attempt exposed a PS5.1-only `Join-Path` fixture incompatibility and was not counted. After correcting only that fixture, test-only head `279a9bab659aaa934686c6b1b935b81a36c3a95e` ran in [Actions 29473870072](https://github.com/zensgit/metasheet2/actions/runs/29473870072) and produced the load-bearing result:

```text
host=PowerShell 5.1 Desktop PASS
captureChecks=3/10 PASS, 7 FAIL
exit0Capture=FAIL
exit7Capture=FAIL
policyAndTokenCleanup=PASS
```

After the scoped runner fix, rebased exact head `292b6d780` ran the same target-shell job in [Actions 29474124328](https://github.com/zensgit/metasheet2/actions/runs/29474124328):

```text
powershell51=10/10 PASS
exit0Capture=PASS
exit7Capture=PASS
stderrExcluded=PASS
exitCodePreserved=PASS
errorPolicyRestored=PASS
tokenEnvCleared=PASS
```

Local cross-version checks:

```text
staticContracts=19/19 PASS
pwsh7Behavior=38/38 PASS
workflowYamlParse=PASS
gitDiffCheck=PASS
```

## Boundary

No business smoke logic, migration, PM2 behavior, package contents, T3b runtime, external-write path, credentials, host values, or entity-machine action changes in this PR. No package should be cut and no entity rerun should occur until this exact head is independently reviewed, merged, and the Windows PowerShell 5.1 check is registered as required on `main`.

Refs #4101.