### PR TITLE
feat(approvals): restore branch authoring with vertical flow canvas

### DIFF
--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -1,14 +1,18 @@
 import type {
   ApprovalAssigneeSource,
   ApprovalGraph,
+  ApprovalMode,
   ApprovalNode,
   ApprovalNodeConfig,
+  AutoApprovalPolicy,
+  EmptyAssigneePolicy,
+  NodeFieldPermission,
 } from '../types/approval'
 import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../types/approval'
 
-// G-5 — approval-node editing inside a preserved complex graph. SCOPE: the approver SOURCE only
-// (`assigneeSources`). `approvalMode` / `emptyAssigneePolicy` / `autoApprovalPolicy` / any other
-// config key are PRESERVED verbatim, NOT yet editable (a later slice). The node's edges/position
+// Approval-node editing inside a preserved graph. The editor owns the fields already available in
+// the linear authoring surface: approver source, approval/empty-assignee modes, requester-merge,
+// and field permissions. Any other allowlisted config stays preserved verbatim. The node's edges
 // are TOPOLOGY — preserved byte-for-byte (G-1 anti-flatten floor). Every OTHER node/edge —
 // condition (G-2), parallel (G-3), cc (G-4), start/end — is preserved verbatim. No .vue / Element
 // Plus import, so this runs under the approval-web-guard vitest gate.
@@ -21,15 +25,14 @@ import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../types/approval'
 // The editor + `validateApprovalNodeEdits` mirror this (backend `normalizeApprovalGraph` stays the
 // sole arbiter; the preview never relaxes it).
 
-/**
- * Editable model for one approval node — the approver `assigneeSources` array ONLY, keyed by node
- * `key`, seeded 1:1 from the preserved approval nodes' existing config. The node's place in the
- * graph (edges), its `approvalMode`, `emptyAssigneePolicy`, and `autoApprovalPolicy` are NOT carried
- * here (preserved verbatim by `applyApprovalNodeEditsToGraph`).
- */
+/** Optional fields preserve absence; `null` explicitly removes autoApprovalPolicy. */
 export interface ApprovalNodeSourceEdit {
   nodeKey: string
   assigneeSources: ApprovalAssigneeSource[]
+  approvalMode?: ApprovalMode
+  emptyAssigneePolicy?: EmptyAssigneePolicy
+  autoApprovalPolicy?: AutoApprovalPolicy | null
+  fieldPermissions?: NodeFieldPermission[]
 }
 
 /** Map of approval-node source edits keyed by node key, seeded from a preserved graph. */
@@ -62,18 +65,21 @@ export function approvalNodeEditsFromGraph(graph: ApprovalGraph | undefined): Ap
   if (!graph) return edits
   for (const node of graph.nodes) {
     if (node.type !== 'approval' || !hasAssigneeSources(node.config)) continue
-    edits[node.key] = { nodeKey: node.key, assigneeSources: cloneJson(node.config.assigneeSources) }
+    edits[node.key] = {
+      nodeKey: node.key,
+      assigneeSources: cloneJson(node.config.assigneeSources),
+      ...(node.config.approvalMode !== undefined ? { approvalMode: node.config.approvalMode } : {}),
+      ...(node.config.emptyAssigneePolicy !== undefined ? { emptyAssigneePolicy: node.config.emptyAssigneePolicy } : {}),
+      ...(node.config.autoApprovalPolicy !== undefined ? { autoApprovalPolicy: cloneJson(node.config.autoApprovalPolicy) } : {}),
+      ...(node.config.fieldPermissions !== undefined ? { fieldPermissions: cloneJson(node.config.fieldPermissions) } : {}),
+    }
   }
   return edits
 }
 
 /**
- * Replace ONLY the `assigneeSources` of each edited approval node, leaving EVERY other node and ALL
- * edges byte-identical (deep-cloned so the input is never mutated). Spread-original-first keeps the
- * other config keys (`approvalMode` / `emptyAssigneePolicy` / `autoApprovalPolicy`) and byte-stable
- * key order, so an UNTOUCHED node reproduces its config exactly (the guard requires `assigneeSources`
- * already present, so the spread never adds a key). A legacy node (no `assigneeSources`) has no edit
- * and is cloned verbatim.
+ * Apply the graph editor's owned fields while leaving every other node, edge, and config field
+ * byte-identical. Optional fields only overwrite when present, preserving untouched absence.
  *
  * Composition with G-2/G-3/G-4: approval / condition / parallel / cc are DISJOINT node types and
  * each pass deep-clones everything else, so composing the four lands all edits while every
@@ -86,6 +92,14 @@ export function applyApprovalNodeEditsToGraph(graph: ApprovalGraph, edits: Appro
     if (!edit) return cloneJson(node)
     const originalConfig = cloneJson(node.config)
     const config: ApprovalNodeConfig = { ...originalConfig, assigneeSources: cloneJson(edit.assigneeSources) }
+    if (edit.approvalMode !== undefined) config.approvalMode = edit.approvalMode
+    if (edit.emptyAssigneePolicy !== undefined) config.emptyAssigneePolicy = edit.emptyAssigneePolicy
+    if (edit.autoApprovalPolicy === null) delete config.autoApprovalPolicy
+    else if (edit.autoApprovalPolicy !== undefined) config.autoApprovalPolicy = cloneJson(edit.autoApprovalPolicy)
+    if (edit.fieldPermissions !== undefined) {
+      if (edit.fieldPermissions.length > 0) config.fieldPermissions = cloneJson(edit.fieldPermissions)
+      else delete config.fieldPermissions
+    }
     return { ...cloneJson(node), config }
   })
   return {
@@ -147,6 +161,21 @@ export function validateApprovalNodeEdits(
         } else {
           errors.push(`审批节点 ${edit.nodeKey} 的审批人来源（${source.kind}）配置无效`)
         }
+      }
+    }
+    if (edit.approvalMode !== undefined && !(['single', 'all', 'any'] as const).includes(edit.approvalMode)) {
+      errors.push(`审批节点 ${edit.nodeKey} 的审批模式无效`)
+    }
+    if (edit.emptyAssigneePolicy !== undefined && !(['error', 'auto-approve'] as const).includes(edit.emptyAssigneePolicy)) {
+      errors.push(`审批节点 ${edit.nodeKey} 的空审批人策略无效`)
+    }
+    for (const permission of edit.fieldPermissions ?? []) {
+      const fieldId = permission.fieldId.trim()
+      if (!fieldId || (fields && !fields.some((field) => field.id.trim() === fieldId))) {
+        errors.push(`审批节点 ${edit.nodeKey} 的字段权限引用了不存在的字段`)
+      }
+      if (!(['editable', 'readonly', 'hidden'] as const).includes(permission.access)) {
+        errors.push(`审批节点 ${edit.nodeKey} 的字段权限类型无效`)
       }
     }
   }

--- a/apps/web/src/approvals/conditionEdit.ts
+++ b/apps/web/src/approvals/conditionEdit.ts
@@ -286,6 +286,14 @@ export function validateConditionEdits(
         errors.push(...validateFormulaReferences(branch.formulaExpression, formSchema, formulaLabel))
         return
       }
+      // A rules-mode branch with ZERO rules is never legitimate: the runtime evaluates
+      // `rules.every(...)`, vacuously TRUE over `[]`, so an empty branch would silently capture ALL
+      // traffic (first-match-wins) and dead-code the default edge — the fall-through "else" is the
+      // node's `defaultEdgeKey`, a separate mechanism, never an empty branch. Fail closed here so a
+      // legacy/hand-built `rules: []` branch can never reach save looking green.
+      if (branch.rules.length === 0) {
+        errors.push(`条件节点 ${nodeLabel} 分支 ${branchIndex + 1} 需要至少一条规则`)
+      }
       branch.rules.forEach((rule, ruleIndex) => {
         const ruleLabel = `条件节点 ${nodeLabel} 分支 ${branchIndex + 1} 规则 ${ruleIndex + 1}`
         const fieldId = rule.fieldId.trim()

--- a/apps/web/src/approvals/graphLayout.ts
+++ b/apps/web/src/approvals/graphLayout.ts
@@ -1,7 +1,7 @@
 import type { ApprovalGraph } from '../types/approval'
 
 // D-1/D-5 canvas foundation — PURE, fully unit-testable (no .vue, no DOM): a longest-path layered
-// layout (node → {x,y,layer}) and a structural validity check (dangling edges / unreachable nodes /
+// vertical layout (node → {x,y,layer}) and a structural validity check (dangling edges / unreachable nodes /
 // no-path-to-end). Bespoke over a graph library on purpose: layout is data, so it's verifiable here,
 // and the canvas component just renders these coordinates + the FE preview reflects these issues
 // (the backend `normalizeApprovalGraph` remains the final arbiter on save).
@@ -20,16 +20,16 @@ export interface GraphLayout {
   height: number
 }
 
-const X_SPACING = 220
-const Y_SPACING = 110
+export const GRAPH_LAYOUT_NODE_WIDTH = 190
+export const GRAPH_LAYOUT_NODE_HEIGHT = 96
+const X_SPACING = 230
+const Y_SPACING = 150
 const X_MARGIN = 40
 const Y_MARGIN = 40
 
 /**
- * Longest-path layered layout: each node's LAYER = the longest path from `start` to it (so a node
- * that rejoins multiple branches sits after all of them), and its ORDER is its slot within the layer.
- * Deterministic (input order), DAG-assuming (approval graphs are DAGs); a node unreachable from start
- * is placed in a trailing layer rather than dropped, so nothing vanishes from the canvas.
+ * Vertical longest-path layout: each node's layer is the longest path from `start` to it, so a
+ * branch join sits below every branch. Same-layer nodes spread horizontally and each row is centered.
  */
 export function computeLayout(graph: ApprovalGraph): GraphLayout {
   const start = graph.nodes.find((n) => n.type === 'start')?.key ?? graph.nodes[0]?.key
@@ -56,18 +56,20 @@ export function computeLayout(graph: ApprovalGraph): GraphLayout {
   }
   const nodes: NodeLayout[] = []
   let maxLayer = 0
-  let maxOrder = 0
-  for (const [l, keys] of byLayer) {
+  const maxLayerSize = Math.max(1, ...Array.from(byLayer.values(), (keys) => keys.length))
+  const width = X_MARGIN * 2 + GRAPH_LAYOUT_NODE_WIDTH + (maxLayerSize - 1) * X_SPACING
+  for (const [l, keys] of [...byLayer.entries()].sort(([a], [b]) => a - b)) {
     maxLayer = Math.max(maxLayer, l)
+    const rowWidth = GRAPH_LAYOUT_NODE_WIDTH + (keys.length - 1) * X_SPACING
+    const rowStart = (width - rowWidth) / 2
     keys.forEach((key, order) => {
-      maxOrder = Math.max(maxOrder, order)
-      nodes.push({ key, layer: l, order, x: X_MARGIN + l * X_SPACING, y: Y_MARGIN + order * Y_SPACING })
+      nodes.push({ key, layer: l, order, x: rowStart + order * X_SPACING, y: Y_MARGIN + l * Y_SPACING })
     })
   }
   return {
     nodes,
-    width: X_MARGIN * 2 + maxLayer * X_SPACING + 160,
-    height: Y_MARGIN * 2 + maxOrder * Y_SPACING + 60,
+    width,
+    height: Y_MARGIN * 2 + maxLayer * Y_SPACING + GRAPH_LAYOUT_NODE_HEIGHT,
   }
 }
 

--- a/apps/web/src/approvals/graphTopologyEdit.ts
+++ b/apps/web/src/approvals/graphTopologyEdit.ts
@@ -1,4 +1,5 @@
 import type { ApprovalGraph, ApprovalNode, ApprovalEdge, ConditionNodeConfig, ParallelNodeConfig } from '../types/approval'
+import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../types/approval'
 
 // D-2/D-3 topology-authoring engine (visual canvas design-lock). Distinct from the G-2..G-5 edit
 // modules (which edit a node's CONFIG): these PURE functions change graph STRUCTURE — add/remove
@@ -27,6 +28,24 @@ function edgeKeys(graph: ApprovalGraph): Set<string> {
 /** A default approval node config — a self-contained, backend-valid starter (requester approves). */
 function defaultApprovalConfig() {
   return { assigneeSources: [{ kind: 'requester' as const }], approvalMode: 'single' as const, emptyAssigneePolicy: 'error' as const }
+}
+
+/**
+ * Starter config for an ADDITIONAL parallel-branch approval node. Parallel branches must not share
+ * an approver: two branches that resolve to the same user 409 EVERY request at fan-out
+ * (`APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT`), so seeding every branch with the same
+ * `requester` default would make the feature's untouched output fail 100% of the time — a
+ * false-green (saves + publishes clean, dies at runtime). Instead the extra branch uses the
+ * existing configure-before-publish machinery: the `static_role` placeholder sentinel that the
+ * publish checklist surfaces and the backend fail-fasts on (`assertNoUnconfiguredPlaceholderRoles`)
+ * — the draft saves, but the admin MUST pick a real approver before it can publish.
+ */
+function placeholderBranchApprovalConfig() {
+  return {
+    assigneeSources: [{ kind: 'static_role' as const, roleIds: [APPROVAL_ROLE_CONFIGURE_SENTINEL] }],
+    approvalMode: 'single' as const,
+    emptyAssigneePolicy: 'error' as const,
+  }
 }
 
 function outEdges(graph: ApprovalGraph, nodeKey: string): ApprovalEdge[] {
@@ -220,7 +239,9 @@ export function insertParallelGateway(
     key: branchTwoKey,
     type: 'approval',
     name: '并行审批 2',
-    config: defaultApprovalConfig(),
+    // NOT defaultApprovalConfig(): requester×requester across the two starter branches would 409
+    // every request at runtime — see placeholderBranchApprovalConfig.
+    config: placeholderBranchApprovalConfig(),
   }
 
   return {
@@ -271,7 +292,9 @@ export function addParallelBranch(graph: ApprovalGraph, parallelNodeKey: string,
   const eKeys = edgeKeys(graph)
   const forkEdge = uniqueKey('edge', eKeys); eKeys.add(forkEdge)
   const joinEdge = uniqueKey('edge', eKeys)
-  const newNode: ApprovalNode = { key: newNodeKey, type: 'approval', name, config: defaultApprovalConfig() }
+  // Placeholder starter, not requester: a concrete dynamic default could silently duplicate an
+  // existing branch's approver (100% runtime 409) — see placeholderBranchApprovalConfig.
+  const newNode: ApprovalNode = { key: newNodeKey, type: 'approval', name, config: placeholderBranchApprovalConfig() }
   return {
     nodes: graph.nodes.map((n) => (n.key === parallelNodeKey ? { ...clone(n), config: { ...config, branches: [...config.branches, forkEdge] } } : clone(n))).concat([newNode]),
     edges: [

--- a/apps/web/src/approvals/graphTopologyEdit.ts
+++ b/apps/web/src/approvals/graphTopologyEdit.ts
@@ -55,6 +55,39 @@ function inEdges(graph: ApprovalGraph, nodeKey: string): ApprovalEdge[] {
   return graph.edges.filter((e) => e.target === nodeKey)
 }
 
+/**
+ * Node keys strictly INSIDE any parallel region — every node on a branch path between a parallel
+ * gateway and its `joinNodeKey` (join and gateway excluded). Mirrors the backend
+ * `collectParallelRegionNodeKeys` (ApprovalProductService.ts). Used to prevent authoring a NESTED
+ * parallel: the backend rejects it at save ("cannot contain nested parallel node"), and the canvas
+ * lock says the canvas must not offer a shape the engine rejects. Condition-in-parallel stays legal.
+ */
+export function collectParallelRegionNodeKeys(graph: ApprovalGraph): Set<string> {
+  const regionNodeKeys = new Set<string>()
+  for (const node of graph.nodes) {
+    if (node.type !== 'parallel') continue
+    const config = node.config as ParallelNodeConfig
+    const joinNodeKey = typeof config.joinNodeKey === 'string' ? config.joinNodeKey : null
+    const branchEdgeKeys = Array.isArray(config.branches)
+      ? config.branches.filter((entry): entry is string => typeof entry === 'string')
+      : []
+    for (const branchEdgeKey of branchEdgeKeys) {
+      const edge = graph.edges.find((candidate) => candidate.key === branchEdgeKey)
+      if (!edge) continue
+      const queue = [edge.target]
+      const visited = new Set<string>()
+      while (queue.length > 0) {
+        const nodeKey = queue.shift()!
+        if (nodeKey === joinNodeKey || visited.has(nodeKey)) continue
+        visited.add(nodeKey)
+        regionNodeKeys.add(nodeKey)
+        for (const out of outEdges(graph, nodeKey)) queue.push(out.target)
+      }
+    }
+  }
+  return regionNodeKeys
+}
+
 function reachableDistances(graph: ApprovalGraph, startKey: string): Map<string, number> {
   const distances = new Map<string, number>([[startKey, 0]])
   const queue = [startKey]
@@ -201,6 +234,12 @@ export function insertParallelGateway(
   const outs = outEdges(graph, afterNodeKey)
   if (outs.length !== 1) {
     throw new Error(`insertParallelGateway: ${afterNodeKey} must have exactly one outgoing edge (has ${outs.length})`)
+  }
+  // F4: the backend rejects NESTED parallel at save (`collectBranchAssignees` — "cannot contain
+  // nested parallel node"); refuse to author it (the view also hides the affordance). A CONDITION
+  // gateway inside a parallel branch remains legal — only parallel-in-parallel is blocked.
+  if (collectParallelRegionNodeKeys(graph).has(afterNodeKey)) {
+    throw new Error(`insertParallelGateway: ${afterNodeKey} is inside a parallel branch — nested parallel is not supported`)
   }
 
   const originalOut = outs[0]

--- a/apps/web/src/approvals/graphTopologyEdit.ts
+++ b/apps/web/src/approvals/graphTopologyEdit.ts
@@ -36,6 +36,39 @@ function inEdges(graph: ApprovalGraph, nodeKey: string): ApprovalEdge[] {
   return graph.edges.filter((e) => e.target === nodeKey)
 }
 
+function reachableDistances(graph: ApprovalGraph, startKey: string): Map<string, number> {
+  const distances = new Map<string, number>([[startKey, 0]])
+  const queue = [startKey]
+  while (queue.length > 0) {
+    const current = queue.shift()!
+    const distance = distances.get(current)!
+    for (const edge of outEdges(graph, current)) {
+      if (distances.has(edge.target)) continue
+      distances.set(edge.target, distance + 1)
+      queue.push(edge.target)
+    }
+  }
+  return distances
+}
+
+/** Find the nearest node reachable from every current condition path. */
+function conditionRejoinTarget(graph: ApprovalGraph, config: ConditionNodeConfig): string | undefined {
+  const pathEdgeKeys = [...config.branches.map((branch) => branch.edgeKey), config.defaultEdgeKey]
+  const pathTargets = pathEdgeKeys
+    .map((edgeKey) => graph.edges.find((edge) => edge.key === edgeKey)?.target)
+    .filter((target): target is string => Boolean(target))
+  if (pathTargets.length !== pathEdgeKeys.length) return undefined
+  const distances = pathTargets.map((target) => reachableDistances(graph, target))
+  return graph.nodes
+    .filter((node) => distances.every((path) => path.has(node.key)))
+    .map((node) => ({
+      key: node.key,
+      maxDistance: Math.max(...distances.map((path) => path.get(node.key)!)),
+      totalDistance: distances.reduce((sum, path) => sum + path.get(node.key)!, 0),
+    }))
+    .sort((a, b) => a.maxDistance - b.maxDistance || a.totalDistance - b.totalDistance)[0]?.key
+}
+
 /**
  * Insert a new `approval` node immediately AFTER `afterNodeKey` on a LINEAR segment (the node must
  * have exactly one outgoing edge). The existing edge `after → target` becomes `after → new → target`.
@@ -62,6 +95,150 @@ export function appendApprovalNode(graph: ApprovalGraph, afterNodeKey: string, n
 }
 
 /**
+ * Insert a condition gateway on a linear segment. The original `after → target` edge keeps its
+ * identity and becomes `after → condition`; the gateway then owns one configurable branch and
+ * one direct default branch, both rejoining at the original target.
+ *
+ * The starter rule is deliberately incomplete. The authoring validator blocks save until the
+ * author selects a real form field, avoiding an empty AND branch that evaluates as always true.
+ */
+export function insertConditionGateway(
+  graph: ApprovalGraph,
+  afterNodeKey: string,
+  name = '条件分支',
+): ApprovalGraph {
+  const after = graph.nodes.find((node) => node.key === afterNodeKey)
+  if (!after) throw new Error(`insertConditionGateway: node ${afterNodeKey} not found`)
+  const outs = outEdges(graph, afterNodeKey)
+  if (outs.length !== 1) {
+    throw new Error(`insertConditionGateway: ${afterNodeKey} must have exactly one outgoing edge (has ${outs.length})`)
+  }
+
+  const originalOut = outs[0]
+  const nKeys = nodeKeys(graph)
+  const conditionKey = uniqueKey('condition', nKeys)
+  nKeys.add(conditionKey)
+  const branchNodeKey = uniqueKey('approval', nKeys)
+  nKeys.add(branchNodeKey)
+  const defaultNodeKey = uniqueKey('approval', nKeys)
+  const eKeys = edgeKeys(graph)
+  const branchEdgeKey = uniqueKey('edge', eKeys)
+  eKeys.add(branchEdgeKey)
+  const defaultEdgeKey = uniqueKey('edge', eKeys)
+  eKeys.add(defaultEdgeKey)
+  const branchJoinEdgeKey = uniqueKey('edge', eKeys)
+  eKeys.add(branchJoinEdgeKey)
+  const defaultJoinEdgeKey = uniqueKey('edge', eKeys)
+
+  const conditionNode: ApprovalNode = {
+    key: conditionKey,
+    type: 'condition',
+    name,
+    config: {
+      branches: [{
+        edgeKey: branchEdgeKey,
+        conjunction: 'and',
+        rules: [{ fieldId: '', operator: 'eq', value: '' }],
+      }],
+      defaultEdgeKey,
+    },
+  }
+  const branchNode: ApprovalNode = {
+    key: branchNodeKey,
+    type: 'approval',
+    name: '条件审批',
+    config: defaultApprovalConfig(),
+  }
+  const defaultNode: ApprovalNode = {
+    key: defaultNodeKey,
+    type: 'approval',
+    name: '默认审批',
+    config: defaultApprovalConfig(),
+  }
+
+  return {
+    nodes: [...graph.nodes.map(clone), conditionNode, branchNode, defaultNode],
+    edges: graph.edges
+      .map((edge) => edge.key === originalOut.key
+        ? { ...clone(edge), target: conditionKey }
+        : clone(edge))
+      .concat([
+        { key: branchEdgeKey, source: conditionKey, target: branchNodeKey },
+        { key: defaultEdgeKey, source: conditionKey, target: defaultNodeKey },
+        { key: branchJoinEdgeKey, source: branchNodeKey, target: originalOut.target },
+        { key: defaultJoinEdgeKey, source: defaultNodeKey, target: originalOut.target },
+      ]),
+  }
+}
+
+/** Insert a two-branch parallel gateway on a linear segment, rejoining at the old target. */
+export function insertParallelGateway(
+  graph: ApprovalGraph,
+  afterNodeKey: string,
+  name = '并行分支',
+): ApprovalGraph {
+  const after = graph.nodes.find((node) => node.key === afterNodeKey)
+  if (!after) throw new Error(`insertParallelGateway: node ${afterNodeKey} not found`)
+  const outs = outEdges(graph, afterNodeKey)
+  if (outs.length !== 1) {
+    throw new Error(`insertParallelGateway: ${afterNodeKey} must have exactly one outgoing edge (has ${outs.length})`)
+  }
+
+  const originalOut = outs[0]
+  const nKeys = nodeKeys(graph)
+  const parallelKey = uniqueKey('parallel', nKeys)
+  nKeys.add(parallelKey)
+  const branchOneKey = uniqueKey('approval', nKeys)
+  nKeys.add(branchOneKey)
+  const branchTwoKey = uniqueKey('approval', nKeys)
+  const eKeys = edgeKeys(graph)
+  const forkOneKey = uniqueKey('edge', eKeys)
+  eKeys.add(forkOneKey)
+  const forkTwoKey = uniqueKey('edge', eKeys)
+  eKeys.add(forkTwoKey)
+  const joinOneKey = uniqueKey('edge', eKeys)
+  eKeys.add(joinOneKey)
+  const joinTwoKey = uniqueKey('edge', eKeys)
+
+  const parallelNode: ApprovalNode = {
+    key: parallelKey,
+    type: 'parallel',
+    name,
+    config: {
+      branches: [forkOneKey, forkTwoKey],
+      joinMode: 'all',
+      joinNodeKey: originalOut.target,
+    },
+  }
+  const branchOne: ApprovalNode = {
+    key: branchOneKey,
+    type: 'approval',
+    name: '并行审批 1',
+    config: defaultApprovalConfig(),
+  }
+  const branchTwo: ApprovalNode = {
+    key: branchTwoKey,
+    type: 'approval',
+    name: '并行审批 2',
+    config: defaultApprovalConfig(),
+  }
+
+  return {
+    nodes: [...graph.nodes.map(clone), parallelNode, branchOne, branchTwo],
+    edges: graph.edges
+      .map((edge) => edge.key === originalOut.key
+        ? { ...clone(edge), target: parallelKey }
+        : clone(edge))
+      .concat([
+        { key: forkOneKey, source: parallelKey, target: branchOneKey },
+        { key: forkTwoKey, source: parallelKey, target: branchTwoKey },
+        { key: joinOneKey, source: branchOneKey, target: originalOut.target },
+        { key: joinTwoKey, source: branchTwoKey, target: originalOut.target },
+      ]),
+  }
+}
+
+/**
  * Remove an `approval` or `cc` node that sits on a LINEAR segment (exactly one in-edge + one
  * out-edge), bridging `pred → succ`. Refuses to remove start/end/condition/parallel or a branching
  * node (ambiguous rewire) — those go through branch ops or are structural anchors.
@@ -73,14 +250,12 @@ export function removeLinearNode(graph: ApprovalGraph, nodeKey: string): Approva
   const ins = inEdges(graph, nodeKey)
   const outs = outEdges(graph, nodeKey)
   if (ins.length !== 1 || outs.length !== 1) throw new Error(`removeLinearNode: ${nodeKey} must be single-in/single-out (in=${ins.length} out=${outs.length})`)
-  const pred = ins[0].source
   const succ = outs[0].target
-  const removedEdgeKeys = new Set([ins[0].key, outs[0].key])
-  const eKeys = new Set(graph.edges.filter((e) => !removedEdgeKeys.has(e.key)).map((e) => e.key))
-  const bridge = uniqueKey('edge', eKeys)
   return {
     nodes: graph.nodes.filter((n) => n.key !== nodeKey).map(clone),
-    edges: graph.edges.filter((e) => !removedEdgeKeys.has(e.key)).map(clone).concat([{ key: bridge, source: pred, target: succ }]),
+    edges: graph.edges
+      .filter((edge) => edge.key !== outs[0].key)
+      .map((edge) => edge.key === ins[0].key ? { ...clone(edge), target: succ } : clone(edge)),
   }
 }
 
@@ -131,15 +306,18 @@ export function removeParallelBranch(graph: ApprovalGraph, parallelNodeKey: stri
 /**
  * Add a condition branch: a fresh edge from `conditionNodeKey` to a new approval target, plus a new
  * `branches[]` entry (empty rules — the admin fills the rule via the G-2 editor). The new target then
- * flows to the same node the condition's default edge targets (so the branch is reachable + joins back).
+ * flows to the nearest node reachable from every existing condition path.
  */
 export function addConditionBranch(graph: ApprovalGraph, conditionNodeKey: string, name = '条件分支'): ApprovalGraph {
   const node = graph.nodes.find((n) => n.key === conditionNodeKey)
   if (!node || node.type !== 'condition') throw new Error(`addConditionBranch: ${conditionNodeKey} is not a condition node`)
   const config = clone(node.config) as ConditionNodeConfig
-  // the new branch target rejoins wherever the default edge goes (a safe, reachable default)
+  // Prefer the real convergence point. The default edge may point to its own approval node rather
+  // than directly to the join, so blindly targeting defaultEdge.target can serialize both paths.
   const defaultEdge = graph.edges.find((e) => e.key === config.defaultEdgeKey)
-  const rejoinTarget = defaultEdge?.target ?? graph.nodes.find((n) => n.type === 'end')?.key
+  const rejoinTarget = conditionRejoinTarget(graph, config)
+    ?? defaultEdge?.target
+    ?? graph.nodes.find((n) => n.type === 'end')?.key
   if (!rejoinTarget) throw new Error('addConditionBranch: no default edge / end node to rejoin')
   const newNodeKey = uniqueKey('approval', nodeKeys(graph))
   const eKeys = edgeKeys(graph)

--- a/apps/web/src/approvals/graphTopologyEdit.ts
+++ b/apps/web/src/approvals/graphTopologyEdit.ts
@@ -305,8 +305,12 @@ export function removeParallelBranch(graph: ApprovalGraph, parallelNodeKey: stri
 
 /**
  * Add a condition branch: a fresh edge from `conditionNodeKey` to a new approval target, plus a new
- * `branches[]` entry (empty rules — the admin fills the rule via the G-2 editor). The new target then
- * flows to the nearest node reachable from every existing condition path.
+ * `branches[]` entry seeded with the SAME deliberately-incomplete starter rule as
+ * `insertConditionGateway` — the authoring validator blocks save until the admin selects a real form
+ * field. An EMPTY rules array would be far worse than incomplete: the runtime evaluates a rules-mode
+ * branch as `rules.every(...)`, which is vacuously TRUE over `[]`, so an empty branch would silently
+ * capture ALL traffic (first-match-wins) and dead-code the default edge. The new target then flows
+ * to the nearest node reachable from every existing condition path.
  */
 export function addConditionBranch(graph: ApprovalGraph, conditionNodeKey: string, name = '条件分支'): ApprovalGraph {
   const node = graph.nodes.find((n) => n.key === conditionNodeKey)
@@ -325,7 +329,20 @@ export function addConditionBranch(graph: ApprovalGraph, conditionNodeKey: strin
   const rejoinEdge = uniqueKey('edge', eKeys)
   const newNode: ApprovalNode = { key: newNodeKey, type: 'approval', name, config: defaultApprovalConfig() }
   return {
-    nodes: graph.nodes.map((n) => (n.key === conditionNodeKey ? { ...clone(n), config: { ...config, branches: [...config.branches, { edgeKey: branchEdge, rules: [] }] } } : clone(n))).concat([newNode]),
+    nodes: graph.nodes.map((n) => (n.key === conditionNodeKey
+      ? {
+          ...clone(n),
+          config: {
+            ...config,
+            branches: [
+              ...config.branches,
+              // Mirrors insertConditionGateway's starter EXACTLY: an incomplete rule the validator
+              // rejects (需要选择字段) — never `rules: []`, which the runtime would match-all.
+              { edgeKey: branchEdge, conjunction: 'and' as const, rules: [{ fieldId: '', operator: 'eq' as const, value: '' }] },
+            ],
+          },
+        }
+      : clone(n))).concat([newNode]),
     edges: [
       ...graph.edges.map(clone),
       { key: branchEdge, source: conditionNodeKey, target: newNodeKey },

--- a/apps/web/src/approvals/parallelEdit.ts
+++ b/apps/web/src/approvals/parallelEdit.ts
@@ -1,4 +1,5 @@
 import type {
+  ApprovalAssigneeSource,
   ApprovalGraph,
   ApprovalNode,
   ParallelJoinMode,
@@ -136,6 +137,84 @@ export function validateParallelEdits(edits: ParallelEdits): string[] {
   for (const edit of Object.values(edits)) {
     if (!isParallelJoinMode(edit.joinMode)) {
       errors.push(`并行节点 ${edit.nodeKey} 的汇聚模式无效`)
+    }
+  }
+  return errors
+}
+
+/**
+ * Fingerprint of a DYNAMIC assignee source: same fingerprint ⇒ the source PROVABLY resolves to the
+ * same user(s) for every request (same kind + same parameters). Static sources return null — the
+ * backend already rejects duplicate static assignees across parallel branches at save time.
+ * MUST stay in lockstep with the backend `dynamicAssigneeSourceFingerprint`
+ * (ApprovalProductService.ts) so authoring flags exactly what publish rejects.
+ */
+function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): string | null {
+  switch (source.kind) {
+    case 'requester':
+    case 'direct_manager':
+    case 'dept_head':
+      return source.kind
+    case 'continuous_managers':
+      return `continuous_managers:${source.levels}`
+    case 'manager_at_level':
+      return `manager_at_level:${source.level}`
+    case 'form_field_user':
+      return `form_field_user:${source.fieldId.trim()}`
+    default:
+      return null
+  }
+}
+
+/**
+ * Publish-preflight PREVIEW (surfaced in the publish checklist, NOT the save gate): flag a parallel
+ * gateway whose branches carry PROVABLY-IDENTICAL dynamic assignee sources. At runtime the fan-out
+ * raises a typed 409 (`APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT`) whenever two branches resolve
+ * to the same user — for identical dynamic sources (requester×requester, direct_manager×direct_manager,
+ * same-parameter manager levels / form fields) that is EVERY request, so the template is unpublishable
+ * in practice. The backend publish gate (`assertNoParallelDynamicAssigneeConflicts`) rejects the same
+ * shape with the same code; this mirror surfaces it BEFORE the rejected request. Only
+ * provably-identical sources are flagged — DIFFERENT kinds or DIFFERENT parameters may still collide
+ * for some org shapes and stay the runtime guard's job. Walk mirrors the backend's conservative
+ * first-outgoing-edge walk per branch, deduped within a branch (sequential same-source nodes in ONE
+ * branch are not a parallel conflict).
+ */
+export function parallelDynamicAssigneeConflicts(graph: ApprovalGraph): string[] {
+  const errors: string[] = []
+  const edgeByKey = new Map(graph.edges.map((edge) => [edge.key, edge]))
+  const firstOutgoing = new Map<string, string>()
+  for (const edge of graph.edges) {
+    if (!firstOutgoing.has(edge.source)) firstOutgoing.set(edge.source, edge.target)
+  }
+  const nodeByKey = new Map(graph.nodes.map((node) => [node.key, node]))
+  for (const node of graph.nodes) {
+    if (node.type !== 'parallel' || !isParallelConfig(node.config)) continue
+    const config = node.config
+    const seenAcrossBranches = new Set<string>()
+    for (const branchEdgeKey of config.branches) {
+      const branchFingerprints = new Set<string>()
+      let currentKey: string | undefined = edgeByKey.get(branchEdgeKey)?.target
+      const visited = new Set<string>()
+      while (currentKey && currentKey !== config.joinNodeKey && !visited.has(currentKey)) {
+        visited.add(currentKey)
+        const current = nodeByKey.get(currentKey)
+        if (!current) break
+        if (current.type === 'approval') {
+          const sources = (current.config as { assigneeSources?: ApprovalAssigneeSource[] }).assigneeSources ?? []
+          for (const source of sources) {
+            const fingerprint = dynamicAssigneeSourceFingerprint(source)
+            if (fingerprint) branchFingerprints.add(fingerprint)
+          }
+        }
+        currentKey = firstOutgoing.get(currentKey)
+      }
+      for (const fingerprint of branchFingerprints) {
+        if (seenAcrossBranches.has(fingerprint)) {
+          errors.push(`并行节点 ${node.key} 的多个分支使用了相同的动态审批人来源（${fingerprint}），发起审批时会因重复审批人失败，请为各分支配置不同的审批人`)
+        } else {
+          seenAcrossBranches.add(fingerprint)
+        }
+      }
     }
   }
   return errors

--- a/apps/web/src/approvals/parallelEdit.ts
+++ b/apps/web/src/approvals/parallelEdit.ts
@@ -175,16 +175,29 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
  * in practice. The backend publish gate (`assertNoParallelDynamicAssigneeConflicts`) rejects the same
  * shape with the same code; this mirror surfaces it BEFORE the rejected request. Only
  * provably-identical sources are flagged — DIFFERENT kinds or DIFFERENT parameters may still collide
- * for some org shapes and stay the runtime guard's job. Walk mirrors the backend's conservative
- * first-outgoing-edge walk per branch, deduped within a branch (sequential same-source nodes in ONE
- * branch are not a parallel conflict).
+ * for some org shapes and stay the runtime guard's job.
+ *
+ * Traversal (review #4433 owner P2, mirror-ports the backend EXACTLY): within each branch the walk
+ * enumerates EVERY runtime-reachable path — a condition node fans out over ALL of its outgoing
+ * edges (every rules-branch edge AND the default edge: which path fires is form-data-dependent, so
+ * each is possible), every other node type follows its first outgoing edge (linear in a normalized
+ * graph). The branch's fingerprint set is the UNION over all condition paths up to the join node,
+ * and a conflict is flagged when SOME path through one branch and SOME path through another carry
+ * the identical dynamic source — exactly the pairings for which the runtime 409 is reachable.
+ * Cycles are cut with a per-branch visited set; an unexpectedly nested parallel (unauthorable via
+ * the canvas F4 guard, but a legacy graph could carry one on a non-first condition path) is
+ * defensively a PASS-THROUGH fan-out over all its outgoing edges (its sub-branches are all
+ * simultaneously active). Deduped within a branch first — sequential same-source nodes, or the same
+ * source on two ALTERNATIVE paths of ONE branch, are not a parallel conflict.
  */
 export function parallelDynamicAssigneeConflicts(graph: ApprovalGraph): string[] {
   const errors: string[] = []
   const edgeByKey = new Map(graph.edges.map((edge) => [edge.key, edge]))
-  const firstOutgoing = new Map<string, string>()
+  const outgoingTargets = new Map<string, string[]>()
   for (const edge of graph.edges) {
-    if (!firstOutgoing.has(edge.source)) firstOutgoing.set(edge.source, edge.target)
+    const targets = outgoingTargets.get(edge.source)
+    if (targets) targets.push(edge.target)
+    else outgoingTargets.set(edge.source, [edge.target])
   }
   const nodeByKey = new Map(graph.nodes.map((node) => [node.key, node]))
   for (const node of graph.nodes) {
@@ -193,12 +206,17 @@ export function parallelDynamicAssigneeConflicts(graph: ApprovalGraph): string[]
     const seenAcrossBranches = new Set<string>()
     for (const branchEdgeKey of config.branches) {
       const branchFingerprints = new Set<string>()
-      let currentKey: string | undefined = edgeByKey.get(branchEdgeKey)?.target
+      const entryKey = edgeByKey.get(branchEdgeKey)?.target
+      // FIFO worklist in edge-declaration order (deterministic report order); the visited set both
+      // cuts cycles and bounds the walk to each node at most once per branch.
+      const queue: string[] = entryKey === undefined ? [] : [entryKey]
       const visited = new Set<string>()
-      while (currentKey && currentKey !== config.joinNodeKey && !visited.has(currentKey)) {
+      for (let head = 0; head < queue.length; head += 1) {
+        const currentKey = queue[head]
+        if (currentKey === config.joinNodeKey || visited.has(currentKey)) continue
         visited.add(currentKey)
         const current = nodeByKey.get(currentKey)
-        if (!current) break
+        if (!current) continue
         if (current.type === 'approval') {
           const sources = (current.config as { assigneeSources?: ApprovalAssigneeSource[] }).assigneeSources ?? []
           for (const source of sources) {
@@ -206,7 +224,15 @@ export function parallelDynamicAssigneeConflicts(graph: ApprovalGraph): string[]
             if (fingerprint) branchFingerprints.add(fingerprint)
           }
         }
-        currentKey = firstOutgoing.get(currentKey)
+        const targets = outgoingTargets.get(currentKey) ?? []
+        if (current.type === 'condition' || current.type === 'parallel') {
+          // Condition: EVERY outgoing edge (each rules branch + the default) is a possible runtime
+          // path. Parallel (defensive — see doc above): pass-through fan-out over all sub-branches.
+          for (const target of targets) queue.push(target)
+        } else if (targets.length > 0) {
+          // Linear node — follow its first outgoing edge, as before.
+          queue.push(targets[0])
+        }
       }
       for (const fingerprint of branchFingerprints) {
         if (seenAcrossBranches.has(fingerprint)) {

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -62,7 +62,7 @@ export type {
 export { CONDITION_RULE_OPERATORS } from './conditionEdit'
 export { approvalFormulaInsertOptions } from './conditionEdit'
 export type { ParallelEdits, ParallelNodeEdit } from './parallelEdit'
-export { PARALLEL_JOIN_MODES } from './parallelEdit'
+export { PARALLEL_JOIN_MODES, parallelDynamicAssigneeConflicts } from './parallelEdit'
 export type { CcEdits, CcNodeEdit } from './ccEdit'
 export { CC_TARGET_TYPES } from './ccEdit'
 export type { ApprovalNodeEdits, ApprovalNodeSourceEdit } from './approvalNodeEdit'

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -779,19 +779,14 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
 }
 
 /**
- * G-1 — reason the GRAPH (not the whole template) must render READ-ONLY: the graph is complex
- * (any cc/condition/parallel node, or non-linear) so the v1 linear `steps` editor can't author
- * it. Distinct from `unsupportedTemplateAuthoringReason`: a complex graph is NOT unsupported — the
- * form/metadata stay EDITABLE and SAVE stays enabled (it preserves the graph verbatim via
- * `draftFromTemplate`→`preservedGraph`→`buildApprovalGraph`). Returns `null` for a linear graph
- * (the steps editor is live) and for a truly-unsupported template (that path is fully read-only
- * via `unsupportedTemplateAuthoringReason`; the graph view never opens). The G-2+ editors will
- * narrow this to only genuinely-unrepresentable constructs.
+ * Legacy-named informational message for templates that use the graph editor instead of the
+ * linear steps editor. Complex graphs remain editable and save-preserved; only genuinely unknown
+ * node config is blocked by `unsupportedTemplateAuthoringReason`.
  */
 export function graphReadOnlyReason(template: ApprovalTemplateDetailDTO): string | null {
   if (unsupportedTemplateAuthoringReason(template)) return null
   if (!isComplexApprovalGraph(template.approvalGraph)) return null
-  return '该审批流程包含复杂节点：条件分支可在下方编辑分支规则，并行 / 抄送节点以只读结构展示；未改动的节点与连线在保存时原样保留，不会被改写。'
+  return '该模板已启用分支流程编辑：可在画布调整流程结构，并在结构列表编辑各节点配置。'
 }
 
 export function draftFromTemplate(template: ApprovalTemplateDetailDTO): TemplateAuthoringDraft {
@@ -1017,9 +1012,25 @@ export function applyTopologyToComplexDraft(
   op: (graph: ApprovalGraph) => ApprovalGraph,
 ): TemplateAuthoringDraft {
   if (!draft.preservedGraph) return draft
-  const next = op(buildApprovalGraph(draft))
+  return draftFromEditedGraph(draft, op(buildApprovalGraph(draft)))
+}
+
+/**
+ * Apply a topology operation to any draft. Linear drafts are promoted to the graph authoring model
+ * first, preserving the graph produced by their current steps. From this point on there is a single
+ * structural source of truth (`preservedGraph`).
+ */
+export function applyTopologyToDraft(
+  draft: TemplateAuthoringDraft,
+  op: (graph: ApprovalGraph) => ApprovalGraph,
+): TemplateAuthoringDraft {
+  return draftFromEditedGraph(draft, op(buildApprovalGraph(draft)))
+}
+
+function draftFromEditedGraph(draft: TemplateAuthoringDraft, next: ApprovalGraph): TemplateAuthoringDraft {
   return {
     ...draft,
+    steps: [],
     preservedGraph: next,
     conditionEdits: conditionEditsFromGraph(next),
     parallelEdits: parallelEditsFromGraph(next),

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -1660,6 +1660,7 @@ import {
   validateTemplateApprovalFlow,
   placeholderRoleNodeKeys,
   approvalFormulaInsertOptions,
+  parallelDynamicAssigneeConflicts,
   CONDITION_RULE_OPERATORS,
   PARALLEL_JOIN_MODES,
   CC_TARGET_TYPES,
@@ -2242,6 +2243,11 @@ const publishFormFieldIssues = computed<string[]>(() => validateTemplateFormFiel
 const publishApprovalFlowIssues = computed<string[]>(() => [
   ...validateTemplateApprovalFlow(draft.value),
   ...canvasValidity.value,
+  // F2 publish preflight: parallel branches with provably-identical DYNAMIC approver sources 409
+  // every request at runtime; the backend publish gate rejects the same shape
+  // (APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT). Checklist-scoped (like the placeholder-role
+  // item): the draft still SAVES — publish is what the conflicting shape can never reach.
+  ...parallelDynamicAssigneeConflicts(canvasEffectiveGraph.value),
 ])
 const publishPlaceholderRoleKeys = computed<string[]>(() => placeholderRoleNodeKeys(draft.value.approvalNodeEdits ?? {}))
 const publishPlaceholderRoleIssues = computed<string[]>(() =>

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -530,7 +530,8 @@
                   <template v-if="canInsertAfter(canvasNodeByKey(pos.key)!)">
                     <el-button size="small" :data-testid="`approval-canvas-insert-${pos.key}`" @click.stop="onInsertApprovalAfter(pos.key)">+审批</el-button>
                     <el-button size="small" :data-testid="`approval-canvas-insert-condition-${pos.key}`" @click.stop="onInsertConditionAfter(pos.key)">+条件</el-button>
-                    <el-button size="small" :data-testid="`approval-canvas-insert-parallel-${pos.key}`" @click.stop="onInsertParallelAfter(pos.key)">+并行</el-button>
+                    <!-- F4: no +并行 inside a parallel branch — the backend rejects nested parallel. -->
+                    <el-button v-if="canInsertParallelAfter(canvasNodeByKey(pos.key)!)" size="small" :data-testid="`approval-canvas-insert-parallel-${pos.key}`" @click.stop="onInsertParallelAfter(pos.key)">+并行</el-button>
                   </template>
                   <el-button v-if="canRemoveNode(canvasNodeByKey(pos.key)!)" size="small" type="danger" :data-testid="`approval-canvas-remove-${pos.key}`" @click.stop="onRemoveNode(pos.key)">删除</el-button>
                 </div>
@@ -579,8 +580,9 @@
                   :data-testid="`approval-topology-insert-condition-after-${node.key}`"
                   @click="onInsertConditionAfter(node.key)"
                 >下方添加条件</el-button>
+                <!-- F4: no 并行 insert inside a parallel branch — the backend rejects nested parallel. -->
                 <el-button
-                  v-if="canInsertAfter(node)"
+                  v-if="canInsertParallelAfter(node)"
                   size="small"
                   :data-testid="`approval-topology-insert-parallel-after-${node.key}`"
                   @click="onInsertParallelAfter(node.key)"
@@ -1681,6 +1683,7 @@ import {
   addConditionBranch,
   addParallelBranch,
   appendApprovalNode,
+  collectParallelRegionNodeKeys,
   insertConditionGateway,
   insertParallelGateway,
   removeLinearNode,
@@ -2193,6 +2196,15 @@ function topologyEdgeCount(nodeKey: string, dir: 'source' | 'target'): number {
 }
 function canInsertAfter(node: ApprovalNode): boolean {
   return node.type !== 'end' && topologyEdgeCount(node.key, 'source') === 1
+}
+// F4: never OFFER a nested parallel — the backend rejects it at save ("cannot contain nested
+// parallel node"), and the canvas lock requires guiding toward valid shapes rather than building a
+// 422. Condition-in-parallel stays legal, so only the +并行 affordance is gated by region membership.
+const parallelRegionKeys = computed<Set<string>>(() =>
+  collectParallelRegionNodeKeys(draft.value.preservedGraph ?? { nodes: [], edges: [] }),
+)
+function canInsertParallelAfter(node: ApprovalNode): boolean {
+  return canInsertAfter(node) && !parallelRegionKeys.value.has(node.key)
 }
 function canRemoveNode(node: ApprovalNode): boolean {
   return (node.type === 'approval' || node.type === 'cc')

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -61,13 +61,11 @@
       data-testid="approval-template-unsupported-alert"
     />
 
-    <!-- G-1..G-5: a complex graph is preserved, not unsupported — informational, save stays enabled.
-         G-2 condition rules, G-3 parallel joinMode, G-4 cc targets, and G-5 approval-node source are
-         all editable; branches / join target / all edges are preserved topology. -->
+    <!-- Complex graphs remain editable. Unknown node config still fails closed above. -->
     <el-alert
       v-if="!unsupportedReason && graphReadOnlyMessage"
       :title="graphReadOnlyMessage"
-      description="表单与基本信息可编辑；条件分支节点可编辑分支规则，并行节点可编辑汇聚模式，抄送节点可编辑抄送对象，审批节点可编辑审批人来源。分支拓扑与连线在保存时原样保留。"
+      description="画布用于编排节点与分支；结构列表用于编辑审批人、条件、并行汇聚、抄送和字段权限。"
       type="info"
       show-icon
       :closable="false"
@@ -451,7 +449,7 @@
       <el-card v-show="activeAuthoringSection === 'flow'" class="template-authoring__panel" shadow="never">
         <template #header>
           <div class="template-authoring__panel-header">
-            <strong>{{ graphReadOnly ? '审批流程（结构）' : '审批步骤' }}</strong>
+            <strong>审批流程</strong>
             <el-button
               v-if="!graphReadOnly"
               size="small"
@@ -465,10 +463,7 @@
           </div>
         </template>
 
-        <!-- G-1/G-2: structured render of a preserved complex graph. condition nodes are EDITABLE
-             (G-2 — branch rules / conjunction / default edge); parallel / cc / approval stay
-             READ-ONLY summaries (G-3 / G-4), and every non-condition node + all edges are preserved
-             byte-for-byte on save. Nothing renders as a bare "unsupported". -->
+        <!-- Complex graphs use a canvas for topology and a structured list for node configuration. -->
         <!-- D-6 view toggle: structured list ⇄ visual canvas (complex graphs only) -->
         <div v-if="graphReadOnly" class="template-authoring__view-toggle" data-testid="approval-graph-view-toggle">
           <el-button size="small" :type="canvasViewMode === 'list' ? 'primary' : 'default'" data-testid="approval-view-list" @click="canvasViewMode = 'list'">结构列表</el-button>
@@ -489,52 +484,56 @@
           >
             <ul class="template-authoring__error-list"><li v-for="issue in canvasValidity" :key="issue">{{ issue }}</li></ul>
           </el-alert>
-          <div
-            class="template-authoring__canvas"
-            data-testid="approval-graph-canvas"
-            :style="{ position: 'relative', height: canvasLayout.height + 'px', width: canvasLayout.width + 'px' }"
-          >
-            <svg class="template-authoring__canvas-edges" :width="canvasLayout.width" :height="canvasLayout.height">
-              <defs>
-                <marker id="approval-canvas-arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
-                  <path d="M0,0 L7,3 L0,6 Z" fill="#bbb" />
-                </marker>
-              </defs>
-              <line
-                v-for="line in canvasEdgeLines"
-                :key="line.key"
-                :x1="line.x1"
-                :y1="line.y1"
-                :x2="line.x2"
-                :y2="line.y2"
-                stroke="#bbb"
-                stroke-width="1.5"
-                marker-end="url(#approval-canvas-arrow)"
-                data-testid="approval-canvas-edge"
-              />
-            </svg>
+          <div class="template-authoring__canvas-viewport">
             <div
-              v-for="pos in canvasLayout.nodes"
-              :key="pos.key"
-              class="template-authoring__canvas-node"
-              :class="{ 'is-selected': selectedCanvasNode === pos.key }"
-              :style="{ position: 'absolute', left: pos.x + 'px', top: pos.y + 'px', width: CANVAS_NODE_W + 'px' }"
-              :data-canvas-node="pos.key"
-              data-testid="approval-canvas-node"
-              :draggable="!readOnly"
-              @click="selectedCanvasNode = pos.key"
-              @dragstart="onCanvasNodeDragStart(pos.key)"
-              @dragend="onCanvasNodeDragEnd($event)"
+              class="template-authoring__canvas"
+              data-testid="approval-graph-canvas"
+              :style="{ position: 'relative', height: canvasLayout.height + 'px', width: canvasLayout.width + 'px' }"
             >
-              <strong>{{ canvasNodeByKey(pos.key)?.name || pos.key }}</strong>
-              <span class="template-authoring__node-type" :data-node-type="canvasNodeByKey(pos.key)?.type">
-                {{ nodeTypeLabel(canvasNodeByKey(pos.key)?.type ?? 'approval') }}
-              </span>
-              <div v-if="!readOnly" class="template-authoring__canvas-node-actions">
-                <el-button v-if="canvasNodeByKey(pos.key)?.type === 'condition'" size="small" :data-testid="`approval-canvas-add-condition-${pos.key}`" @click.stop="onAddConditionBranch(pos.key)">+条件分支</el-button>
-                <el-button v-if="canvasNodeByKey(pos.key)?.type === 'parallel'" size="small" :data-testid="`approval-canvas-add-parallel-${pos.key}`" @click.stop="onAddParallelBranch(pos.key)">+并行分支</el-button>
-                <el-button v-if="canInsertAfter(canvasNodeByKey(pos.key)!)" size="small" :data-testid="`approval-canvas-insert-${pos.key}`" @click.stop="onInsertApprovalAfter(pos.key)">下方插入</el-button>
-                <el-button v-if="canRemoveNode(canvasNodeByKey(pos.key)!)" size="small" type="danger" :data-testid="`approval-canvas-remove-${pos.key}`" @click.stop="onRemoveNode(pos.key)">删除</el-button>
+              <svg class="template-authoring__canvas-edges" :width="canvasLayout.width" :height="canvasLayout.height">
+                <defs>
+                  <marker id="approval-canvas-arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+                    <path d="M0,0 L7,3 L0,6 Z" fill="#bbb" />
+                  </marker>
+                </defs>
+                <path
+                  v-for="line in canvasEdgeLines"
+                  :key="line.key"
+                  :d="line.path"
+                  stroke="#bbb"
+                  stroke-width="1.5"
+                  fill="none"
+                  marker-end="url(#approval-canvas-arrow)"
+                  data-testid="approval-canvas-edge"
+                />
+              </svg>
+              <div
+                v-for="pos in canvasLayout.nodes"
+                :key="pos.key"
+                class="template-authoring__canvas-node"
+                :class="{ 'is-selected': selectedCanvasNode === pos.key }"
+                :style="{ position: 'absolute', left: pos.x + 'px', top: pos.y + 'px', width: CANVAS_NODE_W + 'px' }"
+                :data-canvas-node="pos.key"
+                data-testid="approval-canvas-node"
+                :draggable="!readOnly"
+                @click="selectedCanvasNode = pos.key"
+                @dragstart="onCanvasNodeDragStart(pos.key)"
+                @dragend="onCanvasNodeDragEnd($event)"
+              >
+                <strong>{{ canvasNodeByKey(pos.key)?.name || pos.key }}</strong>
+                <span class="template-authoring__node-type" :data-node-type="canvasNodeByKey(pos.key)?.type">
+                  {{ nodeTypeLabel(canvasNodeByKey(pos.key)?.type ?? 'approval') }}
+                </span>
+                <div v-if="!readOnly" class="template-authoring__canvas-node-actions">
+                  <el-button v-if="canvasNodeByKey(pos.key)?.type === 'condition'" size="small" :data-testid="`approval-canvas-add-condition-${pos.key}`" @click.stop="onAddConditionBranch(pos.key)">+条件分支</el-button>
+                  <el-button v-if="canvasNodeByKey(pos.key)?.type === 'parallel'" size="small" :data-testid="`approval-canvas-add-parallel-${pos.key}`" @click.stop="onAddParallelBranch(pos.key)">+并行分支</el-button>
+                  <template v-if="canInsertAfter(canvasNodeByKey(pos.key)!)">
+                    <el-button size="small" :data-testid="`approval-canvas-insert-${pos.key}`" @click.stop="onInsertApprovalAfter(pos.key)">+审批</el-button>
+                    <el-button size="small" :data-testid="`approval-canvas-insert-condition-${pos.key}`" @click.stop="onInsertConditionAfter(pos.key)">+条件</el-button>
+                    <el-button size="small" :data-testid="`approval-canvas-insert-parallel-${pos.key}`" @click.stop="onInsertParallelAfter(pos.key)">+并行</el-button>
+                  </template>
+                  <el-button v-if="canRemoveNode(canvasNodeByKey(pos.key)!)" size="small" type="danger" :data-testid="`approval-canvas-remove-${pos.key}`" @click.stop="onRemoveNode(pos.key)">删除</el-button>
+                </div>
               </div>
             </div>
           </div>
@@ -574,6 +573,18 @@
                   :data-testid="`approval-topology-insert-after-${node.key}`"
                   @click="onInsertApprovalAfter(node.key)"
                 >下方插入审批</el-button>
+                <el-button
+                  v-if="canInsertAfter(node)"
+                  size="small"
+                  :data-testid="`approval-topology-insert-condition-after-${node.key}`"
+                  @click="onInsertConditionAfter(node.key)"
+                >下方添加条件</el-button>
+                <el-button
+                  v-if="canInsertAfter(node)"
+                  size="small"
+                  :data-testid="`approval-topology-insert-parallel-after-${node.key}`"
+                  @click="onInsertParallelAfter(node.key)"
+                >下方添加并行</el-button>
                 <el-button
                   v-if="canRemoveNode(node)"
                   size="small"
@@ -1000,6 +1011,64 @@
                 title="此为占位审批角色，发布前请替换为真实角色 ID"
                 description="占位角色无人可认领，未替换将无法发布该模板。"
               />
+              <div class="template-authoring__grid template-authoring__approval-node-policy">
+                <el-form-item label="审批模式">
+                  <el-select
+                    :model-value="approvalNodeMode(node.key)"
+                    :disabled="readOnly"
+                    class="ms-w-100pct"
+                    data-testid="approval-node-mode"
+                    @update:model-value="(mode: ApprovalMode) => setApprovalNodeMode(node.key, mode)"
+                  >
+                    <el-option label="单人通过" value="single" />
+                    <el-option label="全部通过" value="all" />
+                    <el-option label="任一通过" value="any" />
+                  </el-select>
+                </el-form-item>
+                <el-form-item label="空审批人策略">
+                  <el-select
+                    :model-value="approvalNodeEmptyPolicy(node.key)"
+                    :disabled="readOnly"
+                    class="ms-w-100pct"
+                    data-testid="approval-node-empty-policy"
+                    @update:model-value="(policy: EmptyAssigneePolicy) => setApprovalNodeEmptyPolicy(node.key, policy)"
+                  >
+                    <el-option label="报错" value="error" />
+                    <el-option label="自动通过" value="auto-approve" />
+                  </el-select>
+                </el-form-item>
+                <el-form-item label="自审策略">
+                  <el-checkbox
+                    :model-value="approvalNodeMergeWithRequester(node.key)"
+                    :disabled="readOnly"
+                    data-testid="approval-node-merge-with-requester"
+                    @update:model-value="(enabled: boolean) => setApprovalNodeMergeWithRequester(node.key, enabled)"
+                  >发起人自动通过（自审合并）</el-checkbox>
+                </el-form-item>
+              </div>
+              <div class="template-authoring__field-perms" data-testid="approval-node-field-permissions">
+                <div class="template-authoring__field-perms-head"><strong>字段权限</strong></div>
+                <div
+                  v-for="field in fieldPermissionFields"
+                  :key="field.id"
+                  class="template-authoring__field-perm-row"
+                  data-testid="approval-node-field-permission-row"
+                >
+                  <span class="template-authoring__field-perm-label">{{ field.label || field.id }}（{{ field.id }}）</span>
+                  <el-select
+                    :model-value="approvalNodeFieldAccess(node.key, field.id)"
+                    :disabled="readOnly"
+                    size="small"
+                    class="ms-w-130"
+                    :data-testid="`approval-node-field-access-${field.id}`"
+                    @update:model-value="(access: NodeFieldAccess) => setApprovalNodeFieldAccess(node.key, field.id, access)"
+                  >
+                    <el-option label="可编辑" value="editable" />
+                    <el-option label="只读" value="readonly" />
+                    <el-option label="隐藏" value="hidden" />
+                  </el-select>
+                </div>
+              </div>
             </div>
 
             <!-- approval (legacy / no edit) / other — read-only summary. -->
@@ -1067,6 +1136,18 @@
               >
                 在下方插入步骤
               </el-button>
+              <el-button
+                size="small"
+                :disabled="readOnly"
+                :data-testid="`approval-step-insert-condition-after-${step.localId}`"
+                @click="insertConditionAfterStep(index)"
+              >下方添加条件分支</el-button>
+              <el-button
+                size="small"
+                :disabled="readOnly"
+                :data-testid="`approval-step-insert-parallel-after-${step.localId}`"
+                @click="insertParallelAfterStep(index)"
+              >下方添加并行分支</el-button>
               <el-button size="small" type="danger" :disabled="readOnly || draft.steps.length === 1" @click="removeStep(index)">删除</el-button>
             </div>
           </div>
@@ -1592,16 +1673,24 @@ import {
   type CcNodeEdit,
   type ApprovalNodeSourceEdit,
   type TemplateAuthoringDraft,
-  applyTopologyToComplexDraft,
+  applyTopologyToDraft,
   moveItemToIndex,
 } from '../../approvals/templateAuthoring'
 import {
   addConditionBranch,
   addParallelBranch,
   appendApprovalNode,
+  insertConditionGateway,
+  insertParallelGateway,
   removeLinearNode,
 } from '../../approvals/graphTopologyEdit'
-import { computeLayout, graphValidityIssues, type GraphLayout } from '../../approvals/graphLayout'
+import {
+  computeLayout,
+  graphValidityIssues,
+  GRAPH_LAYOUT_NODE_HEIGHT,
+  GRAPH_LAYOUT_NODE_WIDTH,
+  type GraphLayout,
+} from '../../approvals/graphLayout'
 import {
   buildCommonApprovalTemplatePresetPayload,
   COMMON_APPROVAL_TEMPLATE_PRESETS,
@@ -1612,9 +1701,11 @@ import type {
   ApprovalAssigneeSourceKind,
   ApprovalAssigneeType,
   ApprovalGraph,
+  ApprovalMode,
   ApprovalNode,
   CcNodeConfig,
   ConditionNodeConfig,
+  EmptyAssigneePolicy,
   FormField,
   NodeFieldAccess,
   ParallelJoinMode,
@@ -1670,9 +1761,9 @@ const commonTemplatePresets = COMMON_APPROVAL_TEMPLATE_PRESETS
 const showPresetLibrary = computed(() => !isEditMode.value && canManageTemplates.value)
 // Truly-unsupported (attachment field / unknown node / extra config keys) locks the WHOLE form.
 const readOnly = computed(() => !canManageTemplates.value || Boolean(unsupportedReason.value))
-// A complex graph is shown via the read-only structured node list (`graphPreviewNodes`); the
-// linear steps editor is hidden. The graph is preserved on save, so this does NOT disable save.
-const graphReadOnly = computed(() => Boolean(graphReadOnlyMessage.value))
+// A draft enters graph authoring when it carries preservedGraph. Linear drafts are promoted when
+// the author inserts their first condition or parallel gateway.
+const graphReadOnly = computed(() => Boolean(draft.value.preservedGraph))
 const canSave = computed(() => canManageTemplates.value && !unsupportedReason.value && !loading.value)
 const draftStateLabel = computed(() => {
   if (!isEditMode.value && !isDraftDirty.value) return '新模板'
@@ -1994,6 +2085,43 @@ function approvalNodeEditFor(nodeKey: string): ApprovalNodeSourceEdit | undefine
 function approvalNodeFirstSource(nodeKey: string): ApprovalAssigneeSource | undefined {
   return approvalNodeEditFor(nodeKey)?.assigneeSources[0]
 }
+function approvalNodeMode(nodeKey: string): ApprovalMode {
+  return approvalNodeEditFor(nodeKey)?.approvalMode ?? 'single'
+}
+function setApprovalNodeMode(nodeKey: string, mode: ApprovalMode): void {
+  const edit = approvalNodeEditFor(nodeKey)
+  if (edit) edit.approvalMode = mode
+}
+function approvalNodeEmptyPolicy(nodeKey: string): EmptyAssigneePolicy {
+  return approvalNodeEditFor(nodeKey)?.emptyAssigneePolicy ?? 'error'
+}
+function setApprovalNodeEmptyPolicy(nodeKey: string, policy: EmptyAssigneePolicy): void {
+  const edit = approvalNodeEditFor(nodeKey)
+  if (edit) edit.emptyAssigneePolicy = policy
+}
+function approvalNodeMergeWithRequester(nodeKey: string): boolean {
+  return Boolean(approvalNodeEditFor(nodeKey)?.autoApprovalPolicy?.mergeWithRequester)
+}
+function setApprovalNodeMergeWithRequester(nodeKey: string, enabled: boolean): void {
+  const edit = approvalNodeEditFor(nodeKey)
+  if (!edit) return
+  const policy = edit.autoApprovalPolicy && edit.autoApprovalPolicy !== null
+    ? { ...edit.autoApprovalPolicy }
+    : {}
+  if (enabled) policy.mergeWithRequester = true
+  else delete policy.mergeWithRequester
+  edit.autoApprovalPolicy = Object.keys(policy).length > 0 ? policy : null
+}
+function approvalNodeFieldAccess(nodeKey: string, fieldId: string): NodeFieldAccess {
+  return approvalNodeEditFor(nodeKey)?.fieldPermissions?.find((permission) => permission.fieldId === fieldId)?.access ?? 'editable'
+}
+function setApprovalNodeFieldAccess(nodeKey: string, fieldId: string, access: NodeFieldAccess): void {
+  const edit = approvalNodeEditFor(nodeKey)
+  if (!edit) return
+  const next = (edit.fieldPermissions ?? []).filter((permission) => permission.fieldId !== fieldId)
+  if (access !== 'editable') next.push({ fieldId, access })
+  edit.fieldPermissions = next
+}
 // Replace ONLY the primary (first) source; preserve any extra sources verbatim (no flatten).
 function setApprovalNodeSource(nodeKey: string, source: ApprovalAssigneeSource): void {
   const edit = approvalNodeEditFor(nodeKey)
@@ -2028,13 +2156,13 @@ function approvalSourceIsPlaceholder(nodeKey: string): boolean {
   return publishPlaceholderRoleKeys.value.includes(nodeKey)
 }
 
-// ── D-2/D-3 topology authoring (structural graph edits via graphTopologyEdit + applyTopologyToComplexDraft) ──
+// ── Topology authoring (structural graph edits via graphTopologyEdit + applyTopologyToDraft) ──
 // Each op runs on the EFFECTIVE graph (configs applied) and re-seeds the draft, so the structured
 // editors stay in sync. Guards mirror the engine preconditions so a shown button never throws; a
 // (defensive) throw surfaces as loadError. The interactive free-drag canvas is the gated next slice.
 function runTopologyOp(op: (graph: ApprovalGraph) => ApprovalGraph): void {
   try {
-    draft.value = applyTopologyToComplexDraft(draft.value, op)
+    draft.value = applyTopologyToDraft(draft.value, op)
   } catch (error) {
     loadError.value = error instanceof Error ? error.message : '拓扑修改失败'
   }
@@ -2047,6 +2175,14 @@ function onAddParallelBranch(nodeKey: string): void {
 }
 function onInsertApprovalAfter(nodeKey: string): void {
   runTopologyOp((graph) => appendApprovalNode(graph, nodeKey))
+}
+function onInsertConditionAfter(nodeKey: string): void {
+  runTopologyOp((graph) => insertConditionGateway(graph, nodeKey))
+  canvasViewMode.value = 'canvas'
+}
+function onInsertParallelAfter(nodeKey: string): void {
+  runTopologyOp((graph) => insertParallelGateway(graph, nodeKey))
+  canvasViewMode.value = 'canvas'
 }
 function onRemoveNode(nodeKey: string): void {
   runTopologyOp((graph) => removeLinearNode(graph, nodeKey))
@@ -2071,8 +2207,8 @@ const canvasViewMode = ref<'list' | 'canvas'>('list')
 const selectedCanvasNode = ref<string | null>(null)
 const nodePositions = ref<Record<string, { x: number; y: number }>>({})
 const draggingCanvasNode = ref<string | null>(null)
-const CANVAS_NODE_W = 150
-const CANVAS_NODE_H = 56
+const CANVAS_NODE_W = GRAPH_LAYOUT_NODE_WIDTH
+const CANVAS_NODE_H = GRAPH_LAYOUT_NODE_HEIGHT
 const canvasEffectiveGraph = computed<ApprovalGraph>(() => buildApprovalGraph(draft.value))
 const canvasLayout = computed<GraphLayout>(() => {
   const layout = computeLayout(canvasEffectiveGraph.value)
@@ -2127,13 +2263,12 @@ const canvasEdgeLines = computed(() => {
   return canvasEffectiveGraph.value.edges.map((edge) => {
     const s = pos.get(edge.source)
     const t = pos.get(edge.target)
-    return {
-      key: edge.key,
-      x1: (s?.x ?? 0) + CANVAS_NODE_W,
-      y1: (s?.y ?? 0) + CANVAS_NODE_H / 2,
-      x2: t?.x ?? 0,
-      y2: (t?.y ?? 0) + CANVAS_NODE_H / 2,
-    }
+    const x1 = (s?.x ?? 0) + CANVAS_NODE_W / 2
+    const y1 = (s?.y ?? 0) + CANVAS_NODE_H
+    const x2 = (t?.x ?? 0) + CANVAS_NODE_W / 2
+    const y2 = t?.y ?? 0
+    const midY = y1 + (y2 - y1) / 2
+    return { key: edge.key, path: `M ${x1} ${y1} L ${x1} ${midY} L ${x2} ${midY} L ${x2} ${y2}` }
   })
 })
 function onCanvasNodeDragStart(key: string): void {
@@ -2364,6 +2499,14 @@ function addStep() {
 // own doc in templateAuthoring.ts for exactly what counts as "still default").
 function insertStep(index: number) {
   draft.value.steps = insertStepAt(draft.value.steps, index)
+}
+
+function insertConditionAfterStep(index: number) {
+  onInsertConditionAfter(`approval_${index + 1}`)
+}
+
+function insertParallelAfterStep(index: number) {
+  onInsertParallelAfter(`approval_${index + 1}`)
 }
 
 function removeStep(index: number) {
@@ -3146,6 +3289,17 @@ pre {
     position: static;
   }
 
+  .template-authoring__header :deep(.ms-page-header__top) {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .template-authoring__header :deep(.ms-page-header__actions) {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+
   .template-authoring__validation-summary,
   .template-authoring__content {
     scroll-margin-top: var(--ms-space-3);
@@ -3154,6 +3308,10 @@ pre {
   .template-authoring__actions,
   .template-authoring__actions :deep(.el-button) {
     width: 100%;
+  }
+
+  .template-authoring__actions :deep(.el-button) {
+    flex: 1;
   }
 
   .template-authoring__steps {
@@ -3180,11 +3338,15 @@ pre {
   gap: 8px;
   margin-bottom: 12px;
 }
-.template-authoring__canvas {
-  position: relative;
+.template-authoring__canvas-viewport {
+  max-width: 100%;
   overflow: auto;
   border: 1px solid var(--el-border-color);
   border-radius: 6px;
+  background: var(--ms-bg-page);
+}
+.template-authoring__canvas {
+  position: relative;
   background: var(--ms-bg-page);
   min-height: 200px;
 }
@@ -3205,6 +3367,7 @@ pre {
   gap: 2px;
   cursor: grab;
   font-size: 12px;
+  min-height: 96px;
 }
 .template-authoring__canvas-node.is-selected {
   border-color: var(--el-color-primary);

--- a/apps/web/tests/approval-graph-layout.test.ts
+++ b/apps/web/tests/approval-graph-layout.test.ts
@@ -37,14 +37,15 @@ const REJOIN: ApprovalGraph = {
   ],
 }
 
-describe('computeLayout (longest-path layered)', () => {
-  it('places a linear graph in increasing layers/x with stable coordinates', () => {
+describe('computeLayout (vertical longest-path layered)', () => {
+  it('places a linear graph in increasing layers/y on one centered column', () => {
     const layout = computeLayout(LINEAR)
     const byKey = new Map(layout.nodes.map((n) => [n.key, n]))
     expect(byKey.get('start')!.layer).toBe(0)
     expect(byKey.get('a1')!.layer).toBe(1)
     expect(byKey.get('end')!.layer).toBe(2)
-    expect(byKey.get('a1')!.x).toBeGreaterThan(byKey.get('start')!.x)
+    expect(byKey.get('a1')!.y).toBeGreaterThan(byKey.get('start')!.y)
+    expect(byKey.get('a1')!.x).toBe(byKey.get('start')!.x)
     expect(layout.nodes).toHaveLength(3)
   })
   it('puts a rejoin node AFTER both of its branches (longest-path, not shortest)', () => {
@@ -54,6 +55,9 @@ describe('computeLayout (longest-path layered)', () => {
     expect(byKey.get('join')!.layer).toBeGreaterThan(byKey.get('high')!.layer)
     expect(byKey.get('join')!.layer).toBeGreaterThan(byKey.get('low')!.layer)
     expect(byKey.get('end')!.layer).toBe(4)
+    expect(byKey.get('high')!.y).toBe(byKey.get('low')!.y)
+    expect(byKey.get('high')!.x).not.toBe(byKey.get('low')!.x)
+    expect(byKey.get('join')!.y).toBeGreaterThan(byKey.get('high')!.y)
   })
 })
 

--- a/apps/web/tests/approval-graph-topology-edit.test.ts
+++ b/apps/web/tests/approval-graph-topology-edit.test.ts
@@ -191,11 +191,19 @@ describe('addParallelBranch / removeParallelBranch', () => {
 })
 
 describe('addConditionBranch / removeConditionBranch', () => {
-  it('adds a branch (empty rules) rejoining at the default target, growing branches to 2', () => {
+  it('adds a branch seeded with the SAME incomplete starter rule as insertConditionGateway (NEVER empty rules), rejoining at the default target', () => {
     const out = addConditionBranch(CONDITION, 'cond_1', '中额')
     const config = node(out, 'cond_1')!.config as { branches: Array<{ edgeKey: string; rules: unknown[] }>; defaultEdgeKey: string }
     expect(config.branches).toHaveLength(2)
-    expect(config.branches[1].rules).toEqual([]) // admin fills the rule via the G-2 editor
+    // A `rules: []` seed would be a P1: the runtime evaluates a rules-mode branch as
+    // `rules.every(...)` — vacuously TRUE over [] — so an empty branch silently captures ALL
+    // traffic (first-match-wins) and dead-codes the default edge. The starter mirrors
+    // insertConditionGateway exactly: an incomplete rule the validator blocks (需要选择字段).
+    expect(config.branches[1]).toEqual({
+      edgeKey: config.branches[1].edgeKey,
+      conjunction: 'and',
+      rules: [{ fieldId: '', operator: 'eq', value: '' }],
+    })
     const newEdge = out.edges.find((e) => e.key === config.branches[1].edgeKey)!
     expect(newEdge.source).toBe('cond_1')
     expect(edgeBetween(out, newEdge.target, 'end')).toBeTruthy() // rejoins where the default edge went
@@ -264,5 +272,26 @@ describe('applyTopologyToComplexDraft — engine ↔ complex draft bridge (one s
     const conditionKey = next.preservedGraph!.nodes.find((candidate) => candidate.type === 'condition')!.key
     next.conditionEdits![conditionKey].branches[0].rules[0].fieldId = 'amount'
     expect(validateTemplateApprovalFlow(next).some((error) => error.includes('需要选择字段'))).toBe(false)
+  })
+
+  // P1 regression (adversarial review F1): +条件分支 via addConditionBranch previously seeded
+  // `rules: []`, which validated CLEAN and published — then the runtime's `[].every(...)` matched
+  // EVERY request, silently capturing all traffic and dead-coding the default edge. The added
+  // branch must be save-blocked exactly like insertConditionGateway's starter branch.
+  // (Mutation catcher: neutralize the addConditionBranch seed back to `rules: []` → this REDs.)
+  it('blocks save after ADDING a condition branch until its starter rule is configured (never a clean empty branch)', () => {
+    const draft = draftFromTemplate(tpl(CONDITION))
+    const next = applyTopologyToComplexDraft(draft, (g) => addConditionBranch(g, 'cond_1', '中额'))
+    expect(validateTemplateApprovalFlow(next).some((error) => error.includes('需要选择字段'))).toBe(true)
+    next.conditionEdits!.cond_1.branches[1].rules[0].fieldId = 'amount'
+    expect(validateTemplateApprovalFlow(next)).toEqual([])
+  })
+
+  // Layer (b) of the same fix: even a graph that ALREADY carries a rules-mode branch with zero
+  // rules (legacy stored / hand-built — no starter rule to be incomplete) must be save-blocked.
+  it('flags a rules-mode condition branch with ZERO rules as a validation error (empty branch would match everything)', () => {
+    const draft = draftFromTemplate(tpl(CONDITION))
+    draft.conditionEdits!.cond_1.branches[0].rules = []
+    expect(validateTemplateApprovalFlow(draft).some((error) => error.includes('需要至少一条规则'))).toBe(true)
   })
 })

--- a/apps/web/tests/approval-graph-topology-edit.test.ts
+++ b/apps/web/tests/approval-graph-topology-edit.test.ts
@@ -2,13 +2,22 @@ import { describe, expect, it } from 'vitest'
 import type { ApprovalGraph, ApprovalTemplateDetailDTO } from '../src/types/approval'
 import {
   appendApprovalNode,
+  insertConditionGateway,
+  insertParallelGateway,
   removeLinearNode,
   addParallelBranch,
   removeParallelBranch,
   addConditionBranch,
   removeConditionBranch,
 } from '../src/approvals/graphTopologyEdit'
-import { applyTopologyToComplexDraft, buildApprovalGraph, draftFromTemplate, moveItemToIndex } from '../src/approvals/templateAuthoring'
+import {
+  applyTopologyToComplexDraft,
+  applyTopologyToDraft,
+  buildApprovalGraph,
+  draftFromTemplate,
+  moveItemToIndex,
+  validateTemplateApprovalFlow,
+} from '../src/approvals/templateAuthoring'
 
 describe('moveItemToIndex (D-4 field drag-reorder logic)', () => {
   it('moves an item to an arbitrary index (pure, returns a new array)', () => {
@@ -94,12 +103,66 @@ describe('appendApprovalNode', () => {
   })
 })
 
+describe('insertConditionGateway', () => {
+  it('turns a linear edge into a configurable branch plus a default path that rejoin', () => {
+    const before = snap(LINEAR)
+    const out = insertConditionGateway(LINEAR, 'approval_1')
+    expect(LINEAR).toEqual(before)
+    const condition = out.nodes.find((candidate) => candidate.type === 'condition')!
+    const config = condition.config as { branches: Array<{ edgeKey: string; rules: Array<{ fieldId: string }> }>; defaultEdgeKey: string }
+    const branchEdge = out.edges.find((edge) => edge.key === config.branches[0].edgeKey)!
+    const defaultEdge = out.edges.find((edge) => edge.key === config.defaultEdgeKey)!
+    const branchNode = node(out, branchEdge.target)!
+    const defaultNode = node(out, defaultEdge.target)!
+    expect(config.branches[0].rules[0].fieldId).toBe('')
+    expect(branchNode.type).toBe('approval')
+    expect(edgeBetween(out, 'approval_1', condition.key)).toBeTruthy()
+    expect(defaultNode.type).toBe('approval')
+    expect(edgeBetween(out, branchNode.key, 'end')).toBeTruthy()
+    expect(edgeBetween(out, defaultNode.key, 'end')).toBeTruthy()
+    expect(edgeBetween(out, 'approval_1', 'end')).toBeFalsy()
+  })
+
+  it('refuses an ambiguous branching insertion point', () => {
+    expect(() => insertConditionGateway(PARALLEL, 'parallel_1')).toThrow(/exactly one outgoing/)
+  })
+})
+
+describe('insertParallelGateway', () => {
+  it('turns a linear edge into a two-branch fork rejoining at the original target', () => {
+    const before = snap(LINEAR)
+    const out = insertParallelGateway(LINEAR, 'approval_1')
+    expect(LINEAR).toEqual(before)
+    const parallel = out.nodes.find((candidate) => candidate.type === 'parallel')!
+    const config = parallel.config as { branches: string[]; joinMode: string; joinNodeKey: string }
+    expect(config).toMatchObject({ joinMode: 'all', joinNodeKey: 'end' })
+    expect(config.branches).toHaveLength(2)
+    const branchTargets = config.branches.map((edgeKey) => out.edges.find((edge) => edge.key === edgeKey)!.target)
+    expect(new Set(branchTargets).size).toBe(2)
+    expect(branchTargets.every((target) => node(out, target)?.type === 'approval')).toBe(true)
+    expect(branchTargets.every((target) => Boolean(edgeBetween(out, target, 'end')))).toBe(true)
+    expect(edgeBetween(out, 'approval_1', parallel.key)).toBeTruthy()
+    expect(edgeBetween(out, 'approval_1', 'end')).toBeFalsy()
+  })
+})
+
 describe('removeLinearNode', () => {
   it('removes a single-in/out approval node and bridges pred→succ', () => {
     const out = removeLinearNode(LINEAR, 'approval_1')
     expect(node(out, 'approval_1')).toBeUndefined()
     expect(edgeBetween(out, 'start', 'end')).toBeTruthy() // bridged
     expect(out.edges).toHaveLength(1)
+  })
+  it('preserves a condition branch edge key when removing its first approval node', () => {
+    const graph = insertConditionGateway(LINEAR, 'approval_1')
+    const condition = graph.nodes.find((candidate) => candidate.type === 'condition')!
+    const branchEdgeKey = (condition.config as { branches: Array<{ edgeKey: string }> }).branches[0].edgeKey
+    const branchTarget = graph.edges.find((edge) => edge.key === branchEdgeKey)!.target
+    const out = removeLinearNode(graph, branchTarget)
+    expect(out.edges.find((edge) => edge.key === branchEdgeKey)).toMatchObject({
+      source: condition.key,
+      target: 'end',
+    })
   })
   it('refuses to remove start/end/condition/parallel', () => {
     expect(() => removeLinearNode(CONDITION, 'cond_1')).toThrow(/only approval\/cc/)
@@ -137,6 +200,17 @@ describe('addConditionBranch / removeConditionBranch', () => {
     expect(newEdge.source).toBe('cond_1')
     expect(edgeBetween(out, newEdge.target, 'end')).toBeTruthy() // rejoins where the default edge went
   })
+  it('adds a sibling at the true convergence point when the default path has its own approval node', () => {
+    const graph = insertConditionGateway(LINEAR, 'approval_1')
+    const condition = graph.nodes.find((candidate) => candidate.type === 'condition')!
+    const before = condition.config as { branches: Array<{ edgeKey: string }>; defaultEdgeKey: string }
+    const defaultTarget = graph.edges.find((edge) => edge.key === before.defaultEdgeKey)!.target
+    const out = addConditionBranch(graph, condition.key, '第三分支')
+    const config = node(out, condition.key)!.config as { branches: Array<{ edgeKey: string }> }
+    const addedTarget = out.edges.find((edge) => edge.key === config.branches.at(-1)!.edgeKey)!.target
+    expect(edgeBetween(out, addedTarget, 'end')).toBeTruthy()
+    expect(edgeBetween(out, addedTarget, defaultTarget)).toBeFalsy()
+  })
   it('removes a non-default branch; refuses to remove the default fall-through edge', () => {
     const two = addConditionBranch(CONDITION, 'cond_1')
     const cfg = two.nodes.find((n) => n.key === 'cond_1')!.config as { branches: Array<{ edgeKey: string }> }
@@ -170,5 +244,25 @@ describe('applyTopologyToComplexDraft — engine ↔ complex draft bridge (one s
     const built = buildApprovalGraph(next)
     expect((node(built, newApproval.key)!.config as { assigneeSources: unknown }).assigneeSources).toEqual([{ kind: 'dept_head' }])
     expect(node(built, 'app_a')).toEqual(node(PARALLEL, 'app_a')) // original branch untouched
+  })
+
+  it('promotes a linear draft before inserting a gateway, preserving existing approval config', () => {
+    const draft = draftFromTemplate(tpl(LINEAR))
+    const next = applyTopologyToDraft(draft, (graph) => insertParallelGateway(graph, 'approval_1'))
+    const built = buildApprovalGraph(next)
+    expect(next.steps).toEqual([])
+    expect(next.preservedGraph).toBeTruthy()
+    expect(node(built, 'approval_1')).toEqual(node(LINEAR, 'approval_1'))
+    expect(built.nodes.some((candidate) => candidate.type === 'parallel')).toBe(true)
+    expect(Object.keys(next.parallelEdits ?? {})).toHaveLength(1)
+  })
+
+  it('blocks save after inserting a condition until its starter rule is configured', () => {
+    const draft = draftFromTemplate(tpl(LINEAR))
+    const next = applyTopologyToDraft(draft, (graph) => insertConditionGateway(graph, 'approval_1'))
+    expect(validateTemplateApprovalFlow(next).some((error) => error.includes('需要选择字段'))).toBe(true)
+    const conditionKey = next.preservedGraph!.nodes.find((candidate) => candidate.type === 'condition')!.key
+    next.conditionEdits![conditionKey].branches[0].rules[0].fieldId = 'amount'
+    expect(validateTemplateApprovalFlow(next).some((error) => error.includes('需要选择字段'))).toBe(false)
   })
 })

--- a/apps/web/tests/approval-graph-topology-edit.test.ts
+++ b/apps/web/tests/approval-graph-topology-edit.test.ts
@@ -5,6 +5,7 @@ import { parallelDynamicAssigneeConflicts } from '../src/approvals/parallelEdit'
 import { placeholderRoleNodeKeys } from '../src/approvals/approvalNodeEdit'
 import {
   appendApprovalNode,
+  collectParallelRegionNodeKeys,
   insertConditionGateway,
   insertParallelGateway,
   removeLinearNode,
@@ -184,6 +185,23 @@ describe('insertParallelGateway', () => {
     expect((node(out, newTarget)!.config as { assigneeSources: ApprovalAssigneeSource[] }).assigneeSources)
       .toEqual([{ kind: 'static_role', roleIds: [APPROVAL_ROLE_CONFIGURE_SENTINEL] }])
     expect(parallelDynamicAssigneeConflicts(out)).toEqual([])
+  })
+})
+
+describe('collectParallelRegionNodeKeys + nested-parallel prevention (F4)', () => {
+  it('collects exactly the branch nodes between fork and join (join and fork excluded)', () => {
+    expect(collectParallelRegionNodeKeys(PARALLEL)).toEqual(new Set(['app_a', 'app_b']))
+    expect(collectParallelRegionNodeKeys(LINEAR)).toEqual(new Set())
+    expect(collectParallelRegionNodeKeys(CONDITION)).toEqual(new Set())
+  })
+
+  it('insertParallelGateway REFUSES a node inside a parallel branch (backend rejects nested parallel at save)', () => {
+    expect(() => insertParallelGateway(PARALLEL, 'app_a')).toThrow(/nested parallel/)
+  })
+
+  it('insertConditionGateway inside a parallel branch stays ALLOWED (condition-in-parallel is legal)', () => {
+    const out = insertConditionGateway(PARALLEL, 'app_a')
+    expect(out.nodes.some((n) => n.type === 'condition')).toBe(true)
   })
 })
 

--- a/apps/web/tests/approval-graph-topology-edit.test.ts
+++ b/apps/web/tests/approval-graph-topology-edit.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import type { ApprovalGraph, ApprovalTemplateDetailDTO } from '../src/types/approval'
+import type { ApprovalGraph, ApprovalTemplateDetailDTO, ApprovalAssigneeSource } from '../src/types/approval'
+import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../src/types/approval'
+import { parallelDynamicAssigneeConflicts } from '../src/approvals/parallelEdit'
+import { placeholderRoleNodeKeys } from '../src/approvals/approvalNodeEdit'
 import {
   appendApprovalNode,
   insertConditionGateway,
@@ -143,6 +146,44 @@ describe('insertParallelGateway', () => {
     expect(branchTargets.every((target) => Boolean(edgeBetween(out, target, 'end')))).toBe(true)
     expect(edgeBetween(out, 'approval_1', parallel.key)).toBeTruthy()
     expect(edgeBetween(out, 'approval_1', 'end')).toBeFalsy()
+  })
+
+  // P2 regression (adversarial review F2): both starter branches used to seed `requester`, so the
+  // UNTOUCHED default output resolved both branches to the same user — publish was green, then the
+  // fan-out 409'd (APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT) on EVERY request. The second branch
+  // now uses the configure-before-publish placeholder role: the draft saves, the publish checklist
+  // + backend sentinel gate force the admin to pick a real approver first.
+  it('starter branches do NOT self-conflict: branch 2 is the configure-before-publish placeholder, not a duplicate requester', () => {
+    const out = insertParallelGateway(LINEAR, 'approval_1')
+    const parallel = out.nodes.find((candidate) => candidate.type === 'parallel')!
+    const config = parallel.config as { branches: string[] }
+    const [oneKey, twoKey] = config.branches.map((edgeKey) => out.edges.find((edge) => edge.key === edgeKey)!.target)
+    const sourcesOf = (key: string) => (node(out, key)!.config as { assigneeSources: ApprovalAssigneeSource[] }).assigneeSources
+    expect(sourcesOf(oneKey)).toEqual([{ kind: 'requester' }])
+    expect(sourcesOf(twoKey)).toEqual([{ kind: 'static_role', roleIds: [APPROVAL_ROLE_CONFIGURE_SENTINEL] }])
+    // No provably-identical dynamic sources across the starter branches…
+    expect(parallelDynamicAssigneeConflicts(out)).toEqual([])
+    // …and the placeholder is visible to the publish checklist once the draft is promoted (the
+    // "forces selection" half of the fix).
+    const draft = draftFromTemplate({
+      id: 't', key: 'k', name: 'n', description: null, category: null,
+      visibilityScope: { type: 'all', ids: [] }, slaHours: null, status: 'draft',
+      activeVersionId: null, latestVersionId: 'v',
+      createdAt: '2026-06-24T00:00:00Z', updatedAt: '2026-06-24T00:00:00Z',
+      formSchema: { fields: [{ id: 'amount', type: 'number', label: '金额', required: true }] },
+      approvalGraph: LINEAR,
+    })
+    const next = applyTopologyToDraft(draft, (graph) => insertParallelGateway(graph, 'approval_1'))
+    expect(placeholderRoleNodeKeys(next.approvalNodeEdits ?? {})).toEqual([twoKey])
+  })
+
+  it('addParallelBranch seeds the placeholder too (a concrete dynamic default could duplicate an existing branch)', () => {
+    const out = addParallelBranch(PARALLEL, 'parallel_1', 'C')
+    const config = node(out, 'parallel_1')!.config as { branches: string[] }
+    const newTarget = out.edges.find((e) => e.key === config.branches[2])!.target
+    expect((node(out, newTarget)!.config as { assigneeSources: ApprovalAssigneeSource[] }).assigneeSources)
+      .toEqual([{ kind: 'static_role', roleIds: [APPROVAL_ROLE_CONFIGURE_SENTINEL] }])
+    expect(parallelDynamicAssigneeConflicts(out)).toEqual([])
   })
 })
 

--- a/apps/web/tests/approval-graph-topology-edit.test.ts
+++ b/apps/web/tests/approval-graph-topology-edit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { ApprovalGraph, ApprovalTemplateDetailDTO, ApprovalAssigneeSource } from '../src/types/approval'
+import type { ApprovalGraph, ApprovalNode, ApprovalTemplateDetailDTO, ApprovalAssigneeSource } from '../src/types/approval'
 import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../src/types/approval'
 import { parallelDynamicAssigneeConflicts } from '../src/approvals/parallelEdit'
 import { placeholderRoleNodeKeys } from '../src/approvals/approvalNodeEdit'
@@ -304,6 +304,74 @@ describe('applyTopologyToComplexDraft — engine ↔ complex draft bridge (one s
     expect(node(built, 'approval_1')).toEqual(node(LINEAR, 'approval_1'))
     expect(built.nodes.some((candidate) => candidate.type === 'parallel')).toBe(true)
     expect(Object.keys(next.parallelEdits ?? {})).toHaveLength(1)
+  })
+
+  // F3 (adversarial review #4433): the LINEAR fixture above carries the flatten-to-default values
+  // (approvalMode 'single' / emptyAssigneePolicy 'error'), so a buildStepConfig that silently
+  // flattened them still passed (mutation M1 survived every suite). This fixture makes every
+  // authorable dimension NON-default so any flatten REDs the byte-equal round-trip.
+  const RICH_LINEAR: ApprovalGraph = {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      {
+        key: 'approval_1',
+        type: 'approval',
+        name: '主管',
+        config: {
+          assigneeSources: [{ kind: 'direct_manager' }],
+          approvalMode: 'all',
+          emptyAssigneePolicy: 'auto-approve',
+          autoApprovalPolicy: {
+            mergeWithRequester: true,
+            mergeAdjacentApprover: true,
+            dedupeHistoricalApprover: true,
+            actorMode: 'original_approver',
+          },
+          fieldPermissions: [{ fieldId: 'amount', access: 'readonly' }],
+        },
+      },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-a1', source: 'start', target: 'approval_1' },
+      { key: 'e-a1-end', source: 'approval_1', target: 'end' },
+    ],
+  }
+
+  it('promote preserves NON-DEFAULT approval config byte-equal (mode/policy/auto-approval/permissions — M1 flatten catcher)', () => {
+    const draft = draftFromTemplate(tpl(RICH_LINEAR))
+    const next = applyTopologyToDraft(draft, (graph) => insertParallelGateway(graph, 'approval_1'))
+    const built = buildApprovalGraph(next)
+    // Full-config equality — approvalMode 'all', emptyAssigneePolicy 'auto-approve', the complete
+    // 4-field autoApprovalPolicy AND fieldPermissions must all survive hydrate → promote → rebuild.
+    expect(node(built, 'approval_1')).toEqual(node(RICH_LINEAR, 'approval_1'))
+    // The same non-defaults ALSO survive a second rebuild from the promoted draft (steady state).
+    expect(node(buildApprovalGraph(next), 'approval_1')).toEqual(node(RICH_LINEAR, 'approval_1'))
+  })
+
+  it('a topology op on a COMPLEX draft preserves an untouched node timeout byte-equal (pure-layer anti-flatten floor)', () => {
+    // `timeout` is not linear-authorable, so it can only exist on the complex path; the pure
+    // apply/rebuild layer must still pass it through verbatim (applyApprovalNodeEditsToGraph's
+    // original-config spread). NB: the VIEW additionally locks timeout-carrying complex templates
+    // read-only via the backend-drop allowlist — this pins the engine-level floor beneath that.
+    const TIMEOUT_CONDITION: ApprovalGraph = {
+      ...CONDITION,
+      nodes: CONDITION.nodes.map((n) => (n.key === 'app_high'
+        ? {
+            ...n,
+            config: {
+              assigneeSources: [{ kind: 'dept_head' }],
+              approvalMode: 'single',
+              emptyAssigneePolicy: 'error',
+              timeout: { afterMinutes: 30, effect: 'remind' },
+            } as ApprovalNode['config'],
+          }
+        : n)),
+    }
+    const draft = draftFromTemplate(tpl(TIMEOUT_CONDITION))
+    const next = applyTopologyToComplexDraft(draft, (g) => addConditionBranch(g, 'cond_1', '中额'))
+    const built = buildApprovalGraph(next)
+    expect(node(built, 'app_high')).toEqual(node(TIMEOUT_CONDITION, 'app_high'))
   })
 
   it('blocks save after inserting a condition until its starter rule is configured', () => {

--- a/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
@@ -13,7 +13,7 @@ import {
   validateApprovalNodeEdits,
 } from '../src/approvals/approvalNodeEdit'
 
-// G-5 — approval-node editing (approver SOURCE only: `assigneeSources`). PURE-LOGIC tests (no .vue)
+// Approval-node editing inside the graph authoring model. PURE-LOGIC tests (no .vue)
 // so they run under approval-web-guard. The GATE is topology + cross-phase + WITHIN-NODE
 // preservation: editing one approval node's source must leave every OTHER node + the FULL edge list
 // byte-identical, must COMPOSE with condition/parallel/cc edits, must keep that node's OWN
@@ -100,7 +100,13 @@ const node = (g: ApprovalGraph, key: string) => g.nodes.find((n) => n.key === ke
 describe('approvalNodeEditsFromGraph (seed)', () => {
   it('seeds one entry per approval node that HAS assigneeSources', () => {
     expect(approvalNodeEditsFromGraph(APPROVAL_GRAPH)).toEqual({
-      approval_1: { nodeKey: 'approval_1', assigneeSources: [{ kind: 'static_role', roleIds: ['mgr'] }] },
+      approval_1: {
+        nodeKey: 'approval_1',
+        assigneeSources: [{ kind: 'static_role', roleIds: ['mgr'] }],
+        approvalMode: 'single',
+        emptyAssigneePolicy: 'error',
+        autoApprovalPolicy: { mergeWithRequester: true },
+      },
     })
   })
   it('does NOT seed a legacy approval node (no assigneeSources array) — stays read-only', () => {
@@ -126,6 +132,22 @@ describe('G-5 topology-preservation — editing an approver source keeps everyth
     expect(cfg.emptyAssigneePolicy).toBe('error')
     expect(cfg.autoApprovalPolicy).toEqual({ mergeWithRequester: true }) // preserved, not dropped
     expect(cfg.assigneeSources).toEqual([{ kind: 'dept_head' }])
+  })
+  it('edits mode, empty policy, requester merge, and field permissions without touching topology', () => {
+    const edits = approvalNodeEditsFromGraph(APPROVAL_GRAPH)
+    edits.approval_1.approvalMode = 'any'
+    edits.approval_1.emptyAssigneePolicy = 'auto-approve'
+    edits.approval_1.autoApprovalPolicy = null
+    edits.approval_1.fieldPermissions = [{ fieldId: 'amount', access: 'hidden' }]
+    const rebuilt = applyApprovalNodeEditsToGraph(APPROVAL_GRAPH, edits)
+    const cfg = node(rebuilt, 'approval_1').config as Record<string, unknown>
+    expect(cfg).toMatchObject({
+      approvalMode: 'any',
+      emptyAssigneePolicy: 'auto-approve',
+      fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }],
+    })
+    expect(cfg.autoApprovalPolicy).toBeUndefined()
+    expect(rebuilt.edges).toEqual(APPROVAL_GRAPH.edges)
   })
   it('does not mutate the input graph', () => {
     const before = clone(APPROVAL_GRAPH)

--- a/apps/web/tests/approval-template-authoring-condition-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-condition-edit.test.ts
@@ -469,6 +469,33 @@ describe('G-2 validation preview (UX-only; backend normalizeApprovalGraph is fin
     expect(validateConditionEdits(edits, formSchema, CONDITION_GRAPH)).toEqual([])
   })
 
+  // P1 F1(b): a rules-mode branch with ZERO rules must be an error — the runtime evaluates
+  // `rules.every(...)`, vacuously TRUE over `[]`, so an empty branch would capture ALL traffic
+  // (first-match-wins) and dead-code the default edge. The fall-through "else" is `defaultEdgeKey`,
+  // a separate mechanism — an empty rules array is never a legitimate way to express it.
+  it('flags a rules-mode branch with ZERO rules (empty branch would match every request)', () => {
+    const edits: ConditionEdits = {
+      cond_1: {
+        nodeKey: 'cond_1',
+        branches: [{ edgeKey: 'edge-cond_1-high', predicateMode: 'rules', conjunction: 'and', rules: [], formulaExpression: '' }],
+        defaultEdgeKey: 'edge-cond_1-low',
+      },
+    }
+    const errors = validateConditionEdits(edits, formSchema, CONDITION_GRAPH)
+    expect(errors.some((message) => message.includes('需要至少一条规则'))).toBe(true)
+  })
+
+  it('does NOT flag a FORMULA branch for having empty rules (formula is the predicate there)', () => {
+    const edits: ConditionEdits = {
+      cond_1: {
+        nodeKey: 'cond_1',
+        branches: [{ edgeKey: 'edge-cond_1-high', predicateMode: 'formula', conjunction: 'and', rules: [], formulaExpression: '{amount} >= 5000' }],
+        defaultEdgeKey: 'edge-cond_1-low',
+      },
+    }
+    expect(validateConditionEdits(edits, formSchema, CONDITION_GRAPH)).toEqual([])
+  })
+
   it('surfaces the rule-fieldId error through validateTemplateDraft when the draft carries condition edits', () => {
     const draft: TemplateAuthoringDraft = draftFromTemplate(buildTemplate(CONDITION_GRAPH))
     draft.conditionEdits!.cond_1.branches[0].rules[0].fieldId = 'ghost'

--- a/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { ApprovalGraph, ApprovalTemplateDetailDTO } from '../src/types/approval'
+import type { ApprovalAssigneeSource, ApprovalGraph, ApprovalTemplateDetailDTO } from '../src/types/approval'
 import {
   buildApprovalGraph,
   draftFromTemplate,
@@ -9,6 +9,7 @@ import {
 } from '../src/approvals/templateAuthoring'
 import {
   applyParallelEditsToGraph,
+  parallelDynamicAssigneeConflicts,
   parallelEditsFromGraph,
   validateParallelEdits,
   PARALLEL_JOIN_MODES,
@@ -360,5 +361,94 @@ describe('G-3 validation preview (UX-only; backend normalizeApprovalGraph is fin
   it('an untouched parallel draft produces NO parallel validation errors (valid graph stays valid)', () => {
     const draft: TemplateAuthoringDraft = draftFromTemplate(buildTemplate(PARALLEL_GRAPH))
     expect(validateTemplateDraft(draft, null).filter((message) => message.includes('汇聚模式'))).toEqual([])
+  })
+})
+
+// ── F2 (adversarial review #4433): publish-preflight for provably-identical DYNAMIC approver
+// sources across parallel branches. Runtime raises a typed 409
+// (APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT) whenever two branches resolve to the same user —
+// for identical dynamic sources that is EVERY request. This mirror (surfaced in the publish
+// checklist, not the save gate) must flag ONLY provably-identical sources: different kinds or
+// different parameters may still be legal for some org shapes and stay the runtime guard's job. ──
+describe('parallelDynamicAssigneeConflicts — publish preflight (F2)', () => {
+  const withBranchSources = (a: ApprovalAssigneeSource[], b: ApprovalAssigneeSource[]): ApprovalGraph => ({
+    ...PARALLEL_GRAPH,
+    nodes: PARALLEL_GRAPH.nodes.map((node) => {
+      if (node.key === 'approval_a') return { ...node, config: { ...(node.config as Record<string, unknown>), assigneeSources: a } as never }
+      if (node.key === 'approval_b') return { ...node, config: { ...(node.config as Record<string, unknown>), assigneeSources: b } as never }
+      return node
+    }),
+  })
+
+  it('flags requester × requester across two branches (the old untouched-starter shape — 409s every request)', () => {
+    const errors = parallelDynamicAssigneeConflicts(withBranchSources([{ kind: 'requester' }], [{ kind: 'requester' }]))
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('fork_1')
+    expect(errors[0]).toContain('requester')
+  })
+
+  it('flags identical parameterized sources: same manager_at_level level, same form_field_user field', () => {
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'manager_at_level', level: 2 }], [{ kind: 'manager_at_level', level: 2 }]),
+    )).toHaveLength(1)
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'form_field_user', fieldId: 'owner' }], [{ kind: 'form_field_user', fieldId: 'owner' }]),
+    )).toHaveLength(1)
+  })
+
+  it('does NOT flag different dynamic kinds or different parameters (negative control — no false positives)', () => {
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'requester' }], [{ kind: 'direct_manager' }]),
+    )).toEqual([])
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'manager_at_level', level: 1 }], [{ kind: 'manager_at_level', level: 2 }]),
+    )).toEqual([])
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'form_field_user', fieldId: 'owner' }], [{ kind: 'form_field_user', fieldId: 'reviewer' }]),
+    )).toEqual([])
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'continuous_managers', levels: 1 }], [{ kind: 'continuous_managers', levels: 3 }]),
+    )).toEqual([])
+  })
+
+  it('does NOT flag static duplicates (the backend static check owns those) and ignores the join node itself', () => {
+    // PARALLEL_GRAPH as-is: static finance/legal branches + a requester JOIN node — no conflict:
+    // the join runs sequentially after the fan-in, and statics are save-time-rejected server-side.
+    expect(parallelDynamicAssigneeConflicts(PARALLEL_GRAPH)).toEqual([])
+    expect(parallelDynamicAssigneeConflicts(
+      withBranchSources([{ kind: 'static_role', roleIds: ['finance'] }], [{ kind: 'static_role', roleIds: ['finance'] }]),
+    )).toEqual([])
+  })
+
+  it('does NOT flag the same dynamic source twice WITHIN one branch (sequential steps are not a parallel conflict)', () => {
+    const oneBranchTwoSteps: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'fork_1', type: 'parallel', name: '并行', config: { branches: ['e-fork-a', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join_1' } },
+        { key: 'a1', type: 'approval', name: 'A1', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'a2', type: 'approval', name: 'A2', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'b', type: 'approval', name: 'B', config: { assigneeSources: [{ kind: 'static_role', roleIds: ['legal'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'join_1', type: 'approval', name: '汇聚', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-fork', source: 'start', target: 'fork_1' },
+        { key: 'e-fork-a', source: 'fork_1', target: 'a1' },
+        { key: 'e-a1-a2', source: 'a1', target: 'a2' },
+        { key: 'e-a2-join', source: 'a2', target: 'join_1' },
+        { key: 'e-fork-b', source: 'fork_1', target: 'b' },
+        { key: 'e-b-join', source: 'b', target: 'join_1' },
+        { key: 'e-join-end', source: 'join_1', target: 'end' },
+      ],
+    }
+    expect(parallelDynamicAssigneeConflicts(oneBranchTwoSteps)).toEqual([])
+    // …but the SAME source appearing in the OTHER branch still conflicts.
+    const conflicted: ApprovalGraph = {
+      ...oneBranchTwoSteps,
+      nodes: oneBranchTwoSteps.nodes.map((node) => (node.key === 'b'
+        ? { ...node, config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } as never }
+        : node)),
+    }
+    expect(parallelDynamicAssigneeConflicts(conflicted)).toHaveLength(1)
   })
 })

--- a/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
@@ -452,3 +452,135 @@ describe('parallelDynamicAssigneeConflicts — publish preflight (F2)', () => {
     expect(parallelDynamicAssigneeConflicts(conflicted)).toHaveLength(1)
   })
 })
+
+// ── Owner P2 (review #4433): a CONDITION nested inside a parallel branch must not hide its
+// alternative paths from the preflight. The old walk followed each node's FIRST outgoing edge only,
+// so a conflict sitting behind a condition's default (or any non-first) edge published green and
+// then 409'd EVERY matching request at runtime. The fixed walk enumerates ALL condition paths up to
+// the join and intersects the per-branch assignee-source SETS across branches. Mirror of the
+// backend `assertNoParallelDynamicAssigneeConflicts` goldens — keep in lockstep. ──
+describe('parallelDynamicAssigneeConflicts — condition paths inside a parallel branch (owner P2)', () => {
+  // Owner's constructed case: branch A = condition (rules path → dept_head, DEFAULT path →
+  // requester), branch B = <branchB>. The rules edge is declared FIRST in the edge list, so a
+  // first-edge-only walk sees only dept_head and never reaches approval_low.
+  const conditionDefaultPathGraph = (branchB: ApprovalAssigneeSource[]): ApprovalGraph => ({
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      { key: 'fork_1', type: 'parallel', name: '并行', config: { branches: ['e-fork-cond', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join_1' } },
+      {
+        key: 'cond_1',
+        type: 'condition',
+        name: '金额判断',
+        config: {
+          branches: [{ edgeKey: 'e-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }],
+          defaultEdgeKey: 'e-cond-low',
+        },
+      },
+      { key: 'approval_high', type: 'approval', name: '大额', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'approval_low', type: 'approval', name: '小额', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'approval_b', type: 'approval', name: 'B支', config: { assigneeSources: branchB, approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'join_1', type: 'approval', name: '汇聚', config: { assigneeSources: [{ kind: 'static_role', roleIds: ['final'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-fork', source: 'start', target: 'fork_1' },
+      { key: 'e-fork-cond', source: 'fork_1', target: 'cond_1' },
+      { key: 'e-fork-b', source: 'fork_1', target: 'approval_b' },
+      // Rules edge FIRST, default edge SECOND — the first-edge-only walk never saw approval_low.
+      { key: 'e-cond-high', source: 'cond_1', target: 'approval_high' },
+      { key: 'e-cond-low', source: 'cond_1', target: 'approval_low' },
+      { key: 'e-high-join', source: 'approval_high', target: 'join_1' },
+      { key: 'e-low-join', source: 'approval_low', target: 'join_1' },
+      { key: 'e-b-join', source: 'approval_b', target: 'join_1' },
+      { key: 'e-join-end', source: 'join_1', target: 'end' },
+    ],
+  })
+
+  it('GOLDEN (owner case): condition DEFAULT path resolves to requester, branch B is requester → 1 conflict naming requester', () => {
+    const errors = parallelDynamicAssigneeConflicts(conditionDefaultPathGraph([{ kind: 'requester' }]))
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('fork_1')
+    expect(errors[0]).toContain('requester')
+  })
+
+  it('does NOT flag when every condition path yields a DIFFERENT source than branch B (negative control)', () => {
+    // Paths yield dept_head / requester; branch B is direct_manager — nothing provably identical.
+    expect(parallelDynamicAssigneeConflicts(conditionDefaultPathGraph([{ kind: 'direct_manager' }]))).toEqual([])
+    // Parameterized near-miss: manager_at_level 2 vs nothing in the condition paths.
+    expect(parallelDynamicAssigneeConflicts(conditionDefaultPathGraph([{ kind: 'manager_at_level', level: 2 }]))).toEqual([])
+  })
+
+  it('flags a conflict hidden behind the RULES edge when the default edge happens to be declared first', () => {
+    // Reorder: default edge (→ approval_low, requester) declared FIRST; the dept_head conflict sits
+    // behind the RULES edge, which a first-edge-only walk would never enter. Branch B = dept_head.
+    const base = conditionDefaultPathGraph([{ kind: 'dept_head' }])
+    const swap = (key: string): string => (key === 'e-cond-high' ? 'e-cond-low' : key === 'e-cond-low' ? 'e-cond-high' : key)
+    const defaultEdgeFirst: ApprovalGraph = {
+      ...base,
+      edges: base.edges.map((edge) => (edge.source === 'cond_1'
+        ? base.edges.find((candidate) => candidate.key === swap(edge.key))!
+        : edge)),
+    }
+    const errors = parallelDynamicAssigneeConflicts(defaultEdgeFirst)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('dept_head')
+  })
+
+  it('flags a conflict reachable only through a DEEP condition chain (condition → condition, default → default)', () => {
+    const deepChain: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'fork_1', type: 'parallel', name: '并行', config: { branches: ['e-fork-cond', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join_1' } },
+        {
+          key: 'cond_1',
+          type: 'condition',
+          name: '一级判断',
+          config: { branches: [{ edgeKey: 'e-c1-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 10000 }], conjunction: 'and' }], defaultEdgeKey: 'e-c1-c2' },
+        },
+        {
+          key: 'cond_2',
+          type: 'condition',
+          name: '二级判断',
+          config: { branches: [{ edgeKey: 'e-c2-mid', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }], defaultEdgeKey: 'e-c2-low' },
+        },
+        { key: 'approval_high', type: 'approval', name: '特大额', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'approval_mid', type: 'approval', name: '中额', config: { assigneeSources: [{ kind: 'manager_at_level', level: 1 }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'approval_low', type: 'approval', name: '小额', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'approval_b', type: 'approval', name: 'B支', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'join_1', type: 'approval', name: '汇聚', config: { assigneeSources: [{ kind: 'static_role', roleIds: ['final'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-fork', source: 'start', target: 'fork_1' },
+        { key: 'e-fork-cond', source: 'fork_1', target: 'cond_1' },
+        { key: 'e-fork-b', source: 'fork_1', target: 'approval_b' },
+        // Rules edges declared first at BOTH levels — the conflicting requester sits two default
+        // hops deep (cond_1 default → cond_2 default → approval_low).
+        { key: 'e-c1-high', source: 'cond_1', target: 'approval_high' },
+        { key: 'e-c1-c2', source: 'cond_1', target: 'cond_2' },
+        { key: 'e-c2-mid', source: 'cond_2', target: 'approval_mid' },
+        { key: 'e-c2-low', source: 'cond_2', target: 'approval_low' },
+        { key: 'e-high-join', source: 'approval_high', target: 'join_1' },
+        { key: 'e-mid-join', source: 'approval_mid', target: 'join_1' },
+        { key: 'e-low-join', source: 'approval_low', target: 'join_1' },
+        { key: 'e-b-join', source: 'approval_b', target: 'join_1' },
+        { key: 'e-join-end', source: 'join_1', target: 'end' },
+      ],
+    }
+    const errors = parallelDynamicAssigneeConflicts(deepChain)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('requester')
+  })
+
+  it('does NOT double-flag the same source on two ALTERNATIVE paths of ONE branch (within-branch union, not multiset)', () => {
+    // Both cond_1 paths resolve to requester; branch B is requester → exactly ONE conflict, not two.
+    const base = conditionDefaultPathGraph([{ kind: 'requester' }])
+    const bothPathsRequester: ApprovalGraph = {
+      ...base,
+      nodes: base.nodes.map((node) => (node.key === 'approval_high'
+        ? { ...node, config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } as never }
+        : node)),
+    }
+    expect(parallelDynamicAssigneeConflicts(bothPathsRequester)).toHaveLength(1)
+  })
+})

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -1127,10 +1127,24 @@ describe('TemplateAuthoringView', () => {
     await flushUi()
     expect(container!.querySelectorAll('[data-testid="approval-graph-node-row"]').length).toBe(rowsBefore + 1) // a new approval node appeared
 
+    // P1 fix (review #4433 F1): the added branch seeds an INCOMPLETE starter rule — saving as-is
+    // is BLOCKED (an empty/unconfigured branch must never publish and capture all traffic).
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(updateTemplateSpy).not.toHaveBeenCalled()
+
+    // Configure the new branch's rule field, then save persists the new structure.
+    const ruleFields = container!.querySelectorAll('[data-testid="approval-condition-rule-field"]')
+    const newRuleField = ruleFields[ruleFields.length - 1] as HTMLSelectElement
+    newRuleField.value = 'amount'
+    newRuleField.dispatchEvent(new Event('change'))
+    await flushUi()
     ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
     await flushUi()
     const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
-    expect(payload.approvalGraph.nodes.find((n: any) => n.key === 'cond_1').config.branches).toHaveLength(2) // the added branch is saved
+    const branches = payload.approvalGraph.nodes.find((n: any) => n.key === 'cond_1').config.branches
+    expect(branches).toHaveLength(2) // the added branch is saved
+    expect(branches[1].rules[0].fieldId).toBe('amount') // …with its configured rule, never rules: []
   })
 
   it('promotes a blank linear template into graph authoring when a condition gateway is inserted', async () => {
@@ -1355,6 +1369,18 @@ describe('TemplateAuthoringView', () => {
     ;(container!.querySelector('[data-testid="approval-canvas-add-condition-cond_1"]') as HTMLButtonElement).click()
     await flushUi()
     expect(container!.querySelectorAll('[data-testid="approval-canvas-node"]').length).toBe(before + 1) // new node on canvas
+    // P1 fix (review #4433 F1): the canvas-added branch seeds an INCOMPLETE starter rule too —
+    // configure it in the list view before the save can go through (empty branch never saves clean).
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(updateTemplateSpy).not.toHaveBeenCalled()
+    ;(container!.querySelector('[data-testid="approval-view-list"]') as HTMLButtonElement).click()
+    await flushUi()
+    const ruleFields = container!.querySelectorAll('[data-testid="approval-condition-rule-field"]')
+    const newRuleField = ruleFields[ruleFields.length - 1] as HTMLSelectElement
+    newRuleField.value = 'amount'
+    newRuleField.dispatchEvent(new Event('change'))
+    await flushUi()
     ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
     await flushUi()
     const payload = updateTemplateSpy.mock.calls[0]?.[1] as any

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -1133,6 +1133,83 @@ describe('TemplateAuthoringView', () => {
     expect(payload.approvalGraph.nodes.find((n: any) => n.key === 'cond_1').config.branches).toHaveLength(2) // the added branch is saved
   })
 
+  it('promotes a blank linear template into graph authoring when a condition gateway is inserted', async () => {
+    await mountView()
+    const insert = container!.querySelector('[data-testid^="approval-step-insert-condition-after-"]') as HTMLButtonElement
+    insert.click()
+    await flushUi()
+    expect(container!.querySelector('[data-testid="approval-graph-view-toggle"]')).not.toBeNull()
+    expect(container!.querySelectorAll('[data-testid="approval-canvas-node"]')).toHaveLength(6)
+    expect(container!.querySelector('[data-node-type="condition"]')).not.toBeNull()
+    ;(container!.querySelector('[data-testid="approval-view-list"]') as HTMLButtonElement).click()
+    await flushUi()
+    const field = container!.querySelector('[data-testid="approval-condition-rule-field"]') as HTMLSelectElement
+    field.value = 'field_1'
+    field.dispatchEvent(new Event('change'))
+    setInput('approval-template-key', 'conditional')
+    setInput('approval-template-name', '条件审批')
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(createTemplateSpy).toHaveBeenCalledTimes(1)
+    const graph = (createTemplateSpy.mock.calls[0]?.[0] as any).approvalGraph
+    const condition = graph.nodes.find((candidate: any) => candidate.type === 'condition')
+    expect(condition.config.branches[0].rules[0].fieldId).toBe('field_1')
+    expect(graph.edges.some((edge: any) => edge.key === condition.config.defaultEdgeKey)).toBe(true)
+  })
+
+  it('promotes a blank linear template into a two-branch parallel graph and edits its join mode', async () => {
+    await mountView()
+    const insert = container!.querySelector('[data-testid^="approval-step-insert-parallel-after-"]') as HTMLButtonElement
+    insert.click()
+    await flushUi()
+    expect(container!.querySelectorAll('[data-testid="approval-canvas-node"]')).toHaveLength(6)
+    ;(container!.querySelector('[data-testid="approval-view-list"]') as HTMLButtonElement).click()
+    await flushUi()
+    const joinMode = container!.querySelector('[data-testid="approval-parallel-join-mode"]') as HTMLSelectElement
+    joinMode.value = 'any'
+    joinMode.dispatchEvent(new Event('change'))
+    setInput('approval-template-key', 'parallel')
+    setInput('approval-template-name', '并行审批')
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    const graph = (createTemplateSpy.mock.calls[0]?.[0] as any).approvalGraph
+    const parallel = graph.nodes.find((candidate: any) => candidate.type === 'parallel')
+    expect(parallel.config.joinMode).toBe('any')
+    expect(parallel.config.branches).toHaveLength(2)
+    expect(graph.edges.filter((edge: any) => edge.source === parallel.key)).toHaveLength(2)
+  })
+
+  it('keeps approval mode, self-approval, and field permissions editable in graph authoring', async () => {
+    routeParams = { id: 'tpl_graph_policy' }
+    getTemplateSpy.mockResolvedValue(
+      buildTemplate({
+        approvalGraph: buildG5ComplexGraph({
+          assigneeSources: [{ kind: 'direct_manager' }],
+          approvalMode: 'single',
+          emptyAssigneePolicy: 'error',
+        }),
+      }),
+    )
+    await mountView()
+    await flushUi()
+    const mode = container!.querySelector('[data-testid="approval-node-mode"]') as HTMLSelectElement
+    mode.value = 'all'
+    mode.dispatchEvent(new Event('change'))
+    const merge = container!.querySelector('[data-testid="approval-node-merge-with-requester"]') as HTMLInputElement
+    merge.checked = true
+    merge.dispatchEvent(new Event('change'))
+    const fieldAccess = container!.querySelector('[data-testid="approval-node-field-access-amount"]') as HTMLSelectElement
+    fieldAccess.value = 'hidden'
+    fieldAccess.dispatchEvent(new Event('change'))
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    const graph = (updateTemplateSpy.mock.calls[0]?.[1] as any).approvalGraph
+    const approval = graph.nodes.find((candidate: any) => candidate.key === 'approval_1')
+    expect(approval.config.approvalMode).toBe('all')
+    expect(approval.config.autoApprovalPolicy).toEqual({ mergeWithRequester: true })
+    expect(approval.config.fieldPermissions).toEqual([{ fieldId: 'amount', access: 'hidden' }])
+  })
+
   it('FC-2 wiring: switching a condition branch to formula writes formula to the save payload while topology stays byte-identical', async () => {
     routeParams = { id: 'tpl_formula_condition' }
     const graph = {

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -1387,6 +1387,38 @@ describe('TemplateAuthoringView', () => {
     expect(payload.approvalGraph.nodes.find((n: any) => n.key === 'cond_1').config.branches).toHaveLength(2) // saved
   })
 
+  it('F4: no +并行 affordance INSIDE a parallel branch (backend rejects nested parallel), while +条件 stays offered', async () => {
+    routeParams = { id: 'tpl_nested_guard' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          { key: 'fork_1', type: 'parallel', name: '并行', config: { branches: ['e-fork-a', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join_1' } },
+          { key: 'app_a', type: 'approval', name: 'A', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'app_b', type: 'approval', name: 'B', config: { assigneeSources: [{ kind: 'static_role', roleIds: ['legal'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'join_1', type: 'approval', name: '汇聚', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'e-start-fork', source: 'start', target: 'fork_1' },
+          { key: 'e-fork-a', source: 'fork_1', target: 'app_a' },
+          { key: 'e-fork-b', source: 'fork_1', target: 'app_b' },
+          { key: 'e-a-join', source: 'app_a', target: 'join_1' },
+          { key: 'e-b-join', source: 'app_b', target: 'join_1' },
+          { key: 'e-join-end', source: 'join_1', target: 'end' },
+        ],
+      },
+    }))
+    await mountView()
+    await flushUi()
+    // In-region branch node: parallel insert HIDDEN, condition insert still offered.
+    expect(container!.querySelector('[data-testid="approval-topology-insert-parallel-after-app_a"]')).toBeNull()
+    expect(container!.querySelector('[data-testid="approval-topology-insert-condition-after-app_a"]')).not.toBeNull()
+    // Out-of-region single-out nodes (start / the join) keep the parallel insert.
+    expect(container!.querySelector('[data-testid="approval-topology-insert-parallel-after-start"]')).not.toBeNull()
+    expect(container!.querySelector('[data-testid="approval-topology-insert-parallel-after-join_1"]')).not.toBeNull()
+  })
+
   it('dept_head reads back editable: a saved dept_head template is NOT fail-closed (no unsupported alert, save enabled, sourceKind hydrated)', async () => {
     routeParams = { id: 'tpl_dh' }
     getTemplateSpy.mockResolvedValue(buildTemplate({

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -1057,6 +1057,13 @@ export class ApprovalGraphExecutor {
       : []
 
     for (const branch of branches) {
+      // Defense-in-depth for LEGACY stored graphs: a rules-mode branch with ZERO rules must NOT
+      // match — `[].every(...)` is vacuously true, which would make the branch capture ALL traffic
+      // (first-match-wins) and dead-code the default edge. Authoring + create/update/publish now
+      // reject this shape (`validateConditionBranchRules`), so from valid graphs this is
+      // unreachable; for a pre-existing stored graph the branch is skipped and routing falls
+      // through to later branches / the default edge (the intended "else" mechanism).
+      if (!branch.formula && branch.rules.length === 0) continue
       const result = branch.formula
         ? evaluateApprovalConditionFormula(branch.formula.expression, this.formData, this.options.requesterContext ?? null)
         : (() => {

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1280,6 +1280,95 @@ function validateNodeTimeoutConfigs(approvalGraph: ApprovalGraph): void {
 }
 
 /**
+ * Fingerprint of a DYNAMIC assignee source: equal fingerprints ⇒ the sources PROVABLY resolve to
+ * the same user(s) for every request (same kind + same parameters). Static kinds return null —
+ * duplicate static assignees across parallel branches are already rejected inside
+ * `normalizeApprovalGraph` (`collectBranchAssignees`). FE mirror:
+ * apps/web/src/approvals/parallelEdit.ts `dynamicAssigneeSourceFingerprint` — keep in lockstep.
+ */
+function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): string | null {
+  switch (source.kind) {
+    case 'requester':
+    case 'direct_manager':
+    case 'dept_head':
+      return source.kind
+    case 'continuous_managers':
+      return `continuous_managers:${source.levels}`
+    case 'manager_at_level':
+      return `manager_at_level:${source.level}`
+    case 'form_field_user':
+      return `form_field_user:${source.fieldId}`
+    default:
+      return null
+  }
+}
+
+/**
+ * Publish preflight: reject a parallel gateway whose branches carry PROVABLY-IDENTICAL dynamic
+ * assignee sources. Such branches resolve to the same user(s) on EVERY request, so fan-out's
+ * `assertNoActiveAssignmentConflicts` raises the typed 409
+ * `APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT` for 100% of instances — authoring was false-green.
+ * Raised here with the SAME code (status 400: an authoring-time config error, like
+ * `APPROVAL_ROLE_PLACEHOLDER_NOT_CONFIGURED`) so the shape can never reach a published definition.
+ *
+ * Only provably-identical sources are flagged: DIFFERENT kinds (requester vs direct_manager) or
+ * DIFFERENT parameters (manager_at_level 1 vs 2) may still collide for SOME org shapes and remain
+ * the runtime guard's job — publish cannot know the org. Deliberately publish-scoped (NOT
+ * create/update, NOT normalize): stored drafts must stay readable and re-saveable while being
+ * fixed. The caller skips it when the publish policy carries `autoApproval.mergeAdjacentApprover`
+ * — the same exemption `allowParallelDuplicateAssignees` grants the static check, because the
+ * merge machinery legitimately absorbs same-approver overlap.
+ *
+ * Walk mirrors `collectBranchAssignees`' conservative first-outgoing-edge walk; the graph is
+ * already normalized (`asApprovalGraph`) so structural failure modes were rejected earlier.
+ * Fingerprints are deduped WITHIN a branch first (sequential same-source nodes in one branch are
+ * not a parallel conflict) and then compared across branches.
+ */
+function assertNoParallelDynamicAssigneeConflicts(approvalGraph: ApprovalGraph): void {
+  const edgeByKey = new Map(approvalGraph.edges.map((edge) => [edge.key, edge]))
+  const firstOutgoing = new Map<string, string>()
+  for (const edge of approvalGraph.edges) {
+    if (!firstOutgoing.has(edge.source)) firstOutgoing.set(edge.source, edge.target)
+  }
+  const nodeByKey = new Map(approvalGraph.nodes.map((node) => [node.key, node]))
+  for (const node of approvalGraph.nodes) {
+    if (node.type !== 'parallel') continue
+    const parallelConfig = node.config as { branches: string[]; joinNodeKey: string }
+    const seenAcrossBranches = new Map<string, string>()
+    for (const branchEdgeKey of parallelConfig.branches) {
+      const branchFingerprints = new Map<string, string>()
+      let currentKey: string | undefined = edgeByKey.get(branchEdgeKey)?.target
+      const visited = new Set<string>()
+      while (currentKey && currentKey !== parallelConfig.joinNodeKey && !visited.has(currentKey)) {
+        visited.add(currentKey)
+        const current = nodeByKey.get(currentKey)
+        if (!current) break
+        if (current.type === 'approval') {
+          const sources = (current.config as { assigneeSources?: ApprovalAssigneeSource[] }).assigneeSources ?? []
+          for (const source of sources) {
+            const fingerprint = dynamicAssigneeSourceFingerprint(source)
+            if (fingerprint && !branchFingerprints.has(fingerprint)) branchFingerprints.set(fingerprint, current.key)
+          }
+        }
+        currentKey = firstOutgoing.get(currentKey)
+      }
+      for (const [fingerprint, carrierNodeKey] of branchFingerprints) {
+        const priorNodeKey = seenAcrossBranches.get(fingerprint)
+        if (priorNodeKey !== undefined) {
+          throw new ServiceError(
+            `approvalGraph parallel node ${node.key} has branches whose approvers provably resolve identically (${fingerprint}) — every request would fail with a parallel assignment conflict`,
+            400,
+            'APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT',
+            { nodeKey: node.key, source: fingerprint, conflictingNodeKeys: [priorNodeKey, carrierNodeKey] },
+          )
+        }
+        seenAcrossBranches.set(fingerprint, carrierNodeKey)
+      }
+    }
+  }
+}
+
+/**
  * Reject a rules-mode condition branch whose `rules` array is EMPTY. The runtime
  * (`ApprovalGraphExecutor.resolveConditionTarget`) evaluates a rules-mode branch as
  * `branch.rules.every(...)`, which is vacuously TRUE over `[]` — an empty branch silently captures
@@ -3216,6 +3305,13 @@ export class ApprovalProductService {
       // otherwise the high path stalls at runtime on an unclaimable role assignment (nobody holds the
       // placeholder role). See APPROVAL_ROLE_CONFIGURE_SENTINEL.
       assertNoUnconfiguredPlaceholderRoles(approvalGraph)
+      // F2 preflight: parallel branches with provably-identical DYNAMIC approver sources 409 every
+      // request at fan-out — reject at publish with the runtime's own code. Exempt when the publish
+      // policy's mergeAdjacentApprover absorbs same-approver overlap (mirrors the
+      // allowParallelDuplicateAssignees exemption the static duplicate check gets in asRuntimeGraph).
+      if (policy.autoApproval?.mergeAdjacentApprover !== true) {
+        assertNoParallelDynamicAssigneeConflicts(approvalGraph)
+      }
       const runtimeGraph = buildRuntimeGraph(approvalGraph, policy)
 
       const publishedDefinitionResult = await client.query<PublishedDefinitionRow>(

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1319,16 +1319,31 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
  * — the same exemption `allowParallelDuplicateAssignees` grants the static check, because the
  * merge machinery legitimately absorbs same-approver overlap.
  *
- * Walk mirrors `collectBranchAssignees`' conservative first-outgoing-edge walk; the graph is
- * already normalized (`asApprovalGraph`) so structural failure modes were rejected earlier.
- * Fingerprints are deduped WITHIN a branch first (sequential same-source nodes in one branch are
- * not a parallel conflict) and then compared across branches.
+ * Traversal (review #4433 owner P2): the walk enumerates EVERY runtime-reachable path inside a
+ * branch — NOT just the first-outgoing-edge chain. A condition node fans out over ALL of its
+ * outgoing edges (every rules-branch edge AND the default edge: which path fires is
+ * form-data-dependent, so publish must treat each as possible); every other node type follows its
+ * first outgoing edge (linear in a normalized graph). The branch's fingerprint set is therefore
+ * the UNION over all condition paths up to the join node, and a conflict is flagged when SOME
+ * path through one branch and SOME path through another carry the identical dynamic source —
+ * exactly the pairings for which the runtime 409 is reachable. Cycles are cut with a per-branch
+ * visited set. A nested parallel node (normalize rejects it on the first-edge path and the canvas
+ * F4 guard cannot author one, but a non-first condition path of a legacy graph could carry one)
+ * is treated defensively as a PASS-THROUGH fan-out over all its outgoing edges: its sub-branches
+ * are all simultaneously active, so every source reachable through it belongs to this outer
+ * branch's set.
+ * Fingerprints are deduped WITHIN a branch first (sequential same-source nodes — or the same
+ * source on two ALTERNATIVE paths of one branch — are not a parallel conflict) and then compared
+ * across branches. FE mirror: apps/web/src/approvals/parallelEdit.ts
+ * `parallelDynamicAssigneeConflicts` — SAME traversal, keep in lockstep.
  */
 function assertNoParallelDynamicAssigneeConflicts(approvalGraph: ApprovalGraph): void {
   const edgeByKey = new Map(approvalGraph.edges.map((edge) => [edge.key, edge]))
-  const firstOutgoing = new Map<string, string>()
+  const outgoingTargets = new Map<string, string[]>()
   for (const edge of approvalGraph.edges) {
-    if (!firstOutgoing.has(edge.source)) firstOutgoing.set(edge.source, edge.target)
+    const targets = outgoingTargets.get(edge.source)
+    if (targets) targets.push(edge.target)
+    else outgoingTargets.set(edge.source, [edge.target])
   }
   const nodeByKey = new Map(approvalGraph.nodes.map((node) => [node.key, node]))
   for (const node of approvalGraph.nodes) {
@@ -1337,12 +1352,17 @@ function assertNoParallelDynamicAssigneeConflicts(approvalGraph: ApprovalGraph):
     const seenAcrossBranches = new Map<string, string>()
     for (const branchEdgeKey of parallelConfig.branches) {
       const branchFingerprints = new Map<string, string>()
-      let currentKey: string | undefined = edgeByKey.get(branchEdgeKey)?.target
+      const entryKey = edgeByKey.get(branchEdgeKey)?.target
+      // FIFO worklist in edge-declaration order (deterministic carrier node per fingerprint); the
+      // visited set both cuts cycles and bounds the walk to each node at most once per branch.
+      const queue: string[] = entryKey === undefined ? [] : [entryKey]
       const visited = new Set<string>()
-      while (currentKey && currentKey !== parallelConfig.joinNodeKey && !visited.has(currentKey)) {
+      for (let head = 0; head < queue.length; head += 1) {
+        const currentKey = queue[head]
+        if (currentKey === parallelConfig.joinNodeKey || visited.has(currentKey)) continue
         visited.add(currentKey)
         const current = nodeByKey.get(currentKey)
-        if (!current) break
+        if (!current) continue
         if (current.type === 'approval') {
           const sources = (current.config as { assigneeSources?: ApprovalAssigneeSource[] }).assigneeSources ?? []
           for (const source of sources) {
@@ -1350,7 +1370,15 @@ function assertNoParallelDynamicAssigneeConflicts(approvalGraph: ApprovalGraph):
             if (fingerprint && !branchFingerprints.has(fingerprint)) branchFingerprints.set(fingerprint, current.key)
           }
         }
-        currentKey = firstOutgoing.get(currentKey)
+        const targets = outgoingTargets.get(currentKey) ?? []
+        if (current.type === 'condition' || current.type === 'parallel') {
+          // Condition: EVERY outgoing edge (each rules branch + the default) is a possible runtime
+          // path. Parallel (defensive — see doc above): pass-through fan-out over all sub-branches.
+          for (const target of targets) queue.push(target)
+        } else if (targets.length > 0) {
+          // Linear node — follow its first outgoing edge, as before.
+          queue.push(targets[0])
+        }
       }
       for (const [fingerprint, carrierNodeKey] of branchFingerprints) {
         const priorNodeKey = seenAcrossBranches.get(fingerprint)

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1279,6 +1279,43 @@ function validateNodeTimeoutConfigs(approvalGraph: ApprovalGraph): void {
   }
 }
 
+/**
+ * Reject a rules-mode condition branch whose `rules` array is EMPTY. The runtime
+ * (`ApprovalGraphExecutor.resolveConditionTarget`) evaluates a rules-mode branch as
+ * `branch.rules.every(...)`, which is vacuously TRUE over `[]` — an empty branch silently captures
+ * ALL traffic (first-match-wins) and dead-codes the default edge and every later branch. The
+ * fall-through "else" is the node's `defaultEdgeKey` — a separate mechanism — so an empty rules
+ * array in a non-formula branch is never legitimate. (A FORMULA branch legitimately carries
+ * `rules: []`; those are exempt.)
+ *
+ * Deliberately NOT inside `normalizeApprovalGraph`: `asApprovalGraph` re-normalizes STORED rows on
+ * plain reads, and a retroactive reject there could brick reads of existing templates. Instead this
+ * raises its own code directly (status 400) at the create / update / publish choke points, exactly
+ * like `validateNodeTimeoutConfigs`, so all three surface the same error while stored-graph READS
+ * stay unaffected (the runtime additionally fails closed on legacy graphs: an empty rules-mode
+ * branch never matches).
+ */
+function validateConditionBranchRules(approvalGraph: ApprovalGraph): void {
+  for (const node of approvalGraph.nodes) {
+    if (node.type !== 'condition') continue
+    const config = node.config as { branches?: unknown }
+    if (!Array.isArray(config.branches)) continue
+    config.branches.forEach((branch, branchIndex) => {
+      if (!isRecord(branch)) return
+      const hasFormula = isRecord(branch.formula)
+      const rules = branch.rules
+      if (!hasFormula && Array.isArray(rules) && rules.length === 0) {
+        throw new ServiceError(
+          `approvalGraph node ${node.key} condition branch ${branchIndex + 1} has no rules and no formula — an empty rules branch would match every request`,
+          400,
+          'APPROVAL_CONDITION_BRANCH_RULES_EMPTY',
+          { nodeKey: node.key, branchIndex },
+        )
+      }
+    })
+  }
+}
+
 function normalizeApprovalGraph(
   value: unknown,
   context: ValidationContext,
@@ -2908,6 +2945,7 @@ export class ApprovalProductService {
     validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
     validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
     validateNodeTimeoutConfigs(approvalGraph)
+    validateConditionBranchRules(approvalGraph)
 
     let client: ApprovalDbClient | null = null
     try {
@@ -3064,6 +3102,7 @@ export class ApprovalProductService {
         validateNodeFieldPermissionsAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
         validateApprovalConditionFormulasAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
         validateNodeTimeoutConfigs(nextApprovalGraph)
+        validateConditionBranchRules(nextApprovalGraph)
 
         const versionResult = await client.query<TemplateVersionRow>(
           `INSERT INTO approval_template_versions (template_id, version, status, form_schema, approval_graph)
@@ -3172,6 +3211,7 @@ export class ApprovalProductService {
         : null
       validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT, curatedRoleIds)
       validateNodeTimeoutConfigs(approvalGraph)
+      validateConditionBranchRules(approvalGraph)
       // Fail-fast: a starter preset's unconfigured placeholder role MUST be replaced before publish —
       // otherwise the high path stalls at runtime on an unclaimable role assignment (nobody holds the
       // placeholder role). See APPROVAL_ROLE_CONFIGURE_SENTINEL.

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -136,6 +136,48 @@ describe('ApprovalGraphExecutor', () => {
     expect(() => new ApprovalGraphExecutor(runtimeGraph, { amount: 0 }).resolveInitialState()).toThrow(/division by zero/)
   })
 
+  it('skips a LEGACY empty-rules branch instead of match-all (defense-in-depth for stored graphs)', () => {
+    // A rules-mode branch with `rules: []` is rejected at authoring/create/update/publish
+    // (validateConditionBranchRules), but a graph STORED before that gate may still carry one.
+    // `[].every(...)` is vacuously true — without the runtime guard the empty branch would capture
+    // EVERY request (first-match-wins) and dead-code both the later branch and the default edge.
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [
+              { edgeKey: 'edge-empty', rules: [] }, // legacy vacuous branch — must never match
+              { edgeKey: 'edge-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }] },
+            ],
+            defaultEdgeKey: 'edge-low',
+          },
+        },
+        { key: 'empty-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['ghost'] } },
+        { key: 'high-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['senior'] } },
+        { key: 'low-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['standard'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-empty', source: 'route', target: 'empty-review' },
+        { key: 'edge-high', source: 'route', target: 'high-review' },
+        { key: 'edge-low', source: 'route', target: 'low-review' },
+        { key: 'edge-empty-end', source: 'empty-review', target: 'end' },
+        { key: 'edge-high-end', source: 'high-review', target: 'end' },
+        { key: 'edge-low-end', source: 'low-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    // A matching request routes via the LATER, real branch — not the empty one.
+    expect(new ApprovalGraphExecutor(runtimeGraph, { amount: 5000 }).resolveInitialState().currentNodeKey).toBe('high-review')
+    // A non-matching request falls through to the default edge — the intended "else" mechanism.
+    expect(new ApprovalGraphExecutor(runtimeGraph, { amount: 10 }).resolveInitialState().currentNodeKey).toBe('low-review')
+  })
+
   it('routes a requester.department branch from threaded requesterContext, fail-closed on absent (RA-1a)', () => {
     const runtimeGraph: RuntimeGraph = {
       nodes: [

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -2147,6 +2147,98 @@ describe('ApprovalProductService', () => {
     })
   })
 
+  describe('parallel dynamic-assignee conflict publish gate (F2)', () => {
+    // Provably-identical DYNAMIC sources across parallel branches resolve to the same user on
+    // EVERY request, so fan-out raises the typed 409 APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT
+    // 100% of the time — publish now rejects the same shape with the same code (status 400).
+    // Different kinds / different parameters must NOT be flagged (they may be legal; the runtime
+    // guard owns org-shape-dependent collisions), and the publish policy's mergeAdjacentApprover
+    // exemption mirrors allowParallelDuplicateAssignees for statics.
+    function parallelDynamicGraph(sourceA: unknown, sourceB: unknown) {
+      return {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'fork', type: 'parallel', config: { branches: ['edge-fork-a', 'edge-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+          { key: 'branch_a', type: 'approval', config: { assigneeSources: [sourceA], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'branch_b', type: 'approval', config: { assigneeSources: [sourceB], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['final-1'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-fork', source: 'start', target: 'fork' },
+          { key: 'edge-fork-a', source: 'fork', target: 'branch_a' },
+          { key: 'edge-fork-b', source: 'fork', target: 'branch_b' },
+          { key: 'edge-a-join', source: 'branch_a', target: 'join' },
+          { key: 'edge-b-join', source: 'branch_b', target: 'join' },
+          { key: 'edge-join-end', source: 'join', target: 'end' },
+        ],
+      }
+    }
+
+    function mockParallelPublish(graph: unknown) {
+      const template = {
+        id: 'tpl-par', key: 'par', name: 'Parallel', description: null, category: null,
+        visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+        active_version_id: null, latest_version_id: 'ver-par', created_at: new Date(), updated_at: new Date(),
+      }
+      const version = {
+        id: 'ver-par', template_id: 'tpl-par', version: 1, status: 'draft',
+        form_schema: { fields: [] }, approval_graph: graph,
+        created_at: new Date(), updated_at: new Date(),
+      }
+      pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+        const statement = normalize(sql)
+        if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') return { rows: [], rowCount: 0 }
+        if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) return { rows: [template], rowCount: 1 }
+        if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) return { rows: [version], rowCount: 1 }
+        if (statement.startsWith('UPDATE approval_published_definitions SET is_active = FALSE')) return { rows: [], rowCount: 0 }
+        if (statement.startsWith('INSERT INTO approval_published_definitions')) {
+          return { rows: [{ id: 'pub-par', template_id: 'tpl-par', template_version_id: 'ver-par', runtime_graph: JSON.parse(String(params?.[2])), is_active: true, published_at: new Date() }], rowCount: 1 }
+        }
+        if (statement.startsWith("UPDATE approval_template_versions SET status = 'published'")) return { rows: [{ ...version, status: 'published' }], rowCount: 1 }
+        if (statement.startsWith("UPDATE approval_templates SET status = 'published'")) return { rows: [], rowCount: 1 }
+        { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
+      })
+    }
+
+    it('rejects requester×requester branches at publish with the runtime conflict code (the old untouched-starter shape)', async () => {
+      mockParallelPublish(parallelDynamicGraph({ kind: 'requester' }, { kind: 'requester' }))
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(
+        new ApprovalProductService().publishTemplate('tpl-par', { policy: { allowRevoke: true } } as never),
+      ).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT' })
+    })
+
+    it('rejects same-parameter dynamic sources (manager_at_level 2 × manager_at_level 2)', async () => {
+      mockParallelPublish(parallelDynamicGraph({ kind: 'manager_at_level', level: 2 }, { kind: 'manager_at_level', level: 2 }))
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(
+        new ApprovalProductService().publishTemplate('tpl-par', { policy: { allowRevoke: true } } as never),
+      ).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT' })
+    })
+
+    it('publishes DIFFERENT dynamic kinds / DIFFERENT parameters clean (no false positive)', async () => {
+      mockParallelPublish(parallelDynamicGraph({ kind: 'requester' }, { kind: 'direct_manager' }))
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().publishTemplate('tpl-par', { policy: { allowRevoke: true } } as never)
+      expect(result.publishedDefinitionId).toBe('pub-par')
+
+      mockParallelPublish(parallelDynamicGraph({ kind: 'manager_at_level', level: 1 }, { kind: 'manager_at_level', level: 2 }))
+      const second = await new ApprovalProductService().publishTemplate('tpl-par', { policy: { allowRevoke: true } } as never)
+      expect(second.publishedDefinitionId).toBe('pub-par')
+    })
+
+    it('exempts a publish policy carrying autoApproval.mergeAdjacentApprover (mirrors allowParallelDuplicateAssignees)', async () => {
+      mockParallelPublish(parallelDynamicGraph({ kind: 'requester' }, { kind: 'requester' }))
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().publishTemplate(
+        'tpl-par',
+        { policy: { allowRevoke: true, autoApproval: { mergeAdjacentApprover: true } } } as never,
+      )
+      expect(result.publishedDefinitionId).toBe('pub-par')
+    })
+  })
+
   it('rejects empty assigneeSources and invalid form field sources before hitting the database', async () => {
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
     const service = new ApprovalProductService()

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -2237,6 +2237,148 @@ describe('ApprovalProductService', () => {
       )
       expect(result.publishedDefinitionId).toBe('pub-par')
     })
+
+    // ── Owner P2 (review #4433): a CONDITION nested inside a parallel branch must not hide its
+    // alternative paths from the publish gate. The old walk followed each node's FIRST outgoing
+    // edge only, so a conflict behind a condition's default (or any non-first) edge published
+    // green and then 409'd every matching request at runtime. The fixed walk enumerates ALL
+    // condition paths up to the join and intersects the per-branch source SETS across branches.
+    // FE mirror goldens: apps/web/tests/approval-template-authoring-parallel-edit.test.ts
+    // ('condition paths inside a parallel branch (owner P2)') — keep in lockstep. ──
+
+    // Owner's constructed case: branch A = condition (rules path → <highPathSource>, DEFAULT path →
+    // requester — rules edge declared FIRST so the old walk never reached the requester),
+    // branch B = <branchBSource>.
+    function conditionDefaultPathGraph(branchBSource: unknown, highPathSource: unknown = { kind: 'dept_head' }) {
+      return {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'fork', type: 'parallel', config: { branches: ['e-fork-cond', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+          {
+            key: 'cond_1',
+            type: 'condition',
+            config: {
+              branches: [{ edgeKey: 'e-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }],
+              defaultEdgeKey: 'e-cond-low',
+            },
+          },
+          { key: 'approval_high', type: 'approval', config: { assigneeSources: [highPathSource], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'approval_low', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'branch_b', type: 'approval', config: { assigneeSources: [branchBSource], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['final-1'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'e-start-fork', source: 'start', target: 'fork' },
+          { key: 'e-fork-cond', source: 'fork', target: 'cond_1' },
+          { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+          // Rules edge FIRST, default edge SECOND — first-edge-only traversal missed approval_low.
+          { key: 'e-cond-high', source: 'cond_1', target: 'approval_high' },
+          { key: 'e-cond-low', source: 'cond_1', target: 'approval_low' },
+          { key: 'e-high-join', source: 'approval_high', target: 'join' },
+          { key: 'e-low-join', source: 'approval_low', target: 'join' },
+          { key: 'e-b-join', source: 'branch_b', target: 'join' },
+          { key: 'e-join-end', source: 'join', target: 'end' },
+        ],
+      }
+    }
+
+    it('GOLDEN (owner case): condition DEFAULT path resolves to requester, branch B is requester → publish rejects naming requester', async () => {
+      mockParallelPublish(conditionDefaultPathGraph({ kind: 'requester' }))
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(
+        new ApprovalProductService().publishTemplate('tpl-par', { policy: { allowRevoke: true } } as never),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT',
+        details: { nodeKey: 'fork', source: 'requester', conflictingNodeKeys: ['approval_low', 'branch_b'] },
+      })
+    })
+
+    it('publishes clean when every condition path yields a DIFFERENT source than branch B (negative control)', async () => {
+      // Paths yield dept_head / requester; branch B is direct_manager — nothing provably identical.
+      mockParallelPublish(conditionDefaultPathGraph({ kind: 'direct_manager' }))
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().publishTemplate('tpl-par', { policy: { allowRevoke: true } } as never)
+      expect(result.publishedDefinitionId).toBe('pub-par')
+    })
+
+    it('rejects a conflict hidden behind the RULES edge when the default edge is declared first', async () => {
+      // Default edge (→ approval_low, requester) declared FIRST; the dept_head conflict sits behind
+      // the RULES edge, which a first-edge-only walk would never enter. Branch B = dept_head.
+      const graph = conditionDefaultPathGraph({ kind: 'dept_head' })
+      const condEdgeKeys = new Set(['e-cond-high', 'e-cond-low'])
+      const [highEdge, lowEdge] = graph.edges.filter((edge) => condEdgeKeys.has(edge.key))
+      graph.edges = graph.edges.map((edge) => (edge.key === 'e-cond-high' ? lowEdge : edge.key === 'e-cond-low' ? highEdge : edge))
+      mockParallelPublish(graph)
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(
+        new ApprovalProductService().publishTemplate('tpl-par', { policy: { allowRevoke: true } } as never),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT',
+        details: { nodeKey: 'fork', source: 'dept_head' },
+      })
+    })
+
+    it('rejects a conflict reachable only through a DEEP condition chain (condition → condition, default → default)', async () => {
+      const deepChain = {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'fork', type: 'parallel', config: { branches: ['e-fork-cond', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+          {
+            key: 'cond_1',
+            type: 'condition',
+            config: { branches: [{ edgeKey: 'e-c1-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 10000 }], conjunction: 'and' }], defaultEdgeKey: 'e-c1-c2' },
+          },
+          {
+            key: 'cond_2',
+            type: 'condition',
+            config: { branches: [{ edgeKey: 'e-c2-mid', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }], defaultEdgeKey: 'e-c2-low' },
+          },
+          { key: 'approval_high', type: 'approval', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'approval_mid', type: 'approval', config: { assigneeSources: [{ kind: 'manager_at_level', level: 1 }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'approval_low', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'branch_b', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+          { key: 'join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['final-1'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'e-start-fork', source: 'start', target: 'fork' },
+          { key: 'e-fork-cond', source: 'fork', target: 'cond_1' },
+          { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+          // Rules edges declared first at BOTH levels — the conflicting requester sits two default
+          // hops deep (cond_1 default → cond_2 default → approval_low).
+          { key: 'e-c1-high', source: 'cond_1', target: 'approval_high' },
+          { key: 'e-c1-c2', source: 'cond_1', target: 'cond_2' },
+          { key: 'e-c2-mid', source: 'cond_2', target: 'approval_mid' },
+          { key: 'e-c2-low', source: 'cond_2', target: 'approval_low' },
+          { key: 'e-high-join', source: 'approval_high', target: 'join' },
+          { key: 'e-mid-join', source: 'approval_mid', target: 'join' },
+          { key: 'e-low-join', source: 'approval_low', target: 'join' },
+          { key: 'e-b-join', source: 'branch_b', target: 'join' },
+          { key: 'e-join-end', source: 'join', target: 'end' },
+        ],
+      }
+      mockParallelPublish(deepChain)
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(
+        new ApprovalProductService().publishTemplate('tpl-par', { policy: { allowRevoke: true } } as never),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT',
+        details: { nodeKey: 'fork', source: 'requester', conflictingNodeKeys: ['approval_low', 'branch_b'] },
+      })
+    })
+
+    it('does NOT reject the same source on two ALTERNATIVE paths of ONE branch alone (within-branch union, not a conflict)', async () => {
+      // Both cond_1 paths resolve to requester but branch B is a STATIC role — alternative paths of
+      // one branch never run simultaneously, so publish must stay green.
+      mockParallelPublish(conditionDefaultPathGraph({ kind: 'static_role', roleIds: ['legal'] }, { kind: 'requester' }))
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().publishTemplate('tpl-par', { policy: { allowRevoke: true } } as never)
+      expect(result.publishedDefinitionId).toBe('pub-par')
+    })
   })
 
   it('rejects empty assigneeSources and invalid form field sources before hitting the database', async () => {

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -2079,6 +2079,74 @@ describe('ApprovalProductService', () => {
     })
   })
 
+  describe('empty condition-branch rules gate (author / publish validation)', () => {
+    // A rules-mode branch with `rules: []` evaluates as `[].every(...)` === TRUE at runtime — it
+    // would silently capture ALL traffic (first-match-wins) and dead-code the default edge. The
+    // gate raises its own code at create / update / publish (like validateNodeTimeoutConfigs),
+    // NEVER inside normalizeApprovalGraph's stored-graph path (plain reads must not brick).
+    // Negative control for the formula exemption: the FC-1 describe above proves createTemplate
+    // ACCEPTS formula branches carrying `rules: []` — dropping the exemption REDs those tests.
+    function emptyBranchGraph() {
+      return {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          {
+            key: 'route',
+            type: 'condition',
+            config: { branches: [{ edgeKey: 'edge-high', rules: [] }], defaultEdgeKey: 'edge-low' },
+          },
+          { key: 'high', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['senior'] } },
+          { key: 'low', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['standard'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-route', source: 'start', target: 'route' },
+          { key: 'edge-high', source: 'route', target: 'high' },
+          { key: 'edge-low', source: 'route', target: 'low' },
+          { key: 'edge-high-end', source: 'high', target: 'end' },
+          { key: 'edge-low-end', source: 'low', target: 'end' },
+        ],
+      }
+    }
+
+    it('rejects a rules-mode branch with EMPTY rules at createTemplate, before hitting the database', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate({
+        key: 'empty-branch-tpl',
+        name: 'Empty Branch Template',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: emptyBranchGraph(),
+      } as never)).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_CONDITION_BRANCH_RULES_EMPTY' })
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
+    it('rejects an already-STORED empty-rules branch at PUBLISH (a legacy draft can never reach a published definition)', async () => {
+      const template = {
+        id: 'tpl-empty-branch', key: 'empty-branch', name: 'Empty Branch', description: null, category: null,
+        visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+        active_version_id: null, latest_version_id: 'ver-eb', created_at: new Date(), updated_at: new Date(),
+      }
+      const version = {
+        id: 'ver-eb', template_id: 'tpl-empty-branch', version: 1, status: 'draft',
+        form_schema: { fields: [] }, approval_graph: emptyBranchGraph(),
+        created_at: new Date(), updated_at: new Date(),
+      }
+      pgState.client.query.mockImplementation(async (sql: string) => {
+        const statement = normalize(sql)
+        if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') return { rows: [], rowCount: 0 }
+        if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) return { rows: [template], rowCount: 1 }
+        if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) return { rows: [version], rowCount: 1 }
+        if (statement.startsWith('UPDATE approval_published_definitions SET is_active = FALSE')) return { rows: [], rowCount: 0 }
+        { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
+      })
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(
+        new ApprovalProductService().publishTemplate('tpl-empty-branch', { policy: { allowRevoke: true } } as never),
+      ).rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_CONDITION_BRANCH_RULES_EMPTY' })
+    })
+  })
+
   it('rejects empty assigneeSources and invalid form field sources before hitting the database', async () => {
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
     const service = new ApprovalProductService()


### PR DESCRIPTION
## Why

The approval engine still supports condition and parallel nodes, but blank-template authoring could only create a linear step list. Existing complex graphs were also presented with read-only-era copy and a horizontal canvas, making the capability appear removed.

## What changed

- add condition and two-branch parallel gateways from a blank or existing flow
- promote linear drafts into the graph model without flattening current approver config
- render graph layers vertically, with real branch spread and orthogonal edges
- keep approval mode, empty-assignee policy, requester merge, and field permissions editable in complex graphs
- preserve branch edge identities when deleting an inline node and find the true convergence point when adding a condition branch
- fix the template authoring header on narrow viewports and constrain the canvas to a scrollable viewport

## Verification

- `pnpm --filter @metasheet/web exec vitest run --watch=false tests/approval-graph-layout.test.ts tests/approval-graph-topology-edit.test.ts tests/approval-template-authoring-approval-node-edit.test.ts tests/approvalTemplateAuthoring.spec.ts` (109 passed)
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- targeted ESLint on all nine changed files
- Playwright/Chrome visual checks at 1440x1000 and 390x844: six-node condition tree, zero node overlaps, zero page-level horizontal overflow; the mobile canvas scrolls within its own viewport


---

## Review + fix status (2026-07-17, Claude takeover — owner-authorized)

Adversarial review at `a85fb4564`: **CHANGES-REQUESTED** (1 live P1 + 2 P2; see the review comment). Fix batch landed (`4566e21f5` / `9acddbf70` / `9bd4ca086` / `fd727dd5e`):

- **P1 empty-rules condition branch (silent capture-all) — closed at four layers**: add-branch seeds the gateway starter rule; FE validate errors on a 0-rule rules-mode branch; backend typed `400 APPROVAL_CONDITION_BRANCH_RULES_EMPTY` at the create/update/publish chokes (deliberately NOT in stored-graph normalize — reads never brick); runtime `resolveConditionTarget` defense-in-depth (an empty rules-mode branch never matches, falls through to the default edge — every pre-existing `rules: []` fixture is a formula branch, verified before landing).
- **P2 same-user parallel false-green**: parallel starters seed the existing configure-before-publish sentinel instead of self-conflicting `requester`×2; publish gate `assertNoParallelDynamicAssigneeConflicts` raises the SAME typed code the runtime uses, for provably-identical dynamic sources only (different kinds/params negative-tested; mergeAdjacentApprover policy exempt); FE mirrors it in the publish checklist.
- **P2 promote-preservation**: non-default RICH_LINEAR fixture (mode 'all', auto-approve policy, field permissions) with full-config `toEqual` round-trip — the review's surviving flatten mutation now reds.
- **P3**: nested parallel can no longer be authored (op throws in-region + canvas/list hide +并行).

**13/13 mutations killed** (incl. the review's survivors M1/M3). Green at `fd727dd5e`: FE 12 suites 278/278 · backend approval unit 24 suites 413/413 · vue-tsc + tsc 0 · eslint --max-warnings=0. Remaining feature gaps (deletion UI, branch reorder, demote/undo, re-merge editing, dry-run, canvas UX, docs) are menu items — see the review comment.
