### PR TITLE
feat(attendance): S7-2 direct-manager resolver

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -732,6 +732,7 @@ jobs:
             tests/integration/attendance-plugin.test.ts \
             tests/integration/attendance-approval-action-authorization.db.test.ts \
             tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts \
+            tests/integration/attendance-approval-direct-manager-s7-2.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -102,10 +102,15 @@ import {
   stopApprovalSlaScheduler,
 } from './services/ApprovalSlaScheduler'
 import { ApprovalProductService } from './services/ApprovalProductService'
-// S7-1 (OD-S7-5=d): the host-resolved chain-depth cap the attendance dynamic-assignee resolver PORT
-// exposes to plugin-attendance, so the plugin validates `manager_at_level.level` against the SAME
-// source the kernel uses and never re-parses APPROVAL_MANAGER_CHAIN_MAX_LEVELS into a second constant.
-import { MAX_MANAGER_CHAIN_LEVELS } from './services/ApprovalDirectoryOrg'
+// S7-1/S7-2 (OD-S7-5=d): host-resolved chain-depth cap + org-scoped directory-read path the attendance
+// dynamic-assignee resolver PORT exposes to plugin-attendance. The plugin validates
+// `manager_at_level.level` against MAX (never re-parses APPROVAL_MANAGER_CHAIN_MAX_LEVELS) and freezes
+// direct_manager via resolveApprovalRequesterOrgRelations (org-anchored, read-only).
+import {
+  MAX_MANAGER_CHAIN_LEVELS,
+  resolveApprovalRequesterOrgRelations,
+} from './services/ApprovalDirectoryOrg'
+import { query as pgQuery } from './db/pg'
 import {
   resolveAttendanceSchedulerIntervalMs,
   resolveAttendanceSchedulerLeaderOptions,
@@ -951,20 +956,57 @@ export class MetaSheetServer {
     return wrappedUnregister
   }
 
-  // S7-1 (RATIFIED attendance-approval-s7 resolver lock, OD-S7-5=d): construct the host binding for the
-  // narrow, org-scoped dynamic approval-assignee resolver port plugin-attendance consumes. It exposes
-  // the SAME MAX_MANAGER_CHAIN_LEVELS constant the kernel uses (no plugin env re-parse) and — at S7-1 —
-  // a resolver that reports EVERY dynamic kind unimplemented (`implementedKinds: []`, `resolve` →
-  // `{ status: 'unimplemented' }`), so the plugin fail-closes at both authoring and runtime. S7-2/S7-3/
-  // S7-4 populate `implementedKinds` and implement per-kind, org-scoped, directory-read-only resolution
-  // here (never a write, never outside the core-backend process boundary).
+  // S7-1/S7-2 (RATIFIED attendance-approval-s7 resolver lock, OD-S7-5=d): construct the host binding for
+  // the narrow, org-scoped dynamic approval-assignee resolver port plugin-attendance consumes. Exposes
+  // the SAME MAX_MANAGER_CHAIN_LEVELS constant the kernel uses (no plugin env re-parse). S7-2 wires
+  // `direct_manager` only (byte-identical to ApprovalDirectoryOrg §2.1: is_manager precedence, legacy
+  // leader_in_dept fallback, deterministic tie-break, same-integration binding, self-exclusion).
+  // `dept_head` / `manager_at_level` stay unimplemented (S7-3/S7-4). Directory data is READ-ONLY.
   private buildApprovalAssigneeResolverPort(): NonNullable<
     import('./types/plugin').PluginServices['approvalAssigneeResolver']
   > {
     return {
       maxManagerChainLevels: MAX_MANAGER_CHAIN_LEVELS,
-      implementedKinds: [],
-      resolve: async () => ({ status: 'unimplemented' as const }),
+      implementedKinds: ['direct_manager'],
+      resolve: async (orgId, request) => {
+        const kind = typeof request?.kind === 'string' ? request.kind.trim() : ''
+        if (kind !== 'direct_manager') {
+          return { status: 'unimplemented' as const }
+        }
+
+        const normalizedOrgId = typeof orgId === 'string' ? orgId.trim() : ''
+        const requesterUserId =
+          typeof request?.requesterUserId === 'string' ? request.requesterUserId.trim() : ''
+        if (!normalizedOrgId || !requesterUserId) {
+          return { status: 'unresolved' as const, reason: 'missing_org_or_requester' }
+        }
+
+        // CREATE-TIME freeze only (§3.3/§3.4). Always directory-resolve with the attendance org anchor;
+        // never trust a caller-supplied snapshot for live re-resolution (step-advance must not call this).
+        // QueryFn is unconstrained (Row not bound to QueryResultRow); adapt pg's typed query.
+        const queryFn = <Row>(text: string, params?: unknown[]): Promise<{ rows: Row[] }> =>
+          pgQuery(text, params).then((r) => ({ rows: r.rows as Row[] }))
+
+        const relations = await resolveApprovalRequesterOrgRelations(requesterUserId, queryFn, {
+          orgId: normalizedOrgId,
+        })
+        const managerId =
+          typeof relations.managerId === 'string' && relations.managerId.trim().length > 0
+            ? relations.managerId.trim()
+            : null
+        // Self-exclusion at the resolver (§2.1): a manager that resolves to the requester is treated
+        // as unresolved — never written as a self-assignment.
+        if (!managerId || managerId === requesterUserId) {
+          return {
+            status: 'unresolved' as const,
+            reason: managerId === requesterUserId ? 'self_manager' : 'no_manager_linked',
+          }
+        }
+        return {
+          status: 'resolved' as const,
+          assignees: [{ assignmentType: 'user' as const, assigneeId: managerId }],
+        }
+      },
     }
   }
 

--- a/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
+++ b/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
@@ -164,39 +164,80 @@ interface RequesterDirectoryRow {
  *
  * `query` is injected (defaults to the shared pool) so the unit path can drive it
  * against an in-memory fixture without a database.
+ *
+ * `options.orgId` (S7 §3.3, optional / backward compatible): when supplied, the
+ * requester-account pick is anchored to `directory_integrations.org_id` BEFORE the
+ * `ORDER BY ... LIMIT 1` tie-break, so a local user linked into two orgs cannot have
+ * the wrong org's account selected. Callers that omit `orgId` retain today's unscoped
+ * (most-recently-updated) pick — kernel `ApprovalProductService` callers included.
+ * Attendance-facing paths MUST pass `orgId`.
  */
 export async function resolveApprovalRequesterOrgRelations(
   localUserId: string,
   query: QueryFn,
-  options: { includeManagerChain?: boolean; maxLevels?: number } = {},
+  options: { includeManagerChain?: boolean; maxLevels?: number; orgId?: string } = {},
 ): Promise<ApprovalRequesterOrgRelations> {
   const userId = localUserId.trim()
   if (!userId) return {}
 
+  // Optional org anchor (S7 §3.3). Trim + non-empty only — an empty string must NOT
+  // accidentally join against `org_id = ''` and force every row out of scope.
+  const orgId =
+    typeof options.orgId === 'string' && options.orgId.trim().length > 0
+      ? options.orgId.trim()
+      : null
+
   // 1) Requester's linked directory account + its primary department's raw.
+  // When `orgId` is set, join `directory_integrations` so the ORDER BY/LIMIT 1 only
+  // ever competes among accounts already inside the calling org.
   const requesterRows = await query<RequesterDirectoryRow>(
-    `SELECT a.integration_id::text       AS integration_id,
-            a.id::text                   AS account_id,
-            a.external_user_id           AS external_user_id,
-            a.raw                        AS raw,
-            a.title                      AS title,
-            d.external_department_id     AS primary_external_department_id,
-            d.raw                        AS primary_department_raw,
-            d.name                       AS primary_department_name
-       FROM directory_account_links l
-       JOIN directory_accounts a
-         ON a.id = l.directory_account_id
-        AND a.is_active = true
-       LEFT JOIN directory_account_departments ad
-         ON ad.directory_account_id = a.id
-        AND ad.is_primary = true
-       LEFT JOIN directory_departments d
-         ON d.id = ad.directory_department_id
-      WHERE l.local_user_id = $1
-        AND l.link_status = 'linked'
-      ORDER BY a.updated_at DESC, a.id ASC
-      LIMIT 1`,
-    [userId],
+    orgId
+      ? `SELECT a.integration_id::text       AS integration_id,
+                a.id::text                   AS account_id,
+                a.external_user_id           AS external_user_id,
+                a.raw                        AS raw,
+                a.title                      AS title,
+                d.external_department_id     AS primary_external_department_id,
+                d.raw                        AS primary_department_raw,
+                d.name                       AS primary_department_name
+           FROM directory_account_links l
+           JOIN directory_accounts a
+             ON a.id = l.directory_account_id
+            AND a.is_active = true
+           JOIN directory_integrations di
+             ON di.id = a.integration_id
+            AND di.org_id = $2
+           LEFT JOIN directory_account_departments ad
+             ON ad.directory_account_id = a.id
+            AND ad.is_primary = true
+           LEFT JOIN directory_departments d
+             ON d.id = ad.directory_department_id
+          WHERE l.local_user_id = $1
+            AND l.link_status = 'linked'
+          ORDER BY a.updated_at DESC, a.id ASC
+          LIMIT 1`
+      : `SELECT a.integration_id::text       AS integration_id,
+                a.id::text                   AS account_id,
+                a.external_user_id           AS external_user_id,
+                a.raw                        AS raw,
+                a.title                      AS title,
+                d.external_department_id     AS primary_external_department_id,
+                d.raw                        AS primary_department_raw,
+                d.name                       AS primary_department_name
+           FROM directory_account_links l
+           JOIN directory_accounts a
+             ON a.id = l.directory_account_id
+            AND a.is_active = true
+           LEFT JOIN directory_account_departments ad
+             ON ad.directory_account_id = a.id
+            AND ad.is_primary = true
+           LEFT JOIN directory_departments d
+             ON d.id = ad.directory_department_id
+          WHERE l.local_user_id = $1
+            AND l.link_status = 'linked'
+          ORDER BY a.updated_at DESC, a.id ASC
+          LIMIT 1`,
+    orgId ? [userId, orgId] : [userId],
   )
   const requester = requesterRows.rows[0]
   if (!requester) return {}

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -979,25 +979,27 @@ export interface PluginServices {
     }): (() => void)
   }
   /**
-   * S7-1 — host→plugin, narrow, org-scoped resolver PORT for the attendance dynamic approval-assignee
-   * kinds (直属上级 `direct_manager` / 部门主管 `dept_head` / 多级上级 `manager_at_level`), per the
-   * RATIFIED attendance-approval-s7 resolver design-lock, OD-S7-5 = (d). It mirrors `workdayCalendar`
-   * above but runs the OPPOSITE direction: core-backend is the PROVIDER, plugin-attendance is the
-   * CONSUMER (it checks `context?.services?.approvalAssigneeResolver?.<member>` before use). The plugin
-   * NEVER takes a runtime dependency on the whole core package and NEVER copies the kernel resolver
-   * logic; when this port is absent the plugin fail-closes (authoring 422 / runtime block), never the
-   * legacy admin fallback (§4.1).
+   * S7-1/S7-2 — host→plugin, narrow, org-scoped resolver PORT for the attendance dynamic
+   * approval-assignee kinds (直属上级 `direct_manager` / 部门主管 `dept_head` / 多级上级
+   * `manager_at_level`), per the RATIFIED attendance-approval-s7 resolver design-lock, OD-S7-5 = (d).
+   * It mirrors `workdayCalendar` above but runs the OPPOSITE direction: core-backend is the PROVIDER,
+   * plugin-attendance is the CONSUMER (it checks `context?.services?.approvalAssigneeResolver?.<member>`
+   * before use). The plugin NEVER takes a runtime dependency on the whole core package and NEVER copies
+   * the kernel resolver logic; when this port is absent the plugin fail-closes (authoring 422 / runtime
+   * block), never the legacy admin fallback (§4.1).
    *
    * - `maxManagerChainLevels` is the host-resolved `MAX_MANAGER_CHAIN_LEVELS` constant
    *   (`ApprovalDirectoryOrg` — env `APPROVAL_MANAGER_CHAIN_MAX_LEVELS`, default 10, hard ceiling 50).
    *   The plugin validates `manager_at_level.level ∈ [1, maxManagerChainLevels]` against THIS value so it
    *   never re-parses the env var into a second constant — one source, two surfaces, no drift.
    * - `implementedKinds` is the set of dynamic kinds this host build can actually resolve at runtime.
-   *   EMPTY at S7-1 (the seam is defined but no kind is wired yet — S7-2/S7-3/S7-4 populate it). A kind
-   *   absent from this list is unimplemented ⇒ the plugin fail-closes.
-   * - `resolve` is the org-scoped runtime resolution seam (the §3.4 freeze point). At S7-1 it returns
-   *   `{ status: 'unimplemented' }` for every kind; S7-2/S7-3/S7-4 implement per-kind resolution. It
-   *   reads only `directory_*` (never writes) and stays inside the core-backend process boundary.
+   *   S7-2 populates `direct_manager` only; `dept_head` / `manager_at_level` remain S7-3/S7-4.
+   *   A kind absent from this list is unimplemented ⇒ the plugin fail-closes.
+   * - `resolve` is the org-scoped CREATE-TIME freeze seam (§3.3 / §3.4). For `direct_manager` it runs the
+   *   kernel's `resolveApprovalRequesterOrgRelations` with the attendance `orgId` anchor, returns the
+   *   linked local manager (or `unresolved`), and NEVER writes. Step-advance must NOT call this again —
+   *   it reads only the frozen `requesterSnapshot.managerId`. Self-exclusion is enforced here (manager
+   *   resolving to the requester is treated as unresolved).
    */
   approvalAssigneeResolver?: {
     readonly maxManagerChainLevels: number

--- a/packages/core-backend/tests/integration/attendance-approval-direct-manager-s7-2.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-approval-direct-manager-s7-2.db.test.ts
@@ -1,0 +1,970 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import type { MetaSheetServer } from '../../src/index'
+import * as path from 'path'
+import net from 'net'
+import http from 'http'
+import { Pool } from 'pg'
+import { randomUUID } from 'crypto'
+
+// S7-2 (RATIFIED attendance-approval-s7 resolver design-lock §2.1 / §3.3 / §3.4 / §4 / §4.1 / §7 S7-2):
+// real-DB, HTTP-level coverage of direct_manager end-to-end:
+//   linked resolution + freeze into requester_snapshot.managerId
+//   unlinked block-with-error + zero persistence
+//   two-org / one-local-user org-anchor
+//   2-step freeze after directory relation mutation
+//   dynamic assignment approve+reject authorization (negative / positive / admin)
+//   flag-off create + flag-off advance rollback
+//   legacy static still works with flag off
+//   S7-1 NITs folded: empty-static-array MIXED + non-string kind → distinct 422
+//
+// RBAC_BYPASS is toggled per-case: authoring / create paths use 'true' for simplicity; the
+// assignment-authorization legs force 'false' so the S7-0 predicate is what we observe.
+
+interface HttpResponse {
+  status: number
+  body: unknown
+  raw: string
+}
+
+function requestJson(
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const req = http.request(
+      {
+        method: options.method || 'GET',
+        hostname: target.hostname,
+        port: target.port,
+        path: `${target.pathname}${target.search}`,
+        headers: options.headers,
+      },
+      (res) => {
+        let data = ''
+        res.on('data', (chunk) => {
+          data += chunk
+        })
+        res.on('end', () => {
+          let body: unknown
+          try {
+            body = data ? JSON.parse(data) : undefined
+          } catch {
+            body = undefined
+          }
+          resolve({ status: res.statusCode || 0, body, raw: data })
+        })
+      },
+    )
+    req.on('error', reject)
+    if (options.body) req.write(options.body)
+    req.end()
+  })
+}
+
+function errorCode(res: HttpResponse): string | undefined {
+  return (res.body as { error?: { code?: string } } | undefined)?.error?.code
+}
+
+const DYNAMIC_FLAG = 'ATTENDANCE_APPROVAL_DYNAMIC_ASSIGNEE_SOURCES_ENABLED'
+const NODE_KEY_0 = 'attendance_request_step_0'
+const NODE_KEY_1 = 'attendance_request_step_1'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl: string | undefined
+  let pool: Pool | undefined
+  let prevRbac: string | undefined
+  let prevFlag: string | undefined
+
+  const runSuffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+  const orgHome = `s7-2-home-${runSuffix}`
+  const orgForeign = `s7-2-foreign-${runSuffix}`
+  const orgUnlinked = `s7-2-unlinked-${runSuffix}`
+  const orgFreeze = `s7-2-freeze-${runSuffix}`
+  const orgAuthz = `s7-2-authz-${runSuffix}`
+  const orgFlagOff = `s7-2-flagoff-${runSuffix}`
+
+  const requester = `s7-2-req-${runSuffix}`
+  const managerHome = `s7-2-mgr-home-${runSuffix}`
+  const managerForeign = `s7-2-mgr-foreign-${runSuffix}`
+  const managerAlt = `s7-2-mgr-alt-${runSuffix}`
+  const otherApprover = `s7-2-other-${runSuffix}`
+  const adminActor = `s7-2-admin-${runSuffix}`
+
+  const userIds: string[] = [requester, managerHome, managerForeign, managerAlt, otherApprover, adminActor]
+  const integrationIds: string[] = []
+  const createdFlowIds: string[] = []
+  const createdInstanceIds: string[] = []
+  const createdRequestIds: string[] = []
+
+  let adminToken = ''
+  let managerToken = ''
+  let otherToken = ''
+  let adminActorToken = ''
+
+  // Directory fixture handles for freeze-mutation + org-anchor cases.
+  let homeMgrAccountId = ''
+  let homeDeptId = ''
+  let homeIntegrationId = ''
+  let freezeMgrAccountId = ''
+  let freezeAltAccountId = ''
+  let freezeDeptId = ''
+
+  function setFlag(on: boolean): void {
+    if (on) process.env[DYNAMIC_FLAG] = 'true'
+    else delete process.env[DYNAMIC_FLAG]
+  }
+
+  async function devToken(userId: string, roles: string, perms: string): Promise<string> {
+    const res = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(
+        roles,
+      )}&perms=${encodeURIComponent(perms)}`,
+    )
+    const token = (res.body as { token?: string } | undefined)?.token
+    if (!token) throw new Error(`dev-token issuance failed for ${userId}: ${res.raw}`)
+    return token
+  }
+
+  function authHeaders(token: string): Record<string, string> {
+    return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+  }
+
+  async function seedUser(userId: string): Promise<void> {
+    await (pool as Pool).query(
+      `INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x') ON CONFLICT (id) DO NOTHING`,
+      [userId, `${userId}@s7-2.test`],
+    )
+  }
+
+  async function seedIntegration(orgId: string, name: string, corpId: string): Promise<string> {
+    const id = (
+      await (pool as Pool).query<{ id: string }>(
+        `INSERT INTO directory_integrations (org_id, name, corp_id, provider, status)
+         VALUES ($1, $2, $3, 'dingtalk', 'active') RETURNING id`,
+        [orgId, name, corpId],
+      )
+    ).rows[0].id
+    integrationIds.push(id)
+    return id
+  }
+
+  async function seedDept(integrationId: string, externalId: string, name: string): Promise<string> {
+    return (
+      await (pool as Pool).query<{ id: string }>(
+        `INSERT INTO directory_departments (integration_id, provider, external_department_id, name, is_active, raw)
+         VALUES ($1, 'dingtalk', $2, $3, true, '{}'::jsonb) RETURNING id`,
+        [integrationId, externalId, name],
+      )
+    ).rows[0].id
+  }
+
+  async function seedAccount(
+    integrationId: string,
+    externalUserId: string,
+    externalKey: string,
+    name: string,
+    raw: Record<string, unknown> = {},
+  ): Promise<string> {
+    return (
+      await (pool as Pool).query<{ id: string }>(
+        `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, raw, is_active)
+         VALUES ($1, 'dingtalk', $2, $3, $4, $5::jsonb, true) RETURNING id`,
+        [integrationId, externalUserId, externalKey, name, JSON.stringify(raw)],
+      )
+    ).rows[0].id
+  }
+
+  async function link(accountId: string, userId: string): Promise<void> {
+    await (pool as Pool).query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+       VALUES ($1, $2, 'linked', 'manual')`,
+      [accountId, userId],
+    )
+  }
+
+  async function membership(
+    accountId: string,
+    departmentId: string,
+    isPrimary: boolean,
+    isManager = false,
+  ): Promise<void> {
+    await (pool as Pool).query(
+      `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary, is_manager)
+       VALUES ($1, $2, $3, $4)`,
+      [accountId, departmentId, isPrimary, isManager],
+    )
+  }
+
+  async function seedFlow(
+    orgId: string,
+    requestType: string,
+    steps: unknown[],
+    name: string,
+  ): Promise<string> {
+    const id = randomUUID()
+    await (pool as Pool).query(
+      `INSERT INTO attendance_approval_flows (id, org_id, name, request_type, steps, is_active)
+       VALUES ($1, $2, $3, $4, $5::jsonb, true)`,
+      [id, orgId, name, requestType, JSON.stringify(steps)],
+    )
+    createdFlowIds.push(id)
+    return id
+  }
+
+  async function createRequest(
+    orgId: string,
+    token: string,
+    workDate: string,
+    reason: string,
+  ): Promise<HttpResponse> {
+    return requestJson(`${baseUrl}/api/attendance/requests`, {
+      method: 'POST',
+      headers: authHeaders(token),
+      body: JSON.stringify({
+        orgId,
+        workDate,
+        requestType: 'time_correction',
+        requestedInAt: `${workDate}T01:00:00Z`,
+        requestedOutAt: `${workDate}T10:00:00Z`,
+        reason,
+      }),
+    })
+  }
+
+  function requestIdFrom(res: HttpResponse): string | undefined {
+    return (res.body as { data?: { request?: { id?: string } } } | undefined)?.data?.request?.id
+  }
+
+  async function act(
+    requestId: string,
+    token: string,
+    action: 'approve' | 'reject',
+  ): Promise<HttpResponse> {
+    return requestJson(`${baseUrl}/api/attendance/requests/${requestId}/${action}`, {
+      method: 'POST',
+      headers: authHeaders(token),
+      body: JSON.stringify({ comment: `s7-2 ${action}` }),
+    })
+  }
+
+  beforeAll(async () => {
+    const canListen: boolean = await new Promise((resolve) => {
+      const s = net.createServer()
+      s.once('error', () => resolve(false))
+      s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
+    })
+    if (!canListen) throw new Error('S7-2 tests require an available loopback port.')
+    if (!dbUrl) throw new Error('DATABASE_URL / ATTENDANCE_TEST_DATABASE_URL is required for the S7-2 suite.')
+
+    process.env.DATABASE_URL = dbUrl
+    prevRbac = process.env.RBAC_BYPASS
+    prevFlag = process.env[DYNAMIC_FLAG]
+    process.env.RBAC_BYPASS = 'true'
+    process.env.SKIP_PLUGINS = 'false'
+    process.env[DYNAMIC_FLAG] = 'true'
+
+    pool = new Pool({ connectionString: dbUrl })
+    await pool.query('SELECT 1')
+
+    for (const uid of userIds) await seedUser(uid)
+
+    // ── orgHome: linked requester + normalized is_manager (authoritative) ──
+    homeIntegrationId = await seedIntegration(orgHome, `s7-2-home-int-${runSuffix}`, `corp-home-${runSuffix}`)
+    homeDeptId = await seedDept(homeIntegrationId, `dept-home-${runSuffix}`, 'Home Eng')
+    const homeReqAcc = await seedAccount(homeIntegrationId, `ext-req-home-${runSuffix}`, `key-req-home-${runSuffix}`, 'ReqHome')
+    homeMgrAccountId = await seedAccount(homeIntegrationId, `ext-mgr-home-${runSuffix}`, `key-mgr-home-${runSuffix}`, 'MgrHome')
+    // Legacy leader that would resolve to managerAlt — precedence must pick normalized managerHome.
+    const homeLegacyAcc = await seedAccount(
+      homeIntegrationId,
+      `ext-legacy-home-${runSuffix}`,
+      `key-legacy-home-${runSuffix}`,
+      'LegacyHome',
+      { leader_in_dept: [{ dept_id: `dept-home-${runSuffix}`, leader: true }] },
+    )
+    await link(homeReqAcc, requester)
+    await link(homeMgrAccountId, managerHome)
+    await link(homeLegacyAcc, managerAlt)
+    await membership(homeReqAcc, homeDeptId, true, false)
+    await membership(homeMgrAccountId, homeDeptId, false, true) // normalized manager
+    await membership(homeLegacyAcc, homeDeptId, false, false)
+
+    // ── orgForeign: same local requester linked into a different org with a different manager ──
+    // updated_at will be more recent than home (inserted later) so the unscoped pick would choose
+    // foreign — the org anchor must force home when attendance requests use orgHome.
+    const foreignInt = await seedIntegration(orgForeign, `s7-2-foreign-int-${runSuffix}`, `corp-foreign-${runSuffix}`)
+    const foreignDept = await seedDept(foreignInt, `dept-foreign-${runSuffix}`, 'Foreign Eng')
+    const foreignReqAcc = await seedAccount(foreignInt, `ext-req-foreign-${runSuffix}`, `key-req-foreign-${runSuffix}`, 'ReqForeign')
+    const foreignMgrAcc = await seedAccount(foreignInt, `ext-mgr-foreign-${runSuffix}`, `key-mgr-foreign-${runSuffix}`, 'MgrForeign')
+    await link(foreignReqAcc, requester)
+    await link(foreignMgrAcc, managerForeign)
+    await membership(foreignReqAcc, foreignDept, true, false)
+    await membership(foreignMgrAcc, foreignDept, false, true)
+    // Bump foreign account updated_at so it is "more recent" than home (unscoped would pick it).
+    await pool.query(`UPDATE directory_accounts SET updated_at = now() + interval '1 hour' WHERE id = $1`, [
+      foreignReqAcc,
+    ])
+
+    // ── orgFreeze: 2-step flow freeze fixture (static step 0 + direct_manager step 1) ──
+    const freezeInt = await seedIntegration(orgFreeze, `s7-2-freeze-int-${runSuffix}`, `corp-freeze-${runSuffix}`)
+    freezeDeptId = await seedDept(freezeInt, `dept-freeze-${runSuffix}`, 'Freeze Eng')
+    const freezeReqAcc = await seedAccount(freezeInt, `ext-req-freeze-${runSuffix}`, `key-req-freeze-${runSuffix}`, 'ReqFreeze')
+    freezeMgrAccountId = await seedAccount(freezeInt, `ext-mgr-freeze-${runSuffix}`, `key-mgr-freeze-${runSuffix}`, 'MgrFreeze')
+    freezeAltAccountId = await seedAccount(freezeInt, `ext-mgr-alt-${runSuffix}`, `key-mgr-alt-${runSuffix}`, 'MgrAlt')
+    // Separate local user for freeze-org requester to avoid multi-org link noise on the shared requester.
+    // Reuse managerHome as the initial freeze manager; managerAlt as the post-mutation manager.
+    await link(freezeReqAcc, requester)
+    await link(freezeMgrAccountId, managerHome)
+    await link(freezeAltAccountId, managerAlt)
+    await membership(freezeReqAcc, freezeDeptId, true, false)
+    await membership(freezeMgrAccountId, freezeDeptId, false, true)
+    await membership(freezeAltAccountId, freezeDeptId, false, false)
+
+    // RBAC substrate for authz legs (real DB tables, not just JWT claims).
+    await pool.query(
+      `INSERT INTO permissions (code, name, description)
+       VALUES
+         ('attendance:approve', 'Attendance Approve', 'Approve attendance requests'),
+         ('attendance:admin', 'Attendance Admin', 'Administer attendance'),
+         ('attendance:write', 'Attendance Write', 'Create attendance requests')
+       ON CONFLICT (code) DO NOTHING`,
+    )
+    await pool.query(
+      `INSERT INTO user_permissions (user_id, permission_code)
+       VALUES
+         ($1, 'attendance:approve'),
+         ($2, 'attendance:approve'),
+         ($3, 'attendance:admin'),
+         ($4, 'attendance:write'),
+         ($4, 'attendance:approve'),
+         ($4, 'attendance:admin')
+       ON CONFLICT DO NOTHING`,
+      [managerHome, otherApprover, adminActor, requester],
+    )
+
+    const repoRoot = path.join(__dirname, '../../../../')
+    const { MetaSheetServer } = await import('../../src/index')
+    server = new MetaSheetServer({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [path.join(repoRoot, 'plugins', 'plugin-attendance')],
+    })
+    await server.start()
+    const address = server.getAddress()
+    if (!address || typeof address === 'string') throw new Error('S7-2 server did not expose a TCP address.')
+    baseUrl = `http://127.0.0.1:${address.port}`
+
+    adminToken = await devToken(requester, 'user', 'attendance:admin,attendance:write,attendance:approve')
+    managerToken = await devToken(managerHome, 'user', 'attendance:approve')
+    otherToken = await devToken(otherApprover, 'user', 'attendance:approve')
+    adminActorToken = await devToken(adminActor, 'user', 'attendance:admin')
+  })
+
+  afterAll(async () => {
+    if (pool) {
+      try {
+        if (createdRequestIds.length > 0) {
+          await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::uuid[])', [createdRequestIds]).catch(() => undefined)
+        }
+        for (const oid of [orgHome, orgForeign, orgUnlinked, orgFreeze, orgAuthz, orgFlagOff]) {
+          await pool.query('DELETE FROM attendance_requests WHERE org_id = $1', [oid]).catch(() => undefined)
+          await pool.query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [oid]).catch(() => undefined)
+        }
+        if (createdInstanceIds.length > 0) {
+          await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [createdInstanceIds]).catch(() => undefined)
+          await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [createdInstanceIds]).catch(() => undefined)
+          await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [createdInstanceIds]).catch(() => undefined)
+        }
+        for (const integrationId of integrationIds) {
+          await pool.query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId]).catch(() => undefined)
+          await pool.query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId]).catch(() => undefined)
+          await pool.query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId]).catch(() => undefined)
+        }
+        await pool.query('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [userIds]).catch(() => undefined)
+        await pool.query('DELETE FROM users WHERE id = ANY($1::text[])', [userIds]).catch(() => undefined)
+      } finally {
+        await pool.end()
+      }
+    }
+    if (server && (server as unknown as { stop?: () => Promise<void> }).stop) {
+      await (server as unknown as { stop: () => Promise<void> }).stop()
+    }
+    if (prevRbac === undefined) delete process.env.RBAC_BYPASS
+    else process.env.RBAC_BYPASS = prevRbac
+    if (prevFlag === undefined) delete process.env[DYNAMIC_FLAG]
+    else process.env[DYNAMIC_FLAG] = prevFlag
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ── Authoring: S7-2 makes direct_manager available when flag ON ──
+  it('AUTHORING: flag ON + direct_manager accepted (S7-2 implements the kind)', async () => {
+    setFlag(true)
+    const res = await requestJson(`${baseUrl}/api/attendance/approval-flows`, {
+      method: 'POST',
+      headers: authHeaders(adminToken),
+      body: JSON.stringify({
+        name: `s7-2-dm-flow-${runSuffix}`,
+        requestType: 'time_correction',
+        steps: [{ kind: 'direct_manager' }],
+        orgId: orgHome,
+        isActive: true,
+      }),
+    })
+    expect(res.status, res.raw).toBe(201)
+    const id = (res.body as { data?: { id?: string } }).data?.id
+    if (id) createdFlowIds.push(id)
+    const steps = (res.body as { data?: { steps?: unknown[] } }).data?.steps
+    expect(steps).toEqual([{ name: undefined, kind: 'direct_manager' }])
+  })
+
+  it('AUTHORING: dept_head still UNAVAILABLE (S7-3 not shipped)', async () => {
+    setFlag(true)
+    const res = await requestJson(`${baseUrl}/api/attendance/approval-flows`, {
+      method: 'POST',
+      headers: authHeaders(adminToken),
+      body: JSON.stringify({
+        name: `s7-2-dh-unavail-${runSuffix}`,
+        requestType: 'time_correction',
+        steps: [{ kind: 'dept_head' }],
+        orgId: orgHome,
+        isActive: true,
+      }),
+    })
+    expect(res.status, res.raw).toBe(422)
+    expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
+  })
+
+  // ── S7-1 NITs folded ──
+  it('NIT: dynamic + empty approverUserIds:[] → 422 MIXED (key-shape constraint)', async () => {
+    setFlag(true)
+    const res = await requestJson(`${baseUrl}/api/attendance/approval-flows`, {
+      method: 'POST',
+      headers: authHeaders(adminToken),
+      body: JSON.stringify({
+        name: `s7-2-mixed-empty-${runSuffix}`,
+        requestType: 'time_correction',
+        steps: [{ kind: 'direct_manager', approverUserIds: [] }],
+        orgId: orgHome,
+        isActive: true,
+      }),
+    })
+    expect(res.status, res.raw).toBe(422)
+    expect(errorCode(res)).toBe('APPROVAL_STEP_STATIC_DYNAMIC_MIXED')
+  })
+
+  it('NIT: non-string kind (number) → 422 APPROVAL_STEP_KIND_INVALID (not zod 400)', async () => {
+    setFlag(true)
+    const res = await requestJson(`${baseUrl}/api/attendance/approval-flows`, {
+      method: 'POST',
+      headers: authHeaders(adminToken),
+      body: JSON.stringify({
+        name: `s7-2-nonstr-kind-${runSuffix}`,
+        requestType: 'time_correction',
+        steps: [{ kind: 123 }],
+        orgId: orgHome,
+        isActive: true,
+      }),
+    })
+    expect(res.status, res.raw).toBe(422)
+    expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_INVALID')
+  })
+
+  // ── Linked resolution + freeze + assignment ──
+  it('RUNTIME create: linked direct_manager freezes managerId and builds user assignment', async () => {
+    setFlag(true)
+    process.env.RBAC_BYPASS = 'true'
+    await seedFlow(orgHome, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-linked-${runSuffix}`)
+
+    const workDate = '2026-06-01'
+    const res = await createRequest(orgHome, adminToken, workDate, 's7-2 linked resolution')
+    expect(res.status, res.raw).toBe(201)
+    const requestId = requestIdFrom(res) as string
+    expect(requestId).toBeTruthy()
+    createdRequestIds.push(requestId)
+
+    const reqRow = await (pool as Pool).query(
+      'SELECT approval_instance_id FROM attendance_requests WHERE id = $1',
+      [requestId],
+    )
+    const instanceId = reqRow.rows[0].approval_instance_id as string
+    createdInstanceIds.push(instanceId)
+
+    const inst = await (pool as Pool).query(
+      'SELECT requester_snapshot, current_node_key FROM approval_instances WHERE id = $1',
+      [instanceId],
+    )
+    const snap = inst.rows[0].requester_snapshot as { id?: string; managerId?: string }
+    // Normalized is_manager (managerHome) wins over legacy leader_in_dept (managerAlt).
+    expect(snap.managerId).toBe(managerHome)
+    expect(snap.id).toBe(requester)
+
+    const assignments = await (pool as Pool).query(
+      `SELECT assignment_type, assignee_id, is_active, metadata
+         FROM approval_assignments
+        WHERE instance_id = $1 AND is_active = TRUE`,
+      [instanceId],
+    )
+    expect(assignments.rows).toHaveLength(1)
+    expect(assignments.rows[0]).toMatchObject({
+      assignment_type: 'user',
+      assignee_id: managerHome,
+    })
+    // Must NOT have fallen through to admin/source_queue.
+    expect(assignments.rows.some((r) => r.assignment_type === 'source_queue')).toBe(false)
+    expect(assignments.rows.some((r) => r.assignee_id === 'admin')).toBe(false)
+  })
+
+  // ── Org anchor: two orgs, one local user ──
+  it('ORG-ANCHOR: two-org/one-local-user resolves manager from the requesting org only', async () => {
+    setFlag(true)
+    process.env.RBAC_BYPASS = 'true'
+    // orgHome flow (already seeded above is leave+direct_manager; ensure one is active for leave).
+    // Create against orgHome — must get managerHome, NEVER managerForeign (even though foreign
+    // account is more recently updated and would win the unscoped pick).
+    const workDate = '2026-06-02'
+    // Deactivate any leftover leave flows on orgHome except we already have one; create a fresh one
+    // in case the prior test's flow is fine.
+    await seedFlow(orgHome, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-anchor-${runSuffix}`)
+
+    const res = await createRequest(orgHome, adminToken, workDate, 's7-2 org anchor')
+    expect(res.status, res.raw).toBe(201)
+    const requestId = requestIdFrom(res) as string
+    createdRequestIds.push(requestId)
+    const reqRow = await (pool as Pool).query(
+      'SELECT approval_instance_id FROM attendance_requests WHERE id = $1',
+      [requestId],
+    )
+    const instanceId = reqRow.rows[0].approval_instance_id as string
+    createdInstanceIds.push(instanceId)
+    const inst = await (pool as Pool).query('SELECT requester_snapshot FROM approval_instances WHERE id = $1', [
+      instanceId,
+    ])
+    const snap = inst.rows[0].requester_snapshot as { managerId?: string }
+    expect(snap.managerId).toBe(managerHome)
+    expect(snap.managerId).not.toBe(managerForeign)
+  })
+
+  // ── Unlinked block-with-error + zero persistence ──
+  it('UNLINKED: direct_manager create fails 422 with ZERO attendance_requests / approval rows', async () => {
+    setFlag(true)
+    process.env.RBAC_BYPASS = 'true'
+    // Purely-local user with no directory link in orgUnlinked.
+    const unlinkedUser = `s7-2-unlinked-user-${runSuffix}`
+    await seedUser(unlinkedUser)
+    userIds.push(unlinkedUser)
+    await (pool as Pool).query(
+      `INSERT INTO user_permissions (user_id, permission_code)
+       VALUES ($1, 'attendance:write'), ($1, 'attendance:admin')
+       ON CONFLICT DO NOTHING`,
+      [unlinkedUser],
+    )
+    await seedFlow(orgUnlinked, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-unlinked-${runSuffix}`)
+
+    const unlinkedToken = await devToken(unlinkedUser, 'user', 'attendance:admin,attendance:write')
+    const beforeReq = await (pool as Pool).query(
+      'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
+      [orgUnlinked],
+    )
+    const beforeInst = await (pool as Pool).query(
+      `SELECT COUNT(*)::int AS n FROM approval_instances WHERE business_key LIKE $1`,
+      [`attendance-request:%`],
+    )
+
+    const res = await requestJson(`${baseUrl}/api/attendance/requests`, {
+      method: 'POST',
+      headers: authHeaders(unlinkedToken),
+      body: JSON.stringify({
+        orgId: orgUnlinked,
+        workDate: '2026-06-03',
+        requestType: 'time_correction',
+        requestedInAt: '2026-06-03T01:00:00Z',
+        requestedOutAt: '2026-06-03T10:00:00Z',
+        reason: 's7-2 unlinked block',
+      }),
+    })
+    expect(res.status, res.raw).toBe(422)
+    expect(errorCode(res)).toBe('APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED')
+
+    const afterReq = await (pool as Pool).query(
+      'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
+      [orgUnlinked],
+    )
+    expect(afterReq.rows[0].n).toBe(beforeReq.rows[0].n)
+    // No new instance for this org's request path (business_key contains the request id which was never written).
+    const afterInst = await (pool as Pool).query(
+      `SELECT COUNT(*)::int AS n FROM approval_instances WHERE business_key LIKE $1`,
+      [`attendance-request:%`],
+    )
+    expect(afterInst.rows[0].n).toBe(beforeInst.rows[0].n)
+  })
+
+  // P2 fix: multi-step [static, direct_manager] must ALSO fail closed at create when manager is
+  // unresolvable — never persist step-0 and strand on advance.
+  it('UNLINKED multi-step [static, direct_manager]: create 422 + zero request/instance/assignment rows (org-scoped)', async () => {
+    setFlag(true)
+    process.env.RBAC_BYPASS = 'true'
+    const orgMulti = `s7-2-unlinked-multi-${runSuffix}`
+    const multiUser = `s7-2-unlinked-multi-user-${runSuffix}`
+    await seedUser(multiUser)
+    userIds.push(multiUser)
+    await (pool as Pool).query(
+      `INSERT INTO user_permissions (user_id, permission_code)
+       VALUES ($1, 'attendance:write'), ($1, 'attendance:admin')
+       ON CONFLICT DO NOTHING`,
+      [multiUser],
+    )
+    // Static step 0 would have assigned multiUser; direct_manager at step 1 is unresolvable (no link).
+    await seedFlow(
+      orgMulti,
+      'time_correction',
+      [
+        { name: 'S0', approverUserIds: [multiUser] },
+        { name: 'S1', kind: 'direct_manager' },
+      ],
+      `s7-2-unlinked-multi-${runSuffix}`,
+    )
+
+    const multiToken = await devToken(multiUser, 'user', 'attendance:admin,attendance:write')
+    const beforeReq = await (pool as Pool).query(
+      'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
+      [orgMulti],
+    )
+    // approval_instances store attendance org on metadata/subject_snapshot (no org_id column).
+    const beforeInst = await (pool as Pool).query(
+      `SELECT COUNT(*)::int AS n FROM approval_instances
+        WHERE (metadata->>'orgId' = $1 OR subject_snapshot->>'orgId' = $1)`,
+      [orgMulti],
+    )
+    const beforeAssign = await (pool as Pool).query(
+      `SELECT COUNT(*)::int AS n FROM approval_assignments aa
+         JOIN approval_instances ai ON ai.id = aa.instance_id
+        WHERE (ai.metadata->>'orgId' = $1 OR ai.subject_snapshot->>'orgId' = $1)`,
+      [orgMulti],
+    )
+
+    const res = await requestJson(`${baseUrl}/api/attendance/requests`, {
+      method: 'POST',
+      headers: authHeaders(multiToken),
+      body: JSON.stringify({
+        orgId: orgMulti,
+        workDate: '2026-06-11',
+        requestType: 'time_correction',
+        requestedInAt: '2026-06-11T01:00:00Z',
+        requestedOutAt: '2026-06-11T10:00:00Z',
+        reason: 's7-2 unlinked multi-step block at create',
+      }),
+    })
+    expect(res.status, res.raw).toBe(422)
+    expect(errorCode(res)).toBe('APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED')
+
+    const afterReq = await (pool as Pool).query(
+      'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
+      [orgMulti],
+    )
+    const afterInst = await (pool as Pool).query(
+      `SELECT COUNT(*)::int AS n FROM approval_instances
+        WHERE (metadata->>'orgId' = $1 OR subject_snapshot->>'orgId' = $1)`,
+      [orgMulti],
+    )
+    const afterAssign = await (pool as Pool).query(
+      `SELECT COUNT(*)::int AS n FROM approval_assignments aa
+         JOIN approval_instances ai ON ai.id = aa.instance_id
+        WHERE (ai.metadata->>'orgId' = $1 OR ai.subject_snapshot->>'orgId' = $1)`,
+      [orgMulti],
+    )
+    expect(afterReq.rows[0].n, 'zero attendance_requests on create-time freeze failure').toBe(beforeReq.rows[0].n)
+    expect(afterInst.rows[0].n, 'zero approval_instances on create-time freeze failure').toBe(beforeInst.rows[0].n)
+    expect(afterAssign.rows[0].n, 'zero approval_assignments on create-time freeze failure').toBe(
+      beforeAssign.rows[0].n,
+    )
+
+    await (pool as Pool).query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [orgMulti]).catch(() => undefined)
+  })
+
+  // ── 2-step freeze after directory mutation ──
+  it('FREEZE: 2-step flow keeps step-2 assignee after directory manager mutation', async () => {
+    setFlag(true)
+    process.env.RBAC_BYPASS = 'true'
+    await seedFlow(
+      orgFreeze,
+      'time_correction',
+      [
+        { name: 'S0', approverUserIds: [managerHome] },
+        { name: 'S1', kind: 'direct_manager' },
+      ],
+      `s7-2-freeze-${runSuffix}`,
+    )
+
+    const workDate = '2026-06-04'
+    const res = await createRequest(orgFreeze, adminToken, workDate, 's7-2 freeze')
+    expect(res.status, res.raw).toBe(201)
+    const requestId = requestIdFrom(res) as string
+    createdRequestIds.push(requestId)
+    const reqRow = await (pool as Pool).query(
+      'SELECT approval_instance_id FROM attendance_requests WHERE id = $1',
+      [requestId],
+    )
+    const instanceId = reqRow.rows[0].approval_instance_id as string
+    createdInstanceIds.push(instanceId)
+
+    const snapBefore = (
+      await (pool as Pool).query('SELECT requester_snapshot FROM approval_instances WHERE id = $1', [instanceId])
+    ).rows[0].requester_snapshot as { managerId?: string }
+    expect(snapBefore.managerId).toBe(managerHome)
+
+    // Mutate directory: flip is_manager from managerHome → managerAlt BEFORE step-1 advance.
+    await (pool as Pool).query(
+      `UPDATE directory_account_departments SET is_manager = false
+        WHERE directory_account_id = $1 AND directory_department_id = $2`,
+      [freezeMgrAccountId, freezeDeptId],
+    )
+    await (pool as Pool).query(
+      `UPDATE directory_account_departments SET is_manager = true
+        WHERE directory_account_id = $1 AND directory_department_id = $2`,
+      [freezeAltAccountId, freezeDeptId],
+    )
+
+    // Step 0 assignee (managerHome) approves → advances to step 1 (direct_manager).
+    const approve = await act(requestId, managerToken, 'approve')
+    expect(approve.status, approve.raw).toBe(200)
+
+    const snapAfter = (
+      await (pool as Pool).query(
+        'SELECT requester_snapshot, current_step, current_node_key FROM approval_instances WHERE id = $1',
+        [instanceId],
+      )
+    ).rows[0]
+    expect((snapAfter.requester_snapshot as { managerId?: string }).managerId).toBe(managerHome)
+    expect(snapAfter.current_step).toBe(1)
+    expect(snapAfter.current_node_key).toBe(NODE_KEY_1)
+
+    const assignments = await (pool as Pool).query(
+      `SELECT assignment_type, assignee_id FROM approval_assignments
+        WHERE instance_id = $1 AND is_active = TRUE AND node_key = $2`,
+      [instanceId, NODE_KEY_1],
+    )
+    expect(assignments.rows).toEqual([
+      expect.objectContaining({ assignment_type: 'user', assignee_id: managerHome }),
+    ])
+    // The mutated managerAlt must NOT be the assignee.
+    expect(assignments.rows.some((r) => r.assignee_id === managerAlt)).toBe(false)
+  })
+
+  // ── Dynamic assignment authorization (S7-0 re-run for this kind) ──
+  it('AUTHZ: dynamic user assignee can approve; unassigned scope-authorized actor 403s; admin override works', async () => {
+    setFlag(true)
+    // Force real authorization (no RBAC bypass).
+    process.env.RBAC_BYPASS = 'false'
+    try {
+      await seedFlow(orgAuthz, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-authz-${runSuffix}`)
+      // Seed directory for orgAuthz so create can freeze managerHome.
+      const authzInt = await seedIntegration(orgAuthz, `s7-2-authz-int-${runSuffix}`, `corp-authz-${runSuffix}`)
+      const authzDept = await seedDept(authzInt, `dept-authz-${runSuffix}`, 'Authz Eng')
+      const authzReqAcc = await seedAccount(authzInt, `ext-req-authz-${runSuffix}`, `key-req-authz-${runSuffix}`, 'ReqAuthz')
+      const authzMgrAcc = await seedAccount(authzInt, `ext-mgr-authz-${runSuffix}`, `key-mgr-authz-${runSuffix}`, 'MgrAuthz')
+      await link(authzReqAcc, requester)
+      await link(authzMgrAcc, managerHome)
+      await membership(authzReqAcc, authzDept, true, false)
+      await membership(authzMgrAcc, authzDept, false, true)
+
+      // Positive approve leg
+      const workDateA = '2026-06-05'
+      const createA = await createRequest(orgAuthz, adminToken, workDateA, 's7-2 authz approve')
+      expect(createA.status, createA.raw).toBe(201)
+      const requestIdA = requestIdFrom(createA) as string
+      createdRequestIds.push(requestIdA)
+      const instA = (
+        await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestIdA])
+      ).rows[0].approval_instance_id as string
+      createdInstanceIds.push(instA)
+
+      // Negative: otherApprover holds attendance:approve (broad gate) but is NOT the manager.
+      const negApprove = await act(requestIdA, otherToken, 'approve')
+      expect(negApprove.status, negApprove.raw).toBe(403)
+      expect(errorCode(negApprove)).toBe('FORBIDDEN')
+
+      // Positive: managerHome is the frozen assignee.
+      const posApprove = await act(requestIdA, managerToken, 'approve')
+      expect(posApprove.status, posApprove.raw).toBe(200)
+
+      // Reject legs on a fresh request.
+      const workDateB = '2026-06-06'
+      const createB = await createRequest(orgAuthz, adminToken, workDateB, 's7-2 authz reject')
+      expect(createB.status, createB.raw).toBe(201)
+      const requestIdB = requestIdFrom(createB) as string
+      createdRequestIds.push(requestIdB)
+      const instB = (
+        await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestIdB])
+      ).rows[0].approval_instance_id as string
+      createdInstanceIds.push(instB)
+
+      const negReject = await act(requestIdB, otherToken, 'reject')
+      expect(negReject.status, negReject.raw).toBe(403)
+      expect(errorCode(negReject)).toBe('FORBIDDEN')
+
+      const posReject = await act(requestIdB, managerToken, 'reject')
+      expect(posReject.status, posReject.raw).toBe(200)
+
+      // Admin override (not the assignee) on a third request — approve.
+      const workDateC = '2026-06-07'
+      const createC = await createRequest(orgAuthz, adminToken, workDateC, 's7-2 authz admin')
+      expect(createC.status, createC.raw).toBe(201)
+      const requestIdC = requestIdFrom(createC) as string
+      createdRequestIds.push(requestIdC)
+      const instC = (
+        await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestIdC])
+      ).rows[0].approval_instance_id as string
+      createdInstanceIds.push(instC)
+
+      const adminApprove = await act(requestIdC, adminActorToken, 'approve')
+      expect(adminApprove.status, adminApprove.raw).toBe(200)
+
+      // P3: admin override reject (symmetric with approve — non-assignee admin still authorized).
+      const workDateD = '2026-06-12'
+      const createD = await createRequest(orgAuthz, adminToken, workDateD, 's7-2 authz admin reject')
+      expect(createD.status, createD.raw).toBe(201)
+      const requestIdD = requestIdFrom(createD) as string
+      createdRequestIds.push(requestIdD)
+      const instD = (
+        await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestIdD])
+      ).rows[0].approval_instance_id as string
+      createdInstanceIds.push(instD)
+
+      const adminReject = await act(requestIdD, adminActorToken, 'reject')
+      expect(adminReject.status, adminReject.raw).toBe(200)
+    } finally {
+      process.env.RBAC_BYPASS = 'true'
+    }
+  })
+
+  // ── Flag-off create ──
+  it('FLAG-OFF create: dynamic flow fails-closed with zero rows', async () => {
+    setFlag(false)
+    process.env.RBAC_BYPASS = 'true'
+    await seedFlow(orgFlagOff, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-flagoff-create-${runSuffix}`)
+
+    const before = await (pool as Pool).query(
+      'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
+      [orgFlagOff],
+    )
+    const res = await createRequest(orgFlagOff, adminToken, '2026-06-08', 's7-2 flag-off create')
+    expect(res.status, res.raw).toBe(422)
+    expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
+    const after = await (pool as Pool).query(
+      'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
+      [orgFlagOff],
+    )
+    expect(after.rows[0].n).toBe(before.rows[0].n)
+  })
+
+  // ── Flag-off advance rollback ──
+  it('FLAG-OFF advance: step-1 approve fails and rolls back (instance still at step 0)', async () => {
+    process.env.RBAC_BYPASS = 'true'
+    setFlag(true)
+    const orgAdv = `s7-2-adv-${runSuffix}`
+    // Directory for this org so create succeeds under flag ON.
+    const advInt = await seedIntegration(orgAdv, `s7-2-adv-int-${runSuffix}`, `corp-adv-${runSuffix}`)
+    const advDept = await seedDept(advInt, `dept-adv-${runSuffix}`, 'Adv Eng')
+    const advReqAcc = await seedAccount(advInt, `ext-req-adv-${runSuffix}`, `key-req-adv-${runSuffix}`, 'ReqAdv')
+    const advMgrAcc = await seedAccount(advInt, `ext-mgr-adv-${runSuffix}`, `key-mgr-adv-${runSuffix}`, 'MgrAdv')
+    await link(advReqAcc, requester)
+    await link(advMgrAcc, managerHome)
+    await membership(advReqAcc, advDept, true, false)
+    await membership(advMgrAcc, advDept, false, true)
+
+    await seedFlow(
+      orgAdv,
+      'time_correction',
+      [
+        { name: 'S0', approverUserIds: [managerHome] },
+        { name: 'S1', kind: 'direct_manager' },
+      ],
+      `s7-2-flagoff-adv-${runSuffix}`,
+    )
+
+    const create = await createRequest(orgAdv, adminToken, '2026-06-09', 's7-2 flag-off advance')
+    expect(create.status, create.raw).toBe(201)
+    const requestId = requestIdFrom(create) as string
+    createdRequestIds.push(requestId)
+    const instanceId = (
+      await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestId])
+    ).rows[0].approval_instance_id as string
+    createdInstanceIds.push(instanceId)
+
+    // Flip flag OFF before step advance.
+    setFlag(false)
+    const approve = await act(requestId, managerToken, 'approve')
+    expect(approve.status, approve.raw).toBe(422)
+    expect(errorCode(approve)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
+
+    const inst = await (pool as Pool).query(
+      'SELECT status, current_step, current_node_key, version FROM approval_instances WHERE id = $1',
+      [instanceId],
+    )
+    expect(inst.rows[0].status).toBe('pending')
+    expect(inst.rows[0].current_step).toBe(0)
+    expect(inst.rows[0].current_node_key).toBe(NODE_KEY_0)
+    // No approval_records appended for the failed advance.
+    const records = await (pool as Pool).query(
+      'SELECT COUNT(*)::int AS n FROM approval_records WHERE instance_id = $1',
+      [instanceId],
+    )
+    expect(records.rows[0].n).toBe(0)
+    // Active assignment still step 0's static assignee.
+    const assignments = await (pool as Pool).query(
+      `SELECT assignment_type, assignee_id FROM approval_assignments
+        WHERE instance_id = $1 AND is_active = TRUE`,
+      [instanceId],
+    )
+    expect(assignments.rows).toEqual([
+      expect.objectContaining({ assignment_type: 'user', assignee_id: managerHome }),
+    ])
+
+    await (pool as Pool).query('DELETE FROM attendance_requests WHERE org_id = $1', [orgAdv]).catch(() => undefined)
+    await (pool as Pool).query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [orgAdv]).catch(() => undefined)
+  })
+
+  // ── Legacy static byte-identity under flag off ──
+  it('LEGACY static: flag OFF flow with no dynamic kind still creates + assigns statically', async () => {
+    setFlag(false)
+    process.env.RBAC_BYPASS = 'true'
+    const orgLegacy = `s7-2-legacy-${runSuffix}`
+    await seedFlow(
+      orgLegacy,
+      'time_correction',
+      [{ name: 'LM', approverUserIds: [managerHome] }],
+      `s7-2-legacy-${runSuffix}`,
+    )
+    const res = await createRequest(orgLegacy, adminToken, '2026-06-10', 's7-2 legacy static')
+    expect(res.status, res.raw).toBe(201)
+    const requestId = requestIdFrom(res) as string
+    createdRequestIds.push(requestId)
+    const instanceId = (
+      await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestId])
+    ).rows[0].approval_instance_id as string
+    createdInstanceIds.push(instanceId)
+    const snap = (
+      await (pool as Pool).query('SELECT requester_snapshot FROM approval_instances WHERE id = $1', [instanceId])
+    ).rows[0].requester_snapshot as Record<string, unknown>
+    // Legacy snapshot shape: id/name only (no managerId freeze when no dynamic kind).
+    expect(snap.managerId).toBeUndefined()
+    expect(snap.id).toBe(requester)
+    const assignments = await (pool as Pool).query(
+      `SELECT assignment_type, assignee_id FROM approval_assignments
+        WHERE instance_id = $1 AND is_active = TRUE`,
+      [instanceId],
+    )
+    expect(assignments.rows).toEqual([
+      expect.objectContaining({ assignment_type: 'user', assignee_id: managerHome }),
+    ])
+    await (pool as Pool).query('DELETE FROM attendance_requests WHERE org_id = $1', [orgLegacy]).catch(() => undefined)
+    await (pool as Pool).query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [orgLegacy]).catch(() => undefined)
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts
@@ -254,10 +254,13 @@ describeIfDatabase('S7-1 dynamic-kind step contract + fail-closed (authoring + r
     })
   }
 
-  it('CREATE rejects a shape-valid dynamic kind at S7-1 (flag ON, no resolver) → 422 APPROVAL_STEP_KIND_UNAVAILABLE', async () => {
+  // S7-2 implements direct_manager: a shape-valid direct_manager with flag ON is now AUTHORING-
+  // accepted. Keep this leg as a fail-closed proof for an STILL-unimplemented kind (dept_head /
+  // S7-3) so the UNAVAILABLE gate remains mutation-provable after S7-2 lands.
+  it('CREATE rejects a shape-valid but unimplemented dynamic kind (dept_head) with flag ON → 422 APPROVAL_STEP_KIND_UNAVAILABLE', async () => {
     setFlag(true)
     try {
-      const res = await createFlow([{ kind: 'direct_manager' }], `s7-1-unavail-${runSuffix}`)
+      const res = await createFlow([{ kind: 'dept_head' }], `s7-1-unavail-${runSuffix}`)
       expect(res.status, res.raw).toBe(422)
       expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
     } finally {

--- a/packages/core-backend/tests/unit/approval-directory-org.test.ts
+++ b/packages/core-backend/tests/unit/approval-directory-org.test.ts
@@ -31,9 +31,23 @@ interface FakeDb {
   localByExternalId?: Record<string, string | null>
 }
 
-function makeQuery(db: FakeDb) {
+function makeQuery(db: FakeDb & {
+  // When the org-anchored path is used, the fake can assert the orgId param and optionally return
+  // a different requester (or empty) so the two-org / one-local-user contract is unit-provable.
+  orgAnchoredRequester?: FakeDb['requester'] | null
+  lastOrgIdParam?: string | null
+  lastRequesterSql?: string
+}) {
   return async <Row>(text: string, params?: unknown[]): Promise<{ rows: Row[] }> => {
     if (text.includes('FROM directory_account_links l') && text.includes('LEFT JOIN directory_account_departments')) {
+      db.lastRequesterSql = text
+      // Org-anchored SELECT joins directory_integrations and binds org_id as $2.
+      if (text.includes('JOIN directory_integrations di') && text.includes('di.org_id = $2')) {
+        db.lastOrgIdParam = params?.[1] != null ? String(params[1]) : null
+        const row = db.orgAnchoredRequester !== undefined ? db.orgAnchoredRequester : db.requester
+        return { rows: (row ? [row] : []) as Row[] }
+      }
+      db.lastOrgIdParam = null
       return { rows: (db.requester ? [db.requester] : []) as Row[] }
     }
     // B3 normalized-manager gate query (`ad.is_manager = true`). Default-empty means the dept has
@@ -267,5 +281,93 @@ describe('resolveApprovalRequesterOrgRelations', () => {
     }
     const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
     expect(result).toEqual({})
+  })
+
+  // ── S7 §3.3 org anchor (optional / backward compatible) ──
+  it('S7 §3.3: omitting orgId keeps the unscoped requester SELECT (no directory_integrations join)', async () => {
+    const db: FakeDb & { lastOrgIdParam?: string | null; lastRequesterSql?: string } = {
+      requester: {
+        integration_id: 'int-unscoped',
+        account_id: 'acc-req',
+        external_user_id: 'ext-req',
+        raw: {},
+        primary_external_department_id: 'D1',
+        primary_department_raw: {},
+      },
+      normalizedDeptManagers: [{ account_id: 'acc-mgr', external_user_id: 'ext-mgr' }],
+      localByAccountId: { 'acc-mgr': 'local-mgr' },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
+    expect(result.managerId).toBe('local-mgr')
+    expect(db.lastOrgIdParam).toBeNull()
+    expect(db.lastRequesterSql).toBeTruthy()
+    expect(db.lastRequesterSql).not.toContain('directory_integrations')
+  })
+
+  it('S7 §3.3: orgId anchors the requester-account pick BEFORE ORDER BY/LIMIT (join + $2)', async () => {
+    const db: FakeDb & { lastOrgIdParam?: string | null; lastRequesterSql?: string; orgAnchoredRequester?: FakeDb['requester'] } = {
+      // Unscoped would pick this (more recent) foreign-org account...
+      requester: {
+        integration_id: 'int-foreign',
+        account_id: 'acc-foreign',
+        external_user_id: 'ext-foreign',
+        raw: {},
+        primary_external_department_id: 'D-foreign',
+        primary_department_raw: {},
+      },
+      // ...but with orgId the anchored path returns the calling-org account only.
+      orgAnchoredRequester: {
+        integration_id: 'int-home',
+        account_id: 'acc-home',
+        external_user_id: 'ext-home',
+        raw: {},
+        primary_external_department_id: 'D-home',
+        primary_department_raw: {},
+      },
+      normalizedDeptManagers: [{ account_id: 'acc-home-mgr', external_user_id: 'ext-home-mgr' }],
+      localByAccountId: { 'acc-home-mgr': 'local-home-mgr' },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db), { orgId: 'org-home' })
+    expect(db.lastOrgIdParam).toBe('org-home')
+    expect(db.lastRequesterSql).toContain('directory_integrations')
+    expect(db.lastRequesterSql).toContain('di.org_id = $2')
+    expect(result.managerId).toBe('local-home-mgr')
+  })
+
+  it('S7 §3.3: orgId with no matching integration account returns {} (does not fall back to unscoped)', async () => {
+    const db: FakeDb & { orgAnchoredRequester?: null } = {
+      requester: {
+        integration_id: 'int-other',
+        account_id: 'acc-other',
+        external_user_id: 'ext-other',
+        raw: {},
+        primary_external_department_id: 'D1',
+        primary_department_raw: {},
+      },
+      orgAnchoredRequester: null, // anchored pick finds nothing
+      normalizedDeptManagers: [{ account_id: 'acc-mgr', external_user_id: 'ext-mgr' }],
+      localByAccountId: { 'acc-mgr': 'local-mgr' },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db), { orgId: 'org-empty' })
+    expect(result).toEqual({}) // never the unscoped foreign manager
+  })
+
+  it('S7 §3.3: blank orgId is treated as omitted (backward-compatible unscoped path)', async () => {
+    const db: FakeDb & { lastOrgIdParam?: string | null; lastRequesterSql?: string } = {
+      requester: {
+        integration_id: 'int-1',
+        account_id: 'acc-req',
+        external_user_id: 'ext-req',
+        raw: {},
+        primary_external_department_id: 'D1',
+        primary_department_raw: {},
+      },
+      normalizedDeptManagers: [{ account_id: 'acc-mgr', external_user_id: 'ext-mgr' }],
+      localByAccountId: { 'acc-mgr': 'local-mgr' },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db), { orgId: '   ' })
+    expect(result.managerId).toBe('local-mgr')
+    expect(db.lastOrgIdParam).toBeNull()
+    expect(db.lastRequesterSql).not.toContain('directory_integrations')
   })
 })

--- a/packages/core-backend/tests/unit/attendance-approval-direct-manager-s7-2.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-direct-manager-s7-2.test.ts
@@ -1,0 +1,343 @@
+import { createRequire } from 'node:module'
+import { afterEach, describe, expect, it } from 'vitest'
+
+// S7-2 (RATIFIED attendance-approval-s7 resolver design-lock §2.1 / §3.4 / §4 / §7 S7-2): pure-helper
+// unit coverage for create-time freeze + assignment build from the frozen requester snapshot.
+// Directory resolution itself is owned by ApprovalDirectoryOrg (+ its unit/db suites); the port
+// wiring is covered by the port-scoping unit + the real-DB S7-2 integration matrix. These tests
+// pin the PLUGIN-side contracts:
+//   • freeze is a no-op for static-only flows (legacy byte-identity)
+//   • freeze calls the port once for a flow containing direct_manager
+//   • unresolved / self / empty at freeze → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (whole-flow,
+//     including multi-step [static, direct_manager] — never empty freeze + later strand)
+//   • assignment build reads ONLY the frozen snapshot (no port re-call)
+//   • self / empty / missing at assignment build → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED
+//   • legacy static empty-approver fallback is preserved when no dynamic kind is present
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceApprovalCenterForTests as {
+  buildAttendanceApprovalAssignments: (
+    steps: unknown,
+    index?: number,
+    snapshot?: Record<string, unknown> | null,
+  ) => Array<Record<string, unknown>>
+  buildAttendanceApprovalInstancePayload: (input: Record<string, unknown>) => {
+    requesterSnapshot: Record<string, unknown>
+  }
+  resolveAttendanceDirectManagerFreeze: (input: {
+    orgId: string
+    userId: string
+    flowSteps: unknown
+    context: unknown
+  }) => Promise<Record<string, unknown>>
+  flowStepsNeedDirectManagerFreeze: (steps: unknown) => boolean
+  ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV: string
+}
+
+const {
+  buildAttendanceApprovalAssignments,
+  buildAttendanceApprovalInstancePayload,
+  resolveAttendanceDirectManagerFreeze,
+  flowStepsNeedDirectManagerFreeze,
+  ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV,
+} = helpers
+
+function httpCode(fn: () => void): { status: number; code: string } | null {
+  try {
+    fn()
+    return null
+  } catch (err) {
+    const e = err as { status?: number; code?: string }
+    return { status: e.status ?? -1, code: e.code ?? '<none>' }
+  }
+}
+
+afterEach(() => {
+  delete process.env[ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV]
+})
+
+describe('S7-2 flowStepsNeedDirectManagerFreeze', () => {
+  it('is false for static-only / empty flows (legacy freeze no-op)', () => {
+    expect(flowStepsNeedDirectManagerFreeze([{ approverUserIds: ['u1'] }])).toBe(false)
+    expect(flowStepsNeedDirectManagerFreeze([])).toBe(false)
+  })
+
+  it('is true when any step is direct_manager (incl. later steps)', () => {
+    expect(flowStepsNeedDirectManagerFreeze([{ kind: 'direct_manager' }])).toBe(true)
+    expect(
+      flowStepsNeedDirectManagerFreeze([
+        { name: 'S', approverUserIds: ['u1'] },
+        { kind: 'direct_manager' },
+      ]),
+    ).toBe(true)
+  })
+
+  it('is false for other dynamic kinds (dept_head is S7-3 — no freeze yet)', () => {
+    expect(flowStepsNeedDirectManagerFreeze([{ kind: 'dept_head' }])).toBe(false)
+  })
+})
+
+describe('S7-2 resolveAttendanceDirectManagerFreeze — create-time port call', () => {
+  it('static-only flow never calls the port', async () => {
+    let calls = 0
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['direct_manager'],
+          resolve: async () => {
+            calls += 1
+            return { status: 'resolved', assignees: [{ assignmentType: 'user', assigneeId: 'm1' }] }
+          },
+        },
+      },
+    }
+    const rel = await resolveAttendanceDirectManagerFreeze({
+      orgId: 'org-1',
+      userId: 'req-1',
+      flowSteps: [{ approverUserIds: ['u1'] }],
+      context,
+    })
+    expect(rel).toEqual({})
+    expect(calls).toBe(0)
+  })
+
+  it('linked resolution freezes managerId from the port assignees', async () => {
+    let seen: { orgId: string; request: Record<string, unknown> } | null = null
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['direct_manager'],
+          resolve: async (orgId: string, request: Record<string, unknown>) => {
+            seen = { orgId, request }
+            return { status: 'resolved', assignees: [{ assignmentType: 'user', assigneeId: 'mgr-local' }] }
+          },
+        },
+      },
+    }
+    const rel = await resolveAttendanceDirectManagerFreeze({
+      orgId: 'org-home',
+      userId: 'req-1',
+      flowSteps: [{ kind: 'direct_manager' }],
+      context,
+    })
+    expect(rel).toEqual({ managerId: 'mgr-local' })
+    expect(seen).toEqual({
+      orgId: 'org-home',
+      request: { kind: 'direct_manager', requesterUserId: 'req-1' },
+    })
+  })
+
+  it('self-resolving manager rejects at create-time freeze (APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED)', async () => {
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['direct_manager'],
+          resolve: async () => ({
+            status: 'resolved',
+            assignees: [{ assignmentType: 'user', assigneeId: 'req-1' }],
+          }),
+        },
+      },
+    }
+    await expect(
+      resolveAttendanceDirectManagerFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ kind: 'direct_manager' }],
+        context,
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('unresolved port result rejects at create-time freeze (whole-flow; never empty freeze)', async () => {
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['direct_manager'],
+          resolve: async () => ({ status: 'unresolved', reason: 'no_manager_linked' }),
+        },
+      },
+    }
+    await expect(
+      resolveAttendanceDirectManagerFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ kind: 'direct_manager' }],
+        context,
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('empty assignees array rejects at create-time freeze', async () => {
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['direct_manager'],
+          resolve: async () => ({ status: 'resolved', assignees: [] }),
+        },
+      },
+    }
+    await expect(
+      resolveAttendanceDirectManagerFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ name: 'S0', approverUserIds: ['u1'] }, { kind: 'direct_manager' }],
+        context,
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('missing port throws APPROVAL_STEP_KIND_UNAVAILABLE (resolver-unavailable §4.1)', async () => {
+    await expect(
+      resolveAttendanceDirectManagerFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ kind: 'direct_manager' }],
+        context: { services: {} },
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_STEP_KIND_UNAVAILABLE' })
+  })
+})
+
+describe('S7-2 buildAttendanceApprovalAssignments — frozen snapshot only', () => {
+  it('builds a user assignment from frozen managerId (linked resolution)', () => {
+    const out = buildAttendanceApprovalAssignments(
+      [{ name: '直属上级', kind: 'direct_manager' }],
+      0,
+      { id: 'req-1', name: 'Requester', managerId: 'mgr-1' },
+    )
+    expect(out).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'mgr-1',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: {
+          source: 'attendance',
+          kind: 'direct_manager',
+          stepName: '直属上级',
+          resolvedFrom: { kind: 'direct_manager' },
+        },
+      },
+    ])
+  })
+
+  it('self-exclusion → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (never admin fallback)', () => {
+    expect(
+      httpCode(() =>
+        buildAttendanceApprovalAssignments([{ kind: 'direct_manager' }], 0, {
+          id: 'req-1',
+          managerId: 'req-1',
+        }),
+      ),
+    ).toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('missing managerId → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED', () => {
+    expect(
+      httpCode(() =>
+        buildAttendanceApprovalAssignments([{ kind: 'direct_manager' }], 0, { id: 'req-1' }),
+      ),
+    ).toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('null snapshot → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED', () => {
+    expect(httpCode(() => buildAttendanceApprovalAssignments([{ kind: 'direct_manager' }], 0, null))).toEqual({
+      status: 422,
+      code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED',
+    })
+  })
+
+  it('mutation canary: dynamic unresolved must NOT produce admin/source_queue rows', () => {
+    try {
+      buildAttendanceApprovalAssignments([{ kind: 'direct_manager' }], 0, { id: 'req-1' })
+      expect.fail('expected throw')
+    } catch (err) {
+      const e = err as { code?: string }
+      expect(e.code).toBe('APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED')
+    }
+    // Positive control: static empty still falls back (legacy reserved path).
+    const legacy = buildAttendanceApprovalAssignments([], 0)
+    expect(legacy.some((a) => a.assignmentType === 'role' && a.assigneeId === 'admin')).toBe(true)
+    expect(legacy.some((a) => a.assignmentType === 'source_queue')).toBe(true)
+  })
+
+  it('step-advance index uses frozen snapshot for step 1 (no live re-resolve)', () => {
+    const steps = [
+      { name: 'S0', approverUserIds: ['u-step0'] },
+      { name: 'S1', kind: 'direct_manager' },
+    ]
+    const snap = { id: 'req-1', managerId: 'mgr-frozen' }
+    const out = buildAttendanceApprovalAssignments(steps, 1, snap)
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({
+      assignmentType: 'user',
+      assigneeId: 'mgr-frozen',
+      sourceStep: 1,
+      nodeKey: 'attendance_request_step_1',
+    })
+  })
+
+  it('legacy static byte-identity: user/role assignments unchanged when snapshot is present', () => {
+    const out = buildAttendanceApprovalAssignments(
+      [{ name: 'LM', approverUserIds: ['u1', 'u2'], approverRoleIds: ['r1'] }],
+      0,
+      { id: 'req-1', managerId: 'mgr-ignored-for-static' },
+    )
+    expect(out).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'u1',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', stepName: 'LM' },
+      },
+      {
+        assignmentType: 'user',
+        assigneeId: 'u2',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', stepName: 'LM' },
+      },
+      {
+        assignmentType: 'role',
+        assigneeId: 'r1',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', stepName: 'LM' },
+      },
+    ])
+  })
+})
+
+describe('S7-2 buildAttendanceApprovalInstancePayload — freeze into requesterSnapshot', () => {
+  it('legacy static: snapshot is still {id, name} only when orgRelations is empty', () => {
+    const payload = buildAttendanceApprovalInstancePayload({
+      approvalId: 'apv_1',
+      requestId: '00000000-0000-4000-8000-000000000001',
+      orgId: 'org-1',
+      userId: 'req-1',
+      requesterName: 'Alice',
+      draft: { requestType: 'leave', workDate: '2026-07-01', metadata: { approvalFlow: { steps: [] } } },
+    })
+    expect(payload.requesterSnapshot).toEqual({ id: 'req-1', name: 'Alice' })
+  })
+
+  it('freezes managerId when orgRelations carries it', () => {
+    const payload = buildAttendanceApprovalInstancePayload({
+      approvalId: 'apv_1',
+      requestId: '00000000-0000-4000-8000-000000000002',
+      orgId: 'org-1',
+      userId: 'req-1',
+      requesterName: 'Alice',
+      draft: {
+        requestType: 'leave',
+        workDate: '2026-07-01',
+        metadata: { approvalFlow: { steps: [{ kind: 'direct_manager' }] } },
+      },
+      orgRelations: { managerId: 'mgr-1' },
+    })
+    expect(payload.requesterSnapshot).toEqual({ id: 'req-1', name: 'Alice', managerId: 'mgr-1' })
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-approval-resolver-port-scoping.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-resolver-port-scoping.test.ts
@@ -21,7 +21,7 @@ function contextFor(name: string): PluginContext {
 }
 
 describe('S7-2 precursor — approvalAssigneeResolver port is scoped to plugin-attendance', () => {
-  it('plugin-attendance receives the port (positive control, host-resolved max present)', () => {
+  it('plugin-attendance receives the port (positive control, host-resolved max present, direct_manager implemented)', () => {
     const services = contextFor('plugin-attendance').services as {
       approvalAssigneeResolver?: { maxManagerChainLevels: number; implementedKinds: readonly string[] }
     }
@@ -29,6 +29,11 @@ describe('S7-2 precursor — approvalAssigneeResolver port is scoped to plugin-a
     expect(typeof services.approvalAssigneeResolver?.maxManagerChainLevels).toBe('number')
     expect(services.approvalAssigneeResolver?.maxManagerChainLevels).toBeGreaterThanOrEqual(1)
     expect(Array.isArray(services.approvalAssigneeResolver?.implementedKinds)).toBe(true)
+    // S7-2: direct_manager is the only implemented kind; dept_head / manager_at_level stay out.
+    expect(services.approvalAssigneeResolver?.implementedKinds).toContain('direct_manager')
+    expect(services.approvalAssigneeResolver?.implementedKinds).not.toContain('dept_head')
+    expect(services.approvalAssigneeResolver?.implementedKinds).not.toContain('manager_at_level')
+    expect(services.approvalAssigneeResolver?.implementedKinds).not.toContain('continuous_managers')
   })
 
   it('a non-attendance plugin does NOT receive the port', () => {

--- a/packages/core-backend/tests/unit/attendance-approval-step-contract-s7-1.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-step-contract-s7-1.test.ts
@@ -5,8 +5,9 @@ import { afterEach, describe, expect, it } from 'vitest'
 // coverage for the DISCRIMINATED-UNION step contract and the RUNTIME fail-closed gate. Every rejection
 // carries a DISTINCT HttpError code, so these tests double as mutation canaries — removing any single
 // guard changes (or removes) the specific code its leg asserts, reddening exactly that leg rather than
-// being masked by a later 422. The port is faked (core-backend is the PROVIDER in prod); at S7-1
-// `implementedKinds` is empty so every well-formed dynamic step is unavailable — correct and safe.
+// being masked by a later 422. The port is faked (core-backend is the PROVIDER in prod). S7-1 cases
+// below default `implementedKinds: []` so well-formed dynamic steps hit UNAVAILABLE; S7-2 unit cases
+// override with `direct_manager` where they assert the implemented path.
 
 const require = createRequire(import.meta.url)
 const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
@@ -303,9 +304,16 @@ describe('S7-1 assertDynamicFlowStepsRuntimeAvailable — §4.1 runtime fail-clo
   })
 })
 
-describe('S7-1 buildAttendanceApprovalAssignments — dynamic step never reaches the admin fallback', () => {
-  it('a dynamic current step throws APPROVAL_STEP_DYNAMIC_UNGATED (defense-in-depth, distinct from the gates)', () => {
+describe('S7-1/S7-2 buildAttendanceApprovalAssignments — dynamic step never reaches the admin fallback', () => {
+  // S7-2: direct_manager is implemented — missing/empty/self snapshot → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED
+  // (block-with-error, §4). Other kinds still hit the S7-1 UNGATED defense-in-depth arm.
+  it('direct_manager without frozen managerId throws APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (never admin fallback)', () => {
     expect(httpCode(() => buildAttendanceApprovalAssignments([{ kind: 'direct_manager' }], 0)))
+      .toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('an unimplemented dynamic kind (dept_head) still throws APPROVAL_STEP_DYNAMIC_UNGATED', () => {
+    expect(httpCode(() => buildAttendanceApprovalAssignments([{ kind: 'dept_head' }], 0)))
       .toEqual({ status: 422, code: 'APPROVAL_STEP_DYNAMIC_UNGATED' })
   })
 
@@ -317,3 +325,27 @@ describe('S7-1 buildAttendanceApprovalAssignments — dynamic step never reaches
     ])
   })
 })
+
+describe('S7-1 F4 NIT — non-string kind reaches DISTINCT 422 (not a silent static step)', () => {
+  it('kind: 123 (number) → APPROVAL_STEP_KIND_INVALID', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: 123 }], allImplementedContext())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_INVALID' })
+  })
+
+  it('kind: null → APPROVAL_STEP_KIND_INVALID', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: null }], allImplementedContext())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_INVALID' })
+  })
+
+  it('kind: true (boolean) → APPROVAL_STEP_KIND_INVALID', () => {
+    setFlag(true)
+    expect(httpCode(() => assertApprovalStepsContract([{ kind: true }], allImplementedContext())))
+      .toEqual({ status: 422, code: 'APPROVAL_STEP_KIND_INVALID' })
+  })
+})
+
+function allImplementedContext() {
+  return makeContext({ implementedKinds: ['direct_manager', 'dept_head', 'manager_at_level'] })
+}

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -301,6 +301,10 @@ export default defineConfig({
       // S7-1 real-DB: DATABASE_URL-gated describeIfDatabase, excluded from the no-DB default job so it
       // cannot skip-green, and wired as a WHOLE FILE into `Run attendance integration tests` below.
       'tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts',
+      // S7-2 direct_manager real-DB: freeze + assignment + org-anchor + authz + flag-off. DATABASE_URL-
+      // gated describeIfDatabase; excluded here so the no-DB job cannot skip-green it; wired whole-file
+      // into the attendance real-DB step in plugin-tests.yml.
+      'tests/integration/attendance-approval-direct-manager-s7-2.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -152,8 +152,8 @@ function getApprovalStepKind(step) {
 // Static (kind-less) steps return early: their legacy tolerance (unmodeled keys stripped by zod, A1
 // round-trip) is deliberately unchanged. The level UPPER bound uses the HOST-resolved MAX
 // (context.services.approvalAssigneeResolver.maxManagerChainLevels), never a plugin-parsed env — one
-// source, two surfaces, no drift. At S7-1 `implementedKinds` is empty, so every well-formed dynamic
-// step lands on (5) — correct and safe.
+// source, two surfaces, no drift. S7-2 populates `implementedKinds: ['direct_manager']` only —
+// other well-formed dynamic kinds still land on (5) until S7-3/S7-4 wire them.
 function assertApprovalStepsContract(steps, context) {
   if (!Array.isArray(steps)) return
   const port = context && context.services ? context.services.approvalAssigneeResolver : undefined
@@ -238,7 +238,7 @@ function assertApprovalStepsContract(steps, context) {
 // S7-1 §4.1 RUNTIME fail-closed gate. Given NORMALIZED flow steps (post-normalizeApprovalSteps, which
 // preserves a dynamic step's `kind`), throw HttpError(422) if a dynamic step is encountered while the
 // trigger set holds: flag OFF, OR the context.services resolver port is absent, OR the kind is not
-// resolver-implemented (S7-1: none are). A flow with NO dynamic step is a no-op (byte-identical legacy).
+// resolver-implemented (S7-2: only `direct_manager`). A flow with NO dynamic step is a no-op (byte-identical legacy).
 //   • request-create: pass no `onlyStepIndex` → WHOLE-flow scan, so a later dynamic step cannot start a
 //     flow and then strand mid-flight.
 //   • step-advance:   pass `onlyStepIndex = nextStepIndex` → check just the step about to become active.
@@ -20717,29 +20717,81 @@ function buildAttendanceApprovalNodeKey(stepIndex) {
   return `attendance_request_step_${Math.max(0, Number(stepIndex ?? 0))}`
 }
 
-function buildAttendanceApprovalAssignments(flowSteps, stepIndex = 0) {
+// S7-2: does the (normalized) flow carry a direct_manager step? Used to decide whether to call the
+// org-scoped resolver port once at request-create for freeze (§3.4). Other dynamic kinds (S7-3/4)
+// will extend this as they land.
+function flowStepsNeedDirectManagerFreeze(flowSteps) {
+  const steps = normalizeApprovalSteps(flowSteps)
+  return steps.some((step) => getApprovalStepKind(step) === 'direct_manager')
+}
+
+// S7-2 §3.4 CREATE-TIME freeze: call the host-injected org-scoped port ONCE for a flow that contains
+// `direct_manager`, and return `{ managerId }` on success. Never called at step-advance.
+//
+// Whole-flow posture (§4 block-with-error + zero-persistence): if ANY step is direct_manager, an
+// unresolved / empty / self-resolving result MUST throw 422 APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED
+// BEFORE any request/instance/assignment write — including multi-step flows whose step 0 is static.
+// Deferring the block to step-advance would let create persist rows that can never complete.
+// Static-only flows remain a no-op (return {}). Port missing / unimplemented / throw still map to
+// APPROVAL_STEP_KIND_UNAVAILABLE (§4.1 resolver-unavailable), never legacy admin fallback.
+async function resolveAttendanceDirectManagerFreeze({ orgId, userId, flowSteps, context }) {
+  if (!flowStepsNeedDirectManagerFreeze(flowSteps)) return {}
+  const port = context && context.services ? context.services.approvalAssigneeResolver : undefined
+  if (!port || typeof port.resolve !== 'function') {
+    throw new HttpError(
+      422,
+      'APPROVAL_STEP_KIND_UNAVAILABLE',
+      '动态审批人类型 "direct_manager" 无法解析(resolver 端口缺失)——请求已阻断(fail-closed)'
+    )
+  }
+  let result
+  try {
+    result = await port.resolve(String(orgId ?? ''), {
+      kind: 'direct_manager',
+      requesterUserId: String(userId ?? ''),
+    })
+  } catch (err) {
+    if (err instanceof HttpError) throw err
+    throw new HttpError(
+      422,
+      'APPROVAL_STEP_KIND_UNAVAILABLE',
+      '动态审批人类型 "direct_manager" 无法解析(resolver 调用失败)——请求已阻断(fail-closed)'
+    )
+  }
+  if (result && result.status === 'unimplemented') {
+    throw new HttpError(
+      422,
+      'APPROVAL_STEP_KIND_UNAVAILABLE',
+      '动态审批人类型 "direct_manager" 当前不可用(能力未启用或无对应 resolver)'
+    )
+  }
+  if (result && result.status === 'resolved' && Array.isArray(result.assignees)) {
+    const hit = result.assignees.find(
+      (a) => a && a.assignmentType === 'user' && typeof a.assigneeId === 'string' && a.assigneeId.trim()
+    )
+    if (hit) {
+      const managerId = hit.assigneeId.trim()
+      // Defense-in-depth self-exclusion (port also excludes); self is unresolvable, not freezable.
+      if (managerId && managerId !== String(userId ?? '').trim()) {
+        return { managerId }
+      }
+    }
+  }
+  // unresolved / empty / self — hard block at create (whole-flow), never empty freeze + later strand.
+  throw new HttpError(
+    422,
+    'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED',
+    '动态审批人类型 "direct_manager" 无法解析(无关联上级、上级未绑定本地用户或解析到本人)——请求已阻断(fail-closed)，不得回退到管理员兜底队列'
+  )
+}
+
+function buildAttendanceApprovalAssignments(flowSteps, stepIndex = 0, requesterSnapshot = null) {
   const steps = normalizeApprovalSteps(flowSteps)
   const index = steps.length > 0
     ? Math.min(Math.max(Number.isFinite(Number(stepIndex)) ? Number(stepIndex) : 0, 0), steps.length - 1)
     : 0
   const currentStep = steps[index]
-  // S7-1 §4.1 defense-in-depth: a DYNAMIC-kind step must NEVER fall through to the legacy admin-queue
-  // fallback below (that fallback is reserved for LEGACY static steps with empty approver arrays). The
-  // runtime gates (request-create whole-flow scan + step-advance) block a dynamic step before this
-  // function is reached; arriving here with a dynamic current step means a gate was bypassed — fail
-  // closed with an explicit error instead of silently admin-routing the resolved-less step.
   const dynamicKind = getApprovalStepKind(currentStep)
-  if (dynamicKind) {
-    // DISTINCT code from the §4.1 gates' APPROVAL_STEP_KIND_UNAVAILABLE: reaching here means a runtime
-    // gate was BYPASSED (a "should never happen" internal invariant), not the normal feature-off /
-    // port-missing path — so removing a gate surfaces this alarming code instead of being masked by the
-    // gates' own code (which is what makes each gate independently mutation-provable).
-    throw new HttpError(
-      422,
-      'APPROVAL_STEP_DYNAMIC_UNGATED',
-      `动态审批人类型 "${dynamicKind}" 未经运行时门控即到达指派构建(fail-closed)——不得回退到管理员兜底队列`
-    )
-  }
   const nodeKey = buildAttendanceApprovalNodeKey(index)
   const assignments = []
   const seen = new Set()
@@ -20757,6 +20809,40 @@ function buildAttendanceApprovalAssignments(flowSteps, stepIndex = 0) {
       nodeKey,
       metadata,
     })
+  }
+
+  // S7-2: direct_manager reads ONLY the creation-frozen requesterSnapshot.managerId (§3.4) — never a
+  // live directory re-query, never the host port again. Unavailable / unlinked / self / empty ⇒
+  // explicit 422 block-with-error (§4); NEVER the legacy admin/source_queue fallback.
+  if (dynamicKind === 'direct_manager') {
+    const snap = requesterSnapshot && typeof requesterSnapshot === 'object' ? requesterSnapshot : null
+    const managerId = snap && typeof snap.managerId === 'string' ? snap.managerId.trim() : ''
+    const requesterId = snap && typeof snap.id === 'string' ? snap.id.trim() : ''
+    if (managerId && managerId !== requesterId) {
+      pushAssignment('user', managerId, {
+        source: 'attendance',
+        kind: 'direct_manager',
+        stepName: currentStep?.name ?? null,
+        resolvedFrom: { kind: 'direct_manager' },
+      })
+      return assignments
+    }
+    throw new HttpError(
+      422,
+      'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED',
+      '动态审批人类型 "direct_manager" 无法解析(无关联上级、上级未绑定本地用户或解析到本人)——请求已阻断(fail-closed)，不得回退到管理员兜底队列'
+    )
+  }
+
+  // S7-1 §4.1 defense-in-depth: any OTHER dynamic kind must NEVER fall through to the legacy
+  // admin-queue fallback (that fallback is reserved for LEGACY static steps with empty approver
+  // arrays). S7-3/S7-4 will replace this arm per-kind; until then, fail closed with a distinct code.
+  if (dynamicKind) {
+    throw new HttpError(
+      422,
+      'APPROVAL_STEP_DYNAMIC_UNGATED',
+      `动态审批人类型 "${dynamicKind}" 未经运行时门控即到达指派构建(fail-closed)——不得回退到管理员兜底队列`
+    )
   }
 
   if (currentStep) {
@@ -20778,7 +20864,15 @@ function buildAttendanceApprovalAssignments(flowSteps, stepIndex = 0) {
   return assignments
 }
 
-function buildAttendanceApprovalInstancePayload({ approvalId, requestId, orgId, userId, requesterName, draft }) {
+function buildAttendanceApprovalInstancePayload({
+  approvalId,
+  requestId,
+  orgId,
+  userId,
+  requesterName,
+  draft,
+  orgRelations = null,
+}) {
   const requestType = draft?.requestType
   const requestLabel = attendanceRequestTypeLabel(requestType)
   const workDate = draft?.workDate ?? null
@@ -20797,6 +20891,14 @@ function buildAttendanceApprovalInstancePayload({ approvalId, requestId, orgId, 
     minutes: draft?.metadata?.minutes ?? null,
   }
 
+  // S7-2 §3.4: freeze create-time org relations (managerId today; deptHeadId/managerChainIds in S7-3/4)
+  // into the requester snapshot. Omitted fields stay omitted — never write null placeholders that would
+  // change the legacy {id,name}-only snapshot shape for static-only flows.
+  const frozenManagerId =
+    orgRelations && typeof orgRelations.managerId === 'string' && orgRelations.managerId.trim()
+      ? orgRelations.managerId.trim()
+      : null
+
   return {
     id: approvalId,
     status: 'pending',
@@ -20808,6 +20910,7 @@ function buildAttendanceApprovalInstancePayload({ approvalId, requestId, orgId, 
     requesterSnapshot: {
       id: userId,
       name: requesterName || userId,
+      ...(frozenManagerId ? { managerId: frozenManagerId } : {}),
     },
     subjectSnapshot: {
       type: 'attendance_request',
@@ -21316,6 +21419,9 @@ module.exports = {
     ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV,
     ATTENDANCE_DYNAMIC_ASSIGNEE_KINDS,
     ATTENDANCE_MANAGER_AT_LEVEL_KIND,
+    // S7-2 create-time freeze seam (pure enough for unit tests with a faked port).
+    resolveAttendanceDirectManagerFreeze,
+    flowStepsNeedDirectManagerFreeze,
   },
 
   async activate(context) {
@@ -24977,12 +25083,14 @@ module.exports = {
     // assertApprovalStepsContract in the create/update handlers so each violation gets a distinct 422
     // code (not a generic 400 VALIDATION_ERROR). `level` is accepted as an unconstrained number here so
     // a non-integer / out-of-range value reaches the contract validator's APPROVAL_STEP_LEVEL_INVALID
-    // arm rather than a zod 400. NOT a blanket `.passthrough()` — only the two modeled union fields.
+    // arm rather than a zod 400. `kind` is z.unknown() (S7-1 F4 NIT folded in S7-2): a non-string kind
+    // (number/boolean/object/null) must reach APPROVAL_STEP_KIND_INVALID (422), not a generic zod 400.
+    // NOT a blanket `.passthrough()` — only the two modeled union fields.
     const approvalStepSchema = z.object({
       name: z.string().optional(),
       approverUserIds: z.array(z.string()).optional(),
       approverRoleIds: z.array(z.string()).optional(),
-      kind: z.string().optional(),
+      kind: z.unknown().optional(),
       level: z.number().optional(),
     })
     const approvalFlowCreateSchema = z.object({
@@ -25217,14 +25325,20 @@ module.exports = {
             }
             const requestId = randomUUID()
             const approvalId = `apv_${randomUUID()}`
-            const approvalPayload = buildAttendanceApprovalInstancePayload({
-              approvalId, requestId, orgId, userId, requesterName: getUserLabel(req, userId), draft,
-            })
             // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation: a dynamic-kind step
             // anywhere in the flow blocks request-create (flag OFF / port missing / kind unimplemented),
             // so a later dynamic step cannot start a flow and strand it mid-flight.
             assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata.approvalFlow.steps), context)
-            const approvalAssignments = buildAttendanceApprovalAssignments(draft.metadata.approvalFlow.steps, 0)
+            // S7-2 §3.4: freeze direct_manager once at create (org-scoped port); assignment build reads only the snapshot.
+            const orgRelations = await resolveAttendanceDirectManagerFreeze({
+              orgId, userId, flowSteps: draft.metadata.approvalFlow.steps, context,
+            })
+            const approvalPayload = buildAttendanceApprovalInstancePayload({
+              approvalId, requestId, orgId, userId, requesterName: getUserLabel(req, userId), draft, orgRelations,
+            })
+            const approvalAssignments = buildAttendanceApprovalAssignments(
+              draft.metadata.approvalFlow.steps, 0, approvalPayload.requesterSnapshot
+            )
             try {
               const request = await db.transaction(async (trx) => {
                 await acquireAttendanceRequestLock(trx, orgId, userId, workDate, 'outdoor_punch')
@@ -27781,6 +27895,12 @@ module.exports = {
 
         const requestId = randomUUID()
         const approvalId = `apv_${randomUUID()}`
+        // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
+        assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
+        // S7-2 §3.4: freeze direct_manager once at create; assignment build reads only the snapshot.
+        const orgRelations = await resolveAttendanceDirectManagerFreeze({
+          orgId, userId, flowSteps: draft.metadata?.approvalFlow?.steps, context,
+        })
         const approvalPayload = buildAttendanceApprovalInstancePayload({
           approvalId,
           requestId,
@@ -27788,10 +27908,11 @@ module.exports = {
           userId,
           requesterName: getUserLabel(req, userId),
           draft,
+          orgRelations,
         })
-        // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
-        assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
-        const approvalAssignments = buildAttendanceApprovalAssignments(draft.metadata?.approvalFlow?.steps, 0)
+        const approvalAssignments = buildAttendanceApprovalAssignments(
+          draft.metadata?.approvalFlow?.steps, 0, approvalPayload.requesterSnapshot
+        )
 
         try {
           const request = await db.transaction(async (trx) => {
@@ -28110,6 +28231,12 @@ module.exports = {
               reason: input.reason,
               metadata,
             }
+            // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
+            assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
+            // S7-2 §3.4: freeze direct_manager once at create; assignment build reads only the snapshot.
+            const orgRelations = await resolveAttendanceDirectManagerFreeze({
+              orgId, userId: input.userId, flowSteps: draft.metadata?.approvalFlow?.steps, context,
+            })
             const approvalPayload = buildAttendanceApprovalInstancePayload({
               approvalId,
               requestId,
@@ -28117,10 +28244,11 @@ module.exports = {
               userId: input.userId,
               requesterName: getUserLabel(req, input.userId),
               draft,
+              orgRelations,
             })
-            // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
-            assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
-            const approvalAssignments = buildAttendanceApprovalAssignments(draft.metadata?.approvalFlow?.steps, 0)
+            const approvalAssignments = buildAttendanceApprovalAssignments(
+              draft.metadata?.approvalFlow?.steps, 0, approvalPayload.requesterSnapshot
+            )
             await upsertAttendanceApprovalInstance(trx, approvalPayload)
             await replaceAttendanceApprovalAssignments(trx, approvalId, approvalAssignments)
 
@@ -28527,6 +28655,12 @@ module.exports = {
               reason,
               metadata,
             }
+            // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
+            assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
+            // S7-2 §3.4: freeze direct_manager once at create; assignment build reads only the snapshot.
+            const orgRelations = await resolveAttendanceDirectManagerFreeze({
+              orgId, userId: requesterSource.userId, flowSteps: draft.metadata?.approvalFlow?.steps, context,
+            })
             const approvalPayload = buildAttendanceApprovalInstancePayload({
               approvalId,
               requestId,
@@ -28534,10 +28668,11 @@ module.exports = {
               userId: requesterSource.userId,
               requesterName: getUserLabel(req, requesterSource.userId),
               draft,
+              orgRelations,
             })
-            // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
-            assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
-            const approvalAssignments = buildAttendanceApprovalAssignments(draft.metadata?.approvalFlow?.steps, 0)
+            const approvalAssignments = buildAttendanceApprovalAssignments(
+              draft.metadata?.approvalFlow?.steps, 0, approvalPayload.requesterSnapshot
+            )
             await upsertAttendanceApprovalInstance(trx, approvalPayload)
             await replaceAttendanceApprovalAssignments(trx, approvalId, approvalAssignments)
 
@@ -29033,6 +29168,15 @@ module.exports = {
             }
 
             const approvalId = existingRequest.approval_instance_id || `apv_${randomUUID()}`
+            // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
+            assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
+            // S7-2 §3.4: freeze direct_manager once at create; assignment build reads only the snapshot.
+            const orgRelations = await resolveAttendanceDirectManagerFreeze({
+              orgId: existingRequest.org_id ?? DEFAULT_ORG_ID,
+              userId: existingRequest.user_id,
+              flowSteps: draft.metadata?.approvalFlow?.steps,
+              context,
+            })
             const approvalPayload = buildAttendanceApprovalInstancePayload({
               approvalId,
               requestId,
@@ -29040,10 +29184,11 @@ module.exports = {
               userId: existingRequest.user_id,
               requesterName: existingRequest.user_id,
               draft,
+              orgRelations,
             })
-            // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
-            assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
-            const approvalAssignments = buildAttendanceApprovalAssignments(draft.metadata?.approvalFlow?.steps, 0)
+            const approvalAssignments = buildAttendanceApprovalAssignments(
+              draft.metadata?.approvalFlow?.steps, 0, approvalPayload.requesterSnapshot
+            )
             await upsertAttendanceApprovalInstance(trx, approvalPayload)
             await replaceAttendanceApprovalAssignments(trx, approvalId, approvalAssignments)
 
@@ -29246,6 +29391,15 @@ module.exports = {
           if (!isFinalApproval) {
             assertDynamicFlowStepsRuntimeAvailable(flowSteps, context, { onlyStepIndex: nextStepIndex })
           }
+          // S7-2 §3.4: step-advance reads the FROZEN requester_snapshot only — never re-calls the
+          // org-scoped resolver port / directory. Build next-step assignments BEFORE the instance
+          // UPDATE so an unresolved dynamic step throws inside the txn and rolls back unchanged
+          // (no advanced current_step, no swapped assignments, no appended record).
+          const frozenRequesterSnapshot = normalizeMetadata(approval.requester_snapshot)
+          const nextStepAssignments = isFinalApproval
+            ? null
+            : buildAttendanceApprovalAssignments(flowSteps, nextStepIndex, frozenRequesterSnapshot)
+
           await trx.query(
             `UPDATE approval_instances
              SET status = $1,
@@ -29263,7 +29417,7 @@ module.exports = {
             await replaceAttendanceApprovalAssignments(
               trx,
               approvalId,
-              buildAttendanceApprovalAssignments(flowSteps, nextStepIndex)
+              nextStepAssignments
             )
           }
 
@@ -30615,17 +30769,15 @@ module.exports = {
       '/api/attendance/approval-flows',
       withPermission('attendance:admin', async (req, res) => {
         const rawPayload = normalizeApprovalFlowPayload(req.body)
+        // S7-1 §7 authoring gate FIRST (before zod): a non-string `kind` (S7-1 F4 NIT) and every other
+        // shape violation must surface as a DISTINCT 422 contract code, never a generic zod 400.
+        // Zod still runs after for the static field types (name/requestType/approver arrays).
+        assertApprovalStepsContract(rawPayload.steps, context)
         const parsed = approvalFlowCreateSchema.safeParse(rawPayload)
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
           return
         }
-
-        // S7-1 §7 authoring gate — enforce the discriminated-union step contract on the PRE-zod raw
-        // steps (zod strips unmodeled keys, so only the raw shape can prove a dynamic step's closed
-        // union). Throws HttpError(422, <distinct code>) → caught by withAnyPermission's wrapper.
-        // A malformed/unavailable dynamic kind can never round-trip inert.
-        assertApprovalStepsContract(rawPayload.steps, context)
 
         const orgId = getOrgId(req)
         const steps = normalizeApprovalSteps(parsed.data.steps)
@@ -30675,15 +30827,13 @@ module.exports = {
       '/api/attendance/approval-flows/:id',
       withPermission('attendance:admin', async (req, res) => {
         const rawPayload = normalizeApprovalFlowPayload(req.body ?? {})
+        // S7-1 §7 authoring gate FIRST (before zod) — same posture as create (non-string kind → 422).
+        assertApprovalStepsContract(rawPayload.steps, context)
         const parsed = approvalFlowUpdateSchema.safeParse(rawPayload)
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
           return
         }
-
-        // S7-1 §7 authoring gate on update — same discriminated-union contract as create, applied to the
-        // PRE-zod raw steps when the update supplies them (undefined ⇒ no-op, existing steps untouched).
-        assertApprovalStepsContract(rawPayload.steps, context)
 
         const orgId = getOrgId(req)
         const flowId = normalizeUuidString(req.params.id)


### PR DESCRIPTION
## Summary

- implement Attendance S7-2 `direct_manager` through the narrow `approvalAssigneeResolver` host port
- anchor directory resolution to the attendance `orgId` before requester-account tie-breaking
- freeze `managerId` into `requester_snapshot` at request creation and use only that snapshot during step advancement
- fail closed with 422 and zero persistence when the manager is missing, unlinked, self-resolving, the flag is off, or the resolver is unavailable
- preserve static-flow behavior and keep `dept_head`, `manager_at_level`, and `continuous_managers` out of this slice

## Dependency and rebase

The precursor #4453 merged to `main` as `761bf3597`. This branch was then rebased onto that `main` head by replaying only the S7-2 implementation commit.

- old implementation head: `203632083`
- rebased implementation head: `32abf0cc0`
- stable patch-id before/after: `9ebef5dfac75ff7933ec17d6b4cfc8fcb7ab0bfa`
- `git range-diff`: one-to-one equivalent

Design basis: `docs/development/attendance-approval-s7-resolver-direct-manager-dept-head-multilevel-design-lock-20260716.md`, especially S7-2, section 3.3, section 3.4, section 4, and the S7-0 authorization completion bar.

## Verification

Re-run on the rebased tree:

- focused unit suites: 4 files, 80 tests passed
- S7-1 + S7-2 + authorization real-DB suites: 3 files, 56 tests passed
- `pnpm --filter @metasheet/core-backend type-check`: passed
- `git diff --check`: passed
- independent mutation: removing the host `orgId` anchor made the two-org/one-local-user real-DB test select the foreign manager and fail; restoring it made the same test pass

The new real-DB suite is excluded from the no-DB Vitest job and explicitly wired into the attendance integration step in `plugin-tests.yml`, so it cannot skip green.

## Runtime posture

`ATTENDANCE_APPROVAL_DYNAMIC_ASSIGNEE_SOURCES_ENABLED` remains default off. Enabling it is a separate operator opt-in after the full S7 sequence and verification record; this PR does not change deployment configuration.

## Review

Implementation was delegated to Grok, then independently reviewed and rerun by Codex. Verdict: APPROVE, 0 P1 / 0 P2.
