### PR TITLE
fix(stock-prep): make snapshot persist atomic

### DIFF
--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -72,7 +72,12 @@ import {
   claimPluginObjectScope,
   createPluginScopedMultitableApi,
   MultitableObjectScopeError,
+  MultitableSheetScopeError,
 } from './multitable/plugin-scope'
+import {
+  acquireStockPreparationPersistUnitOfWorkLocks,
+  validateStockPreparationPersistUnitOfWorkInput,
+} from './multitable/stock-preparation-persist-unit-of-work'
 import { installMetrics, metrics as promMetrics, requestMetricsMiddleware } from './metrics/metrics'
 import { APIGateway } from './gateway/APIGateway'
 import { getPoolStats } from './db/pg'
@@ -1676,6 +1681,55 @@ export class MetaSheetServer {
               await assertPluginOwnsSheet(txQuery, {
                 pluginName,
                 sheetId,
+              })
+            },
+            runStockPreparationPersistUnitOfWork: async (
+              { pluginName, ...rawInput },
+              operation,
+            ) => {
+              const input = validateStockPreparationPersistUnitOfWorkInput(rawInput)
+              return poolManager.get().transaction(async ({ query }) => {
+                const txQuery: MultitableRecordsQueryFn = async (sql, params) => {
+                  const result = await query(sql, params)
+                  return {
+                    rows: Array.isArray((result as { rows?: unknown[] }).rows)
+                      ? (result as { rows: unknown[] }).rows
+                      : [],
+                    rowCount: typeof (result as { rowCount?: number }).rowCount === 'number'
+                      ? (result as { rowCount: number }).rowCount
+                      : undefined,
+                  }
+                }
+
+                for (const sheetId of input.sheetIds) {
+                  const ownsSheet = await assertPluginOwnsSheet(txQuery, { pluginName, sheetId })
+                  if (!ownsSheet) {
+                    throw new MultitableSheetScopeError(pluginName, sheetId, 'unclaimed')
+                  }
+                }
+                await acquireStockPreparationPersistUnitOfWorkLocks(txQuery, input)
+
+                return operation({
+                  queryRecords: ({ sheetId, filters, search, orderBy, limit, offset }) =>
+                    queryMultitableRecords({
+                      query: txQuery,
+                      sheetId,
+                      filters,
+                      search,
+                      orderBy,
+                      limit,
+                      offset,
+                    }),
+                  createRecord: ({ sheetId, data }) =>
+                    createMultitableRecord({ query: txQuery, sheetId, data }),
+                  patchRecord: ({ sheetId, recordId, changes }) =>
+                    patchMultitableRecord({
+                      query: txQuery,
+                      sheetId,
+                      recordId,
+                      changes,
+                    }),
+                })
               })
             },
           }),

--- a/packages/core-backend/src/multitable/plugin-scope.ts
+++ b/packages/core-backend/src/multitable/plugin-scope.ts
@@ -1,4 +1,8 @@
-import type { MultitableAPI } from '../types/plugin'
+import type {
+  MultitableAPI,
+  MultitableRecordsWriteUnitOfWorkAPI,
+  StockPreparationPersistUnitOfWorkInput,
+} from '../types/plugin'
 
 export type MultitableScopeQueryFn = (
   sql: string,
@@ -30,6 +34,28 @@ export type MultitableScopeHooks = {
   assertObjectScope?: (input: AssertPluginObjectScopeInput) => Promise<void>
   claimObjectScope?: (input: ClaimPluginObjectScopeInput) => Promise<void>
   assertSheetScope?: (input: AssertPluginSheetScopeInput) => Promise<void>
+  runStockPreparationPersistUnitOfWork?: <T>(
+    input: StockPreparationPersistUnitOfWorkInput & { pluginName: string },
+    operation: (records: MultitableRecordsWriteUnitOfWorkAPI) => Promise<T>,
+  ) => Promise<T>
+}
+
+export class MultitableUnitOfWorkUnavailableError extends Error {
+  code = 'MULTITABLE_UNIT_OF_WORK_UNAVAILABLE'
+
+  constructor() {
+    super('Required multitable unit-of-work capability is unavailable')
+    this.name = 'MultitableUnitOfWorkUnavailableError'
+  }
+}
+
+export class MultitableUnitOfWorkScopeError extends Error {
+  code = 'MULTITABLE_UNIT_OF_WORK_SCOPE_FORBIDDEN'
+
+  constructor() {
+    super('Multitable unit-of-work attempted to access an undeclared sheet')
+    this.name = 'MultitableUnitOfWorkScopeError'
+  }
 }
 
 export class MultitableProjectNamespaceError extends Error {
@@ -260,6 +286,38 @@ export function createPluginScopedMultitableApi(
       deleteRecord: async (input) => {
         await hooks.assertSheetScope?.({ pluginName, sheetId: input.sheetId })
         return multitable.records.deleteRecord(input)
+      },
+      runStockPreparationPersistUnitOfWork: async (input, operation) => {
+        if (!hooks.runStockPreparationPersistUnitOfWork) {
+          throw new MultitableUnitOfWorkUnavailableError()
+        }
+        if (typeof operation !== 'function') {
+          throw new MultitableUnitOfWorkUnavailableError()
+        }
+        const allowedSheetIds = new Set(Array.isArray(input.sheetIds) ? input.sheetIds : [])
+        return hooks.runStockPreparationPersistUnitOfWork(
+          { ...input, pluginName },
+          async (records) => {
+            const assertAllowed = (sheetId: string) => {
+              if (!allowedSheetIds.has(sheetId)) throw new MultitableUnitOfWorkScopeError()
+            }
+            const scopedRecords: MultitableRecordsWriteUnitOfWorkAPI = {
+              queryRecords: async (recordInput) => {
+                assertAllowed(recordInput.sheetId)
+                return records.queryRecords(recordInput)
+              },
+              createRecord: async (recordInput) => {
+                assertAllowed(recordInput.sheetId)
+                return records.createRecord(recordInput)
+              },
+              patchRecord: async (recordInput) => {
+                assertAllowed(recordInput.sheetId)
+                return records.patchRecord(recordInput)
+              },
+            }
+            return operation(scopedRecords)
+          },
+        )
       },
     },
   }

--- a/packages/core-backend/src/multitable/plugin-scope.ts
+++ b/packages/core-backend/src/multitable/plugin-scope.ts
@@ -292,7 +292,10 @@ export function createPluginScopedMultitableApi(
           throw new MultitableUnitOfWorkUnavailableError()
         }
         if (typeof operation !== 'function') {
-          throw new MultitableUnitOfWorkUnavailableError()
+          throw new TypeError('operation must be a function')
+        }
+        if (!input || typeof input !== 'object' || Array.isArray(input)) {
+          throw new TypeError('input must be an object')
         }
         const allowedSheetIds = new Set(Array.isArray(input.sheetIds) ? input.sheetIds : [])
         return hooks.runStockPreparationPersistUnitOfWork(

--- a/packages/core-backend/src/multitable/plugin-scope.ts
+++ b/packages/core-backend/src/multitable/plugin-scope.ts
@@ -3,6 +3,7 @@ import type {
   MultitableRecordsWriteUnitOfWorkAPI,
   StockPreparationPersistUnitOfWorkInput,
 } from '../types/plugin'
+import { validateStockPreparationPersistUnitOfWorkInput } from './stock-preparation-persist-unit-of-work'
 
 export type MultitableScopeQueryFn = (
   sql: string,
@@ -297,9 +298,13 @@ export function createPluginScopedMultitableApi(
         if (!input || typeof input !== 'object' || Array.isArray(input)) {
           throw new TypeError('input must be an object')
         }
-        const allowedSheetIds = new Set(Array.isArray(input.sheetIds) ? input.sheetIds : [])
+        // Fail closed on the same validated/trimmed shape the host locks and owns. Building the
+        // callback allowlist from raw input.sheetIds would permit a whitespace variant the host
+        // never locked (and would refuse the trimmed id the host did lock).
+        const normalized = validateStockPreparationPersistUnitOfWorkInput(input)
+        const allowedSheetIds = new Set(normalized.sheetIds)
         return hooks.runStockPreparationPersistUnitOfWork(
-          { ...input, pluginName },
+          { ...normalized, pluginName },
           async (records) => {
             const assertAllowed = (sheetId: string) => {
               if (!allowedSheetIds.has(sheetId)) throw new MultitableUnitOfWorkScopeError()

--- a/packages/core-backend/src/multitable/stock-preparation-persist-unit-of-work.ts
+++ b/packages/core-backend/src/multitable/stock-preparation-persist-unit-of-work.ts
@@ -1,0 +1,81 @@
+import {
+  acquireCanonicalSheetFencesInOrder,
+  type FenceQuery,
+} from "./canonical-sheet-fence";
+import type { StockPreparationPersistUnitOfWorkInput } from "../types/plugin";
+
+// Fixed, disjoint int4 namespaces. The two-argument advisory-lock form is also disjoint from the
+// canonical one-argument sheet fences. Keep project before batch everywhere.
+export const STOCK_PREPARATION_PROJECT_LOCK_NS = 0x73700101;
+export const STOCK_PREPARATION_BATCH_LOCK_NS = 0x73700102;
+
+export class StockPreparationPersistUnitOfWorkError extends Error {
+  readonly code = "STOCK_PREPARATION_PERSIST_UNIT_OF_WORK_INVALID";
+
+  constructor() {
+    super("stock-preparation persist unit-of-work input is invalid");
+    this.name = "StockPreparationPersistUnitOfWorkError";
+  }
+}
+
+function requiredString(value: unknown): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new StockPreparationPersistUnitOfWorkError();
+  }
+  return value.trim();
+}
+
+export function validateStockPreparationPersistUnitOfWorkInput(
+  input: StockPreparationPersistUnitOfWorkInput,
+): StockPreparationPersistUnitOfWorkInput {
+  if (!input || !Array.isArray(input.sheetIds)) {
+    throw new StockPreparationPersistUnitOfWorkError();
+  }
+  const tenantId = requiredString(input.tenantId);
+  const sheetIds = input.sheetIds.map(requiredString);
+  if (sheetIds.length !== 4 || new Set(sheetIds).size !== 4) {
+    throw new StockPreparationPersistUnitOfWorkError();
+  }
+  const project = {
+    sheetId: requiredString(input.project?.sheetId),
+    projectId: requiredString(input.project?.projectId),
+  };
+  const batch = {
+    sheetId: requiredString(input.batch?.sheetId),
+    snapshotBatchId: requiredString(input.batch?.snapshotBatchId),
+  };
+  const allowed = new Set(sheetIds);
+  if (!allowed.has(project.sheetId) || !allowed.has(batch.sheetId)) {
+    throw new StockPreparationPersistUnitOfWorkError();
+  }
+  return { tenantId, sheetIds, project, batch };
+}
+
+export function stockPreparationProjectLockKey(
+  input: StockPreparationPersistUnitOfWorkInput,
+): string {
+  return `${input.tenantId}|${input.project.sheetId}|${input.project.projectId}`;
+}
+
+export function stockPreparationBatchLockKey(
+  input: StockPreparationPersistUnitOfWorkInput,
+): string {
+  return `${input.tenantId}|${input.batch.sheetId}|${input.batch.snapshotBatchId}`;
+}
+
+export async function acquireStockPreparationPersistUnitOfWorkLocks(
+  query: FenceQuery,
+  rawInput: StockPreparationPersistUnitOfWorkInput,
+): Promise<StockPreparationPersistUnitOfWorkInput> {
+  const input = validateStockPreparationPersistUnitOfWorkInput(rawInput);
+  await acquireCanonicalSheetFencesInOrder(query, input.sheetIds);
+  await query("SELECT pg_advisory_xact_lock($1::int, hashtext($2)::int)", [
+    STOCK_PREPARATION_PROJECT_LOCK_NS,
+    stockPreparationProjectLockKey(input),
+  ]);
+  await query("SELECT pg_advisory_xact_lock($1::int, hashtext($2)::int)", [
+    STOCK_PREPARATION_BATCH_LOCK_NS,
+    stockPreparationBatchLockKey(input),
+  ]);
+  return input;
+}

--- a/packages/core-backend/src/multitable/stock-preparation-persist-unit-of-work.ts
+++ b/packages/core-backend/src/multitable/stock-preparation-persist-unit-of-work.ts
@@ -1,5 +1,7 @@
 import {
   acquireCanonicalSheetFencesInOrder,
+  assertNoActiveWriterBlock,
+  isWriterFenceEnabled,
   type FenceQuery,
 } from "./canonical-sheet-fence";
 import type { StockPreparationPersistUnitOfWorkInput } from "../types/plugin";
@@ -76,7 +78,12 @@ export async function acquireStockPreparationPersistUnitOfWorkLocks(
   rawInput: StockPreparationPersistUnitOfWorkInput,
 ): Promise<StockPreparationPersistUnitOfWorkInput> {
   const input = validateStockPreparationPersistUnitOfWorkInput(rawInput);
-  await acquireCanonicalSheetFencesInOrder(query, input.sheetIds);
+  const orderedSheetIds = await acquireCanonicalSheetFencesInOrder(query, input.sheetIds);
+  if (isWriterFenceEnabled()) {
+    for (const sheetId of orderedSheetIds) {
+      await assertNoActiveWriterBlock(query, sheetId);
+    }
+  }
   await query("SELECT pg_advisory_xact_lock($1::int, hashtext($2)::int)", [
     STOCK_PREPARATION_PROJECT_LOCK_NS,
     stockPreparationProjectLockKey(input),

--- a/packages/core-backend/src/multitable/stock-preparation-persist-unit-of-work.ts
+++ b/packages/core-backend/src/multitable/stock-preparation-persist-unit-of-work.ts
@@ -54,13 +54,21 @@ export function validateStockPreparationPersistUnitOfWorkInput(
 export function stockPreparationProjectLockKey(
   input: StockPreparationPersistUnitOfWorkInput,
 ): string {
-  return `${input.tenantId}|${input.project.sheetId}|${input.project.projectId}`;
+  return JSON.stringify([
+    input.tenantId,
+    input.project.sheetId,
+    input.project.projectId,
+  ]);
 }
 
 export function stockPreparationBatchLockKey(
   input: StockPreparationPersistUnitOfWorkInput,
 ): string {
-  return `${input.tenantId}|${input.batch.sheetId}|${input.batch.snapshotBatchId}`;
+  return JSON.stringify([
+    input.tenantId,
+    input.batch.sheetId,
+    input.batch.snapshotBatchId,
+  ]);
 }
 
 export async function acquireStockPreparationPersistUnitOfWorkLocks(

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -496,7 +496,33 @@ export interface MultitableRecordsAPI {
     sheetId: string
     version: number
   }>
+  /**
+   * P4 stock-preparation persist hard cut. The host owns the transaction and lock order; the plugin
+   * receives only the records methods needed by the existing persist algorithm.
+   */
+  runStockPreparationPersistUnitOfWork?<T>(
+    input: StockPreparationPersistUnitOfWorkInput,
+    operation: (records: MultitableRecordsWriteUnitOfWorkAPI) => Promise<T>,
+  ): Promise<T>
 }
+
+export interface StockPreparationPersistUnitOfWorkInput {
+  tenantId: string
+  sheetIds: string[]
+  project: {
+    sheetId: string
+    projectId: string
+  }
+  batch: {
+    sheetId: string
+    snapshotBatchId: string
+  }
+}
+
+export type MultitableRecordsWriteUnitOfWorkAPI = Pick<
+  MultitableRecordsAPI,
+  'queryRecords' | 'createRecord' | 'patchRecord'
+>
 
 export interface MultitableAPI {
   provisioning: MultitableProvisioningAPI

--- a/packages/core-backend/tests/integration/stock-preparation-t3b-plm-autopersist-realdb.test.ts
+++ b/packages/core-backend/tests/integration/stock-preparation-t3b-plm-autopersist-realdb.test.ts
@@ -27,6 +27,11 @@ import {
   queryRecords,
   type MultitableRecordsQueryFn,
 } from '../../src/multitable/records'
+import { acquireStockPreparationPersistUnitOfWorkLocks } from '../../src/multitable/stock-preparation-persist-unit-of-work'
+import type {
+  MultitableRecordsWriteUnitOfWorkAPI,
+  StockPreparationPersistUnitOfWorkInput,
+} from '../../src/types/plugin'
 
 const require = createRequire(import.meta.url)
 const { createHandlers } = require('../../../../plugins/plugin-integration-core/lib/http-routes.cjs') as {
@@ -146,6 +151,21 @@ function createRealMultitableFacade() {
       recordId: string
       changes: Record<string, unknown>
     }) => transaction((query) => patchRecord({ query, sheetId, recordId, changes })),
+    runStockPreparationPersistUnitOfWork: <T>(
+      input: StockPreparationPersistUnitOfWorkInput,
+      operation: (records: MultitableRecordsWriteUnitOfWorkAPI) => Promise<T>,
+    ) => transaction(async (query) => {
+      await acquireStockPreparationPersistUnitOfWorkLocks(query, input)
+      const transactionRecords: MultitableRecordsWriteUnitOfWorkAPI = {
+        queryRecords: (recordInput) =>
+          queryRecords({ query, ...recordInput }),
+        createRecord: (recordInput) =>
+          createRecord({ query, ...recordInput }),
+        patchRecord: (recordInput) =>
+          patchRecord({ query, ...recordInput }),
+      }
+      return operation(transactionRecords)
+    }),
   }
   return { provisioning, records }
 }

--- a/packages/core-backend/tests/integration/stock-preparation-t3b-replay-hardening-realdb.test.ts
+++ b/packages/core-backend/tests/integration/stock-preparation-t3b-replay-hardening-realdb.test.ts
@@ -9,21 +9,15 @@ import { createRequire } from 'module'
 
 import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
+import { MetaSheetServer } from '../../src/index'
 import { poolManager } from '../../src/integration/db/connection-pool'
-import {
-  ensureObject,
-  findObjectSheet,
-  patchObjectFieldProperty,
-  resolveObjectFieldIds,
-  type MultitableProvisioningObjectDescriptor,
-  type MultitableProvisioningQueryFn,
-} from '../../src/multitable/provisioning'
-import {
-  createRecord,
-  patchRecord,
-  queryRecords,
-  type MultitableRecordsQueryFn,
-} from '../../src/multitable/records'
+import type { LoadedPlugin } from '../../src/core/plugin-loader'
+import type {
+  MultitableAPI,
+  MultitableRecordsWriteUnitOfWorkAPI,
+  PluginContext,
+  StockPreparationPersistUnitOfWorkInput,
+} from '../../src/types/plugin'
 
 const require = createRequire(import.meta.url)
 const {
@@ -62,63 +56,88 @@ const SOURCE_PROJECT_NO = `SOURCE-PROJECT-${TOKEN}`
 const SYNC_RUN_ID = `run_t3b_${TOKEN}`
 const SNAPSHOT_BATCH_ID = `batch_t3b_${TOKEN}`
 
-type QueryResult = { rows: unknown[]; rowCount?: number | null }
-
-function wrapQuery(
-  query: (sql: string, params?: unknown[]) => Promise<QueryResult>,
-): MultitableProvisioningQueryFn & MultitableRecordsQueryFn {
-  return async (sql, params) => {
-    const result = await query(sql, params)
-    return {
-      rows: Array.isArray(result.rows) ? result.rows : [],
-      rowCount: typeof result.rowCount === 'number' ? result.rowCount : undefined,
-    }
-  }
-}
-
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 
-function transaction<T>(handler: (query: MultitableRecordsQueryFn) => Promise<T>): Promise<T> {
-  return poolManager.get().transaction(async ({ query }) => handler(wrapQuery(query)))
+function createProductionPluginContext(): PluginContext {
+  const server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+  const loaded: LoadedPlugin = {
+    manifest: { name: 'plugin-integration-core', version: 'test' },
+    plugin: { activate: async () => {} },
+    path: 'realdb://plugin-integration-core',
+    loadedAt: new Date(),
+  }
+  return (server as unknown as {
+    createPluginContext: (plugin: LoadedPlugin) => PluginContext
+  }).createPluginContext(loaded)
 }
 
-function createRealMultitableFacade() {
-  const readQuery = wrapQuery(q)
-  const provisioning = {
-    findObjectSheet: ({ projectId, objectId }: { projectId: string; objectId: string }) =>
-      findObjectSheet(readQuery, projectId, objectId),
-    resolveFieldIds: ({ projectId, objectId, fieldIds }: { projectId: string; objectId: string; fieldIds: string[] }) =>
-      resolveObjectFieldIds(projectId, objectId, fieldIds),
-    ensureObject: ({ projectId, baseId, descriptor }: {
-      projectId: string
-      baseId?: string | null
-      descriptor: MultitableProvisioningObjectDescriptor
-    }) => transaction((query) => ensureObject({ query, projectId, baseId, descriptor })),
-    patchObjectFieldProperty: (input: {
-      projectId: string
-      objectId: string
-      fieldId: string
-      propertyPatch: Record<string, unknown>
-    }) => transaction((query) => patchObjectFieldProperty({ query, ...input })),
+function createRealMultitableFacade(multitable: MultitableAPI) {
+  const hostUnitOfWork = multitable.records.runStockPreparationPersistUnitOfWork
+  if (typeof hostUnitOfWork !== 'function') {
+    throw new Error('production plugin context is missing the P4 unit-of-work capability')
   }
+  let failAfterMutation: number | null = null
+  let unitOfWorkBarrier: {
+    expected: number
+    arrived: number
+    wait: Promise<void>
+    release: () => void
+  } | null = null
+  const provisioning = multitable.provisioning
   const records = {
-    queryRecords: (input: {
-      sheetId: string
-      filters?: Record<string, unknown>
-      search?: string
-      orderBy?: { fieldId?: string; direction?: 'asc' | 'desc' }
-      limit?: number
-      offset?: number
-    }) => queryRecords({ query: readQuery, ...input }),
-    createRecord: ({ sheetId, data }: { sheetId: string; data: Record<string, unknown> }) =>
-      transaction((query) => createRecord({ query, sheetId, data })),
-    patchRecord: ({ sheetId, recordId, changes }: {
-      sheetId: string
-      recordId: string
-      changes: Record<string, unknown>
-    }) => transaction((query) => patchRecord({ query, sheetId, recordId, changes })),
+    ...multitable.records,
+    runStockPreparationPersistUnitOfWork: <T>(
+      input: StockPreparationPersistUnitOfWorkInput,
+      operation: (records: MultitableRecordsWriteUnitOfWorkAPI) => Promise<T>,
+    ) => {
+      const enterHostUnitOfWork = async (): Promise<T> => {
+        const barrier = unitOfWorkBarrier
+        if (barrier) {
+          barrier.arrived += 1
+          if (barrier.arrived === barrier.expected) {
+            unitOfWorkBarrier = null
+            barrier.release()
+          }
+          await barrier.wait
+        }
+        return hostUnitOfWork(input, async (transactionRecords) => {
+          let mutationCount = 0
+          const withInjectedCrash = async <R>(mutation: () => Promise<R>): Promise<R> => {
+            const result = await mutation()
+            mutationCount += 1
+            if (failAfterMutation === mutationCount) {
+              failAfterMutation = null
+              throw new Error('P4_INJECTED_TRANSACTION_CRASH')
+            }
+            return result
+          }
+          const crashInjectingRecords: MultitableRecordsWriteUnitOfWorkAPI = {
+            queryRecords: (recordInput) => transactionRecords.queryRecords(recordInput),
+            createRecord: (recordInput) =>
+              withInjectedCrash(() => transactionRecords.createRecord(recordInput)),
+            patchRecord: (recordInput) =>
+              withInjectedCrash(() => transactionRecords.patchRecord(recordInput)),
+          }
+          return operation(crashInjectingRecords)
+        })
+      }
+      return enterHostUnitOfWork()
+    },
   }
-  return { provisioning, records }
+  return {
+    provisioning,
+    records,
+    injectCrashAfterMutation(count: number) {
+      failAfterMutation = count
+    },
+    armUnitOfWorkBarrier(expected: number) {
+      let release = () => {}
+      const wait = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      unitOfWorkBarrier = { expected, arrived: 0, wait, release }
+    },
+  }
 }
 
 async function discoverPhysicalFields(sheetId: string, objectId: string): Promise<Record<string, string>> {
@@ -136,12 +155,16 @@ async function discoverPhysicalFields(sheetId: string, objectId: string): Promis
   }))
 }
 
-function persistInput(facade: ReturnType<typeof createRealMultitableFacade>): Record<string, unknown> {
+function persistInput(
+  facade: ReturnType<typeof createRealMultitableFacade>,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     permission: 'admin',
     recordsApi: facade.records,
     provisioning: facade.provisioning,
     targetProjectId: TARGET_PROJECT_ID,
+    lockTenantId: TENANT_ID,
     projectId: PROJECT_ID,
     sourceProjectNo: SOURCE_PROJECT_NO,
     sourceSystem: 'data-source:sql-readonly',
@@ -156,6 +179,7 @@ function persistInput(facade: ReturnType<typeof createRealMultitableFacade>): Re
       path: `/root/MATERIAL-${TOKEN}`,
       rawQuantity: 3,
     }],
+    ...overrides,
   }
 }
 
@@ -166,7 +190,10 @@ if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL
 }
 
 describeIfDatabase('stock-preparation T3b immutable replay hardening (real DB)', () => {
-  const facade = createRealMultitableFacade()
+  const pluginContext = createProductionPluginContext()
+  const multitable = pluginContext.api.multitable
+  if (!multitable) throw new Error('production plugin context is missing multitable APIs')
+  const facade = createRealMultitableFacade(multitable)
   const context = { api: { multitable: facade }, storage: {}, config: {} }
   const objectIds = [PROJECT_OBJECT_ID, BATCH_OBJECT_ID, LINE_OBJECT_ID, RUN_OBJECT_ID]
   const sheetIds = new Map<string, string>()
@@ -264,4 +291,150 @@ describeIfDatabase('stock-preparation T3b immutable replay hardening (real DB)',
     const afterConflict = await q('SELECT id, version, data FROM meta_records WHERE id = $1 AND sheet_id = $2', [recordId, lineSheetId])
     expect(afterConflict.rows).toEqual(planted.rows)
   })
+
+  test('CW1-CW4 crash matrix rolls back all four tables and revisions before clean retries', async () => {
+    const ids = [...sheetIds.values()]
+    const counts = async () => ({
+      records: (await q(
+        'SELECT count(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[])',
+        [ids],
+      )).rows,
+      revisions: (await q(
+        'SELECT count(*)::int AS count FROM meta_record_revisions WHERE sheet_id = ANY($1::text[])',
+        [ids],
+      )).rows,
+    })
+    const expansionResult = [
+      {
+        componentSourceId: `component_a_${TOKEN}`,
+        componentCode: `MATERIAL-A-${TOKEN}`,
+        sourceVersion: 'A',
+        path: `/root/MATERIAL-A-${TOKEN}`,
+        rawQuantity: 1,
+      },
+      {
+        componentSourceId: `component_b_${TOKEN}`,
+        componentCode: `MATERIAL-B-${TOKEN}`,
+        sourceVersion: 'A',
+        path: `/root/MATERIAL-B-${TOKEN}`,
+        rawQuantity: 2,
+      },
+    ]
+    const scenarios = [
+      { name: 'CW1', failAfter: 1, existingProject: false },
+      { name: 'CW2', failAfter: 2, existingProject: false },
+      { name: 'CW3', failAfter: 3, existingProject: false },
+      { name: 'CW4-first', failAfter: 4, existingProject: false },
+      { name: 'CW4-existing', failAfter: 4, existingProject: true },
+    ]
+
+    for (const scenario of scenarios) {
+      const projectId = `${PROJECT_ID}_${scenario.name}`
+      const common = {
+        projectId,
+        sourceProjectNo: `${SOURCE_PROJECT_NO}_${scenario.name}`,
+        expansionResult,
+      }
+      if (scenario.existingProject) {
+        await persistStockPreparationSyncRun(persistInput(facade, {
+          ...common,
+          syncRunId: `${SYNC_RUN_ID}_${scenario.name}_base`,
+          snapshotBatchId: `${SNAPSHOT_BATCH_ID}_${scenario.name}_base`,
+          snapshotVersion: 1,
+        }))
+      }
+      const input = persistInput(facade, {
+        ...common,
+        syncRunId: `${SYNC_RUN_ID}_${scenario.name}`,
+        snapshotBatchId: `${SNAPSHOT_BATCH_ID}_${scenario.name}`,
+        snapshotVersion: scenario.existingProject ? 2 : 1,
+      })
+      const before = await counts()
+      facade.injectCrashAfterMutation(scenario.failAfter)
+      await expect(persistStockPreparationSyncRun(input))
+        .rejects.toThrow('P4_INJECTED_TRANSACTION_CRASH')
+      expect(await counts()).toEqual(before)
+      await expect(persistStockPreparationSyncRun(input)).resolves.toMatchObject({
+        persisted: true,
+        mode: 'created',
+        created: { batch: 1, lines: 2, run: 1 },
+        project: { mode: scenario.existingProject ? 'patched' : 'created' },
+      })
+    }
+  }, 30_000)
+
+  test('concurrent same-batch writers converge to one create and one exact replay', async () => {
+    const projectId = `${PROJECT_ID}_same_batch`
+    const snapshotBatchId = `${SNAPSHOT_BATCH_ID}_same_batch`
+    const input = persistInput(facade, {
+      projectId,
+      sourceProjectNo: `${SOURCE_PROJECT_NO}_same_batch`,
+      syncRunId: `${SYNC_RUN_ID}_same_batch`,
+      snapshotBatchId,
+      snapshotVersion: 1,
+    })
+    facade.armUnitOfWorkBarrier(2)
+    const results = await Promise.all([
+      persistStockPreparationSyncRun(input),
+      persistStockPreparationSyncRun(input),
+    ])
+    expect(results.map((result) => result.mode).sort()).toEqual(['created', 'skipped_existing'])
+
+    const batchSheetId = sheetIds.get(BATCH_OBJECT_ID)
+    const projectSheetId = sheetIds.get(PROJECT_OBJECT_ID)
+    if (!batchSheetId || !projectSheetId) throw new Error('missing P4 concurrency sheet ids')
+    const batchFields = await discoverPhysicalFields(batchSheetId, BATCH_OBJECT_ID)
+    const projectFields = await discoverPhysicalFields(projectSheetId, PROJECT_OBJECT_ID)
+    const batchRows = await q(
+      'SELECT id FROM meta_records WHERE sheet_id = $1 AND data ->> $2 = $3',
+      [batchSheetId, batchFields.snapshotBatchId, snapshotBatchId],
+    )
+    const projectRows = await q(
+      'SELECT id FROM meta_records WHERE sheet_id = $1 AND data ->> $2 = $3',
+      [projectSheetId, projectFields.projectId, projectId],
+    )
+    expect(batchRows.rows).toHaveLength(1)
+    expect(projectRows.rows).toHaveLength(1)
+  }, 30_000)
+
+  test('concurrent different batches for one project never duplicate its live row', async () => {
+    const projectId = `${PROJECT_ID}_same_project`
+    const inputV1 = persistInput(facade, {
+      projectId,
+      sourceProjectNo: `${SOURCE_PROJECT_NO}_same_project`,
+      syncRunId: `${SYNC_RUN_ID}_same_project_v1`,
+      snapshotBatchId: `${SNAPSHOT_BATCH_ID}_same_project_v1`,
+      snapshotVersion: 1,
+    })
+    const inputV2 = persistInput(facade, {
+      projectId,
+      sourceProjectNo: `${SOURCE_PROJECT_NO}_same_project`,
+      syncRunId: `${SYNC_RUN_ID}_same_project_v2`,
+      snapshotBatchId: `${SNAPSHOT_BATCH_ID}_same_project_v2`,
+      snapshotVersion: 2,
+    })
+    facade.armUnitOfWorkBarrier(2)
+    const outcomes = await Promise.allSettled([
+      persistStockPreparationSyncRun(inputV1),
+      persistStockPreparationSyncRun(inputV2),
+    ])
+    const fulfilled = outcomes.filter((outcome) => outcome.status === 'fulfilled')
+    const rejected = outcomes.filter((outcome) => outcome.status === 'rejected')
+    expect(fulfilled.length).toBeGreaterThanOrEqual(1)
+    for (const outcome of rejected) {
+      expect(outcome.reason).toMatchObject({
+        status: 422,
+        code: 'PERSIST_VERSION_NOT_MONOTONIC',
+      })
+    }
+
+    const projectSheetId = sheetIds.get(PROJECT_OBJECT_ID)
+    if (!projectSheetId) throw new Error('missing P4 project sheet id')
+    const projectFields = await discoverPhysicalFields(projectSheetId, PROJECT_OBJECT_ID)
+    const projectRows = await q(
+      'SELECT id FROM meta_records WHERE sheet_id = $1 AND data ->> $2 = $3',
+      [projectSheetId, projectFields.projectId, projectId],
+    )
+    expect(projectRows.rows).toHaveLength(1)
+  }, 30_000)
 })

--- a/packages/core-backend/tests/unit/multitable-plugin-scope.test.ts
+++ b/packages/core-backend/tests/unit/multitable-plugin-scope.test.ts
@@ -365,4 +365,69 @@ describe('multitable plugin scope helper', () => {
       async () => null,
     )).rejects.toThrow(MultitableUnitOfWorkUnavailableError)
   })
+
+  it('normalizes UOW sheet ids before allowlist and host handoff; whitespace variants stay out of scope', async () => {
+    const transactionRecords = {
+      queryRecords: vi.fn(async (input: { sheetId: string }) => [{ sheetId: input.sheetId }]),
+      createRecord: vi.fn(async (input: { sheetId: string }) => ({ id: 'rec_1', version: 1, sheetId: input.sheetId })),
+      patchRecord: vi.fn(async (input: { sheetId: string; recordId: string }) => ({
+        id: input.recordId,
+        version: 2,
+        sheetId: input.sheetId,
+      })),
+    }
+    const hook = vi.fn(async (_input, operation) => operation(transactionRecords as any))
+    const multitable = {
+      provisioning: {},
+      records: {
+        listRecords: vi.fn(), queryRecords: vi.fn(), createRecord: vi.fn(),
+        getRecord: vi.fn(), patchRecord: vi.fn(), deleteRecord: vi.fn(),
+      },
+    }
+    const scoped = createPluginScopedMultitableApi(multitable as any, 'plugin-integration-core', {
+      runStockPreparationPersistUnitOfWork: hook,
+    })
+
+    const paddedProjectSheetId = ' sheet_project '
+    const rawInput = {
+      tenantId: ' tenant_1 ',
+      sheetIds: [paddedProjectSheetId, ' sheet_batch ', 'sheet_line', 'sheet_run'],
+      project: { sheetId: paddedProjectSheetId, projectId: ' project_1 ' },
+      batch: { sheetId: ' sheet_batch ', snapshotBatchId: ' batch_1 ' },
+    }
+    const normalized = {
+      tenantId: 'tenant_1',
+      sheetIds: ['sheet_project', 'sheet_batch', 'sheet_line', 'sheet_run'],
+      project: { sheetId: 'sheet_project', projectId: 'project_1' },
+      batch: { sheetId: 'sheet_batch', snapshotBatchId: 'batch_1' },
+    }
+
+    const result = await scoped.records.runStockPreparationPersistUnitOfWork?.(
+      rawInput,
+      async (records) => {
+        // Declared (trimmed) id is in scope and reaches the host records API.
+        const rows = await records.queryRecords({ sheetId: 'sheet_project' })
+        // Negative leg / mutation proof: the raw padded string was on the pre-normalization
+        // sheetIds array. If the allowlist were still built from raw input.sheetIds, this call
+        // would succeed and the assertion below would fail. Fail closed requires the throw.
+        await expect(
+          records.queryRecords({ sheetId: paddedProjectSheetId }),
+        ).rejects.toThrow(MultitableUnitOfWorkScopeError)
+        await expect(
+          records.createRecord({ sheetId: paddedProjectSheetId, data: { k: 1 } }),
+        ).rejects.toThrow(MultitableUnitOfWorkScopeError)
+        await expect(
+          records.patchRecord({ sheetId: paddedProjectSheetId, recordId: 'rec_x', changes: { k: 2 } }),
+        ).rejects.toThrow(MultitableUnitOfWorkScopeError)
+        return rows
+      },
+    )
+
+    expect(result).toEqual([{ sheetId: 'sheet_project' }])
+    expect(hook.mock.calls[0]?.[0]).toEqual({ ...normalized, pluginName: 'plugin-integration-core' })
+    expect(transactionRecords.queryRecords).toHaveBeenCalledWith({ sheetId: 'sheet_project' })
+    expect(transactionRecords.queryRecords).not.toHaveBeenCalledWith({ sheetId: paddedProjectSheetId })
+    expect(transactionRecords.createRecord).not.toHaveBeenCalled()
+    expect(transactionRecords.patchRecord).not.toHaveBeenCalled()
+  })
 })

--- a/packages/core-backend/tests/unit/multitable-plugin-scope.test.ts
+++ b/packages/core-backend/tests/unit/multitable-plugin-scope.test.ts
@@ -4,6 +4,8 @@ import {
   MultitableObjectScopeError,
   MultitableProjectNamespaceError,
   MultitableSheetScopeError,
+  MultitableUnitOfWorkScopeError,
+  MultitableUnitOfWorkUnavailableError,
   assertProjectIdAllowedForPlugin,
   assertPluginOwnsObject,
   assertPluginOwnsSheet,
@@ -295,5 +297,63 @@ describe('multitable plugin scope helper', () => {
         objectId: 'serviceTicket',
       }),
     ).rejects.toThrow(MultitableObjectScopeError)
+  })
+
+  it('binds the stock-preparation unit-of-work to the plugin and declared four-sheet scope', async () => {
+    const transactionRecords = {
+      queryRecords: vi.fn(async () => []),
+      createRecord: vi.fn(async (input) => ({ id: 'rec_1', version: 1, data: input.data, ...input })),
+      patchRecord: vi.fn(async (input) => ({ id: input.recordId, version: 2, data: input.changes, ...input })),
+    }
+    const hook = vi.fn(async (_input, operation) => operation(transactionRecords as any))
+    const multitable = {
+      provisioning: {},
+      records: {
+        listRecords: vi.fn(), queryRecords: vi.fn(), createRecord: vi.fn(),
+        getRecord: vi.fn(), patchRecord: vi.fn(), deleteRecord: vi.fn(),
+      },
+    }
+    const scoped = createPluginScopedMultitableApi(multitable as any, 'plugin-integration-core', {
+      runStockPreparationPersistUnitOfWork: hook,
+    })
+    const uowInput = {
+      tenantId: 'tenant_1',
+      sheetIds: ['sheet_project', 'sheet_batch', 'sheet_line', 'sheet_run'],
+      project: { sheetId: 'sheet_project', projectId: 'business_project' },
+      batch: { sheetId: 'sheet_batch', snapshotBatchId: 'batch_1' },
+    }
+
+    const result = await scoped.records.runStockPreparationPersistUnitOfWork?.(
+      uowInput,
+      async (records) => records.queryRecords({ sheetId: 'sheet_batch' }),
+    )
+    expect(result).toEqual([])
+    expect(hook.mock.calls[0]?.[0]).toEqual({ ...uowInput, pluginName: 'plugin-integration-core' })
+    expect(transactionRecords.queryRecords).toHaveBeenCalledWith({ sheetId: 'sheet_batch' })
+
+    await expect(scoped.records.runStockPreparationPersistUnitOfWork?.(
+      uowInput,
+      async (records) => records.queryRecords({ sheetId: 'sheet_foreign' }),
+    )).rejects.toThrow(MultitableUnitOfWorkScopeError)
+  })
+
+  it('fails closed when the host does not provide the required unit-of-work hook', async () => {
+    const multitable = {
+      provisioning: {},
+      records: {
+        listRecords: vi.fn(), queryRecords: vi.fn(), createRecord: vi.fn(),
+        getRecord: vi.fn(), patchRecord: vi.fn(), deleteRecord: vi.fn(),
+      },
+    }
+    const scoped = createPluginScopedMultitableApi(multitable as any, 'plugin-integration-core')
+    await expect(scoped.records.runStockPreparationPersistUnitOfWork?.(
+      {
+        tenantId: 'tenant_1',
+        sheetIds: ['sheet_project', 'sheet_batch', 'sheet_line', 'sheet_run'],
+        project: { sheetId: 'sheet_project', projectId: 'project_1' },
+        batch: { sheetId: 'sheet_batch', snapshotBatchId: 'batch_1' },
+      },
+      async () => null,
+    )).rejects.toThrow(MultitableUnitOfWorkUnavailableError)
   })
 })

--- a/packages/core-backend/tests/unit/multitable-plugin-scope.test.ts
+++ b/packages/core-backend/tests/unit/multitable-plugin-scope.test.ts
@@ -335,6 +335,15 @@ describe('multitable plugin scope helper', () => {
       uowInput,
       async (records) => records.queryRecords({ sheetId: 'sheet_foreign' }),
     )).rejects.toThrow(MultitableUnitOfWorkScopeError)
+
+    const runUnitOfWork = scoped.records.runStockPreparationPersistUnitOfWork as unknown as (
+      input: unknown,
+      operation: unknown,
+    ) => Promise<unknown>
+    const hookCallsBeforeInvalidInput = hook.mock.calls.length
+    await expect(runUnitOfWork(uowInput, null)).rejects.toThrow('operation must be a function')
+    await expect(runUnitOfWork(null, async () => null)).rejects.toThrow('input must be an object')
+    expect(hook).toHaveBeenCalledTimes(hookCallsBeforeInvalidInput)
   })
 
   it('fails closed when the host does not provide the required unit-of-work hook', async () => {

--- a/packages/core-backend/tests/unit/multitable-w13-write-path-layer3-gate.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-w13-write-path-layer3-gate.guard.test.ts
@@ -18,10 +18,10 @@
  *     `field_permissions` scope check on the semantic field being edited (not the shared
  *     `isFieldWriteForbidden` helper), thrown from inside its `preWriteGuard` callback before
  *     `patchRecords`' internal write.
- *   - `multitable/plugin-scope.ts`'s `records.patchRecord` wrapper textually matches the `.patchRecord(`
- *     call-site scan but calls a COMPLETELY DIFFERENT function (`multitable/records.ts`'s own raw-SQL
- *     `patchRecord`, not `RecordService.patchRecord`) — an actor-less plugin-SDK write path with no
- *     per-subject identity to gate against. Classified EXEMPT, not GATED.
+ *   - `multitable/plugin-scope.ts`'s two `records.patchRecord` wrappers textually match the `.patchRecord(`
+ *     call-site scan but call COMPLETELY DIFFERENT functions (the regular plugin records API and the
+ *     transaction-scoped records API, not `RecordService.patchRecord`) — actor-less plugin-SDK write
+ *     paths with no per-subject identity to gate against. Classified EXEMPT, not GATED.
  * This refines (does not contradict) the design-lock: the bridge and the single-record PATCH route remain
  * the only two paths that were actually ungated; the true existing-gated count is higher than "six".
  *
@@ -147,10 +147,17 @@ const PATCHRECORD_ALLOWLIST: Record<string, Array<{ disposition: Disposition; re
     {
       disposition: 'EXEMPT',
       reason:
-        "Different function: delegates to multitable/records.ts's OWN patchRecord (raw SQL " +
+        "Regular records wrapper: delegates to multitable/records.ts's OWN patchRecord (raw SQL " +
         "'UPDATE meta_records SET data = ...'), NOT RecordService.patchRecord — a structurally actor-less " +
         'plugin-SDK write path (guardRecordNotLockedForPlugin is called with actor=null). There is no ' +
         'per-subject identity for field_permissions to gate against on this path.',
+    },
+    {
+      disposition: 'EXEMPT',
+      reason:
+        'P4 transaction-scoped records wrapper: delegates to the host-owned unit-of-work patchRecord, ' +
+        'NOT RecordService.patchRecord. It remains actor-less and is additionally constrained to the ' +
+        'four sheets declared by the stock-preparation persist operation.',
     },
   ],
 }

--- a/packages/core-backend/tests/unit/stock-preparation-persist-unit-of-work.test.ts
+++ b/packages/core-backend/tests/unit/stock-preparation-persist-unit-of-work.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  STOCK_PREPARATION_BATCH_LOCK_NS,
+  STOCK_PREPARATION_PROJECT_LOCK_NS,
+  StockPreparationPersistUnitOfWorkError,
+  acquireStockPreparationPersistUnitOfWorkLocks,
+} from "../../src/multitable/stock-preparation-persist-unit-of-work";
+
+const input = {
+  tenantId: "tenant_1",
+  sheetIds: ["sheet_run", "sheet_project", "sheet_line", "sheet_batch"],
+  project: { sheetId: "sheet_project", projectId: "project_1" },
+  batch: { sheetId: "sheet_batch", snapshotBatchId: "batch_1" },
+};
+
+describe("stock-preparation persist unit-of-work locks", () => {
+  it("takes sorted canonical sheet fences, then project and batch locks in fixed namespaces", async () => {
+    const calls: Array<{ sql: string; params: unknown[] }> = [];
+    const query = vi.fn(async (sql: string, params: unknown[] = []) => {
+      calls.push({ sql, params });
+      return { rows: [] };
+    });
+
+    await expect(
+      acquireStockPreparationPersistUnitOfWorkLocks(query, input),
+    ).resolves.toEqual(input);
+
+    expect(calls).toEqual([
+      {
+        sql: "SELECT pg_advisory_xact_lock(hashtext($1))",
+        params: ["meta:auto-number:sheet:sheet_batch"],
+      },
+      {
+        sql: "SELECT pg_advisory_xact_lock(hashtext($1))",
+        params: ["meta:auto-number:sheet:sheet_line"],
+      },
+      {
+        sql: "SELECT pg_advisory_xact_lock(hashtext($1))",
+        params: ["meta:auto-number:sheet:sheet_project"],
+      },
+      {
+        sql: "SELECT pg_advisory_xact_lock(hashtext($1))",
+        params: ["meta:auto-number:sheet:sheet_run"],
+      },
+      {
+        sql: "SELECT pg_advisory_xact_lock($1::int, hashtext($2)::int)",
+        params: [
+          STOCK_PREPARATION_PROJECT_LOCK_NS,
+          "tenant_1|sheet_project|project_1",
+        ],
+      },
+      {
+        sql: "SELECT pg_advisory_xact_lock($1::int, hashtext($2)::int)",
+        params: [
+          STOCK_PREPARATION_BATCH_LOCK_NS,
+          "tenant_1|sheet_batch|batch_1",
+        ],
+      },
+    ]);
+  });
+
+  it("rejects a non-four-sheet or out-of-scope key before taking any lock", async () => {
+    for (const invalid of [
+      { ...input, sheetIds: input.sheetIds.slice(0, 3) },
+      {
+        ...input,
+        sheetIds: ["sheet_batch", "sheet_batch", "sheet_line", "sheet_run"],
+      },
+      { ...input, project: { ...input.project, sheetId: "sheet_foreign" } },
+    ]) {
+      const query = vi.fn(async () => ({ rows: [] }));
+      await expect(
+        acquireStockPreparationPersistUnitOfWorkLocks(query, invalid),
+      ).rejects.toBeInstanceOf(StockPreparationPersistUnitOfWorkError);
+      expect(query).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/packages/core-backend/tests/unit/stock-preparation-persist-unit-of-work.test.ts
+++ b/packages/core-backend/tests/unit/stock-preparation-persist-unit-of-work.test.ts
@@ -5,6 +5,8 @@ import {
   STOCK_PREPARATION_PROJECT_LOCK_NS,
   StockPreparationPersistUnitOfWorkError,
   acquireStockPreparationPersistUnitOfWorkLocks,
+  stockPreparationBatchLockKey,
+  stockPreparationProjectLockKey,
 } from "../../src/multitable/stock-preparation-persist-unit-of-work";
 
 const input = {
@@ -47,17 +49,39 @@ describe("stock-preparation persist unit-of-work locks", () => {
         sql: "SELECT pg_advisory_xact_lock($1::int, hashtext($2)::int)",
         params: [
           STOCK_PREPARATION_PROJECT_LOCK_NS,
-          "tenant_1|sheet_project|project_1",
+          '["tenant_1","sheet_project","project_1"]',
         ],
       },
       {
         sql: "SELECT pg_advisory_xact_lock($1::int, hashtext($2)::int)",
         params: [
           STOCK_PREPARATION_BATCH_LOCK_NS,
-          "tenant_1|sheet_batch|batch_1",
+          '["tenant_1","sheet_batch","batch_1"]',
         ],
       },
     ]);
+  });
+
+  it("frames lock-key components without delimiter collisions", () => {
+    const left = {
+      ...input,
+      tenantId: "tenant|one",
+      project: { ...input.project, sheetId: "sheet_project" },
+      batch: { ...input.batch, sheetId: "sheet_batch" },
+    };
+    const right = {
+      ...input,
+      tenantId: "tenant",
+      project: { ...input.project, sheetId: "one|sheet_project" },
+      batch: { ...input.batch, sheetId: "one|sheet_batch" },
+    };
+
+    expect(stockPreparationProjectLockKey(left)).not.toBe(
+      stockPreparationProjectLockKey(right),
+    );
+    expect(stockPreparationBatchLockKey(left)).not.toBe(
+      stockPreparationBatchLockKey(right),
+    );
   });
 
   it("rejects a non-four-sheet or out-of-scope key before taking any lock", async () => {

--- a/packages/core-backend/tests/unit/stock-preparation-persist-unit-of-work.test.ts
+++ b/packages/core-backend/tests/unit/stock-preparation-persist-unit-of-work.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  __resetRecoveryWriterStateColumnProbe,
+  SheetWriterBlockedError,
+} from "../../src/multitable/canonical-sheet-fence";
+import {
   STOCK_PREPARATION_BATCH_LOCK_NS,
   STOCK_PREPARATION_PROJECT_LOCK_NS,
   StockPreparationPersistUnitOfWorkError,
@@ -82,6 +86,41 @@ describe("stock-preparation persist unit-of-work locks", () => {
     expect(stockPreparationBatchLockKey(left)).not.toBe(
       stockPreparationBatchLockKey(right),
     );
+  });
+
+  it("refuses an active durable recovery block before taking project or batch locks", async () => {
+    const originalFlag = process.env.MULTITABLE_ENABLE_WRITER_FENCE;
+    process.env.MULTITABLE_ENABLE_WRITER_FENCE = "true";
+    __resetRecoveryWriterStateColumnProbe();
+    const calls: Array<{ sql: string; params: unknown[] }> = [];
+    const query = vi.fn(async (sql: string, params: unknown[] = []) => {
+      calls.push({ sql, params });
+      if (sql.includes("information_schema.columns")) return { rows: [{}] };
+      if (sql.includes("SELECT recovery_writer_state")) {
+        return {
+          rows: [{
+            recovery_writer_state: params[0] === "sheet_batch" ? "applying" : null,
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    try {
+      await expect(
+        acquireStockPreparationPersistUnitOfWorkLocks(query, input),
+      ).rejects.toBeInstanceOf(SheetWriterBlockedError);
+      expect(
+        calls.some(({ sql }) => sql.includes("pg_advisory_xact_lock($1::int")),
+      ).toBe(false);
+    } finally {
+      if (originalFlag === undefined) {
+        delete process.env.MULTITABLE_ENABLE_WRITER_FENCE;
+      } else {
+        process.env.MULTITABLE_ENABLE_WRITER_FENCE = originalFlag;
+      }
+      __resetRecoveryWriterStateColumnProbe();
+    }
   });
 
   it("rejects a non-four-sheet or out-of-scope key before taking any lock", async () => {

--- a/plugins/plugin-integration-core/__tests__/fixtures/stock-preparation-multitable-fakes.cjs
+++ b/plugins/plugin-integration-core/__tests__/fixtures/stock-preparation-multitable-fakes.cjs
@@ -101,7 +101,10 @@ function makeStrictRecordsApi({ objectIdBySheetId, stagingProjectId, rowsBySheet
   const createCalls = []
   const queryCalls = []
   const patchCalls = []
+  const unitOfWorkCalls = []
   let seq = 0
+  let unitOfWorkDepth = 0
+  let recordsCallsOutsideUnitOfWork = 0
 
   function objectIdFor(sheetId) {
     const objectId = objectIdBySheetId[sheetId]
@@ -109,11 +112,18 @@ function makeStrictRecordsApi({ objectIdBySheetId, stagingProjectId, rowsBySheet
     return objectId
   }
 
-  return {
+  const api = {
     store,
     createCalls,
     queryCalls,
     patchCalls,
+    unitOfWorkCalls,
+    get inUnitOfWork() {
+      return unitOfWorkDepth > 0
+    },
+    get recordsCallsOutsideUnitOfWork() {
+      return recordsCallsOutsideUnitOfWork
+    },
     get patchCallCount() {
       return patchCalls.length
     },
@@ -121,6 +131,7 @@ function makeStrictRecordsApi({ objectIdBySheetId, stagingProjectId, rowsBySheet
       return (store.get(sheetId) || []).map((row) => ({ ...row, data: { ...row.data } }))
     },
     async createRecord(input = {}) {
+      if (unitOfWorkDepth === 0) recordsCallsOutsideUnitOfWork += 1
       const { sheetId, data = {} } = input
       assertKnownFieldIds(stagingProjectId, objectIdFor(sheetId), Object.keys(data))
       createCalls.push({ sheetId, data: { ...data } })
@@ -132,6 +143,7 @@ function makeStrictRecordsApi({ objectIdBySheetId, stagingProjectId, rowsBySheet
       return { ...record, data: { ...record.data } }
     },
     async queryRecords(input = {}) {
+      if (unitOfWorkDepth === 0) recordsCallsOutsideUnitOfWork += 1
       const { sheetId, filters = {} } = input
       assertKnownFieldIds(stagingProjectId, objectIdFor(sheetId), Object.keys(filters))
       queryCalls.push({ sheetId, filters: { ...filters } })
@@ -141,6 +153,7 @@ function makeStrictRecordsApi({ objectIdBySheetId, stagingProjectId, rowsBySheet
         .map((record) => ({ ...record, data: { ...record.data } }))
     },
     async patchRecord(input = {}) {
+      if (unitOfWorkDepth === 0) recordsCallsOutsideUnitOfWork += 1
       const { sheetId, recordId, changes = {} } = input
       assertKnownFieldIds(stagingProjectId, objectIdFor(sheetId), Object.keys(changes))
       patchCalls.push({ sheetId, recordId, changes: { ...changes } })
@@ -153,7 +166,37 @@ function makeStrictRecordsApi({ objectIdBySheetId, stagingProjectId, rowsBySheet
       record.version = (record.version || 1) + 1
       return { ...record, data: { ...record.data } }
     },
+    async runStockPreparationPersistUnitOfWork(input, operation) {
+      unitOfWorkCalls.push(structuredClone(input))
+      const beforeStore = new Map(
+        [...store.entries()].map(([sheetId, rows]) => [
+          sheetId,
+          rows.map((row) => ({ ...row, data: { ...row.data } })),
+        ]),
+      )
+      const beforeSeq = seq
+      const beforeCalls = {
+        create: createCalls.length,
+        query: queryCalls.length,
+        patch: patchCalls.length,
+      }
+      unitOfWorkDepth += 1
+      try {
+        return await operation(this)
+      } catch (error) {
+        store.clear()
+        for (const [sheetId, rows] of beforeStore) store.set(sheetId, rows)
+        seq = beforeSeq
+        createCalls.length = beforeCalls.create
+        queryCalls.length = beforeCalls.query
+        patchCalls.length = beforeCalls.patch
+        throw error
+      } finally {
+        unitOfWorkDepth -= 1
+      }
+    },
   }
+  return api
 }
 
 // Seed helper: turn LOGICAL test rows into the PHYSICAL-keyed rows the substrate really stores.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -7562,6 +7562,9 @@ function createInMemoryMvpPersistStore() {
       writes.push({ op: 'patch', sheetId, data: { ...changes } })
       return { id: recordId, sheetId, data: { ...data } }
     },
+    async runStockPreparationPersistUnitOfWork(_input, operation) {
+      return operation(recordsApi)
+    },
   }
   const provisioningApi = {
     async findObjectSheet({ projectId, objectId } = {}) {

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-erp-material-sync-persist.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-erp-material-sync-persist.test.cjs
@@ -526,6 +526,7 @@ async function main() {
       provisioning,
       projectId: 'proj_1',
       targetProjectId: STAGING_PROJECT_ID,
+      lockTenantId: 'tenant_x',
       syncRunId: 'bom_run_1',
       snapshotBatchId: 'batch_1',
       sourceProjectNo: 'PN-1',

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-sync-run-persist.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-sync-run-persist.test.cjs
@@ -58,6 +58,7 @@ const LEAKY_DRAWING_NO = `DRW_${SECRET}`
 // The MVP tables live under the INTERNAL staging project; the business projectId ('proj_1') is a DIFFERENT
 // value. Sheet resolution must use the staging targetProjectId — a lookup with the business project misses.
 const STAGING_PROJECT_ID = 'tenant_x:integration-core'
+const LOCK_TENANT_ID = 'tenant_x'
 
 let passed = 0
 let failed = 0
@@ -166,6 +167,7 @@ function basePlanInputs(overrides = {}) {
   return {
     projectId: 'proj_1',
     targetProjectId: STAGING_PROJECT_ID,
+    lockTenantId: LOCK_TENANT_ID,
     syncRunId: 'run_1',
     snapshotBatchId: 'batch_1',
     sourceProjectNo: 'PN-1',
@@ -195,6 +197,14 @@ async function main() {
     assert.equal(result.persisted, true)
     assert.equal(result.mode, 'created')
     assert.deepEqual(result.created, { batch: 1, lines: 2, run: 1 })
+    assert.equal(recordsApi.unitOfWorkCalls.length, 1, 'persist enters exactly one host-owned unit-of-work')
+    assert.deepEqual(recordsApi.unitOfWorkCalls[0], {
+      tenantId: LOCK_TENANT_ID,
+      sheetIds: [BATCH_SHEET_ID, LINE_SHEET_ID, RUN_SHEET_ID, PROJECT_SHEET_ID],
+      project: { sheetId: PROJECT_SHEET_ID, projectId: 'proj_1' },
+      batch: { sheetId: BATCH_SHEET_ID, snapshotBatchId: 'batch_1' },
+    })
+    assert.equal(recordsApi.recordsCallsOutsideUnitOfWork, 0, 'all idempotency reads and writes stay inside the unit-of-work')
 
     // 5 creates: 1 batch, 2 lines, 1 run, THEN the project row (upserted last) — in that order.
     assert.equal(recordsApi.createCalls.length, 5)
@@ -259,6 +269,22 @@ async function main() {
     )
     assert.equal(provisioning.findObjectSheetCalls, 0, 'no sheet resolved')
     assert.equal(recordsApi.createCalls.length, 0, 'no write')
+  })
+
+  await run('P4 hard cut: missing atomic unit-of-work capability fails before provisioning or records I/O', async () => {
+    const recordsApi = makeRecordsApi()
+    recordsApi.runStockPreparationPersistUnitOfWork = undefined
+    const provisioning = makeProvisioning()
+    await assert.rejects(
+      () => persistStockPreparationSyncRun({
+        permission: 'admin', recordsApi, provisioning, ...basePlanInputs(),
+      }),
+      (error) => error instanceof StockPreparationSyncRunPersistError &&
+        error.status === 503 && error.code === 'PERSIST_UNIT_OF_WORK_UNAVAILABLE',
+    )
+    assert.equal(provisioning.findObjectSheetCalls, 0)
+    assert.equal(recordsApi.createCalls.length, 0)
+    assert.equal(recordsApi.queryCalls.length, 0)
   })
 
   await run('resolving sheets with the BUSINESS projectId misses — proves the split is load-bearing', async () => {
@@ -818,18 +844,17 @@ async function main() {
 
   // ── H-2 (P4 lock round-1): replay verifies the project LIVE POINTER, not just row existence ──────
 
-  await run('H-2: CW4-existing crash (run created, project patch lost) -> replay 409 stale_pointer, not silent 200', async () => {
+  await run('P4: a project-patch crash rolls back batch/lines/run/project together, then the same request retries cleanly', async () => {
     const recordsApi = makeRecordsApi()
     const provisioning = makeProvisioning()
-    // Sync 1 commits fully: project pointer -> run_1 (batch_1, version 1).
-    await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
-    // Sync 2 (batch_2, version 2) crashes at the CW4-existing window: every batch/line/run write lands,
-    // the project PATCH is lost. Injected by failing patchRecord on the PROJECT sheet only.
     const crashingApi = Object.create(recordsApi)
     crashingApi.patchRecord = async (input = {}) => {
       if (input.sheetId === PROJECT_SHEET_ID) throw new Error('injected crash before project patch')
       return recordsApi.patchRecord(input)
     }
+    // Establish an existing project so the next sync exercises the patch branch.
+    await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
+    const callsBeforeCrash = recordsApi.createCalls.length
     await assert.rejects(
       () => persistStockPreparationSyncRun({
         permission: 'admin',
@@ -839,21 +864,42 @@ async function main() {
       }),
       /injected crash before project patch/,
     )
-    // Retry of sync 2 replays batch/lines/run exactly — but the pointer still names run_1 whose batch
-    // sits at a LOWER version. Pre-H-2 this returned 200 skipped_existing (the silent window).
+    assert.equal(recordsApi.createCalls.length, callsBeforeCrash, 'failed unit-of-work leaves zero new creates')
+    const retry = await persistStockPreparationSyncRun({
+      permission: 'admin',
+      recordsApi,
+      provisioning,
+      ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 2 }),
+    })
+    assert.equal(retry.mode, 'created')
+  })
+
+  await run('H-2: a legacy complete batch whose project pointer stayed older still fails closed on replay', async () => {
+    const recordsApi = makeRecordsApi()
+    const provisioning = makeProvisioning()
+    await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
+    await persistStockPreparationSyncRun({
+      permission: 'admin',
+      recordsApi,
+      provisioning,
+      ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 2 }),
+    })
+    const projectRows = await recordsApi.queryRecords({
+      sheetId: PROJECT_SHEET_ID,
+      filters: { [physicalFieldId(STAGING_PROJECT_ID, PROJECT_OBJECT_ID, PROJECT_KEY_FIELD)]: 'proj_1' },
+    })
+    await recordsApi.patchRecord({
+      sheetId: PROJECT_SHEET_ID,
+      recordId: projectRows[0].id,
+      changes: { [physicalFieldId(STAGING_PROJECT_ID, PROJECT_OBJECT_ID, 'lastSyncRunId')]: 'run_1' },
+    })
     await assert.rejects(
       () => persistStockPreparationSyncRun({
-        permission: 'admin',
-        recordsApi,
-        provisioning,
+        permission: 'admin', recordsApi, provisioning,
         ...basePlanInputs({ syncRunId: 'run_2', snapshotBatchId: 'batch_2', snapshotVersion: 2 }),
       }),
-      (error) =>
-        error instanceof StockPreparationSyncRunPersistError &&
-        error.status === 409 &&
-        error.code === 'PERSIST_PROJECT_POINTER_STALE' &&
-        error.details.target === 'project' &&
-        error.details.reason === 'stale_pointer',
+      (error) => error instanceof StockPreparationSyncRunPersistError &&
+        error.code === 'PERSIST_PROJECT_POINTER_STALE' && error.details.reason === 'stale_pointer',
     )
   })
 
@@ -954,27 +1000,25 @@ async function main() {
     assert.equal(recordsApi.createCalls.length, writesAfterFirst, 'rejected before any write')
   })
 
-  await run('R3: a COMPLETE orphan batch (crash before project patch) still counts — intermediate version -> 422, next version proceeds', async () => {
+  await run('R3: a legacy COMPLETE orphan batch still counts — intermediate version -> 422, next version proceeds', async () => {
     const recordsApi = makeRecordsApi()
     const provisioning = makeProvisioning()
     // V1 commits fully (pointer -> run_1).
     await persistStockPreparationSyncRun({ permission: 'admin', recordsApi, provisioning, ...basePlanInputs() })
-    // V3 crashes at CW4-existing: batch/lines/run all land, the project patch is lost — a COMPLETE
-    // orphan V3 exists while the pointer still names V1.
-    const crashingApi = Object.create(recordsApi)
-    crashingApi.patchRecord = async (input = {}) => {
-      if (input.sheetId === PROJECT_SHEET_ID) throw new Error('injected crash before project patch')
-      return recordsApi.patchRecord(input)
-    }
-    await assert.rejects(
-      () => persistStockPreparationSyncRun({
-        permission: 'admin',
-        recordsApi: crashingApi,
-        provisioning,
-        ...basePlanInputs({ syncRunId: 'run_3', snapshotBatchId: 'batch_3', snapshotVersion: 3 }),
-      }),
-      /injected crash before project patch/,
-    )
+    // Construct the pre-P4 legacy shape: V3 is complete while the live pointer remains on V1.
+    await persistStockPreparationSyncRun({
+      permission: 'admin', recordsApi, provisioning,
+      ...basePlanInputs({ syncRunId: 'run_3', snapshotBatchId: 'batch_3', snapshotVersion: 3 }),
+    })
+    const projectRows = await recordsApi.queryRecords({
+      sheetId: PROJECT_SHEET_ID,
+      filters: { [physicalFieldId(STAGING_PROJECT_ID, PROJECT_OBJECT_ID, PROJECT_KEY_FIELD)]: 'proj_1' },
+    })
+    await recordsApi.patchRecord({
+      sheetId: PROJECT_SHEET_ID,
+      recordId: projectRows[0].id,
+      changes: { [physicalFieldId(STAGING_PROJECT_ID, PROJECT_OBJECT_ID, 'lastSyncRunId')]: 'run_1' },
+    })
     // Round-3 finding: a pointer-only compare accepted V2 here (V2 > pointer V1) despite the complete
     // V3 — the guard must scan the project's WHOLE batch history.
     const writesBefore = recordsApi.createCalls.length
@@ -1002,24 +1046,15 @@ async function main() {
     assert.equal(next.mode, 'created')
   })
 
-  await run('R4: FIRST-sync crash at project create (CW4-first) leaves orphan history with NO project row — the scan still runs: V2 rejected, V4 proceeds', async () => {
+  await run('R4: legacy complete history with NO project row still blocks a lower version: V2 rejected, V4 proceeds', async () => {
     const recordsApi = makeRecordsApi()
     const provisioning = makeProvisioning()
-    // Empty project: V3 crashes at the PROJECT createRecord (batch/lines/run all landed; no project row).
-    const crashingApi = Object.create(recordsApi)
-    crashingApi.createRecord = async (input = {}) => {
-      if (input.sheetId === PROJECT_SHEET_ID) throw new Error('injected crash at project create')
-      return recordsApi.createRecord(input)
-    }
-    await assert.rejects(
-      () => persistStockPreparationSyncRun({
-        permission: 'admin',
-        recordsApi: crashingApi,
-        provisioning,
-        ...basePlanInputs({ syncRunId: 'run_3', snapshotBatchId: 'batch_3', snapshotVersion: 3 }),
-      }),
-      /injected crash at project create/,
-    )
+    // Construct the pre-P4 legacy shape: V3 batch/lines/run are complete but the project row is absent.
+    await persistStockPreparationSyncRun({
+      permission: 'admin', recordsApi, provisioning,
+      ...basePlanInputs({ syncRunId: 'run_3', snapshotBatchId: 'batch_3', snapshotVersion: 3 }),
+    })
+    recordsApi.store.set(PROJECT_SHEET_ID, [])
     // Round-4 finding: gating the scan on projectRows.length === 1 skipped it here (no project row),
     // so V2 slipped past the complete orphan V3. The scan must run for EVERY new batch.
     const writesBefore = recordsApi.createCalls.length

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -3898,6 +3898,7 @@ function createHandlers(services, options = {}) {
         recordsApi: getMultitableRecordsApi(),
         provisioning: getMultitableProvisioning(),
         targetProjectId,
+        lockTenantId: tenantId,
         projectId: input.projectId,
         syncRunId: input.syncRunId,
         snapshotBatchId: input.snapshotBatchId,
@@ -3985,6 +3986,7 @@ function createHandlers(services, options = {}) {
         recordsApi: getMultitableRecordsApi(),
         provisioning: getMultitableProvisioning(),
         targetProjectId,
+        lockTenantId: tenantId,
         ...persistInput,
       })
       // OD-5: created overrides the read-only projector's fixed mode:'dry_run' / internalWriteExecuted:

--- a/plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-sync-run-persist.cjs
@@ -52,7 +52,10 @@ const {
   },
   parseStrictVersion,
 } = require('./stock-preparation-sync-run-plan.cjs')
-const { createTargetScopedRecordsApi } = require('./stock-preparation-table-actions.cjs')
+const {
+  createTargetScopedRecordsApi,
+  resolveTargetFieldIds,
+} = require('./stock-preparation-table-actions.cjs')
 const {
   STOCK_PREPARATION_MVP_REQUIRED_OBJECT_IDS,
   STOCK_PREPARATION_MVP_TABLE_TEMPLATES,
@@ -130,6 +133,18 @@ function ensureProvisioning(provisioning) {
   return provisioning
 }
 
+function ensurePersistUnitOfWork(recordsApi) {
+  if (!recordsApi || typeof recordsApi.runStockPreparationPersistUnitOfWork !== 'function') {
+    throw new StockPreparationSyncRunPersistError(
+      503,
+      'PERSIST_UNIT_OF_WORK_UNAVAILABLE',
+      'stock-preparation sync-run persist requires the atomic records unit-of-work',
+      { requiredMethod: 'runStockPreparationPersistUnitOfWork' },
+    )
+  }
+  return recordsApi
+}
+
 // Resolve ONE MVP objectId to a scoped, sheet-bound records API. objectId MUST be a frozen MVP member
 // (fail closed otherwise); the sheet MUST already exist (fail closed — NEVER create a sheet here). The
 // returned scoped API forces every call onto sheet.id, so a write can never leave the resolved sheet,
@@ -157,8 +172,14 @@ async function resolveScopedTarget(recordsApi, provisioning, projectId, objectId
       { objectId },
     )
   }
-  const scoped = await createTargetScopedRecordsApi(recordsApi, { sheetId, objectId }, { provisioning, projectId })
-  return { objectId, sheetId, scoped }
+  const fieldIds = await resolveTargetFieldIds(provisioning, projectId, objectId)
+  const bindRecordsApi = (api) => createTargetScopedRecordsApi(
+    api,
+    { sheetId, objectId },
+    { resolvedFieldIds: fieldIds },
+  )
+  const scoped = await bindRecordsApi(recordsApi)
+  return { objectId, sheetId, scoped, bindRecordsApi }
 }
 
 // Ground a mapped snapshot line to ONLY the frozen line-template field ids (dropping null / undefined
@@ -502,7 +523,15 @@ async function persistStockPreparationSyncRun(input = {}) {
   if (!isPlainObject(input)) {
     throw new StockPreparationSyncRunPersistError(422, 'PERSIST_CONFIG_INVALID', 'input must be an object')
   }
-  const { context, permission, recordsApi, provisioning: provisioningInput, targetProjectId: targetProjectIdInput, ...planInputs } = input
+  const {
+    context,
+    permission,
+    recordsApi: recordsApiInput,
+    provisioning: provisioningInput,
+    targetProjectId: targetProjectIdInput,
+    lockTenantId: lockTenantIdInput,
+    ...planInputs
+  } = input
 
   // 1. admin gate FIRST — fail-closed before ANY provisioning / records access.
   assertAdminPermission(permission)
@@ -546,6 +575,20 @@ async function persistStockPreparationSyncRun(input = {}) {
     )
   }
 
+  // P4 hard cut: there is no sequential per-record transaction fallback. Capability validation happens
+  // before provisioning or records I/O so a host that has not rolled out the atomic primitive cannot
+  // recreate the historical partial-commit window.
+  const recordsApi = ensurePersistUnitOfWork(recordsApiInput)
+  const lockTenantId = optionalString(lockTenantIdInput)
+  if (!lockTenantId) {
+    throw new StockPreparationSyncRunPersistError(
+      422,
+      'PERSIST_CONFIG_INVALID',
+      'lockTenantId is required for the atomic persist lock scope',
+      { field: 'lockTenantId' },
+    )
+  }
+
   // The MVP tables are provisioned under an INTERNAL STAGING project (readiness/ensure route
   // resolveIntegrationStagingProjectId -> `<tenant>:integration-core`), NOT the business projectId. So
   // sheet resolution MUST use the caller-derived targetProjectId (staging); the plan rows keep the
@@ -564,91 +607,111 @@ async function persistStockPreparationSyncRun(input = {}) {
   const runTarget = await resolveScopedTarget(recordsApi, provisioning, targetProjectId, RUN_OBJECT_ID)
   const projectTarget = await resolveScopedTarget(recordsApi, provisioning, targetProjectId, PROJECT_OBJECT_ID)
 
-  // 4. Idempotency + immutability. A batch-key hit is only a successful replay after every immutable
-  //    batch/line/run projection and the project-row existence check match exactly. Partial commits and
-  //    same-key/different-content requests fail closed; this module never repairs or patches snapshots.
-  const existingBatch = await batchTarget.scoped.queryRecords({
-    filters: { [BATCH_KEY_FIELD]: snapshotBatchId },
-    limit: 2,
-    offset: 0,
-  })
-  if (!Array.isArray(existingBatch)) {
-    throw new StockPreparationSyncRunPersistError(500, 'PERSIST_RECORDS_API_INVALID', 'queryRecords must return an array')
-  }
-  if (existingBatch.length > 1) idempotencyConflict('snapshot_batch', 'duplicate_key')
+  // 4. The host takes all four canonical sheet fences, then the project key and batch key, and invokes
+  //    this callback on one transaction-scoped records API. Every idempotency decision, replay read,
+  //    create/patch, and revision write below therefore shares the same transaction and lock lifetime.
+  return recordsApi.runStockPreparationPersistUnitOfWork({
+    tenantId: lockTenantId,
+    sheetIds: [
+      batchTarget.sheetId,
+      lineTarget.sheetId,
+      runTarget.sheetId,
+      projectTarget.sheetId,
+    ],
+    project: { sheetId: projectTarget.sheetId, projectId },
+    batch: { sheetId: batchTarget.sheetId, snapshotBatchId },
+  }, async (transactionRecordsApi) => {
+    const batchScoped = await batchTarget.bindRecordsApi(transactionRecordsApi)
+    const lineScoped = await lineTarget.bindRecordsApi(transactionRecordsApi)
+    const runScoped = await runTarget.bindRecordsApi(transactionRecordsApi)
+    const projectScoped = await projectTarget.bindRecordsApi(transactionRecordsApi)
 
-  // The project preflight occurs before the first write. It both rejects duplicate project keys and
-  // supplies the exact row (if any) that the final live-pointer upsert may patch.
-  const projectRows = await queryProjectRows(projectTarget.scoped, projectId)
-
-  if (existingBatch.length === 1) {
-    await assertExactReplay({
-      existingBatch: existingBatch[0],
-      plan,
-      snapshotLines,
-      lineScoped: lineTarget.scoped,
-      runScoped: runTarget.scoped,
-      batchScoped: batchTarget.scoped,
-      projectRows,
+    // Idempotency + immutability. A batch-key hit is only a successful replay after every immutable
+    // batch/line/run projection and the project-row existence check match exactly. Partial or conflicting
+    // replays fail closed; this module never repairs or patches snapshots.
+    const existingBatch = await batchScoped.queryRecords({
+      filters: { [BATCH_KEY_FIELD]: snapshotBatchId },
+      limit: 2,
+      offset: 0,
     })
-    const created = { batch: 0, lines: 0, run: 0 }
-    return {
-      persisted: false,
-      mode: 'skipped_existing',
-      created,
-      project: { mode: 'skipped' },
-      evidence: buildEvidence({ persisted: false, mode: 'skipped_existing', created, plan, plannedLineCount: snapshotLines.length, existingBatchMatched: true, projectSync: null }),
+    if (!Array.isArray(existingBatch)) {
+      throw new StockPreparationSyncRunPersistError(500, 'PERSIST_RECORDS_API_INVALID', 'queryRecords must return an array')
     }
-  }
+    if (existingBatch.length > 1) idempotencyConflict('snapshot_batch', 'duplicate_key')
 
-  // H-2 precondition — CREATE path monotonic-version guard (before the FIRST write, for EVERY new
-  // batch): the new snapshotVersion must be strictly above EVERY existing batch of the business
-  // project. The scan runs UNCONDITIONALLY — round-4: a FIRST-sync crash at the project create
-  // (CW4-first) leaves orphan batch history with NO project row, so gating the scan on the project
-  // row's existence let the next lower-version sync through. Empty history scans to max 0 (any
-  // positive version passes); unprovable history (page bound exceeded / non-strict version values)
-  // fails closed. This is what makes the replay-side stale/advanced inference sound.
-  {
-    const currentVersion = parseStrictVersion(plan.snapshotBatch.snapshotVersion)
-    if (currentVersion === null) versionNotMonotonic('history_unprovable')
-    const maxVersion = await readProjectMaxBatchVersion(batchTarget.scoped, optionalString(planInputs.projectId))
-    if (maxVersion === null) versionNotMonotonic('history_unprovable')
-    if (currentVersion <= maxVersion) versionNotMonotonic('not_monotonic')
-  }
+    // The project preflight occurs before the first write. It both rejects duplicate project keys and
+    // supplies the exact row (if any) that the final live-pointer upsert may patch.
+    const projectRows = await queryProjectRows(projectScoped, projectId)
 
-  // 5. create-only path: batch row, then each line row, then the run row. createRecord ONLY — no
-  //    existing row is ever mutated. Batch-first plants the idempotency key before lines/run; a crash
-  //    mid-commit is therefore visible on retry as an incomplete 409, never a duplicate or silent skip.
-  await batchTarget.scoped.createRecord({ data: plan.snapshotBatch })
-  let linesCreated = 0
-  for (const line of snapshotLines) {
-    await lineTarget.scoped.createRecord({ data: groundLineRow(line) })
-    linesCreated += 1
-  }
-  await runTarget.scoped.createRecord({ data: plan.syncRun })
+    if (existingBatch.length === 1) {
+      await assertExactReplay({
+        existingBatch: existingBatch[0],
+        plan,
+        snapshotLines,
+        lineScoped,
+        runScoped,
+        batchScoped,
+        projectRows,
+      })
+      const created = { batch: 0, lines: 0, run: 0 }
+      return {
+        persisted: false,
+        mode: 'skipped_existing',
+        created,
+        project: { mode: 'skipped' },
+        evidence: buildEvidence({ persisted: false, mode: 'skipped_existing', created, plan, plannedLineCount: snapshotLines.length, existingBatchMatched: true, projectSync: null }),
+      }
+    }
 
-  // #4163 T1: upsert the project row LAST — the run just genuinely completed, so `lastSyncRunId` /
-  // `lastSyncedAt` on the project row point at a run that actually finished (not one that merely
-  // started). Idempotent by projectId: a SECOND, genuinely-new batch for the same project patches this
-  // same row rather than creating a duplicate — the multi-sync-run case the populator exists for.
-  const projectSync = await upsertStockPreparationProject({
-    scoped: projectTarget.scoped,
-    existing: projectRows,
-    projectId,
-    sourceProjectNo,
-    projectName,
-    sourceSystem: projectSourceSystem,
-    syncRunId: plan.syncRun.runId,
+    // H-2 precondition — CREATE path monotonic-version guard (before the FIRST write, for EVERY new
+    // batch): the new snapshotVersion must be strictly above EVERY existing batch of the business
+    // project. The scan runs UNCONDITIONALLY — round-4: a FIRST-sync crash at the project create
+    // (CW4-first) leaves orphan batch history with NO project row, so gating the scan on the project
+    // row's existence let the next lower-version sync through. Empty history scans to max 0 (any
+    // positive version passes); unprovable history (page bound exceeded / non-strict version values)
+    // fails closed. This is what makes the replay-side stale/advanced inference sound.
+    {
+      const currentVersion = parseStrictVersion(plan.snapshotBatch.snapshotVersion)
+      if (currentVersion === null) versionNotMonotonic('history_unprovable')
+      const maxVersion = await readProjectMaxBatchVersion(batchScoped, optionalString(planInputs.projectId))
+      if (maxVersion === null) versionNotMonotonic('history_unprovable')
+      if (currentVersion <= maxVersion) versionNotMonotonic('not_monotonic')
+    }
+
+    // 5. create-only path: batch row, then each line row, then the run row. createRecord ONLY — no
+    // existing row is ever mutated. The surrounding unit-of-work is the only commit point: a failure
+    // anywhere below rolls back every row and revision rather than exposing a partial batch.
+    await batchScoped.createRecord({ data: plan.snapshotBatch })
+    let linesCreated = 0
+    for (const line of snapshotLines) {
+      await lineScoped.createRecord({ data: groundLineRow(line) })
+      linesCreated += 1
+    }
+    await runScoped.createRecord({ data: plan.syncRun })
+
+    // #4163 T1: upsert the project row LAST — the run just genuinely completed, so `lastSyncRunId` /
+    // `lastSyncedAt` on the project row point at a run that actually finished (not one that merely
+    // started). Idempotent by projectId: a SECOND, genuinely-new batch for the same project patches this
+    // same row rather than creating a duplicate — the multi-sync-run case the populator exists for.
+    const projectSync = await upsertStockPreparationProject({
+      scoped: projectScoped,
+      existing: projectRows,
+      projectId,
+      sourceProjectNo,
+      projectName,
+      sourceSystem: projectSourceSystem,
+      syncRunId: plan.syncRun.runId,
+    })
+
+    const created = { batch: 1, lines: linesCreated, run: 1 }
+    return {
+      persisted: true,
+      mode: 'created',
+      created,
+      project: projectSync,
+      evidence: buildEvidence({ persisted: true, mode: 'created', created, plan, plannedLineCount: snapshotLines.length, existingBatchMatched: false, projectSync }),
+    }
   })
-
-  const created = { batch: 1, lines: linesCreated, run: 1 }
-  return {
-    persisted: true,
-    mode: 'created',
-    created,
-    project: projectSync,
-    evidence: buildEvidence({ persisted: true, mode: 'created', created, plan, plannedLineCount: snapshotLines.length, existingBatchMatched: false, projectSync }),
-  }
 }
 
 module.exports = {

--- a/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
@@ -411,6 +411,26 @@ async function resolveTargetFieldIds(provisioning, projectId, objectId) {
   return map
 }
 
+function validateResolvedTargetFieldIds(objectId, candidate) {
+  const template = MVP_TEMPLATE_BY_OBJECT_ID.get(objectId)
+  if (!template || !isPlainObject(candidate)) {
+    throw new StockPreparationTableActionError(500, 'TABLE_ACTION_FIELD_IDS_UNRESOLVED', 'pre-resolved target field ids are invalid', { objectId })
+  }
+  const expected = template.fields.map((field) => field.id)
+  if (Object.keys(candidate).length !== expected.length) {
+    throw new StockPreparationTableActionError(500, 'TABLE_ACTION_FIELD_IDS_UNRESOLVED', 'pre-resolved target field ids are incomplete', { objectId })
+  }
+  const out = {}
+  for (const fieldId of expected) {
+    const physical = optionalString(candidate[fieldId])
+    if (!physical) {
+      throw new StockPreparationTableActionError(500, 'TABLE_ACTION_FIELD_IDS_UNRESOLVED', 'pre-resolved target field ids are incomplete', { objectId })
+    }
+    out[fieldId] = physical
+  }
+  return out
+}
+
 function invertFieldIdMap(fieldIds) {
   const inverse = {}
   for (const [logical, physical] of Object.entries(fieldIds)) inverse[physical] = logical
@@ -461,7 +481,9 @@ async function createTargetScopedRecordsApi(recordsApi, target, options = {}) {
   }
   const objectId = optionalString(target && target.objectId)
   const fieldIds = mode === 'logical'
-    ? await resolveTargetFieldIds(options.provisioning, options.projectId, objectId)
+    ? options.resolvedFieldIds
+      ? validateResolvedTargetFieldIds(objectId, options.resolvedFieldIds)
+      : await resolveTargetFieldIds(options.provisioning, options.projectId, objectId)
     : null
   const inverse = fieldIds ? invertFieldIdMap(fieldIds) : null
 
@@ -964,6 +986,7 @@ module.exports = {
   createStockPreparationTableActionRegistry,
   resolveStockPrepApplyProductionPolicy,
   resolveStockPrepApplySandboxPolicy,
+  resolveTargetFieldIds,
   createTargetScopedRecordsApi,
   dryRunStockPreparationAction,
   normalizeActionParameters,

--- a/scripts/ops/global-history-flag-manifest.test.mjs
+++ b/scripts/ops/global-history-flag-manifest.test.mjs
@@ -57,6 +57,8 @@ const NON_GH_EXACT = new Set([
   'MULTITABLE_PROJECT_NAMESPACE_FORBIDDEN',
   'MULTITABLE_SHARE_PERMISSIONS', // share permission registry
   'MULTITABLE_SHEET_SCOPE_FORBIDDEN',
+  'MULTITABLE_UNIT_OF_WORK_SCOPE_FORBIDDEN', // plugin-scoped records UOW error code, not a flag
+  'MULTITABLE_UNIT_OF_WORK_UNAVAILABLE', // required host-capability error code, not a flag
 ])
 
 function globalHistoryFlagsInSource() {

--- a/scripts/ops/stock-preparation-erp-material-sync-realdb-smoke.mjs
+++ b/scripts/ops/stock-preparation-erp-material-sync-realdb-smoke.mjs
@@ -62,7 +62,7 @@ function check(name, ok, detail = '') {
 }
 
 // ── the real host multitable API (replicates packages/core-backend/src/index.ts:455-665) ──────────
-function buildHostMultitableApi(poolManager, prov, recs) {
+function buildHostMultitableApi(poolManager, prov, recs, p4) {
   const readFn = async (sql, params) => {
     const r = await poolManager.get().query(sql, params)
     return {
@@ -92,6 +92,16 @@ function buildHostMultitableApi(poolManager, prov, recs) {
       poolManager.get().transaction(async ({ query }) => recs.createRecord({ query: txFnFrom(query), sheetId, data })),
     patchRecord: ({ sheetId, recordId, changes }) =>
       poolManager.get().transaction(async ({ query }) => recs.patchRecord({ query: txFnFrom(query), sheetId, recordId, changes })),
+    runStockPreparationPersistUnitOfWork: (input, operation) =>
+      poolManager.get().transaction(async ({ query }) => {
+        const txQuery = txFnFrom(query)
+        await p4.acquireStockPreparationPersistUnitOfWorkLocks(txQuery, input)
+        return operation({
+          queryRecords: (recordInput) => recs.queryRecords({ query: txQuery, ...recordInput }),
+          createRecord: (recordInput) => recs.createRecord({ query: txQuery, ...recordInput }),
+          patchRecord: (recordInput) => recs.patchRecord({ query: txQuery, ...recordInput }),
+        })
+      }),
   }
   return { provisioning, records }
 }
@@ -121,10 +131,12 @@ async function main() {
   const prov = await import(new URL('../../packages/core-backend/src/multitable/provisioning.ts', import.meta.url).href)
   stage('importing records')
   const recs = await import(new URL('../../packages/core-backend/src/multitable/records.ts', import.meta.url).href)
+  stage('importing stock-preparation P4 unit-of-work')
+  const p4 = await import(new URL('../../packages/core-backend/src/multitable/stock-preparation-persist-unit-of-work.ts', import.meta.url).href)
   stage('core imports done')
   const { poolManager } = cp
 
-  const { provisioning, records } = buildHostMultitableApi(poolManager, prov, recs)
+  const { provisioning, records } = buildHostMultitableApi(poolManager, prov, recs, p4)
   const context = { api: { multitable: { provisioning, records } } }
 
   const {
@@ -178,6 +190,7 @@ async function main() {
     const bomPersist = await persistStockPreparationSyncRun({
       permission: 'admin', recordsApi: records, provisioning,
       projectId: businessProjectId, targetProjectId: stagingProjectId,
+      lockTenantId: args.tenantId,
       syncRunId: bomSyncRunId, snapshotBatchId, snapshotVersion: 1, sourceSystem: 'rdb_smoke',
       sourceProjectNo, defaultDesignUnit: 'pcs',
       expansionResult: [{ componentSourceId: `OBJ_${salt}`, componentCode: drawingA, sourceVersion: 'V1', path: `/root/${drawingA}`, rawQuantity: 3 }],


### PR DESCRIPTION
## What

Implements the ratified Option A from #4452 as a hard cut for stock-preparation snapshot persist:

- adds a host-owned, plugin-scoped records unit of work backed by one PostgreSQL transaction
- acquires canonical four-sheet fences, then project and batch advisory locks in fixed order
- moves batch/project preflight, replay validation, create/patch decisions, all writes, and revision emission into that unit of work
- refuses persist before provisioning/records I/O when the host capability or server-derived tenant lock scope is absent
- keeps the existing immutable snapshot and response contracts unchanged
- updates the standalone ERP real-DB smoke and strict fakes to the hard-cut contract

## Atomicity evidence

The real-DB replay suite now drives the actual `MetaSheetServer.createPluginContext()` production hook, not a transaction facade reimplementation. It covers:

- CW1, CW2, CW3, CW4-first, and CW4-existing injected failures: records and revisions remain unchanged, then a clean retry succeeds
- concurrent same-batch writers: one create plus one exact replay, with one batch/project row
- concurrent different batches for one project: no duplicate project row
- physical `meta_fields` grounding and existing replay conflict behavior

Load-bearing mutations were run and restored:

- routing UOW SQL through the pool instead of the transaction connection leaves a row/revision after injected failure and reds the crash matrix
- removing the outer UOW locks makes concurrent same-batch writers both return `created`
- removing the project lock reds the exact lock-order contract
- restoring delimiter-joined lock keys reds the delimiter-collision contract

## Review hardening

- malformed plugin-scope `input` / `operation` arguments now fail before invoking the host hook with stable `TypeError` messages
- project and batch lock keys use unambiguous JSON array framing, so delimiter-bearing tenant/sheet/business identifiers cannot alias another tuple
- the new actor-less, four-sheet-scoped transaction patch seam is explicitly classified in the existing W1-3 write-path guard

## Verification

- `pnpm --filter @metasheet/core-backend type-check`
- full core-backend suite: 496 files / 6795 passed / 184 skipped, zero failures
- unit: 12/12 (`plugin-scope` + P4 lock/input contract)
- W1-3 write-path guard: 4/4
- persist contract: 44/44
- all 32 stock-preparation plugin CJS suites green
- isolated local PostgreSQL: T3b replay/P4 4/4; T3b PLM route 4/4; T3a ERP route 3/3
- ERP material real-DB smoke: 18/18
- W6/T4 smoke contracts: 49/49
- `git diff --check`

## Boundaries

This PR implements Option A only. The ratified bounded one-shot Option C repair tool remains a separate owner-controlled follow-up. It does not change RC-A #4437, authorize production auto-persist, or introduce any external write path; `externalWrite=false` remains unchanged.