### PR TITLE
feat(stock-prep): T3b-1c/T3b-2 — PLM source-run auto-persist route wiring + real-DB smoke (default-OFF)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -557,6 +557,7 @@ jobs:
             tests/integration/approval-record-projection.test.ts \
             tests/integration/stock-preparation-t3a-erp-autopersist-realdb.test.ts \
             tests/integration/stock-preparation-t3b-replay-hardening-realdb.test.ts \
+            tests/integration/stock-preparation-t3b-plm-autopersist-realdb.test.ts \
             tests/integration/multitable-l4-canonical-fence-realdb.test.ts \
             --reporter=dot
 

--- a/packages/core-backend/tests/integration/stock-preparation-t3b-plm-autopersist-realdb.test.ts
+++ b/packages/core-backend/tests/integration/stock-preparation-t3b-plm-autopersist-realdb.test.ts
@@ -1,0 +1,543 @@
+/**
+ * Stock-preparation T3b-2: approved PLM read source -> internal project/batch/line/run (real DB).
+ *
+ * This suite drives the ACTUAL stockPreparationPlmBomSourceRun route handler through the real
+ * provisioning and records APIs against a real PostgreSQL — never a helper impersonating the route.
+ * Physical field ids are discovered from meta_fields instead of the deterministic id helper, so a
+ * broken logical-to-physical translation cannot self-prove against the same formula.
+ *
+ * design-lock: docs/development/stock-preparation-t3b-plm-source-autopersist-design-lock-20260716.md §5.2
+ */
+import { createRequire } from 'module'
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import {
+  ensureObject,
+  findObjectSheet,
+  patchObjectFieldProperty,
+  resolveObjectFieldIds,
+  type MultitableProvisioningObjectDescriptor,
+  type MultitableProvisioningQueryFn,
+} from '../../src/multitable/provisioning'
+import {
+  createRecord,
+  patchRecord,
+  queryRecords,
+  type MultitableRecordsQueryFn,
+} from '../../src/multitable/records'
+
+const require = createRequire(import.meta.url)
+const { createHandlers } = require('../../../../plugins/plugin-integration-core/lib/http-routes.cjs') as {
+  createHandlers: (
+    services: Record<string, unknown>,
+    options: { context: Record<string, unknown> },
+  ) => Record<string, (req: Record<string, unknown>, res: TestResponse) => Promise<unknown>>
+}
+const { validateReadSourceConfig } = require('../../../../plugins/plugin-integration-core/lib/read-source-config.cjs') as {
+  validateReadSourceConfig: (input: Record<string, unknown>) => {
+    valid: boolean
+    errors: unknown[]
+    normalized: Record<string, unknown>
+  }
+}
+const {
+  ensureStockPreparationMvpTargets,
+  syncStockPreparationMvpOptions,
+} = require('../../../../plugins/plugin-integration-core/lib/stock-preparation-mvp-provisioning.cjs') as {
+  ensureStockPreparationMvpTargets: (input: Record<string, unknown>) => Promise<Record<string, unknown>>
+  syncStockPreparationMvpOptions: (input: Record<string, unknown>) => Promise<Record<string, unknown>>
+}
+const {
+  BATCH_OBJECT_ID,
+  LINE_OBJECT_ID,
+  PROJECT_OBJECT_ID,
+  RUN_OBJECT_ID,
+} = require('../../../../plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs') as {
+  BATCH_OBJECT_ID: string
+  LINE_OBJECT_ID: string
+  PROJECT_OBJECT_ID: string
+  RUN_OBJECT_ID: string
+}
+const { STOCK_PREPARATION_MVP_TABLE_TEMPLATES } = require('../../../../plugins/plugin-integration-core/lib/stock-preparation-templates.cjs') as {
+  STOCK_PREPARATION_MVP_TABLE_TEMPLATES: Array<{
+    objectId: string
+    fields: Array<{ id: string; label: string; type: string }>
+  }>
+}
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TOKEN = `${process.pid}_${Date.now().toString(36)}`
+const TENANT_ID = `tenant_t3b2_${TOKEN}`
+const TARGET_PROJECT_ID = `${TENANT_ID}:integration-core`
+const CONFIG_ID = `cfg_t3b2_${TOKEN}`
+const SYSTEM_ID = `sys_t3b2_${TOKEN}`
+const BUSINESS_PROJECT_ID = `project_t3b2_${TOKEN}`
+const SOURCE_PROJECT_NO = `SOURCE-PROJECT-SECRET-${TOKEN}`
+const PROJECT_NAME = `Secret project name ${TOKEN}`
+const SYNC_RUN_ID = `run_t3b2_${TOKEN}`
+const SNAPSHOT_BATCH_ID = `snapshot_t3b2_${TOKEN}`
+const CHILD_CODE_1 = `PLM-CHILD-1-${TOKEN}`
+const CHILD_CODE_2 = `PLM-CHILD-2-${TOKEN}`
+const SOURCE_CREDENTIAL = `PLM-CREDENTIAL-${TOKEN}`
+const FLAG = 'MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED'
+const OBJECT_IDS = [PROJECT_OBJECT_ID, BATCH_OBJECT_ID, LINE_OBJECT_ID, RUN_OBJECT_ID]
+
+type QueryResult = { rows: unknown[]; rowCount?: number | null }
+type TestResponse = {
+  statusCode: number
+  body: unknown
+  status(code: number): TestResponse
+  json(body: unknown): unknown
+}
+
+function wrapQuery(
+  query: (sql: string, params?: unknown[]) => Promise<QueryResult>,
+): MultitableProvisioningQueryFn & MultitableRecordsQueryFn {
+  return async (sql, params) => {
+    const result = await query(sql, params)
+    return {
+      rows: Array.isArray(result.rows) ? result.rows : [],
+      rowCount: typeof result.rowCount === 'number' ? result.rowCount : undefined,
+    }
+  }
+}
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+function transaction<T>(handler: (query: MultitableRecordsQueryFn) => Promise<T>): Promise<T> {
+  return poolManager.get().transaction(async ({ query }) => handler(wrapQuery(query)))
+}
+
+function createRealMultitableFacade() {
+  const readQuery = wrapQuery(q)
+  const provisioning = {
+    findObjectSheet: ({ projectId, objectId }: { projectId: string; objectId: string }) =>
+      findObjectSheet(readQuery, projectId, objectId),
+    resolveFieldIds: ({ projectId, objectId, fieldIds }: { projectId: string; objectId: string; fieldIds: string[] }) =>
+      resolveObjectFieldIds(projectId, objectId, fieldIds),
+    ensureObject: ({ projectId, baseId, descriptor }: {
+      projectId: string
+      baseId?: string | null
+      descriptor: MultitableProvisioningObjectDescriptor
+    }) =>
+      transaction((query) => ensureObject({ query, projectId, baseId, descriptor })),
+    patchObjectFieldProperty: (input: {
+      projectId: string
+      objectId: string
+      fieldId: string
+      propertyPatch: Record<string, unknown>
+    }) => transaction((query) => patchObjectFieldProperty({ query, ...input })),
+  }
+  const records = {
+    queryRecords: (input: {
+      sheetId: string
+      filters?: Record<string, unknown>
+      search?: string
+      orderBy?: Array<Record<string, unknown>>
+      limit?: number
+      offset?: number
+    }) => queryRecords({ query: readQuery, ...input }),
+    createRecord: ({ sheetId, data }: { sheetId: string; data: Record<string, unknown> }) =>
+      transaction((query) => createRecord({ query, sheetId, data })),
+    patchRecord: ({ sheetId, recordId, changes }: {
+      sheetId: string
+      recordId: string
+      changes: Record<string, unknown>
+    }) => transaction((query) => patchRecord({ query, sheetId, recordId, changes })),
+  }
+  return { provisioning, records }
+}
+
+const DEFAULT_FIELD_MAP = [
+  { source: 'path', target: 'pathKey' },
+  { source: 'childCode', target: 'childDrawingNo' },
+  { source: 'quantity', target: 'designQty' },
+]
+
+function readConfig(fieldMap: Array<Record<string, unknown>>): Record<string, unknown> {
+  const result = validateReadSourceConfig({
+    version: 1,
+    systemId: SYSTEM_ID,
+    requiredKind: 'plm:yuantus-wrapper',
+    object: 'stock-preparation-source',
+    mode: 'list_page',
+    readPath: '/readonly/stock-preparation',
+    readMethod: 'POST',
+    operations: ['read'],
+    containerPaths: ['Rows'],
+    fieldMap,
+  })
+  if (!result.valid) throw new Error(`T3b-2 real-DB fixture config is invalid: ${JSON.stringify(result.errors)}`)
+  return result.normalized
+}
+
+function unused(name: string): () => never {
+  return () => {
+    throw new Error(`unexpected T3b-2 real-DB service call: ${name}`)
+  }
+}
+
+function createServices(
+  sourceRows: Array<Record<string, unknown>>,
+  fieldMap: Array<Record<string, unknown>> = DEFAULT_FIELD_MAP,
+) {
+  const noopAsync = async () => ({})
+  const adapterCreates: string[] = []
+  const services = {
+    externalSystemRegistry: {
+      upsertExternalSystem: unused('upsertExternalSystem'),
+      getExternalSystem: unused('getExternalSystem'),
+      deleteExternalSystem: unused('deleteExternalSystem'),
+      listExternalSystems: unused('listExternalSystems'),
+      async getExternalSystemForAdapter() {
+        return {
+          id: SYSTEM_ID,
+          tenantId: TENANT_ID,
+          kind: 'plm:yuantus-wrapper',
+          credentials: { password: SOURCE_CREDENTIAL },
+          config: {},
+        }
+      },
+    },
+    adapterRegistry: {
+      listAdapterKinds: () => ['plm:yuantus-wrapper'],
+      createAdapter: (system: { kind: string }) => {
+        adapterCreates.push(system.kind)
+        return {
+          async read() {
+            const pageRows = sourceRows.map((row) => ({ ...row }))
+            return {
+              records: pageRows,
+              raw: { Rows: pageRows },
+              metadata: { totalCount: pageRows.length, returnedRecordCount: pageRows.length },
+            }
+          },
+        }
+      },
+    },
+    pipelineRegistry: {
+      upsertPipeline: unused('upsertPipeline'),
+      getPipeline: unused('getPipeline'),
+      listPipelines: unused('listPipelines'),
+      listPipelineRuns: unused('listPipelineRuns'),
+    },
+    pipelineRunner: { runPipeline: unused('runPipeline') },
+    deadLetterStore: { listDeadLetters: unused('listDeadLetters') },
+    stagingInstaller: {
+      installStaging: unused('installStaging'),
+      listStagingDescriptors: unused('listStagingDescriptors'),
+    },
+    templateRegistry: {
+      upsertTemplate: unused('upsertTemplate'),
+      getTemplate: unused('getTemplate'),
+      listTemplates: unused('listTemplates'),
+      deleteTemplate: unused('deleteTemplate'),
+      instantiateTemplate: unused('instantiateTemplate'),
+    },
+    readSourceConfigStore: {
+      saveVersion: unused('readSourceConfig.saveVersion'),
+      list: unused('readSourceConfig.list'),
+      get: unused('readSourceConfig.get'),
+      approve: unused('readSourceConfig.approve'),
+      retire: unused('readSourceConfig.retire'),
+      listAudit: unused('readSourceConfig.listAudit'),
+      async getForRuntime() {
+        return { id: CONFIG_ID, status: 'approved', systemId: SYSTEM_ID, config: readConfig(fieldMap) }
+      },
+    },
+    readSourceCompositionConfigStore: {
+      saveVersion: noopAsync,
+      list: noopAsync,
+      get: noopAsync,
+      approve: noopAsync,
+      retire: noopAsync,
+      listAudit: noopAsync,
+      getForRuntime: noopAsync,
+    },
+    bridgeAgentChecklistStore: {
+      saveVersion: noopAsync,
+      approve: noopAsync,
+      retire: noopAsync,
+      getForApply: noopAsync,
+    },
+  }
+  return { services, adapterCreates }
+}
+
+function response(): TestResponse {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(body) {
+      this.body = body
+      return body
+    },
+  }
+}
+
+function deepIncludes(value: unknown, needle: string): boolean {
+  if (typeof value === 'string') return value.includes(needle)
+  if (Array.isArray(value)) return value.some((entry) => deepIncludes(entry, needle))
+  if (value && typeof value === 'object') return Object.values(value).some((entry) => deepIncludes(entry, needle))
+  return false
+}
+
+async function discoverPhysicalFields(sheetId: string, objectId: string): Promise<Record<string, string>> {
+  const template = STOCK_PREPARATION_MVP_TABLE_TEMPLATES.find((entry) => entry.objectId === objectId)
+  if (!template) throw new Error(`missing frozen template for ${objectId}`)
+  const result = await q('SELECT id, name FROM meta_fields WHERE sheet_id = $1', [sheetId])
+  const rowsByName = new Map(
+    (result.rows as Array<{ id: string; name: string }>).map((row) => [row.name, row.id]),
+  )
+  return Object.fromEntries(template.fields.map((field) => {
+    const physicalId = rowsByName.get(field.label)
+    if (!physicalId) throw new Error(`real meta_fields row missing for ${objectId}.${field.id}`)
+    if (physicalId === field.id) throw new Error(`expected a physical field id for ${objectId}.${field.id}`)
+    return [field.id, physicalId]
+  }))
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('expected object response')
+  return value as Record<string, unknown>
+}
+
+function adminRequest(bodyOverrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    user: { id: `admin_${TOKEN}`, tenantId: TENANT_ID, roles: ['admin'], permissions: ['integration:admin'] },
+    body: {
+      workspaceId: `workspace_${TOKEN}`,
+      projectId: BUSINESS_PROJECT_ID,
+      sourceProjectNo: SOURCE_PROJECT_NO,
+      projectName: PROJECT_NAME,
+      readSourceConfigId: CONFIG_ID,
+      syncRunId: SYNC_RUN_ID,
+      snapshotBatchId: SNAPSHOT_BATCH_ID,
+      snapshotVersion: 1,
+      ...bodyOverrides,
+    },
+    query: {},
+    params: {},
+  }
+}
+
+const SOURCE_ROWS = [
+  { path: '/root/asm-1', childCode: CHILD_CODE_1, quantity: 2 },
+  { path: '/root/asm-1/part-2', childCode: CHILD_CODE_2, quantity: 1 },
+]
+
+if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+  test('T3b-2 real-DB allowlist must provide DATABASE_URL', () => {
+    throw new Error('T3b-2 PLM auto-persist real-DB allowlist step is missing DATABASE_URL')
+  })
+}
+
+describeIfDatabase('stock-preparation T3b-2 PLM source auto-persist (real DB)', () => {
+  const facade = createRealMultitableFacade()
+  const context = { api: { multitable: facade }, storage: {}, config: {} }
+  const sheetIds = new Map<string, string>()
+  let previousFlag: string | undefined
+
+  async function countsBySheet(): Promise<Record<string, number>> {
+    const ids = [...sheetIds.values()]
+    const result = await q(
+      'SELECT sheet_id, COUNT(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[]) GROUP BY sheet_id',
+      [ids],
+    )
+    const counts = Object.fromEntries(ids.map((id) => [id, 0]))
+    for (const row of result.rows as Array<{ sheet_id: string; count: number }>) counts[row.sheet_id] = row.count
+    return counts
+  }
+
+  beforeAll(async () => {
+    previousFlag = process.env[FLAG]
+    const ensured = await ensureStockPreparationMvpTargets({
+      context,
+      projectId: TARGET_PROJECT_ID,
+      permission: 'admin',
+      objectIds: OBJECT_IDS,
+    })
+    expect(ensured).toMatchObject({ ready: true })
+    for (const objectId of OBJECT_IDS) {
+      const sheet = await facade.provisioning.findObjectSheet({ projectId: TARGET_PROJECT_ID, objectId })
+      if (!sheet) throw new Error(`T3b-2 real-DB provisioning did not create the ${objectId} sheet`)
+      sheetIds.set(objectId, sheet.id)
+    }
+    await syncStockPreparationMvpOptions({
+      context,
+      projectId: TARGET_PROJECT_ID,
+      permission: 'admin',
+      objectIds: OBJECT_IDS,
+      optionSets: {
+        stock_preparation_project_status_v1: ['active'].map((value) => ({ value })),
+        stock_preparation_snapshot_status_v1: ['draft', 'active', 'superseded', 'rejected']
+          .map((value) => ({ value })),
+        stock_preparation_bom_line_status_v1: ['imported', 'active', 'inactive', 'incomplete']
+          .map((value) => ({ value })),
+        stock_preparation_run_type_v1: ['plm_sync', 'erp_material_sync', 'mapping_match', 'unit_match', 'prep_generate']
+          .map((value) => ({ value })),
+        stock_preparation_run_status_v1: ['running', 'succeeded', 'failed', 'partial']
+          .map((value) => ({ value })),
+      },
+    })
+  })
+
+  afterAll(async () => {
+    if (previousFlag === undefined) delete process.env[FLAG]
+    else process.env[FLAG] = previousFlag
+    const ids = [...sheetIds.values()]
+    if (ids.length === 0) return
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = ANY($1::text[])', [ids]).catch(() => {})
+    await q(
+      'DELETE FROM meta_links WHERE record_id IN (SELECT id FROM meta_records WHERE sheet_id = ANY($1::text[])) OR foreign_record_id IN (SELECT id FROM meta_records WHERE sheet_id = ANY($1::text[]))',
+      [ids],
+    ).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [ids]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = ANY($1::text[])', [ids]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [ids]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [ids]).catch(() => {})
+  })
+
+  test('flag ON persists project/batch/line/run through physical field ids, stays values-free, and an exact replay is an internal noop', async () => {
+    process.env[FLAG] = 'true'
+    const { services } = createServices(SOURCE_ROWS)
+    const handlers = createHandlers(services, { context })
+    const handler = handlers.stockPreparationPlmBomSourceRun
+    expect(handler).toBeTypeOf('function')
+
+    const first = response()
+    await handler(adminRequest(), first)
+    const firstData = asRecord(asRecord(first.body).data)
+    expect(first.statusCode).toBe(201)
+    expect(firstData).toMatchObject({
+      mode: 'internal_persist',
+      evidence: {
+        internalWriteExecuted: true,
+        externalWriteExecuted: false,
+        productionWrite: false,
+        k3SaveSubmitAudit: false,
+        plmExternalWrite: false,
+      },
+    })
+    expect(asRecord(firstData.autoPersist)).toMatchObject({ persisted: true, mode: 'created' })
+
+    // Values-free response: none of the business sentinels cross HTTP.
+    for (const forbidden of [CHILD_CODE_1, CHILD_CODE_2, SOURCE_PROJECT_NO, PROJECT_NAME, SOURCE_CREDENTIAL, CONFIG_ID, SYSTEM_ID]) {
+      expect(deepIncludes(first.body, forbidden)).toBe(false)
+    }
+    expect(Object.prototype.hasOwnProperty.call(firstData, 'intake')).toBe(false)
+
+    // Physical landing: exactly one project, one batch, one run, and BOTH lines (not one row dropped).
+    const counts = await countsBySheet()
+    expect(counts[sheetIds.get(PROJECT_OBJECT_ID) as string]).toBe(1)
+    expect(counts[sheetIds.get(BATCH_OBJECT_ID) as string]).toBe(1)
+    expect(counts[sheetIds.get(LINE_OBJECT_ID) as string]).toBe(SOURCE_ROWS.length)
+    expect(counts[sheetIds.get(RUN_OBJECT_ID) as string]).toBe(1)
+
+    // Cross-check the line rows against meta_fields-discovered PHYSICAL ids: the sentinel child code
+    // really landed (positive control for the leak scan above) and the default 'imported' intake
+    // status crossed the bridge as canonical 'active'.
+    const lineSheetId = sheetIds.get(LINE_OBJECT_ID) as string
+    const lineFields = await discoverPhysicalFields(lineSheetId, LINE_OBJECT_ID)
+    const lineRows = await q('SELECT data FROM meta_records WHERE sheet_id = $1', [lineSheetId])
+    const lineData = (lineRows.rows as Array<{ data: unknown }>).map((row) => asRecord(row.data))
+    const childCodes = lineData.map((data) => data[lineFields.childDrawingNo]).sort()
+    expect(childCodes).toEqual([CHILD_CODE_1, CHILD_CODE_2].sort())
+    for (const data of lineData) {
+      expect(data[lineFields.lineStatus]).toBe('active')
+      expect(Object.prototype.hasOwnProperty.call(data, 'lineStatus')).toBe(false)
+    }
+
+    // Exact replay: same request, no new rows, and the response says NOOP — never a hard-coded
+    // internal-write claim just because the flag is ON.
+    const replay = response()
+    await handler(adminRequest(), replay)
+    const replayData = asRecord(asRecord(replay.body).data)
+    expect(replay.statusCode).toBe(200)
+    expect(replayData.mode).toBe('internal_noop')
+    expect(asRecord(replayData.evidence).internalWriteExecuted).toBe(false)
+    expect(asRecord(replayData.autoPersist)).toMatchObject({ persisted: false, mode: 'skipped_existing' })
+    expect(await countsBySheet()).toEqual(counts)
+  })
+
+  test('flag OFF preserves the read-only response and writes no internal rows', async () => {
+    delete process.env[FLAG]
+    const before = await countsBySheet()
+    const { services } = createServices(SOURCE_ROWS)
+    const handlers = createHandlers(services, { context })
+    const res = response()
+    await handlers.stockPreparationPlmBomSourceRun(adminRequest({
+      syncRunId: `off_${SYNC_RUN_ID}`,
+      snapshotBatchId: `off_${SNAPSHOT_BATCH_ID}`,
+    }), res)
+    expect(res.statusCode).toBe(200)
+    const data = asRecord(asRecord(res.body).data)
+    expect(data.mode).toBe('dry_run')
+    expect(asRecord(data.evidence).internalWriteExecuted).toBe(false)
+    expect(Object.prototype.hasOwnProperty.call(data, 'autoPersist')).toBe(false)
+    expect(await countsBySheet()).toEqual(before)
+  })
+
+  test('flag ON rejects a source-mapped raw lifecycle with the dedicated 422 and zero writes', async () => {
+    process.env[FLAG] = 'true'
+    const before = await countsBySheet()
+    const { services } = createServices(
+      [
+        { path: '/root/asm-1', childCode: CHILD_CODE_1, quantity: 2, state: 'released' },
+        { path: '/root/asm-1/part-2', childCode: CHILD_CODE_2, quantity: 1, state: 'active' },
+      ],
+      [...DEFAULT_FIELD_MAP, { source: 'state', target: 'lineStatus' }],
+    )
+    const handlers = createHandlers(services, { context })
+    let caught: unknown
+    try {
+      await handlers.stockPreparationPlmBomSourceRun(adminRequest({
+        syncRunId: `lifecycle_${SYNC_RUN_ID}`,
+        snapshotBatchId: `lifecycle_${SNAPSHOT_BATCH_ID}`,
+      }), response())
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toMatchObject({ status: 422, code: 'STOCK_PREPARATION_PLM_AUTOPERSIST_LINE_STATUS_UNSUPPORTED' })
+    const coarse = caught as { message?: unknown; code?: unknown; details?: unknown }
+    expect(deepIncludes({ message: coarse.message, code: coarse.code, details: coarse.details }, 'released')).toBe(false)
+    expect(await countsBySheet()).toEqual(before)
+  })
+
+  test('flag ON structurally rejects a forbidden missingChildBom fieldMap target before any source adapter exists', async () => {
+    process.env[FLAG] = 'true'
+    const before = await countsBySheet()
+    const { services, adapterCreates } = createServices(
+      [
+        { path: '/root/asm-1', childCode: CHILD_CODE_1, quantity: 2, state: 'active', secretMarkerColumn: false },
+        { path: '/root/asm-1/part-2', childCode: CHILD_CODE_2, quantity: 1, state: 'active', secretMarkerColumn: true },
+      ],
+      [
+        ...DEFAULT_FIELD_MAP,
+        { source: 'secretMarkerColumn', target: 'missingChildBom' },
+        { source: 'state', target: 'lineStatus' },
+      ],
+    )
+    const handlers = createHandlers(services, { context })
+    let caught: unknown
+    try {
+      await handlers.stockPreparationPlmBomSourceRun(adminRequest({
+        syncRunId: `guard_${SYNC_RUN_ID}`,
+        snapshotBatchId: `guard_${SNAPSHOT_BATCH_ID}`,
+      }), response())
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toMatchObject({ status: 422, code: 'STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_TARGET_FORBIDDEN' })
+    const coarse = caught as { message?: unknown; code?: unknown; details?: unknown }
+    expect(deepIncludes({ message: coarse.message, code: coarse.code, details: coarse.details }, 'secretMarkerColumn')).toBe(false)
+    expect(adapterCreates).toHaveLength(0)
+    expect(await countsBySheet()).toEqual(before)
+  })
+})

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -7799,6 +7799,419 @@ async function testStockPreparationErpAutoPersistTenantResolversDiffer() {
   console.log('  testStockPreparationErpAutoPersistTenantResolversDiffer OK')
 }
 
+// ── T3b-1c: PLM source-run server-side auto-persist (flag MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED) ──
+// design-lock: docs/development/stock-preparation-t3b-plm-source-autopersist-design-lock-20260716.md
+const T3B_PLM_CONFIG_ID = 'private_plm_config_t3b_9911'
+const T3B_PLM_SYSTEM_ID = 'private_plm_system_t3b_9911'
+const T3B_PLM_CHILD_1 = 'RAW-PLM-CHILD-T3B-9911' // childCode -> childDrawingNo (business value sentinel)
+const T3B_PLM_CHILD_2 = 'RAW-PLM-CHILD2-T3B-9911'
+const T3B_PLM_CREDENTIAL = 'PRIVATE-PLM-CRED-T3B-9911'
+const T3B_SOURCE_PROJECT_NO = 'SOURCE-PROJECT-SECRET-T3B-9911'
+const T3B_PROJECT_NAME = 'Secret project name T3B 9911'
+const T3B_SOURCE_RUN_PATH = '/api/integration/stock-preparation/mvp/source-runs/plm-bom'
+const T3B_DEFAULT_FIELD_MAP = Object.freeze([
+  { source: 'path', target: 'pathKey' },
+  { source: 'childCode', target: 'childDrawingNo' },
+  { source: 'quantity', target: 'designQty' },
+])
+const T3B_DEFAULT_ROWS = Object.freeze([
+  { path: '/root/asm-1', childCode: T3B_PLM_CHILD_1, quantity: 2 },
+  { path: '/root/asm-1/part-2', childCode: T3B_PLM_CHILD_2, quantity: 1 },
+])
+
+function t3bNormalizedPlmConfig(fieldMap) {
+  const validation = validateReadSourceConfig({
+    version: 1,
+    systemId: T3B_PLM_SYSTEM_ID,
+    requiredKind: 'plm:yuantus-wrapper',
+    object: 'stock-preparation-source',
+    mode: 'list_page',
+    readPath: '/readonly/stock-preparation',
+    readMethod: 'POST',
+    operations: ['read'],
+    containerPaths: ['Rows'],
+    fieldMap,
+  })
+  assert.equal(validation.valid, true, JSON.stringify(validation.errors))
+  return validation.normalized
+}
+
+// Approved PLM read-source + a mock adapter emitting BOM rows carrying sentinel business values. The
+// harness counts adapter CREATION separately from reads: the config-guard rejection path must show the
+// adapter was never even constructed (design-lock: rejection with records/provisioning/source-adapter
+// call counts at ZERO).
+function createPlmAutoPersistHarness({ recordsApi, provisioningApi, fieldMap = T3B_DEFAULT_FIELD_MAP, rows = T3B_DEFAULT_ROWS } = {}) {
+  const plmConfig = t3bNormalizedPlmConfig(Array.isArray(fieldMap) ? fieldMap.map((entry) => ({ ...entry })) : fieldMap)
+  const sourceReadCalls = []
+  const adapterCreateCalls = []
+  const externalWriteCalls = []
+  const { services } = createMockServices({
+    readSourceConfigStore: {
+      async getForRuntime(input) {
+        if (input.id === T3B_PLM_CONFIG_ID) {
+          return { id: T3B_PLM_CONFIG_ID, status: 'approved', systemId: T3B_PLM_SYSTEM_ID, config: plmConfig }
+        }
+        throw new Error('unexpected config reference')
+      },
+    },
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        return { id: input.id, tenantId: input.tenantId, kind: 'plm:yuantus-wrapper', credentials: { password: T3B_PLM_CREDENTIAL }, config: {} }
+      },
+    },
+    adapterRegistry: {
+      createAdapter(system) {
+        adapterCreateCalls.push(system.kind)
+        return {
+          async read(request) {
+            sourceReadCalls.push({ kind: system.kind, request })
+            const pageRows = rows.map((row) => ({ ...row }))
+            return { records: pageRows, raw: { Rows: pageRows }, metadata: { totalCount: pageRows.length, returnedRecordCount: pageRows.length } }
+          },
+          async upsert(input) { externalWriteCalls.push(['upsert', input]) },
+          async save(input) { externalWriteCalls.push(['save', input]) },
+          async submit(input) { externalWriteCalls.push(['submit', input]) },
+          async audit(input) { externalWriteCalls.push(['audit', input]) },
+        }
+      },
+    },
+  })
+  const { routes } = mountRoutes(services, { recordsApi, provisioningApi })
+  return { routes, sourceReadCalls, adapterCreateCalls, externalWriteCalls }
+}
+
+function t3bRequestBody(overrides = {}) {
+  return {
+    workspaceId: 'workspace_1',
+    projectId: 'business_project_t3b',
+    sourceProjectNo: T3B_SOURCE_PROJECT_NO,
+    projectName: T3B_PROJECT_NAME,
+    readSourceConfigId: T3B_PLM_CONFIG_ID,
+    syncRunId: 'plm_autopersist_run_1',
+    snapshotBatchId: 'plm_autopersist_snapshot_1',
+    snapshotVersion: 1,
+    ...overrides,
+  }
+}
+
+function withPlmAutoPersistFlag(value, run) {
+  const prev = process.env.MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED
+  if (value === undefined) delete process.env.MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED
+  else process.env.MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED = value
+  return Promise.resolve()
+    .then(run)
+    .finally(() => {
+      if (prev === undefined) delete process.env.MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED
+      else process.env.MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED = prev
+    })
+}
+
+async function testStockPreparationPlmSourceRunAutoPersistOn() {
+  await withPlmAutoPersistFlag('true', async () => {
+    const store = createInMemoryMvpPersistStore()
+    const { routes, sourceReadCalls, externalWriteCalls } = createPlmAutoPersistHarness({
+      recordsApi: store.recordsApi,
+      provisioningApi: store.provisioningApi,
+    })
+
+    const first = await invoke(routes, 'POST', T3B_SOURCE_RUN_PATH, { user: ADMIN_USER, body: t3bRequestBody() })
+    // OD-5 created leg: a real internal write happened — the read-only projector's fixed mode:'dry_run' /
+    // internalWriteExecuted:false are overridden and a landed batch makes it 201.
+    assertOkResponse(first, 201)
+    assert.equal(first.body.data.mode, 'internal_persist')
+    assert.equal(first.body.data.evidence.internalWriteExecuted, true)
+    assert.equal(first.body.data.autoPersist.persisted, true)
+    assert.equal(first.body.data.autoPersist.mode, 'created')
+    // externalWrite invariant: the auto-persist path never touches an external write operation.
+    assert.equal(externalWriteCalls.length, 0, 'auto-persist never calls an external write operation')
+    assert.equal(first.body.data.evidence.externalWriteExecuted, false)
+    assert.equal(first.body.data.evidence.productionWrite, false)
+    assert.equal(first.body.data.evidence.k3SaveSubmitAudit, false)
+    assert.equal(first.body.data.evidence.plmExternalWrite, false)
+
+    // OD-2: the physical target derives from the AUTHENTICATED principal's staging project only — the
+    // body projectId is a business key on the rows, never a target selector.
+    assert.ok(store.findObjectSheetCalls.length > 0, 'the auto-persist resolves at least one MVP target sheet')
+    for (const call of store.findObjectSheetCalls) {
+      assert.equal(call.projectId, `${ADMIN_USER.tenantId}:integration-core`, 'persist target project derives from the auth tenant')
+    }
+
+    // OD-3 "not one row dropped", proven in the write sink: BOTH source rows landed on the snapshot-line
+    // sheet, and the default 'imported' intake status crossed the bridge as canonical 'active'.
+    const lineObjectIds = store.findObjectSheetCalls.map((call) => call.objectId).filter((objectId) => /line/i.test(String(objectId)))
+    assert.ok(lineObjectIds.length > 0, 'a snapshot-line sheet was resolved')
+    const lineSheetIds = new Set(lineObjectIds.map((objectId) => `sheet_${objectId}`))
+    const lineCreates = store.writes.filter((write) => write.op === 'create' && lineSheetIds.has(write.sheetId))
+    assert.equal(lineCreates.length, T3B_DEFAULT_ROWS.length, 'every intake row lands as exactly one snapshot-line create')
+    assert.equal(deepStringIncludes(lineCreates, 'active'), true, "default 'imported' intake status persists as canonical 'active'")
+    assert.equal(deepStringIncludes(store.writes, 'imported'), false, "the raw 'imported' vocabulary never reaches the write sink")
+
+    // Leak-bait, BOTH directions with the SAME scan: the sentinels reached the internal write sink
+    // (positive control proves the scan works) yet never appear in the values-free HTTP response.
+    assert.equal(deepStringIncludes(store.writes, T3B_PLM_CHILD_1), true, 'positive control: the PLM child code reached the internal write sink')
+    for (const forbidden of [T3B_PLM_CHILD_1, T3B_PLM_CHILD_2, T3B_PLM_CREDENTIAL, T3B_SOURCE_PROJECT_NO, T3B_PROJECT_NAME, T3B_PLM_CONFIG_ID, T3B_PLM_SYSTEM_ID]) {
+      assert.equal(deepStringIncludes(first.body, forbidden), false, `values-free: ${forbidden} never crosses the HTTP response`)
+    }
+    assert.equal(Object.prototype.hasOwnProperty.call(first.body.data, 'intake'), false)
+    assert.equal(Object.prototype.hasOwnProperty.call(first.body.data, 'bomSnapshotLines'), false)
+
+    // OD-4/OD-5 exact-replay leg: the SAME request is an internal NOOP — 200 + mode:'internal_noop' +
+    // internalWriteExecuted:false (never a hard-coded internal-write claim), and the sink gains no rows.
+    const createsBeforeReplay = store.writes.filter((write) => write.op === 'create').length
+    const readsBeforeReplay = sourceReadCalls.length
+    const replay = await invoke(routes, 'POST', T3B_SOURCE_RUN_PATH, { user: ADMIN_USER, body: t3bRequestBody() })
+    assertOkResponse(replay, 200)
+    assert.equal(replay.body.data.mode, 'internal_noop')
+    assert.equal(replay.body.data.evidence.internalWriteExecuted, false)
+    assert.equal(replay.body.data.autoPersist.persisted, false)
+    assert.equal(replay.body.data.autoPersist.mode, 'skipped_existing')
+    assert.ok(sourceReadCalls.length > readsBeforeReplay, 'the replay reads the source again')
+    assert.equal(store.writes.filter((write) => write.op === 'create').length, createsBeforeReplay, 'an exact replay creates no new rows')
+  })
+  console.log('  testStockPreparationPlmSourceRunAutoPersistOn OK')
+}
+
+async function testStockPreparationPlmSourceRunAutoPersistSteering() {
+  await withPlmAutoPersistFlag('true', async () => {
+    // OD-2 layered semantics: tenantId is rejected on EVERY carrier; projectId is rejected only on the
+    // ambiguous query/params carriers. Every rejection carries the DEDICATED code and fires BEFORE the
+    // body allowlist AND any I/O (adapter creation, source read, records, provisioning).
+    const vectors = [
+      ['body.tenantId', { body: t3bRequestBody({ tenantId: 'tenant_evil' }) }],
+      ['query.tenantId', { body: t3bRequestBody(), query: { tenantId: 'tenant_evil' } }],
+      ['params.tenantId', { body: t3bRequestBody(), params: { tenantId: 'tenant_evil' } }],
+      ['query.projectId', { body: t3bRequestBody(), query: { projectId: 'tenant_evil:integration-core' } }],
+      ['params.projectId', { body: t3bRequestBody(), params: { projectId: 'tenant_evil:integration-core' } }],
+    ]
+    for (const [label, reqExtra] of vectors) {
+      const bomb = createCountingThrowMvpApis()
+      const { routes, sourceReadCalls, adapterCreateCalls, externalWriteCalls } = createPlmAutoPersistHarness({
+        recordsApi: bomb.recordsApi,
+        provisioningApi: bomb.provisioningApi,
+      })
+      const res = await invoke(routes, 'POST', T3B_SOURCE_RUN_PATH, { user: ADMIN_USER, ...reqExtra })
+      assert.equal(res.statusCode, 400, `${label}: steering rejected`)
+      assert.equal(res.body.error.code, 'STOCK_PREPARATION_PLM_AUTOPERSIST_STEERING_NOT_ALLOWED', `${label}: DEDICATED steering code`)
+      assert.equal(adapterCreateCalls.length, 0, `${label}: guard fires before any source adapter exists`)
+      assert.equal(sourceReadCalls.length, 0, `${label}: guard fires before any source read`)
+      assert.equal(externalWriteCalls.length, 0, `${label}: guard fires before any external write`)
+      assert.equal(bomb.state.calls, 0, `${label}: guard fires before any records/provisioning I/O`)
+    }
+
+    // The BODY projectId is REQUIRED — omitting it fails the source-run's own validation with ZERO
+    // records/provisioning I/O (it is a business key, not an optional decoration).
+    const bomb = createCountingThrowMvpApis()
+    const missing = createPlmAutoPersistHarness({ recordsApi: bomb.recordsApi, provisioningApi: bomb.provisioningApi })
+    const noProject = await invoke(missing.routes, 'POST', T3B_SOURCE_RUN_PATH, {
+      user: ADMIN_USER,
+      body: t3bRequestBody({ projectId: undefined }),
+    })
+    assert.equal(noProject.statusCode, 422, 'a missing body projectId is rejected')
+    assert.equal(noProject.body.error.code, 'SOURCE_RUN_CONFIG_INVALID')
+    assert.equal(noProject.body.error.details.field, 'projectId')
+    assert.equal(bomb.state.calls, 0, 'a missing body projectId causes no records/provisioning I/O')
+
+    // A body projectId SHAPED like another tenant's staging project id is still just a business key:
+    // the run persists (201) but every physical target stays under the AUTH tenant's staging project.
+    const store = createInMemoryMvpPersistStore()
+    const { routes } = createPlmAutoPersistHarness({ recordsApi: store.recordsApi, provisioningApi: store.provisioningApi })
+    const shaped = await invoke(routes, 'POST', T3B_SOURCE_RUN_PATH, {
+      user: ADMIN_USER,
+      body: t3bRequestBody({ projectId: 'tenant_evil:integration-core', syncRunId: 'plm_autopersist_shaped_1', snapshotBatchId: 'plm_autopersist_snapshot_shaped_1' }),
+    })
+    assert.equal(shaped.statusCode, 201, 'a staging-shaped BODY projectId is a business key, not a steering vector')
+    assert.ok(store.findObjectSheetCalls.length > 0)
+    for (const call of store.findObjectSheetCalls) {
+      assert.equal(call.projectId, `${ADMIN_USER.tenantId}:integration-core`, 'the body projectId can never move the physical target')
+    }
+  })
+  console.log('  testStockPreparationPlmSourceRunAutoPersistSteering OK')
+}
+
+async function testStockPreparationPlmSourceRunAutoPersistConfigGuard() {
+  // OD-3 amendment (owner P2): a config that maps ANY column onto the internal `missingChildBom` marker
+  // is structurally rejected on the auto-persist path BEFORE the source adapter is even constructed —
+  // the value-level status vocabulary cannot catch the combined-mapping bypass (marker + explicit
+  // lineStatus), so the CONFIG is the enforcement point.
+  const forbiddenFieldMap = [
+    { source: 'path', target: 'pathKey' },
+    { source: 'childCode', target: 'childDrawingNo' },
+    { source: 'quantity', target: 'designQty' },
+    { source: 'secretSourceColumn9911', target: 'missingChildBom' },
+    { source: 'state', target: 'lineStatus' },
+  ]
+  // The EXACT combined-mapping bypass rows the lock describes: the marker is TRUE while an explicit
+  // canonical lineStatus rides beside it — value-level checks see only 'active' and the missing-child
+  // signal would vanish end-to-end. (The read runtime itself 422s on fieldMap sources absent from the
+  // returned rows, so these columns must really exist on the wire.)
+  const bypassRows = [
+    { path: '/root/asm-1', childCode: T3B_PLM_CHILD_1, quantity: 2, state: 'active', secretSourceColumn9911: false },
+    { path: '/root/asm-1/part-2', childCode: T3B_PLM_CHILD_2, quantity: 1, state: 'active', secretSourceColumn9911: true },
+  ]
+  await withPlmAutoPersistFlag('true', async () => {
+    const bomb = createCountingThrowMvpApis()
+    const { routes, sourceReadCalls, adapterCreateCalls, externalWriteCalls } = createPlmAutoPersistHarness({
+      recordsApi: bomb.recordsApi,
+      provisioningApi: bomb.provisioningApi,
+      fieldMap: forbiddenFieldMap,
+      rows: bypassRows,
+    })
+    const res = await invoke(routes, 'POST', T3B_SOURCE_RUN_PATH, { user: ADMIN_USER, body: t3bRequestBody() })
+    assert.equal(res.statusCode, 422, 'forbidden marker target rejects the whole run')
+    assert.equal(res.body.error.code, 'STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_TARGET_FORBIDDEN')
+    // The rejection names only the forbidden TARGET vocabulary — never the source column.
+    assert.equal(deepStringIncludes(res.body, 'missingChildBom'), true, 'the forbidden target vocabulary is named')
+    assert.equal(deepStringIncludes(res.body, 'secretSourceColumn9911'), false, 'the source column name never crosses the response')
+    assert.equal(adapterCreateCalls.length, 0, 'config guard fires before any source adapter exists')
+    assert.equal(sourceReadCalls.length, 0, 'config guard fires before any source read')
+    assert.equal(externalWriteCalls.length, 0, 'config guard fires before any external write')
+    assert.equal(bomb.state.calls, 0, 'config guard fires before any records/provisioning I/O')
+  })
+  await withPlmAutoPersistFlag(undefined, async () => {
+    // Flag OFF: the same config keeps today's READ-ONLY behavior — the guard is an auto-persist
+    // precondition, not a new restriction on the existing dry-run surface.
+    const bomb = createCountingThrowMvpApis()
+    const { routes } = createPlmAutoPersistHarness({
+      recordsApi: bomb.recordsApi,
+      provisioningApi: bomb.provisioningApi,
+      fieldMap: forbiddenFieldMap,
+      rows: bypassRows,
+    })
+    const res = await invoke(routes, 'POST', T3B_SOURCE_RUN_PATH, { user: ADMIN_USER, body: t3bRequestBody() })
+    assertOkResponse(res, 200)
+    assert.equal(res.body.data.mode, 'dry_run')
+    assert.equal(bomb.state.calls, 0, 'the read-only path still never touches records/provisioning')
+  })
+  console.log('  testStockPreparationPlmSourceRunAutoPersistConfigGuard OK')
+}
+
+async function testStockPreparationPlmSourceRunAutoPersistLineStatus() {
+  const statusFieldMap = [
+    { source: 'path', target: 'pathKey' },
+    { source: 'childCode', target: 'childDrawingNo' },
+    { source: 'quantity', target: 'designQty' },
+    { source: 'state', target: 'lineStatus' },
+  ]
+  await withPlmAutoPersistFlag('true', async () => {
+    // OD-3: a source-mapped RAW lifecycle value outside the bridge input vocabulary rejects the WHOLE
+    // envelope with the dedicated 422 — after the (read-only) source read, but with persist/provisioning
+    // at ZERO calls — and the raw lifecycle value never crosses the response.
+    for (const rawLifecycle of ['released', 'obsolete', 'WIP']) {
+      const bomb = createCountingThrowMvpApis()
+      const { routes, sourceReadCalls } = createPlmAutoPersistHarness({
+        recordsApi: bomb.recordsApi,
+        provisioningApi: bomb.provisioningApi,
+        fieldMap: statusFieldMap,
+        rows: [
+          { path: '/root/asm-1', childCode: T3B_PLM_CHILD_1, quantity: 2, state: rawLifecycle },
+          { path: '/root/asm-1/part-2', childCode: T3B_PLM_CHILD_2, quantity: 1, state: 'active' },
+        ],
+      })
+      const res = await invoke(routes, 'POST', T3B_SOURCE_RUN_PATH, { user: ADMIN_USER, body: t3bRequestBody() })
+      assert.equal(res.statusCode, 422, `${rawLifecycle}: unsupported lifecycle rejects the whole envelope`)
+      assert.equal(res.body.error.code, 'STOCK_PREPARATION_PLM_AUTOPERSIST_LINE_STATUS_UNSUPPORTED', `${rawLifecycle}: dedicated coarse code`)
+      assert.equal(res.body.error.details.unsupportedRowCount, 1, `${rawLifecycle}: only the stable row count is disclosed`)
+      assert.equal(deepStringIncludes(res.body, rawLifecycle), false, `${rawLifecycle}: the raw lifecycle value never crosses the response`)
+      assert.equal(sourceReadCalls.length, 1, `${rawLifecycle}: the read-only source read ran`)
+      assert.equal(bomb.state.calls, 0, `${rawLifecycle}: persist/provisioning never ran`)
+    }
+
+    // Option A (ratified): the config guard already bars MAPPING the missingChildBom marker on this
+    // path, so the one remaining way intake can carry the internal 'missing_child_bom' status is a
+    // source-mapped status column whose VALUE is that marker. It rejects the WHOLE envelope — never a
+    // silent normalization to active/incomplete, never a partial write.
+    const bomb = createCountingThrowMvpApis()
+    const marker = createPlmAutoPersistHarness({
+      recordsApi: bomb.recordsApi,
+      provisioningApi: bomb.provisioningApi,
+      fieldMap: statusFieldMap,
+      rows: [
+        { path: '/root/asm-1', childCode: T3B_PLM_CHILD_1, quantity: 2, state: 'active' },
+        { path: '/root/asm-1/part-2', childCode: T3B_PLM_CHILD_2, quantity: 1, state: 'missing_child_bom' },
+      ],
+    })
+    const res = await invoke(marker.routes, 'POST', T3B_SOURCE_RUN_PATH, { user: ADMIN_USER, body: t3bRequestBody() })
+    assert.equal(res.statusCode, 422, 'a missing-child marker row rejects the whole envelope (Option A)')
+    assert.equal(res.body.error.code, 'STOCK_PREPARATION_PLM_AUTOPERSIST_LINE_STATUS_UNSUPPORTED')
+    assert.equal(deepStringIncludes(res.body, 'missing_child_bom'), false, 'the internal marker status never crosses the response')
+    assert.equal(bomb.state.calls, 0, 'the marker rejection reaches no records/provisioning I/O')
+
+    // A source-mapped status that is ALREADY canonical passes through unchanged (inactive stays inactive).
+    const store = createInMemoryMvpPersistStore()
+    const canonical = createPlmAutoPersistHarness({
+      recordsApi: store.recordsApi,
+      provisioningApi: store.provisioningApi,
+      fieldMap: statusFieldMap,
+      rows: [
+        { path: '/root/asm-1', childCode: T3B_PLM_CHILD_1, quantity: 2, state: 'inactive' },
+        { path: '/root/asm-1/part-2', childCode: T3B_PLM_CHILD_2, quantity: 1, state: 'active' },
+      ],
+    })
+    const ok = await invoke(canonical.routes, 'POST', T3B_SOURCE_RUN_PATH, {
+      user: ADMIN_USER,
+      body: t3bRequestBody({ syncRunId: 'plm_autopersist_canonical_1', snapshotBatchId: 'plm_autopersist_snapshot_canonical_1' }),
+    })
+    assert.equal(ok.statusCode, 201, 'canonical source-mapped statuses persist')
+    assert.equal(deepStringIncludes(store.writes, 'inactive'), true, "canonical 'inactive' survives the bridge into the write sink")
+  })
+  console.log('  testStockPreparationPlmSourceRunAutoPersistLineStatus OK')
+}
+
+async function testStockPreparationPlmSourceRunAutoPersistOffInert() {
+  const offBody = t3bRequestBody({ tenantId: 'tenant_evil', syncRunId: 'plm_autopersist_off_1', snapshotBatchId: 'plm_autopersist_snapshot_off_1' })
+  const responses = []
+  for (const flagValue of [undefined, 'false']) {
+    await withPlmAutoPersistFlag(flagValue, async () => {
+      const bomb = createCountingThrowMvpApis()
+      const { routes, externalWriteCalls, sourceReadCalls } = createPlmAutoPersistHarness({ recordsApi: bomb.recordsApi, provisioningApi: bomb.provisioningApi })
+      // Flag OFF (unset AND explicit 'false'): today's read-only behavior byte-for-byte — even a body
+      // tenantId is harmless because the read has no write side effect; the steering guard is not
+      // engaged and no autoPersist field is added.
+      const res = await invoke(routes, 'POST', T3B_SOURCE_RUN_PATH, { user: ADMIN_USER, body: { ...offBody } })
+      assertOkResponse(res, 200)
+      assert.equal(res.body.data.mode, 'dry_run')
+      assert.equal(res.body.data.evidence.internalWriteExecuted, false)
+      assert.equal(Object.prototype.hasOwnProperty.call(res.body.data, 'autoPersist'), false, 'OFF adds no autoPersist field')
+      assert.equal(bomb.state.calls, 0, 'OFF never touches records/provisioning')
+      assert.equal(externalWriteCalls.length, 0)
+      assert.equal(sourceReadCalls.length, 1, 'OFF still performs exactly the one read-only source read')
+      responses.push(JSON.parse(JSON.stringify(res.body)))
+    })
+  }
+  // Byte-equivalence between the two OFF spellings: the response is deterministic and identical.
+  assert.deepEqual(responses[0], responses[1], "flag unset and flag 'false' produce identical read-only responses")
+  console.log('  testStockPreparationPlmSourceRunAutoPersistOffInert OK')
+}
+
+async function testStockPreparationPlmSourceRunAutoPersistFailureIsCoarse() {
+  await withPlmAutoPersistFlag('true', async () => {
+    // OD-4/OD-5: a mid-persist failure surfaces as a coarse values-free error — no intake echo, no
+    // partial counters, no business values — and the response never claims the write succeeded.
+    const store = createInMemoryMvpPersistStore()
+    const failingRecordsApi = {
+      queryRecords: store.recordsApi.queryRecords,
+      patchRecord: store.recordsApi.patchRecord,
+      async createRecord(input) {
+        const creates = store.writes.filter((write) => write.op === 'create').length
+        if (creates >= 2) throw new Error('injected mid-persist storage failure')
+        return store.recordsApi.createRecord(input)
+      },
+    }
+    const { routes } = createPlmAutoPersistHarness({ recordsApi: failingRecordsApi, provisioningApi: store.provisioningApi })
+    const res = await invoke(routes, 'POST', T3B_SOURCE_RUN_PATH, {
+      user: ADMIN_USER,
+      body: t3bRequestBody({ syncRunId: 'plm_autopersist_fail_1', snapshotBatchId: 'plm_autopersist_snapshot_fail_1' }),
+    })
+    assert.ok(res.statusCode >= 500, `mid-persist failure is a server-side error (got ${res.statusCode})`)
+    assert.equal(res.body.ok, false)
+    for (const forbidden of [T3B_PLM_CHILD_1, T3B_PLM_CHILD_2, T3B_PLM_CREDENTIAL, T3B_SOURCE_PROJECT_NO, T3B_PROJECT_NAME]) {
+      assert.equal(deepStringIncludes(res.body, forbidden), false, `coarse failure: ${forbidden} never crosses the error response`)
+    }
+    assert.equal(deepStringIncludes(res.body, 'internal_persist'), false, 'a failed persist never claims internal_persist')
+  })
+  console.log('  testStockPreparationPlmSourceRunAutoPersistFailureIsCoarse OK')
+}
+
 async function main() {
   await testTemplatesCrudRoutes()
   await testUnauthenticatedWriteRequestIsRejected()
@@ -7834,6 +8247,12 @@ async function main() {
   await testStockPreparationErpSourceRunAutoPersistSteering()
   await testStockPreparationErpSourceRunAutoPersistOffInert()
   await testStockPreparationErpAutoPersistTenantResolversDiffer()
+  await testStockPreparationPlmSourceRunAutoPersistOn()
+  await testStockPreparationPlmSourceRunAutoPersistSteering()
+  await testStockPreparationPlmSourceRunAutoPersistConfigGuard()
+  await testStockPreparationPlmSourceRunAutoPersistLineStatus()
+  await testStockPreparationPlmSourceRunAutoPersistOffInert()
+  await testStockPreparationPlmSourceRunAutoPersistFailureIsCoarse()
   await testExternalSystemUpsertPreservesObjectSchema()
   await testExternalSystemTestPersistsFailureAndPreservesInactive()
   await testExternalSystemTestClearsErrorToActiveOnSuccess()

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -296,6 +296,12 @@ const { planBomSnapshotSyncRun } = require('./stock-preparation-sync-run-plan.cj
 // its batch + line + run rows into the internal MVP tables via a target-scoped records API — the FIRST
 // business-row write. Internal-only (structural), idempotent, immutable, admin-gated, values-free.
 const { persistStockPreparationSyncRun } = require('./stock-preparation-sync-run-persist.cjs')
+// T3b-1c: the pure intake→persist bridge (OD-3) + the pre-I/O structural config guard (OD-3 amendment).
+// Both are pure — the route stays the only place that sequences them against real I/O.
+const {
+  assertPlmAutoPersistSourceConfigSafe,
+  buildPlmSourcePersistInput,
+} = require('./stock-preparation-plm-source-persist-bridge.cjs')
 // #3889: approved PLM / ERP-K3 readonly config -> existing pure intake contract. Routes return only
 // the values-free projection; normalized rows remain an internal backend data plane.
 const {
@@ -582,6 +588,37 @@ function assertStockPreparationErpAutoPersistNoSteering(req) {
       400,
       'STOCK_PREPARATION_ERP_AUTOPERSIST_STEERING_NOT_ALLOWED',
       'an explicit tenantId/projectId is not allowed on the auto-persisting ERP source-run; the tenant and cache target are derived from the authenticated principal',
+    )
+  }
+}
+
+// T3b (OD-1): the PLM source-run auto-persist gate — a SEPARATE flag from the T3a ERP one (the lock
+// forbids folding T3b into the T3a flag or reusing the ERP cache's autoPersist gate). Same strict
+// idiom: only the literal 'true' (trimmed, case-insensitive) turns it on; default OFF keeps the PLM
+// source-run read-only byte-for-byte.
+function stockPreparationPlmAutoPersistEnabled() {
+  return String(process.env.MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED ?? '').trim().toLowerCase() === 'true'
+}
+
+// T3b OD-2 (layered semantics — deliberately NOT a copy of the ERP guard): with auto-persist ON the
+// PLM source-run gains a write side-effect, so an explicit tenantId on ANY carrier is a steering
+// vector and is rejected fail-closed BEFORE body normalization and any I/O. projectId differs from
+// T3a: the BODY projectId is the REQUIRED business project key carried on the written rows (it never
+// derives the tenant or the physical target), so only a query/params projectId — a second, ambiguous
+// carrier — is rejected. workspaceId stays a same-tenant approved-config selector and is not rejected.
+function assertStockPreparationPlmAutoPersistNoSteering(req) {
+  const explicit = (src, key) => Boolean(src) && `${src[key] ?? ''}`.trim() !== ''
+  const body = requestBody(req)
+  const query = requestQuery(req)
+  const params = requestParams(req)
+  if (
+    explicit(body, 'tenantId') || explicit(query, 'tenantId') || explicit(params, 'tenantId') ||
+    explicit(query, 'projectId') || explicit(params, 'projectId')
+  ) {
+    throw new HttpRouteError(
+      400,
+      'STOCK_PREPARATION_PLM_AUTOPERSIST_STEERING_NOT_ALLOWED',
+      'an explicit tenantId (any carrier) or a query/params projectId is not allowed on the auto-persisting PLM source-run; the tenant and staging target derive from the authenticated principal and the business projectId rides only in the body',
     )
   }
 }
@@ -2441,6 +2478,9 @@ function createHandlers(services, options = {}) {
     return {
       preparedRead,
       system,
+      // T3b-1c: the APPROVED config row itself, so the auto-persist path can run its pure structural
+      // guard on it BEFORE any source-adapter creation. Additive — the read-only paths ignore it.
+      config: row.config,
       createAdapter: (adapterSystem) => adapterRegistry.createAdapter(adapterSystem, {
         principal: requestPrincipal(req),
       }),
@@ -3868,20 +3908,38 @@ function createHandlers(services, options = {}) {
     },
 
     // #3889: execute an approved PLM readonly config and feed its mapped rows through the existing
-    // pure intake contract. Dry-run/read only: no business-row write and no raw/value-bearing result.
+    // pure intake contract. Dry-run/read only by default: no business-row write and no raw/value-
+    // bearing result. T3b-1c: with MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED the SAME request
+    // feeds the server-side intake through the pure bridge into the existing sync-run persist —
+    // the business rows still never cross HTTP.
     async stockPreparationPlmBomSourceRun(req, res) {
       const user = requireAccess(req, 'admin')
+      // T3b OD-2: with auto-persist ON the read gains a write side-effect, so tenant steering (and the
+      // ambiguous query/params projectId carriers) are rejected with the DEDICATED code BEFORE the body
+      // allowlist AND any I/O. The BODY projectId stays allowed — it is the required business project
+      // key on the written rows, never a physical-target selector. Flag OFF never engages the guard.
+      const autoPersistEnabled = stockPreparationPlmAutoPersistEnabled()
+      if (autoPersistEnabled) assertStockPreparationPlmAutoPersistNoSteering(req)
       const input = normalizeStockPreparationSourceRunBody(
         requestBody(req),
         VALID_STOCK_PREPARATION_PLM_SOURCE_RUN_REQUEST_KEYS,
         'STOCK_PREPARATION_PLM_SOURCE_RUN_REQUEST_INVALID',
       )
-      const tenantId = resolveTenantId(req, input)
+      // OD-2: ON derives the tenant from the AUTHENTICATED principal only (resolveTenantId would honor
+      // a request tenantId for admins); OFF keeps today's read-only resolution byte-for-byte.
+      const tenantId = autoPersistEnabled ? resolveAuthUserTenantId(req) : resolveTenantId(req, input)
       const sourceRuntime = await loadStockPreparationReadonlySource(
         req,
         { ...input, tenantId },
         'STOCK_PREPARATION_PLM_SOURCE_RUN_REQUEST_INVALID',
       )
+      // T3b OD-3 amendment (owner P2): the value-level status vocabulary cannot catch a COMBINED
+      // mapping bypass (a config that maps some column onto the internal `missingChildBom` marker
+      // while also mapping an explicit lineStatus), so the approved CONFIG itself is structurally
+      // guarded here — after the config-store read that produced it, but BEFORE any source-adapter
+      // creation/read, provisioning, or persist I/O. Only the auto-persist path engages it: flag OFF
+      // keeps the read-only route byte-for-byte, including for configs this guard would reject.
+      if (autoPersistEnabled) assertPlmAutoPersistSourceConfigSafe(sourceRuntime.config)
       const actor = user.id || user.email
       const result = await runPlmBomReadonlySource({
         permission: 'admin',
@@ -3894,7 +3952,44 @@ function createHandlers(services, options = {}) {
         actor,
         ...sourceRuntime,
       })
-      return sendOk(res, publicReadonlySourceRunResult(result))
+      const readProjection = publicReadonlySourceRunResult(result)
+      if (!autoPersistEnabled) {
+        // Flag OFF: the response is BYTE-FOR-BYTE today's read-only projection — no autoPersist field.
+        return sendOk(res, readProjection)
+      }
+      // Flag ON: bridge the server-side intake into the EXISTING sync-run persist within this request
+      // (OD-3 — the pure bridge is the only intake→persist projection; no direct cast/spread). The
+      // physical target derives from the auth tenant's staging project exactly like the sibling MVP
+      // persist route — the body projectId rides on the rows as a business key only (OD-2).
+      const targetProjectId = resolveIntegrationStagingProjectId(tenantId, undefined)
+      const persistInput = buildPlmSourcePersistInput({
+        request: {
+          projectId: input.projectId,
+          sourceProjectNo: input.sourceProjectNo,
+          syncRunId: input.syncRunId,
+          snapshotBatchId: input.snapshotBatchId,
+          snapshotVersion: input.snapshotVersion,
+        },
+        intake: result.intake,
+      })
+      const autoPersist = await persistStockPreparationSyncRun({
+        context,
+        permission: 'admin',
+        recordsApi: getMultitableRecordsApi(),
+        provisioning: getMultitableProvisioning(),
+        targetProjectId,
+        ...persistInput,
+      })
+      // OD-5: created overrides the read-only projector's fixed mode:'dry_run' / internalWriteExecuted:
+      // false (a real write happened — the response may never report "not written"); an exact replay is
+      // an internal NOOP and must say so (never a hard-coded internal-write claim just because the flag
+      // is ON). `autoPersist` is the persist's existing values-free evidence. 201 iff a row landed.
+      return sendOk(res, {
+        ...readProjection,
+        mode: autoPersist.persisted ? 'internal_persist' : 'internal_noop',
+        evidence: { ...readProjection.evidence, internalWriteExecuted: autoPersist.persisted },
+        autoPersist,
+      }, autoPersist.persisted ? 201 : 200)
     },
 
     // #3889: approved ERP/K3 readonly config -> pure material-cache intake shape summary. There is no


### PR DESCRIPTION
## T3b-1c + T3b-2 — approved PLM source-run 服务端直落（default-OFF）

设计锁：`docs/development/stock-preparation-t3b-plm-source-autopersist-design-lock-20260716.md`（RATIFIED #4364；1a #4382 ✅、1b #4383 ✅、config guard #4391 ✅ 均已过门 → 阶梯解锁 1c/2）。

### 变更
- **`http-routes.cjs`**（T3b-1c）：
  - OD-1：独立 flag `MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED`（strict-'true'，与 T3a ERP flag 完全独立）；OFF 时响应/租户解析/I/O 次数逐字节不变。
  - OD-2 分层语义：`assertStockPreparationPlmAutoPersistNoSteering` —— tenantId 全载体拒绝、projectId 仅 query/params 拒绝（**body projectId 必填保留**，是业务键、永不参与物理 target 派生）；guard 在 body allowlist 与一切 I/O 之前，专用 coarse code。
  - OD-3 修正案：`assertPlmAutoPersistSourceConfigSafe(sourceRuntime.config)` 在 **任何 source-adapter 创建/读取、provisioning、persist I/O 之前** 对 approved config 结构守卫（`loadStockPreparationReadonlySource` 增量返回 `config`，只读路径无感知）。
  - OD-3/OD-5：intake 只经 `buildPlmSourcePersistInput` 纯桥进现有 `persistStockPreparationSyncRun`（1a 硬化后的唯一写入口）；201 created=`internal_persist/true`，200 exact-replay=`internal_noop/false`（绝不因 flag ON 谎报写入）。
- **`http-routes.test.cjs`**：+6 测试（ON 全链含双向 leak-bait 与"一行不丢"落沉、steering 5 向量 + body projectId 必填/staging 形状不可转向、config guard 前置 I/O 计数=0、raw lifecycle×3 + Option A 值级整包 422、OFF 双拼写字节等价、mid-persist coarse 失败）。
- **T3b-2 真库**：`stock-preparation-t3b-plm-autopersist-realdb.test.ts` —— 真 route + 真 provisioning/records + meta_fields 物理 fieldId 交叉核对：ON 落 1 project/1 batch/2 line/1 run（`imported→active` 在物理行上证明）、replay 零增行、OFF 零写、lifecycle/config-guard 422 零写且 adapter 创建计数=0。已加入 required `plugin-tests.yml` 真库白名单（与 T3a/T3b-1a 同一步）。

### 验证
- 本地 plugin 链全绿（`pnpm test` exit 0）；`node __tests__/http-routes.test.cjs` 全绿。
- 真库（本地 PostgreSQL，CI 同款 MIGRATION_EXCLUDE 迁移后）：3 文件 8/8 PASS（新 4 + T3a 3 + T3b-1a 1，无回归）。
- core-backend `tsc --noEmit` exit 0。

### Mutation 纪录（每项：commit 后改 → RED 逐字 → 恢复 → GREEN）
| # | Mutation | RED 证据 |
|---|---|---|
| M1 | flag gate 恒 ON | `503 !== 200`（OFF 面测试） |
| M2 | steering guard 移除 | `body.tenantId: steering rejected` / `500 !== 400` |
| M3 | config guard 移除 | `forbidden marker target rejects the whole run` / `500 !== 422` |
| M4 | config guard 挪到 source I/O 之后 | `config guard fires before any source adapter exists` |
| M5 | persist 调用切断 | `200 !== 201` |
| M6 | replay 硬报 internal write | `+ 'internal_persist' - 'internal_noop'` |
| M7 | 物理 target 采用 body projectId | `the body projectId can never move the physical target` |
| M8 | ON 路径 tenant 换回 `resolveTenantId(req,input)` | **route 级 green（如实记录）**：steering guard 封死所有显式载体后该交换不可观测；承重防线 = M2 + 既有 `testStockPreparationErpAutoPersistTenantResolversDiffer` 直测（T3a ratified 先例） |
| — | 白名单移除（`plugin-tests.yml`） | 文档化 mutation：兄弟切片（T3a/T3b-1a）同无 wiring guard，遵循同模式如实声明 |

### 边界（与锁一致）
- `externalWrite=false` 恒定；无 K3 Save/Submit/Audit、无 apply-writer、无 OD-W3-1 值面读。
- default OFF ⇒ 合并即惰性；生产常开仍 barred on P4（OD-4）。
- 不触碰 corrective-5 冻结面（acceptance runner / postdeploy smoke 零改动）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
