### PR TITLE
feat(directory): T1 — fail-closed provider org-transfer schema and admin API

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -204,6 +204,12 @@ jobs:
       - name: B7 round-2 CI wiring contract
         run: node --test scripts/ops/b7-round2-ci-wiring.test.mjs
 
+      # T1 CI two-point wiring contract (no DB): the provider-org-transfer suite must stay wired
+      # into BOTH vitest.config.ts (exclude) AND plugin-tests.yml (directory real-DB step).
+      # Dropping either point silently disables the transfer state-machine + FK-backstop proof.
+      - name: T1 org-transfer CI wiring contract
+        run: node --test scripts/ops/t1-org-transfer-ci-wiring.test.mjs
+
       # The production monitor invokes the same state helper covered here.
       # Keep this in the required 18/20 matrix so HTTP classification, silence
       # barriers, and alert/recovery streak semantics cannot drift silently.
@@ -685,6 +691,7 @@ jobs:
             tests/integration/org-directory-routing-policy-routes.db.test.ts \
             tests/integration/directory-binding-reconciliation.db.test.ts \
             tests/integration/directory-binding-admin-routes.db.test.ts \
+            tests/integration/provider-org-transfer-t1.api.test.ts \
             tests/integration/directory-normalized-manager.db.test.ts \
             tests/integration/attendance-csv-export-bom.test.ts \
             tests/integration/attendance-notification-redelivery.db.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260717120000_create_provider_org_transfers.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260717120000_create_provider_org_transfers.ts
@@ -1,0 +1,164 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * Transfer MVP — T1 (schema), Canonical Org & Provider Transfer v1 sequencing plan §2 row T1;
+ * data model per `provider-org-transfer-development-plan-20260709.md` §7.1/§7.2.
+ *
+ * `provider_org_transfers` is the explicit transfer record (never ad-hoc JSON on integration
+ * rows, and NEVER a direct `corp_id` edit — §12.1 made corp_id immutable). Two schema-level
+ * guarantees are borrowed from the B4 binding-table doctrine (constraints in the schema, not
+ * service convention):
+ *
+ *   - **Cross-org transfer is FK-impossible**: the row carries ONE `org_id` column and BOTH
+ *     integration ids are FK'd to `directory_integrations (id, org_id)` against that same
+ *     column. A source in org A and a target in org B leaves no satisfying `org_id` value.
+ *     (Holds because every FK-participating column is NOT NULL — MATCH SIMPLE would skip the
+ *     check on any NULL.)
+ *   - **Provider mismatch is FK-impossible**: both integration ids are also FK'd to
+ *     `directory_integrations (id, provider)` against the row's single `provider` column, so
+ *     both ends must BE the transfer's provider; `CHECK (provider <> 'local')` additionally
+ *     rules out a local end (a transfer moves between EXTERNAL provider tenants — the local
+ *     canonical org is the anchor that never moves).
+ *
+ * Transfer FKs are deliberately NOT ON DELETE CASCADE (unlike B4's bindings): a transfer row is
+ * an auditable history record referencing two integrations; default NO ACTION blocks a hard
+ * integration delete while transfer history references it (archive-not-delete makes this rare).
+ *
+ * The "at most one ACTIVE transfer per source integration" rule (§7.1) is a partial unique
+ * index over non-terminal statuses — it also caps the per-pair rule. `dry_run_at` is additive
+ * to §7.1: §12.3 (dry-run required) needs a durable "a dry-run happened since the last scan"
+ * marker the apply guard can check; scan clears it.
+ *
+ * The two parent-side UNIQUE constraints referenced here were introduced by the B4 migration
+ * (`zzzz20260717100000`); the guarded ADD CONSTRAINT blocks are repeated verbatim so this
+ * migration is also self-sufficient in isolated schemas that replay a subset (probe pinned to
+ * conname + conrelid + contype, mirroring B4). `directory_integrations` is created by a zzzz
+ * migration, so this MUST also be zzzz-prefixed.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+         WHERE conname = 'uq_directory_integrations_id_org'
+           AND conrelid = 'directory_integrations'::regclass
+           AND contype = 'u'
+      ) THEN
+        ALTER TABLE directory_integrations
+        ADD CONSTRAINT uq_directory_integrations_id_org UNIQUE (id, org_id);
+      END IF;
+    END $$;
+  `.execute(db)
+
+  await sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+         WHERE conname = 'uq_directory_integrations_id_provider'
+           AND conrelid = 'directory_integrations'::regclass
+           AND contype = 'u'
+      ) THEN
+        ALTER TABLE directory_integrations
+        ADD CONSTRAINT uq_directory_integrations_id_provider UNIQUE (id, provider);
+      END IF;
+    END $$;
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS provider_org_transfers (
+      id                     uuid        NOT NULL DEFAULT gen_random_uuid(),
+      org_id                 text        NOT NULL,
+      provider               text        NOT NULL,
+      source_integration_id  uuid        NOT NULL,
+      target_integration_id  uuid        NOT NULL,
+      source_tenant_key      text,
+      target_tenant_key      text,
+      status                 text        NOT NULL DEFAULT 'draft',
+      freeze_source_sync     boolean     NOT NULL DEFAULT true,
+      dry_run_stats          jsonb       NOT NULL DEFAULT '{}'::jsonb,
+      dry_run_at             timestamptz,
+      -- §7.1 sketches uuid here, but this codebase's users.id is TEXT — created_by records the
+      -- acting platform admin's user id, so it must match that type.
+      created_by             text,
+      created_at             timestamptz NOT NULL DEFAULT now(),
+      updated_at             timestamptz NOT NULL DEFAULT now(),
+      scanned_at             timestamptz,
+      applied_at             timestamptz,
+      cancelled_at           timestamptz,
+      last_error             text,
+
+      CONSTRAINT provider_org_transfers_pkey PRIMARY KEY (id),
+
+      CONSTRAINT pot_status_chk CHECK (status IN ('draft', 'scanned', 'applying', 'applied', 'cancelled', 'failed')),
+      CONSTRAINT pot_distinct_ends_chk CHECK (source_integration_id <> target_integration_id),
+      CONSTRAINT pot_provider_not_local_chk CHECK (provider <> 'local'),
+
+      CONSTRAINT pot_source_org_fk FOREIGN KEY (source_integration_id, org_id)
+        REFERENCES directory_integrations (id, org_id),
+      CONSTRAINT pot_target_org_fk FOREIGN KEY (target_integration_id, org_id)
+        REFERENCES directory_integrations (id, org_id),
+
+      CONSTRAINT pot_source_provider_fk FOREIGN KEY (source_integration_id, provider)
+        REFERENCES directory_integrations (id, provider),
+      CONSTRAINT pot_target_provider_fk FOREIGN KEY (target_integration_id, provider)
+        REFERENCES directory_integrations (id, provider)
+    )
+  `.execute(db)
+
+  // At most one ACTIVE (non-terminal) transfer per source integration; this also caps the
+  // per-(source,target) pair rule. 'applied' and 'cancelled' are the two terminal statuses.
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_pot_active_source
+    ON provider_org_transfers (source_integration_id)
+    WHERE status NOT IN ('applied', 'cancelled')
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_pot_org ON provider_org_transfers (org_id)
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_pot_target ON provider_org_transfers (target_integration_id)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS provider_org_transfer_decisions (
+      id                  uuid        NOT NULL DEFAULT gen_random_uuid(),
+      transfer_id         uuid        NOT NULL,
+      binding_kind        text        NOT NULL,
+      source_anchor_type  text        NOT NULL,
+      source_anchor_id    text        NOT NULL,
+      source_handle       jsonb       NOT NULL DEFAULT '{}'::jsonb,
+      proposed_target     jsonb       NOT NULL DEFAULT '{}'::jsonb,
+      decision            text        NOT NULL DEFAULT 'pending',
+      apply_status        text        NOT NULL DEFAULT 'pending',
+      -- text for the same users.id-type reason as provider_org_transfers.created_by.
+      decided_by          text,
+      decided_at          timestamptz,
+      applied_at          timestamptz,
+      apply_attempts      integer     NOT NULL DEFAULT 0,
+      last_error          text,
+      created_at          timestamptz NOT NULL DEFAULT now(),
+      updated_at          timestamptz NOT NULL DEFAULT now(),
+
+      CONSTRAINT provider_org_transfer_decisions_pkey PRIMARY KEY (id),
+
+      CONSTRAINT potd_transfer_fk FOREIGN KEY (transfer_id)
+        REFERENCES provider_org_transfers (id) ON DELETE CASCADE,
+
+      CONSTRAINT potd_decision_chk CHECK (decision IN ('pending', 'rebind', 'drop', 'skip')),
+      CONSTRAINT potd_apply_status_chk CHECK (apply_status IN ('pending', 'applied', 'failed', 'skipped')),
+
+      CONSTRAINT potd_anchor_uniq UNIQUE (transfer_id, binding_kind, source_anchor_type, source_anchor_id)
+    )
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Decisions first (FK), then transfers. The two parent UNIQUE constraints on
+  // directory_integrations are owned by the B4 migration's down() — not dropped here.
+  await sql`DROP TABLE IF EXISTS provider_org_transfer_decisions`.execute(db)
+  await sql`DROP TABLE IF EXISTS provider_org_transfers`.execute(db)
+}

--- a/packages/core-backend/src/directory/org-transfer-service.ts
+++ b/packages/core-backend/src/directory/org-transfer-service.ts
@@ -2,10 +2,13 @@
  * Transfer MVP — T1 (service), Canonical Org & Provider Transfer v1 sequencing plan §2 row T1;
  * API/data model per `provider-org-transfer-development-plan-20260709.md` §6.3 + §7.
  *
- * Lifecycle skeleton over `provider_org_transfers` / `provider_org_transfer_decisions` with a
- * NO-OP binding adapter: T1 proves the state machine, guards, and audit surface — it writes
- * NOTHING to any `directory_*` table (the T1 suite pins that with a fingerprint test). T3/T4
- * replace `noopOrgTransferAdapter` through the `OrgTransferBindingAdapter` seam.
+ * Lifecycle skeleton over `provider_org_transfers` / `provider_org_transfer_decisions`. Scan and
+ * apply are FAIL-CLOSED when no binding adapter is registered for the transfer's provider:
+ * production never falls back to a silent no-op. The exported `noopOrgTransferAdapter` exists
+ * only for explicit test registration (see `registerOrgTransferAdapter` /
+ * `unregisterOrgTransferAdapter`); T3/T4 register real adapters through the same seam. The T1
+ * suite registers the no-op for happy-path lifecycle proofs and pins that apply writes NOTHING
+ * to any `directory_*` table (fingerprint test).
  *
  * State machine (no stuck absorbing non-terminal state):
  *
@@ -13,11 +16,13 @@
  *   scan:    'draft' | 'scanned' | 'failed' → 'scanned'   (idempotent re-scan; 'failed' → scan
  *            is the recovery edge that keeps 'failed' non-absorbing; wipes + regenerates the
  *            decision set and INVALIDATES any prior dry-run: dry_run_at ← NULL)
+ *            Missing adapter → 409 ORG_TRANSFER_ADAPTER_UNAVAILABLE; row unchanged
  *   dry-run: 'scanned' → 'scanned'                        (pure read + stats write; sets dry_run_at)
  *   apply:   'scanned' + dry_run_at IS NOT NULL + zero undecided decisions → 'applied'
- *            ('applying' is in the status domain for T3+'s multi-transaction apply; T1's no-op
- *            apply commits 'scanned' → 'applied' in one transaction, so 'applying' is never
- *            observable here)
+ *            ('applying' is in the status domain for T3+'s multi-transaction apply; with the
+ *            test-registered no-op, apply commits 'scanned' → 'applied' in one transaction, so
+ *            'applying' is never observable here)
+ *            Missing adapter → 409 ORG_TRANSFER_ADAPTER_UNAVAILABLE; row unchanged
  *   cancel:  any non-terminal ('draft' | 'scanned' | 'applying' | 'failed') → 'cancelled'
  *
  * Every transition runs in ONE transaction with `SELECT … FOR UPDATE` on the transfer row —
@@ -61,6 +66,7 @@ export type OrgTransferConflictCode =
   | 'ORG_TRANSFER_INVALID_STATE'
   | 'ORG_TRANSFER_DRY_RUN_REQUIRED'
   | 'ORG_TRANSFER_DECISIONS_PENDING'
+  | 'ORG_TRANSFER_ADAPTER_UNAVAILABLE'
 
 export type OrgTransferStatus = 'draft' | 'scanned' | 'applying' | 'applied' | 'cancelled' | 'failed'
 
@@ -140,7 +146,7 @@ const TRANSFER_COLUMNS =
   'dry_run_stats, dry_run_at, created_by, created_at, updated_at, scanned_at, applied_at, cancelled_at, last_error'
 
 // ---------------------------------------------------------------------------------------------
-// Binding adapter seam (T3/T4 replace the no-op)
+// Binding adapter seam (T3/T4 register provider adapters)
 // ---------------------------------------------------------------------------------------------
 
 /** A provider binding surfaced by scan — becomes one decision row. */
@@ -156,13 +162,18 @@ export interface OrgTransferBindingAdapter {
   /** Enumerate the source integration's bindings that a transfer must decide on. */
   scanBindings(transfer: OrgTransferSummary): Promise<ScannedOrgTransferBinding[]>
   /**
-   * Apply decided decisions. T1's no-op adapter performs no writes; T3/T4 implementations
-   * receive the transfer and do their own per-decision transactional work.
+   * Apply decided decisions. The explicit test-registered no-op performs no writes; T3/T4
+   * implementations receive the transfer and do their own per-decision transactional work.
    */
   applyDecisions(transfer: OrgTransferSummary): Promise<{ applied: number }>
 }
 
-/** T1: the explicit no-op — scan finds nothing, apply touches nothing. */
+/**
+ * Explicit no-op — scan finds nothing, apply touches nothing.
+ * NOT a production fallback: only reachable via `registerOrgTransferAdapter` (tests / future
+ * deliberate wiring). Production scan/apply on an unregistered provider fails closed with
+ * `ORG_TRANSFER_ADAPTER_UNAVAILABLE`.
+ */
 export const noopOrgTransferAdapter: OrgTransferBindingAdapter = {
   async scanBindings(): Promise<ScannedOrgTransferBinding[]> {
     return []
@@ -174,13 +185,32 @@ export const noopOrgTransferAdapter: OrgTransferBindingAdapter = {
 
 const adapterRegistry = new Map<string, OrgTransferBindingAdapter>()
 
-/** T3/T4 register real adapters per provider; unknown providers fall back to the no-op. */
+/** T3/T4 (and tests) register adapters per provider. There is no silent no-op fallback. */
 export function registerOrgTransferAdapter(provider: string, adapter: OrgTransferBindingAdapter): void {
   adapterRegistry.set(provider, adapter)
 }
 
+/**
+ * Remove a previously registered adapter. Tests MUST call this in deterministic cleanup
+ * (afterEach / afterAll) so registry state cannot leak across suites.
+ */
+export function unregisterOrgTransferAdapter(provider: string): void {
+  adapterRegistry.delete(provider)
+}
+
+/**
+ * Resolve the binding adapter for a provider. Fail-closed: missing registration throws a typed
+ * conflict so scan/apply leave the transfer row, decisions, and success audits untouched.
+ */
 function adapterFor(provider: string): OrgTransferBindingAdapter {
-  return adapterRegistry.get(provider) ?? noopOrgTransferAdapter
+  const adapter = adapterRegistry.get(provider)
+  if (!adapter) {
+    throw new OrgTransferConflictError(
+      'ORG_TRANSFER_ADAPTER_UNAVAILABLE',
+      `no org-transfer binding adapter is registered for provider ${provider}`
+    )
+  }
+  return adapter
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -400,8 +430,9 @@ export async function applyOrgTransfer(transferId: string): Promise<OrgTransferS
       )
     }
 
-    // T1: the no-op adapter applies zero decisions and writes nothing; 'applying' never becomes
-    // observable because the flip to 'applied' commits in this same transaction (see header).
+    // With a registered no-op, apply commits zero decisions and writes nothing; 'applying' never
+    // becomes observable because the flip to 'applied' commits in this same transaction (see header).
+    // Missing adapter throws before this write — state stays scanned.
     await adapterFor(row.provider).applyDecisions(toSummary(row))
 
     const updated = await client.query(

--- a/packages/core-backend/src/directory/org-transfer-service.ts
+++ b/packages/core-backend/src/directory/org-transfer-service.ts
@@ -1,0 +1,436 @@
+/**
+ * Transfer MVP — T1 (service), Canonical Org & Provider Transfer v1 sequencing plan §2 row T1;
+ * API/data model per `provider-org-transfer-development-plan-20260709.md` §6.3 + §7.
+ *
+ * Lifecycle skeleton over `provider_org_transfers` / `provider_org_transfer_decisions` with a
+ * NO-OP binding adapter: T1 proves the state machine, guards, and audit surface — it writes
+ * NOTHING to any `directory_*` table (the T1 suite pins that with a fingerprint test). T3/T4
+ * replace `noopOrgTransferAdapter` through the `OrgTransferBindingAdapter` seam.
+ *
+ * State machine (no stuck absorbing non-terminal state):
+ *
+ *   create → 'draft'
+ *   scan:    'draft' | 'scanned' | 'failed' → 'scanned'   (idempotent re-scan; 'failed' → scan
+ *            is the recovery edge that keeps 'failed' non-absorbing; wipes + regenerates the
+ *            decision set and INVALIDATES any prior dry-run: dry_run_at ← NULL)
+ *   dry-run: 'scanned' → 'scanned'                        (pure read + stats write; sets dry_run_at)
+ *   apply:   'scanned' + dry_run_at IS NOT NULL + zero undecided decisions → 'applied'
+ *            ('applying' is in the status domain for T3+'s multi-transaction apply; T1's no-op
+ *            apply commits 'scanned' → 'applied' in one transaction, so 'applying' is never
+ *            observable here)
+ *   cancel:  any non-terminal ('draft' | 'scanned' | 'applying' | 'failed') → 'cancelled'
+ *
+ * Every transition runs in ONE transaction with `SELECT … FOR UPDATE` on the transfer row —
+ * write-point enforcement, not check-then-write (the PB4-2 doctrine): a concurrent
+ * apply/apply or apply/cancel pair linearizes on the row lock and the loser gets a clean 409.
+ *
+ * Like `local-directory-org.ts`, every function takes explicit ids; org identity is NEVER a
+ * caller input — the transfer's `org_id` is derived server-side from the two integration rows
+ * (which must agree), and the schema's composite FKs make a cross-org or provider-mismatched
+ * row impossible to INSERT even if this validation were bypassed.
+ */
+
+import { query, transaction } from '../db/pg'
+
+export class OrgTransferValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'OrgTransferValidationError'
+  }
+}
+
+export class OrgTransferNotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'OrgTransferNotFoundError'
+  }
+}
+
+/** 409-mapped conflicts carry a stable machine code the route layer surfaces verbatim. */
+export class OrgTransferConflictError extends Error {
+  readonly code: OrgTransferConflictCode
+  constructor(code: OrgTransferConflictCode, message: string) {
+    super(message)
+    this.name = 'OrgTransferConflictError'
+    this.code = code
+  }
+}
+
+export type OrgTransferConflictCode =
+  | 'ORG_TRANSFER_ACTIVE_EXISTS'
+  | 'ORG_TRANSFER_INVALID_STATE'
+  | 'ORG_TRANSFER_DRY_RUN_REQUIRED'
+  | 'ORG_TRANSFER_DECISIONS_PENDING'
+
+export type OrgTransferStatus = 'draft' | 'scanned' | 'applying' | 'applied' | 'cancelled' | 'failed'
+
+const NON_TERMINAL_STATUSES: readonly OrgTransferStatus[] = ['draft', 'scanned', 'applying', 'failed']
+const SCANNABLE_STATUSES: readonly OrgTransferStatus[] = ['draft', 'scanned', 'failed']
+
+export interface OrgTransferSummary {
+  id: string
+  orgId: string
+  provider: string
+  sourceIntegrationId: string
+  targetIntegrationId: string
+  status: OrgTransferStatus
+  freezeSourceSync: boolean
+  dryRunStats: Record<string, unknown>
+  dryRunAt: string | null
+  createdBy: string | null
+  createdAt: string
+  updatedAt: string
+  scannedAt: string | null
+  appliedAt: string | null
+  cancelledAt: string | null
+  lastError: string | null
+}
+
+interface OrgTransferRow {
+  id: string
+  org_id: string
+  provider: string
+  source_integration_id: string
+  target_integration_id: string
+  status: OrgTransferStatus
+  freeze_source_sync: boolean
+  dry_run_stats: Record<string, unknown>
+  dry_run_at: Date | string | null
+  created_by: string | null
+  created_at: Date | string
+  updated_at: Date | string
+  scanned_at: Date | string | null
+  applied_at: Date | string | null
+  cancelled_at: Date | string | null
+  last_error: string | null
+}
+
+function toIso(value: Date | string | null): string | null {
+  if (value === null) return null
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString()
+}
+
+function toSummary(row: OrgTransferRow): OrgTransferSummary {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    provider: row.provider,
+    sourceIntegrationId: row.source_integration_id,
+    targetIntegrationId: row.target_integration_id,
+    status: row.status,
+    freezeSourceSync: row.freeze_source_sync,
+    dryRunStats: row.dry_run_stats ?? {},
+    dryRunAt: toIso(row.dry_run_at),
+    createdBy: row.created_by,
+    createdAt: toIso(row.created_at) as string,
+    updatedAt: toIso(row.updated_at) as string,
+    scannedAt: toIso(row.scanned_at),
+    appliedAt: toIso(row.applied_at),
+    cancelledAt: toIso(row.cancelled_at),
+    lastError: row.last_error,
+  }
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { code?: unknown }).code === '23505'
+}
+
+const TRANSFER_COLUMNS =
+  'id, org_id, provider, source_integration_id, target_integration_id, status, freeze_source_sync, ' +
+  'dry_run_stats, dry_run_at, created_by, created_at, updated_at, scanned_at, applied_at, cancelled_at, last_error'
+
+// ---------------------------------------------------------------------------------------------
+// Binding adapter seam (T3/T4 replace the no-op)
+// ---------------------------------------------------------------------------------------------
+
+/** A provider binding surfaced by scan — becomes one decision row. */
+export interface ScannedOrgTransferBinding {
+  bindingKind: string
+  sourceAnchorType: string
+  sourceAnchorId: string
+  /** Masked provider metadata ONLY — never raw secrets (§7.2). */
+  sourceHandle: Record<string, unknown>
+}
+
+export interface OrgTransferBindingAdapter {
+  /** Enumerate the source integration's bindings that a transfer must decide on. */
+  scanBindings(transfer: OrgTransferSummary): Promise<ScannedOrgTransferBinding[]>
+  /**
+   * Apply decided decisions. T1's no-op adapter performs no writes; T3/T4 implementations
+   * receive the transfer and do their own per-decision transactional work.
+   */
+  applyDecisions(transfer: OrgTransferSummary): Promise<{ applied: number }>
+}
+
+/** T1: the explicit no-op — scan finds nothing, apply touches nothing. */
+export const noopOrgTransferAdapter: OrgTransferBindingAdapter = {
+  async scanBindings(): Promise<ScannedOrgTransferBinding[]> {
+    return []
+  },
+  async applyDecisions(): Promise<{ applied: number }> {
+    return { applied: 0 }
+  },
+}
+
+const adapterRegistry = new Map<string, OrgTransferBindingAdapter>()
+
+/** T3/T4 register real adapters per provider; unknown providers fall back to the no-op. */
+export function registerOrgTransferAdapter(provider: string, adapter: OrgTransferBindingAdapter): void {
+  adapterRegistry.set(provider, adapter)
+}
+
+function adapterFor(provider: string): OrgTransferBindingAdapter {
+  return adapterRegistry.get(provider) ?? noopOrgTransferAdapter
+}
+
+// ---------------------------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------------------------
+
+export interface CreateOrgTransferInput {
+  provider: string
+  sourceIntegrationId: string
+  targetIntegrationId: string
+  createdBy: string
+}
+
+interface IntegrationEndRow {
+  id: string
+  org_id: string
+  provider: string
+  corp_id: string | null
+}
+
+export async function createOrgTransfer(input: CreateOrgTransferInput): Promise<OrgTransferSummary> {
+  const provider = input.provider.trim()
+  if (provider.length === 0) {
+    throw new OrgTransferValidationError('provider is required')
+  }
+  if (provider === 'local') {
+    throw new OrgTransferValidationError('a transfer moves between external provider tenants; provider cannot be local')
+  }
+  if (input.sourceIntegrationId === input.targetIntegrationId) {
+    throw new OrgTransferValidationError('source and target integrations must differ')
+  }
+
+  const ends = await query<IntegrationEndRow>(
+    `SELECT id, org_id, provider, corp_id FROM directory_integrations WHERE id = ANY($1::uuid[])`,
+    [[input.sourceIntegrationId, input.targetIntegrationId]]
+  )
+  const source = ends.rows.find((r) => r.id === input.sourceIntegrationId)
+  const target = ends.rows.find((r) => r.id === input.targetIntegrationId)
+  if (!source) throw new OrgTransferNotFoundError('source integration not found')
+  if (!target) throw new OrgTransferNotFoundError('target integration not found')
+  if (source.provider !== provider || target.provider !== provider) {
+    throw new OrgTransferValidationError('both integrations must belong to the requested provider')
+  }
+  if (source.org_id !== target.org_id) {
+    throw new OrgTransferValidationError('source and target integrations must belong to the same org')
+  }
+
+  try {
+    const inserted = await query<OrgTransferRow>(
+      `INSERT INTO provider_org_transfers
+         (org_id, provider, source_integration_id, target_integration_id, source_tenant_key, target_tenant_key, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING ${TRANSFER_COLUMNS}`,
+      [source.org_id, provider, source.id, target.id, source.corp_id, target.corp_id, input.createdBy]
+    )
+    return toSummary(inserted.rows[0])
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new OrgTransferConflictError(
+        'ORG_TRANSFER_ACTIVE_EXISTS',
+        'an active transfer already exists for this source integration'
+      )
+    }
+    throw error
+  }
+}
+
+export interface OrgTransferDetail {
+  transfer: OrgTransferSummary
+  decisionCounts: { total: number; pending: number }
+}
+
+export async function getOrgTransfer(transferId: string): Promise<OrgTransferDetail> {
+  const result = await query<OrgTransferRow>(
+    `SELECT ${TRANSFER_COLUMNS} FROM provider_org_transfers WHERE id = $1`,
+    [transferId]
+  )
+  if (result.rows.length === 0) throw new OrgTransferNotFoundError('transfer not found')
+  const counts = await query<{ total: string; pending: string }>(
+    `SELECT count(*)::text AS total,
+            count(*) FILTER (WHERE decision = 'pending')::text AS pending
+       FROM provider_org_transfer_decisions WHERE transfer_id = $1`,
+    [transferId]
+  )
+  return {
+    transfer: toSummary(result.rows[0]),
+    decisionCounts: {
+      total: Number(counts.rows[0].total),
+      pending: Number(counts.rows[0].pending),
+    },
+  }
+}
+
+/** Locks the transfer row inside the caller's transaction; 404s when missing. */
+async function lockTransfer(
+  client: { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> },
+  transferId: string
+): Promise<OrgTransferRow> {
+  const result = await client.query(
+    `SELECT ${TRANSFER_COLUMNS} FROM provider_org_transfers WHERE id = $1 FOR UPDATE`,
+    [transferId]
+  )
+  const rows = result.rows as OrgTransferRow[]
+  if (rows.length === 0) throw new OrgTransferNotFoundError('transfer not found')
+  return rows[0]
+}
+
+export interface ScanOrgTransferResult {
+  transfer: OrgTransferSummary
+  decisionCounts: { total: number; pending: number }
+}
+
+export async function scanOrgTransfer(transferId: string): Promise<ScanOrgTransferResult> {
+  return transaction(async (client) => {
+    const row = await lockTransfer(client, transferId)
+    if (!SCANNABLE_STATUSES.includes(row.status)) {
+      throw new OrgTransferConflictError(
+        'ORG_TRANSFER_INVALID_STATE',
+        `transfer cannot be scanned from status ${row.status}`
+      )
+    }
+
+    const bindings = await adapterFor(row.provider).scanBindings(toSummary(row))
+
+    // Regenerate the decision set atomically with the status flip; a re-scan invalidates any
+    // earlier dry-run (dry_run_at ← NULL) so apply's §12.3 guard is scan-relative.
+    await client.query(`DELETE FROM provider_org_transfer_decisions WHERE transfer_id = $1`, [transferId])
+    for (const binding of bindings) {
+      await client.query(
+        `INSERT INTO provider_org_transfer_decisions
+           (transfer_id, binding_kind, source_anchor_type, source_anchor_id, source_handle)
+         VALUES ($1, $2, $3, $4, $5::jsonb)`,
+        [transferId, binding.bindingKind, binding.sourceAnchorType, binding.sourceAnchorId, JSON.stringify(binding.sourceHandle)]
+      )
+    }
+
+    const updated = await client.query(
+      `UPDATE provider_org_transfers
+          SET status = 'scanned', scanned_at = now(), dry_run_stats = '{}'::jsonb, dry_run_at = NULL,
+              last_error = NULL, updated_at = now()
+        WHERE id = $1
+        RETURNING ${TRANSFER_COLUMNS}`,
+      [transferId]
+    )
+    return {
+      transfer: toSummary((updated.rows as OrgTransferRow[])[0]),
+      decisionCounts: { total: bindings.length, pending: bindings.length },
+    }
+  })
+}
+
+export interface DryRunOrgTransferResult {
+  transfer: OrgTransferSummary
+  stats: { bindings: number; decisions: number; pending: number }
+}
+
+export async function dryRunOrgTransfer(transferId: string): Promise<DryRunOrgTransferResult> {
+  return transaction(async (client) => {
+    const row = await lockTransfer(client, transferId)
+    if (row.status !== 'scanned') {
+      throw new OrgTransferConflictError(
+        'ORG_TRANSFER_INVALID_STATE',
+        `transfer cannot be dry-run from status ${row.status}`
+      )
+    }
+
+    const counts = await client.query(
+      `SELECT count(*)::text AS total,
+              count(*) FILTER (WHERE decision = 'pending')::text AS pending
+         FROM provider_org_transfer_decisions WHERE transfer_id = $1`,
+      [transferId]
+    )
+    const countRow = (counts.rows as Array<{ total: string; pending: string }>)[0]
+    const stats = {
+      bindings: Number(countRow.total),
+      decisions: Number(countRow.total),
+      pending: Number(countRow.pending),
+    }
+
+    const updated = await client.query(
+      `UPDATE provider_org_transfers
+          SET dry_run_stats = $2::jsonb, dry_run_at = now(), updated_at = now()
+        WHERE id = $1
+        RETURNING ${TRANSFER_COLUMNS}`,
+      [transferId, JSON.stringify(stats)]
+    )
+    return { transfer: toSummary((updated.rows as OrgTransferRow[])[0]), stats }
+  })
+}
+
+export async function applyOrgTransfer(transferId: string): Promise<OrgTransferSummary> {
+  return transaction(async (client) => {
+    const row = await lockTransfer(client, transferId)
+    if (row.status !== 'scanned') {
+      throw new OrgTransferConflictError(
+        'ORG_TRANSFER_INVALID_STATE',
+        `transfer cannot be applied from status ${row.status}`
+      )
+    }
+    // §12.3: dry-run required, and scan-relative (scan clears dry_run_at).
+    if (row.dry_run_at === null) {
+      throw new OrgTransferConflictError(
+        'ORG_TRANSFER_DRY_RUN_REQUIRED',
+        'a dry-run is required after the latest scan before apply'
+      )
+    }
+    const undecided = await client.query(
+      `SELECT count(*)::text AS pending
+         FROM provider_org_transfer_decisions
+        WHERE transfer_id = $1 AND decision = 'pending'`,
+      [transferId]
+    )
+    if (Number((undecided.rows as Array<{ pending: string }>)[0].pending) > 0) {
+      throw new OrgTransferConflictError(
+        'ORG_TRANSFER_DECISIONS_PENDING',
+        'all scanned bindings must be decided before apply'
+      )
+    }
+
+    // T1: the no-op adapter applies zero decisions and writes nothing; 'applying' never becomes
+    // observable because the flip to 'applied' commits in this same transaction (see header).
+    await adapterFor(row.provider).applyDecisions(toSummary(row))
+
+    const updated = await client.query(
+      `UPDATE provider_org_transfers
+          SET status = 'applied', applied_at = now(), last_error = NULL, updated_at = now()
+        WHERE id = $1
+        RETURNING ${TRANSFER_COLUMNS}`,
+      [transferId]
+    )
+    return toSummary((updated.rows as OrgTransferRow[])[0])
+  })
+}
+
+export async function cancelOrgTransfer(transferId: string): Promise<OrgTransferSummary> {
+  return transaction(async (client) => {
+    const row = await lockTransfer(client, transferId)
+    if (!NON_TERMINAL_STATUSES.includes(row.status)) {
+      throw new OrgTransferConflictError(
+        'ORG_TRANSFER_INVALID_STATE',
+        `transfer cannot be cancelled from terminal status ${row.status}`
+      )
+    }
+    const updated = await client.query(
+      `UPDATE provider_org_transfers
+          SET status = 'cancelled', cancelled_at = now(), updated_at = now()
+        WHERE id = $1
+        RETURNING ${TRANSFER_COLUMNS}`,
+      [transferId]
+    )
+    return toSummary((updated.rows as OrgTransferRow[])[0])
+  })
+}

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -174,6 +174,7 @@ import { adminDirectoryRouter } from './routes/admin-directory'
 import { adminDirectoryLocalRouter } from './routes/admin-directory-local'
 import { adminDirectoryDepartmentBindingsRouter } from './routes/admin-directory-department-bindings'
 import { adminDirectoryRoutingPolicyRouter } from './routes/admin-directory-routing-policy'
+import { adminDirectoryOrgTransfersRouter } from './routes/admin-directory-org-transfers'
 import { startDirectorySyncScheduler, stopDirectorySyncScheduler } from './directory/directory-sync-scheduler'
 import { canaryRoutes } from './routes/canary-routes'
 import { CanaryRouter } from './canary/CanaryRouter'
@@ -1354,6 +1355,9 @@ export class MetaSheetServer {
       }),
     }))
     this.app.use(adminUsersRouter())
+    // Transfer MVP T1 — mounted BEFORE the broader /api/admin/directory router so the more
+    // specific path wins outright; same `ensurePlatformAdmin` RBAC gate.
+    this.app.use('/api/admin/directory/org-transfers', adminDirectoryOrgTransfersRouter())
     this.app.use('/api/admin/directory', adminDirectoryRouter())
     // Canonical Org MVP B2 (local departments/accounts/memberships CRUD) — mounted alongside
     // adminDirectoryRouter under the same base path, sharing its `ensurePlatformAdmin` RBAC gate.

--- a/packages/core-backend/src/routes/admin-directory-org-transfers.ts
+++ b/packages/core-backend/src/routes/admin-directory-org-transfers.ts
@@ -1,18 +1,13 @@
 import type { Request, Response } from 'express'
 import { Router } from 'express'
-import { auditLog } from '../audit/audit'
+import * as auditModule from '../audit/audit'
 import { Logger } from '../core/logger'
 import { ensurePlatformAdmin } from './admin-directory'
+import * as orgTransferService from '../directory/org-transfer-service'
 import {
   OrgTransferConflictError,
   OrgTransferNotFoundError,
   OrgTransferValidationError,
-  applyOrgTransfer,
-  cancelOrgTransfer,
-  createOrgTransfer,
-  dryRunOrgTransfer,
-  getOrgTransfer,
-  scanOrgTransfer,
 } from '../directory/org-transfer-service'
 import { jsonError, jsonOk } from '../util/response'
 
@@ -28,13 +23,20 @@ import { jsonError, jsonOk } from '../util/response'
  * identity is never read from the request: the service derives `org_id` from the two integration
  * rows, and the schema's composite FKs make cross-org/provider-mismatched rows impossible.
  * Every successful lifecycle mutation writes ONE values-free audit row (ids/status/counters only —
- * no names, no tenant/corp keys, no URLs). Rejected mutations (including adapter-unavailable)
- * write no success audit.
+ * no names, no tenant/corp keys, no URLs). Rejected mutations (including adapter-unavailable and
+ * unknown body fields) write no success audit.
+ *
+ * Lifecycle body contract: scan / apply (dry-run + real) / cancel accept NO body fields. Any key,
+ * array, or non-plain payload is 400 ORG_TRANSFER_UNKNOWN_FIELDS before service + audit. Empty
+ * object / omitted body remains allowed. CREATE uses the same plain-object gate with its field
+ * allowlist.
  */
 
 const logger = new Logger('AdminDirectoryOrgTransferRoutes')
 
 const CREATE_FIELDS = ['provider', 'sourceIntegrationId', 'targetIntegrationId'] as const
+/** scan / apply / cancel — no request-body fields are accepted. */
+const LIFECYCLE_BODY_FIELDS = [] as const
 
 const UUID_SHAPE_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -50,20 +52,31 @@ function rejectNonUuidParam(res: Response, paramName: string, value: string): bo
 }
 
 /**
+ * JSON plain object only (not array, null, primitive). Omitted body (`undefined`) is treated as
+ * "no body" and allowed — empty-object semantics without inventing keys.
+ */
+function isPlainObjectBody(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
  * Fail-closed field allowlist (B2 owner hard-requirement pattern): any key outside the
  * endpoint's allowlist — org_id/orgId/corp_id most of all — 400s the whole request rather than
- * being silently dropped.
+ * being silently dropped. Arrays and non-plain payloads cannot bypass via Object.keys([]) === []
+ * (empty array would otherwise look like an empty object).
  */
 function rejectUnlistedFields(req: Request, res: Response, allowed: readonly string[]): boolean {
-  const body = (req.body ?? {}) as Record<string, unknown>
-  const unknown = Object.keys(body).filter((key) => !allowed.includes(key))
+  const raw = req.body
+  // Omitted body (no JSON): allowed empty contract.
+  if (raw === undefined) return false
+  if (!isPlainObjectBody(raw)) {
+    jsonError(res, 400, 'ORG_TRANSFER_UNKNOWN_FIELDS', 'Request body contains fields not accepted by this endpoint')
+    return true
+  }
+  const unknown = Object.keys(raw).filter((key) => !allowed.includes(key))
   if (unknown.length === 0) return false
   jsonError(res, 400, 'ORG_TRANSFER_UNKNOWN_FIELDS', 'Request body contains fields not accepted by this endpoint')
   return true
-}
-
-function readErrorMessage(error: unknown, fallback: string): string {
-  return error instanceof Error && error.message.trim().length > 0 ? error.message : fallback
 }
 
 /**
@@ -71,6 +84,11 @@ function readErrorMessage(error: unknown, fallback: string): string {
  * server-side tokens interpolated (status words; for adapter-unavailable, the transfer row's
  * stored provider label). No request body / caller-supplied free text is echoed, so surfacing
  * them stays values-free relative to operator input and directory payload content.
+ *
+ * Unexpected errors log FIXED metadata only (`reason: 'unexpected_error'`) — never
+ * Error.message / Error.name, SQL detail, request body, provider label, corp/tenant keys, URLs,
+ * or directory values. Typed client errors keep their existing bounded server-authored HTTP
+ * messages and do not log raw exception text.
  */
 function handleOrgTransferError(res: Response, error: unknown, fallbackMessage: string): void {
   if (error instanceof OrgTransferValidationError) {
@@ -85,7 +103,7 @@ function handleOrgTransferError(res: Response, error: unknown, fallbackMessage: 
     jsonError(res, 409, error.code, error.message)
     return
   }
-  logger.warn(fallbackMessage, { error: readErrorMessage(error, 'unknown error') })
+  logger.warn(fallbackMessage, { reason: 'unexpected_error' })
   jsonError(res, 500, 'ORG_TRANSFER_INTERNAL_ERROR', fallbackMessage)
 }
 
@@ -99,7 +117,7 @@ async function auditTransfer(
   meta: Record<string, unknown>
 ): Promise<void> {
   try {
-    await auditLog({
+    await auditModule.auditLog({
       actorId: adminUserId,
       actorType: 'user',
       action: `directory.org_transfer.${action}`,
@@ -107,11 +125,9 @@ async function auditTransfer(
       resourceId: transferId,
       meta,
     })
-  } catch (error) {
-    logger.warn('org-transfer audit write failed', {
-      action,
-      error: readErrorMessage(error, 'unknown error'),
-    })
+  } catch {
+    // Fixed metadata only — never Error.message/name, SQL detail, body, provider, or directory values.
+    logger.warn('org-transfer audit write failed', { action, reason: 'audit_write_failed' })
   }
 }
 
@@ -141,7 +157,7 @@ export function adminDirectoryOrgTransfersRouter(): Router {
     }
 
     try {
-      const transfer = await createOrgTransfer({
+      const transfer = await orgTransferService.createOrgTransfer({
         provider,
         sourceIntegrationId,
         targetIntegrationId,
@@ -165,7 +181,7 @@ export function adminDirectoryOrgTransfersRouter(): Router {
     if (rejectNonUuidParam(res, 'transferId', req.params.transferId)) return
 
     try {
-      const detail = await getOrgTransfer(req.params.transferId)
+      const detail = await orgTransferService.getOrgTransfer(req.params.transferId)
       jsonOk(res, detail)
     } catch (error) {
       handleOrgTransferError(res, error, 'Failed to read org transfer')
@@ -176,9 +192,11 @@ export function adminDirectoryOrgTransfersRouter(): Router {
     const adminUserId = await ensurePlatformAdmin(req, res)
     if (!adminUserId) return
     if (rejectNonUuidParam(res, 'transferId', req.params.transferId)) return
+    // Lifecycle body contract: zero accepted fields. Remove this guard → body-smuggle scan test reds.
+    if (rejectUnlistedFields(req, res, LIFECYCLE_BODY_FIELDS)) return
 
     try {
-      const result = await scanOrgTransfer(req.params.transferId)
+      const result = await orgTransferService.scanOrgTransfer(req.params.transferId)
       await auditTransfer(adminUserId, 'scan', result.transfer.id, {
         provider: result.transfer.provider,
         status: result.transfer.status,
@@ -197,6 +215,9 @@ export function adminDirectoryOrgTransfersRouter(): Router {
     const adminUserId = await ensurePlatformAdmin(req, res)
     if (!adminUserId) return
     if (rejectNonUuidParam(res, 'transferId', req.params.transferId)) return
+    // Lifecycle body contract: zero accepted fields (dry-run is query-only). Remove this guard →
+    // body-smuggle apply tests red.
+    if (rejectUnlistedFields(req, res, LIFECYCLE_BODY_FIELDS)) return
 
     const rawDryRun = req.query.dryRun
     const wantsDryRun = rawDryRun === 'true'
@@ -207,7 +228,7 @@ export function adminDirectoryOrgTransfersRouter(): Router {
 
     try {
       if (wantsDryRun) {
-        const result = await dryRunOrgTransfer(req.params.transferId)
+        const result = await orgTransferService.dryRunOrgTransfer(req.params.transferId)
         await auditTransfer(adminUserId, 'dry_run', result.transfer.id, {
           provider: result.transfer.provider,
           status: result.transfer.status,
@@ -217,7 +238,7 @@ export function adminDirectoryOrgTransfersRouter(): Router {
         jsonOk(res, result)
         return
       }
-      const transfer = await applyOrgTransfer(req.params.transferId)
+      const transfer = await orgTransferService.applyOrgTransfer(req.params.transferId)
       await auditTransfer(adminUserId, 'apply', transfer.id, {
         provider: transfer.provider,
         status: transfer.status,
@@ -232,9 +253,11 @@ export function adminDirectoryOrgTransfersRouter(): Router {
     const adminUserId = await ensurePlatformAdmin(req, res)
     if (!adminUserId) return
     if (rejectNonUuidParam(res, 'transferId', req.params.transferId)) return
+    // Lifecycle body contract: zero accepted fields. Remove this guard → body-smuggle cancel test reds.
+    if (rejectUnlistedFields(req, res, LIFECYCLE_BODY_FIELDS)) return
 
     try {
-      const transfer = await cancelOrgTransfer(req.params.transferId)
+      const transfer = await orgTransferService.cancelOrgTransfer(req.params.transferId)
       await auditTransfer(adminUserId, 'cancel', transfer.id, {
         provider: transfer.provider,
         status: transfer.status,

--- a/packages/core-backend/src/routes/admin-directory-org-transfers.ts
+++ b/packages/core-backend/src/routes/admin-directory-org-transfers.ts
@@ -1,0 +1,244 @@
+import type { Request, Response } from 'express'
+import { Router } from 'express'
+import { auditLog } from '../audit/audit'
+import { Logger } from '../core/logger'
+import { ensurePlatformAdmin } from './admin-directory'
+import {
+  OrgTransferConflictError,
+  OrgTransferNotFoundError,
+  OrgTransferValidationError,
+  applyOrgTransfer,
+  cancelOrgTransfer,
+  createOrgTransfer,
+  dryRunOrgTransfer,
+  getOrgTransfer,
+  scanOrgTransfer,
+} from '../directory/org-transfer-service'
+import { jsonError, jsonOk } from '../util/response'
+
+/**
+ * Transfer MVP — T1 (routes), API per `provider-org-transfer-development-plan-20260709.md` §6.3:
+ * create / read / scan / dry-run apply / apply / cancel. The decisions PATCH endpoint of §6.3 is
+ * deliberately NOT here — T1's no-op adapter scans zero bindings, so the decision surface (and
+ * its secret-handling rules) lands with the first real adapter (T3/T4).
+ *
+ * Platform-admin only (`ensurePlatformAdmin`, the single source in admin-directory.ts). Org
+ * identity is never read from the request: the service derives `org_id` from the two integration
+ * rows, and the schema's composite FKs make cross-org/provider-mismatched rows impossible.
+ * Every lifecycle mutation writes ONE values-free audit row (ids/status/counters only — no
+ * names, no tenant/corp keys, no URLs).
+ */
+
+const logger = new Logger('AdminDirectoryOrgTransferRoutes')
+
+const CREATE_FIELDS = ['provider', 'sourceIntegrationId', 'targetIntegrationId'] as const
+
+const UUID_SHAPE_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function isUuidShaped(value: string): boolean {
+  return UUID_SHAPE_RE.test(value)
+}
+
+/** Non-UUID :transferId params 400 at the route edge (pre-B4 hardening item 1 precedent). */
+function rejectNonUuidParam(res: Response, paramName: string, value: string): boolean {
+  if (isUuidShaped(value)) return false
+  jsonError(res, 400, 'ORG_TRANSFER_INVALID_INPUT', `${paramName} must be a UUID`)
+  return true
+}
+
+/**
+ * Fail-closed field allowlist (B2 owner hard-requirement pattern): any key outside the
+ * endpoint's allowlist — org_id/orgId/corp_id most of all — 400s the whole request rather than
+ * being silently dropped.
+ */
+function rejectUnlistedFields(req: Request, res: Response, allowed: readonly string[]): boolean {
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const unknown = Object.keys(body).filter((key) => !allowed.includes(key))
+  if (unknown.length === 0) return false
+  jsonError(res, 400, 'ORG_TRANSFER_UNKNOWN_FIELDS', 'Request body contains fields not accepted by this endpoint')
+  return true
+}
+
+function readErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message.trim().length > 0 ? error.message : fallback
+}
+
+/**
+ * Typed-error → HTTP mapping. All thrown messages are static developer-authored strings (the
+ * only interpolation is a server-side status word), so surfacing them stays values-free.
+ */
+function handleOrgTransferError(res: Response, error: unknown, fallbackMessage: string): void {
+  if (error instanceof OrgTransferValidationError) {
+    jsonError(res, 400, 'ORG_TRANSFER_INVALID_INPUT', error.message)
+    return
+  }
+  if (error instanceof OrgTransferNotFoundError) {
+    jsonError(res, 404, 'ORG_TRANSFER_NOT_FOUND', error.message)
+    return
+  }
+  if (error instanceof OrgTransferConflictError) {
+    jsonError(res, 409, error.code, error.message)
+    return
+  }
+  logger.warn(fallbackMessage, { error: readErrorMessage(error, 'unknown error') })
+  jsonError(res, 500, 'ORG_TRANSFER_INTERNAL_ERROR', fallbackMessage)
+}
+
+type TransferAuditAction = 'create' | 'scan' | 'dry_run' | 'apply' | 'cancel'
+
+/** Values-free lifecycle audit row; best-effort per the directory route precedent. */
+async function auditTransfer(
+  adminUserId: string,
+  action: TransferAuditAction,
+  transferId: string,
+  meta: Record<string, unknown>
+): Promise<void> {
+  try {
+    await auditLog({
+      actorId: adminUserId,
+      actorType: 'user',
+      action: `directory.org_transfer.${action}`,
+      resourceType: 'directory-org-transfer',
+      resourceId: transferId,
+      meta,
+    })
+  } catch (error) {
+    logger.warn('org-transfer audit write failed', {
+      action,
+      error: readErrorMessage(error, 'unknown error'),
+    })
+  }
+}
+
+export function adminDirectoryOrgTransfersRouter(): Router {
+  const router = Router()
+
+  router.post('/', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectUnlistedFields(req, res, CREATE_FIELDS)) return
+
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const provider = typeof body.provider === 'string' ? body.provider.trim() : ''
+    const sourceIntegrationId = typeof body.sourceIntegrationId === 'string' ? body.sourceIntegrationId : ''
+    const targetIntegrationId = typeof body.targetIntegrationId === 'string' ? body.targetIntegrationId : ''
+    if (provider.length === 0) {
+      jsonError(res, 400, 'ORG_TRANSFER_INVALID_INPUT', 'provider is required')
+      return
+    }
+    if (!isUuidShaped(sourceIntegrationId)) {
+      jsonError(res, 400, 'ORG_TRANSFER_INVALID_INPUT', 'sourceIntegrationId must be a UUID')
+      return
+    }
+    if (!isUuidShaped(targetIntegrationId)) {
+      jsonError(res, 400, 'ORG_TRANSFER_INVALID_INPUT', 'targetIntegrationId must be a UUID')
+      return
+    }
+
+    try {
+      const transfer = await createOrgTransfer({
+        provider,
+        sourceIntegrationId,
+        targetIntegrationId,
+        createdBy: adminUserId,
+      })
+      await auditTransfer(adminUserId, 'create', transfer.id, {
+        provider: transfer.provider,
+        sourceIntegrationId: transfer.sourceIntegrationId,
+        targetIntegrationId: transfer.targetIntegrationId,
+        status: transfer.status,
+      })
+      jsonOk(res, { transfer })
+    } catch (error) {
+      handleOrgTransferError(res, error, 'Failed to create org transfer')
+    }
+  })
+
+  router.get('/:transferId', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectNonUuidParam(res, 'transferId', req.params.transferId)) return
+
+    try {
+      const detail = await getOrgTransfer(req.params.transferId)
+      jsonOk(res, detail)
+    } catch (error) {
+      handleOrgTransferError(res, error, 'Failed to read org transfer')
+    }
+  })
+
+  router.post('/:transferId/scan', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectNonUuidParam(res, 'transferId', req.params.transferId)) return
+
+    try {
+      const result = await scanOrgTransfer(req.params.transferId)
+      await auditTransfer(adminUserId, 'scan', result.transfer.id, {
+        provider: result.transfer.provider,
+        status: result.transfer.status,
+        decisionsTotal: result.decisionCounts.total,
+        decisionsPending: result.decisionCounts.pending,
+      })
+      jsonOk(res, result)
+    } catch (error) {
+      handleOrgTransferError(res, error, 'Failed to scan org transfer')
+    }
+  })
+
+  // §6.3: dry-run and apply share the endpoint, split by ?dryRun=true. Any other dryRun value
+  // is a 400 (never silently coerced into a REAL apply).
+  router.post('/:transferId/apply', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectNonUuidParam(res, 'transferId', req.params.transferId)) return
+
+    const rawDryRun = req.query.dryRun
+    const wantsDryRun = rawDryRun === 'true'
+    if (rawDryRun !== undefined && !wantsDryRun) {
+      jsonError(res, 400, 'ORG_TRANSFER_INVALID_INPUT', 'dryRun, when present, must be exactly "true"')
+      return
+    }
+
+    try {
+      if (wantsDryRun) {
+        const result = await dryRunOrgTransfer(req.params.transferId)
+        await auditTransfer(adminUserId, 'dry_run', result.transfer.id, {
+          provider: result.transfer.provider,
+          status: result.transfer.status,
+          bindings: result.stats.bindings,
+          pending: result.stats.pending,
+        })
+        jsonOk(res, result)
+        return
+      }
+      const transfer = await applyOrgTransfer(req.params.transferId)
+      await auditTransfer(adminUserId, 'apply', transfer.id, {
+        provider: transfer.provider,
+        status: transfer.status,
+      })
+      jsonOk(res, { transfer })
+    } catch (error) {
+      handleOrgTransferError(res, error, 'Failed to apply org transfer')
+    }
+  })
+
+  router.post('/:transferId/cancel', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectNonUuidParam(res, 'transferId', req.params.transferId)) return
+
+    try {
+      const transfer = await cancelOrgTransfer(req.params.transferId)
+      await auditTransfer(adminUserId, 'cancel', transfer.id, {
+        provider: transfer.provider,
+        status: transfer.status,
+      })
+      jsonOk(res, { transfer })
+    } catch (error) {
+      handleOrgTransferError(res, error, 'Failed to cancel org transfer')
+    }
+  })
+
+  return router
+}

--- a/packages/core-backend/src/routes/admin-directory-org-transfers.ts
+++ b/packages/core-backend/src/routes/admin-directory-org-transfers.ts
@@ -19,14 +19,17 @@ import { jsonError, jsonOk } from '../util/response'
 /**
  * Transfer MVP — T1 (routes), API per `provider-org-transfer-development-plan-20260709.md` §6.3:
  * create / read / scan / dry-run apply / apply / cancel. The decisions PATCH endpoint of §6.3 is
- * deliberately NOT here — T1's no-op adapter scans zero bindings, so the decision surface (and
- * its secret-handling rules) lands with the first real adapter (T3/T4).
+ * deliberately NOT here — without a registered adapter scan yields zero bindings only when tests
+ * explicitly register the no-op; production scan/apply fail closed with
+ * ORG_TRANSFER_ADAPTER_UNAVAILABLE. The decision surface (and its secret-handling rules) lands
+ * with the first real adapter (T3/T4).
  *
  * Platform-admin only (`ensurePlatformAdmin`, the single source in admin-directory.ts). Org
  * identity is never read from the request: the service derives `org_id` from the two integration
  * rows, and the schema's composite FKs make cross-org/provider-mismatched rows impossible.
- * Every lifecycle mutation writes ONE values-free audit row (ids/status/counters only — no
- * names, no tenant/corp keys, no URLs).
+ * Every successful lifecycle mutation writes ONE values-free audit row (ids/status/counters only —
+ * no names, no tenant/corp keys, no URLs). Rejected mutations (including adapter-unavailable)
+ * write no success audit.
  */
 
 const logger = new Logger('AdminDirectoryOrgTransferRoutes')
@@ -64,8 +67,10 @@ function readErrorMessage(error: unknown, fallback: string): string {
 }
 
 /**
- * Typed-error → HTTP mapping. All thrown messages are static developer-authored strings (the
- * only interpolation is a server-side status word), so surfacing them stays values-free.
+ * Typed-error → HTTP mapping. Thrown messages are developer-authored templates with only
+ * server-side tokens interpolated (status words; for adapter-unavailable, the transfer row's
+ * stored provider label). No request body / caller-supplied free text is echoed, so surfacing
+ * them stays values-free relative to operator input and directory payload content.
  */
 function handleOrgTransferError(res: Response, error: unknown, fallbackMessage: string): void {
   if (error instanceof OrgTransferValidationError) {

--- a/packages/core-backend/tests/integration/provider-org-transfer-t1.api.test.ts
+++ b/packages/core-backend/tests/integration/provider-org-transfer-t1.api.test.ts
@@ -3,10 +3,15 @@ import express from 'express'
 import request from 'supertest'
 import { afterEach, describe, expect, it } from 'vitest'
 import { query } from '../../src/db/pg'
+import {
+  noopOrgTransferAdapter,
+  registerOrgTransferAdapter,
+  unregisterOrgTransferAdapter,
+} from '../../src/directory/org-transfer-service'
 import { adminDirectoryOrgTransfersRouter } from '../../src/routes/admin-directory-org-transfers'
 
 /**
- * Transfer MVP — T1 (schema + admin API skeleton, no-op adapter), real DB + HTTP route layer.
+ * Transfer MVP — T1 (schema + admin API skeleton), real DB + HTTP route layer.
  * Harness mirrors `local-directory-org-crud-route.db.test.ts` (trivial pass-through auth with
  * `role: 'admin'`; the non-admin app exercises the real RBAC query).
  *
@@ -17,13 +22,16 @@ import { adminDirectoryOrgTransfersRouter } from '../../src/routes/admin-directo
  *   - the SCHEMA backstops (not just service validation): cross-org and provider-mismatched
  *     transfers are FK-impossible to INSERT even bypassing the service; provider='local' is
  *     CHECK-impossible;
- *   - lifecycle draft → scan → dry-run → apply with one values-free audit row per mutation;
+ *   - lifecycle draft → scan → dry-run → apply with one values-free audit row per mutation
+ *     (happy path registers the no-op adapter explicitly — production has no silent fallback);
+ *   - production unregistered-provider scan/apply fail closed with ORG_TRANSFER_ADAPTER_UNAVAILABLE,
+ *     leave transfer state unchanged, and write no success audit (route + mutation proofs);
  *   - §12.3 dry-run-required guard, and its SCAN-RELATIVITY (a re-scan invalidates the dry-run);
- *   - the undecided-decisions apply guard (seeded directly — the no-op adapter scans zero);
+ *   - the undecided-decisions apply guard (seeded directly — the registered no-op scans zero);
  *   - at-most-one-ACTIVE-transfer-per-source (both halves: cap while active, free after cancel);
  *   - terminal states reject every further mutation;
  *   - apply/apply concurrency linearizes on the row lock (exactly one 200);
- *   - the T1 no-op apply writes NOTHING to any directory_* table (fingerprint equality).
+ *   - the registered no-op apply writes NOTHING to any directory_* table (fingerprint equality).
  *
  * DATABASE_URL-gated (describeIfDatabase): excluded from the no-DB vitest job so it cannot
  * skip-green, and wired as a WHOLE FILE into the directory real-DB step in plugin-tests.yml
@@ -104,11 +112,19 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
   const createdIntegrationIds: string[] = []
 
   afterEach(async () => {
+    // Deterministic registry cleanup: happy-path tests register the no-op for 'dingtalk';
+    // production-no-adapter tests leave it unregistered. Never leak either state across cases.
+    unregisterOrgTransferAdapter('dingtalk')
     const transfers = createdTransferIds.splice(0)
     for (const id of transfers) await query(`DELETE FROM provider_org_transfers WHERE id = $1`, [id]) // decisions cascade
     const integrations = createdIntegrationIds.splice(0)
     for (const id of integrations) await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
   })
+
+  /** Explicit test-only registration — production has no silent no-op fallback. */
+  function enableNoopAdapter(): void {
+    registerOrgTransferAdapter('dingtalk', noopOrgTransferAdapter)
+  }
 
   async function seedPair(tag: string, org = uniqueOrg(tag)): Promise<{ org: string; source: string; target: string }> {
     const source = await seedIntegration(org, 'dingtalk', `${tag}-src`)
@@ -125,6 +141,35 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     const id = res.body.data.transfer.id as string
     createdTransferIds.push(id)
     return id
+  }
+
+  async function transferRow(transferId: string): Promise<{
+    status: string
+    scanned_at: string | null
+    applied_at: string | null
+    dry_run_at: string | null
+    last_error: string | null
+  }> {
+    const result = await query<{
+      status: string
+      scanned_at: string | null
+      applied_at: string | null
+      dry_run_at: string | null
+      last_error: string | null
+    }>(
+      `SELECT status, scanned_at::text, applied_at::text, dry_run_at::text, last_error
+         FROM provider_org_transfers WHERE id = $1`,
+      [transferId]
+    )
+    return result.rows[0]
+  }
+
+  async function decisionCount(transferId: string): Promise<number> {
+    const result = await query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM provider_org_transfer_decisions WHERE transfer_id = $1`,
+      [transferId]
+    )
+    return Number(result.rows[0].n)
   }
 
   it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
@@ -254,7 +299,78 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     )
   })
 
+  it('production-no-adapter: unregistered provider scan/apply fail closed 409, state unchanged, no success audit', async () => {
+    // No enableNoopAdapter() — this is the production default for providers without a real adapter.
+    const { source, target } = await seedPair('no-adapter')
+    const transferId = await createTransfer(source, target)
+    const auditBefore = await orgTransferAuditCount()
+    const before = await transferRow(transferId)
+    expect(before.status).toBe('draft')
+
+    const scan = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`)
+    expect(scan.status).toBe(409)
+    expect(scan.body.error.code).toBe('ORG_TRANSFER_ADAPTER_UNAVAILABLE')
+
+    const afterScan = await transferRow(transferId)
+    expect(afterScan).toEqual(before)
+    expect(await decisionCount(transferId)).toBe(0)
+    expect(await auditRowFor('scan', transferId)).toBe(0)
+    expect(await orgTransferAuditCount()).toBe(auditBefore)
+
+    // Apply is also fail-closed (even from draft — adapter check is not the only guard, but
+    // production must never silently no-op-apply once scanned either; seed scanned + dry-run
+    // via SQL so the adapter leg is reachable without a successful scan).
+    await query(
+      `UPDATE provider_org_transfers
+          SET status = 'scanned', scanned_at = now(), dry_run_at = now(), dry_run_stats = '{"bindings":0}'::jsonb,
+              updated_at = now()
+        WHERE id = $1`,
+      [transferId]
+    )
+    const preApply = await transferRow(transferId)
+    const apply = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply`)
+    expect(apply.status).toBe(409)
+    expect(apply.body.error.code).toBe('ORG_TRANSFER_ADAPTER_UNAVAILABLE')
+    const afterApply = await transferRow(transferId)
+    expect(afterApply.status).toBe(preApply.status)
+    expect(afterApply.applied_at).toBeNull()
+    expect(await auditRowFor('apply', transferId)).toBe(0)
+    expect(await orgTransferAuditCount()).toBe(auditBefore)
+  })
+
+  it('load-bearing mutation proof: unavailable adapter rolls back — no status flip, no decisions, no success audit', async () => {
+    // Strengthens the route-level 409 above: pins the write-set that must not move.
+    const { source, target } = await seedPair('mutation-proof')
+    const transferId = await createTransfer(source, target)
+    // Seed a stale decision so a buggy scan that DELETE+INSERTs would still change counts/content.
+    await query(
+      `INSERT INTO provider_org_transfer_decisions (transfer_id, binding_kind, source_anchor_type, source_anchor_id)
+       VALUES ($1, 'user_identity', 'user', $2)`,
+      [transferId, `t1-stale-${STAMP}`]
+    )
+    expect(await decisionCount(transferId)).toBe(1)
+    const auditBefore = await orgTransferAuditCount()
+    const statusBefore = await transferRow(transferId)
+
+    const scan = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`)
+    expect(scan.status).toBe(409)
+    expect(scan.body.error.code).toBe('ORG_TRANSFER_ADAPTER_UNAVAILABLE')
+
+    // Status/timestamps unchanged (still draft; scanned_at stays null).
+    expect(await transferRow(transferId)).toEqual(statusBefore)
+    // The pre-existing decision row was NOT wiped — fail closed before decision regeneration.
+    expect(await decisionCount(transferId)).toBe(1)
+    const stillThere = await query<{ source_anchor_id: string }>(
+      `SELECT source_anchor_id FROM provider_org_transfer_decisions WHERE transfer_id = $1`,
+      [transferId]
+    )
+    expect(stillThere.rows[0].source_anchor_id).toBe(`t1-stale-${STAMP}`)
+    expect(await auditRowFor('scan', transferId)).toBe(0)
+    expect(await orgTransferAuditCount()).toBe(auditBefore)
+  })
+
   it('walks the happy lifecycle with one values-free audit row per mutation and an untouched directory fingerprint', async () => {
+    enableNoopAdapter()
     const { source, target } = await seedPair('happy')
     const transferId = await createTransfer(source, target)
     expect(await auditRowFor('create', transferId)).toBe(1)
@@ -293,7 +409,7 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     expect(apply.body.data.transfer.appliedAt).not.toBeNull()
     expect(await auditRowFor('apply', transferId)).toBe(1)
 
-    // T1's apply is a no-op by contract: nothing in the directory substrate moved.
+    // Registered no-op apply is a no-op by contract: nothing in the directory substrate moved.
     expect(await directoryFingerprint()).toBe(fingerprintBefore)
 
     // Terminal: every further mutation is refused.
@@ -305,6 +421,7 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
   })
 
   it('re-scan invalidates a prior dry-run (the §12.3 guard is scan-relative)', async () => {
+    enableNoopAdapter()
     const { source, target } = await seedPair('rescan')
     const transferId = await createTransfer(source, target)
 
@@ -342,7 +459,8 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     await createTransfer(source, secondTarget)
   })
 
-  it('blocks apply while any scanned decision is undecided (guard seeded directly — the no-op adapter scans zero)', async () => {
+  it('blocks apply while any scanned decision is undecided (guard seeded directly — the registered no-op scans zero)', async () => {
+    enableNoopAdapter()
     const { source, target } = await seedPair('undecided')
     const transferId = await createTransfer(source, target)
     await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`).expect(200)
@@ -366,6 +484,7 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
   })
 
   it('linearizes concurrent applies on the row lock — exactly one 200, one clean 409, one applied_at', async () => {
+    enableNoopAdapter()
     const { source, target } = await seedPair('race')
     const transferId = await createTransfer(source, target)
     await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`).expect(200)
@@ -391,10 +510,11 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
   })
 
   it("recovery edges (gate P3): 'failed' is NON-absorbing (failed→scan recovers) and 'applying' is cancellable", async () => {
-    // No T1 producer reaches 'failed' or leaves 'applying' observable (the no-op apply commits
-    // scanned→applied in one txn) — both are future real-adapter states, seeded directly so the
-    // recovery claims in the service header are load-bearing NOW: dropping 'failed' from
+    // No T1 producer reaches 'failed' or leaves 'applying' observable (the registered no-op apply
+    // commits scanned→applied in one txn) — both are future real-adapter states, seeded directly
+    // so the recovery claims in the service header are load-bearing NOW: dropping 'failed' from
     // SCANNABLE_STATUSES or 'applying' from NON_TERMINAL_STATUSES reds this test.
+    enableNoopAdapter()
     const { source, target } = await seedPair('recover')
     const transferId = await createTransfer(source, target)
 

--- a/packages/core-backend/tests/integration/provider-org-transfer-t1.api.test.ts
+++ b/packages/core-backend/tests/integration/provider-org-transfer-t1.api.test.ts
@@ -390,6 +390,28 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     expect(await auditRowFor('apply', transferId)).toBe(1)
   })
 
+  it("recovery edges (gate P3): 'failed' is NON-absorbing (failed→scan recovers) and 'applying' is cancellable", async () => {
+    // No T1 producer reaches 'failed' or leaves 'applying' observable (the no-op apply commits
+    // scanned→applied in one txn) — both are future real-adapter states, seeded directly so the
+    // recovery claims in the service header are load-bearing NOW: dropping 'failed' from
+    // SCANNABLE_STATUSES or 'applying' from NON_TERMINAL_STATUSES reds this test.
+    const { source, target } = await seedPair('recover')
+    const transferId = await createTransfer(source, target)
+
+    await query(`UPDATE provider_org_transfers SET status = 'failed', last_error = 'seeded', updated_at = now() WHERE id = $1`, [
+      transferId,
+    ])
+    const rescued = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`)
+    expect(rescued.status).toBe(200)
+    expect(rescued.body.data.transfer.status).toBe('scanned')
+    expect(rescued.body.data.transfer.lastError).toBeNull() // scan clears the failure
+
+    await query(`UPDATE provider_org_transfers SET status = 'applying', updated_at = now() WHERE id = $1`, [transferId])
+    const cancelled = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/cancel`)
+    expect(cancelled.status).toBe(200)
+    expect(cancelled.body.data.transfer.status).toBe('cancelled')
+  })
+
   it('rejects a dryRun query value other than exactly "true" instead of coercing it into a REAL apply', async () => {
     const { source, target } = await seedPair('dryrun-strict')
     const transferId = await createTransfer(source, target)

--- a/packages/core-backend/tests/integration/provider-org-transfer-t1.api.test.ts
+++ b/packages/core-backend/tests/integration/provider-org-transfer-t1.api.test.ts
@@ -1,0 +1,413 @@
+import { randomUUID } from 'crypto'
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { adminDirectoryOrgTransfersRouter } from '../../src/routes/admin-directory-org-transfers'
+
+/**
+ * Transfer MVP — T1 (schema + admin API skeleton, no-op adapter), real DB + HTTP route layer.
+ * Harness mirrors `local-directory-org-crud-route.db.test.ts` (trivial pass-through auth with
+ * `role: 'admin'`; the non-admin app exercises the real RBAC query).
+ *
+ * What this suite pins, per the T1 row of the MVP sequencing plan:
+ *   - platform-admin gating on every route (403 leg per endpoint);
+ *   - create validations fail closed with ZERO rows and ZERO audit rows (audit-zero assertions
+ *     are scoped to this suite's unique actor id — never global counts);
+ *   - the SCHEMA backstops (not just service validation): cross-org and provider-mismatched
+ *     transfers are FK-impossible to INSERT even bypassing the service; provider='local' is
+ *     CHECK-impossible;
+ *   - lifecycle draft → scan → dry-run → apply with one values-free audit row per mutation;
+ *   - §12.3 dry-run-required guard, and its SCAN-RELATIVITY (a re-scan invalidates the dry-run);
+ *   - the undecided-decisions apply guard (seeded directly — the no-op adapter scans zero);
+ *   - at-most-one-ACTIVE-transfer-per-source (both halves: cap while active, free after cancel);
+ *   - terminal states reject every further mutation;
+ *   - apply/apply concurrency linearizes on the row lock (exactly one 200);
+ *   - the T1 no-op apply writes NOTHING to any directory_* table (fingerprint equality).
+ *
+ * DATABASE_URL-gated (describeIfDatabase): excluded from the no-DB vitest job so it cannot
+ * skip-green, and wired as a WHOLE FILE into the directory real-DB step in plugin-tests.yml
+ * (both points asserted by scripts/ops/t1-org-transfer-ci-wiring.test.mjs).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const STAMP = Date.now()
+const ADMIN_ID = `t1-transfer-admin-${STAMP}`
+
+const adminApp = express()
+adminApp.use(express.json())
+adminApp.use((req, _res, next) => {
+  ;(req as express.Request & { user?: unknown }).user = { id: ADMIN_ID, role: 'admin' }
+  next()
+})
+adminApp.use('/api/admin/directory/org-transfers', adminDirectoryOrgTransfersRouter())
+
+const nonAdminApp = express()
+nonAdminApp.use(express.json())
+nonAdminApp.use((req, _res, next) => {
+  ;(req as express.Request & { user?: unknown }).user = { id: `t1-transfer-nonadmin-${STAMP}` }
+  next()
+})
+nonAdminApp.use('/api/admin/directory/org-transfers', adminDirectoryOrgTransfersRouter())
+
+function uniqueOrg(tag: string): string {
+  return `t1-org-${STAMP}-${tag}-${randomUUID().slice(0, 8)}`
+}
+
+async function seedIntegration(org: string, provider: string, tag: string): Promise<string> {
+  // B1's local_integration_corp_id_shape CHECK pins provider='local' rows to corp_id 'local:<org>'.
+  const corpId = provider === 'local' ? `local:${org}` : `t1-corp-${STAMP}-${tag}`
+  const result = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id, config)
+     VALUES ($1, $2, $3, 'active', $4, '{}'::jsonb) RETURNING id`,
+    [org, provider, `T1 ${provider} ${tag} ${STAMP}`, corpId]
+  )
+  return result.rows[0].id
+}
+
+/**
+ * The `directory.org_transfer.%` action namespace is written by NOTHING but the T1 routes, and
+ * audit_logs has no text actor column (auditLog only maps numeric actor ids into user_id), so
+ * the zero-audit assertions scope on the action prefix — unique to this feature, race-free
+ * against every other suite sharing the CI database.
+ */
+async function orgTransferAuditCount(): Promise<number> {
+  const result = await query<{ n: string }>(
+    `SELECT count(*)::text AS n FROM audit_logs WHERE action LIKE 'directory.org_transfer.%'`
+  )
+  return Number(result.rows[0].n)
+}
+
+async function auditRowFor(action: string, transferId: string): Promise<number> {
+  const result = await query<{ n: string }>(
+    `SELECT count(*)::text AS n FROM audit_logs WHERE action = $1 AND resource_id = $2`,
+    [`directory.org_transfer.${action}`, transferId]
+  )
+  return Number(result.rows[0].n)
+}
+
+/** Row-count + latest-updated fingerprint over every table the no-op apply must not touch. */
+async function directoryFingerprint(): Promise<string> {
+  const result = await query<{ fp: string }>(
+    `SELECT concat_ws('|',
+        (SELECT concat(count(*), ':', coalesce(max(updated_at)::text, '-')) FROM directory_accounts),
+        (SELECT concat(count(*), ':', coalesce(max(updated_at)::text, '-')) FROM directory_departments),
+        (SELECT concat(count(*), ':', coalesce(max(created_at)::text, '-')) FROM directory_account_departments),
+        (SELECT count(*)::text FROM user_external_identities)
+      ) AS fp`
+  )
+  return result.rows[0].fp
+}
+
+describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API skeleton (real DB, HTTP)', () => {
+  const createdTransferIds: string[] = []
+  const createdIntegrationIds: string[] = []
+
+  afterEach(async () => {
+    const transfers = createdTransferIds.splice(0)
+    for (const id of transfers) await query(`DELETE FROM provider_org_transfers WHERE id = $1`, [id]) // decisions cascade
+    const integrations = createdIntegrationIds.splice(0)
+    for (const id of integrations) await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
+  })
+
+  async function seedPair(tag: string, org = uniqueOrg(tag)): Promise<{ org: string; source: string; target: string }> {
+    const source = await seedIntegration(org, 'dingtalk', `${tag}-src`)
+    const target = await seedIntegration(org, 'dingtalk', `${tag}-dst`)
+    createdIntegrationIds.push(source, target)
+    return { org, source, target }
+  }
+
+  async function createTransfer(source: string, target: string): Promise<string> {
+    const res = await request(adminApp)
+      .post('/api/admin/directory/org-transfers')
+      .send({ provider: 'dingtalk', sourceIntegrationId: source, targetIntegrationId: target })
+    expect(res.status).toBe(200)
+    const id = res.body.data.transfer.id as string
+    createdTransferIds.push(id)
+    return id
+  }
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('rejects every route for a non-platform-admin (403/401 family), writing nothing', async () => {
+    const { source, target } = await seedPair('rbac')
+    const before = await query<{ n: string }>(`SELECT count(*)::text AS n FROM provider_org_transfers WHERE source_integration_id = $1`, [source])
+
+    const create = await request(nonAdminApp)
+      .post('/api/admin/directory/org-transfers')
+      .send({ provider: 'dingtalk', sourceIntegrationId: source, targetIntegrationId: target })
+    expect(create.status).toBeGreaterThanOrEqual(401)
+    expect(create.status).toBeLessThanOrEqual(403)
+
+    const probeId = randomUUID()
+    for (const probe of [
+      request(nonAdminApp).get(`/api/admin/directory/org-transfers/${probeId}`),
+      request(nonAdminApp).post(`/api/admin/directory/org-transfers/${probeId}/scan`),
+      request(nonAdminApp).post(`/api/admin/directory/org-transfers/${probeId}/apply?dryRun=true`),
+      request(nonAdminApp).post(`/api/admin/directory/org-transfers/${probeId}/apply`),
+      request(nonAdminApp).post(`/api/admin/directory/org-transfers/${probeId}/cancel`),
+    ]) {
+      const res = await probe
+      expect(res.status).toBeGreaterThanOrEqual(401)
+      expect(res.status).toBeLessThanOrEqual(403)
+    }
+
+    const after = await query<{ n: string }>(`SELECT count(*)::text AS n FROM provider_org_transfers WHERE source_integration_id = $1`, [source])
+    expect(after.rows[0].n).toBe(before.rows[0].n)
+  })
+
+  it('fails create closed on every invalid input — zero rows, zero audit rows (actor-scoped)', async () => {
+    const { org, source, target } = await seedPair('valid')
+    const otherOrgIntegration = await seedIntegration(uniqueOrg('valid-other'), 'dingtalk', 'valid-other')
+    const wecomIntegration = await seedIntegration(org, 'wecom', 'valid-wecom')
+    createdIntegrationIds.push(otherOrgIntegration, wecomIntegration)
+    const auditBefore = await orgTransferAuditCount()
+
+    const cases: Array<{ body: Record<string, unknown>; expectStatus: number; expectCode: string }> = [
+      // unknown source / target
+      { body: { provider: 'dingtalk', sourceIntegrationId: randomUUID(), targetIntegrationId: target }, expectStatus: 404, expectCode: 'ORG_TRANSFER_NOT_FOUND' },
+      { body: { provider: 'dingtalk', sourceIntegrationId: source, targetIntegrationId: randomUUID() }, expectStatus: 404, expectCode: 'ORG_TRANSFER_NOT_FOUND' },
+      // source == target
+      { body: { provider: 'dingtalk', sourceIntegrationId: source, targetIntegrationId: source }, expectStatus: 400, expectCode: 'ORG_TRANSFER_INVALID_INPUT' },
+      // provider mismatch (one end is wecom)
+      { body: { provider: 'dingtalk', sourceIntegrationId: source, targetIntegrationId: wecomIntegration }, expectStatus: 400, expectCode: 'ORG_TRANSFER_INVALID_INPUT' },
+      // cross-org
+      { body: { provider: 'dingtalk', sourceIntegrationId: source, targetIntegrationId: otherOrgIntegration }, expectStatus: 400, expectCode: 'ORG_TRANSFER_INVALID_INPUT' },
+      // provider = local is never transferable
+      { body: { provider: 'local', sourceIntegrationId: source, targetIntegrationId: target }, expectStatus: 400, expectCode: 'ORG_TRANSFER_INVALID_INPUT' },
+      // smuggled org identity fails the whole request (fail-closed allowlist)
+      { body: { provider: 'dingtalk', sourceIntegrationId: source, targetIntegrationId: target, org_id: 'evil' }, expectStatus: 400, expectCode: 'ORG_TRANSFER_UNKNOWN_FIELDS' },
+      // non-UUID ids 400 at the edge (never reach a ::uuid cast 500)
+      { body: { provider: 'dingtalk', sourceIntegrationId: 'not-a-uuid', targetIntegrationId: target }, expectStatus: 400, expectCode: 'ORG_TRANSFER_INVALID_INPUT' },
+      // provider empty
+      { body: { provider: '   ', sourceIntegrationId: source, targetIntegrationId: target }, expectStatus: 400, expectCode: 'ORG_TRANSFER_INVALID_INPUT' },
+    ]
+
+    for (const testCase of cases) {
+      const res = await request(adminApp).post('/api/admin/directory/org-transfers').send(testCase.body)
+      expect(res.status, JSON.stringify(testCase.body)).toBe(testCase.expectStatus)
+      expect(res.body.error.code).toBe(testCase.expectCode)
+    }
+
+    const rows = await query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM provider_org_transfers WHERE source_integration_id = ANY($1::uuid[])`,
+      [[source, wecomIntegration, otherOrgIntegration]]
+    )
+    expect(rows.rows[0].n).toBe('0')
+    expect(await orgTransferAuditCount()).toBe(auditBefore)
+  })
+
+  it('schema backstop: cross-org, provider-mismatch, and local-provider transfers are impossible to INSERT directly', async () => {
+    const { org, source, target } = await seedPair('schema')
+    const otherOrgIntegration = await seedIntegration(uniqueOrg('schema-other'), 'dingtalk', 'schema-other')
+    const localIntegration = await seedIntegration(org, 'local', 'schema-local')
+    createdIntegrationIds.push(otherOrgIntegration, localIntegration)
+
+    // Positive control first: the well-formed direct INSERT succeeds (the probes below fail for
+    // the right reason, not because the INSERT statement itself is malformed).
+    const ok = await query<{ id: string }>(
+      `INSERT INTO provider_org_transfers (org_id, provider, source_integration_id, target_integration_id)
+       VALUES ($1, 'dingtalk', $2, $3) RETURNING id`,
+      [org, source, target]
+    )
+    createdTransferIds.push(ok.rows[0].id)
+
+    // A dedicated probe source: the positive control above occupies `source`'s ACTIVE slot, and
+    // the partial unique index fires before the FK check — probes must fail on the FK, not 23505.
+    const probeSource = await seedIntegration(org, 'dingtalk', 'schema-probe-src')
+    createdIntegrationIds.push(probeSource)
+
+    const expectSqlState = async (sql: string, params: unknown[], expectedCode: string) => {
+      let caught: { code?: string } | null = null
+      try {
+        await query(sql, params)
+      } catch (error) {
+        caught = error as { code?: string }
+      }
+      expect(caught, 'INSERT unexpectedly succeeded').not.toBeNull()
+      expect(caught?.code).toBe(expectedCode)
+    }
+
+    // Cross-org: no org_id value satisfies both composite FKs — 23503 foreign_key_violation.
+    await expectSqlState(
+      `INSERT INTO provider_org_transfers (org_id, provider, source_integration_id, target_integration_id)
+       VALUES ($1, 'dingtalk', $2, $3)`,
+      [org, probeSource, otherOrgIntegration],
+      '23503'
+    )
+    // Provider mismatch: row provider 'wecom' fails both (id, provider) FKs for dingtalk ends.
+    await expectSqlState(
+      `INSERT INTO provider_org_transfers (org_id, provider, source_integration_id, target_integration_id)
+       VALUES ($1, 'wecom', $2, $3)`,
+      [org, probeSource, target],
+      '23503'
+    )
+    // provider='local' violates pot_provider_not_local_chk — 23514 check_violation (row CHECKs
+    // evaluate before the FK triggers, so this fires first regardless of the ends).
+    await expectSqlState(
+      `INSERT INTO provider_org_transfers (org_id, provider, source_integration_id, target_integration_id)
+       VALUES ($1, 'local', $2, $3)`,
+      [org, probeSource, localIntegration],
+      '23514'
+    )
+  })
+
+  it('walks the happy lifecycle with one values-free audit row per mutation and an untouched directory fingerprint', async () => {
+    const { source, target } = await seedPair('happy')
+    const transferId = await createTransfer(source, target)
+    expect(await auditRowFor('create', transferId)).toBe(1)
+
+    const read = await request(adminApp).get(`/api/admin/directory/org-transfers/${transferId}`)
+    expect(read.status).toBe(200)
+    expect(read.body.data.transfer.status).toBe('draft')
+    expect(read.body.data.decisionCounts).toEqual({ total: 0, pending: 0 })
+
+    // §12.3: apply before ANY dry-run is refused.
+    const premature = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply`)
+    expect(premature.status).toBe(409)
+    expect(premature.body.error.code).toBe('ORG_TRANSFER_INVALID_STATE') // not even scanned yet
+
+    const scan = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`)
+    expect(scan.status).toBe(200)
+    expect(scan.body.data.transfer.status).toBe('scanned')
+    expect(scan.body.data.transfer.scannedAt).not.toBeNull()
+    expect(scan.body.data.decisionCounts).toEqual({ total: 0, pending: 0 })
+    expect(await auditRowFor('scan', transferId)).toBe(1)
+
+    const applyWithoutDryRun = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply`)
+    expect(applyWithoutDryRun.status).toBe(409)
+    expect(applyWithoutDryRun.body.error.code).toBe('ORG_TRANSFER_DRY_RUN_REQUIRED')
+
+    const dryRun = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply?dryRun=true`)
+    expect(dryRun.status).toBe(200)
+    expect(dryRun.body.data.stats).toEqual({ bindings: 0, decisions: 0, pending: 0 })
+    expect(dryRun.body.data.transfer.dryRunAt).not.toBeNull()
+    expect(await auditRowFor('dry_run', transferId)).toBe(1)
+
+    const fingerprintBefore = await directoryFingerprint()
+    const apply = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply`)
+    expect(apply.status).toBe(200)
+    expect(apply.body.data.transfer.status).toBe('applied')
+    expect(apply.body.data.transfer.appliedAt).not.toBeNull()
+    expect(await auditRowFor('apply', transferId)).toBe(1)
+
+    // T1's apply is a no-op by contract: nothing in the directory substrate moved.
+    expect(await directoryFingerprint()).toBe(fingerprintBefore)
+
+    // Terminal: every further mutation is refused.
+    for (const path of ['scan', 'apply', 'cancel']) {
+      const res = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/${path}`)
+      expect(res.status, path).toBe(409)
+      expect(res.body.error.code).toBe('ORG_TRANSFER_INVALID_STATE')
+    }
+  })
+
+  it('re-scan invalidates a prior dry-run (the §12.3 guard is scan-relative)', async () => {
+    const { source, target } = await seedPair('rescan')
+    const transferId = await createTransfer(source, target)
+
+    await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`).expect(200)
+    await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply?dryRun=true`).expect(200)
+
+    const rescan = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`)
+    expect(rescan.status).toBe(200)
+    expect(rescan.body.data.transfer.dryRunAt).toBeNull()
+
+    const apply = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply`)
+    expect(apply.status).toBe(409)
+    expect(apply.body.error.code).toBe('ORG_TRANSFER_DRY_RUN_REQUIRED')
+  })
+
+  it('caps ACTIVE transfers per source integration — and frees the slot after cancel (both halves of the partial index)', async () => {
+    const { org, source, target } = await seedPair('cap')
+    const secondTarget = await seedIntegration(org, 'dingtalk', 'cap-dst2')
+    createdIntegrationIds.push(secondTarget)
+
+    const firstId = await createTransfer(source, target)
+
+    const duplicate = await request(adminApp)
+      .post('/api/admin/directory/org-transfers')
+      .send({ provider: 'dingtalk', sourceIntegrationId: source, targetIntegrationId: secondTarget })
+    expect(duplicate.status).toBe(409)
+    expect(duplicate.body.error.code).toBe('ORG_TRANSFER_ACTIVE_EXISTS')
+
+    const cancel = await request(adminApp).post(`/api/admin/directory/org-transfers/${firstId}/cancel`)
+    expect(cancel.status).toBe(200)
+    expect(cancel.body.data.transfer.status).toBe('cancelled')
+    expect(await auditRowFor('cancel', firstId)).toBe(1)
+
+    // Terminal cancelled row no longer occupies the ACTIVE slot.
+    await createTransfer(source, secondTarget)
+  })
+
+  it('blocks apply while any scanned decision is undecided (guard seeded directly — the no-op adapter scans zero)', async () => {
+    const { source, target } = await seedPair('undecided')
+    const transferId = await createTransfer(source, target)
+    await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`).expect(200)
+    await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply?dryRun=true`).expect(200)
+
+    await query(
+      `INSERT INTO provider_org_transfer_decisions (transfer_id, binding_kind, source_anchor_type, source_anchor_id)
+       VALUES ($1, 'user_identity', 'user', $2)`,
+      [transferId, `t1-user-${STAMP}`]
+    )
+
+    const apply = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply`)
+    expect(apply.status).toBe(409)
+    expect(apply.body.error.code).toBe('ORG_TRANSFER_DECISIONS_PENDING')
+
+    // Positive control: deciding the row (skip) unblocks the same apply.
+    await query(`UPDATE provider_org_transfer_decisions SET decision = 'skip', updated_at = now() WHERE transfer_id = $1`, [transferId])
+    const applyAfter = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply`)
+    expect(applyAfter.status).toBe(200)
+    expect(applyAfter.body.data.transfer.status).toBe('applied')
+  })
+
+  it('linearizes concurrent applies on the row lock — exactly one 200, one clean 409, one applied_at', async () => {
+    const { source, target } = await seedPair('race')
+    const transferId = await createTransfer(source, target)
+    await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`).expect(200)
+    await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply?dryRun=true`).expect(200)
+
+    const [first, second] = await Promise.all([
+      request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply`),
+      request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply`),
+    ])
+    const statuses = [first.status, second.status].sort()
+    expect(statuses).toEqual([200, 409])
+    const loser = first.status === 409 ? first : second
+    expect(loser.body.error.code).toBe('ORG_TRANSFER_INVALID_STATE')
+
+    const row = await query<{ status: string; applied_at: string | null }>(
+      `SELECT status, applied_at::text FROM provider_org_transfers WHERE id = $1`,
+      [transferId]
+    )
+    expect(row.rows[0].status).toBe('applied')
+    expect(row.rows[0].applied_at).not.toBeNull()
+    // Exactly one apply audit row — the 409 loser never audits.
+    expect(await auditRowFor('apply', transferId)).toBe(1)
+  })
+
+  it('rejects a dryRun query value other than exactly "true" instead of coercing it into a REAL apply', async () => {
+    const { source, target } = await seedPair('dryrun-strict')
+    const transferId = await createTransfer(source, target)
+
+    for (const value of ['false', '1', 'yes', 'TRUE']) {
+      const res = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply?dryRun=${value}`)
+      expect(res.status, value).toBe(400)
+      expect(res.body.error.code).toBe('ORG_TRANSFER_INVALID_INPUT')
+    }
+  })
+
+  it('404s an unknown transfer and 400s a non-UUID transfer id on read', async () => {
+    const missing = await request(adminApp).get(`/api/admin/directory/org-transfers/${randomUUID()}`)
+    expect(missing.status).toBe(404)
+    expect(missing.body.error.code).toBe('ORG_TRANSFER_NOT_FOUND')
+
+    const malformed = await request(adminApp).get('/api/admin/directory/org-transfers/not-a-uuid')
+    expect(malformed.status).toBe(400)
+    expect(malformed.body.error.code).toBe('ORG_TRANSFER_INVALID_INPUT')
+  })
+})

--- a/packages/core-backend/tests/integration/provider-org-transfer-t1.api.test.ts
+++ b/packages/core-backend/tests/integration/provider-org-transfer-t1.api.test.ts
@@ -21,7 +21,8 @@ import { adminDirectoryOrgTransfersRouter } from '../../src/routes/admin-directo
  * What this suite pins, per the T1 row of the MVP sequencing plan:
  *   - platform-admin gating on every route (403 leg per endpoint);
  *   - create validations fail closed with ZERO rows and ZERO audit rows (audit-zero assertions
- *     are scoped to this suite's unique actor id — never global counts);
+ *     are action-namespace scoped on `directory.org_transfer.%` — never global audit counts,
+ *     never actor-id scoped);
  *   - the SCHEMA backstops (not just service validation): cross-org and provider-mismatched
  *     transfers are FK-impossible to INSERT even bypassing the service; provider='local' is
  *     CHECK-impossible;
@@ -34,11 +35,16 @@ import { adminDirectoryOrgTransfersRouter } from '../../src/routes/admin-directo
  *   - at-most-one-ACTIVE-transfer-per-source (both halves: cap while active, free after cancel);
  *   - terminal states reject every further mutation;
  *   - apply/apply concurrency linearizes on the row lock (exactly one 200);
- *   - the registered no-op apply writes NOTHING to any directory_* table (fingerprint equality);
+ *   - the registered no-op apply writes NOTHING to directory accounts/departments/memberships/
+ *     identities owned by this test's source/target integrations + uniquely seeded identity
+ *     keys (scoped fingerprint — NOT global table counts/max timestamps, so it stays correct
+ *     when this file runs in the same Vitest invocation as B1–B7 directory suites); a positive
+ *     scoped write proves the fingerprint is non-vacuous;
  *   - lifecycle body contract: scan / apply (dry-run + real) / cancel reject ANY smuggled field
  *     with 400 ORG_TRANSFER_UNKNOWN_FIELDS, zero state change, zero success audit, and never
  *     reach the service seam (independent mutations: remove each endpoint's body guard → its
- *     own test reds); CREATE rejects arrays/non-plain objects the same way;
+ *     own test reds); CREATE rejects arrays the same way. Primitive JSON never reaches the route
+ *     under production express.json({strict:true}) — generic parser 400 only, not our code;
  *   - unexpected-error and audit-failure logs are values-free fixed metadata only (never
  *     Error.message/name, SQL detail, body, provider, corp/tenant, URLs, directory values) —
  *     restoring raw error logging reds the log-boundary tests.
@@ -84,10 +90,10 @@ async function seedIntegration(org: string, provider: string, tag: string): Prom
 }
 
 /**
- * The `directory.org_transfer.%` action namespace is written by NOTHING but the T1 routes, and
- * audit_logs has no text actor column (auditLog only maps numeric actor ids into user_id), so
- * the zero-audit assertions scope on the action prefix — unique to this feature, race-free
- * against every other suite sharing the CI database.
+ * The `directory.org_transfer.%` action namespace is written by NOTHING but the T1 routes, so
+ * zero-audit assertions scope on that action prefix (action-namespace scoped) — race-free
+ * against every other suite sharing the CI database. Not actor-id scoped: auditLog maps only
+ * numeric actor ids into user_id, so our string admin ids never land as a reliable actor key.
  */
 async function orgTransferAuditCount(): Promise<number> {
   const result = await query<{ n: string }>(
@@ -104,15 +110,51 @@ async function auditRowFor(action: string, transferId: string): Promise<number> 
   return Number(result.rows[0].n)
 }
 
-/** Row-count + latest-updated fingerprint over every table the no-op apply must not touch. */
-async function directoryFingerprint(): Promise<string> {
+/**
+ * Concurrency-safe fingerprint of directory substrate rows this test owns.
+ *
+ * Scoped strictly to:
+ *   - directory_accounts / directory_departments for the given integration ids (source+target)
+ *   - memberships whose account belongs to those integrations
+ *   - user_external_identities whose external_key is in the test-seeded key set
+ *
+ * Deliberately NOT global counts / max(updated_at) over whole tables — those race with B1–B7
+ * directory suites in the same Vitest invocation (required CI runs this file alongside them).
+ * Content includes id + business anchors + is_active + updated_at so an UPDATE (not only INSERT)
+ * to a owned row still moves the fingerprint.
+ */
+async function scopedDirectoryFingerprint(integrationIds: string[], identityExternalKeys: string[]): Promise<string> {
   const result = await query<{ fp: string }>(
     `SELECT concat_ws('|',
-        (SELECT concat(count(*), ':', coalesce(max(updated_at)::text, '-')) FROM directory_accounts),
-        (SELECT concat(count(*), ':', coalesce(max(updated_at)::text, '-')) FROM directory_departments),
-        (SELECT concat(count(*), ':', coalesce(max(created_at)::text, '-')) FROM directory_account_departments),
-        (SELECT count(*)::text FROM user_external_identities)
-      ) AS fp`
+        (SELECT coalesce(string_agg(sig, ',' ORDER BY sig), '-')
+           FROM (
+             SELECT concat_ws(':', id::text, external_user_id, name, is_active::text, updated_at::text) AS sig
+               FROM directory_accounts
+              WHERE integration_id = ANY($1::uuid[])
+           ) a),
+        (SELECT coalesce(string_agg(sig, ',' ORDER BY sig), '-')
+           FROM (
+             SELECT concat_ws(':', id::text, external_department_id, name, is_active::text, updated_at::text) AS sig
+               FROM directory_departments
+              WHERE integration_id = ANY($1::uuid[])
+           ) d),
+        (SELECT coalesce(string_agg(sig, ',' ORDER BY sig), '-')
+           FROM (
+             SELECT concat_ws(':', ad.directory_account_id::text, ad.directory_department_id::text,
+                             ad.is_primary::text, ad.is_manager::text, ad.created_at::text) AS sig
+               FROM directory_account_departments ad
+               JOIN directory_accounts a ON a.id = ad.directory_account_id
+              WHERE a.integration_id = ANY($1::uuid[])
+           ) m),
+        (SELECT coalesce(string_agg(sig, ',' ORDER BY sig), '-')
+           FROM (
+             SELECT concat_ws(':', id::text, provider, external_key, local_user_id,
+                             coalesce(corp_id, ''), updated_at::text) AS sig
+               FROM user_external_identities
+              WHERE external_key = ANY($2::text[])
+           ) i)
+      ) AS fp`,
+    [integrationIds, identityExternalKeys]
   )
   return result.rows[0].fp
 }
@@ -120,15 +162,40 @@ async function directoryFingerprint(): Promise<string> {
 describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API skeleton (real DB, HTTP)', () => {
   const createdTransferIds: string[] = []
   const createdIntegrationIds: string[] = []
+  const createdUserIds: string[] = []
+  const createdIdentityKeys: string[] = []
+  /** Restored in afterEach even if a test assertion fails mid-flight (mutation hygiene). */
+  const activeSpies: Array<{ mockRestore: () => void }> = []
+
+  function trackSpy<T extends { mockRestore: () => void }>(spy: T): T {
+    activeSpies.push(spy)
+    return spy
+  }
 
   afterEach(async () => {
+    // Spies first: a red assertion must never leave a mock binding for the next case.
+    while (activeSpies.length > 0) {
+      const spy = activeSpies.pop()
+      try {
+        spy?.mockRestore()
+      } catch {
+        // already restored
+      }
+    }
     // Deterministic registry cleanup: happy-path tests register the no-op for 'dingtalk';
     // production-no-adapter tests leave it unregistered. Never leak either state across cases.
     unregisterOrgTransferAdapter('dingtalk')
     const transfers = createdTransferIds.splice(0)
     for (const id of transfers) await query(`DELETE FROM provider_org_transfers WHERE id = $1`, [id]) // decisions cascade
+    // Identities before users (FK); accounts/depts/memberships cascade with integrations.
+    const identityKeys = createdIdentityKeys.splice(0)
+    if (identityKeys.length > 0) {
+      await query(`DELETE FROM user_external_identities WHERE external_key = ANY($1::text[])`, [identityKeys])
+    }
     const integrations = createdIntegrationIds.splice(0)
     for (const id of integrations) await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
+    const users = createdUserIds.splice(0)
+    for (const id of users) await query(`DELETE FROM users WHERE id = $1`, [id])
   })
 
   /** Explicit test-only registration — production has no silent no-op fallback. */
@@ -182,6 +249,75 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     return Number(result.rows[0].n)
   }
 
+  /**
+   * Seed unique directory anchors under source+target integrations (plus one identity key) so the
+   * no-op apply fingerprint is non-empty and concurrency-safe against parallel B1–B7 traffic.
+   */
+  async function seedScopedDirectoryAnchors(
+    sourceIntegrationId: string,
+    targetIntegrationId: string,
+    tag: string
+  ): Promise<{ identityExternalKeys: string[]; sourceAccountId: string }> {
+    const suffix = `${STAMP}-${tag}-${randomUUID().slice(0, 8)}`
+    const localUserId = `t1-fp-user-${suffix}`
+    const identityKey = `dingtalk:t1-fp-${suffix}`
+    const sourceExtUser = `t1-src-user-${suffix}`
+    const targetExtUser = `t1-dst-user-${suffix}`
+    const sourceExtDept = `t1-src-dept-${suffix}`
+    const targetExtDept = `t1-dst-dept-${suffix}`
+
+    await query(
+      `INSERT INTO users (id, email, name, password_hash, role)
+       VALUES ($1, $2, $3, 't1-fp-hash', 'user')`,
+      [localUserId, `${localUserId}@t1.example.test`, `T1 FP ${tag}`]
+    )
+    createdUserIds.push(localUserId)
+
+    const sourceAccount = await query<{ id: string }>(
+      `INSERT INTO directory_accounts
+         (integration_id, provider, external_user_id, external_key, name, is_active, raw)
+       VALUES ($1, 'dingtalk', $2, $2, $3, true, '{}'::jsonb)
+       RETURNING id`,
+      [sourceIntegrationId, sourceExtUser, `T1 source account ${tag}`]
+    )
+    const targetAccount = await query<{ id: string }>(
+      `INSERT INTO directory_accounts
+         (integration_id, provider, external_user_id, external_key, name, is_active, raw)
+       VALUES ($1, 'dingtalk', $2, $2, $3, true, '{}'::jsonb)
+       RETURNING id`,
+      [targetIntegrationId, targetExtUser, `T1 target account ${tag}`]
+    )
+    const sourceDept = await query<{ id: string }>(
+      `INSERT INTO directory_departments
+         (integration_id, provider, external_department_id, name, is_active, raw)
+       VALUES ($1, 'dingtalk', $2, $3, true, '{}'::jsonb)
+       RETURNING id`,
+      [sourceIntegrationId, sourceExtDept, `T1 source dept ${tag}`]
+    )
+    const targetDept = await query<{ id: string }>(
+      `INSERT INTO directory_departments
+         (integration_id, provider, external_department_id, name, is_active, raw)
+       VALUES ($1, 'dingtalk', $2, $3, true, '{}'::jsonb)
+       RETURNING id`,
+      [targetIntegrationId, targetExtDept, `T1 target dept ${tag}`]
+    )
+    await query(
+      `INSERT INTO directory_account_departments
+         (directory_account_id, directory_department_id, is_primary, is_manager)
+       VALUES ($1, $2, true, false), ($3, $4, true, false)`,
+      [sourceAccount.rows[0].id, sourceDept.rows[0].id, targetAccount.rows[0].id, targetDept.rows[0].id]
+    )
+    await query(
+      `INSERT INTO user_external_identities
+         (provider, external_key, provider_user_id, corp_id, local_user_id, profile)
+       VALUES ('dingtalk', $1, $2, $3, $4, '{}'::jsonb)`,
+      [identityKey, sourceExtUser, `t1-corp-${suffix}`, localUserId]
+    )
+    createdIdentityKeys.push(identityKey)
+
+    return { identityExternalKeys: [identityKey], sourceAccountId: sourceAccount.rows[0].id }
+  }
+
   it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
     expect(process.env.DATABASE_URL).toBeTruthy()
   })
@@ -213,7 +349,7 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     expect(after.rows[0].n).toBe(before.rows[0].n)
   })
 
-  it('fails create closed on every invalid input — zero rows, zero audit rows (actor-scoped)', async () => {
+  it('fails create closed on every invalid input — zero rows, zero audit rows (action-namespace scoped)', async () => {
     const { org, source, target } = await seedPair('valid')
     const otherOrgIntegration = await seedIntegration(uniqueOrg('valid-other'), 'dingtalk', 'valid-other')
     const wecomIntegration = await seedIntegration(org, 'wecom', 'valid-wecom')
@@ -379,11 +515,16 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     expect(await orgTransferAuditCount()).toBe(auditBefore)
   })
 
-  it('walks the happy lifecycle with one values-free audit row per mutation and an untouched directory fingerprint', async () => {
+  it('walks the happy lifecycle with one values-free audit row per mutation and an untouched scoped directory fingerprint', async () => {
     enableNoopAdapter()
     const { source, target } = await seedPair('happy')
     const transferId = await createTransfer(source, target)
     expect(await auditRowFor('create', transferId)).toBe(1)
+
+    // Seed unique anchors under THIS transfer's source+target only — fingerprint never reads
+    // global directory counts (those race with B1–B7 in the same Vitest process).
+    const anchors = await seedScopedDirectoryAnchors(source, target, 'happy')
+    const ownedIntegrations = [source, target]
 
     const read = await request(adminApp).get(`/api/admin/directory/org-transfers/${transferId}`)
     expect(read.status).toBe(200)
@@ -412,15 +553,44 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     expect(dryRun.body.data.transfer.dryRunAt).not.toBeNull()
     expect(await auditRowFor('dry_run', transferId)).toBe(1)
 
-    const fingerprintBefore = await directoryFingerprint()
+    const fingerprintBefore = await scopedDirectoryFingerprint(ownedIntegrations, anchors.identityExternalKeys)
+    // Non-vacuous: fingerprint must include the seeded substrate (not an empty sentinel that
+    // would stay equal even if apply wrote unrelated rows elsewhere).
+    expect(fingerprintBefore).not.toBe('-|-|-|-')
+    expect(fingerprintBefore.includes(anchors.sourceAccountId)).toBe(true)
+
+    // Positive mutation control: one scoped directory write MUST move this fingerprint.
+    // Removing the sensitivity of scopedDirectoryFingerprint (or scoping to the wrong ids)
+    // reds this — proving the no-op equality below is load-bearing, not skip-green.
+    const positiveExt = `t1-fp-positive-${STAMP}-${randomUUID().slice(0, 8)}`
+    const positive = await query<{ id: string }>(
+      `INSERT INTO directory_accounts
+         (integration_id, provider, external_user_id, external_key, name, is_active, raw)
+       VALUES ($1, 'dingtalk', $2, $2, 'T1 positive-control write', true, '{}'::jsonb)
+       RETURNING id`,
+      [source, positiveExt]
+    )
+    const fingerprintAfterPositiveWrite = await scopedDirectoryFingerprint(
+      ownedIntegrations,
+      anchors.identityExternalKeys
+    )
+    expect(fingerprintAfterPositiveWrite).not.toBe(fingerprintBefore)
+    expect(fingerprintAfterPositiveWrite.includes(positive.rows[0].id)).toBe(true)
+    // Restore the pre-apply substrate so the no-op proof is against a clean, known set.
+    await query(`DELETE FROM directory_accounts WHERE id = $1`, [positive.rows[0].id])
+    const fingerprintStable = await scopedDirectoryFingerprint(ownedIntegrations, anchors.identityExternalKeys)
+    expect(fingerprintStable).toBe(fingerprintBefore)
+
     const apply = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply`)
     expect(apply.status).toBe(200)
     expect(apply.body.data.transfer.status).toBe('applied')
     expect(apply.body.data.transfer.appliedAt).not.toBeNull()
     expect(await auditRowFor('apply', transferId)).toBe(1)
 
-    // Registered no-op apply is a no-op by contract: nothing in the directory substrate moved.
-    expect(await directoryFingerprint()).toBe(fingerprintBefore)
+    // Registered no-op apply writes nothing to owned accounts/depts/memberships/identities.
+    expect(await scopedDirectoryFingerprint(ownedIntegrations, anchors.identityExternalKeys)).toBe(
+      fingerprintStable
+    )
 
     // Terminal: every further mutation is refused.
     for (const path of ['scan', 'apply', 'cancel']) {
@@ -575,7 +745,7 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     const transferId = await createTransfer(source, target)
     const auditBefore = await orgTransferAuditCount()
     const before = await transferRow(transferId)
-    const scanSpy = vi.spyOn(orgTransferService, 'scanOrgTransfer')
+    const scanSpy = trackSpy(vi.spyOn(orgTransferService, 'scanOrgTransfer'))
 
     const res = await request(adminApp)
       .post(`/api/admin/directory/org-transfers/${transferId}/scan`)
@@ -588,7 +758,6 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     expect(await decisionCount(transferId)).toBe(0)
     expect(await auditRowFor('scan', transferId)).toBe(0)
     expect(await orgTransferAuditCount()).toBe(auditBefore)
-    scanSpy.mockRestore()
   })
 
   it('dry-run apply rejects a smuggled body field — 400 UNKNOWN_FIELDS, zero state/audit, never reaches service', async () => {
@@ -599,8 +768,8 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`).expect(200)
     const auditBefore = await orgTransferAuditCount()
     const before = await transferRow(transferId)
-    const dryRunSpy = vi.spyOn(orgTransferService, 'dryRunOrgTransfer')
-    const applySpy = vi.spyOn(orgTransferService, 'applyOrgTransfer')
+    const dryRunSpy = trackSpy(vi.spyOn(orgTransferService, 'dryRunOrgTransfer'))
+    const applySpy = trackSpy(vi.spyOn(orgTransferService, 'applyOrgTransfer'))
 
     const res = await request(adminApp)
       .post(`/api/admin/directory/org-transfers/${transferId}/apply?dryRun=true`)
@@ -613,8 +782,6 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     expect(await transferRow(transferId)).toEqual(before)
     expect(await auditRowFor('dry_run', transferId)).toBe(0)
     expect(await orgTransferAuditCount()).toBe(auditBefore)
-    dryRunSpy.mockRestore()
-    applySpy.mockRestore()
   })
 
   it('real apply rejects a smuggled body field — 400 UNKNOWN_FIELDS, zero state/audit, never reaches service', async () => {
@@ -626,7 +793,7 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply?dryRun=true`).expect(200)
     const auditBefore = await orgTransferAuditCount()
     const before = await transferRow(transferId)
-    const applySpy = vi.spyOn(orgTransferService, 'applyOrgTransfer')
+    const applySpy = trackSpy(vi.spyOn(orgTransferService, 'applyOrgTransfer'))
 
     const res = await request(adminApp)
       .post(`/api/admin/directory/org-transfers/${transferId}/apply`)
@@ -638,7 +805,6 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     expect(await transferRow(transferId)).toEqual(before)
     expect(await auditRowFor('apply', transferId)).toBe(0)
     expect(await orgTransferAuditCount()).toBe(auditBefore)
-    applySpy.mockRestore()
   })
 
   it('cancel rejects a smuggled body field — 400 UNKNOWN_FIELDS, zero state/audit, never reaches service', async () => {
@@ -647,7 +813,7 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     const transferId = await createTransfer(source, target)
     const auditBefore = await orgTransferAuditCount()
     const before = await transferRow(transferId)
-    const cancelSpy = vi.spyOn(orgTransferService, 'cancelOrgTransfer')
+    const cancelSpy = trackSpy(vi.spyOn(orgTransferService, 'cancelOrgTransfer'))
 
     const res = await request(adminApp)
       .post(`/api/admin/directory/org-transfers/${transferId}/cancel`)
@@ -659,17 +825,17 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     expect(await transferRow(transferId)).toEqual(before)
     expect(await auditRowFor('cancel', transferId)).toBe(0)
     expect(await orgTransferAuditCount()).toBe(auditBefore)
-    cancelSpy.mockRestore()
   })
 
   it('lifecycle empty body / empty object remain allowed; arrays cannot bypass the contract', async () => {
-    // express.json({strict:true}) (default) rejects primitive JSON (number/null/string/bool)
-    // before the route — those never reach our body contract. Arrays DO reach the handler and
-    // are the load-bearing non-plain bypass: Object.keys([]) === [] would look like "empty".
+    // Production express.json({strict:true}) rejects primitive JSON (number/null/string/bool)
+    // at the parser with a generic 400 before the route — we do NOT claim ORG_TRANSFER_UNKNOWN_FIELDS
+    // for those. Arrays DO reach the handler and are the load-bearing non-plain bypass:
+    // Object.keys([]) === [] would look like "empty" without the plain-object gate.
     enableNoopAdapter()
     const { source, target } = await seedPair('body-empty')
     const transferId = await createTransfer(source, target)
-    const cancelSpy = vi.spyOn(orgTransferService, 'cancelOrgTransfer')
+    const cancelSpy = trackSpy(vi.spyOn(orgTransferService, 'cancelOrgTransfer'))
 
     // Omitted body + explicit {} are the only allowed lifecycle payloads.
     await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`).expect(200)
@@ -695,15 +861,15 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     expect(cancelSpy).not.toHaveBeenCalled()
     // Transfer still scanned (cancel never applied); not cancelled.
     expect((await transferRow(transferId)).status).toBe('scanned')
-    cancelSpy.mockRestore()
   })
 
   it('CREATE rejects arrays with ORG_TRANSFER_UNKNOWN_FIELDS (zero rows, zero audit, never reaches service)', async () => {
-    // Feasible through the real Express parser: JSON arrays reach the route. Primitive JSON
-    // bodies are rejected by express.json strict mode before our handler (not ORG_TRANSFER_*).
+    // Arrays reach the route through production express.json. Primitive JSON is rejected by
+    // express.json strict mode with a generic parser 400 — not ORG_TRANSFER_UNKNOWN_FIELDS —
+    // and is intentionally not asserted here.
     const { source, target } = await seedPair('body-create')
     const auditBefore = await orgTransferAuditCount()
-    const createSpy = vi.spyOn(orgTransferService, 'createOrgTransfer')
+    const createSpy = trackSpy(vi.spyOn(orgTransferService, 'createOrgTransfer'))
 
     const arrayBody = await request(adminApp)
       .post('/api/admin/directory/org-transfers')
@@ -725,7 +891,6 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     )
     expect(rows.rows[0].n).toBe('0')
     expect(await orgTransferAuditCount()).toBe(auditBefore)
-    createSpy.mockRestore()
   })
 
   // -------------------------------------------------------------------------------------------
@@ -739,40 +904,36 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     const forced = new Error(`relation "${relationNeedle}" does not exist — corp=dingtalk-corp-xyz url=https://evil.example/sync`)
     forced.name = nameSentinel
 
-    const getSpy = vi.spyOn(orgTransferService, 'getOrgTransfer').mockRejectedValue(forced)
-    const warnSpy = vi.spyOn(Logger.prototype, 'warn')
-    try {
-      const res = await request(adminApp).get(`/api/admin/directory/org-transfers/${randomUUID()}`)
-      expect(res.status).toBe(500)
-      expect(res.body.error.code).toBe('ORG_TRANSFER_INTERNAL_ERROR')
-      // Client HTTP message stays the server-authored fixed fallback — not the raw exception.
-      expect(res.body.error.message).toBe('Failed to read org transfer')
-      expect(JSON.stringify(res.body)).not.toContain(nameSentinel)
-      expect(JSON.stringify(res.body)).not.toContain(relationNeedle)
-      expect(JSON.stringify(res.body)).not.toContain('evil.example')
+    const getSpy = trackSpy(vi.spyOn(orgTransferService, 'getOrgTransfer').mockRejectedValue(forced))
+    const warnSpy = trackSpy(vi.spyOn(Logger.prototype, 'warn'))
 
-      const unexpectedWarns = warnSpy.mock.calls.filter(
-        (call) => typeof call[0] === 'string' && call[0] === 'Failed to read org transfer'
-      )
-      expect(unexpectedWarns.length).toBeGreaterThanOrEqual(1)
-      const [message, meta] = unexpectedWarns[0] as [string, Record<string, unknown>]
-      const serialized = JSON.stringify({ message, meta })
-      expect(serialized).not.toContain(nameSentinel)
-      expect(serialized).not.toContain(relationNeedle)
-      expect(serialized).not.toContain('evil.example')
-      expect(serialized).not.toContain('dingtalk-corp-xyz')
-      expect(serialized.toLowerCase()).not.toContain('does not exist')
-      expect(meta).toEqual({ reason: 'unexpected_error' })
-      expect(meta).not.toHaveProperty('error')
-      expect(meta).not.toHaveProperty('errorClass')
-      expect(meta).not.toHaveProperty('stack')
-      expect(meta).not.toHaveProperty('code')
-      expect(meta).not.toHaveProperty('provider')
-      expect(meta).not.toHaveProperty('body')
-    } finally {
-      warnSpy.mockRestore()
-      getSpy.mockRestore()
-    }
+    const res = await request(adminApp).get(`/api/admin/directory/org-transfers/${randomUUID()}`)
+    expect(res.status).toBe(500)
+    expect(res.body.error.code).toBe('ORG_TRANSFER_INTERNAL_ERROR')
+    // Client HTTP message stays the server-authored fixed fallback — not the raw exception.
+    expect(res.body.error.message).toBe('Failed to read org transfer')
+    expect(JSON.stringify(res.body)).not.toContain(nameSentinel)
+    expect(JSON.stringify(res.body)).not.toContain(relationNeedle)
+    expect(JSON.stringify(res.body)).not.toContain('evil.example')
+
+    const unexpectedWarns = warnSpy.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && call[0] === 'Failed to read org transfer'
+    )
+    expect(unexpectedWarns.length).toBeGreaterThanOrEqual(1)
+    const [message, meta] = unexpectedWarns[0] as [string, Record<string, unknown>]
+    const serialized = JSON.stringify({ message, meta })
+    expect(serialized).not.toContain(nameSentinel)
+    expect(serialized).not.toContain(relationNeedle)
+    expect(serialized).not.toContain('evil.example')
+    expect(serialized).not.toContain('dingtalk-corp-xyz')
+    expect(serialized.toLowerCase()).not.toContain('does not exist')
+    expect(meta).toEqual({ reason: 'unexpected_error' })
+    expect(meta).not.toHaveProperty('error')
+    expect(meta).not.toHaveProperty('errorClass')
+    expect(meta).not.toHaveProperty('stack')
+    expect(meta).not.toHaveProperty('code')
+    expect(meta).not.toHaveProperty('provider')
+    expect(meta).not.toHaveProperty('body')
   })
 
   it('audit-write failures log fixed metadata only (no raw Error text); mutation still succeeds', async () => {
@@ -783,31 +944,28 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     const forced = new Error(`insert into audit_logs failed: detail=provider=dingtalk corp_id=SECRET_CORP`)
     forced.name = nameSentinel
 
-    const auditSpy = vi.spyOn(auditModule, 'auditLog').mockRejectedValue(forced)
-    const warnSpy = vi.spyOn(Logger.prototype, 'warn')
-    try {
-      const transferId = await createTransfer(source, target)
-      // createTransfer expects 200 — audit is best-effort and must not fail the mutation.
-      expect(transferId).toBeTruthy()
+    const auditSpy = trackSpy(vi.spyOn(auditModule, 'auditLog').mockRejectedValue(forced))
+    const warnSpy = trackSpy(vi.spyOn(Logger.prototype, 'warn'))
 
-      const auditWarns = warnSpy.mock.calls.filter(
-        (call) => typeof call[0] === 'string' && call[0] === 'org-transfer audit write failed'
-      )
-      expect(auditWarns.length).toBeGreaterThanOrEqual(1)
-      const [message, meta] = auditWarns[0] as [string, Record<string, unknown>]
-      const serialized = JSON.stringify({ message, meta })
-      expect(serialized).not.toContain(nameSentinel)
-      expect(serialized).not.toContain('SECRET_CORP')
-      expect(serialized).not.toContain('audit_logs')
-      expect(serialized.toLowerCase()).not.toContain('insert into')
-      expect(meta).toEqual({ action: 'create', reason: 'audit_write_failed' })
-      expect(meta).not.toHaveProperty('error')
-      expect(meta).not.toHaveProperty('errorClass')
-      expect(meta).not.toHaveProperty('stack')
-      expect(meta).not.toHaveProperty('provider')
-    } finally {
-      warnSpy.mockRestore()
-      auditSpy.mockRestore()
-    }
+    const transferId = await createTransfer(source, target)
+    // createTransfer expects 200 — audit is best-effort and must not fail the mutation.
+    expect(transferId).toBeTruthy()
+
+    const auditWarns = warnSpy.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && call[0] === 'org-transfer audit write failed'
+    )
+    expect(auditWarns.length).toBeGreaterThanOrEqual(1)
+    const [message, meta] = auditWarns[0] as [string, Record<string, unknown>]
+    const serialized = JSON.stringify({ message, meta })
+    expect(serialized).not.toContain(nameSentinel)
+    expect(serialized).not.toContain('SECRET_CORP')
+    expect(serialized).not.toContain('audit_logs')
+    expect(serialized.toLowerCase()).not.toContain('insert into')
+    expect(meta).toEqual({ action: 'create', reason: 'audit_write_failed' })
+    expect(meta).not.toHaveProperty('error')
+    expect(meta).not.toHaveProperty('errorClass')
+    expect(meta).not.toHaveProperty('stack')
+    expect(meta).not.toHaveProperty('provider')
+    void auditSpy
   })
 })

--- a/packages/core-backend/tests/integration/provider-org-transfer-t1.api.test.ts
+++ b/packages/core-backend/tests/integration/provider-org-transfer-t1.api.test.ts
@@ -1,8 +1,11 @@
 import { randomUUID } from 'crypto'
 import express from 'express'
 import request from 'supertest'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as auditModule from '../../src/audit/audit'
+import { Logger } from '../../src/core/logger'
 import { query } from '../../src/db/pg'
+import * as orgTransferService from '../../src/directory/org-transfer-service'
 import {
   noopOrgTransferAdapter,
   registerOrgTransferAdapter,
@@ -31,7 +34,14 @@ import { adminDirectoryOrgTransfersRouter } from '../../src/routes/admin-directo
  *   - at-most-one-ACTIVE-transfer-per-source (both halves: cap while active, free after cancel);
  *   - terminal states reject every further mutation;
  *   - apply/apply concurrency linearizes on the row lock (exactly one 200);
- *   - the registered no-op apply writes NOTHING to any directory_* table (fingerprint equality).
+ *   - the registered no-op apply writes NOTHING to any directory_* table (fingerprint equality);
+ *   - lifecycle body contract: scan / apply (dry-run + real) / cancel reject ANY smuggled field
+ *     with 400 ORG_TRANSFER_UNKNOWN_FIELDS, zero state change, zero success audit, and never
+ *     reach the service seam (independent mutations: remove each endpoint's body guard → its
+ *     own test reds); CREATE rejects arrays/non-plain objects the same way;
+ *   - unexpected-error and audit-failure logs are values-free fixed metadata only (never
+ *     Error.message/name, SQL detail, body, provider, corp/tenant, URLs, directory values) —
+ *     restoring raw error logging reds the log-boundary tests.
  *
  * DATABASE_URL-gated (describeIfDatabase): excluded from the no-DB vitest job so it cannot
  * skip-green, and wired as a WHOLE FILE into the directory real-DB step in plugin-tests.yml
@@ -551,5 +561,253 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
     const malformed = await request(adminApp).get('/api/admin/directory/org-transfers/not-a-uuid')
     expect(malformed.status).toBe(400)
     expect(malformed.body.error.code).toBe('ORG_TRANSFER_INVALID_INPUT')
+  })
+
+  // -------------------------------------------------------------------------------------------
+  // Lifecycle body contract — fail-closed before service + audit (distinct smuggled field each)
+  // -------------------------------------------------------------------------------------------
+
+  it('scan rejects a smuggled body field — 400 UNKNOWN_FIELDS, zero state/audit, never reaches service', async () => {
+    // Distinct field for THIS endpoint only. Remove the scan-route body guard → this test reds
+    // (service is called, status flips to scanned with the registered no-op).
+    enableNoopAdapter()
+    const { source, target } = await seedPair('body-scan')
+    const transferId = await createTransfer(source, target)
+    const auditBefore = await orgTransferAuditCount()
+    const before = await transferRow(transferId)
+    const scanSpy = vi.spyOn(orgTransferService, 'scanOrgTransfer')
+
+    const res = await request(adminApp)
+      .post(`/api/admin/directory/org-transfers/${transferId}/scan`)
+      .send({ org_id: 'evil-scan-smuggle' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('ORG_TRANSFER_UNKNOWN_FIELDS')
+    expect(scanSpy).not.toHaveBeenCalled()
+    expect(await transferRow(transferId)).toEqual(before)
+    expect(await decisionCount(transferId)).toBe(0)
+    expect(await auditRowFor('scan', transferId)).toBe(0)
+    expect(await orgTransferAuditCount()).toBe(auditBefore)
+    scanSpy.mockRestore()
+  })
+
+  it('dry-run apply rejects a smuggled body field — 400 UNKNOWN_FIELDS, zero state/audit, never reaches service', async () => {
+    // Distinct field vs scan/cancel/real-apply. Remove the apply-route body guard → this test reds.
+    enableNoopAdapter()
+    const { source, target } = await seedPair('body-dryrun')
+    const transferId = await createTransfer(source, target)
+    await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`).expect(200)
+    const auditBefore = await orgTransferAuditCount()
+    const before = await transferRow(transferId)
+    const dryRunSpy = vi.spyOn(orgTransferService, 'dryRunOrgTransfer')
+    const applySpy = vi.spyOn(orgTransferService, 'applyOrgTransfer')
+
+    const res = await request(adminApp)
+      .post(`/api/admin/directory/org-transfers/${transferId}/apply?dryRun=true`)
+      .send({ corp_id: 'evil-dryrun-smuggle' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('ORG_TRANSFER_UNKNOWN_FIELDS')
+    expect(dryRunSpy).not.toHaveBeenCalled()
+    expect(applySpy).not.toHaveBeenCalled()
+    expect(await transferRow(transferId)).toEqual(before)
+    expect(await auditRowFor('dry_run', transferId)).toBe(0)
+    expect(await orgTransferAuditCount()).toBe(auditBefore)
+    dryRunSpy.mockRestore()
+    applySpy.mockRestore()
+  })
+
+  it('real apply rejects a smuggled body field — 400 UNKNOWN_FIELDS, zero state/audit, never reaches service', async () => {
+    // Distinct field. Remove the apply-route body guard → this test reds (would apply).
+    enableNoopAdapter()
+    const { source, target } = await seedPair('body-apply')
+    const transferId = await createTransfer(source, target)
+    await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`).expect(200)
+    await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/apply?dryRun=true`).expect(200)
+    const auditBefore = await orgTransferAuditCount()
+    const before = await transferRow(transferId)
+    const applySpy = vi.spyOn(orgTransferService, 'applyOrgTransfer')
+
+    const res = await request(adminApp)
+      .post(`/api/admin/directory/org-transfers/${transferId}/apply`)
+      .send({ force: true })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('ORG_TRANSFER_UNKNOWN_FIELDS')
+    expect(applySpy).not.toHaveBeenCalled()
+    expect(await transferRow(transferId)).toEqual(before)
+    expect(await auditRowFor('apply', transferId)).toBe(0)
+    expect(await orgTransferAuditCount()).toBe(auditBefore)
+    applySpy.mockRestore()
+  })
+
+  it('cancel rejects a smuggled body field — 400 UNKNOWN_FIELDS, zero state/audit, never reaches service', async () => {
+    // Distinct field. Remove the cancel-route body guard → this test reds (status → cancelled).
+    const { source, target } = await seedPair('body-cancel')
+    const transferId = await createTransfer(source, target)
+    const auditBefore = await orgTransferAuditCount()
+    const before = await transferRow(transferId)
+    const cancelSpy = vi.spyOn(orgTransferService, 'cancelOrgTransfer')
+
+    const res = await request(adminApp)
+      .post(`/api/admin/directory/org-transfers/${transferId}/cancel`)
+      .send({ reason: 'evil-cancel-smuggle' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('ORG_TRANSFER_UNKNOWN_FIELDS')
+    expect(cancelSpy).not.toHaveBeenCalled()
+    expect(await transferRow(transferId)).toEqual(before)
+    expect(await auditRowFor('cancel', transferId)).toBe(0)
+    expect(await orgTransferAuditCount()).toBe(auditBefore)
+    cancelSpy.mockRestore()
+  })
+
+  it('lifecycle empty body / empty object remain allowed; arrays cannot bypass the contract', async () => {
+    // express.json({strict:true}) (default) rejects primitive JSON (number/null/string/bool)
+    // before the route — those never reach our body contract. Arrays DO reach the handler and
+    // are the load-bearing non-plain bypass: Object.keys([]) === [] would look like "empty".
+    enableNoopAdapter()
+    const { source, target } = await seedPair('body-empty')
+    const transferId = await createTransfer(source, target)
+    const cancelSpy = vi.spyOn(orgTransferService, 'cancelOrgTransfer')
+
+    // Omitted body + explicit {} are the only allowed lifecycle payloads.
+    await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`).expect(200)
+    await request(adminApp)
+      .post(`/api/admin/directory/org-transfers/${transferId}/apply?dryRun=true`)
+      .send({})
+      .expect(200)
+
+    // Empty array would look keyless under Object.keys — must still 400 before service.
+    const emptyArray = await request(adminApp)
+      .post(`/api/admin/directory/org-transfers/${transferId}/cancel`)
+      .set('Content-Type', 'application/json')
+      .send('[]')
+    expect(emptyArray.status).toBe(400)
+    expect(emptyArray.body.error.code).toBe('ORG_TRANSFER_UNKNOWN_FIELDS')
+
+    const nonEmptyArray = await request(adminApp)
+      .post(`/api/admin/directory/org-transfers/${transferId}/cancel`)
+      .send([{ reason: 'nope' }])
+    expect(nonEmptyArray.status).toBe(400)
+    expect(nonEmptyArray.body.error.code).toBe('ORG_TRANSFER_UNKNOWN_FIELDS')
+
+    expect(cancelSpy).not.toHaveBeenCalled()
+    // Transfer still scanned (cancel never applied); not cancelled.
+    expect((await transferRow(transferId)).status).toBe('scanned')
+    cancelSpy.mockRestore()
+  })
+
+  it('CREATE rejects arrays with ORG_TRANSFER_UNKNOWN_FIELDS (zero rows, zero audit, never reaches service)', async () => {
+    // Feasible through the real Express parser: JSON arrays reach the route. Primitive JSON
+    // bodies are rejected by express.json strict mode before our handler (not ORG_TRANSFER_*).
+    const { source, target } = await seedPair('body-create')
+    const auditBefore = await orgTransferAuditCount()
+    const createSpy = vi.spyOn(orgTransferService, 'createOrgTransfer')
+
+    const arrayBody = await request(adminApp)
+      .post('/api/admin/directory/org-transfers')
+      .send([{ provider: 'dingtalk', sourceIntegrationId: source, targetIntegrationId: target }])
+    expect(arrayBody.status).toBe(400)
+    expect(arrayBody.body.error.code).toBe('ORG_TRANSFER_UNKNOWN_FIELDS')
+
+    const emptyArray = await request(adminApp)
+      .post('/api/admin/directory/org-transfers')
+      .set('Content-Type', 'application/json')
+      .send('[]')
+    expect(emptyArray.status).toBe(400)
+    expect(emptyArray.body.error.code).toBe('ORG_TRANSFER_UNKNOWN_FIELDS')
+
+    expect(createSpy).not.toHaveBeenCalled()
+    const rows = await query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM provider_org_transfers WHERE source_integration_id = $1`,
+      [source]
+    )
+    expect(rows.rows[0].n).toBe('0')
+    expect(await orgTransferAuditCount()).toBe(auditBefore)
+    createSpy.mockRestore()
+  })
+
+  // -------------------------------------------------------------------------------------------
+  // Log boundary — unexpected + audit failure are values-free fixed metadata only
+  // -------------------------------------------------------------------------------------------
+
+  it('unexpected errors log fixed metadata only (no Error.message/name/SQL/body/provider/directory values)', async () => {
+    // Restore raw `error: readErrorMessage(error)` into handleOrgTransferError → this test reds.
+    const nameSentinel = `SENSITIVE_ORG_TRANSFER_ERR_NAME_${STAMP}_corp_secret_token`
+    const relationNeedle = 'provider_org_transfers'
+    const forced = new Error(`relation "${relationNeedle}" does not exist — corp=dingtalk-corp-xyz url=https://evil.example/sync`)
+    forced.name = nameSentinel
+
+    const getSpy = vi.spyOn(orgTransferService, 'getOrgTransfer').mockRejectedValue(forced)
+    const warnSpy = vi.spyOn(Logger.prototype, 'warn')
+    try {
+      const res = await request(adminApp).get(`/api/admin/directory/org-transfers/${randomUUID()}`)
+      expect(res.status).toBe(500)
+      expect(res.body.error.code).toBe('ORG_TRANSFER_INTERNAL_ERROR')
+      // Client HTTP message stays the server-authored fixed fallback — not the raw exception.
+      expect(res.body.error.message).toBe('Failed to read org transfer')
+      expect(JSON.stringify(res.body)).not.toContain(nameSentinel)
+      expect(JSON.stringify(res.body)).not.toContain(relationNeedle)
+      expect(JSON.stringify(res.body)).not.toContain('evil.example')
+
+      const unexpectedWarns = warnSpy.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0] === 'Failed to read org transfer'
+      )
+      expect(unexpectedWarns.length).toBeGreaterThanOrEqual(1)
+      const [message, meta] = unexpectedWarns[0] as [string, Record<string, unknown>]
+      const serialized = JSON.stringify({ message, meta })
+      expect(serialized).not.toContain(nameSentinel)
+      expect(serialized).not.toContain(relationNeedle)
+      expect(serialized).not.toContain('evil.example')
+      expect(serialized).not.toContain('dingtalk-corp-xyz')
+      expect(serialized.toLowerCase()).not.toContain('does not exist')
+      expect(meta).toEqual({ reason: 'unexpected_error' })
+      expect(meta).not.toHaveProperty('error')
+      expect(meta).not.toHaveProperty('errorClass')
+      expect(meta).not.toHaveProperty('stack')
+      expect(meta).not.toHaveProperty('code')
+      expect(meta).not.toHaveProperty('provider')
+      expect(meta).not.toHaveProperty('body')
+    } finally {
+      warnSpy.mockRestore()
+      getSpy.mockRestore()
+    }
+  })
+
+  it('audit-write failures log fixed metadata only (no raw Error text); mutation still succeeds', async () => {
+    // Restore raw `error: readErrorMessage(error)` into auditTransfer's catch → this test reds.
+    enableNoopAdapter()
+    const { source, target } = await seedPair('audit-log')
+    const nameSentinel = `SENSITIVE_AUDIT_ERR_NAME_${STAMP}_tenant_key_leak`
+    const forced = new Error(`insert into audit_logs failed: detail=provider=dingtalk corp_id=SECRET_CORP`)
+    forced.name = nameSentinel
+
+    const auditSpy = vi.spyOn(auditModule, 'auditLog').mockRejectedValue(forced)
+    const warnSpy = vi.spyOn(Logger.prototype, 'warn')
+    try {
+      const transferId = await createTransfer(source, target)
+      // createTransfer expects 200 — audit is best-effort and must not fail the mutation.
+      expect(transferId).toBeTruthy()
+
+      const auditWarns = warnSpy.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0] === 'org-transfer audit write failed'
+      )
+      expect(auditWarns.length).toBeGreaterThanOrEqual(1)
+      const [message, meta] = auditWarns[0] as [string, Record<string, unknown>]
+      const serialized = JSON.stringify({ message, meta })
+      expect(serialized).not.toContain(nameSentinel)
+      expect(serialized).not.toContain('SECRET_CORP')
+      expect(serialized).not.toContain('audit_logs')
+      expect(serialized.toLowerCase()).not.toContain('insert into')
+      expect(meta).toEqual({ action: 'create', reason: 'audit_write_failed' })
+      expect(meta).not.toHaveProperty('error')
+      expect(meta).not.toHaveProperty('errorClass')
+      expect(meta).not.toHaveProperty('stack')
+      expect(meta).not.toHaveProperty('provider')
+    } finally {
+      warnSpy.mockRestore()
+      auditSpy.mockRestore()
+    }
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -179,6 +179,13 @@ export default defineConfig({
       // index-anchored by b7-round2-ci-wiring.test.mjs so a same-step drift or multitable move reds.
       'tests/integration/directory-binding-admin-routes.db.test.ts',
       'tests/integration/directory-binding-sync-hook.db.test.ts',
+      // Transfer MVP T1 (sequencing plan §2 row T1): provider_org_transfers lifecycle state machine,
+      // the schema-level FK backstops (cross-org / provider-mismatch transfers FK-impossible), the
+      // §12.3 dry-run-required guard, and the no-op apply's untouched-directory fingerprint — HTTP
+      // against real Postgres. DATABASE_URL-gated; excluded here so the no-DB job cannot skip-green
+      // it, and wired as a WHOLE FILE into the directory real-DB step in plugin-tests.yml (both
+      // points asserted by t1-org-transfer-ci-wiring.test.mjs).
+      'tests/integration/provider-org-transfer-t1.api.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
       // resolution against real Postgres — normalized `is_manager` relation for a local integration,
       // the DingTalk `leader_in_dept` regression pin (load-bearing compat leg + is_manager=0 positive

--- a/scripts/ops/t1-org-transfer-ci-wiring.test.mjs
+++ b/scripts/ops/t1-org-transfer-ci-wiring.test.mjs
@@ -1,0 +1,27 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// T1 CI two-point wiring contract. The provider-org-transfer suite proves the transfer lifecycle
+// state machine, the schema-level FK backstops (cross-org / provider-mismatch FK-impossible), the
+// §12.3 dry-run guard, and the no-op apply's untouched-directory fingerprint against real Postgres —
+// meaningless without a DB. It needs BOTH (1) the vitest.config.ts exclude entry (so the no-DB job
+// cannot skip-green it) AND (2) the plugin-tests.yml directory real-DB whole-file step (so a real-DB
+// run actually names it). Removing either point makes the whole T1 proof silently never execute
+// while exact-head CI stays green. This source-level guard (no DB) reddens if either point is
+// dropped. It runs in the no-DB `test` job, so it gates every PR.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/provider-org-transfer-t1.api.test.ts'
+
+test('vitest.config.ts excludes the T1 org-transfer suite from the no-DB job', () => {
+  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE} (DATABASE_URL-gated whole file)`)
+})
+
+test('plugin-tests.yml runs the T1 org-transfer suite as a whole file in the directory real-DB step', () => {
+  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  assert.match(wf, new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${FILE} in the directory real-DB step`)
+})


### PR DESCRIPTION
## T1 — Transfer MVP opening slice (sequencing plan §2 row T1)

> **UNARMED pending exact-head required CI.** Canonical Org is closed on main by #4479. This head has been independently reviewed and locally reverified after a patch-identical rebase onto that closeout.

Implements `provider_org_transfers` + `provider_org_transfer_decisions` (§7.1/§7.2) and the platform-admin lifecycle API (§6.3): create, read, scan, dry-run, apply, and cancel. Successful mutations write values-free `directory.org_transfer.*` audit rows.

### Durable invariants

- One non-null `org_id` plus composite integration FKs makes cross-org transfers schema-impossible.
- Composite provider FKs and `CHECK (provider <> 'local')` make integration/provider mismatch and local-provider transfers schema-impossible.
- A partial unique index permits at most one non-terminal transfer per source integration.
- Every transition locks the transfer row and enforces the state machine at the write point.
- Apply requires a dry-run after the latest scan and zero pending decisions.
- Lifecycle endpoints accept no body fields; smuggled fields fail before service and audit.
- Unexpected and audit-write failures log fixed metadata only.

### Adapter boundary

Production does not silently fall back to a no-op adapter. Scan and apply require an explicitly registered adapter for the transfer provider. Missing registration returns `409 ORG_TRANSFER_ADAPTER_UNAVAILABLE`, rolls back, preserves state and decisions, and writes no success audit.

The exported no-op is test-only. T1 proves the lifecycle skeleton and zero directory writes; it does **not** claim that a real transfer is implemented. T3/T4 must provide real per-decision transactional/idempotent semantics and must not treat this placeholder no-op execution shape as their final apply design.

### Verification at `4fb370dab4a4e0a2275ac5974d73032ed7d8c2bc`

- Fresh PostgreSQL: full migration chain passed; second migration replay passed with no pending work.
- T1 real-DB HTTP suite: 22/22 passed.
- T1 + Canonical Org B1–B7/pre-B4 parallel battery: 17 files / 233 tests, three consecutive runs passed.
- TypeScript `tsc --noEmit`: passed.
- B4–B7 + T1 CI wiring guards: 19/19 passed.
- Independent load-bearing mutations all reddened: scan body guard; dry-run/real-apply body guard; cancel body guard; unexpected-error log redaction; audit-error log redaction; missing-adapter fail-close; and a scoped directory write inside the test-only no-op.
- Rebase range-diff: all eight commits patch-identical to the reviewed pre-rebase series.
- Scope: eight T1-owned files only.

### Deliberate T1 boundaries

- `created_by` / `decided_by` are text because this codebase's `users.id` is text.
- `dry_run_at` is additive durable state for the scan-relative dry-run guard.
- Decision PATCH and secret handling remain deferred to the first real adapter in T3/T4.
- T2 source-freeze and the staging T2-Gate remain separately sequenced after this PR.
