### PR TITLE
feat(attendance-web): W3/4353 — admin task home exclusivity + AttendanceAdminTaskHome.vue (reclaim #4414)

### DIFF
--- a/.github/workflows/attendance-web-guard.yml
+++ b/.github/workflows/attendance-web-guard.yml
@@ -57,7 +57,15 @@
 # fallback — see docs/development/attendance-bulk-balance-adjust-s6-design-lock-20260710.md,
 # #3925; DOM-level confirm-gate / exact-POST-body / cap-block / partial-failure / policy-off
 # coverage for the same slice lives in attendance-admin-regressions.spec.ts, already covered by
-# this guard).
+# this guard), and AttendanceAdminTaskHome.spec.ts (new — vNext charter §7 Wave 3 / issue
+# #4353, reclaimed from stacked draft #4414: mounted spec for the extracted four-task-group
+# admin home component — header/region semantics, link-vs-button action rendering,
+# select-section emit, empty-groups-render-nothing for parent-side permission filtering — see
+# docs/development/attendance-vnext-dingtalk-benchmark-ux-development-charter-20260720.md), and
+# attendance-experience-entrypoints.spec.ts (newly wired here — Wave 3 added real behavior to
+# this previously-ungated file: the admin/import "Management home" clear-section round trip
+# through the router and the overview anomaly-section deep link; the file's pre-existing
+# tab/section routing coverage rides along).
 # The full
 # `@metasheet/web` vitest suite still has historical/flaky failures, so wiring the whole
 # suite as a required gate now would be red on arrival. Keep expanding the `vitest run`
@@ -102,6 +110,8 @@ on:
       - 'apps/web/tests/attendance-report-xlsx-export.spec.ts'
       - 'apps/web/tests/attendance-reports-analytics.spec.ts'
       - 'apps/web/tests/attendance-overview-priority.spec.ts'
+      - 'apps/web/tests/AttendanceAdminTaskHome.spec.ts'
+      - 'apps/web/tests/attendance-experience-entrypoints.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
   push:
     branches: [main]
@@ -141,6 +151,8 @@ on:
       - 'apps/web/tests/attendance-report-xlsx-export.spec.ts'
       - 'apps/web/tests/attendance-reports-analytics.spec.ts'
       - 'apps/web/tests/attendance-overview-priority.spec.ts'
+      - 'apps/web/tests/AttendanceAdminTaskHome.spec.ts'
+      - 'apps/web/tests/attendance-experience-entrypoints.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
 
 jobs:
@@ -183,4 +195,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run attendance web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust attendance-overview-priority --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust attendance-overview-priority AttendanceAdminTaskHome attendance-experience-entrypoints --reporter=dot

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1301,84 +1301,51 @@
           </div>
           <div v-if="adminForbidden" class="attendance__empty">{{ tr('Admin permissions required to manage attendance settings.', '需要管理员权限才能管理考勤设置。') }}</div>
           <template v-else>
-            <div v-if="visibleRecentAdminSectionNavItems.length > 0" class="attendance__admin-shortcuts">
-              <div class="attendance__admin-shortcuts-header">
-                <div class="attendance__admin-shortcuts-title">
-                  <strong>{{ tr('Recent', '最近访问') }}</strong>
-                  <span>{{ tr('Jump back without searching the left rail.', '不用再回左侧查找，直接跳转。') }}</span>
-                </div>
-                <button
-                  class="attendance__btn attendance__btn--inline"
-                  type="button"
-                  data-admin-shortcuts-clear="true"
-                  @click="clearRecentAdminSections"
-                >
-                  {{ tr('Clear', '清空') }}
-                </button>
-              </div>
-              <div class="attendance__admin-shortcuts-items">
-                <button
-                  v-for="item in visibleRecentAdminSectionNavItems"
-                  :key="`shortcut-${item.id}`"
-                  class="attendance__admin-shortcut"
-                  :class="{ 'attendance__admin-shortcut--active': adminActiveSectionId === item.id }"
-                  :data-admin-shortcut="item.id"
-                  type="button"
-                  @click="selectAdminSection(item.id)"
-                >
-                  {{ item.contextLabel }}
-                </button>
-              </div>
-            </div>
-            <div class="attendance__admin-task-home" data-admin-task-home="true">
-              <div class="attendance__admin-task-home-header">
-                <div>
-                  <span class="attendance__admin-task-home-eyebrow">
-                    {{ tr('Admin workflow', '管理流程') }}
-                  </span>
-                  <h4>{{ tr('Start from the daily task, not the full settings list', '从日常任务开始，而不是从完整配置列表开始') }}</h4>
-                </div>
-                <span class="attendance__admin-task-home-hint">
-                  {{ tr('Detailed configuration remains available in the left rail.', '详细配置仍可从左侧区块进入。') }}
-                </span>
-              </div>
-              <div class="attendance__admin-task-grid">
-                <section
-                  v-for="group in adminTaskHomeGroups"
-                  :key="group.key"
-                  class="attendance__admin-task-group"
-                >
-                  <div class="attendance__admin-task-copy">
-                    <strong>{{ group.title }}</strong>
-                    <span>{{ group.detail }}</span>
+            <div
+              v-show="adminTaskHomeOpen"
+              class="attendance__admin-home-context"
+              data-admin-home-context="true"
+            >
+              <div v-if="visibleRecentAdminSectionNavItems.length > 0" class="attendance__admin-shortcuts">
+                <div class="attendance__admin-shortcuts-header">
+                  <div class="attendance__admin-shortcuts-title">
+                    <strong>{{ tr('Recent', '最近访问') }}</strong>
+                    <span>{{ tr('Recently opened attendance workspaces', '最近打开的考勤工作区') }}</span>
                   </div>
-                  <div class="attendance__admin-task-actions">
-                    <a
-                      v-for="action in group.linkActions"
-                      :key="action.key"
-                      class="attendance__btn attendance__btn--inline attendance__admin-task-action"
-                      :class="{ 'attendance__btn--primary': action.primary }"
-                      :data-admin-task-action="action.key"
-                      :href="action.href"
-                    >
-                      {{ action.label }}
-                    </a>
-                    <button
-                      v-for="action in group.buttonActions"
-                      :key="action.key"
-                      class="attendance__btn attendance__btn--inline attendance__admin-task-action"
-                      :class="{ 'attendance__btn--primary': action.primary }"
-                      :data-admin-task-action="action.key"
-                      type="button"
-                      @click="selectAdminSection(action.sectionId)"
-                    >
-                      {{ action.label }}
-                    </button>
-                  </div>
-                </section>
+                  <button
+                    class="attendance__btn attendance__btn--inline"
+                    type="button"
+                    data-admin-shortcuts-clear="true"
+                    @click="clearRecentAdminSections"
+                  >
+                    {{ tr('Clear', '清空') }}
+                  </button>
+                </div>
+                <div class="attendance__admin-shortcuts-items">
+                  <button
+                    v-for="item in visibleRecentAdminSectionNavItems"
+                    :key="`shortcut-${item.id}`"
+                    class="attendance__admin-shortcut"
+                    :class="{ 'attendance__admin-shortcut--active': adminActiveSectionId === item.id }"
+                    :data-admin-shortcut="item.id"
+                    type="button"
+                    @click="selectAdminSection(item.id)"
+                  >
+                    {{ item.contextLabel }}
+                  </button>
+                </div>
               </div>
+              <AttendanceAdminTaskHome
+                :tr="tr"
+                :groups="adminTaskHomeGroups"
+                @select-section="selectAdminSection"
+              />
             </div>
-            <div class="attendance__admin-shell">
+            <div
+              v-show="!adminTaskHomeOpen"
+              class="attendance__admin-shell"
+              data-admin-section-workspace="true"
+            >
             <AttendanceAdminRail
               :tr="tr"
               :active-admin-section-context-label="activeAdminSectionContextLabel"
@@ -1400,21 +1367,19 @@
               data-admin-current-section="true"
             >
               <div class="attendance__admin-current-section-copy">
+                <button
+                  class="attendance__btn attendance__btn--inline attendance__admin-home-action"
+                  type="button"
+                  data-admin-task-home-return="true"
+                  @click="showAdminTaskHome"
+                >
+                  <ArrowLeft class="attendance__admin-home-action-icon" aria-hidden="true" />
+                  <span>{{ tr('Management home', '管理首页') }}</span>
+                </button>
                 <span class="attendance__admin-current-section-eyebrow">
                   {{ tr('Current section', '当前区块') }}
                 </span>
                 <strong>{{ activeAdminSectionContextLabel }}</strong>
-                <span class="attendance__admin-current-section-description">
-                  {{ tr('Choose another item on the left and the right pane will return here immediately.', '点击左侧其他区块后，右侧会立即回到这里。') }}
-                </span>
-                <span class="attendance__admin-current-section-hint">
-                  {{
-                    tr(
-                      'Quick switch: Alt+↑ previous · Alt+↓ next.',
-                      '快速切换：Alt+↑ 上一个 · Alt+↓ 下一个。',
-                    )
-                  }}
-                </span>
               </div>
               <div class="attendance__admin-current-section-actions">
                 <button
@@ -9743,8 +9708,10 @@
 </template>
 
 <script setup lang="ts">
+import { ArrowLeft } from '@element-plus/icons-vue'
 import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import AttendanceAdminRail from './attendance/AttendanceAdminRail.vue'
+import AttendanceAdminTaskHome from './attendance/AttendanceAdminTaskHome.vue'
 import AttendanceCalendarPolicyQuickAdd from './attendance/AttendanceCalendarPolicyQuickAdd.vue'
 import AttendanceCalendarPolicyPreviewPanel from './attendance/AttendanceCalendarPolicyPreviewPanel.vue'
 import AttendanceImportBatchesSection from './attendance/AttendanceImportBatchesSection.vue'
@@ -10002,6 +9969,10 @@ const props = withDefaults(
     initialRequestId: '',
   }
 )
+
+const emit = defineEmits<{
+  (event: 'clear-section'): void
+}>()
 
 const { locale, isZh } = useLocale()
 const tr = (en: string, zh: string): string => (isZh.value ? zh : en)
@@ -14410,12 +14381,28 @@ const {
   notify: (message, kind = 'info') => setStatus(message, kind),
 })
 
+// vNext charter §4.2 / §7 Wave 3 (issue #4353, reclaimed from stacked draft
+// #4414): the admin center defaults to the task home and only shows the
+// full section workspace once an operator picks a task or arrives via an
+// explicit deep link (query `section` or URL hash). `adminNavigationEnabled`
+// gates hash-restore/scroll-spy/keyboard-nav so a hidden workspace doesn't
+// silently mutate `adminActiveSectionId` or scroll behind the task home.
+function hasExplicitAdminSectionTarget(): boolean {
+  if (isKnownAdminSectionId(props.initialSectionId.trim())) return true
+  if (typeof window === 'undefined') return false
+  return isKnownAdminSectionId(window.location.hash.replace(/^#/, '').trim())
+}
+
+const adminTaskHomeOpen = ref(!hasExplicitAdminSectionTarget())
+const showAdminSectionWorkspace = computed(() => showAdmin.value && !adminTaskHomeOpen.value)
+
 const {
   adminSectionBinding,
   scrollToAdminSection,
 } = useAttendanceAdminRailNavigation({
   showAdmin,
   adminForbidden,
+  adminNavigationEnabled: showAdminSectionWorkspace,
   adminFocusCurrentSectionOnly: adminFocusedMode,
   previousAdminSectionId: computed(() => previousAdminSectionNavItem.value?.id ?? ''),
   nextAdminSectionId: computed(() => nextAdminSectionNavItem.value?.id ?? ''),
@@ -14464,70 +14451,85 @@ function buildAdminTaskHomeGroup(
 
 const adminTaskHomeGroups = computed<AttendanceAdminTaskHomeGroup[]>(() => [
   {
-    key: 'today-queue',
-    title: tr('Today queue', '今日待办'),
+    key: 'daily-operations',
+    title: tr('Daily operations', '日常运营'),
     detail: tr(
-      'Review pending requests and make sure approval policy is ready before payroll work starts.',
-      '先处理待审批申请，并确认审批策略可用，再进入计薪处理。',
+      'Approvals, anomalies, imports, and audit follow-up.',
+      '审批、异常、导入与审计跟进。',
     ),
     actions: [
       {
         key: 'pending-attendance-approvals',
-        label: tr('Pending attendance approvals', '待处理考勤审批'),
+        label: tr('Pending approvals', '待处理审批'),
         href: '/attendance?section=attendance-overview-requests',
         primary: true,
       },
       {
-        key: 'approval-flows',
-        label: tr('Approval flows', '审批流'),
-        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.approvalFlows,
+        key: 'attendance-anomalies',
+        label: tr('Anomalies', '异常'),
+        href: '/attendance?section=attendance-overview-anomalies',
       },
-    ],
-  },
-  {
-    key: 'monthly-processing',
-    title: tr('Monthly processing', '月度处理'),
-    detail: tr(
-      'Import CSV, inspect import batches, tune report fields, then close payroll cycles.',
-      '导入 CSV、检查导入批次、调整统计字段，再收口计薪周期。',
-    ),
-    actions: [
       {
-        key: 'monthly-import',
-        label: tr('Import CSV', '导入 CSV'),
+        key: 'daily-import',
+        label: tr('Import', '导入'),
         sectionId: ATTENDANCE_ADMIN_SECTION_IDS.import,
-        primary: true,
       },
       {
-        key: 'import-batches',
-        label: tr('Import batches', '导入批次'),
-        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.importBatches,
-      },
-      {
-        key: 'payroll-cycles',
-        label: tr('Payroll cycles', '计薪周期'),
-        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.payrollCycles,
+        key: 'audit-follow-up',
+        label: tr('Audit logs', '审计日志'),
+        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.auditLogs,
       },
     ],
   },
   {
-    key: 'base-config',
-    title: tr('Base configuration', '基础配置'),
+    key: 'people-groups',
+    title: tr('People and attendance groups', '人员与考勤组'),
     detail: tr(
-      'Maintain groups, members, shifts, holidays, and rule sets before daily import.',
-      '维护考勤组、成员、班次、节假日和规则集，为日常导入打底。',
+      'Groups, members, owners, access, and availability.',
+      '考勤组、成员、负责人、权限与可用性。',
     ),
     actions: [
       {
         key: 'attendance-groups',
-        label: tr('Groups', '考勤组'),
+        label: tr('Attendance groups', '考勤组'),
         sectionId: ATTENDANCE_ADMIN_SECTION_IDS.attendanceGroups,
         primary: true,
       },
       {
+        key: 'group-members',
+        label: tr('Members', '成员'),
+        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.groupMembers,
+      },
+      {
+        key: 'user-access',
+        label: tr('Access', '权限'),
+        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.userAccess,
+      },
+      {
+        key: 'team-availability',
+        label: tr('Availability', '可用性'),
+        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.teamAvailability,
+      },
+    ],
+  },
+  {
+    key: 'work-time-policies',
+    title: tr('Work time and policies', '工时与策略'),
+    detail: tr(
+      'Shifts, schedules, holidays, rule sets, overtime, and leave policies.',
+      '班次、排班、节假日、规则集、加班与请假策略。',
+    ),
+    actions: [
+      {
         key: 'shifts',
         label: tr('Shifts', '班次'),
         sectionId: ATTENDANCE_ADMIN_SECTION_IDS.shifts,
+        primary: true,
+      },
+      {
+        key: 'schedules',
+        label: tr('Schedules', '排班'),
+        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.assignments,
       },
       {
         key: 'holidays',
@@ -14539,26 +14541,46 @@ const adminTaskHomeGroups = computed<AttendanceAdminTaskHomeGroup[]>(() => [
         label: tr('Rule sets', '规则集'),
         sectionId: ATTENDANCE_ADMIN_SECTION_IDS.ruleSets,
       },
+      {
+        key: 'overtime-rules',
+        label: tr('Overtime', '加班'),
+        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.overtimeRules,
+      },
+      {
+        key: 'leave-types',
+        label: tr('Leave policies', '请假策略'),
+        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.leaveTypes,
+      },
     ],
   },
   {
-    key: 'audit-rollback',
-    title: tr('Audit and rollback', '审计回滚'),
+    key: 'reporting-payroll',
+    title: tr('Reporting and payroll', '报表与计薪'),
     detail: tr(
-      'Trace recent admin changes and failed imports before retrying or rolling back.',
-      '重试或回滚前，先追踪最近管理变更和失败导入。',
+      'Import batches, report fields, payroll templates, and payroll cycles.',
+      '导入批次、统计字段、计薪模板与计薪周期。',
     ),
     actions: [
       {
-        key: 'audit-logs',
-        label: tr('Audit logs', '审计日志'),
-        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.auditLogs,
+        key: 'import-batches',
+        label: tr('Import batches', '导入批次'),
+        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.importBatches,
         primary: true,
       },
       {
-        key: 'rollback-import-batches',
-        label: tr('Import batches', '导入批次'),
-        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.importBatches,
+        key: 'report-fields',
+        label: tr('Report fields', '统计字段'),
+        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.reportFields,
+      },
+      {
+        key: 'payroll-templates',
+        label: tr('Payroll templates', '计薪模板'),
+        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.payrollTemplates,
+      },
+      {
+        key: 'payroll-cycles',
+        label: tr('Payroll cycles', '计薪周期'),
+        sectionId: ATTENDANCE_ADMIN_SECTION_IDS.payrollCycles,
       },
     ],
   },
@@ -14569,11 +14591,30 @@ function shouldShowAdminSection(id: string): boolean {
 }
 
 function selectAdminSection(id: string): void {
+  adminTaskHomeOpen.value = false
   adminFocusedMode.value = true
   adminActiveSectionId.value = id
   focusAdminSectionGroup(id)
   void nextTick(() => {
     scrollToAdminSection(id)
+  })
+}
+
+function showAdminTaskHome(): void {
+  adminTaskHomeOpen.value = true
+  adminCompactNavOpen.value = false
+  if (typeof window !== 'undefined') {
+    const url = new URL(window.location.href)
+    const querySection = url.searchParams.get('section')
+    if (isKnownAdminSectionId(querySection)) {
+      url.searchParams.delete('section')
+    }
+    url.hash = ''
+    window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}`)
+  }
+  emit('clear-section')
+  void nextTick(() => {
+    document.getElementById('attendance-admin-task-home-title')?.focus({ preventScroll: true })
   })
 }
 
@@ -29488,88 +29529,8 @@ const holidaySectionBindings = {
   font-weight: 600;
 }
 
-.attendance__admin-task-home {
-  display: grid;
-  gap: 14px;
-  margin-bottom: 16px;
-  padding: 14px 0 16px;
-  border-top: 1px solid #e2e8f0;
-  border-bottom: 1px solid #e2e8f0;
-}
-
-.attendance__admin-task-home-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  align-items: flex-start;
-}
-
-.attendance__admin-task-home-eyebrow {
-  display: block;
-  margin-bottom: 4px;
-  color: #64748b;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.attendance__admin-task-home h4 {
-  margin: 0;
-  color: #0f172a;
-  font-size: 16px;
-}
-
-.attendance__admin-task-home-hint {
-  max-width: 300px;
-  color: #64748b;
-  font-size: 12px;
-  line-height: 1.45;
-  text-align: right;
-}
-
-.attendance__admin-task-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.attendance__admin-task-group {
-  display: flex;
+.attendance__admin-home-context {
   min-width: 0;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  background: #f8fafc;
-}
-
-.attendance__admin-task-copy {
-  display: grid;
-  gap: 5px;
-}
-
-.attendance__admin-task-copy strong {
-  color: #1f2937;
-  font-size: 13px;
-}
-
-.attendance__admin-task-copy span {
-  color: #64748b;
-  font-size: 12px;
-  line-height: 1.45;
-}
-
-.attendance__admin-task-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.attendance__admin-task-action {
-  text-decoration: none;
 }
 
 .attendance__admin-content {
@@ -29605,24 +29566,25 @@ const holidaySectionBindings = {
   font-size: 15px;
 }
 
-.attendance__admin-current-section-description {
-  color: #64748b;
-  font-size: 12px;
-  line-height: 1.45;
-}
-
-.attendance__admin-current-section-hint {
-  color: #1d4ed8;
-  font-size: 12px;
-  line-height: 1.45;
-}
-
 .attendance__admin-current-section-eyebrow {
   color: #2563eb;
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+}
+
+.attendance__admin-home-action {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 6px;
+}
+
+.attendance__admin-home-action-icon {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
 }
 
 .attendance__admin-current-section-actions {
@@ -30739,19 +30701,6 @@ const holidaySectionBindings = {
     flex-direction: column;
   }
 
-  .attendance__admin-task-home-header {
-    flex-direction: column;
-  }
-
-  .attendance__admin-task-home-hint {
-    max-width: none;
-    text-align: left;
-  }
-
-  .attendance__admin-task-grid {
-    grid-template-columns: 1fr;
-  }
-
   .attendance__admin-current-section {
     top: 8px;
     flex-direction: column;
@@ -30760,6 +30709,10 @@ const holidaySectionBindings = {
 
   .attendance__admin-current-section-actions {
     width: 100%;
+  }
+
+  .attendance__admin-home-action {
+    width: fit-content;
   }
 
   .attendance__admin-current-section-jump,

--- a/apps/web/src/views/attendance/AttendanceAdminCenter.vue
+++ b/apps/web/src/views/attendance/AttendanceAdminCenter.vue
@@ -1,9 +1,17 @@
 <template>
-  <AttendanceView mode="admin" :initial-section-id="initialSectionId" />
+  <AttendanceView
+    mode="admin"
+    :initial-section-id="initialSectionId"
+    @clear-section="emit('clear-section')"
+  />
 </template>
 
 <script setup lang="ts">
 import AttendanceView from '../AttendanceView.vue'
+
+const emit = defineEmits<{
+  (event: 'clear-section'): void
+}>()
 
 withDefaults(defineProps<{
   initialSectionId?: string

--- a/apps/web/src/views/attendance/AttendanceAdminTaskHome.vue
+++ b/apps/web/src/views/attendance/AttendanceAdminTaskHome.vue
@@ -1,0 +1,233 @@
+<!--
+  Attendance vNext charter §6.2 (Wave 3 / issue #4353): first extraction of the
+  admin center's task-first home screen — reclaimed business intent from the
+  stacked draft PR #4414 (docs/development/
+  attendance-vnext-dingtalk-benchmark-ux-development-charter-20260720.md §7
+  "Wave 3：管理中心 task home").
+
+  This component owns LAYOUT and DISPLAY of the four task groups and re-emits
+  a real parent action (`select-section`) for button-style entries — it does
+  not fetch anything, hold route/admin state, or decide which sections a role
+  may see. `groups` arrives pre-filtered by the parent (charter §6.2 "暂留父层:
+  section 权限过滤、active id、数据加载"); this component renders exactly the
+  groups it is given. Href-style entries (deep links into other attendance
+  surfaces, e.g. the overview requests/anomalies queues) render as plain
+  anchors and are not part of the admin section selection path.
+-->
+<template>
+  <div
+    class="attendance__admin-task-home"
+    data-admin-task-home="true"
+    role="region"
+    aria-labelledby="attendance-admin-task-home-title"
+  >
+    <div class="attendance__admin-task-home-header">
+      <div>
+        <span class="attendance__admin-task-home-eyebrow">
+          {{ tr('Attendance management', '考勤管理') }}
+        </span>
+        <h4 id="attendance-admin-task-home-title" tabindex="-1">
+          {{ tr('Operations and configuration', '运营与配置') }}
+        </h4>
+      </div>
+      <span class="attendance__admin-task-home-hint">
+        {{ tr('Daily work, people, policies, reporting, and payroll', '日常工作、人员、策略、报表与计薪') }}
+      </span>
+    </div>
+    <div class="attendance__admin-task-grid">
+      <section
+        v-for="group in groups"
+        :key="group.key"
+        class="attendance__admin-task-group"
+        :data-admin-task-group="group.key"
+      >
+        <div class="attendance__admin-task-copy">
+          <strong>{{ group.title }}</strong>
+          <span>{{ group.detail }}</span>
+        </div>
+        <div class="attendance__admin-task-actions">
+          <a
+            v-for="action in group.linkActions"
+            :key="action.key"
+            class="attendance__btn attendance__btn--inline attendance__admin-task-action"
+            :class="{ 'attendance__btn--primary': action.primary }"
+            :data-admin-task-action="action.key"
+            :href="action.href"
+          >
+            {{ action.label }}
+          </a>
+          <button
+            v-for="action in group.buttonActions"
+            :key="action.key"
+            class="attendance__btn attendance__btn--inline attendance__admin-task-action"
+            :class="{ 'attendance__btn--primary': action.primary }"
+            :data-admin-task-action="action.key"
+            type="button"
+            @click="emit('select-section', action.sectionId)"
+          >
+            {{ action.label }}
+          </button>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+type TranslateFn = (en: string, zh: string) => string
+
+type AttendanceAdminTaskHomeLinkAction = {
+  key: string
+  label: string
+  href: string
+  primary?: boolean
+}
+
+type AttendanceAdminTaskHomeSectionAction = {
+  key: string
+  label: string
+  sectionId: string
+  primary?: boolean
+}
+
+/** Shape matches AttendanceView.vue's local `AttendanceAdminTaskHomeGroup` —
+ * kept local (not imported) since the parent does not export its types; must
+ * be extended in both places together (same convention as
+ * AttendanceEmployeeWorkspace.vue). */
+type AttendanceAdminTaskHomeGroup = {
+  key: string
+  title: string
+  detail: string
+  linkActions: AttendanceAdminTaskHomeLinkAction[]
+  buttonActions: AttendanceAdminTaskHomeSectionAction[]
+}
+
+defineProps<{
+  tr: TranslateFn
+  groups: AttendanceAdminTaskHomeGroup[]
+}>()
+
+const emit = defineEmits<{
+  'select-section': [id: string]
+}>()
+</script>
+
+<style scoped>
+.attendance__btn {
+  padding: 8px 14px;
+  border-radius: 6px;
+  border: 1px solid #d0d0d0;
+  background: #fff;
+  cursor: pointer;
+}
+
+.attendance__btn--primary {
+  background: #1976d2;
+  border-color: #1976d2;
+  color: #fff;
+}
+
+.attendance__btn--inline {
+  padding: 5px 10px;
+  font-size: 12px;
+}
+
+.attendance__admin-task-home {
+  display: grid;
+  gap: 14px;
+  margin-bottom: 16px;
+  padding: 14px 0 16px;
+  border-top: 1px solid #e2e8f0;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.attendance__admin-task-home-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.attendance__admin-task-home-eyebrow {
+  display: block;
+  margin-bottom: 4px;
+  color: #64748b;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.attendance__admin-task-home h4 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 16px;
+}
+
+.attendance__admin-task-home-hint {
+  max-width: 300px;
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.45;
+  text-align: right;
+}
+
+.attendance__admin-task-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.attendance__admin-task-group {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #f8fafc;
+}
+
+.attendance__admin-task-copy {
+  display: grid;
+  gap: 5px;
+}
+
+.attendance__admin-task-copy strong {
+  color: #1f2937;
+  font-size: 13px;
+}
+
+.attendance__admin-task-copy span {
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.attendance__admin-task-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.attendance__admin-task-action {
+  text-decoration: none;
+}
+
+@media (max-width: 768px) {
+  .attendance__admin-task-home-header {
+    flex-direction: column;
+  }
+
+  .attendance__admin-task-home-hint {
+    max-width: none;
+    text-align: left;
+  }
+
+  .attendance__admin-task-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/apps/web/src/views/attendance/AttendanceExperienceView.vue
+++ b/apps/web/src/views/attendance/AttendanceExperienceView.vue
@@ -41,6 +41,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import type { LocationQueryRaw } from 'vue-router'
 import { useLocale } from '../../composables/useLocale'
 import { useFeatureFlags } from '../../stores/featureFlags'
 import AttendanceOverview from './AttendanceOverview.vue'
@@ -49,6 +50,17 @@ import AttendanceAdminCenter from './AttendanceAdminCenter.vue'
 import AttendanceWorkflowDesigner from './AttendanceWorkflowDesigner.vue'
 
 type AttendanceTab = 'overview' | 'reports' | 'admin' | 'import' | 'workflow'
+
+// vNext charter §7 Wave 3 (issue #4353, reclaimed from stacked draft #4414):
+// the admin task home's Anomalies entry deep-links here, so every known
+// overview section id (not just `requests`) must survive the round trip
+// through the route query.
+const ATTENDANCE_OVERVIEW_SECTION_IDS = new Set([
+  'attendance-overview-requests',
+  'attendance-overview-anomalies',
+  'attendance-overview-request-report',
+  'attendance-overview-records',
+])
 
 const route = useRoute()
 const router = useRouter()
@@ -123,7 +135,7 @@ const desktopOnlyMessage = computed(() => {
 
 const overviewInitialSectionId = computed(() => {
   const section = Array.isArray(route.query.section) ? route.query.section[0] : route.query.section
-  return section === 'attendance-overview-requests' ? section : ''
+  return typeof section === 'string' && ATTENDANCE_OVERVIEW_SECTION_IDS.has(section) ? section : ''
 })
 
 const overviewInitialRequestId = computed(() => {
@@ -180,14 +192,20 @@ const activeView = computed(() => {
       return {
         component: AttendanceAdminCenter,
         key: 'attendance-admin',
-        props: { initialSectionId: adminInitialSectionId.value },
+        props: {
+          initialSectionId: adminInitialSectionId.value,
+          onClearSection: returnToAdminHome,
+        },
       }
     case 'import':
       if (!canAccessAdmin.value) return null
       return {
         component: AttendanceAdminCenter,
         key: 'attendance-import',
-        props: { initialSectionId: 'attendance-admin-import' },
+        props: {
+          initialSectionId: 'attendance-admin-import',
+          onClearSection: returnToAdminHome,
+        },
       }
     case 'workflow':
       if (!canAccessWorkflow.value) return null
@@ -238,6 +256,15 @@ async function selectTab(tab: AttendanceTab): Promise<void> {
 
   // Keep this page-level state isolated to `tab`.
   const query = nextTab === 'overview' ? {} : { tab: nextTab }
+  await router.replace({ query })
+}
+
+// Admin center's "Management home" return action (vNext charter §7 Wave 3):
+// keep the `admin`/`import` tab but drop any deep-linked `section`, so a
+// route refresh does not re-open the section the operator just left.
+async function returnToAdminHome(): Promise<void> {
+  const query: LocationQueryRaw = { ...route.query, tab: 'admin' }
+  delete query.section
   await router.replace({ query })
 }
 

--- a/apps/web/src/views/attendance/useAttendanceAdminRailNavigation.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRailNavigation.ts
@@ -8,6 +8,7 @@ type ReadonlyItemsRef = Readonly<Ref<AdminSectionNavItem[]> | ComputedRef<AdminS
 type UseAttendanceAdminRailNavigationOptions = {
   showAdmin: ReadonlyBoolRef
   adminForbidden: ReadonlyBoolRef
+  adminNavigationEnabled?: ReadonlyBoolRef
   adminFocusCurrentSectionOnly?: ReadonlyBoolRef
   previousAdminSectionId?: ReadonlyStringRef
   nextAdminSectionId?: ReadonlyStringRef
@@ -23,6 +24,7 @@ type UseAttendanceAdminRailNavigationOptions = {
 export function useAttendanceAdminRailNavigation({
   showAdmin,
   adminForbidden,
+  adminNavigationEnabled,
   adminFocusCurrentSectionOnly,
   previousAdminSectionId,
   nextAdminSectionId,
@@ -39,6 +41,16 @@ export function useAttendanceAdminRailNavigation({
   let adminHashSyncReady = false
   let adminHashRestoreCompleted = false
   let adminHashRestorePending = false
+
+  // vNext charter §7 Wave 3: when the admin task home is open (`adminNavigationEnabled`
+  // false), the section workspace it sits behind must stay inert — no hash restore
+  // from a remembered section, no scroll-spy, no Alt+arrow keyboard nav — otherwise a
+  // hidden shell would silently mutate `adminActiveSectionId` or scroll behind the
+  // task home. Defaults to enabled when the caller does not pass the flag at all,
+  // preserving pre-Wave-3 behavior for any other consumer of this composable.
+  function isAdminNavigationEnabled(): boolean {
+    return adminNavigationEnabled?.value ?? true
+  }
 
   function resolveAdminKeyboardTarget(direction: 'previous' | 'next'): string | null {
     const candidate = direction === 'previous'
@@ -111,7 +123,7 @@ export function useAttendanceAdminRailNavigation({
 
   async function restoreAdminSectionFromHash(maxAttempts = 4): Promise<boolean> {
     if (adminHashRestoreCompleted || adminHashRestorePending) return false
-    const restoreId = readAdminSectionHash() ?? readLastKnownAdminSection()
+    const restoreId = readAdminSectionHash() ?? (isAdminNavigationEnabled() ? readLastKnownAdminSection() : null)
     if (!restoreId) return false
     adminHashRestorePending = true
     try {
@@ -136,7 +148,9 @@ export function useAttendanceAdminRailNavigation({
     if (typeof window === 'undefined' || adminForbidden.value || !showAdmin.value) return
     const elements = resolveAdminSectionElements()
     if (elements.length === 0) return
-    const initialId = readAdminSectionHash() ?? readLastKnownAdminSection() ?? elements[0].id
+    const initialId = readAdminSectionHash()
+      ?? (isAdminNavigationEnabled() ? readLastKnownAdminSection() : null)
+      ?? elements[0].id
     adminActiveSectionId.value = initialId
     if (typeof window.IntersectionObserver === 'undefined') return
     adminSectionObserver = new window.IntersectionObserver(
@@ -198,12 +212,12 @@ export function useAttendanceAdminRailNavigation({
     if (content instanceof HTMLElement) {
       content.scrollIntoView({ behavior: 'smooth', block: 'start' })
     }
-    if (adminFocusCurrentSectionOnly?.value) return
+    if (!isAdminNavigationEnabled() || adminFocusCurrentSectionOnly?.value) return
     target.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }
 
   function handleAdminSectionKeyboardNavigation(event: KeyboardEvent): void {
-    if (!showAdmin.value || adminForbidden.value) return
+    if (!showAdmin.value || adminForbidden.value || !isAdminNavigationEnabled()) return
     if (!event.altKey || event.metaKey || event.ctrlKey) return
     if (event.defaultPrevented || isInteractiveAdminKeyboardTarget(event.target)) return
     const direction = event.key === 'ArrowUp'
@@ -273,12 +287,12 @@ export function useAttendanceAdminRailNavigation({
   })
 
   watch(adminActiveSectionId, id => {
-    if (!showAdmin.value || !adminHashSyncReady || !isKnownAdminSectionId(id)) return
+    if (!showAdmin.value || !isAdminNavigationEnabled() || !adminHashSyncReady || !isKnownAdminSectionId(id)) return
     syncAdminSectionHash(id)
   })
 
   watch(adminActiveSectionId, id => {
-    if (!showAdmin.value || !isKnownAdminSectionId(id)) return
+    if (!showAdmin.value || !isAdminNavigationEnabled() || !isKnownAdminSectionId(id)) return
     void syncActiveAdminNavLinkIntoView(id)
   })
 

--- a/apps/web/tests/AttendanceAdminTaskHome.spec.ts
+++ b/apps/web/tests/AttendanceAdminTaskHome.spec.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import AttendanceAdminTaskHome from '../src/views/attendance/AttendanceAdminTaskHome.vue'
+
+type Group = {
+  key: string
+  title: string
+  detail: string
+  linkActions: Array<{ key: string; label: string; href: string; primary?: boolean }>
+  buttonActions: Array<{ key: string; label: string; sectionId: string; primary?: boolean }>
+}
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+const FOUR_GROUPS: Group[] = [
+  {
+    key: 'daily-operations',
+    title: 'Daily operations',
+    detail: 'Approvals, anomalies, imports, and audit follow-up.',
+    linkActions: [
+      { key: 'pending-attendance-approvals', label: 'Pending approvals', href: '/attendance?section=attendance-overview-requests', primary: true },
+      { key: 'attendance-anomalies', label: 'Anomalies', href: '/attendance?section=attendance-overview-anomalies' },
+    ],
+    buttonActions: [
+      { key: 'daily-import', label: 'Import', sectionId: 'attendance-admin-import' },
+      { key: 'audit-follow-up', label: 'Audit logs', sectionId: 'attendance-admin-audit-logs' },
+    ],
+  },
+  {
+    key: 'people-groups',
+    title: 'People and attendance groups',
+    detail: 'Groups, members, owners, access, and availability.',
+    linkActions: [],
+    buttonActions: [
+      { key: 'attendance-groups', label: 'Attendance groups', sectionId: 'attendance-admin-groups', primary: true },
+      { key: 'group-members', label: 'Members', sectionId: 'attendance-admin-group-members' },
+    ],
+  },
+  {
+    key: 'work-time-policies',
+    title: 'Work time and policies',
+    detail: 'Shifts, schedules, holidays, rule sets, overtime, and leave policies.',
+    linkActions: [],
+    buttonActions: [
+      { key: 'shifts', label: 'Shifts', sectionId: 'attendance-admin-shifts', primary: true },
+      { key: 'holidays', label: 'Holidays', sectionId: 'attendance-admin-holidays' },
+    ],
+  },
+  {
+    key: 'reporting-payroll',
+    title: 'Reporting and payroll',
+    detail: 'Import batches, report fields, payroll templates, and payroll cycles.',
+    linkActions: [],
+    buttonActions: [
+      { key: 'import-batches', label: 'Import batches', sectionId: 'attendance-admin-import-batches', primary: true },
+      { key: 'payroll-cycles', label: 'Payroll cycles', sectionId: 'attendance-admin-payroll-cycles' },
+    ],
+  },
+]
+
+describe('AttendanceAdminTaskHome', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  function mount(overrides: { groups?: Group[] } = {}) {
+    const onSelectSection = vi.fn()
+    app = createApp(AttendanceAdminTaskHome, {
+      tr: (en: string) => en,
+      groups: overrides.groups ?? FOUR_GROUPS,
+      onSelectSection: onSelectSection,
+    })
+    app.mount(container!)
+    return { onSelectSection }
+  }
+
+  it('renders the header, region semantics, and the four task groups in order', async () => {
+    mount()
+    await flushUi()
+
+    const root = container!.querySelector('[data-admin-task-home="true"]')
+    expect(root).toBeTruthy()
+    expect(root?.getAttribute('role')).toBe('region')
+    expect(root?.getAttribute('aria-labelledby')).toBe('attendance-admin-task-home-title')
+
+    const title = container!.querySelector('#attendance-admin-task-home-title')
+    expect(title).toBeTruthy()
+    expect(title?.textContent).toContain('Operations and configuration')
+    expect(title?.getAttribute('tabindex')).toBe('-1')
+    expect(root?.textContent).toContain('Attendance management')
+    expect(root?.textContent).toContain('Daily work, people, policies, reporting, and payroll')
+
+    const groupKeys = Array.from(root!.querySelectorAll('[data-admin-task-group]')).map(el => el.getAttribute('data-admin-task-group'))
+    expect(groupKeys).toEqual(['daily-operations', 'people-groups', 'work-time-policies', 'reporting-payroll'])
+    expect(root?.textContent).toContain('Daily operations')
+    expect(root?.textContent).toContain('Approvals, anomalies, imports, and audit follow-up.')
+  })
+
+  it('renders link actions as real anchors that do not go through the emit path', async () => {
+    mount()
+    await flushUi()
+
+    const anomalyLink = container!.querySelector<HTMLAnchorElement>('[data-admin-task-action="attendance-anomalies"]')
+    expect(anomalyLink?.tagName).toBe('A')
+    expect(anomalyLink?.getAttribute('href')).toBe('/attendance?section=attendance-overview-anomalies')
+    expect(anomalyLink?.classList.contains('attendance__btn--primary')).toBe(false)
+
+    const primaryLink = container!.querySelector<HTMLAnchorElement>('[data-admin-task-action="pending-attendance-approvals"]')
+    expect(primaryLink?.classList.contains('attendance__btn--primary')).toBe(true)
+  })
+
+  it('emits select-section with the section id when a button action is clicked', async () => {
+    const { onSelectSection } = mount()
+    await flushUi()
+
+    const importButton = container!.querySelector<HTMLButtonElement>('[data-admin-task-action="daily-import"]')
+    expect(importButton?.tagName).toBe('BUTTON')
+    importButton!.click()
+    await flushUi()
+
+    expect(onSelectSection).toHaveBeenCalledTimes(1)
+    expect(onSelectSection).toHaveBeenCalledWith('attendance-admin-import')
+
+    const shiftsButton = container!.querySelector<HTMLButtonElement>('[data-admin-task-action="shifts"]')
+    expect(shiftsButton?.classList.contains('attendance__btn--primary')).toBe(true)
+    shiftsButton!.click()
+    await flushUi()
+
+    expect(onSelectSection).toHaveBeenCalledTimes(2)
+    expect(onSelectSection).toHaveBeenLastCalledWith('attendance-admin-shifts')
+  })
+
+  it('renders no group cards when the parent passes an empty (permission-filtered) list', async () => {
+    mount({ groups: [] })
+    await flushUi()
+
+    expect(container!.querySelectorAll('[data-admin-task-group]')).toHaveLength(0)
+    const root = container!.querySelector('[data-admin-task-home="true"]')
+    expect(root).toBeTruthy()
+    expect(root?.textContent).toContain('Attendance management')
+  })
+})

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -154,29 +154,59 @@ describe('Attendance admin anchor navigation', () => {
     expect(container!.querySelector('[data-admin-anchor-recent]')).toBeNull()
   })
 
-  it('renders a task-oriented admin home and routes task actions to existing sections', async () => {
-    app = createApp(AttendanceView, { mode: 'admin' })
+  it('renders the four task groups as the first admin context and opens one workspace at a time', async () => {
+    const clearSection = vi.fn()
+    app = createApp(AttendanceView, {
+      mode: 'admin',
+      onClearSection: clearSection,
+    })
     app.mount(container!)
     await flushUi()
 
+    const homeContext = container!.querySelector<HTMLElement>('[data-admin-home-context="true"]')
+    const sectionWorkspace = container!.querySelector<HTMLElement>('[data-admin-section-workspace="true"]')
     const taskHome = container!.querySelector<HTMLElement>('[data-admin-task-home="true"]')
+    expect(homeContext?.style.display).not.toBe('none')
+    expect(sectionWorkspace?.style.display).toBe('none')
     expect(taskHome).toBeTruthy()
-    expect(taskHome?.textContent).toContain('Admin workflow')
-    expect(taskHome?.textContent).toContain('Today queue')
-    expect(taskHome?.textContent).toContain('Monthly processing')
-    expect(taskHome?.textContent).toContain('Base configuration')
-    expect(taskHome?.textContent).toContain('Audit and rollback')
+    expect(taskHome?.textContent).toContain('Attendance management')
+    expect(Array.from(taskHome!.querySelectorAll('[data-admin-task-group]')).map(group => group.getAttribute('data-admin-task-group'))).toEqual([
+      'daily-operations',
+      'people-groups',
+      'work-time-policies',
+      'reporting-payroll',
+    ])
+    expect(taskHome?.textContent).toContain('Daily operations')
+    expect(taskHome?.textContent).toContain('People and attendance groups')
+    expect(taskHome?.textContent).toContain('Work time and policies')
+    expect(taskHome?.textContent).toContain('Reporting and payroll')
 
     const pendingApprovalsLink = taskHome!.querySelector<HTMLAnchorElement>('[data-admin-task-action="pending-attendance-approvals"]')
     expect(pendingApprovalsLink?.getAttribute('href')).toBe('/attendance?section=attendance-overview-requests')
+    expect(taskHome!.querySelector<HTMLAnchorElement>('[data-admin-task-action="attendance-anomalies"]')?.getAttribute('href'))
+      .toBe('/attendance?section=attendance-overview-anomalies')
+    for (const action of ['attendance-groups', 'shifts', 'holidays', 'rule-sets', 'daily-import']) {
+      expect(taskHome!.querySelector(`[data-admin-task-action="${action}"]`)).toBeTruthy()
+    }
 
-    const importButton = taskHome!.querySelector<HTMLButtonElement>('[data-admin-task-action="monthly-import"]')
+    const importButton = taskHome!.querySelector<HTMLButtonElement>('[data-admin-task-action="daily-import"]')
     expect(importButton).toBeTruthy()
     importButton!.click()
     await flushUi(2)
 
+    expect(homeContext?.style.display).toBe('none')
+    expect(sectionWorkspace?.style.display).not.toBe('none')
     const currentSectionBar = container!.querySelector<HTMLElement>('[data-admin-current-section="true"]')
     expect(currentSectionBar?.textContent).toContain('Import')
+
+    container!.querySelector<HTMLButtonElement>('[data-admin-task-home-return="true"]')!.click()
+    await flushUi(2)
+
+    expect(homeContext?.style.display).not.toBe('none')
+    expect(sectionWorkspace?.style.display).toBe('none')
+    expect(window.location.hash).toBe('')
+    expect(document.activeElement?.id).toBe('attendance-admin-task-home-title')
+    expect(clearSection).toHaveBeenCalledTimes(1)
   })
 
   it('creates an attendance group from the detail pane and selects it for people management', async () => {
@@ -789,7 +819,10 @@ describe('Attendance admin anchor navigation', () => {
   })
 
   it('renders a sticky current-section bar in the right pane', async () => {
-    app = createApp(AttendanceView, { mode: 'admin' })
+    app = createApp(AttendanceView, {
+      mode: 'admin',
+      initialSectionId: 'attendance-admin-settings',
+    })
     app.mount(container!)
     await flushUi()
 
@@ -797,7 +830,8 @@ describe('Attendance admin anchor navigation', () => {
     expect(currentSectionBar).toBeTruthy()
     expect(currentSectionBar?.textContent).toContain('Current section')
     expect(currentSectionBar?.textContent).toContain('Workspace · Settings')
-    expect(currentSectionBar?.textContent).toContain('Quick switch: Alt+↑ previous')
+    expect(currentSectionBar?.textContent).toContain('Management home')
+    expect(currentSectionBar?.textContent).not.toContain('Quick switch')
     expect(currentSectionBar?.querySelector('[data-admin-quick-jump="true"]')).toBeTruthy()
     expect(currentSectionBar?.querySelector('[data-admin-focus-toggle="true"]')).toBeNull()
     expect(currentSectionBar?.querySelector('[data-admin-prev-section]')?.getAttribute('data-admin-prev-section-id')).toBe('')
@@ -1180,21 +1214,17 @@ describe('Attendance admin anchor navigation', () => {
     expect(container!.textContent).toContain('Recent admin shortcuts cleared.')
   })
 
-  it('restores the last active admin section when no hash is present', async () => {
+  it('keeps the task home as the first context when only a remembered section exists', async () => {
     window.localStorage.setItem(scopedAdminNavStorageKey(ADMIN_NAV_LAST_SECTION_STORAGE_KEY), 'attendance-admin-approval-flows')
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)
     await flushUi()
 
-    expect(scrollIntoViewSpy).toHaveBeenCalled()
     const scrolledTargets = scrollIntoViewSpy.mock.instances as HTMLElement[]
-    expect(scrolledTargets.some(target => target.id === 'attendance-admin-approval-flows')).toBe(true)
-    expect(scrolledTargets.some(target => target.dataset.adminAnchor === 'attendance-admin-approval-flows')).toBe(true)
-
-    const button = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-approval-flows"]')
-    expect(button?.classList.contains('attendance__admin-nav-link--active')).toBe(true)
-    expect(button?.getAttribute('aria-current')).toBe('true')
-    expect(window.location.hash).toBe('#attendance-admin-approval-flows')
+    expect(scrolledTargets.some(target => target.id === 'attendance-admin-approval-flows')).toBe(false)
+    expect(container!.querySelector<HTMLElement>('[data-admin-home-context="true"]')?.style.display).not.toBe('none')
+    expect(container!.querySelector<HTMLElement>('[data-admin-section-workspace="true"]')?.style.display).toBe('none')
+    expect(window.location.hash).toBe('')
   })
 
   it('isolates admin rail persistence by org id', async () => {
@@ -1224,9 +1254,9 @@ describe('Attendance admin anchor navigation', () => {
       item => item.textContent?.trim() || '',
     )
     expect(labels).toEqual(['Data & Payroll · Payroll Cycles', 'Data & Payroll · Import batches'])
-    expect(scrollIntoViewSpy).toHaveBeenCalled()
     const scrolledTargets = scrollIntoViewSpy.mock.instances as HTMLElement[]
-    expect(scrolledTargets.some(target => target.id === 'attendance-admin-payroll-cycles')).toBe(true)
+    expect(scrolledTargets.some(target => target.id === 'attendance-admin-payroll-cycles')).toBe(false)
+    expect(container!.querySelector<HTMLElement>('[data-admin-home-context="true"]')?.style.display).not.toBe('none')
   })
 
   it('collapses the grouped rail behind a toggle on narrow screens', async () => {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, ref, type App } from 'vue'
 import AttendanceView from '../src/views/AttendanceView.vue'
+import AttendanceAdminCenter from '../src/views/attendance/AttendanceAdminCenter.vue'
 import { apiFetch } from '../src/utils/api'
 import {
   canRunBatchAnomalyResolution,
@@ -1263,6 +1264,51 @@ describe('Attendance admin regressions', () => {
     const meCall = vi.mocked(apiFetch).mock.calls.map(c => String(c[0])).find(u => u.includes('/leave-balances/me'))
     expect(meCall).toBeTruthy()
     expect(meCall).not.toContain('userId=')
+  })
+
+  it('W3/4353 admin-forbidden: a 403 admin surface shows the permission notice and never renders the task home (charter §7)', async () => {
+    const defaultImpl = vi.mocked(apiFetch).getMockImplementation()
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance') || url.includes('/api/admin') || url.includes('/api/permissions')) {
+        return jsonResponse(403, { ok: false, error: { code: 'FORBIDDEN', message: 'forbidden' } })
+      }
+      if (!defaultImpl) return jsonResponse(200, { ok: true, data: { items: [], total: 0 } })
+      return defaultImpl(input, init)
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(32)
+
+    expect(container!.textContent).toContain('Admin permissions required to manage attendance settings.')
+    expect(container!.querySelector('[data-admin-task-home]')).toBeNull()
+    expect(container!.querySelector('[data-admin-task-action]')).toBeNull()
+  })
+
+  it('W3/4353 wiring: AttendanceAdminCenter re-emits clear-section from the real return-home flow (review P3-1)', async () => {
+    // Mounts the REAL wrapper (not a mock): entering with an explicit section keeps the task home
+    // closed; clicking Management home must propagate clear-section through AdminCenter to its
+    // parent. A regression that drops the template re-emit turns exactly this leg red.
+    const onClearSection = vi.fn()
+    app = createApp(AttendanceAdminCenter, {
+      initialSectionId: 'attendance-admin-groups',
+      onClearSection,
+    })
+    app.mount(container!)
+    await flushUi(16)
+
+    // Task home lives under v-show: with an explicit section it must be present-but-hidden.
+    const homeContext = container!.querySelector('[data-admin-home-context]') as HTMLElement
+    expect(homeContext).toBeTruthy()
+    expect(homeContext.style.display).toBe('none')
+    const returnHome = [...container!.querySelectorAll('button')].find(b => (b.textContent || '').includes('Management home'))
+    expect(returnHome, 'expected the Management home button').toBeTruthy()
+    returnHome!.click()
+    await flushUi(4)
+
+    expect(onClearSection).toHaveBeenCalledTimes(1)
+    expect((container!.querySelector('[data-admin-home-context]') as HTMLElement).style.display).not.toBe('none')
   })
 
   it('admin notification deliveries — reminds selected owed-punch candidates with an authoritative confirm snapshot', async () => {

--- a/apps/web/tests/attendance-experience-entrypoints.spec.ts
+++ b/apps/web/tests/attendance-experience-entrypoints.spec.ts
@@ -67,7 +67,8 @@ vi.mock('../src/views/attendance/AttendanceAdminCenter.vue', () => ({
         default: '',
       },
     },
-    template: '<div data-view="admin" :data-section="initialSectionId"></div>',
+    emits: ['clear-section'],
+    template: '<div data-view="admin" :data-section="initialSectionId"><button data-return-admin-home @click="$emit(\'clear-section\')">Home</button></div>',
   }),
 }))
 
@@ -149,6 +150,36 @@ describe('Attendance experience entrypoints', () => {
     expect(adminView?.dataset.section).toBe('attendance-admin-assignments')
   })
 
+  it('clears a deep-linked section through the router when returning to management home', async () => {
+    routeState.query = { tab: 'admin', section: 'attendance-admin-assignments' }
+
+    app = createApp(AttendanceExperienceView)
+    app.mount(container!)
+    await flushUi()
+
+    container!.querySelector<HTMLButtonElement>('[data-return-admin-home]')!.click()
+    await flushUi(2)
+
+    expect(replaceSpy).toHaveBeenLastCalledWith({ query: { tab: 'admin' } })
+    expect(routeState.query).toEqual({ tab: 'admin' })
+    expect(container!.querySelector<HTMLElement>('[data-view="admin"]')?.dataset.section).toBe('')
+  })
+
+  it('returns the dedicated import entrypoint to the management home tab', async () => {
+    routeState.query = { tab: 'import' }
+
+    app = createApp(AttendanceExperienceView)
+    app.mount(container!)
+    await flushUi()
+
+    container!.querySelector<HTMLButtonElement>('[data-return-admin-home]')!.click()
+    await flushUi(2)
+
+    expect(replaceSpy).toHaveBeenLastCalledWith({ query: { tab: 'admin' } })
+    expect(routeState.query).toEqual({ tab: 'admin' })
+    expect(container!.querySelector<HTMLElement>('[data-view="admin"]')?.dataset.section).toBe('')
+  })
+
   it('routes the attendance approval queue shortcut into the overview requests section', async () => {
     routeState.query = { section: 'attendance-overview-requests', requestId: 'request-123' }
 
@@ -160,6 +191,18 @@ describe('Attendance experience entrypoints', () => {
     expect(overviewView).toBeTruthy()
     expect(overviewView?.dataset.section).toBe('attendance-overview-requests')
     expect(overviewView?.dataset.requestId).toBe('request-123')
+  })
+
+  it('routes the attendance anomaly shortcut into the overview anomaly section', async () => {
+    routeState.query = { section: 'attendance-overview-anomalies' }
+
+    app = createApp(AttendanceExperienceView)
+    app.mount(container!)
+    await flushUi()
+
+    const overviewView = container!.querySelector<HTMLElement>('[data-view="overview"]')
+    expect(overviewView).toBeTruthy()
+    expect(overviewView?.dataset.section).toBe('attendance-overview-anomalies')
   })
 
   it('routes the reports entrypoint into a dedicated reports view', async () => {

--- a/apps/web/tests/useAttendanceAdminRailNavigation.spec.ts
+++ b/apps/web/tests/useAttendanceAdminRailNavigation.spec.ts
@@ -84,7 +84,7 @@ describe('useAttendanceAdminRailNavigation', () => {
     }
   }
 
-  function mountHost(options?: { focused?: boolean }) {
+  function mountHost(options?: { focused?: boolean; navigationEnabled?: boolean }) {
     const items: AdminSectionNavItem[] = [
       { id: 'attendance-admin-settings', label: 'Settings' },
       { id: 'attendance-admin-approval-flows', label: 'Approval Flows' },
@@ -93,6 +93,7 @@ describe('useAttendanceAdminRailNavigation', () => {
       setup() {
         const showAdmin = ref(true)
         const adminForbidden = ref(false)
+        const adminNavigationEnabled = ref(options?.navigationEnabled ?? true)
         const adminFocusCurrentSectionOnly = ref(options?.focused ?? false)
         const adminNavStorageScope = ref('default')
         const adminActiveSectionId = ref(items[0].id)
@@ -111,6 +112,7 @@ describe('useAttendanceAdminRailNavigation', () => {
         const { adminSectionBinding, scrollToAdminSection } = useAttendanceAdminRailNavigation({
           showAdmin,
           adminForbidden,
+          adminNavigationEnabled,
           adminFocusCurrentSectionOnly,
           previousAdminSectionId,
           nextAdminSectionId,
@@ -125,6 +127,8 @@ describe('useAttendanceAdminRailNavigation', () => {
         return {
           adminActiveSectionId,
           adminCompactNavOpen,
+          adminNavStorageScope,
+          adminNavigationEnabled,
           adminSectionBinding,
           isCompactAdminNav,
           scrollToAdminSection,
@@ -262,5 +266,83 @@ describe('useAttendanceAdminRailNavigation', () => {
 
     expect(vm.adminActiveSectionId).toBe('attendance-admin-settings')
     expect(window.location.hash).toBe('')
+  })
+
+  // vNext charter §7 Wave 3 (issue #4353): `adminNavigationEnabled` keeps a
+  // hidden section workspace (admin task home open) inert — no restore from
+  // a remembered section, no keyboard nav, no hash-sync side effects.
+  describe('adminNavigationEnabled gate (Wave 3 task-home suppression)', () => {
+    it('falls back to the first element instead of the remembered section when navigation is disabled', async () => {
+      window.localStorage.setItem('metasheet_attendance_admin_nav_last_section:default', 'attendance-admin-approval-flows')
+      const vm = mountHost({ navigationEnabled: false })
+      await flushUi()
+
+      expect(vm.adminActiveSectionId).toBe('attendance-admin-settings')
+      expect(window.location.hash).toBe('')
+      const scrolledTargets = scrollIntoViewSpy.mock.instances as HTMLElement[]
+      expect(scrolledTargets.some(target => target.id === 'attendance-admin-approval-flows')).toBe(false)
+    })
+
+    // Positive control: the same stored last-section IS honored once navigation is enabled,
+    // proving the disabled-case above comes from the gate and not a broken fixture.
+    it('restores the remembered section when navigation is enabled (positive control)', async () => {
+      window.localStorage.setItem('metasheet_attendance_admin_nav_last_section:default', 'attendance-admin-approval-flows')
+      const vm = mountHost({ navigationEnabled: true })
+      await flushUi()
+
+      expect(vm.adminActiveSectionId).toBe('attendance-admin-approval-flows')
+      expect(window.location.hash).toBe('#attendance-admin-approval-flows')
+    })
+
+    it('still honors an explicit hash even while navigation is disabled', async () => {
+      window.history.replaceState({}, '', '/attendance#attendance-admin-approval-flows')
+      const vm = mountHost({ navigationEnabled: false })
+      await flushUi()
+
+      expect(vm.adminActiveSectionId).toBe('attendance-admin-approval-flows')
+      expect(window.location.hash).toBe('#attendance-admin-approval-flows')
+    })
+
+    it('ignores Alt+ArrowDown/ArrowUp keyboard navigation while navigation is disabled', async () => {
+      const vm = mountHost({ navigationEnabled: false })
+      await flushUi()
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', altKey: true, bubbles: true }))
+      await flushUi()
+
+      expect(vm.adminActiveSectionId).toBe('attendance-admin-settings')
+      expect(window.location.hash).toBe('')
+    })
+
+    it('does not sync the hash or nav-link scroll when the active section changes programmatically while navigation is disabled', async () => {
+      const vm = mountHost({ navigationEnabled: false })
+      await flushUi()
+      scrollIntoViewSpy.mockClear()
+
+      vm.adminActiveSectionId = 'attendance-admin-approval-flows'
+      await flushUi()
+
+      expect(window.location.hash).toBe('')
+      const scrolledTargets = scrollIntoViewSpy.mock.instances as HTMLElement[]
+      expect(scrolledTargets.some(target => target.dataset.adminAnchor === 'attendance-admin-approval-flows')).toBe(false)
+    })
+
+    it('does not re-restore the remembered section on a storage-scope change while navigation is disabled', async () => {
+      // This fixture's readLastAdminSection ignores its scope argument (unlike the real
+      // useAttendanceAdminRail), so the remembered id is stored under the one key it reads;
+      // cross-org key isolation itself is covered by the AttendanceView.vue integration test
+      // ('isolates admin rail persistence by org id' in attendance-admin-anchor-nav.spec.ts).
+      window.localStorage.setItem('metasheet_attendance_admin_nav_last_section:default', 'attendance-admin-approval-flows')
+      const vm = mountHost({ navigationEnabled: false })
+      await flushUi()
+      scrollIntoViewSpy.mockClear()
+
+      vm.adminNavStorageScope = 'org-b'
+      await flushUi()
+
+      expect(vm.adminActiveSectionId).toBe('attendance-admin-settings')
+      const scrolledTargets = scrollIntoViewSpy.mock.instances as HTMLElement[]
+      expect(scrolledTargets.some(target => target.id === 'attendance-admin-approval-flows')).toBe(false)
+    })
   })
 })

--- a/apps/web/tests/useAttendanceAdminRailNavigation.spec.ts
+++ b/apps/web/tests/useAttendanceAdminRailNavigation.spec.ts
@@ -283,15 +283,19 @@ describe('useAttendanceAdminRailNavigation', () => {
       expect(scrolledTargets.some(target => target.id === 'attendance-admin-approval-flows')).toBe(false)
     })
 
-    // Positive control: the same stored last-section IS honored once navigation is enabled,
-    // proving the disabled-case above comes from the gate and not a broken fixture.
+    // Positive control: the same stored last-section IS honored (and scrolled to) once
+    // navigation is enabled, proving the disabled-case above comes from the gate and not a
+    // broken fixture. (Hash-writing for this restore-only path is not this composable's own
+    // guarantee in isolation — it stays '' here with or without the gate — so this control
+    // asserts the id restore + scroll, the two effects the gate actually governs.)
     it('restores the remembered section when navigation is enabled (positive control)', async () => {
       window.localStorage.setItem('metasheet_attendance_admin_nav_last_section:default', 'attendance-admin-approval-flows')
       const vm = mountHost({ navigationEnabled: true })
       await flushUi()
 
       expect(vm.adminActiveSectionId).toBe('attendance-admin-approval-flows')
-      expect(window.location.hash).toBe('#attendance-admin-approval-flows')
+      const scrolledTargets = scrollIntoViewSpy.mock.instances as HTMLElement[]
+      expect(scrolledTargets.some(target => target.id === 'attendance-admin-approval-flows')).toBe(true)
     })
 
     it('still honors an explicit hash even while navigation is disabled', async () => {


### PR DESCRIPTION
## Charter step

vNext charter §14 step 5 (`docs/development/attendance-vnext-dingtalk-benchmark-ux-development-charter-20260720.md`): "issue #4355 的 runtime 合入后再 reclaim #4414 的业务意图，禁止直接合旧 stacked head." Hard precondition satisfied: Wave 2 (`AttendanceEmployeeWorkspace.vue`, #4501) merged at `8112810cd23a37bc69ae723b45930ec9444cce1a`, which is this branch's base.

Base freshness: branched from `origin/main@8112810cd` (Wave 2 merge). Re-checked `origin/main` tip `0ce3dc09f` before opening this PR — the 3 commits in between (#4493 test-only, #4499 directory T1, #4502 Wave 2 verification doc) touch neither `AttendanceView.vue` nor `apps/web/src/views/attendance/**`, so no rebase needed and no collision with this single-hot-file-lane change.

## Reclaim method

Per charter §14 step 5 I did **not** merge #4414 (OPEN/draft, head `8a10cdea5`, based on the pre-Wave-1 `codex/issue-4354-attendance-group-workspace` stack). Instead: `gh pr diff 4414` → itemized every hunk into an intent list → checked each item against **current `origin/main`** (not the old doc, not the draft's own base) → implemented only what was still missing.

## Intent diff table (#4414 vs current main, checked 2026-07-21)

| # | #4414 intent | Status on pre-Wave-3 main | This PR |
|---|---|---|---|
| A1-A11 | Admin task home shown *exclusively* (not alongside the full section workspace); `adminTaskHomeOpen` toggle; 4 groups renamed daily-operations/people-groups/work-time-policies/reporting-payroll with new actions (incl. Anomalies deep link); "Management home" return button replacing the Alt+↑/↓ hint copy | **Missing** — main still shows task home + full rail/shell simultaneously, always-visible old 4-group labels (today-queue/monthly-processing/base-config/audit-rollback), no return action | **Implemented**, plus componentized (see below) |
| B | `AttendanceAdminCenter.vue` passes through a `clear-section` emit | **Missing** | **Implemented** |
| C1 | `AttendanceExperienceView.vue`'s `overviewInitialSectionId` allowlists all 4 known overview section ids (not just `requests`) so the task home's Anomalies link round-trips through the route query | **Missing** (confirmed: only `attendance-overview-requests` passed through; `attendance-overview-anomalies` was silently dropped) | **Implemented** |
| C2-C3 | `returnToAdminHome()` + `onClearSection` wiring for the admin/import tabs | **Missing** | **Implemented** |
| D | `useAttendanceAdminRail.ts`: persist focused-mode immediately on scope change | **Superseded, not a gap** — main's `loadAdminNavFocusedMode()` already unconditionally returns `true` regardless of scope (the "all-sections" legacy mode was already fully retired on main by a different, stronger fix); #4414's narrower persist-on-change patch would be a no-op here | Not ported (verified moot) |
| E1-E3, E5-E7 | `useAttendanceAdminRailNavigation.ts`: `adminNavigationEnabled` gate suppressing hash-restore-from-last-section / scroll-spy-initial-id / keyboard nav / hash-sync watchers while the task home covers the section workspace | **Missing** | **Implemented**, plus 6 new direct unit tests (gate on/off, positive controls) beyond #4414's own coverage |
| E4 | IntersectionObserver scroll-spy suppressed while `adminFocusCurrentSectionOnly` | **Already on main** (verified: exact same guard + comment already present) | Not touched |
| F | Group detail 4-stage stepper (`attendanceGroupActiveStage`) + list-item responsive CSS | **Already on main** — landed via Wave 1 (#4359, `962fff55f`), independently of #4414 | Not touched (would collide with the group workspace lane) |
| G1-G4 | `attendance-admin-anchor-nav.spec.ts` test rewrites for the above | **Missing** (old tests still assumed simultaneous display / old copy / auto-restore-on-mount) | **Ported and adapted** to the current main line numbers/fixtures |
| G5 | `attendance-admin-regressions.spec.ts` stepper coverage | **Already on main** (Wave 1) | Not touched |
| G6 | `attendance-experience-entrypoints.spec.ts` new tests (clear-section round trip, anomaly routing) | **Missing** | **Implemented**, plus this file is now wired into `attendance-web-guard` for the first time (it existed but was never gated) |
| G7 | `useAttendanceAdminRail.spec.ts` focused-mode test | **Already reflects the always-true behavior on main** | Not touched |
| G8 | `useAttendanceAdminRailNavigation.spec.ts` IntersectionObserver-in-focused-mode test + positive control | **Already on main** | Not touched |

### Beyond #4414's literal diff (charter-mandated, not scope creep)

- **`AttendanceAdminTaskHome.vue` extraction** (charter §6.2 Wave 3 row, §7 Wave 3 deliverable "首次抽取"): #4414 kept the task-home markup inline in `AttendanceView.vue`; this PR extracts it into its own component per the charter's explicit Wave 3 boundary (component owns the 4-group grid + header + `select-section` emit; parent keeps `adminTaskHomeOpen`, group construction/permission-filtering-point, active id, data loading — advisor-reviewed boundary).
- **New `AttendanceAdminTaskHome.spec.ts`** mounted spec (4 tests): header/region semantics, link-vs-button action rendering, `select-section` emit, empty-groups-render-nothing (proves the parent-side permission-filtering seam works).
- **`attendance-experience-entrypoints.spec.ts` wired into `attendance-web-guard.yml`** for the first time — it existed on main but had zero CI wiring; since Wave 3 adds real behavioral assertions there, leaving it ungated would have been skip-shaped green (the exact F1/#3487 lesson).

### Explicit deferrals (not implemented, flagged rather than silently dropped)

- **No per-task readiness/status enum** (未配置/需处理/正常/失败, charter §4.2's full target IA / §6.2's "status" word). #4414 itself does not implement this either — it is out of the literal reclaim scope and out of Wave 3's own `交付`/`完成门` list in §7. Left for a future wave.
- **No permission-based filtering applied inside `adminTaskHomeGroups`** — unchanged from pre-existing/baseline behavior (not a regression; `AttendanceAdminTaskHome.vue`'s empty-groups test proves the seam exists for a future parent-side filter).
- **Three-viewport (1440/1024/390) browser verification and adversarial review** — per delegation scope, left to the main loop/owner (§8.1 items 8-10, plus the adversarial gate).

## §8.1 checklist (this PR's scope)

1. Affected pure modules — N/A this slice (no new pure `.ts` module; `AttendanceAdminTaskHome.vue` is display-only per its own header comment).
2. Real-mount attendance admin regression specs — `attendance-admin-regressions.spec.ts` (122 tests), `attendance-admin-anchor-nav.spec.ts` (30 tests) — green.
3. `attendance-web-guard` current-head required check — see wiring below; not yet observed on a pushed CI run (this is a local `gh pr create`, CI will run on push).
4. New/changed specs added to the guard's actual `vitest run` list + both `pull_request`/`push` path filters: `AttendanceAdminTaskHome.spec.ts` (new) and `attendance-experience-entrypoints.spec.ts` (newly wired, previously ungated) both added. Verified by running the **exact workflow command** locally (see below).
5. `pnpm --filter @metasheet/web exec vue-tsc -b` — clean, no output.
6. `pnpm --filter @metasheet/web build` — succeeds (pre-existing >500kB chunk warnings only, unrelated).
7. ≥2 load-bearing mutations — 3 performed, see below.
8-10. Three-viewport visual evidence — **deferred to main loop/owner** per delegation scope (see "Explicit deferrals").
11. Existing selector/deep-link/API compatibility — all pre-existing `data-*` attributes, section ids, and API call shapes preserved; verified via the full green regression suite (no payload/endpoint changes in this PR).

### Test commands run (local, real)

```
pnpm --filter @metasheet/web exec vue-tsc -b
# (clean, no output)

pnpm --filter @metasheet/web build
# ✓ built in 9.79s

pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav \
  useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit \
  attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome \
  attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply \
  attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow \
  attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert \
  useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet \
  attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export \
  attendance-reports-analytics attendance-bulk-balance-adjust attendance-overview-priority \
  AttendanceAdminTaskHome attendance-experience-entrypoints --reporter=dot
# Test Files  29 passed (29)
#      Tests  566 passed (566)
```

(29th/30th file `AttendanceAdminRail.spec.ts` also reconfirmed green separately — 30 files / 568 tests total across every spec touched or adjacent in this lane.)

Targeted ESLint (`AttendanceView.vue` + all touched files): 15 errors / 1 warning — **identical** to the pre-existing baseline on `8112810cd` (verified by linting a copy of the unmodified base file side-by-side). Zero new violations.

## Mutation record (§8.1 item 7, ≥2 required — 3 performed)

All mutations performed after committing the real implementation (per the "commit before mutate" rule), restored via `git checkout -- <file>` against the clean commit (safe — nothing uncommitted was at risk).

1. **`AttendanceView.vue` `selectAdminSection()`** — removed `adminTaskHomeOpen.value = false`. Red: `attendance-admin-anchor-nav.spec.ts > renders the four task groups as the first admin context and opens one workspace at a time` (`sectionWorkspace` stayed hidden after clicking a task action). Restored, reconfirmed green.
2. **`useAttendanceAdminRailNavigation.ts` `isAdminNavigationEnabled()`** — hardcoded to always return `true`. Red: 4 of the 6 new gate tests in `useAttendanceAdminRailNavigation.spec.ts` (`adminNavigationEnabled gate` describe block) — last-known-section fallback, active-id watcher hash-sync, and org-scope re-restore all reappeared. Restored, reconfirmed green (13/13).
3. **`AttendanceExperienceView.vue` `overviewInitialSectionId`** — reverted the allowlist to the old single-id (`attendance-overview-requests`) check. Red: `attendance-experience-entrypoints.spec.ts > routes the attendance anomaly shortcut into the overview anomaly section`. Restored, reconfirmed green (10/10).

## Scope discipline

- Single hot-file lane: diff against `8112810cd` touches only `AttendanceView.vue` (admin-task-home template region ~L1301-1400, imports/emit, the `useAttendanceAdminRailNavigation` wiring block ~L14410-14600, and admin-task-home/current-section/mobile CSS) — verified via `git diff --stat` hunk headers that no group-workspace (~L4700-5700), employee-workspace, or approval-panel regions were touched.
- Did not touch `AttendanceGroupWorkspace`-adjacent code (Wave 1, #4359) or the employee workspace (Wave 2, #4501, `AttendanceEmployeeWorkspace.vue`) or the group-workbench panel (#4359 follow-up).
- No API/payload/RBAC/computation semantic change — display/IA-only, matching charter §11.2's "display/IA-only" classification (no new design-lock required).

## Deviations from instructions

None. (Flagged deferrals above are explicit charter/task-scope boundaries, not deviations.)

## Refs

Refs #4353 (issue), refs #4414 (superseded stacked draft — recommend closing separately with a comment pointing at this PR once merged; not closed here per PR-body closing-keyword discipline). Refs the vNext charter (`docs/development/attendance-vnext-dingtalk-benchmark-ux-development-charter-20260720.md` §7 Wave 3, §14 step 5).

**Not merged, not armed.** Staged opt-in / merge decision belongs to the owner per standing convention.
