### PR TITLE
fix(attendance-ops): RD-4/5 smoke — deterministic recipient-not-bound fixture + stuck-delivery evidence

### DIFF
--- a/docs/development/attendance-rd45-report-digest-staging-smoke-runbook-20260702.md
+++ b/docs/development/attendance-rd45-report-digest-staging-smoke-runbook-20260702.md
@@ -284,10 +284,18 @@ terminal, explainable state:
 | Backend channel env | Expected terminal state | Posture |
 |---|---|---|
 | `ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED=true` (recommended) | `status='sent'`, `delivered_at` set | **default / strongest** — a visible send through the real worker state machine |
-| real work-notification channel env enabled | `status='failed'`, `last_error='dingtalk_recipient_not_bound'` (synthetic users have no directory binding) | acceptable — a visible, attributable failure (the design lock demands "sends **or fails** visibly") |
+| real work-notification channel env enabled (helper seeds the no-send directory fixture) | `status='skipped'`, `last_error='dingtalk_recipient_not_bound'` (H1 hardening, review #3920 P3-1: an unbound recipient in an org WITH an active integration is a structural skip, not a `failed`) | acceptable — a visible, attributable terminal outcome (the design lock demands "sends **or fails** visibly"; H1 renamed this leg's terminal to `skipped`) |
 | no channel env registered | `status='failed'`, `last_error='attendance_delivery_channel_not_configured'` | weakest — visible but proves only the claim/fail path; prefer the fake channel |
 
-Anything else — rows stuck `pending`/`retrying`, or `failed` with an
+Caution (Day-2 lesson, run 29547832431): under the real channel env, a smoke
+org with **no active DingTalk integration at all** takes H1's org-level-outage
+branch — the RETRYABLE `dingtalk_org_integration_inactive` — and the row loops
+`retrying` on the worker's 60s/5m/15m/60m/6h backoff, which the helper's poll
+window can never outlast. The helper's `seedDirectoryFixture` (active,
+`sync_enabled=false`, zero bound accounts, stray member links cleared) exists
+precisely to pin the `skipped` branch instead.
+
+Anything else — rows stuck `pending`/`retrying`, or `failed`/`skipped` with an
 unrecognized error — is a smoke FAIL, not a posture. Record the observed
 posture in the worksheet; it becomes the `sendProof=` field of the final
 stamp. (`WORKER_EXPECTED=0` runs assert rows REMAIN `pending` instead — a
@@ -384,7 +392,7 @@ Use this exact shape after the helper PASS, the RD-4 browser probe, the send
 posture record, and the residue block all succeed:
 
 ```text
-RD45_REPORT_DIGEST_STAGING_SMOKE_PASS deploy=<sha> stamp=<rd45-smoke-...> org=<rd45-smoke-...-org> produced=<n> dedupOk=1 sendProof=<sent|failed_recipient_not_bound|failed_channel_not_configured> residue=0
+RD45_REPORT_DIGEST_STAGING_SMOKE_PASS deploy=<sha> stamp=<rd45-smoke-...> org=<rd45-smoke-...-org> produced=<n> dedupOk=1 sendProof=<sent|skipped_recipient_not_bound|failed_channel_not_configured> residue=0
 ```
 
 Backfill text:
@@ -412,9 +420,13 @@ Backfill text:
   CONFLICT path) — do not pass.
 - Disabled path still produces: gate layering regressed — do not pass.
 - Rows stuck `pending`/`retrying` with the worker expected on: send gate or
-  channel env not effective on the deployed process — fix env, rerun.
-- `failed` with an unrecognized `last_error`: not a posture; investigate before
-  any rerun.
+  channel env not effective on the deployed process — or (Day-2 lesson) the
+  retryable `dingtalk_org_integration_inactive` because the smoke org has no
+  active integration; the helper prints each stuck row's
+  last_error/attempt_count/next_attempt_at before cleanup — read that first,
+  fix env/fixture, rerun.
+- `failed` or `skipped` with an unrecognized `last_error`: not a posture;
+  investigate before any rerun.
 - Default-org digest delta ≠ 0: backend producer gate was on — disable it,
   clean by deterministic prefix on org `default` only, run FAILED.
 - Settings restore mismatch: **blocks the whole window** (bundle §4) until

--- a/scripts/ops/staging-attendance-report-digest-rd45-smoke.mjs
+++ b/scripts/ops/staging-attendance-report-digest-rd45-smoke.mjs
@@ -58,6 +58,16 @@ export const RECOGNIZED_STRUCTURAL_SKIPS = [
   'dingtalk_recipient_not_bound',
 ]
 
+// Single source of truth for the directory-fixture INSERT — exported so the companion test can pin the
+// column list against the committed schema (review #4422 P1: an earlier draft omitted the NOT-NULL
+// `corp_id`, the .catch swallowed the violation, and the never-seeded fixture reproduced the exact Day-2
+// retrying trap it was built to fix). `corp_id` is required (zzzz20260324150000:20, no default); the only
+// shape CHECK (`local_integration_corp_id_shape`) binds provider='local' rows, so a stamped synthetic
+// value is valid for provider='dingtalk'. $1=org_id, $2=corp_id, $3=name.
+export const DIRECTORY_FIXTURE_INSERT_SQL = `INSERT INTO directory_integrations (org_id, corp_id, provider, name, status, sync_enabled)
+     VALUES ($1, $2, 'dingtalk', $3, 'active', false)
+     ON CONFLICT (org_id, provider, name) DO UPDATE SET status = 'active', sync_enabled = false, corp_id = EXCLUDED.corp_id`
+
 // Every table this helper can dirty. system_configs is mutated via PUT /settings and restored —
 // never deleted — so it is preflighted but intentionally NOT in this delete/count triple-check list.
 export const RESIDUE_TABLES = ['attendance_notification_deliveries', 'user_orgs', 'users']
@@ -560,19 +570,31 @@ async function seedDirectoryFixture() {
     throw new Error(`refusing to seed the directory fixture: org "${ORG_ID}" is not the stamped disposable org (${STAMP}-…). The fixture DELETEs org-scoped directory_* rows.`)
   }
   assertSyntheticUser(MEMBER_USER, 'directory-fixture member')
-  await pool.query('DELETE FROM directory_account_links WHERE local_user_id = $1', [MEMBER_USER]).catch(() => undefined)
-  await pool.query("DELETE FROM directory_integrations WHERE org_id = $1 AND provider = 'dingtalk'", [ORG_ID]).catch(() => undefined)
-  await pool.query(
-    `INSERT INTO directory_integrations (org_id, provider, name, status, sync_enabled)
-     VALUES ($1, 'dingtalk', $2, 'active', false)
-     ON CONFLICT (org_id, provider, name) DO UPDATE SET status = 'active', sync_enabled = false`,
-    [ORG_ID, DIRECTORY_FIXTURE_NAME],
-  ).catch(() => undefined)
+  // Fail-closed, NOT best-effort (review #4422 P1/P2-a): a swallowed error here silently flips the H1
+  // branch — a failed INSERT leaves the org integration-less (→ retryable org_integration_inactive →
+  // the Day-2 retrying trap), and a failed link-clear can leave a BOUND recipient (→ a real DingTalk
+  // send attempt). Any error must abort the smoke at the seed stage, before the send-proof.
+  await pool.query('DELETE FROM directory_account_links WHERE local_user_id = $1', [MEMBER_USER])
+  await pool.query("DELETE FROM directory_integrations WHERE org_id = $1 AND provider = 'dingtalk'", [ORG_ID])
+  await pool.query(DIRECTORY_FIXTURE_INSERT_SQL, [ORG_ID, `${STAMP}-corp`, DIRECTORY_FIXTURE_NAME])
+  // Positive-control read-back: prove the state the send-proof depends on actually exists, instead of
+  // trusting the writes. Exactly ONE active dingtalk integration; ZERO account links for the member.
+  const seeded = (await q(
+    `SELECT
+       (SELECT count(*)::int FROM directory_integrations WHERE org_id = $1 AND provider = 'dingtalk' AND status = 'active') AS integrations,
+       (SELECT count(*)::int FROM directory_account_links WHERE local_user_id = $2) AS member_links`,
+    [ORG_ID, MEMBER_USER],
+  ))[0] || {}
+  const integrations = Number(seeded.integrations ?? -1)
+  const memberLinks = Number(seeded.member_links ?? -1)
   ok(
-    true,
-    `seeded no-send DingTalk directory fixture (active, sync_enabled=false, no bound account) for disposable org "${ORG_ID}" — worker terminates as skipped/dingtalk_recipient_not_bound, never calls DingTalk`,
-    { integration: DIRECTORY_FIXTURE_NAME },
+    integrations === 1 && memberLinks === 0,
+    `directory fixture read-back: exactly ONE active dingtalk integration and ZERO member links for disposable org "${ORG_ID}" — pins the H1 skip branch (skipped/dingtalk_recipient_not_bound), never calls DingTalk`,
+    { integrations, memberLinks, integration: DIRECTORY_FIXTURE_NAME },
   )
+  if (integrations !== 1 || memberLinks !== 0) {
+    throw new Error(`directory fixture failed read-back (integrations=${integrations}, memberLinks=${memberLinks}) — aborting before the send-proof; a mis-seeded fixture would reproduce the Day-2 retrying trap or risk a real send`)
+  }
 }
 
 async function resolveExpectedSubjects() {

--- a/scripts/ops/staging-attendance-report-digest-rd45-smoke.mjs
+++ b/scripts/ops/staging-attendance-report-digest-rd45-smoke.mjs
@@ -166,13 +166,18 @@ export function classifySendOutcome(rows) {
     failedRecognized: 0,
     failedOther: [],
     unknown: [],
+    // Direct failure evidence for NON-terminal rows (pending/sending/retrying). The prior helper only
+    // captured last_error for terminal failedOther rows, so a run that timed out in `retrying` — and then
+    // deleted the row in cleanup — left NO record of WHY (which retryable last_error, how many attempts,
+    // when the next backoff was due). Populated for exactly the states that can leave the send-proof stuck.
+    nonTerminal: [],
   }
   for (const row of rows) {
     const status = String(row.status ?? '')
     if (status === 'sent') outcome.sent += 1
-    else if (status === 'pending') outcome.pending += 1
-    else if (status === 'sending') outcome.sending += 1
-    else if (status === 'retrying') outcome.retrying += 1
+    else if (status === 'pending') { outcome.pending += 1; outcome.nonTerminal.push(describeStuckDelivery(row)) }
+    else if (status === 'sending') { outcome.sending += 1; outcome.nonTerminal.push(describeStuckDelivery(row)) }
+    else if (status === 'retrying') { outcome.retrying += 1; outcome.nonTerminal.push(describeStuckDelivery(row)) }
     else if (status === 'failed') {
       if (RECOGNIZED_TERMINAL_FAILURES.includes(String(row.last_error ?? ''))) outcome.failedRecognized += 1
       else outcome.failedOther.push({ id: row.id ?? null, lastError: row.last_error ?? null })
@@ -184,6 +189,18 @@ export function classifySendOutcome(rows) {
     && outcome.failedOther.length === 0
     && outcome.unknown.length === 0
   return outcome
+}
+
+// The last-hammer evidence a stuck send-proof needs: which retryable error, how many attempts so far, and
+// when the worker's exponential backoff (60s→5m→15m→60m→6h) next fires. Pure/deterministic for the test.
+export function describeStuckDelivery(row) {
+  return {
+    id: row.id ?? null,
+    status: String(row.status ?? ''),
+    lastError: row.last_error ?? null,
+    attemptCount: row.attempt_count == null ? null : Number(row.attempt_count),
+    nextAttemptAt: row.next_attempt_at == null ? null : String(row.next_attempt_at),
+  }
 }
 
 // Env-only contract (no CLI args), mirroring the AE-4 / OT-bank v1-8 helpers: BASE_URL/DATABASE_URL
@@ -271,6 +288,8 @@ const USER_PREFIX = `${STAMP}-`
 const MEMBER_USER = process.env.MEMBER_USER_ID || `${USER_PREFIX}member`
 const INACTIVE_USER = process.env.INACTIVE_USER_ID || `${USER_PREFIX}inactive`
 const ADMIN_USER = process.env.ADMIN_USER_ID || `${USER_PREFIX}admin`
+// Stamped name for the no-send DingTalk directory fixture (unique index is (org_id, provider, name)).
+const DIRECTORY_FIXTURE_NAME = `${STAMP}-dingtalk-fixture`
 
 // The period is pinned once at process start (policy timezone is set to UTC by this smoke, so the
 // helper-side computation matches the producer). The seam track passes this todayKey explicitly and
@@ -305,6 +324,13 @@ function ok(condition, label, detail) {
 function assertSyntheticUser(userId, label) {
   if (typeof userId === 'string' && userId.startsWith(USER_PREFIX) && userId.length > USER_PREFIX.length) return
   throw new Error(`refusing to run: ${label} "${userId}" is not stamped with ${USER_PREFIX}. This smoke deletes its synthetic users during cleanup.`)
+}
+
+// The disposable seam org is stamped (`${STAMP}-org`). The directory fixture DELETEs org-scoped rows from
+// the SHARED directory_* tables, so it must NEVER run against a non-stamped / default org — this gate is a
+// hard precondition on every destructive directory op (seed + cleanup), independent of TRIGGER_MODE.
+function isDisposableOrg() {
+  return typeof ORG_ID === 'string' && ORG_ID.startsWith(STAMP) && ORG_ID.length > STAMP.length
 }
 
 function sleep(ms) {
@@ -493,6 +519,40 @@ async function seedUsers() {
   ok(true, `seeded synthetic member (active) + inactive-membership user into org "${ORG_ID}"`, { stamp: STAMP })
 }
 
+async function seedDirectoryFixture() {
+  // Make the RD-5 send outcome DETERMINISTIC without ever calling DingTalk or switching a staging env.
+  // The real work-notification channel resolves a recipient via directory_account_links(linked) ->
+  // directory_accounts(active) -> directory_integrations(active, org-anchored). With NO linked active
+  // account for the member, resolveRecipient returns the non-retryable 'dingtalk_recipient_not_bound' ->
+  // terminal failed -> RECOGNIZED_TERMINAL_FAILURES -> visibly proven (the runbook's
+  // sendProof=failed_recipient_not_bound posture). This is the last-hammer determinism the retrying
+  // timeout lacked: (1) clear any stray/synced link for the synthetic member; (2) fully control the org's
+  // DingTalk directory by dropping any stray integration (FK-cascade clears its accounts/links) and
+  // seeding ONE sync_enabled=false integration with no account — so no sync worker can (re)link the member
+  // and the channel can never reach its config/token/send path (resolveRecipient short-circuits first).
+  //
+  // HARD SCOPE: seam track only, AND only when the org is the stamped disposable org — these DELETEs touch
+  // the SHARED directory_* tables, so the default/real org's directory must never be seeded or deleted.
+  if (TRIGGER_MODE !== 'seam') return
+  if (!isDisposableOrg()) {
+    throw new Error(`refusing to seed the directory fixture: org "${ORG_ID}" is not the stamped disposable org (${STAMP}-…). The fixture DELETEs org-scoped directory_* rows.`)
+  }
+  assertSyntheticUser(MEMBER_USER, 'directory-fixture member')
+  await pool.query('DELETE FROM directory_account_links WHERE local_user_id = $1', [MEMBER_USER]).catch(() => undefined)
+  await pool.query("DELETE FROM directory_integrations WHERE org_id = $1 AND provider = 'dingtalk'", [ORG_ID]).catch(() => undefined)
+  await pool.query(
+    `INSERT INTO directory_integrations (org_id, provider, name, status, sync_enabled)
+     VALUES ($1, 'dingtalk', $2, 'active', false)
+     ON CONFLICT (org_id, provider, name) DO UPDATE SET status = 'active', sync_enabled = false`,
+    [ORG_ID, DIRECTORY_FIXTURE_NAME],
+  ).catch(() => undefined)
+  ok(
+    true,
+    `seeded no-send DingTalk directory fixture (sync_enabled=false, no bound account) for disposable org "${ORG_ID}" — worker resolves to dingtalk_recipient_not_bound, never calls DingTalk`,
+    { integration: DIRECTORY_FIXTURE_NAME },
+  )
+}
+
 async function resolveExpectedSubjects() {
   // Same join discipline as the producer's subject loader: active membership AND active user.
   const rows = await q(
@@ -587,7 +647,7 @@ async function runSeamOnce({ envEnabled = true } = {}) {
 async function fetchDigestRows() {
   return q(
     `SELECT id, org_id, source_type, source_id, source_key, recipient_user_id, recipient_role,
-            channel, status, last_error, payload
+            channel, status, last_error, attempt_count, next_attempt_at, payload
      FROM attendance_notification_deliveries
      WHERE org_id = $1 AND source_type = $2 AND left(source_key, $3) = $4
      ORDER BY source_key ASC`,
@@ -777,7 +837,15 @@ async function assertSendPosture(subjects) {
     outcome,
   )
   if (!outcome.visiblyProven) {
-    throw new Error('delivery worker did not visibly resolve the digest rows — verify the worker env gate, channel envs, and the scheduler interval on the backend, then consult the runbook send-posture table')
+    // Print the direct evidence BEFORE the throw so it survives even though cleanup then deletes the rows:
+    // for each stuck row, its last_error / attempt_count / next_attempt_at (the missing last hammer).
+    if (outcome.nonTerminal.length > 0) {
+      console.error('  STUCK-DELIVERY EVIDENCE (non-terminal rows — recorded before cleanup deletes them):')
+      for (const d of outcome.nonTerminal) {
+        console.error(`    id=${d.id} status=${d.status} attempt_count=${d.attemptCount} next_attempt_at=${d.nextAttemptAt} last_error=${d.lastError}`)
+      }
+    }
+    throw new Error(`delivery worker did not visibly resolve the digest rows — verify the worker env gate, channel envs, and the scheduler interval on the backend, then consult the runbook send-posture table. stuck=${stableJson(outcome.nonTerminal)}`)
   }
   return `worker-on:sent=${outcome.sent},failed_recognized=${outcome.failedRecognized}`
 }
@@ -847,6 +915,13 @@ async function cleanup({ strictSettingsRestore = false } = {}) {
   }
   await pool.query('DELETE FROM user_orgs WHERE org_id = $1 AND left(user_id, $2) = $3', [ORG_ID, USER_PREFIX.length, USER_PREFIX]).catch(() => undefined)
   await pool.query('DELETE FROM users WHERE left(id, $1) = $2', [USER_PREFIX.length, USER_PREFIX]).catch(() => undefined)
+  // Directory fixture cleanup — same HARD SCOPE as seedDirectoryFixture (seam + stamped disposable org).
+  // Deleting the integration FK-cascades to its directory_accounts/directory_account_links; the explicit
+  // link delete also clears any stray/synced link the member may have picked up during the run.
+  if (TRIGGER_MODE === 'seam' && isDisposableOrg()) {
+    await pool.query('DELETE FROM directory_account_links WHERE local_user_id = $1', [MEMBER_USER]).catch(() => undefined)
+    await pool.query("DELETE FROM directory_integrations WHERE org_id = $1 AND provider = 'dingtalk'", [ORG_ID]).catch(() => undefined)
+  }
 }
 
 async function residueCounts() {
@@ -872,6 +947,19 @@ async function residueCounts() {
   if (ORG_ID !== DEFAULT_ORG_ID) {
     residue.default_org_digest_delta = (await countOrgDigestRows(DEFAULT_ORG_ID)) - defaultOrgDigestBaseline
   }
+  // Directory fixture residue — only meaningful (and only safe to count org-wide) for the stamped
+  // disposable seam org; on the default org we never seed directory rows, so counting its real
+  // integrations would be a false residue. Both must be 0 after cleanup.
+  if (TRIGGER_MODE === 'seam' && isDisposableOrg()) {
+    const dir = (await q(
+      `SELECT
+         (SELECT count(*)::int FROM directory_integrations WHERE org_id = $1 AND provider = 'dingtalk') AS fixture_integrations,
+         (SELECT count(*)::int FROM directory_account_links WHERE local_user_id = $2) AS member_links`,
+      [ORG_ID, MEMBER_USER],
+    ))[0] || {}
+    residue.fixture_integrations = Number(dir.fixture_integrations ?? -1)
+    residue.member_directory_links = Number(dir.member_links ?? -1)
+  }
   return residue
 }
 
@@ -890,6 +978,7 @@ async function main() {
   originalSettings = await getSettings()
 
   await seedUsers()
+  await seedDirectoryFixture()
   const subjects = await resolveExpectedSubjects()
   await enableDigestPolicy()
 

--- a/scripts/ops/staging-attendance-report-digest-rd45-smoke.mjs
+++ b/scripts/ops/staging-attendance-report-digest-rd45-smoke.mjs
@@ -42,10 +42,20 @@ export const SETTINGS_CACHE_TTL_MS = 60_000 // in-process settings cache in the 
 export const DELIVERY_CHANNEL_ALLOWLIST = ['dingtalk_work_notification', 'email_smtp']
 
 // Terminal 'failed' reasons that still count as the design lock's "worker sends/FAILS visibly":
-// unbound recipient under the real work-notification channel env, or no channel registered at all.
+// no channel registered at all (worker-level markFailed before any channel dispatch).
 export const RECOGNIZED_TERMINAL_FAILURES = [
-  'dingtalk_recipient_not_bound',
   'attendance_delivery_channel_not_configured',
+]
+
+// Terminal 'skipped' reasons that count as visibly proven. H1 hardening (review #3920 P3-1) made the
+// DingTalk channel's unbound-recipient miss a `skip: true` dispatch — the worker terminates it as
+// status='skipped' (structural "not onboarded", NOT a fault), never 'failed'. The directory fixture
+// (seedDirectoryFixture) guarantees exactly this reason: the disposable org HAS an active integration
+// (so the H1 disambiguation does NOT take the org-level-outage branch, which returns the RETRYABLE
+// 'dingtalk_org_integration_inactive' — the Day-2 retrying-timeout root cause) and the member has no
+// account link (so resolution misses → skip).
+export const RECOGNIZED_STRUCTURAL_SKIPS = [
+  'dingtalk_recipient_not_bound',
 ]
 
 // Every table this helper can dirty. system_configs is mutated via PUT /settings and restored —
@@ -164,7 +174,9 @@ export function classifySendOutcome(rows) {
     sending: 0,
     retrying: 0,
     failedRecognized: 0,
+    skippedRecognized: 0,
     failedOther: [],
+    skippedOther: [],
     unknown: [],
     // Direct failure evidence for NON-terminal rows (pending/sending/retrying). The prior helper only
     // captured last_error for terminal failedOther rows, so a run that timed out in `retrying` — and then
@@ -181,12 +193,20 @@ export function classifySendOutcome(rows) {
     else if (status === 'failed') {
       if (RECOGNIZED_TERMINAL_FAILURES.includes(String(row.last_error ?? ''))) outcome.failedRecognized += 1
       else outcome.failedOther.push({ id: row.id ?? null, lastError: row.last_error ?? null })
+    } else if (status === 'skipped') {
+      // H1 skip semantics: a structural "recipient not onboarded" terminates as `skipped` — a visible,
+      // attributable terminal outcome when the reason is on the recognized list. Any OTHER skipped
+      // reason is not a posture; surface it (with last_error) instead of hiding it in `unknown`.
+      if (RECOGNIZED_STRUCTURAL_SKIPS.includes(String(row.last_error ?? ''))) outcome.skippedRecognized += 1
+      else outcome.skippedOther.push({ id: row.id ?? null, lastError: row.last_error ?? null })
     } else outcome.unknown.push({ id: row.id ?? null, status })
   }
-  outcome.terminal = outcome.sent + outcome.failedRecognized + outcome.failedOther.length
+  outcome.terminal = outcome.sent + outcome.failedRecognized + outcome.skippedRecognized
+    + outcome.failedOther.length + outcome.skippedOther.length
   outcome.visiblyProven = rows.length > 0
-    && outcome.sent + outcome.failedRecognized === rows.length
+    && outcome.sent + outcome.failedRecognized + outcome.skippedRecognized === rows.length
     && outcome.failedOther.length === 0
+    && outcome.skippedOther.length === 0
     && outcome.unknown.length === 0
   return outcome
 }
@@ -521,15 +541,17 @@ async function seedUsers() {
 
 async function seedDirectoryFixture() {
   // Make the RD-5 send outcome DETERMINISTIC without ever calling DingTalk or switching a staging env.
-  // The real work-notification channel resolves a recipient via directory_account_links(linked) ->
-  // directory_accounts(active) -> directory_integrations(active, org-anchored). With NO linked active
-  // account for the member, resolveRecipient returns the non-retryable 'dingtalk_recipient_not_bound' ->
-  // terminal failed -> RECOGNIZED_TERMINAL_FAILURES -> visibly proven (the runbook's
-  // sendProof=failed_recipient_not_bound posture). This is the last-hammer determinism the retrying
-  // timeout lacked: (1) clear any stray/synced link for the synthetic member; (2) fully control the org's
-  // DingTalk directory by dropping any stray integration (FK-cascade clears its accounts/links) and
-  // seeding ONE sync_enabled=false integration with no account — so no sync worker can (re)link the member
-  // and the channel can never reach its config/token/send path (resolveRecipient short-circuits first).
+  // H1 hardening (review #3920 P3-1) disambiguates resolveRecipient's 0-row miss: an org with NO active
+  // DingTalk integration gets the RETRYABLE 'dingtalk_org_integration_inactive' (org-level outage,
+  // self-heals on re-activation) — which for a bare disposable smoke org means an endless backoff loop
+  // the 135s poll can never outlast (the Day-2 retrying-timeout root cause). An org WITH an active
+  // integration but an unlinked member gets the skip dispatch -> terminal status='skipped' with
+  // last_error='dingtalk_recipient_not_bound' -> RECOGNIZED_STRUCTURAL_SKIPS -> visibly proven.
+  // So the fixture pins the SECOND branch: (1) clear any stray/synced link for the synthetic member;
+  // (2) fully control the org's DingTalk directory by dropping any stray integration (FK-cascade clears
+  // its accounts/links) and seeding ONE active, sync_enabled=false integration with no account — no sync
+  // worker can (re)link the member and the channel never reaches its config/token/send path
+  // (resolveRecipient short-circuits first).
   //
   // HARD SCOPE: seam track only, AND only when the org is the stamped disposable org — these DELETEs touch
   // the SHARED directory_* tables, so the default/real org's directory must never be seeded or deleted.
@@ -548,7 +570,7 @@ async function seedDirectoryFixture() {
   ).catch(() => undefined)
   ok(
     true,
-    `seeded no-send DingTalk directory fixture (sync_enabled=false, no bound account) for disposable org "${ORG_ID}" — worker resolves to dingtalk_recipient_not_bound, never calls DingTalk`,
+    `seeded no-send DingTalk directory fixture (active, sync_enabled=false, no bound account) for disposable org "${ORG_ID}" — worker terminates as skipped/dingtalk_recipient_not_bound, never calls DingTalk`,
     { integration: DIRECTORY_FIXTURE_NAME },
   )
 }
@@ -686,7 +708,7 @@ async function produceViaScheduler(subjects) {
 
 // --- assertions --------------------------------------------------------------------------------
 
-const KNOWN_STATUSES = ['pending', 'sending', 'sent', 'retrying', 'failed']
+const KNOWN_STATUSES = ['pending', 'sending', 'sent', 'retrying', 'failed', 'skipped']
 
 function assertProducedGrain(rows, subjects) {
   ok(rows.length === subjects.length, `producer wrote exactly one row per active subject (expected ${subjects.length})`, { rows: rows.length })
@@ -833,7 +855,7 @@ async function assertSendPosture(subjects) {
   }
   ok(
     outcome.visiblyProven,
-    `RD-5 send proof: worker visibly resolved every row (sent=${outcome.sent}, failedRecognized=${outcome.failedRecognized}, pending=${outcome.pending}, sending=${outcome.sending}, retrying=${outcome.retrying}, failedOther=${outcome.failedOther.length})`,
+    `RD-5 send proof: worker visibly resolved every row (sent=${outcome.sent}, failedRecognized=${outcome.failedRecognized}, skippedRecognized=${outcome.skippedRecognized}, pending=${outcome.pending}, sending=${outcome.sending}, retrying=${outcome.retrying}, failedOther=${outcome.failedOther.length}, skippedOther=${outcome.skippedOther.length})`,
     outcome,
   )
   if (!outcome.visiblyProven) {
@@ -845,9 +867,9 @@ async function assertSendPosture(subjects) {
         console.error(`    id=${d.id} status=${d.status} attempt_count=${d.attemptCount} next_attempt_at=${d.nextAttemptAt} last_error=${d.lastError}`)
       }
     }
-    throw new Error(`delivery worker did not visibly resolve the digest rows — verify the worker env gate, channel envs, and the scheduler interval on the backend, then consult the runbook send-posture table. stuck=${stableJson(outcome.nonTerminal)}`)
+    throw new Error(`delivery worker did not visibly resolve the digest rows — verify the worker env gate, channel envs, and the scheduler interval on the backend, then consult the runbook send-posture table. stuck=${stableJson(outcome.nonTerminal)} skippedOther=${stableJson(outcome.skippedOther)}`)
   }
-  return `worker-on:sent=${outcome.sent},failed_recognized=${outcome.failedRecognized}`
+  return `worker-on:sent=${outcome.sent},failed_recognized=${outcome.failedRecognized},skipped_recognized=${outcome.skippedRecognized}`
 }
 
 async function assertNoDefaultOrgLeakage() {

--- a/scripts/ops/staging-attendance-report-digest-rd45-smoke.test.mjs
+++ b/scripts/ops/staging-attendance-report-digest-rd45-smoke.test.mjs
@@ -23,6 +23,7 @@ import {
   buildRestoreDigestPolicyBody,
   classifySendOutcome,
   describeStuckDelivery,
+  RECOGNIZED_STRUCTURAL_SKIPS,
   resolveEnvConfig,
 } from './staging-attendance-report-digest-rd45-smoke.mjs'
 
@@ -184,16 +185,28 @@ test('rd45 settings restore body never PUTs an empty snapshot (deep-merge lesson
   assert.deepEqual(fromNull.attendanceReportDigestPolicy, DISABLED_DIGEST_POLICY_DEFAULT)
 })
 
-test('rd45 send-outcome classifier: sent / recognized visible failure = proven; stuck or unexplained = not proven', () => {
-  assert.deepEqual(RECOGNIZED_TERMINAL_FAILURES, ['dingtalk_recipient_not_bound', 'attendance_delivery_channel_not_configured'])
+test('rd45 send-outcome classifier: sent / recognized visible failure or structural skip = proven; stuck or unexplained = not proven', () => {
+  // H1 hardening (review #3920 P3-1): unbound-recipient is a structural SKIP (status='skipped'), no
+  // longer a terminal 'failed' — the recognized sets are split accordingly.
+  assert.deepEqual(RECOGNIZED_TERMINAL_FAILURES, ['attendance_delivery_channel_not_configured'])
+  assert.deepEqual(RECOGNIZED_STRUCTURAL_SKIPS, ['dingtalk_recipient_not_bound'])
 
   const allSent = classifySendOutcome([{ status: 'sent' }, { status: 'sent' }])
   assert.equal(allSent.visiblyProven, true)
   assert.equal(allSent.sent, 2)
 
-  const mixed = classifySendOutcome([{ status: 'sent' }, { status: 'failed', last_error: 'dingtalk_recipient_not_bound' }])
-  assert.equal(mixed.visiblyProven, true, 'unbound-recipient failure is a documented VISIBLE worker outcome')
-  assert.equal(mixed.failedRecognized, 1)
+  const mixed = classifySendOutcome([{ status: 'sent' }, { status: 'skipped', last_error: 'dingtalk_recipient_not_bound' }])
+  assert.equal(mixed.visiblyProven, true, 'unbound-recipient structural skip is a documented VISIBLE worker outcome (H1)')
+  assert.equal(mixed.skippedRecognized, 1)
+
+  const preH1NotBoundAsFailed = classifySendOutcome([{ status: 'failed', last_error: 'dingtalk_recipient_not_bound' }])
+  assert.equal(preH1NotBoundAsFailed.visiblyProven, false, 'failed/not_bound is NOT a recognized posture post-H1 (a deployed worker producing it deserves investigation, not a pass)')
+  assert.equal(preH1NotBoundAsFailed.failedOther.length, 1)
+
+  const skippedUnrecognized = classifySendOutcome([{ status: 'skipped', last_error: 'mystery_skip' }])
+  assert.equal(skippedUnrecognized.visiblyProven, false, 'an unrecognized skipped reason is not a posture')
+  assert.equal(skippedUnrecognized.skippedOther.length, 1)
+  assert.equal(skippedUnrecognized.skippedOther[0].lastError, 'mystery_skip', 'unrecognized skip surfaces its last_error, not an anonymous unknown')
 
   const channelMissing = classifySendOutcome([{ status: 'failed', last_error: 'attendance_delivery_channel_not_configured' }])
   assert.equal(channelMissing.visiblyProven, true, 'channel-not-configured is terminal and visible (weakest posture; runbook prefers the deterministic fake channel)')

--- a/scripts/ops/staging-attendance-report-digest-rd45-smoke.test.mjs
+++ b/scripts/ops/staging-attendance-report-digest-rd45-smoke.test.mjs
@@ -24,6 +24,7 @@ import {
   classifySendOutcome,
   describeStuckDelivery,
   RECOGNIZED_STRUCTURAL_SKIPS,
+  DIRECTORY_FIXTURE_INSERT_SQL,
   resolveEnvConfig,
 } from './staging-attendance-report-digest-rd45-smoke.mjs'
 
@@ -293,6 +294,27 @@ test('rd45 helper residue triple-check covers every table the smoke can dirty; s
   assert.match(script, /if \(TRIGGER_MODE !== 'seam'\) return/, 'directory fixture is seam-only')
   assert.match(script, /is not the stamped disposable org/, 'directory fixture refuses a non-disposable org')
   assert.match(script, /function isDisposableOrg\(\)/, 'a disposable-org gate exists for the shared directory_* deletes')
+})
+
+test('rd45 directory-fixture INSERT satisfies the committed schema and the seed is fail-closed (review #4422 P1/P2)', () => {
+  // The exported constant IS what pool.query executes — pinning it here is mutation-coupled, not a
+  // source-text regex over dead code. corp_id is NOT NULL with no default (zzzz20260324150000:20); an
+  // INSERT without it fails, and review #4422 proved the pre-fix draft silently never seeded (the .catch
+  // swallowed the violation), reproducing the exact Day-2 retrying trap.
+  assert.match(DIRECTORY_FIXTURE_INSERT_SQL, /INSERT INTO directory_integrations \(org_id, corp_id, provider, name, status, sync_enabled\)/,
+    'column list names every NOT-NULL-without-default column, corp_id included')
+  const placeholders = DIRECTORY_FIXTURE_INSERT_SQL.match(/\$\d+/g) ?? []
+  assert.deepEqual([...new Set(placeholders)].sort(), ['$1', '$2', '$3'], 'exactly $1=org_id, $2=corp_id, $3=name are parameterized')
+  assert.match(DIRECTORY_FIXTURE_INSERT_SQL, /'active', false/, 'fixture pins status=active (H1 skip branch) + sync_enabled=false (no sync worker can link the member)')
+  assert.match(DIRECTORY_FIXTURE_INSERT_SQL, /ON CONFLICT \(org_id, provider, name\)/, 'conflict target matches idx_directory_integrations_org_provider_name')
+  assert.match(script, /pool\.query\(DIRECTORY_FIXTURE_INSERT_SQL, \[ORG_ID, `\$\{STAMP\}-corp`, DIRECTORY_FIXTURE_NAME\]\)/,
+    'the runtime executes THIS constant with org/corp/name bound in order')
+  // Fail-closed seed: no .catch swallow on the three seed statements, and a read-back positive control
+  // (exactly ONE active integration, ZERO member links) that throws before the send-proof can run.
+  assert.match(script, /directory fixture read-back/, 'read-back positive control exists')
+  assert.match(script, /directory fixture failed read-back/, 'read-back failure aborts the smoke (throw), not a warning')
+  const seedBlock = script.slice(script.indexOf('async function seedDirectoryFixture'), script.indexOf('async function resolveExpectedSubjects'))
+  assert.doesNotMatch(seedBlock, /\.catch\(\(\) => undefined\)/, 'seed statements must not swallow errors (a silent seed failure flips the H1 branch or risks a real send)')
 })
 
 test('rd45 helper cleanup is stamped/prefix-scoped, LIKE-free, and restores settings BEFORE deleting rows (re-insert trap)', () => {

--- a/scripts/ops/staging-attendance-report-digest-rd45-smoke.test.mjs
+++ b/scripts/ops/staging-attendance-report-digest-rd45-smoke.test.mjs
@@ -22,6 +22,7 @@ import {
   parseDigestSourceKey,
   buildRestoreDigestPolicyBody,
   classifySendOutcome,
+  describeStuckDelivery,
   resolveEnvConfig,
 } from './staging-attendance-report-digest-rd45-smoke.mjs'
 
@@ -208,6 +209,33 @@ test('rd45 send-outcome classifier: sent / recognized visible failure = proven; 
   assert.equal(classifySendOutcome([]).visiblyProven, false, 'zero rows prove nothing')
 })
 
+test('rd45 classifier captures direct evidence (last_error/attempt_count/next_attempt_at) for every non-terminal row', () => {
+  const retrying = classifySendOutcome([{
+    id: 'd1', status: 'retrying', last_error: 'dingtalk_request_500: upstream busy',
+    attempt_count: 2, next_attempt_at: '2026-07-17T01:42:00Z',
+  }])
+  assert.equal(retrying.retrying, 1)
+  assert.equal(retrying.visiblyProven, false)
+  // The last hammer: the retrying row's evidence is captured, not discarded (the pre-fix gap).
+  assert.equal(retrying.nonTerminal.length, 1)
+  assert.deepEqual(retrying.nonTerminal[0], {
+    id: 'd1', status: 'retrying', lastError: 'dingtalk_request_500: upstream busy',
+    attemptCount: 2, nextAttemptAt: '2026-07-17T01:42:00Z',
+  })
+  // pending and sending rows are captured too; terminal rows (sent / failed) are NOT in nonTerminal.
+  const mix = classifySendOutcome([
+    { id: 'p', status: 'pending' },
+    { id: 's', status: 'sending', attempt_count: 1 },
+    { id: 'ok', status: 'sent' },
+    { id: 'f', status: 'failed', last_error: 'dingtalk_recipient_not_bound' },
+  ])
+  assert.deepEqual(mix.nonTerminal.map(d => d.id).sort(), ['p', 's'])
+  // describeStuckDelivery null-safety: absent numeric/timestamp fields normalize to null, not NaN/'undefined'.
+  assert.deepEqual(describeStuckDelivery({ id: 'x', status: 'retrying' }), {
+    id: 'x', status: 'retrying', lastError: null, attemptCount: null, nextAttemptAt: null,
+  })
+})
+
 test('rd45 helper does not claim the final staging pass and prints the exact API/DB pass-line shape', () => {
   assert.match(script, /RD45_REPORT_DIGEST_API_DB_SMOKE_PASS deploy=\$\{DEPLOY_SHA\} stamp=\$\{STAMP\} org=\$\{ORG_ID\} produced=\$\{subjects\.length\} dedupOk=\$\{dedupOk \? 1 : 0\} residue=0/)
   assert.doesNotMatch(script, /RD45_REPORT_DIGEST_STAGING_SMOKE_PASS/)
@@ -241,6 +269,17 @@ test('rd45 helper residue triple-check covers every table the smoke can dirty; s
   // this smoke writes no other attendance business rows
   assert.doesNotMatch(script, /DELETE FROM attendance_records/)
   assert.doesNotMatch(script, /DELETE FROM attendance_requests/)
+  // The seam directory fixture (deterministic dingtalk_recipient_not_bound) dirties two SHARED directory_*
+  // tables — so the "every table the smoke can dirty" invariant must extend to them: both are counted in
+  // residue AND cleaned (integration delete FK-cascades to accounts; the member-link delete is explicit).
+  for (const table of ['directory_integrations', 'directory_account_links']) {
+    assert.match(script, new RegExp(`FROM ${table}`), `${table} is counted in residue`)
+    assert.match(script, new RegExp(`DELETE FROM ${table}`), `${table} is cleaned`)
+  }
+  // Directory ops are HARD-SCOPED: seam track + stamped disposable org only, never the default/real org.
+  assert.match(script, /if \(TRIGGER_MODE !== 'seam'\) return/, 'directory fixture is seam-only')
+  assert.match(script, /is not the stamped disposable org/, 'directory fixture refuses a non-disposable org')
+  assert.match(script, /function isDisposableOrg\(\)/, 'a disposable-org gate exists for the shared directory_* deletes')
 })
 
 test('rd45 helper cleanup is stamped/prefix-scoped, LIKE-free, and restores settings BEFORE deleting rows (re-insert trap)', () => {


### PR DESCRIPTION
## Why

Day-2 RD-5 send-proof timed out with the sole delivery stuck in `retrying`, no PASS marker (failed run 29547832431; status run 29547777398 healthy, image `d65a77c25`, migrations pending=0). Residue cleanup deleted the row before any `last_error` was recorded — no direct evidence survived.

## Root cause (now code-proven, not inferred)

H1 hardening (review #3920 P3-1, `AttendanceNotificationDeliveryWorker.resolveRecipient`) disambiguates the 0-row recipient miss:

- org has **NO** active DingTalk integration → **retryable** `dingtalk_org_integration_inactive` (org-level outage, self-heals on re-activation) → the row loops `retrying` on the 60s/5m/15m/60m/6h backoff. The bare disposable smoke org took this branch; the helper's 135s poll can never outlast it. **This is the Day-2 failure.**
- org **HAS** an active integration but the member is unlinked → `skip` dispatch → terminal `status='skipped'`, `last_error='dingtalk_recipient_not_bound'` (structural, never calls DingTalk).

## What (helper-only — no staging redeploy/restart/env switch; same deploy SHA)

1. **Stuck-delivery evidence.** `classifySendOutcome` captures `last_error`/`attempt_count`/`next_attempt_at` for every non-terminal row into `outcome.nonTerminal`; `assertSendPosture` prints it **before** throwing, so it survives cleanup. A Day-2-style failure now names its reason directly.
2. **Deterministic `skipped/not_bound`.** `seedDirectoryFixture` (seam **and** stamped disposable org only — hard-gated at config layer + runtime, plus the scheduler-mode path never reaches directory code) clears any stray member link, drops any stray org integration, and seeds ONE `status='active'`, `sync_enabled=false`, no-account integration — pinning H1's *skip* branch instead of the *retryable outage* branch. Never calls DingTalk.
3. **Classifier recognizes the H1 posture.** New `RECOGNIZED_STRUCTURAL_SKIPS = ['dingtalk_recipient_not_bound']`: `skipped` with that reason counts as visibly proven; any other `skipped` reason is surfaced (`skippedOther` with `last_error`) and fails the proof. `failed/dingtalk_recipient_not_bound` (the pre-H1 shape) is now explicitly NOT a posture — a post-H1 worker cannot produce it, so seeing it means SHA drift. `RECOGNIZED_TERMINAL_FAILURES` narrows to `attendance_delivery_channel_not_configured` (still a genuine worker-level `failed`).
4. **Cleanup + residue** extended to `directory_integrations`/`directory_account_links` (FK cascade + explicit link delete), asserted =0.
5. **Runbook** posture table updated to the H1 contract (`skipped/not_bound` row, `sendProof=skipped_recipient_not_bound` stamp vocab) + a Day-2 caution block documenting the `org_integration_inactive` retrying trap.

## Scope safety

All destructive `directory_*` ops are triple-gated: config (`resolveEnvConfig` forces seam ORG_ID to start with `rd45-smoke-`), runtime (`TRIGGER_MODE==='seam' && isDisposableOrg()` on both seed and cleanup, non-disposable org throws), and the scheduler-mode variant never reaches the directory code. Deletes are org-scoped/member-scoped, never prefix-LIKE.

## Tests

15/15 helper unit tests pass, including: recognized structural skip = proven; unrecognized skip surfaced with `last_error`; pre-H1 `failed/not_bound` rejected; non-terminal evidence capture + `describeStuckDelivery` null-safety; residue coverage extended to the two `directory_*` tables; directory ops seam-only + disposable-org-gated.

## Re-run plan

Day-2 only, same deploy SHA `d65a77c25`, new stamp; hold before Day 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
