### PR TITLE
feat(automation): #4196 §2.1/§4 rule action-set fingerprint (catches config-only edits)

### DIFF
--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -5,6 +5,7 @@
 
 import { randomUUID } from 'crypto'
 import { recordRecordRevision, recordVersionMarker } from './record-history-service'
+import { branchChildStepKey, topLevelStepKey } from './automation-step-key'
 import { Logger } from '../core/logger'
 import { withAutomationEventId } from './automation-event-dedup'
 import { redactString } from './automation-log-redact'
@@ -1079,7 +1080,7 @@ export class AutomationExecutor {
       let failedAtBranchIndex = -1
       for (let i = cursor.branchActionIndex + 1; i < branchActions.length; i++) {
         const branchAction = branchActions[i]
-        const stepKey = `${cursor.parentStepIndex}.branch.${cursor.branchKey}.${i}`
+        const stepKey = branchChildStepKey(cursor.parentStepIndex, 'branch', cursor.branchKey, i)
         const jobId = `${context.executionId}:job:${cursor.parentStepIndex}:branch:${cursor.branchKey}:${i}`
         const meta = { stepKey, jobId, upstreamJobId }
 
@@ -1140,7 +1141,7 @@ export class AutomationExecutor {
       // plane complete instead of leaving downstream branch work invisible.
       if (branchFailed && failedAtBranchIndex >= 0) {
         for (let j = failedAtBranchIndex + 1; j < branchActions.length; j++) {
-          const skippedStepKey = `${cursor.parentStepIndex}.branch.${cursor.branchKey}.${j}`
+          const skippedStepKey = branchChildStepKey(cursor.parentStepIndex, 'branch', cursor.branchKey, j)
           const skippedJobId = `${context.executionId}:job:${cursor.parentStepIndex}:branch:${cursor.branchKey}:${j}`
           await jobLifecycle.onSkipped(cursor.parentStepIndex, branchActions[j], {
             stepKey: skippedStepKey,
@@ -1169,7 +1170,7 @@ export class AutomationExecutor {
       execution.steps.push(parentStepResult)
       await jobLifecycle.onSettled(cursor.parentStepIndex, parentAction, parentStepResult, {
         jobId: cursor.parentJobId,
-        stepKey: String(cursor.parentStepIndex),
+        stepKey: topLevelStepKey(cursor.parentStepIndex),
       })
 
       // 4. Top-level tail: continue on success; on failure, fail-stop the remaining top-level
@@ -1426,7 +1427,7 @@ export class AutomationExecutor {
       let branchFailed = false
       for (let actionIndex = 0; actionIndex < branchActions.length; actionIndex++) {
         const branchAction = branchActions[actionIndex]
-        const stepKey = `${stepIndex}.parallel.${branchKey}.${actionIndex}`
+        const stepKey = branchChildStepKey(stepIndex, 'parallel', branchKey, actionIndex)
         const jobId = `${context.executionId}:job:${stepIndex}:parallel:${branchKey}:${actionIndex}`
         const meta = { stepKey, jobId, upstreamJobId }
         childJobIds.push(jobId)
@@ -1441,7 +1442,7 @@ export class AutomationExecutor {
           branchFailed = true
           for (let skippedIndex = actionIndex + 1; skippedIndex < branchActions.length; skippedIndex++) {
             const skippedAction = branchActions[skippedIndex]
-            const skippedStepKey = `${stepIndex}.parallel.${branchKey}.${skippedIndex}`
+            const skippedStepKey = branchChildStepKey(stepIndex, 'parallel', branchKey, skippedIndex)
             const skippedJobId = `${context.executionId}:job:${stepIndex}:parallel:${branchKey}:${skippedIndex}`
             await jobLifecycle.onSkipped(stepIndex, skippedAction, {
               stepKey: skippedStepKey,

--- a/packages/core-backend/src/multitable/automation-rule-fingerprint.ts
+++ b/packages/core-backend/src/multitable/automation-rule-fingerprint.ts
@@ -4,23 +4,31 @@
  * The suspend/resume + bridge guards use `computeActionFingerprint` (automation-suspension-service.ts), which
  * per §2.1 hashes ONLY the sequence of action TYPES — it cannot see a config-only edit (same types, changed
  * config), which is exactly the "rule changed" a retry must refuse (§4). This module derives a fingerprint
- * over the SAME injective identity the applied-ledger locks for `action_key` — `{ structuralPath, action.type,
- * canonicalConfig }` (`deriveActionKey`) — so a config edit, a type swap in place, or an action reorder all
- * change the fingerprint.
+ * over the SAME injective identity the applied-ledger locks for `action_key` — `deriveActionKey({
+ * structuralPath, actionType, canonicalConfig })` — so a config edit, a type swap in place, an action
+ * reorder, or a branch-key change all change the fingerprint.
  *
- * `enumerateRuleActions` is the SHARED canonical walk: it assigns every action (top-level AND nested inside a
- * `parallel_branch` / `condition_branch`, both of which nest via `config.branches[].actions[]`) a stable
- * structural path. The retry rule-change guard AND the future Class-A claim wiring both consume THIS walk, so
- * the structural paths they compare can never drift apart — the exact path string is an internal detail as
- * long as it is injective and position-sensitive, which this scheme is.
+ * `enumerateRuleActions` assigns every action (top-level AND nested inside a `parallel_branch` /
+ * `condition_branch`) the EXACT step-key the executor stamps, via the shared `automation-step-key` builder —
+ * `${i}` / `${i}.parallel.${branchKey}.${j}` / `${i}.branch.${branchKey}.${j}`. The retry guard AND the
+ * future Class-A claim consume THIS walk, so the identities they compare are the executor's own identities,
+ * never a divergent index-based path (#4420 review P1). Config is passed RAW to `deriveActionKey` (which
+ * canonicalizes internally) so the enumerator's key is byte-identical to a direct `deriveActionKey` call
+ * on the same action — i.e. the fingerprint really shares the applied-ledger identity (#4420 review P2).
  */
 import { createHash } from 'node:crypto'
 
-import { canonicalizeConfig, deriveActionKey } from './automation-action-idempotency'
+import { deriveActionKey } from './automation-action-idempotency'
+import { branchChildStepKey, topLevelStepKey, type BranchKind } from './automation-step-key'
 
 interface RuleAction {
   type: string
   config?: unknown
+}
+
+interface Branch {
+  key?: unknown
+  actions?: ReadonlyArray<RuleAction>
 }
 
 export interface RuleActionFingerprint {
@@ -30,50 +38,66 @@ export interface RuleActionFingerprint {
   hash: string
 }
 
-const MAX_NESTING_DEPTH = 8 // guard against a pathological/cyclic config; real rules nest at most a couple deep
+const MAX_NESTING_DEPTH = 8 // guard a pathological/cyclic config; real rules nest a couple deep at most
+
+/** The `.parallel.` vs `.branch.` segment is chosen by the PARENT action's type (matches the executor). */
+function branchKindForParent(parentType: string): BranchKind | null {
+  if (parentType === 'parallel_branch') return 'parallel'
+  if (parentType === 'condition_branch') return 'branch'
+  return null
+}
 
 /**
- * Yield every action in the rule with its canonical structural path, recursing into `config.branches[].actions[]`
- * (the shared nesting shape of parallel_branch and condition_branch). Deterministic order: top-level index, then
- * branch index, then nested action index.
+ * Yield every action in the rule with its canonical executor step-key. Deterministic order: top-level index,
+ * then branch order, then nested action index. A branch's identity is its stable `key` (NOT its array index),
+ * so reordering branches does not move a child's identity.
  */
 export function* enumerateRuleActions(
   actions: ReadonlyArray<RuleAction> | undefined,
-  prefix = 'actions',
-  depth = 0,
 ): Generator<{ action: RuleAction; structuralPath: string }> {
-  if (!Array.isArray(actions) || depth > MAX_NESTING_DEPTH) return
+  if (!Array.isArray(actions)) return
   for (let i = 0; i < actions.length; i++) {
     const action = actions[i]
     if (!action || typeof action.type !== 'string') continue
-    const structuralPath = `${prefix}[${i}]`
-    yield { action, structuralPath }
+    yield { action, structuralPath: topLevelStepKey(i) }
+    const kind = branchKindForParent(action.type)
+    if (!kind) continue
     const config = action.config
     const branches = config && typeof config === 'object' ? (config as { branches?: unknown }).branches : undefined
-    if (Array.isArray(branches)) {
-      for (let b = 0; b < branches.length; b++) {
-        const branch = branches[b] as { actions?: ReadonlyArray<RuleAction> } | undefined
-        yield* enumerateRuleActions(branch?.actions, `${structuralPath}.branches[${b}].actions`, depth + 1)
-      }
+    if (!Array.isArray(branches)) continue
+    for (const branch of branches as Branch[]) {
+      const branchKey = typeof branch?.key === 'string' ? branch.key : ''
+      yield* enumerateBranchActions(branch?.actions, i, kind, branchKey, 1)
     }
+  }
+}
+
+function* enumerateBranchActions(
+  actions: ReadonlyArray<RuleAction> | undefined,
+  parentStepIndex: number,
+  kind: BranchKind,
+  branchKey: string,
+  depth: number,
+): Generator<{ action: RuleAction; structuralPath: string }> {
+  if (!Array.isArray(actions) || depth > MAX_NESTING_DEPTH) return
+  for (let j = 0; j < actions.length; j++) {
+    const action = actions[j]
+    if (!action || typeof action.type !== 'string') continue
+    yield { action, structuralPath: branchChildStepKey(parentStepIndex, kind, branchKey, j) }
   }
 }
 
 /**
  * Fingerprint the rule's action set over the §2.1 identity. Two rules with the same fingerprint have the same
- * actions at the same structural positions with the same types AND the same canonical config; ANY difference
- * (config-only, type swap, reorder, add/remove, nested-branch edit) changes it.
+ * actions at the same structural step-keys with the same types AND the same config; ANY difference
+ * (config-only, type swap, reorder, add/remove, branch-key change) changes it.
  */
 export function deriveRuleActionSetFingerprint(actions: ReadonlyArray<RuleAction> | undefined): RuleActionFingerprint {
   const keys: string[] = []
   for (const { action, structuralPath } of enumerateRuleActions(actions)) {
-    keys.push(
-      deriveActionKey({
-        structuralPath,
-        actionType: action.type,
-        canonicalConfig: canonicalizeConfig(action.config ?? {}),
-      }),
-    )
+    // RAW config — deriveActionKey canonicalizes internally; passing pre-canonicalized text would double-apply
+    // it and diverge from the applied-ledger key (#4420 review P2).
+    keys.push(deriveActionKey({ structuralPath, actionType: action.type, canonicalConfig: action.config ?? {} }))
   }
   keys.sort()
   const hash = createHash('sha256').update(JSON.stringify(keys)).digest('hex')

--- a/packages/core-backend/src/multitable/automation-rule-fingerprint.ts
+++ b/packages/core-backend/src/multitable/automation-rule-fingerprint.ts
@@ -1,0 +1,81 @@
+/**
+ * #4196 §2.1 / §4 — the RULE action-set fingerprint over the FULL action identity.
+ *
+ * The suspend/resume + bridge guards use `computeActionFingerprint` (automation-suspension-service.ts), which
+ * per §2.1 hashes ONLY the sequence of action TYPES — it cannot see a config-only edit (same types, changed
+ * config), which is exactly the "rule changed" a retry must refuse (§4). This module derives a fingerprint
+ * over the SAME injective identity the applied-ledger locks for `action_key` — `{ structuralPath, action.type,
+ * canonicalConfig }` (`deriveActionKey`) — so a config edit, a type swap in place, or an action reorder all
+ * change the fingerprint.
+ *
+ * `enumerateRuleActions` is the SHARED canonical walk: it assigns every action (top-level AND nested inside a
+ * `parallel_branch` / `condition_branch`, both of which nest via `config.branches[].actions[]`) a stable
+ * structural path. The retry rule-change guard AND the future Class-A claim wiring both consume THIS walk, so
+ * the structural paths they compare can never drift apart — the exact path string is an internal detail as
+ * long as it is injective and position-sensitive, which this scheme is.
+ */
+import { createHash } from 'node:crypto'
+
+import { canonicalizeConfig, deriveActionKey } from './automation-action-idempotency'
+
+interface RuleAction {
+  type: string
+  config?: unknown
+}
+
+export interface RuleActionFingerprint {
+  /** total actions counted, including nested — a count mismatch alone is a change */
+  count: number
+  /** sha256 over the sorted set of per-action §2.1 identities */
+  hash: string
+}
+
+const MAX_NESTING_DEPTH = 8 // guard against a pathological/cyclic config; real rules nest at most a couple deep
+
+/**
+ * Yield every action in the rule with its canonical structural path, recursing into `config.branches[].actions[]`
+ * (the shared nesting shape of parallel_branch and condition_branch). Deterministic order: top-level index, then
+ * branch index, then nested action index.
+ */
+export function* enumerateRuleActions(
+  actions: ReadonlyArray<RuleAction> | undefined,
+  prefix = 'actions',
+  depth = 0,
+): Generator<{ action: RuleAction; structuralPath: string }> {
+  if (!Array.isArray(actions) || depth > MAX_NESTING_DEPTH) return
+  for (let i = 0; i < actions.length; i++) {
+    const action = actions[i]
+    if (!action || typeof action.type !== 'string') continue
+    const structuralPath = `${prefix}[${i}]`
+    yield { action, structuralPath }
+    const config = action.config
+    const branches = config && typeof config === 'object' ? (config as { branches?: unknown }).branches : undefined
+    if (Array.isArray(branches)) {
+      for (let b = 0; b < branches.length; b++) {
+        const branch = branches[b] as { actions?: ReadonlyArray<RuleAction> } | undefined
+        yield* enumerateRuleActions(branch?.actions, `${structuralPath}.branches[${b}].actions`, depth + 1)
+      }
+    }
+  }
+}
+
+/**
+ * Fingerprint the rule's action set over the §2.1 identity. Two rules with the same fingerprint have the same
+ * actions at the same structural positions with the same types AND the same canonical config; ANY difference
+ * (config-only, type swap, reorder, add/remove, nested-branch edit) changes it.
+ */
+export function deriveRuleActionSetFingerprint(actions: ReadonlyArray<RuleAction> | undefined): RuleActionFingerprint {
+  const keys: string[] = []
+  for (const { action, structuralPath } of enumerateRuleActions(actions)) {
+    keys.push(
+      deriveActionKey({
+        structuralPath,
+        actionType: action.type,
+        canonicalConfig: canonicalizeConfig(action.config ?? {}),
+      }),
+    )
+  }
+  keys.sort()
+  const hash = createHash('sha256').update(JSON.stringify(keys)).digest('hex')
+  return { count: keys.length, hash }
+}

--- a/packages/core-backend/src/multitable/automation-step-key.ts
+++ b/packages/core-backend/src/multitable/automation-step-key.ts
@@ -1,0 +1,29 @@
+/**
+ * #4196 — the SINGLE source of truth for an action's structural step-key (its `structuralPath` identity).
+ *
+ * The executor already stamps every action with a `stepKey` for its C1 job / step provenance:
+ *   - a top-level action at index i:                    `${i}`                         (e.g. "0")
+ *   - a `parallel_branch` child (branch KEY k, index j): `${i}.parallel.${k}.${j}`
+ *   - a `condition_branch` child (branch KEY k, index j): `${i}.branch.${k}.${j}`
+ *
+ * The retry rule-change fingerprint (§4) AND the future Class-A applied-ledger claim (§2) BOTH key on this
+ * exact identity — so it MUST NOT be re-invented per-consumer (a fingerprint that used branch ARRAY INDEX
+ * instead of branch KEY would diverge from the executor's identity, and a branch reorder would then falsely
+ * read as "rule changed" while a same-index-different-key swap would falsely read as "same" — #4420 review
+ * P1). This module is that one builder; the executor and the fingerprint both call it.
+ *
+ * The branch KEY (not the array position) is deliberate: a branch is identified by its stable `key`, so
+ * reordering branches does NOT change a child's identity, and two branches sharing a child index are still
+ * distinct.
+ */
+export type BranchKind = 'parallel' | 'branch'
+
+/** A top-level action's step-key: just its index. */
+export function topLevelStepKey(stepIndex: number): string {
+  return String(stepIndex)
+}
+
+/** A branch child's step-key: `${parentStepIndex}.${kind}.${branchKey}.${actionIndex}` (kind = parallel | branch). */
+export function branchChildStepKey(parentStepIndex: number, kind: BranchKind, branchKey: string, actionIndex: number): string {
+  return `${parentStepIndex}.${kind}.${branchKey}.${actionIndex}`
+}

--- a/packages/core-backend/tests/unit/automation-rule-fingerprint.test.ts
+++ b/packages/core-backend/tests/unit/automation-rule-fingerprint.test.ts
@@ -1,0 +1,86 @@
+/**
+ * #4196 §2.1/§4 rule action-set fingerprint (unit).
+ *
+ * Proves the §2.1-identity fingerprint detects the rule changes a retry must refuse — including the
+ * config-only edit that the existing type-only `computeActionFingerprint` (suspend/resume guard) CANNOT see.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { deriveRuleActionSetFingerprint, enumerateRuleActions } from '../../src/multitable/automation-rule-fingerprint'
+import { computeActionFingerprint } from '../../src/multitable/automation-suspension-service'
+
+const A = (type: string, config: Record<string, unknown> = {}) => ({ type, config })
+
+describe('#4196 §2.1 rule action-set fingerprint', () => {
+  it('identical action sets fingerprint identically', () => {
+    const r1 = [A('update_record', { fields: { a: 1 } }), A('send_webhook', { url: 'x' })]
+    const r2 = [A('update_record', { fields: { a: 1 } }), A('send_webhook', { url: 'x' })]
+    expect(deriveRuleActionSetFingerprint(r1)).toEqual(deriveRuleActionSetFingerprint(r2))
+  })
+
+  it('a CONFIG-ONLY edit changes the fingerprint — the gap the type-only guard misses', () => {
+    const before = [A('update_record', { fields: { a: 1 } })]
+    const after = [A('update_record', { fields: { a: 2 } })] // same type, changed config
+    // the NEW fingerprint sees the change...
+    expect(deriveRuleActionSetFingerprint(before).hash).not.toBe(deriveRuleActionSetFingerprint(after).hash)
+    // ...while the existing type-only fingerprint is BLIND to it (this is exactly why §4 mandates the upgrade)
+    expect(computeActionFingerprint(before).hash).toBe(computeActionFingerprint(after).hash)
+  })
+
+  it('a TYPE SWAP in place changes the fingerprint', () => {
+    const before = [A('update_record', { fields: { a: 1 } })]
+    const after = [A('delete_record', { fields: { a: 1 } })] // same path + config, different type
+    expect(deriveRuleActionSetFingerprint(before).hash).not.toBe(deriveRuleActionSetFingerprint(after).hash)
+  })
+
+  it('REORDERING actions changes the fingerprint (structural path is position-sensitive)', () => {
+    const before = [A('update_record', { x: 1 }), A('send_webhook', { u: 2 })]
+    const after = [A('send_webhook', { u: 2 }), A('update_record', { x: 1 })]
+    expect(deriveRuleActionSetFingerprint(before).hash).not.toBe(deriveRuleActionSetFingerprint(after).hash)
+  })
+
+  it('ADD / REMOVE changes both count and hash', () => {
+    const one = [A('update_record', { a: 1 })]
+    const two = [A('update_record', { a: 1 }), A('send_webhook', { u: 1 })]
+    const fp1 = deriveRuleActionSetFingerprint(one)
+    const fp2 = deriveRuleActionSetFingerprint(two)
+    expect(fp1.count).toBe(1)
+    expect(fp2.count).toBe(2)
+    expect(fp1.hash).not.toBe(fp2.hash)
+  })
+
+  it('a NESTED branch action config edit changes the fingerprint (walk recurses config.branches[].actions[])', () => {
+    const mk = (v: number) => [
+      A('condition_branch', {
+        branches: [
+          { key: 'b0', actions: [A('update_record', { fields: { n: v } })] },
+          { key: 'b1', actions: [A('send_webhook', { url: 'y' })] },
+        ],
+      }),
+    ]
+    expect(deriveRuleActionSetFingerprint(mk(1)).hash).not.toBe(deriveRuleActionSetFingerprint(mk(2)).hash)
+    // the nested walk counts the parent + both branch actions
+    expect(deriveRuleActionSetFingerprint(mk(1)).count).toBe(3)
+  })
+
+  it('enumerateRuleActions assigns canonical, position-sensitive paths incl. nested', () => {
+    const rule = [
+      A('update_record', { a: 1 }),
+      A('parallel_branch', {
+        branches: [{ key: 'b0', actions: [A('send_notification', {}), A('update_record', {})] }],
+      }),
+    ]
+    const paths = [...enumerateRuleActions(rule)].map((e) => e.structuralPath)
+    expect(paths).toEqual([
+      'actions[0]',
+      'actions[1]',
+      'actions[1].branches[0].actions[0]',
+      'actions[1].branches[0].actions[1]',
+    ])
+  })
+
+  it('empty / undefined action sets fingerprint to an empty, stable value', () => {
+    expect(deriveRuleActionSetFingerprint([])).toEqual(deriveRuleActionSetFingerprint(undefined))
+    expect(deriveRuleActionSetFingerprint([]).count).toBe(0)
+  })
+})

--- a/packages/core-backend/tests/unit/automation-rule-fingerprint.test.ts
+++ b/packages/core-backend/tests/unit/automation-rule-fingerprint.test.ts
@@ -1,12 +1,16 @@
 /**
  * #4196 §2.1/§4 rule action-set fingerprint (unit).
  *
- * Proves the §2.1-identity fingerprint detects the rule changes a retry must refuse — including the
- * config-only edit that the existing type-only `computeActionFingerprint` (suspend/resume guard) CANNOT see.
+ * Proves the §2.1-identity fingerprint (a) detects the rule changes a retry must refuse — including the
+ * config-only edit the type-only `computeActionFingerprint` cannot see; (b) uses the EXECUTOR's exact
+ * step-key identity (branch KEY, not array index) via the shared `automation-step-key` builder; and (c)
+ * derives keys byte-identical to a direct `deriveActionKey` call (no double-canonicalization).
  */
 import { describe, expect, it } from 'vitest'
 
 import { deriveRuleActionSetFingerprint, enumerateRuleActions } from '../../src/multitable/automation-rule-fingerprint'
+import { deriveActionKey } from '../../src/multitable/automation-action-idempotency'
+import { branchChildStepKey, topLevelStepKey } from '../../src/multitable/automation-step-key'
 import { computeActionFingerprint } from '../../src/multitable/automation-suspension-service'
 
 const A = (type: string, config: Record<string, unknown> = {}) => ({ type, config })
@@ -21,19 +25,18 @@ describe('#4196 §2.1 rule action-set fingerprint', () => {
   it('a CONFIG-ONLY edit changes the fingerprint — the gap the type-only guard misses', () => {
     const before = [A('update_record', { fields: { a: 1 } })]
     const after = [A('update_record', { fields: { a: 2 } })] // same type, changed config
-    // the NEW fingerprint sees the change...
     expect(deriveRuleActionSetFingerprint(before).hash).not.toBe(deriveRuleActionSetFingerprint(after).hash)
-    // ...while the existing type-only fingerprint is BLIND to it (this is exactly why §4 mandates the upgrade)
+    // the existing type-only fingerprint is BLIND to it (exactly why §4 mandates the upgrade)
     expect(computeActionFingerprint(before).hash).toBe(computeActionFingerprint(after).hash)
   })
 
   it('a TYPE SWAP in place changes the fingerprint', () => {
     const before = [A('update_record', { fields: { a: 1 } })]
-    const after = [A('delete_record', { fields: { a: 1 } })] // same path + config, different type
+    const after = [A('delete_record', { fields: { a: 1 } })]
     expect(deriveRuleActionSetFingerprint(before).hash).not.toBe(deriveRuleActionSetFingerprint(after).hash)
   })
 
-  it('REORDERING actions changes the fingerprint (structural path is position-sensitive)', () => {
+  it('REORDERING top-level actions changes the fingerprint (step index is position-sensitive)', () => {
     const before = [A('update_record', { x: 1 }), A('send_webhook', { u: 2 })]
     const after = [A('send_webhook', { u: 2 }), A('update_record', { x: 1 })]
     expect(deriveRuleActionSetFingerprint(before).hash).not.toBe(deriveRuleActionSetFingerprint(after).hash)
@@ -42,14 +45,32 @@ describe('#4196 §2.1 rule action-set fingerprint', () => {
   it('ADD / REMOVE changes both count and hash', () => {
     const one = [A('update_record', { a: 1 })]
     const two = [A('update_record', { a: 1 }), A('send_webhook', { u: 1 })]
-    const fp1 = deriveRuleActionSetFingerprint(one)
-    const fp2 = deriveRuleActionSetFingerprint(two)
-    expect(fp1.count).toBe(1)
-    expect(fp2.count).toBe(2)
-    expect(fp1.hash).not.toBe(fp2.hash)
+    expect(deriveRuleActionSetFingerprint(one).count).toBe(1)
+    expect(deriveRuleActionSetFingerprint(two).count).toBe(2)
+    expect(deriveRuleActionSetFingerprint(one).hash).not.toBe(deriveRuleActionSetFingerprint(two).hash)
   })
 
-  it('a NESTED branch action config edit changes the fingerprint (walk recurses config.branches[].actions[])', () => {
+  it('enumerateRuleActions uses the EXECUTOR step-keys exactly (top-level + parallel/condition branch KEY)', () => {
+    const rule = [
+      A('update_record', { a: 1 }),
+      A('parallel_branch', { branches: [{ key: 'p0', actions: [A('send_notification', {}), A('update_record', {})] }] }),
+      A('condition_branch', { branches: [{ key: 'c0', actions: [A('update_record', {})] }] }),
+    ]
+    const paths = [...enumerateRuleActions(rule)].map((e) => e.structuralPath)
+    expect(paths).toEqual([
+      topLevelStepKey(0), // "0"
+      topLevelStepKey(1), // "1"
+      branchChildStepKey(1, 'parallel', 'p0', 0), // "1.parallel.p0.0"
+      branchChildStepKey(1, 'parallel', 'p0', 1), // "1.parallel.p0.1"
+      topLevelStepKey(2), // "2"
+      branchChildStepKey(2, 'branch', 'c0', 0), // "2.branch.c0.0"
+    ])
+    // spot-check the literal executor format
+    expect(paths).toContain('1.parallel.p0.1')
+    expect(paths).toContain('2.branch.c0.0')
+  })
+
+  it('a nested branch action CONFIG edit changes the fingerprint (walk recurses into branch actions)', () => {
     const mk = (v: number) => [
       A('condition_branch', {
         branches: [
@@ -59,24 +80,35 @@ describe('#4196 §2.1 rule action-set fingerprint', () => {
       }),
     ]
     expect(deriveRuleActionSetFingerprint(mk(1)).hash).not.toBe(deriveRuleActionSetFingerprint(mk(2)).hash)
-    // the nested walk counts the parent + both branch actions
-    expect(deriveRuleActionSetFingerprint(mk(1)).count).toBe(3)
+    expect(deriveRuleActionSetFingerprint(mk(1)).count).toBe(3) // parent + 2 branch actions
   })
 
-  it('enumerateRuleActions assigns canonical, position-sensitive paths incl. nested', () => {
-    const rule = [
-      A('update_record', { a: 1 }),
-      A('parallel_branch', {
-        branches: [{ key: 'b0', actions: [A('send_notification', {}), A('update_record', {})] }],
-      }),
-    ]
-    const paths = [...enumerateRuleActions(rule)].map((e) => e.structuralPath)
-    expect(paths).toEqual([
-      'actions[0]',
-      'actions[1]',
-      'actions[1].branches[0].actions[0]',
-      'actions[1].branches[0].actions[1]',
-    ])
+  it('branch CHILD identity binds to the KEY, not the array index (#4420 P1)', () => {
+    const child = A('update_record', { v: 1 })
+    // SAME child index (0), DIFFERENT branch key → different child identity → different fingerprint
+    const keyA = [A('parallel_branch', { branches: [{ key: 'a', actions: [child] }] })]
+    const keyB = [A('parallel_branch', { branches: [{ key: 'b', actions: [child] }] })]
+    expect(deriveRuleActionSetFingerprint(keyA).hash).not.toBe(deriveRuleActionSetFingerprint(keyB).hash)
+    // REORDERING branches does not move a CHILD's key-bound path: the update_record under branch 'a' stays
+    // `0.parallel.a.0` whether 'a' is first or second in the array (index-based paths would have moved it).
+    // (The whole-rule fingerprint still changes — the PARENT parallel_branch's config captures branch order —
+    // which is correct: reordering branches IS a config edit to the parent.)
+    const pathOfUpdate = (rule: ReturnType<typeof A>[]) =>
+      [...enumerateRuleActions(rule)].find((e) => e.action.type === 'update_record' && e.structuralPath.includes('.'))?.structuralPath
+    const ordered = [A('parallel_branch', { branches: [{ key: 'a', actions: [A('update_record', { v: 1 })] }, { key: 'b', actions: [A('send_notification', {})] }] })]
+    const reversed = [A('parallel_branch', { branches: [{ key: 'b', actions: [A('send_notification', {})] }, { key: 'a', actions: [A('update_record', { v: 1 })] }] })]
+    expect(pathOfUpdate(ordered)).toBe('0.parallel.a.0')
+    expect(pathOfUpdate(reversed)).toBe('0.parallel.a.0') // key-bound, not position-bound
+  })
+
+  it('shares the applied-ledger identity: the enumerator key EXACTLY equals a direct deriveActionKey (#4420 P2)', () => {
+    const cfg = { fields: { z: 3, a: 1 }, note: 'x' } // deliberately unsorted keys to exercise canonicalization
+    const rule = [A('update_record', cfg)]
+    const [entry] = [...enumerateRuleActions(rule)]
+    const direct = deriveActionKey({ structuralPath: entry.structuralPath, actionType: 'update_record', canonicalConfig: cfg })
+    // the enumerator passes RAW config, so its per-action key must be byte-identical to the ledger's own call
+    const viaEnumerator = deriveActionKey({ structuralPath: entry.structuralPath, actionType: entry.action.type, canonicalConfig: entry.action.config })
+    expect(viaEnumerator).toBe(direct)
   })
 
   it('empty / undefined action sets fingerprint to an empty, stable value', () => {


### PR DESCRIPTION
**#4196 retry-runtime lane — foundation slice.** Pure functions + a pure executor refactor; no runtime behavior changes. Head `f3d720de3`.

## Context (verified against main)
The retry-root **lineage already exists** on main (`retryExecution` → `collectExecutionLineageIds` → `rootExecutionId`). The genuine #4196 gaps are the retry **guards** + the Class-A **claim wiring**, which share the §2.1 action identity. This slice lands that identity as the reusable, tested foundation — and, per review, makes it the executor's OWN identity.

## What lands
- **`automation-step-key.ts`** — the SINGLE source of truth for an action's structural step-key: `topLevelStepKey(i)` → `${i}`, `branchChildStepKey(i, kind, branchKey, j)` → `${i}.parallel.${branchKey}.${j}` / `${i}.branch.${branchKey}.${j}`. The executor's 5 inline step-key constructions are refactored to it (pure refactor — its unit suite stays 43/43), so the executor, the retry fingerprint, and the future Class-A claim all key on ONE identity.
- **`deriveRuleActionSetFingerprint` / `enumerateRuleActions`** — the §2.1 fingerprint over `deriveActionKey({ structuralPath, actionType, canonicalConfig })`, unlike the type-only `computeActionFingerprint` (§2.1). The walk yields the executor's exact step-keys via the shared builder, keyed on the branch **KEY** (not array index), and passes **raw** config to `deriveActionKey` (which canonicalizes internally) so the key is byte-identical to the applied-ledger's own.

## Review fixes
- **P1 (nested path diverged)**: was branch array index → now the executor's branch-key step-key via the shared builder; a same-index/different-key swap now differs, and a child under branch 'a' keeps `0.parallel.a.0` across branch reorder.
- **P2 (double canonicalization)**: was `canonicalizeConfig` then `deriveActionKey` (double) → now raw config; a test asserts the enumerator key **exactly equals** a direct `deriveActionKey`.

## Verification
Unit (10): config-only edit changes it while `computeActionFingerprint` stays blind (§4 gap); type swap / reorder / add-remove / nested edit; **paths equal the executor step-keys exactly** (`1.parallel.p0.1`, `2.branch.c0.0`); **branch child identity binds to the KEY**; **enumerator key === direct `deriveActionKey`**. Executor refactor output-identical (43/43). `tsc --noEmit` 0.

## Next (this lane)
Wire into `retryExecution`'s `RULE_CHANGED` guard (compare `original.ruleSnapshot` vs current) → age bound (`RETRY_WINDOW_EXPIRED`, §5) + missing-row fail-closed → Class-A claim wiring (the existing `rootExecutionId` + these shared step-keys into `claimExecutionAction`) → Class-B + retry E2E.

**For review — not self-merging runtime.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)