### PR TITLE
feat(automation): S6 lease-runtime — event_fires claim/reclaim (window-2 fix, flag-gated)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -726,6 +726,7 @@ jobs:
             tests/integration/files-storage-key-migration.db.test.ts \
             tests/integration/files-orphan-blob-retention.db.test.ts \
             tests/integration/multitable-automation-event-fires-lease-migration.db.test.ts \
+            tests/integration/multitable-automation-event-fires-lease-realdb.db.test.ts \
             tests/integration/multitable-attachment-blob-purge.db.test.ts \
             tests/integration/multitable-attachment-root-escape.db.test.ts \
             tests/integration/stock-prep-audit-immutable-trigger.db.test.ts \

--- a/packages/core-backend/src/multitable/automation-event-fires-lease.ts
+++ b/packages/core-backend/src/multitable/automation-event-fires-lease.ts
@@ -1,0 +1,56 @@
+/**
+ * S6 — `meta_automation_event_fires` LEASE claim/reclaim primitives (durable-delivery flag ON path).
+ *
+ * Extracted from AutomationService so the load-bearing lease semantics are directly real-DB testable (mirrors
+ * automation-execution-ledger.ts / automation-action-idempotency.ts). The schema is the #4413 tombstone→lease
+ * upgrade: `status` (pending|in_progress|done|outcome_unknown|failed|dead_letter) + `lease_expires_at` +
+ * `attempts` + monotonic `fence`, with the biconditional lease-iff-in_progress CHECK.
+ *
+ * Window-2 fix (design lock §Layer-1): the legacy path wrote a permanent tombstone BEFORE executeRule, so a
+ * crash between the two dropped the work forever. Here the claim is a reclaimable lease: a crash before
+ * `markEventFiresDone` leaves an EXPIRED in_progress row that the next `claimEventFiresLease` reclaims.
+ */
+import { sql, type Kysely } from 'kysely'
+
+/** `{ fence }` when THIS caller owns the (rule, dedup) claim; `'skip'` when it is already done or live-leased. */
+// schema-agnostic query helper: Kysely<T> is invariant so we accept any schema (repo precedent:
+// record-subscription-service.ts, several migrations). Only raw `sql` is used, never typed query builders.
+export async function claimEventFiresLease(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: Kysely<any>,
+  ruleId: string,
+  dedupKey: string,
+  leaseMs: number,
+): Promise<{ fence: string } | 'skip'> {
+  const ms = Math.max(1, Math.floor(leaseMs))
+  // Fresh claim: in_progress + lease + fence 1. ON CONFLICT DO NOTHING → an existing row falls through.
+  const fresh = await sql<{ fence: string }>`
+    INSERT INTO meta_automation_event_fires (rule_id, dedup_key, status, lease_expires_at, fence, attempts)
+    VALUES (${ruleId}, ${dedupKey}, 'in_progress', now() + ${ms} * interval '1 millisecond', 1, 1)
+    ON CONFLICT (rule_id, dedup_key) DO NOTHING
+    RETURNING fence::text AS fence
+  `.execute(db)
+  if (fresh.rows.length > 0) return { fence: fresh.rows[0].fence }
+  // Row exists: RECLAIM iff it is an EXPIRED in_progress lease (crashed/zombie worker). A `done` row or a LIVE
+  // in_progress lease is untouched → 'skip'. Concurrent reclaimers race: exactly one UPDATE matches
+  // (status='in_progress' AND lease_expires_at < now()); the losers see the bumped fence → 0 rows → 'skip'.
+  const reclaim = await sql<{ fence: string }>`
+    UPDATE meta_automation_event_fires
+    SET fence = fence + 1, attempts = attempts + 1, lease_expires_at = now() + ${ms} * interval '1 millisecond'
+    WHERE rule_id = ${ruleId} AND dedup_key = ${dedupKey}
+      AND status = 'in_progress' AND lease_expires_at < now()
+    RETURNING fence::text AS fence
+  `.execute(db)
+  return reclaim.rows.length > 0 ? { fence: reclaim.rows[0].fence } : 'skip'
+}
+
+/** fence-CAS the leased row to terminal `done` (clears the lease atomically). A stale-fence zombie hits 0 rows. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function markEventFiresDone(db: Kysely<any>, ruleId: string, dedupKey: string, fence: string): Promise<boolean> {
+  const res = await sql`
+    UPDATE meta_automation_event_fires
+    SET status = 'done', lease_expires_at = NULL
+    WHERE rule_id = ${ruleId} AND dedup_key = ${dedupKey} AND fence = ${fence}::bigint AND status = 'in_progress'
+  `.execute(db)
+  return Number(res.numAffectedRows ?? 0) === 1
+}

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -2623,8 +2623,6 @@ export class AutomationService {
         continue
       }
       try {
-        const claimed = await this.claimEventDelivery(rule.id, `approval.completed:${event.eventId}`)
-        if (!claimed) continue
         // Q3 record-less payload: the approval event rides along as the trigger event; actions are
         // save-restricted to non-record-targeting side effects, so the empty record context is never read.
         const payload: AutomationEventPayload & Record<string, unknown> = {
@@ -2640,7 +2638,7 @@ export class AutomationService {
           transition: event.transition,
           requester: event.requester,
         }
-        await this.executeRule(toExecutorRule(rule), payload)
+        await this.runWithEventDedup(rule.id, `approval.completed:${event.eventId}`, () => this.executeRule(toExecutorRule(rule), payload))
       } catch (err) {
         logger.error(`approval.completed rule ${rule.id} failed`, err instanceof Error ? err : undefined)
       }
@@ -2683,8 +2681,6 @@ export class AutomationService {
         continue
       }
       try {
-        const claimed = await this.claimEventDelivery(rule.id, `approval.task_created:${event.eventId}`)
-        if (!claimed) continue
         const payload: AutomationEventPayload & Record<string, unknown> = {
           sheetId: rule.sheet_id,
           recordId: '',
@@ -2698,7 +2694,7 @@ export class AutomationService {
           task: event.task,
           requester: event.requester,
         }
-        await this.executeRule(toExecutorRule(rule), payload)
+        await this.runWithEventDedup(rule.id, `approval.task_created:${event.eventId}`, () => this.executeRule(toExecutorRule(rule), payload))
       } catch (err) {
         logger.error(`approval.task_created rule ${rule.id} failed`, err instanceof Error ? err : undefined)
       }

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -32,6 +32,11 @@ import {
   type InboundWebhookRejectReason,
 } from './automation-inbound-webhook'
 import { isValidIanaTimeZone } from './automation-timezone'
+import { isDurableDeliveryEnabled } from './automation-durable-delivery'
+
+/** S6 event-delivery lease window: long enough to cover a normal executeRule, short enough that a crashed
+ *  worker's row is reclaimable promptly. Only consulted on the durable-delivery (flag ON) lease path. */
+const EVENT_DELIVERY_LEASE_MS = 60_000
 import { ensureRecordNotLocked } from './record-lock'
 import { publishMultitableSheetRealtime } from './realtime-publish'
 import { extractSelectOptions, normalizeJson } from './field-codecs'
@@ -1560,6 +1565,72 @@ export class AutomationService {
   }
 
   /**
+   * S6 (durable-delivery flag ON only): claim the (rule, dedup) with a reclaimable LEASE instead of the
+   * permanent tombstone, so a crash BETWEEN the claim and `executeRule` finishing leaves the row RECLAIMABLE
+   * rather than dropping the work forever (design lock §Layer-1 window-2). Returns `{ fence }` when THIS caller
+   * owns the claim — a fresh row (fence 1) OR a reclaimed EXPIRED lease (fence bumped) — or `'skip'` when the
+   * row is already `done` (delivered) or held by a LIVE lease (another worker owns it; do NOT double-run).
+   * The claimer must `markEventDeliveryDone(ruleId, dedupKey, fence)` after `executeRule` succeeds; a zombie
+   * whose fence is stale loses the fence-CAS there (single-writer persisted state). Flag OFF still uses the
+   * legacy tombstone `claimEventDelivery` above — byte-neutral: the #4413 migration's `status DEFAULT 'done'`
+   * makes every legacy tombstone row read as delivered, so the two paths interoperate on the shared table.
+   */
+  private async claimEventDeliveryLeased(ruleId: string, dedupKey: string, leaseMs: number): Promise<{ fence: string } | 'skip'> {
+    const ms = Math.max(1, Math.floor(leaseMs))
+    // Fresh claim: insert in_progress with a lease + fence 1. ON CONFLICT DO NOTHING so an existing row falls
+    // through to the reclaim path (a bare tombstone/done row, or another worker's in_progress).
+    const fresh = await sql<{ fence: string }>`
+      INSERT INTO meta_automation_event_fires (rule_id, dedup_key, status, lease_expires_at, fence, attempts)
+      VALUES (${ruleId}, ${dedupKey}, 'in_progress', now() + ${ms} * interval '1 millisecond', 1, 1)
+      ON CONFLICT (rule_id, dedup_key) DO NOTHING
+      RETURNING fence::text AS fence
+    `.execute(this.db)
+    if (fresh.rows.length > 0) return { fence: fresh.rows[0].fence }
+    // Row exists: RECLAIM iff it is an EXPIRED in_progress lease (a crashed/zombie worker). A `done` row or a
+    // LIVE (unexpired) in_progress lease is left untouched → 'skip' (delivered, or owned by a live worker).
+    // The `status='in_progress' AND lease_expires_at < now()` predicate makes concurrent reclaimers race on
+    // the row: exactly one UPDATE affects it, the others see the already-bumped fence and get 0 rows → 'skip'.
+    const reclaim = await sql<{ fence: string }>`
+      UPDATE meta_automation_event_fires
+      SET fence = fence + 1, attempts = attempts + 1, lease_expires_at = now() + ${ms} * interval '1 millisecond'
+      WHERE rule_id = ${ruleId} AND dedup_key = ${dedupKey}
+        AND status = 'in_progress' AND lease_expires_at < now()
+      RETURNING fence::text AS fence
+    `.execute(this.db)
+    return reclaim.rows.length > 0 ? { fence: reclaim.rows[0].fence } : 'skip'
+  }
+
+  /** fence-CAS the leased row to terminal `done` (clears the lease atomically). A stale-fence zombie hits 0 rows. */
+  private async markEventDeliveryDone(ruleId: string, dedupKey: string, fence: string): Promise<boolean> {
+    const res = await sql`
+      UPDATE meta_automation_event_fires
+      SET status = 'done', lease_expires_at = NULL
+      WHERE rule_id = ${ruleId} AND dedup_key = ${dedupKey} AND fence = ${fence}::bigint AND status = 'in_progress'
+    `.execute(this.db)
+    return Number(res.numAffectedRows ?? 0) === 1
+  }
+
+  /**
+   * Run `run` under the event-dedup ledger, choosing the S6 lease flow when durable delivery is enabled and
+   * the legacy tombstone flow otherwise. Both return early (do nothing) when the delivery is already claimed
+   * by someone else / already done. The lease flow marks the row `done` (fence-CAS) only AFTER `run` succeeds;
+   * if `run` throws, the lease is left to expire so the next scan reclaims it (window-2 fix). Flag OFF is
+   * byte-neutral (legacy at-most-once tombstone).
+   */
+  private async runWithEventDedup(ruleId: string, dedupKey: string, run: () => Promise<unknown>, env: NodeJS.ProcessEnv = process.env): Promise<void> {
+    if (!isDurableDeliveryEnabled(env)) {
+      const claimed = await this.claimEventDelivery(ruleId, dedupKey)
+      if (!claimed) return
+      await run()
+      return
+    }
+    const lease = await this.claimEventDeliveryLeased(ruleId, dedupKey, EVENT_DELIVERY_LEASE_MS)
+    if (lease === 'skip') return
+    await run()
+    await this.markEventDeliveryDone(ruleId, dedupKey, lease.fence)
+  }
+
+  /**
    * Date-reminder scan (`schedule.date_field`). For each record in the rule's sheet whose date field yields a
    * DUE occurrence, claim it in the idempotency ledger and fire the rule once with the record as context.
    *
@@ -2067,10 +2138,10 @@ export class AutomationService {
 
       try {
         if (dedupKey) {
-          const claimed = await this.claimEventDelivery(rule.id, dedupKey)
-          if (!claimed) continue
+          await this.runWithEventDedup(rule.id, dedupKey, () => this.executeRule(execRule, payload))
+        } else {
+          await this.executeRule(execRule, payload)
         }
-        await this.executeRule(execRule, payload)
       } catch (err) {
         logger.error(
           `Automation rule ${rule.id} action failed`,

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -33,6 +33,7 @@ import {
 } from './automation-inbound-webhook'
 import { isValidIanaTimeZone } from './automation-timezone'
 import { isDurableDeliveryEnabled } from './automation-durable-delivery'
+import { claimEventFiresLease, markEventFiresDone } from './automation-event-fires-lease'
 
 /** S6 event-delivery lease window: long enough to cover a normal executeRule, short enough that a crashed
  *  worker's row is reclaimable promptly. Only consulted on the durable-delivery (flag ON) lease path. */
@@ -1575,47 +1576,12 @@ export class AutomationService {
    * legacy tombstone `claimEventDelivery` above — byte-neutral: the #4413 migration's `status DEFAULT 'done'`
    * makes every legacy tombstone row read as delivered, so the two paths interoperate on the shared table.
    */
-  private async claimEventDeliveryLeased(ruleId: string, dedupKey: string, leaseMs: number): Promise<{ fence: string } | 'skip'> {
-    const ms = Math.max(1, Math.floor(leaseMs))
-    // Fresh claim: insert in_progress with a lease + fence 1. ON CONFLICT DO NOTHING so an existing row falls
-    // through to the reclaim path (a bare tombstone/done row, or another worker's in_progress).
-    const fresh = await sql<{ fence: string }>`
-      INSERT INTO meta_automation_event_fires (rule_id, dedup_key, status, lease_expires_at, fence, attempts)
-      VALUES (${ruleId}, ${dedupKey}, 'in_progress', now() + ${ms} * interval '1 millisecond', 1, 1)
-      ON CONFLICT (rule_id, dedup_key) DO NOTHING
-      RETURNING fence::text AS fence
-    `.execute(this.db)
-    if (fresh.rows.length > 0) return { fence: fresh.rows[0].fence }
-    // Row exists: RECLAIM iff it is an EXPIRED in_progress lease (a crashed/zombie worker). A `done` row or a
-    // LIVE (unexpired) in_progress lease is left untouched → 'skip' (delivered, or owned by a live worker).
-    // The `status='in_progress' AND lease_expires_at < now()` predicate makes concurrent reclaimers race on
-    // the row: exactly one UPDATE affects it, the others see the already-bumped fence and get 0 rows → 'skip'.
-    const reclaim = await sql<{ fence: string }>`
-      UPDATE meta_automation_event_fires
-      SET fence = fence + 1, attempts = attempts + 1, lease_expires_at = now() + ${ms} * interval '1 millisecond'
-      WHERE rule_id = ${ruleId} AND dedup_key = ${dedupKey}
-        AND status = 'in_progress' AND lease_expires_at < now()
-      RETURNING fence::text AS fence
-    `.execute(this.db)
-    return reclaim.rows.length > 0 ? { fence: reclaim.rows[0].fence } : 'skip'
-  }
-
-  /** fence-CAS the leased row to terminal `done` (clears the lease atomically). A stale-fence zombie hits 0 rows. */
-  private async markEventDeliveryDone(ruleId: string, dedupKey: string, fence: string): Promise<boolean> {
-    const res = await sql`
-      UPDATE meta_automation_event_fires
-      SET status = 'done', lease_expires_at = NULL
-      WHERE rule_id = ${ruleId} AND dedup_key = ${dedupKey} AND fence = ${fence}::bigint AND status = 'in_progress'
-    `.execute(this.db)
-    return Number(res.numAffectedRows ?? 0) === 1
-  }
-
   /**
    * Run `run` under the event-dedup ledger, choosing the S6 lease flow when durable delivery is enabled and
    * the legacy tombstone flow otherwise. Both return early (do nothing) when the delivery is already claimed
    * by someone else / already done. The lease flow marks the row `done` (fence-CAS) only AFTER `run` succeeds;
    * if `run` throws, the lease is left to expire so the next scan reclaims it (window-2 fix). Flag OFF is
-   * byte-neutral (legacy at-most-once tombstone).
+   * byte-neutral (legacy at-most-once tombstone). Lease semantics live in automation-event-fires-lease.ts.
    */
   private async runWithEventDedup(ruleId: string, dedupKey: string, run: () => Promise<unknown>, env: NodeJS.ProcessEnv = process.env): Promise<void> {
     if (!isDurableDeliveryEnabled(env)) {
@@ -1624,10 +1590,10 @@ export class AutomationService {
       await run()
       return
     }
-    const lease = await this.claimEventDeliveryLeased(ruleId, dedupKey, EVENT_DELIVERY_LEASE_MS)
+    const lease = await claimEventFiresLease(this.db, ruleId, dedupKey, EVENT_DELIVERY_LEASE_MS)
     if (lease === 'skip') return
     await run()
-    await this.markEventDeliveryDone(ruleId, dedupKey, lease.fence)
+    await markEventFiresDone(this.db, ruleId, dedupKey, lease.fence)
   }
 
   /**

--- a/packages/core-backend/tests/integration/multitable-automation-event-fires-lease-realdb.db.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-event-fires-lease-realdb.db.test.ts
@@ -1,0 +1,111 @@
+/**
+ * S6 event_fires LEASE claim/reclaim (real DB, isolated schema).
+ *
+ * Proves the window-2 fix at the load-bearing SQL layer: a fresh claim leases the (rule, dedup); a crash
+ * (no markEventFiresDone) leaves an EXPIRED in_progress row the NEXT claim RECLAIMS (redelivers) — vs the
+ * legacy tombstone which dropped the work; a `done` row and a LIVE lease both `skip`; markEventFiresDone is
+ * a fence-CAS so a stale-fence "zombie" hits 0 rows (single-writer). Uses the #4413 lease schema in an
+ * isolated schema (house rule for shared-DB integration).
+ */
+import { randomUUID } from 'node:crypto'
+
+import { Pool } from 'pg'
+import { Kysely, PostgresDialect, sql } from 'kysely'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { claimEventFiresLease, markEventFiresDone } from '../../src/multitable/automation-event-fires-lease'
+
+const dbUrl = process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+
+describeDb('S6 event_fires lease claim/reclaim (real DB, isolated schema)', () => {
+  let adminPool: Pool
+  let schema: string
+  let testPool: Pool
+  let db: Kysely<unknown>
+  const RULE = `rule_${randomUUID().slice(0, 8)}`
+
+  beforeEach(async () => {
+    adminPool = new Pool({ connectionString: dbUrl })
+    schema = `s6lease_${randomUUID().replace(/-/g, '')}`
+    await adminPool.query(`CREATE SCHEMA "${schema}"`)
+    testPool = new Pool({ connectionString: dbUrl, options: `-c search_path=${schema}` })
+    db = new Kysely<unknown>({ dialect: new PostgresDialect({ pool: testPool }) })
+    // the #4413 lease schema (upgraded shape)
+    await sql`
+      CREATE TABLE meta_automation_event_fires (
+        rule_id text NOT NULL, dedup_key text NOT NULL, fired_at timestamptz NOT NULL DEFAULT now(),
+        status text NOT NULL DEFAULT 'done' CHECK (status IN ('pending','in_progress','done','outcome_unknown','failed','dead_letter')),
+        lease_expires_at timestamptz, attempts int NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+        fence bigint NOT NULL DEFAULT 0 CHECK (fence >= 0),
+        PRIMARY KEY (rule_id, dedup_key),
+        CONSTRAINT lease_iff_in_progress CHECK ((status = 'in_progress') = (lease_expires_at IS NOT NULL)))
+    `.execute(db)
+  })
+
+  afterEach(async () => {
+    await db.destroy()
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+    await adminPool.end()
+  })
+
+  const row = async (dedup: string) =>
+    (
+      await sql<{ status: string; fence: string; lease: string | null; attempts: number }>`
+        SELECT status, fence::text AS fence, lease_expires_at::text AS lease, attempts
+        FROM meta_automation_event_fires WHERE rule_id = ${RULE} AND dedup_key = ${dedup}
+      `.execute(db)
+    ).rows[0]
+
+  it('fresh claim leases the row (in_progress, fence 1); markDone fence-CAS → done, lease cleared', async () => {
+    const c = await claimEventFiresLease(db, RULE, 'e1', 60_000)
+    expect(c).not.toBe('skip')
+    const r = await row('e1')
+    expect(r).toMatchObject({ status: 'in_progress', fence: '1', attempts: 1 })
+    expect(r.lease).not.toBeNull()
+    expect(await markEventFiresDone(db, RULE, 'e1', (c as { fence: string }).fence)).toBe(true)
+    expect(await row('e1')).toMatchObject({ status: 'done', lease: null })
+  })
+
+  it('a DONE delivery is skipped on re-claim (at-most-once for a completed event)', async () => {
+    const c = await claimEventFiresLease(db, RULE, 'e2', 60_000)
+    await markEventFiresDone(db, RULE, 'e2', (c as { fence: string }).fence)
+    expect(await claimEventFiresLease(db, RULE, 'e2', 60_000)).toBe('skip')
+  })
+
+  it('a LIVE (unexpired) lease is skipped — a second worker does NOT double-run', async () => {
+    await claimEventFiresLease(db, RULE, 'e3', 60_000) // long lease, still live
+    expect(await claimEventFiresLease(db, RULE, 'e3', 60_000)).toBe('skip')
+  })
+
+  it('WINDOW-2: a crash (claim but no markDone) leaves an EXPIRED lease the next claim RECLAIMS (redelivers)', async () => {
+    const first = await claimEventFiresLease(db, RULE, 'e4', 1) // 1ms lease → expires immediately
+    expect(first).not.toBe('skip')
+    // "crash": executeRule never finished, markEventFiresDone never called → the row is in_progress + expired.
+    await new Promise((r) => setTimeout(r, 20))
+    const reclaim = await claimEventFiresLease(db, RULE, 'e4', 60_000)
+    expect(reclaim).not.toBe('skip') // the work is RECLAIMED, not dropped (legacy tombstone would have skipped)
+    expect(Number((reclaim as { fence: string }).fence)).toBe(2) // fence bumped on reclaim
+    expect(await row('e4')).toMatchObject({ status: 'in_progress', attempts: 2 })
+  })
+
+  it('fence-CAS: after a reclaim (fence 2), the ZOMBIE (fence 1) markDone hits 0 rows; the reclaimer (fence 2) wins', async () => {
+    const z = await claimEventFiresLease(db, RULE, 'e5', 1)
+    await new Promise((r) => setTimeout(r, 20))
+    const rr = await claimEventFiresLease(db, RULE, 'e5', 60_000)
+    expect(Number((rr as { fence: string }).fence)).toBe(2)
+    // the zombie holding fence 1 finally tries to mark done → stale fence, 0 rows (single-writer)
+    expect(await markEventFiresDone(db, RULE, 'e5', (z as { fence: string }).fence)).toBe(false)
+    expect(await row('e5')).toMatchObject({ status: 'in_progress' }) // still owned by the reclaimer
+    // the reclaimer marks done → wins
+    expect(await markEventFiresDone(db, RULE, 'e5', (rr as { fence: string }).fence)).toBe(true)
+    expect(await row('e5')).toMatchObject({ status: 'done', lease: null })
+  })
+
+  it('interoperates with a legacy tombstone row: a flag-OFF INSERT lands as done (default) → lease claim skips it', async () => {
+    // legacy path: bare INSERT (status defaults to done)
+    await sql`INSERT INTO meta_automation_event_fires (rule_id, dedup_key) VALUES (${RULE}, 'e6')`.execute(db)
+    expect(await row('e6')).toMatchObject({ status: 'done', fence: '0' })
+    expect(await claimEventFiresLease(db, RULE, 'e6', 60_000)).toBe('skip') // already delivered under the old path
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -257,6 +257,9 @@ export default defineConfig({
       // isolated per-test schema, real UPGRADE path (old schema + rows → migrate → assert). Excluded here so it
       // cannot skip-green, whole-file wired into `Run attendance integration tests` in plugin-tests.yml.
       'tests/integration/multitable-automation-event-fires-lease-migration.db.test.ts',
+      // S6 event_fires LEASE claim/reclaim (window-2 fix): isolated-schema real DB. Excluded here so it cannot
+      // skip-green, whole-file wired into the attendance real-DB step in plugin-tests.yml.
+      'tests/integration/multitable-automation-event-fires-lease-realdb.db.test.ts',
       // F9 owner CHANGES-REQUESTED (GF9-1/GF9-2): multitable_attachments blob_purged_at migration +
       // deleteAttachmentBinary index-free delete + sweepMultitableAttachmentBlobPurge compensating-sweep
       // matrix, same shape/rationale as the F5 entry immediately above (DATABASE_URL-gated describeDb,


### PR DESCRIPTION
**Closes the S6 P1** (the review's "event_fires lease-runtime" item). The #4413 schema is on main; this wires the RUNTIME. **Flag-gated** (`AUTOMATION_DURABLE_DELIVERY_ENABLED`, default OFF) — flag OFF is byte-neutral.

## What lands
- **`automation-event-fires-lease.ts`** — `claimEventFiresLease` (fresh claim / reclaim an EXPIRED in_progress lease / `skip` on done or live lease) + `markEventFiresDone` (fence-CAS). Extracted so the lease semantics are directly real-DB testable.
- **`AutomationService.runWithEventDedup`** — flag OFF → legacy tombstone (at-most-once, unchanged); flag ON → claim/reclaim → `executeRule` → mark done only on success. A crash before mark-done leaves the lease to expire → the next claim reclaims (the **window-2 fix**: the tombstone path dropped the work). All 3 event-dedup sites (generic / approval.completed / approval.task_created) rewired.

## Verification
Real-DB crash-injection matrix (isolated schema) **6/6**: fresh-claim→done; done/live-lease skip; **window-2 reclaim** (crash → expired lease → next claim redelivers, fence 2); **fence-CAS** (zombie fence-1 markDone → 0 rows, reclaimer wins); legacy-tombstone interop. `tsc` 0; existing automation-service unit **43/43** (flag-OFF unchanged). Both guards **mutation-proven**. Two-point CI wired.

**For review — not self-merging runtime.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)