### PR TITLE
W0 L8 — exact-anchor destructive apply: one txn, all-or-nothing (DRAFT, stacked)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -457,6 +457,7 @@ jobs:
             tests/integration/multitable-l5wire-checkpoint-activation-realdb.test.ts \
             tests/integration/multitable-exact-anchor-recovery-realdb.test.ts \
             tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts \
+            tests/integration/multitable-exact-anchor-apply-realdb.test.ts \
             tests/integration/multitable-d1c-form-submit-revision-realdb.test.ts \
             tests/integration/multitable-d1c-plugin-revision-realdb.test.ts \
             tests/integration/multitable-d1c-automation-revision-realdb.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260717120000_create_meta_recovery_token_burns.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260717120000_create_meta_recovery_token_burns.ts
@@ -1,0 +1,41 @@
+import { sql, type Kysely } from 'kysely'
+
+/**
+ * W0-1 v3.7 Lane L8 — the ANTI-REPLAY burn ledger for exact-anchor recovery tokens.
+ *
+ * Design authority: v3.7 lock §5 (in-fence execute) + the L6-b gate's pinned L8 deferral #3 (2026-07-16):
+ * a valid exact-anchor preview identity is stateless (HS256 JWT, 10m TTL) and could otherwise be EXECUTED
+ * MORE THAN ONCE within its TTL. The destructive apply burns the token's sha256 INSIDE its own single
+ * transaction (INSERT into this table); a second execute of the same token hits the primary key and the
+ * whole apply rolls back — at-most-once per minted preview, enforced by the database, not by app memory.
+ *
+ * Shape notes:
+ *   - `token_sha256` (PK): hex sha256 of the FULL signed token. The raw token is never stored (it is a
+ *     bearer credential); the hash is enough for the uniqueness barrier and useless to an attacker.
+ *   - `sheet_id` + `burned_at` + `actor_id`: audit surface only — values-free (no anchor/scope contents).
+ *   - No FK to sheets (a burn row must survive sheet deletion for audit).
+ *   - Rows are tiny and bounded by real executes; a retention sweep can prune rows older than the token
+ *     TTL window later (any row older than the max TTL can never match a verifiable token again).
+ *
+ * DEFAULT-OFF: nothing inserts here until the L8 apply is wired and its flags are enabled — the table is
+ * inert schema. zzzz-timestamped ([[feedback_migration_zzzz_ordering]]); proven on a fresh-DB full migrate.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_recovery_token_burns (
+      token_sha256 text PRIMARY KEY,
+      sheet_id     text NOT NULL,
+      actor_id     text,
+      burned_at    timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_recovery_token_burns_sheet
+    ON meta_recovery_token_burns(sheet_id, burned_at)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_meta_recovery_token_burns_sheet`.execute(db)
+  await sql`DROP TABLE IF EXISTS meta_recovery_token_burns`.execute(db)
+}

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -289,13 +289,24 @@ export async function applyExactAnchorRecovery(
           'INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)',
           [s.recordId, input.sheetId, JSON.stringify(s.snapshot), input.actorId],
         )
-        // Rebuild outbound meta_links from the at-anchor snapshot (writable/forward links only) — same insert
-        // shape as create/patch/restoreRecord; `loadLinkValuesByRecord` reads meta_links, not `data`.
+        // Rebuild outbound meta_links from the at-anchor snapshot (writable/forward links only) —
+        // `loadLinkValuesByRecord` reads meta_links, not `data`, so without this the resurrected record's
+        // link cells read empty. IDEMPOTENCE VIA `NOT EXISTS`, NOT `ON CONFLICT`: meta_links has NO unique
+        // constraint on the edge triple (only `meta_links_pkey` on the synthetic `id`), so an
+        // `ON CONFLICT DO NOTHING` with a freshly-minted uuid can NEVER fire — it reads as a guard while
+        // guaranteeing nothing. This is the same discipline 4c-3's inbound replay carries
+        // (`inbound-link-replay.ts` ~:154). Today no duplicate is reachable anyway (the record's outbound
+        // rows were dropped by `meta_links_record_id_fkey ON DELETE CASCADE` when it was deleted), but the
+        // guard makes that a property of THIS statement instead of a precondition inherited from elsewhere.
         for (const fieldId of resurrectLinkFieldIds) {
           for (const foreignId of normalizeLinkIds((s.snapshot as Record<string, unknown>)[fieldId])) {
             await query(
               `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
-               VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`,
+               SELECT $1, $2, $3, $4
+                WHERE NOT EXISTS (
+                  SELECT 1 FROM meta_links ml
+                   WHERE ml.field_id = $2 AND ml.record_id = $3 AND ml.foreign_record_id = $4
+                )`,
               [`lnk_${randomUUID()}`.slice(0, 50), fieldId, s.recordId, foreignId],
             )
           }

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -1,0 +1,341 @@
+import { createHash } from 'node:crypto'
+
+import type { QueryFn } from './permission-service'
+import { fenceWriterEntry } from './canonical-sheet-fence'
+import { selectCheckpointByAnchorSeq } from './history-trust-checkpoint'
+import { reconstructRecordsAtSeq } from './record-reconstructor'
+import { mintOperation, sealOperation } from './operation-ledger'
+import { recordRecordRevision } from './record-history-service'
+import { ensureRecordNotLocked } from './record-lock'
+import {
+  hashAnchorRecoveryScope,
+  hashRecoveryAuthorizationScope,
+  verifyExactAnchorRecoveryIdentity,
+  type ExactAnchorRecoveryMode,
+} from './restore-preview-identity'
+import { composeBaselineOverlay, type EvaluateRecoveryFullReadAccess } from './exact-anchor-recovery'
+import { classifyExactAnchorRecoveryPlan, type ExactAnchorRecoveryPlan } from './exact-anchor-recovery-plan'
+
+/**
+ * W0-1 v3.7 Lane L8 — the exact-anchor DESTRUCTIVE APPLY: one transaction, all-or-nothing.
+ *
+ * Design authority: v3.7 lock (#4331) §5 (execute = full target/schema/set recomputation UNDER THE FENCE,
+ * preview verification in-fence) + §2 (canonical fence) + the L6-b gate's pinned L8 deferrals (2026-07-16):
+ * (1) in-fence checkpoint re-resolution, (2) L5 baseline composition, (3) anti-replay single-use burn.
+ *
+ * THE SHAPE — one outer transaction, every step inside it, COMMIT once, any failure ⇒ FULL ROLLBACK with
+ * zero writes (including the token burn — a refused execute leaves the world byte-identical):
+ *   1. fenceWriterEntry (L4, fence-FIRST): serializes against every fenced writer AND any in-flight
+ *      recovery; observes a durable `applying` block and refuses. A concurrent writer parks on this fence
+ *      until we commit — nothing interleaves with the apply.
+ *   2. BURN the token (INSERT sha256 into `meta_recovery_token_burns`): the PK is the at-most-once
+ *      barrier — a second execute of the same token conflicts here and the whole txn rolls back
+ *      (`token-replayed`). Burned only on SUCCESS (any later refusal rolls the burn back with everything
+ *      else, so a drifted preview's token dies by TTL, not by half-burn).
+ *   3. IN-FENCE AUTHORIZATION RE-ADJUDICATION (P1-2, owner ruling 2026-07-17): the REQUIRED
+ *      `evaluateFullReadAccess` dependency is evaluated FRESH under the fence (revocation between preview
+ *      and execute ⇒ `forbidden`), and the token's signed `authorizedScopeHash` must equal the recomputed
+ *      v1 basis — the token's echo is never the authority.
+ *   4. IN-FENCE CHECKPOINT RE-RESOLUTION (deferral 1): re-run `selectCheckpointByAnchorSeq` and require
+ *      the resolved id to EQUAL the token's `checkpointId` — the token's echo is never trusted. A
+ *      checkpoint pruned/superseded-below since preview ⇒ `checkpoint-changed` (re-preview).
+ *   5. DRIFT RE-CHECK (§5 preview verification): re-reconstruct at the TOKEN-BOUND anchorSeq, compose the
+ *      L5 baseline overlay via the SHARED `composeBaselineOverlay` (deferral 2 + F4: records below the
+ *      replay horizon come from the RESOLVED checkpoint's immutable baseline — non-trashed ⇒ at-anchor
+ *      state, trashed ⇒ deleted-at-anchor), and re-hash the COMPOSED set; any divergence from the signed
+ *      `scopeHash` ⇒ `preview-drift` (409-class, zero writes). The preview hashed the SAME composed set —
+ *      what the actor saw is what gets planned; and it runs UNDER the fence (no check→write TOCTOU).
+ *   6. (folded into 5 — the composed map from the drift re-check IS the plan input.)
+ *   7. PLAN (L7): `classifyExactAnchorRecoveryPlan` over the composed map. `driftCount > 0` ⇒
+ *      `schema-drift` refusal — the WHOLE apply, zero writes (P1-2: no partial-set apply smuggled through
+ *      drift exclusion; explicit partial recovery is a future separate mode).
+ *   8. APPLY all-or-nothing, every write revision-emitted + ledger-tagged (L6-a; the recovery itself
+ *      becomes a sealed operation — a future exact anchor):
+ *        reverts    → UPDATE to the FULL at-anchor data (version+1, optimistic version guard) +
+ *                     revision(action:'update', source:'restore', snapshot = at-anchor data).
+ *        resurrects → INSERT (new generation, version resets to 1 — the MULTI-GEN convention) +
+ *                     revision(action:'create', source:'restore').
+ *        TOKEN mode 'reset' ONLY: DELETE `deletedAtAnchorLiveNow` + `createdAfterAnchor` rows +
+ *                     revision(action:'delete', snapshot = pre-delete data). mode 'revert' KEEPS both
+ *                     (non-destructive). P1-1: the mode is read from the VERIFIED CLAIMS — the caller has
+ *                     no mode input; a revert-preview token can never drive a reset.
+ *   9. SEAL the operation LAST (endpoint after its events — the deferred-FK discipline).
+ *
+ * LAYERING CONTRACT (P1-2 narrowed it — the SECURITY adjudication is KERNEL-OWNED): full-read
+ * authorization, mode authority, schema-drift whole-rejection, anti-replay, checkpoint/scope freshness all
+ * live HERE. What remains the route wiring's obligation: presentation masking of RETURNED data, size
+ * ceilings (SHEET_REVERT_MAX_RECORDS-class), link-field side-effects (mirror guards, foreign-existence
+ * checks), realtime fan-out, HTTP mapping. NOT wired to any route in this lane; the legacy Revert/Reset
+ * routes' switch onto this module is the OWNER's wiring decision behind their existing default-OFF flags
+ * (`MULTITABLE_ENABLE_SHEET_REVERT` / `MULTITABLE_ENABLE_PIT_RESET`). Default-off by construction: nothing
+ * reaches this module today.
+ */
+
+/** The apply's mode IS the token's mode (P1-1) — one vocabulary, defined with the identity claims. */
+export type ExactAnchorApplyMode = ExactAnchorRecoveryMode
+
+export type ExactAnchorApplyRefusal =
+  | 'identity-invalid' // signature/expiry/sheet/actor verification failed (pre-txn, zero DB writes)
+  | 'token-replayed' // the token was already burned by a previous successful execute
+  | 'forbidden' // in-fence fresh full-read adjudication failed, or the token's authorizedScopeHash does not match the recomputed basis (P1-2)
+  | 'no-covering-checkpoint' // no active/retained checkpoint covers the anchor any more (fail-closed)
+  | 'checkpoint-changed' // a checkpoint covers it, but NOT the one the preview was minted under
+  | 'preview-drift' // the live reconstruction diverged from the signed scope (409-class; re-preview)
+  | 'schema-drift' // the plan carries schema-drifted records (driftCount > 0) ⇒ WHOLE apply refused, zero writes (P1-2; explicit partial recovery is a future separate mode)
+
+export interface ExactAnchorApplySuccess {
+  ok: true
+  /** the TOKEN-BOUND mode (P1-1) — never a request-supplied one. */
+  mode: ExactAnchorApplyMode
+  anchorSeq: string
+  checkpointId: string
+  applied: { reverts: number; resurrects: number; deletes: number }
+  keptCreatedAfterAnchor: number
+}
+export type ExactAnchorApplyResult = ExactAnchorApplySuccess | { ok: false; reason: ExactAnchorApplyRefusal }
+
+/** Typed control-flow error: thrown inside the txn to force a FULL rollback, mapped to a refusal outside. */
+class ApplyRefusalError extends Error {
+  constructor(readonly reason: ExactAnchorApplyRefusal) {
+    super(`exact-anchor apply refused: ${reason}`)
+    this.name = 'ApplyRefusalError'
+  }
+}
+
+/** Postgres unique-violation on the burn PK ⇒ the token was already used. */
+const isUniqueViolation = (e: unknown): boolean =>
+  typeof e === 'object' && e !== null && (e as { code?: unknown }).code === '23505'
+
+const asRec = (v: unknown): Record<string, unknown> =>
+  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {}
+
+export interface ExactAnchorApplyInput {
+  token: string
+  sheetId: string
+  actorId: string
+  /** REQUIRED in-fence authorization dependency (P1-2) — same contract as the preview's (see
+   *  `EvaluateRecoveryFullReadAccess`). The apply re-adjudicates FRESH inside the fence; there is no
+   *  "already checked at preview" shortcut and no way to omit it. */
+  evaluateFullReadAccess: EvaluateRecoveryFullReadAccess
+}
+
+/**
+ * Execute the destructive apply. `transaction` must open a REAL database transaction and roll back when the
+ * callback throws (the poolManager.get().transaction shape). See the module doc for the step protocol.
+ * The MODE comes from the VERIFIED TOKEN (P1-1) — there is no mode input: a preview minted for a
+ * non-destructive `revert` is structurally unusable to drive a `reset`.
+ */
+export async function applyExactAnchorRecovery(
+  transaction: <T>(fn: (query: QueryFn) => Promise<T>) => Promise<T>,
+  input: ExactAnchorApplyInput,
+): Promise<ExactAnchorApplyResult> {
+  // Identity verification is pure (no DB) — fail fast before opening a transaction.
+  const verified = verifyExactAnchorRecoveryIdentity(input.token, { sheetId: input.sheetId, actorId: input.actorId })
+  if (!verified.valid || !verified.claims) return { ok: false, reason: 'identity-invalid' }
+  const { anchorSeq, checkpointId, scopeHash, liveSetHash, mode, authorizedScopeHash } = verified.claims
+
+  try {
+    return await transaction(async (query) => {
+      // 1. Fence-first (L4): serialize against all writers + refuse under a durable recovery block.
+      await fenceWriterEntry(query, input.sheetId)
+
+      // 2. Burn — the at-most-once barrier. A replayed token conflicts on the PK; a LATER refusal in this
+      //    txn rolls this row back too (zero-writes refusals).
+      const tokenSha = createHash('sha256').update(input.token).digest('hex')
+      try {
+        await query(
+          'INSERT INTO meta_recovery_token_burns (token_sha256, sheet_id, actor_id) VALUES ($1,$2,$3)',
+          [tokenSha, input.sheetId, input.actorId],
+        )
+      } catch (e) {
+        if (isUniqueViolation(e)) throw new ApplyRefusalError('token-replayed')
+        throw e
+      }
+
+      // 3. IN-FENCE AUTHORIZATION RE-ADJUDICATION (P1-2): evaluate the actor's full-read capability FRESH
+      //    (permission revoked since preview ⇒ refused; the burn above rolls back with everything else, so
+      //    the token survives a refusal and works again if the grant returns) AND recompute the v1
+      //    authorization basis against the token's signed `authorizedScopeHash` — the token's echo is never
+      //    the authority, exactly like the checkpoint re-resolution below.
+      if (!(await input.evaluateFullReadAccess(query))) throw new ApplyRefusalError('forbidden')
+      if (authorizedScopeHash !== hashRecoveryAuthorizationScope({ sheetId: input.sheetId, actorId: input.actorId })) {
+        throw new ApplyRefusalError('forbidden')
+      }
+
+      // 4. In-fence checkpoint re-resolution (deferral 1) — never trust the token's echo.
+      const checkpoint = await selectCheckpointByAnchorSeq(query, input.sheetId, anchorSeq)
+      if (!checkpoint) throw new ApplyRefusalError('no-covering-checkpoint')
+      if (checkpoint.id !== checkpointId) throw new ApplyRefusalError('checkpoint-changed')
+
+      // 5. Drift re-check UNDER the fence (§5) — TWO independent hashes, two failure classes:
+      //    (a) the ANCHOR AUTHORITY: re-reconstruct at the token anchor, compose the SAME L5 baseline
+      //        overlay the preview hashed (F4 symmetry — what the actor previewed IS what gets planned;
+      //        `composeBaselineOverlay` is the one shared implementation), and re-hash the COMPOSED set.
+      //        Immutable under an append-only history + immutable baselines, so a divergence means retention
+      //        pruned below the anchor or the anchor was recomputed (the MAX-recompute mutation class) — refuse.
+      const replayMap = await reconstructRecordsAtSeq(query, input.sheetId, anchorSeq)
+      const composed = await composeBaselineOverlay(query, { sheetId: input.sheetId, checkpointId: checkpoint.id, stateMap: replayMap })
+      const anchorHash = hashAnchorRecoveryScope(
+        [...composed.values()].map((s) => ({ recordId: s.recordId, exists: s.exists, version: s.version })),
+      )
+      if (anchorHash !== scopeHash) throw new ApplyRefusalError('preview-drift')
+      //    (b) PREVIEW FRESHNESS: re-fingerprint the LIVE set {id, version} in-fence. Any concurrent
+      //        version-bumping write / create / delete since the preview changes it — the actor must apply
+      //        exactly the world they previewed (the T-path's changesHash discipline, set-level). Read the
+      //        live rows HERE (they double as the plan input below — one read, checked and planned).
+      const liveById = new Map<string, { data: Record<string, unknown>; version: number; locked?: unknown; locked_by?: unknown; created_by?: unknown }>()
+      for (const r of (await query('SELECT id, data, version, locked, locked_by, created_by FROM meta_records WHERE sheet_id = $1', [input.sheetId])).rows as Array<{ id: unknown; data: unknown; version: unknown; locked?: unknown; locked_by?: unknown; created_by?: unknown }>) {
+        liveById.set(String(r.id), {
+          data: asRec(r.data),
+          version: typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : Number(r.version) || 0,
+          locked: r.locked,
+          locked_by: r.locked_by,
+          created_by: r.created_by,
+        })
+      }
+      const liveHash = hashAnchorRecoveryScope(
+        [...liveById.entries()].map(([recordId, l]) => ({ recordId, exists: true, version: l.version })),
+      )
+      if (liveHash !== liveSetHash) throw new ApplyRefusalError('preview-drift')
+
+      // (Baseline composition happened in step 5 via the shared `composeBaselineOverlay` — the SAME map the
+      // anchor hash covered is the map the plan consumes below: what was checked is what is planned.)
+
+      // 6. Plan (L7) over the composed map, against the SAME in-fence live rows the freshness hash covered
+      //    (one read: what was checked is what is planned) + the current schema.
+      const fieldRes = await query('SELECT id FROM meta_fields WHERE sheet_id = $1', [input.sheetId])
+      const fieldIds = new Set((fieldRes.rows as Array<{ id: unknown }>).map((r) => String(r.id)))
+      const plan: ExactAnchorRecoveryPlan = classifyExactAnchorRecoveryPlan(composed, liveById, fieldIds)
+
+      // P1-2 SCHEMA-DRIFT WHOLE-REJECT (owner ruling 2026-07-17): ANY schema-drifted record ⇒ the WHOLE
+      // apply is refused with zero writes (burn included — the txn rolls back). No partial-set apply is
+      // smuggled through drift exclusion; an EXPLICIT partial recovery is a future separate mode with its
+      // own preview disclosure, not a side effect of a stale field id.
+      if (plan.driftCount > 0) throw new ApplyRefusalError('schema-drift')
+
+      // 7. Apply — every write revision-emitted + ledger-tagged; a single failure rolls EVERYTHING back.
+      const op = await mintOperation(query, input.sheetId)
+
+      for (const r of plan.reverts) {
+        // Lock discipline (rank-8, mirrors the T-path recovery): a LOCKED record refuses the apply — and
+        // because this apply is all-or-nothing, one locked record aborts the WHOLE recovery loudly (unlock
+        // first, re-preview). ensureRecordNotLocked throws unless the actor is the locker/owner.
+        const liveRow = liveById.get(r.recordId)
+        if (liveRow) ensureRecordNotLocked(input.actorId, liveRow, () => new Error(`exact-anchor apply refused: record ${r.recordId} is locked`))
+        // lock-guarded: L8 revert apply — ensureRecordNotLocked just above, same txn.
+        // revision-emitted: L8 revert apply — recordRecordRevision below, same txn (source 'restore').
+        const upd = await query(
+          `UPDATE meta_records SET data = $1::jsonb, version = version + 1, updated_at = now()
+           WHERE id = $2 AND sheet_id = $3 AND version = $4
+           RETURNING version`,
+          [JSON.stringify(r.targetData), r.recordId, input.sheetId, r.liveVersion],
+        )
+        const row = upd.rows[0] as { version?: unknown } | undefined
+        // In-fence, post-drift-check: a 0-row update here is an internal invariant break — abort everything.
+        if (!row) throw new Error(`exact-anchor apply: optimistic version guard failed for ${r.recordId}`)
+        // revision-emitted: L8 revert apply — action:'update', source:'restore', full at-anchor snapshot.
+        await recordRecordRevision(query, {
+          sheetId: input.sheetId,
+          recordId: r.recordId,
+          version: Number(row.version),
+          action: 'update',
+          source: 'restore',
+          actorId: input.actorId,
+          changedFieldIds: Object.keys(r.targetData),
+          patch: r.targetData,
+          snapshot: r.targetData,
+          ledger: op,
+        })
+      }
+
+      for (const s of plan.resurrects) {
+        // New generation: version resets to 1 (the MULTI-GEN delete→recreate convention). No lock can exist
+        // on a row being created; the snapshot is previously-persisted at-anchor data (no new user payload).
+        // revision-emitted: L8 resurrect apply — recordRecordRevision below, same txn (source 'restore').
+        await query(
+          'INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)',
+          [s.recordId, input.sheetId, JSON.stringify(s.snapshot), input.actorId],
+        )
+        // revision-emitted: L8 resurrect apply — action:'create', source:'restore', at-anchor snapshot.
+        await recordRecordRevision(query, {
+          sheetId: input.sheetId,
+          recordId: s.recordId,
+          version: 1,
+          action: 'create',
+          source: 'restore',
+          actorId: input.actorId,
+          changedFieldIds: Object.keys(s.snapshot),
+          patch: s.snapshot,
+          snapshot: s.snapshot,
+          ledger: op,
+        })
+      }
+
+      let deletes = 0
+      // P1-1: the destructive branch keys on the TOKEN-BOUND mode — the one the actor previewed under.
+      if (mode === 'reset') {
+        for (const recordId of [...plan.deletedAtAnchorLiveNow, ...plan.createdAfterAnchor]) {
+          const live = liveById.get(recordId)
+          if (!live) continue // defensive: classified live moments ago, under the fence it must still be
+          // Lock discipline (rank-8): a LOCKED record aborts the whole all-or-nothing reset (unlock first).
+          ensureRecordNotLocked(input.actorId, live, () => new Error(`exact-anchor apply refused: record ${recordId} is locked`))
+          // lock-guarded: L8 reset delete — ensureRecordNotLocked just above, same txn.
+          // revision-emitted: L8 reset delete — recordRecordRevision below, same txn (source 'restore').
+          const del = await query(
+            'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2 RETURNING version',
+            [recordId, input.sheetId],
+          )
+          if (!del.rows[0]) throw new Error(`exact-anchor apply: reset delete found no row for ${recordId}`)
+          // revision-emitted: L8 reset delete — action:'delete', pre-delete snapshot (LOCK-9 convention).
+          await recordRecordRevision(query, {
+            sheetId: input.sheetId,
+            recordId,
+            version: live.version,
+            action: 'delete',
+            source: 'restore',
+            actorId: input.actorId,
+            changedFieldIds: [],
+            patch: {},
+            snapshot: live.data,
+            ledger: op,
+          })
+          deletes++
+        }
+      }
+
+      // 8. Seal LAST (endpoint after events — deferred-FK discipline). No-op when the ledger is inert.
+      await sealOperation(query, op)
+
+      return {
+        ok: true as const,
+        mode,
+        anchorSeq,
+        checkpointId: checkpoint.id,
+        applied: { reverts: plan.reverts.length, resurrects: plan.resurrects.length, deletes },
+        keptCreatedAfterAnchor: mode === 'revert' ? plan.createdAfterAnchor.length + plan.deletedAtAnchorLiveNow.length : 0,
+      }
+    })
+  } catch (e) {
+    if (e instanceof ApplyRefusalError) return { ok: false, reason: e.reason }
+    throw e // real failures propagate — the transaction has already rolled everything back
+  }
+}
+
+/**
+ * G1 (pre-wiring gate list) — BURN-RETENTION SWEEP. `meta_recovery_token_burns` grows one row per
+ * successful apply, forever; a burn row's at-most-once duty ends once its token can no longer verify
+ * (the 10-minute JWT `exp`). Prunes rows older than `keepMinutes`, FLOOR-CLAMPED to 15 minutes: pruning a
+ * burn younger than any possibly-live token's lifetime would RESURRECT a replayed token (the PK conflict
+ * is the at-most-once barrier), so the floor is a correctness bound (token TTL 10m + clock-skew margin),
+ * not a tunable. Values-free (deletes by age only); returns the pruned row count for the operator log.
+ * NOT scheduled anywhere in this lane — the sweep's production caller is route/ops wiring (the same PR
+ * that wires Revert/Reset onto this module), same posture as every other consumer here.
+ */
+export async function pruneExpiredRecoveryTokenBurns(query: QueryFn, keepMinutes = 60): Promise<number> {
+  const keep = Math.max(15, Math.floor(Number.isFinite(keepMinutes) ? keepMinutes : 60))
+  const res = await query(
+    `DELETE FROM meta_recovery_token_burns WHERE burned_at < now() - ($1 || ' minutes')::interval`,
+    [String(keep)],
+  )
+  return typeof res.rowCount === 'number' ? res.rowCount : 0
+}

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 
 import type { QueryFn } from './permission-service'
 import { fenceWriterEntry } from './canonical-sheet-fence'
@@ -7,6 +7,8 @@ import { reconstructRecordsAtSeq } from './record-reconstructor'
 import { mintOperation, sealOperation } from './operation-ledger'
 import { recordRecordRevision } from './record-history-service'
 import { ensureRecordNotLocked } from './record-lock'
+import { loadFieldsForSheet } from './loaders'
+import { isFieldAlwaysReadOnly } from './permission-derivation'
 import {
   hashAnchorRecoveryScope,
   hashRecoveryAuthorizationScope,
@@ -15,6 +17,13 @@ import {
 } from './restore-preview-identity'
 import { composeBaselineOverlay, type EvaluateRecoveryFullReadAccess } from './exact-anchor-recovery'
 import { classifyExactAnchorRecoveryPlan, type ExactAnchorRecoveryPlan } from './exact-anchor-recovery-plan'
+
+/** Normalize a link-field cell (array | single | null) to a string[] of foreign record ids (local copy of the
+ *  record-service private helper — the resurrect outbound-link rebuild needs exactly the same shape). */
+function normalizeLinkIds(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string' && v.length > 0)
+  return typeof value === 'string' && value.length > 0 ? [value] : []
+}
 
 /**
  * W0-1 v3.7 Lane L8 — the exact-anchor DESTRUCTIVE APPLY: one transaction, all-or-nothing.
@@ -53,8 +62,11 @@ import { classifyExactAnchorRecoveryPlan, type ExactAnchorRecoveryPlan } from '.
  *      becomes a sealed operation — a future exact anchor):
  *        reverts    → UPDATE to the FULL at-anchor data (version+1, optimistic version guard) +
  *                     revision(action:'update', source:'restore', snapshot = at-anchor data).
- *        resurrects → INSERT (new generation, version resets to 1 — the MULTI-GEN convention) +
- *                     revision(action:'create', source:'restore').
+ *        resurrects → lock the trash vintage FOR UPDATE → INSERT (new generation, version resets to 1 —
+ *                     the MULTI-GEN convention) → rebuild WRITABLE outbound meta_links from the snapshot →
+ *                     revision(action:'create', source:'restore') → DELETE the `meta_records_trash` row
+ *                     (live/trash mutual exclusion; mirrors `restoreRecord`; owner P1 2026-07-17). All in
+ *                     THIS txn, so an injected failure rolls the resurrect + its trash deletion back together.
  *        TOKEN mode 'reset' ONLY: DELETE `deletedAtAnchorLiveNow` + `createdAfterAnchor` rows +
  *                     revision(action:'delete', snapshot = pre-delete data). mode 'revert' KEEPS both
  *                     (non-destructive). P1-1: the mode is read from the VERIFIED CLAIMS — the caller has
@@ -62,10 +74,12 @@ import { classifyExactAnchorRecoveryPlan, type ExactAnchorRecoveryPlan } from '.
  *   9. SEAL the operation LAST (endpoint after its events — the deferred-FK discipline).
  *
  * LAYERING CONTRACT (P1-2 narrowed it — the SECURITY adjudication is KERNEL-OWNED): full-read
- * authorization, mode authority, schema-drift whole-rejection, anti-replay, checkpoint/scope freshness all
- * live HERE. What remains the route wiring's obligation: presentation masking of RETURNED data, size
- * ceilings (SHEET_REVERT_MAX_RECORDS-class), link-field side-effects (mirror guards, foreign-existence
- * checks), realtime fan-out, HTTP mapping. NOT wired to any route in this lane; the legacy Revert/Reset
+ * authorization, mode authority, schema-drift whole-rejection, anti-replay, checkpoint/scope freshness, AND
+ * the recovery DATA-INTEGRITY invariants (resurrect ⇒ trash-row cleanup + outbound-link rebuild = live/trash
+ * mutual exclusion, owner P1 2026-07-17) all live HERE. What remains the route wiring's obligation:
+ * presentation masking of RETURNED data, size ceilings (SHEET_REVERT_MAX_RECORDS-class), the BROADER
+ * link-field side-effects (mirror guards, foreign-existence checks, inbound-tombstone replay), realtime
+ * fan-out, HTTP mapping. NOT wired to any route in this lane; the legacy Revert/Reset
  * routes' switch onto this module is the OWNER's wiring decision behind their existing default-OFF flags
  * (`MULTITABLE_ENABLE_SHEET_REVERT` / `MULTITABLE_ENABLE_PIT_RESET`). Default-off by construction: nothing
  * reaches this module today.
@@ -248,7 +262,26 @@ export async function applyExactAnchorRecovery(
         })
       }
 
+      // Resurrect trash-lifecycle side effects (owner P1, 2026-07-17): a resurrect candidate was deleted
+      // AFTER the anchor, so its post-anchor delete left a `meta_records_trash` row. Bringing it back to
+      // live WITHOUT removing that row breaks the live/trash mutual-exclusion invariant — the recycle bin
+      // still shows the (now-live) record, a later restore of it 23505-conflicts on the id, and its lingering
+      // `delete_revision_id` mis-pins tombstone/retention. So the resurrect MUST mirror `restoreRecord`'s
+      // trash discipline: lock the vintage FOR UPDATE, rebuild the WRITABLE outbound links from the at-anchor
+      // snapshot (so link reads aren't silently empty; mirror side skipped — the spine invariant is
+      // structural), then DELETE the trash row — ALL inside this same all-or-nothing txn, so an injected
+      // later failure rolls back the INSERT, the revision, the link rebuild AND the trash deletion together.
+      const resurrectLinkFieldIds: string[] = plan.resurrects.length > 0
+        ? (await loadFieldsForSheet(query, input.sheetId))
+            .filter((f) => f.type === 'link' && !isFieldAlwaysReadOnly(f))
+            .map((f) => f.id)
+        : []
       for (const s of plan.resurrects) {
+        // Lock this record's trash vintage(s) FIRST (4c-3 C4 discipline): a concurrent restore/resurrect of
+        // the same id serializes here; the loser sees the rows gone and the whole apply aborts, never racing
+        // to a duplicate insert. A resurrect whose post-anchor delete was a hard delete (no trash row) locks
+        // zero rows — harmless.
+        await query('SELECT id FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2 FOR UPDATE', [s.recordId, input.sheetId])
         // New generation: version resets to 1 (the MULTI-GEN delete→recreate convention). No lock can exist
         // on a row being created; the snapshot is previously-persisted at-anchor data (no new user payload).
         // revision-emitted: L8 resurrect apply — recordRecordRevision below, same txn (source 'restore').
@@ -256,6 +289,17 @@ export async function applyExactAnchorRecovery(
           'INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)',
           [s.recordId, input.sheetId, JSON.stringify(s.snapshot), input.actorId],
         )
+        // Rebuild outbound meta_links from the at-anchor snapshot (writable/forward links only) — same insert
+        // shape as create/patch/restoreRecord; `loadLinkValuesByRecord` reads meta_links, not `data`.
+        for (const fieldId of resurrectLinkFieldIds) {
+          for (const foreignId of normalizeLinkIds((s.snapshot as Record<string, unknown>)[fieldId])) {
+            await query(
+              `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
+               VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`,
+              [`lnk_${randomUUID()}`.slice(0, 50), fieldId, s.recordId, foreignId],
+            )
+          }
+        }
         // revision-emitted: L8 resurrect apply — action:'create', source:'restore', at-anchor snapshot.
         await recordRecordRevision(query, {
           sheetId: input.sheetId,
@@ -269,6 +313,12 @@ export async function applyExactAnchorRecovery(
           snapshot: s.snapshot,
           ledger: op,
         })
+        // Trash cleanup — the live/trash mutual-exclusion invariant. Removing the trash row(s) for this id
+        // also drops the `delete_revision_id` anchor that was mis-pinning tombstone/retention. (Inbound-edge
+        // REPLAY from those terminal-vintage tombstones is deliberately NOT done here: this apply reconstructs
+        // the AT-ANCHOR state, a different vintage than the terminal delete the tombstones belong to — a naive
+        // replay would restore edges from the wrong vintage. That is a route-wiring / future-mode concern.)
+        await query('DELETE FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2', [s.recordId, input.sheetId])
       }
 
       let deletes = 0

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -277,10 +277,17 @@ export async function applyExactAnchorRecovery(
             .map((f) => f.id)
         : []
       for (const s of plan.resurrects) {
-        // Lock this record's trash vintage(s) FIRST (4c-3 C4 discipline): a concurrent restore/resurrect of
-        // the same id serializes here; the loser sees the rows gone and the whole apply aborts, never racing
-        // to a duplicate insert. A resurrect whose post-anchor delete was a hard delete (no trash row) locks
-        // zero rows — harmless.
+        // Lock this record's trash vintage(s) FIRST (4c-3 C4 discipline): a concurrent restoreRecord on the
+        // same id serializes here rather than racing the INSERT below. A resurrect whose post-anchor delete
+        // was a hard delete (no trash row) locks zero rows — harmless.
+        // HONEST COVERAGE (gate F1, 2026-07-17): this lock is DEFENSE-IN-DEPTH BENEATH the canonical fence,
+        // and it is NOT independently covered — neutering it leaves the suite green, because the apply only
+        // ever runs with the writer fence ON (`fenceWriterEntry` is a no-op when the flag is off,
+        // canonical-sheet-fence.ts:185) and that fence already serializes apply-vs-apply. What the lock adds
+        // is protection against a NON-fenced concurrent writer of the same trash row (today: restoreRecord).
+        // Correctness of the race itself is settled by construction rather than by a golden — a second
+        // resurrect of the same id conflicts on the burn PK (23505) and rolls back cleanly — but the
+        // independent coverage for this lock is deliberately DEFERRED to the wiring rung, not claimed here.
         await query('SELECT id FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2 FOR UPDATE', [s.recordId, input.sheetId])
         // New generation: version resets to 1 (the MULTI-GEN delete→recreate convention). No lock can exist
         // on a row being created; the snapshot is previously-persisted at-anchor data (no new user payload).

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -433,8 +433,15 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     )
     // A live foreign target so the outbound-link rebuild has something to point at is unnecessary here (no
     // link field on this fixture); this golden pins the trash-lifecycle invariant.
+    // PROBE: a SECOND trash vintage for the same id (reachable when a resurrect path left one behind — the
+    // very class of bug this fix closes, e.g. the legacy PIT resurrect). The cleanup must restore the
+    // mutual-exclusion invariant regardless of how many vintages exist.
+    await q(
+      'INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)',
+      [R_G2, SHEET, JSON.stringify({ [F_STR]: 'g2-older-vintage' }), 1],
+    )
     const trashBefore = await trashCount(R_G2)
-    expect(trashBefore).toBe(1) // precondition: the record IS in the recycle bin
+    expect(trashBefore).toBe(2) // precondition: TWO vintages in the recycle bin
     const pv = await preview(anchorOp, 'revert')
     const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
     expect(out.ok).toBe(true)

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -68,6 +68,7 @@ const live = (id: string, data: Record<string, unknown>, version = 1) =>
 const liveRow = async (id: string) =>
   (await q('SELECT data, version FROM meta_records WHERE id = $1 AND sheet_id = $2', [id, SHEET])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
 const burnCount = async () => Number(((await q('SELECT count(*)::int c FROM meta_recovery_token_burns WHERE sheet_id = $1', [SHEET])).rows[0] as { c: number }).c)
+const trashCount = async (recordId: string) => Number(((await q('SELECT count(*)::int c FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2', [recordId, SHEET])).rows[0] as { c: number }).c)
 
 /** Seal one synthetic operation (endpoint = exact MAX of its tagged event seqs) to serve as the anchor. */
 async function sealAnchorOp(recordId: string, eventSeqs: Array<{ seq: string; version: number; action?: 'create' | 'update' | 'delete'; snap?: Record<string, unknown> }>): Promise<string> {
@@ -430,12 +431,52 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
       'INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)',
       [R_G2, SHEET, JSON.stringify({ [F_STR]: 'g2-terminal' }), 2],
     )
+    // A live foreign target so the outbound-link rebuild has something to point at is unnecessary here (no
+    // link field on this fixture); this golden pins the trash-lifecycle invariant.
+    const trashBefore = await trashCount(R_G2)
+    expect(trashBefore).toBe(1) // precondition: the record IS in the recycle bin
     const pv = await preview(anchorOp, 'revert')
     const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
     expect(out.ok).toBe(true)
     // Resurrected from the REVISION CHAIN's at-anchor state — the trash row's terminal vintage is never read.
     expect((await liveRow(R_G2))?.data).toEqual({ [F_STR]: 'g2-at-anchor' })
     expect((await liveRow(R_G2))?.version).toBe(1) // new generation
+    // OWNER P1 (2026-07-17): live/trash MUTUAL EXCLUSION — the resurrect must have removed the trash row.
+    // Without the trash cleanup the record is live AND still in the recycle bin (future restore 23505,
+    // mis-pinned tombstone/retention). Mutation: drop the `DELETE FROM meta_records_trash` ⇒ this reds.
+    expect(await trashCount(R_G2)).toBe(0)
+  })
+
+  test('G2b RESURRECT-TRASH-ROLLBACK: an injected failure AFTER the resurrect rolls the live row, its revision AND the trash deletion back together (all-or-nothing)', async () => {
+    const { anchorOp } = await seedWorld()
+    const R_G2B = `rec_g2b_${TS}`
+    await revSeq(R_G2B, 1, 'create', { [F_STR]: 'g2b-at-anchor' }, '9000850')
+    await revSeq(R_G2B, 1, 'delete', { [F_STR]: 'g2b-at-anchor' }, '9002250') // deleted after the anchor
+    await q(
+      'INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)',
+      [R_G2B, SHEET, JSON.stringify({ [F_STR]: 'g2b-at-anchor' }), 1],
+    )
+    expect(await trashCount(R_G2B)).toBe(1)
+    const pv = await preview(anchorOp, 'revert')
+    // Inject a failure at the SEAL step (after every resurrect write incl. the trash deletion). A synthetic
+    // trigger that raises on INSERT into meta_record_history_operations forces the seal to throw ⇒ the whole
+    // outer txn rolls back. If the trash deletion did NOT participate in this txn, the row would stay gone.
+    const fn = `eaa_g2b_seal_fail_${TS}`
+    const trg = `trg_eaa_g2b_seal_fail_${TS}`
+    await q(`CREATE OR REPLACE FUNCTION ${fn}() RETURNS trigger AS $$ BEGIN RAISE EXCEPTION 'injected seal failure (G2b)'; END $$ LANGUAGE plpgsql`)
+    await q(`CREATE TRIGGER ${trg} BEFORE INSERT ON meta_record_history_operations FOR EACH ROW WHEN (NEW.sheet_id = '${SHEET}') EXECUTE FUNCTION ${fn}()`)
+    try {
+      await expect(applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).rejects.toThrow()
+      // EVERYTHING rolled back together: no live row, the trash row SURVIVES, no create revision, no burn.
+      expect(await liveRow(R_G2B)).toBeUndefined()
+      expect(await trashCount(R_G2B)).toBe(1) // the trash deletion rolled back with the failed apply
+      const revs = Number(((await q("SELECT count(*)::int c FROM meta_record_revisions WHERE record_id = $1 AND action = 'create' AND source = 'restore'", [R_G2B])).rows[0] as { c: number }).c)
+      expect(revs).toBe(0)
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q(`DROP TRIGGER IF EXISTS ${trg} ON meta_record_history_operations`).catch(() => {})
+      await q(`DROP FUNCTION IF EXISTS ${fn}()`).catch(() => {})
+    }
   })
 
   // ── G3 (pre-wiring gate list): DOUBLE-TOKEN constructed race ─────────────────────────────────────────────

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -454,6 +454,44 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     expect(await trashCount(R_G2)).toBe(0)
   })
 
+  test('G2c RESURRECT-LINK-REBUILD: the at-anchor snapshot rebuilds WRITABLE outbound meta_links, is NOT-EXISTS idempotent, and skips the mirror side', async () => {
+    const { anchorOp } = await seedWorld()
+    const R_SRC = `rec_g2c_src_${TS}` // resurrected; its snapshot carries link + mirror cells
+    const R_TGT = `rec_g2c_tgt_${TS}` // live foreign target
+    const F_LINK = `fld_g2c_link_${TS}`
+    const F_MIRROR = `fld_g2c_mirror_${TS}`
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_LINK, SHEET, 'Link', 'link', JSON.stringify({ foreignSheetId: SHEET }), 10])
+    // The MIRROR side of a twoWay link (property.mirrorOf) is ALWAYS read-only — it must never own a
+    // meta_links row (the spine invariant), so the rebuild must skip it structurally.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_MIRROR, SHEET, 'Mirror', 'link', JSON.stringify({ foreignSheetId: SHEET, mirrorOf: F_LINK }), 11])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [R_TGT, SHEET, JSON.stringify({ [F_STR]: 'target' })])
+    // at-anchor: R_SRC exists with BOTH a writable link cell and a mirror cell pointing at R_TGT.
+    const snap = { [F_STR]: 'g2c', [F_LINK]: [R_TGT], [F_MIRROR]: [R_TGT] }
+    await revSeq(R_SRC, 1, 'create', snap, '9000870')
+    await revSeq(R_SRC, 1, 'delete', snap, '9002260') // deleted after the anchor (links cascade-dropped)
+    await q('INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)', [R_SRC, SHEET, JSON.stringify(snap), 1])
+
+    const pv = await preview(anchorOp, 'revert')
+    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+
+    const links = (await q('SELECT field_id FROM meta_links WHERE record_id = $1 AND foreign_record_id = $2', [R_SRC, R_TGT])).rows as Array<{ field_id: string }>
+    // Exactly ONE row: the writable link. The mirror side is skipped (isFieldAlwaysReadOnly) — a mirror row
+    // here would break the twoWay spine invariant.
+    expect(links.length).toBe(1)
+    expect(links[0].field_id).toBe(F_LINK)
+
+    // NOT-EXISTS idempotence: re-running the same rebuild statement must not duplicate the edge. (ON CONFLICT
+    // DO NOTHING could never have caught this — meta_links has no unique on the edge triple, only on `id`.)
+    await q(
+      `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
+       SELECT $1, $2, $3, $4 WHERE NOT EXISTS (
+         SELECT 1 FROM meta_links ml WHERE ml.field_id = $2 AND ml.record_id = $3 AND ml.foreign_record_id = $4)`,
+      [`lnk_dup_${TS}`, F_LINK, R_SRC, R_TGT],
+    )
+    const after = (await q('SELECT count(*)::int c FROM meta_links WHERE record_id = $1 AND field_id = $2 AND foreign_record_id = $3', [R_SRC, F_LINK, R_TGT])).rows[0] as { c: number }
+    expect(Number(after.c)).toBe(1) // still exactly one — the guard held
+  })
+
   test('G2b RESURRECT-TRASH-ROLLBACK: an injected failure AFTER the resurrect rolls the live row, its revision AND the trash deletion back together (all-or-nothing)', async () => {
     const { anchorOp } = await seedWorld()
     const R_G2B = `rec_g2b_${TS}`

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -1,0 +1,493 @@
+/**
+ * W0-1 v3.7 Lane L8 — the exact-anchor DESTRUCTIVE APPLY (real DB): one transaction, all-or-nothing.
+ *
+ * Module under test: `exact-anchor-recovery-execute.ts` `applyExactAnchorRecovery`. Goldens (each
+ * mutation-proven in the PR matrix):
+ *   HAPPY-REVERT      end-to-end revert-mode apply: reverts + resurrects land atomically, every write
+ *                     revision-emitted (`source:'restore'`) and ledger-tagged; the apply itself seals an
+ *                     operation endpoint (a future exact anchor); token burned.
+ *   MODE-MATRIX       the SAME world under 'reset' also deletes deletedAtAnchorLiveNow + createdAfterAnchor
+ *                     (with delete revisions); under 'revert' both survive.
+ *   REPLAY            a second execute of the SAME token ⇒ `token-replayed`, zero writes.
+ *   LIVE-DRIFT (409)  a CONCURRENT COMMITTED WRITE between preview and execute ⇒ `preview-drift`, ZERO
+ *                     writes — including the token burn (the token is still executable after the world is
+ *                     restored to the previewed state ⇒ proves full rollback of the burn row).
+ *   CHECKPOINT-GONE   the covering checkpoint pruned/removed between preview and execute ⇒
+ *                     `no-covering-checkpoint`; a DIFFERENT covering checkpoint (superseding activation
+ *                     below the anchor) ⇒ `checkpoint-changed`. Zero writes.
+ *   INJECTED-FAILURE  a mid-apply failure (second revision INSERT forced to fail via a synthetic
+ *                     constraint collision) ⇒ the WHOLE apply rolls back: no record changed, no revisions,
+ *                     no endpoint, no burn.
+ *   BASELINE          a record whose history lives ONLY in the checkpoint baseline (zero revisions ≤
+ *                     anchor): non-trashed baseline row resurrects/reverts from the baseline data;
+ *                     is_trashed=true baseline row stays deleted.
+ *   FENCE-PARK (race) a raw client holds the canonical fence in an open transaction; the apply PARKS
+ *                     (proven via pg_locks/pg_blocking_pids sampling) and completes after release.
+ *
+ * The module is NOT wired to any route; the L4 fence flag is toggled only inside this test process
+ * (default OFF everywhere real). P2-C hygiene: explicit synthetic seq literals, no `setval`, own-row
+ * cleanup. Two-point wiring: plugin-tests.yml real-DB run list + vitest glob; fail-not-skip sentinel.
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { pool } from '../../src/db/pg'
+import { resolveExactAnchor } from '../../src/multitable/exact-anchor-recovery'
+import { applyExactAnchorRecovery, pruneExpiredRecoveryTokenBurns, type ExactAnchorApplyMode } from '../../src/multitable/exact-anchor-recovery-execute'
+import { hashAnchorRecoveryScope, hashRecoveryAuthorizationScope, mintExactAnchorRecoveryIdentity } from '../../src/multitable/restore-preview-identity'
+import { activateCheckpoint, type QueryFn } from '../../src/multitable/history-trust-checkpoint'
+import { __resetRecoveryWriterStateColumnProbe } from '../../src/multitable/canonical-sheet-fence'
+import { __resetOperationLedgerColumnProbe } from '../../src/multitable/operation-ledger'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const FLAG = 'MULTITABLE_ENABLE_WRITER_FENCE'
+const TS = Date.now()
+const BASE = `base_eaa_${TS}`
+const SHEET = `sheet_eaa_${TS}`
+const F_STR = `fld_eaa_note_${TS}`
+const ACTOR = `user_eaa_${TS}`
+
+const q = (sql: string, params: unknown[] = []) => poolManager.get().query(sql, params)
+const txn = <T>(fn: (query: QueryFn) => Promise<T>): Promise<T> =>
+  poolManager.get().transaction(async ({ query }) => fn(query as unknown as QueryFn)) as Promise<T>
+
+// P1-2 kernel adjudication stubs (the production evaluator is the route's `hasFullTableReadAccess`).
+const ALLOW_FULL_READ = async () => true
+const DENY_FULL_READ = async () => false
+
+const revSeq = (recordId: string, version: number, action: 'create' | 'update' | 'delete', snap: Record<string, unknown> | null, seq: string, opId?: string | null) =>
+  q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq, operation_id)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[]::text[],'{}'::jsonb,$5::jsonb,$6::bigint,$7::uuid)`,
+    [SHEET, recordId, version, action, snap === null ? null : JSON.stringify(snap), seq, opId ?? null],
+  )
+const live = (id: string, data: Record<string, unknown>, version = 1) =>
+  q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,$4)', [id, SHEET, JSON.stringify(data), version])
+const liveRow = async (id: string) =>
+  (await q('SELECT data, version FROM meta_records WHERE id = $1 AND sheet_id = $2', [id, SHEET])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+const burnCount = async () => Number(((await q('SELECT count(*)::int c FROM meta_recovery_token_burns WHERE sheet_id = $1', [SHEET])).rows[0] as { c: number }).c)
+
+/** Seal one synthetic operation (endpoint = exact MAX of its tagged event seqs) to serve as the anchor. */
+async function sealAnchorOp(recordId: string, eventSeqs: Array<{ seq: string; version: number; action?: 'create' | 'update' | 'delete'; snap?: Record<string, unknown> }>): Promise<string> {
+  const opId = randomUUID()
+  const maxSeq = eventSeqs.map((e) => e.seq).reduce((a, b) => (BigInt(a) >= BigInt(b) ? a : b))
+  await txn(async (query) => {
+    for (const e of eventSeqs) {
+      await query(
+        `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq, operation_id)
+         VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[]::text[],'{}'::jsonb,$5::jsonb,$6::bigint,$7::uuid)`,
+        [SHEET, recordId, e.version, e.action ?? 'update', JSON.stringify(e.snap ?? { [F_STR]: `v${e.version}` }), e.seq, opId],
+      )
+    }
+    await query(
+      `INSERT INTO meta_record_history_operations (sheet_id, operation_id, endpoint_seq, event_count) VALUES ($1,$2::uuid,$3::bigint,$4::int)`,
+      [SHEET, opId, maxSeq, eventSeqs.length],
+    )
+  })
+  return opId
+}
+const activate = () => txn((query) => activateCheckpoint(query, { sheetId: SHEET }))
+
+async function wipe(): Promise<void> {
+  for (const t of ['meta_history_baselines', 'meta_history_trust_checkpoints', 'meta_recovery_token_burns', 'meta_record_version_markers', 'meta_records_trash', 'meta_record_revisions', 'meta_records'])
+    await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+  await q('DELETE FROM meta_record_history_operations WHERE sheet_id = $1', [SHEET]).catch(() => {})
+}
+
+test('sentinel: the real-DB allowlist step must have DATABASE_URL (fail-not-skip, scoped to that step)', () => {
+  if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+    throw new Error('real-DB allowlist step is missing DATABASE_URL — the harness is broken, not legitimately skippable')
+  }
+  expect(true).toBe(true)
+})
+
+describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', () => {
+  beforeAll(async () => {
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'EAA Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'EAA'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_STR, SHEET, 'Note', 'string', '{}', 1])
+  })
+  beforeEach(async () => {
+    await wipe()
+    process.env[FLAG] = 'true' // this test process only — the apply is meaningful with the fence/ledger on
+    __resetRecoveryWriterStateColumnProbe()
+    __resetOperationLedgerColumnProbe()
+  })
+  afterEach(() => { delete process.env[FLAG] })
+  afterAll(async () => {
+    delete process.env[FLAG]
+    await wipe()
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL is set (this suite must RUN, never skip-green)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  /** The standard world: R_REV live differs from at-anchor; R_RES deleted after the anchor; R_NEW created after.
+   *  FIXTURE CAUSALITY: activate FIRST (empty sheet ⇒ empty baseline, small `trusted_since_seq` ≤ the anchor),
+   *  THEN write the synthetic history with explicit seqs above it. Activating after would snapshot the
+   *  post-anchor world into a baseline stamped BELOW the anchor — a causality violation only a synthetic-seq
+   *  fixture can produce (production seq is monotonic), and exactly what composition would faithfully expose. */
+  async function seedWorld() {
+    const R_REV = `rec_rev_${TS}_${Math.random().toString(36).slice(2, 6)}`
+    const R_RES = `rec_res_${TS}_${Math.random().toString(36).slice(2, 6)}`
+    const R_NEW = `rec_new_${TS}_${Math.random().toString(36).slice(2, 6)}`
+    await activate() // empty baseline; trusted_since = nextval (small) ≤ anchor 9001000
+    const anchorOp = await sealAnchorOp(R_REV, [
+      { seq: '9001000', version: 1, action: 'create', snap: { [F_STR]: 'rev-at-anchor' } },
+    ])
+    await revSeq(R_RES, 1, 'create', { [F_STR]: 'res-at-anchor' }, '9000900')
+    // post-anchor history: R_REV updated (v2), R_RES deleted, R_NEW created.
+    await revSeq(R_REV, 2, 'update', { [F_STR]: 'rev-now' }, '9002000')
+    await revSeq(R_RES, 1, 'delete', { [F_STR]: 'res-at-anchor' }, '9002100')
+    await revSeq(R_NEW, 1, 'create', { [F_STR]: 'newbie' }, '9002200')
+    await live(R_REV, { [F_STR]: 'rev-now' }, 2)
+    await live(R_NEW, { [F_STR]: 'newbie' }, 1)
+    return { R_REV, R_RES, R_NEW, anchorOp }
+  }
+  // P1-1: the MODE is chosen at PREVIEW and frozen into the token — the apply has no mode input at all.
+  const preview = async (anchorOp: string, mode: ExactAnchorApplyMode = 'revert') => {
+    const res = await resolveExactAnchor(q as unknown as QueryFn, { sheetId: SHEET, request: { kind: 'exact-anchor', anchorOperationId: anchorOp }, actorId: ACTOR, mode, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(res.ok).toBe(true)
+    if (!res.ok) throw new Error('preview failed')
+    return res
+  }
+
+  test('HAPPY-REVERT: atomic apply — revert + resurrect land, revisions source=restore + ledger-tagged, endpoint sealed, token burned, keeps preserved', async () => {
+    const { R_REV, R_RES, R_NEW, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out).toMatchObject({ ok: true, mode: 'revert', applied: { reverts: 1, resurrects: 1, deletes: 0 } })
+
+    expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-at-anchor' }) // reverted
+    expect((await liveRow(R_REV))?.version).toBe(3) // version+1, never rewound
+    expect((await liveRow(R_RES))?.data).toEqual({ [F_STR]: 'res-at-anchor' }) // resurrected
+    expect((await liveRow(R_RES))?.version).toBe(1) // new generation
+    expect(await liveRow(R_NEW)).toBeDefined() // revert KEEPS created-after-anchor
+
+    // Every apply write is revision-emitted with source 'restore' and TAGGED into ONE sealed operation.
+    const revRows = (await q(
+      `SELECT operation_id::text AS op FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`,
+      [SHEET],
+    )).rows as Array<{ op: string | null }>
+    expect(revRows.length).toBe(2)
+    expect(new Set(revRows.map((r) => r.op)).size).toBe(1)
+    expect(revRows[0].op).toBeTruthy()
+    const ep = (await q('SELECT event_count FROM meta_record_history_operations WHERE sheet_id = $1 AND operation_id = $2::uuid', [SHEET, revRows[0].op])).rows[0] as { event_count: number }
+    expect(ep.event_count).toBe(2) // the apply sealed its own endpoint — a future exact anchor
+    expect(await burnCount()).toBe(1)
+  })
+
+  test('MODE-MATRIX: reset also deletes deletedAtAnchorLiveNow + createdAfterAnchor (with delete revisions); revert kept them (proven above)', async () => {
+    const { R_RES, R_NEW, anchorOp } = await seedWorld()
+    // make R_RES a deleted-at-anchor-live-now case instead: resurrect it post-anchor so it is LIVE now.
+    await revSeq(R_RES, 1, 'create', { [F_STR]: 'res-gen2' }, '9002300')
+    await live(R_RES, { [F_STR]: 'res-gen2' }, 1)
+    // NOTE the anchor (1000) predates R_RES's create @900? No — 900 < 1000, so R_RES EXISTED at the anchor
+    // with 'res-at-anchor', was deleted @2100, re-created @2300. At the anchor it EXISTS ⇒ it is a REVERT
+    // candidate (live 'res-gen2' → target 'res-at-anchor'), not a delete case. R_NEW (created @2200) is the
+    // reset-delete case this golden pins.
+    // P1-1: reset must be PREVIEWED as reset — the mode rides in the token, not the apply call.
+    const pv = await preview(anchorOp, 'reset')
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out.ok).toBe(true)
+    if (!out.ok) return
+    expect(out.mode).toBe('reset') // the TOKEN's mode, echoed
+    expect(out.applied.deletes).toBe(1) // R_NEW deleted by reset
+    expect(await liveRow(R_NEW)).toBeUndefined()
+    const delRev = (await q(
+      `SELECT snapshot FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2 AND action = 'delete' AND source = 'restore'`,
+      [SHEET, R_NEW],
+    )).rows[0] as { snapshot: Record<string, unknown> } | undefined
+    expect(delRev?.snapshot).toEqual({ [F_STR]: 'newbie' }) // pre-delete snapshot captured
+  })
+
+  test('REPLAY: a second execute of the SAME token ⇒ token-replayed, zero writes', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+    const afterFirst = await liveRow(R_REV)
+    const second = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(second).toEqual({ ok: false, reason: 'token-replayed' })
+    expect(await liveRow(R_REV)).toEqual(afterFirst) // untouched by the replay attempt
+    expect(await burnCount()).toBe(1) // still exactly one burn
+  })
+
+  test('LIVE-DRIFT: a concurrent committed write between preview and execute ⇒ preview-drift, ZERO writes incl. the burn (the token survives and works once the drift is undone)', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    // Concurrent write AFTER the preview: bump R_REV (exactly what a user editing during the confirm dialog does).
+    await q('UPDATE meta_records SET data = $1::jsonb, version = version + 1 WHERE id = $2 AND sheet_id = $3', [JSON.stringify({ [F_STR]: 'sneaky' }), R_REV, SHEET])
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out).toEqual({ ok: false, reason: 'preview-drift' })
+    expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'sneaky' }) // nothing applied
+    expect(await burnCount()).toBe(0) // the burn rolled back with everything else — zero writes means ZERO
+    // Restore the exact previewed world ⇒ the SAME token executes (proves the refusal wrote nothing at all).
+    await q('UPDATE meta_records SET data = $1::jsonb, version = version - 1 WHERE id = $2 AND sheet_id = $3', [JSON.stringify({ [F_STR]: 'rev-now' }), R_REV, SHEET])
+    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+  })
+
+  test('CHECKPOINT-GONE / CHECKPOINT-CHANGED: the in-fence re-resolution never trusts the token echo', async () => {
+    const { anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    // (a) remove the covering checkpoint entirely ⇒ no-covering-checkpoint, zero writes.
+    await q('DELETE FROM meta_history_baselines WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_history_trust_checkpoints WHERE sheet_id = $1', [SHEET])
+    expect(await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'no-covering-checkpoint' })
+    expect(await burnCount()).toBe(0)
+    // (b) a DIFFERENT covering checkpoint (fresh activation) ⇒ the resolved id no longer equals the token's
+    //     checkpointId ⇒ checkpoint-changed (re-preview under the new trust floor).
+    await activate()
+    expect(await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'checkpoint-changed' })
+  })
+
+  test('INJECTED-FAILURE: a mid-apply crash rolls back EVERYTHING (no record change, no revisions, no endpoint, no burn)', async () => {
+    const { R_REV, R_RES, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    // Inject: pre-take R_RES's primary key inside ANOTHER sheet? No — same id across sheets collides on the
+    // meta_records PK (id). Insert a foreign-sheet row with R_RES's id so the apply's resurrect INSERT
+    // violates the PK AFTER the revert UPDATE already ran — a genuine mid-apply failure.
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3) ON CONFLICT (id) DO NOTHING', [`${SHEET}_other`, BASE, 'EAA other'])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [R_RES, `${SHEET}_other`, '{}'])
+    await expect(applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).rejects.toThrow()
+    // FULL rollback: the revert (which ran BEFORE the failing resurrect) is undone too.
+    expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-now' })
+    expect((await liveRow(R_REV))?.version).toBe(2)
+    expect(Number(((await q(`SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }).c)).toBe(0)
+    expect(await burnCount()).toBe(0)
+    // cleanup the injection
+    await q('DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2', [R_RES, `${SHEET}_other`])
+    await q('DELETE FROM meta_sheets WHERE id = $1', [`${SHEET}_other`])
+  })
+
+  test('BASELINE composition: a record living ONLY in the checkpoint baseline resurrects from baseline data; a trashed baseline row stays deleted', async () => {
+    const R_BASE = `rec_base_${TS}`
+    const R_TRASHED = `rec_trashed_${TS}`
+    // Anchor world: one revision-bearing record so an anchor op exists.
+    const R_REV = `rec_rev_${TS}_bl`
+    const anchorOp = await sealAnchorOp(R_REV, [{ seq: '9001000', version: 1, action: 'create', snap: { [F_STR]: 'x' } }])
+    await live(R_REV, { [F_STR]: 'x' }, 1)
+    const ck = await activate()
+    // Inject baseline-only records into the ACTIVE checkpoint (their revisions were "retention-pruned"):
+    // R_BASE existed (non-trashed) at the checkpoint; R_TRASHED was in the recycle bin (is_trashed).
+    const ckId = (ck as { checkpointId: string }).checkpointId
+    await q(
+      `INSERT INTO meta_history_baselines (checkpoint_id, sheet_id, record_id, data, version, is_trashed)
+       VALUES ($1,$2,$3,$4::jsonb,5,false), ($1,$2,$5,$6::jsonb,2,true)`,
+      [ckId, SHEET, R_BASE, JSON.stringify({ [F_STR]: 'from-baseline' }), R_TRASHED, JSON.stringify({ [F_STR]: 'was-trashed' })],
+    )
+    const pv = await preview(anchorOp)
+    // F4 (pre-wiring gate list): the PREVIEW already shows the baseline-composed set — what-you-see-is-
+    // what-applies. Both baseline records are in the preview stateMap (R_BASE as existing at-anchor,
+    // R_TRASHED as deleted-at-anchor), and the token's scopeHash covers this SAME composed set — the apply
+    // below succeeding proves preview↔apply hash symmetry (an asymmetric pair would refuse preview-drift).
+    expect(pv.stateMap.get(R_BASE)).toMatchObject({ exists: true, data: { [F_STR]: 'from-baseline' } })
+    expect(pv.stateMap.get(R_TRASHED)).toMatchObject({ exists: false })
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out.ok).toBe(true)
+    // R_BASE resurrected FROM THE BASELINE (below the replay horizon); R_TRASHED stays deleted.
+    expect((await liveRow(R_BASE))?.data).toEqual({ [F_STR]: 'from-baseline' })
+    expect(await liveRow(R_TRASHED)).toBeUndefined()
+  })
+
+  test('LOCKED record: a lock held by ANOTHER actor aborts the whole all-or-nothing apply (rank-8 discipline); unlocking lets it through', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    await q('UPDATE meta_records SET locked = true, locked_by = $1 WHERE id = $2 AND sheet_id = $3', ['someone-else', R_REV, SHEET])
+    const pv = await preview(anchorOp) // lock columns are not part of the live {id, version} fingerprint
+    await expect(applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).rejects.toThrow(/locked/i)
+    expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-now' }) // nothing applied (all-or-nothing)
+    expect(await burnCount()).toBe(0)
+    // unlock ⇒ the SAME token applies (the refusal wrote nothing).
+    await q('UPDATE meta_records SET locked = false, locked_by = NULL WHERE id = $1 AND sheet_id = $2', [R_REV, SHEET])
+    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+  })
+
+  test('FENCE-PARK (constructed race): a raw client holding the canonical fence parks the apply until release', async () => {
+    const { anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    expect(pool).toBeTruthy()
+    const holder = await pool!.connect()
+    try {
+      await holder.query('BEGIN')
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`meta:auto-number:sheet:${SHEET}`])
+      // Launch the apply concurrently — it must PARK on the fence (not proceed, not fail).
+      const applying = applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+      // Sample pg_locks until the apply's advisory-lock wait is visible (bounded loop, no sleeps beyond polling).
+      let sawWaiter = false
+      for (let i = 0; i < 100; i++) {
+        const waiters = await holder.query(
+          `SELECT count(*)::int AS c FROM pg_locks WHERE locktype = 'advisory' AND NOT granted`,
+        )
+        if (Number((waiters.rows[0] as { c: number }).c) > 0) { sawWaiter = true; break }
+        await new Promise((r) => setTimeout(r, 50))
+      }
+      expect(sawWaiter).toBe(true) // the apply is genuinely parked behind the fence
+      await holder.query('COMMIT') // release ⇒ the apply proceeds to completion
+      const out = await applying
+      expect(out.ok).toBe(true)
+    } finally {
+      holder.release()
+    }
+  })
+
+  // ── P1-1 MODE-BIND: a revert-preview token can NEVER drive a reset ───────────────────────────────────────
+  test('MODE-BIND (P1-1): a token minted at revert-preview performs ZERO deletes even with a live reset-delete candidate — the mode rides in the token, the apply has no mode input', async () => {
+    const { R_NEW, anchorOp } = await seedWorld() // R_NEW = created-after-anchor ⇒ the reset-delete candidate
+    const pv = await preview(anchorOp, 'revert')
+    // The pre-fix attack: same unburned token + `mode:'reset'` at the apply call ⇒ R_NEW destroyed. The
+    // input no longer HAS a mode — the only thing a caller could vary is gone. The behavioral pin:
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out.ok).toBe(true)
+    if (!out.ok) return
+    expect(out.mode).toBe('revert') // the TOKEN's mode
+    expect(out.applied.deletes).toBe(0)
+    expect(await liveRow(R_NEW)).toBeDefined() // the reset-delete candidate SURVIVES a revert-token apply
+  })
+
+  // ── P1-2 IN-FENCE AUTHORIZATION ─────────────────────────────────────────────────────────────────────────
+  test('AUTH-INFENCE (P1-2): permission revoked between preview and execute ⇒ forbidden, ZERO writes incl. the burn; re-granted ⇒ the SAME token applies', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp, 'revert')
+    const before = await liveRow(R_REV)
+    const denied = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: DENY_FULL_READ })
+    expect(denied).toEqual({ ok: false, reason: 'forbidden' })
+    expect(await liveRow(R_REV)).toEqual(before) // zero writes
+    expect(await burnCount()).toBe(0) // the burn rolled back with the refusal — the token is NOT half-dead
+    // re-grant ⇒ the very same token proceeds (fresh adjudication each execute, not a token property).
+    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+  })
+
+  test('AUTH-BASIS (P1-2): a validly-signed token whose authorizedScopeHash mismatches the recomputed basis ⇒ forbidden, zero writes (the token echo is never the authority)', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp, 'revert')
+    const before = await liveRow(R_REV)
+    // Same REAL scopeHash/liveSetHash/checkpoint — only the signed authorization basis is wrong.
+    const claims = {
+      sheetId: SHEET, anchorOperationId: anchorOp, anchorSeq: pv.anchorSeq, checkpointId: pv.checkpointId,
+      scopeHash: pv.scopeHash, actorId: ACTOR, mode: 'revert' as const, authorizedScopeHash: 'e'.repeat(64),
+    }
+    // liveSetHash must be the REAL one so this golden isolates the authorization axis: recompute it the
+    // way the preview does (same primitive over the live {id, version} set).
+    const liveRows = (await q('SELECT id, version FROM meta_records WHERE sheet_id = $1', [SHEET])).rows as Array<{ id: string; version: number }>
+    const wrongBasis = mintExactAnchorRecoveryIdentity({
+      ...claims,
+      liveSetHash: hashAnchorRecoveryScope(liveRows.map((r) => ({ recordId: String(r.id), exists: true, version: Number(r.version) }))),
+    })
+    expect(await applyExactAnchorRecovery(txn, { token: wrongBasis, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'forbidden' })
+    expect(await liveRow(R_REV)).toEqual(before)
+    expect(await burnCount()).toBe(0)
+    // POSITIVE control (anti-vacuous): the same mint with the CORRECT basis applies cleanly.
+    const rightBasis = mintExactAnchorRecoveryIdentity({
+      ...claims,
+      authorizedScopeHash: hashRecoveryAuthorizationScope({ sheetId: SHEET, actorId: ACTOR }),
+      liveSetHash: hashAnchorRecoveryScope(liveRows.map((r) => ({ recordId: String(r.id), exists: true, version: Number(r.version) }))),
+    })
+    expect((await applyExactAnchorRecovery(txn, { token: rightBasis, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+  })
+
+  // ── P1-2 SCHEMA-DRIFT WHOLE-REJECT ──────────────────────────────────────────────────────────────────────
+  test('DRIFT-REJECT (P1-2): driftCount > 0 ⇒ the WHOLE apply refuses schema-drift with zero writes incl. the burn — no partial-set apply through drift exclusion', async () => {
+    const { R_REV, R_NEW, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp, 'revert')
+    const beforeRev = await liveRow(R_REV)
+    // Drop the field AFTER preview: every at-anchor snapshot now carries a stale field id ⇒ plan.driftCount>0.
+    // (The scope/live hashes cover records, not schema — this reaches the PLAN, which is exactly the point.)
+    await q('DELETE FROM meta_fields WHERE id = $1 AND sheet_id = $2', [F_STR, SHEET])
+    try {
+      expect(await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+        .toEqual({ ok: false, reason: 'schema-drift' })
+      expect(await liveRow(R_REV)).toEqual(beforeRev) // untouched
+      expect(await liveRow(R_NEW)).toBeDefined() // nothing deleted
+      expect(await burnCount()).toBe(0) // burn rolled back — token dies by TTL, not half-burn
+    } finally {
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6) ON CONFLICT (id) DO NOTHING', [F_STR, SHEET, 'Note', 'string', '{}', 1])
+    }
+    // POSITIVE CONTROL (anti-vacuous, gate NIT-2): with the schema restored, the SAME token — unburned by
+    // the refusal above — now applies cleanly. Proves the refusal was attributable to the drift alone.
+    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+  })
+
+  // ── G2 (pre-wiring gate list): RESURRECT uses the AT-ANCHOR snapshot, never the trash row's vintage ─────
+  test('G2 RESURRECT-VS-TRASH: a record edited after the anchor then deleted (trash carries the TERMINAL vintage) resurrects to its AT-ANCHOR data', async () => {
+    const { anchorOp } = await seedWorld()
+    const R_G2 = `rec_g2vint_${TS}`
+    // at-anchor (< anchor seq): 'g2-at-anchor'. Post-anchor: edited to 'g2-terminal', then deleted — the
+    // TRASH row (and the delete revision's snapshot) both carry the TERMINAL vintage, the wrong source.
+    await revSeq(R_G2, 1, 'create', { [F_STR]: 'g2-at-anchor' }, '9000800')
+    await revSeq(R_G2, 2, 'update', { [F_STR]: 'g2-terminal' }, '9001900')
+    await revSeq(R_G2, 2, 'delete', { [F_STR]: 'g2-terminal' }, '9002150')
+    await q(
+      'INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)',
+      [R_G2, SHEET, JSON.stringify({ [F_STR]: 'g2-terminal' }), 2],
+    )
+    const pv = await preview(anchorOp, 'revert')
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out.ok).toBe(true)
+    // Resurrected from the REVISION CHAIN's at-anchor state — the trash row's terminal vintage is never read.
+    expect((await liveRow(R_G2))?.data).toEqual({ [F_STR]: 'g2-at-anchor' })
+    expect((await liveRow(R_G2))?.version).toBe(1) // new generation
+  })
+
+  // ── G3 (pre-wiring gate list): DOUBLE-TOKEN constructed race ─────────────────────────────────────────────
+  test('G3 DOUBLE-TOKEN (constructed race): two previews, two concurrent applies — exactly ONE succeeds; the loser refuses preview-drift; exactly one burn', async () => {
+    const { anchorOp } = await seedWorld()
+    const pv1 = await preview(anchorOp, 'revert')
+    await new Promise((r) => setTimeout(r, 1100)) // distinct JWT iat second ⇒ distinct token ⇒ distinct burn PK
+    const pv2 = await preview(anchorOp, 'revert')
+    expect(pv2.token).not.toBe(pv1.token)
+
+    // Both applies race on the canonical fence (each in its own real transaction/connection). The fence
+    // serializes them: the winner commits its reverts/resurrects (bumping live versions); the loser's
+    // in-fence live-set re-hash then diverges from ITS token's liveSetHash ⇒ preview-drift, full rollback.
+    const [r1, r2] = await Promise.all([
+      applyExactAnchorRecovery(txn, { token: pv1.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }),
+      applyExactAnchorRecovery(txn, { token: pv2.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }),
+    ])
+    const oks = [r1, r2].filter((r) => r.ok)
+    const refusals = [r1, r2].filter((r) => !r.ok) as Array<{ ok: false; reason: string }>
+    expect(oks.length).toBe(1) // exactly one winner
+    expect(refusals.length).toBe(1)
+    expect(refusals[0].reason).toBe('preview-drift') // the loser saw the winner's committed world
+    expect(await burnCount()).toBe(1) // the loser's burn rolled back with its refusal
+  })
+
+  // ── G1 (pre-wiring gate list): burn-retention sweep ─────────────────────────────────────────────────────
+  test('G1 BURN-RETENTION: the sweep prunes only burns older than the keep window, and the floor clamp protects any possibly-live token', async () => {
+    const { anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp, 'revert')
+    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+    expect(await burnCount()).toBe(1) // the fresh burn from the successful apply
+
+    // A synthetic OLD burn (2 hours ago) — prunable at the default 60m keep.
+    await q(
+      `INSERT INTO meta_recovery_token_burns (token_sha256, sheet_id, actor_id, burned_at) VALUES ($1,$2,$3, now() - interval '120 minutes')`,
+      [`deadold${TS}`.padEnd(64, '0'), SHEET, ACTOR],
+    )
+    // A synthetic 20-minute-old burn: older than a live token's 10m TTL but INSIDE an aggressive 1-minute
+    // keep request — the 15m FLOOR clamp must protect... no: 20m > 15m floor ⇒ prunable under floor. Use a
+    // 12-minute-old burn instead: younger than the 15m floor ⇒ MUST survive even a keepMinutes=1 request
+    // (pruning it could resurrect a replayed token whose JWT is still within clock-skew of its exp).
+    await q(
+      `INSERT INTO meta_recovery_token_burns (token_sha256, sheet_id, actor_id, burned_at) VALUES ($1,$2,$3, now() - interval '12 minutes')`,
+      [`deadmid${TS}`.padEnd(64, '1'), SHEET, ACTOR],
+    )
+
+    const pruned = await pruneExpiredRecoveryTokenBurns(q as unknown as QueryFn, 1) // aggressive request
+    expect(pruned).toBe(1) // ONLY the 2h-old row — the 12m row is inside the 15m floor, the fresh row is new
+    const remaining = (await q('SELECT token_sha256 FROM meta_recovery_token_burns WHERE sheet_id = $1', [SHEET])).rows as Array<{ token_sha256: string }>
+    const shas = new Set(remaining.map((r) => r.token_sha256))
+    expect(shas.has(`deadold${TS}`.padEnd(64, '0'))).toBe(false) // pruned
+    expect(shas.has(`deadmid${TS}`.padEnd(64, '1'))).toBe(true) // floor-protected
+    expect(remaining.length).toBe(2) // 12m row + the real fresh burn
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -440,8 +440,19 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
       'INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)',
       [R_G2, SHEET, JSON.stringify({ [F_STR]: 'g2-older-vintage' }), 1],
     )
+    // SHEET-SCOPING PROBE (gate F6): a trash row with the SAME record_id but a DIFFERENT sheet must SURVIVE
+    // — the cleanup is scoped by (record_id, sheet_id), and dropping the sheet_id predicate would reach
+    // across sheets. (meta_records_trash has no FK to meta_sheets, so a foreign-sheet row is constructible.)
+    const OTHER_SHEET = `${SHEET}_other`
+    await q(
+      'INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)',
+      [R_G2, OTHER_SHEET, JSON.stringify({ [F_STR]: 'other-sheet-vintage' }), 1],
+    )
+    const foreignTrash = async () => Number(((await q('SELECT count(*)::int c FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2', [R_G2, OTHER_SHEET])).rows[0] as { c: number }).c)
+    expect(await foreignTrash()).toBe(1)
+
     const trashBefore = await trashCount(R_G2)
-    expect(trashBefore).toBe(2) // precondition: TWO vintages in the recycle bin
+    expect(trashBefore).toBe(2) // precondition: TWO vintages in the recycle bin (this sheet)
     const pv = await preview(anchorOp, 'revert')
     const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
     expect(out.ok).toBe(true)
@@ -451,7 +462,11 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     // OWNER P1 (2026-07-17): live/trash MUTUAL EXCLUSION — the resurrect must have removed the trash row.
     // Without the trash cleanup the record is live AND still in the recycle bin (future restore 23505,
     // mis-pinned tombstone/retention). Mutation: drop the `DELETE FROM meta_records_trash` ⇒ this reds.
+    // BOTH vintages go (mutating to restoreRecord's single-PK semantics reds this — gate-verified).
     expect(await trashCount(R_G2)).toBe(0)
+    // ...but the SAME record_id on ANOTHER sheet is untouched — dropping the `sheet_id` predicate reds this.
+    expect(await foreignTrash()).toBe(1)
+    await q('DELETE FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2', [R_G2, OTHER_SHEET])
   })
 
   test('G2c RESURRECT-LINK-REBUILD: the at-anchor snapshot rebuilds WRITABLE outbound meta_links, is NOT-EXISTS idempotent, and skips the mirror side', async () => {
@@ -480,16 +495,16 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     expect(links.length).toBe(1)
     expect(links[0].field_id).toBe(F_LINK)
 
-    // NOT-EXISTS idempotence: re-running the same rebuild statement must not duplicate the edge. (ON CONFLICT
-    // DO NOTHING could never have caught this — meta_links has no unique on the edge triple, only on `id`.)
-    await q(
-      `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
-       SELECT $1, $2, $3, $4 WHERE NOT EXISTS (
-         SELECT 1 FROM meta_links ml WHERE ml.field_id = $2 AND ml.record_id = $3 AND ml.foreign_record_id = $4)`,
-      [`lnk_dup_${TS}`, F_LINK, R_SRC, R_TGT],
-    )
-    const after = (await q('SELECT count(*)::int c FROM meta_links WHERE record_id = $1 AND field_id = $2 AND foreign_record_id = $3', [R_SRC, F_LINK, R_TGT])).rows[0] as { c: number }
-    expect(Number(after.c)).toBe(1) // still exactly one — the guard held
+    // HONEST SCOPE (gate F5, 2026-07-17): there is deliberately NO assertion here for the rebuild's
+    // `NOT EXISTS` idempotence. An earlier draft re-executed a hand-written copy of the INSERT in this test
+    // body and asserted the count stayed 1 — that proves a Postgres property, not the production path, and
+    // NO production mutation could red it (a tautology, the exact fake-green class this suite exists to
+    // reject). The guard is genuinely UNREACHABLE end-to-end today: `meta_links_record_id_fkey` is
+    // ON DELETE CASCADE, so a deleted record has zero outbound rows and a resurrect always starts from
+    // empty — a duplicate cannot be constructed without first breaking that FK. It is therefore
+    // defense-in-depth verified by code reading (meta_links has no unique on the edge triple — only
+    // `meta_links_pkey` on `id` — so the previous `ON CONFLICT DO NOTHING` could never fire), and it is
+    // NOT claimed to be covered by a golden.
   })
 
   test('G2b RESURRECT-TRASH-ROLLBACK: an injected failure AFTER the resurrect rolls the live row, its revision AND the trash deletion back together (all-or-nothing)', async () => {

--- a/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
@@ -64,6 +64,11 @@ function listRuntimeTsFiles(): string[] {
  *   SAFE       — writes only non-user-content columns; a rich-`longText` value can never appear.
  */
 const ALLOWLIST: Record<string, { disposition: 'CHOKEPOINT' | 'SAFE'; reason: string }> = {
+  'multitable/exact-anchor-recovery-execute.ts': {
+    disposition: 'SAFE',
+    reason:
+      'L8 destructive apply writes ONLY previously-persisted at-anchor snapshots (revision-chain / checkpoint-baseline data, validated at their ORIGINAL write through the chokepoints above); no new user payload enters this module',
+  },
   'multitable/records.ts': {
     disposition: 'CHOKEPOINT',
     reason: 'plugin-SDK createRecord/patchRecord → normalizeFieldValue routes longText through validateLongTextValue',


### PR DESCRIPTION
## W0-1 v3.7 Lane L8 — the exact-anchor destructive apply (DRAFT, held, unwired, flags OFF)

**Stacked-PR notice:** base = `claude/w0-l7-execute-plan-20260717` (**#4445**, L7), which stacks on **#4417** (L6-b; seam held `false` until the Revert/Reset wiring PR). Top of the held W0 stack. **Not wired to any route** — the legacy Revert/Reset switch onto this module + the seam flip are the owner's single future PR. Nothing reaches this module today.

### One transaction, all-or-nothing
`applyExactAnchorRecovery(transaction, {token, sheetId, actorId, evaluateFullReadAccess})` — fence-first → burn → in-fence authorization → in-fence checkpoint re-resolution → dual-hash drift → F4 baseline composition → plan → schema-drift whole-reject → apply → seal, **COMMIT once**; any failure ⇒ **full rollback with zero writes, including the burn**.

### P1 token contract (owner second review 2026-07-17)
- **P1-1 mode is token-bound:** the apply has **no `mode` input** — the destructive `reset` branch and the success echo key on `verified.claims.mode` only. A revert-preview token can never drive a reset (structural, not a check).
- **P1-2 kernel adjudication:** a REQUIRED `evaluateFullReadAccess` dependency, re-evaluated FRESH in-fence (revocation between preview and execute ⇒ `forbidden`, burn rolls back — token never half-dead); the token's `authorizedScopeHash` must equal the recomputed v1 basis; `driftCount > 0` ⇒ `schema-drift` **whole-reject, zero writes**.

### The drift contract, honestly delivered
`scopeHash` binds the **immutable** at-anchor reconstruction; the identity also binds **`liveSetHash`** (HMAC over live `{id, version}` at preview), and the apply re-fingerprints the live set **in-fence** ⇒ `preview-drift` (409-class) on any concurrent write. F4: preview and apply hash the SAME baseline-composed set. Every write revision-emitted (`source:'restore'`) + ledger-tagged; the apply **seals its own endpoint** (a recovery is a future exact anchor); rank-8 lock-guarded.

### Owner P1 (2026-07-17) — resurrect trash-lifecycle
The resurrect branch now mirrors `restoreRecord`'s trash discipline **inside the same all-or-nothing txn**: lock the trash vintage `FOR UPDATE` → rebuild WRITABLE outbound `meta_links` from the at-anchor snapshot (mirror side skipped) → **DELETE the `meta_records_trash` row** ⇒ live/trash mutual exclusion, and the `delete_revision_id` that mis-pinned tombstone/retention is gone. (Inbound-edge replay from the trash row's terminal vintage is deliberately not done — this apply reconstructs the AT-ANCHOR state, a different vintage; a route/future-mode concern.)

### Pre-wiring gate items (all mutation-proven)
F4 preview/apply hash symmetry · G1 burn-retention sweep (15m floor = token TTL + skew) · G2 resurrect-vs-trash vintage **+ live/trash mutual exclusion** · **G2b resurrect-trash-rollback** (injected failure rolls the live row + revision + trash deletion back together) · G3 double-token constructed race (one winner, loser preview-drift, one burn) · NIT-2 DRIFT-REJECT positive control.

### Verify
Apply suite **20/20**; three exact-anchor real-DB suites **45/45**; identity/checkpoint unit + checkpoint/strict-seq real-DB green; tsc clean; fresh migrate clean incl. the `meta_recovery_token_burns` migration. Existing goldens (LIVE-DRIFT / INJECTED-FAILURE / FENCE-PARK[`pg_locks`-proven] / REPLAY / CHECKPOINT-GONE·CHANGED / BASELINE / LOCKED / MODE-BIND / AUTH-INFENCE / AUTH-BASIS / DRIFT-REJECT) all load-bearing; each named mutation reds exactly its target golden (incl. the new one: drop the trash DELETE ⇒ G2 reds at `trashCount==0`). Structural guards (OD-6 / rank-8 / rich-longtext sink) green. Two-point CI wiring.

Independent adversarial gates ran CLEAR on the token-contract stack and are re-running for the trash-lifecycle fix at the current head. **Merges + the flip stay owner-held.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

