### PR TITLE
ci: add concurrency cancel-in-progress to 7 high-volume PR workflows

### DIFF
--- a/.github/workflows/batch2-test-stabilization.yml
+++ b/.github/workflows/batch2-test-stabilization.yml
@@ -20,6 +20,10 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   telemetry-plugin:
     runs-on: ubuntu-latest

--- a/.github/workflows/migration-replay.yml
+++ b/.github/workflows/migration-replay.yml
@@ -13,6 +13,10 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/migration-replay.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   migration-replay:
     runs-on: ubuntu-latest

--- a/.github/workflows/observability-e2e.yml
+++ b/.github/workflows/observability-e2e.yml
@@ -23,6 +23,10 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/observability-e2e.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/observability-strict.yml
+++ b/.github/workflows/observability-strict.yml
@@ -19,6 +19,10 @@ on:
       - 'packages/openapi/**'
       - '.github/workflows/observability-strict.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   observability-strict:
     name: Strict E2E with Enhanced Gates

--- a/.github/workflows/phase5-validate.yml
+++ b/.github/workflows/phase5-validate.yml
@@ -9,6 +9,10 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -20,6 +20,10 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dingtalk-p4-ops-regression-gate:
     name: DingTalk P4 ops regression gate

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -30,6 +30,10 @@ on:
   push:
     branches: [main, develop]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   web-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }` to the 7 highest-volume PR-triggered workflows so a new push to a PR cancels its still-running prior run (no signal loss — only the latest commit matters).

**Workflows:** Web Tests, Plugin System Tests, Phase 5 PR Validation, Observability E2E, Observability Strict, Migration Replay, Batch2 Test Stabilization.

**Why:** these 7 = ~9,275 runs/7d (~85% of repo CI volume), triggered on every PR push; none had cancel-in-progress, so superseded runs kept running on this rapid-iteration repo. Expected to cut total volume ~40% (~10,879 → ~7,000/wk) with zero loss of real signal.

Lever 1 of the metasheet2 降频 plan; path-filter levers (Web Tests / Phase 5 / Attendance) to follow once relevant paths are confirmed.