### PR TITLE
fix(automation): P2 S2-b — 3 non-blocking P3s from #4334 round-4 review

### DIFF
--- a/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
+++ b/packages/core-backend/src/multitable/automation-durable-dispatch-loop.ts
@@ -48,9 +48,9 @@
  *     at tick entry (before the claim) and at loop start (before the timer). `intervalMs=0` (hot loop), a
  *     fractional/huge backoff, a sub-minimum lease, and an effective backoff inversion are rejected up front.
  *   - **The long-running loop requires a telemetry sink**: `onUnknownConsumerKeys` + `onTickError` +
- *     `onHeartbeatError` are mandatory (a silent stuck row, a swallowed tick error, or a hidden heartbeat DB
- *     error is an operational blind spot), and every observer call is exception-safe — a broken sink can
- *     neither kill the process nor stop delivery.
+ *     `onHeartbeatError` + `onClaimTimePoison` are mandatory (a silent stuck row, a swallowed tick error, a
+ *     hidden heartbeat DB error, or an unobserved claim-time dead-letter is an operational blind spot), and
+ *     every observer call is exception-safe — a broken sink can neither kill the process nor stop delivery.
  *
  * Nothing here runs while `AUTOMATION_DURABLE_DELIVERY_ENABLED` is OFF: `startDurableDispatchLoop` refuses
  * to start when the flag is off, and no production code calls it yet (that wiring is S5/S4 activation).
@@ -131,12 +131,14 @@ const MAX_INTERVAL_MS = 3_600_000 // 1h — an interval beyond this is almost ce
 // the heartbeat (leaseMs/3) fires and a renew round-trip completes BEFORE the lease expires — otherwise a
 // competitor reclaims a still-running delivery (#4334 review P1-B). 1s is a conservative floor for that margin.
 const MIN_LOOP_LEASE_MS = 1_000
-// Per-slot claim re-claims within one tick if a rescheduled row becomes reclaimable again immediately. A
-// pathological sub-tick backoff (e.g. 1ms) turns retry into a same-tick busy-spin that burns attempts
-// back-to-back and defeats the point of backoff (spreading retries over time). Flooring the backoff base at 1s
-// means a rescheduled row can only be re-claimed after ≥1s of REAL elapsed time — a legitimate retry, not an
-// intra-tick spin (#4334 round-3 adversarial P3). Correctness held either way (attempts == adapter calls), but
-// this keeps the retry schedule honest.
+// A RESCHEDULED row (a retry) must not become reclaimable again within the SAME tick. With per-slot claim a
+// pathological sub-tick backoff (e.g. 1ms) would let a just-rescheduled row be re-claimed slot-after-slot —
+// a same-tick busy-spin that burns its attempts back-to-back and defeats backoff's purpose (spreading retries
+// over time). Flooring the backoff base at 1s means a rescheduled row can only be re-claimed after ≥1s of REAL
+// elapsed time — a legitimate future retry, not an intra-tick spin (#4334 round-3 adversarial P3). (This is
+// distinct from a claim-time-poisoned HEAD, which IS scanned past within the same tick — see runDispatchTick.)
+// Delivery correctness held without the floor (a claimed row is always attempted); the floor keeps the retry
+// SCHEDULE honest.
 const MIN_RETRY_BASE_MS = 1_000
 
 /** Reject fractional, non-finite, out-of-safe-range, or out-of-bounds numeric params before they do anything. */
@@ -526,7 +528,10 @@ export interface DispatchLoopObserver {
   /** A heartbeat renew hit a DB error mid-flight (an infra signal, NOT a normal lost lease). Required so a
    *  degrading store surfaces here instead of hiding inside the lostLease count (#4334 review P2-C). */
   onHeartbeatError(info: { outboxId: string; consumerKey: string }): void
-  /** Optional per-tick metrics for observability (completed/rescheduled/poisoned/lostLease/heartbeatErrors). */
+  /** A row poisoned AT CLAIM (already at the attempt ceiling → dead_letter, never dispatched). Required so the
+   *  terminal transition is observable instead of vanishing behind an empty claim (#4334 review head-of-line). */
+  onClaimTimePoison(info: { outboxId: string; consumerKey: string; attempts: number }): void
+  /** Optional per-tick metrics for observability (completed/rescheduled/poisoned/lostLease/heartbeatErrors/claimTimePoisoned). */
   onTick?(result: DispatchTickResult): void
 }
 
@@ -567,9 +572,10 @@ export function startDurableDispatchLoop(
     !observer ||
     typeof observer.onUnknownConsumerKeys !== 'function' ||
     typeof observer.onTickError !== 'function' ||
-    typeof observer.onHeartbeatError !== 'function'
+    typeof observer.onHeartbeatError !== 'function' ||
+    typeof observer.onClaimTimePoison !== 'function'
   ) {
-    throw new TypeError('durable dispatch loop requires a telemetry sink (observer.onUnknownConsumerKeys + onTickError + onHeartbeatError)')
+    throw new TypeError('durable dispatch loop requires a telemetry sink (observer.onUnknownConsumerKeys + onTickError + onHeartbeatError + onClaimTimePoison)')
   }
   if (!isDurableDeliveryEnabled(opts.env ?? process.env)) {
     throw new Error('durable dispatch loop must not start while AUTOMATION_DURABLE_DELIVERY_ENABLED is off')
@@ -591,6 +597,7 @@ export function startDurableDispatchLoop(
       // fold the loop-stop signal into each adapter's ctx.signal so stop() cancels in-flight work.
       onUnknownConsumerKeys: (keys) => safeInvoke(observer.onUnknownConsumerKeys, keys),
       onHeartbeatError: (info) => safeInvoke(observer.onHeartbeatError, info),
+      onClaimTimePoison: (info) => safeInvoke(observer.onClaimTimePoison, info),
       shouldStop: () => stopped,
       stopSignal: stopController.signal,
     })

--- a/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-dispatch-loop-realdb.test.ts
@@ -33,7 +33,12 @@ import {
 import type { ClaimedConsumer, Queryable } from '../../src/multitable/automation-durable-dispatcher'
 
 /** A minimal always-valid telemetry sink for tests that don't assert on it. */
-const noopObserver: DispatchLoopObserver = { onUnknownConsumerKeys: () => {}, onTickError: () => {}, onHeartbeatError: () => {} }
+const noopObserver: DispatchLoopObserver = {
+  onUnknownConsumerKeys: () => {},
+  onTickError: () => {},
+  onHeartbeatError: () => {},
+  onClaimTimePoison: () => {},
+}
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const db = () => poolManager.get()
@@ -260,10 +265,11 @@ describeIfDatabase('P2 durable-delivery S2-b — dispatch loop (real DB)', () =>
     const id0 = await seedRow(k)
     const id1 = await seedRow(k)
     const id2 = await seedRow(k)
-    // deterministic order id0 < id1 < id2 (claim dispatches oldest-first).
-    await db().query(`UPDATE meta_automation_outbox SET created_at = now() - interval '3 seconds' WHERE id=$1`, [id0])
-    await db().query(`UPDATE meta_automation_outbox SET created_at = now() - interval '2 seconds' WHERE id=$1`, [id1])
-    await db().query(`UPDATE meta_automation_outbox SET created_at = now() - interval '1 second'  WHERE id=$1`, [id2])
+    // deterministic claim order id0 < id1 < id2 — the claim CTE picks by consumer.updated_at ASC (NOT outbox
+    // created_at, which only orders the returned batch), so pin updated_at to control which row is claimed first.
+    await db().query(`UPDATE meta_automation_outbox_consumer SET updated_at = now() - interval '3 seconds' WHERE outbox_id=$1`, [id0])
+    await db().query(`UPDATE meta_automation_outbox_consumer SET updated_at = now() - interval '2 seconds' WHERE outbox_id=$1`, [id1])
+    await db().query(`UPDATE meta_automation_outbox_consumer SET updated_at = now() - interval '1 second'  WHERE outbox_id=$1`, [id2])
     let processed = 0
     const r = new ConsumerAdapterRegistry()
     r.register(
@@ -339,8 +345,9 @@ describeIfDatabase('P2 durable-delivery S2-b — dispatch loop (real DB)', () =>
     const kNew = `ck_${RUN}_holNew`
     const idOld = await seedRow(kOld)
     const idNew = await seedRow(kNew)
-    await db().query(`UPDATE meta_automation_outbox SET created_at = now() - interval '2 seconds' WHERE id=$1`, [idOld])
-    await db().query(`UPDATE meta_automation_outbox SET created_at = now() - interval '1 second'  WHERE id=$1`, [idNew])
+    // claim order is by consumer.updated_at ASC — pin it (not outbox created_at) so idOld is the claimed HEAD.
+    await db().query(`UPDATE meta_automation_outbox_consumer SET updated_at = now() - interval '2 seconds' WHERE outbox_id=$1`, [idOld])
+    await db().query(`UPDATE meta_automation_outbox_consumer SET updated_at = now() - interval '1 second'  WHERE outbox_id=$1`, [idNew])
     // the old row is ALREADY at the ceiling (attempts=2, maxAttempts=2) → poisoned at claim, returns no row.
     await db().query(`UPDATE meta_automation_outbox_consumer SET attempts = 2 WHERE outbox_id=$1`, [idOld])
     let newCalled = 0
@@ -423,6 +430,7 @@ describeIfDatabase('P2 durable-delivery S2-b — dispatch loop (real DB)', () =>
       },
       onTickError: () => {},
       onHeartbeatError: () => {},
+      onClaimTimePoison: () => {},
     }
     const handle = startDurableDispatchLoop(db(), r, throwingObserver, {
       env: { AUTOMATION_DURABLE_DELIVERY_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv,
@@ -706,11 +714,21 @@ describe('P2 durable-delivery S2-b — pure guards (no DB)', () => {
     await expect(runDispatchTick(unreachableDb, oneAdapterRegistry(), { retryBaseMs: aboveDefaultCap })).rejects.toThrow(/retryCapMs/)
   })
 
-  test('P2#4: onHeartbeatError is also a required sink (a degrading store must be observable)', () => {
+  test('P2#4: onHeartbeatError and onClaimTimePoison are also required sinks (degrading store / claim-time dead-letter must be observable)', () => {
+    // missing onHeartbeatError
     expect(() =>
       startDurableDispatchLoop(unreachableDb, oneAdapterRegistry(), { onUnknownConsumerKeys: () => {}, onTickError: () => {} } as unknown as DispatchLoopObserver, {
         env: flagOn,
       }),
+    ).toThrow(/telemetry sink/)
+    // missing onClaimTimePoison (has the other three)
+    expect(() =>
+      startDurableDispatchLoop(
+        unreachableDb,
+        oneAdapterRegistry(),
+        { onUnknownConsumerKeys: () => {}, onTickError: () => {}, onHeartbeatError: () => {} } as unknown as DispatchLoopObserver,
+        { env: flagOn },
+      ),
     ).toThrow(/telemetry sink/)
   })
 
@@ -724,6 +742,7 @@ describe('P2 durable-delivery S2-b — pure guards (no DB)', () => {
     const observer: DispatchLoopObserver = {
       onUnknownConsumerKeys: () => {},
       onHeartbeatError: () => {},
+      onClaimTimePoison: () => {},
       onTickError: () => {
         tickErrorSeen += 1
         throw new Error('and the error sink is down too')


### PR DESCRIPTION
Follow-up to **#4334** (merged as `e3c537430`). You approved S2-b with three explicitly **non-blocking P3s**; I kept them out of #4334 to preserve the "product diff unchanged" mechanical merge you authorized, and out of #4335 (S3) per your instruction. This is that separate follow-up.

## The 3 P3s
- **P3-1 (you gated this to "before S5"):** `onClaimTimePoison` is now a **required** `DispatchLoopObserver` method, routed through `safeInvoke` in the loop like the other sinks — so a claim-time dead-letter is observable and a throwing sink can't break the loop. The required-sink test is extended (an observer missing `onClaimTimePoison` throws) and mutation-proven.
- **P3-2:** the ordering-control in the P1-A / head-of-line real-DB tests pinned `meta_automation_outbox.created_at`, but the claim CTE selects by `meta_automation_outbox_consumer.updated_at` (`created_at` only orders the returned batch — moot at `batchSize=1`). Repinned to `consumer.updated_at` so the tests control the column that actually drives which row is claimed.
- **P3-3 (comment drift):** dropped the "attempts == adapter calls" overclaim (a crash-after-claim still counts an attempt, by design); made the same-tick wording precise — a *rescheduled* row can't re-claim within a tick (backoff floor), distinct from a claim-time-poisoned *head* that IS scanned past same-tick; added `claimTimePoisoned` to the `onTick` metrics doc + the required-sink list.

## Verification
- Fresh PG15: **loop spec 34/34**, `tsc --noEmit` 0 errors.
- Additive / behavior-preserving except the now-**required** `onClaimTimePoison` sink — a startup-time contract (flag OFF, no production caller yet).

**For review — not self-merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)