### PR TITLE
docs(canonical-org): PB4-1..4 real merge SHAs + close pre-B4 hardening batch (held for ratification)

### DIFF
--- a/docs/development/canonical-org-mvp-progress-ledger-20260716.md
+++ b/docs/development/canonical-org-mvp-progress-ledger-20260716.md
@@ -11,15 +11,19 @@
 | **B1** | #4304 | `849f1d53d` | local provider bootstrap：get-or-create（普通 INSERT + 捕 23505 `isUniqueViolation` + re-select winner）；`one_active_local_integration_per_org` partial unique index；`local_integration_corp_id_shape` CHECK；创建审计 | 2（并发唯一性构造证明；CHECK 语义精确措辞）|
 | **B2** | #4317 | `bf52b9513` | 部门/账号/成员关系 CRUD + 8 条 admin 路由（`/api/admin/directory/local`）；fail-closed 字段白名单 + 严格类型校验（int4 有界；错误类型→400 且原值不变）；archive-not-delete；显式 primary 切换 | 2（类型强校验轮）|
 | **B3** | #4318 | `65dec7b36` | `is_manager` 一等主管关系（迁移 `zzzz20260715100000`）；双源 resolver precedence（`a.integration_id`+`d.integration_id` 双侧、DingTalk legacy 路径逐字不变）；membership PATCH 单请求单操作（isPrimary XOR isManager）+ `directory.local_membership.set_manager` 审计；writer 11 谓词守卫（org/integration 双侧/provider 三处/status='active'/account/department）| 3（可达性；双侧边界；三谓词轮）|
+| **PB4-1** | #4366 | `9a0f23037` | membership 输入 + 主切换原子性：非 UUID `membershipId`→**400**（路由 UUID 形状校验）；`switchLocalPrimaryDepartment` 单事务锁账号 + 全 membership 部门（`ORDER BY id FOR UPDATE`）、目标缺失不清旧主、UPDATE 只作用已核验集合 | 4（四锁点：before-any-DB-call 精确校验、gate-head 非 patch-identical 等）|
+| **PB4-2** | #4392 | `a993e8b84` | archive → 全只读，**write-point 强制**（每写函数同事务 `SELECT…FOR UPDATE`→分类→写）；主切换全只读 + 跨作用域越界整体 409 / 目标越界 404；manager writer 账号先于部门锁；404-vs-409 纪律；覆盖 route/service/B3 writer | ~5（TOCTOU→write-point 重写；P1b 越界 demotion；404-vs-409；provider-target route 测；gate 记录措辞）|
+| **PB4-3** | #4397 | `80f4aceae` | 部门环检测：事务内递归祖先 walk（child 命中新父祖先链→409、`path[]` 终止守卫）+ 每-integration `pg_advisory_xact_lock` 串行 reparent（防 disjoint cross-mount 4-环）+ 钉 READ COMMITTED | opus gate APPROVE（P3 = RC 钉线机制证已补）+ owner 审后落地 |
+| **PB4-4** | #4401 | `987bdc5e0` | 本地 integration 重激活：`getOrCreateLocalIntegration` 条件 UPDATE 就地复活同一稳定锚（`name=$2 AND status<>'active'` 竞态安全闩 → 同 id、子表存活、单 `directory.local_integration.reactivate` 审计）| 1（**owner 抓 P2**：并发 mutation 假绿 → 改 `pg_blocking_pids()` 确定性 barrier，删 latch 稳定多审计）|
 
 ## 2. 遗留限制（诚实清单，按归属批次）
 
-### pre-B4 hardening 小批次（不阻塞 B4 启动，**阻塞 Canonical Org MVP DONE**）
-- 非 UUID `membershipId` 进 `::uuid` cast → 500（应 400/404；B2/B3 同形）。
-- archive 不冻结后续写入（向已归档部门加成员、归档账号切 primary 均 200）。
-- 间接部门环可达（A→B→A；实测递归 CTE 无害终止，仍应规范化）。
-- B1 停用后同名重建撞 `UNIQUE(org_id, provider, name)`（B1 不宣称停用后自动重建）。
-- primary-switch 存在性检查移入事务并合成单 UPDATE（owner 判 P3 加固，非阻塞）。
+### pre-B4 hardening 小批次 — ✅ 全部闭合（PB4-1..4 已落地，2026-07-17）
+- ✅ 非 UUID `membershipId`→500 → **400**（PB4-1 `9a0f23037`：路由 UUID 形状校验）。
+- ✅ archive 不冻结后续写入 → **write-point FOR UPDATE 全只读**（PB4-2 `a993e8b84`：route/service/B3 writer 全覆盖）。
+- ✅ 间接部门环可达（A→B→A） → **事务内递归祖先 walk + 每-integration 串行 reparent**（PB4-3 `80f4aceae`）。
+- ✅ B1 停用后同名重建撞 `UNIQUE(org_id, provider, name)` → **getOrCreate 就地重激活同一稳定锚**（PB4-4 `987bdc5e0`）。
+- ✅ primary-switch 存在性检查移入事务并合成单 UPDATE（PB4-1/PB4-2 已含）。
 
 ### routing 加固批（B5/B6 期间处理）
 - resolver **读侧**不过滤 integration `status`：active 期间设置的 `is_manager` 在 integration
@@ -27,6 +31,9 @@
 - 主管**链**（chain hop）与**部门负责人**（dept head）仍走 legacy 源（B3 只泛化 direct-manager 步）。
 
 ## 3. 未开发（顺序 owner 已裁：串行）
+
+> **B4 门控（owner 2026-07-17）**：pre-B4 hardening 四票（PB4-1..4）已全部落地（§1 真实 merge SHA），
+> 但 **B4 在本台账「完成并审定」前继续冻结**。B5/B6 为 routing-core，建议 owner 先出/确认 §6 设计锁。
 
 - **B4** department binding 表（双侧 composite FK、provider-role 约束）→ **B5** 显式 `(org, purpose)`
   routing policy + 只读切换预览 → **B6** local/DingTalk 审批路由真库等价证明（首个真实消费者）→


### PR DESCRIPTION
## Ledger: PB4-1..4 real merge SHAs + pre-B4 hardening batch closed

> **Docs-only. Held for your ratification (审定)** — per your instruction, B4 stays frozen until this ledger is *完成并审定*. Unarmed.

Records the four landed pre-B4 hardening tickets in the persistent ledger (`canonical-org-mvp-progress-ledger-20260716.md`):

**§1 已落地 — added with real merge SHAs (all verified as ancestors of `main`):**
| 步 | PR | Merge SHA |
|---|---|---|
| PB4-1 | #4366 | `9a0f23037` |
| PB4-2 | #4392 | `a993e8b84` |
| PB4-3 | #4397 | `80f4aceae` |
| PB4-4 | #4401 | `987bdc5e0` (squash-merge 2026-07-17 01:24:45Z) |

Each row carries as-built content + honest review provenance — including your **PB4-4 P2 catch** (the bare-`Promise.all` concurrency mutation was false-green; fixed with a `pg_blocking_pids()` deterministic barrier).

**§2 pre-B4 hardening 小批次 — all five gaps marked ✅ closed**, each pointing at the ticket + SHA that closed it. Closures were **verified against the merged `main` code** (not just transcribed): PB4-1 UUID-shape guard, PB4-2 write-point `FOR UPDATE` (×15), PB4-3 recursive-CTE walk + advisory-lock serialization + cycle-detection test on main, PB4-4 reactivation latch + audit + test on main.

**§3** — notes B4 remains frozen until this ledger is completed and ratified; B5/B6 (routing-core) recommended to get owner design locks first.

No code change. When you ratify, this unlocks the B4 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
