### PR TITLE
fix(web): plm-workbench focus allowlist — include /stock-prep

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -154,7 +154,11 @@ router.beforeEach(async (to, _from, next) => {
 
     if (typeof flags.isPlmWorkbenchFocused === 'function' && flags.isPlmWorkbenchFocused()) {
       const path = String(to.path || '')
-      const allowedPrefixes = ['/plm', '/workflows', '/approvals', '/integrations']
+      // '/stock-prep': the stock-preparation operator shell is the natural companion of the PLM
+      // workbench audience; it was missing from this allowlist so plm-workbench-focused users were
+      // redirected away from it (generalization proposal round-1, owner-confirmed gap). The route
+      // keeps its own integration:write permission gate — this only restores reachability.
+      const allowedPrefixes = ['/plm', '/workflows', '/approvals', '/integrations', '/stock-prep']
       const allowed = allowedPrefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))
       if (!allowed) {
         return next('/plm')

--- a/apps/web/tests/StockPreparationWorkspace.spec.ts
+++ b/apps/web/tests/StockPreparationWorkspace.spec.ts
@@ -156,6 +156,26 @@ describe('Stock Preparation route registration (source drift pin)', () => {
     const TYPES = readFileSync(join(__dirname, '../src/router/types.ts'), 'utf8')
     expect(TYPES).toContain("INTEGRATION_STOCK_PREPARATION: 'integration-stock-preparation'")
   })
+
+  // Regression pin for the plm-workbench focus allowlist fix: the guard allowlist is inline in
+  // main.ts (no unit seam until the P2 manifest-driven refactor), so pin it at source level like the
+  // route block above. Deleting '/stock-prep' from the allowlist turns this red. The permission
+  // semantics are NOT relaxed by the allowlist: main.ts runs the isRoutePermitted check BEFORE the
+  // focus-mode allowlists, and the /stock-prep route keeps its integration:write gate (asserted on
+  // the route block above) — the allowlist only restores reachability for authorized users.
+  it('plm-workbench focus allowlist contains exactly /stock-prep alongside the workbench prefixes', () => {
+    const MAIN = readFileSync(join(__dirname, '../src/main.ts'), 'utf8')
+    const focusIdx = MAIN.indexOf('isPlmWorkbenchFocused')
+    expect(focusIdx, 'plm-workbench focus block must exist in main.ts').toBeGreaterThan(-1)
+    const listStart = MAIN.indexOf('allowedPrefixes', focusIdx)
+    expect(listStart, 'plm-workbench allowedPrefixes must exist').toBeGreaterThan(-1)
+    const listEnd = MAIN.indexOf(']', listStart)
+    const allowlist = MAIN.slice(listStart, listEnd + 1)
+    expect(allowlist).toContain("'/stock-prep'")
+    expect(allowlist).toContain("'/integrations'")
+    // Permission check ordering: isRoutePermitted must appear BEFORE the focus-mode blocks.
+    expect(MAIN.indexOf('isRoutePermitted')).toBeLessThan(focusIdx)
+  })
 })
 
 describe('StockPreparationWorkspace shell', () => {


### PR DESCRIPTION
V0 of the generalization proposal (#4467) landing order — the one item the owner marked 现在可开发.

plm-workbench-focused mode's route allowlist (`main.ts:155`) omitted `/stock-prep`, so the stock-prep operator shell's natural audience was redirected to `/plm`. One-line allowlist addition + rationale comment. The route keeps its own `integration:write` permission gate — this only restores reachability for already-authorized users.

vue-tsc green; App / platform-shell-nav / featureFlags.plm specs 11/11. The guard allowlist is inline in main.ts with no direct spec — extracting it for testability belongs to P2 (manifest-driven focus modes), not this fix.

**Not armed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)