### PR TITLE
docs(multitable): add durable recovery archive Phase D to Time Machine plan

### DIFF
--- a/docs/development/multitable-w0-1-v37-exact-anchor-trust-design-lock-20260715.md
+++ b/docs/development/multitable-w0-1-v37-exact-anchor-trust-design-lock-20260715.md
@@ -434,3 +434,128 @@ implementation slices only (as the §9 tail).
 **Take-over discipline (recorded so all integration sessions share it):** a ≥65-min branch silence triggers only a
 READ-ONLY independent review + an alert — it does **NOT** transfer PR ownership. Driving another session's PR branch
 requires an explicit handoff; absent that, open a **superseding branch that does not touch the original PR**.
+
+## 12. Owner-directed roadmap addition — durable recovery archive + sheet version restore (2026-07-17)
+
+**Status:** PLANNED / design-lock-required. The owner directed that post-retention recovery and bulk version restore
+be part of the Time Machine line. This section records the product boundary and dependency order; it does **not**
+ratify runtime implementation, change a retention policy, enable a flag, or expand the Phase-B merge authority in
+section 11.
+
+### 12.1 Product contract: two retention horizons
+
+The product must distinguish two independently configured horizons:
+
+1. **History retention** — hot `meta_record_revisions`, config revisions, operation endpoints, and tombstones used by
+   History Center and low-latency inspection.
+2. **Recovery retention** — immutable, verified recovery archives kept after hot history is pruned, used to restore a
+   sheet to an exact recovery point.
+
+A customer-facing **sheet version** is an exact, server-resolved recovery point rooted at an `anchorOperationId`; it
+is not a per-record version number and is not an authoritative free wall-clock timestamp. One selected recovery point
+therefore restores a coherent sheet state without requiring the customer to restore records one by one.
+
+Phase D is required before the product may promise recovery after history retention. It is also required before the
+current PIT-Reset/retention conflict may be reconsidered. Until Phase D is implemented and accepted, existing
+retention behavior and all fail-closed conflicts remain unchanged.
+
+### 12.2 Archive-before-prune invariant
+
+For every operation/checkpoint range covered by recovery retention:
+
+> hot history may be pruned only after the corresponding archive is durable, tenant/sheet-bound, complete, and
+> independently verified.
+
+The archive writer must use a state machine such as `building → verified → expired`; `building`, missing, corrupt,
+or unverifiable archives never authorize pruning. Archive expiration is a separate owner-configured recovery policy,
+not an implication of hot-history expiration. A failed archive write or verification leaves hot source rows intact.
+
+The archive is immutable after verification. Corrections create a new archive generation and supersede the old one;
+they never edit an already verified payload in place. Archive deletion after the recovery horizon must be explicit,
+auditable, and values-free in logs.
+
+### 12.3 Recovery archive content
+
+The v1 single-sheet archive manifest must bind at least:
+
+- format/schema version, tenant/base/sheet identity, `anchorOperationId`, exact bigint `anchorSeq`, checkpoint id,
+  creation time, and recovery-expiry time;
+- field definitions and order, sheet/view configuration, record existence/version/data, and `meta_links` edges;
+- field-value/link tombstones needed by field/record undelete, plus auto-number sequence state;
+- attachment object references and an explicit availability/pinning result (a database reference is not proof that
+  the underlying object still exists);
+- per-section row counts, content hashes, a root manifest hash, encryption/key metadata, and archive-generation id.
+
+Permission restoration remains a separate high-risk tier in v1: the archive may retain permission evidence for audit,
+but a data restore must not silently overwrite current authorization policy. Formula/lookup/rollup values are derived;
+the restore contract recovers their definitions/source inputs and recomputes them rather than treating stale derived
+bytes as authority.
+
+Storage may use object storage, an archive database, or another durable backend, but the interface and goldens must be
+backend-neutral. No archive URI, credential, tenant identifier, or recovered value may enter ordinary logs.
+
+### 12.4 Restore modes and forward-only semantics
+
+The same verified archive supports three product modes:
+
+1. restore the whole sheet;
+2. restore selected records;
+3. restore selected fields across the selected records.
+
+Every mode is preview-first and binds a signed plan to the archive generation, exact anchor, checkpoint, actor,
+permission-filtered scope, current live-set fingerprint, and conflict policy. Execute creates new `source='restore'`
+revisions and a sealed operation endpoint; it never rewrites or moves historical rows. The restore operation therefore
+becomes a future exact recovery anchor itself.
+
+Small single-sheet restores may use the L8 fenced all-or-nothing path. Work above the synchronous ceiling (initially
+the existing 5,000-record boundary unless post-W0 measurement changes it) uses an asynchronous operation with a frozen
+plan/hash, idempotent operation id, progress, retry/resume, conflict detection, and explicit partial-completion
+semantics. V1 makes no cross-sheet long-transaction atomicity promise.
+
+### 12.5 Phase-D slices and estimate
+
+Phase D starts only after Phase B (`L5-wire → L6-b → L7 → L8`) is frozen on `main`. Draft design work may start
+earlier, but no archive reader or restore executor may bypass those exact-anchor and atomic-apply authorities.
+
+| Slice | Deliverable | Estimate |
+|---|---|---:|
+| D1 | archive contract/design lock, manifest versioning, threat model, storage adapter boundary | 1–1.5 pw |
+| D2 | archive writer + archive-before-prune state machine and retention handoff | 1.5–2 pw |
+| D3 | scheduled/manual recovery-point creation, catalog, lifecycle, integrity verifier | 1–1.5 pw |
+| D4 | checkpoint + archived-delta reader/reconstructor at exact operation anchor | 1.5–2 pw |
+| D5 | whole-sheet/record/field restore planner + asynchronous bulk execution | 1.5–2.5 pw |
+| D6 | Time Machine recovery-point picker, diff, scope selection, progress/retry UI | 1–1.5 pw |
+| D7 | staging fault injection, scale/restore rehearsal, runbook, development+verification MD | 1–1.5 pw |
+
+Expected development volume: **8–12 person-weeks**, excluding a future cross-sheet/base-wide atomicity design and
+production rollout. Implementation may use two isolated development lanes plus an independent adversarial gate, but
+merges remain dependency-ordered and exact-head reviewed.
+
+### 12.6 Required evidence before enablement
+
+At minimum, mutation-proven real-DB/integration evidence must show:
+
+- archive write, upload, hash, or verification failure prevents the matching hot-history prune;
+- a corrupt, truncated, wrong-generation, cross-sheet, cross-tenant, expired, or wrong-key archive is refused before
+  any live write;
+- checkpoint + archived deltas reconstruct the exact token-bound anchor, including delete/recreate generations and
+  seq values above JavaScript's safe-integer range;
+- field-value and inbound-link recovery still works after the matching hot tombstones/revisions are pruned;
+- attachment absence is reported in preview and never represented as a successful full restore;
+- preview/live drift, permission drift, schema drift, locked records, and retention-floor drift produce zero-write
+  refusals or the explicitly selected conflict policy;
+- asynchronous jobs are idempotent across worker crash/retry and cannot double-apply a completed chunk;
+- a mid-apply failure follows the documented single-sheet atomic/partial contract, and the restore's own operation is
+  sealed as a future anchor;
+- flag-off behavior and existing history/retention behavior remain unchanged.
+
+### 12.7 Explicit boundary
+
+This feature is forward-looking. It cannot recover bytes already removed by retention before a verified archive was
+created, nor values destroyed before tombstone/revision capture when no other trustworthy backup contains them. Such
+cases remain `unavailable`, not guessed from an older candidate snapshot. External database/WAL/object backups may be
+offered as a separate operator recovery source, but they are not silently reclassified as Time Machine evidence.
+
+Completing W0 Phase B establishes the trusted recovery substrate. Completing Phase D establishes the additional
+product promise **“recoverable after hot-history retention”**. These are separate completion claims and must remain
+separate in status reports and enablement decisions.

--- a/docs/development/multitable-w0-substrate-integration-status-20260716.md
+++ b/docs/development/multitable-w0-substrate-integration-status-20260716.md
@@ -15,6 +15,10 @@ integration ORDER, dependencies, and take-over discipline live in the v3.7 desig
   with **L8 based on BOTH L6-b AND L7**. Drafting may be parallel; each MERGE is serial + exact-head gated. Flags OFF.
 - **Phase C — enablement:** owner/ops-only (strict/Revert/Reset enablement, staging cutover, #4273 re-measure). Not
   autonomous. All flags stay default-OFF throughout A + B.
+- **Phase D — durable recovery archive + sheet version restore:** owner-directed roadmap addition; starts after
+  Phase B is frozen. It preserves exact recovery points beyond hot-history retention and adds whole-sheet/selected
+  record/selected-field bulk restore. PLANNED only; implementation requires its own design lock and does not change
+  current retention behavior or any flag. Authority = v3.7 lock §12.
 
 ## Live status (final, 2026-07-17 — Phase A COMPLETE on `main`)
 
@@ -122,3 +126,25 @@ this corrected status record is merged and the owner confirms** — merge order 
 attachment/marker mint-surface goldens) and **P3-2** (`recordRecordRevisionsBatch` site-2 coverage) before any
 mint-consuming flag is armed — the resolver that L6-b introduces is the first consumer of `operation_id`, so those
 surfaces stop being inert exactly when L6-b lands.
+
+## Phase D planned — durable recovery archive + sheet version restore
+
+**Status (2026-07-17): PLANNED / zero runtime / zero flag change.** The owner directed that the Time Machine roadmap
+include recovery after hot-history retention and a bulk sheet-version restore so customers do not have to recover
+records one by one. The durable contract is v3.7 lock §12; this section is only its live status pointer.
+
+Dependency boundary:
+
+> Phase B frozen on `main` (`L5-wire → L6-b → L7 → L8`) → D1 archive design lock → D2 archive-before-prune →
+> D3 recovery-point catalog → D4 archive reconstruction → D5 bulk restore → D6 UI → D7 staging evidence.
+
+The product separates **history retention** (hot event detail) from **recovery retention** (verified immutable
+archives). Hot revision/tombstone pruning may not claim post-retention recoverability unless D2 has verified the
+matching archive. The current PIT-Reset/retention conflict remains fail-closed; Phase D planning does not relax it.
+
+V1 is single-sheet and exact-operation anchored. It supports whole-sheet, selected-record, and selected-field restore;
+large restores use an idempotent asynchronous operation. Permission policy restore, cross-sheet atomicity, recovery of
+already-purged pre-archive bytes, and production enablement remain outside this planning addition.
+
+Estimated development volume after Phase B: **8–12 person-weeks**. Two isolated implementation lanes may work in
+parallel where file ownership permits, with an independent adversarial gate; merge order remains dependency-driven.


### PR DESCRIPTION
## Summary

- add §12 to the existing v3.7 W0 design lock for durable recovery archives and sheet-level version restore
- add the matching Phase D pointer to the live W0 substrate status document
- separate hot history retention from longer recovery retention
- lock archive-before-prune, exact-operation anchoring, whole-sheet/record/field restore modes, async bulk restore, evidence requirements, and an 8–12 pw estimate

## Boundaries

- docs only: no runtime, migration, workflow, manifest, host, or flag change
- Phase D is PLANNED / design-lock-required; this PR does not ratify implementation or enable anything
- current PIT-Reset/retention conflict remains fail-closed
- no claim that already-pruned pre-archive bytes can be recovered
- v1 is single-sheet; permission-policy restore and cross-sheet atomicity remain separate

## Stack

This PR is intentionally based on the #4406 branch because it amends the two authority/status documents carried there without editing another session branch. After #4406 lands, this PR can be retargeted to `main` and revalidated.

## Verification

- `git diff --check`
- exact two-file scope confirmed
- full-text contradiction sweep for Phase D COMPLETE/RATIFIED claims, relaxed retention conflicts, and retroactive recovery claims
