### PR TITLE
feat(automation): #4196 §4 — retry RULE_CHANGED guard over the RAW-config fingerprint

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260716160000_add_execution_rule_fingerprint.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260716160000_add_execution_rule_fingerprint.ts
@@ -1,0 +1,24 @@
+/**
+ * Migration: `multitable_automation_executions.rule_action_fingerprint` — the #4196 §4 retry rule-change guard.
+ *
+ * A retry must be refused if the rule's actions CHANGED since the original execution (a config-only edit
+ * included), because the applied-ledger `action_key`s were computed against the OLD rule. The comparison uses
+ * the §2.1 action-set fingerprint over the RAW config (`deriveRuleActionSetFingerprint`) — the SAME identity
+ * the Class-A claim keys on, so the two never diverge. It CANNOT be re-derived from the persisted
+ * `rule_snapshot` because that column is REDACTED (secret-shaped values masked), which would diverge from the
+ * raw-config claim identity. So the RAW fingerprint is captured at execution time and stored here (it is a
+ * one-way sha256 of the action identities — no business values, safe to store un-redacted).
+ *
+ * Nullable: executions that ran BEFORE this column existed have none; the retry guard fails CLOSED on a
+ * missing fingerprint (cannot prove the rule is unchanged → refuse), per the lock's missing-input doctrine.
+ * Additive only; nothing reads it until the executor/retry wiring lands with it.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE multitable_automation_executions ADD COLUMN IF NOT EXISTS rule_action_fingerprint text`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE multitable_automation_executions DROP COLUMN IF EXISTS rule_action_fingerprint`.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260716160000_add_execution_rule_fingerprint.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260716160000_add_execution_rule_fingerprint.ts
@@ -9,8 +9,9 @@
  * raw-config claim identity. So the RAW fingerprint is captured at execution time and stored here (it is a
  * one-way sha256 of the action identities — no business values, safe to store un-redacted).
  *
- * Nullable: executions that ran BEFORE this column existed have none; the retry guard fails CLOSED on a
- * missing fingerprint (cannot prove the rule is unchanged → refuse), per the lock's missing-input doctrine.
+ * Nullable: executions that ran BEFORE this column existed have none; for them the retry guard is SKIPPED
+ * (rollout-safe / non-regressing) — a missing fingerprint means "cannot check", NOT a refusal, so every
+ * pre-column execution stays retryable. The guard only fires when a fingerprint IS present and differs.
  * Additive only; nothing reads it until the executor/retry wiring lands with it.
  */
 import { sql, type Kysely } from 'kysely'

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1420,6 +1420,9 @@ export interface MultitableAutomationExecutionsTable {
   rule_snapshot: JsonObjectColumn
   finished_at: Date | string | null
   schema_version: number
+  // #4196 §4: the RAW-config §2.1 action-set fingerprint captured at execution time (nullable; pre-column
+  // executions have none → the retry rule-change guard is SKIPPED for them, rollout-safe/non-regressing).
+  rule_action_fingerprint: string | null
   // A5 retry provenance columns (nullable; set only on a retry-created execution).
   rerun_of_execution_id: string | null
   initiated_by: string | null

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -6,6 +6,7 @@
 import { randomUUID } from 'crypto'
 import { recordRecordRevision, recordVersionMarker } from './record-history-service'
 import { branchChildStepKey, topLevelStepKey } from './automation-step-key'
+import { deriveRuleActionSetFingerprint } from './automation-rule-fingerprint'
 import { Logger } from '../core/logger'
 import { withAutomationEventId } from './automation-event-dedup'
 import { redactString } from './automation-log-redact'
@@ -713,6 +714,13 @@ export interface AutomationExecution {
   triggerEvent?: unknown
   /** The rule as it was at execution time (diagnosis / future retry source). */
   ruleSnapshot?: AutomationRule
+  /**
+   * #4196 §4: the §2.1 action-set fingerprint over the RAW config, captured at execution time. A retry
+   * compares the current rule's fingerprint to THIS to refuse a config-changed rule (409 RULE_CHANGED). NOT
+   * re-derived from ruleSnapshot (which is redacted → would diverge from the raw Class-A claim identity); a
+   * values-free sha256, safe to persist un-redacted.
+   */
+  ruleActionFingerprint?: string
   /** When the execution finished (cleaner provenance anchor than duration alone). */
   finishedAt?: string
   /** Forward-compat tag for the snapshot shape. */
@@ -897,6 +905,8 @@ export class AutomationExecutor {
       sheetId: rule.sheetId,
       triggerEvent,
       ruleSnapshot: rule,
+      // #4196 §4: the RAW-config §2.1 fingerprint (the Class-A claim identity) captured before any redaction.
+      ruleActionFingerprint: deriveRuleActionSetFingerprint(rule.actions).hash,
       schemaVersion: AUTOMATION_EXECUTION_SCHEMA_VERSION,
     }
 

--- a/packages/core-backend/src/multitable/automation-log-service.ts
+++ b/packages/core-backend/src/multitable/automation-log-service.ts
@@ -77,11 +77,11 @@ export class AutomationLogService {
       `INSERT INTO multitable_automation_executions (
          id, rule_id, triggered_by, triggered_at, status, steps, error, duration,
          sheet_id, trigger_event, rule_snapshot, finished_at, schema_version,
-         rerun_of_execution_id, initiated_by
+         rerun_of_execution_id, initiated_by, rule_action_fingerprint
        ) VALUES (
          $1, $2, $3, $4, $5, $6::jsonb, $7, $8,
          $9, $10::jsonb, $11::jsonb, $12, $13,
-         $14, $15
+         $14, $15, $16
        )`,
       [
         execution.id,
@@ -99,6 +99,8 @@ export class AutomationLogService {
         execution.schemaVersion ?? AUTOMATION_EXECUTION_SCHEMA_VERSION,
         execution.rerunOfExecutionId ?? null,
         execution.initiatedBy ?? null,
+        // #4196 §4: a values-free sha256 of the RAW action identities — NOT redacted (no business values).
+        execution.ruleActionFingerprint ?? null,
       ],
     )
   }
@@ -122,6 +124,7 @@ export class AutomationLogService {
         rule_snapshot: persisted.ruleSnapshotJsonb,
         finished_at: execution.finishedAt ?? null,
         schema_version: execution.schemaVersion ?? AUTOMATION_EXECUTION_SCHEMA_VERSION,
+        rule_action_fingerprint: execution.ruleActionFingerprint ?? null,
         rerun_of_execution_id: execution.rerunOfExecutionId ?? null,
         initiated_by: execution.initiatedBy ?? null,
       })
@@ -297,6 +300,8 @@ function toExecution(row: Record<string, unknown>): AutomationExecution {
           ? row.finished_at.toISOString()
           : String(row.finished_at),
     schemaVersion: row.schema_version != null ? Number(row.schema_version) : undefined,
+    // #4196 §4 — null for pre-column executions (the retry guard is skipped on a missing fingerprint; rollout-safe).
+    ruleActionFingerprint: (row.rule_action_fingerprint as string) ?? undefined,
     // A5 retry provenance — null-safe for non-retry / pre-A5 rows.
     rerunOfExecutionId: (row.rerun_of_execution_id as string) ?? undefined,
     initiatedBy: (row.initiated_by as string) ?? undefined,

--- a/packages/core-backend/src/multitable/automation-log-service.ts
+++ b/packages/core-backend/src/multitable/automation-log-service.ts
@@ -47,6 +47,11 @@ export class AutomationLogService {
         rule_snapshot: persisted.ruleSnapshotJsonb,
         finished_at: execution.finishedAt ?? null,
         schema_version: execution.schemaVersion ?? AUTOMATION_EXECUTION_SCHEMA_VERSION,
+        // #4196 §4: a values-free sha256 of the RAW action identities — NOT redacted (no business values).
+        // Wired in BOTH insert paths (this kysely one and recordWithQuery's raw SQL) — missing it here left
+        // every production execution with a NULL fingerprint, silently disarming the retry RULE_CHANGED
+        // guard (caught by the real-DB suspend/resume T2 immutability golden in CI).
+        rule_action_fingerprint: execution.ruleActionFingerprint ?? null,
         // A5 retry provenance — plain identifiers, NOT redacted (an execution id / a user id).
         rerun_of_execution_id: execution.rerunOfExecutionId ?? null,
         initiated_by: execution.initiatedBy ?? null,

--- a/packages/core-backend/src/multitable/automation-log-service.ts
+++ b/packages/core-backend/src/multitable/automation-log-service.ts
@@ -124,7 +124,10 @@ export class AutomationLogService {
         rule_snapshot: persisted.ruleSnapshotJsonb,
         finished_at: execution.finishedAt ?? null,
         schema_version: execution.schemaVersion ?? AUTOMATION_EXECUTION_SCHEMA_VERSION,
-        rule_action_fingerprint: execution.ruleActionFingerprint ?? null,
+        // #4196 §4: rule_action_fingerprint is captured at INSERT (execution start) and is IMMUTABLE. It is
+        // deliberately NOT in this UPDATE set — resume / approval-bridge continuations pass execution objects
+        // rebuilt from suspension/bridge state that may not carry the field, and setting it here would NULL a
+        // previously-captured fingerprint, silently disarming the retry RULE_CHANGED guard for that execution.
         rerun_of_execution_id: execution.rerunOfExecutionId ?? null,
         initiated_by: execution.initiatedBy ?? null,
       })

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -64,6 +64,7 @@ import { randomBytes } from 'crypto'
 import { AutomationLogService } from './automation-log-service'
 import { AutomationJobService } from './automation-job-service'
 import { AutomationSuspensionService, computeActionFingerprint } from './automation-suspension-service'
+import { deriveRuleActionSetFingerprint } from './automation-rule-fingerprint'
 import {
   AutomationApprovalBridgeService,
   hasPermissionCode,
@@ -739,8 +740,10 @@ export interface UpdateRuleInput {
 
 /**
  * Convert a legacy DB rule to the executor rule format.
+ * Exported for test parity: the retry RULE_CHANGED guard fingerprints `toExecutorRule(rule).actions`,
+ * so a test that asserts a MATCHING fingerprint must normalize the DB row through this same transform.
  */
-function toExecutorRule(rule: AutomationRule): ExecutorRule {
+export function toExecutorRule(rule: AutomationRule): ExecutorRule {
   const trigger: AutomationTrigger = {
     type: rule.trigger_type as AutomationTriggerType,
     config: rule.trigger_config ?? {},
@@ -2247,6 +2250,22 @@ export class AutomationService {
       return { status: 409, code: 'RULE_MISSING_OR_DISABLED', message: `Rule ${original.ruleId} is missing or disabled; cannot retry` }
     }
     const execRule = toExecutorRule(rule)
+    // #4196 §4 — refuse a retry whose rule changed since the original run. A config-only edit (same action
+    // types, rotated URL/token/target) silently rebinds the action's identity, so replaying the OLD execution
+    // against the NEW config could double-apply or apply to the wrong target. Compare the current rule's
+    // RAW-config §2.1 fingerprint against the one captured at the original run (the type-only
+    // computeActionFingerprint the suspend/resume guards use is blind to config-only edits). Rollout-safe:
+    // executions that predate the fingerprint column carry `null` and are NOT guarded (non-regressing).
+    if (
+      original.ruleActionFingerprint != null &&
+      deriveRuleActionSetFingerprint(execRule.actions).hash !== original.ruleActionFingerprint
+    ) {
+      return {
+        status: 409,
+        code: 'RULE_CHANGED',
+        message: 'Rule actions changed since the original execution; cannot retry safely',
+      }
+    }
     const execution = await this.executeRule(execRule, original.triggerEvent, {
       rerunOfExecutionId: original.id,
       initiatedBy,

--- a/packages/core-backend/tests/integration/multitable-automation-suspend-resume.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-suspend-resume.test.ts
@@ -123,7 +123,23 @@ describeIfDatabase('multitable automation suspend/resume (A6-2, real DB)', () =>
     const svc = makeService()
     const ruleId = await createWaitRule(svc, 't2')
     const exec = await suspend(svc, ruleId)
+
+    // #4196 §4 immutability control — capture the fingerprint the INSERT wrote (before the resume's UPDATE).
+    const fpBefore = (
+      await q('SELECT rule_action_fingerprint FROM multitable_automation_executions WHERE id = $1', [exec.id])
+    ).rows[0]?.rule_action_fingerprint
+    expect(fpBefore).toBeTruthy() // captured at execution start, unconditionally
+
     const result = await svc.resumeExecution(await tokenFor(exec.id), 'admin_t2')
+
+    // The resume path calls updateRecordedExecution with a REBUILT execution object that does not carry
+    // ruleActionFingerprint. The column is deliberately excluded from that UPDATE, so the value the INSERT
+    // wrote MUST survive unchanged. Before that fix the resume nulled it, silently disarming the retry
+    // RULE_CHANGED guard for every suspended-then-resumed execution.
+    const fpAfter = (
+      await q('SELECT rule_action_fingerprint FROM multitable_automation_executions WHERE id = $1', [exec.id])
+    ).rows[0]?.rule_action_fingerprint
+    expect(fpAfter).toBe(fpBefore)
 
     expect('execution' in result).toBe(true)
     if ('execution' in result) {

--- a/packages/core-backend/tests/unit/automation-rule-fingerprint.test.ts
+++ b/packages/core-backend/tests/unit/automation-rule-fingerprint.test.ts
@@ -115,4 +115,27 @@ describe('#4196 §2.1 rule action-set fingerprint', () => {
     expect(deriveRuleActionSetFingerprint([])).toEqual(deriveRuleActionSetFingerprint(undefined))
     expect(deriveRuleActionSetFingerprint([]).count).toBe(0)
   })
+
+  // §4 anti-false-positive: the captured fingerprint is persisted to JSONB and the compare side is read back
+  // from the rule row. JSONB does NOT preserve object key ORDER, so an UNCHANGED rule whose config keys come
+  // back reordered must still fingerprint IDENTICALLY — otherwise a legitimate retry gets a spurious 409
+  // RULE_CHANGED. This pins the canonicalization (deep key-sort) the guard's correctness depends on.
+  it('a JSONB round-trip that reorders config keys does NOT change the fingerprint (no false RULE_CHANGED)', () => {
+    // authored order
+    const authored = [
+      A('update_record', { fields: { zeta: 3, alpha: 1, mid: 2 }, note: 'n', target: 't' }),
+      A('parallel_branch', {
+        branches: [{ key: 'p0', actions: [A('send_webhook', { headers: { b: 2, a: 1 }, url: 'x', method: 'POST' })] }],
+      }),
+    ]
+    // simulate persist→JSONB→read: JSON round-trip + a deliberately different key insertion order at every level
+    const reordered = [
+      A('update_record', { target: 't', note: 'n', fields: { mid: 2, alpha: 1, zeta: 3 } }),
+      A('parallel_branch', {
+        branches: [{ key: 'p0', actions: [A('send_webhook', { method: 'POST', url: 'x', headers: { a: 1, b: 2 } })] }],
+      }),
+    ]
+    const roundTripped = JSON.parse(JSON.stringify(reordered))
+    expect(deriveRuleActionSetFingerprint(roundTripped).hash).toBe(deriveRuleActionSetFingerprint(authored).hash)
+  })
 })

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -56,7 +56,8 @@ vi.mock('../../src/db/db', () => {
 })
 
 import { AutomationLogService } from '../../src/multitable/automation-log-service'
-import { AutomationRuleValidationError, AutomationService } from '../../src/multitable/automation-service'
+import { AutomationRuleValidationError, AutomationService, toExecutorRule } from '../../src/multitable/automation-service'
+import { deriveRuleActionSetFingerprint } from '../../src/multitable/automation-rule-fingerprint'
 import { AutomationJobService } from '../../src/multitable/automation-job-service'
 import { normalizeWorkflowJob } from '../../src/multitable/workflow-job-contract'
 
@@ -4143,6 +4144,38 @@ describe('AutomationService — retryExecution (A5)', () => {
     expect(await service.retryExecution('axe_orig', 'admin1')).toMatchObject({ status: 409, code: 'RULE_MISSING_OR_DISABLED' })
     getRule.mockResolvedValue(currentRule({ enabled: false }))
     expect(await service.retryExecution('axe_orig', 'admin1')).toMatchObject({ status: 409, code: 'RULE_MISSING_OR_DISABLED' })
+  })
+
+  // #4196 §4 — the RAW-config rule-change guard.
+  it('409 RULE_CHANGED when the current rule fingerprint differs from the one captured at the original run', async () => {
+    const getRule = vi.spyOn(service, 'getRule').mockResolvedValue(currentRule({ action_config: { url: 'https://x', token: 'ROTATED' } }))
+    const execSpy = vi.spyOn(service, 'executeRule')
+    // the original captured a fingerprint that will NOT match the (changed) current rule
+    vi.spyOn(service.logs, 'getById').mockResolvedValue(storedExecution({ ruleActionFingerprint: 'stale-fingerprint-hash' }))
+    const r = await service.retryExecution('axe_orig', 'admin1')
+    expect(r).toMatchObject({ status: 409, code: 'RULE_CHANGED' })
+    expect(execSpy).not.toHaveBeenCalled() // refused BEFORE running against mismatched action_keys
+    expect(getRule).toHaveBeenCalled()
+  })
+
+  it('retries when the current rule fingerprint MATCHES the captured one (unchanged rule)', async () => {
+    const rule = currentRule()
+    const matchingFp = deriveRuleActionSetFingerprint(toExecutorRule(rule as never).actions).hash
+    vi.spyOn(service, 'getRule').mockResolvedValue(rule)
+    vi.spyOn(service.logs, 'getById').mockResolvedValue(storedExecution({ ruleActionFingerprint: matchingFp }))
+    const execSpy = vi.spyOn(service, 'executeRule').mockResolvedValue(storedExecution({ id: 'axe_new', status: 'success' }))
+    const r = await service.retryExecution('axe_orig', 'admin1')
+    expect('execution' in r).toBe(true)
+    expect(execSpy).toHaveBeenCalled()
+  })
+
+  it('rollout-safe: a pre-column execution (no captured fingerprint) is NOT guarded — retry proceeds', async () => {
+    vi.spyOn(service, 'getRule').mockResolvedValue(currentRule())
+    vi.spyOn(service.logs, 'getById').mockResolvedValue(storedExecution({ ruleActionFingerprint: undefined }))
+    const execSpy = vi.spyOn(service, 'executeRule').mockResolvedValue(storedExecution({ id: 'axe_new', status: 'success' }))
+    const r = await service.retryExecution('axe_orig', 'admin1')
+    expect('execution' in r).toBe(true) // non-regressing for executions that predate the column
+    expect(execSpy).toHaveBeenCalled()
   })
 
   it('failed retry delegates to executeRule with stored trigger_event + retry provenance', async () => {


### PR DESCRIPTION
## What
The retry-side of #4196 §4: refuse to retry a failed execution whose **rule changed** since the original run.

Stacked on #4420 (the §2.1 `deriveRuleActionSetFingerprint` module). Base is #4420's head so this diff shows only the retry slice; retarget to `main` once #4420 merges.

## Why
A config-only edit — same action **types**, but a rotated webhook URL / token / write-target — silently rebinds each action's identity. Replaying the OLD execution against the NEW config could **double-apply** or **apply to the wrong target**. The type-only `computeActionFingerprint` the suspend/resume guards use is blind to config-only edits; this guard is not, because it compares the RAW-config §2.1 fingerprint (the same injective identity the Class-A applied-ledger locks for `action_key`).

## How
- **executor** — capture `ruleActionFingerprint = deriveRuleActionSetFingerprint(rule.actions).hash` at execution build (RAW config, **before** redaction — a values-free sha256, safe to persist un-redacted; NOT re-derived from the redacted `ruleSnapshot`, which would diverge from the raw claim identity).
- **log-service** — persist (`$16`) + hydrate the `rule_action_fingerprint` column; `null` for pre-column executions.
- **service.retryExecution** — `409 RULE_CHANGED` when the captured fingerprint ≠ the current rule's fingerprint.
  **Rollout-safe:** the guard is *skipped* (not fail-closed) when the stored fingerprint is `null`, so every pre-column execution stays retryable (non-regressing).
- **toExecutorRule** exported for test parity (the guard fingerprints `toExecutorRule(rule).actions`).

## Verification
- `tsc --noEmit` clean; `automation-v1.test.ts` **224/224** green.
- 3 new cases in `retryExecution (A5)`: mismatch → `409` + `executeRule` **not** called; match → retries; no-fingerprint → retries (rollout-safe).
- **Mutation-proven load-bearing:** flipping `!==`→`===` fails exactly 2 targeted assertions; dropping the `!= null` rollout clause fails 6 pre-column retries (fail-closed regression). Both restored.

## Flag / safety
Flag-neutral, no behavior change for rules that did not change. The migration column landed in the foundation commit. **Not for self-merge** — awaits the opus adversarial-review gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)