### PR TITLE
test(stock-prep): move P4 repair corrupting-prevention branches into the required gate (#4473 P3-1)

### DIFF
--- a/packages/core-backend/tests/integration/stock-preparation-p4-repair-once-realdb.test.ts
+++ b/packages/core-backend/tests/integration/stock-preparation-p4-repair-once-realdb.test.ts
@@ -174,6 +174,19 @@ async function seedLegacyPartial(
   return { plan, targets }
 }
 
+// Seed ONLY the immutable batch row for `input` (no lines / run / project) — a legacy orphan batch,
+// used to construct history that the pointer-repair proof must reject (advanced_history /
+// ambiguous_history) without any prior pointer move.
+async function seedOrphanBatch(
+  multitable: NonNullable<PluginContext['api']['multitable']>,
+  input: Record<string, unknown>,
+) {
+  const plan = planBomSnapshotSyncRun({ permission: 'admin', ...input })
+  const targets = await resolveTargets(multitable)
+  await targets.batch.scoped.createRecord({ data: plan.snapshotBatch })
+  return { plan, targets }
+}
+
 if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
   test('P4 repair real-DB allowlist must provide DATABASE_URL', () => {
     throw new Error('P4 repair real-DB allowlist step is missing DATABASE_URL')
@@ -328,6 +341,106 @@ describeIfDatabase('stock-preparation P4 one-shot repair (real DB)', () => {
       mode: 'refused',
       detail: { persisted: false, result: 'refused', failureCode: 'PERSIST_REPAIR_REFUSED' },
     })
+  }, 30_000)
+
+  // #4473 P3-1 (owner review): the three CORRUPTING-prevention refusal branches — non_suffix_gap
+  // (a middle gap that a broken guard would double-append), advanced_history and ambiguous_history
+  // (pointer-repair proofs) — were executed only by the path-filtered, NON-required .cjs suite.
+  // These real-DB cases put them in the required gate: each asserts a 409 refusal, ZERO rows added,
+  // and a refused audit row, so deleting a guard turns a required check red instead of an advisory.
+
+  test('a middle line gap is refused as non_suffix_gap and adds no rows (a broken guard would double-append)', async () => {
+    const input = persistInput(multitable, 'gap')
+    const { plan, targets } = await seedLegacyPartial(multitable, input, { lineCount: 0, includeRun: false })
+    // Seed ONLY the SECOND plan line — a non-prefix, plan-order middle/tail gap (line[0] missing).
+    await targets.line.scoped.createRecord({ data: groundLineRow(plan.snapshotLines[1]) })
+    const before = await q('SELECT count(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[])', [sheetIds])
+
+    await expect(repairStockPreparationSyncRunOnce({
+      ...input,
+      auditStore,
+      auditActor: 'p4_repair_realdb',
+      apply: true,
+    })).rejects.toMatchObject({
+      status: 409,
+      code: 'PERSIST_REPAIR_REFUSED',
+      details: { target: 'snapshot_line', reason: 'non_suffix_gap' },
+    })
+    const after = await q('SELECT count(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[])', [sheetIds])
+    expect(after.rows).toEqual(before.rows)
+    const audit = await q(
+      "SELECT mode, detail FROM integration_stock_prep_audit WHERE tenant_id = $1 AND action = 'persist_repair_once' ORDER BY created_at DESC LIMIT 1",
+      [TENANT_ID],
+    )
+    expect(audit.rows[0]).toMatchObject({ mode: 'refused', detail: { result: 'refused', reason: 'non_suffix_gap' } })
+  }, 30_000)
+
+  test('a stale pointer is not patched when a higher batch version exists in history (advanced_history)', async () => {
+    // V1 commits fully — the live pointer names run_v1 (version 1).
+    const v1 = persistInput(multitable, 'adv', {
+      syncRunId: `run_adv_v1_${TOKEN}`,
+      snapshotBatchId: `batch_adv_v1_${TOKEN}`,
+      snapshotVersion: 1,
+    })
+    await persistStockPreparationSyncRun(v1)
+    // A legacy ORPHAN batch at version 3 exists in history (pointer NOT moved to it).
+    await seedOrphanBatch(multitable, persistInput(multitable, 'adv', {
+      syncRunId: `run_adv_v3_${TOKEN}`,
+      snapshotBatchId: `batch_adv_v3_${TOKEN}`,
+      snapshotVersion: 3,
+    }))
+    // A structurally-complete V2 whose only gap is the stale pointer (still on v1).
+    const v2 = persistInput(multitable, 'adv', {
+      syncRunId: `run_adv_v2_${TOKEN}`,
+      snapshotBatchId: `batch_adv_v2_${TOKEN}`,
+      snapshotVersion: 2,
+    })
+    await seedLegacyPartial(multitable, v2, { lineCount: 2, includeRun: true })
+    const before = await q('SELECT count(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[])', [sheetIds])
+
+    // Repairing V2 would patch the pointer (v1 < v2), but history's max version is 3 > 2 → refused.
+    await expect(repairStockPreparationSyncRunOnce({
+      ...v2,
+      auditStore,
+      auditActor: 'p4_repair_realdb',
+      apply: true,
+    })).rejects.toMatchObject({
+      status: 409,
+      code: 'PERSIST_REPAIR_REFUSED',
+      details: { target: 'project', reason: 'advanced_history' },
+    })
+    const after = await q('SELECT count(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[])', [sheetIds])
+    expect(after.rows).toEqual(before.rows)
+  }, 30_000)
+
+  test('a project pointer is not created when the top history version is tied across batches (ambiguous_history)', async () => {
+    // A structurally-complete candidate at version 2, project row MISSING (would create the pointer).
+    const candidate = persistInput(multitable, 'amb', {
+      syncRunId: `run_amb_cand_${TOKEN}`,
+      snapshotBatchId: `batch_amb_cand_${TOKEN}`,
+      snapshotVersion: 2,
+    })
+    await seedLegacyPartial(multitable, candidate, { lineCount: 2, includeRun: true })
+    // A second batch of the SAME project ties the top version (also version 2).
+    await seedOrphanBatch(multitable, persistInput(multitable, 'amb', {
+      syncRunId: `run_amb_other_${TOKEN}`,
+      snapshotBatchId: `batch_amb_other_${TOKEN}`,
+      snapshotVersion: 2,
+    }))
+    const before = await q('SELECT count(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[])', [sheetIds])
+
+    await expect(repairStockPreparationSyncRunOnce({
+      ...candidate,
+      auditStore,
+      auditActor: 'p4_repair_realdb',
+      apply: true,
+    })).rejects.toMatchObject({
+      status: 409,
+      code: 'PERSIST_REPAIR_REFUSED',
+      details: { target: 'project', reason: 'ambiguous_history' },
+    })
+    const after = await q('SELECT count(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[])', [sheetIds])
+    expect(after.rows).toEqual(before.rows)
   }, 30_000)
 
   test('the real CLI defaults to dry-run, emits one values-free line, and writes no snapshot rows', async () => {

--- a/packages/core-backend/tests/integration/stock-preparation-p4-repair-once-realdb.test.ts
+++ b/packages/core-backend/tests/integration/stock-preparation-p4-repair-once-realdb.test.ts
@@ -346,8 +346,10 @@ describeIfDatabase('stock-preparation P4 one-shot repair (real DB)', () => {
   // #4473 P3-1 (owner review): the three CORRUPTING-prevention refusal branches — non_suffix_gap
   // (a middle gap that a broken guard would double-append), advanced_history and ambiguous_history
   // (pointer-repair proofs) — were executed only by the path-filtered, NON-required .cjs suite.
-  // These real-DB cases put them in the required gate: each asserts a 409 refusal, ZERO rows added,
-  // and a refused audit row, so deleting a guard turns a required check red instead of an advisory.
+  // These real-DB cases put them in the required gate: each asserts a 409 refusal and that the state
+  // is untouched (ZERO rows added, and — for the pointer cases — the live pointer unchanged), so
+  // deleting a guard turns a required check red instead of an advisory. The gap case additionally
+  // asserts the refused audit row; the audit path is already covered elsewhere for the other two.
 
   test('a middle line gap is refused as non_suffix_gap and adds no rows (a broken guard would double-append)', async () => {
     const input = persistInput(multitable, 'gap')
@@ -397,6 +399,13 @@ describeIfDatabase('stock-preparation P4 one-shot repair (real DB)', () => {
     })
     await seedLegacyPartial(multitable, v2, { lineCount: 2, includeRun: true })
     const before = await q('SELECT count(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[])', [sheetIds])
+    // Capture the live pointer row's full data blob so a "patch-then-throw" bug (rows count would
+    // stay equal but the pointer would already point at v2) is caught directly, not just by count.
+    const pointerBefore = await q(
+      "SELECT data FROM meta_records WHERE sheet_id = $1 AND data::text LIKE '%' || $2 || '%'",
+      [sheetIds[0], v2.projectId],
+    )
+    expect(pointerBefore.rows).toHaveLength(1)
 
     // Repairing V2 would patch the pointer (v1 < v2), but history's max version is 3 > 2 → refused.
     await expect(repairStockPreparationSyncRunOnce({
@@ -411,6 +420,12 @@ describeIfDatabase('stock-preparation P4 one-shot repair (real DB)', () => {
     })
     const after = await q('SELECT count(*)::int AS count FROM meta_records WHERE sheet_id = ANY($1::text[])', [sheetIds])
     expect(after.rows).toEqual(before.rows)
+    const pointerAfter = await q(
+      "SELECT data FROM meta_records WHERE sheet_id = $1 AND data::text LIKE '%' || $2 || '%'",
+      [sheetIds[0], v2.projectId],
+    )
+    // The live pointer still names run_v1 — unchanged blob proves no partial patch preceded the throw.
+    expect(pointerAfter.rows).toEqual(pointerBefore.rows)
   }, 30_000)
 
   test('a project pointer is not created when the top history version is tied across batches (ambiguous_history)', async () => {


### PR DESCRIPTION
## What (post-merge adversarial review of #4473, owner-approved follow-up)

An independent refute-first review of the merged P4 Option C repair (#4473) confirmed **0 P1/P2** — but surfaced one coverage gap worth closing: three **corrupting-prevention** refusal branches were executed only by the path-filtered, **non-required** `.cjs` suite:

- **`non_suffix_gap`** — a plan-order middle line gap; a broken guard here would **double-append** and corrupt the snapshot;
- **`advanced_history`** — refuses patching a stale pointer when a higher batch version exists in history;
- **`ambiguous_history`** — refuses creating/advancing a pointer when the top history version is tied across batches.

Under the repo's required-checks-only merge model ([[Merge guard: required checks]]), deleting any of these guards was caught only by an advisory check — exactly the [[plugin-integration-core tests NOT in CI]] hazard, and these guard against **data corruption**.

## Change

Three real-DB cases added to `stock-preparation-p4-repair-once-realdb.test.ts` — which runs whole-file in `plugin-tests.yml`'s `test (20.x)` **required** job (verified in the wiring-contract test). Each asserts a 409 `PERSIST_REPAIR_REFUSED` with the exact `{target, reason}`, **zero** `meta_records` added, and (gap case) a refused audit row. A small `seedOrphanBatch` helper builds legacy history without moving the live pointer. **Test-only — no product code touched.**

## Evidence (local real DB, fresh-migrated)

- suite 8/8 (original 5 + new 3);
- mutation-verified: deleting the `non_suffix_gap` / `advanced_history` / `ambiguous_history` guard reds **exactly** its new case (3/3), each restored to 8/8; tree clean.

**Not armed — owner review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)