### PR TITLE
feat(approval): refresh center and template authoring UI

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -399,34 +399,8 @@ html, body {
   }
 }
 
-/* Dark mode support */
-@media (prefers-color-scheme: dark) {
-  html, body {
-    background-color: #1a1a1a;
-    color: #e0e0e0;
-  }
-
-  .app-nav {
-    background: #2d2d2d;
-    border-bottom-color: #404040;
-  }
-
-  .brand-text {
-    color: #64b5f6;
-  }
-
-  .nav-link {
-    color: #aaa;
-  }
-
-  .nav-link:hover {
-    background-color: #3d3d3d;
-    color: #fff;
-  }
-
-  .nav-link.router-link-active {
-    background-color: #1e3a5f;
-    color: #64b5f6;
-  }
-}
+/* The UI foundation currently defines a complete light theme only. Do not partially
+   switch the application shell from the operating-system preference: doing so places
+   light Element Plus surfaces and dark-token text on a dark page. A future dark theme
+   must switch the complete token set and component-library variables together. */
 </style>

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -34,9 +34,10 @@
       <div class="approval-center__filters-primary">
           <el-input
             v-model="searchText"
-            placeholder="搜索标题、发起人或审批编号"
+            placeholder="搜索标题或审批编号"
             clearable
             class="approval-center__toolbar-search"
+            data-testid="approval-search-input"
             @clear="handleSearch"
             @keyup.enter="handleSearch"
           >
@@ -1096,7 +1097,6 @@ function clearFilters() {
   currentPage.value = 1
   clearPendingSelection()
   loadCurrentTab()
-  void refreshPendingBadgeCount()
 }
 
 function handleSourceSystemChange() {

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -1,11 +1,40 @@
 <template>
-  <PageShell width="default">
-    <PageHeader class="approval-center__header" title="审批中心">
+  <PageShell width="wide">
+    <PageHeader
+      class="approval-center__header"
+      title="审批中心"
+      subtitle="集中处理待办、跟进我发起的申请，并快速识别超时事项"
+    >
+      <template #meta>
+        <span class="approval-center__stat">
+          <span>待办</span>
+          <strong>{{ pendingTotalCount }}</strong>
+        </span>
+        <span class="approval-center__stat approval-center__stat--unread">
+          <span>未读</span>
+          <strong>{{ pendingBadgeCount }}</strong>
+        </span>
+        <span v-if="activeFilterCount > 0" class="approval-center__filter-summary">
+          已启用 {{ activeFilterCount }} 项筛选
+        </span>
+      </template>
       <template #actions>
-        <div class="approval-center__toolbar">
+        <el-button
+          v-if="canWrite"
+          type="primary"
+          class="approval-center__create-button"
+          @click="router.push({ name: 'approval-template-list' })"
+        >
+          发起审批
+        </el-button>
+      </template>
+    </PageHeader>
+
+    <section class="approval-center__filters" aria-label="审批筛选">
+      <div class="approval-center__filters-primary">
           <el-input
             v-model="searchText"
-            placeholder="搜索审批编号或标题"
+            placeholder="搜索标题、发起人或审批编号"
             clearable
             class="approval-center__toolbar-search"
             @clear="handleSearch"
@@ -15,6 +44,32 @@
               <el-icon><Search /></el-icon>
             </template>
           </el-input>
+          <el-select
+            v-model="sourceSystemFilter"
+            placeholder="来源系统"
+            class="approval-center__toolbar-select"
+            data-testid="approval-source-filter"
+            @change="handleSourceSystemChange"
+          >
+            <el-option label="全部来源" value="all" />
+            <el-option label="平台审批" value="platform" />
+            <el-option label="PLM 审批" value="plm" />
+          </el-select>
+          <el-button
+            class="approval-center__filter-toggle"
+            :type="filtersExpanded ? 'primary' : 'default'"
+            :plain="filtersExpanded"
+            data-testid="approval-more-filters"
+            @click="filtersExpanded = !filtersExpanded"
+          >
+            {{ filtersExpanded ? '收起筛选' : '更多筛选' }}
+            <span v-if="advancedFilterCount > 0" class="approval-center__filter-count">
+              {{ advancedFilterCount }}
+            </span>
+          </el-button>
+      </div>
+
+      <div v-show="filtersExpanded" class="approval-center__filters-advanced">
           <el-select
             v-model="statusFilter"
             placeholder="状态筛选"
@@ -26,17 +81,6 @@
             <el-option label="已通过" value="approved" />
             <el-option label="已驳回" value="rejected" />
             <el-option label="已撤回" value="revoked" />
-          </el-select>
-          <el-select
-            v-model="sourceSystemFilter"
-            placeholder="来源系统"
-            class="approval-center__toolbar-select"
-            data-testid="approval-source-filter"
-            @change="handleSourceSystemChange"
-          >
-            <el-option label="全部来源" value="all" />
-            <el-option label="平台审批" value="platform" />
-            <el-option label="PLM 审批" value="plm" />
           </el-select>
           <!-- B3-03 (模板/时间筛选): additive filters composing with the existing status/source
                filters above — templateId + a created-at window, mirroring the backend's own
@@ -72,16 +116,16 @@
             @change="handleSearch"
           />
           <el-button
-            v-if="canWrite"
-            type="primary"
-            class="approval-center__toolbar-button"
-            @click="router.push({ name: 'approval-template-list' })"
+            text
+            class="approval-center__clear-filters"
+            :disabled="activeFilterCount === 0"
+            data-testid="approval-clear-filters"
+            @click="clearFilters"
           >
-            发起审批
+            清空筛选
           </el-button>
-        </div>
-      </template>
-    </PageHeader>
+      </div>
+    </section>
 
     <el-alert
       v-if="store.error"
@@ -967,9 +1011,24 @@ const sourceSystemFilter = ref<'all' | 'platform' | 'plm'>('all')
 const templateFilter = ref('')
 const templateOptions = ref<Array<{ id: string; name: string }>>([])
 const createdRange = ref<[string, string] | null>(null)
+const filtersExpanded = ref(false)
 const currentPage = ref(1)
 const pageSize = ref(10)
 const attendanceRequestsSection = 'attendance-overview-requests'
+
+const advancedFilterCount = computed(() => [
+  statusFilter.value,
+  templateFilter.value,
+  createdRange.value,
+].filter(Boolean).length)
+
+const activeFilterCount = computed(() => [
+  searchText.value.trim(),
+  sourceSystemFilter.value === 'all' ? '' : sourceSystemFilter.value,
+  statusFilter.value,
+  templateFilter.value,
+  createdRange.value,
+].filter(Boolean).length)
 
 // B3-03: `createdRange` holds plain `YYYY-MM-DD` day boundaries from the picker (or a deep link);
 // widen to inclusive day-start/day-end ISO timestamps for the server, the same convention
@@ -1026,6 +1085,18 @@ function handleSearch() {
   currentPage.value = 1
   clearPendingSelection()
   loadCurrentTab()
+}
+
+function clearFilters() {
+  searchText.value = ''
+  statusFilter.value = ''
+  sourceSystemFilter.value = 'all'
+  templateFilter.value = ''
+  createdRange.value = null
+  currentPage.value = 1
+  clearPendingSelection()
+  loadCurrentTab()
+  void refreshPendingBadgeCount()
 }
 
 function handleSourceSystemChange() {
@@ -1104,6 +1175,7 @@ function applyDeepLinkFilters(): void {
   const fromDate = typeof rawCreatedFrom === 'string' && rawCreatedFrom ? rawCreatedFrom.slice(0, 10) : ''
   const toDate = typeof rawCreatedTo === 'string' && rawCreatedTo ? rawCreatedTo.slice(0, 10) : ''
   createdRange.value = fromDate && toDate ? [fromDate, toDate] : null
+  filtersExpanded.value = Boolean(templateFilter.value || createdRange.value)
 }
 
 // B3-03: params-only navigation to /approvals (e.g. a second 看板钻取 link clicked while this
@@ -1149,10 +1221,76 @@ onMounted(() => {
   padding: var(--ms-space-4) 0;
 }
 
-.approval-center__toolbar {
+.approval-center__header {
+  margin-bottom: var(--ms-space-4);
+}
+
+.approval-center__stat,
+.approval-center__filter-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ms-space-2);
+  min-height: 28px;
+  padding: var(--ms-space-1) var(--ms-space-3);
+  border: 1px solid var(--ms-border-light);
+  border-radius: 999px;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-2);
+  font-size: 13px;
+}
+
+.approval-center__stat strong {
+  color: var(--ms-text-1);
+  font-size: 15px;
+}
+
+.approval-center__stat--unread strong {
+  color: var(--ms-color-danger);
+}
+
+.approval-center__filter-summary {
+  background: var(--el-color-primary-light-9);
+  border-color: var(--el-color-primary-light-7);
+  color: var(--ms-color-primary);
+}
+
+.approval-center__filters {
+  display: grid;
+  gap: var(--ms-space-3);
+  margin-bottom: var(--ms-space-4);
+  padding: var(--ms-space-4);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-lg);
+  background: var(--ms-bg-card);
+  box-shadow: var(--ms-shadow-card);
+}
+
+.approval-center__filters-primary,
+.approval-center__filters-advanced {
   display: flex;
   align-items: center;
   gap: var(--ms-space-3);
+  flex-wrap: wrap;
+}
+
+.approval-center__filters-advanced {
+  padding-top: var(--ms-space-3);
+  border-top: 1px solid var(--ms-border-light);
+}
+
+.approval-center__filter-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  margin-left: var(--ms-space-1);
+  padding: 0 var(--ms-space-1);
+  border-radius: 999px;
+  background: var(--el-color-primary-light-8);
+  color: var(--ms-color-primary);
+  font-size: 12px;
+  font-weight: 600;
 }
 
 .approval-center__toolbar-search {
@@ -1174,11 +1312,20 @@ onMounted(() => {
 }
 
 .approval-center__error {
-  margin-bottom: 16px;
+  margin-bottom: var(--ms-space-4);
 }
 
 .approval-center__tabs {
-  margin-top: 8px;
+  min-height: 480px;
+  padding: 0 var(--ms-space-4) var(--ms-space-4);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-lg);
+  background: var(--ms-bg-card);
+  box-shadow: var(--ms-shadow-card);
+}
+
+.approval-center__tabs :deep(.el-tabs__header) {
+  margin-bottom: var(--ms-space-4);
 }
 
 .approval-center__pagination {
@@ -1326,6 +1473,16 @@ onMounted(() => {
   line-height: 1.5;
 }
 
+@media (max-width: 1100px) {
+  .approval-center__toolbar-search {
+    flex: 1 1 320px;
+  }
+
+  .approval-center__toolbar-daterange {
+    flex: 1 1 260px;
+  }
+}
+
 @media (max-width: 720px) {
   .approval-center__attendance-entry {
     align-items: flex-start;
@@ -1338,8 +1495,12 @@ onMounted(() => {
    should reflow on any narrow viewport so the search + filters never overflow
    horizontally. */
 @media (max-width: 768px) {
-  .approval-center__toolbar {
-    flex-wrap: wrap;
+  .approval-center__filters {
+    padding: var(--ms-space-3);
+  }
+
+  .approval-center__filters-primary,
+  .approval-center__filters-advanced {
     gap: var(--ms-space-2);
   }
 
@@ -1350,8 +1511,14 @@ onMounted(() => {
   .approval-center__toolbar-search,
   .approval-center__toolbar-select,
   .approval-center__toolbar-daterange,
-  .approval-center__toolbar-button {
+  .approval-center__filter-toggle,
+  .approval-center__clear-filters,
+  .approval-center__create-button {
     width: 100%;
+  }
+
+  .approval-center__tabs {
+    padding: 0 var(--ms-space-3) var(--ms-space-3);
   }
 
   .approval-center__pagination {

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -1725,6 +1725,15 @@ watch(
 }
 
 .approval-detail__form,
+.approval-detail__timeline {
+  min-width: 0;
+  padding: var(--ms-space-5);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-lg);
+  background: var(--ms-bg-card);
+  box-shadow: var(--ms-shadow-card);
+}
+
 .approval-detail__actor-avatar {
   display: inline-flex;
   align-items: center;
@@ -1740,18 +1749,12 @@ watch(
   vertical-align: middle;
 }
 
-.approval-detail__timeline {
-  background: var(--ms-bg-card);
-  border: 1px solid var(--el-border-color-lighter);
-  border-radius: 8px;
-  padding: 20px;
-}
-
 .approval-detail__form h2,
 .approval-detail__timeline h2 {
-  font-size: 16px;
-  font-weight: 600;
-  margin: 0 0 16px;
+  margin: 0 0 var(--ms-space-4);
+  color: var(--ms-text-1);
+  font-size: var(--ms-font-size-section-title);
+  font-weight: var(--ms-font-weight-title);
 }
 
 .approval-detail__meta {
@@ -1937,12 +1940,13 @@ watch(
    snapshot / timeline scroll underneath, instead of requiring a scroll-to-bottom first. The
    safe-area padding keeps the buttons clear of the home-indicator area on notched devices. */
 .approval-detail__actions {
-  margin-top: 24px;
-  padding: 16px 20px;
+  margin-top: var(--ms-space-5);
+  padding: var(--ms-space-4) var(--ms-space-5);
   padding-bottom: calc(8px + env(safe-area-inset-bottom));
-  background: var(--el-bg-color);
-  border: 1px solid var(--el-border-color-lighter);
-  border-radius: 8px;
+  background: var(--ms-bg-card);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-lg);
+  box-shadow: var(--ms-shadow-pop);
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -1,13 +1,23 @@
 <template>
-  <PageShell width="default">
+  <PageShell width="wide">
     <PageHeader
       class="template-authoring__header"
       :title="isEditMode ? '编辑审批模板' : '新建审批模板'"
-      subtitle="面向模板管理员的线性审批模板编辑器"
+      subtitle="分步完成基础信息、表单、流程与发布校验"
       back
       back-label="返回模板列表"
       @back="goBack"
     >
+      <template #meta>
+        <span
+          class="template-authoring__save-state"
+          :class="{ 'template-authoring__save-state--dirty': isDraftDirty }"
+        >
+          {{ draftStateLabel }}
+        </span>
+        <span class="template-authoring__meta-count">{{ draft.fields.length }} 个表单字段</span>
+        <span class="template-authoring__meta-count">{{ authoringFlowNodeCount }} 个流程节点</span>
+      </template>
       <template #actions>
         <div class="template-authoring__actions">
           <el-button
@@ -81,8 +91,41 @@
     </el-alert>
 
     <div v-loading="loading" class="template-authoring__body">
+      <div class="template-authoring__workspace">
+        <nav class="template-authoring__steps" aria-label="模板配置步骤">
+          <div class="template-authoring__steps-heading">
+            <strong>模板配置</strong>
+            <span>按步骤完成，随时可保存草稿</span>
+          </div>
+          <el-button
+            v-for="(section, index) in authoringSections"
+            :key="section.id"
+            class="template-authoring__step"
+            :class="{ 'is-active': activeAuthoringSection === section.id }"
+            text
+            :data-testid="`approval-template-section-${section.id}`"
+            @click="selectAuthoringSection(section.id)"
+          >
+            <span class="template-authoring__step-index">{{ index + 1 }}</span>
+            <span class="template-authoring__step-copy">
+              <strong>{{ section.label }}</strong>
+              <small>{{ section.description }}</small>
+            </span>
+            <span
+              v-if="section.id === 'fields'"
+              class="template-authoring__step-count"
+            >{{ draft.fields.length }}</span>
+            <span
+              v-else-if="section.id === 'flow'"
+              class="template-authoring__step-count"
+            >{{ authoringFlowNodeCount }}</span>
+          </el-button>
+        </nav>
+
+        <main class="template-authoring__content">
       <el-card
         v-if="showPresetLibrary"
+        v-show="activeAuthoringSection === 'basic'"
         class="template-authoring__panel"
         shadow="never"
         data-testid="approval-template-preset-library"
@@ -117,7 +160,7 @@
         </div>
       </el-card>
 
-      <el-card class="template-authoring__panel" shadow="never">
+      <el-card v-show="activeAuthoringSection === 'basic'" class="template-authoring__panel" shadow="never">
         <template #header>
           <strong>基本信息</strong>
         </template>
@@ -165,7 +208,7 @@
         </el-form>
       </el-card>
 
-      <el-card class="template-authoring__panel" shadow="never">
+      <el-card v-show="activeAuthoringSection === 'fields'" class="template-authoring__panel" shadow="never">
         <template #header>
           <div class="template-authoring__panel-header">
             <strong>表单字段</strong>
@@ -393,7 +436,7 @@
         </div>
       </el-card>
 
-      <el-card class="template-authoring__panel" shadow="never">
+      <el-card v-show="activeAuthoringSection === 'flow'" class="template-authoring__panel" shadow="never">
         <template #header>
           <div class="template-authoring__panel-header">
             <strong>{{ graphReadOnly ? '审批流程（结构）' : '审批步骤' }}</strong>
@@ -1179,7 +1222,7 @@
         </div>
       </el-card>
 
-      <el-card class="template-authoring__panel" shadow="never">
+      <el-card v-show="activeAuthoringSection === 'review'" class="template-authoring__panel" shadow="never">
         <template #header>
           <strong>JSON 预览</strong>
         </template>
@@ -1198,6 +1241,7 @@
            the shared race-guard controller (RP-2's createRoutePreviewController, made generic). -->
       <el-card
         v-if="canManageTemplates"
+        v-show="activeAuthoringSection === 'review'"
         class="template-authoring__panel"
         shadow="never"
         data-testid="approval-template-tryrun-panel"
@@ -1396,6 +1440,34 @@
           </ul>
         </div>
       </el-card>
+          <div class="template-authoring__section-actions">
+            <el-button
+              :disabled="authoringSectionIndex === 0"
+              data-testid="approval-template-section-previous"
+              @click="moveAuthoringSection(-1)"
+            >
+              上一步
+            </el-button>
+            <el-button
+              v-if="authoringSectionIndex < authoringSections.length - 1"
+              type="primary"
+              data-testid="approval-template-section-next"
+              @click="moveAuthoringSection(1)"
+            >
+              下一步
+            </el-button>
+            <el-button
+              v-else
+              type="primary"
+              :disabled="!canSave"
+              data-testid="approval-template-section-publish"
+              @click="openPublishChecklist"
+            >
+              检查并发布
+            </el-button>
+          </div>
+        </main>
+      </div>
     </div>
 
     <!-- B2-03: publish pre-flight checklist — replaces the old "confirm first, validate after"
@@ -1554,6 +1626,18 @@ const unsupportedReason = ref<string | null>(null)
 // unsupported — the form/metadata stay editable and save preserves the graph verbatim.
 const graphReadOnlyMessage = ref<string | null>(null)
 const draft = ref<TemplateAuthoringDraft>(createEmptyTemplateDraft())
+type AuthoringSectionId = 'basic' | 'fields' | 'flow' | 'review'
+const authoringSections: Array<{
+  id: AuthoringSectionId
+  label: string
+  description: string
+}> = [
+  { id: 'basic', label: '基础设置', description: '名称、范围与模板起点' },
+  { id: 'fields', label: '表单设计', description: '字段、校验与显隐规则' },
+  { id: 'flow', label: '审批流程', description: '审批人、分支与字段权限' },
+  { id: 'review', label: '测试发布', description: '预览、试运行与发布检查' },
+]
+const activeAuthoringSection = ref<AuthoringSectionId>('basic')
 // B1-07: dirty baseline for discard protection — refreshed on every load/save so only real
 // unsaved edits trigger the leave confirm. Serialized compare; the draft is rebuilt from the
 // same builders on load/save, so key order is deterministic.
@@ -1576,6 +1660,30 @@ const readOnly = computed(() => !canManageTemplates.value || Boolean(unsupported
 // linear steps editor is hidden. The graph is preserved on save, so this does NOT disable save.
 const graphReadOnly = computed(() => Boolean(graphReadOnlyMessage.value))
 const canSave = computed(() => canManageTemplates.value && !unsupportedReason.value && !loading.value)
+const draftStateLabel = computed(() => {
+  if (!isEditMode.value && !isDraftDirty.value) return '新模板'
+  return isDraftDirty.value ? '有未保存更改' : '已保存'
+})
+const authoringFlowNodeCount = computed(() => (
+  graphReadOnly.value
+    ? draft.value.preservedGraph?.nodes.length ?? 0
+    : draft.value.steps.length
+))
+const authoringSectionIndex = computed(() => (
+  authoringSections.findIndex(section => section.id === activeAuthoringSection.value)
+))
+
+function selectAuthoringSection(section: AuthoringSectionId) {
+  activeAuthoringSection.value = section
+}
+
+function moveAuthoringSection(delta: -1 | 1) {
+  const nextIndex = Math.min(
+    authoringSections.length - 1,
+    Math.max(0, authoringSectionIndex.value + delta),
+  )
+  activeAuthoringSection.value = authoringSections[nextIndex].id
+}
 
 // G-1 read-only structured render of a preserved complex graph: a per-node summary of the
 // config the v1 editor doesn't yet author, so authors can SEE the flow they're preserving.
@@ -2513,18 +2621,167 @@ onUnmounted(() => {
   justify-content: flex-end;
 }
 
+.template-authoring__header {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  padding: var(--ms-space-3) 0;
+  border-bottom: 1px solid var(--ms-border-light);
+  background: var(--ms-bg-page);
+}
+
+.template-authoring__save-state,
+.template-authoring__meta-count {
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: var(--ms-space-1) var(--ms-space-3);
+  border: 1px solid var(--ms-border-light);
+  border-radius: 999px;
+  background: var(--ms-bg-card);
+  color: var(--ms-text-2);
+  font-size: 12px;
+}
+
+.template-authoring__save-state::before {
+  width: 7px;
+  height: 7px;
+  margin-right: var(--ms-space-2);
+  border-radius: 50%;
+  background: var(--ms-color-success);
+  content: '';
+}
+
+.template-authoring__save-state--dirty::before {
+  background: var(--ms-color-warning);
+}
+
 .template-authoring__alert {
   margin-bottom: 16px;
 }
 
 .template-authoring__body {
+  min-height: 560px;
+}
+
+.template-authoring__workspace {
+  display: grid;
+  grid-template-columns: 232px minmax(0, 1fr);
+  align-items: start;
+  gap: var(--ms-space-5);
+}
+
+.template-authoring__steps {
+  position: sticky;
+  top: 116px;
+  display: grid;
+  gap: var(--ms-space-2);
+  padding: var(--ms-space-3);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-lg);
+  background: var(--ms-bg-card);
+  box-shadow: var(--ms-shadow-card);
+}
+
+.template-authoring__steps-heading {
+  display: grid;
+  gap: var(--ms-space-1);
+  padding: var(--ms-space-2) var(--ms-space-2) var(--ms-space-3);
+  color: var(--ms-text-1);
+}
+
+.template-authoring__steps-heading span {
+  color: var(--ms-text-3);
+  font-size: 12px;
+}
+
+.template-authoring__step {
+  width: 100%;
+  height: auto;
+  min-height: 58px;
+  margin: 0;
+  padding: var(--ms-space-2);
+  color: var(--ms-text-2);
+  white-space: normal;
+}
+
+.template-authoring__step :deep(> span) {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--ms-space-2);
+  width: 100%;
+  text-align: left;
+}
+
+.template-authoring__step.is-active {
+  background: var(--el-color-primary-light-9);
+  color: var(--ms-color-primary);
+}
+
+.template-authoring__step-index,
+.template-authoring__step-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--el-fill-color-light);
+  color: var(--ms-text-2);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.template-authoring__step.is-active .template-authoring__step-index {
+  background: var(--ms-color-primary);
+  color: var(--ms-bg-card);
+}
+
+.template-authoring__step-count {
+  width: auto;
+  min-width: 24px;
+  height: 22px;
+  padding: 0 var(--ms-space-1);
+  border-radius: 999px;
+}
+
+.template-authoring__step-copy {
+  display: grid;
+  gap: 2px;
+}
+
+.template-authoring__step-copy small {
+  color: var(--ms-text-3);
+  font-size: 11px;
+  font-weight: 400;
+}
+
+.template-authoring__content {
   display: flex;
+  min-width: 0;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--ms-space-4);
 }
 
 .template-authoring__panel {
-  border-radius: 8px;
+  border-color: var(--ms-border-light);
+  border-radius: var(--ms-radius-lg);
+  box-shadow: var(--ms-shadow-card);
+}
+
+.template-authoring__section-actions {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  display: flex;
+  justify-content: space-between;
+  gap: var(--ms-space-3);
+  padding: var(--ms-space-3) var(--ms-space-4);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-lg);
+  background: var(--ms-bg-card);
+  box-shadow: var(--ms-shadow-pop);
 }
 
 .template-authoring__panel-header,
@@ -2810,13 +3067,58 @@ pre {
   font-size: 12px;
 }
 
+@media (max-width: 1024px) {
+  .template-authoring__workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .template-authoring__steps {
+    position: sticky;
+    top: 108px;
+    z-index: 2;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .template-authoring__steps-heading {
+    display: none;
+  }
+
+  .template-authoring__step-copy small,
+  .template-authoring__step-count {
+    display: none;
+  }
+
+  .template-authoring__step :deep(> span) {
+    grid-template-columns: 28px minmax(0, 1fr);
+  }
+}
+
 @media (max-width: 760px) {
+  .template-authoring__header {
+    position: static;
+  }
+
+  .template-authoring__actions,
+  .template-authoring__actions :deep(.el-button) {
+    width: 100%;
+  }
+
+  .template-authoring__steps {
+    top: 0;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .template-authoring__grid {
     grid-template-columns: 1fr;
   }
 
   .template-authoring__preset-grid {
     grid-template-columns: 1fr;
+  }
+
+  .template-authoring__section-actions :deep(.el-button) {
+    flex: 1;
+    min-height: 44px;
   }
 }
 

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -75,20 +75,27 @@
       data-testid="approval-template-graph-readonly-alert"
     />
 
-    <el-alert
+    <div
       v-if="loadError || validationErrors.length"
-      :title="loadError || '请修正后再保存'"
-      type="error"
-      show-icon
-      class="template-authoring__alert"
-      @close="clearErrors"
+      ref="validationSummaryRef"
+      class="template-authoring__validation-summary"
+      data-testid="approval-template-validation-summary"
+      tabindex="-1"
     >
-      <template v-if="validationErrors.length" #default>
-        <ul class="template-authoring__error-list">
-          <li v-for="error in validationErrors" :key="error">{{ error }}</li>
-        </ul>
-      </template>
-    </el-alert>
+      <el-alert
+        :title="loadError || '请修正后再保存'"
+        type="error"
+        show-icon
+        class="template-authoring__alert"
+        @close="clearErrors"
+      >
+        <template v-if="validationErrors.length" #default>
+          <ul class="template-authoring__error-list">
+            <li v-for="error in validationErrors" :key="error">{{ error }}</li>
+          </ul>
+        </template>
+      </el-alert>
+    </div>
 
     <div v-loading="loading" class="template-authoring__body">
       <div class="template-authoring__workspace">
@@ -103,6 +110,7 @@
             class="template-authoring__step"
             :class="{ 'is-active': activeAuthoringSection === section.id }"
             text
+            :aria-current="activeAuthoringSection === section.id ? 'step' : undefined"
             :data-testid="`approval-template-section-${section.id}`"
             @click="selectAuthoringSection(section.id)"
           >
@@ -122,7 +130,11 @@
           </el-button>
         </nav>
 
-        <main class="template-authoring__content">
+        <main
+          ref="authoringContentRef"
+          class="template-authoring__content"
+          data-testid="approval-template-workspace-content"
+        >
       <el-card
         v-if="showPresetLibrary"
         v-show="activeAuthoringSection === 'basic'"
@@ -1522,7 +1534,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import PageShell from '../../components/layout/PageShell.vue'
 import PageHeader from '../../components/layout/PageHeader.vue'
 import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
@@ -1549,6 +1561,7 @@ import {
   buildApprovalGraph,
   buildCreateTemplatePayload,
   buildFormSchema,
+  buildSlaHours,
   buildUpdateTemplatePayload,
   createEmptyDetailColumnDraft,
   createEmptyFieldDraft,
@@ -1562,7 +1575,6 @@ import {
   stepFieldAccess,
   setStepFieldPermission,
   unsupportedTemplateAuthoringReason,
-  validateTemplateDraft,
   validateTemplateFormFields,
   validateTemplateApprovalFlow,
   placeholderRoleNodeKeys,
@@ -1638,6 +1650,8 @@ const authoringSections: Array<{
   { id: 'review', label: '测试发布', description: '预览、试运行与发布检查' },
 ]
 const activeAuthoringSection = ref<AuthoringSectionId>('basic')
+const authoringContentRef = ref<HTMLElement | null>(null)
+const validationSummaryRef = ref<HTMLElement | null>(null)
 // B1-07: dirty baseline for discard protection — refreshed on every load/save so only real
 // unsaved edits trigger the leave confirm. Serialized compare; the draft is rebuilt from the
 // same builders on load/save, so key order is deterministic.
@@ -1673,16 +1687,24 @@ const authoringSectionIndex = computed(() => (
   authoringSections.findIndex(section => section.id === activeAuthoringSection.value)
 ))
 
-function selectAuthoringSection(section: AuthoringSectionId) {
-  activeAuthoringSection.value = section
+function scrollAuthoringTarget(target: HTMLElement | null, focus = false) {
+  if (!target) return
+  if (focus) target.focus({ preventScroll: true })
+  target.scrollIntoView?.({ behavior: 'smooth', block: 'start' })
 }
 
-function moveAuthoringSection(delta: -1 | 1) {
+async function selectAuthoringSection(section: AuthoringSectionId) {
+  activeAuthoringSection.value = section
+  await nextTick()
+  scrollAuthoringTarget(authoringContentRef.value)
+}
+
+async function moveAuthoringSection(delta: -1 | 1) {
   const nextIndex = Math.min(
     authoringSections.length - 1,
     Math.max(0, authoringSectionIndex.value + delta),
   )
-  activeAuthoringSection.value = authoringSections[nextIndex].id
+  await selectAuthoringSection(authoringSections[nextIndex].id)
 }
 
 // G-1 read-only structured render of a preserved complex graph: a per-node summary of the
@@ -2378,17 +2400,33 @@ async function loadTemplateForEdit() {
   }
 }
 
-function validate(): boolean {
-  validationErrors.value = validateTemplateDraft(draft.value, unsupportedReason.value)
+function firstInvalidAuthoringSection(formErrors: string[]): AuthoringSectionId {
+  const hasBasicSettingsError = Boolean(unsupportedReason.value)
+    || !draft.value.key.trim()
+    || !draft.value.name.trim()
+    || (draft.value.visibilityType !== 'all' && parseIdsText(draft.value.visibilityIdsText).length === 0)
+    || Number.isNaN(buildSlaHours(draft.value))
+  if (hasBasicSettingsError) return 'basic'
+  if (formErrors.length > 0) return 'fields'
+  return 'flow'
+}
+
+async function validate(): Promise<boolean> {
+  const formErrors = validateTemplateFormFields(draft.value, unsupportedReason.value)
+  const flowErrors = validateTemplateApprovalFlow(draft.value)
+  validationErrors.value = [...formErrors, ...flowErrors]
   if (validationErrors.value.length > 0) {
+    activeAuthoringSection.value = firstInvalidAuthoringSection(formErrors)
     ElMessage.warning('请先修正模板配置')
+    await nextTick()
+    scrollAuthoringTarget(validationSummaryRef.value, true)
     return false
   }
   return true
 }
 
 async function persistDraft() {
-  if (!validate()) return null
+  if (!(await validate())) return null
   saving.value = true
   try {
     if (draft.value.templateId) {
@@ -2658,6 +2696,16 @@ onUnmounted(() => {
 
 .template-authoring__alert {
   margin-bottom: 16px;
+}
+
+.template-authoring__validation-summary,
+.template-authoring__content {
+  scroll-margin-top: 124px;
+}
+
+.template-authoring__validation-summary:focus {
+  outline: 2px solid var(--ms-color-primary);
+  outline-offset: 2px;
 }
 
 .template-authoring__body {
@@ -3096,6 +3144,11 @@ pre {
 @media (max-width: 760px) {
   .template-authoring__header {
     position: static;
+  }
+
+  .template-authoring__validation-summary,
+  .template-authoring__content {
+    scroll-margin-top: var(--ms-space-3);
   }
 
   .template-authoring__actions,

--- a/apps/web/tests/approval-center.spec.ts
+++ b/apps/web/tests/approval-center.spec.ts
@@ -308,6 +308,7 @@ const ElInput = defineComponent({
     return h('input', {
       'data-el-input': 'true',
       value: this.modelValue ?? '',
+      placeholder: this.placeholder,
       onInput: (e: Event) => this.$emit('update:modelValue', (e.target as HTMLInputElement).value),
     })
   },
@@ -691,8 +692,29 @@ describe('ApprovalCenterView', () => {
 
   it('renders search input and status filter', async () => {
     await mountView()
-    expect(container!.querySelector('[data-el-input]')).toBeTruthy()
+    const search = container!.querySelector('[data-testid="approval-search-input"]') as HTMLInputElement
+    expect(search).toBeTruthy()
+    expect(search.placeholder).toBe('搜索标题或审批编号')
     expect(container!.querySelector('[data-el-select]')).toBeTruthy()
+  })
+
+  it('clears filters with one list reload and one pending-count refresh', async () => {
+    await mountView()
+
+    const source = container!.querySelector('[data-testid="approval-source-filter"]') as HTMLSelectElement
+    source.value = 'platform'
+    source.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    loadPendingSpy.mockClear()
+    getPendingCountSpy.mockClear()
+    ;(container!.querySelector('[data-testid="approval-clear-filters"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(loadPendingSpy).toHaveBeenCalledTimes(1)
+    expect(loadPendingSpy).toHaveBeenCalledWith(expect.objectContaining({ sourceSystem: 'all', page: 1 }))
+    expect(getPendingCountSpy).toHaveBeenCalledTimes(1)
+    expect(getPendingCountSpy).toHaveBeenCalledWith('all')
   })
 
   it('routes the attendance approval queue entry to the first pending attendance request', async () => {

--- a/apps/web/tests/approval-ui-workspace.spec.ts
+++ b/apps/web/tests/approval-ui-workspace.spec.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function read(relativePath: string): string {
+  return readFileSync(join(__dirname, '..', relativePath), 'utf8')
+}
+
+describe('approval workspace visual structure', () => {
+  it('keeps the application shell on the complete light token theme', () => {
+    const source = read('src/App.vue')
+
+    expect(source).toContain('background-color: var(--ms-bg-page)')
+    expect(source).not.toContain('@media (prefers-color-scheme: dark)')
+  })
+
+  it('separates the approval header, primary filters, and advanced filters', () => {
+    const source = read('src/views/approval/ApprovalCenterView.vue')
+
+    expect(source).toContain('<PageShell width="wide">')
+    expect(source).toContain('class="approval-center__filters-primary"')
+    expect(source).toContain('class="approval-center__filters-advanced"')
+    expect(source).toContain('data-testid="approval-more-filters"')
+    expect(source).toContain('data-testid="approval-clear-filters"')
+  })
+
+  it('keeps the detail form and timeline as full card surfaces', () => {
+    const source = read('src/views/approval/ApprovalDetailView.vue')
+
+    expect(source).toMatch(/\.approval-detail__form,\s*\n\.approval-detail__timeline\s*\{/)
+    expect(source).toContain('box-shadow: var(--ms-shadow-card)')
+  })
+
+  it('presents template authoring as a four-step workspace', () => {
+    const source = read('src/views/approval/TemplateAuthoringView.vue')
+
+    expect(source).toContain("type AuthoringSectionId = 'basic' | 'fields' | 'flow' | 'review'")
+    expect(source).toContain('class="template-authoring__workspace"')
+    expect(source).toContain('data-testid="approval-template-section-next"')
+    expect(source).toContain("v-show=\"activeAuthoringSection === 'fields'\"")
+    expect(source).toContain("v-show=\"activeAuthoringSection === 'flow'\"")
+    expect(source).toContain("v-show=\"activeAuthoringSection === 'review'\"")
+  })
+})

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -286,6 +286,9 @@ function buildTemplate(overrides: Partial<ApprovalTemplateDetailDTO> = {}): Appr
 
 let container: HTMLDivElement | null = null
 let app: VueApp<Element> | null = null
+let scrollIntoViewSpy: ReturnType<typeof vi.fn>
+let scrolledElements: HTMLElement[] = []
+const originalScrollIntoView = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollIntoView')
 
 async function mountView() {
   container = document.createElement('div')
@@ -658,6 +661,14 @@ describe('TemplateAuthoringView', () => {
     }))
     publishTemplateSpy.mockResolvedValue({})
     dryRunApprovalConditionFormulaSpy.mockResolvedValue({ success: true, result: true })
+    scrolledElements = []
+    scrollIntoViewSpy = vi.fn(function (this: HTMLElement) {
+      scrolledElements.push(this)
+    })
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoViewSpy,
+    })
   })
 
   afterEach(() => {
@@ -665,6 +676,65 @@ describe('TemplateAuthoringView', () => {
     container?.remove()
     app = null
     container = null
+    if (originalScrollIntoView) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', originalScrollIntoView)
+    } else {
+      delete (HTMLElement.prototype as { scrollIntoView?: unknown }).scrollIntoView
+    }
+  })
+
+  it('scrolls every section navigation path to the workspace start and exposes the active step', async () => {
+    await mountView()
+
+    const content = container!.querySelector('[data-testid="approval-template-workspace-content"]')
+    const basic = container!.querySelector('[data-testid="approval-template-section-basic"]')
+    const fields = container!.querySelector('[data-testid="approval-template-section-fields"]')
+    const review = container!.querySelector('[data-testid="approval-template-section-review"]')
+    expect(basic?.getAttribute('aria-current')).toBe('step')
+
+    ;(container!.querySelector('[data-testid="approval-template-section-next"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(fields?.getAttribute('aria-current')).toBe('step')
+    expect(scrolledElements.at(-1)).toBe(content)
+
+    ;(container!.querySelector('[data-testid="approval-template-section-previous"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(basic?.getAttribute('aria-current')).toBe('step')
+    expect(scrolledElements.at(-1)).toBe(content)
+
+    ;(review as HTMLButtonElement).click()
+    await flushUi()
+    expect(review?.getAttribute('aria-current')).toBe('step')
+    expect(scrolledElements.at(-1)).toBe(content)
+    expect(scrollIntoViewSpy).toHaveBeenLastCalledWith({ behavior: 'smooth', block: 'start' })
+  })
+
+  it('reveals and focuses field validation errors when saving from another section', async () => {
+    await mountView()
+
+    setInput('approval-template-key', 'travel')
+    setInput('approval-template-name', '出差审批')
+    ;(container!.querySelector('[data-testid="approval-template-section-fields"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    const fieldId = container!.querySelector('[data-testid="approval-template-field-row"] input') as HTMLInputElement
+    fieldId.value = ''
+    fieldId.dispatchEvent(new Event('input'))
+    ;(container!.querySelector('[data-testid="approval-template-section-review"]') as HTMLButtonElement).click()
+    await flushUi()
+    scrollIntoViewSpy.mockClear()
+    scrolledElements = []
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    const fieldsStep = container!.querySelector('[data-testid="approval-template-section-fields"]')
+    const summary = container!.querySelector('[data-testid="approval-template-validation-summary"]')
+    expect(createTemplateSpy).not.toHaveBeenCalled()
+    expect(fieldsStep?.getAttribute('aria-current')).toBe('step')
+    expect(summary?.textContent).toContain('字段 id 必填')
+    expect(document.activeElement).toBe(summary)
+    expect(scrolledElements.at(-1)).toBe(summary)
   })
 
   it('creates a draft through the existing backend endpoint wrapper path', async () => {


### PR DESCRIPTION
## What changed

- refresh the Approval Center with a wider workbench layout, clearer status metadata, and primary/advanced filter hierarchy
- turn template authoring into a four-step workspace for basic settings, form design, approval flow, and release validation
- align approval detail form, timeline, and sticky actions with the shared UI foundation
- remove the incomplete global dark-mode override that mixed dark shell colors with light-only approval components
- add structural regression guards for the approval workspaces

## Why

The current approval pages flatten too many controls into one dense surface, while the template authoring page presents the entire form as a single long document. A partial system dark-mode override also creates low-contrast combinations because the component token set is light-only.

This refresh improves information hierarchy and scanability while preserving the existing Vue, Element Plus, API, permission, workflow graph, dry-run, and publish behavior.

## User impact

- faster filtering and status recognition in the Approval Center
- guided template creation with persistent step context and responsive navigation
- more consistent card surfaces and action placement across approval views
- readable light-theme rendering regardless of operating-system color preference

## Validation

- `vue-tsc -b --pretty false`
- 7 focused Vitest files, 197 tests passed
- `pnpm --filter @metasheet/web build`
- `git diff --check`
