### PR TITLE
feat(directory): B7 — suggest-only reconciliation (stale-not-inactive, no auto-match on ambiguity)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -196,6 +196,10 @@ jobs:
       - name: B6 equivalence CI wiring contract
         run: node --test scripts/ops/b6-equivalence-ci-wiring.test.mjs
 
+      # B7 CI two-point wiring contract (no DB).
+      - name: B7 reconciliation CI wiring contract
+        run: node --test scripts/ops/b7-reconciliation-ci-wiring.test.mjs
+
       # The production monitor invokes the same state helper covered here.
       # Keep this in the required 18/20 matrix so HTTP classification, silence
       # barriers, and alert/recovery streak semantics cannot drift silently.
@@ -674,6 +678,7 @@ jobs:
             tests/integration/org-directory-routing-policy-schema.db.test.ts \
             tests/integration/org-directory-routing-policy-resolver.db.test.ts \
             tests/integration/org-directory-routing-policy-routes.db.test.ts \
+            tests/integration/directory-binding-reconciliation.db.test.ts \
             tests/integration/directory-normalized-manager.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             tests/integration/attendance-notification-redelivery.db.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -200,6 +200,10 @@ jobs:
       - name: B7 reconciliation CI wiring contract
         run: node --test scripts/ops/b7-reconciliation-ci-wiring.test.mjs
 
+      # B7 owner-round CI two-point wiring contract (no DB): admin routes + Q6 sync-hook suites.
+      - name: B7 round-2 CI wiring contract
+        run: node --test scripts/ops/b7-round2-ci-wiring.test.mjs
+
       # The production monitor invokes the same state helper covered here.
       # Keep this in the required 18/20 matrix so HTTP classification, silence
       # barriers, and alert/recovery streak semantics cannot drift silently.
@@ -635,6 +639,7 @@ jobs:
             tests/integration/approval-direct-manager.api.test.ts \
             tests/integration/approval-routing-policy-failclose.api.test.ts \
             tests/integration/approval-routing-policy-equivalence.db.test.ts \
+            tests/integration/directory-binding-sync-hook.db.test.ts \
             tests/integration/approval-postgate-acceptance.api.test.ts \
             tests/integration/dept-head-sync-plumbing.test.ts \
             tests/integration/approval-manager-chain.db.test.ts \
@@ -679,6 +684,7 @@ jobs:
             tests/integration/org-directory-routing-policy-resolver.db.test.ts \
             tests/integration/org-directory-routing-policy-routes.db.test.ts \
             tests/integration/directory-binding-reconciliation.db.test.ts \
+            tests/integration/directory-binding-admin-routes.db.test.ts \
             tests/integration/directory-normalized-manager.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             tests/integration/attendance-notification-redelivery.db.test.ts \

--- a/packages/core-backend/src/directory/department-binding-reconciliation.ts
+++ b/packages/core-backend/src/directory/department-binding-reconciliation.ts
@@ -24,10 +24,11 @@ import { query } from '../db/pg'
  *     writes — applying a suggestion is a separate, explicit admin action (future
  *     `PATCH /department-bindings` surface, §7).
  *
- * Neither function is wired into the sync loop yet: WHERE the sweep runs (a post-sync hook vs an
- * admin-triggered action) is an owner decision — wiring it into the hardened sync core without a
- * ruling would be scope creep. Both functions are deterministic and idempotent, so either wiring
- * is safe later.
+ * Wiring (owner Q6 ruling, round 2): the sweep runs from BOTH entry points — automatically after a
+ * successful sync commit (`syncDirectoryIntegration`'s post-commit hook, narrowed to the just-synced
+ * integration, strictly best-effort: a sweep failure never fails the sync) AND on demand via the
+ * admin surface (`POST /api/admin/directory/department-bindings/sweep`, the Q6 admin retry). Both
+ * callers rely on these functions staying deterministic and idempotent.
  */
 
 export interface StaleSweepResult {

--- a/packages/core-backend/src/directory/department-binding-reconciliation.ts
+++ b/packages/core-backend/src/directory/department-binding-reconciliation.ts
@@ -35,31 +35,52 @@ export interface StaleSweepResult {
   healed: number
 }
 
-export async function sweepStaleDepartmentBindings(orgId: string): Promise<StaleSweepResult> {
+/**
+ * @param opts.remoteIntegrationId — Q6 (owner ruling): the post-sync hook narrows the sweep to the
+ * integration that just synced; the admin retry endpoint may narrow the same way or sweep the org.
+ */
+export async function sweepStaleDepartmentBindings(
+  orgId: string,
+  opts: { remoteIntegrationId?: string } = {},
+): Promise<StaleSweepResult> {
+  // Owner review (#4436) — two remote-INTEGRATION guards on BOTH directions:
+  //   - `ri.status = 'active'`: a disabled/frozen remote integration's data is a snapshot, not a
+  //     live fact stream — its bindings must not churn (neither stale nor heal) until it is live.
+  //   - `ri.provider <> 'local'`: the remote side of a binding is by definition a provider;
+  //     belt-and-suspenders here (B4's provider FK + CHECK already make a local remote side
+  //     unconstructible), so a raw-malformed row can never be swept as if it were provider truth.
+  const narrow = opts.remoteIntegrationId ? ' AND b.remote_integration_id = $2::uuid' : ''
+  const params: unknown[] = opts.remoteIntegrationId ? [orgId, opts.remoteIntegrationId] : [orgId]
   // Mark ACTIVE bindings whose remote department disappeared (is_active = false) as STALE.
   const staled = await query<{ id: string }>(
     `UPDATE directory_department_bindings b
         SET status = 'stale', updated_at = NOW()
-       FROM directory_departments rd
+       FROM directory_departments rd, directory_integrations ri
       WHERE rd.id = b.remote_department_id
+        AND ri.id = b.remote_integration_id
+        AND ri.status = 'active'
+        AND ri.provider <> 'local'
         AND b.org_id = $1
         AND b.status = 'active'
-        AND rd.is_active = false
+        AND rd.is_active = false${narrow}
       RETURNING b.id`,
-    [orgId],
+    params,
   )
   // Heal STALE bindings whose remote department is live again. Both directions only ever reflect
   // provider-side FACTS onto the binding row — never onto the local department.
   const healed = await query<{ id: string }>(
     `UPDATE directory_department_bindings b
         SET status = 'active', updated_at = NOW()
-       FROM directory_departments rd
+       FROM directory_departments rd, directory_integrations ri
       WHERE rd.id = b.remote_department_id
+        AND ri.id = b.remote_integration_id
+        AND ri.status = 'active'
+        AND ri.provider <> 'local'
         AND b.org_id = $1
         AND b.status = 'stale'
-        AND rd.is_active = true
+        AND rd.is_active = true${narrow}
       RETURNING b.id`,
-    [orgId],
+    params,
   )
   return { staled: staled.rows.length, healed: healed.rows.length }
 }

--- a/packages/core-backend/src/directory/department-binding-reconciliation.ts
+++ b/packages/core-backend/src/directory/department-binding-reconciliation.ts
@@ -118,6 +118,12 @@ export async function suggestDepartmentBindings(orgId: string): Promise<Departme
   // One read: every UNBOUND active remote department of the org's active non-local integrations,
   // with its exact-name candidate set among the org's ACTIVE local departments (active local
   // integration). LEFT JOIN keeps zero-candidate remotes visible as `unmatched`.
+  //
+  // Read-boundary provider integrity: `rd.provider = ri.provider` rejects a raw/malformed child
+  // whose provider is mislabeled relative to its parent integration (e.g. provider='local' under
+  // an active dingtalk integration). With `ri.provider <> 'local'` that excludes mislabeled local
+  // children from suggestions/ambiguous/unmatched — B4 only rejects them later if a binding is
+  // applied, so the suggest surface must not present them as remote proposals.
   const rows = await query<{
     remote_integration_id: string
     remote_department_id: string
@@ -132,6 +138,7 @@ export async function suggestDepartmentBindings(orgId: string): Promise<Departme
        JOIN directory_departments rd
          ON rd.integration_id = ri.id
         AND rd.is_active = true
+        AND rd.provider = ri.provider
        LEFT JOIN directory_department_bindings b
          ON b.remote_department_id = rd.id
         AND b.remote_integration_id = ri.id

--- a/packages/core-backend/src/directory/department-binding-reconciliation.ts
+++ b/packages/core-backend/src/directory/department-binding-reconciliation.ts
@@ -1,0 +1,172 @@
+import { query } from '../db/pg'
+
+/**
+ * Canonical Org MVP — B7 (external-provider reconciliation, SUGGEST-ONLY), #4215 §9 + §5.5.
+ *
+ * Doctrine (§9, ratified): external providers PROPOSE bindings — they never silently rewrite the
+ * local organization structure. Two service functions, both org-scoped:
+ *
+ *   - `sweepStaleDepartmentBindings(orgId)` — reflect REMOTE department liveness onto the BINDING
+ *     rows only: a binding whose remote department has disappeared from the provider
+ *     (archive-not-delete ⇒ `is_active = false`) is marked `status = 'stale'`; a stale binding
+ *     whose remote department is live again heals back to `'active'`. Both directions touch
+ *     `directory_department_bindings` EXCLUSIVELY — the local department is NEVER deactivated,
+ *     renamed, or otherwise written by this sweep (the headline B7 invariant: a provider-side
+ *     disappearance must not damage the canonical local org).
+ *
+ *   - `suggestDepartmentBindings(orgId)` — READ-ONLY proposals for UNBOUND remote departments.
+ *     v1 matching signal: exact name (case- and whitespace-insensitive) against ACTIVE local
+ *     departments of the org's active local integration. Exactly ONE candidate ⇒ a suggestion the
+ *     admin may apply; MORE THAN ONE ⇒ an `ambiguous` entry that CANNOT be auto-applied (§9: "do
+ *     not auto-match on name alone when multiple candidates exist"); ZERO ⇒ `unmatched`. The
+ *     richer signals §9 lists (normalized path, stored external id, binding history,
+ *     admin-selected) belong to the decision-workflow follow-up, not this v1. This function never
+ *     writes — applying a suggestion is a separate, explicit admin action (future
+ *     `PATCH /department-bindings` surface, §7).
+ *
+ * Neither function is wired into the sync loop yet: WHERE the sweep runs (a post-sync hook vs an
+ * admin-triggered action) is an owner decision — wiring it into the hardened sync core without a
+ * ruling would be scope creep. Both functions are deterministic and idempotent, so either wiring
+ * is safe later.
+ */
+
+export interface StaleSweepResult {
+  staled: number
+  healed: number
+}
+
+export async function sweepStaleDepartmentBindings(orgId: string): Promise<StaleSweepResult> {
+  // Mark ACTIVE bindings whose remote department disappeared (is_active = false) as STALE.
+  const staled = await query<{ id: string }>(
+    `UPDATE directory_department_bindings b
+        SET status = 'stale', updated_at = NOW()
+       FROM directory_departments rd
+      WHERE rd.id = b.remote_department_id
+        AND b.org_id = $1
+        AND b.status = 'active'
+        AND rd.is_active = false
+      RETURNING b.id`,
+    [orgId],
+  )
+  // Heal STALE bindings whose remote department is live again. Both directions only ever reflect
+  // provider-side FACTS onto the binding row — never onto the local department.
+  const healed = await query<{ id: string }>(
+    `UPDATE directory_department_bindings b
+        SET status = 'active', updated_at = NOW()
+       FROM directory_departments rd
+      WHERE rd.id = b.remote_department_id
+        AND b.org_id = $1
+        AND b.status = 'stale'
+        AND rd.is_active = true
+      RETURNING b.id`,
+    [orgId],
+  )
+  return { staled: staled.rows.length, healed: healed.rows.length }
+}
+
+export interface DepartmentBindingSuggestion {
+  remoteIntegrationId: string
+  remoteDepartmentId: string
+  remoteDepartmentName: string
+  localDepartmentId: string
+  matchStrategy: 'exact-name'
+}
+
+export interface AmbiguousDepartmentMatch {
+  remoteIntegrationId: string
+  remoteDepartmentId: string
+  remoteDepartmentName: string
+  candidateLocalDepartmentIds: string[]
+  reason: 'ambiguous-name'
+}
+
+export interface UnmatchedRemoteDepartment {
+  remoteIntegrationId: string
+  remoteDepartmentId: string
+  remoteDepartmentName: string
+}
+
+export interface DepartmentBindingSuggestions {
+  suggestions: DepartmentBindingSuggestion[]
+  ambiguous: AmbiguousDepartmentMatch[]
+  unmatched: UnmatchedRemoteDepartment[]
+}
+
+export async function suggestDepartmentBindings(orgId: string): Promise<DepartmentBindingSuggestions> {
+  // One read: every UNBOUND active remote department of the org's active non-local integrations,
+  // with its exact-name candidate set among the org's ACTIVE local departments (active local
+  // integration). LEFT JOIN keeps zero-candidate remotes visible as `unmatched`.
+  const rows = await query<{
+    remote_integration_id: string
+    remote_department_id: string
+    remote_department_name: string
+    local_department_id: string | null
+  }>(
+    `SELECT ri.id::text  AS remote_integration_id,
+            rd.id::text  AS remote_department_id,
+            rd.name      AS remote_department_name,
+            ld.id::text  AS local_department_id
+       FROM directory_integrations ri
+       JOIN directory_departments rd
+         ON rd.integration_id = ri.id
+        AND rd.is_active = true
+       LEFT JOIN directory_department_bindings b
+         ON b.remote_department_id = rd.id
+        AND b.remote_integration_id = ri.id
+       LEFT JOIN directory_integrations li
+         ON li.org_id = ri.org_id
+        AND li.provider = 'local'
+        AND li.status = 'active'
+       LEFT JOIN directory_departments ld
+         ON ld.integration_id = li.id
+        AND ld.provider = 'local'
+        AND ld.is_active = true
+        AND lower(btrim(ld.name)) = lower(btrim(rd.name))
+      WHERE ri.org_id = $1
+        AND ri.provider <> 'local'
+        AND ri.status = 'active'
+        AND b.id IS NULL
+      ORDER BY rd.id ASC, ld.id ASC`,
+    [orgId],
+  )
+
+  const byRemote = new Map<string, { intId: string; name: string; candidates: string[] }>()
+  for (const r of rows.rows) {
+    let entry = byRemote.get(r.remote_department_id)
+    if (!entry) {
+      entry = { intId: r.remote_integration_id, name: r.remote_department_name, candidates: [] }
+      byRemote.set(r.remote_department_id, entry)
+    }
+    if (r.local_department_id) entry.candidates.push(r.local_department_id)
+  }
+
+  const result: DepartmentBindingSuggestions = { suggestions: [], ambiguous: [], unmatched: [] }
+  for (const [remoteDepartmentId, entry] of byRemote) {
+    if (entry.candidates.length === 1) {
+      result.suggestions.push({
+        remoteIntegrationId: entry.intId,
+        remoteDepartmentId,
+        remoteDepartmentName: entry.name,
+        localDepartmentId: entry.candidates[0],
+        matchStrategy: 'exact-name',
+      })
+    } else if (entry.candidates.length > 1) {
+      // §9: NEVER auto-match on name alone when multiple candidates exist — surfaced for an
+      // explicit admin decision, deliberately NOT shaped like an appliable suggestion.
+      result.ambiguous.push({
+        remoteIntegrationId: entry.intId,
+        remoteDepartmentId,
+        remoteDepartmentName: entry.name,
+        candidateLocalDepartmentIds: entry.candidates,
+        reason: 'ambiguous-name',
+      })
+    } else {
+      result.unmatched.push({
+        remoteIntegrationId: entry.intId,
+        remoteDepartmentId,
+        remoteDepartmentName: entry.name,
+      })
+    }
+  }
+  return result
+}

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -3884,16 +3884,13 @@ export async function syncDirectoryIntegration(
           integrationId,
         })
       }
-    } catch (error) {
-      // Values-free: bounded reason code + Error.name only. Never interpolate error.message /
-      // readErrorMessage — raw DB/adapter text can carry relation names, SQL fragments, values.
-      const errorClass =
-        error instanceof Error && typeof error.name === 'string' && error.name.length > 0
-          ? error.name
-          : 'sweep_failed'
+    } catch (_error) {
+      // Values-free BY CONSTRUCTION: fixed message + closed meta only. Never log error.message,
+      // error.name, code, stack, relation, SQL, or any adapter-derived text — those are mutable /
+      // attacker-or-adapter-controlled and can carry values. Admin sweep endpoint is the retry path.
       logger.warn(
         'Department-binding sweep after successful sync failed (sync unaffected; retry via admin sweep endpoint)',
-        { integrationId, reason: 'sweep_failed', errorClass },
+        { integrationId, reason: 'sweep_failed' },
       )
     }
 

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -3873,8 +3873,8 @@ export async function syncDirectoryIntegration(
     // B7 Q6 (owner ruling): after a SUCCESSFUL sync commit, reflect remote-department liveness
     // onto this integration's bindings — NARROWED to the integration that just synced. Strictly
     // best-effort BY RULING: the sync above already succeeded and committed, so a sweep failure
-    // must never fail (or fail-mark) it — it logs values-free and the admin sweep endpoint
-    // (`POST /api/admin/directory/department-bindings/sweep`) is the retry path.
+    // must never fail (or fail-mark) it — it logs VALUES-FREE BY CONSTRUCTION and the admin sweep
+    // endpoint (`POST /api/admin/directory/department-bindings/sweep`) is the retry path.
     try {
       const sweep = await sweepStaleDepartmentBindings(updatedIntegration.org_id, {
         remoteIntegrationId: integrationId,
@@ -3885,9 +3885,15 @@ export async function syncDirectoryIntegration(
         })
       }
     } catch (error) {
+      // Values-free: bounded reason code + Error.name only. Never interpolate error.message /
+      // readErrorMessage — raw DB/adapter text can carry relation names, SQL fragments, values.
+      const errorClass =
+        error instanceof Error && typeof error.name === 'string' && error.name.length > 0
+          ? error.name
+          : 'sweep_failed'
       logger.warn(
-        `Department-binding sweep after successful sync failed (the sync itself is unaffected; retry via the admin sweep endpoint): ${readErrorMessage(error, 'unknown error')}`,
-        { integrationId },
+        'Department-binding sweep after successful sync failed (sync unaffected; retry via admin sweep endpoint)',
+        { integrationId, reason: 'sweep_failed', errorClass },
       )
     }
 

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -6,6 +6,7 @@ import { issueInviteToken } from '../auth/invite-tokens'
 import { validatePassword } from '../auth/password-policy'
 import { Logger } from '../core/logger'
 import { query, transaction } from '../db/pg'
+import { sweepStaleDepartmentBindings } from './department-binding-reconciliation'
 import {
   fetchDingTalkAppAccessToken,
   getDingTalkDepartmentDetail,
@@ -3867,6 +3868,27 @@ export async function syncDirectoryIntegration(
 
     if (!updatedIntegration || !updatedRun.rows[0]) {
       throw new Error('Directory sync completed but summary reload failed')
+    }
+
+    // B7 Q6 (owner ruling): after a SUCCESSFUL sync commit, reflect remote-department liveness
+    // onto this integration's bindings — NARROWED to the integration that just synced. Strictly
+    // best-effort BY RULING: the sync above already succeeded and committed, so a sweep failure
+    // must never fail (or fail-mark) it — it logs values-free and the admin sweep endpoint
+    // (`POST /api/admin/directory/department-bindings/sweep`) is the retry path.
+    try {
+      const sweep = await sweepStaleDepartmentBindings(updatedIntegration.org_id, {
+        remoteIntegrationId: integrationId,
+      })
+      if (sweep.staled > 0 || sweep.healed > 0) {
+        logger.info(`Department-binding sweep after sync: staled=${sweep.staled} healed=${sweep.healed}`, {
+          integrationId,
+        })
+      }
+    } catch (error) {
+      logger.warn(
+        `Department-binding sweep after successful sync failed (the sync itself is unaffected; retry via the admin sweep endpoint): ${readErrorMessage(error, 'unknown error')}`,
+        { integrationId },
+      )
     }
 
     return {

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -172,6 +172,7 @@ import { initAdminRoutes } from './routes/admin-routes'
 import { adminUsersRouter } from './routes/admin-users'
 import { adminDirectoryRouter } from './routes/admin-directory'
 import { adminDirectoryLocalRouter } from './routes/admin-directory-local'
+import { adminDirectoryDepartmentBindingsRouter } from './routes/admin-directory-department-bindings'
 import { adminDirectoryRoutingPolicyRouter } from './routes/admin-directory-routing-policy'
 import { startDirectorySyncScheduler, stopDirectorySyncScheduler } from './directory/directory-sync-scheduler'
 import { canaryRoutes } from './routes/canary-routes'
@@ -1357,6 +1358,7 @@ export class MetaSheetServer {
     // Canonical Org MVP B2 (local departments/accounts/memberships CRUD) — mounted alongside
     // adminDirectoryRouter under the same base path, sharing its `ensurePlatformAdmin` RBAC gate.
     this.app.use('/api/admin/directory/local', adminDirectoryLocalRouter())
+    this.app.use('/api/admin/directory/department-bindings', adminDirectoryDepartmentBindingsRouter())
     this.app.use('/api/admin/directory/routing-policy', adminDirectoryRoutingPolicyRouter())
 
     // Canary routing (behind ENABLE_CANARY_ROUTING feature flag)

--- a/packages/core-backend/src/routes/admin-directory-department-bindings.ts
+++ b/packages/core-backend/src/routes/admin-directory-department-bindings.ts
@@ -1,0 +1,136 @@
+import type { Request, Response } from 'express'
+import { Router } from 'express'
+import { auditLog } from '../audit/audit'
+import { Logger } from '../core/logger'
+import { ensurePlatformAdmin } from './admin-directory'
+import { query } from '../db/pg'
+import {
+  suggestDepartmentBindings,
+  sweepStaleDepartmentBindings,
+} from '../directory/department-binding-reconciliation'
+import { jsonError, jsonOk } from '../util/response'
+
+const logger = new Logger('AdminDirectoryDepartmentBindingRoutes')
+
+// Same single-tenant org resolution convention as admin-directory-local.ts / the routing-policy
+// routes: org identity is NEVER read from the request.
+const DEFAULT_ORG_ID = 'default'
+function resolveOrgId(_req: Request): string {
+  return DEFAULT_ORG_ID
+}
+
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * B7 owner round (#4436) — the department-binding MANAGEMENT surface (the production entry the
+ * first cut deliberately deferred):
+ *
+ *   GET  /             — list the org's bindings with their status + both sides' names (read-only).
+ *   GET  /suggestions  — the §9 suggest-only proposals (read-only; ambiguous entries are not
+ *                        appliable by construction).
+ *   POST /sweep        — the Q6 ADMIN RETRY path for the post-sync auto-sweep: run the stale/heal
+ *                        sweep now, optionally narrowed to one remote integration (the same
+ *                        narrowing the sync hook uses). Values-free audit with the outcome counts.
+ *
+ * All admin-only; org server-resolved. Applying a suggestion (creating a binding) remains a
+ * follow-up decision-workflow surface (§9 outcomes) — deliberately not a blind POST here.
+ */
+export function adminDirectoryDepartmentBindingsRouter(): Router {
+  const router = Router()
+
+  router.get('/', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    try {
+      const orgId = resolveOrgId(req)
+      const rows = await query(
+        `SELECT b.id::text                    AS id,
+                b.status                      AS status,
+                b.local_integration_id::text  AS local_integration_id,
+                b.local_department_id::text   AS local_department_id,
+                ld.name                       AS local_department_name,
+                b.remote_integration_id::text AS remote_integration_id,
+                b.remote_department_id::text  AS remote_department_id,
+                rd.name                       AS remote_department_name,
+                b.remote_provider             AS remote_provider,
+                b.updated_at::text            AS updated_at
+           FROM directory_department_bindings b
+           JOIN directory_departments ld ON ld.id = b.local_department_id
+           JOIN directory_departments rd ON rd.id = b.remote_department_id
+          WHERE b.org_id = $1
+          ORDER BY b.updated_at DESC, b.id ASC
+          LIMIT 500`,
+        [orgId],
+      )
+      jsonOk(res, { orgId, bindings: rows.rows })
+    } catch (error) {
+      logger.error(`Failed to list department bindings: ${error instanceof Error ? error.message : 'unknown'}`)
+      jsonError(res, 500, 'DEPARTMENT_BINDINGS_LIST_FAILED', 'Failed to list department bindings')
+    }
+  })
+
+  router.get('/suggestions', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    try {
+      const orgId = resolveOrgId(req)
+      const result = await suggestDepartmentBindings(orgId)
+      jsonOk(res, { orgId, ...result })
+    } catch (error) {
+      logger.error(`Failed to compute binding suggestions: ${error instanceof Error ? error.message : 'unknown'}`)
+      jsonError(res, 500, 'DEPARTMENT_BINDINGS_SUGGEST_FAILED', 'Failed to compute binding suggestions')
+    }
+  })
+
+  router.post('/sweep', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const extraKeys = Object.keys(body).filter((k) => k !== 'remoteIntegrationId')
+    if (extraKeys.length > 0) {
+      jsonError(res, 400, 'DEPARTMENT_BINDINGS_INVALID_INPUT', `Unexpected field(s): ${extraKeys.join(', ')}`)
+      return
+    }
+    const remoteIntegrationId = body.remoteIntegrationId
+    if (remoteIntegrationId !== undefined) {
+      if (typeof remoteIntegrationId !== 'string' || !UUID_SHAPE.test(remoteIntegrationId)) {
+        jsonError(res, 400, 'DEPARTMENT_BINDINGS_INVALID_INPUT', 'remoteIntegrationId must be a UUID when present')
+        return
+      }
+    }
+
+    try {
+      const orgId = resolveOrgId(req)
+      if (typeof remoteIntegrationId === 'string') {
+        const owned = await query<{ id: string }>(
+          `SELECT id::text AS id FROM directory_integrations WHERE id = $1::uuid AND org_id = $2`,
+          [remoteIntegrationId, orgId],
+        )
+        if (owned.rows.length === 0) {
+          jsonError(res, 404, 'DEPARTMENT_BINDINGS_INTEGRATION_NOT_FOUND', 'Integration not found in this organization')
+          return
+        }
+      }
+      const sweep = await sweepStaleDepartmentBindings(
+        orgId,
+        typeof remoteIntegrationId === 'string' ? { remoteIntegrationId } : {},
+      )
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'directory.department_binding.sweep',
+        resourceType: 'directory-department-binding',
+        resourceId: `${orgId}:${typeof remoteIntegrationId === 'string' ? remoteIntegrationId : 'all'}`,
+        // values-free: ids + outcome COUNTS only
+        meta: { orgId, ...(typeof remoteIntegrationId === 'string' ? { remoteIntegrationId } : {}), staled: sweep.staled, healed: sweep.healed },
+      })
+      jsonOk(res, sweep)
+    } catch (error) {
+      logger.error(`Failed to sweep department bindings: ${error instanceof Error ? error.message : 'unknown'}`)
+      jsonError(res, 500, 'DEPARTMENT_BINDINGS_SWEEP_FAILED', 'Failed to sweep department bindings')
+    }
+  })
+
+  return router
+}

--- a/packages/core-backend/tests/integration/directory-binding-admin-routes.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-binding-admin-routes.db.test.ts
@@ -155,6 +155,19 @@ describeIfDatabase('B7 — department-binding admin routes (real DB, HTTP)', () 
     const res2 = await request(adminApp).post(`${BASE}/sweep`).send({})
     expect((res2.body.data ?? res2.body).staled).toBe(1)
     expect(await sweepAuditCount()).toBe(2)
+
+    // Gate P3 (restack round): pin the VALUES-FREE property, not just the count — the serialized
+    // sweep audit rows must carry ids/counters only, never department names (a regression adding
+    // names/urls to meta would otherwise stay green).
+    const serialized = await query<{ body: string | null }>(
+      `SELECT string_agg(to_jsonb(a)::text, '|') AS body
+         FROM audit_logs a WHERE a.action = 'directory.department_binding.sweep'`
+    )
+    const auditBody = serialized.rows[0].body ?? ''
+    expect(auditBody.length).toBeGreaterThan(0)
+    for (const leaked of [x.lDeptName, y.lDeptName, 'B7R swx', 'B7R swy']) {
+      expect(auditBody).not.toContain(leaked)
+    }
   })
 
   it('D. POST /sweep validations reject without sweeping or auditing: unlisted field / non-UUID / cross-org', async () => {

--- a/packages/core-backend/tests/integration/directory-binding-admin-routes.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-binding-admin-routes.db.test.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from 'crypto'
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { getOrCreateLocalIntegration } from '../../src/directory/directory-sync'
+import { createLocalDepartment } from '../../src/directory/local-directory-org'
+import { adminDirectoryDepartmentBindingsRouter } from '../../src/routes/admin-directory-department-bindings'
+
+/**
+ * B7 owner round (#4436) — the department-binding MANAGEMENT surface (real DB, HTTP).
+ *
+ *   A. GET / lists the org's bindings with status + both sides' names.
+ *   B. GET /suggestions returns the §9 read-only proposals (and writes nothing).
+ *   C. POST /sweep is the Q6 ADMIN RETRY: stales a disappeared-remote binding on demand, audited
+ *      values-free with outcome counts; narrowed sweep (remoteIntegrationId) leaves the other
+ *      integration's binding untouched — the same scope the post-sync hook uses.
+ *   D. POST /sweep validations: unlisted field 400; non-UUID 400; cross-org integration 404 —
+ *      none of them sweeping or auditing anything.
+ *   E. non-admin 403 on all three routes.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+const orgId = 'default'
+
+const adminApp = express()
+adminApp.use(express.json())
+adminApp.use((req, _res, next) => {
+  ;(req as express.Request & { user?: unknown }).user = { id: `b7r-admin-${STAMP}`, role: 'admin' }
+  next()
+})
+adminApp.use('/api/admin/directory/department-bindings', adminDirectoryDepartmentBindingsRouter())
+
+const nonAdminApp = express()
+nonAdminApp.use(express.json())
+nonAdminApp.use((req, _res, next) => {
+  ;(req as express.Request & { user?: unknown }).user = { id: `b7r-nonadmin-${STAMP}` }
+  next()
+})
+nonAdminApp.use('/api/admin/directory/department-bindings', adminDirectoryDepartmentBindingsRouter())
+
+const BASE = '/api/admin/directory/department-bindings'
+
+async function dingtalkIntegration(org: string, tag: string): Promise<string> {
+  const r = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config)
+     VALUES ($1, 'dingtalk', $2, 'active', $3, '{}'::jsonb) RETURNING id`,
+    [org, `DT b7r ${tag} ${STAMP}`, `corp-b7r-${STAMP}-${tag}`],
+  )
+  return r.rows[0].id
+}
+async function dtDept(integrationId: string, extId: string, name: string): Promise<string> {
+  const r = await query<{ id: string }>(
+    `INSERT INTO directory_departments (integration_id, provider, external_department_id, name, is_active, raw)
+     VALUES ($1, 'dingtalk', $2, $3, true, '{}'::jsonb) RETURNING id`,
+    [integrationId, extId, name],
+  )
+  return r.rows[0].id
+}
+async function bind(org: string, localInt: string, localDept: string, remoteInt: string, remoteDept: string): Promise<string> {
+  const r = await query<{ id: string }>(
+    `INSERT INTO directory_department_bindings
+       (org_id, local_integration_id, local_department_id, local_provider,
+        remote_integration_id, remote_department_id, remote_provider, status)
+     VALUES ($1, $2, $3, 'local', $4, $5, 'dingtalk', 'active') RETURNING id`,
+    [org, localInt, localDept, remoteInt, remoteDept],
+  )
+  return r.rows[0].id
+}
+async function sweepAuditCount(): Promise<number> {
+  const r = await query<{ n: number }>(
+    `SELECT count(*)::int AS n FROM audit_logs WHERE action = 'directory.department_binding.sweep'`,
+  )
+  return r.rows[0]?.n ?? 0
+}
+
+describeIfDatabase('B7 — department-binding admin routes (real DB, HTTP)', () => {
+  const cleanupIntegrationIds: string[] = []
+  const cleanupDeptIds: string[] = []
+  const cleanupBindingIds: string[] = []
+  const cleanupOrgIds: string[] = []
+
+  afterEach(async () => {
+    await query(`DELETE FROM audit_logs WHERE resource_type = 'directory-department-binding'`)
+    for (const id of cleanupBindingIds.splice(0)) await query(`DELETE FROM directory_department_bindings WHERE id = $1`, [id])
+    for (const id of cleanupDeptIds.splice(0)) await query(`DELETE FROM directory_departments WHERE id = $1`, [id])
+    for (const id of cleanupIntegrationIds.splice(0)) await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
+    for (const org of cleanupOrgIds.splice(0)) await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [org])
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  async function seedBoundPair(tag: string): Promise<{ dt: string; rDept: string; binding: string; lDeptName: string }> {
+    const local = await getOrCreateLocalIntegration(orgId)
+    const lDept = await createLocalDepartment({ orgId, name: `B7R ${tag} ${STAMP}` })
+    cleanupDeptIds.push(lDept.id)
+    const dt = await dingtalkIntegration(orgId, tag)
+    cleanupIntegrationIds.push(dt)
+    const rDept = await dtDept(dt, `b7r-${tag}-${STAMP}`, `B7R ${tag} ${STAMP}`)
+    const binding = await bind(orgId, local.id, lDept.id, dt, rDept)
+    cleanupBindingIds.push(binding)
+    return { dt, rDept, binding, lDeptName: `B7R ${tag} ${STAMP}` }
+  }
+
+  it('A. GET / lists bindings with status and both names', async () => {
+    const { binding, lDeptName } = await seedBoundPair('list')
+    const res = await request(adminApp).get(`${BASE}/`)
+    expect(res.status).toBe(200)
+    const rows = (res.body.data?.bindings ?? res.body.bindings) as Array<Record<string, unknown>>
+    const mine = rows.find((r) => r.id === binding)
+    expect(mine).toBeTruthy()
+    expect(mine?.status).toBe('active')
+    expect(mine?.local_department_name).toBe(lDeptName)
+    expect(mine?.remote_department_name).toBe(lDeptName)
+  })
+
+  it('B. GET /suggestions is the §9 read-only surface (returns proposals, writes nothing)', async () => {
+    const dt = await dingtalkIntegration(orgId, 'sugg')
+    cleanupIntegrationIds.push(dt)
+    const lDept = await createLocalDepartment({ orgId, name: `B7R Sugg ${STAMP}` })
+    cleanupDeptIds.push(lDept.id)
+    const rDept = await dtDept(dt, `b7r-sugg-${STAMP}`, `B7R Sugg ${STAMP}`)
+    cleanupDeptIds.push(rDept)
+
+    const before = await query<{ n: number }>(`SELECT count(*)::int AS n FROM directory_department_bindings WHERE org_id = $1`, [orgId])
+    const res = await request(adminApp).get(`${BASE}/suggestions`)
+    expect(res.status).toBe(200)
+    const body = res.body.data ?? res.body
+    const mine = (body.suggestions as Array<Record<string, unknown>>).find((s) => s.remoteDepartmentId === rDept)
+    expect(mine?.localDepartmentId).toBe(lDept.id)
+    const after = await query<{ n: number }>(`SELECT count(*)::int AS n FROM directory_department_bindings WHERE org_id = $1`, [orgId])
+    expect(after.rows[0].n).toBe(before.rows[0].n) // read-only
+  })
+
+  it('C. POST /sweep stales on demand (audited, values-free counts); narrowed sweep leaves the other integration untouched', async () => {
+    const x = await seedBoundPair('swx')
+    const y = await seedBoundPair('swy')
+    await query(`UPDATE directory_departments SET is_active = false WHERE id IN ($1, $2)`, [x.rDept, y.rDept])
+
+    // narrowed to X — the exact post-sync-hook scope
+    const res = await request(adminApp).post(`${BASE}/sweep`).send({ remoteIntegrationId: x.dt })
+    expect(res.status).toBe(200)
+    const out = res.body.data ?? res.body
+    expect(out.staled).toBe(1)
+    const sx = await query<{ status: string }>(`SELECT status FROM directory_department_bindings WHERE id = $1`, [x.binding])
+    const sy = await query<{ status: string }>(`SELECT status FROM directory_department_bindings WHERE id = $1`, [y.binding])
+    expect(sx.rows[0].status).toBe('stale')
+    expect(sy.rows[0].status).toBe('active') // narrowed out
+    expect(await sweepAuditCount()).toBe(1)
+
+    // full-org retry catches Y too
+    const res2 = await request(adminApp).post(`${BASE}/sweep`).send({})
+    expect((res2.body.data ?? res2.body).staled).toBe(1)
+    expect(await sweepAuditCount()).toBe(2)
+  })
+
+  it('D. POST /sweep validations reject without sweeping or auditing: unlisted field / non-UUID / cross-org', async () => {
+    const { rDept, binding } = await seedBoundPair('val')
+    await query(`UPDATE directory_departments SET is_active = false WHERE id = $1`, [rDept])
+
+    const bad1 = await request(adminApp).post(`${BASE}/sweep`).send({ orgId: 'evil' })
+    expect(bad1.status).toBe(400)
+    const bad2 = await request(adminApp).post(`${BASE}/sweep`).send({ remoteIntegrationId: 'nope' })
+    expect(bad2.status).toBe(400)
+    const otherOrg = `b7r-other-${STAMP}`
+    cleanupOrgIds.push(otherOrg)
+    const foreign = await dingtalkIntegration(otherOrg, 'xorg')
+    const bad3 = await request(adminApp).post(`${BASE}/sweep`).send({ remoteIntegrationId: foreign })
+    expect(bad3.status).toBe(404)
+
+    const s = await query<{ status: string }>(`SELECT status FROM directory_department_bindings WHERE id = $1`, [binding])
+    expect(s.rows[0].status).toBe('active') // nothing swept
+    expect(await sweepAuditCount()).toBe(0) // nothing audited
+  })
+
+  it('E. non-admin: 403 on list, suggestions, and sweep (real RBAC path)', async () => {
+    const r1 = await request(nonAdminApp).get(`${BASE}/`)
+    const r2 = await request(nonAdminApp).get(`${BASE}/suggestions`)
+    const r3 = await request(nonAdminApp).post(`${BASE}/sweep`).send({ remoteIntegrationId: randomUUID() })
+    expect(r1.status).toBe(403)
+    expect(r2.status).toBe(403)
+    expect(r3.status).toBe(403)
+  })
+})

--- a/packages/core-backend/tests/integration/directory-binding-reconciliation.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-binding-reconciliation.db.test.ts
@@ -31,6 +31,8 @@ import {
  *   - make the sweep ALSO archive the local department (inject) → A reds (the headline pin).
  *   - inject an INSERT of the suggested (local, remote) binding inside suggest → E reds
  *     (count/fingerprint/pair-absence all fail — proves the zero-write pin is load-bearing).
+ *   - drop suggest's `rd.provider = ri.provider` predicate → I reds (mislabeled local child under
+ *     a dingtalk integration surfaces as a remote proposal).
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -294,6 +296,51 @@ describeIfDatabase('Canonical Org MVP — B7 suggest-only reconciliation (real D
     expect(await sweepStaleDepartmentBindings(org, { remoteIntegrationId: dtX })).toEqual({ staled: 1, healed: 0 })
     expect(await bindingStatus(bX)).toBe('stale')
     expect(await bindingStatus(bY)).toBe('active') // narrowed out — the sync hook's exact scope
+  })
+
+  it('I. read-boundary provider integrity: a mislabeled provider=local child under an active dingtalk integration is never a remote proposal', async () => {
+    // B4 only rejects this shape when a BINDING is applied. The suggest surface is a separate
+    // read boundary: a raw/malformed directory_departments row (provider='local' under dingtalk)
+    // must not appear in suggestions / ambiguous / unmatched. Positive control: a correctly
+    // labeled dingtalk sibling with a unique local name match still surfaces as a suggestion.
+    // Load-bearing: deleting ONLY `rd.provider = ri.provider` from the suggest JOIN reds this test.
+    const org = orgId('malformed-child')
+    seededOrgIds.push(org)
+    await getOrCreateLocalIntegration(org)
+    const dt = await dingtalkIntegration(org, 'mf')
+
+    const malformed = await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, provider, external_department_id, name, is_active, raw)
+       VALUES ($1, 'local', $2, $3, true, '{}'::jsonb) RETURNING id`,
+      [dt, `mf-local-under-dt-${STAMP}`, `Mislabeled ${STAMP}`],
+    )
+    const malformedId = malformed.rows[0].id
+
+    // Same name on the local side would otherwise make this an appliable unique-name suggestion
+    // if the mislabeled child were accepted as a remote row.
+    await createLocalDepartment({ orgId: org, name: `Mislabeled ${STAMP}` })
+
+    const live = await createLocalDepartment({ orgId: org, name: `Healthy ${STAMP}` })
+    const rHealthy = await dtDept(dt, `mf-healthy-${STAMP}`, `Healthy ${STAMP}`)
+
+    const res = await suggestDepartmentBindings(org)
+    const allRemoteIds = [
+      ...res.suggestions.map((s) => s.remoteDepartmentId),
+      ...res.ambiguous.map((a) => a.remoteDepartmentId),
+      ...res.unmatched.map((u) => u.remoteDepartmentId),
+    ]
+    expect(allRemoteIds).not.toContain(malformedId)
+    expect(res.suggestions).toEqual([
+      {
+        remoteIntegrationId: dt,
+        remoteDepartmentId: rHealthy,
+        remoteDepartmentName: `Healthy ${STAMP}`,
+        localDepartmentId: live.id,
+        matchStrategy: 'exact-name',
+      },
+    ])
+    expect(res.ambiguous).toHaveLength(0)
+    expect(res.unmatched.map((u) => u.remoteDepartmentId)).not.toContain(malformedId)
   })
 
   it('E. suggest is READ-ONLY zero-write: org binding count+fingerprint set unchanged; suggested pair never gains a row', async () => {

--- a/packages/core-backend/tests/integration/directory-binding-reconciliation.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-binding-reconciliation.db.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { getOrCreateLocalIntegration } from '../../src/directory/directory-sync'
+import { createLocalDepartment } from '../../src/directory/local-directory-org'
+import {
+  suggestDepartmentBindings,
+  sweepStaleDepartmentBindings,
+} from '../../src/directory/department-binding-reconciliation'
+
+/**
+ * Canonical Org MVP — B7 (external-provider reconciliation, SUGGEST-ONLY), §9 + §5.5, real DB.
+ *
+ *   A. HEADLINE (the B7 done-gate): the remote department disappears (archive-not-delete,
+ *      `is_active=false`) → the sweep marks the BINDING `stale` — and the LOCAL department stays
+ *      `is_active=true` with its row BYTE-IDENTICAL (jsonb-free column compare incl. updated_at):
+ *      a provider-side disappearance never damages the canonical local org.
+ *   B. HEAL + IDEMPOTENCE: remote reappears → binding back to `active`; a second sweep in the same
+ *      state changes nothing ({staled:0, healed:0}).
+ *   C. ORG SCOPE: another org's bindings are untouched by this org's sweep.
+ *   D. SUGGESTIONS (§9): a unique exact-name match (case/whitespace-insensitive) yields ONE
+ *      suggestion; a remote name matching TWO local departments yields an `ambiguous` entry that
+ *      is deliberately NOT appliable (no localDepartmentId) — never auto-matched; a no-match
+ *      remote is `unmatched`; an ALREADY-BOUND remote is excluded entirely.
+ *   E. SUGGEST IS READ-ONLY: binding rows byte-identical before/after the call.
+ *
+ * Load-bearing mutations (out-of-band, each reds this file):
+ *   - drop the sweep's `rd.is_active = false` predicate → B reds (a healthy binding gets staled).
+ *   - auto-pick the first candidate on ambiguity     → D reds (ambiguous becomes a suggestion).
+ *   - make the sweep ALSO archive the local department (inject) → A reds (the headline pin).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+const orgId = (suffix: string): string => `b7-${STAMP}-${suffix}`
+
+async function dingtalkIntegration(org: string, tag: string): Promise<string> {
+  const r = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config)
+     VALUES ($1, 'dingtalk', $2, 'active', $3, '{}'::jsonb) RETURNING id`,
+    [org, `DT b7 ${tag}`, `corp-b7-${STAMP}-${tag}`],
+  )
+  return r.rows[0].id
+}
+async function dtDept(integrationId: string, extId: string, name: string): Promise<string> {
+  const r = await query<{ id: string }>(
+    `INSERT INTO directory_departments (integration_id, provider, external_department_id, name, is_active, raw)
+     VALUES ($1, 'dingtalk', $2, $3, true, '{}'::jsonb) RETURNING id`,
+    [integrationId, extId, name],
+  )
+  return r.rows[0].id
+}
+async function bind(org: string, localInt: string, localDept: string, remoteInt: string, remoteDept: string): Promise<string> {
+  const r = await query<{ id: string }>(
+    `INSERT INTO directory_department_bindings
+       (org_id, local_integration_id, local_department_id, local_provider,
+        remote_integration_id, remote_department_id, remote_provider, status)
+     VALUES ($1, $2, $3, 'local', $4, $5, 'dingtalk', 'active') RETURNING id`,
+    [org, localInt, localDept, remoteInt, remoteDept],
+  )
+  return r.rows[0].id
+}
+async function bindingStatus(id: string): Promise<string> {
+  const r = await query<{ status: string }>(`SELECT status FROM directory_department_bindings WHERE id = $1`, [id])
+  return r.rows[0].status
+}
+/** Whole-row fingerprint of a department (every column) — byte-level "untouched" evidence. */
+async function deptFingerprint(id: string): Promise<string> {
+  const r = await query<{ fp: string }>(`SELECT to_jsonb(d)::text AS fp FROM directory_departments d WHERE d.id = $1`, [id])
+  return r.rows[0].fp
+}
+
+describeIfDatabase('Canonical Org MVP — B7 suggest-only reconciliation (real DB)', () => {
+  const seededOrgIds: string[] = []
+
+  afterEach(async () => {
+    for (const org of seededOrgIds.splice(0)) {
+      await query(`DELETE FROM directory_department_bindings WHERE org_id = $1`, [org])
+      await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [org])
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  async function boundFixture(tag: string) {
+    const org = orgId(tag)
+    seededOrgIds.push(org)
+    const local = await getOrCreateLocalIntegration(org)
+    const lDept = await createLocalDepartment({ orgId: org, name: `Engineering ${tag}` })
+    const dt = await dingtalkIntegration(org, tag)
+    const rDept = await dtDept(dt, `b7:${STAMP}:${tag}`, `Engineering ${tag}`)
+    const binding = await bind(org, local.id, lDept.id, dt, rDept)
+    return { org, localInt: local.id, lDept: lDept.id, dt, rDept, binding }
+  }
+
+  it('A. HEADLINE: remote disappearance stales the BINDING only — the local department row stays byte-identical and active', async () => {
+    const { org, lDept, rDept, binding } = await boundFixture('headline')
+    const before = await deptFingerprint(lDept)
+
+    await query(`UPDATE directory_departments SET is_active = false, updated_at = NOW() WHERE id = $1`, [rDept])
+    const sweep = await sweepStaleDepartmentBindings(org)
+    expect(sweep).toEqual({ staled: 1, healed: 0 })
+    expect(await bindingStatus(binding)).toBe('stale')
+
+    // the LOCAL department is untouched — active, and the WHOLE ROW byte-identical
+    const after = await deptFingerprint(lDept)
+    expect(after).toBe(before)
+    const active = await query<{ is_active: boolean }>(`SELECT is_active FROM directory_departments WHERE id = $1`, [lDept])
+    expect(active.rows[0].is_active).toBe(true)
+  })
+
+  it('B. heal + idempotence: remote reappears → binding active again; a settled sweep changes nothing', async () => {
+    const { org, rDept, binding } = await boundFixture('heal')
+    await query(`UPDATE directory_departments SET is_active = false WHERE id = $1`, [rDept])
+    expect(await sweepStaleDepartmentBindings(org)).toEqual({ staled: 1, healed: 0 })
+
+    await query(`UPDATE directory_departments SET is_active = true WHERE id = $1`, [rDept])
+    expect(await sweepStaleDepartmentBindings(org)).toEqual({ staled: 0, healed: 1 })
+    expect(await bindingStatus(binding)).toBe('active')
+
+    expect(await sweepStaleDepartmentBindings(org)).toEqual({ staled: 0, healed: 0 }) // idempotent
+  })
+
+  it('C. org scope: sweeping org A leaves org B bindings untouched', async () => {
+    const a = await boundFixture('scope-A')
+    const b = await boundFixture('scope-B')
+    await query(`UPDATE directory_departments SET is_active = false WHERE id = $1`, [a.rDept])
+    await query(`UPDATE directory_departments SET is_active = false WHERE id = $1`, [b.rDept])
+
+    expect(await sweepStaleDepartmentBindings(a.org)).toEqual({ staled: 1, healed: 0 })
+    expect(await bindingStatus(a.binding)).toBe('stale')
+    expect(await bindingStatus(b.binding)).toBe('active') // B's org was not swept
+  })
+
+  it('D. suggestions: unique name → suggestion; duplicate local names → ambiguous (never auto-appliable); no match → unmatched; bound remotes excluded', async () => {
+    const org = orgId('suggest')
+    seededOrgIds.push(org)
+    const local = await getOrCreateLocalIntegration(org)
+    const dt = await dingtalkIntegration(org, 'sg')
+
+    const lUnique = await createLocalDepartment({ orgId: org, name: 'Finance' })
+    await createLocalDepartment({ orgId: org, name: 'Sales' })
+    await createLocalDepartment({ orgId: org, name: 'sales ' }) // second candidate after case/trim folding
+    const lBound = await createLocalDepartment({ orgId: org, name: 'Ops' })
+
+    const rFinance = await dtDept(dt, `sg-fin-${STAMP}`, ' finance ') // case+whitespace insensitive match
+    const rSales = await dtDept(dt, `sg-sales-${STAMP}`, 'Sales') // TWO local candidates → ambiguous
+    const rGhost = await dtDept(dt, `sg-ghost-${STAMP}`, 'Warehouse') // no local counterpart
+    const rBound = await dtDept(dt, `sg-ops-${STAMP}`, 'Ops')
+    await bind(org, local.id, lBound.id, dt, rBound) // already bound → excluded from proposals
+
+    const res = await suggestDepartmentBindings(org)
+    expect(res.suggestions).toEqual([
+      {
+        remoteIntegrationId: dt,
+        remoteDepartmentId: rFinance,
+        remoteDepartmentName: ' finance ',
+        localDepartmentId: lUnique.id,
+        matchStrategy: 'exact-name',
+      },
+    ])
+    expect(res.ambiguous).toHaveLength(1)
+    expect(res.ambiguous[0].remoteDepartmentId).toBe(rSales)
+    expect(res.ambiguous[0].candidateLocalDepartmentIds).toHaveLength(2)
+    expect(res.ambiguous[0].reason).toBe('ambiguous-name')
+    expect((res.ambiguous[0] as Record<string, unknown>).localDepartmentId).toBeUndefined() // NOT appliable
+    expect(res.unmatched).toEqual([
+      { remoteIntegrationId: dt, remoteDepartmentId: rGhost, remoteDepartmentName: 'Warehouse' },
+    ])
+    expect([...res.suggestions, ...res.ambiguous, ...res.unmatched].map((e) => e.remoteDepartmentId)).not.toContain(rBound)
+  })
+
+  it('E. suggest is READ-ONLY: binding rows byte-identical before and after', async () => {
+    const { org, binding } = await boundFixture('ro')
+    const before = await query<{ fp: string }>(`SELECT to_jsonb(b)::text AS fp FROM directory_department_bindings b WHERE id = $1`, [binding])
+    await suggestDepartmentBindings(org)
+    const after = await query<{ fp: string }>(`SELECT to_jsonb(b)::text AS fp FROM directory_department_bindings b WHERE id = $1`, [binding])
+    expect(after.rows[0].fp).toBe(before.rows[0].fp)
+  })
+})

--- a/packages/core-backend/tests/integration/directory-binding-reconciliation.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-binding-reconciliation.db.test.ts
@@ -21,12 +21,16 @@ import {
  *      suggestion; a remote name matching TWO local departments yields an `ambiguous` entry that
  *      is deliberately NOT appliable (no localDepartmentId) — never auto-matched; a no-match
  *      remote is `unmatched`; an ALREADY-BOUND remote is excluded entirely.
- *   E. SUGGEST IS READ-ONLY: binding rows byte-identical before/after the call.
+ *   E. SUGGEST IS READ-ONLY (zero-write): org-scoped binding count + complete binding fingerprint
+ *      set are byte-identical before/after; the exact suggested local/remote pair has no binding
+ *      row either before or after (suggest never creates a binding for its own proposal).
  *
  * Load-bearing mutations (out-of-band, each reds this file):
  *   - drop the sweep's `rd.is_active = false` predicate → B reds (a healthy binding gets staled).
  *   - auto-pick the first candidate on ambiguity     → D reds (ambiguous becomes a suggestion).
  *   - make the sweep ALSO archive the local department (inject) → A reds (the headline pin).
+ *   - inject an INSERT of the suggested (local, remote) binding inside suggest → E reds
+ *     (count/fingerprint/pair-absence all fail — proves the zero-write pin is load-bearing).
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -67,6 +71,31 @@ async function bindingStatus(id: string): Promise<string> {
 async function deptFingerprint(id: string): Promise<string> {
   const r = await query<{ fp: string }>(`SELECT to_jsonb(d)::text AS fp FROM directory_departments d WHERE d.id = $1`, [id])
   return r.rows[0].fp
+}
+
+/** Org-scoped binding write surface: count + ordered whole-row fingerprints (complete set). */
+async function orgBindingsSnapshot(org: string): Promise<{ count: number; fingerprints: string[] }> {
+  const r = await query<{ fp: string }>(
+    `SELECT to_jsonb(b)::text AS fp
+       FROM directory_department_bindings b
+      WHERE b.org_id = $1
+      ORDER BY b.id ASC`,
+    [org],
+  )
+  return { count: r.rows.length, fingerprints: r.rows.map((row) => row.fp) }
+}
+
+/** Whether a binding exists for the exact (local, remote) department pair. */
+async function bindingExistsForPair(org: string, localDeptId: string, remoteDeptId: string): Promise<boolean> {
+  const r = await query<{ n: number }>(
+    `SELECT count(*)::int AS n
+       FROM directory_department_bindings
+      WHERE org_id = $1
+        AND local_department_id = $2
+        AND remote_department_id = $3`,
+    [org, localDeptId, remoteDeptId],
+  )
+  return (r.rows[0]?.n ?? 0) > 0
 }
 
 describeIfDatabase('Canonical Org MVP — B7 suggest-only reconciliation (real DB)', () => {
@@ -150,6 +179,11 @@ describeIfDatabase('Canonical Org MVP — B7 suggest-only reconciliation (real D
     const rBound = await dtDept(dt, `sg-ops-${STAMP}`, 'Ops')
     await bind(org, local.id, lBound.id, dt, rBound) // already bound → excluded from proposals
 
+    // Zero-write baseline for the unique-name pair (proved load-bearing in E; asserted here so the
+    // suggestion fixture itself cannot silently apply the proposed binding).
+    expect(await bindingExistsForPair(org, lUnique.id, rFinance)).toBe(false)
+    const beforeSnap = await orgBindingsSnapshot(org)
+
     const res = await suggestDepartmentBindings(org)
     expect(res.suggestions).toEqual([
       {
@@ -169,6 +203,13 @@ describeIfDatabase('Canonical Org MVP — B7 suggest-only reconciliation (real D
       { remoteIntegrationId: dt, remoteDepartmentId: rGhost, remoteDepartmentName: 'Warehouse' },
     ])
     expect([...res.suggestions, ...res.ambiguous, ...res.unmatched].map((e) => e.remoteDepartmentId)).not.toContain(rBound)
+
+    // Suggest never materializes the unique-name proposal: exact pair still unbound, and the full
+    // org binding surface (count + ordered whole-row fingerprints) is unchanged.
+    expect(await bindingExistsForPair(org, lUnique.id, rFinance)).toBe(false)
+    const afterSnap = await orgBindingsSnapshot(org)
+    expect(afterSnap.count).toBe(beforeSnap.count)
+    expect(afterSnap.fingerprints).toEqual(beforeSnap.fingerprints)
   })
 
   it('F. candidate guards (gate P3): an ARCHIVED local dept and a dept under an INACTIVE local integration never count as candidates', async () => {
@@ -255,11 +296,39 @@ describeIfDatabase('Canonical Org MVP — B7 suggest-only reconciliation (real D
     expect(await bindingStatus(bY)).toBe('active') // narrowed out — the sync hook's exact scope
   })
 
-  it('E. suggest is READ-ONLY: binding rows byte-identical before and after', async () => {
-    const { org, binding } = await boundFixture('ro')
-    const before = await query<{ fp: string }>(`SELECT to_jsonb(b)::text AS fp FROM directory_department_bindings b WHERE id = $1`, [binding])
-    await suggestDepartmentBindings(org)
-    const after = await query<{ fp: string }>(`SELECT to_jsonb(b)::text AS fp FROM directory_department_bindings b WHERE id = $1`, [binding])
-    expect(after.rows[0].fp).toBe(before.rows[0].fp)
+  it('E. suggest is READ-ONLY zero-write: org binding count+fingerprint set unchanged; suggested pair never gains a row', async () => {
+    // Unique-name fixture only (no pre-bound row): the zero-write pin must cover the exact
+    // suggested local/remote pair, not merely leave an unrelated already-bound row untouched.
+    const org = orgId('ro-pair')
+    seededOrgIds.push(org)
+    const local = await getOrCreateLocalIntegration(org)
+    const dt = await dingtalkIntegration(org, 'ro')
+    const lDept = await createLocalDepartment({ orgId: org, name: `Treasury ${STAMP}` })
+    const rDept = await dtDept(dt, `ro-treas-${STAMP}`, `Treasury ${STAMP}`)
+
+    expect(await bindingExistsForPair(org, lDept.id, rDept)).toBe(false)
+    const before = await orgBindingsSnapshot(org)
+    expect(before.count).toBe(0)
+
+    const res = await suggestDepartmentBindings(org)
+    expect(res.suggestions).toEqual([
+      {
+        remoteIntegrationId: dt,
+        remoteDepartmentId: rDept,
+        remoteDepartmentName: `Treasury ${STAMP}`,
+        localDepartmentId: lDept.id,
+        matchStrategy: 'exact-name',
+      },
+    ])
+
+    // Complete surface: count, full ordered fingerprint set, and the exact pair row.
+    // Injecting an INSERT of (lDept, rDept) inside suggestDepartmentBindings reds all three.
+    expect(await bindingExistsForPair(org, lDept.id, rDept)).toBe(false)
+    const after = await orgBindingsSnapshot(org)
+    expect(after.count).toBe(0)
+    expect(after.count).toBe(before.count)
+    expect(after.fingerprints).toEqual(before.fingerprints)
+    // local integration id is live and unused by the write surface — silence unused-binding noise
+    expect(local.id).toBeTruthy()
   })
 })

--- a/packages/core-backend/tests/integration/directory-binding-reconciliation.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-binding-reconciliation.db.test.ts
@@ -220,6 +220,20 @@ describeIfDatabase('Canonical Org MVP — B7 suggest-only reconciliation (real D
     await query(`UPDATE directory_integrations SET status = 'active' WHERE id = $1`, [dt])
     expect(await sweepStaleDepartmentBindings(org)).toEqual({ staled: 1, healed: 0 })
     expect(await bindingStatus(binding)).toBe('stale')
+
+    // Gate P2 (restack round): the HEAL direction must honor the same freeze — 'nor heal until
+    // live again'. Revive the remote dept (heal would now fire), then disable the integration:
+    // the stale binding must NOT heal off a frozen snapshot. Neutering the healed-UPDATE's
+    // ri.status='active' predicate turns exactly this leg red.
+    await query(`UPDATE directory_departments SET is_active = true WHERE id = $1`, [rDept])
+    await query(`UPDATE directory_integrations SET status = 'disabled' WHERE id = $1`, [dt])
+    expect(await sweepStaleDepartmentBindings(org)).toEqual({ staled: 0, healed: 0 }) // frozen: no heal either
+    expect(await bindingStatus(binding)).toBe('stale')
+
+    // positive control: re-enable → the SAME sweep heals it back to active
+    await query(`UPDATE directory_integrations SET status = 'active' WHERE id = $1`, [dt])
+    expect(await sweepStaleDepartmentBindings(org)).toEqual({ staled: 0, healed: 1 })
+    expect(await bindingStatus(binding)).toBe('active')
   })
 
   it('H. Q6 narrowing: a sweep narrowed to integration X leaves integration Y bindings untouched in the SAME org', async () => {

--- a/packages/core-backend/tests/integration/directory-binding-reconciliation.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-binding-reconciliation.db.test.ts
@@ -207,6 +207,40 @@ describeIfDatabase('Canonical Org MVP — B7 suggest-only reconciliation (real D
     expect(res.ambiguous).toHaveLength(0)
   })
 
+  it('G. remote-INTEGRATION guard (owner #4436): a disabled remote integration is frozen — its bindings neither stale nor heal until re-enabled', async () => {
+    const { org, dt, rDept, binding } = await boundFixture('ig')
+    // archive the remote dept AND disable the whole remote integration
+    await query(`UPDATE directory_departments SET is_active = false WHERE id = $1`, [rDept])
+    await query(`UPDATE directory_integrations SET status = 'disabled' WHERE id = $1`, [dt])
+
+    expect(await sweepStaleDepartmentBindings(org)).toEqual({ staled: 0, healed: 0 }) // frozen: no churn
+    expect(await bindingStatus(binding)).toBe('active')
+
+    // positive control: re-enable the integration → the SAME sweep now stales the binding
+    await query(`UPDATE directory_integrations SET status = 'active' WHERE id = $1`, [dt])
+    expect(await sweepStaleDepartmentBindings(org)).toEqual({ staled: 1, healed: 0 })
+    expect(await bindingStatus(binding)).toBe('stale')
+  })
+
+  it('H. Q6 narrowing: a sweep narrowed to integration X leaves integration Y bindings untouched in the SAME org', async () => {
+    const org = orgId('narrow')
+    seededOrgIds.push(org)
+    const local = await getOrCreateLocalIntegration(org)
+    const lD1 = await createLocalDepartment({ orgId: org, name: 'N1' })
+    const lD2 = await createLocalDepartment({ orgId: org, name: 'N2' })
+    const dtX = await dingtalkIntegration(org, 'nx')
+    const dtY = await dingtalkIntegration(org, 'ny')
+    const rX = await dtDept(dtX, `n-x-${STAMP}`, 'N1')
+    const rY = await dtDept(dtY, `n-y-${STAMP}`, 'N2')
+    const bX = await bind(org, local.id, lD1.id, dtX, rX)
+    const bY = await bind(org, local.id, lD2.id, dtY, rY)
+    await query(`UPDATE directory_departments SET is_active = false WHERE id IN ($1, $2)`, [rX, rY])
+
+    expect(await sweepStaleDepartmentBindings(org, { remoteIntegrationId: dtX })).toEqual({ staled: 1, healed: 0 })
+    expect(await bindingStatus(bX)).toBe('stale')
+    expect(await bindingStatus(bY)).toBe('active') // narrowed out — the sync hook's exact scope
+  })
+
   it('E. suggest is READ-ONLY: binding rows byte-identical before and after', async () => {
     const { org, binding } = await boundFixture('ro')
     const before = await query<{ fp: string }>(`SELECT to_jsonb(b)::text AS fp FROM directory_department_bindings b WHERE id = $1`, [binding])

--- a/packages/core-backend/tests/integration/directory-binding-reconciliation.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-binding-reconciliation.db.test.ts
@@ -171,6 +171,42 @@ describeIfDatabase('Canonical Org MVP — B7 suggest-only reconciliation (real D
     expect([...res.suggestions, ...res.ambiguous, ...res.unmatched].map((e) => e.remoteDepartmentId)).not.toContain(rBound)
   })
 
+  it('F. candidate guards (gate P3): an ARCHIVED local dept and a dept under an INACTIVE local integration never count as candidates', async () => {
+    const org = orgId('guards')
+    seededOrgIds.push(org)
+    const local = await getOrCreateLocalIntegration(org)
+    const dt = await dingtalkIntegration(org, 'gd')
+
+    // (a) archived local dept with a matching name → remote must land UNMATCHED, never a suggestion
+    const archived = await createLocalDepartment({ orgId: org, name: 'Legal' })
+    await query(`UPDATE directory_departments SET is_active = false WHERE id = $1`, [archived.id])
+    const rLegal = await dtDept(dt, `gd-legal-${STAMP}`, 'Legal')
+
+    // (b) a matching-name dept under an INACTIVE local integration → must not count either
+    const inactiveLocal = await query<{ id: string }>(
+      `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config)
+       VALUES ($1, 'local', 'Local organization (old)', 'inactive', $2, '{"mode":"editable","source":"local"}'::jsonb)
+       RETURNING id`,
+      [org, `local:${org}`],
+    )
+    await query(
+      `INSERT INTO directory_departments (integration_id, provider, external_department_id, name, is_active, raw)
+       VALUES ($1, 'local', $2, 'HR', true, '{}'::jsonb)`,
+      [inactiveLocal.rows[0].id, `local:old-hr-${STAMP}`],
+    )
+    const rHr = await dtDept(dt, `gd-hr-${STAMP}`, 'HR')
+
+    // positive control in the same fixture: a live dept under the ACTIVE local integration matches
+    const live = await createLocalDepartment({ orgId: org, name: 'Live' })
+    const rLive = await dtDept(dt, `gd-live-${STAMP}`, 'Live')
+
+    const res = await suggestDepartmentBindings(org)
+    expect(res.unmatched.map((u) => u.remoteDepartmentId)).toEqual(expect.arrayContaining([rLegal, rHr]))
+    expect(res.suggestions.map((s) => s.remoteDepartmentId)).toEqual([rLive])
+    expect(res.suggestions[0].localDepartmentId).toBe(live.id)
+    expect(res.ambiguous).toHaveLength(0)
+  })
+
   it('E. suggest is READ-ONLY: binding rows byte-identical before and after', async () => {
     const { org, binding } = await boundFixture('ro')
     const before = await query<{ fp: string }>(`SELECT to_jsonb(b)::text AS fp FROM directory_department_bindings b WHERE id = $1`, [binding])

--- a/packages/core-backend/tests/integration/directory-binding-sync-hook.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-binding-sync-hook.db.test.ts
@@ -17,6 +17,7 @@ vi.mock('../../src/integrations/dingtalk/client', () => ({
   getDingTalkUserDetail: clientMocks.getDingTalkUserDetail,
 }))
 
+import { Logger } from '../../src/core/logger'
 import { query } from '../../src/db/pg'
 import { createDirectoryIntegration, getOrCreateLocalIntegration, syncDirectoryIntegration } from '../../src/directory/directory-sync'
 import { createLocalDepartment } from '../../src/directory/local-directory-org'
@@ -29,10 +30,12 @@ import { createLocalDepartment } from '../../src/directory/local-directory-org'
  *      the binding is `stale` — with NO admin action. NARROWING: a second dingtalk integration's
  *      binding (whose remote dept is also archived) is left untouched by THIS integration's sync —
  *      the hook is scoped by `remoteIntegrationId` exactly as ruled.
- *   B. FAILURE ISOLATION: with the bindings table renamed away, the SAME sync still SUCCEEDS
- *      (returns a completed run; last_success stamped) — a sweep failure must never fail (or
- *      fail-mark) the sync that just committed. The admin `POST /department-bindings/sweep`
- *      endpoint is the retry path (proven in directory-binding-admin-routes.db.test.ts).
+ *   B. FAILURE ISOLATION + VALUES-FREE WARN: with the bindings table renamed away, the SAME sync
+ *      still SUCCEEDS (completed run; last_error NULL) AND the post-sync catch emits a bounded
+ *      Logger.warn (reason/errorClass + integrationId only) — raw relation/error.message text
+ *      must not appear. Restoring readErrorMessage interpolation in the catch reds this pin.
+ *      The admin `POST /department-bindings/sweep` endpoint is the retry path
+ *      (proven in directory-binding-admin-routes.db.test.ts).
  *
  *   Note on the table-rename seam (gate P3): this deliberately breaks the sweep at the SQL
  *   catalog, not via a production test-only injection point. A narrower production seam would
@@ -141,7 +144,7 @@ describeIfDatabase('B7 Q6 — post-sync auto-sweep hook (real sync, mocked provi
     expect(await bindingStatus(bindingB)).toBe('active')
   })
 
-  it('B. failure isolation: a broken sweep never fails the sync that just committed', async () => {
+  it('B. failure isolation + values-free warn: a broken sweep never fails the sync and logs no raw error text', async () => {
     const intC = await createDirectoryIntegration({
       name: `b7q6-C-${TS}`,
       corpId: `b7q6-corpC-${TS}`,
@@ -151,7 +154,9 @@ describeIfDatabase('B7 Q6 — post-sync auto-sweep hook (real sync, mocked provi
     })
     cleanupIntegrationIds.push(intC.id)
 
-    await query(`ALTER TABLE directory_department_bindings RENAME TO directory_department_bindings_hidden_${TS}`)
+    const hidden = `directory_department_bindings_hidden_${TS}`
+    const warnSpy = vi.spyOn(Logger.prototype, 'warn')
+    await query(`ALTER TABLE directory_department_bindings RENAME TO ${hidden}`)
     try {
       const result = await syncDirectoryIntegration(intC.id, `system:b7q6c-${TS}`)
       expect(result.run.status).toBe('completed') // the sync is UNAFFECTED by the sweep failure
@@ -160,8 +165,31 @@ describeIfDatabase('B7 Q6 — post-sync auto-sweep hook (real sync, mocked provi
         [intC.id],
       )
       expect(row.rows[0].last_error).toBeNull() // not fail-marked either
+
+      // Values-free warn: bounded reason/errorClass + integrationId only. Raw relation names and
+      // adapter message text (e.g. "relation ... does not exist") must not appear. Mutating the
+      // catch to interpolate readErrorMessage(error) reds the content pins below first.
+      const sweepWarns = warnSpy.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('Department-binding sweep after successful sync failed'),
+      )
+      expect(sweepWarns.length).toBeGreaterThanOrEqual(1)
+      const [message, meta] = sweepWarns[0] as [string, Record<string, unknown>]
+      const serialized = JSON.stringify({ message, meta })
+      // Content pins first: raw DB/adapter text must never reach the log surface.
+      expect(serialized).not.toContain('directory_department_bindings')
+      expect(serialized).not.toContain(hidden)
+      expect(serialized.toLowerCase()).not.toContain('does not exist')
+      expect(message).not.toMatch(/relation|undefined_table|42P01/i)
+      // Shape pin: bounded meta only (integrationId + reason + errorClass).
+      expect(meta).toMatchObject({
+        integrationId: intC.id,
+        reason: 'sweep_failed',
+      })
+      expect(typeof meta.errorClass).toBe('string')
+      expect(String(meta.errorClass).length).toBeGreaterThan(0)
     } finally {
-      await query(`ALTER TABLE directory_department_bindings_hidden_${TS} RENAME TO directory_department_bindings`)
+      warnSpy.mockRestore()
+      await query(`ALTER TABLE ${hidden} RENAME TO directory_department_bindings`)
     }
   })
 })

--- a/packages/core-backend/tests/integration/directory-binding-sync-hook.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-binding-sync-hook.db.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../src/integrations/dingtalk/client', () => ({
 
 import { Logger } from '../../src/core/logger'
 import { query } from '../../src/db/pg'
+import * as departmentBindingReconciliation from '../../src/directory/department-binding-reconciliation'
 import { createDirectoryIntegration, getOrCreateLocalIntegration, syncDirectoryIntegration } from '../../src/directory/directory-sync'
 import { createLocalDepartment } from '../../src/directory/local-directory-org'
 
@@ -30,19 +31,13 @@ import { createLocalDepartment } from '../../src/directory/local-directory-org'
  *      the binding is `stale` — with NO admin action. NARROWING: a second dingtalk integration's
  *      binding (whose remote dept is also archived) is left untouched by THIS integration's sync —
  *      the hook is scoped by `remoteIntegrationId` exactly as ruled.
- *   B. FAILURE ISOLATION + VALUES-FREE WARN: with the bindings table renamed away, the SAME sync
- *      still SUCCEEDS (completed run; last_error NULL) AND the post-sync catch emits a bounded
- *      Logger.warn (reason/errorClass + integrationId only) — raw relation/error.message text
- *      must not appear. Restoring readErrorMessage interpolation in the catch reds this pin.
- *      The admin `POST /department-bindings/sweep` endpoint is the retry path
- *      (proven in directory-binding-admin-routes.db.test.ts).
- *
- *   Note on the table-rename seam (gate P3): this deliberately breaks the sweep at the SQL
- *   catalog, not via a production test-only injection point. A narrower production seam would
- *   alter shipping behavior or require a non-trivial test hook; we retain rename because
- *   `vitest.integration.config.ts` sets `fileParallelism: false` + `maxConcurrency: 1`, so
- *   files share one Postgres serially and the rename cannot race another suite mid-file.
- *   The rename is always restored in `finally`.
+ *   B. FAILURE ISOLATION + VALUES-FREE WARN: the post-sync sweep is forced to throw (Error with a
+ *      unique sensitive name sentinel + PG-relation-like message) while the REAL sync still
+ *      SUCCEEDS (completed run; last_error NULL). Logger.warn meta is ONLY
+ *      { integrationId, reason: 'sweep_failed' } — serialized warn args must exclude the name
+ *      sentinel, relation text, and raw message. Restoring readErrorMessage(error) into the
+ *      message OR error.name into meta reds this pin. Admin `POST /department-bindings/sweep`
+ *      is the retry path (proven in directory-binding-admin-routes.db.test.ts).
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
@@ -154,9 +149,16 @@ describeIfDatabase('B7 Q6 — post-sync auto-sweep hook (real sync, mocked provi
     })
     cleanupIntegrationIds.push(intC.id)
 
-    const hidden = `directory_department_bindings_hidden_${TS}`
+    // Force the post-sync sweep to throw with attacker/adapter-shaped fields: a UNIQUE sensitive
+    // Error.name sentinel plus relation-like message text. Production catch must log neither.
+    const nameSentinel = `SENSITIVE_SWEEP_ERR_NAME_${TS}_corp_secret_token`
+    const relationNeedle = 'directory_department_bindings'
+    const forced = new Error(`relation "${relationNeedle}" does not exist`)
+    forced.name = nameSentinel
+    const sweepSpy = vi
+      .spyOn(departmentBindingReconciliation, 'sweepStaleDepartmentBindings')
+      .mockRejectedValue(forced)
     const warnSpy = vi.spyOn(Logger.prototype, 'warn')
-    await query(`ALTER TABLE directory_department_bindings RENAME TO ${hidden}`)
     try {
       const result = await syncDirectoryIntegration(intC.id, `system:b7q6c-${TS}`)
       expect(result.run.status).toBe('completed') // the sync is UNAFFECTED by the sweep failure
@@ -166,30 +168,31 @@ describeIfDatabase('B7 Q6 — post-sync auto-sweep hook (real sync, mocked provi
       )
       expect(row.rows[0].last_error).toBeNull() // not fail-marked either
 
-      // Values-free warn: bounded reason/errorClass + integrationId only. Raw relation names and
-      // adapter message text (e.g. "relation ... does not exist") must not appear. Mutating the
-      // catch to interpolate readErrorMessage(error) reds the content pins below first.
+      // Values-free warn: ONLY { integrationId, reason: 'sweep_failed' }. Serialized args must
+      // exclude Error.name sentinel, relation text, and raw message. Mutations restoring
+      // readErrorMessage(error) into the message OR error.name into meta red these pins.
       const sweepWarns = warnSpy.mock.calls.filter(
         (call) => typeof call[0] === 'string' && call[0].includes('Department-binding sweep after successful sync failed'),
       )
       expect(sweepWarns.length).toBeGreaterThanOrEqual(1)
       const [message, meta] = sweepWarns[0] as [string, Record<string, unknown>]
       const serialized = JSON.stringify({ message, meta })
-      // Content pins first: raw DB/adapter text must never reach the log surface.
-      expect(serialized).not.toContain('directory_department_bindings')
-      expect(serialized).not.toContain(hidden)
+      expect(serialized).not.toContain(nameSentinel)
+      expect(serialized).not.toContain(relationNeedle)
       expect(serialized.toLowerCase()).not.toContain('does not exist')
       expect(message).not.toMatch(/relation|undefined_table|42P01/i)
-      // Shape pin: bounded meta only (integrationId + reason + errorClass).
-      expect(meta).toMatchObject({
+      expect(meta).toEqual({
         integrationId: intC.id,
         reason: 'sweep_failed',
       })
-      expect(typeof meta.errorClass).toBe('string')
-      expect(String(meta.errorClass).length).toBeGreaterThan(0)
+      expect(meta).not.toHaveProperty('errorClass')
+      expect(meta).not.toHaveProperty('error')
+      expect(meta).not.toHaveProperty('stack')
+      expect(meta).not.toHaveProperty('code')
+      expect(sweepSpy).toHaveBeenCalled()
     } finally {
       warnSpy.mockRestore()
-      await query(`ALTER TABLE ${hidden} RENAME TO directory_department_bindings`)
+      sweepSpy.mockRestore()
     }
   })
 })

--- a/packages/core-backend/tests/integration/directory-binding-sync-hook.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-binding-sync-hook.db.test.ts
@@ -33,6 +33,13 @@ import { createLocalDepartment } from '../../src/directory/local-directory-org'
  *      (returns a completed run; last_success stamped) — a sweep failure must never fail (or
  *      fail-mark) the sync that just committed. The admin `POST /department-bindings/sweep`
  *      endpoint is the retry path (proven in directory-binding-admin-routes.db.test.ts).
+ *
+ *   Note on the table-rename seam (gate P3): this deliberately breaks the sweep at the SQL
+ *   catalog, not via a production test-only injection point. A narrower production seam would
+ *   alter shipping behavior or require a non-trivial test hook; we retain rename because
+ *   `vitest.integration.config.ts` sets `fileParallelism: false` + `maxConcurrency: 1`, so
+ *   files share one Postgres serially and the rename cannot race another suite mid-file.
+ *   The rename is always restored in `finally`.
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()

--- a/packages/core-backend/tests/integration/directory-binding-sync-hook.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-binding-sync-hook.db.test.ts
@@ -1,0 +1,160 @@
+import { afterAll, describe, expect, it, vi } from 'vitest'
+
+// Mocked DingTalk client (same pattern as directory-sync-orchestration.db.test.ts): the REAL
+// syncDirectoryIntegration pulls a synthetic (empty) tenant and applies it against real Postgres.
+const clientMocks = vi.hoisted(() => ({
+  fetchDingTalkAppAccessToken: vi.fn(),
+  listDingTalkDepartments: vi.fn(),
+  getDingTalkDepartmentDetail: vi.fn(),
+  listDingTalkDepartmentUsers: vi.fn(),
+  getDingTalkUserDetail: vi.fn(),
+}))
+vi.mock('../../src/integrations/dingtalk/client', () => ({
+  fetchDingTalkAppAccessToken: clientMocks.fetchDingTalkAppAccessToken,
+  listDingTalkDepartments: clientMocks.listDingTalkDepartments,
+  getDingTalkDepartmentDetail: clientMocks.getDingTalkDepartmentDetail,
+  listDingTalkDepartmentUsers: clientMocks.listDingTalkDepartmentUsers,
+  getDingTalkUserDetail: clientMocks.getDingTalkUserDetail,
+}))
+
+import { query } from '../../src/db/pg'
+import { createDirectoryIntegration, getOrCreateLocalIntegration, syncDirectoryIntegration } from '../../src/directory/directory-sync'
+import { createLocalDepartment } from '../../src/directory/local-directory-org'
+
+/**
+ * B7 Q6 (owner ruling) — the POST-SYNC auto-sweep hook, END-TO-END through the REAL sync:
+ *
+ *   A. A bound remote department disappears from the provider (empty pull → the sync's own absence
+ *      sweep marks it `is_active=false`) → after the SUCCESSFUL sync commit, the hook sweeps and
+ *      the binding is `stale` — with NO admin action. NARROWING: a second dingtalk integration's
+ *      binding (whose remote dept is also archived) is left untouched by THIS integration's sync —
+ *      the hook is scoped by `remoteIntegrationId` exactly as ruled.
+ *   B. FAILURE ISOLATION: with the bindings table renamed away, the SAME sync still SUCCEEDS
+ *      (returns a completed run; last_success stamped) — a sweep failure must never fail (or
+ *      fail-mark) the sync that just committed. The admin `POST /department-bindings/sweep`
+ *      endpoint is the retry path (proven in directory-binding-admin-routes.db.test.ts).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+clientMocks.fetchDingTalkAppAccessToken.mockResolvedValue(`b7q6-token-${TS}`)
+clientMocks.listDingTalkDepartments.mockResolvedValue([]) // EMPTY tenant — every seeded dept departs
+clientMocks.getDingTalkDepartmentDetail.mockResolvedValue({ deptManagerUserIdList: [] })
+clientMocks.listDingTalkDepartmentUsers.mockResolvedValue({ users: [], hasMore: false })
+clientMocks.getDingTalkUserDetail.mockResolvedValue({})
+
+async function dtDeptSeen(integrationId: string, extId: string, name: string): Promise<string> {
+  // last_seen_at in the PAST so the sync's absence sweep (`last_seen_at < syncTimestamp`) fires
+  const r = await query<{ id: string }>(
+    `INSERT INTO directory_departments (integration_id, provider, external_department_id, name, is_active, raw, last_seen_at)
+     VALUES ($1, 'dingtalk', $2, $3, true, '{}'::jsonb, NOW() - interval '1 hour') RETURNING id`,
+    [integrationId, extId, name],
+  )
+  return r.rows[0].id
+}
+async function bind(org: string, localInt: string, localDept: string, remoteInt: string, remoteDept: string): Promise<string> {
+  const r = await query<{ id: string }>(
+    `INSERT INTO directory_department_bindings
+       (org_id, local_integration_id, local_department_id, local_provider,
+        remote_integration_id, remote_department_id, remote_provider, status)
+     VALUES ($1, $2, $3, 'local', $4, $5, 'dingtalk', 'active') RETURNING id`,
+    [org, localInt, localDept, remoteInt, remoteDept],
+  )
+  return r.rows[0].id
+}
+async function bindingStatus(id: string): Promise<string> {
+  const r = await query<{ status: string }>(`SELECT status FROM directory_department_bindings WHERE id = $1`, [id])
+  return r.rows[0].status
+}
+
+describeIfDatabase('B7 Q6 — post-sync auto-sweep hook (real sync, mocked provider pull)', () => {
+  const cleanupBindingIds: string[] = []
+  const cleanupDeptIds: string[] = []
+  const cleanupIntegrationIds: string[] = []
+
+  afterAll(async () => {
+    try {
+      for (const id of cleanupBindingIds.splice(0)) await query(`DELETE FROM directory_department_bindings WHERE id = $1`, [id])
+      for (const id of cleanupDeptIds.splice(0)) await query(`DELETE FROM directory_departments WHERE id = $1`, [id])
+      for (const id of cleanupIntegrationIds.splice(0)) {
+        await query(`DELETE FROM directory_sync_runs WHERE integration_id = $1`, [id])
+        await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
+      }
+    } catch {
+      /* best effort */
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('A. a successful sync auto-stales the departed remote binding — narrowed to the synced integration only', async () => {
+    // integration A (will sync) + integration B (must NOT be swept by A's sync)
+    const intA = await createDirectoryIntegration({
+      name: `b7q6-A-${TS}`,
+      corpId: `b7q6-corpA-${TS}`,
+      appKey: `b7q6-keyA-${TS}`,
+      appSecret: 's',
+      admissionMode: 'manual_only',
+    })
+    cleanupIntegrationIds.push(intA.id)
+    const intB = await query<{ id: string }>(
+      `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config)
+       VALUES ('default', 'dingtalk', $1, 'active', $2, '{}'::jsonb) RETURNING id`,
+      [`b7q6-B-${TS}`, `b7q6-corpB-${TS}`],
+    )
+    cleanupIntegrationIds.push(intB.rows[0].id)
+
+    const local = await getOrCreateLocalIntegration('default')
+    const lDeptA = await createLocalDepartment({ orgId: 'default', name: `B7Q6 A ${TS}` })
+    const lDeptB = await createLocalDepartment({ orgId: 'default', name: `B7Q6 B ${TS}` })
+    cleanupDeptIds.push(lDeptA.id, lDeptB.id)
+    const rDeptA = await dtDeptSeen(intA.id, `b7q6-a-${TS}`, `B7Q6 A ${TS}`)
+    const rDeptB = await query<{ id: string }>(
+      // integration B's remote dept is ALREADY archived — sweepable, but B is not the synced integration
+      `INSERT INTO directory_departments (integration_id, provider, external_department_id, name, is_active, raw)
+       VALUES ($1, 'dingtalk', $2, $3, false, '{}'::jsonb) RETURNING id`,
+      [intB.rows[0].id, `b7q6-b-${TS}`, `B7Q6 B ${TS}`],
+    )
+    cleanupDeptIds.push(rDeptA, rDeptB.rows[0].id)
+    const bindingA = await bind('default', local.id, lDeptA.id, intA.id, rDeptA)
+    const bindingB = await bind('default', local.id, lDeptB.id, intB.rows[0].id, rDeptB.rows[0].id)
+    cleanupBindingIds.push(bindingA, bindingB)
+
+    const result = await syncDirectoryIntegration(intA.id, `system:b7q6-${TS}`)
+    expect(result.run.status).toBe('completed')
+
+    // the sync's own absence sweep archived the departed remote dept…
+    const dept = await query<{ is_active: boolean }>(`SELECT is_active FROM directory_departments WHERE id = $1`, [rDeptA])
+    expect(dept.rows[0].is_active).toBe(false)
+    // …and the post-commit hook staled its binding WITHOUT any admin action
+    expect(await bindingStatus(bindingA)).toBe('stale')
+    // narrowing (Q6): integration B's sweepable binding is untouched by A's sync
+    expect(await bindingStatus(bindingB)).toBe('active')
+  })
+
+  it('B. failure isolation: a broken sweep never fails the sync that just committed', async () => {
+    const intC = await createDirectoryIntegration({
+      name: `b7q6-C-${TS}`,
+      corpId: `b7q6-corpC-${TS}`,
+      appKey: `b7q6-keyC-${TS}`,
+      appSecret: 's',
+      admissionMode: 'manual_only',
+    })
+    cleanupIntegrationIds.push(intC.id)
+
+    await query(`ALTER TABLE directory_department_bindings RENAME TO directory_department_bindings_hidden_${TS}`)
+    try {
+      const result = await syncDirectoryIntegration(intC.id, `system:b7q6c-${TS}`)
+      expect(result.run.status).toBe('completed') // the sync is UNAFFECTED by the sweep failure
+      const row = await query<{ last_error: string | null }>(
+        `SELECT last_error FROM directory_integrations WHERE id = $1`,
+        [intC.id],
+      )
+      expect(row.rows[0].last_error).toBeNull() // not fail-marked either
+    } finally {
+      await query(`ALTER TABLE directory_department_bindings_hidden_${TS} RENAME TO directory_department_bindings`)
+    }
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -168,14 +168,15 @@ export default defineConfig({
       'tests/integration/approval-routing-policy-equivalence.db.test.ts',
       // Canonical Org MVP B7 (§9): suggest-only reconciliation — remote disappearance stales the
       // BINDING only (local dept row byte-identical), heal/idempotent sweep, ambiguous names never
-      // auto-matched, suggest read-only. DATABASE_URL-gated; wired as a WHOLE FILE into the
-      // approval real-DB step (both points asserted by b7-reconciliation-ci-wiring.test.mjs).
+      // auto-matched, suggest read-only zero-write. DATABASE_URL-gated; wired as a WHOLE FILE into
+      // the directory real-DB placement of the `Run approval real-DB integration` step (both
+      // points asserted by b7-reconciliation-ci-wiring.test.mjs — named-step anchored).
       'tests/integration/directory-binding-reconciliation.db.test.ts',
-      // B7 owner round (#4436): the binding ADMIN routes (list/suggestions/sweep+audit) and the
-      // Q6 POST-SYNC auto-sweep hook (end-to-end through the REAL sync with a mocked provider
-      // pull; narrowing + failure isolation). DATABASE_URL-gated; wired as WHOLE FILES into the
-      // approval real-DB step (gate P3 label fix: all three B7 suites run in that one step);
-      // both points asserted by b7-round2-ci-wiring.test.mjs.
+      // B7 owner round (#4436): binding ADMIN routes (list/suggestions/sweep+audit) → directory
+      // real-DB placement (clustered with reconciliation); Q6 POST-SYNC auto-sweep hook → approval
+      // real-DB placement (clustered with approval-routing equivalence). Both live in the same
+      // named step `Run approval real-DB integration` but are step-block + cluster-anchored by
+      // b7-round2-ci-wiring.test.mjs so a move to multitable/elsewhere reds.
       'tests/integration/directory-binding-admin-routes.db.test.ts',
       'tests/integration/directory-binding-sync-hook.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -169,13 +169,13 @@ export default defineConfig({
       // Canonical Org MVP B7 (§9): suggest-only reconciliation — remote disappearance stales the
       // BINDING only (local dept row byte-identical), heal/idempotent sweep, ambiguous names never
       // auto-matched, suggest read-only. DATABASE_URL-gated; wired as a WHOLE FILE into the
-      // directory real-DB step (both points asserted by b7-reconciliation-ci-wiring.test.mjs).
+      // approval real-DB step (both points asserted by b7-reconciliation-ci-wiring.test.mjs).
       'tests/integration/directory-binding-reconciliation.db.test.ts',
       // B7 owner round (#4436): the binding ADMIN routes (list/suggestions/sweep+audit) and the
       // Q6 POST-SYNC auto-sweep hook (end-to-end through the REAL sync with a mocked provider
       // pull; narrowing + failure isolation). DATABASE_URL-gated; wired as WHOLE FILES into the
-      // directory (routes) and approval (sync-hook) real-DB steps; both points asserted by
-      // b7-round2-ci-wiring.test.mjs.
+      // approval real-DB step (gate P3 label fix: all three B7 suites run in that one step);
+      // both points asserted by b7-round2-ci-wiring.test.mjs.
       'tests/integration/directory-binding-admin-routes.db.test.ts',
       'tests/integration/directory-binding-sync-hook.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -173,10 +173,10 @@ export default defineConfig({
       // points asserted by b7-reconciliation-ci-wiring.test.mjs — named-step anchored).
       'tests/integration/directory-binding-reconciliation.db.test.ts',
       // B7 owner round (#4436): binding ADMIN routes (list/suggestions/sweep+audit) → directory
-      // real-DB placement (clustered with reconciliation); Q6 POST-SYNC auto-sweep hook → approval
-      // real-DB placement (clustered with approval-routing equivalence). Both live in the same
-      // named step `Run approval real-DB integration` but are step-block + cluster-anchored by
-      // b7-round2-ci-wiring.test.mjs so a move to multitable/elsewhere reds.
+      // real-DB placement (immediately after reconciliation); Q6 POST-SYNC auto-sweep hook →
+      // approval real-DB placement (immediately after approval-routing equivalence). Both live in
+      // the same named step `Run approval real-DB integration` but are step-block + exact-adjacency
+      // index-anchored by b7-round2-ci-wiring.test.mjs so a same-step drift or multitable move reds.
       'tests/integration/directory-binding-admin-routes.db.test.ts',
       'tests/integration/directory-binding-sync-hook.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -166,6 +166,11 @@ export default defineConfig({
       // DATABASE_URL-gated; wired as a WHOLE FILE into the APPROVAL real-DB step (server-based,
       // like approval-direct-manager) — both points asserted by b6-equivalence-ci-wiring.test.mjs.
       'tests/integration/approval-routing-policy-equivalence.db.test.ts',
+      // Canonical Org MVP B7 (§9): suggest-only reconciliation — remote disappearance stales the
+      // BINDING only (local dept row byte-identical), heal/idempotent sweep, ambiguous names never
+      // auto-matched, suggest read-only. DATABASE_URL-gated; wired as a WHOLE FILE into the
+      // directory real-DB step (both points asserted by b7-reconciliation-ci-wiring.test.mjs).
+      'tests/integration/directory-binding-reconciliation.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
       // resolution against real Postgres — normalized `is_manager` relation for a local integration,
       // the DingTalk `leader_in_dept` regression pin (load-bearing compat leg + is_manager=0 positive

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -171,6 +171,13 @@ export default defineConfig({
       // auto-matched, suggest read-only. DATABASE_URL-gated; wired as a WHOLE FILE into the
       // directory real-DB step (both points asserted by b7-reconciliation-ci-wiring.test.mjs).
       'tests/integration/directory-binding-reconciliation.db.test.ts',
+      // B7 owner round (#4436): the binding ADMIN routes (list/suggestions/sweep+audit) and the
+      // Q6 POST-SYNC auto-sweep hook (end-to-end through the REAL sync with a mocked provider
+      // pull; narrowing + failure isolation). DATABASE_URL-gated; wired as WHOLE FILES into the
+      // directory (routes) and approval (sync-hook) real-DB steps; both points asserted by
+      // b7-round2-ci-wiring.test.mjs.
+      'tests/integration/directory-binding-admin-routes.db.test.ts',
+      'tests/integration/directory-binding-sync-hook.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
       // resolution against real Postgres — normalized `is_manager` relation for a local integration,
       // the DingTalk `leader_in_dept` regression pin (load-bearing compat leg + is_manager=0 positive

--- a/scripts/ops/b7-reconciliation-ci-wiring.test.mjs
+++ b/scripts/ops/b7-reconciliation-ci-wiring.test.mjs
@@ -1,0 +1,24 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// B7 CI two-point wiring contract. The routing-policy schema suite proves the resolver over the (org,purpose)
+// policy store's DB invariants (cross-org FK-impossible, closed purpose set, RESTRICT) against real
+// Postgres — meaningless without a DB. It needs BOTH (1) the vitest.config.ts exclude (so the no-DB
+// job cannot skip-green it) AND (2) the plugin-tests.yml directory real-DB whole-file step. Removing
+// either point silently disables the proof while CI stays green. Runs in the gating no-DB test job.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/directory-binding-reconciliation.db.test.ts'
+
+test('vitest.config.ts excludes the B7 routing-policy suite from the no-DB job', () => {
+  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+})
+
+test('plugin-tests.yml runs the B7 routing-policy suite as a whole file in the directory real-DB step', () => {
+  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  assert.match(wf, new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${FILE}`)
+})

--- a/scripts/ops/b7-reconciliation-ci-wiring.test.mjs
+++ b/scripts/ops/b7-reconciliation-ci-wiring.test.mjs
@@ -4,21 +4,71 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 
-// B7 CI two-point wiring contract. The routing-policy schema suite proves the resolver over the (org,purpose)
-// policy store's DB invariants (cross-org FK-impossible, closed purpose set, RESTRICT) against real
-// Postgres — meaningless without a DB. It needs BOTH (1) the vitest.config.ts exclude (so the no-DB
-// job cannot skip-green it) AND (2) the plugin-tests.yml directory real-DB whole-file step. Removing
-// either point silently disables the proof while CI stays green. Runs in the gating no-DB test job.
+// B7 CI two-point wiring contract. The suggest-only reconciliation suite proves stale-not-inactive,
+// ambiguous-never-auto-match, and zero-write suggest against real Postgres — meaningless without a
+// DB. It needs BOTH (1) the vitest.config.ts exclude (so the no-DB job cannot skip-green it) AND
+// (2) the plugin-tests.yml directory real-DB whole-file step (the named step that hosts directory
+// integration suites). Removing either point silently disables the proof while CI stays green.
+// Runs in the gating no-DB test job.
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '..', '..')
 const FILE = 'tests/integration/directory-binding-reconciliation.db.test.ts'
 
-test('vitest.config.ts excludes the B7 routing-policy suite from the no-DB job', () => {
+// In plugin-tests.yml, directory real-DB suites (B4–B7 reconciliation/admin, org-directory-*,
+// local-directory-*) share the single named step "Run approval real-DB integration (...)" with
+// the approval suites. The guard anchors to that named step block — a path that appears only in
+// a comment, the multitable step, or elsewhere must NOT pass.
+const DIRECTORY_REAL_DB_STEP = 'Run approval real-DB integration'
+
+/**
+ * Body of the first workflow step whose name contains `nameNeedle`, from the line after
+ * `- name:` through (not including) the next same-indent `- name:`.
+ */
+function namedStepBody(wf, nameNeedle) {
+  const lines = wf.split('\n')
+  let start = -1
+  let indent = ''
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(\s*)- name:\s*(.*)$/)
+    if (m && m[2].includes(nameNeedle)) {
+      start = i
+      indent = m[1]
+      break
+    }
+  }
+  assert.ok(start >= 0, `workflow step whose name includes ${JSON.stringify(nameNeedle)} not found`)
+  const body = []
+  for (let i = start + 1; i < lines.length; i++) {
+    const m = lines[i].match(/^(\s*)- name:\s*/)
+    if (m && m[1] === indent) break
+    body.push(lines[i])
+  }
+  return body.join('\n')
+}
+
+/** Whole-file vitest arg line: newline + indent + path + trailing ` \`. */
+function wholeFileRunRe(file) {
+  return new RegExp(`\\n\\s*${file.replace(/[.]/g, '\\.')} \\\\`)
+}
+
+test('vitest.config.ts excludes the B7 reconciliation suite from the no-DB job', () => {
   const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
   assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
 })
 
-test('plugin-tests.yml runs the B7 routing-policy suite as a whole file in the directory real-DB step', () => {
+test('plugin-tests.yml runs the B7 reconciliation suite as a whole file in the directory real-DB step', () => {
   const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
-  assert.match(wf, new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${FILE}`)
+  const step = namedStepBody(wf, DIRECTORY_REAL_DB_STEP)
+  assert.match(
+    step,
+    wholeFileRunRe(FILE),
+    `plugin-tests.yml directory real-DB step (${DIRECTORY_REAL_DB_STEP}) must run ${FILE} as a whole file`,
+  )
+  // Negative: must not be the sole (or any) placement under multitable real-DB.
+  const multi = namedStepBody(wf, 'Run multitable real-DB integration')
+  assert.doesNotMatch(
+    multi,
+    wholeFileRunRe(FILE),
+    `${FILE} must not be wired into the multitable real-DB step`,
+  )
 })

--- a/scripts/ops/b7-round2-ci-wiring.test.mjs
+++ b/scripts/ops/b7-round2-ci-wiring.test.mjs
@@ -10,14 +10,17 @@ import { dirname, join } from 'node:path'
 //
 // Placement (within the shared "Run approval real-DB integration" step block that hosts both
 // directory and approval real-DB suites):
-//   - admin-routes  → directory real-DB placement (next to reconciliation / org-directory-*)
-//   - sync-hook     → approval real-DB placement (next to approval-routing / direct-manager)
-// The guard parses the named step block so a path that only appears in a comment or in another
-// step (e.g. multitable) does not pass.
+//   - admin-routes  → immediately after directory-binding-reconciliation (directory cluster)
+//   - sync-hook     → immediately after approval-routing-policy-equivalence (approval cluster)
+// Guards parse the named step's whole-file vitest argument list and assert EXACT adjacency by
+// index — not merely "somewhere later" via [\s\S]* ordering. A path only in a comment, in the
+// multitable step, or non-adjacent within the same named step does not pass.
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '..', '..')
 const ADMIN_FILE = 'tests/integration/directory-binding-admin-routes.db.test.ts'
 const SYNC_HOOK_FILE = 'tests/integration/directory-binding-sync-hook.db.test.ts'
+const EQUIVALENCE_FILE = 'tests/integration/approval-routing-policy-equivalence.db.test.ts'
+const RECONCILIATION_FILE = 'tests/integration/directory-binding-reconciliation.db.test.ts'
 
 // Same named step hosts both families; anchors still fail if a suite is moved out of it.
 const REAL_DB_STEP = 'Run approval real-DB integration'
@@ -48,8 +51,36 @@ function namedStepBody(wf, nameNeedle) {
   return body.join('\n')
 }
 
+/**
+ * Ordered list of whole-file vitest arguments in a step body.
+ * Matches lines like: `            tests/integration/foo.db.test.ts \`
+ * (path + trailing backslash continuation; last file may omit the backslash).
+ */
+function wholeFileVitestArgs(stepBody) {
+  const files = []
+  for (const line of stepBody.split('\n')) {
+    const m = line.match(/^\s+(tests\/integration\/\S+\.(?:test|spec)\.[tj]sx?)\s*(?:\\)?\s*$/)
+    if (m) files.push(m[1])
+  }
+  return files
+}
+
 function wholeFileRunRe(file) {
   return new RegExp(`\\n\\s*${file.replace(/[.]/g, '\\.')} \\\\`)
+}
+
+function assertImmediatelyFollows(files, predecessor, successor, label) {
+  const iPred = files.indexOf(predecessor)
+  const iSucc = files.indexOf(successor)
+  assert.ok(iPred >= 0, `${label}: predecessor ${predecessor} missing from step vitest arg list`)
+  assert.ok(iSucc >= 0, `${label}: successor ${successor} missing from step vitest arg list`)
+  assert.equal(
+    iSucc,
+    iPred + 1,
+    `${label}: ${successor} must immediately follow ${predecessor} ` +
+      `(indices pred=${iPred} succ=${iSucc}; found[${iPred}..${iPred + 1}]=` +
+      `${JSON.stringify(files.slice(iPred, iPred + 2))})`,
+  )
 }
 
 test('vitest.config.ts excludes both B7 round-2 suites from the no-DB job', () => {
@@ -67,18 +98,12 @@ test('plugin-tests.yml runs the B7 admin-routes suite as a whole file in the dir
     wholeFileRunRe(ADMIN_FILE),
     `plugin-tests.yml directory real-DB step (${REAL_DB_STEP}) must run ${ADMIN_FILE} as a whole file`,
   )
-  // Clustering pin: admin routes sit AFTER reconciliation in the directory suite region
-  // (not only "somewhere" in the shared step).
-  assert.match(
-    step,
-    /directory-binding-reconciliation\.db\.test\.ts \\[\s\S]*directory-binding-admin-routes\.db\.test\.ts \\/,
-    `${ADMIN_FILE} must be clustered after the directory reconciliation suite in the real-DB step`,
-  )
-  // Must not be parked only in the approval cluster (before reconciliation).
-  assert.doesNotMatch(
-    step,
-    /directory-binding-admin-routes\.db\.test\.ts \\[\s\S]*directory-binding-reconciliation\.db\.test\.ts \\/,
-    `${ADMIN_FILE} must not precede reconciliation (wrong cluster)`,
+  const files = wholeFileVitestArgs(step)
+  assertImmediatelyFollows(
+    files,
+    RECONCILIATION_FILE,
+    ADMIN_FILE,
+    'directory cluster adjacency',
   )
   const multi = namedStepBody(wf, 'Run multitable real-DB integration')
   assert.doesNotMatch(multi, wholeFileRunRe(ADMIN_FILE), `${ADMIN_FILE} must not be in multitable real-DB`)
@@ -92,12 +117,12 @@ test('plugin-tests.yml runs the B7 sync-hook suite as a whole file in the approv
     wholeFileRunRe(SYNC_HOOK_FILE),
     `plugin-tests.yml approval real-DB step (${REAL_DB_STEP}) must run ${SYNC_HOOK_FILE} as a whole file`,
   )
-  // Clustering pin: Q6 sync-hook sits in the approval region — AFTER equivalence and BEFORE
-  // the directory reconciliation suite. Moving it into the directory cluster reds this order.
-  assert.match(
-    step,
-    /approval-routing-policy-equivalence\.db\.test\.ts \\[\s\S]*directory-binding-sync-hook\.db\.test\.ts \\[\s\S]*directory-binding-reconciliation\.db\.test\.ts \\/,
-    `${SYNC_HOOK_FILE} must sit between approval equivalence and directory reconciliation in the real-DB step`,
+  const files = wholeFileVitestArgs(step)
+  assertImmediatelyFollows(
+    files,
+    EQUIVALENCE_FILE,
+    SYNC_HOOK_FILE,
+    'approval cluster adjacency',
   )
   const multi = namedStepBody(wf, 'Run multitable real-DB integration')
   assert.doesNotMatch(multi, wholeFileRunRe(SYNC_HOOK_FILE), `${SYNC_HOOK_FILE} must not be in multitable real-DB`)

--- a/scripts/ops/b7-round2-ci-wiring.test.mjs
+++ b/scripts/ops/b7-round2-ci-wiring.test.mjs
@@ -1,0 +1,25 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// B7 owner-round CI two-point wiring contract: the binding admin-routes suite and the Q6 post-sync
+// hook suite are real-DB proofs (the hook one drives the REAL sync). Each needs BOTH the
+// vitest.config.ts exclude (no skip-green) AND its plugin-tests.yml real-DB whole-file step.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILES = [
+  'tests/integration/directory-binding-admin-routes.db.test.ts',
+  'tests/integration/directory-binding-sync-hook.db.test.ts',
+]
+
+test('vitest.config.ts excludes both B7 round-2 suites from the no-DB job', () => {
+  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  for (const f of FILES) assert.ok(cfg.includes(`'${f}'`), `vitest.config.ts must exclude ${f}`)
+})
+
+test('plugin-tests.yml runs both B7 round-2 suites as whole files in real-DB steps', () => {
+  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  for (const f of FILES) assert.match(wf, new RegExp(`\\n\\s*${f.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${f}`)
+})

--- a/scripts/ops/b7-round2-ci-wiring.test.mjs
+++ b/scripts/ops/b7-round2-ci-wiring.test.mjs
@@ -7,19 +7,98 @@ import { dirname, join } from 'node:path'
 // B7 owner-round CI two-point wiring contract: the binding admin-routes suite and the Q6 post-sync
 // hook suite are real-DB proofs (the hook one drives the REAL sync). Each needs BOTH the
 // vitest.config.ts exclude (no skip-green) AND its plugin-tests.yml real-DB whole-file step.
+//
+// Placement (within the shared "Run approval real-DB integration" step block that hosts both
+// directory and approval real-DB suites):
+//   - admin-routes  → directory real-DB placement (next to reconciliation / org-directory-*)
+//   - sync-hook     → approval real-DB placement (next to approval-routing / direct-manager)
+// The guard parses the named step block so a path that only appears in a comment or in another
+// step (e.g. multitable) does not pass.
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '..', '..')
-const FILES = [
-  'tests/integration/directory-binding-admin-routes.db.test.ts',
-  'tests/integration/directory-binding-sync-hook.db.test.ts',
-]
+const ADMIN_FILE = 'tests/integration/directory-binding-admin-routes.db.test.ts'
+const SYNC_HOOK_FILE = 'tests/integration/directory-binding-sync-hook.db.test.ts'
+
+// Same named step hosts both families; anchors still fail if a suite is moved out of it.
+const REAL_DB_STEP = 'Run approval real-DB integration'
+
+/**
+ * Body of the first workflow step whose name contains `nameNeedle`, from the line after
+ * `- name:` through (not including) the next same-indent `- name:`.
+ */
+function namedStepBody(wf, nameNeedle) {
+  const lines = wf.split('\n')
+  let start = -1
+  let indent = ''
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(\s*)- name:\s*(.*)$/)
+    if (m && m[2].includes(nameNeedle)) {
+      start = i
+      indent = m[1]
+      break
+    }
+  }
+  assert.ok(start >= 0, `workflow step whose name includes ${JSON.stringify(nameNeedle)} not found`)
+  const body = []
+  for (let i = start + 1; i < lines.length; i++) {
+    const m = lines[i].match(/^(\s*)- name:\s*/)
+    if (m && m[1] === indent) break
+    body.push(lines[i])
+  }
+  return body.join('\n')
+}
+
+function wholeFileRunRe(file) {
+  return new RegExp(`\\n\\s*${file.replace(/[.]/g, '\\.')} \\\\`)
+}
 
 test('vitest.config.ts excludes both B7 round-2 suites from the no-DB job', () => {
   const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
-  for (const f of FILES) assert.ok(cfg.includes(`'${f}'`), `vitest.config.ts must exclude ${f}`)
+  for (const f of [ADMIN_FILE, SYNC_HOOK_FILE]) {
+    assert.ok(cfg.includes(`'${f}'`), `vitest.config.ts must exclude ${f}`)
+  }
 })
 
-test('plugin-tests.yml runs both B7 round-2 suites as whole files in real-DB steps', () => {
+test('plugin-tests.yml runs the B7 admin-routes suite as a whole file in the directory real-DB step', () => {
   const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
-  for (const f of FILES) assert.match(wf, new RegExp(`\\n\\s*${f.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${f}`)
+  const step = namedStepBody(wf, REAL_DB_STEP)
+  assert.match(
+    step,
+    wholeFileRunRe(ADMIN_FILE),
+    `plugin-tests.yml directory real-DB step (${REAL_DB_STEP}) must run ${ADMIN_FILE} as a whole file`,
+  )
+  // Clustering pin: admin routes sit AFTER reconciliation in the directory suite region
+  // (not only "somewhere" in the shared step).
+  assert.match(
+    step,
+    /directory-binding-reconciliation\.db\.test\.ts \\[\s\S]*directory-binding-admin-routes\.db\.test\.ts \\/,
+    `${ADMIN_FILE} must be clustered after the directory reconciliation suite in the real-DB step`,
+  )
+  // Must not be parked only in the approval cluster (before reconciliation).
+  assert.doesNotMatch(
+    step,
+    /directory-binding-admin-routes\.db\.test\.ts \\[\s\S]*directory-binding-reconciliation\.db\.test\.ts \\/,
+    `${ADMIN_FILE} must not precede reconciliation (wrong cluster)`,
+  )
+  const multi = namedStepBody(wf, 'Run multitable real-DB integration')
+  assert.doesNotMatch(multi, wholeFileRunRe(ADMIN_FILE), `${ADMIN_FILE} must not be in multitable real-DB`)
+})
+
+test('plugin-tests.yml runs the B7 sync-hook suite as a whole file in the approval real-DB step', () => {
+  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  const step = namedStepBody(wf, REAL_DB_STEP)
+  assert.match(
+    step,
+    wholeFileRunRe(SYNC_HOOK_FILE),
+    `plugin-tests.yml approval real-DB step (${REAL_DB_STEP}) must run ${SYNC_HOOK_FILE} as a whole file`,
+  )
+  // Clustering pin: Q6 sync-hook sits in the approval region — AFTER equivalence and BEFORE
+  // the directory reconciliation suite. Moving it into the directory cluster reds this order.
+  assert.match(
+    step,
+    /approval-routing-policy-equivalence\.db\.test\.ts \\[\s\S]*directory-binding-sync-hook\.db\.test\.ts \\[\s\S]*directory-binding-reconciliation\.db\.test\.ts \\/,
+    `${SYNC_HOOK_FILE} must sit between approval equivalence and directory reconciliation in the real-DB step`,
+  )
+  const multi = namedStepBody(wf, 'Run multitable real-DB integration')
+  assert.doesNotMatch(multi, wholeFileRunRe(SYNC_HOOK_FILE), `${SYNC_HOOK_FILE} must not be in multitable real-DB`)
 })


### PR DESCRIPTION
## B7 - suggest-only external-provider reconciliation

Canonical Org MVP B7 implements the ratified provider-proposes boundary: external providers may produce reconciliation suggestions and update binding liveness, but they never rewrite the canonical local organization.

### As built

- `sweepStaleDepartmentBindings(orgId, { remoteIntegrationId? })` moves binding rows between `active` and `stale` from remote-department liveness. It never writes local departments.
- `suggestDepartmentBindings(orgId)` is read-only. A unique normalized-name candidate is suggested, duplicate candidates are returned as non-appliable `ambiguous`, and no candidate is `unmatched`.
- The suggestion read boundary rejects provider-mislabeled child rows with `rd.provider = ri.provider`.
- Platform-admin management routes provide binding list, read-only suggestions, and the Q6 manual sweep retry. Organization scope is server-resolved; sweep audit contains identifiers and counts only.
- After a successful directory sync commit, Q6 runs a sweep narrowed to the synced integration. Failure cannot change the successful sync result and is logged with closed metadata only: `{ integrationId, reason: 'sweep_failed' }`.
- All three DB suites are excluded from the no-DB lane and wired as whole files into the required real-DB workflow step. Guard tests pin the named step and exact adjacency.

### Review fixes included in head `e712eee67`

- Restacked the original B7 delta onto merged B6/main; removed the stale stacked dependency.
- Strengthened suggest zero-write proof with full binding fingerprints and exact-pair absence.
- Replaced broad workflow-order checks with named-step parsing and exact argument adjacency.
- Added malformed child-provider coverage and the load-bearing `rd.provider = ri.provider` predicate.
- Made Q6 failure logging values-free by construction; neither raw error text nor mutable `Error.name` can enter the log.

### Local verification on a fresh PostgreSQL database

- Full migration chain: pass.
- B7 reconciliation, admin-route, and real-sync hook suites: 19/19.
- B7 plus B6 equivalence, routing fail-close, and direct-manager compatibility: 38/38.
- CI wiring guards: 5/5.
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`: pass.

### Independent Codex mutation replay

Each mutation was applied separately, observed red, then restored:

1. Remove `rd.provider = ri.provider` -> malformed-child test red.
2. Materialize one suggestion into a binding -> exact-pair and fingerprint zero-write tests red.
3. Move the admin-route DB suite within the same workflow step -> exact-adjacency guard red.
4. Remove `remoteIntegrationId` narrowing -> same-org second integration is swept; narrowing test red.
5. Restore raw `readErrorMessage(error)` and `Error.name` logging -> values-free sync-hook test red.

The PR remains unarmed while exact-head CI runs. Canonical Org closeout documentation follows only after this PR lands with its real merge SHA.
