### PR TITLE
feat(ops): corrective-5 — bounded values-free smoke diagnostic contract (Draft)

### DIFF
--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -302,6 +302,58 @@ Invoke-SmokeStage -Token $token
     "$stageOutput" -notmatch 'dummy-not-a-real-token'
   )
 
+  # ── corrective-5: a smoke that early-returns (exit 1) with a valid-looking summary must still PROPAGATE
+  # its bounded diagnostics into the acceptance summary, so the failure is localizable even though the runner
+  # discards the child's raw output. Drive the REAL Invoke-SmokeStage; assert the emitted .json carries them.
+  $diagLines = @(
+    "process.stdout.write('mvpSmoke.pass=false\n')",
+    "process.stdout.write('auditActionsCovered=N/8\n')",
+    "process.stdout.write('selfScanClean=true\n')",
+    "process.stdout.write('failureClass=CHECK_FAILED\n')",
+    "process.stdout.write('lastCompletedPhase=AUTH\n')",
+    "process.stdout.write('firstFailedCheck=PROVISIONING\n')",
+    "process.stdout.write('failedCheckCount=2\n')",
+    "process.stdout.write('responseLeakScanStatus=NOT_RUN\n')",
+    'process.exit(1)'
+  )
+  Set-Content -LiteralPath $fakeSmoke -Encoding utf8 -Value ($diagLines -join "`n")
+  $diagSummary = Join-Path $fakeSmokeRoot 'diag-summary.txt'
+  & pwsh -NoProfile -File $stageHarness -AcceptanceScript $scriptPath -DeployRoot $fakeSmokeRoot -SummaryPath $diagSummary *> $null
+  $diagExit = $LASTEXITCODE
+  $diagJsonPath = [System.IO.Path]::ChangeExtension($diagSummary, '.json')
+  $diagJson = if (Test-Path $diagJsonPath) { Get-Content $diagJsonPath -Raw | ConvertFrom-Json } else { $null }
+  Check "corrective-5: an exit-1 smoke still fails closed AND propagates its bounded diagnostics into the summary" (
+    $diagExit -eq 1 -and
+    $null -ne $diagJson -and
+    $diagJson.failedStage -eq 'smoke' -and
+    $diagJson.'mvpSmoke.failureClass' -eq 'CHECK_FAILED' -and
+    $diagJson.'mvpSmoke.lastCompletedPhase' -eq 'AUTH' -and
+    $diagJson.'mvpSmoke.firstFailedCheck' -eq 'PROVISIONING' -and
+    $diagJson.'mvpSmoke.failedCheckCount' -eq '2' -and
+    $diagJson.'mvpSmoke.responseLeakScanStatus' -eq 'NOT_RUN'
+  )
+  # values-free hardening: an off-vocabulary / business-value diagnostic never reaches the summary.
+  $leakLines = @(
+    "process.stdout.write('mvpSmoke.pass=false\n')",
+    "process.stdout.write('selfScanClean=true\n')",
+    "process.stdout.write('failureClass=DWG-88472-A\n')",
+    "process.stdout.write('lastCompletedPhase=SECRET_TENANT_evil\n')",
+    "process.stdout.write('firstFailedCheck=material chinese steel Q235 x 99\n')",
+    'process.exit(1)'
+  )
+  Set-Content -LiteralPath $fakeSmoke -Encoding utf8 -Value ($leakLines -join "`n")
+  $leakSummary = Join-Path $fakeSmokeRoot 'diag-leak-summary.txt'
+  & pwsh -NoProfile -File $stageHarness -AcceptanceScript $scriptPath -DeployRoot $fakeSmokeRoot -SummaryPath $leakSummary *> $null
+  $leakJsonPath = [System.IO.Path]::ChangeExtension($leakSummary, '.json')
+  $leakJson = if (Test-Path $leakJsonPath) { Get-Content $leakJsonPath -Raw | ConvertFrom-Json } else { $null }
+  Check "corrective-5: an off-vocabulary / business-value diagnostic is coerced to NOT_RUN/UNKNOWN, never surfaced" (
+    $null -ne $leakJson -and
+    (@('NOT_RUN', 'UNKNOWN') -contains $leakJson.'mvpSmoke.failureClass') -and
+    $leakJson.'mvpSmoke.lastCompletedPhase' -eq 'UNKNOWN' -and
+    (@('NOT_RUN', 'UNKNOWN') -contains $leakJson.'mvpSmoke.firstFailedCheck') -and
+    ((Get-Content ([System.IO.Path]::ChangeExtension($leakSummary, '.txt')) -Raw) -notmatch 'DWG-88472|Q235|SECRET_TENANT')
+  )
+
   $base = [pscustomobject]@{ state = 'online'; restartTime = 3; uptime = 1000 }
 
   # Entity corrective-1 reproduction: PM2 includes process.env in jlist; on Windows it commonly carries

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
@@ -38,10 +38,10 @@ try {
   $dummyToken = ConvertTo-SecureString 'dummy-not-a-real-token' -AsPlainText -Force
 
   Set-Content -LiteralPath $fakeSmoke -Encoding ASCII -Value @(
-    "process.stderr.write('$sentinel\\n')"
-    "process.stdout.write('mvpSmoke.pass=true\\n')"
-    "process.stdout.write('auditActionsCovered=8/8\\n')"
-    "process.stdout.write('selfScanClean=true\\n')"
+    "process.stderr.write('$sentinel\n')"
+    "process.stdout.write('mvpSmoke.pass=true\n')"
+    "process.stdout.write('auditActionsCovered=8/8\n')"
+    "process.stdout.write('selfScanClean=true\n')"
     'process.exit(0)'
   )
 
@@ -67,10 +67,10 @@ try {
   )
 
   Set-Content -LiteralPath $fakeSmoke -Encoding ASCII -Value @(
-    "process.stderr.write('$sentinel\\n')"
-    "process.stdout.write('mvpSmoke.pass=true\\n')"
-    "process.stdout.write('auditActionsCovered=8/8\\n')"
-    "process.stdout.write('selfScanClean=true\\n')"
+    "process.stderr.write('$sentinel\n')"
+    "process.stdout.write('mvpSmoke.pass=true\n')"
+    "process.stdout.write('auditActionsCovered=8/8\n')"
+    "process.stdout.write('selfScanClean=true\n')"
     'process.exit(7)'
   )
 
@@ -92,6 +92,32 @@ try {
   Check 'exit-7 restores error policy and clears token env' (
     $ErrorActionPreference -eq 'Stop' -and -not (Test-Path Env:METASHEET_AUTH_TOKEN)
   )
+
+  # corrective-5: a non-zero smoke that writes bounded diagnostic lines to stdout (and noise to stderr)
+  # must have its diagnostics captured and parseable under Windows PowerShell 5.1, stderr discarded, exit
+  # preserved exactly. This is the target-shell coverage for the diagnostic contract.
+  Set-Content -LiteralPath $fakeSmoke -Encoding ASCII -Value @(
+    "process.stderr.write('$sentinel\n')"
+    "process.stdout.write('mvpSmoke.pass=false\n')"
+    "process.stdout.write('failureClass=CHECK_FAILED\n')"
+    "process.stdout.write('lastCompletedPhase=SYNC_PERSIST\n')"
+    "process.stdout.write('firstFailedCheck=PROVISIONING\n')"
+    "process.stdout.write('failedCheckCount=3\n')"
+    "process.stdout.write('responseLeakScanStatus=NOT_RUN\n')"
+    'process.exit(1)'
+  )
+  $diagCapture = Invoke-SmokeCapture -NodeArgs @($fakeSmoke) -Token $dummyToken
+  $diagOutcome = Test-SmokeOutcome $diagCapture.stdout
+  Check 'exit-1 diagnostic stdout is captured, stderr excluded, exit preserved' (
+    $null -ne $diagCapture -and $diagCapture.exit -eq 1 -and $diagCapture.stdout -notmatch $sentinel
+  )
+  Check 'exit-1 diagnostics parse to the fixed enums under Windows PowerShell 5.1' (
+    $diagOutcome.failureClass -eq 'CHECK_FAILED' -and
+    $diagOutcome.lastCompletedPhase -eq 'SYNC_PERSIST' -and
+    $diagOutcome.firstFailedCheck -eq 'PROVISIONING' -and
+    $diagOutcome.failedCheckCount -eq '3' -and
+    $diagOutcome.responseLeakScanStatus -eq 'NOT_RUN'
+  )
 } finally {
   Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
   Remove-Item Env:METASHEET_AUTH_TOKEN -ErrorAction SilentlyContinue
@@ -102,5 +128,5 @@ if ($fail -gt 0) {
   exit 1
 }
 
-Write-Host "ALL POWERSHELL 5.1 CHECKS PASS ($pass/10)"
+Write-Host "ALL POWERSHELL 5.1 CHECKS PASS ($pass checks)"
 exit 0

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
@@ -130,15 +130,19 @@ Check "PM2 projection helper is required by the on-prem package build" (
   $packageBuildSrc -match '"scripts/ops/stock-preparation-pm2-sample\.mjs"'
 )
 
-# ── 1. Summary is values-free by construction: exactly the 9 whitelisted keys, nothing else. ─────
-$expected9 = @(
+# ── 1. Summary is values-free by construction: exactly the 14 whitelisted keys, nothing else. ────
+# (9 original + 5 corrective-5 bounded diagnostics; every added default is a fixed enum / integer.)
+$expectedFields = @(
   'packageShaMatch','migrationStatus','pm2StableOnline','healthcheck',
-  'mvpSmoke.pass','auditActionsCovered','selfScanClean','externalPlmK3ErpWrite','failedStage'
+  'mvpSmoke.pass','auditActionsCovered','selfScanClean',
+  'mvpSmoke.failureClass','mvpSmoke.lastCompletedPhase','mvpSmoke.firstFailedCheck',
+  'mvpSmoke.failedCheckCount','mvpSmoke.responseLeakScanStatus',
+  'externalPlmK3ErpWrite','failedStage'
 )
 $summaryBlock = if ($src -match "(?s)\`$Summary = \[ordered\]@\{(.*?)\}") { $Matches[1] } else { '' }
 $foundKeys = [regex]::Matches($summaryBlock, "(?m)^\s*'?([A-Za-z0-9.]+)'?\s*=") | ForEach-Object { $_.Groups[1].Value }
-Check "summary declares exactly the 9 whitelisted fields" (
-  ($foundKeys.Count -eq 9) -and (($expected9 | Where-Object { $_ -notin $foundKeys }).Count -eq 0)
+Check "summary declares exactly the 14 whitelisted fields" (
+  ($foundKeys.Count -eq 14) -and (($expectedFields | Where-Object { $_ -notin $foundKeys }).Count -eq 0)
 )
 Check "summary has NO value-plane field (drawing/qty/unit/material/host/token)" (
   -not ($summaryBlock -match '(?i)drawing|qty|quantity|unit|material|host|token|password|secret|projectName')

--- a/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
+++ b/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
@@ -70,11 +70,13 @@ export const SMOKE_PHASES = Object.freeze([
 ])
 export const SMOKE_FAILURE_CLASSES = Object.freeze(['NONE', 'CHECK_FAILED', 'SELF_SCAN_FAILED', 'FATAL_EXCEPTION'])
 export const SMOKE_LEAK_SCAN_STATUSES = Object.freeze(['NOT_RUN', 'PASS', 'FAIL'])
-const DIAG = { reachedIdx: -1 }
-export function resetDiagnostics() { DIAG.reachedIdx = -1 }
+// Internal-only phase cursor (P3: never written into the summary — the output face is EXACTLY the five
+// declared diagnostic fields; check() reads the current phase from here, not from the summary).
+const DIAG = { reachedIdx: -1, reachedName: 'NONE' }
+export function resetDiagnostics() { DIAG.reachedIdx = -1; DIAG.reachedName = 'NONE' }
 function beginPhase(name) {
   DIAG.reachedIdx = SMOKE_PHASES.indexOf(name)
-  RESULT.summary.reachedPhase = name
+  DIAG.reachedName = name
 }
 // The 4 LOCUS fields (added before the self-scan so it covers them). `result` + sentinels are passed in
 // for testability. lastCompletedPhase: on a run that reached the last phase, everything completed; an
@@ -84,14 +86,19 @@ export function computeDiagnosticLocus(result, reachedIdx = DIAG.reachedIdx) {
   const failedChecks = result.checks.filter((c) => c.ok !== true)
   const last = SMOKE_PHASES.length - 1
   S.failedCheckCount = failedChecks.length
-  S.lastCompletedPhase = reachedIdx >= last ? SMOKE_PHASES[last] : (reachedIdx > 0 ? SMOKE_PHASES[reachedIdx - 1] : 'NONE')
+  // ENTERING a phase only proves the PREVIOUS one completed. The final phase is special-cased on its own
+  // product (owner P2): RESPONSE_LEAK_SCAN counts as completed ONLY once leakScanClean is a boolean — a
+  // mid-phase throw otherwise reported the contradictory pair lastCompletedPhase=RESPONSE_LEAK_SCAN +
+  // responseLeakScanStatus=NOT_RUN; it must report AUDIT_TRAIL + NOT_RUN instead.
+  const lastPhaseCompleted = reachedIdx >= last && typeof S.leakScanClean === 'boolean'
+  S.lastCompletedPhase = lastPhaseCompleted
+    ? SMOKE_PHASES[last]
+    : (reachedIdx > 0 ? SMOKE_PHASES[Math.min(reachedIdx, last) - 1] : 'NONE')
   // firstFailedCheck is the PHASE of the first failed check — a FIXED enum, never a free-form check name
   // (a name could contain a value); each check records its phase at push time.
   const firstPhase = failedChecks.length ? String(failedChecks[0].phase || 'NONE') : 'NONE'
   S.firstFailedCheck = (firstPhase === 'NONE' || SMOKE_PHASES.includes(firstPhase)) ? firstPhase : 'UNKNOWN'
-  S.responseLeakScanStatus = (reachedIdx >= last && typeof S.leakScanClean === 'boolean')
-    ? (S.leakScanClean ? 'PASS' : 'FAIL')
-    : 'NOT_RUN'
+  S.responseLeakScanStatus = lastPhaseCompleted ? (S.leakScanClean ? 'PASS' : 'FAIL') : 'NOT_RUN'
 }
 // failureClass needs the final pass/selfScanClean, so it is computed AFTER the self-scan.
 export function computeFailureClass(result, { fatal = false } = {}) {
@@ -426,7 +433,7 @@ export function formatSummaryBlock(summary) {
 }
 
 function check(name, ok, detail = '') {
-  RESULT.checks.push({ name, ok: ok === true, detail, phase: RESULT.summary.reachedPhase || 'NONE' })
+  RESULT.checks.push({ name, ok: ok === true, detail, phase: DIAG.reachedName })
   const mark = ok === true ? 'ok' : 'FAIL'
   process.stderr.write(`[smoke] ${name}: ${mark}${detail ? ` (${detail})` : ''}\n`)
   return ok === true

--- a/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
+++ b/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
@@ -64,8 +64,8 @@ const RESULT = { checks: [], summary: {} }
 // the finish()/catch self-scan, so the self-scan re-proves the diagnostic fields are sentinel-clean too;
 // firstFailedCheck is additionally guarded so a hostile check name can never smuggle a value.
 export const SMOKE_PHASES = Object.freeze([
-  'AUTH', 'PROVISIONING', 'SYNC_PERSIST', 'PROJECTS', 'SNAPSHOT_DIFF', 'MATERIAL_MAPPINGS',
-  'UNIT_CONVERSIONS', 'GENERATION_RUN', 'FAILCLOSED_PROBES', 'ERP_MATERIAL_SYNC', 'CLEANUP_RETIRES',
+  'AUTH', 'PROVISIONING', 'SYNC_PERSIST', 'PROJECTS', 'SNAPSHOT_DIFF', 'MAPPINGS',
+  'CONVERSIONS', 'GENERATION_RUN', 'FAILCLOSED_PROBES', 'ERP_CACHE_SYNC', 'CLEANUP_RETIRES',
   'AUDIT_TRAIL', 'RESPONSE_LEAK_SCAN',
 ])
 export const SMOKE_FAILURE_CLASSES = Object.freeze(['NONE', 'CHECK_FAILED', 'SELF_SCAN_FAILED', 'FATAL_EXCEPTION'])
@@ -631,7 +631,7 @@ async function main() {
     rows.every((row) => row.diffType === 'added' && ['ready', 'held'].includes(row.reviewStatus)))
 
   // ── 4. material mappings: candidates/sync -> confirm (create) -> human_preserved survival ───────
-  beginPhase('MATERIAL_MAPPINGS')
+  beginPhase('MAPPINGS')
   const candidateIds = async (label) => {
     const list = await req(`${API}/material-mappings/candidates${scope({ projectId: fixture.projectId })}`, { label })
     const listRows = Array.isArray(list.body?.data?.rows) ? list.body.data.rows : []
@@ -700,7 +700,7 @@ async function main() {
     idsAfterResync.length === 1 && idsAfterResync[0] === confirmedMappingId, `newIds=${idsAfterResync.length}`)
 
   // ── 5. unit conversions: COMPUTED candidates -> confirm (manual rule mode) ───────────────────────
-  beginPhase('UNIT_CONVERSIONS')
+  beginPhase('CONVERSIONS')
   const unitCandidates = await req(`${API}/unit-conversions/candidates${scope({ projectId: fixture.projectId, snapshotBatchId: fixture.snapshotBatchId })}`, { label: 'unit-candidates' })
   const unitData = unitCandidates.body?.data || {}
   const unitRows = Array.isArray(unitData.rows) ? unitData.rows : []
@@ -897,7 +897,7 @@ async function main() {
     `http=${ghostCurrent.status} code=${S.probeGhostCurrentCode}`)
 
   // ── 7z. T2: ERP material-master cache sync (POST /mvp/erp-materials/sync) ────────────────────────
-  beginPhase('ERP_MATERIAL_SYNC')
+  beginPhase('ERP_CACHE_SYNC')
   // Deployed-lane coverage of the T2 route: persist an ALREADY-NORMALIZED ERP material into the internal
   // erp_material_master cache, then re-sync to prove the idempotent upsert (patch, not a duplicate).
   // NON-PERTURBING by construction: erpCodeA (SMKERP-A-…) is a DIFFERENT value from the BOM drawings

--- a/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
+++ b/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
@@ -79,10 +79,9 @@ function beginPhase(name) {
 // The 4 LOCUS fields (added before the self-scan so it covers them). `result` + sentinels are passed in
 // for testability. lastCompletedPhase: on a run that reached the last phase, everything completed; an
 // early-return/throw within phase i means the last COMPLETED phase is i-1 (early-returns are mid-phase).
-export function computeDiagnosticLocus(result) {
+export function computeDiagnosticLocus(result, reachedIdx = DIAG.reachedIdx) {
   const S = result.summary
   const failedChecks = result.checks.filter((c) => c.ok !== true)
-  const reachedIdx = DIAG.reachedIdx
   const last = SMOKE_PHASES.length - 1
   S.failedCheckCount = failedChecks.length
   S.lastCompletedPhase = reachedIdx >= last ? SMOKE_PHASES[last] : (reachedIdx > 0 ? SMOKE_PHASES[reachedIdx - 1] : 'NONE')

--- a/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
+++ b/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
@@ -439,25 +439,30 @@ function check(name, ok, detail = '') {
   return ok === true
 }
 
-async function requestJson(baseUrl, pathname, { token, timeoutMs, tenantId, method = 'GET', body, accept = [200], label = '', leakExempt = false } = {}) {
+// Pure request-header builder — the load-bearing tenant-context contract lives here so it can be tested
+// directly (owner P2: a smoke that fails to send x-tenant-id fails on the entity but not in CI). Tenant
+// context rides the platform's tenant-context HEADER, not only the query string: the tenant-hardened WRITE
+// routes (resolveAuthUserTenantId) deliberately ignore request query/body tenant params, and for a
+// principal without an intrinsic tenant claim the deployment's sanctioned mechanism is the x-tenant-id
+// header (jwt-middleware backfill). Without it the smoke fails its FIRST write (mvp/ensure -> 400
+// TENANT_REQUIRED) on any post-hardening package — the RC-0 corrective-4 N/8 entity failure.
+export function buildRequestHeaders({ token, tenantId, hasBody = false } = {}) {
+  const headers = { Accept: 'application/json' }
+  if (token) headers.Authorization = `Bearer ${token}`
+  if (tenantId) headers['x-tenant-id'] = tenantId
+  if (hasBody) headers['Content-Type'] = 'application/json'
+  return headers
+}
+
+export async function requestJson(baseUrl, pathname, { token, timeoutMs, tenantId, method = 'GET', body, accept = [200], label = '', leakExempt = false, fetchImpl } = {}) {
+  const doFetch = fetchImpl || fetch
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
   try {
-    const headers = { Accept: 'application/json' }
-    if (token) headers.Authorization = `Bearer ${token}`
-    // Tenant context rides the platform's tenant-context HEADER, not only the query string. The
-    // tenant-hardened WRITE routes (resolveAuthUserTenantId) deliberately ignore request query/body
-    // tenant params; for a principal without an intrinsic tenant claim, the deployment's sanctioned
-    // context mechanism is the x-tenant-id header (jwt-middleware backfill). Without this header the
-    // smoke fails its FIRST write (mvp/ensure -> 400 TENANT_REQUIRED) on any post-hardening package —
-    // the RC-0 corrective-4 entity failure (auditActionsCovered=N/8) reproduced locally.
-    if (tenantId) headers['x-tenant-id'] = tenantId
+    const headers = buildRequestHeaders({ token, tenantId, hasBody: body !== undefined })
     const init = { method, headers, signal: controller.signal }
-    if (body !== undefined) {
-      headers['Content-Type'] = 'application/json'
-      init.body = JSON.stringify(body)
-    }
-    const response = await fetch(`${baseUrl}${pathname}`, init)
+    if (body !== undefined) init.body = JSON.stringify(body)
+    const response = await doFetch(`${baseUrl}${pathname}`, init)
     const text = await response.text()
     let parsed = null
     try { parsed = text ? JSON.parse(text) : null } catch { parsed = null }

--- a/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
+++ b/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
@@ -57,6 +57,51 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 const RESULT = { checks: [], summary: {} }
+
+// ── Bounded values-free diagnostic contract (corrective-5). A FIXED phase ladder so a failure that
+// early-returns or throws still reports WHERE it stopped and WHAT failed first. Every diagnostic field is
+// a fixed enum or a non-negative integer — never a business value. computeDiagnosticLocus() runs BEFORE
+// the finish()/catch self-scan, so the self-scan re-proves the diagnostic fields are sentinel-clean too;
+// firstFailedCheck is additionally guarded so a hostile check name can never smuggle a value.
+export const SMOKE_PHASES = Object.freeze([
+  'AUTH', 'PROVISIONING', 'SYNC_PERSIST', 'PROJECTS', 'SNAPSHOT_DIFF', 'MATERIAL_MAPPINGS',
+  'UNIT_CONVERSIONS', 'GENERATION_RUN', 'FAILCLOSED_PROBES', 'ERP_MATERIAL_SYNC', 'CLEANUP_RETIRES',
+  'AUDIT_TRAIL', 'RESPONSE_LEAK_SCAN',
+])
+export const SMOKE_FAILURE_CLASSES = Object.freeze(['NONE', 'CHECK_FAILED', 'SELF_SCAN_FAILED', 'FATAL_EXCEPTION'])
+export const SMOKE_LEAK_SCAN_STATUSES = Object.freeze(['NOT_RUN', 'PASS', 'FAIL'])
+const DIAG = { reachedIdx: -1 }
+export function resetDiagnostics() { DIAG.reachedIdx = -1 }
+function beginPhase(name) {
+  DIAG.reachedIdx = SMOKE_PHASES.indexOf(name)
+  RESULT.summary.reachedPhase = name
+}
+// The 4 LOCUS fields (added before the self-scan so it covers them). `result` + sentinels are passed in
+// for testability. lastCompletedPhase: on a run that reached the last phase, everything completed; an
+// early-return/throw within phase i means the last COMPLETED phase is i-1 (early-returns are mid-phase).
+export function computeDiagnosticLocus(result, sentinels = SELF_SCAN_SENTINELS) {
+  const S = result.summary
+  const failedChecks = result.checks.filter((c) => c.ok !== true)
+  const reachedIdx = DIAG.reachedIdx
+  const last = SMOKE_PHASES.length - 1
+  S.failedCheckCount = failedChecks.length
+  S.lastCompletedPhase = reachedIdx >= last ? SMOKE_PHASES[last] : (reachedIdx > 0 ? SMOKE_PHASES[reachedIdx - 1] : 'NONE')
+  // check names are fixed hardcoded literals; the extra leakScan guard makes firstFailedCheck values-free
+  // even if a future name interpolated a value (it would surface as REDACTED, never the value).
+  const name = failedChecks.length ? String(failedChecks[0].name) : 'NONE'
+  S.firstFailedCheck = leakScan(name, sentinels) ? name : 'REDACTED'
+  S.responseLeakScanStatus = (reachedIdx >= last && typeof S.leakScanClean === 'boolean')
+    ? (S.leakScanClean ? 'PASS' : 'FAIL')
+    : 'NOT_RUN'
+}
+// failureClass needs the final pass/selfScanClean, so it is computed AFTER the self-scan.
+export function computeFailureClass(result, { fatal = false } = {}) {
+  const S = result.summary
+  S.failureClass = S.pass === true ? 'NONE'
+    : fatal ? 'FATAL_EXCEPTION'
+    : (S.selfScanClean === false ? 'SELF_SCAN_FAILED' : 'CHECK_FAILED')
+}
+
 // Every response body (except the counted /plan exemption) lands here for the final leak scan.
 const COLLECTED = []
 // Set by main() once the fixture exists; finish() self-scans the composed summary + checks against
@@ -439,12 +484,14 @@ async function main() {
   S.salt = salt
 
   // ── 0. auth round-trip (deploy SOP: a silent 401 usually means schema/token gap) ────────────────
+  beginPhase('AUTH')
   const status = await req(`/api/integration/status${scope()}`, { label: 'status' })
   S.statusHttp = status.status
   must('status auth round-trip', status.ok, `http=${status.status}`)
   if (!status.ok) return finish(failed, args)
 
   // ── 1. MVP provisioning: readiness -> ensure (idempotent) -> options/sync ────────────────────────
+  beginPhase('PROVISIONING')
   const readiness1 = await req(`${API}/mvp/readiness${scope()}`, { label: 'mvp-readiness-pre' })
   S.readinessPreHttp = readiness1.status
   S.readinessPreReady = readiness1.body?.data?.ready === true
@@ -475,6 +522,7 @@ async function main() {
     `synced=${S.optionsSyncedFieldCount} skipped=${S.optionsSkippedFieldCount}`)
 
   // ── 2. sync/plan -> sync/persist (201) -> persist replay (200 skipped_existing) ─────────────────
+  beginPhase('SYNC_PERSIST')
   const planBody = {
     projectId: fixture.projectId,
     syncRunId: fixture.syncRunId,
@@ -524,6 +572,7 @@ async function main() {
     `http=${replay.status} mode=${S.persistReplayMode}`)
 
   // ── 2b. #4163 T1: GET /projects — the populator's project row landed, values-free ────────────────
+  beginPhase('PROJECTS')
   // Proves the FULL gap end-to-end against a real Postgres: the FE project-selector's endpoint (which
   // had NO server route before this) now returns the project the persist call above just populated,
   // and — the values-free hard boundary — never echoes fixture.sourceProjectNo / fixture.projectName
@@ -544,6 +593,7 @@ async function main() {
     `status=${S.projectStatus} batches=${S.projectSnapshotBatchCount}`)
 
   // ── 3. snapshot-batches list -> diff (counts) -> diff/rows (11-key projection) ───────────────────
+  beginPhase('SNAPSHOT_DIFF')
   const batchList = await req(`${API}/snapshot-batches${scope({ projectId: fixture.projectId })}`, { label: 'batch-list' })
   const batchData = batchList.body?.data || {}
   const ourBatch = (batchData.batches || []).find((entry) => entry.snapshotBatchId === fixture.snapshotBatchId) || null
@@ -581,6 +631,7 @@ async function main() {
     rows.every((row) => row.diffType === 'added' && ['ready', 'held'].includes(row.reviewStatus)))
 
   // ── 4. material mappings: candidates/sync -> confirm (create) -> human_preserved survival ───────
+  beginPhase('MATERIAL_MAPPINGS')
   const candidateIds = async (label) => {
     const list = await req(`${API}/material-mappings/candidates${scope({ projectId: fixture.projectId })}`, { label })
     const listRows = Array.isArray(list.body?.data?.rows) ? list.body.data.rows : []
@@ -649,6 +700,7 @@ async function main() {
     idsAfterResync.length === 1 && idsAfterResync[0] === confirmedMappingId, `newIds=${idsAfterResync.length}`)
 
   // ── 5. unit conversions: COMPUTED candidates -> confirm (manual rule mode) ───────────────────────
+  beginPhase('UNIT_CONVERSIONS')
   const unitCandidates = await req(`${API}/unit-conversions/candidates${scope({ projectId: fixture.projectId, snapshotBatchId: fixture.snapshotBatchId })}`, { label: 'unit-candidates' })
   const unitData = unitCandidates.body?.data || {}
   const unitRows = Array.isArray(unitData.rows) ? unitData.rows : []
@@ -689,6 +741,7 @@ async function main() {
     `http=${unitConfirmReplay.status} mode=${S.unitConfirmReplayMode}`)
 
   // ── 6. generation run -> invariant -> resolve (single + bulk) -> re-run flip ─────────────────────
+  beginPhase('GENERATION_RUN')
   const generationBody = { projectId: fixture.projectId, snapshotBatchId: fixture.snapshotBatchId }
   const run1 = await req(`${API}/generation/run${scope()}`, { method: 'POST', body: generationBody, accept: [201], label: 'generation-run-1' })
   const run1Data = run1.body?.data || {}
@@ -801,6 +854,7 @@ async function main() {
     prepLines.ok && S.prepLineRowCount === 0, `http=${prepLines.status} rows=${S.prepLineRowCount}`)
 
   // ── 7. remaining fail-closed probes (exact status + code each) ───────────────────────────────────
+  beginPhase('FAILCLOSED_PROBES')
   const badPolicy = await req(`${API}/material-mappings/candidates/sync${scope()}`, {
     method: 'POST',
     body: { projectId: fixture.projectId, snapshotBatchId: fixture.snapshotBatchId, defaultVersionPolicy: 'bogus_policy' },
@@ -843,6 +897,7 @@ async function main() {
     `http=${ghostCurrent.status} code=${S.probeGhostCurrentCode}`)
 
   // ── 7z. T2: ERP material-master cache sync (POST /mvp/erp-materials/sync) ────────────────────────
+  beginPhase('ERP_MATERIAL_SYNC')
   // Deployed-lane coverage of the T2 route: persist an ALREADY-NORMALIZED ERP material into the internal
   // erp_material_master cache, then re-sync to prove the idempotent upsert (patch, not a duplicate).
   // NON-PERTURBING by construction: erpCodeA (SMKERP-A-…) is a DIFFERENT value from the BOM drawings
@@ -883,6 +938,7 @@ async function main() {
     `http=${erpResync.status} mode=${S.erpResyncMode} patched=${S.erpResyncPatched}`)
 
   // ── 8. cleanup retires (also the mapping_retire / unit_retire audit actions) ─────────────────────
+  beginPhase('CLEANUP_RETIRES')
   let retiredMappings = 0
   for (const mappingId of [confirmedMappingId, ...createdCandidateIds]) {
     const retire = await req(`${API}/material-mappings/retire${scope()}`, {
@@ -901,6 +957,7 @@ async function main() {
   must('unit rule retire -> 200 retired', unitRetire.ok && S.unitRetireMode === 'retired', `http=${unitRetire.status} mode=${S.unitRetireMode}`)
 
   // ── 9. audit trail: every triggered action left a values-free row for THIS run's project ────────
+  beginPhase('AUDIT_TRAIL')
   let auditActionsCovered = 0
   for (const action of AUDIT_ACTIONS) {
     const audit = await req(`${API}/audit${scope({ projectId: fixture.projectId, action, limit: 100 })}`, { label: `audit-${action}` })
@@ -912,6 +969,7 @@ async function main() {
   S.auditActionsCovered = `${auditActionsCovered}/${AUDIT_ACTIONS.length}`
 
   // ── 10. global leak scan over every collected (non-exempt) response body ─────────────────────────
+  beginPhase('RESPONSE_LEAK_SCAN')
   const sentinels = SELF_SCAN_SENTINELS
   const scanned = COLLECTED.filter((entry) => !entry.exempt)
   const exempted = COLLECTED.filter((entry) => entry.exempt)
@@ -932,8 +990,10 @@ function finish(failed, args) {
   // P2-2 backstop: the OUTPUT itself (summary + checks, i.e. everything this run prints or writes)
   // is scanned against the run's sentinels BEFORE it is emitted. The sanitizing accessors make a hit
   // structurally impossible; a hit here means the output layer was bypassed and the run must FAIL.
+  computeDiagnosticLocus(RESULT)
   S.selfScanClean = leakScan({ summary: S, checks: RESULT.checks }, SELF_SCAN_SENTINELS)
   S.pass = !failed && RESULT.checks.every((c) => c.ok) && S.selfScanClean === true
+  computeFailureClass(RESULT, { fatal: false })
   const block = formatSummaryBlock(S)
   process.stdout.write(`${block}\n`)
   if (args.outDir) {
@@ -950,6 +1010,9 @@ if (invokedDirectly) {
     process.stderr.write(`[smoke] fatal: ${error && error.name ? error.name : 'Error'}\n`)
     RESULT.summary.pass = false
     RESULT.summary.fatal = true
+    computeDiagnosticLocus(RESULT)
+    RESULT.summary.selfScanClean = leakScan({ summary: RESULT.summary, checks: RESULT.checks }, SELF_SCAN_SENTINELS)
+    computeFailureClass(RESULT, { fatal: true })
     process.stdout.write(`${formatSummaryBlock(RESULT.summary)}\n`)
     process.exitCode = 1
   })

--- a/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
+++ b/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
@@ -79,17 +79,17 @@ function beginPhase(name) {
 // The 4 LOCUS fields (added before the self-scan so it covers them). `result` + sentinels are passed in
 // for testability. lastCompletedPhase: on a run that reached the last phase, everything completed; an
 // early-return/throw within phase i means the last COMPLETED phase is i-1 (early-returns are mid-phase).
-export function computeDiagnosticLocus(result, sentinels = SELF_SCAN_SENTINELS) {
+export function computeDiagnosticLocus(result) {
   const S = result.summary
   const failedChecks = result.checks.filter((c) => c.ok !== true)
   const reachedIdx = DIAG.reachedIdx
   const last = SMOKE_PHASES.length - 1
   S.failedCheckCount = failedChecks.length
   S.lastCompletedPhase = reachedIdx >= last ? SMOKE_PHASES[last] : (reachedIdx > 0 ? SMOKE_PHASES[reachedIdx - 1] : 'NONE')
-  // check names are fixed hardcoded literals; the extra leakScan guard makes firstFailedCheck values-free
-  // even if a future name interpolated a value (it would surface as REDACTED, never the value).
-  const name = failedChecks.length ? String(failedChecks[0].name) : 'NONE'
-  S.firstFailedCheck = leakScan(name, sentinels) ? name : 'REDACTED'
+  // firstFailedCheck is the PHASE of the first failed check — a FIXED enum, never a free-form check name
+  // (a name could contain a value); each check records its phase at push time.
+  const firstPhase = failedChecks.length ? String(failedChecks[0].phase || 'NONE') : 'NONE'
+  S.firstFailedCheck = (firstPhase === 'NONE' || SMOKE_PHASES.includes(firstPhase)) ? firstPhase : 'UNKNOWN'
   S.responseLeakScanStatus = (reachedIdx >= last && typeof S.leakScanClean === 'boolean')
     ? (S.leakScanClean ? 'PASS' : 'FAIL')
     : 'NOT_RUN'
@@ -427,7 +427,7 @@ export function formatSummaryBlock(summary) {
 }
 
 function check(name, ok, detail = '') {
-  RESULT.checks.push({ name, ok: ok === true, detail })
+  RESULT.checks.push({ name, ok: ok === true, detail, phase: RESULT.summary.reachedPhase || 'NONE' })
   const mark = ok === true ? 'ok' : 'FAIL'
   process.stderr.write(`[smoke] ${name}: ${mark}${detail ? ` (${detail})` : ''}\n`)
   return ok === true

--- a/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
+++ b/scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs
@@ -439,12 +439,19 @@ function check(name, ok, detail = '') {
   return ok === true
 }
 
-async function requestJson(baseUrl, pathname, { token, timeoutMs, method = 'GET', body, accept = [200], label = '', leakExempt = false } = {}) {
+async function requestJson(baseUrl, pathname, { token, timeoutMs, tenantId, method = 'GET', body, accept = [200], label = '', leakExempt = false } = {}) {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
   try {
     const headers = { Accept: 'application/json' }
     if (token) headers.Authorization = `Bearer ${token}`
+    // Tenant context rides the platform's tenant-context HEADER, not only the query string. The
+    // tenant-hardened WRITE routes (resolveAuthUserTenantId) deliberately ignore request query/body
+    // tenant params; for a principal without an intrinsic tenant claim, the deployment's sanctioned
+    // context mechanism is the x-tenant-id header (jwt-middleware backfill). Without this header the
+    // smoke fails its FIRST write (mvp/ensure -> 400 TENANT_REQUIRED) on any post-hardening package —
+    // the RC-0 corrective-4 entity failure (auditActionsCovered=N/8) reproduced locally.
+    if (tenantId) headers['x-tenant-id'] = tenantId
     const init = { method, headers, signal: controller.signal }
     if (body !== undefined) {
       headers['Content-Type'] = 'application/json'
@@ -484,7 +491,7 @@ async function main() {
   const S = RESULT.summary
   let failed = false
   const must = (name, ok, detail) => { if (!check(name, ok, detail)) failed = true }
-  const req = (pathname, options) => requestJson(args.baseUrl, pathname, { token, timeoutMs: args.timeoutMs, ...options })
+  const req = (pathname, options) => requestJson(args.baseUrl, pathname, { token, timeoutMs: args.timeoutMs, tenantId: args.tenantId, ...options })
   const scope = (extra) => scopeQuery(args, extra)
   SELF_SCAN_SENTINELS = [...fixture.sentinels, ...ENGINE_MESSAGE_SENTINELS]
   S.salt = salt

--- a/scripts/ops/stock-preparation-mvp-postdeploy-smoke.test.mjs
+++ b/scripts/ops/stock-preparation-mvp-postdeploy-smoke.test.mjs
@@ -286,3 +286,29 @@ test('computeFailureClass: NONE on pass, FATAL_EXCEPTION on throw, SELF_SCAN_FAI
   r = mk({ pass: false, selfScanClean: false }); computeFailureClass(r); assert.equal(r.summary.failureClass, 'SELF_SCAN_FAILED')
   r = mk({ pass: false, selfScanClean: true }); computeFailureClass(r); assert.equal(r.summary.failureClass, 'CHECK_FAILED')
 })
+
+test('computeDiagnosticLocus: a THROW inside RESPONSE_LEAK_SCAN (leakScanClean not yet produced) reports AUDIT_TRAIL + NOT_RUN — never the contradictory completed-pair', () => {
+  // Owner P2 repro: reached the final phase but died before leakScanClean was assigned.
+  const result = { summary: { leakScanClean: undefined }, checks: [{ name: 'x', ok: true, phase: 'AUDIT_TRAIL' }] }
+  computeDiagnosticLocus(result, SMOKE_PHASES.length - 1)
+  assert.equal(result.summary.lastCompletedPhase, 'AUDIT_TRAIL')
+  assert.equal(result.summary.responseLeakScanStatus, 'NOT_RUN')
+  // the contradictory pair must be impossible: completed-last implies a boolean product
+  assert.notEqual(result.summary.lastCompletedPhase === 'RESPONSE_LEAK_SCAN' && result.summary.responseLeakScanStatus === 'NOT_RUN', true)
+  // and a FAIL product still counts as completed (completed ≠ clean):
+  const failed = { summary: { leakScanClean: false }, checks: [] }
+  computeDiagnosticLocus(failed, SMOKE_PHASES.length - 1)
+  assert.equal(failed.summary.lastCompletedPhase, 'RESPONSE_LEAK_SCAN')
+  assert.equal(failed.summary.responseLeakScanStatus, 'FAIL')
+})
+
+test('diagnostic output face is EXACTLY the five declared fields (no reachedPhase or other internals leak into the summary)', () => {
+  const result = { summary: { leakScanClean: true }, checks: [] }
+  computeDiagnosticLocus(result, SMOKE_PHASES.length - 1)
+  computeFailureClass(result)
+  const diagKeys = Object.keys(result.summary).filter((k) => k !== 'leakScanClean')
+  assert.deepEqual(diagKeys.sort(), [
+    'failedCheckCount', 'failureClass', 'firstFailedCheck', 'lastCompletedPhase', 'responseLeakScanStatus',
+  ])
+  assert.ok(!('reachedPhase' in result.summary), 'internal phase cursor must never appear in the output face')
+})

--- a/scripts/ops/stock-preparation-mvp-postdeploy-smoke.test.mjs
+++ b/scripts/ops/stock-preparation-mvp-postdeploy-smoke.test.mjs
@@ -7,6 +7,9 @@ import {
   ALLOWED_MODES,
   ALLOWED_STATUS_VALUES,
   AUDIT_ACTIONS,
+  SMOKE_PHASES,
+  computeDiagnosticLocus,
+  computeFailureClass,
   DIFF_ROW_KEYS,
   ENGINE_MESSAGE_SENTINELS,
   MISSING,
@@ -231,4 +234,55 @@ test('safeHandle admits only platform handle shapes', () => {
   assert.equal(safeHandle('MAT-001'), UNREGISTERED)
   assert.equal(safeHandle(''), MISSING)
   assert.equal(safeHandle(42), UNREGISTERED)
+})
+
+// ── corrective-5: bounded values-free diagnostic contract ────────────────────────────────────────
+test('SMOKE_PHASES is the closed 13-phase ladder with no values-free-forbidden substrings', () => {
+  assert.equal(SMOKE_PHASES.length, 13)
+  assert.equal(SMOKE_PHASES[0], 'AUTH')
+  assert.equal(SMOKE_PHASES[SMOKE_PHASES.length - 1], 'RESPONSE_LEAK_SCAN')
+  for (const p of SMOKE_PHASES) {
+    assert.ok(/^[A-Z_]+$/.test(p), `phase token ${p} must be an all-caps enum`)
+    assert.ok(!/drawing|qty|quantity|unit|material|host|token|password|secret/i.test(p), `phase token ${p} must not contain a forbidden substring`)
+  }
+})
+
+test('computeDiagnosticLocus: a check-failed early-return localizes to the phase before the stop + the first failed phase', () => {
+  const result = {
+    summary: { leakScanClean: undefined },
+    checks: [
+      { name: 'auth ok', ok: true, phase: 'AUTH' },
+      { name: 'readiness covers 9', ok: false, phase: 'PROVISIONING' },
+      { name: 'options synced', ok: false, phase: 'PROVISIONING' },
+    ],
+  }
+  computeDiagnosticLocus(result, SMOKE_PHASES.indexOf('PROVISIONING')) // stopped in PROVISIONING
+  assert.equal(result.summary.lastCompletedPhase, 'AUTH')       // AUTH completed, PROVISIONING did not
+  assert.equal(result.summary.firstFailedCheck, 'PROVISIONING') // first failed check's phase — a fixed enum
+  assert.equal(result.summary.failedCheckCount, 2)
+  assert.equal(result.summary.responseLeakScanStatus, 'NOT_RUN') // never reached the leak-scan phase
+})
+
+test('computeDiagnosticLocus: firstFailedCheck is a FIXED enum — an off-vocabulary check.phase becomes UNKNOWN, never a value', () => {
+  const result = { summary: {}, checks: [{ name: 'x', ok: false, phase: 'DWG-88472-A material Q235' }] }
+  computeDiagnosticLocus(result, 2)
+  assert.equal(result.summary.firstFailedCheck, 'UNKNOWN')
+  assert.ok(!/DWG-88472|Q235|material/.test(result.summary.firstFailedCheck))
+})
+
+test('computeDiagnosticLocus: a full pass reaching the last phase reports RESPONSE_LEAK_SCAN completed + PASS', () => {
+  const result = { summary: { leakScanClean: true }, checks: [{ name: 'x', ok: true, phase: 'RESPONSE_LEAK_SCAN' }] }
+  computeDiagnosticLocus(result, SMOKE_PHASES.length - 1)
+  assert.equal(result.summary.lastCompletedPhase, 'RESPONSE_LEAK_SCAN')
+  assert.equal(result.summary.firstFailedCheck, 'NONE')
+  assert.equal(result.summary.failedCheckCount, 0)
+  assert.equal(result.summary.responseLeakScanStatus, 'PASS')
+})
+
+test('computeFailureClass: NONE on pass, FATAL_EXCEPTION on throw, SELF_SCAN_FAILED, else CHECK_FAILED', () => {
+  const mk = (over) => { const r = { summary: over }; return r }
+  let r = mk({ pass: true }); computeFailureClass(r); assert.equal(r.summary.failureClass, 'NONE')
+  r = mk({ pass: false }); computeFailureClass(r, { fatal: true }); assert.equal(r.summary.failureClass, 'FATAL_EXCEPTION')
+  r = mk({ pass: false, selfScanClean: false }); computeFailureClass(r); assert.equal(r.summary.failureClass, 'SELF_SCAN_FAILED')
+  r = mk({ pass: false, selfScanClean: true }); computeFailureClass(r); assert.equal(r.summary.failureClass, 'CHECK_FAILED')
 })

--- a/scripts/ops/stock-preparation-mvp-postdeploy-smoke.test.mjs
+++ b/scripts/ops/stock-preparation-mvp-postdeploy-smoke.test.mjs
@@ -7,6 +7,8 @@ import {
   ALLOWED_MODES,
   ALLOWED_STATUS_VALUES,
   AUDIT_ACTIONS,
+  buildRequestHeaders,
+  requestJson,
   SMOKE_PHASES,
   computeDiagnosticLocus,
   computeFailureClass,
@@ -311,4 +313,47 @@ test('diagnostic output face is EXACTLY the five declared fields (no reachedPhas
     'failedCheckCount', 'failureClass', 'firstFailedCheck', 'lastCompletedPhase', 'responseLeakScanStatus',
   ])
   assert.ok(!('reachedPhase' in result.summary), 'internal phase cursor must never appear in the output face')
+})
+
+// ── corrective-5 root-cause guard (owner P2): the tenant-context HEADER is load-bearing ──────────────
+// Deleting the x-tenant-id line passed 22/22 before — because nothing exercised requestJson's headers.
+// These drive the REAL requestJson via an injected fetch and assert the header contract; the delete
+// mutation now reds.
+test('buildRequestHeaders: tenant present -> x-tenant-id sent alongside Authorization; body -> Content-Type', () => {
+  const h = buildRequestHeaders({ token: 'tok', tenantId: 'tenant-9', hasBody: true })
+  assert.equal(h['x-tenant-id'], 'tenant-9')
+  assert.equal(h.Authorization, 'Bearer tok')
+  assert.equal(h['Content-Type'], 'application/json')
+})
+
+test('buildRequestHeaders: tenant absent -> NO x-tenant-id, Authorization still present', () => {
+  const h = buildRequestHeaders({ token: 'tok', tenantId: '', hasBody: false })
+  assert.equal('x-tenant-id' in h, false)
+  assert.equal(h.Authorization, 'Bearer tok')
+  assert.equal('Content-Type' in h, false)
+})
+
+test('requestJson actually SENDS x-tenant-id on a write (POST) — the entity N/8 root-cause guard', async () => {
+  const seen = []
+  const fetchImpl = async (url, init) => {
+    seen.push({ url, headers: { ...init.headers }, method: init.method, body: init.body })
+    return { status: 201, text: async () => JSON.stringify({ ok: true }) }
+  }
+  const res = await requestJson('http://x', '/api/integration/stock-preparation/mvp/ensure', {
+    token: 'tok', tenantId: 'tenant-9', timeoutMs: 1000, method: 'POST', body: { a: 1 }, accept: [201], fetchImpl,
+  })
+  assert.equal(res.status, 201)
+  assert.equal(seen.length, 1)
+  assert.equal(seen[0].headers['x-tenant-id'], 'tenant-9') // WITHOUT the header line the entity 400s TENANT_REQUIRED
+  assert.equal(seen[0].headers.Authorization, 'Bearer tok')
+  assert.equal(seen[0].method, 'POST')
+  assert.equal(seen[0].body, JSON.stringify({ a: 1 }))
+})
+
+test('requestJson omits x-tenant-id when no tenant is configured, but still sends Authorization', async () => {
+  const seen = []
+  const fetchImpl = async (url, init) => { seen.push({ ...init.headers }); return { status: 200, text: async () => '{}' } }
+  await requestJson('http://x', '/api/integration/status', { token: 'tok', tenantId: '', timeoutMs: 1000, fetchImpl })
+  assert.equal('x-tenant-id' in seen[0], false)
+  assert.equal(seen[0].Authorization, 'Bearer tok')
 })

--- a/scripts/ops/stock-preparation-onprem-acceptance.ps1
+++ b/scripts/ops/stock-preparation-onprem-acceptance.ps1
@@ -77,6 +77,14 @@ $Summary = [ordered]@{
   'mvpSmoke.pass'        = 'false'
   auditActionsCovered    = 'N/8'
   selfScanClean          = 'false'
+  # corrective-5 bounded values-free diagnostics — propagated even when the smoke exits 1 so an
+  # early-return/throw is localizable (the runner discards the child's raw stdout/stderr). All fixed
+  # enums / a non-negative integer / a length-capped safe-label; never a business value.
+  'mvpSmoke.failureClass'           = 'NOT_RUN'
+  'mvpSmoke.lastCompletedPhase'     = 'NOT_RUN'
+  'mvpSmoke.firstFailedCheck'       = 'NOT_RUN'
+  'mvpSmoke.failedCheckCount'       = '0'
+  'mvpSmoke.responseLeakScanStatus' = 'NOT_RUN'
   externalPlmK3ErpWrite  = 'false'   # invariant: this line NEVER touches an external write.
   failedStage            = 'none'
 }
@@ -202,7 +210,29 @@ function Test-SmokeOutcome {
   if (-not $pass) { $ok = $false; $reason = 'smoke_not_pass' }
   elseif ($audit -ne '8/8') { $ok = $false; $reason = 'audit_incomplete' }
   elseif (-not $selfScan) { $ok = $false; $reason = 'self_scan_not_clean' }
-  return @{ pass = $pass; audit = $audit; selfScan = $selfScan; ok = $ok; reason = $reason }
+
+  # ── corrective-5: parse the bounded values-free diagnostics. The 4 enum fields are allowlisted (any
+  # off-vocabulary token becomes UNKNOWN, never a raw value); firstFailedCheck is a structural check label
+  # accepted ONLY if it matches a safe-label shape and is length-capped — so a wild/leaky value can never
+  # reach the runner summary (the smoke additionally REDACTs it upstream).
+  $allowedFailure = @('NONE', 'CHECK_FAILED', 'SELF_SCAN_FAILED', 'FATAL_EXCEPTION')
+  $allowedPhase = @('NONE', 'AUTH', 'PROVISIONING', 'SYNC_PERSIST', 'PROJECTS', 'SNAPSHOT_DIFF', 'MAPPINGS',
+    'CONVERSIONS', 'GENERATION_RUN', 'FAILCLOSED_PROBES', 'ERP_CACHE_SYNC', 'CLEANUP_RETIRES', 'AUDIT_TRAIL',
+    'RESPONSE_LEAK_SCAN')
+  $failureClass = if ($Joined -match '(?m)^failureClass=([A-Za-z_]+)\s*$') { $Matches[1] } else { 'NOT_RUN' }
+  if ($failureClass -ne 'NOT_RUN' -and $allowedFailure -notcontains $failureClass) { $failureClass = 'UNKNOWN' }
+  $lastPhase = if ($Joined -match '(?m)^lastCompletedPhase=([A-Za-z_]+)\s*$') { $Matches[1] } else { 'NOT_RUN' }
+  if ($lastPhase -ne 'NOT_RUN' -and $allowedPhase -notcontains $lastPhase) { $lastPhase = 'UNKNOWN' }
+  $leakScan = if ($Joined -match '(?m)^responseLeakScanStatus=(NOT_RUN|PASS|FAIL)\s*$') { $Matches[1] } else { 'NOT_RUN' }
+  $failedCount = if ($Joined -match '(?m)^failedCheckCount=(\d{1,4})\s*$') { $Matches[1] } else { '0' }
+  $firstFailed = if ($Joined -match '(?m)^firstFailedCheck=(.+?)\s*$') { $Matches[1] } else { 'NOT_RUN' }
+  if ($firstFailed -notmatch '^[A-Za-z0-9 _/:>=.,()\-]{1,80}$') { $firstFailed = 'UNKNOWN' }
+
+  return @{
+    pass = $pass; audit = $audit; selfScan = $selfScan; ok = $ok; reason = $reason
+    failureClass = $failureClass; lastCompletedPhase = $lastPhase; firstFailedCheck = $firstFailed
+    failedCheckCount = $failedCount; responseLeakScanStatus = $leakScan
+  }
 }
 
 # ── Read the admin token WITHOUT ever exposing it (env var, else secure prompt). ─────────────────
@@ -409,6 +439,13 @@ function Invoke-SmokeStage {
   $Summary['mvpSmoke.pass'] = if ($outcome.pass) { 'true' } else { 'false' }
   $Summary.auditActionsCovered = $outcome.audit
   $Summary.selfScanClean = if ($outcome.selfScan) { 'true' } else { 'false' }
+  # corrective-5: propagate the bounded diagnostics INTO the summary BEFORE the exit/outcome gates below,
+  # so an exit-1 smoke (Stop-WithFailure) still emits them in the values-free acceptance summary.
+  $Summary['mvpSmoke.failureClass'] = $outcome.failureClass
+  $Summary['mvpSmoke.lastCompletedPhase'] = $outcome.lastCompletedPhase
+  $Summary['mvpSmoke.firstFailedCheck'] = $outcome.firstFailedCheck
+  $Summary['mvpSmoke.failedCheckCount'] = $outcome.failedCheckCount
+  $Summary['mvpSmoke.responseLeakScanStatus'] = $outcome.responseLeakScanStatus
   # Fail-closed: a green exit is NOT a steady state unless the audit surface is fully covered (8/8) and
   # the self-scan is clean. An absent/unparseable field records 'N/8'/'false' and FAILS here — it never
   # passes silently (owner P2).

--- a/scripts/ops/stock-preparation-onprem-acceptance.ps1
+++ b/scripts/ops/stock-preparation-onprem-acceptance.ps1
@@ -225,8 +225,9 @@ function Test-SmokeOutcome {
   if ($lastPhase -ne 'NOT_RUN' -and $allowedPhase -notcontains $lastPhase) { $lastPhase = 'UNKNOWN' }
   $leakScan = if ($Joined -match '(?m)^responseLeakScanStatus=(NOT_RUN|PASS|FAIL)\s*$') { $Matches[1] } else { 'NOT_RUN' }
   $failedCount = if ($Joined -match '(?m)^failedCheckCount=(\d{1,4})\s*$') { $Matches[1] } else { '0' }
-  $firstFailed = if ($Joined -match '(?m)^firstFailedCheck=(.+?)\s*$') { $Matches[1] } else { 'NOT_RUN' }
-  if ($firstFailed -notmatch '^[A-Za-z0-9 _/:>=.,()\-]{1,80}$') { $firstFailed = 'UNKNOWN' }
+  # firstFailedCheck is the PHASE of the first failed check — allowlisted like lastCompletedPhase.
+  $firstFailed = if ($Joined -match '(?m)^firstFailedCheck=([A-Za-z_]+)\s*$') { $Matches[1] } else { 'NOT_RUN' }
+  if ($firstFailed -ne 'NOT_RUN' -and $allowedPhase -notcontains $firstFailed) { $firstFailed = 'UNKNOWN' }
 
   return @{
     pass = $pass; audit = $audit; selfScan = $selfScan; ok = $ok; reason = $reason


### PR DESCRIPTION
## corrective-5 — bounded values-free diagnostic contract (Draft; local real-service PASS still pending)

**Refs #4101.** RC-0 stays FAIL. This does NOT request an entity rerun and does NOT cut a package.

### Why
corrective-4 fixed the PS 5.1 capture, but the packaged smoke still exits 1 with `auditActionsCovered=N/8` — **uninterpretable**, because the runner discards the child's stdout/stderr. `N/8` means the audit-assignment line was never reached (an early-return/throw in an earlier phase), NOT `0/8`; and `selfScanClean=true` only proves the finish() backstop ran, not that the phase-10 full-response leak-scan completed.

### What
A **bounded values-free diagnostic contract** the runner propagates even on exit 1:
```
failureClass=NONE|CHECK_FAILED|SELF_SCAN_FAILED|FATAL_EXCEPTION
lastCompletedPhase=<fixed 13-phase enum | NONE>
firstFailedCheck=<phase of the first failed check — a fixed enum | NONE>
failedCheckCount=<non-negative integer>
responseLeakScanStatus=NOT_RUN|PASS|FAIL
```
- **Smoke** (`stock-preparation-mvp-postdeploy-smoke.mjs`): a fixed `SMOKE_PHASES` ladder + `beginPhase()` markers; `computeDiagnosticLocus()` runs **before** the finish()/catch self-scan so the scan covers the diagnostics. `firstFailedCheck` is the **phase** of the first failed check (each check stamps its phase), never a free-form check name — a leak-hardening test proved a safe-label-shaped business value in a free-form name would surface.
- **Runner** (`stock-preparation-onprem-acceptance.ps1`): `Test-SmokeOutcome` parses the 5 fields; `Invoke-SmokeStage` propagates them **before** the exit/outcome gates. The 4 enum fields are allowlisted (off-vocabulary → `UNKNOWN`); a non-enum-shaped value → `NOT_RUN`. No raw value can reach the values-free summary.

### Validated
- End-to-end on both failure modes: unreachable URL → `FATAL_EXCEPTION`; a 200-stub that fails provisioning → `CHECK_FAILED`, `lastCompletedPhase=AUTH`, `firstFailedCheck=PROVISIONING` (reproduces the entity's early-return mode and localizes it).
- Tests: smoke unit **20/0**; runner static **14-field** whitelist; runner behavior **40/40** (incl. exit-1 propagation + a business-value-diagnostic leak-hardening test); **ps51** adds real-Windows-PowerShell-5.1 diagnostic-stdout capture + exact non-zero exit (and fixes the corrective-4 NIT-1 `\\n`→`\n`).
- Mutations proven load-bearing: drop the runner propagation → propagation test reds; drop the phase allowlist → leak-hardening test reds.

### Still open (the owner's gate before the next package)
Per the sequence, a **local real-service rehearsal reaching `pass=true` / `8/8` / `selfScanClean=true`** is required before cutting the corrective-5 entity package. The diagnostic contract now makes any run — local or entity — self-localizing. Standing up the full backend locally is the next step; not done in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
