### PR TITLE
test(attendance-web): guard focused admin rail behavior

### DIFF
--- a/.github/workflows/attendance-web-guard.yml
+++ b/.github/workflows/attendance-web-guard.yml
@@ -8,7 +8,8 @@
 # Scope (deliberately TARGETED): run the green attendance admin-surface guard specs —
 # attendance-admin-regressions.spec.ts (overview admin-only-preload guard + AE-3
 # result-edit modal matrix), attendance-admin-anchor-nav.spec.ts (member resolve / nav
-# guards), AttendanceRequestCenterSection.result-edit.spec.ts (request-center parity
+# guards), useAttendanceAdminRail.spec.ts (org-scoped memory + retired all-sections-mode
+# guard), AttendanceRequestCenterSection.result-edit.spec.ts (request-center parity
 # for the shared AE-3 result-edit callback), attendance-selfservice-dashboard.spec.ts,
 # attendance-caliber-transparency.spec.ts (display-only 口径透明 slice — #3575 design-lock:
 # G1 records-header title, G2 team-availability legend equation, G3 caliber-guide card),
@@ -68,6 +69,7 @@ on:
       - 'apps/web/src/views/attendance/**'
       - 'apps/web/tests/attendance-admin-regressions.spec.ts'
       - 'apps/web/tests/attendance-admin-anchor-nav.spec.ts'
+      - 'apps/web/tests/useAttendanceAdminRail.spec.ts'
       - 'apps/web/tests/AttendanceRequestCenterSection.result-edit.spec.ts'
       - 'apps/web/tests/attendance-selfservice-dashboard.spec.ts'
       - 'apps/web/tests/attendance-caliber-transparency.spec.ts'
@@ -104,6 +106,7 @@ on:
       - 'apps/web/src/views/attendance/**'
       - 'apps/web/tests/attendance-admin-regressions.spec.ts'
       - 'apps/web/tests/attendance-admin-anchor-nav.spec.ts'
+      - 'apps/web/tests/useAttendanceAdminRail.spec.ts'
       - 'apps/web/tests/AttendanceRequestCenterSection.result-edit.spec.ts'
       - 'apps/web/tests/attendance-selfservice-dashboard.spec.ts'
       - 'apps/web/tests/attendance-caliber-transparency.spec.ts'
@@ -174,4 +177,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run attendance web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav useAttendanceAdminRail AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust --reporter=dot

--- a/apps/web/tests/useAttendanceAdminRail.spec.ts
+++ b/apps/web/tests/useAttendanceAdminRail.spec.ts
@@ -125,7 +125,7 @@ describe('useAttendanceAdminRail', () => {
     scope.stop()
   })
 
-  it('reloads and persists focused mode per org-scoped storage bucket', async () => {
+  it('ignores legacy all-sections preferences and stays focused across org scopes', async () => {
     window.localStorage.setItem(
       scopedKey(ADMIN_NAV_FOCUS_MODE_STORAGE_KEY, 'org-b'),
       JSON.stringify(false),
@@ -148,11 +148,11 @@ describe('useAttendanceAdminRail', () => {
 
     scopeRef.value = 'org-b'
     await flushUi()
-    expect(rail.adminFocusedMode.value).toBe(false)
+    expect(rail.adminFocusedMode.value).toBe(true)
 
-    rail.adminFocusedMode.value = true
+    scopeRef.value = undefined
     await flushUi()
-    expect(window.localStorage.getItem(scopedKey(ADMIN_NAV_FOCUS_MODE_STORAGE_KEY, 'org-b'))).toBe('true')
+    expect(rail.adminFocusedMode.value).toBe(true)
 
     scope.stop()
   })


### PR DESCRIPTION
## What changed

- update the stale admin-rail spec to reflect the intentional retirement of all-sections mode
- assert that a legacy org-scoped `false` preference cannot re-enable the retired mode
- wire `useAttendanceAdminRail.spec.ts` into the attendance web guard run list and both path filters

## Why

`loadAdminNavFocusedMode` has intentionally normalized every scope to focused mode since #586, but this spec still expected the old per-org `false` behavior. The spec was also absent from CI, so the test-vs-runtime drift remained invisible.

This PR changes no runtime behavior. It provides a small guard-coverage hardening adjacent to the #4353 admin-center review.

## Verification

- `pnpm --filter @metasheet/web exec vitest run useAttendanceAdminRail.spec.ts attendance-admin-anchor-nav --reporter=dot` (33 passed)
- full attendance web guard command (26 files, 483 tests passed)
- `pnpm --filter @metasheet/web exec eslint tests/useAttendanceAdminRail.spec.ts`
- mutation: changing the focused-mode loader to return `false` makes the new assertion fail; restored before commit
