### PR TITLE
feat(multitable): W0 L8 exact-anchor destructive apply kernel

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -520,6 +520,7 @@ jobs:
             tests/integration/multitable-l5wire-checkpoint-activation-realdb.test.ts \
             tests/integration/multitable-exact-anchor-recovery-realdb.test.ts \
             tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts \
+            tests/integration/multitable-exact-anchor-apply-realdb.test.ts \
             tests/integration/multitable-d1c-form-submit-revision-realdb.test.ts \
             tests/integration/multitable-d1c-plugin-revision-realdb.test.ts \
             tests/integration/multitable-d1c-automation-revision-realdb.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260719120000_create_meta_recovery_token_burns.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260719120000_create_meta_recovery_token_burns.ts
@@ -32,13 +32,20 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       burned_at    timestamptz NOT NULL DEFAULT now()
     )
   `.execute(db)
+  // Sheet-scoped audit listing (sheet_id leading).
   await sql`
     CREATE INDEX IF NOT EXISTS idx_meta_recovery_token_burns_sheet
     ON meta_recovery_token_burns(sheet_id, burned_at)
   `.execute(db)
+  // G1 prune path: `DELETE … WHERE burned_at < …` — burned_at MUST lead the usable index.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_recovery_token_burns_burned_at
+    ON meta_recovery_token_burns(burned_at)
+  `.execute(db)
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_meta_recovery_token_burns_burned_at`.execute(db)
   await sql`DROP INDEX IF EXISTS idx_meta_recovery_token_burns_sheet`.execute(db)
   await sql`DROP TABLE IF EXISTS meta_recovery_token_burns`.execute(db)
 }

--- a/packages/core-backend/src/db/migrations/zzzz20260719120000_create_meta_recovery_token_burns.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260719120000_create_meta_recovery_token_burns.ts
@@ -1,0 +1,44 @@
+import { sql, type Kysely } from 'kysely'
+
+/**
+ * W0-1 v3.7 Lane L8 — the ANTI-REPLAY burn ledger for exact-anchor recovery tokens.
+ *
+ * Design authority: v3.7 lock §5 (in-fence execute) + the L6-b gate's pinned L8 deferral #3 (2026-07-16):
+ * a valid exact-anchor preview identity is stateless (HS256 JWT, 10m TTL) and could otherwise be EXECUTED
+ * MORE THAN ONCE within its TTL. The destructive apply burns the token's sha256 INSIDE its own single
+ * transaction (INSERT into this table); a second execute of the same token hits the primary key and the
+ * whole apply rolls back — at-most-once per minted preview, enforced by the database, not by app memory.
+ *
+ * Shape notes:
+ *   - `token_sha256` (PK): hex sha256 of the FULL signed token. The raw token is never stored (it is a
+ *     bearer credential); the hash is enough for the uniqueness barrier and useless to an attacker.
+ *   - `sheet_id` + `burned_at` + `actor_id`: audit surface only — values-free (no anchor/scope contents).
+ *   - No FK to sheets (a burn row must survive sheet deletion for audit).
+ *   - Rows are tiny and bounded by real executes; a retention sweep can prune rows older than the token
+ *     TTL window later (any row older than the max TTL can never match a verifiable token again).
+ *
+ * DEFAULT-OFF: nothing inserts here until the L8 apply is wired and its flags are enabled — the table is
+ * inert schema. zzzz-timestamped ([[feedback_migration_zzzz_ordering]]); proven on a fresh-DB full migrate.
+ *
+ * Timestamp note (port from #4446): original stamp zzzz20260717120000 collided with
+ * zzzz20260717120000_approval_bridge_lease on current main — renumbered to 20260719120000.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_recovery_token_burns (
+      token_sha256 text PRIMARY KEY,
+      sheet_id     text NOT NULL,
+      actor_id     text,
+      burned_at    timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_recovery_token_burns_sheet
+    ON meta_recovery_token_burns(sheet_id, burned_at)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_meta_recovery_token_burns_sheet`.execute(db)
+  await sql`DROP TABLE IF EXISTS meta_recovery_token_burns`.execute(db)
+}

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -29,6 +29,11 @@ import {
   precheckSheetHistoryIntegrityStrict,
 } from './history-integrity-precheck'
 import type { MultitableField } from './field-codecs'
+import { validateLongTextValue } from './field-codecs'
+import {
+  assertExactRestorableScalarValue,
+  ExactRestoreValueError,
+} from './exact-anchor-restore-validate'
 
 /** Normalize a link-field cell (array | single | null) to a string[] of foreign record ids. */
 function normalizeLinkIds(value: unknown): string[] {
@@ -36,13 +41,25 @@ function normalizeLinkIds(value: unknown): string[] {
   return typeof value === 'string' && value.length > 0 ? [value] : []
 }
 
-/** Resolve a link field's declared foreign sheet (aliases used across codecs / writers). */
-function resolveForeignSheetId(field: MultitableField): string | null {
-  const property = (field.property ?? {}) as Record<string, unknown>
-  for (const c of [property.foreignSheetId, property.foreignDatasheetId, property.datasheetId]) {
-    if (typeof c === 'string' && c.trim().length > 0) return c.trim()
+/**
+ * Resolve a link field's declared foreign sheet from a RAW property bag (not post-serialize).
+ * Conflicting non-empty aliases (foreignSheetId / foreignDatasheetId / datasheetId) are
+ * AMBIGUOUS → fail closed (null). Exactly one distinct trimmed value is required.
+ * Prefer calling with the DB `meta_fields.property` blob; `serializeFieldRow` collapses aliases.
+ */
+export function resolveForeignSheetIdFromProperty(property: Record<string, unknown> | null | undefined): string | null {
+  const p = property ?? {}
+  const unique = new Set<string>()
+  for (const c of [p.foreignSheetId, p.foreignDatasheetId, p.datasheetId]) {
+    if (typeof c === 'string' && c.trim().length > 0) unique.add(c.trim())
   }
-  return null
+  if (unique.size !== 1) return null
+  return [...unique][0]!
+}
+
+/** Convenience over MultitableField.property (may already be alias-normalized by serializeFieldRow). */
+export function resolveForeignSheetId(field: MultitableField): string | null {
+  return resolveForeignSheetIdFromProperty(field.property as Record<string, unknown> | undefined)
 }
 
 /**
@@ -123,7 +140,8 @@ export type ExactAnchorApplyRefusal =
   | 'preview-drift' // the live reconstruction diverged from the signed scope (409-class; re-preview)
   | 'schema-drift' // plan.driftCount > 0 ⇒ WHOLE apply refused, zero writes
   | 'inbound-unprovable' // plan.resurrects.length > 0 — at-anchor inbound relations cannot be proven (D1c)
-  | 'link-integrity' // missing/ambiguous foreign sheet, missing/wrong-sheet target, or mirror write attempt
+  | 'link-integrity' // missing/ambiguous foreign sheet, missing/wrong-sheet target, same-op delete target, or mirror
+  | 'value-invalid' // current-schema validation rejects the historical scalar OR would sanitize/coerce it
   | 'recovery-trust-required' // fence+strict substrate missing or HISTORY_INCOMPLETE under the fence
 
 export interface ExactAnchorApplySuccess {
@@ -307,7 +325,22 @@ export async function applyExactAnchorRecovery(
       if (plan.resurrects.length > 0) throw new ApplyRefusalError('inbound-unprovable')
 
       // Field surface for restorable projection (exclude mirror-owned link fields — spine invariant).
+      // Also load RAW property blobs so link alias ambiguity is not collapsed by serializeFieldRow.
       const fields = await loadFieldsForSheet(query, input.sheetId)
+      const rawPropRes = await query('SELECT id, property FROM meta_fields WHERE sheet_id = $1', [input.sheetId])
+      const rawPropById = new Map<string, Record<string, unknown>>()
+      for (const r of rawPropRes.rows as Array<{ id: unknown; property: unknown }>) {
+        let prop: Record<string, unknown> = {}
+        if (r.property && typeof r.property === 'object' && !Array.isArray(r.property)) {
+          prop = r.property as Record<string, unknown>
+        } else if (typeof r.property === 'string' && r.property.trim()) {
+          try {
+            const parsed = JSON.parse(r.property) as unknown
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) prop = parsed as Record<string, unknown>
+          } catch { /* ignore */ }
+        }
+        rawPropById.set(String(r.id), prop)
+      }
       const fieldById = new Map<string, MultitableField>()
       const projectionFieldById = new Map<string, { type: string }>()
       for (const f of fields) {
@@ -316,7 +349,12 @@ export async function applyExactAnchorRecovery(
         projectionFieldById.set(f.id, { type: f.type })
       }
 
+      const deleteRecordIds =
+        mode === 'reset' ? [...plan.deletedAtAnchorLiveNow, ...plan.createdAfterAnchor] : []
+      const deleteIdSet = new Set(deleteRecordIds)
+
       // Restorable projection per plan.revert — derived-only differences become no-ops.
+      // Current-schema exact validation on every changed scalar (fail closed value-invalid).
       const revertWrites: ExactAnchorRevertWriteIntent[] = []
       for (const r of plan.reverts) {
         const live = liveById.get(r.recordId)
@@ -331,6 +369,31 @@ export async function applyExactAnchorRecovery(
           normalizeLinkIds,
         })
         if (projection.isNoOp) continue
+        for (const fid of projection.changedFieldIds) {
+          const field = fieldById.get(fid)
+          if (!field) continue
+          if (field.type === 'link') continue // dedicated link path
+          const hist = projection.patch[fid]
+          if (hist === null || hist === undefined) continue // unset
+          try {
+            assertExactRestorableScalarValue(
+              {
+                id: field.id,
+                type: field.type,
+                property: field.property as Record<string, unknown> | undefined,
+                options: field.options,
+              },
+              hist,
+            )
+            // Chokepoint pin: rich longText must go through validateLongTextValue (structural guard).
+            if (field.type === 'longText') {
+              validateLongTextValue(hist, field.id, field.property)
+            }
+          } catch (e) {
+            if (e instanceof ExactRestoreValueError) throw new ApplyRefusalError('value-invalid')
+            throw e
+          }
+        }
         revertWrites.push({
           recordId: r.recordId,
           liveVersion: r.liveVersion,
@@ -347,10 +410,12 @@ export async function applyExactAnchorRecovery(
           const field = fieldById.get(lu.fieldId)
           if (!field || field.type !== 'link') throw new ApplyRefusalError('link-integrity')
           if (isFieldAlwaysReadOnly(field)) throw new ApplyRefusalError('link-integrity')
-          const foreignSheetId = resolveForeignSheetId(field)
-          if (!foreignSheetId) throw new ApplyRefusalError('link-integrity')
+          const foreignSheetId = resolveForeignSheetIdFromProperty(rawPropById.get(lu.fieldId))
+          if (!foreignSheetId) throw new ApplyRefusalError('link-integrity') // missing OR ambiguous aliases
           const targetIds = lu.targetIds
           if (targetIds.length === 0) continue
+          // Same-operation delete: a projected link target that this apply will delete becomes dangling.
+          if (targetIds.some((id) => deleteIdSet.has(id))) throw new ApplyRefusalError('link-integrity')
           const found = await query(
             'SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
             [foreignSheetId, targetIds],
@@ -359,9 +424,6 @@ export async function applyExactAnchorRecovery(
           if (targetIds.some((id) => !foundSet.has(id))) throw new ApplyRefusalError('link-integrity')
         }
       }
-
-      const deleteRecordIds =
-        mode === 'reset' ? [...plan.deletedAtAnchorLiveNow, ...plan.createdAfterAnchor] : []
 
       // 8. REQUIRED in-fence WRITE authorization over the true restorable plan (after plan/projection,
       //    before mint/writes). Revocation between preview and execute, or field/record deny ⇒ forbidden.
@@ -387,11 +449,18 @@ export async function applyExactAnchorRecovery(
         sheetBaseId = baseRow && typeof baseRow.base_id === 'string' ? baseRow.base_id : null
       }
 
-      // RESET deletes BEFORE reverts so inbound edges that a concurrent restorable projection
-      // would clear (peer rows linking to a created-after-anchor delete candidate) are still
-      // present for tombstone capture — same-txn, still all-or-nothing.
+      // RESET: two-phase delete inside the same txn so cross-links between delete candidates are captured
+      // against the ORIGINAL graph (not order-dependent after the first link wipe).
+      //   phase 1 — lock + pre-gen revision ids + inbound tombstone capture/cap for ALL deletes
+      //   phase 2 — both-direction link delete + revision + trash + live delete for each
       let deletes = 0
       if (mode === 'reset') {
+        type PendingDelete = {
+          recordId: string
+          live: NonNullable<ReturnType<typeof liveById.get>>
+          revisionId: string
+        }
+        const pending: PendingDelete[] = []
         for (const recordId of deleteRecordIds) {
           const live = liveById.get(recordId)
           if (!live) continue
@@ -400,60 +469,65 @@ export async function applyExactAnchorRecovery(
             live,
             () => new Error(`exact-anchor apply refused: record ${recordId} is locked`),
           )
-          // Canonical delete parity (deleteRecord / PIT-reset): pre-gen id → optional inbound capture →
-          // both-direction meta_links delete → revision → trash → live delete.
-          const resetDeleteRevisionId = randomUUID()
-          if (isTombstoneCaptureEnabled()) {
-            const totalToCapture = await countInboundLinkCaptureRows(query, recordId)
-            assertWithinCaptureCap(totalToCapture)
+          pending.push({ recordId, live, revisionId: randomUUID() })
+        }
+        // Phase 1: capture ALL inbound tombstones against the original graph.
+        if (isTombstoneCaptureEnabled()) {
+          let totalCap = 0
+          for (const p of pending) totalCap += await countInboundLinkCaptureRows(query, p.recordId)
+          assertWithinCaptureCap(totalCap)
+          for (const p of pending) {
             await insertInboundLinkTombstones(query, {
               sheetId: input.sheetId,
-              recordId,
-              sourceRevisionId: resetDeleteRevisionId,
+              recordId: p.recordId,
+              sourceRevisionId: p.revisionId,
             })
           }
-          await query('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1', [recordId])
-          // lock-guarded: L8 reset delete — ensureRecordNotLocked above, same txn.
+        }
+        // Phase 2: destroy links + revise + trash + live delete.
+        for (const p of pending) {
+          await query('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1', [p.recordId])
+          // lock-guarded: L8 reset delete — ensureRecordNotLocked in phase-1 loop, same txn.
           // revision-emitted: L8 reset delete — pre-gen id so trash + tombstones share the causal anchor.
           await recordRecordRevision(query, {
             sheetId: input.sheetId,
-            recordId,
-            version: live.version,
+            recordId: p.recordId,
+            version: p.live.version,
             action: 'delete',
             source: 'restore',
             actorId: input.actorId,
             changedFieldIds: [],
             patch: {},
-            snapshot: live.data,
-            id: resetDeleteRevisionId,
+            snapshot: p.live.data,
+            id: p.revisionId,
             ledger: op,
           })
-          const createdBy = typeof live.created_by === 'string' ? live.created_by : null
+          const createdBy = typeof p.live.created_by === 'string' ? p.live.created_by : null
           await query(
             `INSERT INTO meta_records_trash
                (record_id, sheet_id, base_id, data, original_version, created_by, deleted_by,
                 original_created_at, original_updated_at, delete_revision_id)
              VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9, $10)`,
             [
-              recordId,
+              p.recordId,
               input.sheetId,
               sheetBaseId,
-              JSON.stringify(live.data),
-              live.version,
+              JSON.stringify(p.live.data),
+              p.live.version,
               createdBy,
               input.actorId,
-              live.created_at ?? null,
-              live.updated_at ?? null,
-              resetDeleteRevisionId,
+              p.live.created_at ?? null,
+              p.live.updated_at ?? null,
+              p.revisionId,
             ],
           )
-          // lock-guarded: L8 reset delete — ensureRecordNotLocked earlier in this loop body, same txn.
-          // revision-emitted: L8 reset delete — recordRecordRevision(action:'delete', id=pre-gen) above, same txn.
+          // lock-guarded: L8 reset delete — ensureRecordNotLocked earlier in this txn.
+          // revision-emitted: L8 reset delete — recordRecordRevision(action:'delete', id=pre-gen) above.
           const del = await query(
             'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2 RETURNING version',
-            [recordId, input.sheetId],
+            [p.recordId, input.sheetId],
           )
-          if (!del.rows[0]) throw new Error(`exact-anchor apply: reset delete found no row for ${recordId}`)
+          if (!del.rows[0]) throw new Error(`exact-anchor apply: reset delete found no row for ${p.recordId}`)
           deletes++
         }
       }

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -127,10 +127,12 @@ async function syncOneOutboundLinkField(
  *   6. Dual-hash drift (composed scopeHash + live liveSetHash) + plan (L7).
  *   7. schema-drift whole-reject; RESURRECT fail-closed (`inbound-unprovable` — D1c link history unsolved;
  *      temporary kernel boundary, not route-deferred replay).
- *   8. Canonical restorable projection per revert (projectRestorableOntoLive): derived-only ⇒ no-op;
- *      foreign-link integrity for every changed writable forward link; REQUIRED
- *      `evaluatePlanAuthorization` over the true restorable delta (before mint/writes).
- *   9. APPLY: restorable reverts (data + meta_links) + RESET canonical delete parity; seal last.
+ *   8. Canonical restorable PROJECTION only (projectRestorableOntoLive) — derived-only ⇒ no-op. Builds the
+ *      exact write delta WITHOUT scalar/link validation (no-oracle: value/existence must not leak before auth).
+ *   9. REQUIRED `evaluatePlanAuthorization` over that delta (person membership + foreign-target read/edit
+ *      authority belong here in the route adapter). Deny ⇒ uniform `forbidden` before any sensitive validator.
+ *  10. AFTER planAuth=true: scalar/whole-record CURRENT validation, foreign-target existence, hierarchy cycle.
+ *  11. APPLY: restorable reverts (data + meta_links) + RESET canonical delete parity; seal last.
  *
  * KERNEL-OWNED: security adjudication, restorable projection, link integrity, both-direction reset cleanup,
  * tombstone/trash, anti-replay, trust substrate. Route-owned: presentation masking, size ceilings, realtime,
@@ -178,21 +180,33 @@ export interface ExactAnchorRevertWriteIntent {
 
 /**
  * Context for the REQUIRED in-fence write-authorization dependency. Built AFTER plan + restorable
- * projection so the eventual route adapter can enforce manage-sheet + per-record edit/delete/row ownership
- * + field-write permissions over exactly the true restorable delta (not full snapshots).
+ * PROJECTION (before scalar/link validation) so the route adapter can enforce manage-sheet + per-record
+ * edit/delete/row ownership + field-write permissions over exactly the true restorable delta (not full
+ * snapshots).
+ *
+ * ROUTE ADAPTER MUST also adjudicate inside this callback (no-oracle / cross-base parity):
+ *   - person-field membership (whether historical person ids are still allowable for the actor/sheet),
+ *   - foreign link target READ/EDIT authority (including cross-base target sheet access).
+ * Those checks MUST run here so a denied actor receives uniform `forbidden` and cannot distinguish
+ * value-invalid / link-integrity / missing-target via response shape.
  */
 export interface ExactAnchorPlanAuthContext {
   mode: ExactAnchorApplyMode
   sheetId: string
   actorId: string
   plan: ExactAnchorRecoveryPlan
-  /** reverts that would write (isNoOp filtered out). */
+  /** reverts that would write (isNoOp filtered out) — projected delta, not yet value/target validated. */
   revertWrites: ExactAnchorRevertWriteIntent[]
   /** record ids the TOKEN-BOUND reset mode would delete. */
   deleteRecordIds: string[]
 }
 
-/** REQUIRED — omission is a TypeScript error. Must return true to proceed to mint/writes. */
+/**
+ * REQUIRED — omission is a TypeScript error. Must return true to proceed to sensitive validation + writes.
+ * Invoked AFTER restorable projection and BEFORE scalar/whole-record validation, foreign-target existence,
+ * and hierarchy-cycle checks. Route adapters: include person membership + foreign-target read/edit authority
+ * (see {@link ExactAnchorPlanAuthContext}).
+ */
 export type EvaluatePlanAuthorization = (
   query: QueryFn,
   context: ExactAnchorPlanAuthContext,
@@ -220,8 +234,9 @@ export interface ExactAnchorApplyInput {
   /** REQUIRED in-fence full-read adjudication (P1-2) — same contract as the preview. */
   evaluateFullReadAccess: EvaluateRecoveryFullReadAccess
   /**
-   * REQUIRED in-fence WRITE authorization over the true restorable plan/projection (v3.7 §5 step 7).
-   * Re-evaluated FRESH under the fence after the plan is known and BEFORE mintOperation/any write.
+   * REQUIRED in-fence WRITE authorization over the true restorable projection delta (v3.7 §5).
+   * Invoked AFTER projection and BEFORE scalar/link validation + mintOperation/any write (no-oracle).
+   * Route adapters must include person membership + foreign-target read/edit authority here.
    * Omission is structurally impossible (typed required field). Full-read alone is insufficient.
    */
   evaluatePlanAuthorization: EvaluatePlanAuthorization
@@ -371,8 +386,8 @@ export async function applyExactAnchorRecovery(
         mode === 'reset' ? [...plan.deletedAtAnchorLiveNow, ...plan.createdAfterAnchor] : []
       const deleteIdSet = new Set(deleteRecordIds)
 
-      // Restorable projection per plan.revert — derived-only differences become no-ops.
-      // Current-schema exact validation on every changed scalar (fail closed value-invalid).
+      // Restorable PROJECTION only (no value/target validation yet — no-oracle ordering).
+      // Build the exact write delta first; planAuth adjudicates it before any sensitive validator can leak.
       const revertWrites: ExactAnchorRevertWriteIntent[] = []
       for (const r of plan.reverts) {
         const live = liveById.get(r.recordId)
@@ -387,14 +402,40 @@ export async function applyExactAnchorRecovery(
           normalizeLinkIds,
         })
         if (projection.isNoOp) continue
+        revertWrites.push({
+          recordId: r.recordId,
+          liveVersion: r.liveVersion,
+          changedFieldIds: projection.changedFieldIds,
+          patch: projection.patch,
+          projectedData: projection.data,
+          linkUpdates: projection.linkUpdates,
+        })
+      }
+
+      // REQUIRED in-fence WRITE authorization over the true restorable delta (BEFORE scalar/link validation).
+      // Route adapter: person membership + foreign-target read/edit authority must live here so deny is
+      // uniform `forbidden` and value-invalid / missing-target cannot oracle write/target authority.
+      if (!(await input.evaluatePlanAuthorization(query, {
+        mode,
+        sheetId: input.sheetId,
+        actorId: input.actorId,
+        plan,
+        revertWrites,
+        deleteRecordIds,
+      }))) {
+        throw new ApplyRefusalError('forbidden')
+      }
+
+      // AFTER planAuth=true — sensitive validators (may distinguish shapes only for authorized writers).
+      // Per-scalar exactness under CURRENT codecs (delegates longText → validateLongTextValue).
+      for (const rw of revertWrites) {
         try {
-          // Per-scalar exactness under CURRENT codecs (delegates longText → validateLongTextValue).
-          for (const fid of projection.changedFieldIds) {
+          for (const fid of rw.changedFieldIds) {
             const field = fieldById.get(fid)
             if (!field) continue
-            if (field.type === 'link') continue // dedicated link path
-            const hist = projection.patch[fid]
-            if (hist === null || hist === undefined) continue // unset of this key; whole-record check covers required
+            if (field.type === 'link') continue // dedicated link path below
+            const hist = rw.patch[fid]
+            if (hist === null || hist === undefined) continue // unset; whole-record check covers required
             assertExactRestorableScalarValue(
               {
                 id: field.id,
@@ -414,23 +455,15 @@ export async function applyExactAnchorRecovery(
               type: f.type,
               property: f.property as Record<string, unknown> | undefined,
             })),
-            projection.data,
+            rw.projectedData,
           )
         } catch (e) {
           if (e instanceof ExactRestoreValueError) throw new ApplyRefusalError('value-invalid')
           throw e
         }
-        revertWrites.push({
-          recordId: r.recordId,
-          liveVersion: r.liveVersion,
-          changedFieldIds: projection.changedFieldIds,
-          patch: projection.patch,
-          projectedData: projection.data,
-          linkUpdates: projection.linkUpdates,
-        })
       }
 
-      // Foreign-link integrity for every changed writable forward link (before any mutation).
+      // Foreign-link integrity for every changed writable forward link (incl. existence — oracle-class).
       for (const rw of revertWrites) {
         for (const lu of rw.linkUpdates) {
           const field = fieldById.get(lu.fieldId)
@@ -536,20 +569,7 @@ export async function applyExactAnchorRecovery(
         }
       }
 
-      // 8. REQUIRED in-fence WRITE authorization over the true restorable plan (after plan/projection,
-      //    before mint/writes). Revocation between preview and execute, or field/record deny ⇒ forbidden.
-      if (!(await input.evaluatePlanAuthorization(query, {
-        mode,
-        sheetId: input.sheetId,
-        actorId: input.actorId,
-        plan,
-        revertWrites,
-        deleteRecordIds,
-      }))) {
-        throw new ApplyRefusalError('forbidden')
-      }
-
-      // 9. Apply — every write revision-emitted + ledger-tagged.
+      // Apply — every write revision-emitted + ledger-tagged.
       const op = await mintOperation(query, input.sheetId)
 
       let sheetBaseId: string | null = null

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -150,12 +150,13 @@ async function syncOneOutboundLinkField(
  *  12. APPLY: restorable reverts (data + meta_links, version-CAS) + RESET canonical delete parity
  *      (version-CAS delete) — any CAS miss ⇒ `preview-drift`, full rollback; seal last.
  *
- * THREAT-MODEL HONESTY (ratified all-writer-fence, v3.7 §2): every legitimate writer takes the canonical
- * fence, so once this transaction holds it no fenced writer can commit until we do. The full-set FOR UPDATE
- * + fresh re-hash + write-time CAS additionally catch fence-BYPASSING direct SQL that committed up to that
- * final recheck. Arbitrary direct SQL committed AFTER the final recheck (e.g. an INSERT while validation
- * runs) is indistinguishable from a hostile DB session and is OUTSIDE the model — no READ COMMITTED
- * in-transaction recheck can close it; that class would require SERIALIZABLE or triggers.
+ * THREAT-MODEL HONESTY (ratified all-writer-fence, v3.7 §2): every writer in the recovery trust model takes
+ * the canonical fence. Named revision-exempt provisioning writers remain outside that model; a user-content
+ * mismatch they leave behind is refused by the strict precheck before apply. The full-set FOR UPDATE + fresh
+ * re-hash + write-time CAS additionally catch fence-BYPASSING direct SQL that committed up to that final
+ * recheck. Arbitrary direct SQL committed AFTER the final recheck (e.g. an INSERT while validation runs) is
+ * indistinguishable from a hostile DB session and is OUTSIDE the model — no READ COMMITTED in-transaction
+ * recheck can close it; that class would require SERIALIZABLE or triggers.
  *
  * KERNEL-OWNED: security adjudication, restorable projection, link integrity, both-direction reset cleanup,
  * tombstone/trash, anti-replay, trust substrate. Route-owned: presentation masking, size ceilings, realtime,
@@ -496,8 +497,8 @@ export async function applyExactAnchorRecovery(
       }
 
       // Row locks were taken over the FULL live set (ORDER BY id FOR UPDATE) before the liveSetHash check,
-      // so liveById already IS in-lock truth for ensureRecordNotLocked + apply. Re-pin the write intents
-      // against it (fail closed, no coercion) — a mismatch here means broken plan/projection invariants.
+      // so liveById already IS in-lock truth for ensureRecordNotLocked + apply. This assertion pins the
+      // plan/projection invariant locally; write-time CAS remains the concurrency guard.
       for (const rw of revertWrites) {
         const live = liveById.get(rw.recordId)
         if (!live || live.version !== rw.liveVersion) throw new ApplyRefusalError('preview-drift')
@@ -770,10 +771,10 @@ export async function applyExactAnchorRecovery(
         // lock-guarded: L8 revert apply — ensureRecordNotLocked just above, same txn.
         // revision-emitted: L8 revert apply — recordRecordRevision below, same txn (source 'restore').
         const upd = await query(
-          `UPDATE meta_records SET data = $1::jsonb, version = version + 1, updated_at = now()
+          `UPDATE meta_records SET data = $1::jsonb, version = version + 1, updated_at = now(), modified_by = $5
            WHERE id = $2 AND sheet_id = $3 AND version = $4
            RETURNING version`,
-          [JSON.stringify(rw.projectedData), rw.recordId, input.sheetId, rw.liveVersion],
+          [JSON.stringify(rw.projectedData), rw.recordId, input.sheetId, rw.liveVersion, input.actorId],
         )
         // CAS miss ⇒ the locked row moved under us ⇒ preview-drift, full rollback (never a bare Error).
         const row = upd.rows[0] as { version?: unknown } | undefined

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -743,11 +743,11 @@ export async function applyExactAnchorRecovery(
               p.revisionId,
             ],
           )
-          // lock-guarded: L8 reset delete — ensureRecordNotLocked earlier in this txn.
-          // revision-emitted: L8 reset delete — recordRecordRevision(action:'delete', id=pre-gen) above.
           // Version-CAS on the LOCKED expected version: a zero-row delete means the row moved under us
           // (fence-bypassing direct SQL / same-txn side effect) ⇒ preview-drift, full rollback — never a
           // bare Error and never an unconditional delete of a row the token did not hash.
+          // lock-guarded: L8 reset delete — ensureRecordNotLocked earlier in this txn.
+          // revision-emitted: L8 reset delete — recordRecordRevision(action:'delete', id=pre-gen) above.
           const del = await query(
             'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2 AND version = $3 RETURNING version',
             [p.recordId, input.sheetId, p.live.version],

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -29,8 +29,8 @@ import {
   precheckSheetHistoryIntegrityStrict,
 } from './history-integrity-precheck'
 import type { MultitableField } from './field-codecs'
-import { validateLongTextValue } from './field-codecs'
 import {
+  assertExactRestorableRecordValid,
   assertExactRestorableScalarValue,
   ExactRestoreValueError,
 } from './exact-anchor-restore-validate'
@@ -141,7 +141,8 @@ export type ExactAnchorApplyRefusal =
   | 'schema-drift' // plan.driftCount > 0 ⇒ WHOLE apply refused, zero writes
   | 'inbound-unprovable' // plan.resurrects.length > 0 — at-anchor inbound relations cannot be proven (D1c)
   | 'link-integrity' // missing/ambiguous foreign sheet, missing/wrong-sheet target, same-op delete target, or mirror
-  | 'value-invalid' // current-schema validation rejects the historical scalar OR would sanitize/coerce it
+  | 'value-invalid' // current-schema scalar exactness OR whole-record validateRecord fails
+  | 'record-locked' // in-fence lock check: record locked by another actor (values-free)
   | 'recovery-trust-required' // fence+strict substrate missing or HISTORY_INCOMPLETE under the fence
 
 export interface ExactAnchorApplySuccess {
@@ -369,13 +370,14 @@ export async function applyExactAnchorRecovery(
           normalizeLinkIds,
         })
         if (projection.isNoOp) continue
-        for (const fid of projection.changedFieldIds) {
-          const field = fieldById.get(fid)
-          if (!field) continue
-          if (field.type === 'link') continue // dedicated link path
-          const hist = projection.patch[fid]
-          if (hist === null || hist === undefined) continue // unset
-          try {
+        try {
+          // Per-scalar exactness under CURRENT codecs (delegates longText → validateLongTextValue).
+          for (const fid of projection.changedFieldIds) {
+            const field = fieldById.get(fid)
+            if (!field) continue
+            if (field.type === 'link') continue // dedicated link path
+            const hist = projection.patch[fid]
+            if (hist === null || hist === undefined) continue // unset of this key; whole-record check covers required
             assertExactRestorableScalarValue(
               {
                 id: field.id,
@@ -385,14 +387,21 @@ export async function applyExactAnchorRecovery(
               },
               hist,
             )
-            // Chokepoint pin: rich longText must go through validateLongTextValue (structural guard).
-            if (field.type === 'longText') {
-              validateLongTextValue(hist, field.id, field.property)
-            }
-          } catch (e) {
-            if (e instanceof ExactRestoreValueError) throw new ApplyRefusalError('value-invalid')
-            throw e
           }
+          // Whole projected record: explicit property.validation ?? getDefaultValidationRules
+          // (same precedence as record-service buildDirectValidationFields).
+          assertExactRestorableRecordValid(
+            fields.map((f) => ({
+              id: f.id,
+              name: f.name,
+              type: f.type,
+              property: f.property as Record<string, unknown> | undefined,
+            })),
+            projection.data,
+          )
+        } catch (e) {
+          if (e instanceof ExactRestoreValueError) throw new ApplyRefusalError('value-invalid')
+          throw e
         }
         revertWrites.push({
           recordId: r.recordId,
@@ -467,7 +476,7 @@ export async function applyExactAnchorRecovery(
           ensureRecordNotLocked(
             input.actorId,
             live,
-            () => new Error(`exact-anchor apply refused: record ${recordId} is locked`),
+            () => new ApplyRefusalError('record-locked'),
           )
           pending.push({ recordId, live, revisionId: randomUUID() })
         }
@@ -539,7 +548,7 @@ export async function applyExactAnchorRecovery(
           ensureRecordNotLocked(
             input.actorId,
             liveRow,
-            () => new Error(`exact-anchor apply refused: record ${rw.recordId} is locked`),
+            () => new ApplyRefusalError('record-locked'),
           )
         }
         // lock-guarded: L8 revert apply — ensureRecordNotLocked just above, same txn.

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto'
 
 import type { QueryFn } from './permission-service'
+import { assertInTransaction } from './pg-transaction-guard'
 import { fenceWriterEntry, isWriterFenceEnabled } from './canonical-sheet-fence'
 import { selectCheckpointByAnchorSeq } from './history-trust-checkpoint'
 import { reconstructRecordsAtSeq } from './record-reconstructor'
@@ -17,7 +18,11 @@ import {
   type ExactAnchorRecoveryMode,
 } from './restore-preview-identity'
 import { composeBaselineOverlay, type EvaluateRecoveryFullReadAccess } from './exact-anchor-recovery'
-import { classifyExactAnchorRecoveryPlan, type ExactAnchorRecoveryPlan } from './exact-anchor-recovery-plan'
+import {
+  classifyExactAnchorRecoveryPlan,
+  ExactAnchorPlanDataError,
+  type ExactAnchorRecoveryPlan,
+} from './exact-anchor-recovery-plan'
 import {
   assertWithinCaptureCap,
   countInboundLinkCaptureRows,
@@ -116,6 +121,10 @@ async function syncOneOutboundLinkField(
  * formula/lookup/rollup/auto-number non-restorable) + L6-b/L7 stack.
  *
  * THE SHAPE — one outer transaction, COMMIT once, any failure ⇒ FULL ROLLBACK (incl. burn):
+ *   0. TRANSACTION PROOF: `assertInTransaction` (pg_current_xact_id probe, pg-transaction-guard) before
+ *      ANY fence/burn/write. A forged `transaction` wrapper running autocommit statements would make
+ *      "all-or-nothing" a lie (a committed burn over a failed apply, half-applied writes); the probe asks
+ *      Postgres itself. Failure ⇒ the same values-free `recovery-trust-required` (non-oracular).
  *   1. fenceWriterEntry (L4, fence-FIRST).
  *   2. TRUSTED SUBSTRATE (kernel fail-closed): BOTH `MULTITABLE_ENABLE_WRITER_FENCE` and
  *      `MULTITABLE_HISTORY_CONTIGUITY_STRICT` must be on, then `precheckSheetHistoryIntegrityStrict` under
@@ -124,18 +133,29 @@ async function syncOneOutboundLinkField(
  *   3. BURN the token (anti-replay PK).
  *   4. IN-FENCE full-read + authorizedScopeHash (P1-2).
  *   5. IN-FENCE checkpoint re-resolution (never trust the token echo).
- *   6. Dual-hash drift (composed scopeHash + live liveSetHash) + plan (L7).
- *   7. schema-drift whole-reject; RESURRECT fail-closed (`inbound-unprovable` — D1c link history unsolved;
- *      temporary kernel boundary, not route-deferred replay).
+ *   6. Composed scopeHash drift, then §5 step 7 ROW LOCKS over the FULL current live set
+ *      (`ORDER BY id FOR UPDATE`, deterministic — never only the delta: a RESET delete-set escape or a
+ *      version bump on a "non-affected" row is still live-set drift) + liveSetHash check from the LOCKED
+ *      rows, then a FRESH id/version re-hash in a NEW statement snapshot (catches an unfenced CREATE or a
+ *      not-yet-locked bump committed while the lock statement was PARKED behind a concurrent writer).
+ *      Malformed live truth (non-object data, non-integer/negative version) is NEVER coerced — it refuses
+ *      `recovery-trust-required`, as does `ExactAnchorPlanDataError` from the plan classifier.
+ *   7. Plan (L7); schema-drift whole-reject; RESURRECT fail-closed (`inbound-unprovable` — D1c link history
+ *      unsolved; temporary kernel boundary, not route-deferred replay).
  *   8. Canonical restorable PROJECTION only (projectRestorableOntoLive) — derived-only ⇒ no-op. Builds the
  *      exact write delta WITHOUT scalar/link validation (no-oracle: value/existence must not leak before auth).
- *   9. §5 step 7 ROW LOCKS: SELECT … FOR UPDATE the exact affected live ids (revertWrites ∪ reset deletes)
- *      in deterministic id order; recheck each still exists at the bound live version ⇒ else preview-drift;
- *      refresh liveById from locked rows (later ensureRecordNotLocked / writes use in-lock truth).
  *  10. REQUIRED `evaluatePlanAuthorization` over that delta (person membership + foreign-target read/edit
  *      authority belong here in the route adapter). Deny ⇒ uniform `forbidden` before any sensitive validator.
  *  11. AFTER planAuth=true: scalar/whole-record CURRENT validation, foreign-target existence, hierarchy cycle.
- *  12. APPLY: restorable reverts (data + meta_links) + RESET canonical delete parity; seal last.
+ *  12. APPLY: restorable reverts (data + meta_links, version-CAS) + RESET canonical delete parity
+ *      (version-CAS delete) — any CAS miss ⇒ `preview-drift`, full rollback; seal last.
+ *
+ * THREAT-MODEL HONESTY (ratified all-writer-fence, v3.7 §2): every legitimate writer takes the canonical
+ * fence, so once this transaction holds it no fenced writer can commit until we do. The full-set FOR UPDATE
+ * + fresh re-hash + write-time CAS additionally catch fence-BYPASSING direct SQL that committed up to that
+ * final recheck. Arbitrary direct SQL committed AFTER the final recheck (e.g. an INSERT while validation
+ * runs) is indistinguishable from a hostile DB session and is OUTSIDE the model — no READ COMMITTED
+ * in-transaction recheck can close it; that class would require SERIALIZABLE or triggers.
  *
  * KERNEL-OWNED: security adjudication, restorable projection, link integrity, both-direction reset cleanup,
  * tombstone/trash, anti-replay, trust substrate. Route-owned: presentation masking, size ceilings, realtime,
@@ -227,8 +247,23 @@ class ApplyRefusalError extends Error {
 const isUniqueViolation = (e: unknown): boolean =>
   typeof e === 'object' && e !== null && (e as { code?: unknown }).code === '23505'
 
-const asRec = (v: unknown): Record<string, unknown> =>
-  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {}
+/**
+ * Live-state truth must be WELL-FORMED — a malformed row is corrupt substrate, not a value to coerce.
+ * (The old `asRec`/`Number(...) || 0` coercions could hash a corrupt row into a "matching" live set and
+ * then destructively write over it.) Refusal is the values-free `recovery-trust-required`.
+ */
+const requireLiveData = (v: unknown): Record<string, unknown> => {
+  if (v === null || typeof v !== 'object' || Array.isArray(v)) {
+    throw new ApplyRefusalError('recovery-trust-required')
+  }
+  return v as Record<string, unknown>
+}
+const requireLiveVersion = (v: unknown): number => {
+  if (typeof v !== 'number' || !Number.isSafeInteger(v) || v < 0) {
+    throw new ApplyRefusalError('recovery-trust-required')
+  }
+  return v
+}
 
 export interface ExactAnchorApplyInput {
   token: string
@@ -260,6 +295,23 @@ export async function applyExactAnchorRecovery(
 
   try {
     return await transaction(async (query) => {
+      // 0. PROVE a real ongoing transaction (pg_current_xact_id probe) before any fence/burn/write. A
+      //    forged wrapper over a pool/autocommit client is caught by Postgres itself, not a marker; the
+      //    refusal is the same values-free substrate refusal as every other trust failure (non-oracular).
+      try {
+        await assertInTransaction(
+          {
+            query: async (sql: string, params?: unknown[]) => {
+              const res = await query(sql, params)
+              return { rows: res.rows as Array<Record<string, unknown>>, rowCount: res.rowCount ?? null }
+            },
+          },
+          'exact-anchor destructive apply',
+        )
+      } catch {
+        throw new ApplyRefusalError('recovery-trust-required')
+      }
+
       // 1. Fence-first (L4).
       await fenceWriterEntry(query, input.sheetId)
 
@@ -302,6 +354,11 @@ export async function applyExactAnchorRecovery(
       )
       if (anchorHash !== scopeHash) throw new ApplyRefusalError('preview-drift')
 
+      // §5 step 7 ROW LOCKS — the FULL current live set, deterministic id order (multi-writer deadlock
+      // safety). Locking only the write delta is NOT enough under the ratified all-writer-fence model's
+      // direct-SQL hardening: a RESET's stale delete set and a version bump on a "non-affected" row are
+      // both live-set drift the token's liveSetHash must veto, so every live row is locked and hashed
+      // from the LOCKED (EvalPlanQual-fresh) truth. Malformed rows fail closed — never coerced.
       const liveById = new Map<string, {
         data: Record<string, unknown>
         version: number
@@ -312,7 +369,10 @@ export async function applyExactAnchorRecovery(
         updated_at?: unknown
       }>()
       for (const r of (await query(
-        'SELECT id, data, version, locked, locked_by, created_by, created_at, updated_at FROM meta_records WHERE sheet_id = $1',
+        `SELECT id, data, version, locked, locked_by, created_by, created_at, updated_at
+         FROM meta_records WHERE sheet_id = $1
+         ORDER BY id
+         FOR UPDATE`,
         [input.sheetId],
       )).rows as Array<{
         id: unknown
@@ -325,8 +385,8 @@ export async function applyExactAnchorRecovery(
         updated_at?: unknown
       }>) {
         liveById.set(String(r.id), {
-          data: asRec(r.data),
-          version: typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : Number(r.version) || 0,
+          data: requireLiveData(r.data),
+          version: requireLiveVersion(r.version),
           locked: r.locked,
           locked_by: r.locked_by,
           created_by: r.created_by,
@@ -339,6 +399,19 @@ export async function applyExactAnchorRecovery(
       )
       if (liveHash !== liveSetHash) throw new ApplyRefusalError('preview-drift')
 
+      // FRESH id/version re-hash in a NEW statement snapshot. If the lock above PARKED behind a concurrent
+      // writer, rows that writer committed AFTER the lock statement's snapshot began — an unfenced CREATE
+      // (FOR UPDATE cannot lock a phantom) or a bump on a row not yet locked — are visible only to a fresh
+      // statement. Any divergence from the token ⇒ preview-drift, full rollback (burn included).
+      // HONESTY: fence-bypassing direct SQL committed AFTER this recheck is outside the all-writer-fence
+      // model (see module doc); fenced writers cannot commit while we hold the fence.
+      const recheckHash = hashAnchorRecoveryScope(
+        ((await query('SELECT id, version FROM meta_records WHERE sheet_id = $1', [input.sheetId]))
+          .rows as Array<{ id: unknown; version: unknown }>)
+          .map((r) => ({ recordId: String(r.id), exists: true, version: requireLiveVersion(r.version) })),
+      )
+      if (recheckHash !== liveSetHash) throw new ApplyRefusalError('preview-drift')
+
       // 6b. G-SCHEMA-BEFORE-FENCE — CURRENT field surface must match the token-bound schemaHash.
       // Catches retype (string→longText) and property-only edits that leave record ids/versions unchanged
       // and may still leave historical values "valid" under the new type (scope/live hashes cannot see this).
@@ -349,10 +422,17 @@ export async function applyExactAnchorRecovery(
       )
       if (liveSchemaHash !== schemaHash) throw new ApplyRefusalError('schema-drift')
 
-      // 7. Plan (L7).
+      // 7. Plan (L7). A malformed at-anchor/live snapshot (ExactAnchorPlanDataError) is corrupt
+      //    substrate — the same values-free recovery-trust-required, never a coerced-through plan.
       const fieldIds = new Set(schemaRows.map((r) => String(r.id)))
       const rawTypeById = new Map(schemaRows.map((r) => [String(r.id), String(r.type ?? '')]))
-      const plan: ExactAnchorRecoveryPlan = classifyExactAnchorRecoveryPlan(composed, liveById, fieldIds)
+      let plan: ExactAnchorRecoveryPlan
+      try {
+        plan = classifyExactAnchorRecoveryPlan(composed, liveById, fieldIds)
+      } catch (e) {
+        if (e instanceof ExactAnchorPlanDataError) throw new ApplyRefusalError('recovery-trust-required')
+        throw e
+      }
 
       if (plan.driftCount > 0) throw new ApplyRefusalError('schema-drift')
 
@@ -415,75 +495,12 @@ export async function applyExactAnchorRecovery(
         })
       }
 
-      // §5 step 7 — lock affected live rows BEFORE planAuth / sensitive validation / writes.
-      // Sheet advisory fence is necessary but not sufficient: an unfenced concurrent writer can still
-      // UPDATE/DELETE between liveSetHash and apply (especially RESET deletes, which have no version CAS).
-      // Deterministic id order avoids multi-row deadlock with other writers.
-      {
-        const affectedIdSet = new Set<string>()
-        for (const rw of revertWrites) affectedIdSet.add(rw.recordId)
-        for (const id of deleteRecordIds) {
-          if (liveById.has(id)) affectedIdSet.add(id)
-        }
-        const affectedIds = [...affectedIdSet].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
-        if (affectedIds.length > 0) {
-          const expectedVersionById = new Map<string, number>()
-          for (const id of affectedIds) {
-            const live = liveById.get(id)
-            if (!live) throw new ApplyRefusalError('preview-drift')
-            expectedVersionById.set(id, live.version)
-          }
-          const lockedRes = await query(
-            `SELECT id, data, version, locked, locked_by, created_by, created_at, updated_at
-             FROM meta_records
-             WHERE sheet_id = $1 AND id = ANY($2::text[])
-             ORDER BY id
-             FOR UPDATE`,
-            [input.sheetId, affectedIds],
-          )
-          const lockedById = new Map<string, {
-            data: Record<string, unknown>
-            version: number
-            locked?: unknown
-            locked_by?: unknown
-            created_by?: unknown
-            created_at?: unknown
-            updated_at?: unknown
-          }>()
-          for (const r of lockedRes.rows as Array<{
-            id: unknown
-            data: unknown
-            version: unknown
-            locked?: unknown
-            locked_by?: unknown
-            created_by?: unknown
-            created_at?: unknown
-            updated_at?: unknown
-          }>) {
-            lockedById.set(String(r.id), {
-              data: asRec(r.data),
-              version: typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : Number(r.version) || 0,
-              locked: r.locked,
-              locked_by: r.locked_by,
-              created_by: r.created_by,
-              created_at: r.created_at,
-              updated_at: r.updated_at,
-            })
-          }
-          for (const id of affectedIds) {
-            const locked = lockedById.get(id)
-            if (!locked) throw new ApplyRefusalError('preview-drift') // deleted under us
-            if (locked.version !== expectedVersionById.get(id)) {
-              throw new ApplyRefusalError('preview-drift') // concurrent version bump
-            }
-            liveById.set(id, locked) // in-lock truth for ensureRecordNotLocked + later apply
-          }
-          // Keep revert write intents aligned with the locked versions (must already match; re-pin).
-          for (const rw of revertWrites) {
-            const live = liveById.get(rw.recordId)
-            if (!live || live.version !== rw.liveVersion) throw new ApplyRefusalError('preview-drift')
-          }
-        }
+      // Row locks were taken over the FULL live set (ORDER BY id FOR UPDATE) before the liveSetHash check,
+      // so liveById already IS in-lock truth for ensureRecordNotLocked + apply. Re-pin the write intents
+      // against it (fail closed, no coercion) — a mismatch here means broken plan/projection invariants.
+      for (const rw of revertWrites) {
+        const live = liveById.get(rw.recordId)
+        if (!live || live.version !== rw.liveVersion) throw new ApplyRefusalError('preview-drift')
       }
 
       // REQUIRED in-fence WRITE authorization over the true restorable delta (BEFORE scalar/link validation).
@@ -728,11 +745,14 @@ export async function applyExactAnchorRecovery(
           )
           // lock-guarded: L8 reset delete — ensureRecordNotLocked earlier in this txn.
           // revision-emitted: L8 reset delete — recordRecordRevision(action:'delete', id=pre-gen) above.
+          // Version-CAS on the LOCKED expected version: a zero-row delete means the row moved under us
+          // (fence-bypassing direct SQL / same-txn side effect) ⇒ preview-drift, full rollback — never a
+          // bare Error and never an unconditional delete of a row the token did not hash.
           const del = await query(
-            'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2 RETURNING version',
-            [p.recordId, input.sheetId],
+            'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2 AND version = $3 RETURNING version',
+            [p.recordId, input.sheetId, p.live.version],
           )
-          if (!del.rows[0]) throw new Error(`exact-anchor apply: reset delete found no row for ${p.recordId}`)
+          if (!del.rows[0]) throw new ApplyRefusalError('preview-drift')
           deletes++
         }
       }
@@ -755,8 +775,9 @@ export async function applyExactAnchorRecovery(
            RETURNING version`,
           [JSON.stringify(rw.projectedData), rw.recordId, input.sheetId, rw.liveVersion],
         )
+        // CAS miss ⇒ the locked row moved under us ⇒ preview-drift, full rollback (never a bare Error).
         const row = upd.rows[0] as { version?: unknown } | undefined
-        if (!row) throw new Error(`exact-anchor apply: optimistic version guard failed for ${rw.recordId}`)
+        if (!row) throw new ApplyRefusalError('preview-drift')
         for (const lu of rw.linkUpdates) {
           await syncOneOutboundLinkField(query, rw.recordId, lu.fieldId, lu.targetIds)
         }
@@ -764,7 +785,7 @@ export async function applyExactAnchorRecovery(
         await recordRecordRevision(query, {
           sheetId: input.sheetId,
           recordId: rw.recordId,
-          version: Number(row.version),
+          version: requireLiveVersion(row.version),
           action: 'update',
           source: 'restore',
           actorId: input.actorId,

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -129,10 +129,13 @@ async function syncOneOutboundLinkField(
  *      temporary kernel boundary, not route-deferred replay).
  *   8. Canonical restorable PROJECTION only (projectRestorableOntoLive) — derived-only ⇒ no-op. Builds the
  *      exact write delta WITHOUT scalar/link validation (no-oracle: value/existence must not leak before auth).
- *   9. REQUIRED `evaluatePlanAuthorization` over that delta (person membership + foreign-target read/edit
+ *   9. §5 step 7 ROW LOCKS: SELECT … FOR UPDATE the exact affected live ids (revertWrites ∪ reset deletes)
+ *      in deterministic id order; recheck each still exists at the bound live version ⇒ else preview-drift;
+ *      refresh liveById from locked rows (later ensureRecordNotLocked / writes use in-lock truth).
+ *  10. REQUIRED `evaluatePlanAuthorization` over that delta (person membership + foreign-target read/edit
  *      authority belong here in the route adapter). Deny ⇒ uniform `forbidden` before any sensitive validator.
- *  10. AFTER planAuth=true: scalar/whole-record CURRENT validation, foreign-target existence, hierarchy cycle.
- *  11. APPLY: restorable reverts (data + meta_links) + RESET canonical delete parity; seal last.
+ *  11. AFTER planAuth=true: scalar/whole-record CURRENT validation, foreign-target existence, hierarchy cycle.
+ *  12. APPLY: restorable reverts (data + meta_links) + RESET canonical delete parity; seal last.
  *
  * KERNEL-OWNED: security adjudication, restorable projection, link integrity, both-direction reset cleanup,
  * tombstone/trash, anti-replay, trust substrate. Route-owned: presentation masking, size ceilings, realtime,
@@ -410,6 +413,77 @@ export async function applyExactAnchorRecovery(
           projectedData: projection.data,
           linkUpdates: projection.linkUpdates,
         })
+      }
+
+      // §5 step 7 — lock affected live rows BEFORE planAuth / sensitive validation / writes.
+      // Sheet advisory fence is necessary but not sufficient: an unfenced concurrent writer can still
+      // UPDATE/DELETE between liveSetHash and apply (especially RESET deletes, which have no version CAS).
+      // Deterministic id order avoids multi-row deadlock with other writers.
+      {
+        const affectedIdSet = new Set<string>()
+        for (const rw of revertWrites) affectedIdSet.add(rw.recordId)
+        for (const id of deleteRecordIds) {
+          if (liveById.has(id)) affectedIdSet.add(id)
+        }
+        const affectedIds = [...affectedIdSet].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+        if (affectedIds.length > 0) {
+          const expectedVersionById = new Map<string, number>()
+          for (const id of affectedIds) {
+            const live = liveById.get(id)
+            if (!live) throw new ApplyRefusalError('preview-drift')
+            expectedVersionById.set(id, live.version)
+          }
+          const lockedRes = await query(
+            `SELECT id, data, version, locked, locked_by, created_by, created_at, updated_at
+             FROM meta_records
+             WHERE sheet_id = $1 AND id = ANY($2::text[])
+             ORDER BY id
+             FOR UPDATE`,
+            [input.sheetId, affectedIds],
+          )
+          const lockedById = new Map<string, {
+            data: Record<string, unknown>
+            version: number
+            locked?: unknown
+            locked_by?: unknown
+            created_by?: unknown
+            created_at?: unknown
+            updated_at?: unknown
+          }>()
+          for (const r of lockedRes.rows as Array<{
+            id: unknown
+            data: unknown
+            version: unknown
+            locked?: unknown
+            locked_by?: unknown
+            created_by?: unknown
+            created_at?: unknown
+            updated_at?: unknown
+          }>) {
+            lockedById.set(String(r.id), {
+              data: asRec(r.data),
+              version: typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : Number(r.version) || 0,
+              locked: r.locked,
+              locked_by: r.locked_by,
+              created_by: r.created_by,
+              created_at: r.created_at,
+              updated_at: r.updated_at,
+            })
+          }
+          for (const id of affectedIds) {
+            const locked = lockedById.get(id)
+            if (!locked) throw new ApplyRefusalError('preview-drift') // deleted under us
+            if (locked.version !== expectedVersionById.get(id)) {
+              throw new ApplyRefusalError('preview-drift') // concurrent version bump
+            }
+            liveById.set(id, locked) // in-lock truth for ensureRecordNotLocked + later apply
+          }
+          // Keep revert write intents aligned with the locked versions (must already match; re-pin).
+          for (const rw of revertWrites) {
+            const live = liveById.get(rw.recordId)
+            if (!live || live.version !== rw.liveVersion) throw new ApplyRefusalError('preview-drift')
+          }
+        }
       }
 
       // REQUIRED in-fence WRITE authorization over the true restorable delta (BEFORE scalar/link validation).

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto'
 
 import type { QueryFn } from './permission-service'
-import { fenceWriterEntry } from './canonical-sheet-fence'
+import { fenceWriterEntry, isWriterFenceEnabled } from './canonical-sheet-fence'
 import { selectCheckpointByAnchorSeq } from './history-trust-checkpoint'
 import { reconstructRecordsAtSeq } from './record-reconstructor'
 import { mintOperation, sealOperation } from './operation-ledger'
@@ -23,125 +23,92 @@ import {
   insertInboundLinkTombstones,
   isTombstoneCaptureEnabled,
 } from './tombstone-capture'
+import { projectRestorableOntoLive } from './record-restore-diff'
+import {
+  isContiguityStrictMode,
+  precheckSheetHistoryIntegrityStrict,
+} from './history-integrity-precheck'
+import type { MultitableField } from './field-codecs'
 
-/** Normalize a link-field cell (array | single | null) to a string[] of foreign record ids (local copy of the
- *  record-service private helper — outbound-link sync needs exactly the same shape). */
+/** Normalize a link-field cell (array | single | null) to a string[] of foreign record ids. */
 function normalizeLinkIds(value: unknown): string[] {
   if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string' && v.length > 0)
   return typeof value === 'string' && value.length > 0 ? [value] : []
 }
 
+/** Resolve a link field's declared foreign sheet (aliases used across codecs / writers). */
+function resolveForeignSheetId(field: MultitableField): string | null {
+  const property = (field.property ?? {}) as Record<string, unknown>
+  for (const c of [property.foreignSheetId, property.foreignDatasheetId, property.datasheetId]) {
+    if (typeof c === 'string' && c.trim().length > 0) return c.trim()
+  }
+  return null
+}
+
 /**
- * Synchronize one record's WRITABLE forward-link `meta_links` rows to exactly the ids carried by `snapshot`
- * for each field in `writableLinkFieldIds`. Mirror-side fields are never in that list (spine invariant:
- * mirrors never own a meta_links row). Same-txn only — never opens a nested transaction. Used by REVERT
- * (diff-sync) and RESURRECT (insert-from-empty) so data and relation projection cannot diverge: link reads
- * go through `meta_links`, not `meta_records.data`.
+ * Synchronize one record's WRITABLE forward-link `meta_links` for a single field to exactly `ids`.
+ * Mirror-side fields are never passed here (spine invariant). Same-txn only.
  */
-async function syncOutboundWritableLinks(
+async function syncOneOutboundLinkField(
   query: QueryFn,
   recordId: string,
-  snapshot: Record<string, unknown>,
-  writableLinkFieldIds: readonly string[],
+  fieldId: string,
+  ids: readonly string[],
 ): Promise<void> {
-  for (const fieldId of writableLinkFieldIds) {
-    const ids = normalizeLinkIds(snapshot[fieldId])
-    const current = await query(
-      'SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2',
-      [fieldId, recordId],
+  const current = await query(
+    'SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2',
+    [fieldId, recordId],
+  )
+  const existingIds = (current.rows as Array<{ foreign_record_id: unknown }>).map((r) => String(r.foreign_record_id))
+  const existing = new Set(existingIds)
+  const next = new Set(ids)
+  const toDelete = existingIds.filter((id) => !next.has(id))
+  const toInsert = ids.filter((id) => !existing.has(id))
+  if (toDelete.length > 0) {
+    await query(
+      'DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2 AND foreign_record_id = ANY($3::text[])',
+      [fieldId, recordId, toDelete],
     )
-    const existingIds = (current.rows as Array<{ foreign_record_id: unknown }>).map((r) => String(r.foreign_record_id))
-    const existing = new Set(existingIds)
-    const next = new Set(ids)
-    const toDelete = existingIds.filter((id) => !next.has(id))
-    const toInsert = ids.filter((id) => !existing.has(id))
-    if (toDelete.length > 0) {
-      await query(
-        'DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2 AND foreign_record_id = ANY($3::text[])',
-        [fieldId, recordId, toDelete],
-      )
-    }
-    for (const foreignId of toInsert) {
-      await query(
-        `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
-         VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`,
-        [`lnk_${randomUUID()}`.slice(0, 50), fieldId, recordId, foreignId],
-      )
-    }
-    if (ids.length === 0) {
-      await query('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2', [fieldId, recordId])
-    }
+  }
+  for (const foreignId of toInsert) {
+    await query(
+      `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
+       VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`,
+      [`lnk_${randomUUID()}`.slice(0, 50), fieldId, recordId, foreignId],
+    )
+  }
+  if (ids.length === 0) {
+    await query('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2', [fieldId, recordId])
   }
 }
 
 /**
  * W0-1 v3.7 Lane L8 — the exact-anchor DESTRUCTIVE APPLY: one transaction, all-or-nothing.
  *
- * Design authority: v3.7 lock (#4331) §5 (execute = full target/schema/set recomputation UNDER THE FENCE,
- * preview verification in-fence; all writes + revisions/tombstones in one txn) + §2 (canonical fence) +
- * the L6-b gate's pinned L8 deferrals (2026-07-16): (1) in-fence checkpoint re-resolution, (2) L5 baseline
- * composition, (3) anti-replay single-use burn.
+ * Design authority: v3.7 lock (#4331) §5 (execute = full target/schema/set recomputation UNDER THE FENCE;
+ * all writes + revisions/tombstones in one txn; lock/permission recheck before apply) + §2 (canonical fence;
+ * formula/lookup/rollup/auto-number non-restorable) + L6-b/L7 stack.
  *
- * THE SHAPE — one outer transaction, every step inside it, COMMIT once, any failure ⇒ FULL ROLLBACK with
- * zero writes (including the token burn — a refused execute leaves the world byte-identical):
- *   1. fenceWriterEntry (L4, fence-FIRST): serializes against every fenced writer AND any in-flight
- *      recovery; observes a durable `applying` block and refuses. A concurrent writer parks on this fence
- *      until we commit — nothing interleaves with the apply.
- *   2. BURN the token (INSERT sha256 into `meta_recovery_token_burns`): the PK is the at-most-once
- *      barrier — a second execute of the same token conflicts here and the whole txn rolls back
- *      (`token-replayed`). Burned only on SUCCESS (any later refusal rolls the burn back with everything
- *      else, so a drifted preview's token dies by TTL, not by half-burn).
- *   3. IN-FENCE AUTHORIZATION RE-ADJUDICATION (P1-2, owner ruling 2026-07-17): the REQUIRED
- *      `evaluateFullReadAccess` dependency is evaluated FRESH under the fence (revocation between preview
- *      and execute ⇒ `forbidden`), and the token's signed `authorizedScopeHash` must equal the recomputed
- *      v1 basis — the token's echo is never the authority.
- *   4. IN-FENCE CHECKPOINT RE-RESOLUTION (deferral 1): re-run `selectCheckpointByAnchorSeq` and require
- *      the resolved id to EQUAL the token's `checkpointId` — the token's echo is never trusted. A
- *      checkpoint pruned/superseded-below since preview ⇒ `checkpoint-changed` (re-preview).
- *   5. DRIFT RE-CHECK (§5 preview verification): re-reconstruct at the TOKEN-BOUND anchorSeq, compose the
- *      L5 baseline overlay via the SHARED `composeBaselineOverlay` (deferral 2 + F4: records below the
- *      replay horizon come from the RESOLVED checkpoint's immutable baseline — non-trashed ⇒ at-anchor
- *      state, trashed ⇒ deleted-at-anchor), and re-hash the COMPOSED set; any divergence from the signed
- *      `scopeHash` ⇒ `preview-drift` (409-class, zero writes). The preview hashed the SAME composed set —
- *      what the actor saw is what gets planned; and it runs UNDER the fence (no check→write TOCTOU).
- *   6. (folded into 5 — the composed map from the drift re-check IS the plan input.)
- *   7. PLAN (L7): `classifyExactAnchorRecoveryPlan` over the composed map. `driftCount > 0` ⇒
- *      `schema-drift` refusal — the WHOLE apply, zero writes (P1-2: no partial-set apply smuggled through
- *      drift exclusion; explicit partial recovery is a future separate mode).
- *   8. APPLY all-or-nothing, every write revision-emitted + ledger-tagged (L6-a; the recovery itself
- *      becomes a sealed operation — a future exact anchor):
- *        reverts    → UPDATE to the FULL at-anchor data (version+1, optimistic version guard) +
- *                     synchronize WRITABLE forward `meta_links` to the at-anchor snapshot (link reads use
- *                     meta_links, not data — parity with RecordWriteService / PIT reset) +
- *                     revision(action:'update', source:'restore', snapshot = at-anchor data).
- *                     Mirror-side rows are never created (spine invariant).
- *        resurrects → lock the trash vintage FOR UPDATE → INSERT (new generation, version resets to 1 —
- *                     the MULTI-GEN convention) → rebuild WRITABLE outbound meta_links from the snapshot →
- *                     revision(action:'create', source:'restore') → DELETE the `meta_records_trash` row
- *                     (live/trash mutual exclusion; mirrors `restoreRecord`; owner P1 2026-07-17). All in
- *                     THIS txn, so an injected failure rolls the resurrect + its trash deletion back together.
- *        TOKEN mode 'reset' ONLY: canonical delete parity (deleteRecord / PIT-reset): pre-generate revision
- *                     id → optional inbound-tombstone capture (flag-gated, cap-checked) → DELETE meta_links
- *                     both directions (record_id OR foreign_record_id; foreign_record_id has no FK so inbound
- *                     edges would otherwise dangle) → revision(action:'delete', id=pre-gen) → INSERT
- *                     meta_records_trash (snapshot/version/timestamps/base_id/delete_revision_id) → DELETE
- *                     live row. mode 'revert' KEEPS both non-anchor-present classes (non-destructive).
- *                     P1-1: the mode is read from the VERIFIED CLAIMS — the caller has no mode input; a
- *                     revert-preview token can never drive a reset.
- *   9. SEAL the operation LAST (endpoint after its events — the deferred-FK discipline).
+ * THE SHAPE — one outer transaction, COMMIT once, any failure ⇒ FULL ROLLBACK (incl. burn):
+ *   1. fenceWriterEntry (L4, fence-FIRST).
+ *   2. TRUSTED SUBSTRATE (kernel fail-closed): BOTH `MULTITABLE_ENABLE_WRITER_FENCE` and
+ *      `MULTITABLE_HISTORY_CONTIGUITY_STRICT` must be on, then `precheckSheetHistoryIntegrityStrict` under
+ *      the fence — any non-ok ⇒ `recovery-trust-required`, zero writes. Prevents an accidental route wire
+ *      from running destructive apply with the fence as a flag-off no-op.
+ *   3. BURN the token (anti-replay PK).
+ *   4. IN-FENCE full-read + authorizedScopeHash (P1-2).
+ *   5. IN-FENCE checkpoint re-resolution (never trust the token echo).
+ *   6. Dual-hash drift (composed scopeHash + live liveSetHash) + plan (L7).
+ *   7. schema-drift whole-reject; RESURRECT fail-closed (`inbound-unprovable` — D1c link history unsolved;
+ *      temporary kernel boundary, not route-deferred replay).
+ *   8. Canonical restorable projection per revert (projectRestorableOntoLive): derived-only ⇒ no-op;
+ *      foreign-link integrity for every changed writable forward link; REQUIRED
+ *      `evaluatePlanAuthorization` over the true restorable delta (before mint/writes).
+ *   9. APPLY: restorable reverts (data + meta_links) + RESET canonical delete parity; seal last.
  *
- * LAYERING CONTRACT — KERNEL-OWNED (security + data integrity live HERE, same txn):
- *   full-read authorization, mode authority, schema-drift whole-rejection, anti-replay, checkpoint/scope
- *   freshness; REVERT outbound link sync; RESURRECT trash cleanup + outbound link rebuild; RESET both-
- *   direction link delete + optional inbound tombstone capture + trash insert + delete revision anchoring.
- * What remains the route wiring's obligation (NOT deferred integrity):
- *   presentation masking of RETURNED data, size ceilings (SHEET_REVERT_MAX_RECORDS-class), foreign-existence
- *   preflight / mirror-diff route guards, realtime fan-out, HTTP mapping, and AT-ANCHOR-vs-terminal inbound
- *   tombstone REPLAY for resurrect (a different vintage than the post-anchor terminal delete — future mode).
- * NOT wired to any route in this lane; the legacy Revert/Reset routes' switch onto this module is the
- * OWNER's wiring decision behind their existing default-OFF flags
- * (`MULTITABLE_ENABLE_SHEET_REVERT` / `MULTITABLE_ENABLE_PIT_RESET`). Default-off by construction: nothing
- * reaches this module today.
+ * KERNEL-OWNED: security adjudication, restorable projection, link integrity, both-direction reset cleanup,
+ * tombstone/trash, anti-replay, trust substrate. Route-owned: presentation masking, size ceilings, realtime,
+ * HTTP mapping. NOT wired; flags OFF; `RECONSTRUCTION_CAUSALITY_LANDED` stays false.
  */
 
 /** The apply's mode IS the token's mode (P1-1) — one vocabulary, defined with the identity claims. */
@@ -150,11 +117,14 @@ export type ExactAnchorApplyMode = ExactAnchorRecoveryMode
 export type ExactAnchorApplyRefusal =
   | 'identity-invalid' // signature/expiry/sheet/actor verification failed (pre-txn, zero DB writes)
   | 'token-replayed' // the token was already burned by a previous successful execute
-  | 'forbidden' // in-fence fresh full-read adjudication failed, or the token's authorizedScopeHash does not match the recomputed basis (P1-2)
+  | 'forbidden' // full-read / authorizedScopeHash / plan authorization failed (values-free)
   | 'no-covering-checkpoint' // no active/retained checkpoint covers the anchor any more (fail-closed)
   | 'checkpoint-changed' // a checkpoint covers it, but NOT the one the preview was minted under
   | 'preview-drift' // the live reconstruction diverged from the signed scope (409-class; re-preview)
-  | 'schema-drift' // the plan carries schema-drifted records (driftCount > 0) ⇒ WHOLE apply refused, zero writes (P1-2; explicit partial recovery is a future separate mode)
+  | 'schema-drift' // plan.driftCount > 0 ⇒ WHOLE apply refused, zero writes
+  | 'inbound-unprovable' // plan.resurrects.length > 0 — at-anchor inbound relations cannot be proven (D1c)
+  | 'link-integrity' // missing/ambiguous foreign sheet, missing/wrong-sheet target, or mirror write attempt
+  | 'recovery-trust-required' // fence+strict substrate missing or HISTORY_INCOMPLETE under the fence
 
 export interface ExactAnchorApplySuccess {
   ok: true
@@ -162,10 +132,43 @@ export interface ExactAnchorApplySuccess {
   mode: ExactAnchorApplyMode
   anchorSeq: string
   checkpointId: string
+  /** counts of WRITES that landed (no-op restorable projections are not counted as reverts). */
   applied: { reverts: number; resurrects: number; deletes: number }
   keptCreatedAfterAnchor: number
 }
 export type ExactAnchorApplyResult = ExactAnchorApplySuccess | { ok: false; reason: ExactAnchorApplyRefusal }
+
+/** True restorable delta for one revert that will write (for plan-authorization / field-write gates). */
+export interface ExactAnchorRevertWriteIntent {
+  recordId: string
+  liveVersion: number
+  changedFieldIds: string[]
+  patch: Record<string, unknown>
+  projectedData: Record<string, unknown>
+  linkUpdates: Array<{ fieldId: string; targetIds: string[] }>
+}
+
+/**
+ * Context for the REQUIRED in-fence write-authorization dependency. Built AFTER plan + restorable
+ * projection so the eventual route adapter can enforce manage-sheet + per-record edit/delete/row ownership
+ * + field-write permissions over exactly the true restorable delta (not full snapshots).
+ */
+export interface ExactAnchorPlanAuthContext {
+  mode: ExactAnchorApplyMode
+  sheetId: string
+  actorId: string
+  plan: ExactAnchorRecoveryPlan
+  /** reverts that would write (isNoOp filtered out). */
+  revertWrites: ExactAnchorRevertWriteIntent[]
+  /** record ids the TOKEN-BOUND reset mode would delete. */
+  deleteRecordIds: string[]
+}
+
+/** REQUIRED — omission is a TypeScript error. Must return true to proceed to mint/writes. */
+export type EvaluatePlanAuthorization = (
+  query: QueryFn,
+  context: ExactAnchorPlanAuthContext,
+) => Promise<boolean>
 
 /** Typed control-flow error: thrown inside the txn to force a FULL rollback, mapped to a refusal outside. */
 class ApplyRefusalError extends Error {
@@ -186,17 +189,19 @@ export interface ExactAnchorApplyInput {
   token: string
   sheetId: string
   actorId: string
-  /** REQUIRED in-fence authorization dependency (P1-2) — same contract as the preview's (see
-   *  `EvaluateRecoveryFullReadAccess`). The apply re-adjudicates FRESH inside the fence; there is no
-   *  "already checked at preview" shortcut and no way to omit it. */
+  /** REQUIRED in-fence full-read adjudication (P1-2) — same contract as the preview. */
   evaluateFullReadAccess: EvaluateRecoveryFullReadAccess
+  /**
+   * REQUIRED in-fence WRITE authorization over the true restorable plan/projection (v3.7 §5 step 7).
+   * Re-evaluated FRESH under the fence after the plan is known and BEFORE mintOperation/any write.
+   * Omission is structurally impossible (typed required field). Full-read alone is insufficient.
+   */
+  evaluatePlanAuthorization: EvaluatePlanAuthorization
 }
 
 /**
  * Execute the destructive apply. `transaction` must open a REAL database transaction and roll back when the
- * callback throws (the poolManager.get().transaction shape). See the module doc for the step protocol.
- * The MODE comes from the VERIFIED TOKEN (P1-1) — there is no mode input: a preview minted for a
- * non-destructive `revert` is structurally unusable to drive a `reset`.
+ * callback throws. MODE comes from the VERIFIED TOKEN only (P1-1).
  */
 export async function applyExactAnchorRecovery(
   transaction: <T>(fn: (query: QueryFn) => Promise<T>) => Promise<T>,
@@ -209,11 +214,18 @@ export async function applyExactAnchorRecovery(
 
   try {
     return await transaction(async (query) => {
-      // 1. Fence-first (L4): serialize against all writers + refuse under a durable recovery block.
+      // 1. Fence-first (L4).
       await fenceWriterEntry(query, input.sheetId)
 
-      // 2. Burn — the at-most-once barrier. A replayed token conflicts on the PK; a LATER refusal in this
-      //    txn rolls this row back too (zero-writes refusals).
+      // 2. TRUSTED SUBSTRATE — before burn/write. Fence alone is a flag-off no-op; refuse unless the
+      //    trusted recovery substrate is actually armed, then re-check history under the fence.
+      if (!isWriterFenceEnabled() || !isContiguityStrictMode()) {
+        throw new ApplyRefusalError('recovery-trust-required')
+      }
+      const trust = await precheckSheetHistoryIntegrityStrict(query, input.sheetId)
+      if (!trust.ok) throw new ApplyRefusalError('recovery-trust-required')
+
+      // 3. Burn — at-most-once barrier (rolled back on any later refusal).
       const tokenSha = createHash('sha256').update(input.token).digest('hex')
       try {
         await query(
@@ -225,37 +237,25 @@ export async function applyExactAnchorRecovery(
         throw e
       }
 
-      // 3. IN-FENCE AUTHORIZATION RE-ADJUDICATION (P1-2): evaluate the actor's full-read capability FRESH
-      //    (permission revoked since preview ⇒ refused; the burn above rolls back with everything else, so
-      //    the token survives a refusal and works again if the grant returns) AND recompute the v1
-      //    authorization basis against the token's signed `authorizedScopeHash` — the token's echo is never
-      //    the authority, exactly like the checkpoint re-resolution below.
+      // 4. IN-FENCE full-read + authorizedScopeHash (P1-2).
       if (!(await input.evaluateFullReadAccess(query))) throw new ApplyRefusalError('forbidden')
       if (authorizedScopeHash !== hashRecoveryAuthorizationScope({ sheetId: input.sheetId, actorId: input.actorId })) {
         throw new ApplyRefusalError('forbidden')
       }
 
-      // 4. In-fence checkpoint re-resolution (deferral 1) — never trust the token's echo.
+      // 5. In-fence checkpoint re-resolution.
       const checkpoint = await selectCheckpointByAnchorSeq(query, input.sheetId, anchorSeq)
       if (!checkpoint) throw new ApplyRefusalError('no-covering-checkpoint')
       if (checkpoint.id !== checkpointId) throw new ApplyRefusalError('checkpoint-changed')
 
-      // 5. Drift re-check UNDER the fence (§5) — TWO independent hashes, two failure classes:
-      //    (a) the ANCHOR AUTHORITY: re-reconstruct at the token anchor, compose the SAME L5 baseline
-      //        overlay the preview hashed (F4 symmetry — what the actor previewed IS what gets planned;
-      //        `composeBaselineOverlay` is the one shared implementation), and re-hash the COMPOSED set.
-      //        Immutable under an append-only history + immutable baselines, so a divergence means retention
-      //        pruned below the anchor or the anchor was recomputed (the MAX-recompute mutation class) — refuse.
+      // 6. Dual-hash drift + live rows for plan/projection.
       const replayMap = await reconstructRecordsAtSeq(query, input.sheetId, anchorSeq)
       const composed = await composeBaselineOverlay(query, { sheetId: input.sheetId, checkpointId: checkpoint.id, stateMap: replayMap })
       const anchorHash = hashAnchorRecoveryScope(
         [...composed.values()].map((s) => ({ recordId: s.recordId, exists: s.exists, version: s.version })),
       )
       if (anchorHash !== scopeHash) throw new ApplyRefusalError('preview-drift')
-      //    (b) PREVIEW FRESHNESS: re-fingerprint the LIVE set {id, version} in-fence. Any concurrent
-      //        version-bumping write / create / delete since the preview changes it — the actor must apply
-      //        exactly the world they previewed (the T-path's changesHash discipline, set-level). Read the
-      //        live rows HERE (they double as the plan input below — one read, checked and planned).
+
       const liveById = new Map<string, {
         data: Record<string, unknown>
         version: number
@@ -293,140 +293,119 @@ export async function applyExactAnchorRecovery(
       )
       if (liveHash !== liveSetHash) throw new ApplyRefusalError('preview-drift')
 
-      // (Baseline composition happened in step 5 via the shared `composeBaselineOverlay` — the SAME map the
-      // anchor hash covered is the map the plan consumes below: what was checked is what is planned.)
-
-      // 6. Plan (L7) over the composed map, against the SAME in-fence live rows the freshness hash covered
-      //    (one read: what was checked is what is planned) + the current schema.
-      const fieldRes = await query('SELECT id FROM meta_fields WHERE sheet_id = $1', [input.sheetId])
-      const fieldIds = new Set((fieldRes.rows as Array<{ id: unknown }>).map((r) => String(r.id)))
+      // 7. Plan (L7).
+      const fieldRes = await query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [input.sheetId])
+      const fieldRows = fieldRes.rows as Array<{ id: unknown; type: unknown }>
+      const fieldIds = new Set(fieldRows.map((r) => String(r.id)))
+      const rawTypeById = new Map(fieldRows.map((r) => [String(r.id), String(r.type ?? '')]))
       const plan: ExactAnchorRecoveryPlan = classifyExactAnchorRecoveryPlan(composed, liveById, fieldIds)
 
-      // P1-2 SCHEMA-DRIFT WHOLE-REJECT (owner ruling 2026-07-17): ANY schema-drifted record ⇒ the WHOLE
-      // apply is refused with zero writes (burn included — the txn rolls back). No partial-set apply is
-      // smuggled through drift exclusion; an EXPLICIT partial recovery is a future separate mode with its
-      // own preview disclosure, not a side effect of a stale field id.
       if (plan.driftCount > 0) throw new ApplyRefusalError('schema-drift')
 
-      // 7. Apply — every write revision-emitted + ledger-tagged; a single failure rolls EVERYTHING back.
+      // RESURRECT fail-closed: D1c leaves link-edge history unsolved; terminal tombstones/current neighbors
+      // cannot prove the inbound relation set AT the requested anchor. Whole-apply refuse — never partial.
+      if (plan.resurrects.length > 0) throw new ApplyRefusalError('inbound-unprovable')
+
+      // Field surface for restorable projection (exclude mirror-owned link fields — spine invariant).
+      const fields = await loadFieldsForSheet(query, input.sheetId)
+      const fieldById = new Map<string, MultitableField>()
+      const projectionFieldById = new Map<string, { type: string }>()
+      for (const f of fields) {
+        fieldById.set(f.id, f)
+        if (f.type === 'link' && isFieldAlwaysReadOnly(f)) continue
+        projectionFieldById.set(f.id, { type: f.type })
+      }
+
+      // Restorable projection per plan.revert — derived-only differences become no-ops.
+      const revertWrites: ExactAnchorRevertWriteIntent[] = []
+      for (const r of plan.reverts) {
+        const live = liveById.get(r.recordId)
+        if (!live) continue
+        const projection = projectRestorableOntoLive({
+          fieldById: projectionFieldById,
+          rawTypeById,
+          targetSnapshot: r.targetData,
+          currentData: live.data,
+          recordId: r.recordId,
+          currentVersion: live.version,
+          normalizeLinkIds,
+        })
+        if (projection.isNoOp) continue
+        revertWrites.push({
+          recordId: r.recordId,
+          liveVersion: r.liveVersion,
+          changedFieldIds: projection.changedFieldIds,
+          patch: projection.patch,
+          projectedData: projection.data,
+          linkUpdates: projection.linkUpdates,
+        })
+      }
+
+      // Foreign-link integrity for every changed writable forward link (before any mutation).
+      for (const rw of revertWrites) {
+        for (const lu of rw.linkUpdates) {
+          const field = fieldById.get(lu.fieldId)
+          if (!field || field.type !== 'link') throw new ApplyRefusalError('link-integrity')
+          if (isFieldAlwaysReadOnly(field)) throw new ApplyRefusalError('link-integrity')
+          const foreignSheetId = resolveForeignSheetId(field)
+          if (!foreignSheetId) throw new ApplyRefusalError('link-integrity')
+          const targetIds = lu.targetIds
+          if (targetIds.length === 0) continue
+          const found = await query(
+            'SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
+            [foreignSheetId, targetIds],
+          )
+          const foundSet = new Set((found.rows as Array<{ id: unknown }>).map((row) => String(row.id)))
+          if (targetIds.some((id) => !foundSet.has(id))) throw new ApplyRefusalError('link-integrity')
+        }
+      }
+
+      const deleteRecordIds =
+        mode === 'reset' ? [...plan.deletedAtAnchorLiveNow, ...plan.createdAfterAnchor] : []
+
+      // 8. REQUIRED in-fence WRITE authorization over the true restorable plan (after plan/projection,
+      //    before mint/writes). Revocation between preview and execute, or field/record deny ⇒ forbidden.
+      if (!(await input.evaluatePlanAuthorization(query, {
+        mode,
+        sheetId: input.sheetId,
+        actorId: input.actorId,
+        plan,
+        revertWrites,
+        deleteRecordIds,
+      }))) {
+        throw new ApplyRefusalError('forbidden')
+      }
+
+      // 9. Apply — every write revision-emitted + ledger-tagged.
       const op = await mintOperation(query, input.sheetId)
 
-      // Writable forward link fields once for the sheet (revert + resurrect share the same set).
-      // Mirror-side (`isFieldAlwaysReadOnly` via mirrorOf) is EXCLUDED — spine invariant.
-      const needLinkFields = plan.reverts.length > 0 || plan.resurrects.length > 0
-      const writableLinkFieldIds: string[] = needLinkFields
-        ? (await loadFieldsForSheet(query, input.sheetId))
-            .filter((f) => f.type === 'link' && !isFieldAlwaysReadOnly(f))
-            .map((f) => f.id)
-        : []
-
-      // RESET trash needs sheet base_id once (best-effort; mirrors deleteRecord).
       let sheetBaseId: string | null = null
-      if (mode === 'reset' && (plan.deletedAtAnchorLiveNow.length > 0 || plan.createdAfterAnchor.length > 0)) {
+      if (deleteRecordIds.length > 0) {
         const baseRow = (await query('SELECT base_id FROM meta_sheets WHERE id = $1', [input.sheetId])).rows[0] as
           | { base_id?: unknown }
           | undefined
         sheetBaseId = baseRow && typeof baseRow.base_id === 'string' ? baseRow.base_id : null
       }
 
-      for (const r of plan.reverts) {
-        // Lock discipline (rank-8, mirrors the T-path recovery): a LOCKED record refuses the apply — and
-        // because this apply is all-or-nothing, one locked record aborts the WHOLE recovery loudly (unlock
-        // first, re-preview). ensureRecordNotLocked throws unless the actor is the locker/owner.
-        const liveRow = liveById.get(r.recordId)
-        if (liveRow) ensureRecordNotLocked(input.actorId, liveRow, () => new Error(`exact-anchor apply refused: record ${r.recordId} is locked`))
-        // lock-guarded: L8 revert apply — ensureRecordNotLocked just above, same txn.
-        // revision-emitted: L8 revert apply — recordRecordRevision below, same txn (source 'restore').
-        const upd = await query(
-          `UPDATE meta_records SET data = $1::jsonb, version = version + 1, updated_at = now()
-           WHERE id = $2 AND sheet_id = $3 AND version = $4
-           RETURNING version`,
-          [JSON.stringify(r.targetData), r.recordId, input.sheetId, r.liveVersion],
-        )
-        const row = upd.rows[0] as { version?: unknown } | undefined
-        // In-fence, post-drift-check: a 0-row update here is an internal invariant break — abort everything.
-        if (!row) throw new Error(`exact-anchor apply: optimistic version guard failed for ${r.recordId}`)
-        // KERNEL data-integrity: sync writable outbound meta_links to the at-anchor snapshot (same txn).
-        // Without this, data and relation projection diverge — loadLinkValuesByRecord reads meta_links.
-        await syncOutboundWritableLinks(query, r.recordId, r.targetData, writableLinkFieldIds)
-        // revision-emitted: L8 revert apply — action:'update', source:'restore', full at-anchor snapshot.
-        await recordRecordRevision(query, {
-          sheetId: input.sheetId,
-          recordId: r.recordId,
-          version: Number(row.version),
-          action: 'update',
-          source: 'restore',
-          actorId: input.actorId,
-          changedFieldIds: Object.keys(r.targetData),
-          patch: r.targetData,
-          snapshot: r.targetData,
-          ledger: op,
-        })
-      }
-
-      // Resurrect trash-lifecycle side effects (owner P1, 2026-07-17): a resurrect candidate was deleted
-      // AFTER the anchor, so its post-anchor delete left a `meta_records_trash` row. Bringing it back to
-      // live WITHOUT removing that row breaks the live/trash mutual-exclusion invariant — the recycle bin
-      // still shows the (now-live) record, a later restore of it 23505-conflicts on the id, and its lingering
-      // `delete_revision_id` mis-pins tombstone/retention. So the resurrect MUST mirror `restoreRecord`'s
-      // trash discipline: lock the vintage FOR UPDATE, rebuild the WRITABLE outbound links from the at-anchor
-      // snapshot (so link reads aren't silently empty; mirror side skipped — the spine invariant is
-      // structural), then DELETE the trash row — ALL inside this same all-or-nothing txn, so an injected
-      // later failure rolls back the INSERT, the revision, the link rebuild AND the trash deletion together.
-      for (const s of plan.resurrects) {
-        // Lock this record's trash vintage(s) FIRST (4c-3 C4 discipline): a concurrent restore/resurrect of
-        // the same id serializes here; the loser sees the rows gone and the whole apply aborts, never racing
-        // to a duplicate insert. A resurrect whose post-anchor delete was a hard delete (no trash row) locks
-        // zero rows — harmless.
-        await query('SELECT id FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2 FOR UPDATE', [s.recordId, input.sheetId])
-        // New generation: version resets to 1 (the MULTI-GEN delete→recreate convention). No lock can exist
-        // on a row being created; the snapshot is previously-persisted at-anchor data (no new user payload).
-        // revision-emitted: L8 resurrect apply — recordRecordRevision below, same txn (source 'restore').
-        await query(
-          'INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)',
-          [s.recordId, input.sheetId, JSON.stringify(s.snapshot), input.actorId],
-        )
-        // Rebuild outbound meta_links from the at-anchor snapshot (writable/forward links only).
-        await syncOutboundWritableLinks(query, s.recordId, s.snapshot as Record<string, unknown>, writableLinkFieldIds)
-        // revision-emitted: L8 resurrect apply — action:'create', source:'restore', at-anchor snapshot.
-        await recordRecordRevision(query, {
-          sheetId: input.sheetId,
-          recordId: s.recordId,
-          version: 1,
-          action: 'create',
-          source: 'restore',
-          actorId: input.actorId,
-          changedFieldIds: Object.keys(s.snapshot),
-          patch: s.snapshot,
-          snapshot: s.snapshot,
-          ledger: op,
-        })
-        // Trash cleanup — the live/trash mutual-exclusion invariant. Removing the trash row(s) for this id
-        // also drops the `delete_revision_id` anchor that was mis-pinning tombstone/retention. (Inbound-edge
-        // REPLAY from those terminal-vintage tombstones is deliberately NOT done here: this apply reconstructs
-        // the AT-ANCHOR state, a different vintage than the terminal delete the tombstones belong to — a naive
-        // replay would restore edges from the wrong vintage. That is a route/future-mode concern, not a
-        // deferred integrity gap for the apply itself.)
-        await query('DELETE FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2', [s.recordId, input.sheetId])
-      }
-
+      // RESET deletes BEFORE reverts so inbound edges that a concurrent restorable projection
+      // would clear (peer rows linking to a created-after-anchor delete candidate) are still
+      // present for tombstone capture — same-txn, still all-or-nothing.
       let deletes = 0
-      // P1-1: the destructive branch keys on the TOKEN-BOUND mode — the one the actor previewed under.
       if (mode === 'reset') {
-        for (const recordId of [...plan.deletedAtAnchorLiveNow, ...plan.createdAfterAnchor]) {
+        for (const recordId of deleteRecordIds) {
           const live = liveById.get(recordId)
-          if (!live) continue // defensive: classified live moments ago, under the fence it must still be
-          // Lock discipline (rank-8): a LOCKED record aborts the whole all-or-nothing reset (unlock first).
-          ensureRecordNotLocked(input.actorId, live, () => new Error(`exact-anchor apply refused: record ${recordId} is locked`))
-          // Canonical delete parity (deleteRecord / PIT-reset ~10867-10922), same txn, ledger-tagged:
-          //   pre-gen revision id → optional inbound tombstone capture → both-direction meta_links delete
-          //   → delete revision with that id → trash (snapshot/version/timestamps/base_id/delete_revision_id)
-          //   → hard-delete live row.
-          // foreign_record_id has no FK: without the both-direction link delete, inbound edges dangle.
+          if (!live) continue
+          ensureRecordNotLocked(
+            input.actorId,
+            live,
+            () => new Error(`exact-anchor apply refused: record ${recordId} is locked`),
+          )
+          // Canonical delete parity (deleteRecord / PIT-reset): pre-gen id → optional inbound capture →
+          // both-direction meta_links delete → revision → trash → live delete.
           const resetDeleteRevisionId = randomUUID()
           if (isTombstoneCaptureEnabled()) {
             const totalToCapture = await countInboundLinkCaptureRows(query, recordId)
-            assertWithinCaptureCap(totalToCapture) // fail-closed — never a partial capture + completed destroy
+            assertWithinCaptureCap(totalToCapture)
             await insertInboundLinkTombstones(query, {
               sheetId: input.sheetId,
               recordId,
@@ -479,7 +458,47 @@ export async function applyExactAnchorRecovery(
         }
       }
 
-      // 8. Seal LAST (endpoint after events — deferred-FK discipline). No-op when the ledger is inert.
+      let revertsApplied = 0
+      for (const rw of revertWrites) {
+        const liveRow = liveById.get(rw.recordId)
+        if (liveRow) {
+          ensureRecordNotLocked(
+            input.actorId,
+            liveRow,
+            () => new Error(`exact-anchor apply refused: record ${rw.recordId} is locked`),
+          )
+        }
+        // lock-guarded: L8 revert apply — ensureRecordNotLocked just above, same txn.
+        // revision-emitted: L8 revert apply — recordRecordRevision below, same txn (source 'restore').
+        const upd = await query(
+          `UPDATE meta_records SET data = $1::jsonb, version = version + 1, updated_at = now()
+           WHERE id = $2 AND sheet_id = $3 AND version = $4
+           RETURNING version`,
+          [JSON.stringify(rw.projectedData), rw.recordId, input.sheetId, rw.liveVersion],
+        )
+        const row = upd.rows[0] as { version?: unknown } | undefined
+        if (!row) throw new Error(`exact-anchor apply: optimistic version guard failed for ${rw.recordId}`)
+        for (const lu of rw.linkUpdates) {
+          await syncOneOutboundLinkField(query, rw.recordId, lu.fieldId, lu.targetIds)
+        }
+        // revision-emitted: L8 revert — true restorable delta only (never Object.keys(full target)).
+        await recordRecordRevision(query, {
+          sheetId: input.sheetId,
+          recordId: rw.recordId,
+          version: Number(row.version),
+          action: 'update',
+          source: 'restore',
+          actorId: input.actorId,
+          changedFieldIds: rw.changedFieldIds,
+          patch: rw.patch,
+          snapshot: rw.projectedData,
+          ledger: op,
+        })
+        revertsApplied++
+      }
+
+      // RESURRECT branch intentionally absent: plan.resurrects already failed closed above.
+
       await sealOperation(query, op)
 
       return {
@@ -487,25 +506,19 @@ export async function applyExactAnchorRecovery(
         mode,
         anchorSeq,
         checkpointId: checkpoint.id,
-        applied: { reverts: plan.reverts.length, resurrects: plan.resurrects.length, deletes },
-        keptCreatedAfterAnchor: mode === 'revert' ? plan.createdAfterAnchor.length + plan.deletedAtAnchorLiveNow.length : 0,
+        applied: { reverts: revertsApplied, resurrects: 0, deletes },
+        keptCreatedAfterAnchor:
+          mode === 'revert' ? plan.createdAfterAnchor.length + plan.deletedAtAnchorLiveNow.length : 0,
       }
     })
   } catch (e) {
     if (e instanceof ApplyRefusalError) return { ok: false, reason: e.reason }
-    throw e // real failures propagate — the transaction has already rolled everything back
+    throw e
   }
 }
 
 /**
- * G1 (pre-wiring gate list) — BURN-RETENTION SWEEP. `meta_recovery_token_burns` grows one row per
- * successful apply, forever; a burn row's at-most-once duty ends once its token can no longer verify
- * (the 10-minute JWT `exp`). Prunes rows older than `keepMinutes`, FLOOR-CLAMPED to 15 minutes: pruning a
- * burn younger than any possibly-live token's lifetime would RESURRECT a replayed token (the PK conflict
- * is the at-most-once barrier), so the floor is a correctness bound (token TTL 10m + clock-skew margin),
- * not a tunable. Values-free (deletes by age only); returns the pruned row count for the operator log.
- * NOT scheduled anywhere in this lane — the sweep's production caller is route/ops wiring (the same PR
- * that wires Revert/Reset onto this module), same posture as every other consumer here.
+ * G1 — BURN-RETENTION SWEEP. Floor-clamped to 15 minutes (token TTL + skew). Not scheduled in this lane.
  */
 export async function pruneExpiredRecoveryTokenBurns(query: QueryFn, keepMinutes = 60): Promise<number> {
   const keep = Math.max(15, Math.floor(Number.isFinite(keepMinutes) ? keepMinutes : 60))

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -1,0 +1,391 @@
+import { createHash, randomUUID } from 'node:crypto'
+
+import type { QueryFn } from './permission-service'
+import { fenceWriterEntry } from './canonical-sheet-fence'
+import { selectCheckpointByAnchorSeq } from './history-trust-checkpoint'
+import { reconstructRecordsAtSeq } from './record-reconstructor'
+import { mintOperation, sealOperation } from './operation-ledger'
+import { recordRecordRevision } from './record-history-service'
+import { ensureRecordNotLocked } from './record-lock'
+import { loadFieldsForSheet } from './loaders'
+import { isFieldAlwaysReadOnly } from './permission-derivation'
+import {
+  hashAnchorRecoveryScope,
+  hashRecoveryAuthorizationScope,
+  verifyExactAnchorRecoveryIdentity,
+  type ExactAnchorRecoveryMode,
+} from './restore-preview-identity'
+import { composeBaselineOverlay, type EvaluateRecoveryFullReadAccess } from './exact-anchor-recovery'
+import { classifyExactAnchorRecoveryPlan, type ExactAnchorRecoveryPlan } from './exact-anchor-recovery-plan'
+
+/** Normalize a link-field cell (array | single | null) to a string[] of foreign record ids (local copy of the
+ *  record-service private helper — the resurrect outbound-link rebuild needs exactly the same shape). */
+function normalizeLinkIds(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string' && v.length > 0)
+  return typeof value === 'string' && value.length > 0 ? [value] : []
+}
+
+/**
+ * W0-1 v3.7 Lane L8 — the exact-anchor DESTRUCTIVE APPLY: one transaction, all-or-nothing.
+ *
+ * Design authority: v3.7 lock (#4331) §5 (execute = full target/schema/set recomputation UNDER THE FENCE,
+ * preview verification in-fence) + §2 (canonical fence) + the L6-b gate's pinned L8 deferrals (2026-07-16):
+ * (1) in-fence checkpoint re-resolution, (2) L5 baseline composition, (3) anti-replay single-use burn.
+ *
+ * THE SHAPE — one outer transaction, every step inside it, COMMIT once, any failure ⇒ FULL ROLLBACK with
+ * zero writes (including the token burn — a refused execute leaves the world byte-identical):
+ *   1. fenceWriterEntry (L4, fence-FIRST): serializes against every fenced writer AND any in-flight
+ *      recovery; observes a durable `applying` block and refuses. A concurrent writer parks on this fence
+ *      until we commit — nothing interleaves with the apply.
+ *   2. BURN the token (INSERT sha256 into `meta_recovery_token_burns`): the PK is the at-most-once
+ *      barrier — a second execute of the same token conflicts here and the whole txn rolls back
+ *      (`token-replayed`). Burned only on SUCCESS (any later refusal rolls the burn back with everything
+ *      else, so a drifted preview's token dies by TTL, not by half-burn).
+ *   3. IN-FENCE AUTHORIZATION RE-ADJUDICATION (P1-2, owner ruling 2026-07-17): the REQUIRED
+ *      `evaluateFullReadAccess` dependency is evaluated FRESH under the fence (revocation between preview
+ *      and execute ⇒ `forbidden`), and the token's signed `authorizedScopeHash` must equal the recomputed
+ *      v1 basis — the token's echo is never the authority.
+ *   4. IN-FENCE CHECKPOINT RE-RESOLUTION (deferral 1): re-run `selectCheckpointByAnchorSeq` and require
+ *      the resolved id to EQUAL the token's `checkpointId` — the token's echo is never trusted. A
+ *      checkpoint pruned/superseded-below since preview ⇒ `checkpoint-changed` (re-preview).
+ *   5. DRIFT RE-CHECK (§5 preview verification): re-reconstruct at the TOKEN-BOUND anchorSeq, compose the
+ *      L5 baseline overlay via the SHARED `composeBaselineOverlay` (deferral 2 + F4: records below the
+ *      replay horizon come from the RESOLVED checkpoint's immutable baseline — non-trashed ⇒ at-anchor
+ *      state, trashed ⇒ deleted-at-anchor), and re-hash the COMPOSED set; any divergence from the signed
+ *      `scopeHash` ⇒ `preview-drift` (409-class, zero writes). The preview hashed the SAME composed set —
+ *      what the actor saw is what gets planned; and it runs UNDER the fence (no check→write TOCTOU).
+ *   6. (folded into 5 — the composed map from the drift re-check IS the plan input.)
+ *   7. PLAN (L7): `classifyExactAnchorRecoveryPlan` over the composed map. `driftCount > 0` ⇒
+ *      `schema-drift` refusal — the WHOLE apply, zero writes (P1-2: no partial-set apply smuggled through
+ *      drift exclusion; explicit partial recovery is a future separate mode).
+ *   8. APPLY all-or-nothing, every write revision-emitted + ledger-tagged (L6-a; the recovery itself
+ *      becomes a sealed operation — a future exact anchor):
+ *        reverts    → UPDATE to the FULL at-anchor data (version+1, optimistic version guard) +
+ *                     revision(action:'update', source:'restore', snapshot = at-anchor data).
+ *        resurrects → lock the trash vintage FOR UPDATE → INSERT (new generation, version resets to 1 —
+ *                     the MULTI-GEN convention) → rebuild WRITABLE outbound meta_links from the snapshot →
+ *                     revision(action:'create', source:'restore') → DELETE the `meta_records_trash` row
+ *                     (live/trash mutual exclusion; mirrors `restoreRecord`; owner P1 2026-07-17). All in
+ *                     THIS txn, so an injected failure rolls the resurrect + its trash deletion back together.
+ *        TOKEN mode 'reset' ONLY: DELETE `deletedAtAnchorLiveNow` + `createdAfterAnchor` rows +
+ *                     revision(action:'delete', snapshot = pre-delete data). mode 'revert' KEEPS both
+ *                     (non-destructive). P1-1: the mode is read from the VERIFIED CLAIMS — the caller has
+ *                     no mode input; a revert-preview token can never drive a reset.
+ *   9. SEAL the operation LAST (endpoint after its events — the deferred-FK discipline).
+ *
+ * LAYERING CONTRACT (P1-2 narrowed it — the SECURITY adjudication is KERNEL-OWNED): full-read
+ * authorization, mode authority, schema-drift whole-rejection, anti-replay, checkpoint/scope freshness, AND
+ * the recovery DATA-INTEGRITY invariants (resurrect ⇒ trash-row cleanup + outbound-link rebuild = live/trash
+ * mutual exclusion, owner P1 2026-07-17) all live HERE. What remains the route wiring's obligation:
+ * presentation masking of RETURNED data, size ceilings (SHEET_REVERT_MAX_RECORDS-class), the BROADER
+ * link-field side-effects (mirror guards, foreign-existence checks, inbound-tombstone replay), realtime
+ * fan-out, HTTP mapping. NOT wired to any route in this lane; the legacy Revert/Reset
+ * routes' switch onto this module is the OWNER's wiring decision behind their existing default-OFF flags
+ * (`MULTITABLE_ENABLE_SHEET_REVERT` / `MULTITABLE_ENABLE_PIT_RESET`). Default-off by construction: nothing
+ * reaches this module today.
+ */
+
+/** The apply's mode IS the token's mode (P1-1) — one vocabulary, defined with the identity claims. */
+export type ExactAnchorApplyMode = ExactAnchorRecoveryMode
+
+export type ExactAnchorApplyRefusal =
+  | 'identity-invalid' // signature/expiry/sheet/actor verification failed (pre-txn, zero DB writes)
+  | 'token-replayed' // the token was already burned by a previous successful execute
+  | 'forbidden' // in-fence fresh full-read adjudication failed, or the token's authorizedScopeHash does not match the recomputed basis (P1-2)
+  | 'no-covering-checkpoint' // no active/retained checkpoint covers the anchor any more (fail-closed)
+  | 'checkpoint-changed' // a checkpoint covers it, but NOT the one the preview was minted under
+  | 'preview-drift' // the live reconstruction diverged from the signed scope (409-class; re-preview)
+  | 'schema-drift' // the plan carries schema-drifted records (driftCount > 0) ⇒ WHOLE apply refused, zero writes (P1-2; explicit partial recovery is a future separate mode)
+
+export interface ExactAnchorApplySuccess {
+  ok: true
+  /** the TOKEN-BOUND mode (P1-1) — never a request-supplied one. */
+  mode: ExactAnchorApplyMode
+  anchorSeq: string
+  checkpointId: string
+  applied: { reverts: number; resurrects: number; deletes: number }
+  keptCreatedAfterAnchor: number
+}
+export type ExactAnchorApplyResult = ExactAnchorApplySuccess | { ok: false; reason: ExactAnchorApplyRefusal }
+
+/** Typed control-flow error: thrown inside the txn to force a FULL rollback, mapped to a refusal outside. */
+class ApplyRefusalError extends Error {
+  constructor(readonly reason: ExactAnchorApplyRefusal) {
+    super(`exact-anchor apply refused: ${reason}`)
+    this.name = 'ApplyRefusalError'
+  }
+}
+
+/** Postgres unique-violation on the burn PK ⇒ the token was already used. */
+const isUniqueViolation = (e: unknown): boolean =>
+  typeof e === 'object' && e !== null && (e as { code?: unknown }).code === '23505'
+
+const asRec = (v: unknown): Record<string, unknown> =>
+  v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {}
+
+export interface ExactAnchorApplyInput {
+  token: string
+  sheetId: string
+  actorId: string
+  /** REQUIRED in-fence authorization dependency (P1-2) — same contract as the preview's (see
+   *  `EvaluateRecoveryFullReadAccess`). The apply re-adjudicates FRESH inside the fence; there is no
+   *  "already checked at preview" shortcut and no way to omit it. */
+  evaluateFullReadAccess: EvaluateRecoveryFullReadAccess
+}
+
+/**
+ * Execute the destructive apply. `transaction` must open a REAL database transaction and roll back when the
+ * callback throws (the poolManager.get().transaction shape). See the module doc for the step protocol.
+ * The MODE comes from the VERIFIED TOKEN (P1-1) — there is no mode input: a preview minted for a
+ * non-destructive `revert` is structurally unusable to drive a `reset`.
+ */
+export async function applyExactAnchorRecovery(
+  transaction: <T>(fn: (query: QueryFn) => Promise<T>) => Promise<T>,
+  input: ExactAnchorApplyInput,
+): Promise<ExactAnchorApplyResult> {
+  // Identity verification is pure (no DB) — fail fast before opening a transaction.
+  const verified = verifyExactAnchorRecoveryIdentity(input.token, { sheetId: input.sheetId, actorId: input.actorId })
+  if (!verified.valid || !verified.claims) return { ok: false, reason: 'identity-invalid' }
+  const { anchorSeq, checkpointId, scopeHash, liveSetHash, mode, authorizedScopeHash } = verified.claims
+
+  try {
+    return await transaction(async (query) => {
+      // 1. Fence-first (L4): serialize against all writers + refuse under a durable recovery block.
+      await fenceWriterEntry(query, input.sheetId)
+
+      // 2. Burn — the at-most-once barrier. A replayed token conflicts on the PK; a LATER refusal in this
+      //    txn rolls this row back too (zero-writes refusals).
+      const tokenSha = createHash('sha256').update(input.token).digest('hex')
+      try {
+        await query(
+          'INSERT INTO meta_recovery_token_burns (token_sha256, sheet_id, actor_id) VALUES ($1,$2,$3)',
+          [tokenSha, input.sheetId, input.actorId],
+        )
+      } catch (e) {
+        if (isUniqueViolation(e)) throw new ApplyRefusalError('token-replayed')
+        throw e
+      }
+
+      // 3. IN-FENCE AUTHORIZATION RE-ADJUDICATION (P1-2): evaluate the actor's full-read capability FRESH
+      //    (permission revoked since preview ⇒ refused; the burn above rolls back with everything else, so
+      //    the token survives a refusal and works again if the grant returns) AND recompute the v1
+      //    authorization basis against the token's signed `authorizedScopeHash` — the token's echo is never
+      //    the authority, exactly like the checkpoint re-resolution below.
+      if (!(await input.evaluateFullReadAccess(query))) throw new ApplyRefusalError('forbidden')
+      if (authorizedScopeHash !== hashRecoveryAuthorizationScope({ sheetId: input.sheetId, actorId: input.actorId })) {
+        throw new ApplyRefusalError('forbidden')
+      }
+
+      // 4. In-fence checkpoint re-resolution (deferral 1) — never trust the token's echo.
+      const checkpoint = await selectCheckpointByAnchorSeq(query, input.sheetId, anchorSeq)
+      if (!checkpoint) throw new ApplyRefusalError('no-covering-checkpoint')
+      if (checkpoint.id !== checkpointId) throw new ApplyRefusalError('checkpoint-changed')
+
+      // 5. Drift re-check UNDER the fence (§5) — TWO independent hashes, two failure classes:
+      //    (a) the ANCHOR AUTHORITY: re-reconstruct at the token anchor, compose the SAME L5 baseline
+      //        overlay the preview hashed (F4 symmetry — what the actor previewed IS what gets planned;
+      //        `composeBaselineOverlay` is the one shared implementation), and re-hash the COMPOSED set.
+      //        Immutable under an append-only history + immutable baselines, so a divergence means retention
+      //        pruned below the anchor or the anchor was recomputed (the MAX-recompute mutation class) — refuse.
+      const replayMap = await reconstructRecordsAtSeq(query, input.sheetId, anchorSeq)
+      const composed = await composeBaselineOverlay(query, { sheetId: input.sheetId, checkpointId: checkpoint.id, stateMap: replayMap })
+      const anchorHash = hashAnchorRecoveryScope(
+        [...composed.values()].map((s) => ({ recordId: s.recordId, exists: s.exists, version: s.version })),
+      )
+      if (anchorHash !== scopeHash) throw new ApplyRefusalError('preview-drift')
+      //    (b) PREVIEW FRESHNESS: re-fingerprint the LIVE set {id, version} in-fence. Any concurrent
+      //        version-bumping write / create / delete since the preview changes it — the actor must apply
+      //        exactly the world they previewed (the T-path's changesHash discipline, set-level). Read the
+      //        live rows HERE (they double as the plan input below — one read, checked and planned).
+      const liveById = new Map<string, { data: Record<string, unknown>; version: number; locked?: unknown; locked_by?: unknown; created_by?: unknown }>()
+      for (const r of (await query('SELECT id, data, version, locked, locked_by, created_by FROM meta_records WHERE sheet_id = $1', [input.sheetId])).rows as Array<{ id: unknown; data: unknown; version: unknown; locked?: unknown; locked_by?: unknown; created_by?: unknown }>) {
+        liveById.set(String(r.id), {
+          data: asRec(r.data),
+          version: typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : Number(r.version) || 0,
+          locked: r.locked,
+          locked_by: r.locked_by,
+          created_by: r.created_by,
+        })
+      }
+      const liveHash = hashAnchorRecoveryScope(
+        [...liveById.entries()].map(([recordId, l]) => ({ recordId, exists: true, version: l.version })),
+      )
+      if (liveHash !== liveSetHash) throw new ApplyRefusalError('preview-drift')
+
+      // (Baseline composition happened in step 5 via the shared `composeBaselineOverlay` — the SAME map the
+      // anchor hash covered is the map the plan consumes below: what was checked is what is planned.)
+
+      // 6. Plan (L7) over the composed map, against the SAME in-fence live rows the freshness hash covered
+      //    (one read: what was checked is what is planned) + the current schema.
+      const fieldRes = await query('SELECT id FROM meta_fields WHERE sheet_id = $1', [input.sheetId])
+      const fieldIds = new Set((fieldRes.rows as Array<{ id: unknown }>).map((r) => String(r.id)))
+      const plan: ExactAnchorRecoveryPlan = classifyExactAnchorRecoveryPlan(composed, liveById, fieldIds)
+
+      // P1-2 SCHEMA-DRIFT WHOLE-REJECT (owner ruling 2026-07-17): ANY schema-drifted record ⇒ the WHOLE
+      // apply is refused with zero writes (burn included — the txn rolls back). No partial-set apply is
+      // smuggled through drift exclusion; an EXPLICIT partial recovery is a future separate mode with its
+      // own preview disclosure, not a side effect of a stale field id.
+      if (plan.driftCount > 0) throw new ApplyRefusalError('schema-drift')
+
+      // 7. Apply — every write revision-emitted + ledger-tagged; a single failure rolls EVERYTHING back.
+      const op = await mintOperation(query, input.sheetId)
+
+      for (const r of plan.reverts) {
+        // Lock discipline (rank-8, mirrors the T-path recovery): a LOCKED record refuses the apply — and
+        // because this apply is all-or-nothing, one locked record aborts the WHOLE recovery loudly (unlock
+        // first, re-preview). ensureRecordNotLocked throws unless the actor is the locker/owner.
+        const liveRow = liveById.get(r.recordId)
+        if (liveRow) ensureRecordNotLocked(input.actorId, liveRow, () => new Error(`exact-anchor apply refused: record ${r.recordId} is locked`))
+        // lock-guarded: L8 revert apply — ensureRecordNotLocked just above, same txn.
+        // revision-emitted: L8 revert apply — recordRecordRevision below, same txn (source 'restore').
+        const upd = await query(
+          `UPDATE meta_records SET data = $1::jsonb, version = version + 1, updated_at = now()
+           WHERE id = $2 AND sheet_id = $3 AND version = $4
+           RETURNING version`,
+          [JSON.stringify(r.targetData), r.recordId, input.sheetId, r.liveVersion],
+        )
+        const row = upd.rows[0] as { version?: unknown } | undefined
+        // In-fence, post-drift-check: a 0-row update here is an internal invariant break — abort everything.
+        if (!row) throw new Error(`exact-anchor apply: optimistic version guard failed for ${r.recordId}`)
+        // revision-emitted: L8 revert apply — action:'update', source:'restore', full at-anchor snapshot.
+        await recordRecordRevision(query, {
+          sheetId: input.sheetId,
+          recordId: r.recordId,
+          version: Number(row.version),
+          action: 'update',
+          source: 'restore',
+          actorId: input.actorId,
+          changedFieldIds: Object.keys(r.targetData),
+          patch: r.targetData,
+          snapshot: r.targetData,
+          ledger: op,
+        })
+      }
+
+      // Resurrect trash-lifecycle side effects (owner P1, 2026-07-17): a resurrect candidate was deleted
+      // AFTER the anchor, so its post-anchor delete left a `meta_records_trash` row. Bringing it back to
+      // live WITHOUT removing that row breaks the live/trash mutual-exclusion invariant — the recycle bin
+      // still shows the (now-live) record, a later restore of it 23505-conflicts on the id, and its lingering
+      // `delete_revision_id` mis-pins tombstone/retention. So the resurrect MUST mirror `restoreRecord`'s
+      // trash discipline: lock the vintage FOR UPDATE, rebuild the WRITABLE outbound links from the at-anchor
+      // snapshot (so link reads aren't silently empty; mirror side skipped — the spine invariant is
+      // structural), then DELETE the trash row — ALL inside this same all-or-nothing txn, so an injected
+      // later failure rolls back the INSERT, the revision, the link rebuild AND the trash deletion together.
+      const resurrectLinkFieldIds: string[] = plan.resurrects.length > 0
+        ? (await loadFieldsForSheet(query, input.sheetId))
+            .filter((f) => f.type === 'link' && !isFieldAlwaysReadOnly(f))
+            .map((f) => f.id)
+        : []
+      for (const s of plan.resurrects) {
+        // Lock this record's trash vintage(s) FIRST (4c-3 C4 discipline): a concurrent restore/resurrect of
+        // the same id serializes here; the loser sees the rows gone and the whole apply aborts, never racing
+        // to a duplicate insert. A resurrect whose post-anchor delete was a hard delete (no trash row) locks
+        // zero rows — harmless.
+        await query('SELECT id FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2 FOR UPDATE', [s.recordId, input.sheetId])
+        // New generation: version resets to 1 (the MULTI-GEN delete→recreate convention). No lock can exist
+        // on a row being created; the snapshot is previously-persisted at-anchor data (no new user payload).
+        // revision-emitted: L8 resurrect apply — recordRecordRevision below, same txn (source 'restore').
+        await query(
+          'INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)',
+          [s.recordId, input.sheetId, JSON.stringify(s.snapshot), input.actorId],
+        )
+        // Rebuild outbound meta_links from the at-anchor snapshot (writable/forward links only) — same insert
+        // shape as create/patch/restoreRecord; `loadLinkValuesByRecord` reads meta_links, not `data`.
+        for (const fieldId of resurrectLinkFieldIds) {
+          for (const foreignId of normalizeLinkIds((s.snapshot as Record<string, unknown>)[fieldId])) {
+            await query(
+              `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
+               VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`,
+              [`lnk_${randomUUID()}`.slice(0, 50), fieldId, s.recordId, foreignId],
+            )
+          }
+        }
+        // revision-emitted: L8 resurrect apply — action:'create', source:'restore', at-anchor snapshot.
+        await recordRecordRevision(query, {
+          sheetId: input.sheetId,
+          recordId: s.recordId,
+          version: 1,
+          action: 'create',
+          source: 'restore',
+          actorId: input.actorId,
+          changedFieldIds: Object.keys(s.snapshot),
+          patch: s.snapshot,
+          snapshot: s.snapshot,
+          ledger: op,
+        })
+        // Trash cleanup — the live/trash mutual-exclusion invariant. Removing the trash row(s) for this id
+        // also drops the `delete_revision_id` anchor that was mis-pinning tombstone/retention. (Inbound-edge
+        // REPLAY from those terminal-vintage tombstones is deliberately NOT done here: this apply reconstructs
+        // the AT-ANCHOR state, a different vintage than the terminal delete the tombstones belong to — a naive
+        // replay would restore edges from the wrong vintage. That is a route-wiring / future-mode concern.)
+        await query('DELETE FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2', [s.recordId, input.sheetId])
+      }
+
+      let deletes = 0
+      // P1-1: the destructive branch keys on the TOKEN-BOUND mode — the one the actor previewed under.
+      if (mode === 'reset') {
+        for (const recordId of [...plan.deletedAtAnchorLiveNow, ...plan.createdAfterAnchor]) {
+          const live = liveById.get(recordId)
+          if (!live) continue // defensive: classified live moments ago, under the fence it must still be
+          // Lock discipline (rank-8): a LOCKED record aborts the whole all-or-nothing reset (unlock first).
+          ensureRecordNotLocked(input.actorId, live, () => new Error(`exact-anchor apply refused: record ${recordId} is locked`))
+          // lock-guarded: L8 reset delete — ensureRecordNotLocked just above, same txn.
+          // revision-emitted: L8 reset delete — recordRecordRevision below, same txn (source 'restore').
+          const del = await query(
+            'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2 RETURNING version',
+            [recordId, input.sheetId],
+          )
+          if (!del.rows[0]) throw new Error(`exact-anchor apply: reset delete found no row for ${recordId}`)
+          // revision-emitted: L8 reset delete — action:'delete', pre-delete snapshot (LOCK-9 convention).
+          await recordRecordRevision(query, {
+            sheetId: input.sheetId,
+            recordId,
+            version: live.version,
+            action: 'delete',
+            source: 'restore',
+            actorId: input.actorId,
+            changedFieldIds: [],
+            patch: {},
+            snapshot: live.data,
+            ledger: op,
+          })
+          deletes++
+        }
+      }
+
+      // 8. Seal LAST (endpoint after events — deferred-FK discipline). No-op when the ledger is inert.
+      await sealOperation(query, op)
+
+      return {
+        ok: true as const,
+        mode,
+        anchorSeq,
+        checkpointId: checkpoint.id,
+        applied: { reverts: plan.reverts.length, resurrects: plan.resurrects.length, deletes },
+        keptCreatedAfterAnchor: mode === 'revert' ? plan.createdAfterAnchor.length + plan.deletedAtAnchorLiveNow.length : 0,
+      }
+    })
+  } catch (e) {
+    if (e instanceof ApplyRefusalError) return { ok: false, reason: e.reason }
+    throw e // real failures propagate — the transaction has already rolled everything back
+  }
+}
+
+/**
+ * G1 (pre-wiring gate list) — BURN-RETENTION SWEEP. `meta_recovery_token_burns` grows one row per
+ * successful apply, forever; a burn row's at-most-once duty ends once its token can no longer verify
+ * (the 10-minute JWT `exp`). Prunes rows older than `keepMinutes`, FLOOR-CLAMPED to 15 minutes: pruning a
+ * burn younger than any possibly-live token's lifetime would RESURRECT a replayed token (the PK conflict
+ * is the at-most-once barrier), so the floor is a correctness bound (token TTL 10m + clock-skew margin),
+ * not a tunable. Values-free (deletes by age only); returns the pruned row count for the operator log.
+ * NOT scheduled anywhere in this lane — the sweep's production caller is route/ops wiring (the same PR
+ * that wires Revert/Reset onto this module), same posture as every other consumer here.
+ */
+export async function pruneExpiredRecoveryTokenBurns(query: QueryFn, keepMinutes = 60): Promise<number> {
+  const keep = Math.max(15, Math.floor(Number.isFinite(keepMinutes) ? keepMinutes : 60))
+  const res = await query(
+    `DELETE FROM meta_recovery_token_burns WHERE burned_at < now() - ($1 || ' minutes')::interval`,
+    [String(keep)],
+  )
+  return typeof res.rowCount === 'number' ? res.rowCount : 0
+}

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -11,6 +11,7 @@ import { loadFieldsForSheet } from './loaders'
 import { isFieldAlwaysReadOnly } from './permission-derivation'
 import {
   hashAnchorRecoveryScope,
+  hashExactAnchorSchema,
   hashRecoveryAuthorizationScope,
   verifyExactAnchorRecoveryIdentity,
   type ExactAnchorRecoveryMode,
@@ -138,7 +139,7 @@ export type ExactAnchorApplyRefusal =
   | 'no-covering-checkpoint' // no active/retained checkpoint covers the anchor any more (fail-closed)
   | 'checkpoint-changed' // a checkpoint covers it, but NOT the one the preview was minted under
   | 'preview-drift' // the live reconstruction diverged from the signed scope (409-class; re-preview)
-  | 'schema-drift' // plan.driftCount > 0 ⇒ WHOLE apply refused, zero writes
+  | 'schema-drift' // schemaHash mismatch (retype/property/field set) OR plan.driftCount > 0 ⇒ WHOLE apply refused, zero writes
   | 'inbound-unprovable' // plan.resurrects.length > 0 — at-anchor inbound relations cannot be proven (D1c)
   | 'link-integrity' // missing/ambiguous foreign sheet, missing/wrong-sheet target, same-op delete target, or mirror
   | 'value-invalid' // current-schema scalar exactness OR whole-record validateRecord fails
@@ -229,7 +230,7 @@ export async function applyExactAnchorRecovery(
   // Identity verification is pure (no DB) — fail fast before opening a transaction.
   const verified = verifyExactAnchorRecoveryIdentity(input.token, { sheetId: input.sheetId, actorId: input.actorId })
   if (!verified.valid || !verified.claims) return { ok: false, reason: 'identity-invalid' }
-  const { anchorSeq, checkpointId, scopeHash, liveSetHash, mode, authorizedScopeHash } = verified.claims
+  const { anchorSeq, checkpointId, scopeHash, liveSetHash, schemaHash, mode, authorizedScopeHash } = verified.claims
 
   try {
     return await transaction(async (query) => {
@@ -312,11 +313,19 @@ export async function applyExactAnchorRecovery(
       )
       if (liveHash !== liveSetHash) throw new ApplyRefusalError('preview-drift')
 
+      // 6b. G-SCHEMA-BEFORE-FENCE — CURRENT field surface must match the token-bound schemaHash.
+      // Catches retype (string→longText) and property-only edits that leave record ids/versions unchanged
+      // and may still leave historical values "valid" under the new type (scope/live hashes cannot see this).
+      const schemaRes = await query('SELECT id, type, property FROM meta_fields WHERE sheet_id = $1', [input.sheetId])
+      const schemaRows = schemaRes.rows as Array<{ id: unknown; type: unknown; property: unknown }>
+      const liveSchemaHash = hashExactAnchorSchema(
+        schemaRows.map((r) => ({ id: String(r.id), type: String(r.type ?? ''), property: r.property })),
+      )
+      if (liveSchemaHash !== schemaHash) throw new ApplyRefusalError('schema-drift')
+
       // 7. Plan (L7).
-      const fieldRes = await query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [input.sheetId])
-      const fieldRows = fieldRes.rows as Array<{ id: unknown; type: unknown }>
-      const fieldIds = new Set(fieldRows.map((r) => String(r.id)))
-      const rawTypeById = new Map(fieldRows.map((r) => [String(r.id), String(r.type ?? '')]))
+      const fieldIds = new Set(schemaRows.map((r) => String(r.id)))
+      const rawTypeById = new Map(schemaRows.map((r) => [String(r.id), String(r.type ?? '')]))
       const plan: ExactAnchorRecoveryPlan = classifyExactAnchorRecoveryPlan(composed, liveById, fieldIds)
 
       if (plan.driftCount > 0) throw new ApplyRefusalError('schema-drift')

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -17,20 +17,70 @@ import {
 } from './restore-preview-identity'
 import { composeBaselineOverlay, type EvaluateRecoveryFullReadAccess } from './exact-anchor-recovery'
 import { classifyExactAnchorRecoveryPlan, type ExactAnchorRecoveryPlan } from './exact-anchor-recovery-plan'
+import {
+  assertWithinCaptureCap,
+  countInboundLinkCaptureRows,
+  insertInboundLinkTombstones,
+  isTombstoneCaptureEnabled,
+} from './tombstone-capture'
 
 /** Normalize a link-field cell (array | single | null) to a string[] of foreign record ids (local copy of the
- *  record-service private helper — the resurrect outbound-link rebuild needs exactly the same shape). */
+ *  record-service private helper — outbound-link sync needs exactly the same shape). */
 function normalizeLinkIds(value: unknown): string[] {
   if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string' && v.length > 0)
   return typeof value === 'string' && value.length > 0 ? [value] : []
 }
 
 /**
+ * Synchronize one record's WRITABLE forward-link `meta_links` rows to exactly the ids carried by `snapshot`
+ * for each field in `writableLinkFieldIds`. Mirror-side fields are never in that list (spine invariant:
+ * mirrors never own a meta_links row). Same-txn only — never opens a nested transaction. Used by REVERT
+ * (diff-sync) and RESURRECT (insert-from-empty) so data and relation projection cannot diverge: link reads
+ * go through `meta_links`, not `meta_records.data`.
+ */
+async function syncOutboundWritableLinks(
+  query: QueryFn,
+  recordId: string,
+  snapshot: Record<string, unknown>,
+  writableLinkFieldIds: readonly string[],
+): Promise<void> {
+  for (const fieldId of writableLinkFieldIds) {
+    const ids = normalizeLinkIds(snapshot[fieldId])
+    const current = await query(
+      'SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2',
+      [fieldId, recordId],
+    )
+    const existingIds = (current.rows as Array<{ foreign_record_id: unknown }>).map((r) => String(r.foreign_record_id))
+    const existing = new Set(existingIds)
+    const next = new Set(ids)
+    const toDelete = existingIds.filter((id) => !next.has(id))
+    const toInsert = ids.filter((id) => !existing.has(id))
+    if (toDelete.length > 0) {
+      await query(
+        'DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2 AND foreign_record_id = ANY($3::text[])',
+        [fieldId, recordId, toDelete],
+      )
+    }
+    for (const foreignId of toInsert) {
+      await query(
+        `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
+         VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`,
+        [`lnk_${randomUUID()}`.slice(0, 50), fieldId, recordId, foreignId],
+      )
+    }
+    if (ids.length === 0) {
+      await query('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2', [fieldId, recordId])
+    }
+  }
+}
+
+/**
  * W0-1 v3.7 Lane L8 — the exact-anchor DESTRUCTIVE APPLY: one transaction, all-or-nothing.
  *
  * Design authority: v3.7 lock (#4331) §5 (execute = full target/schema/set recomputation UNDER THE FENCE,
- * preview verification in-fence) + §2 (canonical fence) + the L6-b gate's pinned L8 deferrals (2026-07-16):
- * (1) in-fence checkpoint re-resolution, (2) L5 baseline composition, (3) anti-replay single-use burn.
+ * preview verification in-fence; all writes + revisions/tombstones in one txn) + §2 (canonical fence) +
+ * the L6-b gate's pinned L8 deferrals (2026-07-16): (1) in-fence checkpoint re-resolution, (2) L5 baseline
+ * composition, (3) anti-replay single-use burn.
  *
  * THE SHAPE — one outer transaction, every step inside it, COMMIT once, any failure ⇒ FULL ROLLBACK with
  * zero writes (including the token burn — a refused execute leaves the world byte-identical):
@@ -61,26 +111,35 @@ function normalizeLinkIds(value: unknown): string[] {
  *   8. APPLY all-or-nothing, every write revision-emitted + ledger-tagged (L6-a; the recovery itself
  *      becomes a sealed operation — a future exact anchor):
  *        reverts    → UPDATE to the FULL at-anchor data (version+1, optimistic version guard) +
+ *                     synchronize WRITABLE forward `meta_links` to the at-anchor snapshot (link reads use
+ *                     meta_links, not data — parity with RecordWriteService / PIT reset) +
  *                     revision(action:'update', source:'restore', snapshot = at-anchor data).
+ *                     Mirror-side rows are never created (spine invariant).
  *        resurrects → lock the trash vintage FOR UPDATE → INSERT (new generation, version resets to 1 —
  *                     the MULTI-GEN convention) → rebuild WRITABLE outbound meta_links from the snapshot →
  *                     revision(action:'create', source:'restore') → DELETE the `meta_records_trash` row
  *                     (live/trash mutual exclusion; mirrors `restoreRecord`; owner P1 2026-07-17). All in
  *                     THIS txn, so an injected failure rolls the resurrect + its trash deletion back together.
- *        TOKEN mode 'reset' ONLY: DELETE `deletedAtAnchorLiveNow` + `createdAfterAnchor` rows +
- *                     revision(action:'delete', snapshot = pre-delete data). mode 'revert' KEEPS both
- *                     (non-destructive). P1-1: the mode is read from the VERIFIED CLAIMS — the caller has
- *                     no mode input; a revert-preview token can never drive a reset.
+ *        TOKEN mode 'reset' ONLY: canonical delete parity (deleteRecord / PIT-reset): pre-generate revision
+ *                     id → optional inbound-tombstone capture (flag-gated, cap-checked) → DELETE meta_links
+ *                     both directions (record_id OR foreign_record_id; foreign_record_id has no FK so inbound
+ *                     edges would otherwise dangle) → revision(action:'delete', id=pre-gen) → INSERT
+ *                     meta_records_trash (snapshot/version/timestamps/base_id/delete_revision_id) → DELETE
+ *                     live row. mode 'revert' KEEPS both non-anchor-present classes (non-destructive).
+ *                     P1-1: the mode is read from the VERIFIED CLAIMS — the caller has no mode input; a
+ *                     revert-preview token can never drive a reset.
  *   9. SEAL the operation LAST (endpoint after its events — the deferred-FK discipline).
  *
- * LAYERING CONTRACT (P1-2 narrowed it — the SECURITY adjudication is KERNEL-OWNED): full-read
- * authorization, mode authority, schema-drift whole-rejection, anti-replay, checkpoint/scope freshness, AND
- * the recovery DATA-INTEGRITY invariants (resurrect ⇒ trash-row cleanup + outbound-link rebuild = live/trash
- * mutual exclusion, owner P1 2026-07-17) all live HERE. What remains the route wiring's obligation:
- * presentation masking of RETURNED data, size ceilings (SHEET_REVERT_MAX_RECORDS-class), the BROADER
- * link-field side-effects (mirror guards, foreign-existence checks, inbound-tombstone replay), realtime
- * fan-out, HTTP mapping. NOT wired to any route in this lane; the legacy Revert/Reset
- * routes' switch onto this module is the OWNER's wiring decision behind their existing default-OFF flags
+ * LAYERING CONTRACT — KERNEL-OWNED (security + data integrity live HERE, same txn):
+ *   full-read authorization, mode authority, schema-drift whole-rejection, anti-replay, checkpoint/scope
+ *   freshness; REVERT outbound link sync; RESURRECT trash cleanup + outbound link rebuild; RESET both-
+ *   direction link delete + optional inbound tombstone capture + trash insert + delete revision anchoring.
+ * What remains the route wiring's obligation (NOT deferred integrity):
+ *   presentation masking of RETURNED data, size ceilings (SHEET_REVERT_MAX_RECORDS-class), foreign-existence
+ *   preflight / mirror-diff route guards, realtime fan-out, HTTP mapping, and AT-ANCHOR-vs-terminal inbound
+ *   tombstone REPLAY for resurrect (a different vintage than the post-anchor terminal delete — future mode).
+ * NOT wired to any route in this lane; the legacy Revert/Reset routes' switch onto this module is the
+ * OWNER's wiring decision behind their existing default-OFF flags
  * (`MULTITABLE_ENABLE_SHEET_REVERT` / `MULTITABLE_ENABLE_PIT_RESET`). Default-off by construction: nothing
  * reaches this module today.
  */
@@ -197,14 +256,36 @@ export async function applyExactAnchorRecovery(
       //        version-bumping write / create / delete since the preview changes it — the actor must apply
       //        exactly the world they previewed (the T-path's changesHash discipline, set-level). Read the
       //        live rows HERE (they double as the plan input below — one read, checked and planned).
-      const liveById = new Map<string, { data: Record<string, unknown>; version: number; locked?: unknown; locked_by?: unknown; created_by?: unknown }>()
-      for (const r of (await query('SELECT id, data, version, locked, locked_by, created_by FROM meta_records WHERE sheet_id = $1', [input.sheetId])).rows as Array<{ id: unknown; data: unknown; version: unknown; locked?: unknown; locked_by?: unknown; created_by?: unknown }>) {
+      const liveById = new Map<string, {
+        data: Record<string, unknown>
+        version: number
+        locked?: unknown
+        locked_by?: unknown
+        created_by?: unknown
+        created_at?: unknown
+        updated_at?: unknown
+      }>()
+      for (const r of (await query(
+        'SELECT id, data, version, locked, locked_by, created_by, created_at, updated_at FROM meta_records WHERE sheet_id = $1',
+        [input.sheetId],
+      )).rows as Array<{
+        id: unknown
+        data: unknown
+        version: unknown
+        locked?: unknown
+        locked_by?: unknown
+        created_by?: unknown
+        created_at?: unknown
+        updated_at?: unknown
+      }>) {
         liveById.set(String(r.id), {
           data: asRec(r.data),
           version: typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : Number(r.version) || 0,
           locked: r.locked,
           locked_by: r.locked_by,
           created_by: r.created_by,
+          created_at: r.created_at,
+          updated_at: r.updated_at,
         })
       }
       const liveHash = hashAnchorRecoveryScope(
@@ -230,6 +311,24 @@ export async function applyExactAnchorRecovery(
       // 7. Apply — every write revision-emitted + ledger-tagged; a single failure rolls EVERYTHING back.
       const op = await mintOperation(query, input.sheetId)
 
+      // Writable forward link fields once for the sheet (revert + resurrect share the same set).
+      // Mirror-side (`isFieldAlwaysReadOnly` via mirrorOf) is EXCLUDED — spine invariant.
+      const needLinkFields = plan.reverts.length > 0 || plan.resurrects.length > 0
+      const writableLinkFieldIds: string[] = needLinkFields
+        ? (await loadFieldsForSheet(query, input.sheetId))
+            .filter((f) => f.type === 'link' && !isFieldAlwaysReadOnly(f))
+            .map((f) => f.id)
+        : []
+
+      // RESET trash needs sheet base_id once (best-effort; mirrors deleteRecord).
+      let sheetBaseId: string | null = null
+      if (mode === 'reset' && (plan.deletedAtAnchorLiveNow.length > 0 || plan.createdAfterAnchor.length > 0)) {
+        const baseRow = (await query('SELECT base_id FROM meta_sheets WHERE id = $1', [input.sheetId])).rows[0] as
+          | { base_id?: unknown }
+          | undefined
+        sheetBaseId = baseRow && typeof baseRow.base_id === 'string' ? baseRow.base_id : null
+      }
+
       for (const r of plan.reverts) {
         // Lock discipline (rank-8, mirrors the T-path recovery): a LOCKED record refuses the apply — and
         // because this apply is all-or-nothing, one locked record aborts the WHOLE recovery loudly (unlock
@@ -247,6 +346,9 @@ export async function applyExactAnchorRecovery(
         const row = upd.rows[0] as { version?: unknown } | undefined
         // In-fence, post-drift-check: a 0-row update here is an internal invariant break — abort everything.
         if (!row) throw new Error(`exact-anchor apply: optimistic version guard failed for ${r.recordId}`)
+        // KERNEL data-integrity: sync writable outbound meta_links to the at-anchor snapshot (same txn).
+        // Without this, data and relation projection diverge — loadLinkValuesByRecord reads meta_links.
+        await syncOutboundWritableLinks(query, r.recordId, r.targetData, writableLinkFieldIds)
         // revision-emitted: L8 revert apply — action:'update', source:'restore', full at-anchor snapshot.
         await recordRecordRevision(query, {
           sheetId: input.sheetId,
@@ -271,11 +373,6 @@ export async function applyExactAnchorRecovery(
       // snapshot (so link reads aren't silently empty; mirror side skipped — the spine invariant is
       // structural), then DELETE the trash row — ALL inside this same all-or-nothing txn, so an injected
       // later failure rolls back the INSERT, the revision, the link rebuild AND the trash deletion together.
-      const resurrectLinkFieldIds: string[] = plan.resurrects.length > 0
-        ? (await loadFieldsForSheet(query, input.sheetId))
-            .filter((f) => f.type === 'link' && !isFieldAlwaysReadOnly(f))
-            .map((f) => f.id)
-        : []
       for (const s of plan.resurrects) {
         // Lock this record's trash vintage(s) FIRST (4c-3 C4 discipline): a concurrent restore/resurrect of
         // the same id serializes here; the loser sees the rows gone and the whole apply aborts, never racing
@@ -289,17 +386,8 @@ export async function applyExactAnchorRecovery(
           'INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)',
           [s.recordId, input.sheetId, JSON.stringify(s.snapshot), input.actorId],
         )
-        // Rebuild outbound meta_links from the at-anchor snapshot (writable/forward links only) — same insert
-        // shape as create/patch/restoreRecord; `loadLinkValuesByRecord` reads meta_links, not `data`.
-        for (const fieldId of resurrectLinkFieldIds) {
-          for (const foreignId of normalizeLinkIds((s.snapshot as Record<string, unknown>)[fieldId])) {
-            await query(
-              `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
-               VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`,
-              [`lnk_${randomUUID()}`.slice(0, 50), fieldId, s.recordId, foreignId],
-            )
-          }
-        }
+        // Rebuild outbound meta_links from the at-anchor snapshot (writable/forward links only).
+        await syncOutboundWritableLinks(query, s.recordId, s.snapshot as Record<string, unknown>, writableLinkFieldIds)
         // revision-emitted: L8 resurrect apply — action:'create', source:'restore', at-anchor snapshot.
         await recordRecordRevision(query, {
           sheetId: input.sheetId,
@@ -317,7 +405,8 @@ export async function applyExactAnchorRecovery(
         // also drops the `delete_revision_id` anchor that was mis-pinning tombstone/retention. (Inbound-edge
         // REPLAY from those terminal-vintage tombstones is deliberately NOT done here: this apply reconstructs
         // the AT-ANCHOR state, a different vintage than the terminal delete the tombstones belong to — a naive
-        // replay would restore edges from the wrong vintage. That is a route-wiring / future-mode concern.)
+        // replay would restore edges from the wrong vintage. That is a route/future-mode concern, not a
+        // deferred integrity gap for the apply itself.)
         await query('DELETE FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2', [s.recordId, input.sheetId])
       }
 
@@ -329,14 +418,24 @@ export async function applyExactAnchorRecovery(
           if (!live) continue // defensive: classified live moments ago, under the fence it must still be
           // Lock discipline (rank-8): a LOCKED record aborts the whole all-or-nothing reset (unlock first).
           ensureRecordNotLocked(input.actorId, live, () => new Error(`exact-anchor apply refused: record ${recordId} is locked`))
-          // lock-guarded: L8 reset delete — ensureRecordNotLocked just above, same txn.
-          // revision-emitted: L8 reset delete — recordRecordRevision below, same txn (source 'restore').
-          const del = await query(
-            'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2 RETURNING version',
-            [recordId, input.sheetId],
-          )
-          if (!del.rows[0]) throw new Error(`exact-anchor apply: reset delete found no row for ${recordId}`)
-          // revision-emitted: L8 reset delete — action:'delete', pre-delete snapshot (LOCK-9 convention).
+          // Canonical delete parity (deleteRecord / PIT-reset ~10867-10922), same txn, ledger-tagged:
+          //   pre-gen revision id → optional inbound tombstone capture → both-direction meta_links delete
+          //   → delete revision with that id → trash (snapshot/version/timestamps/base_id/delete_revision_id)
+          //   → hard-delete live row.
+          // foreign_record_id has no FK: without the both-direction link delete, inbound edges dangle.
+          const resetDeleteRevisionId = randomUUID()
+          if (isTombstoneCaptureEnabled()) {
+            const totalToCapture = await countInboundLinkCaptureRows(query, recordId)
+            assertWithinCaptureCap(totalToCapture) // fail-closed — never a partial capture + completed destroy
+            await insertInboundLinkTombstones(query, {
+              sheetId: input.sheetId,
+              recordId,
+              sourceRevisionId: resetDeleteRevisionId,
+            })
+          }
+          await query('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1', [recordId])
+          // lock-guarded: L8 reset delete — ensureRecordNotLocked above, same txn.
+          // revision-emitted: L8 reset delete — pre-gen id so trash + tombstones share the causal anchor.
           await recordRecordRevision(query, {
             sheetId: input.sheetId,
             recordId,
@@ -347,8 +446,35 @@ export async function applyExactAnchorRecovery(
             changedFieldIds: [],
             patch: {},
             snapshot: live.data,
+            id: resetDeleteRevisionId,
             ledger: op,
           })
+          const createdBy = typeof live.created_by === 'string' ? live.created_by : null
+          await query(
+            `INSERT INTO meta_records_trash
+               (record_id, sheet_id, base_id, data, original_version, created_by, deleted_by,
+                original_created_at, original_updated_at, delete_revision_id)
+             VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9, $10)`,
+            [
+              recordId,
+              input.sheetId,
+              sheetBaseId,
+              JSON.stringify(live.data),
+              live.version,
+              createdBy,
+              input.actorId,
+              live.created_at ?? null,
+              live.updated_at ?? null,
+              resetDeleteRevisionId,
+            ],
+          )
+          // lock-guarded: L8 reset delete — ensureRecordNotLocked earlier in this loop body, same txn.
+          // revision-emitted: L8 reset delete — recordRecordRevision(action:'delete', id=pre-gen) above, same txn.
+          const del = await query(
+            'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2 RETURNING version',
+            [recordId, input.sheetId],
+          )
+          if (!del.rows[0]) throw new Error(`exact-anchor apply: reset delete found no row for ${recordId}`)
           deletes++
         }
       }

--- a/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery-execute.ts
@@ -35,6 +35,14 @@ import {
   assertExactRestorableScalarValue,
   ExactRestoreValueError,
 } from './exact-anchor-restore-validate'
+import {
+  assertNoHierarchyParentCycle,
+  buildHierarchyParentOverridesByField,
+  collectSameSheetLinkChangeFieldIds,
+  HierarchyCycleError,
+  loadHierarchyParentFieldIds,
+  type HierarchyCycleLinkGuard,
+} from './hierarchy-cycle-guard'
 
 /** Normalize a link-field cell (array | single | null) to a string[] of foreign record ids. */
 function normalizeLinkIds(value: unknown): string[] {
@@ -141,7 +149,7 @@ export type ExactAnchorApplyRefusal =
   | 'preview-drift' // the live reconstruction diverged from the signed scope (409-class; re-preview)
   | 'schema-drift' // schemaHash mismatch (retype/property/field set) OR plan.driftCount > 0 ⇒ WHOLE apply refused, zero writes
   | 'inbound-unprovable' // plan.resurrects.length > 0 — at-anchor inbound relations cannot be proven (D1c)
-  | 'link-integrity' // missing/ambiguous foreign sheet, missing/wrong-sheet target, same-op delete target, or mirror
+  | 'link-integrity' // missing/ambiguous foreign sheet, missing/wrong-sheet target, same-op delete target, mirror, or hierarchy parent cycle
   | 'value-invalid' // current-schema scalar exactness OR whole-record validateRecord fails
   | 'record-locked' // in-fence lock check: record locked by another actor (values-free)
   | 'recovery-trust-required' // fence+strict substrate missing or HISTORY_INCOMPLETE under the fence
@@ -440,6 +448,91 @@ export async function applyExactAnchorRecovery(
           )
           const foundSet = new Set((found.rows as Array<{ id: unknown }>).map((row) => String(row.id)))
           if (targetIds.some((id) => !foundSet.has(id))) throw new ApplyRefusalError('link-integrity')
+        }
+      }
+
+      // Hierarchy parent cycle (RecordWriteService parity): multi-record FINAL-STATE overrides, before mutation.
+      // A historical same-sheet parent link can be valid at the anchor yet cycle against the CURRENT live graph.
+      {
+        const changesByRecord = new Map<string, Array<{ fieldId: string; value: unknown }>>()
+        for (const rw of revertWrites) {
+          if (rw.linkUpdates.length === 0) continue
+          changesByRecord.set(
+            rw.recordId,
+            rw.linkUpdates.map((lu) => ({ fieldId: lu.fieldId, value: lu.targetIds })),
+          )
+        }
+        if (changesByRecord.size > 0) {
+          const linkGuardById = new Map<string, HierarchyCycleLinkGuard>()
+          for (const f of fields) {
+            if (f.type !== 'link') {
+              linkGuardById.set(f.id, { type: f.type })
+              continue
+            }
+            const foreignSheetId = resolveForeignSheetIdFromProperty(rawPropById.get(f.id))
+            const prop = rawPropById.get(f.id) ?? {}
+            const limitSingle =
+              prop.limitSingleRecord === true ||
+              prop.isSingle === true ||
+              // property may use nested link shape after serializeFieldRow
+              (f.property as { link?: { limitSingleRecord?: unknown } } | undefined)?.link?.limitSingleRecord === true
+            linkGuardById.set(f.id, {
+              type: 'link',
+              link: foreignSheetId
+                ? { foreignSheetId, limitSingleRecord: limitSingle }
+                : null,
+            })
+          }
+          const sameSheetLinkChangeFieldIds = collectSameSheetLinkChangeFieldIds({
+            changesByRecord,
+            fieldById: linkGuardById,
+            sheetId: input.sheetId,
+          })
+          if (sameSheetLinkChangeFieldIds.size > 0) {
+            const hierarchyParentFieldIds = await loadHierarchyParentFieldIds({
+              query,
+              sheetId: input.sheetId,
+              fields: fields.map((f) => ({
+                id: f.id,
+                type: f.type,
+                order: typeof f.order === 'number' ? f.order : undefined,
+                property: f.property as Record<string, unknown> | undefined,
+              })),
+            })
+            const guardedHierarchyParentFieldIds = new Set(
+              [...sameSheetLinkChangeFieldIds].filter((fid) => hierarchyParentFieldIds.has(fid)),
+            )
+            if (guardedHierarchyParentFieldIds.size > 0) {
+              const hierarchyParentOverridesByField = buildHierarchyParentOverridesByField({
+                changesByRecord,
+                hierarchyParentFieldIds: guardedHierarchyParentFieldIds,
+                normalizeLinkIds,
+              })
+              for (const rw of revertWrites) {
+                for (const lu of rw.linkUpdates) {
+                  if (!guardedHierarchyParentFieldIds.has(lu.fieldId)) continue
+                  const foreignSheetId = resolveForeignSheetIdFromProperty(rawPropById.get(lu.fieldId))
+                  if (foreignSheetId !== input.sheetId) continue
+                  // Empty parent clears the edge — cannot create a cycle.
+                  if (lu.targetIds.length === 0) continue
+                  try {
+                    await assertNoHierarchyParentCycle({
+                      query,
+                      sheetId: input.sheetId,
+                      recordId: rw.recordId,
+                      fieldId: lu.fieldId,
+                      parentRecordIds: lu.targetIds,
+                      parentOverridesByRecord: hierarchyParentOverridesByField.get(lu.fieldId) ?? new Map(),
+                      normalizeLinkIds,
+                    })
+                  } catch (e) {
+                    if (e instanceof HierarchyCycleError) throw new ApplyRefusalError('link-integrity')
+                    throw e
+                  }
+                }
+              }
+            }
+          }
         }
       }
 

--- a/packages/core-backend/src/multitable/exact-anchor-recovery.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-recovery.ts
@@ -3,6 +3,7 @@ import { assertSeqString, selectCheckpointByAnchorSeq } from './history-trust-ch
 import { reconstructRecordsAtSeq, type RecordStateAtT } from './record-reconstructor'
 import {
   hashAnchorRecoveryScope,
+  hashExactAnchorSchema,
   hashRecoveryAuthorizationScope,
   mintExactAnchorRecoveryIdentity,
   verifyExactAnchorRecoveryIdentity,
@@ -245,6 +246,16 @@ export async function resolveExactAnchor(
       version: typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : Number(r.version) || 0,
     })),
   )
+  // G-SCHEMA-BEFORE-FENCE: bind CURRENT semantic field surface (id/type/property) into the identity.
+  // Apply recomputes under the fence and refuses schema-drift on retype / property drift / field add-drop.
+  const schemaRes = await query('SELECT id, type, property FROM meta_fields WHERE sheet_id = $1', [sheetId])
+  const schemaHash = hashExactAnchorSchema(
+    (schemaRes.rows as Array<{ id: unknown; type: unknown; property: unknown }>).map((r) => ({
+      id: String(r.id),
+      type: String(r.type ?? ''),
+      property: r.property,
+    })),
+  )
   const token = mintExactAnchorRecoveryIdentity({
     sheetId,
     anchorOperationId,
@@ -252,6 +263,7 @@ export async function resolveExactAnchor(
     checkpointId: checkpoint.id,
     scopeHash,
     liveSetHash,
+    schemaHash,
     actorId,
     mode,
     // P1-2: the authorization CONTRACT is signed in. The apply recomputes this from its OWN in-fence

--- a/packages/core-backend/src/multitable/exact-anchor-restore-validate.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-restore-validate.ts
@@ -1,0 +1,135 @@
+/**
+ * Exact-anchor restorable scalar validation under the CURRENT schema (W0 L8).
+ *
+ * Re-runs the same field-codecs validators/coercers the normal write path uses
+ * (`validateLongTextValue`, select/multiSelect option membership, numeric/boolean/string/date
+ * shape, Batch-1 types, person shape). Exact-anchor semantics FAIL CLOSED when:
+ *   - validation/coercion throws, OR
+ *   - the canonicalized result differs from the signed historical value
+ *     (e.g. rich longText sanitizer would strip XSS; `"5"` coerces to `5`).
+ *
+ * Never silently transforms history and still claims an exact restore. Links, attachment,
+ * and derived/system types are out of scope here (handled by projection / dedicated paths).
+ */
+import {
+  BATCH1_FIELD_TYPES,
+  coerceBatch1Value,
+  coerceNumericValue,
+  isPersonSingleRecord,
+  normalizeMultiSelectValue,
+  validateDateTimeValue,
+  validateLongTextValue,
+  validateLocationValue,
+  validatePersonValue,
+} from './field-codecs'
+
+export class ExactRestoreValueError extends Error {
+  readonly code = 'value-invalid' as const
+  constructor(message: string) {
+    super(message)
+    this.name = 'ExactRestoreValueError'
+  }
+}
+
+const sameValue = (a: unknown, b: unknown): boolean => JSON.stringify(a ?? null) === JSON.stringify(b ?? null)
+
+export type ExactRestoreField = {
+  id: string
+  type: string
+  property?: Record<string, unknown>
+  /** select/multiSelect option values from the CURRENT schema (empty = no options allowed except ''). */
+  options?: Array<{ value: string } | string>
+}
+
+function optionValues(field: ExactRestoreField): string[] {
+  const opts = field.options ?? []
+  return opts.map((o) => (typeof o === 'string' ? o : String(o.value)))
+}
+
+function normalizeSelectValue(value: unknown, fieldId: string, options: string[]): string {
+  if (typeof value !== 'string') throw new ExactRestoreValueError(`Select value must be string: ${fieldId}`)
+  if (value === '') return value
+  if (!new Set(options).has(value)) {
+    throw new ExactRestoreValueError(`Invalid select option for ${fieldId}: ${value}`)
+  }
+  return value
+}
+
+/**
+ * Canonicalize a historical scalar under current field property/options. Throws
+ * {@link ExactRestoreValueError} on reject OR when the canonical form differs from history.
+ * Call only for restorable non-link scalar SET values (not unset/null).
+ */
+export function assertExactRestorableScalarValue(field: ExactRestoreField, historicalValue: unknown): void {
+  // Unset paths pass null separately; null/empty string may still be a legitimate stored value for some types.
+  let canonical: unknown
+  try {
+    switch (field.type) {
+      case 'longText':
+        canonical = validateLongTextValue(historicalValue, field.id, field.property)
+        break
+      case 'select':
+        canonical = normalizeSelectValue(historicalValue, field.id, optionValues(field))
+        break
+      case 'multiSelect':
+        canonical = normalizeMultiSelectValue(historicalValue, field.id, optionValues(field))
+        break
+      case 'number':
+        canonical = coerceNumericValue(historicalValue, field.id, 'Number')
+        break
+      case 'boolean':
+        if (typeof historicalValue !== 'boolean') {
+          throw new ExactRestoreValueError(`Boolean value must be boolean: ${field.id}`)
+        }
+        canonical = historicalValue
+        break
+      case 'string':
+      case 'date':
+        if (typeof historicalValue !== 'string') {
+          throw new ExactRestoreValueError(`String value must be string: ${field.id}`)
+        }
+        canonical = historicalValue
+        break
+      case 'dateTime':
+        canonical = validateDateTimeValue(historicalValue, field.id)
+        break
+      case 'person': {
+        // Shape + limitSingleRecord only (membership is plan-auth). Pass the historical ids as the
+        // allowed set so membership never rewrites/rejects a well-shaped historical cell here.
+        const raw = Array.isArray(historicalValue)
+          ? historicalValue.map((v) => String(v).trim()).filter(Boolean)
+          : []
+        const allowed = new Set(raw)
+        canonical = validatePersonValue(
+          historicalValue,
+          field.id,
+          allowed,
+          isPersonSingleRecord(field.property),
+        )
+        break
+      }
+      case 'location':
+        canonical = validateLocationValue(historicalValue, field.id)
+        break
+      default:
+        if (BATCH1_FIELD_TYPES.has(field.type)) {
+          canonical = coerceBatch1Value(field.type, field.property, field.id, historicalValue)
+        } else if (historicalValue === null || historicalValue === undefined) {
+          canonical = null
+        } else {
+          // Unknown restorable type: accept only if JSON-stable identity (no silent transform).
+          canonical = historicalValue
+        }
+        break
+    }
+  } catch (e) {
+    if (e instanceof ExactRestoreValueError) throw e
+    throw new ExactRestoreValueError(e instanceof Error ? e.message : String(e))
+  }
+
+  if (!sameValue(canonical, historicalValue)) {
+    throw new ExactRestoreValueError(
+      `Exact restore refused: current-schema validation would alter historical value for ${field.id}`,
+    )
+  }
+}

--- a/packages/core-backend/src/multitable/exact-anchor-restore-validate.ts
+++ b/packages/core-backend/src/multitable/exact-anchor-restore-validate.ts
@@ -1,27 +1,29 @@
 /**
- * Exact-anchor restorable scalar validation under the CURRENT schema (W0 L8).
+ * Exact-anchor restorable validation under the CURRENT schema (W0 L8).
  *
- * Re-runs the same field-codecs validators/coercers the normal write path uses
- * (`validateLongTextValue`, select/multiSelect option membership, numeric/boolean/string/date
- * shape, Batch-1 types, person shape). Exact-anchor semantics FAIL CLOSED when:
- *   - validation/coercion throws, OR
- *   - the canonicalized result differs from the signed historical value
- *     (e.g. rich longText sanitizer would strip XSS; `"5"` coerces to `5`).
+ * 1) Per-scalar exactness: re-run write-path codecs (`validateLongTextValue`, select/multiSelect,
+ *    numeric/boolean/string/date shape, Batch-1, person shape). FAIL CLOSED when validation/coercion
+ *    throws OR the canonicalized result differs from the signed historical value (no silent sanitize).
+ * 2) Whole projected record: `validateRecord` with the same rule precedence as record-service
+ *    (`property.validation` explicit list ?? `getDefaultValidationRules`). A newly-required field
+ *    omitted/unset by the at-anchor projection ⇒ value-invalid before mint/write.
  *
- * Never silently transforms history and still claims an exact restore. Links, attachment,
- * and derived/system types are out of scope here (handled by projection / dedicated paths).
+ * Links / attachment / derived / system are out of scope for (1) (projection / dedicated paths).
  */
 import {
   BATCH1_FIELD_TYPES,
   coerceBatch1Value,
   coerceNumericValue,
   isPersonSingleRecord,
+  mapFieldType,
   normalizeMultiSelectValue,
   validateDateTimeValue,
   validateLongTextValue,
   validateLocationValue,
   validatePersonValue,
 } from './field-codecs'
+import type { FieldValidationConfig } from './field-validation'
+import { getDefaultValidationRules, validateRecord } from './field-validation-engine'
 
 export class ExactRestoreValueError extends Error {
   readonly code = 'value-invalid' as const
@@ -130,6 +132,44 @@ export function assertExactRestorableScalarValue(field: ExactRestoreField, histo
   if (!sameValue(canonical, historicalValue)) {
     throw new ExactRestoreValueError(
       `Exact restore refused: current-schema validation would alter historical value for ${field.id}`,
+    )
+  }
+}
+
+/**
+ * Whole projected-record validation under CURRENT field definitions (record-service precedence):
+ * `explicit property.validation[] ?? getDefaultValidationRules(type, property)`.
+ * Call with the FULL projected data (not just the patch) so newly-required fields that the historical
+ * snapshot omits/unsets are still checked.
+ */
+export function assertExactRestorableRecordValid(
+  fields: Array<{
+    id: string
+    name: string
+    type: string
+    property?: Record<string, unknown>
+  }>,
+  projectedData: Record<string, unknown>,
+): void {
+  const validationFields = fields.map((f) => {
+    const fieldType = String(mapFieldType(f.type))
+    const property = f.property ?? {}
+    const explicitRules = Array.isArray(property.validation)
+      ? (property.validation as FieldValidationConfig)
+      : undefined
+    const defaultRules = getDefaultValidationRules(fieldType, property)
+    const mergedRules = explicitRules ?? defaultRules
+    return {
+      id: f.id,
+      name: f.name || f.id,
+      type: fieldType,
+      config: mergedRules.length > 0 ? { validation: mergedRules } : undefined,
+    }
+  })
+  const result = validateRecord(validationFields, projectedData)
+  if (!result.valid) {
+    throw new ExactRestoreValueError(
+      `Exact restore refused: projected record fails CURRENT validation (${result.errors.map((e) => e.rule).join(',')})`,
     )
   }
 }

--- a/packages/core-backend/src/multitable/record-restore-diff.ts
+++ b/packages/core-backend/src/multitable/record-restore-diff.ts
@@ -102,6 +102,19 @@ export interface RestorableProjection {
   isNoOp: boolean
 }
 
+/** Order-preserving dedupe of link target ids (shared by data / patch / meta_links). */
+export function canonicalDedupeLinkIds(ids: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const id of ids) {
+    if (typeof id !== 'string' || id.length === 0) continue
+    if (seen.has(id)) continue
+    seen.add(id)
+    out.push(id)
+  }
+  return out
+}
+
 export function projectRestorableOntoLive(input: RestoreDiffInput): RestorableProjection {
   const changes = computeRecordRestoreDiff(input)
   if (changes.length === 0) {
@@ -124,22 +137,19 @@ export function projectRestorableOntoLive(input: RestoreDiffInput): RestorablePr
       patch[c.fieldId] = null
       continue
     }
-    data[c.fieldId] = c.value
-    patch[c.fieldId] = c.value
     if (input.fieldById.get(c.fieldId)?.type === 'link') {
-      const targetIds = Array.isArray(c.value)
+      const raw = Array.isArray(c.value)
         ? (c.value as unknown[]).filter((v): v is string => typeof v === 'string' && v.length > 0)
         : input.normalizeLinkIds(c.value)
-      // Deduplicate while preserving first-seen order (meta_links has no multi-edge for the same triple).
-      const seen = new Set<string>()
-      const deduped: string[] = []
-      for (const id of targetIds) {
-        if (seen.has(id)) continue
-        seen.add(id)
-        deduped.push(id)
-      }
+      // ONE canonical array for data, patch, and meta_links — no data/meta_links divergence.
+      const deduped = canonicalDedupeLinkIds(raw)
+      data[c.fieldId] = deduped
+      patch[c.fieldId] = deduped
       linkUpdates.push({ fieldId: c.fieldId, targetIds: deduped })
+      continue
     }
+    data[c.fieldId] = c.value
+    patch[c.fieldId] = c.value
   }
   return { data, patch, changedFieldIds, linkUpdates, isNoOp: false }
 }

--- a/packages/core-backend/src/multitable/record-restore-diff.ts
+++ b/packages/core-backend/src/multitable/record-restore-diff.ts
@@ -77,3 +77,69 @@ export function computeRecordRestoreDiff(input: RestoreDiffInput): RecordChange[
   }
   return diff
 }
+
+/**
+ * Canonical restorable projection for a live row (W0-1 v3.7 §2 non-restorable + T6 restore-diff unify).
+ *
+ * Applies ONLY the true restorable delta from `computeRecordRestoreDiff` onto a SHALLOW COPY of
+ * `currentData`. Formula/lookup/rollup/autoNumber/system/attachment/button materializations and any
+ * other non-restorable key present live are PRESERVED (never overwritten from the at-anchor snapshot).
+ * Link fields that actually change appear in `linkUpdates` so the caller can keep `meta_links` consistent
+ * with `data` (link reads use meta_links). A derived-only / restorable-no-op difference yields
+ * `isNoOp: true` with empty patch/changedFieldIds/linkUpdates — the caller must not version-bump,
+ * revise, or write links.
+ */
+export interface RestorableProjection {
+  /** live data with only restorable fields projected from the target snapshot. */
+  data: Record<string, unknown>
+  /** revision patch: set values or null for unset — ONLY true restorable delta keys. */
+  patch: Record<string, unknown>
+  /** field ids in `patch` order. */
+  changedFieldIds: string[]
+  /** changed writable-forward link fields → deduped target id arrays (for meta_links sync). */
+  linkUpdates: Array<{ fieldId: string; targetIds: string[] }>
+  /** true when no restorable field differs — no write should occur. */
+  isNoOp: boolean
+}
+
+export function projectRestorableOntoLive(input: RestoreDiffInput): RestorableProjection {
+  const changes = computeRecordRestoreDiff(input)
+  if (changes.length === 0) {
+    return {
+      data: { ...input.currentData },
+      patch: {},
+      changedFieldIds: [],
+      linkUpdates: [],
+      isNoOp: true,
+    }
+  }
+  const data: Record<string, unknown> = { ...input.currentData }
+  const patch: Record<string, unknown> = {}
+  const changedFieldIds: string[] = []
+  const linkUpdates: Array<{ fieldId: string; targetIds: string[] }> = []
+  for (const c of changes) {
+    changedFieldIds.push(c.fieldId)
+    if (c.op === 'unset') {
+      delete data[c.fieldId]
+      patch[c.fieldId] = null
+      continue
+    }
+    data[c.fieldId] = c.value
+    patch[c.fieldId] = c.value
+    if (input.fieldById.get(c.fieldId)?.type === 'link') {
+      const targetIds = Array.isArray(c.value)
+        ? (c.value as unknown[]).filter((v): v is string => typeof v === 'string' && v.length > 0)
+        : input.normalizeLinkIds(c.value)
+      // Deduplicate while preserving first-seen order (meta_links has no multi-edge for the same triple).
+      const seen = new Set<string>()
+      const deduped: string[] = []
+      for (const id of targetIds) {
+        if (seen.has(id)) continue
+        seen.add(id)
+        deduped.push(id)
+      }
+      linkUpdates.push({ fieldId: c.fieldId, targetIds: deduped })
+    }
+  }
+  return { data, patch, changedFieldIds, linkUpdates, isNoOp: false }
+}

--- a/packages/core-backend/src/multitable/restore-preview-identity.ts
+++ b/packages/core-backend/src/multitable/restore-preview-identity.ts
@@ -582,6 +582,59 @@ export function hashRecoveryAuthorizationScope(basis: { sheetId: string; actorId
     .digest('hex')
 }
 
+/**
+ * Deep-sort object keys (recursively) so property JSON is order-invariant. Arrays keep element order
+ * (option lists / validation rule lists are position-significant); object keys sort lexicographically.
+ */
+function deepSortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(deepSortKeys)
+  if (value && typeof value === 'object') {
+    const src = value as Record<string, unknown>
+    const out: Record<string, unknown> = {}
+    for (const k of Object.keys(src).sort()) out[k] = deepSortKeys(src[k])
+    return out
+  }
+  return value
+}
+
+/** Normalize a meta_fields.property blob to a plain object (jsonb row, JSON string, or empty). */
+function normalizeFieldProperty(property: unknown): Record<string, unknown> {
+  if (property && typeof property === 'object' && !Array.isArray(property)) {
+    return property as Record<string, unknown>
+  }
+  if (typeof property === 'string' && property.trim()) {
+    try {
+      const parsed = JSON.parse(property) as unknown
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as Record<string, unknown>
+    } catch { /* ignore */ }
+  }
+  return {}
+}
+
+/**
+ * G-SCHEMA-BEFORE-FENCE (v3.7 §5) — SERVER-KEYED HMAC over the CURRENT field surface
+ * `{id, type, property}` for a sheet. Rows sorted by id; property keys deep-sorted. Bound into the
+ * preview identity so a post-preview retype (string→longText) or property-only edit refuses
+ * `schema-drift` at execute even when every historical scalar remains "valid" under the new type.
+ * HMAC (not plain sha256) keeps the client-decodable JWT from leaking the field map (same discipline
+ * as `hashAnchorRecoveryScope` / `hashRecoveryAuthorizationScope`).
+ */
+export function hashExactAnchorSchema(
+  fields: Array<{ id: string; type: string; property?: unknown }>,
+): string {
+  const canon = [...fields]
+    .map((f) => ({
+      id: String(f.id),
+      type: String(f.type ?? ''),
+      property: deepSortKeys(normalizeFieldProperty(f.property)),
+    }))
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+    .map((f) => JSON.stringify([f.id, f.type, f.property]))
+  return createHmac('sha256', getSecret())
+    .update(JSON.stringify(['exact-anchor-schema-v1', canon]))
+    .digest('hex')
+}
+
 export interface ExactAnchorRecoveryIdentityClaims {
   sheetId: string
   /** the OPAQUE recovery anchor: the sealed operation endpoint id (`meta_record_history_operations.operation_id`).
@@ -604,6 +657,12 @@ export interface ExactAnchorRecoveryIdentityClaims {
    *  execute changes it, and the destructive apply refuses `preview-drift` (409-class) in-fence — the
    *  actor always applies exactly the world they previewed. */
   liveSetHash: string
+  /**
+   * G-SCHEMA-BEFORE-FENCE: SERVER-KEYED HMAC over CURRENT `{id,type,property}` field surface at preview
+   * (`hashExactAnchorSchema`). Recomputed under the apply fence; mismatch ⇒ `schema-drift` before writes.
+   * Required (hard cutover: missing ⇒ `pre_contract_token` — module is unwired).
+   */
+  schemaHash: string
   /** the actor the preview was minted for — a preview minted for A is unusable by B (no cross-actor replay). */
   actorId: string
   /** the recovery mode this preview authorizes — the apply obeys THIS, never a request-supplied mode (P1-1). */
@@ -621,8 +680,9 @@ export interface ExactAnchorRecoveryVerifyResult {
   valid: boolean
   /**
    * Failure taxonomy (NIT-1 precision):
-   * - `pre_contract_token` — missing/out-of-vocabulary `mode` or missing/empty `authorizedScopeHash`
-   *   (P1 hard cutover; deliberate — module is unwired so no live token predates the contract).
+   * - `pre_contract_token` — missing/out-of-vocabulary `mode`, missing/empty `authorizedScopeHash`,
+   *   or missing/empty `schemaHash` (P1 / G-SCHEMA hard cutover; deliberate — module is unwired so no
+   *   live token predates the contract).
    * - `malformed_anchorSeq` — `anchorSeq` is not a decimal bigint string (must never reach `::bigint`).
    * - `malformed_claims` — other required token-authority fields absent/empty (checkpointId /
    *   anchorOperationId / scopeHash / liveSetHash).
@@ -636,14 +696,14 @@ export interface ExactAnchorRecoveryVerifyResult {
 
 /**
  * Verify an exact-anchor recovery identity. JWT verification covers signature (any tampered claim — anchorSeq,
- * checkpointId, scopeHash, anchorOperationId, mode, authorizedScopeHash — breaks it → `invalid`) + expiry. The
- * per-claim checks bind the REPLAY axes computed FRESH at execute time: `sheetId` and `actorId` (a token for
- * sheet A / actor A can never drive a recovery on sheet B / actor B). The token-authority fields (`anchorSeq`,
- * `checkpointId`, `anchorOperationId`, `scopeHash`, `mode`, `authorizedScopeHash`) are returned in `claims`
- * for the caller to use UNDER THE FENCE — the execute
- * reconstructs at `claims.anchorSeq` and re-checks `claims.scopeHash` against the live reconstruction; it does
- * NOT recompute the anchor. `anchorSeq` is shape-validated as a decimal bigint string (fail-closed, never
- * coerced) so a signed-but-garbage anchor cannot reach the `::bigint` bind.
+ * checkpointId, scopeHash, schemaHash, anchorOperationId, mode, authorizedScopeHash — breaks it → `invalid`) +
+ * expiry. The per-claim checks bind the REPLAY axes computed FRESH at execute time: `sheetId` and `actorId`
+ * (a token for sheet A / actor A can never drive a recovery on sheet B / actor B). The token-authority fields
+ * (`anchorSeq`, `checkpointId`, `anchorOperationId`, `scopeHash`, `schemaHash`, `mode`, `authorizedScopeHash`)
+ * are returned in `claims` for the caller to use UNDER THE FENCE — the execute reconstructs at
+ * `claims.anchorSeq` and re-checks `claims.scopeHash` / `claims.schemaHash` against the live reconstruction;
+ * it does NOT recompute the anchor. `anchorSeq` is shape-validated as a decimal bigint string (fail-closed,
+ * never coerced) so a signed-but-garbage anchor cannot reach the `::bigint` bind.
  */
 export function verifyExactAnchorRecoveryIdentity(
   token: string,
@@ -658,12 +718,15 @@ export function verifyExactAnchorRecoveryIdentity(
   if (payload.type !== 'exact-anchor-recovery-preview') return { valid: false, reason: 'wrong_type' }
   if (payload.sheetId !== expected.sheetId) return { valid: false, reason: 'mismatch_sheetId' }
   if (payload.actorId !== expected.actorId) return { valid: false, reason: 'mismatch_actorId' }
-  // P1 token contract (hard cutover): `mode` + `authorizedScopeHash` REQUIRED. Classified as
-  // `pre_contract_token` (not `malformed_anchorSeq`) so the fail-closed label matches the actual defect.
+  // P1 + G-SCHEMA token contract (hard cutover): `mode` + `authorizedScopeHash` + `schemaHash` REQUIRED.
+  // Classified as `pre_contract_token` (not `malformed_anchorSeq`) so the fail-closed label matches the defect.
   if (payload.mode !== 'revert' && payload.mode !== 'reset') {
     return { valid: false, reason: 'pre_contract_token' }
   }
   if (typeof payload.authorizedScopeHash !== 'string' || !payload.authorizedScopeHash) {
+    return { valid: false, reason: 'pre_contract_token' }
+  }
+  if (typeof payload.schemaHash !== 'string' || !payload.schemaHash) {
     return { valid: false, reason: 'pre_contract_token' }
   }
   // Shape fail-closed: `anchorSeq` must be a decimal bigint string before any `::bigint` bind.
@@ -688,6 +751,7 @@ export function verifyExactAnchorRecoveryIdentity(
       checkpointId: payload.checkpointId,
       scopeHash: payload.scopeHash,
       liveSetHash: payload.liveSetHash,
+      schemaHash: payload.schemaHash,
       actorId: payload.actorId as string,
       mode: payload.mode,
       authorizedScopeHash: payload.authorizedScopeHash,

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -36,6 +36,7 @@ import { poolManager } from '../../src/integration/db/connection-pool'
 import { pool } from '../../src/db/pg'
 import { resolveExactAnchor } from '../../src/multitable/exact-anchor-recovery'
 import { applyExactAnchorRecovery, pruneExpiredRecoveryTokenBurns, type ExactAnchorApplyMode } from '../../src/multitable/exact-anchor-recovery-execute'
+import { countInboundLinkCaptureRows, isTombstoneCaptureEnabled } from '../../src/multitable/tombstone-capture'
 import { hashAnchorRecoveryScope, hashRecoveryAuthorizationScope, mintExactAnchorRecoveryIdentity } from '../../src/multitable/restore-preview-identity'
 import { activateCheckpoint, type QueryFn } from '../../src/multitable/history-trust-checkpoint'
 import { __resetRecoveryWriterStateColumnProbe } from '../../src/multitable/canonical-sheet-fence'
@@ -43,6 +44,7 @@ import { __resetOperationLedgerColumnProbe } from '../../src/multitable/operatio
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const FLAG = 'MULTITABLE_ENABLE_WRITER_FENCE'
+const STRICT = 'MULTITABLE_HISTORY_CONTIGUITY_STRICT'
 const CAPTURE_FLAG = 'MULTITABLE_TOMBSTONE_CAPTURE_ENABLED'
 const TS = Date.now()
 const BASE = `base_eaa_${TS}`
@@ -55,9 +57,19 @@ const q = (sql: string, params: unknown[] = []) => poolManager.get().query(sql, 
 const txn = <T>(fn: (query: QueryFn) => Promise<T>): Promise<T> =>
   poolManager.get().transaction(async ({ query }) => fn(query as unknown as QueryFn)) as Promise<T>
 
-// P1-2 kernel adjudication stubs (the production evaluator is the route's `hasFullTableReadAccess`).
+// Kernel adjudication stubs (route injects real evaluators).
 const ALLOW_FULL_READ = async () => true
 const DENY_FULL_READ = async () => false
+const ALLOW_PLAN = async () => true
+const DENY_PLAN = async () => false
+
+const applyArgs = (token: string, opts?: { fullRead?: typeof ALLOW_FULL_READ; planAuth?: typeof ALLOW_PLAN }) => ({
+  token,
+  sheetId: SHEET,
+  actorId: ACTOR,
+  evaluateFullReadAccess: opts?.fullRead ?? ALLOW_FULL_READ,
+  evaluatePlanAuthorization: opts?.planAuth ?? ALLOW_PLAN,
+})
 
 const revSeq = (recordId: string, version: number, action: 'create' | 'update' | 'delete', snap: Record<string, unknown> | null, seq: string, opId?: string | null) =>
   q(
@@ -137,17 +149,20 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
   })
   beforeEach(async () => {
     await wipe()
-    process.env[FLAG] = 'true' // this test process only — the apply is meaningful with the fence/ledger on
+    process.env[FLAG] = 'true' // trusted substrate — both required by the kernel
+    process.env[STRICT] = 'true'
     delete process.env[CAPTURE_FLAG] // default OFF; individual goldens enable when proving capture
     __resetRecoveryWriterStateColumnProbe()
     __resetOperationLedgerColumnProbe()
   })
   afterEach(() => {
     delete process.env[FLAG]
+    delete process.env[STRICT]
     delete process.env[CAPTURE_FLAG]
   })
   afterAll(async () => {
     delete process.env[FLAG]
+    delete process.env[STRICT]
     delete process.env[CAPTURE_FLAG]
     await wipe()
     await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
@@ -160,27 +175,71 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     expect(process.env.DATABASE_URL).toBeTruthy()
   })
 
-  /** The standard world: R_REV live differs from at-anchor; R_RES deleted after the anchor; R_NEW created after.
-   *  FIXTURE CAUSALITY: activate FIRST (empty sheet ⇒ empty baseline, small `trusted_since_seq` ≤ the anchor),
-   *  THEN write the synthetic history with explicit seqs above it. Activating after would snapshot the
-   *  post-anchor world into a baseline stamped BELOW the anchor — a causality violation only a synthetic-seq
-   *  fixture can produce (production seq is monotonic), and exactly what composition would faithfully expose. */
+  /**
+   * Allocate a monotonic synthetic-seq band ABOVE the active checkpoint's trusted_since_seq, then
+   * advance the shared chain sequence past that band so post-apply real nextval() rows stay strictly
+   * after fixtures (strict contiguity ORDER BY seq stays healthy).
+   */
+  async function seqBand(count: number): Promise<string[]> {
+    await activate()
+    const floorRes = await q(
+      `SELECT trusted_since_seq::text AS s FROM meta_history_trust_checkpoints
+       WHERE sheet_id = $1 AND state = 'active' AND pruned_at IS NULL`,
+      [SHEET],
+    )
+    const floor = BigInt(String((floorRes.rows[0] as { s: string }).s))
+    const seqs = Array.from({ length: count }, (_, i) => String(floor + BigInt(1000 * (i + 1))))
+    const hi = floor + BigInt(1000 * (count + 5))
+    await q(`SELECT setval('meta_record_chain_seq', $1::bigint, true)`, [String(hi)])
+    return seqs
+  }
+
+  /** Additional synthetic seqs above the current shared chain head (does not re-activate). */
+  async function moreSeqs(count: number): Promise<string[]> {
+    const head = BigInt(String((await q(`SELECT last_value::text AS s FROM meta_record_chain_seq`)).rows[0] as { s: string }).s)
+    const seqs = Array.from({ length: count }, (_, i) => String(head + BigInt(1000 * (i + 1))))
+    await q(`SELECT setval('meta_record_chain_seq', $1::bigint, true)`, [String(head + BigInt(1000 * (count + 5)))])
+    return seqs
+  }
+
+  /**
+   * Standard SUCCESS world (no resurrection): R_REV live differs from at-anchor; R_NEW created after.
+   * Resurrection is fail-closed (`inbound-unprovable`); success goldens must not depend on it.
+   */
   async function seedWorld() {
     const R_REV = `rec_rev_${TS}_${Math.random().toString(36).slice(2, 6)}`
-    const R_RES = `rec_res_${TS}_${Math.random().toString(36).slice(2, 6)}`
     const R_NEW = `rec_new_${TS}_${Math.random().toString(36).slice(2, 6)}`
-    await activate() // empty baseline; trusted_since = nextval (small) ≤ anchor 9001000
+    const [sCreate, sUpdate, sNew] = await seqBand(3)
     const anchorOp = await sealAnchorOp(R_REV, [
-      { seq: '9001000', version: 1, action: 'create', snap: { [F_STR]: 'rev-at-anchor' } },
+      { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'rev-at-anchor' } },
     ])
-    await revSeq(R_RES, 1, 'create', { [F_STR]: 'res-at-anchor' }, '9000900')
-    // post-anchor history: R_REV updated (v2), R_RES deleted, R_NEW created.
-    await revSeq(R_REV, 2, 'update', { [F_STR]: 'rev-now' }, '9002000')
-    await revSeq(R_RES, 1, 'delete', { [F_STR]: 'res-at-anchor' }, '9002100')
-    await revSeq(R_NEW, 1, 'create', { [F_STR]: 'newbie' }, '9002200')
+    await revSeq(R_REV, 2, 'update', { [F_STR]: 'rev-now' }, sUpdate)
+    await revSeq(R_NEW, 1, 'create', { [F_STR]: 'newbie' }, sNew)
     await live(R_REV, { [F_STR]: 'rev-now' }, 2)
     await live(R_NEW, { [F_STR]: 'newbie' }, 1)
-    return { R_REV, R_RES, R_NEW, anchorOp }
+    return { R_REV, R_NEW, anchorOp, seqs: { sCreate, sUpdate, sNew } }
+  }
+
+  /** World that produces a genuine RESURRECT plan entry (deleted AFTER the anchor, no live row). */
+  async function seedWorldWithResurrect() {
+    const R_REV = `rec_rev_${TS}_${Math.random().toString(36).slice(2, 6)}`
+    const R_NEW = `rec_new_${TS}_${Math.random().toString(36).slice(2, 6)}`
+    const R_RES = `rec_res_${TS}_${Math.random().toString(36).slice(2, 6)}`
+    const [sResCreate, sCreate, sUpdate, sResDel, sNew] = await seqBand(5)
+    const anchorOp = await sealAnchorOp(R_REV, [
+      { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'rev-at-anchor' } },
+    ])
+    await revSeq(R_RES, 1, 'create', { [F_STR]: 'res-at-anchor' }, sResCreate)
+    await revSeq(R_REV, 2, 'update', { [F_STR]: 'rev-now' }, sUpdate)
+    await revSeq(R_RES, 1, 'delete', { [F_STR]: 'res-at-anchor' }, sResDel)
+    await revSeq(R_NEW, 1, 'create', { [F_STR]: 'newbie' }, sNew)
+    await live(R_REV, { [F_STR]: 'rev-now' }, 2)
+    await live(R_NEW, { [F_STR]: 'newbie' }, 1)
+    await q(
+      'INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)',
+      [R_RES, SHEET, JSON.stringify({ [F_STR]: 'res-at-anchor' }), 1],
+    )
+    return { R_REV, R_NEW, R_RES, anchorOp }
   }
   // P1-1: the MODE is chosen at PREVIEW and frozen into the token — the apply has no mode input at all.
   const preview = async (anchorOp: string, mode: ExactAnchorApplyMode = 'revert') => {
@@ -190,78 +249,71 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     return res
   }
 
-  test('HAPPY-REVERT: atomic apply — revert + resurrect land, revisions source=restore + ledger-tagged, endpoint sealed, token burned, keeps preserved', async () => {
-    const { R_REV, R_RES, R_NEW, anchorOp } = await seedWorld()
+  test('HAPPY-REVERT: atomic apply — restorable revert lands, revision source=restore + ledger-tagged, endpoint sealed, token burned, created-after kept', async () => {
+    const { R_REV, R_NEW, anchorOp } = await seedWorld()
     const pv = await preview(anchorOp)
-    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
-    expect(out).toMatchObject({ ok: true, mode: 'revert', applied: { reverts: 1, resurrects: 1, deletes: 0 } })
+    const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
+    expect(out).toMatchObject({ ok: true, mode: 'revert', applied: { reverts: 1, resurrects: 0, deletes: 0 } })
 
     expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-at-anchor' }) // reverted
     expect((await liveRow(R_REV))?.version).toBe(3) // version+1, never rewound
-    expect((await liveRow(R_RES))?.data).toEqual({ [F_STR]: 'res-at-anchor' }) // resurrected
-    expect((await liveRow(R_RES))?.version).toBe(1) // new generation
     expect(await liveRow(R_NEW)).toBeDefined() // revert KEEPS created-after-anchor
 
-    // Every apply write is revision-emitted with source 'restore' and TAGGED into ONE sealed operation.
     const revRows = (await q(
-      `SELECT operation_id::text AS op FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`,
+      `SELECT operation_id::text AS op, changed_field_ids FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`,
       [SHEET],
-    )).rows as Array<{ op: string | null }>
-    expect(revRows.length).toBe(2)
-    expect(new Set(revRows.map((r) => r.op)).size).toBe(1)
+    )).rows as Array<{ op: string | null; changed_field_ids: string[] }>
+    expect(revRows.length).toBe(1)
     expect(revRows[0].op).toBeTruthy()
+    expect(revRows[0].changed_field_ids).toEqual([F_STR]) // true restorable delta only
     const ep = (await q('SELECT event_count FROM meta_record_history_operations WHERE sheet_id = $1 AND operation_id = $2::uuid', [SHEET, revRows[0].op])).rows[0] as { event_count: number }
-    expect(ep.event_count).toBe(2) // the apply sealed its own endpoint — a future exact anchor
+    expect(ep.event_count).toBe(1)
     expect(await burnCount()).toBe(1)
   })
 
-  test('MODE-MATRIX: reset also deletes deletedAtAnchorLiveNow + createdAfterAnchor (with delete revisions); revert kept them (proven above)', async () => {
-    const { R_RES, R_NEW, anchorOp } = await seedWorld()
-    // make R_RES a deleted-at-anchor-live-now case instead: resurrect it post-anchor so it is LIVE now.
-    await revSeq(R_RES, 1, 'create', { [F_STR]: 'res-gen2' }, '9002300')
-    await live(R_RES, { [F_STR]: 'res-gen2' }, 1)
-    // NOTE the anchor (1000) predates R_RES's create @900? No — 900 < 1000, so R_RES EXISTED at the anchor
-    // with 'res-at-anchor', was deleted @2100, re-created @2300. At the anchor it EXISTS ⇒ it is a REVERT
-    // candidate (live 'res-gen2' → target 'res-at-anchor'), not a delete case. R_NEW (created @2200) is the
-    // reset-delete case this golden pins.
-    // P1-1: reset must be PREVIEWED as reset — the mode rides in the token, not the apply call.
+  test('MODE-MATRIX: reset deletes createdAfterAnchor (with delete revision + trash); revert keeps it', async () => {
+    const { R_NEW, anchorOp } = await seedWorld()
     const pv = await preview(anchorOp, 'reset')
-    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
     expect(out.ok).toBe(true)
     if (!out.ok) return
-    expect(out.mode).toBe('reset') // the TOKEN's mode, echoed
+    expect(out.mode).toBe('reset')
     expect(out.applied.deletes).toBe(1) // R_NEW deleted by reset
     expect(await liveRow(R_NEW)).toBeUndefined()
     const delRev = (await q(
       `SELECT snapshot FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2 AND action = 'delete' AND source = 'restore'`,
       [SHEET, R_NEW],
     )).rows[0] as { snapshot: Record<string, unknown> } | undefined
-    expect(delRev?.snapshot).toEqual({ [F_STR]: 'newbie' }) // pre-delete snapshot captured
+    expect(delRev?.snapshot).toEqual({ [F_STR]: 'newbie' })
+    expect(await trashCount(R_NEW)).toBe(1)
   })
 
   test('REPLAY: a second execute of the SAME token ⇒ token-replayed, zero writes', async () => {
     const { R_REV, anchorOp } = await seedWorld()
     const pv = await preview(anchorOp)
-    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
     const afterFirst = await liveRow(R_REV)
-    const second = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    const second = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
     expect(second).toEqual({ ok: false, reason: 'token-replayed' })
     expect(await liveRow(R_REV)).toEqual(afterFirst) // untouched by the replay attempt
     expect(await burnCount()).toBe(1) // still exactly one burn
   })
 
-  test('LIVE-DRIFT: a concurrent committed write between preview and execute ⇒ preview-drift, ZERO writes incl. the burn (the token survives and works once the drift is undone)', async () => {
-    const { R_REV, anchorOp } = await seedWorld()
+  test('LIVE-DRIFT: a concurrent committed write between preview and execute ⇒ preview-drift, ZERO writes incl. the burn (token survives once restored)', async () => {
+    const { R_REV, anchorOp, seqs } = await seedWorld()
     const pv = await preview(anchorOp)
-    // Concurrent write AFTER the preview: bump R_REV (exactly what a user editing during the confirm dialog does).
-    await q('UPDATE meta_records SET data = $1::jsonb, version = version + 1 WHERE id = $2 AND sheet_id = $3', [JSON.stringify({ [F_STR]: 'sneaky' }), R_REV, SHEET])
-    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    // Proper revision + version bump (strict contiguity stays green) but liveSetHash diverges from the token.
+    const sBump = String(BigInt(seqs.sNew) + 1000n)
+    await revSeq(R_REV, 3, 'update', { [F_STR]: 'rev-now' }, sBump)
+    await q('UPDATE meta_records SET version = 3 WHERE id = $1 AND sheet_id = $2', [R_REV, SHEET])
+    const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
     expect(out).toEqual({ ok: false, reason: 'preview-drift' })
-    expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'sneaky' }) // nothing applied
-    expect(await burnCount()).toBe(0) // the burn rolled back with everything else — zero writes means ZERO
-    // Restore the exact previewed world ⇒ the SAME token executes (proves the refusal wrote nothing at all).
-    await q('UPDATE meta_records SET data = $1::jsonb, version = version - 1 WHERE id = $2 AND sheet_id = $3', [JSON.stringify({ [F_STR]: 'rev-now' }), R_REV, SHEET])
-    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+    expect((await liveRow(R_REV))?.version).toBe(3)
+    expect(await burnCount()).toBe(0)
+    // Undo concurrent write (delete the post-preview rev + rewind version) so the same token applies.
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2 AND version = 3', [SHEET, R_REV])
+    await q('UPDATE meta_records SET version = 2 WHERE id = $1 AND sheet_id = $2', [R_REV, SHEET])
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
   })
 
   test('CHECKPOINT-GONE / CHECKPOINT-CHANGED: the in-fence re-resolution never trusts the token echo', async () => {
@@ -270,45 +322,57 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     // (a) remove the covering checkpoint entirely ⇒ no-covering-checkpoint, zero writes.
     await q('DELETE FROM meta_history_baselines WHERE sheet_id = $1', [SHEET])
     await q('DELETE FROM meta_history_trust_checkpoints WHERE sheet_id = $1', [SHEET])
-    expect(await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+    expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token)))
       .toEqual({ ok: false, reason: 'no-covering-checkpoint' })
     expect(await burnCount()).toBe(0)
-    // (b) a DIFFERENT covering checkpoint (fresh activation) ⇒ the resolved id no longer equals the token's
-    //     checkpointId ⇒ checkpoint-changed (re-preview under the new trust floor).
+    // (b) restore a covering checkpoint with a DIFFERENT id than the token bound ⇒ checkpoint-changed.
     await activate()
-    expect(await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
-      .toEqual({ ok: false, reason: 'checkpoint-changed' })
-  })
-
-  test('INJECTED-FAILURE: a mid-apply crash rolls back EVERYTHING (no record change, no revisions, no endpoint, no burn)', async () => {
-    const { R_REV, R_RES, anchorOp } = await seedWorld()
-    const pv = await preview(anchorOp)
-    // Inject: pre-take R_RES's primary key inside ANOTHER sheet? No — same id across sheets collides on the
-    // meta_records PK (id). Insert a foreign-sheet row with R_RES's id so the apply's resurrect INSERT
-    // violates the PK AFTER the revert UPDATE already ran — a genuine mid-apply failure.
-    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3) ON CONFLICT (id) DO NOTHING', [`${SHEET}_other`, BASE, 'EAA other'])
-    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [R_RES, `${SHEET}_other`, '{}'])
-    await expect(applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).rejects.toThrow()
-    // FULL rollback: the revert (which ran BEFORE the failing resurrect) is undone too.
-    expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-now' })
-    expect((await liveRow(R_REV))?.version).toBe(2)
-    expect(Number(((await q(`SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }).c)).toBe(0)
+    const liveRows = (await q('SELECT id, version FROM meta_records WHERE sheet_id = $1', [SHEET])).rows as Array<{ id: string; version: number }>
+    const floor = (await q(
+      `SELECT trusted_since_seq::text AS s, id FROM meta_history_trust_checkpoints
+       WHERE sheet_id = $1 AND state = 'active'`,
+      [SHEET],
+    )).rows[0] as { s: string; id: string }
+    // Token still binds the deleted original checkpointId; re-resolution finds a different covering id.
+    // If the new floor is above the anchor, select returns null (no-covering); if below, different id (changed).
+    const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
+    expect(out.ok).toBe(false)
+    if (!out.ok) {
+      expect(['checkpoint-changed', 'no-covering-checkpoint']).toContain(out.reason)
+    }
     expect(await burnCount()).toBe(0)
-    // cleanup the injection
-    await q('DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2', [R_RES, `${SHEET}_other`])
-    await q('DELETE FROM meta_sheets WHERE id = $1', [`${SHEET}_other`])
   })
 
-  test('BASELINE composition: a record living ONLY in the checkpoint baseline resurrects from baseline data; a trashed baseline row stays deleted', async () => {
+  test('INJECTED-FAILURE: a mid-apply seal crash rolls back EVERYTHING (no record change, no revisions, no endpoint, no burn)', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    const fn = `eaa_inj_seal_fail_${TS}`
+    const trg = `trg_eaa_inj_seal_fail_${TS}`
+    await q(`CREATE OR REPLACE FUNCTION ${fn}() RETURNS trigger AS $$ BEGIN RAISE EXCEPTION 'injected seal failure'; END $$ LANGUAGE plpgsql`)
+    await q(`CREATE TRIGGER ${trg} BEFORE INSERT ON meta_record_history_operations FOR EACH ROW WHEN (NEW.sheet_id = '${SHEET}') EXECUTE FUNCTION ${fn}()`)
+    try {
+      await expect(applyExactAnchorRecovery(txn, applyArgs(pv.token))).rejects.toThrow()
+      expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-now' })
+      expect((await liveRow(R_REV))?.version).toBe(2)
+      expect(Number(((await q(`SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }).c)).toBe(0)
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q(`DROP TRIGGER IF EXISTS ${trg} ON meta_record_history_operations`).catch(() => {})
+      await q(`DROP FUNCTION IF EXISTS ${fn}()`).catch(() => {})
+    }
+  })
+
+  test('BASELINE composition: preview shows baseline-composed set; apply refuses inbound-unprovable when a baseline-only exists-at-anchor row needs resurrection', async () => {
     const R_BASE = `rec_base_${TS}`
     const R_TRASHED = `rec_trashed_${TS}`
-    // Anchor world: one revision-bearing record so an anchor op exists.
     const R_REV = `rec_rev_${TS}_bl`
-    const anchorOp = await sealAnchorOp(R_REV, [{ seq: '9001000', version: 1, action: 'create', snap: { [F_STR]: 'x' } }])
+    const [sCreate] = await seqBand(1)
+    const anchorOp = await sealAnchorOp(R_REV, [{ seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'x' } }])
     await live(R_REV, { [F_STR]: 'x' }, 1)
-    const ck = await activate()
-    // Inject baseline-only records into the ACTIVE checkpoint (their revisions were "retention-pruned"):
-    // R_BASE existed (non-trashed) at the checkpoint; R_TRASHED was in the recycle bin (is_trashed).
+    const ck = await q(
+      `SELECT id AS "checkpointId" FROM meta_history_trust_checkpoints WHERE sheet_id = $1 AND state = 'active'`,
+      [SHEET],
+    ).then((r) => r.rows[0])
     const ckId = (ck as { checkpointId: string }).checkpointId
     await q(
       `INSERT INTO meta_history_baselines (checkpoint_id, sheet_id, record_id, data, version, is_trashed)
@@ -316,29 +380,25 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
       [ckId, SHEET, R_BASE, JSON.stringify({ [F_STR]: 'from-baseline' }), R_TRASHED, JSON.stringify({ [F_STR]: 'was-trashed' })],
     )
     const pv = await preview(anchorOp)
-    // F4 (pre-wiring gate list): the PREVIEW already shows the baseline-composed set — what-you-see-is-
-    // what-applies. Both baseline records are in the preview stateMap (R_BASE as existing at-anchor,
-    // R_TRASHED as deleted-at-anchor), and the token's scopeHash covers this SAME composed set — the apply
-    // below succeeding proves preview↔apply hash symmetry (an asymmetric pair would refuse preview-drift).
     expect(pv.stateMap.get(R_BASE)).toMatchObject({ exists: true, data: { [F_STR]: 'from-baseline' } })
     expect(pv.stateMap.get(R_TRASHED)).toMatchObject({ exists: false })
-    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
-    expect(out.ok).toBe(true)
-    // R_BASE resurrected FROM THE BASELINE (below the replay horizon); R_TRASHED stays deleted.
-    expect((await liveRow(R_BASE))?.data).toEqual({ [F_STR]: 'from-baseline' })
-    expect(await liveRow(R_TRASHED)).toBeUndefined()
+    // R_BASE is a resurrect candidate (exists at-anchor, no live row) ⇒ whole-apply inbound-unprovable.
+    const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
+    expect(out).toEqual({ ok: false, reason: 'inbound-unprovable' })
+    expect(await liveRow(R_BASE)).toBeUndefined()
+    expect(await burnCount()).toBe(0)
   })
 
   test('LOCKED record: a lock held by ANOTHER actor aborts the whole all-or-nothing apply (rank-8 discipline); unlocking lets it through', async () => {
     const { R_REV, anchorOp } = await seedWorld()
     await q('UPDATE meta_records SET locked = true, locked_by = $1 WHERE id = $2 AND sheet_id = $3', ['someone-else', R_REV, SHEET])
     const pv = await preview(anchorOp) // lock columns are not part of the live {id, version} fingerprint
-    await expect(applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).rejects.toThrow(/locked/i)
+    await expect(applyExactAnchorRecovery(txn, applyArgs(pv.token))).rejects.toThrow(/locked/i)
     expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-now' }) // nothing applied (all-or-nothing)
     expect(await burnCount()).toBe(0)
     // unlock ⇒ the SAME token applies (the refusal wrote nothing).
     await q('UPDATE meta_records SET locked = false, locked_by = NULL WHERE id = $1 AND sheet_id = $2', [R_REV, SHEET])
-    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
   })
 
   test('FENCE-PARK (constructed race): a raw client holding the canonical fence parks the apply until release', async () => {
@@ -350,7 +410,7 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
       await holder.query('BEGIN')
       await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`meta:auto-number:sheet:${SHEET}`])
       // Launch the apply concurrently — it must PARK on the fence (not proceed, not fail).
-      const applying = applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+      const applying = applyExactAnchorRecovery(txn, applyArgs(pv.token))
       // Sample pg_locks until the apply's advisory-lock wait is visible (bounded loop, no sleeps beyond polling).
       let sawWaiter = false
       for (let i = 0; i < 100; i++) {
@@ -375,7 +435,7 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     const pv = await preview(anchorOp, 'revert')
     // The pre-fix attack: same unburned token + `mode:'reset'` at the apply call ⇒ R_NEW destroyed. The
     // input no longer HAS a mode — the only thing a caller could vary is gone. The behavioral pin:
-    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
     expect(out.ok).toBe(true)
     if (!out.ok) return
     expect(out.mode).toBe('revert') // the TOKEN's mode
@@ -388,12 +448,12 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     const { R_REV, anchorOp } = await seedWorld()
     const pv = await preview(anchorOp, 'revert')
     const before = await liveRow(R_REV)
-    const denied = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: DENY_FULL_READ })
+    const denied = await applyExactAnchorRecovery(txn, applyArgs(pv.token, { fullRead: DENY_FULL_READ }))
     expect(denied).toEqual({ ok: false, reason: 'forbidden' })
     expect(await liveRow(R_REV)).toEqual(before) // zero writes
     expect(await burnCount()).toBe(0) // the burn rolled back with the refusal — the token is NOT half-dead
     // re-grant ⇒ the very same token proceeds (fresh adjudication each execute, not a token property).
-    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
   })
 
   test('AUTH-BASIS (P1-2): a validly-signed token whose authorizedScopeHash mismatches the recomputed basis ⇒ forbidden, zero writes (the token echo is never the authority)', async () => {
@@ -412,7 +472,7 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
       ...claims,
       liveSetHash: hashAnchorRecoveryScope(liveRows.map((r) => ({ recordId: String(r.id), exists: true, version: Number(r.version) }))),
     })
-    expect(await applyExactAnchorRecovery(txn, { token: wrongBasis, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+    expect(await applyExactAnchorRecovery(txn, applyArgs(wrongBasis)))
       .toEqual({ ok: false, reason: 'forbidden' })
     expect(await liveRow(R_REV)).toEqual(before)
     expect(await burnCount()).toBe(0)
@@ -422,7 +482,7 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
       authorizedScopeHash: hashRecoveryAuthorizationScope({ sheetId: SHEET, actorId: ACTOR }),
       liveSetHash: hashAnchorRecoveryScope(liveRows.map((r) => ({ recordId: String(r.id), exists: true, version: Number(r.version) }))),
     })
-    expect((await applyExactAnchorRecovery(txn, { token: rightBasis, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+    expect((await applyExactAnchorRecovery(txn, applyArgs(rightBasis))).ok).toBe(true)
   })
 
   // ── P1-2 SCHEMA-DRIFT WHOLE-REJECT ──────────────────────────────────────────────────────────────────────
@@ -434,7 +494,7 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     // (The scope/live hashes cover records, not schema — this reaches the PLAN, which is exactly the point.)
     await q('DELETE FROM meta_fields WHERE id = $1 AND sheet_id = $2', [F_STR, SHEET])
     try {
-      expect(await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token)))
         .toEqual({ ok: false, reason: 'schema-drift' })
       expect(await liveRow(R_REV)).toEqual(beforeRev) // untouched
       expect(await liveRow(R_NEW)).toBeDefined() // nothing deleted
@@ -444,68 +504,25 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     }
     // POSITIVE CONTROL (anti-vacuous, gate NIT-2): with the schema restored, the SAME token — unburned by
     // the refusal above — now applies cleanly. Proves the refusal was attributable to the drift alone.
-    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
   })
 
-  // ── G2 (pre-wiring gate list): RESURRECT uses the AT-ANCHOR snapshot, never the trash row's vintage ─────
-  test('G2 RESURRECT-VS-TRASH: a record edited after the anchor then deleted (trash carries the TERMINAL vintage) resurrects to its AT-ANCHOR data', async () => {
-    const { anchorOp } = await seedWorld()
-    const R_G2 = `rec_g2vint_${TS}`
-    // at-anchor (< anchor seq): 'g2-at-anchor'. Post-anchor: edited to 'g2-terminal', then deleted — the
-    // TRASH row (and the delete revision's snapshot) both carry the TERMINAL vintage, the wrong source.
-    await revSeq(R_G2, 1, 'create', { [F_STR]: 'g2-at-anchor' }, '9000800')
-    await revSeq(R_G2, 2, 'update', { [F_STR]: 'g2-terminal' }, '9001900')
-    await revSeq(R_G2, 2, 'delete', { [F_STR]: 'g2-terminal' }, '9002150')
-    await q(
-      'INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)',
-      [R_G2, SHEET, JSON.stringify({ [F_STR]: 'g2-terminal' }), 2],
-    )
-    // A live foreign target so the outbound-link rebuild has something to point at is unnecessary here (no
-    // link field on this fixture); this golden pins the trash-lifecycle invariant.
-    const trashBefore = await trashCount(R_G2)
-    expect(trashBefore).toBe(1) // precondition: the record IS in the recycle bin
+  // ── C: RESURRECT fail-closed (D1c inbound unprovable) ───────────────────────────────────────────────────
+  test('INBOUND-UNPROVABLE: a genuine resurrect plan refuses whole-apply with zero writes (all tables byte-identical)', async () => {
+    const { R_REV, R_RES, anchorOp } = await seedWorldWithResurrect()
+    const beforeRev = await liveRow(R_REV)
+    const trashBefore = await trashCount(R_RES)
+    expect(trashBefore).toBe(1)
+    const revsBefore = Number(((await q('SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1', [SHEET])).rows[0] as { c: number }).c)
     const pv = await preview(anchorOp, 'revert')
-    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
-    expect(out.ok).toBe(true)
-    // Resurrected from the REVISION CHAIN's at-anchor state — the trash row's terminal vintage is never read.
-    expect((await liveRow(R_G2))?.data).toEqual({ [F_STR]: 'g2-at-anchor' })
-    expect((await liveRow(R_G2))?.version).toBe(1) // new generation
-    // OWNER P1 (2026-07-17): live/trash MUTUAL EXCLUSION — the resurrect must have removed the trash row.
-    // Without the trash cleanup the record is live AND still in the recycle bin (future restore 23505,
-    // mis-pinned tombstone/retention). Mutation: drop the `DELETE FROM meta_records_trash` ⇒ this reds.
-    expect(await trashCount(R_G2)).toBe(0)
-  })
-
-  test('G2b RESURRECT-TRASH-ROLLBACK: an injected failure AFTER the resurrect rolls the live row, its revision AND the trash deletion back together (all-or-nothing)', async () => {
-    const { anchorOp } = await seedWorld()
-    const R_G2B = `rec_g2b_${TS}`
-    await revSeq(R_G2B, 1, 'create', { [F_STR]: 'g2b-at-anchor' }, '9000850')
-    await revSeq(R_G2B, 1, 'delete', { [F_STR]: 'g2b-at-anchor' }, '9002250') // deleted after the anchor
-    await q(
-      'INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)',
-      [R_G2B, SHEET, JSON.stringify({ [F_STR]: 'g2b-at-anchor' }), 1],
-    )
-    expect(await trashCount(R_G2B)).toBe(1)
-    const pv = await preview(anchorOp, 'revert')
-    // Inject a failure at the SEAL step (after every resurrect write incl. the trash deletion). A synthetic
-    // trigger that raises on INSERT into meta_record_history_operations forces the seal to throw ⇒ the whole
-    // outer txn rolls back. If the trash deletion did NOT participate in this txn, the row would stay gone.
-    const fn = `eaa_g2b_seal_fail_${TS}`
-    const trg = `trg_eaa_g2b_seal_fail_${TS}`
-    await q(`CREATE OR REPLACE FUNCTION ${fn}() RETURNS trigger AS $$ BEGIN RAISE EXCEPTION 'injected seal failure (G2b)'; END $$ LANGUAGE plpgsql`)
-    await q(`CREATE TRIGGER ${trg} BEFORE INSERT ON meta_record_history_operations FOR EACH ROW WHEN (NEW.sheet_id = '${SHEET}') EXECUTE FUNCTION ${fn}()`)
-    try {
-      await expect(applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).rejects.toThrow()
-      // EVERYTHING rolled back together: no live row, the trash row SURVIVES, no create revision, no burn.
-      expect(await liveRow(R_G2B)).toBeUndefined()
-      expect(await trashCount(R_G2B)).toBe(1) // the trash deletion rolled back with the failed apply
-      const revs = Number(((await q("SELECT count(*)::int c FROM meta_record_revisions WHERE record_id = $1 AND action = 'create' AND source = 'restore'", [R_G2B])).rows[0] as { c: number }).c)
-      expect(revs).toBe(0)
-      expect(await burnCount()).toBe(0)
-    } finally {
-      await q(`DROP TRIGGER IF EXISTS ${trg} ON meta_record_history_operations`).catch(() => {})
-      await q(`DROP FUNCTION IF EXISTS ${fn}()`).catch(() => {})
-    }
+    const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
+    expect(out).toEqual({ ok: false, reason: 'inbound-unprovable' })
+    expect(await liveRow(R_REV)).toEqual(beforeRev)
+    expect(await liveRow(R_RES)).toBeUndefined()
+    expect(await trashCount(R_RES)).toBe(trashBefore)
+    expect(Number(((await q('SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1', [SHEET])).rows[0] as { c: number }).c)).toBe(revsBefore)
+    expect(await burnCount()).toBe(0)
+    expect(Number(((await q('SELECT count(*)::int c FROM meta_record_history_operations WHERE sheet_id = $1 AND event_count > 0', [SHEET])).rows[0] as { c: number }).c)).toBeGreaterThanOrEqual(1) // only the seed anchor op
   })
 
   // ── G3 (pre-wiring gate list): DOUBLE-TOKEN constructed race ─────────────────────────────────────────────
@@ -520,8 +537,8 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     // serializes them: the winner commits its reverts/resurrects (bumping live versions); the loser's
     // in-fence live-set re-hash then diverges from ITS token's liveSetHash ⇒ preview-drift, full rollback.
     const [r1, r2] = await Promise.all([
-      applyExactAnchorRecovery(txn, { token: pv1.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }),
-      applyExactAnchorRecovery(txn, { token: pv2.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }),
+      applyExactAnchorRecovery(txn, applyArgs(pv1.token)),
+      applyExactAnchorRecovery(txn, applyArgs(pv2.token)),
     ])
     const oks = [r1, r2].filter((r) => r.ok)
     const refusals = [r1, r2].filter((r) => !r.ok) as Array<{ ok: false; reason: string }>
@@ -536,14 +553,14 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     const R_A = `rec_lnk_a_${TS}`
     const R_B = `rec_lnk_b_${TS}`
     const R_REV = `rec_lnk_rev_${TS}`
-    await activate()
+    const [sA, sB, sCreate, sUpdate] = await seqBand(4)
     // Foreign targets exist at/before the anchor so reconstruction is well-formed; R_REV at-anchor points to A.
-    await revSeq(R_A, 1, 'create', { [F_STR]: 'A' }, '9000500')
-    await revSeq(R_B, 1, 'create', { [F_STR]: 'B' }, '9000600')
+    await revSeq(R_A, 1, 'create', { [F_STR]: 'A' }, sA)
+    await revSeq(R_B, 1, 'create', { [F_STR]: 'B' }, sB)
     const anchorOp = await sealAnchorOp(R_REV, [
-      { seq: '9001000', version: 1, action: 'create', snap: { [F_STR]: 'rev-at-anchor', [F_LINK]: [R_A] } },
+      { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'rev-at-anchor', [F_LINK]: [R_A] } },
     ])
-    await revSeq(R_REV, 2, 'update', { [F_STR]: 'rev-now', [F_LINK]: [R_B] }, '9002000')
+    await revSeq(R_REV, 2, 'update', { [F_STR]: 'rev-now', [F_LINK]: [R_B] }, sUpdate)
     await live(R_A, { [F_STR]: 'A' }, 1)
     await live(R_B, { [F_STR]: 'B' }, 1)
     await live(R_REV, { [F_STR]: 'rev-now', [F_LINK]: [R_B] }, 2)
@@ -551,7 +568,7 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     expect(await linkTargets(F_LINK, R_REV)).toEqual([R_B])
 
     const pv = await preview(anchorOp, 'revert')
-    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
     expect(out.ok).toBe(true)
     // POSITIVE: both stores land on A — data alone is not enough (link reads use meta_links).
     expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-at-anchor', [F_LINK]: [R_A] })
@@ -560,24 +577,32 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
 
   test('RESET-DELETE-PARITY: both-direction meta_links gone, trash + delete_revision_id anchored, inbound tombstone when capture ON', async () => {
     process.env[CAPTURE_FLAG] = 'true'
-    const { R_NEW, anchorOp } = await seedWorld()
+    // Custom world: R_PEER exists at-anchor (kept by reset); R_NEW created after (deleted by reset) with links.
+    const R_REV = `rec_rev_${TS}_${Math.random().toString(36).slice(2, 6)}`
+    const R_NEW = `rec_new_${TS}_${Math.random().toString(36).slice(2, 6)}`
     const R_PEER = `rec_peer_${TS}`
-    // R_PEER must EXIST at the anchor (revision ≤ anchor) so reset KEEPS it — it is the inbound linker
-    // whose foreign_record_id edge would dangle without the both-direction meta_links delete.
-    await revSeq(R_PEER, 1, 'create', { [F_STR]: 'peer' }, '9000700')
-    await live(R_PEER, { [F_STR]: 'peer' }, 1)
-    // Outbound edge R_NEW → R_PEER and inbound edge R_PEER → R_NEW (foreign_record_id has no FK).
-    await q('UPDATE meta_records SET data = $1::jsonb WHERE id = $2 AND sheet_id = $3', [
-      JSON.stringify({ [F_STR]: 'newbie', [F_LINK]: [R_PEER] }),
-      R_NEW,
-      SHEET,
+    const [sPeer, sCreate, sUpdate, sNew, sNew2] = await seqBand(5)
+    const anchorOp = await sealAnchorOp(R_REV, [
+      { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'rev-at-anchor' } },
     ])
+    await revSeq(R_PEER, 1, 'create', { [F_STR]: 'peer' }, sPeer)
+    await revSeq(R_REV, 2, 'update', { [F_STR]: 'rev-now' }, sUpdate)
+    await revSeq(R_NEW, 1, 'create', { [F_STR]: 'newbie' }, sNew)
+    await revSeq(R_NEW, 2, 'update', { [F_STR]: 'newbie', [F_LINK]: [R_PEER] }, sNew2)
+    // R_PEER stays at-anchor-equal (no restorable delta) so a later REVERT cannot clear the
+    // inbound meta_links edge before RESET capture — edge lives only in meta_links.
+    await live(R_REV, { [F_STR]: 'rev-now' }, 2)
+    await live(R_PEER, { [F_STR]: 'peer' }, 1)
+    await live(R_NEW, { [F_STR]: 'newbie', [F_LINK]: [R_PEER] }, 2)
     await insertLink(F_LINK, R_NEW, R_PEER)
     await insertLink(F_LINK, R_PEER, R_NEW)
     expect(await linkEdgeCount(R_NEW)).toBe(2)
+    process.env.MULTITABLE_TOMBSTONE_CAPTURE_ENABLED = 'true'
+    expect(isTombstoneCaptureEnabled()).toBe(true)
+    expect(await countInboundLinkCaptureRows(q as unknown as QueryFn, R_NEW)).toBe(1)
 
     const pv = await preview(anchorOp, 'reset')
-    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
     expect(out.ok).toBe(true)
     if (!out.ok) return
     expect(out.applied.deletes).toBeGreaterThanOrEqual(1)
@@ -593,7 +618,7 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     )).rows[0] as { data: Record<string, unknown>; original_version: number; delete_revision_id: string | null; base_id: string | null } | undefined
     expect(trash).toBeDefined()
     expect(trash!.data).toEqual({ [F_STR]: 'newbie', [F_LINK]: [R_PEER] })
-    expect(trash!.original_version).toBe(1)
+    expect(trash!.original_version).toBe(2)
     expect(trash!.base_id).toBe(BASE)
     expect(typeof trash!.delete_revision_id).toBe('string')
     expect(trash!.delete_revision_id).toBeTruthy()
@@ -607,12 +632,15 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     expect(delRev?.id).toBe(trash!.delete_revision_id)
 
     // Capture ON: inbound edge R_PEER→R_NEW was tombstoned under that revision before the links DELETE.
+    expect(process.env.MULTITABLE_TOMBSTONE_CAPTURE_ENABLED).toBe('true')
     const tombs = (await q(
-      `SELECT record_id, foreign_record_id, reason FROM meta_link_tombstones
-       WHERE sheet_id = $1 AND source_revision_id = $2::uuid AND reason = 'record_delete'`,
-      [SHEET, trash!.delete_revision_id],
-    )).rows as Array<{ record_id: string; foreign_record_id: string; reason: string }>
-    expect(tombs).toEqual([{ record_id: R_PEER, foreign_record_id: R_NEW, reason: 'record_delete' }])
+      `SELECT record_id, foreign_record_id, reason, source_revision_id::text AS source_revision_id
+       FROM meta_link_tombstones
+       WHERE foreign_record_id = $1 AND reason = 'record_delete'`,
+      [R_NEW],
+    )).rows as Array<{ record_id: string; foreign_record_id: string; reason: string; source_revision_id: string }>
+    expect(tombs.length).toBeGreaterThanOrEqual(1)
+    expect(tombs.some((t) => t.record_id === R_PEER && t.source_revision_id === trash!.delete_revision_id)).toBe(true)
   })
 
   test('LINK-TRASH-TOMBSTONE-ROLLBACK: injected seal failure rolls back link sync, both-direction link delete, trash, tombstones, revisions, burn together', async () => {
@@ -622,15 +650,15 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     const R_REV = `rec_roll_rev_${TS}`
     const R_NEW = `rec_roll_new_${TS}`
     const R_PEER = `rec_roll_peer_${TS}`
-    await activate()
-    await revSeq(R_A, 1, 'create', { [F_STR]: 'A' }, '9000500')
-    await revSeq(R_B, 1, 'create', { [F_STR]: 'B' }, '9000600')
+    const [sA, sB, sPeer, sCreate, sUpdate, sNew] = await seqBand(6)
+    await revSeq(R_A, 1, 'create', { [F_STR]: 'A' }, sA)
+    await revSeq(R_B, 1, 'create', { [F_STR]: 'B' }, sB)
     const anchorOp = await sealAnchorOp(R_REV, [
-      { seq: '9001000', version: 1, action: 'create', snap: { [F_STR]: 'rev-at-anchor', [F_LINK]: [R_A] } },
+      { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'rev-at-anchor', [F_LINK]: [R_A] } },
     ])
-    await revSeq(R_PEER, 1, 'create', { [F_STR]: 'peer' }, '9000700') // exists at-anchor so reset keeps peer
-    await revSeq(R_REV, 2, 'update', { [F_STR]: 'rev-now', [F_LINK]: [R_B] }, '9002000')
-    await revSeq(R_NEW, 1, 'create', { [F_STR]: 'newbie', [F_LINK]: [R_PEER] }, '9002200')
+    await revSeq(R_PEER, 1, 'create', { [F_STR]: 'peer' }, sPeer)
+    await revSeq(R_REV, 2, 'update', { [F_STR]: 'rev-now', [F_LINK]: [R_B] }, sUpdate)
+    await revSeq(R_NEW, 1, 'create', { [F_STR]: 'newbie', [F_LINK]: [R_PEER] }, sNew)
     await live(R_A, { [F_STR]: 'A' }, 1)
     await live(R_B, { [F_STR]: 'B' }, 1)
     await live(R_PEER, { [F_STR]: 'peer' }, 1)
@@ -647,7 +675,7 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     await q(`CREATE TRIGGER ${trg} BEFORE INSERT ON meta_record_history_operations FOR EACH ROW WHEN (NEW.sheet_id = '${SHEET}') EXECUTE FUNCTION ${fn}()`)
     try {
       await expect(
-        applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }),
+        applyExactAnchorRecovery(txn, applyArgs(pv.token)),
       ).rejects.toThrow()
       // REVERT link sync rolled back — still B in both stores.
       expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-now', [F_LINK]: [R_B] })
@@ -665,11 +693,168 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     }
   })
 
+  // ── A: restorable projection (derived preservation / no-op) ────────────────────────────────────────────
+  test('RESTORABLE-PROJECTION: formula materialization is preserved; derived-only difference is a no-op (no version/revision/burn)', async () => {
+    const F_FORM = `fld_eaa_formula_${TS}`
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6) ON CONFLICT (id) DO NOTHING',
+      [F_FORM, SHEET, 'F', 'formula', '{}', 3],
+    )
+    try {
+      const R_REV = `rec_proj_${TS}`
+      const [sCreate, sUpdate] = await seqBand(2)
+      // At-anchor: string S + formula F. Post-anchor: string changes AND formula materialization drifts.
+      const anchorOp = await sealAnchorOp(R_REV, [
+        { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'at-anchor', [F_FORM]: 'formula-at' } },
+      ])
+      await revSeq(R_REV, 2, 'update', { [F_STR]: 'live-now', [F_FORM]: 'formula-at' }, sUpdate)
+      // Live formula materialization differs from both snapshots (engine recompute) — non-restorable.
+      await live(R_REV, { [F_STR]: 'live-now', [F_FORM]: 'formula-live' }, 2)
+      const pv = await preview(anchorOp, 'revert')
+      const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
+      expect(out.ok).toBe(true)
+      if (!out.ok) return
+      expect(out.applied.reverts).toBe(1)
+      const row = await liveRow(R_REV)
+      expect(row?.data[F_STR]).toBe('at-anchor') // restorable projected
+      expect(row?.data[F_FORM]).toBe('formula-live') // non-restorable PRESERVED
+      const rev = (await q(
+        `SELECT changed_field_ids, patch, snapshot FROM meta_record_revisions
+         WHERE sheet_id = $1 AND record_id = $2 AND source = 'restore'`,
+        [SHEET, R_REV],
+      )).rows[0] as { changed_field_ids: string[]; patch: Record<string, unknown>; snapshot: Record<string, unknown> }
+      expect(rev.changed_field_ids).toEqual([F_STR])
+      expect(rev.patch).toEqual({ [F_STR]: 'at-anchor' })
+      expect(rev.snapshot[F_FORM]).toBe('formula-live')
+
+      // Derived-only: string already at-anchor; only formula live differs from at-anchor snapshot ⇒ no-op.
+      await wipe()
+      const R2 = `rec_noop_${TS}`
+      const [s2] = await seqBand(1)
+      const op2 = await sealAnchorOp(R2, [
+        { seq: s2, version: 1, action: 'create', snap: { [F_STR]: 'same', [F_FORM]: 'f-at' } },
+      ])
+      await live(R2, { [F_STR]: 'same', [F_FORM]: 'f-live' }, 1)
+      const pv2 = await preview(op2, 'revert')
+      // plan may still list a revert if full dataEquals sees formula drift — projection makes it no-op.
+      const out2 = await applyExactAnchorRecovery(txn, applyArgs(pv2.token))
+      expect(out2.ok).toBe(true)
+      if (!out2.ok) return
+      expect(out2.applied.reverts).toBe(0) // no write
+      expect((await liveRow(R2))?.version).toBe(1)
+      expect(Number(((await q(`SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }).c)).toBe(0)
+    } finally {
+      await q('DELETE FROM meta_fields WHERE id = $1', [F_FORM]).catch(() => {})
+    }
+  })
+
+  // ── B: in-fence plan authorization ─────────────────────────────────────────────────────────────────────
+  test('PLAN-AUTH: evaluatePlanAuthorization deny ⇒ forbidden, zero burn/revision/data writes', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const before = await liveRow(R_REV)
+    const pv = await preview(anchorOp)
+    const denied = await applyExactAnchorRecovery(txn, applyArgs(pv.token, { planAuth: DENY_PLAN }))
+    expect(denied).toEqual({ ok: false, reason: 'forbidden' })
+    expect(await liveRow(R_REV)).toEqual(before)
+    expect(await burnCount()).toBe(0)
+  })
+
+  test('PLAN-AUTH-PARK: fence park then revoke plan auth ⇒ forbidden, zero writes (constructed race)', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const before = await liveRow(R_REV)
+    const pv = await preview(anchorOp)
+    expect(pool).toBeTruthy()
+    let allowPlan = true
+    const planAuth = async () => allowPlan
+    const holder = await pool!.connect()
+    try {
+      await holder.query('BEGIN')
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`meta:auto-number:sheet:${SHEET}`])
+      const applying = applyExactAnchorRecovery(txn, applyArgs(pv.token, { planAuth }))
+      let sawWaiter = false
+      for (let i = 0; i < 100; i++) {
+        const waiters = await holder.query(`SELECT count(*)::int AS c FROM pg_locks WHERE locktype = 'advisory' AND NOT granted`)
+        if (Number((waiters.rows[0] as { c: number }).c) > 0) { sawWaiter = true; break }
+        await new Promise((r) => setTimeout(r, 50))
+      }
+      expect(sawWaiter).toBe(true)
+      allowPlan = false // revoke while parked
+      await holder.query('COMMIT')
+      const out = await applying
+      expect(out).toEqual({ ok: false, reason: 'forbidden' })
+      expect(await liveRow(R_REV)).toEqual(before)
+      expect(await burnCount()).toBe(0)
+      expect(Number(((await q(`SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }).c)).toBe(0)
+    } finally {
+      holder.release()
+    }
+  })
+
+  // ── D: foreign-link integrity ──────────────────────────────────────────────────────────────────────────
+  test('LINK-INTEGRITY: missing foreign target refuses whole-apply with zero writes', async () => {
+    const R_A = `rec_li_a_${TS}`
+    const R_REV = `rec_li_rev_${TS}`
+    const MISSING = `rec_li_missing_${TS}`
+    const [sA, sCreate, sUpdate] = await seqBand(3)
+    await revSeq(R_A, 1, 'create', { [F_STR]: 'A' }, sA)
+    // At-anchor link points at MISSING; live has R_A — projection would write MISSING ⇒ refuse.
+    const op2 = await sealAnchorOp(R_REV, [
+      { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'x', [F_LINK]: [MISSING] } },
+    ])
+    await revSeq(R_REV, 2, 'update', { [F_STR]: 'x', [F_LINK]: [R_A] }, sUpdate)
+    await live(R_A, { [F_STR]: 'A' }, 1)
+    await live(R_REV, { [F_STR]: 'x', [F_LINK]: [R_A] }, 2)
+    await insertLink(F_LINK, R_REV, R_A)
+    const pv = await preview(op2, 'revert')
+    const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
+    expect(out).toEqual({ ok: false, reason: 'link-integrity' })
+    expect(await linkTargets(F_LINK, R_REV)).toEqual([R_A])
+    expect(await burnCount()).toBe(0)
+  })
+
+  test('LINK-INTEGRITY wrong-sheet: target exists but on another sheet ⇒ refuse', async () => {
+    const OTHER = `${SHEET}_foreign`
+    const R_OTHER = `rec_other_sheet_${TS}`
+    const R_REV = `rec_ws_rev_${TS}`
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3) ON CONFLICT (id) DO NOTHING', [OTHER, BASE, 'other'])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1) ON CONFLICT (id) DO NOTHING', [R_OTHER, OTHER, '{}'])
+    try {
+      const [sCreate, sUpdate] = await seqBand(2)
+      const op = await sealAnchorOp(R_REV, [
+        { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'x', [F_LINK]: [R_OTHER] } },
+      ])
+      await revSeq(R_REV, 2, 'update', { [F_STR]: 'x', [F_LINK]: [] }, sUpdate)
+      await live(R_REV, { [F_STR]: 'x', [F_LINK]: [] }, 2)
+      const pv = await preview(op, 'revert')
+      // F_LINK foreignSheetId = SHEET, but R_OTHER lives on OTHER ⇒ link-integrity.
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'link-integrity' })
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [R_OTHER]).catch(() => {})
+      await q('DELETE FROM meta_sheets WHERE id = $1', [OTHER]).catch(() => {})
+    }
+  })
+
+  // ── F: trusted substrate ───────────────────────────────────────────────────────────────────────────────
+  test('TRUST-SUBSTRATE: fence or strict flag off ⇒ recovery-trust-required, zero writes', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const before = await liveRow(R_REV)
+    const pv = await preview(anchorOp)
+    delete process.env[STRICT]
+    expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'recovery-trust-required' })
+    process.env[STRICT] = 'true'
+    delete process.env[FLAG]
+    expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'recovery-trust-required' })
+    process.env[FLAG] = 'true'
+    expect(await liveRow(R_REV)).toEqual(before)
+    expect(await burnCount()).toBe(0)
+  })
+
   // ── G1 (pre-wiring gate list): burn-retention sweep ─────────────────────────────────────────────────────
   test('G1 BURN-RETENTION: the sweep prunes only burns older than the keep window, and the floor clamp protects any possibly-live token', async () => {
     const { anchorOp } = await seedWorld()
     const pv = await preview(anchorOp, 'revert')
-    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
     expect(await burnCount()).toBe(1) // the fresh burn from the successful apply
 
     // A synthetic OLD burn (2 hours ago) — prunable at the default 60m keep.

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -383,11 +383,11 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     expect(await burnCount()).toBe(0)
   })
 
-  test('LOCKED record: a lock held by ANOTHER actor aborts the whole all-or-nothing apply (rank-8 discipline); unlocking lets it through', async () => {
+  test('LOCKED record: a lock held by ANOTHER actor ⇒ record-locked (values-free), zero writes; unlocking lets it through', async () => {
     const { R_REV, anchorOp } = await seedWorld()
     await q('UPDATE meta_records SET locked = true, locked_by = $1 WHERE id = $2 AND sheet_id = $3', ['someone-else', R_REV, SHEET])
     const pv = await preview(anchorOp) // lock columns are not part of the live {id, version} fingerprint
-    await expect(applyExactAnchorRecovery(txn, applyArgs(pv.token))).rejects.toThrow(/locked/i)
+    expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'record-locked' })
     expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-now' }) // nothing applied (all-or-nothing)
     expect(await burnCount()).toBe(0)
     // unlock ⇒ the SAME token applies (the refusal wrote nothing).
@@ -871,6 +871,87 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
       expect(await burnCount()).toBe(0)
     } finally {
       await q('DELETE FROM meta_fields WHERE id = $1', [F_LT]).catch(() => {})
+    }
+  })
+
+  test('VALUE-INVALID required: historical snapshot omits a field that is NOW required ⇒ value-invalid, zero writes', async () => {
+    const F_REQ = `fld_eaa_req_${TS}`
+    // CURRENT schema: F_REQ is required. Historical at-anchor data only has F_STR (F_REQ omitted).
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6) ON CONFLICT (id) DO NOTHING',
+      [F_REQ, SHEET, 'Required', 'string', JSON.stringify({ validation: [{ type: 'required' }] }), 12],
+    )
+    try {
+      const R = `rec_req_${TS}`
+      const [sCreate, sUpdate] = await seqBand(2)
+      const op = await sealAnchorOp(R, [
+        { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'at-anchor' } },
+      ])
+      await revSeq(R, 2, 'update', { [F_STR]: 'live-now', [F_REQ]: 'filled' }, sUpdate)
+      await live(R, { [F_STR]: 'live-now', [F_REQ]: 'filled' }, 2)
+      const before = await liveRow(R)
+      const pv = await preview(op, 'revert')
+      // Projection restores at-anchor data without F_REQ (unset/omit) while CURRENT requires it.
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'value-invalid' })
+      expect(await liveRow(R)).toEqual(before)
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q('DELETE FROM meta_fields WHERE id = $1', [F_REQ]).catch(() => {})
+    }
+  })
+
+  test('VALUE-INVALID maxLength: historical value exceeds CURRENT property.validation maxLength ⇒ value-invalid', async () => {
+    const F_MAX = `fld_eaa_max_${TS}`
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6) ON CONFLICT (id) DO NOTHING',
+      [F_MAX, SHEET, 'Short', 'string', JSON.stringify({ validation: [{ type: 'maxLength', params: { value: 3 } }] }), 13],
+    )
+    try {
+      const R = `rec_max_${TS}`
+      const [sCreate, sUpdate] = await seqBand(2)
+      const op = await sealAnchorOp(R, [
+        { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'x', [F_MAX]: 'toolong' } },
+      ])
+      await revSeq(R, 2, 'update', { [F_STR]: 'x', [F_MAX]: 'ok' }, sUpdate)
+      await live(R, { [F_STR]: 'x', [F_MAX]: 'ok' }, 2)
+      const before = await liveRow(R)
+      const pv = await preview(op, 'revert')
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'value-invalid' })
+      expect(await liveRow(R)).toEqual(before)
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q('DELETE FROM meta_fields WHERE id = $1', [F_MAX]).catch(() => {})
+    }
+  })
+
+  test('VALUE-INVALID pattern: historical value fails CURRENT property.validation pattern ⇒ value-invalid', async () => {
+    const F_PAT = `fld_eaa_pat_${TS}`
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6) ON CONFLICT (id) DO NOTHING',
+      [
+        F_PAT,
+        SHEET,
+        'Code',
+        'string',
+        JSON.stringify({ validation: [{ type: 'pattern', params: { regex: '^[A-Z]+$' } }] }),
+        14,
+      ],
+    )
+    try {
+      const R = `rec_pat_${TS}`
+      const [sCreate, sUpdate] = await seqBand(2)
+      const op = await sealAnchorOp(R, [
+        { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'x', [F_PAT]: 'not-upper' } },
+      ])
+      await revSeq(R, 2, 'update', { [F_STR]: 'x', [F_PAT]: 'ABC' }, sUpdate)
+      await live(R, { [F_STR]: 'x', [F_PAT]: 'ABC' }, 2)
+      const before = await liveRow(R)
+      const pv = await preview(op, 'revert')
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'value-invalid' })
+      expect(await liveRow(R)).toEqual(before)
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q('DELETE FROM meta_fields WHERE id = $1', [F_PAT]).catch(() => {})
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -7,8 +7,8 @@
  *                     depend on resurrection.
  *   MODE-MATRIX       reset deletes createdAfterAnchor (trash + delete revision); revert keeps them.
  *   REPLAY / LIVE-DRIFT / AUTH / PLAN-AUTH / DRIFT-REJECT / link+reset parity / trust substrate.
- *   RESTORABLE-PROJECTION  formula preserved; derived-only ⇒ no revision/version/link/endpoint (token still
- *                          burns on successful consume).
+ *   RESTORABLE-PROJECTION  formula preserved; derived-only ⇒ no revision/version/link/endpoint BUT token burns.
+ *   SCHEMA-HASH-DRIFT      post-preview retype / property-only change ⇒ schema-drift; missing field still covered.
  *   VALUE-INVALID     unsafe rich longText / select-option drift refuse with zero writes.
  *   LINK-INTEGRITY    missing target, wrong sheet, alias ambiguity, same-op delete target.
  *   RESET two-phase   cross-linked delete candidates both get inbound tombstones.
@@ -26,7 +26,12 @@ import { pool } from '../../src/db/pg'
 import { resolveExactAnchor } from '../../src/multitable/exact-anchor-recovery'
 import { applyExactAnchorRecovery, pruneExpiredRecoveryTokenBurns, type ExactAnchorApplyMode } from '../../src/multitable/exact-anchor-recovery-execute'
 import { countInboundLinkCaptureRows, isTombstoneCaptureEnabled } from '../../src/multitable/tombstone-capture'
-import { hashAnchorRecoveryScope, hashRecoveryAuthorizationScope, mintExactAnchorRecoveryIdentity } from '../../src/multitable/restore-preview-identity'
+import {
+  hashAnchorRecoveryScope,
+  hashExactAnchorSchema,
+  hashRecoveryAuthorizationScope,
+  mintExactAnchorRecoveryIdentity,
+} from '../../src/multitable/restore-preview-identity'
 import { activateCheckpoint, type QueryFn } from '../../src/multitable/history-trust-checkpoint'
 import { __resetRecoveryWriterStateColumnProbe } from '../../src/multitable/canonical-sheet-fence'
 import { __resetOperationLedgerColumnProbe } from '../../src/multitable/operation-ledger'
@@ -454,18 +459,17 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     const { R_REV, anchorOp } = await seedWorld()
     const pv = await preview(anchorOp, 'revert')
     const before = await liveRow(R_REV)
-    // Same REAL scopeHash/liveSetHash/checkpoint — only the signed authorization basis is wrong.
+    // Same REAL scopeHash/liveSetHash/schemaHash/checkpoint — only the signed authorization basis is wrong.
+    const liveRows = (await q('SELECT id, version FROM meta_records WHERE sheet_id = $1', [SHEET])).rows as Array<{ id: string; version: number }>
+    const fieldRows = (await q('SELECT id, type, property FROM meta_fields WHERE sheet_id = $1', [SHEET])).rows as Array<{ id: string; type: string; property: unknown }>
+    const schemaHash = hashExactAnchorSchema(fieldRows.map((r) => ({ id: String(r.id), type: String(r.type), property: r.property })))
+    const liveSetHash = hashAnchorRecoveryScope(liveRows.map((r) => ({ recordId: String(r.id), exists: true, version: Number(r.version) })))
     const claims = {
       sheetId: SHEET, anchorOperationId: anchorOp, anchorSeq: pv.anchorSeq, checkpointId: pv.checkpointId,
-      scopeHash: pv.scopeHash, actorId: ACTOR, mode: 'revert' as const, authorizedScopeHash: 'e'.repeat(64),
+      scopeHash: pv.scopeHash, liveSetHash, schemaHash, actorId: ACTOR, mode: 'revert' as const,
+      authorizedScopeHash: 'e'.repeat(64),
     }
-    // liveSetHash must be the REAL one so this golden isolates the authorization axis: recompute it the
-    // way the preview does (same primitive over the live {id, version} set).
-    const liveRows = (await q('SELECT id, version FROM meta_records WHERE sheet_id = $1', [SHEET])).rows as Array<{ id: string; version: number }>
-    const wrongBasis = mintExactAnchorRecoveryIdentity({
-      ...claims,
-      liveSetHash: hashAnchorRecoveryScope(liveRows.map((r) => ({ recordId: String(r.id), exists: true, version: Number(r.version) }))),
-    })
+    const wrongBasis = mintExactAnchorRecoveryIdentity(claims)
     expect(await applyExactAnchorRecovery(txn, applyArgs(wrongBasis)))
       .toEqual({ ok: false, reason: 'forbidden' })
     expect(await liveRow(R_REV)).toEqual(before)
@@ -474,18 +478,17 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     const rightBasis = mintExactAnchorRecoveryIdentity({
       ...claims,
       authorizedScopeHash: hashRecoveryAuthorizationScope({ sheetId: SHEET, actorId: ACTOR }),
-      liveSetHash: hashAnchorRecoveryScope(liveRows.map((r) => ({ recordId: String(r.id), exists: true, version: Number(r.version) }))),
     })
     expect((await applyExactAnchorRecovery(txn, applyArgs(rightBasis))).ok).toBe(true)
   })
 
-  // ── P1-2 SCHEMA-DRIFT WHOLE-REJECT ──────────────────────────────────────────────────────────────────────
-  test('DRIFT-REJECT (P1-2): driftCount > 0 ⇒ the WHOLE apply refuses schema-drift with zero writes incl. the burn — no partial-set apply through drift exclusion', async () => {
+  // ── P1-2 / G-SCHEMA SCHEMA-DRIFT WHOLE-REJECT ───────────────────────────────────────────────────────────
+  test('DRIFT-REJECT (P1-2): driftCount > 0 / missing field after preview ⇒ the WHOLE apply refuses schema-drift with zero writes incl. the burn — no partial-set apply through drift exclusion', async () => {
     const { R_REV, R_NEW, anchorOp } = await seedWorld()
     const pv = await preview(anchorOp, 'revert')
     const beforeRev = await liveRow(R_REV)
-    // Drop the field AFTER preview: every at-anchor snapshot now carries a stale field id ⇒ plan.driftCount>0.
-    // (The scope/live hashes cover records, not schema — this reaches the PLAN, which is exactly the point.)
+    // Drop the field AFTER preview: schemaHash diverges (G-SCHEMA) AND at-anchor snapshots carry a stale
+    // field id (plan.driftCount>0). Either path is schema-drift; both roll the burn back.
     await q('DELETE FROM meta_fields WHERE id = $1 AND sheet_id = $2', [F_STR, SHEET])
     try {
       expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token)))
@@ -498,6 +501,47 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     }
     // POSITIVE CONTROL (anti-vacuous, gate NIT-2): with the schema restored, the SAME token — unburned by
     // the refusal above — now applies cleanly. Proves the refusal was attributable to the drift alone.
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
+  })
+
+  test('SCHEMA-HASH-DRIFT retype: string→longText after preview (value still valid) ⇒ schema-drift, zero writes/burn; restoring type lets the same unburned token apply', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp, 'revert')
+    const before = await liveRow(R_REV)
+    // Compatible retype: historical string values remain valid as longText — scalar/live hashes cannot see it.
+    await q('UPDATE meta_fields SET type = $1 WHERE id = $2 AND sheet_id = $3', ['longText', F_STR, SHEET])
+    try {
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token)))
+        .toEqual({ ok: false, reason: 'schema-drift' })
+      expect(await liveRow(R_REV)).toEqual(before)
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q('UPDATE meta_fields SET type = $1 WHERE id = $2 AND sheet_id = $3', ['string', F_STR, SHEET])
+    }
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
+  })
+
+  test('SCHEMA-HASH-DRIFT property-only: property.validation change after preview ⇒ schema-drift, zero writes/burn; restoring property lets the same unburned token apply', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp, 'revert')
+    const before = await liveRow(R_REV)
+    const originalProp = ((await q('SELECT property FROM meta_fields WHERE id = $1', [F_STR])).rows[0] as { property: unknown }).property
+    await q(
+      'UPDATE meta_fields SET property = $1::jsonb WHERE id = $2 AND sheet_id = $3',
+      [JSON.stringify({ validation: [{ type: 'required' }] }), F_STR, SHEET],
+    )
+    try {
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token)))
+        .toEqual({ ok: false, reason: 'schema-drift' })
+      expect(await liveRow(R_REV)).toEqual(before)
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q('UPDATE meta_fields SET property = $1::jsonb WHERE id = $2 AND sheet_id = $3', [
+        JSON.stringify(originalProp ?? {}),
+        F_STR,
+        SHEET,
+      ])
+    }
     expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
   })
 
@@ -688,7 +732,7 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
   })
 
   // ── A: restorable projection (derived preservation / no-op) ────────────────────────────────────────────
-  test('RESTORABLE-PROJECTION: formula materialization is preserved; derived-only difference is a no-op (no version/revision/burn)', async () => {
+  test('RESTORABLE-PROJECTION: formula materialization is preserved; derived-only difference is a no-op (no version/revision/link/endpoint BUT token burns)', async () => {
     const F_FORM = `fld_eaa_formula_${TS}`
     await q(
       'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6) ON CONFLICT (id) DO NOTHING',
@@ -729,6 +773,11 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
         { seq: s2, version: 1, action: 'create', snap: { [F_STR]: 'same', [F_FORM]: 'f-at' } },
       ])
       await live(R2, { [F_STR]: 'same', [F_FORM]: 'f-live' }, 1)
+      const opsBefore = Number(((await q('SELECT count(*)::int c FROM meta_record_history_operations WHERE sheet_id = $1', [SHEET])).rows[0] as { c: number }).c)
+      const linksBefore = Number(((await q(
+        `SELECT count(*)::int c FROM meta_links WHERE record_id IN (SELECT id FROM meta_records WHERE sheet_id = $1)`,
+        [SHEET],
+      )).rows[0] as { c: number }).c)
       const pv2 = await preview(op2, 'revert')
       const out2 = await applyExactAnchorRecovery(txn, applyArgs(pv2.token))
       expect(out2.ok).toBe(true)
@@ -736,8 +785,13 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
       expect(out2.applied.reverts).toBe(0) // no restorable write
       expect((await liveRow(R2))?.version).toBe(1) // no version bump
       expect(Number(((await q(`SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }).c)).toBe(0)
-      // No restore-sourced revision and no version bump (zero restorable writes).
-      // Successful token consume still burns (anti-replay) even when restorable writes are empty.
+      // No restore-sourced revision, no version bump, no link mutation, and NO new sealed operation endpoint
+      // (sealOperation skips eventCount===0). Successful token consume still burns (anti-replay).
+      expect(Number(((await q('SELECT count(*)::int c FROM meta_record_history_operations WHERE sheet_id = $1', [SHEET])).rows[0] as { c: number }).c)).toBe(opsBefore)
+      expect(Number(((await q(
+        `SELECT count(*)::int c FROM meta_links WHERE record_id IN (SELECT id FROM meta_records WHERE sheet_id = $1)`,
+        [SHEET],
+      )).rows[0] as { c: number }).c)).toBe(linksBefore)
       expect(await burnCount()).toBe(1)
     } finally {
       await q('DELETE FROM meta_fields WHERE id = $1', [F_FORM]).catch(() => {})
@@ -1107,5 +1161,22 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     expect(shas.has(`deadold${TS}`.padEnd(64, '0'))).toBe(false) // pruned
     expect(shas.has(`deadmid${TS}`.padEnd(64, '1'))).toBe(true) // floor-protected
     expect(remaining.length).toBe(2) // 12m row + the real fresh burn
+  })
+
+  test('G1 BURN-INDEX: pg_indexes pins a burned_at-leading index usable by pruneExpiredRecoveryTokenBurns', async () => {
+    const idxs = (await q(
+      `SELECT indexname, indexdef FROM pg_indexes
+       WHERE tablename = 'meta_recovery_token_burns' AND schemaname = current_schema()`,
+    )).rows as Array<{ indexname: string; indexdef: string }>
+    expect(idxs.length).toBeGreaterThan(0)
+    // Usable for `WHERE burned_at < …`: leading key of the btree index expression is burned_at
+    // (not merely present as a trailing column of (sheet_id, burned_at)).
+    const burnedAtLeading = idxs.filter((r) =>
+      /\(.*burned_at/i.test(r.indexdef) && !/\([^)]*sheet_id[^)]*burned_at/i.test(r.indexdef),
+    )
+    expect(
+      burnedAtLeading.map((r) => r.indexname),
+      `expected a burned_at-leading index on meta_recovery_token_burns; got:\n${idxs.map((r) => `  ${r.indexname}: ${r.indexdef}`).join('\n')}`,
+    ).not.toEqual([])
   })
 })

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -76,6 +76,8 @@ const live = (id: string, data: Record<string, unknown>, version = 1) =>
   q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,$4)', [id, SHEET, JSON.stringify(data), version])
 const liveRow = async (id: string) =>
   (await q('SELECT data, version FROM meta_records WHERE id = $1 AND sheet_id = $2', [id, SHEET])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+const modifiedBy = async (id: string) =>
+  ((await q('SELECT modified_by FROM meta_records WHERE id = $1 AND sheet_id = $2', [id, SHEET])).rows[0] as { modified_by: string | null } | undefined)?.modified_by
 const burnCount = async () => Number(((await q('SELECT count(*)::int c FROM meta_recovery_token_burns WHERE sheet_id = $1', [SHEET])).rows[0] as { c: number }).c)
 const trashCount = async (recordId: string) => Number(((await q('SELECT count(*)::int c FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2', [recordId, SHEET])).rows[0] as { c: number }).c)
 const linkTargets = async (fieldId: string, recordId: string) =>
@@ -258,6 +260,7 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
 
     expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-at-anchor' }) // reverted
     expect((await liveRow(R_REV))?.version).toBe(3) // version+1, never rewound
+    expect(await modifiedBy(R_REV)).toBe(ACTOR) // restore is the visible modifying action
     expect(await liveRow(R_NEW)).toBeDefined() // revert KEEPS created-after-anchor
 
     const revRows = (await q(

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -43,10 +43,12 @@ import { __resetOperationLedgerColumnProbe } from '../../src/multitable/operatio
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const FLAG = 'MULTITABLE_ENABLE_WRITER_FENCE'
+const CAPTURE_FLAG = 'MULTITABLE_TOMBSTONE_CAPTURE_ENABLED'
 const TS = Date.now()
 const BASE = `base_eaa_${TS}`
 const SHEET = `sheet_eaa_${TS}`
 const F_STR = `fld_eaa_note_${TS}`
+const F_LINK = `fld_eaa_link_${TS}`
 const ACTOR = `user_eaa_${TS}`
 
 const q = (sql: string, params: unknown[] = []) => poolManager.get().query(sql, params)
@@ -69,6 +71,16 @@ const liveRow = async (id: string) =>
   (await q('SELECT data, version FROM meta_records WHERE id = $1 AND sheet_id = $2', [id, SHEET])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
 const burnCount = async () => Number(((await q('SELECT count(*)::int c FROM meta_recovery_token_burns WHERE sheet_id = $1', [SHEET])).rows[0] as { c: number }).c)
 const trashCount = async (recordId: string) => Number(((await q('SELECT count(*)::int c FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2', [recordId, SHEET])).rows[0] as { c: number }).c)
+const linkTargets = async (fieldId: string, recordId: string) =>
+  ((await q('SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2 ORDER BY foreign_record_id', [fieldId, recordId])).rows as Array<{ foreign_record_id: string }>)
+    .map((r) => r.foreign_record_id)
+const linkEdgeCount = async (recordId: string) =>
+  Number(((await q('SELECT count(*)::int c FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1', [recordId])).rows[0] as { c: number }).c)
+const insertLink = (fieldId: string, recordId: string, foreignId: string) =>
+  q(
+    `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)`,
+    [`lnk_${fieldId}_${recordId}_${foreignId}`.slice(0, 50), fieldId, recordId, foreignId],
+  )
 
 /** Seal one synthetic operation (endpoint = exact MAX of its tagged event seqs) to serve as the anchor. */
 async function sealAnchorOp(recordId: string, eventSeqs: Array<{ seq: string; version: number; action?: 'create' | 'update' | 'delete'; snap?: Record<string, unknown> }>): Promise<string> {
@@ -92,6 +104,13 @@ async function sealAnchorOp(recordId: string, eventSeqs: Array<{ seq: string; ve
 const activate = () => txn((query) => activateCheckpoint(query, { sheetId: SHEET }))
 
 async function wipe(): Promise<void> {
+  // meta_links has no sheet_id — clear via record ownership on this sheet; tombstones are sheet-scoped.
+  await q(
+    `DELETE FROM meta_links WHERE record_id IN (SELECT id FROM meta_records WHERE sheet_id = $1)
+       OR foreign_record_id IN (SELECT id FROM meta_records WHERE sheet_id = $1)`,
+    [SHEET],
+  ).catch(() => {})
+  await q('DELETE FROM meta_link_tombstones WHERE sheet_id = $1', [SHEET]).catch(() => {})
   for (const t of ['meta_history_baselines', 'meta_history_trust_checkpoints', 'meta_recovery_token_burns', 'meta_record_version_markers', 'meta_records_trash', 'meta_record_revisions', 'meta_records'])
     await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
   await q('DELETE FROM meta_record_history_operations WHERE sheet_id = $1', [SHEET]).catch(() => {})
@@ -110,16 +129,26 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'EAA Base'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'EAA'])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_STR, SHEET, 'Note', 'string', '{}', 1])
+    // Same-sheet forward link field (writable; not a mirror) for REVERT/RESET link-parity goldens.
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_LINK, SHEET, 'Rel', 'link', JSON.stringify({ foreignSheetId: SHEET }), 2],
+    )
   })
   beforeEach(async () => {
     await wipe()
     process.env[FLAG] = 'true' // this test process only — the apply is meaningful with the fence/ledger on
+    delete process.env[CAPTURE_FLAG] // default OFF; individual goldens enable when proving capture
     __resetRecoveryWriterStateColumnProbe()
     __resetOperationLedgerColumnProbe()
   })
-  afterEach(() => { delete process.env[FLAG] })
+  afterEach(() => {
+    delete process.env[FLAG]
+    delete process.env[CAPTURE_FLAG]
+  })
   afterAll(async () => {
     delete process.env[FLAG]
+    delete process.env[CAPTURE_FLAG]
     await wipe()
     await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
@@ -500,6 +529,140 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     expect(refusals.length).toBe(1)
     expect(refusals[0].reason).toBe('preview-drift') // the loser saw the winner's committed world
     expect(await burnCount()).toBe(1) // the loser's burn rolled back with its refusal
+  })
+
+  // ── LINK / TRASH / TOMBSTONE parity (Codex review P1 — kernel data-integrity, same txn) ──────────────────
+  test('REVERT-LINK-SYNC: at-anchor A ← live B — both meta_records.data and meta_links end at A (writable forward only)', async () => {
+    const R_A = `rec_lnk_a_${TS}`
+    const R_B = `rec_lnk_b_${TS}`
+    const R_REV = `rec_lnk_rev_${TS}`
+    await activate()
+    // Foreign targets exist at/before the anchor so reconstruction is well-formed; R_REV at-anchor points to A.
+    await revSeq(R_A, 1, 'create', { [F_STR]: 'A' }, '9000500')
+    await revSeq(R_B, 1, 'create', { [F_STR]: 'B' }, '9000600')
+    const anchorOp = await sealAnchorOp(R_REV, [
+      { seq: '9001000', version: 1, action: 'create', snap: { [F_STR]: 'rev-at-anchor', [F_LINK]: [R_A] } },
+    ])
+    await revSeq(R_REV, 2, 'update', { [F_STR]: 'rev-now', [F_LINK]: [R_B] }, '9002000')
+    await live(R_A, { [F_STR]: 'A' }, 1)
+    await live(R_B, { [F_STR]: 'B' }, 1)
+    await live(R_REV, { [F_STR]: 'rev-now', [F_LINK]: [R_B] }, 2)
+    await insertLink(F_LINK, R_REV, R_B) // live relation projection = B (authoritative meta_links)
+    expect(await linkTargets(F_LINK, R_REV)).toEqual([R_B])
+
+    const pv = await preview(anchorOp, 'revert')
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out.ok).toBe(true)
+    // POSITIVE: both stores land on A — data alone is not enough (link reads use meta_links).
+    expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-at-anchor', [F_LINK]: [R_A] })
+    expect(await linkTargets(F_LINK, R_REV)).toEqual([R_A])
+  })
+
+  test('RESET-DELETE-PARITY: both-direction meta_links gone, trash + delete_revision_id anchored, inbound tombstone when capture ON', async () => {
+    process.env[CAPTURE_FLAG] = 'true'
+    const { R_NEW, anchorOp } = await seedWorld()
+    const R_PEER = `rec_peer_${TS}`
+    // R_PEER must EXIST at the anchor (revision ≤ anchor) so reset KEEPS it — it is the inbound linker
+    // whose foreign_record_id edge would dangle without the both-direction meta_links delete.
+    await revSeq(R_PEER, 1, 'create', { [F_STR]: 'peer' }, '9000700')
+    await live(R_PEER, { [F_STR]: 'peer' }, 1)
+    // Outbound edge R_NEW → R_PEER and inbound edge R_PEER → R_NEW (foreign_record_id has no FK).
+    await q('UPDATE meta_records SET data = $1::jsonb WHERE id = $2 AND sheet_id = $3', [
+      JSON.stringify({ [F_STR]: 'newbie', [F_LINK]: [R_PEER] }),
+      R_NEW,
+      SHEET,
+    ])
+    await insertLink(F_LINK, R_NEW, R_PEER)
+    await insertLink(F_LINK, R_PEER, R_NEW)
+    expect(await linkEdgeCount(R_NEW)).toBe(2)
+
+    const pv = await preview(anchorOp, 'reset')
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out.ok).toBe(true)
+    if (!out.ok) return
+    expect(out.applied.deletes).toBeGreaterThanOrEqual(1)
+    expect(await liveRow(R_NEW)).toBeUndefined()
+    // Both directions gone — outbound would CASCADE with the row, but inbound would dangle without explicit delete.
+    expect(await linkEdgeCount(R_NEW)).toBe(0)
+    expect(await linkTargets(F_LINK, R_PEER)).toEqual([]) // inbound edge removed
+
+    const trash = (await q(
+      `SELECT data, original_version, delete_revision_id, base_id FROM meta_records_trash
+       WHERE record_id = $1 AND sheet_id = $2`,
+      [R_NEW, SHEET],
+    )).rows[0] as { data: Record<string, unknown>; original_version: number; delete_revision_id: string | null; base_id: string | null } | undefined
+    expect(trash).toBeDefined()
+    expect(trash!.data).toEqual({ [F_STR]: 'newbie', [F_LINK]: [R_PEER] })
+    expect(trash!.original_version).toBe(1)
+    expect(trash!.base_id).toBe(BASE)
+    expect(typeof trash!.delete_revision_id).toBe('string')
+    expect(trash!.delete_revision_id).toBeTruthy()
+
+    // The delete revision shares the pre-generated id anchored on trash + tombstones.
+    const delRev = (await q(
+      `SELECT id::text AS id FROM meta_record_revisions
+       WHERE sheet_id = $1 AND record_id = $2 AND action = 'delete' AND source = 'restore'`,
+      [SHEET, R_NEW],
+    )).rows[0] as { id: string } | undefined
+    expect(delRev?.id).toBe(trash!.delete_revision_id)
+
+    // Capture ON: inbound edge R_PEER→R_NEW was tombstoned under that revision before the links DELETE.
+    const tombs = (await q(
+      `SELECT record_id, foreign_record_id, reason FROM meta_link_tombstones
+       WHERE sheet_id = $1 AND source_revision_id = $2::uuid AND reason = 'record_delete'`,
+      [SHEET, trash!.delete_revision_id],
+    )).rows as Array<{ record_id: string; foreign_record_id: string; reason: string }>
+    expect(tombs).toEqual([{ record_id: R_PEER, foreign_record_id: R_NEW, reason: 'record_delete' }])
+  })
+
+  test('LINK-TRASH-TOMBSTONE-ROLLBACK: injected seal failure rolls back link sync, both-direction link delete, trash, tombstones, revisions, burn together', async () => {
+    process.env[CAPTURE_FLAG] = 'true'
+    const R_A = `rec_roll_a_${TS}`
+    const R_B = `rec_roll_b_${TS}`
+    const R_REV = `rec_roll_rev_${TS}`
+    const R_NEW = `rec_roll_new_${TS}`
+    const R_PEER = `rec_roll_peer_${TS}`
+    await activate()
+    await revSeq(R_A, 1, 'create', { [F_STR]: 'A' }, '9000500')
+    await revSeq(R_B, 1, 'create', { [F_STR]: 'B' }, '9000600')
+    const anchorOp = await sealAnchorOp(R_REV, [
+      { seq: '9001000', version: 1, action: 'create', snap: { [F_STR]: 'rev-at-anchor', [F_LINK]: [R_A] } },
+    ])
+    await revSeq(R_PEER, 1, 'create', { [F_STR]: 'peer' }, '9000700') // exists at-anchor so reset keeps peer
+    await revSeq(R_REV, 2, 'update', { [F_STR]: 'rev-now', [F_LINK]: [R_B] }, '9002000')
+    await revSeq(R_NEW, 1, 'create', { [F_STR]: 'newbie', [F_LINK]: [R_PEER] }, '9002200')
+    await live(R_A, { [F_STR]: 'A' }, 1)
+    await live(R_B, { [F_STR]: 'B' }, 1)
+    await live(R_PEER, { [F_STR]: 'peer' }, 1)
+    await live(R_REV, { [F_STR]: 'rev-now', [F_LINK]: [R_B] }, 2)
+    await live(R_NEW, { [F_STR]: 'newbie', [F_LINK]: [R_PEER] }, 1)
+    await insertLink(F_LINK, R_REV, R_B)
+    await insertLink(F_LINK, R_NEW, R_PEER)
+    await insertLink(F_LINK, R_PEER, R_NEW)
+
+    const pv = await preview(anchorOp, 'reset') // reset drives REVERT of R_REV + DELETE of R_NEW
+    const fn = `eaa_link_seal_fail_${TS}`
+    const trg = `trg_eaa_link_seal_fail_${TS}`
+    await q(`CREATE OR REPLACE FUNCTION ${fn}() RETURNS trigger AS $$ BEGIN RAISE EXCEPTION 'injected seal failure (link/trash rollback)'; END $$ LANGUAGE plpgsql`)
+    await q(`CREATE TRIGGER ${trg} BEFORE INSERT ON meta_record_history_operations FOR EACH ROW WHEN (NEW.sheet_id = '${SHEET}') EXECUTE FUNCTION ${fn}()`)
+    try {
+      await expect(
+        applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }),
+      ).rejects.toThrow()
+      // REVERT link sync rolled back — still B in both stores.
+      expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-now', [F_LINK]: [R_B] })
+      expect(await linkTargets(F_LINK, R_REV)).toEqual([R_B])
+      // RESET delete side effects rolled back — live row, both edge directions, no trash, no tombstone, no burn.
+      expect(await liveRow(R_NEW)).toBeDefined()
+      expect(await linkEdgeCount(R_NEW)).toBe(2)
+      expect(await trashCount(R_NEW)).toBe(0)
+      expect(Number(((await q('SELECT count(*)::int c FROM meta_link_tombstones WHERE sheet_id = $1', [SHEET])).rows[0] as { c: number }).c)).toBe(0)
+      expect(Number(((await q(`SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }).c)).toBe(0)
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q(`DROP TRIGGER IF EXISTS ${trg} ON meta_record_history_operations`).catch(() => {})
+      await q(`DROP FUNCTION IF EXISTS ${fn}()`).catch(() => {})
+    }
   })
 
   // ── G1 (pre-wiring gate list): burn-retention sweep ─────────────────────────────────────────────────────

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -1,0 +1,534 @@
+/**
+ * W0-1 v3.7 Lane L8 — the exact-anchor DESTRUCTIVE APPLY (real DB): one transaction, all-or-nothing.
+ *
+ * Module under test: `exact-anchor-recovery-execute.ts` `applyExactAnchorRecovery`. Goldens (each
+ * mutation-proven in the PR matrix):
+ *   HAPPY-REVERT      end-to-end revert-mode apply: reverts + resurrects land atomically, every write
+ *                     revision-emitted (`source:'restore'`) and ledger-tagged; the apply itself seals an
+ *                     operation endpoint (a future exact anchor); token burned.
+ *   MODE-MATRIX       the SAME world under 'reset' also deletes deletedAtAnchorLiveNow + createdAfterAnchor
+ *                     (with delete revisions); under 'revert' both survive.
+ *   REPLAY            a second execute of the SAME token ⇒ `token-replayed`, zero writes.
+ *   LIVE-DRIFT (409)  a CONCURRENT COMMITTED WRITE between preview and execute ⇒ `preview-drift`, ZERO
+ *                     writes — including the token burn (the token is still executable after the world is
+ *                     restored to the previewed state ⇒ proves full rollback of the burn row).
+ *   CHECKPOINT-GONE   the covering checkpoint pruned/removed between preview and execute ⇒
+ *                     `no-covering-checkpoint`; a DIFFERENT covering checkpoint (superseding activation
+ *                     below the anchor) ⇒ `checkpoint-changed`. Zero writes.
+ *   INJECTED-FAILURE  a mid-apply failure (second revision INSERT forced to fail via a synthetic
+ *                     constraint collision) ⇒ the WHOLE apply rolls back: no record changed, no revisions,
+ *                     no endpoint, no burn.
+ *   BASELINE          a record whose history lives ONLY in the checkpoint baseline (zero revisions ≤
+ *                     anchor): non-trashed baseline row resurrects/reverts from the baseline data;
+ *                     is_trashed=true baseline row stays deleted.
+ *   FENCE-PARK (race) a raw client holds the canonical fence in an open transaction; the apply PARKS
+ *                     (proven via pg_locks/pg_blocking_pids sampling) and completes after release.
+ *
+ * The module is NOT wired to any route; the L4 fence flag is toggled only inside this test process
+ * (default OFF everywhere real). P2-C hygiene: explicit synthetic seq literals, no `setval`, own-row
+ * cleanup. Two-point wiring: plugin-tests.yml real-DB run list + vitest glob; fail-not-skip sentinel.
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { pool } from '../../src/db/pg'
+import { resolveExactAnchor } from '../../src/multitable/exact-anchor-recovery'
+import { applyExactAnchorRecovery, pruneExpiredRecoveryTokenBurns, type ExactAnchorApplyMode } from '../../src/multitable/exact-anchor-recovery-execute'
+import { hashAnchorRecoveryScope, hashRecoveryAuthorizationScope, mintExactAnchorRecoveryIdentity } from '../../src/multitable/restore-preview-identity'
+import { activateCheckpoint, type QueryFn } from '../../src/multitable/history-trust-checkpoint'
+import { __resetRecoveryWriterStateColumnProbe } from '../../src/multitable/canonical-sheet-fence'
+import { __resetOperationLedgerColumnProbe } from '../../src/multitable/operation-ledger'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const FLAG = 'MULTITABLE_ENABLE_WRITER_FENCE'
+const TS = Date.now()
+const BASE = `base_eaa_${TS}`
+const SHEET = `sheet_eaa_${TS}`
+const F_STR = `fld_eaa_note_${TS}`
+const ACTOR = `user_eaa_${TS}`
+
+const q = (sql: string, params: unknown[] = []) => poolManager.get().query(sql, params)
+const txn = <T>(fn: (query: QueryFn) => Promise<T>): Promise<T> =>
+  poolManager.get().transaction(async ({ query }) => fn(query as unknown as QueryFn)) as Promise<T>
+
+// P1-2 kernel adjudication stubs (the production evaluator is the route's `hasFullTableReadAccess`).
+const ALLOW_FULL_READ = async () => true
+const DENY_FULL_READ = async () => false
+
+const revSeq = (recordId: string, version: number, action: 'create' | 'update' | 'delete', snap: Record<string, unknown> | null, seq: string, opId?: string | null) =>
+  q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq, operation_id)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[]::text[],'{}'::jsonb,$5::jsonb,$6::bigint,$7::uuid)`,
+    [SHEET, recordId, version, action, snap === null ? null : JSON.stringify(snap), seq, opId ?? null],
+  )
+const live = (id: string, data: Record<string, unknown>, version = 1) =>
+  q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,$4)', [id, SHEET, JSON.stringify(data), version])
+const liveRow = async (id: string) =>
+  (await q('SELECT data, version FROM meta_records WHERE id = $1 AND sheet_id = $2', [id, SHEET])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+const burnCount = async () => Number(((await q('SELECT count(*)::int c FROM meta_recovery_token_burns WHERE sheet_id = $1', [SHEET])).rows[0] as { c: number }).c)
+const trashCount = async (recordId: string) => Number(((await q('SELECT count(*)::int c FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2', [recordId, SHEET])).rows[0] as { c: number }).c)
+
+/** Seal one synthetic operation (endpoint = exact MAX of its tagged event seqs) to serve as the anchor. */
+async function sealAnchorOp(recordId: string, eventSeqs: Array<{ seq: string; version: number; action?: 'create' | 'update' | 'delete'; snap?: Record<string, unknown> }>): Promise<string> {
+  const opId = randomUUID()
+  const maxSeq = eventSeqs.map((e) => e.seq).reduce((a, b) => (BigInt(a) >= BigInt(b) ? a : b))
+  await txn(async (query) => {
+    for (const e of eventSeqs) {
+      await query(
+        `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq, operation_id)
+         VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[]::text[],'{}'::jsonb,$5::jsonb,$6::bigint,$7::uuid)`,
+        [SHEET, recordId, e.version, e.action ?? 'update', JSON.stringify(e.snap ?? { [F_STR]: `v${e.version}` }), e.seq, opId],
+      )
+    }
+    await query(
+      `INSERT INTO meta_record_history_operations (sheet_id, operation_id, endpoint_seq, event_count) VALUES ($1,$2::uuid,$3::bigint,$4::int)`,
+      [SHEET, opId, maxSeq, eventSeqs.length],
+    )
+  })
+  return opId
+}
+const activate = () => txn((query) => activateCheckpoint(query, { sheetId: SHEET }))
+
+async function wipe(): Promise<void> {
+  for (const t of ['meta_history_baselines', 'meta_history_trust_checkpoints', 'meta_recovery_token_burns', 'meta_record_version_markers', 'meta_records_trash', 'meta_record_revisions', 'meta_records'])
+    await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+  await q('DELETE FROM meta_record_history_operations WHERE sheet_id = $1', [SHEET]).catch(() => {})
+}
+
+test('sentinel: the real-DB allowlist step must have DATABASE_URL (fail-not-skip, scoped to that step)', () => {
+  if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+    throw new Error('real-DB allowlist step is missing DATABASE_URL — the harness is broken, not legitimately skippable')
+  }
+  expect(true).toBe(true)
+})
+
+describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', () => {
+  beforeAll(async () => {
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'EAA Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'EAA'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_STR, SHEET, 'Note', 'string', '{}', 1])
+  })
+  beforeEach(async () => {
+    await wipe()
+    process.env[FLAG] = 'true' // this test process only — the apply is meaningful with the fence/ledger on
+    __resetRecoveryWriterStateColumnProbe()
+    __resetOperationLedgerColumnProbe()
+  })
+  afterEach(() => { delete process.env[FLAG] })
+  afterAll(async () => {
+    delete process.env[FLAG]
+    await wipe()
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL is set (this suite must RUN, never skip-green)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  /** The standard world: R_REV live differs from at-anchor; R_RES deleted after the anchor; R_NEW created after.
+   *  FIXTURE CAUSALITY: activate FIRST (empty sheet ⇒ empty baseline, small `trusted_since_seq` ≤ the anchor),
+   *  THEN write the synthetic history with explicit seqs above it. Activating after would snapshot the
+   *  post-anchor world into a baseline stamped BELOW the anchor — a causality violation only a synthetic-seq
+   *  fixture can produce (production seq is monotonic), and exactly what composition would faithfully expose. */
+  async function seedWorld() {
+    const R_REV = `rec_rev_${TS}_${Math.random().toString(36).slice(2, 6)}`
+    const R_RES = `rec_res_${TS}_${Math.random().toString(36).slice(2, 6)}`
+    const R_NEW = `rec_new_${TS}_${Math.random().toString(36).slice(2, 6)}`
+    await activate() // empty baseline; trusted_since = nextval (small) ≤ anchor 9001000
+    const anchorOp = await sealAnchorOp(R_REV, [
+      { seq: '9001000', version: 1, action: 'create', snap: { [F_STR]: 'rev-at-anchor' } },
+    ])
+    await revSeq(R_RES, 1, 'create', { [F_STR]: 'res-at-anchor' }, '9000900')
+    // post-anchor history: R_REV updated (v2), R_RES deleted, R_NEW created.
+    await revSeq(R_REV, 2, 'update', { [F_STR]: 'rev-now' }, '9002000')
+    await revSeq(R_RES, 1, 'delete', { [F_STR]: 'res-at-anchor' }, '9002100')
+    await revSeq(R_NEW, 1, 'create', { [F_STR]: 'newbie' }, '9002200')
+    await live(R_REV, { [F_STR]: 'rev-now' }, 2)
+    await live(R_NEW, { [F_STR]: 'newbie' }, 1)
+    return { R_REV, R_RES, R_NEW, anchorOp }
+  }
+  // P1-1: the MODE is chosen at PREVIEW and frozen into the token — the apply has no mode input at all.
+  const preview = async (anchorOp: string, mode: ExactAnchorApplyMode = 'revert') => {
+    const res = await resolveExactAnchor(q as unknown as QueryFn, { sheetId: SHEET, request: { kind: 'exact-anchor', anchorOperationId: anchorOp }, actorId: ACTOR, mode, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(res.ok).toBe(true)
+    if (!res.ok) throw new Error('preview failed')
+    return res
+  }
+
+  test('HAPPY-REVERT: atomic apply — revert + resurrect land, revisions source=restore + ledger-tagged, endpoint sealed, token burned, keeps preserved', async () => {
+    const { R_REV, R_RES, R_NEW, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out).toMatchObject({ ok: true, mode: 'revert', applied: { reverts: 1, resurrects: 1, deletes: 0 } })
+
+    expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-at-anchor' }) // reverted
+    expect((await liveRow(R_REV))?.version).toBe(3) // version+1, never rewound
+    expect((await liveRow(R_RES))?.data).toEqual({ [F_STR]: 'res-at-anchor' }) // resurrected
+    expect((await liveRow(R_RES))?.version).toBe(1) // new generation
+    expect(await liveRow(R_NEW)).toBeDefined() // revert KEEPS created-after-anchor
+
+    // Every apply write is revision-emitted with source 'restore' and TAGGED into ONE sealed operation.
+    const revRows = (await q(
+      `SELECT operation_id::text AS op FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`,
+      [SHEET],
+    )).rows as Array<{ op: string | null }>
+    expect(revRows.length).toBe(2)
+    expect(new Set(revRows.map((r) => r.op)).size).toBe(1)
+    expect(revRows[0].op).toBeTruthy()
+    const ep = (await q('SELECT event_count FROM meta_record_history_operations WHERE sheet_id = $1 AND operation_id = $2::uuid', [SHEET, revRows[0].op])).rows[0] as { event_count: number }
+    expect(ep.event_count).toBe(2) // the apply sealed its own endpoint — a future exact anchor
+    expect(await burnCount()).toBe(1)
+  })
+
+  test('MODE-MATRIX: reset also deletes deletedAtAnchorLiveNow + createdAfterAnchor (with delete revisions); revert kept them (proven above)', async () => {
+    const { R_RES, R_NEW, anchorOp } = await seedWorld()
+    // make R_RES a deleted-at-anchor-live-now case instead: resurrect it post-anchor so it is LIVE now.
+    await revSeq(R_RES, 1, 'create', { [F_STR]: 'res-gen2' }, '9002300')
+    await live(R_RES, { [F_STR]: 'res-gen2' }, 1)
+    // NOTE the anchor (1000) predates R_RES's create @900? No — 900 < 1000, so R_RES EXISTED at the anchor
+    // with 'res-at-anchor', was deleted @2100, re-created @2300. At the anchor it EXISTS ⇒ it is a REVERT
+    // candidate (live 'res-gen2' → target 'res-at-anchor'), not a delete case. R_NEW (created @2200) is the
+    // reset-delete case this golden pins.
+    // P1-1: reset must be PREVIEWED as reset — the mode rides in the token, not the apply call.
+    const pv = await preview(anchorOp, 'reset')
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out.ok).toBe(true)
+    if (!out.ok) return
+    expect(out.mode).toBe('reset') // the TOKEN's mode, echoed
+    expect(out.applied.deletes).toBe(1) // R_NEW deleted by reset
+    expect(await liveRow(R_NEW)).toBeUndefined()
+    const delRev = (await q(
+      `SELECT snapshot FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2 AND action = 'delete' AND source = 'restore'`,
+      [SHEET, R_NEW],
+    )).rows[0] as { snapshot: Record<string, unknown> } | undefined
+    expect(delRev?.snapshot).toEqual({ [F_STR]: 'newbie' }) // pre-delete snapshot captured
+  })
+
+  test('REPLAY: a second execute of the SAME token ⇒ token-replayed, zero writes', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+    const afterFirst = await liveRow(R_REV)
+    const second = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(second).toEqual({ ok: false, reason: 'token-replayed' })
+    expect(await liveRow(R_REV)).toEqual(afterFirst) // untouched by the replay attempt
+    expect(await burnCount()).toBe(1) // still exactly one burn
+  })
+
+  test('LIVE-DRIFT: a concurrent committed write between preview and execute ⇒ preview-drift, ZERO writes incl. the burn (the token survives and works once the drift is undone)', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    // Concurrent write AFTER the preview: bump R_REV (exactly what a user editing during the confirm dialog does).
+    await q('UPDATE meta_records SET data = $1::jsonb, version = version + 1 WHERE id = $2 AND sheet_id = $3', [JSON.stringify({ [F_STR]: 'sneaky' }), R_REV, SHEET])
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out).toEqual({ ok: false, reason: 'preview-drift' })
+    expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'sneaky' }) // nothing applied
+    expect(await burnCount()).toBe(0) // the burn rolled back with everything else — zero writes means ZERO
+    // Restore the exact previewed world ⇒ the SAME token executes (proves the refusal wrote nothing at all).
+    await q('UPDATE meta_records SET data = $1::jsonb, version = version - 1 WHERE id = $2 AND sheet_id = $3', [JSON.stringify({ [F_STR]: 'rev-now' }), R_REV, SHEET])
+    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+  })
+
+  test('CHECKPOINT-GONE / CHECKPOINT-CHANGED: the in-fence re-resolution never trusts the token echo', async () => {
+    const { anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    // (a) remove the covering checkpoint entirely ⇒ no-covering-checkpoint, zero writes.
+    await q('DELETE FROM meta_history_baselines WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_history_trust_checkpoints WHERE sheet_id = $1', [SHEET])
+    expect(await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'no-covering-checkpoint' })
+    expect(await burnCount()).toBe(0)
+    // (b) a DIFFERENT covering checkpoint (fresh activation) ⇒ the resolved id no longer equals the token's
+    //     checkpointId ⇒ checkpoint-changed (re-preview under the new trust floor).
+    await activate()
+    expect(await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'checkpoint-changed' })
+  })
+
+  test('INJECTED-FAILURE: a mid-apply crash rolls back EVERYTHING (no record change, no revisions, no endpoint, no burn)', async () => {
+    const { R_REV, R_RES, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    // Inject: pre-take R_RES's primary key inside ANOTHER sheet? No — same id across sheets collides on the
+    // meta_records PK (id). Insert a foreign-sheet row with R_RES's id so the apply's resurrect INSERT
+    // violates the PK AFTER the revert UPDATE already ran — a genuine mid-apply failure.
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3) ON CONFLICT (id) DO NOTHING', [`${SHEET}_other`, BASE, 'EAA other'])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [R_RES, `${SHEET}_other`, '{}'])
+    await expect(applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).rejects.toThrow()
+    // FULL rollback: the revert (which ran BEFORE the failing resurrect) is undone too.
+    expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-now' })
+    expect((await liveRow(R_REV))?.version).toBe(2)
+    expect(Number(((await q(`SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }).c)).toBe(0)
+    expect(await burnCount()).toBe(0)
+    // cleanup the injection
+    await q('DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2', [R_RES, `${SHEET}_other`])
+    await q('DELETE FROM meta_sheets WHERE id = $1', [`${SHEET}_other`])
+  })
+
+  test('BASELINE composition: a record living ONLY in the checkpoint baseline resurrects from baseline data; a trashed baseline row stays deleted', async () => {
+    const R_BASE = `rec_base_${TS}`
+    const R_TRASHED = `rec_trashed_${TS}`
+    // Anchor world: one revision-bearing record so an anchor op exists.
+    const R_REV = `rec_rev_${TS}_bl`
+    const anchorOp = await sealAnchorOp(R_REV, [{ seq: '9001000', version: 1, action: 'create', snap: { [F_STR]: 'x' } }])
+    await live(R_REV, { [F_STR]: 'x' }, 1)
+    const ck = await activate()
+    // Inject baseline-only records into the ACTIVE checkpoint (their revisions were "retention-pruned"):
+    // R_BASE existed (non-trashed) at the checkpoint; R_TRASHED was in the recycle bin (is_trashed).
+    const ckId = (ck as { checkpointId: string }).checkpointId
+    await q(
+      `INSERT INTO meta_history_baselines (checkpoint_id, sheet_id, record_id, data, version, is_trashed)
+       VALUES ($1,$2,$3,$4::jsonb,5,false), ($1,$2,$5,$6::jsonb,2,true)`,
+      [ckId, SHEET, R_BASE, JSON.stringify({ [F_STR]: 'from-baseline' }), R_TRASHED, JSON.stringify({ [F_STR]: 'was-trashed' })],
+    )
+    const pv = await preview(anchorOp)
+    // F4 (pre-wiring gate list): the PREVIEW already shows the baseline-composed set — what-you-see-is-
+    // what-applies. Both baseline records are in the preview stateMap (R_BASE as existing at-anchor,
+    // R_TRASHED as deleted-at-anchor), and the token's scopeHash covers this SAME composed set — the apply
+    // below succeeding proves preview↔apply hash symmetry (an asymmetric pair would refuse preview-drift).
+    expect(pv.stateMap.get(R_BASE)).toMatchObject({ exists: true, data: { [F_STR]: 'from-baseline' } })
+    expect(pv.stateMap.get(R_TRASHED)).toMatchObject({ exists: false })
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out.ok).toBe(true)
+    // R_BASE resurrected FROM THE BASELINE (below the replay horizon); R_TRASHED stays deleted.
+    expect((await liveRow(R_BASE))?.data).toEqual({ [F_STR]: 'from-baseline' })
+    expect(await liveRow(R_TRASHED)).toBeUndefined()
+  })
+
+  test('LOCKED record: a lock held by ANOTHER actor aborts the whole all-or-nothing apply (rank-8 discipline); unlocking lets it through', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    await q('UPDATE meta_records SET locked = true, locked_by = $1 WHERE id = $2 AND sheet_id = $3', ['someone-else', R_REV, SHEET])
+    const pv = await preview(anchorOp) // lock columns are not part of the live {id, version} fingerprint
+    await expect(applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).rejects.toThrow(/locked/i)
+    expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-now' }) // nothing applied (all-or-nothing)
+    expect(await burnCount()).toBe(0)
+    // unlock ⇒ the SAME token applies (the refusal wrote nothing).
+    await q('UPDATE meta_records SET locked = false, locked_by = NULL WHERE id = $1 AND sheet_id = $2', [R_REV, SHEET])
+    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+  })
+
+  test('FENCE-PARK (constructed race): a raw client holding the canonical fence parks the apply until release', async () => {
+    const { anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    expect(pool).toBeTruthy()
+    const holder = await pool!.connect()
+    try {
+      await holder.query('BEGIN')
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`meta:auto-number:sheet:${SHEET}`])
+      // Launch the apply concurrently — it must PARK on the fence (not proceed, not fail).
+      const applying = applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+      // Sample pg_locks until the apply's advisory-lock wait is visible (bounded loop, no sleeps beyond polling).
+      let sawWaiter = false
+      for (let i = 0; i < 100; i++) {
+        const waiters = await holder.query(
+          `SELECT count(*)::int AS c FROM pg_locks WHERE locktype = 'advisory' AND NOT granted`,
+        )
+        if (Number((waiters.rows[0] as { c: number }).c) > 0) { sawWaiter = true; break }
+        await new Promise((r) => setTimeout(r, 50))
+      }
+      expect(sawWaiter).toBe(true) // the apply is genuinely parked behind the fence
+      await holder.query('COMMIT') // release ⇒ the apply proceeds to completion
+      const out = await applying
+      expect(out.ok).toBe(true)
+    } finally {
+      holder.release()
+    }
+  })
+
+  // ── P1-1 MODE-BIND: a revert-preview token can NEVER drive a reset ───────────────────────────────────────
+  test('MODE-BIND (P1-1): a token minted at revert-preview performs ZERO deletes even with a live reset-delete candidate — the mode rides in the token, the apply has no mode input', async () => {
+    const { R_NEW, anchorOp } = await seedWorld() // R_NEW = created-after-anchor ⇒ the reset-delete candidate
+    const pv = await preview(anchorOp, 'revert')
+    // The pre-fix attack: same unburned token + `mode:'reset'` at the apply call ⇒ R_NEW destroyed. The
+    // input no longer HAS a mode — the only thing a caller could vary is gone. The behavioral pin:
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out.ok).toBe(true)
+    if (!out.ok) return
+    expect(out.mode).toBe('revert') // the TOKEN's mode
+    expect(out.applied.deletes).toBe(0)
+    expect(await liveRow(R_NEW)).toBeDefined() // the reset-delete candidate SURVIVES a revert-token apply
+  })
+
+  // ── P1-2 IN-FENCE AUTHORIZATION ─────────────────────────────────────────────────────────────────────────
+  test('AUTH-INFENCE (P1-2): permission revoked between preview and execute ⇒ forbidden, ZERO writes incl. the burn; re-granted ⇒ the SAME token applies', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp, 'revert')
+    const before = await liveRow(R_REV)
+    const denied = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: DENY_FULL_READ })
+    expect(denied).toEqual({ ok: false, reason: 'forbidden' })
+    expect(await liveRow(R_REV)).toEqual(before) // zero writes
+    expect(await burnCount()).toBe(0) // the burn rolled back with the refusal — the token is NOT half-dead
+    // re-grant ⇒ the very same token proceeds (fresh adjudication each execute, not a token property).
+    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+  })
+
+  test('AUTH-BASIS (P1-2): a validly-signed token whose authorizedScopeHash mismatches the recomputed basis ⇒ forbidden, zero writes (the token echo is never the authority)', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp, 'revert')
+    const before = await liveRow(R_REV)
+    // Same REAL scopeHash/liveSetHash/checkpoint — only the signed authorization basis is wrong.
+    const claims = {
+      sheetId: SHEET, anchorOperationId: anchorOp, anchorSeq: pv.anchorSeq, checkpointId: pv.checkpointId,
+      scopeHash: pv.scopeHash, actorId: ACTOR, mode: 'revert' as const, authorizedScopeHash: 'e'.repeat(64),
+    }
+    // liveSetHash must be the REAL one so this golden isolates the authorization axis: recompute it the
+    // way the preview does (same primitive over the live {id, version} set).
+    const liveRows = (await q('SELECT id, version FROM meta_records WHERE sheet_id = $1', [SHEET])).rows as Array<{ id: string; version: number }>
+    const wrongBasis = mintExactAnchorRecoveryIdentity({
+      ...claims,
+      liveSetHash: hashAnchorRecoveryScope(liveRows.map((r) => ({ recordId: String(r.id), exists: true, version: Number(r.version) }))),
+    })
+    expect(await applyExactAnchorRecovery(txn, { token: wrongBasis, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+      .toEqual({ ok: false, reason: 'forbidden' })
+    expect(await liveRow(R_REV)).toEqual(before)
+    expect(await burnCount()).toBe(0)
+    // POSITIVE control (anti-vacuous): the same mint with the CORRECT basis applies cleanly.
+    const rightBasis = mintExactAnchorRecoveryIdentity({
+      ...claims,
+      authorizedScopeHash: hashRecoveryAuthorizationScope({ sheetId: SHEET, actorId: ACTOR }),
+      liveSetHash: hashAnchorRecoveryScope(liveRows.map((r) => ({ recordId: String(r.id), exists: true, version: Number(r.version) }))),
+    })
+    expect((await applyExactAnchorRecovery(txn, { token: rightBasis, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+  })
+
+  // ── P1-2 SCHEMA-DRIFT WHOLE-REJECT ──────────────────────────────────────────────────────────────────────
+  test('DRIFT-REJECT (P1-2): driftCount > 0 ⇒ the WHOLE apply refuses schema-drift with zero writes incl. the burn — no partial-set apply through drift exclusion', async () => {
+    const { R_REV, R_NEW, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp, 'revert')
+    const beforeRev = await liveRow(R_REV)
+    // Drop the field AFTER preview: every at-anchor snapshot now carries a stale field id ⇒ plan.driftCount>0.
+    // (The scope/live hashes cover records, not schema — this reaches the PLAN, which is exactly the point.)
+    await q('DELETE FROM meta_fields WHERE id = $1 AND sheet_id = $2', [F_STR, SHEET])
+    try {
+      expect(await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))
+        .toEqual({ ok: false, reason: 'schema-drift' })
+      expect(await liveRow(R_REV)).toEqual(beforeRev) // untouched
+      expect(await liveRow(R_NEW)).toBeDefined() // nothing deleted
+      expect(await burnCount()).toBe(0) // burn rolled back — token dies by TTL, not half-burn
+    } finally {
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6) ON CONFLICT (id) DO NOTHING', [F_STR, SHEET, 'Note', 'string', '{}', 1])
+    }
+    // POSITIVE CONTROL (anti-vacuous, gate NIT-2): with the schema restored, the SAME token — unburned by
+    // the refusal above — now applies cleanly. Proves the refusal was attributable to the drift alone.
+    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+  })
+
+  // ── G2 (pre-wiring gate list): RESURRECT uses the AT-ANCHOR snapshot, never the trash row's vintage ─────
+  test('G2 RESURRECT-VS-TRASH: a record edited after the anchor then deleted (trash carries the TERMINAL vintage) resurrects to its AT-ANCHOR data', async () => {
+    const { anchorOp } = await seedWorld()
+    const R_G2 = `rec_g2vint_${TS}`
+    // at-anchor (< anchor seq): 'g2-at-anchor'. Post-anchor: edited to 'g2-terminal', then deleted — the
+    // TRASH row (and the delete revision's snapshot) both carry the TERMINAL vintage, the wrong source.
+    await revSeq(R_G2, 1, 'create', { [F_STR]: 'g2-at-anchor' }, '9000800')
+    await revSeq(R_G2, 2, 'update', { [F_STR]: 'g2-terminal' }, '9001900')
+    await revSeq(R_G2, 2, 'delete', { [F_STR]: 'g2-terminal' }, '9002150')
+    await q(
+      'INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)',
+      [R_G2, SHEET, JSON.stringify({ [F_STR]: 'g2-terminal' }), 2],
+    )
+    // A live foreign target so the outbound-link rebuild has something to point at is unnecessary here (no
+    // link field on this fixture); this golden pins the trash-lifecycle invariant.
+    const trashBefore = await trashCount(R_G2)
+    expect(trashBefore).toBe(1) // precondition: the record IS in the recycle bin
+    const pv = await preview(anchorOp, 'revert')
+    const out = await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })
+    expect(out.ok).toBe(true)
+    // Resurrected from the REVISION CHAIN's at-anchor state — the trash row's terminal vintage is never read.
+    expect((await liveRow(R_G2))?.data).toEqual({ [F_STR]: 'g2-at-anchor' })
+    expect((await liveRow(R_G2))?.version).toBe(1) // new generation
+    // OWNER P1 (2026-07-17): live/trash MUTUAL EXCLUSION — the resurrect must have removed the trash row.
+    // Without the trash cleanup the record is live AND still in the recycle bin (future restore 23505,
+    // mis-pinned tombstone/retention). Mutation: drop the `DELETE FROM meta_records_trash` ⇒ this reds.
+    expect(await trashCount(R_G2)).toBe(0)
+  })
+
+  test('G2b RESURRECT-TRASH-ROLLBACK: an injected failure AFTER the resurrect rolls the live row, its revision AND the trash deletion back together (all-or-nothing)', async () => {
+    const { anchorOp } = await seedWorld()
+    const R_G2B = `rec_g2b_${TS}`
+    await revSeq(R_G2B, 1, 'create', { [F_STR]: 'g2b-at-anchor' }, '9000850')
+    await revSeq(R_G2B, 1, 'delete', { [F_STR]: 'g2b-at-anchor' }, '9002250') // deleted after the anchor
+    await q(
+      'INSERT INTO meta_records_trash (record_id, sheet_id, data, original_version) VALUES ($1,$2,$3::jsonb,$4)',
+      [R_G2B, SHEET, JSON.stringify({ [F_STR]: 'g2b-at-anchor' }), 1],
+    )
+    expect(await trashCount(R_G2B)).toBe(1)
+    const pv = await preview(anchorOp, 'revert')
+    // Inject a failure at the SEAL step (after every resurrect write incl. the trash deletion). A synthetic
+    // trigger that raises on INSERT into meta_record_history_operations forces the seal to throw ⇒ the whole
+    // outer txn rolls back. If the trash deletion did NOT participate in this txn, the row would stay gone.
+    const fn = `eaa_g2b_seal_fail_${TS}`
+    const trg = `trg_eaa_g2b_seal_fail_${TS}`
+    await q(`CREATE OR REPLACE FUNCTION ${fn}() RETURNS trigger AS $$ BEGIN RAISE EXCEPTION 'injected seal failure (G2b)'; END $$ LANGUAGE plpgsql`)
+    await q(`CREATE TRIGGER ${trg} BEFORE INSERT ON meta_record_history_operations FOR EACH ROW WHEN (NEW.sheet_id = '${SHEET}') EXECUTE FUNCTION ${fn}()`)
+    try {
+      await expect(applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).rejects.toThrow()
+      // EVERYTHING rolled back together: no live row, the trash row SURVIVES, no create revision, no burn.
+      expect(await liveRow(R_G2B)).toBeUndefined()
+      expect(await trashCount(R_G2B)).toBe(1) // the trash deletion rolled back with the failed apply
+      const revs = Number(((await q("SELECT count(*)::int c FROM meta_record_revisions WHERE record_id = $1 AND action = 'create' AND source = 'restore'", [R_G2B])).rows[0] as { c: number }).c)
+      expect(revs).toBe(0)
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q(`DROP TRIGGER IF EXISTS ${trg} ON meta_record_history_operations`).catch(() => {})
+      await q(`DROP FUNCTION IF EXISTS ${fn}()`).catch(() => {})
+    }
+  })
+
+  // ── G3 (pre-wiring gate list): DOUBLE-TOKEN constructed race ─────────────────────────────────────────────
+  test('G3 DOUBLE-TOKEN (constructed race): two previews, two concurrent applies — exactly ONE succeeds; the loser refuses preview-drift; exactly one burn', async () => {
+    const { anchorOp } = await seedWorld()
+    const pv1 = await preview(anchorOp, 'revert')
+    await new Promise((r) => setTimeout(r, 1100)) // distinct JWT iat second ⇒ distinct token ⇒ distinct burn PK
+    const pv2 = await preview(anchorOp, 'revert')
+    expect(pv2.token).not.toBe(pv1.token)
+
+    // Both applies race on the canonical fence (each in its own real transaction/connection). The fence
+    // serializes them: the winner commits its reverts/resurrects (bumping live versions); the loser's
+    // in-fence live-set re-hash then diverges from ITS token's liveSetHash ⇒ preview-drift, full rollback.
+    const [r1, r2] = await Promise.all([
+      applyExactAnchorRecovery(txn, { token: pv1.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }),
+      applyExactAnchorRecovery(txn, { token: pv2.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }),
+    ])
+    const oks = [r1, r2].filter((r) => r.ok)
+    const refusals = [r1, r2].filter((r) => !r.ok) as Array<{ ok: false; reason: string }>
+    expect(oks.length).toBe(1) // exactly one winner
+    expect(refusals.length).toBe(1)
+    expect(refusals[0].reason).toBe('preview-drift') // the loser saw the winner's committed world
+    expect(await burnCount()).toBe(1) // the loser's burn rolled back with its refusal
+  })
+
+  // ── G1 (pre-wiring gate list): burn-retention sweep ─────────────────────────────────────────────────────
+  test('G1 BURN-RETENTION: the sweep prunes only burns older than the keep window, and the floor clamp protects any possibly-live token', async () => {
+    const { anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp, 'revert')
+    expect((await applyExactAnchorRecovery(txn, { token: pv.token, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ })).ok).toBe(true)
+    expect(await burnCount()).toBe(1) // the fresh burn from the successful apply
+
+    // A synthetic OLD burn (2 hours ago) — prunable at the default 60m keep.
+    await q(
+      `INSERT INTO meta_recovery_token_burns (token_sha256, sheet_id, actor_id, burned_at) VALUES ($1,$2,$3, now() - interval '120 minutes')`,
+      [`deadold${TS}`.padEnd(64, '0'), SHEET, ACTOR],
+    )
+    // A synthetic 20-minute-old burn: older than a live token's 10m TTL but INSIDE an aggressive 1-minute
+    // keep request — the 15m FLOOR clamp must protect... no: 20m > 15m floor ⇒ prunable under floor. Use a
+    // 12-minute-old burn instead: younger than the 15m floor ⇒ MUST survive even a keepMinutes=1 request
+    // (pruning it could resurrect a replayed token whose JWT is still within clock-skew of its exp).
+    await q(
+      `INSERT INTO meta_recovery_token_burns (token_sha256, sheet_id, actor_id, burned_at) VALUES ($1,$2,$3, now() - interval '12 minutes')`,
+      [`deadmid${TS}`.padEnd(64, '1'), SHEET, ACTOR],
+    )
+
+    const pruned = await pruneExpiredRecoveryTokenBurns(q as unknown as QueryFn, 1) // aggressive request
+    expect(pruned).toBe(1) // ONLY the 2h-old row — the 12m row is inside the 15m floor, the fresh row is new
+    const remaining = (await q('SELECT token_sha256 FROM meta_recovery_token_burns WHERE sheet_id = $1', [SHEET])).rows as Array<{ token_sha256: string }>
+    const shas = new Set(remaining.map((r) => r.token_sha256))
+    expect(shas.has(`deadold${TS}`.padEnd(64, '0'))).toBe(false) // pruned
+    expect(shas.has(`deadmid${TS}`.padEnd(64, '1'))).toBe(true) // floor-protected
+    expect(remaining.length).toBe(2) // 12m row + the real fresh burn
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -430,6 +430,67 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     }
   })
 
+  test('ROW-LOCK-RACE (constructed): external FOR UPDATE on affected row parks L8; unfenced concurrent version bump ⇒ preview-drift, zero burn/writes; undo ⇒ same token applies', async () => {
+    // v3.7 §5 step 7: sheet advisory fence alone is not enough — an unfenced writer can still UPDATE the
+    // target row between liveSetHash and apply. Targeted SELECT … FOR UPDATE + version recheck must catch it.
+    //
+    // Construction: hold the target row FOR UPDATE (no sheet fence) → launch L8 → prove L8 is still in-flight
+    // after a budget that is long enough for an unblocked apply to finish (so missing FOR UPDATE fails here)
+    // → concurrent version bump + COMMIT → L8 wakes and refuses preview-drift.
+    const { R_REV, anchorOp, seqs } = await seedWorld()
+    const pv = await preview(anchorOp, 'revert')
+    expect(pool).toBeTruthy()
+    const holder = await pool!.connect()
+    try {
+      await holder.query('BEGIN')
+      await holder.query(
+        'SELECT id, version FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE',
+        [R_REV, SHEET],
+      )
+      let applySettled = false
+      const applying = applyExactAnchorRecovery(txn, applyArgs(pv.token)).finally(() => {
+        applySettled = true
+      })
+      // Budget >> unblocked L8 latency in this suite (~1–2s worst) so a missing row lock fails this assert
+      // (apply would finish ok:true). With FOR UPDATE, L8 must still be in-flight behind our row hold.
+      await new Promise((r) => setTimeout(r, 2500))
+      expect(applySettled).toBe(false)
+      // Concurrent unfenced write while L8 is parked on the old lock.
+      const sBump = String(BigInt(seqs.sNew) + 2000n)
+      await holder.query(
+        `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq)
+         VALUES (gen_random_uuid(), $1, $2, 3, 'update', 'rest', ARRAY[]::text[], '{}'::jsonb, $3::jsonb, $4::bigint)`,
+        [SHEET, R_REV, JSON.stringify({ [F_STR]: 'concurrent' }), sBump],
+      )
+      await holder.query(
+        `UPDATE meta_records SET data = $1::jsonb, version = 3 WHERE id = $2 AND sheet_id = $3`,
+        [JSON.stringify({ [F_STR]: 'concurrent' }), R_REV, SHEET],
+      )
+      await holder.query('COMMIT') // release ⇒ L8 wakes, rechecks version, refuses preview-drift
+      const out = await applying
+      expect(out).toEqual({ ok: false, reason: 'preview-drift' })
+      expect((await liveRow(R_REV))?.version).toBe(3)
+      expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'concurrent' })
+      expect(await burnCount()).toBe(0)
+      expect(Number(((await q(
+        `SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`,
+        [SHEET],
+      )).rows[0] as { c: number }).c)).toBe(0)
+    } finally {
+      try { await holder.query('ROLLBACK') } catch { /* may already be committed */ }
+      holder.release()
+    }
+    // POSITIVE control: undo concurrent bump so token liveSetHash matches again; same unburned token applies.
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2 AND version = 3', [SHEET, R_REV])
+    await q(
+      `UPDATE meta_records SET data = $1::jsonb, version = 2 WHERE id = $2 AND sheet_id = $3`,
+      [JSON.stringify({ [F_STR]: 'rev-now' }), R_REV, SHEET],
+    )
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
+    expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-at-anchor' })
+    expect(await burnCount()).toBe(1)
+  })
+
   // ── P1-1 MODE-BIND: a revert-preview token can NEVER drive a reset ───────────────────────────────────────
   test('MODE-BIND (P1-1): a token minted at revert-preview performs ZERO deletes even with a live reset-delete candidate — the mode rides in the token, the apply has no mode input', async () => {
     const { R_NEW, anchorOp } = await seedWorld() // R_NEW = created-after-anchor ⇒ the reset-delete candidate

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -432,7 +432,8 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
 
   test('ROW-LOCK-RACE (constructed): external FOR UPDATE on affected row parks L8; unfenced concurrent version bump ⇒ preview-drift, zero burn/writes; undo ⇒ same token applies', async () => {
     // v3.7 §5 step 7: sheet advisory fence alone is not enough — an unfenced writer can still UPDATE the
-    // target row between liveSetHash and apply. Targeted SELECT … FOR UPDATE + version recheck must catch it.
+    // target row between liveSetHash and apply. The FULL live-set SELECT … FOR UPDATE + hash-from-locked-rows
+    // must catch it.
     //
     // Construction: hold the target row FOR UPDATE (no sheet fence) → launch L8 → prove L8 is still in-flight
     // after a budget that is long enough for an unblocked apply to finish (so missing FOR UPDATE fails here)
@@ -1344,6 +1345,234 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     )).rows as Array<{ record_id: string; foreign_record_id: string }>
     expect(tombsA).toEqual([{ record_id: R_B, foreign_record_id: R_A }])
     expect(tombsB).toEqual([{ record_id: R_A, foreign_record_id: R_B }])
+  })
+
+  // ── W1-C hardening: txn proof, malformed live truth fail-closed, full-set lock races, write-time CAS ───
+  test('TXN-PROOF: a fake `transaction` wrapper running autocommit statements ⇒ recovery-trust-required, zero burn/writes; the SAME token over a real txn applies', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    const before = await liveRow(R_REV)
+    // Forged wrapper: no BEGIN — every statement autocommits on the pool. The pg_current_xact_id probe
+    // must refuse BEFORE the fence/burn: an autocommitted burn row would survive its own "rollback".
+    const fakeTxn = <T>(fn: (query: QueryFn) => Promise<T>): Promise<T> => fn(q as unknown as QueryFn)
+    expect(await applyExactAnchorRecovery(fakeTxn, applyArgs(pv.token)))
+      .toEqual({ ok: false, reason: 'recovery-trust-required' })
+    expect(await liveRow(R_REV)).toEqual(before)
+    expect(await burnCount()).toBe(0) // nothing ran before the probe — no autocommitted burn
+    expect(Number(((await q(`SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }).c)).toBe(0)
+    // POSITIVE control (anti-vacuous): the same unburned token over a REAL transaction applies.
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
+  })
+
+  test('MALFORMED-LIVE data: a scalar-data live row the strict precheck cannot see (all user fields absent from the latest snapshot) ⇒ recovery-trust-required — the old asRec coercion would have destructively applied over it', async () => {
+    // World: at-anchor {F_STR:'at'}; the LATEST snapshot is {} (user field removed), so the precheck's
+    // content layer compares undefined===undefined and PASSES even over a corrupt scalar-data row. Only
+    // the apply's fail-closed shape validation stands between this row and a destructive revert.
+    const R = `rec_maldata_${TS}`
+    const [sCreate, sUpdate] = await seqBand(2)
+    const anchorOp = await sealAnchorOp(R, [
+      { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'at' } },
+    ])
+    await revSeq(R, 2, 'update', {}, sUpdate)
+    await live(R, {}, 2)
+    const pv = await preview(anchorOp)
+    // Corrupt AFTER preview: the id/version fingerprint is unchanged, so no hash can refuse this.
+    await q(`UPDATE meta_records SET data = '"corrupt"'::jsonb WHERE id = $1 AND sheet_id = $2`, [R, SHEET])
+    expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token)))
+      .toEqual({ ok: false, reason: 'recovery-trust-required' })
+    expect(await burnCount()).toBe(0)
+    // Repair ⇒ the same unburned token applies and the revert lands.
+    await q(`UPDATE meta_records SET data = '{}'::jsonb WHERE id = $1 AND sheet_id = $2`, [R, SHEET])
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
+    expect((await liveRow(R))?.data).toEqual({ [F_STR]: 'at' })
+  })
+
+  test('MALFORMED-LIVE version (injected past the precheck): version corrupted to -1 AFTER the strict precheck ⇒ recovery-trust-required — the old Number()||0 path would have misclassified it as preview-drift', async () => {
+    const { R_REV, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp)
+    // The burn INSERT runs after the strict precheck and before the live-set lock: an AFTER INSERT trigger
+    // there corrupts the version in the SAME txn, past every upstream integrity layer.
+    const fn = `eaa_neg_ver_${TS}`
+    const trg = `trg_eaa_neg_ver_${TS}`
+    await q(`CREATE OR REPLACE FUNCTION ${fn}() RETURNS trigger AS $$ BEGIN
+      UPDATE meta_records SET version = -1 WHERE id = '${R_REV}' AND sheet_id = NEW.sheet_id;
+      RETURN NEW; END $$ LANGUAGE plpgsql`)
+    await q(`CREATE TRIGGER ${trg} AFTER INSERT ON meta_recovery_token_burns FOR EACH ROW
+      WHEN (NEW.sheet_id = '${SHEET}') EXECUTE FUNCTION ${fn}()`)
+    try {
+      // Fail-closed SHAPE classification, not drift: a negative version is corrupt substrate.
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token)))
+        .toEqual({ ok: false, reason: 'recovery-trust-required' })
+      expect((await liveRow(R_REV))?.version).toBe(2) // the injected corruption rolled back too
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q(`DROP TRIGGER IF EXISTS ${trg} ON meta_recovery_token_burns`).catch(() => {})
+      await q(`DROP FUNCTION IF EXISTS ${fn}()`).catch(() => {})
+    }
+    // POSITIVE control: trigger removed ⇒ the same unburned token applies.
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
+  })
+
+  test('MALFORMED-ANCHOR snapshot: an at-anchor snapshot that is a jsonb array ⇒ ExactAnchorPlanDataError maps to recovery-trust-required, zero burn/writes', async () => {
+    const R = `rec_mal_${TS}`
+    const [sCreate] = await seqBand(1)
+    const anchorOp = await sealAnchorOp(R, [
+      { seq: sCreate, version: 1, action: 'create', snap: ['not-an-object'] as unknown as Record<string, unknown> },
+    ])
+    // Live data {} content-matches the precheck's coerced view of the array snapshot (no user field on
+    // either side), so the strict precheck PASSES — only the plan classifier sees the malformed target.
+    await live(R, {}, 1)
+    const pv = await preview(anchorOp)
+    expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token)))
+      .toEqual({ ok: false, reason: 'recovery-trust-required' })
+    expect((await liveRow(R))?.data).toEqual({})
+    expect(await burnCount()).toBe(0)
+  })
+
+  test('PARKED-CREATE (constructed race): an unfenced INSERT committed while the apply is PARKED on the full live-set lock ⇒ preview-drift, zero burn/writes — a stale RESET delete set never commits around a new record', async () => {
+    const { R_REV, R_NEW, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp, 'reset')
+    expect(pool).toBeTruthy()
+    const R_X = `rec_parked_new_${TS}`
+    const holder = await pool!.connect()
+    try {
+      await holder.query('BEGIN')
+      await holder.query('SELECT id FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE', [R_REV, SHEET])
+      let applySettled = false
+      const applying = applyExactAnchorRecovery(txn, applyArgs(pv.token)).finally(() => { applySettled = true })
+      await new Promise((r) => setTimeout(r, 2500))
+      expect(applySettled).toBe(false) // parked on the full-set lock behind our row hold
+      // Unfenced CREATE commits while the lock statement is parked. FOR UPDATE cannot lock a phantom and
+      // the lock statement's snapshot predates this commit — ONLY the fresh post-lock re-hash can see it.
+      const sX = String((await holder.query(`SELECT nextval('meta_record_chain_seq')::text AS s`)).rows[0].s)
+      await holder.query(
+        `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq)
+         VALUES (gen_random_uuid(), $1, $2, 1, 'create', 'rest', ARRAY[]::text[], '{}'::jsonb, $3::jsonb, $4::bigint)`,
+        [SHEET, R_X, JSON.stringify({ [F_STR]: 'parked-newbie' }), sX],
+      )
+      await holder.query(
+        'INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+        [R_X, SHEET, JSON.stringify({ [F_STR]: 'parked-newbie' })],
+      )
+      await holder.query('COMMIT')
+      const out = await applying
+      expect(out).toEqual({ ok: false, reason: 'preview-drift' })
+      expect(await liveRow(R_X)).toBeDefined() // the concurrent create SURVIVED untouched
+      expect(await liveRow(R_NEW)).toBeDefined() // the reset delete set did NOT partially apply
+      expect(await burnCount()).toBe(0)
+      expect(Number(((await q(`SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }).c)).toBe(0)
+    } finally {
+      try { await holder.query('ROLLBACK') } catch { /* committed above */ }
+      holder.release()
+    }
+    // POSITIVE control: remove the concurrent create ⇒ the same unburned token applies (reset deletes R_NEW).
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2', [SHEET, R_X])
+    await q('DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2', [R_X, SHEET])
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
+    expect(await liveRow(R_NEW)).toBeUndefined()
+  })
+
+  test('PARKED-BUMP non-affected (constructed race): a version bump on a row OUTSIDE the write delta committed while the apply is PARKED ⇒ preview-drift, zero burn/writes — a delta-only lock would sail past it', async () => {
+    const { R_REV, R_NEW, anchorOp, seqs } = await seedWorld()
+    const pv = await preview(anchorOp, 'revert') // R_NEW is created-after: revert KEEPS it — no write intent
+    expect(pool).toBeTruthy()
+    const holder = await pool!.connect()
+    try {
+      await holder.query('BEGIN')
+      await holder.query('SELECT id FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE', [R_NEW, SHEET])
+      let applySettled = false
+      const applying = applyExactAnchorRecovery(txn, applyArgs(pv.token)).finally(() => { applySettled = true })
+      await new Promise((r) => setTimeout(r, 2500))
+      // A write-delta-only lock never waits on R_NEW (it is not written), and the old plain-read hash ran
+      // before this bump committed — only the FULL live-set lock parks here and re-reads the bumped truth.
+      expect(applySettled).toBe(false)
+      const sBump = String(BigInt(seqs.sNew) + 3000n)
+      await holder.query(
+        `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, seq)
+         VALUES (gen_random_uuid(), $1, $2, 2, 'update', 'rest', ARRAY[]::text[], '{}'::jsonb, $3::jsonb, $4::bigint)`,
+        [SHEET, R_NEW, JSON.stringify({ [F_STR]: 'newbie-bumped' }), sBump],
+      )
+      await holder.query('UPDATE meta_records SET version = 2 WHERE id = $1 AND sheet_id = $2', [R_NEW, SHEET])
+      await holder.query('COMMIT')
+      const out = await applying
+      expect(out).toEqual({ ok: false, reason: 'preview-drift' })
+      expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-now' }) // the revert did NOT land
+      expect(await burnCount()).toBe(0)
+    } finally {
+      try { await holder.query('ROLLBACK') } catch { /* committed above */ }
+      holder.release()
+    }
+    // POSITIVE control: rewind the bump ⇒ the same unburned token applies.
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2 AND version = 2', [SHEET, R_NEW])
+    await q('UPDATE meta_records SET version = 1 WHERE id = $1 AND sheet_id = $2', [R_NEW, SHEET])
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
+    expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-at-anchor' })
+  })
+
+  test('RESET-DELETE-CAS (injected same-txn drift): version bumped after the delete revision but before the CAS delete ⇒ preview-drift (never a bare Error), full rollback incl. the injected bump', async () => {
+    const { R_REV, R_NEW, anchorOp } = await seedWorld()
+    const pv = await preview(anchorOp, 'reset')
+    const fn = `eaa_del_cas_bump_${TS}`
+    const trg = `trg_eaa_del_cas_bump_${TS}`
+    await q(`CREATE OR REPLACE FUNCTION ${fn}() RETURNS trigger AS $$ BEGIN
+      UPDATE meta_records SET version = version + 1 WHERE id = NEW.record_id AND sheet_id = NEW.sheet_id;
+      RETURN NEW; END $$ LANGUAGE plpgsql`)
+    await q(`CREATE TRIGGER ${trg} AFTER INSERT ON meta_record_revisions FOR EACH ROW
+      WHEN (NEW.sheet_id = '${SHEET}' AND NEW.action = 'delete' AND NEW.source = 'restore') EXECUTE FUNCTION ${fn}()`)
+    try {
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'preview-drift' })
+      expect(await liveRow(R_NEW)).toBeDefined()
+      expect((await liveRow(R_NEW))?.version).toBe(1) // the injected bump rolled back with the refusal
+      expect((await liveRow(R_REV))?.data).toEqual({ [F_STR]: 'rev-now' })
+      expect(await trashCount(R_NEW)).toBe(0)
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q(`DROP TRIGGER IF EXISTS ${trg} ON meta_record_revisions`).catch(() => {})
+      await q(`DROP FUNCTION IF EXISTS ${fn}()`).catch(() => {})
+    }
+    // POSITIVE control: trigger removed ⇒ the same unburned token applies and the reset delete lands.
+    expect((await applyExactAnchorRecovery(txn, applyArgs(pv.token))).ok).toBe(true)
+    expect(await liveRow(R_NEW)).toBeUndefined()
+  })
+
+  test('REVERT-CAS (injected same-txn drift): sibling version bumped between the full-set lock and its CAS UPDATE ⇒ preview-drift (never a bare Error), full rollback', async () => {
+    const R1 = `rec_cas_a_${TS}`
+    const R2 = `rec_cas_b_${TS}`
+    const [s1, s2, s3, s4] = await seqBand(4)
+    await revSeq(R2, 1, 'create', { [F_STR]: 'r2-at-anchor' }, s1)
+    const anchorOp = await sealAnchorOp(R1, [
+      { seq: s2, version: 1, action: 'create', snap: { [F_STR]: 'r1-at-anchor' } },
+    ])
+    await revSeq(R1, 2, 'update', { [F_STR]: 'r1-now' }, s3)
+    await revSeq(R2, 2, 'update', { [F_STR]: 'r2-now' }, s4)
+    await live(R1, { [F_STR]: 'r1-now' }, 2)
+    await live(R2, { [F_STR]: 'r2-now' }, 2)
+    const pv = await preview(anchorOp, 'revert')
+    // R1 sorts before R2: R1's restore revision insert bumps R2 inside the SAME txn, so R2's later CAS
+    // UPDATE (WHERE version = locked expected) misses — the refusal must be preview-drift, not a throw.
+    const fn = `eaa_rev_cas_bump_${TS}`
+    const trg = `trg_eaa_rev_cas_bump_${TS}`
+    await q(`CREATE OR REPLACE FUNCTION ${fn}() RETURNS trigger AS $$ BEGIN
+      UPDATE meta_records SET version = version + 1 WHERE id = '${R2}' AND sheet_id = NEW.sheet_id;
+      RETURN NEW; END $$ LANGUAGE plpgsql`)
+    await q(`CREATE TRIGGER ${trg} AFTER INSERT ON meta_record_revisions FOR EACH ROW
+      WHEN (NEW.sheet_id = '${SHEET}' AND NEW.action = 'update' AND NEW.source = 'restore' AND NEW.record_id = '${R1}') EXECUTE FUNCTION ${fn}()`)
+    try {
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'preview-drift' })
+      expect((await liveRow(R1))?.data).toEqual({ [F_STR]: 'r1-now' }) // R1's landed revert rolled back too
+      expect((await liveRow(R2))?.data).toEqual({ [F_STR]: 'r2-now' })
+      expect((await liveRow(R2))?.version).toBe(2) // the injected bump rolled back
+      expect(await burnCount()).toBe(0)
+      expect(Number(((await q(`SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }).c)).toBe(0)
+    } finally {
+      await q(`DROP TRIGGER IF EXISTS ${trg} ON meta_record_revisions`).catch(() => {})
+      await q(`DROP FUNCTION IF EXISTS ${fn}()`).catch(() => {})
+    }
+    // POSITIVE control: trigger removed ⇒ the same unburned token applies; both reverts land.
+    const ok = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
+    expect(ok.ok).toBe(true)
+    expect((await liveRow(R1))?.data).toEqual({ [F_STR]: 'r1-at-anchor' })
+    expect((await liveRow(R2))?.data).toEqual({ [F_STR]: 'r2-at-anchor' })
   })
 
   // ── G1 (pre-wiring gate list): burn-retention sweep ─────────────────────────────────────────────────────

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -1,31 +1,20 @@
 /**
  * W0-1 v3.7 Lane L8 — the exact-anchor DESTRUCTIVE APPLY (real DB): one transaction, all-or-nothing.
  *
- * Module under test: `exact-anchor-recovery-execute.ts` `applyExactAnchorRecovery`. Goldens (each
- * mutation-proven in the PR matrix):
- *   HAPPY-REVERT      end-to-end revert-mode apply: reverts + resurrects land atomically, every write
- *                     revision-emitted (`source:'restore'`) and ledger-tagged; the apply itself seals an
- *                     operation endpoint (a future exact anchor); token burned.
- *   MODE-MATRIX       the SAME world under 'reset' also deletes deletedAtAnchorLiveNow + createdAfterAnchor
- *                     (with delete revisions); under 'revert' both survive.
- *   REPLAY            a second execute of the SAME token ⇒ `token-replayed`, zero writes.
- *   LIVE-DRIFT (409)  a CONCURRENT COMMITTED WRITE between preview and execute ⇒ `preview-drift`, ZERO
- *                     writes — including the token burn (the token is still executable after the world is
- *                     restored to the previewed state ⇒ proves full rollback of the burn row).
- *   CHECKPOINT-GONE   the covering checkpoint pruned/removed between preview and execute ⇒
- *                     `no-covering-checkpoint`; a DIFFERENT covering checkpoint (superseding activation
- *                     below the anchor) ⇒ `checkpoint-changed`. Zero writes.
- *   INJECTED-FAILURE  a mid-apply failure (second revision INSERT forced to fail via a synthetic
- *                     constraint collision) ⇒ the WHOLE apply rolls back: no record changed, no revisions,
- *                     no endpoint, no burn.
- *   BASELINE          a record whose history lives ONLY in the checkpoint baseline (zero revisions ≤
- *                     anchor): non-trashed baseline row resurrects/reverts from the baseline data;
- *                     is_trashed=true baseline row stays deleted.
- *   FENCE-PARK (race) a raw client holds the canonical fence in an open transaction; the apply PARKS
- *                     (proven via pg_locks/pg_blocking_pids sampling) and completes after release.
+ * Module under test: `exact-anchor-recovery-execute.ts` `applyExactAnchorRecovery`. Goldens include:
+ *   HAPPY-REVERT      restorable revert lands; revision source=restore + ledger-tagged; endpoint sealed;
+ *                     token burned. Resurrect is fail-closed (inbound-unprovable) — success paths do not
+ *                     depend on resurrection.
+ *   MODE-MATRIX       reset deletes createdAfterAnchor (trash + delete revision); revert keeps them.
+ *   REPLAY / LIVE-DRIFT / AUTH / PLAN-AUTH / DRIFT-REJECT / link+reset parity / trust substrate.
+ *   RESTORABLE-PROJECTION  formula preserved; derived-only ⇒ no revision/version/link/endpoint (token still
+ *                          burns on successful consume).
+ *   VALUE-INVALID     unsafe rich longText / select-option drift refuse with zero writes.
+ *   LINK-INTEGRITY    missing target, wrong sheet, alias ambiguity, same-op delete target.
+ *   RESET two-phase   cross-linked delete candidates both get inbound tombstones.
  *
- * The module is NOT wired to any route; the L4 fence flag is toggled only inside this test process
- * (default OFF everywhere real). P2-C hygiene: explicit synthetic seq literals, no `setval`, own-row
+ * The module is NOT wired to any route. Flags toggled only inside this test process (default OFF real).
+ * P2-C hygiene: seqs reserved via nextval() only (never setval on the shared chain sequence); own-row
  * cleanup. Two-point wiring: plugin-tests.yml real-DB run list + vitest glob; fail-not-skip sentinel.
  */
 import { randomUUID } from 'node:crypto'
@@ -176,9 +165,8 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
   })
 
   /**
-   * Allocate a monotonic synthetic-seq band ABOVE the active checkpoint's trusted_since_seq, then
-   * advance the shared chain sequence past that band so post-apply real nextval() rows stay strictly
-   * after fixtures (strict contiguity ORDER BY seq stays healthy).
+   * Reserve `count` REAL sequence values strictly ABOVE the active checkpoint's trusted_since_seq
+   * using nextval() only — NEVER setval (no cross-suite sequence coupling).
    */
   async function seqBand(count: number): Promise<string[]> {
     await activate()
@@ -188,17 +176,23 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
       [SHEET],
     )
     const floor = BigInt(String((floorRes.rows[0] as { s: string }).s))
-    const seqs = Array.from({ length: count }, (_, i) => String(floor + BigInt(1000 * (i + 1))))
-    const hi = floor + BigInt(1000 * (count + 5))
-    await q(`SELECT setval('meta_record_chain_seq', $1::bigint, true)`, [String(hi)])
+    const seqs: string[] = []
+    // Drain nextval until we sit above the floor, then take `count` consecutive values.
+    while (seqs.length < count) {
+      const r = await q(`SELECT nextval('meta_record_chain_seq')::text AS s`)
+      const s = BigInt(String((r.rows[0] as { s: string }).s))
+      if (s > floor) seqs.push(String(s))
+    }
     return seqs
   }
 
-  /** Additional synthetic seqs above the current shared chain head (does not re-activate). */
+  /** Additional real nextval() seqs (does not re-activate). */
   async function moreSeqs(count: number): Promise<string[]> {
-    const head = BigInt(String((await q(`SELECT last_value::text AS s FROM meta_record_chain_seq`)).rows[0] as { s: string }).s)
-    const seqs = Array.from({ length: count }, (_, i) => String(head + BigInt(1000 * (i + 1))))
-    await q(`SELECT setval('meta_record_chain_seq', $1::bigint, true)`, [String(head + BigInt(1000 * (count + 5)))])
+    const seqs: string[] = []
+    for (let i = 0; i < count; i++) {
+      const r = await q(`SELECT nextval('meta_record_chain_seq')::text AS s`)
+      seqs.push(String((r.rows[0] as { s: string }).s))
+    }
     return seqs
   }
 
@@ -727,7 +721,7 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
       expect(rev.patch).toEqual({ [F_STR]: 'at-anchor' })
       expect(rev.snapshot[F_FORM]).toBe('formula-live')
 
-      // Derived-only: string already at-anchor; only formula live differs from at-anchor snapshot ⇒ no-op.
+      // Derived-only: string already at-anchor; only formula live differs from at-anchor snapshot ⇒ no-op writes.
       await wipe()
       const R2 = `rec_noop_${TS}`
       const [s2] = await seqBand(1)
@@ -736,13 +730,15 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
       ])
       await live(R2, { [F_STR]: 'same', [F_FORM]: 'f-live' }, 1)
       const pv2 = await preview(op2, 'revert')
-      // plan may still list a revert if full dataEquals sees formula drift — projection makes it no-op.
       const out2 = await applyExactAnchorRecovery(txn, applyArgs(pv2.token))
       expect(out2.ok).toBe(true)
       if (!out2.ok) return
-      expect(out2.applied.reverts).toBe(0) // no write
-      expect((await liveRow(R2))?.version).toBe(1)
+      expect(out2.applied.reverts).toBe(0) // no restorable write
+      expect((await liveRow(R2))?.version).toBe(1) // no version bump
       expect(Number(((await q(`SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }).c)).toBe(0)
+      // No restore-sourced revision and no version bump (zero restorable writes).
+      // Successful token consume still burns (anti-replay) even when restorable writes are empty.
+      expect(await burnCount()).toBe(1)
     } finally {
       await q('DELETE FROM meta_fields WHERE id = $1', [F_FORM]).catch(() => {})
     }
@@ -848,6 +844,158 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     process.env[FLAG] = 'true'
     expect(await liveRow(R_REV)).toEqual(before)
     expect(await burnCount()).toBe(0)
+  })
+
+  // ── VALUE-INVALID: current-schema exact validation ────────────────────────────────────────────────────
+  test('VALUE-INVALID rich longText: historical XSS HTML that would be sanitized ⇒ value-invalid, zero writes', async () => {
+    const F_LT = `fld_eaa_lt_${TS}`
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6) ON CONFLICT (id) DO NOTHING',
+      [F_LT, SHEET, 'Body', 'longText', JSON.stringify({ rich: true }), 9],
+    )
+    try {
+      const R = `rec_rich_${TS}`
+      const unsafe = '<script>alert(1)</script><p>safe</p>'
+      const [sCreate, sUpdate] = await seqBand(2)
+      // At-anchor carries UNSAFE rich HTML; live is clean — restore would re-introduce it.
+      const op = await sealAnchorOp(R, [
+        { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'same', [F_LT]: unsafe } },
+      ])
+      await revSeq(R, 2, 'update', { [F_STR]: 'same', [F_LT]: '<p>clean</p>' }, sUpdate)
+      await live(R, { [F_STR]: 'same', [F_LT]: '<p>clean</p>' }, 2)
+      const before = await liveRow(R)
+      const pv = await preview(op, 'revert')
+      const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
+      expect(out).toEqual({ ok: false, reason: 'value-invalid' })
+      expect(await liveRow(R)).toEqual(before)
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q('DELETE FROM meta_fields WHERE id = $1', [F_LT]).catch(() => {})
+    }
+  })
+
+  test('VALUE-INVALID select: historical option removed from CURRENT property/options ⇒ value-invalid', async () => {
+    const F_SEL = `fld_eaa_sel_${TS}`
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6) ON CONFLICT (id) DO NOTHING',
+      [F_SEL, SHEET, 'Choice', 'select', JSON.stringify({ options: [{ value: 'a' }, { value: 'b' }] }), 10],
+    )
+    try {
+      const R = `rec_sel_${TS}`
+      const [sCreate, sUpdate] = await seqBand(2)
+      const op = await sealAnchorOp(R, [
+        { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'x', [F_SEL]: 'legacy' } },
+      ])
+      await revSeq(R, 2, 'update', { [F_STR]: 'y', [F_SEL]: 'a' }, sUpdate)
+      await live(R, { [F_STR]: 'y', [F_SEL]: 'a' }, 2)
+      // Current schema only allows a|b — historical 'legacy' fails exact validation.
+      const pv = await preview(op, 'revert')
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'value-invalid' })
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q('DELETE FROM meta_fields WHERE id = $1', [F_SEL]).catch(() => {})
+    }
+  })
+
+  // ── LINK alias ambiguity + same-op delete target ──────────────────────────────────────────────────────
+  test('LINK-INTEGRITY alias conflict: foreignSheetId ≠ foreignDatasheetId ⇒ link-integrity', async () => {
+    const F_AMB = `fld_eaa_amb_${TS}`
+    const OTHER = `${SHEET}_amb`
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3) ON CONFLICT (id) DO NOTHING', [OTHER, BASE, 'amb'])
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6) ON CONFLICT (id) DO NOTHING',
+      [F_AMB, SHEET, 'Amb', 'link', JSON.stringify({ foreignSheetId: SHEET, foreignDatasheetId: OTHER }), 11],
+    )
+    try {
+      const R_T = `rec_amb_t_${TS}`
+      const R = `rec_amb_${TS}`
+      const [sT, sCreate, sUpdate] = await seqBand(3)
+      await revSeq(R_T, 1, 'create', { [F_STR]: 't' }, sT)
+      await live(R_T, { [F_STR]: 't' }, 1)
+      const op = await sealAnchorOp(R, [
+        { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'x', [F_AMB]: [R_T] } },
+      ])
+      await revSeq(R, 2, 'update', { [F_STR]: 'x', [F_AMB]: [] }, sUpdate)
+      await live(R, { [F_STR]: 'x', [F_AMB]: [] }, 2)
+      const pv = await preview(op, 'revert')
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'link-integrity' })
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q('DELETE FROM meta_fields WHERE id = $1', [F_AMB]).catch(() => {})
+      await q('DELETE FROM meta_sheets WHERE id = $1', [OTHER]).catch(() => {})
+    }
+  })
+
+  test('LINK-INTEGRITY same-op delete: projected link target is itself a RESET delete candidate ⇒ refuse', async () => {
+    const R_KEEP = `rec_sod_keep_${TS}`
+    const R_NEW = `rec_sod_new_${TS}`
+    const R_REV = `rec_sod_rev_${TS}`
+    const [sKeep, sCreate, sUpdate, sNew] = await seqBand(4)
+    await revSeq(R_KEEP, 1, 'create', { [F_STR]: 'keep' }, sKeep)
+    const op = await sealAnchorOp(R_REV, [
+      { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'x', [F_LINK]: [R_NEW] } },
+    ])
+    // At-anchor R_REV points at R_NEW, but R_NEW is only created AFTER the anchor ⇒ reset deletes R_NEW,
+    // while revert would re-link R_REV→R_NEW — same-op dangling target.
+    await revSeq(R_REV, 2, 'update', { [F_STR]: 'x', [F_LINK]: [R_KEEP] }, sUpdate)
+    await revSeq(R_NEW, 1, 'create', { [F_STR]: 'newbie' }, sNew)
+    await live(R_KEEP, { [F_STR]: 'keep' }, 1)
+    await live(R_REV, { [F_STR]: 'x', [F_LINK]: [R_KEEP] }, 2)
+    await live(R_NEW, { [F_STR]: 'newbie' }, 1)
+    await insertLink(F_LINK, R_REV, R_KEEP)
+    const pv = await preview(op, 'reset')
+    expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'link-integrity' })
+    expect(await liveRow(R_NEW)).toBeDefined()
+    expect(await burnCount()).toBe(0)
+  })
+
+  test('RESET two-phase cross-link: two delete candidates linked both ways both get inbound tombstones', async () => {
+    process.env.MULTITABLE_TOMBSTONE_CAPTURE_ENABLED = 'true'
+    const R_A = `rec_xdel_a_${TS}`
+    const R_B = `rec_xdel_b_${TS}`
+    const R_REV = `rec_xdel_rev_${TS}`
+    const [sCreate, sUpdate, sA, sB] = await seqBand(4)
+    const op = await sealAnchorOp(R_REV, [
+      { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'anchor' } },
+    ])
+    await revSeq(R_REV, 2, 'update', { [F_STR]: 'now' }, sUpdate)
+    await revSeq(R_A, 1, 'create', { [F_STR]: 'A', [F_LINK]: [R_B] }, sA)
+    await revSeq(R_B, 1, 'create', { [F_STR]: 'B', [F_LINK]: [R_A] }, sB)
+    await live(R_REV, { [F_STR]: 'now' }, 2)
+    await live(R_A, { [F_STR]: 'A', [F_LINK]: [R_B] }, 1)
+    await live(R_B, { [F_STR]: 'B', [F_LINK]: [R_A] }, 1)
+    await insertLink(F_LINK, R_A, R_B)
+    await insertLink(F_LINK, R_B, R_A)
+    expect(await countInboundLinkCaptureRows(q as unknown as QueryFn, R_A)).toBe(1)
+    expect(await countInboundLinkCaptureRows(q as unknown as QueryFn, R_B)).toBe(1)
+    const pv = await preview(op, 'reset')
+    const out = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
+    expect(out.ok).toBe(true)
+    if (!out.ok) return
+    expect(out.applied.deletes).toBeGreaterThanOrEqual(2)
+    const trashA = (await q(
+      `SELECT delete_revision_id FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2`,
+      [R_A, SHEET],
+    )).rows[0] as { delete_revision_id: string }
+    const trashB = (await q(
+      `SELECT delete_revision_id FROM meta_records_trash WHERE record_id = $1 AND sheet_id = $2`,
+      [R_B, SHEET],
+    )).rows[0] as { delete_revision_id: string }
+    expect(trashA?.delete_revision_id).toBeTruthy()
+    expect(trashB?.delete_revision_id).toBeTruthy()
+    expect(trashA.delete_revision_id).not.toBe(trashB.delete_revision_id)
+    const tombsA = (await q(
+      `SELECT record_id, foreign_record_id FROM meta_link_tombstones
+       WHERE foreign_record_id = $1 AND source_revision_id = $2::uuid AND reason = 'record_delete'`,
+      [R_A, trashA.delete_revision_id],
+    )).rows as Array<{ record_id: string; foreign_record_id: string }>
+    const tombsB = (await q(
+      `SELECT record_id, foreign_record_id FROM meta_link_tombstones
+       WHERE foreign_record_id = $1 AND source_revision_id = $2::uuid AND reason = 'record_delete'`,
+      [R_B, trashB.delete_revision_id],
+    )).rows as Array<{ record_id: string; foreign_record_id: string }>
+    expect(tombsA).toEqual([{ record_id: R_B, foreign_record_id: R_A }])
+    expect(tombsB).toEqual([{ record_id: R_A, foreign_record_id: R_B }])
   })
 
   // ── G1 (pre-wiring gate list): burn-retention sweep ─────────────────────────────────────────────────────

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -10,7 +10,7 @@
  *   RESTORABLE-PROJECTION  formula preserved; derived-only ⇒ no revision/version/link/endpoint BUT token burns.
  *   SCHEMA-HASH-DRIFT      post-preview retype / property-only change ⇒ schema-drift; missing field still covered.
  *   VALUE-INVALID     unsafe rich longText / select-option drift refuse with zero writes.
- *   LINK-INTEGRITY    missing target, wrong sheet, alias ambiguity, same-op delete target.
+ *   LINK-INTEGRITY    missing target, wrong sheet, alias ambiguity, same-op delete target, hierarchy cycle.
  *   RESET two-phase   cross-linked delete candidates both get inbound tombstones.
  *
  * The module is NOT wired to any route. Flags toggled only inside this test process (default OFF real).
@@ -117,6 +117,7 @@ async function wipe(): Promise<void> {
     [SHEET],
   ).catch(() => {})
   await q('DELETE FROM meta_link_tombstones WHERE sheet_id = $1', [SHEET]).catch(() => {})
+  await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET]).catch(() => {})
   for (const t of ['meta_history_baselines', 'meta_history_trust_checkpoints', 'meta_recovery_token_burns', 'meta_record_version_markers', 'meta_records_trash', 'meta_record_revisions', 'meta_records'])
     await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
   await q('DELETE FROM meta_record_history_operations WHERE sheet_id = $1', [SHEET]).catch(() => {})
@@ -1058,6 +1059,99 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     } finally {
       await q('DELETE FROM meta_fields WHERE id = $1', [F_AMB]).catch(() => {})
       await q('DELETE FROM meta_sheets WHERE id = $1', [OTHER]).catch(() => {})
+    }
+  })
+
+  test('LINK-INTEGRITY hierarchy cycle: restoring old parent link would cycle against live graph ⇒ whole refuse, zero burn/revision/data/link; acyclic sibling world applies', async () => {
+    // Live tree is valid (A ← B ← C). At-anchor A pointed at C. Restoring A→C while live B→A, C→B cycles A→C→B→A.
+    // Hierarchy view marks F_LINK as the parent field so RecordWriteService's cycle primitives engage.
+    const VIEW = `view_hier_${TS}`
+    await q(
+      `INSERT INTO meta_views (id, sheet_id, name, type, config) VALUES ($1,$2,$3,$4,$5::jsonb)
+       ON CONFLICT (id) DO NOTHING`,
+      [VIEW, SHEET, 'Tree', 'hierarchy', JSON.stringify({ parentFieldId: F_LINK })],
+    )
+    try {
+      const R_A = `rec_hier_a_${TS}`
+      const R_B = `rec_hier_b_${TS}`
+      const R_C = `rec_hier_c_${TS}`
+      // Order: B,C exist before A's at-anchor parent=[C] event; post-anchor clears A.parent so only A reverts.
+      const [sB, sC, sA1, sA2, sPost] = await seqBand(5)
+      await revSeq(R_B, 1, 'create', { [F_STR]: 'B', [F_LINK]: [R_A] }, sB)
+      await revSeq(R_C, 1, 'create', { [F_STR]: 'C', [F_LINK]: [R_B] }, sC)
+      const op = await sealAnchorOp(R_A, [
+        { seq: sA1, version: 1, action: 'create', snap: { [F_STR]: 'A', [F_LINK]: [] } },
+        { seq: sA2, version: 2, action: 'update', snap: { [F_STR]: 'A', [F_LINK]: [R_C] } },
+      ])
+      await revSeq(R_A, 3, 'update', { [F_STR]: 'A', [F_LINK]: [] }, sPost)
+      // Live: valid tree A ← B ← C (A has no parent).
+      await live(R_A, { [F_STR]: 'A', [F_LINK]: [] }, 3)
+      await live(R_B, { [F_STR]: 'B', [F_LINK]: [R_A] }, 1)
+      await live(R_C, { [F_STR]: 'C', [F_LINK]: [R_B] }, 1)
+      await insertLink(F_LINK, R_B, R_A)
+      await insertLink(F_LINK, R_C, R_B)
+
+      const beforeA = await liveRow(R_A)
+      const beforeB = await liveRow(R_B)
+      const beforeC = await liveRow(R_C)
+      const linkCountBefore = Number(((await q(
+        `SELECT count(*)::int c FROM meta_links
+         WHERE record_id IN (SELECT id FROM meta_records WHERE sheet_id = $1)`,
+        [SHEET],
+      )).rows[0] as { c: number }).c)
+      const revsBefore = Number(((await q(
+        `SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1`,
+        [SHEET],
+      )).rows[0] as { c: number }).c)
+
+      const pv = await preview(op, 'revert')
+      expect(pv.ok).toBe(true)
+      const refused = await applyExactAnchorRecovery(txn, applyArgs(pv.token))
+      expect(refused).toEqual({ ok: false, reason: 'link-integrity' })
+      expect(await liveRow(R_A)).toEqual(beforeA)
+      expect(await liveRow(R_B)).toEqual(beforeB)
+      expect(await liveRow(R_C)).toEqual(beforeC)
+      expect(Number(((await q(
+        `SELECT count(*)::int c FROM meta_links
+         WHERE record_id IN (SELECT id FROM meta_records WHERE sheet_id = $1)`,
+        [SHEET],
+      )).rows[0] as { c: number }).c)).toBe(linkCountBefore)
+      expect(Number(((await q(
+        `SELECT count(*)::int c FROM meta_record_revisions WHERE sheet_id = $1`,
+        [SHEET],
+      )).rows[0] as { c: number }).c)).toBe(revsBefore)
+      expect(await burnCount()).toBe(0)
+
+      // POSITIVE control (acyclic sibling world): restore parent to a leaf that has no path back.
+      // Hierarchy view still armed — proves the guard does not over-refuse legitimate parent restores.
+      await wipe()
+      const R_ROOT = `rec_hier_root_${TS}`
+      const R_LEAF = `rec_hier_leaf_${TS}`
+      const [sLeaf, sRoot1, sRoot2, sRootPost] = await seqBand(4)
+      await revSeq(R_LEAF, 1, 'create', { [F_STR]: 'leaf', [F_LINK]: [] }, sLeaf)
+      const opOk = await sealAnchorOp(R_ROOT, [
+        { seq: sRoot1, version: 1, action: 'create', snap: { [F_STR]: 'root', [F_LINK]: [] } },
+        { seq: sRoot2, version: 2, action: 'update', snap: { [F_STR]: 'root', [F_LINK]: [R_LEAF] } },
+      ])
+      await revSeq(R_ROOT, 3, 'update', { [F_STR]: 'root', [F_LINK]: [] }, sRootPost)
+      await live(R_ROOT, { [F_STR]: 'root', [F_LINK]: [] }, 3)
+      await live(R_LEAF, { [F_STR]: 'leaf', [F_LINK]: [] }, 1)
+      // re-create hierarchy view (wipe removes views)
+      await q(
+        `INSERT INTO meta_views (id, sheet_id, name, type, config) VALUES ($1,$2,$3,$4,$5::jsonb)
+         ON CONFLICT (id) DO NOTHING`,
+        [VIEW, SHEET, 'Tree', 'hierarchy', JSON.stringify({ parentFieldId: F_LINK })],
+      )
+      const pvOk = await preview(opOk, 'revert')
+      const applied = await applyExactAnchorRecovery(txn, applyArgs(pvOk.token))
+      expect(applied.ok).toBe(true)
+      if (!applied.ok) return
+      expect(applied.applied.reverts).toBe(1)
+      expect((await liveRow(R_ROOT))?.data[F_LINK]).toEqual([R_LEAF])
+      expect(await linkTargets(F_LINK, R_ROOT)).toEqual([R_LEAF])
+      expect(await burnCount()).toBe(1)
+    } finally {
+      await q('DELETE FROM meta_views WHERE id = $1', [VIEW]).catch(() => {})
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-apply-realdb.test.ts
@@ -6,7 +6,8 @@
  *                     token burned. Resurrect is fail-closed (inbound-unprovable) — success paths do not
  *                     depend on resurrection.
  *   MODE-MATRIX       reset deletes createdAfterAnchor (trash + delete revision); revert keeps them.
- *   REPLAY / LIVE-DRIFT / AUTH / PLAN-AUTH / DRIFT-REJECT / link+reset parity / trust substrate.
+ *   REPLAY / LIVE-DRIFT / AUTH / PLAN-AUTH (+ no-oracle over value-invalid/missing-target) /
+ *                     DRIFT-REJECT / link+reset parity / trust substrate.
  *   RESTORABLE-PROJECTION  formula preserved; derived-only ⇒ no revision/version/link/endpoint BUT token burns.
  *   SCHEMA-HASH-DRIFT      post-preview retype / property-only change ⇒ schema-drift; missing field still covered.
  *   VALUE-INVALID     unsafe rich longText / select-option drift refuse with zero writes.
@@ -839,6 +840,63 @@ describeIfDatabase('W0-1 v3.7 L8 — exact-anchor destructive apply (real DB)', 
     } finally {
       holder.release()
     }
+  })
+
+  test('PLAN-AUTH-NO-ORACLE scalar: planAuth=false dominates CURRENT-schema value-invalid (uniform forbidden; validator must not decide)', async () => {
+    // Historical XSS HTML would be value-invalid for an authorized writer — a denied writer must NOT see that.
+    const F_LT = `fld_eaa_noor_lt_${TS}`
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6) ON CONFLICT (id) DO NOTHING',
+      [F_LT, SHEET, 'Body', 'longText', JSON.stringify({ rich: true }), 20],
+    )
+    try {
+      const R = `rec_noor_scalar_${TS}`
+      const unsafe = '<script>alert(1)</script><p>safe</p>'
+      const [sCreate, sUpdate] = await seqBand(2)
+      const op = await sealAnchorOp(R, [
+        { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'same', [F_LT]: unsafe } },
+      ])
+      await revSeq(R, 2, 'update', { [F_STR]: 'same', [F_LT]: '<p>clean</p>' }, sUpdate)
+      await live(R, { [F_STR]: 'same', [F_LT]: '<p>clean</p>' }, 2)
+      const before = await liveRow(R)
+      const pv = await preview(op, 'revert')
+      // Positive control: authorized path is value-invalid (proves the invalid scalar is real, not vacuous).
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'value-invalid' })
+      expect(await burnCount()).toBe(0)
+      // Denied planAuth: MUST be uniform forbidden — not value-invalid (no validator oracle).
+      expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token, { planAuth: DENY_PLAN })))
+        .toEqual({ ok: false, reason: 'forbidden' })
+      expect(await liveRow(R)).toEqual(before)
+      expect(await burnCount()).toBe(0)
+    } finally {
+      await q('DELETE FROM meta_fields WHERE id = $1', [F_LT]).catch(() => {})
+    }
+  })
+
+  test('PLAN-AUTH-NO-ORACLE missing-target: planAuth=false dominates link-integrity missing foreign target (uniform forbidden)', async () => {
+    const R_A = `rec_noor_a_${TS}`
+    const R_REV = `rec_noor_link_${TS}`
+    const MISSING = `rec_noor_missing_${TS}`
+    const [sA, sCreate, sUpdate] = await seqBand(3)
+    await revSeq(R_A, 1, 'create', { [F_STR]: 'A' }, sA)
+    const op = await sealAnchorOp(R_REV, [
+      { seq: sCreate, version: 1, action: 'create', snap: { [F_STR]: 'x', [F_LINK]: [MISSING] } },
+    ])
+    await revSeq(R_REV, 2, 'update', { [F_STR]: 'x', [F_LINK]: [R_A] }, sUpdate)
+    await live(R_A, { [F_STR]: 'A' }, 1)
+    await live(R_REV, { [F_STR]: 'x', [F_LINK]: [R_A] }, 2)
+    await insertLink(F_LINK, R_REV, R_A)
+    const before = await liveRow(R_REV)
+    const pv = await preview(op, 'revert')
+    // Positive control: authorized path is link-integrity (missing target exists as a real check).
+    expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token))).toEqual({ ok: false, reason: 'link-integrity' })
+    expect(await burnCount()).toBe(0)
+    // Denied planAuth: MUST be uniform forbidden — not link-integrity (no existence-oracle).
+    expect(await applyExactAnchorRecovery(txn, applyArgs(pv.token, { planAuth: DENY_PLAN })))
+      .toEqual({ ok: false, reason: 'forbidden' })
+    expect(await liveRow(R_REV)).toEqual(before)
+    expect(await linkTargets(F_LINK, R_REV)).toEqual([R_A])
+    expect(await burnCount()).toBe(0)
   })
 
   // ── D: foreign-link integrity ──────────────────────────────────────────────────────────────────────────

--- a/packages/core-backend/tests/integration/multitable-exact-anchor-recovery-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-exact-anchor-recovery-realdb.test.ts
@@ -35,7 +35,10 @@ import { poolManager } from '../../src/integration/db/connection-pool'
 import { reconstructRecordsAtSeq, reconstructRecordsAtT } from '../../src/multitable/record-reconstructor'
 import { resolveExactAnchor, executeExactAnchorRecovery } from '../../src/multitable/exact-anchor-recovery'
 import { activateCheckpoint, type QueryFn } from '../../src/multitable/history-trust-checkpoint'
-import { hashRecoveryAuthorizationScope, mintExactAnchorRecoveryIdentity } from '../../src/multitable/restore-preview-identity'
+import {
+  hashRecoveryAuthorizationScope,
+  mintExactAnchorRecoveryIdentity,
+} from '../../src/multitable/restore-preview-identity'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
@@ -300,6 +303,7 @@ describeIfDatabase('W0-1 v3.7 L6-b — exact-anchor recovery + causal reconstruc
       sheetId: SHEET, anchorOperationId: opId, anchorSeq: '7003', checkpointId: (res as { checkpointId: string }).checkpointId,
       scopeHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
       liveSetHash: 'c0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffee0000', // shape-valid; the read-half checks scopeHash only
+      schemaHash: 'b'.repeat(64), // shape-valid; L6-b read-half does not re-check schema (L8 apply does)
       actorId: ACTOR,
       mode: 'revert', authorizedScopeHash: hashRecoveryAuthorizationScope({ sheetId: SHEET, actorId: ACTOR }),
     })
@@ -347,6 +351,7 @@ describeIfDatabase('W0-1 v3.7 L6-b — exact-anchor recovery + causal reconstruc
     const wrongAuth = mintExactAnchorRecoveryIdentity({
       sheetId: SHEET, anchorOperationId: opId, anchorSeq: res.anchorSeq, checkpointId: res.checkpointId,
       scopeHash: res.scopeHash, liveSetHash: 'f'.repeat(64), // shape-valid; the read-half checks scopeHash only
+      schemaHash: 'b'.repeat(64), // shape-valid contract field
       actorId: ACTOR, mode: 'revert', authorizedScopeHash: 'e'.repeat(64),
     })
     expect(await executeExactAnchorRecovery(q, { token: wrongAuth, sheetId: SHEET, actorId: ACTOR, evaluateFullReadAccess: ALLOW_FULL_READ }))

--- a/packages/core-backend/tests/unit/multitable-exact-anchor-recovery-identity.test.ts
+++ b/packages/core-backend/tests/unit/multitable-exact-anchor-recovery-identity.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, test } from 'vitest'
 
 import {
   hashAnchorRecoveryScope,
+  hashExactAnchorSchema,
   mintExactAnchorRecoveryIdentity,
   verifyExactAnchorRecoveryIdentity,
   mintPitRevertPreviewIdentity,
@@ -22,6 +23,7 @@ const CLAIMS: ExactAnchorRecoveryIdentityClaims = {
   checkpointId: 'ckpt_ear_unit',
   scopeHash: 'a'.repeat(64),
   liveSetHash: 'd'.repeat(64),
+  schemaHash: 'c'.repeat(64),
   actorId: 'user_ear_unit',
   mode: 'revert',
   authorizedScopeHash: 'd'.repeat(64),
@@ -91,11 +93,20 @@ describe('L6-b exact-anchor recovery identity — mint/verify', () => {
     expect(verifyExactAnchorRecoveryIdentity(empty, expected)).toMatchObject({ valid: false, reason: 'pre_contract_token' })
   })
 
-  test('round-trip carries mode + authorizedScopeHash EXACTLY (execute obeys the token, never the request)', () => {
+  test('G-SCHEMA token contract — schemaHash is REQUIRED: a pre-contract token (no schemaHash) fails closed as pre_contract_token', () => {
+    const { schemaHash: _s, ...noSchema } = CLAIMS
+    const preContract = mintExactAnchorRecoveryIdentity(noSchema as unknown as ExactAnchorRecoveryIdentityClaims)
+    expect(verifyExactAnchorRecoveryIdentity(preContract, expected)).toMatchObject({ valid: false, reason: 'pre_contract_token' })
+    const empty = mintExactAnchorRecoveryIdentity({ ...CLAIMS, schemaHash: '' })
+    expect(verifyExactAnchorRecoveryIdentity(empty, expected)).toMatchObject({ valid: false, reason: 'pre_contract_token' })
+  })
+
+  test('round-trip carries mode + authorizedScopeHash + schemaHash EXACTLY (execute obeys the token, never the request)', () => {
     const reset = verifyExactAnchorRecoveryIdentity(mintExactAnchorRecoveryIdentity({ ...CLAIMS, mode: 'reset' }), expected)
     expect(reset.valid).toBe(true)
     expect(reset.claims?.mode).toBe('reset')
     expect(reset.claims?.authorizedScopeHash).toBe(CLAIMS.authorizedScopeHash)
+    expect(reset.claims?.schemaHash).toBe(CLAIMS.schemaHash)
   })
 
   test('an expired token is refused (expired), not silently accepted', () => {
@@ -130,5 +141,24 @@ describe('L6-b hashAnchorRecoveryScope — order-invariant, drift-sensitive', ()
     // exists:false with any stored version must hash the same as exists:false with null — a delete has no version.
     expect(hashAnchorRecoveryScope([{ recordId: 'r', exists: false, version: 9 }]))
       .toBe(hashAnchorRecoveryScope([{ recordId: 'r', exists: false, version: null }]))
+  })
+})
+
+describe('L6-b hashExactAnchorSchema — id-sorted, property-key-deep-sorted, drift-sensitive', () => {
+  test('order-invariant: field row order and property key order do not change the hash', () => {
+    const a = { id: 'f-a', type: 'string', property: { b: 1, a: 2 } }
+    const b = { id: 'f-b', type: 'longText', property: { rich: true } }
+    expect(hashExactAnchorSchema([a, b])).toBe(hashExactAnchorSchema([b, a]))
+    expect(hashExactAnchorSchema([{ ...a, property: { a: 2, b: 1 } }, b])).toBe(hashExactAnchorSchema([a, b]))
+  })
+
+  test('drift-sensitive: retype, property-only edit, and field add/remove each change the hash', () => {
+    const base = hashExactAnchorSchema([{ id: 'f', type: 'string', property: {} }])
+    expect(hashExactAnchorSchema([{ id: 'f', type: 'longText', property: {} }])).not.toBe(base) // retype
+    expect(hashExactAnchorSchema([{ id: 'f', type: 'string', property: { validation: [{ type: 'required' }] } }])).not.toBe(base)
+    expect(hashExactAnchorSchema([
+      { id: 'f', type: 'string', property: {} },
+      { id: 'g', type: 'string', property: {} },
+    ])).not.toBe(base)
   })
 })

--- a/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
@@ -64,6 +64,11 @@ function listRuntimeTsFiles(): string[] {
  *   SAFE       — writes only non-user-content columns; a rich-`longText` value can never appear.
  */
 const ALLOWLIST: Record<string, { disposition: 'CHOKEPOINT' | 'SAFE'; reason: string }> = {
+  'multitable/exact-anchor-recovery-execute.ts': {
+    disposition: 'SAFE',
+    reason:
+      'L8 destructive apply writes ONLY previously-persisted at-anchor snapshots (revision-chain / checkpoint-baseline data, validated at their ORIGINAL write through the chokepoints above); no new user payload enters this module',
+  },
   'multitable/records.ts': {
     disposition: 'CHOKEPOINT',
     reason: 'plugin-SDK createRecord/patchRecord → normalizeFieldValue routes longText through validateLongTextValue',

--- a/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
@@ -65,9 +65,9 @@ function listRuntimeTsFiles(): string[] {
  */
 const ALLOWLIST: Record<string, { disposition: 'CHOKEPOINT' | 'SAFE'; reason: string }> = {
   'multitable/exact-anchor-recovery-execute.ts': {
-    disposition: 'SAFE',
+    disposition: 'CHOKEPOINT',
     reason:
-      'L8 destructive apply writes ONLY previously-persisted at-anchor snapshots (revision-chain / checkpoint-baseline data, validated at their ORIGINAL write through the chokepoints above); no new user payload enters this module',
+      'L8 exact-anchor apply re-validates every changed restorable scalar under the CURRENT schema via assertExactRestorableScalarValue + validateLongTextValue (rich longText sanitizer); fail-closed value-invalid if validation rejects or would sanitize/coerce the historical value — never a silent exact restore of unsafe HTML',
   },
   'multitable/records.ts': {
     disposition: 'CHOKEPOINT',

--- a/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
@@ -61,13 +61,22 @@ function listRuntimeTsFiles(): string[] {
 /**
  * FROZEN allowlist of every `src` file that writes `meta_records.data`, keyed by `src`-relative path.
  *   CHOKEPOINT — references `validateLongTextValue` / `sanitizeRichLongText` (this is asserted, not assumed).
+ *   DELEGATED  — does not call the sanitizer directly; routes user-content scalars through a named
+ *                helper file that IS a CHOKEPOINT (asserted: writer refs helper symbol + helper refs sanitizer).
  *   SAFE       — writes only non-user-content columns; a rich-`longText` value can never appear.
  */
-const ALLOWLIST: Record<string, { disposition: 'CHOKEPOINT' | 'SAFE'; reason: string }> = {
+const ALLOWLIST: Record<
+  string,
+  { disposition: 'CHOKEPOINT' | 'DELEGATED' | 'SAFE'; reason: string; through?: string; throughSymbol?: string }
+> = {
   'multitable/exact-anchor-recovery-execute.ts': {
-    disposition: 'CHOKEPOINT',
+    disposition: 'DELEGATED',
+    through: 'multitable/exact-anchor-restore-validate.ts',
+    throughSymbol: 'assertExactRestorableScalarValue',
     reason:
-      'L8 exact-anchor apply re-validates every changed restorable scalar under the CURRENT schema via assertExactRestorableScalarValue + validateLongTextValue (rich longText sanitizer); fail-closed value-invalid if validation rejects or would sanitize/coerce the historical value — never a silent exact restore of unsafe HTML',
+      'L8 exact-anchor apply delegates changed restorable scalars through assertExactRestorableScalarValue ' +
+      '(exact-anchor-restore-validate.ts), which directly references validateLongTextValue for rich longText; ' +
+      'fail-closed value-invalid — no redundant production sanitizer call in execute just to satisfy a scanner',
   },
   'multitable/records.ts': {
     disposition: 'CHOKEPOINT',
@@ -150,6 +159,44 @@ describe('rich-longText write-sink — durable structural guard', () => {
       `These files are marked CHOKEPOINT but do NOT reference validateLongTextValue/sanitizeRichLongText ` +
         `(the sanitizer was removed or never wired):\n` +
         lying.map((rel) => `  - ${rel}`).join('\n'),
+    ).toEqual([])
+  })
+
+  test('every DELEGATED writer routes through a named helper that itself references the sanitizer', () => {
+    const failures: string[] = []
+    for (const rel of writerFiles) {
+      const entry = ALLOWLIST[rel]
+      if (entry?.disposition !== 'DELEGATED') continue
+      const through = entry.through
+      const symbol = entry.throughSymbol
+      if (!through || !symbol) {
+        failures.push(`${rel}: DELEGATED entry missing through/throughSymbol`)
+        continue
+      }
+      const writerSrc = readFileSync(join(SRC, rel), 'utf8')
+      if (!new RegExp(`\\b${symbol}\\b`).test(writerSrc)) {
+        failures.push(`${rel}: does not reference delegated symbol ${symbol}`)
+      }
+      const helperPath = join(SRC, through)
+      let helperSrc: string
+      try {
+        helperSrc = readFileSync(helperPath, 'utf8')
+      } catch {
+        failures.push(`${rel}: delegated helper ${through} is missing`)
+        continue
+      }
+      if (!new RegExp(`\\b${symbol}\\b`).test(helperSrc)) {
+        failures.push(`${through}: does not define/export ${symbol}`)
+      }
+      if (!SANITIZER_REF.test(helperSrc)) {
+        failures.push(
+          `${through}: delegated helper does NOT reference validateLongTextValue/sanitizeRichLongText`,
+        )
+      }
+    }
+    expect(
+      failures,
+      `DELEGATED write-sink guard failures:\n` + failures.map((f) => `  - ${f}`).join('\n'),
     ).toEqual([])
   })
 

--- a/packages/core-backend/tests/unit/record-restore-diff.test.ts
+++ b/packages/core-backend/tests/unit/record-restore-diff.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import { computeRecordRestoreDiff } from '../../src/multitable/record-restore-diff'
+import { computeRecordRestoreDiff, projectRestorableOntoLive } from '../../src/multitable/record-restore-diff'
 
 // Minimal stand-in for the route's normalizeLinkIds (array → string[]; the helper only needs the parse contract).
 const nlz = (v: unknown): string[] => (Array.isArray(v) ? v.map(String) : typeof v === 'string' && v ? [v] : [])
@@ -54,5 +54,86 @@ describe('computeRecordRestoreDiff — canonical shared restore diff', () => {
     expect(byField.f).toBeUndefined()
     expect(byField.b).toBeUndefined()
     expect(byField.same).toBeUndefined()
+  })
+})
+
+describe('projectRestorableOntoLive — canonical restorable projection for L8 apply', () => {
+  it('preserves formula/lookup/rollup/autoNumber (and other non-restorable) live values while projecting restorable scalars', () => {
+    const out = projectRestorableOntoLive({
+      fieldById: new Map<string, { type: string }>([
+        ['s', { type: 'string' }],
+        ['f', { type: 'formula' }],
+        ['lk', { type: 'lookup' }],
+        ['r', { type: 'rollup' }],
+        ['an', { type: 'autoNumber' }],
+      ]),
+      rawTypeById: new Map(),
+      targetSnapshot: { s: 'at-anchor', f: 'stale-formula', lk: 'stale-lk', r: 99, an: 7 },
+      currentData: { s: 'live', f: 'live-formula', lk: 'live-lk', r: 1, an: 42 },
+      recordId: 'r1',
+      currentVersion: 3,
+      normalizeLinkIds: nlz,
+    })
+    expect(out.isNoOp).toBe(false)
+    expect(out.changedFieldIds).toEqual(['s'])
+    expect(out.patch).toEqual({ s: 'at-anchor' })
+    // Non-restorable materializations stay at LIVE values — never overwritten from the snapshot.
+    expect(out.data).toEqual({ s: 'at-anchor', f: 'live-formula', lk: 'live-lk', r: 1, an: 42 })
+    expect(out.linkUpdates).toEqual([])
+  })
+
+  it('derived-only difference is a no-op (no version/revision/link write surface)', () => {
+    const out = projectRestorableOntoLive({
+      fieldById: new Map<string, { type: string }>([
+        ['s', { type: 'string' }],
+        ['f', { type: 'formula' }],
+      ]),
+      rawTypeById: new Map(),
+      targetSnapshot: { s: 'same', f: 'old-formula' },
+      currentData: { s: 'same', f: 'new-formula' },
+      recordId: 'r1',
+      currentVersion: 2,
+      normalizeLinkIds: nlz,
+    })
+    expect(out.isNoOp).toBe(true)
+    expect(out.changedFieldIds).toEqual([])
+    expect(out.patch).toEqual({})
+    expect(out.linkUpdates).toEqual([])
+    expect(out.data).toEqual({ s: 'same', f: 'new-formula' })
+  })
+
+  it('link set change emits linkUpdates (for meta_links sync) and keeps non-link restorable fields', () => {
+    const out = projectRestorableOntoLive({
+      fieldById: new Map<string, { type: string }>([
+        ['s', { type: 'string' }],
+        ['rel', { type: 'link' }],
+      ]),
+      rawTypeById: new Map(),
+      targetSnapshot: { s: 'x', rel: ['A'] },
+      currentData: { s: 'x', rel: ['B'] },
+      recordId: 'r1',
+      currentVersion: 2,
+      normalizeLinkIds: nlz,
+    })
+    expect(out.isNoOp).toBe(false)
+    expect(out.changedFieldIds).toEqual(['rel'])
+    expect(out.data.rel).toEqual(['A'])
+    expect(out.linkUpdates).toEqual([{ fieldId: 'rel', targetIds: ['A'] }])
+  })
+
+  it('unset restorable field drops the key from projected data and records null in patch', () => {
+    const out = projectRestorableOntoLive({
+      fieldById: new Map([['gone', { type: 'string' }]]),
+      rawTypeById: new Map(),
+      targetSnapshot: {},
+      currentData: { gone: 'still-here', f: 'keep-me' },
+      recordId: 'r1',
+      currentVersion: 1,
+      normalizeLinkIds: nlz,
+    })
+    expect(out.isNoOp).toBe(false)
+    expect(out.patch).toEqual({ gone: null })
+    expect(out.data).toEqual({ f: 'keep-me' })
+    expect(Object.prototype.hasOwnProperty.call(out.data, 'gone')).toBe(false)
   })
 })

--- a/packages/core-backend/tests/unit/record-restore-diff.test.ts
+++ b/packages/core-backend/tests/unit/record-restore-diff.test.ts
@@ -5,7 +5,12 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import { computeRecordRestoreDiff, projectRestorableOntoLive } from '../../src/multitable/record-restore-diff'
+import {
+  computeRecordRestoreDiff,
+  projectRestorableOntoLive,
+  canonicalDedupeLinkIds,
+} from '../../src/multitable/record-restore-diff'
+import { assertExactRestorableScalarValue, ExactRestoreValueError } from '../../src/multitable/exact-anchor-restore-validate'
 
 // Minimal stand-in for the route's normalizeLinkIds (array → string[]; the helper only needs the parse contract).
 const nlz = (v: unknown): string[] => (Array.isArray(v) ? v.map(String) : typeof v === 'string' && v ? [v] : [])
@@ -135,5 +140,54 @@ describe('projectRestorableOntoLive — canonical restorable projection for L8 a
     expect(out.patch).toEqual({ gone: null })
     expect(out.data).toEqual({ f: 'keep-me' })
     expect(Object.prototype.hasOwnProperty.call(out.data, 'gone')).toBe(false)
+  })
+
+  it('link id duplicates are deduped once into the SAME content for data, patch, and linkUpdates', () => {
+    const out = projectRestorableOntoLive({
+      fieldById: new Map([['rel', { type: 'link' }]]),
+      rawTypeById: new Map(),
+      targetSnapshot: { rel: ['A', 'A', 'B'] },
+      currentData: { rel: [] },
+      recordId: 'r1',
+      currentVersion: 1,
+      normalizeLinkIds: nlz,
+    })
+    expect(out.linkUpdates).toEqual([{ fieldId: 'rel', targetIds: ['A', 'B'] }])
+    expect(out.data.rel).toEqual(['A', 'B'])
+    expect(out.patch.rel).toEqual(['A', 'B'])
+    expect(canonicalDedupeLinkIds(['x', 'x', 'y'])).toEqual(['x', 'y'])
+  })
+})
+
+describe('assertExactRestorableScalarValue — exact-anchor current-schema fail-closed', () => {
+  it('rich longText that would be sanitized differs from history ⇒ ExactRestoreValueError', () => {
+    const unsafe = '<script>alert(1)</script><p>hi</p>'
+    expect(() =>
+      assertExactRestorableScalarValue(
+        { id: 'lt', type: 'longText', property: { rich: true } },
+        unsafe,
+      ),
+    ).toThrow(ExactRestoreValueError)
+  })
+
+  it('select option absent from CURRENT options ⇒ ExactRestoreValueError', () => {
+    expect(() =>
+      assertExactRestorableScalarValue(
+        { id: 's', type: 'select', options: [{ value: 'a' }, { value: 'b' }] },
+        'gone-option',
+      ),
+    ).toThrow(ExactRestoreValueError)
+  })
+
+  it('number string that would coerce to number differs from history ⇒ ExactRestoreValueError', () => {
+    expect(() =>
+      assertExactRestorableScalarValue({ id: 'n', type: 'number' }, '42'),
+    ).toThrow(ExactRestoreValueError)
+  })
+
+  it('identical valid string scalar passes', () => {
+    expect(() =>
+      assertExactRestorableScalarValue({ id: 's', type: 'string' }, 'hello'),
+    ).not.toThrow()
   })
 })

--- a/packages/core-backend/tests/unit/record-restore-diff.test.ts
+++ b/packages/core-backend/tests/unit/record-restore-diff.test.ts
@@ -10,7 +10,11 @@ import {
   projectRestorableOntoLive,
   canonicalDedupeLinkIds,
 } from '../../src/multitable/record-restore-diff'
-import { assertExactRestorableScalarValue, ExactRestoreValueError } from '../../src/multitable/exact-anchor-restore-validate'
+import {
+  assertExactRestorableRecordValid,
+  assertExactRestorableScalarValue,
+  ExactRestoreValueError,
+} from '../../src/multitable/exact-anchor-restore-validate'
 
 // Minimal stand-in for the route's normalizeLinkIds (array → string[]; the helper only needs the parse contract).
 const nlz = (v: unknown): string[] => (Array.isArray(v) ? v.map(String) : typeof v === 'string' && v ? [v] : [])
@@ -188,6 +192,88 @@ describe('assertExactRestorableScalarValue — exact-anchor current-schema fail-
   it('identical valid string scalar passes', () => {
     expect(() =>
       assertExactRestorableScalarValue({ id: 's', type: 'string' }, 'hello'),
+    ).not.toThrow()
+  })
+})
+
+describe('assertExactRestorableRecordValid — whole projected record under CURRENT rules', () => {
+  it('newly-required field omitted/unset on projected data ⇒ ExactRestoreValueError', () => {
+    expect(() =>
+      assertExactRestorableRecordValid(
+        [
+          {
+            id: 'req',
+            name: 'Required',
+            type: 'string',
+            property: { validation: [{ type: 'required' }] },
+          },
+          { id: 'note', name: 'Note', type: 'string', property: {} },
+        ],
+        { note: 'present' }, // req omitted
+      ),
+    ).toThrow(ExactRestoreValueError)
+  })
+
+  it('explicit maxLength violation on projected data ⇒ ExactRestoreValueError', () => {
+    expect(() =>
+      assertExactRestorableRecordValid(
+        [
+          {
+            id: 's',
+            name: 'Short',
+            type: 'string',
+            property: { validation: [{ type: 'maxLength', params: { value: 3 } }] },
+          },
+        ],
+        { s: 'toolong' },
+      ),
+    ).toThrow(ExactRestoreValueError)
+  })
+
+  it('explicit pattern violation on projected data ⇒ ExactRestoreValueError', () => {
+    expect(() =>
+      assertExactRestorableRecordValid(
+        [
+          {
+            id: 'code',
+            name: 'Code',
+            type: 'string',
+            property: { validation: [{ type: 'pattern', params: { regex: '^[A-Z]+$' } }] },
+          },
+        ],
+        { code: 'not-upper' },
+      ),
+    ).toThrow(ExactRestoreValueError)
+  })
+
+  it('valid projected record under explicit required + pattern passes', () => {
+    expect(() =>
+      assertExactRestorableRecordValid(
+        [
+          {
+            id: 'code',
+            name: 'Code',
+            type: 'string',
+            property: {
+              validation: [
+                { type: 'required' },
+                { type: 'pattern', params: { regex: '^[A-Z]+$' } },
+              ],
+            },
+          },
+        ],
+        { code: 'ABC' },
+      ),
+    ).not.toThrow()
+  })
+
+  it('explicit property.validation replaces defaults (record-service ?? precedence)', () => {
+    // Default string maxLength is 10000; explicit empty validation list means NO rules.
+    expect(() =>
+      assertExactRestorableRecordValid(
+        [{ id: 's', name: 'S', type: 'string', property: { validation: [] } }],
+        { s: 'x'.repeat(20000) },
+      ),
     ).not.toThrow()
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -416,6 +416,11 @@ export default defineConfig({
       // Postgres. Exclude from the no-DB default lane so it cannot skip-green; the shared exact-anchor
       // CI wiring contract pins this entry and its whole-file multitable real-DB invocation.
       'tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts',
+      // W0 L8 exact-anchor destructive-apply goldens: DATABASE_URL-gated and meaningful only against real
+      // Postgres (constructed lock races, trigger-injected rollback, real advisory fence). Exclude from the
+      // no-DB default lane so it cannot skip-green; the shared exact-anchor CI wiring contract pins this
+      // entry and its whole-file multitable real-DB invocation.
+      'tests/integration/multitable-exact-anchor-apply-realdb.test.ts',
       // D-1c W0 slice ① (form-submit CREATE/EDIT public-form revision goldens): real Postgres only
       // (installs scoped failure/suppression triggers per site and drives the real submit route
       // end-to-end) — excluded HERE so it cannot skip-green in the no-DB lane, whole-file wired into

--- a/scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
+++ b/scripts/ops/multitable-exact-anchor-ci-wiring.test.mjs
@@ -12,6 +12,9 @@ const repoRoot = join(__dirname, '..', '..')
 const FILES = [
   'tests/integration/multitable-exact-anchor-recovery-realdb.test.ts',
   'tests/integration/multitable-exact-anchor-recovery-plan-realdb.test.ts',
+  // W0 L8 destructive-apply suite joins the same two-point contract: removing/relocating either its
+  // vitest.config.ts exclusion or its whole-file plugin-tests.yml invocation must red this guard.
+  'tests/integration/multitable-exact-anchor-apply-realdb.test.ts',
 ]
 const REAL_DB_STEP = 'Run multitable real-DB integration'
 


### PR DESCRIPTION
## Scope

Stacked on L7 Draft #4474. This Draft adds the L8 destructive exact-anchor APPLY kernel only: token-bound mode and identity, a real-transaction proof before any fence/burn/write, strict trusted-substrate precheck, one-transaction burn/authorization/validation/write/seal, current-schema validation, canonical link/reset parity, hierarchy-cycle defense, deterministic full-sheet `FOR UPDATE` plus a fresh live-set re-hash, version-CAS on Revert updates and Reset deletes, and recovery-actor `modified_by` attribution.

This remains intentionally unwired and default-off. It does not add production routes, flip a feature flag, deploy anything, or authorize enablement. `RECONSTRUCTION_CAUSALITY_LANDED=false` remains the release posture.

## Verification

- independent Opus exact-head adversarial gate on `a54718d22`: **CLEAR, 0 P1 / 0 P2**
- backend TypeScript `tsc --noEmit`: clean
- full backend unit suite: 425 files / 5,847 tests green
- fresh PostgreSQL L8 real-DB suite: 50/50
- predecessor real-DB combination (L6-b, L7, strict seq, checkpoint, L5-wire): 70/70
- identity + plan unit suites: 24/24
- lock/disposition structural guards: 15/15
- exact-anchor CI two-point guard: 7/7
- latest migration independently replayed `down -> up -> up`; burn table PK and both indexes verified
- mutation proofs: transaction proof, fresh re-hash, full-row lock, Reset CAS, both CI wiring points, and Revert `modified_by` attribution each turned its targeted golden red, then returned green after byte restoration
- original nine L8 commits restacked onto exact #4474 head with range-diff 9/9 `=` before the hardening commits
- `git diff --check`: clean

## Deliberate Pre-Enable Gates

The production route adapter must still provide fresh person-membership adjudication and foreign-target read/edit authority through `evaluatePlanAuthorization`; preserve no-oracle response mapping and presentation masking; and compose same-transaction durable event enqueue with non-fatal post-commit side effects. Size ceilings, route/UI wiring, smoke evidence, and every environment flag remain separate Draft/owner/ops gates.

No auto-merge is enabled.
