### PR TITLE
ci(web-tests): pilot self-hosted routing via MS2_WEB_RUNNER variable

### DIFF
--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   web-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.MS2_WEB_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
**Pilot** for self-hosting metasheet2 CI ahead of privatization (sizing a dedicated runner box).

`runs-on` becomes `${{ vars.MS2_WEB_RUNNER || 'ubuntu-latest' }}`; the repo variable is currently `metasheet2`, matching pilot runner `ms2-pilot-1` on the CI VM. Web Tests (1,757 runs/7d — the repo's #1 workflow) will run there while we measure per-job duration/memory vs GitHub-hosted. Unset the variable for instant fallback to GitHub-hosted.

This PR itself is the live validation (web-tests is a required check).