### PR TITLE
feat(stock-prep): T3b-1c prep — structural config guard for fieldMap.target=missingChildBom (Draft)

### DIFF
--- a/docs/development/stock-preparation-t3b-plm-source-autopersist-design-lock-20260716.md
+++ b/docs/development/stock-preparation-t3b-plm-source-autopersist-design-lock-20260716.md
@@ -185,6 +185,19 @@ closed set；实现与验收不得依赖 config shape validation 或 records ser
 某个 PLM 的 `released` / `obsolete` / `WIP` 语义时，必须先另开具名 mapping design gate；本锁
 不授权隐式映射。
 
+**结构性 config guard（owner P2，2026-07-16 复审补强）**：value-level 422 抓不住**组合映射
+绕过** —— approved config 同时把某列 target 配成内部 marker 名 `missingChildBom`（布尔）并显式
+映射 `lineStatus`（如 `active`）时，intake 优先保留显式 status、marker 在下游被静默丢弃，
+缺子 BOM 信号端到端消失且整包 422 永不触发。因此 **T3b-1c 路由必须在任何 source read /
+provisioning / persist I/O 之前**，对 approved config 调用纯守卫
+`assertPlmAutoPersistSourceConfigSafe(config)`（bridge 模块导出）：`fieldMap.target ∈
+FORBIDDEN_FIELD_MAP_TARGETS`（当前 = `missingChildBom`）→ 专用 values-free 422
+`STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_TARGET_FORBIDDEN`；fieldMap 缺失/非数组 → 422
+`STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_SHAPE_INVALID`。error details 只含 forbidden
+TARGET 词表，绝不含 source 列名。1c 接线测试必须证明该拒绝路径 **records/provisioning/
+source-adapter 调用计数为 0**。已有的 `lineStatus='missing_child_bom'` 值级整包 422 保持不变；
+**不采用** missing_child_bom → incomplete 的静默归一（Option B 有丢信号风险）。
+
 ### OD-4 — idempotency、不可变性与已知原子性边界
 
 **裁决：分两级。**
@@ -333,6 +346,7 @@ values-free summary 不足以定位首个失败 phase。#4101 的诊断/修复�
 - 把 `imported` 原样写入 select contract；
 - 放行任意 source-mapped lifecycle，或把 unsupported lifecycle 静默改成 `active`；
 - 把 unsupported lifecycle 的原始值放进 error details；
+- 去掉/绕过 `assertPlmAutoPersistSourceConfigSafe`（config guard 在 I/O 之后才调、或 `missingChildBom` 从 forbidden targets 移除）；
 - 把 existing-batch completeness/content conflict 恢复成无条件 skip；
 - 把完整 line 投影判等退化成 `snapshotLineId + sourceFingerprint` 判等；
 - 只读取 existing lines 第一页，或把 page-bound 当成完整结果；

--- a/docs/development/stock-preparation-t3b-plm-source-autopersist-design-lock-20260716.md
+++ b/docs/development/stock-preparation-t3b-plm-source-autopersist-design-lock-20260716.md
@@ -192,8 +192,8 @@ closed set；实现与验收不得依赖 config shape validation 或 records ser
 provisioning / persist I/O 之前**，对 approved config 调用纯守卫
 `assertPlmAutoPersistSourceConfigSafe(config)`（bridge 模块导出）：`fieldMap.target ∈
 FORBIDDEN_FIELD_MAP_TARGETS`（当前 = `missingChildBom`）→ 专用 values-free 422
-`STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_TARGET_FORBIDDEN`；fieldMap 缺失/非数组 → 422
-`STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_SHAPE_INVALID`。error details 只含 forbidden
+`STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_TARGET_FORBIDDEN`；fieldMap 缺失/非数组/**空数组**/**任一畸形 entry(非对象或 target 非非空字符串)** → 422
+`STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_SHAPE_INVALID`(coarse reason,values-free;守卫不依赖上游 validator 永远正确)。error details 只含 forbidden
 TARGET 词表，绝不含 source 列名。1c 接线测试必须证明该拒绝路径 **records/provisioning/
 source-adapter 调用计数为 0**。已有的 `lineStatus='missing_child_bom'` 值级整包 422 保持不变；
 **不采用** missing_child_bom → incomplete 的静默归一（Option B 有丢信号风险）。

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-plm-source-persist-bridge.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-plm-source-persist-bridge.test.cjs
@@ -310,11 +310,22 @@ run('config guard: fieldMap.target=missingChildBom is structurally rejected with
   assert.deepEqual(FORBIDDEN_FIELD_MAP_TARGETS, ['missingChildBom'])
 })
 
-run('config guard: a config without a fieldMap array fails closed (shape invalid), never passes silently', () => {
-  for (const bad of [null, {}, { fieldMap: 'nope' }, { fieldMap: null }]) {
+run('config guard is fully shape-fail-closed: empty array + every malformed entry throws SHAPE_INVALID (owner P2, #4391)', () => {
+  const badConfigs = [
+    null, undefined, 'nope', 42,
+    {}, { fieldMap: null }, { fieldMap: 'nope' }, { fieldMap: {} },
+    { fieldMap: [] },                          // empty array (was previously ACCEPTED)
+    { fieldMap: [null] },                      // null entry (was ACCEPTED)
+    { fieldMap: [{}] },                        // entry without target (was ACCEPTED)
+    { fieldMap: [{ target: 42 }] },            // non-string target (was ACCEPTED)
+    { fieldMap: [{ target: '' }] },            // empty-string target
+    { fieldMap: [{ source: 'x', target: 'ok' }, {}] }, // one valid + one malformed → whole config rejected
+  ]
+  for (const bad of badConfigs) {
     assert.throws(() => assertPlmAutoPersistSourceConfigSafe(bad), (error) =>
       error instanceof StockPreparationPlmSourcePersistBridgeError &&
-      error.status === 422 && error.code === 'STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_SHAPE_INVALID')
+      error.status === 422 && error.code === 'STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_SHAPE_INVALID',
+      `expected SHAPE_INVALID for ${JSON.stringify(bad)}`)
   }
 })
 

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-plm-source-persist-bridge.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-plm-source-persist-bridge.test.cjs
@@ -274,4 +274,71 @@ run('module dependency surface is pure and contains no platform I/O calls', () =
   }
 })
 
+
+// ── T3b-1c structural config guard (owner P2): fieldMap.target=missingChildBom must be rejected at the
+// CONFIG level, because the marker+explicit-status combination is invisible to the value-level 422. ────
+const {
+  FORBIDDEN_FIELD_MAP_TARGETS,
+  assertPlmAutoPersistSourceConfigSafe,
+} = require(path.join(__dirname, '..', 'lib', 'stock-preparation-plm-source-persist-bridge.cjs'))
+
+run('config guard: a clean fieldMap passes', () => {
+  assert.doesNotThrow(() => assertPlmAutoPersistSourceConfigSafe({
+    fieldMap: [
+      { source: 'path', target: 'pathKey' },
+      { source: 'childCode', target: 'childDrawingNo' },
+      { source: 'quantity', target: 'designQty' },
+    ],
+  }))
+})
+
+run('config guard: fieldMap.target=missingChildBom is structurally rejected with the dedicated coarse 422', () => {
+  let thrown = null
+  try {
+    assertPlmAutoPersistSourceConfigSafe({
+      fieldMap: [
+        { source: 'path', target: 'pathKey' },
+        { source: 'HasMissingChild', target: 'missingChildBom' },
+      ],
+    })
+  } catch (error) { thrown = error }
+  assert.ok(thrown instanceof StockPreparationPlmSourcePersistBridgeError)
+  assert.equal(thrown.status, 422)
+  assert.equal(thrown.code, 'STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_TARGET_FORBIDDEN')
+  // values-free: details name only the forbidden TARGET vocabulary, never the source column.
+  assert.equal(JSON.stringify(thrown.details).includes('HasMissingChild'), false)
+  assert.deepEqual(FORBIDDEN_FIELD_MAP_TARGETS, ['missingChildBom'])
+})
+
+run('config guard: a config without a fieldMap array fails closed (shape invalid), never passes silently', () => {
+  for (const bad of [null, {}, { fieldMap: 'nope' }, { fieldMap: null }]) {
+    assert.throws(() => assertPlmAutoPersistSourceConfigSafe(bad), (error) =>
+      error instanceof StockPreparationPlmSourcePersistBridgeError &&
+      error.status === 422 && error.code === 'STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_SHAPE_INVALID')
+  }
+})
+
+run('WHY the config guard is load-bearing (owner bypass repro): marker+explicit-active rows PASS the value-level bridge — the marker is silently dropped, so only the config guard can catch it', () => {
+  // A config mapping {target: missingChildBom} + {target: lineStatus} produces intake rows like this:
+  const bypass = intake({
+    bomSnapshotLines: [line({ missingChildBom: true, lineStatus: 'active' })],
+  })
+  // The bridge ACCEPTS this envelope (lineStatus 'active' is canonical) and its closed projection drops
+  // the marker — no 422 fires anywhere at the VALUE level. This is exactly the silent-signal-loss path
+  // the structural config guard exists to close, BEFORE any source read happens.
+  const out = buildPlmSourcePersistInput({ request: request(), intake: bypass })
+  assert.equal(out.expansionResult.length, 1)
+  assert.equal(out.expansionResult[0].lineStatus, 'active')
+  assert.equal('missingChildBom' in out.expansionResult[0], false)
+})
+
+run('config guard is pure: no I/O tokens and no new requires in the module source', () => {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'lib', 'stock-preparation-plm-source-persist-bridge.cjs'), 'utf8')
+  const requiredModules = [...source.matchAll(/require\('([^']+)'\)/g)].map((match) => match[1])
+  assert.deepEqual(requiredModules, ['./stock-preparation-common.cjs'])
+  for (const token of ['queryRecords(', 'createRecord(', 'patchRecord(', 'fetch(', 'getForRuntime(']) {
+    assert.equal(source.includes(token), false, `${token} is absent from the pure bridge`)
+  }
+})
+
 process.stdout.write('all stock-preparation-plm-source-persist-bridge tests passed\n')

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-plm-source-persist-bridge.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-plm-source-persist-bridge.test.cjs
@@ -320,6 +320,8 @@ run('config guard is fully shape-fail-closed: empty array + every malformed entr
     { fieldMap: [{ target: 42 }] },            // non-string target (was ACCEPTED)
     { fieldMap: [{ target: '' }] },            // empty-string target
     { fieldMap: [{ source: 'x', target: 'ok' }, {}] }, // one valid + one malformed → whole config rejected
+    (() => { const a = []; a.target = 'missingChildBom'; return { fieldMap: [a] } })(), // array-carrying-prop entry (owner P3)
+    { fieldMap: [Object.assign(Object.create({ target: 'ok' }), {})] }, // prototype-bearing entry (owner P3)
   ]
   for (const bad of badConfigs) {
     assert.throws(() => assertPlmAutoPersistSourceConfigSafe(bad), (error) =>

--- a/plugins/plugin-integration-core/lib/stock-preparation-plm-source-persist-bridge.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-plm-source-persist-bridge.cjs
@@ -169,24 +169,31 @@ function buildPlmSourcePersistInput({ request, intake } = {}) {
 // The T3b-1c route MUST call this on the approved config BEFORE any source read / provisioning / persist
 // I/O. Pure: inspects only the given config object; throws the dedicated coarse 422 (values-free).
 const FORBIDDEN_FIELD_MAP_TARGETS = Object.freeze(['missingChildBom'])
+function configShapeInvalid(reason) {
+  throw new StockPreparationPlmSourcePersistBridgeError(
+    422,
+    'STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_SHAPE_INVALID',
+    'approved source config fieldMap is malformed for the auto-persisting PLM source-run',
+    { field: 'fieldMap', reason },
+  )
+}
 function assertPlmAutoPersistSourceConfigSafe(config) {
-  const fieldMap = config && Array.isArray(config.fieldMap) ? config.fieldMap : null
-  if (!fieldMap) {
-    throw new StockPreparationPlmSourcePersistBridgeError(
-      422,
-      'STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_SHAPE_INVALID',
-      'approved source config must carry a fieldMap array',
-      { field: 'fieldMap' },
-    )
-  }
-  for (const entry of fieldMap) {
-    const target = entry && typeof entry.target === 'string' ? entry.target : ''
-    if (FORBIDDEN_FIELD_MAP_TARGETS.includes(target)) {
+  // Fail-closed by construction (owner P2, #4391 review): this helper is defined as T3b-1c's independent,
+  // pre-I/O safety boundary and must NOT lean on an upstream validator always being correct. A non-array
+  // fieldMap, an EMPTY fieldMap, or ANY malformed entry (non-object, or a non-string / empty `target`) is
+  // rejected here — before it can reach source read / provisioning / persist.
+  if (!config || typeof config !== 'object') configShapeInvalid('config_object_required')
+  if (!Array.isArray(config.fieldMap)) configShapeInvalid('fieldmap_array_required')
+  if (config.fieldMap.length < 1) configShapeInvalid('fieldmap_empty')
+  for (const entry of config.fieldMap) {
+    if (!entry || typeof entry !== 'object') configShapeInvalid('entry_object_required')
+    if (typeof entry.target !== 'string' || entry.target.length === 0) configShapeInvalid('entry_target_string_required')
+    if (FORBIDDEN_FIELD_MAP_TARGETS.includes(entry.target)) {
       throw new StockPreparationPlmSourcePersistBridgeError(
         422,
         'STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_TARGET_FORBIDDEN',
         'approved source config maps a forbidden internal marker target for the auto-persisting PLM source-run',
-        { target, forbiddenTargets: FORBIDDEN_FIELD_MAP_TARGETS.slice() },
+        { target: entry.target, forbiddenTargets: FORBIDDEN_FIELD_MAP_TARGETS.slice() },
       )
     }
   }

--- a/plugins/plugin-integration-core/lib/stock-preparation-plm-source-persist-bridge.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-plm-source-persist-bridge.cjs
@@ -182,11 +182,13 @@ function assertPlmAutoPersistSourceConfigSafe(config) {
   // pre-I/O safety boundary and must NOT lean on an upstream validator always being correct. A non-array
   // fieldMap, an EMPTY fieldMap, or ANY malformed entry (non-object, or a non-string / empty `target`) is
   // rejected here — before it can reach source read / provisioning / persist.
-  if (!config || typeof config !== 'object') configShapeInvalid('config_object_required')
+  // isPlainObject (module convention) rejects arrays-carrying-props and prototype-bearing objects that a
+  // bare `typeof x === 'object'` would wave through (owner P3, #4391).
+  if (!isPlainObject(config)) configShapeInvalid('config_object_required')
   if (!Array.isArray(config.fieldMap)) configShapeInvalid('fieldmap_array_required')
   if (config.fieldMap.length < 1) configShapeInvalid('fieldmap_empty')
   for (const entry of config.fieldMap) {
-    if (!entry || typeof entry !== 'object') configShapeInvalid('entry_object_required')
+    if (!isPlainObject(entry)) configShapeInvalid('entry_object_required')
     if (typeof entry.target !== 'string' || entry.target.length === 0) configShapeInvalid('entry_target_string_required')
     if (FORBIDDEN_FIELD_MAP_TARGETS.includes(entry.target)) {
       throw new StockPreparationPlmSourcePersistBridgeError(

--- a/plugins/plugin-integration-core/lib/stock-preparation-plm-source-persist-bridge.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-plm-source-persist-bridge.cjs
@@ -161,11 +161,44 @@ function buildPlmSourcePersistInput({ request, intake } = {}) {
   return output
 }
 
+// ── T3b-1c structural config guard (owner P2, #4390 review round). The bridge's closed status vocabulary
+// 422s a row whose lineStatus IS 'missing_child_bom' — but a config that maps a target literally named
+// `missingChildBom` (boolean marker) TOGETHER WITH an explicit lineStatus (e.g. 'active') slips the marker
+// past the status check entirely: intake keeps the explicit status and the marker is silently dropped
+// downstream, erasing the missing-child signal. Values cannot catch that combination — the CONFIG must.
+// The T3b-1c route MUST call this on the approved config BEFORE any source read / provisioning / persist
+// I/O. Pure: inspects only the given config object; throws the dedicated coarse 422 (values-free).
+const FORBIDDEN_FIELD_MAP_TARGETS = Object.freeze(['missingChildBom'])
+function assertPlmAutoPersistSourceConfigSafe(config) {
+  const fieldMap = config && Array.isArray(config.fieldMap) ? config.fieldMap : null
+  if (!fieldMap) {
+    throw new StockPreparationPlmSourcePersistBridgeError(
+      422,
+      'STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_SHAPE_INVALID',
+      'approved source config must carry a fieldMap array',
+      { field: 'fieldMap' },
+    )
+  }
+  for (const entry of fieldMap) {
+    const target = entry && typeof entry.target === 'string' ? entry.target : ''
+    if (FORBIDDEN_FIELD_MAP_TARGETS.includes(target)) {
+      throw new StockPreparationPlmSourcePersistBridgeError(
+        422,
+        'STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_TARGET_FORBIDDEN',
+        'approved source config maps a forbidden internal marker target for the auto-persisting PLM source-run',
+        { target, forbiddenTargets: FORBIDDEN_FIELD_MAP_TARGETS.slice() },
+      )
+    }
+  }
+}
+
 module.exports = {
   ACCEPTED_LINE_STATUSES,
   CANONICAL_LINE_STATUSES,
   EXPANSION_ROW_KEYS,
+  FORBIDDEN_FIELD_MAP_TARGETS,
   StockPreparationPlmSourcePersistBridgeError,
+  assertPlmAutoPersistSourceConfigSafe,
   buildPlmSourcePersistInput,
   __internals: {
     canonicalLineStatus,


### PR DESCRIPTION
## T3b-1c prep — structural config guard: `fieldMap.target=missingChildBom` (owner P2)

Per the #4390-round review: Option A (whole-envelope 422 on `lineStatus='missing_child_bom'`) is kept, but doc-only was not enough — the owner constructed a **combined-mapping bypass**: an approved config mapping a target literally named `missingChildBom` (boolean marker) *together with* an explicit `lineStatus=active`. Intake keeps the explicit status, the marker is silently dropped downstream, and the missing-child signal is erased end-to-end — the value-level 422 never fires.

### What
- **Pure guard** `assertPlmAutoPersistSourceConfigSafe(config)` exported from the bridge module: `fieldMap.target ∈ FORBIDDEN_FIELD_MAP_TARGETS` (= `['missingChildBom']`) → dedicated values-free 422 `STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_TARGET_FORBIDDEN` (details carry only the forbidden TARGET vocabulary, never the source column name); missing/non-array `fieldMap` → 422 `..._CONFIG_SHAPE_INVALID` (fail-closed). The T3b-1c route MUST call it on the approved config **before any source read / provisioning / persist I/O**; the wiring test must prove the rejection path has zero records/provisioning/adapter calls.
- **Design-lock OD-3 amended in place**: the guard requirement + zero-I/O test + a dedicated must-kill mutation item ("去掉/绕过 assertPlmAutoPersistSourceConfigSafe"). No `missing_child_bom → incomplete` silent normalization (Option B rejected — signal-loss hazard).
- **Tests** (in the bridge chain, runs under integration-guard): clean config passes; forbidden target → dedicated code with values-free details; shape fail-closed on 4 malformed configs; **the owner's bypass repro pinned as a test** (marker+active PASSES the value-level bridge — documenting exactly why the config guard is load-bearing); module purity re-checked (no new requires/I/O tokens).
- **Mutation-proven**: emptying `FORBIDDEN_FIELD_MAP_TARGETS` reds the guard test (landed-anchor, reverted, green).

The existing `lineStatus='missing_child_bom'` value-level whole-envelope 422 is unchanged. No route wiring in this PR (that's T3b-1c proper); flag posture unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
