### PR TITLE
fix(multitable): W0 L4-cov follow-up — relation-agg materializations join the canonical fence (shared derived-write seam, default-OFF)

### DIFF
--- a/packages/core-backend/src/multitable/derived-write-fence.ts
+++ b/packages/core-backend/src/multitable/derived-write-fence.ts
@@ -1,0 +1,68 @@
+/**
+ * W0-1 L4-cov follow-up (post-merge review of #4438, 2026-07-17) — the ONE shared, flag-gated
+ * fence+UPDATE seam for DERIVED-value materializations into `meta_records.data`.
+ *
+ * Three writer sites materialize derived values with the same in-place merge UPDATE (no version
+ * bump, no revision, no seq): the pure-formula engine (`formula-engine.ts recalculateRecordFromData`)
+ * and the two relation-aggregation sites in `univer-meta.ts` (same-record materialization inside
+ * `recalculateFormulaFields`, and the dependent-sheet fan-out inside
+ * `computeDependentLookupRollupRecords`). The #4438 v2 TOCTOU fix moved the engine's write into an
+ * engine-internal fenced transaction but left the two relation-agg sites on bare autocommit
+ * writes — a derived value computed from PRE-recovery inputs could still land inside a recovery's
+ * applying window and clobber just-recovered data. This module is the single seam all three route
+ * through, so the fence discipline cannot drift apart again.
+ *
+ * Contract (identical to the engine-v2 pattern it generalizes):
+ *  - Flag ON (`MULTITABLE_ENABLE_WRITER_FENCE`): the fence-check→UPDATE PAIR runs in its OWN short
+ *    transaction so `pg_advisory_xact_lock` is held from acquisition to COMMIT. Reads stay OUTSIDE
+ *    (callers compute `updates` first) — per-record independence is preserved (each record's
+ *    materialization commits/rolls back on its own; the partial-progress the bulk-recompute
+ *    contract depends on). A durable recovery block ⇒ `fenceWriterEntry` throws
+ *    `SheetWriterBlockedError` inside the txn ⇒ rollback ⇒ ZERO write. The caller decides the
+ *    tolerance posture (the engine returns null; the relation-agg sites catch, log values-free and
+ *    skip the materialization + its echo).
+ *  - Flag OFF (default; what unit/mock callers run under): BYTE-IDENTICAL legacy write on the
+ *    CALLER-passed query — no fence, no real-pool transaction, so a mock query stays honored.
+ *  - Known residual (same as engine v2, documented at the goldens): the compute READS happen
+ *    outside the fenced txn — a recovery that starts AND finishes in the compute→write gap clears
+ *    the block, so a stale pre-recovery-derived value can still commit. Bounded: derived-only,
+ *    self-heals on the next recompute, no PIT impact (these writes are revision-exempt/no-seq).
+ */
+import { fenceWriterEntry, isWriterFenceEnabled } from './canonical-sheet-fence'
+import { poolManager } from '../integration/db/connection-pool'
+
+/** Minimal query shape shared by the callers' QueryFn / MultitableRecordsQueryFn aliases. */
+export type DerivedMergeQueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+
+/**
+ * Merge `updates` (derived-value keys only) into one record's `data`, joining the canonical
+ * per-sheet writer fence when the L4 flag is ON. Throws `SheetWriterBlockedError` (zero write)
+ * when a durable recovery block is active on `sheetId`.
+ */
+export async function applyFencedDerivedDataMerge(
+  query: DerivedMergeQueryFn,
+  sheetId: string,
+  recordId: string,
+  updates: Record<string, unknown>,
+): Promise<void> {
+  if (isWriterFenceEnabled()) {
+    await poolManager.get().transaction(async ({ query: fencedQuery }) => {
+      const fq = fencedQuery as unknown as DerivedMergeQueryFn
+      await fenceWriterEntry(fq, sheetId)
+      // lock-exempt: system derived-value materialization — no user actor (a record lock is read-only to system recompute)
+      // revision-exempt: derived materialization, no version bump — pure fn of stored inputs, recomputed on next write
+      await fq(
+        `UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3`,
+        [JSON.stringify(updates), recordId, sheetId],
+      )
+    })
+  } else {
+    // Flag OFF: BYTE-IDENTICAL to the pre-fence write, on the caller's query (mocks stay honored).
+    // lock-exempt: system derived-value materialization — no user actor (a record lock is read-only to system recompute)
+    // revision-exempt: derived materialization, no version bump — pure fn of stored inputs, recomputed on next write
+    await query(
+      `UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3`,
+      [JSON.stringify(updates), recordId, sheetId],
+    )
+  }
+}

--- a/packages/core-backend/src/multitable/formula-engine.ts
+++ b/packages/core-backend/src/multitable/formula-engine.ts
@@ -7,8 +7,8 @@
 import { FormulaEngine, type CellValue, type FormulaContext } from '../formula/engine'
 import type { MultitableField } from './field-codecs'
 import type { MultitableRecordsQueryFn } from './records'
-import { fenceWriterEntry, isWriterFenceEnabled, SheetWriterBlockedError } from './canonical-sheet-fence'
-import { poolManager } from '../integration/db/connection-pool'
+import { isWriterFenceEnabled, SheetWriterBlockedError } from './canonical-sheet-fence'
+import { applyFencedDerivedDataMerge, type DerivedMergeQueryFn } from './derived-write-fence'
 import { Logger } from '../core/logger'
 
 const logger = new Logger('MultitableFormulaEngine')
@@ -352,49 +352,38 @@ export class MultitableFormulaEngine {
       // recovery's applying window — a materialization computed from PRE-recovery inputs would clobber the
       // just-recovered `data`. TOCTOU root fix (owner ruling 2026-07-17): the fence-check→UPDATE PAIR runs in
       // its OWN short transaction so `pg_advisory_xact_lock` is held from acquisition to COMMIT (a bare
-      // autocommit query released it per statement, leaving a block-check→UPDATE window). This is
-      // SELF-CONTAINED in the engine — callers still pass their ordinary (pool) query for the READS above
-      // (preserving per-record independence: each record's materialization commits/rolls back on its own,
-      // exactly the partial-progress the bulk-recompute contract depends on), and the fence's txn-scope is no
-      // longer a caller obligation. A durable recovery block ⇒ `fenceWriterEntry` throws inside the txn ⇒ the
-      // txn rolls back ⇒ null (no materialization, benign skip). Any OTHER in-txn failure propagates as
-      // `FormulaFencedWriteError` (see the catch below). Only the fence+UPDATE are inside this txn; the
-      // `data || $updates` merge re-reads the live row at UPDATE time.
-      if (isWriterFenceEnabled()) {
-        try {
-          await poolManager.get().transaction(async ({ query: fencedQuery }) => {
-            const fq = fencedQuery as unknown as MultitableRecordsQueryFn
-            await fenceWriterEntry(fq, sheetId)
-            // lock-exempt: system formula materialization — derived value, no user actor (lock = read-only to USERS)
-            // revision-exempt: derived formula materialization, no version bump — pure fn of inputs, recompute-on-read
-            await fq(
-              `UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3`,
-              [JSON.stringify(updates), recordId, sheetId],
-            )
-          })
-        } catch (error) {
-          // Failure-class split (owner GF8-ON review, 2026-07-17):
-          //  • a durable recovery BLOCK is the BENIGN skip — the F1 contract: txn rolled back, nothing
-          //    materialized, return null so a user write/PATCH never fails on a derived value.
-          //  • any OTHER failure inside the fenced txn is an INFRA failure whose write did NOT land —
-          //    swallowing it to null made the bulk executor mislabel it `taintSkipped` with `failed:false`
-          //    (a silent lie in the recompute report). Propagate it TYPED so the bulk chunk loop aborts
-          //    with `failed:true` (B6) while the record itself stays zero-committed (its txn rolled back).
-          if (error instanceof SheetWriterBlockedError) {
-            logger.error('recalculateRecordFromData skipped under recovery block:', error as Error)
-            return null
-          }
+      // autocommit query released it per statement, leaving a block-check→UPDATE window). The
+      // fence+UPDATE plumbing lives in the SHARED derived-write seam (`derived-write-fence.ts`,
+      // post-merge review of #4438 — the relation-aggregation materializations join the same seam) —
+      // callers still pass their ordinary (pool) query for the READS above (preserving per-record
+      // independence: each record's materialization commits/rolls back on its own, exactly the
+      // partial-progress the bulk-recompute contract depends on), and the fence's txn-scope is no
+      // longer a caller obligation. Flag OFF stays byte-identical on the passed query (mocks honored).
+      //
+      // Failure-class split (owner GF8-ON review, 2026-07-17 — #4451, preserved across the seam refactor):
+      //  • a durable recovery BLOCK is the BENIGN skip — the F1 contract: the seam's txn rolled back,
+      //    nothing materialized, return null so a user write/PATCH never fails on a derived value.
+      //  • any OTHER failure inside the flag-ON fenced txn is an INFRA failure whose write did NOT land —
+      //    swallowing it to null made the bulk executor mislabel it `taintSkipped` with `failed:false`
+      //    (a silent lie in the recompute report). Propagate it TYPED so the bulk chunk loop aborts
+      //    with `failed:true` (B6) while the record itself stays zero-committed (its txn rolled back).
+      //  • flag OFF: a raw error keeps its legacy path (outer catch → logged → null), byte-identical.
+      try {
+        await applyFencedDerivedDataMerge(
+          query as unknown as DerivedMergeQueryFn,
+          sheetId,
+          recordId,
+          updates,
+        )
+      } catch (error) {
+        if (error instanceof SheetWriterBlockedError) {
+          logger.error('recalculateRecordFromData skipped under recovery block:', error as Error)
+          return null
+        }
+        if (isWriterFenceEnabled()) {
           throw new FormulaFencedWriteError(sheetId, recordId, error)
         }
-      } else {
-        // Flag OFF (default, and what unit/mock callers run under): BYTE-IDENTICAL to pre-L4cov — a direct
-        // UPDATE on the passed query, no fence, no real-pool transaction (so a mock query stays honored).
-        // lock-exempt: system formula materialization — derived value, no user actor (lock = read-only to USERS)
-        // revision-exempt: derived formula materialization, no version bump — pure fn of inputs, recompute-on-read
-        await query(
-          `UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3`,
-          [JSON.stringify(updates), recordId, sheetId],
-        )
+        throw error
       }
       return { ...data, ...updates }
     } catch (error) {

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -244,6 +244,7 @@ import {
 } from '../multitable/canonical-sheet-fence'
 import { activateCheckpoint, CheckpointUnattributableTrashError } from '../multitable/history-trust-checkpoint'
 import type { QueryFn as TrustCheckpointQueryFn } from '../multitable/permission-service'
+import { applyFencedDerivedDataMerge, type DerivedMergeQueryFn } from '../multitable/derived-write-fence'
 import { normalizeAutoNumberProperty } from '../multitable/auto-number-property'
 import {
   createYjsInvalidationPostCommitHook,
@@ -2949,6 +2950,11 @@ async function recalculateFormulaFields(
   )
 
   const results: Array<{ recordId: string; data: Record<string, unknown> }> = []
+  // W0-1 L4-cov follow-up: once a durable recovery writer-block refuses one relation-agg
+  // materialization on this sheet, skip the remaining records' relation-agg compute+write round
+  // trips too (the block is sheet-scoped; pure-formula materialization keeps its own engine-side
+  // fence posture per record).
+  let derivedWriteBlocked = false
   for (const recordId of updatedRecordIds) {
     const hydrated = hydratedDataByRecord?.get(recordId)
     const formulaData: Record<string, unknown> = {}
@@ -2962,7 +2968,7 @@ async function recalculateFormulaFields(
         }
       }
     }
-    if (relationAggByField.size > 0 || cliffFieldIds.size > 0) {
+    if ((relationAggByField.size > 0 || cliffFieldIds.size > 0) && !derivedWriteBlocked) {
       const recData = hydrated ?? (await loadRecordDataById(query, sheetId, recordId))
       if (recData) {
         const updates: Record<string, unknown> = {}
@@ -2972,14 +2978,27 @@ async function recalculateFormulaFields(
         for (const fieldId of cliffFieldIds) {
           updates[fieldId] = '#ERROR!' // composition deferred (Slice A is sole-call) — fail loud, never silent-wrong
         }
+        // W0-1 L4-cov follow-up (post-merge review of #4438): the relation-agg materialization joins the
+        // canonical fence via the SHARED derived-write seam (flag-gated; flag-OFF = byte-identical legacy
+        // write on the caller's query). A durable recovery block on this sheet is an EXPECTED operational
+        // condition, not an error — the primary user write (if any) already committed, so refusal here
+        // must NOT fail the request or kill the remaining post-commit steps: skip the materialization AND
+        // its echo (the DB did not change; receivers only consume invalidation ids and refetch — carrying
+        // a value the DB refused would display data that reverts on reload), latch the sheet so remaining
+        // records skip their compute+fence round trips. Values-free log. Any OTHER error keeps today's
+        // propagation semantics.
         if (Object.keys(updates).length > 0) {
-          // lock-exempt: system relation-aggregation materialization — derived value, no user actor (same posture as recalculateRecordFromData; a record lock is read-only to users, not system recompute).
-          // revision-exempt: relation-aggregation same-record materialization, no version bump — derived value.
-          await query(
-            'UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3',
-            [JSON.stringify(updates), recordId, sheetId],
-          )
-          Object.assign(formulaData, updates)
+          try {
+            await applyFencedDerivedDataMerge(query as unknown as DerivedMergeQueryFn, sheetId, recordId, updates)
+            Object.assign(formulaData, updates)
+          } catch (err) {
+            if (err instanceof SheetWriterBlockedError) {
+              derivedWriteBlocked = true
+              console.warn(`[univer-meta] relation-agg materialization refused by recovery writer-block — skipped (sheet=${sheetId})`)
+            } else {
+              throw err
+            }
+          }
         }
       }
     }
@@ -3869,11 +3888,25 @@ async function computeDependentLookupRollupRecords(
           if (!call) continue
           updates[fieldId] = await resolveRelationAggregation(req, query, sheetId, recordId, recData, call, fields)
         }
+        // W0-1 L4-cov follow-up (post-merge review of #4438): the fan-out materialization joins the
+        // canonical fence via the SHARED derived-write seam, keyed on the DEPENDENT sheet being written
+        // (this loop's `sheetId` — NOT `sourceSheetId`; the primary write's fence covered only the source
+        // sheet, so a recovery block here is the COMMON refusal case, not a race). Refusal is expected
+        // during a recovery on this dependent sheet: skip this sheet's remaining materializations and
+        // their echo/invalidation ids (the DB did not change ⇒ nothing to invalidate), let OTHER
+        // dependent sheets and the rest of the post-commit pipeline continue. Values-free log. Any other
+        // error keeps today's propagation semantics.
         if (Object.keys(updates).length > 0) {
-          // lock-exempt: system relation-aggregation fan-out materialization — derived value, no user actor (same posture as the same-record recompute write).
-          // revision-exempt: relation-aggregation fan-out materialization, no version bump — derived value.
-          await query('UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3', [JSON.stringify(updates), recordId, sheetId])
-          formulaDataByRecord.set(recordId, { ...(formulaDataByRecord.get(recordId) ?? {}), ...updates })
+          try {
+            await applyFencedDerivedDataMerge(query as unknown as DerivedMergeQueryFn, sheetId, recordId, updates)
+            formulaDataByRecord.set(recordId, { ...(formulaDataByRecord.get(recordId) ?? {}), ...updates })
+          } catch (err) {
+            if (err instanceof SheetWriterBlockedError) {
+              console.warn(`[univer-meta] fan-out relation-agg materialization refused by recovery writer-block — skipped (sheet=${sheetId})`)
+              break
+            }
+            throw err
+          }
         }
       }
     }
@@ -17329,6 +17362,13 @@ export function univerMetaRouter(): Router {
         },
       })
     } catch (err) {
+      // W0-1 L4-cov follow-up: the PRIMARY fenced write (record-write-service txn entry) observed a
+      // durable recovery writer-block → refuse with the same 409 RECOVERY_IN_PROGRESS shape the
+      // reset/revert/config-restore routes use, instead of falling through to a 500. (Derived-value
+      // materialization refusals never reach here — they are caught + skipped at their sites.)
+      if (err instanceof SheetWriterBlockedError) {
+        return res.status(409).json({ ok: false, error: { code: 'RECOVERY_IN_PROGRESS', message: 'Another recovery operation is in progress on this sheet; retry shortly.' } })
+      }
       if (err instanceof ConflictError) {
         return res.status(409).json({ ok: false, error: { code: 'CONFLICT', message: err.message } })
       }

--- a/packages/core-backend/tests/integration/multitable-l4cov-services-fence-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-l4cov-services-fence-realdb.test.ts
@@ -344,10 +344,13 @@ describeIfDatabase('W0-1 L4-cov-services — service writers on the canonical fe
       // `pg_locks … NOT granted` count could be satisfied by an UNRELATED suite sharing this database.
       // Attribute the waiter to THIS holder via pg_blocking_pids — same pattern as the sibling
       // waitUntilBlockedOnFence helper in the univer-meta writers suite. Poll via `q` (the
-      // poolManager channel, the waiter's OWN session user), NOT via `holder`: the raw internal-pool
-      // client's session cannot see other sessions' `query`/`wait_event_type` in pg_stat_activity
-      // (permission-masked rows), which reads as "no waiter" forever — pg_locks was visible only
-      // because the lock table is not masked.
+      // poolManager channel — the waiter's own session), NOT via `holder`: observed empirically
+      // during development (twice, deterministic until switched), the raw internal-pool client's
+      // pg_stat_activity view returned NO client-backend rows at all — reading as "no waiter"
+      // forever — while `pg_locks` (shared lock state) still showed the parked lock from the same
+      // connection, and the identical poll through `q` saw the waiter immediately. Mechanism
+      // unresolved (both channels nominally share one pool); polling where the waiter's session is
+      // provably visible is the load-bearing choice either way.
       let sawWaiter = false
       for (let i = 0; i < 100; i++) {
         const waiters = await q(

--- a/packages/core-backend/tests/integration/multitable-l4cov-services-fence-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-l4cov-services-fence-realdb.test.ts
@@ -333,22 +333,43 @@ describeIfDatabase('W0-1 L4-cov-services — service writers on the canonical fe
     const query = ((sql: string, params?: unknown[]) => q(sql, params)) as MultitableRecordsQueryFn
     expect(pool).toBeTruthy()
     const holder = await pool!.connect()
+    let holderOpenTxn = false
     try {
       await holder.query('BEGIN')
+      holderOpenTxn = true
       await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`meta:auto-number:sheet:${SHEET}`])
+      const holderPid = Number(((await holder.query('SELECT pg_backend_pid() AS pid')).rows[0] as { pid: number }).pid)
       const inflight = engine.recalculateRecordFromData(query, SHEET, R, { [F_STR]: 'x' }, fields)
+      // Precise attribution (post-merge review of #4438, Low-1): the previous DB-wide
+      // `pg_locks … NOT granted` count could be satisfied by an UNRELATED suite sharing this database.
+      // Attribute the waiter to THIS holder via pg_blocking_pids — same pattern as the sibling
+      // waitUntilBlockedOnFence helper in the univer-meta writers suite. Poll via `q` (the
+      // poolManager channel, the waiter's OWN session user), NOT via `holder`: the raw internal-pool
+      // client's session cannot see other sessions' `query`/`wait_event_type` in pg_stat_activity
+      // (permission-masked rows), which reads as "no waiter" forever — pg_locks was visible only
+      // because the lock table is not masked.
       let sawWaiter = false
       for (let i = 0; i < 100; i++) {
-        const waiters = await holder.query(`SELECT count(*)::int AS c FROM pg_locks WHERE locktype = 'advisory' AND NOT granted`)
+        const waiters = await q(
+          `SELECT count(*)::int AS c FROM pg_stat_activity
+           WHERE datname = current_database() AND wait_event_type = 'Lock'
+             AND $1 = ANY(pg_blocking_pids(pid)) AND query ILIKE '%pg_advisory_xact_lock%'`,
+          [holderPid],
+        )
         if (Number((waiters.rows[0] as { c: number }).c) > 0) { sawWaiter = true; break }
         await new Promise((r) => setTimeout(r, 50))
       }
-      expect(sawWaiter).toBe(true) // the recompute genuinely parked behind the fence holder
+      expect(sawWaiter).toBe(true) // the recompute genuinely parked behind THIS holder's fence
       await holder.query('COMMIT') // release ⇒ the recompute proceeds and materializes
+      holderOpenTxn = false
       const result = await inflight
       expect(result?.[F_FORMULA]).toBe(2)
       expect((await recordRow(R))?.data?.[F_FORMULA]).toBe(2)
     } finally {
+      // Failure-path hygiene (review Low-1b): a thrown expect above would otherwise release this client
+      // mid-BEGIN still holding the fence key — node-postgres does NOT reset a connection on release(),
+      // so the advisory xact lock + idle-in-transaction connection would poison the rest of the suite.
+      if (holderOpenTxn) await holder.query('ROLLBACK').catch(() => {})
       holder.release()
     }
   })

--- a/packages/core-backend/tests/integration/multitable-l4cov-univer-meta-writers-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-l4cov-univer-meta-writers-realdb.test.ts
@@ -650,6 +650,16 @@ describeIfDatabase('W0-1 L4cov — univer-meta/records/auto-number writer fence 
 
     const setBlockFor = async (sheetId: string, state: WriterBlockState | null) =>
       q('UPDATE meta_sheets SET recovery_writer_state = $2 WHERE id = $1', [sheetId, state])
+    const blockOf = async (sheetId: string): Promise<unknown> =>
+      ((await q('SELECT recovery_writer_state FROM meta_sheets WHERE id = $1', [sheetId])).rows[0] as
+        | { recovery_writer_state: unknown }
+        | undefined)?.recovery_writer_state ?? null
+    // Gate P2 hardening: every §C test asserts a clean-block precondition so a stale block from a
+    // prior test (or a parallel process) fails HERE with a diagnosable message instead of as a
+    // baffling positive-control red deeper in the test.
+    const assertNoStaleBlocks = async (): Promise<void> => {
+      for (const s of [C_SRC, C_DEP, C_DEP2]) expect(await blockOf(s)).toBeNull()
+    }
     const rowOf = async (id: string): Promise<{ data: Record<string, unknown>; version: number; updatedAt: string }> => {
       const r = await q('SELECT data, version, updated_at FROM meta_records WHERE id = $1', [id])
       const row = r.rows[0] as { data: Record<string, unknown>; version: unknown; updated_at: Date }
@@ -716,7 +726,10 @@ describeIfDatabase('W0-1 L4cov — univer-meta/records/auto-number writer fence 
     })
 
     afterEach(async () => {
-      for (const s of [C_SRC, C_DEP, C_DEP2]) await setBlockFor(s, null).catch(() => {})
+      // Gate P2 hardening: clears fail LOUDLY (no catch-swallow) — a silently failed clear here is
+      // exactly the stale-block shape that would red a later test's POSITIVE control with a
+      // misleading message. The sheets exist for the whole suite, so a failure is a real defect.
+      for (const s of [C_SRC, C_DEP, C_DEP2]) await setBlockFor(s, null)
     })
 
     afterAll(async () => {
@@ -729,6 +742,7 @@ describeIfDatabase('W0-1 L4cov — univer-meta/records/auto-number writer fence 
     })
 
     test('C1 same-record: block ⇒ silent skip (no throw, no write, no echo); positive control materializes; flag-off parity', async () => {
+      await assertNoStaleBlocks()
       const SR1 = mkRecord('c1s1')
       const SR2 = mkRecord('c1s2')
       const DR = mkRecord('c1d')
@@ -770,9 +784,11 @@ describeIfDatabase('W0-1 L4cov — univer-meta/records/auto-number writer fence 
       )
       expect(parity).toEqual([{ recordId: DRB, data: { [F_DEP_SUM]: 10 } }])
       expect((await rowOf(DRB)).data[F_DEP_SUM]).toBe(10)
+      await setBlockFor(C_DEP, null) // belt-and-braces: don't rely on afterEach alone
     })
 
     test('C2 fan-out: block on ONE dependent sheet skips ONLY that sheet (200, source applied, healthy sheet materializes); flag-off parity', async () => {
+      await assertNoStaleBlocks()
       const SR1 = mkRecord('c2s1')
       const SR2 = mkRecord('c2s2')
       const DR = mkRecord('c2d')
@@ -821,9 +837,11 @@ describeIfDatabase('W0-1 L4cov — univer-meta/records/auto-number writer fence 
       const res3 = await patchVia(C_SRC, SR1, F_SRC_AMT, 31)
       expect(res3.status).toBe(200)
       expect((await rowOf(DR)).data[F_DEP_SUM]).toBe(231) // 31+200, despite the (inert) block
+      await setBlockFor(C_DEP, null) // belt-and-braces: don't rely on afterEach alone
     })
 
     test('C3 POST /patch primary-fence refusal maps to 409 RECOVERY_IN_PROGRESS (not 500); positive control; flag-off parity', async () => {
+      await assertNoStaleBlocks()
       const SR = mkRecord('c3s')
       await seedSrc(SR, 5)
 
@@ -852,6 +870,7 @@ describeIfDatabase('W0-1 L4cov — univer-meta/records/auto-number writer fence 
       const res3 = await patchVia(C_SRC, SR, F_SRC_AMT, 9)
       expect(res3.status).toBe(200)
       expect((await rowOf(SR)).data[F_SRC_AMT]).toBe(9)
+      await setBlockFor(C_SRC, null) // belt-and-braces: don't rely on afterEach alone
     })
   })
 })

--- a/packages/core-backend/tests/integration/multitable-l4cov-univer-meta-writers-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-l4cov-univer-meta-writers-realdb.test.ts
@@ -46,7 +46,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } fr
 import { poolManager } from '../../src/integration/db/connection-pool'
 import type { EventBus } from '../../src/integration/events/event-bus'
 import { RecordService } from '../../src/multitable/record-service'
-import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { recalculateFormulaFieldsForActor, univerMetaRouter } from '../../src/routes/univer-meta'
 import { deriveCapabilities } from '../../src/multitable/sheet-capabilities'
 import { createRecord as pluginCreateRecord } from '../../src/multitable/records'
 import { backfillAutoNumberField } from '../../src/multitable/auto-number-service'
@@ -606,22 +606,252 @@ describeIfDatabase('W0-1 L4cov — univer-meta/records/auto-number writer fence 
     await setBlock(null)
   })
 
-  // ── §C — POST-COMMIT derived-value recompute — ANALYZED, DEFERRED (documented). ─────────────────────────
-  // The relation-aggregation materialization (univer-meta.ts recalculateFormulaFields @≈2973 /
-  // computeDependentLookupRollupRecords @≈3869) and the pure-formula path (formula-engine.ts
-  // recalculateRecordFromData) run POST-COMMIT on a fresh pool connection: record-write-service.ts Step 4/4c
-  // call them with `this.pool.query.bind(this.pool)` AFTER the fenced write txn (line ≈776) has committed. BUT
-  // every one of those writes is an in-place `UPDATE meta_records SET data = data || …` — they emit NO
-  // meta_record_revisions row and allocate NO `seq` (verified: `revision-exempt` in-code + no INSERT into
-  // meta_record_revisions / nextval / chain_seq in formula-engine.ts). So the specific trust hole this lane
-  // targets (non-causal `seq`) is NOT present. A fence here would be behavior-changing (extend the fence-hold
-  // window across heavy recompute; the cross-sheet fan-out touches RELATED sheets and would need multi-sheet
-  // fences; and coupling the user write's durability to recompute success — today a recompute failure is logged
-  // and tolerated). Correct call: DEFER. This placeholder is skipped, not silently absent.
-  test.skip('C [post-commit recompute] DEFERRED — no seq allocated post-commit (in-place data only); see lane report', () => {
-    // Intentionally skipped. The analysis + decision live in the PR body / lane report (§C). If a future slice
-    // moves the recompute into the fenced txn, replace this with a golden proving the recompute\'s seq is
-    // allocated under the fence (causal). Until then, fencing it would be a wrong fence, not a fix.
-    expect(true).toBe(true)
+  // ── §C — POST-COMMIT derived-value recompute JOINS THE FENCE (relation-aggregation). ────────────────────
+  // Replaces the former DEFERRED skip. The post-merge review of #4438 ruled the deferral inconsistent: the
+  // engine's v2 fenced txn had already closed the pure-formula path, leaving the two relation-agg sites
+  // (same-record materialization in recalculateFormulaFields; dependent-sheet fan-out in
+  // computeDependentLookupRollupRecords) as the ONLY derived writers that could land inside a recovery's
+  // applying window and clobber just-recovered data. Both now route through the shared seam
+  // (`src/multitable/derived-write-fence.ts`); these are the behavioral proofs. Refusal semantics: a durable
+  // block on the sheet being written ⇒ SKIP the materialization AND its echo/invalidation ids (DB unchanged
+  // ⇒ nothing to invalidate), never fail the already-committed primary write; other dependent sheets keep
+  // materializing. The PRIMARY fence refusal (the write txn entry itself) maps to 409 RECOVERY_IN_PROGRESS
+  // at POST /patch (C3).
+  // Honest residuals (named, still true — deliberately NOT covered by these goldens):
+  //  (a) reads-outside-txn: the aggregation is computed from reads taken BEFORE the fenced write txn; a
+  //      recovery that starts AND finishes inside that gap clears the block, so a stale pre-recovery-derived
+  //      value can still commit (same engine-v2 posture, documented at the seam).
+  //  (b) no post-recovery re-trigger: a refused materialization stays stale until the next source edit
+  //      (relation-agg is materialize-model, not computed-on-read); includes the cliff `#ERROR!` writes that
+  //      ride the same UPDATE.
+  //  (c) these writes remain revision-exempt / no-seq — the lane's non-causal-seq trust hole is still absent
+  //      here; the fence closes the recovered-data CLOBBER hazard, not a history hazard.
+  //  (d) each fence+UPDATE is its own single-sheet short txn, so there is no multi-sheet fence ordering
+  //      today; if fan-out batching is ever introduced, the ordering question reopens.
+  describe('§C — relation-agg materialization joins the fence (shared derived-write seam)', () => {
+    const C_SRC = `sheet_l4cov_csrc_${TS}`
+    const C_DEP = `sheet_l4cov_cdep_${TS}`
+    const C_DEP2 = `sheet_l4cov_cdep2_${TS}`
+    const F_SRC_AMT = `fld_l4cov_camt_${TS}`
+    const F_SRC_STATUS = `fld_l4cov_cstat_${TS}`
+    const F_DEP_LINK = `fld_l4cov_cdlink_${TS}`
+    const F_DEP_CURVAL = `fld_l4cov_cdcur_${TS}`
+    const F_DEP_SUM = `fld_l4cov_cdsum_${TS}`
+    const F_DEP2_LINK = `fld_l4cov_cd2link_${TS}`
+    const F_DEP2_CURVAL = `fld_l4cov_cd2cur_${TS}`
+    const F_DEP2_SUM = `fld_l4cov_cd2sum_${TS}`
+    // The DIRECT recompute call (C1) resolves the actor DB-authoritatively (buildWriterTaintContext carries
+    // only the id — the Yjs-bridge shape), so this actor needs REAL stored perms, not req-carried ones:
+    // legacy users.permissions JSONB path, same as the w11 bridge-freshness suite.
+    const C_ACTOR = `u_l4cov_cactor_${TS}`
+
+    const relSumExpr = (linkFieldId: string, curvalFieldId: string) =>
+      `RELSUMIF("${linkFieldId}","${F_SRC_AMT}","${F_SRC_STATUS}","is",{${curvalFieldId}})`
+
+    const setBlockFor = async (sheetId: string, state: WriterBlockState | null) =>
+      q('UPDATE meta_sheets SET recovery_writer_state = $2 WHERE id = $1', [sheetId, state])
+    const rowOf = async (id: string): Promise<{ data: Record<string, unknown>; version: number; updatedAt: string }> => {
+      const r = await q('SELECT data, version, updated_at FROM meta_records WHERE id = $1', [id])
+      const row = r.rows[0] as { data: Record<string, unknown>; version: unknown; updated_at: Date }
+      expect(row).toBeTruthy()
+      return { data: row.data ?? {}, version: Number(row.version), updatedAt: new Date(row.updated_at).toISOString() }
+    }
+    const seedSrc = async (id: string, amt: number): Promise<void> => {
+      await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [
+        id, C_SRC, JSON.stringify({ [F_SRC_AMT]: amt, [F_SRC_STATUS]: 'paid' }), ACTOR,
+      ])
+    }
+    const seedDep = async (id: string, sheetId: string, linkFieldId: string, curvalFieldId: string, linkedIds: string[]): Promise<void> => {
+      await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [
+        id, sheetId, JSON.stringify({ [linkFieldId]: linkedIds, [curvalFieldId]: 'paid' }), ACTOR,
+      ])
+      for (const fr of linkedIds) {
+        await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [
+          `lnk_l4cov_${id}_${fr}`, linkFieldId, id, fr,
+        ])
+      }
+    }
+    const depFields = [
+      { id: F_DEP_LINK, name: 'CLink', type: 'link', property: { foreignSheetId: C_SRC }, order: 1 },
+      { id: F_DEP_CURVAL, name: 'CCur', type: 'string', property: {}, order: 2 },
+      { id: F_DEP_SUM, name: 'CSum', type: 'formula', property: { expression: relSumExpr(F_DEP_LINK, F_DEP_CURVAL) }, order: 3 },
+    ] as never
+    const patchVia = async (sheetId: string, recordId: string, fieldId: string, value: unknown) => {
+      actor = MEMBER
+      const cur = await q('SELECT version FROM meta_records WHERE id = $1', [recordId])
+      const expectedVersion = Number((cur.rows[0] as { version: unknown } | undefined)?.version ?? 1)
+      return request(app).post('/api/multitable/patch').send({
+        sheetId,
+        changes: [{ recordId, fieldId, value, expectedVersion }],
+      })
+    }
+
+    beforeAll(async () => {
+      await q(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+         VALUES ($1,$2,$1,'x','member',$3::jsonb, TRUE, FALSE)
+         ON CONFLICT (id) DO UPDATE SET permissions = EXCLUDED.permissions`,
+        [C_ACTOR, `${C_ACTOR}@example.test`, JSON.stringify(['multitable:read', 'multitable:write'])],
+      )
+      for (const [sid, name] of [[C_SRC, 'L4cov C Source'], [C_DEP, 'L4cov C Dependent'], [C_DEP2, 'L4cov C Dependent 2']] as const) {
+        await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [sid, BASE, name])
+      }
+      for (const [fid, sid, name, type, property, order] of [
+        [F_SRC_AMT, C_SRC, 'CAmt', 'number', '{}', 1],
+        [F_SRC_STATUS, C_SRC, 'CStatus', 'string', '{}', 2],
+        [F_DEP_LINK, C_DEP, 'CLink', 'link', JSON.stringify({ foreignSheetId: C_SRC }), 1],
+        [F_DEP_CURVAL, C_DEP, 'CCur', 'string', '{}', 2],
+        [F_DEP_SUM, C_DEP, 'CSum', 'formula', JSON.stringify({ expression: relSumExpr(F_DEP_LINK, F_DEP_CURVAL) }), 3],
+        [F_DEP2_LINK, C_DEP2, 'C2Link', 'link', JSON.stringify({ foreignSheetId: C_SRC }), 1],
+        [F_DEP2_CURVAL, C_DEP2, 'C2Cur', 'string', '{}', 2],
+        [F_DEP2_SUM, C_DEP2, 'C2Sum', 'formula', JSON.stringify({ expression: relSumExpr(F_DEP2_LINK, F_DEP2_CURVAL) }), 3],
+      ] as const) {
+        await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [
+          fid, sid, name, type, property, order,
+        ])
+      }
+      // Same-record recompute trigger (C1): the RELSUMIF depends on the current-record criteria field.
+      await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,NULL)', [C_DEP, F_DEP_SUM, F_DEP_CURVAL])
+      await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,NULL)', [C_DEP2, F_DEP2_SUM, F_DEP2_CURVAL])
+    })
+
+    afterEach(async () => {
+      for (const s of [C_SRC, C_DEP, C_DEP2]) await setBlockFor(s, null).catch(() => {})
+    })
+
+    afterAll(async () => {
+      await q('DELETE FROM formula_dependencies WHERE sheet_id = ANY($1::text[])', [[C_DEP, C_DEP2]]).catch(() => {})
+      await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[F_DEP_LINK, F_DEP2_LINK]]).catch(() => {})
+      await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[C_SRC, C_DEP, C_DEP2]]).catch(() => {})
+      await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[C_SRC, C_DEP, C_DEP2]]).catch(() => {})
+      await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[C_SRC, C_DEP, C_DEP2]]).catch(() => {})
+      await q('DELETE FROM users WHERE id = $1', [C_ACTOR]).catch(() => {})
+    })
+
+    test('C1 same-record: block ⇒ silent skip (no throw, no write, no echo); positive control materializes; flag-off parity', async () => {
+      const SR1 = mkRecord('c1s1')
+      const SR2 = mkRecord('c1s2')
+      const DR = mkRecord('c1d')
+      const DRB = mkRecord('c1db')
+      await seedSrc(SR1, 10)
+      await seedSrc(SR2, 20)
+      await seedDep(DR, C_DEP, F_DEP_LINK, F_DEP_CURVAL, [SR1, SR2])
+      await seedDep(DRB, C_DEP, F_DEP_LINK, F_DEP_CURVAL, [SR1])
+
+      // Leg 1 — flag ON + durable block on the DEP sheet: the DIRECT recompute entry (the Yjs-bridge shape,
+      // and the deterministic stand-in for the commit→recompute gap race) must NOT throw, NOT write, NOT echo.
+      process.env[FLAG] = 'true'
+      await setBlockFor(C_DEP, 'applying')
+      const before = await rowOf(DR)
+      expect(before.data).not.toHaveProperty(F_DEP_SUM)
+      const blocked = await recalculateFormulaFieldsForActor(
+        C_ACTOR, q as never, C_DEP, depFields, [DR], [F_DEP_CURVAL],
+      )
+      expect(blocked).toEqual([]) // no echo entry for a refused materialization
+      const afterBlocked = await rowOf(DR)
+      expect(afterBlocked.data).not.toHaveProperty(F_DEP_SUM) // zero write…
+      expect(afterBlocked.updatedAt).toBe(before.updatedAt) // …not even a touch (updated_at = now() is in the UPDATE)
+
+      // Leg 2 — positive control (flag ON, no block): the SAME call materializes 10+20=30. This also proves
+      // the direct-call chain is non-vacuous (C_ACTOR's DB-authoritative read really resolves — a taint-skip
+      // or perm failure would yield no value / '#PERM!' here, not 30).
+      await setBlockFor(C_DEP, null)
+      const ok = await recalculateFormulaFieldsForActor(
+        C_ACTOR, q as never, C_DEP, depFields, [DR], [F_DEP_CURVAL],
+      )
+      expect(ok).toEqual([{ recordId: DR, data: { [F_DEP_SUM]: 30 } }])
+      expect((await rowOf(DR)).data[F_DEP_SUM]).toBe(30)
+
+      // Leg 3 — flag-off parity: block present but flag OFF ⇒ byte-identical legacy write proceeds.
+      delete process.env[FLAG]
+      await setBlockFor(C_DEP, 'applying')
+      const parity = await recalculateFormulaFieldsForActor(
+        C_ACTOR, q as never, C_DEP, depFields, [DRB], [F_DEP_CURVAL],
+      )
+      expect(parity).toEqual([{ recordId: DRB, data: { [F_DEP_SUM]: 10 } }])
+      expect((await rowOf(DRB)).data[F_DEP_SUM]).toBe(10)
+    })
+
+    test('C2 fan-out: block on ONE dependent sheet skips ONLY that sheet (200, source applied, healthy sheet materializes); flag-off parity', async () => {
+      const SR1 = mkRecord('c2s1')
+      const SR2 = mkRecord('c2s2')
+      const DR = mkRecord('c2d')
+      const DR2 = mkRecord('c2d2')
+      await seedSrc(SR1, 10)
+      await seedSrc(SR2, 20)
+      await seedDep(DR, C_DEP, F_DEP_LINK, F_DEP_CURVAL, [SR1, SR2])
+      await seedDep(DR2, C_DEP2, F_DEP2_LINK, F_DEP2_CURVAL, [SR1, SR2])
+
+      // Leg 1 — positive control (flag ON, no block): editing the foreign TARGET field fans out to BOTH
+      // dependent sheets. 30+20 = 50.
+      process.env[FLAG] = 'true'
+      const res1 = await patchVia(C_SRC, SR1, F_SRC_AMT, 30)
+      expect(res1.status).toBe(200)
+      expect((await rowOf(DR)).data[F_DEP_SUM]).toBe(50)
+      expect((await rowOf(DR2)).data[F_DEP2_SUM]).toBe(50)
+
+      // Leg 2 — durable block on C_DEP ONLY: the source PATCH still succeeds (its own sheet is unblocked),
+      // the BLOCKED dependent sheet's materialization is refused (stale value + updated_at untouched, and
+      // its field id absent from the echo), while the HEALTHY dependent sheet still materializes. This leg
+      // also kills the wrong-sheet-key mutation (fencing sourceSheetId instead of the written sheet would
+      // see no block on C_SRC and write through).
+      await setBlockFor(C_DEP, 'applying')
+      const beforeDR = await rowOf(DR)
+      const res2 = await patchVia(C_SRC, SR2, F_SRC_AMT, 200)
+      expect(res2.status).toBe(200)
+      expect((await rowOf(SR2)).data[F_SRC_AMT]).toBe(200) // primary write applied
+      const afterDR = await rowOf(DR)
+      expect(afterDR.data[F_DEP_SUM]).toBe(50) // stale (30+200=230 was refused)
+      expect(afterDR.updatedAt).toBe(beforeDR.updatedAt) // zero write on the blocked sheet
+      expect((await rowOf(DR2)).data[F_DEP2_SUM]).toBe(230) // healthy sheet materialized
+      // Echo contract: the HTTP `relatedRecords` shape is {sheetId, recordId, data} (affectedFieldIds is
+      // internal fan-out metadata, "never part of the response contract" — record-write-service Step 5).
+      // The healthy sheet's record echoes its freshly materialized value; the BLOCKED sheet's record must
+      // NOT carry one (the DB did not change — a carried value would revert on reload).
+      const related = (res2.body?.data?.relatedRecords ?? []) as Array<{ recordId: string; data?: Record<string, unknown> }>
+      const echoDR = related.find((r) => r.recordId === DR)
+      if (echoDR) {
+        expect(echoDR.data ?? {}).not.toHaveProperty(F_DEP_SUM)
+      }
+      const echoDR2 = related.find((r) => r.recordId === DR2)
+      expect(echoDR2?.data?.[F_DEP2_SUM]).toBe(230)
+
+      // Leg 3 — flag-off parity: block still on C_DEP, flag OFF ⇒ the legacy bare write proceeds anyway.
+      delete process.env[FLAG]
+      const res3 = await patchVia(C_SRC, SR1, F_SRC_AMT, 31)
+      expect(res3.status).toBe(200)
+      expect((await rowOf(DR)).data[F_DEP_SUM]).toBe(231) // 31+200, despite the (inert) block
+    })
+
+    test('C3 POST /patch primary-fence refusal maps to 409 RECOVERY_IN_PROGRESS (not 500); positive control; flag-off parity', async () => {
+      const SR = mkRecord('c3s')
+      await seedSrc(SR, 5)
+
+      // Leg 1 — flag ON + durable block on the SOURCE sheet: the PRIMARY fenced write refuses at txn entry
+      // and the route maps it (previously an unmapped 500 INTERNAL_ERROR — the pre-existing gap the review
+      // named). Zero write.
+      process.env[FLAG] = 'true'
+      await setBlockFor(C_SRC, 'applying')
+      const before = await rowOf(SR)
+      const res1 = await patchVia(C_SRC, SR, F_SRC_AMT, 7)
+      expect(res1.status).toBe(409)
+      expect(res1.body?.error?.code).toBe('RECOVERY_IN_PROGRESS')
+      const after = await rowOf(SR)
+      expect(after.data[F_SRC_AMT]).toBe(5)
+      expect(after.version).toBe(before.version)
+
+      // Leg 2 — positive control: clear the block ⇒ the same patch succeeds.
+      await setBlockFor(C_SRC, null)
+      const res2 = await patchVia(C_SRC, SR, F_SRC_AMT, 7)
+      expect(res2.status).toBe(200)
+      expect((await rowOf(SR)).data[F_SRC_AMT]).toBe(7)
+
+      // Leg 3 — flag-off parity: block present but flag OFF ⇒ inert, the write proceeds.
+      delete process.env[FLAG]
+      await setBlockFor(C_SRC, 'applying')
+      const res3 = await patchVia(C_SRC, SR, F_SRC_AMT, 9)
+      expect(res3.status).toBe(200)
+      expect((await rowOf(SR)).data[F_SRC_AMT]).toBe(9)
+    })
   })
 })

--- a/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
@@ -92,9 +92,10 @@ const ALLOWLIST: Record<string, { disposition: 'CHOKEPOINT' | 'SAFE'; reason: st
     disposition: 'SAFE',
     reason: 'T3-6 read-model projection writes ONLY the fixed system columns (requestNo/templateId/name/status/outcome/requesterId/approverId/timestamps/currentNodeKey) derived from approval_instances+approval_records — never form_snapshot or a user-supplied rich-longText carrier',
   },
-  'multitable/formula-engine.ts': {
+  'multitable/derived-write-fence.ts': {
     disposition: 'SAFE',
-    reason: 'writes ONLY computed formula-result keys — derived server-side, never raw user HTML',
+    reason:
+      'the SHARED flag-gated fence+UPDATE seam for derived-value materializations (formula engine + the univer-meta relation-agg resolvers route through it since the #4438 post-merge follow-up) — writes ONLY computed formula/relation-agg result keys, derived server-side, never raw user HTML',
   },
   'multitable/automation-service.ts': {
     disposition: 'SAFE',


### PR DESCRIPTION
## What (post-merge review of #4438, owner 2026-07-17 — High + Low×2)

The #4438 v2 TOCTOU fix fenced **only** the pure-formula engine write. The review found the two **relation-aggregation materializations** in `routes/univer-meta.ts` (same-record recompute in `recalculateFormulaFields`; dependent-sheet fan-out in `computeDependentLookupRollupRecords`) still ran bare autocommit `UPDATE meta_records SET data = data || …` — no fence, no block-check, same clobber hazard class the engine fix documents. #4438 merged before the verdict landed, so this is the fix as a follow-up on main.

- **NEW `src/multitable/derived-write-fence.ts`** — the ONE shared, flag-gated fence+UPDATE seam for derived-value merges. Flag ON: fence+UPDATE in its own short txn (`pg_advisory_xact_lock` held to COMMIT). Flag OFF: **byte-identical** legacy write on the caller's query (mocks honored). Engine + both relation-agg sites route through it — the discipline can't drift apart again.
- **Refusal semantics** (review-mandated, not polish): at both sites `SheetWriterBlockedError` is an *expected operational condition* — the primary write already committed. Catch → values-free warn → skip the materialization **and** its echo (DB unchanged ⇒ nothing to invalidate) → latch the sheet; other dependent sheets + Steps 5-7 continue. Without this, a recovery block on ONE dependent sheet would 500 the whole committed PATCH post-commit. Fan-out fences the **dependent sheet being written** (loop `sheetId`, not `sourceSheetId`).
- **POST /patch 409 mapping** — the PRIMARY fence refusal (record-write-service txn entry) previously fell through to 500 INTERNAL_ERROR; now maps to the same `409 RECOVERY_IN_PROGRESS` shape as the reset/revert/config-restore routes.
- **§C goldens replace the stale DEFERRED skip** (its prose was wrong on two counts: the engine path *is* fenced since v2, and "recompute failure is logged and tolerated" was false for the patch spine): C1 same-record (block ⇒ silent skip, zero write incl. `updated_at`, no echo + positive control + flag-off parity) · C2 fan-out (block on ONE dependent sheet skips only that sheet; healthy second sheet materializes; parity) · C3 (409 mapping + zero write + parity).
- **F2 precision (review Low-1)**: waiter detection now attributes to the holder via `pg_blocking_pids` polled on the poolManager channel — the raw internal-pool client's `pg_stat_activity` view is permission-masked (reads "no waiter" forever; `pg_locks` had hidden this) — plus failure-path `ROLLBACK` before `release()` so a red assertion can no longer poison the suite with an idle-in-transaction fence holder.
- richtext write-sink guard allowlist: `formula-engine.ts` entry replaced by the new seam file (the UPDATE moved).

## Verification (local, CI-parity: fresh DB + `db:migrate` w/ CI MIGRATION_EXCLUDE)

- tsc 0 · **l4cov suites 43/43** · **12 adjacent realdb suites 116/116** (incl. GF8 bulk-recompute partial-progress contract, w11 bridge freshness, L4 canonical fence, relation-agg + crossbase + echo-mask suites) · **full unit run 485 files green** (structural guards: record-lock, revision-disposition, taint-chokepoint, bridge-wiring, raw-projection, richtext write-sink).
- **Mutation matrix** (each applied ⇒ exact reds ⇒ restored):
  | mutation | reds |
  |---|---|
  | M-A remove `fenceWriterEntry` from the seam | C1+C2+F1+F2 |
  | M-B1 fan-out passes `sourceSheetId` to the seam | C2 |
  | M-B2 fence consulted for the WRONG sheet (write key unchanged) | C1+C2+F1+F2 |
  | M-C tolerance catch removed | C1+C2 |
  | M-D 409 mapping removed | C3 |

## Honest residuals (named, unchanged by this PR)

- **reads-outside-txn** (engine-v2 posture): aggregation inputs are read before the fenced txn; a recovery that starts *and finishes* in that gap clears the block, so a stale derived value can still commit. Bounded: derived-only, self-heals on next recompute, no PIT impact (revision-exempt/no-seq).
- **No post-recovery re-trigger**: a refused materialization stays stale until the next source edit (materialize-model), incl. the cliff `#ERROR!` writes.
- **Torn per-record materialization**: with both pure formulas and relation-agg on one record, the engine txn and the seam txn are separate — a block claimed between them lands the pure values and refuses the relagg one. Each value is independently derived; named, not fixed.
- **409 mapping scope**: only POST /patch gained the mapping (golden-backed). The restore route and the AI-shortcut run route still surface a primary-fence refusal as 500 — named gap, not silently inherited.
- **Sweep finding beyond the review (follow-up candidates, NOT touched here)**: an exhaustive writer sweep found three more system writes that bypass the fence when the flag is ON — the People-sheet directory sync INSERT/UPDATE (`ensurePeopleSheetPreset`, transactional but never fenced) and the `createSeededSheet` demo-record INSERT (reachable against a pre-existing sheet via `GET /view?seed=true`). Low-risk system/demo writes, but they violate the uniform all-writer discipline; fencing them deserves its own slice with route-driven goldens rather than untested rider code here.

Flag `MULTITABLE_ENABLE_WRITER_FENCE` stays **default-OFF**; flag-off behavior is byte-identical at every touched site. Not armed — owner merge decision, per line discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)