### PR TITLE
feat(attendance): resolve department-head approvers

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -744,6 +744,7 @@ jobs:
             tests/integration/attendance-approval-action-authorization.db.test.ts \
             tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts \
             tests/integration/attendance-approval-direct-manager-s7-2.db.test.ts \
+            tests/integration/attendance-approval-dept-head-s7-3.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -102,10 +102,10 @@ import {
   stopApprovalSlaScheduler,
 } from './services/ApprovalSlaScheduler'
 import { ApprovalProductService } from './services/ApprovalProductService'
-// S7-1/S7-2 (OD-S7-5=d): host-resolved chain-depth cap + org-scoped directory-read path the attendance
-// dynamic-assignee resolver PORT exposes to plugin-attendance. The plugin validates
+// S7-1/S7-2/S7-3 (OD-S7-5=d): host-resolved chain-depth cap + org-scoped directory-read path the
+// attendance dynamic-assignee resolver PORT exposes to plugin-attendance. The plugin validates
 // `manager_at_level.level` against MAX (never re-parses APPROVAL_MANAGER_CHAIN_MAX_LEVELS) and freezes
-// direct_manager via resolveApprovalRequesterOrgRelations (org-anchored, read-only).
+// direct_manager / dept_head via resolveApprovalRequesterOrgRelations (org-anchored, read-only).
 import {
   MAX_MANAGER_CHAIN_LEVELS,
   resolveApprovalRequesterOrgRelations,
@@ -956,21 +956,21 @@ export class MetaSheetServer {
     return wrappedUnregister
   }
 
-  // S7-1/S7-2 (RATIFIED attendance-approval-s7 resolver lock, OD-S7-5=d): construct the host binding for
-  // the narrow, org-scoped dynamic approval-assignee resolver port plugin-attendance consumes. Exposes
-  // the SAME MAX_MANAGER_CHAIN_LEVELS constant the kernel uses (no plugin env re-parse). S7-2 wires
-  // `direct_manager` only (byte-identical to ApprovalDirectoryOrg §2.1: is_manager precedence, legacy
-  // leader_in_dept fallback, deterministic tie-break, same-integration binding, self-exclusion).
-  // `dept_head` / `manager_at_level` stay unimplemented (S7-3/S7-4). Directory data is READ-ONLY.
+  // S7-1/S7-2/S7-3 (RATIFIED attendance-approval-s7 resolver lock, OD-S7-5=d): construct the host
+  // binding for the narrow, org-scoped dynamic approval-assignee resolver port plugin-attendance
+  // consumes. Exposes the SAME MAX_MANAGER_CHAIN_LEVELS constant the kernel uses (no plugin env
+  // re-parse). S7-2 wires `direct_manager` (byte-identical to ApprovalDirectoryOrg §2.1); S7-3 adds
+  // `dept_head` (byte-identical to §2.2: first-linked dept_manager_userid_list entry, self-exclusion).
+  // `manager_at_level` stays unimplemented (S7-4). Directory data is READ-ONLY.
   private buildApprovalAssigneeResolverPort(): NonNullable<
     import('./types/plugin').PluginServices['approvalAssigneeResolver']
   > {
     return {
       maxManagerChainLevels: MAX_MANAGER_CHAIN_LEVELS,
-      implementedKinds: ['direct_manager'],
+      implementedKinds: ['direct_manager', 'dept_head'],
       resolve: async (orgId, request) => {
         const kind = typeof request?.kind === 'string' ? request.kind.trim() : ''
-        if (kind !== 'direct_manager') {
+        if (kind !== 'direct_manager' && kind !== 'dept_head') {
           return { status: 'unimplemented' as const }
         }
 
@@ -990,21 +990,43 @@ export class MetaSheetServer {
         const relations = await resolveApprovalRequesterOrgRelations(requesterUserId, queryFn, {
           orgId: normalizedOrgId,
         })
-        const managerId =
-          typeof relations.managerId === 'string' && relations.managerId.trim().length > 0
-            ? relations.managerId.trim()
+
+        // S7-2 direct_manager — preserved byte-for-byte (reads only managerId).
+        if (kind === 'direct_manager') {
+          const managerId =
+            typeof relations.managerId === 'string' && relations.managerId.trim().length > 0
+              ? relations.managerId.trim()
+              : null
+          // Self-exclusion at the resolver (§2.1): a manager that resolves to the requester is treated
+          // as unresolved — never written as a self-assignment.
+          if (!managerId || managerId === requesterUserId) {
+            return {
+              status: 'unresolved' as const,
+              reason: managerId === requesterUserId ? 'self_manager' : 'no_manager_linked',
+            }
+          }
+          return {
+            status: 'resolved' as const,
+            assignees: [{ assignmentType: 'user' as const, assigneeId: managerId }],
+          }
+        }
+
+        // S7-3 dept_head — same org-anchored relations call; read ONLY deptHeadId (§2.2).
+        const deptHeadId =
+          typeof relations.deptHeadId === 'string' && relations.deptHeadId.trim().length > 0
+            ? relations.deptHeadId.trim()
             : null
-        // Self-exclusion at the resolver (§2.1): a manager that resolves to the requester is treated
+        // Self-exclusion at the resolver (§2.2): a dept head that resolves to the requester is treated
         // as unresolved — never written as a self-assignment.
-        if (!managerId || managerId === requesterUserId) {
+        if (!deptHeadId || deptHeadId === requesterUserId) {
           return {
             status: 'unresolved' as const,
-            reason: managerId === requesterUserId ? 'self_manager' : 'no_manager_linked',
+            reason: deptHeadId === requesterUserId ? 'self_dept_head' : 'no_dept_head_linked',
           }
         }
         return {
           status: 'resolved' as const,
-          assignees: [{ assignmentType: 'user' as const, assigneeId: managerId }],
+          assignees: [{ assignmentType: 'user' as const, assigneeId: deptHeadId }],
         }
       },
     }

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -979,7 +979,7 @@ export interface PluginServices {
     }): (() => void)
   }
   /**
-   * S7-1/S7-2 — host→plugin, narrow, org-scoped resolver PORT for the attendance dynamic
+   * S7-1/S7-2/S7-3 — host→plugin, narrow, org-scoped resolver PORT for the attendance dynamic
    * approval-assignee kinds (直属上级 `direct_manager` / 部门主管 `dept_head` / 多级上级
    * `manager_at_level`), per the RATIFIED attendance-approval-s7 resolver design-lock, OD-S7-5 = (d).
    * It mirrors `workdayCalendar` above but runs the OPPOSITE direction: core-backend is the PROVIDER,
@@ -993,13 +993,13 @@ export interface PluginServices {
    *   The plugin validates `manager_at_level.level ∈ [1, maxManagerChainLevels]` against THIS value so it
    *   never re-parses the env var into a second constant — one source, two surfaces, no drift.
    * - `implementedKinds` is the set of dynamic kinds this host build can actually resolve at runtime.
-   *   S7-2 populates `direct_manager` only; `dept_head` / `manager_at_level` remain S7-3/S7-4.
+   *   S7-2/S7-3 populate `direct_manager` + `dept_head`; `manager_at_level` remains S7-4.
    *   A kind absent from this list is unimplemented ⇒ the plugin fail-closes.
-   * - `resolve` is the org-scoped CREATE-TIME freeze seam (§3.3 / §3.4). For `direct_manager` it runs the
-   *   kernel's `resolveApprovalRequesterOrgRelations` with the attendance `orgId` anchor, returns the
-   *   linked local manager (or `unresolved`), and NEVER writes. Step-advance must NOT call this again —
-   *   it reads only the frozen `requesterSnapshot.managerId`. Self-exclusion is enforced here (manager
-   *   resolving to the requester is treated as unresolved).
+   * - `resolve` is the org-scoped CREATE-TIME freeze seam (§3.3 / §3.4). For `direct_manager` /
+   *   `dept_head` it runs the kernel's `resolveApprovalRequesterOrgRelations` with the attendance
+   *   `orgId` anchor, returns the linked local manager / dept head (or `unresolved`), and NEVER writes.
+   *   Step-advance must NOT call this again — it reads only the frozen `requesterSnapshot.managerId` /
+   *   `deptHeadId`. Self-exclusion is enforced here (resolving to the requester is treated as unresolved).
    */
   approvalAssigneeResolver?: {
     readonly maxManagerChainLevels: number

--- a/packages/core-backend/tests/integration/attendance-approval-dept-head-s7-3.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-approval-dept-head-s7-3.db.test.ts
@@ -6,16 +6,17 @@ import http from 'http'
 import { Pool } from 'pg'
 import { randomUUID } from 'crypto'
 
-// S7-2 (RATIFIED attendance-approval-s7 resolver design-lock §2.1 / §3.3 / §3.4 / §4 / §4.1 / §7 S7-2):
-// real-DB, HTTP-level coverage of direct_manager end-to-end:
-//   linked resolution + freeze into requester_snapshot.managerId
-//   unlinked block-with-error + zero persistence
+// S7-3 (RATIFIED attendance-approval-s7 resolver design-lock §2.2 / §3.3 / §3.4 / §4 / §4.1 / §7 S7-3):
+// real-DB, HTTP-level coverage of dept_head end-to-end:
+//   linked resolution + freeze into requester_snapshot.deptHeadId
+//   vacant/unlinked head fail-closed + zero persistence
+//   self-exclusion
 //   two-org / one-local-user org-anchor
 //   2-step freeze after directory relation mutation
 //   dynamic assignment approve+reject authorization (negative / positive / admin)
-//   flag-off create + flag-off advance rollback
+//   flag-off create + flag-off advance rollback (§4.1 both paths)
 //   legacy static still works with flag off
-//   S7-1 NITs folded: empty-static-array MIXED + non-string kind → distinct 422
+//   direct_manager regression control
 //
 // RBAC_BYPASS is toggled per-case: authoring / create paths use 'true' for simplicity; the
 // assignment-authorization legs force 'false' so the S7-0 predicate is what we observe.
@@ -73,7 +74,7 @@ const NODE_KEY_1 = 'attendance_request_step_1'
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
 const describeIfDatabase = dbUrl ? describe : describe.skip
 
-describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)', () => {
+describeIfDatabase('S7-3 dept_head — freeze + assignment + auth (real DB)', () => {
   let server: MetaSheetServer | undefined
   let baseUrl: string | undefined
   let pool: Pool | undefined
@@ -81,38 +82,48 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
   let prevFlag: string | undefined
 
   const runSuffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
-  const orgHome = `s7-2-home-${runSuffix}`
-  const orgForeign = `s7-2-foreign-${runSuffix}`
-  const orgUnlinked = `s7-2-unlinked-${runSuffix}`
-  const orgFreeze = `s7-2-freeze-${runSuffix}`
-  const orgAuthz = `s7-2-authz-${runSuffix}`
-  const orgFlagOff = `s7-2-flagoff-${runSuffix}`
+  const orgHome = `s7-3-home-${runSuffix}`
+  const orgForeign = `s7-3-foreign-${runSuffix}`
+  const orgVacant = `s7-3-vacant-${runSuffix}`
+  const orgSelf = `s7-3-self-${runSuffix}`
+  const orgFreeze = `s7-3-freeze-${runSuffix}`
+  const orgAuthz = `s7-3-authz-${runSuffix}`
+  const orgFlagOff = `s7-3-flagoff-${runSuffix}`
+  const orgDm = `s7-3-dm-${runSuffix}`
 
-  const requester = `s7-2-req-${runSuffix}`
-  const managerHome = `s7-2-mgr-home-${runSuffix}`
-  const managerForeign = `s7-2-mgr-foreign-${runSuffix}`
-  const managerAlt = `s7-2-mgr-alt-${runSuffix}`
-  const otherApprover = `s7-2-other-${runSuffix}`
-  const adminActor = `s7-2-admin-${runSuffix}`
+  const requester = `s7-3-req-${runSuffix}`
+  const headHome = `s7-3-head-home-${runSuffix}`
+  const headForeign = `s7-3-head-foreign-${runSuffix}`
+  const headAlt = `s7-3-head-alt-${runSuffix}`
+  const managerHome = `s7-3-mgr-home-${runSuffix}`
+  const otherApprover = `s7-3-other-${runSuffix}`
+  const adminActor = `s7-3-admin-${runSuffix}`
 
-  const userIds: string[] = [requester, managerHome, managerForeign, managerAlt, otherApprover, adminActor]
+  const userIds: string[] = [
+    requester,
+    headHome,
+    headForeign,
+    headAlt,
+    managerHome,
+    otherApprover,
+    adminActor,
+  ]
   const integrationIds: string[] = []
   const createdFlowIds: string[] = []
   const createdInstanceIds: string[] = []
   const createdRequestIds: string[] = []
 
   let adminToken = ''
+  let headToken = ''
   let managerToken = ''
   let otherToken = ''
   let adminActorToken = ''
 
   // Directory fixture handles for freeze-mutation + org-anchor cases.
-  let homeMgrAccountId = ''
-  let homeDeptId = ''
-  let homeIntegrationId = ''
-  let freezeMgrAccountId = ''
-  let freezeAltAccountId = ''
+  let homeHeadExternal = ''
   let freezeDeptId = ''
+  let freezeHeadExternal = ''
+  let freezeAltExternal = ''
 
   function setFlag(on: boolean): void {
     if (on) process.env[DYNAMIC_FLAG] = 'true'
@@ -137,7 +148,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
   async function seedUser(userId: string): Promise<void> {
     await (pool as Pool).query(
       `INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x') ON CONFLICT (id) DO NOTHING`,
-      [userId, `${userId}@s7-2.test`],
+      [userId, `${userId}@s7-3.test`],
     )
   }
 
@@ -153,12 +164,17 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     return id
   }
 
-  async function seedDept(integrationId: string, externalId: string, name: string): Promise<string> {
+  async function seedDept(
+    integrationId: string,
+    externalId: string,
+    name: string,
+    raw: Record<string, unknown> = {},
+  ): Promise<string> {
     return (
       await (pool as Pool).query<{ id: string }>(
         `INSERT INTO directory_departments (integration_id, provider, external_department_id, name, is_active, raw)
-         VALUES ($1, 'dingtalk', $2, $3, true, '{}'::jsonb) RETURNING id`,
-        [integrationId, externalId, name],
+         VALUES ($1, 'dingtalk', $2, $3, true, $4::jsonb) RETURNING id`,
+        [integrationId, externalId, name, JSON.stringify(raw)],
       )
     ).rows[0].id
   }
@@ -248,7 +264,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     return requestJson(`${baseUrl}/api/attendance/requests/${requestId}/${action}`, {
       method: 'POST',
       headers: authHeaders(token),
-      body: JSON.stringify({ comment: `s7-2 ${action}` }),
+      body: JSON.stringify({ comment: `s7-3 ${action}` }),
     })
   }
 
@@ -258,8 +274,8 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       s.once('error', () => resolve(false))
       s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
     })
-    if (!canListen) throw new Error('S7-2 tests require an available loopback port.')
-    if (!dbUrl) throw new Error('DATABASE_URL / ATTENDANCE_TEST_DATABASE_URL is required for the S7-2 suite.')
+    if (!canListen) throw new Error('S7-3 tests require an available loopback port.')
+    if (!dbUrl) throw new Error('DATABASE_URL / ATTENDANCE_TEST_DATABASE_URL is required for the S7-3 suite.')
 
     process.env.DATABASE_URL = dbUrl
     prevRbac = process.env.RBAC_BYPASS
@@ -273,56 +289,124 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
 
     for (const uid of userIds) await seedUser(uid)
 
-    // ── orgHome: linked requester + normalized is_manager (authoritative) ──
-    homeIntegrationId = await seedIntegration(orgHome, `s7-2-home-int-${runSuffix}`, `corp-home-${runSuffix}`)
-    homeDeptId = await seedDept(homeIntegrationId, `dept-home-${runSuffix}`, 'Home Eng')
-    const homeReqAcc = await seedAccount(homeIntegrationId, `ext-req-home-${runSuffix}`, `key-req-home-${runSuffix}`, 'ReqHome')
-    homeMgrAccountId = await seedAccount(homeIntegrationId, `ext-mgr-home-${runSuffix}`, `key-mgr-home-${runSuffix}`, 'MgrHome')
-    // Legacy leader that would resolve to managerAlt — precedence must pick normalized managerHome.
-    const homeLegacyAcc = await seedAccount(
-      homeIntegrationId,
-      `ext-legacy-home-${runSuffix}`,
-      `key-legacy-home-${runSuffix}`,
-      'LegacyHome',
-      { leader_in_dept: [{ dept_id: `dept-home-${runSuffix}`, leader: true }] },
-    )
+    // ── orgHome: linked requester + dept head via dept_manager_userid_list (first-linked wins) ──
+    const homeInt = await seedIntegration(orgHome, `s7-3-home-int-${runSuffix}`, `corp-home-${runSuffix}`)
+    homeHeadExternal = `ext-head-home-${runSuffix}`
+    const homeDeptExternal = `dept-home-${runSuffix}`
+    const homeDeptId = await seedDept(homeInt, homeDeptExternal, 'Home Eng', {
+      dept_manager_userid_list: [homeHeadExternal],
+    })
+    const homeReqAcc = await seedAccount(homeInt, `ext-req-home-${runSuffix}`, `key-req-home-${runSuffix}`, 'ReqHome')
+    const homeHeadAcc = await seedAccount(homeInt, homeHeadExternal, `key-head-home-${runSuffix}`, 'HeadHome')
+    // Also seed a direct manager distinct from dept head so mixed-flow controls stay independent.
+    const homeMgrAcc = await seedAccount(homeInt, `ext-mgr-home-${runSuffix}`, `key-mgr-home-${runSuffix}`, 'MgrHome')
     await link(homeReqAcc, requester)
-    await link(homeMgrAccountId, managerHome)
-    await link(homeLegacyAcc, managerAlt)
+    await link(homeHeadAcc, headHome)
+    await link(homeMgrAcc, managerHome)
     await membership(homeReqAcc, homeDeptId, true, false)
-    await membership(homeMgrAccountId, homeDeptId, false, true) // normalized manager
-    await membership(homeLegacyAcc, homeDeptId, false, false)
+    await membership(homeHeadAcc, homeDeptId, false, false)
+    await membership(homeMgrAcc, homeDeptId, false, true)
 
-    // ── orgForeign: same local requester linked into a different org with a different manager ──
-    // updated_at will be more recent than home (inserted later) so the unscoped pick would choose
-    // foreign — the org anchor must force home when attendance requests use orgHome.
-    const foreignInt = await seedIntegration(orgForeign, `s7-2-foreign-int-${runSuffix}`, `corp-foreign-${runSuffix}`)
-    const foreignDept = await seedDept(foreignInt, `dept-foreign-${runSuffix}`, 'Foreign Eng')
-    const foreignReqAcc = await seedAccount(foreignInt, `ext-req-foreign-${runSuffix}`, `key-req-foreign-${runSuffix}`, 'ReqForeign')
-    const foreignMgrAcc = await seedAccount(foreignInt, `ext-mgr-foreign-${runSuffix}`, `key-mgr-foreign-${runSuffix}`, 'MgrForeign')
+    // ── orgForeign: same local requester linked into a different org with a different dept head ──
+    // updated_at will be more recent than home so the unscoped pick would choose foreign —
+    // the org anchor must force home when attendance requests use orgHome.
+    const foreignInt = await seedIntegration(orgForeign, `s7-3-foreign-int-${runSuffix}`, `corp-foreign-${runSuffix}`)
+    const foreignHeadExternal = `ext-head-foreign-${runSuffix}`
+    const foreignDept = await seedDept(foreignInt, `dept-foreign-${runSuffix}`, 'Foreign Eng', {
+      dept_manager_userid_list: [foreignHeadExternal],
+    })
+    const foreignReqAcc = await seedAccount(
+      foreignInt,
+      `ext-req-foreign-${runSuffix}`,
+      `key-req-foreign-${runSuffix}`,
+      'ReqForeign',
+    )
+    const foreignHeadAcc = await seedAccount(
+      foreignInt,
+      foreignHeadExternal,
+      `key-head-foreign-${runSuffix}`,
+      'HeadForeign',
+    )
     await link(foreignReqAcc, requester)
-    await link(foreignMgrAcc, managerForeign)
+    await link(foreignHeadAcc, headForeign)
     await membership(foreignReqAcc, foreignDept, true, false)
-    await membership(foreignMgrAcc, foreignDept, false, true)
-    // Bump foreign account updated_at so it is "more recent" than home (unscoped would pick it).
+    await membership(foreignHeadAcc, foreignDept, false, false)
     await pool.query(`UPDATE directory_accounts SET updated_at = now() + interval '1 hour' WHERE id = $1`, [
       foreignReqAcc,
     ])
 
-    // ── orgFreeze: 2-step flow freeze fixture (static step 0 + direct_manager step 1) ──
-    const freezeInt = await seedIntegration(orgFreeze, `s7-2-freeze-int-${runSuffix}`, `corp-freeze-${runSuffix}`)
-    freezeDeptId = await seedDept(freezeInt, `dept-freeze-${runSuffix}`, 'Freeze Eng')
-    const freezeReqAcc = await seedAccount(freezeInt, `ext-req-freeze-${runSuffix}`, `key-req-freeze-${runSuffix}`, 'ReqFreeze')
-    freezeMgrAccountId = await seedAccount(freezeInt, `ext-mgr-freeze-${runSuffix}`, `key-mgr-freeze-${runSuffix}`, 'MgrFreeze')
-    freezeAltAccountId = await seedAccount(freezeInt, `ext-mgr-alt-${runSuffix}`, `key-mgr-alt-${runSuffix}`, 'MgrAlt')
-    // Separate local user for freeze-org requester to avoid multi-org link noise on the shared requester.
-    // Reuse managerHome as the initial freeze manager; managerAlt as the post-mutation manager.
+    // ── orgFreeze: 2-step flow freeze fixture (static step 0 + dept_head step 1) ──
+    const freezeInt = await seedIntegration(orgFreeze, `s7-3-freeze-int-${runSuffix}`, `corp-freeze-${runSuffix}`)
+    freezeHeadExternal = `ext-head-freeze-${runSuffix}`
+    freezeAltExternal = `ext-head-alt-${runSuffix}`
+    freezeDeptId = await seedDept(freezeInt, `dept-freeze-${runSuffix}`, 'Freeze Eng', {
+      dept_manager_userid_list: [freezeHeadExternal],
+    })
+    const freezeReqAcc = await seedAccount(
+      freezeInt,
+      `ext-req-freeze-${runSuffix}`,
+      `key-req-freeze-${runSuffix}`,
+      'ReqFreeze',
+    )
+    const freezeHeadAcc = await seedAccount(
+      freezeInt,
+      freezeHeadExternal,
+      `key-head-freeze-${runSuffix}`,
+      'HeadFreeze',
+    )
+    const freezeAltAcc = await seedAccount(
+      freezeInt,
+      freezeAltExternal,
+      `key-head-alt-${runSuffix}`,
+      'HeadAlt',
+    )
     await link(freezeReqAcc, requester)
-    await link(freezeMgrAccountId, managerHome)
-    await link(freezeAltAccountId, managerAlt)
+    await link(freezeHeadAcc, headHome)
+    await link(freezeAltAcc, headAlt)
     await membership(freezeReqAcc, freezeDeptId, true, false)
-    await membership(freezeMgrAccountId, freezeDeptId, false, true)
-    await membership(freezeAltAccountId, freezeDeptId, false, false)
+    await membership(freezeHeadAcc, freezeDeptId, false, false)
+    await membership(freezeAltAcc, freezeDeptId, false, false)
+
+    // ── orgSelf: requester is the only linked dept head → self-exclusion at freeze ──
+    const selfInt = await seedIntegration(orgSelf, `s7-3-self-int-${runSuffix}`, `corp-self-${runSuffix}`)
+    const selfReqExternal = `ext-req-self-${runSuffix}`
+    const selfDept = await seedDept(selfInt, `dept-self-${runSuffix}`, 'Self Eng', {
+      dept_manager_userid_list: [selfReqExternal],
+    })
+    const selfReqAcc = await seedAccount(selfInt, selfReqExternal, `key-req-self-${runSuffix}`, 'ReqSelf')
+    await link(selfReqAcc, requester)
+    await membership(selfReqAcc, selfDept, true, false)
+
+    // ── orgVacant: department with empty / unlinked head list ──
+    const vacantInt = await seedIntegration(orgVacant, `s7-3-vacant-int-${runSuffix}`, `corp-vacant-${runSuffix}`)
+    const vacantDept = await seedDept(vacantInt, `dept-vacant-${runSuffix}`, 'Vacant Eng', {
+      dept_manager_userid_list: [`ext-unlinked-head-${runSuffix}`],
+    })
+    const vacantReqAcc = await seedAccount(
+      vacantInt,
+      `ext-req-vacant-${runSuffix}`,
+      `key-req-vacant-${runSuffix}`,
+      'ReqVacant',
+    )
+    // Unlinked head account (no directory_account_links row) → vacant for resolution purposes.
+    await seedAccount(
+      vacantInt,
+      `ext-unlinked-head-${runSuffix}`,
+      `key-unlinked-head-${runSuffix}`,
+      'UnlinkedHead',
+    )
+    await link(vacantReqAcc, requester)
+    await membership(vacantReqAcc, vacantDept, true, false)
+
+    // ── orgDm: direct_manager regression control (normalized is_manager) ──
+    const dmInt = await seedIntegration(orgDm, `s7-3-dm-int-${runSuffix}`, `corp-dm-${runSuffix}`)
+    const dmDept = await seedDept(dmInt, `dept-dm-${runSuffix}`, 'Dm Eng', {})
+    const dmReqAcc = await seedAccount(dmInt, `ext-req-dm-${runSuffix}`, `key-req-dm-${runSuffix}`, 'ReqDm')
+    const dmMgrAcc = await seedAccount(dmInt, `ext-mgr-dm-${runSuffix}`, `key-mgr-dm-${runSuffix}`, 'MgrDm')
+    await link(dmReqAcc, requester)
+    await link(dmMgrAcc, managerHome)
+    await membership(dmReqAcc, dmDept, true, false)
+    await membership(dmMgrAcc, dmDept, false, true)
 
     // RBAC substrate for authz legs (real DB tables, not just JWT claims).
     await pool.query(
@@ -338,12 +422,13 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
        VALUES
          ($1, 'attendance:approve'),
          ($2, 'attendance:approve'),
-         ($3, 'attendance:admin'),
-         ($4, 'attendance:write'),
-         ($4, 'attendance:approve'),
-         ($4, 'attendance:admin')
+         ($3, 'attendance:approve'),
+         ($4, 'attendance:admin'),
+         ($5, 'attendance:write'),
+         ($5, 'attendance:approve'),
+         ($5, 'attendance:admin')
        ON CONFLICT DO NOTHING`,
-      [managerHome, otherApprover, adminActor, requester],
+      [headHome, managerHome, otherApprover, adminActor, requester],
     )
 
     const repoRoot = path.join(__dirname, '../../../../')
@@ -355,10 +440,11 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     })
     await server.start()
     const address = server.getAddress()
-    if (!address || typeof address === 'string') throw new Error('S7-2 server did not expose a TCP address.')
+    if (!address || typeof address === 'string') throw new Error('S7-3 server did not expose a TCP address.')
     baseUrl = `http://127.0.0.1:${address.port}`
 
     adminToken = await devToken(requester, 'user', 'attendance:admin,attendance:write,attendance:approve')
+    headToken = await devToken(headHome, 'user', 'attendance:approve')
     managerToken = await devToken(managerHome, 'user', 'attendance:approve')
     otherToken = await devToken(otherApprover, 'user', 'attendance:approve')
     adminActorToken = await devToken(adminActor, 'user', 'attendance:admin')
@@ -370,7 +456,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
         if (createdRequestIds.length > 0) {
           await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::uuid[])', [createdRequestIds]).catch(() => undefined)
         }
-        for (const oid of [orgHome, orgForeign, orgUnlinked, orgFreeze, orgAuthz, orgFlagOff]) {
+        for (const oid of [orgHome, orgForeign, orgVacant, orgSelf, orgFreeze, orgAuthz, orgFlagOff, orgDm]) {
           await pool.query('DELETE FROM attendance_requests WHERE org_id = $1', [oid]).catch(() => undefined)
           await pool.query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [oid]).catch(() => undefined)
         }
@@ -403,16 +489,16 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     expect(process.env.DATABASE_URL).toBeTruthy()
   })
 
-  // ── Authoring: S7-2 makes direct_manager available when flag ON ──
-  it('AUTHORING: flag ON + direct_manager accepted (S7-2 implements the kind)', async () => {
+  // ── Authoring: S7-3 makes dept_head available when flag ON ──
+  it('AUTHORING: flag ON + dept_head accepted (S7-3 implements the kind)', async () => {
     setFlag(true)
     const res = await requestJson(`${baseUrl}/api/attendance/approval-flows`, {
       method: 'POST',
       headers: authHeaders(adminToken),
       body: JSON.stringify({
-        name: `s7-2-dm-flow-${runSuffix}`,
+        name: `s7-3-dh-flow-${runSuffix}`,
         requestType: 'time_correction',
-        steps: [{ kind: 'direct_manager' }],
+        steps: [{ kind: 'dept_head' }],
         orgId: orgHome,
         isActive: true,
       }),
@@ -421,7 +507,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     const id = (res.body as { data?: { id?: string } }).data?.id
     if (id) createdFlowIds.push(id)
     const steps = (res.body as { data?: { steps?: unknown[] } }).data?.steps
-    expect(steps).toEqual([{ name: undefined, kind: 'direct_manager' }])
+    expect(steps).toEqual([{ name: undefined, kind: 'dept_head' }])
   })
 
   it('AUTHORING: manager_at_level still UNAVAILABLE (S7-4 not shipped)', async () => {
@@ -430,7 +516,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       method: 'POST',
       headers: authHeaders(adminToken),
       body: JSON.stringify({
-        name: `s7-2-mal-unavail-${runSuffix}`,
+        name: `s7-3-mal-unavail-${runSuffix}`,
         requestType: 'time_correction',
         steps: [{ kind: 'manager_at_level', level: 1 }],
         orgId: orgHome,
@@ -441,49 +527,14 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
   })
 
-  // ── S7-1 NITs folded ──
-  it('NIT: dynamic + empty approverUserIds:[] → 422 MIXED (key-shape constraint)', async () => {
-    setFlag(true)
-    const res = await requestJson(`${baseUrl}/api/attendance/approval-flows`, {
-      method: 'POST',
-      headers: authHeaders(adminToken),
-      body: JSON.stringify({
-        name: `s7-2-mixed-empty-${runSuffix}`,
-        requestType: 'time_correction',
-        steps: [{ kind: 'direct_manager', approverUserIds: [] }],
-        orgId: orgHome,
-        isActive: true,
-      }),
-    })
-    expect(res.status, res.raw).toBe(422)
-    expect(errorCode(res)).toBe('APPROVAL_STEP_STATIC_DYNAMIC_MIXED')
-  })
-
-  it('NIT: non-string kind (number) → 422 APPROVAL_STEP_KIND_INVALID (not zod 400)', async () => {
-    setFlag(true)
-    const res = await requestJson(`${baseUrl}/api/attendance/approval-flows`, {
-      method: 'POST',
-      headers: authHeaders(adminToken),
-      body: JSON.stringify({
-        name: `s7-2-nonstr-kind-${runSuffix}`,
-        requestType: 'time_correction',
-        steps: [{ kind: 123 }],
-        orgId: orgHome,
-        isActive: true,
-      }),
-    })
-    expect(res.status, res.raw).toBe(422)
-    expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_INVALID')
-  })
-
   // ── Linked resolution + freeze + assignment ──
-  it('RUNTIME create: linked direct_manager freezes managerId and builds user assignment', async () => {
+  it('RUNTIME create: linked dept_head freezes deptHeadId and builds user assignment', async () => {
     setFlag(true)
     process.env.RBAC_BYPASS = 'true'
-    await seedFlow(orgHome, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-linked-${runSuffix}`)
+    await seedFlow(orgHome, 'time_correction', [{ kind: 'dept_head' }], `s7-3-linked-${runSuffix}`)
 
-    const workDate = '2026-06-01'
-    const res = await createRequest(orgHome, adminToken, workDate, 's7-2 linked resolution')
+    const workDate = '2026-07-01'
+    const res = await createRequest(orgHome, adminToken, workDate, 's7-3 linked resolution')
     expect(res.status, res.raw).toBe(201)
     const requestId = requestIdFrom(res) as string
     expect(requestId).toBeTruthy()
@@ -500,9 +551,8 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       'SELECT requester_snapshot, current_node_key FROM approval_instances WHERE id = $1',
       [instanceId],
     )
-    const snap = inst.rows[0].requester_snapshot as { id?: string; managerId?: string }
-    // Normalized is_manager (managerHome) wins over legacy leader_in_dept (managerAlt).
-    expect(snap.managerId).toBe(managerHome)
+    const snap = inst.rows[0].requester_snapshot as { id?: string; deptHeadId?: string }
+    expect(snap.deptHeadId).toBe(headHome)
     expect(snap.id).toBe(requester)
 
     const assignments = await (pool as Pool).query(
@@ -514,7 +564,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     expect(assignments.rows).toHaveLength(1)
     expect(assignments.rows[0]).toMatchObject({
       assignment_type: 'user',
-      assignee_id: managerHome,
+      assignee_id: headHome,
     })
     // Must NOT have fallen through to admin/source_queue.
     expect(assignments.rows.some((r) => r.assignment_type === 'source_queue')).toBe(false)
@@ -522,18 +572,13 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
   })
 
   // ── Org anchor: two orgs, one local user ──
-  it('ORG-ANCHOR: two-org/one-local-user resolves manager from the requesting org only', async () => {
+  it('ORG-ANCHOR: two-org/one-local-user resolves dept head from the requesting org only', async () => {
     setFlag(true)
     process.env.RBAC_BYPASS = 'true'
-    // orgHome flow (already seeded above is leave+direct_manager; ensure one is active for leave).
-    // Create against orgHome — must get managerHome, NEVER managerForeign (even though foreign
-    // account is more recently updated and would win the unscoped pick).
-    const workDate = '2026-06-02'
-    // Deactivate any leftover leave flows on orgHome except we already have one; create a fresh one
-    // in case the prior test's flow is fine.
-    await seedFlow(orgHome, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-anchor-${runSuffix}`)
+    const workDate = '2026-07-02'
+    await seedFlow(orgHome, 'time_correction', [{ kind: 'dept_head' }], `s7-3-anchor-${runSuffix}`)
 
-    const res = await createRequest(orgHome, adminToken, workDate, 's7-2 org anchor')
+    const res = await createRequest(orgHome, adminToken, workDate, 's7-3 org anchor')
     expect(res.status, res.raw).toBe(201)
     const requestId = requestIdFrom(res) as string
     createdRequestIds.push(requestId)
@@ -546,72 +591,83 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     const inst = await (pool as Pool).query('SELECT requester_snapshot FROM approval_instances WHERE id = $1', [
       instanceId,
     ])
-    const snap = inst.rows[0].requester_snapshot as { managerId?: string }
-    expect(snap.managerId).toBe(managerHome)
-    expect(snap.managerId).not.toBe(managerForeign)
+    const snap = inst.rows[0].requester_snapshot as { deptHeadId?: string }
+    expect(snap.deptHeadId).toBe(headHome)
+    expect(snap.deptHeadId).not.toBe(headForeign)
   })
 
-  // ── Unlinked block-with-error + zero persistence ──
-  it('UNLINKED: direct_manager create fails 422 with ZERO attendance_requests / approval rows', async () => {
+  // ── Vacant/unlinked head block-with-error + zero persistence ──
+  it('VACANT: unlinked dept head create fails 422 with ZERO attendance_requests / approval rows', async () => {
     setFlag(true)
     process.env.RBAC_BYPASS = 'true'
-    // Purely-local user with no directory link in orgUnlinked.
-    const unlinkedUser = `s7-2-unlinked-user-${runSuffix}`
-    await seedUser(unlinkedUser)
-    userIds.push(unlinkedUser)
-    await (pool as Pool).query(
-      `INSERT INTO user_permissions (user_id, permission_code)
-       VALUES ($1, 'attendance:write'), ($1, 'attendance:admin')
-       ON CONFLICT DO NOTHING`,
-      [unlinkedUser],
-    )
-    await seedFlow(orgUnlinked, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-unlinked-${runSuffix}`)
+    await seedFlow(orgVacant, 'time_correction', [{ kind: 'dept_head' }], `s7-3-vacant-${runSuffix}`)
 
-    const unlinkedToken = await devToken(unlinkedUser, 'user', 'attendance:admin,attendance:write')
     const beforeReq = await (pool as Pool).query(
       'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
-      [orgUnlinked],
+      [orgVacant],
     )
     const beforeInst = await (pool as Pool).query(
-      `SELECT COUNT(*)::int AS n FROM approval_instances WHERE business_key LIKE $1`,
-      [`attendance-request:%`],
+      `SELECT COUNT(*)::int AS n FROM approval_instances
+        WHERE (metadata->>'orgId' = $1 OR subject_snapshot->>'orgId' = $1)`,
+      [orgVacant],
+    )
+    const beforeAssign = await (pool as Pool).query(
+      `SELECT COUNT(*)::int AS n FROM approval_assignments aa
+         JOIN approval_instances ai ON ai.id = aa.instance_id
+        WHERE (ai.metadata->>'orgId' = $1 OR ai.subject_snapshot->>'orgId' = $1)`,
+      [orgVacant],
     )
 
-    const res = await requestJson(`${baseUrl}/api/attendance/requests`, {
-      method: 'POST',
-      headers: authHeaders(unlinkedToken),
-      body: JSON.stringify({
-        orgId: orgUnlinked,
-        workDate: '2026-06-03',
-        requestType: 'time_correction',
-        requestedInAt: '2026-06-03T01:00:00Z',
-        requestedOutAt: '2026-06-03T10:00:00Z',
-        reason: 's7-2 unlinked block',
-      }),
-    })
+    const res = await createRequest(orgVacant, adminToken, '2026-07-03', 's7-3 vacant head block')
     expect(res.status, res.raw).toBe(422)
     expect(errorCode(res)).toBe('APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED')
 
     const afterReq = await (pool as Pool).query(
       'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
-      [orgUnlinked],
+      [orgVacant],
+    )
+    const afterInst = await (pool as Pool).query(
+      `SELECT COUNT(*)::int AS n FROM approval_instances
+        WHERE (metadata->>'orgId' = $1 OR subject_snapshot->>'orgId' = $1)`,
+      [orgVacant],
+    )
+    const afterAssign = await (pool as Pool).query(
+      `SELECT COUNT(*)::int AS n FROM approval_assignments aa
+         JOIN approval_instances ai ON ai.id = aa.instance_id
+        WHERE (ai.metadata->>'orgId' = $1 OR ai.subject_snapshot->>'orgId' = $1)`,
+      [orgVacant],
     )
     expect(afterReq.rows[0].n).toBe(beforeReq.rows[0].n)
-    // No new instance for this org's request path (business_key contains the request id which was never written).
-    const afterInst = await (pool as Pool).query(
-      `SELECT COUNT(*)::int AS n FROM approval_instances WHERE business_key LIKE $1`,
-      [`attendance-request:%`],
-    )
     expect(afterInst.rows[0].n).toBe(beforeInst.rows[0].n)
+    expect(afterAssign.rows[0].n).toBe(beforeAssign.rows[0].n)
   })
 
-  // P2 fix: multi-step [static, direct_manager] must ALSO fail closed at create when manager is
-  // unresolvable — never persist step-0 and strand on advance.
-  it('UNLINKED multi-step [static, direct_manager]: create 422 + zero request/instance/assignment rows (org-scoped)', async () => {
+  // ── Self-exclusion ──
+  it('SELF-EXCLUSION: requester-as-dept-head fails 422 with zero persistence', async () => {
     setFlag(true)
     process.env.RBAC_BYPASS = 'true'
-    const orgMulti = `s7-2-unlinked-multi-${runSuffix}`
-    const multiUser = `s7-2-unlinked-multi-user-${runSuffix}`
+    await seedFlow(orgSelf, 'time_correction', [{ kind: 'dept_head' }], `s7-3-self-${runSuffix}`)
+
+    const beforeReq = await (pool as Pool).query(
+      'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
+      [orgSelf],
+    )
+    const res = await createRequest(orgSelf, adminToken, '2026-07-04', 's7-3 self-exclusion')
+    expect(res.status, res.raw).toBe(422)
+    expect(errorCode(res)).toBe('APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED')
+    const afterReq = await (pool as Pool).query(
+      'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
+      [orgSelf],
+    )
+    expect(afterReq.rows[0].n).toBe(beforeReq.rows[0].n)
+  })
+
+  // ── Multi-step zero-persistence when later step is unresolvable ──
+  it('UNLINKED multi-step [static, dept_head]: create 422 + zero request/instance/assignment rows', async () => {
+    setFlag(true)
+    process.env.RBAC_BYPASS = 'true'
+    const orgMulti = `s7-3-unlinked-multi-${runSuffix}`
+    const multiUser = `s7-3-unlinked-multi-user-${runSuffix}`
     await seedUser(multiUser)
     userIds.push(multiUser)
     await (pool as Pool).query(
@@ -620,15 +676,14 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
        ON CONFLICT DO NOTHING`,
       [multiUser],
     )
-    // Static step 0 would have assigned multiUser; direct_manager at step 1 is unresolvable (no link).
     await seedFlow(
       orgMulti,
       'time_correction',
       [
         { name: 'S0', approverUserIds: [multiUser] },
-        { name: 'S1', kind: 'direct_manager' },
+        { name: 'S1', kind: 'dept_head' },
       ],
-      `s7-2-unlinked-multi-${runSuffix}`,
+      `s7-3-unlinked-multi-${runSuffix}`,
     )
 
     const multiToken = await devToken(multiUser, 'user', 'attendance:admin,attendance:write')
@@ -636,7 +691,6 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
       [orgMulti],
     )
-    // approval_instances store attendance org on metadata/subject_snapshot (no org_id column).
     const beforeInst = await (pool as Pool).query(
       `SELECT COUNT(*)::int AS n FROM approval_instances
         WHERE (metadata->>'orgId' = $1 OR subject_snapshot->>'orgId' = $1)`,
@@ -654,11 +708,11 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       headers: authHeaders(multiToken),
       body: JSON.stringify({
         orgId: orgMulti,
-        workDate: '2026-06-11',
+        workDate: '2026-07-05',
         requestType: 'time_correction',
-        requestedInAt: '2026-06-11T01:00:00Z',
-        requestedOutAt: '2026-06-11T10:00:00Z',
-        reason: 's7-2 unlinked multi-step block at create',
+        requestedInAt: '2026-07-05T01:00:00Z',
+        requestedOutAt: '2026-07-05T10:00:00Z',
+        reason: 's7-3 unlinked multi-step block at create',
       }),
     })
     expect(res.status, res.raw).toBe(422)
@@ -689,21 +743,21 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
   })
 
   // ── 2-step freeze after directory mutation ──
-  it('FREEZE: 2-step flow keeps step-2 assignee after directory manager mutation', async () => {
+  it('FREEZE: 2-step flow keeps step-2 assignee after directory dept-head mutation', async () => {
     setFlag(true)
     process.env.RBAC_BYPASS = 'true'
     await seedFlow(
       orgFreeze,
       'time_correction',
       [
-        { name: 'S0', approverUserIds: [managerHome] },
-        { name: 'S1', kind: 'direct_manager' },
+        { name: 'S0', approverUserIds: [headHome] },
+        { name: 'S1', kind: 'dept_head' },
       ],
-      `s7-2-freeze-${runSuffix}`,
+      `s7-3-freeze-${runSuffix}`,
     )
 
-    const workDate = '2026-06-04'
-    const res = await createRequest(orgFreeze, adminToken, workDate, 's7-2 freeze')
+    const workDate = '2026-07-06'
+    const res = await createRequest(orgFreeze, adminToken, workDate, 's7-3 freeze')
     expect(res.status, res.raw).toBe(201)
     const requestId = requestIdFrom(res) as string
     createdRequestIds.push(requestId)
@@ -716,23 +770,19 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
 
     const snapBefore = (
       await (pool as Pool).query('SELECT requester_snapshot FROM approval_instances WHERE id = $1', [instanceId])
-    ).rows[0].requester_snapshot as { managerId?: string }
-    expect(snapBefore.managerId).toBe(managerHome)
+    ).rows[0].requester_snapshot as { deptHeadId?: string }
+    expect(snapBefore.deptHeadId).toBe(headHome)
 
-    // Mutate directory: flip is_manager from managerHome → managerAlt BEFORE step-1 advance.
+    // Mutate directory: swap dept_manager_userid_list to headAlt BEFORE step-1 advance.
     await (pool as Pool).query(
-      `UPDATE directory_account_departments SET is_manager = false
-        WHERE directory_account_id = $1 AND directory_department_id = $2`,
-      [freezeMgrAccountId, freezeDeptId],
-    )
-    await (pool as Pool).query(
-      `UPDATE directory_account_departments SET is_manager = true
-        WHERE directory_account_id = $1 AND directory_department_id = $2`,
-      [freezeAltAccountId, freezeDeptId],
+      `UPDATE directory_departments
+          SET raw = jsonb_set(COALESCE(raw, '{}'::jsonb), '{dept_manager_userid_list}', $1::jsonb)
+        WHERE id = $2`,
+      [JSON.stringify([freezeAltExternal]), freezeDeptId],
     )
 
-    // Step 0 assignee (managerHome) approves → advances to step 1 (direct_manager).
-    const approve = await act(requestId, managerToken, 'approve')
+    // Step 0 assignee (headHome) approves → advances to step 1 (dept_head).
+    const approve = await act(requestId, headToken, 'approve')
     expect(approve.status, approve.raw).toBe(200)
 
     const snapAfter = (
@@ -741,7 +791,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
         [instanceId],
       )
     ).rows[0]
-    expect((snapAfter.requester_snapshot as { managerId?: string }).managerId).toBe(managerHome)
+    expect((snapAfter.requester_snapshot as { deptHeadId?: string }).deptHeadId).toBe(headHome)
     expect(snapAfter.current_step).toBe(1)
     expect(snapAfter.current_node_key).toBe(NODE_KEY_1)
 
@@ -751,32 +801,43 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       [instanceId, NODE_KEY_1],
     )
     expect(assignments.rows).toEqual([
-      expect.objectContaining({ assignment_type: 'user', assignee_id: managerHome }),
+      expect.objectContaining({ assignment_type: 'user', assignee_id: headHome }),
     ])
-    // The mutated managerAlt must NOT be the assignee.
-    expect(assignments.rows.some((r) => r.assignee_id === managerAlt)).toBe(false)
+    // The mutated headAlt must NOT be the assignee.
+    expect(assignments.rows.some((r) => r.assignee_id === headAlt)).toBe(false)
   })
 
   // ── Dynamic assignment authorization (S7-0 re-run for this kind) ──
-  it('AUTHZ: dynamic user assignee can approve; unassigned scope-authorized actor 403s; admin override works', async () => {
+  it('AUTHZ: dynamic user assignee can approve/reject; unassigned scope-authorized actor 403s; admin override works', async () => {
     setFlag(true)
-    // Force real authorization (no RBAC bypass).
     process.env.RBAC_BYPASS = 'false'
     try {
-      await seedFlow(orgAuthz, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-authz-${runSuffix}`)
-      // Seed directory for orgAuthz so create can freeze managerHome.
-      const authzInt = await seedIntegration(orgAuthz, `s7-2-authz-int-${runSuffix}`, `corp-authz-${runSuffix}`)
-      const authzDept = await seedDept(authzInt, `dept-authz-${runSuffix}`, 'Authz Eng')
-      const authzReqAcc = await seedAccount(authzInt, `ext-req-authz-${runSuffix}`, `key-req-authz-${runSuffix}`, 'ReqAuthz')
-      const authzMgrAcc = await seedAccount(authzInt, `ext-mgr-authz-${runSuffix}`, `key-mgr-authz-${runSuffix}`, 'MgrAuthz')
+      await seedFlow(orgAuthz, 'time_correction', [{ kind: 'dept_head' }], `s7-3-authz-${runSuffix}`)
+      const authzInt = await seedIntegration(orgAuthz, `s7-3-authz-int-${runSuffix}`, `corp-authz-${runSuffix}`)
+      const authzHeadExternal = `ext-head-authz-${runSuffix}`
+      const authzDept = await seedDept(authzInt, `dept-authz-${runSuffix}`, 'Authz Eng', {
+        dept_manager_userid_list: [authzHeadExternal],
+      })
+      const authzReqAcc = await seedAccount(
+        authzInt,
+        `ext-req-authz-${runSuffix}`,
+        `key-req-authz-${runSuffix}`,
+        'ReqAuthz',
+      )
+      const authzHeadAcc = await seedAccount(
+        authzInt,
+        authzHeadExternal,
+        `key-head-authz-${runSuffix}`,
+        'HeadAuthz',
+      )
       await link(authzReqAcc, requester)
-      await link(authzMgrAcc, managerHome)
+      await link(authzHeadAcc, headHome)
       await membership(authzReqAcc, authzDept, true, false)
-      await membership(authzMgrAcc, authzDept, false, true)
+      await membership(authzHeadAcc, authzDept, false, false)
 
       // Positive approve leg
-      const workDateA = '2026-06-05'
-      const createA = await createRequest(orgAuthz, adminToken, workDateA, 's7-2 authz approve')
+      const workDateA = '2026-07-07'
+      const createA = await createRequest(orgAuthz, adminToken, workDateA, 's7-3 authz approve')
       expect(createA.status, createA.raw).toBe(201)
       const requestIdA = requestIdFrom(createA) as string
       createdRequestIds.push(requestIdA)
@@ -785,18 +846,18 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       ).rows[0].approval_instance_id as string
       createdInstanceIds.push(instA)
 
-      // Negative: otherApprover holds attendance:approve (broad gate) but is NOT the manager.
+      // Negative: otherApprover holds attendance:approve (broad gate) but is NOT the dept head.
       const negApprove = await act(requestIdA, otherToken, 'approve')
       expect(negApprove.status, negApprove.raw).toBe(403)
       expect(errorCode(negApprove)).toBe('FORBIDDEN')
 
-      // Positive: managerHome is the frozen assignee.
-      const posApprove = await act(requestIdA, managerToken, 'approve')
+      // Positive: headHome is the frozen assignee.
+      const posApprove = await act(requestIdA, headToken, 'approve')
       expect(posApprove.status, posApprove.raw).toBe(200)
 
       // Reject legs on a fresh request.
-      const workDateB = '2026-06-06'
-      const createB = await createRequest(orgAuthz, adminToken, workDateB, 's7-2 authz reject')
+      const workDateB = '2026-07-08'
+      const createB = await createRequest(orgAuthz, adminToken, workDateB, 's7-3 authz reject')
       expect(createB.status, createB.raw).toBe(201)
       const requestIdB = requestIdFrom(createB) as string
       createdRequestIds.push(requestIdB)
@@ -809,12 +870,12 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       expect(negReject.status, negReject.raw).toBe(403)
       expect(errorCode(negReject)).toBe('FORBIDDEN')
 
-      const posReject = await act(requestIdB, managerToken, 'reject')
+      const posReject = await act(requestIdB, headToken, 'reject')
       expect(posReject.status, posReject.raw).toBe(200)
 
       // Admin override (not the assignee) on a third request — approve.
-      const workDateC = '2026-06-07'
-      const createC = await createRequest(orgAuthz, adminToken, workDateC, 's7-2 authz admin')
+      const workDateC = '2026-07-09'
+      const createC = await createRequest(orgAuthz, adminToken, workDateC, 's7-3 authz admin')
       expect(createC.status, createC.raw).toBe(201)
       const requestIdC = requestIdFrom(createC) as string
       createdRequestIds.push(requestIdC)
@@ -826,9 +887,9 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       const adminApprove = await act(requestIdC, adminActorToken, 'approve')
       expect(adminApprove.status, adminApprove.raw).toBe(200)
 
-      // P3: admin override reject (symmetric with approve — non-assignee admin still authorized).
-      const workDateD = '2026-06-12'
-      const createD = await createRequest(orgAuthz, adminToken, workDateD, 's7-2 authz admin reject')
+      // Admin override reject (symmetric).
+      const workDateD = '2026-07-10'
+      const createD = await createRequest(orgAuthz, adminToken, workDateD, 's7-3 authz admin reject')
       expect(createD.status, createD.raw).toBe(201)
       const requestIdD = requestIdFrom(createD) as string
       createdRequestIds.push(requestIdD)
@@ -845,16 +906,16 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
   })
 
   // ── Flag-off create ──
-  it('FLAG-OFF create: dynamic flow fails-closed with zero rows', async () => {
+  it('FLAG-OFF create: dynamic dept_head flow fails-closed with zero rows', async () => {
     setFlag(false)
     process.env.RBAC_BYPASS = 'true'
-    await seedFlow(orgFlagOff, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-flagoff-create-${runSuffix}`)
+    await seedFlow(orgFlagOff, 'time_correction', [{ kind: 'dept_head' }], `s7-3-flagoff-create-${runSuffix}`)
 
     const before = await (pool as Pool).query(
       'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
       [orgFlagOff],
     )
-    const res = await createRequest(orgFlagOff, adminToken, '2026-06-08', 's7-2 flag-off create')
+    const res = await createRequest(orgFlagOff, adminToken, '2026-07-11', 's7-3 flag-off create')
     expect(res.status, res.raw).toBe(422)
     expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
     const after = await (pool as Pool).query(
@@ -864,32 +925,46 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     expect(after.rows[0].n).toBe(before.rows[0].n)
   })
 
-  // ── Flag-off advance rollback ──
-  it('FLAG-OFF advance: step-1 approve fails and rolls back (instance still at step 0)', async () => {
+  // ── Flag-off advance rollback (design-lock §4.1 path (b) re-verified for dept_head) ──
+  it('FLAG-OFF advance: step-0 approve into dept_head fails and rolls back (instance still at step 0)', async () => {
     process.env.RBAC_BYPASS = 'true'
     setFlag(true)
-    const orgAdv = `s7-2-adv-${runSuffix}`
-    // Directory for this org so create succeeds under flag ON.
-    const advInt = await seedIntegration(orgAdv, `s7-2-adv-int-${runSuffix}`, `corp-adv-${runSuffix}`)
-    const advDept = await seedDept(advInt, `dept-adv-${runSuffix}`, 'Adv Eng')
-    const advReqAcc = await seedAccount(advInt, `ext-req-adv-${runSuffix}`, `key-req-adv-${runSuffix}`, 'ReqAdv')
-    const advMgrAcc = await seedAccount(advInt, `ext-mgr-adv-${runSuffix}`, `key-mgr-adv-${runSuffix}`, 'MgrAdv')
+    const orgAdv = `s7-3-adv-${runSuffix}`
+    // Directory for this org so create freezes dept_head successfully under flag ON.
+    const advInt = await seedIntegration(orgAdv, `s7-3-adv-int-${runSuffix}`, `corp-adv-${runSuffix}`)
+    const advHeadExternal = `ext-head-adv-${runSuffix}`
+    const advDept = await seedDept(advInt, `dept-adv-${runSuffix}`, 'Adv Eng', {
+      dept_manager_userid_list: [advHeadExternal],
+    })
+    const advReqAcc = await seedAccount(
+      advInt,
+      `ext-req-adv-${runSuffix}`,
+      `key-req-adv-${runSuffix}`,
+      'ReqAdv',
+    )
+    const advHeadAcc = await seedAccount(
+      advInt,
+      advHeadExternal,
+      `key-head-adv-${runSuffix}`,
+      'HeadAdv',
+    )
     await link(advReqAcc, requester)
-    await link(advMgrAcc, managerHome)
+    await link(advHeadAcc, headHome)
     await membership(advReqAcc, advDept, true, false)
-    await membership(advMgrAcc, advDept, false, true)
+    await membership(advHeadAcc, advDept, false, false)
 
+    // 2-step: static step 0 (headHome) → dynamic dept_head step 1.
     await seedFlow(
       orgAdv,
       'time_correction',
       [
-        { name: 'S0', approverUserIds: [managerHome] },
-        { name: 'S1', kind: 'direct_manager' },
+        { name: 'S0', approverUserIds: [headHome] },
+        { name: 'S1', kind: 'dept_head' },
       ],
-      `s7-2-flagoff-adv-${runSuffix}`,
+      `s7-3-flagoff-adv-${runSuffix}`,
     )
 
-    const create = await createRequest(orgAdv, adminToken, '2026-06-09', 's7-2 flag-off advance')
+    const create = await createRequest(orgAdv, adminToken, '2026-07-15', 's7-3 flag-off advance')
     expect(create.status, create.raw).toBe(201)
     const requestId = requestIdFrom(create) as string
     createdRequestIds.push(requestId)
@@ -898,51 +973,81 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     ).rows[0].approval_instance_id as string
     createdInstanceIds.push(instanceId)
 
-    // Flip flag OFF before step advance.
+    // Freeze succeeded under flag ON (dept head present in snapshot).
+    const snapBefore = (
+      await (pool as Pool).query('SELECT requester_snapshot FROM approval_instances WHERE id = $1', [instanceId])
+    ).rows[0].requester_snapshot as { deptHeadId?: string }
+    expect(snapBefore.deptHeadId).toBe(headHome)
+
+    // Flip flag OFF before step advance — §4.1 path (b): next dynamic step is unavailable.
     setFlag(false)
-    const approve = await act(requestId, managerToken, 'approve')
-    expect(approve.status, approve.raw).toBe(422)
-    expect(errorCode(approve)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
+    try {
+      const approve = await act(requestId, headToken, 'approve')
+      expect(approve.status, approve.raw).toBe(422)
+      expect(errorCode(approve)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
 
-    const inst = await (pool as Pool).query(
-      'SELECT status, current_step, current_node_key, version FROM approval_instances WHERE id = $1',
-      [instanceId],
-    )
-    expect(inst.rows[0].status).toBe('pending')
-    expect(inst.rows[0].current_step).toBe(0)
-    expect(inst.rows[0].current_node_key).toBe(NODE_KEY_0)
-    // No approval_records appended for the failed advance.
-    const records = await (pool as Pool).query(
-      'SELECT COUNT(*)::int AS n FROM approval_records WHERE instance_id = $1',
-      [instanceId],
-    )
-    expect(records.rows[0].n).toBe(0)
-    // Active assignment still step 0's static assignee.
-    const assignments = await (pool as Pool).query(
-      `SELECT assignment_type, assignee_id FROM approval_assignments
-        WHERE instance_id = $1 AND is_active = TRUE`,
-      [instanceId],
-    )
-    expect(assignments.rows).toEqual([
-      expect.objectContaining({ assignment_type: 'user', assignee_id: managerHome }),
-    ])
+      // Transaction fully rolls back: instance still pending at step 0.
+      const inst = await (pool as Pool).query(
+        'SELECT status, current_step, current_node_key, version FROM approval_instances WHERE id = $1',
+        [instanceId],
+      )
+      expect(inst.rows[0].status).toBe('pending')
+      expect(inst.rows[0].current_step).toBe(0)
+      expect(inst.rows[0].current_node_key).toBe(NODE_KEY_0)
 
-    await (pool as Pool).query('DELETE FROM attendance_requests WHERE org_id = $1', [orgAdv]).catch(() => undefined)
-    await (pool as Pool).query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [orgAdv]).catch(() => undefined)
+      // Attendance request remains pending (no status advance / finalization).
+      const reqRow = await (pool as Pool).query(
+        'SELECT status FROM attendance_requests WHERE id = $1',
+        [requestId],
+      )
+      expect(reqRow.rows[0].status).toBe('pending')
+
+      // No approval_records appended for the failed advance.
+      const records = await (pool as Pool).query(
+        'SELECT COUNT(*)::int AS n FROM approval_records WHERE instance_id = $1',
+        [instanceId],
+      )
+      expect(records.rows[0].n).toBe(0)
+
+      // Original step-0 assignment remains the only active assignment; no step-1 rows.
+      const active = await (pool as Pool).query(
+        `SELECT assignment_type, assignee_id, node_key FROM approval_assignments
+          WHERE instance_id = $1 AND is_active = TRUE`,
+        [instanceId],
+      )
+      expect(active.rows).toEqual([
+        expect.objectContaining({
+          assignment_type: 'user',
+          assignee_id: headHome,
+          node_key: NODE_KEY_0,
+        }),
+      ])
+      const step1Any = await (pool as Pool).query(
+        `SELECT COUNT(*)::int AS n FROM approval_assignments
+          WHERE instance_id = $1 AND node_key = $2`,
+        [instanceId, NODE_KEY_1],
+      )
+      expect(step1Any.rows[0].n).toBe(0)
+    } finally {
+      // Restore flag for subsequent legs (suite afterAll also restores prevFlag).
+      setFlag(true)
+      await (pool as Pool).query('DELETE FROM attendance_requests WHERE org_id = $1', [orgAdv]).catch(() => undefined)
+      await (pool as Pool).query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [orgAdv]).catch(() => undefined)
+    }
   })
 
   // ── Legacy static byte-identity under flag off ──
   it('LEGACY static: flag OFF flow with no dynamic kind still creates + assigns statically', async () => {
     setFlag(false)
     process.env.RBAC_BYPASS = 'true'
-    const orgLegacy = `s7-2-legacy-${runSuffix}`
+    const orgLegacy = `s7-3-legacy-${runSuffix}`
     await seedFlow(
       orgLegacy,
       'time_correction',
-      [{ name: 'LM', approverUserIds: [managerHome] }],
-      `s7-2-legacy-${runSuffix}`,
+      [{ name: 'LM', approverUserIds: [headHome] }],
+      `s7-3-legacy-${runSuffix}`,
     )
-    const res = await createRequest(orgLegacy, adminToken, '2026-06-10', 's7-2 legacy static')
+    const res = await createRequest(orgLegacy, adminToken, '2026-07-12', 's7-3 legacy static')
     expect(res.status, res.raw).toBe(201)
     const requestId = requestIdFrom(res) as string
     createdRequestIds.push(requestId)
@@ -953,7 +1058,8 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     const snap = (
       await (pool as Pool).query('SELECT requester_snapshot FROM approval_instances WHERE id = $1', [instanceId])
     ).rows[0].requester_snapshot as Record<string, unknown>
-    // Legacy snapshot shape: id/name only (no managerId freeze when no dynamic kind).
+    // Legacy snapshot shape: id/name only (no deptHeadId freeze when no dynamic kind).
+    expect(snap.deptHeadId).toBeUndefined()
     expect(snap.managerId).toBeUndefined()
     expect(snap.id).toBe(requester)
     const assignments = await (pool as Pool).query(
@@ -962,9 +1068,89 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       [instanceId],
     )
     expect(assignments.rows).toEqual([
-      expect.objectContaining({ assignment_type: 'user', assignee_id: managerHome }),
+      expect.objectContaining({ assignment_type: 'user', assignee_id: headHome }),
     ])
     await (pool as Pool).query('DELETE FROM attendance_requests WHERE org_id = $1', [orgLegacy]).catch(() => undefined)
     await (pool as Pool).query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [orgLegacy]).catch(() => undefined)
+  })
+
+  // ── direct_manager regression control ──
+  it('REGRESSION: direct_manager still freezes managerId and assigns (S7-2 preserved)', async () => {
+    setFlag(true)
+    process.env.RBAC_BYPASS = 'true'
+    await seedFlow(orgDm, 'time_correction', [{ kind: 'direct_manager' }], `s7-3-dm-reg-${runSuffix}`)
+
+    const res = await createRequest(orgDm, adminToken, '2026-07-13', 's7-3 dm regression')
+    expect(res.status, res.raw).toBe(201)
+    const requestId = requestIdFrom(res) as string
+    createdRequestIds.push(requestId)
+    const instanceId = (
+      await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestId])
+    ).rows[0].approval_instance_id as string
+    createdInstanceIds.push(instanceId)
+    const snap = (
+      await (pool as Pool).query('SELECT requester_snapshot FROM approval_instances WHERE id = $1', [instanceId])
+    ).rows[0].requester_snapshot as { managerId?: string; deptHeadId?: string }
+    expect(snap.managerId).toBe(managerHome)
+    expect(snap.deptHeadId).toBeUndefined()
+    const assignments = await (pool as Pool).query(
+      `SELECT assignment_type, assignee_id FROM approval_assignments
+        WHERE instance_id = $1 AND is_active = TRUE`,
+      [instanceId],
+    )
+    expect(assignments.rows).toEqual([
+      expect.objectContaining({ assignment_type: 'user', assignee_id: managerHome }),
+    ])
+  })
+
+  // ── Mixed direct_manager + dept_head flow freezes both ──
+  it('MIXED: direct_manager + dept_head freezes both and assigns step 0 from manager', async () => {
+    setFlag(true)
+    process.env.RBAC_BYPASS = 'true'
+    await seedFlow(
+      orgHome,
+      'time_correction',
+      [
+        { name: 'S0', kind: 'direct_manager' },
+        { name: 'S1', kind: 'dept_head' },
+      ],
+      `s7-3-mixed-${runSuffix}`,
+    )
+
+    const res = await createRequest(orgHome, adminToken, '2026-07-14', 's7-3 mixed flow')
+    expect(res.status, res.raw).toBe(201)
+    const requestId = requestIdFrom(res) as string
+    createdRequestIds.push(requestId)
+    const instanceId = (
+      await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestId])
+    ).rows[0].approval_instance_id as string
+    createdInstanceIds.push(instanceId)
+
+    const snap = (
+      await (pool as Pool).query('SELECT requester_snapshot FROM approval_instances WHERE id = $1', [instanceId])
+    ).rows[0].requester_snapshot as { managerId?: string; deptHeadId?: string }
+    expect(snap.managerId).toBe(managerHome)
+    expect(snap.deptHeadId).toBe(headHome)
+
+    const step0 = await (pool as Pool).query(
+      `SELECT assignment_type, assignee_id FROM approval_assignments
+        WHERE instance_id = $1 AND is_active = TRUE AND node_key = $2`,
+      [instanceId, NODE_KEY_0],
+    )
+    expect(step0.rows).toEqual([
+      expect.objectContaining({ assignment_type: 'user', assignee_id: managerHome }),
+    ])
+
+    // Advance: manager approves → step 1 uses frozen dept head (not live).
+    const approve = await act(requestId, managerToken, 'approve')
+    expect(approve.status, approve.raw).toBe(200)
+    const step1 = await (pool as Pool).query(
+      `SELECT assignment_type, assignee_id FROM approval_assignments
+        WHERE instance_id = $1 AND is_active = TRUE AND node_key = $2`,
+      [instanceId, NODE_KEY_1],
+    )
+    expect(step1.rows).toEqual([
+      expect.objectContaining({ assignment_type: 'user', assignee_id: headHome }),
+    ])
   })
 })

--- a/packages/core-backend/tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts
@@ -254,13 +254,12 @@ describeIfDatabase('S7-1 dynamic-kind step contract + fail-closed (authoring + r
     })
   }
 
-  // S7-2 implements direct_manager: a shape-valid direct_manager with flag ON is now AUTHORING-
-  // accepted. Keep this leg as a fail-closed proof for an STILL-unimplemented kind (dept_head /
-  // S7-3) so the UNAVAILABLE gate remains mutation-provable after S7-2 lands.
-  it('CREATE rejects a shape-valid but unimplemented dynamic kind (dept_head) with flag ON → 422 APPROVAL_STEP_KIND_UNAVAILABLE', async () => {
+  // S7-2/S7-3 implement direct_manager + dept_head: keep this leg as a fail-closed proof for an
+  // STILL-unimplemented kind (manager_at_level / S7-4) so the UNAVAILABLE gate remains mutation-provable.
+  it('CREATE rejects a shape-valid but unimplemented dynamic kind (manager_at_level) with flag ON → 422 APPROVAL_STEP_KIND_UNAVAILABLE', async () => {
     setFlag(true)
     try {
-      const res = await createFlow([{ kind: 'dept_head' }], `s7-1-unavail-${runSuffix}`)
+      const res = await createFlow([{ kind: 'manager_at_level', level: 1 }], `s7-1-unavail-${runSuffix}`)
       expect(res.status, res.raw).toBe(422)
       expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
     } finally {

--- a/packages/core-backend/tests/unit/attendance-approval-dept-head-s7-3.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-dept-head-s7-3.test.ts
@@ -1,0 +1,479 @@
+import { createRequire } from 'node:module'
+import { afterEach, describe, expect, it } from 'vitest'
+
+// S7-3 (RATIFIED attendance-approval-s7 resolver design-lock §2.2 / §3.4 / §4 / §7 S7-3): pure-helper
+// unit coverage for create-time freeze + assignment build from the frozen requester snapshot.
+// Directory resolution itself is owned by ApprovalDirectoryOrg (+ its unit/db suites); the port
+// wiring is covered by the port-scoping unit + the real-DB S7-3 integration matrix. These tests
+// pin the PLUGIN-side contracts:
+//   • freeze is a no-op for static-only flows (legacy byte-identity)
+//   • freeze calls the port once for a flow containing dept_head
+//   • mixed direct_manager + dept_head freezes BOTH
+//   • unresolved / self / empty at freeze → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (whole-flow)
+//   • assignment build reads ONLY the frozen snapshot (no port re-call)
+//   • self / empty / missing at assignment build → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED
+//   • direct_manager freeze/assignment preserved (regression)
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceApprovalCenterForTests as {
+  buildAttendanceApprovalAssignments: (
+    steps: unknown,
+    index?: number,
+    snapshot?: Record<string, unknown> | null,
+  ) => Array<Record<string, unknown>>
+  buildAttendanceApprovalInstancePayload: (input: Record<string, unknown>) => {
+    requesterSnapshot: Record<string, unknown>
+  }
+  resolveAttendanceDeptHeadFreeze: (input: {
+    orgId: string
+    userId: string
+    flowSteps: unknown
+    context: unknown
+  }) => Promise<Record<string, unknown>>
+  resolveAttendanceOrgRelationsFreeze: (input: {
+    orgId: string
+    userId: string
+    flowSteps: unknown
+    context: unknown
+  }) => Promise<Record<string, unknown>>
+  flowStepsNeedDeptHeadFreeze: (steps: unknown) => boolean
+  ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV: string
+}
+
+const {
+  buildAttendanceApprovalAssignments,
+  buildAttendanceApprovalInstancePayload,
+  resolveAttendanceDeptHeadFreeze,
+  resolveAttendanceOrgRelationsFreeze,
+  flowStepsNeedDeptHeadFreeze,
+  ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV,
+} = helpers
+
+function httpCode(fn: () => void): { status: number; code: string } | null {
+  try {
+    fn()
+    return null
+  } catch (err) {
+    const e = err as { status?: number; code?: string }
+    return { status: e.status ?? -1, code: e.code ?? '<none>' }
+  }
+}
+
+afterEach(() => {
+  delete process.env[ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV]
+})
+
+describe('S7-3 flowStepsNeedDeptHeadFreeze', () => {
+  it('is false for static-only / empty flows (legacy freeze no-op)', () => {
+    expect(flowStepsNeedDeptHeadFreeze([{ approverUserIds: ['u1'] }])).toBe(false)
+    expect(flowStepsNeedDeptHeadFreeze([])).toBe(false)
+  })
+
+  it('is true when any step is dept_head (incl. later steps)', () => {
+    expect(flowStepsNeedDeptHeadFreeze([{ kind: 'dept_head' }])).toBe(true)
+    expect(
+      flowStepsNeedDeptHeadFreeze([
+        { name: 'S', approverUserIds: ['u1'] },
+        { kind: 'dept_head' },
+      ]),
+    ).toBe(true)
+  })
+
+  it('is false for direct_manager (its own S7-2 freeze seam)', () => {
+    expect(flowStepsNeedDeptHeadFreeze([{ kind: 'direct_manager' }])).toBe(false)
+  })
+})
+
+describe('S7-3 resolveAttendanceDeptHeadFreeze — create-time port call', () => {
+  it('static-only flow never calls the port', async () => {
+    let calls = 0
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['dept_head'],
+          resolve: async () => {
+            calls += 1
+            return { status: 'resolved', assignees: [{ assignmentType: 'user', assigneeId: 'dh1' }] }
+          },
+        },
+      },
+    }
+    const rel = await resolveAttendanceDeptHeadFreeze({
+      orgId: 'org-1',
+      userId: 'req-1',
+      flowSteps: [{ approverUserIds: ['u1'] }],
+      context,
+    })
+    expect(rel).toEqual({})
+    expect(calls).toBe(0)
+  })
+
+  it('linked resolution freezes deptHeadId from the port assignees', async () => {
+    let seen: { orgId: string; request: Record<string, unknown> } | null = null
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['dept_head'],
+          resolve: async (orgId: string, request: Record<string, unknown>) => {
+            seen = { orgId, request }
+            return { status: 'resolved', assignees: [{ assignmentType: 'user', assigneeId: 'dh-local' }] }
+          },
+        },
+      },
+    }
+    const rel = await resolveAttendanceDeptHeadFreeze({
+      orgId: 'org-home',
+      userId: 'req-1',
+      flowSteps: [{ kind: 'dept_head' }],
+      context,
+    })
+    expect(rel).toEqual({ deptHeadId: 'dh-local' })
+    expect(seen).toEqual({
+      orgId: 'org-home',
+      request: { kind: 'dept_head', requesterUserId: 'req-1' },
+    })
+  })
+
+  it('self-resolving dept head rejects at create-time freeze (APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED)', async () => {
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['dept_head'],
+          resolve: async () => ({
+            status: 'resolved',
+            assignees: [{ assignmentType: 'user', assigneeId: 'req-1' }],
+          }),
+        },
+      },
+    }
+    await expect(
+      resolveAttendanceDeptHeadFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ kind: 'dept_head' }],
+        context,
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('unresolved port result rejects at create-time freeze (whole-flow; never empty freeze)', async () => {
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['dept_head'],
+          resolve: async () => ({ status: 'unresolved', reason: 'no_dept_head_linked' }),
+        },
+      },
+    }
+    await expect(
+      resolveAttendanceDeptHeadFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ kind: 'dept_head' }],
+        context,
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('empty assignees array rejects at create-time freeze', async () => {
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['dept_head'],
+          resolve: async () => ({ status: 'resolved', assignees: [] }),
+        },
+      },
+    }
+    await expect(
+      resolveAttendanceDeptHeadFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ name: 'S0', approverUserIds: ['u1'] }, { kind: 'dept_head' }],
+        context,
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('missing port throws APPROVAL_STEP_KIND_UNAVAILABLE (resolver-unavailable §4.1)', async () => {
+    await expect(
+      resolveAttendanceDeptHeadFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ kind: 'dept_head' }],
+        context: { services: {} },
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_STEP_KIND_UNAVAILABLE' })
+  })
+})
+
+describe('S7-3 resolveAttendanceOrgRelationsFreeze — mixed direct_manager + dept_head', () => {
+  it('freezes both managerId and deptHeadId for a mixed flow', async () => {
+    const kinds: string[] = []
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['direct_manager', 'dept_head'],
+          resolve: async (_orgId: string, request: { kind: string }) => {
+            kinds.push(request.kind)
+            if (request.kind === 'direct_manager') {
+              return { status: 'resolved', assignees: [{ assignmentType: 'user', assigneeId: 'mgr-1' }] }
+            }
+            if (request.kind === 'dept_head') {
+              return { status: 'resolved', assignees: [{ assignmentType: 'user', assigneeId: 'dh-1' }] }
+            }
+            return { status: 'unimplemented' }
+          },
+        },
+      },
+    }
+    const rel = await resolveAttendanceOrgRelationsFreeze({
+      orgId: 'org-1',
+      userId: 'req-1',
+      flowSteps: [{ kind: 'direct_manager' }, { kind: 'dept_head' }],
+      context,
+    })
+    expect(rel).toEqual({ managerId: 'mgr-1', deptHeadId: 'dh-1' })
+    expect(kinds.sort()).toEqual(['dept_head', 'direct_manager'])
+  })
+
+  it('fails closed when dept_head is unresolved even if direct_manager resolves', async () => {
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['direct_manager', 'dept_head'],
+          resolve: async (_orgId: string, request: { kind: string }) => {
+            if (request.kind === 'direct_manager') {
+              return { status: 'resolved', assignees: [{ assignmentType: 'user', assigneeId: 'mgr-1' }] }
+            }
+            return { status: 'unresolved', reason: 'no_dept_head_linked' }
+          },
+        },
+      },
+    }
+    await expect(
+      resolveAttendanceOrgRelationsFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ kind: 'direct_manager' }, { kind: 'dept_head' }],
+        context,
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('dept_head-only flow freezes only deptHeadId', async () => {
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['direct_manager', 'dept_head'],
+          resolve: async (_orgId: string, request: { kind: string }) => {
+            if (request.kind === 'dept_head') {
+              return { status: 'resolved', assignees: [{ assignmentType: 'user', assigneeId: 'dh-only' }] }
+            }
+            return { status: 'unimplemented' }
+          },
+        },
+      },
+    }
+    const rel = await resolveAttendanceOrgRelationsFreeze({
+      orgId: 'org-1',
+      userId: 'req-1',
+      flowSteps: [{ kind: 'dept_head' }],
+      context,
+    })
+    expect(rel).toEqual({ deptHeadId: 'dh-only' })
+  })
+})
+
+describe('S7-3 buildAttendanceApprovalAssignments — frozen snapshot only', () => {
+  it('builds a user assignment from frozen deptHeadId (linked resolution)', () => {
+    const out = buildAttendanceApprovalAssignments(
+      [{ name: '部门主管', kind: 'dept_head' }],
+      0,
+      { id: 'req-1', name: 'Requester', deptHeadId: 'dh-1' },
+    )
+    expect(out).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'dh-1',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: {
+          source: 'attendance',
+          kind: 'dept_head',
+          stepName: '部门主管',
+          resolvedFrom: { kind: 'dept_head' },
+        },
+      },
+    ])
+  })
+
+  it('self-exclusion → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (never admin fallback)', () => {
+    expect(
+      httpCode(() =>
+        buildAttendanceApprovalAssignments([{ kind: 'dept_head' }], 0, {
+          id: 'req-1',
+          deptHeadId: 'req-1',
+        }),
+      ),
+    ).toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('missing deptHeadId → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED', () => {
+    expect(
+      httpCode(() =>
+        buildAttendanceApprovalAssignments([{ kind: 'dept_head' }], 0, { id: 'req-1' }),
+      ),
+    ).toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('blank deptHeadId → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED', () => {
+    expect(
+      httpCode(() =>
+        buildAttendanceApprovalAssignments([{ kind: 'dept_head' }], 0, {
+          id: 'req-1',
+          deptHeadId: '   ',
+        }),
+      ),
+    ).toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('null snapshot → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED', () => {
+    expect(httpCode(() => buildAttendanceApprovalAssignments([{ kind: 'dept_head' }], 0, null))).toEqual({
+      status: 422,
+      code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED',
+    })
+  })
+
+  it('mutation canary: dynamic unresolved must NOT produce admin/source_queue rows', () => {
+    try {
+      buildAttendanceApprovalAssignments([{ kind: 'dept_head' }], 0, { id: 'req-1' })
+      expect.fail('expected throw')
+    } catch (err) {
+      const e = err as { code?: string }
+      expect(e.code).toBe('APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED')
+    }
+    // Positive control: static empty still falls back (legacy reserved path).
+    const legacy = buildAttendanceApprovalAssignments([], 0)
+    expect(legacy.some((a) => a.assignmentType === 'role' && a.assigneeId === 'admin')).toBe(true)
+    expect(legacy.some((a) => a.assignmentType === 'source_queue')).toBe(true)
+  })
+
+  it('step-advance index uses frozen snapshot for step 1 (no live re-resolve)', () => {
+    const steps = [
+      { name: 'S0', approverUserIds: ['u-step0'] },
+      { name: 'S1', kind: 'dept_head' },
+    ]
+    const snap = { id: 'req-1', deptHeadId: 'dh-frozen' }
+    const out = buildAttendanceApprovalAssignments(steps, 1, snap)
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({
+      assignmentType: 'user',
+      assigneeId: 'dh-frozen',
+      sourceStep: 1,
+      nodeKey: 'attendance_request_step_1',
+    })
+  })
+
+  it('mixed flow step 0 direct_manager + step 1 dept_head read their own frozen fields', () => {
+    const steps = [
+      { name: 'S0', kind: 'direct_manager' },
+      { name: 'S1', kind: 'dept_head' },
+    ]
+    const snap = { id: 'req-1', managerId: 'mgr-frozen', deptHeadId: 'dh-frozen' }
+    expect(buildAttendanceApprovalAssignments(steps, 0, snap)[0]).toMatchObject({
+      assigneeId: 'mgr-frozen',
+      metadata: expect.objectContaining({ kind: 'direct_manager' }),
+    })
+    expect(buildAttendanceApprovalAssignments(steps, 1, snap)[0]).toMatchObject({
+      assigneeId: 'dh-frozen',
+      metadata: expect.objectContaining({ kind: 'dept_head' }),
+    })
+  })
+
+  it('legacy static byte-identity: user/role assignments unchanged when snapshot is present', () => {
+    const out = buildAttendanceApprovalAssignments(
+      [{ name: 'LM', approverUserIds: ['u1', 'u2'], approverRoleIds: ['r1'] }],
+      0,
+      { id: 'req-1', deptHeadId: 'dh-ignored-for-static' },
+    )
+    expect(out).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'u1',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', stepName: 'LM' },
+      },
+      {
+        assignmentType: 'user',
+        assigneeId: 'u2',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', stepName: 'LM' },
+      },
+      {
+        assignmentType: 'role',
+        assigneeId: 'r1',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', stepName: 'LM' },
+      },
+    ])
+  })
+})
+
+describe('S7-3 buildAttendanceApprovalInstancePayload — freeze into requesterSnapshot', () => {
+  it('legacy static: snapshot is still {id, name} only when orgRelations is empty', () => {
+    const payload = buildAttendanceApprovalInstancePayload({
+      approvalId: 'apv_1',
+      requestId: '00000000-0000-4000-8000-000000000001',
+      orgId: 'org-1',
+      userId: 'req-1',
+      requesterName: 'Alice',
+      draft: { requestType: 'leave', workDate: '2026-07-01', metadata: { approvalFlow: { steps: [] } } },
+    })
+    expect(payload.requesterSnapshot).toEqual({ id: 'req-1', name: 'Alice' })
+  })
+
+  it('freezes deptHeadId when orgRelations carries it', () => {
+    const payload = buildAttendanceApprovalInstancePayload({
+      approvalId: 'apv_1',
+      requestId: '00000000-0000-4000-8000-000000000002',
+      orgId: 'org-1',
+      userId: 'req-1',
+      requesterName: 'Alice',
+      draft: {
+        requestType: 'leave',
+        workDate: '2026-07-01',
+        metadata: { approvalFlow: { steps: [{ kind: 'dept_head' }] } },
+      },
+      orgRelations: { deptHeadId: 'dh-1' },
+    })
+    expect(payload.requesterSnapshot).toEqual({ id: 'req-1', name: 'Alice', deptHeadId: 'dh-1' })
+  })
+
+  it('freezes both managerId and deptHeadId for mixed orgRelations', () => {
+    const payload = buildAttendanceApprovalInstancePayload({
+      approvalId: 'apv_1',
+      requestId: '00000000-0000-4000-8000-000000000003',
+      orgId: 'org-1',
+      userId: 'req-1',
+      requesterName: 'Alice',
+      draft: {
+        requestType: 'leave',
+        workDate: '2026-07-01',
+        metadata: {
+          approvalFlow: { steps: [{ kind: 'direct_manager' }, { kind: 'dept_head' }] },
+        },
+      },
+      orgRelations: { managerId: 'mgr-1', deptHeadId: 'dh-1' },
+    })
+    expect(payload.requesterSnapshot).toEqual({
+      id: 'req-1',
+      name: 'Alice',
+      managerId: 'mgr-1',
+      deptHeadId: 'dh-1',
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-approval-direct-manager-s7-2.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-direct-manager-s7-2.test.ts
@@ -73,7 +73,7 @@ describe('S7-2 flowStepsNeedDirectManagerFreeze', () => {
     ).toBe(true)
   })
 
-  it('is false for other dynamic kinds (dept_head is S7-3 — no freeze yet)', () => {
+  it('is false for other dynamic kinds (dept_head freezes via its own S7-3 seam)', () => {
     expect(flowStepsNeedDirectManagerFreeze([{ kind: 'dept_head' }])).toBe(false)
   })
 })

--- a/packages/core-backend/tests/unit/attendance-approval-resolver-port-scoping.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-resolver-port-scoping.test.ts
@@ -29,9 +29,9 @@ describe('S7-2 precursor — approvalAssigneeResolver port is scoped to plugin-a
     expect(typeof services.approvalAssigneeResolver?.maxManagerChainLevels).toBe('number')
     expect(services.approvalAssigneeResolver?.maxManagerChainLevels).toBeGreaterThanOrEqual(1)
     expect(Array.isArray(services.approvalAssigneeResolver?.implementedKinds)).toBe(true)
-    // S7-2: direct_manager is the only implemented kind; dept_head / manager_at_level stay out.
+    // S7-2/S7-3: direct_manager + dept_head implemented; manager_at_level stays S7-4.
     expect(services.approvalAssigneeResolver?.implementedKinds).toContain('direct_manager')
-    expect(services.approvalAssigneeResolver?.implementedKinds).not.toContain('dept_head')
+    expect(services.approvalAssigneeResolver?.implementedKinds).toContain('dept_head')
     expect(services.approvalAssigneeResolver?.implementedKinds).not.toContain('manager_at_level')
     expect(services.approvalAssigneeResolver?.implementedKinds).not.toContain('continuous_managers')
   })

--- a/packages/core-backend/tests/unit/attendance-approval-step-contract-s7-1.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-step-contract-s7-1.test.ts
@@ -304,16 +304,21 @@ describe('S7-1 assertDynamicFlowStepsRuntimeAvailable — §4.1 runtime fail-clo
   })
 })
 
-describe('S7-1/S7-2 buildAttendanceApprovalAssignments — dynamic step never reaches the admin fallback', () => {
-  // S7-2: direct_manager is implemented — missing/empty/self snapshot → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED
-  // (block-with-error, §4). Other kinds still hit the S7-1 UNGATED defense-in-depth arm.
+describe('S7-1/S7-2/S7-3 buildAttendanceApprovalAssignments — dynamic step never reaches the admin fallback', () => {
+  // S7-2/S7-3: direct_manager + dept_head are implemented — missing/empty/self snapshot →
+  // APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (block-with-error, §4). manager_at_level still hits UNGATED.
   it('direct_manager without frozen managerId throws APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (never admin fallback)', () => {
     expect(httpCode(() => buildAttendanceApprovalAssignments([{ kind: 'direct_manager' }], 0)))
       .toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
   })
 
-  it('an unimplemented dynamic kind (dept_head) still throws APPROVAL_STEP_DYNAMIC_UNGATED', () => {
+  it('dept_head without frozen deptHeadId throws APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (never admin fallback)', () => {
     expect(httpCode(() => buildAttendanceApprovalAssignments([{ kind: 'dept_head' }], 0)))
+      .toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('an unimplemented dynamic kind (manager_at_level) still throws APPROVAL_STEP_DYNAMIC_UNGATED', () => {
+    expect(httpCode(() => buildAttendanceApprovalAssignments([{ kind: 'manager_at_level', level: 1 }], 0)))
       .toEqual({ status: 422, code: 'APPROVAL_STEP_DYNAMIC_UNGATED' })
   })
 

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -317,6 +317,10 @@ export default defineConfig({
       // gated describeIfDatabase; excluded here so the no-DB job cannot skip-green it; wired whole-file
       // into the attendance real-DB step in plugin-tests.yml.
       'tests/integration/attendance-approval-direct-manager-s7-2.db.test.ts',
+      // S7-3 dept_head real-DB: freeze + assignment + org-anchor + authz + flag-off + mixed DM+DH.
+      // DATABASE_URL-gated describeIfDatabase; excluded here so the no-DB job cannot skip-green it;
+      // wired whole-file into the attendance real-DB step in plugin-tests.yml.
+      'tests/integration/attendance-approval-dept-head-s7-3.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -152,8 +152,8 @@ function getApprovalStepKind(step) {
 // Static (kind-less) steps return early: their legacy tolerance (unmodeled keys stripped by zod, A1
 // round-trip) is deliberately unchanged. The level UPPER bound uses the HOST-resolved MAX
 // (context.services.approvalAssigneeResolver.maxManagerChainLevels), never a plugin-parsed env — one
-// source, two surfaces, no drift. S7-2 populates `implementedKinds: ['direct_manager']` only —
-// other well-formed dynamic kinds still land on (5) until S7-3/S7-4 wire them.
+// source, two surfaces, no drift. S7-2/S7-3 populate `direct_manager` + `dept_head`;
+// other well-formed dynamic kinds still land on (5) until S7-4 wires them.
 function assertApprovalStepsContract(steps, context) {
   if (!Array.isArray(steps)) return
   const port = context && context.services ? context.services.approvalAssigneeResolver : undefined
@@ -238,7 +238,8 @@ function assertApprovalStepsContract(steps, context) {
 // S7-1 §4.1 RUNTIME fail-closed gate. Given NORMALIZED flow steps (post-normalizeApprovalSteps, which
 // preserves a dynamic step's `kind`), throw HttpError(422) if a dynamic step is encountered while the
 // trigger set holds: flag OFF, OR the context.services resolver port is absent, OR the kind is not
-// resolver-implemented (S7-2: only `direct_manager`). A flow with NO dynamic step is a no-op (byte-identical legacy).
+// resolver-implemented (S7-2/S7-3: `direct_manager` + `dept_head`). A flow with NO dynamic step is a
+// no-op (byte-identical legacy).
 //   • request-create: pass no `onlyStepIndex` → WHOLE-flow scan, so a later dynamic step cannot start a
 //     flow and then strand mid-flight.
 //   • step-advance:   pass `onlyStepIndex = nextStepIndex` → check just the step about to become active.
@@ -20718,11 +20719,72 @@ function buildAttendanceApprovalNodeKey(stepIndex) {
 }
 
 // S7-2: does the (normalized) flow carry a direct_manager step? Used to decide whether to call the
-// org-scoped resolver port once at request-create for freeze (§3.4). Other dynamic kinds (S7-3/4)
-// will extend this as they land.
+// org-scoped resolver port once at request-create for freeze (§3.4).
 function flowStepsNeedDirectManagerFreeze(flowSteps) {
   const steps = normalizeApprovalSteps(flowSteps)
   return steps.some((step) => getApprovalStepKind(step) === 'direct_manager')
+}
+
+// S7-3: does the (normalized) flow carry a dept_head step? Used to decide whether to call the
+// org-scoped resolver port once at request-create for freeze (§3.4).
+function flowStepsNeedDeptHeadFreeze(flowSteps) {
+  const steps = normalizeApprovalSteps(flowSteps)
+  return steps.some((step) => getApprovalStepKind(step) === 'dept_head')
+}
+
+// Shared create-time port resolve for one dynamic kind. Port missing / unimplemented / throw map to
+// APPROVAL_STEP_KIND_UNAVAILABLE (§4.1); unresolved / empty / self map to
+// APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (§4). Never called at step-advance.
+async function resolveAttendanceDynamicKindFreeze({
+  orgId,
+  userId,
+  kind,
+  context,
+  unresolvedMessage,
+}) {
+  const port = context && context.services ? context.services.approvalAssigneeResolver : undefined
+  if (!port || typeof port.resolve !== 'function') {
+    throw new HttpError(
+      422,
+      'APPROVAL_STEP_KIND_UNAVAILABLE',
+      `动态审批人类型 "${kind}" 无法解析(resolver 端口缺失)——请求已阻断(fail-closed)`
+    )
+  }
+  let result
+  try {
+    result = await port.resolve(String(orgId ?? ''), {
+      kind,
+      requesterUserId: String(userId ?? ''),
+    })
+  } catch (err) {
+    if (err instanceof HttpError) throw err
+    throw new HttpError(
+      422,
+      'APPROVAL_STEP_KIND_UNAVAILABLE',
+      `动态审批人类型 "${kind}" 无法解析(resolver 调用失败)——请求已阻断(fail-closed)`
+    )
+  }
+  if (result && result.status === 'unimplemented') {
+    throw new HttpError(
+      422,
+      'APPROVAL_STEP_KIND_UNAVAILABLE',
+      `动态审批人类型 "${kind}" 当前不可用(能力未启用或无对应 resolver)`
+    )
+  }
+  if (result && result.status === 'resolved' && Array.isArray(result.assignees)) {
+    const hit = result.assignees.find(
+      (a) => a && a.assignmentType === 'user' && typeof a.assigneeId === 'string' && a.assigneeId.trim()
+    )
+    if (hit) {
+      const assigneeId = hit.assigneeId.trim()
+      // Defense-in-depth self-exclusion (port also excludes); self is unresolvable, not freezable.
+      if (assigneeId && assigneeId !== String(userId ?? '').trim()) {
+        return assigneeId
+      }
+    }
+  }
+  // unresolved / empty / self — hard block at create (whole-flow), never empty freeze + later strand.
+  throw new HttpError(422, 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED', unresolvedMessage)
 }
 
 // S7-2 §3.4 CREATE-TIME freeze: call the host-injected org-scoped port ONCE for a flow that contains
@@ -20736,53 +20798,40 @@ function flowStepsNeedDirectManagerFreeze(flowSteps) {
 // APPROVAL_STEP_KIND_UNAVAILABLE (§4.1 resolver-unavailable), never legacy admin fallback.
 async function resolveAttendanceDirectManagerFreeze({ orgId, userId, flowSteps, context }) {
   if (!flowStepsNeedDirectManagerFreeze(flowSteps)) return {}
-  const port = context && context.services ? context.services.approvalAssigneeResolver : undefined
-  if (!port || typeof port.resolve !== 'function') {
-    throw new HttpError(
-      422,
-      'APPROVAL_STEP_KIND_UNAVAILABLE',
-      '动态审批人类型 "direct_manager" 无法解析(resolver 端口缺失)——请求已阻断(fail-closed)'
-    )
-  }
-  let result
-  try {
-    result = await port.resolve(String(orgId ?? ''), {
-      kind: 'direct_manager',
-      requesterUserId: String(userId ?? ''),
-    })
-  } catch (err) {
-    if (err instanceof HttpError) throw err
-    throw new HttpError(
-      422,
-      'APPROVAL_STEP_KIND_UNAVAILABLE',
-      '动态审批人类型 "direct_manager" 无法解析(resolver 调用失败)——请求已阻断(fail-closed)'
-    )
-  }
-  if (result && result.status === 'unimplemented') {
-    throw new HttpError(
-      422,
-      'APPROVAL_STEP_KIND_UNAVAILABLE',
-      '动态审批人类型 "direct_manager" 当前不可用(能力未启用或无对应 resolver)'
-    )
-  }
-  if (result && result.status === 'resolved' && Array.isArray(result.assignees)) {
-    const hit = result.assignees.find(
-      (a) => a && a.assignmentType === 'user' && typeof a.assigneeId === 'string' && a.assigneeId.trim()
-    )
-    if (hit) {
-      const managerId = hit.assigneeId.trim()
-      // Defense-in-depth self-exclusion (port also excludes); self is unresolvable, not freezable.
-      if (managerId && managerId !== String(userId ?? '').trim()) {
-        return { managerId }
-      }
-    }
-  }
-  // unresolved / empty / self — hard block at create (whole-flow), never empty freeze + later strand.
-  throw new HttpError(
-    422,
-    'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED',
-    '动态审批人类型 "direct_manager" 无法解析(无关联上级、上级未绑定本地用户或解析到本人)——请求已阻断(fail-closed)，不得回退到管理员兜底队列'
-  )
+  const managerId = await resolveAttendanceDynamicKindFreeze({
+    orgId,
+    userId,
+    kind: 'direct_manager',
+    context,
+    unresolvedMessage:
+      '动态审批人类型 "direct_manager" 无法解析(无关联上级、上级未绑定本地用户或解析到本人)——请求已阻断(fail-closed)，不得回退到管理员兜底队列',
+  })
+  return { managerId }
+}
+
+// S7-3 §3.4 CREATE-TIME freeze: call the host-injected org-scoped port ONCE for a flow that contains
+// `dept_head`, and return `{ deptHeadId }` on success. Never called at step-advance.
+// Whole-flow posture mirrors S7-2: unresolved / empty / self → 422 APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED
+// before any write; port missing / unimplemented / throw → APPROVAL_STEP_KIND_UNAVAILABLE.
+async function resolveAttendanceDeptHeadFreeze({ orgId, userId, flowSteps, context }) {
+  if (!flowStepsNeedDeptHeadFreeze(flowSteps)) return {}
+  const deptHeadId = await resolveAttendanceDynamicKindFreeze({
+    orgId,
+    userId,
+    kind: 'dept_head',
+    context,
+    unresolvedMessage:
+      '动态审批人类型 "dept_head" 无法解析(无关联部门主管、主管未绑定本地用户或解析到本人)——请求已阻断(fail-closed)，不得回退到管理员兜底队列',
+  })
+  return { deptHeadId }
+}
+
+// S7-2 + S7-3: freeze every dynamic org relation the flow requires. A flow with both
+// direct_manager and dept_head freezes BOTH; either unresolved kind fails closed with zero persistence.
+async function resolveAttendanceOrgRelationsFreeze({ orgId, userId, flowSteps, context }) {
+  const directManager = await resolveAttendanceDirectManagerFreeze({ orgId, userId, flowSteps, context })
+  const deptHead = await resolveAttendanceDeptHeadFreeze({ orgId, userId, flowSteps, context })
+  return { ...directManager, ...deptHead }
 }
 
 function buildAttendanceApprovalAssignments(flowSteps, stepIndex = 0, requesterSnapshot = null) {
@@ -20834,9 +20883,33 @@ function buildAttendanceApprovalAssignments(flowSteps, stepIndex = 0, requesterS
     )
   }
 
+  // S7-3: dept_head reads ONLY the creation-frozen requesterSnapshot.deptHeadId (§3.4) — never a
+  // live directory re-query, never the host port again. Missing / blank / self ⇒
+  // APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED; NEVER the legacy admin/source_queue fallback.
+  if (dynamicKind === 'dept_head') {
+    const snap = requesterSnapshot && typeof requesterSnapshot === 'object' ? requesterSnapshot : null
+    const deptHeadId = snap && typeof snap.deptHeadId === 'string' ? snap.deptHeadId.trim() : ''
+    const requesterId = snap && typeof snap.id === 'string' ? snap.id.trim() : ''
+    if (deptHeadId && deptHeadId !== requesterId) {
+      pushAssignment('user', deptHeadId, {
+        source: 'attendance',
+        kind: 'dept_head',
+        stepName: currentStep?.name ?? null,
+        resolvedFrom: { kind: 'dept_head' },
+      })
+      return assignments
+    }
+    throw new HttpError(
+      422,
+      'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED',
+      '动态审批人类型 "dept_head" 无法解析(无关联部门主管、主管未绑定本地用户或解析到本人)——请求已阻断(fail-closed)，不得回退到管理员兜底队列'
+    )
+  }
+
   // S7-1 §4.1 defense-in-depth: any OTHER dynamic kind must NEVER fall through to the legacy
   // admin-queue fallback (that fallback is reserved for LEGACY static steps with empty approver
-  // arrays). S7-3/S7-4 will replace this arm per-kind; until then, fail closed with a distinct code.
+  // arrays). S7-4 will replace this arm for manager_at_level; until then, fail closed with a
+  // distinct code.
   if (dynamicKind) {
     throw new HttpError(
       422,
@@ -20891,12 +20964,16 @@ function buildAttendanceApprovalInstancePayload({
     minutes: draft?.metadata?.minutes ?? null,
   }
 
-  // S7-2 §3.4: freeze create-time org relations (managerId today; deptHeadId/managerChainIds in S7-3/4)
+  // S7-2/S7-3 §3.4: freeze create-time org relations (managerId + deptHeadId; managerChainIds in S7-4)
   // into the requester snapshot. Omitted fields stay omitted — never write null placeholders that would
   // change the legacy {id,name}-only snapshot shape for static-only flows.
   const frozenManagerId =
     orgRelations && typeof orgRelations.managerId === 'string' && orgRelations.managerId.trim()
       ? orgRelations.managerId.trim()
+      : null
+  const frozenDeptHeadId =
+    orgRelations && typeof orgRelations.deptHeadId === 'string' && orgRelations.deptHeadId.trim()
+      ? orgRelations.deptHeadId.trim()
       : null
 
   return {
@@ -20911,6 +20988,7 @@ function buildAttendanceApprovalInstancePayload({
       id: userId,
       name: requesterName || userId,
       ...(frozenManagerId ? { managerId: frozenManagerId } : {}),
+      ...(frozenDeptHeadId ? { deptHeadId: frozenDeptHeadId } : {}),
     },
     subjectSnapshot: {
       type: 'attendance_request',
@@ -21419,9 +21497,12 @@ module.exports = {
     ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV,
     ATTENDANCE_DYNAMIC_ASSIGNEE_KINDS,
     ATTENDANCE_MANAGER_AT_LEVEL_KIND,
-    // S7-2 create-time freeze seam (pure enough for unit tests with a faked port).
+    // S7-2/S7-3 create-time freeze seams (pure enough for unit tests with a faked port).
     resolveAttendanceDirectManagerFreeze,
+    resolveAttendanceDeptHeadFreeze,
+    resolveAttendanceOrgRelationsFreeze,
     flowStepsNeedDirectManagerFreeze,
+    flowStepsNeedDeptHeadFreeze,
   },
 
   async activate(context) {
@@ -25329,8 +25410,8 @@ module.exports = {
             // anywhere in the flow blocks request-create (flag OFF / port missing / kind unimplemented),
             // so a later dynamic step cannot start a flow and strand it mid-flight.
             assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata.approvalFlow.steps), context)
-            // S7-2 §3.4: freeze direct_manager once at create (org-scoped port); assignment build reads only the snapshot.
-            const orgRelations = await resolveAttendanceDirectManagerFreeze({
+            // S7-2/S7-3 §3.4: freeze direct_manager/dept_head once at create (org-scoped port); assignment build reads only the snapshot.
+            const orgRelations = await resolveAttendanceOrgRelationsFreeze({
               orgId, userId, flowSteps: draft.metadata.approvalFlow.steps, context,
             })
             const approvalPayload = buildAttendanceApprovalInstancePayload({
@@ -27897,8 +27978,8 @@ module.exports = {
         const approvalId = `apv_${randomUUID()}`
         // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
         assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
-        // S7-2 §3.4: freeze direct_manager once at create; assignment build reads only the snapshot.
-        const orgRelations = await resolveAttendanceDirectManagerFreeze({
+        // S7-2/S7-3 §3.4: freeze direct_manager/dept_head once at create; assignment build reads only the snapshot.
+        const orgRelations = await resolveAttendanceOrgRelationsFreeze({
           orgId, userId, flowSteps: draft.metadata?.approvalFlow?.steps, context,
         })
         const approvalPayload = buildAttendanceApprovalInstancePayload({
@@ -28233,8 +28314,8 @@ module.exports = {
             }
             // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
             assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
-            // S7-2 §3.4: freeze direct_manager once at create; assignment build reads only the snapshot.
-            const orgRelations = await resolveAttendanceDirectManagerFreeze({
+            // S7-2/S7-3 §3.4: freeze direct_manager/dept_head once at create; assignment build reads only the snapshot.
+            const orgRelations = await resolveAttendanceOrgRelationsFreeze({
               orgId, userId: input.userId, flowSteps: draft.metadata?.approvalFlow?.steps, context,
             })
             const approvalPayload = buildAttendanceApprovalInstancePayload({
@@ -28657,8 +28738,8 @@ module.exports = {
             }
             // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
             assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
-            // S7-2 §3.4: freeze direct_manager once at create; assignment build reads only the snapshot.
-            const orgRelations = await resolveAttendanceDirectManagerFreeze({
+            // S7-2/S7-3 §3.4: freeze direct_manager/dept_head once at create; assignment build reads only the snapshot.
+            const orgRelations = await resolveAttendanceOrgRelationsFreeze({
               orgId, userId: requesterSource.userId, flowSteps: draft.metadata?.approvalFlow?.steps, context,
             })
             const approvalPayload = buildAttendanceApprovalInstancePayload({
@@ -29170,8 +29251,8 @@ module.exports = {
             const approvalId = existingRequest.approval_instance_id || `apv_${randomUUID()}`
             // S7-1 §4.1 runtime fail-closed — whole-flow scan BEFORE any mutation (see request-create note).
             assertDynamicFlowStepsRuntimeAvailable(normalizeApprovalSteps(draft.metadata?.approvalFlow?.steps), context)
-            // S7-2 §3.4: freeze direct_manager once at create; assignment build reads only the snapshot.
-            const orgRelations = await resolveAttendanceDirectManagerFreeze({
+            // S7-2/S7-3 §3.4: freeze direct_manager/dept_head once at create; assignment build reads only the snapshot.
+            const orgRelations = await resolveAttendanceOrgRelationsFreeze({
               orgId: existingRequest.org_id ?? DEFAULT_ORG_ID,
               userId: existingRequest.user_id,
               flowSteps: draft.metadata?.approvalFlow?.steps,


### PR DESCRIPTION
## Summary

- add `dept_head` to the attendance dynamic-assignee resolver port while keeping `manager_at_level` unavailable for S7-4
- resolve the requester's department head through the org-anchored kernel directory seam, freeze `deptHeadId` at request creation, and build later assignments only from the frozen snapshot
- fail closed for missing, unlinked, or self department heads; preserve legacy static flows and S7-2 direct-manager behavior; and wire the S7-3 real-DB suite into the required plugin test lane

## Design

Implements S7-3 from:
`docs/development/attendance-approval-s7-resolver-direct-manager-dept-head-multilevel-design-lock-20260716.md`

The runtime flag remains opt-in and default OFF. S7-4 `manager_at_level`, S7-5 editor wiring, migrations, deployment, and environment changes remain out of scope.

Implementation was delegated to Grok Build. Codex independently reviewed the production call chain, found and closed the missing per-slice flag-off advance test, reran all checks, and reached APPROVE (0 P1 / 0 P2).

## Verification

- S7-1/S7-2/S7-3/scoping unit suites: 88/88
- S7-0/S7-1/S7-2/S7-3 real-DB suites: 71/71
- S7-3 real-DB suite: 15/15
- `pnpm --filter @metasheet/core-backend type-check`
- `git diff --check`

Mutation evidence:

- removed the production org anchor: the S7-3 real-DB suite failed on the cross-org fixture and dependent legs
- bypassed the step-advance runtime gate: the new flag-off advance test returned 200 and advanced instead of returning 422 and rolling back
- neutralized create-time unresolved handling and frozen-snapshot assignment in separate Grok mutations: the zero-persistence and frozen-assignee tests failed
