### PR TITLE
refactor(web)+test: pure route-guard policy behavior-pinned, adapter-bound delegation (allowlist pin line, rounds 6-15)

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -22,7 +22,7 @@ import App from './App.vue'
 import { useAuth } from './composables/useAuth'
 import { resolveAdminRouteRedirect } from './router/adminAccess'
 import { appRoutes } from './router/appRoutes'
-import { buildRouteGuardContext, resolveRouteGuardDecision } from './router/guardPolicy'
+import { buildRouteGuardContext, buildRouteGuardInput, resolveRouteGuardDecision } from './router/guardPolicy'
 import { ROUTE_PATHS } from './router/types'
 import { resolveRouteDocumentTitle } from './router/routeTitles'
 import { useFeatureFlags } from './stores/featureFlags'
@@ -125,7 +125,7 @@ router.beforeEach(async (to, _from, next) => {
     // Feature / permission / focus-mode decisions live in the PURE policy module (round-12: pinned
     // by behavior tests + a thin structural delegation pin; do not re-inline decision logic here).
     const decision = resolveRouteGuardDecision(
-      { path: String(to.path || ''), meta: to.meta },
+      buildRouteGuardInput(to),
       buildRouteGuardContext({ auth, flags }),
     )
     if (decision.action === 'redirect') {

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -22,7 +22,7 @@ import App from './App.vue'
 import { useAuth } from './composables/useAuth'
 import { resolveAdminRouteRedirect } from './router/adminAccess'
 import { appRoutes } from './router/appRoutes'
-import { isRoutePermitted } from './router/routeAccess'
+import { resolveRouteGuardDecision } from './router/guardPolicy'
 import { ROUTE_PATHS } from './router/types'
 import { resolveRouteDocumentTitle } from './router/routeTitles'
 import { useFeatureFlags } from './stores/featureFlags'
@@ -122,47 +122,21 @@ router.beforeEach(async (to, _from, next) => {
     }
     await flags.loadProductFeatures()
 
-    const required = to.meta?.requiredFeature
-    const requiredFeature =
-      required === 'attendance'
-      || required === 'workflow'
-      || required === 'attendanceAdmin'
-      || required === 'attendanceImport'
-      || required === 'plm'
-        ? required
-        : null
-
-    if (requiredFeature && !flags.hasFeature(requiredFeature)) {
-      return next(flags.resolveHomePath())
-    }
-
-    if (!isRoutePermitted(to.meta, (permission) => auth.hasPermission(permission))) {
-      return next(flags.resolveHomePath())
-    }
-
-    if (flags.isAttendanceFocused()) {
-      const allowed = new Set<string>([
-        '/attendance',
-        '/p/plugin-attendance/attendance',
-        '/settings',
-      ])
-      const path = String(to.path || '')
-      if (!allowed.has(path)) {
-        return next('/attendance')
-      }
-    }
-
-    if (typeof flags.isPlmWorkbenchFocused === 'function' && flags.isPlmWorkbenchFocused()) {
-      const path = String(to.path || '')
-      // '/stock-prep': the stock-preparation operator shell is the natural companion of the PLM
-      // workbench audience; it was missing from this allowlist so plm-workbench-focused users were
-      // redirected away from it (generalization proposal round-1, owner-confirmed gap). The route
-      // keeps its own integration:write permission gate — this only restores reachability.
-      const allowedPrefixes = ['/plm', '/workflows', '/approvals', '/integrations', '/stock-prep']
-      const allowed = allowedPrefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))
-      if (!allowed) {
-        return next('/plm')
-      }
+    // Feature / permission / focus-mode decisions live in the PURE policy module (round-12: pinned
+    // by behavior tests + a thin structural delegation pin; do not re-inline decision logic here).
+    const decision = resolveRouteGuardDecision(
+      { path: String(to.path || ''), meta: to.meta },
+      {
+        hasFeature: (feature) => flags.hasFeature(feature),
+        hasPermission: (permission) => auth.hasPermission(permission),
+        attendanceFocused: flags.isAttendanceFocused(),
+        plmWorkbenchFocused:
+          typeof flags.isPlmWorkbenchFocused === 'function' && flags.isPlmWorkbenchFocused(),
+        resolveHomePath: () => flags.resolveHomePath(),
+      },
+    )
+    if (decision.action === 'redirect') {
+      return next(decision.target)
     }
   } catch {
     // If guard fails (network/offline), don't block navigation.

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -22,7 +22,7 @@ import App from './App.vue'
 import { useAuth } from './composables/useAuth'
 import { resolveAdminRouteRedirect } from './router/adminAccess'
 import { appRoutes } from './router/appRoutes'
-import { resolveRouteGuardDecision } from './router/guardPolicy'
+import { buildRouteGuardContext, resolveRouteGuardDecision } from './router/guardPolicy'
 import { ROUTE_PATHS } from './router/types'
 import { resolveRouteDocumentTitle } from './router/routeTitles'
 import { useFeatureFlags } from './stores/featureFlags'
@@ -126,14 +126,7 @@ router.beforeEach(async (to, _from, next) => {
     // by behavior tests + a thin structural delegation pin; do not re-inline decision logic here).
     const decision = resolveRouteGuardDecision(
       { path: String(to.path || ''), meta: to.meta },
-      {
-        hasFeature: (feature) => flags.hasFeature(feature),
-        hasPermission: (permission) => auth.hasPermission(permission),
-        attendanceFocused: flags.isAttendanceFocused(),
-        plmWorkbenchFocused:
-          typeof flags.isPlmWorkbenchFocused === 'function' && flags.isPlmWorkbenchFocused(),
-        resolveHomePath: () => flags.resolveHomePath(),
-      },
+      buildRouteGuardContext({ auth, flags }),
     )
     if (decision.action === 'redirect') {
       return next(decision.target)

--- a/apps/web/src/router/guardPolicy.ts
+++ b/apps/web/src/router/guardPolicy.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure route-guard decision policy (round-12 terminal state of the #4468/#4469 review line).
+ *
+ * Eleven review rounds showed that source/AST pinning of guard semantics inside main.ts trends
+ * toward interpreter complexity: every "the structure exists" assertion admitted one more decoy
+ * (import-vs-call, bare call, whole-file walk, dead-branch copies, coerced allowlists…). The stable
+ * fix is the one the review prescribed: the DECISION logic is a directly executable pure function,
+ * pinned by BEHAVIOR tests (permission → focus → redirect), and main.ts keeps only side-effectful
+ * loading plus a thin, structurally-pinned delegation to this module.
+ *
+ * Ordering contract (behavior-tested; do not reorder):
+ *   1. required-feature gate  → redirect home
+ *   2. route permission gate  → redirect home
+ *   3. attendance focus mode  → exact-path allowlist, else redirect /attendance
+ *   4. plm-workbench focus    → prefix allowlist, else redirect /plm
+ *   5. allow
+ */
+import { isRoutePermitted } from './routeAccess'
+
+/** Attendance focus mode allows EXACT paths only (no prefixes — '/attendance/x' redirects). */
+export const ATTENDANCE_FOCUS_ALLOWED_PATHS: readonly string[] = Object.freeze([
+  '/attendance',
+  '/p/plugin-attendance/attendance',
+  '/settings',
+])
+
+/**
+ * plm-workbench focus mode allows these prefixes (exact match or `${prefix}/…`).
+ * '/stock-prep': the stock-preparation operator shell is the natural companion of the PLM workbench
+ * audience (#4468, owner-confirmed gap). Routes keep their own permission gates — this list only
+ * governs reachability inside the focus mode. Every entry must be a non-empty absolute path: an
+ * empty string would prefix-match EVERY route (behavior-tested).
+ */
+export const PLM_WORKBENCH_ALLOWED_PREFIXES: readonly string[] = Object.freeze([
+  '/plm',
+  '/workflows',
+  '/approvals',
+  '/integrations',
+  '/stock-prep',
+])
+
+const KNOWN_REQUIRED_FEATURES = ['attendance', 'workflow', 'attendanceAdmin', 'attendanceImport', 'plm'] as const
+type KnownRequiredFeature = (typeof KNOWN_REQUIRED_FEATURES)[number]
+
+export type RouteGuardDecision = { action: 'allow' } | { action: 'redirect'; target: string }
+
+export interface RouteGuardPolicyContext {
+  hasFeature: (feature: KnownRequiredFeature) => boolean
+  hasPermission: (permission: string) => boolean
+  attendanceFocused: boolean
+  plmWorkbenchFocused: boolean
+  resolveHomePath: () => string
+}
+
+export function resolveRouteGuardDecision(
+  input: { path: string; meta: unknown },
+  ctx: RouteGuardPolicyContext,
+): RouteGuardDecision {
+  const meta = (input.meta ?? {}) as Record<string, unknown>
+
+  // 1. required-feature gate (unknown feature strings are ignored, same as the pre-extraction guard).
+  const required = meta.requiredFeature
+  const requiredFeature = KNOWN_REQUIRED_FEATURES.includes(required as KnownRequiredFeature)
+    ? (required as KnownRequiredFeature)
+    : null
+  if (requiredFeature && !ctx.hasFeature(requiredFeature)) {
+    return { action: 'redirect', target: ctx.resolveHomePath() }
+  }
+
+  // 2. route permission gate — runs BEFORE any focus allowlist (an allowlist can restore
+  //    reachability but never grant permission).
+  if (!isRoutePermitted(input.meta as Parameters<typeof isRoutePermitted>[0], ctx.hasPermission)) {
+    return { action: 'redirect', target: ctx.resolveHomePath() }
+  }
+
+  const path = String(input.path || '')
+
+  // 3. attendance focus: exact-path set.
+  if (ctx.attendanceFocused && !ATTENDANCE_FOCUS_ALLOWED_PATHS.includes(path)) {
+    return { action: 'redirect', target: '/attendance' }
+  }
+
+  // 4. plm-workbench focus: prefix allowlist.
+  if (ctx.plmWorkbenchFocused) {
+    const allowed = PLM_WORKBENCH_ALLOWED_PREFIXES.some(
+      (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+    )
+    if (!allowed) {
+      return { action: 'redirect', target: '/plm' }
+    }
+  }
+
+  return { action: 'allow' }
+}

--- a/apps/web/src/router/guardPolicy.ts
+++ b/apps/web/src/router/guardPolicy.ts
@@ -52,6 +52,35 @@ export interface RouteGuardPolicyContext {
   resolveHomePath: () => string
 }
 
+
+/**
+ * Executable runtime adapter (round-13): builds the policy context from the live auth/flags stores.
+ * Extracted so its wiring is BEHAVIOR-testable with injected fakes — hasPermission must delegate to
+ * auth.hasPermission (a constant () => true here would disable real route permissions, which the
+ * adapter tests pin), and the plm-focus typeof tolerance lives here, not inline in main.ts.
+ */
+export interface RouteGuardRuntimeDeps {
+  auth: { hasPermission: (permission: string) => boolean }
+  flags: {
+    hasFeature: (feature: KnownRequiredFeature) => boolean
+    isAttendanceFocused: () => boolean
+    isPlmWorkbenchFocused?: unknown
+    resolveHomePath: () => string
+  }
+}
+
+export function buildRouteGuardContext(deps: RouteGuardRuntimeDeps): RouteGuardPolicyContext {
+  return {
+    hasFeature: (feature) => deps.flags.hasFeature(feature),
+    hasPermission: (permission) => deps.auth.hasPermission(permission),
+    attendanceFocused: deps.flags.isAttendanceFocused(),
+    plmWorkbenchFocused:
+      typeof deps.flags.isPlmWorkbenchFocused === 'function' &&
+      (deps.flags.isPlmWorkbenchFocused as () => boolean)(),
+    resolveHomePath: () => deps.flags.resolveHomePath(),
+  }
+}
+
 export function resolveRouteGuardDecision(
   input: { path: string; meta: unknown },
   ctx: RouteGuardPolicyContext,

--- a/apps/web/src/router/guardPolicy.ts
+++ b/apps/web/src/router/guardPolicy.ts
@@ -69,6 +69,16 @@ export interface RouteGuardRuntimeDeps {
   }
 }
 
+
+/**
+ * Executable input adapter (round-14): path/meta passthrough from the live route object. Extracted
+ * so the wiring is behavior-testable — meta must be passed through IDENTICALLY (an inline `meta: {}`
+ * would bypass every route's requiredFeature and permissions), and path folds to a string.
+ */
+export function buildRouteGuardInput(to: { path?: unknown; meta?: unknown }): { path: string; meta: unknown } {
+  return { path: String((to && to.path) || ''), meta: to ? to.meta : undefined }
+}
+
 export function buildRouteGuardContext(deps: RouteGuardRuntimeDeps): RouteGuardPolicyContext {
   return {
     hasFeature: (feature) => deps.flags.hasFeature(feature),

--- a/apps/web/tests/StockPreparationWorkspace.spec.ts
+++ b/apps/web/tests/StockPreparationWorkspace.spec.ts
@@ -157,55 +157,121 @@ describe('Stock Preparation route registration (source drift pin)', () => {
     expect(TYPES).toContain("INTEGRATION_STOCK_PREPARATION: 'integration-stock-preparation'")
   })
 
-  // Regression pin for the plm-workbench focus allowlist fix (round-7 hardening: the original pin's
-  // indexOf('isRoutePermitted') matched the IMPORT at the top of main.ts, not the real guard call —
-  // a mutation deleting the call still passed). The pin now walks the TypeScript AST: it locates the
-  // ACTUAL isRoutePermitted(...) call expression and the ACTUAL isPlmWorkbenchFocused() call inside
-  // the router guard and compares their positions, and it parses the allowedPrefixes array literal
-  // for an EXACT membership comparison. Deleting '/stock-prep', deleting the permission call, or
-  // moving it after the focus block turns this red (mutation-verified). Runtime semantics: the
-  // allowlist never relaxes the route's integration:write gate (route-block pin above).
-  it('plm-workbench focus allowlist is exactly the workbench prefixes + /stock-prep, and the real permission call precedes the focus block (AST)', async () => {
+  // Regression pin for the plm-workbench focus allowlist fix (round-8 hardening). History: the
+  // round-6 indexOf pin matched the IMPORT, not the call; the round-7 AST pin proved the call exists
+  // and where — but not that its RETURN VALUE controls the deny branch (a bare isRoutePermitted(...)
+  // statement still passed), and it walked the whole file (a same-named call in an uncalled helper
+  // could fake it). This version locates STRUCTURE, scoped to the router.beforeEach callback:
+  //   1. the beforeEach callback itself;
+  //   2. inside it, the IfStatement whose condition is EXACTLY !isRoutePermitted(...);
+  //   3. that branch must contain return next(...) — the call ENFORCES, not merely runs;
+  //   4. the flags.isPlmWorkbenchFocused() condition block in the SAME callback, positioned AFTER 2;
+  //   5. allowedPrefixes must live INSIDE that focus block, compared EXACTLY.
+  // Mutations (all verified RED): delete the call; keep the call but strip the enforcing if; move the
+  // enforcing if after the focus block; relocate it to a helper outside the callback; drop '/stock-prep'.
+  it('router.beforeEach: !isRoutePermitted(...) ENFORCES (return next) before the plm-workbench focus block, whose allowlist is exactly the workbench prefixes + /stock-prep (AST)', async () => {
     const ts = (await import('typescript')).default
+    type TsNode = import('typescript').Node
     const MAIN = readFileSync(join(__dirname, '../src/main.ts'), 'utf8')
     const source = ts.createSourceFile('main.ts', MAIN, ts.ScriptTarget.ES2022, true)
 
-    let permittedCallPos = -1
-    let plmFocusCallPos = -1
-    let allowlist: string[] | null = null
-    const visit = (node: import('typescript').Node): void => {
-      if (ts.isCallExpression(node)) {
-        const callee = node.expression
-        if (ts.isIdentifier(callee) && callee.text === 'isRoutePermitted' && permittedCallPos === -1) {
-          permittedCallPos = node.getStart(source)
-        }
-        if (
-          ts.isPropertyAccessExpression(callee) &&
-          callee.name.text === 'isPlmWorkbenchFocused' &&
-          plmFocusCallPos === -1
-        ) {
-          plmFocusCallPos = node.getStart(source)
-        }
-      }
+    // 1. locate the router.beforeEach(...) callback.
+    let guardBody: TsNode | null = null
+    const findGuard = (node: TsNode): void => {
       if (
-        ts.isVariableDeclaration(node) &&
-        ts.isIdentifier(node.name) &&
-        node.name.text === 'allowedPrefixes' &&
-        node.initializer &&
-        ts.isArrayLiteralExpression(node.initializer)
+        guardBody === null &&
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === 'beforeEach' &&
+        ts.isIdentifier(node.expression.expression) &&
+        node.expression.expression.text === 'router' &&
+        node.arguments.length >= 1 &&
+        (ts.isArrowFunction(node.arguments[0]) || ts.isFunctionExpression(node.arguments[0]))
       ) {
-        allowlist = node.initializer.elements
-          .filter((el): el is import('typescript').StringLiteral => ts.isStringLiteral(el))
-          .map((el) => el.text)
+        guardBody = (node.arguments[0] as import('typescript').ArrowFunction).body
+        return
       }
-      ts.forEachChild(node, visit)
+      ts.forEachChild(node, findGuard)
     }
-    visit(source)
+    findGuard(source)
+    expect(guardBody, 'router.beforeEach(callback) must exist').not.toBeNull()
 
-    expect(permittedCallPos, 'the real isRoutePermitted(...) CALL must exist (imports do not count)').toBeGreaterThan(-1)
-    expect(plmFocusCallPos, 'the real isPlmWorkbenchFocused() call must exist').toBeGreaterThan(-1)
-    expect(permittedCallPos, 'permission check must run BEFORE the plm-workbench focus block').toBeLessThan(plmFocusCallPos)
-    expect(allowlist, 'plm-workbench allowedPrefixes array must exist').not.toBeNull()
+    const containsReturnNext = (node: TsNode): boolean => {
+      let found = false
+      const walk = (n: TsNode): void => {
+        if (
+          ts.isReturnStatement(n) &&
+          n.expression &&
+          ts.isCallExpression(n.expression) &&
+          ts.isIdentifier(n.expression.expression) &&
+          n.expression.expression.text === 'next'
+        ) {
+          found = true
+        }
+        if (!found) ts.forEachChild(n, walk)
+      }
+      walk(node)
+      return found
+    }
+
+    // 2-5. scoped scan of the guard body only.
+    let enforcingIfPos = -1
+    let plmFocusIfPos = -1
+    let allowlist: string[] | null = null
+    const scan = (node: TsNode): void => {
+      if (ts.isIfStatement(node)) {
+        const cond = node.expression
+        if (
+          enforcingIfPos === -1 &&
+          ts.isPrefixUnaryExpression(cond) &&
+          cond.operator === ts.SyntaxKind.ExclamationToken &&
+          ts.isCallExpression(cond.operand) &&
+          ts.isIdentifier(cond.operand.expression) &&
+          cond.operand.expression.text === 'isRoutePermitted' &&
+          containsReturnNext(node.thenStatement)
+        ) {
+          enforcingIfPos = node.getStart(source)
+        }
+        let mentionsPlmFocusCall = false
+        const inspectCond = (n: TsNode): void => {
+          if (
+            ts.isCallExpression(n) &&
+            ts.isPropertyAccessExpression(n.expression) &&
+            n.expression.name.text === 'isPlmWorkbenchFocused'
+          ) {
+            mentionsPlmFocusCall = true
+          }
+          ts.forEachChild(n, inspectCond)
+        }
+        inspectCond(cond)
+        if (mentionsPlmFocusCall && plmFocusIfPos === -1) {
+          plmFocusIfPos = node.getStart(source)
+          // 5. allowedPrefixes must live INSIDE this focus block.
+          const findAllowlist = (n: TsNode): void => {
+            if (
+              ts.isVariableDeclaration(n) &&
+              ts.isIdentifier(n.name) &&
+              n.name.text === 'allowedPrefixes' &&
+              n.initializer &&
+              ts.isArrayLiteralExpression(n.initializer)
+            ) {
+              allowlist = n.initializer.elements
+                .filter((el): el is import('typescript').StringLiteral => ts.isStringLiteral(el))
+                .map((el) => el.text)
+            }
+            ts.forEachChild(n, findAllowlist)
+          }
+          findAllowlist(node.thenStatement)
+        }
+      }
+      ts.forEachChild(node, scan)
+    }
+    scan(guardBody!)
+
+    expect(enforcingIfPos, 'the guard must contain if (!isRoutePermitted(...)) { ... return next(...) } — a bare call does not enforce').toBeGreaterThan(-1)
+    expect(plmFocusIfPos, 'the plm-workbench focus if-block must exist inside the guard').toBeGreaterThan(-1)
+    expect(enforcingIfPos, 'the enforcing permission check must precede the plm-workbench focus block').toBeLessThan(plmFocusIfPos)
+    expect(allowlist, 'allowedPrefixes must be declared INSIDE the plm-workbench focus block').not.toBeNull()
     expect(allowlist).toEqual(['/plm', '/workflows', '/approvals', '/integrations', '/stock-prep'])
   })
 })

--- a/apps/web/tests/StockPreparationWorkspace.spec.ts
+++ b/apps/web/tests/StockPreparationWorkspace.spec.ts
@@ -5,6 +5,7 @@ import {
   ATTENDANCE_FOCUS_ALLOWED_PATHS,
   PLM_WORKBENCH_ALLOWED_PREFIXES,
   buildRouteGuardContext,
+  buildRouteGuardInput,
   resolveRouteGuardDecision,
 } from '../src/router/guardPolicy'
 import { join } from 'node:path'
@@ -267,6 +268,55 @@ describe('Stock Preparation route registration (source drift pin)', () => {
       expect(resolveRouteGuardDecision({ path: '/stock-prep', meta: { permissions: ['integration:write'] } }, buildRouteGuardContext(denyDeps)))
         .toEqual({ action: 'redirect', target: '/HOME' })
     })
+
+    // Round-14: the INPUT adapter is behavior-pinned too — meta must pass through IDENTICALLY
+    // (an inline meta: {} bypassed every route's requiredFeature/permissions, M20).
+    it('buildRouteGuardInput passes meta through identically and folds path to a string', () => {
+      const meta = { permissions: ['integration:write'], requiredFeature: 'plm' }
+      const input = buildRouteGuardInput({ path: '/stock-prep', meta })
+      expect(input.meta).toBe(meta)
+      expect(input.path).toBe('/stock-prep')
+      expect(buildRouteGuardInput({ path: undefined, meta }).path).toBe('')
+      expect(buildRouteGuardInput({ path: 123 as unknown as string, meta }).path).toBe('123')
+      // end-to-end: real route meta flows through input adapter + ctx adapter into the policy.
+      const deps = {
+        auth: { hasPermission: () => false },
+        flags: {
+          hasFeature: () => true,
+          isAttendanceFocused: () => false,
+          isPlmWorkbenchFocused: () => false,
+          resolveHomePath: () => '/HOME',
+        },
+      }
+      expect(resolveRouteGuardDecision(buildRouteGuardInput({ path: '/stock-prep', meta }), buildRouteGuardContext(deps)))
+        .toEqual({ action: 'redirect', target: '/HOME' })
+    })
+
+    // Round-14: adapter fields item-by-item (M21 proved hasFeature was unpinned; attendanceFocused
+    // and resolveHomePath get the same treatment).
+    it('buildRouteGuardContext delegates hasFeature / attendanceFocused / resolveHomePath faithfully', () => {
+      const featureSeen: string[] = []
+      const deps = {
+        auth: { hasPermission: () => true },
+        flags: {
+          hasFeature: (f: string) => { featureSeen.push(f); return f === 'plm' },
+          isAttendanceFocused: () => true,
+          isPlmWorkbenchFocused: () => false,
+          resolveHomePath: () => '/HOME-LAZY',
+        },
+      }
+      const built = buildRouteGuardContext(deps)
+      expect(built.hasFeature('plm' as never)).toBe(true)
+      expect(built.hasFeature('workflow' as never)).toBe(false)
+      expect(featureSeen).toEqual(['plm', 'workflow'])
+      expect(built.attendanceFocused).toBe(true)
+      expect(built.resolveHomePath()).toBe('/HOME-LAZY')
+      // adapter+policy feature-deny discriminating leg: a real feature denial through the ADAPTER
+      // must redirect home (an adapter hasFeature: () => true erases this).
+      const denyFeature = { ...deps, flags: { ...deps.flags, hasFeature: () => false, isAttendanceFocused: () => false } }
+      expect(resolveRouteGuardDecision({ path: '/plm', meta: { requiredFeature: 'plm' } }, buildRouteGuardContext(denyFeature)))
+        .toEqual({ action: 'redirect', target: '/HOME-LAZY' })
+    })
   })
 
   // Thin delegation pin: main.ts must DELEGATE to the policy as DIRECT statements of the guard's
@@ -280,7 +330,7 @@ describe('Stock Preparation route registration (source drift pin)', () => {
     expect(MAIN).not.toContain('allowedPrefixes')
     expect(MAIN).not.toContain('isRoutePermitted(')
     expect(MAIN).not.toContain('hasPermission:')
-    expect(MAIN).toContain("import { buildRouteGuardContext, resolveRouteGuardDecision } from './router/guardPolicy'")
+    expect(MAIN).toContain("import { buildRouteGuardContext, buildRouteGuardInput, resolveRouteGuardDecision } from './router/guardPolicy'")
 
     const source = ts.createSourceFile('main.ts', MAIN, ts.ScriptTarget.ES2022, true)
     let guardBody: import('typescript').Block | null = null
@@ -323,9 +373,12 @@ describe('Stock Preparation route registration (source drift pin)', () => {
             ts.isCallExpression(d.initializer) &&
             ts.isIdentifier(d.initializer.expression) &&
             d.initializer.expression.text === 'resolveRouteGuardDecision' &&
-            // Round-13: the SECOND argument must be the executable adapter call — an inline object
-            // (where hasPermission: () => true could hide) is not an accepted shape.
+            // Round-13/14: BOTH arguments must be executable adapter calls — inline objects (where
+            // hasPermission: () => true or meta: {} could hide) are not accepted shapes.
             d.initializer.arguments.length === 2 &&
+            ts.isCallExpression(d.initializer.arguments[0]) &&
+            ts.isIdentifier((d.initializer.arguments[0] as import('typescript').CallExpression).expression) &&
+            ((d.initializer.arguments[0] as import('typescript').CallExpression).expression as import('typescript').Identifier).text === 'buildRouteGuardInput' &&
             ts.isCallExpression(d.initializer.arguments[1]) &&
             ts.isIdentifier((d.initializer.arguments[1] as import('typescript').CallExpression).expression) &&
             ((d.initializer.arguments[1] as import('typescript').CallExpression).expression as import('typescript').Identifier).text === 'buildRouteGuardContext',

--- a/apps/web/tests/StockPreparationWorkspace.spec.ts
+++ b/apps/web/tests/StockPreparationWorkspace.spec.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h as vh, nextTick, ref, type App as VueApp, type Component } from 'vue'
 import { readFileSync } from 'node:fs'
+import {
+  ATTENDANCE_FOCUS_ALLOWED_PATHS,
+  PLM_WORKBENCH_ALLOWED_PREFIXES,
+  resolveRouteGuardDecision,
+} from '../src/router/guardPolicy'
 import { join } from 'node:path'
 
 // Stock Preparation MVP (#3751 — docs/development/stock-preparation-mvp-design-20260707.md).
@@ -157,26 +162,76 @@ describe('Stock Preparation route registration (source drift pin)', () => {
     expect(TYPES).toContain("INTEGRATION_STOCK_PREPARATION: 'integration-stock-preparation'")
   })
 
-  // Regression pin for the plm-workbench focus allowlist fix (round-8 hardening). History: the
-  // round-6 indexOf pin matched the IMPORT, not the call; the round-7 AST pin proved the call exists
-  // and where — but not that its RETURN VALUE controls the deny branch (a bare isRoutePermitted(...)
-  // statement still passed), and it walked the whole file (a same-named call in an uncalled helper
-  // could fake it). This version locates STRUCTURE, scoped to the router.beforeEach callback:
-  //   1. the beforeEach callback itself;
-  //   2. inside it, the IfStatement whose condition is EXACTLY !isRoutePermitted(...);
-  //   3. that branch must contain return next(...) — the call ENFORCES, not merely runs;
-  //   4. the flags.isPlmWorkbenchFocused() condition block in the SAME callback, positioned AFTER 2;
-  //   5. allowedPrefixes must live INSIDE that focus block, compared EXACTLY.
-  // Mutations (all verified RED): delete the call; keep the call but strip the enforcing if; move the
-  // enforcing if after the focus block; relocate it to a helper outside the callback; drop '/stock-prep'.
-  it('router.beforeEach: !isRoutePermitted(...) ENFORCES (return next) before the plm-workbench focus block, whose allowlist is exactly the workbench prefixes + /stock-prep (AST)', async () => {
+  // Round-12 terminal state (owner-prescribed): guard decision logic is a PURE, directly
+  // executable function (src/router/guardPolicy.ts) pinned by BEHAVIOR — permission ordering,
+  // focus semantics and redirect targets are exercised, not pattern-matched. main.ts keeps only a
+  // thin delegation, pinned structurally below (direct statements of the guard's try block).
+  describe('route guard policy (behavior)', () => {
+    const ctx = (over: Partial<import('../src/router/guardPolicy').RouteGuardPolicyContext> = {}) => ({
+      hasFeature: () => true,
+      hasPermission: () => true,
+      attendanceFocused: false,
+      plmWorkbenchFocused: false,
+      resolveHomePath: () => '/HOME',
+      ...over,
+    })
+    const decide = (path: string, meta: unknown, over: Parameters<typeof ctx>[0] = {}) =>
+      resolveRouteGuardDecision({ path, meta }, ctx(over))
+
+    it('permission denial redirects home and WINS over a focus-mode allowlist match (ordering)', () => {
+      expect(decide('/stock-prep', { permissions: ['integration:write'] }, { hasPermission: () => false, plmWorkbenchFocused: true }))
+        .toEqual({ action: 'redirect', target: '/HOME' })
+      expect(decide('/stock-prep', { permissions: ['integration:write'] }, { plmWorkbenchFocused: true }))
+        .toEqual({ action: 'allow' })
+    })
+
+    it('plm-workbench focus: every allowlisted prefix (exact and subpath) is reachable — /stock-prep included', () => {
+      for (const prefix of PLM_WORKBENCH_ALLOWED_PREFIXES) {
+        expect(decide(prefix, {}, { plmWorkbenchFocused: true })).toEqual({ action: 'allow' })
+        expect(decide(`${prefix}/deep/link`, {}, { plmWorkbenchFocused: true })).toEqual({ action: 'allow' })
+      }
+    })
+
+    it('plm-workbench focus: anything else redirects to /plm (an empty/loose prefix would break this)', () => {
+      for (const path of ['/multitable', '/apps', '/stock-preparation', '/x', '']) {
+        expect(decide(path, {}, { plmWorkbenchFocused: true })).toEqual({ action: 'redirect', target: '/plm' })
+      }
+    })
+
+    it('attendance focus: exact paths only — subpaths redirect to /attendance', () => {
+      for (const path of ATTENDANCE_FOCUS_ALLOWED_PATHS) {
+        expect(decide(path, {}, { attendanceFocused: true })).toEqual({ action: 'allow' })
+      }
+      expect(decide('/attendance/sub', {}, { attendanceFocused: true })).toEqual({ action: 'redirect', target: '/attendance' })
+      expect(decide('/multitable', {}, { attendanceFocused: true })).toEqual({ action: 'redirect', target: '/attendance' })
+    })
+
+    it('required-feature gate redirects home before focus handling; unknown feature strings are ignored', () => {
+      expect(decide('/plm', { requiredFeature: 'plm' }, { hasFeature: () => false, plmWorkbenchFocused: true }))
+        .toEqual({ action: 'redirect', target: '/HOME' })
+      expect(decide('/plm', { requiredFeature: 'nonsense' }, { hasFeature: () => false })).toEqual({ action: 'allow' })
+    })
+
+    it('the plm allowlist is exactly the five workbench prefixes — all non-empty absolute strings', () => {
+      expect([...PLM_WORKBENCH_ALLOWED_PREFIXES]).toEqual(['/plm', '/workflows', '/approvals', '/integrations', '/stock-prep'])
+      expect(PLM_WORKBENCH_ALLOWED_PREFIXES.every((p) => typeof p === 'string' && p.startsWith('/') && p.length > 1)).toBe(true)
+    })
+  })
+
+  // Thin delegation pin: main.ts must DELEGATE to the policy as DIRECT statements of the guard's
+  // try block — `const decision = resolveRouteGuardDecision(...)` followed by the redirect
+  // if-statement whose branch is exactly `return next(decision.target)`. Decision logic must not be
+  // re-inlined (negative token pins). Dead-branch wrapping breaks the direct-statement requirement.
+  it('main.ts delegates guard decisions to guardPolicy (direct statements; no inlined decision logic)', async () => {
     const ts = (await import('typescript')).default
     type TsNode = import('typescript').Node
     const MAIN = readFileSync(join(__dirname, '../src/main.ts'), 'utf8')
-    const source = ts.createSourceFile('main.ts', MAIN, ts.ScriptTarget.ES2022, true)
+    expect(MAIN).not.toContain('allowedPrefixes')
+    expect(MAIN).not.toContain('isRoutePermitted(')
+    expect(MAIN).toContain("import { resolveRouteGuardDecision } from './router/guardPolicy'")
 
-    // 1. locate the router.beforeEach(...) callback.
-    let guardBody: TsNode | null = null
+    const source = ts.createSourceFile('main.ts', MAIN, ts.ScriptTarget.ES2022, true)
+    let guardBody: import('typescript').Block | null = null
     const findGuard = (node: TsNode): void => {
       if (
         guardBody === null &&
@@ -186,155 +241,65 @@ describe('Stock Preparation route registration (source drift pin)', () => {
         ts.isIdentifier(node.expression.expression) &&
         node.expression.expression.text === 'router' &&
         node.arguments.length >= 1 &&
-        (ts.isArrowFunction(node.arguments[0]) || ts.isFunctionExpression(node.arguments[0]))
+        ts.isArrowFunction(node.arguments[0]) &&
+        ts.isBlock((node.arguments[0] as import('typescript').ArrowFunction).body)
       ) {
-        guardBody = (node.arguments[0] as import('typescript').ArrowFunction).body
+        guardBody = (node.arguments[0] as import('typescript').ArrowFunction).body as import('typescript').Block
         return
       }
       ts.forEachChild(node, findGuard)
     }
     findGuard(source)
-    expect(guardBody, 'router.beforeEach(callback) must exist').not.toBeNull()
+    expect(guardBody, 'router.beforeEach(arrow with block body) must exist').not.toBeNull()
 
-    // Round-9: the deny branch must DIRECTLY return next(flags.resolveHomePath()) — a bare
-    // next() is an allow-through, and a decoy return inside a nested function must not count,
-    // so the walk refuses to descend into function-like nodes.
-    const isDenyReturn = (n: TsNode): boolean =>
-      ts.isReturnStatement(n) &&
-      !!n.expression &&
-      ts.isCallExpression(n.expression) &&
-      ts.isIdentifier(n.expression.expression) &&
-      n.expression.expression.text === 'next' &&
-      n.expression.arguments.length === 1 &&
-      ts.isCallExpression(n.expression.arguments[0]) &&
-      ts.isPropertyAccessExpression(n.expression.arguments[0].expression) &&
-      n.expression.arguments[0].expression.name.text === 'resolveHomePath' &&
-      ts.isIdentifier(n.expression.arguments[0].expression.expression) &&
-      n.expression.arguments[0].expression.expression.text === 'flags' &&
-      (n.expression.arguments[0] as import('typescript').CallExpression).arguments.length === 0
-    // Round-10: no "exists somewhere" search at all — the deny branch must consist of EXACTLY ONE
-    // top-level statement, and that statement must be the deny return. Hiding the redirect inside
-    // if (false) while actually falling through to next() cannot satisfy this.
-    const denyBranchIsExactly = (thenStatement: TsNode): boolean => {
-      if (ts.isBlock(thenStatement)) {
-        return thenStatement.statements.length === 1 && isDenyReturn(thenStatement.statements[0])
-      }
-      return isDenyReturn(thenStatement)
-    }
-    // Round-9: the permission call's ARGUMENTS are pinned too — first must be to.meta, second must
-    // be a callback whose body really calls auth.hasPermission(<its own parameter>) (a constant
-    // () => true callback is not an enforcing shape).
-    const isEnforcingPermittedCall = (call: import('typescript').CallExpression): boolean => {
-      if (call.arguments.length !== 2) return false
-      const arg0 = call.arguments[0]
-      const arg0Ok =
-        ts.isPropertyAccessExpression(arg0) &&
-        arg0.name.text === 'meta' &&
-        ts.isIdentifier(arg0.expression) &&
-        arg0.expression.text === 'to'
-      if (!arg0Ok) return false
-      const cb = call.arguments[1]
-      // Round-10: the callback must be an EXPRESSION-BODIED arrow whose body IS the permission call
-      // — "the call appears somewhere in a block" allowed { auth.hasPermission(p); return true }.
-      if (!ts.isArrowFunction(cb)) return false
-      if (cb.parameters.length !== 1 || !ts.isIdentifier(cb.parameters[0].name)) return false
-      const paramName = cb.parameters[0].name.text
-      const body = cb.body
+    // The try statement is a DIRECT statement of the guard body; the delegation pair must be DIRECT
+    // statements of its try block.
+    const tryStmt = guardBody!.statements.find((st) => ts.isTryStatement(st)) as
+      | import('typescript').TryStatement
+      | undefined
+    expect(tryStmt, 'the guard must contain its try/catch as a direct statement').toBeTruthy()
+    const stmts = tryStmt!.tryBlock.statements
+
+    const declIdx = stmts.findIndex(
+      (st) =>
+        ts.isVariableStatement(st) &&
+        st.declarationList.declarations.some(
+          (d) =>
+            ts.isIdentifier(d.name) &&
+            d.name.text === 'decision' &&
+            !!d.initializer &&
+            ts.isCallExpression(d.initializer) &&
+            ts.isIdentifier(d.initializer.expression) &&
+            d.initializer.expression.text === 'resolveRouteGuardDecision',
+        ),
+    )
+    expect(declIdx, 'const decision = resolveRouteGuardDecision(...) must be a DIRECT try-block statement').toBeGreaterThan(-1)
+
+    const redirectIdx = stmts.findIndex((st) => {
+      if (!ts.isIfStatement(st)) return false
+      const thenSt = st.thenStatement
+      const single = ts.isBlock(thenSt)
+        ? thenSt.statements.length === 1
+          ? thenSt.statements[0]
+          : null
+        : thenSt
       return (
-        !ts.isBlock(body) &&
-        ts.isCallExpression(body) &&
-        ts.isPropertyAccessExpression(body.expression) &&
-        body.expression.name.text === 'hasPermission' &&
-        ts.isIdentifier(body.expression.expression) &&
-        body.expression.expression.text === 'auth' &&
-        body.arguments.length === 1 &&
-        ts.isIdentifier(body.arguments[0]) &&
-        body.arguments[0].text === paramName
+        !!single &&
+        ts.isReturnStatement(single) &&
+        !!single.expression &&
+        ts.isCallExpression(single.expression) &&
+        ts.isIdentifier(single.expression.expression) &&
+        single.expression.expression.text === 'next' &&
+        single.expression.arguments.length === 1 &&
+        ts.isPropertyAccessExpression(single.expression.arguments[0]) &&
+        single.expression.arguments[0].name.text === 'target' &&
+        ts.isIdentifier(single.expression.arguments[0].expression) &&
+        single.expression.arguments[0].expression.text === 'decision'
       )
-    }
-
-    // Round-11: the OUTER structure is also exact — no descendant searches. The focus IfStatement
-    // must be UNIQUE in the whole guard (a dead-branch decoy copy breaks uniqueness), the enforcing
-    // permission guard must be a DIRECT SIBLING statement in the focus statement's parent block
-    // (exactly one, positioned before it), and allowedPrefixes must be the UNIQUE DIRECT variable
-    // declaration of the focus block. Condition subtrees are inspected only to IDENTIFY the focus
-    // condition (the typeof-guarded call), never to satisfy structural requirements.
-    const conditionHasPlmFocusCall = (cond: TsNode): boolean => {
-      let found = false
-      const inspect = (n: TsNode): void => {
-        if (found) return
-        if (
-          ts.isCallExpression(n) &&
-          ts.isPropertyAccessExpression(n.expression) &&
-          n.expression.name.text === 'isPlmWorkbenchFocused' &&
-          ts.isIdentifier(n.expression.expression) &&
-          n.expression.expression.text === 'flags'
-        ) {
-          found = true
-          return
-        }
-        ts.forEachChild(n, inspect)
-      }
-      inspect(cond)
-      return found
-    }
-
-    // Collect ALL focus-if candidates anywhere in the guard — for a UNIQUENESS assertion only.
-    const focusCandidates: import('typescript').IfStatement[] = []
-    const collect = (n: TsNode): void => {
-      if (ts.isIfStatement(n) && conditionHasPlmFocusCall(n.expression)) focusCandidates.push(n)
-      ts.forEachChild(n, collect)
-    }
-    collect(guardBody!)
-    expect(focusCandidates.length, 'exactly ONE plm-workbench focus if-statement may exist in the guard (dead-branch copies break this)').toBe(1)
-    const focusIf = focusCandidates[0]
-
-    const isEnforcingGuardIf = (st: TsNode): boolean =>
-      ts.isIfStatement(st) &&
-      ts.isPrefixUnaryExpression(st.expression) &&
-      st.expression.operator === ts.SyntaxKind.ExclamationToken &&
-      ts.isCallExpression(st.expression.operand) &&
-      ts.isIdentifier(st.expression.operand.expression) &&
-      st.expression.operand.expression.text === 'isRoutePermitted' &&
-      isEnforcingPermittedCall(st.expression.operand) &&
-      denyBranchIsExactly(st.thenStatement)
-
-    // DIRECT-SIBLING discipline: the focus statement's parent must be a block; the enforcing guard
-    // must appear among that block's direct statements, exactly once, before the focus statement.
-    const parent = focusIf.parent
-    expect(ts.isBlock(parent), 'the focus if-statement must sit directly in a statement block').toBe(true)
-    const siblings = (parent as import('typescript').Block).statements
-    const focusIdx = siblings.findIndex((st) => st === focusIf)
-    const guardIdxs = siblings
-      .map((st, i) => (isEnforcingGuardIf(st) ? i : -1))
-      .filter((i) => i !== -1)
-    expect(guardIdxs.length, 'exactly ONE direct enforcing isRoutePermitted guard must exist beside the focus block (nested/dead-branch copies do not count)').toBe(1)
-    expect(guardIdxs[0], 'the enforcing permission guard must precede the plm-workbench focus block').toBeLessThan(focusIdx)
-
-    // allowedPrefixes: the UNIQUE DIRECT declaration of the focus block — no recursive search.
-    expect(ts.isBlock(focusIf.thenStatement), 'the focus branch must be a block').toBe(true)
-    const focusStatements = (focusIf.thenStatement as import('typescript').Block).statements
-    const allowlistDecls: string[][] = []
-    for (const st of focusStatements) {
-      if (!ts.isVariableStatement(st)) continue
-      for (const decl of st.declarationList.declarations) {
-        if (
-          ts.isIdentifier(decl.name) &&
-          decl.name.text === 'allowedPrefixes' &&
-          decl.initializer &&
-          ts.isArrayLiteralExpression(decl.initializer)
-        ) {
-          allowlistDecls.push(
-            decl.initializer.elements
-              .filter((el): el is import('typescript').StringLiteral => ts.isStringLiteral(el))
-              .map((el) => el.text),
-          )
-        }
-      }
-    }
-    expect(allowlistDecls.length, 'allowedPrefixes must be declared exactly once as a DIRECT statement of the focus block').toBe(1)
-    expect(allowlistDecls[0]).toEqual(['/plm', '/workflows', '/approvals', '/integrations', '/stock-prep'])
+    })
+    expect(redirectIdx, 'if (…) { return next(decision.target) } must be a DIRECT try-block statement').toBeGreaterThan(declIdx)
   })
+
 })
 
 describe('StockPreparationWorkspace shell', () => {

--- a/apps/web/tests/StockPreparationWorkspace.spec.ts
+++ b/apps/web/tests/StockPreparationWorkspace.spec.ts
@@ -253,66 +253,87 @@ describe('Stock Preparation route registration (source drift pin)', () => {
       )
     }
 
-    // 2-5. scoped scan of the guard body only.
-    let enforcingIfPos = -1
-    let plmFocusIfPos = -1
-    let allowlist: string[] | null = null
-    const scan = (node: TsNode): void => {
-      if (ts.isIfStatement(node)) {
-        const cond = node.expression
+    // Round-11: the OUTER structure is also exact — no descendant searches. The focus IfStatement
+    // must be UNIQUE in the whole guard (a dead-branch decoy copy breaks uniqueness), the enforcing
+    // permission guard must be a DIRECT SIBLING statement in the focus statement's parent block
+    // (exactly one, positioned before it), and allowedPrefixes must be the UNIQUE DIRECT variable
+    // declaration of the focus block. Condition subtrees are inspected only to IDENTIFY the focus
+    // condition (the typeof-guarded call), never to satisfy structural requirements.
+    const conditionHasPlmFocusCall = (cond: TsNode): boolean => {
+      let found = false
+      const inspect = (n: TsNode): void => {
+        if (found) return
         if (
-          enforcingIfPos === -1 &&
-          ts.isPrefixUnaryExpression(cond) &&
-          cond.operator === ts.SyntaxKind.ExclamationToken &&
-          ts.isCallExpression(cond.operand) &&
-          ts.isIdentifier(cond.operand.expression) &&
-          cond.operand.expression.text === 'isRoutePermitted' &&
-          isEnforcingPermittedCall(cond.operand) &&
-          denyBranchIsExactly(node.thenStatement)
+          ts.isCallExpression(n) &&
+          ts.isPropertyAccessExpression(n.expression) &&
+          n.expression.name.text === 'isPlmWorkbenchFocused' &&
+          ts.isIdentifier(n.expression.expression) &&
+          n.expression.expression.text === 'flags'
         ) {
-          enforcingIfPos = node.getStart(source)
+          found = true
+          return
         }
-        let mentionsPlmFocusCall = false
-        const inspectCond = (n: TsNode): void => {
-          if (
-            ts.isCallExpression(n) &&
-            ts.isPropertyAccessExpression(n.expression) &&
-            n.expression.name.text === 'isPlmWorkbenchFocused'
-          ) {
-            mentionsPlmFocusCall = true
-          }
-          ts.forEachChild(n, inspectCond)
-        }
-        inspectCond(cond)
-        if (mentionsPlmFocusCall && plmFocusIfPos === -1) {
-          plmFocusIfPos = node.getStart(source)
-          // 5. allowedPrefixes must live INSIDE this focus block.
-          const findAllowlist = (n: TsNode): void => {
-            if (
-              ts.isVariableDeclaration(n) &&
-              ts.isIdentifier(n.name) &&
-              n.name.text === 'allowedPrefixes' &&
-              n.initializer &&
-              ts.isArrayLiteralExpression(n.initializer)
-            ) {
-              allowlist = n.initializer.elements
-                .filter((el): el is import('typescript').StringLiteral => ts.isStringLiteral(el))
-                .map((el) => el.text)
-            }
-            ts.forEachChild(n, findAllowlist)
-          }
-          findAllowlist(node.thenStatement)
+        ts.forEachChild(n, inspect)
+      }
+      inspect(cond)
+      return found
+    }
+
+    // Collect ALL focus-if candidates anywhere in the guard — for a UNIQUENESS assertion only.
+    const focusCandidates: import('typescript').IfStatement[] = []
+    const collect = (n: TsNode): void => {
+      if (ts.isIfStatement(n) && conditionHasPlmFocusCall(n.expression)) focusCandidates.push(n)
+      ts.forEachChild(n, collect)
+    }
+    collect(guardBody!)
+    expect(focusCandidates.length, 'exactly ONE plm-workbench focus if-statement may exist in the guard (dead-branch copies break this)').toBe(1)
+    const focusIf = focusCandidates[0]
+
+    const isEnforcingGuardIf = (st: TsNode): boolean =>
+      ts.isIfStatement(st) &&
+      ts.isPrefixUnaryExpression(st.expression) &&
+      st.expression.operator === ts.SyntaxKind.ExclamationToken &&
+      ts.isCallExpression(st.expression.operand) &&
+      ts.isIdentifier(st.expression.operand.expression) &&
+      st.expression.operand.expression.text === 'isRoutePermitted' &&
+      isEnforcingPermittedCall(st.expression.operand) &&
+      denyBranchIsExactly(st.thenStatement)
+
+    // DIRECT-SIBLING discipline: the focus statement's parent must be a block; the enforcing guard
+    // must appear among that block's direct statements, exactly once, before the focus statement.
+    const parent = focusIf.parent
+    expect(ts.isBlock(parent), 'the focus if-statement must sit directly in a statement block').toBe(true)
+    const siblings = (parent as import('typescript').Block).statements
+    const focusIdx = siblings.findIndex((st) => st === focusIf)
+    const guardIdxs = siblings
+      .map((st, i) => (isEnforcingGuardIf(st) ? i : -1))
+      .filter((i) => i !== -1)
+    expect(guardIdxs.length, 'exactly ONE direct enforcing isRoutePermitted guard must exist beside the focus block (nested/dead-branch copies do not count)').toBe(1)
+    expect(guardIdxs[0], 'the enforcing permission guard must precede the plm-workbench focus block').toBeLessThan(focusIdx)
+
+    // allowedPrefixes: the UNIQUE DIRECT declaration of the focus block — no recursive search.
+    expect(ts.isBlock(focusIf.thenStatement), 'the focus branch must be a block').toBe(true)
+    const focusStatements = (focusIf.thenStatement as import('typescript').Block).statements
+    const allowlistDecls: string[][] = []
+    for (const st of focusStatements) {
+      if (!ts.isVariableStatement(st)) continue
+      for (const decl of st.declarationList.declarations) {
+        if (
+          ts.isIdentifier(decl.name) &&
+          decl.name.text === 'allowedPrefixes' &&
+          decl.initializer &&
+          ts.isArrayLiteralExpression(decl.initializer)
+        ) {
+          allowlistDecls.push(
+            decl.initializer.elements
+              .filter((el): el is import('typescript').StringLiteral => ts.isStringLiteral(el))
+              .map((el) => el.text),
+          )
         }
       }
-      ts.forEachChild(node, scan)
     }
-    scan(guardBody!)
-
-    expect(enforcingIfPos, 'the guard must contain if (!isRoutePermitted(to.meta, cb-calling-auth.hasPermission)) { return next(flags.resolveHomePath()) } — bare calls, constant callbacks, bare next() and nested decoy returns do not enforce').toBeGreaterThan(-1)
-    expect(plmFocusIfPos, 'the plm-workbench focus if-block must exist inside the guard').toBeGreaterThan(-1)
-    expect(enforcingIfPos, 'the enforcing permission check must precede the plm-workbench focus block').toBeLessThan(plmFocusIfPos)
-    expect(allowlist, 'allowedPrefixes must be declared INSIDE the plm-workbench focus block').not.toBeNull()
-    expect(allowlist).toEqual(['/plm', '/workflows', '/approvals', '/integrations', '/stock-prep'])
+    expect(allowlistDecls.length, 'allowedPrefixes must be declared exactly once as a DIRECT statement of the focus block').toBe(1)
+    expect(allowlistDecls[0]).toEqual(['/plm', '/workflows', '/approvals', '/integrations', '/stock-prep'])
   })
 })
 

--- a/apps/web/tests/StockPreparationWorkspace.spec.ts
+++ b/apps/web/tests/StockPreparationWorkspace.spec.ts
@@ -379,9 +379,28 @@ describe('Stock Preparation route registration (source drift pin)', () => {
             ts.isCallExpression(d.initializer.arguments[0]) &&
             ts.isIdentifier((d.initializer.arguments[0] as import('typescript').CallExpression).expression) &&
             ((d.initializer.arguments[0] as import('typescript').CallExpression).expression as import('typescript').Identifier).text === 'buildRouteGuardInput' &&
+            // Round-15 (M22): the input adapter must receive EXACTLY the identifier `to` — a
+            // synthesized object ({ path: to.path, meta: {} }) is not an accepted argument.
+            (d.initializer.arguments[0] as import('typescript').CallExpression).arguments.length === 1 &&
+            ts.isIdentifier((d.initializer.arguments[0] as import('typescript').CallExpression).arguments[0]) &&
+            ((d.initializer.arguments[0] as import('typescript').CallExpression).arguments[0] as import('typescript').Identifier).text === 'to' &&
             ts.isCallExpression(d.initializer.arguments[1]) &&
             ts.isIdentifier((d.initializer.arguments[1] as import('typescript').CallExpression).expression) &&
-            ((d.initializer.arguments[1] as import('typescript').CallExpression).expression as import('typescript').Identifier).text === 'buildRouteGuardContext',
+            ((d.initializer.arguments[1] as import('typescript').CallExpression).expression as import('typescript').Identifier).text === 'buildRouteGuardContext' &&
+            // Round-15 (M23): the ctx adapter must receive EXACTLY { auth, flags } — two shorthand
+            // properties, no spread, no extras, no substitute expressions (where an overriding
+            // flags object with hasFeature: () => true could hide).
+            (() => {
+              const ctxArgs = (d.initializer!.arguments[1] as import('typescript').CallExpression).arguments
+              if (ctxArgs.length !== 1 || !ts.isObjectLiteralExpression(ctxArgs[0])) return false
+              const props = (ctxArgs[0] as import('typescript').ObjectLiteralExpression).properties
+              return (
+                props.length === 2 &&
+                props.every((pr) => ts.isShorthandPropertyAssignment(pr)) &&
+                (props[0] as import('typescript').ShorthandPropertyAssignment).name.text === 'auth' &&
+                (props[1] as import('typescript').ShorthandPropertyAssignment).name.text === 'flags'
+              )
+            })(),
         ),
     )
     expect(declIdx, 'const decision = resolveRouteGuardDecision(...) must be a DIRECT try-block statement').toBeGreaterThan(-1)

--- a/apps/web/tests/StockPreparationWorkspace.spec.ts
+++ b/apps/web/tests/StockPreparationWorkspace.spec.ts
@@ -196,22 +196,72 @@ describe('Stock Preparation route registration (source drift pin)', () => {
     findGuard(source)
     expect(guardBody, 'router.beforeEach(callback) must exist').not.toBeNull()
 
-    const containsReturnNext = (node: TsNode): boolean => {
+    // Round-9: the deny branch must DIRECTLY return next(flags.resolveHomePath()) — a bare
+    // next() is an allow-through, and a decoy return inside a nested function must not count,
+    // so the walk refuses to descend into function-like nodes.
+    const isDenyReturn = (n: TsNode): boolean =>
+      ts.isReturnStatement(n) &&
+      !!n.expression &&
+      ts.isCallExpression(n.expression) &&
+      ts.isIdentifier(n.expression.expression) &&
+      n.expression.expression.text === 'next' &&
+      n.expression.arguments.length === 1 &&
+      ts.isCallExpression(n.expression.arguments[0]) &&
+      ts.isPropertyAccessExpression(n.expression.arguments[0].expression) &&
+      n.expression.arguments[0].expression.name.text === 'resolveHomePath' &&
+      ts.isIdentifier(n.expression.arguments[0].expression.expression) &&
+      n.expression.arguments[0].expression.expression.text === 'flags' &&
+      (n.expression.arguments[0] as import('typescript').CallExpression).arguments.length === 0
+    const containsDirectDenyReturn = (node: TsNode): boolean => {
       let found = false
       const walk = (n: TsNode): void => {
-        if (
-          ts.isReturnStatement(n) &&
-          n.expression &&
-          ts.isCallExpression(n.expression) &&
-          ts.isIdentifier(n.expression.expression) &&
-          n.expression.expression.text === 'next'
-        ) {
+        if (found) return
+        if (ts.isArrowFunction(n) || ts.isFunctionExpression(n) || ts.isFunctionDeclaration(n) || ts.isMethodDeclaration(n)) return
+        if (isDenyReturn(n)) {
           found = true
+          return
         }
-        if (!found) ts.forEachChild(n, walk)
+        ts.forEachChild(n, walk)
       }
       walk(node)
       return found
+    }
+    // Round-9: the permission call's ARGUMENTS are pinned too — first must be to.meta, second must
+    // be a callback whose body really calls auth.hasPermission(<its own parameter>) (a constant
+    // () => true callback is not an enforcing shape).
+    const isEnforcingPermittedCall = (call: import('typescript').CallExpression): boolean => {
+      if (call.arguments.length !== 2) return false
+      const arg0 = call.arguments[0]
+      const arg0Ok =
+        ts.isPropertyAccessExpression(arg0) &&
+        arg0.name.text === 'meta' &&
+        ts.isIdentifier(arg0.expression) &&
+        arg0.expression.text === 'to'
+      if (!arg0Ok) return false
+      const cb = call.arguments[1]
+      if (!(ts.isArrowFunction(cb) || ts.isFunctionExpression(cb))) return false
+      if (cb.parameters.length !== 1 || !ts.isIdentifier(cb.parameters[0].name)) return false
+      const paramName = cb.parameters[0].name.text
+      let callsHasPermission = false
+      const findPerm = (n: TsNode): void => {
+        if (callsHasPermission) return
+        if (
+          ts.isCallExpression(n) &&
+          ts.isPropertyAccessExpression(n.expression) &&
+          n.expression.name.text === 'hasPermission' &&
+          ts.isIdentifier(n.expression.expression) &&
+          n.expression.expression.text === 'auth' &&
+          n.arguments.length === 1 &&
+          ts.isIdentifier(n.arguments[0]) &&
+          n.arguments[0].text === paramName
+        ) {
+          callsHasPermission = true
+          return
+        }
+        ts.forEachChild(n, findPerm)
+      }
+      findPerm(cb)
+      return callsHasPermission
     }
 
     // 2-5. scoped scan of the guard body only.
@@ -228,7 +278,8 @@ describe('Stock Preparation route registration (source drift pin)', () => {
           ts.isCallExpression(cond.operand) &&
           ts.isIdentifier(cond.operand.expression) &&
           cond.operand.expression.text === 'isRoutePermitted' &&
-          containsReturnNext(node.thenStatement)
+          isEnforcingPermittedCall(cond.operand) &&
+          containsDirectDenyReturn(node.thenStatement)
         ) {
           enforcingIfPos = node.getStart(source)
         }
@@ -268,7 +319,7 @@ describe('Stock Preparation route registration (source drift pin)', () => {
     }
     scan(guardBody!)
 
-    expect(enforcingIfPos, 'the guard must contain if (!isRoutePermitted(...)) { ... return next(...) } — a bare call does not enforce').toBeGreaterThan(-1)
+    expect(enforcingIfPos, 'the guard must contain if (!isRoutePermitted(to.meta, cb-calling-auth.hasPermission)) { return next(flags.resolveHomePath()) } — bare calls, constant callbacks, bare next() and nested decoy returns do not enforce').toBeGreaterThan(-1)
     expect(plmFocusIfPos, 'the plm-workbench focus if-block must exist inside the guard').toBeGreaterThan(-1)
     expect(enforcingIfPos, 'the enforcing permission check must precede the plm-workbench focus block').toBeLessThan(plmFocusIfPos)
     expect(allowlist, 'allowedPrefixes must be declared INSIDE the plm-workbench focus block').not.toBeNull()

--- a/apps/web/tests/StockPreparationWorkspace.spec.ts
+++ b/apps/web/tests/StockPreparationWorkspace.spec.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs'
 import {
   ATTENDANCE_FOCUS_ALLOWED_PATHS,
   PLM_WORKBENCH_ALLOWED_PREFIXES,
+  buildRouteGuardContext,
   resolveRouteGuardDecision,
 } from '../src/router/guardPolicy'
 import { join } from 'node:path'
@@ -216,6 +217,56 @@ describe('Stock Preparation route registration (source drift pin)', () => {
       expect([...PLM_WORKBENCH_ALLOWED_PREFIXES]).toEqual(['/plm', '/workflows', '/approvals', '/integrations', '/stock-prep'])
       expect(PLM_WORKBENCH_ALLOWED_PREFIXES.every((p) => typeof p === 'string' && p.startsWith('/') && p.length > 1)).toBe(true)
     })
+
+    // Round-13: pairwise priority matrix — the declared ordering (feature → permission →
+    // attendance → plm) is pinned as behavior, not prose. Swapping any two stages breaks a case.
+    it('priority matrix: every earlier stage wins over every later stage', () => {
+      // feature deny + plm focus (path not plm-allowed): feature wins → /HOME (not /plm).
+      expect(decide('/x', { requiredFeature: 'plm' }, { hasFeature: () => false, plmWorkbenchFocused: true }))
+        .toEqual({ action: 'redirect', target: '/HOME' })
+      // permission deny + attendance focus: permission wins → /HOME (not /attendance).
+      expect(decide('/x', { permissions: ['integration:write'] }, { hasPermission: () => false, attendanceFocused: true }))
+        .toEqual({ action: 'redirect', target: '/HOME' })
+      // attendance AND plm both on, path allowed by neither: attendance wins → /attendance (not /plm).
+      expect(decide('/x', {}, { attendanceFocused: true, plmWorkbenchFocused: true }))
+        .toEqual({ action: 'redirect', target: '/attendance' })
+      // feature deny short-circuits: the permission probe must NOT be consulted (ordering contract).
+      let permissionProbed = false
+      expect(decide('/x', { requiredFeature: 'plm', permissions: ['integration:write'] }, {
+        hasFeature: () => false,
+        hasPermission: () => {
+          permissionProbed = true
+          return true
+        },
+      })).toEqual({ action: 'redirect', target: '/HOME' })
+      expect(permissionProbed, 'feature denial must short-circuit before the permission probe').toBe(false)
+    })
+
+    // Round-13: the runtime adapter is executable and fake-injectable — its wiring is behavior.
+    it('buildRouteGuardContext delegates hasPermission to auth.hasPermission and keeps the typeof tolerance', () => {
+      const seen: string[] = []
+      const deps = {
+        auth: { hasPermission: (p: string) => { seen.push(p); return p === 'integration:write' } },
+        flags: {
+          hasFeature: () => true,
+          isAttendanceFocused: () => false,
+          isPlmWorkbenchFocused: () => true,
+          resolveHomePath: () => '/HOME',
+        },
+      }
+      const built = buildRouteGuardContext(deps)
+      expect(built.hasPermission('integration:write')).toBe(true)
+      expect(built.hasPermission('other:perm')).toBe(false)
+      expect(seen).toEqual(['integration:write', 'other:perm'])
+      expect(built.plmWorkbenchFocused).toBe(true)
+      // typeof tolerance: absent / non-function isPlmWorkbenchFocused folds to false.
+      expect(buildRouteGuardContext({ ...deps, flags: { ...deps.flags, isPlmWorkbenchFocused: undefined } }).plmWorkbenchFocused).toBe(false)
+      expect(buildRouteGuardContext({ ...deps, flags: { ...deps.flags, isPlmWorkbenchFocused: 42 } }).plmWorkbenchFocused).toBe(false)
+      // end-to-end: adapter-built context + real policy = real deny behavior.
+      const denyDeps = { ...deps, auth: { hasPermission: () => false } }
+      expect(resolveRouteGuardDecision({ path: '/stock-prep', meta: { permissions: ['integration:write'] } }, buildRouteGuardContext(denyDeps)))
+        .toEqual({ action: 'redirect', target: '/HOME' })
+    })
   })
 
   // Thin delegation pin: main.ts must DELEGATE to the policy as DIRECT statements of the guard's
@@ -228,7 +279,8 @@ describe('Stock Preparation route registration (source drift pin)', () => {
     const MAIN = readFileSync(join(__dirname, '../src/main.ts'), 'utf8')
     expect(MAIN).not.toContain('allowedPrefixes')
     expect(MAIN).not.toContain('isRoutePermitted(')
-    expect(MAIN).toContain("import { resolveRouteGuardDecision } from './router/guardPolicy'")
+    expect(MAIN).not.toContain('hasPermission:')
+    expect(MAIN).toContain("import { buildRouteGuardContext, resolveRouteGuardDecision } from './router/guardPolicy'")
 
     const source = ts.createSourceFile('main.ts', MAIN, ts.ScriptTarget.ES2022, true)
     let guardBody: import('typescript').Block | null = null
@@ -270,13 +322,32 @@ describe('Stock Preparation route registration (source drift pin)', () => {
             !!d.initializer &&
             ts.isCallExpression(d.initializer) &&
             ts.isIdentifier(d.initializer.expression) &&
-            d.initializer.expression.text === 'resolveRouteGuardDecision',
+            d.initializer.expression.text === 'resolveRouteGuardDecision' &&
+            // Round-13: the SECOND argument must be the executable adapter call — an inline object
+            // (where hasPermission: () => true could hide) is not an accepted shape.
+            d.initializer.arguments.length === 2 &&
+            ts.isCallExpression(d.initializer.arguments[1]) &&
+            ts.isIdentifier((d.initializer.arguments[1] as import('typescript').CallExpression).expression) &&
+            ((d.initializer.arguments[1] as import('typescript').CallExpression).expression as import('typescript').Identifier).text === 'buildRouteGuardContext',
         ),
     )
     expect(declIdx, 'const decision = resolveRouteGuardDecision(...) must be a DIRECT try-block statement').toBeGreaterThan(-1)
 
     const redirectIdx = stmts.findIndex((st) => {
       if (!ts.isIfStatement(st)) return false
+      // Round-13: the CONDITION must be exactly decision.action === 'redirect' — if (false) around
+      // the same branch body previously passed.
+      const cond = st.expression
+      const condOk =
+        ts.isBinaryExpression(cond) &&
+        cond.operatorToken.kind === ts.SyntaxKind.EqualsEqualsEqualsToken &&
+        ts.isPropertyAccessExpression(cond.left) &&
+        cond.left.name.text === 'action' &&
+        ts.isIdentifier(cond.left.expression) &&
+        cond.left.expression.text === 'decision' &&
+        ts.isStringLiteral(cond.right) &&
+        cond.right.text === 'redirect'
+      if (!condOk) return false
       const thenSt = st.thenStatement
       const single = ts.isBlock(thenSt)
         ? thenSt.statements.length === 1

--- a/apps/web/tests/StockPreparationWorkspace.spec.ts
+++ b/apps/web/tests/StockPreparationWorkspace.spec.ts
@@ -212,19 +212,14 @@ describe('Stock Preparation route registration (source drift pin)', () => {
       ts.isIdentifier(n.expression.arguments[0].expression.expression) &&
       n.expression.arguments[0].expression.expression.text === 'flags' &&
       (n.expression.arguments[0] as import('typescript').CallExpression).arguments.length === 0
-    const containsDirectDenyReturn = (node: TsNode): boolean => {
-      let found = false
-      const walk = (n: TsNode): void => {
-        if (found) return
-        if (ts.isArrowFunction(n) || ts.isFunctionExpression(n) || ts.isFunctionDeclaration(n) || ts.isMethodDeclaration(n)) return
-        if (isDenyReturn(n)) {
-          found = true
-          return
-        }
-        ts.forEachChild(n, walk)
+    // Round-10: no "exists somewhere" search at all — the deny branch must consist of EXACTLY ONE
+    // top-level statement, and that statement must be the deny return. Hiding the redirect inside
+    // if (false) while actually falling through to next() cannot satisfy this.
+    const denyBranchIsExactly = (thenStatement: TsNode): boolean => {
+      if (ts.isBlock(thenStatement)) {
+        return thenStatement.statements.length === 1 && isDenyReturn(thenStatement.statements[0])
       }
-      walk(node)
-      return found
+      return isDenyReturn(thenStatement)
     }
     // Round-9: the permission call's ARGUMENTS are pinned too — first must be to.meta, second must
     // be a callback whose body really calls auth.hasPermission(<its own parameter>) (a constant
@@ -239,29 +234,23 @@ describe('Stock Preparation route registration (source drift pin)', () => {
         arg0.expression.text === 'to'
       if (!arg0Ok) return false
       const cb = call.arguments[1]
-      if (!(ts.isArrowFunction(cb) || ts.isFunctionExpression(cb))) return false
+      // Round-10: the callback must be an EXPRESSION-BODIED arrow whose body IS the permission call
+      // — "the call appears somewhere in a block" allowed { auth.hasPermission(p); return true }.
+      if (!ts.isArrowFunction(cb)) return false
       if (cb.parameters.length !== 1 || !ts.isIdentifier(cb.parameters[0].name)) return false
       const paramName = cb.parameters[0].name.text
-      let callsHasPermission = false
-      const findPerm = (n: TsNode): void => {
-        if (callsHasPermission) return
-        if (
-          ts.isCallExpression(n) &&
-          ts.isPropertyAccessExpression(n.expression) &&
-          n.expression.name.text === 'hasPermission' &&
-          ts.isIdentifier(n.expression.expression) &&
-          n.expression.expression.text === 'auth' &&
-          n.arguments.length === 1 &&
-          ts.isIdentifier(n.arguments[0]) &&
-          n.arguments[0].text === paramName
-        ) {
-          callsHasPermission = true
-          return
-        }
-        ts.forEachChild(n, findPerm)
-      }
-      findPerm(cb)
-      return callsHasPermission
+      const body = cb.body
+      return (
+        !ts.isBlock(body) &&
+        ts.isCallExpression(body) &&
+        ts.isPropertyAccessExpression(body.expression) &&
+        body.expression.name.text === 'hasPermission' &&
+        ts.isIdentifier(body.expression.expression) &&
+        body.expression.expression.text === 'auth' &&
+        body.arguments.length === 1 &&
+        ts.isIdentifier(body.arguments[0]) &&
+        body.arguments[0].text === paramName
+      )
     }
 
     // 2-5. scoped scan of the guard body only.
@@ -279,7 +268,7 @@ describe('Stock Preparation route registration (source drift pin)', () => {
           ts.isIdentifier(cond.operand.expression) &&
           cond.operand.expression.text === 'isRoutePermitted' &&
           isEnforcingPermittedCall(cond.operand) &&
-          containsDirectDenyReturn(node.thenStatement)
+          denyBranchIsExactly(node.thenStatement)
         ) {
           enforcingIfPos = node.getStart(source)
         }

--- a/apps/web/tests/StockPreparationWorkspace.spec.ts
+++ b/apps/web/tests/StockPreparationWorkspace.spec.ts
@@ -157,24 +157,56 @@ describe('Stock Preparation route registration (source drift pin)', () => {
     expect(TYPES).toContain("INTEGRATION_STOCK_PREPARATION: 'integration-stock-preparation'")
   })
 
-  // Regression pin for the plm-workbench focus allowlist fix: the guard allowlist is inline in
-  // main.ts (no unit seam until the P2 manifest-driven refactor), so pin it at source level like the
-  // route block above. Deleting '/stock-prep' from the allowlist turns this red. The permission
-  // semantics are NOT relaxed by the allowlist: main.ts runs the isRoutePermitted check BEFORE the
-  // focus-mode allowlists, and the /stock-prep route keeps its integration:write gate (asserted on
-  // the route block above) — the allowlist only restores reachability for authorized users.
-  it('plm-workbench focus allowlist contains exactly /stock-prep alongside the workbench prefixes', () => {
+  // Regression pin for the plm-workbench focus allowlist fix (round-7 hardening: the original pin's
+  // indexOf('isRoutePermitted') matched the IMPORT at the top of main.ts, not the real guard call —
+  // a mutation deleting the call still passed). The pin now walks the TypeScript AST: it locates the
+  // ACTUAL isRoutePermitted(...) call expression and the ACTUAL isPlmWorkbenchFocused() call inside
+  // the router guard and compares their positions, and it parses the allowedPrefixes array literal
+  // for an EXACT membership comparison. Deleting '/stock-prep', deleting the permission call, or
+  // moving it after the focus block turns this red (mutation-verified). Runtime semantics: the
+  // allowlist never relaxes the route's integration:write gate (route-block pin above).
+  it('plm-workbench focus allowlist is exactly the workbench prefixes + /stock-prep, and the real permission call precedes the focus block (AST)', async () => {
+    const ts = (await import('typescript')).default
     const MAIN = readFileSync(join(__dirname, '../src/main.ts'), 'utf8')
-    const focusIdx = MAIN.indexOf('isPlmWorkbenchFocused')
-    expect(focusIdx, 'plm-workbench focus block must exist in main.ts').toBeGreaterThan(-1)
-    const listStart = MAIN.indexOf('allowedPrefixes', focusIdx)
-    expect(listStart, 'plm-workbench allowedPrefixes must exist').toBeGreaterThan(-1)
-    const listEnd = MAIN.indexOf(']', listStart)
-    const allowlist = MAIN.slice(listStart, listEnd + 1)
-    expect(allowlist).toContain("'/stock-prep'")
-    expect(allowlist).toContain("'/integrations'")
-    // Permission check ordering: isRoutePermitted must appear BEFORE the focus-mode blocks.
-    expect(MAIN.indexOf('isRoutePermitted')).toBeLessThan(focusIdx)
+    const source = ts.createSourceFile('main.ts', MAIN, ts.ScriptTarget.ES2022, true)
+
+    let permittedCallPos = -1
+    let plmFocusCallPos = -1
+    let allowlist: string[] | null = null
+    const visit = (node: import('typescript').Node): void => {
+      if (ts.isCallExpression(node)) {
+        const callee = node.expression
+        if (ts.isIdentifier(callee) && callee.text === 'isRoutePermitted' && permittedCallPos === -1) {
+          permittedCallPos = node.getStart(source)
+        }
+        if (
+          ts.isPropertyAccessExpression(callee) &&
+          callee.name.text === 'isPlmWorkbenchFocused' &&
+          plmFocusCallPos === -1
+        ) {
+          plmFocusCallPos = node.getStart(source)
+        }
+      }
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.name.text === 'allowedPrefixes' &&
+        node.initializer &&
+        ts.isArrayLiteralExpression(node.initializer)
+      ) {
+        allowlist = node.initializer.elements
+          .filter((el): el is import('typescript').StringLiteral => ts.isStringLiteral(el))
+          .map((el) => el.text)
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(source)
+
+    expect(permittedCallPos, 'the real isRoutePermitted(...) CALL must exist (imports do not count)').toBeGreaterThan(-1)
+    expect(plmFocusCallPos, 'the real isPlmWorkbenchFocused() call must exist').toBeGreaterThan(-1)
+    expect(permittedCallPos, 'permission check must run BEFORE the plm-workbench focus block').toBeLessThan(plmFocusCallPos)
+    expect(allowlist, 'plm-workbench allowedPrefixes array must exist').not.toBeNull()
+    expect(allowlist).toEqual(['/plm', '/workflows', '/approvals', '/integrations', '/stock-prep'])
   })
 })
 


### PR DESCRIPTION
## What (follow-up to #4468 — owner round-7 P2, landed under a merge race)

The owner's HOLD on #4468 arrived after the merge train had already landed it (`fbbe21e33`). The runtime code is correct per the same review (permission check runs before the focus allowlists; no relaxation of `integration:write`) — **only the regression pin was vacuous**: `MAIN.indexOf('isRoutePermitted')` matched the IMPORT at the top of main.ts, not the real guard call, so a mutation deleting the call still passed (owner-reproduced: `assertedIdx=1197, actualCallIdx=5202, focusIdx=5653`).

Per the prescribed fix, the pin now walks the **TypeScript AST**:

- locates the actual `isRoutePermitted(...)` **CallExpression** (imports don't count) and the actual `flags.isPlmWorkbenchFocused()` call, and asserts call-position ordering;
- parses the `allowedPrefixes` **array literal** and compares **exactly** `['/plm','/workflows','/approvals','/integrations','/stock-prep']` (P3: the old title said "exactly" while asserting includes — now it really is exact).

## Mutation evidence (all restored, tree clean, 21/21)

- **M1** delete the real `if (!isRoutePermitted(...))` block → RED (this exact mutation passed against the old pin);
- **M2** move the permission block AFTER the plm-workbench focus block → RED (two earlier mutation placements that accidentally kept the call before the focus block correctly stayed green — the assertion tracks real positions);
- **M3** delete `'/stock-prep'` from the allowlist → RED.

**Not armed — owner review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Round-8 (owner P2 — fixed in `e59349645`)

The round-7 pin proved call existence + position, **not enforcement** (owner mutation: a bare `isRoutePermitted(...)` statement still passed), and its file-wide walk was decoy-prone. The pin now locates **structure, scoped to the `router.beforeEach` callback only**:

1. the beforeEach callback itself;
2. the IfStatement whose condition is **exactly** `!isRoutePermitted(...)`;
3. **`return next(...)` inside that branch** — the call enforces, not merely runs;
4. the `isPlmWorkbenchFocused()` if-block in the same callback, positioned after it;
5. `allowedPrefixes` declared **inside** that focus block, exact-array compared.

Mutations (each restored + clean-verified, 21/21): **M4** bare-call/if-stripped → RED (the owner's discriminating case); **M5** enforcing-if relocated to an uncalled helper outside the callback → RED (decoy resistance); M1 delete call → RED; M2 move after focus block → RED; M3 drop `'/stock-prep'` → RED.


## Round-9 (owner P2 — fixed; head `25ae22938`, rebased onto current main)

`containsReturnNext` accepted ANY `return next(...)` — the owner's two surviving mutations proved a bare `return next()` (an **allow-through**) and a constant `() => true` permission callback both still counted as enforcing. The pin now requires all three semantic layers:

1. `isRoutePermitted(`**`to.meta`**`, cb)` — first argument pinned;
2. `cb` is a single-parameter callback whose body **really calls `auth.hasPermission(<its own parameter>)`**;
3. the deny branch **directly** executes `return next(flags.resolveHomePath())` — bare `next()` rejected, and the walk refuses to descend into function-like nodes, so a decoy return inside a nested arrow cannot satisfy it.

New mutations (each restored + clean, 21/21): **M6** deny target → bare `next()` → RED; **M7** callback → `() => true` → RED; **M8** nested-arrow decoy return + bare direct `next()` → RED; M4 spot-rechecked RED under the stricter predicate.

Sequencing per round-9: #4456 auto-merge withdrawn; it merges **after** this PR, and its ledger now records #4469 as not-yet-closed until then.


## Round-10 (owner P2 — fixed; head `9a650a3e6`)

"Exists somewhere" matching survived two real bypasses (owner-reproduced): `containsDirectDenyReturn` recursed into ordinary condition blocks — `if (false) { redirect }` + actual `next()` passed; and the callback check only required `auth.hasPermission(param)` to *appear* — `{ auth.hasPermission(p); return true }` passed. **No searches remain**:

- the permission callback must be an **expression-bodied arrow whose body IS** `auth.hasPermission(<its own parameter>)`;
- the deny `thenStatement` must consist of **exactly one top-level statement**: `return next(flags.resolveHomePath())`.

New mutations (restored + clean, 21/21): **M9** callback calls hasPermission but returns constant true → RED; **M10** `if (false)` decoy redirect + actual `next()` → RED; M6/M7 re-checked RED under the exact-form predicate.


## Round-11 (owner P2 — fixed; head `51e344175`)

The OUTER scan was still "exists anywhere": a dead `if (false)` branch carrying a complete correct guard + complete allowlist let a neutered real guard (`return next()`) and a reduced real allowlist (`['/plm']`) pass (owner-reproduced at `9a650a3e6`). No structural searches remain at any level:

- the `flags`-receiver focus IfStatement must be **UNIQUE across the whole guard** (dead-branch copies break uniqueness);
- the enforcing permission guard must be a **DIRECT SIBLING** statement in the focus statement's parent block — **exactly one**, positioned before it (nested/dead-branch copies don't count);
- `allowedPrefixes` must be the **UNIQUE DIRECT** variable declaration of the focus block (no recursion);
- condition subtrees are inspected only to IDENTIFY the typeof-guarded focus call, never to satisfy structure.

Mutations (restored + clean, 21/21): **M11** dead-branch full guard + neutered real guard → RED; **M12** dead-branch full allowlist + reduced real allowlist → RED; M4/M9/M10 re-checked RED under the direct-sibling structure.


## Round-12 — TERMINAL STATE per the review's own prescription (head `4dd3d397a`; scope now refactor+test)

Rather than a thirteenth layer of AST interpretation, the guard's decision logic is now a **pure, directly executable function**: `src/router/guardPolicy.ts` (`resolveRouteGuardDecision`, frozen exported `PLM_WORKBENCH_ALLOWED_PREFIXES` / `ATTENDANCE_FOCUS_ALLOWED_PATHS`; ordering contract feature → permission → attendance → plm → allow). `main.ts` builds the context (keeping the `typeof` tolerance) and delegates — behavior-preserving refactor, vue-tsc green, App/platform-shell-nav/featureFlags.plm suites green.

**Pinning is now behavioral** (6 tests executing the real function): permission-over-focus ordering (distinct `/HOME` vs `/plm` targets); all five prefixes exact+subpath reachable incl. `/stock-prep`; everything-else → `/plm` incl. the empty-path case; attendance exact-set semantics (`/attendance/sub` redirects); feature gate; exact five-element all-non-empty allowlist. Plus **one thin structural pin**: the delegation pair must be **direct statements of the guard's try block**, and `main.ts` may contain no inlined decision tokens (`allowedPrefixes` / `isRoutePermitted` banned).

Mutations (restored + clean, 27/27): **M13** empty-string allowlist element → 2 tests RED; **M14** short-circuited focus condition (`false && …`) → RED; **M15** whole delegation group wrapped in `if (false)` with fall-through `next()` → RED (direct-statement pin); permission gate neutered in the policy → RED (behavior).


## Round-13 (owner P2 ×2 — fixed; head `2b64281d8`; title updated per P3)

- **Executable runtime adapter**: context construction extracted to `buildRouteGuardContext(deps)` — behavior tests pin that `hasPermission` **delegates to `auth.hasPermission`** (argument + result passthrough via spy), the `typeof` tolerance folds absent/non-fn to `false`, and adapter+policy end-to-end denial works. The delegation pin binds exactly two more points (not more AST): the decision call's **second argument must be the `buildRouteGuardContext(...)` call** (inline context objects — where `hasPermission: () => true` could hide — are not an accepted shape), and the if **condition must be exactly `decision.action === 'redirect'`** (the `if (false)` bypass). `main.ts` additionally bans the `hasPermission:` token.
- **Pairwise priority matrix**: feature-deny beats plm-focus (`/HOME` not `/plm`); permission-deny beats attendance-focus (`/HOME` not `/attendance`); attendance beats plm when both on (`/attendance` not `/plm`); feature-deny **short-circuits the permission probe** (spy asserts zero calls).
- Mutations (restored + clean, 29/29): **M16** `if (false) return next(decision.target)` → RED; **M17** adapter `hasPermission: () => true` → RED; **M18** attendance/plm blocks swapped → RED; **M19** inline ctx object bypassing the adapter → RED.


## Round-14 (owner M20/M21 — fixed; head `6bd4b4f79`)

- **M20 (meta passthrough unpinned)**: input construction extracted to `buildRouteGuardInput(to)` — behavior tests pin **identical** meta passthrough (`toBe`), path string-folding, and an end-to-end leg proving real route meta flows input-adapter → ctx-adapter → policy into a permission denial. The structural pin now binds **both** `resolveRouteGuardDecision` arguments to adapter calls — inline objects (where `meta: {}` or `hasPermission: () => true` could hide) are not accepted shapes.
- **M21 (hasFeature unpinned)**: adapter fields pinned item-by-item — `hasFeature` arg+result passthrough via spy, `attendanceFocused`, `resolveHomePath` lazy value — plus the adapter+policy **feature-deny discriminating leg** (`/HOME-LAZY` through the real adapter).
- Mutations (restored + clean, 31/31): **M20** adapter `meta: {}` → RED; **M20b** inline input object in main.ts → RED (arg0 binding); **M21** adapter `hasFeature: () => true` → RED; M17 re-checked → 2 RED (item test + e2e leg).


## Round-15 (owner M22/M23 — fixed; head `fe70b81c7`; title updated to rounds 6-15)

Callee names alone let synthesized arguments through. The delegation pin now binds the adapter calls' **arguments**:

- `buildRouteGuardInput` must receive **exactly the identifier `to`** (a synthesized `{ path: to.path, meta: {} }` is not accepted);
- `buildRouteGuardContext` must receive **exactly `{ auth, flags }`** — one object literal, two shorthand properties, no spread / extras / substitute expressions (where an overriding `flags` with `hasFeature: () => true` could hide).

Verbatim mutations (restored + clean, 31/31, vue-tsc 0): **M22** `buildRouteGuardInput({ path: to.path, meta: {} })` → RED; **M23** `buildRouteGuardContext({ auth, flags: { ...flags, hasFeature: () => true } })` → RED.
