### PR TITLE
test(directory): B6 — approval-routing local/DingTalk real-DB equivalence + in-flight invariance

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -192,6 +192,10 @@ jobs:
       - name: B5-c routing-routes CI wiring contract
         run: node --test scripts/ops/b5c-routing-routes-ci-wiring.test.mjs
 
+      # B6 CI two-point wiring contract (no DB).
+      - name: B6 equivalence CI wiring contract
+        run: node --test scripts/ops/b6-equivalence-ci-wiring.test.mjs
+
       # The production monitor invokes the same state helper covered here.
       # Keep this in the required 18/20 matrix so HTTP classification, silence
       # barriers, and alert/recovery streak semantics cannot drift silently.
@@ -626,6 +630,7 @@ jobs:
             tests/integration/approval-wp-add-reduce-sign.api.test.ts \
             tests/integration/approval-direct-manager.api.test.ts \
             tests/integration/approval-routing-policy-failclose.api.test.ts \
+            tests/integration/approval-routing-policy-equivalence.db.test.ts \
             tests/integration/approval-postgate-acceptance.api.test.ts \
             tests/integration/dept-head-sync-plumbing.test.ts \
             tests/integration/approval-manager-chain.db.test.ts \

--- a/packages/core-backend/tests/integration/approval-routing-policy-equivalence.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-routing-policy-equivalence.db.test.ts
@@ -1,0 +1,301 @@
+import net from 'net'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { query } from '../../src/db/pg'
+import { getOrCreateLocalIntegration, setLocalMembershipManager } from '../../src/directory/directory-sync'
+import {
+  addLocalMembership,
+  createLocalAccount,
+  createLocalDepartment,
+  switchLocalPrimaryDepartment,
+} from '../../src/directory/local-directory-org'
+import { resolveApprovalRequesterOrgRelations } from '../../src/services/ApprovalDirectoryOrg'
+
+/**
+ * Canonical Org MVP — B6 (approval-routing local/DingTalk REAL-DB EQUIVALENCE), §10.1 + design
+ * lock §2. The FIRST (and only) consumer migrated in this milestone is approval routing; this file
+ * is its parity + in-flight-invariance proof:
+ *
+ * MATRIX (resolver-level, dedicated org):
+ *   1. SOURCE CHECK (the vacuity killer): with SENTINEL titles that differ per side, policy→local
+ *      resolves the local sentinel and policy→dingtalk the dingtalk sentinel — proving the policy
+ *      switch genuinely switches sources (if B5-b's restriction broke, THIS reds first; without it
+ *      the equivalence leg below could pass vacuously with both legs reading one source).
+ *   2. EQUIVALENCE: with seeded-EQUIVALENT data (same dept name, same title, same manager person —
+ *      local via the B3 first-class `is_manager`, DingTalk via legacy `raw.leader_in_dept`),
+ *      policy→local and policy→dingtalk produce IDENTICAL requester department/title/manager
+ *      (§10.1's exact triple).
+ *   3. KNOWN GAP PINNED (ledger §2 routing 加固批): deptHead still resolves from the LEGACY
+ *      per-provider source — local side undefined, DingTalk side the manager. Asserted explicitly
+ *      so the asymmetry is a visible, tracked fact, not a silent surprise. (Manager CHAIN likewise
+ *      stays legacy; not exercised here — includeManagerChain is not opted into.)
+ *
+ * IN-FLIGHT INVARIANCE (instance-level, real server + real createApproval, org 'default'):
+ *   4. An approval created under policy→dingtalk bakes `requester_snapshot.directoryTitle` from
+ *      the DingTalk source; FLIPPING the policy to local afterwards leaves that stored snapshot
+ *      BYTE-IDENTICAL (jsonb::text compared pre/post) — in-flight approvals keep baked routing;
+ *      historical instances are not rewritten. A NEW approval created after the flip bakes the
+ *      LOCAL title — the positive control proving the flip really changed new resolutions (so the
+ *      first instance's constancy is meaningful, not "nothing changed anywhere").
+ *
+ * Proof-slice vacuity discipline: this ticket adds NO production code, so the load-bearing
+ * mutation runs against the CONSUMED B5-b predicate — deleting the policy-scoped
+ * `AND a.integration_id = $2::uuid` restriction reds leg 1 (run out-of-band, recorded in the PR).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const MATRIX_ORG = `b6-eq-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+async function seedUser(id: string): Promise<void> {
+  await query(`INSERT INTO users (id, email, name, password_hash) VALUES ($1, $2, $3, 'x') ON CONFLICT (id) DO NOTHING`, [
+    id,
+    `${id}@example.test`,
+    id,
+  ])
+}
+async function dingtalkIntegration(org: string, tag: string): Promise<string> {
+  const r = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config)
+     VALUES ($1, 'dingtalk', $2, 'active', $3, '{}'::jsonb) RETURNING id`,
+    [org, `DT b6 ${tag} ${TS}`, `corp-b6-${TS}-${tag}`],
+  )
+  return r.rows[0].id
+}
+async function dtDept(integrationId: string, extId: string, name: string, raw: unknown = {}): Promise<string> {
+  const r = await query<{ id: string }>(
+    `INSERT INTO directory_departments (integration_id, provider, external_department_id, name, is_active, raw)
+     VALUES ($1, 'dingtalk', $2, $3, true, $4::jsonb) RETURNING id`,
+    [integrationId, extId, name, JSON.stringify(raw ?? {})],
+  )
+  return r.rows[0].id
+}
+async function dtAccount(
+  integrationId: string,
+  userId: string,
+  title: string | null,
+  raw: unknown,
+  primaryDeptId?: string,
+): Promise<string> {
+  const acc = await query<{ id: string }>(
+    `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, title, is_active, raw)
+     VALUES ($1, 'dingtalk', $2, $2, $3, $4, true, $5::jsonb) RETURNING id`,
+    [integrationId, `dt:b6:${TS}:${userId}:${integrationId.slice(0, 8)}`, userId, title, JSON.stringify(raw ?? {})],
+  )
+  await query(
+    `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+     VALUES ($1, $2, 'linked', 'manual')`,
+    [acc.rows[0].id, userId],
+  )
+  if (primaryDeptId) {
+    await query(
+      `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary)
+       VALUES ($1, $2, true)`,
+      [acc.rows[0].id, primaryDeptId],
+    )
+  }
+  return acc.rows[0].id
+}
+async function setPolicy(org: string, canonical: string | null): Promise<void> {
+  if (canonical === null) {
+    await query(`DELETE FROM org_directory_routing_policy WHERE org_id = $1 AND purpose = 'approval_routing'`, [org])
+    return
+  }
+  await query(
+    `INSERT INTO org_directory_routing_policy (org_id, purpose, canonical_integration_id)
+     VALUES ($1, 'approval_routing', $2)
+     ON CONFLICT ON CONSTRAINT orp_org_purpose_uniq
+     DO UPDATE SET canonical_integration_id = EXCLUDED.canonical_integration_id, updated_at = NOW()`,
+    [org, canonical],
+  )
+}
+
+describeIfDatabase('Canonical Org MVP — B6 approval-routing local/DingTalk equivalence (real DB)', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  const REQ = `b6-req-${TS}`
+  let reqTok = ''
+  const cleanupOrgs: string[] = [MATRIX_ORG]
+  const cleanupUsers: string[] = []
+  const cleanupAccountIds: string[] = []
+  const cleanupIntegrationIds: string[] = []
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    const { ensureApprovalSchemaReady } = await import('../helpers/approval-schema-bootstrap')
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ)
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`%-${TS}`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1)`, [tids])).rows.map(
+          (r) => r.id as string,
+        )
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1)`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
+      }
+      await query(`DELETE FROM org_directory_routing_policy WHERE org_id = ANY($1)`, [['default', ...cleanupOrgs]])
+      for (const id of cleanupAccountIds.splice(0)) await query(`DELETE FROM directory_accounts WHERE id = $1`, [id])
+      for (const id of cleanupIntegrationIds.splice(0)) await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
+      for (const org of cleanupOrgs.splice(0)) await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [org])
+      for (const uid of cleanupUsers.splice(0)) await query(`DELETE FROM users WHERE id = $1`, [uid])
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('matrix: source check (sentinels), then seeded-equivalent local vs DingTalk resolve the IDENTICAL dept/title/manager triple; the deptHead legacy asymmetry stays pinned', async () => {
+    const org = MATRIX_ORG
+    const requester = `b6-eq-req-${TS}`
+    const manager = `b6-eq-mgr-${TS}`
+    cleanupUsers.push(requester, manager)
+    await seedUser(requester)
+    await seedUser(manager)
+
+    // ---- local side (B1/B2/B3 writers — the product path, not raw SQL) ----
+    const local = await getOrCreateLocalIntegration(org)
+    const lDept = await createLocalDepartment({ orgId: org, name: 'Engineering' })
+    const lReq = await createLocalAccount({ orgId: org, localUserId: requester, title: 'LOCAL-SENTINEL' })
+    const lMgr = await createLocalAccount({ orgId: org, localUserId: manager, title: 'Manager' })
+    await addLocalMembership({ orgId: org, accountId: lReq.id, departmentId: lDept.id })
+    await switchLocalPrimaryDepartment(org, lReq.id, lDept.id)
+    await addLocalMembership({ orgId: org, accountId: lMgr.id, departmentId: lDept.id })
+    await setLocalMembershipManager(org, { directoryAccountId: lMgr.id, directoryDepartmentId: lDept.id }, true)
+
+    // ---- DingTalk side (provider-shaped rows: manager via legacy raw.leader_in_dept) ----
+    const dt = await dingtalkIntegration(org, 'matrix')
+    const DT_DEPT_EXT = `b6dept-${TS}`
+    const MGR_EXT = `dt:b6:${TS}:${manager}:` // dtAccount() builds external ids with this prefix + integration slice
+    const dDept = await dtDept(dt, DT_DEPT_EXT, 'Engineering', { dept_manager_userid_list: [`${MGR_EXT}${dt.slice(0, 8)}`] })
+    await dtAccount(dt, requester, 'DT-SENTINEL', { dept_ids: [DT_DEPT_EXT] }, dDept)
+    await dtAccount(dt, manager, 'Manager', { leader_in_dept: [{ dept_id: DT_DEPT_EXT, leader: true }] }, dDept)
+
+    // 1) SOURCE CHECK — the policy switch must genuinely switch sources (vacuity killer)
+    await setPolicy(org, local.id)
+    const viaLocalSentinel = await resolveApprovalRequesterOrgRelations(requester, query)
+    expect(viaLocalSentinel.primaryTitle).toBe('LOCAL-SENTINEL')
+    await setPolicy(org, dt)
+    const viaDtSentinel = await resolveApprovalRequesterOrgRelations(requester, query)
+    expect(viaDtSentinel.primaryTitle).toBe('DT-SENTINEL')
+
+    // 2) EQUIVALENCE — align the titles, then the §10.1 triple must be IDENTICAL across sources
+    await query(`UPDATE directory_accounts SET title = 'Engineer' WHERE title IN ('LOCAL-SENTINEL','DT-SENTINEL')`)
+    await setPolicy(org, local.id)
+    const viaLocal = await resolveApprovalRequesterOrgRelations(requester, query)
+    await setPolicy(org, dt)
+    const viaDt = await resolveApprovalRequesterOrgRelations(requester, query)
+
+    const triple = (r: typeof viaLocal) => ({
+      department: r.primaryDepartmentName ?? null,
+      title: r.primaryTitle ?? null,
+      managerId: r.managerId ?? null,
+    })
+    expect(triple(viaLocal)).toEqual({ department: 'Engineering', title: 'Engineer', managerId: manager })
+    expect(triple(viaDt)).toEqual(triple(viaLocal)) // the §10.1 parity claim, both ways seeded equivalent
+
+    // 3) KNOWN GAP (ledger §2): deptHead still comes from the LEGACY per-provider source — pinned,
+    //    not hidden. When this asymmetry is closed (routing 加固批), THIS assertion should flip.
+    expect(viaLocal.deptHeadId).toBeUndefined()
+    expect(viaDt.deptHeadId).toBe(manager)
+  })
+
+  it('in-flight invariance: a policy flip leaves an existing instance requester_snapshot byte-identical; a new instance follows the new policy', async () => {
+    // fixtures in 'default' — the org the approval routes resolve for the dev-token requester
+    cleanupUsers.push(REQ)
+    await seedUser(REQ)
+    const local = await getOrCreateLocalIntegration('default')
+    const lAcc = await createLocalAccount({ orgId: 'default', localUserId: REQ, title: 'Local Title' })
+    const dt = await dingtalkIntegration('default', 'inflight')
+    cleanupIntegrationIds.push(dt)
+    const dAcc = await dtAccount(dt, REQ, 'DingTalk Title', {})
+    cleanupAccountIds.push(lAcc.id, dAcc)
+
+    await setPolicy('default', dt)
+
+    // publish a minimal auto-approve template (no department/title routing → no create-time wedge)
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        { key: 'approval_1', type: 'approval', name: 'mgr', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'auto-approve' } },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'approval_1' },
+        { key: 'e2', source: 'approval_1', target: 'end' },
+      ],
+    }
+    const created = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key: `b6-inflight-${TS}`, name: 'b6', formSchema: { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }, approvalGraph: graph },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    const tid = ((await created.json()) as { id: string }).id
+    expect((await req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
+
+    const start = async (): Promise<string> => {
+      const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+      expect(started.status, await started.clone().text()).toBeLessThan(300)
+      const body = (await started.json()) as { id?: string; data?: { id: string } }
+      return (body.id ?? body.data?.id) as string
+    }
+    const snapshotOf = async (aid: string): Promise<{ text: string; title: string | null }> => {
+      const r = await query<{ snap: string; title: string | null }>(
+        `SELECT requester_snapshot::text AS snap, requester_snapshot->>'directoryTitle' AS title FROM approval_instances WHERE id = $1`,
+        [aid],
+      )
+      return { text: r.rows[0].snap, title: r.rows[0].title }
+    }
+
+    // #1 under policy→dingtalk: bakes the DingTalk title
+    const a1 = await start()
+    const before = await snapshotOf(a1)
+    expect(before.title).toBe('DingTalk Title')
+
+    // FLIP the policy — in-flight #1 must stay byte-identical
+    await setPolicy('default', local.id)
+    const after = await snapshotOf(a1)
+    expect(after.text).toBe(before.text) // stored jsonb unchanged, byte-for-byte
+
+    // #2 after the flip: bakes the LOCAL title — the positive control (the flip changed NEW resolutions)
+    const a2 = await start()
+    const second = await snapshotOf(a2)
+    expect(second.title).toBe('Local Title')
+  })
+})

--- a/packages/core-backend/tests/integration/approval-routing-policy-equivalence.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-routing-policy-equivalence.db.test.ts
@@ -40,8 +40,15 @@ import { resolveApprovalRequesterOrgRelations } from '../../src/services/Approva
  *      first instance's constancy is meaningful, not "nothing changed anywhere").
  *
  * Proof-slice vacuity discipline: this ticket adds NO production code, so the load-bearing
- * mutation runs against the CONSUMED B5-b predicate — deleting the policy-scoped
- * `AND a.integration_id = $2::uuid` restriction reds leg 1 (run out-of-band, recorded in the PR).
+ * mutation runs against the CONSUMED B5-b predicate — neutering the policy-scoped
+ * `AND a.integration_id = $2::uuid` restriction with a PARAM-PRESERVING no-op (e.g.
+ * `AND ($2::uuid IS NOT NULL OR a.integration_id = $2::uuid)`) reds the sentinel leg with the
+ * exact source-collapse signature (`expected 'DT-SENTINEL' to be 'LOCAL-SENTINEL'`) — a literal
+ * deletion also reds but only via a PG param-count error, which proves less (gate P3-3).
+ * On the in-flight leg: the byte-identical re-read is a RESIDUE PIN (today no code path rewrites
+ * snapshots, so it is structurally stable); the LOAD-BEARING invariance evidence is the positive
+ * control — instance #2 differing proves the flip changed new resolutions while #1 stayed frozen
+ * (gate P3-1, stated honestly).
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -152,6 +159,9 @@ describeIfDatabase('Canonical Org MVP — B6 approval-routing local/DingTalk equ
 
   afterAll(async () => {
     try {
+      // gate P3-2: the 'default' routing policy is the single most cross-suite-dangerous residue —
+      // delete it FIRST so a throw later in this block can never leak it into serially-later suites.
+      await query(`DELETE FROM org_directory_routing_policy WHERE org_id = ANY($1)`, [['default', ...cleanupOrgs]])
       const pool = poolManager.get()
       const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`%-${TS}`])).rows.map((r) => r.id as string)
       if (tids.length > 0) {
@@ -166,7 +176,6 @@ describeIfDatabase('Canonical Org MVP — B6 approval-routing local/DingTalk equ
         await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1)`, [tids])
         await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
       }
-      await query(`DELETE FROM org_directory_routing_policy WHERE org_id = ANY($1)`, [['default', ...cleanupOrgs]])
       for (const id of cleanupAccountIds.splice(0)) await query(`DELETE FROM directory_accounts WHERE id = $1`, [id])
       for (const id of cleanupIntegrationIds.splice(0)) await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
       for (const org of cleanupOrgs.splice(0)) await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [org])

--- a/packages/core-backend/tests/integration/approval-routing-policy-equivalence.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-routing-policy-equivalence.db.test.ts
@@ -32,12 +32,16 @@ import { resolveApprovalRequesterOrgRelations } from '../../src/services/Approva
  *      stays legacy; not exercised here — includeManagerChain is not opted into.)
  *
  * IN-FLIGHT INVARIANCE (instance-level, real server + real createApproval, org 'default'):
- *   4. An approval created under policy→dingtalk bakes `requester_snapshot.directoryTitle` from
- *      the DingTalk source; FLIPPING the policy to local afterwards leaves that stored snapshot
- *      BYTE-IDENTICAL (jsonb::text compared pre/post) — in-flight approvals keep baked routing;
- *      historical instances are not rewritten. A NEW approval created after the flip bakes the
- *      LOCAL title — the positive control proving the flip really changed new resolutions (so the
- *      first instance's constancy is meaningful, not "nothing changed anywhere").
+ *   4. Owner rework (#4434): the invariance subject is a GENUINE PENDING instance with a LIVE
+ *      assignment — the requester has a resolvable manager on BOTH sides, and the template uses
+ *      `emptyAssigneePolicy: 'error'` so an unresolvable manager fails the test loudly instead of
+ *      silently auto-approving into a terminal state (a terminal instance's constancy is a trivial
+ *      proposition). Under policy→dingtalk, instance #1 is created PENDING with an assignment and
+ *      bakes `directoryTitle='DingTalk Title'`; FLIPPING the policy to local leaves #1 STILL
+ *      PENDING with its `requester_snapshot` AND its assignment rows BYTE-IDENTICAL
+ *      (jsonb::text fingerprints pre/post) — in-flight approvals keep baked routing; historical
+ *      instances are never rewritten. A NEW instance after the flip is likewise PENDING and bakes
+ *      the LOCAL title — the positive control proving the flip really changed new resolutions.
  *
  * Proof-slice vacuity discipline: this ticket adds NO production code, so the load-bearing
  * mutation runs against the CONSUMED B5-b predicate — neutering the policy-scoped
@@ -245,24 +249,41 @@ describeIfDatabase('Canonical Org MVP — B6 approval-routing local/DingTalk equ
     expect(viaDt.deptHeadId).toBe(manager)
   })
 
-  it('in-flight invariance: a policy flip leaves an existing instance requester_snapshot byte-identical; a new instance follows the new policy', async () => {
-    // fixtures in 'default' — the org the approval routes resolve for the dev-token requester
-    cleanupUsers.push(REQ)
+  it('in-flight invariance: a policy flip leaves a PENDING instance (snapshot + assignment) byte-identical; a new instance follows the new policy', async () => {
+    // fixtures in 'default' — REQ has a resolvable MANAGER on BOTH sides so instances stay PENDING
+    const MGR = `b6-mgr-${TS}`
+    cleanupUsers.push(REQ, MGR)
     await seedUser(REQ)
+    await seedUser(MGR)
+
+    // local side (product writers): dept + accounts + primary + is_manager
     const local = await getOrCreateLocalIntegration('default')
-    const lAcc = await createLocalAccount({ orgId: 'default', localUserId: REQ, title: 'Local Title' })
+    const lDept = await createLocalDepartment({ orgId: 'default', name: `B6 Inflight ${TS}` })
+    const lReq = await createLocalAccount({ orgId: 'default', localUserId: REQ, title: 'Local Title' })
+    const lMgr = await createLocalAccount({ orgId: 'default', localUserId: MGR, title: 'Local Mgr' })
+    cleanupAccountIds.push(lReq.id, lMgr.id)
+    await addLocalMembership({ orgId: 'default', accountId: lReq.id, departmentId: lDept.id })
+    await switchLocalPrimaryDepartment('default', lReq.id, lDept.id)
+    await addLocalMembership({ orgId: 'default', accountId: lMgr.id, departmentId: lDept.id })
+    await setLocalMembershipManager('default', { directoryAccountId: lMgr.id, directoryDepartmentId: lDept.id }, true)
+
+    // dingtalk side (provider-shaped): dept + REQ primary + MGR leader_in_dept
     const dt = await dingtalkIntegration('default', 'inflight')
     cleanupIntegrationIds.push(dt)
-    const dAcc = await dtAccount(dt, REQ, 'DingTalk Title', {})
-    cleanupAccountIds.push(lAcc.id, dAcc)
+    const DT_DEPT = `b6-if-dept-${TS}`
+    const dDept = await dtDept(dt, DT_DEPT, `B6 Inflight DT ${TS}`)
+    const dReq = await dtAccount(dt, REQ, 'DingTalk Title', { dept_ids: [DT_DEPT] }, dDept)
+    const dMgr = await dtAccount(dt, MGR, 'DT Mgr', { leader_in_dept: [{ dept_id: DT_DEPT, leader: true }] }, dDept)
+    cleanupAccountIds.push(dReq, dMgr)
 
     await setPolicy('default', dt)
 
-    // publish a minimal auto-approve template (no department/title routing → no create-time wedge)
+    // emptyAssigneePolicy: 'error' — an unresolvable manager must FAIL the create loudly, never
+    // silently auto-approve into a terminal instance (the owner-caught flaw in the first version)
     const graph = {
       nodes: [
         { key: 'start', type: 'start', name: 's', config: {} },
-        { key: 'approval_1', type: 'approval', name: 'mgr', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'auto-approve' } },
+        { key: 'approval_1', type: 'approval', name: 'mgr', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
         { key: 'end', type: 'end', name: 'e', config: {} },
       ],
       edges: [
@@ -284,27 +305,38 @@ describeIfDatabase('Canonical Org MVP — B6 approval-routing local/DingTalk equ
       const body = (await started.json()) as { id?: string; data?: { id: string } }
       return (body.id ?? body.data?.id) as string
     }
-    const snapshotOf = async (aid: string): Promise<{ text: string; title: string | null }> => {
-      const r = await query<{ snap: string; title: string | null }>(
-        `SELECT requester_snapshot::text AS snap, requester_snapshot->>'directoryTitle' AS title FROM approval_instances WHERE id = $1`,
+    const stateOf = async (aid: string) => {
+      const inst = await query<{ status: string; snap: string; title: string | null }>(
+        `SELECT status, requester_snapshot::text AS snap, requester_snapshot->>'directoryTitle' AS title
+           FROM approval_instances WHERE id = $1`,
         [aid],
       )
-      return { text: r.rows[0].snap, title: r.rows[0].title }
+      const asg = await query<{ fp: string }>(
+        `SELECT to_jsonb(a)::text AS fp FROM approval_assignments a WHERE a.instance_id = $1 ORDER BY a.id`,
+        [aid],
+      )
+      return { status: inst.rows[0].status, snap: inst.rows[0].snap, title: inst.rows[0].title, assignments: asg.rows.map((r) => r.fp) }
     }
 
-    // #1 under policy→dingtalk: bakes the DingTalk title
+    // #1 under policy→dingtalk: PENDING, with a live assignment, DingTalk-baked snapshot
     const a1 = await start()
-    const before = await snapshotOf(a1)
+    const before = await stateOf(a1)
     expect(before.title).toBe('DingTalk Title')
+    expect(['pending', 'in_progress', 'running', 'active']).toContain(before.status) // NOT terminal
+    expect(before.assignments.length).toBeGreaterThan(0) // a REAL live assignment
 
-    // FLIP the policy — in-flight #1 must stay byte-identical
+    // FLIP the policy — the PENDING in-flight instance must stay byte-identical: status, snapshot, assignments
     await setPolicy('default', local.id)
-    const after = await snapshotOf(a1)
-    expect(after.text).toBe(before.text) // stored jsonb unchanged, byte-for-byte
+    const after = await stateOf(a1)
+    expect(after.status).toBe(before.status) // still pending — not re-dispatched or auto-resolved
+    expect(after.snap).toBe(before.snap) // stored snapshot unchanged, byte-for-byte
+    expect(after.assignments).toEqual(before.assignments) // assignment rows unchanged, byte-for-byte
 
-    // #2 after the flip: bakes the LOCAL title — the positive control (the flip changed NEW resolutions)
+    // #2 after the flip: likewise PENDING with an assignment, LOCAL-baked snapshot (positive control)
     const a2 = await start()
-    const second = await snapshotOf(a2)
+    const second = await stateOf(a2)
     expect(second.title).toBe('Local Title')
+    expect(['pending', 'in_progress', 'running', 'active']).toContain(second.status)
+    expect(second.assignments.length).toBeGreaterThan(0)
   })
 })

--- a/packages/core-backend/tests/integration/approval-routing-policy-equivalence.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-routing-policy-equivalence.db.test.ts
@@ -165,9 +165,10 @@ describeIfDatabase('Canonical Org MVP — B6 approval-routing local/DingTalk equ
   })
 
   afterAll(async () => {
+    // Policy delete first (cross-suite-dangerous residue). server.stop() always runs; cleanup
+    // failure must fail the suite (no silent catch).
+    let cleanupError: unknown
     try {
-      // gate P3-2: the 'default' routing policy is the single most cross-suite-dangerous residue —
-      // delete it FIRST so a throw later in this block can never leak it into serially-later suites.
       await query(`DELETE FROM org_directory_routing_policy WHERE org_id = ANY($1)`, [['default', ...cleanupOrgs]])
       const pool = poolManager.get()
       const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`%-${TS}`])).rows.map((r) => r.id as string)
@@ -188,10 +189,11 @@ describeIfDatabase('Canonical Org MVP — B6 approval-routing local/DingTalk equ
       for (const id of cleanupIntegrationIds.splice(0)) await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
       for (const org of cleanupOrgs.splice(0)) await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [org])
       for (const uid of cleanupUsers.splice(0)) await query(`DELETE FROM users WHERE id = $1`, [uid])
-    } catch {
-      /* best effort */
+    } catch (err) {
+      cleanupError = err
     }
     if (server) await server.stop()
+    if (cleanupError) throw cleanupError
   })
 
   it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {

--- a/packages/core-backend/tests/integration/approval-routing-policy-equivalence.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-routing-policy-equivalence.db.test.ts
@@ -150,6 +150,9 @@ describeIfDatabase('Canonical Org MVP — B6 approval-routing local/DingTalk equ
   const cleanupUsers: string[] = []
   const cleanupAccountIds: string[] = []
   const cleanupIntegrationIds: string[] = []
+  // gate P3: departments created on the SHARED 'default' local integration are not covered by the
+  // org/integration cascades below — track and delete them by id.
+  const cleanupDepartmentIds: string[] = []
 
   beforeAll(async () => {
     expect(await canListen()).toBe(true)
@@ -181,6 +184,7 @@ describeIfDatabase('Canonical Org MVP — B6 approval-routing local/DingTalk equ
         await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
       }
       for (const id of cleanupAccountIds.splice(0)) await query(`DELETE FROM directory_accounts WHERE id = $1`, [id])
+      for (const id of cleanupDepartmentIds.splice(0)) await query(`DELETE FROM directory_departments WHERE id = $1`, [id])
       for (const id of cleanupIntegrationIds.splice(0)) await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
       for (const org of cleanupOrgs.splice(0)) await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [org])
       for (const uid of cleanupUsers.splice(0)) await query(`DELETE FROM users WHERE id = $1`, [uid])
@@ -229,7 +233,11 @@ describeIfDatabase('Canonical Org MVP — B6 approval-routing local/DingTalk equ
     expect(viaDtSentinel.primaryTitle).toBe('DT-SENTINEL')
 
     // 2) EQUIVALENCE — align the titles, then the §10.1 triple must be IDENTICAL across sources
-    await query(`UPDATE directory_accounts SET title = 'Engineer' WHERE title IN ('LOCAL-SENTINEL','DT-SENTINEL')`)
+    // (gate P3: scoped to THIS test's two integrations — an unscoped title UPDATE could clobber a
+    // parallel run's sentinel rows on a shared dev DB, or rewrite foreign rows with these titles)
+    await query(`UPDATE directory_accounts SET title = 'Engineer' WHERE title IN ('LOCAL-SENTINEL','DT-SENTINEL') AND integration_id = ANY($1)`, [
+      [local.id, dt],
+    ])
     await setPolicy(org, local.id)
     const viaLocal = await resolveApprovalRequesterOrgRelations(requester, query)
     await setPolicy(org, dt)
@@ -259,6 +267,7 @@ describeIfDatabase('Canonical Org MVP — B6 approval-routing local/DingTalk equ
     // local side (product writers): dept + accounts + primary + is_manager
     const local = await getOrCreateLocalIntegration('default')
     const lDept = await createLocalDepartment({ orgId: 'default', name: `B6 Inflight ${TS}` })
+    cleanupDepartmentIds.push(lDept.id)
     const lReq = await createLocalAccount({ orgId: 'default', localUserId: REQ, title: 'Local Title' })
     const lMgr = await createLocalAccount({ orgId: 'default', localUserId: MGR, title: 'Local Mgr' })
     cleanupAccountIds.push(lReq.id, lMgr.id)

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -160,6 +160,12 @@ export default defineConfig({
       // DATABASE_URL-gated; wired as a WHOLE FILE into the directory real-DB step (both points
       // asserted by b5c-routing-routes-ci-wiring.test.mjs).
       'tests/integration/org-directory-routing-policy-routes.db.test.ts',
+      // Canonical Org MVP B6 (§10.1): approval-routing local/DingTalk REAL-DB equivalence — the
+      // sentinel source-check + seeded-equivalent parity matrix + pinned deptHead legacy asymmetry +
+      // in-flight snapshot invariance through the REAL MetaSheetServer createApproval path.
+      // DATABASE_URL-gated; wired as a WHOLE FILE into the APPROVAL real-DB step (server-based,
+      // like approval-direct-manager) — both points asserted by b6-equivalence-ci-wiring.test.mjs.
+      'tests/integration/approval-routing-policy-equivalence.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
       // resolution against real Postgres — normalized `is_manager` relation for a local integration,
       // the DingTalk `leader_in_dept` regression pin (load-bearing compat leg + is_manager=0 positive

--- a/scripts/ops/b6-equivalence-ci-wiring.test.mjs
+++ b/scripts/ops/b6-equivalence-ci-wiring.test.mjs
@@ -1,0 +1,24 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// B6 CI two-point wiring contract. The routing-policy schema suite proves the resolver over the (org,purpose)
+// policy store's DB invariants (cross-org FK-impossible, closed purpose set, RESTRICT) against real
+// Postgres — meaningless without a DB. It needs BOTH (1) the vitest.config.ts exclude (so the no-DB
+// job cannot skip-green it) AND (2) the plugin-tests.yml directory real-DB whole-file step. Removing
+// either point silently disables the proof while CI stays green. Runs in the gating no-DB test job.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/approval-routing-policy-equivalence.db.test.ts'
+
+test('vitest.config.ts excludes the B6 routing-policy suite from the no-DB job', () => {
+  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+})
+
+test('plugin-tests.yml runs the B6 routing-policy suite as a whole file in the approval real-DB step', () => {
+  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  assert.match(wf, new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${FILE}`)
+})


### PR DESCRIPTION
## B6 — approval-routing local/DingTalk real-DB equivalence

> **Unarmed. Review head: `35605e6fd`.** Restacked on merged #4431/main `5e55b549d`. Proof-only: no production-code delta; exactly four files (one real-DB test, two CI wiring points, one wiring guard).

### Proof

1. **Non-vacuous source switch:** distinct local/DingTalk sentinel titles prove the policy selects different integrations before parity is asserted.
2. **Seeded equivalence:** equivalent local data (B1/B2/B3 product writers, normalized `is_manager`) and DingTalk-shaped data (`leader_in_dept`) resolve the same department/title/manager triple.
3. **Known asymmetry pinned:** `deptHead` remains provider-specific; DingTalk resolves it, local does not. B6 does not claim this gap closed.
4. **Real in-flight invariance:** a real `MetaSheetServer` creates a pending instance with a live assignment under DingTalk; after the policy flips to local, that instance's status/snapshot/assignments remain byte-identical, while a newly created instance uses the local title.

### Fresh post-#4431 verification

- Fresh PostgreSQL database, full migration chain: pass.
- B6 alone: 3/3.
- Serial compatibility battery (`approval-direct-manager` → `approval-routing-policy-failclose` → B6 → `approval-postgate-acceptance`): 22/22.
- Post-suite default `approval_routing` residue: 0.
- CI wiring guard: 2/2; backend `tsc --noEmit`: pass.

### Load-bearing mutations

- Parameter-preserving B5-b scope mutation (`AND ($2::uuid IS NOT NULL OR a.integration_id = $2::uuid)`) fails semantically: local sentinel resolves as DingTalk, and the post-flip new instance still has the DingTalk title. This is not a bind-count failure.
- Local normalized-manager mutation and DingTalk `parseLeaderDeptIds` mutation each red their intended provider leg (Grok replay).
- Cleanup-query failure now fails the suite while `server.stop()` still completes; the former silent `afterAll` catch was removed. Restored head re-runs green.

Implementation/testing was performed by Grok Build in an isolated worktree. Codex independently reviewed the four-file diff, ran a separate fresh-DB battery, and replayed the semantic scope mutation. No P1/P2 found. Exact-head GitHub CI is the remaining gate; auto-merge stays off until it settles.
