### PR TITLE
feat(automation): #4196 Class-A same-transaction idempotency claim wiring

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -457,6 +457,7 @@ jobs:
             tests/integration/multitable-d1c-form-submit-revision-realdb.test.ts \
             tests/integration/multitable-d1c-plugin-revision-realdb.test.ts \
             tests/integration/multitable-d1c-automation-revision-realdb.test.ts \
+            tests/integration/multitable-4196-classa-claim-realdb.test.ts \
             tests/integration/multitable-d1c-approval-revision-realdb.test.ts \
             tests/integration/multitable-d1c-attachment-revision-realdb.test.ts \
             tests/integration/multitable-reset-pit-inbound-capture-realdb.test.ts \

--- a/packages/core-backend/src/multitable/automation-execution-ledger.ts
+++ b/packages/core-backend/src/multitable/automation-execution-ledger.ts
@@ -28,6 +28,16 @@ import { assertInTransaction, type TransactionalQueryable } from './pg-transacti
 
 export type ExecutionLedgerKind = 'execution' | 'test_run'
 
+/**
+ * #4196 Class-A same-transaction claim RUNTIME GATE — default OFF. The executor's Class-A action methods
+ * (update/create/delete/lock_record) only claim-then-skip-on-duplicate when this is ON. Off ⇒ every
+ * Class-A path is BYTE-IDENTICAL to pre-slice (no claim INSERT, no `assertInTransaction` probe, no skip).
+ * Follows the repo flag convention (`env.<NAME> === 'true'`, e.g. isSideDoorDeleteTrashEnabled).
+ */
+export function isClassAExecutionClaimEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.AUTOMATION_CLASSA_CLAIM_ENABLED === 'true'
+}
+
 const LEDGER_KINDS: ReadonlySet<string> = new Set<ExecutionLedgerKind>(['execution', 'test_run'])
 const NON_BLANK = /[!-~]/
 /** §6.1: the clientOperationId is an opaque bounded token — restricted charset, bounded length. */

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -7,6 +7,9 @@ import { randomUUID } from 'crypto'
 import { recordRecordRevision, recordVersionMarker } from './record-history-service'
 import { branchChildStepKey, topLevelStepKey } from './automation-step-key'
 import { deriveRuleActionSetFingerprint } from './automation-rule-fingerprint'
+import { claimExecutionAction, isClassAExecutionClaimEnabled } from './automation-execution-ledger'
+import { deriveActionKey } from './automation-action-idempotency'
+import type { TransactionalQueryable } from './pg-transaction-guard'
 import { Logger } from '../core/logger'
 import { withAutomationEventId } from './automation-event-dedup'
 import { redactString } from './automation-log-redact'
@@ -738,6 +741,25 @@ export interface AutomationStepResult {
   output?: unknown
   error?: string
   durationMs?: number
+  /**
+   * #4196 Class-A at-most-once marker. Set true ONLY when a Class-A action was SKIPPED because its
+   * (rootExecutionId, actionKey) claim was already held by a prior apply — i.e. a retry/replay hit a
+   * duplicate. The step still reports `status:'success'` so the execution proceeds, but NO mutation,
+   * NO revision, and NO downstream effect ran. Distinguishable so callers/tests can assert the skip.
+   */
+  alreadyApplied?: boolean
+}
+
+/**
+ * #4196 Class-A action identity threaded to the four Class-A executors so each can claim its
+ * (lineage-root, structural-path, action-type, config) tuple in the SAME transaction as its mutation.
+ * Absent (undefined) ⇒ no claim (e.g. the ad-hoc single-action dispatch, which is not a replayable
+ * execution action). `structuralPath` is the executor's canonical step-key (automation-step-key.ts);
+ * `rootExecutionId` is the execution lineage root (the original execution's id; a retry threads it).
+ */
+export interface ClassAActionIdentity {
+  structuralPath: string
+  rootExecutionId: string
 }
 
 export interface ExecutionContext {
@@ -749,6 +771,13 @@ export interface ExecutionContext {
   ruleCreatedBy: string
   actorId?: string | null
   triggerEvent: unknown
+  /**
+   * #4196 execution lineage root — the id of the FIRST execution in this retry lineage (defaults to the
+   * execution's own id when there is no parent; a retry threads the original root through
+   * AutomationService). Class-A claims key on this so a retry of the SAME action is a duplicate. Optional
+   * for back-compat: builders that omit it fall back to `executionId` at the claim call site.
+   */
+  rootExecutionId?: string
 }
 
 // ── Dependencies interface for action executors ───────────────────────────
@@ -887,6 +916,7 @@ export class AutomationExecutor {
     rule: AutomationRule,
     triggerEvent: unknown,
     jobLifecycleFactory?: ActionJobLifecycleFactory,
+    rootExecutionId?: string,
   ): Promise<AutomationExecution> {
     const executionId = `axe_${randomUUID()}`
     // A6-1: opt-in rules get a per-action job lifecycle bound to this executionId. The factory
@@ -925,6 +955,9 @@ export class AutomationExecutor {
       ruleCreatedBy: rule.createdBy,
       actorId: (payload?.actorId as string) ?? null,
       triggerEvent,
+      // #4196: the lineage root. A retry threads the original execution's root in; a first run has no
+      // parent, so it defaults to its own id. Class-A claims key on this (retry of the same action → dup).
+      rootExecutionId: rootExecutionId ?? executionId,
     }
 
     // Evaluate conditions
@@ -1130,7 +1163,10 @@ export class AutomationExecutor {
         }
 
         await jobLifecycle.onStart(cursor.parentStepIndex, branchAction, meta)
-        const branchActionResult = await this.executeSingleAction(branchAction, context)
+        const branchActionResult = await this.executeSingleAction(branchAction, context, {
+          structuralPath: stepKey,
+          rootExecutionId: context.rootExecutionId ?? context.executionId,
+        })
         await jobLifecycle.onSettled(cursor.parentStepIndex, branchAction, branchActionResult, meta)
         upstreamJobId = jobId
         if (branchActionResult.status === 'failed') {
@@ -1369,7 +1405,11 @@ export class AutomationExecutor {
       // A6-1 fail-closed: onStart runs BEFORE the inner try, so a job-create failure propagates
       // to execute()'s outer catch (execution fails) — and the action's side effect never runs.
       if (jobLifecycle) await jobLifecycle.onStart(index, action, topLevelMeta)
-      const result = await this.executeSingleAction(action, context)
+      // #4196 Class-A identity — the SAME canonical top-level step-key the job/fingerprint plane uses.
+      const result = await this.executeSingleAction(action, context, {
+        structuralPath: topLevelStepKey(index),
+        rootExecutionId: context.rootExecutionId ?? context.executionId,
+      })
 
       results.push(result)
 
@@ -1443,7 +1483,10 @@ export class AutomationExecutor {
         childJobIds.push(jobId)
 
         await jobLifecycle.onStart(stepIndex, branchAction, meta)
-        const branchActionResult = await this.executeSingleAction(branchAction, context)
+        const branchActionResult = await this.executeSingleAction(branchAction, context, {
+          structuralPath: stepKey,
+          rootExecutionId: context.rootExecutionId ?? context.executionId,
+        })
         await jobLifecycle.onSettled(stepIndex, branchAction, branchActionResult, meta)
 
         upstreamJobId = jobId
@@ -1640,7 +1683,10 @@ export class AutomationExecutor {
       }
 
       await jobLifecycle.onStart(stepIndex, branchAction, meta)
-      const branchActionResult = await this.executeSingleAction(branchAction, context)
+      const branchActionResult = await this.executeSingleAction(branchAction, context, {
+        structuralPath: stepKey,
+        rootExecutionId: context.rootExecutionId ?? context.executionId,
+      })
       await jobLifecycle.onSettled(stepIndex, branchAction, branchActionResult, meta)
       lastJobId = jobId
       upstreamJobId = jobId
@@ -1695,12 +1741,20 @@ export class AutomationExecutor {
     action: AutomationAction,
     context: ExecutionContext,
   ): Promise<AutomationStepResult> {
-    return this.executeSingleAction(action, context)
+    // #4196: NO Class-A claim here (identity undefined). A single ad-hoc action dispatch (a button
+    // click / run route) is not a replayable EXECUTION action — it has no execution lineage root and no
+    // retry semantics, so there is nothing to dedup against. Claiming here would need a lineage root that
+    // does not exist for this path.
+    return this.executeSingleAction(action, context, undefined)
   }
 
   private async executeSingleAction(
     action: AutomationAction,
     context: ExecutionContext,
+    // #4196 Class-A identity. Every rule-driven call site passes its canonical step-key; the ad-hoc
+    // single-action dispatch (runSingleAction) passes undefined → no claim. The four Class-A methods
+    // claim-then-skip-on-duplicate; every other action ignores it.
+    identity?: ClassAActionIdentity,
   ): Promise<AutomationStepResult> {
     const startMs = Date.now()
     let result: AutomationStepResult
@@ -1708,13 +1762,13 @@ export class AutomationExecutor {
     try {
       switch (action.type) {
         case 'update_record':
-          result = await this.executeUpdateRecord(action.config, context)
+          result = await this.executeUpdateRecord(action.config, context, identity)
           break
         case 'create_record':
-          result = await this.executeCreateRecord(action.config, context)
+          result = await this.executeCreateRecord(action.config, context, identity)
           break
         case 'delete_record':
-          result = await this.executeDeleteRecord(action.config, context)
+          result = await this.executeDeleteRecord(action.config, context, identity)
           break
         case 'send_webhook':
           result = await this.executeSendWebhook(action.config, context)
@@ -1735,7 +1789,7 @@ export class AutomationExecutor {
           result = await this.executeSendDingTalkApprovalCard(context)
           break
         case 'lock_record':
-          result = await this.executeLockRecord(action.config, context)
+          result = await this.executeLockRecord(action.config, context, identity)
           break
         case 'start_approval':
           result = {
@@ -2150,6 +2204,7 @@ export class AutomationExecutor {
   private async executeUpdateRecord(
     config: Record<string, unknown>,
     context: ExecutionContext,
+    identity?: ClassAActionIdentity,
   ): Promise<AutomationStepResult> {
     const fields = config.fields as Record<string, unknown> | undefined
     if (!fields || Object.keys(fields).length === 0) {
@@ -2202,6 +2257,12 @@ export class AutomationExecutor {
       // not assumed from D-1). A failed revision INSERT rolls the UPDATE back too — no half-write (an
       // updated `meta_records` row with no matching `meta_record_revisions` row) is possible.
       const txResult = await this.withTransaction(async (query) => {
+        // #4196 Class-A claim — FIRST statement, SAME transaction as the mutation+revision below. A
+        // duplicate (retry/replay) short-circuits: return the already-applied success and skip the UPDATE
+        // and its revision entirely. The (no-op) transaction still commits cleanly.
+        if (await this.claimClassAOrSkip(query, identity, 'update_record', config) === 'duplicate') {
+          return this.alreadyAppliedResult('update_record')
+        }
         // Record-lock guard (rank-8 review B1; decisions d/e/f). An automation acting on behalf of its
         // actor is NOT implicitly the locker/owner — overwriting a locked record is blocked. To write
         // through a lock the rule must first run a `lock_record{locked:false}` action (decision f). The
@@ -2308,6 +2369,7 @@ export class AutomationExecutor {
   private async executeDeleteRecord(
     config: Record<string, unknown>,
     context: ExecutionContext,
+    identity?: ClassAActionIdentity,
   ): Promise<AutomationStepResult> {
     // Phase C2a cross-base addressing — MIRRORS executeUpdateRecord. The resolved target sheet is
     // `config.targetSheetId ?? context.sheetId`. For a CROSS-BASE delete, `targetSheetId` +
@@ -2341,6 +2403,12 @@ export class AutomationExecutor {
       }
 
       const step = await this.withTransaction(async (query) => {
+        // #4196 Class-A claim — FIRST statement, SAME transaction as the delete+revision below. A
+        // duplicate (retry/replay) short-circuits: return the already-applied success and skip the DELETE,
+        // link cleanup, tombstones and revision entirely. The (no-op) transaction still commits cleanly.
+        if (await this.claimClassAOrSkip(query, identity, 'delete_record', config) === 'duplicate') {
+          return this.alreadyAppliedResult('delete_record')
+        }
         // Record-lock guard: you cannot delete a record locked by someone you can't unlock. The SELECT and
         // the DELETE below BOTH read `effectiveSheetId`/`effectiveRecordId`, so a cross-base delete checks
         // the TARGET record's lock (not the trigger record's) — lock priority over base-write.
@@ -2505,9 +2573,59 @@ export class AutomationExecutor {
     return handler(this.deps.queryFn)
   }
 
+  /**
+   * #4196 Class-A claim gate. Active ONLY when (a) the runtime flag is ON AND (b) `deps.transaction` is
+   * present — a REAL transaction. Condition (b) is not optional: `claimExecutionAction` runs
+   * `assertInTransaction` (a `pg_current_xact_id()` probe), which THROWS on the autocommit `queryFn`
+   * fallback `withTransaction` uses when `deps.transaction` is absent (many unit tests). Gating on it keeps
+   * every legacy/autocommit path unchanged. When this returns false the caller runs its original body.
+   */
+  private classAClaimActive(): boolean {
+    return isClassAExecutionClaimEnabled() && this.deps.transaction != null
+  }
+
+  /**
+   * #4196: the FIRST statement inside a Class-A method's `withTransaction` callback. Claims the action's
+   * (rootExecutionId, actionKey) tuple in THIS transaction. Returns 'proceed' when the gate is inactive or
+   * no identity is supplied (no claim — byte-identical legacy path) OR the claim was won ('claimed'); returns
+   * 'duplicate' when a prior apply already holds the claim, in which case the caller returns
+   * {@link alreadyAppliedResult} and skips its mutation entirely. `config` is passed RAW — `deriveActionKey`
+   * canonicalizes it (deep key-sort + sha256) internally, so the key matches the §4 fingerprint's per-action
+   * identity exactly. `query` is `withTransaction`'s transactional query fn; wrapped as a
+   * TransactionalQueryable so the ledger's DB-level xid probe runs against the SAME ongoing transaction.
+   */
+  private async claimClassAOrSkip(
+    query: AutomationDeps['queryFn'],
+    identity: ClassAActionIdentity | undefined,
+    actionType: AutomationActionType,
+    config: unknown,
+  ): Promise<'proceed' | 'duplicate'> {
+    if (!this.classAClaimActive() || !identity) return 'proceed'
+    const outcome = await claimExecutionAction(
+      { query, isTransaction: true } as unknown as TransactionalQueryable,
+      {
+        kind: 'execution',
+        rootExecutionId: identity.rootExecutionId,
+        actionKey: deriveActionKey({ structuralPath: identity.structuralPath, actionType, canonicalConfig: config }),
+        actionType,
+      },
+    )
+    return outcome === 'duplicate' ? 'duplicate' : 'proceed'
+  }
+
+  /**
+   * #4196: the step result for a Class-A action skipped as a duplicate claim. Looks like a success (so the
+   * execution proceeds past it) but carries `alreadyApplied:true` — NO mutation, NO revision, NO event/
+   * realtime fan-out ran (those all sit AFTER the `withTransaction` early-return in each Class-A method).
+   */
+  private alreadyAppliedResult(actionType: AutomationActionType): AutomationStepResult {
+    return { actionType, status: 'success', alreadyApplied: true, output: { alreadyApplied: true } }
+  }
+
   private async executeCreateRecord(
     config: Record<string, unknown>,
     context: ExecutionContext,
+    identity?: ClassAActionIdentity,
   ): Promise<AutomationStepResult> {
     const targetSheetId = (config.sheetId as string) || context.sheetId
     const declaredTargetBaseId = typeof config.targetBaseId === 'string' ? config.targetBaseId : undefined
@@ -2544,7 +2662,16 @@ export class AutomationExecutor {
       // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
       // create is rejected before this INSERT unless claim==truth + trigger-actor base-write. This is
       // the §1.3 create-to-another-base vector the gate closes. revision-emitted: D-1c slice ③ (A4) — recordRecordRevision(action:'create') below, same txn.
-      await this.withTransaction(async (query) => {
+      const skipped = await this.withTransaction(async (query) => {
+        // #4196 Class-A claim — FIRST statement, SAME transaction as the INSERT+revision below. A duplicate
+        // (retry/replay) short-circuits: skip the INSERT and its birth revision entirely. The (no-op)
+        // transaction still commits cleanly; the caller returns the already-applied success below.
+        if (await this.claimClassAOrSkip(query, identity, 'create_record', config) === 'duplicate') {
+          return 'duplicate' as const
+        }
+        // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
+        // create is rejected before this INSERT unless claim==truth + trigger-actor base-write (§1.3 vector).
+        // revision-emitted: D-1c slice ③ (A4) — recordRecordRevision(action:'create') below, same txn.
         await query(
           `INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1, $2, $3::jsonb, 1)`,
           [recordId, targetSheetId, JSON.stringify(data)],
@@ -2564,7 +2691,11 @@ export class AutomationExecutor {
           patch: data,
           snapshot: data,
         })
+        return null
       })
+      // #4196: a duplicate claim skipped the INSERT/revision — report the already-applied success and
+      // emit NO create event and NO real-time fan-out (a replay must produce zero downstream effect).
+      if (skipped === 'duplicate') return this.alreadyAppliedResult('create_record')
 
       this.deps.eventBus.emit('multitable.record.created', withAutomationEventId({
         sheetId: targetSheetId,
@@ -3444,6 +3575,7 @@ export class AutomationExecutor {
   private async executeLockRecord(
     config: Record<string, unknown>,
     context: ExecutionContext,
+    identity?: ClassAActionIdentity,
   ): Promise<AutomationStepResult> {
     const locked = config.locked !== false // default to true (decision f: config.locked === false → unlock)
 
@@ -3500,7 +3632,12 @@ export class AutomationExecutor {
         // withTransaction (mirrors the HTTP lock path) — a transient error between the two must not leave
         // a durable version hole that fail-closed-refuses revert/reset until C6. The three disposition
         // markers live INSIDE the callback: each structural guard scans a fixed window above the SQL line.
-        await this.withTransaction(async (query) => {
+        const skipped = await this.withTransaction(async (query) => {
+          // #4196 Class-A claim — FIRST statement, SAME transaction as the lock UPDATE+marker below. A
+          // duplicate (retry/replay) short-circuits: skip the version bump and the lock marker entirely.
+          if (await this.claimClassAOrSkip(query, identity, 'lock_record', config) === 'duplicate') {
+            return 'duplicate' as const
+          }
           // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — cross-base lock rejected unless claim==truth + base-write.
           // lock-mgmt: LOCK action — sets the lock columns themselves (not a data edit of a locked row).
           // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
@@ -3512,12 +3649,19 @@ export class AutomationExecutor {
           )
           const newVersion = Number((upd.rows[0] as { version?: unknown } | undefined)?.version)
           if (Number.isFinite(newVersion)) await recordVersionMarker(query, { sheetId: effectiveSheetId, recordId: effectiveRecordId, version: newVersion, kind: 'lock', actorId: typeof context.actorId === 'string' ? context.actorId : null })
+          return null
         })
+        if (skipped === 'duplicate') return this.alreadyAppliedResult('lock_record')
       } else {
         // W0-1: write an unlock marker at the new version — legitimate non-data bump, not a hole. Bump +
         // marker are atomic inside withTransaction (mirrors the HTTP unlock path) — no durable version hole.
         // Disposition markers live INSIDE the callback (fixed guard scan windows above the SQL line).
-        await this.withTransaction(async (query) => {
+        const skipped = await this.withTransaction(async (query) => {
+          // #4196 Class-A claim — FIRST statement, SAME transaction as the unlock UPDATE+marker below. A
+          // duplicate (retry/replay) short-circuits: skip the version bump and the unlock marker entirely.
+          if (await this.claimClassAOrSkip(query, identity, 'lock_record', config) === 'duplicate') {
+            return 'duplicate' as const
+          }
           // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — cross-base unlock rejected unless claim==truth + base-write.
           // lock-mgmt: UNLOCK action — clears the lock columns (decision f: automation may unlock).
           // revision-exempt: lock/unlock metadata-only — no `data` column touched, not a user-content edit.
@@ -3529,7 +3673,9 @@ export class AutomationExecutor {
           )
           const newVersion = Number((upd.rows[0] as { version?: unknown } | undefined)?.version)
           if (Number.isFinite(newVersion)) await recordVersionMarker(query, { sheetId: effectiveSheetId, recordId: effectiveRecordId, version: newVersion, kind: 'unlock', actorId: typeof context.actorId === 'string' ? context.actorId : null })
+          return null
         })
+        if (skipped === 'duplicate') return this.alreadyAppliedResult('lock_record')
       }
 
       return {

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -2282,11 +2282,14 @@ export class AutomationExecutor {
         // pre-②b leniency (a missing trigger record yields a 0-row UPDATE reported as success) to avoid
         // any behavior regression.
         if (gate.crossBase && !lockRow) {
-          return {
-            actionType: 'update_record',
-            status: 'failed',
-            error: `Cross-base update_record target record not found in target sheet: ${effectiveRecordId} ∉ ${effectiveSheetId}`,
-          } satisfies AutomationStepResult
+          // #4196 atomicity: THROW (not return) so this transaction — and the Class-A claim taken above —
+          // ROLLS BACK. A non-throwing `return {failed}` would COMMIT the claim for an action that never
+          // mutated, so a legitimate retry would skip as a FALSE duplicate (a lost update — the exact hazard
+          // this ledger exists to prevent). The method's outer catch reports the identical failed result.
+          // Consistent with the lock-conflict check just below, which already throws to roll back.
+          throw new Error(
+            `Cross-base update_record target record not found in target sheet: ${effectiveRecordId} ∉ ${effectiveSheetId}`,
+          )
         }
         if (lockRow) {
           ensureRecordNotLocked(context.actorId ?? null, lockRow, () => new Error('Record is locked'))
@@ -2441,11 +2444,14 @@ export class AutomationExecutor {
         // no-op success). Same-base keeps its leniency (a missing trigger record yields a 0-row DELETE
         // reported as success) to avoid any behavior regression vs the other same-base sinks.
         if (gate.crossBase && !lockRow) {
-          return {
-            actionType: 'delete_record',
-            status: 'failed',
-            error: `Cross-base delete_record target record not found in target sheet: ${effectiveRecordId} ∉ ${effectiveSheetId}`,
-          } satisfies AutomationStepResult
+          // #4196 atomicity: THROW (not return) so this transaction — and the Class-A claim taken above —
+          // ROLLS BACK. A non-throwing `return {failed}` would COMMIT the claim for an action that never
+          // deleted anything, so a legitimate retry would skip as a FALSE duplicate (the exact hazard this
+          // ledger exists to prevent). The method's outer catch reports the identical failed result.
+          // Consistent with the lock-conflict check just below, which already throws to roll back.
+          throw new Error(
+            `Cross-base delete_record target record not found in target sheet: ${effectiveRecordId} ∉ ${effectiveSheetId}`,
+          )
         }
         if (lockRow) {
           ensureRecordNotLocked(context.actorId ?? null, lockRow, () => new Error('Record is locked'))

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -2135,7 +2135,10 @@ export class AutomationService {
     const jobLifecycleFactory = persistJobs
       ? (executionId: string) => this.buildJobLifecycle(executionId, rule, triggerEvent, retryMeta?.rootExecutionId)
       : undefined
-    const execution = await this.executor.execute(rule, triggerEvent, jobLifecycleFactory)
+    // #4196: thread the retry lineage root into the executor so its ExecutionContext.rootExecutionId keys
+    // Class-A claims on the ORIGINAL execution's root (a retry re-running the same action → duplicate →
+    // skip). A first run has no retryMeta, so the executor defaults the root to its own execution id.
+    const execution = await this.executor.execute(rule, triggerEvent, jobLifecycleFactory, retryMeta?.rootExecutionId)
     if (retryMeta) {
       // A5: stamp retry provenance onto the NEW execution before persistence.
       execution.rerunOfExecutionId = retryMeta.rerunOfExecutionId
@@ -2418,6 +2421,9 @@ export class AutomationService {
     }
     const lineageIds = await this.collectExecutionLineageIds(execution)
     const rootExecutionId = lineageIds.at(-1) ?? execution.id
+    // #4196: carry the lineage root onto the resumed context so Class-A actions in the resumed tail claim
+    // on the SAME root as the original run (a resumed action re-applying itself → duplicate → skip).
+    context.rootExecutionId = rootExecutionId
     const jobLifecycle = this.buildJobLifecycle(execution.id, execRule, triggerEvent, rootExecutionId)
     const continued = resumeCursor.kind === 'condition_branch'
       ? await this.executor.continueBranchExecution(execution, execRule, context, resumeCursor.cursor, jobLifecycle)
@@ -2494,6 +2500,9 @@ export class AutomationService {
       ruleCreatedBy: execRule.createdBy,
       actorId: event.actor?.id ?? event.requester.id ?? null,
       triggerEvent,
+      // #4196: the bridge carries the lineage root; carry it onto the resumed context so Class-A actions
+      // in the approval-resumed tail claim on the same root.
+      rootExecutionId: bridge.rootExecutionId,
     }
     const continued = await this.executor.continueExecution(
       execution,

--- a/packages/core-backend/tests/integration/multitable-4196-classa-claim-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-4196-classa-claim-realdb.test.ts
@@ -20,6 +20,10 @@
  *       applies (proving a crash before COMMIT never permanently skips the missing write).
  *   G4  FLAG-OFF POSITIVE CONTROL: with the claim flag OFF, a replay on the same root RE-APPLIES (a second
  *       record) — proving the claim, not some incidental guard, is what enforces at-most-once.
+ *   G5  LOGICAL-FAILURE ROLLS BACK THE CLAIM: a cross-base update/delete whose gate passes but whose target
+ *       record does not exist fails AFTER the claim WITHOUT a DB exception. That path rolls the claim back
+ *       (throws, not `return {failed}`), so a retry re-attempts rather than being skipped as a false
+ *       duplicate. Complements G3 (DB-exception rollback) with the non-throwing logical-failure case.
  *
  * Cannot run locally (no DATABASE_URL). Wired into plugin-tests.yml's multitable real-DB run-list AND
  * excluded from the default no-DB vitest config (two-point convention), mirroring the d1c goldens.
@@ -41,6 +45,9 @@ const BASE = `base_ca_${TS}`
 const SHEET = `sheet_ca_${TS}`
 const SHEET_CRASH = `sheet_ca_crash_${TS}`
 const SHEET_OFF = `sheet_ca_off_${TS}`
+// G5 cross-base: a SECOND base OWNER owns (so the write-gate grants base-write) — the not-found target lives here.
+const BASE_XB = `base_ca_xb_${TS}`
+const SHEET_XB = `sheet_ca_xb_${TS}`
 const FLD_TITLE = `fld_ca_title_${TS}`
 
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
@@ -55,7 +62,7 @@ function realService(): AutomationService {
 
 function ruleFor(
   sheetId: string,
-  action: { type: 'create_record' | 'update_record'; config: Record<string, unknown> },
+  action: { type: 'create_record' | 'update_record' | 'delete_record'; config: Record<string, unknown> },
 ): AutomationRule {
   return {
     id: `atr_ca_${TS}_${Math.random().toString(36).slice(2, 8)}`,
@@ -144,6 +151,9 @@ describeIfDatabase('#4196 Class-A same-transaction claim (real DB)', () => {
         sheet,
       ])
     }
+    // G5: a second base OWNER owns + a sheet in it (the cross-base write target).
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [BASE_XB, 'Class-A XBase', OWNER])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_XB, BASE_XB, 'Class-A XSheet'])
   })
 
   afterAll(async () => {
@@ -156,7 +166,9 @@ describeIfDatabase('#4196 Class-A same-transaction claim (real DB)', () => {
       await q('DELETE FROM meta_fields WHERE sheet_id = $1', [sheet]).catch(() => {})
       await q('DELETE FROM meta_sheets WHERE id = $1', [sheet]).catch(() => {})
     }
-    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_XB]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_XB]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE, BASE_XB]]).catch(() => {})
     delete process.env[FLAG]
   })
 
@@ -277,4 +289,36 @@ describeIfDatabase('#4196 Class-A same-transaction claim (real DB)', () => {
       process.env[FLAG] = 'true'
     }
   })
+
+  // G5 — LOGICAL failure (non-throwing return) after the claim also ROLLS BACK ─────────────────────────
+  // The claim is the first statement in the txn, but a Class-A method can reject an action AFTER the claim
+  // WITHOUT throwing a DB error — e.g. a cross-base update/delete whose write-gate PASSES (OWNER owns the
+  // target base) but whose targetRecordId does not exist in the target sheet. That path must roll the claim
+  // back (it now THROWS instead of `return {failed}`), else the claim would persist for an action that never
+  // mutated and every retry would be skipped as a FALSE duplicate — a permanently-lost update. G3 proves the
+  // DB-exception path rolls back; G5 proves the LOGICAL-failure path does too.
+  for (const kind of ['update_record', 'delete_record'] as const) {
+    test(`G5 ${kind}: a cross-base target-not-found (logical failure after claim) leaves NO claim → retry re-attempts`, async () => {
+      const ghost = `ca_ghost_${kind}_${TS}` // a record id that does NOT exist in SHEET_XB
+      const config =
+        kind === 'update_record'
+          ? { targetBaseId: BASE_XB, targetSheetId: SHEET_XB, targetRecordId: ghost, fields: { [FLD_TITLE]: 'x' } }
+          : { targetBaseId: BASE_XB, targetSheetId: SHEET_XB, targetRecordId: ghost }
+      const rule = ruleFor(SHEET, { type: kind, config })
+
+      const first = await svc.executeRule(rule, { actorId: OWNER, data: {} })
+      expect(first.status).toBe('failed')
+      expect(first.steps[0]?.error).toMatch(/target record not found/)
+      // THE POINT: the transaction rolled back, so the claim is NOT durable (no orphan skip).
+      expect(await claimRowsFor(first.id)).toHaveLength(0)
+
+      // A retry on the SAME root is NOT skipped as a duplicate — it re-attempts and fails the same way,
+      // and STILL leaves no claim. Before the throw-to-rollback fix this returned `alreadyApplied` success.
+      const retry = await replay(svc, rule, { actorId: OWNER, data: {} }, first)
+      expect(retry.status).toBe('failed')
+      expect(retry.steps[0]?.alreadyApplied).toBeUndefined()
+      expect(retry.steps[0]?.error).toMatch(/target record not found/)
+      expect(await claimRowsFor(first.id)).toHaveLength(0)
+    })
+  }
 })

--- a/packages/core-backend/tests/integration/multitable-4196-classa-claim-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-4196-classa-claim-realdb.test.ts
@@ -1,0 +1,280 @@
+/**
+ * #4196 — Class-A same-transaction idempotency claim, real-DB goldens (CI-only; DATABASE_URL-gated).
+ *
+ * When an automation execution is RETRIED/REPLAYED, a Class-A action (a DB mutation) must apply AT MOST
+ * ONCE per (execution-lineage-root, action-identity). The claim rides the SAME transaction as the
+ * mutation: a duplicate claim → the mutation is skipped entirely (zero second row, zero second revision).
+ *
+ * These goldens exercise the REAL production wiring: `AutomationService.executeRule(...)` — index.ts
+ * constructs `AutomationService` with `pool.query.bind(pool)`, and the constructor hard-wires
+ * `deps.transaction` to a real `poolManager.get().transaction(...)`. A replay is driven by calling
+ * `executeRule` again with the ORIGINAL execution's `rootExecutionId` in `retryMeta` — exactly what
+ * `retryExecution` threads through `collectExecutionLineageIds` for a real admin retry.
+ *
+ *   G1  REPLAY IS A NO-OP (create): first run creates 1 record + 1 revision + 1 claim; a replay on the same
+ *       root claims a DUPLICATE, skips the INSERT, and returns `alreadyApplied` — still exactly 1 of each.
+ *   G2  REPLAY IS A NO-OP (update): a fixed-record update applies once (version bump + 1 update revision); a
+ *       replay on the same root does NOT bump the version and writes NO second update revision.
+ *   G3  CRASH ROLLS BACK THE CLAIM: a Postgres failure injected into the revision INSERT rolls the WHOLE
+ *       transaction back — the claim row is NOT durable (no orphan). A clean retry then SUCCEEDS and
+ *       applies (proving a crash before COMMIT never permanently skips the missing write).
+ *   G4  FLAG-OFF POSITIVE CONTROL: with the claim flag OFF, a replay on the same root RE-APPLIES (a second
+ *       record) — proving the claim, not some incidental guard, is what enforces at-most-once.
+ *
+ * Cannot run locally (no DATABASE_URL). Wired into plugin-tests.yml's multitable real-DB run-list AND
+ * excluded from the default no-DB vitest config (two-point convention), mirroring the d1c goldens.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { EventBus } from '../../src/integration/events/event-bus'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { db } from '../../src/db/db'
+import type { AutomationExecution, AutomationRule } from '../../src/multitable/automation-executor'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const FLAG = 'AUTOMATION_CLASSA_CLAIM_ENABLED'
+const TS = Date.now()
+const OWNER = `u_ca_owner_${TS}`
+const BASE = `base_ca_${TS}`
+const SHEET = `sheet_ca_${TS}`
+const SHEET_CRASH = `sheet_ca_crash_${TS}`
+const SHEET_OFF = `sheet_ca_off_${TS}`
+const FLD_TITLE = `fld_ca_title_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+/** The REAL production AutomationService wiring — mirrors index.ts (real queryFn; constructor hard-wires
+ * deps.transaction to a real poolManager.get().transaction(...)). This is what makes the same-transaction
+ * claim + atomicity proofs real, never a hand-rolled query calling private methods. */
+function realService(): AutomationService {
+  const pool = poolManager.get()
+  return new AutomationService(new EventBus(), db as never, pool.query.bind(pool))
+}
+
+function ruleFor(
+  sheetId: string,
+  action: { type: 'create_record' | 'update_record'; config: Record<string, unknown> },
+): AutomationRule {
+  return {
+    id: `atr_ca_${TS}_${Math.random().toString(36).slice(2, 8)}`,
+    name: 'Class-A rule',
+    sheetId,
+    trigger: { type: 'record.created', config: {} },
+    actions: [action as never],
+    enabled: true,
+    createdBy: OWNER,
+    createdAt: new Date().toISOString(),
+  } as unknown as AutomationRule
+}
+
+const recordsIn = async (sheetId: string): Promise<string[]> =>
+  ((await q('SELECT id FROM meta_records WHERE sheet_id = $1 ORDER BY id', [sheetId])).rows as Array<{ id: string }>).map(
+    (r) => r.id,
+  )
+
+const recordRow = async (recordId: string): Promise<{ version: number; data: Record<string, unknown> } | undefined> =>
+  (await q('SELECT version, data FROM meta_records WHERE id = $1', [recordId])).rows[0] as
+    | { version: number; data: Record<string, unknown> }
+    | undefined
+
+const revisionsOf = async (recordId: string): Promise<Array<{ action: string; version: number }>> =>
+  (
+    await q(
+      `SELECT action, version FROM meta_record_revisions WHERE record_id = $1 ORDER BY created_at ASC, version ASC`,
+      [recordId],
+    )
+  ).rows as Array<{ action: string; version: number }>
+
+const claimRowsFor = async (root: string): Promise<Array<{ action_key: string; action_type: string | null }>> =>
+  (
+    await q(
+      `SELECT action_key, action_type FROM meta_automation_action_applied WHERE kind = 'execution' AND root_execution_id = $1`,
+      [root],
+    )
+  ).rows as Array<{ action_key: string; action_type: string | null }>
+
+/** Genuine Postgres-level failure injection (never a JS mock) — mirrors the d1c goldens. */
+async function injectTrigger(
+  name: string,
+  spec: { table: string; timing: string; when: string; errcode: string; message: string },
+): Promise<void> {
+  await q(`CREATE OR REPLACE FUNCTION ${name}() RETURNS trigger AS $fn$
+           BEGIN
+             RAISE EXCEPTION '${spec.message}' USING ERRCODE = '${spec.errcode}';
+           END $fn$ LANGUAGE plpgsql`)
+  await q(`CREATE TRIGGER ${name}_trg BEFORE ${spec.timing} ON ${spec.table}
+           FOR EACH ROW WHEN (${spec.when}) EXECUTE FUNCTION ${name}()`)
+}
+async function dropTrigger(name: string, table: string): Promise<void> {
+  await q(`DROP TRIGGER IF EXISTS ${name}_trg ON ${table}`).catch(() => {})
+  await q(`DROP FUNCTION IF EXISTS ${name}()`).catch(() => {})
+}
+
+/** Replay: re-run the rule with the ORIGINAL execution's lineage root (what a real admin retry threads). */
+function replay(
+  svc: AutomationService,
+  rule: AutomationRule,
+  triggerEvent: unknown,
+  original: AutomationExecution,
+): Promise<AutomationExecution> {
+  return svc.executeRule(rule, triggerEvent, {
+    rerunOfExecutionId: original.id,
+    initiatedBy: OWNER,
+    rootExecutionId: original.id, // first run had no parent, so its root is its own id
+  })
+}
+
+describeIfDatabase('#4196 Class-A same-transaction claim (real DB)', () => {
+  let svc: AutomationService
+
+  beforeAll(async () => {
+    process.env[FLAG] = 'true'
+    svc = realService()
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [BASE, 'Class-A Base', OWNER])
+    for (const [sheet, name] of [
+      [SHEET, 'Class-A Sheet'],
+      [SHEET_CRASH, 'Class-A Crash Sheet'],
+      [SHEET_OFF, 'Class-A Flag-Off Sheet'],
+    ]) {
+      await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [sheet, BASE, name])
+      await q(`INSERT INTO meta_fields (id, sheet_id, name, type, "order") VALUES ($1,$2,'Title','string',0)`, [
+        `${FLD_TITLE}_${sheet}`,
+        sheet,
+      ])
+    }
+  })
+
+  afterAll(async () => {
+    for (const sheet of [SHEET, SHEET_CRASH, SHEET_OFF]) {
+      await q(
+        'DELETE FROM meta_record_revisions WHERE record_id IN (SELECT id FROM meta_records WHERE sheet_id = $1)',
+        [sheet],
+      ).catch(() => {})
+      await q('DELETE FROM meta_records WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_fields WHERE sheet_id = $1', [sheet]).catch(() => {})
+      await q('DELETE FROM meta_sheets WHERE id = $1', [sheet]).catch(() => {})
+    }
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    delete process.env[FLAG]
+  })
+
+  test('sentinel: DATABASE_URL is set and the flag is ON', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+    expect(process.env[FLAG]).toBe('true')
+  })
+
+  // G1 — create_record replay no-op ────────────────────────────────────────────────────────────────────
+  test('G1 create_record: replay on the same root is a NO-OP — exactly ONE record + ONE revision + ONE claim', async () => {
+    const rule = ruleFor(SHEET, { type: 'create_record', config: { sheetId: SHEET, data: { [FLD_TITLE]: 'once' } } })
+    const first = await svc.executeRule(rule, { actorId: OWNER, data: {} })
+    expect(first.status).toBe('success')
+    expect(first.steps[0]?.alreadyApplied).toBeUndefined()
+    const recordId = (first.steps[0]?.output as { recordId: string }).recordId
+
+    // The claim committed alongside the record + revision.
+    expect(await recordsIn(SHEET)).toEqual([recordId])
+    expect(await revisionsOf(recordId)).toEqual([{ action: 'create', version: 1 }])
+    expect(await claimRowsFor(first.id)).toHaveLength(1)
+
+    // Replay on the SAME root → duplicate claim → the INSERT is skipped entirely.
+    const second = await replay(svc, rule, { actorId: OWNER, data: {} }, first)
+    expect(second.status).toBe('success')
+    expect(second.steps[0]?.alreadyApplied).toBe(true) // the distinguishable skip marker
+    expect((second.steps[0]?.output as { recordId?: string }).recordId).toBeUndefined()
+
+    // Zero second row, zero second revision, still exactly one claim.
+    expect(await recordsIn(SHEET)).toEqual([recordId])
+    expect(await revisionsOf(recordId)).toEqual([{ action: 'create', version: 1 }])
+    expect(await claimRowsFor(first.id)).toHaveLength(1)
+  })
+
+  // G2 — update_record replay no-op (fixed record) ─────────────────────────────────────────────────────
+  test('G2 update_record: replay on the same root does NOT bump the version and writes NO second update revision', async () => {
+    const created = await svc.executeRule(
+      ruleFor(SHEET, { type: 'create_record', config: { sheetId: SHEET, data: { [FLD_TITLE]: 'v1' } } }),
+      { actorId: OWNER, data: {} },
+    )
+    const recordId = (created.steps[0]?.output as { recordId: string }).recordId
+
+    const updRule = ruleFor(SHEET, { type: 'update_record', config: { fields: { [FLD_TITLE]: 'v2' } } })
+    const first = await svc.executeRule(updRule, { recordId, actorId: OWNER, data: {} })
+    expect(first.status).toBe('success')
+    expect(first.steps[0]?.alreadyApplied).toBeUndefined()
+    expect((await recordRow(recordId))?.version).toBe(2)
+    expect((await recordRow(recordId))?.data).toMatchObject({ [FLD_TITLE]: 'v2' })
+    expect((await revisionsOf(recordId)).filter((r) => r.action === 'update')).toHaveLength(1)
+
+    // Replay on the SAME root → duplicate → no version bump, no second update revision.
+    const second = await replay(svc, updRule, { recordId, actorId: OWNER, data: {} }, first)
+    expect(second.status).toBe('success')
+    expect(second.steps[0]?.alreadyApplied).toBe(true)
+    expect((await recordRow(recordId))?.version).toBe(2) // still v2 — no third version
+    expect((await revisionsOf(recordId)).filter((r) => r.action === 'update')).toHaveLength(1)
+  })
+
+  // G3 — a crash rolls the claim back (no orphan) ──────────────────────────────────────────────────────
+  test('G3 crash-atomicity: a failing revision INSERT rolls the CLAIM back too — a clean retry then SUCCEEDS', async () => {
+    const rule = ruleFor(SHEET_CRASH, {
+      type: 'create_record',
+      config: { sheetId: SHEET_CRASH, data: { [FLD_TITLE]: 'crash-then-retry' } },
+    })
+    const trg = `ca_crash_rev_trg_${TS}`
+    let firstRoot: string
+    await injectTrigger(trg, {
+      table: 'meta_record_revisions',
+      timing: 'INSERT',
+      when: `NEW.sheet_id = '${SHEET_CRASH}'`,
+      errcode: 'P0001',
+      message: 'Class-A injected revision failure',
+    })
+    try {
+      const failed = await svc.executeRule(rule, { actorId: OWNER, data: {} })
+      firstRoot = failed.id
+      expect(failed.status).toBe('failed')
+      expect(failed.steps[0]?.error).toMatch(/injected revision failure/)
+    } finally {
+      await dropTrigger(trg, 'meta_record_revisions')
+    }
+
+    // The WHOLE transaction (claim + record INSERT + revision) rolled back: no record, no revision, and —
+    // the point of this golden — NO durable claim row. An orphaned claim here would make every retry
+    // return 'duplicate' and permanently skip the never-applied write.
+    expect(await recordsIn(SHEET_CRASH)).toEqual([])
+    expect(await claimRowsFor(firstRoot!)).toHaveLength(0)
+
+    // A clean retry on the SAME root now succeeds (claims fresh, applies once) — not skipped as a duplicate.
+    const retry = await replay(svc, rule, { actorId: OWNER, data: {} }, { id: firstRoot! } as unknown as AutomationExecution)
+    expect(retry.status).toBe('success')
+    expect(retry.steps[0]?.alreadyApplied).toBeUndefined()
+    const recordId = (retry.steps[0]?.output as { recordId: string }).recordId
+    expect(await recordsIn(SHEET_CRASH)).toEqual([recordId])
+    expect(await revisionsOf(recordId)).toEqual([{ action: 'create', version: 1 }])
+    expect(await claimRowsFor(firstRoot!)).toHaveLength(1)
+  })
+
+  // G4 — flag OFF positive control: replay RE-APPLIES ──────────────────────────────────────────────────
+  test('G4 flag-OFF control: with the claim flag OFF a replay RE-APPLIES (a second record) — the claim is what dedups', async () => {
+    delete process.env[FLAG]
+    try {
+      const rule = ruleFor(SHEET_OFF, {
+        type: 'create_record',
+        config: { sheetId: SHEET_OFF, data: { [FLD_TITLE]: 'flag-off' } },
+      })
+      const first = await svc.executeRule(rule, { actorId: OWNER, data: {} })
+      expect(first.status).toBe('success')
+      expect(first.steps[0]?.alreadyApplied).toBeUndefined()
+
+      const second = await replay(svc, rule, { actorId: OWNER, data: {} }, first)
+      expect(second.status).toBe('success')
+      expect(second.steps[0]?.alreadyApplied).toBeUndefined() // NOT a skip — the flag is off
+
+      // Two distinct records exist, and no claim rows were written at all.
+      expect(await recordsIn(SHEET_OFF)).toHaveLength(2)
+      expect(await claimRowsFor(first.id)).toHaveLength(0)
+    } finally {
+      process.env[FLAG] = 'true'
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/automation-classa-claim.test.ts
+++ b/packages/core-backend/tests/unit/automation-classa-claim.test.ts
@@ -1,0 +1,278 @@
+/**
+ * #4196 Class-A same-transaction idempotency claim — executor wiring (unit).
+ *
+ * Proves the claim-then-skip-on-duplicate contract for the four Class-A actions
+ * (update/create/delete/lock_record) with a MOCKED transaction that records claims and controls their
+ * outcome. This is the fast local proof; the real-DB crash-injection golden
+ * (`tests/integration/multitable-4196-classa-claim-realdb.test.ts`) proves the same against a real schema.
+ *
+ * The mock's `deps.transaction` routes the callback's `query` through `handleSql`, which:
+ *   - answers the `pg_current_xact_id()` probe with a STABLE xid (models one ongoing transaction, so the
+ *     ledger's `assertInTransaction` guard passes — exactly as a real pg transaction would);
+ *   - answers the ledger claim INSERT with a controllable rowCount (1 = 'claimed', 0 = 'duplicate');
+ *   - counts the ACTUAL record mutation (UPDATE/INSERT/DELETE meta_records) — the write spy.
+ *
+ * When `deps.transaction` is present the claim gate is active iff the runtime flag is ON; with the flag OFF
+ * the Class-A path must be byte-identical to baseline (no claim, one mutation) — asserted below.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  AutomationExecutor,
+  type ActionJobLifecycle,
+  type AutomationDeps,
+  type AutomationRule,
+} from '../../src/multitable/automation-executor'
+import { deriveActionKey } from '../../src/multitable/automation-action-idempotency'
+import { EventBus } from '../../src/integration/events/event-bus'
+
+const FLAG = 'AUTOMATION_CLASSA_CLAIM_ENABLED'
+const STABLE_XID = '424242'
+
+interface MockState {
+  claimParams: unknown[][] // params array of every ledger-claim INSERT (kind, root, action_key, action_type)
+  recordMutations: number // real meta_records UPDATE/INSERT/DELETE — the write spy
+  revisionInserts: number
+  probeCalls: number
+  /** 1 → the claim is WON ('claimed'); 0 → a prior apply holds it ('duplicate'). */
+  claimRowCount: number
+}
+
+function makeState(): MockState {
+  return { claimParams: [], recordMutations: 0, revisionInserts: 0, probeCalls: 0, claimRowCount: 1 }
+}
+
+function makeHandleSql(state: MockState) {
+  return async (sql: unknown, params?: unknown[]): Promise<{ rows: unknown[]; rowCount: number }> => {
+    const s = String(sql)
+    if (/pg_current_xact_id/i.test(s)) {
+      state.probeCalls++
+      return { rows: [{ xid: STABLE_XID }], rowCount: 1 }
+    }
+    if (/meta_automation_action_applied/i.test(s)) {
+      state.claimParams.push(params ?? [])
+      return { rows: [], rowCount: state.claimRowCount } // 1 = claimed, 0 = duplicate
+    }
+    if (/meta_record_revisions/i.test(s)) {
+      state.revisionInserts++
+      return { rows: [], rowCount: 1 }
+    }
+    if (/UPDATE\s+meta_records|INSERT\s+INTO\s+meta_records|DELETE\s+FROM\s+meta_records/i.test(s)) {
+      state.recordMutations++
+      // UPDATE ... RETURNING version, data → give the revision path a row to work from.
+      return { rows: [{ version: 2, data: {} }], rowCount: 1 }
+    }
+    if (/SELECT[\s\S]*FROM\s+meta_records/i.test(s)) {
+      // lock-check SELECT — an unlocked, existing row so update/delete proceed.
+      return { rows: [{ locked: false, locked_by: null, created_by: 'user_1', version: 1, data: {} }], rowCount: 1 }
+    }
+    if (/FROM\s+meta_fields/i.test(s)) return { rows: [], rowCount: 0 } // rich-longtext sanitize: no longText fields
+    return { rows: [], rowCount: 1 }
+  }
+}
+
+/** deps with BOTH queryFn (autocommit helpers) and a transaction that routes through the same handler. */
+function makeDeps(state: MockState): AutomationDeps {
+  const handle = makeHandleSql(state)
+  return {
+    eventBus: new EventBus(),
+    queryFn: vi.fn(handle),
+    transaction: vi.fn(async (handler) => handler({ query: vi.fn(handle) })),
+  }
+}
+
+/** deps WITHOUT a transaction (autocommit fallback) — the legacy shape the gate's (b) condition excludes. */
+function makeAutocommitDeps(state: MockState): AutomationDeps {
+  const handle = makeHandleSql(state)
+  return { eventBus: new EventBus(), queryFn: vi.fn(handle) }
+}
+
+function ruleWith(action: { type: string; config: Record<string, unknown> }, overrides: Partial<AutomationRule> = {}): AutomationRule {
+  return {
+    id: 'rule_ca',
+    name: 'Class-A rule',
+    sheetId: 'sheet_1',
+    trigger: { type: 'record.created', config: {} },
+    actions: [action as never],
+    enabled: true,
+    createdBy: 'user_1',
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as AutomationRule
+}
+
+const TRIGGER = { recordId: 'rec_1', sheetId: 'sheet_1', actorId: 'user_1', data: {} }
+
+beforeEach(() => {
+  delete process.env[FLAG]
+})
+afterEach(() => {
+  delete process.env[FLAG]
+  vi.restoreAllMocks()
+})
+
+describe('#4196 Class-A claim — flag ON, first run claims and mutates once', () => {
+  for (const action of [
+    { type: 'update_record', config: { fields: { status: 'done' } } },
+    { type: 'create_record', config: { sheetId: 'sheet_1', data: { title: 'x' } } },
+    { type: 'delete_record', config: {} },
+    { type: 'lock_record', config: { locked: true } },
+  ]) {
+    it(`${action.type}: claim WON → one mutation, one ledger claim keyed on the top-level step-key + own execution id`, async () => {
+      process.env[FLAG] = 'true'
+      const state = makeState()
+      state.claimRowCount = 1 // claimed
+      const exec = await new AutomationExecutor(makeDeps(state)).execute(ruleWith(action), TRIGGER)
+
+      expect(exec.steps[0]?.status).toBe('success')
+      expect(exec.steps[0]?.alreadyApplied).toBeUndefined()
+      expect(state.recordMutations).toBe(1) // the write ran exactly once
+      expect(state.claimParams).toHaveLength(1)
+
+      // The claim rode a real (mocked) transaction: assertInTransaction probed pg_current_xact_id twice.
+      expect(state.probeCalls).toBeGreaterThanOrEqual(2)
+
+      // Identity: kind='execution', root = this execution's own id (no parent), action_key = §2.1 triple
+      // over the SAME top-level step-key ('0') the fingerprint/job plane uses.
+      const [kind, root, actionKey, actionType] = state.claimParams[0] as [string, string, string, string]
+      expect(kind).toBe('execution')
+      expect(root).toBe(exec.id)
+      expect(actionType).toBe(action.type)
+      expect(actionKey).toBe(
+        deriveActionKey({ structuralPath: '0', actionType: action.type, canonicalConfig: action.config }),
+      )
+    })
+  }
+})
+
+describe('#4196 Class-A claim — flag ON, replay (duplicate) skips the mutation entirely', () => {
+  for (const action of [
+    { type: 'update_record', config: { fields: { status: 'done' } } },
+    { type: 'create_record', config: { sheetId: 'sheet_1', data: { title: 'x' } } },
+    { type: 'delete_record', config: {} },
+    { type: 'lock_record', config: { locked: true } },
+  ]) {
+    it(`${action.type}: claim DUPLICATE → NO mutation, NO revision, step marked alreadyApplied`, async () => {
+      process.env[FLAG] = 'true'
+      const state = makeState()
+      state.claimRowCount = 0 // duplicate — a prior apply already holds the claim
+      const exec = await new AutomationExecutor(makeDeps(state)).execute(ruleWith(action), TRIGGER)
+
+      expect(exec.status).toBe('success')
+      expect(exec.steps[0]?.status).toBe('success') // still a success so the execution proceeds
+      expect(exec.steps[0]?.alreadyApplied).toBe(true) // …but distinguishably a skip
+      expect(state.claimParams).toHaveLength(1) // the claim was attempted
+      expect(state.recordMutations).toBe(0) // the mutation was NOT run — zero second effect
+      expect(state.revisionInserts).toBe(0) // and no revision was fabricated
+    })
+  }
+})
+
+describe('#4196 Class-A claim — flag OFF is byte-identical to baseline (no claim)', () => {
+  for (const action of [
+    { type: 'update_record', config: { fields: { status: 'done' } } },
+    { type: 'create_record', config: { sheetId: 'sheet_1', data: { title: 'x' } } },
+    { type: 'delete_record', config: {} },
+    { type: 'lock_record', config: { locked: true } },
+  ]) {
+    it(`${action.type}: flag OFF → claim never invoked, mutation runs once, no alreadyApplied marker`, async () => {
+      // Flag unset (default OFF). deps.transaction IS present — proving it is the FLAG, not the missing
+      // transaction, that keeps the claim dormant here.
+      const state = makeState()
+      const exec = await new AutomationExecutor(makeDeps(state)).execute(ruleWith(action), TRIGGER)
+
+      expect(exec.steps[0]?.status).toBe('success')
+      expect(exec.steps[0]?.alreadyApplied).toBeUndefined()
+      expect(state.claimParams).toHaveLength(0) // NO claim INSERT ever ran
+      expect(state.probeCalls).toBe(0) // NO xid probe ran
+      expect(state.recordMutations).toBe(1) // the write ran exactly once, as before this slice
+    })
+  }
+})
+
+describe('#4196 Class-A claim — gate condition (b): no claim on the autocommit fallback even with flag ON', () => {
+  it('flag ON but deps.transaction ABSENT → claim never invoked (would throw in assertInTransaction otherwise)', async () => {
+    process.env[FLAG] = 'true'
+    const state = makeState()
+    const exec = await new AutomationExecutor(makeAutocommitDeps(state)).execute(
+      ruleWith({ type: 'update_record', config: { fields: { status: 'done' } } }),
+      TRIGGER,
+    )
+    // The autocommit path must be untouched: the mutation runs, but the claim (and its xid probe, which
+    // would throw here) never runs — so the legacy/test path is preserved.
+    expect(exec.steps[0]?.status).toBe('success')
+    expect(exec.steps[0]?.alreadyApplied).toBeUndefined()
+    expect(state.claimParams).toHaveLength(0)
+    expect(state.probeCalls).toBe(0)
+    expect(state.recordMutations).toBe(1)
+  })
+})
+
+describe('#4196 Class-A claim — retry lineage root threads into the claim key', () => {
+  it('execute(rule, event, factory, rootExecutionId) → claim keys on the PASSED root, not the new execution id', async () => {
+    process.env[FLAG] = 'true'
+    const state = makeState()
+    const exec = await new AutomationExecutor(makeDeps(state)).execute(
+      ruleWith({ type: 'update_record', config: { fields: { status: 'done' } } }),
+      TRIGGER,
+      undefined,
+      'axe_original_root', // a retry threads the ORIGINAL execution's root
+    )
+    expect(exec.id).not.toBe('axe_original_root') // a fresh execution id…
+    const [, root] = state.claimParams[0] as [string, string]
+    expect(root).toBe('axe_original_root') // …but the claim keys on the lineage root
+  })
+})
+
+describe('#4196 Class-A claim — nested branch child claims on the BRANCH step-key identity', () => {
+  function noopLifecycle(): ActionJobLifecycle {
+    return {
+      onExecutionStarted: vi.fn(async () => {}),
+      onStart: vi.fn(async () => {}),
+      onSettled: vi.fn(async () => {}),
+      onSkipped: vi.fn(async () => {}),
+    }
+  }
+
+  const parallelRule = () =>
+    ruleWith(
+      {
+        type: 'parallel_branch',
+        config: {
+          joinMode: 'all',
+          branches: [
+            { key: 'b1', actions: [{ type: 'update_record', config: { fields: { status: 'branch-done' } } }] },
+          ],
+        },
+      },
+      { executionMode: 'workflow_job_v1' },
+    )
+
+  const CHILD_KEY = deriveActionKey({
+    structuralPath: '0.parallel.b1.0',
+    actionType: 'update_record',
+    canonicalConfig: { fields: { status: 'branch-done' } },
+  })
+
+  it('first run → branch child claims once on `0.parallel.b1.0`, mutation runs once', async () => {
+    process.env[FLAG] = 'true'
+    const state = makeState()
+    state.claimRowCount = 1
+    await new AutomationExecutor(makeDeps(state)).execute(parallelRule(), TRIGGER, () => noopLifecycle())
+
+    expect(state.claimParams).toHaveLength(1)
+    expect((state.claimParams[0] as string[])[2]).toBe(CHILD_KEY) // the BRANCH step-key identity flowed through
+    expect(state.recordMutations).toBe(1)
+  })
+
+  it('replay (duplicate) → branch child mutation skipped', async () => {
+    process.env[FLAG] = 'true'
+    const state = makeState()
+    state.claimRowCount = 0 // duplicate
+    await new AutomationExecutor(makeDeps(state)).execute(parallelRule(), TRIGGER, () => noopLifecycle())
+
+    expect(state.claimParams).toHaveLength(1)
+    expect((state.claimParams[0] as string[])[2]).toBe(CHILD_KEY)
+    expect(state.recordMutations).toBe(0) // the branch-child write did NOT run on replay
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -319,6 +319,12 @@ export default defineConfig({
       // skip-green in the no-DB lane, whole-file wired into `Run multitable real-DB integration` in
       // plugin-tests.yml.
       'tests/integration/multitable-d1c-automation-revision-realdb.test.ts',
+      // #4196 Class-A same-transaction idempotency claim goldens (replay no-op for create/update, crash
+      // rolls the claim back, flag-OFF positive control), driven through the real
+      // AutomationService.executeRule entry point (constructor hard-wires deps.transaction to a real
+      // poolManager.get().transaction). Real Postgres only — excluded HERE so it cannot skip-green in the
+      // no-DB lane, whole-file wired into `Run multitable real-DB integration` in plugin-tests.yml.
+      'tests/integration/multitable-4196-classa-claim-realdb.test.ts',
       // D-1c W0 slice ④ (approval resultWriteback revision goldens, driven through the real
       // dispatchAction -> approval.completed event bus -> AutomationService.handleApprovalCompletionEvent
       // -> writeApprovalResultBack chain + the concurrent-delete zero-row fail-closed golden, which uses a


### PR DESCRIPTION
## What
Wires the four Class-A automation actions (`update_record`, `create_record`, `delete_record`, `lock_record`) to **claim their action identity in the SAME transaction as their mutation**, so a retried/replayed execution applies each Class-A action **at most once** per `(execution-lineage-root, action-identity)`. A duplicate claim → the mutation is skipped entirely: zero second row, zero second revision, zero downstream event/realtime effect.

## Why
On a retry/replay of an automation execution, a Class-A DB mutation would otherwise re-apply — a second record, a second version bump, a second revision. The claim rides the mutation's transaction, so a duplicate claim (a prior apply already holds it) short-circuits before any write; and a crash before COMMIT rolls the claim back *with* the mutation, so a legitimate retry is never permanently skipped by an orphaned claim.

## How
Builds directly on the ledger primitives already on this base (#4400):
- **Identity threading:** a new optional `ClassAActionIdentity { structuralPath, rootExecutionId }` flows through `executeSingleAction` from every rule-driven call site (top-level loop, parallel-branch loop, condition-branch loop, branch-resume tail), each reusing the canonical step-key it already computes (`topLevelStepKey` / `branchChildStepKey`). `runSingleAction` (the ad-hoc single-action dispatch) passes `undefined` → **no claim** (not a replayable execution action; documented inline).
- **Lineage root:** `rootExecutionId` added to `ExecutionContext` (defaults to the execution's own id; a retry threads the original root via `AutomationService.executeRule`, and both resume paths set it).
- **The claim:** each Class-A method calls `claimExecutionAction()` as the FIRST statement inside its existing `withTransaction(...)` callback (config passed RAW — `deriveActionKey` canonicalizes it, so the key equals the §4 fingerprint's per-action identity). `'duplicate'` → returns a success step marked `alreadyApplied:true` and skips the mutation/revision/event/fan-out; the early return is INSIDE the callback so the no-op transaction still commits.

## Flag gate
**Flag-gated DEFAULT OFF** (`AUTOMATION_CLASSA_CLAIM_ENABLED`). Active only when the flag is ON **and** `deps.transaction` is present (a real pg transaction — otherwise the ledger's `pg_current_xact_id` probe would throw on the autocommit fallback). **Flag-OFF is byte-identical to today** — the full existing executor suite (244 automation tests) is unchanged and green.

## Verification
- `npx tsc --noEmit` → **0 errors**.
- **Unit** `tests/unit/automation-classa-claim.test.ts` (16 cases, run locally, green): flag-ON first-run claims + mutates once (keyed on the top-level step-key + own execution id); replay (duplicate) skips the mutation and marks `alreadyApplied`; flag-OFF never claims (byte-identical, no xid probe); gate condition (b) — no claim on the autocommit fallback even with flag ON; retry root threads into the claim key; a nested parallel-branch child claims on its `0.parallel.b1.0` branch step-key.
- **Real-DB crash-injection** `tests/integration/multitable-4196-classa-claim-realdb.test.ts` (CI-only, `DATABASE_URL`-gated — cannot run locally): G1 create replay no-op (exactly 1 record + 1 revision + 1 claim), G2 update replay no-op (no version bump, no 2nd update revision), G3 crash rolls the claim back so a clean retry succeeds (no orphan), G4 flag-OFF positive control that re-applies. Two-point CI wiring: excluded from the default no-DB vitest config **and** added to the `plugin-tests.yml` multitable real-DB run-list.
- **Mutation-proof:** forcing `claimClassAOrSkip` to never return `'duplicate'` fails the 4 replay-skip unit cases + the branch-child replay case (5 tests); restored via the exact reverse edit (working tree verified clean).

**NOT for self-merge — awaits opus review gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)