### PR TITLE
fix(app-center): localize and clarify launcher cards

### DIFF
--- a/apps/web/src/composables/usePlatformApps.ts
+++ b/apps/web/src/composables/usePlatformApps.ts
@@ -1,6 +1,10 @@
 import { computed, ref } from 'vue'
 import { apiGet } from '../utils/api'
-import { platformAppLabel } from '../utils/platformAppLabels'
+import {
+  platformAppLabel,
+  type PlatformAppInstallState,
+  type PlatformAppPluginStatus,
+} from '../utils/platformAppLabels'
 
 const TENANT_HINT_KEYS = ['tenantId', 'workspaceId'] as const
 
@@ -22,7 +26,7 @@ export interface PlatformAppInstanceSummary {
   instanceKey: string
   projectId: string
   displayName: string
-  status: 'active' | 'inactive' | 'failed'
+  status: PlatformAppPluginStatus
   config: Record<string, unknown>
   metadata: Record<string, unknown>
   createdAt?: string
@@ -35,7 +39,7 @@ export interface PlatformAppSummary {
   pluginName: string
   pluginVersion?: string
   pluginDisplayName?: string
-  pluginStatus: 'active' | 'inactive' | 'failed'
+  pluginStatus: PlatformAppPluginStatus
   pluginError?: string
   displayName: string
   runtimeModel: 'instance' | 'direct'
@@ -77,7 +81,9 @@ function resolveShellRoute(appId: string): string {
 
 export type PlatformAppRuntimeInstallState = 'not-installed' | 'installed' | 'partial' | 'failed'
 
-const runtimeInstallStateByAppId = ref<Record<string, PlatformAppRuntimeInstallState>>({})
+type PlatformAppStoredInstallState = Exclude<PlatformAppRuntimeInstallState, 'installed'>
+
+const runtimeInstallStateByAppId = ref<Record<string, PlatformAppStoredInstallState>>({})
 
 function readRuntimeScopeHint(): string {
   if (typeof localStorage !== 'undefined') {
@@ -113,7 +119,7 @@ function resolveRuntimeScopeKey(appId: string, scopeId?: string | null): string 
   return normalizedScopeId ? `${normalizedScopeId}:${appId}` : appId
 }
 
-function clearRuntimeStateForApp(next: Record<string, PlatformAppRuntimeInstallState>, appId: string): void {
+function clearRuntimeStateForApp(next: Record<string, PlatformAppStoredInstallState>, appId: string): void {
   for (const key of Object.keys(next)) {
     if (key === appId || key.endsWith(`:${appId}`)) {
       delete next[key]
@@ -142,7 +148,7 @@ export function setPlatformAppRuntimeInstallState(
 function resolveRuntimeInstallState(
   app: PlatformAppSummary,
   runtimeInstallState?: PlatformAppRuntimeInstallState | null,
-): PlatformAppRuntimeInstallState | 'active' | 'inactive' | 'direct' {
+): PlatformAppInstallState {
   if (app.runtimeModel === 'direct') {
     return 'direct'
   }
@@ -212,7 +218,7 @@ async function syncRuntimeInstallStates(appList: PlatformAppSummary[]): Promise<
 export function resolvePlatformAppInstallState(
   app: PlatformAppSummary,
   runtimeInstallState?: PlatformAppRuntimeInstallState | null,
-): string {
+): PlatformAppInstallState {
   if (app.runtimeModel === 'direct') {
     return 'direct'
   }

--- a/apps/web/src/composables/usePlatformApps.ts
+++ b/apps/web/src/composables/usePlatformApps.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue'
 import { apiGet } from '../utils/api'
+import { platformAppLabel } from '../utils/platformAppLabels'
 
 const TENANT_HINT_KEYS = ['tenantId', 'workspaceId'] as const
 
@@ -224,29 +225,30 @@ export function resolvePlatformAppInstallState(
   return app.instance?.status ?? 'not-installed'
 }
 
-export function resolvePlatformAppProjectLabel(app: PlatformAppSummary): string {
+export function resolvePlatformAppProjectLabel(app: PlatformAppSummary, isZh = false): string {
   if (app.runtimeModel === 'direct') {
-    return 'n/a'
+    return platformAppLabel('value.notRequired', isZh)
   }
-  return app.instance?.projectId || 'Unavailable'
+  return app.instance?.projectId || platformAppLabel('value.unavailable', isZh)
 }
 
-export function resolvePlatformAppInstanceLabel(app: PlatformAppSummary): string {
+export function resolvePlatformAppInstanceLabel(app: PlatformAppSummary, isZh = false): string {
   if (app.runtimeModel === 'direct') {
-    return 'This app runs directly from its entry route and does not require tenant installation.'
+    return platformAppLabel('instance.direct', isZh)
   }
-  return app.instance?.displayName || 'App instance not installed for this tenant yet.'
+  return app.instance?.displayName || platformAppLabel('instance.notInstalled', isZh)
 }
 
 export function resolvePlatformAppPrimaryAction(
   app: PlatformAppSummary,
   runtimeInstallState?: PlatformAppRuntimeInstallState | null,
+  isZh = false,
 ): PlatformAppActionDescriptor {
   if (app.pluginStatus === 'failed') {
     return {
       kind: 'inspect',
-      label: 'Inspect shell',
-      description: 'Plugin runtime is degraded. Review shell state before entering the app.',
+      label: platformAppLabel('action.diagnostics', isZh),
+      description: platformAppLabel('action.description.failed', isZh),
       route: resolveShellRoute(app.id),
     }
   }
@@ -254,8 +256,8 @@ export function resolvePlatformAppPrimaryAction(
   if (app.runtimeModel === 'direct') {
     return {
       kind: 'open',
-      label: 'Open app',
-      description: 'This app runs directly from its entry route and does not require tenant installation.',
+      label: platformAppLabel('action.open', isZh),
+      description: platformAppLabel('action.description.direct', isZh),
       route: app.entryPath || resolveShellRoute(app.id),
     }
   }
@@ -266,8 +268,8 @@ export function resolvePlatformAppPrimaryAction(
     if (app.runtimeBindings?.installPath) {
       return {
         kind: 'install',
-        label: 'Install app',
-        description: 'No tenant-scoped app instance exists yet. Open the platform shell to install it with the app-defined runtime contract.',
+        label: platformAppLabel('action.install', isZh),
+        description: platformAppLabel('action.description.install', isZh),
         route: resolveShellRoute(app.id),
         mutation: {
           path: app.runtimeBindings.installPath,
@@ -277,8 +279,8 @@ export function resolvePlatformAppPrimaryAction(
     }
     return {
       kind: 'onboard',
-      label: 'Open onboarding',
-      description: 'No tenant-scoped app instance exists yet. Enter the app to initialize it.',
+      label: platformAppLabel('action.onboard', isZh),
+      description: platformAppLabel('action.description.onboard', isZh),
       route: app.entryPath || resolveShellRoute(app.id),
     }
   }
@@ -287,8 +289,8 @@ export function resolvePlatformAppPrimaryAction(
     if (app.runtimeBindings?.installPath) {
       return {
         kind: 'reinstall',
-        label: 'Reinstall app',
-        description: 'The current app runtime snapshot is degraded. Open the platform shell to reinstall it with the existing runtime contract.',
+        label: platformAppLabel('action.reinstall', isZh),
+        description: platformAppLabel('action.description.reinstall', isZh),
         route: resolveShellRoute(app.id),
         mutation: {
           path: app.runtimeBindings.installPath,
@@ -301,8 +303,8 @@ export function resolvePlatformAppPrimaryAction(
     }
     return {
       kind: 'recover',
-      label: 'Open recovery',
-      description: 'The current app runtime snapshot is degraded. Enter the app to repair or reinstall it.',
+      label: platformAppLabel('action.recover', isZh),
+      description: platformAppLabel('action.description.recover', isZh),
       route: app.entryPath || resolveShellRoute(app.id),
     }
   }
@@ -310,16 +312,16 @@ export function resolvePlatformAppPrimaryAction(
   if (resolvedInstallState === 'inactive' || app.instance.status === 'inactive') {
     return {
       kind: 'inspect',
-      label: 'Review shell',
-      description: 'The app instance exists but is inactive. Review shell state before reopening runtime entry.',
+      label: platformAppLabel('action.diagnostics', isZh),
+      description: platformAppLabel('action.description.inactive', isZh),
       route: resolveShellRoute(app.id),
     }
   }
 
   return {
     kind: 'open',
-    label: 'Open app',
-    description: 'The app instance is active and ready for direct entry.',
+    label: platformAppLabel('action.open', isZh),
+    description: platformAppLabel('action.description.active', isZh),
     route: app.entryPath || resolveShellRoute(app.id),
   }
 }

--- a/apps/web/src/utils/platformAppLabels.ts
+++ b/apps/web/src/utils/platformAppLabels.ts
@@ -111,20 +111,24 @@ const PLATFORM_APP_LABELS: Record<PlatformAppLabelKey, LocalizedLabel> = {
   },
 }
 
-const PLATFORM_APP_STATUS_LABELS: Record<string, LocalizedLabel> = {
+const PLATFORM_APP_STATUS_LABELS = {
   active: { en: 'Active', zh: '可用' },
   inactive: { en: 'Inactive', zh: '已停用' },
   failed: { en: 'Unavailable', zh: '异常' },
-}
+} satisfies Record<string, LocalizedLabel>
 
-const PLATFORM_APP_INSTALL_STATE_LABELS: Record<string, LocalizedLabel> = {
+export type PlatformAppPluginStatus = keyof typeof PLATFORM_APP_STATUS_LABELS
+
+const PLATFORM_APP_INSTALL_STATE_LABELS = {
   direct: { en: 'Direct entry', zh: '直接使用' },
   active: { en: 'Ready', zh: '已就绪' },
   inactive: { en: 'Inactive', zh: '已停用' },
   failed: { en: 'Failed', zh: '安装失败' },
   partial: { en: 'Incomplete', zh: '安装不完整' },
   'not-installed': { en: 'Not installed', zh: '未安装' },
-}
+} satisfies Record<string, LocalizedLabel>
+
+export type PlatformAppInstallState = keyof typeof PLATFORM_APP_INSTALL_STATE_LABELS
 
 const PLATFORM_APP_COPY: Record<string, { name: LocalizedLabel; description: LocalizedLabel }> = {
   attendance: {
@@ -151,12 +155,12 @@ export function platformAppLabel(key: PlatformAppLabelKey, isZh: boolean): strin
   return resolveLocalizedLabel(PLATFORM_APP_LABELS[key], isZh)
 }
 
-export function platformAppStatusLabel(status: string, isZh: boolean): string {
+export function platformAppStatusLabel(status: PlatformAppPluginStatus, isZh: boolean): string {
   const entry = PLATFORM_APP_STATUS_LABELS[status]
   return entry ? resolveLocalizedLabel(entry, isZh) : status
 }
 
-export function platformAppInstallStateLabel(state: string, isZh: boolean): string {
+export function platformAppInstallStateLabel(state: PlatformAppInstallState, isZh: boolean): string {
   const entry = PLATFORM_APP_INSTALL_STATE_LABELS[state]
   return entry ? resolveLocalizedLabel(entry, isZh) : state
 }

--- a/apps/web/src/utils/platformAppLabels.ts
+++ b/apps/web/src/utils/platformAppLabels.ts
@@ -1,0 +1,173 @@
+export type PlatformAppLabelKey =
+  | 'header.eyebrow'
+  | 'header.title'
+  | 'header.subtitle'
+  | 'action.refresh'
+  | 'action.refreshing'
+  | 'action.open'
+  | 'action.install'
+  | 'action.onboard'
+  | 'action.reinstall'
+  | 'action.recover'
+  | 'action.diagnostics'
+  | 'action.adminDiagnostics'
+  | 'action.adminOnly'
+  | 'action.description.direct'
+  | 'action.description.install'
+  | 'action.description.onboard'
+  | 'action.description.reinstall'
+  | 'action.description.recover'
+  | 'action.description.failed'
+  | 'action.description.inactive'
+  | 'action.description.active'
+  | 'state.loading'
+  | 'state.empty'
+  | 'state.error'
+  | 'description.empty'
+  | 'meta.plugin'
+  | 'meta.install'
+  | 'meta.dependencies'
+  | 'meta.objects'
+  | 'meta.workflows'
+  | 'meta.project'
+  | 'value.notRequired'
+  | 'value.unavailable'
+  | 'instance.direct'
+  | 'instance.notInstalled'
+
+type LocalizedLabel = { en: string; zh: string }
+
+const PLATFORM_APP_LABELS: Record<PlatformAppLabelKey, LocalizedLabel> = {
+  'header.eyebrow': { en: 'Platform Apps', zh: '平台应用' },
+  'header.title': { en: 'App Center', zh: '应用中心' },
+  'header.subtitle': {
+    en: 'Browse available apps and continue work from their standard entry points.',
+    zh: '查看平台可用应用，并从标准入口继续工作。',
+  },
+  'action.refresh': { en: 'Refresh apps', zh: '刷新应用' },
+  'action.refreshing': { en: 'Refreshing apps', zh: '正在刷新应用' },
+  'action.open': { en: 'Open app', zh: '打开应用' },
+  'action.install': { en: 'Install app', zh: '安装应用' },
+  'action.onboard': { en: 'Open onboarding', zh: '开始配置' },
+  'action.reinstall': { en: 'Reinstall app', zh: '重新安装' },
+  'action.recover': { en: 'Open recovery', zh: '进入修复' },
+  'action.diagnostics': { en: 'Admin diagnostics', zh: '管理员诊断' },
+  'action.adminDiagnostics': { en: 'Admin diagnostics', zh: '管理员诊断' },
+  'action.adminOnly': {
+    en: 'An administrator must review the app diagnostics.',
+    zh: '需要管理员查看应用诊断信息。',
+  },
+  'action.description.direct': {
+    en: 'Open this app from its standard entry point. No tenant installation is required.',
+    zh: '从标准入口直接打开应用，无需为当前租户安装。',
+  },
+  'action.description.install': {
+    en: 'No tenant app instance exists yet. Install it with the app-defined setup contract.',
+    zh: '当前租户尚未安装应用实例，请按应用定义的配置流程完成安装。',
+  },
+  'action.description.onboard': {
+    en: 'No tenant app instance exists yet. Open the app to complete its initial setup.',
+    zh: '当前租户尚未安装应用实例，请打开应用完成首次配置。',
+  },
+  'action.description.reinstall': {
+    en: 'The current app installation is incomplete. Reinstall it with the existing setup contract.',
+    zh: '当前应用安装不完整，请按现有配置重新安装。',
+  },
+  'action.description.recover': {
+    en: 'The current app installation is degraded. Open the app to repair it.',
+    zh: '当前应用安装状态异常，请打开应用进行修复。',
+  },
+  'action.description.failed': {
+    en: 'The plugin runtime is degraded. Review diagnostics before continuing.',
+    zh: '插件运行状态异常，请先查看诊断信息。',
+  },
+  'action.description.inactive': {
+    en: 'The app instance is inactive. Review diagnostics before reopening it.',
+    zh: '应用实例已停用，请先查看诊断信息。',
+  },
+  'action.description.active': {
+    en: 'The app is ready to open.',
+    zh: '应用已就绪，可以直接打开。',
+  },
+  'state.loading': { en: 'Loading apps...', zh: '正在加载应用...' },
+  'state.empty': { en: 'No apps are available.', zh: '暂无可用应用。' },
+  'state.error': { en: 'Unable to load apps. Try again.', zh: '应用加载失败，请重试。' },
+  'description.empty': {
+    en: 'No app description is available.',
+    zh: '暂无应用说明。',
+  },
+  'meta.plugin': { en: 'Plugin', zh: '插件' },
+  'meta.install': { en: 'Install', zh: '安装状态' },
+  'meta.dependencies': { en: 'Dependencies', zh: '依赖项' },
+  'meta.objects': { en: 'Objects', zh: '数据对象' },
+  'meta.workflows': { en: 'Workflows', zh: '工作流' },
+  'meta.project': { en: 'Project', zh: '项目' },
+  'value.notRequired': { en: 'Not required', zh: '无需项目' },
+  'value.unavailable': { en: 'Unavailable', zh: '不可用' },
+  'instance.direct': { en: 'Direct runtime', zh: '直接运行' },
+  'instance.notInstalled': {
+    en: 'App instance not installed for this tenant yet.',
+    zh: '当前租户尚未安装应用实例。',
+  },
+}
+
+const PLATFORM_APP_STATUS_LABELS: Record<string, LocalizedLabel> = {
+  active: { en: 'Active', zh: '可用' },
+  inactive: { en: 'Inactive', zh: '已停用' },
+  failed: { en: 'Unavailable', zh: '异常' },
+}
+
+const PLATFORM_APP_INSTALL_STATE_LABELS: Record<string, LocalizedLabel> = {
+  direct: { en: 'Direct entry', zh: '直接使用' },
+  active: { en: 'Ready', zh: '已就绪' },
+  inactive: { en: 'Inactive', zh: '已停用' },
+  failed: { en: 'Failed', zh: '安装失败' },
+  partial: { en: 'Incomplete', zh: '安装不完整' },
+  'not-installed': { en: 'Not installed', zh: '未安装' },
+}
+
+const PLATFORM_APP_COPY: Record<string, { name: LocalizedLabel; description: LocalizedLabel }> = {
+  attendance: {
+    name: { en: 'Attendance', zh: '考勤' },
+    description: {
+      en: 'Attendance tracking, reports, import operations, and workflow-backed adjustments.',
+      zh: '考勤记录、报表、导入操作及工作流驱动的调整。',
+    },
+  },
+  'after-sales': {
+    name: { en: 'After Sales', zh: '售后服务' },
+    description: {
+      en: 'Service tickets, warranty handling, dispatch, and closure feedback.',
+      zh: '服务工单、保修处理、派工及闭环反馈。',
+    },
+  },
+}
+
+function resolveLocalizedLabel(entry: LocalizedLabel, isZh: boolean): string {
+  return isZh ? entry.zh : entry.en
+}
+
+export function platformAppLabel(key: PlatformAppLabelKey, isZh: boolean): string {
+  return resolveLocalizedLabel(PLATFORM_APP_LABELS[key], isZh)
+}
+
+export function platformAppStatusLabel(status: string, isZh: boolean): string {
+  const entry = PLATFORM_APP_STATUS_LABELS[status]
+  return entry ? resolveLocalizedLabel(entry, isZh) : status
+}
+
+export function platformAppInstallStateLabel(state: string, isZh: boolean): string {
+  const entry = PLATFORM_APP_INSTALL_STATE_LABELS[state]
+  return entry ? resolveLocalizedLabel(entry, isZh) : state
+}
+
+export function platformAppDisplayName(appId: string, fallback: string, isZh: boolean): string {
+  const entry = PLATFORM_APP_COPY[appId]?.name
+  return entry ? resolveLocalizedLabel(entry, isZh) : fallback
+}
+
+export function platformAppDescription(appId: string, fallback: string | undefined, isZh: boolean): string {
+  const entry = PLATFORM_APP_COPY[appId]?.description
+  if (entry) return resolveLocalizedLabel(entry, isZh)
+  return fallback || platformAppLabel('description.empty', isZh)
+}

--- a/apps/web/src/views/PlatformAppLauncherView.vue
+++ b/apps/web/src/views/PlatformAppLauncherView.vue
@@ -2,63 +2,79 @@
   <section class="platform-app-launcher">
     <header class="platform-app-launcher__hero">
       <div>
-        <p class="platform-app-launcher__eyebrow">Platform Apps</p>
-        <h1>App Launcher</h1>
+        <p class="platform-app-launcher__eyebrow">{{ platformAppLabel('header.eyebrow', isZh) }}</p>
+        <h1>{{ platformAppLabel('header.title', isZh) }}</h1>
         <p class="platform-app-launcher__lead">
-          统一展示当前平台可用应用，先从 app catalog 和标准入口收口。
+          {{ platformAppLabel('header.subtitle', isZh) }}
         </p>
       </div>
-      <button class="platform-app-launcher__refresh" type="button" :disabled="loading" @click="refresh">
-        Refresh
+      <button
+        class="platform-app-launcher__refresh"
+        type="button"
+        :disabled="loading"
+        :aria-label="platformAppLabel(loading ? 'action.refreshing' : 'action.refresh', isZh)"
+        :title="platformAppLabel(loading ? 'action.refreshing' : 'action.refresh', isZh)"
+        @click="refresh"
+      >
+        <RefreshIcon aria-hidden="true" />
       </button>
     </header>
 
-    <p v-if="error" class="platform-app-launcher__error">{{ error }}</p>
-    <p v-else-if="loading" class="platform-app-launcher__state">Loading platform apps...</p>
-    <p v-else-if="apps.length === 0" class="platform-app-launcher__state">No platform apps discovered.</p>
+    <p v-if="error" class="platform-app-launcher__error" role="alert">
+      {{ platformAppLabel('state.error', isZh) }}
+    </p>
+    <p v-else-if="loading" class="platform-app-launcher__state" aria-live="polite">
+      {{ platformAppLabel('state.loading', isZh) }}
+    </p>
+    <p v-else-if="apps.length === 0" class="platform-app-launcher__state">
+      {{ platformAppLabel('state.empty', isZh) }}
+    </p>
 
     <div v-else class="platform-app-launcher__grid">
       <article v-for="card in appCards" :key="card.app.id" class="platform-app-launcher__card">
         <div class="platform-app-launcher__card-head">
           <div>
             <p class="platform-app-launcher__app-id">{{ card.app.id }}</p>
-            <h2>{{ card.app.displayName }}</h2>
+            <h2>{{ card.displayName }}</h2>
           </div>
-          <span class="platform-app-launcher__status" :data-status="card.app.pluginStatus">{{ card.app.pluginStatus }}</span>
+          <span class="platform-app-launcher__status" :data-status="card.app.pluginStatus">
+            {{ card.pluginStatusLabel }}
+          </span>
         </div>
 
         <p class="platform-app-launcher__description">
-          {{ card.app.boundedContext.description || 'No bounded-context description.' }}
+          {{ card.description }}
         </p>
 
         <dl class="platform-app-launcher__meta">
           <div>
-            <dt>Plugin</dt>
+            <dt>{{ platformAppLabel('meta.plugin', isZh) }}</dt>
             <dd>{{ card.app.pluginName }}</dd>
           </div>
           <div>
-            <dt>Install</dt>
-            <dd>{{ card.installState }}</dd>
+            <dt>{{ platformAppLabel('meta.install', isZh) }}</dt>
+            <dd>{{ card.installStateLabel }}</dd>
           </div>
           <div>
-            <dt>Dependencies</dt>
+            <dt>{{ platformAppLabel('meta.dependencies', isZh) }}</dt>
             <dd>{{ card.app.platformDependencies.length }}</dd>
           </div>
           <div>
-            <dt>Objects</dt>
+            <dt>{{ platformAppLabel('meta.objects', isZh) }}</dt>
             <dd>{{ card.app.objects.length }}</dd>
           </div>
           <div>
-            <dt>Workflows</dt>
+            <dt>{{ platformAppLabel('meta.workflows', isZh) }}</dt>
             <dd>{{ card.app.workflows.length }}</dd>
           </div>
           <div>
-            <dt>Project</dt>
+            <dt>{{ platformAppLabel('meta.project', isZh) }}</dt>
             <dd>{{ card.projectLabel }}</dd>
           </div>
         </dl>
 
         <p
+          v-if="card.instanceLabel"
           class="platform-app-launcher__instance"
           :data-state="card.installState"
         >
@@ -71,17 +87,24 @@
 
         <div class="platform-app-launcher__actions">
           <RouterLink
+            v-if="card.primaryAction.route && (card.primaryAction.kind !== 'inspect' || canInspectShell)"
             class="platform-app-launcher__primary"
             :to="card.primaryAction.route || card.shellRoute"
           >
             {{ card.primaryAction.label }}
           </RouterLink>
+          <span
+            v-else-if="card.primaryAction.kind === 'inspect'"
+            class="platform-app-launcher__admin-only"
+          >
+            {{ platformAppLabel('action.adminOnly', isZh) }}
+          </span>
           <RouterLink
-            v-if="card.primaryAction.route !== card.shellRoute"
+            v-if="canInspectShell && card.primaryAction.route !== card.shellRoute"
             class="platform-app-launcher__ghost"
             :to="card.shellRoute"
           >
-            Open shell
+            {{ platformAppLabel('action.adminDiagnostics', isZh) }}
           </RouterLink>
         </div>
       </article>
@@ -90,8 +113,11 @@
 </template>
 
 <script setup lang="ts">
+import { Refresh as RefreshIcon } from '@element-plus/icons-vue'
 import { computed, onMounted } from 'vue'
 import { RouterLink } from 'vue-router'
+import { useAuth } from '../composables/useAuth'
+import { useLocale } from '../composables/useLocale'
 import {
   type PlatformAppSummary,
   resolvePlatformAppInstallState,
@@ -100,20 +126,36 @@ import {
   resolvePlatformAppProjectLabel,
   usePlatformApps,
 } from '../composables/usePlatformApps'
+import {
+  platformAppDescription,
+  platformAppDisplayName,
+  platformAppInstallStateLabel,
+  platformAppLabel,
+  platformAppStatusLabel,
+} from '../utils/platformAppLabels'
 
 const { apps, loading, error, fetchApps } = usePlatformApps()
+const { isZh } = useLocale()
+const canInspectShell = useAuth().hasAdminAccess()
 
 function resolveShellRoute(app: PlatformAppSummary): string {
   return `/apps/${encodeURIComponent(app.id)}`
 }
 
 const appCards = computed(() => apps.value.map((app) => {
-  const primaryAction = resolvePlatformAppPrimaryAction(app)
+  const installState = resolvePlatformAppInstallState(app)
+  const primaryAction = resolvePlatformAppPrimaryAction(app, undefined, isZh.value)
   return {
     app,
-    installState: resolvePlatformAppInstallState(app),
-    instanceLabel: resolvePlatformAppInstanceLabel(app),
-    projectLabel: resolvePlatformAppProjectLabel(app),
+    displayName: platformAppDisplayName(app.id, app.displayName, isZh.value),
+    description: platformAppDescription(app.id, app.boundedContext.description, isZh.value),
+    pluginStatusLabel: platformAppStatusLabel(app.pluginStatus, isZh.value),
+    installState,
+    installStateLabel: platformAppInstallStateLabel(installState, isZh.value),
+    instanceLabel: app.runtimeModel === 'direct'
+      ? null
+      : resolvePlatformAppInstanceLabel(app, isZh.value),
+    projectLabel: resolvePlatformAppProjectLabel(app, isZh.value),
     primaryAction,
     shellRoute: resolveShellRoute(app),
   }
@@ -165,17 +207,37 @@ onMounted(async () => {
 .platform-app-launcher__primary,
 .platform-app-launcher__ghost {
   border: none;
-  border-radius: 12px;
+  border-radius: 8px;
   padding: 10px 14px;
   font: inherit;
   cursor: pointer;
   text-decoration: none;
 }
 
-.platform-app-launcher__refresh,
-.platform-app-launcher__primary {
+.platform-app-launcher__refresh {
   background: #fff;
   color: #0f172a;
+}
+
+.platform-app-launcher__primary {
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+}
+
+.platform-app-launcher__refresh {
+  display: inline-flex;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 40px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.platform-app-launcher__refresh svg {
+  width: 18px;
+  height: 18px;
 }
 
 .platform-app-launcher__ghost {
@@ -195,8 +257,9 @@ onMounted(async () => {
   gap: 16px;
   padding: 20px;
   border: 1px solid #dbe2ea;
-  border-radius: 18px;
+  border-radius: 8px;
   background: #fff;
+  color: #0f172a;
 }
 
 .platform-app-launcher__card-head {
@@ -232,6 +295,7 @@ onMounted(async () => {
 .platform-app-launcher__meta dd {
   margin: 4px 0 0;
   font-weight: 600;
+  color: #0f172a;
 }
 
 .platform-app-launcher__actions {
@@ -267,6 +331,11 @@ onMounted(async () => {
   font-size: 14px;
 }
 
+.platform-app-launcher__admin-only {
+  color: #475569;
+  font-size: 13px;
+}
+
 .platform-app-launcher__status {
   display: inline-flex;
   align-items: center;
@@ -293,9 +362,10 @@ onMounted(async () => {
 .platform-app-launcher__error,
 .platform-app-launcher__state {
   padding: 16px 18px;
-  border-radius: 14px;
+  border-radius: 8px;
   background: #fff;
   border: 1px solid #dbe2ea;
+  color: #334155;
 }
 
 .platform-app-launcher__error {

--- a/apps/web/src/views/PlatformAppLauncherView.vue
+++ b/apps/web/src/views/PlatformAppLauncherView.vue
@@ -89,7 +89,7 @@
           <RouterLink
             v-if="card.primaryAction.route && (card.primaryAction.kind !== 'inspect' || canInspectShell)"
             class="platform-app-launcher__primary"
-            :to="card.primaryAction.route || card.shellRoute"
+            :to="card.primaryAction.route"
           >
             {{ card.primaryAction.label }}
           </RouterLink>

--- a/apps/web/tests/platform-app-actions.spec.ts
+++ b/apps/web/tests/platform-app-actions.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   resolvePlatformAppInstallState,
+  resolvePlatformAppInstanceLabel,
   resolvePlatformAppPrimaryAction,
+  resolvePlatformAppProjectLabel,
   type PlatformAppRuntimeInstallState,
   type PlatformAppSummary,
 } from '../src/composables/usePlatformApps'
@@ -204,7 +206,7 @@ describe('resolvePlatformAppPrimaryAction', () => {
 
     expect(action).toMatchObject({
       kind: 'inspect',
-      label: 'Inspect shell',
+      label: 'Admin diagnostics',
       route: '/apps/after-sales',
     })
   })
@@ -225,6 +227,27 @@ describe('resolvePlatformAppPrimaryAction', () => {
       label: 'Open app',
       route: '/attendance',
     })
+  })
+
+  it('localizes direct-runtime actions and non-applicable instance metadata', () => {
+    const app = createAppSummary({
+      id: 'attendance',
+      pluginId: 'plugin-attendance',
+      pluginName: 'plugin-attendance',
+      displayName: 'Attendance',
+      runtimeModel: 'direct',
+      entryPath: '/attendance',
+      instance: null,
+    })
+
+    expect(resolvePlatformAppPrimaryAction(app, undefined, true)).toMatchObject({
+      kind: 'open',
+      label: '打开应用',
+      description: '从标准入口直接打开应用，无需为当前租户安装。',
+      route: '/attendance',
+    })
+    expect(resolvePlatformAppProjectLabel(app, true)).toBe('无需项目')
+    expect(resolvePlatformAppInstanceLabel(app, true)).toBe('直接运行')
   })
 
   it('reports direct install state for direct-runtime apps', () => {

--- a/apps/web/tests/platform-app-launcher.spec.ts
+++ b/apps/web/tests/platform-app-launcher.spec.ts
@@ -1,8 +1,7 @@
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, type App as VueApp, type Component } from 'vue'
 import { useLocale } from '../src/composables/useLocale'
+import launcherSource from '../src/views/PlatformAppLauncherView.vue?raw'
 import {
   setPlatformAppRuntimeInstallState,
   type PlatformAppSummary,
@@ -115,9 +114,22 @@ async function flushUi(cycles = 4): Promise<void> {
   }
 }
 
+function installLauncherStyles(): HTMLStyleElement {
+  const openingTag = '<style scoped>'
+  const start = launcherSource.indexOf(openingTag)
+  const end = launcherSource.indexOf('</style>', start)
+  if (start < 0 || end < 0) throw new Error('PlatformAppLauncherView scoped styles not found')
+
+  const style = document.createElement('style')
+  style.textContent = launcherSource.slice(start + openingTag.length, end)
+  document.head.appendChild(style)
+  return style
+}
+
 describe('PlatformAppLauncherView', () => {
   let app: VueApp<Element> | null = null
   let container: HTMLDivElement | null = null
+  let launcherStyle: HTMLStyleElement | null = null
 
   beforeEach(() => {
     setPlatformAppRuntimeInstallState('after-sales', null)
@@ -134,8 +146,10 @@ describe('PlatformAppLauncherView', () => {
   afterEach(() => {
     if (app) app.unmount()
     if (container) container.remove()
+    if (launcherStyle) launcherStyle.remove()
     app = null
     container = null
+    launcherStyle = null
     setPlatformAppRuntimeInstallState('after-sales', null)
     useLocale().setLocale('en')
     window.localStorage.removeItem('user_roles')
@@ -226,20 +240,31 @@ describe('PlatformAppLauncherView', () => {
   it('renders a locale-safe error state without exposing backend fallback text', async () => {
     useLocale().setLocale('zh-CN')
     apiGetMock.mockRejectedValueOnce(new Error('Failed to load platform apps'))
+    launcherStyle = installLauncherStyles()
 
     await mountLauncher()
 
     const alert = container.querySelector<HTMLElement>('[role="alert"]')
     expect(alert?.textContent?.trim()).toBe('应用加载失败，请重试。')
     expect(container.textContent).not.toContain('Failed to load platform apps')
+    expect(getComputedStyle(alert!).backgroundColor).toBe('rgb(255, 255, 255)')
+    expect(getComputedStyle(alert!).color).toBe('rgb(185, 28, 28)')
   })
 
-  it('pins readable foreground colors on light launcher surfaces', () => {
-    const source = readFileSync(resolve(__dirname, '../src/views/PlatformAppLauncherView.vue'), 'utf8')
+  it('pins readable foreground colors on rendered light launcher surfaces', async () => {
+    apiGetMock.mockResolvedValueOnce({ list: [createDirectApp()] })
+    launcherStyle = installLauncherStyles()
 
-    expect(source).toMatch(/\.platform-app-launcher__card\s*\{[^}]*background:\s*#fff;[^}]*color:\s*#0f172a;/s)
-    expect(source).toMatch(/\.platform-app-launcher__meta dd\s*\{[^}]*color:\s*#0f172a;/s)
-    expect(source).toMatch(/\.platform-app-launcher__error,\s*\.platform-app-launcher__state\s*\{[^}]*background:\s*#fff;[^}]*color:\s*#334155;/s)
-    expect(source).toMatch(/\.platform-app-launcher__primary\s*\{[^}]*background:\s*#2563eb;[^}]*color:\s*#fff;/s)
+    await mountLauncher()
+
+    const card = container.querySelector<HTMLElement>('.platform-app-launcher__card')!
+    const metadata = container.querySelector<HTMLElement>('.platform-app-launcher__meta dd')!
+    const primaryAction = container.querySelector<HTMLElement>('.platform-app-launcher__primary')!
+
+    expect(getComputedStyle(card).backgroundColor).toBe('rgb(255, 255, 255)')
+    expect(getComputedStyle(card).color).toBe('rgb(15, 23, 42)')
+    expect(getComputedStyle(metadata).color).toBe('rgb(15, 23, 42)')
+    expect(getComputedStyle(primaryAction).backgroundColor).toBe('rgb(37, 99, 235)')
+    expect(getComputedStyle(primaryAction).color).toBe('rgb(255, 255, 255)')
   })
 })

--- a/apps/web/tests/platform-app-launcher.spec.ts
+++ b/apps/web/tests/platform-app-launcher.spec.ts
@@ -1,6 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, type App as VueApp, type Component } from 'vue'
-import { setPlatformAppRuntimeInstallState, type PlatformAppSummary } from '../src/composables/usePlatformApps'
+import { useLocale } from '../src/composables/useLocale'
+import {
+  setPlatformAppRuntimeInstallState,
+  type PlatformAppSummary,
+  usePlatformApps,
+} from '../src/composables/usePlatformApps'
 
 const apiGetMock = vi.fn()
 
@@ -80,6 +87,27 @@ function createInstanceApp(overrides: Partial<PlatformAppSummary> = {}): Platfor
   }
 }
 
+function createDirectApp(overrides: Partial<PlatformAppSummary> = {}): PlatformAppSummary {
+  return createInstanceApp({
+    id: 'attendance',
+    pluginId: 'plugin-attendance',
+    pluginName: 'plugin-attendance',
+    pluginDisplayName: 'Attendance Plugin',
+    displayName: 'Attendance',
+    runtimeModel: 'direct',
+    boundedContext: {
+      code: 'attendance',
+      owner: 'people-ops',
+      description: 'Attendance tracking, reports, import operations, and workflow-backed adjustments.',
+    },
+    runtimeBindings: undefined,
+    platformDependencies: ['workflow'],
+    entryPath: '/attendance',
+    instance: null,
+    ...overrides,
+  })
+}
+
 async function flushUi(cycles = 4): Promise<void> {
   for (let i = 0; i < cycles; i += 1) {
     await Promise.resolve()
@@ -93,6 +121,13 @@ describe('PlatformAppLauncherView', () => {
 
   beforeEach(() => {
     setPlatformAppRuntimeInstallState('after-sales', null)
+    const platformApps = usePlatformApps()
+    platformApps.apps.value = []
+    platformApps.error.value = null
+    platformApps.loading.value = false
+    useLocale().setLocale('en')
+    window.localStorage.removeItem('user_roles')
+    window.localStorage.removeItem('user_permissions')
     apiGetMock.mockReset()
   })
 
@@ -102,7 +137,19 @@ describe('PlatformAppLauncherView', () => {
     app = null
     container = null
     setPlatformAppRuntimeInstallState('after-sales', null)
+    useLocale().setLocale('en')
+    window.localStorage.removeItem('user_roles')
+    window.localStorage.removeItem('user_permissions')
   })
+
+  async function mountLauncher(): Promise<void> {
+    const View = (await import('../src/views/PlatformAppLauncherView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.mount(container)
+    await flushUi(6)
+  }
 
   it('marks apps as partial when the current runtime snapshot is degraded', async () => {
     apiGetMock
@@ -124,17 +171,75 @@ describe('PlatformAppLauncherView', () => {
         },
       })
 
-    const View = (await import('../src/views/PlatformAppLauncherView.vue')).default
-
-    container = document.createElement('div')
-    document.body.appendChild(container)
-    app = createApp(View as Component)
-    app.mount(container)
-    await flushUi(6)
+    await mountLauncher()
 
     expect(apiGetMock).toHaveBeenNthCalledWith(1, '/api/platform/apps')
-    expect(apiGetMock).toHaveBeenNthCalledWith(2, '/api/after-sales/projects/current')
-    expect(container.textContent).toContain('partial')
+    expect(apiGetMock).toHaveBeenNthCalledWith(2, '/api/after-sales/projects/current', {
+      suppressUnauthorizedRedirect: true,
+    })
+    expect(container.querySelector<HTMLElement>('.platform-app-launcher__instance')?.dataset.state).toBe('partial')
+    expect(container.textContent).toContain('Incomplete')
     expect(container.textContent).toContain('Reinstall app')
+  })
+
+  it('switches every launcher label and built-in app copy with the active locale', async () => {
+    apiGetMock.mockResolvedValueOnce({ list: [createDirectApp()] })
+
+    await mountLauncher()
+
+    expect(container.textContent).toContain('Platform Apps')
+    expect(container.textContent).toContain('App Center')
+    expect(container.textContent).toContain('Attendance')
+    expect(container.textContent).toContain('Direct entry')
+    expect(container.textContent).toContain('Open app')
+    expect(container.querySelector('.platform-app-launcher__instance')).toBeNull()
+    expect(container.querySelector('.platform-app-launcher__ghost')).toBeNull()
+    expect(container.querySelector('.platform-app-launcher__refresh')?.getAttribute('aria-label')).toBe('Refresh apps')
+
+    useLocale().setLocale('zh-CN')
+    await flushUi()
+
+    expect(container.textContent).toContain('平台应用')
+    expect(container.textContent).toContain('应用中心')
+    expect(container.textContent).toContain('考勤')
+    expect(container.textContent).toContain('考勤记录、报表、导入操作及工作流驱动的调整。')
+    expect(container.textContent).toContain('直接使用')
+    expect(container.textContent).toContain('打开应用')
+    expect(container.textContent).toContain('从标准入口直接打开应用，无需为当前租户安装。')
+    expect(container.textContent).not.toContain('Platform Apps')
+    expect(container.textContent).not.toContain('Attendance tracking')
+    expect(container.textContent).not.toContain('Open app')
+    expect(container.querySelector('.platform-app-launcher__refresh')?.getAttribute('aria-label')).toBe('刷新应用')
+  })
+
+  it('shows shell diagnostics only to administrators and labels them as diagnostics', async () => {
+    window.localStorage.setItem('user_roles', JSON.stringify(['admin']))
+    apiGetMock.mockResolvedValueOnce({ list: [createDirectApp()] })
+
+    await mountLauncher()
+
+    const diagnosticLink = container.querySelector<HTMLAnchorElement>('.platform-app-launcher__ghost')
+    expect(diagnosticLink?.textContent?.trim()).toBe('Admin diagnostics')
+    expect(diagnosticLink?.getAttribute('href')).toBe('/apps/attendance')
+  })
+
+  it('renders a locale-safe error state without exposing backend fallback text', async () => {
+    useLocale().setLocale('zh-CN')
+    apiGetMock.mockRejectedValueOnce(new Error('Failed to load platform apps'))
+
+    await mountLauncher()
+
+    const alert = container.querySelector<HTMLElement>('[role="alert"]')
+    expect(alert?.textContent?.trim()).toBe('应用加载失败，请重试。')
+    expect(container.textContent).not.toContain('Failed to load platform apps')
+  })
+
+  it('pins readable foreground colors on light launcher surfaces', () => {
+    const source = readFileSync(resolve(__dirname, '../src/views/PlatformAppLauncherView.vue'), 'utf8')
+
+    expect(source).toMatch(/\.platform-app-launcher__card\s*\{[^}]*background:\s*#fff;[^}]*color:\s*#0f172a;/s)
+    expect(source).toMatch(/\.platform-app-launcher__meta dd\s*\{[^}]*color:\s*#0f172a;/s)
+    expect(source).toMatch(/\.platform-app-launcher__error,\s*\.platform-app-launcher__state\s*\{[^}]*background:\s*#fff;[^}]*color:\s*#334155;/s)
+    expect(source).toMatch(/\.platform-app-launcher__primary\s*\{[^}]*background:\s*#2563eb;[^}]*color:\s*#fff;/s)
   })
 })


### PR DESCRIPTION
## What changed

- add a single zh-CN/en label table for App Center headers, states, metadata, statuses, built-in app copy, and action descriptors
- remove the duplicate direct-runtime instance explanation while keeping the normal app entry prominent
- hide shell diagnostics from ordinary users and label the admin-only entry as diagnostics
- pin readable foreground colors on light cards and state surfaces, and make the primary app action visually distinct
- add locale-switching, role-gating, degraded-runtime, error-state, and style-contract regression coverage

## Why

The launcher mixed English and Chinese, repeated direct-runtime installation guidance, exposed an implementation-oriented shell link to ordinary users, and inherited unreadable foreground colors under a dark system preference.

Addresses #4373, #4374, and #4375.

## Verification

- `pnpm --filter @metasheet/web exec vitest run platform-app --reporter=dot` (18 passed)
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web exec eslint src/composables/usePlatformApps.ts src/utils/platformAppLabels.ts src/views/PlatformAppLauncherView.vue tests/platform-app-actions.spec.ts tests/platform-app-launcher.spec.ts`
- `pnpm --filter @metasheet/web build`
- `git diff --check origin/main...HEAD`

## Browser checks

- system dark preference: white cards computed with `rgb(15, 23, 42)` foreground for card, heading, and metadata
- 390x844 and 1280x720: no horizontal page overflow or overflowing launcher elements
- ordinary user: zero diagnostics links
- admin user: localized `Admin diagnostics` / `管理员诊断` links
