### PR TITLE
fix(multitable): localize template catalog content

### DIFF
--- a/apps/web/src/multitable/components/MetaTemplateCard.vue
+++ b/apps/web/src/multitable/components/MetaTemplateCard.vue
@@ -19,8 +19,8 @@
       </span>
       <span class="meta-template-card__category">{{ categoryDisplay }}</span>
     </div>
-    <h3 class="meta-template-card__name">{{ template.name }}</h3>
-    <p class="meta-template-card__description">{{ template.description }}</p>
+    <h3 class="meta-template-card__name">{{ displayTemplate.name }}</h3>
+    <p class="meta-template-card__description">{{ displayTemplate.description }}</p>
     <small class="meta-template-card__meta">
       {{ cardSheets(template.sheets.length, isZh) }} ·
       {{ cardFields(fieldCount, isZh) }} ·
@@ -51,7 +51,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { MetaTemplate } from '../types'
-import { categoryLabel } from '../utils/category-labels'
 import { useLocale } from '../../composables/useLocale'
 import {
   cardSheets,
@@ -60,6 +59,7 @@ import {
   workbenchLabel,
 } from '../utils/workbench-labels'
 import { resolveTemplateIcon, templateIconFallback } from '../utils/template-icons'
+import { localizeTemplate } from '../utils/template-localization'
 import { MtButton } from '../ui'
 
 const props = defineProps<{
@@ -77,12 +77,13 @@ const emit = defineEmits<{
 // script reads isZh.value.
 const { isZh } = useLocale()
 
-const categoryDisplay = computed(() =>
-  categoryLabel(props.template.category, isZh.value ? 'zh-CN' : 'en'),
+const displayTemplate = computed(() =>
+  localizeTemplate(props.template, isZh.value ? 'zh-CN' : 'en'),
 )
+const categoryDisplay = computed(() => displayTemplate.value.category)
 
 const templateIcon = computed(() => resolveTemplateIcon(props.template.icon))
-const templateIconInitial = computed(() => templateIconFallback(props.template.name))
+const templateIconInitial = computed(() => templateIconFallback(displayTemplate.value.name))
 
 const fieldCount = computed(() => {
   return props.template.sheets.reduce((sum, sheet) => sum + sheet.fields.length, 0)

--- a/apps/web/src/multitable/composables/useTemplateInstall.ts
+++ b/apps/web/src/multitable/composables/useTemplateInstall.ts
@@ -10,6 +10,11 @@ import { useRouter } from 'vue-router'
 import { multitableClient } from '../api/client'
 import type { MetaSheet, MetaTemplate, MetaView } from '../types'
 import { AppRouteNames } from '../../router/types'
+import { useLocale } from '../../composables/useLocale'
+import {
+  templateCatalogLabel,
+  templateDefaultBaseName,
+} from '../utils/template-localization'
 
 export interface TemplateInstallSuccess {
   baseId: string
@@ -24,6 +29,7 @@ export type TemplateInstallOutcome =
 
 export function useTemplateInstall() {
   const router = useRouter()
+  const { isZh } = useLocale()
   const installingTemplateId = ref<string | null>(null)
   const errorMessage = ref('')
 
@@ -36,12 +42,12 @@ export function useTemplateInstall() {
     errorMessage.value = ''
     try {
       const result = await multitableClient.installTemplate(template.id, {
-        baseName: opts?.baseName ?? `${template.name} Base`,
+        baseName: opts?.baseName ?? templateDefaultBaseName(template, isZh.value),
       })
       const sheet = result.sheets[0]
       const view = sheet ? result.views.find((v) => v.sheetId === sheet.id) ?? result.views[0] : null
       if (!sheet || !view) {
-        errorMessage.value = '模板已创建，但默认视图尚未就绪。请刷新后重试。'
+        errorMessage.value = templateCatalogLabel('install.noView', isZh.value)
         return { status: 'installed-no-view', baseId: result.base.id }
       }
       await router.push({
@@ -54,7 +60,9 @@ export function useTemplateInstall() {
         success: { baseId: result.base.id, sheet, view },
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : '模板创建失败'
+      const message = error instanceof Error
+        ? error.message
+        : templateCatalogLabel('install.failed', isZh.value)
       errorMessage.value = message
       return { status: 'failed', error: message }
     } finally {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -801,6 +801,20 @@ export interface MetaTemplateSheet {
   views: MetaTemplateView[]
 }
 
+export interface MetaTemplateTranslationSheet {
+  name?: string
+  description?: string | null
+  fields?: Record<string, string>
+  views?: Record<string, string>
+}
+
+export interface MetaTemplateTranslation {
+  name?: string
+  description?: string
+  category?: string
+  sheets?: Record<string, MetaTemplateTranslationSheet>
+}
+
 export interface MetaTemplate {
   id: string
   name: string
@@ -808,6 +822,7 @@ export interface MetaTemplate {
   category: string
   icon: string
   color: string
+  translations?: Partial<Record<'zh-CN', MetaTemplateTranslation>>
   sheets: MetaTemplateSheet[]
 }
 

--- a/apps/web/src/multitable/utils/template-localization.ts
+++ b/apps/web/src/multitable/utils/template-localization.ts
@@ -1,0 +1,140 @@
+import type { MetaTemplate } from '../types'
+import { categoryLabel } from './category-labels'
+
+export type TemplateCatalogLocale = 'en' | 'zh-CN'
+
+export type TemplateCatalogLabelKey =
+  | 'home.aria'
+  | 'home.title'
+  | 'home.viewAll'
+  | 'home.loading'
+  | 'home.empty'
+  | 'home.loadFailed'
+  | 'center.eyebrow'
+  | 'center.title'
+  | 'center.subtitle'
+  | 'center.back'
+  | 'center.refresh'
+  | 'center.refreshing'
+  | 'center.controlsAria'
+  | 'center.categoriesAria'
+  | 'center.all'
+  | 'center.search'
+  | 'center.searchPlaceholder'
+  | 'center.retry'
+  | 'center.loading'
+  | 'center.empty'
+  | 'center.noMatch'
+  | 'center.loadFailed'
+  | 'install.noView'
+  | 'install.failed'
+
+const TEMPLATE_CATALOG_LABELS: Record<TemplateCatalogLabelKey, { en: string; zh: string }> = {
+  'home.aria': { en: 'Template quick start', zh: '模板快速开始' },
+  'home.title': { en: 'Start from a template', zh: '模板快速开始' },
+  'home.viewAll': { en: 'View all templates →', zh: '查看全部模板 →' },
+  'home.loading': { en: 'Loading templates...', zh: '正在加载模板...' },
+  'home.empty': {
+    en: 'No templates are available. You can still create a blank base.',
+    zh: '暂无可用模板。你仍可直接新建空白工作区。',
+  },
+  'home.loadFailed': {
+    en: 'Failed to load templates. You can still create a blank base.',
+    zh: '模板加载失败，可继续新建空白工作区。',
+  },
+  'center.eyebrow': { en: 'Multitable Templates', zh: '多维表模板' },
+  'center.title': { en: 'Template Center', zh: '模板中心' },
+  'center.subtitle': {
+    en: 'Start a new multitable workspace from an industry template. Installation opens the default view automatically.',
+    zh: '从行业模板新建多维表工作区。安装后会自动打开默认视图。',
+  },
+  'center.back': { en: '← Back to multitable home', zh: '← 返回多维表首页' },
+  'center.refresh': { en: 'Refresh', zh: '刷新' },
+  'center.refreshing': { en: 'Loading...', zh: '加载中...' },
+  'center.controlsAria': { en: 'Filter and search templates', zh: '筛选与搜索模板' },
+  'center.categoriesAria': { en: 'Template categories', zh: '模板分类筛选' },
+  'center.all': { en: 'All', zh: '全部' },
+  'center.search': { en: 'Search templates', zh: '搜索模板' },
+  'center.searchPlaceholder': {
+    en: 'Search by name, description, or category',
+    zh: '按名称、描述或分类搜索',
+  },
+  'center.retry': { en: 'Retry', zh: '重试' },
+  'center.loading': { en: 'Loading templates...', zh: '正在加载模板...' },
+  'center.empty': {
+    en: 'No templates are available. Refresh or return home to create a blank base.',
+    zh: '暂无可用模板。请刷新或返回首页直接新建空白工作区。',
+  },
+  'center.noMatch': {
+    en: 'No templates match. Adjust the category or search query.',
+    zh: '没有匹配的模板。请调整分类或搜索关键词。',
+  },
+  'center.loadFailed': { en: 'Failed to load templates', zh: '加载模板失败' },
+  'install.noView': {
+    en: 'The template was created, but its default view is not ready. Refresh and try again.',
+    zh: '模板已创建，但默认视图尚未就绪。请刷新后重试。',
+  },
+  'install.failed': { en: 'Failed to create template workspace', zh: '模板工作区创建失败' },
+}
+
+function translatedText(value: string | null | undefined, fallback: string): string {
+  return typeof value === 'string' && value.trim() ? value : fallback
+}
+
+export function templateCatalogLabel(key: TemplateCatalogLabelKey, isZh: boolean): string {
+  const entry = TEMPLATE_CATALOG_LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+export function localizeTemplate(template: MetaTemplate, locale: TemplateCatalogLocale): MetaTemplate {
+  if (locale !== 'zh-CN') return template
+
+  const translation = template.translations?.['zh-CN']
+  const localizedCategory = translatedText(
+    translation?.category,
+    categoryLabel(template.category, locale),
+  )
+
+  return {
+    ...template,
+    name: translatedText(translation?.name, template.name),
+    description: translatedText(translation?.description, template.description),
+    category: localizedCategory,
+    sheets: template.sheets.map((sheet) => {
+      const translatedSheet = translation?.sheets?.[sheet.id]
+      return {
+        ...sheet,
+        name: translatedText(translatedSheet?.name, sheet.name),
+        description: translatedText(translatedSheet?.description, sheet.description ?? ''),
+        fields: sheet.fields.map((field) => ({
+          ...field,
+          name: translatedText(translatedSheet?.fields?.[field.id], field.name),
+        })),
+        views: sheet.views.map((view) => ({
+          ...view,
+          name: translatedText(translatedSheet?.views?.[view.id], view.name),
+        })),
+      }
+    }),
+  }
+}
+
+export function templateDefaultBaseName(template: MetaTemplate, isZh: boolean): string {
+  const translatedName = template.translations?.['zh-CN']?.name
+  if (isZh && translatedName?.trim()) return `${translatedName}工作区`
+  return `${template.name} Base`
+}
+
+export function templateCount(count: number, isZh: boolean): string {
+  return isZh ? `${count} 个` : `${count} template${count === 1 ? '' : 's'}`
+}
+
+export function templateTotal(count: number, isZh: boolean): string {
+  return isZh ? `共 ${count} 个模板` : `${count} template${count === 1 ? '' : 's'} total`
+}
+
+export function templateMatchCount(shown: number, total: number, isZh: boolean): string {
+  return isZh
+    ? `匹配 ${shown} / ${total} 个模板`
+    : `${shown} of ${total} templates match`
+}

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -607,6 +607,10 @@ import {
   recordsDeleted as fmtRecordsDeleted,
   recordNotFound as fmtRecordNotFound,
 } from '../utils/workbench-labels'
+import {
+  localizeTemplate,
+  templateDefaultBaseName,
+} from '../utils/template-localization'
 import { recordLabel } from '../utils/meta-record-labels'
 import { resolveButtonFieldProperty } from '../utils/field-config'
 import {
@@ -3429,7 +3433,9 @@ async function onInstallTemplate(template: MetaTemplate) {
   if (!confirmDiscardContextChanges()) return
   installingTemplateId.value = template.id
   try {
-    const result = await workbench.client.installTemplate(template.id)
+    const result = await workbench.client.installTemplate(template.id, {
+      baseName: templateDefaultBaseName(template, isZh.value),
+    })
     if (!bases.value.some((base) => base.id === result.base.id)) {
       bases.value.push(result.base)
     }
@@ -3444,7 +3450,11 @@ async function onInstallTemplate(template: MetaTemplate) {
     }
     rememberWorkbenchBaseOpen(result.base.id)
     showTemplateLibrary.value = false
-    showSuccess(fmtTemplateInstalled(result.template.name, isZh.value))
+    const installedTemplate = localizeTemplate(
+      result.template,
+      isZh.value ? 'zh-CN' : 'en',
+    )
+    showSuccess(fmtTemplateInstalled(installedTemplate.name, isZh.value))
   } catch (e: any) {
     showError(e.message ?? wb('toast.templateInstallFailed', isZh.value))
   } finally {

--- a/apps/web/src/views/MultitableHomeView.vue
+++ b/apps/web/src/views/MultitableHomeView.vue
@@ -35,26 +35,31 @@
     <p v-if="errorMessage" class="multitable-home__error" role="alert">{{ errorMessage }}</p>
     <p v-if="templateError" class="multitable-home__warning" role="status">{{ templateError }}</p>
 
-    <section class="multitable-home__panel" aria-label="Template quick start">
+    <section
+      class="multitable-home__panel"
+      :aria-label="templateCatalogLabel('home.aria', isZh)"
+    >
       <div class="multitable-home__panel-head">
         <div class="multitable-home__panel-title">
-          <h2>模板快速开始</h2>
-          <span class="multitable-home__panel-subtitle">{{ templates.length }} 个</span>
+          <h2>{{ templateCatalogLabel('home.title', isZh) }}</h2>
+          <span class="multitable-home__panel-subtitle">{{ templateCount(templates.length, isZh) }}</span>
         </div>
         <router-link
           class="multitable-home__panel-link"
           :to="{ name: TemplateCenterRouteName }"
           data-testid="multitable-home-template-center-link"
         >
-          查看全部模板 →
+          {{ templateCatalogLabel('home.viewAll', isZh) }}
         </router-link>
       </div>
 
       <p v-if="installError" class="multitable-home__error" role="alert">{{ installError }}</p>
 
-      <div v-if="templateLoading" class="multitable-home__state">正在加载模板...</div>
+      <div v-if="templateLoading" class="multitable-home__state">
+        {{ templateCatalogLabel('home.loading', isZh) }}
+      </div>
       <div v-else-if="!templates.length" class="multitable-home__empty">
-        暂无可用模板。你仍可直接新建空白 Base。
+        {{ templateCatalogLabel('home.empty', isZh) }}
       </div>
       <div v-else class="multitable-home__template-grid">
         <MetaTemplateCard
@@ -155,10 +160,16 @@ import { AppRouteNames } from '../router/types'
 import MetaTemplateCard from '../multitable/components/MetaTemplateCard.vue'
 import { useTemplateInstall } from '../multitable/composables/useTemplateInstall'
 import { MtButton } from '../multitable/ui'
+import { useLocale } from '../composables/useLocale'
+import {
+  templateCatalogLabel,
+  templateCount,
+} from '../multitable/utils/template-localization'
 
 const TemplateCenterRouteName = AppRouteNames.MULTITABLE_TEMPLATES
 
 const router = useRouter()
+const { isZh } = useLocale()
 
 const bases = ref<MetaBase[]>([])
 const templates = ref<MetaTemplate[]>([])
@@ -225,7 +236,9 @@ async function loadTemplates(): Promise<void> {
     const data = await multitableClient.listTemplates()
     templates.value = data.templates ?? []
   } catch (error) {
-    templateError.value = error instanceof Error ? error.message : '模板加载失败，可继续新建空白 Base。'
+    templateError.value = error instanceof Error
+      ? error.message
+      : templateCatalogLabel('home.loadFailed', isZh.value)
   } finally {
     templateLoading.value = false
   }

--- a/apps/web/src/views/MultitableTemplateCenterView.vue
+++ b/apps/web/src/views/MultitableTemplateCenterView.vue
@@ -2,30 +2,41 @@
   <section class="multitable-templates" data-testid="multitable-template-center">
     <header class="multitable-templates__hero">
       <div>
-        <p class="multitable-templates__eyebrow">Multitable Templates</p>
-        <h1>模板中心</h1>
+        <p class="multitable-templates__eyebrow">
+          {{ templateCatalogLabel('center.eyebrow', isZh) }}
+        </p>
+        <h1>{{ templateCatalogLabel('center.title', isZh) }}</h1>
         <p class="multitable-templates__subtitle">
-          从行业模板开始一个新的多维表 Base。安装时会自动跳转到新建 Base 的默认视图。
+          {{ templateCatalogLabel('center.subtitle', isZh) }}
         </p>
       </div>
       <div class="multitable-templates__hero-actions">
         <router-link class="multitable-templates__back" :to="{ name: HomeRouteName }">
-          ← 返回多维表首页
+          {{ templateCatalogLabel('center.back', isZh) }}
         </router-link>
         <MtButton class="multitable-templates__refresh" :disabled="loading" @click="loadTemplates">
-          {{ loading ? '加载中...' : '刷新' }}
+          {{ loading
+            ? templateCatalogLabel('center.refreshing', isZh)
+            : templateCatalogLabel('center.refresh', isZh) }}
         </MtButton>
       </div>
     </header>
 
-    <section class="multitable-templates__controls" aria-label="筛选与搜索">
-      <nav v-if="categories.length" class="multitable-templates__categories" aria-label="分类筛选">
+    <section
+      class="multitable-templates__controls"
+      :aria-label="templateCatalogLabel('center.controlsAria', isZh)"
+    >
+      <nav
+        v-if="categories.length"
+        class="multitable-templates__categories"
+        :aria-label="templateCatalogLabel('center.categoriesAria', isZh)"
+      >
         <MtButton
           class="multitable-templates__category-btn"
           :class="{ 'multitable-templates__category-btn--active': activeCategory === ALL_CATEGORY }"
           @click="activeCategory = ALL_CATEGORY"
         >
-          全部
+          {{ templateCatalogLabel('center.all', isZh) }}
           <span class="multitable-templates__category-count">{{ templates.length }}</span>
         </MtButton>
         <MtButton
@@ -41,12 +52,12 @@
         </MtButton>
       </nav>
       <label class="multitable-templates__search">
-        <span>搜索模板</span>
+        <span>{{ templateCatalogLabel('center.search', isZh) }}</span>
         <input
           v-model="searchQuery"
           type="search"
-          placeholder="按名称、描述或分类搜索"
-          aria-label="Search templates"
+          :placeholder="templateCatalogLabel('center.searchPlaceholder', isZh)"
+          :aria-label="templateCatalogLabel('center.search', isZh)"
         />
       </label>
     </section>
@@ -57,7 +68,9 @@
 
     <p v-if="errorMessage" class="multitable-templates__error" role="alert">
       {{ errorMessage }}
-      <MtButton class="multitable-templates__retry" @click="loadTemplates">重试</MtButton>
+      <MtButton class="multitable-templates__retry" @click="loadTemplates">
+        {{ templateCatalogLabel('center.retry', isZh) }}
+      </MtButton>
     </p>
 
     <p v-if="installError" class="multitable-templates__warning" role="status">
@@ -65,13 +78,13 @@
     </p>
 
     <div v-if="loading && !templates.length" class="multitable-templates__state">
-      正在加载模板...
+      {{ templateCatalogLabel('center.loading', isZh) }}
     </div>
     <div v-else-if="!templates.length && !errorMessage" class="multitable-templates__empty">
-      暂无可用模板。请刷新或返回首页直接新建空白 Base。
+      {{ templateCatalogLabel('center.empty', isZh) }}
     </div>
     <div v-else-if="!visibleTemplates.length" class="multitable-templates__empty">
-      没有匹配的模板。请调整分类或搜索关键词。
+      {{ templateCatalogLabel('center.noMatch', isZh) }}
     </div>
     <div v-else class="multitable-templates__grid">
       <MetaTemplateCard
@@ -93,7 +106,13 @@ import { useRouter } from 'vue-router'
 import MetaTemplateCard from '../multitable/components/MetaTemplateCard.vue'
 import { multitableClient } from '../multitable/api/client'
 import { useTemplateInstall } from '../multitable/composables/useTemplateInstall'
-import { categoryLabel } from '../multitable/utils/category-labels'
+import { useLocale } from '../composables/useLocale'
+import {
+  localizeTemplate,
+  templateCatalogLabel,
+  templateMatchCount,
+  templateTotal,
+} from '../multitable/utils/template-localization'
 import type { MetaTemplate } from '../multitable/types'
 import { AppRouteNames } from '../router/types'
 import { MtButton } from '../multitable/ui'
@@ -102,6 +121,7 @@ const ALL_CATEGORY = '__all__'
 const HomeRouteName = AppRouteNames.MULTITABLE_HOME
 
 const router = useRouter()
+const { isZh } = useLocale()
 const templates = ref<MetaTemplate[]>([])
 const loading = ref(false)
 const errorMessage = ref('')
@@ -110,14 +130,23 @@ const searchQuery = ref('')
 
 const { installingTemplateId, errorMessage: installError, installAndOpen } = useTemplateInstall()
 
+const activeLocale = computed(() => isZh.value ? 'zh-CN' : 'en')
+
 const categories = computed(() => {
   const counts = new Map<string, number>()
   for (const tpl of templates.value) {
     counts.set(tpl.category, (counts.get(tpl.category) ?? 0) + 1)
   }
   return Array.from(counts.entries())
-    .map(([value, count]) => ({ value, label: categoryLabel(value), count }))
-    .sort((a, b) => a.label.localeCompare(b.label, 'zh-CN'))
+    .map(([value, count]) => {
+      const sample = templates.value.find((template) => template.category === value)
+      return {
+        value,
+        label: sample ? localizeTemplate(sample, activeLocale.value).category : value,
+        count,
+      }
+    })
+    .sort((a, b) => a.label.localeCompare(b.label, activeLocale.value))
 })
 
 const visibleTemplates = computed<MetaTemplate[]>(() => {
@@ -127,12 +156,15 @@ const visibleTemplates = computed<MetaTemplate[]>(() => {
       return false
     }
     if (!query) return true
-    return (
-      tpl.name.toLowerCase().includes(query) ||
-      tpl.description.toLowerCase().includes(query) ||
-      tpl.category.toLowerCase().includes(query) ||
-      categoryLabel(tpl.category).toLowerCase().includes(query)
-    )
+    const localized = localizeTemplate(tpl, activeLocale.value)
+    return [
+      tpl.name,
+      tpl.description,
+      tpl.category,
+      localized.name,
+      localized.description,
+      localized.category,
+    ].some((value) => value.toLowerCase().includes(query))
   })
 })
 
@@ -142,9 +174,9 @@ const visibleStats = computed(() => {
   const total = templates.value.length
   const shown = visibleTemplates.value.length
   if (shown === total && activeCategory.value === ALL_CATEGORY && !searchQuery.value.trim()) {
-    return `共 ${total} 个模板`
+    return templateTotal(total, isZh.value)
   }
-  return `匹配 ${shown} / ${total} 个模板`
+  return templateMatchCount(shown, total, isZh.value)
 })
 
 async function loadTemplates(): Promise<void> {
@@ -154,7 +186,9 @@ async function loadTemplates(): Promise<void> {
     const data = await multitableClient.listTemplates()
     templates.value = data.templates ?? []
   } catch (error) {
-    errorMessage.value = error instanceof Error ? error.message : '加载模板失败'
+    errorMessage.value = error instanceof Error
+      ? error.message
+      : templateCatalogLabel('center.loadFailed', isZh.value)
   } finally {
     loading.value = false
   }
@@ -342,5 +376,27 @@ onMounted(() => {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 1rem;
+}
+
+@media (max-width: 640px) {
+  .multitable-templates__hero {
+    flex-direction: column;
+  }
+
+  .multitable-templates__hero-actions {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .multitable-templates__search {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .multitable-templates__search input {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 100%;
+  }
 }
 </style>

--- a/apps/web/src/views/MultitableTemplateDetailView.vue
+++ b/apps/web/src/views/MultitableTemplateDetailView.vue
@@ -24,11 +24,11 @@
           {{ template.icon || template.name.slice(0, 1).toUpperCase() }}
         </span>
         <div class="multitable-template-detail__heading">
-          <h1>{{ template.name }}</h1>
-          <p class="multitable-template-detail__description">{{ template.description }}</p>
+          <h1>{{ displayTemplate?.name }}</h1>
+          <p class="multitable-template-detail__description">{{ displayTemplate?.description }}</p>
           <small class="multitable-template-detail__meta">
             {{ categoryDisplay }} ·
-            {{ cardSheets(template.sheets.length, isZh) }} ·
+            {{ cardSheets(displayTemplate?.sheets.length ?? 0, isZh) }} ·
             {{ cardFields(fieldCount, isZh) }} ·
             {{ cardViews(viewCount, isZh) }}
           </small>
@@ -36,7 +36,7 @@
       </header>
 
       <section
-        v-for="sheet in template.sheets"
+        v-for="sheet in displayTemplate?.sheets ?? []"
         :key="sheet.id"
         class="multitable-template-detail__sheet"
       >
@@ -56,7 +56,7 @@
           <tbody>
             <tr v-for="field in sheet.fields" :key="field.id">
               <td>{{ field.name }}</td>
-              <td><code>{{ field.type }}</code></td>
+              <td><code>{{ fieldTypeLabel(field.type, isZh) }}</code></td>
             </tr>
           </tbody>
         </table>
@@ -65,7 +65,7 @@
         <ul class="multitable-template-detail__views" data-testid="template-detail-views">
           <li v-for="view in sheet.views" :key="view.id">
             <strong>{{ view.name }}</strong>
-            <code>{{ view.type }}</code>
+            <code>{{ viewTypeLabel(view.type, isZh) }}</code>
             <span v-if="groupByFieldName(sheet, view)">
               {{ workbenchLabel('detail.groupBy', isZh) }}: {{ groupByFieldName(sheet, view) }}
             </span>
@@ -156,7 +156,12 @@ import { useRoute } from 'vue-router'
 import { multitableClient } from '../multitable/api/client'
 import { useTemplateInstall } from '../multitable/composables/useTemplateInstall'
 import { useLocale } from '../composables/useLocale'
-import { categoryLabel } from '../multitable/utils/category-labels'
+import { fieldTypeLabel } from '../multitable/utils/meta-core-labels'
+import { viewTypeLabel } from '../multitable/utils/meta-manager-labels'
+import {
+  localizeTemplate,
+  templateDefaultBaseName,
+} from '../multitable/utils/template-localization'
 import {
   cardFields,
   cardSheets,
@@ -190,6 +195,10 @@ const { installingTemplateId, errorMessage: installError, installAndOpen } = use
 
 const templateId = computed(() => String(route.params.templateId ?? '').trim())
 const installing = computed(() => installingTemplateId.value === template.value?.id)
+const displayTemplate = computed(() => {
+  if (!template.value) return null
+  return localizeTemplate(template.value, isZh.value ? 'zh-CN' : 'en')
+})
 // Conflicts block install (design §2.2); no dry-run yet keeps the existing
 // optimistic install path (the server still 409s as the hard backstop).
 const installDisabled = computed(
@@ -197,23 +206,17 @@ const installDisabled = computed(
 )
 
 const categoryDisplay = computed(() => {
-  if (!template.value) return ''
-  return categoryLabel(template.value.category, isZh.value ? 'zh-CN' : 'en')
+  if (!displayTemplate.value) return ''
+  return displayTemplate.value.category
 })
 
 const fieldCount = computed(
-  () => template.value?.sheets.reduce((sum, sheet) => sum + sheet.fields.length, 0) ?? 0,
+  () => displayTemplate.value?.sheets.reduce((sum, sheet) => sum + sheet.fields.length, 0) ?? 0,
 )
 
 const viewCount = computed(
-  () => template.value?.sheets.reduce((sum, sheet) => sum + sheet.views.length, 0) ?? 0,
+  () => displayTemplate.value?.sheets.reduce((sum, sheet) => sum + sheet.views.length, 0) ?? 0,
 )
-
-// Mirrors the default baseName useTemplateInstall sends on install, so the
-// dry-run answers the question for the install the button would actually run.
-function defaultBaseName(tpl: MetaTemplate): string {
-  return `${tpl.name} Base`
-}
 
 function groupByFieldName(sheet: MetaTemplateSheet, view: MetaTemplateView): string {
   if (!view.groupByFieldId) return ''
@@ -241,7 +244,7 @@ async function runDryRun(): Promise<void> {
   dryRunError.value = ''
   try {
     dryRun.value = await multitableClient.dryRunTemplate(template.value.id, {
-      baseName: defaultBaseName(template.value),
+      baseName: templateDefaultBaseName(template.value, isZh.value),
     })
   } catch (error) {
     dryRun.value = null

--- a/apps/web/tests/meta-template-card-localization.spec.ts
+++ b/apps/web/tests/meta-template-card-localization.spec.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
+import MetaTemplateCard from '../src/multitable/components/MetaTemplateCard.vue'
+import type { MetaTemplate } from '../src/multitable/types'
+
+const template: MetaTemplate = {
+  id: 'project-tracker',
+  name: 'Project Tracker',
+  description: 'Track project work.',
+  category: 'Project management',
+  icon: 'kanban',
+  color: '#2563eb',
+  translations: {
+    'zh-CN': {
+      name: '项目跟进',
+      description: '跟踪项目工作。',
+      category: '项目管理',
+    },
+  },
+  sheets: [],
+}
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  app?.unmount()
+  container?.remove()
+  app = null
+  container = null
+  useLocale().setLocale('en')
+})
+
+describe('MetaTemplateCard localization', () => {
+  it('updates catalog content immediately when the active locale changes', async () => {
+    useLocale().setLocale('en')
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({ setup: () => () => h(MetaTemplateCard, { template }) })
+    app.mount(container)
+
+    expect(container.textContent).toContain('Project Tracker')
+    expect(container.textContent).toContain('Track project work.')
+    expect(container.textContent).toContain('Project management')
+    expect(container.textContent).toContain('Use template')
+
+    useLocale().setLocale('zh-CN')
+    await nextTick()
+
+    expect(container.textContent).toContain('项目跟进')
+    expect(container.textContent).toContain('跟踪项目工作。')
+    expect(container.textContent).toContain('项目管理')
+    expect(container.textContent).toContain('使用模板')
+    expect(container.textContent).not.toContain('Project Tracker')
+  })
+})

--- a/apps/web/tests/multitable-home-view.spec.ts
+++ b/apps/web/tests/multitable-home-view.spec.ts
@@ -284,6 +284,13 @@ describe('MultitableHomeView', () => {
           category: 'Project management',
           icon: 'P',
           color: '#2563eb',
+          translations: {
+            'zh-CN': {
+              name: '项目跟进',
+              description: '跟踪项目工作。',
+              category: '项目管理',
+            },
+          },
           sheets: [
             {
               id: 'template-sheet',
@@ -309,7 +316,8 @@ describe('MultitableHomeView', () => {
     const root = mountView()
     await flushUi()
 
-    expect(root.textContent).toContain('Project Tracker')
+    expect(root.textContent).toContain('项目跟进')
+    expect(root.textContent).toContain('跟踪项目工作。')
     // MetaTemplateCard now renders 3 metrics: sheets · fields · views.
     // Project Tracker template has 1 sheet, 0 fields (mock), 2 views.
     expect(root.textContent).toContain('1 个数据表 · 0 个字段 · 2 个视图')
@@ -317,7 +325,7 @@ describe('MultitableHomeView', () => {
     findButton(root, '使用模板').click()
     await flushUi()
 
-    expect(mocks.installTemplate).toHaveBeenCalledWith('project-tracker', { baseName: 'Project Tracker Base' })
+    expect(mocks.installTemplate).toHaveBeenCalledWith('project-tracker', { baseName: '项目跟进工作区' })
     expect(mocks.push).toHaveBeenCalledWith({
       name: AppRouteNames.MULTITABLE,
       params: { sheetId: 'sheet_template', viewId: 'view_template' },
@@ -336,5 +344,39 @@ describe('MultitableHomeView', () => {
     expect(link).not.toBeNull()
     expect(link?.textContent?.trim()).toContain('查看全部模板')
     expect(link?.getAttribute('data-router-link-to')).toContain(AppRouteNames.MULTITABLE_TEMPLATES)
+  })
+
+  it('updates template content and template-section copy when locale changes', async () => {
+    mocks.listBases.mockResolvedValue({ bases: [] })
+    mocks.listTemplates.mockResolvedValue({
+      templates: [{
+        id: 'project-tracker',
+        name: 'Project Tracker',
+        description: 'Track project work.',
+        category: 'Project management',
+        icon: 'kanban',
+        color: '#2563eb',
+        translations: {
+          'zh-CN': {
+            name: '项目跟进',
+            description: '跟踪项目工作。',
+            category: '项目管理',
+          },
+        },
+        sheets: [],
+      }],
+    })
+
+    const root = mountView()
+    await flushUi()
+    expect(root.textContent).toContain('项目跟进')
+    expect(root.textContent).toContain('查看全部模板')
+
+    useLocale().setLocale('en')
+    await flushUi()
+
+    expect(root.textContent).toContain('Project Tracker')
+    expect(root.textContent).toContain('View all templates')
+    expect(mocks.listTemplates).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/tests/multitable-template-center-view.spec.ts
+++ b/apps/web/tests/multitable-template-center-view.spec.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick, type App as VueApp, type Component } from 'vue'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import MultitableTemplateCenterView from '../src/views/MultitableTemplateCenterView.vue'
 import { AppRouteNames } from '../src/router/types'
 import { useLocale } from '../src/composables/useLocale'
@@ -137,6 +139,107 @@ describe('MultitableTemplateCenterView', () => {
     expect(mocks.listTemplates).toHaveBeenCalledTimes(1)
     expect(readCardNames(root)).toEqual(['Project Tracker', 'Sales CRM'])
     expect(root.querySelector('[data-testid="multitable-template-center"]')).not.toBeNull()
+  })
+
+  it('renders localized catalog content and reacts to locale changes without refetching', async () => {
+    const project = {
+      ...makeTemplate({
+        id: 'project-tracker',
+        name: 'Project Tracker',
+        description: 'Track project work.',
+        category: 'Project management',
+      }),
+      translations: {
+        'zh-CN': {
+          name: '项目跟进',
+          description: '跟踪项目工作。',
+          category: '项目管理',
+        },
+      },
+    }
+    const sales = {
+      ...makeTemplate({
+        id: 'sales-crm',
+        name: 'Sales CRM',
+        description: 'Manage customer relationships.',
+        category: 'Sales',
+      }),
+      translations: {
+        'zh-CN': {
+          name: '销售 CRM',
+          description: '管理客户关系。',
+          category: 'CRM',
+        },
+      },
+    }
+    mocks.listTemplates.mockResolvedValue({ templates: [project, sales] })
+
+    const root = mountView()
+    await flushUi()
+
+    expect(readCardNames(root)).toEqual(['项目跟进', '销售 CRM'])
+    expect(root.textContent).toContain('跟踪项目工作。')
+    expect(root.textContent).toContain('模板中心')
+
+    const searchInput = root.querySelector<HTMLInputElement>('.multitable-templates__search input')
+    if (!searchInput) throw new Error('Search input not found')
+    searchInput.value = '客户关系'
+    searchInput.dispatchEvent(new Event('input'))
+    await flushUi()
+    expect(readCardNames(root)).toEqual(['销售 CRM'])
+
+    searchInput.value = ''
+    searchInput.dispatchEvent(new Event('input'))
+    useLocale().setLocale('en')
+    await flushUi()
+
+    expect(readCardNames(root)).toEqual(['Project Tracker', 'Sales CRM'])
+    expect(root.textContent).toContain('Track project work.')
+    expect(root.textContent).toContain('Template Center')
+    expect(root.textContent).toContain('Back to multitable home')
+    expect(mocks.listTemplates).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the localized template name for the default installed workspace', async () => {
+    const project = {
+      ...makeTemplate({ id: 'project-tracker', name: 'Project Tracker' }),
+      translations: {
+        'zh-CN': {
+          name: '项目跟进',
+          description: '跟踪项目工作。',
+          category: '项目管理',
+        },
+      },
+    }
+    mocks.listTemplates.mockResolvedValue({ templates: [project] })
+    mocks.installTemplate.mockResolvedValue({
+      template: project,
+      base: { id: 'base_new', name: '项目跟进工作区' },
+      sheets: [{ id: 'sheet_new', baseId: 'base_new', name: 'Tasks' }],
+      fields: [],
+      views: [{ id: 'view_new', sheetId: 'sheet_new', name: 'Grid', type: 'grid' }],
+    })
+
+    const root = mountView()
+    await flushUi()
+    findButton(root, '使用模板').click()
+    await flushUi()
+
+    expect(mocks.installTemplate).toHaveBeenCalledWith('project-tracker', {
+      baseName: '项目跟进工作区',
+    })
+  })
+
+  it('keeps translated hero and search copy readable at narrow widths', () => {
+    const source = readFileSync(
+      join(__dirname, '../src/views/MultitableTemplateCenterView.vue'),
+      'utf8',
+    )
+
+    expect(source).toMatch(/@media \(max-width: 640px\)/)
+    expect(source).toMatch(/\.multitable-templates__hero\s*{\s*flex-direction: column;/)
+    expect(source).toMatch(/\.multitable-templates__search\s*{[^}]*flex-direction: column;/s)
+    expect(source).toMatch(/\.multitable-templates__search input\s*{[^}]*width: 100%;/s)
   })
 
   it('filters templates by category tab', async () => {

--- a/apps/web/tests/multitable-template-detail-view.spec.ts
+++ b/apps/web/tests/multitable-template-detail-view.spec.ts
@@ -46,6 +46,28 @@ const PROJECT_TRACKER = {
   category: 'Project management',
   icon: 'kanban',
   color: '#2563eb',
+  translations: {
+    'zh-CN': {
+      name: '项目跟进',
+      description: '跟踪负责人、优先级、截止日期、状态和执行备注。',
+      category: '项目管理',
+      sheets: {
+        tasks: {
+          name: '任务',
+          description: '项目任务流程',
+          fields: {
+            task: '任务',
+            status: '状态',
+            dueDate: '截止日期',
+          },
+          views: {
+            grid: '全部任务',
+            kanban: '按状态',
+          },
+        },
+      },
+    },
+  },
   sheets: [
     {
       id: 'tasks',
@@ -68,7 +90,7 @@ function cleanDryRunResult() {
   return {
     templateId: 'project-tracker',
     wouldCreate: {
-      base: { id: 'base_abc', name: 'Project Tracker Base' },
+      base: { id: 'base_abc', name: '项目跟进工作区' },
       sheets: [{ id: 'sheet_abc', name: 'Tasks', fieldCount: 3, viewCount: 2 }],
       fields: [
         { id: 'fld_1', sheetId: 'sheet_abc', name: 'Task', type: 'string' },
@@ -151,30 +173,47 @@ describe('MultitableTemplateDetailView', () => {
     await flushUi()
 
     expect(mocks.listTemplates).toHaveBeenCalledTimes(1)
-    expect(root.textContent).toContain('Project Tracker')
-    expect(root.textContent).toContain('Tasks')
+    expect(root.textContent).toContain('项目跟进')
+    expect(root.textContent).toContain('任务')
 
     const fieldRows = Array.from(root.querySelectorAll('[data-testid="template-detail-fields"] tbody tr'))
     expect(fieldRows.map((row) =>
       Array.from(row.querySelectorAll('td')).map((cell) => cell.textContent?.trim()).join(' | '),
     )).toEqual([
-      'Task | string',
-      'Status | select',
-      'Due Date | date',
+      '任务 | 文本',
+      '状态 | 单选',
+      '截止日期 | 日期',
     ])
 
     const viewItems = Array.from(root.querySelectorAll('[data-testid="template-detail-views"] li'))
     expect(viewItems).toHaveLength(2)
-    expect(viewItems[0].textContent).toContain('All Tasks')
-    expect(viewItems[0].textContent).toContain('grid')
-    expect(viewItems[1].textContent).toContain('By Status')
+    expect(viewItems[0].textContent).toContain('全部任务')
+    expect(viewItems[0].textContent).toContain('网格')
+    expect(viewItems[1].textContent).toContain('按状态')
     // groupByFieldId resolved to the field NAME, not the raw id.
-    expect(viewItems[1].textContent).toContain('Status')
+    expect(viewItems[1].textContent).toContain('状态')
 
     // No dry-run result before the user asks for one.
     expect(root.querySelector('[data-testid="template-detail-dryrun-result"]')).toBeNull()
     // Install stays enabled until a dry-run reports conflicts.
     expect(findButton(root, '使用模板').disabled).toBe(false)
+  })
+
+  it('switches the descriptor back to complete English without refetching', async () => {
+    const root = mountView()
+    await flushUi()
+    expect(root.textContent).toContain('项目跟进')
+
+    useLocale().setLocale('en')
+    await flushUi()
+
+    expect(root.textContent).toContain('Project Tracker')
+    expect(root.textContent).toContain('Track owners, priorities, due dates, status, and execution notes.')
+    const fieldRows = Array.from(root.querySelectorAll('[data-testid="template-detail-fields"] tbody tr'))
+    expect(fieldRows[0].textContent).toContain('Task')
+    expect(fieldRows[0].textContent).toContain('text')
+    expect(root.textContent).toContain('All Tasks')
+    expect(mocks.listTemplates).toHaveBeenCalledTimes(1)
   })
 
   it('shows a not-found state for an unknown templateId', async () => {
@@ -193,11 +232,11 @@ describe('MultitableTemplateDetailView', () => {
     findButton(root, '检查可安装性').click()
     await flushUi()
 
-    expect(mocks.dryRunTemplate).toHaveBeenCalledWith('project-tracker', { baseName: 'Project Tracker Base' })
+    expect(mocks.dryRunTemplate).toHaveBeenCalledWith('project-tracker', { baseName: '项目跟进工作区' })
     const result = root.querySelector('[data-testid="template-detail-dryrun-result"]')
     expect(result).not.toBeNull()
     expect(result?.textContent).toContain('可以安装')
-    expect(result?.textContent).toContain('Project Tracker Base')
+    expect(result?.textContent).toContain('项目跟进工作区')
     expect(result?.textContent).toContain('1 个数据表')
     expect(result?.textContent).toContain('3 个字段')
     expect(result?.textContent).toContain('2 个视图')
@@ -253,7 +292,7 @@ describe('MultitableTemplateDetailView', () => {
     findButton(root, '使用模板').click()
     await flushUi()
 
-    expect(mocks.installTemplate).toHaveBeenCalledWith('project-tracker', { baseName: 'Project Tracker Base' })
+    expect(mocks.installTemplate).toHaveBeenCalledWith('project-tracker', { baseName: '项目跟进工作区' })
     expect(mocks.push).toHaveBeenCalledWith({
       name: AppRouteNames.MULTITABLE,
       params: { sheetId: 'sheet_new', viewId: 'view_new' },

--- a/apps/web/tests/template-localization.spec.ts
+++ b/apps/web/tests/template-localization.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { MetaTemplate } from '../src/multitable/types'
+import {
+  localizeTemplate,
+  templateCatalogLabel,
+  templateCount,
+  templateDefaultBaseName,
+  templateMatchCount,
+  templateTotal,
+} from '../src/multitable/utils/template-localization'
+
+const template: MetaTemplate = {
+  id: 'project-tracker',
+  name: 'Project Tracker',
+  description: 'Track project work.',
+  category: 'Project management',
+  icon: 'kanban',
+  color: '#2563eb',
+  translations: {
+    'zh-CN': {
+      name: '项目跟进',
+      description: '跟踪项目工作。',
+      category: '项目管理',
+      sheets: {
+        tasks: {
+          name: '任务',
+          description: '项目任务流程',
+          fields: { task: '任务' },
+          views: { grid: '全部任务' },
+        },
+      },
+    },
+  },
+  sheets: [{
+    id: 'tasks',
+    name: 'Tasks',
+    description: 'Project task pipeline',
+    fields: [
+      { id: 'task', name: 'Task', type: 'string', order: 0 },
+      { id: 'owner', name: 'Owner', type: 'string', order: 1 },
+    ],
+    views: [
+      { id: 'grid', name: 'All Tasks', type: 'grid' },
+      { id: 'calendar', name: 'Calendar', type: 'calendar' },
+    ],
+  }],
+}
+
+describe('template localization', () => {
+  it('returns canonical English unchanged', () => {
+    expect(localizeTemplate(template, 'en')).toBe(template)
+  })
+
+  it('localizes translated catalog content and falls back field by field', () => {
+    const localized = localizeTemplate(template, 'zh-CN')
+
+    expect(localized).not.toBe(template)
+    expect(localized.name).toBe('项目跟进')
+    expect(localized.description).toBe('跟踪项目工作。')
+    expect(localized.category).toBe('项目管理')
+    expect(localized.sheets[0].name).toBe('任务')
+    expect(localized.sheets[0].description).toBe('项目任务流程')
+    expect(localized.sheets[0].fields.map((field) => field.name)).toEqual(['任务', 'Owner'])
+    expect(localized.sheets[0].views.map((view) => view.name)).toEqual(['全部任务', 'Calendar'])
+    expect(template.sheets[0].fields[0].name).toBe('Task')
+  })
+
+  it('uses the existing category translation for descriptors without locale metadata', () => {
+    const salesTemplate = { ...template, category: 'Sales', translations: undefined }
+    expect(localizeTemplate(salesTemplate, 'zh-CN').category).toBe('CRM')
+  })
+
+  it('builds locale-aware default workspace names and static copy', () => {
+    expect(templateDefaultBaseName(template, true)).toBe('项目跟进工作区')
+    expect(templateDefaultBaseName(template, false)).toBe('Project Tracker Base')
+    expect(templateDefaultBaseName({ ...template, translations: undefined }, true)).toBe('Project Tracker Base')
+    expect(templateCatalogLabel('center.title', true)).toBe('模板中心')
+    expect(templateCatalogLabel('center.title', false)).toBe('Template Center')
+    expect(templateCount(1, false)).toBe('1 template')
+    expect(templateCount(2, true)).toBe('2 个')
+    expect(templateTotal(2, false)).toBe('2 templates total')
+    expect(templateMatchCount(1, 2, true)).toBe('匹配 1 / 2 个模板')
+  })
+})

--- a/packages/core-backend/src/multitable/template-library.ts
+++ b/packages/core-backend/src/multitable/template-library.ts
@@ -34,6 +34,20 @@ export type MultitableTemplateSheet = {
   views: MultitableTemplateView[]
 }
 
+export type MultitableTemplateTranslationSheet = {
+  name: string
+  description?: string | null
+  fields: Record<string, string>
+  views: Record<string, string>
+}
+
+export type MultitableTemplateTranslation = {
+  name: string
+  description: string
+  category: string
+  sheets: Record<string, MultitableTemplateTranslationSheet>
+}
+
 export type MultitableTemplate = {
   id: string
   name: string
@@ -41,6 +55,7 @@ export type MultitableTemplate = {
   category: string
   icon: string
   color: string
+  translations?: Partial<Record<'zh-CN', MultitableTemplateTranslation>>
   sheets: MultitableTemplateSheet[]
 }
 
@@ -122,6 +137,32 @@ const TEMPLATE_LIBRARY: MultitableTemplate[] = [
     category: 'Project management',
     icon: 'kanban',
     color: '#2563eb',
+    translations: {
+      'zh-CN': {
+        name: '项目跟进',
+        description: '跟踪负责人、优先级、截止日期、状态和执行备注。',
+        category: '项目管理',
+        sheets: {
+          tasks: {
+            name: '任务',
+            description: '项目任务流程',
+            fields: {
+              task: '任务',
+              status: '状态',
+              owner: '负责人',
+              priority: '优先级',
+              dueDate: '截止日期',
+              notes: '备注',
+            },
+            views: {
+              grid: '全部任务',
+              kanban: '按状态',
+              calendar: '截止日历',
+            },
+          },
+        },
+      },
+    },
     sheets: [
       {
         id: 'tasks',
@@ -150,6 +191,32 @@ const TEMPLATE_LIBRARY: MultitableTemplate[] = [
     category: 'Sales',
     icon: 'pipeline',
     color: '#16a34a',
+    translations: {
+      'zh-CN': {
+        name: '销售 CRM',
+        description: '管理客户、联系人、阶段、交易金额和下一步行动。',
+        category: 'CRM',
+        sheets: {
+          deals: {
+            name: '商机',
+            description: '销售机会管道',
+            fields: {
+              account: '客户',
+              contact: '联系人',
+              stage: '阶段',
+              value: '交易金额',
+              closeDate: '预计成交日期',
+              nextAction: '下一步行动',
+            },
+            views: {
+              grid: '全部商机',
+              pipeline: '销售管道',
+              calendar: '成交日历',
+            },
+          },
+        },
+      },
+    },
     sheets: [
       {
         id: 'deals',
@@ -178,6 +245,32 @@ const TEMPLATE_LIBRARY: MultitableTemplate[] = [
     category: 'Engineering',
     icon: 'bug',
     color: '#dc2626',
+    translations: {
+      'zh-CN': {
+        name: '问题跟踪',
+        description: '记录缺陷、严重程度、负责人、截止日期和复现步骤。',
+        category: '工程',
+        sheets: {
+          issues: {
+            name: '问题',
+            description: '缺陷与问题分诊',
+            fields: {
+              issue: '问题',
+              severity: '严重程度',
+              status: '状态',
+              assignee: '负责人',
+              dueDate: '截止日期',
+              reproSteps: '复现步骤',
+            },
+            views: {
+              grid: '全部问题',
+              severity: '按严重程度',
+              timeline: '截止时间线',
+            },
+          },
+        },
+      },
+    },
     sheets: [
       {
         id: 'issues',
@@ -206,6 +299,34 @@ const TEMPLATE_LIBRARY: MultitableTemplate[] = [
     category: 'Contract',
     icon: 'contract',
     color: '#7c3aed',
+    translations: {
+      'zh-CN': {
+        name: '合同管理',
+        description: '跟踪合同相对方、金额、状态、签署日期和到期日期。',
+        category: '合同管理',
+        sheets: {
+          contracts: {
+            name: '合同',
+            description: '合同生命周期跟踪',
+            fields: {
+              name: '合同名称',
+              party: '相对方',
+              amount: '金额',
+              status: '状态',
+              signedAt: '签署日期',
+              expiresAt: '到期日期',
+              owner: '负责人',
+              notes: '备注',
+            },
+            views: {
+              grid: '全部合同',
+              byStatus: '按状态',
+              expiry: '到期日历',
+            },
+          },
+        },
+      },
+    },
     sheets: [
       {
         id: 'contracts',
@@ -236,6 +357,33 @@ const TEMPLATE_LIBRARY: MultitableTemplate[] = [
     category: 'Inspection',
     icon: 'inspection',
     color: '#ea580c',
+    translations: {
+      'zh-CN': {
+        name: '现场巡检',
+        description: '记录现场巡检、发现项、严重程度和整改进展。',
+        category: '巡检',
+        sheets: {
+          inspections: {
+            name: '巡检记录',
+            description: '现场巡检与整改跟踪',
+            fields: {
+              site: '地点',
+              inspector: '巡检人',
+              inspectedAt: '巡检日期',
+              finding: '发现项',
+              severity: '严重程度',
+              status: '状态',
+              dueDate: '整改截止日期',
+            },
+            views: {
+              grid: '全部巡检',
+              bySeverity: '按严重程度',
+              due: '整改时间线',
+            },
+          },
+        },
+      },
+    },
     sheets: [
       {
         id: 'inspections',
@@ -265,6 +413,33 @@ const TEMPLATE_LIBRARY: MultitableTemplate[] = [
     category: 'Recruitment',
     icon: 'recruit',
     color: '#0891b2',
+    translations: {
+      'zh-CN': {
+        name: '招聘流程',
+        description: '跟踪候选人、岗位、阶段、招聘负责人和下一步行动。',
+        category: '招聘',
+        sheets: {
+          candidates: {
+            name: '候选人',
+            description: '招聘流程跟踪',
+            fields: {
+              candidate: '候选人',
+              role: '岗位',
+              stage: '阶段',
+              recruiter: '招聘负责人',
+              appliedAt: '申请日期',
+              nextStep: '下一步',
+              rating: '评价',
+            },
+            views: {
+              grid: '全部候选人',
+              pipeline: '招聘流程',
+              applied: '申请日历',
+            },
+          },
+        },
+      },
+    },
     sheets: [
       {
         id: 'candidates',
@@ -294,6 +469,34 @@ const TEMPLATE_LIBRARY: MultitableTemplate[] = [
     category: 'Operations',
     icon: 'notes',
     color: '#475569',
+    translations: {
+      'zh-CN': {
+        name: '会议纪要',
+        description: '记录会议决策并跟踪行动项直至完成。',
+        category: '运营',
+        sheets: {
+          meetings: {
+            name: '会议',
+            description: '会议记录与行动项',
+            fields: {
+              topic: '主题',
+              meetingDate: '会议日期',
+              attendees: '参会人',
+              decisions: '决策',
+              actionItem: '行动项',
+              assignee: '负责人',
+              status: '状态',
+              dueDate: '行动截止日期',
+            },
+            views: {
+              grid: '全部会议',
+              byStatus: '行动看板',
+              dueCal: '行动日历',
+            },
+          },
+        },
+      },
+    },
     sheets: [
       {
         id: 'meetings',
@@ -324,6 +527,34 @@ const TEMPLATE_LIBRARY: MultitableTemplate[] = [
     category: 'Operations',
     icon: 'asset',
     color: '#0d9488',
+    translations: {
+      'zh-CN': {
+        name: '资产台账',
+        description: '登记设备和资产的地点、负责人及状态。',
+        category: '运营',
+        sheets: {
+          assets: {
+            name: '资产',
+            description: '设备与资产登记',
+            fields: {
+              asset: '资产',
+              category: '类别',
+              serialNumber: '序列号',
+              location: '地点',
+              owner: '负责人',
+              status: '状态',
+              purchaseDate: '采购日期',
+              notes: '备注',
+            },
+            views: {
+              grid: '全部资产',
+              byStatus: '按状态',
+              purchase: '采购日历',
+            },
+          },
+        },
+      },
+    },
     sheets: [
       {
         id: 'assets',
@@ -350,8 +581,24 @@ const TEMPLATE_LIBRARY: MultitableTemplate[] = [
 ]
 
 function normalizeTemplate(template: MultitableTemplate): MultitableTemplate {
+  const zhTranslation = template.translations?.['zh-CN']
   return {
     ...template,
+    translations: zhTranslation ? {
+      'zh-CN': {
+        ...zhTranslation,
+        sheets: Object.fromEntries(
+          Object.entries(zhTranslation.sheets).map(([sheetId, sheet]) => [
+            sheetId,
+            {
+              ...sheet,
+              fields: { ...sheet.fields },
+              views: { ...sheet.views },
+            },
+          ]),
+        ),
+      },
+    } : undefined,
     sheets: template.sheets.map((sheet) => ({
       ...sheet,
       fields: sheet.fields.map((field) => ({ ...field, property: { ...(field.property ?? {}) } })),

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -692,6 +692,17 @@ describe('Multitable context API', () => {
       'meeting-minutes',
       'asset-inventory',
     ])
+    expect(response.body.data.templates[0].translations['zh-CN']).toMatchObject({
+      name: '项目跟进',
+      category: '项目管理',
+      sheets: {
+        tasks: {
+          name: '任务',
+          fields: { task: '任务' },
+          views: { grid: '全部任务' },
+        },
+      },
+    })
   })
 
   test('installs a built-in template as a new base in one transaction', async () => {

--- a/packages/core-backend/tests/unit/multitable-template-library.test.ts
+++ b/packages/core-backend/tests/unit/multitable-template-library.test.ts
@@ -189,7 +189,9 @@ describe('multitable template library', () => {
       'asset-inventory',
     ])
     first[0].sheets[0].fields[0].name = 'mutated'
+    first[0].translations!['zh-CN']!.sheets.tasks.fields.task = '已修改'
     expect(second[0].sheets[0].fields[0].name).toBe('Task')
+    expect(second[0].translations!['zh-CN']!.sheets.tasks.fields.task).toBe('任务')
   })
 
   it('installs a template as one base with mapped fields and views', async () => {
@@ -278,6 +280,23 @@ describe('template library quality contract', () => {
       // single sheet
       expect(template.sheets).toHaveLength(1)
       const sheet = template.sheets[0]
+      const zh = template.translations?.['zh-CN']
+
+      expect(zh).toBeDefined()
+      expect(zh!.name.trim()).not.toBe('')
+      expect(zh!.description.trim()).not.toBe('')
+      expect(zh!.category.trim()).not.toBe('')
+      expect(Object.keys(zh!.sheets).sort()).toEqual(template.sheets.map((item) => item.id).sort())
+
+      const translatedSheet = zh!.sheets[sheet.id]
+      expect(translatedSheet.name.trim()).not.toBe('')
+      expect(translatedSheet.description?.trim()).not.toBe('')
+      expect(Object.keys(translatedSheet.fields).sort()).toEqual(
+        sheet.fields.map((field) => field.id).sort(),
+      )
+      expect(Object.keys(translatedSheet.views).sort()).toEqual(
+        sheet.views.map((view) => view.id).sort(),
+      )
 
       // 5-8 fields
       expect(sheet.fields.length).toBeGreaterThanOrEqual(5)

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -2164,6 +2164,51 @@ components:
         - name
         - fields
         - views
+    MultitableTemplateTranslationSheet:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        fields:
+          type: object
+          additionalProperties:
+            type: string
+        views:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - name
+        - fields
+        - views
+    MultitableTemplateTranslation:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+        sheets:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/MultitableTemplateTranslationSheet'
+      required:
+        - name
+        - description
+        - category
+        - sheets
+    MultitableTemplateTranslations:
+      type: object
+      properties:
+        zh-CN:
+          $ref: '#/components/schemas/MultitableTemplateTranslation'
+      required:
+        - zh-CN
     MultitableTemplate:
       type: object
       properties:
@@ -2179,6 +2224,8 @@ components:
           type: string
         color:
           type: string
+        translations:
+          $ref: '#/components/schemas/MultitableTemplateTranslations'
         sheets:
           type: array
           items:
@@ -2190,6 +2237,7 @@ components:
         - category
         - icon
         - color
+        - translations
         - sheets
     MultitableTemplateInstallResult:
       type: object

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -3029,6 +3029,72 @@
           "views"
         ]
       },
+      "MultitableTemplateTranslationSheet": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "fields": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "views": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "fields",
+          "views"
+        ]
+      },
+      "MultitableTemplateTranslation": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "sheets": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/MultitableTemplateTranslationSheet"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "category",
+          "sheets"
+        ]
+      },
+      "MultitableTemplateTranslations": {
+        "type": "object",
+        "properties": {
+          "zh-CN": {
+            "$ref": "#/components/schemas/MultitableTemplateTranslation"
+          }
+        },
+        "required": [
+          "zh-CN"
+        ]
+      },
       "MultitableTemplate": {
         "type": "object",
         "properties": {
@@ -3050,6 +3116,9 @@
           "color": {
             "type": "string"
           },
+          "translations": {
+            "$ref": "#/components/schemas/MultitableTemplateTranslations"
+          },
           "sheets": {
             "type": "array",
             "items": {
@@ -3064,6 +3133,7 @@
           "category",
           "icon",
           "color",
+          "translations",
           "sheets"
         ]
       },

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -2164,6 +2164,51 @@ components:
         - name
         - fields
         - views
+    MultitableTemplateTranslationSheet:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        fields:
+          type: object
+          additionalProperties:
+            type: string
+        views:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - name
+        - fields
+        - views
+    MultitableTemplateTranslation:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+        sheets:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/MultitableTemplateTranslationSheet'
+      required:
+        - name
+        - description
+        - category
+        - sheets
+    MultitableTemplateTranslations:
+      type: object
+      properties:
+        zh-CN:
+          $ref: '#/components/schemas/MultitableTemplateTranslation'
+      required:
+        - zh-CN
     MultitableTemplate:
       type: object
       properties:
@@ -2179,6 +2224,8 @@ components:
           type: string
         color:
           type: string
+        translations:
+          $ref: '#/components/schemas/MultitableTemplateTranslations'
         sheets:
           type: array
           items:
@@ -2190,6 +2237,7 @@ components:
         - category
         - icon
         - color
+        - translations
         - sheets
     MultitableTemplateInstallResult:
       type: object

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1985,6 +1985,51 @@ components:
         - name
         - fields
         - views
+    MultitableTemplateTranslationSheet:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        fields:
+          type: object
+          additionalProperties:
+            type: string
+        views:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - name
+        - fields
+        - views
+    MultitableTemplateTranslation:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+        sheets:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/MultitableTemplateTranslationSheet'
+      required:
+        - name
+        - description
+        - category
+        - sheets
+    MultitableTemplateTranslations:
+      type: object
+      properties:
+        zh-CN:
+          $ref: '#/components/schemas/MultitableTemplateTranslation'
+      required:
+        - zh-CN
     MultitableTemplate:
       type: object
       properties:
@@ -2000,6 +2045,8 @@ components:
           type: string
         color:
           type: string
+        translations:
+          $ref: '#/components/schemas/MultitableTemplateTranslations'
         sheets:
           type: array
           items:
@@ -2011,6 +2058,7 @@ components:
         - category
         - icon
         - color
+        - translations
         - sheets
     MultitableTemplateInstallResult:
       type: object

--- a/scripts/ops/multitable-openapi-parity.test.mjs
+++ b/scripts/ops/multitable-openapi-parity.test.mjs
@@ -24,6 +24,7 @@ const expectedFieldTypes = [
   'currency',
   'percent',
   'rating',
+  'duration',
   'url',
   'email',
   'phone',
@@ -128,6 +129,14 @@ test('multitable openapi stays aligned with runtime contracts', () => {
   assert.equal(
     schemas.MultitableTemplateView?.properties?.type?.$ref,
     '#/components/schemas/MultitableViewType',
+  )
+  assert.equal(
+    schemas.MultitableTemplate?.properties?.translations?.$ref,
+    '#/components/schemas/MultitableTemplateTranslations',
+  )
+  assert.equal(
+    schemas.MultitableTemplateTranslations?.properties?.['zh-CN']?.$ref,
+    '#/components/schemas/MultitableTemplateTranslation',
   )
   assert.equal(
     paths['/api/multitable/fields']?.post?.requestBody?.content?.['application/json']?.schema?.properties?.type?.$ref,


### PR DESCRIPTION
## Summary

- add complete `zh-CN` display metadata for all eight built-in Multitable templates while preserving canonical English installation descriptors
- localize template names, descriptions, categories, sheet/field/view labels, catalog chrome, install defaults, and success copy reactively across home, center, detail, cards, and the workbench library
- publish the translation payload in the Multitable OpenAPI contract and add backend/frontend completeness and locale-switch regression coverage
- keep the translated English template-center layout readable at narrow widths by stacking hero actions and search controls

## Stack

This PR is intentionally stacked on #4403 and targets `codex/template-card-icons-4378`. The review delta is the single commit `4aac1b1ef`. After #4403 lands, this branch can be retargeted or rebased onto `main` without changing the patch.

## Root cause

The built-in template library exposed only canonical English display strings, and each frontend consumer rendered those values directly. Static catalog copy was also split between Chinese literals and English labels, so changing the active locale could not produce a complete, consistent catalog.

## Validation

- `pnpm --filter @metasheet/web exec vitest run template-localization.spec.ts meta-template-card-localization.spec.ts meta-template-card-icons.spec.ts meta-template-card-migration.spec.ts multitable-home-view.spec.ts multitable-home-view-migration.spec.ts multitable-template-center-view.spec.ts multitable-template-center-view-migration.spec.ts multitable-template-detail-view.spec.ts multitable-template-detail-view-migration.spec.ts --reporter=dot` (70 passed)
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-template-library.test.ts --reporter=dot` (18 passed)
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-context.api.test.ts --reporter=dot` (22 passed)
- `pnpm verify:multitable-openapi:parity`
- Web and core-backend type checks/builds passed
- targeted ESLint passed with zero errors (six existing router-link stub warnings)
- browser QA at 1280x720 and 390x844 verified zh-CN/en catalog and detail content, reactive locale switching, and no horizontal overflow

## Contract note

The parity expectation now includes `duration`, which was already present in the runtime and OpenAPI field-type enum; this only repairs the pre-existing parity list omission.

Addresses #4377.