### PR TITLE
fix(ops): normalize WinPS 5.1 native-pipeline BOM

### DIFF
--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -472,13 +472,12 @@ exec node "$(dirname "$0")/pm2-fixture.mjs" "$@"
     ($selectedTok -is [SecureString]) -and (-not [Environment]::GetEnvironmentVariable('METASHEET_ADMIN_TOKEN'))
   )
 
-  # WinPS 5.1 console-width wrap regression pin: a CRLF injected MID-TOKEN (as the 5.1 console host
-  # does when piping a long line to native stdin) must still parse - the helper strips raw CR/LF,
-  # which is provably safe for valid JSON.
-  $wrapJson = '[{"name":"metasheet-back' + "`r`n" + 'end","pm2_env":{"status":"onl' + "`r`n" + 'ine","restart_time":3,"pm_uptime":1000,"env":{"metasheet_admin_token":"LEAKED-WRAP-9911"}}}]'
-  $wrapped = Invoke-Pm2Projection $wrapJson
-  Check "pm2 projection: console-width CRLF wrap mid-token still parses and detects the leak" (
-    $wrapped.Exit -eq 0 -and $wrapped.Sample.state -eq 'online' -and $wrapped.Sample.adminTokenNonEmpty -eq $true -and $wrapped.Raw -notmatch 'LEAKED-WRAP-9911'
+  # WinPS 5.1 prefixes native string-pipeline input with U+FEFF. Pin the helper's exact input-boundary
+  # normalization in the cross-platform suite; the Desktop suite above exercises the real pipeline.
+  $bomJson = ([char]0xfeff) + '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":3,"pm_uptime":1000,"env":{"metasheet_admin_token":"LEAKED-BOM-9911"}}}]'
+  $bomProjected = Invoke-Pm2Projection $bomJson
+  Check "pm2 projection: leading UTF-8 BOM is normalized before parse" (
+    $bomProjected.Exit -eq 0 -and $bomProjected.Sample.state -eq 'online' -and $bomProjected.Sample.adminTokenNonEmpty -eq $true -and $bomProjected.Raw -notmatch 'LEAKED-BOM-9911'
   )
 
   # corrective-6: the PURE hygiene verdict is fail-closed (a stale packaged helper is a FAIL, not a skip).

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -14,8 +14,8 @@ $pass = 0; $fail = 0
 function Check { param([string]$Name, [bool]$Ok) if ($Ok) { $script:pass++; Write-Host "  PASS  $Name" } else { $script:fail++; Write-Host "  FAIL  $Name" } }
 
 function Invoke-Pm2Projection {
-  param([string]$Json)
-  $raw = $Json | & node $pm2SampleHelper 2>$null
+  param([string]$Json, [string[]]$HelperArgs = @())
+  $raw = $Json | & node $pm2SampleHelper @HelperArgs 2>$null
   $exit = $LASTEXITCODE
   $sample = if ($exit -eq 0 -and $raw) { $raw | ConvertFrom-Json } else { $null }
   [pscustomobject]@{ Exit = $exit; Raw = "$raw"; Sample = $sample }
@@ -438,6 +438,40 @@ exec node "$(dirname "$0")/pm2-fixture.mjs" "$@"
     $tokenClean.Exit -eq 0 -and $tokenClean.Sample.adminTokenNonEmpty -eq $false -and $tokenClean.Sample.authTokenNonEmpty -eq $false
   )
 
+  # Owner P2: Windows env names are case-insensitive — ANY case variant must count as leaked.
+  $tokenLower = Invoke-Pm2Projection '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":0,"pm_uptime":1,"env":{"metasheet_admin_token":"LEAKED-LOWER-9911"}}}]'
+  Check "pm2 projection: lower-case admin carrier variant still counts as leaked" (
+    $tokenLower.Exit -eq 0 -and $tokenLower.Sample.adminTokenNonEmpty -eq $true -and $tokenLower.Raw -notmatch 'LEAKED-LOWER-9911'
+  )
+  $tokenMixed = Invoke-Pm2Projection '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":0,"pm_uptime":1,"MetaSheet_Auth_Token":"LEAKED-MIXED-9911"}}]'
+  Check "pm2 projection: mixed-case auth carrier variant on pm2_env still counts as leaked" (
+    $tokenMixed.Exit -eq 0 -and $tokenMixed.Sample.authTokenNonEmpty -eq $true -and $tokenMixed.Raw -notmatch 'LEAKED-MIXED-9911'
+  )
+  # Owner P2: an operator-configured carrier (-AdminTokenEnvVar) is detected when passed to the
+  # helper — and deliberately NOT guessed when it is not configured.
+  $customCarrierJson = '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":0,"pm_uptime":1,"env":{"CUSTOM_ACCEPTANCE_TOKEN":"LEAKED-CUSTOM-9911"}}}]'
+  $customDetected = Invoke-Pm2Projection $customCarrierJson -HelperArgs @('CUSTOM_ACCEPTANCE_TOKEN')
+  Check "pm2 projection: configured custom carrier folds into adminTokenNonEmpty" (
+    $customDetected.Exit -eq 0 -and $customDetected.Sample.adminTokenNonEmpty -eq $true -and $customDetected.Raw -notmatch 'LEAKED-CUSTOM-9911'
+  )
+  $customUnconfigured = Invoke-Pm2Projection $customCarrierJson
+  Check "pm2 projection: an unconfigured custom carrier is not guessed" (
+    $customUnconfigured.Exit -eq 0 -and $customUnconfigured.Sample.adminTokenNonEmpty -eq $false
+  )
+
+  # Owner P1 (entry scrub, in-process legs): a token on an UNSELECTED carrier is scrubbed and NOT
+  # captured; the selected carrier is captured AND scrubbed.
+  $env:METASHEET_AUTH_TOKEN = 'PRESET-AUTH-9911'
+  $unselected = Read-AdminTokenSecureFromEnv
+  Check "entry scrub: unselected auth carrier -> scrubbed from env, nothing captured" (
+    ($null -eq $unselected) -and (-not [Environment]::GetEnvironmentVariable('METASHEET_AUTH_TOKEN'))
+  )
+  $env:METASHEET_ADMIN_TOKEN = 'PRESET-ADMIN-9911'
+  $selectedTok = Read-AdminTokenSecureFromEnv
+  Check "entry scrub: selected admin carrier -> captured as SecureString AND scrubbed from env" (
+    ($selectedTok -is [SecureString]) -and (-not [Environment]::GetEnvironmentVariable('METASHEET_ADMIN_TOKEN'))
+  )
+
   # corrective-6: the PURE hygiene verdict is fail-closed (a stale packaged helper is a FAIL, not a skip).
   # The runner GATES on `.ok` — every FAIL-side check asserts ok=false AND the coarse reason, so a
   # mutant that keeps the reason while flipping ok to true cannot survive (CM2 lesson).
@@ -450,6 +484,67 @@ exec node "$(dirname "$0")/pm2-fixture.mjs" "$@"
   $hAuth = Test-Pm2TokenHygieneSample ([pscustomobject]@{ adminTokenNonEmpty=$false; authTokenNonEmpty=$true })
   Check "hygiene: auth token non-empty -> FAIL with the dedicated coarse reason" ((-not $hAuth.ok) -and $hAuth.reason -eq 'PM2_ENV_METASHEET_AUTH_TOKEN_NONEMPTY')
   Check "hygiene: both clean -> ok" ((Test-Pm2TokenHygieneSample ([pscustomobject]@{ adminTokenNonEmpty=$false; authTokenNonEmpty=$false })).ok)
+
+  # Owner P2 (pre-PM2 guard load-bearing): run the REAL Invoke-Pm2StableStage in a child with a
+  # token preset and a marker-touching fake pm2 — the guard must stop the stage BEFORE pm2 ever runs
+  # and write the fixed hygiene failure. Neutering the condition or moving the guard after the
+  # restart makes the marker appear and this check red.
+  $guardRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("t9accept_guard_" + [guid]::NewGuid().ToString('N').Substring(0, 12))
+  New-Item -ItemType Directory -Path $guardRoot | Out-Null
+  $guardMarker = Join-Path $guardRoot 'pm2-invoked.marker'
+  $guardPm2Js = Join-Path $guardRoot 'pm2-fixture.mjs'
+  Set-Content -Path $guardPm2Js -Value @"
+#!/usr/bin/env node
+require('node:fs').writeFileSync(String.raw`$guardMarker`, 'invoked')
+"@ -NoNewline
+  if ($IsWindows) {
+    Set-Content -Path (Join-Path $guardRoot 'pm2.cmd') -Value "@echo off`r`nnode `"%~dp0pm2-fixture.mjs`" %*" -NoNewline
+  } else {
+    $guardPm2 = Join-Path $guardRoot 'pm2'
+    Set-Content -Path $guardPm2 -Value "#!/bin/sh`nexec node `"`$(dirname `"`$0`")/pm2-fixture.mjs`" `"`$@`"" -NoNewline
+    & chmod +x $guardPm2
+  }
+  $guardSummary = Join-Path $guardRoot 'guard-summary.txt'
+  $guardChild = Join-Path $guardRoot 'invoke-guard.ps1'
+  Set-Content -LiteralPath $guardChild -Encoding utf8 -Value @'
+param(
+  [Parameter(Mandatory = $true)][string]$AcceptanceScript,
+  [Parameter(Mandatory = $true)][string]$DeployRoot,
+  [Parameter(Mandatory = $true)][string]$SummaryPath,
+  [Parameter(Mandatory = $true)][string]$FakePm2Dir,
+  [string]$PresetAuthToken
+)
+$env:PATH = "$FakePm2Dir$([IO.Path]::PathSeparator)$env:PATH"
+$env:METASHEET_ADMIN_TOKEN = 'PRESET-GUARD-TOKEN-9911'
+if ($PresetAuthToken) { $env:METASHEET_AUTH_TOKEN = $PresetAuthToken }
+. $AcceptanceScript -PackagePath $DeployRoot -DeployRoot $DeployRoot -SummaryPath $SummaryPath *> $null
+if ($env:T9_GUARD_MODE -eq 'entry') { $null = Read-AdminTokenSecureFromEnv } else { Invoke-Pm2StableStage }
+exit 0
+'@
+  & pwsh -NoProfile -File $guardChild -AcceptanceScript $scriptPath -DeployRoot $guardRoot -SummaryPath $guardSummary -FakePm2Dir $guardRoot *> $null
+  $guardExit = $LASTEXITCODE
+  $guardJsonPath = [System.IO.Path]::ChangeExtension($guardSummary, '.json')
+  $guardJson = if (Test-Path $guardJsonPath) { Get-Content $guardJsonPath -Raw | ConvertFrom-Json } else { $null }
+  Check "pre-PM2 guard: token in runner env -> stage fails closed BEFORE pm2 is ever invoked" (
+    $guardExit -eq 1 -and (-not (Test-Path $guardMarker)) -and $null -ne $guardJson -and
+    $guardJson.failedStage -eq 'credentialHygiene' -and $guardJson.postRunCredentialHygiene -eq 'FAIL' -and
+    ((Get-Content $guardSummary -Raw) -match 'token_env_present_before_pm2')
+  )
+
+  # Owner P1 (multi-carrier entry, child leg): BOTH carriers non-empty -> fixed fail-closed reason
+  # before any stage; the summary carries the dedicated coarse reason.
+  $entrySummary = Join-Path $guardRoot 'entry-summary.txt'
+  $env:T9_GUARD_MODE = 'entry'
+  & pwsh -NoProfile -File $guardChild -AcceptanceScript $scriptPath -DeployRoot $guardRoot -SummaryPath $entrySummary -FakePm2Dir $guardRoot -PresetAuthToken 'PRESET-AUTH-AMBIG-9911' *> $null
+  $entryExit = $LASTEXITCODE
+  Remove-Item Env:T9_GUARD_MODE -ErrorAction SilentlyContinue
+  $entryJsonPath = [System.IO.Path]::ChangeExtension($entrySummary, '.json')
+  $entryJson = if (Test-Path $entryJsonPath) { Get-Content $entryJsonPath -Raw | ConvertFrom-Json } else { $null }
+  Check "entry scrub: MULTIPLE non-empty carriers -> fail-closed with the fixed reason before any stage" (
+    $entryExit -eq 1 -and $null -ne $entryJson -and
+    $entryJson.failedStage -eq 'credentialHygiene' -and $entryJson.postRunCredentialHygiene -eq 'FAIL' -and
+    ((Get-Content $entrySummary -Raw) -match 'multiple_token_carriers_present')
+  )
 
   Check "pm2: same restart_time + same uptime -> stable" ((Test-Pm2StableSample $base ([pscustomobject]@{ state='online'; restartTime=3; uptime=1000 })).ok)
   Check "pm2: restart_time incremented (crash-loop) -> FAIL (restart_loop)" ((Test-Pm2StableSample $base ([pscustomobject]@{ state='online'; restartTime=4; uptime=1000 })).reason -eq 'restart_loop')

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -472,6 +472,15 @@ exec node "$(dirname "$0")/pm2-fixture.mjs" "$@"
     ($selectedTok -is [SecureString]) -and (-not [Environment]::GetEnvironmentVariable('METASHEET_ADMIN_TOKEN'))
   )
 
+  # WinPS 5.1 console-width wrap regression pin: a CRLF injected MID-TOKEN (as the 5.1 console host
+  # does when piping a long line to native stdin) must still parse - the helper strips raw CR/LF,
+  # which is provably safe for valid JSON.
+  $wrapJson = '[{"name":"metasheet-back' + "`r`n" + 'end","pm2_env":{"status":"onl' + "`r`n" + 'ine","restart_time":3,"pm_uptime":1000,"env":{"metasheet_admin_token":"LEAKED-WRAP-9911"}}}]'
+  $wrapped = Invoke-Pm2Projection $wrapJson
+  Check "pm2 projection: console-width CRLF wrap mid-token still parses and detects the leak" (
+    $wrapped.Exit -eq 0 -and $wrapped.Sample.state -eq 'online' -and $wrapped.Sample.adminTokenNonEmpty -eq $true -and $wrapped.Raw -notmatch 'LEAKED-WRAP-9911'
+  )
+
   # corrective-6: the PURE hygiene verdict is fail-closed (a stale packaged helper is a FAIL, not a skip).
   # The runner GATES on `.ok` — every FAIL-side check asserts ok=false AND the coarse reason, so a
   # mutant that keeps the reason while flipping ok to true cannot survive (CM2 lesson).

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -368,9 +368,9 @@ Invoke-SmokeStage -Token $token
     $projected.Sample.restartTime -eq 3 -and
     $projected.Sample.uptime -eq 1000
   )
-  Check "pm2 projection: environment and sentinel values never cross the projection" (
+  Check "pm2 projection: environment and sentinel values never cross the projection (closed 5-key shape)" (
     $projected.Raw -notmatch $pm2Secret -and
-    @($projected.Sample.PSObject.Properties.Name).Count -eq 3
+    -not (Compare-Object @($projected.Sample.PSObject.Properties.Name) @('state','restartTime','uptime','adminTokenNonEmpty','authTokenNonEmpty'))
   )
 
   # Exercise the actual Get-Pm2Sample native-command pipeline, not only the helper in isolation. This
@@ -423,6 +423,27 @@ exec node "$(dirname "$0")/pm2-fixture.mjs" "$@"
   Check "pm2 projection: malformed counters fail closed with no output" (
     $invalidCounters.Exit -ne 0 -and -not $invalidCounters.Raw
   )
+
+  # corrective-6: token-hygiene projection over the REAL helper — booleans only, NEVER the value.
+  $tokenLeak = Invoke-Pm2Projection '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":0,"pm_uptime":1,"env":{"METASHEET_ADMIN_TOKEN":"LEAKED-TOKEN-VALUE-9911"}}}]'
+  Check "pm2 projection: admin token in the app env bag -> adminTokenNonEmpty=true, value NEVER echoed" (
+    $tokenLeak.Exit -eq 0 -and $tokenLeak.Sample.adminTokenNonEmpty -eq $true -and $tokenLeak.Sample.authTokenNonEmpty -eq $false -and $tokenLeak.Raw -notmatch 'LEAKED-TOKEN-VALUE-9911'
+  )
+  $tokenMerged = Invoke-Pm2Projection '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":0,"pm_uptime":1,"METASHEET_AUTH_TOKEN":"LEAKED-AUTH-VALUE-9911"}}]'
+  Check "pm2 projection: auth token merged into pm2_env (no env bag) -> authTokenNonEmpty=true, value NEVER echoed" (
+    $tokenMerged.Exit -eq 0 -and $tokenMerged.Sample.authTokenNonEmpty -eq $true -and $tokenMerged.Raw -notmatch 'LEAKED-AUTH-VALUE-9911'
+  )
+  $tokenClean = Invoke-Pm2Projection '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":0,"pm_uptime":1,"env":{"OTHER_VAR":"x"}}}]'
+  Check "pm2 projection: clean app env -> both hygiene booleans false" (
+    $tokenClean.Exit -eq 0 -and $tokenClean.Sample.adminTokenNonEmpty -eq $false -and $tokenClean.Sample.authTokenNonEmpty -eq $false
+  )
+
+  # corrective-6: the PURE hygiene verdict is fail-closed (a stale packaged helper is a FAIL, not a skip).
+  Check "hygiene: missing sample -> FAIL (sample_missing)" ((Test-Pm2TokenHygieneSample $null).reason -eq 'sample_missing')
+  Check "hygiene: projection without hygiene booleans -> FAIL (hygiene_fields_missing)" ((Test-Pm2TokenHygieneSample ([pscustomobject]@{ state='online'; restartTime=0; uptime=1 })).reason -eq 'hygiene_fields_missing')
+  Check "hygiene: admin token non-empty -> dedicated coarse reason" ((Test-Pm2TokenHygieneSample ([pscustomobject]@{ adminTokenNonEmpty=$true; authTokenNonEmpty=$false })).reason -eq 'PM2_ENV_METASHEET_ADMIN_TOKEN_NONEMPTY')
+  Check "hygiene: auth token non-empty -> dedicated coarse reason" ((Test-Pm2TokenHygieneSample ([pscustomobject]@{ adminTokenNonEmpty=$false; authTokenNonEmpty=$true })).reason -eq 'PM2_ENV_METASHEET_AUTH_TOKEN_NONEMPTY')
+  Check "hygiene: both clean -> ok" ((Test-Pm2TokenHygieneSample ([pscustomobject]@{ adminTokenNonEmpty=$false; authTokenNonEmpty=$false })).ok)
 
   Check "pm2: same restart_time + same uptime -> stable" ((Test-Pm2StableSample $base ([pscustomobject]@{ state='online'; restartTime=3; uptime=1000 })).ok)
   Check "pm2: restart_time incremented (crash-loop) -> FAIL (restart_loop)" ((Test-Pm2StableSample $base ([pscustomobject]@{ state='online'; restartTime=4; uptime=1000 })).reason -eq 'restart_loop')

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -439,10 +439,16 @@ exec node "$(dirname "$0")/pm2-fixture.mjs" "$@"
   )
 
   # corrective-6: the PURE hygiene verdict is fail-closed (a stale packaged helper is a FAIL, not a skip).
-  Check "hygiene: missing sample -> FAIL (sample_missing)" ((Test-Pm2TokenHygieneSample $null).reason -eq 'sample_missing')
-  Check "hygiene: projection without hygiene booleans -> FAIL (hygiene_fields_missing)" ((Test-Pm2TokenHygieneSample ([pscustomobject]@{ state='online'; restartTime=0; uptime=1 })).reason -eq 'hygiene_fields_missing')
-  Check "hygiene: admin token non-empty -> dedicated coarse reason" ((Test-Pm2TokenHygieneSample ([pscustomobject]@{ adminTokenNonEmpty=$true; authTokenNonEmpty=$false })).reason -eq 'PM2_ENV_METASHEET_ADMIN_TOKEN_NONEMPTY')
-  Check "hygiene: auth token non-empty -> dedicated coarse reason" ((Test-Pm2TokenHygieneSample ([pscustomobject]@{ adminTokenNonEmpty=$false; authTokenNonEmpty=$true })).reason -eq 'PM2_ENV_METASHEET_AUTH_TOKEN_NONEMPTY')
+  # The runner GATES on `.ok` — every FAIL-side check asserts ok=false AND the coarse reason, so a
+  # mutant that keeps the reason while flipping ok to true cannot survive (CM2 lesson).
+  $hMissing = Test-Pm2TokenHygieneSample $null
+  Check "hygiene: missing sample -> FAIL (sample_missing)" ((-not $hMissing.ok) -and $hMissing.reason -eq 'sample_missing')
+  $hStale = Test-Pm2TokenHygieneSample ([pscustomobject]@{ state='online'; restartTime=0; uptime=1 })
+  Check "hygiene: projection without hygiene booleans -> FAIL (hygiene_fields_missing)" ((-not $hStale.ok) -and $hStale.reason -eq 'hygiene_fields_missing')
+  $hAdmin = Test-Pm2TokenHygieneSample ([pscustomobject]@{ adminTokenNonEmpty=$true; authTokenNonEmpty=$false })
+  Check "hygiene: admin token non-empty -> FAIL with the dedicated coarse reason" ((-not $hAdmin.ok) -and $hAdmin.reason -eq 'PM2_ENV_METASHEET_ADMIN_TOKEN_NONEMPTY')
+  $hAuth = Test-Pm2TokenHygieneSample ([pscustomobject]@{ adminTokenNonEmpty=$false; authTokenNonEmpty=$true })
+  Check "hygiene: auth token non-empty -> FAIL with the dedicated coarse reason" ((-not $hAuth.ok) -and $hAuth.reason -eq 'PM2_ENV_METASHEET_AUTH_TOKEN_NONEMPTY')
   Check "hygiene: both clean -> ok" ((Test-Pm2TokenHygieneSample ([pscustomobject]@{ adminTokenNonEmpty=$false; authTokenNonEmpty=$false })).ok)
 
   Check "pm2: same restart_time + same uptime -> stable" ((Test-Pm2StableSample $base ([pscustomobject]@{ state='online'; restartTime=3; uptime=1000 })).ok)

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1
@@ -362,7 +362,7 @@ Invoke-SmokeStage -Token $token
   $pm2Secret = 'MAT-001-SECRET'
   $pm2WithDuplicateCaseKeys = '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":3,"pm_uptime":1000,"env":{"Path":"first","PATH":"second","MATERIAL":"' + $pm2Secret + '"}}}]'
   $projected = Invoke-Pm2Projection $pm2WithDuplicateCaseKeys
-  Check "pm2 projection: Path/PATH duplicate-case payload parses into the three-field sample" (
+  Check "pm2 projection: Path/PATH duplicate-case payload parses into the five-field sample" (
     $projected.Exit -eq 0 -and
     $projected.Sample.state -eq 'online' -and
     $projected.Sample.restartTime -eq 3 -and

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
@@ -133,18 +133,31 @@ if ($PSVersionTable.PSEdition -eq 'Desktop') {
   New-Item -ItemType Directory -Path $hygieneDir | Out-Null
   try {
     # -Encoding ASCII is LOAD-BEARING: Windows PowerShell 5.1 Set-Content defaults to UTF-16LE,
-    # and a BOM'd .mjs/.cmd fixture cannot be executed by node/cmd (entity re-review finding).
-    Set-Content -Path (Join-Path $hygieneDir 'pm2-fixture.mjs') -Encoding ASCII -Value @'
+    # and a BOM'd .mjs fixture cannot be executed by node (entity re-review finding).
+    $hygieneFixture = Join-Path $hygieneDir 'pm2-fixture.mjs'
+    Set-Content -Path $hygieneFixture -Encoding ASCII -Value @'
 #!/usr/bin/env node
 if (process.argv[2] !== 'jlist') process.exit(2)
 process.stdout.write(process.env.T9_PS51_JLIST || '')
 '@ -NoNewline
-    Set-Content -Path (Join-Path $hygieneDir 'pm2.cmd') -Encoding ASCII -Value "@echo off`r`nnode `"%~dp0pm2-fixture.mjs`" %*" -NoNewline
-    $oldPath = $env:PATH
+    # A FUNCTION shim (not a PATH .cmd): PowerShell resolves functions ahead of external commands
+    # and without PATH-cache refresh semantics, which differ between WinPS 5.1 and pwsh — the
+    # runner's own `& pm2` call inside Get-Pm2Sample resolves to this shim deterministically.
+    $script:T9Ps51HygieneFixture = $hygieneFixture
+    function script:pm2 {
+      param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Pm2Args)
+      & node $script:T9Ps51HygieneFixture @Pm2Args
+    }
     try {
-      $env:PATH = "$hygieneDir;$oldPath"
       $env:T9_PS51_JLIST = '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":3,"pm_uptime":1000,"env":{"Path":"first","PATH":"second","metasheet_admin_token":"LEAKED-PS51-9911"}}}]'
       $leakSample = Get-Pm2Sample
+      if ($null -eq $leakSample) {
+        # Values-free localization (exit codes / lengths / booleans only — never payloads).
+        $helperPath = Join-Path $opsDir 'stock-preparation-pm2-sample.mjs'
+        $shimRaw = (& pm2 jlist 2>$null); $shimExit = $LASTEXITCODE
+        $directRaw = ($env:T9_PS51_JLIST | & node $helperPath 'METASHEET_ADMIN_TOKEN' 2>$null); $directExit = $LASTEXITCODE
+        Write-Host ("  DIAG ps51-hygiene: helperExists=" + (Test-Path -LiteralPath $helperPath) + " shimExit=$shimExit shimLen=" + ("$shimRaw").Length + " directExit=$directExit directLen=" + ("$directRaw").Length)
+      }
       Check 'ps51 hygiene: case-variant admin token projects to adminTokenNonEmpty=true through the 5.1 pipeline' (
         $null -ne $leakSample -and $leakSample.adminTokenNonEmpty -eq $true -and $leakSample.authTokenNonEmpty -eq $false
       )
@@ -162,8 +175,8 @@ process.stdout.write(process.env.T9_PS51_JLIST || '')
         (Test-Pm2TokenHygieneSample ([pscustomobject]@{ state = 'online'; restartTime = 3; uptime = 1000 })).reason -eq 'hygiene_fields_missing'
       )
     } finally {
-      $env:PATH = $oldPath
       Remove-Item Env:T9_PS51_JLIST -ErrorAction SilentlyContinue
+      Remove-Item Function:script:pm2 -ErrorAction SilentlyContinue
     }
   } finally {
     Remove-Item -Recurse -Force $hygieneDir -ErrorAction SilentlyContinue

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
@@ -123,6 +123,51 @@ try {
   Remove-Item Env:METASHEET_AUTH_TOKEN -ErrorAction SilentlyContinue
 }
 
+
+# ── corrective-6: token-hygiene projection + verdict under REAL Windows PowerShell 5.1 ───────────
+# (PSObject.Properties indexing, [bool] typing, .cmd PATH shim, ConvertFrom-Json of the 5-key
+# sample). Desktop-gated: on any other host the suite ALREADY fails loudly at the host check above,
+# so this can never green-skip.
+if ($PSVersionTable.PSEdition -eq 'Desktop') {
+  $hygieneDir = Join-Path ([System.IO.Path]::GetTempPath()) ("t9ps51_pm2_" + [guid]::NewGuid().ToString('N').Substring(0, 12))
+  New-Item -ItemType Directory -Path $hygieneDir | Out-Null
+  try {
+    Set-Content -Path (Join-Path $hygieneDir 'pm2-fixture.mjs') -Value @'
+#!/usr/bin/env node
+if (process.argv[2] !== 'jlist') process.exit(2)
+process.stdout.write(process.env.T9_PS51_JLIST || '')
+'@ -NoNewline
+    Set-Content -Path (Join-Path $hygieneDir 'pm2.cmd') -Value "@echo off`r`nnode `"%~dp0pm2-fixture.mjs`" %*" -NoNewline
+    $oldPath = $env:PATH
+    try {
+      $env:PATH = "$hygieneDir;$oldPath"
+      $env:T9_PS51_JLIST = '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":3,"pm_uptime":1000,"env":{"Path":"first","PATH":"second","metasheet_admin_token":"LEAKED-PS51-9911"}}}]'
+      $leakSample = Get-Pm2Sample
+      Check 'ps51 hygiene: case-variant admin token projects to adminTokenNonEmpty=true through the 5.1 pipeline' (
+        $null -ne $leakSample -and $leakSample.adminTokenNonEmpty -eq $true -and $leakSample.authTokenNonEmpty -eq $false
+      )
+      $leakVerdict = Test-Pm2TokenHygieneSample $leakSample
+      Check 'ps51 hygiene: leaked sample fails closed with the dedicated coarse reason' (
+        (-not $leakVerdict.ok) -and $leakVerdict.reason -eq 'PM2_ENV_METASHEET_ADMIN_TOKEN_NONEMPTY'
+      )
+      $env:T9_PS51_JLIST = '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":3,"pm_uptime":1000,"env":{"Path":"first","PATH":"second"}}}]'
+      $cleanSample = Get-Pm2Sample
+      $cleanVerdict = Test-Pm2TokenHygieneSample $cleanSample
+      Check 'ps51 hygiene: clean env parses and passes under 5.1' (
+        $null -ne $cleanSample -and $cleanSample.adminTokenNonEmpty -eq $false -and $cleanVerdict.ok
+      )
+      Check 'ps51 hygiene: stale projection without booleans fails closed' (
+        (Test-Pm2TokenHygieneSample ([pscustomobject]@{ state = 'online'; restartTime = 3; uptime = 1000 })).reason -eq 'hygiene_fields_missing'
+      )
+    } finally {
+      $env:PATH = $oldPath
+      Remove-Item Env:T9_PS51_JLIST -ErrorAction SilentlyContinue
+    }
+  } finally {
+    Remove-Item -Recurse -Force $hygieneDir -ErrorAction SilentlyContinue
+  }
+}
+
 if ($fail -gt 0) {
   Write-Host "FAILED: $fail check(s); $pass passed"
   exit 1

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
@@ -152,11 +152,18 @@ process.stdout.write(process.env.T9_PS51_JLIST || '')
       $env:T9_PS51_JLIST = '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":3,"pm_uptime":1000,"env":{"Path":"first","PATH":"second","metasheet_admin_token":"LEAKED-PS51-9911"}}}]'
       $leakSample = Get-Pm2Sample
       if ($null -eq $leakSample) {
-        # Values-free localization (exit codes / lengths / booleans only — never payloads).
+        # Values-free localization (exit codes / lengths / redacted first-line only — never payloads).
         $helperPath = Join-Path $opsDir 'stock-preparation-pm2-sample.mjs'
         $shimRaw = (& pm2 jlist 2>$null); $shimExit = $LASTEXITCODE
         $directRaw = ($env:T9_PS51_JLIST | & node $helperPath 'METASHEET_ADMIN_TOKEN' 2>$null); $directExit = $LASTEXITCODE
-        Write-Host ("  DIAG ps51-hygiene: helperExists=" + (Test-Path -LiteralPath $helperPath) + " shimExit=$shimExit shimLen=" + ("$shimRaw").Length + " directExit=$directExit directLen=" + ("$directRaw").Length)
+        $directErr = ''
+        try { $directErr = (($env:T9_PS51_JLIST | & node $helperPath 'METASHEET_ADMIN_TOKEN' 2>&1 1>$null) | Out-String) } catch { $directErr = "thrown:$($_.Exception.GetType().Name)" }
+        $directErr = ($directErr -replace 'LEAKED-PS51-9911', '<REDACTED>')
+        if ($directErr.Length -gt 200) { $directErr = $directErr.Substring(0, 200) }
+        $evtProbe = ('hello' | & node -e "let r='';process.stdin.on('data',d=>r+=d).on('end',()=>console.log('EVT='+r.length))" 2>$null); $evtExit = $LASTEXITCODE
+        $aitProbe = ('hello' | & node --input-type=module -e "let r='';for await (const c of process.stdin) r+=c; console.log('AIT='+r.length)" 2>$null); $aitExit = $LASTEXITCODE
+        Write-Host ("  DIAG ps51-hygiene: helperExists=" + (Test-Path -LiteralPath $helperPath) + " shimExit=$shimExit shimLen=" + ("$shimRaw").Length + " directExit=$directExit directLen=" + ("$directRaw").Length + " evt=[$evtProbe/$evtExit] ait=[$aitProbe/$aitExit]")
+        Write-Host ("  DIAG ps51-hygiene stderr: [" + $directErr.Trim() + "]")
       }
       Check 'ps51 hygiene: case-variant admin token projects to adminTokenNonEmpty=true through the 5.1 pipeline' (
         $null -ne $leakSample -and $leakSample.adminTokenNonEmpty -eq $true -and $leakSample.authTokenNonEmpty -eq $false

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
@@ -125,15 +125,14 @@ try {
 
 
 # ── corrective-6: token-hygiene projection + verdict under REAL Windows PowerShell 5.1 ───────────
-# (PSObject.Properties indexing, [bool] typing, .cmd PATH shim, ConvertFrom-Json of the 5-key
-# sample). Desktop-gated: on any other host the suite ALREADY fails loudly at the host check above,
-# so this can never green-skip.
+# (PSObject.Properties indexing, [bool] typing, function shim, native-pipeline BOM normalization,
+# ConvertFrom-Json of the 5-key sample). Desktop-gated: on any other host the suite ALREADY fails
+# loudly at the host check above, so this can never green-skip.
 if ($PSVersionTable.PSEdition -eq 'Desktop') {
   $hygieneDir = Join-Path ([System.IO.Path]::GetTempPath()) ("t9ps51_pm2_" + [guid]::NewGuid().ToString('N').Substring(0, 12))
   New-Item -ItemType Directory -Path $hygieneDir | Out-Null
   try {
-    # -Encoding ASCII is LOAD-BEARING: Windows PowerShell 5.1 Set-Content defaults to UTF-16LE,
-    # and a BOM'd .mjs fixture cannot be executed by node (entity re-review finding).
+    # Keep the generated Node fixture byte-stable across Desktop and Core hosts.
     $hygieneFixture = Join-Path $hygieneDir 'pm2-fixture.mjs'
     Set-Content -Path $hygieneFixture -Encoding ASCII -Value @'
 #!/usr/bin/env node
@@ -151,20 +150,6 @@ process.stdout.write(process.env.T9_PS51_JLIST || '')
     try {
       $env:T9_PS51_JLIST = '[{"name":"metasheet-backend","pm2_env":{"status":"online","restart_time":3,"pm_uptime":1000,"env":{"Path":"first","PATH":"second","metasheet_admin_token":"LEAKED-PS51-9911"}}}]'
       $leakSample = Get-Pm2Sample
-      if ($null -eq $leakSample) {
-        # Values-free localization (exit codes / lengths / redacted first-line only — never payloads).
-        $helperPath = Join-Path $opsDir 'stock-preparation-pm2-sample.mjs'
-        $shimRaw = (& pm2 jlist 2>$null); $shimExit = $LASTEXITCODE
-        $directRaw = ($env:T9_PS51_JLIST | & node $helperPath 'METASHEET_ADMIN_TOKEN' 2>$null); $directExit = $LASTEXITCODE
-        $directErr = ''
-        try { $directErr = (($env:T9_PS51_JLIST | & node $helperPath 'METASHEET_ADMIN_TOKEN' 2>&1 1>$null) | Out-String) } catch { $directErr = "thrown:$($_.Exception.GetType().Name)" }
-        $directErr = ($directErr -replace 'LEAKED-PS51-9911', '<REDACTED>')
-        if ($directErr.Length -gt 200) { $directErr = $directErr.Substring(0, 200) }
-        $evtProbe = ('hello' | & node -e "let r='';process.stdin.on('data',d=>r+=d).on('end',()=>console.log('EVT='+r.length))" 2>$null); $evtExit = $LASTEXITCODE
-        $aitProbe = ('hello' | & node --input-type=module -e "let r='';for await (const c of process.stdin) r+=c; console.log('AIT='+r.length)" 2>$null); $aitExit = $LASTEXITCODE
-        Write-Host ("  DIAG ps51-hygiene: helperExists=" + (Test-Path -LiteralPath $helperPath) + " shimExit=$shimExit shimLen=" + ("$shimRaw").Length + " directExit=$directExit directLen=" + ("$directRaw").Length + " evt=[$evtProbe/$evtExit] ait=[$aitProbe/$aitExit]")
-        Write-Host ("  DIAG ps51-hygiene stderr: [" + $directErr.Trim() + "]")
-      }
       Check 'ps51 hygiene: case-variant admin token projects to adminTokenNonEmpty=true through the 5.1 pipeline' (
         $null -ne $leakSample -and $leakSample.adminTokenNonEmpty -eq $true -and $leakSample.authTokenNonEmpty -eq $false
       )

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.ps51.tests.ps1
@@ -132,12 +132,14 @@ if ($PSVersionTable.PSEdition -eq 'Desktop') {
   $hygieneDir = Join-Path ([System.IO.Path]::GetTempPath()) ("t9ps51_pm2_" + [guid]::NewGuid().ToString('N').Substring(0, 12))
   New-Item -ItemType Directory -Path $hygieneDir | Out-Null
   try {
-    Set-Content -Path (Join-Path $hygieneDir 'pm2-fixture.mjs') -Value @'
+    # -Encoding ASCII is LOAD-BEARING: Windows PowerShell 5.1 Set-Content defaults to UTF-16LE,
+    # and a BOM'd .mjs/.cmd fixture cannot be executed by node/cmd (entity re-review finding).
+    Set-Content -Path (Join-Path $hygieneDir 'pm2-fixture.mjs') -Encoding ASCII -Value @'
 #!/usr/bin/env node
 if (process.argv[2] !== 'jlist') process.exit(2)
 process.stdout.write(process.env.T9_PS51_JLIST || '')
 '@ -NoNewline
-    Set-Content -Path (Join-Path $hygieneDir 'pm2.cmd') -Value "@echo off`r`nnode `"%~dp0pm2-fixture.mjs`" %*" -NoNewline
+    Set-Content -Path (Join-Path $hygieneDir 'pm2.cmd') -Encoding ASCII -Value "@echo off`r`nnode `"%~dp0pm2-fixture.mjs`" %*" -NoNewline
     $oldPath = $env:PATH
     try {
       $env:PATH = "$hygieneDir;$oldPath"

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
@@ -137,15 +137,43 @@ $expectedFields = @(
   'mvpSmoke.pass','auditActionsCovered','selfScanClean',
   'mvpSmoke.failureClass','mvpSmoke.lastCompletedPhase','mvpSmoke.firstFailedCheck',
   'mvpSmoke.failedCheckCount','mvpSmoke.responseLeakScanStatus',
-  'externalPlmK3ErpWrite','failedStage'
+  'externalPlmK3ErpWrite','postRunCredentialHygiene','failedStage'
 )
 $summaryBlock = if ($src -match "(?s)\`$Summary = \[ordered\]@\{(.*?)\}") { $Matches[1] } else { '' }
 $foundKeys = [regex]::Matches($summaryBlock, "(?m)^\s*'?([A-Za-z0-9.]+)'?\s*=") | ForEach-Object { $_.Groups[1].Value }
-Check "summary declares exactly the 14 whitelisted fields" (
-  ($foundKeys.Count -eq 14) -and (($expectedFields | Where-Object { $_ -notin $foundKeys }).Count -eq 0)
+Check "summary declares exactly the 15 whitelisted fields" (
+  ($foundKeys.Count -eq 15) -and (($expectedFields | Where-Object { $_ -notin $foundKeys }).Count -eq 0)
 )
 Check "summary has NO value-plane field (drawing/qty/unit/material/host/token)" (
   -not ($summaryBlock -match '(?i)drawing|qty|quantity|unit|material|host|token|password|secret|projectName')
+)
+
+# ── 1b. corrective-6 token-hygiene wiring (entity FAIL ACCEPTANCE_TOKEN_PERSISTED_IN_PM2_ENV) ────
+# The token must be read+scrubbed at the TOP of the orchestration (before ANY stage can spawn a
+# child that inherits the env), the pm2 stage must assert the runner env is token-free before the
+# restart, and a post-run hygiene stage must run between the smoke stage and Emit-Summary.
+$orchestrationStart = $src.IndexOf("if (`$MyInvocation.InvocationName -ne '.')")
+$orchestration = $src.Substring([Math]::Max($orchestrationStart, 0))
+Check "env-var token is read+scrubbed BEFORE the first stage in the orchestration" (
+  $orchestrationStart -ge 0 -and
+  $orchestration.IndexOf('Read-AdminTokenSecureFromEnv') -ge 0 -and
+  $orchestration.IndexOf('Read-AdminTokenSecureFromEnv') -lt $orchestration.IndexOf('Invoke-ShaStage')
+)
+Check "post-run hygiene stage runs after the smoke stage and before Emit-Summary" (
+  $orchestration.IndexOf('Invoke-PostRunHygieneStage') -gt $orchestration.IndexOf('Invoke-SmokeStage') -and
+  $orchestration.IndexOf('Invoke-PostRunHygieneStage') -lt $orchestration.IndexOf('Emit-Summary')
+)
+Check "pm2 stage asserts the runner env is token-free before the restart" (
+  $src -match 'token_env_present_before_pm2'
+)
+Check "hygiene verdict is fail-closed and values-free (fixed coarse reasons)" (
+  $src -match 'sample_missing' -and $src -match 'hygiene_fields_missing' -and
+  $src -match 'PM2_ENV_METASHEET_ADMIN_TOKEN_NONEMPTY' -and $src -match 'PM2_ENV_METASHEET_AUTH_TOKEN_NONEMPTY'
+)
+$pm2HelperSrc = Get-Content $pm2SampleHelper -Raw
+Check "pm2 projection helper reports token presence as BOOLEANS (never values)" (
+  $pm2HelperSrc -match 'adminTokenNonEmpty' -and $pm2HelperSrc -match 'authTokenNonEmpty' -and
+  $pm2HelperSrc -match 'METASHEET_ADMIN_TOKEN' -and $pm2HelperSrc -match 'tokenNonEmpty'
 )
 
 # ── 2. Token discipline. ─────────────────────────────────────────────────────────────────────────

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
@@ -130,7 +130,7 @@ Check "PM2 projection helper is required by the on-prem package build" (
   $packageBuildSrc -match '"scripts/ops/stock-preparation-pm2-sample\.mjs"'
 )
 
-# ── 1. Summary is values-free by construction: exactly the 14 whitelisted keys, nothing else. ────
+# ── 1. Summary is values-free by construction: exactly the 15 whitelisted keys, nothing else. ────
 # (9 original + 5 corrective-5 bounded diagnostics; every added default is a fixed enum / integer.)
 $expectedFields = @(
   'packageShaMatch','migrationStatus','pm2StableOnline','healthcheck',

--- a/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
+++ b/scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1
@@ -2,7 +2,7 @@
 # Static contract tests for stock-preparation-onprem-acceptance.ps1 (#3751 T9).
 # The full deploy path is Windows-only and cannot run in CI/sandbox, so these lock the two
 # security-critical, statically-verifiable invariants: (1) the summary is values-free by construction
-# (exactly the 9 whitelisted fields), (2) the admin token never crosses into the summary / a file /
+# (exactly the 15 whitelisted fields), (2) the admin token never crosses into the summary / a file /
 # a log — it only ever rides a scoped process env var that is cleared in a finally.
 $ErrorActionPreference = 'Stop'
 $script = Join-Path $PSScriptRoot '..' 'stock-preparation-onprem-acceptance.ps1'
@@ -173,7 +173,14 @@ Check "hygiene verdict is fail-closed and values-free (fixed coarse reasons)" (
 $pm2HelperSrc = Get-Content $pm2SampleHelper -Raw
 Check "pm2 projection helper reports token presence as BOOLEANS (never values)" (
   $pm2HelperSrc -match 'adminTokenNonEmpty' -and $pm2HelperSrc -match 'authTokenNonEmpty' -and
-  $pm2HelperSrc -match 'METASHEET_ADMIN_TOKEN' -and $pm2HelperSrc -match 'tokenNonEmpty'
+  $pm2HelperSrc -match 'METASHEET_ADMIN_TOKEN' -and $pm2HelperSrc -match 'carrierNonEmpty'
+)
+Check "entry scrub handles ALL carriers and fails closed on ambiguity (owner P1)" (
+  $src -match 'multiple_token_carriers_present' -and
+  ($src -match "@\(\`$AdminTokenEnvVar, 'METASHEET_ADMIN_TOKEN', 'METASHEET_AUTH_TOKEN'\)")
+)
+Check "pm2 projection receives the configured admin carrier (owner P2)" (
+  $src -match '\$pm2SampleHelper\s+\$AdminTokenEnvVar'
 )
 
 # ── 2. Token discipline. ─────────────────────────────────────────────────────────────────────────

--- a/scripts/ops/stock-preparation-onprem-acceptance.ps1
+++ b/scripts/ops/stock-preparation-onprem-acceptance.ps1
@@ -16,7 +16,7 @@
                           restart COMMAND returned 0 — a command success is not a stable service).
     5. healthcheck      — GET /api/health.
     6. mvpSmoke         — the in-package stock-preparation smoke (postdeploy-smoke.mjs).
-    7. summary          — one values-free acceptance-summary.txt + .json: the 9 whitelisted status
+    7. summary          — one values-free acceptance-summary.txt + .json: the 15 whitelisted status
                           fields ALWAYS, plus — only on failure — a values-free failDetail block
                           (failedStage + at most a migration name / SQLSTATE / HTTP code, never a value).
 
@@ -27,7 +27,7 @@
       ArgumentList. It is handed to the child smoke ONLY through a scoped process env var that is
       cleared in a finally block.
     * The values-free guarantee is scoped to the SUMMARY ARTIFACTS (acceptance-summary.txt / .json): those
-      can only ever contain the 9 whitelisted status fields — each a PASS/FAIL/enum/count/coarse-code —
+      can only ever contain the 15 whitelisted status fields — each a PASS/FAIL/enum/count/coarse-code —
       never a drawing number, quantity, unit, material name, host, credential, or raw log line. On failure
       they add only failedStage + a coarse code (migration name / SQLSTATE / HTTP status / coarse reason),
       never a full log. The values-free construction is: only whitelisted fields are ever assigned into

--- a/scripts/ops/stock-preparation-onprem-acceptance.ps1
+++ b/scripts/ops/stock-preparation-onprem-acceptance.ps1
@@ -107,7 +107,7 @@ function Stop-WithFailure {
 }
 
 function Emit-Summary {
-  # Build the .txt (9 whitelisted lines) + optional coarse fail detail, and a matching .json.
+  # Build the .txt (the 15 whitelisted summary lines) + optional coarse fail detail, and a matching .json.
   $lines = @()
   foreach ($k in $Summary.Keys) { $lines += "$k=$($Summary[$k])" }
   if ($FailDetail.Count -gt 0) { foreach ($k in $FailDetail.Keys) { $lines += "$k=$($FailDetail[$k])" } }
@@ -247,13 +247,27 @@ function Test-SmokeOutcome {
 # the interactive fallback stays at the smoke stage because Read-Host feeds the SecureString
 # directly and never touches the environment.
 function Read-AdminTokenSecureFromEnv {
-  $fromEnv = [Environment]::GetEnvironmentVariable($AdminTokenEnvVar)
-  if ($fromEnv) {
-    $secure = ConvertTo-SecureString $fromEnv -AsPlainText -Force
-    Remove-Item "Env:$AdminTokenEnvVar" -ErrorAction SilentlyContinue
-    return $secure
+  # Owner P1: EVERY known carrier is scrubbed here — the configured one AND both fixed defaults. A
+  # token that pre-exists on an unselected carrier (e.g. METASHEET_AUTH_TOKEN in the operator shell)
+  # would otherwise ride through SHA/bootstrap/migration into the pm2 daemon exactly like the entity
+  # finding. The SELECTED carrier is captured; more than one non-empty carrier is ambiguous and
+  # fails closed BEFORE any stage (env already scrubbed by then).
+  $carriers = @($AdminTokenEnvVar, 'METASHEET_ADMIN_TOKEN', 'METASHEET_AUTH_TOKEN') | Select-Object -Unique
+  $nonEmpty = @()
+  $selected = $null
+  foreach ($carrier in $carriers) {
+    $value = [Environment]::GetEnvironmentVariable($carrier)
+    if ($value) {
+      $nonEmpty += $carrier
+      if ($carrier -eq $AdminTokenEnvVar) { $selected = ConvertTo-SecureString $value -AsPlainText -Force }
+    }
+    Remove-Item "Env:$carrier" -ErrorAction SilentlyContinue
   }
-  return $null
+  if ($nonEmpty.Count -gt 1) {
+    $Summary.postRunCredentialHygiene = 'FAIL'
+    Stop-WithFailure 'credentialHygiene' @{ reason = 'multiple_token_carriers_present' }
+  }
+  return $selected
 }
 
 # ── Stage 1: package SHA256 vs SHA256SUMS (+ optional git-sha vs metadata) ───────────────────────
@@ -344,16 +358,18 @@ function Invoke-MigrationStage {
 }
 
 # ── Stage 4: pm2 restart + POLL stable-online (command success != stable service) ────────────────
-# Normalize one `pm2 jlist` entry to @{ state; restartTime; uptime } (values-free: no raw jlist echoed).
+# Normalize one `pm2 jlist` entry to the closed 5-key sample (state/restartTime/uptime + the two
+# token-hygiene booleans; values-free: no raw jlist echoed).
 function Get-Pm2Sample {
   # Do not feed the full PM2 payload to PowerShell's ConvertFrom-Json. PM2 includes the process
   # environment, where Windows commonly has both `Path` and `PATH`; Windows PowerShell 5.1 treats
-  # those as duplicate keys and rejects the whole document. Node parses the raw payload and emits a
-  # fixed three-field projection. Any missing helper, parse failure, duplicate target, or invalid
-  # number returns $null and the stable-online stage fails closed.
+  # those as duplicate keys and rejects the whole document. Node parses the raw payload and emits the
+  # fixed five-field projection. Any missing helper, parse failure, duplicate target, or invalid
+  # number returns $null and the stable-online stage fails closed. The configured admin carrier name is
+  # passed so a custom -AdminTokenEnvVar is detected too (case-insensitively, like Windows env names).
   $pm2SampleHelper = Join-Path $PSScriptRoot 'stock-preparation-pm2-sample.mjs'
   if (-not (Test-Path -LiteralPath $pm2SampleHelper -PathType Leaf)) { return $null }
-  $safeJson = (& pm2 jlist 2>$null | & node $pm2SampleHelper 2>$null)
+  $safeJson = (& pm2 jlist 2>$null | & node $pm2SampleHelper $AdminTokenEnvVar 2>$null)
   $sampleExit = $LASTEXITCODE
   if ($sampleExit -ne 0 -or -not $safeJson) { return $null }
   try {
@@ -395,7 +411,7 @@ function Invoke-Pm2StableStage {
   # runner's environment before pm2 can spawn/refresh anything that inherits it (the token was read
   # and scrubbed at entry — see the orchestration block). The entity-machine FAIL was exactly a pm2
   # restart executed while METASHEET_ADMIN_TOKEN still sat in the runner env.
-  foreach ($tokenVar in @($AdminTokenEnvVar, 'METASHEET_AUTH_TOKEN')) {
+  foreach ($tokenVar in (@($AdminTokenEnvVar, 'METASHEET_ADMIN_TOKEN', 'METASHEET_AUTH_TOKEN') | Select-Object -Unique)) {
     if ([Environment]::GetEnvironmentVariable($tokenVar)) {
       $Summary.postRunCredentialHygiene = 'FAIL'
       Stop-WithFailure 'credentialHygiene' @{ reason = 'token_env_present_before_pm2' }

--- a/scripts/ops/stock-preparation-onprem-acceptance.ps1
+++ b/scripts/ops/stock-preparation-onprem-acceptance.ps1
@@ -86,6 +86,10 @@ $Summary = [ordered]@{
   'mvpSmoke.failedCheckCount'       = '0'
   'mvpSmoke.responseLeakScanStatus' = 'NOT_RUN'
   externalPlmK3ErpWrite  = 'false'   # invariant: this line NEVER touches an external write.
+  # corrective-6 (entity finding): PASS only when the deployed pm2 process environment provably
+  # carries NO acceptance credential after the run (booleans from the Node projection — never a
+  # value). FAIL stops the acceptance; NOT_RUN means an earlier stage failed first.
+  postRunCredentialHygiene = 'NOT_RUN'
   failedStage            = 'none'
 }
 # Coarse failure detail (values-free): failedStage + at most a migration name / SQLSTATE / HTTP code.
@@ -237,15 +241,19 @@ function Test-SmokeOutcome {
 }
 
 # ── Read the admin token WITHOUT ever exposing it (env var, else secure prompt). ─────────────────
-function Read-AdminTokenSecure {
+# corrective-6: capture+SCRUB the env-var token at orchestration entry — the env var is the ONLY
+# carrier that can contaminate children (bootstrap may start the pm2 daemon; stage 4 restarts the
+# app; both inherit this process env). Returns $null when the operator did not provide the env var;
+# the interactive fallback stays at the smoke stage because Read-Host feeds the SecureString
+# directly and never touches the environment.
+function Read-AdminTokenSecureFromEnv {
   $fromEnv = [Environment]::GetEnvironmentVariable($AdminTokenEnvVar)
   if ($fromEnv) {
     $secure = ConvertTo-SecureString $fromEnv -AsPlainText -Force
-    # Best-effort scrub of the plaintext env var so it does not linger in this process env.
     Remove-Item "Env:$AdminTokenEnvVar" -ErrorAction SilentlyContinue
     return $secure
   }
-  return (Read-Host -AsSecureString "Admin token (input hidden)")
+  return $null
 }
 
 # ── Stage 1: package SHA256 vs SHA256SUMS (+ optional git-sha vs metadata) ───────────────────────
@@ -350,18 +358,49 @@ function Get-Pm2Sample {
   if ($sampleExit -ne 0 -or -not $safeJson) { return $null }
   try {
     $entry = $safeJson | ConvertFrom-Json
+    $adminTokenNonEmpty = if ($entry.PSObject.Properties['adminTokenNonEmpty'] -and $entry.adminTokenNonEmpty -is [bool]) { [bool]$entry.adminTokenNonEmpty } else { $null }
+    $authTokenNonEmpty = if ($entry.PSObject.Properties['authTokenNonEmpty'] -and $entry.authTokenNonEmpty -is [bool]) { [bool]$entry.authTokenNonEmpty } else { $null }
     [pscustomobject]@{
-      state       = "$($entry.state)"
-      restartTime = [int]($entry.restartTime)
-      uptime      = [long]($entry.uptime)
+      state              = "$($entry.state)"
+      restartTime        = [int]($entry.restartTime)
+      uptime             = [long]($entry.uptime)
+      adminTokenNonEmpty = $adminTokenNonEmpty
+      authTokenNonEmpty  = $authTokenNonEmpty
     }
   } catch {
     return $null
   }
 }
 
+# corrective-6: the token-hygiene verdict over one pm2 sample. PURE (unit-testable) and fail-closed:
+# a missing sample or a projection without the hygiene booleans (a stale packaged helper) is a FAIL,
+# never a skip. Reasons are a fixed values-free vocabulary.
+function Test-Pm2TokenHygieneSample {
+  param($Sample)
+  if (-not $Sample) { return @{ ok = $false; reason = 'sample_missing' } }
+  # StrictMode-safe reads: a projection from a STALE packaged helper simply lacks these properties.
+  $adminProperty = $Sample.PSObject.Properties['adminTokenNonEmpty']
+  $authProperty = $Sample.PSObject.Properties['authTokenNonEmpty']
+  $admin = if ($adminProperty) { $adminProperty.Value } else { $null }
+  $auth = if ($authProperty) { $authProperty.Value } else { $null }
+  if (-not ($admin -is [bool]) -or -not ($auth -is [bool])) { return @{ ok = $false; reason = 'hygiene_fields_missing' } }
+  if ($admin) { return @{ ok = $false; reason = 'PM2_ENV_METASHEET_ADMIN_TOKEN_NONEMPTY' } }
+  if ($auth) { return @{ ok = $false; reason = 'PM2_ENV_METASHEET_AUTH_TOKEN_NONEMPTY' } }
+  return @{ ok = $true; reason = 'clean' }
+}
+
 function Invoke-Pm2StableStage {
   Write-Stage 'stage 4: pm2 restart + stable-online poll'
+  # corrective-6 fail-closed regression guard: the acceptance token vars must ALREADY be out of THIS
+  # runner's environment before pm2 can spawn/refresh anything that inherits it (the token was read
+  # and scrubbed at entry — see the orchestration block). The entity-machine FAIL was exactly a pm2
+  # restart executed while METASHEET_ADMIN_TOKEN still sat in the runner env.
+  foreach ($tokenVar in @($AdminTokenEnvVar, 'METASHEET_AUTH_TOKEN')) {
+    if ([Environment]::GetEnvironmentVariable($tokenVar)) {
+      $Summary.postRunCredentialHygiene = 'FAIL'
+      Stop-WithFailure 'credentialHygiene' @{ reason = 'token_env_present_before_pm2' }
+    }
+  }
   # Coarsen the restart output (do not echo raw pm2 lines) — the values-free guarantee covers the summary
   # artifacts; keep the transcript free of raw tool output too.
   & pm2 restart metasheet-backend *> $null
@@ -380,8 +419,16 @@ function Invoke-Pm2StableStage {
     if (-not $verdict.ok) { Stop-WithFailure 'pm2StableOnline' @{ pm2State = $verdict.reason } }
     Start-Sleep -Seconds 2
   }
+  # corrective-6: check the freshly restarted APP environment immediately — a pm2 daemon left over
+  # from a previous contaminated run can re-inject a token into the app env even when THIS runner's
+  # env is clean. Failing here stops the acceptance before health/smoke ever run.
+  $earlyHygiene = Test-Pm2TokenHygieneSample (Get-Pm2Sample)
+  if (-not $earlyHygiene.ok) {
+    $Summary.postRunCredentialHygiene = 'FAIL'
+    Stop-WithFailure 'credentialHygiene' @{ reason = $earlyHygiene.reason }
+  }
   $Summary.pm2StableOnline = 'PASS'
-  Write-Stage 'stage 4: PASS (stayed online, no restart-loop)'
+  Write-Stage 'stage 4: PASS (stayed online, no restart-loop, app env token-clean)'
 }
 
 # ── Stage 5: /api/health ─────────────────────────────────────────────────────────────────────────
@@ -455,19 +502,41 @@ function Invoke-SmokeStage {
   Write-Stage 'stage 6: PASS'
 }
 
+# ── Stage 7 (corrective-6): post-run credential hygiene — the deployed pm2 process env must carry
+# NO acceptance token after the run. Uses the SAME Node projection as stage 4 (booleans only, never
+# a value); any violation fails the acceptance with a values-free coarse reason.
+function Invoke-PostRunHygieneStage {
+  Write-Stage 'stage 7: post-run credential hygiene'
+  $verdict = Test-Pm2TokenHygieneSample (Get-Pm2Sample)
+  if (-not $verdict.ok) {
+    $Summary.postRunCredentialHygiene = 'FAIL'
+    Stop-WithFailure 'credentialHygiene' @{ reason = $verdict.reason }
+  }
+  $Summary.postRunCredentialHygiene = 'PASS'
+  Write-Stage 'stage 7: PASS (no acceptance token in the pm2 environment)'
+}
+
 # ── Orchestrate ──────────────────────────────────────────────────────────────────────────────────
 # Entry-point guard: when the script is DOT-SOURCED (InvocationName '.') only the functions are defined,
 # so the behavioural tests can exercise the pure helpers (Test-SmokeOutcome / Test-Pm2StableSample) with
 # crafted inputs — the pm2/health/smoke stages cannot be driven end-to-end off a Windows host + live pm2.
 if ($MyInvocation.InvocationName -ne '.') {
   try {
+    # corrective-6 (entity FAIL ACCEPTANCE_TOKEN_PERSISTED_IN_PM2_ENV): the env-var token is read into
+    # a SecureString and SCRUBBED from this process environment BEFORE ANY stage can spawn a child —
+    # stage 2's bootstrap may start the pm2 daemon and stage 4 restarts the app, and both inherit this
+    # environment. The previous read-after-health left METASHEET_ADMIN_TOKEN in the env pm2 captured.
+    $token = Read-AdminTokenSecureFromEnv
     Invoke-ShaStage
     Invoke-BootstrapStage
     Invoke-MigrationStage
     Invoke-Pm2StableStage
     Invoke-HealthStage
-    $token = Read-AdminTokenSecure
+    # Interactive fallback (no env-var token): prompts feed the SecureString directly — the
+    # environment is never touched, so this path cannot contaminate pm2.
+    if (-not $token) { $token = (Read-Host -AsSecureString "Admin token (input hidden)") }
     Invoke-SmokeStage -Token $token
+    Invoke-PostRunHygieneStage
     Emit-Summary
     Write-Stage 'ACCEPTANCE PASS — all stages green'
     exit 0

--- a/scripts/ops/stock-preparation-pm2-sample.mjs
+++ b/scripts/ops/stock-preparation-pm2-sample.mjs
@@ -28,25 +28,15 @@ const CUSTOM_ADMIN_CARRIER = typeof process.argv[2] === 'string' && process.argv
 const ADMIN_CARRIERS = [...new Set([CUSTOM_ADMIN_CARRIER, 'METASHEET_ADMIN_TOKEN'].filter(Boolean))]
 const AUTH_CARRIERS = ['METASHEET_AUTH_TOKEN']
 
-import fs from 'node:fs'
-
-// fs.readFileSync(0) instead of the async stdin iterator: Windows PowerShell 5.1 string-pipes can
-// race an ESM module's async stdin attach (observed as an empty read -> silent exit 1 on the CI
-// windows arm), while a synchronous fd-0 read drains whatever the pipe delivered.
 let raw = ''
-try {
-  raw = fs.readFileSync(0, 'utf8')
-} catch {
-  raw = ''
-}
+for await (const chunk of process.stdin) raw += chunk
+
+// Windows PowerShell 5.1 prefixes native string-pipeline input with a UTF-8 BOM. JSON.parse rejects
+// U+FEFF, so normalize exactly that transport marker while preserving the payload unchanged.
+if (raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1)
 
 try {
-  // Windows PowerShell 5.1 pipes strings to native stdin through the console host, which HARD-WRAPS
-  // at the console buffer width - a CRLF can land in the middle of any JSON token (observed on the
-  // CI windows arm: short probes survive, a 176-char payload does not). Valid JSON cannot contain a
-  // raw CR/LF inside a string literal and no two JSON tokens are delimited by whitespace alone, so
-  // stripping every raw CR/LF provably reconstructs a parseable document.
-  const processes = JSON.parse(raw.replace(/[\r\n]+/g, ''))
+  const processes = JSON.parse(raw)
   if (!Array.isArray(processes)) throw new Error('invalid_shape')
 
   const matches = processes.filter((entry) => entry?.name === APP_NAME)

--- a/scripts/ops/stock-preparation-pm2-sample.mjs
+++ b/scripts/ops/stock-preparation-pm2-sample.mjs
@@ -41,7 +41,12 @@ try {
 }
 
 try {
-  const processes = JSON.parse(raw)
+  // Windows PowerShell 5.1 pipes strings to native stdin through the console host, which HARD-WRAPS
+  // at the console buffer width - a CRLF can land in the middle of any JSON token (observed on the
+  // CI windows arm: short probes survive, a 176-char payload does not). Valid JSON cannot contain a
+  // raw CR/LF inside a string literal and no two JSON tokens are delimited by whitespace alone, so
+  // stripping every raw CR/LF provably reconstructs a parseable document.
+  const processes = JSON.parse(raw.replace(/[\r\n]+/g, ''))
   if (!Array.isArray(processes)) throw new Error('invalid_shape')
 
   const matches = processes.filter((entry) => entry?.name === APP_NAME)

--- a/scripts/ops/stock-preparation-pm2-sample.mjs
+++ b/scripts/ops/stock-preparation-pm2-sample.mjs
@@ -28,8 +28,17 @@ const CUSTOM_ADMIN_CARRIER = typeof process.argv[2] === 'string' && process.argv
 const ADMIN_CARRIERS = [...new Set([CUSTOM_ADMIN_CARRIER, 'METASHEET_ADMIN_TOKEN'].filter(Boolean))]
 const AUTH_CARRIERS = ['METASHEET_AUTH_TOKEN']
 
+import fs from 'node:fs'
+
+// fs.readFileSync(0) instead of the async stdin iterator: Windows PowerShell 5.1 string-pipes can
+// race an ESM module's async stdin attach (observed as an empty read -> silent exit 1 on the CI
+// windows arm), while a synchronous fd-0 read drains whatever the pipe delivered.
 let raw = ''
-for await (const chunk of process.stdin) raw += chunk
+try {
+  raw = fs.readFileSync(0, 'utf8')
+} catch {
+  raw = ''
+}
 
 try {
   const processes = JSON.parse(raw)

--- a/scripts/ops/stock-preparation-pm2-sample.mjs
+++ b/scripts/ops/stock-preparation-pm2-sample.mjs
@@ -21,7 +21,12 @@ const ALLOWED_STATES = new Set([
   'one-launch-status',
   'waiting restart',
 ])
-const TOKEN_ENV_VARS = ['METASHEET_ADMIN_TOKEN', 'METASHEET_AUTH_TOKEN']
+// Windows environment names are case-INSENSITIVE, so detection matches any case variant (owner P2:
+// `metasheet_admin_token=LEAKED` must count). An optional argv[2] names the operator-configured admin
+// carrier (-AdminTokenEnvVar) and folds into the admin boolean.
+const CUSTOM_ADMIN_CARRIER = typeof process.argv[2] === 'string' && process.argv[2].trim() ? process.argv[2].trim() : null
+const ADMIN_CARRIERS = [...new Set([CUSTOM_ADMIN_CARRIER, 'METASHEET_ADMIN_TOKEN'].filter(Boolean))]
+const AUTH_CARRIERS = ['METASHEET_AUTH_TOKEN']
 
 let raw = ''
 for await (const chunk of process.stdin) raw += chunk
@@ -40,12 +45,18 @@ try {
   if (!Number.isSafeInteger(restartTime) || restartTime < 0) throw new Error('restart_time')
   if (!Number.isSafeInteger(uptime) || uptime < 0) throw new Error('uptime')
 
-  // pm2 exposes the captured environment both merged into pm2_env and under pm2_env.env;
-  // a token counts as leaked if it is a non-empty string on EITHER carrier.
+  // pm2 exposes the captured environment both merged into pm2_env and under pm2_env.env; a token
+  // counts as leaked if ANY case variant of a carrier name holds a non-empty string on EITHER bag.
   const envBag = pm2Env && typeof pm2Env.env === 'object' && pm2Env.env !== null ? pm2Env.env : {}
-  const tokenNonEmpty = (name) => {
-    for (const candidate of [envBag[name], pm2Env?.[name]]) {
-      if (typeof candidate === 'string' && candidate.trim().length > 0) return true
+  const carrierNonEmpty = (names) => {
+    const targets = new Set(names.map((name) => name.toUpperCase()))
+    for (const bag of [envBag, pm2Env]) {
+      if (!bag || typeof bag !== 'object') continue
+      for (const key of Object.keys(bag)) {
+        if (!targets.has(key.toUpperCase())) continue
+        const value = bag[key]
+        if (typeof value === 'string' && value.trim().length > 0) return true
+      }
     }
     return false
   }
@@ -54,8 +65,8 @@ try {
     state: ALLOWED_STATES.has(rawState) ? rawState : 'unknown',
     restartTime,
     uptime,
-    adminTokenNonEmpty: tokenNonEmpty(TOKEN_ENV_VARS[0]),
-    authTokenNonEmpty: tokenNonEmpty(TOKEN_ENV_VARS[1]),
+    adminTokenNonEmpty: carrierNonEmpty(ADMIN_CARRIERS),
+    authTokenNonEmpty: carrierNonEmpty(AUTH_CARRIERS),
   }))
 } catch {
   process.exitCode = 1

--- a/scripts/ops/stock-preparation-pm2-sample.mjs
+++ b/scripts/ops/stock-preparation-pm2-sample.mjs
@@ -3,8 +3,13 @@
 // Normalize `pm2 jlist` before PowerShell sees it. Windows PowerShell treats
 // object keys case-insensitively, so ordinary environment pairs such as
 // `Path`/`PATH` make ConvertFrom-Json reject the otherwise valid PM2 payload.
-// This helper emits only the three coarse fields needed by the acceptance
-// runner and never echoes input or parse errors.
+// This helper emits only the coarse fields needed by the acceptance runner
+// and never echoes input, env values, or parse errors.
+//
+// corrective-6 (entity finding ACCEPTANCE_TOKEN_PERSISTED_IN_PM2_ENV): the
+// projection additionally reports whether the acceptance token variables are
+// NON-EMPTY in the managed process environment — booleans only, NEVER the
+// value — so the runner can fail closed when a token leaked into pm2.
 
 const APP_NAME = 'metasheet-backend'
 const ALLOWED_STATES = new Set([
@@ -16,6 +21,7 @@ const ALLOWED_STATES = new Set([
   'one-launch-status',
   'waiting restart',
 ])
+const TOKEN_ENV_VARS = ['METASHEET_ADMIN_TOKEN', 'METASHEET_AUTH_TOKEN']
 
 let raw = ''
 for await (const chunk of process.stdin) raw += chunk
@@ -34,10 +40,22 @@ try {
   if (!Number.isSafeInteger(restartTime) || restartTime < 0) throw new Error('restart_time')
   if (!Number.isSafeInteger(uptime) || uptime < 0) throw new Error('uptime')
 
+  // pm2 exposes the captured environment both merged into pm2_env and under pm2_env.env;
+  // a token counts as leaked if it is a non-empty string on EITHER carrier.
+  const envBag = pm2Env && typeof pm2Env.env === 'object' && pm2Env.env !== null ? pm2Env.env : {}
+  const tokenNonEmpty = (name) => {
+    for (const candidate of [envBag[name], pm2Env?.[name]]) {
+      if (typeof candidate === 'string' && candidate.trim().length > 0) return true
+    }
+    return false
+  }
+
   process.stdout.write(JSON.stringify({
     state: ALLOWED_STATES.has(rawState) ? rawState : 'unknown',
     restartTime,
     uptime,
+    adminTokenNonEmpty: tokenNonEmpty(TOKEN_ENV_VARS[0]),
+    authTokenNonEmpty: tokenNonEmpty(TOKEN_ENV_VARS[1]),
   }))
 } catch {
   process.exitCode = 1


### PR DESCRIPTION
## Summary

Stacked correction for #4410 at parent head `8b97b7d26b1fe6d7aba70e79fccbe272b59795cd`.

- normalize exactly one leading `U+FEFF` before parsing the PM2 projection input;
- remove the disproved async-stdin race and console-width hard-wrap workarounds;
- replace the synthetic mid-token CRLF test with a deterministic leading-BOM regression;
- remove temporary values-free diagnostics from the real Windows PowerShell 5.1 suite.

## Root Cause

The required Windows arm proved that a fixed `hello` string reaches Node as:

```text
len=10 first=efbbbf68 last=6c6f0d0a
```

That is UTF-8 BOM + `hello` + CRLF. Both async and synchronous stdin readers receive the same marker. `JSON.parse` rejects the leading `U+FEFF`; trailing CRLF is valid JSON whitespace.

Independent proof run with the exact normalization: https://github.com/zensgit/metasheet2/actions/runs/29548687802/job/87786421168

## Verification

- `pwsh -NoProfile -File scripts/ops/__tests__/stock-preparation-onprem-acceptance.tests.ps1` — PASS
- `pwsh -NoProfile -File scripts/ops/__tests__/stock-preparation-onprem-acceptance.behavior.tests.ps1` — 57/57 PASS
- direct BOM + CRLF helper probe — PASS, closed five-field projection
- `git diff --check` — PASS

## Landing Boundary

This PR targets the existing corrective-6 branch and must land there before #4410 exact-head re-review. It does not authorize merging #4410, building/applying a package, deploying, restarting PM2, GC, or entity-machine mutation.

Addresses the current corrective-6 CI blocker for #4101; #4101 remains open through parent merge, package build, and authorized entity-machine rerun.