### PR TITLE
feat(automation): #4196 execution-scoped applied ledger — foundation (L1)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -554,6 +554,7 @@ jobs:
             tests/integration/multitable-tombstone-retention-realdb.test.ts \
             tests/integration/multitable-automation-outbox-schema-realdb.test.ts \
             tests/integration/multitable-action-applied-ledger-realdb.test.ts \
+            tests/integration/multitable-automation-execution-ledger-realdb.test.ts \
             tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts \
             tests/integration/multitable-automation-dispatch-loop-realdb.test.ts \
             tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260716100000_create_automation_action_applied.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260716100000_create_automation_action_applied.ts
@@ -1,0 +1,51 @@
+/**
+ * Migration: `meta_automation_action_applied` — the #4196 EXECUTION-SCOPED retry/test-run applied ledger.
+ *
+ * Row shape is the #4196 §2.2 LOCKED contract, verbatim:
+ *   - `kind` is the NON-OPTIONAL namespace discriminator: 'execution' (a real retry lineage) | 'test_run'
+ *     (a real_fire test-run, §6.1). It is PART OF the claim key, so a test-run row and a real-execution row
+ *     can NEVER be the same claim even if their root_execution_id strings were identical — the structural
+ *     disjointness §6.1 guarantees against client-supplied testRunOperationId values.
+ *   - `root_execution_id`: kind='execution' → the original execution's lineage root; kind='test_run' → the
+ *     SERVER-DERIVED scoped root (§6.1) — never the raw caller value.
+ *   - `action_key`: the §2.1 ordered triple { structuralPath, action.type, canonicalConfig } — the same
+ *     injectively-encoded identity `deriveActionKey` (automation-action-idempotency.ts) produces; the
+ *     action's type participates in the key INSIDE this value.
+ *   - `action_type` is NULLABLE audit metadata only — §2's claim INSERT supplies exactly the three key
+ *     columns and must stay valid without it.
+ *   - `UNIQUE (kind, root_execution_id, action_key)` is the exact target of §2's
+ *     `INSERT ... ON CONFLICT DO NOTHING` — the whole class-A exactly-once-effective guarantee rests on it.
+ *
+ * Class-A protocol (§2): BEGIN → claim INSERT → 0 rows ⇒ ROLLBACK + report `already_applied`; 1 row ⇒ perform
+ * the meta_records mutation → COMMIT. A crash at ANY point before COMMIT leaves NEITHER the ledger row NOR the
+ * mutation durable; after COMMIT, BOTH. No window where one is durable and the other is not.
+ *
+ * DISTINCT from `meta_fwb_action_applied` (the FWB approval-instance/node-scoped ledger) — the two tables
+ * coexist; see the cross-ledger golden in the spec.
+ *
+ * Additive only; the executor wiring that WRITES this ledger ships behind its own reviewed slice.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_automation_action_applied (
+      kind               text NOT NULL
+                           CONSTRAINT automation_action_applied_kind_valid CHECK (kind IN ('execution','test_run')),
+      root_execution_id  text NOT NULL
+                           CONSTRAINT automation_action_applied_root_nonblank CHECK (root_execution_id ~ '[!-~]'),
+      action_key         text NOT NULL
+                           CONSTRAINT automation_action_applied_action_key_nonblank CHECK (action_key ~ '[!-~]'),
+      action_type        text,
+      applied_at         timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_automation_action_applied_claim
+    ON meta_automation_action_applied (kind, root_execution_id, action_key)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS meta_automation_action_applied`.execute(db)
+}

--- a/packages/core-backend/src/multitable/automation-execution-ledger.ts
+++ b/packages/core-backend/src/multitable/automation-execution-ledger.ts
@@ -1,0 +1,101 @@
+/**
+ * #4196 execution-scoped applied ledger — Class-A same-transaction claim + the §6.1 server-derived
+ * test-run scoped root. Foundation slice: the ledger primitives only; the executor wiring that calls
+ * them (retry SKIP-vs-apply, real_fire test-run isolation, Class-B intent/outcome states) ships as its
+ * own reviewed slices on top.
+ *
+ *   - `claimExecutionAction(trx, claim)` — §2's claim INSERT, verbatim:
+ *     `INSERT INTO meta_automation_action_applied (kind, root_execution_id, action_key) ON CONFLICT DO
+ *     NOTHING`. 'claimed' → the caller performs the class-A mutation in the SAME transaction and commits;
+ *     'duplicate' → a prior apply holds the claim; the caller ROLLS BACK and reports `already_applied`
+ *     (skip — no mutation attempted). Same-transaction is MACHINE-ENFORCED (pg-transaction-guard xid
+ *     probe): a pool / autocommit client / forged marker is rejected before the claim, because a claim
+ *     that auto-commits apart from its mutation re-opens the exact at-least-once duplicate window §2
+ *     dissolves.
+ *   - `deriveTestRunScopedRoot({ actorId, ruleId, testRunOperationId })` — §6.1: the caller value is an
+ *     INPUT ONLY; the server derives a scoped root deterministic in (actor_id, rule_id, clientOperationId),
+ *     so the same tuple dedups (same derived root → same claim) while two different rules/actors carrying
+ *     the same clientOperationId land on independent roots. The derived value is prefixed + hashed, so a
+ *     client-supplied value can never equal (and thus never address) a real execution's lineage root — and
+ *     even a contrived equality is harmless because `kind='test_run'` keeps the keyspace STRUCTURALLY
+ *     disjoint from `kind='execution'` inside the UNIQUE claim key.
+ *   - `action_key` identity is the shared #4196-C4 triple — use `deriveActionKey` from
+ *     automation-action-idempotency.ts (injective JSON-array encoding); this module does not redefine it.
+ */
+import { createHash } from 'node:crypto'
+
+import { assertInTransaction, type TransactionalQueryable } from './pg-transaction-guard'
+
+export type ExecutionLedgerKind = 'execution' | 'test_run'
+
+const LEDGER_KINDS: ReadonlySet<string> = new Set<ExecutionLedgerKind>(['execution', 'test_run'])
+const NON_BLANK = /[!-~]/
+/** §6.1: the clientOperationId is an opaque bounded token — restricted charset, bounded length. */
+const CLIENT_OPERATION_ID = /^[A-Za-z0-9_-]{1,128}$/
+
+export interface ExecutionActionClaim {
+  kind: ExecutionLedgerKind
+  /** kind='execution': the original execution's lineage root; kind='test_run': the §6.1 DERIVED root. */
+  rootExecutionId: string
+  /** the §2.1 triple identity — produce with deriveActionKey (injective encoding). */
+  actionKey: string
+  /** optional audit metadata — never part of the claim key (§2.2). */
+  actionType?: string | null
+}
+
+/**
+ * Class-A same-transaction claim (§2). 'claimed' → proceed with the mutation in THIS transaction;
+ * 'duplicate' → roll back and report `already_applied`.
+ */
+export async function claimExecutionAction(
+  trx: TransactionalQueryable,
+  c: ExecutionActionClaim,
+): Promise<'claimed' | 'duplicate'> {
+  if (typeof c.kind !== 'string' || !LEDGER_KINDS.has(c.kind)) {
+    throw new RangeError(`claimExecutionAction: kind must be 'execution' | 'test_run' (got ${String(c.kind)})`)
+  }
+  for (const [name, v] of [['rootExecutionId', c.rootExecutionId], ['actionKey', c.actionKey]] as const) {
+    if (typeof v !== 'string' || !NON_BLANK.test(v)) {
+      throw new RangeError(`claimExecutionAction: ${name} must be non-blank`)
+    }
+  }
+  // The claim must ride the SAME transaction as the class-A mutation — probed against the DB itself.
+  await assertInTransaction(trx, 'claimExecutionAction')
+  const res = await trx.query(
+    `INSERT INTO meta_automation_action_applied (kind, root_execution_id, action_key, action_type)
+     VALUES ($1,$2,$3,$4)
+     ON CONFLICT (kind, root_execution_id, action_key) DO NOTHING`,
+    [c.kind, c.rootExecutionId, c.actionKey, c.actionType ?? null],
+  )
+  return Number(res.rowCount ?? 0) === 1 ? 'claimed' : 'duplicate'
+}
+
+export interface TestRunRootInput {
+  actorId: string
+  ruleId: string
+  /** the caller-supplied Idempotency-Key (§6.1) — validated + bounded; an INPUT to the derivation only. */
+  testRunOperationId: string
+}
+
+/**
+ * §6.1 server-side derivation of the test-run scoped root. Deterministic in (actorId, ruleId,
+ * testRunOperationId) via an INJECTIVE JSON-array encoding + sha256, prefixed 'trroot_' so the derived
+ * value is recognizable and can never equal a raw caller value or a real execution's lineage root format.
+ */
+export function deriveTestRunScopedRoot(input: TestRunRootInput): string {
+  for (const [name, v] of [['actorId', input.actorId], ['ruleId', input.ruleId]] as const) {
+    if (typeof v !== 'string' || !NON_BLANK.test(v)) {
+      throw new RangeError(`deriveTestRunScopedRoot: ${name} must be non-blank`)
+    }
+  }
+  if (typeof input.testRunOperationId !== 'string' || !CLIENT_OPERATION_ID.test(input.testRunOperationId)) {
+    throw new RangeError(
+      'deriveTestRunScopedRoot: testRunOperationId must be an opaque token of 1..128 chars from [A-Za-z0-9_-] (it is an Idempotency-Key, not free text)',
+    )
+  }
+  const digest = createHash('sha256')
+    .update(JSON.stringify([input.actorId, input.ruleId, input.testRunOperationId]))
+    .digest('hex')
+    .slice(0, 32)
+  return `trroot_${digest}`
+}

--- a/packages/core-backend/tests/integration/multitable-automation-execution-ledger-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-execution-ledger-realdb.test.ts
@@ -1,0 +1,178 @@
+/**
+ * #4196 execution-scoped applied ledger — foundation slice (real DB).
+ *
+ * Proves the §2.2 LOCKED row shape at the DB layer and the §2 Class-A claim protocol:
+ *   - named CHECKs (kind closed set, non-blank root/action_key) reject by constraint name;
+ *   - the UNIQUE (kind, root_execution_id, action_key) claim key collides duplicates;
+ *   - kind gives STRUCTURAL disjointness (§6.1): identical root+action_key strings under 'execution' vs
+ *     'test_run' are two independent claims;
+ *   - claimExecutionAction: claimed → duplicate; crash-safety (rollback → the retry claims again — §2's
+ *     "no window where one is durable and the other is not"); a constructed two-transaction race yields
+ *     exactly one 'claimed'; the pg-transaction-guard probe rejects pool / forged marker / bare autocommit;
+ *   - deriveTestRunScopedRoot (§6.1): deterministic in (actor, rule, opId); each tuple component changes
+ *     the root; the derived root never equals the raw caller value; opId charset/length is enforced;
+ *   - coexists with the FWB ledger `meta_fwb_action_applied` (both real tables now) — one transaction can
+ *     claim in BOTH, and the rows land in disjoint tables.
+ *
+ * Two-point wired (plugin-tests.yml + vitest.config.ts exclude) so it cannot skip-green.
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import {
+  claimExecutionAction,
+  deriveTestRunScopedRoot,
+} from '../../src/multitable/automation-execution-ledger'
+import { claimActionApplied, deriveActionKey } from '../../src/multitable/automation-action-idempotency'
+import type { TransactionalQueryable } from '../../src/multitable/pg-transaction-guard'
+import type { PoolClient } from 'pg'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const RUN = randomUUID()
+const ROOT = `exec_${RUN}`
+
+const txn = (client: PoolClient): TransactionalQueryable => ({ isTransaction: true, query: (sql, params) => client.query(sql, params) })
+async function inTxn<T>(fn: (trx: TransactionalQueryable, client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await poolManager.get().getInternalPool().connect()
+  try {
+    await client.query('BEGIN')
+    const r = await fn(txn(client), client)
+    await client.query('COMMIT')
+    return r
+  } catch (e) {
+    await client.query('ROLLBACK').catch(() => {})
+    throw e
+  } finally {
+    client.release()
+  }
+}
+
+const rawInsert = (kind: string, root: string, key: string) =>
+  q(`INSERT INTO meta_automation_action_applied (kind, root_execution_id, action_key) VALUES ($1,$2,$3)`, [kind, root, key])
+
+describeIfDatabase('#4196 execution-scoped applied ledger — foundation (real DB)', () => {
+  afterAll(async () => {
+    await q(`DELETE FROM meta_automation_action_applied WHERE root_execution_id LIKE $1`, [`%${RUN}%`]).catch(() => {})
+    await q(`DELETE FROM meta_fwb_action_applied WHERE instance_id LIKE $1`, [`%${RUN}%`]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('schema: named CHECKs reject a bad kind and blank identity parts by constraint name', async () => {
+    await expect(rawInsert('bogus', ROOT, `ak_${RUN}`)).rejects.toThrow(/automation_action_applied_kind_valid/)
+    await expect(rawInsert('execution', '  ', `ak_${RUN}`)).rejects.toThrow(/automation_action_applied_root_nonblank/)
+    await expect(rawInsert('execution', ROOT, '\t')).rejects.toThrow(/automation_action_applied_action_key_nonblank/)
+  })
+
+  test('schema: the UNIQUE claim key collides a duplicate by index name; §2 INSERT with only the 3 key columns is valid', async () => {
+    // §2's exact INSERT shape (3 key columns only — action_type nullable, applied_at defaulted)
+    await rawInsert('execution', ROOT, `ak_${RUN}_uq`)
+    await expect(rawInsert('execution', ROOT, `ak_${RUN}_uq`)).rejects.toThrow(/uq_automation_action_applied_claim/)
+  })
+
+  test('§6.1 STRUCTURAL disjointness: identical root+action_key strings under execution vs test_run are two independent claims', async () => {
+    const key = `ak_${RUN}_kinds`
+    await expect(rawInsert('execution', ROOT, key)).resolves.toBeTruthy()
+    await expect(rawInsert('test_run', ROOT, key)).resolves.toBeTruthy() // kind is part of the claim key
+  })
+
+  test('§2 claim protocol: first=claimed, repeat=duplicate (across committed transactions)', async () => {
+    const key = deriveActionKey({ structuralPath: 's[0]', actionType: 'create_record', canonicalConfig: { t: RUN } })
+    const claim = { kind: 'execution' as const, rootExecutionId: ROOT, actionKey: key, actionType: 'create_record' }
+    expect(await inTxn((t) => claimExecutionAction(t, claim))).toBe('claimed')
+    expect(await inTxn((t) => claimExecutionAction(t, claim))).toBe('duplicate')
+  })
+
+  test('§2 crash-safety: a rolled-back transaction leaves NO claim — the retry claims again (never a permanent skip)', async () => {
+    const key = deriveActionKey({ structuralPath: 's[1]', actionType: 'update_record', canonicalConfig: { t: RUN } })
+    const claim = { kind: 'execution' as const, rootExecutionId: ROOT, actionKey: key }
+    const client = await poolManager.get().getInternalPool().connect()
+    try {
+      await client.query('BEGIN')
+      expect(await claimExecutionAction(txn(client), claim)).toBe('claimed')
+      await client.query('ROLLBACK') // "crash before COMMIT": neither the claim nor the mutation is durable
+    } finally {
+      client.release()
+    }
+    const { rows } = await q(`SELECT count(*)::int AS c FROM meta_automation_action_applied WHERE action_key=$1`, [key])
+    expect(Number(rows[0].c)).toBe(0)
+    expect(await inTxn((t) => claimExecutionAction(t, claim))).toBe('claimed') // the retry re-attempts correctly
+  })
+
+  test('§2 constructed race: two concurrent transactions claim the same key → exactly one claimed', async () => {
+    const key = deriveActionKey({ structuralPath: 's[2]', actionType: 'delete_record', canonicalConfig: { t: RUN } })
+    const claim = { kind: 'execution' as const, rootExecutionId: ROOT, actionKey: key }
+    const [ra, rb] = await Promise.all([
+      inTxn((t) => claimExecutionAction(t, claim)),
+      inTxn((t) => claimExecutionAction(t, claim)),
+    ])
+    expect([ra, rb].filter((r) => r === 'claimed')).toHaveLength(1)
+    expect([ra, rb].filter((r) => r === 'duplicate')).toHaveLength(1)
+  })
+
+  test('P1 guard: pool / forged marker / bare autocommit client are rejected by the xid probe before the claim', async () => {
+    const key = `ak_${RUN}_probe`
+    const claim = { kind: 'execution' as const, rootExecutionId: ROOT, actionKey: key }
+    await expect(claimExecutionAction(poolManager.get() as unknown as TransactionalQueryable, claim)).rejects.toThrow(/real database TRANSACTION/)
+    const forged: TransactionalQueryable = { isTransaction: true, query: (s, p) => poolManager.get().query(s, p) }
+    await expect(claimExecutionAction(forged, claim)).rejects.toThrow(/real database TRANSACTION/)
+    const bare = await poolManager.get().getInternalPool().connect()
+    try {
+      await expect(claimExecutionAction(txn(bare), claim)).rejects.toThrow(/real database TRANSACTION/)
+    } finally {
+      bare.release()
+    }
+    const { rows } = await q(`SELECT count(*)::int AS c FROM meta_automation_action_applied WHERE action_key=$1`, [key])
+    expect(Number(rows[0].c)).toBe(0)
+  })
+
+  test('input validation: bad kind / blank root / blank key throw before any SQL', async () => {
+    const stub: TransactionalQueryable = { isTransaction: true, query: async () => { throw new Error('must not be queried') } }
+    await expect(claimExecutionAction(stub, { kind: 'bogus' as never, rootExecutionId: ROOT, actionKey: 'k' })).rejects.toThrow(/kind must be/)
+    await expect(claimExecutionAction(stub, { kind: 'execution', rootExecutionId: ' ', actionKey: 'k' })).rejects.toThrow(/rootExecutionId/)
+    await expect(claimExecutionAction(stub, { kind: 'test_run', rootExecutionId: ROOT, actionKey: '' })).rejects.toThrow(/actionKey/)
+  })
+
+  test('§6.1 deriveTestRunScopedRoot: deterministic; every tuple component matters; never the raw caller value; bounded opaque token', () => {
+    const base = { actorId: `u_${RUN}`, ruleId: `rule_${RUN}`, testRunOperationId: 'op-123_ABC' }
+    const r1 = deriveTestRunScopedRoot(base)
+    expect(deriveTestRunScopedRoot({ ...base })).toBe(r1) // deterministic → same claim on retry (dedup)
+    expect(deriveTestRunScopedRoot({ ...base, actorId: `u2_${RUN}` })).not.toBe(r1) // actor scopes
+    expect(deriveTestRunScopedRoot({ ...base, ruleId: `rule2_${RUN}` })).not.toBe(r1) // rule scopes
+    expect(deriveTestRunScopedRoot({ ...base, testRunOperationId: 'op-124' })).not.toBe(r1) // opId scopes
+    expect(r1).not.toBe(base.testRunOperationId) // the caller value NEVER becomes the root directly
+    expect(r1).toMatch(/^trroot_[0-9a-f]{32}$/) // recognizable server-derived format
+    // bounded opaque token: bad charset / overlength rejected
+    expect(() => deriveTestRunScopedRoot({ ...base, testRunOperationId: 'has space' })).toThrow(/opaque token/)
+    expect(() => deriveTestRunScopedRoot({ ...base, testRunOperationId: 'x'.repeat(129) })).toThrow(/opaque token/)
+    expect(() => deriveTestRunScopedRoot({ ...base, testRunOperationId: '' })).toThrow(/opaque token/)
+  })
+
+  test('§6.1 end-to-end: a test_run claim under a derived root can never collide with an execution claim — and dedups on the same tuple', async () => {
+    const key = deriveActionKey({ structuralPath: 's[3]', actionType: 'create_record', canonicalConfig: { t: RUN } })
+    const derived = deriveTestRunScopedRoot({ actorId: `u_${RUN}`, ruleId: `rule_${RUN}`, testRunOperationId: 'click-1' })
+    // even a real-execution claim under the SAME derived-root string is independent (kind disjointness)
+    expect(await inTxn((t) => claimExecutionAction(t, { kind: 'execution', rootExecutionId: derived, actionKey: key }))).toBe('claimed')
+    expect(await inTxn((t) => claimExecutionAction(t, { kind: 'test_run', rootExecutionId: derived, actionKey: key }))).toBe('claimed')
+    // a second real_fire click with the SAME testRunOperationId derives the SAME root → dedup
+    const derivedAgain = deriveTestRunScopedRoot({ actorId: `u_${RUN}`, ruleId: `rule_${RUN}`, testRunOperationId: 'click-1' })
+    expect(await inTxn((t) => claimExecutionAction(t, { kind: 'test_run', rootExecutionId: derivedAgain, actionKey: key }))).toBe('duplicate')
+  })
+
+  test('coexists with the FWB ledger: one transaction claims in BOTH tables; rows land disjointly', async () => {
+    const key = deriveActionKey({ structuralPath: 's[coexist]', actionType: 'create_record', canonicalConfig: { t: RUN } })
+    await inTxn(async (t) => {
+      expect(await claimExecutionAction(t, { kind: 'execution', rootExecutionId: ROOT, actionKey: key })).toBe('claimed')
+      expect(await claimActionApplied(t, { id: `aa_${randomUUID()}`, instanceId: `apr_${RUN}`, ruleId: `rule_${RUN}`, actionKey: key })).toBe('claimed')
+    })
+    const exec = await q(`SELECT count(*)::int AS c FROM meta_automation_action_applied WHERE root_execution_id=$1 AND action_key=$2`, [ROOT, key])
+    const fwb = await q(`SELECT count(*)::int AS c FROM meta_fwb_action_applied WHERE instance_id=$1 AND action_key=$2`, [`apr_${RUN}`, key])
+    expect(Number(exec.rows[0].c)).toBe(1)
+    expect(Number(fwb.rows[0].c)).toBe(1)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -337,6 +337,10 @@ export default defineConfig({
       // action-idempotency ledger L1 schema golden — real-DB. Excluded HERE so it cannot skip-green
       // in the no-DB lane; whole-file wired into plugin-tests.yml. Two-point wiring.
       'tests/integration/multitable-action-applied-ledger-realdb.test.ts',
+      // #4196 execution-scoped applied ledger foundation (§2.2 locked table + §2 Class-A claim +
+      // §6.1 derived test-run root): real Postgres only — excluded HERE so it cannot skip-green in the
+      // no-DB lane, whole-file wired into `Run multitable real-DB integration` in plugin-tests.yml.
+      'tests/integration/multitable-automation-execution-ledger-realdb.test.ts',
       // P2 durable-delivery S2-a claim engine / fence-CAS — real-DB constructed-concurrency (zombie/SKIP
       // LOCKED). Excluded HERE so it cannot skip-green in the no-DB lane; whole-file wired into
       // plugin-tests.yml. Two-point wiring.


### PR DESCRIPTION
**Step ③ of the owner's closing sequence** (with #4220 verified superseded — evidence on that PR): the first slice of the **#4196 retry/test-run runtime**. **Additive, no callers yet** — the executor wiring (retry SKIP-vs-apply, `real_fire` isolation, Class-B intent/outcome states, drift/retention gates) ships as follow-on slices.

## What lands
- **Migration** → the REAL `meta_automation_action_applied` per the **#4196 §2.2 LOCKED row shape**, on the name the FWB ledger vacated in #4340: `kind` (`'execution'|'test_run'`, non-optional namespace discriminator, **part of the claim key**), `root_execution_id`, `action_key` (the shared #4196-C4 injective triple), nullable `action_type` (audit), `UNIQUE (kind, root_execution_id, action_key)` — the exact target of §2's `INSERT … ON CONFLICT DO NOTHING`. Named CHECKs throughout.
- **`automation-execution-ledger.ts`**:
  - `claimExecutionAction` — §2's Class-A same-transaction claim ('claimed' → mutate in the same txn and commit; 'duplicate' → roll back, report `already_applied`). Same-transaction is **machine-enforced** via the pg-transaction-guard xid probe.
  - `deriveTestRunScopedRoot` — §6.1: the caller's `testRunOperationId` is an **input only** (bounded opaque token `[A-Za-z0-9_-]{1,128}`); the server derives `trroot_<sha256(injective-JSON(actor,rule,opId))[:32]>`, deterministic in the tuple; structural disjointness from real executions via `kind='test_run'` in the claim key.

## Verification (fresh Postgres 15)
- **12/12** real-DB: §2 INSERT shape (3 key columns only); named-CHECK negatives; UNIQUE collision by index name; §6.1 structural disjointness (identical root+key under both kinds = two claims); claimed→duplicate; **rollback→retry claims again** (crash-safety — no permanent skip); two-transaction race → exactly one claimed; probe negatives (pool/forged/bare); derivation determinism/scoping/bounds + never-the-raw-caller-value; derived-root dedup end-to-end; **coexistence with `meta_fwb_action_applied` in one transaction**. FWB ledger spec still 14/14. `tsc --noEmit` 0.
- **Mutation-proven**: dropping `kind` from the UNIQUE kills 6 tests; widening the kind CHECK, dropping `ruleId` from the derivation, and widening the JS kind validation each kill their test. Two-point CI wired.

**For review — not self-merging runtime.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)