### PR TITLE
fix(directory): T2 source-freeze linearization and apply-time recheck

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -210,6 +210,12 @@ jobs:
       - name: T1 org-transfer CI wiring contract
         run: node --test scripts/ops/t1-org-transfer-ci-wiring.test.mjs
 
+      # T2 CI two-point wiring contract (no DB): the source-freeze suite must stay wired into
+      # BOTH vitest.config.ts (exclude) AND plugin-tests.yml (approval real-DB step). Dropping
+      # either point silently disables the §12.2 freeze proof.
+      - name: T2 source-freeze CI wiring contract
+        run: node --test scripts/ops/t2-source-freeze-ci-wiring.test.mjs
+
       # The production monitor invokes the same state helper covered here.
       # Keep this in the required 18/20 matrix so HTTP classification, silence
       # barriers, and alert/recovery streak semantics cannot drift silently.
@@ -677,6 +683,7 @@ jobs:
             tests/integration/directory-sync-run-lease.db.test.ts \
             tests/integration/directory-tenant-change-immutable.db.test.ts \
             tests/integration/directory-sync-orchestration.db.test.ts \
+            tests/integration/directory-org-transfer-source-freeze.db.test.ts \
             tests/integration/directory-sync-schedule-timezone.db.test.ts \
             tests/integration/directory-local-provider-bootstrap.db.test.ts \
             tests/integration/directory-local-provider-scheduler-exclusion.db.test.ts \

--- a/packages/core-backend/src/directory/directory-sync-scheduler.ts
+++ b/packages/core-backend/src/directory/directory-sync-scheduler.ts
@@ -1,7 +1,7 @@
 import { Logger } from '../core/logger'
 import { query } from '../db/pg'
 import { SchedulerServiceImpl } from '../services/SchedulerService'
-import { DirectorySyncInProgressError, reclaimStaleDirectorySyncRuns, syncDirectoryIntegration } from './directory-sync'
+import { DirectorySyncFrozenByTransferError, DirectorySyncInProgressError, reclaimStaleDirectorySyncRuns, syncDirectoryIntegration } from './directory-sync'
 import { deliverDirectoryInactiveLinkedAlert } from './directory-sync-alert-delivery'
 import { resolveDirectoryScheduleTimezone } from './directory-sync-timezone'
 
@@ -82,6 +82,13 @@ async function runScheduledSync(integrationId: string, integrationName: string):
     // lease. Skipping is the correct outcome — the directory is being refreshed. Any
     // other failure stays an error so the job reports it.
     if (error instanceof DirectorySyncInProgressError) {
+      logger.info(`Skipped scheduled directory sync for ${integrationId}: ${error.message}`)
+      return
+    }
+    // T2 (§12.2): a frozen source is a deliberate transfer state, not a sync failure — skip
+    // quietly each tick until the transfer reaches a terminal status (or its freeze flag is
+    // cleared), exactly like the lease skip above.
+    if (error instanceof DirectorySyncFrozenByTransferError) {
       logger.info(`Skipped scheduled directory sync for ${integrationId}: ${error.message}`)
       return
     }

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -39,6 +39,7 @@ import { getBcryptSaltRounds } from '../security/auth-runtime-config'
 import { SimpleCronExpression } from '../services/SchedulerService'
 import { deliverDirectorySyncFailureAlert, getDirectoryManagerBindingCoverage } from './directory-sync-alert-delivery'
 import { resolveDirectoryScheduleTimezone } from './directory-sync-timezone'
+import { acquireSourceSyncFreezeLock } from './source-sync-freeze-lock'
 
 const logger = new Logger('DirectorySync')
 const DEFAULT_ORG_ID = 'default'
@@ -3104,19 +3105,29 @@ export class DirectorySyncInProgressError extends Error {
  * Transfer MVP T2 (§12.2): an ACTIVE org transfer freezes its SOURCE integration's sync. The
  * dangerous write a mid-transfer sync performs is the unconditional absence sweep — a source
  * tenant being emptied/migrated looks exactly like "everyone left", and the sweep would mark the
- * whole directory inactive. Thrown BEFORE the run lease is claimed, so a frozen trigger creates
- * no run row and leaves nothing to reclaim. The admin override (§12.2 "unless an explicit admin
- * override is supplied") is the transfer row's `freeze_source_sync` flag; the supported operator
- * mutation surface is the platform-admin PATCH .../source-sync-freeze API — flipping it to false
- * un-freezes THIS transfer without cancelling it.
+ * whole directory inactive. The cheap entry check runs BEFORE the run lease is claimed, so a
+ * freeze already active at trigger time creates no run row and leaves nothing to reclaim. The
+ * admin override (§12.2 "unless an explicit admin override is supplied") is the transfer row's
+ * `freeze_source_sync` flag; the supported operator mutation surface is the platform-admin
+ * PATCH .../source-sync-freeze API — flipping it to false un-freezes THIS transfer without
+ * cancelling it.
  *
- * Known window (documented, gate P3): the gate runs ONCE at sync entry, so a transfer created
- * (or a freeze re-asserted / refreeze) while a sync is already past entry does not stop that
- * in-flight run — its absence sweep can still finish. Exposure is bounded: T1/T2 themselves do
- * not drain provider data; fail-closed unregistered-adapter behavior keeps scan/apply from
- * silently no-op-succeeding in production; and the DT-OPS-01 mass-departure breaker caps the
- * local-user cascade. The runbook still orders the transfer record BEFORE any provider-side
- * draining. If T3 needs the window closed, re-assert this freeze immediately before the sweep.
+ * Linearization (P1 closeout): create / freeze=true refreeze and the sync local-apply
+ * transaction share a transaction-scoped advisory lock keyed by source integration
+ * (`directory:source-sync-freeze:${id}`). Inside the apply transaction the lock is acquired
+ * FIRST and the active-freeze recheck runs before ANY local directory mutation (department
+ * upsert, absence sweep, membership rewrite, identity/link write, local-user admission, group
+ * projection, deprovision, integration completion write, run completion write). If freeze
+ * linearized first, the apply rolls back and this error is thrown; if apply owns the lock
+ * first, its local writes may commit before freeze becomes active.
+ *
+ * Honest late-race window: the entry check is still one-shot, so a transfer create / refreeze
+ * that commits after entry may still allow the provider pull to run and a `failed` run row to
+ * exist (lease already claimed). What must never happen is a local directory mutation
+ * committing after a freeze that linearized first — that is what the shared lock + apply-time
+ * recheck close. T1 fail-closed unregistered-adapter scan/apply and the DT-OPS-01 mass-
+ * departure breaker remain independent safety nets; the runbook still orders the transfer
+ * record BEFORE any provider-side draining.
  */
 export class DirectorySyncFrozenByTransferError extends Error {
   readonly statusCode = 409
@@ -3130,21 +3141,42 @@ export class DirectorySyncFrozenByTransferError extends Error {
   }
 }
 
+type FreezeCheckClient = {
+  query: <T extends Record<string, unknown> = Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ) => Promise<{ rows: T[] }>
+}
+
 /**
  * T2 freeze gate. `to_regclass` first: environments whose schema predates the T1 migration have
  * no transfer table and therefore no transfers — proceeding unfrozen is the semantically correct
  * outcome there (logged loudly so a mis-deployed production schema cannot stay silent), while a
  * bare query would brick every sync with a relation-not-found error.
+ *
+ * Used at entry (pool `query`) and again inside the local-apply transaction (transaction
+ * client) after the shared source freeze lock is held. Removing the apply-time recheck
+ * re-opens the create/refreeze-vs-sync race: the barrier suite must go red.
  */
-async function assertDirectorySyncNotFrozenByTransfer(integrationId: string): Promise<void> {
-  const tableProbe = await query<{ reg: string | null }>(
+async function assertDirectorySyncNotFrozenByTransfer(
+  integrationId: string,
+  /**
+   * Optional transaction client. Entry uses the pool `query` helper (a bare function);
+   * apply-time recheck must pass the transaction client so it observes freeze commits that
+   * linearized under the shared source lock.
+   */
+  client?: FreezeCheckClient,
+): Promise<void> {
+  // Pool `query` is a bare function; transaction clients are `{ query }`. Normalize once.
+  const q: FreezeCheckClient = client ?? { query: (sql, params) => query(sql, params) }
+  const tableProbe = await q.query<{ reg: string | null }>(
     `SELECT to_regclass('provider_org_transfers')::text AS reg`,
   )
   if (!tableProbe.rows[0]?.reg) {
     logger.warn('provider_org_transfers table absent — T2 sync-freeze gate inert (schema predates the T1 migration?)')
     return
   }
-  const frozen = await query<{ id: string }>(
+  const frozen = await q.query<{ id: string }>(
     `SELECT id FROM provider_org_transfers
       WHERE source_integration_id = $1
         AND status NOT IN ('applied', 'cancelled')
@@ -3269,8 +3301,10 @@ export async function syncDirectoryIntegration(
   if (!integration) throw new Error('Directory integration not found')
 
   const config = parseIntegrationConfig(integration)
-  // T2 (§12.2): freeze gate BEFORE the lease claim — a frozen trigger must not create a run
-  // row, consume provider quota, or reach the absence sweep. See the error class for why.
+  // T2 (§12.2): cheap freeze gate BEFORE the lease claim — a freeze already active at entry
+  // must not create a run row, consume provider quota, or reach local apply. The apply
+  // transaction re-checks under the shared source freeze lock (see below) so a freeze that
+  // commits after this entry check cannot still land directory mutations.
   await assertDirectorySyncNotFrozenByTransfer(integrationId)
   let deprovisionOutcome: DirectoryDeprovisionOutcome | null = null
   // DT-HARDEN-05: claim the run lease BEFORE the first DingTalk call. The API pull that
@@ -3351,6 +3385,15 @@ export async function syncDirectoryIntegration(
     const autoAdmissionOnboardingPackets: DirectoryAutoAdmissionOnboardingPacket[] = []
 
     await transaction(async (client) => {
+      // T2 P1: shared source freeze lock is the FIRST operation of the local-apply transaction.
+      // Transfer create / freeze=true refreeze take the same key before writing freeze state.
+      // Re-check under the lock before ANY directory upsert, absence sweep, membership rewrite,
+      // identity/link write, local-user admission, group projection, deprovision, integration
+      // completion write, or run completion write. Bypass/remove either the lock or the recheck
+      // → the two-connection create/refreeze-vs-sync barrier suite reds.
+      await acquireSourceSyncFreezeLock(client, integrationId)
+      await assertDirectorySyncNotFrozenByTransfer(integrationId, client as FreezeCheckClient)
+
       // R5: created-vs-updated split for the run summary. `departmentsSynced`/`accountsSynced`
       // conflate "0 new" and "500 new"; the discriminator is `(xmax = 0)` on the upserted row —
       // a freshly INSERTed tuple has xmax 0, an ON CONFLICT DO UPDATE tuple carries the updating

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -3108,6 +3108,12 @@ export class DirectorySyncInProgressError extends Error {
  * no run row and leaves nothing to reclaim. The admin override (§12.2 "unless an explicit admin
  * override is supplied") is the transfer row's `freeze_source_sync` flag — flipping it to false
  * un-freezes THIS transfer without cancelling it.
+ *
+ * Known window (documented, gate P3): the gate runs ONCE at sync entry, so a transfer created
+ * while a sync is already mid-pull does not stop that in-flight run — its absence sweep can still
+ * land. Exposure is bounded (T1 scan/apply are no-ops; the DT-OPS-01 mass-departure breaker caps
+ * the local-user cascade) and the runbook orders the transfer record BEFORE any provider-side
+ * draining. If T3 needs the window closed, re-assert this freeze immediately before the sweep.
  */
 export class DirectorySyncFrozenByTransferError extends Error {
   readonly statusCode = 409

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -3101,6 +3101,54 @@ export class DirectorySyncInProgressError extends Error {
 }
 
 /**
+ * Transfer MVP T2 (§12.2): an ACTIVE org transfer freezes its SOURCE integration's sync. The
+ * dangerous write a mid-transfer sync performs is the unconditional absence sweep — a source
+ * tenant being emptied/migrated looks exactly like "everyone left", and the sweep would mark the
+ * whole directory inactive. Thrown BEFORE the run lease is claimed, so a frozen trigger creates
+ * no run row and leaves nothing to reclaim. The admin override (§12.2 "unless an explicit admin
+ * override is supplied") is the transfer row's `freeze_source_sync` flag — flipping it to false
+ * un-freezes THIS transfer without cancelling it.
+ */
+export class DirectorySyncFrozenByTransferError extends Error {
+  readonly statusCode = 409
+  readonly code = 'DIRECTORY_SYNC_FROZEN_BY_TRANSFER'
+  readonly transferId: string
+
+  constructor(transferId: string) {
+    super(`Directory sync is frozen by an active org transfer for this integration (transfer ${transferId})`)
+    this.name = 'DirectorySyncFrozenByTransferError'
+    this.transferId = transferId
+  }
+}
+
+/**
+ * T2 freeze gate. `to_regclass` first: environments whose schema predates the T1 migration have
+ * no transfer table and therefore no transfers — proceeding unfrozen is the semantically correct
+ * outcome there (logged loudly so a mis-deployed production schema cannot stay silent), while a
+ * bare query would brick every sync with a relation-not-found error.
+ */
+async function assertDirectorySyncNotFrozenByTransfer(integrationId: string): Promise<void> {
+  const tableProbe = await query<{ reg: string | null }>(
+    `SELECT to_regclass('provider_org_transfers')::text AS reg`,
+  )
+  if (!tableProbe.rows[0]?.reg) {
+    logger.warn('provider_org_transfers table absent — T2 sync-freeze gate inert (schema predates the T1 migration?)')
+    return
+  }
+  const frozen = await query<{ id: string }>(
+    `SELECT id FROM provider_org_transfers
+      WHERE source_integration_id = $1
+        AND status NOT IN ('applied', 'cancelled')
+        AND freeze_source_sync = true
+      LIMIT 1`,
+    [integrationId],
+  )
+  if (frozen.rows.length > 0) {
+    throw new DirectorySyncFrozenByTransferError(frozen.rows[0].id)
+  }
+}
+
+/**
  * Thrown when a run reaches its completion write only to find its row is no longer
  * `running` — the lease was reclaimed as stale while this process was still alive
  * (heartbeat starved: event-loop stall, saturated pool, network partition). Thrown
@@ -3212,6 +3260,9 @@ export async function syncDirectoryIntegration(
   if (!integration) throw new Error('Directory integration not found')
 
   const config = parseIntegrationConfig(integration)
+  // T2 (§12.2): freeze gate BEFORE the lease claim — a frozen trigger must not create a run
+  // row, consume provider quota, or reach the absence sweep. See the error class for why.
+  await assertDirectorySyncNotFrozenByTransfer(integrationId)
   let deprovisionOutcome: DirectoryDeprovisionOutcome | null = null
   // DT-HARDEN-05: claim the run lease BEFORE the first DingTalk call. The API pull that
   // follows is the expensive, quota-consuming part; a transaction-scoped lock around the

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -3106,13 +3106,16 @@ export class DirectorySyncInProgressError extends Error {
  * tenant being emptied/migrated looks exactly like "everyone left", and the sweep would mark the
  * whole directory inactive. Thrown BEFORE the run lease is claimed, so a frozen trigger creates
  * no run row and leaves nothing to reclaim. The admin override (§12.2 "unless an explicit admin
- * override is supplied") is the transfer row's `freeze_source_sync` flag — flipping it to false
+ * override is supplied") is the transfer row's `freeze_source_sync` flag; the supported operator
+ * mutation surface is the platform-admin PATCH .../source-sync-freeze API — flipping it to false
  * un-freezes THIS transfer without cancelling it.
  *
  * Known window (documented, gate P3): the gate runs ONCE at sync entry, so a transfer created
- * while a sync is already mid-pull does not stop that in-flight run — its absence sweep can still
- * land. Exposure is bounded (T1 scan/apply are no-ops; the DT-OPS-01 mass-departure breaker caps
- * the local-user cascade) and the runbook orders the transfer record BEFORE any provider-side
+ * (or a freeze re-asserted / refreeze) while a sync is already past entry does not stop that
+ * in-flight run — its absence sweep can still finish. Exposure is bounded: T1/T2 themselves do
+ * not drain provider data; fail-closed unregistered-adapter behavior keeps scan/apply from
+ * silently no-op-succeeding in production; and the DT-OPS-01 mass-departure breaker caps the
+ * local-user cascade. The runbook still orders the transfer record BEFORE any provider-side
  * draining. If T3 needs the window closed, re-assert this freeze immediately before the sweep.
  */
 export class DirectorySyncFrozenByTransferError extends Error {

--- a/packages/core-backend/src/directory/org-transfer-service.ts
+++ b/packages/core-backend/src/directory/org-transfer-service.ts
@@ -24,6 +24,7 @@
  *            'applying' is never observable here)
  *            Missing adapter → 409 ORG_TRANSFER_ADAPTER_UNAVAILABLE; row unchanged
  *   cancel:  any non-terminal ('draft' | 'scanned' | 'applying' | 'failed') → 'cancelled'
+ *   source-sync-freeze (T2 admin override): non-terminal only; toggles freeze_source_sync
  *
  * Every transition runs in ONE transaction with `SELECT … FOR UPDATE` on the transfer row —
  * write-point enforcement, not check-then-write (the PB4-2 doctrine): a concurrent
@@ -461,6 +462,37 @@ export async function cancelOrgTransfer(transferId: string): Promise<OrgTransfer
         WHERE id = $1
         RETURNING ${TRANSFER_COLUMNS}`,
       [transferId]
+    )
+    return toSummary((updated.rows as OrgTransferRow[])[0])
+  })
+}
+
+/**
+ * T2 platform-admin override for §12.2 source-sync freeze.
+ *
+ * Locks the transfer row transactionally, allows only non-terminal statuses, and sets
+ * `freeze_source_sync`. Org identity is never a caller input — it is already on the transfer
+ * row (derived at create from the two integrations). Routes emit one values-free post-commit
+ * audit; rejected mutations write none.
+ */
+export async function setOrgTransferSourceSyncFreeze(
+  transferId: string,
+  freezeSourceSync: boolean
+): Promise<OrgTransferSummary> {
+  return transaction(async (client) => {
+    const row = await lockTransfer(client, transferId)
+    if (!NON_TERMINAL_STATUSES.includes(row.status)) {
+      throw new OrgTransferConflictError(
+        'ORG_TRANSFER_INVALID_STATE',
+        `source-sync freeze cannot be changed on terminal status ${row.status}`
+      )
+    }
+    const updated = await client.query(
+      `UPDATE provider_org_transfers
+          SET freeze_source_sync = $2, updated_at = now()
+        WHERE id = $1
+        RETURNING ${TRANSFER_COLUMNS}`,
+      [transferId, freezeSourceSync]
     )
     return toSummary((updated.rows as OrgTransferRow[])[0])
   })

--- a/packages/core-backend/src/directory/org-transfer-service.ts
+++ b/packages/core-backend/src/directory/org-transfer-service.ts
@@ -30,6 +30,12 @@
  * write-point enforcement, not check-then-write (the PB4-2 doctrine): a concurrent
  * apply/apply or apply/cancel pair linearizes on the row lock and the loser gets a clean 409.
  *
+ * T2 source freeze is linearized across processes with a shared transaction-scoped advisory
+ * lock keyed by source integration (`directory:source-sync-freeze:${sourceId}`). Create and
+ * freeze=true/refreeze acquire that lock before writing freeze-affecting state; the sync
+ * local-apply transaction acquires the same lock and re-checks active freeze before any
+ * local directory mutation. See `source-sync-freeze-lock.ts`.
+ *
  * Like `local-directory-org.ts`, every function takes explicit ids; org identity is NEVER a
  * caller input — the transfer's `org_id` is derived server-side from the two integration rows
  * (which must agree), and the schema's composite FKs make a cross-org or provider-mismatched
@@ -37,6 +43,7 @@
  */
 
 import { query, transaction } from '../db/pg'
+import { acquireSourceSyncFreezeLock } from './source-sync-freeze-lock'
 
 export class OrgTransferValidationError extends Error {
   constructor(message: string) {
@@ -260,14 +267,20 @@ export async function createOrgTransfer(input: CreateOrgTransferInput): Promise<
   }
 
   try {
-    const inserted = await query<OrgTransferRow>(
-      `INSERT INTO provider_org_transfers
-         (org_id, provider, source_integration_id, target_integration_id, source_tenant_key, target_tenant_key, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
-       RETURNING ${TRANSFER_COLUMNS}`,
-      [source.org_id, provider, source.id, target.id, source.corp_id, target.corp_id, input.createdBy]
-    )
-    return toSummary(inserted.rows[0])
+    // T2: take the source freeze lock BEFORE INSERT so a concurrent sync local-apply cannot
+    // pass its apply-time recheck and commit directory writes after this freeze becomes active.
+    // Default freeze_source_sync=true on the row makes create itself a freeze activation.
+    return await transaction(async (client) => {
+      await acquireSourceSyncFreezeLock(client, source.id)
+      const inserted = await client.query(
+        `INSERT INTO provider_org_transfers
+           (org_id, provider, source_integration_id, target_integration_id, source_tenant_key, target_tenant_key, created_by)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         RETURNING ${TRANSFER_COLUMNS}`,
+        [source.org_id, provider, source.id, target.id, source.corp_id, target.corp_id, input.createdBy]
+      )
+      return toSummary((inserted.rows as OrgTransferRow[])[0])
+    })
   } catch (error) {
     if (isUniqueViolation(error)) {
       throw new OrgTransferConflictError(
@@ -470,17 +483,42 @@ export async function cancelOrgTransfer(transferId: string): Promise<OrgTransfer
 /**
  * T2 platform-admin override for §12.2 source-sync freeze.
  *
- * Locks the transfer row transactionally, allows only non-terminal statuses, and sets
- * `freeze_source_sync`. Org identity is never a caller input — it is already on the transfer
+ * Derives the immutable source integration id, acquires the shared source freeze lock, then
+ * locks/revalidates the transfer row and writes `freeze_source_sync`. Only non-terminal
+ * statuses are mutable. Org identity is never a caller input — it is already on the transfer
  * row (derived at create from the two integrations). Routes emit one values-free post-commit
  * audit; rejected mutations write none.
+ *
+ * Order is load-bearing: source lock BEFORE transfer-row FOR UPDATE so create/refreeze and the
+ * sync local-apply path share one linearization key. Taking the transfer row first would leave
+ * a window where sync can still recheck-miss and commit local directory writes.
  */
 export async function setOrgTransferSourceSyncFreeze(
   transferId: string,
   freezeSourceSync: boolean
 ): Promise<OrgTransferSummary> {
   return transaction(async (client) => {
+    // Derive immutable source id first (no row lock yet) so the shared freeze lock is keyed
+    // correctly before we serialize on the transfer row.
+    const sourceProbe = await client.query(
+      `SELECT source_integration_id FROM provider_org_transfers WHERE id = $1`,
+      [transferId]
+    )
+    const sourceRows = sourceProbe.rows as Array<{ source_integration_id: string }>
+    if (sourceRows.length === 0) throw new OrgTransferNotFoundError('transfer not found')
+    const sourceIntegrationId = sourceRows[0].source_integration_id
+
+    await acquireSourceSyncFreezeLock(client, sourceIntegrationId)
+
     const row = await lockTransfer(client, transferId)
+    // Defensive: source_integration_id is immutable post-create; mismatch would mean a
+    // concurrent impossible rewrite, not a supported state.
+    if (row.source_integration_id !== sourceIntegrationId) {
+      throw new OrgTransferConflictError(
+        'ORG_TRANSFER_INVALID_STATE',
+        'transfer source integration changed during freeze update'
+      )
+    }
     if (!NON_TERMINAL_STATUSES.includes(row.status)) {
       throw new OrgTransferConflictError(
         'ORG_TRANSFER_INVALID_STATE',

--- a/packages/core-backend/src/directory/source-sync-freeze-lock.ts
+++ b/packages/core-backend/src/directory/source-sync-freeze-lock.ts
@@ -1,0 +1,44 @@
+/**
+ * Transfer MVP T2 (§12.2) — cross-process linearization for source-sync freeze.
+ *
+ * The cheap entry check in `syncDirectoryIntegration` (before the run lease) is necessary but
+ * not sufficient: a transfer create / freeze=true refreeze can commit after that check and
+ * before the sync's local apply transaction. Without a shared write-point lock, the sync would
+ * still perform the destructive absence sweep (and other local directory mutations) against a
+ * source that is already frozen.
+ *
+ * All freeze writers (create, freeze=true/refreeze mutation) and the sync local-apply
+ * transaction acquire the same transaction-scoped PostgreSQL advisory lock keyed by
+ * source integration id. Under that lock the sync re-checks for an active frozen transfer
+ * before ANY local directory mutation. If freeze linearized first, the apply rolls back and
+ * throws `DirectorySyncFrozenByTransferError`. If the apply owns the lock first, it may
+ * commit before freeze becomes active.
+ *
+ * Key shape mirrors the PB4-3 reparent serialization key (`directory:reparent:${id}`).
+ * `pg_advisory_xact_lock` releases on COMMIT/ROLLBACK — never session-leaked.
+ */
+
+export type SourceSyncFreezeLockClient = {
+  query: (sql: string, params?: unknown[]) => Promise<unknown>
+}
+
+/** Stable advisory-lock key for a source integration's freeze/apply linearization. */
+export function sourceSyncFreezeLockKey(sourceIntegrationId: string): string {
+  return `directory:source-sync-freeze:${sourceIntegrationId}`
+}
+
+/**
+ * Acquire the source freeze lock for the CURRENT transaction. Must be the first operation of
+ * the sync local-apply transaction (before any directory upsert / absence sweep / membership
+ * rewrite / identity-link write / local-user admission / group projection / deprovision /
+ * integration completion / run completion write). Create and freeze mutations take the same
+ * key before their INSERT/UPDATE of freeze-affecting state.
+ */
+export async function acquireSourceSyncFreezeLock(
+  client: SourceSyncFreezeLockClient,
+  sourceIntegrationId: string,
+): Promise<void> {
+  await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+    sourceSyncFreezeLockKey(sourceIntegrationId),
+  ])
+}

--- a/packages/core-backend/src/routes/admin-directory-org-transfers.ts
+++ b/packages/core-backend/src/routes/admin-directory-org-transfers.ts
@@ -12,16 +12,18 @@ import {
 import { jsonError, jsonOk } from '../util/response'
 
 /**
- * Transfer MVP — T1 (routes), API per `provider-org-transfer-development-plan-20260709.md` §6.3:
- * create / read / scan / dry-run apply / apply / cancel. The decisions PATCH endpoint of §6.3 is
- * deliberately NOT here — without a registered adapter scan yields zero bindings only when tests
- * explicitly register the no-op; production scan/apply fail closed with
- * ORG_TRANSFER_ADAPTER_UNAVAILABLE. The decision surface (and its secret-handling rules) lands
- * with the first real adapter (T3/T4).
+ * Transfer MVP — T1 + T2 freeze override routes, API per
+ * `provider-org-transfer-development-plan-20260709.md` §6.3 / §12.2:
+ * create / read / scan / dry-run apply / apply / cancel / source-sync-freeze.
+ * The decisions PATCH endpoint of §6.3 is deliberately NOT here — without a registered adapter
+ * scan yields zero bindings only when tests explicitly register the no-op; production scan/apply
+ * fail closed with ORG_TRANSFER_ADAPTER_UNAVAILABLE. The decision surface (and its secret-handling
+ * rules) lands with the first real adapter (T3/T4).
  *
  * Platform-admin only (`ensurePlatformAdmin`, the single source in admin-directory.ts). Org
  * identity is never read from the request: the service derives `org_id` from the two integration
- * rows, and the schema's composite FKs make cross-org/provider-mismatched rows impossible.
+ * rows (create) or from the transfer row (freeze override), and the schema's composite FKs make
+ * cross-org/provider-mismatched rows impossible.
  * Every successful lifecycle mutation writes ONE values-free audit row (ids/status/counters only —
  * no names, no tenant/corp keys, no URLs). Rejected mutations (including adapter-unavailable and
  * unknown body fields) write no success audit.
@@ -29,7 +31,8 @@ import { jsonError, jsonOk } from '../util/response'
  * Lifecycle body contract: scan / apply (dry-run + real) / cancel accept NO body fields. Any key,
  * array, or non-plain payload is 400 ORG_TRANSFER_UNKNOWN_FIELDS before service + audit. Empty
  * object / omitted body remains allowed. CREATE uses the same plain-object gate with its field
- * allowlist.
+ * allowlist. T2 source-sync-freeze accepts exactly `{ freezeSourceSync: boolean }` via the same
+ * plain-object gate.
  */
 
 const logger = new Logger('AdminDirectoryOrgTransferRoutes')
@@ -37,6 +40,7 @@ const logger = new Logger('AdminDirectoryOrgTransferRoutes')
 const CREATE_FIELDS = ['provider', 'sourceIntegrationId', 'targetIntegrationId'] as const
 /** scan / apply / cancel — no request-body fields are accepted. */
 const LIFECYCLE_BODY_FIELDS = [] as const
+const SOURCE_SYNC_FREEZE_FIELDS = ['freezeSourceSync'] as const
 
 const UUID_SHAPE_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -107,7 +111,7 @@ function handleOrgTransferError(res: Response, error: unknown, fallbackMessage: 
   jsonError(res, 500, 'ORG_TRANSFER_INTERNAL_ERROR', fallbackMessage)
 }
 
-type TransferAuditAction = 'create' | 'scan' | 'dry_run' | 'apply' | 'cancel'
+type TransferAuditAction = 'create' | 'scan' | 'dry_run' | 'apply' | 'cancel' | 'source_sync_freeze'
 
 /** Values-free lifecycle audit row; best-effort per the directory route precedent. */
 async function auditTransfer(
@@ -265,6 +269,38 @@ export function adminDirectoryOrgTransfersRouter(): Router {
       jsonOk(res, { transfer })
     } catch (error) {
       handleOrgTransferError(res, error, 'Failed to cancel org transfer')
+    }
+  })
+
+  /**
+   * T2 §12.2 admin override: PATCH body allowlist is exactly `{ freezeSourceSync: boolean }`.
+   * Org is derived from the transfer row (never from the body). Non-terminal transfers only.
+   */
+  router.patch('/:transferId/source-sync-freeze', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    if (rejectNonUuidParam(res, 'transferId', req.params.transferId)) return
+    if (rejectUnlistedFields(req, res, SOURCE_SYNC_FREEZE_FIELDS)) return
+
+    const body = (req.body ?? {}) as Record<string, unknown>
+    if (typeof body.freezeSourceSync !== 'boolean') {
+      jsonError(res, 400, 'ORG_TRANSFER_INVALID_INPUT', 'freezeSourceSync must be a boolean')
+      return
+    }
+
+    try {
+      const transfer = await orgTransferService.setOrgTransferSourceSyncFreeze(
+        req.params.transferId,
+        body.freezeSourceSync,
+      )
+      await auditTransfer(adminUserId, 'source_sync_freeze', transfer.id, {
+        provider: transfer.provider,
+        status: transfer.status,
+        freezeSourceSync: transfer.freezeSourceSync,
+      })
+      jsonOk(res, { transfer })
+    } catch (error) {
+      handleOrgTransferError(res, error, 'Failed to update org-transfer source-sync freeze')
     }
   })
 

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -3,6 +3,7 @@ import { Router } from 'express'
 import { auditLog } from '../audit/audit'
 import { Logger } from '../core/logger'
 import {
+  DirectorySyncFrozenByTransferError,
   DirectorySyncInProgressError,
   DirectoryTenantChangeBlockedError,
   acknowledgeDirectorySyncAlert,
@@ -549,6 +550,12 @@ export function adminDirectoryRouter(): Router {
           jsonError(res, error.statusCode, error.code, error.message, { activeRunId: error.activeRunId })
           return
         }
+        // T2 (§12.2): an active org transfer freezes this source integration's sync — a
+        // deliberate admin-visible state, not a failure. 409 + the transfer id.
+        if (error instanceof DirectorySyncFrozenByTransferError) {
+          jsonError(res, error.statusCode, error.code, error.message, { transferId: error.transferId })
+          return
+        }
         const message = readErrorMessage(error, 'Failed to start directory sync')
         jsonError(res, /not found/i.test(message) ? 404 : 500, 'DIRECTORY_SYNC_FAILED', message)
         return
@@ -563,6 +570,11 @@ export function adminDirectoryRouter(): Router {
       // admin UI can jump straight to it instead of re-triggering a duplicate API pull.
       if (error instanceof DirectorySyncInProgressError) {
         jsonError(res, error.statusCode, error.code, error.message, { activeRunId: error.activeRunId })
+        return
+      }
+      // T2 (§12.2): same deliberate frozen state as the async branch above.
+      if (error instanceof DirectorySyncFrozenByTransferError) {
+        jsonError(res, error.statusCode, error.code, error.message, { transferId: error.transferId })
         return
       }
       const message = readErrorMessage(error, 'Failed to sync directory integration')

--- a/packages/core-backend/tests/integration/directory-org-transfer-source-freeze.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-org-transfer-source-freeze.db.test.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from 'crypto'
+import express from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+// Transfer MVP — T2 (§12.2 source freeze), real DB + the REAL syncDirectoryIntegration with a
+// mocked DingTalk client (the R1-L4 orchestration-harness pattern): nothing between this suite
+// and the sync orchestration except the network client. The mocked tenant is EMPTY, so any sync
+// that is allowed to run performs the destructive absence sweep — which is exactly the write the
+// freeze exists to stop. That makes the positive control honest: with the freeze bypassed (the
+// transfer row's freeze_source_sync=false admin override), the very same sync deactivates the
+// seeded account, proving test A's frozen sync was blocked from a REAL destructive outcome, not
+// from a no-op.
+//
+// DATABASE_URL-gated (describeIfDatabase): excluded from the no-DB vitest job so it cannot
+// skip-green, and wired as a WHOLE FILE into the approval real-DB step in plugin-tests.yml
+// (both points asserted by t2-source-freeze-ci-wiring.test.mjs).
+const clientMocks = vi.hoisted(() => ({
+  fetchDingTalkAppAccessToken: vi.fn(),
+  listDingTalkDepartments: vi.fn(),
+  getDingTalkDepartmentDetail: vi.fn(),
+  listDingTalkDepartmentUsers: vi.fn(),
+  getDingTalkUserDetail: vi.fn(),
+}))
+
+vi.mock('../../src/integrations/dingtalk/client', () => ({
+  fetchDingTalkAppAccessToken: clientMocks.fetchDingTalkAppAccessToken,
+  listDingTalkDepartments: clientMocks.listDingTalkDepartments,
+  getDingTalkDepartmentDetail: clientMocks.getDingTalkDepartmentDetail,
+  listDingTalkDepartmentUsers: clientMocks.listDingTalkDepartmentUsers,
+  getDingTalkUserDetail: clientMocks.getDingTalkUserDetail,
+}))
+
+import { query } from '../../src/db/pg'
+import {
+  createDirectoryIntegration,
+  DirectorySyncFrozenByTransferError,
+  syncDirectoryIntegration,
+} from '../../src/directory/directory-sync'
+import { adminDirectoryRouter } from '../../src/routes/admin-directory'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+const adminApp = express()
+adminApp.use(express.json())
+adminApp.use((req, _res, next) => {
+  ;(req as express.Request & { user?: unknown }).user = { id: `t2-freeze-admin-${TS}`, role: 'admin' }
+  next()
+})
+adminApp.use('/api/admin/directory', adminDirectoryRouter())
+
+describeIfDatabase('Transfer MVP T2 — §12.2 source freeze during an active org transfer (real sync, mocked pull)', () => {
+  const cleanupTransferIds: string[] = []
+  const cleanupIntegrationIds: string[] = []
+
+  beforeAll(() => {
+    clientMocks.fetchDingTalkAppAccessToken.mockResolvedValue('t2-frz-token')
+    // EMPTY tenant: every sync that runs walks nothing and absence-sweeps everything.
+    clientMocks.listDingTalkDepartments.mockResolvedValue([])
+    clientMocks.getDingTalkDepartmentDetail.mockResolvedValue({ deptManagerUserIdList: [] })
+    clientMocks.listDingTalkDepartmentUsers.mockResolvedValue({ users: [], nextCursor: null, hasMore: false })
+    clientMocks.getDingTalkUserDetail.mockRejectedValue(new Error('empty tenant — no user details expected'))
+  })
+
+  afterAll(async () => {
+    for (const id of cleanupTransferIds.splice(0)) await query(`DELETE FROM provider_org_transfers WHERE id = $1`, [id])
+    // integration delete cascades its departments/accounts/runs
+    for (const id of cleanupIntegrationIds.splice(0)) await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
+  })
+
+  async function seedIntegrationWithLiveAccount(tag: string): Promise<{ integrationId: string; accountId: string }> {
+    const integration = await createDirectoryIntegration({
+      name: `t2-frz-${tag}-${TS}`,
+      corpId: `t2-frz-corp-${tag}-${TS}`,
+      appKey: `t2-frz-appkey-${tag}-${TS}`,
+      appSecret: 't2-frz-secret',
+      admissionMode: 'manual_only',
+    })
+    cleanupIntegrationIds.push(integration.id)
+    // A previously-synced account: present in the DB, ABSENT from the (empty) mocked tenant —
+    // precisely what an allowed sync's absence sweep would mark inactive.
+    const account = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, is_active, raw)
+       VALUES ($1, 'dingtalk', $2, $3, $4, true, '{}'::jsonb) RETURNING id`,
+      [integration.id, `t2-frz-${tag}-user-${TS}`, `dingtalk:t2-frz-${tag}-user-${TS}`, `T2 Freeze ${tag}`]
+    )
+    return { integrationId: integration.id, accountId: account.rows[0].id }
+  }
+
+  async function createTransferRow(sourceId: string, targetId: string, status = 'draft'): Promise<string> {
+    const row = await query<{ id: string }>(
+      `INSERT INTO provider_org_transfers (org_id, provider, source_integration_id, target_integration_id, status)
+       SELECT org_id, provider, $1, $2, $3 FROM directory_integrations WHERE id = $1
+       RETURNING id`,
+      [sourceId, targetId, status]
+    )
+    const id = row.rows[0].id
+    cleanupTransferIds.push(id)
+    return id
+  }
+
+  async function accountActive(accountId: string): Promise<boolean> {
+    const row = await query<{ is_active: boolean }>(`SELECT is_active FROM directory_accounts WHERE id = $1`, [accountId])
+    return row.rows[0].is_active
+  }
+
+  async function runCount(integrationId: string): Promise<number> {
+    const row = await query<{ n: string }>(`SELECT count(*)::text AS n FROM directory_sync_runs WHERE integration_id = $1`, [
+      integrationId,
+    ])
+    return Number(row.rows[0].n)
+  }
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('A. HEADLINE: an active transfer freezes the source — typed 409 error, NO run row, the absence sweep never fires', async () => {
+    const source = await seedIntegrationWithLiveAccount('a-src')
+    const target = await seedIntegrationWithLiveAccount('a-dst')
+    const transferId = await createTransferRow(source.integrationId, target.integrationId)
+
+    let caught: unknown = null
+    try {
+      await syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`)
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(DirectorySyncFrozenByTransferError)
+    expect((caught as DirectorySyncFrozenByTransferError).transferId).toBe(transferId)
+    expect((caught as DirectorySyncFrozenByTransferError).statusCode).toBe(409)
+
+    // Frozen BEFORE the lease claim: no run row exists at all — nothing dangling to reclaim.
+    expect(await runCount(source.integrationId)).toBe(0)
+    // And the destructive outcome never happened: the account the empty pull would sweep is live.
+    expect(await accountActive(source.accountId)).toBe(true)
+  })
+
+  it('B. admin override (freeze_source_sync=false): the SAME sync runs and the absence sweep proves it was destructive', async () => {
+    const source = await seedIntegrationWithLiveAccount('b-src')
+    const target = await seedIntegrationWithLiveAccount('b-dst')
+    const transferId = await createTransferRow(source.integrationId, target.integrationId)
+
+    await query(`UPDATE provider_org_transfers SET freeze_source_sync = false WHERE id = $1`, [transferId])
+
+    const result = await syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`)
+    expect(result.run.status).toBe('completed')
+    // The empty tenant swept the seeded account inactive — the very write test A blocked.
+    expect(await accountActive(source.accountId)).toBe(false)
+  })
+
+  it('C. a TERMINAL transfer does not freeze: cancelled → sync proceeds', async () => {
+    const source = await seedIntegrationWithLiveAccount('c-src')
+    const target = await seedIntegrationWithLiveAccount('c-dst')
+    await createTransferRow(source.integrationId, target.integrationId, 'cancelled')
+
+    const result = await syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`)
+    expect(result.run.status).toBe('completed')
+  })
+
+  it('D. only the SOURCE is frozen: the target integration syncs while the transfer is active', async () => {
+    const source = await seedIntegrationWithLiveAccount('d-src')
+    const target = await seedIntegrationWithLiveAccount('d-dst')
+    await createTransferRow(source.integrationId, target.integrationId)
+
+    const result = await syncDirectoryIntegration(target.integrationId, `t2-admin-${TS}`)
+    expect(result.run.status).toBe('completed')
+    // and the source remains frozen (typed error, run-free)
+    await expect(syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`)).rejects.toBeInstanceOf(
+      DirectorySyncFrozenByTransferError
+    )
+    expect(await runCount(source.integrationId)).toBe(0)
+  })
+
+  it('E. route mapping: manual sync trigger answers 409 DIRECTORY_SYNC_FROZEN_BY_TRANSFER with the transferId', async () => {
+    const source = await seedIntegrationWithLiveAccount('e-src')
+    const target = await seedIntegrationWithLiveAccount('e-dst')
+    const transferId = await createTransferRow(source.integrationId, target.integrationId)
+
+    const res = await request(adminApp).post(`/api/admin/directory/integrations/${source.integrationId}/sync`).send({})
+    expect(res.status).toBe(409)
+    expect(res.body.error.code).toBe('DIRECTORY_SYNC_FROZEN_BY_TRANSFER')
+    expect(res.body.error.details?.transferId ?? res.body.error.transferId).toBe(transferId)
+
+    // async opt-in branch maps identically
+    const asyncRes = await request(adminApp)
+      .post(`/api/admin/directory/integrations/${source.integrationId}/sync`)
+      .send({ async: true })
+    expect(asyncRes.status).toBe(409)
+    expect(asyncRes.body.error.code).toBe('DIRECTORY_SYNC_FROZEN_BY_TRANSFER')
+  })
+
+  it('F. preview stays available during a freeze (the read-only evidence tool writes nothing)', async () => {
+    const source = await seedIntegrationWithLiveAccount('f-src')
+    const target = await seedIntegrationWithLiveAccount('f-dst')
+    await createTransferRow(source.integrationId, target.integrationId)
+
+    const res = await request(adminApp).post(`/api/admin/directory/integrations/${source.integrationId}/sync/preview`).send({})
+    expect(res.status).toBe(200)
+    // preview reported the would-be sweep without performing it
+    expect(await accountActive(source.accountId)).toBe(true)
+    expect(await runCount(source.integrationId)).toBe(0)
+  })
+
+  it('does not confuse an unrelated integration id with a frozen one (freeze is source-scoped by id)', async () => {
+    const bystander = await seedIntegrationWithLiveAccount('bystander')
+    // No transfer references it at all — a sweep of the OTHER fixtures' transfers must not leak.
+    const result = await syncDirectoryIntegration(bystander.integrationId, `t2-admin-${TS}`)
+    expect(result.run.status).toBe('completed')
+  })
+})

--- a/packages/core-backend/tests/integration/directory-org-transfer-source-freeze.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-org-transfer-source-freeze.db.test.ts
@@ -189,6 +189,7 @@ describeIfDatabase('Transfer MVP T2 — §12.2 source freeze during an active or
       .send({ async: true })
     expect(asyncRes.status).toBe(409)
     expect(asyncRes.body.error.code).toBe('DIRECTORY_SYNC_FROZEN_BY_TRANSFER')
+    expect(asyncRes.body.error.details?.transferId ?? asyncRes.body.error.transferId).toBe(transferId)
   })
 
   it('F. preview stays available during a freeze (the read-only evidence tool writes nothing)', async () => {

--- a/packages/core-backend/tests/integration/directory-org-transfer-source-freeze.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-org-transfer-source-freeze.db.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto'
 import express from 'express'
+import { Client } from 'pg'
 import request from 'supertest'
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
@@ -15,6 +16,18 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest
 // Also hosts the composed T1+T2 proof: an unavailable-adapter scan failure must leave the
 // transfer non-terminal and the source freeze intact (no sync run, no absence sweep). And the
 // freeze-API contract surface (auth, allowlist, terminal/missing, refreeze, no audit on reject).
+//
+// P1 race closeout: two-connection barrier tests for create-vs-sync-apply and refreeze-vs-
+// sync-apply in both linearizations. A shared `pg_advisory_xact_lock` keyed by source
+// integration serializes freeze writers with the sync local-apply transaction; apply re-checks
+// active freeze under that lock before ANY local directory mutation. Barriers use
+// pg_blocking_pids / pg_stat_activity (no fixed race sleeps).
+//
+// Mutation proofs (independently red the race suite):
+//   - remove acquireSourceSyncFreezeLock from sync apply / create / refreeze → waiter never
+//     parks on the holder's advisory lock → waitUntilBlockedOnHolder times out
+//   - remove the apply-time assertDirectorySyncNotFrozenByTransfer recheck → freeze-wins
+//     races commit the absence sweep and deactivate the seeded live account
 //
 // DATABASE_URL-gated (describeIfDatabase): excluded from the no-DB vitest job so it cannot
 // skip-green, and wired as a WHOLE FILE into the approval real-DB step in plugin-tests.yml
@@ -41,7 +54,12 @@ import {
   DirectorySyncFrozenByTransferError,
   syncDirectoryIntegration,
 } from '../../src/directory/directory-sync'
-import { unregisterOrgTransferAdapter } from '../../src/directory/org-transfer-service'
+import {
+  createOrgTransfer,
+  setOrgTransferSourceSyncFreeze,
+  unregisterOrgTransferAdapter,
+} from '../../src/directory/org-transfer-service'
+import { sourceSyncFreezeLockKey } from '../../src/directory/source-sync-freeze-lock'
 import { adminDirectoryRouter } from '../../src/routes/admin-directory'
 import { adminDirectoryOrgTransfersRouter } from '../../src/routes/admin-directory-org-transfers'
 
@@ -66,6 +84,52 @@ nonAdminApp.use((req, _res, next) => {
   next()
 })
 nonAdminApp.use('/api/admin/directory/org-transfers', adminDirectoryOrgTransfersRouter())
+
+/** Dedicated raw connection for barrier lock-holders — never from the service pool. */
+async function withHolder(fn: (holder: Client, holderPid: number) => Promise<void>): Promise<void> {
+  const holder = new Client({ connectionString: process.env.DATABASE_URL })
+  await holder.connect()
+  try {
+    const pidRow = await holder.query<{ pid: number }>('SELECT pg_backend_pid() AS pid')
+    await fn(holder, pidRow.rows[0].pid)
+  } finally {
+    try {
+      await holder.query('ROLLBACK')
+    } catch {
+      /* already closed / idle */
+    }
+    await holder.end()
+  }
+}
+
+/**
+ * Deterministic barrier: poll until at least one backend is blocked by the holder's pid
+ * (pg_blocking_pids). Proves the waiter is parked on the holder's lock — not a fixed sleep.
+ */
+async function waitUntilBlockedOnHolder(holderPid: number, timeoutMs = 8000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const r = await query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM pg_stat_activity
+        WHERE state = 'active'
+          AND wait_event_type = 'Lock'
+          AND $1 = ANY(pg_blocking_pids(pid))`,
+      [holderPid],
+    )
+    if ((r.rows[0]?.n ?? 0) >= 1) return
+    await new Promise((res) => setTimeout(res, 20))
+  }
+  throw new Error(
+    `timed out waiting for a backend blocked by holder pid ${holderPid} (source freeze lock never engaged)`,
+  )
+}
+
+function settled<T>(p: Promise<T>): Promise<T | unknown> {
+  return p.then(
+    (v) => v,
+    (e) => e,
+  )
+}
 
 describeIfDatabase('Transfer MVP T2 — §12.2 source freeze during an active org transfer (real sync, mocked pull)', () => {
   const cleanupTransferIds: string[] = []
@@ -374,5 +438,175 @@ describeIfDatabase('Transfer MVP T2 — §12.2 source freeze during an active or
     await expect(syncDirectoryIntegration(liveSource.integrationId, `t2-admin-${TS}`)).rejects.toBeInstanceOf(
       DirectorySyncFrozenByTransferError
     )
+  })
+
+  // -------------------------------------------------------------------------------------------
+  // P1 race closeout — shared source freeze lock + apply-time recheck, both linearizations.
+  // -------------------------------------------------------------------------------------------
+
+  it('RACE create-wins: freeze INSERT holds source lock uncommitted → real sync parks → after commit apply rolls back (account stays live)', async () => {
+    const source = await seedIntegrationWithLiveAccount('race-cwin-src')
+    const target = await seedIntegrationWithLiveAccount('race-cwin-dst')
+
+    let transferId = ''
+    await withHolder(async (holder, holderPid) => {
+      // SQL STAND-IN for createOrgTransfer mid-flight: same advisory key + freeze-active INSERT,
+      // held open so the real sync's apply-time lock acquisition parks (entry check still sees
+      // no freeze under READ COMMITTED — the late-race window the lock closes).
+      await holder.query('BEGIN')
+      await holder.query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED')
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        sourceSyncFreezeLockKey(source.integrationId),
+      ])
+      const ins = await holder.query<{ id: string }>(
+        `INSERT INTO provider_org_transfers
+           (org_id, provider, source_integration_id, target_integration_id, status, freeze_source_sync)
+         SELECT org_id, provider, $1, $2, 'draft', true
+           FROM directory_integrations WHERE id = $1
+         RETURNING id`,
+        [source.integrationId, target.integrationId],
+      )
+      transferId = ins.rows[0].id
+      cleanupTransferIds.push(transferId)
+
+      const syncOutcome = settled(syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`))
+      await waitUntilBlockedOnHolder(holderPid)
+
+      await holder.query('COMMIT')
+
+      const outcome = await syncOutcome
+      expect(outcome).toBeInstanceOf(DirectorySyncFrozenByTransferError)
+      expect((outcome as DirectorySyncFrozenByTransferError).transferId).toBe(transferId)
+    })
+
+    // Local directory mutation must not commit after freeze linearized first.
+    expect(await accountActive(source.accountId)).toBe(true)
+    // Late-race honesty: lease was claimed after the entry check, so a failed run row may exist.
+    const runs = await query<{ status: string; n: string }>(
+      `SELECT status, count(*)::text AS n FROM directory_sync_runs
+        WHERE integration_id = $1 GROUP BY status`,
+      [source.integrationId],
+    )
+    const completed = runs.rows.find((r) => r.status === 'completed')
+    expect(completed).toBeUndefined()
+  })
+
+  it('RACE sync-wins vs create: apply stand-in holds source lock → real create parks → after release create freezes', async () => {
+    const source = await seedIntegrationWithLiveAccount('race-swin-c-src')
+    const target = await seedIntegrationWithLiveAccount('race-swin-c-dst')
+
+    await withHolder(async (holder, holderPid) => {
+      // SQL STAND-IN for sync local-apply mid-flight after lock acquisition (no freeze yet).
+      await holder.query('BEGIN')
+      await holder.query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED')
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        sourceSyncFreezeLockKey(source.integrationId),
+      ])
+
+      const createOutcome = settled(
+        createOrgTransfer({
+          provider: 'dingtalk',
+          sourceIntegrationId: source.integrationId,
+          targetIntegrationId: target.integrationId,
+          createdBy: FREEZE_ADMIN_ID,
+        }),
+      )
+      await waitUntilBlockedOnHolder(holderPid)
+
+      await holder.query('COMMIT')
+
+      const created = await createOutcome
+      expect(created).not.toBeInstanceOf(Error)
+      const transfer = created as Awaited<ReturnType<typeof createOrgTransfer>>
+      cleanupTransferIds.push(transfer.id)
+      expect(transfer.freezeSourceSync).toBe(true)
+      expect(transfer.sourceIntegrationId).toBe(source.integrationId)
+    })
+
+    // After create commits, the source is frozen for subsequent syncs.
+    await expect(syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`)).rejects.toBeInstanceOf(
+      DirectorySyncFrozenByTransferError,
+    )
+    expect(await accountActive(source.accountId)).toBe(true)
+  })
+
+  it('RACE refreeze-wins: freeze=true UPDATE holds source lock uncommitted → real sync parks → after commit apply rolls back', async () => {
+    const source = await seedIntegrationWithLiveAccount('race-rwin-src')
+    const target = await seedIntegrationWithLiveAccount('race-rwin-dst')
+    // Unfrozen active transfer: entry check passes; apply-time recheck must catch the refreeze.
+    const transferId = await createTransferRow(source.integrationId, target.integrationId)
+    await query(`UPDATE provider_org_transfers SET freeze_source_sync = false WHERE id = $1`, [transferId])
+
+    await withHolder(async (holder, holderPid) => {
+      await holder.query('BEGIN')
+      await holder.query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED')
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        sourceSyncFreezeLockKey(source.integrationId),
+      ])
+      await holder.query(
+        `UPDATE provider_org_transfers SET freeze_source_sync = true, updated_at = now() WHERE id = $1`,
+        [transferId],
+      )
+
+      const syncOutcome = settled(syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`))
+      await waitUntilBlockedOnHolder(holderPid)
+
+      await holder.query('COMMIT')
+
+      const outcome = await syncOutcome
+      expect(outcome).toBeInstanceOf(DirectorySyncFrozenByTransferError)
+      expect((outcome as DirectorySyncFrozenByTransferError).transferId).toBe(transferId)
+    })
+
+    expect(await accountActive(source.accountId)).toBe(true)
+    const flag = await query<{ freeze_source_sync: boolean }>(
+      `SELECT freeze_source_sync FROM provider_org_transfers WHERE id = $1`,
+      [transferId],
+    )
+    expect(flag.rows[0].freeze_source_sync).toBe(true)
+  })
+
+  it('RACE sync-wins vs refreeze: apply stand-in holds source lock → real refreeze parks → after release freeze is set', async () => {
+    const source = await seedIntegrationWithLiveAccount('race-swin-r-src')
+    const target = await seedIntegrationWithLiveAccount('race-swin-r-dst')
+    const transferId = await createTransferRow(source.integrationId, target.integrationId)
+    await query(`UPDATE provider_org_transfers SET freeze_source_sync = false WHERE id = $1`, [transferId])
+
+    await withHolder(async (holder, holderPid) => {
+      await holder.query('BEGIN')
+      await holder.query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED')
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        sourceSyncFreezeLockKey(source.integrationId),
+      ])
+
+      const refreezeOutcome = settled(setOrgTransferSourceSyncFreeze(transferId, true))
+      await waitUntilBlockedOnHolder(holderPid)
+
+      await holder.query('COMMIT')
+
+      const updated = await refreezeOutcome
+      expect(updated).not.toBeInstanceOf(Error)
+      expect((updated as Awaited<ReturnType<typeof setOrgTransferSourceSyncFreeze>>).freezeSourceSync).toBe(
+        true,
+      )
+    })
+
+    await expect(syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`)).rejects.toBeInstanceOf(
+      DirectorySyncFrozenByTransferError,
+    )
+    expect(await accountActive(source.accountId)).toBe(true)
+  })
+
+  it('positive control (unfrozen empty tenant): absence sweep deactivates a seeded live account when freeze is off', async () => {
+    // Standalone positive control for the race suite: empty mocked pull + unfrozen source must
+    // actually be destructive. Independent of the admin PATCH path covered in test B.
+    const source = await seedIntegrationWithLiveAccount('race-pos-src')
+    const target = await seedIntegrationWithLiveAccount('race-pos-dst')
+    const transferId = await createTransferRow(source.integrationId, target.integrationId)
+    await query(`UPDATE provider_org_transfers SET freeze_source_sync = false WHERE id = $1`, [transferId])
+
+    const result = await syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`)
+    expect(result.run.status).toBe('completed')
+    expect(await accountActive(source.accountId)).toBe(false)
   })
 })

--- a/packages/core-backend/tests/integration/directory-org-transfer-source-freeze.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-org-transfer-source-freeze.db.test.ts
@@ -1,16 +1,20 @@
 import { randomUUID } from 'crypto'
 import express from 'express'
 import request from 'supertest'
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 // Transfer MVP — T2 (§12.2 source freeze), real DB + the REAL syncDirectoryIntegration with a
 // mocked DingTalk client (the R1-L4 orchestration-harness pattern): nothing between this suite
 // and the sync orchestration except the network client. The mocked tenant is EMPTY, so any sync
 // that is allowed to run performs the destructive absence sweep — which is exactly the write the
-// freeze exists to stop. That makes the positive control honest: with the freeze bypassed (the
-// transfer row's freeze_source_sync=false admin override), the very same sync deactivates the
-// seeded account, proving test A's frozen sync was blocked from a REAL destructive outcome, not
-// from a no-op.
+// freeze exists to stop. That makes the positive control honest: with the freeze bypassed via the
+// supported platform-admin PATCH .../source-sync-freeze API (freezeSourceSync=false), the very
+// same sync deactivates the seeded account, proving test A's frozen sync was blocked from a REAL
+// destructive outcome, not from a no-op. The override path also proves one values-free audit row.
+//
+// Also hosts the composed T1+T2 proof: an unavailable-adapter scan failure must leave the
+// transfer non-terminal and the source freeze intact (no sync run, no absence sweep). And the
+// freeze-API contract surface (auth, allowlist, terminal/missing, refreeze, no audit on reject).
 //
 // DATABASE_URL-gated (describeIfDatabase): excluded from the no-DB vitest job so it cannot
 // skip-green, and wired as a WHOLE FILE into the approval real-DB step in plugin-tests.yml
@@ -37,18 +41,31 @@ import {
   DirectorySyncFrozenByTransferError,
   syncDirectoryIntegration,
 } from '../../src/directory/directory-sync'
+import { unregisterOrgTransferAdapter } from '../../src/directory/org-transfer-service'
 import { adminDirectoryRouter } from '../../src/routes/admin-directory'
+import { adminDirectoryOrgTransfersRouter } from '../../src/routes/admin-directory-org-transfers'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
 
+const FREEZE_ADMIN_ID = `t2-freeze-admin-${TS}`
+
 const adminApp = express()
 adminApp.use(express.json())
 adminApp.use((req, _res, next) => {
-  ;(req as express.Request & { user?: unknown }).user = { id: `t2-freeze-admin-${TS}`, role: 'admin' }
+  ;(req as express.Request & { user?: unknown }).user = { id: FREEZE_ADMIN_ID, role: 'admin' }
   next()
 })
 adminApp.use('/api/admin/directory', adminDirectoryRouter())
+adminApp.use('/api/admin/directory/org-transfers', adminDirectoryOrgTransfersRouter())
+
+const nonAdminApp = express()
+nonAdminApp.use(express.json())
+nonAdminApp.use((req, _res, next) => {
+  ;(req as express.Request & { user?: unknown }).user = { id: `t2-freeze-nonadmin-${TS}` }
+  next()
+})
+nonAdminApp.use('/api/admin/directory/org-transfers', adminDirectoryOrgTransfersRouter())
 
 describeIfDatabase('Transfer MVP T2 — §12.2 source freeze during an active org transfer (real sync, mocked pull)', () => {
   const cleanupTransferIds: string[] = []
@@ -63,11 +80,33 @@ describeIfDatabase('Transfer MVP T2 — §12.2 source freeze during an active or
     clientMocks.getDingTalkUserDetail.mockRejectedValue(new Error('empty tenant — no user details expected'))
   })
 
+  afterEach(() => {
+    // Composed T1+T2 case must not leave a leaked adapter registration for other suites.
+    unregisterOrgTransferAdapter('dingtalk')
+  })
+
   afterAll(async () => {
+    unregisterOrgTransferAdapter('dingtalk')
     for (const id of cleanupTransferIds.splice(0)) await query(`DELETE FROM provider_org_transfers WHERE id = $1`, [id])
     // integration delete cascades its departments/accounts/runs
     for (const id of cleanupIntegrationIds.splice(0)) await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
   })
+
+  async function freezeAuditCount(transferId: string): Promise<number> {
+    const result = await query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM audit_logs
+        WHERE action = 'directory.org_transfer.source_sync_freeze' AND resource_id = $1`,
+      [transferId]
+    )
+    return Number(result.rows[0].n)
+  }
+
+  async function orgTransferFreezeAuditTotal(): Promise<number> {
+    const result = await query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM audit_logs WHERE action = 'directory.org_transfer.source_sync_freeze'`
+    )
+    return Number(result.rows[0].n)
+  }
 
   async function seedIntegrationWithLiveAccount(tag: string): Promise<{ integrationId: string; accountId: string }> {
     const integration = await createDirectoryIntegration({
@@ -137,12 +176,17 @@ describeIfDatabase('Transfer MVP T2 — §12.2 source freeze during an active or
     expect(await accountActive(source.accountId)).toBe(true)
   })
 
-  it('B. admin override (freeze_source_sync=false): the SAME sync runs and the absence sweep proves it was destructive', async () => {
+  it('B. admin override via PATCH source-sync-freeze=false: SAME sync runs, absence sweep is destructive, one freeze audit', async () => {
     const source = await seedIntegrationWithLiveAccount('b-src')
     const target = await seedIntegrationWithLiveAccount('b-dst')
     const transferId = await createTransferRow(source.integrationId, target.integrationId)
 
-    await query(`UPDATE provider_org_transfers SET freeze_source_sync = false WHERE id = $1`, [transferId])
+    const unfreeze = await request(adminApp)
+      .patch(`/api/admin/directory/org-transfers/${transferId}/source-sync-freeze`)
+      .send({ freezeSourceSync: false })
+    expect(unfreeze.status).toBe(200)
+    expect(unfreeze.body.data.transfer.freezeSourceSync).toBe(false)
+    expect(await freezeAuditCount(transferId)).toBe(1)
 
     const result = await syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`)
     expect(result.run.status).toBe('completed')
@@ -209,5 +253,126 @@ describeIfDatabase('Transfer MVP T2 — §12.2 source freeze during an active or
     // No transfer references it at all — a sweep of the OTHER fixtures' transfers must not leak.
     const result = await syncDirectoryIntegration(bystander.integrationId, `t2-admin-${TS}`)
     expect(result.run.status).toBe('completed')
+  })
+
+  it('composed T1+T2: unavailable-adapter scan leaves source frozen — no sync run, absence sweep never executes', async () => {
+    // Deliberately NO adapter registration: production default for unregistered providers.
+    // After the typed scan failure the transfer stays non-terminal, so T2 freeze must still hold.
+    const source = await seedIntegrationWithLiveAccount('t1t2-src')
+    const target = await seedIntegrationWithLiveAccount('t1t2-dst')
+    const create = await request(adminApp)
+      .post('/api/admin/directory/org-transfers')
+      .send({
+        provider: 'dingtalk',
+        sourceIntegrationId: source.integrationId,
+        targetIntegrationId: target.integrationId,
+      })
+    expect(create.status).toBe(200)
+    const transferId = create.body.data.transfer.id as string
+    cleanupTransferIds.push(transferId)
+
+    const scan = await request(adminApp).post(`/api/admin/directory/org-transfers/${transferId}/scan`)
+    expect(scan.status).toBe(409)
+    expect(scan.body.error.code).toBe('ORG_TRANSFER_ADAPTER_UNAVAILABLE')
+
+    const row = await query<{ status: string; freeze_source_sync: boolean }>(
+      `SELECT status, freeze_source_sync FROM provider_org_transfers WHERE id = $1`,
+      [transferId]
+    )
+    expect(row.rows[0].status).toBe('draft') // still non-terminal
+    expect(row.rows[0].freeze_source_sync).toBe(true)
+
+    await expect(syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`)).rejects.toBeInstanceOf(
+      DirectorySyncFrozenByTransferError
+    )
+    expect(await runCount(source.integrationId)).toBe(0)
+    expect(await accountActive(source.accountId)).toBe(true)
+  })
+
+  it('source-sync-freeze API: platform-admin only; unknown fields / non-boolean type reject with no audit', async () => {
+    const source = await seedIntegrationWithLiveAccount('api-auth-src')
+    const target = await seedIntegrationWithLiveAccount('api-auth-dst')
+    const transferId = await createTransferRow(source.integrationId, target.integrationId)
+    const auditBefore = await orgTransferFreezeAuditTotal()
+
+    const denied = await request(nonAdminApp)
+      .patch(`/api/admin/directory/org-transfers/${transferId}/source-sync-freeze`)
+      .send({ freezeSourceSync: false })
+    expect(denied.status).toBeGreaterThanOrEqual(401)
+    expect(denied.status).toBeLessThanOrEqual(403)
+
+    const unknown = await request(adminApp)
+      .patch(`/api/admin/directory/org-transfers/${transferId}/source-sync-freeze`)
+      .send({ freezeSourceSync: false, orgId: 'evil' })
+    expect(unknown.status).toBe(400)
+    expect(unknown.body.error.code).toBe('ORG_TRANSFER_UNKNOWN_FIELDS')
+
+    for (const bad of [null, 'true', 1, { nested: true }, undefined]) {
+      const body =
+        bad === undefined ? {} : ({ freezeSourceSync: bad } as Record<string, unknown>)
+      const res = await request(adminApp)
+        .patch(`/api/admin/directory/org-transfers/${transferId}/source-sync-freeze`)
+        .send(body)
+      expect(res.status, String(bad)).toBe(400)
+      expect(res.body.error.code).toBe('ORG_TRANSFER_INVALID_INPUT')
+    }
+
+    // Flag untouched; no freeze audit written for any rejected mutation.
+    const row = await query<{ freeze_source_sync: boolean }>(
+      `SELECT freeze_source_sync FROM provider_org_transfers WHERE id = $1`,
+      [transferId]
+    )
+    expect(row.rows[0].freeze_source_sync).toBe(true)
+    expect(await orgTransferFreezeAuditTotal()).toBe(auditBefore)
+    expect(await freezeAuditCount(transferId)).toBe(0)
+  })
+
+  it('source-sync-freeze API: missing 404, terminal 409, no audit; unfreeze + refreeze works with audits', async () => {
+    const auditBefore = await orgTransferFreezeAuditTotal()
+
+    const missing = await request(adminApp)
+      .patch(`/api/admin/directory/org-transfers/${randomUUID()}/source-sync-freeze`)
+      .send({ freezeSourceSync: false })
+    expect(missing.status).toBe(404)
+    expect(missing.body.error.code).toBe('ORG_TRANSFER_NOT_FOUND')
+
+    const source = await seedIntegrationWithLiveAccount('api-term-src')
+    const target = await seedIntegrationWithLiveAccount('api-term-dst')
+    const terminalId = await createTransferRow(source.integrationId, target.integrationId, 'cancelled')
+    const terminal = await request(adminApp)
+      .patch(`/api/admin/directory/org-transfers/${terminalId}/source-sync-freeze`)
+      .send({ freezeSourceSync: false })
+    expect(terminal.status).toBe(409)
+    expect(terminal.body.error.code).toBe('ORG_TRANSFER_INVALID_STATE')
+
+    expect(await orgTransferFreezeAuditTotal()).toBe(auditBefore)
+
+    // Happy path + refreeze (idempotent true after false).
+    const liveSource = await seedIntegrationWithLiveAccount('api-refreeze-src')
+    const liveTarget = await seedIntegrationWithLiveAccount('api-refreeze-dst')
+    const liveId = await createTransferRow(liveSource.integrationId, liveTarget.integrationId)
+
+    const unfreeze = await request(adminApp)
+      .patch(`/api/admin/directory/org-transfers/${liveId}/source-sync-freeze`)
+      .send({ freezeSourceSync: false })
+    expect(unfreeze.status).toBe(200)
+    expect(unfreeze.body.data.transfer.freezeSourceSync).toBe(false)
+    expect(await freezeAuditCount(liveId)).toBe(1)
+
+    // While unfrozen, sync is allowed (positive control for the flag).
+    const mid = await syncDirectoryIntegration(liveSource.integrationId, `t2-admin-${TS}`)
+    expect(mid.run.status).toBe('completed')
+
+    const refreeze = await request(adminApp)
+      .patch(`/api/admin/directory/org-transfers/${liveId}/source-sync-freeze`)
+      .send({ freezeSourceSync: true })
+    expect(refreeze.status).toBe(200)
+    expect(refreeze.body.data.transfer.freezeSourceSync).toBe(true)
+    expect(await freezeAuditCount(liveId)).toBe(2)
+
+    // After refreeze the source is frozen again.
+    await expect(syncDirectoryIntegration(liveSource.integrationId, `t2-admin-${TS}`)).rejects.toBeInstanceOf(
+      DirectorySyncFrozenByTransferError
+    )
   })
 })

--- a/packages/core-backend/tests/integration/provider-org-transfer-t1.api.test.ts
+++ b/packages/core-backend/tests/integration/provider-org-transfer-t1.api.test.ts
@@ -339,6 +339,9 @@ describeIfDatabase('Transfer MVP T1 — provider org-transfer schema + admin API
       request(nonAdminApp).post(`/api/admin/directory/org-transfers/${probeId}/apply?dryRun=true`),
       request(nonAdminApp).post(`/api/admin/directory/org-transfers/${probeId}/apply`),
       request(nonAdminApp).post(`/api/admin/directory/org-transfers/${probeId}/cancel`),
+      request(nonAdminApp)
+        .patch(`/api/admin/directory/org-transfers/${probeId}/source-sync-freeze`)
+        .send({ freezeSourceSync: false }),
     ]) {
       const res = await probe
       expect(res.status).toBeGreaterThanOrEqual(401)

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -68,6 +68,13 @@ vi.mock('../../src/directory/directory-sync', async (importOriginal) => ({
   // failure modes neuter exactly the mapping the 409 tests below pin.
   DirectorySyncInProgressError: (await importOriginal<typeof import('../../src/directory/directory-sync')>())
     .DirectorySyncInProgressError,
+  // T2 (§12.2): the same route catch also discriminates
+  // `error instanceof DirectorySyncFrozenByTransferError`. Re-export the REAL class
+  // (constructor identity) for the same factory-trap reason — a local stand-in would
+  // make production freeze errors fall through to 500, and omitting it throws on
+  // every error path that reaches the catch (including the async pre-run-row failure).
+  DirectorySyncFrozenByTransferError: (await importOriginal<typeof import('../../src/directory/directory-sync')>())
+    .DirectorySyncFrozenByTransferError,
   acknowledgeDirectorySyncAlert: directoryMocks.acknowledgeDirectorySyncAlert,
   admitDirectoryAccountUser: directoryMocks.admitDirectoryAccountUser,
   batchAdmitDirectoryAccountUsers: directoryMocks.batchAdmitDirectoryAccountUsers,

--- a/packages/core-backend/tests/unit/directory-sync-run-lease.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-run-lease.test.ts
@@ -160,6 +160,9 @@ describe('DT-HARDEN-05 directory sync run lease', () => {
     pgMocks.query
       // getIntegrationRow
       .mockResolvedValueOnce({ rows: [INTEGRATION_ROW] })
+      // T2 freeze gate (migrated schema present, no active frozen transfer)
+      .mockResolvedValueOnce({ rows: [{ reg: 'provider_org_transfers' }] }) // to_regclass
+      .mockResolvedValueOnce({ rows: [] }) // active frozen-transfer SELECT
       // reclaimStaleDirectorySyncRuns → nothing stale
       .mockResolvedValueOnce({ rows: [] })
       // claimDirectorySyncRun → another run holds the lease
@@ -178,6 +181,8 @@ describe('DT-HARDEN-05 directory sync run lease', () => {
   it('carries the active run id so the caller can observe the run in flight', async () => {
     pgMocks.query
       .mockResolvedValueOnce({ rows: [INTEGRATION_ROW] })
+      .mockResolvedValueOnce({ rows: [{ reg: 'provider_org_transfers' }] })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockRejectedValueOnce(uniqueViolation())
       .mockResolvedValueOnce({ rows: [{ id: 'run-active' }] })
@@ -191,23 +196,36 @@ describe('DT-HARDEN-05 directory sync run lease', () => {
   it('reclaims the lease before claiming it, so a crashed run cannot wedge an integration', async () => {
     pgMocks.query
       .mockResolvedValueOnce({ rows: [INTEGRATION_ROW] })
+      // T2 freeze gate: migrated schema present, no active freeze — both queries must
+      // precede reclaim, which must precede claim (indexes below pin that order).
+      .mockResolvedValueOnce({ rows: [{ reg: 'provider_org_transfers' }] })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ id: 'stale-run' }] }) // reclaim
       .mockRejectedValueOnce(uniqueViolation())
       .mockResolvedValueOnce({ rows: [{ id: 'run-active' }] })
 
     await expect(syncDirectoryIntegration('dir-1', 'admin-1', 'manual')).rejects.toBeInstanceOf(DirectorySyncInProgressError)
 
-    const reclaimCall = pgMocks.query.mock.calls[1]
+    // Freeze-gate SQL shapes: to_regclass then active frozen-transfer SELECT.
+    expect(String(pgMocks.query.mock.calls[1][0])).toContain("to_regclass('provider_org_transfers')")
+    expect(String(pgMocks.query.mock.calls[2][0])).toContain('FROM provider_org_transfers')
+    expect(String(pgMocks.query.mock.calls[2][0])).toContain('freeze_source_sync')
+
+    const reclaimCall = pgMocks.query.mock.calls[3]
     expect(String(reclaimCall[0])).toContain('UPDATE directory_sync_runs')
     expect(String(reclaimCall[0])).toContain("status = 'running'")
-    // Reclaim strictly precedes the claim.
-    expect(String(pgMocks.query.mock.calls[2][0])).toContain('INSERT INTO directory_sync_runs')
+    // Reclaim strictly precedes the claim (and freeze-gate strictly precedes reclaim).
+    expect(String(pgMocks.query.mock.calls[4][0])).toContain('INSERT INTO directory_sync_runs')
   })
 
   it('propagates a non-unique-violation insert error unchanged', async () => {
     pgMocks.query
       .mockResolvedValueOnce({ rows: [INTEGRATION_ROW] })
+      // Same migrated-schema freeze gate as the lease-conflict path above so this rejection
+      // still lands on claim/INSERT rather than the freeze SELECT or reclaim.
+      .mockResolvedValueOnce({ rows: [{ reg: 'provider_org_transfers' }] })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] }) // reclaim
       .mockRejectedValueOnce(new Error('connection reset'))
 
     await expect(syncDirectoryIntegration('dir-1', 'admin-1', 'manual')).rejects.toThrow('connection reset')

--- a/packages/core-backend/tests/unit/directory-sync-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-scheduler.test.ts
@@ -34,11 +34,15 @@ vi.mock('../../src/directory/directory-sync', async (importOriginal) => ({
   // DT-HARDEN-05 guard in this file was unfalsifiable.
   DirectorySyncInProgressError: (await importOriginal<typeof import('../../src/directory/directory-sync')>())
     .DirectorySyncInProgressError,
+  // T2 (§12.2): runScheduledSync discriminates the frozen-source skip the same way — the REAL
+  // class again, for the same factory-trap reason.
+  DirectorySyncFrozenByTransferError: (await importOriginal<typeof import('../../src/directory/directory-sync')>())
+    .DirectorySyncFrozenByTransferError,
   syncDirectoryIntegration: directoryMocks.syncDirectoryIntegration,
   reclaimStaleDirectorySyncRuns: directoryMocks.reclaimStaleDirectorySyncRuns,
 }))
 
-import { DirectorySyncInProgressError } from '../../src/directory/directory-sync'
+import { DirectorySyncFrozenByTransferError, DirectorySyncInProgressError } from '../../src/directory/directory-sync'
 import {
   refreshDirectoryIntegrationSchedule,
   resetDirectorySyncSchedulerForTests,
@@ -213,6 +217,13 @@ describe('directory-sync-scheduler', () => {
     const scheduleHandler = scheduler.schedule.mock.calls[0][2] as () => Promise<void>
 
     directoryMocks.syncDirectoryIntegration.mockRejectedValueOnce(new DirectorySyncInProgressError('run-held'))
+    await expect(scheduleHandler()).resolves.toBeUndefined()
+    expect(alertDeliveryMocks.deliverDirectoryInactiveLinkedAlert).not.toHaveBeenCalled()
+
+    // T2 (§12.2, gate P2): a frozen source is the multi-day steady state of an active transfer —
+    // every nightly tick must be a quiet skip, never a job:failed the alerting pages on. Removing
+    // the frozen-skip branch in runScheduledSync turns this leg into a rejection.
+    directoryMocks.syncDirectoryIntegration.mockRejectedValueOnce(new DirectorySyncFrozenByTransferError('transfer-held'))
     await expect(scheduleHandler()).resolves.toBeUndefined()
     expect(alertDeliveryMocks.deliverDirectoryInactiveLinkedAlert).not.toHaveBeenCalled()
 

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -187,12 +187,13 @@ export default defineConfig({
       // points asserted by t1-org-transfer-ci-wiring.test.mjs).
       'tests/integration/provider-org-transfer-t1.api.test.ts',
       // Transfer MVP T2 (§12.2): an ACTIVE org transfer freezes its source integration's sync —
-      // typed 409 before the lease claim, zero run rows, the destructive absence sweep provably
-      // blocked (freeze_source_sync=false override = positive control), scheduler/route mapping.
-      // Drives the REAL syncDirectoryIntegration with a mocked DingTalk client against real
-      // Postgres. DATABASE_URL-gated; excluded here so the no-DB job cannot skip-green it, and
-      // wired as a WHOLE FILE into the approval real-DB step in plugin-tests.yml (both points
-      // asserted by t2-source-freeze-ci-wiring.test.mjs).
+      // typed 409 before the lease claim, zero run rows on entry freeze, the destructive absence
+      // sweep provably blocked (freeze_source_sync=false override = positive control),
+      // scheduler/route mapping, plus two-connection advisory-lock barriers for create/refreeze
+      // vs sync-apply linearization. Drives the REAL syncDirectoryIntegration with a mocked
+      // DingTalk client against real Postgres. DATABASE_URL-gated; excluded here so the no-DB
+      // job cannot skip-green it, and wired as a WHOLE FILE into the approval real-DB step in
+      // plugin-tests.yml (both points asserted by t2-source-freeze-ci-wiring.test.mjs).
       'tests/integration/directory-org-transfer-source-freeze.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
       // resolution against real Postgres — normalized `is_manager` relation for a local integration,

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -186,6 +186,14 @@ export default defineConfig({
       // it, and wired as a WHOLE FILE into the directory real-DB step in plugin-tests.yml (both
       // points asserted by t1-org-transfer-ci-wiring.test.mjs).
       'tests/integration/provider-org-transfer-t1.api.test.ts',
+      // Transfer MVP T2 (§12.2): an ACTIVE org transfer freezes its source integration's sync —
+      // typed 409 before the lease claim, zero run rows, the destructive absence sweep provably
+      // blocked (freeze_source_sync=false override = positive control), scheduler/route mapping.
+      // Drives the REAL syncDirectoryIntegration with a mocked DingTalk client against real
+      // Postgres. DATABASE_URL-gated; excluded here so the no-DB job cannot skip-green it, and
+      // wired as a WHOLE FILE into the approval real-DB step in plugin-tests.yml (both points
+      // asserted by t2-source-freeze-ci-wiring.test.mjs).
+      'tests/integration/directory-org-transfer-source-freeze.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
       // resolution against real Postgres — normalized `is_manager` relation for a local integration,
       // the DingTalk `leader_in_dept` regression pin (load-bearing compat leg + is_manager=0 positive

--- a/scripts/ops/t2-source-freeze-ci-wiring.test.mjs
+++ b/scripts/ops/t2-source-freeze-ci-wiring.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// T2 CI two-point wiring contract. The source-freeze suite proves an ACTIVE org transfer freezes
+// its source integration's sync (typed 409 before the lease claim, zero run rows, the destructive
+// absence sweep provably blocked — with the freeze_source_sync=false override as the positive
+// control) against the REAL syncDirectoryIntegration + real Postgres — meaningless without a DB.
+// It needs BOTH (1) the vitest.config.ts exclude entry (so the no-DB job cannot skip-green it)
+// AND (2) the plugin-tests.yml approval real-DB whole-file step. Removing either point silently
+// disables the §12.2 freeze proof while CI stays green. Runs in the gating no-DB test job.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/directory-org-transfer-source-freeze.db.test.ts'
+
+test('vitest.config.ts excludes the T2 source-freeze suite from the no-DB job', () => {
+  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE} (DATABASE_URL-gated whole file)`)
+})
+
+test('plugin-tests.yml runs the T2 source-freeze suite as a whole file in a real-DB step', () => {
+  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  assert.match(wf, new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${FILE} in a real-DB step`)
+})


### PR DESCRIPTION
## T2 - source sync freeze (Transfer MVP slice 2)

> **UNARMED while exact-head CI runs.** T1 landed as `b9b354a38`; the production slice was replayed onto that merge without semantic drift (`git range-diff`: 6/6 commits `=`). Exact review head: `8b8f8ffde`; its final commit is test-only CI compatibility over production head `63875c021`.

An active org transfer freezes its source integration before directory sync claims a lease. A shared transaction-scoped PostgreSQL advisory lock also closes the create/refreeze-vs-sync apply race, so a freeze that linearizes first cannot be followed by committed local-directory writes.

### Runtime behavior

- Entry gate: an active frozen transfer throws typed `409 DIRECTORY_SYNC_FROZEN_BY_TRANSFER` before the run lease, producing no run row and no provider pull.
- Apply gate: the local-apply transaction acquires the source freeze advisory lock as its first operation and rechecks frozen state before every directory upsert, absence sweep, membership/identity/link write, projection, deprovision, or completion write.
- Freeze writers: transfer create and `freezeSourceSync=true` refreeze take the same lock before persisting freeze-affecting state.
- Linearization: apply-first may commit before freeze activates; freeze-first makes apply roll back. A late freeze can still leave a failed run row/provider pull, but no local-directory mutation commits after the freeze.
- Scheduler ticks treat the typed freeze as a deliberate quiet skip. Read-only preview remains available.
- A pre-T1 schema is detected with `to_regclass`; no transfer table means no transfer can freeze a sync.

### Operator override

`PATCH /api/admin/directory/org-transfers/:id/source-sync-freeze`

The platform-admin-only body contract is exactly `{ "freezeSourceSync": boolean }`. Unknown fields, arrays, wrong types, missing transfers, and terminal transfers fail closed and write no success audit. Successful changes write one values-free `directory.org_transfer.source_sync_freeze` audit row.

### Independent verification at exact head `8b8f8ffde`

Production behavior was verified at `63875c021`, then the test-only compatibility commit `8b8f8ffde` was independently rechecked:

- Fresh PostgreSQL full migration chain and second replay: pass.
- T1 + T2 real-DB suites: 38/38.
- T1 + T2 + sync lease + orchestration: 54/54.
- Exact affected unit files after the compatibility fix: 117/117; scheduler: 12/12.
- Full backend unit lane at `8b8f8ffde`: 415 files / 5748 tests; backend type-check: pass.
- The compatibility commit changes only two pre-existing test files. It re-exports the real typed freeze error from a partial route mock and models the T1/T2 schema-probe/freeze-query order in positional lease mocks; production code is unchanged.
- Mutation checks: removing the class re-export makes the async route-error case red; removing the freeze-query mock responses makes the lease reclaim case red at the wrong query stage.
- Exact-head required GitHub CI is authoritative before landing.

### Load-bearing production mutations replayed by Codex

Each mutation was applied alone and restored before the next:

- Remove apply-time frozen-state recheck: both freeze-first race legs red; sync committed instead of throwing.
- Remove sync apply advisory lock: create-first barrier red because sync never parked.
- Remove create advisory lock: apply-first barrier red because create never parked.
- Remove refreeze advisory lock: apply-first barrier red because refreeze never parked.
- Remove the entry gate: headline test red with one run row instead of zero.
- Remove scheduler frozen-skip branch: scheduler test red with a rejected tick.
- Remove PATCH field allowlist: body-smuggling test red (`200` instead of `400`).

### Scope boundary

This closes T2's code-side source-freeze invariant. It does not claim the staging dual-corp collision decision, conditional T2.5 tenant-key migration, or T3-T5 transfer apply work; those remain behind T2-Gate evidence.
