### PR TITLE
feat(directory): B5-b — routing-policy resolver (policy-authoritative, fail-closed, legacy byte-identical)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -184,6 +184,10 @@ jobs:
       - name: B5-b routing-resolver CI wiring contract
         run: node --test scripts/ops/b5b-routing-resolver-ci-wiring.test.mjs
 
+      # B5-b P1 fail-close CI two-point wiring contract (no DB).
+      - name: B5-b fail-close CI wiring contract
+        run: node --test scripts/ops/b5b-failclose-ci-wiring.test.mjs
+
       # The production monitor invokes the same state helper covered here.
       # Keep this in the required 18/20 matrix so HTTP classification, silence
       # barriers, and alert/recovery streak semantics cannot drift silently.
@@ -617,6 +621,7 @@ jobs:
             tests/integration/approval-p1c-field-permissions.api.test.ts \
             tests/integration/approval-wp-add-reduce-sign.api.test.ts \
             tests/integration/approval-direct-manager.api.test.ts \
+            tests/integration/approval-routing-policy-failclose.api.test.ts \
             tests/integration/approval-postgate-acceptance.api.test.ts \
             tests/integration/dept-head-sync-plumbing.test.ts \
             tests/integration/approval-manager-chain.db.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -179,6 +179,11 @@ jobs:
       - name: B5-a routing-policy CI wiring contract
         run: node --test scripts/ops/b5a-routing-policy-ci-wiring.test.mjs
 
+      # B5-b CI two-point wiring contract (no DB): the routing-policy RESOLVER suite must stay wired
+      # into BOTH vitest.config.ts (exclude) AND plugin-tests.yml (directory real-DB step).
+      - name: B5-b routing-resolver CI wiring contract
+        run: node --test scripts/ops/b5b-routing-resolver-ci-wiring.test.mjs
+
       # The production monitor invokes the same state helper covered here.
       # Keep this in the required 18/20 matrix so HTTP classification, silence
       # barriers, and alert/recovery streak semantics cannot drift silently.
@@ -653,6 +658,7 @@ jobs:
             tests/integration/directory-local-integration-reactivation.db.test.ts \
             tests/integration/directory-department-bindings.db.test.ts \
             tests/integration/org-directory-routing-policy-schema.db.test.ts \
+            tests/integration/org-directory-routing-policy-resolver.db.test.ts \
             tests/integration/directory-normalized-manager.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             tests/integration/attendance-notification-redelivery.db.test.ts \

--- a/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
+++ b/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
@@ -186,14 +186,17 @@ export class ApprovalRoutingPolicyError extends Error {
  * `query` is injected (defaults to the shared pool) so the unit path can drive it
  * against an in-memory fixture without a database.
  *
- * `options.orgId` (S7 §3.3, optional / backward compatible): when supplied AND no
- * `approval_routing` policy governs, the requester-account pick is anchored to
- * `directory_integrations.org_id` BEFORE the `ORDER BY ... LIMIT 1` tie-break, so a
- * local user linked into two orgs cannot have the wrong org's account selected.
- * Callers that omit `orgId` retain today's unscoped (most-recently-updated) pick —
- * kernel `ApprovalProductService` callers included. Attendance-facing paths MUST
- * pass `orgId`. When an `approval_routing` policy DOES govern (B5-b), the policy's
- * canonical integration is authoritative over the org-anchor/legacy pick.
+ * `options.orgId` (S7 §3.3, optional / backward compatible) is a TENANT BOUNDARY:
+ * when supplied, every step of resolution is confined to that org — including the
+ * B5-b `approval_routing` policy probe (foreign-org policies must neither steer the
+ * pick nor trigger multi-org ambiguity). Within that org:
+ *   - a same-org policy is AUTHORITATIVE (canonical-integration pick);
+ *   - no same-org policy → org-anchored requester SELECT (`directory_integrations.org_id`
+ *     before ORDER BY/LIMIT 1) so a local user linked into two orgs cannot have the
+ *     wrong org's account selected.
+ * Callers that omit `orgId` retain the unscoped kernel path (B5-b Q4 across all
+ * linked orgs) — kernel `ApprovalProductService` callers included. Attendance-facing
+ * paths MUST pass `orgId`.
  */
 export async function resolveApprovalRequesterOrgRelations(
   localUserId: string,
@@ -205,7 +208,8 @@ export async function resolveApprovalRequesterOrgRelations(
 
   // Optional org anchor (S7 §3.3). Trim + non-empty only — an empty string must NOT
   // accidentally join against `org_id = ''` and force every row out of scope.
-  // Applied only on the no-policy path below (policy is authoritative when present).
+  // When present this is a tenant boundary: it SCOPES the B5-b policy probe first,
+  // then (if no same-org policy) the requester-account pick.
   const orgId =
     typeof options.orgId === 'string' && options.orgId.trim().length > 0
       ? options.orgId.trim()
@@ -214,11 +218,16 @@ export async function resolveApprovalRequesterOrgRelations(
   // 0) B5-b (design lock Lock 2 + Q4): explicit `(org, purpose='approval_routing')` routing policy.
   //    Since B1 an org can hold MULTIPLE directory integrations (DingTalk + local), and the legacy
   //    requester pick below guesses among them by `ORDER BY a.updated_at DESC` — the exact
-  //    "latest integration wins" behavior the §6 owner ruling forbids. The probe finds any policy
-  //    governing an org this user is linked in:
-  //      - NO policy row  → the LEGACY / S7-org-anchor path below runs (Q1: zero behavior change
-  //        until a policy is explicitly set — staged opt-in). With `orgId`, the S7 join applies;
-  //        without it, the pick is byte-identical to pre-B5/pre-S7 unscoped.
+  //    "latest integration wins" behavior the §6 owner ruling forbids.
+  //
+  //    TENANT BOUNDARY: when `orgId` is set, the probe is restricted to
+  //    `p.org_id = $2` for that exact org. A foreign-org policy is invisible here —
+  //    it must neither select a canonical integration nor inflate multi-org ambiguity.
+  //
+  //    When `orgId` is OMITTED (kernel path), the probe considers every org the user
+  //    is linked in (B5-b Q4, unchanged):
+  //      - NO policy row  → LEGACY unscoped pick below (Q1: zero behavior change until a
+  //        policy is explicitly set — staged opt-in).
   //      - ONE policy     → the policy is AUTHORITATIVE: the requester pick is restricted to the
   //        canonical integration. A policy whose canonical target is missing or not 'active' is a
   //        CONFIG error → fail-closed typed throw (operator must fix the policy; silently falling
@@ -229,8 +238,31 @@ export async function resolveApprovalRequesterOrgRelations(
   //        fail-closed typed throw (multi-org users need explicit resolution, Q4). A user linked in
   //        one policy-governed org AND one policy-less org follows the single governed policy —
   //        deterministic, never a guess.
+  //
+  //    When `orgId` IS set:
+  //      - NO same-org policy → fall through to the S7 org-anchored requester SELECT.
+  //      - ONE same-org policy → AUTHORITATIVE canonical-integration pick (within the tenant).
+  //      - (multi-org ambiguity cannot fire: foreign policies are filtered out by p.org_id = $2.)
   const policyRows = await query<RoutingPolicyProbeRow>(
-    `SELECT DISTINCT p.org_id                            AS org_id,
+    orgId
+      ? `SELECT DISTINCT p.org_id                            AS org_id,
+            p.canonical_integration_id::text             AS canonical_integration_id,
+            ci.status                                    AS canonical_status
+       FROM directory_account_links l
+       JOIN directory_accounts a
+         ON a.id = l.directory_account_id
+        AND a.is_active = true
+       JOIN directory_integrations ai
+         ON ai.id = a.integration_id
+       JOIN org_directory_routing_policy p
+         ON p.org_id = ai.org_id
+        AND p.purpose = 'approval_routing'
+       LEFT JOIN directory_integrations ci
+         ON ci.id = p.canonical_integration_id
+      WHERE l.local_user_id = $1
+        AND l.link_status = 'linked'
+        AND p.org_id = $2`
+      : `SELECT DISTINCT p.org_id                            AS org_id,
             p.canonical_integration_id::text             AS canonical_integration_id,
             ci.status                                    AS canonical_status
        FROM directory_account_links l
@@ -246,12 +278,13 @@ export async function resolveApprovalRequesterOrgRelations(
          ON ci.id = p.canonical_integration_id
       WHERE l.local_user_id = $1
         AND l.link_status = 'linked'`,
-    [userId],
+    orgId ? [userId, orgId] : [userId],
   )
   let canonicalIntegrationId: string | null = null
   if (policyRows.rows.length > 0) {
     const orgs = new Set(policyRows.rows.map((r) => r.org_id))
     if (orgs.size > 1) {
+      // Only reachable on the no-orgId (kernel) path: org-scoped probe binds p.org_id = $2.
       throw new ApprovalRoutingPolicyError(
         `approval routing is policy-managed in ${orgs.size} orgs this user is linked in; multi-org routing requires explicit resolution`,
       )
@@ -266,12 +299,12 @@ export async function resolveApprovalRequesterOrgRelations(
   }
 
   // 1) Requester's linked directory account + its primary department's raw.
-  //    Precedence (preserve both B5-b and S7 §3.3):
-  //      a) POLICY-SCOPED when a policy governs — restricted to the canonical integration
-  //         (identical projection, so every consumer below is source-agnostic).
-  //      b) ORG-ANCHORED when no policy and `orgId` is set — join directory_integrations so
-  //         ORDER BY/LIMIT 1 only competes among accounts inside the calling org (S7).
-  //      c) LEGACY unscoped otherwise — byte-identical pre-B5/pre-S7 pick.
+  //    Precedence (tenant-scoped policy first, then S7 org anchor, then legacy):
+  //      a) POLICY-SCOPED when a (tenant-visible) policy governs — restricted to the
+  //         canonical integration (identical projection; consumers below are source-agnostic).
+  //      b) ORG-ANCHORED when no same-org/no-orgId policy and `orgId` is set — join
+  //         directory_integrations so ORDER BY/LIMIT 1 only competes inside the calling org (S7).
+  //      c) LEGACY unscoped otherwise — byte-identical pre-B5/pre-S7 pick (no-orgId + no policy).
   const requesterRows = canonicalIntegrationId
     ? await query<RequesterDirectoryRow>(
         `SELECT a.integration_id::text       AS integration_id,

--- a/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
+++ b/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
@@ -157,6 +157,27 @@ interface RequesterDirectoryRow {
   primary_department_name: string | null
 }
 
+interface RoutingPolicyProbeRow {
+  org_id: string
+  canonical_integration_id: string
+  canonical_status: string | null
+}
+
+/**
+ * B5-b fail-closed CONFIG error (design lock Lock 2): thrown when an `approval_routing` policy
+ * exists but cannot be honored — its canonical integration is missing/not-active, or the requester
+ * is linked in MORE THAN ONE policy-governed org. Deliberately a distinct type so the create-time
+ * caller can surface "routing policy misconfigured — contact an administrator" instead of the
+ * generic transient "please retry": retrying never fixes a broken policy. NOT thrown for data
+ * absence (a requester simply missing from the canonical directory resolves to `{}`).
+ */
+export class ApprovalRoutingPolicyError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ApprovalRoutingPolicyError'
+  }
+}
+
 /**
  * Read-only resolution of the requester's direct manager + department head as
  * LOCAL user ids. Returns `{}` when the requester has no linked directory account
@@ -165,12 +186,14 @@ interface RequesterDirectoryRow {
  * `query` is injected (defaults to the shared pool) so the unit path can drive it
  * against an in-memory fixture without a database.
  *
- * `options.orgId` (S7 §3.3, optional / backward compatible): when supplied, the
- * requester-account pick is anchored to `directory_integrations.org_id` BEFORE the
- * `ORDER BY ... LIMIT 1` tie-break, so a local user linked into two orgs cannot have
- * the wrong org's account selected. Callers that omit `orgId` retain today's unscoped
- * (most-recently-updated) pick — kernel `ApprovalProductService` callers included.
- * Attendance-facing paths MUST pass `orgId`.
+ * `options.orgId` (S7 §3.3, optional / backward compatible): when supplied AND no
+ * `approval_routing` policy governs, the requester-account pick is anchored to
+ * `directory_integrations.org_id` BEFORE the `ORDER BY ... LIMIT 1` tie-break, so a
+ * local user linked into two orgs cannot have the wrong org's account selected.
+ * Callers that omit `orgId` retain today's unscoped (most-recently-updated) pick —
+ * kernel `ApprovalProductService` callers included. Attendance-facing paths MUST
+ * pass `orgId`. When an `approval_routing` policy DOES govern (B5-b), the policy's
+ * canonical integration is authoritative over the org-anchor/legacy pick.
  */
 export async function resolveApprovalRequesterOrgRelations(
   localUserId: string,
@@ -182,17 +205,102 @@ export async function resolveApprovalRequesterOrgRelations(
 
   // Optional org anchor (S7 §3.3). Trim + non-empty only — an empty string must NOT
   // accidentally join against `org_id = ''` and force every row out of scope.
+  // Applied only on the no-policy path below (policy is authoritative when present).
   const orgId =
     typeof options.orgId === 'string' && options.orgId.trim().length > 0
       ? options.orgId.trim()
       : null
 
+  // 0) B5-b (design lock Lock 2 + Q4): explicit `(org, purpose='approval_routing')` routing policy.
+  //    Since B1 an org can hold MULTIPLE directory integrations (DingTalk + local), and the legacy
+  //    requester pick below guesses among them by `ORDER BY a.updated_at DESC` — the exact
+  //    "latest integration wins" behavior the §6 owner ruling forbids. The probe finds any policy
+  //    governing an org this user is linked in:
+  //      - NO policy row  → the LEGACY / S7-org-anchor path below runs (Q1: zero behavior change
+  //        until a policy is explicitly set — staged opt-in). With `orgId`, the S7 join applies;
+  //        without it, the pick is byte-identical to pre-B5/pre-S7 unscoped.
+  //      - ONE policy     → the policy is AUTHORITATIVE: the requester pick is restricted to the
+  //        canonical integration. A policy whose canonical target is missing or not 'active' is a
+  //        CONFIG error → fail-closed typed throw (operator must fix the policy; silently falling
+  //        back to guessing would defeat the policy's purpose). A requester with no active account
+  //        in the canonical integration is DATA absence, not a config error → `{}` (same semantics
+  //        as "no linked directory account", e.g. a not-yet-synced employee).
+  //      - POLICIES IN >1 ORG the user is linked in → ambiguity is real and policy-managed →
+  //        fail-closed typed throw (multi-org users need explicit resolution, Q4). A user linked in
+  //        one policy-governed org AND one policy-less org follows the single governed policy —
+  //        deterministic, never a guess.
+  const policyRows = await query<RoutingPolicyProbeRow>(
+    `SELECT DISTINCT p.org_id                            AS org_id,
+            p.canonical_integration_id::text             AS canonical_integration_id,
+            ci.status                                    AS canonical_status
+       FROM directory_account_links l
+       JOIN directory_accounts a
+         ON a.id = l.directory_account_id
+        AND a.is_active = true
+       JOIN directory_integrations ai
+         ON ai.id = a.integration_id
+       JOIN org_directory_routing_policy p
+         ON p.org_id = ai.org_id
+        AND p.purpose = 'approval_routing'
+       LEFT JOIN directory_integrations ci
+         ON ci.id = p.canonical_integration_id
+      WHERE l.local_user_id = $1
+        AND l.link_status = 'linked'`,
+    [userId],
+  )
+  let canonicalIntegrationId: string | null = null
+  if (policyRows.rows.length > 0) {
+    const orgs = new Set(policyRows.rows.map((r) => r.org_id))
+    if (orgs.size > 1) {
+      throw new ApprovalRoutingPolicyError(
+        `approval routing is policy-managed in ${orgs.size} orgs this user is linked in; multi-org routing requires explicit resolution`,
+      )
+    }
+    const policy = policyRows.rows[0]
+    if (policy.canonical_status !== 'active') {
+      throw new ApprovalRoutingPolicyError(
+        `the approval_routing policy for org "${policy.org_id}" points at a ${policy.canonical_status === null ? 'missing' : `'${policy.canonical_status}'`} integration; fix the routing policy`,
+      )
+    }
+    canonicalIntegrationId = policy.canonical_integration_id
+  }
+
   // 1) Requester's linked directory account + its primary department's raw.
-  // When `orgId` is set, join `directory_integrations` so the ORDER BY/LIMIT 1 only
-  // ever competes among accounts already inside the calling org.
-  const requesterRows = await query<RequesterDirectoryRow>(
-    orgId
-      ? `SELECT a.integration_id::text       AS integration_id,
+  //    Precedence (preserve both B5-b and S7 §3.3):
+  //      a) POLICY-SCOPED when a policy governs — restricted to the canonical integration
+  //         (identical projection, so every consumer below is source-agnostic).
+  //      b) ORG-ANCHORED when no policy and `orgId` is set — join directory_integrations so
+  //         ORDER BY/LIMIT 1 only competes among accounts inside the calling org (S7).
+  //      c) LEGACY unscoped otherwise — byte-identical pre-B5/pre-S7 pick.
+  const requesterRows = canonicalIntegrationId
+    ? await query<RequesterDirectoryRow>(
+        `SELECT a.integration_id::text       AS integration_id,
+            a.id::text                   AS account_id,
+            a.external_user_id           AS external_user_id,
+            a.raw                        AS raw,
+            a.title                      AS title,
+            d.external_department_id     AS primary_external_department_id,
+            d.raw                        AS primary_department_raw,
+            d.name                       AS primary_department_name
+       FROM directory_account_links l
+       JOIN directory_accounts a
+         ON a.id = l.directory_account_id
+        AND a.is_active = true
+        AND a.integration_id = $2::uuid
+       LEFT JOIN directory_account_departments ad
+         ON ad.directory_account_id = a.id
+        AND ad.is_primary = true
+       LEFT JOIN directory_departments d
+         ON d.id = ad.directory_department_id
+      WHERE l.local_user_id = $1
+        AND l.link_status = 'linked'
+      ORDER BY a.updated_at DESC, a.id ASC
+      LIMIT 1`,
+        [userId, canonicalIntegrationId],
+      )
+    : orgId
+      ? await query<RequesterDirectoryRow>(
+          `SELECT a.integration_id::text       AS integration_id,
                 a.id::text                   AS account_id,
                 a.external_user_id           AS external_user_id,
                 a.raw                        AS raw,
@@ -215,30 +323,33 @@ export async function resolveApprovalRequesterOrgRelations(
           WHERE l.local_user_id = $1
             AND l.link_status = 'linked'
           ORDER BY a.updated_at DESC, a.id ASC
-          LIMIT 1`
-      : `SELECT a.integration_id::text       AS integration_id,
-                a.id::text                   AS account_id,
-                a.external_user_id           AS external_user_id,
-                a.raw                        AS raw,
-                a.title                      AS title,
-                d.external_department_id     AS primary_external_department_id,
-                d.raw                        AS primary_department_raw,
-                d.name                       AS primary_department_name
-           FROM directory_account_links l
-           JOIN directory_accounts a
-             ON a.id = l.directory_account_id
-            AND a.is_active = true
-           LEFT JOIN directory_account_departments ad
-             ON ad.directory_account_id = a.id
-            AND ad.is_primary = true
-           LEFT JOIN directory_departments d
-             ON d.id = ad.directory_department_id
-          WHERE l.local_user_id = $1
-            AND l.link_status = 'linked'
-          ORDER BY a.updated_at DESC, a.id ASC
           LIMIT 1`,
-    orgId ? [userId, orgId] : [userId],
-  )
+          [userId, orgId],
+        )
+      : await query<RequesterDirectoryRow>(
+          `SELECT a.integration_id::text       AS integration_id,
+            a.id::text                   AS account_id,
+            a.external_user_id           AS external_user_id,
+            a.raw                        AS raw,
+            a.title                      AS title,
+            d.external_department_id     AS primary_external_department_id,
+            d.raw                        AS primary_department_raw,
+            d.name                       AS primary_department_name
+       FROM directory_account_links l
+       JOIN directory_accounts a
+         ON a.id = l.directory_account_id
+        AND a.is_active = true
+       LEFT JOIN directory_account_departments ad
+         ON ad.directory_account_id = a.id
+        AND ad.is_primary = true
+       LEFT JOIN directory_departments d
+         ON d.id = ad.directory_department_id
+      WHERE l.local_user_id = $1
+        AND l.link_status = 'linked'
+      ORDER BY a.updated_at DESC, a.id ASC
+      LIMIT 1`,
+          [userId],
+        )
   const requester = requesterRows.rows[0]
   if (!requester) return {}
 

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -56,7 +56,7 @@ import {
   formulaReferencesRequesterAttribute,
   parseApprovalConditionFormula,
 } from './ApprovalConditionFormula'
-import { resolveApprovalRequesterOrgRelations, MAX_MANAGER_CHAIN_LEVELS, type ApprovalRequesterOrgRelations } from './ApprovalDirectoryOrg'
+import { resolveApprovalRequesterOrgRelations, ApprovalRoutingPolicyError, MAX_MANAGER_CHAIN_LEVELS, type ApprovalRequesterOrgRelations } from './ApprovalDirectoryOrg'
 import { resolveApprovalRequesterRoleIds } from './ApprovalRequesterRoles'
 import { fetchCuratedApprovalRoleIds } from './approval-directory'
 import { resolveActiveDelegationMap } from './ApprovalDelegations'
@@ -3616,12 +3616,20 @@ export class ApprovalProductService {
     const needsManagerChain = runtimeGraphUsesManagerChain(runtimeGraph)
     let orgRelations: ApprovalRequesterOrgRelations = {}
     let orgReadFailed = false
+    // B5-b: a routing-POLICY config error (policy points at a missing/inactive integration, or the
+    // requester is linked in >1 policy-governed org) is persistent, not transient — "please retry"
+    // is actively misleading for it. Track it separately so the wedge guards below surface a
+    // distinct, actionable code. Same guard POSITIONS as before (fires only when the graph actually
+    // routes on the attribute) — the blast radius of a broken policy stays scoped to templates that
+    // consume org data, exactly like today's transient-failure semantics.
+    let orgPolicyMisconfigured = false
     try {
       orgRelations = await resolveApprovalRequesterOrgRelations(effectiveRequester.userId, pool.query.bind(pool), {
         includeManagerChain: needsManagerChain,
       })
     } catch (error) {
       orgReadFailed = true
+      orgPolicyMisconfigured = error instanceof ApprovalRoutingPolicyError
       metricsLogger.warn(
         `Failed to resolve requester org relations for ${effectiveRequester.userId}: ${
           error instanceof Error ? error.message : 'unknown error'
@@ -3660,6 +3668,14 @@ export class ApprovalProductService {
     // Only fires when the graph actually routes on requester.department (manager-chain / dept-head and
     // non-department templates are unaffected; genuine absence on those follows their emptyAssigneePolicy).
     if (!orgRelations.primaryDepartmentName && runtimeGraphUsesRequesterAttribute(runtimeGraph, 'department')) {
+      if (orgPolicyMisconfigured) {
+        // persistent CONFIG error — retrying never fixes a broken routing policy
+        throw new ServiceError(
+          'The directory routing policy for this organization is misconfigured, so the requester department cannot be resolved. Contact an administrator.',
+          422,
+          'APPROVAL_ROUTING_POLICY_MISCONFIGURED',
+        )
+      }
       if (orgReadFailed) {
         throw new ServiceError(
           'Could not resolve the requester department required by this approval template. Please retry.',
@@ -3679,6 +3695,13 @@ export class ApprovalProductService {
     // applies: a directory read that THREW -> 503 (retryable); a read that SUCCEEDED but left title unset
     // -> 422 (genuine row-level absence). Only fires when the graph actually routes on requester.title.
     if (!orgRelations.primaryTitle && runtimeGraphUsesRequesterAttribute(runtimeGraph, 'title')) {
+      if (orgPolicyMisconfigured) {
+        throw new ServiceError(
+          'The directory routing policy for this organization is misconfigured, so the requester title cannot be resolved. Contact an administrator.',
+          422,
+          'APPROVAL_ROUTING_POLICY_MISCONFIGURED',
+        )
+      }
       if (orgReadFailed) {
         throw new ServiceError(
           'Could not resolve the requester title required by this approval template. Please retry.',

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -2207,6 +2207,33 @@ export function runtimeGraphUsesManagerChain(runtimeGraph: RuntimeGraph): boolea
 }
 
 /**
+ * B5-b owner P1: does the graph use ANY org-derived assignee source? All four kinds resolve from
+ * `orgRelations` — so when the org read FAILED (transient) or the routing POLICY is misconfigured,
+ * an empty `orgRelations` is not "requester has no manager", it is "we could not find out". Letting
+ * that empty flow into assignment resolution turns `emptyAssigneePolicy: 'auto-approve'` into a
+ * FAIL-OPEN (a broken routing policy silently auto-approves approvals). The create-time guard keyed
+ * on this detector fail-closes instead: 422 for the persistent policy config error, 503 for the
+ * transient read failure — with NO instance and NO assignment created. Genuine data absence (the
+ * read SUCCEEDED, the requester simply has no manager) still follows `emptyAssigneePolicy`.
+ */
+export function runtimeGraphUsesOrgAssigneeSource(runtimeGraph: RuntimeGraph): boolean {
+  return runtimeGraph.nodes.some((node) => {
+    if (node.type !== 'approval') return false
+    const config: unknown = node.config
+    const sources = isRecord(config) ? config.assigneeSources : undefined
+    if (!Array.isArray(sources)) return false
+    return sources.some(
+      (source) =>
+        isRecord(source) &&
+        (source.kind === 'direct_manager' ||
+          source.kind === 'dept_head' ||
+          source.kind === 'continuous_managers' ||
+          source.kind === 'manager_at_level'),
+    )
+  })
+}
+
+/**
  * Does the published runtime graph route on `requester.<attr>` (e.g. `department` / `title`)? Used by the
  * create-time wedge guard — a transient directory-read failure must fail the create fast (retryable) when
  * such a condition exists, rather than freezing an absent attribute that would wedge every later approval
@@ -3667,6 +3694,30 @@ export class ApprovalProductService {
     //   - read SUCCEEDED but empty (genuine row-level absence) -> 422, the requester's department is unset.
     // Only fires when the graph actually routes on requester.department (manager-chain / dept-head and
     // non-department templates are unaffected; genuine absence on those follows their emptyAssigneePolicy).
+    // B5-b owner P1 (fail-open closure): when the ORG READ failed — transient throw OR a
+    // misconfigured routing policy — an empty `orgRelations` must NOT flow into any org-derived
+    // assignee source (direct_manager / dept_head / continuous_managers / manager_at_level). It
+    // would resolve to an empty assignee set and, under `emptyAssigneePolicy: 'auto-approve'`,
+    // silently AUTO-APPROVE the instance: a broken policy becomes a fail-open. Fail-close at
+    // create instead, BEFORE any instance/assignment insert: 422 for the persistent config error
+    // ("contact an administrator" — retrying never fixes a policy), 503 for the transient failure
+    // (retryable). Genuine absence (read succeeded, requester has no manager) is untouched and
+    // still follows `emptyAssigneePolicy` — that is the pre-existing, deliberate semantic.
+    if (orgReadFailed && runtimeGraphUsesOrgAssigneeSource(runtimeGraph)) {
+      if (orgPolicyMisconfigured) {
+        throw new ServiceError(
+          'The directory routing policy for this organization is misconfigured, so approver resolution cannot run. Contact an administrator.',
+          422,
+          'APPROVAL_ROUTING_POLICY_MISCONFIGURED',
+        )
+      }
+      throw new ServiceError(
+        'Could not resolve the requester organization relations required by this approval template. Please retry.',
+        503,
+        'APPROVAL_REQUESTER_ORG_UNRESOLVED',
+      )
+    }
+
     if (!orgRelations.primaryDepartmentName && runtimeGraphUsesRequesterAttribute(runtimeGraph, 'department')) {
       if (orgPolicyMisconfigured) {
         // persistent CONFIG error — retrying never fixes a broken routing policy

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -3613,15 +3613,18 @@ export class ApprovalProductService {
 
     // Org-relation plumbing — freeze the requester's org relations (direct manager
     // / dept head / management chain, as LOCAL user ids) from the directory `raw`
-    // payload. READ-ONLY (directory_* SELECTs only) and best-effort: a directory
-    // read failure must never block create, so an unresolved lookup just omits the
-    // fields. direct_manager / dept_head read managerId / deptHeadId; the chain is
-    // walked only when the published graph uses a management-chain source
+    // payload. READ-ONLY (directory_* SELECTs only). A SUCCESSFUL read that finds no
+    // manager/dept/title simply omits those fields and emptyAssigneePolicy applies.
+    // A FAILED read (transient throw OR a misconfigured routing policy) is NOT
+    // best-effort when the graph consumes org data: the wedge guards below fail-close
+    // create AND the shared preview substrate (B3-05/B3-06) so a broken policy cannot
+    // silently auto-approve. direct_manager / dept_head read managerId / deptHeadId;
+    // the chain is walked only when the published graph uses a management-chain source
     // (continuous_managers or manager_at_level) — so the extra per-hop queries stay
-    // off every approval. Absence falls through to the node's emptyAssigneePolicy.
-    // Draft dry-run (B3-06) compiles the authoring graph with the SAME compiler the publish path
-    // uses; the default path reads the frozen published runtime graph (create + B3-05, unchanged).
-    // The `!` on the published branch is sound: the non-draft gate above already threw if absent.
+    // off every approval. Draft dry-run (B3-06) compiles the authoring graph with the
+    // SAME compiler the publish path uses; the default path reads the frozen published
+    // runtime graph (create + B3-05, unchanged). The `!` on the published branch is
+    // sound: the non-draft gate above already threw if absent.
     const runtimeGraph = previewFromDraft
       ? buildRuntimeGraph(asApprovalGraph(bundle.version.approval_graph), { allowRevoke: false })
       : asRuntimeGraph(bundle.publishedDefinition!.runtime_graph)

--- a/packages/core-backend/tests/integration/approval-routing-policy-failclose.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-routing-policy-failclose.api.test.ts
@@ -1,8 +1,9 @@
 import net from 'net'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi, type MockInstance } from 'vitest'
+import type { Pool } from 'pg'
 import { MetaSheetServer } from '../../src/index'
 import { poolManager } from '../../src/integration/db/connection-pool'
-import { query } from '../../src/db/pg'
+import { pool, query } from '../../src/db/pg'
 import { getOrCreateLocalIntegration, setLocalMembershipManager } from '../../src/directory/directory-sync'
 import {
   addLocalMembership,
@@ -12,7 +13,8 @@ import {
 } from '../../src/directory/local-directory-org'
 
 /**
- * B5-b owner P1 — the routing-policy FAIL-CLOSE at approval create, real server + real DB.
+ * B5-b owner P1 — the routing-policy FAIL-CLOSE at approval create + shared preview substrate,
+ * real server + real DB.
  *
  * The hazard being closed (owner review): a misconfigured `approval_routing` policy makes the org
  * resolver throw; the create path caught it and proceeded with EMPTY orgRelations; every org-derived
@@ -24,8 +26,10 @@ import {
  *   A. BROKEN POLICY (canonical target disabled) → create rejected **422
  *      APPROVAL_ROUTING_POLICY_MISCONFIGURED**, and — the load-bearing half — **ZERO
  *      approval_instances and ZERO approval_assignments** exist for the template.
- *   B. TRANSIENT org-read failure (policy table renamed away → probe throws a non-policy error)
- *      → create rejected **503 APPROVAL_REQUESTER_ORG_UNRESOLVED**, zero instances/assignments.
+ *   B. TRANSIENT org-read failure (test-local vi.spyOn on Pool.query: Reflect.apply-delegates
+ *      every overload arg; throws only the routing-policy probe while a scoped boolean is enabled —
+ *      no shared-schema DDL, no production hook) → create rejected **503
+ *      APPROVAL_REQUESTER_ORG_UNRESOLVED**, zero instances/assignments.
  *   C. POSITIVE CONTROLS (the guard must not over-block):
  *      C1. healthy policy→local + requester HAS a manager → direct_manager creates a genuine
  *          PENDING instance WITH an assignment (the resolvable case works end-to-end);
@@ -33,8 +37,18 @@ import {
  *          absence keeps the pre-existing emptyAssigneePolicy semantic — fail-close is only for
  *          "could not find out", never for "found out: none").
  *
+ * Permanent HTTP pins for the SHARED assembleCreationContext substrate — each endpoint is its
+ * OWN load-bearing case (so a guard mutation reds B3-05 and B3-06 independently, not only the
+ * first sequential assertion):
+ *   D1/D2. BROKEN policy → 422 APPROVAL_ROUTING_POLICY_MISCONFIGURED on
+ *          POST /api/approvals/preview and POST /api/approval-templates/:id/route-preview
+ *          (own fixture each, zero approval instances/assignments).
+ *   E1/E2. TRANSIENT org-read failure → 503 APPROVAL_REQUESTER_ORG_UNRESOLVED on the same two
+ *          surfaces (own fixture each, zero approval instances/assignments).
+ *
  * Load-bearing mutation (out-of-band, recorded in the PR): deleting the create-time
- * `runtimeGraphUsesOrgAssigneeSource` guard turns leg A back into a 2xx auto-approval → A reds.
+ * `runtimeGraphUsesOrgAssigneeSource` guard turns leg A back into a 2xx auto-approval → A reds;
+ * each of D1/D2/E1/E2 also reds independently (they share the same guard).
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
@@ -88,6 +102,37 @@ async function setPolicy(org: string, canonical: string): Promise<void> {
   )
 }
 
+/** B5-b policy-probe SELECT shape (ApprovalDirectoryOrg step 0). */
+function isRoutingPolicyProbeSql(text: unknown): text is string {
+  return (
+    typeof text === 'string' &&
+    text.includes('org_directory_routing_policy') &&
+    text.includes('approval_routing')
+  )
+}
+
+type PreviewEndpoint = {
+  id: string
+  label: string
+  path: (tid: string) => string
+  body: (tid: string) => Record<string, unknown>
+}
+
+const PREVIEW_ENDPOINTS: PreviewEndpoint[] = [
+  {
+    id: 'b305',
+    label: 'POST /api/approvals/preview (B3-05)',
+    path: () => '/api/approvals/preview',
+    body: (tid) => ({ templateId: tid, formData: { reason: 'r' } }),
+  },
+  {
+    id: 'b306',
+    label: 'POST /api/approval-templates/:id/route-preview (B3-06)',
+    path: (tid) => `/api/approval-templates/${tid}/route-preview`,
+    body: () => ({ sampleFormData: { reason: 'r' }, sampleRequesterId: REQ }),
+  },
+]
+
 describeIfDatabase('B5-b owner P1 — routing-policy fail-close at approval create (real server, real DB)', () => {
   let server: MetaSheetServer | undefined
   let base = ''
@@ -98,8 +143,40 @@ describeIfDatabase('B5-b owner P1 — routing-policy fail-close at approval crea
   const cleanupUserIds: string[] = []
   const cleanupAccountIds: string[] = []
 
+  /**
+   * Test-local vi.spyOn on the SAME pg Pool.query ApprovalProductService binds into
+   * `resolveApprovalRequesterOrgRelations` (`import { pool } from '../db/pg'` →
+   * poolManager.getInternalPool()). Reflect.apply-forwards every overload argument to the
+   * original method; the routing-policy probe throws ONLY while `orgPolicyProbeFaultEnabled`
+   * is true. No shared-schema DDL, no production hook. Spy installed in beforeAll; boolean
+   * cleared in afterEach; mockRestore in afterAll.
+   */
+  let orgPolicyProbeFaultEnabled = false
+  let orgPolicyProbeFaultFired = 0
+  let querySpy: MockInstance | null = null
+  const servicePool = pool as Pool | null
+
+  function enableOrgPolicyProbeFault(): void {
+    orgPolicyProbeFaultEnabled = true
+    orgPolicyProbeFaultFired = 0
+  }
+  function disableOrgPolicyProbeFault(): void {
+    orgPolicyProbeFaultEnabled = false
+  }
+
   beforeAll(async () => {
     expect(await canListen()).toBe(true)
+    expect(servicePool, 'ApprovalProductService pool must be available for fault injection').toBeTruthy()
+    const originalQuery = servicePool!.query
+    querySpy = vi.spyOn(servicePool!, 'query').mockImplementation(function (this: Pool, ...args: unknown[]) {
+      const text = args[0]
+      if (orgPolicyProbeFaultEnabled && isRoutingPolicyProbeSql(text)) {
+        orgPolicyProbeFaultFired += 1
+        return Promise.reject(new Error('simulated transient org routing-policy read failure'))
+      }
+      return Reflect.apply(originalQuery, this, args)
+    })
+
     const { ensureApprovalSchemaReady } = await import('../helpers/approval-schema-bootstrap')
     await ensureApprovalSchemaReady()
     server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
@@ -140,22 +217,31 @@ describeIfDatabase('B5-b owner P1 — routing-policy fail-close at approval crea
     dtIntId = dt.rows[0].id
   })
 
+  afterEach(() => {
+    // Safety net: a test must never leave the scoped fault boolean armed.
+    disableOrgPolicyProbeFault()
+  })
+
   afterAll(async () => {
+    disableOrgPolicyProbeFault()
+    // Restore the real Pool.query — the spy must not outlive this suite.
+    querySpy?.mockRestore()
+    querySpy = null
     try {
       await query(`DELETE FROM org_directory_routing_policy WHERE org_id = 'default'`)
-      const pool = poolManager.get()
-      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`%-${TS}`])).rows.map((r) => r.id as string)
+      const poolClient = poolManager.get()
+      const tids = (await poolClient.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`%-${TS}`])).rows.map((r) => r.id as string)
       if (tids.length > 0) {
-        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1)`, [tids])).rows.map(
+        const iids = (await poolClient.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1)`, [tids])).rows.map(
           (r) => r.id as string,
         )
         if (iids.length > 0) {
-          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
-          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
-          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+          await poolClient.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await poolClient.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await poolClient.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
         }
-        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1)`, [tids])
-        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
+        await poolClient.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1)`, [tids])
+        await poolClient.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
       }
       for (const id of cleanupAccountIds.splice(0)) await query(`DELETE FROM directory_accounts WHERE id = $1`, [id])
       await query(`DELETE FROM directory_integrations WHERE id = $1`, [dtIntId])
@@ -211,21 +297,29 @@ describeIfDatabase('B5-b owner P1 — routing-policy fail-close at approval crea
   })
 
   it('B. TRANSIENT org-read failure → 503 APPROVAL_REQUESTER_ORG_UNRESOLVED for all four sources, zero instances, zero assignments', async () => {
-    // healthy policy in place; then break the READ transiently (rename the policy table so the
-    // probe throws a non-policy error — the transient-infra shape, not a config error)
+    // healthy policy in place; arm the scoped Pool.query spy only for the create calls
+    // (non-policy Error shape — not a config error). Publish stays on the healthy path.
     await setPolicy('default', localIntId)
-    await query(`ALTER TABLE org_directory_routing_policy RENAME TO org_directory_routing_policy_hidden_${TS}`)
     try {
+      const tids: Array<{ kind: OrgSourceKind; tid: string }> = []
       for (const kind of KINDS) {
-        const tid = await publish(`fc-transient-${kind}-${TS}`, kind)
-        const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
-        const text = await started.clone().text()
-        expect(started.status, `${kind}: ${text}`).toBe(503)
-        expect(text).toContain('APPROVAL_REQUESTER_ORG_UNRESOLVED')
-        await zeroRows(tid)
+        tids.push({ kind, tid: await publish(`fc-transient-${kind}-${TS}`, kind) })
+      }
+      enableOrgPolicyProbeFault()
+      try {
+        for (const { kind, tid } of tids) {
+          const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+          const text = await started.clone().text()
+          expect(started.status, `${kind}: ${text}`).toBe(503)
+          expect(text).toContain('APPROVAL_REQUESTER_ORG_UNRESOLVED')
+          await zeroRows(tid)
+        }
+        // spy must have matched the real probe (guards against silent SQL-shape drift)
+        expect(orgPolicyProbeFaultFired).toBeGreaterThan(0)
+      } finally {
+        disableOrgPolicyProbeFault()
       }
     } finally {
-      await query(`ALTER TABLE org_directory_routing_policy_hidden_${TS} RENAME TO org_directory_routing_policy`)
       await query(`DELETE FROM org_directory_routing_policy WHERE org_id = 'default'`)
     }
   })
@@ -264,4 +358,54 @@ describeIfDatabase('B5-b owner P1 — routing-policy fail-close at approval crea
       await query(`DELETE FROM org_directory_routing_policy WHERE org_id = 'default'`)
     }
   })
+
+  // Independently load-bearing: each preview endpoint is its own case so a guard mutation reds
+  // B3-05 and B3-06 separately (a sequential dual-assert in one test would stop at the first fail).
+  it.each(PREVIEW_ENDPOINTS)(
+    'D. BROKEN policy → 422 APPROVAL_ROUTING_POLICY_MISCONFIGURED on $label, zero approval instances/assignments',
+    async (endpoint) => {
+      await setPolicy('default', dtIntId)
+      await query(`UPDATE directory_integrations SET status = 'disabled' WHERE id = $1`, [dtIntId])
+      try {
+        const tid = await publish(`fc-prev-broken-${endpoint.id}-${TS}`, 'direct_manager')
+        const res = await req(base, endpoint.path(tid), reqTok, {
+          method: 'POST',
+          body: endpoint.body(tid),
+        })
+        const text = await res.clone().text()
+        expect(res.status, `${endpoint.label}: ${text}`).toBe(422)
+        expect(text).toContain('APPROVAL_ROUTING_POLICY_MISCONFIGURED')
+        await zeroRows(tid)
+      } finally {
+        await query(`UPDATE directory_integrations SET status = 'active' WHERE id = $1`, [dtIntId])
+        await query(`DELETE FROM org_directory_routing_policy WHERE org_id = 'default'`)
+      }
+    },
+  )
+
+  it.each(PREVIEW_ENDPOINTS)(
+    'E. TRANSIENT org-read failure → 503 APPROVAL_REQUESTER_ORG_UNRESOLVED on $label, zero approval instances/assignments',
+    async (endpoint) => {
+      await setPolicy('default', localIntId)
+      try {
+        const tid = await publish(`fc-prev-transient-${endpoint.id}-${TS}`, 'direct_manager')
+        enableOrgPolicyProbeFault()
+        try {
+          const res = await req(base, endpoint.path(tid), reqTok, {
+            method: 'POST',
+            body: endpoint.body(tid),
+          })
+          const text = await res.clone().text()
+          expect(res.status, `${endpoint.label}: ${text}`).toBe(503)
+          expect(text).toContain('APPROVAL_REQUESTER_ORG_UNRESOLVED')
+          await zeroRows(tid)
+          expect(orgPolicyProbeFaultFired).toBeGreaterThan(0)
+        } finally {
+          disableOrgPolicyProbeFault()
+        }
+      } finally {
+        await query(`DELETE FROM org_directory_routing_policy WHERE org_id = 'default'`)
+      }
+    },
+  )
 })

--- a/packages/core-backend/tests/integration/approval-routing-policy-failclose.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-routing-policy-failclose.api.test.ts
@@ -1,0 +1,267 @@
+import net from 'net'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { query } from '../../src/db/pg'
+import { getOrCreateLocalIntegration, setLocalMembershipManager } from '../../src/directory/directory-sync'
+import {
+  addLocalMembership,
+  createLocalAccount,
+  createLocalDepartment,
+  switchLocalPrimaryDepartment,
+} from '../../src/directory/local-directory-org'
+
+/**
+ * B5-b owner P1 — the routing-policy FAIL-CLOSE at approval create, real server + real DB.
+ *
+ * The hazard being closed (owner review): a misconfigured `approval_routing` policy makes the org
+ * resolver throw; the create path caught it and proceeded with EMPTY orgRelations; every org-derived
+ * assignee source (direct_manager / dept_head / continuous_managers / manager_at_level) then
+ * resolved empty; under `emptyAssigneePolicy: 'auto-approve'` the instance was AUTO-APPROVED —
+ * a broken policy became a FAIL-OPEN that silently approves approvals.
+ *
+ * Proof, for EACH of the four org assignee sources (all with the dangerous auto-approve policy):
+ *   A. BROKEN POLICY (canonical target disabled) → create rejected **422
+ *      APPROVAL_ROUTING_POLICY_MISCONFIGURED**, and — the load-bearing half — **ZERO
+ *      approval_instances and ZERO approval_assignments** exist for the template.
+ *   B. TRANSIENT org-read failure (policy table renamed away → probe throws a non-policy error)
+ *      → create rejected **503 APPROVAL_REQUESTER_ORG_UNRESOLVED**, zero instances/assignments.
+ *   C. POSITIVE CONTROLS (the guard must not over-block):
+ *      C1. healthy policy→local + requester HAS a manager → direct_manager creates a genuine
+ *          PENDING instance WITH an assignment (the resolvable case works end-to-end);
+ *      C2. healthy policy + a requester with NO manager → auto-approve still fires (GENUINE data
+ *          absence keeps the pre-existing emptyAssigneePolicy semantic — fail-close is only for
+ *          "could not find out", never for "found out: none").
+ *
+ * Load-bearing mutation (out-of-band, recorded in the PR): deleting the create-time
+ * `runtimeGraphUsesOrgAssigneeSource` guard turns leg A back into a 2xx auto-approval → A reds.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQ = `b5bfc-req-${TS}` // requester WITH manager (positive control C1) + all fail legs
+const REQ_NOMGR = `b5bfc-nomgr-${TS}` // requester with NO manager (positive control C2)
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+type OrgSourceKind = 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level'
+function graph(kind: OrgSourceKind) {
+  const source =
+    kind === 'continuous_managers' ? { kind, levels: 2 } : kind === 'manager_at_level' ? { kind, level: 1 } : { kind }
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      // auto-approve is DELIBERATE: it is the dangerous policy the fail-open exploited
+      { key: 'approval_1', type: 'approval', name: 'a', config: { assigneeSources: [source], approvalMode: 'single', emptyAssigneePolicy: 'auto-approve' } },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: 'approval_1' },
+      { key: 'e2', source: 'approval_1', target: 'end' },
+    ],
+  }
+}
+
+async function setPolicy(org: string, canonical: string): Promise<void> {
+  await query(
+    `INSERT INTO org_directory_routing_policy (org_id, purpose, canonical_integration_id)
+     VALUES ($1, 'approval_routing', $2)
+     ON CONFLICT ON CONSTRAINT orp_org_purpose_uniq
+     DO UPDATE SET canonical_integration_id = EXCLUDED.canonical_integration_id, updated_at = NOW()`,
+    [org, canonical],
+  )
+}
+
+describeIfDatabase('B5-b owner P1 — routing-policy fail-close at approval create (real server, real DB)', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let reqTok = ''
+  let reqNoMgrTok = ''
+  let localIntId = ''
+  let dtIntId = ''
+  const cleanupUserIds: string[] = []
+  const cleanupAccountIds: string[] = []
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    const { ensureApprovalSchemaReady } = await import('../helpers/approval-schema-bootstrap')
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ)
+    reqNoMgrTok = await tok(base, REQ_NOMGR)
+
+    // fixtures in 'default' (the org the server resolves): local integration + requester with a
+    // real manager (dept membership + is_manager), plus a dingtalk integration to be the broken
+    // policy target.
+    const MGR = `b5bfc-mgr-${TS}`
+    for (const u of [REQ, REQ_NOMGR, MGR]) {
+      cleanupUserIds.push(u)
+      await query(`INSERT INTO users (id, email, name, password_hash) VALUES ($1, $2, $3, 'x') ON CONFLICT (id) DO NOTHING`, [
+        u,
+        `${u}@example.test`,
+        u,
+      ])
+    }
+    const local = await getOrCreateLocalIntegration('default')
+    localIntId = local.id
+    const dept = await createLocalDepartment({ orgId: 'default', name: `FC Dept ${TS}` })
+    const aReq = await createLocalAccount({ orgId: 'default', localUserId: REQ, title: 'FC Requester' })
+    const aNo = await createLocalAccount({ orgId: 'default', localUserId: REQ_NOMGR, title: 'FC NoMgr' })
+    const aMgr = await createLocalAccount({ orgId: 'default', localUserId: MGR, title: 'FC Manager' })
+    cleanupAccountIds.push(aReq.id, aNo.id, aMgr.id)
+    await addLocalMembership({ orgId: 'default', accountId: aReq.id, departmentId: dept.id })
+    await switchLocalPrimaryDepartment('default', aReq.id, dept.id)
+    await addLocalMembership({ orgId: 'default', accountId: aMgr.id, departmentId: dept.id })
+    await setLocalMembershipManager('default', { directoryAccountId: aMgr.id, directoryDepartmentId: dept.id }, true)
+
+    const dt = await query<{ id: string }>(
+      `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config)
+       VALUES ('default', 'dingtalk', $1, 'active', $2, '{}'::jsonb) RETURNING id`,
+      [`DT fc ${TS}`, `corp-fc-${TS}`],
+    )
+    dtIntId = dt.rows[0].id
+  })
+
+  afterAll(async () => {
+    try {
+      await query(`DELETE FROM org_directory_routing_policy WHERE org_id = 'default'`)
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`%-${TS}`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1)`, [tids])).rows.map(
+          (r) => r.id as string,
+        )
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1)`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
+      }
+      for (const id of cleanupAccountIds.splice(0)) await query(`DELETE FROM directory_accounts WHERE id = $1`, [id])
+      await query(`DELETE FROM directory_integrations WHERE id = $1`, [dtIntId])
+      for (const uid of cleanupUserIds.splice(0)) await query(`DELETE FROM users WHERE id = $1`, [uid])
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  async function publish(key: string, kind: OrgSourceKind): Promise<string> {
+    const created = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }, approvalGraph: graph(kind) },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    const tid = ((await created.json()) as { id: string }).id
+    expect((await req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
+    return tid
+  }
+  async function zeroRows(tid: string): Promise<void> {
+    const inst = await query<{ n: number }>(`SELECT count(*)::int AS n FROM approval_instances WHERE template_id = $1`, [tid])
+    expect(inst.rows[0].n).toBe(0)
+    const asg = await query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM approval_assignments a JOIN approval_instances i ON i.id = a.instance_id WHERE i.template_id = $1`,
+      [tid],
+    )
+    expect(asg.rows[0].n).toBe(0)
+  }
+
+  const KINDS: OrgSourceKind[] = ['direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level']
+
+  it('A. BROKEN policy → 422 APPROVAL_ROUTING_POLICY_MISCONFIGURED for ALL FOUR org sources, zero instances, zero assignments', async () => {
+    await setPolicy('default', dtIntId)
+    await query(`UPDATE directory_integrations SET status = 'disabled' WHERE id = $1`, [dtIntId])
+    try {
+      for (const kind of KINDS) {
+        const tid = await publish(`fc-broken-${kind}-${TS}`, kind)
+        const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+        const text = await started.clone().text()
+        expect(started.status, `${kind}: ${text}`).toBe(422)
+        expect(text).toContain('APPROVAL_ROUTING_POLICY_MISCONFIGURED')
+        await zeroRows(tid) // the fail-open would have left an auto-approved instance here
+      }
+    } finally {
+      await query(`UPDATE directory_integrations SET status = 'active' WHERE id = $1`, [dtIntId])
+      await query(`DELETE FROM org_directory_routing_policy WHERE org_id = 'default'`)
+    }
+  })
+
+  it('B. TRANSIENT org-read failure → 503 APPROVAL_REQUESTER_ORG_UNRESOLVED for all four sources, zero instances, zero assignments', async () => {
+    // healthy policy in place; then break the READ transiently (rename the policy table so the
+    // probe throws a non-policy error — the transient-infra shape, not a config error)
+    await setPolicy('default', localIntId)
+    await query(`ALTER TABLE org_directory_routing_policy RENAME TO org_directory_routing_policy_hidden_${TS}`)
+    try {
+      for (const kind of KINDS) {
+        const tid = await publish(`fc-transient-${kind}-${TS}`, kind)
+        const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+        const text = await started.clone().text()
+        expect(started.status, `${kind}: ${text}`).toBe(503)
+        expect(text).toContain('APPROVAL_REQUESTER_ORG_UNRESOLVED')
+        await zeroRows(tid)
+      }
+    } finally {
+      await query(`ALTER TABLE org_directory_routing_policy_hidden_${TS} RENAME TO org_directory_routing_policy`)
+      await query(`DELETE FROM org_directory_routing_policy WHERE org_id = 'default'`)
+    }
+  })
+
+  it('C1. positive control: healthy policy→local + resolvable manager → a genuine PENDING instance WITH an assignment', async () => {
+    await setPolicy('default', localIntId)
+    try {
+      const tid = await publish(`fc-ok-${TS}`, 'direct_manager')
+      const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+      expect(started.status, await started.clone().text()).toBeLessThan(300)
+      const inst = await query<{ id: string; status: string }>(
+        `SELECT id, status FROM approval_instances WHERE template_id = $1`,
+        [tid],
+      )
+      expect(inst.rows).toHaveLength(1)
+      expect(['pending', 'in_progress', 'running', 'active']).toContain(inst.rows[0].status)
+      const asg = await query<{ n: number }>(`SELECT count(*)::int AS n FROM approval_assignments WHERE instance_id = $1`, [
+        inst.rows[0].id,
+      ])
+      expect(asg.rows[0].n).toBeGreaterThan(0) // a REAL live assignment — not auto-approved
+    } finally {
+      await query(`DELETE FROM org_directory_routing_policy WHERE org_id = 'default'`)
+    }
+  })
+
+  it('C2. positive control: healthy policy + requester with NO manager → auto-approve still fires (genuine absence unchanged)', async () => {
+    await setPolicy('default', localIntId)
+    try {
+      const tid = await publish(`fc-nomgr-${TS}`, 'direct_manager')
+      const started = await req(base, '/api/approvals', reqNoMgrTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+      expect(started.status, await started.clone().text()).toBeLessThan(300)
+      const inst = await query<{ status: string }>(`SELECT status FROM approval_instances WHERE template_id = $1`, [tid])
+      expect(inst.rows).toHaveLength(1)
+      expect(['approved', 'completed', 'auto_approved']).toContain(inst.rows[0].status)
+    } finally {
+      await query(`DELETE FROM org_directory_routing_policy WHERE org_id = 'default'`)
+    }
+  })
+})

--- a/packages/core-backend/tests/integration/org-directory-routing-policy-resolver.db.test.ts
+++ b/packages/core-backend/tests/integration/org-directory-routing-policy-resolver.db.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { getOrCreateLocalIntegration } from '../../src/directory/directory-sync'
+import { ApprovalRoutingPolicyError, resolveApprovalRequesterOrgRelations } from '../../src/services/ApprovalDirectoryOrg'
+
+/**
+ * Canonical Org MVP — B5-b (routing-policy RESOLVER), design lock Lock 2 + Q4, real DB.
+ *
+ * `resolveApprovalRequesterOrgRelations` picks the requester's directory account. LEGACY behavior
+ * guesses among a user's linked accounts by `ORDER BY a.updated_at DESC LIMIT 1` — "latest
+ * integration wins", forbidden by the §6 owner ruling once an org has multiple integrations.
+ * This file proves the B5-b precedence end-to-end against real Postgres:
+ *
+ *   A. LEGACY CONTROL (no policy): with the SAME two-integration fixture, the resolver picks the
+ *      LATEST-updated account (the dingtalk one) — proving the fixture genuinely exercises the
+ *      guessing path this policy exists to kill, and that a policy-less org keeps byte-identical
+ *      legacy behavior (Q1 staged opt-in).
+ *   B. POLICY-AUTHORITATIVE: policy → local ⇒ resolves the LOCAL account (title proves the source)
+ *      even though the dingtalk account is newer; flip the policy → dingtalk ⇒ resolves dingtalk.
+ *      Never "latest wins" once a policy exists.
+ *   C. FAIL-CLOSED on a broken target: policy → non-active integration ⇒ typed
+ *      `ApprovalRoutingPolicyError` (CONFIG error — silent fallback to guessing would defeat the
+ *      policy); positive control: reactivate ⇒ resolves.
+ *   D. MULTI-ORG POLICY AMBIGUITY (Q4): user linked in TWO orgs that BOTH have policies ⇒ typed
+ *      error; delete one policy ⇒ resolves via the remaining one (a policy-less second org does
+ *      not re-ambiguate — deterministic, not a guess).
+ *   E. DATA ABSENCE ≠ CONFIG ERROR: policy → local, but the requester has NO account in the local
+ *      integration ⇒ `{}` (same semantics as "no linked directory account"), NOT an error.
+ *
+ * Load-bearing mutations (out-of-band, each reds this file):
+ *   - remove `AND a.integration_id = $2::uuid` from the policy-scoped requester query → B reds
+ *     (policy→local still resolves the newer dingtalk account — guessing came back).
+ *   - remove the `canonical_status !== 'active'` fail-closed check → C reds (no throw).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+const orgId = (suffix: string): string => `b5b-${STAMP}-${suffix}`
+const newUserId = (suffix: string): string => `b5b-user-${STAMP}-${suffix}`
+
+const q = query
+
+async function seedUser(id: string): Promise<void> {
+  await q(`INSERT INTO users (id, email, name, password_hash) VALUES ($1, $2, $3, 'x')`, [id, `${id}@example.test`, id])
+}
+
+async function dingtalkIntegration(org: string, tag: string): Promise<string> {
+  const r = await q<{ id: string }>(
+    `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config)
+     VALUES ($1, 'dingtalk', $2, 'active', $3, '{}'::jsonb) RETURNING id`,
+    [org, `DT ${tag}`, `corp-${STAMP}-${tag}`],
+  )
+  return r.rows[0].id
+}
+
+/** Raw-link an account (provider-agnostic) to a local user with a title that names its source. */
+async function linkedAccount(integrationId: string, provider: string, userId: string, title: string): Promise<string> {
+  const acc = await q<{ id: string }>(
+    `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, title, is_active, raw)
+     VALUES ($1, $2, $3, $3, $4, $5, true, '{}'::jsonb) RETURNING id`,
+    [integrationId, provider, `${provider}:${STAMP}:${userId}:${integrationId.slice(0, 8)}`, userId, title],
+  )
+  await q(
+    `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+     VALUES ($1, $2, 'linked', 'manual')`,
+    [acc.rows[0].id, userId],
+  )
+  return acc.rows[0].id
+}
+
+async function setPolicy(org: string, canonical: string): Promise<void> {
+  await q(
+    `INSERT INTO org_directory_routing_policy (org_id, purpose, canonical_integration_id)
+     VALUES ($1, 'approval_routing', $2)
+     ON CONFLICT ON CONSTRAINT orp_org_purpose_uniq
+     DO UPDATE SET canonical_integration_id = EXCLUDED.canonical_integration_id, updated_at = NOW()`,
+    [org, canonical],
+  )
+}
+
+async function bumpUpdatedAt(accountId: string): Promise<void> {
+  await q(`UPDATE directory_accounts SET updated_at = NOW() + interval '1 hour' WHERE id = $1`, [accountId])
+}
+
+describeIfDatabase('Canonical Org MVP — B5-b routing-policy resolver (real DB)', () => {
+  const seededOrgIds: string[] = []
+  const seededUserIds: string[] = []
+
+  afterEach(async () => {
+    for (const org of seededOrgIds.splice(0)) {
+      await q(`DELETE FROM org_directory_routing_policy WHERE org_id = $1`, [org])
+      await q(`DELETE FROM directory_integrations WHERE org_id = $1`, [org])
+    }
+    for (const uid of seededUserIds.splice(0)) {
+      await q(`DELETE FROM users WHERE id = $1`, [uid])
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  async function twoSourceFixture(tag: string): Promise<{ org: string; user: string; localInt: string; dtInt: string }> {
+    const org = orgId(tag)
+    seededOrgIds.push(org)
+    const user = newUserId(tag)
+    seededUserIds.push(user)
+    await seedUser(user)
+    const local = await getOrCreateLocalIntegration(org)
+    const dt = await dingtalkIntegration(org, tag)
+    await linkedAccount(local.id, 'local', user, 'Local Title')
+    const dtAcc = await linkedAccount(dt, 'dingtalk', user, 'DingTalk Title')
+    await bumpUpdatedAt(dtAcc) // the dingtalk account is NEWER — legacy guessing picks it
+    return { org, user, localInt: local.id, dtInt: dt }
+  }
+
+  it('A. legacy control (no policy): latest-updated account wins — the guessing path is real and stays byte-identical', async () => {
+    const { user } = await twoSourceFixture('legacy')
+    const rel = await resolveApprovalRequesterOrgRelations(user, q)
+    expect(rel.primaryTitle).toBe('DingTalk Title') // latest wins — today's behavior, unchanged without a policy
+  })
+
+  it('B. policy-authoritative: policy→local resolves the LOCAL account despite the newer dingtalk one; flip→dingtalk follows the policy', async () => {
+    const { org, user, localInt, dtInt } = await twoSourceFixture('auth')
+
+    await setPolicy(org, localInt)
+    const viaLocal = await resolveApprovalRequesterOrgRelations(user, q)
+    expect(viaLocal.primaryTitle).toBe('Local Title') // NOT the newer dingtalk account
+
+    await setPolicy(org, dtInt)
+    const viaDt = await resolveApprovalRequesterOrgRelations(user, q)
+    expect(viaDt.primaryTitle).toBe('DingTalk Title')
+  })
+
+  it('C. fail-closed on a broken canonical: non-active target throws the typed CONFIG error; reactivating resolves', async () => {
+    const { org, user, localInt } = await twoSourceFixture('failclosed')
+    await setPolicy(org, localInt)
+    await q(`UPDATE directory_integrations SET status = 'disabled' WHERE id = $1`, [localInt])
+
+    await expect(resolveApprovalRequesterOrgRelations(user, q)).rejects.toBeInstanceOf(ApprovalRoutingPolicyError)
+
+    // positive control: fix the target → resolves from it (the guard rejects BROKEN policies, not all policies)
+    await q(`UPDATE directory_integrations SET status = 'active' WHERE id = $1`, [localInt])
+    const rel = await resolveApprovalRequesterOrgRelations(user, q)
+    expect(rel.primaryTitle).toBe('Local Title')
+  })
+
+  it('D. multi-org policy ambiguity (Q4): two policy-governed orgs → typed error; removing one policy resolves via the other', async () => {
+    const a = await twoSourceFixture('mo-A')
+    // link the SAME user into a second org that also has a policy
+    const orgB = orgId('mo-B')
+    seededOrgIds.push(orgB)
+    const dtB = await dingtalkIntegration(orgB, 'mo-B')
+    await linkedAccount(dtB, 'dingtalk', a.user, 'OrgB Title')
+    await setPolicy(a.org, a.localInt)
+    await setPolicy(orgB, dtB)
+
+    await expect(resolveApprovalRequesterOrgRelations(a.user, q)).rejects.toBeInstanceOf(ApprovalRoutingPolicyError)
+
+    // drop org B's policy: exactly one governed org remains → deterministic resolution via it
+    await q(`DELETE FROM org_directory_routing_policy WHERE org_id = $1`, [orgB])
+    const rel = await resolveApprovalRequesterOrgRelations(a.user, q)
+    expect(rel.primaryTitle).toBe('Local Title')
+  })
+
+  it('E. data absence is not a config error: policy→local with no local account for the requester → {}', async () => {
+    const org = orgId('absent')
+    seededOrgIds.push(org)
+    const user = newUserId('absent')
+    seededUserIds.push(user)
+    await seedUser(user)
+    const local = await getOrCreateLocalIntegration(org)
+    const dt = await dingtalkIntegration(org, 'absent')
+    await linkedAccount(dt, 'dingtalk', user, 'DingTalk Title') // linked ONLY on the dingtalk side
+    await setPolicy(org, local.id)
+
+    const rel = await resolveApprovalRequesterOrgRelations(user, q)
+    expect(rel).toEqual({}) // absent from the canonical directory — not an error, same as unlinked
+  })
+})

--- a/packages/core-backend/tests/integration/org-directory-routing-policy-resolver.db.test.ts
+++ b/packages/core-backend/tests/integration/org-directory-routing-policy-resolver.db.test.ts
@@ -21,16 +21,30 @@ import { ApprovalRoutingPolicyError, resolveApprovalRequesterOrgRelations } from
  *   C. FAIL-CLOSED on a broken target: policy → non-active integration ⇒ typed
  *      `ApprovalRoutingPolicyError` (CONFIG error — silent fallback to guessing would defeat the
  *      policy); positive control: reactivate ⇒ resolves.
- *   D. MULTI-ORG POLICY AMBIGUITY (Q4): user linked in TWO orgs that BOTH have policies ⇒ typed
- *      error; delete one policy ⇒ resolves via the remaining one (a policy-less second org does
- *      not re-ambiguate — deterministic, not a guess).
+ *   D. MULTI-ORG POLICY AMBIGUITY (Q4, unscoped / no orgId): user linked in TWO orgs that BOTH
+ *      have policies ⇒ typed error; delete one policy ⇒ resolves via the remaining one (a
+ *      policy-less second org does not re-ambiguate — deterministic, not a guess). This remains
+ *      the kernel-path contract; F proves the orgId-scoped exception.
  *   E. DATA ABSENCE ≠ CONFIG ERROR: policy → local, but the requester has NO account in the local
  *      integration ⇒ `{}` (same semantics as "no linked directory account"), NOT an error.
+ *   F. TENANT BOUNDARY (options.orgId scopes the policy probe — real Postgres, not a SQL-text
+ *      fake): one user linked into org A and org B.
+ *        Stage 1: policy exists ONLY in B; call with orgId=A → A's org-anchored account/title is
+ *          selected; B's policy neither steers the pick nor multi-org-fails.
+ *        Stage 2: add an A policy while B's remains; call with orgId=A → A's CANONICAL wins
+ *          (not multi-org fail-close, not B's title). Unscoped Q4 stays covered by D.
  *
- * Load-bearing mutations (out-of-band, each reds this file):
+ * Load-bearing mutations (out-of-band, each reds this file for the stated reason):
  *   - remove `AND a.integration_id = $2::uuid` from the policy-scoped requester query → B reds
  *     (policy→local still resolves the newer dingtalk account — guessing came back).
  *   - remove the `canonical_status !== 'active'` fail-closed check → C reds (no throw).
+ *   - remove ONLY the production policy-probe predicate `AND p.org_id = $2` (orgId-scoped arm)
+ *     → F reds for the RIGHT wrong-org / ambiguity reason:
+ *       Stage 1 (policy only in B + orgId=A) steers to B's title instead of A's org-anchored
+ *       title (foreign policy becomes visible and authoritative).
+ *       Stage 2 (policies in A and B + orgId=A) throws multi-org ambiguity instead of selecting
+ *       A's canonical (the tenant boundary no longer filters B out before Q4).
+ *     Unit fakes that mirror SQL text are NOT sufficient evidence for this boundary — F is.
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -176,5 +190,52 @@ describeIfDatabase('Canonical Org MVP — B5-b routing-policy resolver (real DB)
 
     const rel = await resolveApprovalRequesterOrgRelations(user, q)
     expect(rel).toEqual({}) // absent from the canonical directory — not an error, same as unlinked
+  })
+
+  it('F. tenant boundary: orgId scopes the policy probe (foreign B policy cannot steer A; same-org A policy wins without multi-org fail-close)', async () => {
+    // One user linked into org A (local + dingtalk, dingtalk newer) AND org B (dingtalk).
+    // Titles are the discrimination channel — real Postgres rows, not a SQL-text fake.
+    const orgA = orgId('tb-A')
+    const orgB = orgId('tb-B')
+    seededOrgIds.push(orgA, orgB)
+    const user = newUserId('tb')
+    seededUserIds.push(user)
+    await seedUser(user)
+
+    const localA = await getOrCreateLocalIntegration(orgA)
+    const dtA = await dingtalkIntegration(orgA, 'tb-A')
+    await linkedAccount(localA.id, 'local', user, 'OrgA Local Title')
+    const dtAAcc = await linkedAccount(dtA, 'dingtalk', user, 'OrgA DingTalk Title')
+    await bumpUpdatedAt(dtAAcc) // within A, legacy/org-anchor without policy picks dingtalk
+
+    const dtB = await dingtalkIntegration(orgB, 'tb-B')
+    const dtBAcc = await linkedAccount(dtB, 'dingtalk', user, 'OrgB Policy Title')
+    await bumpUpdatedAt(dtBAcc) // B account is also very new — unscoped guessing would notice it
+
+    // Stage 1: policy exists ONLY in B. Call with orgId=A → tenant-scoped probe sees ZERO same-org
+    // policies → S7 org-anchored pick inside A (newer dingtalk) — NOT B's title, NOT multi-org throw.
+    await setPolicy(orgB, dtB)
+    const stage1 = await resolveApprovalRequesterOrgRelations(user, q, { orgId: orgA })
+    expect(stage1.primaryTitle).toBe('OrgA DingTalk Title')
+    expect(stage1.primaryTitle).not.toBe('OrgB Policy Title')
+    expect(stage1.primaryTitle).not.toBe('OrgA Local Title')
+
+    // Positive control on the same fixture: unscoped (no orgId) with only B's policy follows B
+    // (one governed org → authoritative). Proves the fixture's foreign policy is real and would
+    // steer if the tenant predicate were absent.
+    const unscopedOnlyB = await resolveApprovalRequesterOrgRelations(user, q)
+    expect(unscopedOnlyB.primaryTitle).toBe('OrgB Policy Title')
+
+    // Stage 2: add an A policy (→ local) while B's policy remains. orgId=A must NOT multi-org
+    // fail-close; A's CANONICAL (local) wins over A's newer dingtalk and over B entirely.
+    await setPolicy(orgA, localA.id)
+    const stage2 = await resolveApprovalRequesterOrgRelations(user, q, { orgId: orgA })
+    expect(stage2.primaryTitle).toBe('OrgA Local Title')
+    expect(stage2.primaryTitle).not.toBe('OrgA DingTalk Title')
+    expect(stage2.primaryTitle).not.toBe('OrgB Policy Title')
+
+    // Unscoped Q4 still fails closed with both policies present (D's contract; re-asserted here
+    // so F's tenant path cannot regress into "silently pick one" without D noticing either).
+    await expect(resolveApprovalRequesterOrgRelations(user, q)).rejects.toBeInstanceOf(ApprovalRoutingPolicyError)
   })
 })

--- a/packages/core-backend/tests/unit/approval-directory-org.test.ts
+++ b/packages/core-backend/tests/unit/approval-directory-org.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { resolveApprovalRequesterOrgRelations } from '../../src/services/ApprovalDirectoryOrg'
+import {
+  ApprovalRoutingPolicyError,
+  resolveApprovalRequesterOrgRelations,
+} from '../../src/services/ApprovalDirectoryOrg'
 
 /**
  * Lane G (P1-A) plumbing unit test — drives the read-only org resolver against an
@@ -33,30 +36,62 @@ interface FakeDb {
   policies?: Array<{ org_id: string; canonical_integration_id: string; canonical_status: string | null }>
 }
 
-function makeQuery(db: FakeDb & {
+type FakeDbWithTrace = FakeDb & {
   // When the org-anchored path is used, the fake can assert the orgId param and optionally return
   // a different requester (or empty) so the two-org / one-local-user contract is unit-provable.
   orgAnchoredRequester?: FakeDb['requester'] | null
+  // Policy-scoped path (`a.integration_id = $2::uuid`) can return a different account than
+  // the unscoped / org-anchored fixtures so same-org policy vs foreign-policy steering is
+  // discriminable.
+  policyScopedRequester?: FakeDb['requester'] | null
   lastOrgIdParam?: string | null
   lastRequesterSql?: string
-}) {
+  lastPolicySql?: string
+  lastPolicyOrgIdParam?: string | null
+  lastPolicyCanonicalParam?: string | null
+}
+
+function makeQuery(db: FakeDbWithTrace) {
   return async <Row>(text: string, params?: unknown[]): Promise<{ rows: Row[] }> => {
     // B5-b routing-policy probe (`org_directory_routing_policy`). Default-empty means NO policy
     // governs any org the user is linked in, so the resolver runs the LEGACY path byte-identical —
     // which is why every pre-B5 fixture below keeps its expectations unchanged (same convention as
     // the B3 normalized-manager default-empty note further down). Policy scenarios set db.policies.
+    //
+    // LOAD-BEARING MIRROR of production tenant boundary: when the probe SQL includes
+    // `p.org_id = $2`, only that org's policy rows are visible. Removing the production
+    // predicate (so this fragment is absent) makes the fake return ALL policies — and the
+    // foreign-policy discrimination tests below go red for the right reason.
     if (text.includes('FROM directory_account_links l') && text.includes('org_directory_routing_policy')) {
-      return { rows: (db.policies ?? []) as Row[] }
+      db.lastPolicySql = text
+      let rows = db.policies ?? []
+      if (text.includes('p.org_id = $2')) {
+        const scopedOrg = params?.[1] != null ? String(params[1]) : null
+        db.lastPolicyOrgIdParam = scopedOrg
+        rows = rows.filter((p) => p.org_id === scopedOrg)
+      } else {
+        db.lastPolicyOrgIdParam = null
+      }
+      return { rows: rows as Row[] }
     }
     if (text.includes('FROM directory_account_links l') && text.includes('LEFT JOIN directory_account_departments')) {
       db.lastRequesterSql = text
+      // Policy-scoped SELECT binds the canonical integration as $2 (must precede org-anchor check).
+      if (text.includes('a.integration_id = $2::uuid') || text.includes('a.integration_id = $2')) {
+        db.lastPolicyCanonicalParam = params?.[1] != null ? String(params[1]) : null
+        db.lastOrgIdParam = null
+        const row = db.policyScopedRequester !== undefined ? db.policyScopedRequester : db.requester
+        return { rows: (row ? [row] : []) as Row[] }
+      }
       // Org-anchored SELECT joins directory_integrations and binds org_id as $2.
       if (text.includes('JOIN directory_integrations di') && text.includes('di.org_id = $2')) {
         db.lastOrgIdParam = params?.[1] != null ? String(params[1]) : null
+        db.lastPolicyCanonicalParam = null
         const row = db.orgAnchoredRequester !== undefined ? db.orgAnchoredRequester : db.requester
         return { rows: (row ? [row] : []) as Row[] }
       }
       db.lastOrgIdParam = null
+      db.lastPolicyCanonicalParam = null
       return { rows: (db.requester ? [db.requester] : []) as Row[] }
     }
     // B3 normalized-manager gate query (`ad.is_manager = true`). Default-empty means the dept has
@@ -378,5 +413,241 @@ describe('resolveApprovalRequesterOrgRelations', () => {
     expect(result.managerId).toBe('local-mgr')
     expect(db.lastOrgIdParam).toBeNull()
     expect(db.lastRequesterSql).not.toContain('directory_integrations')
+  })
+
+  // ── S7 tenant boundary × B5-b policy probe (orgId scopes policy visibility) ──
+  it('tenant boundary: policy only in org-B + orgId=A selects A via org-anchor (foreign policy neither steers nor multi-org-fails)', async () => {
+    const db: FakeDbWithTrace = {
+      // Unscoped / foreign-policy path would serve this B-side account (wrong).
+      requester: {
+        integration_id: 'int-B-canonical',
+        account_id: 'acc-B',
+        external_user_id: 'ext-B',
+        raw: {},
+        primary_external_department_id: 'D-B',
+        primary_department_raw: {},
+      },
+      policyScopedRequester: {
+        integration_id: 'int-B-canonical',
+        account_id: 'acc-B-policy',
+        external_user_id: 'ext-B-policy',
+        raw: {},
+        primary_external_department_id: 'D-B',
+        primary_department_raw: {},
+      },
+      // Correct: org-anchored A account.
+      orgAnchoredRequester: {
+        integration_id: 'int-A',
+        account_id: 'acc-A',
+        external_user_id: 'ext-A',
+        raw: {},
+        primary_external_department_id: 'D-A',
+        primary_department_raw: {},
+      },
+      // Policy only in foreign org B — must be invisible when orgId=A.
+      policies: [
+        {
+          org_id: 'org-B',
+          canonical_integration_id: 'int-B-canonical',
+          canonical_status: 'active',
+        },
+      ],
+      // Only the A manager is linked so a B-steered path cannot accidentally share the same id.
+      // Path discrimination is primarily lastPolicyCanonicalParam / lastOrgIdParam / lastRequesterSql.
+      normalizedDeptManagers: [{ account_id: 'acc-A-mgr', external_user_id: 'ext-A-mgr' }],
+      localByAccountId: { 'acc-A-mgr': 'local-A-mgr' },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db), { orgId: 'org-A' })
+    // Probe was tenant-scoped and saw zero same-org policies → org-anchored A pick.
+    expect(db.lastPolicySql).toContain('p.org_id = $2')
+    expect(db.lastPolicyOrgIdParam).toBe('org-A')
+    expect(db.lastPolicyCanonicalParam).toBeNull()
+    expect(db.lastOrgIdParam).toBe('org-A')
+    expect(db.lastRequesterSql).toContain('di.org_id = $2')
+    expect(result.managerId).toBe('local-A-mgr')
+  })
+
+  it('tenant boundary: same-org policy + orgId=A selects the policy canonical integration (authoritative within A)', async () => {
+    const db: FakeDbWithTrace = {
+      // Org-anchored would pick a non-canonical A integration (wrong under policy).
+      orgAnchoredRequester: {
+        integration_id: 'int-A-other',
+        account_id: 'acc-A-other',
+        external_user_id: 'ext-A-other',
+        raw: {},
+        primary_external_department_id: 'D-A',
+        primary_department_raw: {},
+      },
+      // Policy-scoped canonical account inside A.
+      policyScopedRequester: {
+        integration_id: 'int-A-canonical',
+        account_id: 'acc-A-canonical',
+        external_user_id: 'ext-A-canonical',
+        raw: {},
+        primary_external_department_id: 'D-A',
+        primary_department_raw: {},
+      },
+      requester: {
+        integration_id: 'int-A-other',
+        account_id: 'acc-A-other',
+        external_user_id: 'ext-A-other',
+        raw: {},
+        primary_external_department_id: 'D-A',
+        primary_department_raw: {},
+      },
+      policies: [
+        {
+          org_id: 'org-A',
+          canonical_integration_id: 'int-A-canonical',
+          canonical_status: 'active',
+        },
+      ],
+      normalizedDeptManagers: [{ account_id: 'acc-A-canon-mgr', external_user_id: 'ext-A-canon-mgr' }],
+      localByAccountId: { 'acc-A-canon-mgr': 'local-A-canon-mgr' },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db), { orgId: 'org-A' })
+    expect(db.lastPolicySql).toContain('p.org_id = $2')
+    expect(db.lastPolicyOrgIdParam).toBe('org-A')
+    expect(db.lastPolicyCanonicalParam).toBe('int-A-canonical')
+    expect(db.lastOrgIdParam).toBeNull() // not the org-anchored path
+    expect(db.lastRequesterSql).toMatch(/a\.integration_id = \$2/)
+    expect(result.managerId).toBe('local-A-canon-mgr')
+  })
+
+  it('tenant boundary: two policies (A+B) with orgId=A considers only A (no multi-org fail-close)', async () => {
+    const db: FakeDbWithTrace = {
+      policyScopedRequester: {
+        integration_id: 'int-A-canonical',
+        account_id: 'acc-A-canonical',
+        external_user_id: 'ext-A-canonical',
+        raw: {},
+        primary_external_department_id: 'D-A',
+        primary_department_raw: {},
+      },
+      orgAnchoredRequester: {
+        integration_id: 'int-A-other',
+        account_id: 'acc-A-other',
+        external_user_id: 'ext-A-other',
+        raw: {},
+        primary_external_department_id: 'D-A',
+        primary_department_raw: {},
+      },
+      policies: [
+        {
+          org_id: 'org-A',
+          canonical_integration_id: 'int-A-canonical',
+          canonical_status: 'active',
+        },
+        {
+          org_id: 'org-B',
+          canonical_integration_id: 'int-B-canonical',
+          canonical_status: 'active',
+        },
+      ],
+      normalizedDeptManagers: [{ account_id: 'acc-A-canon-mgr', external_user_id: 'ext-A-canon-mgr' }],
+      localByAccountId: { 'acc-A-canon-mgr': 'local-A-canon-mgr' },
+    }
+    // Must NOT throw multi-org ambiguity — B is filtered by p.org_id = $2.
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db), { orgId: 'org-A' })
+    expect(db.lastPolicyOrgIdParam).toBe('org-A')
+    expect(db.lastPolicyCanonicalParam).toBe('int-A-canonical')
+    expect(result.managerId).toBe('local-A-canon-mgr')
+  })
+
+  it('B5-b Q4 unchanged: no-orgId + two governed orgs still fail-closes (multi-org ambiguity)', async () => {
+    const db: FakeDbWithTrace = {
+      requester: {
+        integration_id: 'int-A',
+        account_id: 'acc-A',
+        external_user_id: 'ext-A',
+        raw: {},
+        primary_external_department_id: 'D-A',
+        primary_department_raw: {},
+      },
+      policies: [
+        {
+          org_id: 'org-A',
+          canonical_integration_id: 'int-A-canonical',
+          canonical_status: 'active',
+        },
+        {
+          org_id: 'org-B',
+          canonical_integration_id: 'int-B-canonical',
+          canonical_status: 'active',
+        },
+      ],
+    }
+    await expect(
+      resolveApprovalRequesterOrgRelations('local-req', makeQuery(db)),
+    ).rejects.toBeInstanceOf(ApprovalRoutingPolicyError)
+    // Kernel path: unscoped probe (no p.org_id = $2), so both policies are visible.
+    expect(db.lastPolicySql).toBeTruthy()
+    expect(db.lastPolicySql).not.toContain('p.org_id = $2')
+    expect(db.lastPolicyOrgIdParam).toBeNull()
+  })
+
+  it('mutation demo: without p.org_id = $2 the foreign-policy case steers wrong (predicate is load-bearing)', async () => {
+    // Same fixture as the foreign-policy tenant-boundary test, but the probe deliberately
+    // omits the tenant predicate — simulating a production mutation that drops only
+    // `AND p.org_id = $2`. The foreign org-B policy becomes visible, steers the pick to
+    // B's canonical integration, and yields local-B-mgr instead of local-A-mgr.
+    // same-org / no-orgId controls remain independently meaningful elsewhere in this file.
+    const db: FakeDbWithTrace = {
+      requester: {
+        integration_id: 'int-B-canonical',
+        account_id: 'acc-B',
+        external_user_id: 'ext-B',
+        raw: {},
+        primary_external_department_id: 'D-B',
+        primary_department_raw: {},
+      },
+      policyScopedRequester: {
+        integration_id: 'int-B-canonical',
+        account_id: 'acc-B-policy',
+        external_user_id: 'ext-B-policy',
+        raw: {},
+        primary_external_department_id: 'D-B',
+        primary_department_raw: {},
+      },
+      orgAnchoredRequester: {
+        integration_id: 'int-A',
+        account_id: 'acc-A',
+        external_user_id: 'ext-A',
+        raw: {},
+        primary_external_department_id: 'D-A',
+        primary_department_raw: {},
+      },
+      policies: [
+        {
+          org_id: 'org-B',
+          canonical_integration_id: 'int-B-canonical',
+          canonical_status: 'active',
+        },
+      ],
+      // B manager only — when foreign policy steers, this is the linked manager for the B account.
+      // With the production predicate the same fixture yields A (org-anchor; see sibling test).
+      normalizedDeptManagers: [{ account_id: 'acc-B-mgr', external_user_id: 'ext-B-mgr' }],
+      localByAccountId: { 'acc-B-mgr': 'local-B-mgr' },
+    }
+
+    // Broken probe: always return ALL policies (as if production dropped p.org_id = $2).
+    // Requester / manager branches still use the real makeQuery shapes.
+    const realQuery = makeQuery(db)
+    const mutatedQuery: typeof realQuery = async <Row>(text: string, params?: unknown[]) => {
+      if (text.includes('FROM directory_account_links l') && text.includes('org_directory_routing_policy')) {
+        db.lastPolicySql = text
+        // MUTATION: ignore any org predicate; expose every policy row.
+        db.lastPolicyOrgIdParam = null
+        return { rows: (db.policies ?? []) as Row[] }
+      }
+      return realQuery<Row>(text, params)
+    }
+
+    const result = await resolveApprovalRequesterOrgRelations('local-req', mutatedQuery, { orgId: 'org-A' })
+    // Production WITH the predicate: foreign policy filtered → org-anchor A (sibling test).
+    // Without it: foreign policy steers → policy-scoped B → canonical int-B-canonical.
+    // That lastPolicyCanonicalParam flip is the load-bearing red reason.
+    expect(db.lastPolicyCanonicalParam).toBe('int-B-canonical')
+    expect(result.managerId).toBe('local-B-mgr')
   })
 })

--- a/packages/core-backend/tests/unit/approval-directory-org.test.ts
+++ b/packages/core-backend/tests/unit/approval-directory-org.test.ts
@@ -29,6 +29,8 @@ interface FakeDb {
   localByAccountId?: Record<string, string | null>
   // external_user_id -> linked local user id
   localByExternalId?: Record<string, string | null>
+  // B5-b routing-policy probe rows (default undefined/empty = no policy = legacy path)
+  policies?: Array<{ org_id: string; canonical_integration_id: string; canonical_status: string | null }>
 }
 
 function makeQuery(db: FakeDb & {
@@ -39,6 +41,13 @@ function makeQuery(db: FakeDb & {
   lastRequesterSql?: string
 }) {
   return async <Row>(text: string, params?: unknown[]): Promise<{ rows: Row[] }> => {
+    // B5-b routing-policy probe (`org_directory_routing_policy`). Default-empty means NO policy
+    // governs any org the user is linked in, so the resolver runs the LEGACY path byte-identical —
+    // which is why every pre-B5 fixture below keeps its expectations unchanged (same convention as
+    // the B3 normalized-manager default-empty note further down). Policy scenarios set db.policies.
+    if (text.includes('FROM directory_account_links l') && text.includes('org_directory_routing_policy')) {
+      return { rows: (db.policies ?? []) as Row[] }
+    }
     if (text.includes('FROM directory_account_links l') && text.includes('LEFT JOIN directory_account_departments')) {
       db.lastRequesterSql = text
       // Org-anchored SELECT joins directory_integrations and binds org_id as $2.

--- a/packages/core-backend/tests/unit/approval-directory-org.test.ts
+++ b/packages/core-backend/tests/unit/approval-directory-org.test.ts
@@ -58,10 +58,10 @@ function makeQuery(db: FakeDbWithTrace) {
     // which is why every pre-B5 fixture below keeps its expectations unchanged (same convention as
     // the B3 normalized-manager default-empty note further down). Policy scenarios set db.policies.
     //
-    // LOAD-BEARING MIRROR of production tenant boundary: when the probe SQL includes
-    // `p.org_id = $2`, only that org's policy rows are visible. Removing the production
-    // predicate (so this fragment is absent) makes the fake return ALL policies — and the
-    // foreign-policy discrimination tests below go red for the right reason.
+    // When production SQL includes `p.org_id = $2`, filter fixture rows to that org so the unit
+    // boundary cases below stay meaningful. This is NOT the load-bearing proof of the tenant
+    // boundary — that lives in org-directory-routing-policy-resolver.db.test.ts case F (real
+    // Postgres). Do not add permanent tests that assert vulnerable B-steering via a mutated fake.
     if (text.includes('FROM directory_account_links l') && text.includes('org_directory_routing_policy')) {
       db.lastPolicySql = text
       let rows = db.policies ?? []
@@ -584,70 +584,5 @@ describe('resolveApprovalRequesterOrgRelations', () => {
     expect(db.lastPolicySql).toBeTruthy()
     expect(db.lastPolicySql).not.toContain('p.org_id = $2')
     expect(db.lastPolicyOrgIdParam).toBeNull()
-  })
-
-  it('mutation demo: without p.org_id = $2 the foreign-policy case steers wrong (predicate is load-bearing)', async () => {
-    // Same fixture as the foreign-policy tenant-boundary test, but the probe deliberately
-    // omits the tenant predicate — simulating a production mutation that drops only
-    // `AND p.org_id = $2`. The foreign org-B policy becomes visible, steers the pick to
-    // B's canonical integration, and yields local-B-mgr instead of local-A-mgr.
-    // same-org / no-orgId controls remain independently meaningful elsewhere in this file.
-    const db: FakeDbWithTrace = {
-      requester: {
-        integration_id: 'int-B-canonical',
-        account_id: 'acc-B',
-        external_user_id: 'ext-B',
-        raw: {},
-        primary_external_department_id: 'D-B',
-        primary_department_raw: {},
-      },
-      policyScopedRequester: {
-        integration_id: 'int-B-canonical',
-        account_id: 'acc-B-policy',
-        external_user_id: 'ext-B-policy',
-        raw: {},
-        primary_external_department_id: 'D-B',
-        primary_department_raw: {},
-      },
-      orgAnchoredRequester: {
-        integration_id: 'int-A',
-        account_id: 'acc-A',
-        external_user_id: 'ext-A',
-        raw: {},
-        primary_external_department_id: 'D-A',
-        primary_department_raw: {},
-      },
-      policies: [
-        {
-          org_id: 'org-B',
-          canonical_integration_id: 'int-B-canonical',
-          canonical_status: 'active',
-        },
-      ],
-      // B manager only — when foreign policy steers, this is the linked manager for the B account.
-      // With the production predicate the same fixture yields A (org-anchor; see sibling test).
-      normalizedDeptManagers: [{ account_id: 'acc-B-mgr', external_user_id: 'ext-B-mgr' }],
-      localByAccountId: { 'acc-B-mgr': 'local-B-mgr' },
-    }
-
-    // Broken probe: always return ALL policies (as if production dropped p.org_id = $2).
-    // Requester / manager branches still use the real makeQuery shapes.
-    const realQuery = makeQuery(db)
-    const mutatedQuery: typeof realQuery = async <Row>(text: string, params?: unknown[]) => {
-      if (text.includes('FROM directory_account_links l') && text.includes('org_directory_routing_policy')) {
-        db.lastPolicySql = text
-        // MUTATION: ignore any org predicate; expose every policy row.
-        db.lastPolicyOrgIdParam = null
-        return { rows: (db.policies ?? []) as Row[] }
-      }
-      return realQuery<Row>(text, params)
-    }
-
-    const result = await resolveApprovalRequesterOrgRelations('local-req', mutatedQuery, { orgId: 'org-A' })
-    // Production WITH the predicate: foreign policy filtered → org-anchor A (sibling test).
-    // Without it: foreign policy steers → policy-scoped B → canonical int-B-canonical.
-    // That lastPolicyCanonicalParam flip is the load-bearing red reason.
-    expect(db.lastPolicyCanonicalParam).toBe('int-B-canonical')
-    expect(result.managerId).toBe('local-B-mgr')
   })
 })

--- a/packages/core-backend/tests/unit/approval-manager-chain.test.ts
+++ b/packages/core-backend/tests/unit/approval-manager-chain.test.ts
@@ -33,6 +33,11 @@ interface OrgModel {
 
 function makeOrgQuery(org: OrgModel) {
   return async <Row>(text: string, params?: unknown[]): Promise<{ rows: Row[] }> => {
+    // 0) B5-b routing-policy probe (`org_directory_routing_policy`). Empty rows = no policy
+    //    → legacy fixture path (same contract as pre-B5-b). Do not stub other SQL shapes here.
+    if (text.includes('FROM directory_account_links l') && text.includes('org_directory_routing_policy')) {
+      return { rows: [] }
+    }
     // 1) requester lookup by local user id
     if (text.includes('FROM directory_account_links l') && text.includes('LEFT JOIN directory_account_departments')) {
       if (String(params?.[0]) !== org.requesterLocalId) return { rows: [] }

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -149,6 +149,11 @@ export default defineConfig({
       // wired as a WHOLE FILE into the directory real-DB step (both points asserted by
       // b5b-routing-resolver-ci-wiring.test.mjs).
       'tests/integration/org-directory-routing-policy-resolver.db.test.ts',
+      // B5-b owner P1 (fail-open closure): broken/unreadable routing policy must fail-close ALL
+      // FOUR org assignee sources at approval create (422/503, zero instances, zero assignments) —
+      // real MetaSheetServer + real createApproval. DATABASE_URL-gated; wired as a WHOLE FILE into
+      // the APPROVAL real-DB step (both points asserted by b5b-failclose-ci-wiring.test.mjs).
+      'tests/integration/approval-routing-policy-failclose.api.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
       // resolution against real Postgres — normalized `is_manager` relation for a local integration,
       // the DingTalk `leader_in_dept` regression pin (load-bearing compat leg + is_manager=0 positive

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -142,6 +142,13 @@ export default defineConfig({
       // WHOLE FILE into the directory real-DB step in plugin-tests.yml (both points asserted by
       // b5a-routing-policy-ci-wiring.test.mjs so neither can silently drop).
       'tests/integration/org-directory-routing-policy-schema.db.test.ts',
+      // Canonical Org MVP B5-b (design lock Lock 2 + Q4): the routing-policy RESOLVER — policy-
+      // authoritative vs latest-updated guessing, fail-closed on broken canonical, multi-org
+      // ambiguity, data-absence {} semantics, and the no-policy legacy control. Real-DB end-to-end
+      // through resolveApprovalRequesterOrgRelations — meaningless without a DB. DATABASE_URL-gated;
+      // wired as a WHOLE FILE into the directory real-DB step (both points asserted by
+      // b5b-routing-resolver-ci-wiring.test.mjs).
+      'tests/integration/org-directory-routing-policy-resolver.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
       // resolution against real Postgres — normalized `is_manager` relation for a local integration,
       // the DingTalk `leader_in_dept` regression pin (load-bearing compat leg + is_manager=0 positive

--- a/scripts/ops/b5b-failclose-ci-wiring.test.mjs
+++ b/scripts/ops/b5b-failclose-ci-wiring.test.mjs
@@ -4,11 +4,12 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 
-// B5-b CI two-point wiring contract. The routing-policy schema suite proves the resolver over the (org,purpose)
-// policy store's DB invariants (cross-org FK-impossible, closed purpose set, RESTRICT) against real
-// Postgres — meaningless without a DB. It needs BOTH (1) the vitest.config.ts exclude (so the no-DB
-// job cannot skip-green it) AND (2) the plugin-tests.yml directory real-DB whole-file step. Removing
-// either point silently disables the proof while CI stays green. Runs in the gating no-DB test job.
+// B5-b P1 fail-close CI two-point wiring contract. The fail-close suite proves a broken/unreadable
+// routing policy fail-closes ALL FOUR org assignee sources at approval create (422/503, zero
+// instances, zero assignments) against a real server + real Postgres — meaningless without a DB.
+// It needs BOTH (1) the vitest.config.ts exclude (so the no-DB job cannot skip-green it) AND
+// (2) the plugin-tests.yml APPROVAL real-DB whole-file step. Removing either point silently
+// disables the fail-open regression proof while CI stays green. Runs in the gating no-DB test job.
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '..', '..')
 const FILE = 'tests/integration/approval-routing-policy-failclose.api.test.ts'

--- a/scripts/ops/b5b-failclose-ci-wiring.test.mjs
+++ b/scripts/ops/b5b-failclose-ci-wiring.test.mjs
@@ -1,0 +1,24 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// B5-b CI two-point wiring contract. The routing-policy schema suite proves the resolver over the (org,purpose)
+// policy store's DB invariants (cross-org FK-impossible, closed purpose set, RESTRICT) against real
+// Postgres — meaningless without a DB. It needs BOTH (1) the vitest.config.ts exclude (so the no-DB
+// job cannot skip-green it) AND (2) the plugin-tests.yml directory real-DB whole-file step. Removing
+// either point silently disables the proof while CI stays green. Runs in the gating no-DB test job.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/approval-routing-policy-failclose.api.test.ts'
+
+test('vitest.config.ts excludes the B5-b routing-policy suite from the no-DB job', () => {
+  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+})
+
+test('plugin-tests.yml runs the B5-b routing-policy suite as a whole file in the approval real-DB step', () => {
+  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  assert.match(wf, new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${FILE}`)
+})

--- a/scripts/ops/b5b-routing-resolver-ci-wiring.test.mjs
+++ b/scripts/ops/b5b-routing-resolver-ci-wiring.test.mjs
@@ -1,0 +1,24 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// B5-b CI two-point wiring contract. The routing-policy schema suite proves the resolver over the (org,purpose)
+// policy store's DB invariants (cross-org FK-impossible, closed purpose set, RESTRICT) against real
+// Postgres — meaningless without a DB. It needs BOTH (1) the vitest.config.ts exclude (so the no-DB
+// job cannot skip-green it) AND (2) the plugin-tests.yml directory real-DB whole-file step. Removing
+// either point silently disables the proof while CI stays green. Runs in the gating no-DB test job.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/org-directory-routing-policy-resolver.db.test.ts'
+
+test('vitest.config.ts excludes the B5-b routing-policy suite from the no-DB job', () => {
+  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+})
+
+test('plugin-tests.yml runs the B5-b routing-policy suite as a whole file in the directory real-DB step', () => {
+  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  assert.match(wf, new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${FILE}`)
+})


### PR DESCRIPTION
## B5-b - policy-authoritative approval routing resolver

> **HELD/unarmed for exact-head CI and single-window landing.** Base is `main`. Prerequisite B5-a landed as #4429 / `81aff8203`. Current B5-b scope is 10 files; no migration is added here.

### Runtime behavior

- No `approval_routing` policy: preserve the legacy requester-account selection path.
- One policy: resolve only through its canonical integration; never fall back to "latest integration wins".
- Missing or inactive canonical integration: fail closed with typed `ApprovalRoutingPolicyError`.
- Policies in more than one linked org: fail closed as an explicit multi-org ambiguity.
- When a caller supplies `orgId`, treat it as a tenant boundary: only that org's policy may steer routing; foreign-org policies are invisible. Omitting `orgId` preserves the Q4 multi-org ambiguity contract.
- Requester absent from an otherwise healthy canonical integration: return `{}` as genuine data absence.
- Approval create and the shared preview substrate distinguish persistent policy misconfiguration (`422 APPROVAL_ROUTING_POLICY_MISCONFIGURED`) from transient directory reads (`503 APPROVAL_REQUESTER_ORG_UNRESOLVED`) before any approval instance or assignment is created.

### Review hardening

- Replaced the former shared-schema `ALTER TABLE ... RENAME` fault injection with a test-local `vi.spyOn` wrapper on the real `pg.Pool.query`. It throws only for the policy probe while a scoped flag is enabled, delegates every other overload argument with `Reflect.apply`, resets after each test, and restores the exact method after the suite.
- Added independent HTTP cases for both preview surfaces:
  - `POST /api/approvals/preview`
  - `POST /api/approval-templates/:id/route-preview`
- Each surface separately proves `422` for a broken policy, `503` for a transient read failure, and zero approval instances/assignments.
- Corrected the service comment: successful absence remains best-effort; failed reads fail closed only when the graph consumes org-derived routing data.
- Fixed the required-CI regression in the strict legacy manager-chain fixture by recognizing only the new routing-policy probe and returning no policy rows. All other unknown SQL shapes still throw.
- Rebased over the attendance direct-manager work and closed the resulting cross-org composition gap: the scoped policy probe now binds `p.org_id = $2`, with unit and real-Postgres coverage for foreign-only policy, same-org precedence, and the unscoped Q4 fail-close path.

### Load-bearing evidence

- Removing the canonical-integration predicate restores guessing and reddens the policy-authoritative resolver case.
- Removing the active-canonical guard reddens the broken-target case.
- Disabling the create/preview fail-close guard produces 6 independent failures: broken-policy create, transient create, and both preview endpoints under both `422` and `503` conditions. Positive manager and genuine-no-manager controls remain green.
- CI wiring is pinned at both points: excluded from the no-DB lane and included as a whole file in the Node 20 approval real-DB lane.
- Removing the strict fixture's routing-policy branch reproduces the exact CI failure: 8 manager-chain cases fail and the other 10 remain green; restoring it returns the file to 18/18.
- Semantic tenant-boundary mutation: replacing `p.org_id = $2` with a bind-compatible tautology makes the real-DB F case route org A to `OrgB Policy Title`; restoring the predicate returns the file to 7/7. This is not a parameter-count or SQL-bind failure.

### Fresh verification after retargeting to main

- Clean PostgreSQL migration chain: pass.
- Current-head focused unit suites: 57/57.
- Current-head resolver/fail-close/direct-manager/attendance/manager-chain real-DB suites: 41/41 on an independently created and fully migrated database.
- Grok's combined post-rebase battery: 102/102.
- Legacy manager-chain fixture: 18/18; mutation: 8 failed / 10 passed.
- Pre-final-rebase full backend no-DB lane: 495 files passed, 6790 tests passed, 184 files / 1634 tests skipped; the final exact-head full signal is delegated to required GitHub CI below.
- CI wiring contracts: 4/4.
- `pnpm --filter @metasheet/core-backend type-check`: pass.
- `git diff --check`: pass.

Implementation/test hardening was delegated to Grok Build. Codex independently reviewed the full 10-file diff, rejected two initial test-evidence defects, created a separate fresh database, reran the focused unit/real-DB suites, and replayed the runtime guard, strict-fixture, and bind-compatible tenant-boundary mutations before this push. Required GitHub checks on the new head remain the landing gate.
