### PR TITLE
W0 L5-wire — trust-checkpoint activation route (production caller for activateCheckpoint)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -454,6 +454,7 @@ jobs:
             tests/integration/multitable-history-contiguity-realdb.test.ts \
             tests/integration/multitable-history-contiguity-strict-seq-realdb.test.ts \
             tests/integration/multitable-history-trust-checkpoint-realdb.test.ts \
+            tests/integration/multitable-l5wire-checkpoint-activation-realdb.test.ts \
             tests/integration/multitable-d1c-form-submit-revision-realdb.test.ts \
             tests/integration/multitable-d1c-plugin-revision-realdb.test.ts \
             tests/integration/multitable-d1c-automation-revision-realdb.test.ts \

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -240,6 +240,8 @@ import {
   setRecoveryWriterState,
   SheetWriterBlockedError,
 } from '../multitable/canonical-sheet-fence'
+import { activateCheckpoint, CheckpointUnattributableTrashError } from '../multitable/history-trust-checkpoint'
+import type { QueryFn as TrustCheckpointQueryFn } from '../multitable/permission-service'
 import { normalizeAutoNumberProperty } from '../multitable/auto-number-property'
 import {
   createYjsInvalidationPostCommitHook,
@@ -10204,6 +10206,54 @@ export function univerMetaRouter(): Router {
   // resolution). revert-preview stays UNGATED (read-only, no writes to protect, and the FE preview UI still
   // needs to render even while the button that would call execute is hidden).
   const SHEET_REVERT_ENABLED = () => String(process.env.MULTITABLE_ENABLE_SHEET_REVERT ?? '').trim().toLowerCase() === 'true'
+
+  // ── W0-1 L5-wire: trust-checkpoint ACTIVATION (the production caller for activateCheckpoint) ────────────
+  // Owner review 2026-07-17: activateCheckpoint had NO production caller — without an activated checkpoint,
+  // exact-anchor recovery (L6-b) can only ever refuse `no-covering-checkpoint`. This route is the canonical
+  // L5-wire slice (order: L5-wire → L6-b → L7 → L8). It is ADDITIVE-ONLY trust provisioning: one fenced
+  // transaction that snapshots baselines and activates a checkpoint (design lock §3 cutover) — it performs no
+  // destructive write and enables nothing by itself (strict/Revert/Reset stay behind their own flags).
+  // Default-OFF flag + sheet-admin (D2) floor, mirroring the recovery routes' gating discipline exactly.
+  const TRUST_CHECKPOINT_ACTIVATION_ENABLED = () =>
+    String(process.env.MULTITABLE_ENABLE_TRUST_CHECKPOINT_ACTIVATION ?? '').trim().toLowerCase() === 'true'
+
+  router.post('/sheets/:sheetId/trust-checkpoint-activate', async (req: Request, res: Response) => {
+    if (!TRUST_CHECKPOINT_ACTIVATION_ENABLED()) {
+      return res.status(403).json({ ok: false, error: { code: 'TRUST_CHECKPOINT_ACTIVATION_DISABLED', message: 'Trust-checkpoint activation is disabled (MULTITABLE_ENABLE_TRUST_CHECKPOINT_ACTIVATION is off).' } })
+    }
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    if (!sheetId) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId required' } })
+    try {
+      const pool = poolManager.get()
+      const { access, capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+      // D2 floor: provisioning the trust anchor for destructive recovery is a sheet-admin capability, the
+      // same floor as revert/reset themselves — a plain writer must not move the sheet's trust floor.
+      if (!capabilities.canManageSheetAccess) return sendForbidden(res)
+      const exists = await pool.query('SELECT 1 FROM meta_sheets WHERE id = $1', [sheetId])
+      if (exists.rows.length === 0) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+
+      // Design lock §3: ONE fenced transaction — canonical fence first (serializes against every fenced
+      // writer AND any in-flight recovery; observes a durable block), then the cutover. Any failure —
+      // including the fail-closed unattributable-trash abort — rolls the whole activation back.
+      const result = await pool.transaction(async ({ query }) => {
+        await fenceWriterEntry(query as unknown as TrustCheckpointQueryFn, sheetId)
+        return activateCheckpoint(query as unknown as TrustCheckpointQueryFn, { sheetId })
+      })
+      return res.json({ ok: true, data: { checkpointId: result.checkpointId, trustedSinceSeq: result.trustedSinceSeq, baselineCount: result.baselineCount } })
+    } catch (err) {
+      if (err instanceof CheckpointUnattributableTrashError) {
+        // Fail-closed abort (owner P1, L5): a trashed-only record whose vintage cannot be causally attributed
+        // makes the baseline untrustworthy. Values-free envelope (no record ids, no counts — D-1c rule 1).
+        return res.status(409).json({ ok: false, error: { code: 'HISTORY_INCOMPLETE', message: 'Record history for this sheet is incomplete or inconsistent with its live data; the trust checkpoint was not activated and nothing was written.' } })
+      }
+      if (err instanceof SheetWriterBlockedError) {
+        return res.status(409).json({ ok: false, error: { code: 'RECOVERY_IN_PROGRESS', message: 'A recovery operation is in progress on this sheet; try again once it completes.' } })
+      }
+      console.error('[univer-meta] trust-checkpoint-activate failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to activate trust checkpoint' } })
+    }
+  })
 
   router.post('/sheets/:sheetId/revert-preview', async (req: Request, res: Response) => {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -10221,6 +10221,14 @@ export function univerMetaRouter(): Router {
     if (!TRUST_CHECKPOINT_ACTIVATION_ENABLED()) {
       return res.status(403).json({ ok: false, error: { code: 'TRUST_CHECKPOINT_ACTIVATION_DISABLED', message: 'Trust-checkpoint activation is disabled (MULTITABLE_ENABLE_TRUST_CHECKPOINT_ACTIVATION is off).' } })
     }
+    // Gate P2 (independent gate, 2026-07-17): a checkpoint's trust DEPENDS on the canonical fence — the §3
+    // cutover allocates `trusted_since_seq` and snapshots baselines, and without the L4 fence a concurrent
+    // write can interleave between the two (torn baseline: a record's baseline row disagrees with the seq
+    // boundary), minting a DURABLE untrustworthy artifact that persists into the fence-on era. Fail closed:
+    // activation refuses unless the fence flag is on. Env-only check — before any DB read (no oracle).
+    if (!isWriterFenceEnabled()) {
+      return res.status(409).json({ ok: false, error: { code: 'TRUST_CHECKPOINT_FENCE_REQUIRED', message: 'Trust-checkpoint activation requires the canonical writer fence (MULTITABLE_ENABLE_WRITER_FENCE) to be enabled.' } })
+    }
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
     if (!sheetId) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId required' } })
     try {
@@ -10249,6 +10257,12 @@ export function univerMetaRouter(): Router {
       }
       if (err instanceof SheetWriterBlockedError) {
         return res.status(409).json({ ok: false, error: { code: 'RECOVERY_IN_PROGRESS', message: 'A recovery operation is in progress on this sheet; try again once it completes.' } })
+      }
+      // Belt-and-braces (gate P3): a RACING second activation trips the one-active partial-unique at the
+      // building→active flip — surface it as a conflict, not a 500. (With the fence required above, two
+      // activations serialize on the fence and this is near-unreachable; kept for the raw-SQL edge.)
+      if (typeof err === 'object' && err !== null && (err as { code?: unknown }).code === '23505') {
+        return res.status(409).json({ ok: false, error: { code: 'ACTIVATION_CONFLICT', message: 'Another trust-checkpoint activation for this sheet completed first; retry to supersede it.' } })
       }
       console.error('[univer-meta] trust-checkpoint-activate failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to activate trust checkpoint' } })

--- a/packages/core-backend/tests/integration/multitable-l5wire-checkpoint-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-l5wire-checkpoint-activation-realdb.test.ts
@@ -171,6 +171,55 @@ describeIfDatabase('W0-1 L5-wire — trust-checkpoint activation route (real DB)
     expect(res.status).toBe(404)
   })
 
+  test('CONCURRENT-ACTIVATION (two real connections, persistent CI golden — owner P2): route-level race serializes on the fence; module-level race is caught by the one-active partial-unique', async () => {
+    enableBoth()
+    // (a) ROUTE level: two concurrent requests. The fence serializes the two cutover transactions, so the
+    // outcome is deterministic in SHAPE: every success activated exactly once, later success supersedes,
+    // and the DB ends with EXACTLY ONE active row. (A loser that interleaves at the flip maps to 409
+    // ACTIVATION_CONFLICT — accepted; never a 500, never two actives.)
+    const [r1, r2] = await Promise.all([activateReq().then((r) => r), activateReq().then((r) => r)])
+    const statuses = [r1.status, r2.status].sort()
+    expect([[200, 200], [200, 409]]).toContainEqual(statuses)
+    const rows = await checkpointRows()
+    expect(rows.filter((r) => r.state === 'active').length).toBe(1)
+    expect(rows.length).toBe([r1, r2].filter((r) => r.status === 200).length)
+
+    // (b) MODULE level (the DB backstop itself): two raw clients race activateCheckpoint WITHOUT the fence
+    // (the exact bypass the route's M1 guard forbids) — the one-active partial-unique must let exactly one
+    // commit; the loser gets a unique violation and rolls back fully.
+    expect(pool).toBeTruthy()
+    const [c1, c2] = await Promise.all([pool!.connect(), pool!.connect()])
+    try {
+      await q('DELETE FROM meta_history_baselines WHERE sheet_id = $1', [SHEET])
+      await q('DELETE FROM meta_history_trust_checkpoints WHERE sheet_id = $1', [SHEET])
+      const { activateCheckpoint } = await import('../../src/multitable/history-trust-checkpoint')
+      const raceOne = async (client: (typeof c1)) => {
+        await client.query('BEGIN')
+        try {
+          const res = await activateCheckpoint(((sql: string, params?: unknown[]) => client.query(sql, params)) as never, { sheetId: SHEET })
+          await client.query('COMMIT')
+          return { ok: true as const, id: res.checkpointId }
+        } catch (e) {
+          await client.query('ROLLBACK').catch(() => undefined)
+          return { ok: false as const, code: (e as { code?: string }).code }
+        }
+      }
+      const [a, b] = await Promise.all([raceOne(c1), raceOne(c2)])
+      const winners = [a, b].filter((r) => r.ok)
+      const losers = [a, b].filter((r) => !r.ok)
+      // Either they serialized on row locks (both commit, second supersedes) or the partial-unique caught
+      // the true flip race (loser 23505) — in EVERY outcome: exactly one active, loser left zero rows.
+      expect(winners.length).toBeGreaterThanOrEqual(1)
+      for (const l of losers) expect(l.code).toBe('23505')
+      const finalRows = await checkpointRows()
+      expect(finalRows.filter((r) => r.state === 'active').length).toBe(1)
+      expect(finalRows.length).toBe(winners.length)
+    } finally {
+      c1.release()
+      c2.release()
+    }
+  })
+
   test('FENCE-PARK (constructed race): a raw client holding the canonical fence parks the activation until release', async () => {
     enableBoth()
     expect(pool).toBeTruthy()

--- a/packages/core-backend/tests/integration/multitable-l5wire-checkpoint-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-l5wire-checkpoint-activation-realdb.test.ts
@@ -32,6 +32,9 @@ import { __resetRecoveryWriterStateColumnProbe } from '../../src/multitable/cano
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const FLAG = 'MULTITABLE_ENABLE_TRUST_CHECKPOINT_ACTIVATION'
+const FENCE_FLAG = 'MULTITABLE_ENABLE_WRITER_FENCE'
+// Gate M1: activation requires the canonical fence — the standard posture for these goldens is BOTH ON.
+const enableBoth = () => { process.env[FLAG] = 'true'; process.env[FENCE_FLAG] = 'true' }
 const TS = Date.now()
 const BASE = `base_l5w_${TS}`
 const SHEET = `sheet_l5w_${TS}`
@@ -70,6 +73,7 @@ describeIfDatabase('W0-1 L5-wire — trust-checkpoint activation route (real DB)
   })
   afterEach(async () => {
     delete process.env[FLAG]
+    delete process.env[FENCE_FLAG]
     __resetRecoveryWriterStateColumnProbe()
     actor = { id: ADMIN, perms: ['multitable:read', 'multitable:write', 'multitable:share'] }
     for (const t of ['meta_history_baselines', 'meta_history_trust_checkpoints', 'meta_records_trash', 'meta_record_revisions', 'meta_records'])
@@ -95,8 +99,33 @@ describeIfDatabase('W0-1 L5-wire — trust-checkpoint activation route (real DB)
     expect(await checkpointRows()).toEqual([])
   })
 
-  test('NON-ADMIN: a plain writer is refused (D2 floor), zero rows', async () => {
+  test('FENCE-REQUIRED (gate M1): activation flag ON but the L4 fence flag OFF ⇒ 409 TRUST_CHECKPOINT_FENCE_REQUIRED, zero rows', async () => {
+    // A checkpoint minted without the canonical fence is a DURABLE untrustworthy artifact (a concurrent
+    // write can interleave between the trusted_since_seq allocation and the baseline snapshot — torn
+    // baseline). The route must fail closed rather than provision it.
     process.env[FLAG] = 'true'
+    delete process.env[FENCE_FLAG]
+    const res = await activateReq()
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('TRUST_CHECKPOINT_FENCE_REQUIRED')
+    expect(await checkpointRows()).toEqual([])
+  })
+
+  test('RECOVERY_IN_PROGRESS (gate M2): a durable writer block on the sheet refuses the activation with zero rows', async () => {
+    enableBoth()
+    await q(`UPDATE meta_sheets SET recovery_writer_state = 'applying' WHERE id = $1`, [SHEET])
+    try {
+      const res = await activateReq()
+      expect(res.status).toBe(409)
+      expect(res.body?.error?.code).toBe('RECOVERY_IN_PROGRESS')
+      expect(await checkpointRows()).toEqual([])
+    } finally {
+      await q('UPDATE meta_sheets SET recovery_writer_state = NULL WHERE id = $1', [SHEET])
+    }
+  })
+
+  test('NON-ADMIN: a plain writer is refused (D2 floor), zero rows', async () => {
+    enableBoth()
     actor = { id: WRITER, perms: ['multitable:read', 'multitable:write'] }
     const res = await activateReq()
     expect(res.status).toBe(403)
@@ -104,7 +133,7 @@ describeIfDatabase('W0-1 L5-wire — trust-checkpoint activation route (real DB)
   })
 
   test('HAPPY: admin + flag ON activates; baselines snapshot live rows; a second activation supersedes (exactly one active)', async () => {
-    process.env[FLAG] = 'true'
+    enableBoth()
     await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [`rec_l5w_a_${TS}`, SHEET, JSON.stringify({ [F_STR]: 'a' }), ADMIN])
     await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [`rec_l5w_b_${TS}`, SHEET, JSON.stringify({ [F_STR]: 'b' }), ADMIN])
 
@@ -125,7 +154,7 @@ describeIfDatabase('W0-1 L5-wire — trust-checkpoint activation route (real DB)
   })
 
   test('UNATTRIBUTABLE trash: 409 HISTORY_INCOMPLETE (values-free) and the WHOLE activation rolls back', async () => {
-    process.env[FLAG] = 'true'
+    enableBoth()
     // A trashed-only record whose vintage cannot be causally attributed (NULL delete_revision_id, no live row).
     await q('INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,1)', [`rec_l5w_ghost_${TS}`, SHEET, '{}'])
     const res = await activateReq()
@@ -137,13 +166,13 @@ describeIfDatabase('W0-1 L5-wire — trust-checkpoint activation route (real DB)
   })
 
   test('NOT-FOUND: unknown sheet ⇒ 404', async () => {
-    process.env[FLAG] = 'true'
+    enableBoth()
     const res = await activateReq(`sheet_l5w_missing_${TS}`)
     expect(res.status).toBe(404)
   })
 
   test('FENCE-PARK (constructed race): a raw client holding the canonical fence parks the activation until release', async () => {
-    process.env[FLAG] = 'true'
+    enableBoth()
     expect(pool).toBeTruthy()
     const holder = await pool!.connect()
     try {

--- a/packages/core-backend/tests/integration/multitable-l5wire-checkpoint-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-l5wire-checkpoint-activation-realdb.test.ts
@@ -1,0 +1,172 @@
+/**
+ * W0-1 L5-wire — trust-checkpoint ACTIVATION route (real DB): the production caller for activateCheckpoint.
+ *
+ * Owner review 2026-07-17: `activateCheckpoint` had NO production caller — without an activated checkpoint,
+ * exact-anchor recovery (L6-b) can only refuse `no-covering-checkpoint`. This route is that caller:
+ * `POST /sheets/:sheetId/trust-checkpoint-activate`, default-OFF `MULTITABLE_ENABLE_TRUST_CHECKPOINT_ACTIVATION`,
+ * sheet-admin (D2) floor, ONE fenced transaction (canonical fence first → design-lock §3 cutover).
+ *
+ * Goldens (each mutation-proven in the PR matrix):
+ *   FLAG-OFF          route refuses 403 TRUST_CHECKPOINT_ACTIVATION_DISABLED, zero checkpoint rows.
+ *   NON-ADMIN         a plain writer (no canManageSheetAccess) ⇒ 403, zero rows (D2 floor).
+ *   HAPPY             admin + flag ON ⇒ 200 {checkpointId, trustedSinceSeq, baselineCount}; row is `active`;
+ *                     baselines snapshot live rows; a SECOND activation supersedes the first (exactly one
+ *                     active per sheet).
+ *   UNATTRIBUTABLE    a trashed-only record with a NULL delete_revision_id ⇒ 409 HISTORY_INCOMPLETE
+ *                     (values-free) and the WHOLE activation rolls back (no checkpoint, no baselines).
+ *   FENCE-PARK        a raw client holding the canonical fence parks the activation until release
+ *                     (constructed race — proves the fence call is real, not decorative).
+ *   NOT-FOUND         unknown sheet ⇒ 404.
+ *
+ * P2-C hygiene: unique fixture ids; no `setval`; cleanup deletes only this suite's rows. Two-point wiring:
+ * plugin-tests.yml real-DB run list + vitest glob; fail-not-skip sentinel scoped to the allowlist step.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { pool } from '../../src/db/pg'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { __resetRecoveryWriterStateColumnProbe } from '../../src/multitable/canonical-sheet-fence'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const FLAG = 'MULTITABLE_ENABLE_TRUST_CHECKPOINT_ACTIVATION'
+const TS = Date.now()
+const BASE = `base_l5w_${TS}`
+const SHEET = `sheet_l5w_${TS}`
+const F_STR = `fld_l5w_note_${TS}`
+const ADMIN = `u_l5w_admin_${TS}` // base owner ⇒ canManageSheetAccess
+const WRITER = `u_l5w_writer_${TS}` // plain writer ⇒ NO canManageSheetAccess
+
+const q = (sql: string, params: unknown[] = []) => poolManager.get().query(sql, params)
+
+let app: Express
+let actor: { id: string; perms: string[] } = { id: ADMIN, perms: ['multitable:read', 'multitable:write', 'multitable:share'] }
+
+const activateReq = (sheetId: string = SHEET) => request(app).post(`/api/multitable/sheets/${sheetId}/trust-checkpoint-activate`).send({})
+const checkpointRows = async () =>
+  (await q(`SELECT id, state FROM meta_history_trust_checkpoints WHERE sheet_id = $1 ORDER BY created_at`, [SHEET])).rows as Array<{ id: string; state: string }>
+const baselineCountFor = async (checkpointId: string) =>
+  Number(((await q('SELECT count(*)::int c FROM meta_history_baselines WHERE checkpoint_id = $1', [checkpointId])).rows[0] as { c: number }).c)
+
+test('sentinel: the real-DB allowlist step must have DATABASE_URL (fail-not-skip, scoped to that step)', () => {
+  if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+    throw new Error('real-DB allowlist step is missing DATABASE_URL — the harness is broken, not legitimately skippable')
+  }
+  expect(true).toBe(true)
+})
+
+describeIfDatabase('W0-1 L5-wire — trust-checkpoint activation route (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: actor.id, roles: ['member'], perms: actor.perms }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    for (const u of [ADMIN, WRITER]) await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [u])
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [BASE, 'L5W Base', ADMIN])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'L5W'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_STR, SHEET, 'Note', 'string', '{}', 1])
+  })
+  afterEach(async () => {
+    delete process.env[FLAG]
+    __resetRecoveryWriterStateColumnProbe()
+    actor = { id: ADMIN, perms: ['multitable:read', 'multitable:write', 'multitable:share'] }
+    for (const t of ['meta_history_baselines', 'meta_history_trust_checkpoints', 'meta_records_trash', 'meta_record_revisions', 'meta_records'])
+      await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+  })
+  afterAll(async () => {
+    delete process.env[FLAG]
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    for (const u of [ADMIN, WRITER]) await q('DELETE FROM users WHERE id = $1', [u]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL is set (this suite must RUN, never skip-green)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('FLAG-OFF: refuses 403 TRUST_CHECKPOINT_ACTIVATION_DISABLED, zero checkpoint rows (default posture)', async () => {
+    delete process.env[FLAG]
+    const res = await activateReq()
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('TRUST_CHECKPOINT_ACTIVATION_DISABLED')
+    expect(await checkpointRows()).toEqual([])
+  })
+
+  test('NON-ADMIN: a plain writer is refused (D2 floor), zero rows', async () => {
+    process.env[FLAG] = 'true'
+    actor = { id: WRITER, perms: ['multitable:read', 'multitable:write'] }
+    const res = await activateReq()
+    expect(res.status).toBe(403)
+    expect(await checkpointRows()).toEqual([])
+  })
+
+  test('HAPPY: admin + flag ON activates; baselines snapshot live rows; a second activation supersedes (exactly one active)', async () => {
+    process.env[FLAG] = 'true'
+    await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [`rec_l5w_a_${TS}`, SHEET, JSON.stringify({ [F_STR]: 'a' }), ADMIN])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [`rec_l5w_b_${TS}`, SHEET, JSON.stringify({ [F_STR]: 'b' }), ADMIN])
+
+    const first = await activateReq()
+    expect(first.status).toBe(200)
+    expect(first.body?.data?.checkpointId).toBeTruthy()
+    expect(String(first.body?.data?.trustedSinceSeq)).toMatch(/^[0-9]+$/)
+    expect(first.body?.data?.baselineCount).toBe(2)
+    expect(await baselineCountFor(first.body.data.checkpointId)).toBe(2)
+
+    const second = await activateReq()
+    expect(second.status).toBe(200)
+    const rows = await checkpointRows()
+    expect(rows.length).toBe(2)
+    expect(rows.filter((r) => r.state === 'active').length).toBe(1) // exactly one active
+    expect(rows.find((r) => r.id === first.body.data.checkpointId)?.state).toBe('superseded')
+    expect(rows.find((r) => r.id === second.body.data.checkpointId)?.state).toBe('active')
+  })
+
+  test('UNATTRIBUTABLE trash: 409 HISTORY_INCOMPLETE (values-free) and the WHOLE activation rolls back', async () => {
+    process.env[FLAG] = 'true'
+    // A trashed-only record whose vintage cannot be causally attributed (NULL delete_revision_id, no live row).
+    await q('INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,1)', [`rec_l5w_ghost_${TS}`, SHEET, '{}'])
+    const res = await activateReq()
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('HISTORY_INCOMPLETE')
+    // values-free: no record id / count leaks in the envelope.
+    expect(JSON.stringify(res.body)).not.toContain(`rec_l5w_ghost_${TS}`)
+    expect(await checkpointRows()).toEqual([]) // full rollback — not even a `building` row
+  })
+
+  test('NOT-FOUND: unknown sheet ⇒ 404', async () => {
+    process.env[FLAG] = 'true'
+    const res = await activateReq(`sheet_l5w_missing_${TS}`)
+    expect(res.status).toBe(404)
+  })
+
+  test('FENCE-PARK (constructed race): a raw client holding the canonical fence parks the activation until release', async () => {
+    process.env[FLAG] = 'true'
+    expect(pool).toBeTruthy()
+    const holder = await pool!.connect()
+    try {
+      await holder.query('BEGIN')
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`meta:auto-number:sheet:${SHEET}`])
+      // NOTE: the route's fence is flag-gated by the L4 fence flag — turn it on for THIS test so the
+      // activation genuinely parks (with it off, fenceWriterEntry is a no-op by design).
+      process.env.MULTITABLE_ENABLE_WRITER_FENCE = 'true'
+      // supertest Tests are LAZY (nothing fires until then/await) — kick it off eagerly so it can park.
+      const inflight = activateReq().then((r) => r)
+      let sawWaiter = false
+      for (let i = 0; i < 100; i++) {
+        const waiters = await holder.query(`SELECT count(*)::int AS c FROM pg_locks WHERE locktype = 'advisory' AND NOT granted`)
+        if (Number((waiters.rows[0] as { c: number }).c) > 0) { sawWaiter = true; break }
+        await new Promise((r) => setTimeout(r, 50))
+      }
+      expect(sawWaiter).toBe(true) // genuinely parked behind the fence
+      await holder.query('COMMIT')
+      const res = await inflight
+      expect(res.status).toBe(200) // proceeds to a successful activation once the fence is released
+    } finally {
+      delete process.env.MULTITABLE_ENABLE_WRITER_FENCE
+      holder.release()
+    }
+  })
+})

--- a/scripts/ops/global-history-flag-manifest.mjs
+++ b/scripts/ops/global-history-flag-manifest.mjs
@@ -135,7 +135,11 @@ export const GLOBAL_HISTORY_FLAG_MANIFEST = Object.freeze([
     type: 'boolean',
     activationValue: 'true',
     caseInsensitive: true, // `.trim().toLowerCase() === 'true'`, same resolution family as SHEET_REVERT/PIT_RESET
-    dependsOn: [],
+    // Gate P2 (2026-07-17): a checkpoint minted without the canonical fence is a DURABLE untrustworthy
+    // artifact (torn baseline vs the allocated trusted_since_seq). The route ALSO fails closed at runtime
+    // (409 TRUST_CHECKPOINT_FENCE_REQUIRED when the fence flag is off) — this dep is the operator-facing
+    // declaration of the same invariant.
+    dependsOn: ['MULTITABLE_ENABLE_WRITER_FENCE'],
     conflictsWith: [],
     danger: 'medium',
     purpose:

--- a/scripts/ops/global-history-flag-manifest.mjs
+++ b/scripts/ops/global-history-flag-manifest.mjs
@@ -131,6 +131,18 @@ export const GLOBAL_HISTORY_FLAG_MANIFEST = Object.freeze([
     ],
   },
   {
+    key: 'MULTITABLE_ENABLE_TRUST_CHECKPOINT_ACTIVATION',
+    type: 'boolean',
+    activationValue: 'true',
+    caseInsensitive: true, // `.trim().toLowerCase() === 'true'`, same resolution family as SHEET_REVERT/PIT_RESET
+    dependsOn: [],
+    conflictsWith: [],
+    danger: 'medium',
+    purpose:
+      'W0-1 L5-wire (owner review 2026-07-17): the production caller for activateCheckpoint — POST /sheets/:sheetId/trust-checkpoint-activate provisions a trust checkpoint for one sheet in ONE fenced transaction (canonical fence first, then the design-lock §3 cutover: allocate trusted_since_seq, snapshot live + attributable-trash baselines, supersede the prior active checkpoint, activate). ADDITIVE-ONLY trust provisioning: no destructive write, and activating a checkpoint enables NOTHING by itself — strict mode and Revert/Reset stay behind their own default-OFF flags; a checkpoint is merely the (a)-half of the strict-enablement precondition. Fail-closed: an unattributable trashed-only record aborts the whole activation (409 HISTORY_INCOMPLETE, values-free). Sheet-admin (canManageSheetAccess, D2) floor — provisioning the trust floor for destructive recovery is an admin capability. danger=medium (not high): it writes only checkpoint/baseline rows, never live record data, but it moves the sheet\'s trust floor that later destructive recoveries anchor on, so it is not a plain ops convenience either.',
+    source: 'packages/core-backend/src/routes/univer-meta.ts#TRUST_CHECKPOINT_ACTIVATION_ENABLED,/trust-checkpoint-activate',
+  },
+  {
     key: 'MULTITABLE_ENABLE_SHEET_REVERT',
     type: 'boolean',
     activationValue: 'true',


### PR DESCRIPTION
## W0-1 L5-wire — trust-checkpoint activation route (owner review P2; canonical order L5-wire → L6-b → L7 → L8)

`activateCheckpoint` had **no production caller** — L6-b could only ever refuse `no-covering-checkpoint`. This is the missing runtime slice: `POST /sheets/:sheetId/trust-checkpoint-activate`.

- **Default-OFF** `MULTITABLE_ENABLE_TRUST_CHECKPOINT_ACTIVATION` (manifest-registered, danger:medium — additive-only trust provisioning; writes only checkpoint/baseline rows, never live data, but moves the trust floor recoveries anchor on). **D2 floor** (`canManageSheetAccess`).
- **One fenced transaction** (design lock §3): `fenceWriterEntry` first → cutover (allocate `trusted_since_seq` → baselines → supersede prior active → activate). Unattributable trash ⇒ **409 HISTORY_INCOMPLETE values-free + full rollback**; durable block ⇒ 409 RECOVERY_IN_PROGRESS.
- Activation **enables nothing by itself** — strict/Revert/Reset stay behind their own OFF flags.

### Verify
8 real-DB goldens; mutations each exactly-one-red: W1 flag gate ⇒ FLAG-OFF red · W2 D2 floor ⇒ NON-ADMIN red · W3 fence call ⇒ FENCE-PARK red (constructed race, `pg_locks`-proven parking). HAPPY proves baselines + supersede-to-exactly-one-active; UNATTRIBUTABLE proves the fail-closed abort rolls back everything. Manifest contract 37/37; regression 42/42; unit **5603/5603**; tsc clean; two-point CI wiring.

Independent gate runs against this head before it leaves Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
