### PR TITLE
fix(stock-prep): OD2 round-1 — fail-closed category_rule version policy (server 422 + match-time guard + FE removal)

### DIFF
--- a/apps/web/src/services/integration/stockPreparation/materialMapping.ts
+++ b/apps/web/src/services/integration/stockPreparation/materialMapping.ts
@@ -29,16 +29,21 @@ export type StockPreparationMatchStatus =
   | 'not_found'
   | 'version_conflict'
 
+// OD2 round-1 hardening: `category_rule` was REMOVED from this union and the whitelist below — it
+// remains a reserved enum name server-side (stock-preparation-mvp-generation.cjs VERSION_POLICIES)
+// with NO implementation branch, and the server now refuses it fail-closed (422
+// STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED). Legacy stored rows carrying it never auto-match
+// (they degrade to the visible missing_mapping path); on the read side such a stored value can
+// still cross the wire as a plain string (versionPolicyCounts keys / candidate row versionPolicy).
 export type StockPreparationVersionPolicy =
   | 'drawing_and_version'
   | 'drawing_only'
-  | 'category_rule'
   | 'manual'
 
 // Fixed FE whitelists mirroring the server's frozen vocabularies (stock-preparation-material-match /
 // -mvp-generation .cjs). The candidates read zero-fills byMatchStatus over exactly the five statuses
 // (+ an optional `unknown` fold), and the sync route validates defaultVersionPolicy against exactly
-// these four policies (OD2: required per request, no server default).
+// these three IMPLEMENTED policies (OD2: required per request, no server default).
 export const STOCK_PREPARATION_MATCH_STATUSES: readonly StockPreparationMatchStatus[] = [
   'matched',
   'pending_confirm',
@@ -50,7 +55,6 @@ export const STOCK_PREPARATION_MATCH_STATUSES: readonly StockPreparationMatchSta
 export const STOCK_PREPARATION_VERSION_POLICIES: readonly StockPreparationVersionPolicy[] = [
   'drawing_and_version',
   'drawing_only',
-  'category_rule',
   'manual',
 ]
 

--- a/apps/web/src/services/integration/stockPreparation/materialMapping.ts
+++ b/apps/web/src/services/integration/stockPreparation/materialMapping.ts
@@ -102,7 +102,8 @@ export interface StockPreparationMaterialMappingCandidateRow {
   matchStatus: StockPreparationMatchStatus | 'unknown'
   /** Absent when the stored row carries no method; junk stored values fold to `unknown`. */
   matchMethod?: StockPreparationMatchMethod | 'unknown'
-  versionPolicy: StockPreparationVersionPolicy | 'unknown'
+  // READ vocabulary ≠ write whitelist: confirm-reads still projects a legacy stored 'category_rule' verbatim.
+  versionPolicy: StockPreparationVersionPolicy | 'category_rule' | 'unknown'
   confidence: number | null
   isActive: boolean
   confirmed: boolean

--- a/apps/web/tests/StockPreparationMappingConfirmView.spec.ts
+++ b/apps/web/tests/StockPreparationMappingConfirmView.spec.ts
@@ -33,6 +33,7 @@ vi.mock('../src/utils/api', async () => {
 })
 
 import StockPreparationMappingConfirmView from '../src/components/integration/stockPreparation/StockPreparationMappingConfirmView.vue'
+import { STOCK_PREPARATION_VERSION_POLICIES } from '../src/services/integration/stockPreparation/materialMapping'
 
 // Planted business values — the view must render NONE of them (fixed-whitelist rendering).
 const PLANTED_DRAWING_NO = 'DWG-88472-A'
@@ -378,6 +379,22 @@ describe('StockPreparationMappingConfirmView (view 3: confirm reads + human conf
     expect(note.textContent).toContain('created')
     expect(note.textContent).toContain('3')
     await waitForCondition(() => urlsMatching('/material-mappings/summary').length === 2)
+  })
+
+  it('offers ONLY the three implemented version policies (OD2 round-1: category_rule removed fail-closed)', async () => {
+    // Whitelist pin: the reserved-but-unimplemented category_rule is no longer selectable anywhere —
+    // the server refuses it 422 STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED, so the FE must not
+    // offer it (both the sync policy select and the create-form policy select feed this list).
+    expect(STOCK_PREPARATION_VERSION_POLICIES).toEqual(['drawing_and_version', 'drawing_only', 'manual'])
+    mockRoutes()
+    const root = mountView()
+    await waitForSelector(root, '[data-testid="stock-prep-mapping-overview"]')
+    for (const testid of ['stock-prep-mapping-sync-policy', 'stock-prep-mapping-form-policy']) {
+      const select = root.querySelector(`[data-testid="${testid}"]`) as HTMLSelectElement
+      const values = [...select.querySelectorAll('option')].map((option) => option.value)
+      expect(values.filter((value) => value !== '')).toEqual(['drawing_and_version', 'drawing_only', 'manual'])
+      expect(values).not.toContain('category_rule')
+    }
   })
 
   it('mirrors the server create-mode rules client-side ({field} errors, NO premature POST)', async () => {

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -8368,6 +8368,7 @@ async function main() {
   await testSampleLimitCap()
   await testListOffsetCap()
   await testStockPreparationWritesRefuseWithoutAuditStore()
+  await testStockPreparationMappingWritesRejectUnimplementedVersionPolicy()
   await testStockPreparationTenantScopedWriteSteeringHasNoEffect()
   await testStockPreparationStructureWriteSteeringHasNoEffect()
   await testStockPreparationWriteRejectsExplicitBaseId()
@@ -8417,6 +8418,61 @@ async function testStockPreparationWritesRefuseWithoutAuditStore() {
   const { routes: routesWithStore } = mountRoutes(services)
   const res2 = await invoke(routesWithStore, 'POST', '/api/integration/stock-preparation/material-mappings/retire', { user: admin, body: { projectId: 'proj_1', mappingId: 'm1' } })
   assert.notEqual(res2.body && res2.body.error && res2.body.error.code, 'AUDIT_STORE_UNAVAILABLE', 'with the store present the gate opens')
+}
+
+// OD2 round-1 hardening: the mapping candidate-sync and confirm routes surface the module's
+// fail-closed version-policy gate — an UNIMPLEMENTED value (the reserved category_rule and junk
+// alike; the guard is allowlist-shaped) => 422 STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED with
+// ONLY the field NAME in details (values-free). Positive control: the SAME sync call with an
+// implemented policy proceeds PAST the policy gate and fails on a different dependency (the empty
+// batch fixture), proving the 422 comes from the policy gate specifically.
+async function testStockPreparationMappingWritesRejectUnimplementedVersionPolicy() {
+  const admin = { id: 'admin_1', tenantId: 'tenant_1', permissions: ['integration:admin'] }
+  const setup = () => {
+    const { services } = createMockServices()
+    services.stockPreparationAuditStore = { async append() {}, async list() { return { rowCount: 0, entries: [] } } }
+    const provisioning = createStockPreparationTargetProvisioningApi({ sheetExists: true })
+    const records = createTableActionRecordsApi()
+    const { routes } = mountRoutes(services, { provisioningApi: provisioning.api, recordsApi: records.recordsApi })
+    return { routes, records }
+  }
+  for (const unimplementedPolicy of ['category_rule', 'totally_bogus']) {
+    // Candidate-sync: body defaultVersionPolicy (OD2: required per request, no server default).
+    const sync = setup()
+    const syncRes = await invoke(sync.routes, 'POST', '/api/integration/stock-preparation/material-mappings/candidates/sync', {
+      user: admin,
+      body: { projectId: 'proj_1', defaultVersionPolicy: unimplementedPolicy },
+    })
+    assert.equal(syncRes.statusCode, 422, `candidate-sync refuses the unimplemented policy`)
+    assert.equal(syncRes.body.error.code, 'STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED')
+    assert.deepEqual({ ...syncRes.body.error.details }, { field: 'defaultVersionPolicy' }, 'details carry ONLY the field name')
+    assert.equal(String(syncRes.body.error.message).includes(unimplementedPolicy), false, 'message is values-free')
+    assert.equal(sync.records.calls.filter(([name]) => name === 'createRecord').length, 0, 'refusal happens before any write')
+
+    // Confirm create-mode: mapping.versionPolicy.
+    const confirm = setup()
+    const confirmRes = await invoke(confirm.routes, 'POST', '/api/integration/stock-preparation/material-mappings/confirm', {
+      user: admin,
+      body: { projectId: 'proj_1', mapping: { plmDrawingNo: 'D', erpMaterialCode: 'C', erpMaterialInternalId: 'I', versionPolicy: unimplementedPolicy } },
+    })
+    assert.equal(confirmRes.statusCode, 422, `confirm create-mode refuses the unimplemented policy`)
+    assert.equal(confirmRes.body.error.code, 'STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED')
+    assert.deepEqual({ ...confirmRes.body.error.details }, { field: 'versionPolicy' }, 'details carry ONLY the field name')
+    assert.equal(String(confirmRes.body.error.message).includes(unimplementedPolicy), false, 'message is values-free')
+    assert.equal(confirm.records.calls.filter(([name]) => name === 'createRecord').length, 0, 'refusal happens before any write')
+  }
+  // Positive control: an implemented policy passes the policy gate (it then fails on the EMPTY
+  // batch fixture — a DIFFERENT, non-policy error — never on the policy gate).
+  const control = setup()
+  const controlRes = await invoke(control.routes, 'POST', '/api/integration/stock-preparation/material-mappings/candidates/sync', {
+    user: admin,
+    body: { projectId: 'proj_1', defaultVersionPolicy: 'drawing_only' },
+  })
+  assert.notEqual(
+    controlRes.body.error && controlRes.body.error.code,
+    'STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED',
+    'implemented policy passes the policy gate',
+  )
 }
 
 // GHSA (private) step 1: a tenant-scoped WRITE route must derive its write target from the AUTHENTICATED

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-confirm-writes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-confirm-writes.test.cjs
@@ -8,7 +8,8 @@
 //        human_preserved trio (confirmedBy / confirmedAt / notes) is STRUCTURALLY absent;
 //   (c)  R5 create-only idempotency — replay creates nothing, patches nothing;
 //   (d)  R5 never creates a CONFIRMED row (drift guard via an id-less confirmed mapping fixture);
-//   (e)  R5 OD2 — defaultVersionPolicy absent / non-vocabulary => 400; both policies round-trip;
+//   (e)  R5 OD2 — defaultVersionPolicy absent => 400; UNIMPLEMENTED (reserved category_rule / junk,
+//        allowlist-shaped) => 422 UNSUPPORTED with the field NAME only; implemented policies round-trip;
 //   (f)  R5 batch gates — unknown / other-project => 404; run-less or line-less => 409 INCOMPLETE;
 //        latest-complete auto-pick SKIPS an orphaned newer batch;
 //   (g)  staging/business split — business projectId as locator => 409 NOT_PROVISIONED, zero writes;
@@ -341,7 +342,7 @@ async function main() {
   })
 
   // ---- (e) OD2 ----
-  await run('R5 rejects an absent or non-vocabulary defaultVersionPolicy and accepts both shipped policies', async () => {
+  await run('R5 rejects absent (400) and UNIMPLEMENTED (422, field name only) defaultVersionPolicy; implemented policies pass', async () => {
     const api = makeRecordsApi()
     const provisioning = makeProvisioning()
     seedCompleteBatch(api)
@@ -350,19 +351,28 @@ async function main() {
       syncMaterialMappingCandidates(baseSyncInput(api, provisioning, { defaultVersionPolicy: undefined })),
       { status: 400, code: 'CONFIRM_VERSION_POLICY_INVALID' },
     )
-    await expectError(
-      syncMaterialMappingCandidates(baseSyncInput(api, provisioning, { defaultVersionPolicy: 'bogus_policy' })),
-      { status: 400, code: 'CONFIRM_VERSION_POLICY_INVALID' },
-    )
+    // OD2 round-1 hardening: the reserved-but-unimplemented category_rule and a junk value are
+    // refused IDENTICALLY (allowlist-shaped guard), 422 with ONLY the field name in details.
+    for (const unimplementedPolicy of ['category_rule', 'totally_bogus']) {
+      const unsupported = await expectError(
+        syncMaterialMappingCandidates(baseSyncInput(api, provisioning, { defaultVersionPolicy: unimplementedPolicy })),
+        { status: 422, code: 'STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED' },
+      )
+      assert.deepEqual(unsupported.details, { field: 'defaultVersionPolicy' }, 'details carry ONLY the field name')
+      assert.equal(unsupported.message.includes(unimplementedPolicy), false, 'error message is values-free')
+    }
+    assert.equal(api.createCalls.length, 0, 'rejected policies never reach a write')
     const withVersion = await syncMaterialMappingCandidates(baseSyncInput(api, provisioning, { defaultVersionPolicy: 'drawing_and_version' }))
     assert.ok(api.createCalls.filter((call) => call.sheetId === SHEET.mapping).every((call) => call.data.versionPolicy === 'drawing_and_version'))
     assert.equal(withVersion.persisted, true)
-    // drawing_only run on a fresh store round-trips the policy too.
-    const api2 = makeRecordsApi()
-    seedCompleteBatch(api2)
-    seedMaterials(api2)
-    await syncMaterialMappingCandidates(baseSyncInput(api2, makeProvisioning(), { defaultVersionPolicy: 'drawing_only' }))
-    assert.ok(api2.createCalls.filter((call) => call.sheetId === SHEET.mapping).every((call) => call.data.versionPolicy === 'drawing_only'))
+    // The other two implemented policies round-trip on fresh stores too.
+    for (const implementedPolicy of ['drawing_only', 'manual']) {
+      const apiN = makeRecordsApi()
+      seedCompleteBatch(apiN)
+      seedMaterials(apiN)
+      await syncMaterialMappingCandidates(baseSyncInput(apiN, makeProvisioning(), { defaultVersionPolicy: implementedPolicy }))
+      assert.ok(apiN.createCalls.filter((call) => call.sheetId === SHEET.mapping).every((call) => call.data.versionPolicy === implementedPolicy))
+    }
   })
 
   // ---- (f) batch gates ----
@@ -486,7 +496,18 @@ async function main() {
     await expectError(create(api, { erpMaterialCode: 'C', erpMaterialInternalId: 'I', versionPolicy: 'drawing_only' }), { status: 400, code: 'CONFIRM_MAPPING_FIELDS_INVALID' })
     await expectError(create(api, { plmDrawingNo: 'D', erpMaterialInternalId: 'I', versionPolicy: 'drawing_only' }), { status: 400, code: 'CONFIRM_MAPPING_FIELDS_INVALID' })
     await expectError(create(api, { plmDrawingNo: 'D', erpMaterialCode: 'C', versionPolicy: 'drawing_only' }), { status: 400, code: 'CONFIRM_MAPPING_FIELDS_INVALID' })
-    await expectError(create(api, { plmDrawingNo: 'D', erpMaterialCode: 'C', erpMaterialInternalId: 'I', versionPolicy: 'bogus' }), { status: 400, code: 'CONFIRM_MAPPING_FIELDS_INVALID' })
+    // Absent versionPolicy stays a 400 required-field error.
+    await expectError(create(api, { plmDrawingNo: 'D', erpMaterialCode: 'C', erpMaterialInternalId: 'I' }), { status: 400, code: 'CONFIRM_MAPPING_FIELDS_INVALID' })
+    // OD2 round-1 hardening: UNIMPLEMENTED policies (reserved category_rule / junk alike —
+    // allowlist-shaped) => 422 UNSUPPORTED with ONLY the field name in details.
+    for (const unimplementedPolicy of ['category_rule', 'totally_bogus']) {
+      const unsupported = await expectError(
+        create(api, { plmDrawingNo: 'D', erpMaterialCode: 'C', erpMaterialInternalId: 'I', versionPolicy: unimplementedPolicy }),
+        { status: 422, code: 'STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED' },
+      )
+      assert.deepEqual(unsupported.details, { field: 'versionPolicy' }, 'details carry ONLY the field name')
+      assert.equal(unsupported.message.includes(unimplementedPolicy), false, 'error message is values-free')
+    }
     await expectError(create(api, { plmDrawingNo: 'D', erpMaterialCode: 'C', erpMaterialInternalId: 'I', versionPolicy: 'drawing_and_version' }), { status: 400, code: 'CONFIRM_MAPPING_FIELDS_INVALID' })
     assert.equal(api.createCalls.length, 0)
   })

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-confirm-writes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-confirm-writes.test.cjs
@@ -14,7 +14,7 @@
 //        latest-complete auto-pick SKIPS an orphaned newer batch;
 //   (g)  staging/business split — business projectId as locator => 409 NOT_PROVISIONED, zero writes;
 //   (h)  R6 XOR + confirm-existing patch shape (EXACT key set) + notes variant + target-incomplete 409
-//        + inactive 409 + already-confirmed skip + key-ambiguity 500;
+//        + inactive 409 + already-confirmed skip + key-ambiguity 500 + stored unimplemented policy 422;
 //   (i)  R6 create-confirmed — closed allowlist, both-ERP-ids required, policy vocabulary, version
 //        required under drawing_and_version, replay skips;
 //   (j)  R7 / R11 retire — patch EXACTLY { isActive: false }, replay skips, retire-then-recreate with
@@ -487,6 +487,30 @@ async function main() {
   })
 
   // ---- (i) R6 create-confirmed ----
+  await run('R6 confirm-existing refuses a stored candidate carrying an unimplemented versionPolicy (422, zero writes)', async () => {
+    // OD2 round-2: stamping a legacy category_rule (or junk-policy) candidate matched would plant a
+    // confirmed row the engines can never select — the 'dead confirmed row' class this function
+    // refuses elsewhere. Recovery path is retire + re-create with an implemented policy.
+    const provisioning = makeProvisioning()
+    for (const unimplementedPolicy of ['category_rule', 'totally_bogus']) {
+      const api = makeRecordsApi()
+      api.seed(SHEET.mapping, { mappingId: 'map_unimpl', plmDrawingNo: 'D', erpMaterialCode: 'C', erpMaterialInternalId: 'I', versionPolicy: unimplementedPolicy, matchStatus: 'pending_confirm', isActive: true })
+      const caught = await expectError(
+        confirmMaterialMapping({ permission: 'admin', recordsApi: api, provisioning, targetProjectId: STAGING_PROJECT_ID, mappingId: 'map_unimpl', confirmedBy: OPERATOR }),
+        { status: 422, code: 'STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED' },
+      )
+      assert.deepEqual(caught.details, { field: 'versionPolicy' }, 'details carry ONLY the field name')
+      assert.equal(caught.message.includes(unimplementedPolicy), false, 'error message is values-free')
+      assert.equal(api.patchCalls.length + api.createCalls.length, 0, 'refusal happens before any write')
+    }
+    // A policy-less stored candidate stays confirmable (absence folds to manual at match time).
+    const api = makeRecordsApi()
+    api.seed(SHEET.mapping, { mappingId: 'map_nopolicy', plmDrawingNo: 'D', erpMaterialCode: 'C', erpMaterialInternalId: 'I', matchStatus: 'pending_confirm', isActive: true })
+    const confirmed = await confirmMaterialMapping({ permission: 'admin', recordsApi: api, provisioning, targetProjectId: STAGING_PROJECT_ID, mappingId: 'map_nopolicy', confirmedBy: OPERATOR })
+    assert.equal(confirmed.mode, 'confirmed')
+    assert.equal(api.patchCalls.length, 1)
+  })
+
   await run('R6 create-confirmed validates the closed allowlist and required fields', async () => {
     const provisioning = makeProvisioning()
     const create = (api, mapping) => confirmMaterialMapping({ permission: 'admin', recordsApi: api, provisioning, targetProjectId: STAGING_PROJECT_ID, mapping, confirmedBy: OPERATOR })

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-material-match.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-material-match.test.cjs
@@ -153,6 +153,14 @@ function main() {
       confirmedMappings: [{ ...storedRow, plmVersion: 'B' }],
     })
     assert.equal(mismatch.mappingRows[0].matchStatus, MATCH_STATUSES.NOT_FOUND, `${unimplementedPolicy} version mismatch is not reported as version_conflict`)
+    // Round 2 (guard ordering): a stored matchStatus='version_conflict' must not FORCE the
+    // version_conflict path either — the policy guard runs BEFORE the stored-status short-circuit,
+    // so the row never participates and the line degrades to the visible missing path.
+    const storedConflict = result({
+      erpMaterials: [],
+      confirmedMappings: [{ ...storedRow, matchStatus: MATCH_STATUSES.VERSION_CONFLICT }],
+    })
+    assert.equal(storedConflict.mappingRows[0].matchStatus, MATCH_STATUSES.NOT_FOUND, `${unimplementedPolicy} stored version_conflict status degrades to the missing path`)
   }
 
   // OD2 input boundary (engine backstop; the confirm-writes validator rejects first with 422): a

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-material-match.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-material-match.test.cjs
@@ -126,6 +126,54 @@ function main() {
   })
   assert.equal(duplicateLines.mappingRows.length, 1, 'same drawing/version is matched once')
 
+  // OD2 round-1 fail-closed (#4391 doctrine: stored approved rows are not trusted): a stored
+  // confirmed row carrying an UNIMPLEMENTED versionPolicy — the reserved category_rule and junk
+  // alike, the guard is allowlist-shaped — NEVER auto-matches. The OLD tail heuristic matched it
+  // on drawing alone whenever a version was absent; now the line degrades to the visible
+  // not_found/missing path, and a version mismatch is NOT reported as version_conflict either.
+  for (const unimplementedPolicy of ['category_rule', 'totally_bogus']) {
+    const storedRow = {
+      mappingId: 'confirmed_mapping_unimplemented',
+      plmDrawingNo: 'DRAW-001',
+      erpMaterialCode: 'ERP-CODE-HIST',
+      erpMaterialInternalId: 'ERP-INTERNAL-HIST',
+      versionPolicy: unimplementedPolicy,
+      matchStatus: MATCH_STATUSES.MATCHED,
+      isActive: true,
+    }
+    const failClosed = result({
+      plmBomLines: [line({ childVersion: undefined })],
+      erpMaterials: [],
+      confirmedMappings: [storedRow],
+    })
+    assert.equal(failClosed.mappingRows[0].matchStatus, MATCH_STATUSES.NOT_FOUND, `${unimplementedPolicy} never auto-matches even with versions absent`)
+    assert.notEqual(failClosed.mappingRows[0].mappingId, 'confirmed_mapping_unimplemented', `${unimplementedPolicy} stored row is never re-emitted as matched`)
+    const mismatch = result({
+      erpMaterials: [],
+      confirmedMappings: [{ ...storedRow, plmVersion: 'B' }],
+    })
+    assert.equal(mismatch.mappingRows[0].matchStatus, MATCH_STATUSES.NOT_FOUND, `${unimplementedPolicy} version mismatch is not reported as version_conflict`)
+  }
+
+  // OD2 input boundary (engine backstop; the confirm-writes validator rejects first with 422): a
+  // SUPPLIED defaultVersionPolicy outside the implemented set throws with the field NAME only.
+  for (const unimplementedPolicy of ['category_rule', 'totally_bogus']) {
+    assert.throws(
+      () => generateMaterialMappingCandidates({ plmBomLines: [line()], erpMaterials: [material()], defaultVersionPolicy: unimplementedPolicy }),
+      (error) => {
+        assert.ok(error instanceof StockPreparationMaterialMatchError)
+        assert.deepEqual(error.details, { field: 'defaultVersionPolicy' }, 'details carry ONLY the field name')
+        assert.equal(error.message.includes(unimplementedPolicy), false, 'error message is values-free')
+        return true
+      },
+      `unimplemented defaultVersionPolicy ${unimplementedPolicy} is refused`,
+    )
+  }
+  for (const implementedPolicy of Object.values(VERSION_POLICIES)) {
+    const accepted = result({ defaultVersionPolicy: implementedPolicy })
+    assert.equal(accepted.mappingRows[0].versionPolicy, implementedPolicy, `implemented policy ${implementedPolicy} still passes`)
+  }
+
   const evidenceText = JSON.stringify(exact.evidence)
   for (const rawValue of ['DRAW-001', 'ERP-INTERNAL-001', 'name_alpha', 'spec_alpha']) {
     assert.equal(evidenceText.includes(rawValue), false, `evidence omits row value ${rawValue}`)

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-mvp-generation.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-mvp-generation.test.cjs
@@ -180,6 +180,18 @@ function main() {
         },
       ],
     }), EXCEPTION_TYPES.MISSING_MAPPING)
+    // Round 2 (guard ordering): a stored matchStatus='version_conflict' must not FORCE the
+    // version_conflict exception either — the policy guard runs BEFORE the stored-status
+    // short-circuit, so the row never participates and the line degrades to missing_mapping.
+    assertSingleException(generate({
+      materialMappings: [
+        {
+          ...clone(baseInput().materialMappings[0]),
+          versionPolicy: unimplementedPolicy,
+          matchStatus: MATERIAL_MATCH_STATUSES.VERSION_CONFLICT,
+        },
+      ],
+    }), EXCEPTION_TYPES.MISSING_MAPPING)
   }
 
   assertSingleException(generate({ erpMaterials: [] }), EXCEPTION_TYPES.MISSING_MATERIAL_MASTER)

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-mvp-generation.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-mvp-generation.test.cjs
@@ -155,6 +155,33 @@ function main() {
     ],
   }), EXCEPTION_TYPES.VERSION_CONFLICT)
 
+  // OD2 round-1 fail-closed (#4391 doctrine: stored approved rows are not trusted): a stored
+  // mapping row carrying an UNIMPLEMENTED versionPolicy — the reserved CATEGORY_RULE and junk
+  // alike, the guard is allowlist-shaped — NEVER auto-matches. The OLD tail heuristic matched it
+  // on drawing alone whenever a version was absent (silently generating a draft line); now the
+  // line degrades to the visible missing_mapping (HELD) exception, and a version mismatch under
+  // such a policy is missing_mapping too — never version_conflict.
+  for (const unimplementedPolicy of [VERSION_POLICIES.CATEGORY_RULE, 'totally_bogus']) {
+    assertSingleException(generate({
+      materialMappings: [
+        {
+          ...clone(baseInput().materialMappings[0]),
+          plmVersion: undefined,
+          versionPolicy: unimplementedPolicy,
+        },
+      ],
+    }), EXCEPTION_TYPES.MISSING_MAPPING)
+    assertSingleException(generate({
+      materialMappings: [
+        {
+          ...clone(baseInput().materialMappings[0]),
+          plmVersion: 'B',
+          versionPolicy: unimplementedPolicy,
+        },
+      ],
+    }), EXCEPTION_TYPES.MISSING_MAPPING)
+  }
+
   assertSingleException(generate({ erpMaterials: [] }), EXCEPTION_TYPES.MISSING_MATERIAL_MASTER)
 
   assertSingleException(generate({ unitConversionRules: [] }), EXCEPTION_TYPES.UNIT_MISSING)

--- a/plugins/plugin-integration-core/lib/stock-preparation-confirm-writes.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-confirm-writes.cjs
@@ -40,7 +40,7 @@ const {
   __internals: { mappingIdFor },
 } = require('./stock-preparation-material-match.cjs')
 const { generateUnitConversionRuleCandidates, RULE_OUTCOMES } = require('./stock-preparation-unit-rule-match.cjs')
-const { VERSION_POLICIES } = require('./stock-preparation-mvp-generation.cjs')
+const { VERSION_POLICIES, IMPLEMENTED_VERSION_POLICIES } = require('./stock-preparation-mvp-generation.cjs')
 const { optionalString, isPlainObject } = require('./stock-preparation-common.cjs')
 
 const REQUIRED_PERMISSION = 'admin'
@@ -51,7 +51,11 @@ const READ_MAX_PAGES = 50
 
 // Closed vocabularies THIS module validates before any write. The select option-sets on the frozen
 // templates are admin-supplied at option-sync time, so the fail-closed contract lives here.
-const VERSION_POLICY_SET = new Set(Object.values(VERSION_POLICIES))
+// OD2 round-1 hardening: version policies are validated against the IMPLEMENTED set, not the full
+// vocabulary — category_rule stays a reserved enum name with NO matcher branch, so accepting it
+// would plant rows that silently degrade to the tail heuristic. Any value outside the implemented
+// set (reserved OR junk — the guard is allowlist-shaped) is refused 422 with the field NAME only.
+const IMPLEMENTED_VERSION_POLICY_SET = IMPLEMENTED_VERSION_POLICIES
 const ROUNDING_RULES = Object.freeze(['none', 'ceil', 'floor', 'nearest', 'pack_size'])
 const ROUNDING_RULE_SET = new Set(ROUNDING_RULES)
 const SCOPE_TYPES = Object.freeze(['material', 'category', 'generic'])
@@ -328,9 +332,14 @@ async function syncMaterialMappingCandidates(input = {}) {
   const projectId = requiredString(input.projectId, 'projectId')
   const snapshotBatchId = optionalString(input.snapshotBatchId)
   const defaultVersionPolicy = optionalString(input.defaultVersionPolicy)
-  // OD2: there is NO server default — absence (or a non-vocabulary value) is an error, per request.
-  if (!defaultVersionPolicy || !VERSION_POLICY_SET.has(defaultVersionPolicy)) {
-    throw new StockPreparationConfirmWriteError(400, 'CONFIRM_VERSION_POLICY_INVALID', 'defaultVersionPolicy must be one of the version-policy vocabulary', { field: 'defaultVersionPolicy' })
+  // OD2: there is NO server default — absence is an error, per request.
+  if (!defaultVersionPolicy) {
+    throw new StockPreparationConfirmWriteError(400, 'CONFIRM_VERSION_POLICY_INVALID', 'defaultVersionPolicy is required', { field: 'defaultVersionPolicy' })
+  }
+  // OD2 round-1 hardening: only IMPLEMENTED policies are accepted (allowlist-shaped — reserved
+  // vocabulary values without a matcher branch and junk values are refused identically).
+  if (!IMPLEMENTED_VERSION_POLICY_SET.has(defaultVersionPolicy)) {
+    throw new StockPreparationConfirmWriteError(422, 'STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED', 'defaultVersionPolicy is not an implemented version policy', { field: 'defaultVersionPolicy' })
   }
 
   const batchContext = await resolveCompleteBatchLines(api, prov, targetProjectId, projectId, snapshotBatchId)
@@ -458,8 +467,13 @@ async function confirmMaterialMapping(input = {}) {
   if (!erpMaterialInternalId) {
     throw new StockPreparationConfirmWriteError(400, 'CONFIRM_MAPPING_FIELDS_INVALID', 'erpMaterialInternalId is required', { field: 'erpMaterialInternalId' })
   }
-  if (!versionPolicy || !VERSION_POLICY_SET.has(versionPolicy)) {
-    throw new StockPreparationConfirmWriteError(400, 'CONFIRM_MAPPING_FIELDS_INVALID', 'versionPolicy must be one of the version-policy vocabulary', { field: 'versionPolicy' })
+  if (!versionPolicy) {
+    throw new StockPreparationConfirmWriteError(400, 'CONFIRM_MAPPING_FIELDS_INVALID', 'versionPolicy is required', { field: 'versionPolicy' })
+  }
+  // OD2 round-1 hardening: only IMPLEMENTED policies are accepted (allowlist-shaped — reserved
+  // vocabulary values without a matcher branch and junk values are refused identically).
+  if (!IMPLEMENTED_VERSION_POLICY_SET.has(versionPolicy)) {
+    throw new StockPreparationConfirmWriteError(422, 'STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED', 'versionPolicy is not an implemented version policy', { field: 'versionPolicy' })
   }
   // Under drawing_and_version a version-less row could NEVER match a line (the matcher requires a
   // version on both sides) — reject rather than create a dead confirmed row.

--- a/plugins/plugin-integration-core/lib/stock-preparation-confirm-writes.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-confirm-writes.cjs
@@ -426,6 +426,14 @@ async function confirmMaterialMapping(input = {}) {
     if (data.isActive === false) {
       throw new StockPreparationConfirmWriteError(409, 'CONFIRM_MAPPING_INACTIVE', 'material mapping is retired; re-create it to confirm', { mappingId })
     }
+    // OD2 round-2 hardening: a STORED candidate carrying an unimplemented versionPolicy (the
+    // reserved category_rule or junk — absence folds to manual and stays confirmable) must not be
+    // stamped matched: the match engines will never select it, so confirming it would plant exactly
+    // the 'dead confirmed row' class this function refuses elsewhere. Retire/re-create instead.
+    const storedVersionPolicy = optionalString(data.versionPolicy)
+    if (storedVersionPolicy && !IMPLEMENTED_VERSION_POLICY_SET.has(storedVersionPolicy)) {
+      throw new StockPreparationConfirmWriteError(422, 'STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED', 'material mapping carries an unimplemented version policy; retire and re-create it', { field: 'versionPolicy' })
+    }
     if (data.matchStatus === MATCH_STATUSES.MATCHED && isStamped(data)) {
       return { persisted: false, mode: 'skipped_already_confirmed', mappingId, evidence: buildConfirmEvidence('mapping', 'skipped_already_confirmed') }
     }

--- a/plugins/plugin-integration-core/lib/stock-preparation-material-match.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-material-match.cjs
@@ -35,8 +35,13 @@ const VERSION_POLICIES = Object.freeze({
 // `category_rule` stays RESERVED in the wider vocabulary (stock-preparation-mvp-generation.cjs
 // VERSION_POLICIES) but has NO branch — so it, like any unknown stored string, must NEVER
 // auto-match and never fall into the tail heuristic (fail-closed; #4391 doctrine: stored legacy
-// rows are not trusted either).
-const IMPLEMENTED_VERSION_POLICIES = Object.freeze(new Set(Object.values(VERSION_POLICIES)))
+// rows are not trusted either). Enumerated EXPLICITLY (never derived from the enum object) so a
+// future vocabulary widening cannot silently widen this guard without adding a matcher branch.
+const IMPLEMENTED_VERSION_POLICIES = Object.freeze(new Set([
+  VERSION_POLICIES.DRAWING_AND_VERSION,
+  VERSION_POLICIES.DRAWING_ONLY,
+  VERSION_POLICIES.MANUAL,
+]))
 
 class StockPreparationMaterialMatchError extends Error {
   constructor(message, details = {}) {
@@ -137,11 +142,12 @@ function mappingMatchesLine(mapping, drawingNo, version) {
 
 function mappingIsVersionConflict(mapping, drawingNo, version) {
   if (!sameText(mapping.plmDrawingNo, drawingNo)) return false
-  if (mapping.matchStatus === MATCH_STATUSES.VERSION_CONFLICT) return true
   const policy = optionalString(mapping.versionPolicy) || VERSION_POLICIES.MANUAL
-  // OD2 fail-closed: an unimplemented policy is never REPORTED as a version conflict either — the
-  // row simply never participates (missing_mapping is the visible exception, not version_conflict).
+  // OD2 fail-closed (round 2): the policy guard runs BEFORE the stored-status short-circuit — a
+  // legacy row carrying an unimplemented policy must not force version_conflict via a stored
+  // matchStatus either. It never participates at all; the visible exception is the missing path.
   if (!IMPLEMENTED_VERSION_POLICIES.has(policy)) return false
+  if (mapping.matchStatus === MATCH_STATUSES.VERSION_CONFLICT) return true
   if (policy !== VERSION_POLICIES.DRAWING_AND_VERSION) return false
   const mappingVersion = optionalString(mapping.plmVersion)
   return Boolean(mappingVersion && version && !sameText(mappingVersion, version))

--- a/plugins/plugin-integration-core/lib/stock-preparation-material-match.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-material-match.cjs
@@ -31,6 +31,13 @@ const VERSION_POLICIES = Object.freeze({
   MANUAL: 'manual',
 })
 
+// OD2 round-1 hardening: exactly these three policies have an implementation branch below.
+// `category_rule` stays RESERVED in the wider vocabulary (stock-preparation-mvp-generation.cjs
+// VERSION_POLICIES) but has NO branch — so it, like any unknown stored string, must NEVER
+// auto-match and never fall into the tail heuristic (fail-closed; #4391 doctrine: stored legacy
+// rows are not trusted either).
+const IMPLEMENTED_VERSION_POLICIES = Object.freeze(new Set(Object.values(VERSION_POLICIES)))
+
 class StockPreparationMaterialMatchError extends Error {
   constructor(message, details = {}) {
     super(message)
@@ -116,6 +123,9 @@ function activeRows(rows) {
 function mappingMatchesLine(mapping, drawingNo, version) {
   if (!sameText(mapping.plmDrawingNo, drawingNo)) return false
   const policy = optionalString(mapping.versionPolicy) || VERSION_POLICIES.MANUAL
+  // OD2 fail-closed match guard: an UNIMPLEMENTED policy value (category_rule or any junk string)
+  // never auto-matches — the line degrades to a visible missing-mapping exception instead.
+  if (!IMPLEMENTED_VERSION_POLICIES.has(policy)) return false
   if (policy === VERSION_POLICIES.DRAWING_ONLY) return true
   if (policy === VERSION_POLICIES.DRAWING_AND_VERSION) {
     return optionalString(version) !== null && sameText(mapping.plmVersion, version)
@@ -129,6 +139,9 @@ function mappingIsVersionConflict(mapping, drawingNo, version) {
   if (!sameText(mapping.plmDrawingNo, drawingNo)) return false
   if (mapping.matchStatus === MATCH_STATUSES.VERSION_CONFLICT) return true
   const policy = optionalString(mapping.versionPolicy) || VERSION_POLICIES.MANUAL
+  // OD2 fail-closed: an unimplemented policy is never REPORTED as a version conflict either — the
+  // row simply never participates (missing_mapping is the visible exception, not version_conflict).
+  if (!IMPLEMENTED_VERSION_POLICIES.has(policy)) return false
   if (policy !== VERSION_POLICIES.DRAWING_AND_VERSION) return false
   const mappingVersion = optionalString(mapping.plmVersion)
   return Boolean(mappingVersion && version && !sameText(mappingVersion, version))
@@ -275,11 +288,18 @@ function buildValuesFreeEvidence(input, rows) {
 }
 
 function normalizeInput(input = {}) {
+  const defaultVersionPolicy = optionalString(input.defaultVersionPolicy)
+  // OD2 input boundary (engine-level backstop; the route validator rejects first with 422): a
+  // SUPPLIED defaultVersionPolicy outside the implemented set is refused — it would be stamped
+  // onto every generated candidate row. Details carry the field NAME only (values-free).
+  if (defaultVersionPolicy && !IMPLEMENTED_VERSION_POLICIES.has(defaultVersionPolicy)) {
+    throw new StockPreparationMaterialMatchError('defaultVersionPolicy is not an implemented version policy', { field: 'defaultVersionPolicy' })
+  }
   return {
     plmBomLines: normalizeRows(input.plmBomLines, 'plmBomLines'),
     erpMaterials: normalizeRows(input.erpMaterials, 'erpMaterials'),
     confirmedMappings: normalizeRows(input.confirmedMappings, 'confirmedMappings'),
-    defaultVersionPolicy: optionalString(input.defaultVersionPolicy) || VERSION_POLICIES.DRAWING_AND_VERSION,
+    defaultVersionPolicy: defaultVersionPolicy || VERSION_POLICIES.DRAWING_AND_VERSION,
   }
 }
 
@@ -355,6 +375,7 @@ module.exports = {
   MATCH_METHODS,
   MATCH_STATUSES,
   VERSION_POLICIES,
+  IMPLEMENTED_VERSION_POLICIES,
   StockPreparationMaterialMatchError,
   generateMaterialMappingCandidates,
   __internals: {

--- a/plugins/plugin-integration-core/lib/stock-preparation-mvp-generation.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-mvp-generation.cjs
@@ -39,6 +39,17 @@ const VERSION_POLICIES = Object.freeze({
   MANUAL: 'manual',
 })
 
+// OD2 round-1 hardening: only these three vocabulary values have an implementation branch in the
+// matchers below. CATEGORY_RULE stays RESERVED in the vocabulary (the enum name does not move) but
+// acceptance and matching are closed: a stored row carrying it — or any unknown junk string — must
+// NEVER auto-match and never fall into the tail heuristic (fail-closed; #4391 doctrine: legacy
+// approved rows are not trusted either).
+const IMPLEMENTED_VERSION_POLICIES = Object.freeze(new Set([
+  VERSION_POLICIES.DRAWING_AND_VERSION,
+  VERSION_POLICIES.DRAWING_ONLY,
+  VERSION_POLICIES.MANUAL,
+]))
+
 const UNIT_SCOPE_PRIORITIES = Object.freeze({
   material: 1,
   category: 2,
@@ -133,6 +144,9 @@ function sameText(left, right) {
 function mappingMatchesLine(mapping, line) {
   if (!sameText(mapping.plmDrawingNo, line.childDrawingNo)) return false
   const policy = optionalString(mapping.versionPolicy) || VERSION_POLICIES.MANUAL
+  // OD2 fail-closed match guard: an UNIMPLEMENTED policy value (category_rule or any junk string)
+  // never auto-matches — the line degrades to a visible missing_mapping exception (HELD) instead.
+  if (!IMPLEMENTED_VERSION_POLICIES.has(policy)) return false
   if (policy === VERSION_POLICIES.DRAWING_ONLY) return true
   const mappingVersion = optionalString(mapping.plmVersion)
   const lineVersion = optionalString(line.childVersion)
@@ -147,6 +161,9 @@ function mappingHasVersionConflict(mapping, line) {
   if (!sameText(mapping.plmDrawingNo, line.childDrawingNo)) return false
   if (mapping.matchStatus === MATERIAL_MATCH_STATUSES.VERSION_CONFLICT) return true
   const policy = optionalString(mapping.versionPolicy) || VERSION_POLICIES.MANUAL
+  // OD2 fail-closed: an unimplemented policy is never REPORTED as a version conflict either — the
+  // row simply never participates (missing_mapping is the visible exception, not version_conflict).
+  if (!IMPLEMENTED_VERSION_POLICIES.has(policy)) return false
   if (policy !== VERSION_POLICIES.DRAWING_AND_VERSION) return false
   const mappingVersion = optionalString(mapping.plmVersion)
   const lineVersion = optionalString(line.childVersion)
@@ -465,6 +482,7 @@ module.exports = {
   UNIT_STATUSES,
   MATERIAL_MATCH_STATUSES,
   VERSION_POLICIES,
+  IMPLEMENTED_VERSION_POLICIES,
   StockPreparationMvpGenerationError,
   generateStockPreparationMvp,
   __internals: {

--- a/plugins/plugin-integration-core/lib/stock-preparation-mvp-generation.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-mvp-generation.cjs
@@ -159,11 +159,12 @@ function mappingMatchesLine(mapping, line) {
 
 function mappingHasVersionConflict(mapping, line) {
   if (!sameText(mapping.plmDrawingNo, line.childDrawingNo)) return false
-  if (mapping.matchStatus === MATERIAL_MATCH_STATUSES.VERSION_CONFLICT) return true
   const policy = optionalString(mapping.versionPolicy) || VERSION_POLICIES.MANUAL
-  // OD2 fail-closed: an unimplemented policy is never REPORTED as a version conflict either — the
-  // row simply never participates (missing_mapping is the visible exception, not version_conflict).
+  // OD2 fail-closed (round 2): the policy guard runs BEFORE the stored-status short-circuit — a
+  // legacy row carrying an unimplemented policy must not force version_conflict via a stored
+  // matchStatus either. It never participates at all; the visible exception is missing_mapping.
   if (!IMPLEMENTED_VERSION_POLICIES.has(policy)) return false
+  if (mapping.matchStatus === MATERIAL_MATCH_STATUSES.VERSION_CONFLICT) return true
   if (policy !== VERSION_POLICIES.DRAWING_AND_VERSION) return false
   const mappingVersion = optionalString(mapping.plmVersion)
   const lineVersion = optionalString(line.childVersion)


### PR DESCRIPTION
## What (#4194 ballot round-1: category_rule 「不能继续静默接受」; this lands the recommended ①+② pair, full implementation ③ stays a gated future design)

`category_rule` was an accepted versionPolicy vocabulary value with NO implementation branch: the matchers only implement drawing_only / drawing_and_version, and every other value fell into a tail fallback that **matches on drawing number alone whenever either version is absent** and never flags version_conflict — silently behaving like manual (or looser) while the user believes a category rule applies.

Fail-closed at four points (allowlist-shaped — any unimplemented value, not category_rule-special-cased):

1. **Candidate-sync (R5)**: unimplemented `defaultVersionPolicy` → 422 `STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED`, details `{field}` only;
2. **Mapping confirm create (R6)**: unimplemented `versionPolicy` → same 422;
3. **Engine backstop** (material-match input normalization) — defense-in-depth behind the route validators;
4. **Match-time guards in BOTH engines** (material-match AND mvp-generation's own copy; #4391 doctrine — stored legacy rows untrusted): an unimplemented policy on a stored mapping row **never auto-matches and never version-conflicts** — the line degrades to the visible missing_mapping/HELD exception path instead of silently matching.

FE: `category_rule` removed from whitelist AND type union (vue-tsc green); read-side projections deliberately still surface legacy stored values for observability. Vocabulary constant stays reserved (nothing renamed); T3a/T3b/source-run paths verified to carry no versionPolicy input.

## Evidence

- Tests: full plugin chain (~95 files) PASS; new cases across 4 plugin suites + FE spec (unimplemented×2 values × input-boundary/match-time/generation-HELD paths; positive controls for the 3 implemented values; values-free 422 details; zero-write on rejection). The match-time never-matches test **fails on unpatched code** (locks the fix).
- Mutations (commit-first): **M1** delete both engines' match-time guards → never-matches + generation tests RED verbatim (a draft line silently generated on unpatched behavior); **M2** delete both 422 rejections → route/confirm tests RED (engine backstop visibly catches R5 — defense-in-depth demonstrated); both reverted, suites green, diff clean.
- vue-tsc exit 0; touched FE specs 59/59.

**Not armed — owner review**; if the owner prefers option ③ (real category-rule implementation) later, this PR's guards are the safe substrate it would replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Round-2 (adversarial review findings — fixed in `5db599796`)

- **P2 guard ordering**: the stored `matchStatus='version_conflict'` short-circuit ran BEFORE the policy guard in both engines — a legacy category_rule row with that stored status still forced VERSION_CONFLICT. Guard now runs first; such rows degrade to the missing path (tests in both engines; mutation restoring the old order goes RED verbatim).
- **P2 confirm-existing branch**: confirm-by-mappingId never inspected the stored row's policy — a legacy category_rule candidate could be stamped confirmed and become a dead confirmed row. Now 422 `STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED` `{field:'versionPolicy'}`, zero writes; policy-absent stored rows stay confirmable (absence folds to manual — asserted).
- **P3 FE read-side type**: candidate-row `versionPolicy` widened to include `'category_rule'` (read vocabulary ≠ write whitelist — confirm-reads still projects legacy values verbatim); write surfaces stay 3-valued. vue-tsc exit 0.
- **P3 status-code note**: junk versionPolicy values shifted 400 (`CONFIRM_*_INVALID`) → 422 `STOCK_PREPARATION_VERSION_POLICY_UNSUPPORTED` at the unified allowlist — no FE branch keyed on the old codes; external consumers keying on 400 should note the change.
- **NIT**: material-match's implemented set now enumerates the 3 values explicitly (no longer derived from its local enum — enum widening can't silently widen the guard).
