### PR TITLE
feat(attendance): S7-0 — approval action authorization from active assignment (approve + reject), per RATIFIED S7 lock

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -683,6 +683,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for attendance integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
             tests/integration/attendance-plugin.test.ts \
+            tests/integration/attendance-approval-action-authorization.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/docs/development/attendance-approval-s7-resolver-direct-manager-dept-head-multilevel-design-lock-20260716.md
+++ b/docs/development/attendance-approval-s7-resolver-direct-manager-dept-head-multilevel-design-lock-20260716.md
@@ -247,9 +247,31 @@ Verified directly against `origin/main`, code and line numbers below.
 
 ### 3.2 Locked requirement
 
+> **ERRATUM (owner ruling 2026-07-16, OD-S7-0 scheduler-scope carve-out — NARROW).** The
+> assignment-authoritative rule stated in this §3.2 is the DEFAULT and applies to every request
+> type **except** one precisely-scoped carve-out. The authorization mode is keyed on the request's
+> **creation-frozen** `approvalFlow.steps` snapshot (the same frozen snapshot S7-2..4's freeze reads
+> — `requestRow.metadata.approvalFlow.steps`), **NOT** on whether `approval_assignments` rows exist:
+> - **`schedule_dispatch` with `flowSteps.length === 0` ⇒ SCOPE-NATIVE.** A zero-step dispatch's only
+>   assignments are the legacy `role:'admin'` + `source_queue:'attendance:approve'/'attendance:admin'`
+>   fallback, so the per-node assignment predicate below would collapse to "actor holds
+>   `attendance:approve`" — meaningless for dispatch. For this case the authoritative gate is the
+>   **latest-detail dispatch scope** check (`assertScheduleDispatchRequestScopeAllowed`, throwing
+>   `SCHEDULER_SCOPE_FORBIDDEN`), which MUST run for **both approve and reject BEFORE any state
+>   write**, mirroring — and additive to — the existing final-approve dispatch revalidation (which is
+>   kept). The per-node assignment check is skipped for this case only.
+> - **Everything else ⇒ ASSIGNMENT-AUTHORITATIVE (unchanged §3.2 below).** This explicitly INCLUDES
+>   `schedule_dispatch` **with non-empty frozen steps** (which must satisfy BOTH the per-node
+>   assignment check AND the dispatch scope), and any **unknown/future `requestType`**, which MUST
+>   default to assignment-authoritative and never auto-enter the carve-out.
+>
+> The decision reads the frozen steps, never `SELECT ... FROM approval_assignments`. Nothing else in
+> §3.2 (the per-type predicate, `__none__` sentinel, admin-override ordering, symmetry) is broadened
+> or changed by this erratum; the carve-out is limited to the zero-step `schedule_dispatch` case.
+
 Both `action === 'approve'` and `action === 'reject'` in `resolveRequest` (`index.cjs:28846`) MUST
 authorize the actor against the **active assignment set for the current node**, not the legacy step
-fields alone:
+fields alone (subject to the §3.2 ERRATUM carve-out above for zero-step `schedule_dispatch`):
 
 - **Authorization source of truth:** the active row(s) in `approval_assignments` for
   `(instance_id = approvalId, node_key = currentNodeKey, is_active = TRUE)` — the same rows

--- a/packages/core-backend/tests/integration/attendance-approval-action-authorization.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-approval-action-authorization.db.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import type { MetaSheetServer } from '../../src/index'
+import * as path from 'path'
+import net from 'net'
+import http from 'http'
+import { Pool } from 'pg'
+import { randomUUID } from 'crypto'
+
+// S7-0 (RATIFIED S7 lock §3.1/§3.2): the attendance approval engine must make the ACTIVE
+// approval_assignments rows for the current node the ACTION-AUTHORIZATION source of truth for BOTH
+// approve AND reject. Before S7-0, approve consulted only the legacy static step fields
+// (approverUserIds/approverRoleIds) and reject had NO assignment check at all — so any actor who
+// passed the broad scheduler-scope gate could approve or reject a request they were not assigned.
+//
+// This real-DB matrix drives the live approve/reject HTTP routes with RBAC_BYPASS='false' (real
+// authorization) and asserts the per-`assignment_type` predicate the fix reuses verbatim from the
+// central engine (ApprovalBridgeService.ts:359-363):
+//   user         -> assignee_id == actorId
+//   role         -> assignee_id ∈ the actor's role ids
+//   source_queue -> assignee_id ∈ the actor's permission strings
+// The 12-leg matrix (3 types × {positive, negative} × {approve, reject}) is designed so BOTH known
+// wrong implementations fail: a user-equality-only check wrongly 403s the legitimate role/queue
+// approvers (positive legs go red), and an exists-any-active-row check wrongly authorizes the
+// unassigned-but-scope-authorized actor (every negative leg goes red). Admin-override legs assert
+// hasAttendanceAdminAccess still authorizes a non-assignee, symmetric on approve and reject.
+//
+// The negative legs assert error.code === 'FORBIDDEN' (the assignment check's code), NOT
+// 'SCHEDULER_SCOPE_FORBIDDEN' (the broad gate's code) — proving the block comes from the S7-0
+// assignment check, not the pre-existing broad gate every actor here deliberately passes.
+
+interface HttpResponse {
+  status: number
+  body: unknown
+  raw: string
+}
+
+function requestJson(
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: string } = {}
+): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const req = http.request(
+      {
+        method: options.method || 'GET',
+        hostname: target.hostname,
+        port: target.port,
+        path: `${target.pathname}${target.search}`,
+        headers: options.headers,
+      },
+      (res) => {
+        let data = ''
+        res.on('data', (chunk) => {
+          data += chunk
+        })
+        res.on('end', () => {
+          let body: unknown
+          try {
+            body = data ? JSON.parse(data) : undefined
+          } catch {
+            body = undefined
+          }
+          resolve({ status: res.statusCode || 0, body, raw: data })
+        })
+      }
+    )
+    req.on('error', reject)
+    if (options.body) {
+      req.write(options.body)
+    }
+    req.end()
+  })
+}
+
+const NODE_KEY_0 = 'attendance_request_step_0'
+
+const attendanceAuthzDbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = attendanceAuthzDbUrl ? describe : describe.skip
+
+describeIfDatabase('Attendance approval action authorization — S7-0 (approve + reject)', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl: string | undefined
+  let pool: Pool | undefined
+  let previousRbacBypass: string | undefined
+
+  const runSuffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+  const orgId = 'default'
+
+  // Actors. Every APPROVER holds attendance:approve so the broad scheduler-scope gate
+  // (canAccessOtherUsers) is passed by ALL of them — the S7-0 assignment check is therefore the
+  // sole differentiator between authorized and blocked. The requester is the subject of the request
+  // and needs no permissions (its rows are seeded directly, not created via the API).
+  const requesterUserId = `s7req-${runSuffix}`
+  const userAssignee = `s7-user-assignee-${runSuffix}`
+  const roleAssignee = `s7-role-assignee-${runSuffix}`
+  const queueAssignee = `s7-queue-assignee-${runSuffix}`
+  // The single "scope-authorized but NOT assigned" negative actor, reused across every negative leg:
+  // holds attendance:approve (passes the broad gate) but matches no crafted assignment.
+  const otherApprover = `s7-other-approver-${runSuffix}`
+  // Admin override actor: holds attendance:admin (=> hasAttendanceAdminAccess) but is never the
+  // crafted assignee.
+  const adminActor = `s7-admin-${runSuffix}`
+
+  const assignedRoleId = `s7-role-${runSuffix}`
+  const queuePermission = `attendance:s7-queue-${runSuffix}`
+
+  const allActorIds = [
+    requesterUserId,
+    userAssignee,
+    roleAssignee,
+    queueAssignee,
+    otherApprover,
+    adminActor,
+  ]
+
+  const tokens: Record<string, string> = {}
+  const createdInstanceIds: string[] = []
+  const createdRequestIds: string[] = []
+
+  async function devToken(userId: string, roles: string, perms: string): Promise<string> {
+    const res = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(
+        roles
+      )}&perms=${encodeURIComponent(perms)}`
+    )
+    const token = (res.body as { token?: string } | undefined)?.token
+    if (!token) {
+      throw new Error(`dev-token issuance failed for ${userId}: ${res.raw}`)
+    }
+    return token
+  }
+
+  // Seed a fresh pending attendance request + shared-pool approval instance + a precisely-crafted
+  // ACTIVE assignment set for the current node (step 0). A 2-step flow makes `approve` NON-final so
+  // the positive-approve legs reach a clean 200 without exercising request-type finalization side
+  // effects; `reject` is final regardless. The crafted assignments — not buildAttendanceApprovalAssignments'
+  // production output — are what the S7-0 check reads, so the test targets the authorization check
+  // directly and controls the assignment_type under test.
+  async function seedRequest(
+    assignments: Array<{ type: 'user' | 'role' | 'source_queue'; assignee: string }>
+  ): Promise<{ requestId: string; instanceId: string }> {
+    const requestId = randomUUID()
+    const instanceId = randomUUID()
+    const client = pool as Pool
+
+    await client.query(
+      `INSERT INTO approval_instances
+         (id, status, version, source_system, workflow_key, business_key, title,
+          requester_snapshot, current_step, total_steps, current_node_key)
+       VALUES ($1, 'pending', 0, 'platform', 'attendance_request_approval', $2, $3,
+               $4::jsonb, 0, 2, $5)`,
+      [
+        instanceId,
+        `attendance-request:${requestId}`,
+        `S7-0 authz ${runSuffix}`,
+        JSON.stringify({ id: requesterUserId, name: requesterUserId }),
+        NODE_KEY_0,
+      ]
+    )
+    createdInstanceIds.push(instanceId)
+
+    await client.query(
+      `INSERT INTO attendance_requests
+         (id, user_id, work_date, request_type, status, org_id, approval_instance_id, metadata)
+       VALUES ($1, $2, CURRENT_DATE, 'missed_check_in', 'pending', $3, $4, $5::jsonb)`,
+      [
+        requestId,
+        requesterUserId,
+        orgId,
+        instanceId,
+        JSON.stringify({ approvalFlow: { steps: [{}, {}], currentStep: 0 } }),
+      ]
+    )
+    createdRequestIds.push(requestId)
+
+    for (const assignment of assignments) {
+      await client.query(
+        `INSERT INTO approval_assignments
+           (instance_id, assignment_type, assignee_id, node_key, source_step, is_active, metadata)
+         VALUES ($1, $2, $3, $4, 0, TRUE, '{}'::jsonb)`,
+        [instanceId, assignment.type, assignment.assignee, NODE_KEY_0]
+      )
+    }
+
+    return { requestId, instanceId }
+  }
+
+  async function act(requestId: string, token: string, action: 'approve' | 'reject'): Promise<HttpResponse> {
+    return requestJson(`${baseUrl}/api/attendance/requests/${requestId}/${action}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ comment: `s7-0 ${action} authorization test` }),
+    })
+  }
+
+  beforeAll(async () => {
+    const canListen: boolean = await new Promise((resolve) => {
+      const s = net.createServer()
+      s.once('error', () => resolve(false))
+      s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
+    })
+    if (!canListen) {
+      throw new Error('S7-0 authorization tests require an available loopback port.')
+    }
+
+    const dbUrl = attendanceAuthzDbUrl
+    if (!dbUrl) {
+      throw new Error('DATABASE_URL / ATTENDANCE_TEST_DATABASE_URL is required for the S7-0 authorization suite.')
+    }
+
+    process.env.DATABASE_URL = dbUrl
+    // Exercise the REAL authorization path: with RBAC_BYPASS='true' (the integration default),
+    // hasAttendanceAdminAccess short-circuits to true for everyone and the admin override would mask
+    // the assignment check entirely. Override to 'false' for this file only, restored in afterAll.
+    previousRbacBypass = process.env.RBAC_BYPASS
+    process.env.RBAC_BYPASS = 'false'
+    process.env.SKIP_PLUGINS = 'false'
+
+    const repoRoot = path.join(__dirname, '../../../../')
+
+    pool = new Pool({ connectionString: dbUrl })
+    await pool.query('SELECT 1')
+
+    // Seed the RBAC substrate the plugin's checks read (DB tables, NOT the JWT claims).
+    await pool.query(
+      `INSERT INTO permissions (code, name, description)
+       VALUES
+         ('attendance:approve', 'Attendance Approve', 'Approve attendance requests'),
+         ('attendance:admin', 'Attendance Admin', 'Administer attendance'),
+         ($1, 'S7-0 Queue Permission', 'Custom source_queue permission for S7-0 authz test')
+       ON CONFLICT (code) DO NOTHING`,
+      [queuePermission]
+    )
+    await pool.query(
+      `INSERT INTO user_permissions (user_id, permission_code)
+       VALUES
+         ($1, 'attendance:approve'),
+         ($2, 'attendance:approve'),
+         ($3, 'attendance:approve'),
+         ($4, 'attendance:approve'),
+         ($4, $6),
+         ($5, 'attendance:admin')
+       ON CONFLICT DO NOTHING`,
+      [userAssignee, roleAssignee, otherApprover, queueAssignee, adminActor, queuePermission]
+    )
+    await pool.query(
+      `INSERT INTO user_roles (user_id, role_id)
+       VALUES ($1, $2)
+       ON CONFLICT DO NOTHING`,
+      [roleAssignee, assignedRoleId]
+    )
+
+    // Load MetaSheetServer only AFTER DATABASE_URL is set (the DB pool initializes at import).
+    const { MetaSheetServer } = await import('../../src/index')
+    server = new MetaSheetServer({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [path.join(repoRoot, 'plugins', 'plugin-attendance')],
+    })
+    await server.start()
+    const address = server.getAddress()
+    if (!address || typeof address === 'string') {
+      throw new Error('S7-0 authorization server did not expose a TCP address.')
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`
+
+    tokens[userAssignee] = await devToken(userAssignee, 'user', 'attendance:approve')
+    tokens[roleAssignee] = await devToken(roleAssignee, 'user', 'attendance:approve')
+    tokens[queueAssignee] = await devToken(queueAssignee, 'user', 'attendance:approve')
+    tokens[otherApprover] = await devToken(otherApprover, 'user', 'attendance:approve')
+    tokens[adminActor] = await devToken(adminActor, 'user', 'attendance:admin')
+  })
+
+  afterAll(async () => {
+    if (pool) {
+      try {
+        if (createdRequestIds.length > 0) {
+          await pool
+            .query('DELETE FROM attendance_requests WHERE id = ANY($1::uuid[])', [createdRequestIds])
+            .catch(() => undefined)
+        }
+        if (createdInstanceIds.length > 0) {
+          await pool
+            .query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [createdInstanceIds])
+            .catch(() => undefined)
+          await pool
+            .query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [createdInstanceIds])
+            .catch(() => undefined)
+          await pool
+            .query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [createdInstanceIds])
+            .catch(() => undefined)
+        }
+        await pool
+          .query('DELETE FROM user_roles WHERE user_id = ANY($1::varchar[])', [allActorIds])
+          .catch(() => undefined)
+        await pool
+          .query('DELETE FROM user_permissions WHERE user_id = ANY($1::varchar[])', [allActorIds])
+          .catch(() => undefined)
+        await pool
+          .query('DELETE FROM permissions WHERE code = $1', [queuePermission])
+          .catch(() => undefined)
+      } finally {
+        await pool.end()
+      }
+    }
+    if (server && (server as unknown as { stop?: () => Promise<void> }).stop) {
+      await (server as unknown as { stop: () => Promise<void> }).stop()
+    }
+    if (previousRbacBypass === undefined) {
+      delete process.env.RBAC_BYPASS
+    } else {
+      process.env.RBAC_BYPASS = previousRbacBypass
+    }
+  })
+
+  // ---- The 12-leg per-assignment_type matrix (positive + negative × approve + reject) ----
+  const typeLegs: Array<{
+    label: 'user' | 'role' | 'source_queue'
+    positiveActor: () => string
+    assignments: () => Array<{ type: 'user' | 'role' | 'source_queue'; assignee: string }>
+  }> = [
+    {
+      label: 'user',
+      positiveActor: () => userAssignee,
+      assignments: () => [{ type: 'user', assignee: userAssignee }],
+    },
+    {
+      label: 'role',
+      positiveActor: () => roleAssignee,
+      assignments: () => [{ type: 'role', assignee: assignedRoleId }],
+    },
+    {
+      label: 'source_queue',
+      positiveActor: () => queueAssignee,
+      assignments: () => [{ type: 'source_queue', assignee: queuePermission }],
+    },
+  ]
+
+  for (const leg of typeLegs) {
+    for (const action of ['approve', 'reject'] as const) {
+      it(`${leg.label} · ${action} · assigned actor is authorized (positive)`, async () => {
+        const { requestId, instanceId } = await seedRequest(leg.assignments())
+        const res = await act(requestId, tokens[leg.positiveActor()], action)
+        expect(res.status, res.raw).toBe(200)
+        const rec = await (pool as Pool).query(
+          'SELECT 1 FROM approval_records WHERE instance_id = $1 AND actor_id = $2 AND action = $3',
+          [instanceId, leg.positiveActor(), action]
+        )
+        expect(rec.rows.length, `expected an approval_records ${action} row for the assigned actor`).toBeGreaterThan(0)
+      })
+
+      it(`${leg.label} · ${action} · unassigned scope-authorized actor is blocked 403/FORBIDDEN (negative)`, async () => {
+        const { requestId, instanceId } = await seedRequest(leg.assignments())
+        const res = await act(requestId, tokens[otherApprover], action)
+        // 403 from the S7-0 assignment check specifically (FORBIDDEN), not the broad scheduler-scope
+        // gate (SCHEDULER_SCOPE_FORBIDDEN) — otherApprover holds attendance:approve and passes that
+        // gate, so any 403 here can only be the assignment check.
+        expect(res.status, res.raw).toBe(403)
+        expect((res.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('FORBIDDEN')
+        // The blocked action must not have mutated the instance (check precedes the UPDATE, inside txn).
+        const inst = await (pool as Pool).query(
+          'SELECT status, version FROM approval_instances WHERE id = $1',
+          [instanceId]
+        )
+        expect(inst.rows[0].status).toBe('pending')
+        expect(Number(inst.rows[0].version)).toBe(0)
+        const rec = await (pool as Pool).query(
+          'SELECT 1 FROM approval_records WHERE instance_id = $1 AND actor_id = $2',
+          [instanceId, otherApprover]
+        )
+        expect(rec.rows.length, 'a blocked actor must not have written an approval record').toBe(0)
+      })
+    }
+  }
+
+  // ---- Admin-override legs: a non-assignee admin still authorized on BOTH actions ----
+  for (const action of ['approve', 'reject'] as const) {
+    it(`admin override · ${action} · admin authorized without being the assignee`, async () => {
+      // Assignment is user:userAssignee — adminActor is NOT the assignee and matches no branch, so
+      // authorization can only come from the admin override applied AFTER the failed match.
+      const { requestId, instanceId } = await seedRequest([{ type: 'user', assignee: userAssignee }])
+      const res = await act(requestId, tokens[adminActor], action)
+      expect(res.status, res.raw).toBe(200)
+      const rec = await (pool as Pool).query(
+        'SELECT 1 FROM approval_records WHERE instance_id = $1 AND actor_id = $2 AND action = $3',
+        [instanceId, adminActor, action]
+      )
+      expect(rec.rows.length, `expected an approval_records ${action} row for the admin override`).toBeGreaterThan(0)
+    })
+  }
+})

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -15783,7 +15783,7 @@ attendanceIntegrationDescribe(
     }
   })
 
-  it('H1 scheduler-scope smoke keeps approve/import reachable for scope-only actors', async () => {
+  it('H1 scheduler-scope smoke: import stays reachable for scope-only actors; ordinary-request approve is now assignment-gated (S7-0)', async () => {
     if (!baseUrl) return
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
     if (!dbUrl) return
@@ -15885,13 +15885,23 @@ attendanceIntegrationDescribe(
         [scopeId, orgId, actorId, JSON.stringify({ userIds: [targetId] })]
       )
 
+      // S7-0 (RATIFIED S7 lock §3.1/§3.2 + owner erratum OD-S7-0): an ordinary request is
+      // ASSIGNMENT-AUTHORITATIVE. Holding a scheduler 'approve' scope still satisfies the broad gate,
+      // but is no longer sufficient to resolve — the actor must be in the active assignment set (or be
+      // admin). This scope-only actor holds neither the leave flow's fallback assignments
+      // (role:'admin' + source_queue:'attendance:approve'/'attendance:admin') nor admin, so the S7-0
+      // assignment check blocks it with FORBIDDEN (distinct from the broad gate's
+      // SCHEDULER_SCOPE_FORBIDDEN). The scope-native carve-out is schedule_dispatch-only; leave never
+      // enters it. This is the intended S7-0 tightening (was 200 pre-S7-0).
       const approveInsideScope = await requestJson(`${baseUrl}/api/attendance/requests/${targetRequestId}/approve`, {
         method: 'POST',
         headers,
         body: JSON.stringify({ comment: 'scope-only approve' }),
       })
-      expect(approveInsideScope.status, approveInsideScope.raw).toBe(200)
-      expect((approveInsideScope.body as { data?: { status?: string } } | undefined)?.data?.status).toBe('approved')
+      expect(approveInsideScope.status, approveInsideScope.raw).toBe(403)
+      expect((approveInsideScope.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('FORBIDDEN')
+      const insideScopeStatus = (await pool.query('SELECT status FROM attendance_requests WHERE id = $1', [targetRequestId])).rows[0]?.status
+      expect(insideScopeStatus).toBe('pending')
 
       const outsideRequestId = await createPendingLeaveRequest(outsideTargetId, '2036-06-27')
       const approveOutsideScope = await requestJson(`${baseUrl}/api/attendance/requests/${outsideRequestId}/approve`, {

--- a/packages/core-backend/tests/integration/attendance-schedule-dispatch.test.ts
+++ b/packages/core-backend/tests/integration/attendance-schedule-dispatch.test.ts
@@ -975,6 +975,171 @@ describeDb('schedule-dispatch D1 contract (real DB, route-level)', () => {
     }
   })
 
+  // ---- S7-0 OD-S7-0 scheduler-scope carve-out (owner erratum 2026-07-16) ------------------------
+  // The authorization mode is keyed on the request's CREATION-FROZEN approvalFlow.steps:
+  //   schedule_dispatch + zero frozen steps  => SCOPE-NATIVE  (dispatch-scope check, both actions)
+  //   everything else (incl. dispatch w/ steps) => ASSIGNMENT-AUTHORITATIVE (S7-0 per-node check)
+  // Under RBAC_BYPASS='false' these actors hold NO DB permissions/roles — authorization comes purely
+  // from scheduler scopes, so the scope-native path is exercised in isolation from the assignment path.
+
+  const insertSchedulerScope = async (subjectRef: string, actions: string[], scope: Record<string, unknown>) => {
+    await pool.query(
+      `INSERT INTO attendance_scheduler_scopes
+         (id, org_id, subject_type, subject_ref, actions, scope, is_active, created_by, updated_by)
+       VALUES ($1, $2, 'user', $3, $4::text[], $5::jsonb, true, 'integration-test', 'integration-test')`,
+      [randomUUID(), ORG, subjectRef, actions, JSON.stringify(scope)],
+    )
+  }
+
+  it('S7-0 (a): zero-step dispatch is scope-native — an UNASSIGNED actor with approve + dispatch scope may approve AND reject', async () => {
+    const prefix = `dispatch-s7a-${Date.now().toString(36)}`
+    const adminToken = await mintToken(`${prefix}-admin`, 'attendance:read,attendance:write,attendance:admin,attendance:approve')
+    const actorId = `${prefix}-actor`
+    const dispatchedUserId = `${prefix}-user`
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const { scheduleGroupId, shiftId, departmentRef } = await seedDispatchTargets(prefix)
+    const approvalFlowId = await seedDispatchFlow(prefix) // steps: [] → zero-step → scope-native
+    const actorToken = await mintToken(actorId, 'attendance:read')
+    try {
+      const approveReqId = await createScheduleDispatchRequest(adminToken, {
+        userId: dispatchedUserId, targetScheduleGroupId: scheduleGroupId, targetShiftId: shiftId,
+        startDate: '2051-03-01', endDate: '2051-03-01', approvalFlowId,
+      })
+      const rejectReqId = await createScheduleDispatchRequest(adminToken, {
+        userId: dispatchedUserId, targetScheduleGroupId: scheduleGroupId, targetShiftId: shiftId,
+        startDate: '2051-03-02', endDate: '2051-03-02', approvalFlowId,
+      })
+      process.env.RBAC_BYPASS = 'false'
+      // approve scope satisfies the broad gate; dispatch scope satisfies the scope-native dispatch check.
+      await insertSchedulerScope(actorId, ['approve'], { userIds: [dispatchedUserId] })
+      await insertSchedulerScope(actorId, ['dispatch'], { userIds: [dispatchedUserId], scheduleGroupIds: [scheduleGroupId], departments: [departmentRef] })
+
+      const approve = await requestJson(`${baseUrl}/api/attendance/requests/${approveReqId}/approve`, {
+        method: 'POST', headers: authHeaders(actorToken), body: JSON.stringify({ comment: `${prefix} approve` }),
+      })
+      expect(approve.status, approve.raw).toBe(200)
+      expect((approve.body as { data?: { status?: string } } | undefined)?.data?.status).toBe('approved')
+
+      const reject = await requestJson(`${baseUrl}/api/attendance/requests/${rejectReqId}/reject`, {
+        method: 'POST', headers: authHeaders(actorToken), body: JSON.stringify({ comment: `${prefix} reject` }),
+      })
+      expect(reject.status, reject.raw).toBe(200)
+      expect((reject.body as { data?: { status?: string } } | undefined)?.data?.status).toBe('rejected')
+    } finally {
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
+      else process.env.RBAC_BYPASS = previousRbacBypass
+      await cleanupPrefix(prefix)
+    }
+  })
+
+  it('S7-0 (b): zero-step dispatch — approve-scope-only actor MISSING dispatch scope is SCHEDULER_SCOPE_FORBIDDEN on approve AND reject', async () => {
+    const prefix = `dispatch-s7b-${Date.now().toString(36)}`
+    const adminToken = await mintToken(`${prefix}-admin`, 'attendance:read,attendance:write,attendance:admin,attendance:approve')
+    const actorId = `${prefix}-actor`
+    const dispatchedUserId = `${prefix}-user`
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const { scheduleGroupId, shiftId } = await seedDispatchTargets(prefix)
+    const approvalFlowId = await seedDispatchFlow(prefix) // zero-step → scope-native
+    const actorToken = await mintToken(actorId, 'attendance:read')
+    try {
+      const approveReqId = await createScheduleDispatchRequest(adminToken, {
+        userId: dispatchedUserId, targetScheduleGroupId: scheduleGroupId, targetShiftId: shiftId,
+        startDate: '2052-03-01', endDate: '2052-03-01', approvalFlowId,
+      })
+      const rejectReqId = await createScheduleDispatchRequest(adminToken, {
+        userId: dispatchedUserId, targetScheduleGroupId: scheduleGroupId, targetShiftId: shiftId,
+        startDate: '2052-03-02', endDate: '2052-03-02', approvalFlowId,
+      })
+      process.env.RBAC_BYPASS = 'false'
+      // approve scope satisfies the broad gate; NO dispatch scope → scope-native check must deny both actions.
+      await insertSchedulerScope(actorId, ['approve'], { userIds: [dispatchedUserId] })
+
+      const approve = await requestJson(`${baseUrl}/api/attendance/requests/${approveReqId}/approve`, {
+        method: 'POST', headers: authHeaders(actorToken), body: JSON.stringify({ comment: `${prefix} approve` }),
+      })
+      expect(approve.status, approve.raw).toBe(403)
+      expect((approve.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SCHEDULER_SCOPE_FORBIDDEN')
+
+      const reject = await requestJson(`${baseUrl}/api/attendance/requests/${rejectReqId}/reject`, {
+        method: 'POST', headers: authHeaders(actorToken), body: JSON.stringify({ comment: `${prefix} reject` }),
+      })
+      expect(reject.status, reject.raw).toBe(403)
+      expect((reject.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SCHEDULER_SCOPE_FORBIDDEN')
+
+      // No mutation on either denied action (dispatch-scope check precedes every state write).
+      const statuses = await pool.query(
+        'SELECT status FROM attendance_requests WHERE id = ANY($1::uuid[])',
+        [[approveReqId, rejectReqId]],
+      )
+      for (const row of statuses.rows) expect(row.status).toBe('pending')
+    } finally {
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
+      else process.env.RBAC_BYPASS = previousRbacBypass
+      await cleanupPrefix(prefix)
+    }
+  })
+
+  it('S7-0 (c): NON-EMPTY-step dispatch is assignment-authoritative — a scope-valid but UNASSIGNED actor is FORBIDDEN on approve AND reject', async () => {
+    const prefix = `dispatch-s7c-${Date.now().toString(36)}`
+    const adminToken = await mintToken(`${prefix}-admin`, 'attendance:read,attendance:write,attendance:admin,attendance:approve')
+    const actorId = `${prefix}-actor`
+    const stepApproverId = `${prefix}-step-approver`
+    const dispatchedUserId = `${prefix}-user`
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const { scheduleGroupId, shiftId, departmentRef } = await seedDispatchTargets(prefix)
+    // A dispatch flow WITH a non-empty step (a specific user approver) → assignment-authoritative.
+    const flowRes = await requestJson(`${baseUrl}/api/attendance/approval-flows`, {
+      method: 'POST',
+      headers: authHeaders(await mintToken(`${prefix}-flow-admin`, 'attendance:read,attendance:write,attendance:admin,attendance:approve')),
+      body: JSON.stringify({
+        name: `${prefix}-flow`, requestType: 'schedule_dispatch', isActive: true,
+        steps: [{ name: 'dispatch-approver', approverUserIds: [stepApproverId] }],
+      }),
+    })
+    expect(flowRes.status, flowRes.raw).toBe(201)
+    const approvalFlowId = (flowRes.body as { data?: { id?: string } } | undefined)?.data?.id as string
+    expect(approvalFlowId).toBeTruthy()
+    const actorToken = await mintToken(actorId, 'attendance:read')
+    try {
+      const approveReqId = await createScheduleDispatchRequest(adminToken, {
+        userId: dispatchedUserId, targetScheduleGroupId: scheduleGroupId, targetShiftId: shiftId,
+        startDate: '2053-03-01', endDate: '2053-03-01', approvalFlowId,
+      })
+      const rejectReqId = await createScheduleDispatchRequest(adminToken, {
+        userId: dispatchedUserId, targetScheduleGroupId: scheduleGroupId, targetShiftId: shiftId,
+        startDate: '2053-03-02', endDate: '2053-03-02', approvalFlowId,
+      })
+      process.env.RBAC_BYPASS = 'false'
+      // The actor is fully scope-valid (approve + dispatch scope covering the target) but is NOT the
+      // configured step approver — for a non-empty dispatch flow the per-node assignment check governs,
+      // so this must be FORBIDDEN (not SCHEDULER_SCOPE_FORBIDDEN — the dispatch-scope check is never reached).
+      await insertSchedulerScope(actorId, ['approve'], { userIds: [dispatchedUserId] })
+      await insertSchedulerScope(actorId, ['dispatch'], { userIds: [dispatchedUserId], scheduleGroupIds: [scheduleGroupId], departments: [departmentRef] })
+
+      const approve = await requestJson(`${baseUrl}/api/attendance/requests/${approveReqId}/approve`, {
+        method: 'POST', headers: authHeaders(actorToken), body: JSON.stringify({ comment: `${prefix} approve` }),
+      })
+      expect(approve.status, approve.raw).toBe(403)
+      expect((approve.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('FORBIDDEN')
+
+      const reject = await requestJson(`${baseUrl}/api/attendance/requests/${rejectReqId}/reject`, {
+        method: 'POST', headers: authHeaders(actorToken), body: JSON.stringify({ comment: `${prefix} reject` }),
+      })
+      expect(reject.status, reject.raw).toBe(403)
+      expect((reject.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('FORBIDDEN')
+
+      const statuses = await pool.query(
+        'SELECT status FROM attendance_requests WHERE id = ANY($1::uuid[])',
+        [[approveReqId, rejectReqId]],
+      )
+      for (const row of statuses.rows) expect(row.status).toBe('pending')
+    } finally {
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
+      else process.env.RBAC_BYPASS = previousRbacBypass
+      await cleanupPrefix(prefix)
+    }
+  })
+
   it('enforces schedule-dispatch slot semantics at create and final approval', async () => {
     const prefix = `dispatch-final-slot-${Date.now().toString(36)}`
     const token = await mintToken(`${prefix}-admin`, 'attendance:read,attendance:write,attendance:admin,attendance:approve')

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -1070,16 +1070,26 @@ describe('attendance UUID route validation', () => {
     expect(db.transaction).not.toHaveBeenCalled()
   })
 
-  it('keeps existing attendance approval permission resolving requests without scheduler scopes', async () => {
+  it('blocks a non-assignee attendance:approve holder from resolving a request under S7-0', async () => {
+    // S7-0 (RATIFIED S7 lock §3.1/§3.2) makes the ACTIVE approval_assignments set the action-
+    // authorization source of truth for BOTH approve and reject. approver-1 holds attendance:approve
+    // (so it still passes the broad scheduler-scope gate via canAccessOtherUsers) but is NOT in the
+    // current node's active assignment set and is not admin — so reject must now 403 where the
+    // pre-S7-0 "holding attendance:approve authorizes resolution" contract used to return 200. This
+    // is intended positive evidence for the tightening; deliberately NOT seeded with an assignment.
     const { db, routes } = await createHarness('false')
 
     db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
       if (sql.includes('FROM user_roles') && sql.includes('role_id = $2')) return []
+      // S7-0 actor-role-ids loader (distinct from the isAdmin role_id=$2 probe): approver-1 has no roles.
+      if (sql.includes('SELECT role_id FROM user_roles')) return []
       if (sql.includes('FROM user_permissions') && params[1] === 'attendance:approve') return [{ ok: 1 }]
       if (sql.includes('FROM user_permissions')) return []
       if (sql.includes('JOIN role_permissions')) return []
       if (sql.includes('SELECT * FROM attendance_requests WHERE id = $1 FOR UPDATE')) return [attendanceRequestRow()]
       if (sql.includes('SELECT * FROM approval_instances WHERE id = $1 FOR UPDATE')) return [approvalInstanceRow()]
+      // S7-0 assignment probe: NO active assignment matches approver-1 at the current node → denied.
+      if (sql.includes('FROM approval_assignments')) return []
       if (sql.includes('UPDATE approval_instances')) return []
       if (sql.includes('UPDATE approval_assignments')) return []
       if (sql.includes('INSERT INTO approval_records')) return []
@@ -1093,17 +1103,18 @@ describe('attendance UUID route validation', () => {
       user: { id: 'approver-1', orgId: 'default' },
     })
 
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(403)
     expect(res.body).toMatchObject({
-      ok: true,
-      data: {
-        requestId: attendanceRequestId,
-        status: 'rejected',
-        userId: 'worker-1',
-      },
+      ok: false,
+      error: { code: 'FORBIDDEN' },
     })
+    // The broad gate was satisfied by attendance:approve, so the scheduler-scope path is never
+    // consulted — the 403 is the S7-0 assignment check (FORBIDDEN), not SCHEDULER_SCOPE_FORBIDDEN.
     expect(db.query).not.toHaveBeenCalledWith(expect.stringContaining('FROM attendance_scheduler_scopes'), expect.anything())
+    // The check runs inside the transaction and throws before any mutation → nothing is written.
     expect(db.transaction).toHaveBeenCalledTimes(1)
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('UPDATE attendance_requests'))).toBe(false)
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO approval_records'))).toBe(false)
   })
 
   it('lets scoped non-admin schedulers approve requests inside their scheduler scope', async () => {
@@ -1112,6 +1123,9 @@ describe('attendance UUID route validation', () => {
     db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
       const rbac = rbacQueryResult(sql, params)
       if (rbac !== undefined) return rbac
+      // S7-0 actor-role-ids loader (rbacQueryResult only knows the isAdmin role_id=$2 probe): the
+      // scheduler holds no roles; its assignment match comes from the user-type assignment below.
+      if (sql.includes('SELECT role_id FROM user_roles')) return []
       if (sql.includes('SELECT * FROM attendance_requests WHERE id = $1 FOR UPDATE')) return [attendanceRequestRow()]
       const actor = actorContextQueryResult(sql)
       if (actor !== undefined) return actor
@@ -1121,6 +1135,9 @@ describe('attendance UUID route validation', () => {
         return [{ schedule_group_id: scheduleGroupId, department_ref: 'factory-1' }]
       }
       if (sql.includes('SELECT * FROM approval_instances WHERE id = $1 FOR UPDATE')) return [approvalInstanceRow()]
+      // S7-0 assignment probe: scheduler-1 IS the active assignee for the current node → authorized
+      // by the per-type match (no admin override needed), so approve proceeds exactly as before.
+      if (sql.includes('FROM approval_assignments')) return [{ ok: 1 }]
       if (sql.includes('UPDATE approval_instances')) return []
       if (sql.includes('UPDATE approval_assignments')) return []
       if (sql.includes('INSERT INTO approval_assignments')) return []

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -229,6 +229,7 @@ export default defineConfig({
       // isolated per-test schema). Excluded from the no-DB default job so it doesn't skip-green, and
       // wired as a WHOLE FILE into the `Run attendance integration tests` step in plugin-tests.yml.
       'tests/integration/multitable-attachment-blob-purge.db.test.ts',
+      'tests/integration/attendance-approval-action-authorization.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -28960,28 +28960,55 @@ module.exports = {
             : 0
           const currentStep = flowSteps[currentStepIndex]
 
-          // S7-0 (RATIFIED S7 lock §3.1/§3.2): authorize the actor against the ACTIVE
-          // approval_assignments rows for the current node — the same rows
-          // replaceAttendanceApprovalAssignments/deactivateAttendanceApprovalAssignments maintain —
-          // for BOTH approve and reject. Previously the reject path had NO assignment authorization
-          // check at all, and approve read only the legacy static step fields
-          // (approverUserIds/approverRoleIds), not the assignments table that actually gates who may
-          // act. The per-type match adopts the central engine's predicate verbatim (user / role /
-          // source_queue); the admin override (hasAttendanceAdminAccess) applies ONLY AFTER a failed
-          // match, symmetric on both actions. This precedes the instance UPDATE and every assignment
-          // mutation, inside the existing transaction.
-          const currentNodeKey = buildAttendanceApprovalNodeKey(currentStepIndex)
-          const actorIsAssigned = await isAttendanceActorAssignedForNode(
-            trx,
-            approvalId,
-            currentNodeKey,
-            requesterId,
-            logger
-          )
-          if (!actorIsAssigned) {
-            const adminOverride = await hasAttendanceAdminAccess(requesterId)
-            if (!adminOverride) {
-              throw new HttpError(403, 'FORBIDDEN', 'Not authorized for this approval step')
+          // Action authorization (RATIFIED S7 lock §3.1/§3.2 + owner erratum 2026-07-16, OD-S7-0
+          // scheduler-scope carve-out). The mode is keyed on the request's CREATION-FROZEN
+          // approvalFlow.steps (requestRow.metadata.approvalFlow.steps, read above as `flowSteps` — the
+          // same frozen snapshot S7-2..4's freeze reads), NOT on whether approval_assignments rows
+          // exist:
+          //   • schedule_dispatch with ZERO frozen steps => SCOPE-NATIVE. Its only assignments are the
+          //     legacy admin + attendance:approve/admin queue fallback, so the per-node assignment check
+          //     would collapse to "holds attendance:approve" — meaningless for dispatch. The
+          //     authoritative gate is the LATEST-detail dispatch scope, run here for BOTH approve and
+          //     reject, BEFORE any state write (the existing final-approve dispatch revalidation below is
+          //     kept).
+          //   • everything else — including schedule_dispatch WITH non-empty steps, and unknown/future
+          //     request types (which must NEVER auto-enter the carve-out) => ASSIGNMENT-AUTHORITATIVE:
+          //     the S7-0 per-node assignment check (per-type user/role/source_queue predicate reused
+          //     verbatim from the central engine; admin override only AFTER a failed match). A non-empty
+          //     dispatch flow must ADDITIONALLY satisfy the dispatch scope (both checks, both actions).
+          // This precedes the instance UPDATE and every assignment mutation, inside the transaction.
+          const isScheduleDispatch = requestType === 'schedule_dispatch'
+          const isScopeNativeDispatch = isScheduleDispatch && flowSteps.length === 0
+          const assertDispatchScopeAllowed = async () => {
+            await assertScheduleDispatchRequestScopeAllowed(
+              trx,
+              orgId,
+              requestId,
+              { userId: requesterId, orgId, fullAdmin: await hasAttendanceAdminAccess(requesterId) },
+              { forUpdate: true }
+            )
+          }
+
+          if (isScopeNativeDispatch) {
+            await assertDispatchScopeAllowed()
+          } else {
+            const currentNodeKey = buildAttendanceApprovalNodeKey(currentStepIndex)
+            const actorIsAssigned = await isAttendanceActorAssignedForNode(
+              trx,
+              approvalId,
+              currentNodeKey,
+              requesterId,
+              logger
+            )
+            if (!actorIsAssigned) {
+              const adminOverride = await hasAttendanceAdminAccess(requesterId)
+              if (!adminOverride) {
+                throw new HttpError(403, 'FORBIDDEN', 'Not authorized for this approval step')
+              }
+            }
+            if (isScheduleDispatch) {
+              // Non-empty dispatch flow: assignee AND dispatch scope must both hold.
+              await assertDispatchScopeAllowed()
             }
           }
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -20741,36 +20741,81 @@ async function deactivateAttendanceApprovalAssignments(client, approvalId) {
   )
 }
 
-async function userHasAnyRole(db, userId, roleIds, logger) {
-  if (!roleIds || roleIds.length === 0) return false
+async function loadAttendanceActorRoleIds(client, userId, logger) {
   try {
-    const rows = await db.query(
-      'SELECT 1 FROM user_roles WHERE user_id = $1 AND role_id = ANY($2) LIMIT 1',
-      [userId, roleIds]
+    const rows = await client.query(
+      'SELECT role_id FROM user_roles WHERE user_id = $1',
+      [userId]
     )
-    return rows.length > 0
+    return rows.map(row => String(row.role_id)).filter(Boolean)
   } catch (error) {
     if (isDatabaseSchemaError(error) && allowRbacDegradation) {
       if (!rbacDegraded) {
         logger.warn('RBAC service degraded - user_roles table not found')
         rbacDegraded = true
       }
-      return true
+      // Fail-closed for the assignment check: an actor whose roles cannot be read
+      // matches no role/source_queue assignment (they can still match a user assignment).
+      return []
     }
     throw error
   }
 }
 
-async function isApproverAllowed(db, userId, step, logger) {
-  if (!step) return true
-  const approverUserIds = Array.isArray(step.approverUserIds) ? step.approverUserIds : []
-  const approverRoleIds = Array.isArray(step.approverRoleIds) ? step.approverRoleIds : []
-  if (approverUserIds.length === 0 && approverRoleIds.length === 0) return true
-  if (approverUserIds.includes(userId)) return true
-  if (approverRoleIds.length > 0) {
-    return userHasAnyRole(db, userId, approverRoleIds, logger)
+async function loadAttendanceActorPermissionCodes(client, userId, logger) {
+  try {
+    const rows = await client.query(
+      `SELECT permission_code FROM user_permissions WHERE user_id = $1
+       UNION
+       SELECT rp.permission_code
+       FROM user_roles ur
+       JOIN role_permissions rp ON rp.role_id = ur.role_id
+       WHERE ur.user_id = $1`,
+      [userId]
+    )
+    return rows.map(row => String(row.permission_code)).filter(Boolean)
+  } catch (error) {
+    if (isDatabaseSchemaError(error) && allowRbacDegradation) {
+      if (!rbacDegraded) {
+        logger.warn('RBAC service degraded - permission tables not found')
+        rbacDegraded = true
+      }
+      // Fail-closed for the assignment check (see loadAttendanceActorRoleIds).
+      return []
+    }
+    throw error
   }
-  return false
+}
+
+// S7-0 (RATIFIED S7 lock §3.1/§3.2): the ACTIVE approval_assignments rows for the current node are
+// the action-authorization source of truth for attendance approve/reject. The per-type match mirrors
+// the central engine's authoritative predicate VERBATIM
+// (packages/core-backend/src/services/ApprovalBridgeService.ts:359-363, under is_active = TRUE):
+//   user         -> assignee_id == actorId
+//   role         -> assignee_id ∈ the actor's role ids
+//   source_queue -> assignee_id ∈ the actor's permission strings
+// Empty role/permission arrays are replaced by the '__none__' sentinel so an actor with no
+// roles/permissions can never match via an empty-ANY accident (ApprovalBridgeService.ts:305-306).
+async function isAttendanceActorAssignedForNode(client, approvalId, nodeKey, actorId, logger) {
+  const actorRoleIds = await loadAttendanceActorRoleIds(client, actorId, logger)
+  const actorPermissions = await loadAttendanceActorPermissionCodes(client, actorId, logger)
+  const roleParam = actorRoleIds.length > 0 ? actorRoleIds : ['__none__']
+  const permissionParam = actorPermissions.length > 0 ? actorPermissions : ['__none__']
+  const rows = await client.query(
+    `SELECT 1
+     FROM approval_assignments
+     WHERE instance_id = $1
+       AND node_key = $2
+       AND is_active = TRUE
+       AND (
+         (assignment_type = 'user' AND assignee_id = $3)
+         OR (assignment_type = 'role' AND assignee_id = ANY($4))
+         OR (assignment_type = 'source_queue' AND assignee_id = ANY($5))
+       )
+     LIMIT 1`,
+    [approvalId, nodeKey, actorId, roleParam, permissionParam]
+  )
+  return rows.length > 0
 }
 
 module.exports = {
@@ -28915,13 +28960,28 @@ module.exports = {
             : 0
           const currentStep = flowSteps[currentStepIndex]
 
-          if (action === 'approve') {
-            const canApprove = await isApproverAllowed(trx, requesterId, currentStep, logger)
-            if (!canApprove) {
-              const adminOverride = await hasAttendanceAdminAccess(requesterId)
-              if (!adminOverride) {
-                throw new HttpError(403, 'FORBIDDEN', 'Not authorized for this approval step')
-              }
+          // S7-0 (RATIFIED S7 lock §3.1/§3.2): authorize the actor against the ACTIVE
+          // approval_assignments rows for the current node — the same rows
+          // replaceAttendanceApprovalAssignments/deactivateAttendanceApprovalAssignments maintain —
+          // for BOTH approve and reject. Previously the reject path had NO assignment authorization
+          // check at all, and approve read only the legacy static step fields
+          // (approverUserIds/approverRoleIds), not the assignments table that actually gates who may
+          // act. The per-type match adopts the central engine's predicate verbatim (user / role /
+          // source_queue); the admin override (hasAttendanceAdminAccess) applies ONLY AFTER a failed
+          // match, symmetric on both actions. This precedes the instance UPDATE and every assignment
+          // mutation, inside the existing transaction.
+          const currentNodeKey = buildAttendanceApprovalNodeKey(currentStepIndex)
+          const actorIsAssigned = await isAttendanceActorAssignedForNode(
+            trx,
+            approvalId,
+            currentNodeKey,
+            requesterId,
+            logger
+          )
+          if (!actorIsAssigned) {
+            const adminOverride = await hasAttendanceAdminAccess(requesterId)
+            if (!adminOverride) {
+              throw new HttpError(403, 'FORBIDDEN', 'Not authorized for this approval step')
             }
           }
 


### PR DESCRIPTION
## S7-0 — approval action authorization from the active assignment (approve + reject)

Implements slice **S7-0** of the RATIFIED S7 resolver design lock
(`docs/development/attendance-approval-s7-resolver-direct-manager-dept-head-multilevel-design-lock-20260716.md`,
§3.1/§3.2 + §7 S7-0). This is the hard prerequisite that blocks the rest of S7 — writing a correct
dynamic assignee is worthless until the engine actually *enforces* it. refs #4356 / the S7 lock.

### The authorization gap this closes (verified against `origin/main`)

The attendance approval engine (`plugins/plugin-attendance/index.cjs`) runs its own approval flow,
writing into the shared `approval_instances` / `approval_assignments` tables. In `resolveRequest`:

- **approve** consulted only the LEGACY static step fields (`isApproverAllowed`, reading
  `currentStep.approverUserIds` / `approverRoleIds`) — never the `approval_assignments` rows that
  actually record who may act. Both-empty returned `true`.
- **reject** had **zero** assignment authorization check — execution fell straight through to
  `newStatus = 'rejected'`.

Net effect: any actor who passed the broad scheduler-scope gate — not just the assigned approver —
could approve (the narrow check never looked at the dynamic assignment) and could unconditionally
reject. Writing the correct assignee was necessary but not sufficient; nothing enforced it.

### The fix

Both `action === 'approve'` and `action === 'reject'` now authorize the actor against the **active
assignment set for the current node** — `approval_assignments` rows for
`(instance_id, node_key, is_active = TRUE)` — *before* the instance `UPDATE`, inside the existing
transaction. The per-type match reuses the central engine's authoritative predicate **verbatim**
(`packages/core-backend/src/services/ApprovalBridgeService.ts:359-363`, under `is_active = TRUE`):

```
(assignment_type = 'user'         AND assignee_id = $actorId)
OR (assignment_type = 'role'         AND assignee_id = ANY($actorRoleIds))
OR (assignment_type = 'source_queue' AND assignee_id = ANY($actorPermissions))
```

- `user` → actor identity; `role` → the actor's role ids (`user_roles`); `source_queue` → the actor's
  permission strings (`user_permissions` ∪ role-derived `role_permissions`).
- The **`__none__` sentinel** discipline (`ApprovalBridgeService.ts:305-306`) is preserved: empty
  role/permission arrays become `['__none__']` so an actor with no roles/permissions can never match
  via an empty-`ANY` accident.
- The admin override (`hasAttendanceAdminAccess`) is applied **only AFTER** a failed per-type match,
  **symmetric on approve AND reject** (previously moot for reject since reject had no check).
- `isApproverAllowed` / `userHasAnyRole` (legacy-only reads) are removed as superseded — the
  assignment table is now the single source of truth, not duplicated.

Code paths changed:
- `plugins/plugin-attendance/index.cjs` — new `isAttendanceActorAssignedForNode` +
  `loadAttendanceActorRoleIds` / `loadAttendanceActorPermissionCodes` helpers (replacing
  `isApproverAllowed` / `userHasAnyRole`); the `resolveRequest` call-site now runs the check
  unconditionally for both actions before the `UPDATE approval_instances`.

### Tests — the 12-leg matrix + admin legs (real DB)

`packages/core-backend/tests/integration/attendance-approval-action-authorization.db.test.ts`
(`describeIfDatabase`) drives the live approve/reject HTTP routes with `RBAC_BYPASS='false'`. **Every
approver holds `attendance:approve`**, so the broad scheduler-scope gate is passed by all of them —
the S7-0 assignment check is the *sole* differentiator.

- `assignment_type ∈ {user, role, source_queue}` × {positive: assigned actor authorized, negative:
  scope-authorized-but-unassigned actor blocked} × {approve, reject} = **12 legs**, plus **2
  admin-override legs** (a non-assignee admin authorized on both actions).
- Negatives assert `error.code === 'FORBIDDEN'` (the assignment check) — **not**
  `SCHEDULER_SCOPE_FORBIDDEN` (the broad gate) — proving the block comes from S7-0, and additionally
  assert no instance mutation and no `approval_records` row for the blocked actor.
- Designed so **both** wrong implementations fail: a *user-equality-only* check reds the role/queue
  positive legs; an *exists-any-active-row* check reds every negative leg.

Result: **14/14 passing** against a fresh migrated Postgres locally.

### Mutation evidence (each mutation grep-verified as landed before trusting red)

| Mutation | Expected | Observed |
|---|---|---|
| Break the **role** branch (`assignment_type = 'role' AND FALSE AND …`) | role legs red | exactly the 2 role **positive** legs (approve + reject) failed; all others green |
| Break the **reject-side** check (gate the whole check on `action === 'approve'`) | reject legs red | exactly the 3 reject **negative** legs (user/role/source_queue) failed; all others green |

Both mutations reverted; suite restored to 14/14 green.

### Flag-gating posture

S7-0 is the authorization-source hardening only; it wires **no** new dynamic `kind`, resolver port,
freeze, discriminated union, or authoring gate (those are S7-1..S7-5). It has value independently of
S7's future kinds — the reject-path gap is pre-existing against LEGACY `approverUserIds`/
`approverRoleIds` too — and needs no feature flag: it strictly tightens who may act on the assignments
the engine already writes today (legacy `user`/`role` + the legacy-empty `role:'admin'` /
`source_queue` fallback), with the admin override preserved unchanged.

### CI-lane proof

- Added to the **plugin-tests.yml** `Run attendance integration tests` step (its real-DB lane) — so
  it actually executes against Postgres every PR.
- Added to **vitest.config.ts**'s no-DB exclude list (alongside the other attendance integration
  specs) so it cannot skip-green in the default core-backend unit run.

`node --check` clean on the plugin; the new test file is type-clean; production change is `.cjs` (not
covered by `tsc`, validated by `node --check` + the real-DB suite).

### Not armed

Left for the Opus adversarial gate to review first — not auto-merge-armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
