### PR TITLE
feat(stock-prep): persist hardening — H-2 stale project-pointer 409 + H-3 explicit plan-size bound

### DIFF
--- a/plugins/plugin-integration-core/__tests__/stock-preparation-sync-run-persist.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-sync-run-persist.test.cjs
@@ -928,11 +928,9 @@ async function main() {
     const provisioning = makeProvisioning()
     await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
     const writesAfterFirst = recordsApi.createCalls.length
-    for (const [overrides, reason] of [
-      [{ syncRunId: 'run_2', snapshotBatchId: 'batch_2' }, 'not_monotonic'], // omitted -> defaults to 1 == history max
-      [{ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 1 }, 'not_monotonic'],
-      // 0 is not a strict version at all (R4 parser: positive integers only) -> unprovable, not merely non-increasing.
-      [{ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 0 }, 'history_unprovable'],
+    for (const overrides of [
+      { syncRunId: 'run_2', snapshotBatchId: 'batch_2' }, // omitted -> defaults to 1 == history max
+      { syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 1 },
     ]) {
       await assert.rejects(
         () => persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs(overrides) }),
@@ -941,9 +939,18 @@ async function main() {
           error.status === 422 &&
           error.code === 'PERSIST_VERSION_NOT_MONOTONIC' &&
           error.details.field === 'snapshotVersion' &&
-          error.details.reason === reason,
+          error.details.reason === 'not_monotonic',
       )
     }
+    // 0 is not a strict version at all — the SHARED parser rejects it at PLAN level (R5: preview and
+    // commit reject identically; it never reaches the persist guard).
+    await assert.rejects(
+      () => persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 0 }) }),
+      (error) =>
+        error instanceof StockPreparationSyncRunPlanError &&
+        error.status === 422 &&
+        error.details.field === 'snapshotVersion',
+    )
     assert.equal(recordsApi.createCalls.length, writesAfterFirst, 'rejected before any write')
   })
 
@@ -1081,6 +1088,58 @@ async function main() {
       ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 2 }),
     })
     assert.equal(ok.mode, 'created')
+  })
+
+  await run("R5: coercive version FORMS ('01'/'+1'/'1e2'/'0x10'/unsafe) — CURRENT input rejects at plan level, zero writes", async () => {
+    const recordsApi = makeRecordsApi()
+    const provisioning = makeProvisioning()
+    for (const bad of ['01', '+1', '1e2', '0x10', 2 ** 53, '9007199254740993', 1.5]) {
+      await assert.rejects(
+        () => persistStockPreparationSyncRun({
+          permission: 'admin',
+          recordsApi,
+          provisioning,
+          ...basePlanInputs({ syncRunId: 'run_x', snapshotBatchId: 'batch_x', snapshotVersion: bad }),
+        }),
+        (error) =>
+          error instanceof StockPreparationSyncRunPlanError &&
+          error.status === 422 &&
+          error.details.field === 'snapshotVersion',
+      )
+    }
+    assert.equal(recordsApi.createCalls.length, 0, 'zero writes across all rejected forms')
+  })
+
+  await run("R5: coercive version forms in HISTORY rows -> 422 history_unprovable, zero writes (Number() previously accepted every one)", async () => {
+    for (const bad of ['01', '+1', '1e2', '0x10', 2 ** 53]) {
+      const recordsApi = makeRecordsApi()
+      const provisioning = makeProvisioning()
+      await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
+      const batchRows = await recordsApi.queryRecords({
+        sheetId: BATCH_SHEET_ID,
+        filters: { [physicalFieldId(STAGING_PROJECT_ID, BATCH_OBJECT_ID, 'snapshotBatchId')]: 'batch_1' },
+      })
+      await recordsApi.patchRecord({
+        sheetId: BATCH_SHEET_ID,
+        recordId: batchRows[0].id,
+        changes: { [physicalFieldId(STAGING_PROJECT_ID, BATCH_OBJECT_ID, 'snapshotVersion')]: bad },
+      })
+      const writesBefore = recordsApi.createCalls.length
+      await assert.rejects(
+        () => persistStockPreparationSyncRun({
+          permission: 'admin',
+          recordsApi,
+          provisioning,
+          ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 2 }),
+        }),
+        (error) =>
+          error instanceof StockPreparationSyncRunPersistError &&
+          error.status === 422 &&
+          error.code === 'PERSIST_VERSION_NOT_MONOTONIC' &&
+          error.details.reason === 'history_unprovable',
+      )
+      assert.equal(recordsApi.createCalls.length, writesBefore, 'zero writes on unprovable history')
+    }
   })
 
   await run('H-2: equal-version pointer on a DIFFERENT run (legacy/degenerate data) -> 409 pointer_unresolvable, never a silent 200', async () => {

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-sync-run-persist.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-sync-run-persist.test.cjs
@@ -31,7 +31,7 @@ const {
   RUN_OBJECT_ID,
   PROJECT_OBJECT_ID,
   PROJECT_KEY_FIELD,
-  __internals: { MVP_OBJECT_ID_SET, READ_PAGE_LIMIT, READ_MAX_PAGES, readExistingSnapshotLines },
+  __internals: { MVP_OBJECT_ID_SET, READ_PAGE_LIMIT, READ_MAX_PAGES, PERSIST_MAX_PLAN_LINES, readExistingSnapshotLines },
 } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-sync-run-persist.cjs'))
 const {
   __internals: { LINE_FIELD_IDS },
@@ -811,6 +811,129 @@ async function main() {
     )
     assert.equal(provisioning.findObjectSheetCalls, 0, 'fails before any sheet resolution')
     assert.equal(recordsApi.createCalls.length, 0)
+  })
+
+  // ── H-2 (P4 lock round-1): replay verifies the project LIVE POINTER, not just row existence ──────
+
+  await run('H-2: CW4-existing crash (run created, project patch lost) -> replay 409 stale_pointer, not silent 200', async () => {
+    const recordsApi = makeRecordsApi()
+    const provisioning = makeProvisioning()
+    // Sync 1 commits fully: project pointer -> run_1 (batch_1, version 1).
+    await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
+    // Sync 2 (batch_2, version 2) crashes at the CW4-existing window: every batch/line/run write lands,
+    // the project PATCH is lost. Injected by failing patchRecord on the PROJECT sheet only.
+    const crashingApi = Object.create(recordsApi)
+    crashingApi.patchRecord = async (input = {}) => {
+      if (input.sheetId === PROJECT_SHEET_ID) throw new Error('injected crash before project patch')
+      return recordsApi.patchRecord(input)
+    }
+    await assert.rejects(
+      () => persistStockPreparationSyncRun({
+        permission: 'admin',
+        recordsApi: crashingApi,
+        provisioning,
+        ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 2 }),
+      }),
+      /injected crash before project patch/,
+    )
+    // Retry of sync 2 replays batch/lines/run exactly — but the pointer still names run_1 whose batch
+    // sits at a LOWER version. Pre-H-2 this returned 200 skipped_existing (the silent window).
+    await assert.rejects(
+      () => persistStockPreparationSyncRun({
+        permission: 'admin',
+        recordsApi,
+        provisioning,
+        ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 2 }),
+      }),
+      (error) =>
+        error instanceof StockPreparationSyncRunPersistError &&
+        error.status === 409 &&
+        error.code === 'PERSIST_PROJECT_POINTER_STALE' &&
+        error.details.target === 'project' &&
+        error.details.reason === 'stale_pointer',
+    )
+  })
+
+  await run('H-2: pointer advanced by a LATER sync -> replaying the older batch still returns 200 skipped_existing', async () => {
+    const recordsApi = makeRecordsApi()
+    const provisioning = makeProvisioning()
+    await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
+    await persistStockPreparationSyncRun({
+      permission: 'admin',
+      recordsApi,
+      provisioning,
+      ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 2 }),
+    })
+    // Pointer now names run_2 (version 2). Replaying sync 1 must remain a legal exact replay.
+    const replay = await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
+    assert.equal(replay.mode, 'skipped_existing')
+    assert.equal(replay.persisted, false)
+  })
+
+  await run('H-2: pointer naming a run with no batch row -> 409 pointer_unresolvable (fail closed)', async () => {
+    const recordsApi = makeRecordsApi()
+    const provisioning = makeProvisioning()
+    await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
+    // Corrupt the pointer to a run id no batch row carries (raw physical patch, as a poisoned/legacy
+    // row would look).
+    const projectRows = await recordsApi.queryRecords({
+      sheetId: PROJECT_SHEET_ID,
+      filters: { [physicalFieldId(STAGING_PROJECT_ID, PROJECT_OBJECT_ID, PROJECT_KEY_FIELD)]: 'proj_1' },
+    })
+    assert.equal(projectRows.length, 1)
+    await recordsApi.patchRecord({
+      sheetId: PROJECT_SHEET_ID,
+      recordId: projectRows[0].id,
+      changes: { [physicalFieldId(STAGING_PROJECT_ID, PROJECT_OBJECT_ID, 'lastSyncRunId')]: 'run_ghost' },
+    })
+    await assert.rejects(
+      () => persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() }),
+      (error) =>
+        error instanceof StockPreparationSyncRunPersistError &&
+        error.status === 409 &&
+        error.code === 'PERSIST_PROJECT_POINTER_STALE' &&
+        error.details.target === 'project' &&
+        error.details.reason === 'pointer_unresolvable',
+    )
+  })
+
+  // ── H-3 (P4 lock round-1: Option-A prerequisite): explicit plan-size bound ──────────────────────
+
+  await run('H-3: plan larger than PERSIST_MAX_PLAN_LINES -> 422 PERSIST_PLAN_TOO_LARGE before ANY provisioning/records access', async () => {
+    const recordsApi = makeRecordsApi()
+    const provisioning = makeProvisioning()
+    await assert.rejects(
+      () => persistStockPreparationSyncRun({
+        permission: 'admin',
+        recordsApi,
+        provisioning,
+        ...basePlanInputs({ expansionResult: manyExpansionRows(PERSIST_MAX_PLAN_LINES + 1) }),
+      }),
+      (error) =>
+        error instanceof StockPreparationSyncRunPersistError &&
+        error.status === 422 &&
+        error.code === 'PERSIST_PLAN_TOO_LARGE' &&
+        error.details.field === 'snapshotLines' &&
+        error.details.maxLines === PERSIST_MAX_PLAN_LINES,
+    )
+    assert.equal(provisioning.findObjectSheetCalls, 0, 'rejected before sheet resolution')
+    assert.equal(recordsApi.createCalls.length, 0, 'rejected before any write')
+  })
+
+  await run('H-3: plan at EXACTLY the bound passes the cap (fails later on unprovisioned target, proving the cap did not fire)', async () => {
+    const recordsApi = makeRecordsApi()
+    const provisioning = makeProvisioning({ missing: new Set([BATCH_OBJECT_ID]) })
+    await assert.rejects(
+      () => persistStockPreparationSyncRun({
+        permission: 'admin',
+        recordsApi,
+        provisioning,
+        ...basePlanInputs({ expansionResult: manyExpansionRows(PERSIST_MAX_PLAN_LINES) }),
+      }),
+      (error) =>
+        error instanceof StockPreparationSyncRunPersistError &&
+        error.code === 'PERSIST_TARGET_NOT_PROVISIONED',
+    )
   })
 
   console.log(`\nstock-preparation-sync-run-persist.test.cjs: ${passed} passed, ${failed} failed`)

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-sync-run-persist.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-sync-run-persist.test.cjs
@@ -946,6 +946,54 @@ async function main() {
     assert.equal(recordsApi.createCalls.length, writesAfterFirst, 'rejected before any write')
   })
 
+  await run('R3: a COMPLETE orphan batch (crash before project patch) still counts — intermediate version -> 422, next version proceeds', async () => {
+    const recordsApi = makeRecordsApi()
+    const provisioning = makeProvisioning()
+    // V1 commits fully (pointer -> run_1).
+    await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
+    // V3 crashes at CW4-existing: batch/lines/run all land, the project patch is lost — a COMPLETE
+    // orphan V3 exists while the pointer still names V1.
+    const crashingApi = Object.create(recordsApi)
+    crashingApi.patchRecord = async (input = {}) => {
+      if (input.sheetId === PROJECT_SHEET_ID) throw new Error('injected crash before project patch')
+      return recordsApi.patchRecord(input)
+    }
+    await assert.rejects(
+      () => persistStockPreparationSyncRun({
+        permission: 'admin',
+        recordsApi: crashingApi,
+        provisioning,
+        ...basePlanInputs({ syncRunId: 'run_3', snapshotBatchId: 'batch_3', snapshotVersion: 3 }),
+      }),
+      /injected crash before project patch/,
+    )
+    // Round-3 finding: a pointer-only compare accepted V2 here (V2 > pointer V1) despite the complete
+    // V3 — the guard must scan the project's WHOLE batch history.
+    const writesBefore = recordsApi.createCalls.length
+    await assert.rejects(
+      () => persistStockPreparationSyncRun({
+        permission: 'admin',
+        recordsApi,
+        provisioning,
+        ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 2 }),
+      }),
+      (error) =>
+        error instanceof StockPreparationSyncRunPersistError &&
+        error.status === 422 &&
+        error.code === 'PERSIST_VERSION_NOT_MONOTONIC' &&
+        error.details.reason === 'not_monotonic',
+    )
+    assert.equal(recordsApi.createCalls.length, writesBefore, 'rejected before any write')
+    // Moving past the orphan is allowed: V4 > max(V3).
+    const next = await persistStockPreparationSyncRun({
+      permission: 'admin',
+      recordsApi,
+      provisioning,
+      ...basePlanInputs({ syncRunId: 'run_4', snapshotBatchId: 'batch_4', snapshotVersion: 4 }),
+    })
+    assert.equal(next.mode, 'created')
+  })
+
   await run('H-2: equal-version pointer on a DIFFERENT run (legacy/degenerate data) -> 409 pointer_unresolvable, never a silent 200', async () => {
     const recordsApi = makeRecordsApi()
     const provisioning = makeProvisioning()

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-sync-run-persist.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-sync-run-persist.test.cjs
@@ -636,6 +636,8 @@ async function main() {
     })
 
     // A SECOND, genuinely different batch/syncRun for the SAME project — NOT a duplicate/retry.
+    // snapshotVersion bumps to 2: repeat syncs must be strictly monotonic per project (H-2
+    // precondition guard) — a default-version repeat sync now fails loudly (own test below).
     const second = await persistStockPreparationSyncRun({
       permission: 'admin',
       recordsApi,
@@ -643,6 +645,7 @@ async function main() {
       ...basePlanInputs({
         syncRunId: 'run_2',
         snapshotBatchId: 'batch_2',
+        snapshotVersion: 2,
         // sourceProjectNo/projectName supplied again (a real caller always sends the populator inputs);
         // they must NOT overwrite the ORIGINAL stored values on this patch path.
         sourceProjectNo: 'PN-CHANGED-LATER',
@@ -918,6 +921,79 @@ async function main() {
     )
     assert.equal(provisioning.findObjectSheetCalls, 0, 'rejected before sheet resolution')
     assert.equal(recordsApi.createCalls.length, 0, 'rejected before any write')
+  })
+
+  await run('H-2 precondition: a repeat sync with a non-increasing snapshotVersion (incl. the default) -> 422 PERSIST_VERSION_NOT_MONOTONIC before any write', async () => {
+    const recordsApi = makeRecordsApi()
+    const provisioning = makeProvisioning()
+    await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
+    const writesAfterFirst = recordsApi.createCalls.length
+    for (const overrides of [
+      { syncRunId: 'run_2', snapshotBatchId: 'batch_2' }, // omitted -> defaults to 1 == pointer version
+      { syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 1 },
+      { syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 0 },
+    ]) {
+      await assert.rejects(
+        () => persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs(overrides) }),
+        (error) =>
+          error instanceof StockPreparationSyncRunPersistError &&
+          error.status === 422 &&
+          error.code === 'PERSIST_VERSION_NOT_MONOTONIC' &&
+          error.details.field === 'snapshotVersion' &&
+          error.details.reason === 'not_monotonic',
+      )
+    }
+    assert.equal(recordsApi.createCalls.length, writesAfterFirst, 'rejected before any write')
+  })
+
+  await run('H-2: equal-version pointer on a DIFFERENT run (legacy/degenerate data) -> 409 pointer_unresolvable, never a silent 200', async () => {
+    const recordsApi = makeRecordsApi()
+    const provisioning = makeProvisioning()
+    await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
+    await persistStockPreparationSyncRun({
+      permission: 'admin',
+      recordsApi,
+      provisioning,
+      ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 2 }),
+    })
+    // Simulate legacy degenerate data: flatten batch_2's version back to 1 (equal to batch_1) via a
+    // raw physical patch — the monotonic create guard makes this state unreachable going forward.
+    const batchRows = await recordsApi.queryRecords({
+      sheetId: BATCH_SHEET_ID,
+      filters: { [physicalFieldId(STAGING_PROJECT_ID, BATCH_OBJECT_ID, 'snapshotBatchId')]: 'batch_2' },
+    })
+    assert.equal(batchRows.length, 1)
+    await recordsApi.patchRecord({
+      sheetId: BATCH_SHEET_ID,
+      recordId: batchRows[0].id,
+      changes: { [physicalFieldId(STAGING_PROJECT_ID, BATCH_OBJECT_ID, 'snapshotVersion')]: 1 },
+    })
+    // Replaying batch_1 now sees pointer=run_2 whose batch version EQUALS its own — not provably
+    // advanced -> fail closed.
+    await assert.rejects(
+      () => persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() }),
+      (error) =>
+        error instanceof StockPreparationSyncRunPersistError &&
+        error.status === 409 &&
+        error.code === 'PERSIST_PROJECT_POINTER_STALE' &&
+        error.details.reason === 'pointer_unresolvable',
+    )
+  })
+
+  await run('H-3: create AND exact replay both succeed at the true bound (PERSIST_MAX_PLAN_LINES lines)', async () => {
+    // Paginated fake: the replay path's bounded read must see REAL limit/offset pages (the plain fake
+    // returns everything in one oversized page and would false-trip the page-size guard).
+    const recordsApi = makePaginatedRecordsApi()
+    const provisioning = makeProvisioning()
+    const inputs = basePlanInputs({ expansionResult: manyExpansionRows(PERSIST_MAX_PLAN_LINES) })
+    const first = await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...inputs })
+    assert.equal(first.mode, 'created')
+    assert.equal(first.created.lines, PERSIST_MAX_PLAN_LINES)
+    // The bound is defined as the largest EXACTLY-REPLAYABLE plan (short-page provability): the
+    // retry must be a clean 200 skip, never PERSIST_EXISTING_BATCH_READ_UNPROVABLE (round-2 finding:
+    // at 25,000 the create succeeded and every replay 409'd forever).
+    const replay = await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...inputs })
+    assert.equal(replay.mode, 'skipped_existing')
   })
 
   await run('H-3: plan at EXACTLY the bound passes the cap (fails later on unprovisioned target, proving the cap did not fire)', async () => {

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-sync-run-persist.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-sync-run-persist.test.cjs
@@ -928,10 +928,11 @@ async function main() {
     const provisioning = makeProvisioning()
     await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
     const writesAfterFirst = recordsApi.createCalls.length
-    for (const overrides of [
-      { syncRunId: 'run_2', snapshotBatchId: 'batch_2' }, // omitted -> defaults to 1 == pointer version
-      { syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 1 },
-      { syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 0 },
+    for (const [overrides, reason] of [
+      [{ syncRunId: 'run_2', snapshotBatchId: 'batch_2' }, 'not_monotonic'], // omitted -> defaults to 1 == history max
+      [{ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 1 }, 'not_monotonic'],
+      // 0 is not a strict version at all (R4 parser: positive integers only) -> unprovable, not merely non-increasing.
+      [{ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 0 }, 'history_unprovable'],
     ]) {
       await assert.rejects(
         () => persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs(overrides) }),
@@ -940,7 +941,7 @@ async function main() {
           error.status === 422 &&
           error.code === 'PERSIST_VERSION_NOT_MONOTONIC' &&
           error.details.field === 'snapshotVersion' &&
-          error.details.reason === 'not_monotonic',
+          error.details.reason === reason,
       )
     }
     assert.equal(recordsApi.createCalls.length, writesAfterFirst, 'rejected before any write')
@@ -992,6 +993,94 @@ async function main() {
       ...basePlanInputs({ syncRunId: 'run_4', snapshotBatchId: 'batch_4', snapshotVersion: 4 }),
     })
     assert.equal(next.mode, 'created')
+  })
+
+  await run('R4: FIRST-sync crash at project create (CW4-first) leaves orphan history with NO project row — the scan still runs: V2 rejected, V4 proceeds', async () => {
+    const recordsApi = makeRecordsApi()
+    const provisioning = makeProvisioning()
+    // Empty project: V3 crashes at the PROJECT createRecord (batch/lines/run all landed; no project row).
+    const crashingApi = Object.create(recordsApi)
+    crashingApi.createRecord = async (input = {}) => {
+      if (input.sheetId === PROJECT_SHEET_ID) throw new Error('injected crash at project create')
+      return recordsApi.createRecord(input)
+    }
+    await assert.rejects(
+      () => persistStockPreparationSyncRun({
+        permission: 'admin',
+        recordsApi: crashingApi,
+        provisioning,
+        ...basePlanInputs({ syncRunId: 'run_3', snapshotBatchId: 'batch_3', snapshotVersion: 3 }),
+      }),
+      /injected crash at project create/,
+    )
+    // Round-4 finding: gating the scan on projectRows.length === 1 skipped it here (no project row),
+    // so V2 slipped past the complete orphan V3. The scan must run for EVERY new batch.
+    const writesBefore = recordsApi.createCalls.length
+    await assert.rejects(
+      () => persistStockPreparationSyncRun({
+        permission: 'admin',
+        recordsApi,
+        provisioning,
+        ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 2 }),
+      }),
+      (error) =>
+        error instanceof StockPreparationSyncRunPersistError &&
+        error.status === 422 &&
+        error.code === 'PERSIST_VERSION_NOT_MONOTONIC' &&
+        error.details.reason === 'not_monotonic',
+    )
+    assert.equal(recordsApi.createCalls.length, writesBefore, 'rejected before any write')
+    const next = await persistStockPreparationSyncRun({
+      permission: 'admin',
+      recordsApi,
+      provisioning,
+      ...basePlanInputs({ syncRunId: 'run_4', snapshotBatchId: 'batch_4', snapshotVersion: 4 }),
+    })
+    assert.equal(next.mode, 'created')
+  })
+
+  await run('R4: strict version parsing — a null-version history row fails closed (history_unprovable), never coerced to 0', async () => {
+    const recordsApi = makeRecordsApi()
+    const provisioning = makeProvisioning()
+    await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
+    // Corrupt V1's stored version to null (raw physical patch — legacy/degenerate data shape).
+    const batchRows = await recordsApi.queryRecords({
+      sheetId: BATCH_SHEET_ID,
+      filters: { [physicalFieldId(STAGING_PROJECT_ID, BATCH_OBJECT_ID, 'snapshotBatchId')]: 'batch_1' },
+    })
+    await recordsApi.patchRecord({
+      sheetId: BATCH_SHEET_ID,
+      recordId: batchRows[0].id,
+      changes: { [physicalFieldId(STAGING_PROJECT_ID, BATCH_OBJECT_ID, 'snapshotVersion')]: null },
+    })
+    // Round-4 finding: Number(null) === 0 let this slip through as "max 0". Strict parsing must
+    // fail closed instead of silently writing V2 over unprovable history.
+    await assert.rejects(
+      () => persistStockPreparationSyncRun({
+        permission: 'admin',
+        recordsApi,
+        provisioning,
+        ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 2 }),
+      }),
+      (error) =>
+        error instanceof StockPreparationSyncRunPersistError &&
+        error.status === 422 &&
+        error.code === 'PERSIST_VERSION_NOT_MONOTONIC' &&
+        error.details.reason === 'history_unprovable',
+    )
+    // Positive control: a numeric-STRING stored version is accepted by the strict parser.
+    await recordsApi.patchRecord({
+      sheetId: BATCH_SHEET_ID,
+      recordId: batchRows[0].id,
+      changes: { [physicalFieldId(STAGING_PROJECT_ID, BATCH_OBJECT_ID, 'snapshotVersion')]: '1' },
+    })
+    const ok = await persistStockPreparationSyncRun({
+      permission: 'admin',
+      recordsApi,
+      provisioning,
+      ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 2 }),
+    })
+    assert.equal(ok.mode, 'created')
   })
 
   await run('H-2: equal-version pointer on a DIFFERENT run (legacy/degenerate data) -> 409 pointer_unresolvable, never a silent 200', async () => {

--- a/plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs
@@ -240,13 +240,13 @@ function projectPointerStale(reason) {
   )
 }
 
-// H-2 precondition (adversarial round-2): the stale-pointer discriminator compares snapshotVersion,
-// which is caller-supplied and DEFAULTS to 1 — without enforcement, two default-version syncs make
-// CW4-existing invisible again (equal versions never compare as stale). So the CREATE path enforces
-// strictly-monotonic per-project versions: a genuinely-new batch for an EXISTING project must carry a
-// snapshotVersion strictly above the version of the batch the live pointer names. This also matches
-// what the read side already assumes (predecessor picking / latest-complete resolution order by
-// version). reason ∈ {not_monotonic, pointer_unresolvable}.
+// H-2 precondition (rounds 2-4): the stale-pointer discriminator compares snapshotVersion, which is
+// caller-supplied and DEFAULTS to 1 — without enforcement, two default-version syncs make
+// CW4-existing invisible again. The CREATE path therefore enforces strictly-monotonic per-project
+// versions against the WHOLE batch history of the business project (not the pointer batch — orphan
+// complete batches are part of the history; and not gated on the project row existing — a first-sync
+// crash leaves history with no project row). Matches what the read side already assumes (predecessor
+// picking / latest-complete resolution order by version). reason ∈ {not_monotonic, history_unprovable}.
 function versionNotMonotonic(reason) {
   throw new StockPreparationSyncRunPersistError(
     422,
@@ -268,8 +268,21 @@ async function resolvePointerBatchVersion({ batchScoped, plan, pointerRunId }) {
     throw new StockPreparationSyncRunPersistError(500, 'PERSIST_RECORDS_API_INVALID', 'queryRecords must return an array')
   }
   if (pointerBatches.length !== 1) return null
-  const pointerVersion = Number(pointerBatches[0] && pointerBatches[0].data && pointerBatches[0].data.snapshotVersion)
-  return Number.isFinite(pointerVersion) ? pointerVersion : null
+  return parseStrictVersion(pointerBatches[0] && pointerBatches[0].data && pointerBatches[0].data.snapshotVersion)
+}
+
+// Round-4: STRICT version parser — Number() coerces null/''/booleans to finite numbers, which let
+// a null-version history row slip past the "non-numeric fails closed" intent. Versions must be
+// positive integers (or their non-empty string serializations); everything else is null → callers
+// fail closed. Used by ALL THREE consumers: the history max-scan, the pointer-batch resolution, and
+// the plan's own current version.
+function parseStrictVersion(value) {
+  let numeric = null
+  if (typeof value === 'number') numeric = value
+  else if (typeof value === 'string' && value.trim() !== '') numeric = Number(value)
+  else return null
+  if (!Number.isFinite(numeric) || !Number.isInteger(numeric) || numeric <= 0) return null
+  return numeric
 }
 
 // Round-3: bounded, numeric MAX-version scan over ALL batch rows of a business project (orphan
@@ -286,8 +299,8 @@ async function readProjectMaxBatchVersion(batchScoped, projectId) {
     })
     if (!Array.isArray(pageRows) || pageRows.length > READ_PAGE_LIMIT) return null
     for (const row of pageRows) {
-      const version = Number(row && row.data && row.data.snapshotVersion)
-      if (!Number.isFinite(version)) return null
+      const version = parseStrictVersion(row && row.data && row.data.snapshotVersion)
+      if (version === null) return null
       if (version > maxVersion) maxVersion = version
     }
     if (pageRows.length < READ_PAGE_LIMIT) return maxVersion
@@ -420,8 +433,8 @@ async function assertExactReplay({
   if (pointerRunId !== currentRunId) {
     if (!pointerRunId) projectPointerStale('pointer_unresolvable')
     const pointerVersion = await resolvePointerBatchVersion({ batchScoped, plan, pointerRunId })
-    const currentVersion = Number(plan.snapshotBatch.snapshotVersion)
-    if (pointerVersion === null || !Number.isFinite(currentVersion)) projectPointerStale('pointer_unresolvable')
+    const currentVersion = parseStrictVersion(plan.snapshotBatch.snapshotVersion)
+    if (pointerVersion === null || currentVersion === null) projectPointerStale('pointer_unresolvable')
     if (pointerVersion < currentVersion) projectPointerStale('stale_pointer')
     // EQUAL version on a DIFFERENT run cannot prove the pointer advanced (adversarial round-2: with
     // versions enforced monotonic at create, this state is only reachable on legacy/degenerate data)
@@ -598,16 +611,16 @@ async function persistStockPreparationSyncRun(input = {}) {
     }
   }
 
-  // H-2 precondition — CREATE path monotonic-version guard (before the FIRST write): a genuinely-new
-  // batch for an EXISTING project must carry a snapshotVersion strictly above EVERY existing batch of
-  // that project — not merely above the batch the live pointer names (round-3 finding: V1 commit →
-  // V3 crash before the project patch leaves a COMPLETE orphan V3 with the pointer still on V1; a
-  // pointer-only compare then wrongly accepted V2). The scan is bounded and numeric: paged read of
-  // the project's batch rows; an unprovable history (page bound exceeded / non-numeric version)
+  // H-2 precondition — CREATE path monotonic-version guard (before the FIRST write, for EVERY new
+  // batch): the new snapshotVersion must be strictly above EVERY existing batch of the business
+  // project. The scan runs UNCONDITIONALLY — round-4: a FIRST-sync crash at the project create
+  // (CW4-first) leaves orphan batch history with NO project row, so gating the scan on the project
+  // row's existence let the next lower-version sync through. Empty history scans to max 0 (any
+  // positive version passes); unprovable history (page bound exceeded / non-strict version values)
   // fails closed. This is what makes the replay-side stale/advanced inference sound.
-  if (projectRows.length === 1) {
-    const currentVersion = Number(plan.snapshotBatch.snapshotVersion)
-    if (!Number.isFinite(currentVersion)) versionNotMonotonic('history_unprovable')
+  {
+    const currentVersion = parseStrictVersion(plan.snapshotBatch.snapshotVersion)
+    if (currentVersion === null) versionNotMonotonic('history_unprovable')
     const maxVersion = await readProjectMaxBatchVersion(batchTarget.scoped, optionalString(planInputs.projectId))
     if (maxVersion === null) versionNotMonotonic('history_unprovable')
     if (currentVersion <= maxVersion) versionNotMonotonic('not_monotonic')

--- a/plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs
@@ -75,7 +75,11 @@ const READ_MAX_PAGES = 50
 // precondition TODAY): a plan larger than the bounded replay read could be CREATED but never exactly
 // replayed — every retry would 409 PERSIST_EXISTING_BATCH_READ_UNPROVABLE forever. Reject loudly
 // before any provisioning / records access instead of persisting an unprovable batch.
-const PERSIST_MAX_PLAN_LINES = READ_PAGE_LIMIT * READ_MAX_PAGES
+// The bound is READ_PAGE_LIMIT×READ_MAX_PAGES − 1, NOT the product itself: completeness is only
+// provable by a SHORT page, so 50 full 500-row pages (exactly 25,000 rows) fall out of the read loop
+// unprovable (adversarial round-2 finding — a 25,000-line batch persisted fine and then every replay
+// 409'd forever).
+const PERSIST_MAX_PLAN_LINES = READ_PAGE_LIMIT * READ_MAX_PAGES - 1
 
 // #4163 T1: the PROJECT table template — grounds the project-row upsert the SAME way BATCH/LINE/RUN are
 // grounded above (frozen template, never an invented field name).
@@ -236,6 +240,38 @@ function projectPointerStale(reason) {
   )
 }
 
+// H-2 precondition (adversarial round-2): the stale-pointer discriminator compares snapshotVersion,
+// which is caller-supplied and DEFAULTS to 1 — without enforcement, two default-version syncs make
+// CW4-existing invisible again (equal versions never compare as stale). So the CREATE path enforces
+// strictly-monotonic per-project versions: a genuinely-new batch for an EXISTING project must carry a
+// snapshotVersion strictly above the version of the batch the live pointer names. This also matches
+// what the read side already assumes (predecessor picking / latest-complete resolution order by
+// version). reason ∈ {not_monotonic, pointer_unresolvable}.
+function versionNotMonotonic(reason) {
+  throw new StockPreparationSyncRunPersistError(
+    422,
+    'PERSIST_VERSION_NOT_MONOTONIC',
+    'snapshot version must strictly increase per project',
+    { field: 'snapshotVersion', reason },
+  )
+}
+
+// Resolve the batch row named by the project live pointer (same business project; limit 2). Returns
+// its numeric snapshotVersion, or null when the pointer/batch/version cannot be resolved.
+async function resolvePointerBatchVersion({ batchScoped, plan, pointerRunId }) {
+  const pointerBatches = await batchScoped.queryRecords({
+    filters: { projectId: optionalString(plan.snapshotBatch.projectId), syncRunId: pointerRunId },
+    limit: 2,
+    offset: 0,
+  })
+  if (!Array.isArray(pointerBatches)) {
+    throw new StockPreparationSyncRunPersistError(500, 'PERSIST_RECORDS_API_INVALID', 'queryRecords must return an array')
+  }
+  if (pointerBatches.length !== 1) return null
+  const pointerVersion = Number(pointerBatches[0] && pointerBatches[0].data && pointerBatches[0].data.snapshotVersion)
+  return Number.isFinite(pointerVersion) ? pointerVersion : null
+}
+
 function assertPlanIdentityKeys(plan, snapshotLines) {
   if (!optionalString(plan && plan.snapshotBatch && plan.snapshotBatch[BATCH_KEY_FIELD])) {
     throw new StockPreparationSyncRunPersistError(422, 'PERSIST_CONFIG_INVALID', 'planned snapshot batch key is required', { field: BATCH_KEY_FIELD })
@@ -360,19 +396,14 @@ async function assertExactReplay({
   const currentRunId = optionalString(plan.syncRun[RUN_KEY_FIELD])
   if (pointerRunId !== currentRunId) {
     if (!pointerRunId) projectPointerStale('pointer_unresolvable')
-    const pointerBatches = await batchScoped.queryRecords({
-      filters: { projectId: optionalString(plan.snapshotBatch.projectId), syncRunId: pointerRunId },
-      limit: 2,
-      offset: 0,
-    })
-    if (!Array.isArray(pointerBatches)) {
-      throw new StockPreparationSyncRunPersistError(500, 'PERSIST_RECORDS_API_INVALID', 'queryRecords must return an array')
-    }
-    if (pointerBatches.length !== 1) projectPointerStale('pointer_unresolvable')
-    const pointerVersion = Number(pointerBatches[0] && pointerBatches[0].data && pointerBatches[0].data.snapshotVersion)
+    const pointerVersion = await resolvePointerBatchVersion({ batchScoped, plan, pointerRunId })
     const currentVersion = Number(plan.snapshotBatch.snapshotVersion)
-    if (!Number.isFinite(pointerVersion) || !Number.isFinite(currentVersion)) projectPointerStale('pointer_unresolvable')
+    if (pointerVersion === null || !Number.isFinite(currentVersion)) projectPointerStale('pointer_unresolvable')
     if (pointerVersion < currentVersion) projectPointerStale('stale_pointer')
+    // EQUAL version on a DIFFERENT run cannot prove the pointer advanced (adversarial round-2: with
+    // versions enforced monotonic at create, this state is only reachable on legacy/degenerate data)
+    // — fail closed rather than silently blessing it.
+    if (pointerVersion === currentVersion) projectPointerStale('pointer_unresolvable')
   }
 }
 
@@ -542,6 +573,20 @@ async function persistStockPreparationSyncRun(input = {}) {
       project: { mode: 'skipped' },
       evidence: buildEvidence({ persisted: false, mode: 'skipped_existing', created, plan, plannedLineCount: snapshotLines.length, existingBatchMatched: true, projectSync: null }),
     }
+  }
+
+  // H-2 precondition — CREATE path monotonic-version guard (before the FIRST write): a genuinely-new
+  // batch for an EXISTING project must carry a snapshotVersion strictly above the pointer batch's
+  // version. This is what makes the replay-side stale/advanced inference sound (see
+  // versionNotMonotonic above); a repeat sync that omits snapshotVersion (default 1) now fails loudly
+  // here instead of silently disabling CW4-existing detection.
+  if (projectRows.length === 1) {
+    const createPointerRunId = optionalString(projectRows[0] && projectRows[0].data && projectRows[0].data.lastSyncRunId)
+    if (!createPointerRunId) versionNotMonotonic('pointer_unresolvable')
+    const pointerVersion = await resolvePointerBatchVersion({ batchScoped: batchTarget.scoped, plan, pointerRunId: createPointerRunId })
+    const currentVersion = Number(plan.snapshotBatch.snapshotVersion)
+    if (pointerVersion === null || !Number.isFinite(currentVersion)) versionNotMonotonic('pointer_unresolvable')
+    if (currentVersion <= pointerVersion) versionNotMonotonic('not_monotonic')
   }
 
   // 5. create-only path: batch row, then each line row, then the run row. createRecord ONLY — no

--- a/plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs
@@ -71,6 +71,11 @@ const LINE_KEY_FIELD = LINE_TEMPLATE.keyFields[0]
 const RUN_KEY_FIELD = RUN_TEMPLATE.keyFields[0]
 const READ_PAGE_LIMIT = 500
 const READ_MAX_PAGES = 50
+// H-3 (P4 lock round-1: prerequisite for the Option-A long transaction, and a replay-provability
+// precondition TODAY): a plan larger than the bounded replay read could be CREATED but never exactly
+// replayed — every retry would 409 PERSIST_EXISTING_BATCH_READ_UNPROVABLE forever. Reject loudly
+// before any provisioning / records access instead of persisting an unprovable batch.
+const PERSIST_MAX_PLAN_LINES = READ_PAGE_LIMIT * READ_MAX_PAGES
 
 // #4163 T1: the PROJECT table template — grounds the project-row upsert the SAME way BATCH/LINE/RUN are
 // grounded above (frozen template, never an invented field name).
@@ -221,6 +226,16 @@ function existingBatchIncomplete(target, reason) {
   )
 }
 
+// H-2 (P4 lock round-1: mandatory-first hardening). reason ∈ {stale_pointer, pointer_unresolvable}.
+function projectPointerStale(reason) {
+  throw new StockPreparationSyncRunPersistError(
+    409,
+    'PERSIST_PROJECT_POINTER_STALE',
+    'existing project live pointer does not cover this batch',
+    { target: 'project', reason },
+  )
+}
+
 function assertPlanIdentityKeys(plan, snapshotLines) {
   if (!optionalString(plan && plan.snapshotBatch && plan.snapshotBatch[BATCH_KEY_FIELD])) {
     throw new StockPreparationSyncRunPersistError(422, 'PERSIST_CONFIG_INVALID', 'planned snapshot batch key is required', { field: BATCH_KEY_FIELD })
@@ -295,6 +310,7 @@ async function assertExactReplay({
   snapshotLines,
   lineScoped,
   runScoped,
+  batchScoped,
   projectRows,
 }) {
   if (!projectionsEqual(BATCH_TEMPLATE, plan.snapshotBatch, existingBatch)) {
@@ -330,6 +346,34 @@ async function assertExactReplay({
   }
 
   if (projectRows.length === 0) existingBatchIncomplete('project', 'missing')
+
+  // H-2 (P4 lock round-1: mandatory-first): project-row EXISTENCE is not enough. A crash between the
+  // run create and the project upsert on a repeat sync (CW4-existing) used to replay as a silent 200
+  // with the live pointer still on an OLDER run — the only crash window with no observable at all.
+  // Discriminator (run rows carry no timestamps by design): batch rows carry `syncRunId`, so resolve
+  // the batch the pointer's run belongs to (same business project) and compare `snapshotVersion`:
+  //   pointer at this run                    -> covered, 200 path continues;
+  //   pointer batch at a HIGHER/EQUAL version -> a later sync legitimately advanced the pointer, 200;
+  //   pointer batch at a LOWER version        -> stale pointer (CW4-existing), 409;
+  //   pointer/pointer-batch not resolvable    -> not provable either way, fail closed 409.
+  const pointerRunId = optionalString(projectRows[0] && projectRows[0].data && projectRows[0].data.lastSyncRunId)
+  const currentRunId = optionalString(plan.syncRun[RUN_KEY_FIELD])
+  if (pointerRunId !== currentRunId) {
+    if (!pointerRunId) projectPointerStale('pointer_unresolvable')
+    const pointerBatches = await batchScoped.queryRecords({
+      filters: { projectId: optionalString(plan.snapshotBatch.projectId), syncRunId: pointerRunId },
+      limit: 2,
+      offset: 0,
+    })
+    if (!Array.isArray(pointerBatches)) {
+      throw new StockPreparationSyncRunPersistError(500, 'PERSIST_RECORDS_API_INVALID', 'queryRecords must return an array')
+    }
+    if (pointerBatches.length !== 1) projectPointerStale('pointer_unresolvable')
+    const pointerVersion = Number(pointerBatches[0] && pointerBatches[0].data && pointerBatches[0].data.snapshotVersion)
+    const currentVersion = Number(plan.snapshotBatch.snapshotVersion)
+    if (!Number.isFinite(pointerVersion) || !Number.isFinite(currentVersion)) projectPointerStale('pointer_unresolvable')
+    if (pointerVersion < currentVersion) projectPointerStale('stale_pointer')
+  }
 }
 
 // #4163 T1 — upsert the PROJECT row: query by the key field first (never trust "it must be new"), then
@@ -433,6 +477,18 @@ async function persistStockPreparationSyncRun(input = {}) {
   const snapshotLines = Array.isArray(plan.snapshotLines) ? plan.snapshotLines : []
   assertPlanIdentityKeys(plan, snapshotLines)
 
+  // H-3: explicit plan-size bound — fail before ANY provisioning / records access. See
+  // PERSIST_MAX_PLAN_LINES above; counts are values-free by doctrine, the details carry only the
+  // design-constant bound and the field name, never row content.
+  if (snapshotLines.length > PERSIST_MAX_PLAN_LINES) {
+    throw new StockPreparationSyncRunPersistError(
+      422,
+      'PERSIST_PLAN_TOO_LARGE',
+      'planned snapshot line count exceeds the provable persist bound',
+      { field: 'snapshotLines', maxLines: PERSIST_MAX_PLAN_LINES },
+    )
+  }
+
   // The MVP tables are provisioned under an INTERNAL STAGING project (readiness/ensure route
   // resolveIntegrationStagingProjectId -> `<tenant>:integration-core`), NOT the business projectId. So
   // sheet resolution MUST use the caller-derived targetProjectId (staging); the plan rows keep the
@@ -475,6 +531,7 @@ async function persistStockPreparationSyncRun(input = {}) {
       snapshotLines,
       lineScoped: lineTarget.scoped,
       runScoped: runTarget.scoped,
+      batchScoped: batchTarget.scoped,
       projectRows,
     })
     const created = { batch: 0, lines: 0, run: 0 }
@@ -551,5 +608,6 @@ module.exports = {
     PROJECT_FIELD_IDS,
     READ_PAGE_LIMIT,
     READ_MAX_PAGES,
+    PERSIST_MAX_PLAN_LINES,
   },
 }

--- a/plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs
@@ -272,6 +272,29 @@ async function resolvePointerBatchVersion({ batchScoped, plan, pointerRunId }) {
   return Number.isFinite(pointerVersion) ? pointerVersion : null
 }
 
+// Round-3: bounded, numeric MAX-version scan over ALL batch rows of a business project (orphan
+// complete batches included — the pointer alone is not the history). Returns the maximum numeric
+// snapshotVersion (0 when the project has no batch rows), or null when the history is unprovable
+// (page bound exceeded, malformed page, or any row with a non-numeric version) — callers fail closed.
+async function readProjectMaxBatchVersion(batchScoped, projectId) {
+  let maxVersion = 0
+  for (let page = 0; page < READ_MAX_PAGES; page += 1) {
+    const pageRows = await batchScoped.queryRecords({
+      filters: { projectId },
+      limit: READ_PAGE_LIMIT,
+      offset: page * READ_PAGE_LIMIT,
+    })
+    if (!Array.isArray(pageRows) || pageRows.length > READ_PAGE_LIMIT) return null
+    for (const row of pageRows) {
+      const version = Number(row && row.data && row.data.snapshotVersion)
+      if (!Number.isFinite(version)) return null
+      if (version > maxVersion) maxVersion = version
+    }
+    if (pageRows.length < READ_PAGE_LIMIT) return maxVersion
+  }
+  return null
+}
+
 function assertPlanIdentityKeys(plan, snapshotLines) {
   if (!optionalString(plan && plan.snapshotBatch && plan.snapshotBatch[BATCH_KEY_FIELD])) {
     throw new StockPreparationSyncRunPersistError(422, 'PERSIST_CONFIG_INVALID', 'planned snapshot batch key is required', { field: BATCH_KEY_FIELD })
@@ -576,17 +599,18 @@ async function persistStockPreparationSyncRun(input = {}) {
   }
 
   // H-2 precondition — CREATE path monotonic-version guard (before the FIRST write): a genuinely-new
-  // batch for an EXISTING project must carry a snapshotVersion strictly above the pointer batch's
-  // version. This is what makes the replay-side stale/advanced inference sound (see
-  // versionNotMonotonic above); a repeat sync that omits snapshotVersion (default 1) now fails loudly
-  // here instead of silently disabling CW4-existing detection.
+  // batch for an EXISTING project must carry a snapshotVersion strictly above EVERY existing batch of
+  // that project — not merely above the batch the live pointer names (round-3 finding: V1 commit →
+  // V3 crash before the project patch leaves a COMPLETE orphan V3 with the pointer still on V1; a
+  // pointer-only compare then wrongly accepted V2). The scan is bounded and numeric: paged read of
+  // the project's batch rows; an unprovable history (page bound exceeded / non-numeric version)
+  // fails closed. This is what makes the replay-side stale/advanced inference sound.
   if (projectRows.length === 1) {
-    const createPointerRunId = optionalString(projectRows[0] && projectRows[0].data && projectRows[0].data.lastSyncRunId)
-    if (!createPointerRunId) versionNotMonotonic('pointer_unresolvable')
-    const pointerVersion = await resolvePointerBatchVersion({ batchScoped: batchTarget.scoped, plan, pointerRunId: createPointerRunId })
     const currentVersion = Number(plan.snapshotBatch.snapshotVersion)
-    if (pointerVersion === null || !Number.isFinite(currentVersion)) versionNotMonotonic('pointer_unresolvable')
-    if (currentVersion <= pointerVersion) versionNotMonotonic('not_monotonic')
+    if (!Number.isFinite(currentVersion)) versionNotMonotonic('history_unprovable')
+    const maxVersion = await readProjectMaxBatchVersion(batchTarget.scoped, optionalString(planInputs.projectId))
+    if (maxVersion === null) versionNotMonotonic('history_unprovable')
+    if (currentVersion <= maxVersion) versionNotMonotonic('not_monotonic')
   }
 
   // 5. create-only path: batch row, then each line row, then the run row. createRecord ONLY — no

--- a/plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs
@@ -50,6 +50,7 @@ const {
     LINE_FIELD_IDS,
     RUN_FIELD_IDS,
   },
+  parseStrictVersion,
 } = require('./stock-preparation-sync-run-plan.cjs')
 const { createTargetScopedRecordsApi } = require('./stock-preparation-table-actions.cjs')
 const {
@@ -271,19 +272,8 @@ async function resolvePointerBatchVersion({ batchScoped, plan, pointerRunId }) {
   return parseStrictVersion(pointerBatches[0] && pointerBatches[0].data && pointerBatches[0].data.snapshotVersion)
 }
 
-// Round-4: STRICT version parser — Number() coerces null/''/booleans to finite numbers, which let
-// a null-version history row slip past the "non-numeric fails closed" intent. Versions must be
-// positive integers (or their non-empty string serializations); everything else is null → callers
-// fail closed. Used by ALL THREE consumers: the history max-scan, the pointer-batch resolution, and
-// the plan's own current version.
-function parseStrictVersion(value) {
-  let numeric = null
-  if (typeof value === 'number') numeric = value
-  else if (typeof value === 'string' && value.trim() !== '') numeric = Number(value)
-  else return null
-  if (!Number.isFinite(numeric) || !Number.isInteger(numeric) || numeric <= 0) return null
-  return numeric
-}
+// Round-5: parseStrictVersion is SHARED from sync-run-plan.cjs — plan (preview) and persist
+// (commit + history scan) reject identically; see that module for the canonical-decimal contract.
 
 // Round-3: bounded, numeric MAX-version scan over ALL batch rows of a business project (orphan
 // complete batches included — the pointer alone is not the history). Returns the maximum numeric

--- a/plugins/plugin-integration-core/lib/stock-preparation-sync-run-plan.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-sync-run-plan.cjs
@@ -251,7 +251,18 @@ function planBomSnapshotSyncRun(input = {}) {
   const snapshotBatchId = requiredString(input.snapshotBatchId, 'snapshotBatchId')
   const sourceSystem = optionalString(input.sourceSystem) // passthrough only — never invent a source
   const snapshotVersionProvided = input.snapshotVersion !== undefined && input.snapshotVersion !== null
-  const snapshotVersion = snapshotVersionProvided ? input.snapshotVersion : DEFAULT_SNAPSHOT_VERSION
+  let snapshotVersion = DEFAULT_SNAPSHOT_VERSION
+  if (snapshotVersionProvided) {
+    snapshotVersion = parseStrictVersion(input.snapshotVersion)
+    if (snapshotVersion === null) {
+      throw new StockPreparationSyncRunPlanError(
+        422,
+        'SYNC_RUN_PLAN_CONFIG_INVALID',
+        'snapshotVersion must be a positive safe integer (canonical decimal form)',
+        { field: 'snapshotVersion' },
+      )
+    }
+  }
   const defaultDesignUnit = optionalString(input.defaultDesignUnit) || undefined
   const readPlan = isPlainObject(input.readPlan) ? input.readPlan : undefined
   const previousSnapshotBatchId = optionalString(input.previousSnapshotBatchId)
@@ -336,6 +347,21 @@ function planBomSnapshotSyncRun(input = {}) {
   return { snapshotBatch, snapshotLines, syncRun, diff, flags, evidence }
 }
 
+// Round-5: STRICT snapshot-version parser, shared by plan (preview) and persist (commit + history
+// scan) so a version can never preview-succeed and only commit-reject. Positive SAFE integers only;
+// string forms are restricted to canonical decimal ^[1-9]\d*$ — "01" / "+1" / "1e2" / "0x10" and
+// unsafe-range values are all rejected (Number() alone accepts every one of those).
+function parseStrictVersion(value) {
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value > 0 ? value : null
+  }
+  if (typeof value === 'string' && /^[1-9]\d*$/.test(value)) {
+    const numeric = Number(value)
+    return Number.isSafeInteger(numeric) ? numeric : null
+  }
+  return null
+}
+
 module.exports = {
   REQUIRED_PERMISSION,
   SNAPSHOT_STATUS_DRAFT,
@@ -345,6 +371,7 @@ module.exports = {
   DEFAULT_SNAPSHOT_VERSION,
   StockPreparationSyncRunPlanError,
   planBomSnapshotSyncRun,
+  parseStrictVersion,
   __internals: {
     assertAdminPermission,
     computeFlags,


### PR DESCRIPTION
## What (P4 lock #4452 round-1: H-2 = mandatory-first silent-correctness gap; H-3 = Option-A prerequisite)

Current head reflects three review rounds; this body describes the FINAL semantics (earlier claims superseded).

**H-2 — stale project-pointer detection.** `assertExactReplay` verifies the project **live pointer** covers the replayed batch, closing the only crash window with zero observability (CW4-existing: crash between run-create and project-patch on a repeat sync used to replay as a silent 200 with the pointer permanently stale). Replay-side discriminator (run rows carry no timestamps by design; batch rows carry `syncRunId`):

- pointer at this run → 200 path unchanged;
- pointer batch at a **higher** version → a later sync legitimately advanced the pointer → 200;
- pointer batch at a **lower** version → 409 `PERSIST_PROJECT_POINTER_STALE` `{target:'project', reason:'stale_pointer'}`;
- **equal** version on a different run, or unresolvable pointer/batch/version → fail-closed 409 `{reason:'pointer_unresolvable'}` (never silently blessed).

**H-2 precondition — per-project version monotonicity (create path).** The discriminator is only sound if versions strictly increase per project, and `snapshotVersion` is caller-supplied with default 1. A genuinely-new batch for an existing project must therefore exceed the **maximum version across ALL of the project's batch rows** — not merely the pointer batch (round-3: a complete orphan V3 from a CW4 crash left the pointer on V1 and a pointer-only compare wrongly accepted V2). The scan (`readProjectMaxBatchVersion`) is a bounded, numeric paged read; unprovable history (page bound exceeded / non-numeric version) fails closed. Violations → 422 `PERSIST_VERSION_NOT_MONOTONIC` `{field:'snapshotVersion', reason:'not_monotonic'|'history_unprovable'}` **before any write**.

**H-3 — explicit plan-size bound.** `PERSIST_MAX_PLAN_LINES = READ_PAGE_LIMIT × READ_MAX_PAGES − 1 = 24,999`: completeness is only provable by a SHORT page, so a 25,000-line batch would persist and then be permanently unreplayable (round-2, reviewer-reproduced). Over-bound plans reject 422 `PERSIST_PLAN_TOO_LARGE` before any provisioning/records access; a create-then-replay test locks the exact bound (paginated fake). Must land before the Option-A long transaction per round-1.

## Operator-facing behavior changes

1. Repeat syncs that previously omitted `snapshotVersion` (default 1) now fail loudly (422 `PERSIST_VERSION_NOT_MONOTONIC`) — bump the version per sync; the read side (predecessor picking, latest-complete resolution) already assumed monotonic versions.
2. Pre-existing over-bound (≥25,000-line) batches now replay as 422 `PERSIST_PLAN_TOO_LARGE` instead of 409 `READ_UNPROVABLE` (both loud; code shift only).
3. Previously-silent stale-pointer replays now 409; **no repair is performed** (repair remains a P4 Option-C decision).

## Evidence (cumulative, 42/42)

- CW4-existing reproduced by **crash injection** (project-sheet patch failure mid-persist; unpatched code returned a silent 200); advanced-pointer legal replay stays 200; pointer/equal-version fail-closed cases; over-cap 422 with zero I/O; exact-bound create+replay; **round-3 crash sequence** (V1 ok → V3 CW4 crash → V2 rejected 422 zero-write → V4 proceeds).
- Mutations (commit-first, each restored+clean-verified): disable pointer block → 2 tests RED; disable cap → 1 RED; ignore history in the monotonic guard → 2 RED (incl. the round-3 sequence).
- Adjacent consumers green: sync-run-plan / plm-source-persist-bridge / erp-material-sync-persist / snapshot-reads / http-routes.
- Values-free: details carry only `{target,reason}` / `{field,maxLines|reason}` (design constants).

Both production callers (`/mvp/sync/persist` + flag-gated T3b bridge) share this module.

**Round-6 owner verdict: GO.** Current head `bddc1e9dc` = `8cb1b7c41` rebased onto `dfc9318fc` (content-identical; pre-rebase commit ids appear in earlier round notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Round-4 (owner review — fixed in `9c94e4ec5`)

- **Unconditional history scan**: the guard was gated on `projectRows.length === 1` — a FIRST-sync crash at the project create (CW4-first) leaves complete orphan history with **no project row**, so the next lower-version sync skipped the scan (owner-reproduced). The scan now runs before **every** new batch create; empty history scans to max 0.
- **Strict version parser**: `Number()` coerced null/`''`/booleans to finite numbers — a null-version history row slipped past fail-closed as "max 0" (owner-reproduced). `parseStrictVersion` (positive integers or their non-empty string serializations; all else → fail-closed) is now used at all three consumers: history max-scan, pointer resolution, plan current version. `snapshotVersion: 0` reclassifies as `history_unprovable`.
- Stale pointer-only comments rewritten; +2 tests (first-sync crash sequence; null-version fail-closed with numeric-string positive control). 40/40; disabling the whole guard turns 4 tests RED.


## Round-5 (owner review — fixed in `8cb1b7c41`)

- **Canonical-decimal strict parser, SHARED plan+persist**: `parseStrictVersion` still rode `Number(value)` — `'01'`/`'+1'`/`'1e2'`/`'0x10'` all parsed, and `Number.isInteger` admitted unsafe-range values (owner-reproduced). New contract: positive **safe** integers only; strings restricted to `^[1-9]\d*$` + `Number.isSafeInteger` after conversion. The parser now lives in `sync-run-plan.cjs` and is shared — **preview and commit reject identically** (422 `SYNC_RUN_PLAN_CONFIG_INVALID {field:'snapshotVersion'}`); persist keeps the strict parse for HISTORY rows (`history_unprovable`) as defense in depth.
- Two discriminating test groups (current-input forms → plan-level 422 zero-write; history-row forms `'01'/'+1'/'1e2'/'0x10'/2^53` → `history_unprovable` zero-write); regex-loosening mutation turns both groups RED. 42/42; plan/bridge/http-routes green.

