### PR TITLE
fix(multitable): GF8-ON — propagate non-block failures from the engine's fenced materialization txn + flag-ON golden

### DIFF
--- a/packages/core-backend/src/multitable/formula-engine.ts
+++ b/packages/core-backend/src/multitable/formula-engine.ts
@@ -7,7 +7,7 @@
 import { FormulaEngine, type CellValue, type FormulaContext } from '../formula/engine'
 import type { MultitableField } from './field-codecs'
 import type { MultitableRecordsQueryFn } from './records'
-import { fenceWriterEntry, isWriterFenceEnabled } from './canonical-sheet-fence'
+import { fenceWriterEntry, isWriterFenceEnabled, SheetWriterBlockedError } from './canonical-sheet-fence'
 import { poolManager } from '../integration/db/connection-pool'
 import { Logger } from '../core/logger'
 
@@ -272,6 +272,8 @@ export class MultitableFormulaEngine {
 
       return await this.recalculateRecordFromData(query, sheetId, recordId, data, fields, onlyFormulaFieldIds)
     } catch (error) {
+      // The typed fenced-write failure must cross this wrapper too (bulk recompute enters here).
+      if (error instanceof FormulaFencedWriteError) throw error
       logger.error('recalculateRecord failed:', error as Error)
       return null
     }
@@ -355,19 +357,35 @@ export class MultitableFormulaEngine {
       // (preserving per-record independence: each record's materialization commits/rolls back on its own,
       // exactly the partial-progress the bulk-recompute contract depends on), and the fence's txn-scope is no
       // longer a caller obligation. A durable recovery block ⇒ `fenceWriterEntry` throws inside the txn ⇒ the
-      // txn rolls back ⇒ the outer catch returns null (no materialization). Only the fence+UPDATE are inside
-      // this txn; the `data || $updates` merge re-reads the live row at UPDATE time.
+      // txn rolls back ⇒ null (no materialization, benign skip). Any OTHER in-txn failure propagates as
+      // `FormulaFencedWriteError` (see the catch below). Only the fence+UPDATE are inside this txn; the
+      // `data || $updates` merge re-reads the live row at UPDATE time.
       if (isWriterFenceEnabled()) {
-        await poolManager.get().transaction(async ({ query: fencedQuery }) => {
-          const fq = fencedQuery as unknown as MultitableRecordsQueryFn
-          await fenceWriterEntry(fq, sheetId)
-          // lock-exempt: system formula materialization — derived value, no user actor (lock = read-only to USERS)
-          // revision-exempt: derived formula materialization, no version bump — pure fn of inputs, recompute-on-read
-          await fq(
-            `UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3`,
-            [JSON.stringify(updates), recordId, sheetId],
-          )
-        })
+        try {
+          await poolManager.get().transaction(async ({ query: fencedQuery }) => {
+            const fq = fencedQuery as unknown as MultitableRecordsQueryFn
+            await fenceWriterEntry(fq, sheetId)
+            // lock-exempt: system formula materialization — derived value, no user actor (lock = read-only to USERS)
+            // revision-exempt: derived formula materialization, no version bump — pure fn of inputs, recompute-on-read
+            await fq(
+              `UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3`,
+              [JSON.stringify(updates), recordId, sheetId],
+            )
+          })
+        } catch (error) {
+          // Failure-class split (owner GF8-ON review, 2026-07-17):
+          //  • a durable recovery BLOCK is the BENIGN skip — the F1 contract: txn rolled back, nothing
+          //    materialized, return null so a user write/PATCH never fails on a derived value.
+          //  • any OTHER failure inside the fenced txn is an INFRA failure whose write did NOT land —
+          //    swallowing it to null made the bulk executor mislabel it `taintSkipped` with `failed:false`
+          //    (a silent lie in the recompute report). Propagate it TYPED so the bulk chunk loop aborts
+          //    with `failed:true` (B6) while the record itself stays zero-committed (its txn rolled back).
+          if (error instanceof SheetWriterBlockedError) {
+            logger.error('recalculateRecordFromData skipped under recovery block:', error as Error)
+            return null
+          }
+          throw new FormulaFencedWriteError(sheetId, recordId, error)
+        }
       } else {
         // Flag OFF (default, and what unit/mock callers run under): BYTE-IDENTICAL to pre-L4cov — a direct
         // UPDATE on the passed query, no fence, no real-pool transaction (so a mock query stays honored).
@@ -380,8 +398,25 @@ export class MultitableFormulaEngine {
       }
       return { ...data, ...updates }
     } catch (error) {
+      // The typed fenced-write failure MUST cross this boundary (see the fenced-txn catch above) — it is
+      // the one failure class the caller may not treat as "no materialization, carry on".
+      if (error instanceof FormulaFencedWriteError) throw error
       logger.error('recalculateRecordFromData failed:', error as Error)
       return null
     }
+  }
+}
+
+/**
+ * A NON-block failure inside the flag-ON fenced materialization transaction (owner GF8-ON review,
+ * 2026-07-17). The record's fence+UPDATE txn rolled back — ZERO writes for that record — but the failure is
+ * infrastructure, not a recovery block, so it must reach the bulk-recompute executor as a failure
+ * (`failed:true`, remaining chunks aborted) instead of being silently absorbed into `taintSkipped`.
+ * Flag OFF is untouched: the direct-UPDATE branch throws raw into the caller exactly as before.
+ */
+export class FormulaFencedWriteError extends Error {
+  constructor(readonly sheetId: string, readonly recordId: string, readonly cause: unknown) {
+    super(`formula fenced materialization failed for record ${recordId} on sheet ${sheetId}: ${(cause as Error)?.message ?? String(cause)}`)
+    this.name = 'FormulaFencedWriteError'
   }
 }

--- a/packages/core-backend/tests/integration/multitable-w11-expression-bulk-recompute-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-w11-expression-bulk-recompute-realdb.test.ts
@@ -19,6 +19,9 @@
  *    skipped (taintSkipped == attempted, recomputed == 0), old values preserved; an unmasked
  *    editor's identical PATCH recomputes fully.
  *  - GF8: an injected mid-chunk failure aborts the remaining chunk (failed:true, coarse error)
+ *  - GF8-ON: flag-ON parity — a failure INSIDE the engine's fenced txn (trigger-injected; the pool.query
+ *    monkeypatch can't reach that client) still propagates: failed:true, poisoned record zero-committed,
+ *    earlier record retained (per-record txn independence), later record not attempted
  *    while whatever already persisted stands; a same-expression re-save (the B1 no-op-resave
  *    trigger) re-runs the recompute and converges to full freshness.
  *  - GF12: a same-expression re-save fires the bulk recompute but records ZERO new
@@ -84,6 +87,21 @@ const REC_GF8_B = `rec_w11bulk_gf8_b_${TS}`
 const REC_GF8_C = `rec_w11bulk_gf8_c_${TS}`
 const REC_GF12 = [`rec_w11bulk_gf12_1_${TS}`, `rec_w11bulk_gf12_2_${TS}`]
 
+// GF8-ON — the flag-ON parity of GF8. PURE formula (no relation-agg) so the write goes through the
+// ENGINE's fenced-txn path (`recalculateRecordFromData` under MULTITABLE_ENABLE_WRITER_FENCE), which is
+// exactly the surface GF8's pool.query monkeypatch cannot reach (the engine txn runs on its own client).
+// Alphabetical a/b/c for the route's deterministic ORDER BY id ASC processing order.
+const SHEET_GF8ON = `sheet_w11bulk_gf8on_${TS}`
+const FLD_GF8ON_NAME = `fld_w11bulk_gf8on_name_${TS}`
+const FLD_GF8ON_FORMULA = `fld_w11bulk_gf8on_formula_${TS}`
+const REC_GF8ON_A = `rec_w11bulk_gf8on_a_${TS}`
+const REC_GF8ON_B = `rec_w11bulk_gf8on_b_${TS}`
+const REC_GF8ON_C = `rec_w11bulk_gf8on_c_${TS}`
+// Injection artifacts (shared-DB discipline: the trigger is WHEN-scoped to exactly REC_GF8ON_B, so no
+// other file/fixture in the sequential real-DB bundle can ever fire it; both are dropped in finally).
+const GF8ON_POISON_FN = `w11bulk_gf8on_poison_${TS}`
+const GF8ON_POISON_TRG = `trg_w11bulk_gf8on_poison_${TS}`
+
 function buildApp(userId: string): Express {
   const a = express()
   a.use(express.json())
@@ -130,7 +148,7 @@ const relCountExpr = (linkFieldId: string) => `RELCOUNTIF("${linkFieldId}","${FL
 describeIfDatabase('W1-1 LOCK-B golden matrix — expression-change bulk recompute (real DB)', () => {
   beforeAll(async () => {
     await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'W1-1 Bulk Base'])
-    for (const sheetId of [SHEET_GF5, SHEET_GF6, SHEET_GF7, SHEET_GF8, SHEET_GF12, SHEET_FOREIGN]) {
+    for (const sheetId of [SHEET_GF5, SHEET_GF6, SHEET_GF7, SHEET_GF8, SHEET_GF8ON, SHEET_GF12, SHEET_FOREIGN]) {
       await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [sheetId, BASE_ID, sheetId])
     }
     for (const id of [WRITER, MASKED]) {
@@ -195,6 +213,16 @@ describeIfDatabase('W1-1 LOCK-B golden matrix — expression-change bulk recompu
     }
 
     // ---- GF12 sheet: pure formula, 2 records, re-save decoupling ----
+    // GF8-ON fixture: pure formula `={name}` seeded stale — the engine fenced-txn write path's sheet.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_GF8ON_NAME, SHEET_GF8ON, 'Name', 'string', '{}', 1])
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_GF8ON_FORMULA, SHEET_GF8ON, 'Formula', 'formula', JSON.stringify({ expression: `={${FLD_GF8ON_NAME}}` }), 2],
+    )
+    for (const [i, rid] of [REC_GF8ON_A, REC_GF8ON_B, REC_GF8ON_C].entries()) {
+      await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [rid, SHEET_GF8ON, JSON.stringify({ [FLD_GF8ON_NAME]: `n${i}`, [FLD_GF8ON_FORMULA]: 'stale' })])
+    }
+
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_GF12_NAME, SHEET_GF12, 'Name', 'string', '{}', 1])
     await q(
       'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
@@ -212,7 +240,7 @@ describeIfDatabase('W1-1 LOCK-B golden matrix — expression-change bulk recompu
   })
 
   afterAll(async () => {
-    const allSheets = [SHEET_GF5, SHEET_GF6, SHEET_GF7, SHEET_GF8, SHEET_GF12, SHEET_FOREIGN]
+    const allSheets = [SHEET_GF5, SHEET_GF6, SHEET_GF7, SHEET_GF8, SHEET_GF8ON, SHEET_GF12, SHEET_FOREIGN]
     await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[FLD_GF7_LINK, FLD_GF8_LINK]]).catch(() => {})
     await q('DELETE FROM formula_dependencies WHERE sheet_id = ANY($1::text[])', [allSheets]).catch(() => {})
     await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_FOREIGN]).catch(() => {})
@@ -322,6 +350,53 @@ describeIfDatabase('W1-1 LOCK-B golden matrix — expression-change bulk recompu
     }
     // The re-save is a config no-op (identical expression) -> no NEW meta_config_revisions row.
     expect(await configRevisionCount(SHEET_GF8, FLD_GF8_FORMULA)).toBe(revBefore)
+  })
+
+  test('GF8-ON: a failure INSIDE the engine fenced txn (flag ON) propagates — failed:true, poisoned record ZERO-committed, earlier record retained, later record not executed; healthy re-save converges', async () => {
+    // The GF8 pool.query monkeypatch cannot reach this surface: under MULTITABLE_ENABLE_WRITER_FENCE the
+    // engine's fence+UPDATE run on their OWN transaction client (poolManager.transaction). The injection is
+    // therefore a WHEN-scoped BEFORE UPDATE trigger — it fires inside that fenced txn by construction.
+    // Contract pinned here (owner GF8-ON review, 2026-07-17, adapted to the v2 per-record txn architecture):
+    //  • the v2 atomicity unit is ONE record's fence+UPDATE txn — the poisoned record is ZERO-committed;
+    //  • records already materialized earlier in the chunk KEEP their committed values (the original GF8
+    //    partial-progress contract — per-record independence, NOT v1's per-chunk rollback);
+    //  • the failure PROPAGATES: bulkRecompute reports failed:true (B6 abort) instead of silently
+    //    mislabeling an infra failure as taintSkipped with failed:false (the pre-fix engine swallowed the
+    //    fenced-txn error to null — reverting FormulaFencedWriteError propagation reds exactly this test);
+    //  • records after the poison are NOT attempted (abort semantics, same as GF8).
+    await q(`CREATE OR REPLACE FUNCTION ${GF8ON_POISON_FN}() RETURNS trigger AS $$
+             BEGIN RAISE EXCEPTION 'injected fenced-txn failure (GF8-ON)'; END $$ LANGUAGE plpgsql`)
+    await q(`CREATE TRIGGER ${GF8ON_POISON_TRG} BEFORE UPDATE ON meta_records
+             FOR EACH ROW WHEN (NEW.id = '${REC_GF8ON_B}') EXECUTE FUNCTION ${GF8ON_POISON_FN}()`)
+    const prevFence = process.env.MULTITABLE_ENABLE_WRITER_FENCE
+    process.env.MULTITABLE_ENABLE_WRITER_FENCE = 'true'
+    try {
+      const res = await patchField(WRITER, FLD_GF8ON_FORMULA, { property: { expression: `={${FLD_GF8ON_NAME}}` } })
+      expect(res.status).toBe(200) // the config PATCH stands — recompute failure never rolls it back
+      expect(res.body?.data?.bulkRecompute?.failed).toBe(true)
+      expect(res.body?.data?.bulkRecompute?.error).toBe('BULK_RECOMPUTE_FAILED')
+      // rec_a (before the poison in ORDER BY id ASC): its OWN fenced txn committed — retained.
+      expect(await readFormulaField(REC_GF8ON_A, FLD_GF8ON_FORMULA)).toBe('n0')
+      // rec_b: the fenced txn rolled back — ZERO-committed, stale value byte-preserved.
+      expect(await readFormulaField(REC_GF8ON_B, FLD_GF8ON_FORMULA)).toBe('stale')
+      // rec_c (after the poison): never attempted (abort remaining).
+      expect(await readFormulaField(REC_GF8ON_C, FLD_GF8ON_FORMULA)).toBe('stale')
+
+      // Positive control for the HEALTHY flag-ON path (anti-vacuous): drop the poison, keep the fence ON —
+      // a same-expression re-save converges every record through the fenced txn.
+      await q(`DROP TRIGGER IF EXISTS ${GF8ON_POISON_TRG} ON meta_records`)
+      const resave = await patchField(WRITER, FLD_GF8ON_FORMULA, { property: { expression: `={${FLD_GF8ON_NAME}}` } })
+      expect(resave.status).toBe(200)
+      expect(resave.body?.data?.bulkRecompute).toMatchObject({ attempted: 3, recomputed: 3, taintSkipped: 0, failed: false })
+      expect(await readFormulaField(REC_GF8ON_A, FLD_GF8ON_FORMULA)).toBe('n0')
+      expect(await readFormulaField(REC_GF8ON_B, FLD_GF8ON_FORMULA)).toBe('n1')
+      expect(await readFormulaField(REC_GF8ON_C, FLD_GF8ON_FORMULA)).toBe('n2')
+    } finally {
+      if (prevFence === undefined) delete process.env.MULTITABLE_ENABLE_WRITER_FENCE
+      else process.env.MULTITABLE_ENABLE_WRITER_FENCE = prevFence
+      await q(`DROP TRIGGER IF EXISTS ${GF8ON_POISON_TRG} ON meta_records`).catch(() => {})
+      await q(`DROP FUNCTION IF EXISTS ${GF8ON_POISON_FN}()`).catch(() => {})
+    }
   })
 
   test('GF12: a same-expression re-save fires the bulk recompute but records ZERO new meta_config_revisions rows (recompute-trigger and config-audit-trigger are decoupled)', async () => {


### PR DESCRIPTION
## What

Owner GF8 review follow-up (2026-07-17, in-session): under `MULTITABLE_ENABLE_WRITER_FENCE` the v2 engine ran fence+UPDATE in its own short transaction but **swallowed every in-txn failure to `null`** — the B6 bulk-recompute executor then mislabeled an infra failure as `taintSkipped` with `failed:false` (a silent lie in the recompute report). GF8's `pool.query` monkeypatch can never reach that surface: the engine txn runs on its own client.

## Fix (engine, flag-ON path only)

Failure-class split in `recalculateRecordFromData`:
- `SheetWriterBlockedError` (durable recovery block) ⇒ `null`, benign skip — **F1 contract unchanged**; a user write never fails on a derived value.
- any **other** fenced-txn failure ⇒ typed `FormulaFencedWriteError`, propagated (through `recalculateRecord` too) so the B6 chunk loop aborts with `failed:true` — while the poisoned record itself stays **zero-committed** (its txn rolled back).

**Flag OFF: byte-identical** (the direct-UPDATE branch is untouched; GF8's existing injection + assertions unchanged).

## GF8-ON golden (real DB)

WHEN-scoped `BEFORE UPDATE` trigger injects the failure **inside** the fenced txn (per-record-id scoped — shared-DB discipline; dropped in `finally`):
- `failed:true` + `BULK_RECOMPUTE_FAILED`
- `rec_a` (before the poison) **retained** — per-record txn independence, the original GF8 partial-progress contract (v1's per-chunk rollback was abandoned for exactly this)
- `rec_b` **zero-committed** (stale value byte-preserved)
- `rec_c` **not attempted** (abort remaining)
- healthy flag-ON re-save converges 3/3 (anti-vacuous positive control)

## Verify

- w11 suite 7/7; w11 + l4cov-services fence suites together **24/24** (F1 null-on-block still green) on fresh-migrated PG
- **Mutation-proven**: revert the propagation (swallow to null, pre-fix behavior) ⇒ exactly GF8-ON red at the `failed:true` assertion, 6/7 others green; restore ⇒ 7/7
- tsc clean

## Owner-reviewable point

Flag-ON REST/PATCH single-record materialization now also propagates infra failures (previously silent-stale). Recovery-block skips are unchanged. Flags remain OFF everywhere — zero live-path impact until the fence flag is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
