### PR TITLE
test(plm): add Discussion read-auth dual-service E2E

### DIFF
--- a/packages/core-backend/tests/e2e/harness.ts
+++ b/packages/core-backend/tests/e2e/harness.ts
@@ -1,0 +1,202 @@
+/**
+ * PLM-COLLAB Discussion read-auth line — sub-slice 6 (capstone dual-service E2E) harness.
+ *
+ * Boots a REAL temp Yuantus provider (uvicorn subprocess) against a shared temp sqlite file that a
+ * standalone Python seed script has populated, and mints REAL Ed25519 embed tokens via the
+ * production mint service. Everything here is local-only plumbing for the E2E test; the actual
+ * dual-service assertions live in `plm-discussion-read-e2e.test.ts`.
+ *
+ * Local defaults are hard-coded but overridable by env (E2E_YUANTUS_WORKTREE / E2E_YUANTUS_PYTHON).
+ * CI wiring is DEFERRED (build-then-HOLD) — the owner will wire ports/paths for CI once Actions is
+ * restored.
+ */
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+
+export const YUANTUS_WORKTREE = process.env.E2E_YUANTUS_WORKTREE || '/private/tmp/yuantus-readauth'
+export const YUANTUS_PYTHON =
+  process.env.E2E_YUANTUS_PYTHON || '/Users/chouhua/Downloads/Github/Yuantus/.venv-wp13/bin/python'
+export const YUANTUS_SRC = path.join(YUANTUS_WORKTREE, 'src')
+
+export const EMBED_ORIGIN = 'https://plm.example.com'
+export const EMBED_KEY_ID = 'embed-1'
+export const EMBED_AUDIENCE = 'metasheet2.embed'
+export const EMBED_TTL_SECONDS = '600'
+export const SERVED_TENANT = 'default'
+
+const HERE = path.dirname(new URL(import.meta.url).pathname)
+const SEED_SCRIPT = path.join(HERE, 'seed_yuantus.py')
+const MINT_SCRIPT = path.join(HERE, 'mint_embed_token.py')
+
+/** A fresh Ed25519 keypair shared by the provider (signs+verifies) and the relay (verifies). */
+export interface EmbedKeys {
+  /** base64 of the raw 32-byte private seed — the provider's YUANTUS_EMBED_TOKEN_SIGNING_KEY. */
+  privateSeedB64: string
+  /** base64 of the raw 32-byte public key — the relay's YUANTUS_EMBED_PUBLIC_KEY. */
+  publicB64: string
+}
+
+export function generateEmbedKeys(): EmbedKeys {
+  const { privateKey } = crypto.generateKeyPairSync('ed25519')
+  const jwk = privateKey.export({ format: 'jwk' }) as { d: string; x: string }
+  return {
+    privateSeedB64: Buffer.from(jwk.d, 'base64url').toString('base64'),
+    publicB64: Buffer.from(jwk.x, 'base64url').toString('base64'),
+  }
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer()
+    srv.unref()
+    srv.on('error', reject)
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address()
+      if (addr && typeof addr === 'object') {
+        const p = addr.port
+        srv.close(() => resolve(p))
+      } else {
+        srv.close(() => reject(new Error('could not resolve a free port')))
+      }
+    })
+  })
+}
+
+/** The env every Yuantus python process shares (mint helper, seed, uvicorn). */
+function providerEnv(keys: EmbedKeys, extra: Record<string, string> = {}): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    PYTHONPATH: YUANTUS_SRC,
+    PYTHONUNBUFFERED: '1',
+    YUANTUS_EMBED_TOKEN_SIGNING_KEY: keys.privateSeedB64,
+    YUANTUS_EMBED_TOKEN_KEY_ID: EMBED_KEY_ID,
+    YUANTUS_EMBED_TOKEN_AUDIENCE: EMBED_AUDIENCE,
+    YUANTUS_EMBED_TOKEN_TTL_SECONDS: EMBED_TTL_SECONDS,
+    YUANTUS_EMBED_ALLOWED_ORIGINS: EMBED_ORIGIN,
+    EMBED_ORIGIN,
+    ...extra,
+  }
+}
+
+export interface MintSpec {
+  name: string
+  user_id: number
+  tenant_id: string
+  org_id: string | null
+  part_id: string
+}
+
+/** Mint a batch of REAL embed tokens in a single python invocation. */
+export function mintTokens(keys: EmbedKeys, specs: MintSpec[]): Record<string, string> {
+  const res = spawnSync(YUANTUS_PYTHON, [MINT_SCRIPT], {
+    cwd: YUANTUS_WORKTREE,
+    env: providerEnv(keys),
+    input: JSON.stringify(specs),
+    encoding: 'utf8',
+  })
+  if (res.status !== 0) {
+    throw new Error(`mint_embed_token.py failed (status ${res.status}): ${res.stderr}`)
+  }
+  return JSON.parse(res.stdout) as Record<string, string>
+}
+
+/** Seed the shared temp sqlite `dbPath` (must run BEFORE the uvicorn that serves it). */
+export function seed(keys: EmbedKeys, dbPath: string): void {
+  const res = spawnSync(YUANTUS_PYTHON, [SEED_SCRIPT], {
+    cwd: YUANTUS_WORKTREE,
+    env: providerEnv(keys, { YUANTUS_DATABASE_URL: `sqlite:///${dbPath}` }),
+    encoding: 'utf8',
+  })
+  if (res.status !== 0) {
+    throw new Error(`seed_yuantus.py failed (status ${res.status}): ${res.stdout}\n${res.stderr}`)
+  }
+}
+
+export interface Provider {
+  url: string
+  port: number
+  proc: ChildProcess
+  dbPath: string
+  logs: () => string
+}
+
+async function waitForHealth(url: string, proc: ChildProcess, timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  let lastErr = ''
+  while (Date.now() < deadline) {
+    if (proc.exitCode !== null) {
+      throw new Error(`uvicorn exited early (code ${proc.exitCode})`)
+    }
+    try {
+      const res = await fetch(`${url}/api/v1/health`)
+      if (res.status === 200) return
+      lastErr = `health ${res.status}`
+    } catch (e) {
+      lastErr = e instanceof Error ? e.message : String(e)
+    }
+    await new Promise((r) => setTimeout(r, 250))
+  }
+  throw new Error(`temp Yuantus never became healthy at ${url} (last: ${lastErr})`)
+}
+
+/**
+ * Start a REAL uvicorn provider against `dbPath`. `readSessionEnabled` toggles the read dark flag
+ * (a second provider with it OFF backs the dark-flag-401 case). AUTH_MODE stays at its `required`
+ * default so the FULL production middleware chain (pre-auth exchange + read-cred admission on
+ * exactly the 2 read paths) is exercised, not bypassed.
+ */
+export async function startProvider(
+  keys: EmbedKeys,
+  dbPath: string,
+  opts: { readSessionEnabled: boolean },
+): Promise<Provider> {
+  const port = await freePort()
+  const url = `http://127.0.0.1:${port}`
+  const env = providerEnv(keys, {
+    YUANTUS_DATABASE_URL: `sqlite:///${dbPath}`,
+    YUANTUS_TENANCY_MODE: 'single',
+    YUANTUS_DISCUSSION_READ_SESSION_ENABLED: opts.readSessionEnabled ? '1' : '0',
+  })
+  const proc = spawn(
+    YUANTUS_PYTHON,
+    ['-m', 'uvicorn', 'yuantus.api.app:app', '--host', '127.0.0.1', '--port', String(port), '--log-level', 'warning'],
+    { cwd: YUANTUS_WORKTREE, env },
+  )
+  const buf: string[] = []
+  proc.stdout?.on('data', (d) => buf.push(d.toString()))
+  proc.stderr?.on('data', (d) => buf.push(d.toString()))
+  const logs = () => buf.join('')
+  try {
+    await waitForHealth(url, proc)
+  } catch (e) {
+    proc.kill('SIGKILL')
+    throw new Error(`${e instanceof Error ? e.message : e}\n--- uvicorn output ---\n${logs()}`)
+  }
+  return { url, port, proc, dbPath, logs }
+}
+
+export function stopProvider(p: Provider | null): void {
+  if (!p) return
+  try {
+    p.proc.kill('SIGKILL')
+  } catch {
+    /* already gone */
+  }
+}
+
+export function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'plm-read-e2e-'))
+}
+
+export function rmTempDir(dir: string | null): void {
+  if (!dir) return
+  try {
+    fs.rmSync(dir, { recursive: true, force: true })
+  } catch {
+    /* best effort */
+  }
+}

--- a/packages/core-backend/tests/e2e/harness.ts
+++ b/packages/core-backend/tests/e2e/harness.ts
@@ -27,6 +27,18 @@ export const EMBED_KEY_ID = 'embed-1'
 export const EMBED_AUDIENCE = 'metasheet2.embed'
 export const EMBED_TTL_SECONDS = '600'
 export const SERVED_TENANT = 'default'
+export const SERVED_ORG = 'org-1'
+// Must match seed_yuantus.py (the seeded login credential the HTTP mint route is reached through).
+export const SEED_USERNAME = 'u42'
+export const SEED_PASSWORD = 'e2e-pw-42'
+// P2-3 / owner P2: the pre-auth rate-limit posture the flag-on provider runs with. GOVERNANCE —
+// pre-auth must NOT be wider than the global inbound default (120/60), so use a reasonable 30/min +
+// burst 20 (both well under the cap). That is enough headroom for this run's pre-auth hits to the
+// single main provider (login + a handful of read-session exchanges) without throttling, while still
+// proving the limiter genuinely enforces the read-exchange path (the E2E asserts X-RateLimit-Limit
+// === the burst below on an allowed response).
+export const PREAUTH_PER_MINUTE = '30'
+export const PREAUTH_BURST = '20'
 
 const HERE = path.dirname(new URL(import.meta.url).pathname)
 const SEED_SCRIPT = path.join(HERE, 'seed_yuantus.py')
@@ -104,6 +116,63 @@ export function mintTokens(keys: EmbedKeys, specs: MintSpec[]): Record<string, s
   return JSON.parse(res.stdout) as Record<string, string>
 }
 
+/** Log in via the REAL POST /api/v1/auth/login -> a bearer token (P2-1: the HTTP mint route is
+ * reached through a genuine login, not a bypass). */
+export async function httpLogin(url: string): Promise<string> {
+  const res = await fetch(`${url}/api/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      username: SEED_USERNAME,
+      password: SEED_PASSWORD,
+      tenant_id: SERVED_TENANT,
+      org_id: SERVED_ORG,
+    }),
+  })
+  if (res.status !== 200) throw new Error(`login failed ${res.status}: ${await res.text()}`)
+  return ((await res.json()) as { access_token: string }).access_token
+}
+
+/** Mint a REAL embed token through the REAL POST /api/v1/bom/multitable/{partId}/embed-token —
+ * exercising the route's auth + is_entitled + Part-type + permission + origin allowlist + jti
+ * audit. Returns the token and its jti. */
+export async function httpMint(
+  url: string,
+  bearer: string,
+  partId: string,
+): Promise<{ embed_token: string; jti: string }> {
+  const res = await fetch(`${url}/api/v1/bom/multitable/${partId}/embed-token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${bearer}`,
+      'x-tenant-id': SERVED_TENANT,
+      'x-org-id': SERVED_ORG,
+    },
+    body: JSON.stringify({ origin: EMBED_ORIGIN }),
+  })
+  if (res.status !== 200) throw new Error(`mint failed ${res.status}: ${await res.text()}`)
+  const j = (await res.json()) as { embed_token?: string; jti?: string }
+  if (!j.embed_token || !j.jti) throw new Error(`mint returned no token/jti: ${JSON.stringify(j)}`)
+  return { embed_token: j.embed_token, jti: j.jti }
+}
+
+/** Read the issuance AuditLog rows the mint route wrote (method=MINT) directly from the shared temp
+ * sqlite — stdlib sqlite3 only (no heavy yuantus import). Lets the E2E prove the jti is tracked but
+ * the raw JWT is never persisted. */
+export function queryMintAudit(dbPath: string): Array<Record<string, unknown>> {
+  const py = [
+    'import sqlite3, json, sys',
+    'con = sqlite3.connect(sys.argv[1])',
+    'con.row_factory = sqlite3.Row',
+    "rows = con.execute(\"SELECT * FROM audit_logs WHERE method='MINT'\").fetchall()",
+    'print(json.dumps([dict(r) for r in rows]))',
+  ].join('\n')
+  const res = spawnSync(YUANTUS_PYTHON, ['-c', py, dbPath], { encoding: 'utf8' })
+  if (res.status !== 0) throw new Error(`queryMintAudit failed (status ${res.status}): ${res.stderr}`)
+  return JSON.parse(res.stdout) as Array<Record<string, unknown>>
+}
+
 /** Seed the shared temp sqlite `dbPath` (must run BEFORE the uvicorn that serves it). */
 export function seed(keys: EmbedKeys, dbPath: string): void {
   const res = spawnSync(YUANTUS_PYTHON, [SEED_SCRIPT], {
@@ -160,6 +229,16 @@ export async function startProvider(
     YUANTUS_DATABASE_URL: `sqlite:///${dbPath}`,
     YUANTUS_TENANCY_MODE: 'single',
     YUANTUS_DISCUSSION_READ_SESSION_ENABLED: opts.readSessionEnabled ? '1' : '0',
+    // P2-3: the APPROVED flag-on posture runs the pre-auth rate limiter (the read exchange is in
+    // PREAUTH_RATE_LIMIT_PATHS by design). Enabled with high limits so the full happy path is not
+    // throttled; the default 30/min + burst 10 would 429 this test's many exchange hits.
+    ...(opts.readSessionEnabled
+      ? {
+          YUANTUS_PREAUTH_RATE_LIMIT_ENABLED: 'true',
+          YUANTUS_PREAUTH_RATE_LIMIT_PER_MINUTE: PREAUTH_PER_MINUTE,
+          YUANTUS_PREAUTH_RATE_LIMIT_BURST: PREAUTH_BURST,
+        }
+      : {}),
   })
   const proc = spawn(
     YUANTUS_PYTHON,

--- a/packages/core-backend/tests/e2e/mint_embed_token.py
+++ b/packages/core-backend/tests/e2e/mint_embed_token.py
@@ -1,0 +1,61 @@
+"""PLM-COLLAB Discussion read-auth line — sub-slice 6 (capstone dual-service E2E).
+
+Mint helper: emit REAL Ed25519 embed tokens via the PRODUCTION `mint_embed_token` service — the
+exact signing path the provider's own end-to-end test uses (`_mint_real_embed_token` in
+`test_discussion_router.py`). The provider independently verifies the Ed25519 signature at the read
+exchange, so a token minted here is as real as one minted through the HTTP endpoint.
+
+WHY the service and not the `POST /api/v1/bom/multitable/{part_id}/embed-token` HTTP endpoint:
+the HTTP mint binds `tenant_id`/`part_id` to the AUTHENTICATED request context
+(`resolve_license_scope()` -> the caller's tenant; the part must exist and be entitled), so it
+CANNOT mint the adversarial tokens this E2E requires — a cross-TENANT token (tenant != the served
+tenant) or a token bound to an arbitrary part. It also needs a full login + entitlement +
+permission bootstrap. The signing key here is the SAME one the temp provider verifies with, so the
+mint hop stays real; only the issuance vehicle differs. Stated plainly in the E2E reality table.
+
+Reads a JSON array of specs from stdin:
+  [{ "name": str, "user_id": int, "tenant_id": str, "org_id": str|null, "part_id": str }, ...]
+and writes `{ name: token }` JSON to stdout. Signing material comes from the SAME env the provider
+uses (YUANTUS_EMBED_TOKEN_SIGNING_KEY / _KEY_ID / _AUDIENCE / _TTL_SECONDS) plus EMBED_ORIGIN.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def main() -> int:
+    signing_key = os.environ.get("YUANTUS_EMBED_TOKEN_SIGNING_KEY")
+    key_id = os.environ.get("YUANTUS_EMBED_TOKEN_KEY_ID", "embed-1")
+    audience = os.environ.get("YUANTUS_EMBED_TOKEN_AUDIENCE", "metasheet2.embed")
+    ttl_seconds = int(os.environ.get("YUANTUS_EMBED_TOKEN_TTL_SECONDS", "600"))
+    origin = os.environ.get("EMBED_ORIGIN", "https://plm.example.com")
+    if not signing_key:
+        print("mint_embed_token: YUANTUS_EMBED_TOKEN_SIGNING_KEY must be set", file=sys.stderr)
+        return 2
+
+    from yuantus.meta_engine.services.bom_multitable_embed_token_service import mint_embed_token
+
+    specs = json.load(sys.stdin)
+    out = {}
+    for spec in specs:
+        minted = mint_embed_token(
+            user_id=spec["user_id"],
+            tenant_id=spec["tenant_id"],
+            org_id=spec.get("org_id"),
+            part_id=spec["part_id"],
+            origin=origin,
+            audience=audience,
+            signing_key_b64=signing_key,
+            key_id=key_id,
+            ttl_seconds=ttl_seconds,
+        )
+        out[spec["name"]] = minted["token"]
+
+    json.dump(out, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/core-backend/tests/e2e/plm-discussion-read-e2e.test.ts
+++ b/packages/core-backend/tests/e2e/plm-discussion-read-e2e.test.ts
@@ -18,17 +18,20 @@
  *
  * Gated behind RUN_PLM_READ_E2E; CI wiring DEFERRED (owner wires it as the final merge gate).
  */
-import crypto from 'node:crypto'
 import express from 'express'
 import request from 'supertest'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import {
   EMBED_AUDIENCE,
   EMBED_KEY_ID,
+  PREAUTH_BURST,
   SERVED_TENANT,
   generateEmbedKeys,
+  httpLogin,
+  httpMint,
   makeTempDir,
   mintTokens,
+  queryMintAudit,
   rmTempDir,
   seed,
   startProvider,
@@ -68,6 +71,14 @@ vi.mock('../../src/routes/data-sources', () => ({
 
 import plmEmbedDiscussionReadRouter from '../../src/routes/plm-embed-discussion-read'
 import { PLMAdapter } from '../../src/data-adapters/PLMAdapter'
+// The REAL scoped-jti key fn (NOT mocked — only db/redis is). Used to prove the relay did not
+// consume the cross-tenant token's jti.
+import { embedJtiKey } from '../../src/auth/embed-jti-store'
+
+/** Decode an embed JWT's claims (unverified — only to derive the scoped jti key for assertions). */
+function decodeClaims(jwt: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(jwt.split('.')[1], 'base64url').toString('utf8'))
+}
 
 const DS_ID = 'plm-ds'
 const USER = 42
@@ -82,6 +93,7 @@ let tmpDir: string
 let main: Provider | null = null
 let dark: Provider | null = null
 let tokens: Record<string, string>
+let mintJti: Record<string, string> // jti of each HTTP-minted token (for the audit-log assertion)
 let app: express.Express
 let mainAdapter: PLMAdapter
 let darkAdapter: PLMAdapter
@@ -154,21 +166,26 @@ async function boot(): Promise<void> {
   dsState.adapter = mainAdapter
   app = buildApp()
 
-  // One batch of REAL embed tokens (unique jti each). tenant 'default'/part item-1 unless noted.
-  const T = SERVED_TENANT
-  tokens = mintTokens(keys, [
-    { name: 'list', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
-    { name: 'detail', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
-    { name: 'smoke', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
-    { name: 'replay', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
-    { name: 'provConsume', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
-    { name: 'provCtrl', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
-    { name: 'missingDetail', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
-    { name: 'crossPartDetail', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
-    { name: 'dark', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
-    // Bound to a DIFFERENT tenant than the adapter serves -> relay pre-rejects.
-    { name: 'crossTenant', user_id: USER, tenant_id: 'tenant-a', org_id: 'org-1', part_id: PART },
-  ])
+  // Tokens the REAL HTTP mint route CAN issue (tenant 'default'/part item-1) are obtained through
+  // it: one genuine login, then the real POST .../embed-token per token. This exercises the mint
+  // route's auth/entitlement/permission/part-binding/audit — no direct mint-service bypass here.
+  const bearer = await httpLogin(main.url)
+  tokens = {}
+  mintJti = {}
+  for (const name of ['list', 'detail', 'smoke', 'replay', 'provConsume', 'provCtrl', 'missingDetail', 'crossPartDetail', 'dark']) {
+    const m = await httpMint(main.url, bearer, PART)
+    tokens[name] = m.embed_token
+    mintJti[name] = m.jti
+  }
+  // ONLY the cross-tenant token uses the direct mint service: the HTTP route binds tenant_id to the
+  // authenticated request context (always the served tenant), so it CANNOT issue a token bound to a
+  // different tenant by design. The provider still verifies its real Ed25519 signature.
+  Object.assign(
+    tokens,
+    mintTokens(keys, [
+      { name: 'crossTenant', user_id: USER, tenant_id: 'tenant-a', org_id: 'org-1', part_id: PART },
+    ]),
+  )
 }
 
 describe.skipIf(!RUN)('PLM discussion read-auth — dual-service E2E (sub-slice 6, build-then-HOLD)', () => {
@@ -216,6 +233,21 @@ describe.skipIf(!RUN)('PLM discussion read-auth — dual-service E2E (sub-slice 
       const res = await request(app).get(THREAD_URL('T-open-1')).set('X-PLM-Embed-Token', tokens.detail)
       expect(res.status).toBe(200)
       expect(res.body.data.id).toBe('T-open-1')
+    })
+
+    it('the HTTP mint route audited each issuance by jti WITHOUT persisting the raw JWT (P2-1)', () => {
+      const rows = queryMintAudit(main!.dbPath)
+      expect(rows.length).toBeGreaterThanOrEqual(9) // one MINT row per HTTP-minted token
+      const paths = rows.map((r) => String(r.path))
+      // the happy-path 'list' token's jti is tracked in an issuance audit row...
+      expect(paths.some((p) => p.includes(mintJti.list))).toBe(true)
+      // ...but the raw embed JWT is NEVER written to any audit column (no token plaintext at rest).
+      const dump = JSON.stringify(rows)
+      for (const name of ['list', 'detail']) {
+        expect(dump).not.toContain(tokens[name])
+      }
+      // every MINT row is jti-shaped (…?jti=<uuid>), never a token blob.
+      for (const p of paths) expect(p).toMatch(/\/embed-token\?jti=[0-9a-f-]{36}$/)
     })
   })
 
@@ -278,6 +310,22 @@ describe.skipIf(!RUN)('PLM discussion read-auth — dual-service E2E (sub-slice 
     })
   })
 
+  describe('approved flag-on posture: pre-auth rate limiter enforcing on the read exchange (P2-3)', () => {
+    it('the read-exchange path returns X-RateLimit headers set to the configured burst (limiter genuinely ON, not a silent no-op)', async () => {
+      // A bad token still traverses the pre-auth limiter before the endpoint 401s — the limiter
+      // stamps X-RateLimit-Limit on the (allowed) response, proving PREAUTH_RATE_LIMIT is enabled
+      // AND matches the read-exchange path with THIS config (no token consumed, no throttle).
+      const probe = await fetch(`${main!.url}/api/v1/auth/embed/discussion-read-session`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ embed_token: 'not-a-valid-embed-token' }),
+      })
+      expect(probe.status).toBe(401) // invalid token, past the limiter
+      expect(probe.headers.get('x-ratelimit-limit')).toBe(PREAUTH_BURST)
+      expect(probe.headers.get('x-ratelimit-remaining')).not.toBeNull()
+    })
+  })
+
   describe('dark-flag 401 (provider read exchange disabled on a separate temp Yuantus)', () => {
     it('relay pointed at the dark provider (DISCUSSION_READ_SESSION_ENABLED off) -> uniform 401 EMBED_SESSION_EXCHANGE_FAILED', async () => {
       dsState.adapter = darkAdapter
@@ -289,14 +337,30 @@ describe.skipIf(!RUN)('PLM discussion read-auth — dual-service E2E (sub-slice 
   })
 
   describe('cross-tenant pre-rejection (relay guard, before the exchange)', () => {
-    it('an embed token bound to tenant-a used against a provider serving tenant default -> 403 EMBED_TENANT_MISMATCH, and the jti is untouched (the token still exchanges directly)', async () => {
+    it('an embed token bound to tenant-a -> 403 EMBED_TENANT_MISMATCH; the RELAY Redis jti is NOT consumed (rejected before the consume) (P2-2)', async () => {
       dsState.adapter = mainAdapter
+      const c = decodeClaims(tokens.crossTenant)
+      const scopedKey = embedJtiKey({
+        aud: String(c.aud ?? ''),
+        feature_key: String(c.feature_key ?? ''),
+        tenant_id: String(c.tenant_id ?? ''),
+        part_id: String(c.part_id ?? ''),
+        jti: String(c.jti ?? ''),
+      })
+      const sizeBefore = redisSub.store.size
+      expect(redisSub.store.has(scopedKey)).toBe(false) // not present going in
+
       const res = await request(app).get(THREADS_URL).set('X-PLM-Embed-Token', tokens.crossTenant)
       expect(res.status).toBe(403)
       expect(res.body.error.code).toBe('EMBED_TENANT_MISMATCH')
-      // Pre-rejection evidence: the relay rejected BEFORE consuming the jti / calling the exchange,
-      // so the SAME token can still be exchanged directly at the provider (its provider-side jti was
-      // never burned). Proves the tenant check fires ahead of the single-use consume + exchange.
+
+      // P2-2 core: the relay tenant cross-check fires BEFORE the single-use consume, so the relay's
+      // Redis store gained NO entry for this token (distinct from the provider's AuthEmbedExchangeJti,
+      // which is a SEPARATE store — this asserts the RELAY layer specifically).
+      expect(redisSub.store.has(scopedKey)).toBe(false)
+      expect(redisSub.store.size).toBe(sizeBefore)
+
+      // Corroborating: the provider-side jti is untouched too (the token still exchanges directly).
       const stillExchangeable = await fetch(`${main!.url}/api/v1/auth/embed/discussion-read-session`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -306,5 +370,3 @@ describe.skipIf(!RUN)('PLM discussion read-auth — dual-service E2E (sub-slice 
     })
   })
 })
-
-void crypto

--- a/packages/core-backend/tests/e2e/plm-discussion-read-e2e.test.ts
+++ b/packages/core-backend/tests/e2e/plm-discussion-read-e2e.test.ts
@@ -1,0 +1,310 @@
+/**
+ * PLM-COLLAB Discussion read-auth line — sub-slice 6: LOCAL DUAL-SERVICE E2E (build-then-HOLD).
+ *
+ * Traverses the FULL chain with NO mocked middle in the security path:
+ *   mint (real Ed25519) -> supertest -> REAL ms2 read relay (embedTokenAuth + runEmbedReadGuards +
+ *   REAL consumeEmbedJti/embedJtiKey) -> REAL PLMAdapter over REAL HTTP -> REAL temp Yuantus
+ *   provider (read-session exchange + the two /discussions read-gate routes).
+ *
+ * What is REAL vs substituted (honest — see the reality table in the task report):
+ *   - REAL: the mint signature; the relay app + embedTokenAuth + guards; the jti single-use LOGIC
+ *     (consumeEmbedJti/embedJtiKey run unmodified); the PLMAdapter; the Node->Yuantus HTTP hop; the
+ *     Yuantus read exchange + read gate; the provider's AuthEmbedExchangeJti single-use.
+ *   - SUBSTITUTED (labeled): the Redis BACKEND behind getRedisClient is an in-process NX-semantics
+ *     Map (no redis binary / ioredis-mock in this env) — NOT "real Redis"; the DataSourceManager
+ *     REGISTRY lookup returns the real adapter directly; the driver->relay transport is supertest
+ *     (which still runs the real relay middleware in-process). The global session-JWT gate is
+ *     inlined (a stand-in, per the unit test) so no infra module graph is pulled in.
+ *
+ * Gated behind RUN_PLM_READ_E2E; CI wiring DEFERRED (owner wires it as the final merge gate).
+ */
+import crypto from 'node:crypto'
+import express from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import {
+  EMBED_AUDIENCE,
+  EMBED_KEY_ID,
+  SERVED_TENANT,
+  generateEmbedKeys,
+  makeTempDir,
+  mintTokens,
+  rmTempDir,
+  seed,
+  startProvider,
+  stopProvider,
+  type EmbedKeys,
+  type Provider,
+} from './harness'
+
+// ---- in-process Redis BACKEND substitute (NX single-use semantics; NOT real Redis) -------------
+// The REAL consumeEmbedJti/embedJtiKey run on top of this — only the storage backend is in-memory,
+// because this env has no redis binary and no ioredis-mock. The NX branch is what makes a replay
+// return null (a regression that dropped NX would flip the replay assertions), so single-use is
+// genuinely exercised, not asserted against a stub.
+const redisSub = vi.hoisted(() => {
+  const store = new Map<string, string>()
+  const client = {
+    set: async (key: string, val: string, _ex: string, _ttl: number, nx?: string) => {
+      if (nx === 'NX' && store.has(key)) return null
+      store.set(key, val)
+      return 'OK'
+    },
+  }
+  return { client, store }
+})
+vi.mock('../../src/db/redis', () => ({
+  getRedisClient: async () => redisSub.client,
+  closeRedisClient: async () => {},
+}))
+
+// ---- DataSourceManager registry lookup -> the REAL PLMAdapter (mutable so we can point the relay
+// at the main provider or the dark-flag provider per case). The ADAPTER is real; only the registry
+// indirection is stubbed. -----------------------------------------------------------------------
+const dsState = vi.hoisted(() => ({ adapter: null as unknown }))
+vi.mock('../../src/routes/data-sources', () => ({
+  getDataSourceManager: () => ({ getDataSource: () => dsState.adapter }),
+}))
+
+import plmEmbedDiscussionReadRouter from '../../src/routes/plm-embed-discussion-read'
+import { PLMAdapter } from '../../src/data-adapters/PLMAdapter'
+
+const DS_ID = 'plm-ds'
+const USER = 42
+const PART = 'item-1'
+const THREADS_URL = '/api/plm-embed/discussion/threads'
+const THREAD_URL = (id: string) => `/api/plm-embed/discussion/threads/${id}`
+
+const RUN = !!process.env.RUN_PLM_READ_E2E
+
+let keys: EmbedKeys
+let tmpDir: string
+let main: Provider | null = null
+let dark: Provider | null = null
+let tokens: Record<string, string>
+let app: express.Express
+let mainAdapter: PLMAdapter
+let darkAdapter: PLMAdapter
+
+/** Build the REAL read relay app. The pre-router gate is an inlined stand-in for the global
+ * session-JWT gate (identical intent to the unit test's buildApp): embed routes pass through, any
+ * other /api/* would 401. */
+function buildApp(): express.Express {
+  const a = express()
+  a.use(express.json())
+  a.use((req, res, next) => {
+    if (req.path.startsWith('/api/plm-embed/')) return next()
+    if (req.path.startsWith('/api/')) return res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED' } })
+    return next()
+  })
+  a.use(plmEmbedDiscussionReadRouter())
+  return a
+}
+
+/** A real PLMAdapter bound to `url`, apiMode 'yuantus', serving tenant 'default' (so the relay's
+ * tenant cross-check matches a token minted for 'default'). No username/password -> no service
+ * login; the discussion read methods authenticate with the exchanged read credential, not a
+ * service token. */
+async function makeAdapter(url: string): Promise<PLMAdapter> {
+  const cfgMap: Record<string, unknown> = {
+    'plm.url': url,
+    'plm.apiMode': 'yuantus',
+    'plm.tenantId': SERVED_TENANT,
+    'plm.mock': false,
+  }
+  const configService = { get: async (k: string) => cfgMap[k] }
+  const logger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
+  const adapter = new PLMAdapter(configService as never, logger as never, {
+    id: DS_ID,
+    name: 'temp PLM',
+    type: 'plm',
+    connection: { url },
+    options: { apiMode: 'yuantus', tenantId: SERVED_TENANT },
+  } as never)
+  await adapter.connect()
+  return adapter
+}
+
+async function boot(): Promise<void> {
+  keys = generateEmbedKeys()
+  tmpDir = makeTempDir()
+  seed(keys, `${tmpDir}/main.db`)
+  // allSettled (not Promise.all): if one provider fails health, the sibling that DID start is still
+  // assigned to a module var so afterAll tears it down — Promise.all destructuring would leak it.
+  const [mRes, dRes] = await Promise.allSettled([
+    startProvider(keys, `${tmpDir}/main.db`, { readSessionEnabled: true }),
+    startProvider(keys, `${tmpDir}/dark.db`, { readSessionEnabled: false }),
+  ])
+  if (mRes.status === 'fulfilled') main = mRes.value
+  if (dRes.status === 'fulfilled') dark = dRes.value
+  if (mRes.status === 'rejected') throw mRes.reason
+  if (dRes.status === 'rejected') throw dRes.reason
+
+  // The relay verifies embed tokens OFFLINE with the provider's PUBLIC key.
+  process.env.YUANTUS_EMBED_PUBLIC_KEY = keys.publicB64
+  process.env.YUANTUS_EMBED_KEY_ID = EMBED_KEY_ID
+  process.env.PLM_EMBED_AUDIENCE = EMBED_AUDIENCE
+  process.env.PLM_EMBED_ALLOWED_ORIGINS = 'https://plm.example.com'
+  process.env.PLM_EMBED_DATA_SOURCE_ID = DS_ID
+
+  mainAdapter = await makeAdapter(main.url)
+  darkAdapter = await makeAdapter(dark.url)
+  expect(mainAdapter.isConnected()).toBe(true)
+  expect(mainAdapter.getEffectiveTenantId()).toBe(SERVED_TENANT)
+  dsState.adapter = mainAdapter
+  app = buildApp()
+
+  // One batch of REAL embed tokens (unique jti each). tenant 'default'/part item-1 unless noted.
+  const T = SERVED_TENANT
+  tokens = mintTokens(keys, [
+    { name: 'list', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
+    { name: 'detail', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
+    { name: 'smoke', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
+    { name: 'replay', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
+    { name: 'provConsume', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
+    { name: 'provCtrl', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
+    { name: 'missingDetail', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
+    { name: 'crossPartDetail', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
+    { name: 'dark', user_id: USER, tenant_id: T, org_id: 'org-1', part_id: PART },
+    // Bound to a DIFFERENT tenant than the adapter serves -> relay pre-rejects.
+    { name: 'crossTenant', user_id: USER, tenant_id: 'tenant-a', org_id: 'org-1', part_id: PART },
+  ])
+}
+
+describe.skipIf(!RUN)('PLM discussion read-auth — dual-service E2E (sub-slice 6, build-then-HOLD)', () => {
+  beforeAll(boot)
+  afterAll(() => {
+    stopProvider(main)
+    stopProvider(dark)
+    rmTempDir(tmpDir)
+  })
+
+  describe('provider HTTP smoke (no relay) — mint sig + read exchange + read gate are real', () => {
+    it('mint -> exchange -> list returns the seeded open + resolved threads', async () => {
+      const exchange = await fetch(`${main!.url}/api/v1/auth/embed/discussion-read-session`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ embed_token: tokens.smoke }),
+      })
+      expect(exchange.status).toBe(200)
+      const cred = (await exchange.json()) as { access_token: string; aud: string }
+      expect(cred.aud).toBe('discussion')
+      const list = await fetch(
+        `${main!.url}/api/v1/discussions?target_type=item&target_id=${PART}&include_resolved=true`,
+        { headers: { Authorization: `Bearer ${cred.access_token}` } },
+      )
+      expect(list.status).toBe(200)
+      const ids = ((await list.json()) as { threads: Array<{ id: string }> }).threads.map((t) => t.id)
+      expect(ids).toEqual(expect.arrayContaining(['T-open-1', 'T-resolved-1']))
+    })
+  })
+
+  describe('happy path through the REAL relay', () => {
+    it('GET threads: relay -> exchange -> read gate returns the seeded threads (incl. resolved), no cred leak', async () => {
+      dsState.adapter = mainAdapter
+      const res = await request(app).get(THREADS_URL).set('X-PLM-Embed-Token', tokens.list)
+      expect(res.status).toBe(200)
+      const ids = (res.body.data.threads as Array<{ id: string }>).map((t) => t.id)
+      expect(ids).toEqual(expect.arrayContaining(['T-open-1', 'T-resolved-1']))
+      // no read credential / access_token ever leaks to the client
+      const serialized = JSON.stringify(res.body) + JSON.stringify(res.headers)
+      expect(serialized).not.toContain('access_token')
+    })
+
+    it('GET threads/:id: relay returns the bound-part thread detail', async () => {
+      dsState.adapter = mainAdapter
+      const res = await request(app).get(THREAD_URL('T-open-1')).set('X-PLM-Embed-Token', tokens.detail)
+      expect(res.status).toBe(200)
+      expect(res.body.data.id).toBe('T-open-1')
+    })
+  })
+
+  // =============================================================================================
+  // Owner acceptance coverage — all REAL except the honestly-labeled Redis backend substitute.
+  // =============================================================================================
+
+  describe('single-use — TWO independent jti stores, asserted separately', () => {
+    it('(a) RELAY layer: replaying the SAME embed token on a 2nd relay call -> 401 (relay Redis substitute burned the jti before the exchange)', async () => {
+      dsState.adapter = mainAdapter
+      const first = await request(app).get(THREADS_URL).set('X-PLM-Embed-Token', tokens.replay)
+      expect(first.status).toBe(200) // first use: real consumeEmbedJti stored it
+      const second = await request(app).get(THREADS_URL).set('X-PLM-Embed-Token', tokens.replay)
+      expect(second.status).toBe(401)
+      expect(second.body.error.code).toBe('EMBED_TOKEN_REPLAYED')
+    })
+
+    it('(b) YUANTUS layer: after a real relay FLOW, a DIRECT 2nd call to the provider read exchange with the SAME embed token -> 401 (AuthEmbedExchangeJti already consumed during the flow)', async () => {
+      dsState.adapter = mainAdapter
+      // Control first: a FRESH token exchanges directly -> 200, proving the exchange path works and
+      // the read flag is on (so the 401 below is specifically the provider-side single-use, not a
+      // blanket failure).
+      const control = await fetch(`${main!.url}/api/v1/auth/embed/discussion-read-session`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ embed_token: tokens.provCtrl }),
+      })
+      expect(control.status).toBe(200)
+
+      // The relay flow really runs the exchange (a 200 with threads REQUIRES the exchange to have
+      // minted the read credential), so provConsume's jti is now burned in the provider's store.
+      const flow = await request(app).get(THREADS_URL).set('X-PLM-Embed-Token', tokens.provConsume)
+      expect(flow.status).toBe(200)
+      const direct = await fetch(`${main!.url}/api/v1/auth/embed/discussion-read-session`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ embed_token: tokens.provConsume }),
+      })
+      expect(direct.status).toBe(401) // provider AuthEmbedExchangeJti collision -> uniform 401
+    })
+  })
+
+  describe('error mapping + no-existence-oracle', () => {
+    it('provider 404 (nonexistent thread) and a cross-Part thread both surface as the relay uniform 404 with a BYTE-IDENTICAL body, no raw provider detail leaked', async () => {
+      dsState.adapter = mainAdapter
+      const missing = await request(app).get(THREAD_URL('does-not-exist')).set('X-PLM-Embed-Token', tokens.missingDetail)
+      // T-otherpart-1 is a real thread bound to item-ro; this token is bound to item-1 -> provider 404.
+      const crossPart = await request(app).get(THREAD_URL('T-otherpart-1')).set('X-PLM-Embed-Token', tokens.crossPartDetail)
+
+      expect(missing.status).toBe(404)
+      expect(crossPart.status).toBe(404)
+      // no-existence-oracle: same status AND byte-identical body (a cross-part hit is indistinguishable
+      // from a plain miss at the relay boundary).
+      expect(JSON.stringify(crossPart.body)).toBe(JSON.stringify(missing.body))
+      // the relay never echoes the provider's own wording
+      const body = JSON.stringify(missing.body)
+      expect(body).not.toContain('discussion target not found')
+      expect(body).not.toContain('discussion thread not found')
+      expect(missing.body.ok).toBe(false)
+    })
+  })
+
+  describe('dark-flag 401 (provider read exchange disabled on a separate temp Yuantus)', () => {
+    it('relay pointed at the dark provider (DISCUSSION_READ_SESSION_ENABLED off) -> uniform 401 EMBED_SESSION_EXCHANGE_FAILED', async () => {
+      dsState.adapter = darkAdapter
+      const res = await request(app).get(THREADS_URL).set('X-PLM-Embed-Token', tokens.dark)
+      dsState.adapter = mainAdapter
+      expect(res.status).toBe(401)
+      expect(res.body.error.code).toBe('EMBED_SESSION_EXCHANGE_FAILED')
+    })
+  })
+
+  describe('cross-tenant pre-rejection (relay guard, before the exchange)', () => {
+    it('an embed token bound to tenant-a used against a provider serving tenant default -> 403 EMBED_TENANT_MISMATCH, and the jti is untouched (the token still exchanges directly)', async () => {
+      dsState.adapter = mainAdapter
+      const res = await request(app).get(THREADS_URL).set('X-PLM-Embed-Token', tokens.crossTenant)
+      expect(res.status).toBe(403)
+      expect(res.body.error.code).toBe('EMBED_TENANT_MISMATCH')
+      // Pre-rejection evidence: the relay rejected BEFORE consuming the jti / calling the exchange,
+      // so the SAME token can still be exchanged directly at the provider (its provider-side jti was
+      // never burned). Proves the tenant check fires ahead of the single-use consume + exchange.
+      const stillExchangeable = await fetch(`${main!.url}/api/v1/auth/embed/discussion-read-session`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ embed_token: tokens.crossTenant }),
+      })
+      expect(stillExchangeable.status).toBe(200)
+    })
+  })
+})
+
+void crypto

--- a/packages/core-backend/tests/e2e/seed_yuantus.py
+++ b/packages/core-backend/tests/e2e/seed_yuantus.py
@@ -1,0 +1,202 @@
+"""PLM-COLLAB Discussion read-auth line — sub-slice 6 (capstone dual-service E2E).
+
+Standalone seed script for the TEMP Yuantus provider used by the local dual-service E2E
+(`plm-discussion-read-e2e.test.ts`). Run with the Yuantus venv python and PYTHONPATH pointed at
+the yuantus-readauth worktree src (the Node harness sets both). It boots the SAME DB the uvicorn
+provider process will serve (a shared temp sqlite file via `YUANTUS_DATABASE_URL`), so seeding
+here is visible to the live API. Because `IDENTITY_DATABASE_URL` defaults to `DATABASE_URL`, the
+single sqlite file backs BOTH the main and the identity schema — one create_all covers every
+table (all models hang off the shared `Base`/`WorkflowBase`).
+
+Mirrors the provider's own read-gate tests' seeding (`test_discussion_router.py`):
+`_seed_membership` (Tenant/Organization/OrgMembership + AuthUser/RBACUser), a readable Part item
+(item/`item-1`), the `metasheet_review` read entitlement (`plm.metasheet_review`), and discussion
+threads on the bound part — one OPEN + one RESOLVED (to exercise include_resolved) — plus an
+off-part thread and a foreign-tenant thread for the negative cases.
+
+CI wiring is DEFERRED (build-then-HOLD): the harness hard-codes local worktree/venv paths via env
+with sensible defaults; the owner will wire this to CI as the final merge gate.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime
+
+
+def main() -> int:
+    db_url = os.environ.get("YUANTUS_DATABASE_URL")
+    if not db_url:
+        print("seed_yuantus: YUANTUS_DATABASE_URL must be set", file=sys.stderr)
+        return 2
+
+    # Register every ORM model so create_all builds the full schema and FK targets resolve.
+    from sqlalchemy import create_engine
+    from yuantus.meta_engine.bootstrap import import_all_models
+    from yuantus.models.base import Base, WorkflowBase
+
+    import_all_models()
+    # Core `users` table is an FK target (e.g. meta_effectivities.created_by_id) that
+    # import_all_models does not pull in — init_db imports it explicitly, so we must too.
+    import yuantus.models.user as _user  # noqa: F401
+    # Identity models live under the same Base but are imported by init_identity_db, not by
+    # import_all_models — pull them in explicitly so their tables are created in the shared file.
+    import yuantus.security.auth.models as _auth_models  # noqa: F401
+    import yuantus.security.auth.sso_models as _sso_models  # noqa: F401
+
+    from sqlalchemy.orm import sessionmaker
+
+    from yuantus.security.auth.models import (
+        AuthUser,
+        OrgMembership,
+        Organization,
+        Tenant,
+    )
+    from yuantus.security.rbac.models import RBACUser
+    from yuantus.meta_engine.models.meta_schema import ItemType
+    from yuantus.meta_engine.models.item import Item
+    from yuantus.meta_engine.app_framework.store_models import AppLicense
+    from yuantus.meta_engine.discussion.models import (
+        DiscussionThread,
+        THREAD_STATUS_OPEN,
+        THREAD_STATUS_RESOLVED,
+    )
+
+    TENANT = "default"
+    ORG = "org-1"
+    USER_ID = 42
+    PART = "item-1"
+    PART_OTHER = "item-ro"
+
+    # Plain engine with FK enforcement OFF — mirrors the provider's own read-gate test fixture
+    # (`test_discussion_router.py::db`), whose seeding order these rows follow. The live uvicorn uses
+    # its own FK-enforcing engine for its runtime writes; the seed just needs the rows present.
+    url = db_url[len("sqlite:///"):] if db_url.startswith("sqlite:///") else db_url
+    engine = create_engine(
+        f"sqlite:///{url}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(bind=engine, checkfirst=True)
+    WorkflowBase.metadata.create_all(bind=engine, checkfirst=True)
+
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    s = Session()
+    try:
+        # Identity: the REAL get_current_user path needs an AuthUser + an active OrgMembership
+        # (AuthService.get_roles_for_user_org), not just an RBACUser.
+        s.merge(AuthUser(id=USER_ID, tenant_id=TENANT, username="u42", email="u42@x.io"))
+        s.merge(RBACUser(id=USER_ID, user_id=USER_ID, username="u42", is_active=True))
+        s.merge(Tenant(id=TENANT))
+        s.merge(Organization(id=ORG, tenant_id=TENANT))
+        s.merge(
+            OrgMembership(
+                tenant_id=TENANT, org_id=ORG, user_id=USER_ID, roles=[], is_active=True
+            )
+        )
+
+        # A readable Part item (the bound part) + a second Part used only as an off-part target.
+        s.merge(ItemType(id="Part", label="Part", is_versionable=True))
+        s.merge(
+            Item(
+                id=PART,
+                item_type_id="Part",
+                config_id=PART,
+                generation=1,
+                is_current=True,
+                state="active",
+                created_by_id=USER_ID,
+            )
+        )
+        s.merge(
+            Item(
+                id=PART_OTHER,
+                item_type_id="Part",
+                config_id=PART_OTHER,
+                generation=1,
+                is_current=True,
+                state="active",
+                created_by_id=USER_ID,
+            )
+        )
+
+        # The READ entitlement SKU (base review key `metasheet_review` -> app `plm.metasheet_review`),
+        # active for the tenant. Re-checked per read by the route gate.
+        s.merge(
+            AppLicense(
+                id="lic-msr-read",
+                app_name="plm.metasheet_review",
+                license_key="k-msr-read",
+                status="Active",
+                tenant_id=TENANT,
+            )
+        )
+
+        # Threads on the bound part: one OPEN + one RESOLVED. The relay's read list sends a fixed
+        # include_resolved=true, so BOTH must come back — the E2E asserts the resolved one is present.
+        s.merge(
+            DiscussionThread(
+                id="T-open-1",
+                tenant_id=TENANT,
+                org_id=ORG,
+                target_type="item",
+                target_id=PART,
+                title="open thread",
+                status=THREAD_STATUS_OPEN,
+                created_by_id=USER_ID,
+                comment_count=0,
+            )
+        )
+        s.merge(
+            DiscussionThread(
+                id="T-resolved-1",
+                tenant_id=TENANT,
+                org_id=ORG,
+                target_type="item",
+                target_id=PART,
+                title="resolved thread",
+                status=THREAD_STATUS_RESOLVED,
+                created_by_id=USER_ID,
+                resolved_by_id=USER_ID,
+                resolved_at=datetime.utcnow(),
+                comment_count=0,
+            )
+        )
+        # A thread on ANOTHER part (for the cross-Part detail 404 case).
+        s.merge(
+            DiscussionThread(
+                id="T-otherpart-1",
+                tenant_id=TENANT,
+                org_id=ORG,
+                target_type="item",
+                target_id=PART_OTHER,
+                title="off-part thread",
+                status=THREAD_STATUS_OPEN,
+                created_by_id=USER_ID,
+                comment_count=0,
+            )
+        )
+        # A thread in a DIFFERENT tenant whose target_id COLLIDES with the bound part (for the
+        # provider-side cross-tenant 404: the tenant-scoped lookup must never surface it).
+        s.merge(
+            DiscussionThread(
+                id="T-foreign-tenant-1",
+                tenant_id="other-tenant",
+                org_id="other-org",
+                target_type="item",
+                target_id=PART,
+                title="foreign tenant thread",
+                status=THREAD_STATUS_OPEN,
+                created_by_id=USER_ID,
+                comment_count=0,
+            )
+        )
+
+        s.commit()
+    finally:
+        s.close()
+
+    print("seed_yuantus: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/core-backend/tests/e2e/seed_yuantus.py
+++ b/packages/core-backend/tests/e2e/seed_yuantus.py
@@ -52,9 +52,12 @@ def main() -> int:
         Organization,
         Tenant,
     )
+    from yuantus.security.auth.models import AuthCredential
+    from yuantus.security.auth.passwords import hash_password
     from yuantus.security.rbac.models import RBACUser
     from yuantus.meta_engine.models.meta_schema import ItemType
     from yuantus.meta_engine.models.item import Item
+    from yuantus.meta_engine.permission.models import Access, Permission
     from yuantus.meta_engine.app_framework.store_models import AppLicense
     from yuantus.meta_engine.discussion.models import (
         DiscussionThread,
@@ -65,8 +68,11 @@ def main() -> int:
     TENANT = "default"
     ORG = "org-1"
     USER_ID = 42
+    USER_NAME = "u42"
+    USER_PASSWORD = "e2e-pw-42"  # seeded so the HTTP mint route can be reached via a real login
     PART = "item-1"
     PART_OTHER = "item-ro"
+    BOM_LINE_TYPE = "Part BOM"  # the mint route checks GET permission on this type too
 
     # Plain engine with FK enforcement OFF — mirrors the provider's own read-gate test fixture
     # (`test_discussion_router.py::db`), whose seeding order these rows follow. The live uvicorn uses
@@ -83,8 +89,11 @@ def main() -> int:
     try:
         # Identity: the REAL get_current_user path needs an AuthUser + an active OrgMembership
         # (AuthService.get_roles_for_user_org), not just an RBACUser.
-        s.merge(AuthUser(id=USER_ID, tenant_id=TENANT, username="u42", email="u42@x.io"))
-        s.merge(RBACUser(id=USER_ID, user_id=USER_ID, username="u42", is_active=True))
+        s.merge(AuthUser(id=USER_ID, tenant_id=TENANT, username=USER_NAME, email="u42@x.io"))
+        s.merge(RBACUser(id=USER_ID, user_id=USER_ID, username=USER_NAME, is_active=True))
+        # A password credential so the E2E can log in via the REAL POST /api/v1/auth/login and
+        # then call the REAL mint route (P2-1) — not the direct mint service.
+        s.merge(AuthCredential(user_id=USER_ID, password_hash=hash_password(USER_PASSWORD)))
         s.merge(Tenant(id=TENANT))
         s.merge(Organization(id=ORG, tenant_id=TENANT))
         s.merge(
@@ -93,8 +102,26 @@ def main() -> int:
             )
         )
 
+        # Surgical world GET grant so the mint route's permission checks (Part + Part BOM, action
+        # get) pass — check_permission returns False for a type with no permission set, so this is
+        # required to reach the real mint. It grants ONLY get; it does NOT touch the discussion read
+        # gate (that is credential/part-scoped, not MetaPermissionService-gated), so the negative
+        # read cases still fail closed.
+        s.merge(Permission(id="perm-world-get", name="world get"))
+        s.merge(
+            Access(
+                id="perm-world-get:world",
+                permission_id="perm-world-get",
+                identity_id="world",
+                can_get=True,
+                can_update=False,
+            )
+        )
+
         # A readable Part item (the bound part) + a second Part used only as an off-part target.
-        s.merge(ItemType(id="Part", label="Part", is_versionable=True))
+        # The BOM-line type must exist + be gettable for the mint route's second permission check.
+        s.merge(ItemType(id="Part", label="Part", is_versionable=True, permission_id="perm-world-get"))
+        s.merge(ItemType(id=BOM_LINE_TYPE, label=BOM_LINE_TYPE, permission_id="perm-world-get"))
         s.merge(
             Item(
                 id=PART,
@@ -125,6 +152,16 @@ def main() -> int:
                 id="lic-msr-read",
                 app_name="plm.metasheet_review",
                 license_key="k-msr-read",
+                status="Active",
+                tenant_id=TENANT,
+            )
+        )
+        # The mint route gates on is_entitled("bom_multitable") -> app `plm.bom_multitable`.
+        s.merge(
+            AppLicense(
+                id="lic-bom-multitable",
+                app_name="plm.bom_multitable",
+                license_key="k-bom-mt",
                 status="Active",
                 tenant_id=TENANT,
             )

--- a/packages/core-backend/vitest.e2e.config.ts
+++ b/packages/core-backend/vitest.e2e.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * PLM-COLLAB Discussion read-auth line — sub-slice 6 (capstone dual-service E2E) runner.
+ *
+ * Isolated config: the E2E boots REAL Yuantus uvicorn subprocesses (heavy, ~10s startup) and is
+ * gated behind RUN_PLM_READ_E2E so the normal unit run never touches it. Single fork, long
+ * timeouts. CI wiring is DEFERRED (build-then-HOLD): the owner will wire this as the final merge
+ * gate once Actions is restored.
+ *
+ * Run: RUN_PLM_READ_E2E=1 npx vitest run --config vitest.e2e.config.ts
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+    include: ['tests/e2e/**/*.test.ts'],
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+    retry: 0,
+  },
+})


### PR DESCRIPTION
## Summary

- add the controlled server-path E2E for Discussion read authorization
- traverse real login + HTTP embed-token mint -> MetaSheet read relay -> Yuantus read-session exchange -> provider list/detail routes
- cover relay and provider single-use stores, uniform 404 behavior, dark-mode 401, cross-tenant pre-rejection, the approved 30/min + burst-20 pre-auth posture, and audit-log token redaction

## Reality boundary

The security-critical service path and HTTP hop are real. The only substitutes are the in-process Map behind the Redis seam and the DataSourceManager registry indirection returning the real adapter. This is intentionally a server-path E2E, not a browser postMessage E2E; the parent/child/panel layers are covered by the already-landed handler and component suites in #4387 and #4388.

## Final-base verification

- rebased onto `main@23fae3f1` with no conflicts
- `git range-diff`: both reviewed commits are unchanged (`=`)
- stable aggregate patch-id unchanged: `a951b7370dfd1ce3316afb2505a0a36ef329016e`
- `RUN_PLM_READ_E2E=1 pnpm --filter @metasheet/core-backend exec vitest run --config vitest.e2e.config.ts` -> 10 passed
- `pnpm --filter @metasheet/core-backend type-check` -> passed
- `git diff --check origin/main..HEAD` -> clean

Runtime remains dark: the Yuantus Discussion read/write session flags stay default-OFF. This PR does not activate or deploy either path.
