### PR TITLE
feat(stock-prep-ops): RC-A abort-provenance diagnostic client (#4437) — tested probe, fixed 15000, values-free block

### DIFF
--- a/.github/workflows/stock-preparation-prep-line-extended-smoke.yml
+++ b/.github/workflows/stock-preparation-prep-line-extended-smoke.yml
@@ -21,6 +21,8 @@ on:
       - 'scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs'
       - 'scripts/ops/stock-preparation-mvp-postdeploy-smoke.mjs'
       - 'scripts/ops/stock-preparation-mvp-postdeploy-smoke.test.mjs'
+      - 'scripts/ops/stock-preparation-rca-abort-provenance.mjs'
+      - 'scripts/ops/stock-preparation-rca-abort-provenance.test.mjs'
   workflow_dispatch:
     inputs:
       base_url:
@@ -65,6 +67,8 @@ jobs:
         run: node --test scripts/ops/stock-preparation-prep-line-extended-smoke.test.mjs
       - name: Run W6 harness contract tests (T4 imports its sanitizing layer)
         run: node --test scripts/ops/stock-preparation-mvp-postdeploy-smoke.test.mjs
+      - name: Run RC-A abort-provenance diagnostic contract tests (#4437, no server, no DB)
+        run: node --test scripts/ops/stock-preparation-rca-abort-provenance.test.mjs
 
   smoke:
     name: deployed prep-line extended smoke

--- a/docs/development/stock-preparation-rca-abort-provenance-diagnostic-20260720.md
+++ b/docs/development/stock-preparation-rca-abort-provenance-diagnostic-20260720.md
@@ -63,7 +63,7 @@ rendered block is additionally scanned for the auth token and scrubbed fail-clos
 STOCK_PREPARATION_RCA_ABORT_PROVENANCE
 executionState=DIAGNOSTIC_COMPLETE|DIAGNOSTIC_BLOCKED
 diagnosticAction=RUNTIME_ABORT_PROVENANCE
-blockedReasonClass=NONE|USAGE|HELPER_MISMATCH|IMPORT|NO_REQUEST|INTERNAL
+blockedReasonClass=NONE|USAGE|HELPER_MISMATCH|IMPORT|NO_REQUEST|REQUEST_ANOMALY|INTERNAL
 runtimeIdentity=NODE|BUN|DENO|OTHER|UNAVAILABLE
 nodeMajorClass=18|20|22|24|OTHER|UNAVAILABLE
 timerProbeResult=NORMAL|ABORT_EARLY|CLOCK_ANOMALY|UNAVAILABLE
@@ -169,6 +169,37 @@ zero import/fetch spies, fetch-less NO_REQUEST closure); CLI end-to-end for the 
 a tampered-copy path (BLOCKED, exit 2). Mutations M9-M12 (import-despite-mismatch,
 zero-request-complete, digest-drift, sibling-dropped) each RED with the intended discriminating
 test first; clean rerun 35/35.
+
+## 4c. Round-3 review absorption (2026-07-20)
+
+Owner round-3 reproduced two more false-PASSes; both closed:
+
+1. **Symlink bypassed the exact-SHA binding.** Verification derived the sibling directory from
+   `path.dirname(path.resolve(helperPath))`, which normalises `..` but does NOT follow symlinks,
+   while the Node loader imports a symlinked module by its real path and resolves that module's
+   static sibling import relative to the real directory. An attacker holding a byte-correct sibling
+   copy beside a symlink could make an UNVERIFIED real sibling execute. Fix: `resolveRealHelperFiles`
+   `realpath`s the target and each sibling, requires each real basename to equal its logical name
+   and each sibling to reside in the target's real directory, and both verification and import
+   operate on those real paths. Reproduced end-to-end: a tampered real sibling behind a clean
+   link-dir copy now yields `HELPER_MISMATCH` / exit 2. (Import via the caller path vs the resolved
+   real target is behaviourally equivalent — Node realpaths either to the same module — so that
+   mutation is an intentional equivalent; the residence and content guards are the load-bearing ones.)
+2. **Multiple / non-internal requests could read as COMPLETE.** The closure only blocked zero
+   requests. `DIAGNOSTIC_COMPLETE` now requires exactly one dispatch to the internal origin with
+   `externalWrite=false`; anything else (two dispatches, non-internal target, external-write guard
+   tripped) is `DIAGNOSTIC_BLOCKED` / `REQUEST_ANOMALY` / exit 2.
+
+Also fixed the P3: internal-target classification moved from `startsWith(baseUrl)` (which called
+`http://internal.example.evil` internal) to a same-origin `URL` comparison with an optional base
+path-prefix check; unparseable targets fail closed to non-internal.
+
+Verification grew to 42/42: `isInternalTarget` origin cases incl. the evil-suffix host, symlink
+repro (resolve into the real dir, tampered real sibling caught, differently-named target refused,
+sibling escaping the pinned dir refused), and two `REQUEST_ANOMALY` end-to-end cases (two internal
+dispatches, one external dispatch). Mutations M13/M15/M16/M17 (drop realpath, startsWith
+regression, drop anomaly guard, count-only anomaly check) each RED with the intended test first;
+M14 (drop sibling residence guard) RED via the escape test; clean rerun 42/42.
 
 ## 5. Operating notes (entity machine, owner-authorized runs only)
 

--- a/docs/development/stock-preparation-rca-abort-provenance-diagnostic-20260720.md
+++ b/docs/development/stock-preparation-rca-abort-provenance-diagnostic-20260720.md
@@ -63,10 +63,11 @@ rendered block is additionally scanned for the auth token and scrubbed fail-clos
 STOCK_PREPARATION_RCA_ABORT_PROVENANCE
 executionState=DIAGNOSTIC_COMPLETE|DIAGNOSTIC_BLOCKED
 diagnosticAction=RUNTIME_ABORT_PROVENANCE
-blockedReasonClass=NONE|USAGE|IMPORT|INTERNAL
+blockedReasonClass=NONE|USAGE|HELPER_MISMATCH|IMPORT|NO_REQUEST|INTERNAL
 runtimeIdentity=NODE|BUN|DENO|OTHER|UNAVAILABLE
 nodeMajorClass=18|20|22|24|OTHER|UNAVAILABLE
 timerProbeResult=NORMAL|ABORT_EARLY|CLOCK_ANOMALY|UNAVAILABLE
+helperContentVerified=PASS|FAIL|UNAVAILABLE
 fileUrlImport=PASS|FAIL|UNAVAILABLE
 timeoutArgumentMs=15000
 networkRequestCount=0|1|OTHER
@@ -142,6 +143,32 @@ Mutation battery (commit `04f6f5401`; apply -> expect RED -> restore -> clean re
 | M6 elapsed boundary `<` -> `<=` at 1s | RED (1) — bucket boundary test |
 | M7 remove closed-vocabulary validation throw | RED (1) — out-of-registry refusal test |
 | M8 skip token-scrub scan (always return tentative) | RED (1) — collision-scrub test |
+
+## 4b. Round-2 review absorption (2026-07-20)
+
+Owner round-2 identified two false protections in the first cut; both are closed:
+
+1. **Basename allowlist was not an exact-SHA binding.** Any file renamed to an allowlisted
+   basename would have been dynamically imported and executed. Now `HELPER_CONTENT_SHA256` pins
+   the SHA-256 of both smoke harnesses as of the RC-A exact package SHA
+   `d87e086fd1218b4cfb150177d43f2c52904b1d6d`, and `verifyHelperContent` byte-checks the target
+   file AND its statically-imported sibling (the extended smoke imports its sanitizing layer from
+   the W6 smoke) BEFORE any dynamic import. Any mismatch, unreadable file, or missing sibling ->
+   `DIAGNOSTIC_BLOCKED` / `HELPER_MISMATCH` with zero imports and zero requests (exit 2). A
+   repo-parity tripwire test fails loudly if the frozen smokes ever drift from the pinned digests
+   without a new diagnostic release.
+2. **Zero-request runs could read as COMPLETE.** A runtime without `fetch` (or any skipped
+   request phase) previously fell through to `DIAGNOSTIC_COMPLETE` with `UNAVAILABLE` request
+   fields. `DIAGNOSTIC_COMPLETE` is now a contract: content verified + import passed + exactly
+   the intended request dispatched and classified; otherwise `DIAGNOSTIC_BLOCKED` /
+   `NO_REQUEST`. Precedence: `HELPER_MISMATCH` > `IMPORT` > `NO_REQUEST`.
+
+Added verification: suite grew to 35/35 (constants shape + sibling map closure, repo-parity
+tripwire, fixture-based verify PASS/FAIL/missing-sibling/tamper cases, mismatch end-to-end with
+zero import/fetch spies, fetch-less NO_REQUEST closure); CLI end-to-end for the verified path and
+a tampered-copy path (BLOCKED, exit 2). Mutations M9-M12 (import-despite-mismatch,
+zero-request-complete, digest-drift, sibling-dropped) each RED with the intended discriminating
+test first; clean rerun 35/35.
 
 ## 5. Operating notes (entity machine, owner-authorized runs only)
 

--- a/docs/development/stock-preparation-rca-abort-provenance-diagnostic-20260720.md
+++ b/docs/development/stock-preparation-rca-abort-provenance-diagnostic-20260720.md
@@ -1,0 +1,164 @@
+# Stock-Preparation RC-A Abort-Provenance Diagnostic Client — Development & Verification (2026-07-20)
+
+Issue: #4437 (RC-A on-prem acceptance, diagnostic chain). Scope: one new tested, read-only,
+values-free diagnostic client plus its contract tests and CI wiring. No service-side change, no
+RC-A package republish, no flag or PM2 interaction.
+
+## 1. Why
+
+The #4437 diagnostic chain reached a contradiction. With the numeric literal `timeoutMs: 15000`
+attested at the call site, the probe still reported `authReadResult=ABORT_ERROR` with
+`elapsedClass=LT_1S`. At the exact package SHA, the smoke helper `requestJson` has exactly one
+abort source — `setTimeout(() => controller.abort(), timeoutMs)`, cleared in `finally` — so a
+sub-second AbortError cannot originate from that timer in a standard Node runtime. The remaining
+hypotheses are: the abort came from outside the helper's controller, the supplied timeout value
+did not actually reach the helper, or the machine's JS runtime has nonstandard timer/abort
+semantics (the preserved capture's `clientNodeMajor=OTHER` remains unresolved).
+
+Owner verdict (2026-07-20): the diagnosis direction stands, but hand-written operator wrappers
+have exhausted their evidentiary credit (consecutive import-method and timeout contradictions).
+The next probe must be a tested script whose output block is produced by the script itself.
+
+What this diagnostic can and cannot conclude, per the same verdict:
+
+- The exact-SHA helper is NOT "structurally cleared" wholesale. Only one path is excluded: its
+  own correctly-scheduled 15s timer producing a sub-second abort. Independent tool gaps (for
+  example, the smokes' `--timeout-ms` argument is `Number()`-coerced without a strict
+  positive-integer guard) remain open and are out of scope here (see §6).
+- `abortProvenance=OUTSIDE_HELPER_SIGNAL` only states the helper's controller did not fire. It
+  does not by itself attribute the abort to the operator context, the fetch implementation, or
+  the runtime.
+- `abortErrorNameClass=TIMEOUT_ERROR` is a strong hint that some `AbortSignal.timeout()` exists
+  in the failure path (the helper's mechanism produces plain `AbortError`), reported as an
+  observation, not as sole attribution.
+
+## 2. Deliverable
+
+`scripts/ops/stock-preparation-rca-abort-provenance.mjs` — single-file client, Node builtins
+only, shipped separately from the RC-A package. It imports the exact-SHA helper module from the
+existing on-machine checkout via `pathToFileURL` (basename allowlist: the two RC-A smoke
+harnesses) and produces one fixed values-free result block.
+
+Three observation phases:
+
+1. **Runtime identity (no network).** `runtimeIdentity=NODE|BUN|DENO|OTHER` — Bun/Deno
+   compat markers are checked before Node, since both emulate `process.versions.node` —
+   plus `nodeMajorClass=18|20|22|24|OTHER|UNAVAILABLE`.
+2. **Local timer/abort semantics (no network).** Schedules the same abort-timer shape the helper
+   uses (15s `setTimeout` -> `controller.abort()`), sleeps ~1.2s, and classifies against
+   `process.hrtime.bigint()`: `NORMAL | ABORT_EARLY | CLOCK_ANOMALY`. The abort timer is cleared
+   in `finally` on every path so it can never outlive the probe and pollute the real request.
+3. **One request through the helper's own `fetchImpl` seam.** Exactly one internal read-only GET
+   with the smoke AUTH shape (tenant scope via query + header when supplied), fixed
+   `timeoutMs: 15000` (no CLI override exists; unknown flags — including `--timeout-ms` — fail
+   closed with a usage error). The provenance shim only observes: it counts dispatches, latches
+   whether every target stayed under the base URL, subscribes to the helper-provided
+   `AbortSignal`, and delegates to global fetch unmodified. Elapsed time is monotonic-clock
+   bucketed (`LT_1S | 1_TO_14S | 15_TO_20S | GT_20S`).
+
+Result block (closed vocabulary, fixed order, every value validated before rendering; the
+rendered block is additionally scanned for the auth token and scrubbed fail-closed):
+
+```text
+STOCK_PREPARATION_RCA_ABORT_PROVENANCE
+executionState=DIAGNOSTIC_COMPLETE|DIAGNOSTIC_BLOCKED
+diagnosticAction=RUNTIME_ABORT_PROVENANCE
+blockedReasonClass=NONE|USAGE|IMPORT|INTERNAL
+runtimeIdentity=NODE|BUN|DENO|OTHER|UNAVAILABLE
+nodeMajorClass=18|20|22|24|OTHER|UNAVAILABLE
+timerProbeResult=NORMAL|ABORT_EARLY|CLOCK_ANOMALY|UNAVAILABLE
+fileUrlImport=PASS|FAIL|UNAVAILABLE
+timeoutArgumentMs=15000
+networkRequestCount=0|1|OTHER
+networkTarget=INTERNAL_API_ONLY|OTHER|UNAVAILABLE
+authReadResult=HTTP_2XX|HTTP_4XX|HTTP_5XX|TYPE_ERROR|ABORT_ERROR|OTHER|UNAVAILABLE
+elapsedClass=LT_1S|1_TO_14S|15_TO_20S|GT_20S|UNAVAILABLE
+typeErrorBoundary=INVALID_URL|REQUEST_HEADERS|CONNECT|DNS|TLS|FETCH_API|RESPONSE_READ|OTHER|NONE|UNAVAILABLE
+abortErrorNameClass=ABORT_ERROR|TIMEOUT_ERROR|OTHER|NONE
+abortProvenance=HELPER_SIGNAL|OUTSIDE_HELPER_SIGNAL|NONE|UNAVAILABLE
+externalWrite=false|true
+tokenScrubbed=PASS|FAIL|NOT_USED
+flagTouched=false
+```
+
+Fail-closed accounting: `externalWrite=true` for anything beyond exactly one internal request
+(over-reporting direction); `networkTarget` latches `OTHER` permanently once any non-internal
+target is observed; a failed helper import blocks the request phase entirely
+(`DIAGNOSTIC_BLOCKED` / `IMPORT`, zero dispatches). `flagTouched=false` is a constant: the client
+has no code path that touches service-side flags.
+
+TypeError boundary classification collects error codes from a closed set of locations (error,
+cause, AggregateError members, one nested cause level — Node >= 20 wraps connection failures in
+AggregateError) and maps them into coarse families; no code at any location -> `FETCH_API`,
+unrecognized codes -> `OTHER`. Values are never printed.
+
+## 3. Owner-verdict absorption map
+
+| Verdict item | Where absorbed |
+|---|---|
+| "Structurally cleared" was too strong | §1 scope statement; script header comment states the narrow exclusion only |
+| Local timer probe must clean up | `runTimerProbe` clears the abort timer in `finally`; leaked-timer test + mutation M1 |
+| Elapsed must use `process.hrtime.bigint()` | `defaultNowNs`; timer probe measures the sleep against it (`CLOCK_ANOMALY`), request elapsed bucketed from it |
+| `helperSignalFired=FALSE` must not indict the operator wrapper | Neutral enum `abortProvenance=OUTSIDE_HELPER_SIGNAL`; comment forbids further attribution |
+| TimeoutError is a hint, not sole attribution | Separate observation field `abortErrorNameClass`; no causal wording |
+| No more self-reported wrapper fields | Every field is computed and rendered by the script; closed-vocabulary validation throws on any out-of-registry value; token scrub is a final fail-closed pass over the rendered block |
+| Fixed 15000, no CLI override | `TIMEOUT_MS` constant; `--timeout-ms` (and any unknown flag) raises a usage error; end-to-end test pins `timeoutMs === 15000` at the real helper call site |
+| Acceptance on CI-parity Node 20 | Contract tests wired into the existing prep-line workflow's contract job (`node-version: 20`) |
+
+## 4. Verification
+
+Suites (local, Node 25; CI runs the same files on Node 20):
+
+- `node --test scripts/ops/stock-preparation-rca-abort-provenance.test.mjs` — 30/30 pass.
+  Owner-required scenarios covered: HTTP 2xx (real helper through the seam), helper-signal abort
+  (real helper, its own timer firing, `HELPER_SIGNAL`), outside-signal abort (AbortError with the
+  helper signal never firing, `OUTSIDE_HELPER_SIGNAL`), anomalous runtime (Bun/Deno markers,
+  non-enumerated majors), leaked timer (counting hooks assert the abort-timer handle is cleared
+  on normal and anomaly paths). Plus: vocabulary/order pinning, blocked blocks, arg parsing
+  fail-closed, elapsed bucket boundaries, rejection classification (AbortError / TimeoutError /
+  TypeError families incl. AggregateError members), network accounting fail-closed, tenant-scoped
+  AUTH pathname shape, token-scrub PASS/FAIL/NOT_USED including an adversarial token colliding
+  with rendered vocabulary text.
+- Regression: `stock-preparation-prep-line-extended-smoke.test.mjs` 19/19,
+  `stock-preparation-mvp-postdeploy-smoke.test.mjs` 30/30 (same contract job).
+
+CLI end-to-end (real fetch, no server):
+
+- Refused high port -> `authReadResult=TYPE_ERROR`, `typeErrorBoundary=CONNECT`,
+  `networkRequestCount=1`, exit 0. (Initial check against a fetch-spec blocked port surfaced the
+  AggregateError/plain-cause classification gap; fixed and covered by test.)
+- `--timeout-ms` present -> `DIAGNOSTIC_BLOCKED` / `blockedReasonClass=USAGE`, static usage text,
+  exit 2.
+
+Mutation battery (commit `04f6f5401`; apply -> expect RED -> restore -> clean rerun 30/30):
+
+| Mutation | Result |
+|---|---|
+| M1 drop abort-timer `clearTimeout` in `finally` | RED (2) — leaked-timer test first |
+| M2 `timeoutMs: TIMEOUT_MS` -> `1500` at call site | RED (1) — fixed-15000 call-site pin |
+| M3 unknown flags silently ignored | RED (2) — `--timeout-ms` rejection test |
+| M4 swap HELPER/OUTSIDE provenance branches | RED (3) — helper-signal test first |
+| M5 remove helper-signal listener subscription | RED (4) — seam contract test first |
+| M6 elapsed boundary `<` -> `<=` at 1s | RED (1) — bucket boundary test |
+| M7 remove closed-vocabulary validation throw | RED (1) — out-of-registry refusal test |
+| M8 skip token-scrub scan (always return tentative) | RED (1) — collision-scrub test |
+
+## 5. Operating notes (entity machine, owner-authorized runs only)
+
+```
+node scripts/ops/stock-preparation-rca-abort-provenance.mjs \
+  --helper <exact-sha-checkout>/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs \
+  --base-url <internal-base-url> [--tenant-id <tenant>]
+```
+
+Token via `METASHEET_AUTH_TOKEN` (never printed; scrub is checked over the final render). The
+client performs at most one internal GET, keeps the service flag posture untouched, and exits 0
+only on `DIAGNOSTIC_COMPLETE`. Routing of the result block stays owner-court; this document
+deliberately encodes no fast-track condition.
+
+## 6. Acknowledged independent gap (not addressed here)
+
+The existing smoke harnesses parse `--timeout-ms` with `Number(next())` (accepts `''`->0-like
+coercions, exponent/hex forms, non-integers) and schedule `setTimeout` from it unvalidated. A
+strict positive-safe-integer guard is a separate acceptance-tool hardening slice; it is left
+untouched in this PR so the exact-SHA package surface stays byte-stable for #4437.

--- a/scripts/ops/stock-preparation-rca-abort-provenance.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.mjs
@@ -36,7 +36,7 @@
 //     as an observation, not as sole attribution.
 
 import { createHash } from 'node:crypto'
-import { readFile } from 'node:fs/promises'
+import { readFile, realpath } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
@@ -76,7 +76,7 @@ export const HELPER_SIBLING_REQUIREMENTS = Object.freeze({
 export const RESULT_VOCABULARY = Object.freeze({
   executionState: Object.freeze(['DIAGNOSTIC_COMPLETE', 'DIAGNOSTIC_BLOCKED']),
   diagnosticAction: Object.freeze([DIAGNOSTIC_ACTION]),
-  blockedReasonClass: Object.freeze(['NONE', 'USAGE', 'HELPER_MISMATCH', 'IMPORT', 'NO_REQUEST', 'INTERNAL']),
+  blockedReasonClass: Object.freeze(['NONE', 'USAGE', 'HELPER_MISMATCH', 'IMPORT', 'NO_REQUEST', 'REQUEST_ANOMALY', 'INTERNAL']),
   runtimeIdentity: Object.freeze(['NODE', 'BUN', 'DENO', 'OTHER', 'UNAVAILABLE']),
   nodeMajorClass: Object.freeze(['18', '20', '22', '24', 'OTHER', 'UNAVAILABLE']),
   timerProbeResult: Object.freeze(['NORMAL', 'ABORT_EARLY', 'CLOCK_ANOMALY', 'UNAVAILABLE']),
@@ -219,6 +219,26 @@ export async function runTimerProbe({
 
 // ── Abort-provenance fetchImpl (observe-only shim over the helper's existing seam) ───────────────
 
+// Same-origin test, not a string prefix: `startsWith(baseUrl)` classifies
+// `http://internal.example.evil/…` as internal against base `http://internal.example` (owner
+// round-3 P3). Parse both and require identical origin (protocol + host + port); when the base
+// carries a path prefix, require the target path to sit under it. Unparseable targets fail closed
+// to non-internal.
+export function isInternalTarget(url, baseUrl) {
+  let target
+  let base
+  try {
+    target = new URL(String(url))
+    base = new URL(String(baseUrl))
+  } catch {
+    return false
+  }
+  if (target.origin !== base.origin) return false
+  const basePath = base.pathname === '/' ? '' : base.pathname.replace(/\/$/, '')
+  if (!basePath) return true
+  return target.pathname === basePath || target.pathname.startsWith(`${basePath}/`)
+}
+
 // Records, without altering behavior: how many requests the helper dispatched, whether every
 // target stayed under the supplied base URL, and whether the helper's own AbortSignal ever fired.
 // helperSignalObserved: UNAVAILABLE until a request carrying a signal is seen, then FALSE, then
@@ -234,7 +254,7 @@ export function buildProvenanceFetchImpl({ baseUrl, nowNs = defaultNowNs, fetchD
   const fetchImpl = (url, init) => {
     state.requestCount += 1
     if (state.startedNs === null) state.startedNs = nowNs()
-    const internal = String(url).startsWith(baseUrl)
+    const internal = isInternalTarget(url, baseUrl)
     state.networkTarget = state.networkTarget === 'OTHER' ? 'OTHER' : internal ? 'INTERNAL_API_ONLY' : 'OTHER'
     const signal = init ? init.signal : undefined
     if (signal && typeof signal.addEventListener === 'function') {
@@ -353,22 +373,56 @@ export function buildAuthReadPathname(tenantId) {
   return `${AUTH_READ_PATHNAME}?${params.toString()}`
 }
 
-// ── Helper content verification + import (pathToFileURL only) ────────────────────────────────────
+// ── Helper content verification + import (realpath-bound) ────────────────────────────────────────
 
-// Byte-binds the probe to the exact-SHA helper before any dynamic import: the target file and its
-// required sibling(s) must hash to the release-pinned digests. Returns 'PASS' | 'FAIL' only —
-// unreadable files, unknown basenames, and digest mismatches all FAIL closed.
-export async function verifyHelperContent(helperPath, { readFileImpl = readFile } = {}) {
+// Resolve the exact real files the Node loader will execute. A basename allowlist plus
+// `path.resolve` (which normalises `..` but does NOT follow symlinks) is not enough: Node imports
+// a symlinked module by its REAL path and resolves that module's static sibling import relative to
+// the real directory, so a symlink in a directory holding a byte-correct sibling copy would let an
+// UNVERIFIED real sibling execute (owner round-3 repro). `realpath` every file so verification and
+// import operate on identical bytes. Also require each real file's basename to equal its logical
+// name — a symlink pointing at a differently-named target is refused rather than silently accepted.
+export async function resolveRealHelperFiles(helperPath, { realpathImpl = realpath } = {}) {
   const base = path.basename(helperPath)
   const siblings = HELPER_SIBLING_REQUIREMENTS[base]
-  if (!Array.isArray(siblings)) return 'FAIL'
-  const dir = path.dirname(path.resolve(helperPath))
-  for (const name of [base, ...siblings]) {
+  if (!Array.isArray(siblings)) return null
+  let realTarget
+  try {
+    realTarget = await realpathImpl(helperPath)
+  } catch {
+    return null
+  }
+  if (path.basename(realTarget) !== base) return null
+  const dir = path.dirname(realTarget)
+  const files = [{ name: base, realPath: realTarget }]
+  for (const name of siblings) {
+    let realSibling
+    try {
+      realSibling = await realpathImpl(path.join(dir, name))
+    } catch {
+      return null
+    }
+    // The sibling Node will import must live in the target's real directory under its own name;
+    // a sibling that realpaths elsewhere (a nested symlink) is refused.
+    if (path.dirname(realSibling) !== dir || path.basename(realSibling) !== name) return null
+    files.push({ name, realPath: realSibling })
+  }
+  return { realTarget, dir, files }
+}
+
+// Byte-binds the probe to the exact-SHA helper before any dynamic import: every real file the
+// loader will execute (target + required sibling(s)) must hash to the release-pinned digests.
+// Returns 'PASS' | 'FAIL' only — unresolvable paths, symlink redirection, unknown basenames, and
+// digest mismatches all FAIL closed.
+export async function verifyHelperContent(helperPath, { readFileImpl = readFile, realpathImpl = realpath } = {}) {
+  const resolved = await resolveRealHelperFiles(helperPath, { realpathImpl })
+  if (!resolved) return 'FAIL'
+  for (const { name, realPath } of resolved.files) {
     const expected = HELPER_CONTENT_SHA256[name]
     if (typeof expected !== 'string') return 'FAIL'
     let bytes
     try {
-      bytes = await readFileImpl(path.join(dir, name))
+      bytes = await readFileImpl(realPath)
     } catch {
       return 'FAIL'
     }
@@ -378,8 +432,18 @@ export async function verifyHelperContent(helperPath, { readFileImpl = readFile 
   return 'PASS'
 }
 
-export async function importHelperModule(helperPath, { importImpl } = {}) {
-  const href = pathToFileURL(path.resolve(helperPath)).href
+// Import the verified real target (not the caller-supplied, possibly-symlinked path) so the module
+// that executes is exactly the one whose bytes were hashed. When importImpl is injected (tests),
+// realpath resolution is skipped and the caller-supplied path is used directly.
+export async function importHelperModule(helperPath, { importImpl, realpathImpl = realpath } = {}) {
+  let href
+  if (importImpl) {
+    href = pathToFileURL(path.resolve(helperPath)).href
+  } else {
+    const resolved = await resolveRealHelperFiles(helperPath, { realpathImpl })
+    if (!resolved) throw new Error('helper path could not be resolved to verified real files')
+    href = pathToFileURL(resolved.realTarget).href
+  }
   const mod = importImpl ? await importImpl(href) : await import(href)
   if (!mod || typeof mod.requestJson !== 'function') {
     throw new Error('helper module missing requestJson export')
@@ -489,9 +553,11 @@ export async function runDiagnostic({
   }
 
   // DIAGNOSTIC_COMPLETE is a contract, not a default: the exact-SHA binding must be proven, the
-  // import must succeed, and exactly the intended request must actually have been dispatched and
-  // classified. A run that never fired its one request (missing fetch, skipped phase) is BLOCKED
-  // — zero-request outcomes must never read as a completed diagnostic.
+  // import must succeed, and EXACTLY ONE request must have been dispatched to the internal target
+  // with externalWrite=false. A run that never fired its request (missing fetch, skipped phase) is
+  // NO_REQUEST; a run that fired more than one, hit a non-internal target, or tripped the
+  // external-write guard is REQUEST_ANOMALY — neither may read as a completed diagnostic (owner
+  // round-3: two dispatches / networkRequestCount=OTHER / externalWrite=true must exit 2).
   if (fields.helperContentVerified !== 'PASS') {
     fields.executionState = 'DIAGNOSTIC_BLOCKED'
     fields.blockedReasonClass = 'HELPER_MISMATCH'
@@ -501,6 +567,13 @@ export async function runDiagnostic({
   } else if (fields.networkRequestCount === '0' || fields.authReadResult === 'UNAVAILABLE') {
     fields.executionState = 'DIAGNOSTIC_BLOCKED'
     fields.blockedReasonClass = 'NO_REQUEST'
+  } else if (
+    fields.networkRequestCount !== '1' ||
+    fields.networkTarget !== 'INTERNAL_API_ONLY' ||
+    fields.externalWrite !== 'false'
+  ) {
+    fields.executionState = 'DIAGNOSTIC_BLOCKED'
+    fields.blockedReasonClass = 'REQUEST_ANOMALY'
   }
 
   return fields

--- a/scripts/ops/stock-preparation-rca-abort-provenance.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.mjs
@@ -35,6 +35,8 @@
 //     in the failure path (the helper's mechanism produces plain AbortError), but it is reported
 //     as an observation, not as sole attribution.
 
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
@@ -52,15 +54,33 @@ export const HELPER_BASENAME_ALLOWLIST = Object.freeze([
   'stock-preparation-mvp-postdeploy-smoke.mjs',
 ])
 
+// A basename allowlist alone does not bind the probe to the exact-SHA helper: any file renamed to
+// an allowlisted basename would be dynamically imported and executed. Before ANY import, the
+// target file — and, because the extended smoke statically imports its sanitizing layer from the
+// W6 smoke, that sibling too — must byte-match the release-pinned SHA-256 digests below, computed
+// from the RC-A exact package SHA d87e086fd1218b4cfb150177d43f2c52904b1d6d. Any mismatch blocks
+// the diagnostic (HELPER_MISMATCH) with zero imports and zero network requests. Editing the
+// frozen smoke harnesses requires cutting a new pinned diagnostic release (a repo-parity test
+// fails loudly otherwise).
+export const HELPER_CONTENT_SHA256 = Object.freeze({
+  'stock-preparation-prep-line-extended-smoke.mjs': '912f3ef75c4487dbdd946486d4cb7374f1c3ea1eb126c3b68381ad11963f0049',
+  'stock-preparation-mvp-postdeploy-smoke.mjs': 'e5265a2a8052ddc34866438a1ee3356b5d2aa1a106c8199f5e2fbbe4f2614df4',
+})
+export const HELPER_SIBLING_REQUIREMENTS = Object.freeze({
+  'stock-preparation-prep-line-extended-smoke.mjs': Object.freeze(['stock-preparation-mvp-postdeploy-smoke.mjs']),
+  'stock-preparation-mvp-postdeploy-smoke.mjs': Object.freeze([]),
+})
+
 // Closed vocabulary per field, in fixed render order. composeResultBlock refuses any value
 // outside its field's registry, so the printed surface is values-free by construction.
 export const RESULT_VOCABULARY = Object.freeze({
   executionState: Object.freeze(['DIAGNOSTIC_COMPLETE', 'DIAGNOSTIC_BLOCKED']),
   diagnosticAction: Object.freeze([DIAGNOSTIC_ACTION]),
-  blockedReasonClass: Object.freeze(['NONE', 'USAGE', 'IMPORT', 'INTERNAL']),
+  blockedReasonClass: Object.freeze(['NONE', 'USAGE', 'HELPER_MISMATCH', 'IMPORT', 'NO_REQUEST', 'INTERNAL']),
   runtimeIdentity: Object.freeze(['NODE', 'BUN', 'DENO', 'OTHER', 'UNAVAILABLE']),
   nodeMajorClass: Object.freeze(['18', '20', '22', '24', 'OTHER', 'UNAVAILABLE']),
   timerProbeResult: Object.freeze(['NORMAL', 'ABORT_EARLY', 'CLOCK_ANOMALY', 'UNAVAILABLE']),
+  helperContentVerified: Object.freeze(['PASS', 'FAIL', 'UNAVAILABLE']),
   fileUrlImport: Object.freeze(['PASS', 'FAIL', 'UNAVAILABLE']),
   timeoutArgumentMs: Object.freeze(['15000']),
   networkRequestCount: Object.freeze(['0', '1', 'OTHER']),
@@ -333,7 +353,30 @@ export function buildAuthReadPathname(tenantId) {
   return `${AUTH_READ_PATHNAME}?${params.toString()}`
 }
 
-// ── Helper import (pathToFileURL only) ───────────────────────────────────────────────────────────
+// ── Helper content verification + import (pathToFileURL only) ────────────────────────────────────
+
+// Byte-binds the probe to the exact-SHA helper before any dynamic import: the target file and its
+// required sibling(s) must hash to the release-pinned digests. Returns 'PASS' | 'FAIL' only —
+// unreadable files, unknown basenames, and digest mismatches all FAIL closed.
+export async function verifyHelperContent(helperPath, { readFileImpl = readFile } = {}) {
+  const base = path.basename(helperPath)
+  const siblings = HELPER_SIBLING_REQUIREMENTS[base]
+  if (!Array.isArray(siblings)) return 'FAIL'
+  const dir = path.dirname(path.resolve(helperPath))
+  for (const name of [base, ...siblings]) {
+    const expected = HELPER_CONTENT_SHA256[name]
+    if (typeof expected !== 'string') return 'FAIL'
+    let bytes
+    try {
+      bytes = await readFileImpl(path.join(dir, name))
+    } catch {
+      return 'FAIL'
+    }
+    const actual = createHash('sha256').update(bytes).digest('hex')
+    if (actual !== expected) return 'FAIL'
+  }
+  return 'PASS'
+}
 
 export async function importHelperModule(helperPath, { importImpl } = {}) {
   const href = pathToFileURL(path.resolve(helperPath)).href
@@ -354,6 +397,7 @@ export function baselineFields() {
     runtimeIdentity: 'UNAVAILABLE',
     nodeMajorClass: 'UNAVAILABLE',
     timerProbeResult: 'UNAVAILABLE',
+    helperContentVerified: 'UNAVAILABLE',
     fileUrlImport: 'UNAVAILABLE',
     timeoutArgumentMs: '15000',
     networkRequestCount: '0',
@@ -376,6 +420,7 @@ export async function runDiagnostic({
   nowNs = defaultNowNs,
   timerHooks = defaultTimerHooks(),
   timerProbeOverrides = {},
+  verifyImpl = verifyHelperContent,
   importImpl,
   fetchDelegate = globalThis.fetch,
 } = {}) {
@@ -387,12 +432,21 @@ export async function runDiagnostic({
   const timerProbe = await runTimerProbe({ nowNs, timerHooks, ...timerProbeOverrides })
   fields.timerProbeResult = timerProbe.timerProbeResult
 
+  // Content verification gates the dynamic import: a FAIL means the exact-SHA binding could not
+  // be proven, so nothing is imported and no request is dispatched.
   let helper = null
   try {
-    helper = await importHelperModule(args.helperPath, importImpl ? { importImpl } : {})
-    fields.fileUrlImport = 'PASS'
+    fields.helperContentVerified = (await verifyImpl(args.helperPath)) === 'PASS' ? 'PASS' : 'FAIL'
   } catch {
-    fields.fileUrlImport = 'FAIL'
+    fields.helperContentVerified = 'FAIL'
+  }
+  if (fields.helperContentVerified === 'PASS') {
+    try {
+      helper = await importHelperModule(args.helperPath, importImpl ? { importImpl } : {})
+      fields.fileUrlImport = 'PASS'
+    } catch {
+      fields.fileUrlImport = 'FAIL'
+    }
   }
 
   if (helper && typeof fetchDelegate === 'function') {
@@ -434,9 +488,19 @@ export async function runDiagnostic({
     fields.externalWrite = deriveExternalWrite({ requestCount: state.requestCount, networkTarget: state.networkTarget })
   }
 
-  if (fields.fileUrlImport === 'FAIL') {
+  // DIAGNOSTIC_COMPLETE is a contract, not a default: the exact-SHA binding must be proven, the
+  // import must succeed, and exactly the intended request must actually have been dispatched and
+  // classified. A run that never fired its one request (missing fetch, skipped phase) is BLOCKED
+  // — zero-request outcomes must never read as a completed diagnostic.
+  if (fields.helperContentVerified !== 'PASS') {
+    fields.executionState = 'DIAGNOSTIC_BLOCKED'
+    fields.blockedReasonClass = 'HELPER_MISMATCH'
+  } else if (fields.fileUrlImport !== 'PASS') {
     fields.executionState = 'DIAGNOSTIC_BLOCKED'
     fields.blockedReasonClass = 'IMPORT'
+  } else if (fields.networkRequestCount === '0' || fields.authReadResult === 'UNAVAILABLE') {
+    fields.executionState = 'DIAGNOSTIC_BLOCKED'
+    fields.blockedReasonClass = 'NO_REQUEST'
   }
 
   return fields

--- a/scripts/ops/stock-preparation-rca-abort-provenance.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.mjs
@@ -1,0 +1,504 @@
+#!/usr/bin/env node
+// stock-preparation-rca-abort-provenance.mjs — RC-A (#4437) abort-provenance diagnostic client.
+//
+// Why this exists: the #4437 diagnostic chain observed authReadResult=ABORT_ERROR with
+// elapsedClass=LT_1S while the exact-SHA smoke helper was given the numeric literal
+// timeoutMs=15000. The helper's only abort source is `setTimeout(() => controller.abort(),
+// timeoutMs)` cleared in `finally`, so a sub-second AbortError cannot come from that timer in a
+// standard Node runtime. This script replaces hand-written operator wrappers with a tested,
+// values-free client that separates the remaining hypotheses:
+//   - runtime identity (Node vs Bun vs Deno vs other; Node major class),
+//   - local timer/abort semantics against a monotonic clock (no network),
+//   - abort provenance for one real request: did the HELPER's own signal fire, observed through
+//     the helper's existing `fetchImpl` seam, or did the abort originate outside it?
+//
+// Discipline (owner verdict on #4437):
+//   - flag OFF posture: this client performs at most ONE internal read-only GET, zero writes,
+//     zero external systems, and never touches service-side flags (flagTouched=false constant).
+//   - timeoutMs is FIXED at 15000; there is deliberately no CLI override (unknown flags fail
+//     closed with a usage error — including --timeout-ms).
+//   - the exact-SHA helper module is imported via pathToFileURL from an allowlisted basename;
+//     this script ships separately and does not require republishing the RC-A package.
+//   - the provenance fetchImpl only observes the helper-provided AbortSignal and delegates to
+//     global fetch; it never patches globals.
+//   - every timer this script schedules is cleared in a `finally`.
+//   - elapsed time uses process.hrtime.bigint() (monotonic), classified into coarse buckets.
+//   - output is a fixed values-free block: every field is validated against a closed vocabulary
+//     before rendering, and the rendered block is scrubbed against the auth token as a final
+//     fail-closed check. No error text, URL, path, or identifier is ever printed.
+//
+// Interpretation notes (kept deliberately neutral):
+//   - abortProvenance=OUTSIDE_HELPER_SIGNAL only states the abort did not come from the helper's
+//     controller. It does not by itself attribute the abort to any specific layer (fetch
+//     implementation, runtime, or embedding context).
+//   - abortErrorNameClass=TIMEOUT_ERROR is a strong hint that some AbortSignal.timeout() exists
+//     in the failure path (the helper's mechanism produces plain AbortError), but it is reported
+//     as an observation, not as sole attribution.
+
+import path from 'node:path'
+import process from 'node:process'
+import { pathToFileURL } from 'node:url'
+
+export const DIAGNOSTIC_HEADER = 'STOCK_PREPARATION_RCA_ABORT_PROVENANCE'
+export const DIAGNOSTIC_ACTION = 'RUNTIME_ABORT_PROVENANCE'
+export const TIMEOUT_MS = 15000
+export const AUTH_READ_PATHNAME = '/api/integration/status'
+export const TOKEN_SCRUB_SENTINEL = '<scrubbed>'
+
+// Fail closed on what this client may import: only the two RC-A smoke harnesses that export the
+// requestJson helper under test. This keeps the diagnostic from becoming a generic module runner.
+export const HELPER_BASENAME_ALLOWLIST = Object.freeze([
+  'stock-preparation-prep-line-extended-smoke.mjs',
+  'stock-preparation-mvp-postdeploy-smoke.mjs',
+])
+
+// Closed vocabulary per field, in fixed render order. composeResultBlock refuses any value
+// outside its field's registry, so the printed surface is values-free by construction.
+export const RESULT_VOCABULARY = Object.freeze({
+  executionState: Object.freeze(['DIAGNOSTIC_COMPLETE', 'DIAGNOSTIC_BLOCKED']),
+  diagnosticAction: Object.freeze([DIAGNOSTIC_ACTION]),
+  blockedReasonClass: Object.freeze(['NONE', 'USAGE', 'IMPORT', 'INTERNAL']),
+  runtimeIdentity: Object.freeze(['NODE', 'BUN', 'DENO', 'OTHER', 'UNAVAILABLE']),
+  nodeMajorClass: Object.freeze(['18', '20', '22', '24', 'OTHER', 'UNAVAILABLE']),
+  timerProbeResult: Object.freeze(['NORMAL', 'ABORT_EARLY', 'CLOCK_ANOMALY', 'UNAVAILABLE']),
+  fileUrlImport: Object.freeze(['PASS', 'FAIL', 'UNAVAILABLE']),
+  timeoutArgumentMs: Object.freeze(['15000']),
+  networkRequestCount: Object.freeze(['0', '1', 'OTHER']),
+  networkTarget: Object.freeze(['INTERNAL_API_ONLY', 'OTHER', 'UNAVAILABLE']),
+  authReadResult: Object.freeze(['HTTP_2XX', 'HTTP_4XX', 'HTTP_5XX', 'TYPE_ERROR', 'ABORT_ERROR', 'OTHER', 'UNAVAILABLE']),
+  elapsedClass: Object.freeze(['LT_1S', '1_TO_14S', '15_TO_20S', 'GT_20S', 'UNAVAILABLE']),
+  typeErrorBoundary: Object.freeze(['INVALID_URL', 'REQUEST_HEADERS', 'CONNECT', 'DNS', 'TLS', 'FETCH_API', 'RESPONSE_READ', 'OTHER', 'NONE', 'UNAVAILABLE']),
+  abortErrorNameClass: Object.freeze(['ABORT_ERROR', 'TIMEOUT_ERROR', 'OTHER', 'NONE']),
+  abortProvenance: Object.freeze(['HELPER_SIGNAL', 'OUTSIDE_HELPER_SIGNAL', 'NONE', 'UNAVAILABLE']),
+  externalWrite: Object.freeze(['false', 'true']),
+  tokenScrubbed: Object.freeze(['PASS', 'FAIL', 'NOT_USED']),
+  flagTouched: Object.freeze(['false']),
+})
+export const RESULT_FIELD_ORDER = Object.freeze(Object.keys(RESULT_VOCABULARY))
+
+export const USAGE_TEXT = [
+  'usage: node scripts/ops/stock-preparation-rca-abort-provenance.mjs \\',
+  '         --helper <exact-sha-smoke-module-path> --base-url <http-or-https-base-url> [--tenant-id <tenant>]',
+  'notes: timeoutMs is fixed at 15000 and cannot be overridden; at most one internal read-only GET;',
+  '       auth token is read from the METASHEET_AUTH_TOKEN environment variable and never printed.',
+].join('\n')
+
+export class UsageError extends Error {}
+
+export function parseArgs(argv) {
+  const args = { helperPath: '', baseUrl: '', tenantId: '' }
+  const rest = argv.slice(2)
+  for (let i = 0; i < rest.length; i += 1) {
+    const flag = rest[i]
+    const next = () => {
+      const value = rest[i + 1]
+      if (value === undefined) throw new UsageError('missing flag value')
+      i += 1
+      return value
+    }
+    if (flag === '--helper') args.helperPath = next()
+    else if (flag === '--base-url') args.baseUrl = next()
+    else if (flag === '--tenant-id') args.tenantId = next()
+    // Unknown flags fail closed. This is load-bearing for the fixed-timeout contract: --timeout-ms
+    // must be rejected, not silently ignored.
+    else throw new UsageError('unknown flag')
+  }
+  if (!args.helperPath || !args.baseUrl) throw new UsageError('missing required flag')
+  if (!HELPER_BASENAME_ALLOWLIST.includes(path.basename(args.helperPath))) {
+    throw new UsageError('helper module not allowlisted')
+  }
+  let parsedBaseUrl
+  try {
+    parsedBaseUrl = new URL(args.baseUrl)
+  } catch {
+    throw new UsageError('base url unparseable')
+  }
+  if (parsedBaseUrl.protocol !== 'http:' && parsedBaseUrl.protocol !== 'https:') {
+    throw new UsageError('base url protocol not allowed')
+  }
+  return args
+}
+
+// ── Runtime identity ─────────────────────────────────────────────────────────────────────────────
+
+export function defaultRuntimeSurface() {
+  return {
+    versions: typeof process === 'object' && process ? process.versions : undefined,
+    bunGlobal: typeof globalThis.Bun !== 'undefined',
+    denoGlobal: typeof globalThis.Deno !== 'undefined',
+  }
+}
+
+// Bun/Deno both emulate process.versions.node, so the compat markers are checked first and NODE is
+// only reported when neither marker is present.
+export function detectRuntime(surface = defaultRuntimeSurface()) {
+  const versions = surface && typeof surface.versions === 'object' && surface.versions !== null ? surface.versions : {}
+  if (typeof versions.bun === 'string' || surface?.bunGlobal) return 'BUN'
+  if (surface?.denoGlobal) return 'DENO'
+  if (typeof versions.node === 'string' && versions.node.length > 0) return 'NODE'
+  return 'OTHER'
+}
+
+export function classifyNodeMajor(versionString) {
+  if (typeof versionString !== 'string') return 'UNAVAILABLE'
+  const match = /^(\d+)\./.exec(versionString)
+  if (!match) return 'UNAVAILABLE'
+  const major = match[1]
+  return ['18', '20', '22', '24'].includes(major) ? major : 'OTHER'
+}
+
+// ── Local timer/abort semantics probe (no network) ───────────────────────────────────────────────
+
+export function defaultNowNs() {
+  return process.hrtime.bigint()
+}
+
+export function defaultTimerHooks() {
+  return { setTimeout: globalThis.setTimeout, clearTimeout: globalThis.clearTimeout }
+}
+
+export const TIMER_PROBE_DEFAULTS = Object.freeze({
+  sleepTargetMs: 1200,
+  minSleepMs: 1000,
+  maxSleepMs: 5000,
+  abortTimerMs: TIMEOUT_MS,
+})
+
+// Schedules the same abort-timer shape the helper uses (setTimeout -> controller.abort()), sleeps
+// well short of it, and checks against a monotonic clock:
+//   ABORT_EARLY   — the long abort timer fired during the short sleep (broken timer semantics).
+//   CLOCK_ANOMALY — the sleep's measured monotonic duration fell outside its plausible window.
+//   NORMAL        — neither anomaly observed.
+// The abort timer is cleared in `finally` so it can never outlive the probe and pollute the
+// subsequent real request.
+export async function runTimerProbe({
+  sleepTargetMs = TIMER_PROBE_DEFAULTS.sleepTargetMs,
+  minSleepMs = TIMER_PROBE_DEFAULTS.minSleepMs,
+  maxSleepMs = TIMER_PROBE_DEFAULTS.maxSleepMs,
+  abortTimerMs = TIMER_PROBE_DEFAULTS.abortTimerMs,
+  nowNs = defaultNowNs,
+  timerHooks = defaultTimerHooks(),
+} = {}) {
+  if (typeof AbortController !== 'function') return { timerProbeResult: 'UNAVAILABLE' }
+  const controller = new AbortController()
+  let abortTimer
+  try {
+    const startedNs = nowNs()
+    abortTimer = timerHooks.setTimeout(() => controller.abort(), abortTimerMs)
+    await new Promise((resolve) => {
+      timerHooks.setTimeout(resolve, sleepTargetMs)
+    })
+    const elapsedMs = Number((nowNs() - startedNs) / 1_000_000n)
+    if (controller.signal.aborted) return { timerProbeResult: 'ABORT_EARLY' }
+    if (elapsedMs < minSleepMs || elapsedMs > maxSleepMs) return { timerProbeResult: 'CLOCK_ANOMALY' }
+    return { timerProbeResult: 'NORMAL' }
+  } finally {
+    timerHooks.clearTimeout(abortTimer)
+  }
+}
+
+// ── Abort-provenance fetchImpl (observe-only shim over the helper's existing seam) ───────────────
+
+// Records, without altering behavior: how many requests the helper dispatched, whether every
+// target stayed under the supplied base URL, and whether the helper's own AbortSignal ever fired.
+// helperSignalObserved: UNAVAILABLE until a request carrying a signal is seen, then FALSE, then
+// TRUE if that signal aborts before settle.
+export function buildProvenanceFetchImpl({ baseUrl, nowNs = defaultNowNs, fetchDelegate = globalThis.fetch } = {}) {
+  const state = {
+    requestCount: 0,
+    networkTarget: 'UNAVAILABLE',
+    helperSignalObserved: 'UNAVAILABLE',
+    helperSignalElapsedNs: null,
+    startedNs: null,
+  }
+  const fetchImpl = (url, init) => {
+    state.requestCount += 1
+    if (state.startedNs === null) state.startedNs = nowNs()
+    const internal = String(url).startsWith(baseUrl)
+    state.networkTarget = state.networkTarget === 'OTHER' ? 'OTHER' : internal ? 'INTERNAL_API_ONLY' : 'OTHER'
+    const signal = init ? init.signal : undefined
+    if (signal && typeof signal.addEventListener === 'function') {
+      if (state.helperSignalObserved === 'UNAVAILABLE') state.helperSignalObserved = 'FALSE'
+      signal.addEventListener(
+        'abort',
+        () => {
+          state.helperSignalObserved = 'TRUE'
+          state.helperSignalElapsedNs = nowNs() - state.startedNs
+        },
+        { once: true },
+      )
+    }
+    return fetchDelegate(url, init)
+  }
+  return { fetchImpl, state }
+}
+
+// ── Outcome classification ───────────────────────────────────────────────────────────────────────
+
+export function classifyElapsedNs(elapsedNs) {
+  if (typeof elapsedNs !== 'bigint' || elapsedNs < 0n) return 'UNAVAILABLE'
+  if (elapsedNs < 1_000_000_000n) return 'LT_1S'
+  if (elapsedNs < 15_000_000_000n) return '1_TO_14S'
+  if (elapsedNs <= 20_000_000_000n) return '15_TO_20S'
+  return 'GT_20S'
+}
+
+export function classifyHttpStatusClass(status) {
+  if (!Number.isInteger(status)) return 'OTHER'
+  if (status >= 200 && status <= 299) return 'HTTP_2XX'
+  if (status >= 400 && status <= 499) return 'HTTP_4XX'
+  if (status >= 500 && status <= 599) return 'HTTP_5XX'
+  return 'OTHER'
+}
+
+// Error codes are collected from a small closed set of locations: the error itself, its cause,
+// the cause's AggregateError members (Node >=20 wraps connection failures this way), and one
+// nested cause level. Values are never printed — they only feed the closed classification below.
+export function collectErrorCodes(error) {
+  const codes = []
+  const push = (value) => {
+    if (typeof value === 'string' && value.length > 0) codes.push(value)
+  }
+  push(error && error.code)
+  const cause = error && error.cause
+  push(cause && cause.code)
+  const nested = cause && cause.errors
+  if (Array.isArray(nested)) {
+    for (const item of nested) push(item && item.code)
+  }
+  push(cause && cause.cause && cause.cause.code)
+  return codes
+}
+
+function classifySingleErrorCode(code) {
+  if (code === 'ERR_INVALID_URL') return 'INVALID_URL'
+  if (code === 'ERR_INVALID_CHAR' || code === 'ERR_INVALID_HTTP_TOKEN') return 'REQUEST_HEADERS'
+  if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') return 'DNS'
+  if (['ECONNREFUSED', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'ETIMEDOUT', 'EPIPE', 'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_SOCKET'].includes(code)) return 'CONNECT'
+  if (code.startsWith('ERR_TLS') || code.includes('CERT')) return 'TLS'
+  if (['UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT', 'ERR_STREAM_PREMATURE_CLOSE'].includes(code)) return 'RESPONSE_READ'
+  return null
+}
+
+// Coarse boundary classification for TypeError rejections. UND_ERR_SOCKET (peer closed
+// mid-exchange) is grouped under CONNECT deliberately: it is a transport-layer failure, not a
+// parsed-response failure. No code at any collected location -> FETCH_API (the fetch layer itself
+// rejected); codes present but all unrecognized -> OTHER.
+export function classifyTypeErrorBoundary(error) {
+  const codes = collectErrorCodes(error)
+  if (codes.length === 0) return 'FETCH_API'
+  for (const code of codes) {
+    const family = classifySingleErrorCode(code)
+    if (family) return family
+  }
+  return 'OTHER'
+}
+
+export function classifyRejection(error) {
+  const name = error && typeof error.name === 'string' ? error.name : ''
+  if (name === 'AbortError') {
+    return { authReadResult: 'ABORT_ERROR', typeErrorBoundary: 'NONE', abortErrorNameClass: 'ABORT_ERROR' }
+  }
+  if (name === 'TimeoutError') {
+    return { authReadResult: 'ABORT_ERROR', typeErrorBoundary: 'NONE', abortErrorNameClass: 'TIMEOUT_ERROR' }
+  }
+  if (name === 'TypeError' || error instanceof TypeError) {
+    return { authReadResult: 'TYPE_ERROR', typeErrorBoundary: classifyTypeErrorBoundary(error), abortErrorNameClass: 'NONE' }
+  }
+  return { authReadResult: 'OTHER', typeErrorBoundary: 'NONE', abortErrorNameClass: 'OTHER' }
+}
+
+// HELPER_SIGNAL / OUTSIDE_HELPER_SIGNAL are deliberately neutral: OUTSIDE only states the helper's
+// own controller did not fire before the abort-shaped rejection. Attribution beyond that (fetch
+// implementation, runtime, embedding context) is out of scope for this client.
+export function deriveAbortProvenance({ authReadResult, helperSignalObserved }) {
+  if (authReadResult !== 'ABORT_ERROR') return 'NONE'
+  if (helperSignalObserved === 'TRUE') return 'HELPER_SIGNAL'
+  if (helperSignalObserved === 'FALSE') return 'OUTSIDE_HELPER_SIGNAL'
+  return 'UNAVAILABLE'
+}
+
+// Fail closed: anything beyond exactly one internal request is reported as externalWrite=true,
+// over-reporting rather than under-reporting risk. The single request is a GET by construction
+// (this client passes neither method nor body to the helper).
+export function deriveExternalWrite({ requestCount, networkTarget }) {
+  if (requestCount === 0) return 'false'
+  return networkTarget === 'INTERNAL_API_ONLY' && requestCount === 1 ? 'false' : 'true'
+}
+
+export function buildAuthReadPathname(tenantId) {
+  if (!tenantId) return AUTH_READ_PATHNAME
+  const params = new URLSearchParams()
+  params.set('tenantId', tenantId)
+  return `${AUTH_READ_PATHNAME}?${params.toString()}`
+}
+
+// ── Helper import (pathToFileURL only) ───────────────────────────────────────────────────────────
+
+export async function importHelperModule(helperPath, { importImpl } = {}) {
+  const href = pathToFileURL(path.resolve(helperPath)).href
+  const mod = importImpl ? await importImpl(href) : await import(href)
+  if (!mod || typeof mod.requestJson !== 'function') {
+    throw new Error('helper module missing requestJson export')
+  }
+  return mod
+}
+
+// ── Orchestration ────────────────────────────────────────────────────────────────────────────────
+
+export function baselineFields() {
+  return {
+    executionState: 'DIAGNOSTIC_COMPLETE',
+    diagnosticAction: DIAGNOSTIC_ACTION,
+    blockedReasonClass: 'NONE',
+    runtimeIdentity: 'UNAVAILABLE',
+    nodeMajorClass: 'UNAVAILABLE',
+    timerProbeResult: 'UNAVAILABLE',
+    fileUrlImport: 'UNAVAILABLE',
+    timeoutArgumentMs: '15000',
+    networkRequestCount: '0',
+    networkTarget: 'UNAVAILABLE',
+    authReadResult: 'UNAVAILABLE',
+    elapsedClass: 'UNAVAILABLE',
+    typeErrorBoundary: 'UNAVAILABLE',
+    abortErrorNameClass: 'NONE',
+    abortProvenance: 'UNAVAILABLE',
+    externalWrite: 'false',
+    tokenScrubbed: 'NOT_USED',
+    flagTouched: 'false',
+  }
+}
+
+export async function runDiagnostic({
+  args,
+  token = '',
+  runtimeSurface = defaultRuntimeSurface(),
+  nowNs = defaultNowNs,
+  timerHooks = defaultTimerHooks(),
+  timerProbeOverrides = {},
+  importImpl,
+  fetchDelegate = globalThis.fetch,
+} = {}) {
+  const fields = baselineFields()
+
+  fields.runtimeIdentity = detectRuntime(runtimeSurface)
+  fields.nodeMajorClass = classifyNodeMajor(runtimeSurface && runtimeSurface.versions ? runtimeSurface.versions.node : undefined)
+
+  const timerProbe = await runTimerProbe({ nowNs, timerHooks, ...timerProbeOverrides })
+  fields.timerProbeResult = timerProbe.timerProbeResult
+
+  let helper = null
+  try {
+    helper = await importHelperModule(args.helperPath, importImpl ? { importImpl } : {})
+    fields.fileUrlImport = 'PASS'
+  } catch {
+    fields.fileUrlImport = 'FAIL'
+  }
+
+  if (helper && typeof fetchDelegate === 'function') {
+    const { fetchImpl, state } = buildProvenanceFetchImpl({ baseUrl: args.baseUrl, nowNs, fetchDelegate })
+    const pathname = buildAuthReadPathname(args.tenantId)
+    const startedNs = nowNs()
+    let outcome
+    try {
+      const response = await helper.requestJson(args.baseUrl, pathname, {
+        token,
+        tenantId: args.tenantId || undefined,
+        timeoutMs: TIMEOUT_MS,
+        label: 'rca-abort-provenance',
+        leakExempt: true,
+        fetchImpl,
+      })
+      outcome = { resolved: true, response }
+    } catch (error) {
+      outcome = { resolved: false, error }
+    }
+    const elapsedNs = nowNs() - startedNs
+    fields.elapsedClass = classifyElapsedNs(elapsedNs)
+    fields.networkRequestCount = state.requestCount === 0 ? '0' : state.requestCount === 1 ? '1' : 'OTHER'
+    fields.networkTarget = state.requestCount === 0 ? 'UNAVAILABLE' : state.networkTarget
+    if (outcome.resolved) {
+      fields.authReadResult = classifyHttpStatusClass(outcome.response ? outcome.response.status : undefined)
+      fields.typeErrorBoundary = 'NONE'
+      fields.abortErrorNameClass = 'NONE'
+    } else {
+      const rejection = classifyRejection(outcome.error)
+      fields.authReadResult = rejection.authReadResult
+      fields.typeErrorBoundary = rejection.typeErrorBoundary
+      fields.abortErrorNameClass = rejection.abortErrorNameClass
+    }
+    fields.abortProvenance = deriveAbortProvenance({
+      authReadResult: fields.authReadResult,
+      helperSignalObserved: state.helperSignalObserved,
+    })
+    fields.externalWrite = deriveExternalWrite({ requestCount: state.requestCount, networkTarget: state.networkTarget })
+  }
+
+  if (fields.fileUrlImport === 'FAIL') {
+    fields.executionState = 'DIAGNOSTIC_BLOCKED'
+    fields.blockedReasonClass = 'IMPORT'
+  }
+
+  return fields
+}
+
+// ── Rendering (closed vocabulary + token scrub) ──────────────────────────────────────────────────
+
+export function composeResultBlock(fields) {
+  const lines = [DIAGNOSTIC_HEADER]
+  for (const key of RESULT_FIELD_ORDER) {
+    const value = fields[key]
+    const allowed = RESULT_VOCABULARY[key]
+    if (!allowed.includes(value)) {
+      throw new TypeError('result field outside closed vocabulary')
+    }
+    lines.push(`${key}=${value}`)
+  }
+  return lines.join('\n')
+}
+
+// Belt-and-suspenders: the vocabulary already makes a token leak impossible by construction, but
+// the rendered block is still scanned for the auth token; a hit flips tokenScrubbed to FAIL and
+// replaces every occurrence with a fixed sentinel.
+export function composeScrubbedBlock(fields, token) {
+  const tentative = composeResultBlock({ ...fields, tokenScrubbed: token ? 'PASS' : 'NOT_USED' })
+  if (!token || !tentative.includes(token)) return tentative
+  const failed = composeResultBlock({ ...fields, tokenScrubbed: 'FAIL' })
+  return failed.split(token).join(TOKEN_SCRUB_SENTINEL)
+}
+
+export function composeBlockedBlock(blockedReasonClass) {
+  return composeResultBlock({
+    ...baselineFields(),
+    executionState: 'DIAGNOSTIC_BLOCKED',
+    blockedReasonClass,
+  })
+}
+
+async function main() {
+  let args
+  try {
+    args = parseArgs(process.argv)
+  } catch (error) {
+    process.stdout.write(`${composeBlockedBlock(error instanceof UsageError ? 'USAGE' : 'INTERNAL')}\n`)
+    process.stdout.write(`${USAGE_TEXT}\n`)
+    process.exitCode = 2
+    return
+  }
+  const token = process.env.METASHEET_AUTH_TOKEN || ''
+  let fields
+  try {
+    fields = await runDiagnostic({ args, token })
+  } catch {
+    process.stdout.write(`${composeBlockedBlock('INTERNAL')}\n`)
+    process.exitCode = 2
+    return
+  }
+  process.stdout.write(`${composeScrubbedBlock(fields, token)}\n`)
+  process.exitCode = fields.executionState === 'DIAGNOSTIC_COMPLETE' ? 0 : 2
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1]))
+if (invokedDirectly) {
+  main()
+}

--- a/scripts/ops/stock-preparation-rca-abort-provenance.test.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.test.mjs
@@ -1,0 +1,499 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+// Contract tests for the RC-A (#4437) abort-provenance diagnostic client. No live server, no DB.
+// Owner-required coverage: HTTP 2xx, helper-signal abort, outside-signal abort, anomalous runtime,
+// leaked timer. The provenance seam is exercised against the REAL exact-SHA helper shape by
+// importing requestJson from the in-repo extended smoke harness.
+
+import {
+  AUTH_READ_PATHNAME,
+  DIAGNOSTIC_HEADER,
+  HELPER_BASENAME_ALLOWLIST,
+  RESULT_FIELD_ORDER,
+  RESULT_VOCABULARY,
+  TIMEOUT_MS,
+  TOKEN_SCRUB_SENTINEL,
+  UsageError,
+  baselineFields,
+  buildAuthReadPathname,
+  buildProvenanceFetchImpl,
+  classifyElapsedNs,
+  classifyHttpStatusClass,
+  classifyNodeMajor,
+  classifyRejection,
+  classifyTypeErrorBoundary,
+  composeBlockedBlock,
+  composeResultBlock,
+  composeScrubbedBlock,
+  deriveAbortProvenance,
+  deriveExternalWrite,
+  detectRuntime,
+  parseArgs,
+  runDiagnostic,
+  runTimerProbe,
+} from './stock-preparation-rca-abort-provenance.mjs'
+
+import { requestJson as realRequestJson } from './stock-preparation-prep-line-extended-smoke.mjs'
+
+const BASE_URL = 'http://127.0.0.1:9'
+
+function makeDomError(name) {
+  // DOMException carries the same name/shape undici uses for abort-family rejections.
+  return new DOMException('probe', name)
+}
+
+function jsonResponse(status, body = '{}') {
+  return { status, text: async () => body }
+}
+
+function countingTimerHooks() {
+  const scheduled = []
+  const cleared = []
+  return {
+    scheduled,
+    cleared,
+    hooks: {
+      setTimeout: (fn, delay) => {
+        const handle = setTimeout(fn, delay)
+        scheduled.push({ handle, delay })
+        return handle
+      },
+      clearTimeout: (handle) => {
+        cleared.push(handle)
+        clearTimeout(handle)
+      },
+    },
+  }
+}
+
+// ── Closed vocabulary + rendering ────────────────────────────────────────────────────────────────
+
+test('composeResultBlock renders header plus every field in fixed order', () => {
+  const rendered = composeResultBlock(baselineFields())
+  const lines = rendered.split('\n')
+  assert.equal(lines[0], DIAGNOSTIC_HEADER)
+  assert.equal(lines.length, 1 + RESULT_FIELD_ORDER.length)
+  RESULT_FIELD_ORDER.forEach((key, index) => {
+    assert.ok(lines[1 + index].startsWith(`${key}=`))
+    const value = lines[1 + index].slice(key.length + 1)
+    assert.ok(RESULT_VOCABULARY[key].includes(value))
+  })
+})
+
+test('composeResultBlock refuses any value outside the closed vocabulary', () => {
+  const fields = { ...baselineFields(), authReadResult: 'HTTP_302' }
+  assert.throws(() => composeResultBlock(fields), TypeError)
+  const injected = { ...baselineFields(), networkTarget: 'http://10.0.0.1/exfil' }
+  assert.throws(() => composeResultBlock(injected), TypeError)
+})
+
+test('composeBlockedBlock renders a values-free blocked block', () => {
+  const rendered = composeBlockedBlock('USAGE')
+  assert.ok(rendered.includes('executionState=DIAGNOSTIC_BLOCKED'))
+  assert.ok(rendered.includes('blockedReasonClass=USAGE'))
+  assert.ok(rendered.includes('networkRequestCount=0'))
+  assert.ok(rendered.includes('flagTouched=false'))
+})
+
+// ── Arg parsing: fixed timeout is not overridable ────────────────────────────────────────────────
+
+test('parseArgs accepts the three known flags and validates the base url', () => {
+  const args = parseArgs(['node', 'x', '--helper', 'pkg/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs', '--base-url', 'http://127.0.0.1:8081', '--tenant-id', 't1'])
+  assert.equal(args.tenantId, 't1')
+  assert.equal(args.baseUrl, 'http://127.0.0.1:8081')
+})
+
+test('parseArgs rejects --timeout-ms: the 15000 timeout is a fixed constant', () => {
+  assert.throws(
+    () => parseArgs(['node', 'x', '--helper', 'a/stock-preparation-prep-line-extended-smoke.mjs', '--base-url', 'http://h', '--timeout-ms', '200']),
+    UsageError,
+  )
+  assert.equal(TIMEOUT_MS, 15000)
+  assert.deepEqual(RESULT_VOCABULARY.timeoutArgumentMs, ['15000'])
+})
+
+test('parseArgs fails closed on unknown flags, missing requireds, bad urls, non-allowlisted helpers', () => {
+  assert.throws(() => parseArgs(['node', 'x', '--helper', 'a/stock-preparation-prep-line-extended-smoke.mjs', '--base-url', 'http://h', '--out-dir', '/tmp']), UsageError)
+  assert.throws(() => parseArgs(['node', 'x', '--base-url', 'http://h']), UsageError)
+  assert.throws(() => parseArgs(['node', 'x', '--helper', 'a/stock-preparation-prep-line-extended-smoke.mjs']), UsageError)
+  assert.throws(() => parseArgs(['node', 'x', '--helper', 'a/evil-module.mjs', '--base-url', 'http://h']), UsageError)
+  assert.throws(() => parseArgs(['node', 'x', '--helper', 'a/stock-preparation-prep-line-extended-smoke.mjs', '--base-url', 'not a url']), UsageError)
+  assert.throws(() => parseArgs(['node', 'x', '--helper', 'a/stock-preparation-prep-line-extended-smoke.mjs', '--base-url', 'file:///etc/passwd']), UsageError)
+  assert.deepEqual(
+    [...HELPER_BASENAME_ALLOWLIST],
+    ['stock-preparation-prep-line-extended-smoke.mjs', 'stock-preparation-mvp-postdeploy-smoke.mjs'],
+    'allowlist is exactly the two RC-A smoke harnesses',
+  )
+})
+
+// ── Runtime identity (anomalous-runtime coverage) ────────────────────────────────────────────────
+
+test('detectRuntime: NODE only when no Bun/Deno marker is present', () => {
+  assert.equal(detectRuntime({ versions: { node: '20.11.1' }, bunGlobal: false, denoGlobal: false }), 'NODE')
+  assert.equal(detectRuntime({ versions: { node: '20.11.1', bun: '1.1.0' }, bunGlobal: false, denoGlobal: false }), 'BUN')
+  assert.equal(detectRuntime({ versions: { node: '20.11.1' }, bunGlobal: true, denoGlobal: false }), 'BUN')
+  assert.equal(detectRuntime({ versions: { node: '20.11.1' }, bunGlobal: false, denoGlobal: true }), 'DENO')
+  assert.equal(detectRuntime({ versions: {}, bunGlobal: false, denoGlobal: false }), 'OTHER')
+  assert.equal(detectRuntime({ versions: undefined, bunGlobal: false, denoGlobal: false }), 'OTHER')
+})
+
+test('classifyNodeMajor: enumerated LTS majors, OTHER for the rest, UNAVAILABLE when unparseable', () => {
+  assert.equal(classifyNodeMajor('18.19.0'), '18')
+  assert.equal(classifyNodeMajor('20.11.1'), '20')
+  assert.equal(classifyNodeMajor('22.6.0'), '22')
+  assert.equal(classifyNodeMajor('24.1.0'), '24')
+  assert.equal(classifyNodeMajor('19.9.0'), 'OTHER')
+  assert.equal(classifyNodeMajor('25.9.0'), 'OTHER')
+  assert.equal(classifyNodeMajor('weird'), 'UNAVAILABLE')
+  assert.equal(classifyNodeMajor(undefined), 'UNAVAILABLE')
+})
+
+// ── Timer probe (leaked-timer + early-abort coverage) ────────────────────────────────────────────
+
+test('runTimerProbe NORMAL: healthy timers, and the abort timer is ALWAYS cleared in finally', async () => {
+  const { hooks, scheduled, cleared } = countingTimerHooks()
+  const probe = await runTimerProbe({
+    sleepTargetMs: 60,
+    minSleepMs: 40,
+    maxSleepMs: 4000,
+    abortTimerMs: 5000,
+    timerHooks: hooks,
+  })
+  assert.equal(probe.timerProbeResult, 'NORMAL')
+  const abortEntry = scheduled.find((entry) => entry.delay === 5000)
+  assert.ok(abortEntry, 'abort timer was scheduled')
+  assert.ok(cleared.includes(abortEntry.handle), 'abort timer handle was cleared — a leaked 15s timer would pollute the subsequent real request')
+})
+
+test('runTimerProbe ABORT_EARLY: a long abort timer firing during a short sleep is reported', async () => {
+  const { hooks, scheduled, cleared } = countingTimerHooks()
+  const probe = await runTimerProbe({
+    sleepTargetMs: 80,
+    minSleepMs: 1,
+    maxSleepMs: 4000,
+    abortTimerMs: 10,
+    timerHooks: hooks,
+  })
+  assert.equal(probe.timerProbeResult, 'ABORT_EARLY')
+  const abortEntry = scheduled.find((entry) => entry.delay === 10)
+  assert.ok(cleared.includes(abortEntry.handle), 'abort timer cleared even on the anomaly path')
+})
+
+test('runTimerProbe CLOCK_ANOMALY: monotonic elapsed outside the plausible sleep window', async () => {
+  let tick = 0n
+  const fakeNowNs = () => {
+    tick += 10_000_000_000n // each reading advances 10s: the 50ms sleep "took" 10s monotonically
+    return tick
+  }
+  const probe = await runTimerProbe({
+    sleepTargetMs: 50,
+    minSleepMs: 30,
+    maxSleepMs: 5000,
+    abortTimerMs: 5000,
+    nowNs: fakeNowNs,
+  })
+  assert.equal(probe.timerProbeResult, 'CLOCK_ANOMALY')
+})
+
+// ── Elapsed classification boundaries (hrtime.bigint buckets) ────────────────────────────────────
+
+test('classifyElapsedNs pins every bucket boundary', () => {
+  assert.equal(classifyElapsedNs(0n), 'LT_1S')
+  assert.equal(classifyElapsedNs(999_999_999n), 'LT_1S')
+  assert.equal(classifyElapsedNs(1_000_000_000n), '1_TO_14S')
+  assert.equal(classifyElapsedNs(14_999_999_999n), '1_TO_14S')
+  assert.equal(classifyElapsedNs(15_000_000_000n), '15_TO_20S')
+  assert.equal(classifyElapsedNs(20_000_000_000n), '15_TO_20S')
+  assert.equal(classifyElapsedNs(20_000_000_001n), 'GT_20S')
+  assert.equal(classifyElapsedNs(-1n), 'UNAVAILABLE')
+  assert.equal(classifyElapsedNs(1500), 'UNAVAILABLE')
+})
+
+// ── Rejection classification ─────────────────────────────────────────────────────────────────────
+
+test('classifyRejection separates AbortError, TimeoutError, TypeError, and unknown rejections', () => {
+  assert.deepEqual(classifyRejection(makeDomError('AbortError')), {
+    authReadResult: 'ABORT_ERROR',
+    typeErrorBoundary: 'NONE',
+    abortErrorNameClass: 'ABORT_ERROR',
+  })
+  assert.deepEqual(classifyRejection(makeDomError('TimeoutError')), {
+    authReadResult: 'ABORT_ERROR',
+    typeErrorBoundary: 'NONE',
+    abortErrorNameClass: 'TIMEOUT_ERROR',
+  })
+  const connectError = new TypeError('fetch failed')
+  connectError.cause = { code: 'ECONNREFUSED' }
+  assert.deepEqual(classifyRejection(connectError), {
+    authReadResult: 'TYPE_ERROR',
+    typeErrorBoundary: 'CONNECT',
+    abortErrorNameClass: 'NONE',
+  })
+  assert.deepEqual(classifyRejection(new Error('weird')), {
+    authReadResult: 'OTHER',
+    typeErrorBoundary: 'NONE',
+    abortErrorNameClass: 'OTHER',
+  })
+})
+
+test('classifyTypeErrorBoundary maps closed cause-code families', () => {
+  const withCause = (code) => {
+    const error = new TypeError('fetch failed')
+    error.cause = { code }
+    return error
+  }
+  assert.equal(classifyTypeErrorBoundary(withCause('ENOTFOUND')), 'DNS')
+  assert.equal(classifyTypeErrorBoundary(withCause('ECONNRESET')), 'CONNECT')
+  assert.equal(classifyTypeErrorBoundary(withCause('UND_ERR_CONNECT_TIMEOUT')), 'CONNECT')
+  assert.equal(classifyTypeErrorBoundary(withCause('ERR_TLS_CERT_ALTNAME_INVALID')), 'TLS')
+  assert.equal(classifyTypeErrorBoundary(withCause('DEPTH_ZERO_SELF_SIGNED_CERT')), 'TLS')
+  assert.equal(classifyTypeErrorBoundary(withCause('UND_ERR_HEADERS_TIMEOUT')), 'RESPONSE_READ')
+  assert.equal(classifyTypeErrorBoundary(withCause('ERR_INVALID_URL')), 'INVALID_URL')
+  assert.equal(classifyTypeErrorBoundary(withCause('SOMETHING_ELSE')), 'OTHER')
+  assert.equal(classifyTypeErrorBoundary(new TypeError('bare')), 'FETCH_API')
+})
+
+test('classifyTypeErrorBoundary reads AggregateError members (Node >=20 connection-refused shape)', () => {
+  const aggregate = new TypeError('fetch failed')
+  const member = new Error('connect ECONNREFUSED')
+  member.code = 'ECONNREFUSED'
+  aggregate.cause = new AggregateError([member], 'aggregate connect failure')
+  assert.equal(classifyTypeErrorBoundary(aggregate), 'CONNECT')
+
+  const nested = new TypeError('fetch failed')
+  const inner = new Error('socket hang up')
+  inner.code = 'UND_ERR_SOCKET'
+  nested.cause = { cause: inner }
+  assert.equal(classifyTypeErrorBoundary(nested), 'CONNECT')
+})
+
+// ── Provenance seam against the REAL helper (2xx + helper-signal + outside-signal coverage) ──────
+
+test('2xx path: real requestJson passes its own signal into fetchImpl; provenance stays NONE', async () => {
+  const { fetchImpl, state } = buildProvenanceFetchImpl({
+    baseUrl: BASE_URL,
+    fetchDelegate: async (url, init) => {
+      assert.ok(String(url).startsWith(BASE_URL))
+      assert.ok(init.signal, 'helper must thread its AbortController signal through the seam')
+      return jsonResponse(200)
+    },
+  })
+  const response = await realRequestJson(BASE_URL, AUTH_READ_PATHNAME, {
+    timeoutMs: 15000,
+    label: 'probe-2xx',
+    leakExempt: true,
+    fetchImpl,
+  })
+  assert.equal(response.status, 200)
+  assert.equal(state.requestCount, 1)
+  assert.equal(state.networkTarget, 'INTERNAL_API_ONLY')
+  assert.equal(state.helperSignalObserved, 'FALSE')
+  assert.equal(deriveAbortProvenance({ authReadResult: 'HTTP_2XX', helperSignalObserved: state.helperSignalObserved }), 'NONE')
+})
+
+test('helper-signal abort: when the helper timer fires, provenance reports HELPER_SIGNAL', async () => {
+  const { fetchImpl, state } = buildProvenanceFetchImpl({
+    baseUrl: BASE_URL,
+    fetchDelegate: (url, init) =>
+      new Promise((resolve, reject) => {
+        // Simulate undici: never respond; reject with AbortError only when the caller's signal fires.
+        init.signal.addEventListener('abort', () => reject(makeDomError('AbortError')), { once: true })
+      }),
+  })
+  await assert.rejects(
+    // Short timeout here only to keep the test fast; the diagnostic's own contract (fixed 15000)
+    // is pinned separately in the runDiagnostic test below.
+    realRequestJson(BASE_URL, AUTH_READ_PATHNAME, { timeoutMs: 30, label: 'probe-abort', leakExempt: true, fetchImpl }),
+    (error) => error.name === 'AbortError',
+  )
+  assert.equal(state.helperSignalObserved, 'TRUE')
+  assert.equal(typeof state.helperSignalElapsedNs, 'bigint')
+  assert.equal(deriveAbortProvenance({ authReadResult: 'ABORT_ERROR', helperSignalObserved: state.helperSignalObserved }), 'HELPER_SIGNAL')
+})
+
+test('outside-signal abort: an AbortError with the helper signal never firing is OUTSIDE_HELPER_SIGNAL', async () => {
+  const { fetchImpl, state } = buildProvenanceFetchImpl({
+    baseUrl: BASE_URL,
+    fetchDelegate: async () => {
+      throw makeDomError('AbortError') // aborted by something that is NOT the helper's controller
+    },
+  })
+  await assert.rejects(
+    realRequestJson(BASE_URL, AUTH_READ_PATHNAME, { timeoutMs: 15000, label: 'probe-outside', leakExempt: true, fetchImpl }),
+    (error) => error.name === 'AbortError',
+  )
+  assert.equal(state.helperSignalObserved, 'FALSE', 'helper signal never fired')
+  assert.equal(deriveAbortProvenance({ authReadResult: 'ABORT_ERROR', helperSignalObserved: state.helperSignalObserved }), 'OUTSIDE_HELPER_SIGNAL')
+})
+
+test('deriveAbortProvenance: non-abort outcomes report NONE; unobserved signal reports UNAVAILABLE', () => {
+  assert.equal(deriveAbortProvenance({ authReadResult: 'HTTP_2XX', helperSignalObserved: 'FALSE' }), 'NONE')
+  assert.equal(deriveAbortProvenance({ authReadResult: 'TYPE_ERROR', helperSignalObserved: 'FALSE' }), 'NONE')
+  assert.equal(deriveAbortProvenance({ authReadResult: 'ABORT_ERROR', helperSignalObserved: 'UNAVAILABLE' }), 'UNAVAILABLE')
+})
+
+// ── Network accounting fail-closed ───────────────────────────────────────────────────────────────
+
+test('externalWrite fail-closed: anything beyond exactly one internal request reports true', () => {
+  assert.equal(deriveExternalWrite({ requestCount: 0, networkTarget: 'UNAVAILABLE' }), 'false')
+  assert.equal(deriveExternalWrite({ requestCount: 1, networkTarget: 'INTERNAL_API_ONLY' }), 'false')
+  assert.equal(deriveExternalWrite({ requestCount: 1, networkTarget: 'OTHER' }), 'true')
+  assert.equal(deriveExternalWrite({ requestCount: 2, networkTarget: 'INTERNAL_API_ONLY' }), 'true')
+})
+
+test('provenance shim latches networkTarget=OTHER once any non-internal target is seen', async () => {
+  const { fetchImpl, state } = buildProvenanceFetchImpl({ baseUrl: BASE_URL, fetchDelegate: async () => jsonResponse(200) })
+  await fetchImpl(`${BASE_URL}/api/one`, {})
+  await fetchImpl('http://93.184.216.34/exfil', {})
+  await fetchImpl(`${BASE_URL}/api/two`, {})
+  assert.equal(state.requestCount, 3)
+  assert.equal(state.networkTarget, 'OTHER')
+})
+
+// ── End-to-end runDiagnostic ─────────────────────────────────────────────────────────────────────
+
+const REAL_HELPER_IMPORT = () => import('./stock-preparation-prep-line-extended-smoke.mjs')
+
+test('runDiagnostic 2xx end-to-end: fixed 15000 reaches the real helper call site', async () => {
+  let seenOptions = null
+  const importImpl = async () => {
+    const mod = await REAL_HELPER_IMPORT()
+    return {
+      requestJson: (baseUrl, pathname, options) => {
+        seenOptions = options
+        return mod.requestJson(baseUrl, pathname, options)
+      },
+    }
+  }
+  const fields = await runDiagnostic({
+    args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: 't1' },
+    token: 'tok_secret_1',
+    importImpl,
+    fetchDelegate: async (url) => {
+      assert.ok(String(url).includes('tenantId=t1'), 'tenant scope rides the query like the smoke AUTH shape')
+      return jsonResponse(200)
+    },
+    timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+  })
+  assert.equal(seenOptions.timeoutMs, 15000, 'the fixed timeout constant must reach the helper unchanged')
+  assert.equal(seenOptions.leakExempt, true)
+  assert.equal(typeof seenOptions.fetchImpl, 'function')
+  assert.equal(fields.executionState, 'DIAGNOSTIC_COMPLETE')
+  assert.equal(fields.fileUrlImport, 'PASS')
+  assert.equal(fields.timerProbeResult, 'NORMAL')
+  assert.equal(fields.networkRequestCount, '1')
+  assert.equal(fields.networkTarget, 'INTERNAL_API_ONLY')
+  assert.equal(fields.authReadResult, 'HTTP_2XX')
+  assert.equal(fields.abortProvenance, 'NONE')
+  assert.equal(fields.externalWrite, 'false')
+  assert.equal(fields.timeoutArgumentMs, '15000')
+  assert.equal(fields.flagTouched, 'false')
+})
+
+test('runDiagnostic outside-signal abort end-to-end classifies ABORT_ERROR + OUTSIDE_HELPER_SIGNAL', async () => {
+  const fields = await runDiagnostic({
+    args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    importImpl: REAL_HELPER_IMPORT,
+    fetchDelegate: async () => {
+      throw makeDomError('AbortError')
+    },
+    timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+  })
+  assert.equal(fields.authReadResult, 'ABORT_ERROR')
+  assert.equal(fields.abortErrorNameClass, 'ABORT_ERROR')
+  assert.equal(fields.abortProvenance, 'OUTSIDE_HELPER_SIGNAL')
+  assert.equal(fields.elapsedClass, 'LT_1S')
+  assert.equal(fields.executionState, 'DIAGNOSTIC_COMPLETE')
+})
+
+test('runDiagnostic import failure blocks the request phase entirely', async () => {
+  let delegateCalls = 0
+  const fields = await runDiagnostic({
+    args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    importImpl: async () => {
+      throw new Error('module not found')
+    },
+    fetchDelegate: async () => {
+      delegateCalls += 1
+      return jsonResponse(200)
+    },
+    timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+  })
+  assert.equal(fields.fileUrlImport, 'FAIL')
+  assert.equal(fields.executionState, 'DIAGNOSTIC_BLOCKED')
+  assert.equal(fields.blockedReasonClass, 'IMPORT')
+  assert.equal(fields.networkRequestCount, '0')
+  assert.equal(delegateCalls, 0, 'no request may be dispatched when the helper import failed')
+})
+
+test('runDiagnostic import of a module without requestJson is also an import failure', async () => {
+  const fields = await runDiagnostic({
+    args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    importImpl: async () => ({ somethingElse: true }),
+    fetchDelegate: async () => jsonResponse(200),
+    timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+  })
+  assert.equal(fields.fileUrlImport, 'FAIL')
+  assert.equal(fields.executionState, 'DIAGNOSTIC_BLOCKED')
+})
+
+test('runDiagnostic on an anomalous runtime surface still completes with identity fields', async () => {
+  const fields = await runDiagnostic({
+    args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    runtimeSurface: { versions: { node: '21.7.0', bun: '1.1.0' }, bunGlobal: true, denoGlobal: false },
+    importImpl: REAL_HELPER_IMPORT,
+    fetchDelegate: async () => jsonResponse(200),
+    timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+  })
+  assert.equal(fields.runtimeIdentity, 'BUN')
+  assert.equal(fields.nodeMajorClass, 'OTHER')
+  assert.equal(fields.executionState, 'DIAGNOSTIC_COMPLETE')
+})
+
+test('runDiagnostic classifies 4xx/5xx and TypeError CONNECT outcomes', async () => {
+  const run = (fetchDelegate) =>
+    runDiagnostic({
+      args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+      importImpl: REAL_HELPER_IMPORT,
+      fetchDelegate,
+      timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+    })
+  const unauthorized = await run(async () => jsonResponse(401))
+  assert.equal(unauthorized.authReadResult, 'HTTP_4XX')
+  const failing = await run(async () => jsonResponse(500))
+  assert.equal(failing.authReadResult, 'HTTP_5XX')
+  const refused = await run(async () => {
+    const error = new TypeError('fetch failed')
+    error.cause = { code: 'ECONNREFUSED' }
+    throw error
+  })
+  assert.equal(refused.authReadResult, 'TYPE_ERROR')
+  assert.equal(refused.typeErrorBoundary, 'CONNECT')
+  assert.equal(refused.abortProvenance, 'NONE')
+})
+
+// ── Pathname shape ───────────────────────────────────────────────────────────────────────────────
+
+test('buildAuthReadPathname mirrors the smoke AUTH shape: bare path, tenant via query when scoped', () => {
+  assert.equal(buildAuthReadPathname(''), AUTH_READ_PATHNAME)
+  assert.equal(buildAuthReadPathname('t1'), `${AUTH_READ_PATHNAME}?tenantId=t1`)
+})
+
+// ── Token scrub (belt-and-suspenders over the closed vocabulary) ─────────────────────────────────
+
+test('composeScrubbedBlock: PASS when token absent from render, NOT_USED when no token', () => {
+  const clean = composeScrubbedBlock(baselineFields(), 'tok_never_rendered')
+  assert.ok(clean.includes('tokenScrubbed=PASS'))
+  assert.ok(!clean.includes('tok_never_rendered'))
+  const untokened = composeScrubbedBlock(baselineFields(), '')
+  assert.ok(untokened.includes('tokenScrubbed=NOT_USED'))
+})
+
+test('composeScrubbedBlock: a token colliding with rendered text flips to FAIL and is scrubbed', () => {
+  // Adversarial collision: a "token" equal to a vocabulary word must still never survive printing.
+  const rendered = composeScrubbedBlock(baselineFields(), 'DIAGNOSTIC_COMPLETE')
+  assert.ok(rendered.includes('tokenScrubbed=FAIL'))
+  assert.ok(!rendered.includes('DIAGNOSTIC_COMPLETE'))
+  assert.ok(rendered.includes(TOKEN_SCRUB_SENTINEL))
+})

--- a/scripts/ops/stock-preparation-rca-abort-provenance.test.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.test.mjs
@@ -1,5 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { mkdtemp, readFile, writeFile, copyFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 // Contract tests for the RC-A (#4437) abort-provenance diagnostic client. No live server, no DB.
 // Owner-required coverage: HTTP 2xx, helper-signal abort, outside-signal abort, anomalous runtime,
@@ -10,6 +15,8 @@ import {
   AUTH_READ_PATHNAME,
   DIAGNOSTIC_HEADER,
   HELPER_BASENAME_ALLOWLIST,
+  HELPER_CONTENT_SHA256,
+  HELPER_SIBLING_REQUIREMENTS,
   RESULT_FIELD_ORDER,
   RESULT_VOCABULARY,
   TIMEOUT_MS,
@@ -32,6 +39,7 @@ import {
   parseArgs,
   runDiagnostic,
   runTimerProbe,
+  verifyHelperContent,
 } from './stock-preparation-rca-abort-provenance.mjs'
 
 import { requestJson as realRequestJson } from './stock-preparation-prep-line-extended-smoke.mjs'
@@ -351,9 +359,99 @@ test('provenance shim latches networkTarget=OTHER once any non-internal target i
   assert.equal(state.networkTarget, 'OTHER')
 })
 
+// ── Exact-SHA content binding (basename allowlist alone is not a binding) ────────────────────────
+
+const OPS_DIR = path.dirname(fileURLToPath(import.meta.url))
+const EXTENDED_BASENAME = 'stock-preparation-prep-line-extended-smoke.mjs'
+const MVP_BASENAME = 'stock-preparation-mvp-postdeploy-smoke.mjs'
+
+test('pinned digest constants: exactly the allowlisted basenames, 64-hex values, sibling map closed', () => {
+  assert.deepEqual(Object.keys(HELPER_CONTENT_SHA256).sort(), [...HELPER_BASENAME_ALLOWLIST].sort())
+  for (const digest of Object.values(HELPER_CONTENT_SHA256)) {
+    assert.match(digest, /^[0-9a-f]{64}$/)
+  }
+  assert.deepEqual([...HELPER_SIBLING_REQUIREMENTS[EXTENDED_BASENAME]], [MVP_BASENAME])
+  assert.deepEqual([...HELPER_SIBLING_REQUIREMENTS[MVP_BASENAME]], [])
+})
+
+test('repo-parity tripwire: the frozen smoke harnesses still hash to the release-pinned digests', async () => {
+  for (const name of HELPER_BASENAME_ALLOWLIST) {
+    const bytes = await readFile(path.join(OPS_DIR, name))
+    const actual = createHash('sha256').update(bytes).digest('hex')
+    assert.equal(
+      actual,
+      HELPER_CONTENT_SHA256[name],
+      `${name} drifted from the RC-A exact-SHA content — editing the frozen smokes requires cutting a new pinned diagnostic release`,
+    )
+  }
+})
+
+async function makeHelperFixtureDir() {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'rca-probe-fixture-'))
+  await copyFile(path.join(OPS_DIR, EXTENDED_BASENAME), path.join(dir, EXTENDED_BASENAME))
+  await copyFile(path.join(OPS_DIR, MVP_BASENAME), path.join(dir, MVP_BASENAME))
+  return dir
+}
+
+test('verifyHelperContent: byte-exact copies PASS; any tamper of target or sibling FAILs closed', async () => {
+  const dir = await makeHelperFixtureDir()
+  assert.equal(await verifyHelperContent(path.join(dir, EXTENDED_BASENAME)), 'PASS')
+  assert.equal(await verifyHelperContent(path.join(dir, MVP_BASENAME)), 'PASS')
+
+  const sibling = path.join(dir, MVP_BASENAME)
+  await writeFile(sibling, `${await readFile(sibling, 'utf8')}\n// tampered`)
+  assert.equal(await verifyHelperContent(path.join(dir, EXTENDED_BASENAME)), 'FAIL', 'tampered sibling in the static import chain must FAIL')
+  assert.equal(await verifyHelperContent(sibling), 'FAIL', 'tampered target must FAIL')
+
+  const lonely = await mkdtemp(path.join(os.tmpdir(), 'rca-probe-lonely-'))
+  await copyFile(path.join(OPS_DIR, EXTENDED_BASENAME), path.join(lonely, EXTENDED_BASENAME))
+  assert.equal(await verifyHelperContent(path.join(lonely, EXTENDED_BASENAME)), 'FAIL', 'missing required sibling must FAIL')
+  assert.equal(await verifyHelperContent(path.join(dir, 'evil-module.mjs')), 'FAIL', 'non-allowlisted basename must FAIL')
+})
+
+test('runDiagnostic on a content mismatch: BLOCKED/HELPER_MISMATCH, zero imports, zero requests', async () => {
+  let importCalls = 0
+  let fetchCalls = 0
+  const fields = await runDiagnostic({
+    args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    verifyImpl: async () => 'FAIL',
+    importImpl: async () => {
+      importCalls += 1
+      return { requestJson: async () => jsonResponse(200) }
+    },
+    fetchDelegate: async () => {
+      fetchCalls += 1
+      return jsonResponse(200)
+    },
+    timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+  })
+  assert.equal(fields.helperContentVerified, 'FAIL')
+  assert.equal(fields.executionState, 'DIAGNOSTIC_BLOCKED')
+  assert.equal(fields.blockedReasonClass, 'HELPER_MISMATCH')
+  assert.equal(fields.fileUrlImport, 'UNAVAILABLE', 'no dynamic import may run on unverified content')
+  assert.equal(fields.networkRequestCount, '0')
+  assert.equal(importCalls, 0)
+  assert.equal(fetchCalls, 0)
+})
+
+test('runDiagnostic zero-request closure: verified + imported but no dispatch is BLOCKED/NO_REQUEST, never COMPLETE', async () => {
+  const fields = await runDiagnostic({
+    args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    verifyImpl: async () => 'PASS',
+    importImpl: () => import('./stock-preparation-prep-line-extended-smoke.mjs'),
+    fetchDelegate: null, // a runtime without fetch: request phase must not silently pass as COMPLETE
+    timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+  })
+  assert.equal(fields.fileUrlImport, 'PASS')
+  assert.equal(fields.networkRequestCount, '0')
+  assert.equal(fields.executionState, 'DIAGNOSTIC_BLOCKED')
+  assert.equal(fields.blockedReasonClass, 'NO_REQUEST')
+})
+
 // ── End-to-end runDiagnostic ─────────────────────────────────────────────────────────────────────
 
 const REAL_HELPER_IMPORT = () => import('./stock-preparation-prep-line-extended-smoke.mjs')
+const VERIFY_PASS = async () => 'PASS'
 
 test('runDiagnostic 2xx end-to-end: fixed 15000 reaches the real helper call site', async () => {
   let seenOptions = null
@@ -369,6 +467,7 @@ test('runDiagnostic 2xx end-to-end: fixed 15000 reaches the real helper call sit
   const fields = await runDiagnostic({
     args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: 't1' },
     token: 'tok_secret_1',
+    verifyImpl: VERIFY_PASS,
     importImpl,
     fetchDelegate: async (url) => {
       assert.ok(String(url).includes('tenantId=t1'), 'tenant scope rides the query like the smoke AUTH shape')
@@ -394,6 +493,7 @@ test('runDiagnostic 2xx end-to-end: fixed 15000 reaches the real helper call sit
 test('runDiagnostic outside-signal abort end-to-end classifies ABORT_ERROR + OUTSIDE_HELPER_SIGNAL', async () => {
   const fields = await runDiagnostic({
     args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    verifyImpl: VERIFY_PASS,
     importImpl: REAL_HELPER_IMPORT,
     fetchDelegate: async () => {
       throw makeDomError('AbortError')
@@ -411,6 +511,7 @@ test('runDiagnostic import failure blocks the request phase entirely', async () 
   let delegateCalls = 0
   const fields = await runDiagnostic({
     args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    verifyImpl: VERIFY_PASS,
     importImpl: async () => {
       throw new Error('module not found')
     },
@@ -430,6 +531,7 @@ test('runDiagnostic import failure blocks the request phase entirely', async () 
 test('runDiagnostic import of a module without requestJson is also an import failure', async () => {
   const fields = await runDiagnostic({
     args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    verifyImpl: VERIFY_PASS,
     importImpl: async () => ({ somethingElse: true }),
     fetchDelegate: async () => jsonResponse(200),
     timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
@@ -442,6 +544,7 @@ test('runDiagnostic on an anomalous runtime surface still completes with identit
   const fields = await runDiagnostic({
     args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
     runtimeSurface: { versions: { node: '21.7.0', bun: '1.1.0' }, bunGlobal: true, denoGlobal: false },
+    verifyImpl: VERIFY_PASS,
     importImpl: REAL_HELPER_IMPORT,
     fetchDelegate: async () => jsonResponse(200),
     timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
@@ -455,6 +558,7 @@ test('runDiagnostic classifies 4xx/5xx and TypeError CONNECT outcomes', async ()
   const run = (fetchDelegate) =>
     runDiagnostic({
       args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+      verifyImpl: VERIFY_PASS,
       importImpl: REAL_HELPER_IMPORT,
       fetchDelegate,
       timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },

--- a/scripts/ops/stock-preparation-rca-abort-provenance.test.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
-import { mkdtemp, readFile, writeFile, copyFile } from 'node:fs/promises'
+import { mkdtemp, readFile, writeFile, copyFile, symlink, realpath } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -36,7 +36,9 @@ import {
   deriveAbortProvenance,
   deriveExternalWrite,
   detectRuntime,
+  isInternalTarget,
   parseArgs,
+  resolveRealHelperFiles,
   runDiagnostic,
   runTimerProbe,
   verifyHelperContent,
@@ -409,6 +411,84 @@ test('verifyHelperContent: byte-exact copies PASS; any tamper of target or sibli
   assert.equal(await verifyHelperContent(path.join(dir, 'evil-module.mjs')), 'FAIL', 'non-allowlisted basename must FAIL')
 })
 
+test('symlink bypass (owner round-3 repro): verify+import must resolve the SAME real files', async () => {
+  // Real dir holds the genuine, byte-correct helper + sibling.
+  const realDir = await makeHelperFixtureDir()
+  // Attack dir: a byte-correct sibling copy, but the TARGET is a symlink into the real dir. The
+  // pre-fix code verified the sibling from the symlink's own directory while Node would import the
+  // sibling that lives beside the symlink's REAL target — a different file could execute unverified.
+  const linkDir = await mkdtemp(path.join(os.tmpdir(), 'rca-probe-link-'))
+  await symlink(path.join(realDir, EXTENDED_BASENAME), path.join(linkDir, EXTENDED_BASENAME))
+  await copyFile(path.join(OPS_DIR, MVP_BASENAME), path.join(linkDir, MVP_BASENAME))
+
+  const realDirCanonical = await realpath(realDir) // macOS /var -> /private/var
+  const resolved = await resolveRealHelperFiles(path.join(linkDir, EXTENDED_BASENAME))
+  assert.ok(resolved, 'symlink to a same-named real target resolves')
+  assert.equal(resolved.realTarget, path.join(realDirCanonical, EXTENDED_BASENAME), 'target resolves into the REAL dir')
+  assert.equal(resolved.dir, realDirCanonical, 'sibling verification directory is the real dir, not the link dir')
+  for (const f of resolved.files) {
+    assert.equal(path.dirname(f.realPath), realDirCanonical, `${f.name} is verified from the real dir Node will import from`)
+  }
+  // Byte-correct real files => PASS, and it is the real sibling that was hashed.
+  assert.equal(await verifyHelperContent(path.join(linkDir, EXTENDED_BASENAME)), 'PASS')
+
+  // Now tamper the REAL sibling: verification must FAIL even though the link-dir sibling is clean.
+  const realSibling = path.join(realDir, MVP_BASENAME)
+  await writeFile(realSibling, `${await readFile(realSibling, 'utf8')}\n// tampered real sibling`)
+  assert.equal(
+    await verifyHelperContent(path.join(linkDir, EXTENDED_BASENAME)),
+    'FAIL',
+    'the real sibling Node imports is tampered — a clean link-dir copy must not mask it',
+  )
+})
+
+test('resolveRealHelperFiles refuses a symlink whose real target has a different logical name', async () => {
+  const realDir = await makeHelperFixtureDir()
+  const linkDir = await mkdtemp(path.join(os.tmpdir(), 'rca-probe-link2-'))
+  // extended.mjs -> real mvp.mjs: logical name and real basename disagree; must refuse.
+  await symlink(path.join(realDir, MVP_BASENAME), path.join(linkDir, EXTENDED_BASENAME))
+  assert.equal(await resolveRealHelperFiles(path.join(linkDir, EXTENDED_BASENAME)), null)
+  assert.equal(await verifyHelperContent(path.join(linkDir, EXTENDED_BASENAME)), 'FAIL')
+})
+
+test('resolveRealHelperFiles refuses a sibling that realpaths OUT of the target real directory', async () => {
+  // Real target dir; its sibling is a symlink to a byte-correct copy in a DIFFERENT directory.
+  // Node would import that escaped sibling; a content-only check would pass it. The residence guard
+  // requires the executed sibling to live in the target's real dir under its own name, so it FAILs.
+  const realDir = await mkdtemp(path.join(os.tmpdir(), 'rca-probe-escape-'))
+  await copyFile(path.join(OPS_DIR, EXTENDED_BASENAME), path.join(realDir, EXTENDED_BASENAME))
+  const elsewhere = await mkdtemp(path.join(os.tmpdir(), 'rca-probe-elsewhere-'))
+  await copyFile(path.join(OPS_DIR, MVP_BASENAME), path.join(elsewhere, MVP_BASENAME)) // byte-correct
+  await symlink(path.join(elsewhere, MVP_BASENAME), path.join(realDir, MVP_BASENAME))
+  assert.equal(
+    await resolveRealHelperFiles(path.join(realDir, EXTENDED_BASENAME)),
+    null,
+    'a byte-correct sibling that escapes the pinned directory is still refused',
+  )
+  assert.equal(await verifyHelperContent(path.join(realDir, EXTENDED_BASENAME)), 'FAIL')
+})
+
+// ── Internal-target classification (origin, not string prefix) ───────────────────────────────────
+
+test('isInternalTarget: same-origin only — the evil-suffix host is external', () => {
+  assert.equal(isInternalTarget('http://internal.example/api/integration/status', 'http://internal.example'), true)
+  assert.equal(isInternalTarget('http://internal.example:8081/api/x', 'http://internal.example:8081'), true)
+  // The bug: startsWith would call this internal; origin comparison rejects it.
+  assert.equal(isInternalTarget('http://internal.example.evil/api/x', 'http://internal.example'), false)
+  assert.equal(isInternalTarget('http://internal.example:9999/api/x', 'http://internal.example:8081'), false)
+  assert.equal(isInternalTarget('https://internal.example/api/x', 'http://internal.example'), false)
+  assert.equal(isInternalTarget('not a url', 'http://internal.example'), false)
+  // Base with a path prefix: only true subpaths are internal.
+  assert.equal(isInternalTarget('http://h/base/api', 'http://h/base'), true)
+  assert.equal(isInternalTarget('http://h/baseevil/api', 'http://h/base'), false)
+})
+
+test('provenance shim uses origin classification: evil-suffix target latches OTHER', async () => {
+  const { fetchImpl, state } = buildProvenanceFetchImpl({ baseUrl: 'http://internal.example', fetchDelegate: async () => jsonResponse(200) })
+  await fetchImpl('http://internal.example.evil/api/x', {})
+  assert.equal(state.networkTarget, 'OTHER')
+})
+
 test('runDiagnostic on a content mismatch: BLOCKED/HELPER_MISMATCH, zero imports, zero requests', async () => {
   let importCalls = 0
   let fetchCalls = 0
@@ -446,6 +526,49 @@ test('runDiagnostic zero-request closure: verified + imported but no dispatch is
   assert.equal(fields.networkRequestCount, '0')
   assert.equal(fields.executionState, 'DIAGNOSTIC_BLOCKED')
   assert.equal(fields.blockedReasonClass, 'NO_REQUEST')
+})
+
+// A stand-in helper whose requestJson dispatches through the provided fetchImpl N times to whichever
+// targets — used to prove the closure rejects anything but exactly one clean internal request.
+function multiDispatchHelperImport(targets) {
+  return async () => ({
+    requestJson: async (baseUrl, pathname, opts) => {
+      let last
+      for (const t of targets) {
+        last = await opts.fetchImpl(t === 'INTERNAL' ? `${baseUrl}${pathname}` : t, { signal: new AbortController().signal })
+      }
+      return last
+    },
+  })
+}
+
+test('runDiagnostic REQUEST_ANOMALY: two dispatches never read as COMPLETE (externalWrite=true, exit-2 posture)', async () => {
+  const fields = await runDiagnostic({
+    args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    verifyImpl: async () => 'PASS',
+    importImpl: multiDispatchHelperImport(['INTERNAL', 'INTERNAL']),
+    fetchDelegate: async () => jsonResponse(200),
+    timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+  })
+  assert.equal(fields.networkRequestCount, 'OTHER')
+  assert.equal(fields.externalWrite, 'true')
+  assert.equal(fields.executionState, 'DIAGNOSTIC_BLOCKED')
+  assert.equal(fields.blockedReasonClass, 'REQUEST_ANOMALY')
+})
+
+test('runDiagnostic REQUEST_ANOMALY: one dispatch to a non-internal target is not COMPLETE', async () => {
+  const fields = await runDiagnostic({
+    args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    verifyImpl: async () => 'PASS',
+    importImpl: multiDispatchHelperImport(['http://exfil.example/x']),
+    fetchDelegate: async () => jsonResponse(200),
+    timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+  })
+  assert.equal(fields.networkRequestCount, '1')
+  assert.equal(fields.networkTarget, 'OTHER')
+  assert.equal(fields.externalWrite, 'true')
+  assert.equal(fields.executionState, 'DIAGNOSTIC_BLOCKED')
+  assert.equal(fields.blockedReasonClass, 'REQUEST_ANOMALY')
 })
 
 // ── End-to-end runDiagnostic ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Refs #4437 (RC-A diagnostic chain). Owner verdict 2026-07-20: the abort-provenance diagnosis direction is approved, but the next entity-machine probe must be a tested script, not a hand-written wrapper. This PR delivers that script.

## What

`scripts/ops/stock-preparation-rca-abort-provenance.mjs` — standalone read-only diagnostic client (Node builtins only, shipped separately; **no RC-A package republish, no service-side change, no flag/PM2 interaction**):

1. **Runtime identity** (no network): `NODE|BUN|DENO|OTHER` (compat markers checked before Node) + Node major class.
2. **Local timer/abort semantics** (no network): schedules the helper's abort-timer shape (15s `setTimeout` → `controller.abort()`), sleeps ~1.2s, classifies against `process.hrtime.bigint()` → `NORMAL|ABORT_EARLY|CLOCK_ANOMALY`. Abort timer cleared in `finally` on every path.
3. **One internal read-only GET** through the exact-SHA helper's own `fetchImpl` seam (import via `pathToFileURL`, basename allowlist = the two RC-A smoke harnesses). Fixed `timeoutMs: 15000` — no CLI override exists; `--timeout-ms` and any unknown flag fail closed with a usage error. The shim only observes (dispatch count, target latch, helper-signal subscription) and delegates to global fetch unmodified.

Output: one fixed values-free block, every field validated against a closed vocabulary before rendering, token-scrub as a final fail-closed pass. Key new fields: `timerProbeResult`, `abortProvenance=HELPER_SIGNAL|OUTSIDE_HELPER_SIGNAL|NONE|UNAVAILABLE` (deliberately neutral — OUTSIDE does not attribute), `abortErrorNameClass=…|TIMEOUT_ERROR|…` (observation, not sole attribution), `flagTouched=false` constant.

## Verdict absorption

- "structurally cleared" narrowed: only the helper's-own-15s-timer→sub-second-abort path is excluded (script header + docs §1)
- timer cleanup in `finally` (mutation M1 red)
- monotonic elapsed via `hrtime.bigint()`
- `OUTSIDE_HELPER_SIGNAL` neutral naming, no wrapper indictment
- TimeoutError = hint field only
- zero self-reported fields: the script computes and renders everything
- acceptance on CI-parity Node 20: contract tests wired into the prep-line workflow's contract job (`node-version: 20`)

## Verification

- New suite 42/42 (`node --test`); owner-required coverage: 2xx (real helper through the seam), helper-signal abort (real helper timer, `HELPER_SIGNAL`), outside-signal abort (`OUTSIDE_HELPER_SIGNAL`), anomalous runtime (Bun/Deno/major classes), leaked timer (counting hooks); round-2 exact-SHA content binding + NO_REQUEST closure; round-3 realpath symlink binding, origin-based internal target, REQUEST_ANOMALY closure. Regression: extended-smoke 19/19, mvp-smoke 30/30.
- CLI end-to-end (real fetch): refused high port → `TYPE_ERROR`/`CONNECT`/exit 0; `--timeout-ms` → `DIAGNOSTIC_BLOCKED`/`USAGE`/exit 2. (The first E2E check surfaced a real classification gap — Node ≥20 wraps connection failures in `AggregateError`/plain causes — fixed with closed-location code collection + test.)
- Mutation battery: rounds 1-3 = M1-M18, each RED with the intended discriminating test first, clean rerun 42/42 (M18 = intentional equivalent: Node realpaths the caller path to the same module). Covers timer-leak, fixed-timeout call-site, unknown-flag/scrub/vocabulary guards, provenance swap, listener removal, elapsed boundary, exact-SHA digest drift + sibling-dropped, import-despite-mismatch, zero-request-complete, realpath bypass, sibling residence guard, startsWith regression, request-anomaly guard. Details in `docs/development/stock-preparation-rca-abort-provenance-diagnostic-20260720.md`.

## Acknowledged independent gap (untouched)

Existing smokes' `--timeout-ms` is `Number()`-coerced without a strict positive-integer guard — separate hardening slice; left untouched so the exact-SHA package surface stays byte-stable for #4437.

**Not armed** — owner review/GO per RC-A line discipline. Routing of entity-machine results stays owner-court; the script encodes no fast-track condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

