### PR TITLE
feat(automation): #4196 Class-B follow-up — wire send_email + send_dingtalk_approval_card onto the two-phase outbound substrate

### DIFF
--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -1804,7 +1804,9 @@ export class AutomationExecutor {
           result = await this.executeSendDingTalkPersonMessage(action.config as unknown as SendDingTalkPersonMessageConfig, context)
           break
         case 'send_dingtalk_approval_card':
-          result = await this.executeSendDingTalkApprovalCard(context)
+          // #4196 Class-B follow-up: thread the raw config + execution identity so the approval card can take
+          // the two-phase intent/outcome path when the flag is ON (flag OFF ⇒ both ignored, byte-identical).
+          result = await this.executeSendDingTalkApprovalCard(context, action.config, identity)
           break
         case 'lock_record':
           result = await this.executeLockRecord(action.config, context, identity)
@@ -3145,7 +3147,13 @@ export class AutomationExecutor {
    * - The deep link carries ONLY the delivery id + an HMAC token (values-free): the decision page
    *   resolves everything server-side through the card-delivery wrapper (§4/§5), never raw /actions.
    */
-  private async executeSendDingTalkApprovalCard(context: ExecutionContext): Promise<AutomationStepResult> {
+  private async executeSendDingTalkApprovalCard(
+    context: ExecutionContext,
+    // #4196 Class-B follow-up. `config` (raw action config) feeds the §2.1 action-key; `identity` is the
+    // execution lineage. Both are ignored when AUTOMATION_CLASSB_OUTBOUND_ENABLED is OFF (byte-identical).
+    config: unknown,
+    identity?: ClassAActionIdentity,
+  ): Promise<AutomationStepResult> {
     const actionType = 'send_dingtalk_approval_card' as const
     const event = context.triggerEvent as {
       eventType?: unknown
@@ -3265,6 +3273,20 @@ export class AutomationExecutor {
         ruleId: context.ruleId,
       })
     }
+    // #4196 Class-B two-phase (flag ON + identity present). Claim the outbound intent (Tx A) BEFORE the
+    // card-delivery row is inserted, so a replay that already `sent` (or is ambiguously `outcome_unknown`)
+    // short-circuits with NO card row and NO send. This sits AFTER every validation early-return above (those
+    // are DEFINITE pre-send failures that must NOT leave a phantom `pending` intent that a later replay would
+    // fail-close to unknown). Flag OFF (or the ad-hoc no-identity path) ⇒ outboundId null ⇒ everything below,
+    // including the existing card-delivery ledger, is BYTE-IDENTICAL to pre-slice.
+    const outboundId = this.classBOutboundIdentity(identity, 'send_dingtalk_approval_card', config)
+    if (outboundId) {
+      const decision = await claimOutboundIntent(this.deps.queryFn, outboundId)
+      if (decision === 'skip_sent' || decision === 'skip_unknown') {
+        return this.alreadyAppliedResult('send_dingtalk_approval_card')
+      }
+    }
+
     const delivery = await insertDingTalkApprovalCardDelivery(this.deps.queryFn, {
       instanceId,
       nodeKey,
@@ -3290,6 +3312,10 @@ export class AutomationExecutor {
       '请点击下方按钮处理。',
     ].filter(Boolean)
 
+    // #4196 Class-B: tracks whether the DingTalk send call RETURNED (the card was delivered). Used in the
+    // catch to distinguish a post-send bookkeeping failure (markSent / Tx-B throw AFTER a successful send —
+    // must never be recorded as a retryable `failed` that would resend a delivered card) from a send failure.
+    let sendReturned = false
     try {
       const result = await (async () => {
         if (useInteractiveCard) {
@@ -3333,6 +3359,12 @@ export class AutomationExecutor {
           { fetchFn: this.deps.fetchFn },
         )
       })()
+      // The send RETURNED → the card was delivered. #4196 Class-B: record the terminal `sent` outcome
+      // (Tx B) BEFORE the card-ledger mark, so a subsequent bookkeeping failure (markSent throw) lands in
+      // the catch with the intent ALREADY `sent` and cannot be mis-recorded as a retryable `failed`. Guarded
+      // WHERE status='pending' (single-writer); reason is a bounded, values-free class.
+      sendReturned = true
+      if (outboundId) await recordOutboundOutcome(this.deps.queryFn, outboundId, 'sent', 'dingtalk_card_sent')
       await markDingTalkApprovalCardDeliverySent(this.deps.queryFn, delivery.id, result.taskId ?? null)
       return {
         actionType,
@@ -3371,6 +3403,23 @@ export class AutomationExecutor {
         logger.error(
           `DingTalk approval-card delivery ${delivery.id} is stuck pending: failed to record the send ${outcomeUnknown ? 'outcome-unknown state' : 'failure'}`,
           markError instanceof Error ? markError : new Error(ledgerError),
+        )
+      }
+      // #4196 Class-B outcome (Tx B), recorded AFTER the existing card-ledger mark so that ledger's behavior
+      // is byte-identical when the flag is OFF. Mapping:
+      //   - sendReturned → the send DID return (only a post-send bookkeeping write threw): record `sent`,
+      //     NEVER a retryable `failed` (a resend would DUPLICATE a delivered card). Guarded WHERE
+      //     status='pending', so if the success path already flipped it to `sent` this is a no-op.
+      //   - else, REUSE the transport's own send-tier signal (`isDingTalkOutcomeUnknown`, computed above —
+      //     we do NOT re-run classifyFetchError on a result the DingTalk transport already interpreted):
+      //     ambiguous ⇒ outcome_unknown (the card may have reached the recipient; never auto-resent);
+      //     definite (HTTP 429 / non-5xx / business error — nothing delivered) ⇒ failed (re-attemptable).
+      if (outboundId) {
+        await recordOutboundOutcome(
+          this.deps.queryFn,
+          outboundId,
+          sendReturned ? 'sent' : outcomeUnknown ? 'outcome_unknown' : 'failed',
+          sendReturned ? 'dingtalk_card_sent' : outcomeUnknown ? 'dingtalk_send_outcome_unknown' : 'dingtalk_send_failed',
         )
       }
       return {

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -18,6 +18,7 @@ import {
   recordOutboundOutcome,
   type OutboundAttemptResult,
   type OutboundIntentIdentity,
+  type OutboundOutcome,
 } from './automation-outbound-intent'
 import type { TransactionalQueryable } from './pg-transaction-guard'
 import { Logger } from '../core/logger'
@@ -82,7 +83,7 @@ import type {
 import type { ConditionGroup } from './automation-conditions'
 import { evaluateConditions } from './automation-conditions'
 import type { AutomationTrigger } from './automation-triggers'
-import type { NotificationService } from '../types/plugin'
+import type { Notification, NotificationResult, NotificationService } from '../types/plugin'
 import { WebhookService } from './webhook-service'
 
 const logger = new Logger('AutomationExecutor')
@@ -1790,7 +1791,11 @@ export class AutomationExecutor {
           result = await this.executeSendNotification(action.config, context)
           break
         case 'send_email':
-          result = await this.executeSendEmail(action.config as unknown as SendEmailConfig, context)
+          // #4196 Class-B follow-up: thread the execution identity so send_email can take the two-phase
+          // intent/outcome path when AUTOMATION_CLASSB_OUTBOUND_ENABLED is ON (flag OFF ⇒ identity ignored,
+          // byte-identical legacy send). The typed `config` is the same runtime object used for the §2.1
+          // action-key, exactly as send_webhook passes its raw config.
+          result = await this.executeSendEmail(action.config as unknown as SendEmailConfig, context, identity)
           break
         case 'send_dingtalk_group_message':
           result = await this.executeSendDingTalkGroupMessage(action.config as unknown as SendDingTalkGroupMessageConfig, context)
@@ -2972,6 +2977,9 @@ export class AutomationExecutor {
   private async executeSendEmail(
     config: SendEmailConfig,
     context: ExecutionContext,
+    // #4196 Class-B identity. Present on every rule-driven call; undefined for the ad-hoc single-action
+    // dispatch (runSingleAction). Ignored entirely when AUTOMATION_CLASSB_OUTBOUND_ENABLED is OFF.
+    identity?: ClassAActionIdentity,
   ): Promise<AutomationStepResult> {
     const recipients = Array.from(new Set(
       (Array.isArray(config.recipients) ? config.recipients : [])
@@ -2995,6 +3003,8 @@ export class AutomationExecutor {
       return { actionType: 'send_email', status: 'failed', error: 'NotificationService is not configured for send_email automation action' }
     }
 
+    // Non-null after the guard above; captured so the two-phase helper shares the exact instance.
+    const notificationService = this.deps.notificationService
     const templateData: Record<string, unknown> = {
       sheetId: context.sheetId,
       recordId: context.recordId,
@@ -3004,7 +3014,7 @@ export class AutomationExecutor {
     const subject = renderAutomationTemplate(subjectTemplate, templateData).trim()
     const content = renderAutomationTemplate(bodyTemplate, templateData).trim()
 
-    const result = await this.deps.notificationService.send({
+    const notification: Notification = {
       channel: 'email',
       subject,
       content,
@@ -3017,7 +3027,18 @@ export class AutomationExecutor {
         recordId: context.recordId,
         actorId: context.actorId ?? null,
       },
-    })
+    }
+
+    // #4196 Class-B two-phase (flag ON + identity present). Intent (Tx A) commits BEFORE the send; a prior
+    // `sent`/`outcome_unknown` short-circuits with NO send. Flag OFF (or no execution identity — the
+    // runSingleAction ad-hoc path) ⇒ the legacy send below runs BYTE-IDENTICAL to pre-slice (no intent
+    // row, no classification, no outcome write).
+    const outboundId = this.classBOutboundIdentity(identity, 'send_email', config)
+    if (outboundId) {
+      return this.executeSendEmailTwoPhase(outboundId, notificationService, notification, recipients.length)
+    }
+
+    const result = await notificationService.send(notification)
 
     if (result.status === 'failed') {
       return {
@@ -3035,6 +3056,80 @@ export class AutomationExecutor {
         notificationId: result.id,
         notificationStatus: result.status,
         recipientCount: recipients.length,
+      },
+    }
+  }
+
+  /**
+   * #4196 Class-B two-phase send for send_email. Tx A (claim) already decided we may attempt; here we attempt
+   * EXACTLY ONCE (at-most-once — no in-call resend on an ambiguous failure), classify, record the outcome
+   * (Tx B, guarded single-writer), and map to a step result.
+   *
+   * CLASSIFICATION (fail-closed, see the PR body): `NotificationService.send()` catches every transport
+   * error internally and returns `{ status:'failed', failedReason:<REDACTED string> }` (or throws, rarely).
+   * It NEVER surfaces the socket-level error code that would distinguish DEFINITE pre-dispatch non-delivery
+   * (DNS / connection-refused / TLS handshake = nothing left the client) from post-dispatch loss (timeout /
+   * reset after the DATA phase = the message MAY have been delivered). So `classifyOutboundResult` /
+   * `classifyFetchError` are INAPPLICABLE here (there is no HTTP status and no undici code to read). Because
+   * pre-dispatch non-delivery CANNOT be proven, a failed/thrown send maps to `outcome_unknown`, NEVER a plain
+   * `failed` — a plain `failed` is retryable and a resend would risk a DUPLICATE email. Only a non-failed
+   * result is `sent`. There is therefore no `failed` (retryable) terminal state on this path by construction.
+   */
+  private async executeSendEmailTwoPhase(
+    outboundId: OutboundIntentIdentity,
+    notificationService: Pick<NotificationService, 'send'>,
+    notification: Notification,
+    recipientCount: number,
+  ): Promise<AutomationStepResult> {
+    // Tx A — intent committed BEFORE the send. A prior sent/unknown short-circuits with no send.
+    const decision = await claimOutboundIntent(this.deps.queryFn, outboundId)
+    if (decision === 'skip_sent' || decision === 'skip_unknown') {
+      return this.alreadyAppliedResult('send_email')
+    }
+
+    // decision is 'proceed' | 'retry_failed' → attempt ONCE.
+    let outcome: OutboundOutcome
+    let reason: string
+    let sendResult: NotificationResult | null = null
+    try {
+      sendResult = await notificationService.send(notification)
+      // Fail-closed mapping (see the method doc): only a non-failed result proves the send left the client;
+      // a 'failed' result carries a REDACTED reason with no socket code, so it is un-provable as pre-dispatch
+      // non-delivery ⇒ outcome_unknown (never a false `failed` that would permit a resend / duplicate email).
+      outcome = sendResult.status === 'failed' ? 'outcome_unknown' : 'sent'
+      reason = sendResult.status === 'failed' ? 'email_send_failed' : 'sent'
+    } catch {
+      // send() is not expected to throw (it catches internally), but a throw is equally un-provable as
+      // pre-dispatch non-delivery ⇒ fail closed to outcome_unknown, never plain failed.
+      outcome = 'outcome_unknown'
+      reason = 'email_send_threw'
+    }
+
+    // Tx B — record the terminal outcome (guarded `status='pending'`, single-writer).
+    await recordOutboundOutcome(this.deps.queryFn, outboundId, outcome, reason)
+
+    if (outcome === 'sent') {
+      return {
+        actionType: 'send_email',
+        status: 'success',
+        output: {
+          outcome: 'sent',
+          notificationId: sendResult?.id,
+          notificationStatus: sendResult?.status,
+          recipientCount,
+        },
+      }
+    }
+    // outcome_unknown — the email MAY have been delivered; surfaced as failed so the run does NOT silently
+    // succeed, and NEVER auto-resent (a retry consults the intent row and skips).
+    return {
+      actionType: 'send_email',
+      status: 'failed',
+      error: `send_email outcome_unknown (${reason}); recorded, not auto-resent`,
+      output: {
+        outcome: 'outcome_unknown',
+        reason,
+        ...(sendResult ? { notificationStatus: sendResult.status, failedReason: sendResult.failedReason } : {}),
       },
     }
   }

--- a/packages/core-backend/tests/unit/automation-classb-dingtalk-approval-card.test.ts
+++ b/packages/core-backend/tests/unit/automation-classb-dingtalk-approval-card.test.ts
@@ -182,6 +182,39 @@ describe('flag ON — two-phase intent/outcome', () => {
     expect(asyncAfter).toBe(asyncBefore) // NOT re-sent
   })
 
+  // MUTATION-PROOF for the catch's `sendReturned → 'sent'` leg: the ONLY scenario where that leg DECIDES the
+  // durable outcome is a Tx-B failure AFTER a successful send — the success-path recordOutboundOutcome('sent')
+  // throws, so the intent is still `pending` when the catch writes. Under the mutant (classify the DB error
+  // instead), the catch records the retryable `failed` for a DELIVERED card → a retry re-sends = duplicate.
+  it('Tx-B throw AFTER a successful send → catch records SENT (never failed); retry skips, no duplicate card', async () => {
+    const h = makeHarness((call) => (call === 0 ? tokenResponse() : asyncSendOk()))
+    const orig = h.deps.queryFn
+    let injected = false
+    // Throw ONCE on the first outcome-UPDATE that records 'sent' (recordOutboundOutcome's `SET status = $4`);
+    // the claim's literal-SQL flips (`SET status = 'outcome_unknown'` / `'pending'`) are untouched.
+    h.deps.queryFn = (async (sql: string, params: unknown[] = []) => {
+      const s = String(sql)
+      if (!injected && /meta_automation_outbound_intent/i.test(s) && /SET status = \$4/i.test(s) && params?.[3] === 'sent') {
+        injected = true
+        throw new Error('injected Tx-B outcome-write failure')
+      }
+      return (orig as (sql: string, params?: unknown[]) => Promise<unknown>)(sql, params)
+    }) as AutomationDeps['queryFn']
+
+    const first = await new AutomationExecutor(h.deps).execute(ruleWith(CARD), TRIGGER, undefined, ROOT)
+    expect(injected).toBe(true) // the success-path Tx B genuinely failed
+    // The card WAS delivered; the catch (sendReturned) must still terminalize the intent as `sent`.
+    expect(only(h.intent).status).toBe('sent')
+    expect(first.steps[0]?.status).toBe('failed') // the step surfaces the bookkeeping failure honestly
+
+    // And a retry must SKIP (skip_sent) — never a duplicate card for the delivered send.
+    const asyncBefore = h.fetch.mock.calls.filter((c) => String(c[0] ?? '').includes('asyncsend')).length
+    const retry = await new AutomationExecutor(h.deps).execute(ruleWith(CARD), TRIGGER, undefined, ROOT)
+    expect(retry.steps[0]?.alreadyApplied).toBe(true)
+    const asyncAfter = h.fetch.mock.calls.filter((c) => String(c[0] ?? '').includes('asyncsend')).length
+    expect(asyncAfter).toBe(asyncBefore)
+  })
+
   // MUTATION-PROOF for the catch outcome MAPPING (`… : outcomeUnknown ? 'outcome_unknown' : 'failed'`):
   // mutating the 'outcome_unknown' branch to 'failed' makes the intent terminal `failed` (retryable), so BOTH
   // the intent-status assertion AND the retry-skip assertion (a `failed` intent would retry_failed → re-send)

--- a/packages/core-backend/tests/unit/automation-classb-dingtalk-approval-card.test.ts
+++ b/packages/core-backend/tests/unit/automation-classb-dingtalk-approval-card.test.ts
@@ -1,0 +1,211 @@
+/**
+ * #4196 Class-B outbound two-phase — executor wiring (unit) for send_dingtalk_approval_card (follow-up to
+ * send_webhook / send_email).
+ *
+ * The approval card is a SINGLE-recipient, SINGLE send (the recipient is FIXED from the trigger event), so it
+ * fits the at-most-once substrate. It reuses the DingTalk transport's own send-tier signal: a returned send is
+ * `sent`; a throw carrying isDingTalkOutcomeUnknown is `outcome_unknown` (the card may have reached the
+ * recipient — never auto-resent); a definite throw (HTTP 429 / 4xx / business error) is `failed`
+ * (re-attemptable). The claim (Tx A) is committed BEFORE the card-delivery ledger row is inserted, so a replay
+ * short-circuits with NO card row and NO send. Flag OFF ⇒ the pre-existing card-delivery path is byte-identical.
+ *
+ * Harness: env supplies the public URL + link secret + DingTalk work-notification credentials so the config
+ * resolvers bypass the DB; deps.queryFn dispatches by SQL substring (approval_instances, the recipient
+ * directory lateral, the card-deliveries table, and the meta_automation_outbound_intent two-phase table);
+ * deps.fetchFn returns the gettoken then asyncsend envelopes (or rejects the send for the ambiguous case).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  AutomationExecutor,
+  type AutomationDeps,
+  type AutomationRule,
+} from '../../src/multitable/automation-executor'
+import { EventBus } from '../../src/integration/events/event-bus'
+import { __resetDingTalkAppAccessTokenCacheForTests } from '../../src/integrations/dingtalk/client'
+
+const FLAG = 'AUTOMATION_CLASSB_OUTBOUND_ENABLED'
+const ROOT = 'exec_root_classb_card'
+const CARD = { type: 'send_dingtalk_approval_card', config: {} }
+const TRIGGER = {
+  recordId: 'rec_1',
+  sheetId: 'sheet_1',
+  actorId: 'user_1',
+  data: {},
+  eventType: 'approval.task_created',
+  approval: { instanceId: 'inst_1', requestNo: 'R1', templateId: 'tpl_1' },
+  task: { nodeKey: 'node_1', entryEpoch: 1, assigneeUserId: 'assignee_1', sourceStep: 1 },
+}
+
+type IntentRow = { status: string; attempts: number; last_error: string | null }
+
+interface Harness {
+  deps: AutomationDeps
+  fetch: ReturnType<typeof vi.fn>
+  intent: Map<string, IntentRow>
+  intentInserts: number
+}
+
+const tokenResponse = () =>
+  new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', access_token: 'app-access-token' }), {
+    status: 200, headers: { 'Content-Type': 'application/json' },
+  })
+const asyncSendOk = () =>
+  new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', task_id: 778899 }), {
+    status: 200, headers: { 'Content-Type': 'application/json' },
+  })
+
+/**
+ * @param fetchImpl called per fetch invocation. Return a Response (or an Error to reject). The DingTalk
+ *   work-notification path fetches gettoken FIRST (call 0), then asyncsend (call 1). The token cache is
+ *   reset before every test so call 0 always fires.
+ */
+function makeHarness(fetchImpl: (call: number) => Response | Error): Harness {
+  const intent = new Map<string, IntentRow>()
+  let calls = 0
+  const fetchSpy = vi.fn(async () => {
+    const out = fetchImpl(calls++)
+    if (out instanceof Error) throw out
+    return out
+  })
+  const state = { intentInserts: 0 }
+  const keyOf = (p: unknown[]) => `${String(p[0])}|${String(p[1])}|${String(p[2])}`
+  const queryFn = vi.fn(async (sql: string, params: unknown[] = []) => {
+    const s = String(sql)
+    if (/meta_automation_outbound_intent/i.test(s)) {
+      const key = keyOf(params)
+      if (/^\s*INSERT INTO/i.test(s)) {
+        if (intent.has(key)) return { rows: [], rowCount: 0 }
+        intent.set(key, { status: 'pending', attempts: 0, last_error: null })
+        state.intentInserts++
+        return { rows: [], rowCount: 1 }
+      }
+      if (/^\s*SELECT status/i.test(s)) {
+        const r = intent.get(key)
+        return { rows: r ? [{ status: r.status }] : [], rowCount: r ? 1 : 0 }
+      }
+      const r = intent.get(key)
+      if (!r) return { rows: [], rowCount: 0 }
+      const guard = /AND status = '([a-z_]+)'/i.exec(s)?.[1] ?? null
+      if (guard && r.status !== guard) return { rows: [], rowCount: 0 }
+      const literal = /SET status = '([a-z_]+)'/i.exec(s)?.[1]
+      r.status = literal ?? (s.includes('status = $4') ? String(params[3]) : r.status)
+      if (/attempts = attempts \+ 1/i.test(s)) r.attempts += 1
+      if (s.includes('last_error = $5')) r.last_error = (params[4] ?? null) as string | null
+      return { rows: [], rowCount: 1 }
+    }
+    if (/FROM approval_instances/i.test(s)) {
+      return { rows: [{ title: 'Leave request', request_no: 'R1' }], rowCount: 1 }
+    }
+    if (/directory_account_links/i.test(s)) {
+      // Recipient: linked + active DingTalk account bound under integration intg_1.
+      return { rows: [{ local_user_id: 'assignee_1', local_user_active: true, dingtalk_user_id: 'dtu_1', integration_id: 'intg_1' }], rowCount: 1 }
+    }
+    if (/INSERT INTO dingtalk_approval_card_deliveries/i.test(s)) {
+      return { rows: [{ id: 'del_1' }], rowCount: 1 }
+    }
+    if (/dingtalk_approval_card_deliveries/i.test(s)) {
+      // markSent / markSendFailed / markSendOutcomeUnknown — UPDATE ... RETURNING.
+      return { rows: [{ id: 'del_1' }], rowCount: 1 }
+    }
+    return { rows: [], rowCount: 1 }
+  }) as unknown as AutomationDeps['queryFn']
+  return {
+    deps: { eventBus: new EventBus(), queryFn, fetchFn: fetchSpy as unknown as typeof fetch },
+    fetch: fetchSpy,
+    intent,
+    get intentInserts() { return state.intentInserts },
+  } as Harness
+}
+
+function ruleWith(action: { type: string; config: Record<string, unknown> }): AutomationRule {
+  return {
+    id: 'rule_cb_card', name: 'Class-B card rule', sheetId: 'sheet_1',
+    trigger: { type: 'approval.task_created', config: {} },
+    actions: [action as never], enabled: true, createdBy: 'user_1', createdAt: '2026-01-01T00:00:00Z',
+  } as AutomationRule
+}
+const only = (m: Map<string, IntentRow>) => [...m.values()][0]
+
+beforeEach(() => {
+  delete process.env[FLAG]
+  process.env.PUBLIC_APP_URL = 'https://app.test'
+  process.env.APPROVAL_CARD_LINK_SECRET = 'link-secret'
+  process.env.DINGTALK_APP_KEY = 'dt-app-key'
+  process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+  process.env.DINGTALK_AGENT_ID = '123456789'
+  __resetDingTalkAppAccessTokenCacheForTests()
+})
+afterEach(() => {
+  delete process.env[FLAG]
+  delete process.env.PUBLIC_APP_URL
+  delete process.env.APPROVAL_CARD_LINK_SECRET
+  delete process.env.DINGTALK_APP_KEY
+  delete process.env.DINGTALK_APP_SECRET
+  delete process.env.DINGTALK_AGENT_ID
+  vi.restoreAllMocks()
+})
+
+describe('flag OFF — byte-identical legacy send_dingtalk_approval_card (no intent row)', () => {
+  it('sent: card delivered, success step, NO intent SQL written', async () => {
+    const h = makeHarness((call) => (call === 0 ? tokenResponse() : asyncSendOk()))
+    const exec = await new AutomationExecutor(h.deps).execute(ruleWith(CARD), TRIGGER, undefined, ROOT)
+    expect(exec.steps[0]?.status).toBe('success')
+    expect(exec.steps[0]?.alreadyApplied).toBeUndefined()
+    expect(exec.steps[0]?.output).toMatchObject({ deliveryId: 'del_1', taskId: '778899' })
+    expect(h.intentInserts).toBe(0) // the two-phase table was never touched
+    expect(h.intent.size).toBe(0)
+  })
+})
+
+describe('flag ON — two-phase intent/outcome', () => {
+  beforeEach(() => { process.env[FLAG] = 'true' })
+
+  it('proceed → sent: card delivered once, success step, intent row = sent', async () => {
+    const h = makeHarness((call) => (call === 0 ? tokenResponse() : asyncSendOk()))
+    const exec = await new AutomationExecutor(h.deps).execute(ruleWith(CARD), TRIGGER, undefined, ROOT)
+    expect(exec.steps[0]?.status).toBe('success')
+    expect(only(h.intent).status).toBe('sent')
+    // gettoken + asyncsend = 2 fetches; exactly one asyncsend (one card delivered).
+    expect(h.fetch.mock.calls.filter((c) => String(c[0] ?? '').includes('asyncsend'))).toHaveLength(1)
+  })
+
+  it('retry after sent → skip_sent: alreadyApplied, NO second send', async () => {
+    const h = makeHarness((call) => (call === 0 ? tokenResponse() : asyncSendOk()))
+    await new AutomationExecutor(h.deps).execute(ruleWith(CARD), TRIGGER, undefined, ROOT) // first: sent
+    const asyncBefore = h.fetch.mock.calls.filter((c) => String(c[0] ?? '').includes('asyncsend')).length
+    const second = await new AutomationExecutor(h.deps).execute(ruleWith(CARD), TRIGGER, undefined, ROOT) // retry
+    expect(second.steps[0]?.status).toBe('success')
+    expect(second.steps[0]?.alreadyApplied).toBe(true)
+    expect(only(h.intent).status).toBe('sent')
+    const asyncAfter = h.fetch.mock.calls.filter((c) => String(c[0] ?? '').includes('asyncsend')).length
+    expect(asyncAfter).toBe(asyncBefore) // NOT re-sent
+  })
+
+  // MUTATION-PROOF for the catch outcome MAPPING (`… : outcomeUnknown ? 'outcome_unknown' : 'failed'`):
+  // mutating the 'outcome_unknown' branch to 'failed' makes the intent terminal `failed` (retryable), so BOTH
+  // the intent-status assertion AND the retry-skip assertion (a `failed` intent would retry_failed → re-send)
+  // fail.
+  it('ambiguous send (network reject → transport outcome_unknown) → outcome_unknown, NEVER failed; retry → skip_unknown, no resend', async () => {
+    const h = makeHarness((call) => (call === 0 ? tokenResponse() : new TypeError('fetch failed')))
+    const first = await new AutomationExecutor(h.deps).execute(ruleWith(CARD), TRIGGER, undefined, ROOT)
+    expect(first.steps[0]?.status).toBe('failed')
+    expect(only(h.intent).status).toBe('outcome_unknown') // fail-closed: never the retryable `failed`
+    expect(only(h.intent).last_error).toBe('dingtalk_send_outcome_unknown')
+
+    const asyncBefore = h.fetch.mock.calls.filter((c) => String(c[0] ?? '').includes('asyncsend')).length
+    const retry = await new AutomationExecutor(h.deps).execute(ruleWith(CARD), TRIGGER, undefined, ROOT)
+    expect(retry.steps[0]?.alreadyApplied).toBe(true) // skip_unknown → alreadyApplied
+    const asyncAfter = h.fetch.mock.calls.filter((c) => String(c[0] ?? '').includes('asyncsend')).length
+    expect(asyncAfter).toBe(asyncBefore) // TERMINAL: never a second send
+  })
+
+  it('no identity (runSingleAction ad-hoc dispatch) → no intent even with the flag ON', async () => {
+    const h = makeHarness((call) => (call === 0 ? tokenResponse() : asyncSendOk()))
+    const result = await new AutomationExecutor(h.deps).runSingleAction(CARD as never, {
+      executionId: 'x', ruleId: 'r', sheetId: 'sheet_1', recordId: 'rec_1', recordData: {}, ruleCreatedBy: 'user_1', actorId: 'user_1', triggerEvent: TRIGGER,
+    })
+    expect(result.status).toBe('success')
+    expect(h.intent.size).toBe(0) // ad-hoc dispatch has no lineage → no intent
+  })
+})

--- a/packages/core-backend/tests/unit/automation-classb-email.test.ts
+++ b/packages/core-backend/tests/unit/automation-classb-email.test.ts
@@ -1,0 +1,177 @@
+/**
+ * #4196 Class-B outbound two-phase — executor wiring (unit) for send_email (follow-up to send_webhook).
+ *
+ * Proves the two-phase intent/outcome path drives send_email when AUTOMATION_CLASSB_OUTBOUND_ENABLED is ON
+ * AND an execution identity is present, and that with the flag OFF the send path is BYTE-IDENTICAL to
+ * pre-slice (single NotificationService.send, no intent row ever written).
+ *
+ * The crash-flip + single-writer guards are proven action-agnostically in the substrate goldens
+ * (automation-outbound-intent.test.ts); here we add the per-action CLASSIFICATION contract: because
+ * NotificationService.send() returns a redacted { status:'failed' } with NO socket code, a failed send is
+ * un-provable as pre-dispatch non-delivery ⇒ outcome_unknown (fail-closed), NEVER a retryable `failed`.
+ *
+ * deps.queryFn routes `meta_automation_outbound_intent` SQL through an in-memory table (shared across two
+ * execute() calls so a "retry" — same lineage root — consults the SAME row); deps.notificationService.send
+ * is the send spy.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  AutomationExecutor,
+  type AutomationDeps,
+  type AutomationRule,
+} from '../../src/multitable/automation-executor'
+import { EventBus } from '../../src/integration/events/event-bus'
+
+const FLAG = 'AUTOMATION_CLASSB_OUTBOUND_ENABLED'
+const ROOT = 'exec_root_classb_email'
+const EMAIL = {
+  type: 'send_email',
+  config: { recipients: ['ops@example.test'], subjectTemplate: 'Subject', bodyTemplate: 'Body' },
+}
+const TRIGGER = { recordId: 'rec_1', sheetId: 'sheet_1', actorId: 'user_1', data: { title: 'X' } }
+
+type IntentRow = { status: string; attempts: number; last_error: string | null }
+type SendResult = { id: string; status: string; failedReason?: string }
+
+interface Harness {
+  deps: AutomationDeps
+  send: ReturnType<typeof vi.fn>
+  intent: Map<string, IntentRow>
+  intentInserts: number
+}
+
+function makeHarness(sendImpl: (call: number) => SendResult): Harness {
+  const intent = new Map<string, IntentRow>()
+  let calls = 0
+  const sendSpy = vi.fn(async () => sendImpl(calls++))
+  const state = { intentInserts: 0 }
+  const keyOf = (p: unknown[]) => `${String(p[0])}|${String(p[1])}|${String(p[2])}`
+  const queryFn = vi.fn(async (sql: string, params: unknown[] = []) => {
+    const s = String(sql)
+    if (/meta_automation_outbound_intent/i.test(s)) {
+      const key = keyOf(params)
+      if (/^\s*INSERT INTO/i.test(s)) {
+        if (intent.has(key)) return { rows: [], rowCount: 0 }
+        intent.set(key, { status: 'pending', attempts: 0, last_error: null })
+        state.intentInserts++
+        return { rows: [], rowCount: 1 }
+      }
+      if (/^\s*SELECT status/i.test(s)) {
+        const r = intent.get(key)
+        return { rows: r ? [{ status: r.status }] : [], rowCount: r ? 1 : 0 }
+      }
+      // UPDATE — honor the `AND status = '…'` guard parsed from the SQL text.
+      const r = intent.get(key)
+      if (!r) return { rows: [], rowCount: 0 }
+      const guard = /AND status = '([a-z_]+)'/i.exec(s)?.[1] ?? null
+      if (guard && r.status !== guard) return { rows: [], rowCount: 0 }
+      const literal = /SET status = '([a-z_]+)'/i.exec(s)?.[1]
+      r.status = literal ?? (s.includes('status = $4') ? String(params[3]) : r.status)
+      if (/attempts = attempts \+ 1/i.test(s)) r.attempts += 1
+      if (s.includes('last_error = $5')) r.last_error = (params[4] ?? null) as string | null
+      return { rows: [], rowCount: 1 }
+    }
+    // The email path never mutates records; any other SQL is inert.
+    return { rows: [], rowCount: 1 }
+  }) as unknown as AutomationDeps['queryFn']
+  return {
+    deps: { eventBus: new EventBus(), queryFn, notificationService: { send: sendSpy as never } },
+    send: sendSpy,
+    intent,
+    get intentInserts() { return state.intentInserts },
+  } as Harness
+}
+
+function ruleWith(action: { type: string; config: Record<string, unknown> }): AutomationRule {
+  return {
+    id: 'rule_cb_email', name: 'Class-B email rule', sheetId: 'sheet_1',
+    trigger: { type: 'record.created', config: {} },
+    actions: [action as never], enabled: true, createdBy: 'user_1', createdAt: '2026-01-01T00:00:00Z',
+  } as AutomationRule
+}
+const only = (m: Map<string, IntentRow>) => [...m.values()][0]
+const sent = (): SendResult => ({ id: 'notif_1', status: 'sent' })
+const failed = (): SendResult => ({ id: 'notif_1', status: 'failed', failedReason: 'SMTP blocked: redacted' })
+
+beforeEach(() => { delete process.env[FLAG] })
+afterEach(() => { delete process.env[FLAG]; vi.restoreAllMocks() })
+
+describe('flag OFF — byte-identical legacy send_email (no intent row)', () => {
+  it('sent: one send, success step, NO intent SQL written', async () => {
+    const h = makeHarness(sent)
+    const exec = await new AutomationExecutor(h.deps).execute(ruleWith(EMAIL), TRIGGER, undefined, ROOT)
+    expect(exec.steps[0]?.status).toBe('success')
+    expect(exec.steps[0]?.alreadyApplied).toBeUndefined()
+    expect(h.send).toHaveBeenCalledTimes(1)
+    expect(h.intentInserts).toBe(0) // the two-phase table was never touched
+    expect(h.intent.size).toBe(0)
+  })
+
+  it('transport failure keeps the legacy failed step + result output (unchanged), no intent row', async () => {
+    const h = makeHarness(failed)
+    const exec = await new AutomationExecutor(h.deps).execute(ruleWith(EMAIL), TRIGGER, undefined, ROOT)
+    expect(exec.steps[0]?.status).toBe('failed')
+    expect(exec.steps[0]?.error).toBe('SMTP blocked: redacted')
+    expect(exec.steps[0]?.error).not.toMatch(/outcome_unknown/) // legacy wording, not the two-phase wording
+    expect(h.intent.size).toBe(0)
+  })
+})
+
+describe('flag ON — two-phase intent/outcome', () => {
+  beforeEach(() => { process.env[FLAG] = 'true' })
+
+  it('proceed → sent: single send, success step, intent row = sent', async () => {
+    const h = makeHarness(sent)
+    const exec = await new AutomationExecutor(h.deps).execute(ruleWith(EMAIL), TRIGGER, undefined, ROOT)
+    expect(exec.steps[0]?.status).toBe('success')
+    expect(exec.steps[0]?.output).toMatchObject({ outcome: 'sent' })
+    expect(h.send).toHaveBeenCalledTimes(1) // exactly one attempt
+    expect(only(h.intent).status).toBe('sent')
+  })
+
+  it('retry after sent → skip_sent: alreadyApplied, NO second send', async () => {
+    const h = makeHarness(sent)
+    await new AutomationExecutor(h.deps).execute(ruleWith(EMAIL), TRIGGER, undefined, ROOT) // first: sent
+    const second = await new AutomationExecutor(h.deps).execute(ruleWith(EMAIL), TRIGGER, undefined, ROOT) // retry
+    expect(second.steps[0]?.status).toBe('success')
+    expect(second.steps[0]?.alreadyApplied).toBe(true)
+    expect(h.send).toHaveBeenCalledTimes(1) // NOT re-sent
+    expect(only(h.intent).status).toBe('sent')
+  })
+
+  // MUTATION-PROOF for the outcome MAPPING (`status==='failed' ? 'outcome_unknown' : 'sent'`): mutating the
+  // 'outcome_unknown' branch to 'failed' makes the intent terminal `failed` (retryable) instead of
+  // outcome_unknown, so BOTH the intent-status assertion below AND the retry-skip assertion (a `failed`
+  // intent would retry_failed → re-send) fail.
+  it('transport failure → outcome_unknown (NEVER failed); retry → skip_unknown, no resend', async () => {
+    const h = makeHarness(failed)
+    const first = await new AutomationExecutor(h.deps).execute(ruleWith(EMAIL), TRIGGER, undefined, ROOT)
+    expect(first.steps[0]?.status).toBe('failed')
+    expect(first.steps[0]?.error).toMatch(/outcome_unknown/)
+    expect(only(h.intent).status).toBe('outcome_unknown') // fail-closed: never the retryable `failed`
+    expect(only(h.intent).last_error).toBe('email_send_failed')
+
+    const retry = await new AutomationExecutor(h.deps).execute(ruleWith(EMAIL), TRIGGER, undefined, ROOT)
+    expect(retry.steps[0]?.alreadyApplied).toBe(true) // skip_unknown → alreadyApplied
+    expect(h.send).toHaveBeenCalledTimes(1) // TERMINAL: never a second send
+  })
+
+  it('send() throws → outcome_unknown (fail-closed), intent = outcome_unknown', async () => {
+    const h = makeHarness(() => { throw new Error('unexpected throw') })
+    const exec = await new AutomationExecutor(h.deps).execute(ruleWith(EMAIL), TRIGGER, undefined, ROOT)
+    expect(exec.steps[0]?.status).toBe('failed')
+    expect(exec.steps[0]?.error).toMatch(/outcome_unknown/)
+    expect(only(h.intent).status).toBe('outcome_unknown')
+    expect(only(h.intent).last_error).toBe('email_send_threw')
+  })
+
+  it('no identity (runSingleAction ad-hoc dispatch) → no intent even with the flag ON', async () => {
+    const h = makeHarness(sent)
+    const result = await new AutomationExecutor(h.deps).runSingleAction(EMAIL as never, {
+      executionId: 'x', ruleId: 'r', sheetId: 'sheet_1', recordId: 'rec_1', recordData: {}, ruleCreatedBy: 'user_1', actorId: 'user_1', triggerEvent: null,
+    })
+    expect(result.status).toBe('success')
+    expect(h.intent.size).toBe(0) // ad-hoc dispatch has no lineage → no intent
+  })
+})


### PR DESCRIPTION
## #4196 Class-B outbound — follow-up: wire the remaining send actions onto the two-phase substrate

Extends the #4196 Class-B two-phase intent/outcome substrate (built + reviewed in the base branch for
`send_webhook`) to the remaining send actions, reusing `claimOutboundIntent` / `recordOutboundOutcome` /
`classifyOutboundResult` / `isClassBOutboundEnabled` and mirroring `executeSendWebhookTwoPhase`.

**Base:** `claude/p2-4196-classB-outbound` (PR #4441). **NOT for self-merge** — hand to the adversarial gate.

### Actions WIRED (2/4)

- **`send_email`** — single send, no domain ledger, clean fit.
- **`send_dingtalk_approval_card`** — single-recipient / single send (recipient FIXED from the trigger
  event), fits the at-most-once substrate.

Both: flag ON + execution identity present ⇒ claim intent (Tx A) BEFORE the network call → `skip_sent` /
`skip_unknown` ⇒ `alreadyApplied` (no send) → else attempt ONCE → classify → record outcome (Tx B, guarded
single-writer) → map (`sent`=success, `outcome_unknown`=FAILED-shaped step naming `outcome_unknown`, never
auto-resent). Flag OFF (or the ad-hoc `runSingleAction` no-identity path) ⇒ **byte-identical** legacy send.

### Actions DEFERRED (2/4) — specific blockers

- **`send_dingtalk_person_message`** and **`send_dingtalk_group_message`** — both **fan out to N sends**
  (person: batches × integrations; group: a loop over destinations, each its own signed webhook fetch). The
  substrate keys ONE intent per action identity (`kind, root_execution_id, action_key`) → a single at-most-once
  side effect. A fan-out has per-target outcomes that a single action-level intent cannot represent:
  - coarsening mixed outcomes to a whole-action `outcome_unknown` **permanently blocks retry of KNOWN-failed
    targets** (a DNS-failed destination is never re-sent), and
  - coarsening to a whole-action `failed`→retry **re-sends already-delivered targets** (duplicate).

  Both already carry per-target `outcome_unknown` telemetry ledgers (`recordDingTalkPersonDeliverySafely` /
  `recordDingTalkGroupDeliverySafely`). Correct wiring needs **per-target intent keys** — a §2.1 action-key
  design-lock extension, out of scope for this impl follow-up. Left UNCHANGED here.

### Classification decisions (per transport)

- **`send_email` — FAIL-CLOSED to `outcome_unknown` (the flagged default).** `NotificationService.send()`
  catches all transport errors internally and returns `{ status:'failed', failedReason:<REDACTED string> }`
  (or, rarely, throws). It **never surfaces the socket-level error code** that would distinguish DEFINITE
  pre-dispatch non-delivery (DNS / conn-refused / TLS = nothing left the client) from post-dispatch loss
  (timeout / reset after DATA = maybe delivered). So `classifyOutboundResult` / `classifyFetchError` are
  inapplicable (no HTTP status, no undici code). A failed/thrown send therefore maps to **`outcome_unknown`,
  never a plain `failed`** (a plain `failed` is retryable and a resend would risk a DUPLICATE email). Only a
  non-failed result is `sent`. Consequence: this path has **no `failed` (retryable) terminal state** by
  construction. Documented in a code comment on `executeSendEmailTwoPhase`.

- **`send_dingtalk_approval_card` — REUSE the transport's own send-tier signal.** The DingTalk transport
  (`integrations/dingtalk/transport.ts`) already classifies its `send`-tier calls and marks ambiguous
  outcomes via `isDingTalkOutcomeUnknown`. We consume that signal (we do NOT re-run `classifyFetchError` on a
  result the transport already interpreted): a returned send ⇒ `sent`; a throw with
  `isDingTalkOutcomeUnknown` ⇒ `outcome_unknown` (card may have reached the recipient — never auto-resent); a
  definite throw (HTTP 429 / non-5xx / business error — nothing delivered) ⇒ `failed` (re-attemptable).

### Atomicity invariant (the review lens)

- **Approval card — post-send bookkeeping failure must not resend a delivered card.** The pre-existing
  `try/catch` conflates a post-send bookkeeping failure (`markSent` / Tx-B throw AFTER a successful send) with
  a send failure. To keep the flag-OFF path byte-identical the `try/catch` is NOT restructured; instead a
  `sendReturned` flag records `sent` immediately after the send returns (before `markSent`), and the catch
  forces `sent` whenever the send already returned. The `recordOutboundOutcome` guard `WHERE status='pending'`
  makes the two records mutually exclusive, so a delivered card is never recorded as a retryable `failed`.
- The intent commits (Tx A) BEFORE the network call in both actions; every non-happy exit records a terminal
  outcome (or leaves `pending`, which a replay fail-closes to `outcome_unknown` via the substrate's
  crash-flip). No path can produce a `failed` (retryable) for something that might have been delivered.

### Flag

`AUTOMATION_CLASSB_OUTBOUND_ENABLED`, **default OFF**. OFF ⇒ no intent row, no classification, no outcome
write; the legacy send path is byte-identical (proven by the pre-existing per-action specs staying green).

### Tests

Per action: flag-OFF parity (legacy send, no intent row) · flag-ON proceed→`sent` · replay→`skip_sent`
(no second send) · classification (ambiguous→`outcome_unknown`, NEVER `failed`) + retry→`skip_unknown`
(no resend) · no-identity→no intent.

- `tests/unit/automation-classb-email.test.ts` (7)
- `tests/unit/automation-classb-dingtalk-approval-card.test.ts` (5)

The crash-flip + single-writer guards are proven action-agnostically in the substrate goldens
(`automation-outbound-intent.test.ts`) and are not re-proven here.

**Mutation → test map** (mutate outcome MAPPING, confirm a named test fails, restore with the exact reverse):
- `send_email`: `status==='failed' ? 'outcome_unknown' : 'sent'` → mutate `'outcome_unknown'`→`'failed'` ⇒
  *"transport failure → outcome_unknown (NEVER failed)…"* fails (`expected 'failed' to be 'outcome_unknown'`).
- `send_dingtalk_approval_card`: catch `… : outcomeUnknown ? 'outcome_unknown' : 'failed'` → mutate
  `'outcome_unknown'`→`'failed'` ⇒ *"ambiguous send → outcome_unknown, NEVER failed…"* fails.

No new real-DB tests added (the wiring is exercised by the unit specs; the substrate's own real-DB test
already covers the `meta_automation_outbound_intent` table). New unit files live in `tests/unit/` — the same
CI lane as the existing `automation-classb-outbound.test.ts`.

### Results

- `tsc --noEmit`: 0 errors.
- 281 passing across the touched automation/dingtalk/email surface (incl. all 221 `automation-v1` specs —
  flag-OFF byte-identical for send_email and approval-card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
