### PR TITLE
feat(multitable): W0 L7 exact-anchor recovery plan on current L6-b

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -519,6 +519,7 @@ jobs:
             tests/integration/multitable-history-trust-checkpoint-realdb.test.ts \
             tests/integration/multitable-l5wire-checkpoint-activation-realdb.test.ts \
             tests/integration/multitable-exact-anchor-recovery-realdb.test.ts \
+            tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts \
             tests/integration/multitable-d1c-form-submit-revision-realdb.test.ts \
             tests/integration/multitable-d1c-plugin-revision-realdb.test.ts \
             tests/integration/multitable-d1c-automation-revision-realdb.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -150,9 +150,9 @@ jobs:
       - name: Global History flag manifest contract (R12-C)
         run: node --test scripts/ops/global-history-flag-manifest.test.mjs scripts/ops/multitable-global-history-flag-status.test.mjs
 
-      # W0 L6-b CI two-point wiring contract (no DB): the exact-anchor authority real-DB suite must
-      # stay excluded from the no-DB Vitest lane and named in the multitable real-DB whole-file step.
-      - name: W0 L6-b exact-anchor CI wiring contract
+      # W0 L6/L7 CI two-point wiring contract (no DB): both exact-anchor real-DB suites must stay
+      # excluded from the no-DB Vitest lane and named in the multitable real-DB whole-file step.
+      - name: W0 exact-anchor L6/L7 CI wiring contract
         run: node --test scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
 
       # PB4-2 CI two-point wiring contract (no DB): the archive-read-only two-connection suite must

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-plan.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-plan.ts
@@ -1,0 +1,168 @@
+import type { QueryFn } from './permission-service'
+import { reconstructRecordsAtSeq } from './record-reconstructor'
+import { assertSeqString } from './history-trust-checkpoint'
+
+/**
+ * W0-1 v3.7 Lane L7 — the EXACT-ANCHOR recovery PLAN (target-set classification for execute).
+ *
+ * Design authority: `…v37-exact-anchor-trust-design-lock-20260715.md` (#4331) §5 (execute = full
+ * target/schema/set recomputation under the fence) + §9 item 3 (target-generation A) + item 5. Builds on
+ * L6-b: the causal reconstructor already resolves each record's TARGET-GENERATION state at the exact
+ * `anchorSeq` (a delete→recreate chain reconstructs to the generation whose window contains the anchor —
+ * proven by the MULTI-GEN golden), so this layer's job is the remaining §5 semantics: classify the FULL
+ * record set (live ∪ at-anchor, deleted/trash-aware) into the executable plan a destructive apply consumes.
+ *
+ * CLASSIFICATION (per record, target = as-of-anchorSeq state from `reconstructRecordsAtSeq`):
+ *   target EXISTS + live row present  → REVERT candidate (live differs from target; identical rows skipped)
+ *   target EXISTS + no live row       → RESURRECT candidate (deleted AFTER the anchor; carries the full
+ *                                       at-anchor snapshot — never the trash row's terminal-vintage data)
+ *   target DELETED (delete ≤ anchor) + live row → `deletedAtAnchorLiveNow` (the record was deleted as of the
+ *                                       anchor but was later resurrected): Revert semantics KEEP it
+ *                                       (non-destructive); Reset semantics delete it. The plan EXPOSES the
+ *                                       list; the L8 caller picks — this module never chooses destruction.
+ *   target DELETED + no live row      → unchanged (stays deleted; NEVER resurrected — LOCK-9).
+ *   absent from stateMap + live row   → `createdAfterAnchor` (no revision ≤ anchor): Revert keeps, Reset
+ *                                       deletes — exposed, caller picks.
+ *
+ * SCHEMA DRIFT (§5 "schema recomputation"): a target snapshot carrying a field id that no longer exists in
+ * the CURRENT schema is EXCLUDED from the plan and counted in `driftCount` — re-inserting it would write a
+ * stale field key into `meta_records.data`. SEMANTICS (owner P1-2 ruling 2026-07-17, superseding the F2
+ * "honest partial" note): the L8 apply core treats `driftCount > 0` as a WHOLE-apply refusal
+ * (`schema-drift`, zero writes, burn rolled back) — T-path parity; no partial-set apply is smuggled
+ * through drift exclusion, and an EXPLICIT partial recovery is a future separate mode. This plan layer
+ * still computes and exposes `driftCount` so a read-only preview can DISCLOSE the drift to the actor
+ * before they ever mint/spend a token.
+ *
+ * LAYERING CONTRACT (deliberate, loud): this is the CORE set-classification only — it performs NO
+ * permission masking, NO row-level-deny filtering, NO size ceilings, and NO fence acquisition. Those are
+ * the HTTP/execute wiring's obligations (L8): the route must (a) run this UNDER the canonical fence,
+ * (b) apply the actor's field mask + denied-record filter to what it returns/executes (the T-path's PIT-3
+ * discipline), and (c) enforce SHEET_REVERT_MAX_RECORDS-class ceilings. Consuming this module without those
+ * layers is NOT a production path — it is not wired to any route in this lane (default-off by construction).
+ *
+ * EXACT BIGINT: `anchorSeq` is a decimal string handed to `reconstructRecordsAtSeq`'s `::bigint` bind;
+ * `assertSeqString` fails closed here too so a garbage anchor never reaches SQL from the plan layer.
+ */
+
+export interface AnchorRevertCandidate {
+  recordId: string
+  /** the FULL at-anchor record data (unmasked — see the layering contract). */
+  targetData: Record<string, unknown>
+  /** the at-anchor version (the version the record had as of the anchor). */
+  targetVersion: number | null
+  /** the CURRENT live version (optimistic-concurrency anchor for the apply). */
+  liveVersion: number
+}
+
+export interface AnchorResurrectCandidate {
+  recordId: string
+  /** the FULL at-anchor snapshot (from the revision chain — never the trash row's terminal vintage). */
+  snapshot: Record<string, unknown>
+  targetVersion: number | null
+}
+
+export interface ExactAnchorRecoveryPlan {
+  /** records whose live data differs from the at-anchor state (live row present). */
+  reverts: AnchorRevertCandidate[]
+  /** records that existed at the anchor but have NO live row now (deleted after the anchor). */
+  resurrects: AnchorResurrectCandidate[]
+  /** records DELETED as of the anchor that are live now (later resurrected): Revert keeps, Reset deletes. */
+  deletedAtAnchorLiveNow: string[]
+  /** live records with no revision ≤ anchor (created after the anchor): Revert keeps, Reset deletes. */
+  createdAfterAnchor: string[]
+  /** records excluded because their target snapshot carries a field id absent from the current schema. */
+  driftCount: number
+  /** records whose live data already equals the at-anchor state (no-op — informational). */
+  unchangedCount: number
+}
+
+const asRec = (v: unknown): Record<string, unknown> =>
+  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {}
+
+/** Order-insensitive deep-ish equality on record data objects (JSON-shaped values). */
+function dataEquals(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  const ka = Object.keys(a)
+  const kb = Object.keys(b)
+  if (ka.length !== kb.length) return false
+  for (const k of ka) {
+    if (!(k in b)) return false
+    if (JSON.stringify(a[k]) !== JSON.stringify(b[k])) return false
+  }
+  return true
+}
+
+/**
+ * Build the exact-anchor recovery plan for a sheet (§5 set recomputation; PURE READ — writes nothing).
+ * See the module doc for the classification table and the layering contract.
+ */
+export async function buildExactAnchorRecoveryPlan(
+  query: QueryFn,
+  sheetId: string,
+  anchorSeq: string,
+): Promise<ExactAnchorRecoveryPlan> {
+  assertSeqString(anchorSeq, 'buildExactAnchorRecoveryPlan.anchorSeq') // fail-closed on a garbage anchor
+
+  // Current schema — the drift guard's truth (a stale field key must never be re-written).
+  const fieldRes = await query('SELECT id FROM meta_fields WHERE sheet_id = $1', [sheetId])
+  const fieldIds = new Set((fieldRes.rows as Array<{ id: unknown }>).map((r) => String(r.id)))
+
+  // Live rows.
+  const liveById = new Map<string, { data: Record<string, unknown>; version: number }>()
+  const liveRes = await query('SELECT id, data, version FROM meta_records WHERE sheet_id = $1', [sheetId])
+  for (const r of liveRes.rows as Array<{ id: unknown; data: unknown; version: unknown }>) {
+    liveById.set(String(r.id), {
+      data: asRec(r.data),
+      version: typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : Number(r.version) || 0,
+    })
+  }
+
+  // The causal at-anchor state (delete-aware, target-generation-correct — L6-b).
+  const stateMap = await reconstructRecordsAtSeq(query, sheetId, anchorSeq)
+  return classifyExactAnchorRecoveryPlan(stateMap, liveById, fieldIds)
+}
+
+/**
+ * The PURE classification core (extracted for L8's execute, which composes the L5 baseline into the state
+ * map before planning — the classification semantics are identical either way; see the module doc table).
+ */
+export function classifyExactAnchorRecoveryPlan(
+  stateMap: Map<string, { recordId: string; exists: boolean; data: Record<string, unknown> | null; version: number | null }>,
+  liveById: Map<string, { data: Record<string, unknown>; version: number }>,
+  fieldIds: ReadonlySet<string>,
+): ExactAnchorRecoveryPlan {
+  const plan: ExactAnchorRecoveryPlan = {
+    reverts: [],
+    resurrects: [],
+    deletedAtAnchorLiveNow: [],
+    createdAfterAnchor: [],
+    driftCount: 0,
+    unchangedCount: 0,
+  }
+
+  for (const [recordId, target] of stateMap) {
+    const live = liveById.get(recordId)
+    if (target.exists) {
+      const targetData = asRec(target.data)
+      // Schema-drift guard — identical for the revert and resurrect branches (excluded, counted, re-preview).
+      let drift = false
+      for (const fid of Object.keys(targetData)) if (!fieldIds.has(fid)) { drift = true; break }
+      if (drift) { plan.driftCount++; continue }
+      if (!live) {
+        // Existed at the anchor, gone now ⇒ deleted AFTER the anchor ⇒ resurrectable to its at-anchor state.
+        plan.resurrects.push({ recordId, snapshot: targetData, targetVersion: target.version })
+        continue
+      }
+      if (dataEquals(live.data, targetData)) { plan.unchangedCount++; continue }
+      plan.reverts.push({ recordId, targetData, targetVersion: target.version, liveVersion: live.version })
+      continue
+    }
+    // target deleted as of the anchor (latest seq<=anchor revision is a delete — LOCK-9):
+    if (live) plan.deletedAtAnchorLiveNow.push(recordId) // resurrected after the anchor — caller picks keep/delete
+    // no live row ⇒ stays deleted; NEVER resurrected.
+  }
+
+  // Live rows with no revision ≤ anchor at all: created after the anchor.
+  for (const id of liveById.keys()) if (!stateMap.has(id)) plan.createdAfterAnchor.push(id)
+
+  return plan
+}

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-plan.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-plan.ts
@@ -39,6 +39,9 @@ import { assertSeqString } from './history-trust-checkpoint'
  * (b) apply the actor's field mask + denied-record filter to what it returns/executes (the T-path's PIT-3
  * discipline), and (c) enforce SHEET_REVERT_MAX_RECORDS-class ceilings. Consuming this module without those
  * layers is NOT a production path — it is not wired to any route in this lane (default-off by construction).
+ * After retention has pruned raw revisions, production callers must also resolve the trusted checkpoint,
+ * compose its baseline overlay, and pass that composed state to `classifyExactAnchorRecoveryPlan`; the direct
+ * builder below is intentionally raw-history-only and is not a checkpoint-complete recovery authority.
  *
  * EXACT BIGINT: `anchorSeq` is a decimal string handed to `reconstructRecordsAtSeq`'s `::bigint` bind;
  * `assertSeqString` fails closed here too so a garbage anchor never reaches SQL from the plan layer.
@@ -77,18 +80,52 @@ export interface ExactAnchorRecoveryPlan {
 }
 
 const asRec = (v: unknown): Record<string, unknown> =>
-  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {}
+  v && typeof v === 'object' && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : {}
 
-/** Order-insensitive deep-ish equality on record data objects (JSON-shaped values). */
-function dataEquals(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
-  const ka = Object.keys(a)
-  const kb = Object.keys(b)
-  if (ka.length !== kb.length) return false
-  for (const k of ka) {
-    if (!(k in b)) return false
-    if (JSON.stringify(a[k]) !== JSON.stringify(b[k])) return false
+function canonicalize(value: unknown): string {
+  const normalize = (v: unknown): unknown => {
+    if (v === undefined) return null
+    if (Array.isArray(v)) return v.map(normalize)
+    if (v !== null && typeof v === 'object') {
+      const source = v as Record<string, unknown>
+      const ordered: Record<string, unknown> = {}
+      for (const key of Object.keys(source).sort())
+        ordered[key] = normalize(source[key])
+      return ordered
+    }
+    return v
   }
-  return true
+  return JSON.stringify(normalize(value) ?? null)
+}
+
+/** Key-order-insensitive equality on JSON-shaped record data. */
+function dataEquals(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): boolean {
+  return canonicalize(a) === canonicalize(b)
+}
+
+export class ExactAnchorPlanDataError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ExactAnchorPlanDataError'
+  }
+}
+
+function requireLiveVersion(value: unknown, recordId: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new ExactAnchorPlanDataError(
+      `live record ${recordId} has an invalid version`,
+    )
+  }
+  return value
+}
+
+function compareRecordId(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
 }
 
 /**
@@ -103,16 +140,32 @@ export async function buildExactAnchorRecoveryPlan(
   assertSeqString(anchorSeq, 'buildExactAnchorRecoveryPlan.anchorSeq') // fail-closed on a garbage anchor
 
   // Current schema — the drift guard's truth (a stale field key must never be re-written).
-  const fieldRes = await query('SELECT id FROM meta_fields WHERE sheet_id = $1', [sheetId])
-  const fieldIds = new Set((fieldRes.rows as Array<{ id: unknown }>).map((r) => String(r.id)))
+  const fieldRes = await query(
+    'SELECT id FROM meta_fields WHERE sheet_id = $1',
+    [sheetId],
+  )
+  const fieldIds = new Set(
+    (fieldRes.rows as Array<{ id: unknown }>).map((r) => String(r.id)),
+  )
 
   // Live rows.
-  const liveById = new Map<string, { data: Record<string, unknown>; version: number }>()
-  const liveRes = await query('SELECT id, data, version FROM meta_records WHERE sheet_id = $1', [sheetId])
-  for (const r of liveRes.rows as Array<{ id: unknown; data: unknown; version: unknown }>) {
-    liveById.set(String(r.id), {
+  const liveById = new Map<
+    string,
+    { data: Record<string, unknown>; version: number }
+  >()
+  const liveRes = await query(
+    'SELECT id, data, version FROM meta_records WHERE sheet_id = $1',
+    [sheetId],
+  )
+  for (const r of liveRes.rows as Array<{
+    id: unknown
+    data: unknown
+    version: unknown
+  }>) {
+    const recordId = String(r.id)
+    liveById.set(recordId, {
       data: asRec(r.data),
-      version: typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : Number(r.version) || 0,
+      version: requireLiveVersion(r.version, recordId),
     })
   }
 
@@ -126,7 +179,15 @@ export async function buildExactAnchorRecoveryPlan(
  * map before planning — the classification semantics are identical either way; see the module doc table).
  */
 export function classifyExactAnchorRecoveryPlan(
-  stateMap: Map<string, { recordId: string; exists: boolean; data: Record<string, unknown> | null; version: number | null }>,
+  stateMap: Map<
+    string,
+    {
+      recordId: string
+      exists: boolean
+      data: Record<string, unknown> | null
+      version: number | null
+    }
+  >,
   liveById: Map<string, { data: Record<string, unknown>; version: number }>,
   fieldIds: ReadonlySet<string>,
 ): ExactAnchorRecoveryPlan {
@@ -145,15 +206,34 @@ export function classifyExactAnchorRecoveryPlan(
       const targetData = asRec(target.data)
       // Schema-drift guard — identical for the revert and resurrect branches (excluded, counted, re-preview).
       let drift = false
-      for (const fid of Object.keys(targetData)) if (!fieldIds.has(fid)) { drift = true; break }
-      if (drift) { plan.driftCount++; continue }
-      if (!live) {
-        // Existed at the anchor, gone now ⇒ deleted AFTER the anchor ⇒ resurrectable to its at-anchor state.
-        plan.resurrects.push({ recordId, snapshot: targetData, targetVersion: target.version })
+      for (const fid of Object.keys(targetData))
+        if (!fieldIds.has(fid)) {
+          drift = true
+          break
+        }
+      if (drift) {
+        plan.driftCount++
         continue
       }
-      if (dataEquals(live.data, targetData)) { plan.unchangedCount++; continue }
-      plan.reverts.push({ recordId, targetData, targetVersion: target.version, liveVersion: live.version })
+      if (!live) {
+        // Existed at the anchor, gone now ⇒ deleted AFTER the anchor ⇒ resurrectable to its at-anchor state.
+        plan.resurrects.push({
+          recordId,
+          snapshot: targetData,
+          targetVersion: target.version,
+        })
+        continue
+      }
+      if (dataEquals(live.data, targetData)) {
+        plan.unchangedCount++
+        continue
+      }
+      plan.reverts.push({
+        recordId,
+        targetData,
+        targetVersion: target.version,
+        liveVersion: live.version,
+      })
       continue
     }
     // target deleted as of the anchor (latest seq<=anchor revision is a delete — LOCK-9):
@@ -162,7 +242,13 @@ export function classifyExactAnchorRecoveryPlan(
   }
 
   // Live rows with no revision ≤ anchor at all: created after the anchor.
-  for (const id of liveById.keys()) if (!stateMap.has(id)) plan.createdAfterAnchor.push(id)
+  for (const id of liveById.keys())
+    if (!stateMap.has(id)) plan.createdAfterAnchor.push(id)
+
+  plan.reverts.sort((a, b) => compareRecordId(a.recordId, b.recordId))
+  plan.resurrects.sort((a, b) => compareRecordId(a.recordId, b.recordId))
+  plan.deletedAtAnchorLiveNow.sort(compareRecordId)
+  plan.createdAfterAnchor.sort(compareRecordId)
 
   return plan
 }

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-plan.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-plan.ts
@@ -1,7 +1,3 @@
-import type { QueryFn } from './permission-service'
-import { reconstructRecordsAtSeq } from './record-reconstructor'
-import { assertSeqString } from './history-trust-checkpoint'
-
 /**
  * W0-1 v3.7 Lane L7 — the EXACT-ANCHOR recovery PLAN (target-set classification for execute).
  *
@@ -39,12 +35,15 @@ import { assertSeqString } from './history-trust-checkpoint'
  * (b) apply the actor's field mask + denied-record filter to what it returns/executes (the T-path's PIT-3
  * discipline), and (c) enforce SHEET_REVERT_MAX_RECORDS-class ceilings. Consuming this module without those
  * layers is NOT a production path — it is not wired to any route in this lane (default-off by construction).
- * After retention has pruned raw revisions, production callers must also resolve the trusted checkpoint,
- * compose its baseline overlay, and pass that composed state to `classifyExactAnchorRecoveryPlan`; the direct
- * builder below is intentionally raw-history-only and is not a checkpoint-complete recovery authority.
+ * After retention has pruned raw revisions, production callers must also resolve the trusted checkpoint and
+ * compose its baseline overlay before calling `classifyExactAnchorRecoveryPlan`. This module intentionally
+ * exposes NO multi-query builder: assembling fields, live rows, and revisions from separate autocommit reads
+ * can produce a state that never existed. The L8 caller owns that assembly inside one transaction after taking
+ * the canonical sheet fence, then hands this pure classifier the resulting snapshot.
  *
- * EXACT BIGINT: `anchorSeq` is a decimal string handed to `reconstructRecordsAtSeq`'s `::bigint` bind;
- * `assertSeqString` fails closed here too so a garbage anchor never reaches SQL from the plan layer.
+ * EXACT BIGINT remains the assembly layer's obligation: `anchorSeq` stays a decimal string through
+ * `reconstructRecordsAtSeq`'s `::bigint` bind. This classifier receives the already-resolved state map and
+ * performs no sequence arithmetic or coercion.
  */
 
 export interface AnchorRevertCandidate {
@@ -52,7 +51,7 @@ export interface AnchorRevertCandidate {
   /** the FULL at-anchor record data (unmasked — see the layering contract). */
   targetData: Record<string, unknown>
   /** the at-anchor version (the version the record had as of the anchor). */
-  targetVersion: number | null
+  targetVersion: number
   /** the CURRENT live version (optimistic-concurrency anchor for the apply). */
   liveVersion: number
 }
@@ -61,7 +60,7 @@ export interface AnchorResurrectCandidate {
   recordId: string
   /** the FULL at-anchor snapshot (from the revision chain — never the trash row's terminal vintage). */
   snapshot: Record<string, unknown>
-  targetVersion: number | null
+  targetVersion: number
 }
 
 export interface ExactAnchorRecoveryPlan {
@@ -78,11 +77,6 @@ export interface ExactAnchorRecoveryPlan {
   /** records whose live data already equals the at-anchor state (no-op — informational). */
   unchangedCount: number
 }
-
-const asRec = (v: unknown): Record<string, unknown> =>
-  v && typeof v === 'object' && !Array.isArray(v)
-    ? (v as Record<string, unknown>)
-    : {}
 
 function canonicalize(value: unknown): string {
   const normalize = (v: unknown): unknown => {
@@ -124,54 +118,26 @@ function requireLiveVersion(value: unknown, recordId: string): number {
   return value
 }
 
-function compareRecordId(a: string, b: string): number {
-  return a < b ? -1 : a > b ? 1 : 0
+function requireTargetVersion(value: unknown, recordId: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new ExactAnchorPlanDataError(`at-anchor record ${recordId} has an invalid version`)
+  }
+  return value
 }
 
-/**
- * Build the exact-anchor recovery plan for a sheet (§5 set recomputation; PURE READ — writes nothing).
- * See the module doc for the classification table and the layering contract.
- */
-export async function buildExactAnchorRecoveryPlan(
-  query: QueryFn,
-  sheetId: string,
-  anchorSeq: string,
-): Promise<ExactAnchorRecoveryPlan> {
-  assertSeqString(anchorSeq, 'buildExactAnchorRecoveryPlan.anchorSeq') // fail-closed on a garbage anchor
-
-  // Current schema — the drift guard's truth (a stale field key must never be re-written).
-  const fieldRes = await query(
-    'SELECT id FROM meta_fields WHERE sheet_id = $1',
-    [sheetId],
-  )
-  const fieldIds = new Set(
-    (fieldRes.rows as Array<{ id: unknown }>).map((r) => String(r.id)),
-  )
-
-  // Live rows.
-  const liveById = new Map<
-    string,
-    { data: Record<string, unknown>; version: number }
-  >()
-  const liveRes = await query(
-    'SELECT id, data, version FROM meta_records WHERE sheet_id = $1',
-    [sheetId],
-  )
-  for (const r of liveRes.rows as Array<{
-    id: unknown
-    data: unknown
-    version: unknown
-  }>) {
-    const recordId = String(r.id)
-    liveById.set(recordId, {
-      data: asRec(r.data),
-      version: requireLiveVersion(r.version, recordId),
-    })
+function requireRecordData(
+  value: unknown,
+  recordId: string,
+  side: 'live' | 'at-anchor',
+): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new ExactAnchorPlanDataError(`${side} record ${recordId} has an invalid data snapshot`)
   }
+  return value as Record<string, unknown>
+}
 
-  // The causal at-anchor state (delete-aware, target-generation-correct — L6-b).
-  const stateMap = await reconstructRecordsAtSeq(query, sheetId, anchorSeq)
-  return classifyExactAnchorRecoveryPlan(stateMap, liveById, fieldIds)
+function compareRecordId(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
 }
 
 /**
@@ -188,7 +154,7 @@ export function classifyExactAnchorRecoveryPlan(
       version: number | null
     }
   >,
-  liveById: Map<string, { data: Record<string, unknown>; version: number }>,
+  liveById: ReadonlyMap<string, { data: unknown; version: unknown }>,
   fieldIds: ReadonlySet<string>,
 ): ExactAnchorRecoveryPlan {
   const plan: ExactAnchorRecoveryPlan = {
@@ -200,10 +166,23 @@ export function classifyExactAnchorRecoveryPlan(
     unchangedCount: 0,
   }
 
+  const validatedLiveById = new Map<string, { data: Record<string, unknown>; version: number }>()
+  for (const [recordId, live] of liveById) {
+    validatedLiveById.set(recordId, {
+      data: requireRecordData(live.data, recordId, 'live'),
+      version: requireLiveVersion(live.version, recordId),
+    })
+  }
+
   for (const [recordId, target] of stateMap) {
-    const live = liveById.get(recordId)
+    const live = validatedLiveById.get(recordId)
     if (target.exists) {
-      const targetData = asRec(target.data)
+      const targetData = requireRecordData(target.data, recordId, 'at-anchor')
+      const targetVersion = requireTargetVersion(target.version, recordId)
+      if (live && dataEquals(live.data, targetData)) {
+        plan.unchangedCount++
+        continue
+      }
       // Schema-drift guard — identical for the revert and resurrect branches (excluded, counted, re-preview).
       let drift = false
       for (const fid of Object.keys(targetData))
@@ -220,18 +199,14 @@ export function classifyExactAnchorRecoveryPlan(
         plan.resurrects.push({
           recordId,
           snapshot: targetData,
-          targetVersion: target.version,
+          targetVersion,
         })
-        continue
-      }
-      if (dataEquals(live.data, targetData)) {
-        plan.unchangedCount++
         continue
       }
       plan.reverts.push({
         recordId,
         targetData,
-        targetVersion: target.version,
+        targetVersion,
         liveVersion: live.version,
       })
       continue
@@ -242,7 +217,7 @@ export function classifyExactAnchorRecoveryPlan(
   }
 
   // Live rows with no revision ≤ anchor at all: created after the anchor.
-  for (const id of liveById.keys())
+  for (const id of validatedLiveById.keys())
     if (!stateMap.has(id)) plan.createdAfterAnchor.push(id)
 
   plan.reverts.sort((a, b) => compareRecordId(a.recordId, b.recordId))

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts
@@ -1,0 +1,197 @@
+/**
+ * W0-1 v3.7 Lane L7 — exact-anchor recovery PLAN classification (real DB).
+ *
+ * Module under test: `exact-anchor-recovery-plan.ts` `buildExactAnchorRecoveryPlan` — the §5 target-set
+ * recomputation on top of L6-b's causal reconstructor. Goldens (each mutation-proven in the PR matrix):
+ *   REVERT           live differs from at-anchor ⇒ revert candidate carrying the AT-ANCHOR data.
+ *   RESURRECT-AFTER  deleted AFTER the anchor (delete seq > anchor), no live row ⇒ resurrect candidate with
+ *                    the at-anchor snapshot (from the revision chain — NOT the trash row's terminal vintage).
+ *   STAYS-DELETED    deleted BEFORE/AT the anchor, no live row ⇒ NOT resurrected (LOCK-9; no candidate).
+ *   DELETED-AT-ANCHOR-LIVE-NOW  deleted as of the anchor but resurrected later (live now) ⇒ exposed in the
+ *                    caller-picks list, NEVER auto-classified as a revert/resurrect.
+ *   CREATED-AFTER    live row with no revision ≤ anchor ⇒ createdAfterAnchor, NOT a revert.
+ *   MULTI-GEN        anchor inside generation 1 of a delete→recreate ⇒ target = GEN-1 state (the live gen-2
+ *                    row becomes a revert candidate whose targetData is g1's, target-generation A).
+ *   DRIFT            at-anchor snapshot carries a field id absent from the CURRENT schema ⇒ excluded +
+ *                    driftCount (both the revert and resurrect branches).
+ *   UNCHANGED        live equals at-anchor ⇒ unchangedCount, no candidate.
+ *   EXACT-BIGINT     the 2^53/2^53+1 anchor boundary classifies exactly (bigint, never float).
+ *
+ * P2-C hygiene: explicit synthetic seq literals on isolated fixture rows; NEVER `setval` on the shared
+ * sequence; cleanup deletes only this suite's rows. Two-point wiring: plugin-tests.yml real-DB run list +
+ * vitest glob. Runs only with DATABASE_URL; the top-level sentinel fails-not-skips in the allowlist step.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { buildExactAnchorRecoveryPlan } from '../../src/multitable/exact-anchor-recovery-plan'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_earp_${TS}`
+const SHEET = `sheet_earp_${TS}`
+const F_STR = `fld_earp_note_${TS}`
+const ACTOR = `user_earp_${TS}`
+
+const q = (sql: string, params: unknown[] = []) => poolManager.get().query(sql, params)
+
+const revSeq = (
+  recordId: string,
+  version: number,
+  action: 'create' | 'update' | 'delete',
+  snap: Record<string, unknown> | null,
+  seq: string,
+) =>
+  q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[]::text[],'{}'::jsonb,$5::jsonb,$6::bigint)`,
+    [SHEET, recordId, version, action, snap === null ? null : JSON.stringify(snap), seq],
+  )
+const live = (id: string, data: Record<string, unknown>, version = 1) =>
+  q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,$4)', [id, SHEET, JSON.stringify(data), version])
+
+async function wipe(): Promise<void> {
+  for (const t of ['meta_records_trash', 'meta_record_revisions', 'meta_records'])
+    await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+}
+
+test('sentinel: the real-DB allowlist step must have DATABASE_URL (fail-not-skip, scoped to that step)', () => {
+  if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+    throw new Error('real-DB allowlist step is missing DATABASE_URL — the harness is broken, not legitimately skippable')
+  }
+  expect(true).toBe(true)
+})
+
+describeIfDatabase('W0-1 v3.7 L7 — exact-anchor recovery plan (real DB)', () => {
+  beforeAll(async () => {
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'EARP Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'EARP'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_STR, SHEET, 'Note', 'string', '{}', 1])
+  })
+  beforeEach(wipe)
+  afterAll(async () => {
+    await wipe()
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL is set (this suite must RUN, never skip-green)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('REVERT: live differs from at-anchor ⇒ candidate carries the AT-ANCHOR data + both versions', async () => {
+    const R = `rec_rev_${TS}`
+    await revSeq(R, 1, 'create', { [F_STR]: 'old' }, '100')
+    await revSeq(R, 2, 'update', { [F_STR]: 'new' }, '200')
+    await live(R, { [F_STR]: 'new' }, 2)
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '150')
+    expect(plan.reverts).toEqual([{ recordId: R, targetData: { [F_STR]: 'old' }, targetVersion: 1, liveVersion: 2 }])
+    expect(plan.resurrects).toEqual([])
+    expect(plan.createdAfterAnchor).toEqual([])
+    expect(plan.deletedAtAnchorLiveNow).toEqual([])
+  })
+
+  test('RESURRECT-AFTER vs STAYS-DELETED: delete AFTER the anchor resurrects to the AT-ANCHOR state; delete AT/BEFORE the anchor stays deleted', async () => {
+    const AFTER = `rec_after_${TS}`
+    const BEFORE = `rec_before_${TS}`
+    // AFTER: create@100 (v1 'keep-me'), update@200 (v2 'newer'), delete@300. Anchor 250 ⇒ existed at v2.
+    await revSeq(AFTER, 1, 'create', { [F_STR]: 'keep-me' }, '100')
+    await revSeq(AFTER, 2, 'update', { [F_STR]: 'newer' }, '200')
+    await revSeq(AFTER, 2, 'delete', { [F_STR]: 'newer' }, '300')
+    // BEFORE: create@110, delete@120 — deleted before the anchor ⇒ stays deleted.
+    await revSeq(BEFORE, 1, 'create', { [F_STR]: 'gone' }, '110')
+    await revSeq(BEFORE, 1, 'delete', { [F_STR]: 'gone' }, '120')
+
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '250')
+    // AFTER resurrects with its AT-ANCHOR (v2 'newer') snapshot — from the revision chain, not any trash vintage.
+    expect(plan.resurrects).toEqual([{ recordId: AFTER, snapshot: { [F_STR]: 'newer' }, targetVersion: 2 }])
+    // BEFORE appears NOWHERE (stays deleted — LOCK-9).
+    expect(plan.reverts.map((r) => r.recordId)).not.toContain(BEFORE)
+    expect(plan.deletedAtAnchorLiveNow).toEqual([])
+    expect(plan.createdAfterAnchor).toEqual([])
+  })
+
+  test('DELETED-AT-ANCHOR-LIVE-NOW + CREATED-AFTER: exposed in the caller-picks lists, never auto-destructed', async () => {
+    const RESURRECTED = `rec_resu_${TS}` // deleted before anchor, re-created after ⇒ live now
+    const NEWBIE = `rec_new_${TS}` // created after the anchor
+    await revSeq(RESURRECTED, 1, 'create', { [F_STR]: 'g1' }, '100')
+    await revSeq(RESURRECTED, 1, 'delete', { [F_STR]: 'g1' }, '150')
+    await revSeq(RESURRECTED, 1, 'create', { [F_STR]: 'g2' }, '400') // after the anchor
+    await live(RESURRECTED, { [F_STR]: 'g2' }, 1)
+    await revSeq(NEWBIE, 1, 'create', { [F_STR]: 'brand-new' }, '500')
+    await live(NEWBIE, { [F_STR]: 'brand-new' }, 1)
+
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '200')
+    expect(plan.deletedAtAnchorLiveNow).toEqual([RESURRECTED]) // deleted as of anchor 200, live now
+    expect(plan.createdAfterAnchor).toEqual([NEWBIE]) // no revision ≤ 200
+    // Neither is a revert or resurrect — the plan never chooses destruction.
+    expect(plan.reverts).toEqual([])
+    expect(plan.resurrects).toEqual([])
+  })
+
+  test('MULTI-GEN target-generation A: an anchor inside generation 1 makes the live gen-2 row a revert to the G1 state', async () => {
+    const R = `rec_gen_${TS}`
+    // gen1: create v1@10 ('g1v1'), update v2@20 ('g1v2'), delete v2@30. gen2: create v1@40 ('g2v1') — live.
+    await revSeq(R, 1, 'create', { [F_STR]: 'g1v1' }, '10')
+    await revSeq(R, 2, 'update', { [F_STR]: 'g1v2' }, '20')
+    await revSeq(R, 2, 'delete', { [F_STR]: 'g1v2' }, '30')
+    await revSeq(R, 1, 'create', { [F_STR]: 'g2v1' }, '40')
+    await live(R, { [F_STR]: 'g2v1' }, 1)
+
+    // anchor 25: inside GEN 1, at its v2 state — the plan must target g1v2 (target-generation A), not the
+    // terminal generation's state and not "stays deleted".
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '25')
+    expect(plan.reverts).toEqual([{ recordId: R, targetData: { [F_STR]: 'g1v2' }, targetVersion: 2, liveVersion: 1 }])
+
+    // anchor 35 (inside the deletion window): deleted as of the anchor but live now ⇒ caller-picks list.
+    const plan35 = await buildExactAnchorRecoveryPlan(q, SHEET, '35')
+    expect(plan35.deletedAtAnchorLiveNow).toEqual([R])
+    expect(plan35.reverts).toEqual([])
+  })
+
+  test('DRIFT: a stale field id in the at-anchor snapshot excludes the record (both branches) and counts drift', async () => {
+    const GHOST_FIELD = `fld_ghost_${TS}` // never inserted into meta_fields
+    const R_LIVE = `rec_drift_live_${TS}`
+    const R_GONE = `rec_drift_gone_${TS}`
+    await revSeq(R_LIVE, 1, 'create', { [GHOST_FIELD]: 'stale' }, '100')
+    await revSeq(R_LIVE, 2, 'update', { [F_STR]: 'now' }, '300')
+    await live(R_LIVE, { [F_STR]: 'now' }, 2)
+    await revSeq(R_GONE, 1, 'create', { [GHOST_FIELD]: 'stale' }, '110')
+    await revSeq(R_GONE, 1, 'delete', { [GHOST_FIELD]: 'stale' }, '400')
+
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '200')
+    expect(plan.driftCount).toBe(2) // one revert-branch drift + one resurrect-branch drift
+    expect(plan.reverts).toEqual([])
+    expect(plan.resurrects).toEqual([])
+  })
+
+  test('UNCHANGED: live equals at-anchor ⇒ counted, no candidate', async () => {
+    const R = `rec_same_${TS}`
+    await revSeq(R, 1, 'create', { [F_STR]: 'same' }, '100')
+    await live(R, { [F_STR]: 'same' }, 1)
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '200')
+    expect(plan.unchangedCount).toBe(1)
+    expect(plan.reverts).toEqual([])
+  })
+
+  test('EXACT-BIGINT: the 2^53 anchor boundary classifies exactly (a float compare would include the +1 write)', async () => {
+    const R = `rec_big_${TS}`
+    const LO = '9007199254740992' // 2^53
+    const HI = '9007199254740993' // 2^53+1 — Number() collapses onto LO
+    expect(Number(LO) === Number(HI)).toBe(true)
+    await revSeq(R, 1, 'create', { [F_STR]: 'lo' }, LO)
+    await revSeq(R, 2, 'update', { [F_STR]: 'hi' }, HI)
+    await live(R, { [F_STR]: 'hi' }, 2)
+    // anchor = LO exactly: the HI write has NOT happened yet ⇒ the plan reverts live('hi') → target('lo').
+    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, LO)
+    expect(plan.reverts).toEqual([{ recordId: R, targetData: { [F_STR]: 'lo' }, targetVersion: 1, liveVersion: 2 }])
+  })
+
+  test('garbage anchor fails closed (assertSeqString throws before any SQL)', async () => {
+    const throwQ = (() => { throw new Error('plan touched the DB on a garbage anchor') }) as never
+    await expect(buildExactAnchorRecoveryPlan(throwQ, SHEET, 'not-a-seq')).rejects.toThrow(/seq/i)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts
@@ -1,8 +1,11 @@
 /**
  * W0-1 v3.7 Lane L7 — exact-anchor recovery PLAN classification (real DB).
  *
- * Module under test: `exact-anchor-recovery-plan.ts` `buildExactAnchorRecoveryPlan` — the §5 target-set
- * recomputation on top of L6-b's causal reconstructor. Goldens (each mutation-proven in the PR matrix):
+ * Module under test: `exact-anchor-recovery-plan.ts`'s PURE classifier — the §5 target-set recomputation on
+ * top of L6-b's causal reconstructor. This integration harness deliberately performs the three input reads
+ * inside one transaction after acquiring the canonical sheet fence; the production module exposes no bare
+ * multi-query builder that could splice together different autocommit snapshots. Goldens (each
+ * mutation-proven in the PR matrix):
  *   REVERT           live differs from at-anchor ⇒ revert candidate carrying the AT-ANCHOR data.
  *   RESURRECT-AFTER  deleted AFTER the anchor (delete seq > anchor), no live row ⇒ resurrect candidate with
  *                    the at-anchor snapshot (from the revision chain — NOT the trash row's terminal vintage).
@@ -24,7 +27,13 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
-import { buildExactAnchorRecoveryPlan } from '../../src/multitable/exact-anchor-recovery-plan'
+import { acquireCanonicalSheetFence } from '../../src/multitable/canonical-sheet-fence'
+import {
+  classifyExactAnchorRecoveryPlan,
+  type ExactAnchorRecoveryPlan,
+} from '../../src/multitable/exact-anchor-recovery-plan'
+import { assertSeqString } from '../../src/multitable/history-trust-checkpoint'
+import { reconstructRecordsAtSeq } from '../../src/multitable/record-reconstructor'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
@@ -34,6 +43,31 @@ const F_STR = `fld_earp_note_${TS}`
 const ACTOR = `user_earp_${TS}`
 
 const q = (sql: string, params: unknown[] = []) => poolManager.get().query(sql, params)
+
+async function buildPlan(anchorSeq: string): Promise<ExactAnchorRecoveryPlan> {
+  assertSeqString(anchorSeq, 'exact-anchor recovery-plan realDB harness')
+  return poolManager.get().transaction(async ({ query }) => {
+    await acquireCanonicalSheetFence(query, SHEET)
+    const fieldRes = await query('SELECT id FROM meta_fields WHERE sheet_id = $1', [SHEET])
+    const fieldIds = new Set((fieldRes.rows as Array<{ id: unknown }>).map((row) => String(row.id)))
+    const liveRes = await query('SELECT id, data, version FROM meta_records WHERE sheet_id = $1', [
+      SHEET,
+    ])
+    const liveById = new Map<string, { data: unknown; version: unknown }>()
+    for (const row of liveRes.rows as Array<{
+      id: unknown
+      data: unknown
+      version: unknown
+    }>) {
+      liveById.set(String(row.id), {
+        data: row.data,
+        version: row.version,
+      })
+    }
+    const stateMap = await reconstructRecordsAtSeq(query, SHEET, anchorSeq)
+    return classifyExactAnchorRecoveryPlan(stateMap, liveById, fieldIds)
+  })
+}
 
 const revSeq = (
   recordId: string,
@@ -87,7 +121,7 @@ describeIfDatabase('W0-1 v3.7 L7 — exact-anchor recovery plan (real DB)', () =
     await revSeq(R, 1, 'create', { [F_STR]: 'old' }, '100')
     await revSeq(R, 2, 'update', { [F_STR]: 'new' }, '200')
     await live(R, { [F_STR]: 'new' }, 2)
-    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '150')
+    const plan = await buildPlan('150')
     expect(plan.reverts).toEqual([{ recordId: R, targetData: { [F_STR]: 'old' }, targetVersion: 1, liveVersion: 2 }])
     expect(plan.resurrects).toEqual([])
     expect(plan.createdAfterAnchor).toEqual([])
@@ -105,7 +139,7 @@ describeIfDatabase('W0-1 v3.7 L7 — exact-anchor recovery plan (real DB)', () =
     await revSeq(BEFORE, 1, 'create', { [F_STR]: 'gone' }, '110')
     await revSeq(BEFORE, 1, 'delete', { [F_STR]: 'gone' }, '120')
 
-    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '250')
+    const plan = await buildPlan('250')
     // AFTER resurrects with its AT-ANCHOR (v2 'newer') snapshot — from the revision chain, not any trash vintage.
     expect(plan.resurrects).toEqual([{ recordId: AFTER, snapshot: { [F_STR]: 'newer' }, targetVersion: 2 }])
     // BEFORE appears NOWHERE (stays deleted — LOCK-9).
@@ -124,7 +158,7 @@ describeIfDatabase('W0-1 v3.7 L7 — exact-anchor recovery plan (real DB)', () =
     await revSeq(NEWBIE, 1, 'create', { [F_STR]: 'brand-new' }, '500')
     await live(NEWBIE, { [F_STR]: 'brand-new' }, 1)
 
-    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '200')
+    const plan = await buildPlan('200')
     expect(plan.deletedAtAnchorLiveNow).toEqual([RESURRECTED]) // deleted as of anchor 200, live now
     expect(plan.createdAfterAnchor).toEqual([NEWBIE]) // no revision ≤ 200
     // Neither is a revert or resurrect — the plan never chooses destruction.
@@ -143,11 +177,11 @@ describeIfDatabase('W0-1 v3.7 L7 — exact-anchor recovery plan (real DB)', () =
 
     // anchor 25: inside GEN 1, at its v2 state — the plan must target g1v2 (target-generation A), not the
     // terminal generation's state and not "stays deleted".
-    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '25')
+    const plan = await buildPlan('25')
     expect(plan.reverts).toEqual([{ recordId: R, targetData: { [F_STR]: 'g1v2' }, targetVersion: 2, liveVersion: 1 }])
 
     // anchor 35 (inside the deletion window): deleted as of the anchor but live now ⇒ caller-picks list.
-    const plan35 = await buildExactAnchorRecoveryPlan(q, SHEET, '35')
+    const plan35 = await buildPlan('35')
     expect(plan35.deletedAtAnchorLiveNow).toEqual([R])
     expect(plan35.reverts).toEqual([])
   })
@@ -162,7 +196,7 @@ describeIfDatabase('W0-1 v3.7 L7 — exact-anchor recovery plan (real DB)', () =
     await revSeq(R_GONE, 1, 'create', { [GHOST_FIELD]: 'stale' }, '110')
     await revSeq(R_GONE, 1, 'delete', { [GHOST_FIELD]: 'stale' }, '400')
 
-    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '200')
+    const plan = await buildPlan('200')
     expect(plan.driftCount).toBe(2) // one revert-branch drift + one resurrect-branch drift
     expect(plan.reverts).toEqual([])
     expect(plan.resurrects).toEqual([])
@@ -172,7 +206,7 @@ describeIfDatabase('W0-1 v3.7 L7 — exact-anchor recovery plan (real DB)', () =
     const R = `rec_same_${TS}`
     await revSeq(R, 1, 'create', { [F_STR]: 'same' }, '100')
     await live(R, { [F_STR]: 'same' }, 1)
-    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, '200')
+    const plan = await buildPlan('200')
     expect(plan.unchangedCount).toBe(1)
     expect(plan.reverts).toEqual([])
   })
@@ -186,12 +220,11 @@ describeIfDatabase('W0-1 v3.7 L7 — exact-anchor recovery plan (real DB)', () =
     await revSeq(R, 2, 'update', { [F_STR]: 'hi' }, HI)
     await live(R, { [F_STR]: 'hi' }, 2)
     // anchor = LO exactly: the HI write has NOT happened yet ⇒ the plan reverts live('hi') → target('lo').
-    const plan = await buildExactAnchorRecoveryPlan(q, SHEET, LO)
+    const plan = await buildPlan(LO)
     expect(plan.reverts).toEqual([{ recordId: R, targetData: { [F_STR]: 'lo' }, targetVersion: 1, liveVersion: 2 }])
   })
 
-  test('garbage anchor fails closed (assertSeqString throws before any SQL)', async () => {
-    const throwQ = (() => { throw new Error('plan touched the DB on a garbage anchor') }) as never
-    await expect(buildExactAnchorRecoveryPlan(throwQ, SHEET, 'not-a-seq')).rejects.toThrow(/seq/i)
+  test('garbage anchor fails closed before opening the fenced read transaction', async () => {
+    await expect(buildPlan('not-a-seq')).rejects.toThrow(/seq/i)
   })
 })

--- a/packages/core-backend/tests/unit/multitable-exact-anchor-recovery-plan.test.ts
+++ b/packages/core-backend/tests/unit/multitable-exact-anchor-recovery-plan.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, test } from 'vitest'
 
-import {
-  buildExactAnchorRecoveryPlan,
-  classifyExactAnchorRecoveryPlan,
-  ExactAnchorPlanDataError,
-} from '../../src/multitable/exact-anchor-recovery-plan'
-import type { QueryFn } from '../../src/multitable/permission-service'
+import * as exactAnchorPlan from '../../src/multitable/exact-anchor-recovery-plan'
+
+const { classifyExactAnchorRecoveryPlan, ExactAnchorPlanDataError } = exactAnchorPlan
 
 describe('W0 L7 exact-anchor recovery plan hardening', () => {
+  test('the public runtime surface is pure classification only (no autocommit multi-read builder)', () => {
+    expect(Object.keys(exactAnchorPlan).sort()).toEqual([
+      'ExactAnchorPlanDataError',
+      'classifyExactAnchorRecoveryPlan',
+    ])
+  })
+
   test('nested object key order is semantic-equal, so an unchanged record is not reverted', () => {
     const state = new Map([
       [
@@ -100,21 +104,81 @@ describe('W0 L7 exact-anchor recovery plan hardening', () => {
     expect(plan.createdAfterAnchor).toEqual(['a-created', 'z-created'])
   })
 
-  test('an invalid live version fails closed before reconstruction can produce an apply anchor', async () => {
-    let queryCount = 0
-    const query: QueryFn = async () => {
-      queryCount++
-      if (queryCount === 1) return { rows: [{ id: 'f1' }] }
-      if (queryCount === 2)
-        return { rows: [{ id: 'r1', data: { f1: 'v' }, version: null }] }
-      throw new Error(
-        'reconstruction must not run after an invalid live version',
-      )
-    }
+  test('an invalid live version fails closed before it can become an apply anchor', () => {
+    const state = new Map([
+      [
+        'r1',
+        {
+          recordId: 'r1',
+          exists: true,
+          data: { f1: 'old' },
+          version: 1,
+        },
+      ],
+    ])
+    const live = new Map([['r1', { data: { f1: 'new' }, version: null }]])
 
-    await expect(
-      buildExactAnchorRecoveryPlan(query, 'sheet-1', '10'),
-    ).rejects.toThrow(ExactAnchorPlanDataError)
-    expect(queryCount).toBe(2)
+    expect(() => classifyExactAnchorRecoveryPlan(state, live, new Set(['f1']))).toThrow(
+      ExactAnchorPlanDataError,
+    )
+  })
+
+  test('an existing target with no trustworthy snapshot fails closed instead of becoming an empty write', () => {
+    const state = new Map([
+      [
+        'r1',
+        {
+          recordId: 'r1',
+          exists: true,
+          data: null,
+          version: 1,
+        },
+      ],
+    ])
+    const live = new Map([['r1', { data: { f1: 'live' }, version: 2 }]])
+
+    expect(() => classifyExactAnchorRecoveryPlan(state, live, new Set(['f1']))).toThrow(
+      ExactAnchorPlanDataError,
+    )
+  })
+
+  test('an existing target with no trustworthy version fails closed', () => {
+    const state = new Map([
+      [
+        'r1',
+        {
+          recordId: 'r1',
+          exists: true,
+          data: { f1: 'old' },
+          version: null,
+        },
+      ],
+    ])
+    const live = new Map([['r1', { data: { f1: 'live' }, version: 2 }]])
+
+    expect(() => classifyExactAnchorRecoveryPlan(state, live, new Set(['f1']))).toThrow(
+      ExactAnchorPlanDataError,
+    )
+  })
+
+  test('an unchanged stale-key record is a no-op, not whole-plan schema drift', () => {
+    const state = new Map([
+      [
+        'r1',
+        {
+          recordId: 'r1',
+          exists: true,
+          data: { removedField: 'same' },
+          version: 1,
+        },
+      ],
+    ])
+    const live = new Map([['r1', { data: { removedField: 'same' }, version: 1 }]])
+
+    const plan = classifyExactAnchorRecoveryPlan(state, live, new Set())
+
+    expect(plan.unchangedCount).toBe(1)
+    expect(plan.driftCount).toBe(0)
+    expect(plan.reverts).toEqual([])
   })
 })

--- a/packages/core-backend/tests/unit/multitable-exact-anchor-recovery-plan.test.ts
+++ b/packages/core-backend/tests/unit/multitable-exact-anchor-recovery-plan.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  buildExactAnchorRecoveryPlan,
+  classifyExactAnchorRecoveryPlan,
+  ExactAnchorPlanDataError,
+} from '../../src/multitable/exact-anchor-recovery-plan'
+import type { QueryFn } from '../../src/multitable/permission-service'
+
+describe('W0 L7 exact-anchor recovery plan hardening', () => {
+  test('nested object key order is semantic-equal, so an unchanged record is not reverted', () => {
+    const state = new Map([
+      [
+        'r1',
+        {
+          recordId: 'r1',
+          exists: true,
+          data: { f1: { a: 1, b: { x: 2, y: 3 } } },
+          version: 4,
+        },
+      ],
+    ])
+    const live = new Map([
+      ['r1', { data: { f1: { b: { y: 3, x: 2 }, a: 1 } }, version: 4 }],
+    ])
+
+    const plan = classifyExactAnchorRecoveryPlan(state, live, new Set(['f1']))
+
+    expect(plan.unchangedCount).toBe(1)
+    expect(plan.reverts).toEqual([])
+  })
+
+  test('all record-id arrays and candidates are deterministic across reverse map insertion order', () => {
+    const state = new Map([
+      [
+        'z-revert',
+        {
+          recordId: 'z-revert',
+          exists: true,
+          data: { f1: 'old-z' },
+          version: 1,
+        },
+      ],
+      [
+        'a-revert',
+        {
+          recordId: 'a-revert',
+          exists: true,
+          data: { f1: 'old-a' },
+          version: 1,
+        },
+      ],
+      [
+        'z-resurrect',
+        {
+          recordId: 'z-resurrect',
+          exists: true,
+          data: { f1: 'gone-z' },
+          version: 1,
+        },
+      ],
+      [
+        'a-resurrect',
+        {
+          recordId: 'a-resurrect',
+          exists: true,
+          data: { f1: 'gone-a' },
+          version: 1,
+        },
+      ],
+      [
+        'z-deleted',
+        { recordId: 'z-deleted', exists: false, data: null, version: 2 },
+      ],
+      [
+        'a-deleted',
+        { recordId: 'a-deleted', exists: false, data: null, version: 2 },
+      ],
+    ])
+    const live = new Map([
+      ['z-created', { data: { f1: 'new-z' }, version: 1 }],
+      ['a-created', { data: { f1: 'new-a' }, version: 1 }],
+      ['z-deleted', { data: { f1: 'live-z' }, version: 3 }],
+      ['a-deleted', { data: { f1: 'live-a' }, version: 3 }],
+      ['z-revert', { data: { f1: 'new-z' }, version: 2 }],
+      ['a-revert', { data: { f1: 'new-a' }, version: 2 }],
+    ])
+
+    const plan = classifyExactAnchorRecoveryPlan(state, live, new Set(['f1']))
+
+    expect(plan.reverts.map((item) => item.recordId)).toEqual([
+      'a-revert',
+      'z-revert',
+    ])
+    expect(plan.resurrects.map((item) => item.recordId)).toEqual([
+      'a-resurrect',
+      'z-resurrect',
+    ])
+    expect(plan.deletedAtAnchorLiveNow).toEqual(['a-deleted', 'z-deleted'])
+    expect(plan.createdAfterAnchor).toEqual(['a-created', 'z-created'])
+  })
+
+  test('an invalid live version fails closed before reconstruction can produce an apply anchor', async () => {
+    let queryCount = 0
+    const query: QueryFn = async () => {
+      queryCount++
+      if (queryCount === 1) return { rows: [{ id: 'f1' }] }
+      if (queryCount === 2)
+        return { rows: [{ id: 'r1', data: { f1: 'v' }, version: null }] }
+      throw new Error(
+        'reconstruction must not run after an invalid live version',
+      )
+    }
+
+    await expect(
+      buildExactAnchorRecoveryPlan(query, 'sheet-1', '10'),
+    ).rejects.toThrow(ExactAnchorPlanDataError)
+    expect(queryCount).toBe(2)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -412,6 +412,10 @@ export default defineConfig({
       // wired into `Run multitable real-DB integration` in plugin-tests.yml. The no-DB wiring contract
       // pins both points.
       'tests/integration/multitable-exact-anchor-recovery-realdb.test.ts',
+      // W0 L7 exact-anchor recovery-plan goldens: DATABASE_URL-gated and meaningful only against real
+      // Postgres. Exclude from the no-DB default lane so it cannot skip-green; the shared exact-anchor
+      // CI wiring contract pins this entry and its whole-file multitable real-DB invocation.
+      'tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts',
       // D-1c W0 slice ① (form-submit CREATE/EDIT public-form revision goldens): real Postgres only
       // (installs scoped failure/suppression triggers per site and drives the real submit route
       // end-to-end) — excluded HERE so it cannot skip-green in the no-DB lane, whole-file wired into

--- a/scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
+++ b/scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
@@ -9,7 +9,10 @@ import { fileURLToPath } from 'node:url'
 // whole-file entry in plugin-tests.yml's multitable real-DB step. Removing either point must fail CI.
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '..', '..')
-const FILE = 'tests/integration/multitable-exact-anchor-recovery-realdb.test.ts'
+const FILES = [
+  'tests/integration/multitable-exact-anchor-recovery-realdb.test.ts',
+  'tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts',
+]
 const REAL_DB_STEP = 'Run multitable real-DB integration'
 
 function maskCommentsAndStrings(src) {
@@ -146,59 +149,62 @@ function wholeFileVitestArgs(stepBody) {
   })
 }
 
-test('vitest.config.ts excludes the exact-anchor authority suite from the no-DB job', () => {
-  const config = readFileSync(
-    join(repoRoot, 'packages/core-backend/vitest.config.ts'),
-    'utf8',
-  )
-  assert.ok(
-    testExcludeEntries(config).includes(FILE),
-    `test.exclude must contain the exact entry ${FILE}`,
-  )
-})
+for (const file of FILES) {
+  test(`vitest.config.ts excludes ${file} from the no-DB job`, () => {
+    const config = readFileSync(
+      join(repoRoot, 'packages/core-backend/vitest.config.ts'),
+      'utf8',
+    )
+    assert.ok(
+      testExcludeEntries(config).includes(file),
+      `test.exclude must contain the exact entry ${file}`,
+    )
+  })
 
-test('plugin-tests.yml runs the exact-anchor authority suite as a whole file with real Postgres', () => {
-  const workflow = readFileSync(
-    join(repoRoot, '.github/workflows/plugin-tests.yml'),
-    'utf8',
-  )
-  const step = namedStepBody(workflow, REAL_DB_STEP)
-  assert.ok(
-    stepHasEnvKey(step, 'DATABASE_URL'),
-    `${REAL_DB_STEP} must define DATABASE_URL`,
-  )
-  assert.ok(
-    stepHasEnvKey(step, 'METASHEET_REAL_DB_TEST_STEP'),
-    `${REAL_DB_STEP} must set the fail-not-skip marker`,
-  )
-  assert.match(
-    step,
-    /\bvitest\b[^\n]*--config\s+vitest\.integration\.config\.ts\b/,
-  )
-  assert.ok(
-    wholeFileVitestArgs(step).includes(FILE),
-    `${REAL_DB_STEP} must run ${FILE} as a whole-file argument`,
-  )
-})
+  test(`plugin-tests.yml runs ${file} as a whole file with real Postgres`, () => {
+    const workflow = readFileSync(
+      join(repoRoot, '.github/workflows/plugin-tests.yml'),
+      'utf8',
+    )
+    const step = namedStepBody(workflow, REAL_DB_STEP)
+    assert.ok(
+      stepHasEnvKey(step, 'DATABASE_URL'),
+      `${REAL_DB_STEP} must define DATABASE_URL`,
+    )
+    assert.ok(
+      stepHasEnvKey(step, 'METASHEET_REAL_DB_TEST_STEP'),
+      `${REAL_DB_STEP} must set the fail-not-skip marker`,
+    )
+    assert.match(
+      step,
+      /\bvitest\b[^\n]*--config\s+vitest\.integration\.config\.ts\b/,
+    )
+    assert.ok(
+      wholeFileVitestArgs(step).includes(file),
+      `${REAL_DB_STEP} must run ${file} as a whole-file argument`,
+    )
+  })
+}
 
 test('placement parsers reject comment-only and wrong-step decoys', () => {
-  const configDecoy = `export default defineConfig({ test: { // '${FILE}'\nexclude: ['other.test.ts'] } })`
-  assert.equal(testExcludeEntries(configDecoy).includes(FILE), false)
+  const file = FILES[1]
+  const configDecoy = `export default defineConfig({ test: { // '${file}'\nexclude: ['other.test.ts'] } })`
+  assert.equal(testExcludeEntries(configDecoy).includes(file), false)
 
   const workflowDecoy = [
     'steps:',
-    `  # ${FILE}`,
+    `  # ${file}`,
     '  - name: Run some other integration',
     '    env:',
     '      DATABASE_URL: postgresql://example',
     '      METASHEET_REAL_DB_TEST_STEP: 1',
     '    run: |',
     '      pnpm exec vitest --config vitest.integration.config.ts run \\',
-    `        ${FILE} \\`,
+    `        ${file} \\`,
     `  - name: ${REAL_DB_STEP}`,
     '    run: echo no-db',
   ].join('\n')
   const realStep = namedStepBody(workflowDecoy, REAL_DB_STEP)
   assert.equal(stepHasEnvKey(realStep, 'DATABASE_URL'), false)
-  assert.equal(wholeFileVitestArgs(realStep).includes(FILE), false)
+  assert.equal(wholeFileVitestArgs(realStep).includes(file), false)
 })


### PR DESCRIPTION
## Scope

Current-stack W0 L7 exact-anchor recovery planning, based on the re-gated L6-b Draft #4472.

This head exposes a pure classifier only. It deterministically classifies revert, resurrect, deleted-at-anchor/live-now, created-after-anchor, unchanged, and schema-drift cases from an already checkpoint-composed target. The former multi-query production builder is removed, so no public runtime API can assemble fields/live/revisions across independent snapshots.

Hardening on this head:

- recursive canonical JSON comparison with deterministic record/change ordering
- typed fail-closed validation for malformed live versions, target versions, and target snapshots
- no-op equality before schema-drift refusal, avoiding false refusal for unchanged stale keys
- exact runtime export-surface golden
- explicit Vitest real-DB exclusion plus two-point CI wiring guard

No production route wiring, destructive apply, flag change, seam flip, deployment, or auto-merge. The predecessor #4445 remains untouched.

## Restack evidence

- base: #4472 at `8ced2ef50`
- original L7 semantic commit replay: range-diff 1/1 `=`
- final head: `5190c455e`
- independent Opus exact-head adversarial re-gate: CLEAR, 0 P1 / 0 P2

The re-gate specifically confirmed that (1) `target.data = null` now fails closed and (2) there is no reachable production torn-read builder: only the pure classifier is exported.

## Verification

- fresh PostgreSQL 15 full migration and no-op replay: pass
- L6 exact-anchor + L7 plan + L5 checkpoint + strict-seq real-DB suites: 59/59
- focused L7 unit suite: 21/21
- full backend unit suite: 425 files, 5829 tests
- backend typecheck: pass
- source ESLint: 0 errors
- structural CI guard: 5/5

Executed mutation controls each turned the intended golden red:

- accept `target.data = null`
- re-export a raw builder symbol
- move no-op equality after schema drift
- bypass target-version validation
- remove L7 Vitest exclusion or either CI run-list location
- replace canonical equality / deterministic ordering
- coerce invalid live versions

## Carry to L8

L8 must assemble fields, live rows, revisions, and checkpoint-composed state only after acquiring the canonical sheet fence in the same transaction. Because PostgreSQL READ COMMITTED uses statement snapshots and the writer fence is default-OFF, the future caller must either prove the fence is enabled and shared by all writers or use an explicit repeatable snapshot. L8 must also add fresh authorization/masking, size ceilings, mode-bound policy, drift whole-reject, transaction proof, and all-or-nothing apply.

This Draft does not claim those downstream guarantees.