### PR TITLE
ops(discussion-pilot): dispatch-only pilot lighting workflow (manual, gated)

### DIFF
--- a/.github/workflows/discussion-pilot-ops.yml
+++ b/.github/workflows/discussion-pilot-ops.yml
@@ -1,0 +1,135 @@
+name: Discussion Pilot Ops (manual)
+
+# Manual, dispatch-only operator workflow for the Discussion 点灯 pilot. Runs a single
+# action per dispatch on the deploy host over SSH (reuses the DEPLOY_* secrets already
+# used by attendance-remote-docker-gc-prod.yml). One action = one dispatch, mirroring the
+# owner's three-口令 protocol: provisioning, lighting the READ flag, and lighting the WRITE
+# flag are SEPARATE dispatches that never chain. All acceptance traffic stays on the host's
+# 127.0.0.1 / a private docker bridge — no public HTTP in the path.
+#
+# NOT scheduled. NOT triggered by push/PR.
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Ops action'
+        required: true
+        type: choice
+        options:
+          - status
+          - stage0-provision
+          - stage0-datasource
+          - stage0-probe
+          - grant-read
+          - light-read
+          - rollback-read
+      pilot_tenant:
+        description: 'Pilot tenant id'
+        required: false
+        default: 'pilot-tenant'
+      pilot_org:
+        description: 'Pilot org id'
+        required: false
+        default: 'pilot-org'
+      ms2_public_origin:
+        description: 'Origin the ms2 web UI is served from (for embed allowlist); required for stage0-provision'
+        required: false
+        default: ''
+      confirm:
+        description: 'Type the action name again to confirm mutating actions (provision/datasource/grant/light/rollback)'
+        required: false
+        default: ''
+
+concurrency:
+  group: discussion-pilot-ops
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  pilot-ops:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout (for the ops scripts)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Confirm gate for mutating actions
+        env:
+          ACTION: ${{ github.event.inputs.action }}
+          CONFIRM: ${{ github.event.inputs.confirm }}
+        run: |
+          set -euo pipefail
+          case "$ACTION" in
+            status|stage0-probe) echo "read-only-ish action '$ACTION'; no confirm needed" ;;
+            *)
+              if [ "$CONFIRM" != "$ACTION" ]; then
+                echo "::error title=confirm required::mutating action '$ACTION' needs input confirm='$ACTION' (got '$CONFIRM')"
+                exit 1
+              fi
+              echo "confirmed: $ACTION" ;;
+          esac
+
+      - name: Require ms2_public_origin for provision
+        if: ${{ github.event.inputs.action == 'stage0-provision' }}
+        env:
+          ORIGIN: ${{ github.event.inputs.ms2_public_origin }}
+        run: |
+          set -euo pipefail
+          [ -n "$ORIGIN" ] || { echo "::error::stage0-provision requires ms2_public_origin"; exit 1; }
+          case "$ORIGIN" in
+            https://*|http://127.0.0.1*|http://localhost*) echo "origin ok: $ORIGIN" ;;
+            *) echo "::error title=transport::ms2_public_origin must be https:// or a loopback tunnel (got $ORIGIN)"; exit 1 ;;
+          esac
+
+      - name: Run pilot ops on deploy host (SSH)
+        id: run
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          ACTION: ${{ github.event.inputs.action }}
+          PILOT_TENANT: ${{ github.event.inputs.pilot_tenant }}
+          PILOT_ORG: ${{ github.event.inputs.pilot_org }}
+          MS2_PUBLIC_ORIGIN: ${{ github.event.inputs.ms2_public_origin }}
+          MS2_ADMIN_BEARER: ${{ secrets.MS2_ADMIN_BEARER }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh_opts="-o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=6 -i ~/.ssh/deploy_key"
+
+          # Ship the ops scripts to the host (small, self-contained dir).
+          remote_dir="~/discussion-pilot-ops"
+          tar -czf - -C scripts/ops discussion-pilot | ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "mkdir -p $remote_dir && tar -xzf - -C $remote_dir"
+
+          # Execute the single action; env is passed through explicitly (no secrets echoed).
+          ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" \
+            "PILOT_TENANT='$PILOT_TENANT' PILOT_ORG='$PILOT_ORG' MS2_PUBLIC_ORIGIN='$MS2_PUBLIC_ORIGIN' \
+             MS2_ADMIN_BEARER='${MS2_ADMIN_BEARER:-}' \
+             bash $remote_dir/discussion-pilot/pilot_ops.sh '$ACTION'" 2>&1 | tee ops-output.log
+          echo "rc=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+          # Pull back the evidence dir (no secrets — scripts write only status/smoke/logs there).
+          ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "cd /tmp && tar -czf - discussion-pilot-evidence 2>/dev/null || true" > evidence.tgz || true
+
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: discussion-pilot-${{ github.event.inputs.action }}-${{ github.run_id }}
+          retention-days: 14
+          path: |
+            ops-output.log
+            evidence.tgz
+
+      - name: Fail if ops action failed
+        if: always()
+        run: |
+          rc="${{ steps.run.outputs.rc }}"
+          [ "$rc" = "0" ] || { echo "pilot ops action failed rc=$rc"; exit 1; }

--- a/scripts/ops/discussion-pilot/pilot_ops.sh
+++ b/scripts/ops/discussion-pilot/pilot_ops.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Discussion pilot ops — runs ON THE DEPLOY HOST over SSH (dispatched via
+# .github/workflows/discussion-pilot-ops.yml). One action per dispatch, mirroring the
+# owner's three-口令 protocol. All service traffic stays on 127.0.0.1 / a private
+# docker bridge — no public HTTP anywhere in the acceptance path (P1 transport rule).
+#
+# Actions:
+#   status            read-only: containers, health, flags, nginx public-exposure check
+#   stage0-provision  clone/refresh Yuantus @ origin/main, host-generated secrets,
+#                     127.0.0.1-only compose override, up + health, private bridge to the
+#                     metasheet backend, ms2 .env PLM_* keys (apiMode/tenant/org), backend recreate
+#   stage0-datasource register/verify the 'plm' data source (needs MS2_ADMIN_BEARER)
+#   stage0-probe      Stage-0.3 strict probe + MODE=dark smoke (expects flags OFF)
+#   grant-read        seed pilot tenant + sign/import READ SKUs license (in-container signer)
+#   light-read        DISCUSSION_READ_SESSION_ENABLED=true + restart + MODE=lit smoke
+#   rollback-read     flag back to false + restart + MODE=dark smoke (uniform-401 dark proof)
+#
+# Env (from workflow inputs): PILOT_TENANT, PILOT_ORG, MS2_PUBLIC_ORIGIN, PART_ID (optional),
+#   MS2_ADMIN_BEARER (only for stage0-datasource), MS2_ENV_FILE (default: auto-detect)
+set -euo pipefail
+
+ACTION="${1:?usage: pilot_ops.sh <action>}"
+PILOT_DIR="${PILOT_DIR:-$HOME/yuantus-pilot}"
+REPO_URL="${YUANTUS_REPO_URL:-https://github.com/zensgit/yuantus-plm.git}"
+SECRETS_DIR="$PILOT_DIR/.pilot-secrets"
+COMPOSE_PROJ="yuantus-pilot"
+YUANTUS_PORT=17910           # host loopback bind; container-internal stays 7910
+BRIDGE_NET="discussion-pilot-bridge"
+YUANTUS_ALIAS="yuantus-pilot-api"
+PILOT_TENANT="${PILOT_TENANT:-pilot-tenant}"
+PILOT_ORG="${PILOT_ORG:-pilot-org}"
+MS2_PUBLIC_ORIGIN="${MS2_PUBLIC_ORIGIN:-}"
+EVIDENCE_DIR="${EVIDENCE_DIR:-/tmp/discussion-pilot-evidence}"
+mkdir -p "$EVIDENCE_DIR"
+
+log() { echo "[pilot-ops] $*"; }
+die() { echo "[pilot-ops][error] $*" >&2; exit 1; }
+
+yq_compose() { docker compose -p "$COMPOSE_PROJ" -f "$PILOT_DIR/repo/docker-compose.yml" -f "$PILOT_DIR/docker-compose.pilot-override.yml" "$@"; }
+
+detect_ms2_env_file() {
+  # the prod backend uses env_file: — find it next to the deployed compose
+  for f in "${MS2_ENV_FILE:-}" "$HOME/metasheet2/.env" "$HOME/metasheet2/.env.production"; do
+    [ -n "$f" ] && [ -f "$f" ] && { echo "$f"; return 0; }
+  done
+  die "ms2 backend env_file not found; set MS2_ENV_FILE explicitly"
+}
+
+set_env_kv() { # file key value  (idempotent upsert)
+  local f=$1 k=$2 v=$3
+  if grep -q "^${k}=" "$f" 2>/dev/null; then
+    sed -i "s|^${k}=.*|${k}=${v}|" "$f"
+  else
+    echo "${k}=${v}" >> "$f"
+  fi
+}
+
+nginx_exposure_check() {
+  # P1: the v1.2 sslip.io vhosts must NOT route public HTTP onto the pilot Yuantus.
+  local hits
+  hits=$(grep -rlE "plm\..*sslip\.io|proxy_pass.*(:7910|:${YUANTUS_PORT})" /etc/nginx 2>/dev/null || true)
+  if [ -n "$hits" ]; then
+    echo "PUBLIC-EXPOSURE-RISK: nginx routes reference the PLM upstream:" | tee -a "$EVIDENCE_DIR/nginx-check.txt"
+    echo "$hits" | tee -a "$EVIDENCE_DIR/nginx-check.txt"
+    return 1
+  fi
+  log "nginx check clean (no sslip/plm proxy to $YUANTUS_PORT)"; return 0
+}
+
+yuantus_health() {
+  curl -fsS -m 10 "http://127.0.0.1:${YUANTUS_PORT}/api/v1/health" >/dev/null
+}
+
+case "$ACTION" in
+
+status)
+  { echo "== containers =="; docker ps --format '{{.Names}}\t{{.Status}}\t{{.Ports}}' | grep -Ei "metasheet|yuantus" || true
+    echo "== metasheet-backend PRODUCT_MODE / PLM (DECIDES pilot feasibility on THIS host) =="
+    MS2_CID=$(docker ps -qf name=metasheet-backend || true)
+    if [ -n "$MS2_CID" ]; then
+      pm=$(docker exec "$MS2_CID" sh -c 'echo "PRODUCT_MODE=${PRODUCT_MODE:-<unset>} ENABLE_PLM=${ENABLE_PLM:-<unset>}"' 2>/dev/null || echo "exec-failed")
+      echo "  $pm"
+      # PLM embed routes mounted? (loopback; unauthenticated probe — expect 401, not 404)
+      code=$(docker exec "$MS2_CID" sh -c 'curl -s -o /dev/null -w "%{http_code}" -m 5 http://127.0.0.1:8900/api/plm-embed/discussion/threads -H "X-PLM-Embed-Token: probe"' 2>/dev/null || echo "ERR")
+      echo "  plm-embed read route probe -> HTTP $code  (401/403=mounted; 404=NOT mounted => attendance mode, pilot NOT feasible here)"
+    else
+      echo "  metasheet-backend container NOT found"
+    fi
+    echo "== yuantus health (pilot) =="; yuantus_health && echo OK || echo "UNREACHABLE (no pilot instance yet — normal before stage0)"
+    echo "== flags (pilot .env) =="; grep -E "^YUANTUS_DISCUSSION|^YUANTUS_PREAUTH_RATE_LIMIT_ENABLED" "$PILOT_DIR/yuantus.env" 2>/dev/null || echo "(no pilot env yet)"
+    echo "== nginx exposure =="; nginx_exposure_check || true
+    echo "== docker host disk =="; df -Pk / | awk 'NR==2{print "  avail_kb="$4" use="$5}'
+  } | tee "$EVIDENCE_DIR/status.txt"
+  ;;
+
+stage0-provision)
+  [ -n "$MS2_PUBLIC_ORIGIN" ] || die "MS2_PUBLIC_ORIGIN required (the origin the ms2 web UI is served from)"
+  mkdir -p "$PILOT_DIR" "$SECRETS_DIR"; chmod 700 "$SECRETS_DIR"
+
+  # 1) Yuantus source @ current origin/main (version hard-requirement)
+  if [ -d "$PILOT_DIR/repo/.git" ]; then
+    git -C "$PILOT_DIR/repo" fetch origin main && git -C "$PILOT_DIR/repo" reset --hard origin/main
+  else
+    git clone --depth 1 "$REPO_URL" "$PILOT_DIR/repo"
+  fi
+  log "yuantus @ $(git -C "$PILOT_DIR/repo" rev-parse --short HEAD)"
+
+  # 2) host-generated secrets (idempotent; never leave the host)
+  [ -f "$SECRETS_DIR/jwt.secret" ] || python3 -c "import secrets;print(secrets.token_urlsafe(48))" > "$SECRETS_DIR/jwt.secret"
+  [ -f "$SECRETS_DIR/embed_seed.b64" ] || python3 -c "import os,base64;print(base64.b64encode(os.urandom(32)).decode())" > "$SECRETS_DIR/embed_seed.b64"
+  chmod 600 "$SECRETS_DIR"/*
+  EMBED_PUB=$(docker run --rm -i python:3.11-slim sh -c "pip -q install cryptography >/dev/null 2>&1 && python - <<'PY'
+import base64,sys
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization as s
+k=Ed25519PrivateKey.from_private_bytes(base64.b64decode(sys.stdin.read().strip()))
+print(base64.b64encode(k.public_key().public_bytes(s.Encoding.Raw,s.PublicFormat.Raw)).decode())
+PY" < "$SECRETS_DIR/embed_seed.b64")
+  [ -n "$EMBED_PUB" ] || die "embed pubkey derivation failed"
+  echo "$EMBED_PUB" > "$SECRETS_DIR/embed_pub.b64"
+
+  # 3) pilot env (flags OFF; limiter ON — the governed posture)
+  cat > "$PILOT_DIR/yuantus.env" <<EOF
+YUANTUS_JWT_SECRET_KEY=$(cat "$SECRETS_DIR/jwt.secret")
+YUANTUS_EMBED_TOKEN_SIGNING_KEY=$(cat "$SECRETS_DIR/embed_seed.b64")
+YUANTUS_EMBED_TOKEN_KEY_ID=embed-1
+YUANTUS_ENABLE_METASHEET=true
+YUANTUS_METASHEET_EMBED_URL=${MS2_PUBLIC_ORIGIN}/plm-embed/bom-review
+YUANTUS_EMBED_ALLOWED_ORIGINS=${MS2_PUBLIC_ORIGIN}
+YUANTUS_PREAUTH_RATE_LIMIT_ENABLED=true
+YUANTUS_DISCUSSION_READ_SESSION_ENABLED=false
+YUANTUS_DISCUSSION_SESSION_ENABLED=false
+EOF
+  chmod 600 "$PILOT_DIR/yuantus.env"
+
+  # 4) loopback-only override (P1: never a public bind)
+  cat > "$PILOT_DIR/docker-compose.pilot-override.yml" <<EOF
+services:
+  api:
+    env_file: [$PILOT_DIR/yuantus.env]
+    ports: !override
+      - "127.0.0.1:${YUANTUS_PORT}:7910"
+EOF
+
+  # 5) up + health
+  yq_compose up -d --build postgres minio api
+  for i in $(seq 1 60); do yuantus_health && break; sleep 2; [ "$i" = 60 ] && die "yuantus health timeout"; done
+  log "yuantus healthy on 127.0.0.1:${YUANTUS_PORT}"
+
+  # 6) private bridge: metasheet backend <-> pilot api (no compose edits, reversible)
+  docker network inspect "$BRIDGE_NET" >/dev/null 2>&1 || docker network create "$BRIDGE_NET"
+  API_CID=$(yq_compose ps -q api)
+  docker network disconnect "$BRIDGE_NET" "$API_CID" >/dev/null 2>&1 || true
+  docker network connect --alias "$YUANTUS_ALIAS" "$BRIDGE_NET" "$API_CID"
+  MS2_CID=$(docker ps -qf name=metasheet-backend)
+  [ -n "$MS2_CID" ] || die "metasheet-backend container not found"
+  docker network disconnect "$BRIDGE_NET" "$MS2_CID" >/dev/null 2>&1 || true
+  docker network connect "$BRIDGE_NET" "$MS2_CID"
+
+  # 7) ms2 .env: the P1-complete key set (apiMode/tenant/org — NOT just URL+ID)
+  ENVF=$(detect_ms2_env_file); cp "$ENVF" "$ENVF.pilot-backup.$(date +%s)"
+  set_env_kv "$ENVF" PLM_URL "http://${YUANTUS_ALIAS}:7910"
+  set_env_kv "$ENVF" PLM_API_MODE "yuantus"
+  set_env_kv "$ENVF" PLM_TENANT_ID "$PILOT_TENANT"
+  set_env_kv "$ENVF" PLM_ORG_ID "$PILOT_ORG"
+  set_env_kv "$ENVF" PLM_EMBED_ALLOWED_ORIGINS "$MS2_PUBLIC_ORIGIN"
+  set_env_kv "$ENVF" PLM_EMBED_AUDIENCE "metasheet2.embed"
+  set_env_kv "$ENVF" YUANTUS_EMBED_PUBLIC_KEYS "{\"embed-1\":\"${EMBED_PUB}\"}"
+  grep -q "^REDIS_URL=" "$ENVF" || set_env_kv "$ENVF" REDIS_URL "redis://redis:6379"
+  grep -q "^PLM_EMBED_DATA_SOURCE_ID=" "$ENVF" || log "NOTE: PLM_EMBED_DATA_SOURCE_ID not set yet — run stage0-datasource next"
+
+  # 8) recreate backend to pick up env (same image, no deploy)
+  ( cd "$(dirname "$ENVF")" && docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate backend )
+  # network connect does not survive recreation — reconnect
+  MS2_CID=$(docker ps -qf name=metasheet-backend)
+  docker network connect "$BRIDGE_NET" "$MS2_CID" 2>/dev/null || true
+
+  # 9) P1 exposure check LAST (fail loud if nginx would publish the pilot)
+  nginx_exposure_check || die "disable the sslip/plm nginx vhost before proceeding (see nginx-check.txt)"
+  log "stage0-provision complete"
+  ;;
+
+stage0-datasource)
+  [ -n "${MS2_ADMIN_BEARER:-}" ] || die "MS2_ADMIN_BEARER required"
+  ENVF=$(detect_ms2_env_file)
+  # register (or find) the pilot plm data source via the backend's own REST API on loopback
+  EXISTING=$(curl -fsS -m 15 http://127.0.0.1:8900/api/data-sources -H "Authorization: Bearer $MS2_ADMIN_BEARER" \
+    | python3 -c "import json,sys;ds=[d for d in json.load(sys.stdin) if d.get('type')=='plm' and d.get('name')=='yuantus-pilot'];print(ds[0]['id'] if ds else '')" 2>/dev/null || true)
+  if [ -n "$EXISTING" ]; then DS_ID="$EXISTING"; log "reusing data source $DS_ID"; else
+    DS_ID=$(curl -fsS -m 15 -X POST http://127.0.0.1:8900/api/data-sources \
+      -H "Authorization: Bearer $MS2_ADMIN_BEARER" -H 'Content-Type: application/json' \
+      -d "{\"name\":\"yuantus-pilot\",\"type\":\"plm\",\"config\":{\"connection\":{\"url\":\"http://${YUANTUS_ALIAS}:7910\"},\"options\":{\"apiMode\":\"yuantus\",\"tenantId\":\"${PILOT_TENANT}\",\"orgId\":\"${PILOT_ORG}\"}}}" \
+      | python3 -c "import json,sys;print(json.load(sys.stdin).get('id',''))")
+    [ -n "$DS_ID" ] || die "data source registration failed"
+    log "registered data source $DS_ID"
+  fi
+  set_env_kv "$ENVF" PLM_EMBED_DATA_SOURCE_ID "$DS_ID"
+  ( cd "$(dirname "$ENVF")" && docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate backend )
+  docker network connect "$BRIDGE_NET" "$(docker ps -qf name=metasheet-backend)" 2>/dev/null || true
+  log "stage0-datasource complete (id=$DS_ID)"
+  ;;
+
+stage0-probe)
+  SMOKE="$(dirname "$0")/smoke.sh"
+  YUANTUS_BASE="http://127.0.0.1:${YUANTUS_PORT}" MS2_BASE="http://127.0.0.1:8900" \
+  USERNAME="${PILOT_ADMIN_USER:-pilot-admin}" PASSWORD="$(cat "$SECRETS_DIR/pilot_admin.pass" 2>/dev/null || echo unset)" \
+  TENANT_ID="$PILOT_TENANT" ORG_ID="$PILOT_ORG" PART_ID="$(cat "$SECRETS_DIR/part_id" 2>/dev/null || echo unset)" \
+  MODE=dark bash "$SMOKE" | tee "$EVIDENCE_DIR/smoke-dark.txt"
+  ;;
+
+grant-read)
+  # seed pilot identity/meta/data (idempotent-ish; pilot instance only)
+  [ -f "$SECRETS_DIR/pilot_admin.pass" ] || python3 -c "import secrets;print(secrets.token_urlsafe(18))" > "$SECRETS_DIR/pilot_admin.pass"
+  chmod 600 "$SECRETS_DIR/pilot_admin.pass"
+  ADMIN_PASS=$(cat "$SECRETS_DIR/pilot_admin.pass")
+  yq_compose exec -T api yuantus seed-identity --tenant "$PILOT_TENANT" --org "$PILOT_ORG" \
+      --username "${PILOT_ADMIN_USER:-pilot-admin}" --password "$ADMIN_PASS" --user-id 9001 --roles admin || true
+  yq_compose exec -T api yuantus seed-meta || true
+  yq_compose exec -T api sh -c "YUANTUS_TENANT_ID=$PILOT_TENANT YUANTUS_ORG_ID=$PILOT_ORG yuantus seed-data --part-count 3 --doc-count 1 --bom-roots 1 --bom-depth 1" || true
+
+  # sign READ SKUs in-container (repo canonical scheme), kid pilot-read-1, 30d expiry
+  docker cp "$(dirname "$0")/sign_pilot_license.py" "$(yq_compose ps -q api)":/tmp/sign_pilot_license.py
+  yq_compose exec -T api sh -c "cd /app 2>/dev/null || cd /srv/app 2>/dev/null || cd /; \
+    python /tmp/sign_pilot_license.py --tenant-id $PILOT_TENANT \
+      --features bom_multitable,metasheet_review --kid pilot-read-1 \
+      --priv-out /tmp/pilot-read-1.pem --out /tmp/pilot-license.json" | tee "$EVIDENCE_DIR/license-issue.txt"
+  PUB=$(grep -A1 'YUANTUS_LICENSE_PUBLIC_KEYS' "$EVIDENCE_DIR/license-issue.txt" | tail -1)
+  set_env_kv "$PILOT_DIR/yuantus.env" YUANTUS_LICENSE_PUBLIC_KEYS "$PUB"
+  yq_compose up -d --no-deps --force-recreate api
+  for i in $(seq 1 60); do yuantus_health && break; sleep 2; done
+  yq_compose exec -T api yuantus license import /tmp/pilot-license.json --tenant-id "$PILOT_TENANT" | tee -a "$EVIDENCE_DIR/license-issue.txt"
+  # keep custody copies on host, then remove from container
+  docker cp "$(yq_compose ps -q api)":/tmp/pilot-read-1.pem "$SECRETS_DIR/pilot-read-1.pem"
+  docker cp "$(yq_compose ps -q api)":/tmp/pilot-license.json "$SECRETS_DIR/pilot-license.json"
+  yq_compose exec -T api rm -f /tmp/pilot-read-1.pem /tmp/pilot-license.json /tmp/sign_pilot_license.py
+  # remember a real seeded part id for smoke
+  yq_compose exec -T api python -c "
+from yuantus.meta_engine.bootstrap import import_all_models; import_all_models()
+from yuantus.database import SessionLocal
+from yuantus.meta_engine.models.item import Item
+s=SessionLocal();p=s.query(Item).filter(Item.item_type_id=='Part').first();print(p.id if p else '')" \
+    | tr -d '\r' | tail -1 > "$SECRETS_DIR/part_id" || true
+  log "grant-read complete (part_id=$(cat "$SECRETS_DIR/part_id" 2>/dev/null))"
+  ;;
+
+light-read)
+  set_env_kv "$PILOT_DIR/yuantus.env" YUANTUS_DISCUSSION_READ_SESSION_ENABLED true
+  yq_compose up -d --no-deps --force-recreate api
+  docker network connect --alias "$YUANTUS_ALIAS" "$BRIDGE_NET" "$(yq_compose ps -q api)" 2>/dev/null || true
+  for i in $(seq 1 60); do yuantus_health && break; sleep 2; done
+  SMOKE="$(dirname "$0")/smoke.sh"
+  YUANTUS_BASE="http://127.0.0.1:${YUANTUS_PORT}" MS2_BASE="http://127.0.0.1:8900" \
+  USERNAME="${PILOT_ADMIN_USER:-pilot-admin}" PASSWORD="$(cat "$SECRETS_DIR/pilot_admin.pass")" \
+  TENANT_ID="$PILOT_TENANT" ORG_ID="$PILOT_ORG" PART_ID="$(cat "$SECRETS_DIR/part_id")" \
+  MODE=lit bash "$SMOKE" | tee "$EVIDENCE_DIR/smoke-lit.txt"
+  ;;
+
+rollback-read)
+  set_env_kv "$PILOT_DIR/yuantus.env" YUANTUS_DISCUSSION_READ_SESSION_ENABLED false
+  yq_compose up -d --no-deps --force-recreate api
+  docker network connect --alias "$YUANTUS_ALIAS" "$BRIDGE_NET" "$(yq_compose ps -q api)" 2>/dev/null || true
+  for i in $(seq 1 60); do yuantus_health && break; sleep 2; done
+  SMOKE="$(dirname "$0")/smoke.sh"
+  YUANTUS_BASE="http://127.0.0.1:${YUANTUS_PORT}" MS2_BASE="http://127.0.0.1:8900" \
+  USERNAME="${PILOT_ADMIN_USER:-pilot-admin}" PASSWORD="$(cat "$SECRETS_DIR/pilot_admin.pass")" \
+  TENANT_ID="$PILOT_TENANT" ORG_ID="$PILOT_ORG" PART_ID="$(cat "$SECRETS_DIR/part_id")" \
+  MODE=dark bash "$SMOKE" | tee "$EVIDENCE_DIR/smoke-dark-rollback.txt"
+  ;;
+
+*) die "unknown action: $ACTION" ;;
+esac

--- a/scripts/ops/discussion-pilot/sign_pilot_license.py
+++ b/scripts/ops/discussion-pilot/sign_pilot_license.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""PILOT ONLY — sign a multi-SKU offline PLM license for the Discussion 点灯试点. rev2.
+
+Derived from the repo's scripts/dev/sign_dogfood_license.py (same canonical signing
+scheme via yuantus.meta_engine.app_framework.license_verification.canonical_payload_bytes),
+parameterized over feature keys:
+
+  bom_multitable            -> plm.bom_multitable            (embed-token mint gate)
+  metasheet_review          -> plm.metasheet_review          (Discussion READ)
+  metasheet_review_writeback-> plm.metasheet_review_writeback(Discussion WRITE)
+
+rev2 changes (owner review):
+  * --kid is REQUIRED (use a distinct kid per issuance batch, e.g. pilot-read-1 /
+    pilot-write-1) — reusing one kid across freshly generated keys breaks audit/re-signing.
+  * --priv-in <pem> loads a FIXED private key (pairs with --priv-out from a prior run),
+    so later batches can share a kid legitimately.
+  * pilot licenses EXPIRE by default: --expires-at defaults to now+30d (UTC).
+    Pass --expires-at none explicitly for perpetual (not recommended for the pilot).
+  * prints the EXACT AppLicense keys the import stores: a single-app license stores the
+    base license_key verbatim; a multi-app license stores ONE ROW PER app_name keyed
+    "<base>#<app_name>" (license_import_service.py) — revoke each of THOSE, not the base.
+
+Run FROM THE YUANTUS REPO ROOT (a checkout at/after current origin/main):
+
+  python ~/Downloads/sign_pilot_license.py --tenant-id pilot-tenant \
+      --features bom_multitable,metasheet_review --kid pilot-read-1 \
+      --priv-out pilot-read-1.pem --out pilot-license.json
+
+Then:
+  1. add the printed kid->pubkey JSON entry to the deployment's YUANTUS_LICENSE_PUBLIC_KEYS
+  2. yuantus license import pilot-license.json --tenant-id pilot-tenant
+  3. record the printed stored license keys for later revocation.
+
+Never commit the license file or the private key.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Import the in-repo canonical scheme (run from the Yuantus repo root).
+sys.path.insert(0, str(Path.cwd() / "src"))
+try:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from yuantus.meta_engine.app_framework.license_verification import (
+        canonical_payload_bytes,
+        verify_license,
+    )
+except ImportError as exc:  # pragma: no cover
+    sys.exit(f"run from the Yuantus repo root with its venv active (import failed: {exc})")
+
+# Mirror entitlement_service.FEATURE_APP_NAMES for the three pilot SKUs.
+FEATURE_APP_MAP = {
+    "bom_multitable": "plm.bom_multitable",
+    "metasheet_review": "plm.metasheet_review",
+    "metasheet_review_writeback": "plm.metasheet_review_writeback",
+}
+
+
+def build_and_sign(priv: Ed25519PrivateKey, *, tenant_id: str, features: list[str],
+                   subject: str, kid: str, plan_type: str, issued_at: str,
+                   expires_at: str | None) -> dict:
+    unknown = [f for f in features if f not in FEATURE_APP_MAP]
+    if unknown:
+        raise ValueError(f"unknown feature key(s) {unknown}; known: {sorted(FEATURE_APP_MAP)}")
+    if not features:
+        raise ValueError("at least one feature required")
+    payload = {
+        "tenant_id": tenant_id,
+        "app_names": [FEATURE_APP_MAP[f] for f in features],
+        "features": list(features),
+        "plan_type": plan_type,
+        "license_key": uuid.uuid4().hex,
+        "subject": subject,
+        "issued_at": issued_at,
+        "expires_at": expires_at,  # pilot default: now+30d; None only via explicit --expires-at none
+    }
+    signature = base64.b64encode(priv.sign(canonical_payload_bytes(payload))).decode()
+    return {"alg": "Ed25519", "kid": kid, "payload": payload, "signature": signature}
+
+
+def stored_license_keys(payload: dict) -> list[str]:
+    """The exact AppLicense.license_key values `yuantus license import` will store.
+
+    Mirrors license_import_service.py: single app -> base key; multi-app -> one row per
+    app_name keyed '<base>#<app_name>'. Revocation must target THESE keys.
+    """
+    base = payload["license_key"]
+    apps = payload["app_names"]
+    return [base] if len(apps) == 1 else [f"{base}#{app}" for app in apps]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Sign a multi-SKU pilot license (Discussion 点灯). rev2")
+    ap.add_argument("--tenant-id", required=True)
+    ap.add_argument("--features", required=True,
+                    help=f"CSV of feature keys, subset of {sorted(FEATURE_APP_MAP)}")
+    ap.add_argument("--subject", default="Discussion Pilot")
+    ap.add_argument("--kid", required=True,
+                    help="REQUIRED. Distinct per issuance batch (e.g. pilot-read-1, pilot-write-1) "
+                         "unless re-signing with --priv-in; must match the deployment's "
+                         "YUANTUS_LICENSE_PUBLIC_KEYS entry")
+    ap.add_argument("--plan-type", default="Pilot")
+    ap.add_argument("--issued-at", default=None, help="ISO-8601; default: now (UTC)")
+    ap.add_argument("--expires-at", default=None,
+                    help="ISO-8601, or the literal 'none' for perpetual (NOT recommended for a "
+                         "pilot). Default: now+30 days (UTC).")
+    ap.add_argument("--out", default="pilot-license.json")
+    key_group = ap.add_mutually_exclusive_group()
+    key_group.add_argument("--priv-in", default=None,
+                    help="PEM path of an EXISTING private key to sign with (keeps kid stable "
+                         "across batches)")
+    ap.add_argument("--priv-out", default=None,
+                    help="write the private key (PEM) here for later --priv-in re-signing. "
+                         "Keep in custody; never commit.")
+    args = ap.parse_args()
+
+    features = [f.strip() for f in args.features.split(",") if f.strip()]
+
+    if args.priv_in:
+        priv = serialization.load_pem_private_key(Path(args.priv_in).read_bytes(), password=None)
+        if not isinstance(priv, Ed25519PrivateKey):
+            sys.exit(f"--priv-in {args.priv_in} is not an Ed25519 private key")
+    else:
+        priv = Ed25519PrivateKey.generate()
+
+    pub_b64 = base64.b64encode(priv.public_key().public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw)).decode()
+
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    issued_at = args.issued_at or now.isoformat()
+    if args.expires_at is None:
+        expires_at: str | None = (now + timedelta(days=30)).isoformat()
+    elif args.expires_at.strip().lower() == "none":
+        expires_at = None
+        print("WARNING: perpetual license requested — not recommended for a pilot", file=sys.stderr)
+    else:
+        expires_at = args.expires_at
+
+    lic = build_and_sign(priv, tenant_id=args.tenant_id, features=features,
+                         subject=args.subject, kid=args.kid,
+                         plan_type=args.plan_type, issued_at=issued_at,
+                         expires_at=expires_at)
+
+    # Self-verify with the repo's own verifier before writing (fail here, not at import time).
+    verify_license(lic, {args.kid: pub_b64})
+
+    Path(args.out).write_text(json.dumps(lic, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    if args.priv_out:
+        Path(args.priv_out).write_bytes(priv.private_bytes(
+            serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption()))
+
+    print(f"license written: {args.out}")
+    print(f"features: {features} -> app_names: {[FEATURE_APP_MAP[f] for f in features]}")
+    print(f"issued_at: {issued_at}   expires_at: {expires_at or 'PERPETUAL'}")
+    print("add to YUANTUS_LICENSE_PUBLIC_KEYS:")
+    print(json.dumps({args.kid: pub_b64}))
+    print(f"then: yuantus license import {args.out} --tenant-id {args.tenant_id}")
+    print("stored AppLicense keys (REVOKE TARGETS — record these):")
+    for key in stored_license_keys(lic["payload"]):
+        print(f"  {key}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/discussion-pilot/smoke.sh
+++ b/scripts/ops/discussion-pilot/smoke.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Discussion 试点 smoke — 读通道 正/负 用例 (口令③ 阶段2 用) · rev2 (owner NO-GO 修订版)
+#
+# 传输安全 (P1): 本脚本传输用户名/密码/Bearer/embed token。
+#   仅允许: https:// 目标,或 SSH 隧道后的 http://127.0.0.1|localhost。
+#   公网 http:// 一律硬拒 —— 不提供任何绕过开关。
+#
+# 用法 (HTTPS):
+#   YUANTUS_BASE=https://plm.example.com MS2_BASE=https://ms.example.com \
+#   USERNAME=admin PASSWORD=*** TENANT_ID=pilot-tenant ORG_ID=org-1 PART_ID=<part> \
+#   MODE=lit bash discussion_pilot_smoke.sh
+# 用法 (SSH 隧道私有验收):
+#   ssh -N -L 17910:127.0.0.1:7910 -L 18900:127.0.0.1:8900 <deploy-host> &
+#   YUANTUS_BASE=http://127.0.0.1:17910 MS2_BASE=http://127.0.0.1:18900 ... MODE=dark bash discussion_pilot_smoke.sh
+#
+# MODE=dark : 点灯前 — 严格断言暗态: 交换 401;relay 401 且 code=EMBED_SESSION_EXCHANGE_FAILED
+#             (404/503 等 ≠ 暗态,是环境错误,判 FAIL)
+# MODE=lit  : 点灯后 — 正向 + 负向 (重放/写路由/兄弟路由,均严格断言 401 与稳定错误码) + 限流头
+#
+# 端点/字段/错误码取自 ms2 与 Yuantus origin/main 原文 (harness.ts, plm-discussion-read-e2e.test.ts,
+# plm-embed-discussion-read.ts) — 非猜测。
+set -uo pipefail
+
+: "${YUANTUS_BASE:?set YUANTUS_BASE}"; : "${MS2_BASE:?set MS2_BASE}"
+: "${USERNAME:?set USERNAME}"; : "${PASSWORD:?set PASSWORD}"
+: "${TENANT_ID:?set TENANT_ID}"; : "${ORG_ID:?set ORG_ID}"; : "${PART_ID:?set PART_ID}"
+MODE="${MODE:-lit}"
+
+# --- P1 传输安全守卫: 公网 HTTP 硬拒 ------------------------------------------
+check_scheme() { # $1=name $2=url
+  case "$2" in
+    https://*) return 0 ;;
+    http://127.0.0.1*|http://localhost*|http://\[::1\]*) return 0 ;;  # SSH 隧道
+    http://*) echo "FATAL: $1=$2 是公网 HTTP — 凭证会明文暴露。改用 HTTPS 或 SSH 隧道(127.0.0.1)。"; exit 3 ;;
+    *) echo "FATAL: $1=$2 不是 http(s) URL"; exit 3 ;;
+  esac
+}
+check_scheme YUANTUS_BASE "$YUANTUS_BASE"; check_scheme MS2_BASE "$MS2_BASE"
+
+PASS=0; FAIL=0
+ok()   { echo "  PASS  $1"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
+need() { command -v "$1" >/dev/null || { echo "missing dependency: $1"; exit 2; }; }
+need curl; need jq
+
+BODY=/tmp/smoke_body.$$
+body_code() { jq -r '.error.code // .detail // empty' "$BODY" 2>/dev/null; }
+
+# --- login (1次) -------------------------------------------------------------
+login_res=$(curl -sS -m 20 -w '\n%{http_code}' -X POST "$YUANTUS_BASE/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$USERNAME\",\"password\":\"$PASSWORD\",\"tenant_id\":\"$TENANT_ID\",\"org_id\":\"$ORG_ID\"}")
+login_code=${login_res##*$'\n'}; login_body=${login_res%$'\n'*}
+BEARER=$(jq -r '.access_token // empty' <<<"$login_body")
+[ "$login_code" = "200" ] && [ -n "$BEARER" ] && ok "login 200 + access_token" || { bad "login ($login_code)"; echo "$login_body" | head -c 300; echo; exit 1; }
+
+mint() { # -> embed_token 到 stdout;失败输出空
+  curl -sS -m 20 -X POST "$YUANTUS_BASE/api/v1/bom/multitable/$PART_ID/embed-token" \
+    -H 'Content-Type: application/json' -H "Authorization: Bearer $BEARER" \
+    -H "x-tenant-id: $TENANT_ID" -H "x-org-id: $ORG_ID" -d '{}' | jq -r '.embed_token // empty'
+}
+
+code_of() { # method url [json_body] x [extra_header...]
+  local method=$1 url=$2 body=${3:-}; shift; shift; [ $# -gt 0 ] && shift
+  local args=(-sS -m 20 -o "$BODY" -w '%{http_code}' -X "$method" "$url" -H 'Content-Type: application/json')
+  for h in "$@"; do args+=(-H "$h"); done
+  [ -n "$body" ] && args+=(-d "$body")
+  curl "${args[@]}"
+}
+
+exchange_code() { # embed_token -> http code (body 存 $BODY)
+  code_of POST "$YUANTUS_BASE/api/v1/auth/embed/discussion-read-session" "{\"embed_token\":\"$1\"}"
+}
+
+if [ "$MODE" = "dark" ]; then
+  echo "== MODE=dark:点灯前暗态验证 (严格断言,404/503 = 环境错误 = FAIL) =="
+  t=$(mint)
+  if [ -z "$t" ]; then bad "mint (dark 模式也应可铸 embed token — 检查 bom_multitable 授权 / 数据源租户)"; else
+    ok "mint embed token"
+    c=$(exchange_code "$t"); [ "$c" = "401" ] && ok "read exchange 暗态 401" || bad "read exchange 期望 401 实得 $c ($(body_code))"
+    c=$(code_of GET "$MS2_BASE/api/plm-embed/discussion/threads" "" x "X-PLM-Embed-Token: $t")
+    ec=$(body_code)
+    if [ "$c" = "401" ] && [ "$ec" = "EMBED_SESSION_EXCHANGE_FAILED" ]; then
+      ok "relay 暗态 401 + EMBED_SESSION_EXCHANGE_FAILED"
+    else
+      bad "relay 暗态期望 401+EMBED_SESSION_EXCHANGE_FAILED,实得 $c+${ec:-<no code>} (404=路由未挂载? 503=数据源/Redis 未配? 403 EMBED_TENANT_MISMATCH=数据源租户不符?)"
+    fi
+  fi
+else
+  echo "== MODE=lit:点灯后正负用例 (负向严格断言 401 与错误码) =="
+  # P1 relay list (真实浏览器路径同款: 仅 X-PLM-Embed-Token)
+  t1=$(mint); [ -n "$t1" ] || { bad "mint#1"; exit 1; }
+  c=$(code_of GET "$MS2_BASE/api/plm-embed/discussion/threads" "" x "X-PLM-Embed-Token: $t1")
+  if [ "$c" = "200" ] && jq -e '.ok == true or (.threads|type=="array") or (.data|type=="array")' "$BODY" >/dev/null 2>&1; then
+    ok "relay list 200 + JSON"; else bad "relay list ($c $(body_code)): $(head -c 200 "$BODY")"; fi
+  # P2 同 token 重放 relay → 401 + EMBED_TOKEN_REPLAYED (relay Redis jti)
+  c=$(code_of GET "$MS2_BASE/api/plm-embed/discussion/threads" "" x "X-PLM-Embed-Token: $t1")
+  ec=$(body_code)
+  [ "$c" = "401" ] && [ "$ec" = "EMBED_TOKEN_REPLAYED" ] && ok "relay 重放 401 + EMBED_TOKEN_REPLAYED" \
+    || bad "relay 重放期望 401+EMBED_TOKEN_REPLAYED 实得 $c+${ec:-<no code>}"
+  # P3 provider 直连: exchange → 200 + aud=discussion; 限流头; 交换重放 → 401
+  t2=$(mint); c=$(exchange_code "$t2")
+  if [ "$c" = "200" ] && [ "$(jq -r '.aud // empty' "$BODY")" = "discussion" ]; then
+    ok "read exchange 200 + aud=discussion"; READ_CRED=$(jq -r '.access_token' "$BODY")
+  else bad "read exchange ($c $(body_code))"; READ_CRED=""; fi
+  rl=$(curl -sSI -m 20 -X POST "$YUANTUS_BASE/api/v1/auth/embed/discussion-read-session" \
+        -H 'Content-Type: application/json' -d '{"embed_token":"x"}' | grep -i 'x-ratelimit-limit' || true)
+  [ -n "$rl" ] && ok "PREAUTH 限流头存在 ($(echo "$rl"|tr -d '\r'))" || bad "缺 X-RateLimit-Limit — 限流未开?"
+  c=$(exchange_code "$t2"); [ "$c" = "401" ] && ok "provider 交换重放 401 (AuthEmbedExchangeJti)" || bad "交换重放期望 401 实得 $c"
+  if [ -n "$READ_CRED" ]; then
+    # P4 读凭证 → provider list
+    c=$(code_of GET "$YUANTUS_BASE/api/v1/discussions?target_type=item&target_id=$PART_ID&include_resolved=true" "" x \
+        "Authorization: Bearer $READ_CRED")
+    [ "$c" = "200" ] && ok "provider list (读凭证) 200" || bad "provider list ($c $(body_code))"
+    # N1 读凭证发写 → 401 (middleware 只放行 2 个读 (method,path) 对)
+    c=$(code_of POST "$YUANTUS_BASE/api/v1/discussions" "{\"target_type\":\"item\",\"target_id\":\"$PART_ID\",\"body\":\"smoke\"}" x \
+        "Authorization: Bearer $READ_CRED")
+    [ "$c" = "401" ] && ok "读凭证写路由 401" || bad "读凭证写路由期望 401 实得 $c ($(body_code))"
+    # N2 读凭证访问兄弟路由 /my → 401
+    c=$(code_of GET "$YUANTUS_BASE/api/v1/discussions/my" "" x "Authorization: Bearer $READ_CRED")
+    [ "$c" = "401" ] && ok "读凭证 /my 401" || bad "读凭证 /my 期望 401 实得 $c ($(body_code))"
+    # N3 读凭证当普通登录用 → 401
+    c=$(code_of GET "$YUANTUS_BASE/api/v1/search/" "" x "Authorization: Bearer $READ_CRED")
+    [ "$c" = "401" ] && ok "读凭证通用路由 401" || bad "读凭证通用路由期望 401 实得 $c ($(body_code))"
+  fi
+fi
+
+rm -f "$BODY" 2>/dev/null
+echo; echo "== 结果: PASS=$PASS FAIL=$FAIL =="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What
Operator tooling to **execute** the Discussion 点灯 pilot on the deploy host, entirely over SSH (reuses the existing `DEPLOY_*` secrets, same channel as `attendance-remote-docker-gc-prod.yml`). **CI-only footprint** (1 workflow + 3 host scripts); touches no product code.

Designed to honor the owner's **three-口令 protocol**: provisioning, lighting the READ flag, and lighting the WRITE flag are **separate `workflow_dispatch` runs that never chain**. Every acceptance hop stays on the host's `127.0.0.1` / a private docker bridge — **no public HTTP** in the path (the rev2 transport rule).

## Why a PR (and what it unblocks)
`workflow_dispatch` is only dispatchable once the workflow is on **main**. Merging this lets me drive the pilot dispatch-by-dispatch on your word.

## ⛔ Two blockers to resolve before/at execution
1. **Feasibility unknown — is this host's `metasheet-backend` `PRODUCT_MODE=platform` or `attendance`?** PLM embed routes mount by default under *platform*; under *attendance* they are **not mounted** and the pilot cannot run on this host. The first action (`status`, read-only) probes exactly this (`PRODUCT_MODE`/`ENABLE_PLM` + an unauthenticated `/api/plm-embed/discussion/threads` probe: 401/403 = mounted, 404 = not). **Run `status` first; if 404, we need a platform-mode instance/host, not this one.**
2. **`MS2_ADMIN_BEARER` secret** is required for `stage0-datasource` (register the `plm` data source). Not currently set on the repo.

## Actions (one per dispatch)
| action | mutating | effect |
|---|---|---|
| `status` | no | feasibility probe (PRODUCT_MODE, PLM route mount, health, nginx public-exposure, disk) |
| `stage0-provision` | yes (confirm) | Yuantus @origin/main, **127.0.0.1-only** bind, host-generated secrets, private bridge to metasheet-backend, ms2 `.env` `PLM_API_MODE=yuantus`+`PLM_TENANT_ID`+`PLM_ORG_ID`, backend recreate; flags stay **OFF** |
| `stage0-datasource` | yes (confirm) | register/verify the `plm` data source (needs `MS2_ADMIN_BEARER`) |
| `stage0-probe` | no | strict `MODE=dark` smoke (expects flags OFF; 401+`EMBED_SESSION_EXCHANGE_FAILED`) |
| `grant-read` | yes (confirm) | seed pilot tenant + sign/import READ SKUs (in-container, kid `pilot-read-1`, 30d expiry) |
| `light-read` | yes (confirm) | **flip** `DISCUSSION_READ_SESSION_ENABLED=true` + restart + `MODE=lit` smoke |
| `rollback-read` | yes (confirm) | flag back to false + `MODE=dark` proof |

Guards: mutating actions require `confirm=<action>`; `stage0-provision` requires an `https://` or loopback `ms2_public_origin`; a post-provision nginx check **fails loud** if the host would publish the pilot Yuantus over the old sslip.io vhost. WRITE-flag lighting is intentionally **not** in this workflow yet — a separate step after the read soak.

## Safety
- No infra touched by merging; execution is manual dispatch only.
- Yuantus binds `127.0.0.1:17910` (never public); relay reaches it via an internal docker alias, not a published port.
- All steps reversible (flag flip = `rollback-read`; env edits backed up; license revoke keys printed by the signer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)