### PR TITLE
feat(directory): B4 — department binding table (buildable FK chain, cross-org FK-impossible)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -168,6 +168,12 @@ jobs:
       - name: PB4-4 reactivation CI wiring contract
         run: node --test scripts/ops/pb4-4-reactivation-ci-wiring.test.mjs
 
+      # B4 CI two-point wiring contract (no DB): the department-bindings FK-chain suite must stay
+      # wired into BOTH vitest.config.ts (exclude) AND plugin-tests.yml (directory real-DB step).
+      # Dropping either point silently disables the cross-org-FK-impossible proof.
+      - name: B4 department-bindings CI wiring contract
+        run: node --test scripts/ops/b4-department-bindings-ci-wiring.test.mjs
+
       # The production monitor invokes the same state helper covered here.
       # Keep this in the required 18/20 matrix so HTTP classification, silence
       # barriers, and alert/recovery streak semantics cannot drift silently.
@@ -634,6 +640,7 @@ jobs:
             tests/integration/local-directory-org-archive-readonly.db.test.ts \
             tests/integration/local-directory-org-cycle-detection.db.test.ts \
             tests/integration/directory-local-integration-reactivation.db.test.ts \
+            tests/integration/directory-department-bindings.db.test.ts \
             tests/integration/directory-normalized-manager.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             tests/integration/attendance-notification-redelivery.db.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260717100000_create_directory_department_bindings.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260717100000_create_directory_department_bindings.ts
@@ -1,0 +1,161 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * Canonical Org MVP — B4 (department binding table), #4215 §5.5.
+ *
+ * `directory_department_bindings` binds a LOCAL department to an external-provider (e.g. DingTalk)
+ * department so routing/reconciliation can resolve across the canonical local org and a provider
+ * directory. The owner design goal is that a **cross-org binding is impossible to INSERT** — not
+ * enforced by service convention, but by a BUILDABLE FK CHAIN in the schema itself.
+ *
+ * How the chain makes cross-org FK-impossible: the binding carries a SINGLE `org_id` column, and
+ * BOTH integration ids are FK'd to `directory_integrations (id, org_id)` against that same column.
+ * A binding whose local integration lives in org A and remote integration lives in org B therefore
+ * has NO satisfying `org_id` value — `org_id = A` fails the remote FK, `org_id = B` fails the local
+ * FK — so the row cannot be inserted. (Postgres composite FKs are MATCH SIMPLE, so this only holds
+ * because every FK-participating column is NOT NULL: a NULL in any of them would skip the FK check
+ * entirely and let a cross-org row slip past. All seven such columns are NOT NULL below.)
+ *
+ * provider-role (one side local, the other a provider) is likewise FK-enforced, not triggered: the
+ * binding carries redundant `local_provider`/`remote_provider` columns, each FK'd to
+ * `directory_integrations (id, provider)`, plus a CHECK that local_provider='local' AND
+ * remote_provider<>'local'. So the local side must be a `provider='local'` integration and the
+ * remote side must not be — with no trigger.
+ *
+ * Each department is pinned to its own integration via `(department_id, integration_id) ->
+ * directory_departments (id, integration_id)`, so a binding cannot reference a department that
+ * belongs to a different integration than the one it names.
+ *
+ * The three parent-side UNIQUE constraints this needs — `directory_integrations (id, org_id)`,
+ * `directory_integrations (id, provider)`, `directory_departments (id, integration_id)` — are all
+ * REDUNDANT supersets of an existing primary key (`id` is already unique), so they reject no
+ * existing row and are safe to add; a composite FK requires a real UNIQUE CONSTRAINT on exactly the
+ * referenced columns (a plain unique INDEX is not referenceable), which is why they are ADD
+ * CONSTRAINT, not CREATE UNIQUE INDEX.
+ *
+ * ON DELETE CASCADE on every FK matches the existing `directory_departments`/`directory_accounts`
+ * → integration cascade: a binding is meaningless once either referenced integration or department
+ * is hard-deleted. Archive-not-delete means this rarely fires; when a real delete happens the
+ * binding is removed rather than left dangling. Multiple cascade paths to one binding row (via the
+ * integration and via its department) are fine — Postgres deletes the row once.
+ *
+ * `status` is 'active' | 'stale' for the B7 suggest-only reconciliation (a vanished external
+ * department marks its binding 'stale', never deactivating the local department).
+ *
+ * `directory_integrations`/`directory_departments` are created by a zzzz migration, so this MUST
+ * also be zzzz-prefixed (a plain 0xx SQL migration runs before those tables exist). Postgres has no
+ * `ADD CONSTRAINT IF NOT EXISTS`, so each parent constraint is guarded by a `pg_constraint`
+ * existence probe pinned to conname + conrelid + contype (a bare conname probe would false-positive
+ * on a same-named constraint elsewhere — mirrors zzzz20260715090000). The table itself is
+ * `CREATE TABLE IF NOT EXISTS` (atomic: all its inline constraints exist or none do), which keeps
+ * the whole migration idempotent on replay.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // 1) Parent UNIQUE constraints the composite FKs reference (redundant supersets of the PKs).
+  await sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+         WHERE conname = 'uq_directory_integrations_id_org'
+           AND conrelid = 'directory_integrations'::regclass
+           AND contype = 'u'
+      ) THEN
+        ALTER TABLE directory_integrations
+        ADD CONSTRAINT uq_directory_integrations_id_org UNIQUE (id, org_id);
+      END IF;
+    END $$;
+  `.execute(db)
+
+  await sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+         WHERE conname = 'uq_directory_integrations_id_provider'
+           AND conrelid = 'directory_integrations'::regclass
+           AND contype = 'u'
+      ) THEN
+        ALTER TABLE directory_integrations
+        ADD CONSTRAINT uq_directory_integrations_id_provider UNIQUE (id, provider);
+      END IF;
+    END $$;
+  `.execute(db)
+
+  await sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+         WHERE conname = 'uq_directory_departments_id_integration'
+           AND conrelid = 'directory_departments'::regclass
+           AND contype = 'u'
+      ) THEN
+        ALTER TABLE directory_departments
+        ADD CONSTRAINT uq_directory_departments_id_integration UNIQUE (id, integration_id);
+      END IF;
+    END $$;
+  `.execute(db)
+
+  // 2) The binding table + its buildable FK chain, provider-role CHECK, and status CHECK.
+  await sql`
+    CREATE TABLE IF NOT EXISTS directory_department_bindings (
+      id                     uuid        NOT NULL DEFAULT gen_random_uuid(),
+      org_id                 text        NOT NULL,
+      local_integration_id   uuid        NOT NULL,
+      local_department_id    uuid        NOT NULL,
+      local_provider         text        NOT NULL,
+      remote_integration_id  uuid        NOT NULL,
+      remote_department_id   uuid        NOT NULL,
+      remote_provider        text        NOT NULL,
+      status                 text        NOT NULL DEFAULT 'active',
+      created_at             timestamptz NOT NULL DEFAULT now(),
+      updated_at             timestamptz NOT NULL DEFAULT now(),
+
+      CONSTRAINT directory_department_bindings_pkey PRIMARY KEY (id),
+
+      CONSTRAINT ddb_provider_role_chk CHECK (local_provider = 'local' AND remote_provider <> 'local'),
+      CONSTRAINT ddb_status_chk        CHECK (status IN ('active', 'stale')),
+
+      -- one binding per external/remote department
+      CONSTRAINT ddb_remote_dept_uniq UNIQUE (remote_integration_id, remote_department_id),
+
+      -- same-org chain: both integrations FK'd to the SAME org_id column => cross-org FK-impossible
+      CONSTRAINT ddb_local_int_org_fk FOREIGN KEY (local_integration_id, org_id)
+        REFERENCES directory_integrations (id, org_id) ON DELETE CASCADE,
+      CONSTRAINT ddb_remote_int_org_fk FOREIGN KEY (remote_integration_id, org_id)
+        REFERENCES directory_integrations (id, org_id) ON DELETE CASCADE,
+
+      -- provider-role, FK-backed
+      CONSTRAINT ddb_local_int_provider_fk FOREIGN KEY (local_integration_id, local_provider)
+        REFERENCES directory_integrations (id, provider) ON DELETE CASCADE,
+      CONSTRAINT ddb_remote_int_provider_fk FOREIGN KEY (remote_integration_id, remote_provider)
+        REFERENCES directory_integrations (id, provider) ON DELETE CASCADE,
+
+      -- each department belongs to its named integration
+      CONSTRAINT ddb_local_dept_fk FOREIGN KEY (local_department_id, local_integration_id)
+        REFERENCES directory_departments (id, integration_id) ON DELETE CASCADE,
+      CONSTRAINT ddb_remote_dept_fk FOREIGN KEY (remote_department_id, remote_integration_id)
+        REFERENCES directory_departments (id, integration_id) ON DELETE CASCADE
+    )
+  `.execute(db)
+
+  // Lookup index for the local side (the remote side is already covered by ddb_remote_dept_uniq).
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_ddb_local_department
+    ON directory_department_bindings (local_integration_id, local_department_id)
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_ddb_org
+    ON directory_department_bindings (org_id)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Drop the table first (removes its FKs), then the redundant parent constraints.
+  await sql`DROP TABLE IF EXISTS directory_department_bindings`.execute(db)
+  await sql`ALTER TABLE directory_departments DROP CONSTRAINT IF EXISTS uq_directory_departments_id_integration`.execute(db)
+  await sql`ALTER TABLE directory_integrations DROP CONSTRAINT IF EXISTS uq_directory_integrations_id_provider`.execute(db)
+  await sql`ALTER TABLE directory_integrations DROP CONSTRAINT IF EXISTS uq_directory_integrations_id_org`.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260717100000_create_directory_department_bindings.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260717100000_create_directory_department_bindings.ts
@@ -23,12 +23,16 @@ import { sql } from 'kysely'
  * remote_provider<>'local'. So the local side must be a `provider='local'` integration and the
  * remote side must not be — with no trigger.
  *
- * Each department is pinned to its own integration via `(department_id, integration_id) ->
- * directory_departments (id, integration_id)`, so a binding cannot reference a department that
- * belongs to a different integration than the one it names.
+ * Each department is pinned to its own integration AND to the role's provider via the THREE-column
+ * `(department_id, integration_id, provider) -> directory_departments (id, integration_id,
+ * provider)` (owner P2 round): the integration-level provider FKs alone say nothing about the
+ * DEPARTMENT row's own `provider` column, so a provider-mislabeled department under a
+ * correctly-labeled integration — the malformed-but-real shape B3/PB4-2 already treat as existing
+ * and reject on their write paths — could otherwise occupy either side of a binding. The provider
+ * leg closes that: dept.provider must equal the binding's role provider.
  *
  * The three parent-side UNIQUE constraints this needs — `directory_integrations (id, org_id)`,
- * `directory_integrations (id, provider)`, `directory_departments (id, integration_id)` — are all
+ * `directory_integrations (id, provider)`, `directory_departments (id, integration_id, provider)` — are all
  * REDUNDANT supersets of an existing primary key (`id` is already unique), so they reject no
  * existing row and are safe to add; a composite FK requires a real UNIQUE CONSTRAINT on exactly the
  * referenced columns (a plain unique INDEX is not referenceable), which is why they are ADD
@@ -88,12 +92,12 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     BEGIN
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
-         WHERE conname = 'uq_directory_departments_id_integration'
+         WHERE conname = 'uq_directory_departments_id_integration_provider'
            AND conrelid = 'directory_departments'::regclass
            AND contype = 'u'
       ) THEN
         ALTER TABLE directory_departments
-        ADD CONSTRAINT uq_directory_departments_id_integration UNIQUE (id, integration_id);
+        ADD CONSTRAINT uq_directory_departments_id_integration_provider UNIQUE (id, integration_id, provider);
       END IF;
     END $$;
   `.execute(db)
@@ -133,11 +137,15 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       CONSTRAINT ddb_remote_int_provider_fk FOREIGN KEY (remote_integration_id, remote_provider)
         REFERENCES directory_integrations (id, provider) ON DELETE CASCADE,
 
-      -- each department belongs to its named integration
-      CONSTRAINT ddb_local_dept_fk FOREIGN KEY (local_department_id, local_integration_id)
-        REFERENCES directory_departments (id, integration_id) ON DELETE CASCADE,
-      CONSTRAINT ddb_remote_dept_fk FOREIGN KEY (remote_department_id, remote_integration_id)
-        REFERENCES directory_departments (id, integration_id) ON DELETE CASCADE
+      -- each department belongs to its named integration AND carries the role's provider itself
+      -- (owner P2: integration-level provider FKs alone do NOT constrain the DEPARTMENT row's own
+      -- provider column — a provider-mislabeled department under a correctly-labeled integration
+      -- (the malformed-but-real shape B3/PB4-2 already reject on their write paths) could otherwise
+      -- occupy either side of a binding. The provider leg pins dept.provider = the binding's role.)
+      CONSTRAINT ddb_local_dept_fk FOREIGN KEY (local_department_id, local_integration_id, local_provider)
+        REFERENCES directory_departments (id, integration_id, provider) ON DELETE CASCADE,
+      CONSTRAINT ddb_remote_dept_fk FOREIGN KEY (remote_department_id, remote_integration_id, remote_provider)
+        REFERENCES directory_departments (id, integration_id, provider) ON DELETE CASCADE
     )
   `.execute(db)
 
@@ -155,7 +163,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 export async function down(db: Kysely<unknown>): Promise<void> {
   // Drop the table first (removes its FKs), then the redundant parent constraints.
   await sql`DROP TABLE IF EXISTS directory_department_bindings`.execute(db)
-  await sql`ALTER TABLE directory_departments DROP CONSTRAINT IF EXISTS uq_directory_departments_id_integration`.execute(db)
+  await sql`ALTER TABLE directory_departments DROP CONSTRAINT IF EXISTS uq_directory_departments_id_integration_provider`.execute(db)
   await sql`ALTER TABLE directory_integrations DROP CONSTRAINT IF EXISTS uq_directory_integrations_id_provider`.execute(db)
   await sql`ALTER TABLE directory_integrations DROP CONSTRAINT IF EXISTS uq_directory_integrations_id_org`.execute(db)
 }

--- a/packages/core-backend/tests/integration/directory-department-bindings.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-department-bindings.db.test.ts
@@ -23,12 +23,20 @@ import { createLocalDepartment } from '../../src/directory/local-directory-org'
  *      so a NULL in any FK column skips the FK entirely; without the NOT NULL a NULL-org_id cross-org
  *      binding would slip past the org chain (proven by the drop-NOT-NULL mutation below).
  *   E. a department must belong to its named integration (`ddb_*_dept_fk`).
- *   F. schema contract — the six FKs + provider CHECK + three parent UNIQUE constraints exist.
+ *   F. schema contract — the six FKs (dept FKs asserted THREE-column) + provider CHECK + three
+ *      parent UNIQUE constraints exist.
+ *   I/J. provider-mismatch (owner P2) — a provider-mislabeled department (dingtalk-dept under the
+ *      local integration / local-dept under the dingtalk integration; the malformed-but-real shape
+ *      B3/PB4-2 already reject on write paths) cannot occupy either side: the dept FK's provider
+ *      leg rejects it by name. Integration-level provider FKs alone cannot catch this.
+ *   G/H. UPDATE-path bypass legs and CASCADE radius (see below).
  *
  * Load-bearing mutations (out-of-band, each reds this file):
  *   - `ALTER … org_id DROP NOT NULL`                     → D reds (NULL-org_id cross-org insert now
  *                                                          slips past the org chain via MATCH SIMPLE).
  *   - `ALTER … DROP CONSTRAINT ddb_remote_int_org_fk`    → B reds (the cross-org binding inserts).
+ *   - drop ddb_local_dept_fk's provider leg (re-add 2-col) → I reds (mislabeled local side inserts).
+ *   - drop ddb_remote_dept_fk's provider leg (re-add 2-col)→ J reds (mislabeled remote side inserts).
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -259,6 +267,62 @@ describeIfDatabase('Canonical Org MVP — B4 department binding table (real DB)'
     expect(err?.constraint).toBe('ddb_local_dept_fk')
   })
 
+  it('I. local-side provider-mismatch: a dingtalk-provider department under the LOCAL integration cannot be the local side (owner P2)', async () => {
+    // The malformed-but-real shape from B3/PB4-2: a provider-mislabeled department row under a
+    // correctly-labeled integration (only creatable via raw ops / a buggy sync — which is the
+    // point). Integration-level provider FKs pass (the INTEGRATION is 'local'); only the dept FK's
+    // provider leg can catch that the DEPARTMENT row itself says 'dingtalk'.
+    const org = orgId('pm-l')
+    seededOrgIds.push(org)
+    const local = await localSide(org)
+    const remote = await dingtalkSide(org, 'pm-l')
+    const mislabeled = await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, provider, external_department_id, name, is_active, raw)
+       VALUES ($1, 'dingtalk', $2, 'Mislabeled under local', true, '{}'::jsonb) RETURNING id`,
+      [local.intId, `dt-under-local:${STAMP}`],
+    )
+
+    const err = await reject(() =>
+      insertBinding({
+        org_id: org,
+        local_integration_id: local.intId,
+        local_department_id: mislabeled.rows[0].id, // dept.provider='dingtalk' under the local int
+        local_provider: 'local',
+        remote_integration_id: remote.intId,
+        remote_department_id: remote.deptId,
+        remote_provider: 'dingtalk',
+      }),
+    )
+    expect(err?.code).toBe('23503')
+    expect(err?.constraint).toBe('ddb_local_dept_fk') // the three-column provider leg, by name
+  })
+
+  it('J. remote-side provider-mismatch: a local-provider department under the DINGTALK integration cannot be the remote side (owner P2)', async () => {
+    const org = orgId('pm-r')
+    seededOrgIds.push(org)
+    const local = await localSide(org)
+    const remote = await dingtalkSide(org, 'pm-r')
+    const mislabeled = await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, provider, external_department_id, name, is_active, raw)
+       VALUES ($1, 'local', $2, 'Mislabeled under dingtalk', true, '{}'::jsonb) RETURNING id`,
+      [remote.intId, `local-under-dt:${STAMP}`],
+    )
+
+    const err = await reject(() =>
+      insertBinding({
+        org_id: org,
+        local_integration_id: local.intId,
+        local_department_id: local.deptId,
+        local_provider: 'local',
+        remote_integration_id: remote.intId,
+        remote_department_id: mislabeled.rows[0].id, // dept.provider='local' under the dingtalk int
+        remote_provider: 'dingtalk',
+      }),
+    )
+    expect(err?.code).toBe('23503')
+    expect(err?.constraint).toBe('ddb_remote_dept_fk') // the three-column provider leg, by name
+  })
+
   it('G. UPDATE path cannot bypass the chain: repoint-remote / rewrite-org_id / NULL-org_id / parent-org rewrite all rejected', async () => {
     // FKs re-check on UPDATE of referencing columns — but that is an ASSERTED invariant until
     // pinned. Owner review focus: "无 NULL、更新或 raw SQL 绕过". Four legs, each by exact cause.
@@ -363,8 +427,21 @@ describeIfDatabase('Canonical Org MVP — B4 department binding table (real DB)'
         WHERE contype = 'u'
           AND ((conname = 'uq_directory_integrations_id_org'      AND conrelid = 'directory_integrations'::regclass)
             OR (conname = 'uq_directory_integrations_id_provider' AND conrelid = 'directory_integrations'::regclass)
-            OR (conname = 'uq_directory_departments_id_integration' AND conrelid = 'directory_departments'::regclass))`,
+            OR (conname = 'uq_directory_departments_id_integration_provider' AND conrelid = 'directory_departments'::regclass))`,
     )
     expect(parents.rows.length).toBe(3)
+
+    // The dept FKs carry the provider leg (owner P2): assert the ACTUAL referencing column count,
+    // not just existence — a two-column ddb_local_dept_fk would pass a name check but reopen the
+    // provider-mislabel hole.
+    const deptFkArity = await query<{ conname: string; ncols: number }>(
+      `SELECT conname, array_length(conkey, 1) AS ncols FROM pg_constraint
+        WHERE conrelid = 'directory_department_bindings'::regclass
+          AND conname IN ('ddb_local_dept_fk', 'ddb_remote_dept_fk')`,
+    )
+    expect(deptFkArity.rows.length).toBe(2)
+    for (const row of deptFkArity.rows) {
+      expect(row.ncols).toBe(3)
+    }
   })
 })

--- a/packages/core-backend/tests/integration/directory-department-bindings.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-department-bindings.db.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { getOrCreateLocalIntegration } from '../../src/directory/directory-sync'
+import { createLocalDepartment } from '../../src/directory/local-directory-org'
+
+/**
+ * Canonical Org MVP — B4 (department binding table), #4215 §5.5, real DB.
+ *
+ * `directory_department_bindings` binds a local department to an external-provider department. The
+ * owner done-gate is that a CROSS-ORG binding is IMPOSSIBLE TO INSERT — enforced by the schema's
+ * buildable FK chain, not by service code. This proves that against real Postgres:
+ *
+ *   A. positive control — a same-org local↔dingtalk binding inserts fine (the guard rejects the
+ *      cross-org case, not all bindings).
+ *   B. cross-org is FK-impossible FOR THE RIGHT REASON — a binding whose local and remote
+ *      integrations live in different orgs is rejected specifically by the org-chain FK
+ *      (`ddb_*_int_org_fk`), by constraint name — not incidentally by the provider CHECK or a dept
+ *      FK. Both org_id choices are covered (each fails the opposite side's org FK).
+ *   C. provider-role — local side must be `provider='local'`, remote side must NOT be; a local↔local
+ *      or dingtalk↔dingtalk binding is rejected (CHECK or provider FK).
+ *   D. NOT NULL closes the MATCH SIMPLE hole — the same cross-org binding with `org_id = NULL` is
+ *      rejected by NOT NULL (23502). This is load-bearing: Postgres composite FKs are MATCH SIMPLE,
+ *      so a NULL in any FK column skips the FK entirely; without the NOT NULL a NULL-org_id cross-org
+ *      binding would slip past the org chain (proven by the drop-NOT-NULL mutation below).
+ *   E. a department must belong to its named integration (`ddb_*_dept_fk`).
+ *   F. schema contract — the six FKs + provider CHECK + three parent UNIQUE constraints exist.
+ *
+ * Load-bearing mutations (out-of-band, each reds this file):
+ *   - `ALTER … org_id DROP NOT NULL`                     → D reds (NULL-org_id cross-org insert now
+ *                                                          slips past the org chain via MATCH SIMPLE).
+ *   - `ALTER … DROP CONSTRAINT ddb_remote_int_org_fk`    → B reds (the cross-org binding inserts).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+const orgId = (suffix: string): string => `b4-${STAMP}-${suffix}`
+
+interface Side {
+  intId: string
+  deptId: string
+  provider: string
+}
+
+async function localSide(org: string): Promise<Side> {
+  const int = await getOrCreateLocalIntegration(org)
+  const dept = await createLocalDepartment({ orgId: org, name: 'Local Dept' })
+  return { intId: int.id, deptId: dept.id, provider: 'local' }
+}
+
+async function dingtalkSide(org: string, tag: string): Promise<Side> {
+  const int = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config)
+     VALUES ($1, 'dingtalk', $2, 'active', $3, '{}'::jsonb) RETURNING id`,
+    [org, `DingTalk ${tag}`, `corp-${STAMP}-${tag}`],
+  )
+  const intId = int.rows[0].id
+  const dept = await query<{ id: string }>(
+    `INSERT INTO directory_departments (integration_id, provider, external_department_id, name, is_active, raw)
+     VALUES ($1, 'dingtalk', $2, $3, true, '{}'::jsonb) RETURNING id`,
+    [intId, `dt:${STAMP}:${tag}`, `DT Dept ${tag}`],
+  )
+  return { intId, deptId: dept.rows[0].id, provider: 'dingtalk' }
+}
+
+interface BindingCols {
+  org_id: string | null
+  local_integration_id: string
+  local_department_id: string
+  local_provider: string
+  remote_integration_id: string
+  remote_department_id: string
+  remote_provider: string
+  status?: string
+}
+
+async function insertBinding(b: BindingCols): Promise<{ id: string }> {
+  const r = await query<{ id: string }>(
+    `INSERT INTO directory_department_bindings
+       (org_id, local_integration_id, local_department_id, local_provider,
+        remote_integration_id, remote_department_id, remote_provider, status)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING id`,
+    [
+      b.org_id,
+      b.local_integration_id,
+      b.local_department_id,
+      b.local_provider,
+      b.remote_integration_id,
+      b.remote_department_id,
+      b.remote_provider,
+      b.status ?? 'active',
+    ],
+  )
+  return r.rows[0]
+}
+
+interface PgError extends Error {
+  code?: string
+  constraint?: string
+  column?: string
+}
+
+async function reject(fn: () => Promise<unknown>): Promise<PgError | null> {
+  try {
+    await fn()
+    return null
+  } catch (e) {
+    return e as PgError
+  }
+}
+
+describeIfDatabase('Canonical Org MVP — B4 department binding table (real DB)', () => {
+  const seededOrgIds: string[] = []
+
+  afterEach(async () => {
+    // bindings + departments cascade on integration delete
+    for (const org of seededOrgIds.splice(0)) {
+      await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [org])
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('A. positive control: a same-org local↔dingtalk binding inserts', async () => {
+    const org = orgId('pos')
+    seededOrgIds.push(org)
+    const local = await localSide(org)
+    const remote = await dingtalkSide(org, 'pos')
+
+    const inserted = await insertBinding({
+      org_id: org,
+      local_integration_id: local.intId,
+      local_department_id: local.deptId,
+      local_provider: 'local',
+      remote_integration_id: remote.intId,
+      remote_department_id: remote.deptId,
+      remote_provider: 'dingtalk',
+    })
+    expect(inserted.id).toBeTruthy()
+  })
+
+  it('B. cross-org binding is FK-impossible — rejected by the org-chain FK (right reason), both org_id choices', async () => {
+    const orgA = orgId('xo-A')
+    const orgB = orgId('xo-B')
+    seededOrgIds.push(orgA, orgB)
+    const local = await localSide(orgA) // local int+dept in A
+    const remote = await dingtalkSide(orgB, 'B') // dingtalk int+dept in B
+
+    // org_id = A → the REMOTE integration (in B) fails its (id, A) org FK
+    const errA = await reject(() =>
+      insertBinding({
+        org_id: orgA,
+        local_integration_id: local.intId,
+        local_department_id: local.deptId,
+        local_provider: 'local',
+        remote_integration_id: remote.intId,
+        remote_department_id: remote.deptId,
+        remote_provider: 'dingtalk',
+      }),
+    )
+    expect(errA?.code).toBe('23503') // foreign_key_violation, NOT 23514 (check) / not a dept FK
+    expect(errA?.constraint).toBe('ddb_remote_int_org_fk')
+
+    // org_id = B → the LOCAL integration (in A) fails its (id, B) org FK
+    const errB = await reject(() =>
+      insertBinding({
+        org_id: orgB,
+        local_integration_id: local.intId,
+        local_department_id: local.deptId,
+        local_provider: 'local',
+        remote_integration_id: remote.intId,
+        remote_department_id: remote.deptId,
+        remote_provider: 'dingtalk',
+      }),
+    )
+    expect(errB?.code).toBe('23503')
+    expect(errB?.constraint).toBe('ddb_local_int_org_fk')
+  })
+
+  it('C. provider-role: local↔local and dingtalk↔dingtalk bindings are rejected', async () => {
+    const org = orgId('role')
+    seededOrgIds.push(org)
+    const local = await localSide(org)
+    const local2 = await createLocalDepartment({ orgId: org, name: 'Local Dept 2' })
+    const dt = await dingtalkSide(org, 'role')
+
+    // local↔local: remote side is the local integration → cannot be a valid remote (CHECK or FK)
+    const errLL = await reject(() =>
+      insertBinding({
+        org_id: org,
+        local_integration_id: local.intId,
+        local_department_id: local.deptId,
+        local_provider: 'local',
+        remote_integration_id: local.intId, // local integration as the "remote" side
+        remote_department_id: local2.id,
+        remote_provider: 'local', // honest → CHECK(remote_provider<>'local') fails
+      }),
+    )
+    expect(errLL).toBeTruthy()
+    expect(['23514', '23503']).toContain(errLL?.code) // provider-role CHECK or provider FK
+
+    // dingtalk↔dingtalk: local side is a dingtalk integration → cannot be a valid local side
+    const dt2 = await dingtalkSide(org, 'role2')
+    const errDD = await reject(() =>
+      insertBinding({
+        org_id: org,
+        local_integration_id: dt.intId, // dingtalk integration as the "local" side
+        local_department_id: dt.deptId,
+        local_provider: 'local', // lie → provider FK (dt.intId,'local') fails
+        remote_integration_id: dt2.intId,
+        remote_department_id: dt2.deptId,
+        remote_provider: 'dingtalk',
+      }),
+    )
+    expect(errDD).toBeTruthy()
+    expect(['23514', '23503']).toContain(errDD?.code)
+  })
+
+  it('D. NOT NULL closes the MATCH SIMPLE hole: the cross-org binding with org_id=NULL is rejected by NOT NULL', async () => {
+    const orgA = orgId('null-A')
+    const orgB = orgId('null-B')
+    seededOrgIds.push(orgA, orgB)
+    const local = await localSide(orgA)
+    const remote = await dingtalkSide(orgB, 'nb')
+
+    const err = await reject(() =>
+      query(
+        `INSERT INTO directory_department_bindings
+           (org_id, local_integration_id, local_department_id, local_provider,
+            remote_integration_id, remote_department_id, remote_provider, status)
+         VALUES (NULL, $1, $2, 'local', $3, $4, 'dingtalk', 'active')`,
+        [local.intId, local.deptId, remote.intId, remote.deptId],
+      ),
+    )
+    expect(err?.code).toBe('23502') // not_null_violation — org_id may not be NULL
+    expect(err?.column).toBe('org_id')
+  })
+
+  it('E. a department must belong to its named integration', async () => {
+    const org = orgId('dept')
+    seededOrgIds.push(org)
+    const local = await localSide(org)
+    const remote = await dingtalkSide(org, 'dept')
+
+    // local_department_id is the DINGTALK dept, but local_integration_id is the local int → dept FK fails
+    const err = await reject(() =>
+      insertBinding({
+        org_id: org,
+        local_integration_id: local.intId,
+        local_department_id: remote.deptId, // wrong: belongs to the dingtalk integration
+        local_provider: 'local',
+        remote_integration_id: remote.intId,
+        remote_department_id: remote.deptId,
+        remote_provider: 'dingtalk',
+      }),
+    )
+    expect(err?.code).toBe('23503')
+    expect(err?.constraint).toBe('ddb_local_dept_fk')
+  })
+
+  it('F. schema contract: the six FKs + provider CHECK + three parent UNIQUE constraints exist', async () => {
+    const own = await query<{ conname: string }>(
+      `SELECT conname FROM pg_constraint WHERE conrelid = 'directory_department_bindings'::regclass`,
+    )
+    const names = own.rows.map((r) => r.conname)
+    for (const c of [
+      'ddb_local_int_org_fk',
+      'ddb_remote_int_org_fk',
+      'ddb_local_int_provider_fk',
+      'ddb_remote_int_provider_fk',
+      'ddb_local_dept_fk',
+      'ddb_remote_dept_fk',
+      'ddb_provider_role_chk',
+    ]) {
+      expect(names).toContain(c)
+    }
+
+    const parents = await query<{ conname: string }>(
+      `SELECT conname FROM pg_constraint
+        WHERE conname IN ('uq_directory_integrations_id_org','uq_directory_integrations_id_provider','uq_directory_departments_id_integration')
+          AND contype = 'u'`,
+    )
+    expect(parents.rows.length).toBe(3)
+  })
+})

--- a/packages/core-backend/tests/integration/directory-department-bindings.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-department-bindings.db.test.ts
@@ -259,6 +259,86 @@ describeIfDatabase('Canonical Org MVP — B4 department binding table (real DB)'
     expect(err?.constraint).toBe('ddb_local_dept_fk')
   })
 
+  it('G. UPDATE path cannot bypass the chain: repoint-remote / rewrite-org_id / NULL-org_id / parent-org rewrite all rejected', async () => {
+    // FKs re-check on UPDATE of referencing columns — but that is an ASSERTED invariant until
+    // pinned. Owner review focus: "无 NULL、更新或 raw SQL 绕过". Four legs, each by exact cause.
+    const orgA = orgId('upd-A')
+    const orgB = orgId('upd-B')
+    seededOrgIds.push(orgA, orgB)
+    const local = await localSide(orgA)
+    const remoteA = await dingtalkSide(orgA, 'updA')
+    const remoteB = await dingtalkSide(orgB, 'updB')
+    const binding = await insertBinding({
+      org_id: orgA,
+      local_integration_id: local.intId,
+      local_department_id: local.deptId,
+      local_provider: 'local',
+      remote_integration_id: remoteA.intId,
+      remote_department_id: remoteA.deptId,
+      remote_provider: 'dingtalk',
+    })
+
+    // (a) repoint the remote side to an org-B integration → remote org FK rejects
+    const errA = await reject(() =>
+      query(
+        `UPDATE directory_department_bindings SET remote_integration_id=$1, remote_department_id=$2 WHERE id=$3`,
+        [remoteB.intId, remoteB.deptId, binding.id],
+      ),
+    )
+    expect(errA?.code).toBe('23503')
+    expect(errA?.constraint).toBe('ddb_remote_int_org_fk')
+
+    // (b) rewrite org_id alone → the LOCAL org FK rejects (both sides re-check)
+    const errB = await reject(() =>
+      query(`UPDATE directory_department_bindings SET org_id=$1 WHERE id=$2`, [orgB, binding.id]),
+    )
+    expect(errB?.code).toBe('23503')
+    expect(errB?.constraint).toBe('ddb_local_int_org_fk')
+
+    // (c) NULL org_id via UPDATE → NOT NULL rejects (the MATCH SIMPLE closer holds on UPDATE too)
+    const errC = await reject(() =>
+      query(`UPDATE directory_department_bindings SET org_id=NULL WHERE id=$1`, [binding.id]),
+    )
+    expect(errC?.code).toBe('23502')
+
+    // (d) PARENT-side rewrite: moving a BOUND integration to another org is rejected — the chain
+    // also pins the parent's org while a binding references it (a transfer must handle bindings
+    // first; it cannot silently drag a binding cross-org from the parent side).
+    const errD = await reject(() =>
+      query(`UPDATE directory_integrations SET org_id=$1 WHERE id=$2`, [orgB, remoteA.intId]),
+    )
+    expect(errD?.code).toBe('23503')
+    expect(errD?.constraint).toBe('ddb_remote_int_org_fk')
+  })
+
+  it('H. CASCADE radius: deleting the remote integration removes the binding ONLY — local integration and department survive', async () => {
+    const org = orgId('casc')
+    seededOrgIds.push(org)
+    const local = await localSide(org)
+    const remote = await dingtalkSide(org, 'casc')
+    const binding = await insertBinding({
+      org_id: org,
+      local_integration_id: local.intId,
+      local_department_id: local.deptId,
+      local_provider: 'local',
+      remote_integration_id: remote.intId,
+      remote_department_id: remote.deptId,
+      remote_provider: 'dingtalk',
+    })
+
+    await query(`DELETE FROM directory_integrations WHERE id = $1`, [remote.intId])
+
+    const gone = await query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM directory_department_bindings WHERE id = $1`,
+      [binding.id],
+    )
+    expect(gone.rows[0].n).toBe(0) // binding cascaded away
+    const localInt = await query<{ n: number }>(`SELECT count(*)::int AS n FROM directory_integrations WHERE id = $1`, [local.intId])
+    const localDept = await query<{ n: number }>(`SELECT count(*)::int AS n FROM directory_departments WHERE id = $1`, [local.deptId])
+    expect(localInt.rows[0].n).toBe(1) // local parents untouched
+    expect(localDept.rows[0].n).toBe(1)
+  })
+
   it('F. schema contract: the six FKs + provider CHECK + three parent UNIQUE constraints exist', async () => {
     const own = await query<{ conname: string }>(
       `SELECT conname FROM pg_constraint WHERE conrelid = 'directory_department_bindings'::regclass`,

--- a/packages/core-backend/tests/integration/directory-department-bindings.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-department-bindings.db.test.ts
@@ -356,10 +356,14 @@ describeIfDatabase('Canonical Org MVP — B4 department binding table (real DB)'
       expect(names).toContain(c)
     }
 
+    // conname is NOT database-unique (same lesson as the migration's own probes): pin each parent
+    // constraint to ITS table via conrelid, so a same-named constraint elsewhere can't fake the 3.
     const parents = await query<{ conname: string }>(
       `SELECT conname FROM pg_constraint
-        WHERE conname IN ('uq_directory_integrations_id_org','uq_directory_integrations_id_provider','uq_directory_departments_id_integration')
-          AND contype = 'u'`,
+        WHERE contype = 'u'
+          AND ((conname = 'uq_directory_integrations_id_org'      AND conrelid = 'directory_integrations'::regclass)
+            OR (conname = 'uq_directory_integrations_id_provider' AND conrelid = 'directory_integrations'::regclass)
+            OR (conname = 'uq_directory_departments_id_integration' AND conrelid = 'directory_departments'::regclass))`,
     )
     expect(parents.rows.length).toBe(3)
   })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -128,6 +128,13 @@ export default defineConfig({
       // a WHOLE FILE into the directory real-DB step in plugin-tests.yml (both points asserted by
       // pb4-4-reactivation-ci-wiring.test.mjs so neither can silently drop).
       'tests/integration/directory-local-integration-reactivation.db.test.ts',
+      // Canonical Org MVP B4 (#4215 §5.5): directory_department_bindings buildable FK chain — a
+      // cross-org binding is FK-IMPOSSIBLE to insert (both integrations pinned to one org_id column;
+      // NOT NULL closes the MATCH SIMPLE hole). Proves rejection BY the org-chain FK by name + the
+      // NOT NULL/FK mutations — meaningless without a real DB. DATABASE_URL-gated; excluded here so
+      // the no-DB job cannot skip-green it, and wired as a WHOLE FILE into the directory real-DB step
+      // in plugin-tests.yml (both points asserted by b4-department-bindings-ci-wiring.test.mjs).
+      'tests/integration/directory-department-bindings.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
       // resolution against real Postgres — normalized `is_manager` relation for a local integration,
       // the DingTalk `leader_in_dept` regression pin (load-bearing compat leg + is_manager=0 positive

--- a/scripts/ops/b4-department-bindings-ci-wiring.test.mjs
+++ b/scripts/ops/b4-department-bindings-ci-wiring.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// B4 CI two-point wiring contract. The department-bindings suite proves the buildable FK chain makes
+// a cross-org binding FK-impossible (and that the NOT NULL closes the MATCH SIMPLE hole) against real
+// Postgres — meaningless without a DB. It needs BOTH (1) the vitest.config.ts exclude entry (so the
+// no-DB job cannot skip-green it) AND (2) the plugin-tests.yml directory real-DB whole-file step (so
+// a real-DB run actually names it). Removing either point makes the entire FK-chain proof silently
+// never execute while exact-head CI stays green. This source-level guard (no DB) reddens if either
+// point is dropped. It runs in the no-DB `test` job, so it gates every PR.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/directory-department-bindings.db.test.ts'
+
+test('vitest.config.ts excludes the B4 department-bindings suite from the no-DB job', () => {
+  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE} (DATABASE_URL-gated whole file)`)
+})
+
+test('plugin-tests.yml runs the B4 department-bindings suite as a whole file in the directory real-DB step', () => {
+  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  assert.match(wf, new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${FILE} in the directory real-DB step`)
+})


### PR DESCRIPTION
## B4 — Department binding table (`directory_department_bindings`)

> **Posture: HELD for owner review — do NOT auto-land. Unarmed.** First B-series ticket after the pre-B4 hardening batch + ledger ratification. Base is `main`.

Canonical Org MVP §5.5. Binds a local department to an external-provider (DingTalk) department so routing/reconciliation can resolve across the canonical local org and a provider directory. Done-gate: **a cross-org binding is impossible to INSERT** — enforced by the schema's buildable FK chain, not service code.

### The buildable FK chain
- The binding carries a **single `org_id`**, and **both** integration ids are FK'd to `directory_integrations(id, org_id)` against that same column → a local-in-A / remote-in-B binding has **no satisfying `org_id`** → FK-rejected.
- **Every FK-participating column is NOT NULL.** Postgres composite FKs are **MATCH SIMPLE** — a NULL in any FK column skips the FK entirely — so the NOT NULL is what makes the org chain unbypassable (proven load-bearing by the drop-NOT-NULL mutation).
- **provider-role is FK-backed, no trigger**: redundant `local_provider`/`remote_provider` columns each FK'd to `directory_integrations(id, provider)` + `CHECK(local_provider='local' AND remote_provider<>'local')`.
- Each department pinned to its integration **and to the role's provider** via the THREE-column `(department_id, integration_id, provider) → directory_departments(id, integration_id, provider)` (owner P2 round — see below).
- **ON DELETE CASCADE** on every FK, matching the existing integration→departments cascade (a binding is meaningless once a referenced row is hard-deleted; archive-not-delete means this rarely fires).
- `status` is `active | stale` for B7 suggest-only reconciliation.

The three parent `UNIQUE` constraints the composite FKs reference (`integrations(id,org_id)`, `integrations(id,provider)`, `departments(id,integration_id,provider)`) are **redundant supersets of the PKs** — reject no existing row — added via `pg_constraint` existence probes. Table is `CREATE TABLE IF NOT EXISTS`; **migration is replay-idempotent** (verified: re-run no-ops, down/up round-trips).

### Real-DB proof — `directory-department-bindings.db.test.ts` (11 tests: 10 behavioral + DB sentinel)
- **A** positive control — same-org local↔dingtalk binding inserts (guard rejects the cross-org case, not all bindings).
- **B** cross-org FK-impossible **for the right reason** — rejected by the org-chain FK **by constraint name**, both `org_id` choices (`ddb_remote_int_org_fk` / `ddb_local_int_org_fk`), not incidentally by the CHECK or a dept FK.
- **C** provider-role — local↔local and dingtalk↔dingtalk rejected.
- **D** **NOT NULL closes the MATCH SIMPLE hole** — the cross-org binding with `org_id=NULL` is rejected by NOT NULL (23502).
- **E** dept-belongs-to-integration (`ddb_local_dept_fk`).
- **F** schema contract — six FKs + provider CHECK + three parent UNIQUE constraints.

### Load-bearing mutations (proven out-of-band, each reds this file)
- `ALTER … org_id DROP NOT NULL` → **D reds** (NULL-org_id cross-org binding now inserts — the MATCH SIMPLE bypass opens).
- `ALTER … DROP CONSTRAINT ddb_remote_int_org_fk` → **B reds** (cross-org binding inserts).

### CI wiring (two points + guard)
`vitest.config.ts` exclude + `plugin-tests.yml` directory real-DB whole-file step; `scripts/ops/b4-department-bindings-ci-wiring.test.mjs` (no-DB, gating job) reds if either point drops — proven load-bearing.

### Owner pre-review evidence pack (head `bc77b04c9`; migration byte-identical to the gate-reviewed `5d1f68beb` — the delta is test-only)
Mapping your seven re-review checkpoints to durable evidence:
1. **同一 org_id 闭环，无 NULL/UPDATE/raw-SQL 绕过** — tests B (INSERT, rejected by org FK *by name*, both org_id choices) + D (NULL-org_id INSERT → 23502) + **new test G** (UPDATE path, four legs each by exact cause: repoint-remote → `ddb_remote_int_org_fk`; rewrite-org_id-alone → `ddb_local_int_org_fk`; NULL-org_id UPDATE → 23502; **parent-side org rewrite of a bound integration → rejected** — the chain pins the parent's org while referenced, so a future transfer must handle bindings first). All raw SQL (no service layer exists yet — that is B7).
2. **provider-role + dept→integration 皆 DB 强制** — tests C (local↔local and dingtalk↔dingtalk rejected: CHECK + provider FK) and E (`ddb_local_dept_fk` by name).
3. **CASCADE 删除半径只清 binding** — **new test H**: delete the remote integration → binding gone, local integration + department survive. (Parents are never touched by a binding delete — FKs only point outward.)
4. **up/down/up、fresh、upgrade、replay** — fresh DB migrate ✅; replay no-ops ✅ (runner re-run executes 0); down→up round-trip ✅; **upgrade over a data-bearing pre-B4 DB** ✅ (seeded integrations/departments in two orgs → B4 applied, 3 parent uniques installed over existing rows → cross-org INSERT still rejected by `ddb_remote_int_org_fk` on the upgraded DB).
5. **两个 mutation 因目标不变量变红** — drop-NOT-NULL → test D reds with `expected undefined to be '23502'` (i.e. the INSERT *succeeded* — MATCH SIMPLE bypass opened, not another constraint intercepting); drop `ddb_remote_int_org_fk` → test B reds with `expected undefined to be '23503'` (cross-org INSERT succeeded). Both asserted by exact code+constraint name, so incidental interception cannot fake the pass.
6. **CI 真实执行** — two-point wiring (vitest exclude + plugin-tests directory real-DB whole-file step) + no-DB guard `b4-department-bindings-ci-wiring.test.mjs`, itself proven load-bearing (dropping the exclude reds it).
7. **净范围只有 B4** — 5 files (migration, test, vitest.config exclude, plugin-tests wiring, wiring guard). No B5/B6 routing changes.

### Adversarial gate — VERDICT: APPROVE (no P1/P2)
Opus refute-first gate, all empirical on its own scratch DB: could not construct a single cross-org INSERT that survives. It verified all 7 FK columns NOT NULL in the live schema; cross-org rejected for both `org_id` choices + a third value + child-UPDATE + parent-side org-UPDATE, each by the exact intended constraint; provider-role/dept-integration bypasses closed; **both mutations reproduced AND the hole confirmed to actually open** (a NULL-org / cross-org row inserts under the mutation — not merely test-reds); CASCADE correct with 3 converging paths (concurs with CASCADE over RESTRICT); replay + down/up clean, probes correctly pinned; uniqueness grain matches §5.5 (external-side only, local-multi-bind by design); CI gate real (`test (20.x)` required, no path filter, no continue-on-error). Gate verdict is SHA-scoped to `bc77b04c9` (migration byte-identical since its assigned head; the delta was the G/H pin tests, which it ran green and proved non-vacuous).
- **NIT-1 (fixed, head `28118c3df`)**: test F's parent-uniques probe was conrelid-unpinned — now pinned per-table (same lesson the migration's own probes encode). Test-only; migration unchanged.
- **NIT-2 (documented, owner's call)**: schema is leaner than §5.5's *Suggested* table — `match_strategy`/`confidence`/`decided_by` omitted, `status` limited to `active|stale`. Meets the B4 done-gate; the gate and I both read the review-workflow columns as a B5/B7 follow-up when the reconciliation surface exists. Say the word if you want them in the B4 schema now.

### Owner review round — P2 fixed (head `c8873308a`)
**[P2] The dept FKs carried no provider leg** — you reproduced both illegal INSERTs on a fresh DB at `28118c3df`: a `provider='dingtalk'` department under the LOCAL integration as the local side, and a `provider='local'` department under the DINGTALK integration as the remote side (the provider-mislabeled shape B3/PB4-2 already treat as real). Integration-level provider FKs cannot see the DEPARTMENT row's own provider column.

Fixed exactly per prescription:
- Parent UNIQUE is now `uq_directory_departments_id_integration_provider (id, integration_id, provider)` (replacing the two-column one — nothing else referenced it); `down()` synced.
- Both dept FKs are **three-column**: `(local_department_id, local_integration_id, local_provider)` and `(remote_department_id, remote_integration_id, remote_provider)` → `directory_departments(id, integration_id, provider)`. Integration-provider FKs + role CHECK kept.
- **New tests I/J**: each mislabeled shape rejected by its dept FK **by name** (`ddb_local_dept_fk` / `ddb_remote_dept_fk`).
- **Both prescribed mutations red**: dropping each FK's provider leg separately (re-adding the two-column form) → its test reds with `expected undefined to be '23503'` — i.e. the illegal INSERT *succeeded* under the mutation, so each test pins its own provider leg, not incidental interception.
- Test F now also asserts the dept FKs' **referencing-column count = 3** (a two-column FK would pass a name-existence check while reopening the hole).
- Re-verified on the edited migration: fresh migrate, replay no-op, down→up round-trip, full 9-file directory suite 164/164, tsc clean.

**[P3] fixed**: test-count corrected to the real total (11: 10 behavioral + DB sentinel) throughout this body.
`match_strategy`/`confidence`/`decided_by` deferred to the B7 design lock per your ruling.

**B5/B6 (routing-core) await your design locks before implementation.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)



