### PR TITLE
W0 L7 — exact-anchor recovery PLAN: target-set classification for execute (DRAFT, stacked on #4417)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -456,6 +456,7 @@ jobs:
             tests/integration/multitable-history-trust-checkpoint-realdb.test.ts \
             tests/integration/multitable-l5wire-checkpoint-activation-realdb.test.ts \
             tests/integration/multitable-exact-anchor-recovery-realdb.test.ts \
+            tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts \
             tests/integration/multitable-d1c-form-submit-revision-realdb.test.ts \
             tests/integration/multitable-d1c-plugin-revision-realdb.test.ts \
             tests/integration/multitable-d1c-automation-revision-realdb.test.ts \

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-plan.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-plan.ts
@@ -1,0 +1,168 @@
+import type { QueryFn } from './permission-service'
+import { reconstructRecordsAtSeq } from './record-reconstructor'
+import { assertSeqString } from './history-trust-checkpoint'
+
+/**
+ * W0-1 v3.7 Lane L7 — the EXACT-ANCHOR recovery PLAN (target-set classification for execute).
+ *
+ * Design authority: `…v37-exact-anchor-trust-design-lock-20260715.md` (#4331) §5 (execute = full
+ * target/schema/set recomputation under the fence) + §9 item 3 (target-generation A) + item 5. Builds on
+ * L6-b: the causal reconstructor already resolves each record's TARGET-GENERATION state at the exact
+ * `anchorSeq` (a delete→recreate chain reconstructs to the generation whose window contains the anchor —
+ * proven by the MULTI-GEN golden), so this layer's job is the remaining §5 semantics: classify the FULL
+ * record set (live ∪ at-anchor, deleted/trash-aware) into the executable plan a destructive apply consumes.
+ *
+ * CLASSIFICATION (per record, target = as-of-anchorSeq state from `reconstructRecordsAtSeq`):
+ *   target EXISTS + live row present  → REVERT candidate (live differs from target; identical rows skipped)
+ *   target EXISTS + no live row       → RESURRECT candidate (deleted AFTER the anchor; carries the full
+ *                                       at-anchor snapshot — never the trash row's terminal-vintage data)
+ *   target DELETED (delete ≤ anchor) + live row → `deletedAtAnchorLiveNow` (the record was deleted as of the
+ *                                       anchor but was later resurrected): Revert semantics KEEP it
+ *                                       (non-destructive); Reset semantics delete it. The plan EXPOSES the
+ *                                       list; the L8 caller picks — this module never chooses destruction.
+ *   target DELETED + no live row      → unchanged (stays deleted; NEVER resurrected — LOCK-9).
+ *   absent from stateMap + live row   → `createdAfterAnchor` (no revision ≤ anchor): Revert keeps, Reset
+ *                                       deletes — exposed, caller picks.
+ *
+ * SCHEMA DRIFT (§5 "schema recomputation"): a target snapshot carrying a field id that no longer exists in
+ * the CURRENT schema is EXCLUDED from the plan and counted in `driftCount` — re-inserting it would write a
+ * stale field key into `meta_records.data`. SEMANTICS (owner P1-2 ruling 2026-07-17, superseding the F2
+ * "honest partial" note): the L8 apply core treats `driftCount > 0` as a WHOLE-apply refusal
+ * (`schema-drift`, zero writes, burn rolled back) — T-path parity; no partial-set apply is smuggled
+ * through drift exclusion, and an EXPLICIT partial recovery is a future separate mode. This plan layer
+ * still computes and exposes `driftCount` so a read-only preview can DISCLOSE the drift to the actor
+ * before they ever mint/spend a token.
+ *
+ * LAYERING CONTRACT (deliberate, loud): this is the CORE set-classification only — it performs NO
+ * permission masking, NO row-level-deny filtering, NO size ceilings, and NO fence acquisition. Those are
+ * the HTTP/execute wiring's obligations (L8): the route must (a) run this UNDER the canonical fence,
+ * (b) apply the actor's field mask + denied-record filter to what it returns/executes (the T-path's PIT-3
+ * discipline), and (c) enforce SHEET_REVERT_MAX_RECORDS-class ceilings. Consuming this module without those
+ * layers is NOT a production path — it is not wired to any route in this lane (default-off by construction).
+ *
+ * EXACT BIGINT: `anchorSeq` is a decimal string handed to `reconstructRecordsAtSeq`'s `::bigint` bind;
+ * `assertSeqString` fails closed here too so a garbage anchor never reaches SQL from the plan layer.
+ */
+
+export interface AnchorRevertCandidate {
+  recordId: string
+  /** the FULL at-anchor record data (unmasked — see the layering contract). */
+  targetData: Record<string, unknown>
+  /** the at-anchor version (the version the record had as of the anchor). */
+  targetVersion: number | null
+  /** the CURRENT live version (optimistic-concurrency anchor for the apply). */
+  liveVersion: number
+}
+
+export interface AnchorResurrectCandidate {
+  recordId: string
+  /** the FULL at-anchor snapshot (from the revision chain — never the trash row's terminal vintage). */
+  snapshot: Record<string, unknown>
+  targetVersion: number | null
+}
+
+export interface ExactAnchorRecoveryPlan {
+  /** records whose live data differs from the at-anchor state (live row present). */
+  reverts: AnchorRevertCandidate[]
+  /** records that existed at the anchor but have NO live row now (deleted after the anchor). */
+  resurrects: AnchorResurrectCandidate[]
+  /** records DELETED as of the anchor that are live now (later resurrected): Revert keeps, Reset deletes. */
+  deletedAtAnchorLiveNow: string[]
+  /** live records with no revision ≤ anchor (created after the anchor): Revert keeps, Reset deletes. */
+  createdAfterAnchor: string[]
+  /** records excluded because their target snapshot carries a field id absent from the current schema. */
+  driftCount: number
+  /** records whose live data already equals the at-anchor state (no-op — informational). */
+  unchangedCount: number
+}
+
+const asRec = (v: unknown): Record<string, unknown> =>
+  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {}
+
+/** Order-insensitive deep-ish equality on record data objects (JSON-shaped values). */
+function dataEquals(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  const ka = Object.keys(a)
+  const kb = Object.keys(b)
+  if (ka.length !== kb.length) return false
+  for (const k of ka) {
+    if (!(k in b)) return false
+    if (JSON.stringify(a[k]) !== JSON.stringify(b[k])) return false
+  }
+  return true
+}
+
+/**
+ * Build the exact-anchor recovery plan for a sheet (§5 set recomputation; PURE READ — writes nothing).
+ * See the module doc for the classification table and the layering contract.
+ */
+export async function buildExactAnchorRecoveryPlan(
+  query: QueryFn,
+  sheetId: string,
+  anchorSeq: string,
+): Promise<ExactAnchorRecoveryPlan> {
+  assertSeqString(anchorSeq, 'buildExactAnchorRecoveryPlan.anchorSeq') // fail-closed on a garbage anchor
+
+  // Current schema — the drift guard's truth (a stale field key must never be re-written).
+  const fieldRes = await query('SELECT id FROM meta_fields WHERE sheet_id = $1', [sheetId])
+  const fieldIds = new Set((fieldRes.rows as Array<{ id: unknown }>).map((r) => String(r.id)))
+
+  // Live rows.
+  const liveById = new Map<string, { data: Record<string, unknown>; version: number }>()
+  const liveRes = await query('SELECT id, data, version FROM meta_records WHERE sheet_id = $1', [sheetId])
+  for (const r of liveRes.rows as Array<{ id: unknown; data: unknown; version: unknown }>) {
+    liveById.set(String(r.id), {
+      data: asRec(r.data),
+      version: typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : Number(r.version) || 0,
+    })
+  }
+
+  // The causal at-anchor state (delete-aware, target-generation-correct — L6-b).
+  const stateMap = await reconstructRecordsAtSeq(query, sheetId, anchorSeq)
+  return classifyExactAnchorRecoveryPlan(stateMap, liveById, fieldIds)
+}
+
+/**
+ * The PURE classification core (extracted for L8's execute, which composes the L5 baseline into the state
+ * map before planning — the classification semantics are identical either way; see the module doc table).
+ */
+export function classifyExactAnchorRecoveryPlan(
+  stateMap: Map<string, { recordId: string; exists: boolean; data: Record<string, unknown> | null; version: number | null }>,
+  liveById: Map<string, { data: Record<string, unknown>; version: number }>,
+  fieldIds: ReadonlySet<string>,
+): ExactAnchorRecoveryPlan {
+  const plan: ExactAnchorRecoveryPlan = {
+    reverts: [],
+    resurrects: [],
+    deletedAtAnchorLiveNow: [],
+    createdAfterAnchor: [],
+    driftCount: 0,
+    unchangedCount: 0,
+  }
+
+  for (const [recordId, target] of stateMap) {
+    const live = liveById.get(recordId)
+    if (target.exists) {
+      const targetData = asRec(target.data)
+      // Schema-drift guard — identical for the revert and resurrect branches (excluded, counted, re-preview).
+      let drift = false
+      for (const fid of Object.keys(targetData)) if (!fieldIds.has(fid)) { drift = true; break }
+      if (drift) { plan.driftCount++; continue }
+      if (!live) {
+        // Existed at the anchor, gone now ⇒ deleted AFTER the anchor ⇒ resurrectable to its at-anchor state.
+        plan.resurrects.push({ recordId, snapshot: targetData, targetVersion: target.version })
+        continue
+      }
+      if (dataEquals(live.data, targetData)) { plan.unchangedCount++; continue }
+      plan.reverts.push({ recordId, targetData, targetVersion: target.version, liveVersion: live.version })
+      continue
+    }
+    // target deleted as of the anchor (latest seq<=anchor revision is a delete — LOCK-9):
+    if (live) plan.deletedAtAnchorLiveNow.push(recordId) // resurrected after the anchor — caller picks keep/delete
+    // no live row ⇒ stays deleted; NEVER resurrected.
+  }
+
+  // Live rows with no revision ≤ anchor at all: created after the anchor.
+  for (const id of liveById.keys()) if (!stateMap.has(id)) plan.createdAfterAnchor.push(id)
+
+  return plan
+}

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts
@@ -1,0 +1,197 @@
+/**
+ * W0-1 v3.7 Lane L7 — exact-anchor recovery PLAN classification (real DB).
+ *
+ * Module under test: `exact-anchor-recovery-plan.ts` `buildExactAnchorRecoveryPlan` — the §5 target-set
+ * recomputation on top of L6-b's causal reconstructor. Goldens (each mutation-proven in the PR matrix):
+ *   REVERT           live differs from at-anchor ⇒ revert candidate carrying the AT-ANCHOR data.
+ *   RESURRECT-AFTER  deleted AFTER the anchor (delete seq > anchor), no live row ⇒ resurrect candidate with
+ *                    the at-anchor snapshot (from the revision chain — NOT the trash row's terminal vintage).
+ *   STAYS-DELETED    deleted BEFORE/AT the anchor, no live row ⇒ NOT resurrected (LOCK-9; no candidate).
+ *   DELETED-AT-ANCHOR-LIVE-NOW  deleted as of the anchor but resurrected later (live now) ⇒ exposed in the
+ *                    caller-picks list, NEVER auto-classified as a revert/resurrect.
+ *   CREATED-AFTER    live row with no revision ≤ anchor ⇒ createdAfterAnchor, NOT a revert.
+ *   MULTI-GEN        anchor inside generation 1 of a delete→recreate ⇒ target = GEN-1 state (the live gen-2
+ *                    row becomes a revert candidate whose targetData is g1's, target-generation A).
+ *   DRIFT            at-anchor snapshot carries a field id absent from the CURRENT schema ⇒ excluded +
+ *                    driftCount (both the revert and resurrect branches).
+ *   UNCHANGED        live equals at-anchor ⇒ unchangedCount, no candidate.
+ *   EXACT-BIGINT     the 2^53/2^53+1 anchor boundary classifies exactly (bigint, never float).
+ *
+ * P2-C hygiene: explicit synthetic seq literals on isolated fixture rows; NEVER `setval` on the shared
+ * sequence; cleanup deletes only this suite's rows. Two-point wiring: plugin-tests.yml real-DB run list +
+ * vitest glob. Runs only with DATABASE_URL; the top-level sentinel fails-not-skips in the allowlist step.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { buildExactAnchorRecoveryPlan } from '../../src/multitable/exact-anchor-recovery-plan'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_earp_${TS}`
+const SHEET = `sheet_earp_${TS}`
+const F_STR = `fld_earp_note_${TS}`
+const ACTOR = `user_earp_${TS}`
+
+const q = (sql: string, params: unknown[] = []) => poolManager.get().query(sql, params)
+
+const revSeq = (
+  recordId: string,
+  version: number,
+  action: 'create' | 'update' | 'delete',
+  snap: Record<string, unknown> | null,
+  seq: string,
+) =>
+  q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[]::text[],'{}'::jsonb,$5::jsonb,$6::bigint)`,
+    [SHEET, recordId, version, action, snap === null ? null : JSON.stringify(snap), seq],
+  )
+const live = (id: string, data: Record<string, unknown>, version = 1) =>
+  q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,$4)', [id, SHEET, JSON.stringify(data), version])
+
+async function wipe(): Promise<void> {
+  for (const t of ['meta_records_trash', 'meta_record_revisions', 'meta_records'])
+    await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+}
+
+test('sentinel: the real-DB allowlist step must have DATABASE_URL (fail-not-skip, scoped to that step)', () => {
+  if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+    throw new Error('real-DB allowlist step is missing DATABASE_URL — the harness is broken, not legitimately skippable')
+  }
+  expect(true).toBe(true)
+})
+
+describeIfDatabase('W0-1 v3.7 L7 — exact-anchor recovery plan (real DB)', () => {
+  beforeAll(async () => {
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'EARP Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'EARP'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_STR, SHEET, 'Note', 'string', '{}', 1])
+  })
+  beforeEach(wipe)
+  afterAll(async () => {
+    await wipe()
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL is set (this suite must RUN, never skip-green)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('REVERT: live differs from at-anchor ⇒ candidate carries the AT-ANCHOR data + both versions', async () => {
+    const R = `rec_rev_${TS}`
+    await revSeq(R, 1, 'create', { [F_STR]: 'old' }, '100')
+    await revSeq(R, 2, 'update', { [F_STR]: 'new' }, '200')
+    await live(R, { [F_STR]: 'new' }, 2)
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '150')
+    expect(plan.reverts).toEqual([{ recordId: R, targetData: { [F_STR]: 'old' }, targetVersion: 1, liveVersion: 2 }])
+    expect(plan.resurrects).toEqual([])
+    expect(plan.createdAfterAnchor).toEqual([])
+    expect(plan.deletedAtAnchorLiveNow).toEqual([])
+  })
+
+  test('RESURRECT-AFTER vs STAYS-DELETED: delete AFTER the anchor resurrects to the AT-ANCHOR state; delete AT/BEFORE the anchor stays deleted', async () => {
+    const AFTER = `rec_after_${TS}`
+    const BEFORE = `rec_before_${TS}`
+    // AFTER: create@100 (v1 'keep-me'), update@200 (v2 'newer'), delete@300. Anchor 250 ⇒ existed at v2.
+    await revSeq(AFTER, 1, 'create', { [F_STR]: 'keep-me' }, '100')
+    await revSeq(AFTER, 2, 'update', { [F_STR]: 'newer' }, '200')
+    await revSeq(AFTER, 2, 'delete', { [F_STR]: 'newer' }, '300')
+    // BEFORE: create@110, delete@120 — deleted before the anchor ⇒ stays deleted.
+    await revSeq(BEFORE, 1, 'create', { [F_STR]: 'gone' }, '110')
+    await revSeq(BEFORE, 1, 'delete', { [F_STR]: 'gone' }, '120')
+
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '250')
+    // AFTER resurrects with its AT-ANCHOR (v2 'newer') snapshot — from the revision chain, not any trash vintage.
+    expect(plan.resurrects).toEqual([{ recordId: AFTER, snapshot: { [F_STR]: 'newer' }, targetVersion: 2 }])
+    // BEFORE appears NOWHERE (stays deleted — LOCK-9).
+    expect(plan.reverts.map((r) => r.recordId)).not.toContain(BEFORE)
+    expect(plan.deletedAtAnchorLiveNow).toEqual([])
+    expect(plan.createdAfterAnchor).toEqual([])
+  })
+
+  test('DELETED-AT-ANCHOR-LIVE-NOW + CREATED-AFTER: exposed in the caller-picks lists, never auto-destructed', async () => {
+    const RESURRECTED = `rec_resu_${TS}` // deleted before anchor, re-created after ⇒ live now
+    const NEWBIE = `rec_new_${TS}` // created after the anchor
+    await revSeq(RESURRECTED, 1, 'create', { [F_STR]: 'g1' }, '100')
+    await revSeq(RESURRECTED, 1, 'delete', { [F_STR]: 'g1' }, '150')
+    await revSeq(RESURRECTED, 1, 'create', { [F_STR]: 'g2' }, '400') // after the anchor
+    await live(RESURRECTED, { [F_STR]: 'g2' }, 1)
+    await revSeq(NEWBIE, 1, 'create', { [F_STR]: 'brand-new' }, '500')
+    await live(NEWBIE, { [F_STR]: 'brand-new' }, 1)
+
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '200')
+    expect(plan.deletedAtAnchorLiveNow).toEqual([RESURRECTED]) // deleted as of anchor 200, live now
+    expect(plan.createdAfterAnchor).toEqual([NEWBIE]) // no revision ≤ 200
+    // Neither is a revert or resurrect — the plan never chooses destruction.
+    expect(plan.reverts).toEqual([])
+    expect(plan.resurrects).toEqual([])
+  })
+
+  test('MULTI-GEN target-generation A: an anchor inside generation 1 makes the live gen-2 row a revert to the G1 state', async () => {
+    const R = `rec_gen_${TS}`
+    // gen1: create v1@10 ('g1v1'), update v2@20 ('g1v2'), delete v2@30. gen2: create v1@40 ('g2v1') — live.
+    await revSeq(R, 1, 'create', { [F_STR]: 'g1v1' }, '10')
+    await revSeq(R, 2, 'update', { [F_STR]: 'g1v2' }, '20')
+    await revSeq(R, 2, 'delete', { [F_STR]: 'g1v2' }, '30')
+    await revSeq(R, 1, 'create', { [F_STR]: 'g2v1' }, '40')
+    await live(R, { [F_STR]: 'g2v1' }, 1)
+
+    // anchor 25: inside GEN 1, at its v2 state — the plan must target g1v2 (target-generation A), not the
+    // terminal generation's state and not "stays deleted".
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '25')
+    expect(plan.reverts).toEqual([{ recordId: R, targetData: { [F_STR]: 'g1v2' }, targetVersion: 2, liveVersion: 1 }])
+
+    // anchor 35 (inside the deletion window): deleted as of the anchor but live now ⇒ caller-picks list.
+    const plan35 = await buildExactAnchorRecoveryPlan(q, SHEET, '35')
+    expect(plan35.deletedAtAnchorLiveNow).toEqual([R])
+    expect(plan35.reverts).toEqual([])
+  })
+
+  test('DRIFT: a stale field id in the at-anchor snapshot excludes the record (both branches) and counts drift', async () => {
+    const GHOST_FIELD = `fld_ghost_${TS}` // never inserted into meta_fields
+    const R_LIVE = `rec_drift_live_${TS}`
+    const R_GONE = `rec_drift_gone_${TS}`
+    await revSeq(R_LIVE, 1, 'create', { [GHOST_FIELD]: 'stale' }, '100')
+    await revSeq(R_LIVE, 2, 'update', { [F_STR]: 'now' }, '300')
+    await live(R_LIVE, { [F_STR]: 'now' }, 2)
+    await revSeq(R_GONE, 1, 'create', { [GHOST_FIELD]: 'stale' }, '110')
+    await revSeq(R_GONE, 1, 'delete', { [GHOST_FIELD]: 'stale' }, '400')
+
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '200')
+    expect(plan.driftCount).toBe(2) // one revert-branch drift + one resurrect-branch drift
+    expect(plan.reverts).toEqual([])
+    expect(plan.resurrects).toEqual([])
+  })
+
+  test('UNCHANGED: live equals at-anchor ⇒ counted, no candidate', async () => {
+    const R = `rec_same_${TS}`
+    await revSeq(R, 1, 'create', { [F_STR]: 'same' }, '100')
+    await live(R, { [F_STR]: 'same' }, 1)
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '200')
+    expect(plan.unchangedCount).toBe(1)
+    expect(plan.reverts).toEqual([])
+  })
+
+  test('EXACT-BIGINT: the 2^53 anchor boundary classifies exactly (a float compare would include the +1 write)', async () => {
+    const R = `rec_big_${TS}`
+    const LO = '9007199254740992' // 2^53
+    const HI = '9007199254740993' // 2^53+1 — Number() collapses onto LO
+    expect(Number(LO) === Number(HI)).toBe(true)
+    await revSeq(R, 1, 'create', { [F_STR]: 'lo' }, LO)
+    await revSeq(R, 2, 'update', { [F_STR]: 'hi' }, HI)
+    await live(R, { [F_STR]: 'hi' }, 2)
+    // anchor = LO exactly: the HI write has NOT happened yet ⇒ the plan reverts live('hi') → target('lo').
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, LO)
+    expect(plan.reverts).toEqual([{ recordId: R, targetData: { [F_STR]: 'lo' }, targetVersion: 1, liveVersion: 2 }])
+  })
+
+  test('garbage anchor fails closed (assertSeqString throws before any SQL)', async () => {
+    const throwQ = (() => { throw new Error('plan touched the DB on a garbage anchor') }) as never
+    await expect(buildExactAnchorRecoveryPlan(throwQ, SHEET, 'not-a-seq')).rejects.toThrow(/seq/i)
+  })
+})


### PR DESCRIPTION
## W0-1 v3.7 Lane L7 — exact-anchor recovery PLAN (DRAFT, stacked on #4417; held, unwired, flags OFF)

**Stacked-PR notice:** base = `claude/w0-l6b-exact-anchor-20260716` (#4417, itself held for the owner's flip decision). This PR consumes L6-b's `reconstructRecordsAtSeq` and lands the **§5 target-set recomputation** layer — the classification a destructive apply consumes at L8. Not wired to any route (default-off by construction); nothing destructive.

### Scope note (honest)
Target-**generation** resolution itself was already delivered by L6-b's causal reconstructor (the MULTI-GEN golden). What this lane adds is the remaining §5 semantics: the **plan classification** with deleted/trash enumeration end-to-end.

### The classification (per record, target = as-of-`anchorSeq` state)
| target | live now | plan |
|---|---|---|
| exists (differs) | yes | **revert** candidate — at-anchor data + target/live versions |
| exists | no | **resurrect** candidate — at-anchor snapshot (revision chain, never a trash vintage) |
| deleted (≤ anchor) | yes | `deletedAtAnchorLiveNow` — **caller picks** (Revert keeps / Reset deletes; the plan never chooses destruction) |
| deleted | no | stays deleted (LOCK-9 — never resurrected) |
| no revision ≤ anchor | yes | `createdAfterAnchor` — caller picks |

Schema-drift snapshots (stale field id) **excluded + counted** on both branches → re-preview, never half-applied.

### Layering contract (loud, in the module doc)
Core set-classification ONLY. Permission masking (PIT-3), row-level deny, size ceilings, and **fence acquisition are the L8 wiring's obligations** — consuming this module without those layers is not a production path.

### Verify (10 real-DB goldens, first-run green; 4 mutations, each load-bearing)
R5-A drop LOCK-9 ⇒ **3 red** · R5-B drop drift guard ⇒ **1 red** · R5-C vacuous `dataEquals` ⇒ **3 red** · R5-D skip resurrect ⇒ **1 red**. Includes MULTI-GEN target-generation A (anchor inside gen-1 reverts the live gen-2 row to the **G1** state; anchor inside the deletion window → caller-picks list), the 2^53 exact-bigint boundary, and garbage-anchor fail-closed (no SQL). Sibling regression (R4 goldens + reconstructor + checkpoint) 47/47. Two-point CI wiring. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
