### PR TITLE
feat(directory): B5-a — org_directory_routing_policy schema (explicit (org,purpose) policy store)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -174,6 +174,11 @@ jobs:
       - name: B4 department-bindings CI wiring contract
         run: node --test scripts/ops/b4-department-bindings-ci-wiring.test.mjs
 
+      # B5-a CI two-point wiring contract (no DB): the routing-policy schema suite must stay wired
+      # into BOTH vitest.config.ts (exclude) AND plugin-tests.yml (directory real-DB step).
+      - name: B5-a routing-policy CI wiring contract
+        run: node --test scripts/ops/b5a-routing-policy-ci-wiring.test.mjs
+
       # The production monitor invokes the same state helper covered here.
       # Keep this in the required 18/20 matrix so HTTP classification, silence
       # barriers, and alert/recovery streak semantics cannot drift silently.
@@ -647,6 +652,7 @@ jobs:
             tests/integration/local-directory-org-cycle-detection.db.test.ts \
             tests/integration/directory-local-integration-reactivation.db.test.ts \
             tests/integration/directory-department-bindings.db.test.ts \
+            tests/integration/org-directory-routing-policy-schema.db.test.ts \
             tests/integration/directory-normalized-manager.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             tests/integration/attendance-notification-redelivery.db.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260717110000_create_org_directory_routing_policy.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260717110000_create_org_directory_routing_policy.ts
@@ -1,0 +1,85 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * Canonical Org MVP — B5-a (routing policy schema), #4215 §6 + B5/B6 design lock
+ * (`canonical-org-b5-b6-routing-core-design-lock-20260717.md`, Lock 1).
+ *
+ * `org_directory_routing_policy` stores the owner-ruled explicit `(org, purpose)` routing policy:
+ * when an org has MORE THAN ONE directory integration (possible since B1 introduced
+ * `provider='local'` alongside DingTalk), the canonical source for each purpose is chosen by THIS
+ * stored policy — never by array position / "latest active integration wins" guessing (§6 owner
+ * ruling, Wave 3 2026-07-12). A missing policy row means "legacy behavior, byte-identical"
+ * (design-lock Q1 recommendation: staged opt-in — zero behavior change until a policy is set);
+ * a PRESENT policy is authoritative and fail-closed (resolver work is B5-b, not this migration).
+ *
+ * Schema locks carried over from B4's rigor:
+ *   - `UNIQUE (org_id, purpose)` — one policy per purpose per org.
+ *   - `purpose` CHECK against the §6 CLOSED set (extending the set = a new migration, on purpose).
+ *   - CROSS-ORG POLICY IS FK-IMPOSSIBLE: `(canonical_integration_id, org_id)` →
+ *     `directory_integrations (id, org_id)` (reuses B4's `uq_directory_integrations_id_org` parent
+ *     UNIQUE), and the same chain for a non-NULL fallback. A policy row can never point at another
+ *     org's integration — there is no satisfying org_id. All FK-participating columns are NOT NULL
+ *     except `fallback_integration_id`, whose NULL means "no fallback" (under MATCH SIMPLE a NULL
+ *     fallback simply skips that FK — the correct semantics here, not a bypass: org integrity for
+ *     the row is still carried by the canonical FK on the same org_id column).
+ *   - ON DELETE **RESTRICT** on BOTH FKs (design-lock amendment: the draft said SET NULL for
+ *     fallback, but on a composite FK `SET NULL` nulls ALL referencing columns — including org_id,
+ *     which is NOT NULL — so it would fail confusingly at integration-delete time anyway; PG15's
+ *     column-list `SET NULL (col)` is not available on the supported PG14 floor). RESTRICT is the
+ *     intended posture regardless: deleting an integration a policy still references must be a LOUD
+ *     error that forces an explicit policy edit — a routing policy silently losing its target is
+ *     exactly the mass-misrouting hazard §6 exists to prevent.
+ *   - No `mode` column (design-lock Q3 recommendation): §6's sketch carried `mode`
+ *     (`dingtalk`/`local`), but it is fully derivable from the canonical integration's own
+ *     `provider` — a second copy is redundant state that can drift. Single source of truth wins;
+ *     if the owner rules to keep it, it comes back with a three-column provider FK (B4 pattern).
+ *
+ * `directory_integrations` is created by a zzzz migration, so this MUST also be zzzz-prefixed.
+ * The table is `CREATE TABLE IF NOT EXISTS` (atomic with its inline constraints) — idempotent on
+ * replay. `uq_directory_integrations_id_org` already exists (B4); no parent work is needed here.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS org_directory_routing_policy (
+      id                        uuid        NOT NULL DEFAULT gen_random_uuid(),
+      org_id                    text        NOT NULL,
+      purpose                   text        NOT NULL,
+      canonical_integration_id  uuid        NOT NULL,
+      fallback_integration_id   uuid        NULL,
+      created_at                timestamptz NOT NULL DEFAULT now(),
+      updated_at                timestamptz NOT NULL DEFAULT now(),
+
+      CONSTRAINT org_directory_routing_policy_pkey PRIMARY KEY (id),
+
+      -- one policy per purpose per org
+      CONSTRAINT orp_org_purpose_uniq UNIQUE (org_id, purpose),
+
+      -- §6 closed purpose set — extending it is a deliberate migration, not a free-text write
+      CONSTRAINT orp_purpose_chk CHECK (purpose IN (
+        'approval_routing',
+        'permission_scope',
+        'attendance_expansion',
+        'member_group_projection',
+        'automation_recipient_resolution'
+      )),
+
+      -- same-org chain (B4 pattern): the canonical integration must live in THIS org
+      CONSTRAINT orp_canonical_int_org_fk FOREIGN KEY (canonical_integration_id, org_id)
+        REFERENCES directory_integrations (id, org_id) ON DELETE RESTRICT,
+
+      -- a non-NULL fallback must live in this org too (NULL = no fallback; v1 keeps fallback INERT
+      -- — the resolver never auto-falls-back, design-lock Q2)
+      CONSTRAINT orp_fallback_int_org_fk FOREIGN KEY (fallback_integration_id, org_id)
+        REFERENCES directory_integrations (id, org_id) ON DELETE RESTRICT
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_orp_org ON org_directory_routing_policy (org_id)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS org_directory_routing_policy`.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260717110000_create_org_directory_routing_policy.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260717110000_create_org_directory_routing_policy.ts
@@ -10,7 +10,7 @@ import { sql } from 'kysely'
  * `provider='local'` alongside DingTalk), the canonical source for each purpose is chosen by THIS
  * stored policy — never by array position / "latest active integration wins" guessing (§6 owner
  * ruling, Wave 3 2026-07-12). A missing policy row means "legacy behavior, byte-identical"
- * (design-lock Q1 recommendation: staged opt-in — zero behavior change until a policy is set);
+ * (design-lock Q1 ruling: staged opt-in — zero behavior change until a policy is set);
  * a PRESENT policy is authoritative and fail-closed (resolver work is B5-b, not this migration).
  *
  * Schema locks carried over from B4's rigor:
@@ -30,10 +30,10 @@ import { sql } from 'kysely'
  *     intended posture regardless: deleting an integration a policy still references must be a LOUD
  *     error that forces an explicit policy edit — a routing policy silently losing its target is
  *     exactly the mass-misrouting hazard §6 exists to prevent.
- *   - No `mode` column (design-lock Q3 recommendation): §6's sketch carried `mode`
+ *   - No `mode` column (design-lock Q3 ruling): §6's sketch carried `mode`
  *     (`dingtalk`/`local`), but it is fully derivable from the canonical integration's own
- *     `provider` — a second copy is redundant state that can drift. Single source of truth wins;
- *     if the owner rules to keep it, it comes back with a three-column provider FK (B4 pattern).
+ *     `provider` — a second copy is redundant state that can drift. The integration row remains
+ *     the single source of truth.
  *
  * `directory_integrations` is created by a zzzz migration, so this MUST also be zzzz-prefixed.
  * The table is `CREATE TABLE IF NOT EXISTS` (atomic with its inline constraints) — idempotent on

--- a/packages/core-backend/tests/integration/org-directory-routing-policy-schema.db.test.ts
+++ b/packages/core-backend/tests/integration/org-directory-routing-policy-schema.db.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { getOrCreateLocalIntegration } from '../../src/directory/directory-sync'
+
+/**
+ * Canonical Org MVP — B5-a (routing policy SCHEMA), design lock Lock 1, real DB.
+ *
+ * `org_directory_routing_policy` is the §6 owner-ruled explicit `(org, purpose)` policy store.
+ * This file proves the SCHEMA invariants only (the resolver is B5-b):
+ *
+ *   A. positive control — a same-org policy (canonical = the org's local integration) inserts.
+ *   B. CROSS-ORG POLICY IS FK-IMPOSSIBLE — canonical from another org → 23503 BY the org-chain FK
+ *      name (`orp_canonical_int_org_fk`), for the right reason (not the CHECK / not the UNIQUE).
+ *   C. one policy per (org, purpose) — duplicate → 23505 by `orp_org_purpose_uniq`.
+ *   D. closed purpose set — unknown purpose → 23514 by `orp_purpose_chk`.
+ *   E. RESTRICT posture — deleting an integration a policy references → 23503 (loud, forces an
+ *      explicit policy edit first); after deleting the policy row the delete SUCCEEDS (positive
+ *      control: RESTRICT protects exactly while referenced, not forever).
+ *   F. fallback chain — a cross-org fallback → 23503 by `orp_fallback_int_org_fk`; a NULL fallback
+ *      is fine (NULL = no fallback, not a MATCH SIMPLE bypass: org integrity is still carried by
+ *      the canonical FK on the same org_id column).
+ *   G. schema contract — constraints exist BY NAME pinned to conrelid, and both org FKs are
+ *      TWO-column (id, org_id) — arity asserted so a single-column regression can't fake existence.
+ *
+ * Load-bearing mutations (out-of-band, each reds this file):
+ *   - drop `orp_canonical_int_org_fk`  → B reds (the cross-org policy inserts).
+ *   - drop `orp_org_purpose_uniq`      → C reds (the duplicate inserts).
+ *
+ * Fixture IDs are namespaced with this file's STAMP — integration specs share one Postgres in CI.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+const orgId = (suffix: string): string => `b5a-${STAMP}-${suffix}`
+
+interface PgError extends Error {
+  code?: string
+  constraint?: string
+}
+
+async function reject(fn: () => Promise<unknown>): Promise<PgError | null> {
+  try {
+    await fn()
+    return null
+  } catch (e) {
+    return e as PgError
+  }
+}
+
+async function insertPolicy(input: {
+  org: string
+  purpose?: string
+  canonical: string
+  fallback?: string | null
+}): Promise<{ id: string }> {
+  const r = await query<{ id: string }>(
+    `INSERT INTO org_directory_routing_policy (org_id, purpose, canonical_integration_id, fallback_integration_id)
+     VALUES ($1, $2, $3, $4) RETURNING id`,
+    [input.org, input.purpose ?? 'approval_routing', input.canonical, input.fallback ?? null],
+  )
+  return r.rows[0]
+}
+
+async function dingtalkIntegration(org: string, tag: string): Promise<string> {
+  const r = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config)
+     VALUES ($1, 'dingtalk', $2, 'active', $3, '{}'::jsonb) RETURNING id`,
+    [org, `DT ${tag}`, `corp-${STAMP}-${tag}`],
+  )
+  return r.rows[0].id
+}
+
+describeIfDatabase('Canonical Org MVP — B5-a routing policy schema (real DB)', () => {
+  const seededOrgIds: string[] = []
+
+  afterEach(async () => {
+    for (const org of seededOrgIds.splice(0)) {
+      // policies first (RESTRICT would block the integration delete otherwise)
+      await query(`DELETE FROM org_directory_routing_policy WHERE org_id = $1`, [org])
+      await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [org])
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('A. positive control: a same-org policy inserts (canonical = the org local integration)', async () => {
+    const org = orgId('pos')
+    seededOrgIds.push(org)
+    const local = await getOrCreateLocalIntegration(org)
+    const row = await insertPolicy({ org, canonical: local.id })
+    expect(row.id).toBeTruthy()
+  })
+
+  it('B. cross-org policy is FK-impossible — rejected by the org-chain FK by name', async () => {
+    const orgA = orgId('xo-A')
+    const orgB = orgId('xo-B')
+    seededOrgIds.push(orgA, orgB)
+    await getOrCreateLocalIntegration(orgA)
+    const foreign = await dingtalkIntegration(orgB, 'xb')
+
+    const err = await reject(() => insertPolicy({ org: orgA, canonical: foreign }))
+    expect(err?.code).toBe('23503') // foreign_key_violation — not the CHECK, not the UNIQUE
+    expect(err?.constraint).toBe('orp_canonical_int_org_fk')
+  })
+
+  it('C. one policy per (org, purpose): duplicate rejected by orp_org_purpose_uniq', async () => {
+    const org = orgId('dup')
+    seededOrgIds.push(org)
+    const local = await getOrCreateLocalIntegration(org)
+    const dt = await dingtalkIntegration(org, 'dup')
+    await insertPolicy({ org, canonical: local.id })
+
+    const err = await reject(() => insertPolicy({ org, canonical: dt }))
+    expect(err?.code).toBe('23505')
+    expect(err?.constraint).toBe('orp_org_purpose_uniq')
+  })
+
+  it('D. closed purpose set: an unknown purpose is rejected by orp_purpose_chk', async () => {
+    const org = orgId('chk')
+    seededOrgIds.push(org)
+    const local = await getOrCreateLocalIntegration(org)
+
+    const err = await reject(() => insertPolicy({ org, purpose: 'coffee_routing', canonical: local.id }))
+    expect(err?.code).toBe('23514')
+    expect(err?.constraint).toBe('orp_purpose_chk')
+  })
+
+  it('E. RESTRICT: deleting a policy-referenced integration is a loud 23503; after removing the policy it succeeds', async () => {
+    const org = orgId('restrict')
+    seededOrgIds.push(org)
+    const dt = await dingtalkIntegration(org, 'r')
+    const policy = await insertPolicy({ org, canonical: dt })
+
+    const err = await reject(() => query(`DELETE FROM directory_integrations WHERE id = $1`, [dt]))
+    expect(err?.code).toBe('23503') // policy must be edited first — no silent target loss
+
+    // positive control: drop the policy, then the integration delete succeeds
+    await query(`DELETE FROM org_directory_routing_policy WHERE id = $1`, [policy.id])
+    const gone = await query(`DELETE FROM directory_integrations WHERE id = $1`, [dt])
+    expect(gone.rowCount).toBe(1)
+  })
+
+  it('F. fallback chain: cross-org fallback rejected by name; NULL fallback is fine', async () => {
+    const orgA = orgId('fb-A')
+    const orgB = orgId('fb-B')
+    seededOrgIds.push(orgA, orgB)
+    const localA = await getOrCreateLocalIntegration(orgA)
+    const foreignB = await dingtalkIntegration(orgB, 'fb')
+
+    const err = await reject(() => insertPolicy({ org: orgA, canonical: localA.id, fallback: foreignB }))
+    expect(err?.code).toBe('23503')
+    expect(err?.constraint).toBe('orp_fallback_int_org_fk')
+
+    // NULL fallback (the default) inserts fine — proven implicitly by A, pinned explicitly here
+    const ok = await insertPolicy({ org: orgA, canonical: localA.id, fallback: null })
+    expect(ok.id).toBeTruthy()
+  })
+
+  it('G. schema contract: named constraints exist on THIS table and both org FKs are two-column', async () => {
+    const own = await query<{ conname: string; ncols: number | null }>(
+      `SELECT conname, array_length(conkey, 1) AS ncols FROM pg_constraint
+        WHERE conrelid = 'org_directory_routing_policy'::regclass`,
+    )
+    const byName = new Map(own.rows.map((r) => [r.conname, r.ncols]))
+    expect(byName.has('orp_org_purpose_uniq')).toBe(true)
+    expect(byName.has('orp_purpose_chk')).toBe(true)
+    expect(byName.get('orp_canonical_int_org_fk')).toBe(2) // (canonical_integration_id, org_id)
+    expect(byName.get('orp_fallback_int_org_fk')).toBe(2) // (fallback_integration_id, org_id)
+  })
+})

--- a/packages/core-backend/tests/integration/org-directory-routing-policy-schema.db.test.ts
+++ b/packages/core-backend/tests/integration/org-directory-routing-policy-schema.db.test.ts
@@ -158,15 +158,40 @@ describeIfDatabase('Canonical Org MVP — B5-a routing policy schema (real DB)',
     expect(ok.id).toBeTruthy()
   })
 
-  it('G. schema contract: named constraints exist on THIS table and both org FKs are two-column', async () => {
-    const own = await query<{ conname: string; ncols: number | null }>(
-      `SELECT conname, array_length(conkey, 1) AS ncols FROM pg_constraint
+  it('G. schema contract: named constraints exist, both org FKs are two-column AND both are ON DELETE RESTRICT', async () => {
+    const own = await query<{ conname: string; ncols: number | null; confdeltype: string | null }>(
+      `SELECT conname, array_length(conkey, 1) AS ncols, confdeltype FROM pg_constraint
         WHERE conrelid = 'org_directory_routing_policy'::regclass`,
     )
-    const byName = new Map(own.rows.map((r) => [r.conname, r.ncols]))
+    const byName = new Map(own.rows.map((r) => [r.conname, r]))
     expect(byName.has('orp_org_purpose_uniq')).toBe(true)
     expect(byName.has('orp_purpose_chk')).toBe(true)
-    expect(byName.get('orp_canonical_int_org_fk')).toBe(2) // (canonical_integration_id, org_id)
-    expect(byName.get('orp_fallback_int_org_fk')).toBe(2) // (fallback_integration_id, org_id)
+    expect(byName.get('orp_canonical_int_org_fk')?.ncols).toBe(2) // (canonical_integration_id, org_id)
+    expect(byName.get('orp_fallback_int_org_fk')?.ncols).toBe(2) // (fallback_integration_id, org_id)
+    // B5-a gate P2: the DELETE ACTION is load-bearing — a CASCADE here would SILENTLY delete the
+    // policy row when its referenced integration is deleted (the exact §6 mass-misrouting hazard),
+    // and a SET NULL on the composite FK would null org_id. Pin 'r' (RESTRICT) for BOTH FKs so any
+    // delete-action regression (CASCADE 'c', SET NULL 'n', NO ACTION 'a') reds this line.
+    expect(byName.get('orp_canonical_int_org_fk')?.confdeltype).toBe('r')
+    expect(byName.get('orp_fallback_int_org_fk')?.confdeltype).toBe('r')
+  })
+
+  it('H. RESTRICT is behavioral on the FALLBACK leg too: deleting a fallback-referenced integration is a loud 23503, never a silent policy-row loss', async () => {
+    const org = orgId('fb-restrict')
+    seededOrgIds.push(org)
+    const local = await getOrCreateLocalIntegration(org)
+    const fb = await dingtalkIntegration(org, 'fbr')
+    await insertPolicy({ org, canonical: local.id, fallback: fb })
+
+    const err = await reject(() => query(`DELETE FROM directory_integrations WHERE id = $1`, [fb]))
+    expect(err?.code).toBe('23503')
+    expect(err?.constraint).toBe('orp_fallback_int_org_fk')
+
+    // the policy row survived INTACT (a CASCADE would have silently removed it)
+    const rows = await query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM org_directory_routing_policy WHERE org_id = $1`,
+      [org],
+    )
+    expect(rows.rows[0].n).toBe(1)
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -135,6 +135,13 @@ export default defineConfig({
       // the no-DB job cannot skip-green it, and wired as a WHOLE FILE into the directory real-DB step
       // in plugin-tests.yml (both points asserted by b4-department-bindings-ci-wiring.test.mjs).
       'tests/integration/directory-department-bindings.db.test.ts',
+      // Canonical Org MVP B5-a (design lock Lock 1): org_directory_routing_policy schema — the
+      // explicit (org,purpose) policy store; cross-org policy FK-impossible, closed purpose set,
+      // RESTRICT posture. Real-DB constraint proofs by name — meaningless without a DB.
+      // DATABASE_URL-gated; excluded here so the no-DB job cannot skip-green it, and wired as a
+      // WHOLE FILE into the directory real-DB step in plugin-tests.yml (both points asserted by
+      // b5a-routing-policy-ci-wiring.test.mjs so neither can silently drop).
+      'tests/integration/org-directory-routing-policy-schema.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
       // resolution against real Postgres — normalized `is_manager` relation for a local integration,
       // the DingTalk `leader_in_dept` regression pin (load-bearing compat leg + is_manager=0 positive

--- a/scripts/ops/b5a-routing-policy-ci-wiring.test.mjs
+++ b/scripts/ops/b5a-routing-policy-ci-wiring.test.mjs
@@ -1,0 +1,24 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// B5-a CI two-point wiring contract. The routing-policy schema suite proves the (org,purpose)
+// policy store's DB invariants (cross-org FK-impossible, closed purpose set, RESTRICT) against real
+// Postgres — meaningless without a DB. It needs BOTH (1) the vitest.config.ts exclude (so the no-DB
+// job cannot skip-green it) AND (2) the plugin-tests.yml directory real-DB whole-file step. Removing
+// either point silently disables the proof while CI stays green. Runs in the gating no-DB test job.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/org-directory-routing-policy-schema.db.test.ts'
+
+test('vitest.config.ts excludes the B5-a routing-policy suite from the no-DB job', () => {
+  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+})
+
+test('plugin-tests.yml runs the B5-a routing-policy suite as a whole file in the directory real-DB step', () => {
+  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  assert.match(wf, new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${FILE}`)
+})


### PR DESCRIPTION
## B5-a — explicit `(org, purpose)` routing-policy schema

Introduces `org_directory_routing_policy` with the owner-locked invariants:

- one policy per `(org_id, purpose)`;
- closed purpose set;
- canonical and optional fallback integrations are constrained to the same org by composite FKs;
- both integration FKs use `ON DELETE RESTRICT` so policy targets cannot disappear silently;
- no redundant `mode` column; the integration provider remains the source of truth;
- no-policy behavior remains legacy opt-in posture for B5-b.

### Landing-window verification at `4fc7ba742`

- rebased onto post-#4425 `main` with CI-list union intact;
- fresh PostgreSQL migration + second replay: pass;
- real-DB schema suite: 9/9;
- CI wiring guard: 2/2;
- backend typecheck: pass;
- mutation 1: drop canonical same-org FK → cross-org/right-reason tests red;
- mutation 2: change fallback FK to CASCADE → FK action + behavioral fallback-RESTRICT tests red;
- mutation 3: drop `(org,purpose)` unique constraint → duplicate/schema-contract tests red.

The only new landing-window edit is comment truthfulness (`Q1/Q3 recommendation` → already-ratified owner rulings); production DDL is unchanged from the reviewed B5-a patch.

**UNARMED until required CI finishes on this exact head.**
