### PR TITLE
feat(plm): add Discussion embed token clients

### DIFF
--- a/.github/workflows/plm-embed-web-guard.yml
+++ b/.github/workflows/plm-embed-web-guard.yml
@@ -21,7 +21,9 @@
 # full @metasheet/web vitest suite has historical flakes, so wiring it whole would be red on arrival.
 # Verified green at time of wiring: 27/27. Extended 2026-07-13 to cover the discussion write-UI's
 # on-demand embed-token child protocol layer (plmEmbedWriteToken.ts, listen-only + one outbound
-# postMessage type, not yet wired into the view) — now 40/40.
+# postMessage type, not yet wired into the view) — now 40/40. Extended 2026-07-15 (sub-slice 4) to
+# cover the discussion READ-UI child protocol layer, which shares plmEmbedWriteToken.ts's internal
+# factory (purpose='discussion-read' instead of 'discussion-write') — now 60/60.
 #
 # NOT a required check (mirrors the other *-web-guard workflows): it cannot hang a PR, but it turns
 # a silent FE regression on the embed surface into a visible red.
@@ -45,8 +47,11 @@ on:
       # (child -> parent token-request / parent -> child token-response|token-error). Listen-only
       # today (not yet wired into PlmEmbedBomReviewView.vue -- see that module's docstring), but it
       # is the first OUTBOUND postMessage this embed page family makes, so it gets the same guard.
+      # This same file now also hosts the discussion read-UI's child protocol (sub-slice 4, shared
+      # internal factory, purpose='discussion-read') -- one path trigger covers both.
       - 'apps/web/src/services/integration/plmEmbedWriteToken.ts'
       - 'apps/web/tests/plm-embed-write-token.spec.ts'
+      - 'apps/web/tests/plm-embed-read-token.spec.ts'
       # Server side of the same wire: response shapes these specs pin (config allowlist + context degrade).
       - 'packages/core-backend/src/routes/plm-embed.ts'
       # This guard itself.
@@ -92,8 +97,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run PLM-embed web guard specs (targeted)
-        # Three files, 40 tests. The filter is a substring match — it resolves to exactly
-        # tests/plm-embed-bom-review.spec.ts, tests/plm-embed-service.spec.ts, and
-        # tests/plm-embed-write-token.spec.ts. (This is an explicit enumeration, not a glob — a
-        # future spec file needs its own substring added here or it silently never runs in CI.)
-        run: pnpm --filter @metasheet/web exec vitest run plm-embed-bom-review plm-embed-service plm-embed-write-token --reporter=dot
+        # Four files. The filter is a substring match — it resolves to exactly
+        # tests/plm-embed-bom-review.spec.ts, tests/plm-embed-service.spec.ts,
+        # tests/plm-embed-write-token.spec.ts, and tests/plm-embed-read-token.spec.ts. (This is an
+        # explicit enumeration, not a glob — a future spec file needs its own substring added here
+        # or it silently never runs in CI. NOTE: 'plm-embed-read-token' as a substring would ALSO
+        # match a future 'plm-embed-read-token-foo.spec.ts' -- that's fine, same convention as the
+        # other three entries here.)
+        run: pnpm --filter @metasheet/web exec vitest run plm-embed-bom-review plm-embed-service plm-embed-write-token plm-embed-read-token --reporter=dot

--- a/.github/workflows/plm-embed-web-guard.yml
+++ b/.github/workflows/plm-embed-web-guard.yml
@@ -19,7 +19,9 @@
 #
 # Scope: deliberately TARGETED (same convention as multitable/approval/attendance web-guards) — the
 # full @metasheet/web vitest suite has historical flakes, so wiring it whole would be red on arrival.
-# Verified green at time of wiring: 27/27.
+# Verified green at time of wiring: 27/27. Extended 2026-07-13 to cover the discussion write-UI's
+# on-demand embed-token child protocol layer (plmEmbedWriteToken.ts, listen-only + one outbound
+# postMessage type, not yet wired into the view) — now 40/40.
 #
 # NOT a required check (mirrors the other *-web-guard workflows): it cannot hang a PR, but it turns
 # a silent FE regression on the embed surface into a visible red.
@@ -39,6 +41,12 @@ on:
       # The specs themselves.
       - 'apps/web/tests/plm-embed-bom-review.spec.ts'
       - 'apps/web/tests/plm-embed-service.spec.ts'
+      # The child protocol layer for the discussion write-UI's on-demand embed-token handshake
+      # (child -> parent token-request / parent -> child token-response|token-error). Listen-only
+      # today (not yet wired into PlmEmbedBomReviewView.vue -- see that module's docstring), but it
+      # is the first OUTBOUND postMessage this embed page family makes, so it gets the same guard.
+      - 'apps/web/src/services/integration/plmEmbedWriteToken.ts'
+      - 'apps/web/tests/plm-embed-write-token.spec.ts'
       # Server side of the same wire: response shapes these specs pin (config allowlist + context degrade).
       - 'packages/core-backend/src/routes/plm-embed.ts'
       # This guard itself.
@@ -84,6 +92,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run PLM-embed web guard specs (targeted)
-        # Two files, 27 tests. The filter is a substring match — it resolves to exactly
-        # tests/plm-embed-bom-review.spec.ts and tests/plm-embed-service.spec.ts.
-        run: pnpm --filter @metasheet/web exec vitest run plm-embed-bom-review plm-embed-service --reporter=dot
+        # Three files, 40 tests. The filter is a substring match — it resolves to exactly
+        # tests/plm-embed-bom-review.spec.ts, tests/plm-embed-service.spec.ts, and
+        # tests/plm-embed-write-token.spec.ts. (This is an explicit enumeration, not a glob — a
+        # future spec file needs its own substring added here or it silently never runs in CI.)
+        run: pnpm --filter @metasheet/web exec vitest run plm-embed-bom-review plm-embed-service plm-embed-write-token --reporter=dot

--- a/apps/web/src/services/integration/plmEmbedWriteToken.ts
+++ b/apps/web/src/services/integration/plmEmbedWriteToken.ts
@@ -9,13 +9,22 @@
 // fresh by the parent for that one write. This module is the outbound half of that: it posts a
 // `plm-embed:token-request` to the parent and resolves the matching `plm-embed:token-response`.
 //
+// Sub-slice 4 (2026-07-15): the discussion READ-UI child needs the identical on-demand protocol,
+// differing ONLY in the `purpose` field the parent uses to decide what the minted token is good
+// for (the ratified sub-slice-3 parent accepts both `discussion-write` and `discussion-read`). The
+// security-critical protocol body (origin pin, nonce correlation, timeout, dispose-guard, CSPRNG
+// fail-closed) is extracted below into `createTokenClient`, an internal purpose-parameterized
+// factory, so it is written and tested ONCE and shared by both
+// `createPlmEmbedWriteTokenClient` and `createPlmEmbedReadTokenClient` rather than duplicated.
+//
 // Wire contract (child <-> parent), exact shape -- do not rename fields, the parent is a separate
 // build against this same contract:
-//   child -> parent:  { type: 'plm-embed:token-request', nonce: '<crypto-random>', purpose: 'discussion-write' }
+//   child -> parent:  { type: 'plm-embed:token-request', nonce: '<crypto-random>', purpose: 'discussion-write' | 'discussion-read' }
 //   parent -> child:  { type: 'plm-embed:token-response', nonce: '<echoed>', token: '<fresh JWT>' }
 //   parent -> child:  { type: 'plm-embed:token-error',    nonce: '<echoed>', reason: '<opaque>' }
 //
-// Security invariants (each backed by a test in tests/plm-embed-write-token.spec.ts):
+// Security invariants (each backed by a test in tests/plm-embed-write-token.spec.ts, and mirrored
+// for the read purpose in tests/plm-embed-read-token.spec.ts):
 //   1. Pinned origin, not allowlist membership. This module NEVER consults the origin allowlist --
 //      it is handed the origin the READ handshake already pinned (the first valid inbound token's
 //      origin) via `getParentOrigin()`, and requires an EXACT match plus `event.source ===
@@ -44,10 +53,11 @@ const TOKEN_REQUEST_TYPE = 'plm-embed:token-request' as const
 const TOKEN_RESPONSE_TYPE = 'plm-embed:token-response' as const
 const TOKEN_ERROR_TYPE = 'plm-embed:token-error' as const
 
-/** This module's sole purpose today; a distinct field per the locked contract, but NOT treated as
- * an authorization boundary here (a compromised child could send any value) -- the parent, not this
- * module, is responsible for deciding what `purpose` authorizes. */
+/** Distinct `purpose` fields per the locked contract, one per token client this module exports.
+ * NOT treated as an authorization boundary here (a compromised child could send any value) -- the
+ * parent, not this module, is responsible for deciding what `purpose` authorizes. */
 const WRITE_TOKEN_PURPOSE = 'discussion-write' as const
+const READ_TOKEN_PURPOSE = 'discussion-read' as const
 
 const TOKEN_REQUEST_TIMEOUT_MS = 5000
 
@@ -62,6 +72,24 @@ export class PlmEmbedWriteTokenError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'PlmEmbedWriteTokenError'
+  }
+}
+
+/** Read-purpose siblings of the write errors above -- same shape, distinctly named so a caller can
+ * tell a read-token failure from a write-token failure by `instanceof` without inspecting message
+ * text. Kept as separate classes (rather than reusing the write ones) so neither client's error
+ * messages says the wrong word ("write" on a read failure or vice versa). */
+export class PlmEmbedReadTokenTimeoutError extends Error {
+  constructor() {
+    super('timed out waiting for a fresh PLM embed read token')
+    this.name = 'PlmEmbedReadTokenTimeoutError'
+  }
+}
+
+export class PlmEmbedReadTokenError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PlmEmbedReadTokenError'
   }
 }
 
@@ -85,6 +113,24 @@ export interface PlmEmbedWriteTokenClient {
   dispose(): void
 }
 
+export interface PlmEmbedReadTokenClient {
+  /**
+   * Requests ONE fresh, single-use embed token for a read. Same lifecycle/security contract as
+   * {@link PlmEmbedWriteTokenClient.requestWriteToken} (memory-only, no replay, 5s timeout) -- the
+   * only difference is the outbound `purpose: 'discussion-read'`.
+   */
+  requestReadToken(): Promise<string>
+  /** Detaches the message listener and rejects any in-flight request. Idempotent. */
+  dispose(): void
+}
+
+/** Error-class pair a `createTokenClient(...)` instance uses to reject with, so the shared factory
+ * below stays purpose-agnostic while each public wrapper still throws its own named error types. */
+interface TokenErrorFactory {
+  timeout(): Error
+  generic(message: string): Error
+}
+
 function randomNonce(): string | null {
   const cryptoApi = globalThis.crypto as { randomUUID?: () => string; getRandomValues?: <T extends ArrayBufferView>(a: T) => T } | undefined
   if (typeof cryptoApi?.randomUUID === 'function') return cryptoApi.randomUUID()
@@ -105,13 +151,25 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Creates the child-side write-token channel. `getParentOrigin` MUST return the origin the read
- * handshake pinned (or `null` before it has pinned one) -- read it live on every call/message
- * rather than capturing a snapshot, so this channel tracks the same single source of truth the
- * read page uses. Callers own the returned client's lifetime: create it once per embed mount,
- * call `dispose()` on unmount.
+ * Internal purpose-parameterized factory: the ENTIRE security-critical protocol body (origin pin,
+ * `window.parent` source check, nonce correlation, memory-only settlement, 5s timeout,
+ * disposed-guard, CSPRNG fail-closed nonce) lives here ONCE, verbatim from the pre-refactor
+ * `createPlmEmbedWriteTokenClient`. `purpose` is the only thing that varies in the outbound
+ * `plm-embed:token-request` payload; `tokenLabel` / `errors` only vary the *wording* and *class* of
+ * the rejections each public wrapper below produces (never the control flow). Not exported --
+ * callers use `createPlmEmbedWriteTokenClient` / `createPlmEmbedReadTokenClient`.
+ *
+ * `getParentOrigin` MUST return the origin the read handshake pinned (or `null` before it has
+ * pinned one) -- read it live on every call/message rather than capturing a snapshot, so this
+ * channel tracks the same single source of truth the read page uses. Callers own the returned
+ * client's lifetime: create it once per embed mount, call `dispose()` on unmount.
  */
-export function createPlmEmbedWriteTokenClient(getParentOrigin: () => string | null): PlmEmbedWriteTokenClient {
+function createTokenClient(
+  getParentOrigin: () => string | null,
+  purpose: typeof WRITE_TOKEN_PURPOSE | typeof READ_TOKEN_PURPOSE,
+  tokenLabel: 'write' | 'read',
+  errors: TokenErrorFactory,
+): { request(): Promise<string>; dispose(): void } {
   let inFlight: InFlightRequest | null = null
   let disposed = false
 
@@ -149,14 +207,14 @@ export function createPlmEmbedWriteTokenClient(getParentOrigin: () => string | n
       if (typeof token === 'string' && token.length > 0) {
         current?.resolve(token)
       } else {
-        current?.reject(new PlmEmbedWriteTokenError('malformed token-response'))
+        current?.reject(errors.generic('malformed token-response'))
       }
       return
     }
     if (type === TOKEN_ERROR_TYPE) {
       const reason = data.reason
       const current = settleInFlight()
-      current?.reject(new PlmEmbedWriteTokenError(typeof reason === 'string' && reason ? reason : 'token-error'))
+      current?.reject(errors.generic(typeof reason === 'string' && reason ? reason : 'token-error'))
       return
     }
     // Any other type sharing our nonce is ignored -- neither resolves nor rejects nor consumes it.
@@ -164,42 +222,79 @@ export function createPlmEmbedWriteTokenClient(getParentOrigin: () => string | n
 
   window.addEventListener('message', onMessage)
 
-  function requestWriteToken(): Promise<string> {
+  function request(): Promise<string> {
     if (disposed) {
       // Fail fast after teardown: never post a spurious token-request (which the parent could
       // mint + burn a single-use jti for) and never hang the caller on a listener that is gone.
-      return Promise.reject(new PlmEmbedWriteTokenError('write-token client is disposed'))
+      return Promise.reject(errors.generic(`${tokenLabel}-token client is disposed`))
     }
     if (inFlight) {
-      return Promise.reject(new PlmEmbedWriteTokenError('a write-token request is already in flight'))
+      return Promise.reject(errors.generic(`a ${tokenLabel}-token request is already in flight`))
     }
     const parentOrigin = getParentOrigin()
     if (!parentOrigin) {
-      return Promise.reject(new PlmEmbedWriteTokenError('parent origin is not pinned yet'))
+      return Promise.reject(errors.generic('parent origin is not pinned yet'))
     }
 
     const nonce = randomNonce()
     if (nonce === null) {
-      return Promise.reject(new PlmEmbedWriteTokenError('secure randomness (Web Crypto) is unavailable'))
+      return Promise.reject(errors.generic('secure randomness (Web Crypto) is unavailable'))
     }
     return new Promise<string>((resolve, reject) => {
       const timeoutHandle = setTimeout(() => {
         settleInFlight()
-        reject(new PlmEmbedWriteTokenTimeoutError())
+        reject(errors.timeout())
       }, TOKEN_REQUEST_TIMEOUT_MS)
       inFlight = { nonce, resolve, reject, timeoutHandle }
       // targetOrigin is ALWAYS the pinned parentOrigin -- never '*'. This is the first outbound
       // postMessage this embed page family makes; see module docstring invariant 4.
-      window.parent.postMessage({ type: TOKEN_REQUEST_TYPE, nonce, purpose: WRITE_TOKEN_PURPOSE }, parentOrigin)
+      window.parent.postMessage({ type: TOKEN_REQUEST_TYPE, nonce, purpose }, parentOrigin)
     })
   }
 
   function dispose(): void {
     disposed = true
     const current = settleInFlight()
-    current?.reject(new PlmEmbedWriteTokenError('write-token client disposed'))
+    current?.reject(errors.generic(`${tokenLabel}-token client disposed`))
     window.removeEventListener('message', onMessage)
   }
 
-  return { requestWriteToken, dispose }
+  return { request, dispose }
+}
+
+const writeTokenErrors: TokenErrorFactory = {
+  timeout: () => new PlmEmbedWriteTokenTimeoutError(),
+  generic: (message: string) => new PlmEmbedWriteTokenError(message),
+}
+
+const readTokenErrors: TokenErrorFactory = {
+  timeout: () => new PlmEmbedReadTokenTimeoutError(),
+  generic: (message: string) => new PlmEmbedReadTokenError(message),
+}
+
+/**
+ * Creates the child-side write-token channel (`purpose: 'discussion-write'`). Thin wrapper over
+ * {@link createTokenClient} -- see that function's docstring for the shared protocol contract.
+ * Behavior is unchanged from before the sub-slice-4 refactor: same wire shape, same rejections.
+ */
+export function createPlmEmbedWriteTokenClient(getParentOrigin: () => string | null): PlmEmbedWriteTokenClient {
+  const client = createTokenClient(getParentOrigin, WRITE_TOKEN_PURPOSE, 'write', writeTokenErrors)
+  return {
+    requestWriteToken: () => client.request(),
+    dispose: () => client.dispose(),
+  }
+}
+
+/**
+ * Creates the child-side read-token channel (`purpose: 'discussion-read'`). Thin wrapper over
+ * {@link createTokenClient} -- identical protocol/security invariants to the write client, just a
+ * different `purpose` and error-class pair. See {@link createPlmEmbedWriteTokenClient}'s docstring
+ * and the module header for the shared contract.
+ */
+export function createPlmEmbedReadTokenClient(getParentOrigin: () => string | null): PlmEmbedReadTokenClient {
+  const client = createTokenClient(getParentOrigin, READ_TOKEN_PURPOSE, 'read', readTokenErrors)
+  return {
+    requestReadToken: () => client.request(),
+    dispose: () => client.dispose(),
+  }
 }

--- a/apps/web/src/services/integration/plmEmbedWriteToken.ts
+++ b/apps/web/src/services/integration/plmEmbedWriteToken.ts
@@ -1,0 +1,189 @@
+// PLM-COLLAB Discussion Phase-3 write-UI — CHILD half of the child→parent on-demand embed-token
+// protocol (contract locked in the ratified taskbook
+// docs/development/plm-discussion-c1-read-panel-design-lock-20260711.md §1/§3: "the on-demand
+// token protocol is the single unlock for the entire discussion surface").
+//
+// Why this exists: the BOM-review embed's ORIGINAL handshake (PlmEmbedBomReviewView.vue) is
+// LISTEN-only and first-token-wins -- one mount = one token = one authenticated read call. A write
+// (create/comment/resolve/reopen a discussion thread) needs its OWN embed token, single-use, minted
+// fresh by the parent for that one write. This module is the outbound half of that: it posts a
+// `plm-embed:token-request` to the parent and resolves the matching `plm-embed:token-response`.
+//
+// Wire contract (child <-> parent), exact shape -- do not rename fields, the parent is a separate
+// build against this same contract:
+//   child -> parent:  { type: 'plm-embed:token-request', nonce: '<crypto-random>', purpose: 'discussion-write' }
+//   parent -> child:  { type: 'plm-embed:token-response', nonce: '<echoed>', token: '<fresh JWT>' }
+//   parent -> child:  { type: 'plm-embed:token-error',    nonce: '<echoed>', reason: '<opaque>' }
+//
+// Security invariants (each backed by a test in tests/plm-embed-write-token.spec.ts):
+//   1. Pinned origin, not allowlist membership. This module NEVER consults the origin allowlist --
+//      it is handed the origin the READ handshake already pinned (the first valid inbound token's
+//      origin) via `getParentOrigin()`, and requires an EXACT match plus `event.source ===
+//      window.parent` on every token-response/token-error. A different origin that also happens to
+//      be allowlisted is still rejected: pinning is a stricter, narrower check than allowlist
+//      membership, and this module only ever knows the ONE pinned value.
+//   2. Request correlation. Exactly one in-flight request at a time, keyed by a fresh crypto-random
+//      nonce; any inbound message whose nonce does not match the in-flight one is dropped silently
+//      (covers stale responses to an already-settled/timed-out request, and forged/guessed nonces).
+//   3. Fresh token per write, memory-only. The resolved token is handed to the caller as a plain
+//      string for that ONE write; this module never persists it (no localStorage/sessionStorage/
+//      cookie/URL/logs) and never caches or reuses it -- the caller's local `const` falls out of
+//      scope after the single relay call.
+//   4. Outbound post is targeted, never '*'. `targetOrigin` is always the pinned `parentOrigin` --
+//      this is the FIRST outbound postMessage this embed page family makes, so it is audited with
+//      the same care as the read page's inbound gate.
+//   5. 5-second timeout. No token-response/token-error for the in-flight nonce within 5s clears the
+//      in-flight state and rejects -- callers get a clean retry path, never a hang.
+//   6. Re-request, not replay. Every failure path (token-error, timeout, dispose) clears the
+//      in-flight nonce. There is no "resend the same request" API -- a retry can only be a brand
+//      new `requestWriteToken()` call, which mints a brand new nonce and posts a brand new request.
+//      A spent/failed token is never re-sent because there is no code path that re-sends anything.
+
+/** Inbound/outbound message `type` discriminators -- exact strings per the locked contract. */
+const TOKEN_REQUEST_TYPE = 'plm-embed:token-request' as const
+const TOKEN_RESPONSE_TYPE = 'plm-embed:token-response' as const
+const TOKEN_ERROR_TYPE = 'plm-embed:token-error' as const
+
+/** This module's sole purpose today; a distinct field per the locked contract, but NOT treated as
+ * an authorization boundary here (a compromised child could send any value) -- the parent, not this
+ * module, is responsible for deciding what `purpose` authorizes. */
+const WRITE_TOKEN_PURPOSE = 'discussion-write' as const
+
+const TOKEN_REQUEST_TIMEOUT_MS = 5000
+
+export class PlmEmbedWriteTokenTimeoutError extends Error {
+  constructor() {
+    super('timed out waiting for a fresh PLM embed write token')
+    this.name = 'PlmEmbedWriteTokenTimeoutError'
+  }
+}
+
+export class PlmEmbedWriteTokenError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PlmEmbedWriteTokenError'
+  }
+}
+
+interface InFlightRequest {
+  nonce: string
+  resolve: (token: string) => void
+  reject: (err: Error) => void
+  timeoutHandle: ReturnType<typeof setTimeout>
+}
+
+export interface PlmEmbedWriteTokenClient {
+  /**
+   * Requests ONE fresh, single-use embed token for a write. Resolves with the raw token string
+   * (memory-only -- the caller must use it for exactly one relay write and let it fall out of
+   * scope; never store it). Rejects on token-error, timeout (5s), or disposal. There is no replay:
+   * every call -- including a retry after a rejection -- mints a brand new nonce and posts a brand
+   * new `plm-embed:token-request`.
+   */
+  requestWriteToken(): Promise<string>
+  /** Detaches the message listener and rejects any in-flight request. Idempotent. */
+  dispose(): void
+}
+
+function randomNonce(): string {
+  const cryptoApi = globalThis.crypto as { randomUUID?: () => string; getRandomValues?: <T extends ArrayBufferView>(a: T) => T } | undefined
+  if (typeof cryptoApi?.randomUUID === 'function') return cryptoApi.randomUUID()
+  if (typeof cryptoApi?.getRandomValues === 'function') {
+    const bytes = new Uint8Array(16)
+    cryptoApi.getRandomValues(bytes)
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+  }
+  // Defensive-only fallback; every supported runtime (browser + jsdom test env) provides `crypto`.
+  return `wtok-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+/**
+ * Creates the child-side write-token channel. `getParentOrigin` MUST return the origin the read
+ * handshake pinned (or `null` before it has pinned one) -- read it live on every call/message
+ * rather than capturing a snapshot, so this channel tracks the same single source of truth the
+ * read page uses. Callers own the returned client's lifetime: create it once per embed mount,
+ * call `dispose()` on unmount.
+ */
+export function createPlmEmbedWriteTokenClient(getParentOrigin: () => string | null): PlmEmbedWriteTokenClient {
+  let inFlight: InFlightRequest | null = null
+
+  function settleInFlight(): InFlightRequest | null {
+    const current = inFlight
+    if (current) {
+      clearTimeout(current.timeoutHandle)
+      inFlight = null
+    }
+    return current
+  }
+
+  function onMessage(event: MessageEvent): void {
+    if (!inFlight) return // nothing outstanding: nothing to correlate, drop unconditionally
+
+    // Pinned-origin gate: exact match against the SAME origin the read handshake pinned, plus a
+    // real-parent source check. Allowlist membership is irrelevant here on purpose (see module
+    // docstring, invariant 1) -- a different allowlisted origin must still fail this check.
+    const parentOrigin = getParentOrigin()
+    if (!parentOrigin || event.origin !== parentOrigin) return
+    if (event.source && event.source !== window.parent) return
+
+    const data = event.data
+    if (!isRecord(data)) return
+    const type = data.type
+    const nonce = data.nonce
+    if (typeof nonce !== 'string' || nonce !== inFlight.nonce) return // stale/foreign nonce: drop
+
+    if (type === TOKEN_RESPONSE_TYPE) {
+      const token = data.token
+      const current = settleInFlight()
+      if (typeof token === 'string' && token.length > 0) {
+        current?.resolve(token)
+      } else {
+        current?.reject(new PlmEmbedWriteTokenError('malformed token-response'))
+      }
+      return
+    }
+    if (type === TOKEN_ERROR_TYPE) {
+      const reason = data.reason
+      const current = settleInFlight()
+      current?.reject(new PlmEmbedWriteTokenError(typeof reason === 'string' && reason ? reason : 'token-error'))
+      return
+    }
+    // Any other type sharing our nonce is ignored -- neither resolves nor rejects nor consumes it.
+  }
+
+  window.addEventListener('message', onMessage)
+
+  function requestWriteToken(): Promise<string> {
+    if (inFlight) {
+      return Promise.reject(new PlmEmbedWriteTokenError('a write-token request is already in flight'))
+    }
+    const parentOrigin = getParentOrigin()
+    if (!parentOrigin) {
+      return Promise.reject(new PlmEmbedWriteTokenError('parent origin is not pinned yet'))
+    }
+
+    const nonce = randomNonce()
+    return new Promise<string>((resolve, reject) => {
+      const timeoutHandle = setTimeout(() => {
+        settleInFlight()
+        reject(new PlmEmbedWriteTokenTimeoutError())
+      }, TOKEN_REQUEST_TIMEOUT_MS)
+      inFlight = { nonce, resolve, reject, timeoutHandle }
+      // targetOrigin is ALWAYS the pinned parentOrigin -- never '*'. This is the first outbound
+      // postMessage this embed page family makes; see module docstring invariant 4.
+      window.parent.postMessage({ type: TOKEN_REQUEST_TYPE, nonce, purpose: WRITE_TOKEN_PURPOSE }, parentOrigin)
+    })
+  }
+
+  function dispose(): void {
+    const current = settleInFlight()
+    current?.reject(new PlmEmbedWriteTokenError('write-token client disposed'))
+    window.removeEventListener('message', onMessage)
+  }
+
+  return { requestWriteToken, dispose }
+}

--- a/apps/web/src/services/integration/plmEmbedWriteToken.ts
+++ b/apps/web/src/services/integration/plmEmbedWriteToken.ts
@@ -110,6 +110,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  */
 export function createPlmEmbedWriteTokenClient(getParentOrigin: () => string | null): PlmEmbedWriteTokenClient {
   let inFlight: InFlightRequest | null = null
+  let disposed = false
 
   function settleInFlight(): InFlightRequest | null {
     const current = inFlight
@@ -128,7 +129,10 @@ export function createPlmEmbedWriteTokenClient(getParentOrigin: () => string | n
     // docstring, invariant 1) -- a different allowlisted origin must still fail this check.
     const parentOrigin = getParentOrigin()
     if (!parentOrigin || event.origin !== parentOrigin) return
-    if (event.source && event.source !== window.parent) return
+    // Positive conjunct per the ratified taskbook lock 1: `event.source === window.parent`. A
+    // null/absent source is REJECTED (a token-response is write-authorizing — unlike the read
+    // page's inbound gate, we do not fall back to origin-only for source-less synthetic events).
+    if (event.source !== window.parent) return
 
     const data = event.data
     if (!isRecord(data)) return
@@ -158,6 +162,11 @@ export function createPlmEmbedWriteTokenClient(getParentOrigin: () => string | n
   window.addEventListener('message', onMessage)
 
   function requestWriteToken(): Promise<string> {
+    if (disposed) {
+      // Fail fast after teardown: never post a spurious token-request (which the parent could
+      // mint + burn a single-use jti for) and never hang the caller on a listener that is gone.
+      return Promise.reject(new PlmEmbedWriteTokenError('write-token client is disposed'))
+    }
     if (inFlight) {
       return Promise.reject(new PlmEmbedWriteTokenError('a write-token request is already in flight'))
     }
@@ -180,6 +189,7 @@ export function createPlmEmbedWriteTokenClient(getParentOrigin: () => string | n
   }
 
   function dispose(): void {
+    disposed = true
     const current = settleInFlight()
     current?.reject(new PlmEmbedWriteTokenError('write-token client disposed'))
     window.removeEventListener('message', onMessage)

--- a/apps/web/src/services/integration/plmEmbedWriteToken.ts
+++ b/apps/web/src/services/integration/plmEmbedWriteToken.ts
@@ -85,7 +85,7 @@ export interface PlmEmbedWriteTokenClient {
   dispose(): void
 }
 
-function randomNonce(): string {
+function randomNonce(): string | null {
   const cryptoApi = globalThis.crypto as { randomUUID?: () => string; getRandomValues?: <T extends ArrayBufferView>(a: T) => T } | undefined
   if (typeof cryptoApi?.randomUUID === 'function') return cryptoApi.randomUUID()
   if (typeof cryptoApi?.getRandomValues === 'function') {
@@ -93,8 +93,11 @@ function randomNonce(): string {
     cryptoApi.getRandomValues(bytes)
     return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
   }
-  // Defensive-only fallback; every supported runtime (browser + jsdom test env) provides `crypto`.
-  return `wtok-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  // FAIL CLOSED (adversarial-verify P2): with no CSPRNG, return null so requestWriteToken() rejects
+  // and posts NOTHING. A predictable Date.now()+Math.random() nonce would weaken the correlation
+  // lock; a write channel must not silently degrade. Every supported runtime (browser + jsdom test
+  // env) provides Web Crypto, so this is a fail-closed guard, not an expected path.
+  return null
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -176,6 +179,9 @@ export function createPlmEmbedWriteTokenClient(getParentOrigin: () => string | n
     }
 
     const nonce = randomNonce()
+    if (nonce === null) {
+      return Promise.reject(new PlmEmbedWriteTokenError('secure randomness (Web Crypto) is unavailable'))
+    }
     return new Promise<string>((resolve, reject) => {
       const timeoutHandle = setTimeout(() => {
         settleInFlight()

--- a/apps/web/tests/plm-embed-read-token.spec.ts
+++ b/apps/web/tests/plm-embed-read-token.spec.ts
@@ -1,0 +1,312 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createPlmEmbedReadTokenClient,
+  createPlmEmbedWriteTokenClient,
+  PlmEmbedReadTokenError,
+  PlmEmbedReadTokenTimeoutError,
+  type PlmEmbedReadTokenClient,
+} from '../src/services/integration/plmEmbedWriteToken'
+
+// Child half of the child->parent on-demand embed-token protocol (discussion READ-UI, sub-slice 4).
+// This mirrors tests/plm-embed-write-token.spec.ts one-for-one -- same invariants, same client
+// shape -- because createPlmEmbedReadTokenClient is a thin wrapper over the SAME internal
+// `createTokenClient` factory the write client uses (see plmEmbedWriteToken.ts). The write spec is
+// left completely untouched; this file only adds read-purpose coverage, plus one write-side
+// assertion (below) proving the refactor did not cross the two purposes.
+//
+// PLM_ORIGIN is the ONE origin this channel is pinned to in each test (mirroring the origin the
+// read handshake already pinned). OTHER_ALLOWED_ORIGIN stands in for a origin that IS present in
+// the server's allowlist elsewhere but is NOT the pinned origin for this mount -- MUST-1 requires
+// it be rejected all the same (pinning, not allowlist membership, is the gate this module enforces).
+const PLM_ORIGIN = 'https://plm.example.com'
+const OTHER_ALLOWED_ORIGIN = 'https://plm-secondary.example.com'
+
+const TOKEN_REQUEST_TYPE = 'plm-embed:token-request'
+const TOKEN_RESPONSE_TYPE = 'plm-embed:token-response'
+const TOKEN_ERROR_TYPE = 'plm-embed:token-error'
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function postFromParent(origin: string, data: unknown, source: MessageEventSource | null = window.parent): void {
+  window.dispatchEvent(new MessageEvent('message', { origin, data, source }))
+}
+
+/** Reads the nonce the channel just posted off the postMessage spy's most recent call. */
+function lastPostedNonce(postSpy: ReturnType<typeof vi.spyOn>): string {
+  const lastCall = postSpy.mock.calls[postSpy.mock.calls.length - 1] as [{ nonce: string }, string]
+  return lastCall[0].nonce
+}
+
+describe('plmEmbedWriteToken — child protocol layer (discussion read-UI on-demand token)', () => {
+  let client: PlmEmbedReadTokenClient | null = null
+  let parentOrigin: string | null = PLM_ORIGIN
+  let postSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    parentOrigin = PLM_ORIGIN
+    postSpy = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+    client = createPlmEmbedReadTokenClient(() => parentOrigin)
+  })
+
+  afterEach(() => {
+    client?.dispose()
+    client = null
+    postSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it('MUST-4: posts the token-request to the PINNED parentOrigin, never "*", with the exact contract shape, purpose=discussion-read', async () => {
+    // Fire-and-forget: this test only inspects the outbound post, not the eventual settlement.
+    // afterEach's dispose() rejects any request still in flight when the test ends, so attach a
+    // no-op catch to avoid an unhandled-rejection warning bleeding into a later test's output.
+    client!.requestReadToken().catch(() => {})
+    expect(postSpy).toHaveBeenCalledTimes(1)
+    const [message, targetOrigin] = postSpy.mock.calls[0] as [Record<string, unknown>, string]
+    expect(targetOrigin).toBe(PLM_ORIGIN)
+    expect(targetOrigin).not.toBe('*')
+    expect(message.type).toBe(TOKEN_REQUEST_TYPE)
+    expect(message.purpose).toBe('discussion-read')
+    expect(typeof message.nonce).toBe('string')
+    expect((message.nonce as string).length).toBeGreaterThan(0)
+  })
+
+  it('cross-check: the WRITE client (same module, same shared factory) still posts purpose=discussion-write, proving the refactor did not cross the two purposes', async () => {
+    const writePostSpy = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+    const writeClient = createPlmEmbedWriteTokenClient(() => PLM_ORIGIN)
+    try {
+      writeClient.requestWriteToken().catch(() => {})
+      const [message] = writePostSpy.mock.calls[writePostSpy.mock.calls.length - 1] as [Record<string, unknown>, string]
+      expect(message.purpose).toBe('discussion-write')
+      expect(message.purpose).not.toBe('discussion-read')
+    } finally {
+      writeClient.dispose()
+      writePostSpy.mockRestore()
+    }
+  })
+
+  it('MUST-1: accepts a token-response from the pinned origin + window.parent source', async () => {
+    const promise = client!.requestReadToken()
+    const nonce = lastPostedNonce(postSpy)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'fresh-jwt-1' })
+    await expect(promise).resolves.toBe('fresh-jwt-1')
+  })
+
+  it('MUST-1: rejects a response from a DIFFERENT origin, even one that is ALSO allowlisted elsewhere', async () => {
+    const promise = client!.requestReadToken()
+    const nonce = lastPostedNonce(postSpy)
+    // OTHER_ALLOWED_ORIGIN is not the pinned origin for this mount -- must be dropped even though a
+    // real deployment's server-side allowlist may contain it. Allowlist membership is necessary but
+    // not sufficient; only the pinned origin exact-matches.
+    postFromParent(OTHER_ALLOWED_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'should-not-resolve' })
+    await flush()
+    // The dropped message must not have settled the promise -- prove it by now delivering the
+    // CORRECT response and confirming that one (and only that one) resolves it.
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'correct-token' })
+    await expect(promise).resolves.toBe('correct-token')
+  })
+
+  it('MUST-1: rejects a response whose event.source is not window.parent, even from the pinned origin', async () => {
+    const frame = document.createElement('iframe')
+    document.body.appendChild(frame)
+    try {
+      const promise = client!.requestReadToken()
+      const nonce = lastPostedNonce(postSpy)
+      // Correct origin, WRONG source (a foreign window masquerading as the pinned origin).
+      postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'should-not-resolve' }, frame.contentWindow)
+      await flush()
+      postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'correct-token' })
+      await expect(promise).resolves.toBe('correct-token')
+    } finally {
+      frame.remove()
+    }
+  })
+
+  it('MUST-1: rejects a response with a NULL/absent event.source, even from the pinned origin', async () => {
+    // Positive conjunct (taskbook lock 1): source must EQUAL window.parent; a source-less event
+    // is NOT accepted via an origin-only fallback (a token-response is authorizing).
+    const promise = client!.requestReadToken()
+    const nonce = lastPostedNonce(postSpy)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'should-not-resolve' }, null)
+    await flush()
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'correct-token' })
+    await expect(promise).resolves.toBe('correct-token')
+  })
+
+  it('MUST-2: drops a response whose nonce does not match the single in-flight request', async () => {
+    const promise = client!.requestReadToken()
+    const nonce = lastPostedNonce(postSpy)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: 'some-other-nonce', token: 'wrong-nonce-token' })
+    await flush()
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'right-nonce-token' })
+    await expect(promise).resolves.toBe('right-nonce-token')
+  })
+
+  it('MUST-2/6: a stale response for a request that already TIMED OUT is dropped by the NEXT request', async () => {
+    vi.useFakeTimers()
+    const firstPromise = client!.requestReadToken()
+    const staleNonce = lastPostedNonce(postSpy)
+    firstPromise.catch(() => {}) // expected rejection; silence unhandled-rejection noise
+    await vi.advanceTimersByTimeAsync(5000)
+    await expect(firstPromise).rejects.toBeInstanceOf(PlmEmbedReadTokenTimeoutError)
+
+    // Re-request per MUST-6: a NEW nonce, tracked as the ONLY in-flight request now.
+    const secondPromise = client!.requestReadToken()
+    const secondNonce = lastPostedNonce(postSpy)
+    expect(secondNonce).not.toBe(staleNonce)
+
+    // A late response using the STALE (first) nonce must be dropped, even though it is otherwise
+    // well-formed and from the pinned origin -- it does not resolve/replay onto the second request.
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: staleNonce, token: 'late-stale-token' })
+    await vi.advanceTimersByTimeAsync(0)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: secondNonce, token: 'second-token' })
+    await expect(secondPromise).resolves.toBe('second-token')
+  })
+
+  it('MUST-5: rejects with a timeout after 5s of silence, clearing the in-flight nonce', async () => {
+    vi.useFakeTimers()
+    const promise = client!.requestReadToken()
+    // Not yet at the deadline: still pending.
+    await vi.advanceTimersByTimeAsync(4999)
+    let settled = false
+    promise.then(
+      () => (settled = true),
+      () => (settled = true),
+    )
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(2)
+    await expect(promise).rejects.toBeInstanceOf(PlmEmbedReadTokenTimeoutError)
+  })
+
+  it('MUST-6: a token-error clears the in-flight nonce; retrying issues a brand-new request, never a replay', async () => {
+    const firstPromise = client!.requestReadToken()
+    const firstNonce = lastPostedNonce(postSpy)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_ERROR_TYPE, nonce: firstNonce, reason: 'rate_limited' })
+    await expect(firstPromise).rejects.toBeInstanceOf(PlmEmbedReadTokenError)
+
+    const secondPromise = client!.requestReadToken()
+    const secondNonce = lastPostedNonce(postSpy)
+    expect(secondNonce).not.toBe(firstNonce)
+    expect(postSpy).toHaveBeenCalledTimes(2)
+
+    // The failed first token is never re-sent: a response bearing the OLD nonce cannot resolve the
+    // new request.
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: firstNonce, token: 'must-not-apply' })
+    await flush()
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: secondNonce, token: 'fresh-retry-token' })
+    await expect(secondPromise).resolves.toBe('fresh-retry-token')
+  })
+
+  it('MUST-3: one-token-one-read — each requestReadToken() call yields its OWN distinct token, never reused', async () => {
+    const firstPromise = client!.requestReadToken()
+    const firstNonce = lastPostedNonce(postSpy)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: firstNonce, token: 'token-for-read-1' })
+    const firstToken = await firstPromise
+
+    const secondPromise = client!.requestReadToken()
+    const secondNonce = lastPostedNonce(postSpy)
+    expect(secondNonce).not.toBe(firstNonce)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: secondNonce, token: 'token-for-read-2' })
+    const secondToken = await secondPromise
+
+    expect(firstToken).toBe('token-for-read-1')
+    expect(secondToken).toBe('token-for-read-2')
+    expect(firstToken).not.toBe(secondToken)
+  })
+
+  it('MUST-3: memory-only — the resolved token never touches localStorage/sessionStorage/cookies, and nothing is logged', async () => {
+    const localSetItemSpy = vi.spyOn(window.localStorage, 'setItem')
+    const sessionSetItemSpy =
+      typeof window.sessionStorage?.setItem === 'function' ? vi.spyOn(window.sessionStorage, 'setItem') : null
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const cookieBefore = document.cookie
+    const SECRET_TOKEN = 'super-secret-single-use-jwt-zzz'
+
+    try {
+      const promise = client!.requestReadToken()
+      const nonce = lastPostedNonce(postSpy)
+      postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: SECRET_TOKEN })
+      const token = await promise
+      expect(token).toBe(SECRET_TOKEN)
+
+      expect(localSetItemSpy).not.toHaveBeenCalled()
+      if (sessionSetItemSpy) expect(sessionSetItemSpy).not.toHaveBeenCalled()
+      expect(document.cookie).toBe(cookieBefore)
+      expect(consoleLogSpy).not.toHaveBeenCalled()
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+      // Literal-scan proof: the token string must not appear anywhere in local/session storage or
+      // the cookie jar, regardless of how it got there.
+      const localDump = JSON.stringify({ ...window.localStorage })
+      expect(localDump).not.toContain(SECRET_TOKEN)
+      expect(document.cookie).not.toContain(SECRET_TOKEN)
+    } finally {
+      localSetItemSpy.mockRestore()
+      sessionSetItemSpy?.mockRestore()
+      consoleLogSpy.mockRestore()
+      consoleWarnSpy.mockRestore()
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
+  it('a second requestReadToken() while one is already in flight is rejected (fail-fast, exactly one in-flight)', async () => {
+    const firstPromise = client!.requestReadToken()
+    const firstNonce = lastPostedNonce(postSpy)
+    await expect(client!.requestReadToken()).rejects.toBeInstanceOf(PlmEmbedReadTokenError)
+    expect(postSpy).toHaveBeenCalledTimes(1) // the rejected second call never posted anything
+
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: firstNonce, token: 'still-the-first' })
+    await expect(firstPromise).resolves.toBe('still-the-first')
+  })
+
+  it('ignores malformed/irrelevant messages from the pinned origin without settling the request', async () => {
+    const promise = client!.requestReadToken()
+    const nonce = lastPostedNonce(postSpy)
+    postFromParent(PLM_ORIGIN, { type: 'something-else', nonce, token: 'ignored' })
+    postFromParent(PLM_ORIGIN, 'not-an-object')
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE }) // no nonce
+    await flush()
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'finally' })
+    await expect(promise).resolves.toBe('finally')
+  })
+
+  it('MUST-2 fail-closed: with no Web Crypto CSPRNG, requestReadToken() rejects and posts NOTHING', async () => {
+    const realCrypto = globalThis.crypto
+    // A runtime with no usable CSPRNG (no randomUUID, no getRandomValues) must NOT degrade to a
+    // predictable nonce -- it must reject before any outbound token-request.
+    Object.defineProperty(globalThis, 'crypto', { value: {}, configurable: true })
+    try {
+      const postsBefore = postSpy.mock.calls.length
+      await expect(client!.requestReadToken()).rejects.toBeInstanceOf(PlmEmbedReadTokenError)
+      expect(postSpy.mock.calls.length).toBe(postsBefore)
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', { value: realCrypto, configurable: true })
+    }
+  })
+
+  it('dispose() rejects an in-flight request and REMOVES the message listener (non-vacuous)', async () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+    const promise = client!.requestReadToken()
+    client!.dispose()
+    await expect(promise).rejects.toBeInstanceOf(PlmEmbedReadTokenError)
+    // Prove the listener is actually detached, not just that a stray message doesn't throw: the
+    // exact 'message' handler passed to addEventListener must be handed to removeEventListener.
+    expect(removeSpy).toHaveBeenCalledWith('message', expect.any(Function))
+    removeSpy.mockRestore()
+  })
+
+  it('use-after-dispose: requestReadToken() after dispose() rejects immediately and posts NOTHING', async () => {
+    // Regression: a deferred consumer firing after unmount must not re-post a token-request (which
+    // the parent could mint + burn a single-use jti for) nor hang 5s on a removed listener.
+    client!.dispose()
+    const postsBefore = postSpy.mock.calls.length
+    await expect(client!.requestReadToken()).rejects.toBeInstanceOf(PlmEmbedReadTokenError)
+    expect(postSpy.mock.calls.length).toBe(postsBefore) // no outbound token-request after dispose
+  })
+})

--- a/apps/web/tests/plm-embed-write-token.spec.ts
+++ b/apps/web/tests/plm-embed-write-token.spec.ts
@@ -255,6 +255,20 @@ describe('plmEmbedWriteToken — child protocol layer (discussion write-UI on-de
     await expect(promise).resolves.toBe('finally')
   })
 
+  it('MUST-2 fail-closed: with no Web Crypto CSPRNG, requestWriteToken() rejects and posts NOTHING', async () => {
+    const realCrypto = globalThis.crypto
+    // A runtime with no usable CSPRNG (no randomUUID, no getRandomValues) must NOT degrade to a
+    // predictable nonce -- it must reject before any outbound token-request.
+    Object.defineProperty(globalThis, 'crypto', { value: {}, configurable: true })
+    try {
+      const postsBefore = postSpy.mock.calls.length
+      await expect(client!.requestWriteToken()).rejects.toBeInstanceOf(PlmEmbedWriteTokenError)
+      expect(postSpy.mock.calls.length).toBe(postsBefore)
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', { value: realCrypto, configurable: true })
+    }
+  })
+
   it('dispose() rejects an in-flight request and REMOVES the message listener (non-vacuous)', async () => {
     const removeSpy = vi.spyOn(window, 'removeEventListener')
     const promise = client!.requestWriteToken()

--- a/apps/web/tests/plm-embed-write-token.spec.ts
+++ b/apps/web/tests/plm-embed-write-token.spec.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createPlmEmbedWriteTokenClient,
+  PlmEmbedWriteTokenError,
+  PlmEmbedWriteTokenTimeoutError,
+  type PlmEmbedWriteTokenClient,
+} from '../src/services/integration/plmEmbedWriteToken'
+
+// Child half of the child->parent on-demand embed-token protocol (discussion write-UI).
+// PLM_ORIGIN is the ONE origin this channel is pinned to in each test (mirroring the origin the
+// read handshake already pinned). OTHER_ALLOWED_ORIGIN stands in for a origin that IS present in
+// the server's allowlist elsewhere but is NOT the pinned origin for this mount -- MUST-1 requires
+// it be rejected all the same (pinning, not allowlist membership, is the gate this module enforces).
+const PLM_ORIGIN = 'https://plm.example.com'
+const OTHER_ALLOWED_ORIGIN = 'https://plm-secondary.example.com'
+
+const TOKEN_REQUEST_TYPE = 'plm-embed:token-request'
+const TOKEN_RESPONSE_TYPE = 'plm-embed:token-response'
+const TOKEN_ERROR_TYPE = 'plm-embed:token-error'
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function postFromParent(origin: string, data: unknown, source: MessageEventSource | null = window.parent): void {
+  window.dispatchEvent(new MessageEvent('message', { origin, data, source }))
+}
+
+/** Reads the nonce the channel just posted off the postMessage spy's most recent call. */
+function lastPostedNonce(postSpy: ReturnType<typeof vi.spyOn>): string {
+  const lastCall = postSpy.mock.calls[postSpy.mock.calls.length - 1] as [{ nonce: string }, string]
+  return lastCall[0].nonce
+}
+
+describe('plmEmbedWriteToken — child protocol layer (discussion write-UI on-demand token)', () => {
+  let client: PlmEmbedWriteTokenClient | null = null
+  let parentOrigin: string | null = PLM_ORIGIN
+  let postSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    parentOrigin = PLM_ORIGIN
+    postSpy = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {})
+    client = createPlmEmbedWriteTokenClient(() => parentOrigin)
+  })
+
+  afterEach(() => {
+    client?.dispose()
+    client = null
+    postSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it('MUST-4: posts the token-request to the PINNED parentOrigin, never "*", with the exact contract shape', async () => {
+    // Fire-and-forget: this test only inspects the outbound post, not the eventual settlement.
+    // afterEach's dispose() rejects any request still in flight when the test ends, so attach a
+    // no-op catch to avoid an unhandled-rejection warning bleeding into a later test's output.
+    client!.requestWriteToken().catch(() => {})
+    expect(postSpy).toHaveBeenCalledTimes(1)
+    const [message, targetOrigin] = postSpy.mock.calls[0] as [Record<string, unknown>, string]
+    expect(targetOrigin).toBe(PLM_ORIGIN)
+    expect(targetOrigin).not.toBe('*')
+    expect(message.type).toBe(TOKEN_REQUEST_TYPE)
+    expect(message.purpose).toBe('discussion-write')
+    expect(typeof message.nonce).toBe('string')
+    expect((message.nonce as string).length).toBeGreaterThan(0)
+  })
+
+  it('MUST-1: accepts a token-response from the pinned origin + window.parent source', async () => {
+    const promise = client!.requestWriteToken()
+    const nonce = lastPostedNonce(postSpy)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'fresh-jwt-1' })
+    await expect(promise).resolves.toBe('fresh-jwt-1')
+  })
+
+  it('MUST-1: rejects a response from a DIFFERENT origin, even one that is ALSO allowlisted elsewhere', async () => {
+    const promise = client!.requestWriteToken()
+    const nonce = lastPostedNonce(postSpy)
+    // OTHER_ALLOWED_ORIGIN is not the pinned origin for this mount -- must be dropped even though a
+    // real deployment's server-side allowlist may contain it. Allowlist membership is necessary but
+    // not sufficient; only the pinned origin exact-matches.
+    postFromParent(OTHER_ALLOWED_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'should-not-resolve' })
+    await flush()
+    // The dropped message must not have settled the promise -- prove it by now delivering the
+    // CORRECT response and confirming that one (and only that one) resolves it.
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'correct-token' })
+    await expect(promise).resolves.toBe('correct-token')
+  })
+
+  it('MUST-1: rejects a response whose event.source is not window.parent, even from the pinned origin', async () => {
+    const frame = document.createElement('iframe')
+    document.body.appendChild(frame)
+    try {
+      const promise = client!.requestWriteToken()
+      const nonce = lastPostedNonce(postSpy)
+      // Correct origin, WRONG source (a foreign window masquerading as the pinned origin).
+      postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'should-not-resolve' }, frame.contentWindow)
+      await flush()
+      postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'correct-token' })
+      await expect(promise).resolves.toBe('correct-token')
+    } finally {
+      frame.remove()
+    }
+  })
+
+  it('MUST-2: drops a response whose nonce does not match the single in-flight request', async () => {
+    const promise = client!.requestWriteToken()
+    const nonce = lastPostedNonce(postSpy)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: 'some-other-nonce', token: 'wrong-nonce-token' })
+    await flush()
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'right-nonce-token' })
+    await expect(promise).resolves.toBe('right-nonce-token')
+  })
+
+  it('MUST-2/6: a stale response for a request that already TIMED OUT is dropped by the NEXT request', async () => {
+    vi.useFakeTimers()
+    const firstPromise = client!.requestWriteToken()
+    const staleNonce = lastPostedNonce(postSpy)
+    firstPromise.catch(() => {}) // expected rejection; silence unhandled-rejection noise
+    await vi.advanceTimersByTimeAsync(5000)
+    await expect(firstPromise).rejects.toBeInstanceOf(PlmEmbedWriteTokenTimeoutError)
+
+    // Re-request per MUST-6: a NEW nonce, tracked as the ONLY in-flight request now.
+    const secondPromise = client!.requestWriteToken()
+    const secondNonce = lastPostedNonce(postSpy)
+    expect(secondNonce).not.toBe(staleNonce)
+
+    // A late response using the STALE (first) nonce must be dropped, even though it is otherwise
+    // well-formed and from the pinned origin -- it does not resolve/replay onto the second request.
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: staleNonce, token: 'late-stale-token' })
+    await vi.advanceTimersByTimeAsync(0)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: secondNonce, token: 'second-token' })
+    await expect(secondPromise).resolves.toBe('second-token')
+  })
+
+  it('MUST-5: rejects with a timeout after 5s of silence, clearing the in-flight nonce', async () => {
+    vi.useFakeTimers()
+    const promise = client!.requestWriteToken()
+    // Not yet at the deadline: still pending.
+    await vi.advanceTimersByTimeAsync(4999)
+    let settled = false
+    promise.then(
+      () => (settled = true),
+      () => (settled = true),
+    )
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(2)
+    await expect(promise).rejects.toBeInstanceOf(PlmEmbedWriteTokenTimeoutError)
+  })
+
+  it('MUST-6: a token-error clears the in-flight nonce; retrying issues a brand-new request, never a replay', async () => {
+    const firstPromise = client!.requestWriteToken()
+    const firstNonce = lastPostedNonce(postSpy)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_ERROR_TYPE, nonce: firstNonce, reason: 'rate_limited' })
+    await expect(firstPromise).rejects.toBeInstanceOf(PlmEmbedWriteTokenError)
+
+    const secondPromise = client!.requestWriteToken()
+    const secondNonce = lastPostedNonce(postSpy)
+    expect(secondNonce).not.toBe(firstNonce)
+    expect(postSpy).toHaveBeenCalledTimes(2)
+
+    // The failed first token is never re-sent: a response bearing the OLD nonce cannot resolve the
+    // new request.
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: firstNonce, token: 'must-not-apply' })
+    await flush()
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: secondNonce, token: 'fresh-retry-token' })
+    await expect(secondPromise).resolves.toBe('fresh-retry-token')
+  })
+
+  it('MUST-3: one-token-one-write — each requestWriteToken() call yields its OWN distinct token, never reused', async () => {
+    const firstPromise = client!.requestWriteToken()
+    const firstNonce = lastPostedNonce(postSpy)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: firstNonce, token: 'token-for-write-1' })
+    const firstToken = await firstPromise
+
+    const secondPromise = client!.requestWriteToken()
+    const secondNonce = lastPostedNonce(postSpy)
+    expect(secondNonce).not.toBe(firstNonce)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: secondNonce, token: 'token-for-write-2' })
+    const secondToken = await secondPromise
+
+    expect(firstToken).toBe('token-for-write-1')
+    expect(secondToken).toBe('token-for-write-2')
+    expect(firstToken).not.toBe(secondToken)
+  })
+
+  it('MUST-3: memory-only — the resolved token never touches localStorage/sessionStorage/cookies, and nothing is logged', async () => {
+    const localSetItemSpy = vi.spyOn(window.localStorage, 'setItem')
+    const sessionSetItemSpy =
+      typeof window.sessionStorage?.setItem === 'function' ? vi.spyOn(window.sessionStorage, 'setItem') : null
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const cookieBefore = document.cookie
+    const SECRET_TOKEN = 'super-secret-single-use-jwt-zzz'
+
+    try {
+      const promise = client!.requestWriteToken()
+      const nonce = lastPostedNonce(postSpy)
+      postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: SECRET_TOKEN })
+      const token = await promise
+      expect(token).toBe(SECRET_TOKEN)
+
+      expect(localSetItemSpy).not.toHaveBeenCalled()
+      if (sessionSetItemSpy) expect(sessionSetItemSpy).not.toHaveBeenCalled()
+      expect(document.cookie).toBe(cookieBefore)
+      expect(consoleLogSpy).not.toHaveBeenCalled()
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+      // Literal-scan proof: the token string must not appear anywhere in local/session storage or
+      // the cookie jar, regardless of how it got there.
+      const localDump = JSON.stringify({ ...window.localStorage })
+      expect(localDump).not.toContain(SECRET_TOKEN)
+      expect(document.cookie).not.toContain(SECRET_TOKEN)
+    } finally {
+      localSetItemSpy.mockRestore()
+      sessionSetItemSpy?.mockRestore()
+      consoleLogSpy.mockRestore()
+      consoleWarnSpy.mockRestore()
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
+  it('a second requestWriteToken() while one is already in flight is rejected (fail-fast, exactly one in-flight)', async () => {
+    const firstPromise = client!.requestWriteToken()
+    const firstNonce = lastPostedNonce(postSpy)
+    await expect(client!.requestWriteToken()).rejects.toBeInstanceOf(PlmEmbedWriteTokenError)
+    expect(postSpy).toHaveBeenCalledTimes(1) // the rejected second call never posted anything
+
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce: firstNonce, token: 'still-the-first' })
+    await expect(firstPromise).resolves.toBe('still-the-first')
+  })
+
+  it('ignores malformed/irrelevant messages from the pinned origin without settling the request', async () => {
+    const promise = client!.requestWriteToken()
+    const nonce = lastPostedNonce(postSpy)
+    postFromParent(PLM_ORIGIN, { type: 'something-else', nonce, token: 'ignored' })
+    postFromParent(PLM_ORIGIN, 'not-an-object')
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE }) // no nonce
+    await flush()
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'finally' })
+    await expect(promise).resolves.toBe('finally')
+  })
+
+  it('dispose() rejects an in-flight request and stops listening', async () => {
+    const promise = client!.requestWriteToken()
+    const nonce = lastPostedNonce(postSpy)
+    client!.dispose()
+    await expect(promise).rejects.toBeInstanceOf(PlmEmbedWriteTokenError)
+    // Post-dispose, an inbound message must not throw or resurrect anything (listener removed).
+    expect(() => postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'too-late' })).not.toThrow()
+  })
+})

--- a/apps/web/tests/plm-embed-write-token.spec.ts
+++ b/apps/web/tests/plm-embed-write-token.spec.ts
@@ -102,6 +102,17 @@ describe('plmEmbedWriteToken — child protocol layer (discussion write-UI on-de
     }
   })
 
+  it('MUST-1: rejects a response with a NULL/absent event.source, even from the pinned origin', async () => {
+    // Positive conjunct (taskbook lock 1): source must EQUAL window.parent; a source-less event
+    // is NOT accepted via an origin-only fallback (a token-response is write-authorizing).
+    const promise = client!.requestWriteToken()
+    const nonce = lastPostedNonce(postSpy)
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'should-not-resolve' }, null)
+    await flush()
+    postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'correct-token' })
+    await expect(promise).resolves.toBe('correct-token')
+  })
+
   it('MUST-2: drops a response whose nonce does not match the single in-flight request', async () => {
     const promise = client!.requestWriteToken()
     const nonce = lastPostedNonce(postSpy)
@@ -244,12 +255,23 @@ describe('plmEmbedWriteToken — child protocol layer (discussion write-UI on-de
     await expect(promise).resolves.toBe('finally')
   })
 
-  it('dispose() rejects an in-flight request and stops listening', async () => {
+  it('dispose() rejects an in-flight request and REMOVES the message listener (non-vacuous)', async () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
     const promise = client!.requestWriteToken()
-    const nonce = lastPostedNonce(postSpy)
     client!.dispose()
     await expect(promise).rejects.toBeInstanceOf(PlmEmbedWriteTokenError)
-    // Post-dispose, an inbound message must not throw or resurrect anything (listener removed).
-    expect(() => postFromParent(PLM_ORIGIN, { type: TOKEN_RESPONSE_TYPE, nonce, token: 'too-late' })).not.toThrow()
+    // Prove the listener is actually detached, not just that a stray message doesn't throw: the
+    // exact 'message' handler passed to addEventListener must be handed to removeEventListener.
+    expect(removeSpy).toHaveBeenCalledWith('message', expect.any(Function))
+    removeSpy.mockRestore()
+  })
+
+  it('use-after-dispose: requestWriteToken() after dispose() rejects immediately and posts NOTHING', async () => {
+    // Regression: a deferred submit firing after unmount must not re-post a token-request (which the
+    // parent could mint + burn a single-use jti for) nor hang 5s on a removed listener.
+    client!.dispose()
+    const postsBefore = postSpy.mock.calls.length
+    await expect(client!.requestWriteToken()).rejects.toBeInstanceOf(PlmEmbedWriteTokenError)
+    expect(postSpy.mock.calls.length).toBe(postsBefore) // no outbound token-request after dispose
   })
 })


### PR DESCRIPTION
## Summary

- add the shared postMessage token-client factory for Discussion write and read purposes
- keep write behavior byte-compatible while adding `purpose=discussion-read`
- enforce pinned parent source/origin, nonce correlation, one request per token, memory-only handling, and dispose guards
- fail closed when Web Crypto CSPRNG is unavailable
- register both protocol suites in the PLM embed web guard

## Verification

- all four reviewed commits preserved by final range-diff (`4467a121e..1389a2935` → `88f78174a..f6114dc2a`)
- `60 passed` across BOM review, embed service, write-token, and read-token suites
- `pnpm --filter @metasheet/web run type-check`
- `git diff --check`

Yuantus parent channels and the read relay are already on main. Runtime provider flags remain OFF.