### PR TITLE
feat(attendance): S7-1 — discriminated-union step contract + fail-closed 422 (authoring+runtime) + host-injected resolver port, per RATIFIED S7 lock

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -723,6 +723,7 @@ jobs:
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
             tests/integration/attendance-plugin.test.ts \
             tests/integration/attendance-approval-action-authorization.db.test.ts \
+            tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -102,6 +102,10 @@ import {
   stopApprovalSlaScheduler,
 } from './services/ApprovalSlaScheduler'
 import { ApprovalProductService } from './services/ApprovalProductService'
+// S7-1 (OD-S7-5=d): the host-resolved chain-depth cap the attendance dynamic-assignee resolver PORT
+// exposes to plugin-attendance, so the plugin validates `manager_at_level.level` against the SAME
+// source the kernel uses and never re-parses APPROVAL_MANAGER_CHAIN_MAX_LEVELS into a second constant.
+import { MAX_MANAGER_CHAIN_LEVELS } from './services/ApprovalDirectoryOrg'
 import {
   resolveAttendanceSchedulerIntervalMs,
   resolveAttendanceSchedulerLeaderOptions,
@@ -937,6 +941,23 @@ export class MetaSheetServer {
     return wrappedUnregister
   }
 
+  // S7-1 (RATIFIED attendance-approval-s7 resolver lock, OD-S7-5=d): construct the host binding for the
+  // narrow, org-scoped dynamic approval-assignee resolver port plugin-attendance consumes. It exposes
+  // the SAME MAX_MANAGER_CHAIN_LEVELS constant the kernel uses (no plugin env re-parse) and — at S7-1 —
+  // a resolver that reports EVERY dynamic kind unimplemented (`implementedKinds: []`, `resolve` →
+  // `{ status: 'unimplemented' }`), so the plugin fail-closes at both authoring and runtime. S7-2/S7-3/
+  // S7-4 populate `implementedKinds` and implement per-kind, org-scoped, directory-read-only resolution
+  // here (never a write, never outside the core-backend process boundary).
+  private buildApprovalAssigneeResolverPort(): NonNullable<
+    import('./types/plugin').PluginServices['approvalAssigneeResolver']
+  > {
+    return {
+      maxManagerChainLevels: MAX_MANAGER_CHAIN_LEVELS,
+      implementedKinds: [],
+      resolve: async () => ({ status: 'unimplemented' as const }),
+    }
+  }
+
   private registerPluginWorkdayCalendarProvider(pluginName: string, provider: WorkdayCalendarPort): (() => void) {
     getWorkdayCalendarRegistry().register(provider)
     this.workdayCalendarProviderOwner = pluginName
@@ -1719,6 +1740,11 @@ export class MetaSheetServer {
         workdayCalendar: {
           register: (provider: WorkdayCalendarPort) => this.registerPluginWorkdayCalendarProvider(pluginName, provider),
         },
+        // S7-1 (OD-S7-5=d): the host binding for the dynamic approval-assignee resolver port. Unlike
+        // workdayCalendar (plugin-provided), core-backend is the PROVIDER here; plugin-attendance
+        // consumes it and fail-closes when it is absent. At S7-1 it reports every dynamic kind
+        // unimplemented, so a dynamic-kind step can never round-trip inert — see buildApprovalAssigneeResolverPort.
+        approvalAssigneeResolver: this.buildApprovalAssigneeResolverPort(),
         automationRegistry,
         rbacProvisioning,
         platformAppInstances,

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -978,6 +978,44 @@ export interface PluginServices {
       } | null>
     }): (() => void)
   }
+  /**
+   * S7-1 — host→plugin, narrow, org-scoped resolver PORT for the attendance dynamic approval-assignee
+   * kinds (直属上级 `direct_manager` / 部门主管 `dept_head` / 多级上级 `manager_at_level`), per the
+   * RATIFIED attendance-approval-s7 resolver design-lock, OD-S7-5 = (d). It mirrors `workdayCalendar`
+   * above but runs the OPPOSITE direction: core-backend is the PROVIDER, plugin-attendance is the
+   * CONSUMER (it checks `context?.services?.approvalAssigneeResolver?.<member>` before use). The plugin
+   * NEVER takes a runtime dependency on the whole core package and NEVER copies the kernel resolver
+   * logic; when this port is absent the plugin fail-closes (authoring 422 / runtime block), never the
+   * legacy admin fallback (§4.1).
+   *
+   * - `maxManagerChainLevels` is the host-resolved `MAX_MANAGER_CHAIN_LEVELS` constant
+   *   (`ApprovalDirectoryOrg` — env `APPROVAL_MANAGER_CHAIN_MAX_LEVELS`, default 10, hard ceiling 50).
+   *   The plugin validates `manager_at_level.level ∈ [1, maxManagerChainLevels]` against THIS value so it
+   *   never re-parses the env var into a second constant — one source, two surfaces, no drift.
+   * - `implementedKinds` is the set of dynamic kinds this host build can actually resolve at runtime.
+   *   EMPTY at S7-1 (the seam is defined but no kind is wired yet — S7-2/S7-3/S7-4 populate it). A kind
+   *   absent from this list is unimplemented ⇒ the plugin fail-closes.
+   * - `resolve` is the org-scoped runtime resolution seam (the §3.4 freeze point). At S7-1 it returns
+   *   `{ status: 'unimplemented' }` for every kind; S7-2/S7-3/S7-4 implement per-kind resolution. It
+   *   reads only `directory_*` (never writes) and stays inside the core-backend process boundary.
+   */
+  approvalAssigneeResolver?: {
+    readonly maxManagerChainLevels: number
+    readonly implementedKinds: readonly string[]
+    resolve(
+      orgId: string,
+      request: {
+        kind: string
+        level?: number
+        requesterUserId: string
+        requesterSnapshot?: Record<string, unknown>
+      },
+    ): Promise<
+      | { status: 'resolved'; assignees: Array<{ assignmentType: 'user'; assigneeId: string }> }
+      | { status: 'unresolved'; reason: string }
+      | { status: 'unimplemented' }
+    >
+  }
   notification: NotificationService // Notification service instance
   automationRegistry: PluginAutomationRegistryService
   rbacProvisioning: PluginRbacProvisioningService

--- a/packages/core-backend/tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts
@@ -70,7 +70,10 @@ function errorCode(res: HttpResponse): string | undefined {
 const NODE_KEY_0 = 'attendance_request_step_0'
 const NODE_KEY_1 = 'attendance_request_step_1'
 const DYNAMIC_FLAG = 'ATTENDANCE_APPROVAL_DYNAMIC_ASSIGNEE_SOURCES_ENABLED'
-const HOST_MAX_LEVEL = 10 // host-resolved default (APPROVAL_MANAGER_CHAIN_MAX_LEVELS unset)
+// Pinned into APPROVAL_MANAGER_CHAIN_MAX_LEVELS in beforeAll BEFORE the core import — the host resolves
+// MAX_MANAGER_CHAIN_LEVELS at module load (ApprovalDirectoryOrg.ts), so the MAX+1 leg stays truthful even
+// when the ambient CI/dev environment sets its own value.
+const HOST_MAX_LEVEL = 10
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
 const describeIfDatabase = dbUrl ? describe : describe.skip
@@ -81,9 +84,13 @@ describeIfDatabase('S7-1 dynamic-kind step contract + fail-closed (authoring + r
   let pool: Pool | undefined
   let prevRbac: string | undefined
   let prevFlag: string | undefined
+  let prevMaxLevels: string | undefined
 
   const runSuffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
   const orgId = `s7-1-${runSuffix}`
+  // Isolated org for the whole-flow breadth case: keeps its single active flow unambiguous under
+  // loadApprovalFlow's newest-first pick, independent of every flow the main org accumulates.
+  const breadthOrgId = `s7-1b-${runSuffix}`
   const requester = `s7-1-req-${runSuffix}`
   let adminToken: string
   const createdFlowIds: string[] = []
@@ -155,6 +162,8 @@ describeIfDatabase('S7-1 dynamic-kind step contract + fail-closed (authoring + r
     process.env.RBAC_BYPASS = 'true'
     process.env.SKIP_PLUGINS = 'false'
     delete process.env[DYNAMIC_FLAG] // default OFF
+    prevMaxLevels = process.env.APPROVAL_MANAGER_CHAIN_MAX_LEVELS
+    process.env.APPROVAL_MANAGER_CHAIN_MAX_LEVELS = String(HOST_MAX_LEVEL)
 
     const repoRoot = path.join(__dirname, '../../../../')
     pool = new Pool({ connectionString: dbUrl })
@@ -181,12 +190,14 @@ describeIfDatabase('S7-1 dynamic-kind step contract + fail-closed (authoring + r
           await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::uuid[])', [createdRequestIds]).catch(() => undefined)
         }
         await pool.query('DELETE FROM attendance_requests WHERE org_id = $1', [orgId]).catch(() => undefined)
+        await pool.query('DELETE FROM attendance_requests WHERE org_id = $1', [breadthOrgId]).catch(() => undefined)
         if (createdInstanceIds.length > 0) {
           await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [createdInstanceIds]).catch(() => undefined)
           await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [createdInstanceIds]).catch(() => undefined)
           await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [createdInstanceIds]).catch(() => undefined)
         }
         await pool.query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [orgId]).catch(() => undefined)
+        await pool.query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [breadthOrgId]).catch(() => undefined)
       } finally {
         await pool.end()
       }
@@ -196,6 +207,8 @@ describeIfDatabase('S7-1 dynamic-kind step contract + fail-closed (authoring + r
     }
     if (prevRbac === undefined) delete process.env.RBAC_BYPASS
     else process.env.RBAC_BYPASS = prevRbac
+    if (prevMaxLevels === undefined) delete process.env.APPROVAL_MANAGER_CHAIN_MAX_LEVELS
+    else process.env.APPROVAL_MANAGER_CHAIN_MAX_LEVELS = prevMaxLevels
     if (prevFlag === undefined) delete process.env[DYNAMIC_FLAG]
     else process.env[DYNAMIC_FLAG] = prevFlag
   })
@@ -290,6 +303,45 @@ describeIfDatabase('S7-1 dynamic-kind step contract + fail-closed (authoring + r
       [orgId, requester],
     )
     expect(after.rows[0].n, 'no attendance_requests row may persist on a fail-closed create').toBe(before.rows[0].n)
+  })
+
+  // ── §4.1 runtime create WHOLE-FLOW breadth: the dynamic step is at index 1, NOT index 0. The create
+  // gate passes no onlyStepIndex (whole-flow scan) — a mutation narrowing it to step 0 must turn this red. ──
+  it('RUNTIME create: [static, dynamic] flow + flag OFF ⇒ fails-closed on the LATER dynamic step, zero rows', async () => {
+    setFlag(false)
+    const breadthFlowId = randomUUID()
+    await (pool as Pool).query(
+      `INSERT INTO attendance_approval_flows (id, org_id, name, request_type, steps, is_active)
+       VALUES ($1, $2, $3, 'time_correction', $4::jsonb, true)`,
+      [
+        breadthFlowId,
+        breadthOrgId,
+        `s7-1-runtime-breadth-${runSuffix}`,
+        JSON.stringify([{ name: 'S', approverUserIds: [requester] }, { kind: 'direct_manager' }]),
+      ],
+    )
+    createdFlowIds.push(breadthFlowId)
+
+    const workDate = '2026-05-21'
+    const res = await requestJson(`${baseUrl}/api/attendance/requests`, {
+      method: 'POST',
+      headers: authHeaders(adminToken),
+      body: JSON.stringify({
+        orgId: breadthOrgId,
+        workDate,
+        requestType: 'time_correction',
+        requestedInAt: `${workDate}T01:25:00Z`,
+        requestedOutAt: `${workDate}T10:00:00Z`,
+        reason: 's7-1 runtime create whole-flow breadth',
+      }),
+    })
+    expect(res.status, res.raw).toBe(422)
+    expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
+    const after = await (pool as Pool).query(
+      'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
+      [breadthOrgId],
+    )
+    expect(after.rows[0].n, 'no attendance_requests row may persist when a LATER step is dynamic').toBe(0)
   })
 
   // ── §4.1 runtime step-advance fail-closed: approve step 1 advancing into a dynamic step 2, flag OFF ──

--- a/packages/core-backend/tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts
@@ -224,6 +224,14 @@ describeIfDatabase('S7-1 dynamic-kind step contract + fail-closed (authoring + r
     { label: 'manager_at_level level 0', steps: [{ kind: 'manager_at_level', level: 0 }], code: 'APPROVAL_STEP_LEVEL_INVALID' },
     { label: 'manager_at_level level MAX+1', steps: [{ kind: 'manager_at_level', level: HOST_MAX_LEVEL + 1 }], code: 'APPROVAL_STEP_LEVEL_INVALID' },
     { label: 'static/dynamic mixed', steps: [{ kind: 'direct_manager', approverUserIds: ['u1'] }], code: 'APPROVAL_STEP_STATIC_DYNAMIC_MIXED' },
+    // Owner P2 round 2: the union is a KEY-shape constraint — empty arrays still carry the static key.
+    { label: 'dynamic + EMPTY approverUserIds key', steps: [{ kind: 'direct_manager', approverUserIds: [] }], code: 'APPROVAL_STEP_STATIC_DYNAMIC_MIXED' },
+    { label: 'dynamic + EMPTY approverRoleIds key', steps: [{ kind: 'direct_manager', approverRoleIds: [] }], code: 'APPROVAL_STEP_STATIC_DYNAMIC_MIXED' },
+    // Owner P2 round 2: closed per-kind param union — level is manager_at_level-only.
+    { label: 'level on a no-param kind (direct_manager)', steps: [{ kind: 'direct_manager', level: 2 }], code: 'APPROVAL_STEP_PARAMS_INVALID' },
+    // Unmodeled param: zod strips `target` from its parse, so this leg only 422s if the contract is
+    // wired to the PRE-zod raw steps — it pins the raw-steps call-site, not just the validator.
+    { label: 'unmodeled dynamic param (dept_head + target)', steps: [{ kind: 'dept_head', target: 'x' }], code: 'APPROVAL_STEP_PARAMS_INVALID' },
   ]
 
   for (const c of shapeCases) {
@@ -264,6 +272,15 @@ describeIfDatabase('S7-1 dynamic-kind step contract + fail-closed (authoring + r
     const flowId = (created.body as { data?: { id?: string } }).data?.id as string
     const updated = await updateFlow(flowId, [{ name: 'LM2', approverUserIds: [requester] }])
     expect(updated.status, updated.raw).toBe(200)
+  })
+
+  it('CREATE accepts a STATIC step with a stray unmodeled key (legacy tolerance unchanged — closed union is dynamic-only)', async () => {
+    setFlag(false)
+    const created = await createFlow(
+      [{ name: 'LM', approverUserIds: [requester], legacyStray: 'kept-tolerant' }],
+      `s7-1-static-stray-${runSuffix}`,
+    )
+    expect(created.status, created.raw).toBe(201)
   })
 
   // ── §4.1 runtime create fail-closed: a dynamic flow reached at request submission, flag OFF ──

--- a/packages/core-backend/tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import type { MetaSheetServer } from '../../src/index'
+import * as path from 'path'
+import net from 'net'
+import http from 'http'
+import { Pool } from 'pg'
+import { randomUUID } from 'crypto'
+
+// S7-1 (RATIFIED attendance-approval-s7 resolver design-lock): real-DB, HTTP-level coverage of the
+// DISCRIMINATED-UNION step contract (§7 S7-1) and the RUNTIME fail-closed gate (§4.1). Two behavior
+// classes:
+//   • Authoring: the create (POST) AND update (PUT) approval-flow routes 422 every malformed/unavailable
+//     dynamic step, each with a DISTINCT error code (mutation-friendly). At S7-1 no resolver is wired,
+//     so even a shape-valid dynamic kind (flag ON) is APPROVAL_STEP_KIND_UNAVAILABLE.
+//   • Runtime: a persisted dynamic-kind flow reached at request-create or step-advance while the flag is
+//     OFF fails-closed BEFORE any mutation — never the legacy admin fallback. Because S7-1's authoring
+//     API refuses dynamic kinds, the runtime tests seed the dynamic flow directly via SQL (simulating a
+//     flow authored under a future flag-ON+resolver state, then the flag flipped off) — exactly the
+//     defense-in-depth window §4.1 exists to close.
+//
+// RBAC_BYPASS='true' for this file: authorization is not under test here (S7-0 owns it); the bypass lets
+// the approve reach the step-advance gate via the admin override so the §4.1 block is what we observe.
+
+interface HttpResponse {
+  status: number
+  body: unknown
+  raw: string
+}
+
+function requestJson(
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const req = http.request(
+      {
+        method: options.method || 'GET',
+        hostname: target.hostname,
+        port: target.port,
+        path: `${target.pathname}${target.search}`,
+        headers: options.headers,
+      },
+      (res) => {
+        let data = ''
+        res.on('data', (chunk) => {
+          data += chunk
+        })
+        res.on('end', () => {
+          let body: unknown
+          try {
+            body = data ? JSON.parse(data) : undefined
+          } catch {
+            body = undefined
+          }
+          resolve({ status: res.statusCode || 0, body, raw: data })
+        })
+      },
+    )
+    req.on('error', reject)
+    if (options.body) req.write(options.body)
+    req.end()
+  })
+}
+
+function errorCode(res: HttpResponse): string | undefined {
+  return (res.body as { error?: { code?: string } } | undefined)?.error?.code
+}
+
+const NODE_KEY_0 = 'attendance_request_step_0'
+const NODE_KEY_1 = 'attendance_request_step_1'
+const DYNAMIC_FLAG = 'ATTENDANCE_APPROVAL_DYNAMIC_ASSIGNEE_SOURCES_ENABLED'
+const HOST_MAX_LEVEL = 10 // host-resolved default (APPROVAL_MANAGER_CHAIN_MAX_LEVELS unset)
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+describeIfDatabase('S7-1 dynamic-kind step contract + fail-closed (authoring + runtime)', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl: string | undefined
+  let pool: Pool | undefined
+  let prevRbac: string | undefined
+  let prevFlag: string | undefined
+
+  const runSuffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+  const orgId = `s7-1-${runSuffix}`
+  const requester = `s7-1-req-${runSuffix}`
+  let adminToken: string
+  const createdFlowIds: string[] = []
+  const createdInstanceIds: string[] = []
+  const createdRequestIds: string[] = []
+
+  function setFlag(on: boolean): void {
+    if (on) process.env[DYNAMIC_FLAG] = 'true'
+    else delete process.env[DYNAMIC_FLAG]
+  }
+
+  async function devToken(userId: string, roles: string, perms: string): Promise<string> {
+    const res = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(
+        roles,
+      )}&perms=${encodeURIComponent(perms)}`,
+    )
+    const token = (res.body as { token?: string } | undefined)?.token
+    if (!token) throw new Error(`dev-token issuance failed for ${userId}: ${res.raw}`)
+    return token
+  }
+
+  function authHeaders(token: string): Record<string, string> {
+    return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+  }
+
+  async function createFlow(steps: unknown[], name: string): Promise<HttpResponse> {
+    const res = await requestJson(`${baseUrl}/api/attendance/approval-flows`, {
+      method: 'POST',
+      headers: authHeaders(adminToken),
+      body: JSON.stringify({ name, requestType: 'leave', steps, orgId, isActive: true }),
+    })
+    const id = (res.body as { data?: { id?: string } } | undefined)?.data?.id
+    if (id) createdFlowIds.push(id)
+    return res
+  }
+
+  async function seedStaticFlowRow(name: string): Promise<string> {
+    const id = randomUUID()
+    await (pool as Pool).query(
+      `INSERT INTO attendance_approval_flows (id, org_id, name, request_type, steps, is_active)
+       VALUES ($1, $2, $3, 'leave', $4::jsonb, true)`,
+      [id, orgId, name, JSON.stringify([{ name: 'S', approverUserIds: [requester] }])],
+    )
+    createdFlowIds.push(id)
+    return id
+  }
+
+  async function updateFlow(id: string, steps: unknown[]): Promise<HttpResponse> {
+    return requestJson(`${baseUrl}/api/attendance/approval-flows/${id}`, {
+      method: 'PUT',
+      headers: authHeaders(adminToken),
+      body: JSON.stringify({ steps, orgId }),
+    })
+  }
+
+  beforeAll(async () => {
+    const canListen: boolean = await new Promise((resolve) => {
+      const s = net.createServer()
+      s.once('error', () => resolve(false))
+      s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
+    })
+    if (!canListen) throw new Error('S7-1 tests require an available loopback port.')
+    if (!dbUrl) throw new Error('DATABASE_URL / ATTENDANCE_TEST_DATABASE_URL is required for the S7-1 suite.')
+
+    process.env.DATABASE_URL = dbUrl
+    prevRbac = process.env.RBAC_BYPASS
+    prevFlag = process.env[DYNAMIC_FLAG]
+    process.env.RBAC_BYPASS = 'true'
+    process.env.SKIP_PLUGINS = 'false'
+    delete process.env[DYNAMIC_FLAG] // default OFF
+
+    const repoRoot = path.join(__dirname, '../../../../')
+    pool = new Pool({ connectionString: dbUrl })
+    await pool.query('SELECT 1')
+
+    const { MetaSheetServer } = await import('../../src/index')
+    server = new MetaSheetServer({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [path.join(repoRoot, 'plugins', 'plugin-attendance')],
+    })
+    await server.start()
+    const address = server.getAddress()
+    if (!address || typeof address === 'string') throw new Error('S7-1 server did not expose a TCP address.')
+    baseUrl = `http://127.0.0.1:${address.port}`
+
+    adminToken = await devToken(requester, 'user', 'attendance:admin,attendance:write,attendance:approve')
+  })
+
+  afterAll(async () => {
+    if (pool) {
+      try {
+        if (createdRequestIds.length > 0) {
+          await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::uuid[])', [createdRequestIds]).catch(() => undefined)
+        }
+        await pool.query('DELETE FROM attendance_requests WHERE org_id = $1', [orgId]).catch(() => undefined)
+        if (createdInstanceIds.length > 0) {
+          await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [createdInstanceIds]).catch(() => undefined)
+          await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [createdInstanceIds]).catch(() => undefined)
+          await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [createdInstanceIds]).catch(() => undefined)
+        }
+        await pool.query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [orgId]).catch(() => undefined)
+      } finally {
+        await pool.end()
+      }
+    }
+    if (server && (server as unknown as { stop?: () => Promise<void> }).stop) {
+      await (server as unknown as { stop: () => Promise<void> }).stop()
+    }
+    if (prevRbac === undefined) delete process.env.RBAC_BYPASS
+    else process.env.RBAC_BYPASS = prevRbac
+    if (prevFlag === undefined) delete process.env[DYNAMIC_FLAG]
+    else process.env[DYNAMIC_FLAG] = prevFlag
+  })
+
+  // ── Authoring rejection matrix — each shape gets a DISTINCT code, on BOTH create and update ──
+  // Shape cases run with the flag OFF (default): the shape check precedes the availability check, so the
+  // SHAPE code (not APPROVAL_STEP_KIND_UNAVAILABLE) must still surface — proving shape precedence.
+  const shapeCases: Array<{ label: string; steps: unknown[]; code: string }> = [
+    { label: 'unknown kind', steps: [{ kind: 'bogus_kind' }], code: 'APPROVAL_STEP_KIND_INVALID' },
+    { label: 'continuous_managers is OUT-of-v1', steps: [{ kind: 'continuous_managers', levels: 2 }], code: 'APPROVAL_STEP_KIND_INVALID' },
+    { label: 'manager_at_level missing level', steps: [{ kind: 'manager_at_level' }], code: 'APPROVAL_STEP_LEVEL_INVALID' },
+    { label: 'manager_at_level non-integer level', steps: [{ kind: 'manager_at_level', level: 1.5 }], code: 'APPROVAL_STEP_LEVEL_INVALID' },
+    { label: 'manager_at_level level 0', steps: [{ kind: 'manager_at_level', level: 0 }], code: 'APPROVAL_STEP_LEVEL_INVALID' },
+    { label: 'manager_at_level level MAX+1', steps: [{ kind: 'manager_at_level', level: HOST_MAX_LEVEL + 1 }], code: 'APPROVAL_STEP_LEVEL_INVALID' },
+    { label: 'static/dynamic mixed', steps: [{ kind: 'direct_manager', approverUserIds: ['u1'] }], code: 'APPROVAL_STEP_STATIC_DYNAMIC_MIXED' },
+  ]
+
+  for (const c of shapeCases) {
+    it(`CREATE rejects ${c.label} → 422 ${c.code}`, async () => {
+      setFlag(false)
+      const res = await createFlow(c.steps, `s7-1-create-${c.code}-${runSuffix}-${Math.random().toString(36).slice(2, 6)}`)
+      expect(res.status, res.raw).toBe(422)
+      expect(errorCode(res)).toBe(c.code)
+    })
+
+    it(`UPDATE rejects ${c.label} → 422 ${c.code}`, async () => {
+      setFlag(false)
+      const flowId = await seedStaticFlowRow(`s7-1-update-${c.code}-${runSuffix}-${Math.random().toString(36).slice(2, 6)}`)
+      const res = await updateFlow(flowId, c.steps)
+      expect(res.status, res.raw).toBe(422)
+      expect(errorCode(res)).toBe(c.code)
+      // The rejected update must not have replaced the persisted static steps.
+      const row = await (pool as Pool).query('SELECT steps FROM attendance_approval_flows WHERE id = $1', [flowId])
+      expect(JSON.stringify(row.rows[0].steps)).toContain(requester)
+    })
+  }
+
+  it('CREATE rejects a shape-valid dynamic kind at S7-1 (flag ON, no resolver) → 422 APPROVAL_STEP_KIND_UNAVAILABLE', async () => {
+    setFlag(true)
+    try {
+      const res = await createFlow([{ kind: 'direct_manager' }], `s7-1-unavail-${runSuffix}`)
+      expect(res.status, res.raw).toBe(422)
+      expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
+    } finally {
+      setFlag(false)
+    }
+  })
+
+  it('CREATE + UPDATE accept a valid static flow (legacy path unaffected)', async () => {
+    setFlag(false)
+    const created = await createFlow([{ name: 'LM', approverUserIds: [requester] }], `s7-1-static-${runSuffix}`)
+    expect(created.status, created.raw).toBe(201)
+    const flowId = (created.body as { data?: { id?: string } }).data?.id as string
+    const updated = await updateFlow(flowId, [{ name: 'LM2', approverUserIds: [requester] }])
+    expect(updated.status, updated.raw).toBe(200)
+  })
+
+  // ── §4.1 runtime create fail-closed: a dynamic flow reached at request submission, flag OFF ──
+  it('RUNTIME create: dynamic flow + flag OFF ⇒ request-create fails-closed with ZERO persisted rows', async () => {
+    setFlag(false)
+    // Seed (bypassing the S7-1 authoring gate) an ACTIVE dynamic time_correction flow — the only active
+    // time_correction flow in this unique org, so loadApprovalFlow picks it.
+    const dynFlowId = randomUUID()
+    await (pool as Pool).query(
+      `INSERT INTO attendance_approval_flows (id, org_id, name, request_type, steps, is_active)
+       VALUES ($1, $2, $3, 'time_correction', $4::jsonb, true)`,
+      [dynFlowId, orgId, `s7-1-runtime-create-${runSuffix}`, JSON.stringify([{ kind: 'direct_manager' }])],
+    )
+    createdFlowIds.push(dynFlowId)
+
+    const workDate = '2026-05-20'
+    const before = await (pool as Pool).query(
+      'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1 AND user_id = $2',
+      [orgId, requester],
+    )
+    const res = await requestJson(`${baseUrl}/api/attendance/requests`, {
+      method: 'POST',
+      headers: authHeaders(adminToken),
+      body: JSON.stringify({
+        orgId,
+        workDate,
+        requestType: 'time_correction',
+        requestedInAt: `${workDate}T01:25:00Z`,
+        requestedOutAt: `${workDate}T10:00:00Z`,
+        reason: 's7-1 runtime create fail-closed',
+      }),
+    })
+    expect(res.status, res.raw).toBe(422)
+    expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
+    const after = await (pool as Pool).query(
+      'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1 AND user_id = $2',
+      [orgId, requester],
+    )
+    expect(after.rows[0].n, 'no attendance_requests row may persist on a fail-closed create').toBe(before.rows[0].n)
+  })
+
+  // ── §4.1 runtime step-advance fail-closed: approve step 1 advancing into a dynamic step 2, flag OFF ──
+  it('RUNTIME advance: approve step 1 into dynamic step 2 + flag OFF ⇒ fails-closed and rolls back (no mutation)', async () => {
+    setFlag(false)
+    const requestId = randomUUID()
+    const instanceId = randomUUID()
+    const client = pool as Pool
+
+    // step 1 static (index 0), step 2 dynamic (index 1) — frozen into the request metadata.
+    await client.query(
+      `INSERT INTO approval_instances
+         (id, status, version, source_system, workflow_key, business_key, title,
+          requester_snapshot, current_step, total_steps, current_node_key)
+       VALUES ($1, 'pending', 0, 'platform', 'attendance_request_approval', $2, $3,
+               $4::jsonb, 0, 2, $5)`,
+      [
+        instanceId,
+        `attendance-request:${requestId}`,
+        `S7-1 advance ${runSuffix}`,
+        JSON.stringify({ id: requester, name: requester }),
+        NODE_KEY_0,
+      ],
+    )
+    createdInstanceIds.push(instanceId)
+
+    await client.query(
+      `INSERT INTO attendance_requests
+         (id, user_id, work_date, request_type, status, org_id, approval_instance_id, metadata)
+       VALUES ($1, $2, CURRENT_DATE, 'missed_check_in', 'pending', $3, $4, $5::jsonb)`,
+      [
+        requestId,
+        requester,
+        orgId,
+        instanceId,
+        JSON.stringify({ approvalFlow: { steps: [{ approverUserIds: [requester] }, { kind: 'direct_manager' }], currentStep: 0 } }),
+      ],
+    )
+    createdRequestIds.push(requestId)
+
+    // Active assignment for the current (static, step-0) node — requester is the assignee.
+    await client.query(
+      `INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, node_key, source_step, is_active, metadata)
+       VALUES ($1, 'user', $2, $3, 0, TRUE, '{}'::jsonb)`,
+      [instanceId, requester, NODE_KEY_0],
+    )
+
+    const res = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}/approve`, {
+      method: 'POST',
+      headers: authHeaders(adminToken),
+      body: JSON.stringify({ comment: 's7-1 advance fail-closed' }),
+    })
+    expect(res.status, res.raw).toBe(422)
+    expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
+
+    // The transaction must have rolled back: still step 0, version 0, pending, no record, node unchanged.
+    const inst = await client.query('SELECT status, version, current_step, current_node_key FROM approval_instances WHERE id = $1', [instanceId])
+    expect(inst.rows[0].status).toBe('pending')
+    expect(Number(inst.rows[0].version)).toBe(0)
+    expect(Number(inst.rows[0].current_step)).toBe(0)
+    expect(inst.rows[0].current_node_key).toBe(NODE_KEY_0)
+    const rec = await client.query('SELECT 1 FROM approval_records WHERE instance_id = $1', [instanceId])
+    expect(rec.rows.length, 'a fail-closed advance must not append an approval record').toBe(0)
+    // No step-1 (dynamic) assignments were swapped in, and the step-0 assignment is untouched.
+    const step1 = await client.query('SELECT 1 FROM approval_assignments WHERE instance_id = $1 AND node_key = $2', [instanceId, NODE_KEY_1])
+    expect(step1.rows.length, 'no dynamic step-2 assignment may be written on a rolled-back advance').toBe(0)
+    const step0 = await client.query('SELECT is_active FROM approval_assignments WHERE instance_id = $1 AND node_key = $2', [instanceId, NODE_KEY_0])
+    expect(step0.rows.length).toBe(1)
+    expect(step0.rows[0].is_active).toBe(true)
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-approval-step-contract-s7-1.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-step-contract-s7-1.test.ts
@@ -1,0 +1,260 @@
+import { createRequire } from 'node:module'
+import { afterEach, describe, expect, it } from 'vitest'
+
+// S7-1 (RATIFIED attendance-approval-s7 resolver design-lock, §7 S7-1 + §4.1): pure-helper unit
+// coverage for the DISCRIMINATED-UNION step contract and the RUNTIME fail-closed gate. Every rejection
+// carries a DISTINCT HttpError code, so these tests double as mutation canaries — removing any single
+// guard changes (or removes) the specific code its leg asserts, reddening exactly that leg rather than
+// being masked by a later 422. The port is faked (core-backend is the PROVIDER in prod); at S7-1
+// `implementedKinds` is empty so every well-formed dynamic step is unavailable — correct and safe.
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceApprovalCenterForTests as {
+  normalizeApprovalSteps: (value: unknown) => Array<Record<string, unknown>>
+  assertApprovalStepsContract: (steps: unknown, context: unknown) => void
+  assertDynamicFlowStepsRuntimeAvailable: (
+    steps: unknown,
+    context: unknown,
+    options?: { onlyStepIndex?: number },
+  ) => void
+  buildAttendanceApprovalAssignments: (steps: unknown, index?: number) => unknown
+  getApprovalStepKind: (step: unknown) => string | null
+  ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV: string
+  ATTENDANCE_DYNAMIC_ASSIGNEE_KINDS: string[]
+}
+
+const {
+  normalizeApprovalSteps,
+  assertApprovalStepsContract,
+  assertDynamicFlowStepsRuntimeAvailable,
+  buildAttendanceApprovalAssignments,
+  ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV,
+} = helpers
+
+const MAX = 10 // host-resolved default (APPROVAL_MANAGER_CHAIN_MAX_LEVELS unset ⇒ 10)
+
+function makeContext(
+  opts: { implementedKinds?: string[]; maxManagerChainLevels?: number; port?: boolean } = {},
+): unknown {
+  if (opts.port === false) return { services: {} }
+  return {
+    services: {
+      approvalAssigneeResolver: {
+        maxManagerChainLevels: opts.maxManagerChainLevels ?? MAX,
+        implementedKinds: opts.implementedKinds ?? [],
+        resolve: async () => ({ status: 'unimplemented' as const }),
+      },
+    },
+  }
+}
+
+function setFlag(enabled: boolean): void {
+  process.env[ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV] = enabled ? 'true' : 'false'
+}
+
+function httpCode(fn: () => void): { status: number; code: string } | null {
+  try {
+    fn()
+    return null
+  } catch (err) {
+    const e = err as { status?: number; code?: string }
+    return { status: e.status ?? -1, code: e.code ?? '<none>' }
+  }
+}
+
+afterEach(() => {
+  delete process.env[ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV]
+})
+
+describe('S7-1 normalizeApprovalSteps — discriminated union survives to persistence', () => {
+  it('preserves a static step byte-for-byte (legacy, unchanged — normalizer does not dedup)', () => {
+    expect(
+      normalizeApprovalSteps([{ name: 'LM', approverUserIds: ['u1', 'u2'], approverRoleIds: ['r1'] }]),
+    ).toEqual([{ name: 'LM', approverUserIds: ['u1', 'u2'], approverRoleIds: ['r1'] }])
+  })
+
+  it('preserves a dynamic kind (direct_manager) and drops static approver arrays', () => {
+    expect(normalizeApprovalSteps([{ name: 'Mgr', kind: 'direct_manager' }])).toEqual([
+      { name: 'Mgr', kind: 'direct_manager' },
+    ])
+  })
+
+  it('preserves manager_at_level with its integer level', () => {
+    expect(normalizeApprovalSteps([{ kind: 'manager_at_level', level: 3 }])).toEqual([
+      { name: undefined, kind: 'manager_at_level', level: 3 },
+    ])
+  })
+
+  it('a mixed step normalizes to dynamic (kind wins) so it cannot route to the admin fallback', () => {
+    expect(normalizeApprovalSteps([{ kind: 'direct_manager', approverUserIds: ['u1'] }])).toEqual([
+      { name: undefined, kind: 'direct_manager' },
+    ])
+  })
+})
+
+describe('S7-1 assertApprovalStepsContract — discriminated-union authoring matrix (distinct codes)', () => {
+  // Shape checks run with flag ON + ALL kinds "implemented" so a shape rejection is NOT masked by the
+  // availability arm — proving shape precedence and that each shape code is the load-bearing reason.
+  const allImplemented = () =>
+    makeContext({ implementedKinds: ['direct_manager', 'dept_head', 'manager_at_level'] })
+
+  it('static/dynamic MIXED → APPROVAL_STEP_STATIC_DYNAMIC_MIXED', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'direct_manager', approverUserIds: ['u1'] }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_STATIC_DYNAMIC_MIXED' })
+  })
+
+  it('MIXED still 422/MIXED even with flag OFF + no implemented kinds (shape precedes availability)', () => {
+    setFlag(false)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'direct_manager', approverRoleIds: ['r1'] }], makeContext())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_STATIC_DYNAMIC_MIXED' })
+  })
+
+  it('unknown kind → APPROVAL_STEP_KIND_INVALID', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'bogus_kind' }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_INVALID' })
+  })
+
+  it('continuous_managers is OUT-of-v1 → APPROVAL_STEP_KIND_INVALID', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'continuous_managers', levels: 2 }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_INVALID' })
+  })
+
+  it('kind present but empty string → APPROVAL_STEP_KIND_INVALID', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: '' }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_INVALID' })
+  })
+
+  it('manager_at_level missing level → APPROVAL_STEP_LEVEL_INVALID', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'manager_at_level' }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_LEVEL_INVALID' })
+  })
+
+  it('manager_at_level non-integer level (1.5) → APPROVAL_STEP_LEVEL_INVALID', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'manager_at_level', level: 1.5 }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_LEVEL_INVALID' })
+  })
+
+  it('manager_at_level level 0 (below range) → APPROVAL_STEP_LEVEL_INVALID', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'manager_at_level', level: 0 }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_LEVEL_INVALID' })
+  })
+
+  it('manager_at_level level MAX+1 (11) → APPROVAL_STEP_LEVEL_INVALID (host-resolved bound)', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'manager_at_level', level: MAX + 1 }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_LEVEL_INVALID' })
+  })
+
+  it('level MAX+1 is a LEVEL error even with flag OFF (bound precedes availability — bound is load-bearing)', () => {
+    setFlag(false)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'manager_at_level', level: MAX + 1 }], makeContext())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_LEVEL_INVALID' })
+  })
+
+  it('a well-formed static step is accepted (no throw)', () => {
+    setFlag(false)
+    expect(httpCode(() => assertApprovalStepsContract([{ name: 'x', approverUserIds: ['u1'] }, {}], makeContext())))
+      .toBeNull()
+  })
+})
+
+describe('S7-1 assertApprovalStepsContract — availability gate (S7-1 fail-closed posture)', () => {
+  it('flag ON + no implemented kinds → well-formed direct_manager is APPROVAL_STEP_KIND_UNAVAILABLE', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'direct_manager' }], makeContext({ implementedKinds: [] }))))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_UNAVAILABLE' })
+  })
+
+  it('flag ON + no implemented kinds → well-formed manager_at_level (valid level) is UNAVAILABLE', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'manager_at_level', level: 3 }], makeContext({ implementedKinds: [] }))))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_UNAVAILABLE' })
+  })
+
+  it('flag OFF (even if a kind were implemented) → UNAVAILABLE', () => {
+    setFlag(false)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'direct_manager' }], makeContext({ implementedKinds: ['direct_manager'] }))))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_UNAVAILABLE' })
+  })
+
+  it('port absent + flag ON → UNAVAILABLE', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'direct_manager' }], makeContext({ port: false }))))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_UNAVAILABLE' })
+  })
+
+  it('NOT vacuous: flag ON + kind implemented → the well-formed dynamic step is accepted (forward-compat for S7-2+)', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract(
+      [{ kind: 'direct_manager' }, { kind: 'manager_at_level', level: MAX }],
+      makeContext({ implementedKinds: ['direct_manager', 'manager_at_level'] }),
+    ))).toBeNull()
+  })
+})
+
+describe('S7-1 assertDynamicFlowStepsRuntimeAvailable — §4.1 runtime fail-closed', () => {
+  const flow = () => normalizeApprovalSteps([{}, { kind: 'direct_manager' }])
+
+  it('whole-flow scan: a later dynamic step + flag OFF → throws (cannot start and strand)', () => {
+    setFlag(false)
+    expect(httpCode(() => assertDynamicFlowStepsRuntimeAvailable(flow(), makeContext())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_UNAVAILABLE' })
+  })
+
+  it('whole-flow scan: all-static flow → no throw (byte-identical legacy)', () => {
+    setFlag(false)
+    expect(httpCode(() => assertDynamicFlowStepsRuntimeAvailable(
+      normalizeApprovalSteps([{ approverUserIds: ['u1'] }, {}]),
+      makeContext(),
+    ))).toBeNull()
+  })
+
+  it('onlyStepIndex targets the step about to become active (advance): index 1 dynamic → throws', () => {
+    setFlag(false)
+    expect(httpCode(() => assertDynamicFlowStepsRuntimeAvailable(flow(), makeContext(), { onlyStepIndex: 1 })))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_UNAVAILABLE' })
+  })
+
+  it('onlyStepIndex 0 (static step 0) → no throw', () => {
+    setFlag(false)
+    expect(httpCode(() => assertDynamicFlowStepsRuntimeAvailable(flow(), makeContext(), { onlyStepIndex: 0 })))
+      .toBeNull()
+  })
+
+  it('port absent + dynamic step → throws (trigger set includes port-absent)', () => {
+    setFlag(true)
+    expect(httpCode(() => assertDynamicFlowStepsRuntimeAvailable(flow(), makeContext({ port: false }))))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_UNAVAILABLE' })
+  })
+
+  it('NOT vacuous: flag ON + kind implemented → dynamic step passes the runtime gate', () => {
+    setFlag(true)
+    expect(httpCode(() => assertDynamicFlowStepsRuntimeAvailable(
+      flow(),
+      makeContext({ implementedKinds: ['direct_manager'] }),
+    ))).toBeNull()
+  })
+})
+
+describe('S7-1 buildAttendanceApprovalAssignments — dynamic step never reaches the admin fallback', () => {
+  it('a dynamic current step throws APPROVAL_STEP_KIND_UNAVAILABLE (defense-in-depth)', () => {
+    expect(httpCode(() => buildAttendanceApprovalAssignments([{ kind: 'direct_manager' }], 0)))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_UNAVAILABLE' })
+  })
+
+  it('legacy static + empty-approver fallback behavior is preserved', () => {
+    expect(buildAttendanceApprovalAssignments([], 0)).toEqual([
+      { assignmentType: 'role', assigneeId: 'admin', sourceStep: 0, nodeKey: 'attendance_request_step_0', metadata: { source: 'attendance', queue: 'attendance-approval' } },
+      { assignmentType: 'source_queue', assigneeId: 'attendance:approve', sourceStep: 0, nodeKey: 'attendance_request_step_0', metadata: { source: 'attendance', queue: 'attendance-approval' } },
+      { assignmentType: 'source_queue', assigneeId: 'attendance:admin', sourceStep: 0, nodeKey: 'attendance_request_step_0', metadata: { source: 'attendance', queue: 'attendance-approval' } },
+    ])
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-approval-step-contract-s7-1.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-step-contract-s7-1.test.ts
@@ -245,9 +245,9 @@ describe('S7-1 assertDynamicFlowStepsRuntimeAvailable — §4.1 runtime fail-clo
 })
 
 describe('S7-1 buildAttendanceApprovalAssignments — dynamic step never reaches the admin fallback', () => {
-  it('a dynamic current step throws APPROVAL_STEP_KIND_UNAVAILABLE (defense-in-depth)', () => {
+  it('a dynamic current step throws APPROVAL_STEP_DYNAMIC_UNGATED (defense-in-depth, distinct from the gates)', () => {
     expect(httpCode(() => buildAttendanceApprovalAssignments([{ kind: 'direct_manager' }], 0)))
-      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_UNAVAILABLE' })
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_DYNAMIC_UNGATED' })
   })
 
   it('legacy static + empty-approver fallback behavior is preserved', () => {

--- a/packages/core-backend/tests/unit/attendance-approval-step-contract-s7-1.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-step-contract-s7-1.test.ts
@@ -111,6 +111,65 @@ describe('S7-1 assertApprovalStepsContract — discriminated-union authoring mat
       .toEqual({ status: 422, code: 'APPROVAL_STEP_STATIC_DYNAMIC_MIXED' })
   })
 
+  // Owner P2 (#4415 round 2): the lock's union is a KEY-shape constraint — an EMPTY array still carries
+  // the static key, so it must 422 MIXED, never be silently key-dropped by the normalizer.
+  it('dynamic + approverUserIds: [] (empty array carries the key) → MIXED', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'direct_manager', approverUserIds: [] }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_STATIC_DYNAMIC_MIXED' })
+  })
+
+  it('dynamic + approverRoleIds: [] (empty array carries the key) → MIXED', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'direct_manager', approverRoleIds: [] }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_STATIC_DYNAMIC_MIXED' })
+  })
+
+  it('dynamic + approverUserIds: null (JSON null carries the key) → MIXED', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'direct_manager', approverUserIds: null }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_STATIC_DYNAMIC_MIXED' })
+  })
+
+  it('undefined-valued approver keys are NOT mixing (normalizeApprovalStepPayload materializes both keys as undefined on every step)', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract(
+      [{ kind: 'manager_at_level', level: 2, approverUserIds: undefined, approverRoleIds: undefined }],
+      allImplemented(),
+    ))).toBeNull()
+  })
+
+  // Owner P2 (#4415 round 2): closed per-kind param union — {name, kind} ∪ ({level} iff manager_at_level).
+  it('direct_manager + level (no-param kind) → APPROVAL_STEP_PARAMS_INVALID', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'direct_manager', level: 2 }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_PARAMS_INVALID' })
+  })
+
+  it('dept_head + level (no-param kind) → APPROVAL_STEP_PARAMS_INVALID', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'dept_head', level: 1 }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_PARAMS_INVALID' })
+  })
+
+  it('unmodeled dynamic param (dept_head + target) → APPROVAL_STEP_PARAMS_INVALID', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'dept_head', target: 'x' }], allImplemented())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_PARAMS_INVALID' })
+  })
+
+  it('PARAMS_INVALID still surfaces with flag OFF + no implemented kinds (shape precedes availability)', () => {
+    setFlag(false)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 'direct_manager', level: 2 }], makeContext())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_PARAMS_INVALID' })
+  })
+
+  it('name + level on manager_at_level are inside the closed union (no throw)', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ name: '主管', kind: 'manager_at_level', level: 2 }], allImplemented())))
+      .toBeNull()
+  })
+
   it('unknown kind → APPROVAL_STEP_KIND_INVALID', () => {
     setFlag(true)
     expect(httpCode(() => assertApprovalStepsContract([{ kind: 'bogus_kind' }], allImplemented())))

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -267,6 +267,9 @@ export default defineConfig({
       // wired as a WHOLE FILE into the `Run attendance integration tests` step in plugin-tests.yml.
       'tests/integration/multitable-attachment-blob-purge.db.test.ts',
       'tests/integration/attendance-approval-action-authorization.db.test.ts',
+      // S7-1 real-DB: DATABASE_URL-gated describeIfDatabase, excluded from the no-DB default job so it
+      // cannot skip-green, and wired as a WHOLE FILE into `Run attendance integration tests` below.
+      'tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -112,6 +112,137 @@ const OUTDOOR_APPROVAL_EVENT_SOURCE = 'outdoor_approval'
 const RESERVED_EVENT_SOURCES = new Set([OUTDOOR_APPROVAL_EVENT_SOURCE])
 const ATTENDANCE_APPROVAL_WORKFLOW_KEY = 'attendance.request'
 const ATTENDANCE_APPROVAL_QUEUE_PERMISSIONS = ['attendance:approve', 'attendance:admin']
+
+// ── S7-1 dynamic approval-assignee sources (RATIFIED attendance-approval-s7 resolver design-lock) ──
+// The whole capability is a default-OFF, flag-gated opt-in (§5). Read the flag at REQUEST time (not at
+// activate) so a test / operator flip takes effect without a restart.
+const ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV = 'ATTENDANCE_APPROVAL_DYNAMIC_ASSIGNEE_SOURCES_ENABLED'
+// The DISCRIMINATED-UNION recognized dynamic-kind SET — the authoring schema's knowledge of "valid
+// dynamic kind". This is a v1 scope decision (OD-S7-2: manager_at_level is the ONLY chain reading;
+// `continuous_managers` is explicitly OUT — quorum-semantics gap), NOT a host-derived list. `resolve`
+// availability (below) is a SEPARATE, runtime concern layered on top of this shape recognition.
+const ATTENDANCE_DYNAMIC_ASSIGNEE_KINDS = ['direct_manager', 'dept_head', 'manager_at_level']
+const ATTENDANCE_MANAGER_AT_LEVEL_KIND = 'manager_at_level'
+
+function isAttendanceDynamicAssigneeFlagEnabled() {
+  return process.env[ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV] === 'true'
+}
+
+// Read the non-empty trimmed `kind` off a step, or null when the step is static (legacy). A single
+// definition so the classifier, normalizer, runtime gate, and buildAttendanceApprovalAssignments all
+// agree on what "dynamic" means.
+function getApprovalStepKind(step) {
+  if (!step || typeof step !== 'object') return null
+  const kind = typeof step.kind === 'string' ? step.kind.trim() : ''
+  return kind.length > 0 ? kind : null
+}
+
+// S7-1 §7 authoring gate — the DISCRIMINATED-UNION step contract, enforced on flow create AND update
+// against the RAW (zod-parsed) steps before persistence. Throws HttpError(422, <distinct code>, …) —
+// each violation carries a DISTINCT code so a test can assert the specific guard (and a mutation that
+// removes one guard reddens exactly its leg rather than being masked by a later 422). Order matters:
+//   1) static/dynamic mixing         → APPROVAL_STEP_STATIC_DYNAMIC_MIXED
+//   2) unknown kind (incl. the OUT-of-v1 continuous_managers) → APPROVAL_STEP_KIND_INVALID
+//   3) manager_at_level level shape (missing / non-integer / < 1 / > host MAX) → APPROVAL_STEP_LEVEL_INVALID
+//   4) availability (flag OFF / port absent / kind not resolver-implemented) → APPROVAL_STEP_KIND_UNAVAILABLE
+// The level UPPER bound uses the HOST-resolved MAX (context.services.approvalAssigneeResolver
+// .maxManagerChainLevels), never a plugin-parsed env — one source, two surfaces, no drift. At S7-1
+// `implementedKinds` is empty, so every well-formed dynamic step lands on (4) — correct and safe.
+function assertApprovalStepsContract(steps, context) {
+  if (!Array.isArray(steps)) return
+  const port = context && context.services ? context.services.approvalAssigneeResolver : undefined
+  const maxLevel = port && typeof port.maxManagerChainLevels === 'number' ? port.maxManagerChainLevels : null
+  const implementedKinds = port && Array.isArray(port.implementedKinds) ? port.implementedKinds : []
+  const flagEnabled = isAttendanceDynamicAssigneeFlagEnabled()
+
+  steps.forEach((rawStep, idx) => {
+    const step = rawStep && typeof rawStep === 'object' ? rawStep : {}
+    const stepLabel = `步骤 ${idx + 1}`
+    const kind = getApprovalStepKind(step)
+    if (!kind) {
+      // A `kind` key that is present but not a non-empty string is a malformed dynamic attempt — reject
+      // it rather than silently treating the step as static.
+      if (Object.prototype.hasOwnProperty.call(step, 'kind')) {
+        throw new HttpError(422, 'APPROVAL_STEP_KIND_INVALID', `${stepLabel}: kind 必须是非空字符串`)
+      }
+      return // static (or empty legacy) step — unchanged path, no dynamic validation
+    }
+
+    // (1) discriminated union: a dynamic step must NOT also carry static approver arrays.
+    const hasStaticApprovers =
+      (Array.isArray(step.approverUserIds) && step.approverUserIds.length > 0) ||
+      (Array.isArray(step.approverRoleIds) && step.approverRoleIds.length > 0)
+    if (hasStaticApprovers) {
+      throw new HttpError(
+        422,
+        'APPROVAL_STEP_STATIC_DYNAMIC_MIXED',
+        `${stepLabel}: 步骤为静态(approverUserIds/approverRoleIds)或动态(kind)二选一，不能同时存在`
+      )
+    }
+
+    // (2) recognized kind set (continuous_managers is OUT-of-v1, OD-S7-2).
+    if (!ATTENDANCE_DYNAMIC_ASSIGNEE_KINDS.includes(kind)) {
+      throw new HttpError(422, 'APPROVAL_STEP_KIND_INVALID', `${stepLabel}: 未知的动态审批人类型 "${kind}"`)
+    }
+
+    // (3) per-kind params — manager_at_level requires an integer level ∈ [1, host MAX].
+    if (kind === ATTENDANCE_MANAGER_AT_LEVEL_KIND) {
+      const level = step.level
+      if (typeof level !== 'number' || !Number.isInteger(level) || level < 1) {
+        throw new HttpError(422, 'APPROVAL_STEP_LEVEL_INVALID', `${stepLabel}: manager_at_level 需要 >= 1 的整数 level`)
+      }
+      if (maxLevel !== null && level > maxLevel) {
+        throw new HttpError(
+          422,
+          'APPROVAL_STEP_LEVEL_INVALID',
+          `${stepLabel}: manager_at_level 的 level 必须在 1 到 ${maxLevel} 之间`
+        )
+      }
+    }
+
+    // (4) availability — the kind must be BOTH flag-enabled AND resolver-implemented at this moment.
+    if (!flagEnabled || !port || !implementedKinds.includes(kind)) {
+      throw new HttpError(
+        422,
+        'APPROVAL_STEP_KIND_UNAVAILABLE',
+        `${stepLabel}: 动态审批人类型 "${kind}" 当前不可用(能力未启用或无对应 resolver)`
+      )
+    }
+  })
+}
+
+// S7-1 §4.1 RUNTIME fail-closed gate. Given NORMALIZED flow steps (post-normalizeApprovalSteps, which
+// preserves a dynamic step's `kind`), throw HttpError(422) if a dynamic step is encountered while the
+// trigger set holds: flag OFF, OR the context.services resolver port is absent, OR the kind is not
+// resolver-implemented (S7-1: none are). A flow with NO dynamic step is a no-op (byte-identical legacy).
+//   • request-create: pass no `onlyStepIndex` → WHOLE-flow scan, so a later dynamic step cannot start a
+//     flow and then strand mid-flight.
+//   • step-advance:   pass `onlyStepIndex = nextStepIndex` → check just the step about to become active.
+// NEVER falls through to the legacy admin fallback for a dynamic step.
+function assertDynamicFlowStepsRuntimeAvailable(normalizedSteps, context, options = {}) {
+  const steps = Array.isArray(normalizedSteps) ? normalizedSteps : []
+  let indices
+  if (Number.isInteger(options.onlyStepIndex)) {
+    indices = options.onlyStepIndex >= 0 && options.onlyStepIndex < steps.length ? [options.onlyStepIndex] : []
+  } else {
+    indices = steps.map((_, i) => i)
+  }
+  const port = context && context.services ? context.services.approvalAssigneeResolver : undefined
+  const implementedKinds = port && Array.isArray(port.implementedKinds) ? port.implementedKinds : []
+  const flagEnabled = isAttendanceDynamicAssigneeFlagEnabled()
+
+  for (const i of indices) {
+    const kind = getApprovalStepKind(steps[i])
+    if (!kind) continue
+    if (!flagEnabled || !port || !implementedKinds.includes(kind)) {
+      throw new HttpError(
+        422,
+        'APPROVAL_STEP_KIND_UNAVAILABLE',
+        `动态审批人类型 "${kind}" 无法解析(能力未启用、resolver 端口缺失或该类型未实现)——请求已阻断(fail-closed)`
+      )
+    }
+  }
+}
 const ATTENDANCE_SCHEDULE_GROUP_SOURCES = new Set(['manual', 'import', 'integration'])
 const ATTENDANCE_SCHEDULE_GROUP_MEMBER_ROLES = new Set(['member', 'lead', 'backup'])
 const ATTENDANCE_SCHEDULER_SCOPE_SUBJECT_TYPES = new Set(['user', 'role', 'role_tag'])
@@ -20517,6 +20648,22 @@ function normalizeApprovalSteps(value) {
     .map((step) => {
       if (!step || typeof step !== 'object') return null
       const name = typeof step.name === 'string' ? step.name : undefined
+      // S7-1 discriminated union: a step is EITHER dynamic (carries a `kind`) XOR static. The two
+      // silent-drop layers this replaces (old 3-key allowlist reconstruction + zod without passthrough)
+      // stripped any `kind` before persistence; preserve it here so a dynamic step survives end-to-end
+      // and the runtime fail-closed gate (§4.1) can see it. Authoring-time validity is enforced
+      // separately by assertApprovalStepsContract; this normalizer never rejects (it also runs on the
+      // runtime read path). A dynamic step deliberately drops the static approver arrays — kind wins,
+      // matching the mutually-exclusive contract — so a mixed step that ever bypassed authoring still
+      // fail-closes at runtime rather than routing to the legacy admin fallback.
+      const kind = getApprovalStepKind(step)
+      if (kind) {
+        const normalized = { name, kind }
+        if (kind === ATTENDANCE_MANAGER_AT_LEVEL_KIND && typeof step.level === 'number') {
+          normalized.level = step.level
+        }
+        return normalized
+      }
       const approverUserIds = Array.isArray(step.approverUserIds)
         ? step.approverUserIds.map(item => String(item)).filter(Boolean)
         : []
@@ -20552,6 +20699,19 @@ function buildAttendanceApprovalAssignments(flowSteps, stepIndex = 0) {
     ? Math.min(Math.max(Number.isFinite(Number(stepIndex)) ? Number(stepIndex) : 0, 0), steps.length - 1)
     : 0
   const currentStep = steps[index]
+  // S7-1 §4.1 defense-in-depth: a DYNAMIC-kind step must NEVER fall through to the legacy admin-queue
+  // fallback below (that fallback is reserved for LEGACY static steps with empty approver arrays). The
+  // runtime gates (request-create whole-flow scan + step-advance) block a dynamic step before this
+  // function is reached; arriving here with a dynamic current step means a gate was bypassed — fail
+  // closed with an explicit error instead of silently admin-routing the resolved-less step.
+  const dynamicKind = getApprovalStepKind(currentStep)
+  if (dynamicKind) {
+    throw new HttpError(
+      422,
+      'APPROVAL_STEP_KIND_UNAVAILABLE',
+      `动态审批人类型 "${dynamicKind}" 无对应 resolver(fail-closed)——不得回退到管理员兜底队列`
+    )
+  }
   const nodeKey = buildAttendanceApprovalNodeKey(index)
   const assignments = []
   const seen = new Set()
@@ -21119,6 +21279,15 @@ module.exports = {
     buildAttendanceApprovalNodeKey,
     buildAttendanceApprovalAssignments,
     buildAttendanceApprovalInstancePayload,
+    // S7-1 discriminated-union step contract + runtime fail-closed gate (pure; unit-tested seams).
+    normalizeApprovalSteps,
+    assertApprovalStepsContract,
+    assertDynamicFlowStepsRuntimeAvailable,
+    getApprovalStepKind,
+    isAttendanceDynamicAssigneeFlagEnabled,
+    ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV,
+    ATTENDANCE_DYNAMIC_ASSIGNEE_KINDS,
+    ATTENDANCE_MANAGER_AT_LEVEL_KIND,
   },
 
   async activate(context) {
@@ -24774,10 +24943,19 @@ module.exports = {
       })
     })
 
+    // S7-1: the persisted step is a DISCRIMINATED UNION (static XOR dynamic). zod lets the new
+    // `kind`/`level` fields SURVIVE parsing (they were silently stripped before — no passthrough +
+    // 3-key normalizer); the discriminated-union / enum-strict rejection is done by
+    // assertApprovalStepsContract in the create/update handlers so each violation gets a distinct 422
+    // code (not a generic 400 VALIDATION_ERROR). `level` is accepted as an unconstrained number here so
+    // a non-integer / out-of-range value reaches the contract validator's APPROVAL_STEP_LEVEL_INVALID
+    // arm rather than a zod 400. NOT a blanket `.passthrough()` — only the two modeled union fields.
     const approvalStepSchema = z.object({
       name: z.string().optional(),
       approverUserIds: z.array(z.string()).optional(),
       approverRoleIds: z.array(z.string()).optional(),
+      kind: z.string().optional(),
+      level: z.number().optional(),
     })
     const approvalFlowCreateSchema = z.object({
       name: z.string().min(1),
@@ -25014,6 +25192,10 @@ module.exports = {
             const approvalPayload = buildAttendanceApprovalInstancePayload({
               approvalId, requestId, orgId, userId, requesterName: getUserLabel(req, userId), draft,
             })
+            // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation: a dynamic-kind step
+            // anywhere in the flow blocks request-create (flag OFF / port missing / kind unimplemented),
+            // so a later dynamic step cannot start a flow and strand it mid-flight.
+            assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata.approvalFlow.steps), context)
             const approvalAssignments = buildAttendanceApprovalAssignments(draft.metadata.approvalFlow.steps, 0)
             try {
               const request = await db.transaction(async (trx) => {
@@ -27579,6 +27761,8 @@ module.exports = {
           requesterName: getUserLabel(req, userId),
           draft,
         })
+        // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
+        assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
         const approvalAssignments = buildAttendanceApprovalAssignments(draft.metadata?.approvalFlow?.steps, 0)
 
         try {
@@ -27906,6 +28090,8 @@ module.exports = {
               requesterName: getUserLabel(req, input.userId),
               draft,
             })
+            // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
+            assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
             const approvalAssignments = buildAttendanceApprovalAssignments(draft.metadata?.approvalFlow?.steps, 0)
             await upsertAttendanceApprovalInstance(trx, approvalPayload)
             await replaceAttendanceApprovalAssignments(trx, approvalId, approvalAssignments)
@@ -28321,6 +28507,8 @@ module.exports = {
               requesterName: getUserLabel(req, requesterSource.userId),
               draft,
             })
+            // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
+            assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
             const approvalAssignments = buildAttendanceApprovalAssignments(draft.metadata?.approvalFlow?.steps, 0)
             await upsertAttendanceApprovalInstance(trx, approvalPayload)
             await replaceAttendanceApprovalAssignments(trx, approvalId, approvalAssignments)
@@ -28825,6 +29013,8 @@ module.exports = {
               requesterName: existingRequest.user_id,
               draft,
             })
+            // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
+            assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
             const approvalAssignments = buildAttendanceApprovalAssignments(draft.metadata?.approvalFlow?.steps, 0)
             await upsertAttendanceApprovalInstance(trx, approvalPayload)
             await replaceAttendanceApprovalAssignments(trx, approvalId, approvalAssignments)
@@ -29020,6 +29210,14 @@ module.exports = {
           const resolvedAt = new Date()
 
           const nextStepIndex = isFinalApproval ? currentStepIndex : currentStepIndex + 1
+          // S7-1 §4.1 runtime fail-closed — step-advance: if the step about to become active is dynamic
+          // and the trigger set holds (flag OFF / port missing / kind unimplemented), fail BEFORE the
+          // approval_instances UPDATE and the assignment swap. This whole branch runs inside db.transaction,
+          // so the throw rolls back atomically — no advanced current_step, no swapped assignments, no
+          // appended approval record, and never the legacy admin fallback.
+          if (!isFinalApproval) {
+            assertDynamicFlowStepsRuntimeAvailable(flowSteps, context, { onlyStepIndex: nextStepIndex })
+          }
           await trx.query(
             `UPDATE approval_instances
              SET status = $1,
@@ -30394,6 +30592,11 @@ module.exports = {
           return
         }
 
+        // S7-1 §7 authoring gate — enforce the discriminated-union step contract on the RAW parsed steps
+        // (kind/level still present) before persistence. Throws HttpError(422, <distinct code>) → caught
+        // by withAnyPermission's wrapper. A malformed/unavailable dynamic kind can never round-trip inert.
+        assertApprovalStepsContract(parsed.data.steps, context)
+
         const orgId = getOrgId(req)
         const steps = normalizeApprovalSteps(parsed.data.steps)
         const payload = {
@@ -30446,6 +30649,10 @@ module.exports = {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
           return
         }
+
+        // S7-1 §7 authoring gate on update — same discriminated-union contract as create, applied to the
+        // RAW parsed steps when the update supplies them (undefined ⇒ no-op, existing steps untouched).
+        assertApprovalStepsContract(parsed.data.steps, context)
 
         const orgId = getOrgId(req)
         const flowId = normalizeUuidString(req.params.id)

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -138,16 +138,22 @@ function getApprovalStepKind(step) {
 }
 
 // S7-1 §7 authoring gate — the DISCRIMINATED-UNION step contract, enforced on flow create AND update
-// against the RAW (zod-parsed) steps before persistence. Throws HttpError(422, <distinct code>, …) —
-// each violation carries a DISTINCT code so a test can assert the specific guard (and a mutation that
+// against the PRE-zod raw steps (zod strips unmodeled keys, so only the raw payload can prove a dynamic
+// step carries nothing outside its closed union). Throws HttpError(422, <distinct code>, …) — each
+// violation carries a DISTINCT code so a test can assert the specific guard (and a mutation that
 // removes one guard reddens exactly its leg rather than being masked by a later 422). Order matters:
-//   1) static/dynamic mixing         → APPROVAL_STEP_STATIC_DYNAMIC_MIXED
+//   1) static/dynamic mixing — either approver KEY carried, even as an empty array; the lock constrains
+//      the union's key shape, not whether the approver set is non-empty → APPROVAL_STEP_STATIC_DYNAMIC_MIXED
 //   2) unknown kind (incl. the OUT-of-v1 continuous_managers) → APPROVAL_STEP_KIND_INVALID
-//   3) manager_at_level level shape (missing / non-integer / < 1 / > host MAX) → APPROVAL_STEP_LEVEL_INVALID
-//   4) availability (flag OFF / port absent / kind not resolver-implemented) → APPROVAL_STEP_KIND_UNAVAILABLE
-// The level UPPER bound uses the HOST-resolved MAX (context.services.approvalAssigneeResolver
-// .maxManagerChainLevels), never a plugin-parsed env — one source, two surfaces, no drift. At S7-1
-// `implementedKinds` is empty, so every well-formed dynamic step lands on (4) — correct and safe.
+//   3) closed per-kind param union — {name, kind} ∪ ({level} iff manager_at_level); any other key on a
+//      dynamic step 422s instead of being silently dropped downstream → APPROVAL_STEP_PARAMS_INVALID
+//   4) manager_at_level level shape (missing / non-integer / < 1 / > host MAX) → APPROVAL_STEP_LEVEL_INVALID
+//   5) availability (flag OFF / port absent / kind not resolver-implemented) → APPROVAL_STEP_KIND_UNAVAILABLE
+// Static (kind-less) steps return early: their legacy tolerance (unmodeled keys stripped by zod, A1
+// round-trip) is deliberately unchanged. The level UPPER bound uses the HOST-resolved MAX
+// (context.services.approvalAssigneeResolver.maxManagerChainLevels), never a plugin-parsed env — one
+// source, two surfaces, no drift. At S7-1 `implementedKinds` is empty, so every well-formed dynamic
+// step lands on (5) — correct and safe.
 function assertApprovalStepsContract(steps, context) {
   if (!Array.isArray(steps)) return
   const port = context && context.services ? context.services.approvalAssigneeResolver : undefined
@@ -168,15 +174,17 @@ function assertApprovalStepsContract(steps, context) {
       return // static (or empty legacy) step — unchanged path, no dynamic validation
     }
 
-    // (1) discriminated union: a dynamic step must NOT also carry static approver arrays.
-    const hasStaticApprovers =
-      (Array.isArray(step.approverUserIds) && step.approverUserIds.length > 0) ||
-      (Array.isArray(step.approverRoleIds) && step.approverRoleIds.length > 0)
-    if (hasStaticApprovers) {
+    // (1) discriminated union: a dynamic step must NOT carry either static approver KEY at all —
+    // carrying the key (even as `[]` or `null`) is mixing. The lock's union is a KEY-shape constraint
+    // (owner P2 on #4415): an empty array would otherwise be silently key-dropped by the normalizer,
+    // the exact silent-drop-instead-of-422 the contract forbids. "Carried" is value !== undefined, NOT
+    // hasOwnProperty: normalizeApprovalStepPayload materializes BOTH keys as `undefined` on every step
+    // (camel/snake alias resolution), so undefined here proves the client payload had no such key.
+    if (step.approverUserIds !== undefined || step.approverRoleIds !== undefined) {
       throw new HttpError(
         422,
         'APPROVAL_STEP_STATIC_DYNAMIC_MIXED',
-        `${stepLabel}: 步骤为静态(approverUserIds/approverRoleIds)或动态(kind)二选一，不能同时存在`
+        `${stepLabel}: 步骤为静态(approverUserIds/approverRoleIds)或动态(kind)二选一，不能同时携带两类键`
       )
     }
 
@@ -185,7 +193,23 @@ function assertApprovalStepsContract(steps, context) {
       throw new HttpError(422, 'APPROVAL_STEP_KIND_INVALID', `${stepLabel}: 未知的动态审批人类型 "${kind}"`)
     }
 
-    // (3) per-kind params — manager_at_level requires an integer level ∈ [1, host MAX].
+    // (3) closed per-kind param union: direct_manager/dept_head take NO params; only manager_at_level
+    // takes `level`. Any other key CARRIED on a dynamic step (value !== undefined, same semantics as
+    // the mixing check above) is rejected here — never silently dropped by zod/the normalizer.
+    const allowedDynamicKeys =
+      kind === ATTENDANCE_MANAGER_AT_LEVEL_KIND ? ['name', 'kind', 'level'] : ['name', 'kind']
+    for (const key of Object.keys(step)) {
+      if (step[key] === undefined) continue
+      if (!allowedDynamicKeys.includes(key)) {
+        throw new HttpError(
+          422,
+          'APPROVAL_STEP_PARAMS_INVALID',
+          `${stepLabel}: 动态步骤(${kind})不允许参数 "${key}"(合法键: ${allowedDynamicKeys.join('/')})`
+        )
+      }
+    }
+
+    // (4) per-kind params — manager_at_level requires an integer level ∈ [1, host MAX].
     if (kind === ATTENDANCE_MANAGER_AT_LEVEL_KIND) {
       const level = step.level
       if (typeof level !== 'number' || !Number.isInteger(level) || level < 1) {
@@ -200,7 +224,7 @@ function assertApprovalStepsContract(steps, context) {
       }
     }
 
-    // (4) availability — the kind must be BOTH flag-enabled AND resolver-implemented at this moment.
+    // (5) availability — the kind must be BOTH flag-enabled AND resolver-implemented at this moment.
     if (!flagEnabled || !port || !implementedKinds.includes(kind)) {
       throw new HttpError(
         422,
@@ -30590,16 +30614,18 @@ module.exports = {
       'POST',
       '/api/attendance/approval-flows',
       withPermission('attendance:admin', async (req, res) => {
-        const parsed = approvalFlowCreateSchema.safeParse(normalizeApprovalFlowPayload(req.body))
+        const rawPayload = normalizeApprovalFlowPayload(req.body)
+        const parsed = approvalFlowCreateSchema.safeParse(rawPayload)
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
           return
         }
 
-        // S7-1 §7 authoring gate — enforce the discriminated-union step contract on the RAW parsed steps
-        // (kind/level still present) before persistence. Throws HttpError(422, <distinct code>) → caught
-        // by withAnyPermission's wrapper. A malformed/unavailable dynamic kind can never round-trip inert.
-        assertApprovalStepsContract(parsed.data.steps, context)
+        // S7-1 §7 authoring gate — enforce the discriminated-union step contract on the PRE-zod raw
+        // steps (zod strips unmodeled keys, so only the raw shape can prove a dynamic step's closed
+        // union). Throws HttpError(422, <distinct code>) → caught by withAnyPermission's wrapper.
+        // A malformed/unavailable dynamic kind can never round-trip inert.
+        assertApprovalStepsContract(rawPayload.steps, context)
 
         const orgId = getOrgId(req)
         const steps = normalizeApprovalSteps(parsed.data.steps)
@@ -30648,15 +30674,16 @@ module.exports = {
       'PUT',
       '/api/attendance/approval-flows/:id',
       withPermission('attendance:admin', async (req, res) => {
-        const parsed = approvalFlowUpdateSchema.safeParse(normalizeApprovalFlowPayload(req.body ?? {}))
+        const rawPayload = normalizeApprovalFlowPayload(req.body ?? {})
+        const parsed = approvalFlowUpdateSchema.safeParse(rawPayload)
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
           return
         }
 
         // S7-1 §7 authoring gate on update — same discriminated-union contract as create, applied to the
-        // RAW parsed steps when the update supplies them (undefined ⇒ no-op, existing steps untouched).
-        assertApprovalStepsContract(parsed.data.steps, context)
+        // PRE-zod raw steps when the update supplies them (undefined ⇒ no-op, existing steps untouched).
+        assertApprovalStepsContract(rawPayload.steps, context)
 
         const orgId = getOrgId(req)
         const flowId = normalizeUuidString(req.params.id)

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -20706,10 +20706,14 @@ function buildAttendanceApprovalAssignments(flowSteps, stepIndex = 0) {
   // closed with an explicit error instead of silently admin-routing the resolved-less step.
   const dynamicKind = getApprovalStepKind(currentStep)
   if (dynamicKind) {
+    // DISTINCT code from the §4.1 gates' APPROVAL_STEP_KIND_UNAVAILABLE: reaching here means a runtime
+    // gate was BYPASSED (a "should never happen" internal invariant), not the normal feature-off /
+    // port-missing path — so removing a gate surfaces this alarming code instead of being masked by the
+    // gates' own code (which is what makes each gate independently mutation-provable).
     throw new HttpError(
       422,
-      'APPROVAL_STEP_KIND_UNAVAILABLE',
-      `动态审批人类型 "${dynamicKind}" 无对应 resolver(fail-closed)——不得回退到管理员兜底队列`
+      'APPROVAL_STEP_DYNAMIC_UNGATED',
+      `动态审批人类型 "${dynamicKind}" 未经运行时门控即到达指派构建(fail-closed)——不得回退到管理员兜底队列`
     )
   }
   const nodeKey = buildAttendanceApprovalNodeKey(index)


### PR DESCRIPTION
Implements slice **S7-1** of the RATIFIED attendance-approval-s7 resolver design-lock
(`docs/development/attendance-approval-s7-resolver-direct-manager-dept-head-multilevel-design-lock-20260716.md`).
This slice lands the **contract + seam + fail-closed gates ONLY** — the actual per-kind resolver logic
for `direct_manager` / `dept_head` / `manager_at_level` is S7-2/S7-3/S7-4. At S7-1 every dynamic kind
correctly hits the fail-closed path (no resolver yet ⇒ resolver-unavailable ⇒ 422 / block).

Refs the S7 lock (§4.1, §7 S7-1, OD-S7-5=d, §5). No issue-closing keywords.

## Discriminated-union step contract (§7 S7-1)

A persisted step is now **EITHER static** (`{name?, approverUserIds?, approverRoleIds?}`, NO `kind`)
**XOR dynamic** (`{name?, kind, ...params}`, NO static approver arrays), mutually exclusive. The two
silent-drop layers are opened so a `kind` survives to persistence:
- `normalizeApprovalSteps` (was: reconstruct from a 3-key allowlist) now preserves a dynamic step's
  `kind` (+ integer `level` for `manager_at_level`) and drops the static arrays (kind wins).
- the zod `approvalStepSchema` now models `kind`/`level` (NOT a blanket `.passthrough()` — only the two
  union fields), so they reach the handler instead of being stripped.

**Authoring 422 matrix** — enforced on flow **create** (`POST /api/attendance/approval-flows`) AND
**update** (`PUT …/:id`) by `assertApprovalStepsContract`, each violation with a DISTINCT code:
- static/dynamic mixed → `APPROVAL_STEP_STATIC_DYNAMIC_MIXED`
- unknown kind (incl. the OUT-of-v1 `continuous_managers`, OD-S7-2) → `APPROVAL_STEP_KIND_INVALID`
- `manager_at_level` missing / non-integer / out-of-range (`0` and MAX+1) level → `APPROVAL_STEP_LEVEL_INVALID`
- flag-off / port-absent / kind-not-resolver-implemented → `APPROVAL_STEP_KIND_UNAVAILABLE`

This mirrors the kernel's enum-strict validation (`ApprovalProductService.ts:512-519`, `:529-531`) and
the discriminated-union shape (`approval-product.ts:145-166`). At S7-1 `implementedKinds` is empty, so
even a shape-valid dynamic kind (flag ON) is `APPROVAL_STEP_KIND_UNAVAILABLE`.

## Host-resolved MAX_MANAGER_CHAIN_LEVELS (no plugin env re-parse)

The plugin does NOT re-parse `APPROVAL_MANAGER_CHAIN_MAX_LEVELS`. The `manager_at_level` level upper
bound is validated against the host-exposed `context.services.approvalAssigneeResolver.maxManagerChainLevels`,
which the host binds from the kernel constant `MAX_MANAGER_CHAIN_LEVELS` (`ApprovalDirectoryOrg.ts:101`,
default 10 `:76`, ceiling 50 `:79`) — one source, two surfaces, no drift.

## The `context.services` resolver port (OD-S7-5 = d)

Follows the existing `workdayCalendar` capability byte-for-byte, in the OPPOSITE direction (core-backend
is the PROVIDER, plugin-attendance the CONSUMER):
- **Port type** — `PluginServices.approvalAssigneeResolver?` in `packages/core-backend/src/types/plugin.ts`
  (optional, next to `workdayCalendar`): `readonly maxManagerChainLevels`, `readonly implementedKinds`
  (`[]` at S7-1), and an org-scoped `resolve(orgId, request)` (the §3.4 freeze seam, returns
  `{ status: 'unimplemented' }` for every kind at S7-1).
- **Host binding** — `buildApprovalAssigneeResolverPort()` in `packages/core-backend/src/index.ts`, wired
  into the per-plugin `services` object.
- **Consumer** — the plugin checks `context?.services?.approvalAssigneeResolver?.<member>` (same idiom it
  already uses for `workdayCalendar`) in the authoring gate and both runtime gates; a missing port ⇒
  fail-closed. This is the seam S7-2/S7-3/S7-4 fill.

## Runtime fail-closed (§4.1) — BOTH encounters, never the admin fallback

`assertDynamicFlowStepsRuntimeAvailable` blocks a dynamic-kind step before any mutation. **Trigger set:**
dynamic-assignee flag OFF, OR the resolver port absent, OR the kind not resolver-implemented.
- **request-create** — a WHOLE-flow scan at all five `buildAttendanceApprovalAssignments(steps, 0)` call
  sites (so a later dynamic step can't start a flow and strand mid-flight).
- **step-advance** — before the `UPDATE approval_instances` in `resolveRequest`; runs inside
  `db.transaction`, so a throw rolls back atomically (no advanced step, no swapped assignments, no record).
- `buildAttendanceApprovalAssignments` additionally fail-closes on a dynamic current step with a DISTINCT
  `APPROVAL_STEP_DYNAMIC_UNGATED` code (a "gate-bypassed" internal invariant), so it can NEVER route a
  dynamic step to the legacy `role:'admin'` + `source_queue` fallback — that fallback stays reserved for
  LEGACY static empty-approver steps only.

## Feature flag

`ATTENDANCE_APPROVAL_DYNAMIC_ASSIGNEE_SOURCES_ENABLED`, default **OFF**, read at request time. Flag-off is
byte-identical legacy behavior ONLY for flows with no dynamic kind; a flow that contains a dynamic kind
has no legacy behavior to match — under flag-off it fails-closed (§4.1), never the admin fallback.

## Tests + mutation evidence

- **Unit** (`tests/unit/attendance-approval-step-contract-s7-1.test.ts`, 28 tests, pure, auto-run by the
  required "Run core-backend tests" step): normalizer preservation; the full authoring matrix with
  distinct-code asserts + shape-precedes-availability ordering proofs; the runtime gate (whole-flow /
  onlyStepIndex / port-absent / flag toggling); a NOT-vacuous leg (flag ON + kind implemented ⇒ accepted);
  and the `buildAttendanceApprovalAssignments` defense-in-depth.
- **Real-DB** (`tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts`, 18 tests, wired
  into `plugin-tests.yml`'s attendance list + `vitest.config.ts` exclude — two-point CI wiring): the
  authoring 422 matrix on BOTH create and update; §4.1 (a) flag-off create ⇒ zero persisted rows; §4.1
  (b) approve step 1 into dynamic step 2 ⇒ rolled back with the instance still pending at step 1.
- **Mutation proofs** (applied, observed red, reverted, grep-verified restored):
  - remove the mixed-step rejection ⇒ 2 unit + 2 integration "mixed" legs red (code changes to
    `APPROVAL_STEP_KIND_UNAVAILABLE`);
  - remove the step-advance gate ⇒ the step-2 advance test reds (code changes to the distinct
    `APPROVAL_STEP_DYNAMIC_UNGATED` from the defense-in-depth, proving the gate — not the fallback throw —
    is the load-bearing §4.1 enforcement).
- CI-lane proof: the new real-DB file is in the `plugin-tests.yml` "Run attendance integration tests"
  vitest list AND the `vitest.config.ts` exclude (so it can't skip-green in the no-DB job).

## Local verification

`node --check` clean; `pnpm type-check` green (core-backend + apps/web); full default core-backend vitest
green (6673 passed / 1579 skipped, 0 failed — includes the 28 new unit tests); the 18 real-DB tests green
against a local Postgres. Regression-checked: the touched request-create / step-advance / approval-flow
routes are a no-op for static flows (each existing attendance integration file passes in isolation; the
only combined-run failures reproduce identically on clean `origin/main` — a pre-existing shared-DB
cross-file fixture collision, not this change).

Do NOT arm — Opus adversarial gate reviews first.
