### PR TITLE
fix(directory): B1 — a transfer freeze is a deliberate abort, not a sync failure

### DIFF
--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -4555,10 +4555,30 @@ async function pollAsyncRun(integrationId: string, runId: string, token: number)
   const run = items.find((item) => item.id === runId)
   if (run && run.status !== 'running') {
     stopRunPolling()
+    // DISPLAY TRUTH (B1 rework): the success summary is an ALLOWLIST — reachable only by an
+    // explicit 'completed'. Every other terminal value, including ones this build has never
+    // heard of, must fall through to the fail-safe `else` and say the sync did NOT complete.
+    // Blocklisting the known-bad states instead ("not running, not failed, no errorMessage
+    // ⇒ 完成") is exactly how the deliberate 'aborted' state rendered as SUCCESS: the admin
+    // is not going to retry on their own, and the message never corrects itself.
     if (run.status === 'failed' || run.errorMessage) {
       setStatus(`后台同步失败（运行 ${runId}）：${run.errorMessage || '未知错误'}`, 'error')
-    } else {
+    } else if (run.status === 'aborted') {
+      // 'aborted' is written by exactly one backend path — markSyncAbortedByFreeze, i.e. the
+      // apply-time recheck found an active org transfer and rolled the apply back (deliberate
+      // state, no alert, error_message stays NULL). The reason lives in the run's `meta`, which
+      // this runs payload does not carry, so the wording is derived from the status alone.
+      setStatus(
+        `后台同步已中止（运行 ${runId}）：该集成的来源正被进行中的组织迁移冻结，本次同步未写入任何数据。请先完成或取消该迁移，然后重新发起同步。`,
+        'error',
+      )
+    } else if (run.status === 'completed') {
       setStatus(buildAsyncRunSummary(run))
+    } else {
+      setStatus(
+        `后台同步以未识别的终态结束（运行 ${runId}，状态 ${run.status}），无法确认是否成功，请前往下方运行记录核对后再决定是否重试。`,
+        'error',
+      )
     }
     await refreshAfterDirectorySync(integrationId)
     return

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -7413,6 +7413,98 @@ describe('DirectoryManagementView', () => {
       }
     })
 
+    // B1 rework (owner P2 on #4498): the backend now ends a freeze-aborted run as
+    // status='aborted' with error_message NULL. The old terminal branch was a BLOCKLIST
+    // ("not running, not failed, no errorMessage ⇒ 后台同步已完成"), so this deliberate
+    // abort — nothing synced, the source is frozen by an active org transfer — was shown
+    // to the admin as SUCCESS. Nobody retries a success, and the message never self-corrects.
+    it('stops polling at terminal aborted and says the sync was ABORTED by an active org transfer — never the success line', async () => {
+      vi.useFakeTimers()
+      try {
+        mockInitialLoad(createIntegration())
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(
+          { ok: true, data: { accepted: true, runId: 'run-bg-1', integrationId: 'dir-1' } },
+          202,
+        ))
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(createRunsPayload([createBackgroundRun('running')])))
+        // Exactly what markSyncAbortedByFreeze leaves behind: 'aborted', errorMessage NULL,
+        // no stats (the apply rolled back). The abortReason/transferId live in the run's
+        // `meta`, which the /runs payload this view reads does not carry.
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(createRunsPayload([
+          createBackgroundRun('aborted'),
+        ])))
+        mockPostSyncRefresh(createRunsPayload([createBackgroundRun('aborted')]))
+
+        mountView()
+        await flushUi()
+
+        findButton('后台同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flushUi(8)
+
+        await vi.advanceTimersByTimeAsync(5000)
+        await flushUi(8)
+
+        // The surfaced message tells the operator (a) it was aborted, (b) why — an active org
+        // transfer froze the source, (c) that nothing was written, (d) the resolution.
+        expect(container?.textContent).toContain('后台同步已中止（运行 run-bg-1）')
+        expect(container?.textContent).toContain('正被进行中的组织迁移冻结')
+        expect(container?.textContent).toContain('未写入任何数据')
+        expect(container?.textContent).toContain('请先完成或取消该迁移')
+        // THE REGRESSION ITSELF: an aborted run must never render as a completed one.
+        expect(container?.textContent).not.toContain('后台同步已完成')
+
+        const settledCallCount = apiFetchMock.mock.calls.length
+        await vi.advanceTimersByTimeAsync(30_000)
+        await flushUi(4)
+        expect(apiFetchMock.mock.calls.length).toBe(settledCallCount)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    // B1 rework fail-safe: the success branch is an ALLOWLIST on 'completed'. Any terminal
+    // status this build does not recognise — a future backend state, a typo, a replayed old
+    // row — must fall through to the "cannot confirm" line, never to 后台同步已完成.
+    it('an UNRECOGNISED terminal status must not take the success branch (fail-safe default)', async () => {
+      vi.useFakeTimers()
+      try {
+        mockInitialLoad(createIntegration())
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(
+          { ok: true, data: { accepted: true, runId: 'run-bg-1', integrationId: 'dir-1' } },
+          202,
+        ))
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(createRunsPayload([createBackgroundRun('running')])))
+        // Deliberately a status no branch knows about, carrying the exact shape the old
+        // blocklist treated as success: not running, not failed, errorMessage NULL.
+        apiFetchMock.mockResolvedValueOnce(createJsonResponse(createRunsPayload([
+          createBackgroundRun('quarantined_by_future_backend'),
+        ])))
+        mockPostSyncRefresh(createRunsPayload([createBackgroundRun('quarantined_by_future_backend')]))
+
+        mountView()
+        await flushUi()
+
+        findButton('后台同步')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        await flushUi(8)
+
+        await vi.advanceTimersByTimeAsync(5000)
+        await flushUi(8)
+
+        // Non-vacuous: assert the fail-safe line is actually surfaced, not merely that the
+        // success line is absent (an empty status would satisfy absence alone).
+        expect(container?.textContent).toContain('后台同步以未识别的终态结束（运行 run-bg-1，状态 quarantined_by_future_backend）')
+        expect(container?.textContent).toContain('无法确认是否成功')
+        expect(container?.textContent).not.toContain('后台同步已完成')
+
+        const settledCallCount = apiFetchMock.mock.calls.length
+        await vi.advanceTimersByTimeAsync(30_000)
+        await flushUi(4)
+        expect(apiFetchMock.mock.calls.length).toBe(settledCallCount)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it('clears the poll timer on unmount — no fetch ever fires after the view is gone', async () => {
       vi.useFakeTimers()
       try {

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -3158,6 +3158,55 @@ async function markSyncFailure(integrationId: string, runId: string, message: st
   await deliverDirectorySyncFailureAlert({ integrationId, integrationName, runId, message })
 }
 
+/**
+ * Terminal run state for a DELIBERATE abort: the apply-time freeze recheck found an active
+ * org transfer and rolled the apply back (see `DirectorySyncFrozenByTransferError`).
+ *
+ * A frozen source is a deliberate transfer state, not an outage — every other surface in this
+ * lane already says so (the scheduler skips quietly, the route answers a deliberate 409 that
+ * must never page monitoring). Routing this through `markSyncFailure` contradicted all of them
+ * and, worse, was not self-healing: `directory_integrations.last_error` is only cleared inside
+ * the SUCCESSFUL apply transaction, and the freeze is exactly what prevents a successful apply —
+ * so a multi-day transfer (the designed steady state) left the integration reading "errored"
+ * for its whole duration and fed `countConsecutiveFailedRuns` escalation.
+ *
+ * What this leaves behind instead:
+ *  - the run reaches a TERMINAL, non-'running' state, so the partial unique index frees the
+ *    lease immediately and nothing has to wait for stale-lease reclaim;
+ *  - status is 'aborted', a distinct value: `countConsecutiveFailedRuns` filters
+ *    `status IN ('completed','failed')`, so a deliberate abort can never drive failure
+ *    escalation, and no migration is needed (the column is bare `text`, no CHECK constraint);
+ *  - `error_message` stays NULL — the admin run panel styles that field as an error;
+ *    the reason lives in `meta` (which no summary/toast surface reads);
+ *  - `directory_integrations` is NOT touched at all: no `last_error`, no `last_sync_at` bump
+ *    (nothing was synced);
+ *  - no `directory_sync_alerts` 'sync_failed' row and therefore no failure-alert delivery.
+ *
+ * Unlike `markSyncFailure` this UPDATE IS guarded on `status = 'running'`: if the lease was
+ * reclaimed while this run was alive, the row already carries the reclaimer's truthful
+ * `failed`/orphaned record and this run no longer owns it — overwriting it with a softer
+ * 'aborted' would erase a real liveness incident. Either way the row is terminal and the
+ * lease is free.
+ */
+async function markSyncAbortedByFreeze(runId: string, transferId: string): Promise<void> {
+  await query(
+    `UPDATE directory_sync_runs
+        SET status = 'aborted',
+            finished_at = NOW(),
+            meta = COALESCE(meta, '{}'::jsonb) || jsonb_build_object(
+              'abortReason', 'frozen_by_org_transfer',
+              'transferId', $2::text
+            ),
+            updated_at = NOW()
+      WHERE id = $1
+        AND status = 'running'`,
+    [runId, transferId],
+  )
+  logger.info(
+    `Directory sync run ${runId} aborted: source frozen by active org transfer ${transferId} (deliberate state, not a failure)`,
+  )
+}
+
 export function buildUniqueLocalUserMatchMap(
   rows: LocalUserRow[],
   readKey: (row: LocalUserRow) => string,
@@ -4298,6 +4347,14 @@ export async function syncDirectoryIntegration(
       autoAdmissionOnboardingPackets,
     }
   } catch (error) {
+    // A freeze that linearized first is a DELIBERATE abort, not an integration failure —
+    // the apply already rolled back, so there is nothing to alert on. Take the terminal
+    // abort path (see `markSyncAbortedByFreeze`) and re-throw the error UNCHANGED, so the
+    // route's deliberate 409 mapping and the scheduler's quiet info-skip are untouched.
+    if (error instanceof DirectorySyncFrozenByTransferError) {
+      await markSyncAbortedByFreeze(runId, error.transferId)
+      throw error
+    }
     const message = readErrorMessage(error, 'Directory sync failed')
     await markSyncFailure(integrationId, runId, message)
     throw error

--- a/packages/core-backend/tests/integration/directory-org-transfer-source-freeze.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-org-transfer-source-freeze.db.test.ts
@@ -601,6 +601,62 @@ describeIfDatabase('Transfer MVP T2 — §12.2 source freeze during an active or
     expect(await countConsecutiveFailedRuns(source.integrationId)).toBe(2)
   })
 
+  it('B1 abort never softens a RECLAIMED run: a reclaimer-written failed row survives the freeze abort', async () => {
+    // The abort UPDATE is guarded on `status = 'running'` for a reason the docblock states but
+    // nothing pinned: if the lease was reclaimed while this run was alive-but-silent, the row
+    // already carries the reclaimer's truthful `failed` record, and this run no longer owns it —
+    // softening that to 'aborted' would erase a real liveness incident. Dropping the guard used
+    // to leave the whole suite green.
+    const source = await seedIntegrationWithLiveAccount('b1-reclaimed-src')
+    const target = await seedIntegrationWithLiveAccount('b1-reclaimed-dst')
+
+    await withHolder(async (holder, holderPid) => {
+      // Freeze writer holds the shared source lock uncommitted, so the real sync parks in its
+      // apply transaction (entry check still saw no freeze) — a deterministic barrier.
+      await holder.query('BEGIN')
+      await holder.query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED')
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        sourceSyncFreezeLockKey(source.integrationId),
+      ])
+      const ins = await holder.query<{ id: string }>(
+        `INSERT INTO provider_org_transfers
+           (org_id, provider, source_integration_id, target_integration_id, status, freeze_source_sync)
+         SELECT org_id, provider, $1, $2, 'draft', true
+           FROM directory_integrations WHERE id = $1
+         RETURNING id`,
+        [source.integrationId, target.integrationId],
+      )
+      cleanupTransferIds.push(ins.rows[0].id)
+
+      const syncOutcome = settled(syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`))
+      await waitUntilBlockedOnHolder(holderPid)
+
+      // While the sync is provably parked, a stale-lease reclaimer takes its run row away and
+      // records the truthful liveness failure.
+      const reclaimed = await query<{ id: string }>(
+        `UPDATE directory_sync_runs
+            SET status = 'failed', error_message = 'reclaimed as stale', finished_at = NOW(), updated_at = NOW()
+          WHERE integration_id = $1 AND status = 'running'
+          RETURNING id`,
+        [source.integrationId],
+      )
+      expect(reclaimed.rows).toHaveLength(1)
+
+      await holder.query('COMMIT')
+      const outcome = await syncOutcome
+      expect(outcome).toBeInstanceOf(DirectorySyncFrozenByTransferError)
+    })
+
+    // The reclaimer's record stands: not softened to 'aborted', message intact.
+    const row = await query<{ status: string; error_message: string | null }>(
+      `SELECT status, error_message FROM directory_sync_runs
+        WHERE integration_id = $1 ORDER BY started_at DESC LIMIT 1`,
+      [source.integrationId],
+    )
+    expect(row.rows[0].status).toBe('failed')
+    expect(row.rows[0].error_message).toBe('reclaimed as stale')
+  })
+
   it('RACE sync-wins vs create: apply stand-in holds source lock → real create parks → after release create freezes', async () => {
     const source = await seedIntegrationWithLiveAccount('race-swin-c-src')
     const target = await seedIntegrationWithLiveAccount('race-swin-c-dst')

--- a/packages/core-backend/tests/integration/directory-org-transfer-source-freeze.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-org-transfer-source-freeze.db.test.ts
@@ -29,6 +29,11 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest
 //   - remove the apply-time assertDirectorySyncNotFrozenByTransfer recheck → freeze-wins
 //     races commit the absence sweep and deactivate the seeded live account
 //
+// B1 (audit follow-up, deliberate freeze ≠ integration failure) mutation proofs:
+//   - revert the discrimination in the sync catch (route DirectorySyncFrozenByTransferError
+//     back through markSyncFailure) → the create-wins race's abort assertions go red
+//   - suppress markSyncFailure for ALL errors → the genuine-failure positive control goes red
+//
 // DATABASE_URL-gated (describeIfDatabase): excluded from the no-DB vitest job so it cannot
 // skip-green, and wired as a WHOLE FILE into the approval real-DB step in plugin-tests.yml
 // (both points asserted by t2-source-freeze-ci-wiring.test.mjs).
@@ -49,6 +54,7 @@ vi.mock('../../src/integrations/dingtalk/client', () => ({
 }))
 
 import { query } from '../../src/db/pg'
+import { countConsecutiveFailedRuns } from '../../src/directory/directory-sync-alert-delivery'
 import {
   createDirectoryIntegration,
   DirectorySyncFrozenByTransferError,
@@ -212,6 +218,41 @@ describeIfDatabase('Transfer MVP T2 — §12.2 source freeze during an active or
     const row = await query<{ n: string }>(`SELECT count(*)::text AS n FROM directory_sync_runs WHERE integration_id = $1`, [
       integrationId,
     ])
+    return Number(row.rows[0].n)
+  }
+
+  type AbortRunRow = {
+    id: string
+    status: string
+    finished_at: string | null
+    error_message: string | null
+    meta: { abortReason?: string; transferId?: string } | null
+  }
+
+  /** All run rows for ONE fixture integration (shared dev DB — never scan the table). */
+  async function runRows(integrationId: string): Promise<AbortRunRow[]> {
+    const rows = await query<AbortRunRow>(
+      `SELECT id, status, finished_at, error_message, meta
+         FROM directory_sync_runs WHERE integration_id = $1 ORDER BY started_at ASC`,
+      [integrationId],
+    )
+    return rows.rows
+  }
+
+  async function integrationLastError(integrationId: string): Promise<string | null> {
+    const row = await query<{ last_error: string | null }>(
+      `SELECT last_error FROM directory_integrations WHERE id = $1`,
+      [integrationId],
+    )
+    return row.rows[0]?.last_error ?? null
+  }
+
+  async function syncFailedAlertCount(integrationId: string): Promise<number> {
+    const row = await query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM directory_sync_alerts
+        WHERE integration_id = $1 AND code = 'sync_failed'`,
+      [integrationId],
+    )
     return Number(row.rows[0].n)
   }
 
@@ -481,14 +522,83 @@ describeIfDatabase('Transfer MVP T2 — §12.2 source freeze during an active or
 
     // Local directory mutation must not commit after freeze linearized first.
     expect(await accountActive(source.accountId)).toBe(true)
-    // Late-race honesty: lease was claimed after the entry check, so a failed run row may exist.
-    const runs = await query<{ status: string; n: string }>(
-      `SELECT status, count(*)::text AS n FROM directory_sync_runs
-        WHERE integration_id = $1 GROUP BY status`,
-      [source.integrationId],
+
+    // B1 (audit follow-up): the lease WAS claimed after the entry check, so this late race does
+    // leave a run row behind — but a deliberate freeze must not be recorded as an integration
+    // FAILURE. Before this ticket the unconditional catch called markSyncFailure and left
+    // status='failed' + integrations.last_error + an 'error'/'sync_failed' alert standing for the
+    // ENTIRE (multi-day) transfer, because last_error is only cleared by a SUCCESSFUL apply —
+    // which the freeze is precisely what prevents. Assert the deliberate-abort aftermath instead.
+    const runs = await runRows(source.integrationId)
+    expect(runs.find((r) => r.status === 'completed')).toBeUndefined()
+    expect(runs.find((r) => r.status === 'failed')).toBeUndefined()
+    expect(runs.filter((r) => r.status === 'aborted')).toHaveLength(1)
+    const aborted = runs.find((r) => r.status === 'aborted')!
+    // Terminal (lease free) and NOT styled as an error on the admin run panel.
+    expect(aborted.finished_at).not.toBeNull()
+    expect(aborted.error_message).toBeNull()
+    // Reason is still recorded — in meta, which no run-summary/toast surface reads.
+    expect(aborted.meta?.abortReason).toBe('frozen_by_org_transfer')
+    expect(aborted.meta?.transferId).toBe(transferId)
+    // The integration itself must not read "errored" for the duration of the transfer.
+    expect(await integrationLastError(source.integrationId)).toBeNull()
+    // No failure alert row → nothing for the (owner-pending) alert webhook to page on.
+    expect(await syncFailedAlertCount(source.integrationId)).toBe(0)
+
+    // Escalation exclusion, pinned directly: a deliberate abort is not a consecutive failure.
+    expect(await countConsecutiveFailedRuns(source.integrationId)).toBe(0)
+
+    // LEASE IS FREE, end-to-end: with the freeze lifted the very next sync claims and completes.
+    // (Also the destructive positive control — the empty tenant sweeps the seeded account.)
+    await query(`UPDATE provider_org_transfers SET freeze_source_sync = false WHERE id = $1`, [transferId])
+    const followUp = await syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`)
+    expect(followUp.run.status).toBe('completed')
+    expect(await accountActive(source.accountId)).toBe(false)
+    expect(await integrationLastError(source.integrationId)).toBeNull()
+  })
+
+  it('B1 POSITIVE CONTROL: a GENUINE sync failure still marks failed + last_error + a sync_failed alert', async () => {
+    // Proves the catch was NARROWED, not gutted: same catch, non-freeze error, full failure path.
+    const source = await seedIntegrationWithLiveAccount('b1-genuine-fail')
+    clientMocks.listDingTalkDepartments.mockRejectedValueOnce(new Error('b1 provider pull exploded'))
+
+    await expect(syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`)).rejects.toThrow(
+      /b1 provider pull exploded/,
     )
-    const completed = runs.rows.find((r) => r.status === 'completed')
-    expect(completed).toBeUndefined()
+
+    const runs = await runRows(source.integrationId)
+    expect(runs).toHaveLength(1)
+    expect(runs[0].status).toBe('failed')
+    expect(runs[0].error_message).toContain('b1 provider pull exploded')
+    expect(await integrationLastError(source.integrationId)).toContain('b1 provider pull exploded')
+    expect(await syncFailedAlertCount(source.integrationId)).toBe(1)
+    // …and THIS one does drive escalation.
+    expect(await countConsecutiveFailedRuns(source.integrationId)).toBe(1)
+  })
+
+  it('B1 escalation exclusion: an aborted run neither counts nor breaks a failure streak', async () => {
+    // Direct pin on the escalation input (`countConsecutiveFailedRuns` filters
+    // status IN ('completed','failed')): a genuine failure, then a deliberate abort, then
+    // another genuine failure = a streak of 2 — the abort is invisible to escalation, and it
+    // must not silently reset the streak either.
+    const source = await seedIntegrationWithLiveAccount('b1-escalation')
+
+    clientMocks.listDingTalkDepartments.mockRejectedValueOnce(new Error('b1 escalation failure one'))
+    await expect(syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`)).rejects.toThrow(/failure one/)
+    expect(await countConsecutiveFailedRuns(source.integrationId)).toBe(1)
+
+    // Insert the deliberate-abort row exactly as the abort path writes it, in between.
+    await query(
+      `INSERT INTO directory_sync_runs (integration_id, status, started_at, finished_at, stats, meta, triggered_by, trigger_source)
+       VALUES ($1, 'aborted', NOW(), NOW(), '{}'::jsonb,
+               jsonb_build_object('abortReason', 'frozen_by_org_transfer'), $2, 'manual')`,
+      [source.integrationId, `t2-admin-${TS}`],
+    )
+    expect(await countConsecutiveFailedRuns(source.integrationId)).toBe(1)
+
+    clientMocks.listDingTalkDepartments.mockRejectedValueOnce(new Error('b1 escalation failure two'))
+    await expect(syncDirectoryIntegration(source.integrationId, `t2-admin-${TS}`)).rejects.toThrow(/failure two/)
+    expect(await countConsecutiveFailedRuns(source.integrationId)).toBe(2)
   })
 
   it('RACE sync-wins vs create: apply stand-in holds source lock → real create parks → after release create freezes', async () => {


### PR DESCRIPTION
## What / Why

**Audit finding B1 — a deliberate freeze was recorded as an integration failure.**

When a transfer freeze linearizes first during an in-flight sync, the apply correctly rolls back and `DirectorySyncFrozenByTransferError` propagates into the **unconditional** catch at the end of `syncDirectoryIntegration`, which called `markSyncFailure`. Aftermath observed on `main` (reproduced by extending the landed create-wins race test):

```
runStatuses:          ["failed"]
integrationLastError: "Directory sync is frozen by an active org transfer for this integration (transfer <uuid>)"
alerts:               [{ level: "error", code: "sync_failed", message: same }]
```

That contradicts this lane's own semantics: a frozen source is a **deliberate** state everywhere else — the scheduler path is a quiet info skip (`directory-sync-scheduler.ts`), the route path maps it to a deliberate 409 that must "never page monitoring". And it is not self-healing: `directory_integrations.last_error` is only cleared inside the **successful** apply transaction — and the freeze is exactly what prevents a successful apply — so the integration reads as errored for the **entire** transfer (the design's documented multi-day steady state), while also feeding `countConsecutiveFailedRuns` escalation once the alert webhook is enabled (pending owner decision).

The audit agent had already flagged this code path as an untested guard (MUT10: skipping `markSyncFailure` on the frozen error left 32/32 green).

## Change (backend only, 2 files)

`packages/core-backend/src/directory/directory-sync.ts`

1. Discriminate `DirectorySyncFrozenByTransferError` in that catch and take a terminal **deliberate-abort** path (`markSyncAbortedByFreeze`) instead of `markSyncFailure`:
   - run reaches a terminal, non-`running` state → the partial unique index frees the lease immediately, nothing is wedged, no waiting on stale-lease reclaim;
   - `error_message` stays **NULL** (the admin run panel styles that field as an error); the reason lives in `meta` (`abortReason: 'frozen_by_org_transfer'`, `transferId`), which no run-summary/toast surface reads;
   - `directory_integrations` is **not touched at all** — no `last_error`, no `last_sync_at` bump (nothing was synced);
   - **no** `directory_sync_alerts` `'sync_failed'` row, and therefore no failure-alert delivery.
2. **Run status = `'aborted'`** (the ticket's preferred option; no migration). Verified before choosing:
   - no CHECK constraint on `directory_sync_runs.status` (bare `text`, confirmed both in `zzzz20260324150000_create_directory_sync_tables.ts` and against a live DB via `pg_constraint`);
   - **every** reader of `directory_sync_runs.status` across `src/` and `apps/web` was grepped:
     | reader | behaviour with `'aborted'` |
     |---|---|
     | `countConsecutiveFailedRuns` (alert-delivery:57-67) — `status IN ('completed','failed')` | excluded from escalation ✅ (this is why `'aborted'` needs no extra code) |
     | `reclaimStaleDirectorySyncRuns` — `WHERE status='running'` | excluded (row already terminal) ✅ |
     | `findActiveDirectorySyncRunId` — `WHERE status='running'` | excluded ✅ |
     | partial unique index `uq_directory_sync_runs_one_running_per_integration` | lease freed ✅ |
     | completion write — `WHERE status='running'` | n/a ✅ |
     | `listDirectorySyncRuns`, `getDirectorySyncScheduleSnapshot`, `last_run_status` sub-select | unfiltered text passthrough ✅ |
     | `apps/web` `DirectoryManagementView.vue` — run panel (`{{ run.status }}`), integration card (`lastRunStatus`) | renders the raw value, exactly as it does for `completed`/`failed` today ✅ |
   - **~~One known cosmetic wrinkle, deliberately not fixed here~~ — SUPERSEDED, now fixed in this PR.** The owner reviewed this and ruled it is NOT cosmetic: the async-poll path at `DirectoryManagementView.vue` sent every "not running, not failed, no errorMessage" state into `buildAsyncRunSummary()`, so an aborted run told the operator 后台同步已完成 — the user will not retry on their own and the message never corrects itself. The view now handles `aborted` explicitly, the success branch is reachable ONLY by `completed`, and any unknown terminal state fails safe. Covered by a polling web test and an unknown-terminal fail-safe test, both wired into the required web-tests run-list; reverting the view reds the polling test and neutering the fail-safe reds the unknown-state test.
3. `markSyncAbortedByFreeze`'s UPDATE **is** guarded on `status = 'running'` (unlike `markSyncFailure`, which deliberately has no guard): if the lease was already reclaimed, the row carries the reclaimer's truthful `failed`/orphaned record and this run no longer owns it — overwriting it with a softer `'aborted'` would erase a real liveness incident. Either way the row is terminal and the lease is free. Documented at the call site.
4. The thrown error and the **409 route / scheduler mappings are unchanged** — `throw error` re-raises the original instance. Tests E (route 409, both sync and async branches) and the scheduler unit suite stay green untouched.

## Proof (`tests/integration/directory-org-transfer-source-freeze.db.test.ts`)

Extended the landed `RACE create-wins` test (the one that actually drives the freeze-wins linearization through the real sync) to assert the full aftermath, plus two new cases:

- **create-wins race now asserts**: no `completed` run, no `failed` run, exactly one `aborted` run with `finished_at` set and `error_message` NULL, `meta.abortReason='frozen_by_org_transfer'` + `meta.transferId`, `integrations.last_error` NULL, **zero** `sync_failed` alert rows for that integration, `countConsecutiveFailedRuns() === 0`, and — end-to-end — **the lease is free**: lifting the freeze and calling `syncDirectoryIntegration` again yields `run.status === 'completed'` and the empty-tenant absence sweep deactivates the seeded account (so the follow-up sync is proven non-vacuous).
- **`B1 POSITIVE CONTROL`** (new): a genuine failure (provider pull throws) still marks the run `failed`, writes `integrations.last_error`, and creates exactly one `sync_failed` alert — proving the catch was narrowed, not gutted.
- **`B1 escalation exclusion`** (new): pins the escalation input directly — genuine failure → deliberate abort row → genuine failure gives `countConsecutiveFailedRuns() === 2`; the abort neither counts toward the streak nor resets it.

All fixtures/assertions are scoped by the suite's own unique integration ids (shared dev DB).

## Mutation signatures (each applied, red confirmed, restored, green confirmed)

| mutation | result |
|---|---|
| revert the discrimination — delete the `if (error instanceof DirectorySyncFrozenByTransferError)` branch so the frozen error routes back through `markSyncFailure` | **1 failed / 17 passed** — `RACE create-wins` → `AssertionError: expected { …(5) } to be undefined` at `directory-org-transfer-source-freeze.db.test.ts:534` (`expect(runs.find((r) => r.status === 'failed')).toBeUndefined()`) |
| break the positive control's path — suppress `markSyncFailure` for **all** errors | **2 failed / 16 passed** — `B1 POSITIVE CONTROL` → `AssertionError: expected 'running' to be 'failed'` at `:571`; `B1 escalation exclusion` → `AssertionError: expected +0 to be 1` |
| (restored) | **18 passed / 18** |

## Test counts

- `directory-org-transfer-source-freeze.db.test.ts`: **18 passed** (16 on `main` + 2 new; the create-wins case extended in place).
- Neighbouring real-DB suites, unchanged and green: `directory-sync-run-lease` + `directory-sync-alert-coverage` + `directory-sync-orchestration` → **30 passed**.
- Unit: `directory-sync-alert-delivery` + `directory-sync-scheduler` + `admin-directory-routes` → **137 passed**.
- Ops guard: `node --test scripts/ops/t2-source-freeze-ci-wiring.test.mjs` → **2/2 pass** (suite still excluded from the no-DB job and wired whole-file into the real-DB step).
- `npx tsc --noEmit` in `packages/core-backend`: clean.
- `git diff origin/main --name-only` lists exactly the two ticket files.
- Local Node is v25.9.0; **CI authority is Node 20** — not blocking, just noted.

## Rebase replay (2026-07-22, owner order step 2)

Owner APPROVEd the content on the old green; per order the proofs were replayed on current `main`.

- Head: `b3dc0d9e1` → **`a6536c54d`** (rebased onto `origin/main` = `f55d99e12`, the W4 wave incl. W4-PRE-1a..1d lifecycle). Rebase was conflict-free; marker sweep clean (0 UU, `git diff --check` clean, anchor grep empty). Three-dot scope vs `origin/main` is exactly the same 4 files.
- Replay on `a6536c54d`: freeze suite **19/19** (the 19th is the gate-round reclaimer-barrier test), guard-removal mutation reds it with the exact `expected 'aborted' to be 'failed'` signature, web spec **70/70**, `tsc --noEmit` + `vue-tsc -b` clean.
- `markSyncFailure` caller census on the rebased head: still exactly **one** call site (`directory-sync.ts:4359`), behind the freeze discrimination (`:4354-4356`); W4-PRE-1's diff adds **zero** catch clauses — no new unconditional failure route. Full classification in the replay comment below.

**UNARMED — owner review pending.** No auto-merge, no merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


