### PR TITLE
fix(stock-prep): T4 prelude stops on tainted external-write evidence + ledger 19/19

### DIFF
--- a/docs/development/stock-preparation-t3-line-dev-and-verification-20260716.md
+++ b/docs/development/stock-preparation-t3-line-dev-and-verification-20260716.md
@@ -80,7 +80,7 @@ POST /api/integration/stock-preparation/mvp/source-runs/plm-bom   (admin)
 - `stock-preparation-mvp-postdeploy-smoke.test.mjs`：`tests 26 / pass 26 / fail 0`（逐字）。
 - PowerShell 契约/行为面（pwsh 7.6.2, macOS）：contract `ALL CONTRACT CHECKS PASS`；behavior `ALL 40 BEHAVIOURAL CHECKS PASS`；ps51 套件 11/12——唯一 FAIL 是「host 必须为 Windows PowerShell 5.1 Desktop」的环境守卫（macOS 上结构性不可满足；该套件的目标环境是 CI `windows-latest` 步骤，见 `plugin-tests.yml` 的 PS 5.1 arm）。
 - core-backend `tsc --noEmit` exit 0。
-- T4-final harness（#4402）：prep-line smoke 契约测试 18/18（10 基线 + 8 新行为测试，经可注入 `req/must/registerSentinels` 驱动——happy path、dry_run(flag OFF)必败且**不再 replay**、replay 谎报写入必败、外写证据污染必败、steering-free 请求、哨兵注册契约必需即抛；另以**真实 `requestJson` + 注入 `fetchImpl`** 钉住 `x-tenant-id` 上线——owner 复审 P2 指出此前测试全走 scripted req、真实 header 组装从未被执行）；W6 冻结面零改动且其测试仍 26/0；两 PR（#4398/#4402）均经独立 Opus 对抗审阅（APPROVE，0 P1 / 0 P2；#4402 的 P3-1 hardening 当场闭合）。
+- T4-final harness（#4402）：prep-line smoke 契约测试 19/19（10 基线 + 9 新行为测试，含 buildRequestDefaults 透传钉与外写污染即停，经可注入 `req/must/registerSentinels` 驱动——happy path、dry_run(flag OFF)必败且**不再 replay**、replay 谎报写入必败、外写证据污染必败、steering-free 请求、哨兵注册契约必需即抛；另以**真实 `requestJson` + 注入 `fetchImpl`** 钉住 `x-tenant-id` 上线——owner 复审 P2 指出此前测试全走 scripted req、真实 header 组装从未被执行）；W6 冻结面零改动且其测试仍 26/0；两 PR（#4398/#4402）均经独立 Opus 对抗审阅（APPROVE，0 P1 / 0 P2；#4402 的 P3-1 hardening 当场闭合）。
 
 ### 5.2 真库（本地 PostgreSQL，CI 同款 MIGRATION_EXCLUDE 迁移）
 `stock-preparation-t3b-plm-autopersist-realdb.test.ts`（新，走**真 route handler + 真 provisioning/records**，物理 fieldId 从 `meta_fields` 交叉核对、拒绝逻辑 id 自证）4/4：

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs
@@ -288,10 +288,15 @@ export async function runApprovedSourcePrelude({ salt, args, req, must, summary,
   // Owner review P3: a failed first call already fails the run — do NOT keep reading the external
   // source or risk creating internal rows with a second call.
   if (!createdOk) return prelude
-  must('approved-source run keeps every external-write invariant false',
+  // Owner re-review (2026-07-17): the SAME stop applies when the create looked right but the
+  // external-write evidence is tainted — a 201 with externalWriteExecuted=true is a failed
+  // acceptance, and a failed acceptance never replays.
+  const externalWriteClean =
     data.evidence?.externalWriteExecuted === false && data.evidence?.productionWrite === false &&
-    data.evidence?.k3SaveSubmitAudit === false && data.evidence?.plmExternalWrite === false,
+    data.evidence?.k3SaveSubmitAudit === false && data.evidence?.plmExternalWrite === false
+  must('approved-source run keeps every external-write invariant false', externalWriteClean,
     `http=${sourceRun.status}`)
+  if (!externalWriteClean) return prelude
   const replay = await req(`${API}/mvp/source-runs/plm-bom`, {
     method: 'POST', body: prelude.body, accept: [200], label: 'approved-source-run-replay',
   })

--- a/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
+++ b/scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
@@ -316,13 +316,15 @@ test('prelude run: a replay that hard-claims an internal write FAILS the replay 
   assert.equal(checks[2].ok, false, 'the internal_noop replay check must fail')
 })
 
-test('prelude run: any external-write evidence flips the invariant check to FAIL', async () => {
+test('prelude run: any external-write evidence flips the invariant check to FAIL and STOPS the replay', async () => {
   const tainted = approvedCreateResponse()
   tainted.body.data.evidence.externalWriteExecuted = true
-  const { req } = scriptedReq([tainted, approvedReplayResponse()])
+  const { calls, req } = scriptedReq([tainted, approvedReplayResponse()])
   const { checks, must } = collectMust()
   await runApprovedSourcePrelude({ salt: 't123', args: PRELUDE_ARGS, req, must, summary: {}, registerSentinels: () => {} })
   assert.equal(checks[1].ok, false, 'the externalWrite invariant check must fail')
+  assert.equal(checks.length, 2, 'a tainted acceptance records no replay check')
+  assert.equal(calls.length, 1, 'a tainted acceptance never replays (owner re-review)')
 })
 
 


### PR DESCRIPTION
## T4 prelude — 外写污染证据同样触发早停（owner 复审处方）

owner 判别运行确认：首响 201 `internal_persist` 但 `externalWriteExecuted=true` 时，外写检查 FAIL 而 replay 仍执行（exact head 上 calls=2）。修复：

- 外写不变量条件提取为 `externalWriteClean` 布尔，`must()` 后 `if (!externalWriteClean) return prelude`——与 create-shape 早停完全同构；
- 既有 tainted 测试加断言 `checks.length===2` 且 **`calls.length===1`**；
- mutation（删该 return，commit 后）→ `✖ prelude run: any external-write evidence flips the invariant check to FAIL and STOPS the replay`（18/1）→ 恢复 19/0；
- 账面 P3 同步：MD 计数 18/18 → **19/19（10 基线 + 9 新）**（P3-1 的 `buildRequestDefaults` 钉测落在 MD 写就之后）。

W6 冻结邻居 26/26 未动。不涉及 corrective-6（#4410，独立文件面，审阅中）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
