### PR TITLE
feat(stock-prep): H-1 — server-side diff completeness gate (409 SNAPSHOT_DIFF_BATCH_INCOMPLETE)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
@@ -841,6 +841,53 @@ async function main() {
     }
   })
 
+  await run('R5: AUTO base tie — two distinct predecessors at the same highest version => 409 ambiguous on BOTH endpoints, forward AND reversed order', async () => {
+    // Two COMPLETE predecessor batches share the highest prior version (substrate has no logical
+    // unique index; concurrent writers can produce this). The auto-pick previously depended on
+    // database return order ({"ab":"base_a","ba":"base_b"} at the pre-fix head).
+    const makeRows = (reversed) => {
+      const preds = [
+        { snapshotBatchId: 'base_a', projectId: BUSINESS_PROJECT, snapshotVersion: 1, snapshotStatus: 'draft', syncRunId: 'ta1', createdAt: 'x' },
+        { snapshotBatchId: 'base_b', projectId: BUSINESS_PROJECT, snapshotVersion: 1, snapshotStatus: 'draft', syncRunId: 'tb1', createdAt: 'x' },
+      ]
+      return {
+        [SHEET_IDS[BATCH_OBJECT_ID]]: [
+          { snapshotBatchId: 'tie_cur', projectId: BUSINESS_PROJECT, snapshotVersion: 2, snapshotStatus: 'draft', syncRunId: 'tc1', createdAt: 'x' },
+          ...(reversed ? [...preds].reverse() : preds),
+        ],
+        [SHEET_IDS[LINE_OBJECT_ID]]: [
+          { snapshotLineId: 'tc_l1', snapshotBatchId: 'tie_cur', projectId: BUSINESS_PROJECT, pathKey: '/root/a', childDrawingNo: 'D-1', designQty: 1, lineStatus: 'active' },
+          { snapshotLineId: 'ta_l1', snapshotBatchId: 'base_a', projectId: BUSINESS_PROJECT, pathKey: '/root/a', childDrawingNo: 'D-1', designQty: 1, lineStatus: 'active' },
+          { snapshotLineId: 'tb_l1', snapshotBatchId: 'base_b', projectId: BUSINESS_PROJECT, pathKey: '/root/a', childDrawingNo: 'D-1', designQty: 1, lineStatus: 'active' },
+        ],
+        [SHEET_IDS[RUN_OBJECT_ID]]: [
+          { runId: 'tc1', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+          { runId: 'ta1', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+          { runId: 'tb1', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+        ],
+      }
+    }
+    for (const reversed of [false, true]) {
+      for (const fn of [getSnapshotDiff, listSnapshotDiffRows]) {
+        const caught = await expectIncomplete409(fn, {
+          recordsApi: makeRecordsApi(makeRows(reversed)),
+          snapshotBatchId: 'tie_cur',
+        })
+        assert.deepEqual(caught.details, { target: 'base', reason: 'ambiguous' })
+      }
+    }
+    // Positive control: an EXPLICIT base pick between the twins remains allowed (caller named one).
+    const explicit = await getSnapshotDiff({
+      recordsApi: makeRecordsApi(makeRows(false)),
+      provisioning: makeProvisioning(),
+      targetProjectId: STAGING_PROJECT,
+      snapshotBatchId: 'tie_cur',
+      baseSnapshotBatchId: 'base_a',
+      permission: 'admin',
+    })
+    assert.equal(explicit.baseSnapshotBatchId, 'base_a')
+  })
+
   await run('H-1 gate: 409 error is values-free — details carry ONLY {target, reason}, no ids or counts', async () => {
     // Plant the secret into the HANDLES the gate touches (batch id / run id): none of them may appear
     // anywhere in the thrown 409 (closed details shape + fixed values-free message).

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
@@ -749,6 +749,79 @@ async function main() {
     assert.equal(emptyGhost.baseSnapshotBatchId, null)
   })
 
+  await run('R3: duplicate batch identity (same snapshotBatchId, different projects) => 409 ambiguous on BOTH endpoints, never an arbitrary twin', async () => {
+    // Two batch rows share one snapshotBatchId (substrate has no unique index; concurrent writers can
+    // produce this — P4 lock §0.3). Both twins are individually COMPLETE so the completeness gate
+    // alone would pass; the exactly-one identity check must refuse instead of answering from rows[0].
+    const rows = {
+      [SHEET_IDS[BATCH_OBJECT_ID]]: [
+        { snapshotBatchId: 'dup1', projectId: BUSINESS_PROJECT, snapshotVersion: 2, snapshotStatus: 'draft', syncRunId: 'dr1', createdAt: 'x' },
+        { snapshotBatchId: 'dup1', projectId: 'proj_other', snapshotVersion: 5, snapshotStatus: 'draft', syncRunId: 'dr2', createdAt: 'x' },
+      ],
+      [SHEET_IDS[LINE_OBJECT_ID]]: [
+        { snapshotLineId: 'dl1', snapshotBatchId: 'dup1', projectId: BUSINESS_PROJECT, pathKey: '/root/a', childDrawingNo: 'D-1', designQty: 1, lineStatus: 'active' },
+      ],
+      [SHEET_IDS[RUN_OBJECT_ID]]: [
+        { runId: 'dr1', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+        { runId: 'dr2', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+      ],
+    }
+    for (const fn of [getSnapshotDiff, listSnapshotDiffRows]) {
+      const caught = await expectIncomplete409(fn, {
+        recordsApi: makeRecordsApi(rows),
+        snapshotBatchId: 'dup1',
+      })
+      assert.deepEqual(caught.details, { target: 'current', reason: 'ambiguous' })
+    }
+  })
+
+  await run('R3: duplicate BASE identity and duplicate RUN identity => 409 ambiguous {target: base/current}', async () => {
+    const rows = {
+      [SHEET_IDS[BATCH_OBJECT_ID]]: [
+        { snapshotBatchId: 'cur1', projectId: BUSINESS_PROJECT, snapshotVersion: 2, snapshotStatus: 'draft', syncRunId: 'cr1', createdAt: 'x' },
+        { snapshotBatchId: 'baseX', projectId: BUSINESS_PROJECT, snapshotVersion: 1, snapshotStatus: 'draft', syncRunId: 'br1', createdAt: 'x' },
+        { snapshotBatchId: 'baseX', projectId: 'proj_other', snapshotVersion: 1, snapshotStatus: 'draft', syncRunId: 'br2', createdAt: 'x' },
+      ],
+      [SHEET_IDS[LINE_OBJECT_ID]]: [
+        { snapshotLineId: 'cl1', snapshotBatchId: 'cur1', projectId: BUSINESS_PROJECT, pathKey: '/root/a', childDrawingNo: 'D-1', designQty: 1, lineStatus: 'active' },
+        { snapshotLineId: 'bl1', snapshotBatchId: 'baseX', projectId: BUSINESS_PROJECT, pathKey: '/root/a', childDrawingNo: 'D-1', designQty: 1, lineStatus: 'active' },
+      ],
+      [SHEET_IDS[RUN_OBJECT_ID]]: [
+        { runId: 'cr1', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+        { runId: 'br1', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+        { runId: 'br2', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+      ],
+    }
+    // Explicit-base path: base identity is duplicated -> ambiguous {target: 'base'}.
+    const caughtBase = await expectIncomplete409(getSnapshotDiff, {
+      recordsApi: makeRecordsApi(rows),
+      snapshotBatchId: 'cur1',
+      baseSnapshotBatchId: 'baseX',
+    })
+    assert.deepEqual(caughtBase.details, { target: 'base', reason: 'ambiguous' })
+
+    // Duplicate RUN identity for the current batch -> ambiguous {target: 'current'} (both endpoints).
+    const runDupRows = {
+      [SHEET_IDS[BATCH_OBJECT_ID]]: [
+        { snapshotBatchId: 'cur2', projectId: BUSINESS_PROJECT, snapshotVersion: 1, snapshotStatus: 'draft', syncRunId: 'rr1', createdAt: 'x' },
+      ],
+      [SHEET_IDS[LINE_OBJECT_ID]]: [
+        { snapshotLineId: 'rl1', snapshotBatchId: 'cur2', projectId: BUSINESS_PROJECT, pathKey: '/root/a', childDrawingNo: 'D-1', designQty: 1, lineStatus: 'active' },
+      ],
+      [SHEET_IDS[RUN_OBJECT_ID]]: [
+        { runId: 'rr1', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+        { runId: 'rr1', runType: 'plm_sync', status: 'failed', startedAt: 'y' },
+      ],
+    }
+    for (const fn of [getSnapshotDiff, listSnapshotDiffRows]) {
+      const caught = await expectIncomplete409(fn, {
+        recordsApi: makeRecordsApi(runDupRows),
+        snapshotBatchId: 'cur2',
+      })
+      assert.deepEqual(caught.details, { target: 'current', reason: 'ambiguous' })
+    }
+  })
+
   await run('H-1 gate: 409 error is values-free — details carry ONLY {target, reason}, no ids or counts', async () => {
     // Plant the secret into the HANDLES the gate touches (batch id / run id): none of them may appear
     // anywhere in the thrown 409 (closed details shape + fixed values-free message).

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
@@ -800,6 +800,25 @@ async function main() {
     })
     assert.deepEqual(caughtBase.details, { target: 'base', reason: 'ambiguous' })
 
+    // Round-4: REVERSED twin order must yield the SAME verdict — before the fix the outcome depended
+    // on database return order ([other-project twin first] surfaced BASE_PROJECT_MISMATCH instead).
+    const reversedRows = {
+      ...rows,
+      [SHEET_IDS[BATCH_OBJECT_ID]]: [
+        rows[SHEET_IDS[BATCH_OBJECT_ID]][0],
+        { snapshotBatchId: 'baseX', projectId: 'proj_other', snapshotVersion: 1, snapshotStatus: 'draft', syncRunId: 'br2', createdAt: 'x' },
+        { snapshotBatchId: 'baseX', projectId: BUSINESS_PROJECT, snapshotVersion: 1, snapshotStatus: 'draft', syncRunId: 'br1', createdAt: 'x' },
+      ],
+    }
+    for (const fn of [getSnapshotDiff, listSnapshotDiffRows]) {
+      const caughtReversed = await expectIncomplete409(fn, {
+        recordsApi: makeRecordsApi(reversedRows),
+        snapshotBatchId: 'cur1',
+        baseSnapshotBatchId: 'baseX',
+      })
+      assert.deepEqual(caughtReversed.details, { target: 'base', reason: 'ambiguous' })
+    }
+
     // Duplicate RUN identity for the current batch -> ambiguous {target: 'current'} (both endpoints).
     const runDupRows = {
       [SHEET_IDS[BATCH_OBJECT_ID]]: [

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
@@ -10,6 +10,9 @@
 //   - PROJECT-SCOPE SPLIT: findObjectSheet uses the STAGING targetProjectId (business project => null),
 //     so using the business project as the locator finds nothing (kills a revert of the split);
 //   - COMPLETENESS: a batch with a row but zero lines OR a missing run row => incomplete:true;
+//   - H-1 GATE (#4452 P4 round-1): diff + diff/rows refuse an incomplete CURRENT or BASE (explicit
+//     AND auto-picked — no silent skip to an older complete batch) with 409
+//     SNAPSHOT_DIFF_BATCH_INCOMPLETE and closed values-free details { target, reason };
 //   - admin-denied => 403 before any read (fail closed);
 //   - READONLY: createRecord/patchRecord/deleteRecord are NEVER called;
 //   - values-free: a planted drawing number / quantity / exception message never reaches a summary.
@@ -383,6 +386,12 @@ async function main() {
         { snapshotLineId: 'l1', snapshotBatchId: 'b1', childDrawingNo: 'A', childVersion: 'V1', pathKey: '/root/A', designQty: 1 },
         { snapshotLineId: 'l3', snapshotBatchId: 'b3', childDrawingNo: 'A', childVersion: 'V3', pathKey: '/root/A', designQty: 1 },
       ],
+      // H-1: run rows so b1/b3 (the gated current/base pair) are COMPLETE — this test locks the base-
+      // override validation codes, not the completeness gate (which has its own tests below).
+      [SHEET_IDS[RUN_OBJECT_ID]]: [
+        { runId: 'r1', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+        { runId: 'r3', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+      ],
     }
     // Explicit base b1 (predecessor auto-pick would choose b2): version change A V1 -> V3 counts.
     const result = await getSnapshotDiff({
@@ -465,6 +474,11 @@ async function main() {
         { snapshotLineId: 'c2', snapshotBatchId: 'd2', childDrawingNo: 'B', childVersion: 'V2', pathKey: '/root/B', designQty: 1 },
         { snapshotLineId: 'c3', snapshotBatchId: 'd2', childDrawingNo: 'C', childVersion: 'V1', pathKey: '/root/C', designQty: 1 },
       ],
+      // H-1: run rows so both sides of the browsed pair are complete (the gate has its own tests).
+      [SHEET_IDS[RUN_OBJECT_ID]]: [
+        { runId: 'r1', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+        { runId: 'r2', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+      ],
     }
     const DIFF_ROW_KEY_SET = new Set([
       'diffId', 'diffType', 'reviewStatus', 'changeTypes', 'reason', 'rowCount',
@@ -540,6 +554,10 @@ async function main() {
         { snapshotBatchId: 'big1', projectId: BUSINESS_PROJECT, snapshotVersion: 1, syncRunId: 'r1' },
       ],
       [SHEET_IDS[LINE_OBJECT_ID]]: manyLines,
+      // H-1: big1 must be COMPLETE so the read reaches the row-cap check (not the completeness 409).
+      [SHEET_IDS[RUN_OBJECT_ID]]: [
+        { runId: 'r1', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+      ],
     }
     let caught = null
     try {
@@ -555,6 +573,175 @@ async function main() {
     }
     assert.equal(caught && caught.status, 422)
     assert.equal(caught && caught.code, 'SNAPSHOT_READS_ROWS_TOO_LARGE')
+  })
+
+  // ---- H-1 (#4452 P4 round-1): SERVER-SIDE diff completeness gate ----
+  // The FE only DISABLES the diff entry for an incomplete batch; deep links / list-vs-diff races reach
+  // the endpoints directly. Any incomplete side => 409 SNAPSHOT_DIFF_BATCH_INCOMPLETE, values-free.
+  const expectIncomplete409 = async (fn, args) => {
+    let caught = null
+    try {
+      await fn({
+        provisioning: makeProvisioning(),
+        targetProjectId: STAGING_PROJECT,
+        permission: 'admin',
+        ...args,
+      })
+    } catch (error) {
+      caught = error
+    }
+    assert.ok(caught, 'an incomplete side must not be answered')
+    assert.ok(caught instanceof StockPreparationTargetProvisioningError)
+    assert.equal(caught.status, 409)
+    assert.equal(caught.code, 'SNAPSHOT_DIFF_BATCH_INCOMPLETE')
+    return caught
+  }
+
+  // a1 COMPLETE (v1) < a2 INCOMPLETE (v2, zero lines, run row present) < a3 COMPLETE (v3): the
+  // auto-pick for a3 is a2 (highest version strictly below 3) — the incomplete one.
+  const h1AutoBaseFixture = () => ({
+    [SHEET_IDS[BATCH_OBJECT_ID]]: [
+      { snapshotBatchId: 'a1', projectId: BUSINESS_PROJECT, snapshotVersion: 1, snapshotStatus: 'superseded', syncRunId: 'ar1', createdAt: 'x' },
+      { snapshotBatchId: 'a2', projectId: BUSINESS_PROJECT, snapshotVersion: 2, snapshotStatus: 'draft', syncRunId: 'ar2' },
+      { snapshotBatchId: 'a3', projectId: BUSINESS_PROJECT, snapshotVersion: 3, snapshotStatus: 'active', syncRunId: 'ar3', createdAt: 'x' },
+    ],
+    [SHEET_IDS[LINE_OBJECT_ID]]: [
+      { snapshotLineId: 'al1', snapshotBatchId: 'a1', childDrawingNo: 'A', childVersion: 'V1', pathKey: '/root/A', designQty: 1 },
+      // a2: NO lines — the 0-line orphan sitting between two complete batches.
+      { snapshotLineId: 'al3', snapshotBatchId: 'a3', childDrawingNo: 'A', childVersion: 'V2', pathKey: '/root/A', designQty: 2 },
+    ],
+    [SHEET_IDS[RUN_OBJECT_ID]]: [
+      { runId: 'ar1', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+      { runId: 'ar2', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+      { runId: 'ar3', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+    ],
+  })
+
+  await run('H-1 gate: current batch with zero lines => 409 incomplete {target: current}', async () => {
+    // Run row PRESENT + zero lines: isolates the lineCount signal of the shared predicate.
+    const rows = {
+      [SHEET_IDS[BATCH_OBJECT_ID]]: [
+        { snapshotBatchId: 'g1', projectId: BUSINESS_PROJECT, snapshotVersion: 1, snapshotStatus: 'draft', syncRunId: 'gr1', createdAt: 'x' },
+      ],
+      [SHEET_IDS[LINE_OBJECT_ID]]: [],
+      [SHEET_IDS[RUN_OBJECT_ID]]: [{ runId: 'gr1', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' }],
+    }
+    const caught = await expectIncomplete409(getSnapshotDiff, {
+      recordsApi: makeRecordsApi(rows),
+      snapshotBatchId: 'g1',
+    })
+    assert.deepEqual(caught.details, { target: 'current', reason: 'incomplete' })
+  })
+
+  await run('H-1 gate: current with lines but missing run row => 409 incomplete {target: current}', async () => {
+    // fullFixture b4: 1 line, no run4 row. Its auto-pick b3 is ALSO incomplete — the CURRENT side is
+    // checked first, so target must say 'current'.
+    const caught = await expectIncomplete409(getSnapshotDiff, {
+      recordsApi: makeRecordsApi(fullFixture()),
+      snapshotBatchId: 'b4',
+    })
+    assert.deepEqual(caught.details, { target: 'current', reason: 'incomplete' })
+  })
+
+  await run('H-1 gate: explicit base incomplete (0-line orphan) => 409 incomplete {target: base}', async () => {
+    // The 0-line orphan as an EXPLICIT base is exactly the fabricated all-'added' diff H-1 closes.
+    const rows = {
+      [SHEET_IDS[BATCH_OBJECT_ID]]: [
+        { snapshotBatchId: 'e1', projectId: BUSINESS_PROJECT, snapshotVersion: 1, snapshotStatus: 'draft', syncRunId: 'er1' },
+        { snapshotBatchId: 'e2', projectId: BUSINESS_PROJECT, snapshotVersion: 2, snapshotStatus: 'active', syncRunId: 'er2', createdAt: 'x' },
+      ],
+      [SHEET_IDS[LINE_OBJECT_ID]]: [
+        // e1 has NO lines (orphan); e2 is complete.
+        { snapshotLineId: 'el2', snapshotBatchId: 'e2', childDrawingNo: 'A', childVersion: 'V1', pathKey: '/root/A', designQty: 1 },
+      ],
+      [SHEET_IDS[RUN_OBJECT_ID]]: [
+        { runId: 'er1', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+        { runId: 'er2', runType: 'plm_sync', status: 'succeeded', startedAt: 'x' },
+      ],
+    }
+    const caught = await expectIncomplete409(getSnapshotDiff, {
+      recordsApi: makeRecordsApi(rows),
+      snapshotBatchId: 'e2',
+      baseSnapshotBatchId: 'e1',
+    })
+    assert.deepEqual(caught.details, { target: 'base', reason: 'incomplete' })
+  })
+
+  await run('H-1 gate: AUTO-picked predecessor incomplete => 409 {target: base}, never a silent skip', async () => {
+    // a1 (older) is COMPLETE: a silent-skip implementation would answer with base a1 and silently
+    // change the diff result. The lock chose loud-409 — the incomplete auto-picked a2 must surface.
+    const caught = await expectIncomplete409(getSnapshotDiff, {
+      recordsApi: makeRecordsApi(h1AutoBaseFixture()),
+      snapshotBatchId: 'a3',
+    })
+    assert.deepEqual(caught.details, { target: 'base', reason: 'incomplete' })
+  })
+
+  await run('H-1 gate: both sides complete => diff and diff/rows answer exactly as before (regression)', async () => {
+    const diffResult = await getSnapshotDiff({
+      recordsApi: makeRecordsApi(fullFixture()),
+      provisioning: makeProvisioning(),
+      targetProjectId: STAGING_PROJECT,
+      snapshotBatchId: 'b2',
+      permission: 'admin',
+    })
+    assert.equal(diffResult.baseSnapshotBatchId, 'b1')
+    assert.deepEqual(diffResult.changeCounts, {
+      added: 1,
+      removed: 1,
+      quantityChanged: 1,
+      unitChanged: 0,
+      versionChanged: 0,
+      pathChanged: 0,
+      missingChildBom: 0,
+      fingerprintChanged: 0,
+    })
+    assert.equal(diffResult.blockingExceptionCount, 2)
+    const rowsResult = await listSnapshotDiffRows({
+      recordsApi: makeRecordsApi(fullFixture()),
+      provisioning: makeProvisioning(),
+      targetProjectId: STAGING_PROJECT,
+      snapshotBatchId: 'b2',
+      permission: 'admin',
+    })
+    assert.equal(rowsResult.baseSnapshotBatchId, 'b1')
+    assert.ok(rowsResult.rowCount >= 3, 'changed + removed + added rows still surface under the gate')
+  })
+
+  await run('H-1 gate: diff/rows is gated identically (incomplete current AND incomplete auto base)', async () => {
+    const caughtCurrent = await expectIncomplete409(listSnapshotDiffRows, {
+      recordsApi: makeRecordsApi(fullFixture()),
+      snapshotBatchId: 'b4',
+    })
+    assert.deepEqual(caughtCurrent.details, { target: 'current', reason: 'incomplete' })
+    const caughtBase = await expectIncomplete409(listSnapshotDiffRows, {
+      recordsApi: makeRecordsApi(h1AutoBaseFixture()),
+      snapshotBatchId: 'a3',
+    })
+    assert.deepEqual(caughtBase.details, { target: 'base', reason: 'incomplete' })
+  })
+
+  await run('H-1 gate: 409 error is values-free — details carry ONLY {target, reason}, no ids or counts', async () => {
+    // Plant the secret into the HANDLES the gate touches (batch id / run id): none of them may appear
+    // anywhere in the thrown 409 (closed details shape + fixed values-free message).
+    const batchId = `batch_${SECRET}`
+    const rows = {
+      [SHEET_IDS[BATCH_OBJECT_ID]]: [
+        { snapshotBatchId: batchId, projectId: BUSINESS_PROJECT, snapshotVersion: 1, snapshotStatus: 'draft', syncRunId: `run_${SECRET}` },
+      ],
+      [SHEET_IDS[LINE_OBJECT_ID]]: [],
+      [SHEET_IDS[RUN_OBJECT_ID]]: [],
+    }
+    const caught = await expectIncomplete409(getSnapshotDiff, {
+      recordsApi: makeRecordsApi(rows),
+      snapshotBatchId: batchId,
+    })
+    assert.deepEqual(Object.keys(caught.details).sort(), ['reason', 'target'])
+    assert.equal(caught.details.target, 'current')
+    assert.equal(caught.details.reason, 'incomplete')
+    const serialized = JSON.stringify({ message: caught.message, details: caught.details })
+    assert.equal(serialized.includes(SECRET), false, 'no handle/value leaks through the 409')
+    assert.equal(/\d/.test(JSON.stringify(caught.details)), false, 'no counts leak into the details')
   })
 
   console.log(`\nstock-preparation-snapshot-reads.test.cjs: ${passed} passed, ${failed} failed`)

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-snapshot-reads.test.cjs
@@ -721,6 +721,34 @@ async function main() {
     assert.deepEqual(caughtBase.details, { target: 'base', reason: 'incomplete' })
   })
 
+  await run('H-1 round-2: GHOST current (no batch row) with orphan LINE rows => 409, never a fabricated all-added diff; empty ghost keeps the #4002 graceful shape', async () => {
+    // Orphan line rows under an id that has NO batch row: the row-conditioned gate cannot fire, so a
+    // dedicated ghost-with-lines gate must. A genuinely empty ghost id (second call) still answers
+    // the locked graceful shape.
+    const rows = {
+      [SHEET_IDS[BATCH_OBJECT_ID]]: [],
+      [SHEET_IDS[LINE_OBJECT_ID]]: [
+        { snapshotLineId: 'gl1', snapshotBatchId: 'ghost_with_lines', projectId: BUSINESS_PROJECT, pathKey: '/root/a', childDrawingNo: 'D-1', designQty: 1, lineStatus: 'active' },
+      ],
+      [SHEET_IDS[RUN_OBJECT_ID]]: [],
+    }
+    for (const fn of [getSnapshotDiff, listSnapshotDiffRows]) {
+      const caught = await expectIncomplete409(fn, {
+        recordsApi: makeRecordsApi(rows),
+        snapshotBatchId: 'ghost_with_lines',
+      })
+      assert.deepEqual(caught.details, { target: 'current', reason: 'incomplete' })
+    }
+    const emptyGhost = await getSnapshotDiff({
+      recordsApi: makeRecordsApi(rows),
+      provisioning: makeProvisioning(),
+      targetProjectId: STAGING_PROJECT,
+      snapshotBatchId: 'ghost_truly_empty',
+      permission: 'admin',
+    })
+    assert.equal(emptyGhost.baseSnapshotBatchId, null)
+  })
+
   await run('H-1 gate: 409 error is values-free — details carry ONLY {target, reason}, no ids or counts', async () => {
     // Plant the secret into the HANDLES the gate touches (batch id / run id): none of them may appear
     // anywhere in the thrown 409 (closed details shape + fixed values-free message).

--- a/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
@@ -443,6 +443,17 @@ async function getSnapshotDiff({ recordsApi, provisioning, targetProjectId, busi
   const currentLines = lineSheet
     ? (await queryAllRecords(lineSheet, { snapshotBatchId: currentSnapshotBatchId })).map(recordData)
     : []
+  // H-1 round-2 residual: a GHOST current (no batch row) whose id still has orphan LINE rows would
+  // otherwise serve a fabricated all-'added' diff with no gate (the row-conditioned gate above
+  // skipped, auto base null). Genuinely empty ghost ids keep the #4002 graceful shape.
+  if (!currentBatchRow && currentLines.length > 0) {
+    throw new StockPreparationTargetProvisioningError(
+      409,
+      'SNAPSHOT_DIFF_BATCH_INCOMPLETE',
+      'snapshot diff refuses an incomplete snapshot batch',
+      { target: 'current', reason: 'incomplete' },
+    )
+  }
   const previousLines = lineSheet && baseSnapshotBatchId
     ? (await queryAllRecords(lineSheet, { snapshotBatchId: baseSnapshotBatchId })).map(recordData)
     : []
@@ -581,6 +592,15 @@ async function listSnapshotDiffRows({ recordsApi, provisioning, targetProjectId,
   const currentLines = lineSheet
     ? (await queryAllRecords(lineSheet, { snapshotBatchId: currentSnapshotBatchId })).map(recordData)
     : []
+  // H-1 round-2 residual — identical to getSnapshotDiff's ghost-with-orphan-lines gate.
+  if (!currentBatchRow && currentLines.length > 0) {
+    throw new StockPreparationTargetProvisioningError(
+      409,
+      'SNAPSHOT_DIFF_BATCH_INCOMPLETE',
+      'snapshot diff refuses an incomplete snapshot batch',
+      { target: 'current', reason: 'incomplete' },
+    )
+  }
   const previousLines = lineSheet && baseSnapshotBatchId
     ? (await queryAllRecords(lineSheet, { snapshotBatchId: baseSnapshotBatchId })).map(recordData)
     : []

--- a/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
@@ -308,6 +308,9 @@ async function resolveDiffBase(api, batchSheet, { currentSnapshotBatchId, projec
       throw new StockPreparationTargetProvisioningError(400, 'SNAPSHOT_DIFF_BASE_INVALID', 'baseSnapshotBatchId must differ from the diffed batch', { field: 'baseSnapshotBatchId' })
     }
     const baseRows = batchSheet ? await queryAllRecords(batchSheet, { snapshotBatchId: requestedBase }) : []
+    // Round-4: the ambiguity check MUST precede any [0] read — with duplicate base identities the
+    // outcome otherwise depended on database return order (first-twin project match vs mismatch).
+    if (baseRows.length > 1) diffBatchAmbiguous('base')
     const baseRow = baseRows[0] || null
     if (!baseRow) {
       throw new StockPreparationTargetProvisioningError(404, 'SNAPSHOT_DIFF_BASE_NOT_FOUND', 'base snapshot batch was not found', { field: 'baseSnapshotBatchId' })

--- a/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
@@ -339,12 +339,25 @@ async function resolveDiffBase(api, batchSheet, { currentSnapshotBatchId, projec
 // false (exactly the list path's semantics).
 // The details shape is CLOSED and values-free: ONLY { target: 'current'|'base', reason: 'incomplete' }
 // — no counts, no ids; the message is a fixed values-free string.
+function diffBatchAmbiguous(target) {
+  // Round-3: duplicate business identities (no substrate unique index; concurrent writers can
+  // produce them — P4 lock §0.3) mean "pick rows[0]" would silently answer from an arbitrary twin.
+  throw new StockPreparationTargetProvisioningError(
+    409,
+    'SNAPSHOT_DIFF_BATCH_INCOMPLETE',
+    'snapshot diff refuses an ambiguous snapshot batch identity',
+    { target, reason: 'ambiguous' },
+  )
+}
+
 async function assertDiffBatchComplete({ lineSheet, runSheet, batchRow, snapshotBatchId, target }) {
   const lineRows = lineSheet ? await queryAllRecords(lineSheet, { snapshotBatchId }) : []
   const syncRunId = optionalString(readCell(batchRow, 'syncRunId'))
   let runPresent = false
   if (runSheet && syncRunId) {
     const runRows = await queryAllRecords(runSheet, { runId: syncRunId })
+    // Exactly-one run identity: duplicates are as unanswerable as absence (round-3).
+    if (runRows.length > 1) diffBatchAmbiguous(target)
     runPresent = runRows.length > 0
   }
   if (isBatchIncomplete(lineRows.length, runPresent)) {
@@ -399,6 +412,7 @@ async function getSnapshotDiff({ recordsApi, provisioning, targetProjectId, busi
   let currentVersion = null
   if (batchSheet) {
     const currentRows = await queryAllRecords(batchSheet, { snapshotBatchId: currentSnapshotBatchId })
+    if (currentRows.length > 1) diffBatchAmbiguous('current')
     currentBatchRow = currentRows[0] || null
     if (currentBatchRow) {
       projectId = optionalString(readCell(currentBatchRow, 'projectId')) || projectId
@@ -430,6 +444,7 @@ async function getSnapshotDiff({ recordsApi, provisioning, targetProjectId, busi
   }
   if (baseSnapshotBatchId) {
     const baseRows = batchSheet ? await queryAllRecords(batchSheet, { snapshotBatchId: baseSnapshotBatchId }) : []
+    if (baseRows.length > 1) diffBatchAmbiguous('base')
     await assertDiffBatchComplete({
       lineSheet,
       runSheet,
@@ -551,6 +566,7 @@ async function listSnapshotDiffRows({ recordsApi, provisioning, targetProjectId,
   let currentBatchRow = null
   if (batchSheet) {
     const currentRows = await queryAllRecords(batchSheet, { snapshotBatchId: currentSnapshotBatchId })
+    if (currentRows.length > 1) diffBatchAmbiguous('current')
     currentBatchRow = currentRows[0] || null
     if (currentBatchRow) {
       projectId = optionalString(readCell(currentBatchRow, 'projectId')) || projectId
@@ -580,6 +596,7 @@ async function listSnapshotDiffRows({ recordsApi, provisioning, targetProjectId,
   }
   if (baseSnapshotBatchId) {
     const baseRows = batchSheet ? await queryAllRecords(batchSheet, { snapshotBatchId: baseSnapshotBatchId }) : []
+    if (baseRows.length > 1) diffBatchAmbiguous('base')
     await assertDiffBatchComplete({
       lineSheet,
       runSheet,

--- a/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
@@ -276,10 +276,15 @@ function changeCountsFromEvidence(diff) {
 
 // Predecessor rule: the batch (same business project) with the HIGHEST snapshotVersion strictly LESS
 // than the current batch's version. null when the current version is unknown or nothing precedes it.
+// Round-5: when the highest predecessor version is carried by MORE THAN ONE distinct snapshotBatchId
+// (the substrate has no logical unique index and P4 is not landed — concurrent writers can produce
+// such history), the auto-pick would otherwise depend on database return order. That is refused loud
+// as 409 {target:'base', reason:'ambiguous'}; an EXPLICIT base keeps the existing rules (the caller
+// named one specific batch).
 function pickPredecessor(batchRows, currentSnapshotBatchId, currentVersion) {
   if (currentVersion === null) return null
-  let best = null
   let bestVersion = null
+  let bestIds = new Set()
   for (const row of batchRows) {
     const snapshotBatchId = optionalString(readCell(row, 'snapshotBatchId'))
     if (!snapshotBatchId || snapshotBatchId === currentSnapshotBatchId) continue
@@ -287,10 +292,14 @@ function pickPredecessor(batchRows, currentSnapshotBatchId, currentVersion) {
     if (version === null || version >= currentVersion) continue
     if (bestVersion === null || version > bestVersion) {
       bestVersion = version
-      best = snapshotBatchId
+      bestIds = new Set([snapshotBatchId])
+    } else if (version === bestVersion) {
+      bestIds.add(snapshotBatchId)
     }
   }
-  return best
+  if (bestIds.size === 0) return null
+  if (bestIds.size > 1) diffBatchAmbiguous('base')
+  return bestIds.values().next().value
 }
 
 // Resolve the diff BASE batch id. An EXPLICIT `requestedBase` is a caller-chosen pair and must be

--- a/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-snapshot-reads.cjs
@@ -192,6 +192,12 @@ async function queryAllRecords(target, filters) {
 // A batch is `incomplete` when the multi-step persist path (batch row -> lines -> run row) did not
 // finish: zero lines OR no matching run row. A batch row alone is NOT proof of completeness — an
 // orphaned batch (crash mid-commit) must not be presented as normal.
+// This single structural predicate backs BOTH the list's `incomplete` flag and the H-1 diff gate
+// (assertDiffBatchComplete below) — one definition of completeness, not two drifting copies.
+function isBatchIncomplete(lineCount, runPresent) {
+  return lineCount === 0 || runPresent !== true
+}
+
 function batchSummary(batchRecord, lineCount, runPresent) {
   return {
     snapshotBatchId: optionalString(readCell(batchRecord, 'snapshotBatchId')),
@@ -201,7 +207,7 @@ function batchSummary(batchRecord, lineCount, runPresent) {
     lineCount,
     // Presence of the createdAt stamp only — never the timestamp value itself (values-free).
     createdAtPresent: optionalString(readCell(batchRecord, 'createdAt')) !== null,
-    incomplete: lineCount === 0 || runPresent !== true,
+    incomplete: isBatchIncomplete(lineCount, runPresent),
   }
 }
 
@@ -319,6 +325,38 @@ async function resolveDiffBase(api, batchSheet, { currentSnapshotBatchId, projec
   return null
 }
 
+// H-1 (P4 design-lock #4452, round-1 owner ruling): SERVER-SIDE diff completeness gate. The FE only
+// DISABLES the diff entry for an incomplete batch (list `incomplete` flag); a deep link or a
+// list-vs-diff race can still reach the diff endpoints directly, where an incomplete CURRENT serves a
+// silently partial diff and a 0-line orphan BASE fabricates an all-'added' diff. So after base
+// resolution BOTH sides are verified against the SAME structural predicate the list uses
+// (isBatchIncomplete: at least one line AND the run row named by the batch row's syncRunId exists) and
+// any incomplete side fails LOUD: 409 SNAPSHOT_DIFF_BATCH_INCOMPLETE. This applies to the AUTO-picked
+// predecessor too — silently skipping past an incomplete predecessor to an older complete batch would
+// silently change the diff result; the lock chose loud-409 over silent-skip.
+// `batchRow` null (a base row that vanished between resolution and the gate) fails closed the same
+// way: no row -> no verifiable run link -> incomplete. An absent RUN sheet likewise leaves runPresent
+// false (exactly the list path's semantics).
+// The details shape is CLOSED and values-free: ONLY { target: 'current'|'base', reason: 'incomplete' }
+// — no counts, no ids; the message is a fixed values-free string.
+async function assertDiffBatchComplete({ lineSheet, runSheet, batchRow, snapshotBatchId, target }) {
+  const lineRows = lineSheet ? await queryAllRecords(lineSheet, { snapshotBatchId }) : []
+  const syncRunId = optionalString(readCell(batchRow, 'syncRunId'))
+  let runPresent = false
+  if (runSheet && syncRunId) {
+    const runRows = await queryAllRecords(runSheet, { runId: syncRunId })
+    runPresent = runRows.length > 0
+  }
+  if (isBatchIncomplete(lineRows.length, runPresent)) {
+    throw new StockPreparationTargetProvisioningError(
+      409,
+      'SNAPSHOT_DIFF_BATCH_INCOMPLETE',
+      'snapshot diff refuses an incomplete snapshot batch',
+      { target, reason: 'incomplete' },
+    )
+  }
+}
+
 /**
  * Values-free diff of a snapshot batch against its immutable predecessor batch.
  * The batch id arrives from the route PATH. `targetProjectId` (STAGING) locates the MVP tables; the
@@ -326,6 +364,8 @@ async function resolveDiffBase(api, batchSheet, { currentSnapshotBatchId, projec
  * FE diff call carries no projectId), falling back to `businessProjectId` when the batch row is absent.
  * An optional `baseSnapshotBatchId` overrides the predecessor auto-pick with a validated caller-chosen
  * pair; when absent the original predecessor semantics are preserved unchanged.
+ * H-1: both sides are completeness-gated after base resolution — an incomplete current or base
+ * (explicit OR auto-picked) fails loud with 409 SNAPSHOT_DIFF_BATCH_INCOMPLETE, never a partial diff.
  */
 async function getSnapshotDiff({ recordsApi, provisioning, targetProjectId, businessProjectId, snapshotBatchId, baseSnapshotBatchId: baseOverride, permission } = {}) {
   assertAdminPermission(permission)
@@ -373,6 +413,31 @@ async function getSnapshotDiff({ recordsApi, provisioning, targetProjectId, busi
     requestedBase,
     currentBatchRowPresent: Boolean(currentBatchRow),
   })
+
+  // H-1 completeness gate — AFTER base resolution (explicit-base validation errors keep precedence),
+  // BEFORE any diff is computed. Runs only when the current batch ROW exists: a ghost current keeps
+  // the #4002 graceful empty shape on the auto path (locked by the existing ghost test) and already
+  // 404s on the explicit-base path inside resolveDiffBase.
+  const runSheet = await findMvpSheet(api, prov, stagingProjectId, RUN_OBJECT_ID)
+  if (currentBatchRow) {
+    await assertDiffBatchComplete({
+      lineSheet,
+      runSheet,
+      batchRow: currentBatchRow,
+      snapshotBatchId: currentSnapshotBatchId,
+      target: 'current',
+    })
+  }
+  if (baseSnapshotBatchId) {
+    const baseRows = batchSheet ? await queryAllRecords(batchSheet, { snapshotBatchId: baseSnapshotBatchId }) : []
+    await assertDiffBatchComplete({
+      lineSheet,
+      runSheet,
+      batchRow: baseRows[0] || null,
+      snapshotBatchId: baseSnapshotBatchId,
+      target: 'base',
+    })
+  }
 
   // Lines for the current + predecessor batches (never mutated; passed straight to the diff engine).
   const currentLines = lineSheet
@@ -472,12 +537,11 @@ async function listSnapshotDiffRows({ recordsApi, provisioning, targetProjectId,
 
   let projectId = optionalString(businessProjectId)
   let currentVersion = null
-  let currentBatchRowPresent = false
+  let currentBatchRow = null
   if (batchSheet) {
     const currentRows = await queryAllRecords(batchSheet, { snapshotBatchId: currentSnapshotBatchId })
-    const currentBatchRow = currentRows[0] || null
+    currentBatchRow = currentRows[0] || null
     if (currentBatchRow) {
-      currentBatchRowPresent = true
       projectId = optionalString(readCell(currentBatchRow, 'projectId')) || projectId
       currentVersion = toNumber(readCell(currentBatchRow, 'snapshotVersion'))
     }
@@ -488,8 +552,31 @@ async function listSnapshotDiffRows({ recordsApi, provisioning, targetProjectId,
     projectId,
     currentVersion,
     requestedBase,
-    currentBatchRowPresent,
+    currentBatchRowPresent: Boolean(currentBatchRow),
   })
+
+  // H-1 completeness gate — identical to getSnapshotDiff's (same order, same 409, same closed
+  // values-free details): the per-row browse must not answer for an incomplete side either.
+  const runSheet = await findMvpSheet(api, prov, stagingProjectId, RUN_OBJECT_ID)
+  if (currentBatchRow) {
+    await assertDiffBatchComplete({
+      lineSheet,
+      runSheet,
+      batchRow: currentBatchRow,
+      snapshotBatchId: currentSnapshotBatchId,
+      target: 'current',
+    })
+  }
+  if (baseSnapshotBatchId) {
+    const baseRows = batchSheet ? await queryAllRecords(batchSheet, { snapshotBatchId: baseSnapshotBatchId }) : []
+    await assertDiffBatchComplete({
+      lineSheet,
+      runSheet,
+      batchRow: baseRows[0] || null,
+      snapshotBatchId: baseSnapshotBatchId,
+      target: 'base',
+    })
+  }
 
   const currentLines = lineSheet
     ? (await queryAllRecords(lineSheet, { snapshotBatchId: currentSnapshotBatchId })).map(recordData)
@@ -545,6 +632,8 @@ module.exports = {
     toNumber,
     queryAllRecords,
     batchSummary,
+    isBatchIncomplete,
+    assertDiffBatchComplete,
     orderBatches,
     changeCountsFromEvidence,
     pickPredecessor,


### PR DESCRIPTION
## What (P4 lock #4452 round-1: mandatory-first silent-correctness gap)

The snapshot diff endpoints relied on the FE's disabled button alone — a deep link or list-vs-diff race could still diff an orphaned/mid-crash batch: an incomplete **current** serves a silently partial diff; a 0-line orphan **base** fabricates an all-'added' diff. This lands the server-side gate:

- The batch-list completeness predicate is extracted into a single `isBatchIncomplete` (lineCount > 0 AND run row present for the batch's `syncRunId`) — one definition, reused by list flag and gate.
- Both `diff` and `diff/rows`: after base resolution (explicit-base 400/404/409 validations keep precedence), incomplete current or base → **409 `SNAPSHOT_DIFF_BATCH_INCOMPLETE`**, closed values-free details `{target:'current'|'base', reason:'incomplete'}`.
- An incomplete **auto-picked** predecessor 409s too — loud-409 per the lock, never a silent skip to an older base (which would silently change diff results).
- Ghost current (no batch row) keeps the locked #4002 graceful shape / explicit-base 404 path; empty-substrate early return unchanged.

## Evidence

- Tests 12 → **23** across five review rounds (H-1 gate ×7; R2 ghost-with-orphan-lines; R3 duplicate-identity ambiguity for current/base/run across both endpoints; R4 reversed-twin order-independence). Full plugin chain green.
- Mutations (commit-first): M1 remove current gate → exactly the current-side tests red (15/19); M2 remove base gate → exactly the base-side tests red (16/19); both restored + clean rerun 19/19.
- FE verified read-only: non-2xx routes through the view's neutral error state with retry (`parseIntegrationResponse` throws; view catches) — no FE change needed.
- Three pre-existing fixtures gained run rows (their subjects were orthogonal; assertions unchanged).

**Not armed — owner review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Rounds 2-4 (adversarial + owner reviews — all applied)

- **R2**: ghost current (no batch row) with orphan LINE rows now 409s instead of serving a fabricated all-'added' diff; genuinely empty ghost ids keep the locked #4002 graceful shape (`b2a129c5e`).
- **R3 (owner P2)**: duplicate business identities could answer from an arbitrary `rows[0]` twin — current/base batch rows and the run row now require **exactly one**; violations 409 `SNAPSHOT_DIFF_BATCH_INCOMPLETE` `{target, reason:'ambiguous'}` (closed reason vocab {incomplete, ambiguous}) (`0c7d178c4`).
- **R4 (owner P2)**: the explicit-base ambiguity verdict depended on database return order (`resolveDiffBase` read `[0]` + project-mismatch before counting) — the length check now precedes any first-row read; reversed-twin tests on both endpoints; mutation restoring the old order goes RED (`a2bebf3dc`).

- **R5 (owner P2)**: `pickPredecessor` updated best only on strictly-greater version — two distinct complete predecessors at the same highest prior version made the auto base **depend on database return order** (owner probe `{ab:'base_a', ba:'base_b'}`). Ties across distinct snapshotBatchIds now refuse loud: 409 `{target:'base', reason:'ambiguous'}`; explicit base keeps existing rules (positive control locked). Forward+reversed × both endpoints; tie-check mutation RED (`f747c7693`).

**Round-6 owner verdict: GO.** Current head `ee4d3f8f7` = `f747c7693` rebased onto `dfc9318fc` (content-identical; pre-rebase commit ids appear in earlier round notes).

