### PR TITLE
feat(attendance-web): W2/4355 — employee overview task-first (AttendanceEmployeeWorkspace.vue first extraction)

### DIFF
--- a/.github/workflows/attendance-web-guard.yml
+++ b/.github/workflows/attendance-web-guard.yml
@@ -101,6 +101,7 @@ on:
       - 'apps/web/src/views/attendance/reportXlsxExport.ts'
       - 'apps/web/tests/attendance-report-xlsx-export.spec.ts'
       - 'apps/web/tests/attendance-reports-analytics.spec.ts'
+      - 'apps/web/tests/attendance-overview-priority.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
   push:
     branches: [main]
@@ -139,6 +140,7 @@ on:
       - 'apps/web/src/views/attendance/reportXlsxExport.ts'
       - 'apps/web/tests/attendance-report-xlsx-export.spec.ts'
       - 'apps/web/tests/attendance-reports-analytics.spec.ts'
+      - 'apps/web/tests/attendance-overview-priority.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
 
 jobs:
@@ -181,4 +183,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run attendance web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust attendance-overview-priority --reporter=dot

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -24,32 +24,7 @@
             }}
           </p>
         </div>
-        <div v-if="showOverview" class="attendance__hero-punch" data-testid="attendance-hero-punch">
-          <div class="attendance__hero-clock">
-            <span class="attendance__hero-time" data-testid="attendance-hero-time">{{ heroClockTime }}</span>
-            <span class="attendance__hero-date">{{ heroClockDate }}</span>
-          </div>
-          <div class="attendance__actions attendance__hero-actions">
-            <button class="attendance__btn attendance__btn--primary attendance__btn--hero" :disabled="punching" @click="punch('check_in')">
-              {{ punching ? tr('Working...', '处理中...') : tr('Check In', '上班打卡') }}
-            </button>
-            <button class="attendance__btn attendance__btn--hero-secondary" :disabled="punching" @click="punch('check_out')">
-              {{ punching ? tr('Working...', '处理中...') : tr('Check Out', '下班打卡') }}
-            </button>
-          </div>
-          <div v-if="heroTodayTimeline" class="attendance__hero-timeline" data-testid="attendance-hero-timeline">
-            <span class="attendance__hero-timeline-node" :class="{ 'attendance__hero-timeline-node--pending': !heroTodayTimeline.checkIn }">
-              <span class="attendance__hero-timeline-dot" />
-              {{ tr('In', '上班') }} {{ heroTodayTimeline.checkIn ?? '--:--' }}
-            </span>
-            <span class="attendance__hero-timeline-rail" />
-            <span class="attendance__hero-timeline-node" :class="{ 'attendance__hero-timeline-node--pending': !heroTodayTimeline.checkOut }">
-              <span class="attendance__hero-timeline-dot" />
-              {{ tr('Out', '下班') }} {{ heroTodayTimeline.checkOut ?? '--:--' }}
-            </span>
-          </div>
-        </div>
-        <div v-else class="attendance__chip-list attendance__chip-list--header">
+        <div v-if="showReports" class="attendance__chip-list attendance__chip-list--header">
           <span class="attendance__status-chip">
             {{ tr('Records', '记录') }} {{ recordsTotal }}
           </span>
@@ -60,30 +35,14 @@
             {{ tr('Minutes', '分钟') }} {{ requestReportMinutesTotal }}
           </span>
         </div>
-        <div v-if="showOverview && punchOutdoorNoteRequired" class="attendance__punch-note" data-attendance-punch-note-form>
-          <label class="attendance__field" for="attendance-punch-outdoor-note">
-            <span>{{ tr('Outdoor punch note', '外勤打卡备注') }}</span>
-            <input
-              id="attendance-punch-outdoor-note"
-              v-model="punchOutdoorNoteDraft"
-              type="text"
-              :placeholder="tr('Required to submit an outdoor punch', '提交外勤打卡需填写')"
-              @keydown.enter.prevent="retryPunchWithOutdoorNote"
-            />
-          </label>
-          <button
-            class="attendance__btn attendance__btn--inline"
-            type="button"
-            data-attendance-punch-note-retry
-            :disabled="punching || !punchOutdoorNoteDraft.trim()"
-            @click="retryPunchWithOutdoorNote"
-          >
-            {{ punching ? tr('Working...', '处理中...') : tr('Retry punch with note', '补充备注后重试打卡') }}
-          </button>
-        </div>
       </header>
 
-      <section class="attendance__filters" v-if="showOverview || showReports">
+      <!-- Reports mode keeps its existing filter-row position/behavior
+           byte-identical (employee-overview-task-first-design-lock-20260716
+           §5: "this lock changes only mode === 'overview' presentation").
+           The overview filter row moves into AttendanceEmployeeWorkspace's
+           collapsed-by-default history disclosure below. -->
+      <section class="attendance__filters" v-if="showReports">
         <label class="attendance__field" for="attendance-from-date">
           <span>{{ tr('From', '开始') }}</span>
           <input id="attendance-from-date" name="fromDate" v-model="fromDate" type="date" />
@@ -107,7 +66,7 @@
           />
         </label>
         <button class="attendance__btn" :disabled="loading || reportLoading" @click="refreshVisibleSurfaceWithStatus">
-          {{ showReports ? tr('Reload report', '重载报表') : tr('Refresh', '刷新') }}
+          {{ tr('Reload report', '重载报表') }}
         </button>
         <div v-if="statusMessage" class="attendance__status-block">
           <span class="attendance__status" :class="{ 'attendance__status--error': statusKind === 'error' }">
@@ -131,344 +90,107 @@
         </div>
       </section>
 
-      <section v-if="showOverview" class="attendance__grid attendance__grid--selfservice">
-        <div class="attendance__card attendance__card--selfservice" data-selfservice-card="annual-balance">
-          <div class="attendance__requests-header">
-            <div><h3>{{ tr('My annual leave', '我的年假') }}</h3></div>
-          </div>
-          <p v-if="annualSelfBalanceLoading" class="attendance__field-hint">{{ tr('Loading...', '加载中...') }}</p>
-          <p v-else-if="annualSelfBalanceError" class="attendance__error" data-annual-self-balance-error>{{ annualSelfBalanceError }}</p>
-          <div v-else-if="annualSelfBalance" class="attendance__selfbalance" data-annual-self-balance>
-            <div class="attendance__selfbalance-remaining">
-              <strong>{{ annualSelfBalance.summary.remainingMinutes }}</strong> {{ tr('min remaining', '分钟剩余') }}
-            </div>
-            <small class="attendance__field-hint">
-              {{ tr('Granted', '已发放') }} {{ annualSelfBalance.summary.grantedMinutes }} ·
-              {{ tr('Used', '已用') }} {{ annualSelfBalance.summary.exhaustedMinutes }} ·
-              {{ tr('Expired', '已过期') }} {{ annualSelfBalance.summary.expiredMinutes }}
-            </small>
-          </div>
-          <p v-else class="attendance__field-hint">{{ tr('No annual leave balance yet.', '暂无年假余额。') }}</p>
-        </div>
-        <div class="attendance__card attendance__card--selfservice" data-selfservice-card="status">
-          <div class="attendance__requests-header">
-            <div>
-              <h3>{{ tr('My status', '我的状态') }}</h3>
-              <small class="attendance__field-hint">
-                {{
-                  activeWorkbenchRecord
-                    ? tr(
-                      `Focus date: ${formatDate(activeWorkbenchRecord.work_date)}`,
-                      `关注日期：${formatDate(activeWorkbenchRecord.work_date)}`,
-                    )
-                    : tr('Focus date: current range', '关注日期：当前区间')
-                }}
-              </small>
-            </div>
-            <span
-              v-if="activeWorkbenchRecord"
-              class="attendance__status-chip"
-              :class="`attendance__status-chip--${activeWorkbenchRecord.status}`"
-            >
-              {{ formatStatus(activeWorkbenchRecord.status) }}
-            </span>
-          </div>
-          <p class="attendance__selfservice-lead">
-            {{ activeWorkbenchStatusDescription }}
-          </p>
-          <div class="attendance__summary attendance__summary--workbench attendance__summary--stat">
-            <div class="attendance__summary-item attendance__summary-item--stat">
-              <svg class="attendance__summary-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 2" /></svg>
-              <span>{{ tr('Latest punch', '最近一次打卡') }}</span>
-              <strong class="attendance__summary-value">{{ activeWorkbenchLatestPunchLabel }}</strong>
-            </div>
-            <div class="attendance__summary-item attendance__summary-item--stat">
-              <svg class="attendance__summary-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M10 2h4M12 2v4" /><circle cx="12" cy="14" r="7" /><path d="M12 14l2.5-2.5" /></svg>
-              <span>{{ tr('Work minutes', '工时分钟') }}</span>
-              <strong class="attendance__summary-value">{{ activeWorkbenchRecord?.work_minutes ?? 0 }}</strong>
-            </div>
-            <div class="attendance__summary-item attendance__summary-item--stat">
-              <svg class="attendance__summary-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 3l10 18H2z" /><path d="M12 10v5M12 18.5v.5" /></svg>
-              <span>{{ tr('Late / Early', '迟到 / 早退') }}</span>
-              <strong class="attendance__summary-value" :class="{ 'attendance__summary-value--warning': activeWorkbenchHasLateEarly }">{{ activeWorkbenchLateEarlyLabel }}</strong>
-            </div>
-            <div class="attendance__summary-item attendance__summary-item--stat">
-              <svg class="attendance__summary-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M8 6h13M8 12h13M8 18h13" /><path d="M3 6h.01M3 12h.01M3 18h.01" /></svg>
-              <span>{{ tr('Attention items', '需处理事项') }}</span>
-              <strong class="attendance__summary-value" :class="{ 'attendance__summary-value--danger': activeWorkbenchAttentionCount > 0 }">{{ activeWorkbenchAttentionCount }}</strong>
-            </div>
-          </div>
-          <p class="attendance__field-hint attendance__field-hint--strong">
-            {{
-              activeWorkbenchAttentionCount > 0
-                ? tr(
-                  `You have ${activeWorkbenchAttentionCount} anomaly reminders in this range.`,
-                  `当前区间内有 ${activeWorkbenchAttentionCount} 条异常提醒。`,
-                )
-                : tr('No anomaly reminders in the current range.', '当前区间内没有异常提醒。')
-            }}
-          </p>
-          <p
-            v-if="selfServiceNeedsSetupHint"
-            class="attendance__field-hint attendance__field-hint--strong"
-            data-selfservice-setup-hint
-          >
-            {{ selfServiceSetupFollowupHint }}
-          </p>
-          <ul class="attendance__selfservice-focus-list" data-selfservice-focus-list>
-            <li v-for="item in selfServiceFocusItems" :key="item.key" class="attendance__selfservice-focus-item">
-              <div class="attendance__selfservice-focus-copy">
-                <strong>{{ item.title }}</strong>
-                <span>{{ item.detail }}</span>
-              </div>
-              <button
-                v-if="item.action && item.actionLabel"
-                class="attendance__btn attendance__btn--inline"
-                type="button"
-                :data-selfservice-focus-action="item.action"
-                @click="runSelfServiceAction(item.action)"
-              >
-                {{ item.actionLabel }}
-              </button>
-            </li>
-          </ul>
-        </div>
+      <AttendanceEmployeeWorkspace
+        v-if="showOverview"
+        :tr="tr"
+        :hero-clock-time="heroClockTime"
+        :hero-clock-date="heroClockDate"
+        :punching="punching"
+        :hero-timeline="heroTodayTimeline"
+        :punch-outdoor-note-required="punchOutdoorNoteRequired"
+        :punch-outdoor-note-draft="punchOutdoorNoteDraft"
+        :workbench-status-description="activeWorkbenchStatusDescription"
+        :workbench-record-status="workbenchRecordStatus"
+        :workbench-focus-date-label="workbenchFocusDateLabel"
+        :workbench-latest-punch-label="activeWorkbenchLatestPunchLabel"
+        :workbench-work-minutes="workbenchWorkMinutes"
+        :workbench-late-early-label="activeWorkbenchLateEarlyLabel"
+        :workbench-has-late-early="activeWorkbenchHasLateEarly"
+        :self-service-needs-setup-hint="selfServiceNeedsSetupHint"
+        :self-service-setup-followup-hint="selfServiceSetupFollowupHint"
+        :format-status="formatStatus"
+        :status-message="statusMessage"
+        :status-kind="statusKind"
+        :status-code="statusCode"
+        :status-hint="statusHint"
+        :status-action-label="statusActionLabel"
+        :status-action-busy="statusActionBusy"
+        :attention-item="attendanceOverviewAttentionItem"
+        :requests-total="requests.length"
+        :self-service-request-status-items="selfServiceRequestStatusItems"
+        :self-service-request-followup="selfServiceRequestFollowup"
+        :self-service-recent-requests="selfServiceRecentRequests"
+        :format-request-type="formatRequestType"
+        :format-date="formatDate"
+        :self-service-request-subtitle="selfServiceRequestSubtitle"
+        :request-reason-text="requestReasonText"
+        :request-decision-comment-text="requestDecisionCommentText"
+        :request-decision-comment-label="requestDecisionCommentLabel"
+        :describe-request-status="describeRequestStatus"
+        :self-service-quick-action-hint="selfServiceQuickActionHint"
+        :annual-self-balance-loading="annualSelfBalanceLoading"
+        :annual-self-balance-error="annualSelfBalanceError"
+        :annual-self-balance-summary="annualSelfBalanceSummary"
+        :self-rules-loading="selfRulesLoading"
+        :self-rules-error="selfRulesError"
+        :self-rules-has-data="selfRulesHasData"
+        :self-rules-attendance-group-summary="selfRulesAttendanceGroupSummary"
+        :self-rules-schedule-group-summary="selfRulesScheduleGroupSummary"
+        :self-rules-work-window-summary="selfRulesWorkWindowSummary"
+        :self-rules-punch-policy-summary="selfRulesPunchPolicySummary"
+        :self-rules-working-days-summary="selfRulesWorkingDaysSummary"
+        :self-rules-grace-summary="selfRulesGraceSummary"
+        :self-rules-late-threshold-summary="selfRulesLateThresholdSummary"
+        :self-rules-configured-rule-summary="selfRulesConfiguredRuleSummary"
+        :self-rules-warning-codes="selfRulesWarningCodes"
+        :format-self-rules-warning="formatSelfRulesWarning"
+        :attendance-status-guide-items="attendanceStatusGuideItems"
+        @punch="punch"
+        @retry-punch-note="retryPunchWithOutdoorNote"
+        @update:punch-outdoor-note-draft="punchOutdoorNoteDraft = $event"
+        @status-action="runStatusAction"
+        @self-service-action="runSelfServiceAction"
+      >
+        <template #historyFilters>
+          <label class="attendance__field" for="attendance-from-date">
+            <span>{{ tr('From', '开始') }}</span>
+            <input id="attendance-from-date" name="fromDate" v-model="fromDate" type="date" />
+          </label>
+          <label class="attendance__field" for="attendance-to-date">
+            <span>{{ tr('To', '结束') }}</span>
+            <input id="attendance-to-date" name="toDate" v-model="toDate" type="date" />
+          </label>
+          <label class="attendance__field" for="attendance-org-id">
+            <span>{{ tr('Org ID', '组织 ID') }}</span>
+            <input id="attendance-org-id" name="orgId" v-model="orgId" type="text" :placeholder="tr('default', '默认')" />
+          </label>
+          <label class="attendance__field" for="attendance-user-id">
+            <span>{{ tr('User ID (optional)', '用户 ID（可选）') }}</span>
+            <input
+              id="attendance-user-id"
+              name="targetUserId"
+              v-model="targetUserId"
+              type="text"
+              :placeholder="tr('Current user', '当前用户')"
+            />
+          </label>
+          <button class="attendance__btn" :disabled="loading || reportLoading" @click="refreshVisibleSurfaceWithStatus">
+            {{ tr('Refresh', '刷新') }}
+          </button>
+        </template>
+      </AttendanceEmployeeWorkspace>
 
-        <div class="attendance__card attendance__card--selfservice" data-selfservice-card="rules">
-          <div class="attendance__requests-header">
-            <div>
-              <h3>{{ tr('My attendance rules', '我的考勤规则') }}</h3>
-              <small class="attendance__field-hint">{{ tr('Read-only summary of the rules currently used for you.', '当前适用于您的考勤规则只读摘要。') }}</small>
-            </div>
-          </div>
-          <p v-if="selfRulesLoading" class="attendance__field-hint">{{ tr('Loading...', '加载中...') }}</p>
-          <p v-else-if="selfRulesError" class="attendance__error" data-selfservice-rules-error>{{ selfRulesError }}</p>
-          <div v-else-if="selfRulesData" class="attendance__selfrules" data-selfservice-rules>
-            <div class="attendance__summary attendance__summary--workbench">
-              <div class="attendance__summary-item">
-                <span>{{ tr('Attendance group', '考勤组') }}</span>
-                <strong>{{ selfRulesAttendanceGroupSummary }}</strong>
-              </div>
-              <div class="attendance__summary-item">
-                <span>{{ tr('Schedule group', '排班组') }}</span>
-                <strong>{{ selfRulesScheduleGroupSummary }}</strong>
-              </div>
-              <div class="attendance__summary-item">
-                <span>{{ tr('Work window', '工作时间') }}</span>
-                <strong>{{ selfRulesWorkWindowSummary }}</strong>
-              </div>
-              <div class="attendance__summary-item">
-                <span>{{ tr('Punch policy', '打卡策略') }}</span>
-                <strong>{{ selfRulesPunchPolicySummary }}</strong>
-              </div>
-              <div class="attendance__summary-item">
-                <span>{{ tr('Working days', '工作日') }}</span>
-                <strong>{{ selfRulesWorkingDaysSummary }}</strong>
-              </div>
-              <div class="attendance__summary-item">
-                <span>{{ tr('Late / early grace', '迟到 / 早退宽限') }}</span>
-                <strong>{{ selfRulesGraceSummary }}</strong>
-              </div>
-              <div class="attendance__summary-item">
-                <span>{{ tr('Severe / absence late', '严重 / 旷工迟到') }}</span>
-                <strong>{{ selfRulesLateThresholdSummary }}</strong>
-              </div>
-            </div>
-            <p v-if="selfRulesConfiguredRuleSummary" class="attendance__field-hint attendance__field-hint--strong">
-              {{ selfRulesConfiguredRuleSummary }}
-            </p>
-            <div v-if="selfRulesWarningCodes.length > 0" class="attendance__chip-list" data-selfservice-rules-warnings>
-              <span
-                v-for="code in selfRulesWarningCodes"
-                :key="code"
-                class="attendance__status-chip attendance__status-chip--pending"
-              >
-                {{ formatSelfRulesWarning(code) }}
-              </span>
-            </div>
-          </div>
-          <p v-else class="attendance__field-hint">{{ tr('No attendance rules loaded yet.', '暂无考勤规则摘要。') }}</p>
-        </div>
-
-        <div class="attendance__card attendance__card--selfservice" data-selfservice-card="requests">
-          <div class="attendance__requests-header">
-            <div>
-              <h3>{{ tr('My request status', '我的申请状态') }}</h3>
-              <small class="attendance__field-hint">
-                {{
-                  tr(
-                    'Summarizes the current request backlog from the visible date range.',
-                    '汇总当前可见日期区间内的申请处理状态。',
-                  )
-                }}
-              </small>
-            </div>
-            <strong>{{ requests.length }}</strong>
-          </div>
-          <div class="attendance__chip-list">
-            <span
-              v-for="item in selfServiceRequestStatusItems"
-              :key="item.key"
-              class="attendance__status-chip"
-              :class="`attendance__status-chip--${item.key}`"
-              :data-selfservice-request-stat="item.key"
-            >
-              {{ item.label }} · {{ item.count }}
-            </span>
-          </div>
-          <div class="attendance__selfservice-callout" data-selfservice-request-followup>
-            <div class="attendance__selfservice-callout-copy">
-              <div class="attendance__selfservice-callout-header">
-                <strong>{{ selfServiceRequestFollowup.title }}</strong>
-                <span
-                  v-if="selfServiceRequestFollowup.status"
-                  class="attendance__status-chip"
-                  :class="`attendance__status-chip--${selfServiceRequestFollowup.status}`"
-                >
-                  {{ formatStatus(selfServiceRequestFollowup.status) }}
-                </span>
-              </div>
-              <p>{{ selfServiceRequestFollowup.detail }}</p>
-            </div>
-            <button
-              class="attendance__btn attendance__btn--inline"
-              type="button"
-              data-selfservice-action="request-followup"
-              @click="runSelfServiceAction(selfServiceRequestFollowup.action)"
-            >
-              {{ selfServiceRequestFollowup.actionLabel }}
-            </button>
-          </div>
-          <ul v-if="selfServiceRecentRequests.length > 0" class="attendance__request-list attendance__request-list--compact">
-            <li v-for="item in selfServiceRecentRequests" :key="item.id" class="attendance__request-item">
-              <div>
-                <strong>{{ formatRequestType(item.request_type) }}</strong>
-                <span class="attendance__status-chip" :class="`attendance__status-chip--${item.status}`">
-                  {{ formatStatus(item.status) }}
-                </span>
-              </div>
-              <div class="attendance__request-meta">
-                <span>{{ formatDate(item.work_date) }}</span>
-                <span>{{ selfServiceRequestSubtitle(item) }}</span>
-              </div>
-              <div class="attendance__request-meta" v-if="requestReasonText(item)">
-                <span>{{ tr('Reason', '原因') }}: {{ requestReasonText(item) }}</span>
-              </div>
-              <div class="attendance__request-meta" v-if="requestDecisionCommentText(item)">
-                <span>{{ requestDecisionCommentLabel(item) }}: {{ requestDecisionCommentText(item) }}</span>
-              </div>
-              <p class="attendance__request-note">
-                {{ describeRequestStatus(item.status, item) }}
-              </p>
-            </li>
-          </ul>
-          <div v-else class="attendance__empty">{{ tr('No recent requests in this range.', '当前区间内暂无申请。') }}</div>
-        </div>
-
-        <div class="attendance__card attendance__card--selfservice" data-selfservice-card="actions">
-          <div class="attendance__requests-header">
-            <div>
-              <h3>{{ tr('Quick actions', '快捷操作') }}</h3>
-              <small class="attendance__field-hint">
-                {{
-                  tr(
-                    'Jump straight into the most common employee actions without leaving overview.',
-                    '无需离开总览，直接进入最常用的员工操作。',
-                  )
-                }}
-              </small>
-            </div>
-          </div>
-          <div class="attendance__selfservice-callout" data-selfservice-primary-action>
-            <div class="attendance__selfservice-callout-copy">
-              <div class="attendance__selfservice-callout-header">
-                <strong>{{ selfServicePrimaryAction.title }}</strong>
-              </div>
-              <p>{{ selfServicePrimaryAction.detail }}</p>
-            </div>
-            <button
-              v-if="selfServicePrimaryAction.action && selfServicePrimaryAction.actionLabel"
-              class="attendance__btn attendance__btn--primary"
-              type="button"
-              data-selfservice-action="recommended"
-              @click="runSelfServiceAction(selfServicePrimaryAction.action)"
-            >
-              {{ selfServicePrimaryAction.actionLabel }}
-            </button>
-          </div>
-          <div class="attendance__quick-actions">
-            <button
-              class="attendance__btn attendance__btn--primary"
-              type="button"
-              data-selfservice-action="missing-punch"
-              @click="openMissingPunchQuickAction"
-            >
-              {{ tr('Fix missing punch', '处理缺卡') }}
-            </button>
-            <button
-              class="attendance__btn"
-              type="button"
-              data-selfservice-action="leave"
-              @click="openQuickRequestDraft('leave')"
-            >
-              {{ tr('Leave request', '请假申请') }}
-            </button>
-            <button
-              class="attendance__btn"
-              type="button"
-              data-selfservice-action="overtime"
-              @click="openQuickRequestDraft('overtime')"
-            >
-              {{ tr('Overtime request', '加班申请') }}
-            </button>
-            <button
-              class="attendance__btn"
-              type="button"
-              data-selfservice-action="shift-swap"
-              @click="openQuickRequestDraft('shift_swap')"
-            >
-              {{ tr('Shift swap', '换班申请') }}
-            </button>
-            <button
-              class="attendance__btn"
-              type="button"
-              data-selfservice-action="records"
-              @click="scrollToOverviewSection(ATTENDANCE_OVERVIEW_SECTION_IDS.records)"
-            >
-              {{ tr('Review records', '查看记录') }}
-            </button>
-          </div>
-          <p class="attendance__field-hint attendance__field-hint--strong">
-            {{ selfServiceQuickActionHint }}
-          </p>
-        </div>
-
-        <div class="attendance__card attendance__card--selfservice" data-selfservice-card="guide">
-          <div class="attendance__requests-header">
-            <div>
-              <h3>{{ tr('Status guide', '状态说明') }}</h3>
-              <small class="attendance__field-hint">
-                {{
-                  tr(
-                    'Turns attendance status codes into plain-language reminders for employees.',
-                    '把考勤状态码转换成员工能直接理解的说明。',
-                  )
-                }}
-              </small>
-            </div>
-          </div>
-          <ul class="attendance__status-guide">
-            <li v-for="item in attendanceStatusGuideItems" :key="item.key" class="attendance__status-guide-item">
-              <div class="attendance__status-guide-header">
-                <strong>{{ item.label }}</strong>
-                <span class="attendance__field-hint">{{ item.code }}</span>
-              </div>
-              <p>{{ item.description }}</p>
-            </li>
-          </ul>
-        </div>
-      </section>
-
+      <!--
+        The historical surfaces below (summary/calendar/adjustment-request/
+        request-report, then status guide) stay parent-authored and simply
+        keep their existing v-if gating — since the reports-only toolbar/
+        insights sections between here and there render zero DOM nodes in
+        overview mode, they do not break DOM adjacency (lock §5: the history
+        disclosure sits "immediately before historical content"; §4.3 item 6
+        keeps the status guide last). This first extraction does not move
+        this handler-dense block into AttendanceEmployeeWorkspace — see the
+        component's file header comment.
+      -->
       <section v-if="showReports" class="attendance__card attendance__card--report-toolbar">
         <div class="attendance__requests-header">
           <h3>{{ tr('Report Period', '报表区间') }}</h3>
@@ -1358,6 +1080,31 @@
             </table>
           </div>
         </div>
+      </section>
+
+      <section v-if="showOverview" class="attendance__card attendance__card--selfservice" data-selfservice-card="guide">
+        <div class="attendance__requests-header">
+          <div>
+            <h3>{{ tr('Status guide', '状态说明') }}</h3>
+            <small class="attendance__field-hint">
+              {{
+                tr(
+                  'Turns attendance status codes into plain-language reminders for employees.',
+                  '把考勤状态码转换成员工能直接理解的说明。',
+                )
+              }}
+            </small>
+          </div>
+        </div>
+        <ul class="attendance__status-guide">
+          <li v-for="item in attendanceStatusGuideItems" :key="item.key" class="attendance__status-guide-item">
+            <div class="attendance__status-guide-header">
+              <strong>{{ item.label }}</strong>
+              <span class="attendance__field-hint">{{ item.code }}</span>
+            </div>
+            <p>{{ item.description }}</p>
+          </li>
+        </ul>
       </section>
 
       <section
@@ -10015,6 +9762,8 @@ import {
 } from './attendance/attendanceApprovalSteps'
 import { useAttendanceApprovalDirectoryReadiness } from './attendance/useAttendanceApprovalDirectoryReadiness'
 import AttendanceReportFieldsSection from './attendance/AttendanceReportFieldsSection.vue'
+import AttendanceEmployeeWorkspace from './attendance/AttendanceEmployeeWorkspace.vue'
+import { resolveAttendanceOverviewAttention } from './attendance/attendanceOverviewPriority'
 import {
   buildCalendarPolicyOverrideDiagnostics,
   calendarPolicyOverridesFromForm,
@@ -10586,14 +10335,6 @@ type AttendanceSelfServiceActionKey =
   | 'shift_swap'
   | 'records'
   | 'request-report'
-
-interface AttendanceSelfServiceFocusItem {
-  key: string
-  title: string
-  detail: string
-  action: AttendanceSelfServiceActionKey | null
-  actionLabel: string | null
-}
 
 interface AttendanceSelfServiceRequestFollowup {
   title: string
@@ -11790,6 +11531,15 @@ const missedPunchReminderConfirm = reactive({
 const statusMessage = ref('')
 const statusKind = ref<'info' | 'error'>('info')
 const statusMeta = ref<AttendanceStatusMeta | null>(null)
+// Employee-overview task-first design-lock (RATIFIED 2026-07-21) §4.2 row 1:
+// the shared status banner is reused by many non-punch flows (refresh,
+// admin, import, save-settings...), so "actionable punch failure" needs a
+// marker scoped to punch specifically — set only by punch()'s catch branches
+// via setStatus's optional `source` argument, cleared whenever any OTHER
+// call to setStatus/setStatusFromError supersedes the banner (default source
+// is null, so every pre-existing call site is unaffected).
+const statusSource = ref<'punch' | null>(null)
+const punchFailureActive = computed(() => statusKind.value === 'error' && statusSource.value === 'punch')
 const calendarMonth = ref(new Date())
 const pluginsLoaded = ref(false)
 const exporting = ref(false)
@@ -13180,100 +12930,34 @@ const attendanceStatusGuideItems = computed<AttendanceSelfServiceStatusGuideItem
   },
 ])
 
-const selfServiceFocusItems = computed<AttendanceSelfServiceFocusItem[]>(() => {
-  if (selfServiceNeedsSetupHint.value) {
-    return [
-      {
-        key: 'setup-guidance',
-        title: tr('Check attendance setup', '检查考勤配置'),
-        detail: selfServiceSetupFollowupHint.value,
-        action: null,
-        actionLabel: null,
-      },
-    ]
-  }
+// Employee-overview task-first design-lock (RATIFIED 2026-07-21) §4.2: ONE
+// canonical "Needs attention" item, built from the same facts the retired
+// selfServiceFocusItems/selfServicePrimaryAction computeds used to derive
+// (activeWorkbenchRecord, anomalies, requests, the setup gate) plus the
+// shared status banner. See attendanceOverviewPriority.ts for the pure,
+// independently-tested first-match table.
+const workbenchRecordStatus = computed<string | null>(() => activeWorkbenchRecord.value?.status ?? null)
+const workbenchFocusDateLabel = computed<string | null>(() =>
+  activeWorkbenchRecord.value ? formatDate(activeWorkbenchRecord.value.work_date) : null
+)
+const workbenchWorkMinutes = computed(() => activeWorkbenchRecord.value?.work_minutes ?? 0)
 
-  const items: AttendanceSelfServiceFocusItem[] = []
-  const focusRecord = activeWorkbenchRecord.value
-  const attentionCount = activeWorkbenchAttentionCount.value
-  const pendingCount = countRequestsByStatus('pending')
-
-  if (attentionCount > 0) {
-    items.push({
-      key: 'anomalies',
-      title: tr('Resolve anomaly reminders', '优先处理异常提醒'),
-      detail: tr(
-        `The focus date still has ${attentionCount} anomaly reminder${attentionCount === 1 ? '' : 's'}.`,
-        `关注日期仍有 ${attentionCount} 条异常提醒待处理。`,
-      ),
-      action: 'missing-punch',
-      actionLabel: tr('Fix missing punch', '处理缺卡'),
-    })
-  }
-
-  if (pendingCount > 0) {
-    items.push({
-      key: 'pending-requests',
-      title: tr('Track pending approvals', '跟进待审批申请'),
-      detail: tr(
-        `${pendingCount} request${pendingCount === 1 ? '' : 's'} in this range still need approval.`,
-        `当前区间内还有 ${pendingCount} 条申请待审批。`,
-      ),
-      action: 'request-report',
-      actionLabel: tr('Open request report', '打开申请报表'),
-    })
-  }
-
-  if (focusRecord && !['normal', 'off'].includes(focusRecord.status)) {
-    items.push({
-      key: 'record-review',
-      title: tr('Review the focus workday', '查看关注工作日'),
-      detail: tr(
-        `${formatStatus(focusRecord.status)} was recorded for ${formatDate(focusRecord.work_date)}.`,
-        `${formatDate(focusRecord.work_date)} 记录为${formatStatus(focusRecord.status)}。`,
-      ),
-      action: 'records',
-      actionLabel: tr('Review records', '查看记录'),
-    })
-  }
-
-  if (items.length === 0) {
-    items.push({
-      key: 'all-clear',
-      title: tr('You are caught up', '当前已处理完毕'),
-      detail: tr(
-        'No anomaly reminders or pending approvals are blocking your attendance follow-up in this range.',
-        '当前区间内没有异常提醒或待审批事项阻塞你的考勤跟进。',
-      ),
-      action: 'records',
-      actionLabel: tr('Open records', '打开记录'),
-    })
-  }
-
-  return items
-})
-
-const selfServicePrimaryAction = computed<AttendanceSelfServiceFocusItem>(() => {
-  if (selfServiceNeedsSetupHint.value) {
-    return {
-      key: 'setup-wait',
-      title: tr('Wait for attendance setup', '等待考勤配置'),
-      detail: selfServiceSetupFollowupHint.value,
-      action: null,
-      actionLabel: null,
-    }
-  }
-  return selfServiceFocusItems.value.find(item => item.action && item.actionLabel) ?? {
-    key: 'default-leave',
-    title: tr('Start a new attendance request', '发起新的考勤申请'),
-    detail: tr(
-      'Use the quick actions to create a leave, overtime, or missing-punch request without leaving overview.',
-      '无需离开总览，即可用快捷操作发起请假、加班或补卡申请。',
-    ),
-    action: 'leave',
-    actionLabel: tr('Leave request', '请假申请'),
-  }
-})
+const attendanceOverviewAttentionItem = computed(() => resolveAttendanceOverviewAttention(
+  {
+    punchFailureActive: punchFailureActive.value,
+    punchFailureMessage: statusMessage.value,
+    anomalyCount: activeWorkbenchAttentionCount.value,
+    focusDateLabel: workbenchFocusDateLabel.value,
+    latestRequestStatus: selfServiceSortedRequests.value[0]?.status ?? null,
+    pendingRequestCount: countRequestsByStatus('pending'),
+    focusRecordStatus: workbenchRecordStatus.value,
+    focusRecordStatusLabel: workbenchRecordStatus.value ? formatStatus(workbenchRecordStatus.value) : null,
+    focusRecordDateLabel: workbenchFocusDateLabel.value,
+    needsSetup: selfServiceNeedsSetupHint.value,
+    setupHint: selfServiceSetupFollowupHint.value,
+  },
+  tr,
+))
 
 const selfServiceQuickActionHint = computed(() => {
   if (selfServiceNeedsSetupHint.value) {
@@ -20073,9 +19757,14 @@ function classifyStatusError(
   return { message, meta }
 }
 
-function setStatusFromError(error: unknown, fallbackMessage: string, context: AttendanceStatusContext) {
+function setStatusFromError(
+  error: unknown,
+  fallbackMessage: string,
+  context: AttendanceStatusContext,
+  source: 'punch' | null = null,
+) {
   const { message, meta } = classifyStatusError(error, fallbackMessage, context)
-  setStatus(message || fallbackMessage, 'error', meta)
+  setStatus(message || fallbackMessage, 'error', meta, source)
 }
 
 async function runStatusAction() {
@@ -20144,12 +19833,18 @@ async function runStatusAction() {
   }
 }
 
-function setStatus(message: string, kind: 'info' | 'error' = 'info', meta: AttendanceStatusMeta | null = null) {
+function setStatus(
+  message: string,
+  kind: 'info' | 'error' = 'info',
+  meta: AttendanceStatusMeta | null = null,
+  source: 'punch' | null = null,
+) {
   const normalizedMessage = kind === 'error'
     ? localizeRuntimeErrorMessage(message, message)
     : message
   statusKind.value = kind
   statusMeta.value = kind === 'error' ? meta : null
+  statusSource.value = normalizedMessage ? source : null
   if (statusMessage.value === normalizedMessage && normalizedMessage) {
     statusMessage.value = ''
     void nextTick(() => {
@@ -20167,6 +19862,9 @@ function setStatus(message: string, kind: 'info' | 'error' = 'info', meta: Atten
       statusMessage.value = ''
       if (statusMeta.value === meta) {
         statusMeta.value = null
+      }
+      if (statusSource.value === source) {
+        statusSource.value = null
       }
     }
   }, timeoutMs)
@@ -20973,16 +20671,18 @@ async function punch(eventType: PunchEventType, retryNote?: string) {
       // G2: enum-strict — only this exact code opens the inline note form.
       punchOutdoorNoteRequired.value = true
       punchOutdoorNoteEventType.value = eventType
-      setStatus(errorOutcome.message, 'error', { code: errorOutcome.code })
+      // source: 'punch' — employee-overview task-first design-lock §4.2 row 1
+      // ("actionable punch failure") reads this via punchFailureActive.
+      setStatus(errorOutcome.message, 'error', { code: errorOutcome.code }, 'punch')
     } else if (errorOutcome?.kind === 'locationRestricted') {
       // G3: a calibrated dead-end — no retry action (a retry would fail the
       // same way every time under the current org configuration).
       resetPunchOutdoorNote()
-      setStatus(errorOutcome.message, 'error', { code: errorOutcome.code })
+      setStatus(errorOutcome.message, 'error', { code: errorOutcome.code }, 'punch')
     } else {
       // Unknown/other codes: unchanged existing generic path.
       resetPunchOutdoorNote()
-      setStatusFromError(error, tr('Punch failed', '打卡失败'), 'refresh')
+      setStatusFromError(error, tr('Punch failed', '打卡失败'), 'refresh', 'punch')
     }
   } finally {
     punching.value = false
@@ -23836,6 +23536,7 @@ const annualBalanceData = ref<AnnualLeaveBalanceData | null>(null)
 const selfRulesData = ref<AttendanceSelfRulesData | null>(null)
 const selfRulesLoading = ref(false)
 const selfRulesError = ref<string | null>(null)
+const selfRulesHasData = computed(() => selfRulesData.value !== null)
 
 function summarizeSelfRulesGroups(groups: AttendanceSelfRulesGroupSummary[] | undefined, emptyLabel: string): string {
   if (!Array.isArray(groups) || groups.length === 0) return emptyLabel
@@ -24032,6 +23733,7 @@ const leaveMinutesDaysHint = computed(() => {
 const annualSelfBalance = ref<AnnualLeaveBalanceData | null>(null)
 const annualSelfBalanceLoading = ref(false)
 const annualSelfBalanceError = ref<string | null>(null)
+const annualSelfBalanceSummary = computed(() => annualSelfBalance.value?.summary ?? null)
 
 async function loadAnnualSelfBalance(): Promise<void> {
   annualSelfBalanceLoading.value = true

--- a/apps/web/src/views/attendance/AttendanceEmployeeWorkspace.vue
+++ b/apps/web/src/views/attendance/AttendanceEmployeeWorkspace.vue
@@ -1,0 +1,978 @@
+<!--
+  Employee overview task-first design-lock (2026-07-16, RATIFIED 2026-07-21):
+  docs/development/attendance-employee-overview-task-first-design-lock-20260716.md
+  vNext charter §6.2 (Wave 2 / issue #4355): first extraction of the overview's
+  Today / Needs-attention / More-attendance-tools bands.
+
+  This component owns LAYOUT, DISPLAY, and re-emitting real parent actions —
+  it fetches nothing, holds no route/API state, and duplicates no write path.
+  API calls, route sync, and the punch/request handlers stay in
+  AttendanceView.vue (charter §6.2 table, "暂留父层"). The heavy historical
+  surfaces (summary, calendar, adjustment/request list, request report) are
+  NOT re-authored here — they remain parent-owned markup, passed in through
+  the `historyFilters` slot, so this first extraction does not touch their
+  handler-dense code (charter §6.1: "先拆展示和纯状态, 再拆网络与写入"). The
+  history disclosure this component renders sits immediately before that
+  parent-owned historical content and the parent-owned status-guide card
+  (lock §5, §4.3 item 6) — AttendanceView.vue keeps both as siblings right
+  after this component so the reports-only sections between them (zero DOM
+  nodes in overview mode) do not break that adjacency.
+-->
+<template>
+  <div class="attendance-ew">
+    <div class="attendance-ew__today">
+      <div class="attendance__hero-punch" data-testid="attendance-hero-punch">
+        <div class="attendance__hero-clock">
+          <span class="attendance__hero-time" data-testid="attendance-hero-time">{{ heroClockTime }}</span>
+          <span class="attendance__hero-date">{{ heroClockDate }}</span>
+        </div>
+        <div class="attendance__actions attendance__hero-actions">
+          <button
+            class="attendance__btn attendance__btn--primary attendance__btn--hero"
+            :disabled="punching"
+            @click="$emit('punch', 'check_in')"
+          >
+            {{ punching ? tr('Working...', '处理中...') : tr('Check In', '上班打卡') }}
+          </button>
+          <button
+            class="attendance__btn attendance__btn--hero-secondary"
+            :disabled="punching"
+            @click="$emit('punch', 'check_out')"
+          >
+            {{ punching ? tr('Working...', '处理中...') : tr('Check Out', '下班打卡') }}
+          </button>
+        </div>
+        <div v-if="heroTimeline" class="attendance__hero-timeline" data-testid="attendance-hero-timeline">
+          <span class="attendance__hero-timeline-node" :class="{ 'attendance__hero-timeline-node--pending': !heroTimeline.checkIn }">
+            <span class="attendance__hero-timeline-dot" />
+            {{ tr('In', '上班') }} {{ heroTimeline.checkIn ?? '--:--' }}
+          </span>
+          <span class="attendance__hero-timeline-rail" />
+          <span class="attendance__hero-timeline-node" :class="{ 'attendance__hero-timeline-node--pending': !heroTimeline.checkOut }">
+            <span class="attendance__hero-timeline-dot" />
+            {{ tr('Out', '下班') }} {{ heroTimeline.checkOut ?? '--:--' }}
+          </span>
+        </div>
+        <div v-if="punchOutdoorNoteRequired" class="attendance__punch-note" data-attendance-punch-note-form>
+          <label class="attendance__field" for="attendance-punch-outdoor-note">
+            <span>{{ tr('Outdoor punch note', '外勤打卡备注') }}</span>
+            <input
+              id="attendance-punch-outdoor-note"
+              :value="punchOutdoorNoteDraft"
+              type="text"
+              :placeholder="tr('Required to submit an outdoor punch', '提交外勤打卡需填写')"
+              @input="$emit('update:punchOutdoorNoteDraft', ($event.target as HTMLInputElement).value)"
+              @keydown.enter.prevent="$emit('retryPunchNote')"
+            />
+          </label>
+          <button
+            class="attendance__btn attendance__btn--inline"
+            type="button"
+            data-attendance-punch-note-retry
+            :disabled="punching || !punchOutdoorNoteDraft.trim()"
+            @click="$emit('retryPunchNote')"
+          >
+            {{ punching ? tr('Working...', '处理中...') : tr('Retry punch with note', '补充备注后重试打卡') }}
+          </button>
+        </div>
+      </div>
+
+      <div class="attendance__card attendance__card--selfservice attendance-ew__today-status" data-selfservice-card="status">
+        <div class="attendance__requests-header">
+          <div>
+            <h3>{{ tr('My status', '我的状态') }}</h3>
+            <small class="attendance__field-hint">
+              {{
+                workbenchFocusDateLabel
+                  ? tr(`Focus date: ${workbenchFocusDateLabel}`, `关注日期：${workbenchFocusDateLabel}`)
+                  : tr('Focus date: current range', '关注日期：当前区间')
+              }}
+            </small>
+          </div>
+          <span
+            v-if="workbenchRecordStatus"
+            class="attendance__status-chip"
+            :class="`attendance__status-chip--${workbenchRecordStatus}`"
+          >
+            {{ formatStatus(workbenchRecordStatus) }}
+          </span>
+        </div>
+        <p class="attendance__selfservice-lead">{{ workbenchStatusDescription }}</p>
+        <div class="attendance__summary attendance__summary--workbench attendance__summary--stat">
+          <div class="attendance__summary-item attendance__summary-item--stat">
+            <svg class="attendance__summary-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 2" /></svg>
+            <span>{{ tr('Latest punch', '最近一次打卡') }}</span>
+            <strong class="attendance__summary-value">{{ workbenchLatestPunchLabel }}</strong>
+          </div>
+          <div class="attendance__summary-item attendance__summary-item--stat">
+            <svg class="attendance__summary-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M10 2h4M12 2v4" /><circle cx="12" cy="14" r="7" /><path d="M12 14l2.5-2.5" /></svg>
+            <span>{{ tr('Work minutes', '工时分钟') }}</span>
+            <strong class="attendance__summary-value">{{ workbenchWorkMinutes }}</strong>
+          </div>
+          <div class="attendance__summary-item attendance__summary-item--stat">
+            <svg class="attendance__summary-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 3l10 18H2z" /><path d="M12 10v5M12 18.5v.5" /></svg>
+            <span>{{ tr('Late / Early', '迟到 / 早退') }}</span>
+            <strong class="attendance__summary-value" :class="{ 'attendance__summary-value--warning': workbenchHasLateEarly }">{{ workbenchLateEarlyLabel }}</strong>
+          </div>
+        </div>
+        <p
+          v-if="selfServiceNeedsSetupHint"
+          class="attendance__field-hint attendance__field-hint--strong"
+          data-selfservice-setup-hint
+        >
+          {{ selfServiceSetupFollowupHint }}
+        </p>
+      </div>
+    </div>
+
+    <div v-if="statusMessage" class="attendance__status-block">
+      <span class="attendance__status" :class="{ 'attendance__status--error': statusKind === 'error' }">
+        {{ statusMessage }}
+      </span>
+      <span v-if="statusCode" class="attendance__field-hint attendance__field-hint--error">
+        {{ tr('Code', '代码') }}: {{ statusCode }}
+      </span>
+      <span v-if="statusHint" class="attendance__field-hint" :class="{ 'attendance__field-hint--error': statusKind === 'error' }">
+        {{ statusHint }}
+      </span>
+      <button
+        v-if="statusActionLabel"
+        class="attendance__btn attendance__btn--inline"
+        type="button"
+        :disabled="statusActionBusy"
+        @click="$emit('statusAction')"
+      >
+        {{ statusActionBusy ? tr('Working...', '处理中...') : statusActionLabel }}
+      </button>
+    </div>
+
+    <div
+      class="attendance-ew__attention"
+      data-attendance-overview-attention
+      :data-attendance-overview-attention-key="attentionItem.key"
+    >
+      <strong>{{ attentionItem.title }}</strong>
+      <p>{{ attentionItem.detail }}</p>
+      <button
+        v-if="attentionItem.action && attentionItem.actionLabel"
+        class="attendance__btn attendance__btn--primary"
+        type="button"
+        data-attendance-overview-attention-action
+        @click="$emit('selfServiceAction', attentionItem.action)"
+      >
+        {{ attentionItem.actionLabel }}
+      </button>
+    </div>
+
+    <div class="attendance-ew__tools">
+      <div class="attendance__card attendance__card--selfservice" data-selfservice-card="requests">
+        <div class="attendance__requests-header">
+          <div>
+            <h3>{{ tr('My request status', '我的申请状态') }}</h3>
+            <small class="attendance__field-hint">
+              {{ tr('Summarizes the current request backlog from the visible date range.', '汇总当前可见日期区间内的申请处理状态。') }}
+            </small>
+          </div>
+          <strong>{{ requestsTotal }}</strong>
+        </div>
+        <div class="attendance__chip-list">
+          <span
+            v-for="item in selfServiceRequestStatusItems"
+            :key="item.key"
+            class="attendance__status-chip"
+            :class="`attendance__status-chip--${item.key}`"
+            :data-selfservice-request-stat="item.key"
+          >
+            {{ item.label }} · {{ item.count }}
+          </span>
+        </div>
+        <div class="attendance__selfservice-callout" data-selfservice-request-followup>
+          <div class="attendance__selfservice-callout-copy">
+            <div class="attendance__selfservice-callout-header">
+              <strong>{{ selfServiceRequestFollowup.title }}</strong>
+              <span
+                v-if="selfServiceRequestFollowup.status"
+                class="attendance__status-chip"
+                :class="`attendance__status-chip--${selfServiceRequestFollowup.status}`"
+              >
+                {{ formatStatus(selfServiceRequestFollowup.status) }}
+              </span>
+            </div>
+            <p>{{ selfServiceRequestFollowup.detail }}</p>
+          </div>
+          <button
+            class="attendance__btn attendance__btn--inline"
+            type="button"
+            data-selfservice-action="request-followup"
+            @click="$emit('selfServiceAction', selfServiceRequestFollowup.action)"
+          >
+            {{ selfServiceRequestFollowup.actionLabel }}
+          </button>
+        </div>
+        <ul v-if="selfServiceRecentRequests.length > 0" class="attendance__request-list attendance__request-list--compact">
+          <li v-for="item in selfServiceRecentRequests" :key="item.id" class="attendance__request-item">
+            <div>
+              <strong>{{ formatRequestType(item.request_type) }}</strong>
+              <span class="attendance__status-chip" :class="`attendance__status-chip--${item.status}`">
+                {{ formatStatus(item.status) }}
+              </span>
+            </div>
+            <div class="attendance__request-meta">
+              <span>{{ formatDate(item.work_date) }}</span>
+              <span>{{ selfServiceRequestSubtitle(item) }}</span>
+            </div>
+            <div class="attendance__request-meta" v-if="requestReasonText(item)">
+              <span>{{ tr('Reason', '原因') }}: {{ requestReasonText(item) }}</span>
+            </div>
+            <div class="attendance__request-meta" v-if="requestDecisionCommentText(item)">
+              <span>{{ requestDecisionCommentLabel(item) }}: {{ requestDecisionCommentText(item) }}</span>
+            </div>
+            <p class="attendance__request-note">
+              {{ describeRequestStatus(item.status, item) }}
+            </p>
+          </li>
+        </ul>
+        <div v-else class="attendance__empty">{{ tr('No recent requests in this range.', '当前区间内暂无申请。') }}</div>
+      </div>
+
+      <div class="attendance__card attendance__card--selfservice" data-selfservice-card="actions">
+        <div class="attendance__requests-header">
+          <div>
+            <h3>{{ tr('Quick actions', '快捷操作') }}</h3>
+            <small class="attendance__field-hint">
+              {{ tr('Jump straight into the most common employee actions without leaving overview.', '无需离开总览，直接进入最常用的员工操作。') }}
+            </small>
+          </div>
+        </div>
+        <div class="attendance__quick-actions">
+          <button
+            class="attendance__btn attendance__btn--primary"
+            type="button"
+            data-selfservice-action="missing-punch"
+            @click="$emit('selfServiceAction', 'missing-punch')"
+          >
+            {{ tr('Fix missing punch', '处理缺卡') }}
+          </button>
+          <button
+            class="attendance__btn"
+            type="button"
+            data-selfservice-action="leave"
+            @click="$emit('selfServiceAction', 'leave')"
+          >
+            {{ tr('Leave request', '请假申请') }}
+          </button>
+          <button
+            class="attendance__btn"
+            type="button"
+            data-selfservice-action="overtime"
+            @click="$emit('selfServiceAction', 'overtime')"
+          >
+            {{ tr('Overtime request', '加班申请') }}
+          </button>
+          <button
+            class="attendance__btn"
+            type="button"
+            data-selfservice-action="shift-swap"
+            @click="$emit('selfServiceAction', 'shift_swap')"
+          >
+            {{ tr('Shift swap', '换班申请') }}
+          </button>
+          <button
+            class="attendance__btn"
+            type="button"
+            data-selfservice-action="records"
+            @click="$emit('selfServiceAction', 'records')"
+          >
+            {{ tr('Review records', '查看记录') }}
+          </button>
+        </div>
+        <p class="attendance__field-hint attendance__field-hint--strong">
+          {{ selfServiceQuickActionHint }}
+        </p>
+      </div>
+
+      <div class="attendance__card attendance__card--selfservice" data-selfservice-card="annual-balance">
+        <div class="attendance__requests-header">
+          <div><h3>{{ tr('My annual leave', '我的年假') }}</h3></div>
+        </div>
+        <p v-if="annualSelfBalanceLoading" class="attendance__field-hint">{{ tr('Loading...', '加载中...') }}</p>
+        <p v-else-if="annualSelfBalanceError" class="attendance__error" data-annual-self-balance-error>{{ annualSelfBalanceError }}</p>
+        <div v-else-if="annualSelfBalanceSummary" class="attendance__selfbalance" data-annual-self-balance>
+          <div class="attendance__selfbalance-remaining">
+            <strong>{{ annualSelfBalanceSummary.remainingMinutes }}</strong> {{ tr('min remaining', '分钟剩余') }}
+          </div>
+          <small class="attendance__field-hint">
+            {{ tr('Granted', '已发放') }} {{ annualSelfBalanceSummary.grantedMinutes }} ·
+            {{ tr('Used', '已用') }} {{ annualSelfBalanceSummary.exhaustedMinutes }} ·
+            {{ tr('Expired', '已过期') }} {{ annualSelfBalanceSummary.expiredMinutes }}
+          </small>
+        </div>
+        <p v-else class="attendance__field-hint">{{ tr('No annual leave balance yet.', '暂无年假余额。') }}</p>
+      </div>
+
+      <div class="attendance__card attendance__card--selfservice attendance-ew__tools-deemphasized" data-selfservice-card="rules">
+        <div class="attendance__requests-header">
+          <div>
+            <h3>{{ tr('My attendance rules', '我的考勤规则') }}</h3>
+            <small class="attendance__field-hint">{{ tr('Read-only summary of the rules currently used for you.', '当前适用于您的考勤规则只读摘要。') }}</small>
+          </div>
+        </div>
+        <p v-if="selfRulesLoading" class="attendance__field-hint">{{ tr('Loading...', '加载中...') }}</p>
+        <p v-else-if="selfRulesError" class="attendance__error" data-selfservice-rules-error>{{ selfRulesError }}</p>
+        <div v-else-if="selfRulesHasData" class="attendance__selfrules" data-selfservice-rules>
+          <div class="attendance__summary attendance__summary--workbench">
+            <div class="attendance__summary-item">
+              <span>{{ tr('Attendance group', '考勤组') }}</span>
+              <strong>{{ selfRulesAttendanceGroupSummary }}</strong>
+            </div>
+            <div class="attendance__summary-item">
+              <span>{{ tr('Schedule group', '排班组') }}</span>
+              <strong>{{ selfRulesScheduleGroupSummary }}</strong>
+            </div>
+            <div class="attendance__summary-item">
+              <span>{{ tr('Work window', '工作时间') }}</span>
+              <strong>{{ selfRulesWorkWindowSummary }}</strong>
+            </div>
+            <div class="attendance__summary-item">
+              <span>{{ tr('Punch policy', '打卡策略') }}</span>
+              <strong>{{ selfRulesPunchPolicySummary }}</strong>
+            </div>
+            <div class="attendance__summary-item">
+              <span>{{ tr('Working days', '工作日') }}</span>
+              <strong>{{ selfRulesWorkingDaysSummary }}</strong>
+            </div>
+            <div class="attendance__summary-item">
+              <span>{{ tr('Late / early grace', '迟到 / 早退宽限') }}</span>
+              <strong>{{ selfRulesGraceSummary }}</strong>
+            </div>
+            <div class="attendance__summary-item">
+              <span>{{ tr('Severe / absence late', '严重 / 旷工迟到') }}</span>
+              <strong>{{ selfRulesLateThresholdSummary }}</strong>
+            </div>
+          </div>
+          <p v-if="selfRulesConfiguredRuleSummary" class="attendance__field-hint attendance__field-hint--strong">
+            {{ selfRulesConfiguredRuleSummary }}
+          </p>
+          <div v-if="selfRulesWarningCodes.length > 0" class="attendance__chip-list" data-selfservice-rules-warnings>
+            <span
+              v-for="code in selfRulesWarningCodes"
+              :key="code"
+              class="attendance__status-chip attendance__status-chip--pending"
+            >
+              {{ formatSelfRulesWarning(code) }}
+            </span>
+          </div>
+        </div>
+        <p v-else class="attendance__field-hint">{{ tr('No attendance rules loaded yet.', '暂无考勤规则摘要。') }}</p>
+      </div>
+
+      <details class="attendance-ew__history-filters" data-attendance-history-filters>
+        <summary class="attendance__details-summary">
+          {{ tr('Date, org, and user filters', '日期 / 组织 / 用户筛选') }}
+        </summary>
+        <div class="attendance__filters">
+          <slot name="historyFilters" />
+        </div>
+      </details>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AttendanceOverviewAttentionItem } from './attendanceOverviewPriority'
+
+type TranslateFn = (en: string, zh: string) => string
+
+/** Same key space `runSelfServiceAction` (AttendanceView.vue) already
+ * switches on — kept local (not imported) since AttendanceView.vue does not
+ * export its types; must be extended in both places together. */
+type WorkspaceSelfServiceActionKey =
+  | 'missing-punch'
+  | 'leave'
+  | 'overtime'
+  | 'shift_swap'
+  | 'records'
+  | 'request-report'
+
+interface WorkspaceRequestItem {
+  id: string
+  work_date: string
+  request_type: string
+  status: string
+  requested_in_at: string | null
+  requested_out_at: string | null
+  reason?: string | null
+  metadata?: Record<string, any>
+}
+
+interface RequestStatusItem {
+  key: string
+  label: string
+  count: number
+}
+
+interface RequestFollowup {
+  title: string
+  detail: string
+  status: string | null
+  action: WorkspaceSelfServiceActionKey
+  actionLabel: string
+}
+
+interface AnnualBalanceSummary {
+  remainingMinutes: number
+  grantedMinutes: number
+  exhaustedMinutes: number
+  expiredMinutes: number
+}
+
+defineProps<{
+  tr: TranslateFn
+  // Today band
+  heroClockTime: string
+  heroClockDate: string
+  punching: boolean
+  heroTimeline: { checkIn: string | null; checkOut: string | null } | null
+  punchOutdoorNoteRequired: boolean
+  punchOutdoorNoteDraft: string
+  workbenchStatusDescription: string
+  workbenchRecordStatus: string | null
+  workbenchFocusDateLabel: string | null
+  workbenchLatestPunchLabel: string
+  workbenchWorkMinutes: number
+  workbenchLateEarlyLabel: string
+  workbenchHasLateEarly: boolean
+  selfServiceNeedsSetupHint: boolean
+  selfServiceSetupFollowupHint: string
+  formatStatus: (value: string) => string
+  // Status banner (not part of the history disclosure)
+  statusMessage: string
+  statusKind: 'info' | 'error'
+  statusCode: string
+  statusHint: string
+  statusActionLabel: string
+  statusActionBusy: boolean
+  // Needs-attention band
+  attentionItem: AttendanceOverviewAttentionItem
+  // Tools band: requests
+  requestsTotal: number
+  selfServiceRequestStatusItems: RequestStatusItem[]
+  selfServiceRequestFollowup: RequestFollowup
+  selfServiceRecentRequests: WorkspaceRequestItem[]
+  formatRequestType: (value: string) => string
+  formatDate: (value: string | null | undefined) => string
+  selfServiceRequestSubtitle: (item: WorkspaceRequestItem) => string
+  requestReasonText: (item: WorkspaceRequestItem) => string
+  requestDecisionCommentText: (item: WorkspaceRequestItem) => string
+  requestDecisionCommentLabel: (item: WorkspaceRequestItem) => string
+  describeRequestStatus: (status: string | null | undefined, item?: WorkspaceRequestItem | null) => string
+  // Tools band: quick actions
+  selfServiceQuickActionHint: string
+  // Tools band: annual balance
+  annualSelfBalanceLoading: boolean
+  annualSelfBalanceError: string | null
+  annualSelfBalanceSummary: AnnualBalanceSummary | null
+  // Tools band: rules (de-emphasized, not removed — lock §4.3 item 4)
+  selfRulesLoading: boolean
+  selfRulesError: string | null
+  selfRulesHasData: boolean
+  selfRulesAttendanceGroupSummary: string
+  selfRulesScheduleGroupSummary: string
+  selfRulesWorkWindowSummary: string
+  selfRulesPunchPolicySummary: string
+  selfRulesWorkingDaysSummary: string
+  selfRulesGraceSummary: string
+  selfRulesLateThresholdSummary: string
+  selfRulesConfiguredRuleSummary: string
+  selfRulesWarningCodes: string[]
+  formatSelfRulesWarning: (code: string) => string
+}>()
+
+defineEmits<{
+  punch: [eventType: 'check_in' | 'check_out']
+  retryPunchNote: []
+  'update:punchOutdoorNoteDraft': [value: string]
+  statusAction: []
+  selfServiceAction: [action: WorkspaceSelfServiceActionKey]
+}>()
+</script>
+
+<style scoped>
+/* Layout shell — new band structure (lock §4, §7). All spacing/colors here
+   use --ms-* tokens; the relocated card styling below is copied verbatim
+   from AttendanceView.vue (byte-identical values) so the reorg introduces
+   no visual drift. */
+.attendance-ew {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-5, 20px);
+}
+
+.attendance-ew__today {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: var(--ms-space-5, 20px);
+  align-items: start;
+}
+
+.attendance-ew__today-status {
+  margin: 0;
+}
+
+.attendance-ew__attention {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-2, 8px);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-lg);
+  background: var(--ms-bg-card);
+  box-shadow: var(--ms-shadow-card);
+  padding: var(--ms-space-4, 16px) var(--ms-space-5, 20px);
+}
+
+.attendance-ew__attention p {
+  margin: 0;
+  color: var(--ms-text-2);
+  line-height: 1.5;
+}
+
+.attendance-ew__tools {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 20px;
+}
+
+.attendance-ew__tools-deemphasized {
+  opacity: 0.92;
+}
+
+.attendance-ew__history-filters {
+  grid-column: 1 / -1;
+  border: 1px dashed var(--ms-border);
+  border-radius: var(--ms-radius-md);
+  padding: var(--ms-space-3, 12px) var(--ms-space-4, 16px);
+  background: var(--ms-bg-page);
+}
+
+.attendance-ew__history-filters[open] {
+  background: var(--ms-bg-card);
+}
+
+/* Relocated card/hero styling, copied verbatim from AttendanceView.vue's
+   scoped stylesheet (Vue scoped CSS does not cross component boundaries —
+   see attendance-employee-overview-task-first-design-lock-20260716.md
+   implementation notes). Do not retokenize values here independently of
+   the source; keep both copies in sync if either changes. */
+.attendance__filters {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.attendance__punch-note {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+
+.attendance__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #555;
+}
+
+.attendance__field input {
+  padding: 6px 10px;
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+  min-width: 180px;
+}
+
+.attendance__field-hint {
+  color: #777;
+  font-size: 11px;
+}
+
+.attendance__field-hint--error {
+  color: #c0392b;
+}
+
+.attendance__field-hint--strong {
+  display: inline-flex;
+  margin-top: 12px;
+  font-weight: 600;
+}
+
+.attendance__btn {
+  padding: 8px 14px;
+  border-radius: 6px;
+  border: 1px solid #d0d0d0;
+  background: #fff;
+  cursor: pointer;
+}
+
+.attendance__btn--primary {
+  background: #1976d2;
+  border-color: #1976d2;
+  color: #fff;
+}
+
+.attendance__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.attendance__btn--inline {
+  padding: 5px 10px;
+  font-size: 12px;
+}
+
+.attendance__status-block {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.attendance__status {
+  font-size: 12px;
+  color: #2e7d32;
+}
+
+.attendance__status--error {
+  color: #c62828;
+}
+
+.attendance__card {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.04);
+}
+
+.attendance__card--selfservice {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.attendance__summary--workbench {
+  margin-top: 0;
+}
+
+.attendance__selfservice-lead {
+  margin: 0;
+  color: #334155;
+  line-height: 1.5;
+}
+
+.attendance__selfservice-callout {
+  border: 1px solid #dbe4f0;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #f8fbff, #eef6ff);
+  padding: 12px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.attendance__selfservice-callout-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.attendance__selfservice-callout-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.attendance__selfservice-callout-copy p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.attendance__quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.attendance__request-list--compact {
+  gap: 8px;
+}
+
+.attendance__request-item {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.attendance__request-meta {
+  display: flex;
+  gap: 12px;
+  font-size: 12px;
+  color: #666;
+}
+
+.attendance__request-note {
+  margin: 0;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.attendance__chip-list {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.attendance__status-chip {
+  margin-left: 8px;
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #f0f0f0;
+}
+
+.attendance__status-chip--pending { background: #fff3e0; color: #ef6c00; }
+.attendance__status-chip--approved { background: #e8f5e9; color: #2e7d32; }
+.attendance__status-chip--normal { background: #e8f5e9; color: #2e7d32; }
+.attendance__status-chip--late { background: #fff3e0; color: #ef6c00; }
+.attendance__status-chip--early_leave { background: #ede7f6; color: #6a1b9a; }
+.attendance__status-chip--late_early { background: #ffebee; color: #c62828; }
+.attendance__status-chip--partial { background: #e3f2fd; color: #1565c0; }
+.attendance__status-chip--adjusted { background: #e0f7fa; color: #006064; }
+.attendance__status-chip--off { background: #eceff1; color: #546e7a; }
+.attendance__status-chip--absent { background: #f5f5f5; color: #616161; }
+.attendance__status-chip--rejected { background: #ffebee; color: #c62828; }
+.attendance__status-chip--cancelled { background: #eceff1; color: #546e7a; }
+
+.attendance__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.attendance__summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: #f7f9fb;
+  border-radius: 8px;
+  padding: 10px;
+}
+
+.attendance__summary-item span {
+  font-size: 12px;
+  color: #666;
+}
+
+.attendance__details-summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--ms-text-1);
+}
+
+.attendance__error {
+  color: #c0392b;
+  font-size: 12px;
+}
+
+.attendance__empty {
+  color: #777;
+  font-size: 13px;
+}
+
+.attendance__selfbalance-remaining {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--ms-text-1);
+}
+
+/* UI-P0'/P1 hero + stat cards — already fully tokenized in the source
+   (see AttendanceView.vue's "UI-P0′ hero punch card" comment); copied
+   verbatim, no hardcoded hex introduced. */
+.attendance__hero-punch {
+  display: flex;
+  align-items: center;
+  gap: var(--ms-space-5);
+  padding: var(--ms-space-4) var(--ms-space-5);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-lg);
+  background: var(--ms-bg-card);
+  box-shadow: var(--ms-shadow-card);
+}
+
+.attendance__hero-clock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-1);
+  min-width: 132px;
+}
+
+.attendance__hero-time {
+  font-size: 32px;
+  font-weight: var(--ms-font-weight-title);
+  line-height: 1.1;
+  color: var(--ms-text-1);
+  font-variant-numeric: tabular-nums;
+}
+
+.attendance__hero-date {
+  font-size: 12px;
+  color: var(--ms-text-3);
+}
+
+.attendance__hero-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--ms-space-3);
+}
+
+.attendance__btn--hero {
+  min-height: 56px;
+  min-width: 160px;
+  font-size: 16px;
+  font-weight: var(--ms-font-weight-title);
+  border-radius: var(--ms-radius-md);
+}
+
+.attendance__btn--hero-secondary {
+  min-height: 56px;
+  min-width: 132px;
+  font-size: 15px;
+  border-radius: var(--ms-radius-md);
+  border-color: var(--ms-color-primary);
+  color: var(--ms-color-primary);
+}
+
+.attendance__hero-timeline {
+  display: flex;
+  align-items: center;
+  gap: var(--ms-space-2);
+  font-size: 12px;
+  color: var(--ms-text-2);
+  font-variant-numeric: tabular-nums;
+}
+
+.attendance__hero-timeline-node {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ms-space-1);
+}
+
+.attendance__hero-timeline-node--pending {
+  color: var(--ms-text-3);
+}
+
+.attendance__hero-timeline-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--ms-color-success);
+}
+
+.attendance__hero-timeline-node--pending .attendance__hero-timeline-dot {
+  background: var(--ms-border);
+}
+
+.attendance__hero-timeline-rail {
+  flex: 0 0 32px;
+  height: 2px;
+  background: var(--ms-border-light);
+  border-radius: 1px;
+}
+
+.attendance__summary--stat {
+  gap: var(--ms-space-3);
+}
+
+.attendance__summary-item--stat {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ms-space-1);
+  padding: var(--ms-space-3) var(--ms-space-4);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-md);
+  background: var(--ms-bg-card);
+  box-shadow: var(--ms-shadow-card);
+}
+
+.attendance__summary-icon {
+  width: 18px;
+  height: 18px;
+  color: var(--ms-color-primary);
+}
+
+.attendance__summary-value {
+  font-size: 22px;
+  line-height: 1.2;
+  font-weight: var(--ms-font-weight-title);
+  color: var(--ms-text-1);
+  font-variant-numeric: tabular-nums;
+}
+
+.attendance__summary-value--warning {
+  color: var(--ms-color-warning);
+}
+
+@media (max-width: 768px) {
+  .attendance-ew__today {
+    grid-template-columns: 1fr;
+  }
+
+  .attendance__hero-punch {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--ms-space-3);
+  }
+
+  .attendance__hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .attendance__hero-timeline {
+    flex-wrap: wrap;
+  }
+
+  .attendance__summary--stat {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .attendance__selfservice-callout {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .attendance__btn {
+    width: 100%;
+  }
+
+  .attendance__request-meta {
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .attendance__filters .attendance__field {
+    width: 100%;
+  }
+}
+</style>

--- a/apps/web/src/views/attendance/attendanceOverviewPriority.ts
+++ b/apps/web/src/views/attendance/attendanceOverviewPriority.ts
@@ -1,0 +1,215 @@
+// Employee overview task-first design-lock (2026-07-16, RATIFIED 2026-07-21):
+// docs/development/attendance-employee-overview-task-first-design-lock-20260716.md
+// §4.2 (attention priority table) / §9.1 (verification gates).
+//
+// Pure first-match "Needs attention" builder for the overview band. It
+// consumes the SAME facts `AttendanceView.vue` already derives from
+// `activeWorkbenchRecord` / `anomalies` / `requests` / the shared status
+// banner (`statusMessage`/`statusKind`/`statusMeta`) — it fetches no new
+// data and reinterprets no backend status/error code. Its only job is to
+// pick ONE canonical attention item so the overview never renders the old
+// focus-list + recommended-action callout as two competing copies (lock §1,
+// §4.2 opening paragraph).
+//
+// Row order is first-match-wins and MUST NOT be reordered without a lock
+// amendment — see the §4.2 table for the authoritative priority text.
+
+export type TranslateFn = (en: string, zh: string) => string
+
+export type AttendanceOverviewAttentionKey =
+  | 'punch_failure'
+  | 'anomaly'
+  | 'request_rejected'
+  | 'request_pending'
+  | 'record_review'
+  | 'setup_needed'
+  | 'all_clear'
+  | 'unknown_status'
+
+export type AttendanceOverviewAttentionAction =
+  | 'missing-punch'
+  | 'leave'
+  | 'overtime'
+  | 'shift_swap'
+  | 'records'
+  | 'request-report'
+  | null
+
+export interface AttendanceOverviewAttentionItem {
+  key: AttendanceOverviewAttentionKey
+  title: string
+  detail: string
+  action: AttendanceOverviewAttentionAction
+  actionLabel: string | null
+  /**
+   * True only for `punch_failure`. The shared status banner (directly below
+   * the daily workspace, lock §4.1) already renders this item's message,
+   * code, hint, and any real retry control — the attention band must render
+   * no SECOND actionable control for it (lock §9.2: "exactly one primary
+   * recommended action is rendered").
+   */
+  presentedByStatusBanner: boolean
+}
+
+// The record-status enum the backend actually emits, mirrored from
+// `AttendanceView.vue`'s `describeAttendanceStatus` / status-chip classes.
+// Any status outside these two sets is unrecognized and must fail closed to
+// `unknown_status`, never silently read as `all_clear` (lock §9.1).
+const RECORD_STATUS_NEEDS_REVIEW = new Set(['late', 'early_leave', 'late_early', 'partial', 'absent'])
+const RECORD_STATUS_ALL_CLEAR = new Set(['normal', 'adjusted', 'off'])
+
+export interface AttendanceOverviewAttentionFacts {
+  /**
+   * True while the status banner currently shows a punch-triggered error
+   * (outdoor note required OR any other punch failure) — never a refresh,
+   * admin, save-settings, or import error unrelated to punching. The caller
+   * is responsible for scoping this (e.g. a dedicated status-source marker),
+   * since the shared banner is reused by many non-punch flows.
+   */
+  punchFailureActive: boolean
+  /** Mirrors `statusMessage` while `punchFailureActive` is true. */
+  punchFailureMessage: string
+  /** Current focus-date anomaly count, already scoped like
+   * `activeWorkbenchAttentionCount` (0 when there is none). */
+  anomalyCount: number
+  /** Human-readable focus date, or null when there is no focus record. */
+  focusDateLabel: string | null
+  /**
+   * Status of the most-recently-submitted request (same sort order as
+   * `selfServiceSortedRequests`), or null when there are no requests at all.
+   */
+  latestRequestStatus: string | null
+  pendingRequestCount: number
+  /** `activeWorkbenchRecord?.status ?? null` — raw backend value, untouched. */
+  focusRecordStatus: string | null
+  /** Localized label for `focusRecordStatus` (e.g. via `formatStatus`). */
+  focusRecordStatusLabel: string | null
+  /** Localized date for `focusRecordStatus`'s work_date, if any. */
+  focusRecordDateLabel: string | null
+  /** Same gate `selfServiceNeedsSetupHint` already computes. */
+  needsSetup: boolean
+  /** Same copy `selfServiceSetupFollowupHint` already computes. */
+  setupHint: string
+}
+
+export function resolveAttendanceOverviewAttention(
+  facts: AttendanceOverviewAttentionFacts,
+  tr: TranslateFn,
+): AttendanceOverviewAttentionItem {
+  // Priority 1 — outdoor note required or an actionable punch failure.
+  if (facts.punchFailureActive) {
+    return {
+      key: 'punch_failure',
+      title: tr('Resolve your punch first', '请先处理打卡问题'),
+      detail: facts.punchFailureMessage,
+      action: null,
+      actionLabel: null,
+      presentedByStatusBanner: true,
+    }
+  }
+
+  // Priority 2 — current focus date has an anomaly.
+  if (facts.anomalyCount > 0) {
+    return {
+      key: 'anomaly',
+      title: tr('Resolve anomaly reminders', '优先处理异常提醒'),
+      detail: facts.focusDateLabel
+        ? tr(
+          `${facts.anomalyCount} anomaly reminder${facts.anomalyCount === 1 ? '' : 's'} on ${facts.focusDateLabel}.`,
+          `${facts.focusDateLabel} 仍有 ${facts.anomalyCount} 条异常提醒待处理。`,
+        )
+        : tr(
+          `${facts.anomalyCount} anomaly reminder${facts.anomalyCount === 1 ? '' : 's'} need attention.`,
+          `仍有 ${facts.anomalyCount} 条异常提醒待处理。`,
+        ),
+      action: 'missing-punch',
+      actionLabel: tr('Fix missing punch', '处理缺卡'),
+      presentedByStatusBanner: false,
+    }
+  }
+
+  // Priority 3 — the latest request was rejected (state it plainly; never as pending).
+  if (facts.latestRequestStatus === 'rejected') {
+    return {
+      key: 'request_rejected',
+      title: tr('Needs attention', '需要关注'),
+      detail: tr(
+        'Your latest request was rejected and may need a new submission.',
+        '你最近提交的申请已被驳回，可能需要重新提交。',
+      ),
+      action: 'request-report',
+      actionLabel: tr('Review request history', '查看申请历史'),
+      presentedByStatusBanner: false,
+    }
+  }
+
+  // Priority 4 — one or more requests pending (never implies approval power).
+  if (facts.pendingRequestCount > 0) {
+    return {
+      key: 'request_pending',
+      title: tr('Track pending approvals', '跟进待审批申请'),
+      detail: tr(
+        `${facts.pendingRequestCount} request${facts.pendingRequestCount === 1 ? '' : 's'} still waiting for approval.`,
+        `还有 ${facts.pendingRequestCount} 条申请正在等待审批。`,
+      ),
+      action: 'request-report',
+      actionLabel: tr('Open request report', '打开申请报表'),
+      presentedByStatusBanner: false,
+    }
+  }
+
+  // Priority 5 — focus record is late / early / late+early / partial / absent.
+  if (facts.focusRecordStatus && RECORD_STATUS_NEEDS_REVIEW.has(facts.focusRecordStatus)) {
+    const statusLabel = facts.focusRecordStatusLabel ?? facts.focusRecordStatus
+    return {
+      key: 'record_review',
+      title: tr('Review the focus workday', '查看关注工作日'),
+      detail: facts.focusRecordDateLabel
+        ? tr(`${statusLabel} was recorded for ${facts.focusRecordDateLabel}.`, `${facts.focusRecordDateLabel} 记录为${statusLabel}。`)
+        : tr(`${statusLabel} was recorded for the focus workday.`, `关注工作日记录为${statusLabel}。`),
+      action: 'records',
+      actionLabel: tr('Review records', '查看记录'),
+      presentedByStatusBanner: false,
+    }
+  }
+
+  // Priority 6 — no record/request/anomaly signal exists at all.
+  if (facts.needsSetup) {
+    return {
+      key: 'setup_needed',
+      title: tr('Check attendance setup', '检查考勤配置'),
+      detail: facts.setupHint,
+      action: null,
+      actionLabel: null,
+      presentedByStatusBanner: false,
+    }
+  }
+
+  // Priority 7 — normal / adjusted / off / otherwise caught up.
+  if (facts.focusRecordStatus === null || RECORD_STATUS_ALL_CLEAR.has(facts.focusRecordStatus)) {
+    return {
+      key: 'all_clear',
+      title: tr('You are caught up', '当前已处理完毕'),
+      detail: tr(
+        'No anomaly reminders or pending approvals are blocking your attendance follow-up.',
+        '当前没有异常提醒或待审批事项阻塞你的考勤跟进。',
+      ),
+      action: null,
+      actionLabel: null,
+      presentedByStatusBanner: false,
+    }
+  }
+
+  // Fail-closed: an unrecognized record status must never read as success.
+  return {
+    key: 'unknown_status',
+    title: tr('Review your attendance record', '请查看你的考勤记录'),
+    detail: tr(
+      'This workday has a status this page does not recognize yet — review the records for details.',
+      '该工作日的状态暂未被识别，请在记录中查看详情。',
+    ),
+    action: 'records',
+    actionLabel: tr('Review records', '查看记录'),
+    presentedByStatusBanner: false,
+  }
+}

--- a/apps/web/tests/attendance-overview-priority.spec.ts
+++ b/apps/web/tests/attendance-overview-priority.spec.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveAttendanceOverviewAttention,
+  type AttendanceOverviewAttentionFacts,
+} from '../src/views/attendance/attendanceOverviewPriority'
+
+// Employee overview task-first design-lock (RATIFIED 2026-07-21):
+// docs/development/attendance-employee-overview-task-first-design-lock-20260716.md
+// §4.2 (attention priority table) / §9.1 (pure priority matrix gates).
+
+const tr = (en: string, _zh: string) => en
+
+const BASE_FACTS: AttendanceOverviewAttentionFacts = {
+  punchFailureActive: false,
+  punchFailureMessage: '',
+  anomalyCount: 0,
+  focusDateLabel: null,
+  latestRequestStatus: null,
+  pendingRequestCount: 0,
+  focusRecordStatus: null,
+  focusRecordStatusLabel: null,
+  focusRecordDateLabel: null,
+  needsSetup: false,
+  setupHint: '',
+}
+
+function facts(overrides: Partial<AttendanceOverviewAttentionFacts>): AttendanceOverviewAttentionFacts {
+  return { ...BASE_FACTS, ...overrides }
+}
+
+describe('resolveAttendanceOverviewAttention (pure priority matrix)', () => {
+  it('priority 1: an actionable punch failure outranks anomaly and pending/rejected requests', () => {
+    const item = resolveAttendanceOverviewAttention(
+      facts({
+        punchFailureActive: true,
+        punchFailureMessage: 'Punch interval is too short. Try again shortly.',
+        anomalyCount: 3,
+        latestRequestStatus: 'rejected',
+        pendingRequestCount: 2,
+      }),
+      tr,
+    )
+    expect(item.key).toBe('punch_failure')
+    expect(item.detail).toBe('Punch interval is too short. Try again shortly.')
+    // The status banner already renders message/code/hint/retry — the
+    // attention band must not fabricate a second actionable control.
+    expect(item.action).toBeNull()
+    expect(item.actionLabel).toBeNull()
+    expect(item.presentedByStatusBanner).toBe(true)
+  })
+
+  it('priority 2: anomaly outranks rejected and pending requests (mutation target A)', () => {
+    const item = resolveAttendanceOverviewAttention(
+      facts({
+        anomalyCount: 2,
+        focusDateLabel: '2026-04-15',
+        latestRequestStatus: 'rejected',
+        pendingRequestCount: 4,
+      }),
+      tr,
+    )
+    expect(item.key).toBe('anomaly')
+    expect(item.action).toBe('missing-punch')
+    expect(item.detail).toContain('2 anomaly reminders')
+    expect(item.detail).toContain('2026-04-15')
+  })
+
+  it('priority 2 singular copy: exactly one anomaly reminder does not pluralize', () => {
+    const item = resolveAttendanceOverviewAttention(facts({ anomalyCount: 1 }), tr)
+    expect(item.key).toBe('anomaly')
+    expect(item.detail).toContain('1 anomaly reminder ')
+    expect(item.detail).not.toContain('reminders')
+  })
+
+  it('priority 3: a rejected latest request is not lost behind an all-clear record', () => {
+    const item = resolveAttendanceOverviewAttention(
+      facts({ latestRequestStatus: 'rejected', focusRecordStatus: 'normal' }),
+      tr,
+    )
+    expect(item.key).toBe('request_rejected')
+    expect(item.action).toBe('request-report')
+    expect(item.detail.toLowerCase()).not.toContain('pending')
+  })
+
+  it('priority 3 does not fire when the latest request is merely pending (falls to priority 4 instead)', () => {
+    const item = resolveAttendanceOverviewAttention(
+      facts({ latestRequestStatus: 'pending', pendingRequestCount: 1 }),
+      tr,
+    )
+    expect(item.key).toBe('request_pending')
+  })
+
+  it('priority 4: a pending request never exposes approval actions or approve/reject wording', () => {
+    const item = resolveAttendanceOverviewAttention(
+      facts({ latestRequestStatus: 'pending', pendingRequestCount: 3 }),
+      tr,
+    )
+    expect(item.key).toBe('request_pending')
+    expect(item.action).toBe('request-report')
+    expect(item.title.toLowerCase()).not.toContain('approve')
+    expect(item.title.toLowerCase()).not.toContain('reject')
+    expect(item.detail.toLowerCase()).not.toContain('approve')
+    expect(item.detail).toContain('3 requests still waiting for approval')
+  })
+
+  it.each(['late', 'early_leave', 'late_early', 'partial', 'absent'])(
+    'priority 5: focus record status "%s" maps to record_review',
+    (status) => {
+      const item = resolveAttendanceOverviewAttention(
+        facts({ focusRecordStatus: status, focusRecordStatusLabel: status, focusRecordDateLabel: '2026-04-15' }),
+        tr,
+      )
+      expect(item.key).toBe('record_review')
+      expect(item.action).toBe('records')
+      expect(item.detail).toContain('2026-04-15')
+    },
+  )
+
+  it('priority 6: no record/request/anomaly signal produces the setup guidance with no fabricated CTA', () => {
+    const item = resolveAttendanceOverviewAttention(
+      facts({ needsSetup: true, setupHint: 'Ask an attendance admin to confirm your group and shift setup.' }),
+      tr,
+    )
+    expect(item.key).toBe('setup_needed')
+    expect(item.detail).toBe('Ask an attendance admin to confirm your group and shift setup.')
+    expect(item.action).toBeNull()
+    expect(item.actionLabel).toBeNull()
+  })
+
+  it.each([null, 'normal', 'adjusted', 'off'])(
+    'priority 7: focus record status %s is an explicit all-clear with no fabricated blocking task',
+    (status) => {
+      const item = resolveAttendanceOverviewAttention(facts({ focusRecordStatus: status }), tr)
+      expect(item.key).toBe('all_clear')
+      expect(item.action).toBeNull()
+      expect(item.actionLabel).toBeNull()
+    },
+  )
+
+  it('fail-closed: an unrecognized record status never reads as all_clear (mutation target B)', () => {
+    const item = resolveAttendanceOverviewAttention(
+      facts({ focusRecordStatus: 'some_future_backend_status' }),
+      tr,
+    )
+    expect(item.key).toBe('unknown_status')
+    expect(item.key).not.toBe('all_clear')
+    expect(item.action).toBe('records')
+  })
+
+  it('first-match order (OD-O1): higher priority facts always dominate regardless of lower-priority facts', () => {
+    const everythingOn = resolveAttendanceOverviewAttention(
+      facts({
+        punchFailureActive: true,
+        punchFailureMessage: 'boom',
+        anomalyCount: 1,
+        latestRequestStatus: 'rejected',
+        pendingRequestCount: 1,
+        focusRecordStatus: 'late',
+        focusRecordStatusLabel: 'Late',
+        needsSetup: false,
+      }),
+      tr,
+    )
+    expect(everythingOn.key).toBe('punch_failure')
+
+    const withoutPunchFailure = resolveAttendanceOverviewAttention(
+      facts({
+        anomalyCount: 1,
+        latestRequestStatus: 'rejected',
+        pendingRequestCount: 1,
+        focusRecordStatus: 'late',
+        focusRecordStatusLabel: 'Late',
+      }),
+      tr,
+    )
+    expect(withoutPunchFailure.key).toBe('anomaly')
+
+    const withoutAnomaly = resolveAttendanceOverviewAttention(
+      facts({ latestRequestStatus: 'rejected', pendingRequestCount: 1, focusRecordStatus: 'late', focusRecordStatusLabel: 'Late' }),
+      tr,
+    )
+    expect(withoutAnomaly.key).toBe('request_rejected')
+
+    const withoutRejected = resolveAttendanceOverviewAttention(
+      facts({ pendingRequestCount: 1, focusRecordStatus: 'late', focusRecordStatusLabel: 'Late' }),
+      tr,
+    )
+    expect(withoutRejected.key).toBe('request_pending')
+
+    const withoutPending = resolveAttendanceOverviewAttention(
+      facts({ focusRecordStatus: 'late', focusRecordStatusLabel: 'Late' }),
+      tr,
+    )
+    expect(withoutPending.key).toBe('record_review')
+  })
+
+  it('always returns exactly one item shape (no dual-copy fields)', () => {
+    const item = resolveAttendanceOverviewAttention(facts({}), tr)
+    expect(Object.keys(item).sort()).toEqual(
+      ['action', 'actionLabel', 'detail', 'key', 'presentedByStatusBanner', 'title'].sort(),
+    )
+  })
+})

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -714,6 +714,159 @@ describe('Attendance self-service dashboard', () => {
     expect(container?.querySelector('[data-selfservice-card="guide"]')?.textContent).toContain('manual correction')
   })
 
+  // ---- Employee-overview task-first design-lock (RATIFIED 2026-07-21) ----
+  // docs/development/attendance-employee-overview-task-first-design-lock-20260716.md
+  // AttendanceEmployeeWorkspace.vue mounted coverage: Today/attention/tools
+  // band order (§4, §9.2), OD-O1 first-match precedence surfaced through the
+  // mount, OD-O2 collapsed-by-default history disclosure + expand without
+  // reset, OD-O3 requests/quick-actions-before-balance/rules ordering, and
+  // the statusMessage visibility guard (§5: "not part of the disclosure").
+
+  function domOrderIndex(container: HTMLElement, selector: string): number {
+    const el = container.querySelector(selector)
+    expect(el, `expected an element for ${selector}`).toBeTruthy()
+    return Array.from(container.querySelectorAll('*')).indexOf(el as Element)
+  }
+
+  it('W2/4355 DOM order: Today -> Needs-attention -> tools bands, and exactly one primary attention action', async () => {
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    const heroIndex = domOrderIndex(container!, '[data-testid="attendance-hero-punch"]')
+    const todayStatusIndex = domOrderIndex(container!, '[data-selfservice-card="status"]')
+    const attentionIndex = domOrderIndex(container!, '[data-attendance-overview-attention]')
+    const requestsIndex = domOrderIndex(container!, '[data-selfservice-card="requests"]')
+    const actionsIndex = domOrderIndex(container!, '[data-selfservice-card="actions"]')
+    const balanceIndex = domOrderIndex(container!, '[data-selfservice-card="annual-balance"]')
+    const rulesIndex = domOrderIndex(container!, '[data-selfservice-card="rules"]')
+    const filtersIndex = domOrderIndex(container!, '[data-attendance-history-filters]')
+    const summaryIndex = domOrderIndex(container!, '#attendance-overview-requests')
+    const guideIndex = domOrderIndex(container!, '[data-selfservice-card="guide"]')
+
+    expect(heroIndex).toBeLessThan(todayStatusIndex)
+    expect(todayStatusIndex).toBeLessThan(attentionIndex)
+    expect(attentionIndex).toBeLessThan(requestsIndex)
+    // OD-O3: request status + quick actions ahead of annual balance/rules.
+    expect(requestsIndex).toBeLessThan(actionsIndex)
+    expect(actionsIndex).toBeLessThan(balanceIndex)
+    expect(balanceIndex).toBeLessThan(rulesIndex)
+    expect(rulesIndex).toBeLessThan(filtersIndex)
+    // lock §5: the history disclosure sits immediately before historical content.
+    expect(filtersIndex).toBeLessThan(summaryIndex)
+    // lock §4.3 item 6: status guide is the last, lowest-frequency surface.
+    expect(summaryIndex).toBeLessThan(guideIndex)
+
+    // §9.2: exactly one primary recommended action across the whole page.
+    expect(container!.querySelectorAll('[data-attendance-overview-attention-action]')).toHaveLength(1)
+    expect(container!.querySelector('[data-attendance-overview-attention]')?.getAttribute('data-attendance-overview-attention-key')).toBe('anomaly')
+  })
+
+  it('W2/4355 OD-O1: an actionable punch failure outranks anomaly/pending in the attention band, with no second retry control', async () => {
+    const defaultImpl = vi.mocked(apiFetch).getMockImplementation()
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/punch')) {
+        return jsonResponse(400, { ok: false, error: { code: 'PUNCH_TOO_SOON', message: 'PUNCH_TOO_SOON' } })
+      }
+      if (!defaultImpl) return jsonResponse(200, { ok: true, data: { items: [], total: 0 } })
+      return defaultImpl(input, init)
+    })
+
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    findButton(container!, 'Check Out').click()
+    await flushUi(4)
+
+    const attention = container!.querySelector('[data-attendance-overview-attention]')
+    expect(attention?.getAttribute('data-attendance-overview-attention-key')).toBe('punch_failure')
+    expect(attention?.textContent).not.toContain('Resolve anomaly reminders')
+    // The status banner (Today band) carries the one real retry for this
+    // state; the attention band must not render a second actionable control.
+    expect(container!.querySelectorAll('[data-attendance-overview-attention-action]')).toHaveLength(0)
+    expect(container!.textContent).toContain('Retry refresh')
+  })
+
+  it('W2/4355 OD-O2: history filters start collapsed, expand without resetting values or firing new requests', async () => {
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    const details = container!.querySelector('[data-attendance-history-filters]') as HTMLDetailsElement
+    expect(details).toBeTruthy()
+    expect(details.open).toBe(false)
+
+    const orgInput = container!.querySelector<HTMLInputElement>('input[name="orgId"]')
+    expect(orgInput).toBeTruthy()
+    orgInput!.value = 'collapsed-entry-org'
+    orgInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    const callsBeforeExpand = vi.mocked(apiFetch).mock.calls.length
+    const summary = details.querySelector('summary') as HTMLElement
+    summary.click()
+    await flushUi()
+
+    expect(details.open).toBe(true)
+    expect(orgInput!.value).toBe('collapsed-entry-org')
+    expect(vi.mocked(apiFetch).mock.calls.length).toBe(callsBeforeExpand)
+
+    summary.click()
+    await flushUi()
+    expect(details.open).toBe(false)
+    expect(orgInput!.value).toBe('collapsed-entry-org')
+    expect(vi.mocked(apiFetch).mock.calls.length).toBe(callsBeforeExpand)
+  })
+
+  it('W2/4355 statusMessage visibility guard: stays outside the disclosure and visible while filters are collapsed', async () => {
+    const defaultImpl = vi.mocked(apiFetch).getMockImplementation()
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/punch')) {
+        return jsonResponse(400, { ok: false, error: { code: 'PUNCH_TOO_SOON', message: 'PUNCH_TOO_SOON' } })
+      }
+      if (!defaultImpl) return jsonResponse(200, { ok: true, data: { items: [], total: 0 } })
+      return defaultImpl(input, init)
+    })
+
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    const details = container!.querySelector('[data-attendance-history-filters]') as HTMLDetailsElement
+    expect(details.open).toBe(false)
+
+    findButton(container!, 'Check Out').click()
+    await flushUi(4)
+
+    expect(container!.textContent).toContain('Punch interval is too short. Try again shortly.')
+    const statusBlock = container!.querySelector('.attendance__status-block')
+    expect(statusBlock).toBeTruthy()
+    expect(details.contains(statusBlock)).toBe(false)
+    expect(details.open).toBe(false)
+  })
+
+  it('W2/4355 compatibility: the five reused state signals still surface through their preserved anchors', async () => {
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    // activeWorkbenchRecord — Today status card, unchanged anchor.
+    expect(container!.querySelector('[data-selfservice-card="status"]')?.textContent).toContain('Late + Early')
+    // heroTodayTimeline — unchanged data-testid.
+    expect(container!.querySelector('[data-testid="attendance-hero-timeline"]')).toBeTruthy()
+    // selfServiceRequestFollowup — unchanged anchor, still request-card-owned.
+    expect(container!.querySelector('[data-selfservice-request-followup]')?.textContent).toContain('Pending follow-up')
+    // selfServiceFocusItems / selfServicePrimaryAction — deliberately
+    // consolidated (lock §4.2) into the single attention-band anchor; the
+    // underlying facts (anomaly count) still surface, just once.
+    expect(container!.querySelector('[data-attendance-overview-attention]')?.textContent).toContain('Resolve anomaly reminders')
+    expect(container!.querySelector('[data-selfservice-focus-list]')).toBeNull()
+    expect(container!.querySelector('[data-selfservice-primary-action]')).toBeNull()
+  })
+
   it('updates self-service rules weekday labels when the locale changes', async () => {
     useLocale().setLocale('en')
     app = createApp(AttendanceView, { mode: 'overview' })

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -687,7 +687,11 @@ describe('Attendance self-service dashboard', () => {
 
     expect(container?.querySelector('[data-selfservice-card="status"]')?.textContent).toContain('Late + Early')
     expect(container?.querySelector('[data-selfservice-card="status"]')?.textContent).toContain('Both a late arrival and an early departure')
-    expect(container?.querySelector('[data-selfservice-focus-list]')?.textContent).toContain('Resolve anomaly reminders')
+    // Employee-overview task-first design-lock (RATIFIED 2026-07-21) §4.2: ONE
+    // canonical attention item replaces the old focus-list + primary-action
+    // "two competing copies" (data-selfservice-focus-list / -primary-action).
+    expect(container?.querySelector('[data-attendance-overview-attention]')?.textContent).toContain('Resolve anomaly reminders')
+    expect(container?.querySelector('[data-attendance-overview-attention]')?.getAttribute('data-attendance-overview-attention-key')).toBe('anomaly')
     expect(container?.querySelector('[data-selfservice-card="requests"]')?.textContent).toContain('Pending · 1')
     expect(container?.querySelector('[data-selfservice-card="requests"]')?.textContent).toContain('Approved · 1')
     expect(container?.querySelector('[data-selfservice-card="requests"]')?.textContent).toContain('Rejected · 1')
@@ -706,7 +710,6 @@ describe('Attendance self-service dashboard', () => {
     expect(rulesCard).not.toContain('wifi-secret')
     expect(rulesCard).not.toContain('integration-secret')
     expect(container?.querySelector('[data-selfservice-card="actions"]')?.textContent).toContain('Fix missing punch')
-    expect(container?.querySelector('[data-selfservice-primary-action]')?.textContent).toContain('Resolve anomaly reminders')
     expect(container?.querySelector('[data-selfservice-card="guide"]')?.textContent).toContain('Adjusted')
     expect(container?.querySelector('[data-selfservice-card="guide"]')?.textContent).toContain('manual correction')
   })
@@ -864,15 +867,17 @@ describe('Attendance self-service dashboard', () => {
     app.mount(container!)
     await flushUi()
 
-    const statusCard = container!.querySelector('[data-selfservice-card="status"]')?.textContent ?? ''
     const requestsCard = container!.querySelector('[data-selfservice-card="requests"]')?.textContent ?? ''
     const actionsCard = container!.querySelector('[data-selfservice-card="actions"]')?.textContent ?? ''
+    const attentionBand = container!.querySelector('[data-attendance-overview-attention]')?.textContent ?? ''
 
-    expect(statusCard).toContain('Attention items')
-    expect(statusCard).toContain('1')
-    expect(statusCard).toContain('You have 1 anomaly reminders in this range.')
-    expect(statusCard).toContain('Resolve anomaly reminders')
-    expect(statusCard).toContain('Track pending approvals')
+    // Employee-overview task-first design-lock (RATIFIED 2026-07-21) §4.1:
+    // Today's status card is narrowed to exactly latest-punch/work-minutes/
+    // late-early — the anomaly count/copy moves to the single Needs-attention
+    // item (§4.2), which is anomaly (priority 2) here, never a second
+    // competing "Track pending approvals" copy for the same fixture.
+    expect(attentionBand).toContain('Resolve anomaly reminders')
+    expect(attentionBand).not.toContain('Track pending approvals')
     expect(requestsCard).toContain('Summarizes the current request backlog from the visible date range.')
     expect(requestsCard).toContain('Pending follow-up')
     expect(requestsCard).toContain('waiting for approval')
@@ -886,7 +891,6 @@ describe('Attendance self-service dashboard', () => {
     expect(requestsCard).toContain('Rejection note: Please attach lobby access evidence.')
     expect(requestsCard).toContain('has already been approved')
     expect(requestsCard).toContain('was rejected')
-    expect(actionsCard).toContain('Resolve anomaly reminders')
     expect(actionsCard).toContain('Start with missing-punch handling to resolve the current anomaly reminder.')
   })
 
@@ -1158,14 +1162,20 @@ describe('Attendance self-service dashboard', () => {
 
     const statusCard = container!.querySelector('[data-selfservice-card="status"]')?.textContent ?? ''
     const setupHint = container!.querySelector('[data-selfservice-setup-hint]')?.textContent ?? ''
-    const focusList = container!.querySelector('[data-selfservice-focus-list]')?.textContent ?? ''
+    const attentionBand = container!.querySelector('[data-attendance-overview-attention]')?.textContent ?? ''
+    const attentionKey = container!.querySelector('[data-attendance-overview-attention]')?.getAttribute('data-attendance-overview-attention-key')
     const actionsCard = container!.querySelector('[data-selfservice-card="actions"]')?.textContent ?? ''
 
     expect(statusCard).toContain('No attendance data is available in this range yet.')
     expect(setupHint).toContain('you may not be assigned to an attendance group yet')
     expect(setupHint).toContain('confirm your group and shift setup')
-    expect(focusList).toContain('Check attendance setup')
-    expect(actionsCard).toContain('Wait for attendance setup')
+    // Employee-overview task-first design-lock §4.2 row 6 (setup_needed):
+    // the single canonical attention item reuses this same setup guidance —
+    // no fabricated CTA and no second competing "primary action" copy.
+    expect(attentionKey).toBe('setup_needed')
+    expect(attentionBand).toContain('Check attendance setup')
+    expect(container!.querySelector('[data-attendance-overview-attention-action]')).toBeNull()
+    expect(actionsCard).toContain('confirm your group and shift setup')
 
     const requestType = container!.querySelector<HTMLSelectElement>('#attendance-request-type')
     expect(requestType).toBeTruthy()
@@ -1587,11 +1597,15 @@ describe('Attendance self-service dashboard', () => {
     app.mount(container!)
     await flushUi()
 
+    // Employee-overview task-first design-lock (RATIFIED 2026-07-21) §4.1:
+    // Today's status card narrows to exactly latest-punch/work-minutes/
+    // late-early — no fourth "Attention items" stat (that signal now lives
+    // solely in the Needs-attention band, §4.2, avoiding a second copy).
     const summary = container!.querySelector('.attendance__summary--workbench') as HTMLElement
     expect(summary.textContent).toContain('Latest punch')
     expect(summary.textContent).toContain('Work minutes')
     expect(summary.textContent).toContain('Late / Early')
-    expect(summary.textContent).toContain('Attention items')
+    expect(summary.textContent).not.toContain('Attention items')
     const warning = summary.querySelector('.attendance__summary-value--warning') as HTMLElement | null
     expect(warning, 'late/early 18/18 should color as warning').toBeTruthy()
     expect(warning!.textContent).toContain('18 / 18')

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -754,8 +754,13 @@ describe('Attendance self-service dashboard', () => {
     expect(rulesIndex).toBeLessThan(filtersIndex)
     // lock §5: the history disclosure sits immediately before historical content.
     expect(filtersIndex).toBeLessThan(summaryIndex)
-    // lock §4.3 item 6: status guide is the last, lowest-frequency surface.
+    // lock §4.3 item 6: status guide is the last, lowest-frequency surface — pinned against EVERY
+    // historical section, not just the requests summary (review NIT: under-pinned order).
+    const anomaliesIndex = domOrderIndex(container!, '#attendance-overview-anomalies')
+    const requestReportIndex = domOrderIndex(container!, '#attendance-overview-request-report')
     expect(summaryIndex).toBeLessThan(guideIndex)
+    expect(anomaliesIndex).toBeLessThan(guideIndex)
+    expect(requestReportIndex).toBeLessThan(guideIndex)
 
     // §9.2: exactly one primary recommended action across the whole page.
     expect(container!.querySelectorAll('[data-attendance-overview-attention-action]')).toHaveLength(1)
@@ -787,6 +792,37 @@ describe('Attendance self-service dashboard', () => {
     // state; the attention band must not render a second actionable control.
     expect(container!.querySelectorAll('[data-attendance-overview-attention-action]')).toHaveLength(0)
     expect(container!.textContent).toContain('Retry refresh')
+  })
+
+  it('W2/4355 negative scoping: a NON-punch error must never occupy the punch_failure attention slot', async () => {
+    // Review P3-a: punchFailureActive = statusKind==='error' AND statusSource==='punch'. The shared
+    // status banner is reused by refresh/admin/import/save paths with source=null — a regression that
+    // widens statusSource to every error must turn THIS leg red (the sibling punch test alone cannot:
+    // it only ever drives a punch error).
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    // After a clean mount, make every attendance GET fail, then drive the overview Refresh action —
+    // a non-punch setStatus(error) path (source=null) through the SHARED banner.
+    vi.mocked(apiFetch).mockImplementation(async () =>
+      jsonResponse(500, { ok: false, error: { code: 'INTERNAL', message: 'refresh boom' } }))
+
+    const details = container!.querySelector('[data-attendance-history-filters]') as HTMLDetailsElement
+    details.open = true
+    details.dispatchEvent(new Event('toggle'))
+    await flushUi()
+    findButton(container!, 'Refresh').click()
+    await flushUi(4)
+
+    // Positive control INSIDE the negative test: the refresh failure genuinely reached the shared
+    // banner (its retry control renders the refresh-overview action label) — without this the leg
+    // could pass vacuously with no error at all.
+    expect(container!.textContent).toContain('Retry refresh')
+
+    const attention = container!.querySelector('[data-attendance-overview-attention]')
+    expect(attention).toBeTruthy()
+    expect(attention?.getAttribute('data-attendance-overview-attention-key')).not.toBe('punch_failure')
   })
 
   it('W2/4355 OD-O2: history filters start collapsed, expand without resetting values or firing new requests', async () => {


### PR DESCRIPTION
## Summary

Implements vNext charter Wave 2 (issue #4355): task-first employee overview, per the RATIFIED design-lock (owner 2026-07-21, `docs/development/attendance-employee-overview-task-first-design-lock-20260716.md`, landed at `d430601e6`).

- New pure module `apps/web/src/views/attendance/attendanceOverviewPriority.ts`: `resolveAttendanceOverviewAttention` — a first-match, 8-outcome (7 lock rows + `unknown_status` fail-closed) "Needs attention" builder.
- New component `apps/web/src/views/attendance/AttendanceEmployeeWorkspace.vue` — first extraction from `AttendanceView.vue` (charter §6.2 Wave 2 row). Owns Today / Needs-attention / tools-band layout and display; emits real actions (`punch`, `retryPunchNote`, `statusAction`, `selfServiceAction`) back to the parent, which still owns every API call, route sync, and handler.
- `AttendanceView.vue` rewired for `mode === 'overview'` only. Reports mode's filter row keeps its exact prior position/behavior (untouched `v-if="showReports"` branch).
- `attendance-overview-priority.spec.ts` (new, pure matrix) + `attendance-selfservice-dashboard.spec.ts` extended (mounted).
- `.github/workflows/attendance-web-guard.yml`: `attendance-overview-priority` added to the run-list and both `pull_request`/`push` path filters.

No backend, API, payload, schema, or permission change. No feature flag (OD-O4).

## Lock clause → implementation mapping

| Lock clause | Implementation |
|---|---|
| §4.1 Today band (punch actions, timeline, status, exactly one follow-up ahead of history) | `AttendanceEmployeeWorkspace.vue` `.attendance-ew__today`: hero punch/timeline/outdoor-note + status card narrowed to latest-punch/work-minutes/late-early (3 values, not 4 — see "Deliberate behavior changes" below) |
| §4.1 status banner moves below daily workspace, message/code/hint/retry intact | Rendered directly after `.attendance-ew__today`, driven by the same `statusMessage/statusKind/statusCode/statusHint/statusActionLabel/statusActionBusy` refs, unchanged logic |
| §4.1 outdoor-note form stays adjacent to punch, not hidden in disclosure | Kept inside `.attendance-ew__today-punch`, outside the `<details>` |
| §4.2 ONE canonical attention item, first-match table | `resolveAttendanceOverviewAttention` (pure, independently tested) + `attendanceOverviewAttentionItem` computed in `AttendanceView.vue`, rendered once via `[data-attendance-overview-attention]` |
| §4.2 row 1 punch failure: preserve message/code/hint/retry, never invent one | New `statusSource` marker (optional 4th arg on `setStatus`/`setStatusFromError`, default `null` — every pre-existing call site unaffected) scopes `punchFailureActive` to punch's own catch branches only; the attention item for this state has `action: null` (the status banner carries the one real retry) |
| §4.2 unknown record status fails to neutral review, not success | `unknown_status` key, distinct from `all_clear`, mutation-tested (see below) |
| §4.3 tools-band order: requests → quick actions → balance → rules (de-emphasized) → history filters + historical → status guide | Exact DOM order asserted in the new "W2/4355 DOM order" mounted test |
| §5 `data-attendance-history-filters` disclosure, collapsed by default, preserves input state, no network on toggle | Native `<details data-attendance-history-filters>` (no `open` attribute = collapsed); filter inputs passed via `#historyFilters` slot, unchanged `v-model` refs; OD-O2 mounted test proves no new `apiFetch` calls |
| §5 status block not part of the disclosure | `.attendance__status-block` renders as a sibling before `.attendance-ew__attention`, outside `<details>`; guarded by a dedicated mounted test |
| §5 reports mode unchanged | Reports' `<section class="attendance__filters" v-if="showReports">` kept in its original position, untouched markup |
| §6 selector/id preservation | `data-testid="attendance-hero-punch"`/`"attendance-hero-timeline"`, all 6 `data-selfservice-card`, all 6 `data-selfservice-action`, `attendance-overview-requests/anomalies/request-report/records` ids, `initialSectionId`/`initialRequestId` deep-link — all grepped present, all pre-existing mounted tests for them green unmodified |
| §7 responsive | Existing UI-P0/P1 tokenized hero/stat-card CSS copied verbatim (byte-identical values) into the new component's scoped style (Vue scoped CSS doesn't cross component boundaries); new band-shell CSS uses `--ms-*` tokens only |
| §8 file shape | Matches the lock's recommended shape plus the charter's `AttendanceEmployeeWorkspace.vue` extraction; the new spec is wired per §8's explicit requirement |

### Deliberate, lock-mandated behavior changes to existing assertions

1. **Today's status card narrows from 4 stats to 3** (drops "Attention items" count) — §4.1 literally enumerates "compact values for latest punch, work minutes, and late/early minutes." The anomaly signal now lives solely in the Needs-attention band (no second copy).
2. **`selfServiceFocusItems`/`selfServicePrimaryAction` computeds retired**, along with their DOM anchors `data-selfservice-focus-list`/`data-selfservice-primary-action` — this *is* the "two competing copies" fix §4.2 requires. Neither anchor is in the §6 protected-selector list. Replaced by one anchor, `[data-attendance-overview-attention]`. A new mounted test explicitly confirms the old anchors are gone and the underlying facts (anomaly count, setup hint) still surface through the new one.
3. Existing `attendance-selfservice-dashboard.spec.ts` assertions that pinned the old two-copy/4-stat structure were updated in the same commit that changed the structure (see slice 3 commit).

### Interpretation notes (engineering judgment within the ratified lock, not a design decision)

- "Actionable punch failure" (row 1) is scoped via a new `statusSource: 'punch' | null` marker rather than `statusKind === 'error'` alone, because the shared status banner is reused by refresh/admin/import/save-settings flows too (confirmed via code read — `setStatusFromError(..., 'refresh')` is called both from `punch()`'s catch and from the unrelated overview-refresh failure path). Scoping it prevents a non-punch error from falsely claiming the top attention slot.
- "Latest request is rejected" (row 3) = the most-recently-submitted request (existing `selfServiceSortedRequests` order) has status `rejected` — plain reading of "latest," pinned in a pure-matrix test.
- The heavy historical surfaces (summary/calendar/adjustment-request list, request report — ~650 lines of handler-dense markup) are **not** re-authored inside the new component in this first extraction; they stay parent-owned siblings rendered right after it (reports-only sections between them render zero DOM nodes in overview mode, so DOM adjacency to the history disclosure and precedence over the status-guide card both hold). This matches the charter §6.1 explicit "先拆展示和纯状态, 再拆网络与写入" (display first, network/write later) guidance against a one-time rewrite.

## §8.1 gate checklist (this PR)

- [x] 1. Affected pure module spec: `attendance-overview-priority.spec.ts`, 19/19.
- [x] 2. Real-mounted self-service regression spec: `attendance-selfservice-dashboard.spec.ts`, 45/45 (40 pre-existing + 5 new).
- [x] 3/4. `attendance-web-guard` run-list + both path filters updated for the new spec; local run of the **exact** guard command below is green.
- [x] 5. `pnpm --filter @metasheet/web exec vue-tsc -b` — clean.
- [x] 6. `pnpm --filter @metasheet/web build` — clean.
- [x] 7. ≥2 mutations on load-bearing branches, recorded below.
- [ ] 8/9/10. 1440x900 / 1024x768 / 390x844 Playwright visual proof (scrollWidth/overlap/non-zero-box) — **deferred to the parent orchestration's adversarial gate**, per this task's explicit scope split.
- [x] 11. Existing selector/deep-link/API call-count compatibility — unmodified pre-existing tests (deep-link focused-request, employee-only actions, no-settings-read, PR2 typed-userId-commit-on-refresh, etc.) all still green, unchanged.

### Local command (identical to the workflow step)

```
pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust attendance-overview-priority --reporter=dot
```

Result: **27 files, 545/545 passed.**

## Mutation record (§8.1.7 / lock §9.1)

All three: committed baseline → mutate → run targeted command → observe red → `git checkout --` the single file → re-run → green.

1. **Swap anomaly/pending precedence** (`attendanceOverviewPriority.ts`): inserted a `pendingRequestCount > 0` short-circuit before the anomaly check. `vitest run attendance-overview-priority` → 3 tests red (`priority 2: anomaly outranks...`, `priority 4: ...`, `first-match order...`). Reverted → 19/19 green.
2. **Fold unknown status into all_clear** (`attendanceOverviewPriority.ts`): changed the fail-closed fallback to return `key: 'all_clear'`. → 1 test red (`fail-closed: an unrecognized record status never reads as all_clear`). Reverted → 19/19 green.
3. **Swap `data-selfservice-card` labels on the requests/rules cards** (`AttendanceEmployeeWorkspace.vue`, mounted-layer guard): → `W2/4355 DOM order...` red (`expected 117 to be less than 100`, OD-O3 ordering assertion). Reverted → 45/45 green.

## Deferred to the parent orchestration (not done in this PR)

- 1440x900 / 1024x768 / 390x844 Playwright visual proof + screenshots (lock §9.3, charter §8.1 items 8-10).
- Adversarial/independent review and go/no-go (charter §10 Codex role).
- Verification MD recording merged SHA + full evidence (lock §11 item 5).

## Deviations from the lock

None identified. Two implementation-level judgment calls (punch-failure scoping via a new `statusSource` marker; "latest request rejected" = most-recent by existing sort order) are documented above as engineering decisions within the ratified text, not product decisions — flagged for the adversarial reviewer to double-check rather than silently assumed correct.

refs #4355
