### PR TITLE
fix(multitable): render real template catalog icons

### DIFF
--- a/apps/web/src/multitable/components/MetaTemplateCard.vue
+++ b/apps/web/src/multitable/components/MetaTemplateCard.vue
@@ -5,8 +5,17 @@
     :data-template-id="template.id"
   >
     <div class="meta-template-card__top">
-      <span class="meta-template-card__icon" :style="{ background: template.color || '#2563eb' }">
-        {{ template.icon || template.name.slice(0, 1).toUpperCase() }}
+      <span
+        class="meta-template-card__icon"
+        :style="{ background: template.color || '#2563eb' }"
+        aria-hidden="true"
+      >
+        <component
+          :is="templateIcon"
+          v-if="templateIcon"
+          class="meta-template-card__icon-svg"
+        />
+        <span v-else class="meta-template-card__icon-fallback">{{ templateIconInitial }}</span>
       </span>
       <span class="meta-template-card__category">{{ categoryDisplay }}</span>
     </div>
@@ -50,6 +59,7 @@ import {
   cardViews,
   workbenchLabel,
 } from '../utils/workbench-labels'
+import { resolveTemplateIcon, templateIconFallback } from '../utils/template-icons'
 import { MtButton } from '../ui'
 
 const props = defineProps<{
@@ -70,6 +80,9 @@ const { isZh } = useLocale()
 const categoryDisplay = computed(() =>
   categoryLabel(props.template.category, isZh.value ? 'zh-CN' : 'en'),
 )
+
+const templateIcon = computed(() => resolveTemplateIcon(props.template.icon))
+const templateIconInitial = computed(() => templateIconFallback(props.template.name))
 
 const fieldCount = computed(() => {
   return props.template.sheets.reduce((sum, sheet) => sum + sheet.fields.length, 0)
@@ -105,10 +118,21 @@ const viewCount = computed(() => {
   justify-content: center;
   width: 2.25rem;
   height: 2.25rem;
+  flex: 0 0 2.25rem;
   border-radius: 8px;
   color: #ffffff;
   font-weight: 600;
   font-size: 1rem;
+  overflow: hidden;
+}
+
+.meta-template-card__icon-svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.meta-template-card__icon-fallback {
+  line-height: 1;
 }
 
 .meta-template-card__category {

--- a/apps/web/src/multitable/utils/template-icons.ts
+++ b/apps/web/src/multitable/utils/template-icons.ts
@@ -1,0 +1,32 @@
+import {
+  Box,
+  CircleCheck,
+  DataLine,
+  Document,
+  Grid,
+  Notebook,
+  User,
+  Warning,
+} from '@element-plus/icons-vue'
+import type { Component } from 'vue'
+
+const TEMPLATE_ICON_COMPONENTS: Record<string, Component> = {
+  kanban: Grid,
+  pipeline: DataLine,
+  bug: Warning,
+  contract: Document,
+  inspection: CircleCheck,
+  recruit: User,
+  notes: Notebook,
+  asset: Box,
+}
+
+export function resolveTemplateIcon(token: string | null | undefined): Component | null {
+  const normalized = token?.trim().toLowerCase()
+  return normalized ? TEMPLATE_ICON_COMPONENTS[normalized] ?? null : null
+}
+
+export function templateIconFallback(name: string): string {
+  const [firstCharacter] = Array.from(name.trim())
+  return firstCharacter ? firstCharacter.toUpperCase() : '?'
+}

--- a/apps/web/src/multitable/utils/template-icons.ts
+++ b/apps/web/src/multitable/utils/template-icons.ts
@@ -26,7 +26,7 @@ export function resolveTemplateIcon(token: string | null | undefined): Component
   return normalized ? TEMPLATE_ICON_COMPONENTS[normalized] ?? null : null
 }
 
-export function templateIconFallback(name: string): string {
-  const [firstCharacter] = Array.from(name.trim())
+export function templateIconFallback(name: string | null | undefined): string {
+  const [firstCharacter] = Array.from(name?.trim() ?? '')
   return firstCharacter ? firstCharacter.toUpperCase() : '?'
 }

--- a/apps/web/tests/meta-template-card-icons.spec.ts
+++ b/apps/web/tests/meta-template-card-icons.spec.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import {
+  Box,
+  CircleCheck,
+  DataLine,
+  Document,
+  Grid,
+  Notebook,
+  User,
+  Warning,
+} from '@element-plus/icons-vue'
+import MetaTemplateCard from '../src/multitable/components/MetaTemplateCard.vue'
+import type { MetaTemplate } from '../src/multitable/types'
+import {
+  resolveTemplateIcon,
+  templateIconFallback,
+} from '../src/multitable/utils/template-icons'
+import { useLocale } from '../src/composables/useLocale'
+
+const mounts: Array<{ app: App<Element>; container: HTMLDivElement }> = []
+
+afterEach(() => {
+  while (mounts.length) {
+    const mounted = mounts.pop()!
+    mounted.app.unmount()
+    mounted.container.remove()
+  }
+  useLocale().setLocale('en')
+})
+
+function makeTemplate(icon: string, name = 'Project Tracker'): MetaTemplate {
+  return {
+    id: 'template-1',
+    name,
+    description: 'Template description',
+    category: 'Project management',
+    icon,
+    color: '#2563eb',
+    sheets: [],
+  }
+}
+
+function mountCard(template: MetaTemplate): HTMLDivElement {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({
+    setup: () => () => h(MetaTemplateCard, { template }),
+  })
+  app.mount(container)
+  mounts.push({ app, container })
+  return container
+}
+
+describe('template icon mapping', () => {
+  it.each([
+    ['kanban', Grid],
+    ['pipeline', DataLine],
+    ['bug', Warning],
+    ['contract', Document],
+    ['inspection', CircleCheck],
+    ['recruit', User],
+    ['notes', Notebook],
+    ['asset', Box],
+  ])('maps %s to its Element Plus icon', (token, icon) => {
+    expect(resolveTemplateIcon(token)).toBe(icon)
+  })
+
+  it('normalizes known tokens and rejects unknown tokens', () => {
+    expect(resolveTemplateIcon(' KANBAN ')).toBe(Grid)
+    expect(resolveTemplateIcon('unknown-token')).toBeNull()
+    expect(resolveTemplateIcon('')).toBeNull()
+  })
+
+  it('builds a stable first-character fallback', () => {
+    expect(templateIconFallback('  custom template')).toBe('C')
+    expect(templateIconFallback('istanbul tracker')).toBe('I')
+    expect(templateIconFallback('')).toBe('?')
+  })
+})
+
+describe('MetaTemplateCard template icon', () => {
+  it.each(['kanban', 'pipeline', 'bug', 'contract', 'inspection', 'recruit', 'notes', 'asset'])(
+    'renders the known %s token as an SVG instead of raw text',
+    (token) => {
+      const root = mountCard(makeTemplate(token))
+      const icon = root.querySelector('.meta-template-card__icon')
+
+      expect(icon?.getAttribute('aria-hidden')).toBe('true')
+      expect(icon?.querySelector('svg')).not.toBeNull()
+      expect(icon?.querySelector('.meta-template-card__icon-fallback')).toBeNull()
+      expect(icon?.textContent).not.toContain(token)
+    },
+  )
+
+  it('renders only the template initial for an unknown token', () => {
+    const root = mountCard(makeTemplate('very-long-internal-token', 'custom workflow'))
+    const icon = root.querySelector('.meta-template-card__icon')
+
+    expect(icon?.querySelector('svg')).toBeNull()
+    expect(icon?.querySelector('.meta-template-card__icon-fallback')?.textContent).toBe('C')
+    expect(icon?.textContent).not.toContain('very-long-internal-token')
+  })
+})

--- a/apps/web/tests/meta-template-card-icons.spec.ts
+++ b/apps/web/tests/meta-template-card-icons.spec.ts
@@ -76,6 +76,8 @@ describe('template icon mapping', () => {
     expect(templateIconFallback('  custom template')).toBe('C')
     expect(templateIconFallback('istanbul tracker')).toBe('I')
     expect(templateIconFallback('')).toBe('?')
+    expect(templateIconFallback(null)).toBe('?')
+    expect(templateIconFallback(undefined)).toBe('?')
   })
 })
 


### PR DESCRIPTION
## What changed

- map all eight current template catalog icon tokens to recognizable Element Plus icons;
- render unknown tokens as a stable first character from the template name instead of clipped internal text;
- keep the icon badge at a fixed 36 x 36 px with overflow protection;
- add focused mapping and component coverage for known icons, normalization, and fallback behavior.

## Why

`MetaTemplateCard` rendered `template.icon` directly as text inside a 2.25rem badge. Catalog values such as `kanban` and `pipeline` therefore appeared as clipped fragments rather than meaningful visual identifiers.

Addresses #4378. Keep the issue open until this PR merges and merged-main CI is confirmed.

## Verification

- `pnpm --filter @metasheet/web exec vitest run meta-template-card-icons.spec.ts meta-template-card-migration.spec.ts multitable-template-center-view.spec.ts multitable-home-view.spec.ts multitable-phase3.spec.ts multitable-template-detail-view.spec.ts multitable-template-center-view-migration.spec.ts multitable-template-detail-view-migration.spec.ts --reporter=dot` (69/69)
- `pnpm --filter @metasheet/web type-check`
- targeted ESLint for the component, resolver, and new spec
- `pnpm --filter @metasheet/web build`
- `git diff --check origin/main...HEAD`
- browser QA at 1280 x 720 and 390 x 844: 8 SVG icons plus one `C` fallback; no horizontal overflow, card overflow, offscreen cards, or icon/category overlap
- post-rebase `range-diff` is `=` at exact head `1acbe70aebe300870967e64a1a8666fe655ac722`