### PR TITLE
feat(multitable): W0-1 finding-#1 runtime — decouple batch_id/operation_id + G-MULTIOP golden (owner ruling 2026-07-16)

### DIFF
--- a/packages/core-backend/src/multitable/operation-ledger.ts
+++ b/packages/core-backend/src/multitable/operation-ledger.ts
@@ -17,8 +17,9 @@ import { isWriterFenceEnabled } from './canonical-sheet-fence'
  *   1. `const op = await mintOperation(query, sheetId)` — AFTER the fence, mint one server-side operation id.
  *   2. Write each revision/marker THROUGH the history-service helpers, passing `ledger: op`. Each tagged
  *      event carries `operation_id = op.operationId` and its exact `seq` (returned by the INSERT) is fed back
- *      into the ledger via `op.track(seq)`; the helper also aligns `batch_id = op.operationId` so a trusted
- *      write satisfies the design's "batch_id == operation_id" invariant.
+ *      into the ledger via `op.track(seq)`. `batch_id` is NOT touched (finding #1, owner ruling 2026-07-16,
+ *      v3.7 lock §10): it keeps the S1 user-action grouping — one commit action may span N transactions
+ *      sharing one batchId, so one batch maps to N operations; the two identities are permanently decoupled.
  *   3. `await sealOperation(query, op)` — LAST, before COMMIT: insert the endpoint row with
  *      `endpoint_seq = MAX(tracked seq)` and `event_count = number of tracked events`.
  *   4. COMMIT. An aborted txn exposes neither events nor endpoint (the endpoint is only visible post-commit —

--- a/packages/core-backend/src/multitable/record-history-service.ts
+++ b/packages/core-backend/src/multitable/record-history-service.ts
@@ -55,9 +55,10 @@ export interface RecordRevisionInput {
   /**
    * W0-1 L6-a (sealed operation endpoints — `operation-ledger.ts`): the active operation ledger for the
    * fenced write transaction. When present AND active (`ledger.operationId !== null`, i.e. the L4 fence flag
-   * is on and the L6 migration is deployed), this revision is TAGGED with `operation_id = ledger.operationId`,
-   * its `batch_id` is aligned to the same operation id (one operation = one batch), and its exact `seq` is fed
-   * back into the ledger for the endpoint seal. Omitted / inert ⇒ `operation_id` stays NULL and the write is
+   * is on and the L6 migration is deployed), this revision is TAGGED with `operation_id = ledger.operationId`
+   * and its exact `seq` is fed back into the ledger for the endpoint seal. `batch_id` is UNTOUCHED (finding #1,
+   * owner ruling 2026-07-16): it keeps the S1 user-action grouping — one batch may span N operations; the two
+   * identities are permanently decoupled. Omitted / inert ⇒ `operation_id` stays NULL and the write is
    * byte-identical to L4cov (legacy/untrusted, never an executable anchor).
    */
   ledger?: OperationLedger | null
@@ -105,11 +106,14 @@ async function hasRestoredFromVersionColumn(query: QueryFn): Promise<boolean> {
 export async function recordRecordRevision(query: QueryFn, input: RecordRevisionInput): Promise<string> {
   const id = input.id ?? randomUUID()
   const changedFieldIds = Array.from(new Set((input.changedFieldIds ?? []).filter(Boolean)))
-  // W0-1 L6-a: when the ledger is active, TAG this revision with the operation id and align batch_id to it
-  // (one operation = one batch — the design's "batch_id == operation_id" for trusted writes). Inert/omitted
-  // ledger ⇒ operationId null ⇒ base columns + batch_id default, byte-identical to L4cov.
+  // W0-1 finding #1 (owner ruling 2026-07-16, v3.7 lock §10): batch_id and operation_id are PERMANENTLY
+  // DECOUPLED. batch_id keeps the S1 user-action grouping — one commit action may span N per-row transactions
+  // sharing ONE caller-supplied batchId — and is NEVER overwritten by the operation id (the earlier
+  // "batch_id == operation_id" alignment re-split one AI commit into N History batches). operation_id is the
+  // per-transaction sealed-endpoint anchor and rides in its OWN column below. Inert/omitted ledger ⇒
+  // operationId null ⇒ base columns, byte-identical to L4cov.
   const operationId = input.ledger?.operationId ?? null
-  const batchId = operationId ?? input.batchId ?? id
+  const batchId = input.batchId ?? id
 
   // Base INSERT is the default for every write (zero deploy-window risk). Only a record-version restore
   // (restoredFromVersion non-null) uses the extended column, gated by a txn-safe column-existence probe so a
@@ -191,10 +195,11 @@ const BATCH_CHUNK_ROWS = 1000
 export async function recordRecordRevisionsBatch(query: QueryFn, inputs: RecordRevisionInput[]): Promise<string[]> {
   if (inputs.length === 0) return []
 
-  // W0-1 L6-a: all rows of one batch belong to the SAME operation (the caller threads one ledger through
-  // every input). Read it once; when active, TAG every row with the operation id, align batch_id to it, add
-  // `RETURNING seq`, and feed each returned seq into the ledger (order-independent — the endpoint needs only
-  // exact count + MAX). Inert/omitted ledger ⇒ operationId null ⇒ byte-identical to L4cov.
+  // W0-1 L6-a: all rows of one CALL belong to the SAME operation (the caller threads one ledger through
+  // every input). Read it once; when active, TAG every row with the operation id, add `RETURNING seq`, and
+  // feed each returned seq into the ledger (order-independent — the endpoint needs only exact count + MAX).
+  // batch_id is NOT aligned to it (finding #1, owner ruling 2026-07-16 — S1 grouping stays caller-owned).
+  // Inert/omitted ledger ⇒ operationId null ⇒ byte-identical to L4cov.
   const ledger = inputs[0]?.ledger ?? null
   const operationId = ledger?.operationId ?? null
 
@@ -211,7 +216,8 @@ export async function recordRecordRevisionsBatch(query: QueryFn, inputs: RecordR
       changedFieldIds: Array.from(new Set((input.changedFieldIds ?? []).filter(Boolean))),
       patch: JSON.stringify(input.patch ?? {}),
       snapshot: input.snapshot === undefined ? null : JSON.stringify(input.snapshot),
-      batchId: operationId ?? input.batchId ?? id,
+      // finding #1 decouple (owner ruling 2026-07-16): NEVER operationId here — batch_id is the S1 grouping key.
+      batchId: input.batchId ?? id,
       restoredFromVersion: input.restoredFromVersion ?? null,
     }
   })

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -1462,10 +1462,12 @@ export class RecordWriteService {
       ...(patchAttachmentSummaries ? { attachmentSummaries: patchAttachmentSummaries } : {}),
       ...(crossSheetRelated.length > 0 ? { relatedRecords: crossSheetRelated } : {}),
       // W3-5: only echo the batchId when something was actually written under it (never point a caller's
-      // history deep-link at a batch with zero revisions). W0-1 L6-a: when the operation ledger is active
-      // the stored batch_id is aligned to the operation id (one operation = one batch), so echo THAT so the
-      // caller's deep-link matches the persisted rows; inert ledger ⇒ the pre-existing bulkBatchId.
-      ...(updates.length > 0 ? { batchId: ledger.operationId ?? bulkBatchId } : {}),
+      // history deep-link at a batch with zero revisions). W0-1 finding #1 (owner ruling 2026-07-16):
+      // batch_id is DECOUPLED from operation_id — the stored batch_id is always the S1 user-action batch
+      // (the caller's explicit batchId or this call's bulkBatchId), so echo THAT. Echoing the per-transaction
+      // operation id would point the History deep-link at a batch id that matches ZERO stored rows for any
+      // S1 multi-transaction commit.
+      ...(updates.length > 0 ? { batchId: bulkBatchId } : {}),
     }
   }
 

--- a/packages/core-backend/tests/integration/multitable-l6a-sealed-operation-endpoint-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-l6a-sealed-operation-endpoint-realdb.test.ts
@@ -339,16 +339,21 @@ describeIfDatabase('W0-1 L6-a — sealed operation-endpoint ledger (real DB)', (
       access,
     }
     const result = await mkWriteService().patchRecords(input)
-    const opId = (result as { batchId?: string }).batchId as string
-    expect(opId).toMatch(/^[0-9a-f-]{36}$/)
+    // finding #1 decouple (owner ruling 2026-07-16): the echo is the S1 user-action batch id, NOT the
+    // per-transaction operation id — the deep-link must match the stored batch_id rows.
+    const echoedBatchId = (result as { batchId?: string }).batchId as string
+    expect(echoedBatchId).toMatch(/^[0-9a-f-]{36}$/)
 
-    // every revision this op wrote carries the SAME operation_id, aligned to batch_id
-    const revs = (await q('SELECT seq::text AS seq, operation_id, batch_id FROM meta_record_revisions WHERE sheet_id=$1 AND operation_id=$2 ORDER BY seq ASC', [SHEET, opId])).rows as Array<{ seq: string; operation_id: string; batch_id: string }>
+    // every revision of this call carries the echoed batch_id AND one shared operation_id — two DISTINCT identities
+    const revs = (await q('SELECT seq::text AS seq, operation_id, batch_id FROM meta_record_revisions WHERE sheet_id=$1 AND batch_id=$2 ORDER BY seq ASC', [SHEET, echoedBatchId])).rows as Array<{ seq: string; operation_id: string; batch_id: string }>
     expect(revs).toHaveLength(ids.length)
+    const opId = revs[0]!.operation_id
+    expect(opId).toMatch(/^[0-9a-f-]{36}$/)
     for (const r of revs) {
-      expect(r.operation_id).toBe(opId)
-      expect(r.batch_id).toBe(opId) // one operation == one batch
+      expect(r.operation_id).toBe(opId) // ONE transaction ⇒ one shared operation
+      expect(r.batch_id).toBe(echoedBatchId) // batch_id NEVER overwritten by the operation id
     }
+    expect(opId).not.toBe(echoedBatchId) // permanently decoupled identities
     // the endpoint sits AFTER all rows: endpoint_seq == exact MAX, count == N, and NO revision exceeds it
     const ep = await endpointOf(opId)
     expect(ep).toBeDefined()
@@ -380,6 +385,56 @@ describeIfDatabase('W0-1 L6-a — sealed operation-endpoint ledger (real DB)', (
     // minted AFTER the fence ⇒ the endpoint seq equals the op's own event seq (commit-order reflection)
     expect(ep!.endpoint_seq).toBe(rev.seq)
     expect(ep!.event_count).toBe(1)
+  })
+
+  // ── §G-MULTIOP-BATCH (owner-mandated, ruling 2026-07-16 — pins the original finding-#1 defect) ──────
+  // One S1 commit action spanning N per-row patchRecords TRANSACTIONS sharing ONE caller batchId (the AI
+  // bulk-commit shape, S1 LOCK-B/B2). Covers ruling parts (a)-(c): same batch_id on every revision, N distinct
+  // operation_ids + N sealed endpoints, and ONE History grouping key. Parts (d) resolver-max-endpoint_seq and
+  // (e) EXACT_ANCHOR_REQUIRED refusal live in L6-b (the resolver does not exist yet) — deferred, not skipped.
+  test('G-MULTIOP [S1 shape] one commit action across N transactions: ONE batch_id, N operation_ids + N endpoints, ONE History grouping key', async () => {
+    const ids = [mkRecord('mo1'), mkRecord('mo2'), mkRecord('mo3')]
+    for (const id of ids) await seedRecord(id)
+    process.env[FLAG] = 'true'
+    const commitBatchId = mkOpId() // the S1 server-minted commit-action batch id, shared across all N calls
+    const mkInput = (id: string): WriteRecordPatchInput => ({
+      sheetId: SHEET,
+      changesByRecord: new Map([[id, [{ fieldId: F_STR, value: `multiop-${id}` }]]]),
+      actorId: ACTOR,
+      batchId: commitBatchId, // ← threaded through every per-row call, exactly like the AI commit
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fields: [{ id: F_STR, name: 'Note', type: 'string', property: {}, order: 1 }] as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      visiblePropertyFields: [{ id: F_STR, name: 'Note', type: 'string', property: {}, order: 1 }] as any,
+      visiblePropertyFieldIds: new Set([F_STR]),
+      attachmentFields: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fieldById: new Map([[F_STR, { type: 'string', readOnly: false, hidden: false } as Record<string, unknown>]]) as any,
+      capabilities,
+      access,
+    })
+    const svc = mkWriteService()
+    for (const id of ids) {
+      const res = await svc.patchRecords(mkInput(id)) // each call = its OWN transaction (the S1 multi-txn shape)
+      // (echo leg) every per-row call echoes the SHARED commit batch id, never its private operation id
+      expect((res as { batchId?: string }).batchId).toBe(commitBatchId)
+    }
+
+    const revs = (await q('SELECT operation_id, batch_id FROM meta_record_revisions WHERE sheet_id=$1 AND batch_id=$2', [SHEET, commitBatchId])).rows as Array<{ operation_id: string; batch_id: string }>
+    // (a) ALL N revisions keep the SAME S1 batch_id — operation_id never overwrote it
+    expect(revs).toHaveLength(ids.length)
+    for (const r of revs) expect(r.batch_id).toBe(commitBatchId)
+    // (b) N DISTINCT operation_ids, one per transaction — and N sealed endpoints exist
+    const opIds = [...new Set(revs.map((r) => r.operation_id))]
+    expect(opIds).toHaveLength(ids.length)
+    for (const op of opIds) {
+      expect(op).toMatch(/^[0-9a-f-]{36}$/)
+      expect(op).not.toBe(commitBatchId)
+      expect(await endpointOf(op)).toBeDefined()
+    }
+    // (c) the History projection grouping key (COALESCE(batch_id, id)) yields ONE batch for the whole commit
+    const groups = (await q('SELECT COUNT(DISTINCT COALESCE(batch_id, id::text))::int AS n FROM meta_record_revisions WHERE sheet_id=$1 AND batch_id=$2', [SHEET, commitBatchId])).rows[0] as { n: number }
+    expect(groups.n).toBe(1)
   })
 
   // ── §P — flag-off PARITY: no operation id, no endpoint, byte-identical to L4cov ─────────────────────


### PR DESCRIPTION
## W0-1 finding-#1 runtime — decouple `batch_id` / `operation_id` (owner ruling 2026-07-16) + G-MULTIOP golden

**Implements the ratified v3.7 lock §10 terms 1–3** (owner ruling 2026-07-16; the design authority landed via #4376 → #4331). Stacked on #4380 (endpoint immutability) so the L6-a integration takes both together per the owner's step "L6-a (+ #4380 + runtime decouple)". **Draft; NOT merged directly; flags OFF; flag-off byte-identical (inert ledger).**

### The fix
- `record-history-service.ts` (both insert paths): `batch_id = input.batchId ?? id` — the per-transaction `operationId` **never** overwrites the S1 user-action batch id; `operation_id` rides its own column.
- `record-write-service.ts`: the patch result echoes `bulkBatchId` (the S1 batch), not `ledger.operationId` — the old echo pointed the History deep-link at a batch id matching zero stored rows for any S1 multi-transaction commit.
- Full-text sweep: all "batch_id == operation_id" / alignment wording corrected (operation-ledger protocol doc, interface docstrings, W1 assertions).

### Verification
- **G-MULTIOP golden (owner-mandated)** — one commit action across **N** `patchRecords` transactions sharing ONE `batchId` (the S1/AI-commit shape): (a) all revisions keep the SAME `batch_id`; (b) N DISTINCT `operation_id`s + N sealed endpoints; (c) ONE History grouping key (`COALESCE(batch_id, id)`); echo leg — every call echoes the shared batch id. Parts (d) resolver-max-`endpoint_seq` and (e) `EXACT_ANCHOR_REQUIRED` live in **L6-b** (the resolver doesn't exist yet) — deferred explicitly, not skipped.
- Fresh `postgres:14`: **18/18** (suite incl. §F2 + updated W1).
- **Mutation-proven**: restoring the overwrite at BOTH sites reds **G-MULTIOP and W1**; revert → 18/18.
- `tsc --noEmit` clean.

Per the owner's finish order this folds into the L6-a integration (after L3→L5→L4→L4cov), re-gated at exact head with full CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
