### PR TITLE
fix(stock-prep): T4 corrective — x-tenant-id via shared W6 header builder + prelude stops on first failure

### DIFF
--- a/docs/development/stock-preparation-t3-line-dev-and-verification-20260716.md
+++ b/docs/development/stock-preparation-t3-line-dev-and-verification-20260716.md
@@ -19,6 +19,7 @@
 | #4391 | T3b-1c 前置：结构性 config guard（`fieldMap.target=missingChildBom` 禁映射） | `343b48bba` |
 | #4398 | T3b-1c + T3b-2：route 接线（default-OFF）+ 真库 route smoke + CI 白名单 | `6789bcca7` |
 | #4402 | T4-final：prep-line smoke 的 approved-source 前置（OD-6 扩展） | `5447fbcd1` |
+| T4-corr | T4 corrective（owner 复审 P2/P3）：T4 `requestJson` 复用 W6 `buildRequestHeaders` 发送 `x-tenant-id`（corrective-5 N/8 同类缺陷）+ prelude 首调失败即停不 replay | （本修正 PR，合并后生效） |
 | #4351 | corrective-3：acceptance runner 的 smoke 捕获 stdout-only 化 + AST 接线守卫 | `9ae9f94ce` |
 | #4369 | corrective-4：Windows PowerShell 5.1 下 native stderr promotion 修复 | `56c6d28e6` |
 | #4390 | corrective-5：有界 values-free smoke 诊断契约 + x-tenant-id 根因修复 | `3bf7292e1` |
@@ -79,7 +80,7 @@ POST /api/integration/stock-preparation/mvp/source-runs/plm-bom   (admin)
 - `stock-preparation-mvp-postdeploy-smoke.test.mjs`：`tests 26 / pass 26 / fail 0`（逐字）。
 - PowerShell 契约/行为面（pwsh 7.6.2, macOS）：contract `ALL CONTRACT CHECKS PASS`；behavior `ALL 40 BEHAVIOURAL CHECKS PASS`；ps51 套件 11/12——唯一 FAIL 是「host 必须为 Windows PowerShell 5.1 Desktop」的环境守卫（macOS 上结构性不可满足；该套件的目标环境是 CI `windows-latest` 步骤，见 `plugin-tests.yml` 的 PS 5.1 arm）。
 - core-backend `tsc --noEmit` exit 0。
-- T4-final harness（#4402）：prep-line smoke 契约测试 17/17（10 基线 + 7 新行为测试，经可注入 `req/must/registerSentinels` 驱动——happy path、dry_run(flag OFF)必败、replay 谎报写入必败、外写证据污染必败、steering-free 请求、哨兵注册契约必需即抛）；W6 冻结面零改动且其测试仍 26/0；两 PR（#4398/#4402）均经独立 Opus 对抗审阅（APPROVE，0 P1 / 0 P2；#4402 的 P3-1 hardening 当场闭合）。
+- T4-final harness（#4402）：prep-line smoke 契约测试 18/18（10 基线 + 8 新行为测试，经可注入 `req/must/registerSentinels` 驱动——happy path、dry_run(flag OFF)必败且**不再 replay**、replay 谎报写入必败、外写证据污染必败、steering-free 请求、哨兵注册契约必需即抛；另以**真实 `requestJson` + 注入 `fetchImpl`** 钉住 `x-tenant-id` 上线——owner 复审 P2 指出此前测试全走 scripted req、真实 header 组装从未被执行）；W6 冻结面零改动且其测试仍 26/0；两 PR（#4398/#4402）均经独立 Opus 对抗审阅（APPROVE，0 P1 / 0 P2；#4402 的 P3-1 hardening 当场闭合）。
 
 ### 5.2 真库（本地 PostgreSQL，CI 同款 MIGRATION_EXCLUDE 迁移）
 `stock-preparation-t3b-plm-autopersist-realdb.test.ts`（新，走**真 route handler + 真 provisioning/records**，物理 fieldId 从 `meta_fields` 交叉核对、拒绝逻辑 id 自证）4/4：
@@ -103,7 +104,7 @@ POST /api/integration/stock-preparation/mvp/source-runs/plm-bom   (admin)
 | M7 | 物理 target 采用 body projectId | `the body projectId can never move the physical target` |
 | M8 | ON 路径 tenant 换回 `resolveTenantId(req,input)` | **route 级 green（如实记录）**：steering guard 封死全部显式载体后该交换不可观测；承重防线 = M2 + 既有 resolver-differ 直测（T3a ratified 先例） |
 
-T4-final（#4402）smoke 侧 mutation：TM1 放宽接受 dry_run → `✖ ... a 200 dry_run (T3b flag OFF) FAILS the prelude`；TM2 请求携带 query steering 载体 → `✖ ... steering-free requests`；HM1 删哨兵注册调用 → 16/1 RED；均恢复后复绿。
+T4-final（#4402）smoke 侧 mutation：TM1 放宽接受 dry_run → `✖ ... a 200 dry_run (T3b flag OFF) FAILS the prelude`；TM2 请求携带 query steering 载体 → `✖ ... steering-free requests`；HM1 删哨兵注册调用 → 16/1 RED；TC1 删 `x-tenant-id` header 装配 → header 钉测 RED；TC2 删首调失败即停 → 单调用断言 RED；均恢复后复绿。
 corrective-5 侧关键 mutation（#4390 复审轮已 KILL）：删 `x-tenant-id` 头 → `pass 24 / fail 2`；伪造末相位完成 → P2-1 gate RED；`fieldMap` 空数组/畸形 entry 放行 → guard 单测 RED。
 白名单移除类 mutation（`plugin-tests.yml` 去行）为**文档化声明**：兄弟切片（T3a/T3b-1a realdb）同无 wiring-guard，遵循同模式如实记录，未虚称已被测试钉死。
 
@@ -117,7 +118,7 @@ corrective-5 侧关键 mutation（#4390 复审轮已 KILL）：删 `x-tenant-id`
 ## 6. 冻结面与剩余门（如实边界）
 
 - **实体机纯等待中**：corrective-5 包/runner/smoke 冻结；PASS → corrective-4 标记 `[SUPERSEDED]`、关 #4101；FAIL → 保留现场，按 5 个诊断字段定位相位/检查点。本文不将实体机结果计为已达成。
-- **T4-final**（OD-6 扩展）：harness 已交付（#4402）——`--approved-source-config-id` 可选前置，独立盐化 id 空间证明 approved source → project/batch/line/run 前段，合成链判据原样保留。**活体端到端执行按锁归 RC-A 的单次受控窗口**（operator 临时开 flag → 跑 → 恢复；本文不将其计为已执行）。
+- **T4-final**（OD-6 扩展）：harness 已交付（#4402 + T4 corrective：租户 header 与失败即停）；**RC-A 须在 T4 corrective 合并后才可执行**。原 #4402——`--approved-source-config-id` 可选前置，独立盐化 id 空间证明 approved source → project/batch/line/run 前段，合成链判据原样保留。**活体端到端执行按锁归 RC-A 的单次受控窗口**（operator 临时开 flag → 跑 → 恢复；本文不将其计为已执行）。
 - **RC-A**：单次 exact-SHA 包 + 实体机验收，三前置见 OD-6；reviewed FAIL 不解锁。
 - **P4**：persist 原子性/repair 硬化，独立设计门；此前**生产常开保持 barred**（本弧从未声称跨表原子或孤儿 batch 可自愈——1a 只是把 false-success 改成显式 409）。
 - 部署模板不写死任何 auto-persist flag；两 flag 均 default OFF。

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
@@ -75,6 +75,7 @@ import {
   AUDIT_ACTIONS,
   ENGINE_MESSAGE_SENTINELS,
   buildOptionSetsFixture,
+  buildRequestHeaders,
   leakScan,
   newIds,
   projectCounts,
@@ -276,12 +277,17 @@ export async function runApprovedSourcePrelude({ salt, args, req, must, summary,
   summary.approvedSourceCreated = projectCounts(auto.created, ['batch', 'lines', 'run'])
   // A 200 dry_run here means the T3b flag is OFF on the service — the prelude REQUIRES the flag and
   // must fail loudly rather than "pass" as a read-only run (OD-6 item 1).
-  must('approved-source run -> 201 internal_persist with non-empty batch/lines/run (T3b flag ON)',
+  const createdOk =
     sourceRun.ok && data.mode === 'internal_persist' &&
     data.evidence?.internalWriteExecuted === true &&
     auto.persisted === true && auto.mode === 'created' &&
-    auto.created?.batch === 1 && safeCount(auto.created?.lines) >= 1 && auto.created?.run === 1,
+    auto.created?.batch === 1 && safeCount(auto.created?.lines) >= 1 && auto.created?.run === 1
+  must('approved-source run -> 201 internal_persist with non-empty batch/lines/run (T3b flag ON)',
+    createdOk,
     `http=${sourceRun.status} mode=${summary.approvedSourceMode} created=${summary.approvedSourceCreated}`)
+  // Owner review P3: a failed first call already fails the run — do NOT keep reading the external
+  // source or risk creating internal rows with a second call.
+  if (!createdOk) return prelude
   must('approved-source run keeps every external-write invariant false',
     data.evidence?.externalWriteExecuted === false && data.evidence?.productionWrite === false &&
     data.evidence?.k3SaveSubmitAudit === false && data.evidence?.plmExternalWrite === false,
@@ -340,18 +346,23 @@ function check(name, ok, detail = '') {
   return ok === true
 }
 
-async function requestJson(baseUrl, pathname, { token, timeoutMs, method = 'GET', body, accept = [200], label = '', leakExempt = false } = {}) {
+// T4 corrective (owner review, 2026-07-16): headers come from the SAME builder the W6 smoke uses —
+// x-tenant-id rides on EVERY request when --tenant-id is given. The jwt middleware backfills the
+// authenticated principal's tenant from that header, and the T3b/T2 write routes resolve the tenant
+// from the principal only (resolveAuthUserTenantId) — without the header a tenant-scoped token-less
+// deployment 400s TENANT_REQUIRED, the exact corrective-5 N/8 root cause. fetchImpl is injectable so
+// the REAL header assembly is test-pinned (never a scripted stand-in).
+export async function requestJson(baseUrl, pathname, { token, timeoutMs, tenantId, method = 'GET', body, accept = [200], label = '', leakExempt = false, fetchImpl } = {}) {
+  const doFetch = fetchImpl || fetch
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
   try {
-    const headers = { Accept: 'application/json' }
-    if (token) headers.Authorization = `Bearer ${token}`
+    const headers = buildRequestHeaders({ token, tenantId, hasBody: body !== undefined })
     const init = { method, headers, signal: controller.signal }
     if (body !== undefined) {
-      headers['Content-Type'] = 'application/json'
       init.body = JSON.stringify(body)
     }
-    const response = await fetch(`${baseUrl}${pathname}`, init)
+    const response = await doFetch(`${baseUrl}${pathname}`, init)
     const text = await response.text()
     let parsed = null
     try { parsed = text ? JSON.parse(text) : null } catch { parsed = null }
@@ -385,7 +396,7 @@ async function main() {
   const S = RESULT.summary
   let failed = false
   const must = (name, ok, detail) => { if (!check(name, ok, detail)) failed = true }
-  const req = (pathname, options) => requestJson(args.baseUrl, pathname, { token, timeoutMs: args.timeoutMs, ...options })
+  const req = (pathname, options) => requestJson(args.baseUrl, pathname, { token, timeoutMs: args.timeoutMs, tenantId: args.tenantId, ...options })
   const scope = (extra) => scopeQuery(args, extra)
   SELF_SCAN_SENTINELS = [...fixture.sentinels, ...ENGINE_MESSAGE_SENTINELS]
   S.salt = salt

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
@@ -346,6 +346,13 @@ function check(name, ok, detail = '') {
   return ok === true
 }
 
+// T4 corrective P3-1 (reviewer): the per-request defaults main() feeds into EVERY requestJson call,
+// extracted pure so the tenant passthrough is unit-pinnable — deleting tenantId here reds a test
+// instead of silently reverting the entity run to the corrective-5 N/8 failure class.
+export function buildRequestDefaults(args, token) {
+  return { token, timeoutMs: args.timeoutMs, tenantId: args.tenantId }
+}
+
 // T4 corrective (owner review, 2026-07-16): headers come from the SAME builder the W6 smoke uses —
 // x-tenant-id rides on EVERY request when --tenant-id is given. The jwt middleware backfills the
 // authenticated principal's tenant from that header, and the T3b/T2 write routes resolve the tenant
@@ -396,7 +403,7 @@ async function main() {
   const S = RESULT.summary
   let failed = false
   const must = (name, ok, detail) => { if (!check(name, ok, detail)) failed = true }
-  const req = (pathname, options) => requestJson(args.baseUrl, pathname, { token, timeoutMs: args.timeoutMs, tenantId: args.tenantId, ...options })
+  const req = (pathname, options) => requestJson(args.baseUrl, pathname, { ...buildRequestDefaults(args, token), ...options })
   const scope = (extra) => scopeQuery(args, extra)
   SELF_SCAN_SENTINELS = [...fixture.sentinels, ...ENGINE_MESSAGE_SENTINELS]
   S.salt = salt

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
@@ -15,6 +15,7 @@ import {
   formatSummaryBlock,
   prepLineRowProjectionValid,
   prepLineRowResolved,
+  requestJson,
   runApprovedSourcePrelude,
   safeCode,
   safeT4Mode,
@@ -294,12 +295,14 @@ test('prelude run: the sentinel-registration callback is REQUIRED — omitting i
   assert.equal(calls.length, 0, 'no request may run without the leak-scan registration contract')
 })
 
-test('prelude run: a 200 dry_run (T3b flag OFF) FAILS the prelude — it can never pass as a read-only run', async () => {
+test('prelude run: a 200 dry_run (T3b flag OFF) FAILS the prelude and STOPS — no replay after a failed first call', async () => {
   const dryRun = { status: 200, body: { ok: true, data: { mode: 'dry_run', evidence: { internalWriteExecuted: false, externalWriteExecuted: false, productionWrite: false, k3SaveSubmitAudit: false, plmExternalWrite: false } } } }
-  const { req } = scriptedReq([dryRun, dryRun])
+  const { calls, req } = scriptedReq([dryRun, dryRun])
   const { checks, must } = collectMust()
   await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary: {}, registerSentinels: () => {} })
   assert.equal(checks[0].ok, false, 'the internal_persist check must fail on a dry_run response')
+  assert.equal(checks.length, 1, 'a failed first call records no further checks')
+  assert.equal(calls.length, 1, 'a failed acceptance never re-reads the source (owner review P3)')
 })
 
 test('prelude run: a replay that hard-claims an internal write FAILS the replay check', async () => {
@@ -319,4 +322,23 @@ test('prelude run: any external-write evidence flips the invariant check to FAIL
   const { checks, must } = collectMust()
   await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary: {}, registerSentinels: () => {} })
   assert.equal(checks[1].ok, false, 'the externalWrite invariant check must fail')
+})
+
+
+test('requestJson (REAL header assembly): x-tenant-id rides when tenantId is given — the corrective-5 N/8 class stays fixed', async () => {
+  const seen = []
+  const fetchImpl = async (url, init) => {
+    seen.push({ url, init })
+    return { status: 200, text: async () => JSON.stringify({ ok: true, data: {} }) }
+  }
+  const withTenant = await requestJson('http://smoke.test', '/api/x', {
+    token: 'tok_1', tenantId: 'tenant_probe', timeoutMs: 1000, method: 'POST', body: { a: 1 }, accept: [200], label: 't', fetchImpl,
+  })
+  assert.equal(withTenant.status, 200)
+  assert.equal(seen[0].init.headers['x-tenant-id'], 'tenant_probe', 'the tenant header MUST ride on the wire')
+  assert.equal(seen[0].init.headers.Authorization, 'Bearer tok_1')
+  assert.equal(seen[0].init.headers['Content-Type'], 'application/json')
+  await requestJson('http://smoke.test', '/api/y', { token: 'tok_1', timeoutMs: 1000, fetchImpl })
+  assert.equal(Object.prototype.hasOwnProperty.call(seen[1].init.headers, 'x-tenant-id'), false, 'no tenantId -> no header')
+  assert.equal(Object.prototype.hasOwnProperty.call(seen[1].init.headers, 'Content-Type'), false, 'no body -> no Content-Type')
 })

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
@@ -15,6 +15,7 @@ import {
   formatSummaryBlock,
   prepLineRowProjectionValid,
   prepLineRowResolved,
+  buildRequestDefaults,
   requestJson,
   runApprovedSourcePrelude,
   safeCode,
@@ -341,4 +342,12 @@ test('requestJson (REAL header assembly): x-tenant-id rides when tenantId is giv
   await requestJson('http://smoke.test', '/api/y', { token: 'tok_1', timeoutMs: 1000, fetchImpl })
   assert.equal(Object.prototype.hasOwnProperty.call(seen[1].init.headers, 'x-tenant-id'), false, 'no tenantId -> no header')
   assert.equal(Object.prototype.hasOwnProperty.call(seen[1].init.headers, 'Content-Type'), false, 'no body -> no Content-Type')
+})
+
+
+test('request defaults: main()\'s per-request wiring carries --tenant-id into EVERY call (P3-1 pin)', () => {
+  const defaults = buildRequestDefaults({ tenantId: 'tenant_probe', timeoutMs: 1234 }, 'tok_9')
+  assert.deepEqual(defaults, { token: 'tok_9', timeoutMs: 1234, tenantId: 'tenant_probe' })
+  const noTenant = buildRequestDefaults({ tenantId: '', timeoutMs: 1234 }, 'tok_9')
+  assert.equal(noTenant.tenantId, '', 'empty stays empty — requestJson/buildRequestHeaders omit the header')
 })


### PR DESCRIPTION
## T4 corrective — owner 复审 P2/P3 修复（RC-A 前置）

按 owner 拍板五项逐条落实：

1. **复用 W6 `buildRequestHeaders()`**：T4 `requestJson` 改用 W6 smoke 导出的同一 header builder（`import` only——冻结文件字节未动，`git diff origin/main` 对两个冻结文件为空）。
2. **`requestJson()` 接受并发送 `tenantId`**：`main()` 把 `--tenant-id` 注入每个请求；header 组装 `x-tenant-id` 与 W6 完全同源，消除 corrective-5 N/8 同类缺陷在 T4 harness 的复发。
3. **真实 `requestJson` + `fetchImpl` 钉住 `x-tenant-id`**：新测试驱动真实组装（非 scripted 替身），断言 header 在 wire 上、无 tenantId 则无 header、body↔Content-Type。
4. **删 header 的 mutation 变红**：TC1（`buildRequestHeaders` 调用去掉 `tenantId`）→ `✖ requestJson (REAL header assembly): x-tenant-id rides when tenantId is given`（17/1）→ 恢复 18/0。
5. **首次 approved-source 失败即停**：`createdOk` 为假立即 return——不再对失败验收做第二次 source 读取或冒内部行风险；dry_run 测试新增「恰一次调用、恰一条 check」断言；TC2（删早停）→ `✖ ... FAILS the prelude and STOPS`（17/1）→ 恢复 18/0。

**测试**：T4 18/18；W6 26/26（未触碰）。**MD 账面**同步：台账加 T4-corr 行、17/17→18/18、TC1/TC2 入 mutation 台账、§6 明确 **RC-A 须在本修正合并后才可执行**。

承认此前缺陷根源：#4402 的行为测试全部走注入 `scriptedReq`，真实 header 组装从未被执行——"被触发≠被验证"在自家 harness 上复发；本 PR 以真实组装路径 + fetchImpl 注入补上这一课。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
