### PR TITLE
feat(directory): B5-c — routing-policy admin routes (list / set-clear / read-only preview)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -188,6 +188,10 @@ jobs:
       - name: B5-b fail-close CI wiring contract
         run: node --test scripts/ops/b5b-failclose-ci-wiring.test.mjs
 
+      # B5-c CI two-point wiring contract (no DB).
+      - name: B5-c routing-routes CI wiring contract
+        run: node --test scripts/ops/b5c-routing-routes-ci-wiring.test.mjs
+
       # The production monitor invokes the same state helper covered here.
       # Keep this in the required 18/20 matrix so HTTP classification, silence
       # barriers, and alert/recovery streak semantics cannot drift silently.
@@ -664,6 +668,7 @@ jobs:
             tests/integration/directory-department-bindings.db.test.ts \
             tests/integration/org-directory-routing-policy-schema.db.test.ts \
             tests/integration/org-directory-routing-policy-resolver.db.test.ts \
+            tests/integration/org-directory-routing-policy-routes.db.test.ts \
             tests/integration/directory-normalized-manager.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             tests/integration/attendance-notification-redelivery.db.test.ts \

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -172,6 +172,7 @@ import { initAdminRoutes } from './routes/admin-routes'
 import { adminUsersRouter } from './routes/admin-users'
 import { adminDirectoryRouter } from './routes/admin-directory'
 import { adminDirectoryLocalRouter } from './routes/admin-directory-local'
+import { adminDirectoryRoutingPolicyRouter } from './routes/admin-directory-routing-policy'
 import { startDirectorySyncScheduler, stopDirectorySyncScheduler } from './directory/directory-sync-scheduler'
 import { canaryRoutes } from './routes/canary-routes'
 import { CanaryRouter } from './canary/CanaryRouter'
@@ -1356,6 +1357,7 @@ export class MetaSheetServer {
     // Canonical Org MVP B2 (local departments/accounts/memberships CRUD) — mounted alongside
     // adminDirectoryRouter under the same base path, sharing its `ensurePlatformAdmin` RBAC gate.
     this.app.use('/api/admin/directory/local', adminDirectoryLocalRouter())
+    this.app.use('/api/admin/directory/routing-policy', adminDirectoryRoutingPolicyRouter())
 
     // Canary routing (behind ENABLE_CANARY_ROUTING feature flag)
     const canaryEnabled = process.env.ENABLE_CANARY_ROUTING === 'true'

--- a/packages/core-backend/src/routes/admin-directory-routing-policy.ts
+++ b/packages/core-backend/src/routes/admin-directory-routing-policy.ts
@@ -3,7 +3,7 @@ import { Router } from 'express'
 import { auditLog } from '../audit/audit'
 import { Logger } from '../core/logger'
 import { ensurePlatformAdmin } from './admin-directory'
-import { query } from '../db/pg'
+import { query, transaction } from '../db/pg'
 import { resolveApprovalRequesterOrgRelations } from '../services/ApprovalDirectoryOrg'
 import { jsonError, jsonOk } from '../util/response'
 
@@ -187,35 +187,68 @@ export function adminDirectoryRoutingPolicyRouter(): Router {
         return
       }
 
-      const integration = await loadOrgIntegration(orgId, canonical)
-      if (!integration) {
+      // TOCTOU close (write-point): active-target validation and the policy upsert MUST share one
+      // transaction, and the target integration row is locked `FOR SHARE` at the write point
+      // through commit. A concurrent disable that commits between a separate SELECT and INSERT
+      // would otherwise accept a policy pointing at a now-inactive target (B5-b would then
+      // fail-close every consuming approval). `FOR SHARE` conflicts with the exclusive row lock
+      // a status UPDATE takes, so the two serialize: disable-first → PATCH re-reads inactive →
+      // 409 with zero write; set-first → set commits, then disable, resolver fails closed.
+      // Audit is deliberately POST-commit (and values-free) so a rolled-back / rejected write
+      // never leaves a partial audit trail.
+      type WriteOutcome =
+        | { kind: 'not_found' }
+        | { kind: 'not_active' }
+        | { kind: 'local_not_enabled' }
+        | { kind: 'ok'; provider: string }
+
+      const outcome = await transaction(async (client) => {
+        const locked = await client.query(
+          `SELECT id::text AS id, provider, status
+             FROM directory_integrations
+            WHERE id = $1::uuid AND org_id = $2
+            FOR SHARE`,
+          [canonical, orgId],
+        )
+        const integration = (locked.rows[0] as IntegrationRow | undefined) ?? null
+        if (!integration) return { kind: 'not_found' } satisfies WriteOutcome
+        if (integration.status !== 'active') {
+          // fail at WRITE time — a policy pointing at a broken target would fail-close every
+          // policy-consuming approval later (B5-b), which is strictly worse than rejecting here.
+          return { kind: 'not_active' } satisfies WriteOutcome
+        }
+        // Owner review (#4431): switching approval routing to the LOCAL provider is a capability
+        // decision, not a config edit — it must be explicitly enabled (env-gate, default OFF, the
+        // repo's staged-opt-in pattern) after the owner accepts the B6 parity evidence for the
+        // deployment. Until then a local canonical is rejected at the WRITE surface. (Preview stays
+        // available for local candidates on purpose — it is the read-only evidence tool for making
+        // exactly this decision.)
+        if (integration.provider === 'local' && !isLocalCanonicalEnabled()) {
+          return { kind: 'local_not_enabled' } satisfies WriteOutcome
+        }
+        await client.query(
+          `INSERT INTO org_directory_routing_policy (org_id, purpose, canonical_integration_id)
+           VALUES ($1, $2, $3)
+           ON CONFLICT ON CONSTRAINT orp_org_purpose_uniq
+           DO UPDATE SET canonical_integration_id = EXCLUDED.canonical_integration_id, updated_at = NOW()`,
+          [orgId, purpose, canonical],
+        )
+        return { kind: 'ok', provider: integration.provider } satisfies WriteOutcome
+      })
+
+      if (outcome.kind === 'not_found') {
         jsonError(res, 404, 'ROUTING_POLICY_INTEGRATION_NOT_FOUND', 'Integration not found in this organization')
         return
       }
-      if (integration.status !== 'active') {
-        // fail at WRITE time — a policy pointing at a broken target would fail-close every
-        // policy-consuming approval later (B5-b), which is strictly worse than rejecting here.
+      if (outcome.kind === 'not_active') {
         jsonError(res, 409, 'ROUTING_POLICY_TARGET_NOT_ACTIVE', 'The target integration is not active')
         return
       }
-      // Owner review (#4431): switching approval routing to the LOCAL provider is a capability
-      // decision, not a config edit — it must be explicitly enabled (env-gate, default OFF, the
-      // repo's staged-opt-in pattern) after the owner accepts the B6 parity evidence for the
-      // deployment. Until then a local canonical is rejected at the WRITE surface. (Preview stays
-      // available for local candidates on purpose — it is the read-only evidence tool for making
-      // exactly this decision.)
-      if (integration.provider === 'local' && !isLocalCanonicalEnabled()) {
+      if (outcome.kind === 'local_not_enabled') {
         jsonError(res, 409, 'ROUTING_POLICY_LOCAL_NOT_ENABLED', 'Routing to the local provider is not enabled (set DIRECTORY_ROUTING_LOCAL_CANONICAL_ENABLED=1 after accepting parity evidence)')
         return
       }
 
-      await query(
-        `INSERT INTO org_directory_routing_policy (org_id, purpose, canonical_integration_id)
-         VALUES ($1, $2, $3)
-         ON CONFLICT ON CONSTRAINT orp_org_purpose_uniq
-         DO UPDATE SET canonical_integration_id = EXCLUDED.canonical_integration_id, updated_at = NOW()`,
-        [orgId, purpose, canonical],
-      )
       await auditLog({
         actorId: adminUserId,
         actorType: 'user',
@@ -225,7 +258,7 @@ export function adminDirectoryRoutingPolicyRouter(): Router {
         // values-free: ids only, no config echo
         meta: { orgId, purpose, integrationId: canonical },
       })
-      jsonOk(res, { policy: { purpose, canonicalIntegrationId: canonical, canonicalProvider: integration.provider } })
+      jsonOk(res, { policy: { purpose, canonicalIntegrationId: canonical, canonicalProvider: outcome.provider } })
     } catch (error) {
       logger.error(`Failed to set routing policy: ${error instanceof Error ? error.message : 'unknown'}`)
       jsonError(res, 500, 'ROUTING_POLICY_WRITE_FAILED', 'Failed to update the routing policy')

--- a/packages/core-backend/src/routes/admin-directory-routing-policy.ts
+++ b/packages/core-backend/src/routes/admin-directory-routing-policy.ts
@@ -1,0 +1,306 @@
+import type { Request, Response } from 'express'
+import { Router } from 'express'
+import { auditLog } from '../audit/audit'
+import { Logger } from '../core/logger'
+import { ensurePlatformAdmin } from './admin-directory'
+import { query } from '../db/pg'
+import { resolveApprovalRequesterOrgRelations } from '../services/ApprovalDirectoryOrg'
+import { jsonError, jsonOk } from '../util/response'
+
+const logger = new Logger('AdminDirectoryRoutingPolicyRoutes')
+
+// Same single-tenant org resolution convention as admin-directory-local.ts (see the long comment
+// there): org identity is NEVER read from the request — this is what makes org_id unspoofable.
+const DEFAULT_ORG_ID = 'default'
+function resolveOrgId(_req: Request): string {
+  return DEFAULT_ORG_ID
+}
+
+/** Mirrors the `orp_purpose_chk` CHECK — the §6 closed purpose set. */
+const PURPOSES = [
+  'approval_routing',
+  'permission_scope',
+  'attendance_expansion',
+  'member_group_projection',
+  'automation_recipient_resolution',
+] as const
+type Purpose = (typeof PURPOSES)[number]
+
+function isPurpose(value: string): value is Purpose {
+  return (PURPOSES as readonly string[]).includes(value)
+}
+
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+function isUuidShaped(value: string): boolean {
+  return UUID_SHAPE.test(value)
+}
+
+interface PolicyRow {
+  purpose: string
+  canonical_integration_id: string
+  canonical_provider: string
+  canonical_status: string
+  fallback_integration_id: string | null
+  updated_at: string
+}
+
+interface IntegrationRow {
+  id: string
+  provider: string
+  status: string
+}
+
+async function loadOrgIntegration(orgId: string, integrationId: string): Promise<IntegrationRow | null> {
+  const r = await query<IntegrationRow>(
+    `SELECT id::text AS id, provider, status FROM directory_integrations WHERE id = $1::uuid AND org_id = $2`,
+    [integrationId, orgId],
+  )
+  return r.rows[0] ?? null
+}
+
+/**
+ * B5-c (design lock Lock 3 + §7): the routing-policy admin surface.
+ *
+ *   GET   /                       — every §6 purpose with its EFFECTIVE source: the stored policy
+ *                                   (canonical integration + provider/status) or 'legacy-default'
+ *                                   (no policy row → the resolver's byte-identical legacy path).
+ *   PATCH /:purpose               — the ONLY write point. `{ canonicalIntegrationId: uuid }` sets
+ *                                   (upsert; target must exist in THIS org and be 'active' — a
+ *                                   policy pointing at a broken target is rejected 409 at write
+ *                                   time instead of failing approvals later); `null` clears (back
+ *                                   to legacy). Values-free audit on both.
+ *   GET   /:purpose/preview       — READ-ONLY switch preview (v1: approval_routing only):
+ *                                   `?candidate=<integrationId>` resolves a sample of linked users
+ *                                   under the CURRENT effective source and AS-IF the candidate
+ *                                   were canonical (the resolver's preview override — the same
+ *                                   resolver both legs, so preview cannot drift from production),
+ *                                   and reports per-user dept/title/manager/dept-head diffs.
+ *                                   No writes, no policy row, no audit (design-lock Q5).
+ *
+ * All routes are platform-admin-only. Org identity is server-resolved (never from the request).
+ */
+export function adminDirectoryRoutingPolicyRouter(): Router {
+  const router = Router()
+
+  router.get('/', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    try {
+      const orgId = resolveOrgId(req)
+      const rows = await query<PolicyRow>(
+        `SELECT p.purpose,
+                p.canonical_integration_id::text AS canonical_integration_id,
+                i.provider                       AS canonical_provider,
+                i.status                         AS canonical_status,
+                p.fallback_integration_id::text  AS fallback_integration_id,
+                p.updated_at::text               AS updated_at
+           FROM org_directory_routing_policy p
+           JOIN directory_integrations i ON i.id = p.canonical_integration_id
+          WHERE p.org_id = $1`,
+        [orgId],
+      )
+      const byPurpose = new Map(rows.rows.map((r) => [r.purpose, r]))
+      const purposes = PURPOSES.map((purpose) => {
+        const p = byPurpose.get(purpose)
+        return p
+          ? {
+              purpose,
+              source: 'policy' as const,
+              canonicalIntegrationId: p.canonical_integration_id,
+              canonicalProvider: p.canonical_provider,
+              canonicalStatus: p.canonical_status,
+              fallbackIntegrationId: p.fallback_integration_id,
+              updatedAt: p.updated_at,
+            }
+          : { purpose, source: 'legacy-default' as const }
+      })
+      jsonOk(res, { orgId, purposes })
+    } catch (error) {
+      logger.error(`Failed to list routing policies: ${error instanceof Error ? error.message : 'unknown'}`)
+      jsonError(res, 500, 'ROUTING_POLICY_LIST_FAILED', 'Failed to list routing policies')
+    }
+  })
+
+  router.patch('/:purpose', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    const purpose = String(req.params.purpose ?? '')
+    if (!isPurpose(purpose)) {
+      jsonError(res, 400, 'ROUTING_POLICY_INVALID_PURPOSE', 'Unknown routing purpose')
+      return
+    }
+
+    // Field allowlist (B2 convention): ONLY canonicalIntegrationId; anything else — org/corp
+    // identity especially — is rejected loudly, never silently dropped.
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const extraKeys = Object.keys(body).filter((k) => k !== 'canonicalIntegrationId')
+    if (extraKeys.length > 0) {
+      jsonError(res, 400, 'ROUTING_POLICY_INVALID_INPUT', `Unexpected field(s): ${extraKeys.join(', ')}`)
+      return
+    }
+    if (!('canonicalIntegrationId' in body)) {
+      jsonError(res, 400, 'ROUTING_POLICY_INVALID_INPUT', 'canonicalIntegrationId is required (uuid to set, null to clear)')
+      return
+    }
+    const canonical = body.canonicalIntegrationId
+
+    try {
+      const orgId = resolveOrgId(req)
+
+      if (canonical === null) {
+        const deleted = await query<{ id: string }>(
+          `DELETE FROM org_directory_routing_policy WHERE org_id = $1 AND purpose = $2 RETURNING id`,
+          [orgId, purpose],
+        )
+        const cleared = deleted.rows.length > 0
+        if (cleared) {
+          await auditLog({
+            actorId: adminUserId,
+            actorType: 'user',
+            action: 'directory.routing_policy.clear',
+            resourceType: 'directory-routing-policy',
+            resourceId: `${orgId}:${purpose}`,
+            meta: { orgId, purpose },
+          })
+        }
+        jsonOk(res, { cleared })
+        return
+      }
+
+      if (typeof canonical !== 'string' || !isUuidShaped(canonical)) {
+        jsonError(res, 400, 'ROUTING_POLICY_INVALID_INPUT', 'canonicalIntegrationId must be a UUID or null')
+        return
+      }
+
+      const integration = await loadOrgIntegration(orgId, canonical)
+      if (!integration) {
+        jsonError(res, 404, 'ROUTING_POLICY_INTEGRATION_NOT_FOUND', 'Integration not found in this organization')
+        return
+      }
+      if (integration.status !== 'active') {
+        // fail at WRITE time — a policy pointing at a broken target would fail-close every
+        // policy-consuming approval later (B5-b), which is strictly worse than rejecting here.
+        jsonError(res, 409, 'ROUTING_POLICY_TARGET_NOT_ACTIVE', 'The target integration is not active')
+        return
+      }
+
+      await query(
+        `INSERT INTO org_directory_routing_policy (org_id, purpose, canonical_integration_id)
+         VALUES ($1, $2, $3)
+         ON CONFLICT ON CONSTRAINT orp_org_purpose_uniq
+         DO UPDATE SET canonical_integration_id = EXCLUDED.canonical_integration_id, updated_at = NOW()`,
+        [orgId, purpose, canonical],
+      )
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'directory.routing_policy.set',
+        resourceType: 'directory-routing-policy',
+        resourceId: `${orgId}:${purpose}`,
+        // values-free: ids only, no config echo
+        meta: { orgId, purpose, integrationId: canonical },
+      })
+      jsonOk(res, { policy: { purpose, canonicalIntegrationId: canonical, canonicalProvider: integration.provider } })
+    } catch (error) {
+      logger.error(`Failed to set routing policy: ${error instanceof Error ? error.message : 'unknown'}`)
+      jsonError(res, 500, 'ROUTING_POLICY_WRITE_FAILED', 'Failed to update the routing policy')
+    }
+  })
+
+  router.get('/:purpose/preview', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    const purpose = String(req.params.purpose ?? '')
+    if (purpose !== 'approval_routing') {
+      // v1 previews the FIRST consumer only (B6 scope); other purposes stay legacy until their own
+      // parity proofs exist (§10.2+).
+      jsonError(res, 400, 'ROUTING_POLICY_PREVIEW_UNSUPPORTED', 'v1 preview supports approval_routing only')
+      return
+    }
+    const candidate = typeof req.query.candidate === 'string' ? req.query.candidate : ''
+    if (!isUuidShaped(candidate)) {
+      jsonError(res, 400, 'ROUTING_POLICY_INVALID_INPUT', 'candidate must be an integration UUID')
+      return
+    }
+
+    try {
+      const orgId = resolveOrgId(req)
+      const integration = await loadOrgIntegration(orgId, candidate)
+      if (!integration) {
+        jsonError(res, 404, 'ROUTING_POLICY_INTEGRATION_NOT_FOUND', 'Candidate integration not found in this organization')
+        return
+      }
+      if (integration.status !== 'active') {
+        jsonError(res, 409, 'ROUTING_POLICY_TARGET_NOT_ACTIVE', 'The candidate integration is not active')
+        return
+      }
+
+      // Current effective source (for the report header + broken-current guard).
+      const current = await query<{ canonical_integration_id: string; status: string }>(
+        `SELECT p.canonical_integration_id::text AS canonical_integration_id, i.status
+           FROM org_directory_routing_policy p
+           JOIN directory_integrations i ON i.id = p.canonical_integration_id
+          WHERE p.org_id = $1 AND p.purpose = 'approval_routing'`,
+        [orgId],
+      )
+      const currentPolicy = current.rows[0] ?? null
+      if (currentPolicy && currentPolicy.status !== 'active') {
+        jsonError(res, 409, 'ROUTING_POLICY_MISCONFIGURED', 'The CURRENT routing policy points at a non-active integration; fix it before previewing a switch')
+        return
+      }
+
+      // Deterministic sample: users linked to any account in THIS org's integrations.
+      const sample = await query<{ local_user_id: string }>(
+        `SELECT DISTINCT l.local_user_id
+           FROM directory_account_links l
+           JOIN directory_accounts a ON a.id = l.directory_account_id AND a.is_active = true
+           JOIN directory_integrations i ON i.id = a.integration_id
+          WHERE l.link_status = 'linked' AND i.org_id = $1
+          ORDER BY l.local_user_id ASC
+          LIMIT 20`,
+        [orgId],
+      )
+
+      const rows = []
+      let changedCount = 0
+      for (const { local_user_id: userId } of sample.rows) {
+        // both legs run the REAL resolver — current = real probe; candidate = preview override
+        const before = await resolveApprovalRequesterOrgRelations(userId, query)
+        const after = await resolveApprovalRequesterOrgRelations(userId, query, {
+          overrideCanonicalIntegrationId: candidate,
+        })
+        const pick = (r: typeof before) => ({
+          departmentName: r.primaryDepartmentName ?? null,
+          title: r.primaryTitle ?? null,
+          managerId: r.managerId ?? null,
+          deptHeadId: r.deptHeadId ?? null,
+        })
+        const b = pick(before)
+        const a = pick(after)
+        const changed = JSON.stringify(b) !== JSON.stringify(a)
+        if (changed) changedCount++
+        rows.push({ userId, changed, before: b, after: a })
+      }
+
+      // READ-ONLY by design (Lock 3 / Q5): no policy write, no audit — a pure GET report.
+      jsonOk(res, {
+        orgId,
+        purpose,
+        current: currentPolicy
+          ? { source: 'policy', canonicalIntegrationId: currentPolicy.canonical_integration_id }
+          : { source: 'legacy-default' },
+        candidate: { integrationId: candidate, provider: integration.provider },
+        sampleSize: rows.length,
+        changedCount,
+        rows,
+      })
+    } catch (error) {
+      logger.error(`Failed to preview routing policy: ${error instanceof Error ? error.message : 'unknown'}`)
+      jsonError(res, 500, 'ROUTING_POLICY_PREVIEW_FAILED', 'Failed to compute the routing preview')
+    }
+  })
+
+  return router
+}

--- a/packages/core-backend/src/routes/admin-directory-routing-policy.ts
+++ b/packages/core-backend/src/routes/admin-directory-routing-policy.ts
@@ -30,6 +30,12 @@ function isPurpose(value: string): value is Purpose {
   return (PURPOSES as readonly string[]).includes(value)
 }
 
+/** Owner review (#4431): default-OFF capability gate for canonical=local (staged opt-in pattern). */
+function isLocalCanonicalEnabled(): boolean {
+  const v = process.env.DIRECTORY_ROUTING_LOCAL_CANONICAL_ENABLED
+  return v === '1' || v === 'true'
+}
+
 const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 function isUuidShaped(value: string): boolean {
   return UUID_SHAPE.test(value)
@@ -130,6 +136,14 @@ export function adminDirectoryRoutingPolicyRouter(): Router {
       jsonError(res, 400, 'ROUTING_POLICY_INVALID_PURPOSE', 'Unknown routing purpose')
       return
     }
+    // Owner review (#4431): v1 has exactly ONE consumer — approval_routing (B6 parity). Writing a
+    // policy for the other four §6 purposes would create DEAD CONFIG no resolver reads (and imply
+    // governance that does not exist). The schema CHECK keeps the full closed set for the future;
+    // the WRITE surface only opens a purpose when its consumer + parity proof land (§10.2+).
+    if (purpose !== 'approval_routing') {
+      jsonError(res, 400, 'ROUTING_POLICY_PURPOSE_UNSUPPORTED', 'v1 supports approval_routing only; other purposes have no consumer yet')
+      return
+    }
 
     // Field allowlist (B2 convention): ONLY canonicalIntegrationId; anything else — org/corp
     // identity especially — is rejected loudly, never silently dropped.
@@ -182,6 +196,16 @@ export function adminDirectoryRoutingPolicyRouter(): Router {
         // fail at WRITE time — a policy pointing at a broken target would fail-close every
         // policy-consuming approval later (B5-b), which is strictly worse than rejecting here.
         jsonError(res, 409, 'ROUTING_POLICY_TARGET_NOT_ACTIVE', 'The target integration is not active')
+        return
+      }
+      // Owner review (#4431): switching approval routing to the LOCAL provider is a capability
+      // decision, not a config edit — it must be explicitly enabled (env-gate, default OFF, the
+      // repo's staged-opt-in pattern) after the owner accepts the B6 parity evidence for the
+      // deployment. Until then a local canonical is rejected at the WRITE surface. (Preview stays
+      // available for local candidates on purpose — it is the read-only evidence tool for making
+      // exactly this decision.)
+      if (integration.provider === 'local' && !isLocalCanonicalEnabled()) {
+        jsonError(res, 409, 'ROUTING_POLICY_LOCAL_NOT_ENABLED', 'Routing to the local provider is not enabled (set DIRECTORY_ROUTING_LOCAL_CANONICAL_ENABLED=1 after accepting parity evidence)')
         return
       }
 

--- a/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
+++ b/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
@@ -201,7 +201,20 @@ export class ApprovalRoutingPolicyError extends Error {
 export async function resolveApprovalRequesterOrgRelations(
   localUserId: string,
   query: QueryFn,
-  options: { includeManagerChain?: boolean; maxLevels?: number; orgId?: string } = {},
+  options: {
+    includeManagerChain?: boolean
+    maxLevels?: number
+    orgId?: string
+    /**
+     * B5-c read-only PREVIEW hook: `undefined` (default) = run the real policy probe;
+     * `null` = force the LEGACY path; a string = resolve AS IF that integration were the policy's
+     * canonical — WITHOUT reading or writing any policy row. Only the admin preview route passes
+     * this (it validates the candidate is same-org + active first); production approval creation
+     * never sets it, so the probe stays the sole authority there. Using the same resolver for both
+     * preview legs is deliberate: a separate preview resolution would drift from the real one.
+     */
+    overrideCanonicalIntegrationId?: string | null
+  } = {},
 ): Promise<ApprovalRequesterOrgRelations> {
   const userId = localUserId.trim()
   if (!userId) return {}
@@ -243,9 +256,17 @@ export async function resolveApprovalRequesterOrgRelations(
   //      - NO same-org policy → fall through to the S7 org-anchored requester SELECT.
   //      - ONE same-org policy → AUTHORITATIVE canonical-integration pick (within the tenant).
   //      - (multi-org ambiguity cannot fire: foreign policies are filtered out by p.org_id = $2.)
-  const policyRows = await query<RoutingPolicyProbeRow>(
-    orgId
-      ? `SELECT DISTINCT p.org_id                            AS org_id,
+  //
+  //    B5-c PREVIEW: when overrideCanonicalIntegrationId is defined, skip the probe entirely and
+  //    resolve AS-IF that integration were canonical (or force legacy when null). Production never
+  //    sets this option — the real policy row remains the sole authority there.
+  let canonicalIntegrationId: string | null = null
+  const policyRows =
+    options.overrideCanonicalIntegrationId !== undefined
+      ? { rows: [] as RoutingPolicyProbeRow[] }
+      : await query<RoutingPolicyProbeRow>(
+          orgId
+            ? `SELECT DISTINCT p.org_id                            AS org_id,
             p.canonical_integration_id::text             AS canonical_integration_id,
             ci.status                                    AS canonical_status
        FROM directory_account_links l
@@ -262,7 +283,7 @@ export async function resolveApprovalRequesterOrgRelations(
       WHERE l.local_user_id = $1
         AND l.link_status = 'linked'
         AND p.org_id = $2`
-      : `SELECT DISTINCT p.org_id                            AS org_id,
+            : `SELECT DISTINCT p.org_id                            AS org_id,
             p.canonical_integration_id::text             AS canonical_integration_id,
             ci.status                                    AS canonical_status
        FROM directory_account_links l
@@ -278,9 +299,11 @@ export async function resolveApprovalRequesterOrgRelations(
          ON ci.id = p.canonical_integration_id
       WHERE l.local_user_id = $1
         AND l.link_status = 'linked'`,
-    orgId ? [userId, orgId] : [userId],
-  )
-  let canonicalIntegrationId: string | null = null
+          orgId ? [userId, orgId] : [userId],
+        )
+  if (options.overrideCanonicalIntegrationId !== undefined) {
+    canonicalIntegrationId = options.overrideCanonicalIntegrationId
+  }
   if (policyRows.rows.length > 0) {
     const orgs = new Set(policyRows.rows.map((r) => r.org_id))
     if (orgs.size > 1) {

--- a/packages/core-backend/tests/integration/org-directory-routing-policy-routes.db.test.ts
+++ b/packages/core-backend/tests/integration/org-directory-routing-policy-routes.db.test.ts
@@ -189,6 +189,17 @@ describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real
     expect(bad7.status).toBe(409)
     expect(JSON.stringify(bad7.body)).toContain('ROUTING_POLICY_LOCAL_NOT_ENABLED')
 
+    // Gate P2 (restack round): the gate must STRICT-parse — a falsy-ish string an operator sets
+    // to mean OFF ('false', '0') must NOT enable local canonical. Pins isLocalCanonicalEnabled's
+    // `v === '1' || v === 'true'` shape: loosening it to Boolean(v) turns these legs red.
+    for (const falsy of ['false', '0']) {
+      process.env.DIRECTORY_ROUTING_LOCAL_CANONICAL_ENABLED = falsy
+      const bad8 = await request(adminApp).patch(`${BASE}/approval_routing`).send({ canonicalIntegrationId: local.id })
+      expect(bad8.status, `env=${falsy}`).toBe(409)
+      expect(JSON.stringify(bad8.body)).toContain('ROUTING_POLICY_LOCAL_NOT_ENABLED')
+    }
+    delete process.env.DIRECTORY_ROUTING_LOCAL_CANONICAL_ENABLED
+
     expect(await auditCount('directory.routing_policy.set', rid)).toBe(0)
     const count = await query<{ n: number }>(`SELECT count(*)::int AS n FROM org_directory_routing_policy WHERE org_id = $1`, [orgId])
     expect(count.rows[0].n).toBe(0) // none of the rejects wrote a row

--- a/packages/core-backend/tests/integration/org-directory-routing-policy-routes.db.test.ts
+++ b/packages/core-backend/tests/integration/org-directory-routing-policy-routes.db.test.ts
@@ -32,9 +32,10 @@ import { ApprovalRoutingPolicyError, resolveApprovalRequesterOrgRelations } from
  *   G. TOCTOU disable-first (two real connections): an uncommitted disable holds the exclusive
  *      row lock; PATCH's write-point `FOR SHARE` blocks (observed via pg_blocking_pids, never a
  *      fixed sleep); after disable commits, PATCH returns 409 with zero policy/audit.
- *   H. TOCTOU set-first: PATCH holds `FOR SHARE` through its write (barrier so disable can race
- *      while the lock is still held); disable blocks; after set commits, disable proceeds; the
- *      existing resolver fails closed on the now-disabled canonical.
+ *   H. TOCTOU set-first: advisory barrier parks PATCH mid-txn after write-point FOR SHARE; the
+ *      proof is a PID-exact chain (holder → PATCH via pg_blocking_pids + advisory wait; disabler →
+ *      PATCH via pg_blocking_pids(disablerPid)), never a broad pg_stat_activity scan; after set
+ *      commits, disable proceeds; the existing resolver fails closed on the now-disabled canonical.
  *
  * Load-bearing mutations (out-of-band, each reds this file):
  *   - remove the PATCH `status !== 'active'` check → C's 409 leg reds (broken policy accepted).
@@ -119,6 +120,54 @@ async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
 
 /** Stable bigint key for the set-first advisory barrier (session-level, not xact). */
 const SET_FIRST_ADVISORY_KEY = 0xb5c5e701 // B5-c set-first barrier
+
+/**
+ * H set-first step 1: poll until a backend is advisory-waiting with `holderPid` in
+ * `pg_blocking_pids(pid)`. Returns that exact PATCH backend PID (not a count of any waiter).
+ * Poll backoff only — correctness is the PID match, never a fixed sleep oracle.
+ */
+async function waitForPatchPidBlockedByAdvisoryHolder(holderPid: number): Promise<number> {
+  for (let i = 0; i < 500; i++) {
+    const r = await query<{ pid: number }>(
+      `SELECT pid
+         FROM pg_stat_activity
+        WHERE state = 'active'
+          AND datname = current_database()
+          AND pid <> pg_backend_pid()
+          AND pid <> $1
+          AND wait_event_type = 'Lock'
+          AND wait_event = 'advisory'
+          AND $1 = ANY(pg_blocking_pids(pid))
+        ORDER BY pid
+        LIMIT 1`,
+      [holderPid],
+    )
+    if (r.rows[0]?.pid != null) return r.rows[0].pid
+    await new Promise((res) => setTimeout(res, 20))
+  }
+  throw new Error(
+    `timed out waiting for PATCH backend blocked by advisory holder pid ${holderPid} (exact chain never engaged)`,
+  )
+}
+
+/**
+ * H set-first step 2: poll until `pg_blocking_pids(waiterPid)` contains `blockerPid` —
+ * proves the disabler is blocked specifically by the PATCH backend that holds FOR SHARE.
+ */
+async function waitUntilPidBlockedBy(waiterPid: number, blockerPid: number): Promise<void> {
+  for (let i = 0; i < 500; i++) {
+    const r = await query<{ blocked: boolean }>(
+      `SELECT $2::int = ANY(pg_blocking_pids($1::int)) AS blocked`,
+      [waiterPid, blockerPid],
+    )
+    if (r.rows[0]?.blocked === true) return
+    await new Promise((res) => setTimeout(res, 20))
+  }
+  throw new Error(
+    `timed out waiting for pid ${waiterPid} to be blocked specifically by pid ${blockerPid} via pg_blocking_pids`,
+  )
+}
+
 describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real DB, HTTP)', () => {
   const cleanupAccountIds: string[] = []
   const cleanupIntegrationIds: string[] = []
@@ -383,10 +432,12 @@ describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real
     ])
     cleanupAccountIds.push(await linkedAccount(target, 'dingtalk', user, 'Race Title'))
 
-    // Advisory barrier: a BEFORE INSERT/UPDATE trigger on the policy table parks the PATCH
-    // transaction AFTER it has taken FOR SHARE on the integration row and BEFORE commit — so a
-    // concurrent disable can be observed blocking on the row lock (never a fixed sleep).
+    // Advisory barrier: BEFORE INSERT/UPDATE trigger parks the PATCH txn AFTER write-point
+    // FOR SHARE and BEFORE commit. The chain proof is PID-exact:
+    //   barrier holder (advisory) → PATCH backend (advisory wait + holder in pg_blocking_pids)
+    //   → disabler (holder of FOR SHARE = PATCH pid in pg_blocking_pids(disablerPid)).
     await withClient(async (barrier) => {
+      const holderPid = (await barrier.query<{ pid: number }>('SELECT pg_backend_pid() AS pid')).rows[0].pid
       await barrier.query('SELECT pg_advisory_lock($1)', [SET_FIRST_ADVISORY_KEY])
       try {
         await query(`
@@ -414,14 +465,20 @@ describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real
             return r
           })
 
-        // Wait until PATCH is parked on the advisory (it already holds FOR SHARE at this point).
-        await waitUntilAdvisoryWaiters(1)
+        // Exact chain link 1: the PATCH backend is advisory-blocked by THIS holder PID.
+        const patchPid = await waitForPatchPidBlockedByAdvisoryHolder(holderPid)
         expect(patchSettled).toBe(false)
+        expect(patchPid).not.toBe(holderPid)
 
-        // Concurrent disable: must block on the exclusive lock conflict with PATCH's FOR SHARE.
+        // Concurrent disable: must block on exclusive lock conflict with PATCH's FOR SHARE.
         const disabler = new Client({ connectionString: process.env.DATABASE_URL })
         await disabler.connect()
         try {
+          const disablerPid = (await disabler.query<{ pid: number }>('SELECT pg_backend_pid() AS pid')).rows[0]
+            .pid
+          expect(disablerPid).not.toBe(patchPid)
+          expect(disablerPid).not.toBe(holderPid)
+
           let disableSettled = false
           const disableP = disabler
             .query(`UPDATE directory_integrations SET status = 'disabled' WHERE id = $1`, [target])
@@ -430,8 +487,8 @@ describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real
               return r
             })
 
-          // Observe disable blocked by someone (the PATCH txn holding FOR SHARE).
-          await waitUntilDisableBlocked(target)
+          // Exact chain link 2: disabler is blocked specifically by the PATCH backend PID.
+          await waitUntilPidBlockedBy(disablerPid, patchPid)
           expect(disableSettled).toBe(false)
           expect(patchSettled).toBe(false)
 
@@ -465,48 +522,3 @@ describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real
     await expect(resolveApprovalRequesterOrgRelations(user, query)).rejects.toBeInstanceOf(ApprovalRoutingPolicyError)
   })
 })
-
-/** Wait until ≥ min backends are Lock-waiting on an advisory lock (set-first barrier engaged). */
-async function waitUntilAdvisoryWaiters(min: number): Promise<void> {
-  for (let i = 0; i < 500; i++) {
-    const r = await query<{ n: number }>(
-      `SELECT count(*)::int AS n FROM pg_stat_activity
-        WHERE wait_event_type = 'Lock' AND wait_event = 'advisory' AND state = 'active'`,
-    )
-    if ((r.rows[0]?.n ?? 0) >= min) return
-    await new Promise((res) => setTimeout(res, 20))
-  }
-  throw new Error('timed out waiting for PATCH parked on the set-first advisory barrier')
-}
-
-/**
- * Wait until a concurrent UPDATE of directory_integrations for `targetId` is Lock-blocked
- * (proves disable is serialized behind the PATCH write-point FOR SHARE).
- */
-async function waitUntilDisableBlocked(targetId: string): Promise<void> {
-  for (let i = 0; i < 500; i++) {
-    const r = await query<{ n: number }>(
-      `SELECT count(*)::int AS n FROM pg_stat_activity
-        WHERE state = 'active'
-          AND datname = current_database()
-          AND wait_event_type = 'Lock'
-          AND query ILIKE '%directory_integrations%'
-          AND query ILIKE '%status%'
-          AND query ILIKE '%' || $1 || '%'`,
-      [targetId],
-    )
-    if ((r.rows[0]?.n ?? 0) >= 1) return
-    // Also accept any backend blocked on a lock whose query mentions the table (param may be bound).
-    const r2 = await query<{ n: number }>(
-      `SELECT count(*)::int AS n FROM pg_stat_activity
-        WHERE state = 'active'
-          AND datname = current_database()
-          AND wait_event_type = 'Lock'
-          AND cardinality(pg_blocking_pids(pid)) > 0
-          AND (query ILIKE '%directory_integrations%' OR query ILIKE '%SET status%')`,
-    )
-    if ((r2.rows[0]?.n ?? 0) >= 1) return
-    await new Promise((res) => setTimeout(res, 20))
-  }
-  throw new Error('timed out waiting for disable UPDATE blocked behind PATCH FOR SHARE')
-}

--- a/packages/core-backend/tests/integration/org-directory-routing-policy-routes.db.test.ts
+++ b/packages/core-backend/tests/integration/org-directory-routing-policy-routes.db.test.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from 'crypto'
 import express from 'express'
+import { Client } from 'pg'
 import request from 'supertest'
 import { afterEach, describe, expect, it } from 'vitest'
 import { query } from '../../src/db/pg'
 import { getOrCreateLocalIntegration } from '../../src/directory/directory-sync'
 import { adminDirectoryRoutingPolicyRouter } from '../../src/routes/admin-directory-routing-policy'
+import { ApprovalRoutingPolicyError, resolveApprovalRequesterOrgRelations } from '../../src/services/ApprovalDirectoryOrg'
 
 /**
  * Canonical Org MVP — B5-c (routing-policy admin ROUTES), design lock Lock 3 + §7, real DB + HTTP.
@@ -27,10 +29,18 @@ import { adminDirectoryRoutingPolicyRouter } from '../../src/routes/admin-direct
  *   E. PREVIEW validations: unsupported purpose 400; non-UUID candidate 400; cross-org candidate
  *      404; inactive candidate 409.
  *   F. non-admin: all three routes 403 via the real RBAC path.
+ *   G. TOCTOU disable-first (two real connections): an uncommitted disable holds the exclusive
+ *      row lock; PATCH's write-point `FOR SHARE` blocks (observed via pg_blocking_pids, never a
+ *      fixed sleep); after disable commits, PATCH returns 409 with zero policy/audit.
+ *   H. TOCTOU set-first: PATCH holds `FOR SHARE` through its write (barrier so disable can race
+ *      while the lock is still held); disable blocks; after set commits, disable proceeds; the
+ *      existing resolver fails closed on the now-disabled canonical.
  *
  * Load-bearing mutations (out-of-band, each reds this file):
  *   - remove the PATCH `status !== 'active'` check → C's 409 leg reds (broken policy accepted).
  *   - remove the preview's `overrideCanonicalIntegrationId` pass-through → D reds (after == before).
+ *   - remove the write-point `FOR SHARE` / single-txn wrap → G reds for the SEMANTIC reason
+ *     (PATCH accepts 200 + writes a policy at a concurrently-disabled target), not a SQL bind error.
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -65,6 +75,14 @@ async function auditCount(action: string, resourceId: string): Promise<number> {
   return r.rows[0]?.n ?? 0
 }
 
+async function policyCount(): Promise<number> {
+  const r = await query<{ n: number }>(
+    `SELECT count(*)::int AS n FROM org_directory_routing_policy WHERE org_id = $1`,
+    [orgId],
+  )
+  return r.rows[0]?.n ?? 0
+}
+
 async function dingtalkIntegration(org: string, tag: string, status = 'active'): Promise<string> {
   const r = await query<{ id: string }>(
     `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config)
@@ -88,6 +106,19 @@ async function linkedAccount(integrationId: string, provider: string, userId: st
   return acc.rows[0].id
 }
 
+/** Dedicated raw connection for concurrency holders — never from the service pool. */
+async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+  const client = new Client({ connectionString: process.env.DATABASE_URL })
+  await client.connect()
+  try {
+    return await fn(client)
+  } finally {
+    await client.end()
+  }
+}
+
+/** Stable bigint key for the set-first advisory barrier (session-level, not xact). */
+const SET_FIRST_ADVISORY_KEY = 0xb5c5e701 // B5-c set-first barrier
 describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real DB, HTTP)', () => {
   const cleanupAccountIds: string[] = []
   const cleanupIntegrationIds: string[] = []
@@ -95,6 +126,11 @@ describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real
   const cleanupOrgIds: string[] = []
 
   afterEach(async () => {
+    // Unconditional: a failed assertion must not leak the local-canonical env gate into later tests.
+    delete process.env.DIRECTORY_ROUTING_LOCAL_CANONICAL_ENABLED
+    // Drop any set-first advisory barrier trigger/function left mid-test (best-effort).
+    await query(`DROP TRIGGER IF EXISTS b5c_set_first_barrier_trg ON org_directory_routing_policy`).catch(() => {})
+    await query(`DROP FUNCTION IF EXISTS b5c_set_first_barrier()`).catch(() => {})
     // the shared 'default' org's policy rows: always clear ours (purpose keyspace is tiny/shared)
     await query(`DELETE FROM org_directory_routing_policy WHERE org_id = $1`, [orgId])
     await query(`DELETE FROM audit_logs WHERE resource_type = 'directory-routing-policy'`)
@@ -148,7 +184,7 @@ describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real
     expect(again.status).toBe(200)
     expect(again.body.data?.cleared ?? again.body.cleared).toBe(false)
     expect(await auditCount('directory.routing_policy.clear', rid)).toBe(1) // no second audit
-    delete process.env.DIRECTORY_ROUTING_LOCAL_CANONICAL_ENABLED
+    // env cleanup is unconditional in afterEach (do not rely on this line after a mid-test failure)
   })
 
   it('C. PATCH validations reject without auditing: bad purpose / non-UUID / smuggled field / cross-org / inactive target', async () => {
@@ -272,4 +308,205 @@ describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real
     expect(r2.status).toBe(403)
     expect(r3.status).toBe(403)
   })
+
+  it('G. TOCTOU disable-first: PATCH blocks on FOR SHARE, then 409 with zero policy/audit', async () => {
+    const target = await dingtalkIntegration(orgId, 'race-df')
+    cleanupIntegrationIds.push(target)
+    const rid = `${orgId}:approval_routing`
+
+    await withClient(async (holder) => {
+      await holder.query('BEGIN')
+      const holderPid = (await holder.query<{ pid: number }>('SELECT pg_backend_pid() AS pid')).rows[0].pid
+      // Uncommitted disable: exclusive row lock held; status change not yet visible to non-locking readers.
+      await holder.query(`UPDATE directory_integrations SET status = 'disabled' WHERE id = $1`, [target])
+
+      let settled = false
+      const patchP = request(adminApp)
+        .patch(`${BASE}/approval_routing`)
+        .send({ canonicalIntegrationId: target })
+        .then((r) => {
+          settled = true
+          return r
+        })
+
+      // Dual-outcome race observer (no fixed sleep as the correctness signal):
+      //   FIXED: PATCH's FOR SHARE parks behind the holder → sawBlock=true, settled=false.
+      //   UNFIXED (no write-point lock/txn): non-locking SELECT sees still-committed 'active',
+      //   upserts, settles 200 while the disable is still uncommitted → sawBlock=false.
+      // Semantic end-state asserts (409 + zero policy/audit) red the unfixed path for the
+      // INTENDED reason — accepted a policy at a concurrently-disabled target — not a barrier
+      // timeout or SQL bind error. sawBlock is the positive proof the lock engaged.
+      let sawBlock = false
+      for (let i = 0; i < 500; i++) {
+        if (settled) break
+        const r = await query<{ n: number }>(
+          `SELECT count(*)::int AS n
+             FROM pg_stat_activity
+            WHERE state = 'active'
+              AND datname = current_database()
+              AND pid <> pg_backend_pid()
+              AND $1 = ANY(pg_blocking_pids(pid))`,
+          [holderPid],
+        )
+        if ((r.rows[0]?.n ?? 0) >= 1) {
+          sawBlock = true
+          break
+        }
+        await new Promise((res) => setTimeout(res, 20))
+      }
+
+      await holder.query('COMMIT') // disable becomes visible; parked FOR SHARE re-reads inactive
+      const res = await patchP
+      // Semantic contract first (mutation-red without the lock: 200 + a written policy row).
+      expect(res.status).toBe(409)
+      expect(JSON.stringify(res.body)).toContain('ROUTING_POLICY_TARGET_NOT_ACTIVE')
+      expect(await policyCount()).toBe(0)
+      expect(await auditCount('directory.routing_policy.set', rid)).toBe(0)
+      // Lock engagement proof (fixed path only).
+      expect(sawBlock).toBe(true)
+    })
+  })
+
+  it('H. TOCTOU set-first: set commits before disable; resolver fails closed on the disabled canonical', async () => {
+    const target = await dingtalkIntegration(orgId, 'race-sf')
+    cleanupIntegrationIds.push(target)
+    const rid = `${orgId}:approval_routing`
+
+    // Seed a linked user so the post-disable resolver probe actually hits the policy row
+    // (B5-b joins policy through the requester's linked accounts in the org).
+    const user = newUserId('sf')
+    cleanupUserIds.push(user)
+    await query(`INSERT INTO users (id, email, name, password_hash) VALUES ($1, $2, $3, 'x')`, [
+      user,
+      `${user}@example.test`,
+      user,
+    ])
+    cleanupAccountIds.push(await linkedAccount(target, 'dingtalk', user, 'Race Title'))
+
+    // Advisory barrier: a BEFORE INSERT/UPDATE trigger on the policy table parks the PATCH
+    // transaction AFTER it has taken FOR SHARE on the integration row and BEFORE commit — so a
+    // concurrent disable can be observed blocking on the row lock (never a fixed sleep).
+    await withClient(async (barrier) => {
+      await barrier.query('SELECT pg_advisory_lock($1)', [SET_FIRST_ADVISORY_KEY])
+      try {
+        await query(`
+          CREATE OR REPLACE FUNCTION b5c_set_first_barrier() RETURNS trigger AS $$
+          BEGIN
+            PERFORM pg_advisory_lock(${SET_FIRST_ADVISORY_KEY});
+            PERFORM pg_advisory_unlock(${SET_FIRST_ADVISORY_KEY});
+            RETURN NEW;
+          END;
+          $$ LANGUAGE plpgsql
+        `)
+        await query(`DROP TRIGGER IF EXISTS b5c_set_first_barrier_trg ON org_directory_routing_policy`)
+        await query(`
+          CREATE TRIGGER b5c_set_first_barrier_trg
+            BEFORE INSERT OR UPDATE ON org_directory_routing_policy
+            FOR EACH ROW EXECUTE FUNCTION b5c_set_first_barrier()
+        `)
+
+        let patchSettled = false
+        const patchP = request(adminApp)
+          .patch(`${BASE}/approval_routing`)
+          .send({ canonicalIntegrationId: target })
+          .then((r) => {
+            patchSettled = true
+            return r
+          })
+
+        // Wait until PATCH is parked on the advisory (it already holds FOR SHARE at this point).
+        await waitUntilAdvisoryWaiters(1)
+        expect(patchSettled).toBe(false)
+
+        // Concurrent disable: must block on the exclusive lock conflict with PATCH's FOR SHARE.
+        const disabler = new Client({ connectionString: process.env.DATABASE_URL })
+        await disabler.connect()
+        try {
+          let disableSettled = false
+          const disableP = disabler
+            .query(`UPDATE directory_integrations SET status = 'disabled' WHERE id = $1`, [target])
+            .then((r) => {
+              disableSettled = true
+              return r
+            })
+
+          // Observe disable blocked by someone (the PATCH txn holding FOR SHARE).
+          await waitUntilDisableBlocked(target)
+          expect(disableSettled).toBe(false)
+          expect(patchSettled).toBe(false)
+
+          // Release the advisory → PATCH INSERT completes, commits, releases FOR SHARE.
+          await barrier.query('SELECT pg_advisory_unlock($1)', [SET_FIRST_ADVISORY_KEY])
+          const patchRes = await patchP
+          expect(patchRes.status).toBe(200)
+          expect(patchSettled).toBe(true)
+
+          await disableP
+          expect(disableSettled).toBe(true)
+        } finally {
+          await disabler.end()
+        }
+      } finally {
+        // Always drop barrier objects even if assertions fail mid-flight.
+        await query(`DROP TRIGGER IF EXISTS b5c_set_first_barrier_trg ON org_directory_routing_policy`).catch(() => {})
+        await query(`DROP FUNCTION IF EXISTS b5c_set_first_barrier()`).catch(() => {})
+        // If we still hold the advisory (error before unlock), release it.
+        await barrier.query('SELECT pg_advisory_unlock($1)', [SET_FIRST_ADVISORY_KEY]).catch(() => {})
+      }
+    })
+
+    // Set committed before disable: policy row exists, target is now disabled.
+    expect(await policyCount()).toBe(1)
+    expect(await auditCount('directory.routing_policy.set', rid)).toBe(1)
+    const status = await query<{ status: string }>(`SELECT status FROM directory_integrations WHERE id = $1`, [target])
+    expect(status.rows[0]?.status).toBe('disabled')
+
+    // Existing B5-b resolver fails closed on the now-disabled canonical (CONFIG error).
+    await expect(resolveApprovalRequesterOrgRelations(user, query)).rejects.toBeInstanceOf(ApprovalRoutingPolicyError)
+  })
 })
+
+/** Wait until ≥ min backends are Lock-waiting on an advisory lock (set-first barrier engaged). */
+async function waitUntilAdvisoryWaiters(min: number): Promise<void> {
+  for (let i = 0; i < 500; i++) {
+    const r = await query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM pg_stat_activity
+        WHERE wait_event_type = 'Lock' AND wait_event = 'advisory' AND state = 'active'`,
+    )
+    if ((r.rows[0]?.n ?? 0) >= min) return
+    await new Promise((res) => setTimeout(res, 20))
+  }
+  throw new Error('timed out waiting for PATCH parked on the set-first advisory barrier')
+}
+
+/**
+ * Wait until a concurrent UPDATE of directory_integrations for `targetId` is Lock-blocked
+ * (proves disable is serialized behind the PATCH write-point FOR SHARE).
+ */
+async function waitUntilDisableBlocked(targetId: string): Promise<void> {
+  for (let i = 0; i < 500; i++) {
+    const r = await query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM pg_stat_activity
+        WHERE state = 'active'
+          AND datname = current_database()
+          AND wait_event_type = 'Lock'
+          AND query ILIKE '%directory_integrations%'
+          AND query ILIKE '%status%'
+          AND query ILIKE '%' || $1 || '%'`,
+      [targetId],
+    )
+    if ((r.rows[0]?.n ?? 0) >= 1) return
+    // Also accept any backend blocked on a lock whose query mentions the table (param may be bound).
+    const r2 = await query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM pg_stat_activity
+        WHERE state = 'active'
+          AND datname = current_database()
+          AND wait_event_type = 'Lock'
+          AND cardinality(pg_blocking_pids(pid)) > 0
+          AND (query ILIKE '%directory_integrations%' OR query ILIKE '%SET status%')`,
+    )
+    if ((r2.rows[0]?.n ?? 0) >= 1) return
+    await new Promise((res) => setTimeout(res, 20))
+  }
+  throw new Error('timed out waiting for disable UPDATE blocked behind PATCH FOR SHARE')
+}

--- a/packages/core-backend/tests/integration/org-directory-routing-policy-routes.db.test.ts
+++ b/packages/core-backend/tests/integration/org-directory-routing-policy-routes.db.test.ts
@@ -125,6 +125,7 @@ describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real
   })
 
   it('B. PATCH set → audit + GET shows policy; PATCH null clears (audited once, idempotent after)', async () => {
+    process.env.DIRECTORY_ROUTING_LOCAL_CANONICAL_ENABLED = '1' // owner #4431: local canonical is env-gated
     const local = await getOrCreateLocalIntegration(orgId)
     const rid = `${orgId}:approval_routing`
 
@@ -147,6 +148,7 @@ describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real
     expect(again.status).toBe(200)
     expect(again.body.data?.cleared ?? again.body.cleared).toBe(false)
     expect(await auditCount('directory.routing_policy.clear', rid)).toBe(1) // no second audit
+    delete process.env.DIRECTORY_ROUTING_LOCAL_CANONICAL_ENABLED
   })
 
   it('C. PATCH validations reject without auditing: bad purpose / non-UUID / smuggled field / cross-org / inactive target', async () => {
@@ -172,6 +174,20 @@ describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real
     cleanupIntegrationIds.push(inactive)
     const bad5 = await request(adminApp).patch(`${BASE}/approval_routing`).send({ canonicalIntegrationId: inactive })
     expect(bad5.status).toBe(409) // broken-target policies are rejected at WRITE time
+
+    // owner #4431: a purpose with NO consumer cannot be written (dead config) — even a valid §6 one
+    const active = await dingtalkIntegration(orgId, 'ps-ok')
+    cleanupIntegrationIds.push(active)
+    const bad6 = await request(adminApp).patch(`${BASE}/permission_scope`).send({ canonicalIntegrationId: active })
+    expect(bad6.status).toBe(400)
+    expect(JSON.stringify(bad6.body)).toContain('ROUTING_POLICY_PURPOSE_UNSUPPORTED')
+
+    // owner #4431: canonical=local is capability-gated (default OFF) — rejected without the env
+    delete process.env.DIRECTORY_ROUTING_LOCAL_CANONICAL_ENABLED
+    const local = await getOrCreateLocalIntegration(orgId)
+    const bad7 = await request(adminApp).patch(`${BASE}/approval_routing`).send({ canonicalIntegrationId: local.id })
+    expect(bad7.status).toBe(409)
+    expect(JSON.stringify(bad7.body)).toContain('ROUTING_POLICY_LOCAL_NOT_ENABLED')
 
     expect(await auditCount('directory.routing_policy.set', rid)).toBe(0)
     const count = await query<{ n: number }>(`SELECT count(*)::int AS n FROM org_directory_routing_policy WHERE org_id = $1`, [orgId])

--- a/packages/core-backend/tests/integration/org-directory-routing-policy-routes.db.test.ts
+++ b/packages/core-backend/tests/integration/org-directory-routing-policy-routes.db.test.ts
@@ -1,0 +1,236 @@
+import { randomUUID } from 'crypto'
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { getOrCreateLocalIntegration } from '../../src/directory/directory-sync'
+import { adminDirectoryRoutingPolicyRouter } from '../../src/routes/admin-directory-routing-policy'
+
+/**
+ * Canonical Org MVP — B5-c (routing-policy admin ROUTES), design lock Lock 3 + §7, real DB + HTTP.
+ *
+ * Pairs with the B5-a schema and B5-b resolver files: this file proves the actual admin surface —
+ * platform-admin gating, the PATCH write point's validations + values-free audit, the clear path,
+ * and the READ-ONLY preview (no policy row, no audit, both legs through the REAL resolver).
+ *
+ *   A. GET lists all 5 §6 purposes; with no rows, every purpose is 'legacy-default'.
+ *   B. PATCH set: 200 + audit `directory.routing_policy.set`; GET flips to source='policy';
+ *      PATCH null clears + audit `.clear`; GET back to legacy-default; clearing again → 200
+ *      cleared:false with NO second audit (idempotent, audit only on real deletion).
+ *   C. PATCH validations, each WITHOUT an audit row: unknown purpose 400; non-UUID 400; unlisted
+ *      body field (org smuggling) 400; integration from another org 404; non-active target 409
+ *      (a policy pointing at a broken target is rejected at WRITE time — B5-b would fail-close
+ *      every consuming approval otherwise).
+ *   D. PREVIEW (approval_routing): with NO current policy, a candidate=local preview reports the
+ *      per-user diff (before = legacy latest-updated dingtalk source; after = local candidate) —
+ *      and is READ-ONLY: zero policy rows written, zero audit rows.
+ *   E. PREVIEW validations: unsupported purpose 400; non-UUID candidate 400; cross-org candidate
+ *      404; inactive candidate 409.
+ *   F. non-admin: all three routes 403 via the real RBAC path.
+ *
+ * Load-bearing mutations (out-of-band, each reds this file):
+ *   - remove the PATCH `status !== 'active'` check → C's 409 leg reds (broken policy accepted).
+ *   - remove the preview's `overrideCanonicalIntegrationId` pass-through → D reds (after == before).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+const orgId = 'default' // routes are single-tenant server-resolved; fixtures must live in 'default'
+const newUserId = (suffix: string): string => `b5c-user-${STAMP}-${suffix}`
+
+const adminApp = express()
+adminApp.use(express.json())
+adminApp.use((req, _res, next) => {
+  ;(req as express.Request & { user?: unknown }).user = { id: `b5c-admin-${STAMP}`, role: 'admin' }
+  next()
+})
+adminApp.use('/api/admin/directory/routing-policy', adminDirectoryRoutingPolicyRouter())
+
+const nonAdminApp = express()
+nonAdminApp.use(express.json())
+nonAdminApp.use((req, _res, next) => {
+  ;(req as express.Request & { user?: unknown }).user = { id: `b5c-nonadmin-${STAMP}` }
+  next()
+})
+nonAdminApp.use('/api/admin/directory/routing-policy', adminDirectoryRoutingPolicyRouter())
+
+const BASE = '/api/admin/directory/routing-policy'
+
+async function auditCount(action: string, resourceId: string): Promise<number> {
+  const r = await query<{ n: number }>(
+    `SELECT count(*)::int AS n FROM audit_logs
+      WHERE action = $1 AND resource_type = 'directory-routing-policy' AND resource_id = $2`,
+    [action, resourceId],
+  )
+  return r.rows[0]?.n ?? 0
+}
+
+async function dingtalkIntegration(org: string, tag: string, status = 'active'): Promise<string> {
+  const r = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config)
+     VALUES ($1, 'dingtalk', $2, $3, $4, '{}'::jsonb) RETURNING id`,
+    [org, `DT b5c ${tag} ${STAMP}`, status, `corp-b5c-${STAMP}-${tag}`],
+  )
+  return r.rows[0].id
+}
+
+async function linkedAccount(integrationId: string, provider: string, userId: string, title: string): Promise<string> {
+  const acc = await query<{ id: string }>(
+    `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, title, is_active, raw)
+     VALUES ($1, $2, $3, $3, $4, $5, true, '{}'::jsonb) RETURNING id`,
+    [integrationId, provider, `${provider}:b5c:${STAMP}:${userId}:${integrationId.slice(0, 8)}`, userId, title],
+  )
+  await query(
+    `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+     VALUES ($1, $2, 'linked', 'manual')`,
+    [acc.rows[0].id, userId],
+  )
+  return acc.rows[0].id
+}
+
+describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real DB, HTTP)', () => {
+  const cleanupAccountIds: string[] = []
+  const cleanupIntegrationIds: string[] = []
+  const cleanupUserIds: string[] = []
+  const cleanupOrgIds: string[] = []
+
+  afterEach(async () => {
+    // the shared 'default' org's policy rows: always clear ours (purpose keyspace is tiny/shared)
+    await query(`DELETE FROM org_directory_routing_policy WHERE org_id = $1`, [orgId])
+    await query(`DELETE FROM audit_logs WHERE resource_type = 'directory-routing-policy'`)
+    for (const id of cleanupAccountIds.splice(0)) {
+      await query(`DELETE FROM directory_accounts WHERE id = $1`, [id]) // links cascade
+    }
+    for (const id of cleanupIntegrationIds.splice(0)) {
+      await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
+    }
+    for (const org of cleanupOrgIds.splice(0)) {
+      await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [org])
+    }
+    for (const id of cleanupUserIds.splice(0)) {
+      await query(`DELETE FROM users WHERE id = $1`, [id])
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('A. GET lists all 5 purposes as legacy-default when no policy rows exist', async () => {
+    const res = await request(adminApp).get(`${BASE}/`)
+    expect(res.status).toBe(200)
+    const purposes = res.body.data?.purposes ?? res.body.purposes
+    expect(purposes).toHaveLength(5)
+    for (const p of purposes) expect(p.source).toBe('legacy-default')
+  })
+
+  it('B. PATCH set → audit + GET shows policy; PATCH null clears (audited once, idempotent after)', async () => {
+    const local = await getOrCreateLocalIntegration(orgId)
+    const rid = `${orgId}:approval_routing`
+
+    const set = await request(adminApp).patch(`${BASE}/approval_routing`).send({ canonicalIntegrationId: local.id })
+    expect(set.status).toBe(200)
+    expect(await auditCount('directory.routing_policy.set', rid)).toBe(1)
+
+    const listed = await request(adminApp).get(`${BASE}/`)
+    const row = (listed.body.data?.purposes ?? listed.body.purposes).find((p: { purpose: string }) => p.purpose === 'approval_routing')
+    expect(row.source).toBe('policy')
+    expect(row.canonicalIntegrationId).toBe(local.id)
+    expect(row.canonicalProvider).toBe('local')
+
+    const clear = await request(adminApp).patch(`${BASE}/approval_routing`).send({ canonicalIntegrationId: null })
+    expect(clear.status).toBe(200)
+    expect(clear.body.data?.cleared ?? clear.body.cleared).toBe(true)
+    expect(await auditCount('directory.routing_policy.clear', rid)).toBe(1)
+
+    const again = await request(adminApp).patch(`${BASE}/approval_routing`).send({ canonicalIntegrationId: null })
+    expect(again.status).toBe(200)
+    expect(again.body.data?.cleared ?? again.body.cleared).toBe(false)
+    expect(await auditCount('directory.routing_policy.clear', rid)).toBe(1) // no second audit
+  })
+
+  it('C. PATCH validations reject without auditing: bad purpose / non-UUID / smuggled field / cross-org / inactive target', async () => {
+    const rid = `${orgId}:approval_routing`
+    const bad1 = await request(adminApp).patch(`${BASE}/coffee_routing`).send({ canonicalIntegrationId: randomUUID() })
+    expect(bad1.status).toBe(400)
+
+    const bad2 = await request(adminApp).patch(`${BASE}/approval_routing`).send({ canonicalIntegrationId: 'not-a-uuid' })
+    expect(bad2.status).toBe(400)
+
+    const bad3 = await request(adminApp)
+      .patch(`${BASE}/approval_routing`)
+      .send({ canonicalIntegrationId: randomUUID(), orgId: 'evil-org' })
+    expect(bad3.status).toBe(400) // unlisted field — org identity is never client-writable
+
+    const otherOrg = `b5c-other-${STAMP}`
+    cleanupOrgIds.push(otherOrg)
+    const foreign = await dingtalkIntegration(otherOrg, 'xorg')
+    const bad4 = await request(adminApp).patch(`${BASE}/approval_routing`).send({ canonicalIntegrationId: foreign })
+    expect(bad4.status).toBe(404)
+
+    const inactive = await dingtalkIntegration(orgId, 'inact', 'disabled')
+    cleanupIntegrationIds.push(inactive)
+    const bad5 = await request(adminApp).patch(`${BASE}/approval_routing`).send({ canonicalIntegrationId: inactive })
+    expect(bad5.status).toBe(409) // broken-target policies are rejected at WRITE time
+
+    expect(await auditCount('directory.routing_policy.set', rid)).toBe(0)
+    const count = await query<{ n: number }>(`SELECT count(*)::int AS n FROM org_directory_routing_policy WHERE org_id = $1`, [orgId])
+    expect(count.rows[0].n).toBe(0) // none of the rejects wrote a row
+  })
+
+  it('D. preview is a real diff AND read-only: no policy row, no audit; both legs through the real resolver', async () => {
+    const user = newUserId('pv')
+    cleanupUserIds.push(user)
+    await query(`INSERT INTO users (id, email, name, password_hash) VALUES ($1, $2, $3, 'x')`, [user, `${user}@example.test`, user])
+    const local = await getOrCreateLocalIntegration(orgId)
+    const dt = await dingtalkIntegration(orgId, 'pv')
+    cleanupIntegrationIds.push(dt)
+    cleanupAccountIds.push(await linkedAccount(local.id, 'local', user, 'Local Title'))
+    const dtAcc = await linkedAccount(dt, 'dingtalk', user, 'DingTalk Title')
+    cleanupAccountIds.push(dtAcc)
+    await query(`UPDATE directory_accounts SET updated_at = NOW() + interval '1 hour' WHERE id = $1`, [dtAcc])
+
+    const res = await request(adminApp).get(`${BASE}/approval_routing/preview`).query({ candidate: local.id })
+    expect(res.status).toBe(200)
+    const body = res.body.data ?? res.body
+    expect(body.current.source).toBe('legacy-default')
+    const mine = body.rows.find((r: { userId: string }) => r.userId === user)
+    expect(mine).toBeTruthy()
+    expect(mine.before.title).toBe('DingTalk Title') // legacy latest-updated guessing
+    expect(mine.after.title).toBe('Local Title') // as-if candidate were canonical
+    expect(mine.changed).toBe(true)
+
+    // READ-ONLY: zero policy rows, zero audit
+    const rows = await query<{ n: number }>(`SELECT count(*)::int AS n FROM org_directory_routing_policy WHERE org_id = $1`, [orgId])
+    expect(rows.rows[0].n).toBe(0)
+    const audits = await query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM audit_logs WHERE resource_type = 'directory-routing-policy'`,
+    )
+    expect(audits.rows[0].n).toBe(0)
+  })
+
+  it('E. preview validations: unsupported purpose 400; non-UUID 400; cross-org 404; inactive 409', async () => {
+    const e1 = await request(adminApp).get(`${BASE}/permission_scope/preview`).query({ candidate: randomUUID() })
+    expect(e1.status).toBe(400)
+    const e2 = await request(adminApp).get(`${BASE}/approval_routing/preview`).query({ candidate: 'nope' })
+    expect(e2.status).toBe(400)
+    const otherOrg = `b5c-other2-${STAMP}`
+    cleanupOrgIds.push(otherOrg)
+    const foreign = await dingtalkIntegration(otherOrg, 'pxorg')
+    const e3 = await request(adminApp).get(`${BASE}/approval_routing/preview`).query({ candidate: foreign })
+    expect(e3.status).toBe(404)
+    const inactive = await dingtalkIntegration(orgId, 'pinact', 'disabled')
+    cleanupIntegrationIds.push(inactive)
+    const e4 = await request(adminApp).get(`${BASE}/approval_routing/preview`).query({ candidate: inactive })
+    expect(e4.status).toBe(409)
+  })
+
+  it('F. non-admin: 403 on list, set, and preview (real RBAC path)', async () => {
+    const r1 = await request(nonAdminApp).get(`${BASE}/`)
+    const r2 = await request(nonAdminApp).patch(`${BASE}/approval_routing`).send({ canonicalIntegrationId: randomUUID() })
+    const r3 = await request(nonAdminApp).get(`${BASE}/approval_routing/preview`).query({ candidate: randomUUID() })
+    expect(r1.status).toBe(403)
+    expect(r2.status).toBe(403)
+    expect(r3.status).toBe(403)
+  })
+})

--- a/packages/core-backend/tests/integration/org-directory-routing-policy-routes.db.test.ts
+++ b/packages/core-backend/tests/integration/org-directory-routing-policy-routes.db.test.ts
@@ -209,7 +209,7 @@ describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real
     expect(audits.rows[0].n).toBe(0)
   })
 
-  it('E. preview validations: unsupported purpose 400; non-UUID 400; cross-org 404; inactive 409', async () => {
+  it('E. preview validations: unsupported purpose 400; non-UUID 400; cross-org 404; inactive candidate 409; broken CURRENT policy 409', async () => {
     const e1 = await request(adminApp).get(`${BASE}/permission_scope/preview`).query({ candidate: randomUUID() })
     expect(e1.status).toBe(400)
     const e2 = await request(adminApp).get(`${BASE}/approval_routing/preview`).query({ candidate: 'nope' })
@@ -223,6 +223,18 @@ describeIfDatabase('Canonical Org MVP — B5-c routing-policy admin routes (real
     cleanupIntegrationIds.push(inactive)
     const e4 = await request(adminApp).get(`${BASE}/approval_routing/preview`).query({ candidate: inactive })
     expect(e4.status).toBe(409)
+
+    // gate P3: a broken CURRENT policy (its canonical went non-active AFTER being set) must 409
+    // with the MISCONFIGURED code — the operator fixes the live policy before previewing a switch.
+    const local = await getOrCreateLocalIntegration(orgId)
+    const willBreak = await dingtalkIntegration(orgId, 'pbrk')
+    cleanupIntegrationIds.push(willBreak)
+    const set = await request(adminApp).patch(`${BASE}/approval_routing`).send({ canonicalIntegrationId: willBreak })
+    expect(set.status).toBe(200)
+    await query(`UPDATE directory_integrations SET status = 'disabled' WHERE id = $1`, [willBreak])
+    const e5 = await request(adminApp).get(`${BASE}/approval_routing/preview`).query({ candidate: local.id })
+    expect(e5.status).toBe(409)
+    expect((e5.body.error?.code ?? e5.body.code)).toBe('ROUTING_POLICY_MISCONFIGURED')
   })
 
   it('F. non-admin: 403 on list, set, and preview (real RBAC path)', async () => {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -154,6 +154,12 @@ export default defineConfig({
       // real MetaSheetServer + real createApproval. DATABASE_URL-gated; wired as a WHOLE FILE into
       // the APPROVAL real-DB step (both points asserted by b5b-failclose-ci-wiring.test.mjs).
       'tests/integration/approval-routing-policy-failclose.api.test.ts',
+      // Canonical Org MVP B5-c (design lock Lock 3 + §7): the routing-policy admin ROUTES —
+      // platform-admin gating, PATCH write-point validations + values-free audit, clear path, and
+      // the READ-ONLY preview (real resolver both legs). HTTP against real Postgres.
+      // DATABASE_URL-gated; wired as a WHOLE FILE into the directory real-DB step (both points
+      // asserted by b5c-routing-routes-ci-wiring.test.mjs).
+      'tests/integration/org-directory-routing-policy-routes.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
       // resolution against real Postgres — normalized `is_manager` relation for a local integration,
       // the DingTalk `leader_in_dept` regression pin (load-bearing compat leg + is_manager=0 positive

--- a/scripts/ops/b5c-routing-routes-ci-wiring.test.mjs
+++ b/scripts/ops/b5c-routing-routes-ci-wiring.test.mjs
@@ -1,0 +1,24 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// B5-c CI two-point wiring contract. The routing-policy schema suite proves the resolver over the (org,purpose)
+// policy store's DB invariants (cross-org FK-impossible, closed purpose set, RESTRICT) against real
+// Postgres — meaningless without a DB. It needs BOTH (1) the vitest.config.ts exclude (so the no-DB
+// job cannot skip-green it) AND (2) the plugin-tests.yml directory real-DB whole-file step. Removing
+// either point silently disables the proof while CI stays green. Runs in the gating no-DB test job.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/org-directory-routing-policy-routes.db.test.ts'
+
+test('vitest.config.ts excludes the B5-c routing-policy suite from the no-DB job', () => {
+  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+})
+
+test('plugin-tests.yml runs the B5-c routing-policy suite as a whole file in the directory real-DB step', () => {
+  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  assert.match(wf, new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${FILE}`)
+})


### PR DESCRIPTION
## B5-c — routing-policy admin routes (routing-core slice 3 of 3)

> **HELD/unarmed until exact-head CI completes.** Restacked directly on current `main` `b09c380e2` after #4476. Current reviewed head: `424861ea3`. Delta: 7 files.

### As built

- `GET /api/admin/directory/routing-policy/`: lists all five closed purposes and each effective source.
- `PATCH /:purpose`: platform-admin-only, server-derived org, strict field allowlist. V1 writes only `approval_routing`; `canonicalIntegrationId: null` clears idempotently.
- Canonical targets must be same-org and active. Local canonical is default-OFF behind `DIRECTORY_ROUTING_LOCAL_CANONICAL_ENABLED=1`; preview remains available while OFF.
- `GET /:purpose/preview?candidate=...`: read-only current-vs-candidate comparison through the real resolver; no policy or audit write.
- Set/clear mutations emit values-free semantic audit records.

### Write-point race closure

The active-target read and policy upsert run in one transaction. The target row is selected `FOR SHARE` and held through commit:

- disable-first: PATCH waits, re-reads the committed inactive row, returns 409, writes no policy/audit;
- set-first: PATCH commits first, the later disable proceeds, and the B5-b resolver then fails closed on the disabled canonical.

The set-first test proves the exact blocking chain with backend PIDs:
`advisory holder -> PATCH -> disabler` via `pg_blocking_pids`. It does not accept a broad database waiter scan or a fixed sleep as the correctness oracle.

### Independent verification

Grok implemented and ran the focused checks; Codex then reviewed the diff and repeated the evidence on a newly created database `codex_b5c_review_20260719`:

- fresh migration chain and second replay: pass;
- B5-a schema + B5-b resolver/fail-close + B5-c routes + direct-manager compatibility: **55/55**;
- after rebasing across #4476, B5-c plus the newly landed dept-head suite: **24/24**;
- B5-c routes restored at the exact head: **9/9**;
- B5-b/B5-c two-point CI wiring guards: **4/4**;
- backend TypeScript check and `git diff --check`: pass.

Rebase evidence: aggregate patch-id stayed exactly `42ce56a430f4813b4ec60ac30461aca683bcde82`; both B5-c and #4476 CI entries remain present.

Independent load-bearing mutation replayed after the rebase: remove only SQL `FOR SHARE` while preserving the transaction. Test G fails semantically with `received 200, expected 409`; restoring it returns the route suite to 9/9.

No P1/P2 remains in the reviewed diff. Exact-head GitHub CI must settle green before the single auto-merge window is armed.
