### PR TITLE
test(directory): T2-Gate collision mechanism and two-corp staging runbook

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -216,6 +216,16 @@ jobs:
       - name: T2 source-freeze CI wiring contract
         run: node --test scripts/ops/t2-source-freeze-ci-wiring.test.mjs
 
+      # T2-Gate CI contracts (no DB): (1) collision-mechanism suite two-point wiring —
+      # exact quoted path inside test.exclude + whole-file arg inside the named
+      # "Run approval real-DB integration" step (DATABASE_URL + vitest.integration.config.ts);
+      # (2) values-free runbook contract — closed booleans only (duplicate_key_detected /
+      # expected_constraint_detected), never raw error_message / err-head; provenance
+      # (SHA, date/actor, internal integration ids) is allowed.
+      # Dropping either contract silently disables the §3.4 mechanism/evidence gate.
+      - name: T2-Gate collision-mechanism CI wiring contract
+        run: node --test scripts/ops/t2gate-collision-mechanism-ci-wiring.test.mjs scripts/ops/t2gate-runbook-values-free-contract.test.mjs
+
       # The production monitor invokes the same state helper covered here.
       # Keep this in the required 18/20 matrix so HTTP classification, silence
       # barriers, and alert/recovery streak semantics cannot drift silently.
@@ -684,6 +694,7 @@ jobs:
             tests/integration/directory-tenant-change-immutable.db.test.ts \
             tests/integration/directory-sync-orchestration.db.test.ts \
             tests/integration/directory-org-transfer-source-freeze.db.test.ts \
+            tests/integration/directory-account-external-key-collision-mechanism.db.test.ts \
             tests/integration/directory-sync-schedule-timezone.db.test.ts \
             tests/integration/directory-local-provider-bootstrap.db.test.ts \
             tests/integration/directory-local-provider-scheduler-exclusion.db.test.ts \

--- a/docs/development/canonical-org-t2-gate-two-corp-staging-runbook-20260717.md
+++ b/docs/development/canonical-org-t2-gate-two-corp-staging-runbook-20260717.md
@@ -1,0 +1,132 @@
+# T2-Gate — Two-Corp Coexistence Proof · Staging Runbook (2026-07-17)
+
+Milestone: Canonical Org & Provider Transfer v1, Transfer MVP row **T2-Gate**（§3.4 of
+`provider-org-transfer-development-plan-20260709.md`; sequencing per
+`canonical-org-provider-transfer-v1-mvp-implementation-plan-20260713.md` §2）。
+Owner ruling (2026-07-16): **T2.5 is an explicit decision branch** — a CONFIRMED collision requires
+the tenant-scoped key migration `(provider, tenant_key, external_key)` to land **before any T3
+work**; a DISPROVED collision skips T2.5 and unlocks T3; **anything INCONCLUSIVE keeps T3 frozen**.
+
+## 0. What is already proven vs what only staging can prove
+
+**Proven in CI, permanently** (suite
+`directory-account-external-key-collision-mechanism.db.test.ts`, real sync + real Postgres):
+
+1. `directory_accounts` is UNIQUE on `(provider, external_key)`
+   (`idx_directory_accounts_provider_external_key`) — same key across two integrations is
+   **uninsertable**; distinct keys coexist.
+2. The sync derives `external_key` as the **bare `unionId || openId || userId`** — no corp
+   scoping (`directory-sync.ts`, account upsert loop).
+3. The account upsert loop has **no per-account savepoint**, so a cross-corp collision does not
+   skip one account — it aborts the apply transaction and the **second corp's sync run FAILS
+   wholesale** (`status='failed'`, with server-side classification
+   `duplicate_key_detected=true` AND `expected_constraint_detected=true` for
+   `idx_directory_accounts_provider_external_key`), with **zero** rows written for that corp.
+
+**Only staging can prove** (this runbook): whether real DingTalk actually hands the same person
+the same `unionId` across two different corps for our app identity. That is a provider-behavior
+fact, not a schema fact — the sandbox cannot create real corps. **Do not fabricate or simulate a
+staging verdict** — leave §4 TBD until owner/ops execute against real two-corp staging.
+
+## 1. Prerequisites (ops)
+
+- Staging deploy at a recorded **exact SHA** (write it into §4's evidence block).
+- **Two real DingTalk corps** (A and B) with app credentials each, and **one real person who is a
+  member of BOTH corps** (the "overlap person").
+- Platform-admin access to staging's directory admin API; read access to the staging Postgres.
+- The staging DB migrated through the current main (no pending directory migrations).
+
+## 2. Procedure (values-free evidence)
+
+**Values-free** here means: no raw **provider identity** (unionId / openId / userId / corpId),
+no **business values**, and no **raw SQL error text** (PostgreSQL duplicate-key messages can
+embed the real `external_key` / `unionId`). SQL outputs stay **booleans / counts / statuses**
+only.
+
+**Provenance is allowed** (and required in §4): exact staging **SHA**, **execution date /
+actor**, and **internal integration resource IDs** (platform `directory_integrations.id` for
+corps A and B). Those are not provider secrets or business values.
+
+1. Create integration A (corp A credentials), run a sync, confirm `status='completed'`.
+2. Record the overlap person's key shape under A (values-free — length/equality booleans only;
+   do **not** paste provider union/open/user IDs into the evidence pack):
+   ```sql
+   SELECT length(external_key) AS key_len,
+          (union_id IS NOT NULL) AS has_union,
+          (external_key = union_id) AS key_is_bare_union
+     FROM directory_accounts
+    WHERE integration_id = '<A>' AND external_user_id = '<overlap userId in A>';
+   ```
+3. Create integration B (corp B credentials), run a sync.
+4. Read the outcome — **closed classifications only**. PostgreSQL duplicate-key text can embed
+   the real `external_key` / `unionId`; **never** project, print, grep, copy, or persist
+   `error_message` / err-head into the evidence pack. Derive booleans server-side and record
+   only the booleans + status:
+   ```sql
+   SELECT status,
+          (error_message IS NOT NULL
+            AND position('duplicate key' in error_message) > 0) AS duplicate_key_detected,
+          (error_message IS NOT NULL
+            AND position('idx_directory_accounts_provider_external_key' in error_message) > 0)
+            AS expected_constraint_detected
+     FROM directory_sync_runs
+    WHERE integration_id = '<B>'
+    ORDER BY started_at DESC LIMIT 1;
+   ```
+   And the cross-corp key comparison:
+   ```sql
+   SELECT count(*) FILTER (WHERE integration_id = '<A>') AS corp_a_rows,
+          count(*) FILTER (WHERE integration_id = '<B>') AS corp_b_rows,
+          count(DISTINCT external_key) AS distinct_keys
+     FROM directory_accounts
+    WHERE integration_id IN ('<A>', '<B>');
+   ```
+   And the OVERLAP PERSON's presence on each side (the row-2/row-3 discriminator — values-free):
+   ```sql
+   SELECT (count(*) FILTER (WHERE integration_id = '<A>' AND external_user_id = '<overlap userId in A>')) AS present_in_a,
+          (count(*) FILTER (WHERE integration_id = '<B>' AND external_user_id = '<overlap userId in B>')) AS present_in_b,
+          (count(DISTINCT external_key) = count(*)) AS keys_all_distinct
+     FROM directory_accounts
+    WHERE (integration_id = '<A>' AND external_user_id = '<overlap userId in A>')
+       OR (integration_id = '<B>' AND external_user_id = '<overlap userId in B>');
+   ```
+
+## 3. Decision matrix (owner ruling 2026-07-16)
+
+| Observation | Verdict | Consequence |
+|---|---|---|
+| Corp-B run `status='failed'`, `duplicate_key_detected=true`, `expected_constraint_detected=true`; corp B row count 0 | **Collision CONFIRMED** | **T2.5 MUST land before T3**: tenant-scoped key migration `(provider, tenant_key, external_key)` + backfill + uniqueness proof on staging data |
+| Both runs `completed`; presence query shows `present_in_a=1 AND present_in_b=1 AND keys_all_distinct=true` | **Collision DISPROVED** | T2.5 skipped; **T3 unlocked** (owner-accepted disproof only) |
+| Both runs `completed` but `present_in_b=0` (overlap person missing under corp B), or any other shape (including failed without both closed classifications true) | **Inconclusive** | **T3 remains frozen** — capture the full values-free evidence and return to the owner |
+
+Either way, attach provenance + closed SQL outputs: staging SHA, execution date/actor, internal
+integration resource IDs, the SQL outputs (**booleans/counts/statuses only**), run timestamps.
+**No** names, raw provider union/open/user IDs, DingTalk corp IDs, credentials, URLs, SQL error
+strings, or business values in operator evidence.
+
+## 4. Evidence block (fill at execution — leave TBD until real two-corp staging; do not simulate)
+
+```
+staging SHA:                    _TBD_
+executed by / date:             _TBD_
+corp A integration id:          _TBD_
+corp B integration id:          _TBD_
+corp A run status:              _TBD_ (completed|failed|…)
+corp B run status:              _TBD_ (completed|failed|…)
+corp B duplicate_key_detected:  _TBD_ (true|false)
+corp B expected_constraint_detected: _TBD_ (true|false)
+key comparison:                 _TBD_ (corp_a_rows / corp_b_rows / distinct_keys)
+presence:                       _TBD_ (present_in_a / present_in_b / keys_all_distinct)
+verdict:                        _TBD_ (CONFIRMED / DISPROVED / INCONCLUSIVE)
+```
+
+## 5. Cleanup / rollback
+
+- The proof writes only `directory_integrations` / `directory_accounts` / `directory_departments`
+  / `directory_sync_runs` rows under the two new integrations. Removing both integration rows
+  cascades all of it away (archive-not-delete does not apply to a staging proof fixture).
+- If corp B's failed sync left alerting noise, note the **closed classification** (failed +
+  both booleans true) in the evidence block — that is the EXPECTED confirmed-collision
+  signature, not an incident. Do **not** paste the raw `error_message`.
+- **Do not** attempt the proof against production corps, and do not leave either staging
+  integration `sync_enabled` on a schedule after the proof.

--- a/packages/core-backend/tests/integration/directory-account-external-key-collision-mechanism.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-account-external-key-collision-mechanism.db.test.ts
@@ -1,0 +1,246 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+// T2-Gate EVIDENCE TOOLING (§3.4) — the DB-LEVEL half of the two-corp coexistence question.
+//
+// §3.4's open question is staging-gated: only two REAL DingTalk corps can show whether the
+// provider hands the same person the same provider-level identity (unionId) in both corps. What
+// this suite proves — permanently, in CI — is the MECHANISM that makes that question load-bearing:
+//
+//   1. `directory_accounts` is UNIQUE on (provider, external_key)
+//      [idx_directory_accounts_provider_external_key], and
+//   2. the sync derives external_key WITHOUT corp scoping — `unionId || openId || userId`
+//      (directory-sync.ts account upsert) — and
+//   3. the account upsert loop has NO per-account savepoint, so a cross-corp collision does not
+//      skip one account: it aborts the whole apply transaction and the SECOND corp's sync run
+//      FAILS wholesale — including department rows upserted earlier in the same apply (not just
+//      accounts).
+//
+// Together: IF staging shows equal unionIds across corps, coexistence is impossible today and the
+// collision signature is a failed corp-B sync run whose closed classifications are
+// duplicate_key_detected + expected_constraint_detected (idx_directory_accounts_provider_external_key)
+// — which is exactly what the staging runbook
+// (canonical-org-t2-gate-two-corp-staging-runbook-20260717.md) tells ops to record (never raw
+// error_message / err-head — PostgreSQL duplicate-key text can embed the real external_key), and
+// what T2.5's tenant-scoped key migration would fix. If staging shows distinct unionIds, the
+// contrast leg here (distinct keys coexist, both syncs complete) is the shape ops should observe.
+//
+// DATABASE_URL-gated (describeIfDatabase): excluded from the no-DB vitest job so it cannot
+// skip-green, and wired as a WHOLE FILE into the approval real-DB step in plugin-tests.yml
+// (both points asserted by t2gate-collision-mechanism-ci-wiring.test.mjs).
+const clientMocks = vi.hoisted(() => ({
+  fetchDingTalkAppAccessToken: vi.fn(),
+  listDingTalkDepartments: vi.fn(),
+  getDingTalkDepartmentDetail: vi.fn(),
+  listDingTalkDepartmentUsers: vi.fn(),
+  getDingTalkUserDetail: vi.fn(),
+}))
+
+vi.mock('../../src/integrations/dingtalk/client', () => ({
+  fetchDingTalkAppAccessToken: clientMocks.fetchDingTalkAppAccessToken,
+  listDingTalkDepartments: clientMocks.listDingTalkDepartments,
+  getDingTalkDepartmentDetail: clientMocks.getDingTalkDepartmentDetail,
+  listDingTalkDepartmentUsers: clientMocks.listDingTalkDepartmentUsers,
+  getDingTalkUserDetail: clientMocks.getDingTalkUserDetail,
+}))
+
+import { query } from '../../src/db/pg'
+import { createDirectoryIntegration, syncDirectoryIntegration } from '../../src/directory/directory-sync'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+/** One root department with one user; the user's identity fields are per-test knobs. */
+type MockTenant = { unionId?: string; openId?: string; userId: string; name: string }
+let activeTenant: MockTenant | null = null
+
+describeIfDatabase('T2-Gate evidence — directory_accounts (provider, external_key) collision mechanism (real sync, mocked pull)', () => {
+  const cleanupIntegrationIds: string[] = []
+
+  beforeAll(() => {
+    clientMocks.fetchDingTalkAppAccessToken.mockResolvedValue('t2g-token')
+    clientMocks.listDingTalkDepartments.mockImplementation(async (_token: string, parentId: string) =>
+      parentId === '1' && activeTenant ? [{ id: 'd100', parentId: '1', name: 'Mechanism Dept', order: 1, source: {} }] : []
+    )
+    clientMocks.getDingTalkDepartmentDetail.mockResolvedValue({ deptManagerUserIdList: [] })
+    clientMocks.listDingTalkDepartmentUsers.mockImplementation(async (_token: string, deptId: string) => ({
+      users:
+        deptId === 'd100' && activeTenant
+          ? [{ userId: activeTenant.userId, name: activeTenant.name, departmentIds: ['d100'], source: {} }]
+          : [],
+      nextCursor: null,
+      hasMore: false,
+    }))
+    clientMocks.getDingTalkUserDetail.mockImplementation(async () => ({
+      userId: activeTenant!.userId,
+      name: activeTenant!.name,
+      unionId: activeTenant!.unionId,
+      openId: activeTenant!.openId,
+      email: undefined,
+      mobile: undefined,
+      departmentIds: ['d100'],
+      source: {},
+    }))
+  })
+
+  afterAll(async () => {
+    for (const id of cleanupIntegrationIds.splice(0)) await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
+  })
+
+  async function seedIntegration(tag: string): Promise<string> {
+    const integration = await createDirectoryIntegration({
+      name: `t2g-${tag}-${TS}`,
+      corpId: `t2g-corp-${tag}-${TS}`,
+      appKey: `t2g-appkey-${tag}-${TS}`,
+      appSecret: 't2g-secret',
+      admissionMode: 'manual_only',
+    })
+    cleanupIntegrationIds.push(integration.id)
+    return integration.id
+  }
+
+  async function accountKeys(integrationId: string): Promise<Array<{ external_key: string; is_active: boolean }>> {
+    const rows = await query<{ external_key: string; is_active: boolean }>(
+      `SELECT external_key, is_active FROM directory_accounts WHERE integration_id = $1 ORDER BY external_key`,
+      [integrationId]
+    )
+    return rows.rows
+  }
+
+  /** Values-free local-directory write probe: count of department rows for one integration. */
+  async function departmentCount(integrationId: string): Promise<number> {
+    const rows = await query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM directory_departments WHERE integration_id = $1`,
+      [integrationId],
+    )
+    return rows.rows[0]?.n ?? 0
+  }
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('pins the schema mechanism: same (provider, external_key) across two integrations is UNINSERTABLE — distinct keys coexist', async () => {
+    const a = await seedIntegration('probe-a')
+    const b = await seedIntegration('probe-b')
+    const sharedKey = `t2g-shared-${TS}`
+
+    await query(
+      `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, is_active, raw)
+       VALUES ($1, 'dingtalk', $2, $3, 'Probe A', true, '{}'::jsonb)`,
+      [a, `t2g-probe-a-${TS}`, sharedKey]
+    )
+    // positive-coexistence control FIRST: a distinct key under B inserts fine
+    await query(
+      `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, is_active, raw)
+       VALUES ($1, 'dingtalk', $2, $3, 'Probe B distinct', true, '{}'::jsonb)`,
+      [b, `t2g-probe-b1-${TS}`, `t2g-distinct-${TS}`]
+    )
+    // the collision: same key under B — 23505 on the exact closed constraint name the runbook
+    // classifies via expected_constraint_detected (never raw error text in operator evidence)
+    let caught: { code?: string; constraint?: string } | null = null
+    try {
+      await query(
+        `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, is_active, raw)
+         VALUES ($1, 'dingtalk', $2, $3, 'Probe B colliding', true, '{}'::jsonb)`,
+        [b, `t2g-probe-b2-${TS}`, sharedKey]
+      )
+    } catch (error) {
+      caught = error as { code?: string; constraint?: string }
+    }
+    expect(caught, 'colliding INSERT unexpectedly succeeded').not.toBeNull()
+    expect(caught?.code).toBe('23505')
+    expect(caught?.constraint).toBe('idx_directory_accounts_provider_external_key')
+  })
+
+  it('pins the derivation: the synced external_key is the BARE unionId — no corp scoping (the §3.4 precondition; T2.5 would change this)', async () => {
+    const a = await seedIntegration('derive')
+    activeTenant = { unionId: `t2g-union-derive-${TS}`, openId: `t2g-open-derive-${TS}`, userId: `t2g-uid-derive-${TS}`, name: 'Derive' }
+    const result = await syncDirectoryIntegration(a, `t2g-admin-${TS}`)
+    expect(result.run.status).toBe('completed')
+    const keys = await accountKeys(a)
+    expect(keys).toHaveLength(1)
+    // bare unionId wins over openId/userId, and carries NO corp prefix
+    expect(keys[0].external_key).toBe(`t2g-union-derive-${TS}`)
+  })
+
+  it('END-TO-END collision signature: the SECOND corp sync FAILS WHOLESALE when the overlapping person carries the same unionId', async () => {
+    const corpA = await seedIntegration('e2e-a')
+    const corpB = await seedIntegration('e2e-b')
+    const sharedUnion = `t2g-union-shared-${TS}`
+
+    activeTenant = { unionId: sharedUnion, userId: `t2g-uid-a-${TS}`, name: 'Overlap Person' }
+    const first = await syncDirectoryIntegration(corpA, `t2g-admin-${TS}`)
+    expect(first.run.status).toBe('completed')
+    expect((await accountKeys(corpA)).map((r) => r.external_key)).toEqual([sharedUnion])
+
+    // same person, same unionId, DIFFERENT corp + different corp-local userId
+    activeTenant = { unionId: sharedUnion, userId: `t2g-uid-b-${TS}`, name: 'Overlap Person' }
+    let caught: unknown = null
+    try {
+      await syncDirectoryIntegration(corpB, `t2g-admin-${TS}`)
+    } catch (error) {
+      caught = error
+    }
+    // no per-account savepoint in the upsert loop: the whole apply aborts — corp B's run FAILS
+    expect(caught, 'corp-B sync unexpectedly completed despite the shared unionId').not.toBeNull()
+    // Closed constraint name only — do not assert/print full SQL error text (can embed external_key).
+    const thrown = caught as { code?: string; constraint?: string; message?: string }
+    const constraintHit =
+      thrown.constraint === 'idx_directory_accounts_provider_external_key' ||
+      (typeof thrown.message === 'string' &&
+        thrown.message.includes('idx_directory_accounts_provider_external_key'))
+    expect(constraintHit, 'thrown failure must name the closed unique-index constraint').toBe(true)
+
+    // corp B got NOTHING (whole apply transaction rolled back) — not only accounts.
+    // Departments are upserted BEFORE the colliding account; a regression that catches the
+    // 23505, marks the run failed, but commits the already-upserted d100 department would still
+    // pass an accounts-only empty check. Pin zero directory_departments for corp B.
+    expect(await accountKeys(corpB)).toHaveLength(0)
+    expect(
+      await departmentCount(corpB),
+      'corp-B directory_departments must be empty after wholesale collision rollback (dept upsert precedes account collision)',
+    ).toBe(0)
+    // Positive control: corp A still holds its synced department + account (untouched).
+    expect((await accountKeys(corpA)).map((r) => r.external_key)).toEqual([sharedUnion])
+    expect(
+      await departmentCount(corpA),
+      'corp-A directory_departments positive control: successful first sync must leave its dept row',
+    ).toBeGreaterThan(0)
+
+    // Run-row evidence uses the same closed boolean classifications as the staging runbook —
+    // never SELECT/project raw error_message (PostgreSQL duplicate-key DETAIL can embed the key).
+    const run = await query<{
+      status: string
+      duplicate_key_detected: boolean
+      expected_constraint_detected: boolean
+    }>(
+      `SELECT status,
+              (error_message IS NOT NULL
+                AND position('duplicate key' in error_message) > 0) AS duplicate_key_detected,
+              (error_message IS NOT NULL
+                AND position('idx_directory_accounts_provider_external_key' in error_message) > 0)
+                AS expected_constraint_detected
+         FROM directory_sync_runs
+        WHERE integration_id = $1
+        ORDER BY started_at DESC LIMIT 1`,
+      [corpB]
+    )
+    expect(run.rows[0].status).toBe('failed')
+    expect(run.rows[0].duplicate_key_detected).toBe(true)
+    expect(run.rows[0].expected_constraint_detected).toBe(true)
+  })
+
+  it('CONTRAST (what a collision-free staging proof would look like): distinct unionIds per corp — both syncs complete and coexist', async () => {
+    const corpA = await seedIntegration('ok-a')
+    const corpB = await seedIntegration('ok-b')
+
+    activeTenant = { unionId: `t2g-union-okA-${TS}`, userId: `t2g-uid-okA-${TS}`, name: 'Person A-side' }
+    expect((await syncDirectoryIntegration(corpA, `t2g-admin-${TS}`)).run.status).toBe('completed')
+
+    activeTenant = { unionId: `t2g-union-okB-${TS}`, userId: `t2g-uid-okB-${TS}`, name: 'Person B-side' }
+    expect((await syncDirectoryIntegration(corpB, `t2g-admin-${TS}`)).run.status).toBe('completed')
+
+    expect((await accountKeys(corpA)).map((r) => r.external_key)).toEqual([`t2g-union-okA-${TS}`])
+    expect((await accountKeys(corpB)).map((r) => r.external_key)).toEqual([`t2g-union-okB-${TS}`])
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -195,6 +195,13 @@ export default defineConfig({
       // job cannot skip-green it, and wired as a WHOLE FILE into the approval real-DB step in
       // plugin-tests.yml (both points asserted by t2-source-freeze-ci-wiring.test.mjs).
       'tests/integration/directory-org-transfer-source-freeze.db.test.ts',
+      // T2-Gate evidence (§3.4): the (provider, external_key) collision MECHANISM — unique-index
+      // pin, bare-unionId derivation pin, and the end-to-end wholesale second-corp sync failure
+      // signature the staging two-corp runbook greps for. Real sync + mocked DingTalk client.
+      // DATABASE_URL-gated; excluded here so the no-DB job cannot skip-green it, and wired as a
+      // WHOLE FILE into the approval real-DB step in plugin-tests.yml (both points asserted by
+      // t2gate-collision-mechanism-ci-wiring.test.mjs).
+      'tests/integration/directory-account-external-key-collision-mechanism.db.test.ts',
       // Canonical Org MVP B3 (#4215 §5.4): proves ApprovalDirectoryOrg's DUAL-SOURCE direct-manager
       // resolution against real Postgres — normalized `is_manager` relation for a local integration,
       // the DingTalk `leader_in_dept` regression pin (load-bearing compat leg + is_manager=0 positive

--- a/scripts/ops/t2gate-collision-mechanism-ci-wiring.test.mjs
+++ b/scripts/ops/t2gate-collision-mechanism-ci-wiring.test.mjs
@@ -1,0 +1,542 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// T2-Gate CI two-point wiring contract. The collision-mechanism suite is the CI-provable half of
+// the §3.4 two-corp question: the (provider, external_key) unique index, the bare-unionId
+// derivation, and the wholesale second-corp sync failure signature (closed classifications:
+// duplicate_key_detected + expected_constraint_detected — never raw error_message in operator
+// evidence; see t2gate-runbook-values-free-contract.test.mjs, co-run by the same no-DB CI step).
+//
+// Two load-bearing placements (both must hold or CI can stay green while the suite never runs):
+//   (1) exact quoted path inside the real `test.exclude` array of vitest.config.ts
+//       (a comment / coverage.exclude / nested exclude / free-text hit is NOT enough)
+//   (2) whole-file vitest arg inside the named "Run approval real-DB integration..." step that
+//       has a real env.DATABASE_URL key and a real run line invoking vitest with
+//       vitest.integration.config.ts (comment-only decoys do not count)
+//
+// Helpers parse source structure — mere whole-file filename / keyword search is insufficient.
+// Runs in the gating no-DB test job.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/directory-account-external-key-collision-mechanism.db.test.ts'
+const REAL_DB_STEP = 'Run approval real-DB integration'
+const VITEST_CFG = join(repoRoot, 'packages/core-backend/vitest.config.ts')
+const WORKFLOW = join(repoRoot, '.github/workflows/plugin-tests.yml')
+
+// ---------------------------------------------------------------------------
+// Source parsers (exported for synthetic mutation coverage)
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip // line comments and "..." / '...' string literals so brace scanning
+ * does not trip on braces inside comments/strings. Good enough for vitest config.
+ * @param {string} src
+ * @returns {string} same length; non-code regions replaced with spaces
+ */
+function maskCommentsAndStrings(src) {
+  let out = ''
+  let i = 0
+  while (i < src.length) {
+    // line comment
+    if (src[i] === '/' && src[i + 1] === '/') {
+      out += '  '
+      i += 2
+      while (i < src.length && src[i] !== '\n') {
+        out += ' '
+        i += 1
+      }
+      continue
+    }
+    // block comment
+    if (src[i] === '/' && src[i + 1] === '*') {
+      out += '  '
+      i += 2
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) {
+        out += src[i] === '\n' ? '\n' : ' '
+        i += 1
+      }
+      if (i < src.length) {
+        out += '  '
+        i += 2
+      }
+      continue
+    }
+    // single- or double-quoted string (no template literals needed for exclude arrays)
+    if (src[i] === "'" || src[i] === '"') {
+      const q = src[i]
+      out += ' '
+      i += 1
+      while (i < src.length && src[i] !== q) {
+        if (src[i] === '\\' && i + 1 < src.length) {
+          out += '  '
+          i += 2
+          continue
+        }
+        out += src[i] === '\n' ? '\n' : ' '
+        i += 1
+      }
+      if (i < src.length) {
+        out += ' '
+        i += 1
+      }
+      continue
+    }
+    out += src[i]
+    i += 1
+  }
+  return out
+}
+
+/**
+ * Body of the direct `test.exclude: [ ... ]` array only — property of the `test` object
+ * at brace depth 1. Nested `coverage.exclude` (or any later/deeper exclude) is ignored.
+ * @param {string} src
+ * @returns {string | null} raw array body, or null if no direct test.exclude
+ */
+export function extractTestExcludeArrayBody(src) {
+  const masked = maskCommentsAndStrings(src)
+  const testKey = /\btest\s*:\s*\{/.exec(masked)
+  if (!testKey) return null
+  // Position of the `{` that opens the test object.
+  const openBrace = masked.indexOf('{', testKey.index + testKey[0].length - 1)
+  if (openBrace < 0) return null
+
+  let depth = 1
+  let i = openBrace + 1
+  while (i < masked.length && depth > 0) {
+    const ch = masked[i]
+    if (ch === '{') {
+      depth += 1
+      i += 1
+      continue
+    }
+    if (ch === '}') {
+      depth -= 1
+      i += 1
+      continue
+    }
+    // Direct property of `test` only (depth === 1).
+    if (depth === 1) {
+      const rest = masked.slice(i)
+      const m = /^(exclude\s*:\s*\[)/.exec(rest)
+      if (m) {
+        const bracketOpen = i + m[1].length - 1 // index of `[`
+        let bDepth = 0
+        for (let j = bracketOpen; j < masked.length; j++) {
+          if (masked[j] === '[') bDepth += 1
+          else if (masked[j] === ']') {
+            bDepth -= 1
+            if (bDepth === 0) {
+              // Slice the ORIGINAL source so quoted entries stay intact.
+              return src.slice(bracketOpen + 1, j)
+            }
+          }
+        }
+        return null
+      }
+    }
+    i += 1
+  }
+  return null
+}
+
+/**
+ * Quoted string entries in an exclude-array body. Strips // line comments first so a
+ * decoy path that only appears in a comment is NOT counted as an exclude entry.
+ * @param {string} arrayBody
+ * @returns {string[]}
+ */
+export function quotedExcludeEntries(arrayBody) {
+  const noLineComments = arrayBody
+    .split('\n')
+    .map((line) => line.replace(/\/\/.*$/, ''))
+    .join('\n')
+  const entries = []
+  const re = /'([^']+)'|"([^"]+)"/g
+  let m
+  while ((m = re.exec(noLineComments)) !== null) {
+    entries.push(m[1] ?? m[2])
+  }
+  return entries
+}
+
+/** @param {string} src @param {string} file */
+export function isQuotedInTestExclude(src, file) {
+  const body = extractTestExcludeArrayBody(src)
+  if (body == null) return false
+  return quotedExcludeEntries(body).includes(file)
+}
+
+/**
+ * Body of the first workflow step whose name contains `nameNeedle`, from the line after
+ * `- name:` through (not including) the next same-indent `- name:`.
+ * @param {string} wf
+ * @param {string} nameNeedle
+ * @returns {string}
+ */
+export function namedStepBody(wf, nameNeedle) {
+  const lines = wf.split('\n')
+  let start = -1
+  let indent = ''
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(\s*)- name:\s*(.*)$/)
+    if (m && m[2].includes(nameNeedle)) {
+      start = i
+      indent = m[1]
+      break
+    }
+  }
+  assert.ok(start >= 0, `workflow step whose name includes ${JSON.stringify(nameNeedle)} not found`)
+  const body = []
+  for (let i = start + 1; i < lines.length; i++) {
+    const m = lines[i].match(/^(\s*)- name:\s*/)
+    if (m && m[1] === indent) break
+    body.push(lines[i])
+  }
+  return body.join('\n')
+}
+
+/**
+ * True iff the step body has a real YAML `env:` mapping child with a `DATABASE_URL:` key.
+ * Comment lines and free-text mentions do not count.
+ * @param {string} stepBody
+ */
+export function stepHasEnvDatabaseUrl(stepBody) {
+  const lines = stepBody.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const envM = /^(\s*)env:\s*$/.exec(lines[i])
+    if (!envM) continue
+    const envIndent = envM[1].length
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j]
+      if (/^\s*$/.test(line) || /^\s*#/.test(line)) continue
+      const indent = (line.match(/^(\s*)/) || ['', ''])[1].length
+      if (indent <= envIndent) break
+      // Real key under env: — not a comment.
+      if (/^\s*DATABASE_URL:\s*\S/.test(line)) return true
+    }
+  }
+  return false
+}
+
+/**
+ * True iff the step body has a non-comment run command line that invokes `vitest`
+ * with `--config vitest.integration.config.ts` (order-tolerant enough for the real
+ * `pnpm ... exec vitest --config vitest.integration.config.ts run \` line).
+ * Free-text / comment mentions do not count.
+ * @param {string} stepBody
+ */
+export function stepInvokesVitestIntegrationConfig(stepBody) {
+  for (const line of stepBody.split('\n')) {
+    if (/^\s*#/.test(line)) continue
+    // Strip trailing shell comments for the match surface.
+    const code = line.replace(/(^|[^\\])#.*$/, '$1')
+    if (!/\bvitest\b/.test(code)) continue
+    if (/--config\s+vitest\.integration\.config\.ts\b/.test(code)) return true
+  }
+  return false
+}
+
+/**
+ * Ordered whole-file vitest path args in a step body
+ * (`tests/integration/foo.db.test.ts` with optional trailing `\`).
+ * Comment lines ignored.
+ * @param {string} stepBody
+ * @returns {string[]}
+ */
+export function wholeFileVitestArgs(stepBody) {
+  const files = []
+  for (const line of stepBody.split('\n')) {
+    if (/^\s*#/.test(line)) continue
+    const m = line.match(/^\s+(tests\/integration\/\S+\.(?:test|spec)\.[tj]sx?)\s*(?:\\)?\s*$/)
+    if (m) files.push(m[1])
+  }
+  return files
+}
+
+/**
+ * True iff `file` is a whole-file vitest arg inside the named real-DB step that also
+ * has a real env.DATABASE_URL key and a real vitest --config vitest.integration.config.ts run line.
+ * @param {string} wf
+ * @param {string} file
+ * @param {string} [stepNeedle]
+ */
+export function isWholeFileInApprovalRealDbStep(wf, file, stepNeedle = REAL_DB_STEP) {
+  const step = namedStepBody(wf, stepNeedle)
+  assert.ok(
+    stepHasEnvDatabaseUrl(step),
+    `${stepNeedle} step must have env.DATABASE_URL (real YAML key, not a comment/decoy)`,
+  )
+  assert.ok(
+    stepInvokesVitestIntegrationConfig(step),
+    `${stepNeedle} step must run vitest with --config vitest.integration.config.ts ` +
+      `(real command line, not a comment/decoy)`,
+  )
+  return wholeFileVitestArgs(step).includes(file)
+}
+
+// ---------------------------------------------------------------------------
+// Repo contracts (real sources)
+// ---------------------------------------------------------------------------
+
+test('vitest.config.ts quotes the T2-Gate collision-mechanism suite inside test.exclude', () => {
+  const cfg = readFileSync(VITEST_CFG, 'utf8')
+  assert.ok(
+    isQuotedInTestExclude(cfg, FILE),
+    `test.exclude must contain the exact quoted entry '${FILE}' ` +
+      `(a comment / coverage.exclude / free-text hit is not placement)`,
+  )
+})
+
+test('plugin-tests.yml runs the suite as a whole file in the approval real-DB step (DATABASE_URL + integration config)', () => {
+  const wf = readFileSync(WORKFLOW, 'utf8')
+  assert.ok(
+    isWholeFileInApprovalRealDbStep(wf, FILE),
+    `plugin-tests.yml step "${REAL_DB_STEP}" (with env.DATABASE_URL + vitest.integration.config.ts) ` +
+      `must list ${FILE} as a whole-file vitest arg`,
+  )
+  // Negative: multitable real-DB must not be the (sole) placement.
+  const multi = namedStepBody(wf, 'Run multitable real-DB integration')
+  assert.equal(
+    wholeFileVitestArgs(multi).includes(FILE),
+    false,
+    `${FILE} must not be wired into the multitable real-DB step`,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Synthetic / mutation guards (in-memory) — prove parsers, not whole-file search
+// ---------------------------------------------------------------------------
+
+test('synthetic: path only in a comment outside the exclude array does not count as excluded', () => {
+  const decoy = [
+    "export default defineConfig({",
+    '  test: {',
+    '    // decoy mention only: ' + `'${FILE}'`,
+    '    exclude: [',
+    "      '**/node_modules/**',",
+    "      'tests/integration/other.db.test.ts',",
+    '    ],',
+    '  },',
+    '})',
+  ].join('\n')
+  assert.ok(decoy.includes(`'${FILE}'`), 'decoy source still mentions the path')
+  assert.equal(
+    isQuotedInTestExclude(decoy, FILE),
+    false,
+    'comment-only / outside-array decoy must not satisfy test.exclude placement',
+  )
+})
+
+test('synthetic: path only inside coverage.exclude (with a sibling empty top-level exclude) does not count', () => {
+  // Path lives only under coverage.exclude; top-level test.exclude exists but without FILE.
+  const decoy = [
+    "export default defineConfig({",
+    '  test: {',
+    '    exclude: [',
+    "      '**/node_modules/**',",
+    '    ],',
+    '    coverage: {',
+    '      exclude: [',
+    `        '${FILE}',`,
+    '      ],',
+    '    },',
+    '  },',
+    '})',
+  ].join('\n')
+  assert.ok(decoy.includes(`'${FILE}'`))
+  assert.equal(
+    isQuotedInTestExclude(decoy, FILE),
+    false,
+    'coverage.exclude decoy must not satisfy test.exclude placement',
+  )
+})
+
+test('synthetic: no top-level test.exclude — coverage.exclude-only must NOT false-green', () => {
+  // Exact Codex repro: first exclude after test: is nested coverage.exclude.
+  // Prior parser took that first exclude and greened; depth-1 parse must red.
+  const decoy = [
+    'export default defineConfig({',
+    '  test: {',
+    '    coverage: {',
+    '      exclude: [',
+    `        '${FILE}',`,
+    '      ],',
+    '    },',
+    '  },',
+    '});',
+  ].join('\n')
+  assert.ok(decoy.includes(`'${FILE}'`), 'repro source still mentions the path')
+  assert.equal(
+    extractTestExcludeArrayBody(decoy),
+    null,
+    'no direct test.exclude property → extract must return null (not coverage.exclude)',
+  )
+  assert.equal(
+    isQuotedInTestExclude(decoy, FILE),
+    false,
+    'coverage-only / no-top-level-exclude must not satisfy test.exclude placement',
+  )
+})
+
+test('synthetic positive: exact quoted entry inside direct test.exclude passes', () => {
+  const ok = [
+    "export default defineConfig({",
+    '  test: {',
+    '    exclude: [',
+    "      '**/node_modules/**',",
+    `      '${FILE}',`,
+    '    ],',
+    '    coverage: {',
+    '      exclude: [',
+    "        'tests/**',",
+    '      ],',
+    '    },',
+    '  },',
+    '})',
+  ].join('\n')
+  assert.equal(isQuotedInTestExclude(ok, FILE), true)
+  // Sibling coverage.exclude path must not be confused with the direct entry.
+  assert.equal(isQuotedInTestExclude(ok, 'tests/**'), false)
+})
+
+test('synthetic: wrong-step relocation (multitable only) fails the approval real-DB placement check', () => {
+  const wf = [
+    'jobs:',
+    '  test:',
+    '    steps:',
+    '      - name: Run multitable real-DB integration',
+    '        env:',
+    '          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test',
+    '        run: |',
+    '          pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \\',
+    `            ${FILE} \\`,
+    '            --reporter=dot',
+    '      - name: Run approval real-DB integration (directory endpoints)',
+    '        env:',
+    '          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test',
+    '        run: |',
+    '          pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \\',
+    '            tests/integration/other.db.test.ts \\',
+    '            --reporter=dot',
+    '      - name: Next step',
+    '        run: echo ok',
+  ].join('\n')
+  assert.ok(wf.includes(FILE))
+  assert.equal(
+    isWholeFileInApprovalRealDbStep(wf, FILE),
+    false,
+    'file present only under multitable real-DB must not satisfy approval real-DB placement',
+  )
+  assert.equal(
+    wholeFileVitestArgs(namedStepBody(wf, 'Run multitable real-DB integration')).includes(FILE),
+    true,
+    'control: multitable step does list the file',
+  )
+})
+
+test('synthetic: approval real-DB step without env.DATABASE_URL fails even if the file is listed', () => {
+  const wf = [
+    'jobs:',
+    '  test:',
+    '    steps:',
+    '      - name: Run approval real-DB integration (directory endpoints)',
+    '        run: |',
+    '          pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \\',
+    `            ${FILE} \\`,
+    '            --reporter=dot',
+    '      - name: Next step',
+    '        run: echo ok',
+  ].join('\n')
+  assert.throws(
+    () => isWholeFileInApprovalRealDbStep(wf, FILE),
+    /env\.DATABASE_URL|DATABASE_URL/,
+    'missing env.DATABASE_URL must red the real-DB placement check',
+  )
+})
+
+test('synthetic: comment-only DATABASE_URL / vitest.integration.config decoys fail step placement', () => {
+  // Keywords appear only in comments — old /\bDATABASE_URL\b/ search would green.
+  const commentOnly = [
+    'jobs:',
+    '  test:',
+    '    steps:',
+    '      - name: Run approval real-DB integration (directory endpoints)',
+    '        # env:',
+    '        #   DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test',
+    '        run: |',
+    '          # pnpm exec vitest --config vitest.integration.config.ts run \\',
+    `          echo "mention ${FILE} DATABASE_URL vitest.integration.config.ts"`,
+    '      - name: Next step',
+    '        run: echo ok',
+  ].join('\n')
+  assert.ok(commentOnly.includes('DATABASE_URL'))
+  assert.ok(commentOnly.includes('vitest.integration.config.ts'))
+  assert.throws(
+    () => isWholeFileInApprovalRealDbStep(commentOnly, FILE),
+    /env\.DATABASE_URL|DATABASE_URL/,
+    'comment-only DATABASE_URL must red',
+  )
+
+  // env.DATABASE_URL present, but vitest config only in a comment.
+  const configCommentOnly = [
+    'jobs:',
+    '  test:',
+    '    steps:',
+    '      - name: Run approval real-DB integration (directory endpoints)',
+    '        env:',
+    '          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test',
+    '        run: |',
+    '          # pnpm exec vitest --config vitest.integration.config.ts run',
+    '          echo hi',
+    `            ${FILE} \\`,
+    '      - name: Next step',
+    '        run: echo ok',
+  ].join('\n')
+  assert.throws(
+    () => isWholeFileInApprovalRealDbStep(configCommentOnly, FILE),
+    /vitest\.integration\.config/,
+    'comment-only vitest.integration.config.ts must red',
+  )
+
+  // Real env key + real vitest line, but FILE only under another step — still false for FILE.
+  const noFile = [
+    'jobs:',
+    '  test:',
+    '    steps:',
+    '      - name: Run approval real-DB integration (directory endpoints)',
+    '        env:',
+    '          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test',
+    '        run: |',
+    '          pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \\',
+    '            tests/integration/other.db.test.ts \\',
+    '            --reporter=dot',
+    '      - name: Next step',
+    '        run: echo ok',
+  ].join('\n')
+  assert.equal(isWholeFileInApprovalRealDbStep(noFile, FILE), false)
+})
+
+test('synthetic positive: file inside named approval real-DB step with env.DATABASE_URL + vitest integration config passes', () => {
+  const wf = [
+    'jobs:',
+    '  test:',
+    '    steps:',
+    '      - name: Run approval real-DB integration (directory endpoints)',
+    '        env:',
+    '          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test',
+    '        run: |',
+    '          : "${DATABASE_URL:?DATABASE_URL is required}"',
+    '          pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \\',
+    `            ${FILE} \\`,
+    '            --reporter=dot',
+    '      - name: Next step',
+    '        run: echo ok',
+  ].join('\n')
+  assert.equal(isWholeFileInApprovalRealDbStep(wf, FILE), true)
+  assert.equal(stepHasEnvDatabaseUrl(namedStepBody(wf, REAL_DB_STEP)), true)
+  assert.equal(stepInvokesVitestIntegrationConfig(namedStepBody(wf, REAL_DB_STEP)), true)
+})

--- a/scripts/ops/t2gate-runbook-values-free-contract.test.mjs
+++ b/scripts/ops/t2gate-runbook-values-free-contract.test.mjs
@@ -1,0 +1,500 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// T2-Gate values-free evidence contract (no DB).
+//
+// "Values-free" = no raw provider identity / business values / raw SQL error text.
+// Provenance is allowed: exact SHA, execution date/actor, internal integration resource IDs.
+// SQL outputs remain booleans/counts/statuses only.
+//
+// The staging runbook claims values-free operator evidence, but PostgreSQL duplicate-key
+// text can embed the real external_key / unionId. Operator-facing SQL and the §4 evidence
+// block must therefore NEVER project, print, grep, copy, or persist raw error_message /
+// err-head output. Closed booleans/classifications only:
+//   status + duplicate_key_detected + expected_constraint_detected
+//
+// Load-bearing invariant for fenced SQL: every top-level SELECT projection that *references*
+// error_message must be EXACTLY one of the two closed boolean expression families used by
+// the runbook (whitespace/case tolerant), ending in the matching AS alias:
+//
+//   (error_message IS NOT NULL AND position('duplicate key' in error_message) > 0)
+//     AS duplicate_key_detected
+//   (error_message IS NOT NULL
+//     AND position('idx_directory_accounts_provider_external_key' in error_message) > 0)
+//     AS expected_constraint_detected
+//
+// Alias-only validation is NOT enough: `substring(error_message,1,120) AS duplicate_key_detected`
+// and `error_message AS expected_constraint_detected` must fail. Direct projection, other
+// aliases (preview/err), and arbitrary string functions under an allowed alias must fail.
+//
+// Load-bearing: runs in the gating no-DB job (same T2-Gate CI command as the wiring guard).
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const RUNBOOK = join(
+  repoRoot,
+  'docs/development/canonical-org-t2-gate-two-corp-staging-runbook-20260717.md',
+)
+
+const ALLOWED_ERROR_MESSAGE_ALIASES = new Set([
+  'duplicate_key_detected',
+  'expected_constraint_detected',
+])
+
+/**
+ * Exact closed-boolean expression families pinned to the runbook (optional outer parens;
+ * whitespace/case tolerant on keywords/idents; string literals fixed).
+ * Matched against the projection BODY only (everything before trailing AS <alias>).
+ */
+const CLOSED_BOOLEAN_BODY_BY_ALIAS = {
+  // error_message IS NOT NULL AND position('duplicate key' in error_message) > 0
+  duplicate_key_detected:
+    /^\(?\s*error_message\s+IS\s+NOT\s+NULL\s+AND\s+position\s*\(\s*'duplicate key'\s+IN\s+error_message\s*\)\s*>\s*0\s*\)?$/i,
+  // error_message IS NOT NULL AND position('idx_directory_accounts_provider_external_key' in error_message) > 0
+  expected_constraint_detected:
+    /^\(?\s*error_message\s+IS\s+NOT\s+NULL\s+AND\s+position\s*\(\s*'idx_directory_accounts_provider_external_key'\s+IN\s+error_message\s*\)\s*>\s*0\s*\)?$/i,
+}
+
+/** Regex surface bans that still catch evidence-block / prose regressions. */
+const FORBIDDEN_RAW_ERROR_OUTPUT = [
+  /\bas\s+err_head\b/i,
+  /\bas\s+err\b/i,
+  /\berr\s+head\b/i,
+  /\berror_message\b[^\n]{0,40}\bnames\b/i,
+  /status\s*\/\s*err/i,
+]
+
+function loadRunbook() {
+  return readFileSync(RUNBOOK, 'utf8')
+}
+
+/**
+ * Extract fenced ```sql ... ``` bodies from markdown (case-insensitive fence tag).
+ * @param {string} markdown
+ * @returns {string[]}
+ */
+export function extractFencedSqlBlocks(markdown) {
+  const blocks = []
+  const re = /```sql\s*\n([\s\S]*?)```/gi
+  let m
+  while ((m = re.exec(markdown)) !== null) {
+    blocks.push(m[1])
+  }
+  return blocks
+}
+
+/**
+ * Split a SELECT list on top-level commas only (depth-aware; ignores commas inside () ).
+ * Does not attempt full SQL parsing — sufficient for runbook projection lists.
+ * @param {string} selectList
+ * @returns {string[]}
+ */
+export function splitTopLevelProjections(selectList) {
+  const parts = []
+  let depth = 0
+  let current = ''
+  for (let i = 0; i < selectList.length; i++) {
+    const ch = selectList[i]
+    if (ch === '(') {
+      depth += 1
+      current += ch
+      continue
+    }
+    if (ch === ')') {
+      depth = Math.max(0, depth - 1)
+      current += ch
+      continue
+    }
+    if (ch === ',' && depth === 0) {
+      const trimmed = current.trim()
+      if (trimmed) parts.push(trimmed)
+      current = ''
+      continue
+    }
+    current += ch
+  }
+  const tail = current.trim()
+  if (tail) parts.push(tail)
+  return parts
+}
+
+/**
+ * For each SELECT in `sql`, yield the raw projection-list text between SELECT and the
+ * matching FROM / WHERE / GROUP / ORDER / LIMIT / ; terminator at depth 0.
+ * Handles multi-line runbook SQL.
+ * @param {string} sql
+ * @returns {string[]}
+ */
+export function extractSelectLists(sql) {
+  const lists = []
+  let fromIdx = 0
+  while (fromIdx < sql.length) {
+    const selectMatch = /\bSELECT\b/i.exec(sql.slice(fromIdx))
+    if (!selectMatch) break
+    const selectStart = fromIdx + selectMatch.index + selectMatch[0].length
+
+    let depth = 0
+    let i = selectStart
+    let end = sql.length
+    while (i < sql.length) {
+      const ch = sql[i]
+      if (ch === '(') {
+        depth += 1
+        i += 1
+        continue
+      }
+      if (ch === ')') {
+        depth = Math.max(0, depth - 1)
+        i += 1
+        continue
+      }
+      if (depth === 0) {
+        const rest = sql.slice(i)
+        const term = /^(?:\s|;)*(?:\bFROM\b|\bWHERE\b|\bGROUP\s+BY\b|\bORDER\s+BY\b|\bLIMIT\b|\bUNION\b|\bINTERSECT\b|\bEXCEPT\b|;)/i.exec(
+          rest,
+        )
+        if (term && term.index === 0) {
+          const kw = /\b(?:FROM|WHERE|GROUP\s+BY|ORDER\s+BY|LIMIT|UNION|INTERSECT|EXCEPT)\b|;/i.exec(rest)
+          end = i + (kw ? kw.index : 0)
+          break
+        }
+      }
+      i += 1
+    }
+    const list = sql.slice(selectStart, end).trim()
+    if (list) lists.push(list)
+    fromIdx = end === sql.length ? sql.length : end + 1
+  }
+  return lists
+}
+
+/**
+ * Normalize a projection/body for closed-boolean matching: collapse whitespace only.
+ * Keyword/ident case is handled by the family regex `/i` flag; string literals stay exact.
+ * @param {string} s
+ * @returns {string}
+ */
+export function normalizeSqlWs(s) {
+  return s.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * If a projection expression references error_message, return its trailing AS alias
+ * and the body before that alias (or null alias if bare / direct projection).
+ * @param {string} expr
+ * @returns {{ referencesErrorMessage: boolean, alias: string | null, body: string }}
+ */
+export function inspectProjection(expr) {
+  const normalized = normalizeSqlWs(expr)
+  const referencesErrorMessage = /\berror_message\b/i.test(normalized)
+  if (!referencesErrorMessage) {
+    return { referencesErrorMessage: false, alias: null, body: normalized }
+  }
+  // Trailing `AS <ident>` only — require it at the end of the expression.
+  const asMatch = /\s+AS\s+([A-Za-z_][A-Za-z0-9_]*)\s*$/i.exec(normalized)
+  if (!asMatch) {
+    return { referencesErrorMessage: true, alias: null, body: normalized }
+  }
+  const alias = asMatch[1].toLowerCase()
+  const body = normalized.slice(0, asMatch.index).trim()
+  return { referencesErrorMessage: true, alias, body }
+}
+
+/**
+ * True iff the projection body is the pinned closed-boolean family for the given alias.
+ * @param {string} body
+ * @param {string} alias
+ * @returns {boolean}
+ */
+export function isClosedBooleanBodyForAlias(body, alias) {
+  const pattern = CLOSED_BOOLEAN_BODY_BY_ALIAS[alias]
+  if (!pattern) return false
+  return pattern.test(normalizeSqlWs(body))
+}
+
+/**
+ * Validate that every fenced-SQL projection referencing error_message is exactly one of
+ * the two closed boolean expression families (body + matching AS alias).
+ * @param {string} markdownOrSql  full runbook markdown OR a bare SQL snippet
+ * @param {{ bareSql?: boolean }} [opts]
+ * @returns {{ ok: true } | { ok: false, violations: string[] }}
+ */
+export function assertErrorMessageProjectionsAreClosed(markdownOrSql, opts = {}) {
+  const sqlBlocks = opts.bareSql
+    ? [markdownOrSql]
+    : extractFencedSqlBlocks(markdownOrSql)
+  const violations = []
+
+  for (const block of sqlBlocks) {
+    for (const selectList of extractSelectLists(block)) {
+      for (const proj of splitTopLevelProjections(selectList)) {
+        const { referencesErrorMessage, alias, body } = inspectProjection(proj)
+        if (!referencesErrorMessage) continue
+
+        if (!alias || !ALLOWED_ERROR_MESSAGE_ALIASES.has(alias)) {
+          violations.push(
+            alias === null
+              ? `direct/unaliased error_message projection forbidden: ${proj}`
+              : `error_message projection alias "${alias}" is not a closed classification (must be duplicate_key_detected|expected_constraint_detected): ${proj}`,
+          )
+          continue
+        }
+
+        // Alias alone is insufficient — body must be the pinned closed boolean family.
+        if (!isClosedBooleanBodyForAlias(body, alias)) {
+          violations.push(
+            `error_message projection AS ${alias} is not the pinned closed boolean family ` +
+              `(must be: error_message IS NOT NULL AND position('<needle>' in error_message) > 0): ${proj}`,
+          )
+        }
+      }
+    }
+  }
+
+  return violations.length === 0 ? { ok: true } : { ok: false, violations }
+}
+
+function assertRunbookValuesFree(runbook) {
+  const proj = assertErrorMessageProjectionsAreClosed(runbook)
+  assert.equal(
+    proj.ok,
+    true,
+    proj.ok
+      ? 'ok'
+      : `runbook fenced SQL projects raw error_message:\n- ${proj.violations.join('\n- ')}`,
+  )
+
+  for (const pattern of FORBIDDEN_RAW_ERROR_OUTPUT) {
+    assert.doesNotMatch(
+      runbook,
+      pattern,
+      `runbook must not expose raw error text to operators (matched ${pattern})`,
+    )
+  }
+
+  assert.match(
+    runbook,
+    /corp B duplicate_key_detected:/,
+    'evidence block must record corp B duplicate_key_detected',
+  )
+  assert.match(
+    runbook,
+    /corp B expected_constraint_detected:/,
+    'evidence block must record corp B expected_constraint_detected',
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic guards (in-memory) — prove closed-boolean body pinning, not alias-only.
+// These do NOT touch the runbook file.
+// ---------------------------------------------------------------------------
+
+const ALLOWED_DUP = `(error_message IS NOT NULL AND position('duplicate key' in error_message) > 0) AS duplicate_key_detected`
+const ALLOWED_CONSTRAINT = `(error_message IS NOT NULL AND position('idx_directory_accounts_provider_external_key' in error_message) > 0) AS expected_constraint_detected`
+
+test('synthetic: direct SELECT error_message is rejected', () => {
+  const sql = `SELECT status, error_message FROM directory_sync_runs WHERE integration_id = '<B>' ORDER BY started_at DESC LIMIT 1;`
+  const result = assertErrorMessageProjectionsAreClosed(sql, { bareSql: true })
+  assert.equal(result.ok, false, 'direct error_message projection must fail')
+  assert.ok(
+    result.violations.some((v) => /direct\/unaliased/i.test(v)),
+    `expected direct/unaliased violation, got: ${result.violations?.join(' | ')}`,
+  )
+})
+
+test('synthetic: substring(error_message,...) AS preview is rejected', () => {
+  const sql = `SELECT status, substring(error_message, 1, 120) AS preview FROM directory_sync_runs;`
+  const result = assertErrorMessageProjectionsAreClosed(sql, { bareSql: true })
+  assert.equal(result.ok, false, 'substring AS preview must fail')
+  assert.ok(
+    result.violations.some((v) => /alias "preview"/i.test(v)),
+    `expected preview-alias violation, got: ${result.violations?.join(' | ')}`,
+  )
+})
+
+test('synthetic: classic left(coalesce(error_message...)) AS err is rejected', () => {
+  const sql = `SELECT status, left(coalesce(error_message, ''), 120) AS err FROM directory_sync_runs;`
+  const result = assertErrorMessageProjectionsAreClosed(sql, { bareSql: true })
+  assert.equal(result.ok, false, 'left(coalesce...) AS err must fail')
+  assert.ok(
+    result.violations.some((v) => /alias "err"/i.test(v)),
+    `expected err-alias violation, got: ${result.violations?.join(' | ')}`,
+  )
+})
+
+test('synthetic: substring(...) AS duplicate_key_detected alias-smuggle is rejected', () => {
+  const sql = `SELECT substring(error_message,1,120) AS duplicate_key_detected FROM directory_sync_runs;`
+  const result = assertErrorMessageProjectionsAreClosed(sql, { bareSql: true })
+  assert.equal(result.ok, false, 'substring under allowed alias must fail')
+  assert.ok(
+    result.violations.some(
+      (v) =>
+        /AS duplicate_key_detected/i.test(v) &&
+        /not the pinned closed boolean family/i.test(v),
+    ),
+    `expected closed-boolean-family violation for alias-smuggle, got: ${result.violations?.join(' | ')}`,
+  )
+})
+
+test('synthetic: bare error_message AS expected_constraint_detected alias-smuggle is rejected', () => {
+  const sql = `SELECT error_message AS expected_constraint_detected FROM directory_sync_runs;`
+  const result = assertErrorMessageProjectionsAreClosed(sql, { bareSql: true })
+  assert.equal(result.ok, false, 'bare error_message under allowed alias must fail')
+  assert.ok(
+    result.violations.some(
+      (v) =>
+        /AS expected_constraint_detected/i.test(v) &&
+        /not the pinned closed boolean family/i.test(v),
+    ),
+    `expected closed-boolean-family violation for bare alias-smuggle, got: ${result.violations?.join(' | ')}`,
+  )
+})
+
+test('synthetic: the two closed boolean projections pass', () => {
+  const sql = `SELECT status, ${ALLOWED_DUP}, ${ALLOWED_CONSTRAINT}
+     FROM directory_sync_runs
+    WHERE integration_id = '<B>'
+    ORDER BY started_at DESC LIMIT 1;`
+  const result = assertErrorMessageProjectionsAreClosed(sql, { bareSql: true })
+  assert.equal(
+    result.ok,
+    true,
+    result.ok ? 'ok' : `allowed booleans must pass:\n- ${result.violations.join('\n- ')}`,
+  )
+})
+
+test('synthetic: whitespace/case variants of the allowed families still pass', () => {
+  const sql = `SELECT
+      STATUS,
+      ( Error_Message  is  not  null  AND  POSITION( 'duplicate key'  IN  Error_Message )  >  0 )  AS  Duplicate_Key_Detected,
+      Error_Message IS NOT NULL AND position('idx_directory_accounts_provider_external_key' in error_message)>0 AS expected_constraint_detected
+    FROM directory_sync_runs;`
+  const result = assertErrorMessageProjectionsAreClosed(sql, { bareSql: true })
+  assert.equal(
+    result.ok,
+    true,
+    result.ok ? 'ok' : `ws/case variants must pass:\n- ${result.violations.join('\n- ')}`,
+  )
+})
+
+test('synthetic: fenced markdown with a bypass fails; allowed fence passes', () => {
+  const bad = [
+    '```sql',
+    'SELECT error_message FROM directory_sync_runs;',
+    '```',
+  ].join('\n')
+  const badResult = assertErrorMessageProjectionsAreClosed(bad)
+  assert.equal(badResult.ok, false, 'fenced direct error_message must fail')
+
+  const smuggle = [
+    '```sql',
+    'SELECT substring(error_message,1,120) AS duplicate_key_detected FROM directory_sync_runs;',
+    '```',
+  ].join('\n')
+  const smuggleResult = assertErrorMessageProjectionsAreClosed(smuggle)
+  assert.equal(smuggleResult.ok, false, 'fenced alias-smuggle must fail')
+
+  const good = [
+    '```sql',
+    `SELECT status, ${ALLOWED_DUP}, ${ALLOWED_CONSTRAINT}`,
+    '  FROM directory_sync_runs',
+    " WHERE integration_id = '<B>'",
+    ' ORDER BY started_at DESC LIMIT 1;',
+    '```',
+  ].join('\n')
+  const goodResult = assertErrorMessageProjectionsAreClosed(good)
+  assert.equal(
+    goodResult.ok,
+    true,
+    goodResult.ok ? 'ok' : `allowed fence must pass:\n- ${goodResult.violations.join('\n- ')}`,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Actual runbook file contracts
+// ---------------------------------------------------------------------------
+
+test('T2-Gate runbook requires closed collision classifications (not raw error text)', () => {
+  const runbook = loadRunbook()
+  assert.match(
+    runbook,
+    /\bduplicate_key_detected\b/,
+    'runbook must require duplicate_key_detected (closed boolean)',
+  )
+  assert.match(
+    runbook,
+    /\bexpected_constraint_detected\b/,
+    'runbook must require expected_constraint_detected (closed boolean)',
+  )
+  assert.match(
+    runbook,
+    /idx_directory_accounts_provider_external_key/,
+    'runbook must pin the closed constraint name used for expected_constraint_detected',
+  )
+  assert.match(
+    runbook,
+    /duplicate_key_detected\s*=\s*true/i,
+    'decision matrix must key CONFIRMED on duplicate_key_detected=true',
+  )
+  assert.match(
+    runbook,
+    /expected_constraint_detected\s*=\s*true/i,
+    'decision matrix must key CONFIRMED on expected_constraint_detected=true',
+  )
+})
+
+test('T2-Gate runbook never selects or records raw error_message / err-head operator output', () => {
+  assertRunbookValuesFree(loadRunbook())
+})
+
+test('T2-Gate runbook keeps T2.5 conditional + staging owner/ops boundary (no fabricated verdict)', () => {
+  const runbook = loadRunbook()
+  assert.match(runbook, /T2\.5/, 'runbook must name the T2.5 decision branch')
+  assert.match(runbook, /CONFIRMED/, 'runbook must include CONFIRMED verdict')
+  assert.match(runbook, /DISPROVED/, 'runbook must include DISPROVED verdict')
+  assert.match(runbook, /INCONCLUSIVE/, 'runbook must include INCONCLUSIVE verdict')
+  assert.match(
+    runbook,
+    /T3 remains frozen|keeps T3 frozen|T3 frozen/i,
+    'inconclusive path must keep T3 frozen',
+  )
+  assert.match(
+    runbook,
+    /_TBD_/,
+    'evidence block must stay TBD until real two-corp staging (no fabricated verdict)',
+  )
+  assert.match(
+    runbook,
+    /do not fabricate|leave §4 TBD|leave TBD/i,
+    'runbook must forbid fabricating a staging verdict in-repo',
+  )
+})
+
+test('T2-Gate runbook values-free scope allows provenance (SHA / actor / integration ids), bans provider identity', () => {
+  const runbook = loadRunbook()
+  // Provenance fields in §4 evidence block + explicit allow-list wording.
+  assert.match(runbook, /staging SHA:/, 'evidence block records exact staging SHA')
+  assert.match(runbook, /executed by \/ date:/, 'evidence block records execution date/actor')
+  assert.match(
+    runbook,
+    /corp A integration id:/,
+    'evidence block records internal integration resource id for corp A',
+  )
+  assert.match(
+    runbook,
+    /Provenance is allowed|provenance is allowed/i,
+    'runbook must state that SHA/date/actor/integration ids are allowed provenance',
+  )
+  assert.match(
+    runbook,
+    /provider identity|raw provider/i,
+    'values-free ban must target provider identity, not unbounded "raw IDs"',
+  )
+  assert.match(
+    runbook,
+    /booleans\s*\/\s*counts\s*\/\s*statuses|booleans \/ counts \/ statuses/i,
+    'SQL outputs remain booleans/counts/statuses only',
+  )
+})


### PR DESCRIPTION
## Scope

Closes the automatable half of Transfer **T2-Gate** after T1 and T2 landed:

- T1 merged as `b9b354a38ddc34845fbbf71e87863fbe191eee16`.
- T2 merged as `85ef8b7ab84f6546c4d01bf3068dbd7960709bd7`.
- This PR is rebased directly on that T2 merge; reviewed head: `3f657e56f264c20ba93b6cd5329e8cc01d9e456f`.

It adds:

1. a real-Postgres mechanism suite proving the current `(provider, external_key)` collision behavior, bare `unionId || openId || userId` derivation, wholesale rollback of the second corp sync, and the distinct-key coexistence control;
2. a values-free two-real-corp staging runbook with a conditional T2.5 decision;
3. fail-honest CI wiring and runbook contracts.

## Boundary

This PR **does not** claim the real two-corp result. The runbook evidence remains `_TBD_` and owner/ops-gated:

- `CONFIRMED` collision: T2.5 tenant-scoped key migration must land before T3.
- owner-accepted `DISPROVED`: T2.5 may be skipped and T3 unlocked.
- `INCONCLUSIVE`: T3 remains frozen.

Operator evidence excludes raw provider identity, business values, and raw SQL error text. It records only closed booleans/counts/statuses plus allowed provenance (SHA, date/actor, internal integration resource IDs).

## Implementation and review

Grok Build implemented the closeout and follow-up hardening. Codex independently inspected the six-file diff, rebased it onto the landed T2 merge, reproduced the load-bearing failures, and reran the tests.

### Exact-head local verification

- `pnpm --filter @metasheet/core-backend type-check`
- T1 + T2 + T2-Gate real-DB composition: **43/43**
- T2-Gate no-DB wiring + values-free contracts: **22/22**
- migration replay on the review DB: two consecutive passes
- `git diff --check`

### Load-bearing checks reproduced

- Injecting a corp-B department before the collision assertion reddens the wholesale-rollback test.
- Replacing the closed boolean with `substring(error_message, ...) AS duplicate_key_detected` reddens the values-free contract.
- Commenting out the direct `test.exclude` entry reddens only the placement contract.
- Removing the whole-file approval real-DB placement, moving it to the wrong step, omitting `DATABASE_URL`, or relying on comments cannot satisfy the wiring guard.

## Files

- `.github/workflows/plugin-tests.yml`
- `packages/core-backend/vitest.config.ts`
- `packages/core-backend/tests/integration/directory-account-external-key-collision-mechanism.db.test.ts`
- `scripts/ops/t2gate-collision-mechanism-ci-wiring.test.mjs`
- `scripts/ops/t2gate-runbook-values-free-contract.test.mjs`
- `docs/development/canonical-org-t2-gate-two-corp-staging-runbook-20260717.md`
