### PR TITLE
feat(automation): S6 — event_fires tombstone→lease upgrade migration + backfill (schema foundation)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -718,6 +718,7 @@ jobs:
             tests/integration/attendance-files-acl.test.ts \
             tests/integration/files-storage-key-migration.db.test.ts \
             tests/integration/files-orphan-blob-retention.db.test.ts \
+            tests/integration/multitable-automation-event-fires-lease-migration.db.test.ts \
             tests/integration/multitable-attachment-blob-purge.db.test.ts \
             tests/integration/multitable-attachment-root-escape.db.test.ts \
             tests/integration/stock-prep-audit-immutable-trigger.db.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260716140000_event_fires_lease.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260716140000_event_fires_lease.ts
@@ -5,8 +5,9 @@
  * `claimEventDelivery` writes a bare `(rule_id, dedup_key)` "came-through" row BEFORE `executeRule`. If the
  * process crashes after the claim but before the rule finishes, the row already exists, so redelivery is
  * skipped — the work is PERMANENTLY LOST, not retried. The fix upgrades the tombstone into a reclaimable
- * lease: `status` (pending|in_progress|done|dead_letter) + `lease_expires_at` + `attempts`, so a crash mid-
- * execution leaves the row reclaimable (lease expires → the next scan reclaims it).
+ * lease: `status` (pending|in_progress|done|outcome_unknown|failed|dead_letter) + `lease_expires_at` +
+ * `attempts` + a monotonic `fence` (see below), so a crash mid-execution leaves the row reclaimable (lease
+ * expires → the next scan reclaims it) and fence-CAS keeps persistent state single-writer.
  *
  * BACKFILL (design lock item 5, "迁移回填 — 关键"): every PRE-EXISTING row in a deployed environment is a
  * historical, already-completed delivery. It MUST be backfilled to `status='done'`, else on the day of

--- a/packages/core-backend/src/db/migrations/zzzz20260716140000_event_fires_lease.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260716140000_event_fires_lease.ts
@@ -15,9 +15,19 @@
  * UPGRADE path — old-schema rows written BEFORE this migration then this migration applied — not fresh-DB,
  * which would create rows already-backfilled and never exercise the backfill statement.)
  *
- * The `status`/lease CHECKs mirror `meta_automation_outbox_consumer` (create_automation_outbox): a
- * BICONDITIONAL that ties `lease_expires_at IS NOT NULL` to `status='in_progress'` in BOTH directions, so a
- * settled row can never carry stale ownership and an in_progress row is always reclaimable.
+ * State machine (design lock §Layer-1, lines 353-355): `pending` | `in_progress` | and the FOUR
+ * resolve-permitting terminals `done` | `outcome_unknown` | `failed` | `dead_letter` (success; external-send
+ * ambiguity; deterministic permanent failure after bounded attempts). The `status`/lease CHECKs mirror
+ * `meta_automation_outbox_consumer`: a BICONDITIONAL ties `lease_expires_at IS NOT NULL` to
+ * `status='in_progress'` in BOTH directions, so every terminal (done/outcome_unknown/failed/dead_letter) and
+ * pending is lease-NULL — no stale ownership — and an in_progress row is always reclaimable.
+ *
+ * FENCE (design lock round-5, lines 49-50 + 59 — a UNIVERSAL rule covering EVERY reclaimable lease row): a
+ * monotonic `fence` self-incremented on claim/reclaim; writes to persistent state MUST be fence-CAS
+ * (`WHERE fence = <claimed>`), so a reclaimed "zombie" (alive but lease-expired holder) that tries to write
+ * with its stale fence hits 0 rows and aborts → persistent state is SINGLE-WRITER. `bigint` (not int): fence
+ * values can exceed 2^31, and must round-trip as a STRING at the driver seam (a JS number loses precision
+ * past 2^53).
  */
 import { sql, type Kysely } from 'kysely'
 
@@ -26,7 +36,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`
     ALTER TABLE meta_automation_event_fires
       ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'done'
-        CONSTRAINT automation_event_fires_status_valid CHECK (status IN ('pending','in_progress','done','dead_letter'))
+        CONSTRAINT automation_event_fires_status_valid
+        CHECK (status IN ('pending','in_progress','done','outcome_unknown','failed','dead_letter'))
   `.execute(db)
   await sql`ALTER TABLE meta_automation_event_fires ADD COLUMN IF NOT EXISTS lease_expires_at timestamptz`.execute(db)
   await sql`
@@ -34,8 +45,14 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       ADD COLUMN IF NOT EXISTS attempts int NOT NULL DEFAULT 0
         CONSTRAINT automation_event_fires_attempts_nonneg CHECK (attempts >= 0)
   `.execute(db)
+  // FENCE — monotonic single-writer token, incremented on claim/reclaim; persistent-state writes are fence-CAS.
+  await sql`
+    ALTER TABLE meta_automation_event_fires
+      ADD COLUMN IF NOT EXISTS fence bigint NOT NULL DEFAULT 0
+        CONSTRAINT automation_event_fires_fence_nonneg CHECK (fence >= 0)
+  `.execute(db)
   // BICONDITIONAL: a lease exists IFF the row is in_progress (mirrors outbox_consumer). in_progress ⇒ leased
-  // (reclaimable); settled/pending ⇒ NO lease (no stale ownership).
+  // (reclaimable); every terminal + pending ⇒ NO lease (no stale ownership).
   await sql`
     ALTER TABLE meta_automation_event_fires
       ADD CONSTRAINT automation_event_fires_lease_iff_in_progress
@@ -51,6 +68,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 export async function down(db: Kysely<unknown>): Promise<void> {
   await sql`DROP INDEX IF EXISTS idx_automation_event_fires_reclaim`.execute(db)
   await sql`ALTER TABLE meta_automation_event_fires DROP CONSTRAINT IF EXISTS automation_event_fires_lease_iff_in_progress`.execute(db)
+  await sql`ALTER TABLE meta_automation_event_fires DROP COLUMN IF EXISTS fence`.execute(db)
   await sql`ALTER TABLE meta_automation_event_fires DROP COLUMN IF EXISTS attempts`.execute(db)
   await sql`ALTER TABLE meta_automation_event_fires DROP COLUMN IF EXISTS lease_expires_at`.execute(db)
   await sql`ALTER TABLE meta_automation_event_fires DROP COLUMN IF EXISTS status`.execute(db)

--- a/packages/core-backend/src/db/migrations/zzzz20260716140000_event_fires_lease.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260716140000_event_fires_lease.ts
@@ -1,0 +1,57 @@
+/**
+ * Migration: `meta_automation_event_fires` — S6 upgrade from terminal TOMBSTONE to a per-`rule_id` LEASE.
+ *
+ * Design lock (approval-form-writeback-fwb0-designlock-20260712, §Layer-1 window-2 + item 5): the existing
+ * `claimEventDelivery` writes a bare `(rule_id, dedup_key)` "came-through" row BEFORE `executeRule`. If the
+ * process crashes after the claim but before the rule finishes, the row already exists, so redelivery is
+ * skipped — the work is PERMANENTLY LOST, not retried. The fix upgrades the tombstone into a reclaimable
+ * lease: `status` (pending|in_progress|done|dead_letter) + `lease_expires_at` + `attempts`, so a crash mid-
+ * execution leaves the row reclaimable (lease expires → the next scan reclaims it).
+ *
+ * BACKFILL (design lock item 5, "迁移回填 — 关键"): every PRE-EXISTING row in a deployed environment is a
+ * historical, already-completed delivery. It MUST be backfilled to `status='done'`, else on the day of
+ * deploy those rows are read as "never done" under the new schema and RE-FIRED. `ADD COLUMN status ...
+ * DEFAULT 'done'` does exactly that at ALTER time for every existing row. (This must be tested via the real
+ * UPGRADE path — old-schema rows written BEFORE this migration then this migration applied — not fresh-DB,
+ * which would create rows already-backfilled and never exercise the backfill statement.)
+ *
+ * The `status`/lease CHECKs mirror `meta_automation_outbox_consumer` (create_automation_outbox): a
+ * BICONDITIONAL that ties `lease_expires_at IS NOT NULL` to `status='in_progress'` in BOTH directions, so a
+ * settled row can never carry stale ownership and an in_progress row is always reclaimable.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // status DEFAULT 'done' BACKFILLS every pre-existing tombstone row to done at ALTER time (item 5).
+  await sql`
+    ALTER TABLE meta_automation_event_fires
+      ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'done'
+        CONSTRAINT automation_event_fires_status_valid CHECK (status IN ('pending','in_progress','done','dead_letter'))
+  `.execute(db)
+  await sql`ALTER TABLE meta_automation_event_fires ADD COLUMN IF NOT EXISTS lease_expires_at timestamptz`.execute(db)
+  await sql`
+    ALTER TABLE meta_automation_event_fires
+      ADD COLUMN IF NOT EXISTS attempts int NOT NULL DEFAULT 0
+        CONSTRAINT automation_event_fires_attempts_nonneg CHECK (attempts >= 0)
+  `.execute(db)
+  // BICONDITIONAL: a lease exists IFF the row is in_progress (mirrors outbox_consumer). in_progress ⇒ leased
+  // (reclaimable); settled/pending ⇒ NO lease (no stale ownership).
+  await sql`
+    ALTER TABLE meta_automation_event_fires
+      ADD CONSTRAINT automation_event_fires_lease_iff_in_progress
+        CHECK ((status = 'in_progress') = (lease_expires_at IS NOT NULL))
+  `.execute(db)
+  // reclaim scan reads (status='in_progress' AND lease_expires_at < now()); index it.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_automation_event_fires_reclaim
+    ON meta_automation_event_fires (status, lease_expires_at)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_automation_event_fires_reclaim`.execute(db)
+  await sql`ALTER TABLE meta_automation_event_fires DROP CONSTRAINT IF EXISTS automation_event_fires_lease_iff_in_progress`.execute(db)
+  await sql`ALTER TABLE meta_automation_event_fires DROP COLUMN IF EXISTS attempts`.execute(db)
+  await sql`ALTER TABLE meta_automation_event_fires DROP COLUMN IF EXISTS lease_expires_at`.execute(db)
+  await sql`ALTER TABLE meta_automation_event_fires DROP COLUMN IF EXISTS status`.execute(db)
+}

--- a/packages/core-backend/tests/integration/multitable-automation-event-fires-lease-migration.db.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-event-fires-lease-migration.db.test.ts
@@ -60,7 +60,7 @@ describeDb('S6 event_fires tombstone→lease upgrade migration (real DB, isolate
   const rowsOf = async (ruleId: string) =>
     (
       await sql<{ dedup_key: string; status: string; lease: string | null; attempts: number; fence: string }>`
-        SELECT dedup_key, status, lease_expires_at::text AS lease, attempts, fence::text AS fence
+        SELECT dedup_key, status, lease_expires_at::text AS lease, attempts, fence
         FROM meta_automation_event_fires WHERE rule_id = ${ruleId} ORDER BY dedup_key
       `.execute(testDb)
     ).rows
@@ -94,15 +94,16 @@ describeDb('S6 event_fires tombstone→lease upgrade migration (real DB, isolate
   it('FENCE is a monotonic single-writer token: claim increments, a stale-fence CAS writes 0 rows, bigint round-trips as string past 2^53', async () => {
     await insertOld('rule_F', 'record.created:evt_f')
     await migrateUp(testDb)
-    // claim: fence 0 → 1 via fence-CAS (WHERE fence = current)
+    // claim: fence 0 → 1 via fence-CAS (WHERE fence = current). RAW `RETURNING fence` (no ::text) — the driver
+    // must hand back the bigint as it will at runtime.
     const claim = await sql<{ fence: string }>`
       UPDATE meta_automation_event_fires SET fence = fence + 1, status='in_progress', lease_expires_at = now() + interval '30 s'
-      WHERE rule_id='rule_F' AND fence = 0 RETURNING fence::text AS fence
+      WHERE rule_id='rule_F' AND fence = 0 RETURNING fence
     `.execute(testDb)
     expect(claim.rows[0].fence).toBe('1')
     // reclaim: fence 1 → 2
     const reclaim = await sql<{ fence: string }>`
-      UPDATE meta_automation_event_fires SET fence = fence + 1 WHERE rule_id='rule_F' AND fence = 1 RETURNING fence::text AS fence
+      UPDATE meta_automation_event_fires SET fence = fence + 1 WHERE rule_id='rule_F' AND fence = 1 RETURNING fence
     `.execute(testDb)
     expect(reclaim.rows[0].fence).toBe('2')
     // a ZOMBIE holding the stale fence 1 tries to write a terminal — fence-CAS hits 0 rows (single-writer)
@@ -110,10 +111,13 @@ describeDb('S6 event_fires tombstone→lease upgrade migration (real DB, isolate
       UPDATE meta_automation_event_fires SET status='done', lease_expires_at = NULL WHERE rule_id='rule_F' AND fence = 1
     `.execute(testDb)
     expect(Number(zombie.numAffectedRows ?? 0)).toBe(0)
-    // bigint precision: a fence past 2^53 must round-trip EXACTLY as a string (a JS number would corrupt it)
+    // bigint DRIVER BOUNDARY: a fence past 2^53 must survive a RAW `SELECT fence` (NO ::text cast — the cast
+    // would make Postgres itself return text and prove nothing). node-postgres returns int8 as a STRING to
+    // preserve precision; a JS number would corrupt 2^53+1. Assert BOTH the type and the exact value.
     const big = '9007199254740993' // 2^53 + 1
     await sql`UPDATE meta_automation_event_fires SET fence = ${big}::bigint WHERE rule_id='rule_F' AND fence = 2`.execute(testDb)
-    const back = await sql<{ fence: string }>`SELECT fence::text AS fence FROM meta_automation_event_fires WHERE rule_id='rule_F'`.execute(testDb)
+    const back = await sql<{ fence: string }>`SELECT fence FROM meta_automation_event_fires WHERE rule_id='rule_F'`.execute(testDb)
+    expect(typeof back.rows[0].fence).toBe('string')
     expect(back.rows[0].fence).toBe(big)
     // fence CHECK: negative rejected by the named constraint
     await expect(

--- a/packages/core-backend/tests/integration/multitable-automation-event-fires-lease-migration.db.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-event-fires-lease-migration.db.test.ts
@@ -59,8 +59,8 @@ describeDb('S6 event_fires tombstone→lease upgrade migration (real DB, isolate
 
   const rowsOf = async (ruleId: string) =>
     (
-      await sql<{ dedup_key: string; status: string; lease: string | null; attempts: number }>`
-        SELECT dedup_key, status, lease_expires_at::text AS lease, attempts
+      await sql<{ dedup_key: string; status: string; lease: string | null; attempts: number; fence: string }>`
+        SELECT dedup_key, status, lease_expires_at::text AS lease, attempts, fence::text AS fence
         FROM meta_automation_event_fires WHERE rule_id = ${ruleId} ORDER BY dedup_key
       `.execute(testDb)
     ).rows
@@ -74,12 +74,13 @@ describeDb('S6 event_fires tombstone→lease upgrade migration (real DB, isolate
     // run the REAL migration up() — the ALTER + backfill
     await expect(migrateUp(testDb)).resolves.toBeUndefined()
 
-    // every historical row is backfilled to done, lease-free, attempts 0 — so it is NOT re-fired
+    // every historical row is backfilled to done, lease-free, attempts 0, fence 0 — so it is NOT re-fired
     for (const ruleId of ['rule_A', 'rule_B']) {
       for (const r of await rowsOf(ruleId)) {
         expect(r.status).toBe('done')
         expect(r.lease).toBeNull()
         expect(r.attempts).toBe(0)
+        expect(r.fence).toBe('0')
       }
     }
     // a reclaim scan (in_progress + expired lease) sees NONE of them — no historical re-fire
@@ -88,6 +89,57 @@ describeDb('S6 event_fires tombstone→lease upgrade migration (real DB, isolate
       WHERE status = 'in_progress' AND lease_expires_at < now()
     `.execute(testDb)
     expect(reclaimable.rows[0].n).toBe(0)
+  })
+
+  it('FENCE is a monotonic single-writer token: claim increments, a stale-fence CAS writes 0 rows, bigint round-trips as string past 2^53', async () => {
+    await insertOld('rule_F', 'record.created:evt_f')
+    await migrateUp(testDb)
+    // claim: fence 0 → 1 via fence-CAS (WHERE fence = current)
+    const claim = await sql<{ fence: string }>`
+      UPDATE meta_automation_event_fires SET fence = fence + 1, status='in_progress', lease_expires_at = now() + interval '30 s'
+      WHERE rule_id='rule_F' AND fence = 0 RETURNING fence::text AS fence
+    `.execute(testDb)
+    expect(claim.rows[0].fence).toBe('1')
+    // reclaim: fence 1 → 2
+    const reclaim = await sql<{ fence: string }>`
+      UPDATE meta_automation_event_fires SET fence = fence + 1 WHERE rule_id='rule_F' AND fence = 1 RETURNING fence::text AS fence
+    `.execute(testDb)
+    expect(reclaim.rows[0].fence).toBe('2')
+    // a ZOMBIE holding the stale fence 1 tries to write a terminal — fence-CAS hits 0 rows (single-writer)
+    const zombie = await sql`
+      UPDATE meta_automation_event_fires SET status='done', lease_expires_at = NULL WHERE rule_id='rule_F' AND fence = 1
+    `.execute(testDb)
+    expect(Number(zombie.numAffectedRows ?? 0)).toBe(0)
+    // bigint precision: a fence past 2^53 must round-trip EXACTLY as a string (a JS number would corrupt it)
+    const big = '9007199254740993' // 2^53 + 1
+    await sql`UPDATE meta_automation_event_fires SET fence = ${big}::bigint WHERE rule_id='rule_F' AND fence = 2`.execute(testDb)
+    const back = await sql<{ fence: string }>`SELECT fence::text AS fence FROM meta_automation_event_fires WHERE rule_id='rule_F'`.execute(testDb)
+    expect(back.rows[0].fence).toBe(big)
+    // fence CHECK: negative rejected by the named constraint
+    await expect(
+      sql`UPDATE meta_automation_event_fires SET fence = -1 WHERE rule_id='rule_F'`.execute(testDb),
+    ).rejects.toThrow(/automation_event_fires_fence_nonneg/)
+  })
+
+  it('the FOUR ratified terminals done|outcome_unknown|failed|dead_letter are accepted and are lease-NULL', async () => {
+    await migrateUp(testDb)
+    for (const term of ['done', 'outcome_unknown', 'failed', 'dead_letter']) {
+      // a terminal row inserts cleanly (closed-set accepts it) and carries NO lease (biconditional)
+      await expect(
+        sql`INSERT INTO meta_automation_event_fires (rule_id, dedup_key, status) VALUES ('rule_T', ${term}, ${term})`.execute(testDb),
+      ).resolves.toBeTruthy()
+      // attaching a lease to a terminal is rejected — a settled row can never carry ownership
+      await expect(
+        sql`UPDATE meta_automation_event_fires SET lease_expires_at = now() + interval '30 s' WHERE rule_id='rule_T' AND dedup_key=${term}`.execute(testDb),
+      ).rejects.toThrow(/automation_event_fires_lease_iff_in_progress/)
+    }
+  })
+
+  it('attempts CHECK: a negative attempts is rejected by the named constraint', async () => {
+    await migrateUp(testDb)
+    await expect(
+      sql`INSERT INTO meta_automation_event_fires (rule_id, dedup_key, attempts) VALUES ('rule_N','k', -1)`.execute(testDb),
+    ).rejects.toThrow(/automation_event_fires_attempts_nonneg/)
   })
 
   it('lease biconditional CHECK: a done/pending row rejects a lease; an in_progress row requires one', async () => {

--- a/packages/core-backend/tests/integration/multitable-automation-event-fires-lease-migration.db.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-event-fires-lease-migration.db.test.ts
@@ -1,0 +1,121 @@
+/**
+ * S6 — `meta_automation_event_fires` tombstone→lease UPGRADE migration (real DB, ISOLATED SCHEMA).
+ *
+ * Verifies the design-lock item 5 ("迁移回填 — 关键") via the REAL UPGRADE PATH, NOT fresh-DB:
+ *   1. create the OLD-schema table ((rule_id, dedup_key, fired_at), no state columns) in an isolated schema;
+ *   2. write historical rows (existing, un-backfilled deploy data);
+ *   3. run the REAL migration's up() (the ALTER);
+ *   4. assert every historical row is backfilled to status='done' (else it would be re-fired on next scan) —
+ *      lease NULL, attempts 0 — and a reclaim scan (in_progress + expired lease) returns NONE for them.
+ * A fresh-DB full migrate would create the historical rows already-backfilled and never exercise the ALTER's
+ * backfill statement, so this test deliberately reconstructs the pre-migration schema by hand.
+ *
+ * Also asserts the lease biconditional CHECK (a done/pending row can't carry a lease; an in_progress row must).
+ * Isolated schema + search_path (house rule for shared-DB integration) — no shared-table pollution.
+ */
+import { randomUUID } from 'node:crypto'
+
+import { Pool } from 'pg'
+import { Kysely, PostgresDialect, sql } from 'kysely'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { up as migrateUp } from '../../src/db/migrations/zzzz20260716140000_event_fires_lease'
+
+const dbUrl = process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+
+describeDb('S6 event_fires tombstone→lease upgrade migration (real DB, isolated schema)', () => {
+  let adminPool: Pool
+  let schema: string
+  let testPool: Pool
+  let testDb: Kysely<unknown>
+
+  beforeEach(async () => {
+    adminPool = new Pool({ connectionString: dbUrl })
+    schema = `s6ef_${randomUUID().replace(/-/g, '')}`
+    await adminPool.query(`CREATE SCHEMA "${schema}"`)
+    testPool = new Pool({ connectionString: dbUrl, options: `-c search_path=${schema}` })
+    testDb = new Kysely<unknown>({ dialect: new PostgresDialect({ pool: testPool }) })
+    // OLD schema exactly as zzzz20260701120000_create_automation_event_fires (minus the automation_rules FK,
+    // which is irrelevant to the ALTER backfill and would drag the whole rules table into the isolated schema).
+    await sql`
+      CREATE TABLE meta_automation_event_fires (
+        rule_id text NOT NULL,
+        dedup_key text NOT NULL,
+        fired_at timestamptz NOT NULL DEFAULT now(),
+        PRIMARY KEY (rule_id, dedup_key)
+      )
+    `.execute(testDb)
+  })
+
+  afterEach(async () => {
+    await testDb.destroy()
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await adminPool.end()
+  })
+
+  const insertOld = (ruleId: string, dedupKey: string) =>
+    sql`INSERT INTO meta_automation_event_fires (rule_id, dedup_key) VALUES (${ruleId}, ${dedupKey})`.execute(testDb)
+
+  const rowsOf = async (ruleId: string) =>
+    (
+      await sql<{ dedup_key: string; status: string; lease: string | null; attempts: number }>`
+        SELECT dedup_key, status, lease_expires_at::text AS lease, attempts
+        FROM meta_automation_event_fires WHERE rule_id = ${ruleId} ORDER BY dedup_key
+      `.execute(testDb)
+    ).rows
+
+  it('UPGRADE PATH: pre-existing tombstone rows are backfilled to done (not re-fired); new columns + CHECKs land', async () => {
+    // existing, un-backfilled deploy data (historical, already-completed deliveries)
+    await insertOld('rule_A', 'record.created:evt_1')
+    await insertOld('rule_A', 'record.updated:evt_2')
+    await insertOld('rule_B', 'approval.completed:evt_3')
+
+    // run the REAL migration up() — the ALTER + backfill
+    await expect(migrateUp(testDb)).resolves.toBeUndefined()
+
+    // every historical row is backfilled to done, lease-free, attempts 0 — so it is NOT re-fired
+    for (const ruleId of ['rule_A', 'rule_B']) {
+      for (const r of await rowsOf(ruleId)) {
+        expect(r.status).toBe('done')
+        expect(r.lease).toBeNull()
+        expect(r.attempts).toBe(0)
+      }
+    }
+    // a reclaim scan (in_progress + expired lease) sees NONE of them — no historical re-fire
+    const reclaimable = await sql<{ n: number }>`
+      SELECT count(*)::int AS n FROM meta_automation_event_fires
+      WHERE status = 'in_progress' AND lease_expires_at < now()
+    `.execute(testDb)
+    expect(reclaimable.rows[0].n).toBe(0)
+  })
+
+  it('lease biconditional CHECK: a done/pending row rejects a lease; an in_progress row requires one', async () => {
+    await insertOld('rule_C', 'record.created:evt_c')
+    await migrateUp(testDb)
+    // done row + a lease → rejected (settled row can never carry ownership)
+    await expect(
+      sql`UPDATE meta_automation_event_fires SET lease_expires_at = now() + interval '30 s' WHERE rule_id='rule_C'`.execute(testDb),
+    ).rejects.toThrow(/automation_event_fires_lease_iff_in_progress/)
+    // in_progress WITHOUT a lease → rejected (unreclaimable)
+    await expect(
+      sql`UPDATE meta_automation_event_fires SET status='in_progress' WHERE rule_id='rule_C'`.execute(testDb),
+    ).rejects.toThrow(/automation_event_fires_lease_iff_in_progress/)
+    // in_progress WITH a lease → accepted (a live, reclaimable claim)
+    await expect(
+      sql`UPDATE meta_automation_event_fires SET status='in_progress', lease_expires_at = now() + interval '30 s' WHERE rule_id='rule_C'`.execute(testDb),
+    ).resolves.toBeTruthy()
+    // bad status value → rejected by the closed-set CHECK
+    await expect(
+      sql`INSERT INTO meta_automation_event_fires (rule_id, dedup_key, status) VALUES ('rule_C','k','bogus')`.execute(testDb),
+    ).rejects.toThrow(/automation_event_fires_status_valid/)
+  })
+
+  it('a NEW claim inserted after the upgrade defaults to done unless it opts into the lease lifecycle', async () => {
+    await migrateUp(testDb)
+    // the bare INSERT shape the OLD claimEventDelivery used still works (DEFAULT 'done') — cutover-safe
+    await sql`INSERT INTO meta_automation_event_fires (rule_id, dedup_key) VALUES ('rule_D','k1')`.execute(testDb)
+    const [row] = await rowsOf('rule_D')
+    expect(row).toMatchObject({ status: 'done', lease: null, attempts: 0 })
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -246,6 +246,10 @@ export default defineConfig({
       // step in plugin-tests.yml (alongside files-storage-key-migration.db.test.ts) where it runs
       // against real Postgres every PR.
       'tests/integration/files-orphan-blob-retention.db.test.ts',
+      // S6 event_fires tombstone→lease upgrade migration (backfill historical rows → done): DATABASE_URL-gated,
+      // isolated per-test schema, real UPGRADE path (old schema + rows → migrate → assert). Excluded here so it
+      // cannot skip-green, whole-file wired into `Run attendance integration tests` in plugin-tests.yml.
+      'tests/integration/multitable-automation-event-fires-lease-migration.db.test.ts',
       // F9 owner CHANGES-REQUESTED (GF9-1/GF9-2): multitable_attachments blob_purged_at migration +
       // deleteAttachmentBinary index-free delete + sweepMultitableAttachmentBlobPurge compensating-sweep
       // matrix, same shape/rationale as the F5 entry immediately above (DATABASE_URL-gated describeDb,


### PR DESCRIPTION
**Part of the #4337 P1** (the review's S6 item: *event_fires lease-ification + upgrade backfill*). Additive migration; no runtime callers change here. Head `a29a4fba5`.

## What lands
Per the RATIFIED design lock (`approval-form-writeback-fwb0-designlock-20260712`, §Layer-1 window-2 + round-5 + item 5), `meta_automation_event_fires` upgrades tombstone → **per-`rule_id` lease**:
- **State machine** (lock lines 353-355): `pending | in_progress` + the FOUR resolve-permitting terminals `done | outcome_unknown | failed | dead_letter` (success; external-send ambiguity; deterministic permanent failure). Closed-set CHECK.
- **`fence bigint NOT NULL DEFAULT 0`** (lock lines 49-50 + 59 — universal for every reclaimable lease row): monotonic, incremented at claim/reclaim; persistent-state writes are fence-CAS so a stale-fence zombie hits 0 rows (single-writer). Non-negative named CHECK.
- **`lease_expires_at` + `attempts`** + a **biconditional** lease-iff-`in_progress` CHECK (mirrors `outbox_consumer`: every terminal + pending is lease-NULL) + reclaim index.
- **Backfill** (item 5, the "关键 critique catch"): `ADD COLUMN status … DEFAULT 'done'` marks every pre-existing row `done` at ALTER time, so deploy-day historical rows aren't re-fired.

## Verification (real UPGRADE path — the design forbids fresh-DB)
Isolated-schema real-DB test: reconstruct OLD schema → write historical rows → run the real `up()` → assert **6/6**:
- backfill: all → `done`, lease NULL, attempts 0, **fence 0**; reclaim scan sees none (no re-fire);
- **fence**: claim 0→1→2; stale-fence (1) terminal write affects **0 rows**; a fence past 2^53 (`9007199254740993`) round-trips **exactly as a string**; negative fence rejected by name;
- **four terminals** `done|outcome_unknown|failed|dead_letter` all insert and are **lease-NULL** (biconditional rejects a lease on each);
- **attempts** negative rejected by the named constraint;
- the closed status set rejects a bad value; the old bare INSERT still works (cutover-safe).

`tsc --noEmit` 0. All guards **mutation-proven** (dropping the fence column reds 3 tests; narrowing the status set reds the terminals test; dropping the attempts CHECK reds the negative test; `DEFAULT 'done'→'pending'` reds the backfill; weakening the biconditional reds the CHECK). Two-point CI wired.

## Scope
Schema foundation only. The `claimEventDelivery` lease-runtime (claim→lease→execute→done; crash→reclaim, using fence-CAS), the recoverable bridge/trigger/projection sinks, and real producer/consumer/boot wiring are the paired follow-on slices.

**For review — not self-merging runtime.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)