### PR TITLE
fix(ops): make branch policy checker Bash 3 compatible

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -174,11 +174,14 @@ jobs:
       - name: B4 department-bindings CI wiring contract
         run: node --test scripts/ops/b4-department-bindings-ci-wiring.test.mjs
 
-      # The production monitor invokes the same state helper covered here.
-      # Keep this in the required 18/20 matrix so HTTP classification, silence
-      # barriers, and alert/recovery streak semantics cannot drift silently.
-      - name: Prod health probe monitor contract
-        run: node --test scripts/ops/prod-health-probe-state.test.mjs
+      # Production monitors invoke the same helpers covered here. Keep these in
+      # the required 18/20 matrix so health semantics and shell portability
+      # cannot drift silently.
+      - name: Production monitor contracts
+        run: |
+          node --test \
+            scripts/ops/prod-health-probe-state.test.mjs \
+            scripts/ops/attendance-check-branch-protection.test.mjs
 
       # #4210 T9: the stock-preparation one-click acceptance script's cross-platform contract + behavioural
       # tests are pure pwsh 7 + tar + node. Run once in the required 20.x arm. The package's target-shell

--- a/scripts/ops/attendance-check-branch-protection.sh
+++ b/scripts/ops/attendance-check-branch-protection.sh
@@ -193,10 +193,12 @@ else
   strict_current="$(jq -r '.required_status_checks.strict // false' "$protection_json")"
   enforce_admins_current="$(jq -r '.enforce_admins.enabled // false' "$protection_json")"
   pr_reviews_required_current="$(jq -r 'if (.required_pull_request_reviews == null) then false else true end' "$protection_json")"
-  pr_reviews_required_current="$(jq -r 'if (.required_pull_request_reviews == null) then false else true end' "$protection_json")"
   approving_review_count_current="$(jq -r '.required_pull_request_reviews.required_approving_review_count // 0' "$protection_json")"
   code_owner_reviews_current="$(jq -r '.required_pull_request_reviews.require_code_owner_reviews // false' "$protection_json")"
-  mapfile -t contexts_current < <(jq -r '.required_status_checks.contexts[]? // empty' "$protection_json")
+  while IFS= read -r context; do
+    [[ -n "$context" ]] || continue
+    contexts_current+=("$context")
+  done < <(jq -r '.required_status_checks.contexts[]? // empty' "$protection_json")
 fi
 
 missing_checks=()

--- a/scripts/ops/attendance-check-branch-protection.test.mjs
+++ b/scripts/ops/attendance-check-branch-protection.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+
+const repoRoot = process.cwd()
+const scriptPath = path.join(repoRoot, 'scripts/ops/attendance-check-branch-protection.sh')
+
+test('REST protection parsing does not require Bash 4 array builtins', () => {
+  const tempRoot = mkdtempSync(path.join(tmpdir(), 'attendance-branch-protection-'))
+  const binDir = path.join(tempRoot, 'bin')
+  const ghPath = path.join(binDir, 'gh')
+  const bashEnvPath = path.join(tempRoot, 'bash-env.sh')
+  const outputPath = path.join(tempRoot, 'policy.json')
+
+  try {
+    mkdirSync(binDir)
+    writeFileSync(
+      ghPath,
+      `#!/bin/sh
+cat <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["contracts (strict)", "contracts (dashboard)"]
+  },
+  "enforce_admins": { "enabled": true },
+  "required_pull_request_reviews": null
+}
+JSON
+`,
+      'utf8',
+    )
+    chmodSync(ghPath, 0o755)
+    writeFileSync(
+      bashEnvPath,
+      'enable -n mapfile 2>/dev/null || true\nenable -n readarray 2>/dev/null || true\n',
+      'utf8',
+    )
+
+    const result = spawnSync('bash', [scriptPath], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        BASH_ENV: bashEnvPath,
+        PATH: `${binDir}:${process.env.PATH || ''}`,
+        REPO: 'zensgit/metasheet2',
+        BRANCH: 'main',
+        REQUIRED_CHECKS_CSV: 'contracts (strict),contracts (dashboard)',
+        REQUIRE_STRICT: 'true',
+        REQUIRE_ENFORCE_ADMINS: 'true',
+        REQUIRE_PR_REVIEWS: 'false',
+        MIN_APPROVING_REVIEW_COUNT: '1',
+        REQUIRE_CODE_OWNER_REVIEWS: 'false',
+        OUTPUT_JSON: outputPath,
+      },
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stderr, /contexts_current=contracts \(strict\),contracts \(dashboard\)/)
+    const output = JSON.parse(readFileSync(outputPath, 'utf8'))
+    assert.equal(output.ok, true)
+    assert.deepEqual(output.contextsCurrent, ['contracts (strict)', 'contracts (dashboard)'])
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## What changed

- replace the Bash 4-only `mapfile` call with a portable line-reading loop;
- add a full-script REST fixture test that disables both `mapfile` and `readarray`;
- remove the duplicated pull-request review-state assignment.

## Why

During recovery of branch-policy alert #190, `attendance-ensure-branch-protection.sh` successfully restored the GitHub setting but its post-apply verification failed on macOS Bash 3.2 because the checker used `mapfile`. That left a successful mutation with an ambiguous local result. The checker now completes on the repository-supported macOS shell as well as Linux Actions.

## Verification

- `node --test scripts/ops/attendance-check-branch-protection.test.mjs scripts/ops/attendance-branch-token-fallback-workflow-contract.test.mjs` (6/6 pass)
- `bash -n scripts/ops/attendance-check-branch-protection.sh`
- `node --check scripts/ops/attendance-check-branch-protection.test.mjs`
- live read-only checker run on macOS Bash 3.2 against `main` (PASS; all seven required contexts present)
- `git diff --cached --check`

The repository root has no ESLint configuration for standalone `scripts/ops/*.mjs` files, so the focused Node syntax and behavior checks are the applicable local gates. No merge, deployment, or additional branch-setting change is performed by this PR.