### PR TITLE
feat(stock-prep): T4-final — approved-source prelude for the prep-line extended smoke (T3b OD-6)

### DIFF
--- a/.github/workflows/stock-preparation-prep-line-extended-smoke.yml
+++ b/.github/workflows/stock-preparation-prep-line-extended-smoke.yml
@@ -40,6 +40,13 @@ on:
         description: Per-request timeout in ms
         required: false
         default: '15000'
+      approved_source_config_id:
+        description: >-
+          T4-final (T3b OD-6) approved-source prelude — an APPROVED read-source config reference.
+          Requires the service-side MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED=true for the run
+          (flip on, run once, restore). Empty = prelude skipped (byte-for-byte legacy smoke).
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -99,6 +106,7 @@ jobs:
           METASHEET_WORKSPACE_ID: ${{ github.event.inputs.workspace_id || '' }}
           SMOKE_PROJECT_PREFIX: ${{ github.event.inputs.project_prefix || 'stockprep-t4' }}
           TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '15000' }}
+          APPROVED_SOURCE_CONFIG_ID: ${{ github.event.inputs.approved_source_config_id || '' }}
         run: |
           set -euo pipefail
           out_dir="output/stock-preparation-prep-line-extended-smoke/manual"
@@ -113,6 +121,7 @@ jobs:
           )
           if [[ -n "${METASHEET_TENANT_ID:-}" ]]; then args+=(--tenant-id "$METASHEET_TENANT_ID"); fi
           if [[ -n "${METASHEET_WORKSPACE_ID:-}" ]]; then args+=(--workspace-id "$METASHEET_WORKSPACE_ID"); fi
+          if [[ -n "${APPROVED_SOURCE_CONFIG_ID:-}" ]]; then args+=(--approved-source-config-id "$APPROVED_SOURCE_CONFIG_ID"); fi
           if [[ -n "${K3_WISE_SMOKE_TOKEN:-}" ]]; then
             export METASHEET_AUTH_TOKEN="$K3_WISE_SMOKE_TOKEN"
           fi

--- a/docs/development/stock-preparation-t4-prep-line-extended-smoke-runbook-20260714.md
+++ b/docs/development/stock-preparation-t4-prep-line-extended-smoke-runbook-20260714.md
@@ -111,3 +111,28 @@ physically present in the internal `Stock Preparation Line` sheet (`meta_records
 ## Deployed-lane PASS record
 
 _None yet. Record the workflow run URL + summary block here after the first deployed dispatch._
+
+## T4-final：approved-source 前置（T3b OD-6 扩展，2026-07-16）
+
+可选前置，把「approved PLM read → 同请求内部落库」接到本 smoke 前端；合成链判据原样保留（扩展而非重写）。
+
+### 前提（operator 提供，smoke 不自造）
+1. 一份 **approved** read-source config（`readSourceConfigId` 引用即可，smoke 绝不携带凭证或 raw payload 控制）。其 `fieldMap.target` 只允许 bounded 结构目标（如 `pathKey`/`childDrawingNo`/`designQty`）；**不得**映射 `missingChildBom`（T3b 结构守卫会 422 `CONFIG_TARGET_FORBIDDEN`），映射 `status`/`lineStatus` 时上游值必须已是 `imported/active/inactive/incomplete` 词表（否则整包 422 `LINE_STATUS_UNSUPPORTED`）。
+2. 服务侧 **临时** 打开 `MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED=true`：开 → 跑一次 → 恢复 OFF。**禁止**把该 flag 写入任何生产模板（OD-1/OD-6）。
+
+### 运行
+```
+node scripts/ops/stock-preparation-prep-line-extended-smoke.mjs \
+  --base-url http://HOST:PORT ... --approved-source-config-id <cfg_ref>
+```
+（或 workflow_dispatch 输入 `approved_source_config_id`。）
+
+### 判据（全部 values-free）
+- `approvedSourceHttp=201`、`approvedSourceMode=internal_persist`、created 计数 `batch:1 / lines>=1 / run:1`；
+- 外写不变量全 false（`externalWriteExecuted/productionWrite/k3SaveSubmitAudit/plmExternalWrite`）；
+- exact replay：`approvedSourceReplayHttp=200`、`approvedSourceReplayMode=internal_noop`、`skipped_existing`、零增行；
+- flag OFF 时该前置**必失败**（200 dry_run 不满足 201 internal_persist 判据），不会被静默当作通过；
+- 前置请求**不带任何 query 载体**（ON 路径把 query `tenantId/projectId` 视为 steering 并 fail-close；租户只随认证 token）；
+- config 引用与请求中的值面 token（sourceProjectNo/projectName）注册为泄漏哨兵，响应命中即整跑 FAIL。
+
+不带 `--approved-source-config-id` 时，本 smoke 与 T4-final 之前逐字节等价（无新增请求、无新增 summary 键）。

--- a/docs/development/stock-preparation-t4-prep-line-extended-smoke-runbook-20260714.md
+++ b/docs/development/stock-preparation-t4-prep-line-extended-smoke-runbook-20260714.md
@@ -117,7 +117,7 @@ _None yet. Record the workflow run URL + summary block here after the first depl
 可选前置，把「approved PLM read → 同请求内部落库」接到本 smoke 前端；合成链判据原样保留（扩展而非重写）。
 
 ### 前提（operator 提供，smoke 不自造）
-1. 一份 **approved** read-source config（`readSourceConfigId` 引用即可，smoke 绝不携带凭证或 raw payload 控制）。其 `fieldMap.target` 只允许 bounded 结构目标（如 `pathKey`/`childDrawingNo`/`designQty`）；**不得**映射 `missingChildBom`（T3b 结构守卫会 422 `CONFIG_TARGET_FORBIDDEN`），映射 `status`/`lineStatus` 时上游值必须已是 `imported/active/inactive/incomplete` 词表（否则整包 422 `LINE_STATUS_UNSUPPORTED`）。
+1. 一份 **approved** read-source config（`readSourceConfigId` 引用即可，smoke 绝不携带凭证或 raw payload 控制）。其 `fieldMap.target` 只允许 bounded 结构目标（如 `pathKey`/`childDrawingNo`/`designQty`）；**不得**映射 `missingChildBom`（T3b 结构守卫会 422 `STOCK_PREPARATION_PLM_AUTOPERSIST_CONFIG_TARGET_FORBIDDEN`），映射 `status`/`lineStatus` 时上游值必须已是 `imported/active/inactive/incomplete` 词表（否则整包 422 `STOCK_PREPARATION_PLM_AUTOPERSIST_LINE_STATUS_UNSUPPORTED`）。
 2. 服务侧 **临时** 打开 `MULTITABLE_STOCK_PREP_PLM_AUTOPERSIST_ENABLED=true`：开 → 跑一次 → 恢复 OFF。**禁止**把该 flag 写入任何生产模板（OD-1/OD-6）。
 
 ### 运行

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
@@ -17,6 +17,9 @@
 //
 // Chain (per-run-salted, self-contained fixture; 3 BOM lines A/B/C):
 //   provisioning : mvp/readiness -> mvp/ensure -> mvp/options/sync (closed vocabulary fixture)
+//   approved-src : (T4-final, opt-in --approved-source-config-id; T3b OD-6) approved PLM read ->
+//                  SAME-REQUEST internal persist (201 internal_persist, batch/lines/run non-empty)
+//                  -> exact replay (200 internal_noop) — requires the service-side T3b flag ON
 //   snapshot     : sync/plan -> sync/persist (201, 3 lines) -> persist replay (200 skipped_existing)
 //   projects     : GET /projects carries the populated project row, values-free (T1 #4190 endpoint)
 //   cache        : POST /mvp/erp-materials/sync (T2 #4206) caches material MA with
@@ -60,13 +63,15 @@
 // Run:
 //   METASHEET_AUTH_TOKEN=... node scripts/ops/stock-preparation-prep-line-extended-smoke.mjs \
 //     --base-url http://HOST:PORT [--tenant-id t] [--workspace-id w] \
-//     [--project-prefix stockprep-t4] [--timeout-ms 15000] [--out-dir output/dir]
+//     [--project-prefix stockprep-t4] [--timeout-ms 15000] [--out-dir output/dir] \
+//     [--approved-source-config-id cfg_ref]   # T4-final OD-6 prelude (service T3b flag must be ON)
 
 import fs from 'node:fs'
 import path from 'node:path'
 
 import {
   ALLOWED_ERROR_CODES,
+  ALLOWED_MODES,
   AUDIT_ACTIONS,
   ENGINE_MESSAGE_SENTINELS,
   buildOptionSetsFixture,
@@ -103,6 +108,15 @@ export const T4_ALLOWED_ERROR_CODES = Object.freeze(new Set([
 ]))
 
 export function safeCode(value) { return registeredValue(value, T4_ALLOWED_ERROR_CODES) }
+
+// T4-final additionally asserts on the T3b source-run response modes, which postdate the W6 registry.
+// Same closed-merge pattern as T4_ALLOWED_ERROR_CODES — an unknown mode still prints '<unregistered>'.
+export const T4_ALLOWED_MODES = Object.freeze(new Set([
+  ...ALLOWED_MODES,
+  'dry_run', 'internal_persist', 'internal_noop',
+]))
+
+export function safeT4Mode(value) { return registeredValue(value, T4_ALLOWED_MODES) }
 
 // The closed values-free per-row projection of GET /prep-lines (shape-lock against the W5 read
 // contract in stock-preparation-confirm-reads.cjs listStockPreparationPrepLines). Optional handles
@@ -210,6 +224,79 @@ export function buildExtendedSmokeFixture(salt, projectPrefix = 'stockprep-t4') 
   }
 }
 
+// T4-final (T3b design-lock OD-6): the approved-source prelude request. A per-run salted business
+// scope for a SEPARATE internal project/batch/run id space, so the prelude can never collide with
+// the synthetic chain's fixture. The config REFERENCE is operator-provided (an approved read-source
+// config; the smoke never carries source credentials or raw payload controls).
+export function buildApprovedSourcePrelude(salt, { projectPrefix = 'stockprep-t4', approvedSourceConfigId, workspaceId = '' } = {}) {
+  if (!approvedSourceConfigId) throw new Error('approvedSourceConfigId is required for the approved-source prelude')
+  const sourceProjectNo = `T4APRJNO-${salt}`
+  const projectName = `T4 Approved Source Project ${salt}`
+  const body = {
+    projectId: `${projectPrefix}-approved-${salt}`,
+    sourceProjectNo,
+    projectName,
+    readSourceConfigId: approvedSourceConfigId,
+    syncRunId: `smoke_t4_approved_syncrun_${salt}`,
+    snapshotBatchId: `smoke_t4_approved_batch_${salt}`,
+    snapshotVersion: 1,
+  }
+  if (workspaceId) body.workspaceId = workspaceId
+  return {
+    body,
+    // The values-free source-run response must never echo the config reference or the request's
+    // value-bearing tokens. projectId is deliberately NOT a sentinel: it is an opaque business
+    // handle that read surfaces (GET /projects) legitimately list.
+    sentinels: [approvedSourceConfigId, sourceProjectNo, projectName],
+  }
+}
+
+// T4-final prelude execution (OD-6 items 1-3 + 5 over real HTTP): approved PLM read -> SAME-REQUEST
+// internal persist -> exact replay noop. Injectable `req`/`must`/`summary` so the stage's PASS/FAIL
+// discipline is unit-testable without a server (corrective-5 fetchImpl precedent). NOTE the prelude
+// deliberately sends NO tenantId/projectId query carriers: with the T3b flag ON those are steering
+// vectors the route fail-closes on — the tenant rides the AUTHENTICATED token only (OD-2).
+export async function runApprovedSourcePrelude({ salt, args, req, must, summary }) {
+  const prelude = buildApprovedSourcePrelude(salt, {
+    projectPrefix: args.projectPrefix,
+    approvedSourceConfigId: args.approvedSourceConfigId,
+    workspaceId: args.workspaceId,
+  })
+  const sourceRun = await req(`${API}/mvp/source-runs/plm-bom`, {
+    method: 'POST', body: prelude.body, accept: [201], label: 'approved-source-run',
+  })
+  const data = (sourceRun.body && sourceRun.body.data) || {}
+  const auto = data.autoPersist || {}
+  summary.approvedSourceHttp = sourceRun.status
+  summary.approvedSourceMode = safeT4Mode(data.mode)
+  summary.approvedSourceCreated = projectCounts(auto.created, ['batch', 'lines', 'run'])
+  // A 200 dry_run here means the T3b flag is OFF on the service — the prelude REQUIRES the flag and
+  // must fail loudly rather than "pass" as a read-only run (OD-6 item 1).
+  must('approved-source run -> 201 internal_persist with non-empty batch/lines/run (T3b flag ON)',
+    sourceRun.ok && data.mode === 'internal_persist' &&
+    data.evidence?.internalWriteExecuted === true &&
+    auto.persisted === true && auto.mode === 'created' &&
+    auto.created?.batch === 1 && safeCount(auto.created?.lines) >= 1 && auto.created?.run === 1,
+    `http=${sourceRun.status} mode=${summary.approvedSourceMode} created=${summary.approvedSourceCreated}`)
+  must('approved-source run keeps every external-write invariant false',
+    data.evidence?.externalWriteExecuted === false && data.evidence?.productionWrite === false &&
+    data.evidence?.k3SaveSubmitAudit === false && data.evidence?.plmExternalWrite === false,
+    `http=${sourceRun.status}`)
+  const replay = await req(`${API}/mvp/source-runs/plm-bom`, {
+    method: 'POST', body: prelude.body, accept: [200], label: 'approved-source-run-replay',
+  })
+  const replayData = (replay.body && replay.body.data) || {}
+  summary.approvedSourceReplayHttp = replay.status
+  summary.approvedSourceReplayMode = safeT4Mode(replayData.mode)
+  must('approved-source exact replay -> 200 internal_noop skipped_existing with zero new rows',
+    replay.ok && replayData.mode === 'internal_noop' &&
+    replayData.evidence?.internalWriteExecuted === false &&
+    replayData.autoPersist?.persisted === false && replayData.autoPersist?.mode === 'skipped_existing' &&
+    replayData.autoPersist?.created?.batch === 0,
+    `http=${replay.status} mode=${summary.approvedSourceReplayMode}`)
+  return prelude
+}
+
 export function formatSummaryBlock(summary) {
   const lines = [SUMMARY_HEADER]
   for (const [key, value] of Object.entries(summary)) lines.push(`${key}=${value}`)
@@ -224,6 +311,7 @@ function parseArgs(argv) {
     projectPrefix: 'stockprep-t4',
     timeoutMs: 15000,
     outDir: '',
+    approvedSourceConfigId: '',
   }
   for (let i = 2; i < argv.length; i++) {
     const flag = argv[i]
@@ -234,6 +322,7 @@ function parseArgs(argv) {
     else if (flag === '--project-prefix') args.projectPrefix = next()
     else if (flag === '--timeout-ms') args.timeoutMs = Number(next())
     else if (flag === '--out-dir') args.outDir = next()
+    else if (flag === '--approved-source-config-id') args.approvedSourceConfigId = next()
     else throw new Error(`unknown flag: ${flag}`)
   }
   if (!args.baseUrl) throw new Error('--base-url is required')
@@ -325,6 +414,16 @@ async function main() {
   must('options sync http 200 + covered every option field',
     optionsSync.ok && S.optionsSyncedFieldCount > 0 && S.optionsSkippedFieldCount === 0,
     `http=${optionsSync.status} synced=${S.optionsSyncedFieldCount} skipped=${S.optionsSkippedFieldCount}`)
+
+  // ── 1b. T4-final approved-source prelude (T3b OD-6): approved PLM read -> internal persist ───
+  // Opt-in via --approved-source-config-id; absent, this run is byte-for-byte the pre-T4-final
+  // smoke (no new request, no new summary key). The prelude proves the approved source -> project/
+  // batch/line/run front-end in ITS OWN salted id space; the synthetic chain below stays the
+  // unchanged non-empty prep-line proof (OD-6: extend, don't rewrite).
+  if (args.approvedSourceConfigId) {
+    const prelude = await runApprovedSourcePrelude({ salt, args, req, must, summary: S })
+    SELF_SCAN_SENTINELS = [...SELF_SCAN_SENTINELS, ...prelude.sentinels]
+  }
 
   // ── 2. snapshot: plan -> persist (201, 3 lines) -> replay (200 skipped_existing) ─────────────
   const planBody = {

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
@@ -256,12 +256,16 @@ export function buildApprovedSourcePrelude(salt, { projectPrefix = 'stockprep-t4
 // discipline is unit-testable without a server (corrective-5 fetchImpl precedent). NOTE the prelude
 // deliberately sends NO tenantId/projectId query carriers: with the T3b flag ON those are steering
 // vectors the route fail-closes on — the tenant rides the AUTHENTICATED token only (OD-2).
-export async function runApprovedSourcePrelude({ salt, args, req, must, summary }) {
+export async function runApprovedSourcePrelude({ salt, args, req, must, summary, registerSentinels }) {
+  if (typeof registerSentinels !== 'function') {
+    throw new Error('runApprovedSourcePrelude requires a registerSentinels callback — the prelude sentinels MUST join the run-level leak scan')
+  }
   const prelude = buildApprovedSourcePrelude(salt, {
     projectPrefix: args.projectPrefix,
     approvedSourceConfigId: args.approvedSourceConfigId,
     workspaceId: args.workspaceId,
   })
+  registerSentinels(prelude.sentinels)
   const sourceRun = await req(`${API}/mvp/source-runs/plm-bom`, {
     method: 'POST', body: prelude.body, accept: [201], label: 'approved-source-run',
   })
@@ -421,8 +425,10 @@ async function main() {
   // batch/line/run front-end in ITS OWN salted id space; the synthetic chain below stays the
   // unchanged non-empty prep-line proof (OD-6: extend, don't rewrite).
   if (args.approvedSourceConfigId) {
-    const prelude = await runApprovedSourcePrelude({ salt, args, req, must, summary: S })
-    SELF_SCAN_SENTINELS = [...SELF_SCAN_SENTINELS, ...prelude.sentinels]
+    await runApprovedSourcePrelude({
+      salt, args, req, must, summary: S,
+      registerSentinels: (sentinels) => { SELF_SCAN_SENTINELS = [...SELF_SCAN_SENTINELS, ...sentinels] },
+    })
   }
 
   // ── 2. snapshot: plan -> persist (201, 3 lines) -> replay (200 skipped_existing) ─────────────

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
@@ -9,11 +9,15 @@ import {
   PREP_LINE_ROW_KEYS,
   SUMMARY_HEADER,
   T4_ALLOWED_ERROR_CODES,
+  T4_ALLOWED_MODES,
+  buildApprovedSourcePrelude,
   buildExtendedSmokeFixture,
   formatSummaryBlock,
   prepLineRowProjectionValid,
   prepLineRowResolved,
+  runApprovedSourcePrelude,
   safeCode,
+  safeT4Mode,
 } from './stock-preparation-prep-line-extended-smoke.mjs'
 
 import {
@@ -178,4 +182,127 @@ test('summary block: own header, flat values-free key=value lines', () => {
   assert.ok(block.includes('pass=true'))
   assert.ok(block.includes('auditActionsCovered=8/8'))
   assert.ok(block.includes('externalWrite=false'))
+})
+
+// ── T4-final (T3b OD-6): approved-source prelude ─────────────────────────────────────────────────
+
+const PRELUDE_ARGS = { projectPrefix: 'stockprep-t4', approvedSourceConfigId: 'cfg_approved_ref_1', workspaceId: '' }
+
+function scriptedReq(responses) {
+  const calls = []
+  const req = async (pathname, options = {}) => {
+    calls.push({ pathname, options })
+    const scripted = responses[calls.length - 1]
+    if (!scripted) throw new Error(`unscripted request #${calls.length}: ${pathname}`)
+    const accept = Array.isArray(options.accept) ? options.accept : [200]
+    return { status: scripted.status, body: scripted.body, ok: accept.includes(scripted.status) }
+  }
+  return { calls, req }
+}
+
+function collectMust() {
+  const checks = []
+  return { checks, must: (name, ok, detail = '') => { checks.push({ name, ok: ok === true, detail }) } }
+}
+
+function approvedCreateResponse() {
+  return {
+    status: 201,
+    body: { ok: true, data: {
+      mode: 'internal_persist',
+      evidence: { internalWriteExecuted: true, externalWriteExecuted: false, productionWrite: false, k3SaveSubmitAudit: false, plmExternalWrite: false },
+      autoPersist: { persisted: true, mode: 'created', created: { batch: 1, lines: 3, run: 1 } },
+    } },
+  }
+}
+
+function approvedReplayResponse() {
+  return {
+    status: 200,
+    body: { ok: true, data: {
+      mode: 'internal_noop',
+      evidence: { internalWriteExecuted: false, externalWriteExecuted: false, productionWrite: false, k3SaveSubmitAudit: false, plmExternalWrite: false },
+      autoPersist: { persisted: false, mode: 'skipped_existing', created: { batch: 0, lines: 0, run: 0 } },
+    } },
+  }
+}
+
+test('prelude fixture: closed body shape, own salted id space, sentinels carry the value-bearing tokens', () => {
+  const prelude = buildApprovedSourcePrelude('t123', PRELUDE_ARGS)
+  assert.deepEqual(Object.keys(prelude.body).sort(), [
+    'projectId', 'projectName', 'readSourceConfigId', 'snapshotBatchId', 'snapshotVersion', 'sourceProjectNo', 'syncRunId',
+  ].sort())
+  assert.equal(prelude.body.snapshotVersion, 1)
+  assert.equal(prelude.body.readSourceConfigId, 'cfg_approved_ref_1')
+  // The prelude id space can NEVER collide with the synthetic chain's fixture ids.
+  const fixture = buildExtendedSmokeFixture('t123')
+  assert.notEqual(prelude.body.projectId, fixture.projectId)
+  assert.notEqual(prelude.body.snapshotBatchId, fixture.snapshotBatchId)
+  assert.notEqual(prelude.body.syncRunId, fixture.syncRunId)
+  assert.notEqual(prelude.body.sourceProjectNo, fixture.sourceProjectNo)
+  // Sentinels: config reference + value-bearing tokens; the opaque projectId handle is NOT one.
+  assert.deepEqual(prelude.sentinels, ['cfg_approved_ref_1', prelude.body.sourceProjectNo, prelude.body.projectName])
+  assert.ok(!prelude.sentinels.includes(prelude.body.projectId))
+  // workspaceId appears only when provided (an intra-tenant selector, never required).
+  const scoped = buildApprovedSourcePrelude('t123', { ...PRELUDE_ARGS, workspaceId: 'w9' })
+  assert.equal(scoped.body.workspaceId, 'w9')
+  assert.throws(() => buildApprovedSourcePrelude('t123', { projectPrefix: 'x', approvedSourceConfigId: '' }))
+})
+
+test('prelude modes: the T4-final merged mode registry stays closed', () => {
+  assert.equal(safeT4Mode('internal_persist'), 'internal_persist')
+  assert.equal(safeT4Mode('internal_noop'), 'internal_noop')
+  assert.equal(safeT4Mode('dry_run'), 'dry_run')
+  assert.ok(T4_ALLOWED_MODES.has('created') && T4_ALLOWED_MODES.has('skipped_existing'))
+  assert.equal(safeT4Mode('totally_new_mode'), UNREGISTERED)
+})
+
+test('prelude run: 201 internal_persist + 200 internal_noop replay -> all checks ok, steering-free requests', async () => {
+  const { calls, req } = scriptedReq([approvedCreateResponse(), approvedReplayResponse()])
+  const { checks, must } = collectMust()
+  const summary = {}
+  const prelude = await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary })
+  assert.equal(checks.length, 3)
+  assert.ok(checks.every((c) => c.ok), JSON.stringify(checks))
+  assert.equal(summary.approvedSourceHttp, 201)
+  assert.equal(summary.approvedSourceMode, 'internal_persist')
+  assert.equal(summary.approvedSourceReplayHttp, 200)
+  assert.equal(summary.approvedSourceReplayMode, 'internal_noop')
+  assert.equal(calls.length, 2)
+  for (const call of calls) {
+    // OD-2: the ON-path route fail-closes on query tenantId/projectId carriers — the prelude must
+    // never send a query string; the tenant rides the authenticated token only.
+    assert.ok(!call.pathname.includes('?'), `steering-free path: ${call.pathname}`)
+    assert.ok(call.pathname.endsWith('/mvp/source-runs/plm-bom'))
+    // Every prelude response is leak-scanned — never exempt.
+    assert.notEqual(call.options.leakExempt, true)
+  }
+  assert.deepEqual(prelude.sentinels, ['cfg_approved_ref_1', prelude.body.sourceProjectNo, prelude.body.projectName])
+})
+
+test('prelude run: a 200 dry_run (T3b flag OFF) FAILS the prelude — it can never pass as a read-only run', async () => {
+  const dryRun = { status: 200, body: { ok: true, data: { mode: 'dry_run', evidence: { internalWriteExecuted: false, externalWriteExecuted: false, productionWrite: false, k3SaveSubmitAudit: false, plmExternalWrite: false } } } }
+  const { req } = scriptedReq([dryRun, dryRun])
+  const { checks, must } = collectMust()
+  await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary: {} })
+  assert.equal(checks[0].ok, false, 'the internal_persist check must fail on a dry_run response')
+})
+
+test('prelude run: a replay that hard-claims an internal write FAILS the replay check', async () => {
+  const lyingReplay = approvedReplayResponse()
+  lyingReplay.body.data.mode = 'internal_persist'
+  lyingReplay.body.data.evidence.internalWriteExecuted = true
+  const { req } = scriptedReq([approvedCreateResponse(), lyingReplay])
+  const { checks, must } = collectMust()
+  await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary: {} })
+  assert.equal(checks[2].ok, false, 'the internal_noop replay check must fail')
+})
+
+test('prelude run: any external-write evidence flips the invariant check to FAIL', async () => {
+  const tainted = approvedCreateResponse()
+  tainted.body.data.evidence.externalWriteExecuted = true
+  const { req } = scriptedReq([tainted, approvedReplayResponse()])
+  const { checks, must } = collectMust()
+  await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary: {} })
+  assert.equal(checks[1].ok, false, 'the externalWrite invariant check must fail')
 })

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
@@ -261,7 +261,8 @@ test('prelude run: 201 internal_persist + 200 internal_noop replay -> all checks
   const { calls, req } = scriptedReq([approvedCreateResponse(), approvedReplayResponse()])
   const { checks, must } = collectMust()
   const summary = {}
-  const prelude = await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary })
+  const registered = []
+  const prelude = await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary, registerSentinels: (list) => registered.push(...list) })
   assert.equal(checks.length, 3)
   assert.ok(checks.every((c) => c.ok), JSON.stringify(checks))
   assert.equal(summary.approvedSourceHttp, 201)
@@ -278,13 +279,26 @@ test('prelude run: 201 internal_persist + 200 internal_noop replay -> all checks
     assert.notEqual(call.options.leakExempt, true)
   }
   assert.deepEqual(prelude.sentinels, ['cfg_approved_ref_1', prelude.body.sourceProjectNo, prelude.body.projectName])
+  // P3-1 hardening pin: the prelude ITSELF registers its exact sentinel list into the run-level
+  // leak scan — the caller cannot forget it.
+  assert.deepEqual(registered, prelude.sentinels)
+})
+
+test('prelude run: the sentinel-registration callback is REQUIRED — omitting it throws before any request', async () => {
+  const { calls, req } = scriptedReq([approvedCreateResponse(), approvedReplayResponse()])
+  const { must } = collectMust()
+  await assert.rejects(
+    () => runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary: {} }),
+    /registerSentinels/,
+  )
+  assert.equal(calls.length, 0, 'no request may run without the leak-scan registration contract')
 })
 
 test('prelude run: a 200 dry_run (T3b flag OFF) FAILS the prelude — it can never pass as a read-only run', async () => {
   const dryRun = { status: 200, body: { ok: true, data: { mode: 'dry_run', evidence: { internalWriteExecuted: false, externalWriteExecuted: false, productionWrite: false, k3SaveSubmitAudit: false, plmExternalWrite: false } } } }
   const { req } = scriptedReq([dryRun, dryRun])
   const { checks, must } = collectMust()
-  await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary: {} })
+  await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary: {}, registerSentinels: () => {} })
   assert.equal(checks[0].ok, false, 'the internal_persist check must fail on a dry_run response')
 })
 
@@ -294,7 +308,7 @@ test('prelude run: a replay that hard-claims an internal write FAILS the replay 
   lyingReplay.body.data.evidence.internalWriteExecuted = true
   const { req } = scriptedReq([approvedCreateResponse(), lyingReplay])
   const { checks, must } = collectMust()
-  await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary: {} })
+  await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary: {}, registerSentinels: () => {} })
   assert.equal(checks[2].ok, false, 'the internal_noop replay check must fail')
 })
 
@@ -303,6 +317,6 @@ test('prelude run: any external-write evidence flips the invariant check to FAIL
   tainted.body.data.evidence.externalWriteExecuted = true
   const { req } = scriptedReq([tainted, approvedReplayResponse()])
   const { checks, must } = collectMust()
-  await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary: {} })
+  await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary: {}, registerSentinels: () => {} })
   assert.equal(checks[1].ok, false, 'the externalWrite invariant check must fail')
 })


### PR DESCRIPTION
## T4-final — prep-line extended smoke 的 approved-source 前置（T3b OD-6：扩展而非重写）

设计锁 OD-6 / §6 阶梯：`T4-final | 现有 #4266 approved-source 扩展 | 门 = T3b-2 合入`（#4398 已合，门开）。

### 变更
- **`stock-preparation-prep-line-extended-smoke.mjs`**：
  - 新可选参数 `--approved-source-config-id`（缺省=逐字节旧行为：零新增请求、零新增 summary 键）。
  - `buildApprovedSourcePrelude`：独立盐化 id 空间（`-approved-` 前缀，与合成链 fixture 永不相撞）；closed body shape；config 引用 + sourceProjectNo/projectName 注册为泄漏哨兵（projectId 是合法列举的 opaque handle，刻意不作哨兵）。
  - `runApprovedSourcePrelude`（可注入 `req/must/summary`，corrective-5 fetchImpl 先例）：201 `internal_persist` + created `batch:1/lines≥1/run:1` + 四项外写不变量 false + exact replay 200 `internal_noop` `skipped_existing` 零增行；**flag OFF（200 dry_run）必失败**；请求**不带任何 query 载体**（ON 路径 query tenantId/projectId = steering，OD-2）。
  - `T4_ALLOWED_MODES` 封闭合并注册表（`dry_run/internal_persist/internal_noop`，沿 `T4_ALLOWED_ERROR_CODES` 先例；未注册模式仍打 `<unregistered>`）。
- **测试**：16/16（10 基线 + 6 新行为测试：closed shape/id 隔离/哨兵集、happy path + steering-free + 永不 leakExempt、dry_run 必败、replay 谎报写入必败、外写证据污染必败、模式注册表封闭）。
- **workflow**：`approved_source_config_id` dispatch 输入（空=跳过）。
- **runbook**：operator 前提（approved config 的 fieldMap 约束——`missingChildBom` 会被 #4391 结构守卫 422；status 映射只许 canonical 词表）、flag 开→跑→恢复、禁产模板、判据清单。

### 验证与诚实边界
- 冻结面零改动：`git diff origin/main -- <corrective-5 runner/smoke>` = 空；W6 harness 测试仍 26/0。
- Mutation（commit 后改→RED 逐字→恢复→GREEN）：
  - TM1 放宽 prelude 接受 dry_run → `✖ prelude run: a 200 dry_run (T3b flag OFF) FAILS the prelude`（15/1）→ 恢复 16/0；
  - TM2 prelude 携带 query steering 载体 → `✖ ... steering-free requests`（15/1）→ 恢复 16/0。
- 断言的响应形状全部对**真实实现**核对：`mode/evidence/autoPersist.{persisted,mode}` 来自 #4398 的 route 单测+真库测试（真 route + 真 PG 实跑）；`created.{batch,lines,run}` 是本 smoke 既有 stage-2 对已部署 `/mvp/sync/persist` 长期断言的同一 persist 结果形状（T3b 路由原样附带）。
- **活体端到端 prelude 执行刻意留给 RC-A**（OD-6：单次受控窗口、owner 门控、flag 临时 ON 后恢复）；本 PR 不请求实体机、不触碰 #4101、不影响 corrective-5 等待。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
