### PR TITLE
feat(multitable): W0-1 L6-a finding-#2 — sealed endpoint immutability (BEFORE UPDATE reject + golden, owner review 2026-07-16)

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260715190000_create_meta_record_history_operations.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260715190000_create_meta_record_history_operations.ts
@@ -169,12 +169,36 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     BEFORE INSERT ON meta_record_history_operations
     FOR EACH ROW EXECUTE FUNCTION meta_record_history_operations_validate_endpoint()
   `.execute(db)
+
+  // Finding #2 (owner review 2026-07-16): the sealed endpoint row is the immutable recovery anchor —
+  // v3.7 §1.3 takes anchorSeq from "that immutable endpoint row". The INSERT trigger above validates the
+  // seal at mint time, but nothing forbade a later UPDATE, so `UPDATE ... SET endpoint_seq=999999` (or
+  // event_count / created_at) on a sealed row would silently MOVE an already-sealed anchor. The endpoint is
+  // write-once by design (minted last, then only read), so a blanket UPDATE-reject at the DB level is the
+  // correct fail-closed guard. (DELETE is left to retention design, not this constraint.)
+  await sql`
+    CREATE OR REPLACE FUNCTION meta_record_history_operations_reject_update()
+    RETURNS trigger AS $fn$
+    BEGIN
+      RAISE EXCEPTION 'sealed operation endpoint % on sheet % is immutable (UPDATE forbidden)',
+        OLD.operation_id, OLD.sheet_id USING ERRCODE = 'check_violation';
+    END;
+    $fn$ LANGUAGE plpgsql
+  `.execute(db)
+  await sql`DROP TRIGGER IF EXISTS trg_mrho_reject_update ON meta_record_history_operations`.execute(db)
+  await sql`
+    CREATE TRIGGER trg_mrho_reject_update
+    BEFORE UPDATE ON meta_record_history_operations
+    FOR EACH ROW EXECUTE FUNCTION meta_record_history_operations_reject_update()
+  `.execute(db)
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TRIGGER IF EXISTS trg_mrho_reject_update ON meta_record_history_operations`.execute(db)
   await sql`DROP TRIGGER IF EXISTS trg_mrho_validate_endpoint ON meta_record_history_operations`.execute(db)
   await sql`DROP TRIGGER IF EXISTS trg_mrr_reject_append_sealed ON meta_record_revisions`.execute(db)
   await sql`DROP TRIGGER IF EXISTS trg_mrvm_reject_append_sealed ON meta_record_version_markers`.execute(db)
+  await sql`DROP FUNCTION IF EXISTS meta_record_history_operations_reject_update()`.execute(db)
   await sql`DROP FUNCTION IF EXISTS meta_record_history_operations_validate_endpoint()`.execute(db)
   await sql`DROP FUNCTION IF EXISTS meta_record_reject_append_to_sealed_operation()`.execute(db)
 

--- a/packages/core-backend/tests/integration/multitable-l6a-sealed-operation-endpoint-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-l6a-sealed-operation-endpoint-realdb.test.ts
@@ -409,4 +409,39 @@ describeIfDatabase('W0-1 L6-a — sealed operation-endpoint ledger (real DB)', (
     const after = (await q('SELECT count(*)::int AS n FROM meta_record_history_operations WHERE sheet_id=$1', [SHEET])).rows[0] as { n: number }
     expect(after.n).toBe(before.n) // no endpoint minted with the flag off
   })
+
+  // §F2 (finding #2, owner review 2026-07-16): v3.7 §1.3 reads the recovery anchorSeq from "that immutable
+  // endpoint row". The INSERT trigger seals it at mint; nothing forbade a later UPDATE, so a sealed endpoint's
+  // endpoint_seq / event_count / created_at could be silently moved — shifting an already-committed recovery
+  // anchor. The migration now installs trg_mrho_reject_update (BEFORE UPDATE → RAISE). This golden seals a real
+  // endpoint, attempts each column UPDATE, asserts the DB rejects fail-closed, and (positive control) that the
+  // anchor is byte-unchanged after. Mutation: dropping trg_mrho_reject_update makes every expect().rejects red.
+  test('§F2 a SEALED operation endpoint is DB-immutable — UPDATE of endpoint_seq/event_count/created_at is rejected; anchor never moves', async () => {
+    const op = mkOpId()
+    const R = mkRecord('f2imm')
+    await inTxn(async (run) => {
+      await synthRevision(run, R, 1, '9001', op)
+      await synthRevision(run, R, 2, '9002', op)
+      await insertEndpoint(run, op, '9002', 2) // endpoint written LAST, count/max exact
+    })
+    expect(await endpointOf(op)).toEqual({ endpoint_seq: '9002', event_count: 2 })
+
+    // every UPDATE of a sealed column is rejected at the DB level (fail-closed, not app-level)
+    await expect(
+      q('UPDATE meta_record_history_operations SET endpoint_seq = 999999 WHERE sheet_id=$1 AND operation_id=$2', [SHEET, op]),
+    ).rejects.toThrow(/immutable \(UPDATE forbidden\)/)
+    await expect(
+      q('UPDATE meta_record_history_operations SET event_count = 999 WHERE sheet_id=$1 AND operation_id=$2', [SHEET, op]),
+    ).rejects.toThrow(/immutable \(UPDATE forbidden\)/)
+    await expect(
+      q("UPDATE meta_record_history_operations SET created_at = now() + interval '1 year' WHERE sheet_id=$1 AND operation_id=$2", [SHEET, op]),
+    ).rejects.toThrow(/immutable \(UPDATE forbidden\)/)
+    // even a no-op UPDATE (same values) is rejected — the row is write-once, period
+    await expect(
+      q('UPDATE meta_record_history_operations SET endpoint_seq = endpoint_seq WHERE sheet_id=$1 AND operation_id=$2', [SHEET, op]),
+    ).rejects.toThrow(/immutable \(UPDATE forbidden\)/)
+
+    // positive control: the sealed anchor is byte-unchanged after every rejected attempt
+    expect(await endpointOf(op)).toEqual({ endpoint_seq: '9002', event_count: 2 })
+  })
 })


### PR DESCRIPTION
## W0-1 L6-a finding-#2 — sealed endpoint rows are DB-immutable

**Owner review 2026-07-16, finding #2** (Medium). Targets the L6-a branch (#4368) so the diff is exactly the migration guard + golden. **Docs+migration+test; Draft; NOT merged, NOT armed. flags OFF.**

### The hole
v3.7 §1.3 reads the recovery `anchorSeq` from *"that immutable endpoint row"*. The migration installed only a `BEFORE INSERT` trigger (`trg_mrho_validate_endpoint`) that validates the seal at mint time — but nothing forbade a later **UPDATE**. So `UPDATE meta_record_history_operations SET endpoint_seq = 999999` (or `event_count` / `created_at`) on a sealed row **silently moves an already-committed recovery anchor**. Confirmed by independent verification: the only trigger on the table was `BEFORE INSERT` (`:169`); `created_at` had no CHECK; `endpoint_seq`/`event_count` only positivity CHECKs.

### The fix (DB-level, fail-closed)
- Migration `up()`: `trg_mrho_reject_update` — `BEFORE UPDATE ... RAISE 'immutable (UPDATE forbidden)'`. The endpoint is **write-once by design** (minted last, then only read), so a blanket UPDATE-reject is the correct guard. `down()` drops the trigger + function. (DELETE stays with retention design, not this constraint.)
- **§F2 real-DB golden**: seals a real endpoint, asserts every column UPDATE — including a no-op `SET endpoint_seq = endpoint_seq` — is DB-rejected, and (positive control) the anchor is byte-unchanged after every rejected attempt.

### Verification
- Fresh `postgres:14` + migrate (with the CI exclude set): L6-a suite **17/17 pass** incl §F2.
- **Mutation-proven**: dropping `trg_mrho_reject_update` reds §F2 (the UPDATE succeeds → `.rejects.toThrow` fails); restoring it greens it.
- core-backend `tsc --noEmit` clean; migration up/down present.

### Scope
Independent of #4331 ratification (a DB constraint, not the batch/operation design of finding #1). Per the owner's finish order this lands **into the L6-a integration before L6-a merges** (step 4), re-gated at exact head. Held here as the verified fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
