### PR TITLE
feat(plm): add Discussion read relay routes

### DIFF
--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -2631,6 +2631,117 @@ export class PLMAdapter extends HTTPAdapter {
   }
 
   /**
+   * PLM-COLLAB Discussion read-relay (metasheet2 sub-slice 2, Yuantus provider sub-slice 1b):
+   * exchange the SAME BOM-review embed token (feature_key="bom_multitable") for a discussion
+   * READ-ONLY credential (`POST /api/v1/auth/embed/discussion-read-session`). Mirrors
+   * `exchangeDiscussionSession` EXACTLY -- pre-auth (sends NO Authorization header), fail-closed
+   * and uniform: dark-flag-off and an invalid/expired embed token both come back as the SAME 401,
+   * surfaced as `QueryResult.error`, never thrown. The returned `access_token` is short-TTL and
+   * part-scoped; it authorizes ONLY `getDiscussionsWithReadToken`/`getDiscussionThreadWithReadToken`
+   * below (the provider rejects it on any write route). This adapter never stores it.
+   */
+  async exchangeDiscussionReadSession(embedToken: string): Promise<QueryResult<DiscussionSessionCredential>> {
+    if (this.mockMode) {
+      return {
+        data: [{ access_token: 'mock-discussion-read-session-token', token_type: 'bearer', expires_in: 300, aud: 'discussion' }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('Discussion reads are not supported for this PLM API mode') }
+    }
+
+    return this.yuantusDiscussionFetch<DiscussionSessionCredential>('/api/v1/auth/embed/discussion-read-session', {
+      method: 'POST',
+      body: { embed_token: embedToken },
+    })
+  }
+
+  /**
+   * PLM-COLLAB Discussion read-relay: list discussion threads bound to a PLM target, authenticated
+   * with a discussion READ credential (`readToken`, from `exchangeDiscussionReadSession`) as the
+   * bearer -- NOT the adapter's own service token. Deliberately goes through
+   * `yuantusDiscussionFetch` (bypasses `this.query`'s interceptor, which unconditionally overwrites
+   * `Authorization` with the service token) rather than `getDiscussions`, which uses `this.query`
+   * and therefore authenticates as the service account, not the caller's read credential.
+   *
+   * Sends target_type/target_id + a FIXED `include_resolved=true`, and NOTHING else. Yuantus's list
+   * defaults to open-only (`include_resolved=False`), so WITHOUT this a resolved thread vanishes on
+   * the next list load and can never be reopened from the panel (owner review P2). `include_resolved`
+   * is hardcoded here, NEVER read from a client query param -- the relay derives every list arg from
+   * the verified embed claims, so a caller still cannot inject or widen anything. It does NOT widen
+   * the PART scope: the provider still enforces target_type=="item" and target_id==the credential's
+   * bound part, and rejects include_children outright; it only makes the bound part's resolved
+   * threads visible alongside its open ones. Any mismatch is the provider's uniform 404 (no leak).
+   */
+  async getDiscussionsWithReadToken(
+    readToken: string,
+    target: { targetType: string; targetId: string },
+  ): Promise<QueryResult<DiscussionThreadListResult>> {
+    if (this.mockMode) {
+      return {
+        data: [{ threads: [], next_cursor: null }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('Discussions are not supported for this PLM API mode') }
+    }
+
+    const query = new URLSearchParams({
+      target_type: target.targetType,
+      target_id: target.targetId,
+      include_resolved: 'true',
+    }).toString()
+    return this.yuantusDiscussionFetch<DiscussionThreadListResult>(`/api/v1/discussions?${query}`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${readToken}` },
+    })
+  }
+
+  /**
+   * PLM-COLLAB Discussion read-relay: fetch one discussion thread with its comments, authenticated
+   * with a discussion READ credential as the bearer. Same rationale as
+   * `getDiscussionsWithReadToken` for bypassing `this.query`/`getDiscussionThread`. No query
+   * params -- the provider enforces the thread resolves back to the credential's bound part,
+   * surfacing any mismatch as the same uniform 404 as an absent thread id. (Detail is per-thread,
+   * so resolved/open is irrelevant here -- only the LIST needs include_resolved.)
+   */
+  async getDiscussionThreadWithReadToken(
+    readToken: string,
+    threadId: string,
+  ): Promise<QueryResult<DiscussionThreadDetail>> {
+    if (this.mockMode) {
+      return {
+        data: [{
+          id: threadId,
+          target_type: 'item',
+          target_id: 'mock-item-1',
+          title: 'Mock discussion thread',
+          status: 'open',
+          created_by_id: 1,
+          created_at: new Date().toISOString(),
+          resolved_by_id: null,
+          resolved_at: null,
+          last_comment_at: null,
+          comment_count: 0,
+          anchor: null,
+          comments: [],
+        }],
+        metadata: { totalCount: 1 },
+      }
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { data: [], error: new Error('Discussions are not supported for this PLM API mode') }
+    }
+
+    return this.yuantusDiscussionFetch<DiscussionThreadDetail>(`/api/v1/discussions/${encodeURIComponent(threadId)}`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${readToken}` },
+    })
+  }
+
+  /**
    * PLM-COLLAB Discussion Phase 3 slice-2 (WRITE): open a new discussion thread
    * (`POST /api/v1/discussions`). `sessionToken` is the `access_token` from
    * `exchangeDiscussionSession`, passed explicitly on every call -- see the type-block docstring

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -173,6 +173,7 @@ import workflowDesignerRouter from './routes/workflow-designer'
 import plmWorkbenchRouter from './routes/plm-workbench'
 import plmEmbedRouter from './routes/plm-embed'
 import plmEmbedDiscussionWriteRouter from './routes/plm-embed-discussion'
+import plmEmbedDiscussionReadRouter from './routes/plm-embed-discussion-read'
 import { createHostPluginStorage } from './plugins/plugin-durable-storage'
 import { univerMockRouter } from './routes/univer-mock'
 import { univerMetaRouter } from './routes/univer-meta'
@@ -1144,6 +1145,7 @@ export class MetaSheetServer {
       this.app.use(plmWorkbenchRouter)
       this.app.use(plmEmbedRouter())
       this.app.use(plmEmbedDiscussionWriteRouter())
+      this.app.use(plmEmbedDiscussionReadRouter())
     } else {
       this.app.use('/api/plm-workbench', disabledFeatureHandler('PLM workbench is disabled in this deployment'))
       this.app.use('/api/plm-embed', disabledFeatureHandler('PLM embed is disabled in this deployment'))

--- a/packages/core-backend/src/middleware/embed-token-auth.ts
+++ b/packages/core-backend/src/middleware/embed-token-auth.ts
@@ -16,12 +16,14 @@ declare global {
   namespace Express {
     interface Request {
       embedToken?: EmbedTokenClaims
-      // PLM-COLLAB Discussion Phase-3 WRITE (Option A, stateless single-use-per-write): the raw
-      // embed JWT string, set ONLY here, ONLY for the lifetime of this request. It exists solely
-      // so a write-relay route can pass it, unmodified, to PLMAdapter.exchangeDiscussionSession
-      // for a Yuantus-side discussion-session credential exchange -- it MUST NEVER be persisted,
-      // cached on any shared object (adapter/module/store), logged, or returned to the client.
-      // The read relay (plm-embed.ts) has no use for this and continues to read only req.embedToken.
+      // PLM-COLLAB Discussion Phase-3 (Option A, stateless single-use-per-relay-call): the raw
+      // embed JWT string, set ONLY here, ONLY for the lifetime of this request. It exists solely so
+      // a discussion relay route can pass it, unmodified, to PLMAdapter for a Yuantus-side
+      // credential exchange -- the WRITE relay to `exchangeDiscussionSession`, and the READ relay
+      // (plm-embed-discussion-read.ts, read-auth sub-slice 2) to `exchangeDiscussionReadSession`.
+      // It MUST NEVER be persisted, cached on any shared object (adapter/module/store), logged, or
+      // returned to the client. The BOM-projection read relay (plm-embed.ts) has no use for it and
+      // reads only req.embedToken.
       embedTokenRaw?: string
     }
   }

--- a/packages/core-backend/src/routes/plm-embed-discussion-read.ts
+++ b/packages/core-backend/src/routes/plm-embed-discussion-read.ts
@@ -1,0 +1,248 @@
+/**
+ * PLM-COLLAB Discussion read-auth line, metasheet2 sub-slice 2: the discussion READ relay.
+ * Companion to the WRITE relay (`./plm-embed-discussion.ts` -- READ IT FIRST, this file mirrors
+ * its guard sequence, transport, and error-mapping conventions deliberately). Calls the Yuantus
+ * provider contract built + Opus-verified in sub-slice 1b:
+ *   - `POST /api/v1/auth/embed/discussion-read-session` -- exchanges a verified embed token for a
+ *     `typ=discussion_read` credential (short TTL, part-scoped). Pre-auth. Fail-closed uniform 401
+ *     (dark-flag-off and a bad token are indistinguishable).
+ *   - `GET /api/v1/discussions?target_type=item&target_id=<part_id>` -- list. The provider
+ *     ENFORCES target_type=="item" and target_id==the credential's bound part; include_children is
+ *     FORBIDDEN. Any mismatch -> uniform 404.
+ *   - `GET /api/v1/discussions/{thread_id}` -- detail. The provider enforces the thread resolves
+ *     back to the bound part -> uniform 404 otherwise.
+ *
+ * **Guard reuse: COPIED, not imported, from the write relay.** `runEmbedWriteGuards` in
+ * `plm-embed-discussion.ts` is typed against `PlmDiscussionWriteAdapter` (its type guard checks
+ * for all 6 write methods + `exchangeDiscussionSession`), which does not duck-type match the read
+ * adapter surface this file needs (`exchangeDiscussionReadSession` +
+ * `getDiscussionsWithReadToken`/`getDiscussionThreadWithReadToken`). Genericizing the shared guard
+ * to accept an injected type-guard predicate would require editing the already-shipped/ratified
+ * write-relay file and re-running its full test surface for a routine addition -- the guard logic
+ * that actually varies by adapter shape is a single `isPlmDiscussionWriteAdapter` call, so a
+ * faithful copy (`runEmbedReadGuards` below) is the lower-risk option explicitly sanctioned by the
+ * taskbook. The single-use property is NOT duplicated by this copy: both relays import the SAME
+ * `consumeEmbedJti`/`embedJtiKey` from `../auth/embed-jti-store`, which is backed by the shared
+ * Redis store -- so a jti consumed by a write call is unavailable to a read call and vice versa,
+ * regardless of which file's guard code ran. No guard is weakened relative to the write relay: same
+ * feature_key check, same origin allowlist, same data-source resolve+connect+tenant cross-check,
+ * same jti ttl/consume ordering (guards first, jti burned last, before any exchange/call).
+ *
+ * Unlike the write relay, the read credential exchange happens on EVERY GET, and the LIST route
+ * never trusts a client-supplied target -- it always resolves `{ targetType: 'item', targetId:
+ * claims.part_id }` from the verified embed-token claims, never from a query string, so a caller
+ * cannot widen the read past the part the embed token was minted for (the provider independently
+ * enforces the same binding, so this is defense in depth, not the only gate).
+ */
+import { Router, type Request, type Response } from 'express'
+import { getDataSourceManager } from './data-sources'
+import { embedTokenAuth } from '../middleware/embed-token-auth'
+import { embedAllowedOrigins, embedDataSourceId } from '../auth/embed-config'
+import { consumeEmbedJti, embedJtiKey } from '../auth/embed-jti-store'
+import type { QueryResult } from '../data-adapters/BaseAdapter'
+import type {
+  DiscussionSessionCredential,
+  DiscussionThreadDetail,
+  DiscussionThreadListResult,
+} from '../data-adapters/PLMAdapter'
+import type { EmbedTokenClaims } from '../auth/embed-token-verify'
+
+const BOM_FEATURE_KEY = 'bom_multitable'
+
+interface PlmDiscussionReadAdapter {
+  exchangeDiscussionReadSession(embedToken: string): Promise<QueryResult<DiscussionSessionCredential>>
+  getDiscussionsWithReadToken(readToken: string, target: { targetType: string; targetId: string }): Promise<QueryResult<DiscussionThreadListResult>>
+  getDiscussionThreadWithReadToken(readToken: string, threadId: string): Promise<QueryResult<DiscussionThreadDetail>>
+  // tenant/connect surface, same duck-type contract the write relay enforces
+  getEffectiveTenantId(): string | undefined
+  isConnected(): boolean
+  connect(): Promise<void>
+}
+
+function isPlmDiscussionReadAdapter(adapter: unknown): adapter is PlmDiscussionReadAdapter {
+  const a = adapter as Partial<PlmDiscussionReadAdapter> | null
+  return typeof a?.exchangeDiscussionReadSession === 'function'
+    && typeof a?.getDiscussionsWithReadToken === 'function'
+    && typeof a?.getDiscussionThreadWithReadToken === 'function'
+    && typeof a?.getEffectiveTenantId === 'function'
+    && typeof a?.isConnected === 'function'
+    && typeof a?.connect === 'function'
+}
+
+/**
+ * Faithful copy of the write relay's `runEmbedWriteGuards` (feature_key -> embed_origin ->
+ * data-source resolve -> connect -> tenant cross-check -> single-use jti consume), adapted to the
+ * read adapter duck-type. See the file docstring for why this is a copy rather than a shared
+ * import. On failure it has already written the response and returns `null` -- callers must
+ * return immediately without touching the response again.
+ */
+async function runEmbedReadGuards(req: Request, res: Response): Promise<{ claims: EmbedTokenClaims; adapter: PlmDiscussionReadAdapter } | null> {
+  const claims = req.embedToken!
+
+  if (claims.feature_key !== BOM_FEATURE_KEY) {
+    res.status(403).json({ ok: false, error: { code: 'EMBED_FEATURE_MISMATCH', message: 'token not scoped to bom_multitable' } })
+    return null
+  }
+  const origin = typeof claims.embed_origin === 'string' ? claims.embed_origin : ''
+  if (!origin || !embedAllowedOrigins().includes(origin)) {
+    res.status(403).json({ ok: false, error: { code: 'EMBED_ORIGIN_NOT_ALLOWED', message: 'embed origin not allowed' } })
+    return null
+  }
+
+  const dataSourceId = embedDataSourceId()
+  if (!dataSourceId) {
+    res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed data source not configured' } })
+    return null
+  }
+
+  let adapter: unknown
+  try {
+    adapter = getDataSourceManager().getDataSource(dataSourceId)
+  } catch {
+    res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed data source unavailable' } })
+    return null
+  }
+  if (!isPlmDiscussionReadAdapter(adapter)) {
+    res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed data source unsupported' } })
+    return null
+  }
+
+  try {
+    if (!adapter.isConnected()) await adapter.connect()
+  } catch {
+    res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed data source unavailable' } })
+    return null
+  }
+
+  // Same fail-closed cross-check as the write relay: compare against the tenant ACTUALLY served,
+  // before consuming the jti or doing any read.
+  const servedTenantId = adapter.getEffectiveTenantId()
+  if (!servedTenantId || claims.tenant_id !== servedTenantId) {
+    res.status(403).json({ ok: false, error: { code: 'EMBED_TENANT_MISMATCH', message: 'token tenant does not match the embed data source tenant' } })
+    return null
+  }
+
+  // Single-use, shared with the write relay: one embed token authorizes exactly one relay call
+  // (read OR write), ever -- the SAME consumeEmbedJti/embedJtiKey backed by the shared Redis
+  // store. Consumed AFTER all other guards, BEFORE the session exchange / read.
+  const jti = typeof claims.jti === 'string' ? claims.jti : ''
+  if (!jti) {
+    res.status(401).json({ ok: false, error: { code: 'INVALID_EMBED_TOKEN', message: 'missing jti' } })
+    return null
+  }
+  const now = Math.floor(Date.now() / 1000)
+  const ttl = Math.min(typeof claims.exp === 'number' ? claims.exp - now : 0, 600)
+  if (ttl < 1) {
+    res.status(401).json({ ok: false, error: { code: 'INVALID_EMBED_TOKEN', message: 'token expired' } })
+    return null
+  }
+  let firstUse: boolean
+  try {
+    firstUse = await consumeEmbedJti(
+      embedJtiKey({
+        aud: claims.aud ?? '',
+        feature_key: claims.feature_key ?? '',
+        tenant_id: claims.tenant_id ?? '',
+        part_id: claims.part_id,
+        jti,
+      }),
+      ttl,
+    )
+  } catch {
+    res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed replay store unavailable' } })
+    return null
+  }
+  if (!firstUse) {
+    res.status(401).json({ ok: false, error: { code: 'EMBED_TOKEN_REPLAYED', message: 'embed token already used' } })
+    return null
+  }
+
+  return { claims, adapter }
+}
+
+/**
+ * Exchanges the request's raw embed token for a discussion READ credential and returns ONLY its
+ * `access_token`, as a value the caller must keep local -- never assigned to `req`, the adapter
+ * instance, module scope, or any cache. A failed/empty exchange is a uniform 401 (mirrors the
+ * write relay's `exchangeForAccessToken`): the adapter already collapses "dark-flag off" and "bad
+ * token" into the same shape upstream, so this must not re-introduce a distinction (no oracle).
+ */
+async function exchangeForReadToken(req: Request, res: Response, adapter: PlmDiscussionReadAdapter): Promise<string | null> {
+  const rawToken = req.embedTokenRaw
+  if (!rawToken) {
+    // Should be unreachable (embedTokenAuth always sets it on success), but fail closed.
+    res.status(401).json({ ok: false, error: { code: 'EMBED_SESSION_EXCHANGE_FAILED', message: 'discussion read session exchange failed' } })
+    return null
+  }
+  const cred = await adapter.exchangeDiscussionReadSession(rawToken)
+  const credential = cred.data[0]
+  if (cred.error || !credential || !credential.access_token) {
+    res.status(401).json({ ok: false, error: { code: 'EMBED_SESSION_EXCHANGE_FAILED', message: 'discussion read session exchange failed' } })
+    return null
+  }
+  return credential.access_token
+}
+
+/** Reads a provider HTTP status off a QueryResult.error, mirroring the write relay's providerErrorStatus. */
+function providerErrorStatus(error: unknown): number | null {
+  const candidate = error as { response?: { status?: unknown } } | null
+  const status = candidate?.response?.status
+  return typeof status === 'number' ? status : null
+}
+
+const KNOWN_PROVIDER_STATUSES = new Set([400, 401, 403, 404, 409, 422])
+
+/**
+ * Maps a read method's QueryResult.error to a relay HTTP response. Mirrors the write relay's
+ * `respondWriteError`: the provider's own status is authoritative for the small set of statuses
+ * this relay understands (incl. the provider's uniform 404 for an unreadable/unbound target or
+ * thread -- never re-derived or distinguished here); anything else (network failure, unexpected
+ * status) degrades to a generic 502. The relay must never echo the raw upstream error body/message
+ * (no oracle on internals).
+ */
+function respondReadError(res: Response, error: Error): void {
+  const status = providerErrorStatus(error)
+  if (status !== null && KNOWN_PROVIDER_STATUSES.has(status)) {
+    res.status(status).json({ ok: false, error: { code: 'EMBED_DISCUSSION_READ_REJECTED', message: 'the discussion read was rejected' } })
+    return
+  }
+  res.status(502).json({ ok: false, error: { code: 'EMBED_DISCUSSION_READ_UNAVAILABLE', message: 'the discussion read could not be completed' } })
+}
+
+export default function plmEmbedDiscussionReadRouter(): Router {
+  const router = Router()
+
+  // GET /api/plm-embed/discussion/threads -- list threads bound to the embed token's part.
+  // The target is ALWAYS derived from the verified claims (targetType 'item', targetId
+  // claims.part_id) -- any client-supplied target_type/target_id/include_children query param is
+  // ignored entirely, never read.
+  router.get('/api/plm-embed/discussion/threads', embedTokenAuth, async (req: Request, res: Response) => {
+    const guarded = await runEmbedReadGuards(req, res)
+    if (!guarded) return
+
+    const readToken = await exchangeForReadToken(req, res, guarded.adapter)
+    if (!readToken) return
+    const result = await guarded.adapter.getDiscussionsWithReadToken(readToken, {
+      targetType: 'item',
+      targetId: guarded.claims.part_id,
+    })
+    if (result.error) return respondReadError(res, result.error)
+    return res.json({ ok: true, data: result.data[0] ?? null })
+  })
+
+  // GET /api/plm-embed/discussion/threads/:threadId -- one thread with its comments. The
+  // provider independently enforces the thread resolves back to the credential's bound part.
+  router.get('/api/plm-embed/discussion/threads/:threadId', embedTokenAuth, async (req: Request, res: Response) => {
+    const guarded = await runEmbedReadGuards(req, res)
+    if (!guarded) return
+
+    const threadId = req.params.threadId
+    const readToken = await exchangeForReadToken(req, res, guarded.adapter)
+    if (!readToken) return
+    const result = await guarded.adapter.getDiscussionThreadWithReadToken(readToken, threadId)
+    if (result.error) return respondReadError(res, result.error)
+    return res.json({ ok: true, data: result.data[0] ?? null })
+  })
+
+  return router
+}

--- a/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts
@@ -1595,3 +1595,202 @@ describe('PLMAdapter Yuantus discussion writes', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 })
+
+// PLM-COLLAB Discussion read-relay (metasheet2 sub-slice 2): exchangeDiscussionReadSession +
+// getDiscussionsWithReadToken/getDiscussionThreadWithReadToken. SAME auth style as the WRITE
+// methods above -- they bypass this.select/this.query (whose interceptor overwrites Authorization
+// with the adapter's SERVICE token) and issue a raw fetch() carrying the CALLER-supplied read
+// credential, never the service account. These tests exercise the REAL fetch seam (not the route
+// mocks) so a typo in a path/param/header is caught.
+describe('PLMAdapter Yuantus discussion read-relay methods', () => {
+  const jsonResponse = (status: number, body: unknown) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  })
+
+  const threadSummary = (overrides: Record<string, unknown> = {}) => ({
+    id: 'thread-1',
+    target_type: 'item',
+    target_id: 'P1',
+    title: 'Check tolerance',
+    status: 'open',
+    created_by_id: 1,
+    created_at: '2026-07-09T00:00:00.000Z',
+    resolved_by_id: null,
+    resolved_at: null,
+    last_comment_at: '2026-07-09T00:05:00.000Z',
+    comment_count: 1,
+    anchor: null,
+    ...overrides,
+  })
+
+  beforeEach(() => {
+    ;(fetch as Mock).mockClear()
+  })
+
+  it('exchanges an embed token for a discussion READ credential at /discussion-read-session, sending NO Authorization header', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+      access_token: 'read-token-abc',
+      token_type: 'bearer',
+      expires_in: 300,
+      aud: 'discussion',
+    }))
+
+    const result = await adapter.exchangeDiscussionReadSession('embed-token-1')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8001/api/v1/auth/embed/discussion-read-session')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({ embed_token: 'embed-token-1' })
+    expect(init.headers).not.toHaveProperty('Authorization')
+
+    expect(result.error).toBeUndefined()
+    expect(result.data[0]).toMatchObject({ access_token: 'read-token-abc', aud: 'discussion' })
+  })
+
+  it('fails closed and uniform on a 401 read-session exchange (dark-flag-off and an invalid token are indistinguishable)', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, { detail: 'invalid or expired embed token' }))
+
+    const result = await adapter.exchangeDiscussionReadSession('bad-embed-token')
+
+    expect(result.data).toHaveLength(0)
+    expect(result.error).toBeDefined()
+    expect((result.error as any)?.response?.status).toBe(401)
+  })
+
+  it('lists discussions with the read token as bearer, hitting /discussions with target_type/target_id ONLY (no include_children)', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+      threads: [threadSummary()],
+      next_cursor: null,
+    }))
+
+    const result = await adapter.getDiscussionsWithReadToken('read-token-1', { targetType: 'item', targetId: 'P1' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8001/api/v1/discussions?target_type=item&target_id=P1&include_resolved=true')
+    expect(init.method).toBe('GET')
+    expect(init.headers.Authorization).toBe('Bearer read-token-1')
+    // FIXED include_resolved=true so a resolved thread stays visible/reopenable (owner review P2);
+    // still NO include_children (provider forbids it for read creds), and neither is client-injectable.
+    expect(url).toContain('include_resolved=true')
+    expect(url).not.toContain('include_children')
+    expect(init.body).toBeUndefined()
+
+    expect(result.error).toBeUndefined()
+    expect(result.data[0]).toMatchObject({
+      threads: [expect.objectContaining({ id: 'thread-1', status: 'open' })],
+      next_cursor: null,
+    })
+  })
+
+  it('URL-encodes the list target params', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { threads: [], next_cursor: null }))
+
+    await adapter.getDiscussionsWithReadToken('read-token-1', { targetType: 'item', targetId: 'part id/with?chars' })
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8001/api/v1/discussions?target_type=item&target_id=part+id%2Fwith%3Fchars&include_resolved=true')
+  })
+
+  it('the list request carries a FIXED include_resolved=true so resolved threads stay visible (owner P2), and it is not client-injectable', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+      threads: [threadSummary({ id: 'thread-open', status: 'open' }), threadSummary({ id: 'thread-resolved', status: 'resolved' })],
+      next_cursor: null,
+    }))
+
+    const result = await adapter.getDiscussionsWithReadToken('read-token-1', { targetType: 'item', targetId: 'P1' })
+
+    const [url] = fetchMock.mock.calls[0]
+    // include_resolved=true is always sent; the caller has no way to pass query params to this
+    // method (the relay only ever hands it { targetType, targetId } from the verified claim).
+    expect(url).toContain('include_resolved=true')
+    // A resolved thread from the provider is returned to the caller (visible for reopen).
+    const statuses = (result.data[0] as { threads: Array<{ id: string; status: string }> }).threads.map((t) => t.status)
+    expect(statuses).toContain('resolved')
+    expect(statuses).toContain('open')
+  })
+
+  it('fetches one thread with the read token as bearer, hitting /discussions/{thread_id} with no query params', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { ...threadSummary(), comments: [] }))
+
+    const result = await adapter.getDiscussionThreadWithReadToken('read-token-1', 'thread-1')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8001/api/v1/discussions/thread-1')
+    expect(init.method).toBe('GET')
+    expect(init.headers.Authorization).toBe('Bearer read-token-1')
+    expect(init.body).toBeUndefined()
+
+    expect(result.error).toBeUndefined()
+    expect(result.data[0]).toMatchObject({ id: 'thread-1', comments: [] })
+  })
+
+  it('URL-encodes the thread id in the detail path', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { ...threadSummary(), comments: [] }))
+
+    await adapter.getDiscussionThreadWithReadToken('read-token-1', 'weird/id?x=1')
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8001/api/v1/discussions/weird%2Fid%3Fx%3D1')
+  })
+
+  it('surfaces the provider no-leak 404 as a QueryResult error, never a thrown exception (list)', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(404, { detail: 'discussion target not found' }))
+
+    const result = await adapter.getDiscussionsWithReadToken('read-token-1', { targetType: 'item', targetId: 'missing' })
+
+    expect(result.data).toHaveLength(0)
+    expect(result.error).toBeDefined()
+    expect((result.error as any)?.response?.status).toBe(404)
+  })
+
+  it('surfaces the provider no-leak 404 as a QueryResult error (detail)', async () => {
+    const adapter = createAdapter()
+    const fetchMock = fetch as Mock
+    fetchMock.mockResolvedValueOnce(jsonResponse(404, { detail: 'discussion target not found' }))
+
+    const result = await adapter.getDiscussionThreadWithReadToken('read-token-1', 'missing-thread')
+
+    expect(result.data).toHaveLength(0)
+    expect(result.error).toBeDefined()
+    expect((result.error as any)?.response?.status).toBe(404)
+  })
+
+  it('is not gated by apiMode !== yuantus (legacy PLM has no discussion read-relay surface)', async () => {
+    const adapter = createAdapter()
+    ;(adapter as any).apiMode = 'legacy'
+    const fetchMock = fetch as Mock
+
+    const exchangeResult = await adapter.exchangeDiscussionReadSession('embed-token-1')
+    expect(exchangeResult.error).toBeDefined()
+
+    const listResult = await adapter.getDiscussionsWithReadToken('read-token-1', { targetType: 'item', targetId: 'P1' })
+    expect(listResult.error).toBeDefined()
+
+    const detailResult = await adapter.getDiscussionThreadWithReadToken('read-token-1', 'thread-1')
+    expect(detailResult.error).toBeDefined()
+
+    // never reaches the network in legacy mode
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core-backend/tests/unit/plm-embed-discussion-read-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-embed-discussion-read-routes.test.ts
@@ -1,0 +1,374 @@
+import crypto from 'node:crypto'
+import express from 'express'
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Controllable DataSourceManager mock.
+const dsMocks = vi.hoisted(() => ({ getDataSource: vi.fn() }))
+
+// Controllable single-use jti store -- the SAME shared store the write relay uses.
+const jtiMocks = vi.hoisted(() => ({ consume: vi.fn() }))
+vi.mock('../../src/auth/embed-jti-store', () => ({
+  consumeEmbedJti: (...args: unknown[]) => jtiMocks.consume(...args),
+  embedJtiKey: (scope: { jti?: unknown }) => `plm-embed:jti:${String(scope.jti)}`,
+}))
+
+vi.mock('../../src/db/sharding/tenant-context', () => ({ extractTenantFromHeaders: () => undefined }))
+vi.mock('../../src/metrics/metrics', () => ({ metrics: new Proxy({}, { get: () => ({ inc: () => {} }) }) }))
+vi.mock('../../src/auth/AuthService', () => ({ authService: {} }))
+vi.mock('../../src/routes/data-sources', () => ({
+  getDataSourceManager: () => ({ getDataSource: dsMocks.getDataSource }),
+}))
+
+import { isWhitelisted } from '../../src/auth/jwt-middleware'
+import plmEmbedDiscussionReadRouter from '../../src/routes/plm-embed-discussion-read'
+
+const KID = 'embed-1'
+const AUD = 'metasheet2.embed'
+const ORIGIN = 'https://plm.example.com'
+const DS_ID = 'plm-ds'
+
+const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519')
+const PUB_B64 = Buffer.from((publicKey.export({ format: 'jwk' }) as { x: string }).x, 'base64url').toString('base64')
+
+let jtiCounter = 0
+function mint(overrides: Record<string, unknown> = {}, kid = KID): string {
+  const now = Math.floor(Date.now() / 1000)
+  jtiCounter += 1
+  const claims = {
+    sub: '7',
+    tenant_id: 'default',
+    part_id: 'P1',
+    feature_key: 'bom_multitable',
+    aud: AUD,
+    embed_origin: ORIGIN,
+    iat: now,
+    exp: now + 120,
+    jti: `j-${jtiCounter}`,
+    typ: 'embed',
+    ...overrides,
+  }
+  const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT', kid })).toString('base64url')
+  const payload = Buffer.from(JSON.stringify(claims)).toString('base64url')
+  const sig = crypto.sign(null, Buffer.from(`${header}.${payload}`, 'ascii'), privateKey).toString('base64url')
+  return `${header}.${payload}.${sig}`
+}
+
+const READ_TOKEN = 'discussion-read-session-secret-xyz789'
+const THREAD_SUMMARY = {
+  id: 't1',
+  target_type: 'item',
+  target_id: 'P1',
+  title: 'Discuss',
+  status: 'open',
+  created_by_id: 1,
+  created_at: '2026-07-11T00:00:00Z',
+  resolved_by_id: null,
+  resolved_at: null,
+  last_comment_at: '2026-07-11T00:00:00Z',
+  comment_count: 1,
+  anchor: null,
+}
+const THREADS_LIST = { threads: [THREAD_SUMMARY], next_cursor: null }
+const THREAD_DETAIL = { ...THREAD_SUMMARY, comments: [] }
+
+function credentialResult(overrides: Record<string, unknown> = {}) {
+  return {
+    data: [{ access_token: READ_TOKEN, token_type: 'bearer', expires_in: 300, aud: 'discussion', ...overrides }],
+    metadata: { totalCount: 1 },
+  }
+}
+
+// A COMPLETE PlmDiscussionReadAdapter mock (exchange + the two read methods + tenant/connect
+// surface). Each read method defaults to a wrapped success; override any via `opts` to simulate a
+// provider error / different payload.
+function fullAdapter(opts: {
+  exchangeDiscussionReadSession?: ReturnType<typeof vi.fn>
+  getDiscussionsWithReadToken?: ReturnType<typeof vi.fn>
+  getDiscussionThreadWithReadToken?: ReturnType<typeof vi.fn>
+  tenant?: string | undefined
+  connected?: boolean
+  connect?: ReturnType<typeof vi.fn>
+} = {}) {
+  return {
+    exchangeDiscussionReadSession: opts.exchangeDiscussionReadSession ?? vi.fn().mockResolvedValue(credentialResult()),
+    getDiscussionsWithReadToken: opts.getDiscussionsWithReadToken ?? vi.fn().mockResolvedValue({ data: [THREADS_LIST], metadata: { totalCount: 1 } }),
+    getDiscussionThreadWithReadToken: opts.getDiscussionThreadWithReadToken ?? vi.fn().mockResolvedValue({ data: [THREAD_DETAIL], metadata: { totalCount: 1 } }),
+    getEffectiveTenantId: () => ('tenant' in opts ? opts.tenant : 'default'),
+    isConnected: () => opts.connected ?? true,
+    connect: opts.connect ?? vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function providerError(status: number, message = 'rejected') {
+  return Object.assign(new Error(message), { response: { status, data: { detail: message } } })
+}
+
+function buildApp() {
+  const app = express()
+  app.use(express.json())
+  // Reproduce the REAL global gate (index.ts): whitelisted -> through; else /api/* needs the
+  // session JWT (stood in here by a 401, exactly what jwtAuthMiddleware does on a missing token).
+  app.use((req, res, next) => {
+    if (isWhitelisted(req.path)) return next()
+    if (req.path.startsWith('/api/')) return res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED' } })
+    return next()
+  })
+  app.use(plmEmbedDiscussionReadRouter())
+  return app
+}
+
+const THREADS_URL = '/api/plm-embed/discussion/threads'
+const THREAD_URL = (threadId = 't1') => `/api/plm-embed/discussion/threads/${threadId}`
+
+describe('PLM embed discussion READ relay (Discussion read-auth line, sub-slice 2)', () => {
+  beforeEach(() => {
+    dsMocks.getDataSource.mockReset()
+    jtiMocks.consume.mockReset()
+    jtiMocks.consume.mockResolvedValue(true) // default: first use
+    process.env.YUANTUS_EMBED_PUBLIC_KEY = PUB_B64
+    process.env.YUANTUS_EMBED_KEY_ID = KID
+    process.env.PLM_EMBED_AUDIENCE = AUD
+    process.env.PLM_EMBED_ALLOWED_ORIGINS = ORIGIN
+    process.env.PLM_EMBED_DATA_SOURCE_ID = DS_ID
+  })
+  afterEach(() => {
+    for (const k of ['YUANTUS_EMBED_PUBLIC_KEYS', 'YUANTUS_EMBED_PUBLIC_KEY', 'YUANTUS_EMBED_KEY_ID', 'PLM_EMBED_AUDIENCE', 'PLM_EMBED_ALLOWED_ORIGINS', 'PLM_EMBED_DATA_SOURCE_ID']) delete process.env[k]
+  })
+
+  it('the read routes are whitelisted from the global session gate (same prefix as the write relay)', () => {
+    expect(isWhitelisted(THREADS_URL)).toBe(true)
+    expect(isWhitelisted(THREAD_URL())).toBe(true)
+  })
+
+  // --- happy path + no-credential-leak (load-bearing security tests) ---
+
+  it('happy list: returns threads, exchange used, read credential NEVER in the response body or headers', async () => {
+    const getDiscussionsWithReadToken = vi.fn().mockResolvedValue({ data: [THREADS_LIST], metadata: { totalCount: 1 } })
+    const exchangeDiscussionReadSession = vi.fn().mockResolvedValue(credentialResult())
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getDiscussionsWithReadToken, exchangeDiscussionReadSession }))
+
+    const res = await request(buildApp()).get(THREADS_URL).set('X-PLM-Embed-Token', mint())
+
+    expect(res.status).toBe(200)
+    expect(res.body.data).toEqual(THREADS_LIST)
+    expect(exchangeDiscussionReadSession).toHaveBeenCalledTimes(1)
+    expect(getDiscussionsWithReadToken).toHaveBeenCalledWith(READ_TOKEN, { targetType: 'item', targetId: 'P1' })
+
+    const serializedBody = JSON.stringify(res.body)
+    expect(serializedBody).not.toContain(READ_TOKEN)
+    expect(serializedBody).not.toContain('access_token')
+    const serializedHeaders = JSON.stringify(res.headers)
+    expect(serializedHeaders).not.toContain(READ_TOKEN)
+  })
+
+  it('happy detail: returns the thread, read credential NEVER in the response body or headers', async () => {
+    const getDiscussionThreadWithReadToken = vi.fn().mockResolvedValue({ data: [THREAD_DETAIL], metadata: { totalCount: 1 } })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getDiscussionThreadWithReadToken }))
+
+    const res = await request(buildApp()).get(THREAD_URL('t1')).set('X-PLM-Embed-Token', mint())
+
+    expect(res.status).toBe(200)
+    expect(res.body.data).toEqual(THREAD_DETAIL)
+    expect(getDiscussionThreadWithReadToken).toHaveBeenCalledWith(READ_TOKEN, 't1')
+
+    const serializedBody = JSON.stringify(res.body)
+    expect(serializedBody).not.toContain(READ_TOKEN)
+    expect(serializedBody).not.toContain('access_token')
+  })
+
+  it('NO CACHING: two sequential list requests (two fresh embed tokens) both call exchangeDiscussionReadSession with THEIR OWN raw token -- no cred is reused/cached', async () => {
+    const exchangeDiscussionReadSession = vi.fn().mockResolvedValue(credentialResult())
+    const getDiscussionsWithReadToken = vi.fn().mockResolvedValue({ data: [THREADS_LIST], metadata: { totalCount: 1 } })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionReadSession, getDiscussionsWithReadToken }))
+
+    const app = buildApp()
+    const token1 = mint()
+    const token2 = mint()
+    const res1 = await request(app).get(THREADS_URL).set('X-PLM-Embed-Token', token1)
+    const res2 = await request(app).get(THREADS_URL).set('X-PLM-Embed-Token', token2)
+
+    expect(res1.status).toBe(200)
+    expect(res2.status).toBe(200)
+    expect(exchangeDiscussionReadSession).toHaveBeenCalledTimes(2) // fired on BOTH, not cached after the first
+    expect(exchangeDiscussionReadSession).toHaveBeenNthCalledWith(1, token1)
+    expect(exchangeDiscussionReadSession).toHaveBeenNthCalledWith(2, token2)
+    expect(token1).not.toEqual(token2)
+  })
+
+  // --- exchange failure -> uniform 401 ---
+
+  it('exchange failure (adapter returns error) -> 401, read method never called', async () => {
+    const exchangeDiscussionReadSession = vi.fn().mockResolvedValue({ data: [], error: new Error('exchange rejected') })
+    const getDiscussionsWithReadToken = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionReadSession, getDiscussionsWithReadToken }))
+
+    const res = await request(buildApp()).get(THREADS_URL).set('X-PLM-Embed-Token', mint())
+
+    expect(res.status).toBe(401)
+    expect(res.body.error.code).toBe('EMBED_SESSION_EXCHANGE_FAILED')
+    expect(getDiscussionsWithReadToken).not.toHaveBeenCalled()
+  })
+
+  it('exchange returns no data (dark-flag-off shape) -> the SAME uniform 401 as a bad token (no oracle)', async () => {
+    const exchangeDiscussionReadSession = vi.fn().mockResolvedValue({ data: [] })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionReadSession }))
+
+    const res = await request(buildApp()).get(THREADS_URL).set('X-PLM-Embed-Token', mint())
+
+    expect(res.status).toBe(401)
+    expect(res.body.error.code).toBe('EMBED_SESSION_EXCHANGE_FAILED')
+  })
+
+  // --- provider read errors propagated (no-leak) ---
+
+  it('provider 404 (unreadable/unbound target) on the list route is propagated as 404, no-leak', async () => {
+    // A distinctive provider-internal message (NOT the relay's own generic wording, which itself
+    // legitimately contains the word "rejected") -- proves the raw upstream detail never echoes.
+    const getDiscussionsWithReadToken = vi.fn().mockResolvedValue({ data: [], error: providerError(404, 'sensitive-provider-detail-xyz') })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getDiscussionsWithReadToken }))
+
+    const res = await request(buildApp()).get(THREADS_URL).set('X-PLM-Embed-Token', mint())
+
+    expect(res.status).toBe(404)
+    expect(res.body.ok).toBe(false)
+    expect(JSON.stringify(res.body)).not.toContain('sensitive-provider-detail-xyz')
+  })
+
+  it('provider 404 (unknown thread / not bound to this part) on the detail route is propagated as 404, no-leak', async () => {
+    const getDiscussionThreadWithReadToken = vi.fn().mockResolvedValue({ data: [], error: providerError(404) })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getDiscussionThreadWithReadToken }))
+
+    const res = await request(buildApp()).get(THREAD_URL('missing-thread')).set('X-PLM-Embed-Token', mint())
+
+    expect(res.status).toBe(404)
+  })
+
+  it('a network-level / unrecognized provider failure degrades to 502, never a silent 200', async () => {
+    const getDiscussionsWithReadToken = vi.fn().mockResolvedValue({ data: [], error: new Error('fetch failed') })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getDiscussionsWithReadToken }))
+
+    const res = await request(buildApp()).get(THREADS_URL).set('X-PLM-Embed-Token', mint())
+
+    expect(res.status).toBe(502)
+  })
+
+  // --- jti single-use / shared store with the write relay ---
+
+  it('jti reuse (already consumed) -> 401 EMBED_TOKEN_REPLAYED, exchange never attempted', async () => {
+    jtiMocks.consume.mockResolvedValue(false)
+    const exchangeDiscussionReadSession = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionReadSession }))
+
+    const res = await request(buildApp()).get(THREADS_URL).set('X-PLM-Embed-Token', mint())
+
+    expect(res.status).toBe(401)
+    expect(res.body.error.code).toBe('EMBED_TOKEN_REPLAYED')
+    expect(exchangeDiscussionReadSession).not.toHaveBeenCalled()
+  })
+
+  it('a token with no jti -> 401, jti store never consulted, exchange never attempted', async () => {
+    const exchangeDiscussionReadSession = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionReadSession }))
+
+    const res = await request(buildApp()).get(THREADS_URL).set('X-PLM-Embed-Token', mint({ jti: undefined }))
+
+    expect(res.status).toBe(401)
+    expect(jtiMocks.consume).not.toHaveBeenCalled()
+    expect(exchangeDiscussionReadSession).not.toHaveBeenCalled()
+  })
+
+  it('an already-expired embed token -> 401 (rejected fail-closed before any guard runs), read method never called', async () => {
+    // verifyEmbedToken itself rejects `now > exp` at the embedTokenAuth middleware layer -- this
+    // never even reaches runEmbedReadGuards's own ttl<1 check. Same shape as the write relay: an
+    // expired token is a 401 regardless of which layer catches it.
+    const exchangeDiscussionReadSession = vi.fn()
+    const getDiscussionsWithReadToken = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionReadSession, getDiscussionsWithReadToken }))
+    const now = Math.floor(Date.now() / 1000)
+
+    const res = await request(buildApp()).get(THREADS_URL).set('X-PLM-Embed-Token', mint({ exp: now - 10 }))
+
+    expect(res.status).toBe(401)
+    expect(exchangeDiscussionReadSession).not.toHaveBeenCalled()
+    expect(getDiscussionsWithReadToken).not.toHaveBeenCalled()
+  })
+
+  // --- feature_key / origin / tenant guards (shared with the write relay) ---
+
+  it('a token scoped to a DIFFERENT feature -> 403, nothing downstream called', async () => {
+    const exchangeDiscussionReadSession = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ exchangeDiscussionReadSession }))
+
+    const res = await request(buildApp()).get(THREADS_URL).set('X-PLM-Embed-Token', mint({ feature_key: 'approval_automation' }))
+
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('EMBED_FEATURE_MISMATCH')
+    expect(exchangeDiscussionReadSession).not.toHaveBeenCalled()
+  })
+
+  it('embed_origin not in the allowlist -> 403', async () => {
+    dsMocks.getDataSource.mockReturnValue(fullAdapter())
+    const res = await request(buildApp()).get(THREADS_URL).set('X-PLM-Embed-Token', mint({ embed_origin: 'https://evil.example.com' }))
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('EMBED_ORIGIN_NOT_ALLOWED')
+  })
+
+  it('token tenant does not match the served tenant -> 403, jti never consumed, exchange never attempted', async () => {
+    const exchangeDiscussionReadSession = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ tenant: 'tenant-b', exchangeDiscussionReadSession }))
+
+    const res = await request(buildApp()).get(THREADS_URL).set('X-PLM-Embed-Token', mint({ tenant_id: 'tenant-a' }))
+
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('EMBED_TENANT_MISMATCH')
+    expect(jtiMocks.consume).not.toHaveBeenCalled()
+    expect(exchangeDiscussionReadSession).not.toHaveBeenCalled()
+  })
+
+  it('no embed token -> 401 (embedTokenAuth itself)', async () => {
+    const res = await request(buildApp()).get(THREADS_URL)
+    expect(res.status).toBe(401)
+  })
+
+  // --- the relay uses the CLAIM's part_id and ignores any client-supplied target ---
+
+  it('list IGNORES a client-supplied target_type/target_id/include_children query and always resolves target from the claim\'s part_id', async () => {
+    const getDiscussionsWithReadToken = vi.fn().mockResolvedValue({ data: [THREADS_LIST], metadata: { totalCount: 1 } })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getDiscussionsWithReadToken }))
+
+    const res = await request(buildApp())
+      .get(`${THREADS_URL}?target_type=eco&target_id=EVIL-OTHER-PART&include_children=true&include_resolved=true`)
+      .set('X-PLM-Embed-Token', mint({ part_id: 'P1' }))
+
+    expect(res.status).toBe(200)
+    // Called with exactly the claim's part_id / a fixed 'item' targetType -- NOT the bogus query values.
+    expect(getDiscussionsWithReadToken).toHaveBeenCalledWith(READ_TOKEN, { targetType: 'item', targetId: 'P1' })
+    expect(getDiscussionsWithReadToken).not.toHaveBeenCalledWith(READ_TOKEN, expect.objectContaining({ targetId: 'EVIL-OTHER-PART' }))
+  })
+
+  it('list with a DIFFERENT embed token part_id resolves target from THAT token\'s part_id, never a query override', async () => {
+    const getDiscussionsWithReadToken = vi.fn().mockResolvedValue({ data: [THREADS_LIST], metadata: { totalCount: 1 } })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getDiscussionsWithReadToken }))
+
+    const res = await request(buildApp())
+      .get(`${THREADS_URL}?target_id=someone-elses-part`)
+      .set('X-PLM-Embed-Token', mint({ part_id: 'P-mine' }))
+
+    expect(res.status).toBe(200)
+    expect(getDiscussionsWithReadToken).toHaveBeenCalledWith(READ_TOKEN, { targetType: 'item', targetId: 'P-mine' })
+  })
+
+  // --- per-route dispatch smoke test ---
+
+  it('detail: GET .../threads/:threadId dispatches to getDiscussionThreadWithReadToken with (readToken, threadId)', async () => {
+    const getDiscussionThreadWithReadToken = vi.fn().mockResolvedValue({ data: [{ ...THREAD_DETAIL, id: 't9' }], metadata: { totalCount: 1 } })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getDiscussionThreadWithReadToken }))
+
+    const res = await request(buildApp()).get(THREAD_URL('t9')).set('X-PLM-Embed-Token', mint())
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.id).toBe('t9')
+    expect(getDiscussionThreadWithReadToken).toHaveBeenCalledWith(READ_TOKEN, 't9')
+  })
+})


### PR DESCRIPTION
## Summary

- add read-scoped Discussion list/detail relay routes
- exchange a fresh embed token for a handler-local read credential on every call
- bind tenant and part scope exclusively to verified embed claims
- include resolved threads for historical reopen flows without accepting client scope overrides

## Security posture

- depends on the dark-by-default Yuantus read-auth provider merged in zensgit/yuantus-plm#15
- does not persist or return the exchanged read credential
- keeps write and read credentials separated

## Verification

- reviewed patch preserved across final rebase: `ed87fde7b = d6d99a545`
- `72 passed` for adapter and read-relay unit suites
- `pnpm --filter @metasheet/core-backend run type-check`
- `git diff --check`

Merge only after the refreshed strict checks are green; runtime provider flags remain OFF.