### PR TITLE
feat(attendance): resolve manager-at-level approvers

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -791,6 +791,7 @@ jobs:
             tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts \
             tests/integration/attendance-approval-direct-manager-s7-2.db.test.ts \
             tests/integration/attendance-approval-dept-head-s7-3.db.test.ts \
+            tests/integration/attendance-approval-manager-at-level-s7-4.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -959,21 +959,21 @@ export class MetaSheetServer {
     return wrappedUnregister
   }
 
-  // S7-1/S7-2/S7-3 (RATIFIED attendance-approval-s7 resolver lock, OD-S7-5=d): construct the host
+  // S7-1..S7-4 (RATIFIED attendance-approval-s7 resolver lock, OD-S7-5=d): construct the host
   // binding for the narrow, org-scoped dynamic approval-assignee resolver port plugin-attendance
   // consumes. Exposes the SAME MAX_MANAGER_CHAIN_LEVELS constant the kernel uses (no plugin env
   // re-parse). S7-2 wires `direct_manager` (byte-identical to ApprovalDirectoryOrg §2.1); S7-3 adds
-  // `dept_head` (byte-identical to §2.2: first-linked dept_manager_userid_list entry, self-exclusion).
-  // `manager_at_level` stays unimplemented (S7-4). Directory data is READ-ONLY.
+  // `dept_head` (byte-identical to §2.2); S7-4 adds `manager_at_level` (dense chain positional pick,
+  // §2.3 B1 — includeManagerChain walk, self-exclusion, no continuous_managers). Directory READ-ONLY.
   private buildApprovalAssigneeResolverPort(): NonNullable<
     import('./types/plugin').PluginServices['approvalAssigneeResolver']
   > {
     return {
       maxManagerChainLevels: MAX_MANAGER_CHAIN_LEVELS,
-      implementedKinds: ['direct_manager', 'dept_head'],
+      implementedKinds: ['direct_manager', 'dept_head', 'manager_at_level'],
       resolve: async (orgId, request) => {
         const kind = typeof request?.kind === 'string' ? request.kind.trim() : ''
-        if (kind !== 'direct_manager' && kind !== 'dept_head') {
+        if (kind !== 'direct_manager' && kind !== 'dept_head' && kind !== 'manager_at_level') {
           return { status: 'unimplemented' as const }
         }
 
@@ -990,8 +990,10 @@ export class MetaSheetServer {
         const queryFn = <Row>(text: string, params?: unknown[]): Promise<{ rows: Row[] }> =>
           pgQuery(text, params).then((r) => ({ rows: r.rows as Row[] }))
 
+        // manager_at_level needs the dense manager chain (includeManagerChain); other kinds do not.
         const relations = await resolveApprovalRequesterOrgRelations(requesterUserId, queryFn, {
           orgId: normalizedOrgId,
+          includeManagerChain: kind === 'manager_at_level',
         })
 
         // S7-2 direct_manager — preserved byte-for-byte (reads only managerId).
@@ -1015,21 +1017,57 @@ export class MetaSheetServer {
         }
 
         // S7-3 dept_head — same org-anchored relations call; read ONLY deptHeadId (§2.2).
-        const deptHeadId =
-          typeof relations.deptHeadId === 'string' && relations.deptHeadId.trim().length > 0
-            ? relations.deptHeadId.trim()
-            : null
-        // Self-exclusion at the resolver (§2.2): a dept head that resolves to the requester is treated
-        // as unresolved — never written as a self-assignment.
-        if (!deptHeadId || deptHeadId === requesterUserId) {
-          return {
-            status: 'unresolved' as const,
-            reason: deptHeadId === requesterUserId ? 'self_dept_head' : 'no_dept_head_linked',
+        if (kind === 'dept_head') {
+          const deptHeadId =
+            typeof relations.deptHeadId === 'string' && relations.deptHeadId.trim().length > 0
+              ? relations.deptHeadId.trim()
+              : null
+          // Self-exclusion at the resolver (§2.2): a dept head that resolves to the requester is treated
+          // as unresolved — never written as a self-assignment.
+          if (!deptHeadId || deptHeadId === requesterUserId) {
+            return {
+              status: 'unresolved' as const,
+              reason: deptHeadId === requesterUserId ? 'self_dept_head' : 'no_dept_head_linked',
+            }
           }
+          return {
+            status: 'resolved' as const,
+            assignees: [{ assignmentType: 'user' as const, assigneeId: deptHeadId }],
+          }
+        }
+
+        // S7-4 manager_at_level — dense chain from includeManagerChain walk (§2.3 B1).
+        // CREATE-TIME freeze (no level): return the FULL dense chain as ordered assignees so the
+        // plugin freezes requesterSnapshot.managerChainIds once; step-advance never re-calls this.
+        // With integer level: single positional pick chain[level-1] (1 = direct manager).
+        // Self-exclusion / unlinked walk-through / cycle / maxLevels are owned by ApprovalDirectoryOrg.
+        const rawChain = Array.isArray(relations.managerChainIds) ? relations.managerChainIds : []
+        const chain = rawChain
+          .map((id) => (typeof id === 'string' ? id.trim() : ''))
+          .filter((id) => id.length > 0 && id !== requesterUserId)
+
+        const level = request?.level
+        if (typeof level === 'number' && Number.isInteger(level) && level >= 1) {
+          const managerId = chain[level - 1] ?? null
+          if (!managerId) {
+            return {
+              status: 'unresolved' as const,
+              reason: chain.length === 0 ? 'no_manager_chain' : 'chain_shorter_than_level',
+            }
+          }
+          return {
+            status: 'resolved' as const,
+            assignees: [{ assignmentType: 'user' as const, assigneeId: managerId }],
+          }
+        }
+
+        // Freeze path (no level): empty chain ⇒ unresolved; else ordered assignees = dense chain.
+        if (chain.length === 0) {
+          return { status: 'unresolved' as const, reason: 'no_manager_chain' }
         }
         return {
           status: 'resolved' as const,
-          assignees: [{ assignmentType: 'user' as const, assigneeId: deptHeadId }],
+          assignees: chain.map((assigneeId) => ({ assignmentType: 'user' as const, assigneeId })),
         }
       },
     }

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -979,7 +979,7 @@ export interface PluginServices {
     }): (() => void)
   }
   /**
-   * S7-1/S7-2/S7-3 — host→plugin, narrow, org-scoped resolver PORT for the attendance dynamic
+   * S7-1..S7-4 — host→plugin, narrow, org-scoped resolver PORT for the attendance dynamic
    * approval-assignee kinds (直属上级 `direct_manager` / 部门主管 `dept_head` / 多级上级
    * `manager_at_level`), per the RATIFIED attendance-approval-s7 resolver design-lock, OD-S7-5 = (d).
    * It mirrors `workdayCalendar` above but runs the OPPOSITE direction: core-backend is the PROVIDER,
@@ -993,13 +993,15 @@ export interface PluginServices {
    *   The plugin validates `manager_at_level.level ∈ [1, maxManagerChainLevels]` against THIS value so it
    *   never re-parses the env var into a second constant — one source, two surfaces, no drift.
    * - `implementedKinds` is the set of dynamic kinds this host build can actually resolve at runtime.
-   *   S7-2/S7-3 populate `direct_manager` + `dept_head`; `manager_at_level` remains S7-4.
-   *   A kind absent from this list is unimplemented ⇒ the plugin fail-closes.
+   *   S7-2/S7-3/S7-4 populate `direct_manager` + `dept_head` + `manager_at_level` (NOT
+   *   `continuous_managers` — OD-S7-2 OUT-of-v1). A kind absent from this list is unimplemented ⇒
+   *   the plugin fail-closes.
    * - `resolve` is the org-scoped CREATE-TIME freeze seam (§3.3 / §3.4). For `direct_manager` /
-   *   `dept_head` it runs the kernel's `resolveApprovalRequesterOrgRelations` with the attendance
-   *   `orgId` anchor, returns the linked local manager / dept head (or `unresolved`), and NEVER writes.
-   *   Step-advance must NOT call this again — it reads only the frozen `requesterSnapshot.managerId` /
-   *   `deptHeadId`. Self-exclusion is enforced here (resolving to the requester is treated as unresolved).
+   *   `dept_head` it returns a single linked local assignee; for `manager_at_level` with no level it
+   *   returns the FULL dense chain as ordered assignees (plugin freezes `managerChainIds`); with an
+   *   integer level it returns the single positional pick. Step-advance must NOT call this again —
+   *   it reads only the frozen `requesterSnapshot.managerId` / `deptHeadId` / `managerChainIds`.
+   *   Self-exclusion is enforced here (resolving to the requester is treated as unresolved).
    */
   approvalAssigneeResolver?: {
     readonly maxManagerChainLevels: number

--- a/packages/core-backend/tests/integration/attendance-approval-dept-head-s7-3.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-approval-dept-head-s7-3.db.test.ts
@@ -510,21 +510,21 @@ describeIfDatabase('S7-3 dept_head — freeze + assignment + auth (real DB)', ()
     expect(steps).toEqual([{ name: undefined, kind: 'dept_head' }])
   })
 
-  it('AUTHORING: manager_at_level still UNAVAILABLE (S7-4 not shipped)', async () => {
+  it('AUTHORING: continuous_managers stays OUT-of-v1 (KIND_INVALID, not silent accept)', async () => {
     setFlag(true)
     const res = await requestJson(`${baseUrl}/api/attendance/approval-flows`, {
       method: 'POST',
       headers: authHeaders(adminToken),
       body: JSON.stringify({
-        name: `s7-3-mal-unavail-${runSuffix}`,
+        name: `s7-3-cm-out-${runSuffix}`,
         requestType: 'time_correction',
-        steps: [{ kind: 'manager_at_level', level: 1 }],
+        steps: [{ kind: 'continuous_managers', levels: 2 }],
         orgId: orgHome,
         isActive: true,
       }),
     })
     expect(res.status, res.raw).toBe(422)
-    expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
+    expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_INVALID')
   })
 
   // ── Linked resolution + freeze + assignment ──

--- a/packages/core-backend/tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts
@@ -254,14 +254,27 @@ describeIfDatabase('S7-1 dynamic-kind step contract + fail-closed (authoring + r
     })
   }
 
-  // S7-2/S7-3 implement direct_manager + dept_head: keep this leg as a fail-closed proof for an
-  // STILL-unimplemented kind (manager_at_level / S7-4) so the UNAVAILABLE gate remains mutation-provable.
-  it('CREATE rejects a shape-valid but unimplemented dynamic kind (manager_at_level) with flag ON → 422 APPROVAL_STEP_KIND_UNAVAILABLE', async () => {
+  // S7-2/S7-3/S7-4 implement all three recognized dynamic kinds. continuous_managers remains
+  // OUT-of-v1 (OD-S7-2) → KIND_INVALID (not silent accept / admin fallback). Flag-off still
+  // proves UNAVAILABLE for shape-valid kinds elsewhere in this suite.
+  it('CREATE rejects OUT-of-v1 continuous_managers with flag ON → 422 APPROVAL_STEP_KIND_INVALID', async () => {
     setFlag(true)
     try {
-      const res = await createFlow([{ kind: 'manager_at_level', level: 1 }], `s7-1-unavail-${runSuffix}`)
+      const res = await createFlow([{ kind: 'continuous_managers', levels: 2 }], `s7-1-cm-out-${runSuffix}`)
       expect(res.status, res.raw).toBe(422)
-      expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
+      expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_INVALID')
+    } finally {
+      setFlag(false)
+    }
+  })
+
+  it('CREATE accepts manager_at_level when flag ON (S7-4 implements the kind)', async () => {
+    setFlag(true)
+    try {
+      const res = await createFlow([{ kind: 'manager_at_level', level: 1 }], `s7-1-mal-ok-${runSuffix}`)
+      expect(res.status, res.raw).toBe(201)
+      const steps = (res.body as { data?: { steps?: unknown[] } }).data?.steps
+      expect(steps).toEqual([{ name: undefined, kind: 'manager_at_level', level: 1 }])
     } finally {
       setFlag(false)
     }

--- a/packages/core-backend/tests/integration/attendance-approval-manager-at-level-s7-4.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-approval-manager-at-level-s7-4.db.test.ts
@@ -6,19 +6,19 @@ import http from 'http'
 import { Pool } from 'pg'
 import { randomUUID } from 'crypto'
 
-// S7-2 (RATIFIED attendance-approval-s7 resolver design-lock §2.1 / §3.3 / §3.4 / §4 / §4.1 / §7 S7-2):
-// real-DB, HTTP-level coverage of direct_manager end-to-end:
-//   linked resolution + freeze into requester_snapshot.managerId
-//   unlinked block-with-error + zero persistence
+// S7-4 (RATIFIED attendance-approval-s7 resolver design-lock §2.3 B1 / §3.3 / §3.4 / §4 / §4.1 / §7 S7-4):
+// real-DB, HTTP-level coverage of manager_at_level end-to-end:
+//   valid level-1/level-2 resolution + freeze into requester_snapshot.managerChainIds
+//   unlinked / short chain block-with-error + zero persistence
 //   two-org / one-local-user org-anchor
-//   2-step freeze after directory relation mutation
+//   2-step freeze after directory chain mutation
 //   dynamic assignment approve+reject authorization (negative / positive / admin)
 //   flag-off create + flag-off advance rollback
+//   missing/throwing port fail-closed is covered by unit tests (port is host-injected here)
 //   legacy static still works with flag off
-//   S7-1 NITs folded: empty-static-array MIXED + non-string kind → distinct 422
+//   cycle/dense-chain/cap behavior is covered by ApprovalDirectoryOrg unit + approval-manager-chain.db
 //
-// RBAC_BYPASS is toggled per-case: authoring / create paths use 'true' for simplicity; the
-// assignment-authorization legs force 'false' so the S7-0 predicate is what we observe.
+// Chain fixtures use leader_in_dept (the walk source for managerChainIds), NOT is_manager.
 
 interface HttpResponse {
   status: number
@@ -73,7 +73,7 @@ const NODE_KEY_1 = 'attendance_request_step_1'
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
 const describeIfDatabase = dbUrl ? describe : describe.skip
 
-describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)', () => {
+describeIfDatabase('S7-4 manager_at_level — freeze + assignment + auth (real DB)', () => {
   let server: MetaSheetServer | undefined
   let baseUrl: string | undefined
   let pool: Pool | undefined
@@ -81,38 +81,46 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
   let prevFlag: string | undefined
 
   const runSuffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
-  const orgHome = `s7-2-home-${runSuffix}`
-  const orgForeign = `s7-2-foreign-${runSuffix}`
-  const orgUnlinked = `s7-2-unlinked-${runSuffix}`
-  const orgFreeze = `s7-2-freeze-${runSuffix}`
-  const orgAuthz = `s7-2-authz-${runSuffix}`
-  const orgFlagOff = `s7-2-flagoff-${runSuffix}`
+  const orgHome = `s7-4-home-${runSuffix}`
+  const orgForeign = `s7-4-foreign-${runSuffix}`
+  const orgUnlinked = `s7-4-unlinked-${runSuffix}`
+  const orgFreeze = `s7-4-freeze-${runSuffix}`
+  const orgAuthz = `s7-4-authz-${runSuffix}`
+  const orgFlagOff = `s7-4-flagoff-${runSuffix}`
+  const orgShort = `s7-4-short-${runSuffix}`
 
-  const requester = `s7-2-req-${runSuffix}`
-  const managerHome = `s7-2-mgr-home-${runSuffix}`
-  const managerForeign = `s7-2-mgr-foreign-${runSuffix}`
-  const managerAlt = `s7-2-mgr-alt-${runSuffix}`
-  const otherApprover = `s7-2-other-${runSuffix}`
-  const adminActor = `s7-2-admin-${runSuffix}`
+  const requester = `s7-4-req-${runSuffix}`
+  const managerL1Home = `s7-4-m1-home-${runSuffix}`
+  const managerL2Home = `s7-4-m2-home-${runSuffix}`
+  const managerL1Foreign = `s7-4-m1-foreign-${runSuffix}`
+  const managerL1Alt = `s7-4-m1-alt-${runSuffix}`
+  const otherApprover = `s7-4-other-${runSuffix}`
+  const adminActor = `s7-4-admin-${runSuffix}`
 
-  const userIds: string[] = [requester, managerHome, managerForeign, managerAlt, otherApprover, adminActor]
+  const userIds: string[] = [
+    requester,
+    managerL1Home,
+    managerL2Home,
+    managerL1Foreign,
+    managerL1Alt,
+    otherApprover,
+    adminActor,
+  ]
   const integrationIds: string[] = []
   const createdFlowIds: string[] = []
   const createdInstanceIds: string[] = []
   const createdRequestIds: string[] = []
 
   let adminToken = ''
-  let managerToken = ''
+  let managerL1Token = ''
+  let managerL2Token = ''
   let otherToken = ''
   let adminActorToken = ''
 
-  // Directory fixture handles for freeze-mutation + org-anchor cases.
-  let homeMgrAccountId = ''
-  let homeDeptId = ''
-  let homeIntegrationId = ''
-  let freezeMgrAccountId = ''
-  let freezeAltAccountId = ''
-  let freezeDeptId = ''
+  // Freeze-mutation fixture handles (orgFreeze leader swap).
+  let freezeDeptR = ''
+  let freezeAccM1 = ''
+  let freezeAccAlt = ''
 
   function setFlag(on: boolean): void {
     if (on) process.env[DYNAMIC_FLAG] = 'true'
@@ -137,7 +145,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
   async function seedUser(userId: string): Promise<void> {
     await (pool as Pool).query(
       `INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x') ON CONFLICT (id) DO NOTHING`,
-      [userId, `${userId}@s7-2.test`],
+      [userId, `${userId}@s7-4.test`],
     )
   }
 
@@ -191,13 +199,62 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     accountId: string,
     departmentId: string,
     isPrimary: boolean,
-    isManager = false,
   ): Promise<void> {
     await (pool as Pool).query(
       `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary, is_manager)
-       VALUES ($1, $2, $3, $4)`,
-      [accountId, departmentId, isPrimary, isManager],
+       VALUES ($1, $2, $3, false)`,
+      [accountId, departmentId, isPrimary],
     )
+  }
+
+  /**
+   * Two-level dense chain for orgHome:
+   *   R primary DEPT_R
+   *   M1 leader of DEPT_R (leader_in_dept), primary DEPT_M1
+   *   M2 leader of DEPT_M1, primary DEPT_M2 (top)
+   * → managerChainIds = [managerL1Home, managerL2Home]
+   */
+  async function seedTwoLevelChain(
+    orgId: string,
+    localRequester: string,
+    localM1: string,
+    localM2: string,
+    tag: string,
+  ): Promise<{ integrationId: string; deptR: string; accM1: string; accM2: string }> {
+    const integrationId = await seedIntegration(orgId, `s7-4-${tag}-int-${runSuffix}`, `corp-${tag}-${runSuffix}`)
+    const extDeptR = `dept-r-${tag}-${runSuffix}`
+    const extDeptM1 = `dept-m1-${tag}-${runSuffix}`
+    const extDeptM2 = `dept-m2-${tag}-${runSuffix}`
+    const deptR = await seedDept(integrationId, extDeptR, `${tag} R Eng`)
+    const deptM1 = await seedDept(integrationId, extDeptM1, `${tag} M1 Eng`)
+    const deptM2 = await seedDept(integrationId, extDeptM2, `${tag} M2 Eng`)
+
+    const accR = await seedAccount(integrationId, `ext-r-${tag}-${runSuffix}`, `key-r-${tag}-${runSuffix}`, `Req${tag}`)
+    const accM1 = await seedAccount(
+      integrationId,
+      `ext-m1-${tag}-${runSuffix}`,
+      `key-m1-${tag}-${runSuffix}`,
+      `M1${tag}`,
+      { leader_in_dept: [{ dept_id: extDeptR, leader: true }] },
+    )
+    const accM2 = await seedAccount(
+      integrationId,
+      `ext-m2-${tag}-${runSuffix}`,
+      `key-m2-${tag}-${runSuffix}`,
+      `M2${tag}`,
+      { leader_in_dept: [{ dept_id: extDeptM1, leader: true }] },
+    )
+
+    await link(accR, localRequester)
+    await link(accM1, localM1)
+    await link(accM2, localM2)
+    await membership(accR, deptR, true)
+    await membership(accM1, deptR, false)
+    await membership(accM1, deptM1, true)
+    await membership(accM2, deptM1, false)
+    await membership(accM2, deptM2, true)
+
+    return { integrationId, deptR, accM1, accM2 }
   }
 
   async function seedFlow(
@@ -248,7 +305,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     return requestJson(`${baseUrl}/api/attendance/requests/${requestId}/${action}`, {
       method: 'POST',
       headers: authHeaders(token),
-      body: JSON.stringify({ comment: `s7-2 ${action}` }),
+      body: JSON.stringify({ comment: `s7-4 ${action}` }),
     })
   }
 
@@ -258,8 +315,8 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       s.once('error', () => resolve(false))
       s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
     })
-    if (!canListen) throw new Error('S7-2 tests require an available loopback port.')
-    if (!dbUrl) throw new Error('DATABASE_URL / ATTENDANCE_TEST_DATABASE_URL is required for the S7-2 suite.')
+    if (!canListen) throw new Error('S7-4 tests require an available loopback port.')
+    if (!dbUrl) throw new Error('DATABASE_URL / ATTENDANCE_TEST_DATABASE_URL is required for the S7-4 suite.')
 
     process.env.DATABASE_URL = dbUrl
     prevRbac = process.env.RBAC_BYPASS
@@ -273,58 +330,36 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
 
     for (const uid of userIds) await seedUser(uid)
 
-    // ── orgHome: linked requester + normalized is_manager (authoritative) ──
-    homeIntegrationId = await seedIntegration(orgHome, `s7-2-home-int-${runSuffix}`, `corp-home-${runSuffix}`)
-    homeDeptId = await seedDept(homeIntegrationId, `dept-home-${runSuffix}`, 'Home Eng')
-    const homeReqAcc = await seedAccount(homeIntegrationId, `ext-req-home-${runSuffix}`, `key-req-home-${runSuffix}`, 'ReqHome')
-    homeMgrAccountId = await seedAccount(homeIntegrationId, `ext-mgr-home-${runSuffix}`, `key-mgr-home-${runSuffix}`, 'MgrHome')
-    // Legacy leader that would resolve to managerAlt — precedence must pick normalized managerHome.
-    const homeLegacyAcc = await seedAccount(
-      homeIntegrationId,
-      `ext-legacy-home-${runSuffix}`,
-      `key-legacy-home-${runSuffix}`,
-      'LegacyHome',
-      { leader_in_dept: [{ dept_id: `dept-home-${runSuffix}`, leader: true }] },
+    // ── orgHome: two-level chain ──
+    await seedTwoLevelChain(orgHome, requester, managerL1Home, managerL2Home, 'home')
+
+    // ── orgForeign: same local requester, different L1 manager (more recent updated_at) ──
+    const foreign = await seedTwoLevelChain(
+      orgForeign,
+      requester,
+      managerL1Foreign,
+      managerL2Home,
+      'foreign',
     )
-    await link(homeReqAcc, requester)
-    await link(homeMgrAccountId, managerHome)
-    await link(homeLegacyAcc, managerAlt)
-    await membership(homeReqAcc, homeDeptId, true, false)
-    await membership(homeMgrAccountId, homeDeptId, false, true) // normalized manager
-    await membership(homeLegacyAcc, homeDeptId, false, false)
+    await pool.query(`UPDATE directory_accounts SET updated_at = now() + interval '1 hour'
+      WHERE integration_id = $1`, [foreign.integrationId])
 
-    // ── orgForeign: same local requester linked into a different org with a different manager ──
-    // updated_at will be more recent than home (inserted later) so the unscoped pick would choose
-    // foreign — the org anchor must force home when attendance requests use orgHome.
-    const foreignInt = await seedIntegration(orgForeign, `s7-2-foreign-int-${runSuffix}`, `corp-foreign-${runSuffix}`)
-    const foreignDept = await seedDept(foreignInt, `dept-foreign-${runSuffix}`, 'Foreign Eng')
-    const foreignReqAcc = await seedAccount(foreignInt, `ext-req-foreign-${runSuffix}`, `key-req-foreign-${runSuffix}`, 'ReqForeign')
-    const foreignMgrAcc = await seedAccount(foreignInt, `ext-mgr-foreign-${runSuffix}`, `key-mgr-foreign-${runSuffix}`, 'MgrForeign')
-    await link(foreignReqAcc, requester)
-    await link(foreignMgrAcc, managerForeign)
-    await membership(foreignReqAcc, foreignDept, true, false)
-    await membership(foreignMgrAcc, foreignDept, false, true)
-    // Bump foreign account updated_at so it is "more recent" than home (unscoped would pick it).
-    await pool.query(`UPDATE directory_accounts SET updated_at = now() + interval '1 hour' WHERE id = $1`, [
-      foreignReqAcc,
-    ])
+    // ── orgFreeze: two-level chain for freeze-mutation (swap L1 leader after create) ──
+    const freeze = await seedTwoLevelChain(orgFreeze, requester, managerL1Home, managerL2Home, 'freeze')
+    freezeDeptR = freeze.deptR
+    freezeAccM1 = freeze.accM1
+    // Alternate L1 leader account (linked to managerL1Alt), not leader yet.
+    freezeAccAlt = await seedAccount(
+      freeze.integrationId,
+      `ext-m1-alt-${runSuffix}`,
+      `key-m1-alt-${runSuffix}`,
+      'M1Alt',
+      {},
+    )
+    await link(freezeAccAlt, managerL1Alt)
+    await membership(freezeAccAlt, freezeDeptR, false)
 
-    // ── orgFreeze: 2-step flow freeze fixture (static step 0 + direct_manager step 1) ──
-    const freezeInt = await seedIntegration(orgFreeze, `s7-2-freeze-int-${runSuffix}`, `corp-freeze-${runSuffix}`)
-    freezeDeptId = await seedDept(freezeInt, `dept-freeze-${runSuffix}`, 'Freeze Eng')
-    const freezeReqAcc = await seedAccount(freezeInt, `ext-req-freeze-${runSuffix}`, `key-req-freeze-${runSuffix}`, 'ReqFreeze')
-    freezeMgrAccountId = await seedAccount(freezeInt, `ext-mgr-freeze-${runSuffix}`, `key-mgr-freeze-${runSuffix}`, 'MgrFreeze')
-    freezeAltAccountId = await seedAccount(freezeInt, `ext-mgr-alt-${runSuffix}`, `key-mgr-alt-${runSuffix}`, 'MgrAlt')
-    // Separate local user for freeze-org requester to avoid multi-org link noise on the shared requester.
-    // Reuse managerHome as the initial freeze manager; managerAlt as the post-mutation manager.
-    await link(freezeReqAcc, requester)
-    await link(freezeMgrAccountId, managerHome)
-    await link(freezeAltAccountId, managerAlt)
-    await membership(freezeReqAcc, freezeDeptId, true, false)
-    await membership(freezeMgrAccountId, freezeDeptId, false, true)
-    await membership(freezeAltAccountId, freezeDeptId, false, false)
-
-    // RBAC substrate for authz legs (real DB tables, not just JWT claims).
+    // RBAC substrate for authz legs.
     await pool.query(
       `INSERT INTO permissions (code, name, description)
        VALUES
@@ -338,12 +373,13 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
        VALUES
          ($1, 'attendance:approve'),
          ($2, 'attendance:approve'),
-         ($3, 'attendance:admin'),
-         ($4, 'attendance:write'),
-         ($4, 'attendance:approve'),
-         ($4, 'attendance:admin')
+         ($3, 'attendance:approve'),
+         ($4, 'attendance:admin'),
+         ($5, 'attendance:write'),
+         ($5, 'attendance:approve'),
+         ($5, 'attendance:admin')
        ON CONFLICT DO NOTHING`,
-      [managerHome, otherApprover, adminActor, requester],
+      [managerL1Home, managerL2Home, otherApprover, adminActor, requester],
     )
 
     const repoRoot = path.join(__dirname, '../../../../')
@@ -355,11 +391,12 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     })
     await server.start()
     const address = server.getAddress()
-    if (!address || typeof address === 'string') throw new Error('S7-2 server did not expose a TCP address.')
+    if (!address || typeof address === 'string') throw new Error('S7-4 server did not expose a TCP address.')
     baseUrl = `http://127.0.0.1:${address.port}`
 
     adminToken = await devToken(requester, 'user', 'attendance:admin,attendance:write,attendance:approve')
-    managerToken = await devToken(managerHome, 'user', 'attendance:approve')
+    managerL1Token = await devToken(managerL1Home, 'user', 'attendance:approve')
+    managerL2Token = await devToken(managerL2Home, 'user', 'attendance:approve')
     otherToken = await devToken(otherApprover, 'user', 'attendance:approve')
     adminActorToken = await devToken(adminActor, 'user', 'attendance:admin')
   })
@@ -370,7 +407,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
         if (createdRequestIds.length > 0) {
           await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::uuid[])', [createdRequestIds]).catch(() => undefined)
         }
-        for (const oid of [orgHome, orgForeign, orgUnlinked, orgFreeze, orgAuthz, orgFlagOff]) {
+        for (const oid of [orgHome, orgForeign, orgUnlinked, orgFreeze, orgAuthz, orgFlagOff, orgShort]) {
           await pool.query('DELETE FROM attendance_requests WHERE org_id = $1', [oid]).catch(() => undefined)
           await pool.query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [oid]).catch(() => undefined)
         }
@@ -403,16 +440,16 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     expect(process.env.DATABASE_URL).toBeTruthy()
   })
 
-  // ── Authoring: S7-2 makes direct_manager available when flag ON ──
-  it('AUTHORING: flag ON + direct_manager accepted (S7-2 implements the kind)', async () => {
+  // ── Authoring: S7-4 makes manager_at_level available when flag ON ──
+  it('AUTHORING: flag ON + manager_at_level accepted (S7-4 implements the kind)', async () => {
     setFlag(true)
     const res = await requestJson(`${baseUrl}/api/attendance/approval-flows`, {
       method: 'POST',
       headers: authHeaders(adminToken),
       body: JSON.stringify({
-        name: `s7-2-dm-flow-${runSuffix}`,
+        name: `s7-4-mal-flow-${runSuffix}`,
         requestType: 'time_correction',
-        steps: [{ kind: 'direct_manager' }],
+        steps: [{ kind: 'manager_at_level', level: 2 }],
         orgId: orgHome,
         isActive: true,
       }),
@@ -421,36 +458,19 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     const id = (res.body as { data?: { id?: string } }).data?.id
     if (id) createdFlowIds.push(id)
     const steps = (res.body as { data?: { steps?: unknown[] } }).data?.steps
-    expect(steps).toEqual([{ name: undefined, kind: 'direct_manager' }])
+    expect(steps).toEqual([{ name: undefined, kind: 'manager_at_level', level: 2 }])
   })
 
-  it('AUTHORING: continuous_managers stays OUT-of-v1 (KIND_INVALID, not silent accept)', async () => {
-    setFlag(true)
-    const res = await requestJson(`${baseUrl}/api/attendance/approval-flows`, {
-      method: 'POST',
-      headers: authHeaders(adminToken),
-      body: JSON.stringify({
-        name: `s7-2-cm-out-${runSuffix}`,
-        requestType: 'time_correction',
-        steps: [{ kind: 'continuous_managers', levels: 2 }],
-        orgId: orgHome,
-        isActive: true,
-      }),
-    })
-    expect(res.status, res.raw).toBe(422)
-    expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_INVALID')
-  })
-
-  // ── S7-1 NITs folded ──
+  // ── S7-1 NITs remain fixed ──
   it('NIT: dynamic + empty approverUserIds:[] → 422 MIXED (key-shape constraint)', async () => {
     setFlag(true)
     const res = await requestJson(`${baseUrl}/api/attendance/approval-flows`, {
       method: 'POST',
       headers: authHeaders(adminToken),
       body: JSON.stringify({
-        name: `s7-2-mixed-empty-${runSuffix}`,
+        name: `s7-4-mixed-empty-${runSuffix}`,
         requestType: 'time_correction',
-        steps: [{ kind: 'direct_manager', approverUserIds: [] }],
+        steps: [{ kind: 'manager_at_level', level: 1, approverUserIds: [] }],
         orgId: orgHome,
         isActive: true,
       }),
@@ -465,7 +485,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       method: 'POST',
       headers: authHeaders(adminToken),
       body: JSON.stringify({
-        name: `s7-2-nonstr-kind-${runSuffix}`,
+        name: `s7-4-nonstr-kind-${runSuffix}`,
         requestType: 'time_correction',
         steps: [{ kind: 123 }],
         orgId: orgHome,
@@ -476,14 +496,14 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_INVALID')
   })
 
-  // ── Linked resolution + freeze + assignment ──
-  it('RUNTIME create: linked direct_manager freezes managerId and builds user assignment', async () => {
+  // ── Linked resolution + freeze + assignment (level 1) ──
+  it('RUNTIME create: level=1 freezes managerChainIds and assigns chain[0]', async () => {
     setFlag(true)
     process.env.RBAC_BYPASS = 'true'
-    await seedFlow(orgHome, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-linked-${runSuffix}`)
+    await seedFlow(orgHome, 'time_correction', [{ kind: 'manager_at_level', level: 1 }], `s7-4-l1-${runSuffix}`)
 
-    const workDate = '2026-06-01'
-    const res = await createRequest(orgHome, adminToken, workDate, 's7-2 linked resolution')
+    const workDate = '2026-07-01'
+    const res = await createRequest(orgHome, adminToken, workDate, 's7-4 level1 resolution')
     expect(res.status, res.raw).toBe(201)
     const requestId = requestIdFrom(res) as string
     expect(requestId).toBeTruthy()
@@ -497,13 +517,12 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     createdInstanceIds.push(instanceId)
 
     const inst = await (pool as Pool).query(
-      'SELECT requester_snapshot, current_node_key FROM approval_instances WHERE id = $1',
+      'SELECT requester_snapshot FROM approval_instances WHERE id = $1',
       [instanceId],
     )
-    const snap = inst.rows[0].requester_snapshot as { id?: string; managerId?: string }
-    // Normalized is_manager (managerHome) wins over legacy leader_in_dept (managerAlt).
-    expect(snap.managerId).toBe(managerHome)
+    const snap = inst.rows[0].requester_snapshot as { id?: string; managerChainIds?: string[] }
     expect(snap.id).toBe(requester)
+    expect(snap.managerChainIds).toEqual([managerL1Home, managerL2Home])
 
     const assignments = await (pool as Pool).query(
       `SELECT assignment_type, assignee_id, is_active, metadata
@@ -514,49 +533,66 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     expect(assignments.rows).toHaveLength(1)
     expect(assignments.rows[0]).toMatchObject({
       assignment_type: 'user',
-      assignee_id: managerHome,
+      assignee_id: managerL1Home,
     })
-    // Must NOT have fallen through to admin/source_queue.
     expect(assignments.rows.some((r) => r.assignment_type === 'source_queue')).toBe(false)
     expect(assignments.rows.some((r) => r.assignee_id === 'admin')).toBe(false)
   })
 
-  // ── Org anchor: two orgs, one local user ──
-  it('ORG-ANCHOR: two-org/one-local-user resolves manager from the requesting org only', async () => {
+  // ── Level 2 positional pick ──
+  it('RUNTIME create: level=2 assigns chain[1] (exactly one positional manager)', async () => {
     setFlag(true)
     process.env.RBAC_BYPASS = 'true'
-    // orgHome flow (already seeded above is leave+direct_manager; ensure one is active for leave).
-    // Create against orgHome — must get managerHome, NEVER managerForeign (even though foreign
-    // account is more recently updated and would win the unscoped pick).
-    const workDate = '2026-06-02'
-    // Deactivate any leftover leave flows on orgHome except we already have one; create a fresh one
-    // in case the prior test's flow is fine.
-    await seedFlow(orgHome, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-anchor-${runSuffix}`)
+    await seedFlow(orgHome, 'time_correction', [{ kind: 'manager_at_level', level: 2 }], `s7-4-l2-${runSuffix}`)
 
-    const res = await createRequest(orgHome, adminToken, workDate, 's7-2 org anchor')
+    const res = await createRequest(orgHome, adminToken, '2026-07-02', 's7-4 level2 resolution')
     expect(res.status, res.raw).toBe(201)
     const requestId = requestIdFrom(res) as string
     createdRequestIds.push(requestId)
-    const reqRow = await (pool as Pool).query(
-      'SELECT approval_instance_id FROM attendance_requests WHERE id = $1',
-      [requestId],
-    )
-    const instanceId = reqRow.rows[0].approval_instance_id as string
+    const instanceId = (
+      await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestId])
+    ).rows[0].approval_instance_id as string
     createdInstanceIds.push(instanceId)
-    const inst = await (pool as Pool).query('SELECT requester_snapshot FROM approval_instances WHERE id = $1', [
-      instanceId,
+
+    const assignments = await (pool as Pool).query(
+      `SELECT assignment_type, assignee_id FROM approval_assignments
+        WHERE instance_id = $1 AND is_active = TRUE`,
+      [instanceId],
+    )
+    expect(assignments.rows).toEqual([
+      expect.objectContaining({ assignment_type: 'user', assignee_id: managerL2Home }),
     ])
-    const snap = inst.rows[0].requester_snapshot as { managerId?: string }
-    expect(snap.managerId).toBe(managerHome)
-    expect(snap.managerId).not.toBe(managerForeign)
+    // Must not assign L1 or expand to multiple managers.
+    expect(assignments.rows.some((r) => r.assignee_id === managerL1Home)).toBe(false)
+    expect(assignments.rows).toHaveLength(1)
+  })
+
+  // ── Org anchor: two orgs, one local user ──
+  it('ORG-ANCHOR: two-org/one-local-user freezes chain from the requesting org only', async () => {
+    setFlag(true)
+    process.env.RBAC_BYPASS = 'true'
+    await seedFlow(orgHome, 'time_correction', [{ kind: 'manager_at_level', level: 1 }], `s7-4-anchor-${runSuffix}`)
+
+    const res = await createRequest(orgHome, adminToken, '2026-07-03', 's7-4 org anchor')
+    expect(res.status, res.raw).toBe(201)
+    const requestId = requestIdFrom(res) as string
+    createdRequestIds.push(requestId)
+    const instanceId = (
+      await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestId])
+    ).rows[0].approval_instance_id as string
+    createdInstanceIds.push(instanceId)
+    const snap = (
+      await (pool as Pool).query('SELECT requester_snapshot FROM approval_instances WHERE id = $1', [instanceId])
+    ).rows[0].requester_snapshot as { managerChainIds?: string[] }
+    expect(snap.managerChainIds?.[0]).toBe(managerL1Home)
+    expect(snap.managerChainIds?.[0]).not.toBe(managerL1Foreign)
   })
 
   // ── Unlinked block-with-error + zero persistence ──
-  it('UNLINKED: direct_manager create fails 422 with ZERO attendance_requests / approval rows', async () => {
+  it('UNLINKED: manager_at_level create fails 422 with ZERO attendance_requests / approval rows', async () => {
     setFlag(true)
     process.env.RBAC_BYPASS = 'true'
-    // Purely-local user with no directory link in orgUnlinked.
-    const unlinkedUser = `s7-2-unlinked-user-${runSuffix}`
+    const unlinkedUser = `s7-4-unlinked-user-${runSuffix}`
     await seedUser(unlinkedUser)
     userIds.push(unlinkedUser)
     await (pool as Pool).query(
@@ -565,7 +601,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
        ON CONFLICT DO NOTHING`,
       [unlinkedUser],
     )
-    await seedFlow(orgUnlinked, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-unlinked-${runSuffix}`)
+    await seedFlow(orgUnlinked, 'time_correction', [{ kind: 'manager_at_level', level: 1 }], `s7-4-unlinked-${runSuffix}`)
 
     const unlinkedToken = await devToken(unlinkedUser, 'user', 'attendance:admin,attendance:write')
     const beforeReq = await (pool as Pool).query(
@@ -573,8 +609,9 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       [orgUnlinked],
     )
     const beforeInst = await (pool as Pool).query(
-      `SELECT COUNT(*)::int AS n FROM approval_instances WHERE business_key LIKE $1`,
-      [`attendance-request:%`],
+      `SELECT COUNT(*)::int AS n FROM approval_instances
+        WHERE (metadata->>'orgId' = $1 OR subject_snapshot->>'orgId' = $1)`,
+      [orgUnlinked],
     )
 
     const res = await requestJson(`${baseUrl}/api/attendance/requests`, {
@@ -582,11 +619,11 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       headers: authHeaders(unlinkedToken),
       body: JSON.stringify({
         orgId: orgUnlinked,
-        workDate: '2026-06-03',
+        workDate: '2026-07-04',
         requestType: 'time_correction',
-        requestedInAt: '2026-06-03T01:00:00Z',
-        requestedOutAt: '2026-06-03T10:00:00Z',
-        reason: 's7-2 unlinked block',
+        requestedInAt: '2026-07-04T01:00:00Z',
+        requestedOutAt: '2026-07-04T10:00:00Z',
+        reason: 's7-4 unlinked block',
       }),
     })
     expect(res.status, res.raw).toBe(422)
@@ -596,143 +633,107 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
       [orgUnlinked],
     )
-    expect(afterReq.rows[0].n).toBe(beforeReq.rows[0].n)
-    // No new instance for this org's request path (business_key contains the request id which was never written).
     const afterInst = await (pool as Pool).query(
-      `SELECT COUNT(*)::int AS n FROM approval_instances WHERE business_key LIKE $1`,
-      [`attendance-request:%`],
+      `SELECT COUNT(*)::int AS n FROM approval_instances
+        WHERE (metadata->>'orgId' = $1 OR subject_snapshot->>'orgId' = $1)`,
+      [orgUnlinked],
     )
+    expect(afterReq.rows[0].n).toBe(beforeReq.rows[0].n)
     expect(afterInst.rows[0].n).toBe(beforeInst.rows[0].n)
   })
 
-  // P2 fix: multi-step [static, direct_manager] must ALSO fail closed at create when manager is
-  // unresolvable — never persist step-0 and strand on advance.
-  it('UNLINKED multi-step [static, direct_manager]: create 422 + zero request/instance/assignment rows (org-scoped)', async () => {
+  // ── Short chain (level 2 on a one-level org) ──
+  it('SHORT CHAIN: level=2 with only one linked manager → create 422 + zero rows', async () => {
     setFlag(true)
     process.env.RBAC_BYPASS = 'true'
-    const orgMulti = `s7-2-unlinked-multi-${runSuffix}`
-    const multiUser = `s7-2-unlinked-multi-user-${runSuffix}`
-    await seedUser(multiUser)
-    userIds.push(multiUser)
-    await (pool as Pool).query(
-      `INSERT INTO user_permissions (user_id, permission_code)
-       VALUES ($1, 'attendance:write'), ($1, 'attendance:admin')
-       ON CONFLICT DO NOTHING`,
-      [multiUser],
+    // One-level chain only.
+    const intId = await seedIntegration(orgShort, `s7-4-short-int-${runSuffix}`, `corp-short-${runSuffix}`)
+    const extDept = `dept-short-${runSuffix}`
+    const deptId = await seedDept(intId, extDept, 'Short Eng')
+    const accR = await seedAccount(intId, `ext-r-short-${runSuffix}`, `key-r-short-${runSuffix}`, 'ReqShort')
+    const accM = await seedAccount(
+      intId,
+      `ext-m-short-${runSuffix}`,
+      `key-m-short-${runSuffix}`,
+      'MgrShort',
+      { leader_in_dept: [{ dept_id: extDept, leader: true }] },
     )
-    // Static step 0 would have assigned multiUser; direct_manager at step 1 is unresolvable (no link).
-    await seedFlow(
-      orgMulti,
-      'time_correction',
-      [
-        { name: 'S0', approverUserIds: [multiUser] },
-        { name: 'S1', kind: 'direct_manager' },
-      ],
-      `s7-2-unlinked-multi-${runSuffix}`,
-    )
+    await link(accR, requester)
+    await link(accM, managerL1Home)
+    await membership(accR, deptId, true)
+    await membership(accM, deptId, false)
 
-    const multiToken = await devToken(multiUser, 'user', 'attendance:admin,attendance:write')
+    await seedFlow(orgShort, 'time_correction', [{ kind: 'manager_at_level', level: 2 }], `s7-4-short-${runSuffix}`)
+
     const beforeReq = await (pool as Pool).query(
       'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
-      [orgMulti],
+      [orgShort],
     )
-    // approval_instances store attendance org on metadata/subject_snapshot (no org_id column).
-    const beforeInst = await (pool as Pool).query(
-      `SELECT COUNT(*)::int AS n FROM approval_instances
-        WHERE (metadata->>'orgId' = $1 OR subject_snapshot->>'orgId' = $1)`,
-      [orgMulti],
-    )
-    const beforeAssign = await (pool as Pool).query(
-      `SELECT COUNT(*)::int AS n FROM approval_assignments aa
-         JOIN approval_instances ai ON ai.id = aa.instance_id
-        WHERE (ai.metadata->>'orgId' = $1 OR ai.subject_snapshot->>'orgId' = $1)`,
-      [orgMulti],
-    )
-
-    const res = await requestJson(`${baseUrl}/api/attendance/requests`, {
-      method: 'POST',
-      headers: authHeaders(multiToken),
-      body: JSON.stringify({
-        orgId: orgMulti,
-        workDate: '2026-06-11',
-        requestType: 'time_correction',
-        requestedInAt: '2026-06-11T01:00:00Z',
-        requestedOutAt: '2026-06-11T10:00:00Z',
-        reason: 's7-2 unlinked multi-step block at create',
-      }),
-    })
+    const res = await createRequest(orgShort, adminToken, '2026-07-05', 's7-4 short chain')
     expect(res.status, res.raw).toBe(422)
     expect(errorCode(res)).toBe('APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED')
-
     const afterReq = await (pool as Pool).query(
       'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
-      [orgMulti],
+      [orgShort],
     )
-    const afterInst = await (pool as Pool).query(
-      `SELECT COUNT(*)::int AS n FROM approval_instances
-        WHERE (metadata->>'orgId' = $1 OR subject_snapshot->>'orgId' = $1)`,
-      [orgMulti],
-    )
-    const afterAssign = await (pool as Pool).query(
-      `SELECT COUNT(*)::int AS n FROM approval_assignments aa
-         JOIN approval_instances ai ON ai.id = aa.instance_id
-        WHERE (ai.metadata->>'orgId' = $1 OR ai.subject_snapshot->>'orgId' = $1)`,
-      [orgMulti],
-    )
-    expect(afterReq.rows[0].n, 'zero attendance_requests on create-time freeze failure').toBe(beforeReq.rows[0].n)
-    expect(afterInst.rows[0].n, 'zero approval_instances on create-time freeze failure').toBe(beforeInst.rows[0].n)
-    expect(afterAssign.rows[0].n, 'zero approval_assignments on create-time freeze failure').toBe(
-      beforeAssign.rows[0].n,
-    )
-
-    await (pool as Pool).query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [orgMulti]).catch(() => undefined)
+    expect(afterReq.rows[0].n).toBe(beforeReq.rows[0].n)
   })
 
   // ── 2-step freeze after directory mutation ──
-  it('FREEZE: 2-step flow keeps step-2 assignee after directory manager mutation', async () => {
+  it('FREEZE: 2-step flow keeps step-2 assignee after directory chain mutation', async () => {
     setFlag(true)
     process.env.RBAC_BYPASS = 'true'
     await seedFlow(
       orgFreeze,
       'time_correction',
       [
-        { name: 'S0', approverUserIds: [managerHome] },
-        { name: 'S1', kind: 'direct_manager' },
+        { name: 'S0', approverUserIds: [managerL1Home] },
+        { name: 'S1', kind: 'manager_at_level', level: 1 },
       ],
-      `s7-2-freeze-${runSuffix}`,
+      `s7-4-freeze-${runSuffix}`,
     )
 
-    const workDate = '2026-06-04'
-    const res = await createRequest(orgFreeze, adminToken, workDate, 's7-2 freeze')
+    const res = await createRequest(orgFreeze, adminToken, '2026-07-06', 's7-4 freeze')
     expect(res.status, res.raw).toBe(201)
     const requestId = requestIdFrom(res) as string
     createdRequestIds.push(requestId)
-    const reqRow = await (pool as Pool).query(
-      'SELECT approval_instance_id FROM attendance_requests WHERE id = $1',
-      [requestId],
-    )
-    const instanceId = reqRow.rows[0].approval_instance_id as string
+    const instanceId = (
+      await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestId])
+    ).rows[0].approval_instance_id as string
     createdInstanceIds.push(instanceId)
 
     const snapBefore = (
       await (pool as Pool).query('SELECT requester_snapshot FROM approval_instances WHERE id = $1', [instanceId])
-    ).rows[0].requester_snapshot as { managerId?: string }
-    expect(snapBefore.managerId).toBe(managerHome)
+    ).rows[0].requester_snapshot as { managerChainIds?: string[] }
+    expect(snapBefore.managerChainIds?.[0]).toBe(managerL1Home)
 
-    // Mutate directory: flip is_manager from managerHome → managerAlt BEFORE step-1 advance.
+    // Mutate directory: strip L1 leadership from freezeAccM1, give it to freezeAccAlt BEFORE advance.
     await (pool as Pool).query(
-      `UPDATE directory_account_departments SET is_manager = false
-        WHERE directory_account_id = $1 AND directory_department_id = $2`,
-      [freezeMgrAccountId, freezeDeptId],
+      `UPDATE directory_accounts SET raw = '{}'::jsonb WHERE id = $1`,
+      [freezeAccM1],
     )
     await (pool as Pool).query(
-      `UPDATE directory_account_departments SET is_manager = true
-        WHERE directory_account_id = $1 AND directory_department_id = $2`,
-      [freezeAltAccountId, freezeDeptId],
+      `UPDATE directory_accounts SET raw = $2::jsonb WHERE id = $1`,
+      [
+        freezeAccAlt,
+        JSON.stringify({
+          leader_in_dept: [
+            {
+              dept_id: (
+                await (pool as Pool).query<{ external_department_id: string }>(
+                  'SELECT external_department_id FROM directory_departments WHERE id = $1',
+                  [freezeDeptR],
+                )
+              ).rows[0].external_department_id,
+              leader: true,
+            },
+          ],
+        }),
+      ],
     )
 
-    // Step 0 assignee (managerHome) approves → advances to step 1 (direct_manager).
-    const approve = await act(requestId, managerToken, 'approve')
+    // Step 0 assignee approves → advances to step 1 (manager_at_level level 1).
+    const approve = await act(requestId, managerL1Token, 'approve')
     expect(approve.status, approve.raw).toBe(200)
 
     const snapAfter = (
@@ -741,7 +742,9 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
         [instanceId],
       )
     ).rows[0]
-    expect((snapAfter.requester_snapshot as { managerId?: string }).managerId).toBe(managerHome)
+    expect((snapAfter.requester_snapshot as { managerChainIds?: string[] }).managerChainIds?.[0]).toBe(
+      managerL1Home,
+    )
     expect(snapAfter.current_step).toBe(1)
     expect(snapAfter.current_node_key).toBe(NODE_KEY_1)
 
@@ -751,92 +754,91 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       [instanceId, NODE_KEY_1],
     )
     expect(assignments.rows).toEqual([
-      expect.objectContaining({ assignment_type: 'user', assignee_id: managerHome }),
+      expect.objectContaining({ assignment_type: 'user', assignee_id: managerL1Home }),
     ])
-    // The mutated managerAlt must NOT be the assignee.
-    expect(assignments.rows.some((r) => r.assignee_id === managerAlt)).toBe(false)
+    // Mutated L1 alt must NOT be the assignee.
+    expect(assignments.rows.some((r) => r.assignee_id === managerL1Alt)).toBe(false)
   })
 
   // ── Dynamic assignment authorization (S7-0 re-run for this kind) ──
-  it('AUTHZ: dynamic user assignee can approve; unassigned scope-authorized actor 403s; admin override works', async () => {
+  it('AUTHZ: dynamic user assignee can approve+reject; unassigned scope-authorized actor 403s; admin override works', async () => {
     setFlag(true)
-    // Force real authorization (no RBAC bypass).
     process.env.RBAC_BYPASS = 'false'
     try {
-      await seedFlow(orgAuthz, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-authz-${runSuffix}`)
-      // Seed directory for orgAuthz so create can freeze managerHome.
-      const authzInt = await seedIntegration(orgAuthz, `s7-2-authz-int-${runSuffix}`, `corp-authz-${runSuffix}`)
-      const authzDept = await seedDept(authzInt, `dept-authz-${runSuffix}`, 'Authz Eng')
-      const authzReqAcc = await seedAccount(authzInt, `ext-req-authz-${runSuffix}`, `key-req-authz-${runSuffix}`, 'ReqAuthz')
-      const authzMgrAcc = await seedAccount(authzInt, `ext-mgr-authz-${runSuffix}`, `key-mgr-authz-${runSuffix}`, 'MgrAuthz')
-      await link(authzReqAcc, requester)
-      await link(authzMgrAcc, managerHome)
-      await membership(authzReqAcc, authzDept, true, false)
-      await membership(authzMgrAcc, authzDept, false, true)
+      await seedFlow(orgAuthz, 'time_correction', [{ kind: 'manager_at_level', level: 1 }], `s7-4-authz-${runSuffix}`)
+      await seedTwoLevelChain(orgAuthz, requester, managerL1Home, managerL2Home, 'authz')
 
-      // Positive approve leg
-      const workDateA = '2026-06-05'
-      const createA = await createRequest(orgAuthz, adminToken, workDateA, 's7-2 authz approve')
+      // Positive approve
+      const createA = await createRequest(orgAuthz, adminToken, '2026-07-07', 's7-4 authz approve')
       expect(createA.status, createA.raw).toBe(201)
       const requestIdA = requestIdFrom(createA) as string
       createdRequestIds.push(requestIdA)
-      const instA = (
-        await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestIdA])
-      ).rows[0].approval_instance_id as string
-      createdInstanceIds.push(instA)
+      createdInstanceIds.push(
+        (
+          await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [
+            requestIdA,
+          ])
+        ).rows[0].approval_instance_id as string,
+      )
 
-      // Negative: otherApprover holds attendance:approve (broad gate) but is NOT the manager.
       const negApprove = await act(requestIdA, otherToken, 'approve')
       expect(negApprove.status, negApprove.raw).toBe(403)
       expect(errorCode(negApprove)).toBe('FORBIDDEN')
 
-      // Positive: managerHome is the frozen assignee.
-      const posApprove = await act(requestIdA, managerToken, 'approve')
+      // L2 is on the chain but is NOT the level-1 assignee — must also 403.
+      const l2Approve = await act(requestIdA, managerL2Token, 'approve')
+      expect(l2Approve.status, l2Approve.raw).toBe(403)
+
+      const posApprove = await act(requestIdA, managerL1Token, 'approve')
       expect(posApprove.status, posApprove.raw).toBe(200)
 
-      // Reject legs on a fresh request.
-      const workDateB = '2026-06-06'
-      const createB = await createRequest(orgAuthz, adminToken, workDateB, 's7-2 authz reject')
+      // Reject legs
+      const createB = await createRequest(orgAuthz, adminToken, '2026-07-08', 's7-4 authz reject')
       expect(createB.status, createB.raw).toBe(201)
       const requestIdB = requestIdFrom(createB) as string
       createdRequestIds.push(requestIdB)
-      const instB = (
-        await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestIdB])
-      ).rows[0].approval_instance_id as string
-      createdInstanceIds.push(instB)
+      createdInstanceIds.push(
+        (
+          await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [
+            requestIdB,
+          ])
+        ).rows[0].approval_instance_id as string,
+      )
 
       const negReject = await act(requestIdB, otherToken, 'reject')
       expect(negReject.status, negReject.raw).toBe(403)
       expect(errorCode(negReject)).toBe('FORBIDDEN')
 
-      const posReject = await act(requestIdB, managerToken, 'reject')
+      const posReject = await act(requestIdB, managerL1Token, 'reject')
       expect(posReject.status, posReject.raw).toBe(200)
 
-      // Admin override (not the assignee) on a third request — approve.
-      const workDateC = '2026-06-07'
-      const createC = await createRequest(orgAuthz, adminToken, workDateC, 's7-2 authz admin')
+      // Admin override approve
+      const createC = await createRequest(orgAuthz, adminToken, '2026-07-09', 's7-4 authz admin')
       expect(createC.status, createC.raw).toBe(201)
       const requestIdC = requestIdFrom(createC) as string
       createdRequestIds.push(requestIdC)
-      const instC = (
-        await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestIdC])
-      ).rows[0].approval_instance_id as string
-      createdInstanceIds.push(instC)
-
+      createdInstanceIds.push(
+        (
+          await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [
+            requestIdC,
+          ])
+        ).rows[0].approval_instance_id as string,
+      )
       const adminApprove = await act(requestIdC, adminActorToken, 'approve')
       expect(adminApprove.status, adminApprove.raw).toBe(200)
 
-      // P3: admin override reject (symmetric with approve — non-assignee admin still authorized).
-      const workDateD = '2026-06-12'
-      const createD = await createRequest(orgAuthz, adminToken, workDateD, 's7-2 authz admin reject')
+      // Admin override reject
+      const createD = await createRequest(orgAuthz, adminToken, '2026-07-10', 's7-4 authz admin reject')
       expect(createD.status, createD.raw).toBe(201)
       const requestIdD = requestIdFrom(createD) as string
       createdRequestIds.push(requestIdD)
-      const instD = (
-        await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [requestIdD])
-      ).rows[0].approval_instance_id as string
-      createdInstanceIds.push(instD)
-
+      createdInstanceIds.push(
+        (
+          await (pool as Pool).query('SELECT approval_instance_id FROM attendance_requests WHERE id = $1', [
+            requestIdD,
+          ])
+        ).rows[0].approval_instance_id as string,
+      )
       const adminReject = await act(requestIdD, adminActorToken, 'reject')
       expect(adminReject.status, adminReject.raw).toBe(200)
     } finally {
@@ -848,13 +850,13 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
   it('FLAG-OFF create: dynamic flow fails-closed with zero rows', async () => {
     setFlag(false)
     process.env.RBAC_BYPASS = 'true'
-    await seedFlow(orgFlagOff, 'time_correction', [{ kind: 'direct_manager' }], `s7-2-flagoff-create-${runSuffix}`)
+    await seedFlow(orgFlagOff, 'time_correction', [{ kind: 'manager_at_level', level: 1 }], `s7-4-flagoff-create-${runSuffix}`)
 
     const before = await (pool as Pool).query(
       'SELECT COUNT(*)::int AS n FROM attendance_requests WHERE org_id = $1',
       [orgFlagOff],
     )
-    const res = await createRequest(orgFlagOff, adminToken, '2026-06-08', 's7-2 flag-off create')
+    const res = await createRequest(orgFlagOff, adminToken, '2026-07-11', 's7-4 flag-off create')
     expect(res.status, res.raw).toBe(422)
     expect(errorCode(res)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
     const after = await (pool as Pool).query(
@@ -868,28 +870,20 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
   it('FLAG-OFF advance: step-1 approve fails and rolls back (instance still at step 0)', async () => {
     process.env.RBAC_BYPASS = 'true'
     setFlag(true)
-    const orgAdv = `s7-2-adv-${runSuffix}`
-    // Directory for this org so create succeeds under flag ON.
-    const advInt = await seedIntegration(orgAdv, `s7-2-adv-int-${runSuffix}`, `corp-adv-${runSuffix}`)
-    const advDept = await seedDept(advInt, `dept-adv-${runSuffix}`, 'Adv Eng')
-    const advReqAcc = await seedAccount(advInt, `ext-req-adv-${runSuffix}`, `key-req-adv-${runSuffix}`, 'ReqAdv')
-    const advMgrAcc = await seedAccount(advInt, `ext-mgr-adv-${runSuffix}`, `key-mgr-adv-${runSuffix}`, 'MgrAdv')
-    await link(advReqAcc, requester)
-    await link(advMgrAcc, managerHome)
-    await membership(advReqAcc, advDept, true, false)
-    await membership(advMgrAcc, advDept, false, true)
+    const orgAdv = `s7-4-adv-${runSuffix}`
+    await seedTwoLevelChain(orgAdv, requester, managerL1Home, managerL2Home, 'adv')
 
     await seedFlow(
       orgAdv,
       'time_correction',
       [
-        { name: 'S0', approverUserIds: [managerHome] },
-        { name: 'S1', kind: 'direct_manager' },
+        { name: 'S0', approverUserIds: [managerL1Home] },
+        { name: 'S1', kind: 'manager_at_level', level: 2 },
       ],
-      `s7-2-flagoff-adv-${runSuffix}`,
+      `s7-4-flagoff-adv-${runSuffix}`,
     )
 
-    const create = await createRequest(orgAdv, adminToken, '2026-06-09', 's7-2 flag-off advance')
+    const create = await createRequest(orgAdv, adminToken, '2026-07-12', 's7-4 flag-off advance')
     expect(create.status, create.raw).toBe(201)
     const requestId = requestIdFrom(create) as string
     createdRequestIds.push(requestId)
@@ -898,33 +892,30 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     ).rows[0].approval_instance_id as string
     createdInstanceIds.push(instanceId)
 
-    // Flip flag OFF before step advance.
     setFlag(false)
-    const approve = await act(requestId, managerToken, 'approve')
+    const approve = await act(requestId, managerL1Token, 'approve')
     expect(approve.status, approve.raw).toBe(422)
     expect(errorCode(approve)).toBe('APPROVAL_STEP_KIND_UNAVAILABLE')
 
     const inst = await (pool as Pool).query(
-      'SELECT status, current_step, current_node_key, version FROM approval_instances WHERE id = $1',
+      'SELECT status, current_step, current_node_key FROM approval_instances WHERE id = $1',
       [instanceId],
     )
     expect(inst.rows[0].status).toBe('pending')
     expect(inst.rows[0].current_step).toBe(0)
     expect(inst.rows[0].current_node_key).toBe(NODE_KEY_0)
-    // No approval_records appended for the failed advance.
     const records = await (pool as Pool).query(
       'SELECT COUNT(*)::int AS n FROM approval_records WHERE instance_id = $1',
       [instanceId],
     )
     expect(records.rows[0].n).toBe(0)
-    // Active assignment still step 0's static assignee.
     const assignments = await (pool as Pool).query(
       `SELECT assignment_type, assignee_id FROM approval_assignments
         WHERE instance_id = $1 AND is_active = TRUE`,
       [instanceId],
     )
     expect(assignments.rows).toEqual([
-      expect.objectContaining({ assignment_type: 'user', assignee_id: managerHome }),
+      expect.objectContaining({ assignment_type: 'user', assignee_id: managerL1Home }),
     ])
 
     await (pool as Pool).query('DELETE FROM attendance_requests WHERE org_id = $1', [orgAdv]).catch(() => undefined)
@@ -935,14 +926,14 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
   it('LEGACY static: flag OFF flow with no dynamic kind still creates + assigns statically', async () => {
     setFlag(false)
     process.env.RBAC_BYPASS = 'true'
-    const orgLegacy = `s7-2-legacy-${runSuffix}`
+    const orgLegacy = `s7-4-legacy-${runSuffix}`
     await seedFlow(
       orgLegacy,
       'time_correction',
-      [{ name: 'LM', approverUserIds: [managerHome] }],
-      `s7-2-legacy-${runSuffix}`,
+      [{ name: 'LM', approverUserIds: [managerL1Home] }],
+      `s7-4-legacy-${runSuffix}`,
     )
-    const res = await createRequest(orgLegacy, adminToken, '2026-06-10', 's7-2 legacy static')
+    const res = await createRequest(orgLegacy, adminToken, '2026-07-13', 's7-4 legacy static')
     expect(res.status, res.raw).toBe(201)
     const requestId = requestIdFrom(res) as string
     createdRequestIds.push(requestId)
@@ -953,7 +944,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
     const snap = (
       await (pool as Pool).query('SELECT requester_snapshot FROM approval_instances WHERE id = $1', [instanceId])
     ).rows[0].requester_snapshot as Record<string, unknown>
-    // Legacy snapshot shape: id/name only (no managerId freeze when no dynamic kind).
+    expect(snap.managerChainIds).toBeUndefined()
     expect(snap.managerId).toBeUndefined()
     expect(snap.id).toBe(requester)
     const assignments = await (pool as Pool).query(
@@ -962,7 +953,7 @@ describeIfDatabase('S7-2 direct_manager — freeze + assignment + auth (real DB)
       [instanceId],
     )
     expect(assignments.rows).toEqual([
-      expect.objectContaining({ assignment_type: 'user', assignee_id: managerHome }),
+      expect.objectContaining({ assignment_type: 'user', assignee_id: managerL1Home }),
     ])
     await (pool as Pool).query('DELETE FROM attendance_requests WHERE org_id = $1', [orgLegacy]).catch(() => undefined)
     await (pool as Pool).query('DELETE FROM attendance_approval_flows WHERE org_id = $1', [orgLegacy]).catch(() => undefined)

--- a/packages/core-backend/tests/unit/attendance-approval-manager-at-level-s7-4.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-manager-at-level-s7-4.test.ts
@@ -1,0 +1,582 @@
+import { createRequire } from 'node:module'
+import { afterEach, describe, expect, it } from 'vitest'
+
+// S7-4 (RATIFIED attendance-approval-s7 resolver design-lock §2.3 B1 / §3.4 / §4 / §7 S7-4): pure-helper
+// unit coverage for create-time managerChainIds freeze + positional assignment build from the frozen
+// snapshot. Directory chain walk is owned by ApprovalDirectoryOrg (+ its unit/db suites); the port
+// wiring is covered by the port-scoping unit + the real-DB S7-4 integration matrix. These tests pin
+// the PLUGIN-side contracts:
+//   • freeze is a no-op for static-only flows (legacy byte-identity)
+//   • freeze calls the port once for a flow containing manager_at_level (no level arg)
+//   • short/empty chain at freeze → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (whole-flow)
+//   • assignment build reads ONLY frozen managerChainIds at level-1 (no port re-call)
+//   • self / empty / short / missing at assignment build → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED
+//   • direct_manager + dept_head freeze/assignment preserved (regression)
+//   • continuous_managers remains UNGATED (OUT-of-v1)
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceApprovalCenterForTests as {
+  buildAttendanceApprovalAssignments: (
+    steps: unknown,
+    index?: number,
+    snapshot?: Record<string, unknown> | null,
+  ) => Array<Record<string, unknown>>
+  buildAttendanceApprovalInstancePayload: (input: Record<string, unknown>) => {
+    requesterSnapshot: Record<string, unknown>
+  }
+  resolveAttendanceManagerChainFreeze: (input: {
+    orgId: string
+    userId: string
+    flowSteps: unknown
+    context: unknown
+  }) => Promise<Record<string, unknown>>
+  resolveAttendanceOrgRelationsFreeze: (input: {
+    orgId: string
+    userId: string
+    flowSteps: unknown
+    context: unknown
+  }) => Promise<Record<string, unknown>>
+  flowStepsNeedManagerChainFreeze: (steps: unknown) => boolean
+  ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV: string
+}
+
+const {
+  buildAttendanceApprovalAssignments,
+  buildAttendanceApprovalInstancePayload,
+  resolveAttendanceManagerChainFreeze,
+  resolveAttendanceOrgRelationsFreeze,
+  flowStepsNeedManagerChainFreeze,
+  ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV,
+} = helpers
+
+function httpCode(fn: () => void): { status: number; code: string } | null {
+  try {
+    fn()
+    return null
+  } catch (err) {
+    const e = err as { status?: number; code?: string }
+    return { status: e.status ?? -1, code: e.code ?? '<none>' }
+  }
+}
+
+afterEach(() => {
+  delete process.env[ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV]
+})
+
+describe('S7-4 flowStepsNeedManagerChainFreeze', () => {
+  it('is false for static-only / empty flows (legacy freeze no-op)', () => {
+    expect(flowStepsNeedManagerChainFreeze([{ approverUserIds: ['u1'] }])).toBe(false)
+    expect(flowStepsNeedManagerChainFreeze([])).toBe(false)
+  })
+
+  it('is true when any step is manager_at_level (incl. later steps)', () => {
+    expect(flowStepsNeedManagerChainFreeze([{ kind: 'manager_at_level', level: 1 }])).toBe(true)
+    expect(
+      flowStepsNeedManagerChainFreeze([
+        { name: 'S', approverUserIds: ['u1'] },
+        { kind: 'manager_at_level', level: 2 },
+      ]),
+    ).toBe(true)
+  })
+
+  it('is false for direct_manager / dept_head (their own freeze seams)', () => {
+    expect(flowStepsNeedManagerChainFreeze([{ kind: 'direct_manager' }])).toBe(false)
+    expect(flowStepsNeedManagerChainFreeze([{ kind: 'dept_head' }])).toBe(false)
+  })
+})
+
+describe('S7-4 resolveAttendanceManagerChainFreeze — create-time port call', () => {
+  it('static-only flow never calls the port', async () => {
+    let calls = 0
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['manager_at_level'],
+          resolve: async () => {
+            calls += 1
+            return {
+              status: 'resolved',
+              assignees: [{ assignmentType: 'user', assigneeId: 'm1' }],
+            }
+          },
+        },
+      },
+    }
+    const rel = await resolveAttendanceManagerChainFreeze({
+      orgId: 'org-1',
+      userId: 'req-1',
+      flowSteps: [{ approverUserIds: ['u1'] }],
+      context,
+    })
+    expect(rel).toEqual({})
+    expect(calls).toBe(0)
+  })
+
+  it('linked chain freezes managerChainIds from ordered port assignees (no level arg)', async () => {
+    let seen: { orgId: string; request: Record<string, unknown> } | null = null
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['manager_at_level'],
+          resolve: async (orgId: string, request: Record<string, unknown>) => {
+            seen = { orgId, request }
+            return {
+              status: 'resolved',
+              assignees: [
+                { assignmentType: 'user', assigneeId: 'm1' },
+                { assignmentType: 'user', assigneeId: 'm2' },
+                { assignmentType: 'user', assigneeId: 'm3' },
+              ],
+            }
+          },
+        },
+      },
+    }
+    const rel = await resolveAttendanceManagerChainFreeze({
+      orgId: 'org-home',
+      userId: 'req-1',
+      flowSteps: [{ kind: 'manager_at_level', level: 2 }],
+      context,
+    })
+    expect(rel).toEqual({ managerChainIds: ['m1', 'm2', 'm3'] })
+    expect(seen).toEqual({
+      orgId: 'org-home',
+      request: { kind: 'manager_at_level', requesterUserId: 'req-1' },
+    })
+    // Freeze path must NOT pass level — full chain hydrate, positional pick is assignment-time only.
+    expect((seen as { request: Record<string, unknown> }).request.level).toBeUndefined()
+  })
+
+  it('short chain vs required level rejects at create-time freeze (whole-flow)', async () => {
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['manager_at_level'],
+          resolve: async () => ({
+            status: 'resolved',
+            assignees: [{ assignmentType: 'user', assigneeId: 'm1' }],
+          }),
+        },
+      },
+    }
+    await expect(
+      resolveAttendanceManagerChainFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [
+          { name: 'S0', approverUserIds: ['u1'] },
+          { kind: 'manager_at_level', level: 2 },
+        ],
+        context,
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('empty / unresolved chain rejects at create-time freeze', async () => {
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['manager_at_level'],
+          resolve: async () => ({ status: 'unresolved', reason: 'no_manager_chain' }),
+        },
+      },
+    }
+    await expect(
+      resolveAttendanceManagerChainFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ kind: 'manager_at_level', level: 1 }],
+        context,
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('self id in chain is stripped; if level then empty → UNRESOLVED', async () => {
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['manager_at_level'],
+          resolve: async () => ({
+            status: 'resolved',
+            assignees: [{ assignmentType: 'user', assigneeId: 'req-1' }],
+          }),
+        },
+      },
+    }
+    await expect(
+      resolveAttendanceManagerChainFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ kind: 'manager_at_level', level: 1 }],
+        context,
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('missing port throws APPROVAL_STEP_KIND_UNAVAILABLE (resolver-unavailable §4.1)', async () => {
+    await expect(
+      resolveAttendanceManagerChainFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ kind: 'manager_at_level', level: 1 }],
+        context: { services: {} },
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_STEP_KIND_UNAVAILABLE' })
+  })
+
+  it('throwing port maps to APPROVAL_STEP_KIND_UNAVAILABLE (never admin fallback)', async () => {
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['manager_at_level'],
+          resolve: async () => {
+            throw new Error('directory boom')
+          },
+        },
+      },
+    }
+    await expect(
+      resolveAttendanceManagerChainFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ kind: 'manager_at_level', level: 1 }],
+        context,
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_STEP_KIND_UNAVAILABLE' })
+  })
+})
+
+describe('S7-4 resolveAttendanceOrgRelationsFreeze — mixed kinds', () => {
+  it('freezes managerId + deptHeadId + managerChainIds for a triple mixed flow', async () => {
+    const kinds: string[] = []
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['direct_manager', 'dept_head', 'manager_at_level'],
+          resolve: async (_orgId: string, request: { kind: string }) => {
+            kinds.push(request.kind)
+            if (request.kind === 'direct_manager') {
+              return { status: 'resolved', assignees: [{ assignmentType: 'user', assigneeId: 'mgr-1' }] }
+            }
+            if (request.kind === 'dept_head') {
+              return { status: 'resolved', assignees: [{ assignmentType: 'user', assigneeId: 'dh-1' }] }
+            }
+            if (request.kind === 'manager_at_level') {
+              return {
+                status: 'resolved',
+                assignees: [
+                  { assignmentType: 'user', assigneeId: 'm1' },
+                  { assignmentType: 'user', assigneeId: 'm2' },
+                ],
+              }
+            }
+            return { status: 'unimplemented' }
+          },
+        },
+      },
+    }
+    const rel = await resolveAttendanceOrgRelationsFreeze({
+      orgId: 'org-1',
+      userId: 'req-1',
+      flowSteps: [
+        { kind: 'direct_manager' },
+        { kind: 'dept_head' },
+        { kind: 'manager_at_level', level: 2 },
+      ],
+      context,
+    })
+    expect(rel).toEqual({
+      managerId: 'mgr-1',
+      deptHeadId: 'dh-1',
+      managerChainIds: ['m1', 'm2'],
+    })
+    expect(kinds.sort()).toEqual(['dept_head', 'direct_manager', 'manager_at_level'])
+  })
+
+  it('fails closed when manager_at_level is short even if direct_manager resolves', async () => {
+    const context = {
+      services: {
+        approvalAssigneeResolver: {
+          implementedKinds: ['direct_manager', 'manager_at_level'],
+          resolve: async (_orgId: string, request: { kind: string }) => {
+            if (request.kind === 'direct_manager') {
+              return { status: 'resolved', assignees: [{ assignmentType: 'user', assigneeId: 'mgr-1' }] }
+            }
+            return {
+              status: 'resolved',
+              assignees: [{ assignmentType: 'user', assigneeId: 'm1' }],
+            }
+          },
+        },
+      },
+    }
+    await expect(
+      resolveAttendanceOrgRelationsFreeze({
+        orgId: 'org-1',
+        userId: 'req-1',
+        flowSteps: [{ kind: 'direct_manager' }, { kind: 'manager_at_level', level: 2 }],
+        context,
+      }),
+    ).rejects.toMatchObject({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+})
+
+describe('S7-4 buildAttendanceApprovalAssignments — frozen managerChainIds only', () => {
+  it('resolves exactly one positional manager at level-1 (1-based index)', () => {
+    const snap = { id: 'req-1', name: 'Requester', managerChainIds: ['m1', 'm2', 'm3'] }
+    expect(
+      buildAttendanceApprovalAssignments([{ name: 'L1', kind: 'manager_at_level', level: 1 }], 0, snap),
+    ).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'm1',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: {
+          source: 'attendance',
+          kind: 'manager_at_level',
+          stepName: 'L1',
+          resolvedFrom: { kind: 'manager_at_level', level: 1 },
+        },
+      },
+    ])
+    expect(
+      buildAttendanceApprovalAssignments([{ name: 'L2', kind: 'manager_at_level', level: 2 }], 0, snap),
+    ).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'm2',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: {
+          source: 'attendance',
+          kind: 'manager_at_level',
+          stepName: 'L2',
+          resolvedFrom: { kind: 'manager_at_level', level: 2 },
+        },
+      },
+    ])
+    expect(
+      buildAttendanceApprovalAssignments([{ name: 'L3', kind: 'manager_at_level', level: 3 }], 0, snap),
+    ).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'm3',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: {
+          source: 'attendance',
+          kind: 'manager_at_level',
+          stepName: 'L3',
+          resolvedFrom: { kind: 'manager_at_level', level: 3 },
+        },
+      },
+    ])
+  })
+
+  it('short chain at assignment → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (never admin fallback)', () => {
+    expect(
+      httpCode(() =>
+        buildAttendanceApprovalAssignments([{ kind: 'manager_at_level', level: 3 }], 0, {
+          id: 'req-1',
+          managerChainIds: ['m1', 'm2'],
+        }),
+      ),
+    ).toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('self-exclusion at picked level → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED', () => {
+    expect(
+      httpCode(() =>
+        buildAttendanceApprovalAssignments([{ kind: 'manager_at_level', level: 1 }], 0, {
+          id: 'req-1',
+          managerChainIds: ['req-1', 'm2'],
+        }),
+      ),
+    ).toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+    // Level 2 still works if that slot is non-self.
+    const out = buildAttendanceApprovalAssignments([{ kind: 'manager_at_level', level: 2 }], 0, {
+      id: 'req-1',
+      managerChainIds: ['req-1', 'm2'],
+    })
+    expect(out[0]).toMatchObject({ assigneeId: 'm2' })
+  })
+
+  it('missing managerChainIds / null snapshot → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED', () => {
+    expect(
+      httpCode(() =>
+        buildAttendanceApprovalAssignments([{ kind: 'manager_at_level', level: 1 }], 0, { id: 'req-1' }),
+      ),
+    ).toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+    expect(
+      httpCode(() => buildAttendanceApprovalAssignments([{ kind: 'manager_at_level', level: 1 }], 0, null)),
+    ).toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('mutation canary: dynamic unresolved must NOT produce admin/source_queue rows', () => {
+    try {
+      buildAttendanceApprovalAssignments([{ kind: 'manager_at_level', level: 1 }], 0, { id: 'req-1' })
+      expect.fail('expected throw')
+    } catch (err) {
+      const e = err as { code?: string }
+      expect(e.code).toBe('APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED')
+    }
+    const legacy = buildAttendanceApprovalAssignments([], 0)
+    expect(legacy.some((a) => a.assignmentType === 'role' && a.assigneeId === 'admin')).toBe(true)
+    expect(legacy.some((a) => a.assignmentType === 'source_queue')).toBe(true)
+  })
+
+  it('step-advance index uses frozen chain for step 1 (no live re-resolve)', () => {
+    const steps = [
+      { name: 'S0', approverUserIds: ['u-step0'] },
+      { name: 'S1', kind: 'manager_at_level', level: 2 },
+    ]
+    const snap = { id: 'req-1', managerChainIds: ['m1-frozen', 'm2-frozen'] }
+    const out = buildAttendanceApprovalAssignments(steps, 1, snap)
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({
+      assignmentType: 'user',
+      assigneeId: 'm2-frozen',
+      sourceStep: 1,
+      nodeKey: 'attendance_request_step_1',
+      metadata: expect.objectContaining({
+        kind: 'manager_at_level',
+        resolvedFrom: { kind: 'manager_at_level', level: 2 },
+      }),
+    })
+  })
+
+  it('sequential levels 1 then 2 each pick their own frozen index (no auto-expansion)', () => {
+    const steps = [
+      { kind: 'manager_at_level', level: 1 },
+      { kind: 'manager_at_level', level: 2 },
+    ]
+    const snap = { id: 'req-1', managerChainIds: ['m1', 'm2', 'm3'] }
+    expect(buildAttendanceApprovalAssignments(steps, 0, snap)[0].assigneeId).toBe('m1')
+    expect(buildAttendanceApprovalAssignments(steps, 1, snap)[0].assigneeId).toBe('m2')
+  })
+
+  it('legacy static byte-identity: user/role assignments unchanged when chain snapshot is present', () => {
+    const out = buildAttendanceApprovalAssignments(
+      [{ name: 'LM', approverUserIds: ['u1', 'u2'], approverRoleIds: ['r1'] }],
+      0,
+      { id: 'req-1', managerChainIds: ['m1', 'm2'] },
+    )
+    expect(out).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'u1',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', stepName: 'LM' },
+      },
+      {
+        assignmentType: 'user',
+        assigneeId: 'u2',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', stepName: 'LM' },
+      },
+      {
+        assignmentType: 'role',
+        assigneeId: 'r1',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', stepName: 'LM' },
+      },
+    ])
+  })
+
+  it('direct_manager + dept_head assignment paths still work alongside manager_at_level freeze fields', () => {
+    const steps = [
+      { kind: 'direct_manager' },
+      { kind: 'dept_head' },
+      { kind: 'manager_at_level', level: 1 },
+    ]
+    const snap = {
+      id: 'req-1',
+      managerId: 'mgr-frozen',
+      deptHeadId: 'dh-frozen',
+      managerChainIds: ['m1', 'm2'],
+    }
+    expect(buildAttendanceApprovalAssignments(steps, 0, snap)[0]).toMatchObject({
+      assigneeId: 'mgr-frozen',
+      metadata: expect.objectContaining({ kind: 'direct_manager' }),
+    })
+    expect(buildAttendanceApprovalAssignments(steps, 1, snap)[0]).toMatchObject({
+      assigneeId: 'dh-frozen',
+      metadata: expect.objectContaining({ kind: 'dept_head' }),
+    })
+    expect(buildAttendanceApprovalAssignments(steps, 2, snap)[0]).toMatchObject({
+      assigneeId: 'm1',
+      metadata: expect.objectContaining({ kind: 'manager_at_level' }),
+    })
+  })
+})
+
+describe('S7-4 buildAttendanceApprovalInstancePayload — freeze managerChainIds into requesterSnapshot', () => {
+  it('legacy static: snapshot is still {id, name} only when orgRelations is empty', () => {
+    const payload = buildAttendanceApprovalInstancePayload({
+      approvalId: 'apv_1',
+      requestId: '00000000-0000-4000-8000-000000000001',
+      orgId: 'org-1',
+      userId: 'req-1',
+      requesterName: 'Alice',
+      draft: { requestType: 'leave', workDate: '2026-07-01', metadata: { approvalFlow: { steps: [] } } },
+    })
+    expect(payload.requesterSnapshot).toEqual({ id: 'req-1', name: 'Alice' })
+  })
+
+  it('freezes managerChainIds when orgRelations carries them', () => {
+    const payload = buildAttendanceApprovalInstancePayload({
+      approvalId: 'apv_1',
+      requestId: '00000000-0000-4000-8000-000000000002',
+      orgId: 'org-1',
+      userId: 'req-1',
+      requesterName: 'Alice',
+      draft: {
+        requestType: 'leave',
+        workDate: '2026-07-01',
+        metadata: { approvalFlow: { steps: [{ kind: 'manager_at_level', level: 1 }] } },
+      },
+      orgRelations: { managerChainIds: ['m1', 'm2'] },
+    })
+    expect(payload.requesterSnapshot).toEqual({
+      id: 'req-1',
+      name: 'Alice',
+      managerChainIds: ['m1', 'm2'],
+    })
+  })
+
+  it('freezes all three org-relation fields for mixed orgRelations', () => {
+    const payload = buildAttendanceApprovalInstancePayload({
+      approvalId: 'apv_1',
+      requestId: '00000000-0000-4000-8000-000000000003',
+      orgId: 'org-1',
+      userId: 'req-1',
+      requesterName: 'Alice',
+      draft: {
+        requestType: 'leave',
+        workDate: '2026-07-01',
+        metadata: {
+          approvalFlow: {
+            steps: [
+              { kind: 'direct_manager' },
+              { kind: 'dept_head' },
+              { kind: 'manager_at_level', level: 1 },
+            ],
+          },
+        },
+      },
+      orgRelations: { managerId: 'mgr-1', deptHeadId: 'dh-1', managerChainIds: ['m1', 'm2'] },
+    })
+    expect(payload.requesterSnapshot).toEqual({
+      id: 'req-1',
+      name: 'Alice',
+      managerId: 'mgr-1',
+      deptHeadId: 'dh-1',
+      managerChainIds: ['m1', 'm2'],
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-approval-resolver-port-scoping.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-resolver-port-scoping.test.ts
@@ -29,10 +29,10 @@ describe('S7-2 precursor — approvalAssigneeResolver port is scoped to plugin-a
     expect(typeof services.approvalAssigneeResolver?.maxManagerChainLevels).toBe('number')
     expect(services.approvalAssigneeResolver?.maxManagerChainLevels).toBeGreaterThanOrEqual(1)
     expect(Array.isArray(services.approvalAssigneeResolver?.implementedKinds)).toBe(true)
-    // S7-2/S7-3: direct_manager + dept_head implemented; manager_at_level stays S7-4.
+    // S7-2/S7-3/S7-4: direct_manager + dept_head + manager_at_level implemented; continuous_managers OUT.
     expect(services.approvalAssigneeResolver?.implementedKinds).toContain('direct_manager')
     expect(services.approvalAssigneeResolver?.implementedKinds).toContain('dept_head')
-    expect(services.approvalAssigneeResolver?.implementedKinds).not.toContain('manager_at_level')
+    expect(services.approvalAssigneeResolver?.implementedKinds).toContain('manager_at_level')
     expect(services.approvalAssigneeResolver?.implementedKinds).not.toContain('continuous_managers')
   })
 

--- a/packages/core-backend/tests/unit/attendance-approval-step-contract-s7-1.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-step-contract-s7-1.test.ts
@@ -304,9 +304,9 @@ describe('S7-1 assertDynamicFlowStepsRuntimeAvailable — §4.1 runtime fail-clo
   })
 })
 
-describe('S7-1/S7-2/S7-3 buildAttendanceApprovalAssignments — dynamic step never reaches the admin fallback', () => {
-  // S7-2/S7-3: direct_manager + dept_head are implemented — missing/empty/self snapshot →
-  // APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (block-with-error, §4). manager_at_level still hits UNGATED.
+describe('S7-1/S7-2/S7-3/S7-4 buildAttendanceApprovalAssignments — dynamic step never reaches the admin fallback', () => {
+  // S7-2/S7-3/S7-4: implemented kinds missing frozen snapshot → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED
+  // (block-with-error, §4). continuous_managers remains OUT and hits UNGATED if ever normalized in.
   it('direct_manager without frozen managerId throws APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (never admin fallback)', () => {
     expect(httpCode(() => buildAttendanceApprovalAssignments([{ kind: 'direct_manager' }], 0)))
       .toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
@@ -317,8 +317,13 @@ describe('S7-1/S7-2/S7-3 buildAttendanceApprovalAssignments — dynamic step nev
       .toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
   })
 
-  it('an unimplemented dynamic kind (manager_at_level) still throws APPROVAL_STEP_DYNAMIC_UNGATED', () => {
+  it('manager_at_level without frozen managerChainIds throws APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (never admin fallback)', () => {
     expect(httpCode(() => buildAttendanceApprovalAssignments([{ kind: 'manager_at_level', level: 1 }], 0)))
+      .toEqual({ status: 422, code: 'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED' })
+  })
+
+  it('OUT-of-v1 continuous_managers still throws APPROVAL_STEP_DYNAMIC_UNGATED (never admin fallback)', () => {
+    expect(httpCode(() => buildAttendanceApprovalAssignments([{ kind: 'continuous_managers', levels: 2 }], 0)))
       .toEqual({ status: 422, code: 'APPROVAL_STEP_DYNAMIC_UNGATED' })
   })
 

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -369,6 +369,10 @@ export default defineConfig({
       // DATABASE_URL-gated describeIfDatabase; excluded here so the no-DB job cannot skip-green it;
       // wired whole-file into the attendance real-DB step in plugin-tests.yml.
       'tests/integration/attendance-approval-dept-head-s7-3.db.test.ts',
+      // S7-4 manager_at_level real-DB: freeze managerChainIds + positional assignment + org-anchor +
+      // authz + flag-off. DATABASE_URL-gated describeIfDatabase; excluded here so the no-DB job cannot
+      // skip-green it; wired whole-file into the attendance real-DB step in plugin-tests.yml.
+      'tests/integration/attendance-approval-manager-at-level-s7-4.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -152,8 +152,8 @@ function getApprovalStepKind(step) {
 // Static (kind-less) steps return early: their legacy tolerance (unmodeled keys stripped by zod, A1
 // round-trip) is deliberately unchanged. The level UPPER bound uses the HOST-resolved MAX
 // (context.services.approvalAssigneeResolver.maxManagerChainLevels), never a plugin-parsed env — one
-// source, two surfaces, no drift. S7-2/S7-3 populate `direct_manager` + `dept_head`;
-// other well-formed dynamic kinds still land on (5) until S7-4 wires them.
+// source, two surfaces, no drift. S7-2/S7-3/S7-4 populate all three recognized kinds;
+// continuous_managers remains OUT-of-v1 (OD-S7-2) and lands on (2) KIND_INVALID.
 function assertApprovalStepsContract(steps, context) {
   if (!Array.isArray(steps)) return
   const port = context && context.services ? context.services.approvalAssigneeResolver : undefined
@@ -238,8 +238,8 @@ function assertApprovalStepsContract(steps, context) {
 // S7-1 §4.1 RUNTIME fail-closed gate. Given NORMALIZED flow steps (post-normalizeApprovalSteps, which
 // preserves a dynamic step's `kind`), throw HttpError(422) if a dynamic step is encountered while the
 // trigger set holds: flag OFF, OR the context.services resolver port is absent, OR the kind is not
-// resolver-implemented (S7-2/S7-3: `direct_manager` + `dept_head`). A flow with NO dynamic step is a
-// no-op (byte-identical legacy).
+// resolver-implemented (S7-2/S7-3/S7-4: `direct_manager` + `dept_head` + `manager_at_level`). A flow
+// with NO dynamic step is a no-op (byte-identical legacy).
 //   • request-create: pass no `onlyStepIndex` → WHOLE-flow scan, so a later dynamic step cannot start a
 //     flow and then strand mid-flight.
 //   • step-advance:   pass `onlyStepIndex = nextStepIndex` → check just the step about to become active.
@@ -20732,6 +20732,13 @@ function flowStepsNeedDeptHeadFreeze(flowSteps) {
   return steps.some((step) => getApprovalStepKind(step) === 'dept_head')
 }
 
+// S7-4: does the (normalized) flow carry a manager_at_level step? Used to decide whether to call the
+// org-scoped resolver port once at request-create to freeze managerChainIds (§3.4).
+function flowStepsNeedManagerChainFreeze(flowSteps) {
+  const steps = normalizeApprovalSteps(flowSteps)
+  return steps.some((step) => getApprovalStepKind(step) === ATTENDANCE_MANAGER_AT_LEVEL_KIND)
+}
+
 // Shared create-time port resolve for one dynamic kind. Port missing / unimplemented / throw map to
 // APPROVAL_STEP_KIND_UNAVAILABLE (§4.1); unresolved / empty / self map to
 // APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED (§4). Never called at step-advance.
@@ -20826,12 +20833,102 @@ async function resolveAttendanceDeptHeadFreeze({ orgId, userId, flowSteps, conte
   return { deptHeadId }
 }
 
-// S7-2 + S7-3: freeze every dynamic org relation the flow requires. A flow with both
-// direct_manager and dept_head freezes BOTH; either unresolved kind fails closed with zero persistence.
+// S7-4 §3.4 CREATE-TIME freeze: call the host-injected org-scoped port ONCE for a flow that contains
+// `manager_at_level`, freeze the FULL dense managerChainIds, and validate EVERY manager_at_level
+// step's positional level is resolvable (whole-flow; never empty freeze + later strand).
+// Never called at step-advance. Port missing / unimplemented / throw → APPROVAL_STEP_KIND_UNAVAILABLE;
+// empty / short / self chain → APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED. NEVER legacy admin fallback.
+async function resolveAttendanceManagerChainFreeze({ orgId, userId, flowSteps, context }) {
+  if (!flowStepsNeedManagerChainFreeze(flowSteps)) return {}
+
+  const port = context && context.services ? context.services.approvalAssigneeResolver : undefined
+  if (!port || typeof port.resolve !== 'function') {
+    throw new HttpError(
+      422,
+      'APPROVAL_STEP_KIND_UNAVAILABLE',
+      `动态审批人类型 "${ATTENDANCE_MANAGER_AT_LEVEL_KIND}" 无法解析(resolver 端口缺失)——请求已阻断(fail-closed)`
+    )
+  }
+
+  let result
+  try {
+    // No level: host returns the FULL dense chain as ordered assignees (S7-4 freeze contract).
+    result = await port.resolve(String(orgId ?? ''), {
+      kind: ATTENDANCE_MANAGER_AT_LEVEL_KIND,
+      requesterUserId: String(userId ?? ''),
+    })
+  } catch (err) {
+    if (err instanceof HttpError) throw err
+    const detail = err && typeof err.message === 'string' ? err.message : String(err)
+    throw new HttpError(
+      422,
+      'APPROVAL_STEP_KIND_UNAVAILABLE',
+      `动态审批人类型 "${ATTENDANCE_MANAGER_AT_LEVEL_KIND}" 无法解析(resolver 调用失败: ${detail})——请求已阻断(fail-closed)`
+    )
+  }
+  if (result && result.status === 'unimplemented') {
+    throw new HttpError(
+      422,
+      'APPROVAL_STEP_KIND_UNAVAILABLE',
+      `动态审批人类型 "${ATTENDANCE_MANAGER_AT_LEVEL_KIND}" 当前不可用(能力未启用或无对应 resolver)`
+    )
+  }
+
+  const requesterId = String(userId ?? '').trim()
+  const chain = []
+  if (result && result.status === 'resolved' && Array.isArray(result.assignees)) {
+    const seen = new Set()
+    for (const a of result.assignees) {
+      if (!a || a.assignmentType !== 'user' || typeof a.assigneeId !== 'string') continue
+      const id = a.assigneeId.trim()
+      // Defense-in-depth self-exclusion + dense-order dedup (host already excludes self).
+      if (!id || id === requesterId || seen.has(id)) continue
+      seen.add(id)
+      chain.push(id)
+    }
+  }
+
+  // Whole-flow: every manager_at_level step must resolve a positional manager from this frozen chain.
+  const steps = normalizeApprovalSteps(flowSteps)
+  for (let i = 0; i < steps.length; i += 1) {
+    const step = steps[i]
+    if (getApprovalStepKind(step) !== ATTENDANCE_MANAGER_AT_LEVEL_KIND) continue
+    const level = step.level
+    if (typeof level !== 'number' || !Number.isInteger(level) || level < 1) {
+      throw new HttpError(
+        422,
+        'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED',
+        `动态审批人类型 "manager_at_level" 无法解析(level 非法)——请求已阻断(fail-closed)，不得回退到管理员兜底队列`
+      )
+    }
+    const managerId = chain[level - 1]
+    if (!managerId || managerId === requesterId) {
+      throw new HttpError(
+        422,
+        'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED',
+        `动态审批人类型 "manager_at_level" 无法解析(链路不足 level=${level}、上级未绑定本地用户或解析到本人)——请求已阻断(fail-closed)，不得回退到管理员兜底队列`
+      )
+    }
+  }
+
+  if (chain.length === 0) {
+    throw new HttpError(
+      422,
+      'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED',
+      '动态审批人类型 "manager_at_level" 无法解析(无管理链路、上级未绑定本地用户或解析到本人)——请求已阻断(fail-closed)，不得回退到管理员兜底队列'
+    )
+  }
+
+  return { managerChainIds: chain }
+}
+
+// S7-2 + S7-3 + S7-4: freeze every dynamic org relation the flow requires. A flow with multiple
+// dynamic kinds freezes all of them; any unresolved kind fails closed with zero persistence.
 async function resolveAttendanceOrgRelationsFreeze({ orgId, userId, flowSteps, context }) {
   const directManager = await resolveAttendanceDirectManagerFreeze({ orgId, userId, flowSteps, context })
   const deptHead = await resolveAttendanceDeptHeadFreeze({ orgId, userId, flowSteps, context })
-  return { ...directManager, ...deptHead }
+  const managerChain = await resolveAttendanceManagerChainFreeze({ orgId, userId, flowSteps, context })
+  return { ...directManager, ...deptHead, ...managerChain }
 }
 
 function buildAttendanceApprovalAssignments(flowSteps, stepIndex = 0, requesterSnapshot = null) {
@@ -20906,10 +21003,38 @@ function buildAttendanceApprovalAssignments(flowSteps, stepIndex = 0, requesterS
     )
   }
 
+  // S7-4: manager_at_level reads ONLY the creation-frozen requesterSnapshot.managerChainIds (§3.4)
+  // and picks EXACTLY one positional manager at level-1 (1 = direct). No continuous_managers, no
+  // auto-expansion, never a live directory re-query. Missing / short / self ⇒
+  // APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED; NEVER the legacy admin/source_queue fallback.
+  if (dynamicKind === ATTENDANCE_MANAGER_AT_LEVEL_KIND) {
+    const snap = requesterSnapshot && typeof requesterSnapshot === 'object' ? requesterSnapshot : null
+    const requesterId = snap && typeof snap.id === 'string' ? snap.id.trim() : ''
+    const rawChain = snap && Array.isArray(snap.managerChainIds) ? snap.managerChainIds : []
+    const level = currentStep && typeof currentStep.level === 'number' ? currentStep.level : null
+    const managerId =
+      level !== null && Number.isInteger(level) && level >= 1 && typeof rawChain[level - 1] === 'string'
+        ? String(rawChain[level - 1]).trim()
+        : ''
+    if (managerId && managerId !== requesterId) {
+      pushAssignment('user', managerId, {
+        source: 'attendance',
+        kind: ATTENDANCE_MANAGER_AT_LEVEL_KIND,
+        stepName: currentStep?.name ?? null,
+        resolvedFrom: { kind: ATTENDANCE_MANAGER_AT_LEVEL_KIND, level },
+      })
+      return assignments
+    }
+    throw new HttpError(
+      422,
+      'APPROVAL_DYNAMIC_ASSIGNEE_UNRESOLVED',
+      '动态审批人类型 "manager_at_level" 无法解析(链路不足、上级未绑定本地用户或解析到本人)——请求已阻断(fail-closed)，不得回退到管理员兜底队列'
+    )
+  }
+
   // S7-1 §4.1 defense-in-depth: any OTHER dynamic kind must NEVER fall through to the legacy
   // admin-queue fallback (that fallback is reserved for LEGACY static steps with empty approver
-  // arrays). S7-4 will replace this arm for manager_at_level; until then, fail closed with a
-  // distinct code.
+  // arrays). continuous_managers and unknown kinds stay fail-closed with a distinct code.
   if (dynamicKind) {
     throw new HttpError(
       422,
@@ -20964,7 +21089,7 @@ function buildAttendanceApprovalInstancePayload({
     minutes: draft?.metadata?.minutes ?? null,
   }
 
-  // S7-2/S7-3 §3.4: freeze create-time org relations (managerId + deptHeadId; managerChainIds in S7-4)
+  // S7-2/S7-3/S7-4 §3.4: freeze create-time org relations (managerId + deptHeadId + managerChainIds)
   // into the requester snapshot. Omitted fields stay omitted — never write null placeholders that would
   // change the legacy {id,name}-only snapshot shape for static-only flows.
   const frozenManagerId =
@@ -20975,6 +21100,19 @@ function buildAttendanceApprovalInstancePayload({
     orgRelations && typeof orgRelations.deptHeadId === 'string' && orgRelations.deptHeadId.trim()
       ? orgRelations.deptHeadId.trim()
       : null
+  let frozenManagerChainIds = null
+  if (orgRelations && Array.isArray(orgRelations.managerChainIds) && orgRelations.managerChainIds.length > 0) {
+    const seen = new Set()
+    const chain = []
+    for (const entry of orgRelations.managerChainIds) {
+      if (typeof entry !== 'string') continue
+      const id = entry.trim()
+      if (!id || seen.has(id)) continue
+      seen.add(id)
+      chain.push(id)
+    }
+    if (chain.length > 0) frozenManagerChainIds = chain
+  }
 
   return {
     id: approvalId,
@@ -20989,6 +21127,7 @@ function buildAttendanceApprovalInstancePayload({
       name: requesterName || userId,
       ...(frozenManagerId ? { managerId: frozenManagerId } : {}),
       ...(frozenDeptHeadId ? { deptHeadId: frozenDeptHeadId } : {}),
+      ...(frozenManagerChainIds ? { managerChainIds: frozenManagerChainIds } : {}),
     },
     subjectSnapshot: {
       type: 'attendance_request',
@@ -21497,12 +21636,14 @@ module.exports = {
     ATTENDANCE_DYNAMIC_ASSIGNEE_FLAG_ENV,
     ATTENDANCE_DYNAMIC_ASSIGNEE_KINDS,
     ATTENDANCE_MANAGER_AT_LEVEL_KIND,
-    // S7-2/S7-3 create-time freeze seams (pure enough for unit tests with a faked port).
+    // S7-2/S7-3/S7-4 create-time freeze seams (pure enough for unit tests with a faked port).
     resolveAttendanceDirectManagerFreeze,
     resolveAttendanceDeptHeadFreeze,
+    resolveAttendanceManagerChainFreeze,
     resolveAttendanceOrgRelationsFreeze,
     flowStepsNeedDirectManagerFreeze,
     flowStepsNeedDeptHeadFreeze,
+    flowStepsNeedManagerChainFreeze,
   },
 
   async activate(context) {


### PR DESCRIPTION
## Summary

- implement the RATIFIED S7-4 `manager_at_level` slice through the attendance-only, org-scoped resolver port
- freeze the dense manager chain at request creation and resolve exactly one positional manager from the frozen snapshot at each step
- preserve fail-closed behavior, S7-0 approve/reject authorization, legacy static flows, and the default-OFF runtime flag
- keep `continuous_managers`, S7-5 editor work, deployment, and flag enablement out of scope
- wire the new real-DB suite into both the no-DB exclusion list and the explicit PostgreSQL CI run list

## Review

Grok produced the implementation and focused tests. Codex independently reviewed the full diff, found and fixed one P2 CI-wiring gap, reran the test matrix against a current migrated PostgreSQL database, and performed operand-level mutation checks.

## Verification

- `pnpm --filter @metasheet/core-backend type-check`
- focused unit/kernel regression set: 116/116
- S7-0 through S7-4 plus manager-chain real-DB set: 90/90
- S7-4 focused unit suite: 24/24
- S7-4 focused real-DB suite: 14/14
- YAML parse and `git diff --check`
- mutation: positional `level - 1` changed to `level` -> 5 S7-4 unit failures
- mutation: whole-flow short-chain validation forced to rung 0 -> short-chain freeze test failed
- mutation: removed the host `orgId` anchor -> two-org real-DB test selected the foreign manager and failed

Design lock: `docs/development/attendance-approval-s7-resolver-direct-manager-dept-head-multilevel-design-lock-20260716.md`
