### PR TITLE
feat(automation): #4196 Class-B outbound two-phase intent/outcome (send_webhook wired)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -568,6 +568,7 @@ jobs:
             tests/integration/multitable-automation-outbox-schema-realdb.test.ts \
             tests/integration/multitable-action-applied-ledger-realdb.test.ts \
             tests/integration/multitable-automation-execution-ledger-realdb.test.ts \
+            tests/integration/multitable-automation-outbound-intent-realdb.test.ts \
             tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts \
             tests/integration/multitable-automation-dispatch-loop-realdb.test.ts \
             tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260716110000_create_automation_outbound_intent.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260716110000_create_automation_outbound_intent.ts
@@ -1,0 +1,52 @@
+/**
+ * Migration: `meta_automation_outbound_intent` — the #4196 Class-B two-phase intent/outcome table
+ * (design-lock `approval-automation-retry-action-classification-designlock-20260712.md` §3).
+ *
+ * SEPARATE from the class-A `meta_automation_action_applied` claim table: the class-A table stays TERMINAL
+ * (a UNIQUE claim row, no status transitions); class-B needs a two-phase state machine because its effect
+ * leaves the process and cannot sit inside a transaction (§0). The row is keyed by the SAME identity family
+ * as the class-A ledger — (kind, root_execution_id, action_key), same `kind` namespace discriminator (§2.2)
+ * so a real_fire test-run's outbound intent is disjoint from any real execution's — but this is its own
+ * table with its own lifecycle:
+ *
+ *   pending → sent            (the attempt got a definite 2xx)
+ *           → failed          (DEFINITE pre-dispatch non-delivery — DNS/conn-refused/TLS; eligible to retry)
+ *           → outcome_unknown (TERMINAL: timeout / reset / ANY HTTP status incl every 4xx §8 Q-B —
+ *                              the send MAY have happened; NEVER auto-resend)
+ *
+ * VALUES-FREE: only the identity (a sha256 action_key), a status, an attempt count, and a BOUNDED redacted
+ * reason class in `last_error` — never a payload, URL, or token.
+ *
+ * Additive, new table; `down()` drops it.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_automation_outbound_intent (
+      id                 bigserial PRIMARY KEY,
+      kind               text NOT NULL
+                           CONSTRAINT outbound_intent_kind_valid CHECK (kind IN ('execution','test_run')),
+      root_execution_id  text NOT NULL
+                           CONSTRAINT outbound_intent_root_nonblank CHECK (root_execution_id ~ '[!-~]'),
+      action_key         text NOT NULL
+                           CONSTRAINT outbound_intent_action_key_nonblank CHECK (action_key ~ '[!-~]'),
+      status             text NOT NULL DEFAULT 'pending'
+                           CONSTRAINT outbound_intent_status_valid
+                             CHECK (status IN ('pending','sent','failed','outcome_unknown')),
+      attempts           int  NOT NULL DEFAULT 0
+                           CONSTRAINT outbound_intent_attempts_nonneg CHECK (attempts >= 0),
+      last_error         text,
+      created_at         timestamptz NOT NULL DEFAULT now(),
+      updated_at         timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_outbound_intent_identity
+    ON meta_automation_outbound_intent (kind, root_execution_id, action_key)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS meta_automation_outbound_intent`.execute(db)
+}

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -9,6 +9,16 @@ import { branchChildStepKey, topLevelStepKey } from './automation-step-key'
 import { deriveRuleActionSetFingerprint } from './automation-rule-fingerprint'
 import { claimExecutionAction, isClassAExecutionClaimEnabled } from './automation-execution-ledger'
 import { deriveActionKey } from './automation-action-idempotency'
+import {
+  classifyFetchError,
+  classifyOutboundResult,
+  claimOutboundIntent,
+  isClassBOutboundEnabled,
+  outboundReasonClass,
+  recordOutboundOutcome,
+  type OutboundAttemptResult,
+  type OutboundIntentIdentity,
+} from './automation-outbound-intent'
 import type { TransactionalQueryable } from './pg-transaction-guard'
 import { Logger } from '../core/logger'
 import { withAutomationEventId } from './automation-event-dedup'
@@ -1771,7 +1781,10 @@ export class AutomationExecutor {
           result = await this.executeDeleteRecord(action.config, context, identity)
           break
         case 'send_webhook':
-          result = await this.executeSendWebhook(action.config, context)
+          // #4196 Class-B: thread the execution identity so send_webhook can take the two-phase
+          // intent/outcome path when AUTOMATION_CLASSB_OUTBOUND_ENABLED is ON (flag OFF ⇒ identity ignored,
+          // byte-identical). The other four send_* actions are a clearly-flagged follow-up (see PR body).
+          result = await this.executeSendWebhook(action.config, context, identity)
           break
         case 'send_notification':
           result = await this.executeSendNotification(action.config, context)
@@ -2723,6 +2736,9 @@ export class AutomationExecutor {
   private async executeSendWebhook(
     config: Record<string, unknown>,
     context: ExecutionContext,
+    // #4196 Class-B identity. Present on every rule-driven call; undefined for the ad-hoc single-action
+    // dispatch (runSingleAction — no execution lineage, so no intent). Ignored entirely when the flag is OFF.
+    identity?: ClassAActionIdentity,
   ): Promise<AutomationStepResult> {
     const url = config.url as string | undefined
     if (!url) {
@@ -2757,6 +2773,16 @@ export class AutomationExecutor {
 
     const fetchFn = this.deps.fetchFn ?? globalThis.fetch
     const timeoutMs = webhookTimeoutMs()
+
+    // #4196 Class-B two-phase (flag ON + identity present). Intent (Tx A) commits BEFORE the send; a prior
+    // `sent`/`outcome_unknown` short-circuits with NO network call. When the flag is OFF (or there is no
+    // execution identity — the runSingleAction ad-hoc path) this is skipped and the legacy retry loop below
+    // runs BYTE-IDENTICAL to pre-slice.
+    const outboundId = this.classBOutboundIdentity(identity, 'send_webhook', config)
+    if (outboundId) {
+      return this.executeSendWebhookTwoPhase(outboundId, { url, method, headers, bodyStr, fetchFn, timeoutMs })
+    }
+
     const retries = maxWebhookRetries()
 
     let lastError: string | undefined
@@ -2801,6 +2827,103 @@ export class AutomationExecutor {
       actionType: 'send_webhook',
       status: 'failed',
       error: `Webhook failed after ${retries + 1} attempts: ${lastError}`,
+    }
+  }
+
+  /**
+   * #4196 Class-B gate: an outbound intent identity is present ONLY when the flag is ON AND the caller
+   * supplied a class-A execution identity (a rule-driven dispatch with a lineage root). Unlike class-A this
+   * does NOT require `deps.transaction` — the intent row is its own commit (Tx A) via the autocommit
+   * `queryFn`, with no DB mutation to co-commit. `config` is passed RAW to `deriveActionKey` so the outbound
+   * key is the SAME §2.1 identity as the class-A claim / §4 fingerprint.
+   */
+  private classBOutboundIdentity(
+    identity: ClassAActionIdentity | undefined,
+    actionType: AutomationActionType,
+    config: unknown,
+  ): OutboundIntentIdentity | null {
+    if (!isClassBOutboundEnabled() || !identity) return null
+    return {
+      kind: 'execution',
+      rootExecutionId: identity.rootExecutionId,
+      actionKey: deriveActionKey({ structuralPath: identity.structuralPath, actionType, canonicalConfig: config }),
+    }
+  }
+
+  /**
+   * #4196 Class-B two-phase send for send_webhook. Tx A (claim) already decided we may attempt; here we
+   * attempt EXACTLY ONCE — a send is at-most-once on this path, so there is NO in-call resend on an ambiguous
+   * failure (that would be the duplicate external effect `outcome_unknown` exists to forbid). Classify the
+   * single attempt, record the outcome (Tx B, guarded single-writer), and map to a step result:
+   *   - sent            → success;
+   *   - failed          → failed (definite pre-dispatch non-delivery; a later retry re-attempts via Tx A);
+   *   - outcome_unknown  → a FAILED-shaped step naming outcome_unknown (operator-visible; NEVER auto-resent).
+   */
+  private async executeSendWebhookTwoPhase(
+    outboundId: OutboundIntentIdentity,
+    req: {
+      url: string
+      method: string
+      headers: Record<string, string>
+      bodyStr: string
+      fetchFn: typeof fetch
+      timeoutMs: number
+    },
+  ): Promise<AutomationStepResult> {
+    // Tx A — intent committed BEFORE the network call. A prior sent/unknown short-circuits with no send.
+    const decision = await claimOutboundIntent(this.deps.queryFn, outboundId)
+    if (decision === 'skip_sent' || decision === 'skip_unknown') {
+      // Success-shaped, alreadyApplied — no second delivery for an already-sent or ambiguous prior attempt.
+      return this.alreadyAppliedResult('send_webhook')
+    }
+
+    // decision is 'proceed' | 'retry_failed' → attempt ONCE.
+    let attempt: OutboundAttemptResult
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), req.timeoutMs)
+    try {
+      const response = await req.fetchFn(req.url, {
+        method: req.method,
+        headers: req.headers,
+        body: req.bodyStr,
+        signal: controller.signal,
+      })
+      attempt = { kind: 'response', status: response.status }
+    } catch (err) {
+      attempt = classifyFetchError(err)
+    } finally {
+      clearTimeout(timeout)
+    }
+
+    const outcome = classifyOutboundResult(attempt)
+    const reason = outboundReasonClass(attempt) // bounded, redacted class — never a body/URL/token
+    // Tx B — record the terminal outcome (guarded `status='pending'`, single-writer).
+    await recordOutboundOutcome(this.deps.queryFn, outboundId, outcome, reason)
+
+    if (outcome === 'sent') {
+      return {
+        actionType: 'send_webhook',
+        status: 'success',
+        output: { outcome: 'sent', httpStatus: attempt.kind === 'response' ? attempt.status : null },
+      }
+    }
+    if (outcome === 'failed') {
+      // Definite non-delivery (nothing left the client) — retryable; the run is marked failed.
+      return {
+        actionType: 'send_webhook',
+        status: 'failed',
+        error: `send_webhook definite non-delivery (${reason}); eligible for retry`,
+        output: { outcome: 'failed', reason },
+      }
+    }
+    // outcome_unknown — the send MAY have happened; surfaced as failed so the run does NOT silently succeed,
+    // and NEVER auto-resent (a retry consults the intent row and skips).
+    logger.warn(`send_webhook to ${redactString(req.url)} → outcome_unknown (${reason}); recorded, not auto-resent`)
+    return {
+      actionType: 'send_webhook',
+      status: 'failed',
+      error: `send_webhook outcome_unknown (${reason}); recorded, not auto-resent`,
+      output: { outcome: 'outcome_unknown', reason },
     }
   }
 

--- a/packages/core-backend/src/multitable/automation-outbound-intent.ts
+++ b/packages/core-backend/src/multitable/automation-outbound-intent.ts
@@ -1,0 +1,279 @@
+/**
+ * #4196 Class-B — outbound / external side-effect two-phase intent/outcome (design-lock
+ * `approval-automation-retry-action-classification-designlock-20260712.md` §3 + §8 Q-B + §9 V7/V8/V9).
+ *
+ * Class-B actions (`send_webhook`, `send_email`, `send_dingtalk_*`) leave the process (HTTP/DingTalk
+ * egress), so NO transaction can span the network call (§0). The correct answer is NOT a durability trade
+ * but TWO-PHASE state plus an `outcome_unknown` terminal state that NEVER auto-resends:
+ *
+ *   (1) record intent  — a durable row keyed by (kind, root_execution_id, action_key), committed in state
+ *       `pending` BEFORE the network call (Tx A, its OWN commit — there is no DB mutation to co-commit, so
+ *       unlike the class-A claim it does not require the same-transaction guarantee; it only needs its own
+ *       commit to LAND FIRST so a crash cannot lose the fact that a send was about to happen);
+ *   (2) attempt        — the actual HTTP/DingTalk call, OUTSIDE any DB transaction;
+ *   (3) record outcome — a SECOND, separate commit (Tx B) flipping the row to a terminal state
+ *       `sent` / `failed` / `outcome_unknown`, guarded `WHERE status='pending'` so a concurrent zombie that
+ *       already terminalized the row writes 0 rows (single-writer for the terminal outcome).
+ *
+ * The core hazard is the CRASH-MID-SEND window: intent committed `pending`, the send MAY have gone out, but
+ * the process died before recording an outcome. A retry that finds `pending` MUST fail closed — flip it to
+ * `outcome_unknown` and NEVER auto-resend (a resend on ambiguity is a duplicate external effect §3).
+ *
+ * VALUES-FREE by construction: the row carries only the identity (a sha256 `action_key`, never a payload),
+ * a status, an attempt count, and a BOUNDED, REDACTED reason CLASS in `last_error` — never a raw response
+ * body, a URL, or a token.
+ *
+ * V7/V8/V9 scope (§9): this v1 slice writes intent/outcome INLINE in the dispatch path (not a background
+ * re-lease worker), so it introduces NO new lease surface — the zombie-fence (V7), poison-terminal (V8),
+ * and class-B storm-leg (V9) obligations remain satisfied by the S6 event_fires lease (#4426) plus the
+ * `status='pending'` single-writer outcome guard here. Any FUTURE time-based re-lease of class-B would
+ * inherit #4203 Layer-1 fencing.
+ */
+
+const NON_BLANK = /[!-~]/
+const OUTBOUND_KINDS: ReadonlySet<string> = new Set(['execution', 'test_run'])
+/** last_error is a bounded, redacted CLASS string — hard cap so a caller can never smuggle a body in. */
+const LAST_ERROR_MAX = 200
+
+export type OutboundIntentKind = 'execution' | 'test_run'
+export type OutboundIntentStatus = 'pending' | 'sent' | 'failed' | 'outcome_unknown'
+export type OutboundOutcome = 'sent' | 'failed' | 'outcome_unknown'
+export type OutboundClaimDecision = 'proceed' | 'skip_sent' | 'skip_unknown' | 'retry_failed'
+
+export interface OutboundIntentIdentity {
+  kind: OutboundIntentKind
+  /** kind='execution': the execution lineage root; kind='test_run': the §6.1 server-derived scoped root. */
+  rootExecutionId: string
+  /** the §2.1 triple identity — produce with deriveActionKey (injective JSON-array encoding). */
+  actionKey: string
+}
+
+/** The autocommit query fn shape used across the automation executor (AutomationDeps['queryFn']). */
+export type OutboundQueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+/**
+ * #4196 Class-B outbound RUNTIME GATE — default OFF. The executor's send_* methods only take the two-phase
+ * intent/outcome path when this is ON AND a class-A action identity is present. Off ⇒ every send path is
+ * BYTE-IDENTICAL to pre-slice (no intent row, no classification, no outcome write). Follows the repo flag
+ * convention (`env.<NAME> === 'true'`, mirroring isClassAExecutionClaimEnabled).
+ */
+export function isClassBOutboundEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.AUTOMATION_CLASSB_OUTBOUND_ENABLED === 'true'
+}
+
+function assertIdentity(id: OutboundIntentIdentity, fn: string): void {
+  if (typeof id.kind !== 'string' || !OUTBOUND_KINDS.has(id.kind)) {
+    throw new RangeError(`${fn}: kind must be 'execution' | 'test_run' (got ${String(id.kind)})`)
+  }
+  for (const [name, v] of [['rootExecutionId', id.rootExecutionId], ['actionKey', id.actionKey]] as const) {
+    if (typeof v !== 'string' || !NON_BLANK.test(v)) {
+      throw new RangeError(`${fn}: ${name} must be non-blank`)
+    }
+  }
+}
+
+/**
+ * Tx A — record intent (its own committed transaction, BEFORE the network call). INSERT a fresh `pending`
+ * row; ON CONFLICT DO NOTHING. The decision governs whether the caller performs the send:
+ *
+ *   - fresh insert (rowCount 1) → 'proceed' — we own a fresh `pending`; attempt the send.
+ *   - row already exists (rowCount 0) → consult its status:
+ *       'sent'            → 'skip_sent'    — already delivered; do NOT resend.
+ *       'outcome_unknown' → 'skip_unknown' — §3 TERMINAL; NEVER auto-resend.
+ *       'pending'         → a prior attempt committed intent then CRASHED before recording an outcome ⇒ the
+ *                           send MAY have happened ⇒ FAIL CLOSED: flip pending→outcome_unknown (guarded
+ *                           `AND status='pending'`) and return 'skip_unknown' — never a second send.
+ *       'failed'          → prior attempt was DEFINITE pre-dispatch non-delivery (nothing ever sent) ⇒
+ *                           eligible to re-attempt: flip failed→pending (attempts+1) and return
+ *                           'retry_failed' (caller attempts the send).
+ *       (absent/other)    → the row vanished between the conflict and the SELECT (concurrent delete) ⇒ fail
+ *                           closed to 'skip_unknown'; never send when the state cannot be proven.
+ */
+export async function claimOutboundIntent(
+  query: OutboundQueryFn,
+  id: OutboundIntentIdentity,
+): Promise<OutboundClaimDecision> {
+  assertIdentity(id, 'claimOutboundIntent')
+  const inserted = await query(
+    `INSERT INTO meta_automation_outbound_intent (kind, root_execution_id, action_key)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (kind, root_execution_id, action_key) DO NOTHING`,
+    [id.kind, id.rootExecutionId, id.actionKey],
+  )
+  if (Number(inserted.rowCount ?? 0) === 1) return 'proceed'
+
+  const consult = await query(
+    `SELECT status FROM meta_automation_outbound_intent
+      WHERE kind = $1 AND root_execution_id = $2 AND action_key = $3`,
+    [id.kind, id.rootExecutionId, id.actionKey],
+  )
+  const status = (consult.rows[0] as { status?: string } | undefined)?.status
+
+  if (status === 'sent') return 'skip_sent'
+  if (status === 'outcome_unknown') return 'skip_unknown'
+  if (status === 'pending') {
+    // CRASH-MID-SEND fail-closed flip. Guarded `AND status='pending'` so a racing writer that already
+    // terminalized the row does not get clobbered back to unknown. NEVER auto-resend after this.
+    await query(
+      `UPDATE meta_automation_outbound_intent
+          SET status = 'outcome_unknown', updated_at = now()
+        WHERE kind = $1 AND root_execution_id = $2 AND action_key = $3 AND status = 'pending'`,
+      [id.kind, id.rootExecutionId, id.actionKey],
+    )
+    return 'skip_unknown'
+  }
+  if (status === 'failed') {
+    // Definite pre-dispatch non-delivery last time (nothing left the client) ⇒ safe to re-attempt.
+    await query(
+      `UPDATE meta_automation_outbound_intent
+          SET status = 'pending', attempts = attempts + 1, updated_at = now()
+        WHERE kind = $1 AND root_execution_id = $2 AND action_key = $3 AND status = 'failed'`,
+      [id.kind, id.rootExecutionId, id.actionKey],
+    )
+    return 'retry_failed'
+  }
+  // Row vanished (swept/deleted concurrently) — cannot prove non-delivery, so never send.
+  return 'skip_unknown'
+}
+
+/**
+ * Tx B — record outcome (a SECOND, separate commit AFTER the attempt). The `AND status='pending'` guard is
+ * the SINGLE-WRITER guard: a concurrent zombie that already terminalized the row writes 0 rows, so the
+ * terminal outcome is written exactly once. `lastError` is bounded + stored as-is: callers pass a REDACTED
+ * reason CLASS (see {@link outboundReasonClass}), never a raw body/URL/token; the bound is defense-in-depth.
+ */
+export async function recordOutboundOutcome(
+  query: OutboundQueryFn,
+  id: OutboundIntentIdentity,
+  outcome: OutboundOutcome,
+  lastError?: string | null,
+): Promise<void> {
+  assertIdentity(id, 'recordOutboundOutcome')
+  if (outcome !== 'sent' && outcome !== 'failed' && outcome !== 'outcome_unknown') {
+    throw new RangeError(`recordOutboundOutcome: outcome must be 'sent' | 'failed' | 'outcome_unknown'`)
+  }
+  const boundedError = lastError == null ? null : String(lastError).slice(0, LAST_ERROR_MAX)
+  await query(
+    `UPDATE meta_automation_outbound_intent
+        SET status = $4, last_error = $5, updated_at = now()
+      WHERE kind = $1 AND root_execution_id = $2 AND action_key = $3 AND status = 'pending'`,
+    [id.kind, id.rootExecutionId, id.actionKey, outcome, boundedError],
+  )
+}
+
+/**
+ * The single attempt's transport result, in a values-free shape so classification is unit-testable without
+ * a live socket:
+ *   - `response`      — fetch RESOLVED with a Response; only the HTTP status matters (never the body).
+ *   - `timeout`       — the per-attempt timeout / caller abort fired.
+ *   - `network-error` — fetch REJECTED without producing a response; `code`/`name` are the undici system
+ *     error identifiers used to tell DEFINITE pre-dispatch non-delivery from ambiguous post-dispatch loss.
+ */
+export type OutboundAttemptResult =
+  | { kind: 'response'; status: number }
+  | { kind: 'timeout' }
+  | { kind: 'network-error'; code: string | null; name?: string | null }
+
+/**
+ * Node/undici DNS-resolution and connection-refused system error codes: the request body never left the
+ * client, so the receiver cannot have acted on it — the ENTIRE definite-`failed` set alongside TLS below.
+ */
+const PRE_DISPATCH_NON_DELIVERY_CODES: ReadonlySet<string> = new Set([
+  'ENOTFOUND', // DNS: host not found
+  'EAI_AGAIN', // DNS: temporary resolution failure
+  'ECONNREFUSED', // connection refused (no listener) — the TCP handshake never completed
+])
+
+/**
+ * TLS handshake failure — the handshake PRECEDES any request body leaving the client, so a cert/SSL error
+ * is definite pre-dispatch non-delivery. Node surfaces these as a curated set of codes plus the
+ * `ERR_TLS_*` / `ERR_SSL_*` families.
+ */
+const TLS_HANDSHAKE_CODES: ReadonlySet<string> = new Set([
+  'CERT_HAS_EXPIRED',
+  'CERT_NOT_YET_VALID',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+  'HOSTNAME_MISMATCH',
+])
+
+function isPreDispatchNonDelivery(code: string | null | undefined): boolean {
+  if (typeof code !== 'string' || code.length === 0) return false
+  if (PRE_DISPATCH_NON_DELIVERY_CODES.has(code)) return true
+  if (TLS_HANDSHAKE_CODES.has(code)) return true
+  return code.startsWith('ERR_TLS_') || code.startsWith('ERR_SSL_')
+}
+
+/**
+ * §3 + §8 Q-B classification, MIRRORING the DingTalk transport's `send`-tier doctrine
+ * (`integrations/dingtalk/transport.ts:110-136`): "network error ≠ not executed; an ambiguous outcome is
+ * `outcome_unknown`, never auto-resent." Tiers:
+ *
+ *   - 2xx → 'sent'.
+ *   - DEFINITE pre-dispatch non-delivery ONLY (nothing left the client): DNS failure, connection refused,
+ *     TLS handshake failure → 'failed' (eligible to re-attempt).
+ *   - EVERYTHING after the body was sent → 'outcome_unknown': request timeout, connection reset, ANY HTTP
+ *     status received (INCLUDING every 4xx per §8 Q-B — NO 4xx subset is definite-`failed` in v1 — and every
+ *     5xx/3xx), or any client-indistinguishable network error (ECONNRESET/EPIPE/ETIMEDOUT/unknown).
+ *
+ * NOTE (reported lock-vs-transport divergence): the literal `classifyDingTalkFailure` marks a generic 4xx
+ * and a DNS/conn-refused `network_error` on the send tier as NOT-unknown / unknown respectively; the LOCK
+ * (§3, §8 Q-B) is MORE conservative for webhook/email — every 4xx ⇒ outcome_unknown, and DNS/conn-refused/
+ * TLS is carved out as plain `failed`. Per the build directive the LOCK wins; this mirrors the transport's
+ * *tiers* (read/exchange/send), not that call site's DingTalk-specific 4xx/network boundaries.
+ */
+export function classifyOutboundResult(result: OutboundAttemptResult): OutboundOutcome {
+  if (result.kind === 'response') {
+    return result.status >= 200 && result.status < 300 ? 'sent' : 'outcome_unknown'
+  }
+  if (result.kind === 'timeout') {
+    return 'outcome_unknown'
+  }
+  // network-error: only DEFINITE pre-dispatch non-delivery is plain `failed`; all else is ambiguous.
+  return isPreDispatchNonDelivery(result.code) ? 'failed' : 'outcome_unknown'
+}
+
+/**
+ * A BOUNDED, REDACTED reason CLASS for `last_error` — a coarse category, never a raw body/URL/token. Kept
+ * in lock-step with {@link classifyOutboundResult} so the recorded class matches the recorded status.
+ */
+export function outboundReasonClass(result: OutboundAttemptResult): string {
+  if (result.kind === 'response') {
+    return result.status >= 200 && result.status < 300 ? 'sent_2xx' : `http_${result.status}`
+  }
+  if (result.kind === 'timeout') return 'timeout'
+  const code = result.code
+  if (typeof code === 'string' && code.length > 0) {
+    if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') return 'dns_failure'
+    if (code === 'ECONNREFUSED') return 'conn_refused'
+    if (isPreDispatchNonDelivery(code)) return 'tls_failure'
+    return `network_${code}`.slice(0, LAST_ERROR_MAX)
+  }
+  return 'network_error'
+}
+
+/**
+ * Map a raw fetch rejection to the values-free {@link OutboundAttemptResult}. A caller-abort / per-attempt
+ * timeout surfaces as `timeout`; every other rejection is a `network-error` whose `code`/`name` are read
+ * from the error and its undici `cause` (undici wraps the socket error as the `cause` of a TypeError).
+ */
+export function classifyFetchError(error: unknown): OutboundAttemptResult {
+  if (typeof error === 'object' && error !== null) {
+    const name = (error as { name?: unknown }).name
+    const cause = (error as { cause?: unknown }).cause
+    const causeName = typeof cause === 'object' && cause !== null ? (cause as { name?: unknown }).name : undefined
+    if (name === 'AbortError' || name === 'TimeoutError' || causeName === 'AbortError' || causeName === 'TimeoutError') {
+      return { kind: 'timeout' }
+    }
+    const directCode = (error as { code?: unknown }).code
+    const causeCode = typeof cause === 'object' && cause !== null ? (cause as { code?: unknown }).code : undefined
+    const code = typeof directCode === 'string' ? directCode : typeof causeCode === 'string' ? causeCode : null
+    return { kind: 'network-error', code, name: typeof name === 'string' ? name : null }
+  }
+  return { kind: 'network-error', code: null, name: null }
+}

--- a/packages/core-backend/tests/integration/multitable-automation-outbound-intent-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-outbound-intent-realdb.test.ts
@@ -1,0 +1,134 @@
+/**
+ * #4196 Class-B outbound two-phase intent/outcome — real-DB goldens (design-lock
+ * `approval-automation-retry-action-classification-designlock-20260712.md` §3 + §8 Q-B + §9 V3/V7).
+ *
+ * Proves against a REAL Postgres schema:
+ *   - the §3 table shape: named CHECKs (kind closed set, non-blank root/action_key, status closed set,
+ *     attempts non-negative) reject by constraint name; the UNIQUE (kind, root, action_key) identity index;
+ *   - the two-phase HAPPY path (proceed → sent; retry consults `sent` → skip_sent, NO resend);
+ *   - the CRASH-MID-SEND hazard: intent committed `pending`, NO outcome recorded, a retry sees `pending`
+ *     and FAILS CLOSED — flips it to `outcome_unknown` and returns `skip_unknown` (never a second send);
+ *   - `outcome_unknown` is TERMINAL: a further retry stays `skip_unknown`;
+ *   - DEFINITE pre-dispatch non-delivery (`failed`) is re-attemptable (`retry_failed`) and can then succeed;
+ *   - the `status='pending'` single-writer guard: a late terminal write does NOT clobber a terminalized row;
+ *   - §6.1 STRUCTURAL disjointness: execution vs test_run under identical root+action_key are independent.
+ *
+ * Two-point wired (plugin-tests.yml + vitest.config.ts exclude) so it cannot skip-green.
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import {
+  claimOutboundIntent,
+  recordOutboundOutcome,
+  type OutboundIntentIdentity,
+  type OutboundQueryFn,
+} from '../../src/multitable/automation-outbound-intent'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const q: OutboundQueryFn = (sql, params) => poolManager.get().query(sql, params)
+const RUN = randomUUID()
+const ROOT = `exec_${RUN}`
+
+const id = (suffix: string, kind: 'execution' | 'test_run' = 'execution'): OutboundIntentIdentity => ({
+  kind,
+  rootExecutionId: ROOT,
+  actionKey: `ak_${RUN}_${suffix}`,
+})
+const statusOf = async (i: OutboundIntentIdentity): Promise<string | undefined> => {
+  const { rows } = await q(
+    `SELECT status FROM meta_automation_outbound_intent WHERE kind=$1 AND root_execution_id=$2 AND action_key=$3`,
+    [i.kind, i.rootExecutionId, i.actionKey],
+  )
+  return (rows[0] as { status?: string } | undefined)?.status
+}
+const rawInsert = (kind: string, root: string, key: string, status = 'pending') =>
+  q(`INSERT INTO meta_automation_outbound_intent (kind, root_execution_id, action_key, status) VALUES ($1,$2,$3,$4)`, [kind, root, key, status])
+
+describeIfDatabase('#4196 Class-B outbound two-phase intent/outcome (real DB)', () => {
+  afterAll(async () => {
+    await q(`DELETE FROM meta_automation_outbound_intent WHERE root_execution_id LIKE $1`, [`%${RUN}%`]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('schema: named CHECKs reject bad kind / blank identity / bad status / negative attempts by constraint name', async () => {
+    await expect(rawInsert('bogus', ROOT, `ak_${RUN}_c1`)).rejects.toThrow(/outbound_intent_kind_valid/)
+    await expect(rawInsert('execution', '  ', `ak_${RUN}_c2`)).rejects.toThrow(/outbound_intent_root_nonblank/)
+    await expect(rawInsert('execution', ROOT, '\t')).rejects.toThrow(/outbound_intent_action_key_nonblank/)
+    await expect(rawInsert('execution', ROOT, `ak_${RUN}_c3`, 'delivered')).rejects.toThrow(/outbound_intent_status_valid/)
+    await expect(
+      q(`INSERT INTO meta_automation_outbound_intent (kind, root_execution_id, action_key, attempts) VALUES ($1,$2,$3,$4)`, ['execution', ROOT, `ak_${RUN}_c4`, -1]),
+    ).rejects.toThrow(/outbound_intent_attempts_nonneg/)
+  })
+
+  test('schema: the UNIQUE (kind, root, action_key) identity collides a duplicate by index name', async () => {
+    await rawInsert('execution', ROOT, `ak_${RUN}_uq`)
+    await expect(rawInsert('execution', ROOT, `ak_${RUN}_uq`)).rejects.toThrow(/uq_outbound_intent_identity/)
+  })
+
+  test('§6.1 disjointness: execution vs test_run under identical root+action_key are independent identities', async () => {
+    const key = `ak_${RUN}_kinds`
+    await expect(rawInsert('execution', ROOT, key)).resolves.toBeTruthy()
+    await expect(rawInsert('test_run', ROOT, key)).resolves.toBeTruthy()
+  })
+
+  test('two-phase HAPPY: proceed → record sent → retry consults sent → skip_sent (no resend)', async () => {
+    const i = id('happy')
+    expect(await claimOutboundIntent(q, i)).toBe('proceed')
+    await recordOutboundOutcome(q, i, 'sent', 'sent_2xx')
+    expect(await statusOf(i)).toBe('sent')
+    expect(await claimOutboundIntent(q, i)).toBe('skip_sent') // a retry never re-sends a delivered intent
+  })
+
+  test('CRASH-MID-SEND: pending intent, NO outcome, retry → flips pending→outcome_unknown → skip_unknown (never a 2nd send)', async () => {
+    const i = id('crash')
+    expect(await claimOutboundIntent(q, i)).toBe('proceed') // intent committed pending; then "crash" (no outcome)
+    expect(await statusOf(i)).toBe('pending')
+    expect(await claimOutboundIntent(q, i)).toBe('skip_unknown') // the retry fails closed
+    expect(await statusOf(i)).toBe('outcome_unknown') // flipped — the send may have happened, never resend
+  })
+
+  test('outcome_unknown is TERMINAL: a further retry stays skip_unknown', async () => {
+    const i = id('terminal')
+    await claimOutboundIntent(q, i)
+    await recordOutboundOutcome(q, i, 'outcome_unknown', 'timeout')
+    expect(await statusOf(i)).toBe('outcome_unknown')
+    expect(await claimOutboundIntent(q, i)).toBe('skip_unknown')
+    expect(await claimOutboundIntent(q, i)).toBe('skip_unknown')
+  })
+
+  test('DEFINITE non-delivery (failed) → retry_failed permitted → can then succeed', async () => {
+    const i = id('failed')
+    await claimOutboundIntent(q, i)
+    await recordOutboundOutcome(q, i, 'failed', 'dns_failure') // nothing ever left the client
+    expect(await statusOf(i)).toBe('failed')
+    expect(await claimOutboundIntent(q, i)).toBe('retry_failed') // eligible to re-attempt
+    expect(await statusOf(i)).toBe('pending')
+    const { rows } = await q(`SELECT attempts FROM meta_automation_outbound_intent WHERE kind=$1 AND root_execution_id=$2 AND action_key=$3`, [i.kind, i.rootExecutionId, i.actionKey])
+    expect(Number((rows[0] as { attempts: number }).attempts)).toBe(1) // attempt bumped
+    await recordOutboundOutcome(q, i, 'sent', 'sent_2xx')
+    expect(await claimOutboundIntent(q, i)).toBe('skip_sent')
+  })
+
+  test('status=pending single-writer guard: a late terminal write does NOT clobber a terminalized row', async () => {
+    const i = id('guard')
+    await claimOutboundIntent(q, i)
+    await recordOutboundOutcome(q, i, 'outcome_unknown', 'timeout') // terminalized
+    await recordOutboundOutcome(q, i, 'sent', 'sent_2xx') // a zombie's late write — must be a 0-row no-op
+    expect(await statusOf(i)).toBe('outcome_unknown') // stays terminal
+  })
+
+  test('constructed race: two concurrent first-claims of the same identity → exactly one proceed', async () => {
+    const i = id('race')
+    const [a, b] = await Promise.all([claimOutboundIntent(q, i), claimOutboundIntent(q, i)])
+    // Exactly one wins the fresh INSERT ('proceed'); the loser sees the row. Its status is 'pending' (the
+    // winner has not recorded an outcome yet) so it fails closed to skip_unknown, never a duplicate send.
+    expect([a, b].filter((r) => r === 'proceed')).toHaveLength(1)
+    expect([a, b].filter((r) => r === 'skip_unknown')).toHaveLength(1)
+  })
+})

--- a/packages/core-backend/tests/unit/automation-classb-outbound.test.ts
+++ b/packages/core-backend/tests/unit/automation-classb-outbound.test.ts
@@ -1,0 +1,165 @@
+/**
+ * #4196 Class-B outbound two-phase — executor wiring (unit) for send_webhook.
+ *
+ * Proves the two-phase intent/outcome path drives send_webhook when AUTOMATION_CLASSB_OUTBOUND_ENABLED is
+ * ON AND an execution identity is present, and that with the flag OFF the send path is BYTE-IDENTICAL to
+ * pre-slice (legacy in-call retry loop, no intent row ever written).
+ *
+ * deps.queryFn routes `meta_automation_outbound_intent` SQL through an in-memory table (shared across two
+ * execute() calls so a "retry" — same lineage root — consults the SAME row); deps.fetchFn is the send spy.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  AutomationExecutor,
+  type AutomationDeps,
+  type AutomationRule,
+} from '../../src/multitable/automation-executor'
+import { EventBus } from '../../src/integration/events/event-bus'
+
+const FLAG = 'AUTOMATION_CLASSB_OUTBOUND_ENABLED'
+const ROOT = 'exec_root_classb'
+const WEBHOOK = { type: 'send_webhook', config: { url: 'https://example.test/hook', body: { x: 1 } } }
+const TRIGGER = { recordId: 'rec_1', sheetId: 'sheet_1', actorId: 'user_1', data: {} }
+
+interface Harness {
+  deps: AutomationDeps
+  fetch: ReturnType<typeof vi.fn>
+  intent: Map<string, { status: string; attempts: number; last_error: string | null }>
+  intentInserts: number
+}
+
+/** A response-shaped stub for the send spy. */
+const resp = (status: number) => ({ ok: status >= 200 && status < 300, status }) as unknown as Response
+
+function makeHarness(fetchImpl: (call: number) => unknown): Harness {
+  const intent = new Map<string, { status: string; attempts: number; last_error: string | null }>()
+  let calls = 0
+  const fetchSpy = vi.fn(async () => {
+    const out = fetchImpl(calls++)
+    if (out instanceof Error) throw out
+    return out as Response
+  })
+  const state = { intentInserts: 0 }
+  const keyOf = (p: unknown[]) => `${String(p[0])}|${String(p[1])}|${String(p[2])}`
+  const queryFn = vi.fn(async (sql: string, params: unknown[] = []) => {
+    const s = String(sql)
+    if (/meta_automation_outbound_intent/i.test(s)) {
+      const key = keyOf(params)
+      if (/^\s*INSERT INTO/i.test(s)) {
+        if (intent.has(key)) return { rows: [], rowCount: 0 }
+        intent.set(key, { status: 'pending', attempts: 0, last_error: null })
+        state.intentInserts++
+        return { rows: [], rowCount: 1 }
+      }
+      if (/^\s*SELECT status/i.test(s)) {
+        const r = intent.get(key)
+        return { rows: r ? [{ status: r.status }] : [], rowCount: r ? 1 : 0 }
+      }
+      // UPDATE — honor the `AND status = '…'` guard parsed from the SQL text.
+      const r = intent.get(key)
+      if (!r) return { rows: [], rowCount: 0 }
+      const guard = /AND status = '([a-z_]+)'/i.exec(s)?.[1] ?? null
+      if (guard && r.status !== guard) return { rows: [], rowCount: 0 }
+      const literal = /SET status = '([a-z_]+)'/i.exec(s)?.[1]
+      r.status = literal ?? (s.includes('status = $4') ? String(params[3]) : r.status)
+      if (/attempts = attempts \+ 1/i.test(s)) r.attempts += 1
+      if (s.includes('last_error = $5')) r.last_error = (params[4] ?? null) as string | null
+      return { rows: [], rowCount: 1 }
+    }
+    return { rows: [], rowCount: 1 }
+  }) as unknown as AutomationDeps['queryFn']
+  return {
+    deps: { eventBus: new EventBus(), queryFn, fetchFn: fetchSpy as unknown as typeof fetch },
+    fetch: fetchSpy,
+    intent,
+    get intentInserts() { return state.intentInserts },
+  } as Harness
+}
+
+function ruleWith(action: { type: string; config: Record<string, unknown> }): AutomationRule {
+  return {
+    id: 'rule_cb', name: 'Class-B rule', sheetId: 'sheet_1',
+    trigger: { type: 'record.created', config: {} },
+    actions: [action as never], enabled: true, createdBy: 'user_1', createdAt: '2026-01-01T00:00:00Z',
+  } as AutomationRule
+}
+const only = (m: Map<string, { status: string; attempts: number; last_error: string | null }>) => [...m.values()][0]
+
+beforeEach(() => { delete process.env[FLAG] })
+afterEach(() => { delete process.env[FLAG]; vi.restoreAllMocks() })
+
+describe('flag OFF — byte-identical legacy send_webhook (no intent row)', () => {
+  it('2xx success: one fetch, success step, NO intent SQL written', async () => {
+    const h = makeHarness(() => resp(200))
+    const exec = await new AutomationExecutor(h.deps).execute(ruleWith(WEBHOOK), TRIGGER, undefined, ROOT)
+    expect(exec.steps[0]?.status).toBe('success')
+    expect(exec.steps[0]?.alreadyApplied).toBeUndefined()
+    expect(h.fetch).toHaveBeenCalledTimes(1)
+    expect(h.intentInserts).toBe(0) // the two-phase table was never touched
+    expect(h.intent.size).toBe(0)
+  })
+
+  it('non-2xx keeps the legacy in-call retry loop (fetched retries+1 times, then a failed step)', async () => {
+    const h = makeHarness(() => resp(500))
+    const exec = await new AutomationExecutor(h.deps).execute(ruleWith(WEBHOOK), TRIGGER, undefined, ROOT)
+    expect(exec.steps[0]?.status).toBe('failed')
+    expect(h.fetch.mock.calls.length).toBeGreaterThan(1) // the legacy loop retried — proves OFF path unchanged
+    expect(h.intent.size).toBe(0)
+  })
+})
+
+describe('flag ON — two-phase intent/outcome', () => {
+  beforeEach(() => { process.env[FLAG] = 'true' })
+
+  it('proceed → sent: single fetch, success step, intent row = sent', async () => {
+    const h = makeHarness(() => resp(200))
+    const exec = await new AutomationExecutor(h.deps).execute(ruleWith(WEBHOOK), TRIGGER, undefined, ROOT)
+    expect(exec.steps[0]?.status).toBe('success')
+    expect(h.fetch).toHaveBeenCalledTimes(1) // exactly one attempt — NO legacy retry loop
+    expect(only(h.intent).status).toBe('sent')
+  })
+
+  it('retry after sent → skip_sent: alreadyApplied, NO second fetch', async () => {
+    const h = makeHarness(() => resp(200))
+    await new AutomationExecutor(h.deps).execute(ruleWith(WEBHOOK), TRIGGER, undefined, ROOT) // first: sent
+    const second = await new AutomationExecutor(h.deps).execute(ruleWith(WEBHOOK), TRIGGER, undefined, ROOT) // retry
+    expect(second.steps[0]?.status).toBe('success')
+    expect(second.steps[0]?.alreadyApplied).toBe(true)
+    expect(h.fetch).toHaveBeenCalledTimes(1) // NOT re-sent
+    expect(only(h.intent).status).toBe('sent')
+  })
+
+  it('4xx (§8 Q-B) → outcome_unknown: failed-shaped step naming outcome_unknown; retry → skip_unknown, no resend', async () => {
+    const h = makeHarness(() => resp(404))
+    const first = await new AutomationExecutor(h.deps).execute(ruleWith(WEBHOOK), TRIGGER, undefined, ROOT)
+    expect(first.steps[0]?.status).toBe('failed')
+    expect(first.steps[0]?.error).toMatch(/outcome_unknown/)
+    expect(only(h.intent).status).toBe('outcome_unknown')
+    const retry = await new AutomationExecutor(h.deps).execute(ruleWith(WEBHOOK), TRIGGER, undefined, ROOT)
+    expect(retry.steps[0]?.alreadyApplied).toBe(true) // skip_unknown → alreadyApplied
+    expect(h.fetch).toHaveBeenCalledTimes(1) // TERMINAL: never a second send
+  })
+
+  it('DNS failure (ENOTFOUND) → failed step; retry → retry_failed re-attempts (fetch called again)', async () => {
+    // First attempt DNS-fails (definite pre-dispatch non-delivery), the retry succeeds.
+    const h = makeHarness((call) => (call === 0 ? Object.assign(new TypeError('fetch failed'), { cause: Object.assign(new Error('dns'), { code: 'ENOTFOUND' }) }) : resp(200)))
+    const first = await new AutomationExecutor(h.deps).execute(ruleWith(WEBHOOK), TRIGGER, undefined, ROOT)
+    expect(first.steps[0]?.status).toBe('failed')
+    expect(first.steps[0]?.error).toMatch(/definite non-delivery/)
+    expect(only(h.intent).status).toBe('failed')
+    const retry = await new AutomationExecutor(h.deps).execute(ruleWith(WEBHOOK), TRIGGER, undefined, ROOT)
+    expect(retry.steps[0]?.status).toBe('success')
+    expect(h.fetch).toHaveBeenCalledTimes(2) // re-attempted — a definite failure is retryable
+    expect(only(h.intent).status).toBe('sent')
+  })
+
+  it('no identity (runSingleAction ad-hoc dispatch) → no intent even with the flag ON', async () => {
+    const h = makeHarness(() => resp(200))
+    const result = await new AutomationExecutor(h.deps).runSingleAction(WEBHOOK as never, {
+      executionId: 'x', ruleId: 'r', sheetId: 'sheet_1', recordId: 'rec_1', recordData: {}, ruleCreatedBy: 'user_1', actorId: 'user_1', triggerEvent: null,
+    })
+    expect(result.status).toBe('success')
+    expect(h.intent.size).toBe(0) // ad-hoc dispatch has no lineage → no intent
+  })
+})

--- a/packages/core-backend/tests/unit/automation-outbound-intent.test.ts
+++ b/packages/core-backend/tests/unit/automation-outbound-intent.test.ts
@@ -1,0 +1,221 @@
+/**
+ * #4196 Class-B outbound two-phase intent/outcome — module unit tests (design-lock
+ * `approval-automation-retry-action-classification-designlock-20260712.md` §3 + §8 Q-B).
+ *
+ * Fast local proof of (1) the §3+§8-Q-B classification tiers and (2) the two-phase state machine
+ * (`claimOutboundIntent` / `recordOutboundOutcome`) against an IN-MEMORY table mock that faithfully honors
+ * the guard clauses read from the SQL TEXT — so the crash-flip and the `status='pending'` single-writer
+ * guard are mutation-provable here as well as in the real-DB golden.
+ *
+ * The mock keys rows by (kind, root, action_key) and parses each statement:
+ *   - INSERT ... ON CONFLICT DO NOTHING  → rowCount 1 if new, 0 if the identity already exists;
+ *   - SELECT status                      → the current status;
+ *   - UPDATE ... SET status = 'X' ...    → applies iff the row's status satisfies the `AND status = '…'`
+ *     guard PARSED FROM THE SQL (so deleting a guard in the module changes behavior through the mock).
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  claimOutboundIntent,
+  classifyFetchError,
+  classifyOutboundResult,
+  isClassBOutboundEnabled,
+  outboundReasonClass,
+  recordOutboundOutcome,
+  type OutboundAttemptResult,
+  type OutboundIntentIdentity,
+  type OutboundQueryFn,
+} from '../../src/multitable/automation-outbound-intent'
+
+// ── in-memory faithful table mock ────────────────────────────────────────────
+interface Row {
+  status: string
+  attempts: number
+  last_error: string | null
+}
+function makeTable(): { query: OutboundQueryFn; rows: Map<string, Row> } {
+  const rows = new Map<string, Row>()
+  const keyOf = (p: unknown[]) => `${String(p[0])}|${String(p[1])}|${String(p[2])}`
+  const query: OutboundQueryFn = async (sql, params = []) => {
+    const s = String(sql)
+    const key = keyOf(params)
+    if (/^\s*INSERT INTO meta_automation_outbound_intent/i.test(s)) {
+      if (rows.has(key)) return { rows: [], rowCount: 0 } // ON CONFLICT DO NOTHING
+      rows.set(key, { status: 'pending', attempts: 0, last_error: null })
+      return { rows: [], rowCount: 1 }
+    }
+    if (/^\s*SELECT status FROM meta_automation_outbound_intent/i.test(s)) {
+      const r = rows.get(key)
+      return { rows: r ? [{ status: r.status }] : [], rowCount: r ? 1 : 0 }
+    }
+    if (/^\s*UPDATE meta_automation_outbound_intent/i.test(s)) {
+      const r = rows.get(key)
+      if (!r) return { rows: [], rowCount: 0 }
+      // Honor whichever `AND status = '…'` guard the SQL actually carries (absent ⇒ unconditional).
+      const guard = /AND status = '([a-z_]+)'/i.exec(s)?.[1] ?? null
+      if (guard && r.status !== guard) return { rows: [], rowCount: 0 }
+      // Target status: a literal `SET status = 'X'` or the parameterized `SET status = $4`.
+      const literal = /SET status = '([a-z_]+)'/i.exec(s)?.[1]
+      const next = literal ?? (String(sql).includes('status = $4') ? String(params[3]) : r.status)
+      r.status = next
+      if (/attempts = attempts \+ 1/i.test(s)) r.attempts += 1
+      if (String(sql).includes('last_error = $5')) r.last_error = (params[4] ?? null) as string | null
+      rows.set(key, r)
+      return { rows: [], rowCount: 1 }
+    }
+    throw new Error(`unexpected SQL: ${s}`)
+  }
+  return { query, rows }
+}
+
+const ID: OutboundIntentIdentity = { kind: 'execution', rootExecutionId: 'exec_root_1', actionKey: 'ak_hook_1' }
+
+afterEach(() => {
+  delete process.env.AUTOMATION_CLASSB_OUTBOUND_ENABLED
+})
+
+// ── §3 + §8 Q-B classification ───────────────────────────────────────────────
+describe('classifyOutboundResult — §3 + §8 Q-B tiers', () => {
+  it('2xx → sent', () => {
+    for (const status of [200, 201, 202, 204, 299]) {
+      expect(classifyOutboundResult({ kind: 'response', status })).toBe('sent')
+    }
+  })
+
+  it('§8 Q-B: EVERY 4xx received after body-sent → outcome_unknown (NOT failed) — 400/404/409/429/499', () => {
+    for (const status of [400, 401, 403, 404, 409, 422, 429, 499]) {
+      expect(classifyOutboundResult({ kind: 'response', status })).toBe('outcome_unknown')
+    }
+  })
+
+  it('5xx and 3xx received after body-sent → outcome_unknown', () => {
+    for (const status of [301, 302, 500, 502, 503, 504]) {
+      expect(classifyOutboundResult({ kind: 'response', status })).toBe('outcome_unknown')
+    }
+  })
+
+  it('timeout → outcome_unknown (the request MAY be processing server-side)', () => {
+    expect(classifyOutboundResult({ kind: 'timeout' })).toBe('outcome_unknown')
+  })
+
+  it('DEFINITE pre-dispatch non-delivery ONLY → failed: DNS / conn-refused / TLS handshake', () => {
+    for (const code of ['ENOTFOUND', 'EAI_AGAIN', 'ECONNREFUSED']) {
+      expect(classifyOutboundResult({ kind: 'network-error', code })).toBe('failed')
+    }
+    for (const code of ['CERT_HAS_EXPIRED', 'DEPTH_ZERO_SELF_SIGNED_CERT', 'ERR_TLS_CERT_ALTNAME_INVALID', 'ERR_SSL_WRONG_VERSION_NUMBER']) {
+      expect(classifyOutboundResult({ kind: 'network-error', code })).toBe('failed')
+    }
+  })
+
+  it('post-dispatch / indistinguishable network errors → outcome_unknown (reset / broken pipe / socket timeout / unknown)', () => {
+    for (const code of ['ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'UND_ERR_SOCKET', null]) {
+      expect(classifyOutboundResult({ kind: 'network-error', code })).toBe('outcome_unknown')
+    }
+  })
+})
+
+describe('outboundReasonClass — bounded redacted classes (never a body/URL/token)', () => {
+  it('maps to coarse categories in lock-step with the outcome', () => {
+    expect(outboundReasonClass({ kind: 'response', status: 200 })).toBe('sent_2xx')
+    expect(outboundReasonClass({ kind: 'response', status: 404 })).toBe('http_404')
+    expect(outboundReasonClass({ kind: 'timeout' })).toBe('timeout')
+    expect(outboundReasonClass({ kind: 'network-error', code: 'ENOTFOUND' })).toBe('dns_failure')
+    expect(outboundReasonClass({ kind: 'network-error', code: 'ECONNREFUSED' })).toBe('conn_refused')
+    expect(outboundReasonClass({ kind: 'network-error', code: 'CERT_HAS_EXPIRED' })).toBe('tls_failure')
+    expect(outboundReasonClass({ kind: 'network-error', code: 'ECONNRESET' })).toBe('network_ECONNRESET')
+    expect(outboundReasonClass({ kind: 'network-error', code: null })).toBe('network_error')
+  })
+})
+
+describe('classifyFetchError — raw fetch rejection → values-free attempt result', () => {
+  it('AbortError / TimeoutError (direct or as cause) → timeout', () => {
+    const abort = Object.assign(new Error('aborted'), { name: 'AbortError' })
+    expect(classifyFetchError(abort)).toEqual({ kind: 'timeout' })
+    const wrapped = Object.assign(new TypeError('terminated'), { cause: Object.assign(new Error('t'), { name: 'TimeoutError' }) })
+    expect(classifyFetchError(wrapped)).toEqual({ kind: 'timeout' })
+  })
+
+  it('undici TypeError with a socket cause → network-error carrying cause.code', () => {
+    const err = Object.assign(new TypeError('fetch failed'), { cause: Object.assign(new Error('x'), { code: 'ECONNREFUSED' }) })
+    expect(classifyFetchError(err)).toEqual({ kind: 'network-error', code: 'ECONNREFUSED', name: 'TypeError' })
+  })
+
+  it('direct .code (e.g. ENOTFOUND) is read when there is no cause', () => {
+    const err = Object.assign(new Error('dns'), { code: 'ENOTFOUND' })
+    expect(classifyFetchError(err)).toEqual({ kind: 'network-error', code: 'ENOTFOUND', name: 'Error' })
+  })
+
+  it('a non-object rejection → network-error with null code', () => {
+    expect(classifyFetchError('boom')).toEqual({ kind: 'network-error', code: null, name: null })
+  })
+})
+
+// ── two-phase state machine (in-memory mock) ─────────────────────────────────
+describe('claimOutboundIntent — two-phase decisions', () => {
+  it('happy path: fresh insert → proceed; after sent → skip_sent (no resend)', async () => {
+    const t = makeTable()
+    expect(await claimOutboundIntent(t.query, ID)).toBe('proceed')
+    await recordOutboundOutcome(t.query, ID, 'sent', 'sent_2xx')
+    expect(await claimOutboundIntent(t.query, ID)).toBe('skip_sent')
+    expect(t.rows.get('execution|exec_root_1|ak_hook_1')?.status).toBe('sent')
+  })
+
+  it('CRASH-MID-SEND: intent pending, no outcome recorded, retry → flips pending→outcome_unknown and skip_unknown', async () => {
+    const t = makeTable()
+    expect(await claimOutboundIntent(t.query, ID)).toBe('proceed') // committed pending, then "crash" (no outcome)
+    const decision = await claimOutboundIntent(t.query, ID) // the retry
+    expect(decision).toBe('skip_unknown') // NEVER a second send
+    expect(t.rows.get('execution|exec_root_1|ak_hook_1')?.status).toBe('outcome_unknown') // failed closed
+  })
+
+  it('outcome_unknown is TERMINAL: a further retry stays skip_unknown, never re-sends', async () => {
+    const t = makeTable()
+    await claimOutboundIntent(t.query, ID)
+    await recordOutboundOutcome(t.query, ID, 'outcome_unknown', 'timeout')
+    expect(await claimOutboundIntent(t.query, ID)).toBe('skip_unknown')
+    expect(await claimOutboundIntent(t.query, ID)).toBe('skip_unknown')
+  })
+
+  it('failed (definite pre-dispatch non-delivery) → retry_failed permitted → can then succeed', async () => {
+    const t = makeTable()
+    await claimOutboundIntent(t.query, ID)
+    await recordOutboundOutcome(t.query, ID, 'failed', 'dns_failure')
+    expect(await claimOutboundIntent(t.query, ID)).toBe('retry_failed') // eligible to re-attempt
+    expect(t.rows.get('execution|exec_root_1|ak_hook_1')?.status).toBe('pending')
+    expect(t.rows.get('execution|exec_root_1|ak_hook_1')?.attempts).toBe(1) // attempt bumped
+    await recordOutboundOutcome(t.query, ID, 'sent', 'sent_2xx')
+    expect(await claimOutboundIntent(t.query, ID)).toBe('skip_sent')
+  })
+
+  it('input validation: bad kind / blank root / blank key throw before any SQL', async () => {
+    const stub: OutboundQueryFn = async () => { throw new Error('must not be queried') }
+    await expect(claimOutboundIntent(stub, { kind: 'bogus' as never, rootExecutionId: 'r', actionKey: 'k' })).rejects.toThrow(/kind must be/)
+    await expect(claimOutboundIntent(stub, { kind: 'execution', rootExecutionId: ' ', actionKey: 'k' })).rejects.toThrow(/rootExecutionId/)
+    await expect(claimOutboundIntent(stub, { kind: 'execution', rootExecutionId: 'r', actionKey: '' })).rejects.toThrow(/actionKey/)
+  })
+})
+
+describe('recordOutboundOutcome — status=pending single-writer guard', () => {
+  it('a terminalized (outcome_unknown) row is NOT overwritten by a later sent (guard writes 0 rows)', async () => {
+    const t = makeTable()
+    await claimOutboundIntent(t.query, ID) // pending
+    await recordOutboundOutcome(t.query, ID, 'outcome_unknown', 'timeout') // terminal
+    await recordOutboundOutcome(t.query, ID, 'sent', 'sent_2xx') // a concurrent zombie's late write
+    expect(t.rows.get('execution|exec_root_1|ak_hook_1')?.status).toBe('outcome_unknown') // stays terminal
+  })
+
+  it('last_error is bounded to a redacted class (defense-in-depth cap)', async () => {
+    const t = makeTable()
+    await claimOutboundIntent(t.query, ID)
+    await recordOutboundOutcome(t.query, ID, 'failed', 'x'.repeat(500))
+    expect((t.rows.get('execution|exec_root_1|ak_hook_1')?.last_error ?? '').length).toBe(200)
+  })
+})
+
+describe('isClassBOutboundEnabled — default OFF', () => {
+  it('unset / anything-but-true → false; exactly "true" → true', () => {
+    expect(isClassBOutboundEnabled({} as NodeJS.ProcessEnv)).toBe(false)
+    expect(isClassBOutboundEnabled({ AUTOMATION_CLASSB_OUTBOUND_ENABLED: '1' } as unknown as NodeJS.ProcessEnv)).toBe(false)
+    expect(isClassBOutboundEnabled({ AUTOMATION_CLASSB_OUTBOUND_ENABLED: 'true' } as unknown as NodeJS.ProcessEnv)).toBe(true)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -368,6 +368,10 @@ export default defineConfig({
       // §6.1 derived test-run root): real Postgres only — excluded HERE so it cannot skip-green in the
       // no-DB lane, whole-file wired into `Run multitable real-DB integration` in plugin-tests.yml.
       'tests/integration/multitable-automation-execution-ledger-realdb.test.ts',
+      // #4196 Class-B outbound two-phase intent/outcome (§3 table + two-phase state machine + crash-flip +
+      // status='pending' single-writer guard): real Postgres only — excluded HERE so it cannot skip-green in
+      // the no-DB lane, whole-file wired into `Run multitable real-DB integration` in plugin-tests.yml.
+      'tests/integration/multitable-automation-outbound-intent-realdb.test.ts',
       // P2 durable-delivery S2-a claim engine / fence-CAS — real-DB constructed-concurrency (zombie/SKIP
       // LOCKED). Excluded HERE so it cannot skip-green in the no-DB lane; whole-file wired into
       // plugin-tests.yml. Two-point wiring.


### PR DESCRIPTION
## What

#4196 **Class-B — outbound / external side-effect two-phase intent/outcome**, grounded in the ratified design-lock `docs/development/approval-automation-retry-action-classification-designlock-20260712.md` §3 (+ §8 Q-B, §9 V7/V8/V9). Stacked on **#4432** (Class-A claim) — reuses its `ClassAActionIdentity` threading + `deriveActionKey` identity + `rootExecutionId`.

## Why

Class-B actions (`send_webhook`, `send_email`, `send_dingtalk_*`) leave the process, so no DB transaction can span the network call (§0). The correct answer is not a durability trade but **two-phase state + an `outcome_unknown` terminal state that NEVER auto-resends**, mirroring the DingTalk transport's `send`-tier doctrine ("network error ≠ not executed"). The core hazard is the **crash-mid-send** window: intent committed `pending`, the send may have gone out, process dies before recording an outcome — a retry must fail closed, never a second send.

## How

- **Migration** `meta_automation_outbound_intent` (`zzzz20260716110000…`): `pending → sent/failed/outcome_unknown`, `UNIQUE(kind, root_execution_id, action_key)`, named CHECKs (kind/status closed sets, non-blank root/action_key, attempts ≥ 0). New table; `down()` drops it. Same `kind` discriminator as the Class-A ledger (§2.2), so a `real_fire` test-run's intent is structurally disjoint from any real execution's.
- **Module** `automation-outbound-intent.ts` (values-free — identity is a sha256 key, `last_error` is a bounded redacted **class**, never a body/URL/token):
  - `claimOutboundIntent` (Tx A, own commit BEFORE the send): INSERT-or-consult → `proceed` / `skip_sent` / `skip_unknown` / `retry_failed`, **including the crash `pending`→`outcome_unknown` fail-closed flip**.
  - `recordOutboundOutcome` (Tx B, separate commit): `WHERE status='pending'` **single-writer guard** so a concurrent zombie that already terminalized the row writes 0 rows.
  - `classifyOutboundResult`: mirrors the transport `send`-tier — 2xx → `sent`; **every 4xx (§8 Q-B, no subset is definite-failed in v1)** + 5xx/3xx + timeout/reset → `outcome_unknown`; **only** DNS / conn-refused / TLS handshake (nothing left the client) → `failed`. Plus `classifyFetchError` / `outboundReasonClass` helpers.
- **Flag** `AUTOMATION_CLASSB_OUTBOUND_ENABLED` (default **OFF**). **Flag-OFF path is byte-identical** to today (proven by the existing send tests, unchanged).
- **Executor**: `send_webhook` **fully wired** — Tx A claim → `skip_sent`/`skip_unknown` short-circuit as a success-shaped `alreadyApplied` step with **no network call** → else a **single** attempt (no in-call resend on ambiguity) → classify → Tx B outcome → step result (`sent`=success, `failed`=failed/retryable, `outcome_unknown`=FAILED-shaped step naming `outcome_unknown`, operator-visible). Adds the pre-dispatch-vs-post-dispatch distinction the old `executeSendWebhook` lacked (it collapsed every non-2xx to `failed`).

### Partial wiring (stated, not silent)

Only **`send_webhook`** is wired this slice — it is the §3 exemplar the lock calls out and a self-contained `fetch`. The other four send_* actions (`send_email` + 3 `send_dingtalk_*`, each 100–400 lines with their own delivery ledgers / a `notificationService` that doesn't expose the socket error to split DNS/TLS) are an **explicitly-flagged follow-up**. The migration + module + classification + all correctness goldens are action-agnostic, so the full correctness surface ships here. **`send_notification` is EXCLUDED** (lock B′: in-app eventBus, no external egress).

## Lock deviation (reported)

`classifyOutboundResult` mirrors the transport's **tiers** (read/exchange/send doctrine), NOT the literal `classifyDingTalkFailure` call site, which differs on two points where the LOCK is more conservative for webhook/email and therefore wins: (1) it marks a generic non-429 4xx on the send tier as `outcomeUnknown:false` — §8 Q-B requires **every** 4xx ⇒ `outcome_unknown`; (2) it lumps DNS/conn-refused into `network_error → outcomeUnknown:true` — §3 carves DNS/conn-refused/TLS out as plain `failed` (definite pre-dispatch non-delivery). Per the build directive, where the lock and transport code differ the LOCK governs; this is called out rather than silently re-derived.

## V7/V8/V9 scope note (§9)

This v1 slice writes intent/outcome **INLINE** in the dispatch path — it introduces **no new lease surface**. The zombie-fence (V7), poison-terminal (V8), and class-B storm-leg (V9) obligations attach to a lease-reclaimed worker; here they remain satisfied by the S6 `event_fires` lease (#4426) plus the `status='pending'` single-writer outcome guard. Any future time-based re-lease of class-B would inherit #4203 Layer-1 fencing. Not silently skipped — addressed explicitly.

## Verification

- **tsc**: 0 errors.
- **Unit (local, 26 tests)**: classification (§8 Q-B every-4xx → `outcome_unknown`; 2xx → `sent`; DNS/conn-refused/TLS → `failed`; timeout/reset → `outcome_unknown`), two-phase state machine incl. crash-flip + terminal `outcome_unknown` + `retry_failed`, `recordOutboundOutcome` pending-guard, `classifyFetchError`, and executor-level flag-OFF **byte-identical parity** + flag-ON two-phase (proceed→sent, skip_sent no-resend, 4xx→outcome_unknown terminal, DNS→failed→retry). Existing send_webhook/automation suites (264 tests) unchanged.
- **Real-DB goldens** (`multitable-automation-outbound-intent-realdb.test.ts`): schema CHECKs/UNIQUE by name, two-phase happy, crash-mid-send flip, `outcome_unknown` terminal, `failed`→`retry_failed`→succeed, pending single-writer guard, §6.1 kind disjointness, constructed concurrent-claim race. **Two-point wired** (vitest.config exclude + plugin-tests.yml run-list) so it cannot skip-green. Not runnable locally (no DATABASE_URL) — CI-verified.
- **Mutation-proofs** (mutate in place → named test RED → revert exact reverse; tree confirmed clean after):
  - every-4xx classification → mutate 4xx→`failed` ⇒ `§8 Q-B: EVERY 4xx…` FAILS.
  - crash-flip → drop the `pending`→`outcome_unknown` flip (return `proceed`) ⇒ `CRASH-MID-SEND…` FAILS.
  - `status='pending'` outcome guard → drop the guard ⇒ `single-writer guard…` FAILS.

**Flag `AUTOMATION_CLASSB_OUTBOUND_ENABLED` default OFF; flag-OFF byte-identical.**

**NOT for self-merge — awaits opus review gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
