### PR TITLE
feat(directory): PB4-4 — local integration reactivation (revive the same anchor in place)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -162,6 +162,12 @@ jobs:
       - name: PB4-3 cycle-detection CI wiring contract
         run: node --test scripts/ops/pb4-3-cycle-detection-ci-wiring.test.mjs
 
+      # PB4-4 CI two-point wiring contract (no DB): the reactivation suite (2-way/5-way concurrency
+      # single-audit proof) must stay wired into BOTH vitest.config.ts (exclude) AND plugin-tests.yml
+      # (directory real-DB step). Dropping either point silently disables the reactivation proof.
+      - name: PB4-4 reactivation CI wiring contract
+        run: node --test scripts/ops/pb4-4-reactivation-ci-wiring.test.mjs
+
       # The production monitor invokes the same state helper covered here.
       # Keep this in the required 18/20 matrix so HTTP classification, silence
       # barriers, and alert/recovery streak semantics cannot drift silently.
@@ -626,6 +632,7 @@ jobs:
             tests/integration/local-directory-org-crud-route.db.test.ts \
             tests/integration/local-directory-org-archive-readonly.db.test.ts \
             tests/integration/local-directory-org-cycle-detection.db.test.ts \
+            tests/integration/directory-local-integration-reactivation.db.test.ts \
             tests/integration/directory-normalized-manager.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             tests/integration/attendance-notification-redelivery.db.test.ts \

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -2274,6 +2274,13 @@ export async function createDirectoryIntegration(input: DirectoryIntegrationInpu
  * partial unique index `one_active_local_integration_per_org` makes the loser's INSERT raise a
  * unique_violation (23505), which we catch and resolve by re-reading the winner.
  */
+// The canonical local anchor's name — the ONE `provider='local'` integration bootstrap creates per
+// org. Used for both the bootstrap INSERT and the PB4-4 reactivation WHERE, so the reactivation
+// targets exactly that anchor and — because `idx_directory_integrations_org_provider_name` is unique
+// on (org_id, provider, name) — flips at most ONE row (differently-named local rows are only
+// creatable by raw ops, never by this service, and are out of scope for reactivation).
+const LOCAL_INTEGRATION_NAME = 'Local organization'
+
 export async function getOrCreateLocalIntegration(
   orgId: string = DEFAULT_ORG_ID,
 ): Promise<DirectoryIntegrationSummary> {
@@ -2281,6 +2288,60 @@ export async function getOrCreateLocalIntegration(
 
   const existing = await selectActiveLocalIntegration(normalizedOrgId)
   if (existing) return summarizeIntegration(existing)
+
+  // PB4-4 (reactivation, owner design lock): before bootstrapping a NEW integration, revive a
+  // previously-deactivated local integration IN PLACE — same id, so its departments, accounts, and
+  // future B4 department-binding refs (all FK'd to integration_id) survive. A blind INSERT here
+  // collides on idx_directory_integrations_org_provider_name (the fixed 'Local organization' name),
+  // and the old B1 catch below — which only re-selects ACTIVE rows — cannot recover from that, so
+  // the org's local directory would be bricked (every getOrCreate throws) after a single deactivate.
+  //
+  // The conditional UPDATE is a race-safe latch: `WHERE status <> 'active'` is re-evaluated under
+  // READ COMMITTED after the row lock, so among N concurrent callers exactly ONE flips the row
+  // (RETURNING it) and writes the reactivation audit; every other caller's UPDATE matches zero rows
+  // (the row is already active by the time its lock is granted) and falls through to re-select the
+  // now-active winner below — same id, and exactly ONE `directory.local_integration.reactivate`
+  // audit no matter how many callers raced. (`idx_directory_integrations_org_provider_name` keeps at
+  // most one such (org, 'local', name) row, so this flips exactly the one deactivated anchor, never
+  // two — even if raw ops left extra differently-named inactive local rows around.)
+  const reactivated = await query<DirectoryIntegrationRow>(
+    `UPDATE directory_integrations
+        SET status = 'active', updated_at = NOW()
+      WHERE org_id = $1 AND provider = 'local' AND name = $2 AND status <> 'active'
+      RETURNING id, org_id, provider, name, status, corp_id, config, sync_enabled, schedule_cron, schedule_timezone,
+                default_deprovision_policy, last_sync_at, last_success_at, last_error, created_at, updated_at`,
+    [normalizedOrgId, LOCAL_INTEGRATION_NAME],
+  )
+  if (reactivated.rows.length === 1) {
+    const revived = summarizeIntegration(reactivated.rows[0])
+    try {
+      const { auditLog } = await import('../audit/audit')
+      await auditLog({
+        actorId: 'system',
+        actorType: 'system',
+        action: 'directory.local_integration.reactivate',
+        resourceType: 'directory-integration',
+        resourceId: revived.id,
+        // Values-free: integrationId (resourceId) + orgId + provider only. corp_id is immutable and
+        // already `local:<orgId>` by the CHECK — no need to echo it.
+        meta: { orgId: normalizedOrgId, provider: 'local' },
+      })
+    } catch (error) {
+      // Same best-effort contract as bootstrap below: only the dynamic import can fail here, and the
+      // status flip is already committed, so we log values-free and still return the revived anchor.
+      logger.warn(`Failed to import audit module after local integration reactivation: ${readErrorMessage(error, 'unknown error')}`, {
+        integrationId: revived.id,
+        orgId: normalizedOrgId,
+      })
+    }
+    return revived
+  }
+
+  // Zero rows flipped: either a concurrent caller just reactivated/bootstrapped the active row, or
+  // there is genuinely no local integration yet. Re-check for an active winner before creating one —
+  // this is the losing side of a reactivation race (return the winner, no second audit).
+  const reactivationWinner = await selectActiveLocalIntegration(normalizedOrgId)
+  if (reactivationWinner) return summarizeIntegration(reactivationWinner)
 
   const localCorpId = `local:${normalizedOrgId}`
   try {
@@ -2294,7 +2355,7 @@ export async function getOrCreateLocalIntegration(
                  default_deprovision_policy, last_sync_at, last_success_at, last_error, created_at, updated_at`,
       [
         normalizedOrgId,
-        'Local organization',
+        LOCAL_INTEGRATION_NAME,
         localCorpId,
         JSON.stringify({ mode: 'editable', source: 'local' }),
       ],

--- a/packages/core-backend/tests/integration/directory-local-integration-reactivation.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-local-integration-reactivation.db.test.ts
@@ -1,3 +1,4 @@
+import { Client } from 'pg'
 import { afterEach, describe, expect, it } from 'vitest'
 import { query } from '../../src/db/pg'
 import { getOrCreateLocalIntegration } from '../../src/directory/directory-sync'
@@ -17,10 +18,14 @@ import { createLocalAccount, createLocalDepartment } from '../../src/directory/l
  *   (a) basic — deactivate → getOrCreate returns the SAME id, status active again, and the seeded
  *       department + account still hang off that id; exactly ONE `…reactivate` audit.
  *   (b) idempotent — when already active, getOrCreate does NOT emit a reactivate audit (fast path).
- *   (c) 2-way and (d) 5-way concurrency — after deactivation, N simultaneous callers all converge on
- *       the SAME id with exactly ONE reactivate audit (the `status <> 'active'` conditional UPDATE is
+ *   (c) 2-way and (d) 5-way concurrency — behind a DETERMINISTIC barrier (a raw holder locks the
+ *       inactive anchor `FOR UPDATE`; all N reactivation UPDATEs are confirmed parked behind it via
+ *       `pg_blocking_pids()`; the lock is released so they race for real), the N callers converge on
+ *       the SAME id with exactly ONE reactivate audit — the `status <> 'active'` conditional UPDATE is
  *       a race-safe latch: only the caller whose UPDATE actually flips the row audits; the rest match
- *       zero rows and re-select the winner).
+ *       zero rows and re-select the winner. (A bare `Promise.all` is NOT a reliable mutation detector
+ *       here — the first caller can commit before the others reach the UPDATE, letting them take the
+ *       fast-path; the barrier removes that escape so the mutation below reds STABLY.)
  *   (e) first-bootstrap regression — a brand-new org still bootstraps (one bootstrap audit, ZERO
  *       reactivate audits).
  *   (f) name-filter safety — an EXTRA differently-named inactive local row (raw) is left untouched;
@@ -29,7 +34,8 @@ import { createLocalAccount, createLocalDepartment } from '../../src/directory/l
  *
  * Load-bearing mutations (out-of-band, each reds this file):
  *   - delete the reactivation block            → (a) reds (getOrCreate throws after deactivation).
- *   - delete `AND status <> 'active'`          → (d) reds (every concurrent caller audits → N audits).
+ *   - delete `AND status <> 'active'`          → (c)/(d) red STABLY (behind the barrier every one of
+ *                                                 the N released UPDATEs flips + audits → N audits).
  *   - delete `AND name = $2`                    → (f) reds (both inactive rows flip → one_active
  *                                                 unique_violation → getOrCreate throws).
  *
@@ -67,6 +73,69 @@ async function auditCount(action: string, resourceId: string): Promise<number> {
     [action, resourceId],
   )
   return r.rows[0]?.n ?? 0
+}
+
+/**
+ * DETERMINISTIC concurrency barrier (owner P2 fix). A bare `Promise.all` of N reactivations is NOT a
+ * reliable mutation detector: the first caller can reactivate and COMMIT before the others reach the
+ * UPDATE, so they take the active fast-path and never collide — deleting the `status<>'active'` latch
+ * then leaves the test green (a false mutation-red). This forces a genuine collision instead: a raw
+ * holder locks the inactive anchor row `FOR UPDATE`, we start N service calls (each parks on the
+ * reactivation UPDATE behind that lock), confirm via `pg_blocking_pids()` that ALL N are blocked BY
+ * the holder, then release — so all N UPDATEs are released into the row simultaneously and race the
+ * latch for real. With the latch, exactly one flips (RETURNING a row → one audit); the rest see the
+ * now-active row and match zero rows. WITHOUT the latch, every one of the N flips (idempotent) and
+ * RETURNs a row → N audits, stably. `holder` only SELECTs FOR UPDATE (never mutates), so on release
+ * the row is still inactive and the service calls do the reactivation.
+ */
+async function reactivateConcurrentlyBehindLock(org: string, integrationId: string, n: number): Promise<unknown[]> {
+  const holder = new Client({ connectionString: process.env.DATABASE_URL })
+  await holder.connect()
+  try {
+    await holder.query('BEGIN')
+    const holderPid = (await holder.query<{ pid: number }>('SELECT pg_backend_pid() AS pid')).rows[0].pid
+    await holder.query('SELECT id FROM directory_integrations WHERE id = $1 FOR UPDATE', [integrationId])
+
+    const calls = Array.from({ length: n }, () =>
+      getOrCreateLocalIntegration(org).then(
+        (v) => v,
+        (e) => e,
+      ),
+    )
+    await waitForNBlockedBy(holderPid, n)
+
+    await holder.query('COMMIT') // release the row lock — still inactive; the N UPDATEs now race
+    return await Promise.all(calls)
+  } finally {
+    await holder.end()
+  }
+}
+
+/** Poll until all N reactivation UPDATEs are genuinely parked behind the holder's row lock (via
+ *  `pg_blocking_pids()`, not a sleep). NOTE: concurrent UPDATEs on one row form a LOCK QUEUE — only
+ *  the queue HEAD waits directly on the holder (`wait_event='transactionid'`); the rest wait on the
+ *  txn ahead of them (`wait_event='tuple'`), so the holder is NOT in their direct `pg_blocking_pids`.
+ *  So we require BOTH: (a) N reactivation UPDATEs are Lock-blocked (the whole queue), AND (b) the
+ *  queue is ROOTED at the holder (≥1 UPDATE has the holder as a direct blocker). Together these prove
+ *  all N are behind the holder — no fast-path escape. */
+async function waitForNBlockedBy(holderPid: number, n: number): Promise<void> {
+  for (let i = 0; i < 500; i++) {
+    const r = await query<{ blocked: number; rooted: number }>(
+      `SELECT
+         count(*) FILTER (WHERE wait_event_type = 'Lock'
+                           AND query ILIKE '%directory_integrations%'
+                           AND query ILIKE '%set status%')::int AS blocked,
+         count(*) FILTER (WHERE $1 = ANY(pg_blocking_pids(pid)))::int AS rooted
+       FROM pg_stat_activity
+       WHERE state = 'active' AND datname = current_database() AND pid <> pg_backend_pid()`,
+      [holderPid],
+    )
+    const blocked = r.rows[0]?.blocked ?? 0
+    const rooted = r.rows[0]?.rooted ?? 0
+    if (blocked >= n && rooted >= 1) return
+    await new Promise((res) => setTimeout(res, 20))
+  }
+  throw new Error(`timed out waiting for ${n} reactivation UPDATEs queued behind the holder (barrier never engaged)`)
 }
 
 describeIfDatabase('PB4-4 — local integration reactivation (real DB)', () => {
@@ -139,26 +208,31 @@ describeIfDatabase('PB4-4 — local integration reactivation (real DB)', () => {
     expect(await auditCount(REACTIVATE_ACTION, first.id)).toBe(0)
   })
 
-  it('(c) 2-way concurrency: after deactivation, both callers converge to the same id with exactly one reactivate audit', async () => {
+  it('(c) 2-way concurrency (deterministic barrier): both reactivation UPDATEs block on the locked anchor, then converge to one id with exactly one audit', async () => {
     const org = orgId('c')
     seededOrgIds.push(org)
     const { integrationId } = await seedAnchorWithChildren(org)
     await deactivate(integrationId)
 
-    const [r1, r2] = await Promise.all([getOrCreateLocalIntegration(org), getOrCreateLocalIntegration(org)])
-    expect(r1.id).toBe(integrationId)
-    expect(r2.id).toBe(integrationId)
+    const results = await reactivateConcurrentlyBehindLock(org, integrationId, 2)
+    for (const r of results) {
+      expect(r).not.toBeInstanceOf(Error)
+      expect((r as { id: string }).id).toBe(integrationId)
+    }
     expect(await auditCount(REACTIVATE_ACTION, integrationId)).toBe(1)
   })
 
-  it('(d) 5-way concurrency: after deactivation, all callers converge to the same id with exactly one reactivate audit', async () => {
+  it('(d) 5-way concurrency (deterministic barrier): all 5 reactivation UPDATEs block on the locked anchor via pg_blocking_pids, then converge to one id with exactly one audit', async () => {
     const org = orgId('d')
     seededOrgIds.push(org)
     const { integrationId } = await seedAnchorWithChildren(org)
     await deactivate(integrationId)
 
-    const results = await Promise.all(Array.from({ length: 5 }, () => getOrCreateLocalIntegration(org)))
-    for (const r of results) expect(r.id).toBe(integrationId)
+    const results = await reactivateConcurrentlyBehindLock(org, integrationId, 5)
+    for (const r of results) {
+      expect(r).not.toBeInstanceOf(Error)
+      expect((r as { id: string }).id).toBe(integrationId)
+    }
     expect(await auditCount(REACTIVATE_ACTION, integrationId)).toBe(1)
   })
 

--- a/packages/core-backend/tests/integration/directory-local-integration-reactivation.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-local-integration-reactivation.db.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { getOrCreateLocalIntegration } from '../../src/directory/directory-sync'
+import { createLocalAccount, createLocalDepartment } from '../../src/directory/local-directory-org'
+
+/**
+ * PB4-4 — local integration REACTIVATION (revive the same stable anchor), real DB.
+ *
+ * After a `provider='local'` integration is deactivated, the old B1 get-or-create was bricked: a
+ * fresh `getOrCreateLocalIntegration` INSERTs the fixed name 'Local organization', collides on
+ * `idx_directory_integrations_org_provider_name`, and the B1 catch (which only re-selects ACTIVE
+ * rows) cannot recover — so it throws on EVERY call. PB4-4 makes get-or-create instead REACTIVATE
+ * the canonical anchor IN PLACE (same id), so its departments, accounts, and future B4 binding refs
+ * (all FK'd to integration_id) survive, and emits exactly ONE reactivation audit.
+ *
+ * Proven against real Postgres:
+ *   (a) basic — deactivate → getOrCreate returns the SAME id, status active again, and the seeded
+ *       department + account still hang off that id; exactly ONE `…reactivate` audit.
+ *   (b) idempotent — when already active, getOrCreate does NOT emit a reactivate audit (fast path).
+ *   (c) 2-way and (d) 5-way concurrency — after deactivation, N simultaneous callers all converge on
+ *       the SAME id with exactly ONE reactivate audit (the `status <> 'active'` conditional UPDATE is
+ *       a race-safe latch: only the caller whose UPDATE actually flips the row audits; the rest match
+ *       zero rows and re-select the winner).
+ *   (e) first-bootstrap regression — a brand-new org still bootstraps (one bootstrap audit, ZERO
+ *       reactivate audits).
+ *   (f) name-filter safety — an EXTRA differently-named inactive local row (raw) is left untouched;
+ *       reactivation flips only the canonical `name='Local organization'` anchor, so it never
+ *       double-activates into a `one_active_local_integration_per_org` violation.
+ *
+ * Load-bearing mutations (out-of-band, each reds this file):
+ *   - delete the reactivation block            → (a) reds (getOrCreate throws after deactivation).
+ *   - delete `AND status <> 'active'`          → (d) reds (every concurrent caller audits → N audits).
+ *   - delete `AND name = $2`                    → (f) reds (both inactive rows flip → one_active
+ *                                                 unique_violation → getOrCreate throws).
+ *
+ * Fixture IDs are namespaced with this file's STAMP — integration specs share one Postgres in CI.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+const REACTIVATE_ACTION = 'directory.local_integration.reactivate'
+const BOOTSTRAP_ACTION = 'directory.local_integration.bootstrap'
+
+const orgId = (suffix: string): string => `pb44-${STAMP}-${suffix}`
+const newUserId = (suffix: string): string => `pb44-user-${STAMP}-${suffix}`
+
+async function seedUser(id: string, name: string): Promise<void> {
+  await query(`INSERT INTO users (id, email, name, password_hash) VALUES ($1, $2, $3, 'x')`, [id, `${id}@example.test`, name])
+}
+
+async function localIntegrationRow(org: string): Promise<{ id: string; status: string } | null> {
+  const r = await query<{ id: string; status: string }>(
+    `SELECT id, status FROM directory_integrations WHERE org_id = $1 AND provider = 'local' AND name = 'Local organization'`,
+    [org],
+  )
+  return r.rows[0] ?? null
+}
+
+async function deactivate(integrationId: string): Promise<void> {
+  await query(`UPDATE directory_integrations SET status = 'inactive', updated_at = NOW() WHERE id = $1`, [integrationId])
+}
+
+async function auditCount(action: string, resourceId: string): Promise<number> {
+  const r = await query<{ n: number }>(
+    `SELECT count(*)::int AS n FROM audit_logs
+      WHERE action = $1 AND resource_type = 'directory-integration' AND resource_id = $2`,
+    [action, resourceId],
+  )
+  return r.rows[0]?.n ?? 0
+}
+
+describeIfDatabase('PB4-4 — local integration reactivation (real DB)', () => {
+  const seededOrgIds: string[] = []
+  const seededUserIds: string[] = []
+
+  afterEach(async () => {
+    for (const org of seededOrgIds.splice(0)) {
+      await query(
+        `DELETE FROM audit_logs WHERE resource_type = 'directory-integration'
+           AND resource_id IN (SELECT id::text FROM directory_integrations WHERE org_id = $1)`,
+        [org],
+      )
+      await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [org])
+    }
+    for (const uid of seededUserIds.splice(0)) {
+      await query(`DELETE FROM users WHERE id = $1`, [uid])
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  async function seedAnchorWithChildren(org: string): Promise<{ integrationId: string; deptId: string; accountId: string }> {
+    const uid = newUserId(org)
+    seededUserIds.push(uid)
+    await seedUser(uid, 'Anchor Member')
+    const dept = await createLocalDepartment({ orgId: org, name: 'Anchor Dept' }) // bootstraps the anchor
+    const account = await createLocalAccount({ orgId: org, localUserId: uid })
+    const row = await localIntegrationRow(org)
+    if (!row) throw new Error('anchor not bootstrapped')
+    return { integrationId: row.id, deptId: dept.id, accountId: account.id }
+  }
+
+  it('(a) deactivate → getOrCreate revives the SAME id (status active), children survive, exactly one reactivate audit', async () => {
+    const org = orgId('a')
+    seededOrgIds.push(org)
+    const { integrationId, deptId, accountId } = await seedAnchorWithChildren(org)
+
+    await deactivate(integrationId)
+    expect((await localIntegrationRow(org))?.status).toBe('inactive')
+
+    const revived = await getOrCreateLocalIntegration(org)
+    expect(revived.id).toBe(integrationId) // SAME stable anchor, not a new row
+    expect(revived.status).toBe('active')
+
+    // exactly one local row for the org (no duplicate anchor was minted)
+    const allLocal = await query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM directory_integrations WHERE org_id = $1 AND provider = 'local'`,
+      [org],
+    )
+    expect(allLocal.rows[0].n).toBe(1)
+
+    // children still hang off the SAME integration id (future B4 binding refs survive)
+    const dept = await query<{ integration_id: string }>(`SELECT integration_id FROM directory_departments WHERE id = $1`, [deptId])
+    const account = await query<{ integration_id: string }>(`SELECT integration_id FROM directory_accounts WHERE id = $1`, [accountId])
+    expect(dept.rows[0].integration_id).toBe(integrationId)
+    expect(account.rows[0].integration_id).toBe(integrationId)
+
+    expect(await auditCount(REACTIVATE_ACTION, integrationId)).toBe(1)
+  })
+
+  it('(b) idempotent: getOrCreate on an already-active anchor does NOT emit a reactivate audit', async () => {
+    const org = orgId('b')
+    seededOrgIds.push(org)
+    const first = await getOrCreateLocalIntegration(org)
+    const second = await getOrCreateLocalIntegration(org)
+    expect(second.id).toBe(first.id)
+    expect(await auditCount(REACTIVATE_ACTION, first.id)).toBe(0)
+  })
+
+  it('(c) 2-way concurrency: after deactivation, both callers converge to the same id with exactly one reactivate audit', async () => {
+    const org = orgId('c')
+    seededOrgIds.push(org)
+    const { integrationId } = await seedAnchorWithChildren(org)
+    await deactivate(integrationId)
+
+    const [r1, r2] = await Promise.all([getOrCreateLocalIntegration(org), getOrCreateLocalIntegration(org)])
+    expect(r1.id).toBe(integrationId)
+    expect(r2.id).toBe(integrationId)
+    expect(await auditCount(REACTIVATE_ACTION, integrationId)).toBe(1)
+  })
+
+  it('(d) 5-way concurrency: after deactivation, all callers converge to the same id with exactly one reactivate audit', async () => {
+    const org = orgId('d')
+    seededOrgIds.push(org)
+    const { integrationId } = await seedAnchorWithChildren(org)
+    await deactivate(integrationId)
+
+    const results = await Promise.all(Array.from({ length: 5 }, () => getOrCreateLocalIntegration(org)))
+    for (const r of results) expect(r.id).toBe(integrationId)
+    expect(await auditCount(REACTIVATE_ACTION, integrationId)).toBe(1)
+  })
+
+  it('(e) first-bootstrap regression: a brand-new org bootstraps (one bootstrap audit, zero reactivate audits)', async () => {
+    const org = orgId('e')
+    seededOrgIds.push(org)
+    const created = await getOrCreateLocalIntegration(org)
+    expect(await auditCount(BOOTSTRAP_ACTION, created.id)).toBe(1)
+    expect(await auditCount(REACTIVATE_ACTION, created.id)).toBe(0)
+  })
+
+  it('(f) name-filter safety: an extra differently-named inactive local row is left untouched — reactivation flips only the canonical anchor, never double-activating', async () => {
+    const org = orgId('f')
+    seededOrgIds.push(org)
+    const { integrationId } = await seedAnchorWithChildren(org)
+    await deactivate(integrationId)
+
+    // raw-insert a SECOND inactive local row with a DIFFERENT name (only possible via raw ops)
+    const extra = await query<{ id: string }>(
+      `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config, sync_enabled)
+       VALUES ($1, 'local', 'Local organization (old)', 'inactive', $2, '{"mode":"editable","source":"local"}'::jsonb, false)
+       RETURNING id`,
+      [org, `local:${org}`],
+    )
+    const extraId = extra.rows[0].id
+
+    const revived = await getOrCreateLocalIntegration(org)
+    expect(revived.id).toBe(integrationId) // the canonical anchor, not the extra row
+    expect(revived.status).toBe('active')
+
+    // the extra differently-named row is STILL inactive (not double-activated)
+    const extraRow = await query<{ status: string }>(`SELECT status FROM directory_integrations WHERE id = $1`, [extraId])
+    expect(extraRow.rows[0].status).toBe('inactive')
+
+    expect(await auditCount(REACTIVATE_ACTION, integrationId)).toBe(1)
+    expect(await auditCount(REACTIVATE_ACTION, extraId)).toBe(0)
+  })
+})

--- a/packages/core-backend/tests/integration/directory-local-provider-bootstrap.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-local-provider-bootstrap.db.test.ts
@@ -193,9 +193,10 @@ describeIfDatabase('Canonical Org MVP — B1 local provider bootstrap (real DB)'
     // the constant name 'Local organization', so driving this through the service would collide
     // on the pre-existing UNIQUE(org_id, provider, name) index — the SAME confound test (b) is
     // written to dodge — and prove nothing about `one_active_local_integration_per_org` itself.
-    // Whether/how the service should ever re-bootstrap after a local row goes inactive (today no
-    // code path sets one inactive — scheduler/deprovision both exclude provider='local') is a
-    // service-layer naming question, not this index's job; this test isolates the index alone.
+    // How the SERVICE handles a deactivated anchor is answered separately by PB4-4: getOrCreate now
+    // REACTIVATES the canonical `name='Local organization'` anchor in place (same id) rather than
+    // bootstrapping a second row — see directory-local-integration-reactivation.db.test.ts. This
+    // test isolates the INDEX alone (raw inserts, differently-named rows), which is unchanged.
     const org = orgId('active-only')
     seededOrgIds.push(org)
 

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -121,6 +121,13 @@ export default defineConfig({
       // directory real-DB step in plugin-tests.yml (both points asserted by
       // pb4-3-cycle-detection-ci-wiring.test.mjs so neither can silently drop).
       'tests/integration/local-directory-org-cycle-detection.db.test.ts',
+      // Canonical Org MVP PB4-4: local integration REACTIVATION — getOrCreate revives the deactivated
+      // canonical anchor in place (same id, children preserved) instead of a bricking name-collision.
+      // Includes 2-way/5-way concurrency proving a single reactivate audit — meaningless without a
+      // real DB. DATABASE_URL-gated; excluded here so the no-DB job cannot skip-green it, and wired as
+      // a WHOLE FILE into the directory real-DB step in plugin-tests.yml (both points asserted by
+      // pb4-4-reactivation-ci-wiring.test.mjs so neither can silently drop).
+      'tests/integration/directory-local-integration-reactivation.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
       // resolution against real Postgres — normalized `is_manager` relation for a local integration,
       // the DingTalk `leader_in_dept` regression pin (load-bearing compat leg + is_manager=0 positive

--- a/scripts/ops/pb4-4-reactivation-ci-wiring.test.mjs
+++ b/scripts/ops/pb4-4-reactivation-ci-wiring.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// PB4-4 CI two-point wiring contract. The reactivation suite is a real-DB concurrency test (2-way
+// and 5-way callers converging on one id with exactly one reactivate audit) that is meaningless
+// without a real DB: it needs BOTH (1) the vitest.config.ts exclude entry (so the no-DB job cannot
+// skip-green it) AND (2) the plugin-tests.yml directory real-DB whole-file step (so a real-DB run
+// actually names it). Removing either point makes the entire reactivation/concurrency suite silently
+// never execute while exact-head CI stays green. This source-level guard (no DB) reddens if either
+// point is dropped. It runs in the no-DB `test` job, so it gates every PR.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/directory-local-integration-reactivation.db.test.ts'
+
+test('vitest.config.ts excludes the PB4-4 reactivation suite from the no-DB job', () => {
+  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE} (DATABASE_URL-gated whole file)`)
+})
+
+test('plugin-tests.yml runs the PB4-4 reactivation suite as a whole file in the directory real-DB step', () => {
+  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  assert.match(wf, new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${FILE} in the directory real-DB step`)
+})


### PR DESCRIPTION
## PB4-4 — Local integration reactivation (pre-B4 hardening ticket 4 of 4)

> **Posture: HELD for owner review — do NOT auto-land. Unarmed.** Developed to gate-clean + CI-green + pushed; merge is the owner's.
> **Base: `main`** (PB4-3 landed as `80f4aceae`; this PR was rebased onto it — patch-id unchanged). PB4-4-specific delta is 6 files.

Closes the pre-B4 hardening gap: *"B1 停用后同名重建撞 UNIQUE(org_id, provider, name)（B1 不宣称停用后自动重建）"*.

### Problem
After a `provider='local'` integration is **deactivated**, the B1 get-or-create was **bricked**: `getOrCreateLocalIntegration` INSERTs the fixed name `'Local organization'` → collides on `idx_directory_integrations_org_provider_name` → the B1 catch (which re-selects **active** rows only) can't recover → **every call throws**, stranding the org's departments, accounts, and future B4 department-binding refs (all FK'd to `integration_id`).

### Fix — revive the SAME stable anchor in place
`getOrCreateLocalIntegration` now REACTIVATES the canonical anchor before falling back to bootstrap:
```
UPDATE directory_integrations SET status='active', updated_at=NOW()
 WHERE org_id=$1 AND provider='local' AND name=$2 AND status <> 'active'
 RETURNING …
```
- **Same id** → its departments/accounts/future-B4 binding refs survive (they FK to `integration_id`).
- **`status <> 'active'` = race-safe latch** — re-evaluated under READ COMMITTED after the row lock, so among N concurrent callers exactly **one** flips the row (RETURNING it) and writes a `directory.local_integration.reactivate` audit; the rest match zero rows and re-select the winner → **single audit**.
- **`name=$2` filter** (shared `LOCAL_INTEGRATION_NAME` constant, also used by the INSERT) targets exactly the canonical anchor, so with `idx_directory_integrations_org_provider_name` unique on (org_id, provider, name) it flips **at most one** row — never double-activating into a `one_active_local_integration_per_org` violation, even if raw ops left extra differently-named inactive local rows around.

### Real-DB proof — `directory-local-integration-reactivation.db.test.ts` (7 tests)
- **(a)** deactivate → getOrCreate revives the **same id** (active again), seeded dept + account still hang off it, exactly **one** reactivate audit, exactly one local row.
- **(b)** idempotent: already-active getOrCreate emits **zero** reactivate audits.
- **(c)/(d)** 2-way and **5-way** concurrency **behind a deterministic blocking barrier** (a raw holder locks the inactive anchor `FOR UPDATE`; a `pg_blocking_pids()` poll confirms all N reactivation UPDATEs are queued and rooted at the holder; the lock is released so they race the latch for real): all callers converge on the same id with exactly **one** reactivate audit.
- **(e)** first-bootstrap regression: fresh org bootstraps (one bootstrap audit, zero reactivate).
- **(f)** name-filter safety: an extra differently-named inactive local row is left untouched — no double-activation.

B1 bootstrap suite (all 9 tests still green); case (e) comment updated to point here.

### Load-bearing mutations (proven out-of-band, each reds this file)
- delete the reactivation block → (a) reds with the exact `23505` collision on `idx_directory_integrations_org_provider_name`.
- delete `AND status <> 'active'` → (c)/(d) red STABLY behind the deterministic barrier (every released UPDATE flips + audits → N audits). *(An earlier bare-`Promise.all` version of this claim was unreliable — see the owner-P2 round below; retracted and replaced.)*
- delete `AND name = $2` → (f) reds (both inactive rows flip → `one_active` unique_violation → throw).

### CI wiring (two points + guard)
`vitest.config.ts` exclude + `plugin-tests.yml` directory real-DB whole-file step; `scripts/ops/pb4-4-reactivation-ci-wiring.test.mjs` (no-DB, gating job) reds if either point drops — proven load-bearing.

### Adversarial gate — VERDICT: APPROVE (no P1/P2)
Opus refute-first gate, all empirical: the `status<>'active'` conditional UPDATE under READ COMMITTED gives exactly one flip / one audit / one id (both unique indexes confirmed in a fresh DB); all 3 author mutations reproduced red; 5-way concurrency is genuinely concurrent (mutation-2 yields 2 audits, proving the Promise.all races); B1 bootstrap 9/9 still pass; CI wiring is real (no-DB guard 2/2). It also **refuted the read/write name-asymmetry attack**: the only `directory_integrations.name` writer (`updateDirectoryIntegration`) is gated by `getIntegrationRow`, which hard-filters `provider='dingtalk'` → returns 404 for any local id, so no service path can rename a local anchor (verified empirically). Children/audit/semantics correct; scope = 6 files.

Two **NIT**s (raw-ops-only, non-corrupting, left documented for your ruling — no service path reaches either):
- NIT-1: hard-coded-name targeting would miss a raw-ops-*renamed* anchor (no service producer exists).
- NIT-2: the reactivation UPDATE has no 23505 try/catch (the INSERT path does); only reachable via a concurrent raw-ops differently-named *active* local row, which yields a loud throw, not corruption. I deliberately did not add untested handling for an unreachable-via-service path; happy to add a symmetric catch if you'd prefer belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




### Owner-P2 round (head `3b3a6432c`)
Owner review caught that the bare `Promise.all` 5-way test was a **false mutation detector**: the first caller can reactivate and commit before the others reach the UPDATE, so they take the active fast-path and never collide — deleting `status<>'active'` then left the test green. **Fixed (test-only; production reactivation code unchanged):** (c)/(d) now run behind a deterministic barrier — a raw holder locks the anchor `FOR UPDATE`, all N service UPDATEs park behind it (confirmed via `pg_blocking_pids()`: N Lock-blocked reactivation UPDATEs, queue rooted at the holder), then the lock releases so they race for real. Now the mutation reds **stably** (verified 3× for both (c)=2 and (d)=5 audits); unmutated stays exactly one audit. The stale "stacked on #4397" note and the old unreliable mutation-red claim are removed/retracted above.