### PR TITLE
feat(multitable): W0 L6-b exact-anchor authority on current main

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -150,6 +150,11 @@ jobs:
       - name: Global History flag manifest contract (R12-C)
         run: node --test scripts/ops/global-history-flag-manifest.test.mjs scripts/ops/multitable-global-history-flag-status.test.mjs
 
+      # W0 L6-b CI two-point wiring contract (no DB): the exact-anchor authority real-DB suite must
+      # stay excluded from the no-DB Vitest lane and named in the multitable real-DB whole-file step.
+      - name: W0 L6-b exact-anchor CI wiring contract
+        run: node --test scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
+
       # PB4-2 CI two-point wiring contract (no DB): the archive-read-only two-connection suite must
       # stay wired into BOTH vitest.config.ts (exclude) AND plugin-tests.yml (directory real-DB step).
       # Dropping either point makes the whole barrier suite silently never run while CI stays green.

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -513,6 +513,7 @@ jobs:
             tests/integration/multitable-history-contiguity-strict-seq-realdb.test.ts \
             tests/integration/multitable-history-trust-checkpoint-realdb.test.ts \
             tests/integration/multitable-l5wire-checkpoint-activation-realdb.test.ts \
+            tests/integration/multitable-exact-anchor-recovery-realdb.test.ts \
             tests/integration/multitable-d1c-form-submit-revision-realdb.test.ts \
             tests/integration/multitable-d1c-plugin-revision-realdb.test.ts \
             tests/integration/multitable-d1c-automation-revision-realdb.test.ts \

--- a/packages/core-backend/src/multitable/exact-anchor-recovery.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery.ts
@@ -1,0 +1,319 @@
+import type { QueryFn } from './permission-service'
+import { assertSeqString, selectCheckpointByAnchorSeq } from './history-trust-checkpoint'
+import { reconstructRecordsAtSeq, type RecordStateAtT } from './record-reconstructor'
+import {
+  hashAnchorRecoveryScope,
+  hashRecoveryAuthorizationScope,
+  mintExactAnchorRecoveryIdentity,
+  verifyExactAnchorRecoveryIdentity,
+  type ExactAnchorRecoveryMode,
+} from './restore-preview-identity'
+
+/**
+ * W0-1 v3.7 Lane L6-b — the EXACT-ANCHOR recovery resolution + execute authority.
+ *
+ * Design authority: `…v37-exact-anchor-trust-design-lock-20260715.md` (#4331) §1.3 (exact recovery anchor
+ * resolution), §0/P2-B (why a wall-clock `T` / a mutable `MAX(seq)` is NOT a trustworthy anchor), §9 item 6
+ * (sealed operation ledger; server-minted, exact anchorSeq frozen in a signed identity). PROPOSED design.
+ *
+ * THE PROTOCOL (§1.3):
+ *   PREVIEW  `resolveExactAnchor`:
+ *     opaque `anchorOperationId` (the sealed operation endpoint id, L6-a — NEVER a wall-clock `T`, NEVER a
+ *     client-supplied seq) OR a History-Center `historyBatchId` resolved server-side to the batch's sealed
+ *     terminal operation (owner ruling ⑤; unsealed/legacy ⇒ refused, ruling ⑧) → the immutable endpoint row
+ *     in `meta_record_history_operations` → `anchorSeq = endpoint_seq` (exact bigint string) → the active
+ *     trust checkpoint (L5) whose `trusted_since_seq <= anchorSeq` → FULL-READ adjudication (P1-2) →
+ *     reconstruct the record set at `anchorSeq` (the causal `reconstructRecordsAtSeq`) → FREEZE
+ *     {sheetId, anchorOperationId, anchorSeq, checkpointId, actorId, mode, authorizedScopeHash, scopeHash}
+ *     into an HS256-signed preview identity (`exact-anchor-recovery.ts` reuses the server token-signing helper
+ *     in `restore-preview-identity.ts` — no new crypto).
+ *   EXECUTE  `executeExactAnchorRecovery`:
+ *     verify the signed identity (signature + expiry + sheet/actor binding) → take the TOKEN-BOUND `anchorSeq`
+ *     → reconstruct at exactly that seq (never `MAX(seq)`) → re-hash the reconstructed set and reject on drift.
+ *     The token's `anchorSeq` is the sole recovery authority; the execute NEVER re-derives it.
+ *
+ * WALL-CLOCK REFUSAL (§1.3, values-free / no-oracle): a destructive-recovery request that carries a free
+ * wall-clock `T` instead of an `anchorBatchId` is REFUSED `exact-anchor-required` BEFORE any DB access — the
+ * refusal is identical whether the sheet/data exists or not, so it leaks nothing. Manual-datetime navigation of
+ * a read-only point-in-time VIEW still uses `T` (`reconstructRecordsAtT`, v3.7 §9.2) — that is display, not the
+ * destructive authority; only the destructive recovery authority is anchor-only.
+ *
+ * DRAFT / DEFAULT-OFF: this module is the recovery precheck/execute AUTHORITY, ready for the Revert/Reset routes
+ * to adopt, but it performs NO destructive write itself — the actual apply stays behind the existing default-OFF
+ * `MULTITABLE_ENABLE_SHEET_REVERT` / `MULTITABLE_ENABLE_PIT_RESET` flags. Resolving/verifying an anchor is a pure
+ * read; with every flag off nothing here is reached from a default-on path (flag-off parity: byte-identical).
+ */
+
+/** A recovery ANCHOR request. Discriminated so the wall-clock branch is refused by construction (§1.3). */
+export type RecoveryAnchorRequest =
+  /** the sealed operation endpoint id DIRECTLY (`meta_record_history_operations.operation_id`). */
+  | { kind: 'exact-anchor'; anchorOperationId: string }
+  /** a History-Center BATCH selection (the S1 user-action `batch_id`). The server resolves it to the batch's
+   *  sealed TERMINAL operation on this sheet — MAX `endpoint_seq` (owner ruling ⑤, 2026-07-16). A batch with
+   *  NO sealed operation (legacy / unsealed) is refused `exact-anchor-required`, NEVER given a wall-clock
+   *  fallback (ruling ⑧). */
+  | { kind: 'history-batch'; historyBatchId: string }
+  /** a free wall-clock `T` — REFUSED for destructive recovery (`exact-anchor-required`). */
+  | { kind: 'wall-clock'; asOf: string }
+
+export type ResolveAnchorRefusal =
+  /** the request carried a wall-clock `T` (refused, no DB access), OR a history-batch with no sealed terminal
+   *  operation (legacy/unsealed — ruling ⑧: uniform refusal, no wall-clock fallback, no existence oracle:
+   *  an unknown batch and an unsealed batch refuse identically). */
+  | 'exact-anchor-required'
+  /** `anchorOperationId` is not a well-formed sealed-operation endpoint id (uuid). */
+  | 'invalid-anchor'
+  /** no sealed operation endpoint exists for (sheet, anchorOperationId) — an unknown/forged anchor. */
+  | 'unknown-anchor'
+  /** no active/retained trust checkpoint covers the anchor (`trusted_since_seq <= anchorSeq`) — fail-closed. */
+  | 'no-covering-checkpoint'
+  /** the actor fails the v1 FULL-READ authorization (owner P1-2 — U-L8 gate shape): the whole surface is
+   *  refused BEFORE any anchor/batch resolution, so an unauthorized actor learns nothing (not even whether
+   *  the anchor exists). */
+  | 'forbidden'
+
+/**
+ * The kernel's REQUIRED authorization dependency (owner P1-2): evaluates whether the acting principal has
+ * FULL-TABLE READ on the sheet (the 4c-1 U-L8 gate — CONFIG-derived axes only, never a data probe; see
+ * `hasFullTableReadAccess` in the univer-meta route, which is the production evaluator and closes over the
+ * request/capability context the kernel cannot reach). The ADJUDICATION lives HERE in the kernel — the
+ * evaluator only answers the capability question; the kernel refuses `forbidden` on preview AND re-evaluates
+ * in-fence at the destructive apply. There is no default and no way to omit it: a caller must hand the kernel
+ * an evaluator to get a token at all.
+ */
+export type EvaluateRecoveryFullReadAccess = (query: QueryFn) => Promise<boolean>
+
+export interface ResolveAnchorSuccess {
+  ok: true
+  /** the HS256-signed preview identity — presented back at execute. */
+  token: string
+  /** the exact causal anchor (decimal bigint string) — the sealed operation's `endpoint_seq`. */
+  anchorSeq: string
+  /** the covering trust checkpoint id. */
+  checkpointId: string
+  /** the resolved sealed operation endpoint id (for a history-batch request: the batch's terminal operation). */
+  anchorOperationId: string
+  /** the recovery mode this preview (and its token) authorizes — bound into the identity (P1-1). */
+  mode: ExactAnchorRecoveryMode
+  /** order-invariant HMAC over the reconstructed set at the anchor (bound into the token). */
+  scopeHash: string
+  /** the reconstructed record set at the anchor (the preview the actor sees). */
+  stateMap: Map<string, RecordStateAtT>
+}
+export type ResolveAnchorResult = ResolveAnchorSuccess | { ok: false; reason: ResolveAnchorRefusal }
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Order-invariant array form of a reconstructed state map, for `hashAnchorRecoveryScope`. */
+export function scopeEntriesOf(stateMap: Map<string, RecordStateAtT>): Array<{ recordId: string; exists: boolean; version: number | null }> {
+  return [...stateMap.values()].map((s) => ({ recordId: s.recordId, exists: s.exists, version: s.version }))
+}
+
+const asRecord = (v: unknown): Record<string, unknown> =>
+  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {}
+
+/**
+ * F4 (pre-wiring gate list) — L5 BASELINE COMPOSITION, shared by PREVIEW and APPLY so the two sides are
+ * SYMMETRIC BY CONSTRUCTION: records absent from the replay map (their revisions predate the trust floor or
+ * were retention-pruned) come from the RESOLVED checkpoint's immutable `meta_history_baselines` rows — a
+ * non-trashed baseline row IS that record's at-anchor state; a trashed one means deleted-at-anchor. The
+ * replay map always wins (it is at-anchor-exact). Because BOTH the preview's `scopeHash` and the apply's
+ * in-fence re-hash are computed over this COMPOSED map, the actor previews EXACTLY the set the apply will
+ * plan over — a baseline-only record can no longer appear in the apply without having been shown at preview
+ * (what-you-see-is-what-applies). Baseline rows are immutable post-activation and the token binds
+ * `checkpointId` (re-resolved in-fence at apply), so composing does not weaken the drift tripwire.
+ */
+export async function composeBaselineOverlay(
+  query: QueryFn,
+  input: { sheetId: string; checkpointId: string; stateMap: Map<string, RecordStateAtT> },
+): Promise<Map<string, RecordStateAtT>> {
+  const baselineRes = await query(
+    'SELECT record_id, data, version, is_trashed FROM meta_history_baselines WHERE checkpoint_id = $1 AND sheet_id = $2',
+    [input.checkpointId, input.sheetId],
+  )
+  const composed = new Map<string, RecordStateAtT>(input.stateMap)
+  for (const raw of baselineRes.rows as Array<Record<string, unknown>>) {
+    const recordId = String(raw.record_id)
+    if (composed.has(recordId)) continue // replay map wins — it is at-anchor-exact
+    const trashed = raw.is_trashed === true
+    composed.set(recordId, {
+      recordId,
+      exists: !trashed,
+      data: trashed ? null : asRecord(raw.data),
+      version: typeof raw.version === 'number' && Number.isFinite(raw.version) ? raw.version : null,
+    })
+  }
+  return composed
+}
+
+/**
+ * PREVIEW: resolve an exact recovery anchor and mint the signed preview identity (§1.3). A wall-clock request is
+ * refused `exact-anchor-required` with NO DB access (values-free). The actor is then FULL-READ adjudicated
+ * (P1-2) BEFORE any anchor/batch resolution — an unauthorized actor learns nothing. An `anchorOperationId` that
+ * is not a uuid → `invalid-anchor`; one with no sealed endpoint → `unknown-anchor`; a history-batch with no
+ * sealed terminal operation → `exact-anchor-required` (ruling ⑧); an anchor with no covering trust checkpoint
+ * → `no-covering-checkpoint` (fail-closed — a recovery below every trust floor is untrustworthy). On success the
+ * anchorSeq comes from the IMMUTABLE endpoint row (`endpoint_seq`), never from a live `MAX(seq)`, and the token
+ * binds `mode` + `authorizedScopeHash` (P1-1/P1-2 — the destructive apply obeys the TOKEN, not its request).
+ */
+export async function resolveExactAnchor(
+  query: QueryFn,
+  input: {
+    sheetId: string
+    request: RecoveryAnchorRequest
+    actorId: string
+    /** the recovery mode this preview authorizes — frozen into the signed identity (P1-1). */
+    mode: ExactAnchorRecoveryMode
+    /** REQUIRED v1 full-read adjudication dependency (P1-2) — see `EvaluateRecoveryFullReadAccess`. */
+    evaluateFullReadAccess: EvaluateRecoveryFullReadAccess
+  },
+): Promise<ResolveAnchorResult> {
+  const { sheetId, request, actorId, mode, evaluateFullReadAccess } = input
+  // §1.3 wall-clock refusal — BEFORE any DB read (no-oracle: same refusal regardless of sheet/data existence).
+  if (request.kind === 'wall-clock') return { ok: false, reason: 'exact-anchor-required' }
+
+  // P1-2 FULL-READ gate — the FIRST DB-touching step: an actor without full-table read is refused the whole
+  // surface here, before the anchor/batch is even looked up (no anchor-existence oracle for the unauthorized).
+  if (!(await evaluateFullReadAccess(query))) return { ok: false, reason: 'forbidden' }
+
+  let anchorOperationId: string
+  let anchorSeq: string
+  if (request.kind === 'history-batch') {
+    // Ruling ⑤ resolver: the batch's sealed TERMINAL operation on THIS sheet = MAX endpoint_seq among the
+    // sealed operations whose events carry this batch_id. Presence of the endpoint row IS the seal (the
+    // ledger inserts the endpoint LAST, same-txn, DEFERRABLE-FK-validated). An unknown batch and a batch
+    // with only unsealed/legacy (NULL operation_id) events refuse IDENTICALLY (ruling ⑧, no oracle).
+    const historyBatchId = request.historyBatchId
+    if (typeof historyBatchId !== 'string' || !historyBatchId) return { ok: false, reason: 'exact-anchor-required' }
+    const terminalRes = await query(
+      `SELECT o.operation_id::text AS operation_id, o.endpoint_seq::text AS endpoint_seq
+       FROM meta_record_history_operations o
+       WHERE o.sheet_id = $1
+         AND o.operation_id IN (
+           SELECT r.operation_id FROM meta_record_revisions r
+           WHERE r.sheet_id = $1 AND r.batch_id = $2 AND r.operation_id IS NOT NULL
+         )
+       ORDER BY o.endpoint_seq DESC
+       LIMIT 1`,
+      [sheetId, historyBatchId],
+    )
+    const terminal = terminalRes.rows[0] as { operation_id?: unknown; endpoint_seq?: unknown } | undefined
+    if (!terminal || typeof terminal.operation_id !== 'string' || typeof terminal.endpoint_seq !== 'string') {
+      return { ok: false, reason: 'exact-anchor-required' }
+    }
+    anchorOperationId = terminal.operation_id
+    anchorSeq = terminal.endpoint_seq
+  } else {
+    const requested = request.anchorOperationId
+    if (typeof requested !== 'string' || !UUID_RE.test(requested)) return { ok: false, reason: 'invalid-anchor' }
+    // The sealed operation endpoint is the exact, externally-visible commit boundary (L6-a). anchorSeq is its
+    // FROZEN endpoint_seq — read as `::text` so it crosses the boundary as an exact bigint string.
+    const endpointRes = await query(
+      `SELECT endpoint_seq::text AS endpoint_seq
+       FROM meta_record_history_operations
+       WHERE sheet_id = $1 AND operation_id = $2::uuid`,
+      [sheetId, requested],
+    )
+    const endpoint = endpointRes.rows[0] as { endpoint_seq?: unknown } | undefined
+    if (!endpoint || typeof endpoint.endpoint_seq !== 'string') return { ok: false, reason: 'unknown-anchor' }
+    anchorOperationId = requested
+    anchorSeq = endpoint.endpoint_seq
+  }
+  assertSeqString(anchorSeq, 'resolveExactAnchor.endpoint_seq') // fail-closed; endpoint_seq is a DB bigint
+
+  // The active trust checkpoint covering the anchor (L5). No covering checkpoint ⇒ fail-closed (a recovery to an
+  // anchor below every trust floor is untrustworthy — v3.7 §3).
+  const checkpoint = await selectCheckpointByAnchorSeq(query, sheetId, anchorSeq)
+  if (!checkpoint) return { ok: false, reason: 'no-covering-checkpoint' }
+
+  // Reconstruct the record set at the exact anchor (causal, seq-based), COMPOSE the L5 baseline overlay
+  // (F4 — the preview must show exactly the set the apply will plan over), and bind the COMPOSED set into
+  // the token.
+  const replayMap = await reconstructRecordsAtSeq(query, sheetId, anchorSeq)
+  const stateMap = await composeBaselineOverlay(query, { sheetId, checkpointId: checkpoint.id, stateMap: replayMap })
+  const scopeHash = hashAnchorRecoveryScope(scopeEntriesOf(stateMap))
+  // W0-1 L8 preview-freshness binding: fingerprint the LIVE set {id, version} too (same order-invariant
+  // HMAC primitive, exists:true). The destructive apply re-hashes the live set IN-FENCE and refuses
+  // `preview-drift` when a concurrent write landed between preview and execute — the anchor-authority
+  // `scopeHash` alone cannot see that (the at-anchor reconstruction is immutable under append-only history).
+  const liveRes = await query('SELECT id, version FROM meta_records WHERE sheet_id = $1', [sheetId])
+  const liveSetHash = hashAnchorRecoveryScope(
+    (liveRes.rows as Array<{ id: unknown; version: unknown }>).map((r) => ({
+      recordId: String(r.id),
+      exists: true,
+      version: typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : Number(r.version) || 0,
+    })),
+  )
+  const token = mintExactAnchorRecoveryIdentity({
+    sheetId,
+    anchorOperationId,
+    anchorSeq,
+    checkpointId: checkpoint.id,
+    scopeHash,
+    liveSetHash,
+    actorId,
+    mode,
+    // P1-2: the authorization CONTRACT is signed in. The apply recomputes this from its OWN in-fence
+    // adjudication and compares — the mint here records which contract the preview was authorized under.
+    authorizedScopeHash: hashRecoveryAuthorizationScope({ sheetId, actorId }),
+  })
+  return { ok: true, token, anchorSeq, checkpointId: checkpoint.id, anchorOperationId, mode, scopeHash, stateMap }
+}
+
+export type ExecuteAnchorRefusal =
+  /** the signed identity failed verification (tampered/expired/wrong sheet or actor/malformed anchor). */
+  | 'identity-invalid'
+  /** the actor fails the FRESH full-read adjudication at execute time, or the token's `authorizedScopeHash`
+   *  does not match the recomputed v1 authorization basis (P1-2 — permission revoked since preview, or a
+   *  token minted under a different authorization contract). Values-free, one reason for both. */
+  | 'forbidden'
+  /** the reconstructed set at the token-bound anchorSeq no longer matches what the preview signed (data moved
+   *  since preview, OR — the load-bearing mutation surface — the execute recomputed the anchor as MAX(seq)). */
+  | 'scope-drift'
+
+export interface ExecuteAnchorSuccess {
+  ok: true
+  /** the TOKEN-BOUND anchor used to reconstruct (decimal bigint string) — never a recomputed MAX(seq). */
+  anchorSeq: string
+  checkpointId: string
+  /** the TOKEN-BOUND recovery mode (P1-1) — the apply obeys this, never a request-supplied mode. */
+  mode: ExactAnchorRecoveryMode
+  /** the reconstructed record set at the token-bound anchor — the exact plan a Revert/Reset apply consumes. */
+  stateMap: Map<string, RecordStateAtT>
+}
+export type ExecuteAnchorResult = ExecuteAnchorSuccess | { ok: false; reason: ExecuteAnchorRefusal }
+
+/**
+ * EXECUTE (the read/authority half — the destructive apply stays behind the default-OFF Revert/Reset flags).
+ * Verify the signed identity, then reconstruct at the TOKEN-BOUND `anchorSeq` and re-check the scope hash. The
+ * anchorSeq is taken verbatim from the verified token — the execute NEVER recomputes `MAX(seq)` as authority
+ * (that mutable value drifts the moment any write lands; §0/P2-B). A drift between the token's `scopeHash` and
+ * the live reconstruction → `scope-drift` (re-preview); this is exactly what reds if the execute is mutated to
+ * anchor on `MAX(seq)` instead of the frozen `anchorSeq`. `sheetId`/`actorId` are re-bound fresh from the
+ * request so a token can never be replayed onto another sheet or by another actor.
+ */
+export async function executeExactAnchorRecovery(
+  query: QueryFn,
+  input: { token: string; sheetId: string; actorId: string; evaluateFullReadAccess: EvaluateRecoveryFullReadAccess },
+): Promise<ExecuteAnchorResult> {
+  const verified = verifyExactAnchorRecoveryIdentity(input.token, { sheetId: input.sheetId, actorId: input.actorId })
+  if (!verified.valid || !verified.claims) return { ok: false, reason: 'identity-invalid' }
+  const { anchorSeq, checkpointId, scopeHash, mode, authorizedScopeHash } = verified.claims
+
+  // P1-2: FRESH full-read adjudication at execute time — permission revoked since preview ⇒ refused; and
+  // the token's authorization contract must MATCH this surface's recomputed v1 basis (the token's echo is
+  // never the authority). Both failure shapes collapse into one values-free `forbidden`.
+  if (!(await input.evaluateFullReadAccess(query))) return { ok: false, reason: 'forbidden' }
+  if (authorizedScopeHash !== hashRecoveryAuthorizationScope({ sheetId: input.sheetId, actorId: input.actorId })) {
+    return { ok: false, reason: 'forbidden' }
+  }
+
+  // Reconstruct at the TOKEN-BOUND anchorSeq — the sole authority. NOT MAX(seq), NOT the request — then
+  // compose the SAME baseline overlay the preview hashed (F4 symmetry; checkpointId is token-bound).
+  const replayMap = await reconstructRecordsAtSeq(query, input.sheetId, anchorSeq)
+  const stateMap = await composeBaselineOverlay(query, { sheetId: input.sheetId, checkpointId, stateMap: replayMap })
+  const liveScopeHash = hashAnchorRecoveryScope(scopeEntriesOf(stateMap))
+  if (liveScopeHash !== scopeHash) return { ok: false, reason: 'scope-drift' }
+
+  return { ok: true, anchorSeq, checkpointId, mode, stateMap }
+}

--- a/packages/core-backend/src/multitable/exact-anchor-recovery.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery.ts
@@ -122,7 +122,7 @@ const asRecord = (v: unknown): Record<string, unknown> =>
  * in-fence re-hash are computed over this COMPOSED map, the actor previews EXACTLY the set the apply will
  * plan over — a baseline-only record can no longer appear in the apply without having been shown at preview
  * (what-you-see-is-what-applies). Baseline rows are immutable post-activation and the token binds
- * `checkpointId` (re-resolved in-fence at apply), so composing does not weaken the drift tripwire.
+ * `checkpointId`; the unwired L8 apply must re-resolve it in-fence before this seam can be enabled.
  */
 export async function composeBaselineOverlay(
   query: QueryFn,

--- a/packages/core-backend/src/multitable/exact-anchor-recovery.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery.ts
@@ -14,7 +14,7 @@ import {
  *
  * Design authority: `…v37-exact-anchor-trust-design-lock-20260715.md` (#4331) §1.3 (exact recovery anchor
  * resolution), §0/P2-B (why a wall-clock `T` / a mutable `MAX(seq)` is NOT a trustworthy anchor), §9 item 6
- * (sealed operation ledger; server-minted, exact anchorSeq frozen in a signed identity). PROPOSED design.
+ * (sealed operation ledger; server-minted, exact anchorSeq frozen in a signed identity). Owner-ratified design.
  *
  * THE PROTOCOL (§1.3):
  *   PREVIEW  `resolveExactAnchor`:
@@ -33,7 +33,8 @@ import {
  *     The token's `anchorSeq` is the sole recovery authority; the execute NEVER re-derives it.
  *
  * WALL-CLOCK REFUSAL (§1.3, values-free / no-oracle): a destructive-recovery request that carries a free
- * wall-clock `T` instead of an `anchorBatchId` is REFUSED `exact-anchor-required` BEFORE any DB access — the
+ * wall-clock `T` instead of an exact `anchorOperationId` or server-resolved `historyBatchId` is REFUSED
+ * `exact-anchor-required` BEFORE any DB access — the
  * refusal is identical whether the sheet/data exists or not, so it leaks nothing. Manual-datetime navigation of
  * a read-only point-in-time VIEW still uses `T` (`reconstructRecordsAtT`, v3.7 §9.2) — that is display, not the
  * destructive authority; only the destructive recovery authority is anchor-only.

--- a/packages/core-backend/src/multitable/history-integrity-precheck.ts
+++ b/packages/core-backend/src/multitable/history-integrity-precheck.ts
@@ -467,10 +467,13 @@ export async function precheckSheetHistoryIntegrity(
     // UNCONDITIONALLY (owner P2, 2026-07-16: an earlier draft exempted `no_active_checkpoint`, which let an
     // operator flip strict on and have every checkpoint-LESS sheet walk straight into the strict comparator —
     // a production bypass that existed to keep test fixtures convenient; tests that need the comparator call
-    // `precheckSheetHistoryIntegrityStrict` directly instead). With RECONSTRUCTION_CAUSALITY_LANDED=false,
-    // (b) is unmet for EVERY sheet, so the production strict path refuses fail-closed until L6 lands —
-    // "migration/backfill presence alone never enables recovery" (design lock §3). The Revert/Reset routes
-    // inherit this refusal through this single entry.
+    // `precheckSheetHistoryIntegrityStrict` directly instead). RECONSTRUCTION_CAUSALITY_LANDED is DELIBERATELY
+    // HELD false (owner ruling 2026-07-17): the causal reconstructor mechanism landed with L6-b, but the seam
+    // flips only in the PR that wires the legacy Revert/Reset routes onto the L8 exact-anchor apply — until
+    // then this gate refuses EVERY sheet under strict-on (checkpoint or not), the fail-closed backstop. The
+    // whole branch only runs when the operator flips the default-OFF strict flag anyway ("migration/backfill
+    // presence alone never enables recovery", design lock §3). The Revert/Reset routes inherit this gate
+    // through this single entry.
     const enablement = await checkStrictEnablementPrecondition(query, sheetId)
     if (!enablement.canEnable) {
       return { ok: false, reason: 'strict_enablement_unmet' }

--- a/packages/core-backend/src/multitable/history-trust-precondition.ts
+++ b/packages/core-backend/src/multitable/history-trust-precondition.ts
@@ -8,11 +8,13 @@ import { hasActiveTrustCheckpoint } from './history-trust-checkpoint'
  *   (a) an ACTIVE trust checkpoint exists for the sheet, AND
  *   (b) reconstruction causality is satisfied.
  *
- * Condition (b) is NOT yet satisfiable: the reconstructor still selects by `created_at <= T` (non-causal)
- * until Lane L6 lands the exact event-anchor resolver. So this precondition CURRENTLY FAILS CLOSED for every
- * sheet — which is the CORRECT behavior (design lock §3: "migration/backfill presence alone never enables
- * recovery"; §9.7: ratification authorizes default-off slices only, not strict-mode enablement). This guard
- * MUST stay fail-closed until L6; it must not be weakened to pass.
+ * Condition (b)'s MECHANISM landed with Lane L6-b — the recovery-authority reconstructor is CAUSAL
+ * (`reconstructRecordsAtSeq`, seq-anchored on the shared `meta_record_chain_seq` domain; `created_at <= T`
+ * stays for read-only display only) — but the constant below is DELIBERATELY HELD `false` (owner ruling
+ * 2026-07-17): it flips to `true` ONLY in the same PR that actually wires the legacy Revert/Reset routes
+ * onto the L8 exact-anchor apply. Until that wiring PR, this precondition refuses EVERY sheet regardless of
+ * checkpoints or the flag — the last fail-closed backstop stays in place. Removing a backstop and adding the
+ * consumers that depend on its guarantees must be ONE reviewable change, not two.
  *
  * WIRED (L5 P2): {@link checkStrictEnablementPrecondition} is called by the authoritative strict-mode entry
  * point `precheckSheetHistoryIntegrity` (history-integrity-precheck.ts) — the function the Revert/Reset
@@ -22,25 +24,33 @@ import { hasActiveTrustCheckpoint } from './history-trust-checkpoint'
  * on without provisioning a checkpoint) kept exercising the comparator via HTTP — that was a production
  * bypass protecting test convenience (owner P2, 2026-07-16) and let every checkpoint-less sheet into the
  * strict comparator the moment an operator flipped the flag. Removed: tests that need the comparator call
- * `precheckSheetHistoryIntegrityStrict` directly (or provision a real checkpoint once L6 satisfies (b));
- * the production path stays uniformly fail-closed until then.
+ * `precheckSheetHistoryIntegrityStrict` directly (or, now that L6-b satisfies (b), provision a real active
+ * checkpoint); the production path stays fail-closed for any sheet WITHOUT an active checkpoint, and — even
+ * with one — nothing runs unless the operator flips the default-OFF flag.
  * The pure {@link evaluateStrictEnablementPrecondition} proves the two-condition logic (including the positive
  * control where both hold); the real-DB behavioral golden in
- * `multitable-history-trust-checkpoint-realdb.test.ts` proves strict-on is refused by this WIRED path.
+ * `multitable-history-trust-checkpoint-realdb.test.ts` proves strict-on is refused for a checkpoint-less sheet
+ * AND that a checkpoint-bearing sheet is STILL refused (`reconstruction_non_causal`) while the seam constant
+ * is held `false` — the backstop pin, via this WIRED path.
  */
 
 /**
- * The single L6 seam. Reconstruction is still non-causal (selects by `created_at <= T`) until L6 lands the
- * exact event-anchor resolver; L6 flips this constant to `true`. Until then the strict-enablement precondition
- * fails closed no matter what (see the module doc comment). Kept as a runtime const (not an env flag) so it
- * cannot be turned on by operator misconfiguration — only a code change in L6 may flip it.
+ * The L6 seam — DELIBERATELY HELD `false` (owner ruling 2026-07-17). The causal recovery-authority
+ * reconstructor (`reconstructRecordsAtSeq`, seq-anchored under the L4 all-writer fence + L5 trusted-since
+ * checkpoint) DID land with Lane L6-b, so the mechanism for condition (b) exists — but this constant is the
+ * LAST fail-closed backstop for strict enablement, and the owner ruled it flips to `true` only in the same
+ * PR that wires the legacy Revert/Reset routes onto the L8 exact-anchor apply (backstop removal and the
+ * consumers that rely on it = one reviewable change). It stays a runtime const (NOT an env flag) so the
+ * posture is a code fact pinned by goldens: while `false`, strict-on refuses EVERY sheet
+ * (`reconstruction_non_causal`) even with an active checkpoint — flipping this prematurely reds the seam
+ * golden in `multitable-history-trust-checkpoint.test.ts`.
  */
 export const RECONSTRUCTION_CAUSALITY_LANDED = false
 
 export type StrictEnablementUnmet = 'no_active_checkpoint' | 'reconstruction_non_causal'
 
 export interface StrictEnablementPreconditionResult {
-  /** true iff EVERY precondition is satisfied (currently impossible pre-L6) */
+  /** true iff EVERY precondition is satisfied (while the seam constant is held false: NEVER in production) */
   canEnable: boolean
   /** the specific unmet conditions — the guard distinguishes exactly what it claims to distinguish */
   unmet: StrictEnablementUnmet[]
@@ -63,8 +73,10 @@ export function evaluateStrictEnablementPrecondition(input: {
 
 /**
  * Real-DB precondition check for a sheet: reads (a) from `meta_history_trust_checkpoints` and (b) from the L6
- * seam constant. Currently ALWAYS returns `canEnable: false` (b is never satisfied pre-L6); the `unmet` array
- * still reflects (a) precisely, so callers/tests can see the checkpoint half evaluated independently.
+ * seam constant. While the seam is HELD `false` (owner ruling — until the Revert/Reset wiring PR), this NEVER
+ * returns `canEnable: true`: a checkpoint-bearing sheet still lists `reconstruction_non_causal`, a
+ * checkpoint-less one lists both. The `unmet` array reflects each half precisely, so callers/tests can see
+ * the checkpoint half evaluated independently of the held-back seam.
  */
 export async function checkStrictEnablementPrecondition(
   query: QueryFn,

--- a/packages/core-backend/src/multitable/record-reconstructor.ts
+++ b/packages/core-backend/src/multitable/record-reconstructor.ts
@@ -1,11 +1,24 @@
 import type { QueryFn } from './permission-service'
+import { assertSeqString } from './history-trust-checkpoint'
 
 /**
- * Global History — T5-1: as-of-time-T record reconstruction (the read primitive the restore-preview (T5-2) and
- * the point-in-time read-only view (T7) both build on). PURE READ — writes nothing.
+ * Global History — T5-1: as-of record reconstruction. TWO read primitives, PURE READ (writes nothing):
+ *
+ *   • {@link reconstructRecordsAtT} — as-of a WALL-CLOCK time T (`created_at <= T`). This is
+ *     MANUAL-DATETIME READ-ONLY NAVIGATION only (v3.7 §9.2): a human scrubbing a time slider / the
+ *     point-in-time read-only view (T7). It is DISPLAY/navigation, NOT the destructive-recovery authority —
+ *     `created_at` is txn-start (same-ms events collide) and, worse, is NOT commit order, so a record whose
+ *     `created_at` order disagrees with its `seq` (commit) order reconstructs to a state that was never
+ *     externally visible (the C2 bug). Keep this path for navigation; NEVER anchor a destructive revert/reset on it.
+ *
+ *   • {@link reconstructRecordsAtSeq} — as-of an EXACT causal anchor `seq` (`seq <= anchorSeq`). W0-1 v3.7 §1.3
+ *     (L6-b): the RECOVERY-AUTHORITY path. `seq` is the one shared causal `meta_record_chain_seq` domain
+ *     (allocated at write time under the L4 canonical fence), so `seq <= anchorSeq` reconstructs the EXACT
+ *     as-of-the-sealed-operation-endpoint state a recovery can trust. The `anchorSeq` is the immutable
+ *     `endpoint_seq` of a sealed operation (L6-a) frozen into a signed identity (see `exact-anchor-recovery.ts`).
  *
  * Design-lock: docs/development/multitable-global-history-t5-restore-preview-design-lock-20260621.md (#2985),
- * PV-5. LOCK-9 + LOCK-11 from the canonical global-history design-lock (#2952).
+ * PV-5; LOCK-9 + LOCK-11 (#2952); W0-1 v3.7 exact-anchor trust design-lock (#4331) §1.3/§9.2.
  */
 
 export interface RecordStateAtT {
@@ -55,18 +68,81 @@ export async function reconstructRecordsAtT(
     args,
   )
   for (const raw of res.rows as Array<Record<string, unknown>>) {
-    const recordId = String(raw.record_id)
-    const deleted = raw.action === 'delete'
-    // version is `number | null` per the contract: a finite numeric value stays a number; anything else (null /
-    // undefined / non-numeric) becomes null — NEVER coerced to 0, so "unknown version" cannot masquerade as a
-    // real version 0 for the T5-2 / T7 / T8 consumers. Check `typeof` BEFORE Number() — `Number(null) === 0`
-    // would otherwise resurrect the very bug this guards against.
-    out.set(recordId, {
-      recordId,
-      exists: !deleted,
-      data: deleted ? null : asRecord(raw.snapshot),
-      version: typeof raw.version === 'number' && Number.isFinite(raw.version) ? raw.version : null,
-    })
+    mapReconstructedRow(out, raw)
   }
   return out
+}
+
+/**
+ * Reconstruct each record's state as of an EXACT causal anchor `seq` = the LATEST revision with `seq <= anchorSeq`
+ * per record, ordered by the shared `meta_record_chain_seq` bigint (`ORDER BY record_id, seq DESC`). This is the
+ * W0-1 v3.7 §1.3 (L6-b) RECOVERY-AUTHORITY reconstruction — the state a destructive revert/reset resolves against.
+ *
+ * WHY seq, not created_at (the C2 fix): `seq` is allocated at write time under the L4 canonical fence, so it is
+ * the exact causal order in which writes were serialized; `created_at` is txn-start (not commit order). For a
+ * record whose `created_at` order disagrees with its `seq` order, the `created_at` path picks a write that was
+ * never the externally-visible latest as-of the anchor (an "un-happened" state), while this seq path picks the
+ * true as-of-anchorSeq state. `seq` is UNIQUE in the shared domain, so `seq DESC` alone is a total order — no
+ * `version`/`id` tiebreak is needed (contrast the LOCK-11 tiebreaks the created_at path must carry).
+ *
+ * DELETE-CHAIN (LOCK-9, identical to the created_at path and the strict precheck's delete handling): a `delete`
+ * revision stores the PRE-delete snapshot, so if the latest `seq <= anchorSeq` revision is a delete the record
+ * did NOT exist as of the anchor → `exists:false, data:null` (never resurrected). A record with no revision
+ * `seq <= anchorSeq` is absent from the map (it was created after the anchor). SAME-GENERATION contiguity /
+ * chain integrity is proven separately by the strict precheck; this primitive only reads the as-of state.
+ *
+ * EXACT BIGINT (§1.1): `anchorSeq` is a decimal-string bound straight into a `::bigint` parameter — never
+ * Number()/parseInt/+/-. A non-decimal-integer `anchorSeq` FAILS CLOSED (`assertSeqString` throws) rather than
+ * silently coercing; callers resolve `anchorSeq` from the immutable `endpoint_seq` of a sealed operation.
+ *
+ * @param anchorSeq the exact causal anchor as a decimal bigint string (the sealed operation's `endpoint_seq`).
+ * @param recordIds undefined → every record with a revision `seq <= anchorSeq`; otherwise only the given ids.
+ */
+export async function reconstructRecordsAtSeq(
+  query: QueryFn,
+  sheetId: string,
+  anchorSeq: string,
+  recordIds?: string[],
+): Promise<Map<string, RecordStateAtT>> {
+  const out = new Map<string, RecordStateAtT>()
+  if (!sheetId) return out
+  assertSeqString(anchorSeq, 'reconstructRecordsAtSeq.anchorSeq') // fail-closed on a forged/garbage anchor
+  const args: unknown[] = [sheetId, anchorSeq]
+  let recFilter = ''
+  if (recordIds) {
+    if (recordIds.length === 0) return out
+    args.push(recordIds)
+    recFilter = `AND record_id = ANY($${args.length}::text[])`
+  }
+  // DISTINCT ON (record_id) + `seq DESC` picks exactly the latest `seq <= anchorSeq` revision per record. Native
+  // SQL bigint comparison (`<= $2::bigint`) — exact regardless of magnitude (a >2^53 seq never collapses).
+  const res = await query(
+    `SELECT DISTINCT ON (record_id) record_id, action, snapshot, version
+     FROM meta_record_revisions
+     WHERE sheet_id = $1 AND seq <= $2::bigint ${recFilter}
+     ORDER BY record_id, seq DESC`,
+    args,
+  )
+  for (const raw of res.rows as Array<Record<string, unknown>>) {
+    mapReconstructedRow(out, raw)
+  }
+  return out
+}
+
+/**
+ * Shared row → RecordStateAtT mapping for BOTH reconstruction paths (created_at and seq). LOCK-9 delete
+ * awareness + the strict `version` typing: version is `number | null` — a finite numeric value stays a number;
+ * anything else (null / undefined / non-numeric) becomes null, NEVER coerced to 0, so "unknown version" cannot
+ * masquerade as a real version 0 for the T5-2 / T7 / T8 / recovery consumers. Check `typeof` BEFORE Number() —
+ * `Number(null) === 0` would otherwise resurrect the very bug this guards against.
+ */
+function mapReconstructedRow(out: Map<string, RecordStateAtT>, raw: Record<string, unknown>): void {
+  const recordId = String(raw.record_id)
+  const deleted = raw.action === 'delete'
+  out.set(recordId, {
+    recordId,
+    exists: !deleted,
+    data: deleted ? null : asRecord(raw.snapshot),
+    version: typeof raw.version === 'number' && Number.isFinite(raw.version) ? raw.version : null,
+  })
 }

--- a/packages/core-backend/src/multitable/restore-preview-identity.ts
+++ b/packages/core-backend/src/multitable/restore-preview-identity.ts
@@ -530,3 +530,167 @@ export function verifyPitResetPreviewIdentity(token: string, expected: PitResetP
   if (payload.actorId !== expected.actorId) return { valid: false, reason: 'mismatch_actorId' }
   return { valid: true }
 }
+
+// ── W0-1 v3.7 L6-b: EXACT-ANCHOR recovery preview-identity (design-lock #4331 §1.3 / §9 item 6) ───────────────
+// The DESTRUCTIVE-recovery authority token. A recovery preview resolves an OPAQUE anchor to an EXACT causal
+// `anchorSeq` (the immutable `endpoint_seq` of a sealed operation, L6-a) under the active trust checkpoint (L5),
+// then FREEZES that resolution into this signed identity. Execute verifies it and reconstructs at the
+// TOKEN-BOUND `anchorSeq` — it NEVER recomputes `MAX(seq)` as authority (that mutable value is exactly the
+// non-anchor a wall-clock/`MAX` sample would drift on; v3.7 §0/P2-B). `type: 'exact-anchor-recovery-preview'`
+// keeps it DISJOINT from every T5/T6/T8 identity above (a revert/reset/config token can never drive it and vice
+// versa). Same stateless HS256 primitive + server secret (`getSecret`); signature defeats forgery, `exp` bounds
+// the window, and `scopeHash` defeats stale replay (the reconstructed set moved since preview → execute re-hash
+// diverges → reject → re-preview).
+
+/**
+ * Order-invariant, SERVER-KEYED (HMAC) hash of the reconstructed record set AT the anchor — the exact
+ * {recordId, exists, version} the preview computed via `reconstructRecordsAtSeq(anchorSeq)`. Binding this into
+ * the identity means the execute (which re-reconstructs at the TOKEN-BOUND anchorSeq and re-hashes) rejects if
+ * the set drifted, AND — the load-bearing safety property — reds if the execute recomputes the anchor as
+ * `MAX(seq)` instead of using the frozen `anchorSeq` (a later write advances MAX, so the reconstructed set and
+ * this hash diverge). HMAC (server key), not a plain sha256, so a token holder cannot brute-force the record
+ * set / version map out of the client-decodable JWT (no-oracle, same discipline as `hashLossSummary`). A
+ * deleted (exists:false) record contributes `null` for its version (it has none as of the anchor).
+ */
+export function hashAnchorRecoveryScope(records: Array<{ recordId: string; exists: boolean; version: number | null }>): string {
+  const canon = [...records]
+    .sort((a, b) => (a.recordId < b.recordId ? -1 : a.recordId > b.recordId ? 1 : 0))
+    .map((r) => JSON.stringify([r.recordId, r.exists === true, r.exists && typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : null]))
+  return createHmac('sha256', getSecret()).update(JSON.stringify(canon)).digest('hex')
+}
+
+/** The recovery mode the preview was minted FOR. Bound into the signed identity (owner P1-1, 2026-07-17):
+ *  the destructive apply reads the mode from the VERIFIED CLAIMS, never from the execute request — a token
+ *  minted while previewing a non-destructive `revert` is structurally unusable to drive a `reset` (which
+ *  deletes `deletedAtAnchorLiveNow` ∪ `createdAfterAnchor` rows). The burn table only makes a token
+ *  at-most-once; it is THIS binding that pins WHAT the once is. */
+export type ExactAnchorRecoveryMode = 'revert' | 'reset'
+
+/**
+ * SERVER-KEYED hash of the v1 recovery-authorization basis (owner P1-2, 2026-07-17). Whole-sheet recovery is
+ * authorized by exactly one grant shape in v1 — the 4c-1 U-L8 FULL-READ gate (an actor who cannot read every
+ * record × field of the sheet is refused the whole surface; no partial scope exists yet). Binding a hash of
+ * that basis into the identity makes the AUTHORIZATION CONTRACT part of the signed token: the execute
+ * recomputes this hash from its OWN in-fence adjudication and compares — the token's echo is never the
+ * authority (the same discipline as the in-fence checkpoint re-resolution). A future partial-scope recovery
+ * mode versions the basis string, so a full-read-era token can never be presented to a partial-scope surface
+ * (or vice versa) — cross-contract replay is structurally dead, not checked.
+ */
+export function hashRecoveryAuthorizationScope(basis: { sheetId: string; actorId: string }): string {
+  return createHmac('sha256', getSecret())
+    .update(JSON.stringify(['recovery-auth-v1', 'full-read', basis.sheetId, basis.actorId]))
+    .digest('hex')
+}
+
+export interface ExactAnchorRecoveryIdentityClaims {
+  sheetId: string
+  /** the OPAQUE recovery anchor: the sealed operation endpoint id (`meta_record_history_operations.operation_id`).
+   *  NOT the S1 user-action `batch_id` (L6-a finding #1 permanently decouples the two identities — this field
+   *  was previously named `anchorBatchId`, which was exactly that conflation; renamed with the P1 token-contract
+   *  fix). A History-Center batch selection reaches this via the ruling-⑤ resolver (batch → its sealed terminal
+   *  operation with MAX `endpoint_seq` on this sheet), server-side only. */
+  anchorOperationId: string
+  /** the FROZEN exact causal anchor — the sealed operation's `endpoint_seq` as a decimal bigint STRING (never a
+   *  Number). Reconstruction/execute bind this straight into `seq <= $::bigint`. */
+  anchorSeq: string
+  /** the active trust checkpoint covering the anchor (`trusted_since_seq <= anchorSeq`, L5). */
+  checkpointId: string
+  /** order-invariant HMAC over the reconstructed record set at `anchorSeq` (`hashAnchorRecoveryScope`). */
+  scopeHash: string
+  /** W0-1 L8: order-invariant HMAC over the LIVE record set {id, version} at preview time (same
+   *  `hashAnchorRecoveryScope` primitive, `exists:true`). `scopeHash` binds the ANCHOR AUTHORITY (the
+   *  immutable at-anchor reconstruction — it can never move under an append-only history), while this
+   *  binds PREVIEW FRESHNESS: any concurrent version-bumping write / create / delete between preview and
+   *  execute changes it, and the destructive apply refuses `preview-drift` (409-class) in-fence — the
+   *  actor always applies exactly the world they previewed. */
+  liveSetHash: string
+  /** the actor the preview was minted for — a preview minted for A is unusable by B (no cross-actor replay). */
+  actorId: string
+  /** the recovery mode this preview authorizes — the apply obeys THIS, never a request-supplied mode (P1-1). */
+  mode: ExactAnchorRecoveryMode
+  /** `hashRecoveryAuthorizationScope` over the v1 full-read authorization basis (P1-2) — recomputed and
+   *  compared at execute from the execute's OWN fresh adjudication, never trusted from the token alone. */
+  authorizedScopeHash: string
+}
+
+export function mintExactAnchorRecoveryIdentity(claims: ExactAnchorRecoveryIdentityClaims, expiresIn: SignOptions['expiresIn'] = DEFAULT_TTL): string {
+  return jwt.sign({ type: 'exact-anchor-recovery-preview', ...claims }, getSecret(), { algorithm: 'HS256', expiresIn } as SignOptions)
+}
+
+export interface ExactAnchorRecoveryVerifyResult {
+  valid: boolean
+  /**
+   * Failure taxonomy (NIT-1 precision):
+   * - `pre_contract_token` — missing/out-of-vocabulary `mode` or missing/empty `authorizedScopeHash`
+   *   (P1 hard cutover; deliberate — module is unwired so no live token predates the contract).
+   * - `malformed_anchorSeq` — `anchorSeq` is not a decimal bigint string (must never reach `::bigint`).
+   * - `malformed_claims` — other required token-authority fields absent/empty (checkpointId /
+   *   anchorOperationId / scopeHash / liveSetHash).
+   * Execute collapses every `!valid` into `identity-invalid`; these labels are for diagnostics + unit pins.
+   */
+  reason?: 'invalid' | 'expired' | 'wrong_type' | 'mismatch_sheetId' | 'mismatch_actorId' | 'malformed_anchorSeq' | 'pre_contract_token' | 'malformed_claims'
+  /** the verified (signature-checked, sheet+actor-bound) claims — the caller reads the TOKEN-BOUND `anchorSeq`
+   *  and `checkpointId` from here; present ONLY when `valid`. */
+  claims?: ExactAnchorRecoveryIdentityClaims
+}
+
+/**
+ * Verify an exact-anchor recovery identity. JWT verification covers signature (any tampered claim — anchorSeq,
+ * checkpointId, scopeHash, anchorOperationId, mode, authorizedScopeHash — breaks it → `invalid`) + expiry. The
+ * per-claim checks bind the REPLAY axes computed FRESH at execute time: `sheetId` and `actorId` (a token for
+ * sheet A / actor A can never drive a recovery on sheet B / actor B). The token-authority fields (`anchorSeq`,
+ * `checkpointId`, `anchorOperationId`, `scopeHash`, `mode`, `authorizedScopeHash`) are returned in `claims`
+ * for the caller to use UNDER THE FENCE — the execute
+ * reconstructs at `claims.anchorSeq` and re-checks `claims.scopeHash` against the live reconstruction; it does
+ * NOT recompute the anchor. `anchorSeq` is shape-validated as a decimal bigint string (fail-closed, never
+ * coerced) so a signed-but-garbage anchor cannot reach the `::bigint` bind.
+ */
+export function verifyExactAnchorRecoveryIdentity(
+  token: string,
+  expected: { sheetId: string; actorId: string },
+): ExactAnchorRecoveryVerifyResult {
+  let payload: Partial<ExactAnchorRecoveryIdentityClaims> & { type?: string }
+  try {
+    payload = jwt.verify(token, getSecret()) as Partial<ExactAnchorRecoveryIdentityClaims> & { type?: string }
+  } catch (e) {
+    return { valid: false, reason: (e as Error)?.name === 'TokenExpiredError' ? 'expired' : 'invalid' }
+  }
+  if (payload.type !== 'exact-anchor-recovery-preview') return { valid: false, reason: 'wrong_type' }
+  if (payload.sheetId !== expected.sheetId) return { valid: false, reason: 'mismatch_sheetId' }
+  if (payload.actorId !== expected.actorId) return { valid: false, reason: 'mismatch_actorId' }
+  // P1 token contract (hard cutover): `mode` + `authorizedScopeHash` REQUIRED. Classified as
+  // `pre_contract_token` (not `malformed_anchorSeq`) so the fail-closed label matches the actual defect.
+  if (payload.mode !== 'revert' && payload.mode !== 'reset') {
+    return { valid: false, reason: 'pre_contract_token' }
+  }
+  if (typeof payload.authorizedScopeHash !== 'string' || !payload.authorizedScopeHash) {
+    return { valid: false, reason: 'pre_contract_token' }
+  }
+  // Shape fail-closed: `anchorSeq` must be a decimal bigint string before any `::bigint` bind.
+  if (typeof payload.anchorSeq !== 'string' || !/^[0-9]+$/.test(payload.anchorSeq)) {
+    return { valid: false, reason: 'malformed_anchorSeq' }
+  }
+  // Remaining required token-authority fields — precise label, not collapsed into malformed_anchorSeq.
+  if (
+    typeof payload.checkpointId !== 'string' || !payload.checkpointId ||
+    typeof payload.anchorOperationId !== 'string' || !payload.anchorOperationId ||
+    typeof payload.scopeHash !== 'string' || !payload.scopeHash ||
+    typeof payload.liveSetHash !== 'string' || !payload.liveSetHash
+  ) {
+    return { valid: false, reason: 'malformed_claims' }
+  }
+  return {
+    valid: true,
+    claims: {
+      sheetId: payload.sheetId,
+      anchorOperationId: payload.anchorOperationId,
+      anchorSeq: payload.anchorSeq,
+      checkpointId: payload.checkpointId,
+      scopeHash: payload.scopeHash,
+      liveSetHash: payload.liveSetHash,
+      actorId: payload.actorId as string,
+      mode: payload.mode,
+      authorizedScopeHash: payload.authorizedScopeHash,
+    },
+  }
+}

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-recovery-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-recovery-realdb.test.ts
@@ -1,0 +1,384 @@
+/**
+ * W0-1 v3.7 Lane L6-b — EXACT-ANCHOR recovery resolution/execute + causal reconstructor (real DB).
+ *
+ * Design authority: docs/development/multitable-w0-1-v37-exact-anchor-trust-design-lock-20260715.md (#4331)
+ * §1.3 (exact recovery-anchor resolution), §0/P2-B (why wall-clock `T` / a mutable `MAX(seq)` is NOT a
+ * trustworthy anchor), §9 item 6 (sealed operation ledger). Modules under test:
+ *   • `record-reconstructor.ts`  `reconstructRecordsAtSeq` — the CAUSAL (seq-anchored) recovery-authority read.
+ *   • `exact-anchor-recovery.ts`  `resolveExactAnchor` / `executeExactAnchorRecovery` — resolve an opaque sealed
+ *     operation endpoint to an exact `anchorSeq`, freeze it into a signed identity, and execute against the
+ *     TOKEN-BOUND anchor (never a recomputed `MAX(seq)`).
+ *
+ * Goldens (each is mutation-proven — see the PR's mutation matrix):
+ *   C2 COUNTEREXAMPLE          a record whose `created_at` order DISAGREES with its `seq` (commit) order —
+ *       the seq path reconstructs the true as-of-anchor (commit-latest) state; a `created_at`-ordered
+ *       reconstruction would pick the un-happened write. Mutation: order by created_at ⇒ reds.
+ *   DELETE-CHAIN (LOCK-9)      the latest `seq <= anchor` revision is a delete ⇒ record does NOT exist at the
+ *       anchor (never resurrected from its pre-delete snapshot).
+ *   EXACT BIGINT > 2^53        seq neighbours that Number() collapses are ordered exactly by `<= $::bigint`.
+ *   ANCHOR RESOLUTION          a sealed endpoint resolves to its exact `endpoint_seq` under a covering trust
+ *       checkpoint; an unknown anchor / a checkpoint-less anchor / a wall-clock request / a non-uuid all refuse.
+ *   EXECUTE / NO-MAX-RECOMPUTE a later write advances `MAX(seq)`; execute STILL reconstructs at the TOKEN-BOUND
+ *       anchor (the later record stays absent) ⇒ ok. Mutation: recompute anchor as MAX(seq) ⇒ scope-drift reds.
+ *   SCOPE-DRIFT positive       a token carrying a deliberately-wrong scopeHash ⇒ execute refuses scope-drift.
+ *
+ * Two-point wiring: plugin-tests.yml real-DB run list + vitest.integration.config.ts. Runs only with
+ * DATABASE_URL (a top-level sentinel FAILS — not skips — in the real-DB allowlist step). Fixture hygiene (P2-C):
+ * every seq is an EXPLICIT literal on an isolated fixture row; this file NEVER calls `setval` on the shared
+ * `meta_record_chain_seq`, and cleans up only its own sheet/base/user rows.
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { reconstructRecordsAtSeq, reconstructRecordsAtT } from '../../src/multitable/record-reconstructor'
+import { resolveExactAnchor, executeExactAnchorRecovery } from '../../src/multitable/exact-anchor-recovery'
+import { activateCheckpoint, type QueryFn } from '../../src/multitable/history-trust-checkpoint'
+import { hashRecoveryAuthorizationScope, mintExactAnchorRecoveryIdentity } from '../../src/multitable/restore-preview-identity'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_ear_${TS}`
+const SHEET = `sheet_ear_${TS}`
+const F_STR = `fld_ear_note_${TS}`
+const ACTOR = `user_ear_${TS}`
+
+const q = (sql: string, params: unknown[] = []) => poolManager.get().query(sql, params)
+type Run = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+const inTxn = <T>(fn: (run: Run) => Promise<T>): Promise<T> =>
+  poolManager.get().transaction(async ({ query }) => fn(query as unknown as Run)) as Promise<T>
+
+// P1-2 kernel adjudication: the tests inject the full-read verdict (the production evaluator is the route's
+// `hasFullTableReadAccess`, which closes over req/capabilities the kernel can't reach). ALLOW is the default
+// harness posture; DENY exercises the kernel's fail-closed `forbidden` branches.
+const ALLOW_FULL_READ = async () => true
+const DENY_FULL_READ = async () => false
+
+// A revision at an EXPLICIT seq + created_at (never nextval/setval) — the C2 counterexample needs seq order and
+// created_at order to disagree, so both are controlled per row.
+const revSeq = (
+  recordId: string,
+  version: number,
+  action: 'create' | 'update' | 'delete',
+  snap: Record<string, unknown> | null,
+  seq: string,
+  createdAtIso?: string,
+  run: Run = q,
+) =>
+  run(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq, created_at)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[]::text[],'{}'::jsonb,$5::jsonb,$6::bigint,COALESCE($7::timestamptz, now()))`,
+    [SHEET, recordId, version, action, snap === null ? null : JSON.stringify(snap), seq, createdAtIso ?? null],
+  )
+
+// A revision tagged with an operation_id, inside a sealing txn (the DEFERRABLE-INITIALLY-DEFERRED FK is checked
+// at COMMIT, so the endpoint must land in the SAME txn).
+const revSeqOp = (run: Run, recordId: string, version: number, seq: string, opId: string, snap: Record<string, unknown> = { [F_STR]: `v${version}` }, batchId: string | null = null) =>
+  run(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq, operation_id, batch_id)
+     VALUES (gen_random_uuid(),$1,$2,$3,'create','rest',ARRAY[]::text[],'{}'::jsonb,$4::jsonb,$5::bigint,$6::uuid,$7)`,
+    [SHEET, recordId, version, JSON.stringify(snap), seq, opId, batchId],
+  )
+const insertEndpoint = (run: Run, opId: string, endpointSeq: string, eventCount: number) =>
+  run(
+    `INSERT INTO meta_record_history_operations (sheet_id, operation_id, endpoint_seq, event_count)
+     VALUES ($1,$2::uuid,$3::bigint,$4::int)`,
+    [SHEET, opId, endpointSeq, eventCount],
+  )
+
+/** Seal one operation: `eventSeqs` synthetic revisions for a record, endpoint_seq = exact MAX (validate trigger).
+ *  `batchId` (optional) stamps the S1 user-action grouping onto the revisions — the ruling-⑤ resolver's key. */
+async function sealOp(recordId: string, eventSeqs: string[], batchId: string | null = null): Promise<string> {
+  const opId = randomUUID()
+  const maxSeq = eventSeqs.reduce((a, b) => (BigInt(a) >= BigInt(b) ? a : b))
+  await inTxn(async (run) => {
+    let v = 1
+    for (const s of eventSeqs) await revSeqOp(run, recordId, v++, s, opId, undefined, batchId)
+    await insertEndpoint(run, opId, maxSeq, eventSeqs.length)
+  })
+  return opId
+}
+const activate = () => poolManager.get().transaction(async ({ query }) => activateCheckpoint(query as unknown as QueryFn, { sheetId: SHEET }))
+
+async function wipeSheetHistory(): Promise<void> {
+  for (const t of ['meta_history_baselines', 'meta_history_trust_checkpoints', 'meta_record_version_markers', 'meta_records_trash', 'meta_record_revisions', 'meta_records'])
+    await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+  // history-operations has no sheet_id-only cascade concerns; clear tagged endpoints last (revisions gone above).
+  await q('DELETE FROM meta_record_history_operations WHERE sheet_id = $1', [SHEET]).catch(() => {})
+}
+
+// Top-level (NOT inside describeIfDatabase) so the real-DB allowlist step FAILS — not silently skips — if it runs
+// this file without a DB. Scoped to that step via METASHEET_REAL_DB_TEST_STEP so the normal (no-DB) core-backend
+// job's collection of this file stays green (the describeIfDatabase goldens skip there).
+test('sentinel: the real-DB allowlist step must have DATABASE_URL (fail-not-skip, scoped to that step)', () => {
+  if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+    throw new Error('real-DB allowlist step is missing DATABASE_URL — the harness is broken, not legitimately skippable')
+  }
+  expect(true).toBe(true)
+})
+
+describeIfDatabase('W0-1 v3.7 L6-b — exact-anchor recovery + causal reconstructor (real DB)', () => {
+  beforeAll(async () => {
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'EAR Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'EAR Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_STR, SHEET, 'Note', 'string', '{}', 1])
+  })
+  beforeEach(wipeSheetHistory)
+  afterAll(async () => {
+    await wipeSheetHistory()
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL is set (this suite must RUN, never skip-green)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ── C2 COUNTEREXAMPLE ────────────────────────────────────────────────────────────────────────────────────
+  test('C2: created_at order DISAGREES with seq order — the causal path reconstructs the commit-latest state', async () => {
+    const R = `rec_c2_${TS}`
+    // X committed FIRST (seq 100) but has the LATER created_at (Jun 10); Y committed SECOND (seq 200) with the
+    // EARLIER created_at (Jun 01). A created_at-ordered reconstruction would call X the latest — the un-happened
+    // state. The seq (commit) order is the truth.
+    await revSeq(R, 1, 'create', { [F_STR]: 'x' }, '100', '2026-06-10T00:00:00.000Z')
+    await revSeq(R, 2, 'update', { [F_STR]: 'y' }, '200', '2026-06-01T00:00:00.000Z')
+
+    // anchor 250: both events have happened; the true as-of state is Y (the last commit, seq 200).
+    const at250 = await reconstructRecordsAtSeq(q, SHEET, '250')
+    expect(at250.get(R)).toMatchObject({ exists: true, data: { [F_STR]: 'y' }, version: 2 })
+
+    // anchor 150: only X (seq 100) has happened — the anchor precisely controls the as-of state.
+    const at150 = await reconstructRecordsAtSeq(q, SHEET, '150')
+    expect(at150.get(R)).toMatchObject({ exists: true, data: { [F_STR]: 'x' }, version: 1 })
+
+    // Contrast (the C2 bug being fixed): the created_at path over the same two committed events picks X (the
+    // LATER-created, seq-EARLIER write) — the un-happened "latest" — where the seq path at anchor 250 picks Y.
+    // The two orders genuinely disagree on this fixture, so a mutation swapping the recovery read to created_at
+    // ordering is a real defect the seq assertion above catches.
+    const tPath = await reconstructRecordsAtT(q, SHEET, '2026-06-15T00:00:00.000Z')
+    expect(tPath.get(R)).toMatchObject({ exists: true, data: { [F_STR]: 'x' }, version: 1 })
+  })
+
+  // ── DELETE-CHAIN (LOCK-9) ────────────────────────────────────────────────────────────────────────────────
+  test('DELETE-CHAIN: the latest seq<=anchor revision is a delete ⇒ record does NOT exist at the anchor', async () => {
+    const R = `rec_del_${TS}`
+    await revSeq(R, 1, 'create', { [F_STR]: 'a' }, '100')
+    await revSeq(R, 1, 'delete', { [F_STR]: 'a' }, '200') // delete stores the PRE-delete snapshot
+    expect((await reconstructRecordsAtSeq(q, SHEET, '150')).get(R)).toMatchObject({ exists: true, data: { [F_STR]: 'a' }, version: 1 })
+    expect((await reconstructRecordsAtSeq(q, SHEET, '250')).get(R)).toMatchObject({ exists: false, data: null })
+  })
+
+  // ── MULTI-GENERATION delete→recreate (version reset) — seq order, NOT version order ──────────────────────
+  test('MULTI-GEN: a delete→recreate resets version to 1; the seq path picks the RECREATED generation, never the higher-version deleted one', async () => {
+    const R = `rec_gen_${TS}`
+    // gen1: create v1 @10, update v2 @20, delete v2 @30 (pre-delete snapshot). gen2: create v1 @40 (version
+    // RESET to 1), update v2 @50. The recreated generation's rows have LOWER versions but HIGHER seq — so a
+    // version-based tiebreak would wrongly resurrect gen1's v2 (its delete) at an anchor past the recreate.
+    await revSeq(R, 1, 'create', { [F_STR]: 'g1v1' }, '10')
+    await revSeq(R, 2, 'update', { [F_STR]: 'g1v2' }, '20')
+    await revSeq(R, 2, 'delete', { [F_STR]: 'g1v2' }, '30')
+    await revSeq(R, 1, 'create', { [F_STR]: 'g2v1' }, '40')
+    await revSeq(R, 2, 'update', { [F_STR]: 'g2v2' }, '50')
+
+    // anchor 25 (inside gen1): the mid-generation update.
+    expect((await reconstructRecordsAtSeq(q, SHEET, '25')).get(R)).toMatchObject({ exists: true, data: { [F_STR]: 'g1v2' }, version: 2 })
+    // anchor 35 (gen1 deleted, before recreate): absent (LOCK-9).
+    expect((await reconstructRecordsAtSeq(q, SHEET, '35')).get(R)).toMatchObject({ exists: false, data: null })
+    // anchor 45 (just after the recreate): the RECREATED gen2 v1 — NOT gen1's v2 delete. This is the assertion a
+    // `version DESC` tiebreak on the seq ORDER BY reds (it would pick the v2 delete row → exists:false).
+    expect((await reconstructRecordsAtSeq(q, SHEET, '45')).get(R)).toMatchObject({ exists: true, data: { [F_STR]: 'g2v1' }, version: 1 })
+    // anchor 99 (gen2 terminal).
+    expect((await reconstructRecordsAtSeq(q, SHEET, '99')).get(R)).toMatchObject({ exists: true, data: { [F_STR]: 'g2v2' }, version: 2 })
+  })
+
+  // ── EXACT BIGINT > 2^53 ──────────────────────────────────────────────────────────────────────────────────
+  test('EXACT-BIGINT: seq neighbours Number() collapses are ordered exactly by <= $::bigint', async () => {
+    const R = `rec_big_${TS}`
+    const LO = '9007199254740992' // 2^53
+    const HI = '9007199254740993' // 2^53 + 1 — Number() rounds this DOWN to 2^53, colliding with LO
+    expect(Number(LO) === Number(HI)).toBe(true) // the float64 trap: the two distinct seqs collapse to one float
+    await revSeq(R, 1, 'create', { [F_STR]: 'lo' }, LO)
+    await revSeq(R, 2, 'update', { [F_STR]: 'hi' }, HI)
+    // anchor = LO exactly: seq<=LO includes LO, EXCLUDES HI (HI > LO as a bigint). A Number()-based comparison
+    // would see Number(HI) <= Number(anchor) as true and wrongly include HI (then seq DESC would pick it) — so
+    // the exact ::bigint path is what keeps the as-of-anchor state at LO.
+    expect((await reconstructRecordsAtSeq(q, SHEET, LO)).get(R)).toMatchObject({ exists: true, data: { [F_STR]: 'lo' }, version: 1 })
+  })
+
+  // ── ANCHOR RESOLUTION ────────────────────────────────────────────────────────────────────────────────────
+  test('RESOLVE: a sealed endpoint under a covering checkpoint → exact anchorSeq + a verifiable token', async () => {
+    const R = `rec_res_${TS}`
+    const opId = await sealOp(R, ['7001', '7002', '7003'])
+    await activate() // trusted_since = a small nextval ≤ 7003 ⇒ covers the anchor
+    const res = await resolveExactAnchor(q, { sheetId: SHEET, request: { kind: 'exact-anchor', anchorOperationId: opId }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    expect(res.anchorSeq).toBe('7003') // the sealed endpoint_seq, exact — NOT a live MAX(seq)
+    expect(res.anchorOperationId).toBe(opId)
+    expect(res.mode).toBe('revert') // the mode the token authorizes — frozen at preview (P1-1)
+    // the minted token executes end-to-end for the same sheet+actor.
+    const ex = await executeExactAnchorRecovery(q, { token: res.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(ex.ok).toBe(true)
+    if (ex.ok) expect(ex.anchorSeq).toBe('7003')
+  })
+
+  test('RESOLVE refusals: unknown anchor, checkpoint-less anchor, wall-clock, non-uuid', async () => {
+    // wall-clock request → exact-anchor-required, with NO DB access (a throwing query proves it never reads).
+    const throwQ = (() => { throw new Error('resolveExactAnchor touched the DB on a wall-clock request') }) as unknown as QueryFn
+    expect(await resolveExactAnchor(throwQ, { sheetId: SHEET, request: { kind: 'wall-clock', asOf: '2026-06-01T00:00:00Z' }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'exact-anchor-required' })
+    // non-uuid anchorOperationId → invalid-anchor. (P1-2 adjudication runs first and MAY read config
+    // tables in production; here the ALLOW stub keeps the throwing query untouched, so this still proves
+    // the anchor lookup itself never fires for a malformed id.)
+    expect(await resolveExactAnchor(throwQ, { sheetId: SHEET, request: { kind: 'exact-anchor', anchorOperationId: 'not-a-uuid' }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'invalid-anchor' })
+    // a well-formed but UNKNOWN uuid → unknown-anchor (no sealed endpoint).
+    expect(await resolveExactAnchor(q, { sheetId: SHEET, request: { kind: 'exact-anchor', anchorOperationId: randomUUID() }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'unknown-anchor' })
+    // a sealed endpoint but NO active checkpoint covering it → no-covering-checkpoint (fail-closed).
+    const opId = await sealOp(`rec_nock_${TS}`, ['8001', '8002'])
+    expect(await resolveExactAnchor(q, { sheetId: SHEET, request: { kind: 'exact-anchor', anchorOperationId: opId }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'no-covering-checkpoint' })
+  })
+
+  // ── EXECUTE — TOKEN-BOUND ANCHOR, NEVER MAX(seq) ─────────────────────────────────────────────────────────
+  test('EXECUTE never recomputes MAX(seq): a later write advances MAX yet execute stays on the token-bound anchor', async () => {
+    const R = `rec_max_${TS}`
+    const opId = await sealOp(R, ['7001', '7002', '7003'])
+    await activate()
+    const res = await resolveExactAnchor(q, { sheetId: SHEET, request: { kind: 'exact-anchor', anchorOperationId: opId }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+
+    // A NEW record is created AFTER the anchor (seq 9000 > 7003, legacy NULL operation_id — no endpoint needed).
+    // It is absent from the reconstruction AT the token anchor (7003), so the token's scopeHash still matches and
+    // execute succeeds. If execute recomputed the anchor as MAX(seq)=9000, this new record would appear ⇒ the
+    // reconstructed set diverges from the frozen scopeHash ⇒ scope-drift. (That is the mutation this golden reds.)
+    await revSeq(`rec_late_${TS}`, 1, 'create', { [F_STR]: 'late' }, '9000')
+    const ex = await executeExactAnchorRecovery(q, { token: res.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(ex.ok).toBe(true)
+    if (ex.ok) {
+      expect(ex.anchorSeq).toBe('7003')
+      expect(ex.stateMap.has(`rec_late_${TS}`)).toBe(false) // the post-anchor record is NOT in the plan
+    }
+  })
+
+  test('EXECUTE replay/tamper: cross-sheet, cross-actor, and a wrong scopeHash all refuse (identity-invalid / scope-drift)', async () => {
+    const R = `rec_tamper_${TS}`
+    const opId = await sealOp(R, ['7001', '7002', '7003'])
+    await activate()
+    const res = await resolveExactAnchor(q, { sheetId: SHEET, request: { kind: 'exact-anchor', anchorOperationId: opId }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+
+    // cross-sheet replay: the token is bound to SHEET; another sheet re-binds sheetId fresh ⇒ identity-invalid.
+    expect(await executeExactAnchorRecovery(q, { token: res.token, sheetId: `${SHEET}_other`, actorId: ACTOR }))
+      .toEqual({ ok: false, reason: 'identity-invalid' })
+    // cross-actor replay: a preview minted for ACTOR is unusable by another actor ⇒ identity-invalid.
+    expect(await executeExactAnchorRecovery(q, { token: res.token, sheetId: SHEET, actorId: `${ACTOR}_other`, evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'identity-invalid' })
+    // a signature-tampered token ⇒ identity-invalid (mutate the last char of the JWT signature segment).
+    const bad = res.token.slice(0, -1) + (res.token.slice(-1) === 'A' ? 'B' : 'A')
+    expect(await executeExactAnchorRecovery(q, { token: bad, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'identity-invalid' })
+
+    // SCOPE-DRIFT positive control: a VALIDLY-signed token whose scopeHash is deliberately wrong ⇒ the live
+    // reconstruction at the (correct) token anchor re-hashes and diverges ⇒ scope-drift (this exercises the
+    // drift branch for real, complementing the MAX-recompute mutation which triggers the same branch).
+    // authorizedScopeHash is the MATCHING one so this golden isolates the scopeHash axis (P1-2's own axis
+    // has its own goldens below).
+    const forged = mintExactAnchorRecoveryIdentity({
+      sheetId: SHEET, anchorOperationId: opId, anchorSeq: '7003', checkpointId: (res as { checkpointId: string }).checkpointId,
+      scopeHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      liveSetHash: 'c0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffee0000', // shape-valid; the read-half checks scopeHash only
+      actorId: ACTOR,
+      mode: 'revert', authorizedScopeHash: hashRecoveryAuthorizationScope({ sheetId: SHEET, actorId: ACTOR }),
+    })
+    expect(await executeExactAnchorRecovery(q, { token: forged, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'scope-drift' })
+  })
+
+  // ── P1-2 KERNEL ADJUDICATION (full-read gate + signed authorization basis) ───────────────────────────────
+  test('AUTH: a non-full-read actor is refused at PREVIEW (forbidden, no token, no stateMap) — before any anchor oracle', async () => {
+    const R = `rec_auth_${TS}`
+    const opId = await sealOp(R, ['7001', '7002'])
+    await activate()
+    // DENY ⇒ forbidden. The anchor EXISTS and is covered — the refusal must reveal none of that.
+    expect(await resolveExactAnchor(q, { sheetId: SHEET, request: { kind: 'exact-anchor', anchorOperationId: opId }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: DENY_FULL_READ }))
+      .toEqual({ ok: false, reason: 'forbidden' })
+    // an UNKNOWN anchor refuses IDENTICALLY under DENY (no existence oracle for the unauthorized).
+    expect(await resolveExactAnchor(q, { sheetId: SHEET, request: { kind: 'exact-anchor', anchorOperationId: randomUUID() }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: DENY_FULL_READ }))
+      .toEqual({ ok: false, reason: 'forbidden' })
+  })
+
+  test('AUTH: permission revoked BETWEEN preview and execute ⇒ forbidden (fresh adjudication, not the token echo)', async () => {
+    const R = `rec_authrev_${TS}`
+    const opId = await sealOp(R, ['7001', '7002', '7003'])
+    await activate()
+    const res = await resolveExactAnchor(q, { sheetId: SHEET, request: { kind: 'exact-anchor', anchorOperationId: opId }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    // the SAME (valid, unexpired) token — only the live adjudication changed ⇒ forbidden.
+    expect(await executeExactAnchorRecovery(q, { token: res.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: DENY_FULL_READ }))
+      .toEqual({ ok: false, reason: 'forbidden' })
+    // re-grant ⇒ the same token proceeds (nothing was burned by the read-half refusal).
+    const ok = await executeExactAnchorRecovery(q, { token: res.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(ok.ok).toBe(true)
+  })
+
+  test('AUTH: a validly-signed token whose authorizedScopeHash does not match the recomputed v1 basis ⇒ forbidden', async () => {
+    const R = `rec_authhash_${TS}`
+    const opId = await sealOp(R, ['7001', '7002', '7003'])
+    await activate()
+    const res = await resolveExactAnchor(q, { sheetId: SHEET, request: { kind: 'exact-anchor', anchorOperationId: opId }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    // Mint with the REAL scopeHash but a WRONG authorization basis — signature valid, adjudication live-ALLOW:
+    // only the signed authorization contract diverges ⇒ forbidden (the token's echo is never the authority).
+    const wrongAuth = mintExactAnchorRecoveryIdentity({
+      sheetId: SHEET, anchorOperationId: opId, anchorSeq: res.anchorSeq, checkpointId: res.checkpointId,
+      scopeHash: res.scopeHash, liveSetHash: 'f'.repeat(64), // shape-valid; the read-half checks scopeHash only
+      actorId: ACTOR, mode: 'revert', authorizedScopeHash: 'e'.repeat(64),
+    })
+    expect(await executeExactAnchorRecovery(q, { token: wrongAuth, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'forbidden' })
+  })
+
+  // ── RULING-⑤ RESOLVER: History-Center batch → sealed terminal operation ─────────────────────────────────
+  test('RESOLVER (d): a batch spanning N sealed operations on this sheet anchors on the MAX endpoint_seq terminal op', async () => {
+    const R = `rec_batch_${TS}`
+    const batchId = `batch_hb_${TS}`
+    // TWO sealed operations whose revisions share ONE user-action batch_id (the S1 multi-txn commit shape).
+    const op1 = await sealOp(R, ['7001', '7002'], batchId)
+    const op2 = await sealOp(`${R}_2`, ['7005', '7006'], batchId)
+    await activate()
+    const res = await resolveExactAnchor(q, { sheetId: SHEET, request: { kind: 'history-batch', historyBatchId: batchId }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    expect(res.anchorOperationId).toBe(op2) // the TERMINAL sealed op — MAX endpoint_seq (7006 > 7002)
+    expect(res.anchorSeq).toBe('7006')
+    expect(op1).not.toBe(op2)
+    // and the minted token executes end-to-end (same trust chain as a direct exact-anchor).
+    const ex = await executeExactAnchorRecovery(q, { token: res.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(ex.ok).toBe(true)
+    if (ex.ok) expect(ex.anchorSeq).toBe('7006')
+  })
+
+  test('RESOLVER (e): a legacy/unsealed batch (no sealed operation) refuses exact-anchor-required — never a wall-clock fallback, no unknown-vs-unsealed oracle', async () => {
+    const R = `rec_legacy_${TS}`
+    const batchId = `batch_legacy_${TS}`
+    // Legacy shape: revisions carry the batch_id but NULL operation_id (pre-ledger writer) — unsealed.
+    await revSeq(R, 1, 'create', { [F_STR]: 'l1' }, '7001')
+    await q('UPDATE meta_record_revisions SET batch_id = $1 WHERE sheet_id = $2 AND record_id = $3', [batchId, SHEET, R])
+    await activate()
+    expect(await resolveExactAnchor(q, { sheetId: SHEET, request: { kind: 'history-batch', historyBatchId: batchId }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'exact-anchor-required' })
+    // an entirely UNKNOWN batch refuses IDENTICALLY (ruling ⑧ uniform refusal).
+    expect(await resolveExactAnchor(q, { sheetId: SHEET, request: { kind: 'history-batch', historyBatchId: `batch_unknown_${TS}` }, actorId: ACTOR, mode: 'revert', evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'exact-anchor-required' })
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-recovery-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-recovery-realdb.test.ts
@@ -276,7 +276,12 @@ describeIfDatabase('W0-1 v3.7 L6-b — exact-anchor recovery + causal reconstruc
     if (!res.ok) return
 
     // cross-sheet replay: the token is bound to SHEET; another sheet re-binds sheetId fresh ⇒ identity-invalid.
-    expect(await executeExactAnchorRecovery(q, { token: res.token, sheetId: `${SHEET}_other`, actorId: ACTOR }))
+    expect(await executeExactAnchorRecovery(q, {
+      token: res.token,
+      sheetId: `${SHEET}_other`,
+      actorId: ACTOR,
+      evaluateFullReadAccess: ALLOW_FULL_READ,
+    }))
       .toEqual({ ok: false, reason: 'identity-invalid' })
     // cross-actor replay: a preview minted for ACTOR is unusable by another actor ⇒ identity-invalid.
     expect(await executeExactAnchorRecovery(q, { token: res.token, sheetId: SHEET, actorId: `${ACTOR}_other`, evaluateFullReadAccess: ALLOW_FULL_READ }))

--- a/packages/core-backend/tests/integration/multitable-history-contiguity-strict-seq-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-contiguity-strict-seq-realdb.test.ts
@@ -46,6 +46,7 @@ import { poolManager } from '../../src/integration/db/connection-pool'
 import { univerMetaRouter } from '../../src/routes/univer-meta'
 import { precheckSheetHistoryIntegrity, precheckSheetHistoryIntegrityStrict } from '../../src/multitable/history-integrity-precheck'
 import { activateCheckpoint, type QueryFn } from '../../src/multitable/history-trust-checkpoint'
+import { checkStrictEnablementPrecondition } from '../../src/multitable/history-trust-precondition'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
@@ -106,7 +107,8 @@ async function sheetWriteState(sheet: string) {
 }
 
 /**
- * Owner P2 (2026-07-16): under the flipped strict-enablement gate, EVERY strict-flag-on production request
+ * Owner P2 (2026-07-16): under the wired strict-enablement gate (seam held false — owner ruling 2026-07-17),
+ * EVERY strict-flag-on production request
  * refuses `strict_enablement_unmet` before the comparator runs — so the HTTP 409 alone would be a VACUOUS
  * proof of the chain-level verdict. This helper therefore asserts BOTH layers: the comparator itself (called
  * directly — the pure strict function, per the owner's prescription) returns the expected chain-level reason,
@@ -354,7 +356,7 @@ describeIfDatabase('W0-1 v3.7 STRICT history contiguity — seq-ordered, ALL gen
   })
 
   // ── POSITIVE CONTROL ─────────────────────────────────────────────────────────────────────────────────────
-  test('POSITIVE CONTROL: strict comparator passes the healthy chain; the full revert executes end-to-end (flag off — strict-on HTTP is gate-refused pre-L6)', async () => {
+  test('POSITIVE CONTROL: strict comparator passes the healthy chain; the full revert executes end-to-end (flag off — strict-on HTTP is gate-refused for this checkpoint-less sheet)', async () => {
     const pool = poolManager.get()
     expect(await precheckSheetHistoryIntegrityStrict(pool.query.bind(pool), SHEET)).toEqual({ ok: true })
     delete process.env.MULTITABLE_HISTORY_CONTIGUITY_STRICT
@@ -368,28 +370,38 @@ describeIfDatabase('W0-1 v3.7 STRICT history contiguity — seq-ordered, ALL gen
     expect(h?.version).toBe(3)
   })
 
-  // ── STRICT-ENABLEMENT GATE (owner P2, 2026-07-16 — the no-checkpoint refusal golden) ────────────────────
-  test('ENABLEMENT-GATE: with the strict flag ON the production path refuses fail-closed with zero writes — for a NO-checkpoint sheet AND for a checkpoint-bearing sheet (causality unlanded) — via the same values-free envelope', async () => {
-    // The shared fixture record is HEALTHY (the strict comparator passes it) — the refusal below is therefore
-    // attributable ONLY to the enablement gate, not to any chain verdict.
+  // ── STRICT-ENABLEMENT GATE (owner P2, 2026-07-16; seam HELD false, owner ruling 2026-07-17) ─────────────
+  test('ENABLEMENT-GATE: strict ON — a NO-checkpoint sheet refuses fail-closed with zero writes; a checkpoint-bearing HEALTHY sheet is STILL refused (seam held false until the Revert/Reset wiring PR)', async () => {
+    // The shared fixture record is HEALTHY (the strict comparator passes it), so any gate verdict below is
+    // attributable ONLY to the enablement precondition, not to a chain verdict.
     const pool = poolManager.get()
     expect(await precheckSheetHistoryIntegrityStrict(pool.query.bind(pool), SHEET)).toEqual({ ok: true })
 
-    // (a) NO active checkpoint: refuse, zero writes, unified values-free envelope (no oracle — D-1c rule 1).
-    const before = await sheetWriteState(SHEET)
+    // (a) NO active checkpoint: BOTH halves unmet (the seam is held false too). The WIRED entry returns
+    // `strict_enablement_unmet`, and the production HTTP surface refuses with the unified values-free
+    // envelope + zero writes (no oracle — D-1c).
+    const beforeState = await sheetWriteState(SHEET)
+    const preNoCkpt = await checkStrictEnablementPrecondition(pool.query.bind(pool), SHEET)
+    expect(preNoCkpt.canEnable).toBe(false)
+    expect([...preNoCkpt.unmet].sort()).toEqual(['no_active_checkpoint', 'reconstruction_non_causal'])
+    expect(await precheckSheetHistoryIntegrity(pool.query.bind(pool), SHEET)).toEqual({ ok: false, reason: 'strict_enablement_unmet' })
     const pv1 = await revertPreview(SHEET)
     expect(pv1.status).toBe(409)
     expect(pv1.body).toEqual(HISTORY_INCOMPLETE_BODY)
-    expect(await sheetWriteState(SHEET)).toEqual(before)
+    expect(await sheetWriteState(SHEET)).toEqual(beforeState)
 
-    // (b) checkpoint-BEARING sheet: STILL refused (condition (b) reconstruction causality is unlanded pre-L6)
-    // — proving the refusal is unconditional on !canEnable, not scoped to the no-checkpoint case (the exact
-    // production bypass the owner rejected).
+    // (b) checkpoint-BEARING sheet: the refusal narrows to EXACTLY the held-back seam — and the WIRED entry
+    // STILL refuses. This is the backstop pin at the wired layer (owner ruling 2026-07-17): even a healthy,
+    // checkpoint-bearing sheet stays categorically refused until the PR that wires legacy Revert/Reset onto
+    // the L8 exact-anchor apply flips `RECONSTRUCTION_CAUSALITY_LANDED`. The unmet SET changing (not just its
+    // size) proves the checkpoint half is evaluated independently on this path.
     await pool.transaction(async ({ query }) => activateCheckpoint(query as unknown as QueryFn, { sheetId: SHEET }))
-    const pv2 = await revertPreview(SHEET)
-    expect(pv2.status).toBe(409)
-    expect(pv2.body).toEqual(HISTORY_INCOMPLETE_BODY)
-    expect(await sheetWriteState(SHEET)).toEqual(before)
+    const preCkpt = await checkStrictEnablementPrecondition(pool.query.bind(pool), SHEET)
+    expect(preCkpt).toEqual({ canEnable: false, unmet: ['reconstruction_non_causal'] })
+    expect(await precheckSheetHistoryIntegrity(pool.query.bind(pool), SHEET)).toEqual({ ok: false, reason: 'strict_enablement_unmet' })
+    // The comparator itself still PASSES the healthy chain when called directly — the refusal above is the
+    // gate, not a chain verdict (keeps this golden non-vacuous about WHAT refused).
+    expect(await precheckSheetHistoryIntegrityStrict(pool.query.bind(pool), SHEET)).toEqual({ ok: true })
     // cleanup: remove the checkpoint rows so sibling tests see a checkpoint-free sheet.
     await q('DELETE FROM meta_history_baselines WHERE sheet_id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_history_trust_checkpoints WHERE sheet_id = $1', [SHEET]).catch(() => {})

--- a/packages/core-backend/tests/integration/multitable-history-trust-checkpoint-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-trust-checkpoint-realdb.test.ts
@@ -411,18 +411,22 @@ describeIfDatabase('W0-1 v3.7 L5 trust checkpoint (real DB)', () => {
     expect(ck?.system_kind).toBe('approval_projection')
   })
 
-  // ── P3-2 ENABLEMENT PRECONDITION (real-DB checkpoint half) ───────────────────────────────────────────
-  test('checkStrictEnablementPrecondition detects the active-checkpoint half against a real DB, and stays fail-closed until L6', async () => {
+  // ── P3-2 ENABLEMENT PRECONDITION (real-DB checkpoint half) — the HELD-FALSE BACKSTOP PIN ─────────────
+  test('checkStrictEnablementPrecondition: checkpoint-less sheet lists BOTH unmet; a checkpoint-bearing sheet is STILL refused (seam held false until the Revert/Reset wiring PR)', async () => {
     const S = await mkSheet()
-    // No checkpoint yet: both conditions unmet.
+    // No checkpoint yet AND the seam is held false ⇒ BOTH conditions listed (the guard distinguishes them).
     const before = await checkStrictEnablementPrecondition(q, S)
     expect(before.canEnable).toBe(false)
     expect([...before.unmet].sort()).toEqual(['no_active_checkpoint', 'reconstruction_non_causal'])
 
     await activate(S)
-    // Checkpoint half now satisfied — ONLY reconstruction remains unmet (still fail-closed: L6 not landed).
+    // Checkpoint half satisfied — the refusal narrows to EXACTLY the held-back seam. This is the end-to-end
+    // backstop pin (owner ruling 2026-07-17): a trustworthy, checkpoint-bearing sheet is STILL categorically
+    // refused until the PR that wires legacy Revert/Reset onto the L8 apply flips the seam. It also proves the
+    // checkpoint half is evaluated independently on the WIRED path (not a count-only guard): activating the
+    // checkpoint changed the unmet SET, not just its size.
     const after = await checkStrictEnablementPrecondition(q, S)
-    expect(after.canEnable).toBe(false) // GUARD stays fail-closed until L6 — must not pass
+    expect(after.canEnable).toBe(false)
     expect(after.unmet).toEqual(['reconstruction_non_causal'])
   })
 })

--- a/packages/core-backend/tests/unit/multitable-exact-anchor-recovery-identity.test.ts
+++ b/packages/core-backend/tests/unit/multitable-exact-anchor-recovery-identity.test.ts
@@ -1,0 +1,134 @@
+/**
+ * W0-1 v3.7 Lane L6-b — UNIT tests for the EXACT-ANCHOR recovery preview-identity (design-lock #4331 §1.3 /
+ * §9 item 6). The signed identity is the destructive-recovery authority: execute takes the TOKEN-BOUND
+ * `anchorSeq` and never recomputes `MAX(seq)`, so the token must be unforgeable, non-replayable across
+ * sheet/actor, type-disjoint from every sibling preview token, and fail-closed on a malformed anchor. These are
+ * pure (no DB); the real-DB resolve/execute path is `tests/integration/multitable-exact-anchor-recovery-realdb.test.ts`.
+ */
+import { describe, expect, test } from 'vitest'
+
+import {
+  hashAnchorRecoveryScope,
+  mintExactAnchorRecoveryIdentity,
+  verifyExactAnchorRecoveryIdentity,
+  mintPitRevertPreviewIdentity,
+  type ExactAnchorRecoveryIdentityClaims,
+} from '../../src/multitable/restore-preview-identity'
+
+const CLAIMS: ExactAnchorRecoveryIdentityClaims = {
+  sheetId: 'sheet_ear_unit',
+  anchorOperationId: '11111111-1111-4111-8111-111111111111',
+  anchorSeq: '7003',
+  checkpointId: 'ckpt_ear_unit',
+  scopeHash: 'a'.repeat(64),
+  liveSetHash: 'd'.repeat(64),
+  actorId: 'user_ear_unit',
+  mode: 'revert',
+  authorizedScopeHash: 'd'.repeat(64),
+}
+const expected = { sheetId: CLAIMS.sheetId, actorId: CLAIMS.actorId }
+
+describe('L6-b exact-anchor recovery identity — mint/verify', () => {
+  test('round-trip: a valid token verifies and returns the exact TOKEN-BOUND claims', () => {
+    const r = verifyExactAnchorRecoveryIdentity(mintExactAnchorRecoveryIdentity(CLAIMS), expected)
+    expect(r.valid).toBe(true)
+    expect(r.claims).toEqual(CLAIMS) // execute reads anchorSeq/checkpointId/scopeHash from here — must be exact
+  })
+
+  test('cross-sheet replay is refused (mismatch_sheetId): a token for sheet A cannot drive sheet B', () => {
+    const r = verifyExactAnchorRecoveryIdentity(mintExactAnchorRecoveryIdentity(CLAIMS), { sheetId: 'sheet_other', actorId: CLAIMS.actorId })
+    expect(r).toMatchObject({ valid: false, reason: 'mismatch_sheetId' })
+    expect(r.claims).toBeUndefined()
+  })
+
+  test('cross-actor replay is refused (mismatch_actorId): a preview minted for A is unusable by B', () => {
+    const r = verifyExactAnchorRecoveryIdentity(mintExactAnchorRecoveryIdentity(CLAIMS), { sheetId: CLAIMS.sheetId, actorId: 'user_other' })
+    expect(r).toMatchObject({ valid: false, reason: 'mismatch_actorId' })
+  })
+
+  test('token confusion is refused (wrong_type): a sibling restore-preview token cannot be replayed as an anchor token', () => {
+    // Same server secret, valid signature, but a DIFFERENT type — the disjoint `type` check rejects it.
+    const pitRevert = mintPitRevertPreviewIdentity({
+      sheetId: CLAIMS.sheetId, asOf: '2026-06-01T00:00:00Z', strategy: 'revert',
+      scopeHash: 'b'.repeat(64), resurrectScopeHash: 'c'.repeat(64), actorId: CLAIMS.actorId,
+    })
+    expect(verifyExactAnchorRecoveryIdentity(pitRevert, expected)).toMatchObject({ valid: false, reason: 'wrong_type' })
+  })
+
+  test('malformed anchorSeq fails closed (malformed_anchorSeq): a signed-but-garbage anchor never reaches ::bigint', () => {
+    const bad = mintExactAnchorRecoveryIdentity({ ...CLAIMS, anchorSeq: 'not-a-number' })
+    expect(verifyExactAnchorRecoveryIdentity(bad, expected)).toMatchObject({ valid: false, reason: 'malformed_anchorSeq' })
+    // a NEGATIVE seq is not a decimal bigint string either.
+    const neg = mintExactAnchorRecoveryIdentity({ ...CLAIMS, anchorSeq: '-1' })
+    expect(verifyExactAnchorRecoveryIdentity(neg, expected)).toMatchObject({ valid: false, reason: 'malformed_anchorSeq' })
+  })
+
+  test('malformed claims fail closed (malformed_claims): empty required token-authority fields (not anchorSeq)', () => {
+    // NIT-1 precision: empty checkpoint / liveSetHash are shape defects, NOT pre-contract and NOT anchorSeq.
+    const emptyCkpt = mintExactAnchorRecoveryIdentity({ ...CLAIMS, checkpointId: '' })
+    expect(verifyExactAnchorRecoveryIdentity(emptyCkpt, expected)).toMatchObject({ valid: false, reason: 'malformed_claims' })
+    const noLive = mintExactAnchorRecoveryIdentity({ ...CLAIMS, liveSetHash: '' })
+    expect(verifyExactAnchorRecoveryIdentity(noLive, expected)).toMatchObject({ valid: false, reason: 'malformed_claims' })
+  })
+
+  test('P1 token contract — mode is REQUIRED and closed-vocabulary: a pre-contract token (no mode) and a garbage mode both fail closed as pre_contract_token', () => {
+    // A token signed under the PRE-contract shape (its destructive semantics were caller-chosen) must
+    // verify INVALID — deliberate hard cutover; the module is unwired so no live token predates this.
+    // NIT-1: reason is `pre_contract_token` (not the imprecise `malformed_anchorSeq`).
+    const { mode: _m, ...noMode } = CLAIMS
+    const preContract = mintExactAnchorRecoveryIdentity(noMode as unknown as ExactAnchorRecoveryIdentityClaims)
+    expect(verifyExactAnchorRecoveryIdentity(preContract, expected)).toMatchObject({ valid: false, reason: 'pre_contract_token' })
+    // A signed-but-out-of-vocabulary mode never reaches the apply's mode switch.
+    const badMode = mintExactAnchorRecoveryIdentity({ ...CLAIMS, mode: 'purge' as unknown as ExactAnchorRecoveryIdentityClaims['mode'] })
+    expect(verifyExactAnchorRecoveryIdentity(badMode, expected)).toMatchObject({ valid: false, reason: 'pre_contract_token' })
+  })
+
+  test('P1 token contract — authorizedScopeHash is REQUIRED: a token without the signed authorization basis fails closed as pre_contract_token', () => {
+    const { authorizedScopeHash: _a, ...noAuth } = CLAIMS
+    const preContract = mintExactAnchorRecoveryIdentity(noAuth as unknown as ExactAnchorRecoveryIdentityClaims)
+    expect(verifyExactAnchorRecoveryIdentity(preContract, expected)).toMatchObject({ valid: false, reason: 'pre_contract_token' })
+    const empty = mintExactAnchorRecoveryIdentity({ ...CLAIMS, authorizedScopeHash: '' })
+    expect(verifyExactAnchorRecoveryIdentity(empty, expected)).toMatchObject({ valid: false, reason: 'pre_contract_token' })
+  })
+
+  test('round-trip carries mode + authorizedScopeHash EXACTLY (execute obeys the token, never the request)', () => {
+    const reset = verifyExactAnchorRecoveryIdentity(mintExactAnchorRecoveryIdentity({ ...CLAIMS, mode: 'reset' }), expected)
+    expect(reset.valid).toBe(true)
+    expect(reset.claims?.mode).toBe('reset')
+    expect(reset.claims?.authorizedScopeHash).toBe(CLAIMS.authorizedScopeHash)
+  })
+
+  test('an expired token is refused (expired), not silently accepted', () => {
+    const r = verifyExactAnchorRecoveryIdentity(mintExactAnchorRecoveryIdentity(CLAIMS, -10), expected)
+    expect(r).toMatchObject({ valid: false, reason: 'expired' })
+  })
+
+  test('a signature-tampered token is refused (invalid)', () => {
+    const token = mintExactAnchorRecoveryIdentity(CLAIMS)
+    const tampered = token.slice(0, -1) + (token.slice(-1) === 'A' ? 'B' : 'A')
+    expect(verifyExactAnchorRecoveryIdentity(tampered, expected)).toMatchObject({ valid: false, reason: 'invalid' })
+  })
+})
+
+describe('L6-b hashAnchorRecoveryScope — order-invariant, drift-sensitive', () => {
+  const a = { recordId: 'r-a', exists: true, version: 1 }
+  const b = { recordId: 'r-b', exists: true, version: 3 }
+  const del = { recordId: 'r-c', exists: false, version: null }
+
+  test('order-invariant: the same set in a different order hashes identically', () => {
+    expect(hashAnchorRecoveryScope([a, b, del])).toBe(hashAnchorRecoveryScope([del, b, a]))
+  })
+
+  test('drift-sensitive: a changed version, changed existence, or added/removed record changes the hash', () => {
+    const base = hashAnchorRecoveryScope([a, b])
+    expect(hashAnchorRecoveryScope([{ ...a, version: 2 }, b])).not.toBe(base) // version bump
+    expect(hashAnchorRecoveryScope([{ ...a, exists: false, version: null }, b])).not.toBe(base) // deleted
+    expect(hashAnchorRecoveryScope([a, b, del])).not.toBe(base) // a post-anchor record appears (the MAX-recompute drift)
+  })
+
+  test('a deleted record contributes a null version (it has none as of the anchor)', () => {
+    // exists:false with any stored version must hash the same as exists:false with null — a delete has no version.
+    expect(hashAnchorRecoveryScope([{ recordId: 'r', exists: false, version: 9 }]))
+      .toBe(hashAnchorRecoveryScope([{ recordId: 'r', exists: false, version: null }]))
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-history-trust-checkpoint.test.ts
+++ b/packages/core-backend/tests/unit/multitable-history-trust-checkpoint.test.ts
@@ -87,7 +87,11 @@ describe('L5 anchor-covering retention (selectRetentionCoveringSeq) — P1-c', (
 })
 
 describe('L5 P3-2 strict-enablement precondition (pure)', () => {
-  test('the L6 seam is still OFF — reconstruction is not yet causal', () => {
+  test('the L6 seam is HELD false — the backstop stays until the Revert/Reset wiring PR (owner ruling 2026-07-17)', () => {
+    // L6-b landed the causal `reconstructRecordsAtSeq` MECHANISM, but the owner ruled the seam flips to true
+    // only in the same PR that wires the legacy Revert/Reset routes onto the L8 exact-anchor apply (backstop
+    // removal + its consumers = one reviewable change). This golden is the PREMATURE-FLIP TRIPWIRE: any PR
+    // that flips the constant without also owning this assertion (i.e. the wiring PR, deliberately) reds here.
     expect(RECONSTRUCTION_CAUSALITY_LANDED).toBe(false)
   })
 
@@ -98,9 +102,9 @@ describe('L5 P3-2 strict-enablement precondition (pure)', () => {
   })
 
   test('DISTINGUISHES the two conditions: active checkpoint present but reconstruction non-causal ⇒ ONLY reconstruction listed', () => {
-    // Proves the guard evaluates the checkpoint half independently (not a count-only guard). This is the
-    // real pre-L6 production shape: a sheet DOES have an active checkpoint, but L6 has not landed. The wired
-    // gate keys off exactly this: no_active_checkpoint absent ⇒ checkpoint-bearing ⇒ refuse.
+    // Proves the guard evaluates the checkpoint half independently (not a count-only guard). While the seam
+    // is HELD false this is exactly the PRODUCTION state of a checkpoint-bearing sheet — the wired path's
+    // refusal is attributable solely to the held-back seam, never silently to the checkpoint half.
     const r = evaluateStrictEnablementPrecondition({ hasActiveCheckpoint: true, reconstructionIsCausal: false })
     expect(r.canEnable).toBe(false)
     expect(r.unmet).toEqual(['reconstruction_non_causal'])

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -407,6 +407,11 @@ export default defineConfig({
       // skip-green it, and whole-file wired into `Run multitable real-DB integration` in plugin-tests.yml.
       // Two-point wiring: BOTH points or the file silently never runs.
       'tests/integration/multitable-history-contiguity-realdb.test.ts',
+      // W0 L6-b exact-anchor authority goldens: DATABASE_URL-gated and meaningful only against real
+      // Postgres. Exclude from the no-DB default lane so it cannot skip-green, and keep the whole file
+      // wired into `Run multitable real-DB integration` in plugin-tests.yml. The no-DB wiring contract
+      // pins both points.
+      'tests/integration/multitable-exact-anchor-recovery-realdb.test.ts',
       // D-1c W0 slice ① (form-submit CREATE/EDIT public-form revision goldens): real Postgres only
       // (installs scoped failure/suppression triggers per site and drives the real submit route
       // end-to-end) — excluded HERE so it cannot skip-green in the no-DB lane, whole-file wired into

--- a/scripts/ops/global-history-flag-manifest.mjs
+++ b/scripts/ops/global-history-flag-manifest.mjs
@@ -379,20 +379,21 @@ export const GLOBAL_HISTORY_FLAG_MANIFEST = Object.freeze([
     source: 'packages/core-backend/src/multitable/history-integrity-precheck.ts:100,459',
     // P3-2 FLAG-ON PRECONDITION (design lock §3/§9; L5). This flag — and later Revert/Reset enablement — MUST
     // NOT be relied upon for a sheet unless BOTH: (a) an ACTIVE trust checkpoint exists for the sheet, AND
-    // (b) reconstruction causality is satisfied. Condition (b) is NOT yet satisfiable: the reconstructor still
-    // selects by created_at<=T (non-causal) until Lane L6 lands the exact event-anchor resolver, so this
-    // precondition CURRENTLY FAILS CLOSED for every checkpoint-bearing sheet — which is CORRECT ("migration/
-    // backfill presence alone never enables recovery"). WIRED (L5 P2): enforced by
-    // checkStrictEnablementPrecondition, CALLED from precheckSheetHistoryIntegrity's strict branch (the
-    // authoritative strict-mode entry the Revert/Reset routes traverse). A checkpoint-bearing sheet with the
-    // strict flag on is refused fail-closed (`strict_enablement_unmet`) until L6; the single L6 seam is the
-    // RECONSTRUCTION_CAUSALITY_LANDED constant. The refusal is UNCONDITIONAL on !canEnable (owner P2,
-    // 2026-07-16 — an earlier scope-seam exemption for no-checkpoint sheets was a production bypass and is
-    // REMOVED); goldens that need the comparator call the exported precheckSheetHistoryIntegrityStrict
-    // directly. Do not weaken it to pass. (Not modeled as a cross-flag rule: conditions (a)/(b) are runtime
-    // STATE, not other flag env values.)
+    // (b) reconstruction causality is satisfied. The MECHANISM for (b) landed with Lane L6-b (the causal
+    // reconstructRecordsAtSeq, seq-anchored), but RECONSTRUCTION_CAUSALITY_LANDED is DELIBERATELY HELD false
+    // (owner ruling 2026-07-17): the seam flips only in the PR that wires legacy Revert/Reset onto the L8
+    // exact-anchor apply. Until then strict-on refuses EVERY sheet — checkpoint-bearing included
+    // (`reconstruction_non_causal`) — the last code-level fail-closed backstop is RETAINED. Gating the strict
+    // flag ON remains the operator's default-OFF decision ("migration/backfill presence alone never enables
+    // recovery"). WIRED
+    // (L5 P2): enforced by checkStrictEnablementPrecondition, CALLED from precheckSheetHistoryIntegrity's
+    // strict branch (the authoritative strict-mode entry the Revert/Reset routes traverse). The refusal is
+    // UNCONDITIONAL on !canEnable (owner P2, 2026-07-16 — an earlier scope-seam exemption for no-checkpoint
+    // sheets was a production bypass and is REMOVED); goldens that need the comparator call the exported
+    // precheckSheetHistoryIntegrityStrict directly. Do not weaken it to pass. (Not modeled as a cross-flag
+    // rule: conditions (a)/(b) are runtime STATE, not other flag env values.)
     enablementPrecondition:
-      'L5/P3-2 (checkStrictEnablementPrecondition): requires (a) an active meta_history_trust_checkpoints row for the sheet AND (b) RECONSTRUCTION_CAUSALITY_LANDED (L6). Fails closed until L6.',
+      'L5/P3-2 (checkStrictEnablementPrecondition): requires (a) an active meta_history_trust_checkpoints row for the sheet AND (b) RECONSTRUCTION_CAUSALITY_LANDED — DELIBERATELY HELD false (owner ruling 2026-07-17): the causal reconstructor mechanism landed with L6-b, but the seam flips only in the PR that wires legacy Revert/Reset onto the L8 exact-anchor apply. Until then strict-on refuses EVERY sheet (checkpoint-bearing included, reason reconstruction_non_causal) — the fail-closed backstop is retained. The flag itself stays the operator decision (default OFF).',
     enablementPreconditionSource:
       'packages/core-backend/src/multitable/history-trust-precondition.ts (RECONSTRUCTION_CAUSALITY_LANDED, evaluateStrictEnablementPrecondition, checkStrictEnablementPrecondition)',
     enablementEnforcedVia:

--- a/scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
+++ b/scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
@@ -10,17 +10,195 @@ import { fileURLToPath } from 'node:url'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '..', '..')
 const FILE = 'tests/integration/multitable-exact-anchor-recovery-realdb.test.ts'
+const REAL_DB_STEP = 'Run multitable real-DB integration'
+
+function maskCommentsAndStrings(src) {
+  let out = ''
+  let i = 0
+  while (i < src.length) {
+    if (src[i] === '/' && src[i + 1] === '/') {
+      out += '  '
+      i += 2
+      while (i < src.length && src[i] !== '\n') {
+        out += ' '
+        i++
+      }
+      continue
+    }
+    if (src[i] === '/' && src[i + 1] === '*') {
+      out += '  '
+      i += 2
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) {
+        out += src[i] === '\n' ? '\n' : ' '
+        i++
+      }
+      if (i < src.length) {
+        out += '  '
+        i += 2
+      }
+      continue
+    }
+    if (src[i] === "'" || src[i] === '"') {
+      const quote = src[i]
+      out += ' '
+      i++
+      while (i < src.length && src[i] !== quote) {
+        if (src[i] === '\\' && i + 1 < src.length) {
+          out += '  '
+          i += 2
+          continue
+        }
+        out += src[i] === '\n' ? '\n' : ' '
+        i++
+      }
+      if (i < src.length) {
+        out += ' '
+        i++
+      }
+      continue
+    }
+    out += src[i]
+    i++
+  }
+  return out
+}
+
+function testExcludeEntries(src) {
+  const masked = maskCommentsAndStrings(src)
+  const testKey = /\btest\s*:\s*\{/.exec(masked)
+  assert.ok(testKey, 'vitest config must contain a test object')
+  const openBrace = masked.indexOf('{', testKey.index + testKey[0].length - 1)
+  let depth = 1
+  for (let i = openBrace + 1; i < masked.length && depth > 0; i++) {
+    if (masked[i] === '{') depth++
+    else if (masked[i] === '}') depth--
+    else if (depth === 1) {
+      const match = /^(exclude\s*:\s*\[)/.exec(masked.slice(i))
+      if (!match) continue
+      const arrayStart = i + match[1].length - 1
+      let arrayDepth = 0
+      for (let j = arrayStart; j < masked.length; j++) {
+        if (masked[j] === '[') arrayDepth++
+        else if (masked[j] === ']' && --arrayDepth === 0) {
+          const body = src
+            .slice(arrayStart + 1, j)
+            .split('\n')
+            .map((line) => line.replace(/\/\/.*$/, ''))
+            .join('\n')
+          return [...body.matchAll(/'([^']+)'|"([^"]+)"/g)].map(
+            (entry) => entry[1] ?? entry[2],
+          )
+        }
+      }
+    }
+  }
+  return []
+}
+
+function namedStepBody(workflow, nameNeedle) {
+  const lines = workflow.split('\n')
+  let start = -1
+  let indent = ''
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(/^(\s*)- name:\s*(.*)$/)
+    if (match && match[2].includes(nameNeedle)) {
+      start = i
+      indent = match[1]
+      break
+    }
+  }
+  assert.ok(
+    start >= 0,
+    `workflow step containing ${JSON.stringify(nameNeedle)} not found`,
+  )
+  const body = []
+  for (let i = start + 1; i < lines.length; i++) {
+    const match = lines[i].match(/^(\s*)- name:\s*/)
+    if (match && match[1] === indent) break
+    body.push(lines[i])
+  }
+  return body.join('\n')
+}
+
+function stepHasEnvKey(stepBody, key) {
+  const lines = stepBody.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const env = /^(\s*)env:\s*$/.exec(lines[i])
+    if (!env) continue
+    const envIndent = env[1].length
+    for (let j = i + 1; j < lines.length; j++) {
+      if (/^\s*(?:#.*)?$/.test(lines[j])) continue
+      const indent = lines[j].match(/^(\s*)/)[1].length
+      if (indent <= envIndent) break
+      if (new RegExp(`^\\s*${key}:\\s*\\S`).test(lines[j])) return true
+    }
+  }
+  return false
+}
+
+function wholeFileVitestArgs(stepBody) {
+  return stepBody.split('\n').flatMap((line) => {
+    if (/^\s*#/.test(line)) return []
+    const match = line.match(
+      /^\s+(tests\/integration\/\S+\.(?:test|spec)\.[tj]sx?)\s*(?:\\)?\s*$/,
+    )
+    return match ? [match[1]] : []
+  })
+}
 
 test('vitest.config.ts excludes the exact-anchor authority suite from the no-DB job', () => {
-  const config = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
-  assert.ok(config.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+  const config = readFileSync(
+    join(repoRoot, 'packages/core-backend/vitest.config.ts'),
+    'utf8',
+  )
+  assert.ok(
+    testExcludeEntries(config).includes(FILE),
+    `test.exclude must contain the exact entry ${FILE}`,
+  )
 })
 
 test('plugin-tests.yml runs the exact-anchor authority suite as a whole file with real Postgres', () => {
-  const workflow = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
-  assert.match(
-    workflow,
-    new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`),
-    `plugin-tests.yml must run ${FILE} in the multitable real-DB step`,
+  const workflow = readFileSync(
+    join(repoRoot, '.github/workflows/plugin-tests.yml'),
+    'utf8',
   )
+  const step = namedStepBody(workflow, REAL_DB_STEP)
+  assert.ok(
+    stepHasEnvKey(step, 'DATABASE_URL'),
+    `${REAL_DB_STEP} must define DATABASE_URL`,
+  )
+  assert.ok(
+    stepHasEnvKey(step, 'METASHEET_REAL_DB_TEST_STEP'),
+    `${REAL_DB_STEP} must set the fail-not-skip marker`,
+  )
+  assert.match(
+    step,
+    /\bvitest\b[^\n]*--config\s+vitest\.integration\.config\.ts\b/,
+  )
+  assert.ok(
+    wholeFileVitestArgs(step).includes(FILE),
+    `${REAL_DB_STEP} must run ${FILE} as a whole-file argument`,
+  )
+})
+
+test('placement parsers reject comment-only and wrong-step decoys', () => {
+  const configDecoy = `export default defineConfig({ test: { // '${FILE}'\nexclude: ['other.test.ts'] } })`
+  assert.equal(testExcludeEntries(configDecoy).includes(FILE), false)
+
+  const workflowDecoy = [
+    'steps:',
+    `  # ${FILE}`,
+    '  - name: Run some other integration',
+    '    env:',
+    '      DATABASE_URL: postgresql://example',
+    '      METASHEET_REAL_DB_TEST_STEP: 1',
+    '    run: |',
+    '      pnpm exec vitest --config vitest.integration.config.ts run \\',
+    `        ${FILE} \\`,
+    `  - name: ${REAL_DB_STEP}`,
+    '    run: echo no-db',
+  ].join('\n')
+  const realStep = namedStepBody(workflowDecoy, REAL_DB_STEP)
+  assert.equal(stepHasEnvKey(realStep, 'DATABASE_URL'), false)
+  assert.equal(wholeFileVitestArgs(realStep).includes(FILE), false)
 })

--- a/scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
+++ b/scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+// W0 L6-b CI two-point wiring contract. The exact-anchor authority suite is DATABASE_URL-gated and
+// must have BOTH (1) a vitest.config.ts exclusion so the no-DB lane cannot skip-green it and (2) a
+// whole-file entry in plugin-tests.yml's multitable real-DB step. Removing either point must fail CI.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const FILE = 'tests/integration/multitable-exact-anchor-recovery-realdb.test.ts'
+
+test('vitest.config.ts excludes the exact-anchor authority suite from the no-DB job', () => {
+  const config = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+  assert.ok(config.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE}`)
+})
+
+test('plugin-tests.yml runs the exact-anchor authority suite as a whole file with real Postgres', () => {
+  const workflow = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+  assert.match(
+    workflow,
+    new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`),
+    `plugin-tests.yml must run ${FILE} in the multitable real-DB step`,
+  )
+})


### PR DESCRIPTION
## Scope

Current-main successor for the standalone L6-b mechanism from #4417. It adds the exact-anchor recovery authority, seq-based causal reconstructor, and signed P1 token contract without wiring a production route. The old PR/branch was not modified or closed.

Hard posture:
- `RECONSTRUCTION_CAUSALITY_LANDED` remains `false`.
- Revert, Reset, and strict-contiguity flags remain default-OFF.
- No production caller reaches `resolveExactAnchor` or `executeExactAnchorRecovery`.
- Wall-clock destructive anchors fail closed; History batches resolve server-side to the sealed terminal operation.

## Implementation and review

Grok Build ported the gated #4417 patch onto current main in an isolated worktree and fixed the prior diagnostic NIT by separating `pre_contract_token`, `malformed_claims`, and `malformed_anchorSeq`. Codex independently reviewed the final diff, verified the existing `(sheet_id, batch_id)` index, confirmed zero production callers/default-OFF posture, and corrected two stale comments. No blocking findings remain.

## Verification

- backend TypeScript check: pass
- unit: 31/31
- fresh PostgreSQL full migration: pass
- exact-anchor + checkpoint + strict-seq real-DB: 49/49
- independent C2 mutation (`ORDER BY seq DESC` to `created_at DESC`): exactly the causal-order golden failed; restore returned 15/15 green
- `git diff --check`: pass

## Boundaries

This PR does not port L7/L8, remove the held backstop, wire legacy Revert/Reset, enable flags, or deploy anything. Those remain serial follow-ups after owner review.