### PR TITLE
feat(automation): FWB activation — production write_approval_form_values action (flag-gated, default OFF)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -630,6 +630,7 @@ jobs:
             tests/integration/multitable-automation-execution-ledger-realdb.test.ts \
             tests/integration/multitable-automation-outbound-intent-realdb.test.ts \
             tests/integration/multitable-fwb-write-action-realdb.test.ts \
+            tests/integration/multitable-fwb-activation-realdb.test.ts \
             tests/integration/multitable-automation-dispatcher-claim-realdb.test.ts \
             tests/integration/multitable-automation-dispatch-loop-realdb.test.ts \
             tests/integration/multitable-automation-outbox-enqueue-realdb.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260720120000_add_write_approval_form_values_automation_action.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260720120000_add_write_approval_form_values_automation_action.ts
@@ -1,0 +1,44 @@
+/**
+ * Migration: `write_approval_form_values` automation action (FWB activation, FWB0 design lock
+ * `approval-form-writeback-fwb0-designlock-20260712.md` D11) — widen the action_type CHECK constraint.
+ * A dedicated restricted action (NOT reusing create_record — lock §1): save-allowed only on
+ * approval.completed rules; execution flag-gated (APPROVAL_FWB_WRITEBACK_ENABLED, default OFF) and
+ * riding the durable outbox + the FWB instance-scoped ledger (`meta_fwb_action_applied`). Pure DDL;
+ * idempotent; mirrors the send_dingtalk_approval_card widening pattern.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export const AUTOMATION_ACTION_TYPES_BEFORE_FWB = [
+  'notify', 'update_field', 'update_record', 'create_record', 'delete_record',
+  'send_webhook', 'send_notification', 'send_email',
+  'send_dingtalk_group_message', 'send_dingtalk_person_message',
+  'lock_record', 'wait_for_callback', 'condition_branch', 'start_approval',
+  'parallel_branch', 'record_click', 'send_dingtalk_approval_card',
+] as const
+
+export const AUTOMATION_ACTION_TYPES_WITH_FWB = [
+  ...AUTOMATION_ACTION_TYPES_BEFORE_FWB,
+  'write_approval_form_values',
+] as const
+
+function quoted(actions: readonly string[]): string {
+  return actions.map((action) => `'${action}'`).join(', ')
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await sql.raw(`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (${quoted(AUTOMATION_ACTION_TYPES_WITH_FWB)}))
+  `).execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await sql.raw(`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (${quoted(AUTOMATION_ACTION_TYPES_BEFORE_FWB)}))
+  `).execute(db)
+}

--- a/packages/core-backend/src/multitable/approval-fwb-activation.ts
+++ b/packages/core-backend/src/multitable/approval-fwb-activation.ts
@@ -1,0 +1,235 @@
+/**
+ * FWB activation — production plumbing shared by the rule-save gate and the executor
+ * (`write_approval_form_values`, FWB0 design lock `approval-form-writeback-fwb0-designlock-20260712.md`,
+ * RATIFIED 2026-07-15).
+ *
+ * This module owns three things and NOTHING execution-order-sensitive:
+ *   1. the runtime flag (default OFF). The lock names no env var (its header only rules "FWB … flag 保持
+ *      OFF，直至完整实现 + 8 场景全链验收通过"), so the NAME here is an implementation choice; the
+ *      POSTURE (default OFF, execution refuses while OFF, no half-durable path) is the lock's.
+ *   2. fail-closed structural validation of the mapping config — the server-side mirror of
+ *      `apps/web/src/approvals/fwbMappingConfig.ts` (same issue codes; the FE model is UX, THIS is the
+ *      unbypassable boundary — its own header says "the server re-validates on save").
+ *   3. the §11 Q6 gate-3 confirmation hash: sha256 over the CANONICALIZED `{templateId, targetSheetId,
+ *      mappings}` triple. Save requires the submitted `confirmationHash` to equal the server-derived one;
+ *      execute re-derives from the CURRENT persisted rule row — so "任一映射项或目标（base/sheet/模板…）
+ *      变化都令确认失效" holds by construction (a config no longer matching its hash denies G4), and the
+ *      recorded confirmation is identifiers+hash only, never values (Q6: 审计只记标识不记值).
+ *
+ * Gate binding (`buildProductionFwbGateChecks`) implements the §11 Q6 four-gate set with the checks the
+ * lock names: G1 admin OR existing `canManageSheetAccess` on the target sheet, G2 source template
+ * readable (both existing creator legs), G3 target sheet writable, G4 recorded confirmation — with the
+ * per-sheet resolution going through `resolveSheetCapabilitiesForUser` as Q6 gate (4) explicitly demands
+ * ("权限复核须显式调用目标 sheet 的 resolveSheetCapabilitiesForUser……不能只读一个全局 capability").
+ */
+import { createHash } from 'node:crypto'
+
+import { canonicalizeConfig } from './automation-action-idempotency'
+import type { FwbFieldMapping } from './approval-form-value-mapping'
+import type { FwbGateChecks } from './approval-fwb-permission-gates'
+import { resolveSheetCapabilitiesForUser } from './sheet-capabilities'
+
+export const FWB_ACTION_TYPE = 'write_approval_form_values'
+
+/**
+ * Runtime flag, default OFF. Execution additionally requires the durable-delivery flag (D9/D10: claim +
+ * record + revision + outbox commit in ONE transaction and ride the durable dispatcher — with durable OFF
+ * the outbox seam is a no-op, so running would silently drop the chained event: no half-durable path).
+ */
+export function isFwbWritebackEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return String(env.APPROVAL_FWB_WRITEBACK_ENABLED ?? '').trim().toLowerCase() === 'true'
+}
+
+const V1_TARGET_TYPES = new Set(['text', 'number', 'date', 'select'])
+const NON_BLANK = /[!-~]/
+
+export type FwbConfigStructuralIssue =
+  | 'empty_config'
+  | 'invalid_mapping_entry'
+  | 'unsupported_target_type'
+  | 'select_options_missing'
+  | 'duplicate_target'
+  | 'confirmation_hash_missing'
+
+/**
+ * Structural (schema-free) validation of a `write_approval_form_values` action config. Mirrors the FE
+ * model's fail-closed rules (`fwbMappingConfig.ts`): empty config, non-v1 target types, select without
+ * options and duplicate targets are all save-rejected. Field EXISTENCE (unknown_form_field /
+ * unknown_target_field) needs the template/sheet schemas, so it lives in the save validator
+ * (automation-service) which has query access. Returns the typed mappings or the first issue.
+ */
+export function normalizeFwbMappings(raw: unknown):
+  | { ok: true; mappings: FwbFieldMapping[] }
+  | { ok: false; issue: FwbConfigStructuralIssue } {
+  if (!Array.isArray(raw) || raw.length === 0) return { ok: false, issue: 'empty_config' }
+  const mappings: FwbFieldMapping[] = []
+  const seenTargets = new Set<string>()
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return { ok: false, issue: 'invalid_mapping_entry' }
+    const m = entry as Record<string, unknown>
+    const formFieldId = typeof m.formFieldId === 'string' ? m.formFieldId.trim() : ''
+    const targetFieldId = typeof m.targetFieldId === 'string' ? m.targetFieldId.trim() : ''
+    const targetType = typeof m.targetType === 'string' ? m.targetType : ''
+    if (!NON_BLANK.test(formFieldId) || !NON_BLANK.test(targetFieldId)) return { ok: false, issue: 'invalid_mapping_entry' }
+    if (!V1_TARGET_TYPES.has(targetType)) return { ok: false, issue: 'unsupported_target_type' }
+    let selectOptions: string[] | undefined
+    if (targetType === 'select') {
+      const opts = Array.isArray(m.selectOptions)
+        ? m.selectOptions.filter((o): o is string => typeof o === 'string' && o.length > 0)
+        : []
+      if (opts.length === 0) return { ok: false, issue: 'select_options_missing' }
+      selectOptions = opts
+    }
+    if (seenTargets.has(targetFieldId)) return { ok: false, issue: 'duplicate_target' }
+    seenTargets.add(targetFieldId)
+    mappings.push({
+      formFieldId,
+      targetFieldId,
+      targetType: targetType as FwbFieldMapping['targetType'],
+      ...(selectOptions ? { selectOptions } : {}),
+    })
+  }
+  return { ok: true, mappings }
+}
+
+export interface FwbConfirmationSubject {
+  /** the approval template the rule listens on (trigger_config.templateId). */
+  templateId: string
+  /** FWB-1 target = the rule's OWN sheet (lock D2) — bound into the hash so a sheet move invalidates. */
+  targetSheetId: string
+  mappings: readonly FwbFieldMapping[]
+}
+
+/**
+ * §11 Q6 gate-3 confirmation hash: sha256 over the canonicalized (deep key-sorted; array order kept —
+ * it is meaning) subject. Deterministic across process restarts and property order.
+ */
+export function deriveFwbConfirmationHash(subject: FwbConfirmationSubject): string {
+  return createHash('sha256')
+    .update(canonicalizeConfig({
+      templateId: subject.templateId,
+      targetSheetId: subject.targetSheetId,
+      mappings: subject.mappings,
+    }))
+    .digest('hex')
+}
+
+/** An action row as persisted on `automation_rules` (top-level pair or `actions[]` entry). */
+interface PersistedActionShape {
+  type?: unknown
+  config?: unknown
+}
+
+/** Collect every FWB action config on a persisted/incoming rule shape (top-level + actions array). */
+export function collectFwbActionConfigs(
+  actionType: string | null | undefined,
+  actionConfig: unknown,
+  actions: readonly PersistedActionShape[] | null | undefined,
+): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = []
+  if (actionType === FWB_ACTION_TYPE && actionConfig && typeof actionConfig === 'object' && !Array.isArray(actionConfig)) {
+    out.push(actionConfig as Record<string, unknown>)
+  }
+  for (const action of actions ?? []) {
+    if (action && action.type === FWB_ACTION_TYPE && action.config && typeof action.config === 'object' && !Array.isArray(action.config)) {
+      out.push(action.config as Record<string, unknown>)
+    }
+  }
+  return out
+}
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+export interface ProductionFwbGateDeps {
+  queryFn: QueryFn
+  /** platform admin check (rbac/service.isAdmin in production wiring). */
+  isAdminFn(userId: string): Promise<boolean>
+  /**
+   * G2 source-readable: BOTH existing creator legs (`approvals:read` + template visibility_scope), the
+   * same pair the approval.completed trigger enforces at save AND fire (lock §2.1: FWB "不新增任何
+   * 检查器，挂进同一对钩子").
+   */
+  canReadTemplateFn(userId: string, templateId: string): Promise<boolean>
+}
+
+/**
+ * The REAL §11 Q6 gate set bound at AutomationService construction. Every check is fail-closed at the
+ * caller (`recheckFwbPermissionGates` counts a thrown check as failed), so none of these needs its own
+ * try/catch. Per-sheet checks go through `resolveSheetCapabilitiesForUser` (Q6 gate 4 — never a global
+ * capability read).
+ */
+export function buildProductionFwbGateChecks(deps: ProductionFwbGateDeps): FwbGateChecks {
+  return {
+    isAdmin: (userId) => deps.isAdminFn(userId),
+    canManageSheetAccess: async (userId, sheetId) => {
+      const resolved = await resolveSheetCapabilitiesForUser(deps.queryFn, sheetId, userId)
+      return resolved.capabilities.canManageSheetAccess
+    },
+    canReadTemplate: (userId, templateId) => deps.canReadTemplateFn(userId, templateId),
+    canWriteSheet: async (userId, sheetId) => {
+      // FWB-1 writes = record CREATE on the target sheet (lock §4 mode:'create').
+      const resolved = await resolveSheetCapabilitiesForUser(deps.queryFn, sheetId, userId)
+      return resolved.capabilities.canCreateRecord
+    },
+    hasRecordedConfirmation: async (ruleId) => {
+      // G4 re-derivation against the CURRENT persisted rule: every FWB action's stored confirmationHash
+      // must equal the hash of its CURRENT normalized config + the rule's CURRENT sheet/template. A rule
+      // with no FWB action, a broken config, or ANY stale hash → false (fail-closed).
+      const res = await deps.queryFn(
+        `SELECT sheet_id, trigger_config, action_type, action_config, actions FROM automation_rules WHERE id = $1`,
+        [ruleId],
+      )
+      const row = res.rows[0] as {
+        sheet_id?: unknown
+        trigger_config?: unknown
+        action_type?: unknown
+        action_config?: unknown
+        actions?: unknown
+      } | undefined
+      if (!row || typeof row.sheet_id !== 'string') return false
+      const triggerConfig = parseJsonObject(row.trigger_config)
+      const templateId = typeof triggerConfig?.templateId === 'string' ? triggerConfig.templateId : ''
+      if (!templateId) return false
+      const configs = collectFwbActionConfigs(
+        typeof row.action_type === 'string' ? row.action_type : null,
+        parseJsonObject(row.action_config),
+        parseJsonArray(row.actions) as PersistedActionShape[] | null,
+      )
+      if (configs.length === 0) return false
+      for (const config of configs) {
+        const normalized = normalizeFwbMappings(config.mappings)
+        if (!normalized.ok) return false
+        const stored = typeof config.confirmationHash === 'string' ? config.confirmationHash : ''
+        const expected = deriveFwbConfirmationHash({
+          templateId,
+          targetSheetId: row.sheet_id,
+          mappings: normalized.mappings,
+        })
+        if (stored !== expected) return false
+      }
+      return true
+    },
+  }
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === 'object' && !Array.isArray(value)) return value as Record<string, unknown>
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as Record<string, unknown>
+    } catch { /* fall through */ }
+  }
+  return null
+}
+
+function parseJsonArray(value: unknown): unknown[] | null {
+  if (Array.isArray(value)) return value
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      if (Array.isArray(parsed)) return parsed
+    } catch { /* fall through */ }
+  }
+  return null
+}

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -24,6 +24,13 @@ export type AutomationActionType =
   // business side effect (no record write / no outbound / no job). Dispatched
   // through the SAME executor path as every other action (no parallel path).
   | 'record_click'
+  // FWB activation (FWB0 lock, RATIFIED 2026-07-15): write approved form values into the rule's OWN
+  // sheet as a NEW record (lock D2 — FWB-1 target = rule.sheet_id, no cross-base, no explicit sheet
+  // target; §11 Q3 rejected same-base explicit targets). Save-allowed ONLY on approval.completed rules
+  // (lock D11: APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES "只放行这一个新动作"). Execution is flag-gated
+  // (APPROVAL_FWB_WRITEBACK_ENABLED, default OFF) and rides the durable outbox + the FWB instance-scoped
+  // idempotency ledger (lock D9: claim + record + revision + outbox = ONE transaction).
+  | 'write_approval_form_values'
 
 export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'update_record',
@@ -41,7 +48,33 @@ export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'start_approval',
   'parallel_branch',
   'record_click',
+  'write_approval_form_values',
 ]
+
+/**
+ * Config shape for write_approval_form_values (FWB activation).
+ *
+ * Deliberately NO target sheet/base fields: FWB-1's target is the rule's own sheet (FWB0 lock D2; §11 Q3
+ * rejected same-base explicit sheet targets — "显式表目标无表单锚点，会重开 W7 Q2 字面目标之争").
+ * Form VALUES never appear here either — the executor reads the immutable `form_snapshot` server-side by
+ * instanceId (lock D4: 表单值永不进事件载荷/动作配置).
+ */
+export interface WriteApprovalFormValuesConfig {
+  /** template form field → target field mappings; v1 types text/number/date/select (lock §4, D5-D8). */
+  mappings: Array<{
+    formFieldId: string
+    targetFieldId: string
+    targetType: 'text' | 'number' | 'date' | 'select'
+    /** required for 'select': the CLOSED allowed-option set (lock D6 — no create-on-write). */
+    selectOptions?: string[]
+  }>
+  /**
+   * §11 Q6 gate-3 explicit confirmation, BOUND to the actual config: the server-derived sha256 of the
+   * canonicalized {templateId, targetSheetId, mappings}. Save rejects a mismatch; execute re-derives from
+   * the persisted row, so any config/target/template change invalidates the confirmation.
+   */
+  confirmationHash: string
+}
 
 /** Config shape for update_record */
 export interface UpdateRecordConfig {

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -1779,147 +1779,6 @@ export class AutomationExecutor {
     return this.executeSingleAction(action, context, undefined)
   }
 
-  /**
-   * FWB activation — `write_approval_form_values` (FWB0 lock, RATIFIED). Writes the approved instance's
-   * immutable `form_snapshot` (D4 — values NEVER ride the event payload or action config) into the rule's
-   * OWN sheet as a NEW record (D2), atomically with the FWB idempotency claim, the create revision and the
-   * chained durable outbox row (D9: ONE transaction). Preconditions fail closed with zero writes:
-   * flag OFF → skipped; durable chain OFF → failed (no half-durable path, D10); no rule-execution identity
-   * (ad-hoc dispatch) → failed (D11); no transaction seam → failed (the withTransaction autocommit
-   * fallback would silently break the four-way atomicity). Gates default to DENY when unbound.
-   */
-  private async executeWriteApprovalFormValuesAction(
-    config: Record<string, unknown>,
-    context: ExecutionContext,
-    identity?: ClassAActionIdentity,
-  ): Promise<AutomationStepResult> {
-    const actionType = 'write_approval_form_values'
-    try {
-      if (!isFwbWritebackEnabled()) {
-        return { actionType, status: 'skipped', output: { reason: 'APPROVAL_FWB_WRITEBACK_ENABLED is OFF' } }
-      }
-      if (!isDurableDeliveryEnabled()) {
-        return {
-          actionType,
-          status: 'failed',
-          error: 'write_approval_form_values requires AUTOMATION_DURABLE_DELIVERY_ENABLED=true — FWB rides the durable chain (FWB0 D9/D10); a half-durable write would silently drop its chained event',
-        }
-      }
-      if (!identity) {
-        return {
-          actionType,
-          status: 'failed',
-          error: 'write_approval_form_values requires the rule-execution identity (structural path + lineage root) — ad-hoc single-action dispatch is out of contract (FWB0 D11)',
-        }
-      }
-      if (!this.deps.transaction) {
-        return {
-          actionType,
-          status: 'failed',
-          error: 'write_approval_form_values requires the transaction seam — the autocommit fallback cannot honour claim+record+revision+outbox atomicity (FWB0 D9)',
-        }
-      }
-      const trig = (context.triggerEvent && typeof context.triggerEvent === 'object' ? context.triggerEvent : {}) as Record<string, unknown>
-      const approval = (trig.approval && typeof trig.approval === 'object' ? trig.approval : {}) as Record<string, unknown>
-      const instanceId = typeof approval.instanceId === 'string' ? approval.instanceId.trim() : ''
-      const templateId = typeof approval.templateId === 'string' ? approval.templateId.trim() : ''
-      const baseEventId = typeof trig.eventId === 'string' && trig.eventId.trim()
-        ? trig.eventId.trim()
-        : (typeof trig._eventId === 'string' ? trig._eventId.trim() : '')
-      if (!instanceId || !templateId || !baseEventId) {
-        return { actionType, status: 'failed', error: 'write_approval_form_values requires an approval completion event carrying instanceId + templateId + a stable eventId' }
-      }
-      // D1 hard gate: writeback fires on APPROVED completions only — regardless of the rule's outcome filter.
-      const transition = (trig.transition && typeof trig.transition === 'object' ? trig.transition : {}) as Record<string, unknown>
-      const outcome = typeof transition.toStatus === 'string' && transition.toStatus
-        ? transition.toStatus
-        : (typeof trig.eventType === 'string' && trig.eventType.startsWith('approval.') ? trig.eventType.slice('approval.'.length) : '')
-      if (outcome !== 'approved') {
-        return { actionType, status: 'skipped', output: { reason: 'fwb_outcome_not_approved' } }
-      }
-      const normalized = normalizeFwbMappings((config as { mappings?: unknown }).mappings)
-      if (!normalized.ok) {
-        return { actionType, status: 'failed', error: `fwb_rejected:mapping_config:${(normalized as { issue: string }).issue}` }
-      }
-      const gates = this.deps.fwbGateChecks ?? DEFAULT_DENY_FWB_GATES
-      // Per-action identity: the SAME §2.1 derivation Class-A uses — structuralPath keeps two
-      // byte-identical FWB actions in one rule distinct (config-hash identity would collapse them).
-      const actionKey = deriveActionKey({ structuralPath: identity.structuralPath, actionType, canonicalConfig: config })
-      const fwbEventId = `${baseEventId}::fwb::${identity.structuralPath}`
-      const automationDepth = (typeof trig._automationDepth === 'number' ? trig._automationDepth : 0) + 1
-
-      const result = await this.withTransaction(context.sheetId, async (query) => {
-        // D4: the immutable form snapshot is the ONLY value source, read server-side inside the txn.
-        const snapRes = await query('SELECT form_snapshot FROM approval_instances WHERE id = $1', [instanceId])
-        const snapRow = snapRes.rows[0] as { form_snapshot?: unknown } | undefined
-        if (!snapRow) throw new Error('fwb_rejected:instance_not_found')
-        const rawSnap = snapRow.form_snapshot
-        const formValues = (rawSnap && typeof rawSnap === 'object' && !Array.isArray(rawSnap)
-          ? rawSnap
-          : (() => { try { return JSON.parse(String(rawSnap ?? '{}')) as Record<string, unknown> } catch { return {} } })()) as Record<string, unknown>
-        const trx = { query, isTransaction: true } as unknown as TransactionalQueryable
-        const seam: FwbRecordWriteSeam = {
-          createRecordWithRevision: async (t, targetSheetId, values) => {
-            const recordId = `rec_${randomUUID()}`
-            await t.query(
-              'INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1, $2, $3::jsonb, 1)',
-              [recordId, targetSheetId, JSON.stringify(values)],
-            )
-            // Same revision contract as executeCreateRecord (OD-2 source names the write entry point;
-            // the write identity is the rule CREATOR — §2.2: system completions carry no human actor).
-            await recordRecordRevision(t.query as AutomationDeps['queryFn'], {
-              sheetId: targetSheetId,
-              recordId,
-              version: 1,
-              action: 'create',
-              source: 'automation',
-              actorId: context.ruleCreatedBy ?? null,
-              changedFieldIds: Object.keys(values),
-              patch: values,
-              snapshot: values,
-            })
-            return recordId
-          },
-          enqueueOutbox: async (t, event) => {
-            await produceAutomationEvent(
-              { query: t.query, isTransaction: true } as unknown as TransactionalQueryable,
-              { eventType: event.eventType, eventId: event.eventId, payload: event.payload, automationDepth: event.automationDepth },
-            )
-          },
-        }
-        return executeWriteApprovalFormValues(trx, {
-          claimId: `fwb_${randomUUID()}`,
-          instanceId,
-          ruleId: context.ruleId,
-          actionKey,
-          gateSubject: {
-            configurerUserId: context.ruleCreatedBy,
-            ruleId: context.ruleId,
-            sourceTemplateId: templateId,
-            targetSheetId: context.sheetId,
-          },
-          mappings: normalized.mappings,
-          formValues,
-          eventId: fwbEventId,
-          automationDepth,
-        }, gates, seam)
-      })
-
-      if (result.status === 'applied') {
-        return { actionType, status: 'success', output: { recordId: result.recordId, sheetId: context.sheetId } }
-      }
-      if (result.status === 'already_applied') {
-        return { actionType, status: 'success', alreadyApplied: true, output: { alreadyApplied: true } }
-      }
-      if (result.reason === 'permission_gates') {
-        return { actionType, status: 'failed', error: `fwb_rejected:permission_gates:${(result.failedGates ?? []).join(',')}` }
-      }
-      return { actionType, status: 'failed', error: 'fwb_rejected:mapping' }
-    } catch (err) {
-      return { actionType, status: 'failed', error: err instanceof Error ? err.message : String(err) }
-    }
-  }
-
   private async executeSingleAction(
     action: AutomationAction,
     context: ExecutionContext,
@@ -2969,6 +2828,151 @@ export class AutomationExecutor {
       return { actionType: 'create_record', status: 'success', output: { recordId, sheetId: targetSheetId } }
     } catch (err) {
       return { actionType: 'create_record', status: 'failed', error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
+  /**
+   * FWB activation — `write_approval_form_values` (FWB0 lock, RATIFIED). Writes the approved instance's
+   * immutable `form_snapshot` (D4 — values NEVER ride the event payload or action config) into the rule's
+   * OWN sheet as a NEW record (D2), atomically with the FWB idempotency claim, the create revision and the
+   * chained durable outbox row (D9: ONE transaction). Preconditions fail closed with zero writes:
+   * flag OFF → skipped; durable chain OFF → failed (no half-durable path, D10); no rule-execution identity
+   * (ad-hoc dispatch) → failed (D11); no transaction seam → failed (the withTransaction autocommit
+   * fallback would silently break the four-way atomicity). Gates default to DENY when unbound.
+   */
+  private async executeWriteApprovalFormValuesAction(
+    config: Record<string, unknown>,
+    context: ExecutionContext,
+    identity?: ClassAActionIdentity,
+  ): Promise<AutomationStepResult> {
+    const actionType = 'write_approval_form_values'
+    try {
+      if (!isFwbWritebackEnabled()) {
+        return { actionType, status: 'skipped', output: { reason: 'APPROVAL_FWB_WRITEBACK_ENABLED is OFF' } }
+      }
+      if (!isDurableDeliveryEnabled()) {
+        return {
+          actionType,
+          status: 'failed',
+          error: 'write_approval_form_values requires AUTOMATION_DURABLE_DELIVERY_ENABLED=true — FWB rides the durable chain (FWB0 D9/D10); a half-durable write would silently drop its chained event',
+        }
+      }
+      if (!identity) {
+        return {
+          actionType,
+          status: 'failed',
+          error: 'write_approval_form_values requires the rule-execution identity (structural path + lineage root) — ad-hoc single-action dispatch is out of contract (FWB0 D11)',
+        }
+      }
+      if (!this.deps.transaction) {
+        return {
+          actionType,
+          status: 'failed',
+          error: 'write_approval_form_values requires the transaction seam — the autocommit fallback cannot honour claim+record+revision+outbox atomicity (FWB0 D9)',
+        }
+      }
+      const trig = (context.triggerEvent && typeof context.triggerEvent === 'object' ? context.triggerEvent : {}) as Record<string, unknown>
+      const approval = (trig.approval && typeof trig.approval === 'object' ? trig.approval : {}) as Record<string, unknown>
+      const instanceId = typeof approval.instanceId === 'string' ? approval.instanceId.trim() : ''
+      const templateId = typeof approval.templateId === 'string' ? approval.templateId.trim() : ''
+      const baseEventId = typeof trig.eventId === 'string' && trig.eventId.trim()
+        ? trig.eventId.trim()
+        : (typeof trig._eventId === 'string' ? trig._eventId.trim() : '')
+      if (!instanceId || !templateId || !baseEventId) {
+        return { actionType, status: 'failed', error: 'write_approval_form_values requires an approval completion event carrying instanceId + templateId + a stable eventId' }
+      }
+      // D1 hard gate: writeback fires on APPROVED completions only — regardless of the rule's outcome filter.
+      const transition = (trig.transition && typeof trig.transition === 'object' ? trig.transition : {}) as Record<string, unknown>
+      const outcome = typeof transition.toStatus === 'string' && transition.toStatus
+        ? transition.toStatus
+        : (typeof trig.eventType === 'string' && trig.eventType.startsWith('approval.') ? trig.eventType.slice('approval.'.length) : '')
+      if (outcome !== 'approved') {
+        return { actionType, status: 'skipped', output: { reason: 'fwb_outcome_not_approved' } }
+      }
+      const normalized = normalizeFwbMappings((config as { mappings?: unknown }).mappings)
+      if (!normalized.ok) {
+        return { actionType, status: 'failed', error: `fwb_rejected:mapping_config:${(normalized as { issue: string }).issue}` }
+      }
+      const gates = this.deps.fwbGateChecks ?? DEFAULT_DENY_FWB_GATES
+      // Per-action identity: the SAME §2.1 derivation Class-A uses — structuralPath keeps two
+      // byte-identical FWB actions in one rule distinct (config-hash identity would collapse them).
+      const actionKey = deriveActionKey({ structuralPath: identity.structuralPath, actionType, canonicalConfig: config })
+      const fwbEventId = `${baseEventId}::fwb::${identity.structuralPath}`
+      const automationDepth = (typeof trig._automationDepth === 'number' ? trig._automationDepth : 0) + 1
+
+      const result = await this.withTransaction(context.sheetId, async (query) => {
+        // D4: the immutable form snapshot is the ONLY value source, read server-side inside the txn.
+        const snapRes = await query('SELECT form_snapshot FROM approval_instances WHERE id = $1', [instanceId])
+        const snapRow = snapRes.rows[0] as { form_snapshot?: unknown } | undefined
+        if (!snapRow) throw new Error('fwb_rejected:instance_not_found')
+        const rawSnap = snapRow.form_snapshot
+        const formValues = (rawSnap && typeof rawSnap === 'object' && !Array.isArray(rawSnap)
+          ? rawSnap
+          : (() => { try { return JSON.parse(String(rawSnap ?? '{}')) as Record<string, unknown> } catch { return {} } })()) as Record<string, unknown>
+        const trx = { query, isTransaction: true } as unknown as TransactionalQueryable
+        const seam: FwbRecordWriteSeam = {
+          createRecordWithRevision: async (t, targetSheetId, values) => {
+            const recordId = `rec_${randomUUID()}`
+            // xbase-write-exempt: FWB-1 writes ONLY the rule's OWN sheet (FWB0 D2 — the config schema has
+            // no targetBase/targetSheet fields, §11 Q3 rejected them), so this create can never retarget
+            // to a config-declared base; the §11 Q6 gate set (incl. canWriteSheet on THIS sheet) ran above.
+            // revision-emitted: recordRecordRevision(action:'create') immediately below, SAME transaction.
+            await t.query(
+              'INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1, $2, $3::jsonb, 1)',
+              [recordId, targetSheetId, JSON.stringify(values)],
+            )
+            // Same revision contract as executeCreateRecord (OD-2 source names the write entry point;
+            // the write identity is the rule CREATOR — §2.2: system completions carry no human actor).
+            await recordRecordRevision(t.query as AutomationDeps['queryFn'], {
+              sheetId: targetSheetId,
+              recordId,
+              version: 1,
+              action: 'create',
+              source: 'automation',
+              actorId: context.ruleCreatedBy ?? null,
+              changedFieldIds: Object.keys(values),
+              patch: values,
+              snapshot: values,
+            })
+            return recordId
+          },
+          enqueueOutbox: async (t, event) => {
+            await produceAutomationEvent(
+              { query: t.query, isTransaction: true } as unknown as TransactionalQueryable,
+              { eventType: event.eventType, eventId: event.eventId, payload: event.payload, automationDepth: event.automationDepth },
+            )
+          },
+        }
+        return executeWriteApprovalFormValues(trx, {
+          claimId: `fwb_${randomUUID()}`,
+          instanceId,
+          ruleId: context.ruleId,
+          actionKey,
+          gateSubject: {
+            configurerUserId: context.ruleCreatedBy,
+            ruleId: context.ruleId,
+            sourceTemplateId: templateId,
+            targetSheetId: context.sheetId,
+          },
+          mappings: normalized.mappings,
+          formValues,
+          eventId: fwbEventId,
+          automationDepth,
+        }, gates, seam)
+      })
+
+      if (result.status === 'applied') {
+        return { actionType, status: 'success', output: { recordId: result.recordId, sheetId: context.sheetId } }
+      }
+      if (result.status === 'already_applied') {
+        return { actionType, status: 'success', alreadyApplied: true, output: { alreadyApplied: true } }
+      }
+      if (result.reason === 'permission_gates') {
+        return { actionType, status: 'failed', error: `fwb_rejected:permission_gates:${(result.failedGates ?? []).join(',')}` }
+      }
+      return { actionType, status: 'failed', error: 'fwb_rejected:mapping' }
+    } catch (err) {
+      return { actionType, status: 'failed', error: err instanceof Error ? err.message : String(err) }
     }
   }
 

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -24,6 +24,11 @@ import type { TransactionalQueryable } from './pg-transaction-guard'
 import { Logger } from '../core/logger'
 import { withAutomationEventId } from './automation-event-dedup'
 import { enqueueRecordEventIfDurable, emitRecordEventIfLegacy } from './automation-producer-emit'
+import { isDurableDeliveryEnabled } from './automation-durable-delivery'
+import { produceAutomationEvent } from './automation-durable-activation'
+import { isFwbWritebackEnabled, normalizeFwbMappings } from './approval-fwb-activation'
+import { executeWriteApprovalFormValues, type FwbRecordWriteSeam } from './approval-fwb-write-action'
+import type { FwbGateChecks } from './approval-fwb-permission-gates'
 import { redactString } from './automation-log-redact'
 import { computeActionFingerprint } from './automation-suspension-service'
 import type { ConditionBranchResumeCursor } from './automation-resume-cursor'
@@ -893,6 +898,19 @@ export interface AutomationDeps {
   notificationService?: Pick<NotificationService, 'send'>
   /** Optional cross-base write quota override (limit/window/store). Omit → process-global default. */
   crossBaseWriteQuota?: CrossBaseWriteQuotaConfig
+  /** FWB activation (§11 Q6): the four-gate set re-checked at execute time. OMITTED ⇒ DEFAULT-DENY —
+   *  a wiring that forgets to bind gates can never silently allow (fail-closed, kills default-allow). */
+  fwbGateChecks?: FwbGateChecks
+}
+
+/** FWB fail-closed default: every gate denies. Production binds real checks at AutomationService
+ *  construction; only a test seam should ever see this deny-all set actually reject. */
+const DEFAULT_DENY_FWB_GATES: FwbGateChecks = {
+  isAdmin: async () => false,
+  canManageSheetAccess: async () => false,
+  canReadTemplate: async () => false,
+  canWriteSheet: async () => false,
+  hasRecordedConfirmation: async () => false,
 }
 
 // ②b cross-base write-gate verdict. `crossBase: false` → same-base, no gate (zero regression).
@@ -1761,6 +1779,147 @@ export class AutomationExecutor {
     return this.executeSingleAction(action, context, undefined)
   }
 
+  /**
+   * FWB activation — `write_approval_form_values` (FWB0 lock, RATIFIED). Writes the approved instance's
+   * immutable `form_snapshot` (D4 — values NEVER ride the event payload or action config) into the rule's
+   * OWN sheet as a NEW record (D2), atomically with the FWB idempotency claim, the create revision and the
+   * chained durable outbox row (D9: ONE transaction). Preconditions fail closed with zero writes:
+   * flag OFF → skipped; durable chain OFF → failed (no half-durable path, D10); no rule-execution identity
+   * (ad-hoc dispatch) → failed (D11); no transaction seam → failed (the withTransaction autocommit
+   * fallback would silently break the four-way atomicity). Gates default to DENY when unbound.
+   */
+  private async executeWriteApprovalFormValuesAction(
+    config: Record<string, unknown>,
+    context: ExecutionContext,
+    identity?: ClassAActionIdentity,
+  ): Promise<AutomationStepResult> {
+    const actionType = 'write_approval_form_values'
+    try {
+      if (!isFwbWritebackEnabled()) {
+        return { actionType, status: 'skipped', output: { reason: 'APPROVAL_FWB_WRITEBACK_ENABLED is OFF' } }
+      }
+      if (!isDurableDeliveryEnabled()) {
+        return {
+          actionType,
+          status: 'failed',
+          error: 'write_approval_form_values requires AUTOMATION_DURABLE_DELIVERY_ENABLED=true — FWB rides the durable chain (FWB0 D9/D10); a half-durable write would silently drop its chained event',
+        }
+      }
+      if (!identity) {
+        return {
+          actionType,
+          status: 'failed',
+          error: 'write_approval_form_values requires the rule-execution identity (structural path + lineage root) — ad-hoc single-action dispatch is out of contract (FWB0 D11)',
+        }
+      }
+      if (!this.deps.transaction) {
+        return {
+          actionType,
+          status: 'failed',
+          error: 'write_approval_form_values requires the transaction seam — the autocommit fallback cannot honour claim+record+revision+outbox atomicity (FWB0 D9)',
+        }
+      }
+      const trig = (context.triggerEvent && typeof context.triggerEvent === 'object' ? context.triggerEvent : {}) as Record<string, unknown>
+      const approval = (trig.approval && typeof trig.approval === 'object' ? trig.approval : {}) as Record<string, unknown>
+      const instanceId = typeof approval.instanceId === 'string' ? approval.instanceId.trim() : ''
+      const templateId = typeof approval.templateId === 'string' ? approval.templateId.trim() : ''
+      const baseEventId = typeof trig.eventId === 'string' && trig.eventId.trim()
+        ? trig.eventId.trim()
+        : (typeof trig._eventId === 'string' ? trig._eventId.trim() : '')
+      if (!instanceId || !templateId || !baseEventId) {
+        return { actionType, status: 'failed', error: 'write_approval_form_values requires an approval completion event carrying instanceId + templateId + a stable eventId' }
+      }
+      // D1 hard gate: writeback fires on APPROVED completions only — regardless of the rule's outcome filter.
+      const transition = (trig.transition && typeof trig.transition === 'object' ? trig.transition : {}) as Record<string, unknown>
+      const outcome = typeof transition.toStatus === 'string' && transition.toStatus
+        ? transition.toStatus
+        : (typeof trig.eventType === 'string' && trig.eventType.startsWith('approval.') ? trig.eventType.slice('approval.'.length) : '')
+      if (outcome !== 'approved') {
+        return { actionType, status: 'skipped', output: { reason: 'fwb_outcome_not_approved' } }
+      }
+      const normalized = normalizeFwbMappings((config as { mappings?: unknown }).mappings)
+      if (!normalized.ok) {
+        return { actionType, status: 'failed', error: `fwb_rejected:mapping_config:${(normalized as { issue: string }).issue}` }
+      }
+      const gates = this.deps.fwbGateChecks ?? DEFAULT_DENY_FWB_GATES
+      // Per-action identity: the SAME §2.1 derivation Class-A uses — structuralPath keeps two
+      // byte-identical FWB actions in one rule distinct (config-hash identity would collapse them).
+      const actionKey = deriveActionKey({ structuralPath: identity.structuralPath, actionType, canonicalConfig: config })
+      const fwbEventId = `${baseEventId}::fwb::${identity.structuralPath}`
+      const automationDepth = (typeof trig._automationDepth === 'number' ? trig._automationDepth : 0) + 1
+
+      const result = await this.withTransaction(context.sheetId, async (query) => {
+        // D4: the immutable form snapshot is the ONLY value source, read server-side inside the txn.
+        const snapRes = await query('SELECT form_snapshot FROM approval_instances WHERE id = $1', [instanceId])
+        const snapRow = snapRes.rows[0] as { form_snapshot?: unknown } | undefined
+        if (!snapRow) throw new Error('fwb_rejected:instance_not_found')
+        const rawSnap = snapRow.form_snapshot
+        const formValues = (rawSnap && typeof rawSnap === 'object' && !Array.isArray(rawSnap)
+          ? rawSnap
+          : (() => { try { return JSON.parse(String(rawSnap ?? '{}')) as Record<string, unknown> } catch { return {} } })()) as Record<string, unknown>
+        const trx = { query, isTransaction: true } as unknown as TransactionalQueryable
+        const seam: FwbRecordWriteSeam = {
+          createRecordWithRevision: async (t, targetSheetId, values) => {
+            const recordId = `rec_${randomUUID()}`
+            await t.query(
+              'INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1, $2, $3::jsonb, 1)',
+              [recordId, targetSheetId, JSON.stringify(values)],
+            )
+            // Same revision contract as executeCreateRecord (OD-2 source names the write entry point;
+            // the write identity is the rule CREATOR — §2.2: system completions carry no human actor).
+            await recordRecordRevision(t.query as AutomationDeps['queryFn'], {
+              sheetId: targetSheetId,
+              recordId,
+              version: 1,
+              action: 'create',
+              source: 'automation',
+              actorId: context.ruleCreatedBy ?? null,
+              changedFieldIds: Object.keys(values),
+              patch: values,
+              snapshot: values,
+            })
+            return recordId
+          },
+          enqueueOutbox: async (t, event) => {
+            await produceAutomationEvent(
+              { query: t.query, isTransaction: true } as unknown as TransactionalQueryable,
+              { eventType: event.eventType, eventId: event.eventId, payload: event.payload, automationDepth: event.automationDepth },
+            )
+          },
+        }
+        return executeWriteApprovalFormValues(trx, {
+          claimId: `fwb_${randomUUID()}`,
+          instanceId,
+          ruleId: context.ruleId,
+          actionKey,
+          gateSubject: {
+            configurerUserId: context.ruleCreatedBy,
+            ruleId: context.ruleId,
+            sourceTemplateId: templateId,
+            targetSheetId: context.sheetId,
+          },
+          mappings: normalized.mappings,
+          formValues,
+          eventId: fwbEventId,
+          automationDepth,
+        }, gates, seam)
+      })
+
+      if (result.status === 'applied') {
+        return { actionType, status: 'success', output: { recordId: result.recordId, sheetId: context.sheetId } }
+      }
+      if (result.status === 'already_applied') {
+        return { actionType, status: 'success', alreadyApplied: true, output: { alreadyApplied: true } }
+      }
+      if (result.reason === 'permission_gates') {
+        return { actionType, status: 'failed', error: `fwb_rejected:permission_gates:${(result.failedGates ?? []).join(',')}` }
+      }
+      return { actionType, status: 'failed', error: 'fwb_rejected:mapping' }
+    } catch (err) {
+      return { actionType, status: 'failed', error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
   private async executeSingleAction(
     action: AutomationAction,
     context: ExecutionContext,
@@ -1819,6 +1978,12 @@ export class AutomationExecutor {
             status: 'failed',
             error: 'start_approval requires execution_mode workflow_job_v1',
           }
+          break
+        case 'write_approval_form_values':
+          // FWB activation (FWB0 lock): approval form-writeback into the rule's own sheet. Flag-gated
+          // (skip while OFF), durable-chain-required, identity-required (D11), transaction-seam-required
+          // (D9) — every precondition fails closed with zero writes.
+          result = await this.executeWriteApprovalFormValuesAction(action.config, context, identity)
           break
         case 'record_click':
           // B1 button field — executor-owned INERT action. Records an auditable

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -35,6 +35,15 @@ import { isValidIanaTimeZone } from './automation-timezone'
 import { DurableSinkBusyError, isDurableDeliveryEnabled } from './automation-durable-delivery'
 import { enqueueRecordEventIfDurable, emitRecordEventIfLegacy } from './automation-producer-emit'
 import { claimEventFiresLease, markEventFiresDone } from './automation-event-fires-lease'
+import {
+  FWB_ACTION_TYPE,
+  buildProductionFwbGateChecks,
+  collectFwbActionConfigs,
+  deriveFwbConfirmationHash,
+  normalizeFwbMappings,
+} from './approval-fwb-activation'
+import { isAdmin as rbacIsAdmin } from '../rbac/service'
+import { resolveSheetCapabilitiesForUser } from './sheet-capabilities'
 
 /** S6 event-delivery lease window: long enough to cover a normal executeRule, short enough that a crashed
  *  worker's row is reclaimable promptly. Only consulted on the durable-delivery (flag ON) lease path. */
@@ -118,12 +127,19 @@ const VALID_TRIGGER_TYPES = new Set([
 // start_approval → approval.completed → start_approval loop (Q4a).
 const APPROVAL_COMPLETED_TRIGGER = 'approval.completed'
 const APPROVAL_COMPLETED_OUTCOMES: ReadonlySet<string> = new Set(['approved', 'rejected', 'revoked', 'cancelled'])
-const APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES: ReadonlySet<string> = new Set([
+const APPROVAL_COMPLETED_SIDE_EFFECT_ACTION_TYPES: ReadonlySet<string> = new Set([
   'send_notification',
   'send_webhook',
   'send_email',
   'send_dingtalk_group_message',
   'send_dingtalk_person_message',
+])
+// FWB activation (FWB0 lock D11): write_approval_form_values joins the approval.completed allowlist ONLY —
+// task_created keeps the side-effect-only set (spreading the shared base below, NOT this set, so the FWB
+// action cannot leak onto pending-task rules).
+const APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES: ReadonlySet<string> = new Set([
+  ...APPROVAL_COMPLETED_SIDE_EFFECT_ACTION_TYPES,
+  FWB_ACTION_TYPE,
 ])
 const APPROVAL_COMPLETION_TRIGGER_EVENT_TYPES: readonly string[] = [
   'approval.approved',
@@ -140,7 +156,7 @@ const APPROVAL_TASK_CREATED_TRIGGER = 'approval.task_created'
 // on every other trigger because its recipient comes from the pending-task event.
 const APPROVAL_CARD_ACTION_TYPE = 'send_dingtalk_approval_card'
 const APPROVAL_TASK_CREATED_ALLOWED_ACTION_TYPES: ReadonlySet<string> = new Set([
-  ...APPROVAL_COMPLETED_ALLOWED_ACTION_TYPES,
+  ...APPROVAL_COMPLETED_SIDE_EFFECT_ACTION_TYPES,
   APPROVAL_CARD_ACTION_TYPE,
 ])
 
@@ -865,6 +881,15 @@ export class AutomationService {
       }),
       fetchFn,
       notificationService,
+      // FWB activation (§11 Q6): the REAL four-gate set, re-checked at execute time inside the write
+      // transaction. Test seams inject their own; production always binds these.
+      fwbGateChecks: buildProductionFwbGateChecks({
+        queryFn,
+        isAdminFn: (userId) => rbacIsAdmin(userId),
+        canReadTemplateFn: async (userId, templateId) =>
+          (await this.approvalCompletedCreatorAuthorized(userId)) &&
+          (await this.approvalTemplateVisibleToCreator(templateId, userId)),
+      }),
     }
     this.executor = new AutomationExecutor(deps)
     this.logService = new AutomationLogService()
@@ -1034,6 +1059,19 @@ export class AutomationService {
       input.createdBy ?? null,
     )
     if (approvalCompletedError) throw new AutomationRuleValidationError(approvalCompletedError)
+
+    // FWB activation (FWB0 §11 Q6): placement + D1 outcome lock + mapping/schema/confirmation + creator
+    // authority — all fail-closed at save, independent of the runtime flag.
+    const fwbSaveError = await this.validateFwbActionAtSave(
+      sheetId,
+      input.triggerType,
+      (input.triggerConfig ?? null) as Record<string, unknown> | null,
+      input.actionType,
+      (input.actionConfig ?? null) as Record<string, unknown> | null,
+      actionsForValidation,
+      input.createdBy ?? null,
+    )
+    if (fwbSaveError) throw new AutomationRuleValidationError(fwbSaveError)
 
     const approvalTaskCreatedError = await this.validateApprovalTaskCreatedRuleAtSave(
       input.triggerType,
@@ -1346,6 +1384,17 @@ export class AutomationService {
         )
         if (approvalTaskCreatedError) throw new AutomationRuleValidationError(approvalTaskCreatedError)
       }
+      // FWB activation: the same fail-closed save gate for every resulting shape of a partial update.
+      const fwbUpdateError = await this.validateFwbActionAtSave(
+        existingForApproval.sheet_id,
+        nextTriggerType,
+        nextTriggerConfig,
+        nextActionType,
+        (nextActionConfig ?? null) as Record<string, unknown> | null,
+        approvalActions,
+        existingForApproval.created_by,
+      )
+      if (fwbUpdateError) throw new AutomationRuleValidationError(fwbUpdateError)
     }
 
     if (Object.keys(updates).length === 0) return this.getRule(ruleId)
@@ -1854,6 +1903,102 @@ export class AutomationService {
     this.subscriptionIds = []
     this.scheduler.destroy()
     logger.info('AutomationService shut down')
+  }
+
+  /**
+   * FWB activation save gate (FWB0 lock, RATIFIED; §11 Q6). Applies IFF the rule carries a
+   * `write_approval_form_values` action (top-level or nested). Fail-closed, flag-independent:
+   *   - placement: approval.completed rules ONLY (D11 — the allowlist above admits it there alone);
+   *   - D1: an EXPLICIT trigger_config.outcomes must be exactly ["approved"] (absent = allowed at save;
+   *     the executor additionally hard-gates on the approved outcome, so a broader filter can never
+   *     write back a rejection);
+   *   - mapping structure via `normalizeFwbMappings` (empty/duplicate/unsupported/select-without-options);
+   *   - target-schema truth: every targetFieldId exists on the RULE's sheet, its meta_fields.type equals
+   *     the declared targetType, and select options are ⊆ the field's configured option values (D6
+   *     closed vocabulary — `select_option_not_on_field`);
+   *   - Q6 gate 3: the submitted confirmationHash equals the server-derived hash over
+   *     {templateId, targetSheetId, normalized mappings} — any drift invalidates the confirmation;
+   *   - Q6 gate 1 at save: the creator is a platform admin OR holds canManageSheetAccess on the target
+   *     sheet (re-checked at execute time by the bound production gates).
+   */
+  private async validateFwbActionAtSave(
+    sheetId: string,
+    triggerType: string,
+    triggerConfig: Record<string, unknown> | null,
+    actionType: string,
+    actionConfig: Record<string, unknown> | null,
+    nestedActions: AutomationAction[],
+    createdBy: string | null,
+  ): Promise<string | null> {
+    const configs = collectFwbActionConfigs(actionType, actionConfig, nestedActions)
+    if (configs.length === 0) return null
+    if (triggerType !== APPROVAL_COMPLETED_TRIGGER) {
+      return `action ${FWB_ACTION_TYPE} is only allowed on approval.completed rules (FWB0 D11)`
+    }
+    const templateIdRaw = (triggerConfig ?? {}).templateId
+    const templateId = typeof templateIdRaw === 'string' ? templateIdRaw.trim() : ''
+    // templateId presence/existence/visibility are already enforced by validateApprovalCompletedRuleAtSave
+    // (which runs first); an empty id here would have thrown there.
+    const outcomesRaw = (triggerConfig ?? {}).outcomes
+    if (outcomesRaw !== undefined) {
+      const ok = Array.isArray(outcomesRaw) && outcomesRaw.length === 1 && outcomesRaw[0] === 'approved'
+      if (!ok) {
+        return `${FWB_ACTION_TYPE} requires trigger_config.outcomes = ["approved"] (FWB0 D1 — writeback fires on approved completions only)`
+      }
+    }
+    for (const config of configs) {
+      const normalized = normalizeFwbMappings(config.mappings)
+      if (!normalized.ok) {
+        return `${FWB_ACTION_TYPE} mapping config invalid: ${(normalized as { issue: string }).issue}`
+      }
+      // target-schema truth on the rule's OWN sheet (FWB-1 target, lock D2)
+      const targetIds = normalized.mappings.map((m) => m.targetFieldId)
+      const fieldRes = await this.queryFn(
+        'SELECT id, type, property FROM meta_fields WHERE sheet_id = $1 AND id = ANY($2::text[])',
+        [sheetId, targetIds],
+      )
+      const byId = new Map<string, { type: string; property: unknown }>()
+      for (const row of fieldRes.rows as Array<{ id: string; type: string; property: unknown }>) {
+        byId.set(row.id, { type: row.type, property: row.property })
+      }
+      for (const m of normalized.mappings) {
+        const field = byId.get(m.targetFieldId)
+        if (!field) return `${FWB_ACTION_TYPE} mapping invalid: unknown_target_field`
+        if (field.type !== m.targetType) return `${FWB_ACTION_TYPE} mapping invalid: target_type_mismatch`
+        if (m.targetType === 'select') {
+          const property = typeof field.property === 'string'
+            ? (() => { try { return JSON.parse(field.property as string) as Record<string, unknown> } catch { return {} } })()
+            : (field.property && typeof field.property === 'object' ? field.property as Record<string, unknown> : {})
+          const options = Array.isArray((property as { options?: unknown }).options)
+            ? ((property as { options: unknown[] }).options)
+            : []
+          const allowed = new Set(
+            options
+              .map((o) => (o && typeof o === 'object' ? (o as { value?: unknown }).value : undefined))
+              .filter((v): v is string => typeof v === 'string'),
+          )
+          for (const opt of m.selectOptions ?? []) {
+            if (!allowed.has(opt)) return `${FWB_ACTION_TYPE} mapping invalid: select_option_not_on_field`
+          }
+        }
+      }
+      // Q6 gate 3: recorded confirmation = hash over the canonicalized subject
+      const stored = typeof config.confirmationHash === 'string' ? config.confirmationHash : ''
+      const expected = deriveFwbConfirmationHash({ templateId, targetSheetId: sheetId, mappings: normalized.mappings })
+      if (stored !== expected) {
+        return `${FWB_ACTION_TYPE} actionConfig.confirmationHash must match the server-derived confirmation hash (FWB0 §11 Q6 gate 3)`
+      }
+    }
+    // Q6 gate 1 at save: platform admin OR canManageSheetAccess on the target sheet
+    if (!createdBy) return `${FWB_ACTION_TYPE} rules require an authenticated creator`
+    const admin = await rbacIsAdmin(createdBy).catch(() => false)
+    if (!admin) {
+      const resolved = await resolveSheetCapabilitiesForUser(this.queryFn, sheetId, createdBy).catch(() => null)
+      if (!resolved || !resolved.capabilities.canManageSheetAccess) {
+        return `${FWB_ACTION_TYPE} rules require the creator to be a platform admin or hold canManageSheetAccess on the target sheet (FWB0 §11 Q6 gate 1)`
+      }
+    }
+    return null
   }
 
   /**

--- a/packages/core-backend/tests/integration/multitable-fwb-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-fwb-activation-realdb.test.ts
@@ -1,0 +1,601 @@
+/**
+ * FWB activation — production `write_approval_form_values` wiring (real DB, real service surfaces).
+ *
+ * Drives the REAL boundaries, not seams:
+ *   - rule save through `AutomationService.createRule` (the unbypassable persistence gate): placement,
+ *     D1 outcome lock, mapping-config negatives (empty/duplicate/unsupported/select/unknown-field),
+ *     Q6 confirmation-hash binding, Q6 creator-authority gates — all typed rejections, all while the
+ *     FWB flag is OFF (save validates independently of the runtime flag);
+ *   - execution through the REAL `AutomationService.handleApprovalCompletionTrigger` → `executeRule` →
+ *     `AutomationExecutor` chain against a REAL approval instance (ApprovalProductService template +
+ *     createApproval + dispatchAction(approve) — the form_snapshot is the real one, lock D4);
+ *   - flag-OFF skip (zero writes), half-durable refusal (FWB ON + durable OFF → failed, zero writes),
+ *     happy path (record + revision + FWB ledger claim + outbox row, ONE commit), redelivery net-once
+ *     under a NEW eventId (the §2.3 case the event-level ledger cannot catch) with a NEW-instance
+ *     positive control, and the V4 revoked-authority leg (save-time authority stripped → execute-time
+ *     gate recheck rejects, zero writes);
+ *   - executor-level goldens that need seam control: injected-failure atomicity (post-handler abort →
+ *     all four rows vanish; no-injection control → all four exist), unbound-gates default-deny,
+ *     missing-transaction-seam refusal, ad-hoc dispatch refusal, and the structural-path identity
+ *     discriminator (two byte-identical FWB actions in ONE rule → two records, distinct action_keys).
+ *
+ * Two-point wired (plugin-tests.yml multitable real-DB step + vitest.config.ts exclude).
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { db } from '../../src/db/db'
+import { eventBus as integrationEventBus } from '../../src/integration/events/event-bus'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+import { AutomationExecutor, type AutomationDeps, type AutomationRule as ExecutorRule } from '../../src/multitable/automation-executor'
+import { deriveFwbConfirmationHash } from '../../src/multitable/approval-fwb-activation'
+import type { FwbGateChecks } from '../../src/multitable/approval-fwb-permission-gates'
+import { invalidateUserPerms } from '../../src/rbac/service'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_fwbact_${TS}`
+const SHEET_ID = `sheet_fwbact_${TS}`
+const F_TITLE = `fld_fwbact_title_${TS}`
+const F_AMOUNT = `fld_fwbact_amount_${TS}`
+const F_STATUS = `fld_fwbact_status_${TS}`
+const CREATOR = `u_fwbact_creator_${TS}`
+const REQUESTER = `u_fwbact_req_${TS}`
+const APPROVER = `u_fwbact_appr_${TS}`
+
+const q = (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)
+const queryFn = ((sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)) as never
+
+let svc: AutomationService
+let approvals: ApprovalProductService
+let templateId = ''
+const ruleIds: string[] = []
+
+const MAPPINGS = [
+  { formFieldId: 'summary', targetFieldId: F_TITLE, targetType: 'text' as const },
+  { formFieldId: 'amount', targetFieldId: F_AMOUNT, targetType: 'number' as const },
+]
+const confirmation = (mappings: unknown = MAPPINGS) =>
+  deriveFwbConfirmationHash({ templateId, targetSheetId: SHEET_ID, mappings: mappings as never })
+
+function setFlags(fwb: boolean, durable: boolean) {
+  if (fwb) process.env.APPROVAL_FWB_WRITEBACK_ENABLED = 'true'
+  else delete process.env.APPROVAL_FWB_WRITEBACK_ENABLED
+  if (durable) process.env.AUTOMATION_DURABLE_DELIVERY_ENABLED = 'true'
+  else delete process.env.AUTOMATION_DURABLE_DELIVERY_ENABLED
+}
+
+function approvalTemplateRequest() {
+  return {
+    key: `fwbact-${TS}`,
+    name: 'FWB Activation Template',
+    formSchema: {
+      fields: [
+        { id: 'summary', type: 'text', label: 'Summary', required: true },
+        { id: 'amount', type: 'number', label: 'Amount', required: true },
+      ],
+    },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: 'Start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          name: 'Approver',
+          config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }] },
+        },
+        { key: 'end', type: 'end', name: 'End', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+  }
+}
+
+async function startInstance(formData: Record<string, unknown>): Promise<string> {
+  const dto = await approvals.createApproval(
+    { templateId, formData },
+    { userId: REQUESTER, userName: REQUESTER },
+  )
+  return (dto as { id: string }).id
+}
+
+async function approveInstance(instanceId: string): Promise<void> {
+  await approvals.dispatchAction(instanceId, { action: 'approve', comment: 'ok' } as never, { userId: APPROVER, userName: APPROVER })
+}
+
+/** Synthetic completion event mirroring the producer shape the durable adapter redelivers. */
+function completionEvent(instanceId: string, eventId: string) {
+  return {
+    version: 1,
+    source: 'approval-product',
+    eventType: 'approval.approved',
+    eventId,
+    occurredAt: new Date().toISOString(),
+    approval: { instanceId, templateId, status: 'approved' },
+    transition: { action: 'approve', fromStatus: 'pending', toStatus: 'approved', fromVersion: 1, toVersion: 2, nodeKey: 'approval_1' },
+    requester: { id: REQUESTER, name: REQUESTER },
+    actor: null, // §2.2: auto/system completion has no human actor — the write identity is the rule creator
+  } as never
+}
+
+async function stateFor(instanceId: string, ruleId: string) {
+  const rec = await q('SELECT id, data FROM meta_records WHERE sheet_id = $1 ORDER BY created_at', [SHEET_ID])
+  const led = await q('SELECT action_key FROM meta_fwb_action_applied WHERE instance_id = $1 AND rule_id = $2', [instanceId, ruleId])
+  return { records: rec.rows as Array<{ id: string; data: Record<string, unknown> }>, claims: led.rows.length }
+}
+
+async function outboxCountLike(prefix: string): Promise<number> {
+  const r = await q('SELECT COUNT(*)::int AS c FROM meta_automation_outbox WHERE event_id LIKE $1', [`${prefix}%`])
+  return Number((r.rows[0] as { c: number }).c)
+}
+
+async function revisionCountFor(recordId: string): Promise<number> {
+  const r = await q('SELECT COUNT(*)::int AS c FROM meta_record_revisions WHERE record_id = $1 AND action = $2 AND source = $3', [recordId, 'create', 'automation'])
+  return Number((r.rows[0] as { c: number }).c)
+}
+
+async function lastExecution(ruleId: string): Promise<{ status: string; steps: Array<Record<string, unknown>> } | null> {
+  const r = await q(
+    'SELECT status, steps FROM multitable_automation_executions WHERE rule_id = $1 ORDER BY triggered_at DESC LIMIT 1',
+    [ruleId],
+  )
+  const row = r.rows[0] as { status?: string; steps?: unknown } | undefined
+  if (!row) return null
+  const steps = typeof row.steps === 'string' ? JSON.parse(row.steps) as Array<Record<string, unknown>> : (row.steps as Array<Record<string, unknown>> ?? [])
+  return { status: String(row.status), steps }
+}
+
+async function waitForExecutionCount(ruleId: string, expected: number, timeoutMs = 6000): Promise<number> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const r = await q('SELECT COUNT(*)::int AS c FROM multitable_automation_executions WHERE rule_id = $1', [ruleId])
+    const count = Number((r.rows[0] as { c: number }).c)
+    if (count >= expected || Date.now() > deadline) return count
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+}
+
+describeIfDatabase('FWB activation — production write_approval_form_values wiring (real DB)', () => {
+  beforeAll(async () => {
+    setFlags(false, false)
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'FWB Act Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'FWB Act Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_TITLE, SHEET_ID, 'Title', 'text', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_AMOUNT, SHEET_ID, 'Amount', 'number', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [
+      F_STATUS, SHEET_ID, 'Status', 'select', JSON.stringify({ options: [{ value: 'A' }, { value: 'B' }] }), 3,
+    ])
+    await q(
+      `INSERT INTO permissions (code, name, description)
+       VALUES ('approvals:read', 'Approvals Read', 'FWBACT test'),
+              ('approvals:write', 'Approvals Write', 'FWBACT test'),
+              ('approvals:act', 'Approvals Act', 'FWBACT test')
+       ON CONFLICT (code) DO NOTHING`,
+    )
+    for (const uid of [CREATOR, REQUESTER, APPROVER]) {
+      await q(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+         VALUES ($1, $2, $1, 'x', 'user', '[]'::jsonb, TRUE, $3)
+         ON CONFLICT (id) DO UPDATE SET is_active = TRUE, is_admin = EXCLUDED.is_admin`,
+        [uid, `${uid}@fwbact.test`, uid === CREATOR],
+      )
+    }
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:read') ON CONFLICT DO NOTHING`, [CREATOR])
+    // rbac/service.isAdmin reads user_roles(role_id='admin') — the platform-admin leg Q6 G1 binds to.
+    await q(`INSERT INTO roles (id, name) VALUES ('admin', 'admin') ON CONFLICT (id) DO NOTHING`).catch(() => {})
+    await q(`INSERT INTO user_roles (user_id, role_id) VALUES ($1, 'admin') ON CONFLICT DO NOTHING`, [CREATOR])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:write') ON CONFLICT DO NOTHING`, [REQUESTER])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:act') ON CONFLICT DO NOTHING`, [APPROVER])
+
+    approvals = new ApprovalProductService()
+    const template = await approvals.createTemplate(approvalTemplateRequest() as never)
+    templateId = (template as { id: string }).id
+    await approvals.publishTemplate(templateId, { policy: { allowRevoke: true } } as never)
+
+    svc = new AutomationService(integrationEventBus, db as never, queryFn)
+  })
+
+  afterAll(async () => {
+    setFlags(false, false)
+    try { svc?.shutdown() } catch { /* noop */ }
+    for (const ruleId of ruleIds) {
+      await q('DELETE FROM automation_rules WHERE id = $1', [ruleId]).catch(() => {})
+      await q('DELETE FROM multitable_automation_executions WHERE rule_id = $1', [ruleId]).catch(() => {})
+    }
+    await q('DELETE FROM meta_fwb_action_applied WHERE rule_id = ANY($1::text[])', [ruleIds]).catch(() => {})
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  // ── Save gate (flag OFF throughout — validation is independent of the runtime flag) ─────────────
+
+  test('save gate: placement, D1 outcome lock, mapping negatives, confirmation hash, creator authority', async () => {
+    const fwbBase = {
+      name: 'fwb rule',
+      triggerType: 'approval.completed',
+      triggerConfig: { templateId },
+      actionType: 'write_approval_form_values',
+      createdBy: CREATOR,
+    }
+    // placement: FWB on a record trigger is rejected regardless of config validity
+    await expect(svc.createRule(SHEET_ID, {
+      ...fwbBase,
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionConfig: { mappings: MAPPINGS, confirmationHash: confirmation() },
+    } as never)).rejects.toThrow(/only allowed on approval\.completed rules/)
+    // D1: outcomes must be exactly ['approved']
+    await expect(svc.createRule(SHEET_ID, {
+      ...fwbBase,
+      triggerConfig: { templateId, outcomes: ['approved', 'rejected'] },
+      actionConfig: { mappings: MAPPINGS, confirmationHash: confirmation() },
+    } as never)).rejects.toThrow(/outcomes = \["approved"\]/)
+    // empty config
+    await expect(svc.createRule(SHEET_ID, {
+      ...fwbBase,
+      actionConfig: { mappings: [], confirmationHash: confirmation([]) },
+    } as never)).rejects.toThrow(/empty_config/)
+    // duplicate target
+    const dup = [MAPPINGS[0], { ...MAPPINGS[1], targetFieldId: F_TITLE, targetType: 'text' as const }]
+    await expect(svc.createRule(SHEET_ID, {
+      ...fwbBase,
+      actionConfig: { mappings: dup, confirmationHash: confirmation(dup) },
+    } as never)).rejects.toThrow(/duplicate_target/)
+    // non-v1 target type
+    const badType = [{ formFieldId: 'summary', targetFieldId: F_TITLE, targetType: 'attachment' }]
+    await expect(svc.createRule(SHEET_ID, {
+      ...fwbBase,
+      actionConfig: { mappings: badType, confirmationHash: confirmation(badType) },
+    } as never)).rejects.toThrow(/unsupported_target_type/)
+    // select without options
+    const selNoOpts = [{ formFieldId: 'summary', targetFieldId: F_STATUS, targetType: 'select' }]
+    await expect(svc.createRule(SHEET_ID, {
+      ...fwbBase,
+      actionConfig: { mappings: selNoOpts, confirmationHash: confirmation(selNoOpts) },
+    } as never)).rejects.toThrow(/select_options_missing/)
+    // select option outside the field's configured set (D6: closed vocabulary)
+    const selBadOpt = [{ formFieldId: 'summary', targetFieldId: F_STATUS, targetType: 'select', selectOptions: ['NOT_ON_FIELD'] }]
+    await expect(svc.createRule(SHEET_ID, {
+      ...fwbBase,
+      actionConfig: { mappings: selBadOpt, confirmationHash: confirmation(selBadOpt) },
+    } as never)).rejects.toThrow(/select_option_not_on_field/)
+    // unknown target field
+    const unknownTarget = [{ formFieldId: 'summary', targetFieldId: 'fld_does_not_exist', targetType: 'text' }]
+    await expect(svc.createRule(SHEET_ID, {
+      ...fwbBase,
+      actionConfig: { mappings: unknownTarget, confirmationHash: confirmation(unknownTarget) },
+    } as never)).rejects.toThrow(/unknown_target_field/)
+    // type mismatch (number field declared text)
+    const mismatch = [{ formFieldId: 'amount', targetFieldId: F_AMOUNT, targetType: 'text' }]
+    await expect(svc.createRule(SHEET_ID, {
+      ...fwbBase,
+      actionConfig: { mappings: mismatch, confirmationHash: confirmation(mismatch) },
+    } as never)).rejects.toThrow(/target_type_mismatch/)
+    // Q6 gate 3: confirmation hash must match the server-derived hash of the ACTUAL config
+    await expect(svc.createRule(SHEET_ID, {
+      ...fwbBase,
+      actionConfig: { mappings: MAPPINGS, confirmationHash: 'deadbeef' },
+    } as never)).rejects.toThrow(/confirmationHash must match/)
+    // Q6 gate 1: non-admin creator without canManageSheetAccess (REQUESTER holds approvals:write only —
+    // grant approvals:read so the earlier trigger legs pass and THIS gate is the one that rejects)
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:read') ON CONFLICT DO NOTHING`, [REQUESTER])
+    await expect(svc.createRule(SHEET_ID, {
+      ...fwbBase,
+      createdBy: REQUESTER,
+      actionConfig: { mappings: MAPPINGS, confirmationHash: confirmation() },
+    } as never)).rejects.toThrow(/canManageSheetAccess/)
+  })
+
+  test('save gate positive control: a valid FWB rule saves while the flag is OFF', async () => {
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'fwb writeback',
+      triggerType: 'approval.completed',
+      triggerConfig: { templateId, outcomes: ['approved'] },
+      actionType: 'write_approval_form_values',
+      actionConfig: { mappings: MAPPINGS, confirmationHash: confirmation() },
+      createdBy: CREATOR,
+    } as never)
+    ruleIds.push((rule as { id: string }).id)
+    expect((rule as { id: string }).id).toBeTruthy()
+  })
+
+  // ── Execution through the REAL trigger → executeRule → executor chain ───────────────────────────
+
+  test('flag OFF → step skipped, ZERO writes; FWB ON + durable OFF → failed (no half-durable), ZERO writes; both ON → record+revision+claim+outbox in one commit; net-once redelivery; new-instance positive control', async () => {
+    const ruleId = ruleIds[0]
+    const instanceId = await startInstance({ summary: 'FWB run', amount: 42 })
+    await approveInstance(instanceId) // real approval; real immutable form_snapshot (lock D4)
+
+    // 1) flag OFF (default): the rule fires (trigger side is live) but the FWB step SKIPS — zero writes.
+    setFlags(false, false)
+    await svc.handleApprovalCompletionTrigger(completionEvent(instanceId, `evt_fwbact_${TS}_off`))
+    await waitForExecutionCount(ruleId, 1)
+    let exec = await lastExecution(ruleId)
+    expect(exec?.steps?.[0]?.status).toBe('skipped')
+    let state = await stateFor(instanceId, ruleId)
+    expect(state.records.length).toBe(0)
+    expect(state.claims).toBe(0)
+
+    // 2) FWB ON + durable OFF: the lock ties FWB to the durable chain (§9-0/D10) — hard fail, zero writes.
+    setFlags(true, false)
+    await svc.handleApprovalCompletionTrigger(completionEvent(instanceId, `evt_fwbact_${TS}_hd`))
+    await waitForExecutionCount(ruleId, 2)
+    exec = await lastExecution(ruleId)
+    expect(exec?.steps?.[0]?.status).toBe('failed')
+    expect(String(exec?.steps?.[0]?.error ?? '')).toMatch(/AUTOMATION_DURABLE_DELIVERY_ENABLED/)
+    state = await stateFor(instanceId, ruleId)
+    expect(state.records.length).toBe(0)
+    expect(state.claims).toBe(0)
+
+    // 3) both ON: applied — record + create-revision + FWB ledger claim + chained outbox row, one commit.
+    setFlags(true, true)
+    const evtOn = `evt_fwbact_${TS}_on`
+    // REPLACE-seam observability: while durable is ON the chained record event must NOT ride the legacy bus.
+    let legacyChainedEmits = 0
+    const unsubscribeProbe = integrationEventBus.subscribe('multitable.record.created', (payload) => {
+      const p = payload as Record<string, unknown>
+      if (typeof p._eventId === 'string' && p._eventId.startsWith(`${evtOn}::fwb::`)) legacyChainedEmits += 1
+    })
+    await svc.handleApprovalCompletionTrigger(completionEvent(instanceId, evtOn))
+    await waitForExecutionCount(ruleId, 3)
+    exec = await lastExecution(ruleId)
+    expect(exec?.steps?.[0]?.status).toBe('success')
+    state = await stateFor(instanceId, ruleId)
+    expect(state.records.length).toBe(1)
+    expect(state.claims).toBe(1)
+    expect(state.records[0].data).toMatchObject({ [F_TITLE]: 'FWB run', [F_AMOUNT]: 42 })
+    expect(await revisionCountFor(state.records[0].id)).toBe(1)
+    expect(await outboxCountLike(`${evtOn}::fwb::`)).toBe(1)
+    expect(legacyChainedEmits).toBe(0) // REPLACE, not keep-both
+    if (typeof unsubscribeProbe === 'function') unsubscribeProbe()
+
+    // 4) redelivery under a NEW eventId (same instance): the event-level ledger passes, the FWB
+    //    instance-scoped claim dedups — net-once, no new record/claim/outbox (lock §2.3 / §9-1).
+    const evtDup = `evt_fwbact_${TS}_dup`
+    await svc.handleApprovalCompletionTrigger(completionEvent(instanceId, evtDup))
+    await waitForExecutionCount(ruleId, 4)
+    exec = await lastExecution(ruleId)
+    expect(exec?.steps?.[0]?.status).toBe('success')
+    expect(exec?.steps?.[0]?.alreadyApplied).toBe(true)
+    state = await stateFor(instanceId, ruleId)
+    expect(state.records.length).toBe(1)
+    expect(state.claims).toBe(1)
+    expect(await outboxCountLike(`${evtDup}::fwb::`)).toBe(0)
+
+    // 5) positive control (V1): a DIFFERENT instance MUST produce a second record — proving the
+    //    "exactly one" assertions above discriminate.
+    const instanceB = await startInstance({ summary: 'FWB second', amount: 7 })
+    await approveInstance(instanceB)
+    await svc.handleApprovalCompletionTrigger(completionEvent(instanceB, `evt_fwbact_${TS}_b`))
+    await waitForExecutionCount(ruleId, 5)
+    const stateB = await stateFor(instanceB, ruleId)
+    expect(stateB.claims).toBe(1)
+    const allRecords = await q('SELECT COUNT(*)::int AS c FROM meta_records WHERE sheet_id = $1', [SHEET_ID])
+    expect(Number((allRecords.rows[0] as { c: number }).c)).toBe(2)
+    setFlags(false, false)
+  })
+
+  test('V4 revoked authority: creator stripped AFTER save → execute-time Q6 recheck rejects, zero writes (real production gate binding)', async () => {
+    const ruleId = ruleIds[0]
+    const instanceC = await startInstance({ summary: 'revoked', amount: 1 })
+    await approveInstance(instanceC)
+    const before = await waitForExecutionCount(ruleId, 0)
+    // Strip the creator's platform-admin role — with no sheet grants either, Q6 G1 (admin OR
+    // canManageSheetAccess) and G3 (canCreateRecord) both fail at the REAL bound gates. The per-sheet
+    // legs read permissions through the platform-wide RBAC cache (rbac/service, 60s TTL — the same
+    // staleness bound EVERY authorization surface in this codebase has), so the test invalidates the
+    // creator's cache entry exactly as a real revocation flow does; in production a revocation takes
+    // effect within the cache TTL.
+    await q(`DELETE FROM user_roles WHERE user_id = $1 AND role_id = 'admin'`, [CREATOR])
+    await q('UPDATE users SET is_admin = FALSE WHERE id = $1', [CREATOR])
+    invalidateUserPerms(CREATOR)
+    try {
+      setFlags(true, true)
+      await svc.handleApprovalCompletionTrigger(completionEvent(instanceC, `evt_fwbact_${TS}_rev`))
+      await waitForExecutionCount(ruleId, before + 1)
+      const exec = await lastExecution(ruleId)
+      expect(exec?.steps?.[0]?.status).toBe('failed')
+      expect(String(exec?.steps?.[0]?.error ?? '')).toMatch(/fwb_rejected:permission_gates/)
+      const state = await stateFor(instanceC, ruleId)
+      expect(state.claims).toBe(0)
+      const count = await q('SELECT COUNT(*)::int AS c FROM meta_records WHERE sheet_id = $1', [SHEET_ID])
+      expect(Number((count.rows[0] as { c: number }).c)).toBe(2) // unchanged from the previous test
+    } finally {
+      setFlags(false, false)
+      await q(`INSERT INTO user_roles (user_id, role_id) VALUES ($1, 'admin') ON CONFLICT DO NOTHING`, [CREATOR])
+      await q('UPDATE users SET is_admin = TRUE WHERE id = $1', [CREATOR])
+      invalidateUserPerms(CREATOR)
+    }
+  })
+
+  // ── Executor-level goldens that require seam control (still real DB, real executor, real FWB core) ──
+
+  function executorRule(ruleId: string, actions: Array<{ type: string; config: Record<string, unknown> }>): ExecutorRule {
+    return {
+      id: ruleId,
+      name: 'fwb executor golden',
+      sheetId: SHEET_ID,
+      trigger: { type: 'approval.completed', config: { templateId } } as never,
+      actions: actions as never,
+      enabled: true,
+      createdBy: CREATOR,
+      createdAt: new Date().toISOString(),
+    }
+  }
+
+  function triggerPayload(instanceId: string, eventId: string): Record<string, unknown> {
+    return {
+      sheetId: SHEET_ID,
+      recordId: '',
+      data: {},
+      actorId: null,
+      _automationDepth: 0,
+      eventId,
+      eventType: 'approval.approved',
+      approval: { instanceId, templateId },
+      transition: { action: 'approve', fromStatus: 'pending', toStatus: 'approved' },
+      requester: { id: REQUESTER, name: REQUESTER },
+    }
+  }
+
+  const allowAllGates: FwbGateChecks = {
+    isAdmin: async () => true,
+    canManageSheetAccess: async () => true,
+    canReadTemplate: async () => true,
+    canWriteSheet: async () => true,
+    hasRecordedConfirmation: async () => true,
+  }
+
+  const realTransaction: NonNullable<AutomationDeps['transaction']> = async (handler) =>
+    poolManager.get().transaction(async ({ query }) => handler({
+      query: async (sqlText: string, params?: unknown[]) => {
+        const result = await query(sqlText, params)
+        return {
+          rows: Array.isArray((result as { rows?: unknown[] }).rows) ? (result as { rows: unknown[] }).rows : [],
+          rowCount: typeof (result as { rowCount?: number }).rowCount === 'number' ? (result as { rowCount: number }).rowCount : undefined,
+        }
+      },
+    }))
+
+  function buildExecutor(overrides: Partial<AutomationDeps> & { omitTransaction?: boolean; omitGates?: boolean } = {}) {
+    const deps: AutomationDeps = {
+      eventBus: { emit: () => {}, subscribe: () => () => {} } as never,
+      queryFn: (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params) as never,
+      ...(overrides.omitTransaction ? {} : { transaction: overrides.transaction ?? realTransaction }),
+      ...(overrides.omitGates ? {} : { fwbGateChecks: overrides.fwbGateChecks ?? allowAllGates }),
+    }
+    return new AutomationExecutor(deps)
+  }
+
+  const fwbAction = () => ({
+    type: 'write_approval_form_values',
+    config: { mappings: MAPPINGS, confirmationHash: confirmation() },
+  })
+
+  test('ATOMICITY golden: injected post-handler abort erases record + revision + claim + outbox together; no-injection control commits all four', async () => {
+    setFlags(true, true)
+    try {
+      const instanceD = await startInstance({ summary: 'atomic', amount: 3 })
+      await approveInstance(instanceD)
+      const ruleId = `rule_fwbact_atomic_${TS}`
+      let inject = true
+      const injectingTransaction: NonNullable<AutomationDeps['transaction']> = async (handler) =>
+        realTransaction(async (client) => {
+          const result = await handler(client)
+          if (inject) throw new Error('injected post-handler abort (before COMMIT)')
+          return result
+        })
+      const executor = buildExecutor({ transaction: injectingTransaction })
+
+      const beforeCount = Number(((await q('SELECT COUNT(*)::int AS c FROM meta_records WHERE sheet_id = $1', [SHEET_ID])).rows[0] as { c: number }).c)
+      const run1 = await executor.execute(executorRule(ruleId, [fwbAction()]), triggerPayload(instanceD, `evt_fwbact_${TS}_atomic1`))
+      expect(run1.steps[0]?.status).toBe('failed')
+      expect(String(run1.steps[0]?.error ?? '')).toMatch(/injected post-handler abort/)
+      // all four gone together: no record, no revision (checked via record absence), no claim, no outbox
+      const afterAbort = Number(((await q('SELECT COUNT(*)::int AS c FROM meta_records WHERE sheet_id = $1', [SHEET_ID])).rows[0] as { c: number }).c)
+      expect(afterAbort).toBe(beforeCount)
+      expect((await stateFor(instanceD, ruleId)).claims).toBe(0)
+      expect(await outboxCountLike(`evt_fwbact_${TS}_atomic1::fwb::`)).toBe(0)
+
+      // positive control on the SAME identity: without injection the retry commits all four together
+      inject = false
+      const run2 = await executor.execute(executorRule(ruleId, [fwbAction()]), triggerPayload(instanceD, `evt_fwbact_${TS}_atomic2`))
+      expect(run2.steps[0]?.status).toBe('success')
+      const state = await stateFor(instanceD, ruleId)
+      expect(state.claims).toBe(1)
+      const created = (run2.steps[0]?.output as { recordId?: string })?.recordId ?? ''
+      expect(created).toBeTruthy()
+      expect(await revisionCountFor(created)).toBe(1)
+      expect(await outboxCountLike(`evt_fwbact_${TS}_atomic2::fwb::`)).toBe(1)
+      await q('DELETE FROM meta_records WHERE id = $1', [created])
+      await q('DELETE FROM meta_record_revisions WHERE record_id = $1', [created])
+      await q('DELETE FROM meta_fwb_action_applied WHERE rule_id = $1', [ruleId])
+    } finally {
+      setFlags(false, false)
+    }
+  })
+
+  test('fail-closed defaults: unbound gates → permission_gates reject; missing transaction seam → refusal; ad-hoc dispatch (no identity) → refusal — all with zero writes', async () => {
+    setFlags(true, true)
+    try {
+      const instanceE = await startInstance({ summary: 'failclosed', amount: 9 })
+      await approveInstance(instanceE)
+      const before = Number(((await q('SELECT COUNT(*)::int AS c FROM meta_records WHERE sheet_id = $1', [SHEET_ID])).rows[0] as { c: number }).c)
+
+      // (a) NO fwbGateChecks injected → DEFAULT_DENY_FWB_GATES: every leg denies (kills a default-allow mutant)
+      const noGates = buildExecutor({ omitGates: true })
+      const runA = await noGates.execute(executorRule(`rule_fwbact_nogates_${TS}`, [fwbAction()]), triggerPayload(instanceE, `evt_fwbact_${TS}_ng`))
+      expect(runA.steps[0]?.status).toBe('failed')
+      expect(String(runA.steps[0]?.error ?? '')).toMatch(/fwb_rejected:permission_gates/)
+
+      // (b) NO transaction seam → hard refusal BEFORE any statement (withTransaction autocommit fallback hazard)
+      const noTxn = buildExecutor({ omitTransaction: true })
+      const runB = await noTxn.execute(executorRule(`rule_fwbact_notxn_${TS}`, [fwbAction()]), triggerPayload(instanceE, `evt_fwbact_${TS}_nt`))
+      expect(runB.steps[0]?.status).toBe('failed')
+      expect(String(runB.steps[0]?.error ?? '')).toMatch(/transaction seam/)
+
+      // (c) ad-hoc single-action dispatch carries no Class-A identity → out of contract (lock D11)
+      const executor = buildExecutor({})
+      const runC = await executor.runSingleAction(fwbAction() as never, {
+        executionId: `axe_${randomUUID()}`,
+        ruleId: `rule_fwbact_adhoc_${TS}`,
+        sheetId: SHEET_ID,
+        recordId: '',
+        recordData: {},
+        ruleCreatedBy: CREATOR,
+        actorId: null,
+        triggerEvent: triggerPayload(instanceE, `evt_fwbact_${TS}_ah`),
+      })
+      expect(runC.status).toBe('failed')
+      expect(String(runC.error ?? '')).toMatch(/rule-execution identity/)
+
+      const after = Number(((await q('SELECT COUNT(*)::int AS c FROM meta_records WHERE sheet_id = $1', [SHEET_ID])).rows[0] as { c: number }).c)
+      expect(after).toBe(before)
+      expect((await stateFor(instanceE, `rule_fwbact_nogates_${TS}`)).claims).toBe(0)
+    } finally {
+      setFlags(false, false)
+    }
+  })
+
+  test('structural-path identity: two byte-identical FWB actions in ONE rule claim DISTINCT action_keys and both apply (config-hash identity would dedup one)', async () => {
+    setFlags(true, true)
+    try {
+      const instanceF = await startInstance({ summary: 'twins', amount: 5 })
+      await approveInstance(instanceF)
+      const ruleId = `rule_fwbact_twins_${TS}`
+      const executor = buildExecutor({})
+      const run = await executor.execute(
+        executorRule(ruleId, [fwbAction(), fwbAction()]), // byte-identical configs
+        triggerPayload(instanceF, `evt_fwbact_${TS}_tw`),
+      )
+      expect(run.steps[0]?.status).toBe('success')
+      expect(run.steps[1]?.status).toBe('success')
+      expect(run.steps[1]?.alreadyApplied).not.toBe(true)
+      const led = await q('SELECT action_key FROM meta_fwb_action_applied WHERE instance_id = $1 AND rule_id = $2', [instanceF, ruleId])
+      expect(led.rows.length).toBe(2)
+      const keys = led.rows.map((r) => (r as { action_key: string }).action_key)
+      expect(new Set(keys).size).toBe(2) // distinct structural paths → distinct keys
+      const ids = run.steps.map((s) => (s.output as { recordId?: string })?.recordId).filter(Boolean) as string[]
+      expect(new Set(ids).size).toBe(2)
+      for (const id of ids) {
+        await q('DELETE FROM meta_record_revisions WHERE record_id = $1', [id])
+        await q('DELETE FROM meta_records WHERE id = $1', [id])
+      }
+      await q('DELETE FROM meta_fwb_action_applied WHERE rule_id = $1', [ruleId])
+    } finally {
+      setFlags(false, false)
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/approval-card-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/approval-card-automation-action-migration.test.ts
@@ -6,10 +6,12 @@ import {
 } from '../../src/db/migrations/zzzz20260705150000_add_send_dingtalk_approval_card_automation_action'
 
 describe('send_dingtalk_approval_card automation action migration (A-2b)', () => {
-  it('keeps the latest database action constraint in sync with app-level action types', () => {
-    // This migration widens chk_automation_action_type to the CURRENT ALL_ACTION_TYPES — so a future
-    // action type added to the app without a DB migration trips this drift guard RED.
+  it('keeps this constraint in sync with app-level action types except those added by later migrations', () => {
+    // No longer the LATEST migration (write_approval_form_values widened the constraint afterwards —
+    // see fwb-automation-action-migration.test.ts for the live "latest in sync" guard).
+    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['write_approval_form_values'])
     for (const actionType of ALL_ACTION_TYPES) {
+      if (ADDED_BY_LATER_MIGRATIONS.has(actionType)) continue
       expect(AUTOMATION_ACTION_TYPES_WITH_APPROVAL_CARD).toContain(actionType)
     }
   })

--- a/packages/core-backend/tests/unit/delete-record-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/delete-record-automation-action-migration.test.ts
@@ -10,7 +10,7 @@ describe('delete_record automation action migration (Phase C2)', () => {
     // No longer the LATEST migration (record_click widened the constraint afterwards — see
     // record-click-automation-action-migration.test.ts for the live "latest in sync" guard). Every
     // app-level action type except the ones introduced by a strictly-later migration must be here.
-    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['record_click', 'send_dingtalk_approval_card'])
+    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['record_click', 'send_dingtalk_approval_card', 'write_approval_form_values'])
     for (const actionType of ALL_ACTION_TYPES) {
       if (ADDED_BY_LATER_MIGRATIONS.has(actionType)) continue
       expect(AUTOMATION_ACTION_TYPES_WITH_DELETE_RECORD).toContain(actionType)

--- a/packages/core-backend/tests/unit/fwb-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/fwb-automation-action-migration.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { ALL_ACTION_TYPES } from '../../src/multitable/automation-actions'
+import {
+  AUTOMATION_ACTION_TYPES_BEFORE_FWB,
+  AUTOMATION_ACTION_TYPES_WITH_FWB,
+} from '../../src/db/migrations/zzzz20260720120000_add_write_approval_form_values_automation_action'
+
+describe('write_approval_form_values automation action migration (FWB activation)', () => {
+  it('keeps the latest database action constraint in sync with app-level action types', () => {
+    // This migration widens chk_automation_action_type to the CURRENT ALL_ACTION_TYPES — so a future
+    // action type added to the app without a DB migration trips this drift guard RED.
+    for (const actionType of ALL_ACTION_TYPES) {
+      expect(AUTOMATION_ACTION_TYPES_WITH_FWB).toContain(actionType)
+    }
+  })
+
+  it('adds write_approval_form_values on top of the prior approval-card action set, and nothing else', () => {
+    expect(AUTOMATION_ACTION_TYPES_WITH_FWB).toContain('write_approval_form_values')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_FWB).not.toContain('write_approval_form_values')
+    expect(AUTOMATION_ACTION_TYPES_WITH_FWB.filter((a) => a !== 'write_approval_form_values'))
+      .toEqual([...AUTOMATION_ACTION_TYPES_BEFORE_FWB])
+  })
+
+  it('rolls back only the FWB widening (send_dingtalk_approval_card + record_click remain)', () => {
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_FWB).toContain('send_dingtalk_approval_card')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_FWB).toContain('record_click')
+  })
+})

--- a/packages/core-backend/tests/unit/parallel-branch-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/parallel-branch-automation-action-migration.test.ts
@@ -10,7 +10,7 @@ describe('parallel_branch automation action migration (A6-3-4 / W3-1)', () => {
     // This is no longer the LATEST migration (delete_record widened the constraint afterwards — see
     // `delete-record-automation-action-migration.test.ts` for the live "latest in sync" guard). Every
     // app-level action type except the ones introduced by a strictly-later migration must already be here.
-    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['delete_record', 'record_click', 'send_dingtalk_approval_card'])
+    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['delete_record', 'record_click', 'send_dingtalk_approval_card', 'write_approval_form_values'])
     for (const actionType of ALL_ACTION_TYPES) {
       if (ADDED_BY_LATER_MIGRATIONS.has(actionType)) continue
       expect(AUTOMATION_ACTION_TYPES_WITH_PARALLEL_BRANCH).toContain(actionType)

--- a/packages/core-backend/tests/unit/record-click-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/record-click-automation-action-migration.test.ts
@@ -9,7 +9,7 @@ describe('record_click automation action migration (B1-a1)', () => {
   it('keeps this constraint in sync with app-level action types except those added by later migrations', () => {
     // No longer the LATEST migration (send_dingtalk_approval_card widened the constraint afterwards —
     // see approval-card-automation-action-migration.test.ts for the live "latest in sync" guard).
-    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['send_dingtalk_approval_card'])
+    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['send_dingtalk_approval_card', 'write_approval_form_values'])
     for (const actionType of ALL_ACTION_TYPES) {
       if (ADDED_BY_LATER_MIGRATIONS.has(actionType)) continue
       expect(AUTOMATION_ACTION_TYPES_WITH_RECORD_CLICK).toContain(actionType)

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -480,6 +480,11 @@ export default defineConfig({
       'tests/integration/multitable-automation-outbound-intent-realdb.test.ts',
       // FWB-1 slice ③ write_approval_form_values same-txn composition — real-DB. Two-point wiring.
       'tests/integration/multitable-fwb-write-action-realdb.test.ts',
+      // FWB activation — production write_approval_form_values wiring (save gate + real trigger chain +
+      // atomicity/net-once/fail-closed goldens): real Postgres only — excluded HERE so it cannot
+      // skip-green in the no-DB lane, whole-file wired into `Run multitable real-DB integration` in
+      // plugin-tests.yml. Two-point wiring.
+      'tests/integration/multitable-fwb-activation-realdb.test.ts',
       // P2 durable-delivery S2-a claim engine / fence-CAS — real-DB constructed-concurrency (zombie/SKIP
       // LOCKED). Excluded HERE so it cannot skip-green in the no-DB lane; whole-file wired into
       // plugin-tests.yml. Two-point wiring.


### PR DESCRIPTION
Closes the owner P1「FWB 尚无生产调用链」: users can now actually configure 审批表单值写回 — the action type is registered, save-validated fail-closed, executed through the real rule chain, and the §11 Q6 four-gate set is production-bound.

**Grounding**: every decision cites its FWB0 lock D-number in code (D1 approved-only / D2 own-sheet target / D4 immutable form_snapshot, values never in config/payload / D6 select closed vocabulary / D9 one-transaction atomicity / D10 no half-durable path / D11 approval.completed-only placement + identity requirement / §11 Q3 no explicit targets / §11 Q6 gates + confirmation hash).

**Wiring**: allowlist restructure keeps FWB OFF task_created (shared base set — the naive spread would have leaked it); save gate in createRule AND updateRule (partial-update shapes covered); executor case with fail-closed preconditions (flag/durable/identity/txn-seam, gates default-DENY); chained event via produceAutomationEvent (REPLACE — never the legacy bus); claim key = §2.1 deriveActionKey over identity.structuralPath (byte-identical twins stay distinct).

**Evidence**: real-DB spec 8/8 (save-gate 11 negatives+positive · flag matrix · four-way single-commit + injected-abort atomicity · net-once redelivery + NEW-instance positive control · V4 revoked-authority through the REAL bound gates · fail-closed defaults ×3 · structural-path twins). Mutations 3/3 killed at exact head: full default-allow gates → fail-closed golden RED; config-hash identity (structuralPath dropped) → 5 RED incl. twins; confirmation-hash save check disabled → save-gate RED. tsc 0; migration + automation-v1 227/227; full unit suite running (will confirm on the thread). Two-point wired.

**Honest scope**: FE rule-editor exposure (action-type option + mapping panel reusing fwbMappingConfig) = named follow-up slice; boot needs no new wiring (the trigger chain + durable adapters already reach executeRule; gates bind at AutomationService construction). Flags stay OFF. Salvage note: built across an agent session-limit death — the wip checkpoint commit precedes the real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)