### PR TITLE
fix(material-reconciliation): D1 corrective — Set poisoning, snapshot multiset canonicalization, values-free evidence, closed partial predicate, charter RATIFIED (owner review 0P1/4P2/1P3)

### DIFF
--- a/docs/development/material-reconciliation-d1-dev-verification-20260721.md
+++ b/docs/development/material-reconciliation-d1-dev-verification-20260721.md
@@ -189,6 +189,15 @@ been applied to the TEMPLATES module:
 Round-4 mutation battery: re-export a live Set through `__internals` → RED; revert either
 detail sanitization → RED.
 
+**Round-4b (owner exact-head review of `a1c5e6c87`, 1 P2):** the first surface check scanned
+only two levels, so a nested re-export (`__internals.membership.{SET}`) stayed green while the
+poisoning still reproduced. The check is now a recursive walker over `Object.entries` —
+objects AND functions traversed, WeakSet cycle guard — rejecting `Set` instances and `*_SET`
+keys at any depth. Battery: the owner's nested mutant → RED; three-deep nesting → RED; a Set
+under an innocent key name (instance check, not key match) → RED; direct re-export → RED;
+walker probes: a Set mounted on an exported function is caught, and a cyclic export terminates
+without a false positive.
+
 ## 4. Explicitly out of scope (per §7 gates)
 
 D2 (scenario/binding store, pointer CAS runtime, `SET LOCAL lock_timeout` claim mechanics with

--- a/docs/development/material-reconciliation-d1-dev-verification-20260721.md
+++ b/docs/development/material-reconciliation-d1-dev-verification-20260721.md
@@ -152,6 +152,16 @@ partial-field check to template-only). One equivalent mutant noted honestly: reo
 spread `{ multiplicityBound, ...group }` is behaviourally identical because the hasOwnProperty
 guard already strips any group-level bound before the encode call.
 
+## 3e. Owner corrective review round-3 — absorption (2026-07-21)
+
+**1 P2**: `computeSnapshotContentDigest([])` succeeded WITHOUT a bound (the bound was only checked
+inside the group loop, which never runs for an empty snapshot), contradicting the PR's
+"missing snapshot bound fails closed" claim. Fixed: the snapshot-level `multiplicityBound` is
+validated BEFORE the loop. `computeSnapshotContentDigest([], validBound)` still succeeds (empty
+snapshot is the chartered §8.2-4 positive control); `computeSnapshotContentDigest([])` with no /
+zero / over-range bound now throws `MULTIPLICITY_OUT_OF_BOUNDS`. Mutation: dropping the pre-loop
+guard → RED. Header comment reconciled.
+
 ## 4. Explicitly out of scope (per §7 gates)
 
 D2 (scenario/binding store, pointer CAS runtime, `SET LOCAL lock_timeout` claim mechanics with

--- a/docs/development/material-reconciliation-d1-dev-verification-20260721.md
+++ b/docs/development/material-reconciliation-d1-dev-verification-20260721.md
@@ -118,6 +118,24 @@ independent lane proved whole rule-edges unpinned. The battery now stands at 15 
 12 review-round kills, with golden byte vectors extended (golden-2 carries an interior-zero
 decimal, boolean false, and composed unicode).
 
+## 3c. Owner corrective deep review — absorption (2026-07-21)
+
+An independent review at merged SHA `1f06ecea9` found **0 P1 / 4 P2 / 1 P3** — real contract
+gaps the green tests did not cover (proven with add-poison / plant / SQL probes). This corrective
+PR closes all five (D1 has no route/migration/runtime consumer, so no rollback was needed):
+
+| Finding | Fix |
+|---|---|
+| P2: exported `*_SET` mutable membership Sets are a poisoning vector — `MR_FIELD_TYPE_SET.add('x')` flipped the validator permissive (Object.freeze doesn't stop Set.add) | Removed ALL `*_SET` from the public surface (module-private now); test asserts `Object.keys(mod)` has no `_SET`, the public arrays are frozen (`push` throws), and an out-of-vocab field type is still rejected (private Set unreachable) |
+| P2: `computeSnapshotContentDigest` took pre-encoded tuples → two encodings of one multiset ([mult=1,mult=1] vs [mult=2]) with different digests; a test even pinned "duplicate tuple → different" as correct | API now takes structured identity GROUPS and rejects a repeated identity-content group (`DUPLICATE_IDENTITY_GROUP`) — one legal encoding per multiset; the dedup key is (class,key,digest) WITHOUT multiplicity, so the same row with differing multiplicities is also rejected |
+| P2: `summarizeMaterialReconciliationEvidence(templates)` echoed caller-planted prefix-valid objectIds (`material_reconciliation_MAT-001-SECRET`, label `customer-alpha`) | Takes NO argument; derives evidence ONLY from the frozen registry; plant-and-assert test proves planted business ids never surface |
+| P2: partial-unique predicate was a raw SQL free string (`1=1; DROP TABLE` passed) | Closed structured predicate `{ predicate: <MR_PARTIAL_PREDICATES>, field: <fieldId> }`; the D2 migration layer maps `not_null:X → "X IS NOT NULL"`; free-string / unknown-predicate / unknown-field all rejected |
+| P3: charter header still `PROPOSED / doc-only` while D1 doc claims ratified | Charter header → `RATIFIED` (owner ruling 2026-07-21; ratify unlocks D1 only, not D2 runtime) |
+
+Corrective mutation battery **6/6 RED** (re-export a Set, drop the dup-group guard, restore the
+evidence argument, open the partial-predicate vocab, key dedup on the full tuple incl.
+multiplicity, open the partial-field check); full plugin CJS chain (70 suites) green.
+
 ## 4. Explicitly out of scope (per §7 gates)
 
 D2 (scenario/binding store, pointer CAS runtime, `SET LOCAL lock_timeout` claim mechanics with

--- a/docs/development/material-reconciliation-d1-dev-verification-20260721.md
+++ b/docs/development/material-reconciliation-d1-dev-verification-20260721.md
@@ -134,7 +134,9 @@ PR closes all five (D1 has no route/migration/runtime consumer, so no rollback w
 
 Corrective mutation battery **6/6 RED** (re-export a Set, drop the dup-group guard, restore the
 evidence argument, open the partial-predicate vocab, key dedup on the full tuple incl.
-multiplicity, open the partial-field check); full plugin CJS chain (70 suites) green.
+multiplicity, open the partial-field check); full plugin CJS chain green (94 `scripts.test`
+suites; an earlier "70 suites" figure here counted only the suites that print a literal `OK`
+line — corrected in round-4).
 
 ## 3d. Owner corrective review round-2 — absorption (2026-07-21)
 
@@ -150,7 +152,8 @@ fixes), all closed in this PR:
 Round-2 mutation battery RED on both P2 fixes (reinstate per-group bound override; revert the
 partial-field check to template-only). One equivalent mutant noted honestly: reordering the
 spread `{ multiplicityBound, ...group }` is behaviourally identical because the hasOwnProperty
-guard already strips any group-level bound before the encode call.
+guard already rejects (fail-closed) any group carrying its own bound before the spread is
+reached — no group-level bound ever survives to the encode call.
 
 ## 3e. Owner corrective review round-3 — absorption (2026-07-21)
 
@@ -161,6 +164,30 @@ validated BEFORE the loop. `computeSnapshotContentDigest([], validBound)` still 
 snapshot is the chartered §8.2-4 positive control); `computeSnapshotContentDigest([])` with no /
 zero / over-range bound now throws `MULTIPLICITY_OUT_OF_BOUNDS`. Mutation: dropping the pre-loop
 guard → RED. Header comment reconciled.
+
+## 3f. Round-4 — post-APPROVE verify-pass absorption (2026-07-21)
+
+An independent verify pass over the round-1..3 ledger (adversarial agents, after the owner's
+0 P1 / 0 P2 code verdict at `8b9e7a5e8`) found the round-1 Set-privatization ruling had only
+been applied to the TEMPLATES module:
+
+- **P2: the codec `__internals` still exported three live membership Sets**
+  (`MR_DIGEST_ERROR_REASON_SET`, `MR_VALUE_KIND_SET`, `MR_IDENTITY_KEY_CLASS_SET`), and
+  `MR_IDENTITY_KEY_CLASS_SET` is load-bearing in `encodeIdentitySortTuple`. Probe:
+  `__internals.MR_IDENTITY_KEY_CLASS_SET.add('evil')` flipped an unknown `identityKeyClass`
+  from reject to ACCEPT, encoding class byte `0x00` — colliding with the `identity_invalid`
+  domain separator. Fixed: the Sets are module-private; no `*_SET` key and no live `Set`
+  instance anywhere on the export surface (module or `__internals`), pinned by a test that
+  also runs the poisoning attempt as a no-op with reject-before/reject-after positive controls.
+- **P3 (raised in the round-3 re-review, absorbed here): error-detail sanitization aligned** —
+  the in-loop `encodeIdentitySortTuple` guards now null out non-safe-integer
+  `multiplicityBound`/`multiplicity` in `details`, matching the snapshot-level pre-loop guard's
+  discipline; pinned by tests asserting `details.<field> === null` for string inputs.
+- Ledger corrections: "70 suites" → 94 (§3c); §3d equivalent-mutant rationale reworded — the
+  hasOwnProperty guard *rejects fail-closed*, it does not strip.
+
+Round-4 mutation battery: re-export a live Set through `__internals` → RED; revert either
+detail sanitization → RED.
 
 ## 4. Explicitly out of scope (per §7 gates)
 

--- a/docs/development/material-reconciliation-d1-dev-verification-20260721.md
+++ b/docs/development/material-reconciliation-d1-dev-verification-20260721.md
@@ -136,6 +136,22 @@ Corrective mutation battery **6/6 RED** (re-export a Set, drop the dup-group gua
 evidence argument, open the partial-predicate vocab, key dedup on the full tuple incl.
 multiplicity, open the partial-field check); full plugin CJS chain (70 suites) green.
 
+## 3d. Owner corrective review round-2 — absorption (2026-07-21)
+
+A second corrective review found **0 P1 / 2 P2 / 1 P3** (second-order gaps in the round-1
+fixes), all closed in this PR:
+
+| Finding | Fix |
+|---|---|
+| P2: the snapshot-level `multiplicityBound` could be bypassed by a per-group `multiplicityBound` (snapshot bound 1 + group bound 10 + multiplicity 2 was accepted, violating the Charter unified read bound) | the snapshot-level bound is the SOLE authority; any per-group `multiplicityBound` is rejected fail-closed, and a group multiplicity above the snapshot bound is rejected with no group-level escape; a missing snapshot bound fails closed |
+| P2: the partial-unique predicate field was only checked against template fields, not the uniqueness constraint's own fields (a run unique on `run_identity_key` with an `attempt_id` predicate — `attempt_id` being a real run field — passed) | the predicate field must be a member of `uniqueness.fields`; a discriminating test (predicate field IS a template field but NOT in the constraint) pins it |
+| P3: charter §10 still said "建议裁决" and §11 exit criteria were framed as pending | §10 → final RATIFY ruling; §11 criteria marked satisfied (D1 merged at `1f06ecea9`); rev-level deferred wording flagged as historical |
+
+Round-2 mutation battery RED on both P2 fixes (reinstate per-group bound override; revert the
+partial-field check to template-only). One equivalent mutant noted honestly: reordering the
+spread `{ multiplicityBound, ...group }` is behaviourally identical because the hasOwnProperty
+guard already strips any group-level bound before the encode call.
+
 ## 4. Explicitly out of scope (per §7 gates)
 
 D2 (scenario/binding store, pointer CAS runtime, `SET LOCAL lock_timeout` claim mechanics with

--- a/docs/development/stock-preparation-v2-material-master-reconciliation-charter-20260719.md
+++ b/docs/development/stock-preparation-v2-material-master-reconciliation-charter-20260719.md
@@ -1,8 +1,11 @@
-# PLM <-> ERP 物料主数据对账 V2 Charter（PROPOSED）— 2026-07-19
+# PLM <-> ERP 物料主数据对账 V2 Charter（RATIFIED）— 2026-07-19
 
-> **状态：PROPOSED / doc-only。** 本文把备料通用化计划的下一开发目标收敛为一个真实的
-> 第二场景：**PLM <-> ERP 物料主数据对账**。本文不授权运行时代码、迁移、路由、开关、
-> 实体机重跑或外部写；运行时实现须等 §10 的 owner 决策与 Charter ratify。
+> **状态：RATIFIED（owner 裁决 2026-07-21：OD-V2-1..7 全部按推荐 ratify；ratify 仅解锁 D1）。**
+> 本文把备料通用化计划的下一开发目标收敛为一个真实的第二场景：**PLM <-> ERP 物料主数据对账**。
+> ratify 只解锁 D1（独立 manifest + 冻结模板 + 闭词表 + flag/权限合同 + canonicalRowDigest
+> 确定性契约，schema-only、无 routes/runtime/migration）；D2 及以后仍须逐刀过 §7 门,ratify
+> **不自动授权** D2 及以后的运行时代码、迁移、路由、开关、实体机重跑或外部写。原始
+> PROPOSED 状态见 §12 修订记录。
 >
 > **代码锚：** `origin/main` `d83cf5875f517c3046eb43b37ab83da9e9d2fef9`（rev-5 刷新；较 rev-3 锚
 > `698997cf8…` 仅多一笔 attendance 文档提交 `#4492`,stock-prep / integration-core 面零变动;

--- a/docs/development/stock-preparation-v2-material-master-reconciliation-charter-20260719.md
+++ b/docs/development/stock-preparation-v2-material-master-reconciliation-charter-20260719.md
@@ -625,18 +625,22 @@ D3a 的并发面**（指针 CAS、`runIdentityKey` 部分唯一索引与并发 d
 | OD-V2-6 | 发布姿态 | **独立 default-OFF flag；仅内部写；`externalWrite=false`** | 解锁 D1，仍不授权 ON rollout |
 | OD-V2-7 | 场景绑定与换绑 | **§2.3/§4.5/§4.6 模型整体冻结：绑定版本生命周期（supersede/revoke 拆分；`active` 为指针派生谓词非存储状态）+ 指针权威唯一 active（复合 FK；revoke 清指针同事务，切换预选替代版本 = 同事务完整 Activate 重验；partial-unique 变体不采用）+ 外部系统身份 pin（内容键单轨：`systemContentKey` 进绑定成员、bindingFingerprint、run-start pin 与 activate/commit 重验；不引入无权威来源的版本 ID）+ 四层重验 + commit 漂移拆分 + 血缘/运行双键 + 双指纹（业务摘要不裸 SHA 外显；排序元组编码 rev-4 冻结）+ 运行请求仅 scenarioInstanceId + V1 双源不 N** | 解锁 D2 绑定底座设计 |
 
-**建议裁决：七项全部按推荐 ratify。** 该裁决只解锁 D1；D2 及以后仍按 §7 逐刀过门，
-不会自动触发运行时开发、发布或实体机执行。
+**最终裁决（owner 2026-07-21）：OD-V2-1..7 七项全部按推荐 RATIFY。** 该裁决只解锁 D1；
+D2 及以后仍按 §7 逐刀过门，不会自动触发运行时开发、发布或实体机执行。
+（上文各 rev 里的「暂缓 / 待复审」等 deferred 口径均为历史过程记录,以本最终裁决为准。）
 
-## 11. Charter 退出判据
+## 11. Charter 退出判据（**全部满足 → 已 RATIFIED，owner 2026-07-21**）
 
-本 Charter 只有在以下条件同时满足后才从 PROPOSED 转为 RATIFIED：
+本 Charter 已从 PROPOSED 转为 RATIFIED；下列判据在合并时逐条满足（历史记录）：
 
-1. owner 对 OD-V2-1..7 逐项裁决；
-2. 独立 code-vs-doc 审阅确认现有 cache、P4 UOW、source capability 和 external-write 边界表述
-   与代码一致；
-3. PR 仅含文档，且无 closing keyword、secret、客户标识、业务值或运行时授权；
-4. `#4437` 状态保持独立，不以 Charter 合并代替实体机验收。
+1. ✅ owner 对 OD-V2-1..7 逐项裁决（七项按推荐 ratify，§10 最终裁决）；
+2. ✅ 独立 code-vs-doc 审阅确认现有 cache、P4 UOW、source capability 和 external-write 边界
+   表述与代码一致；
+3. ✅ PR 仅含文档，且无 closing keyword、secret、客户标识、业务值或运行时授权；
+4. ✅ `#4437` 状态保持独立，不以 Charter 合并代替实体机验收。
+
+ratify 仅解锁 D1；D1 已合入 main（PR #4507，`1f06ecea9`）。D2 及以后仍逐刀过 §7 门,ratify
+不自动授权 D2 运行时。
 
 ## 12. 本轮设计审计与验证记录
 

--- a/plugins/plugin-integration-core/__tests__/material-reconciliation-row-digest.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/material-reconciliation-row-digest.test.cjs
@@ -608,6 +608,42 @@ function deepReviewRound() {
   assert.equal(golden2.hex, '35785be424f326d567759cbf530f0c0a5cb85091ada133ec710833021e872296', 'golden 2 canonical row digest')
 }
 
+// Round-4 (post-APPROVE verify pass): the CODEC export surface must not leak a
+// live membership Set either — same poisoning class the templates round-1 fix
+// closed. A reachable mutable Set flips a validator from reject to accept, and
+// a poisoned identityKeyClass would encode class byte 0x00, colliding with the
+// identity_invalid domain separator.
+function round4CodecSurface() {
+  const mod = require(MODULE_PATH)
+  // 1. No *_SET key and no live Set instance anywhere on the export surface.
+  for (const [scopeName, scope] of [['module', mod], ['__internals', mod.__internals]]) {
+    for (const [key, value] of Object.entries(scope)) {
+      assert.ok(!key.includes('_SET'), `${scopeName}.${key}: no exported Set-mirror names`)
+      assert.ok(!(value instanceof Set), `${scopeName}.${key}: no live Set instances exported`)
+    }
+  }
+  // 2. Poisoning attempt is a no-op: the Set is unreachable, and an unknown
+  //    identityKeyClass still fails closed afterwards (positive control pair).
+  const evil = { identityKeyClass: 'evil', identityKeyBytes: Buffer.from('k'), canonicalRowDigest: Buffer.alloc(32), multiplicity: 1, multiplicityBound: 16 }
+  assertThrowsReason(() => encodeIdentitySortTuple(evil), 'UNSUPPORTED_KIND', 'unknown identityKeyClass rejected before poisoning attempt')
+  __internals.MR_IDENTITY_KEY_CLASS_SET?.add?.('evil') // unreachable: optional-chain no-op
+  assertThrowsReason(() => encodeIdentitySortTuple(evil), 'UNSUPPORTED_KIND', 'unknown identityKeyClass STILL rejected after poisoning attempt')
+  // Positive control: the two chartered classes still encode.
+  assert.equal(encodeIdentitySortTuple({ identityKeyClass: 'valid', identityKeyBytes: Buffer.from('k'), canonicalRowDigest: Buffer.alloc(32), multiplicity: 1, multiplicityBound: 16 })[0], MR_IDENTITY_KEY_CLASS_BYTES.valid, 'valid class still encodes')
+  assert.equal(encodeIdentitySortTuple({ identityKeyClass: 'identity_invalid', identityKeyBytes: Buffer.alloc(0), canonicalRowDigest: Buffer.alloc(32), multiplicity: 1, multiplicityBound: 16 })[0], MR_IDENTITY_KEY_CLASS_BYTES.identity_invalid, 'identity_invalid class still encodes')
+  // 3. Round-4 P3: error details carry sanitized values only — a non-integer
+  //    bound/multiplicity never round-trips into the error surface verbatim.
+  for (const [label, input, field] of [
+    ['non-integer bound sanitized', { ...evil, identityKeyClass: 'valid', multiplicityBound: '9' }, 'multiplicityBound'],
+    ['non-integer multiplicity sanitized', { ...evil, identityKeyClass: 'valid', multiplicity: 'x' }, 'multiplicity'],
+  ]) {
+    let thrown = null
+    try { encodeIdentitySortTuple(input) } catch (error) { thrown = error }
+    assert.ok(thrown && thrown.reason === 'MULTIPLICITY_OUT_OF_BOUNDS', `${label}: fails closed`)
+    assert.equal(thrown.details[field], null, `${label}: details.${field} is null, not the raw value`)
+  }
+}
+
 function main() {
   structuralIndependence()
   frozenVocabularies()
@@ -621,6 +657,7 @@ function main() {
   digestShape()
   reviewHardening()
   deepReviewRound()
+  round4CodecSurface()
 }
 
 main()

--- a/plugins/plugin-integration-core/__tests__/material-reconciliation-row-digest.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/material-reconciliation-row-digest.test.cjs
@@ -587,12 +587,18 @@ function deepReviewRound() {
     'bound above 2^32-1 rejected with the closed reason',
   )
 
-  // Empty snapshot is LEGAL (charter §8.2-4 positive control): sha256 of zero tuples.
+  // Empty snapshot is LEGAL WITH a valid bound (charter §8.2-4 positive control):
+  // sha256 of zero tuples. Corrective round-3 P2: the bound is validated BEFORE
+  // the loop, so an empty snapshot cannot bypass it.
   assert.equal(
-    computeSnapshotContentDigest([]).hex,
+    computeSnapshotContentDigest([], 16).hex,
     'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-    'empty snapshot digest pinned',
+    'empty snapshot digest pinned (with a valid bound)',
   )
+  // Empty snapshot with NO / invalid bound fails closed.
+  assertThrowsReason(() => computeSnapshotContentDigest([]), 'MULTIPLICITY_OUT_OF_BOUNDS', 'empty snapshot with no bound fails closed')
+  assertThrowsReason(() => computeSnapshotContentDigest([], 0), 'MULTIPLICITY_OUT_OF_BOUNDS', 'empty snapshot with zero bound fails closed')
+  assertThrowsReason(() => computeSnapshotContentDigest([], 2 ** 32), 'MULTIPLICITY_OUT_OF_BOUNDS', 'empty snapshot with over-range bound fails closed')
 
   // Golden 2: interior-zero decimal + boolean false + composed unicode.
   const golden2 = computeCanonicalRowDigest({

--- a/plugins/plugin-integration-core/__tests__/material-reconciliation-row-digest.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/material-reconciliation-row-digest.test.cjs
@@ -351,47 +351,76 @@ function sortTupleContract() {
 }
 
 function snapshotContentDigestContract() {
+  // Corrective-review P2: the API takes structured identity GROUPS and enforces
+  // ONE encoding per multiset — a repeated identity-content group is rejected,
+  // so [mult=1, mult=1 same-row] can no longer masquerade as [mult=2].
   const digestOf = (token) => computeCanonicalRowDigest({ fieldOrder: ['k1'], row: { k1: token } }).buffer
-  const tuple = (token, multiplicity) =>
-    encodeIdentitySortTuple({
-      identityKeyClass: 'valid',
-      identityKeyBytes: Buffer.from(token, 'utf8'),
-      canonicalRowDigest: digestOf(token),
-      multiplicity,
-      multiplicityBound: 16,
-    })
-  const t1 = tuple('row-a', 1)
-  const t2 = tuple('row-b', 2)
-  const t3 = tuple('row-c', 1)
-  const invalidT = encodeIdentitySortTuple({
+  const group = (token, multiplicity) => ({
+    identityKeyClass: 'valid',
+    identityKeyBytes: Buffer.from(token, 'utf8'),
+    canonicalRowDigest: digestOf(token),
+    multiplicity,
+    multiplicityBound: 16,
+  })
+  const g1 = group('row-a', 1)
+  const g2 = group('row-b', 2)
+  const g3 = group('row-c', 1)
+  const invalidG = {
     identityKeyClass: 'identity_invalid',
     identityKeyBytes: Buffer.alloc(0),
     canonicalRowDigest: digestOf('row-d'),
     multiplicity: 1,
     multiplicityBound: 16,
-  })
+  }
 
-  const forward = computeSnapshotContentDigest([t1, t2, t3, invalidT]).hex
-  const shuffled = computeSnapshotContentDigest([invalidT, t3, t1, t2]).hex
-  const shuffled2 = computeSnapshotContentDigest([t2, invalidT, t1, t3]).hex
+  const forward = computeSnapshotContentDigest([g1, g2, g3, invalidG]).hex
+  const shuffled = computeSnapshotContentDigest([invalidG, g3, g1, g2]).hex
+  const shuffled2 = computeSnapshotContentDigest([g2, invalidG, g1, g3]).hex
   assert.equal(forward, shuffled, 'snapshot digest is order-independent (normalized multiset)')
   assert.equal(forward, shuffled2, 'snapshot digest is order-independent under any permutation')
 
   // changing one multiplicity -> different
-  const bumped = computeSnapshotContentDigest([t1, tuple('row-b', 3), t3, invalidT]).hex
+  const bumped = computeSnapshotContentDigest([g1, group('row-b', 3), g3, invalidG]).hex
   assert.notEqual(forward, bumped, 'multiplicity change changes the snapshot digest')
 
-  // multiset: adding a duplicate tuple -> different
-  const withDuplicate = computeSnapshotContentDigest([t1, t2, t3, invalidT, t1]).hex
-  assert.notEqual(forward, withDuplicate, 'duplicate tuple counts (multiset semantics)')
+  // Canonical multiset: a REPEATED identity-content group is rejected (the exact
+  // ambiguity the reviewer flagged — two mult=1 vs one mult=2 must not both be
+  // legal); the caller must pre-aggregate.
+  assertThrowsReason(
+    () => computeSnapshotContentDigest([g1, g2, g3, invalidG, group('row-a', 1)]),
+    'DUPLICATE_IDENTITY_GROUP',
+    'repeated identity-content group rejected',
+  )
+  // Same row as mult=2 is DISTINCT from mult=1 and is the ONLY legal encoding
+  // for two such rows.
+  assert.notEqual(
+    computeSnapshotContentDigest([group('row-a', 1)]).hex,
+    computeSnapshotContentDigest([group('row-a', 2)]).hex,
+    'multiplicity is value-bearing',
+  )
+  // The dedup key is the identity-content (class,key,digest) WITHOUT multiplicity:
+  // the SAME row declared with two DIFFERENT multiplicities is contradictory and
+  // must be rejected (kills a mutant that keys dedup on the full tuple).
+  assertThrowsReason(
+    () => computeSnapshotContentDigest([group('row-a', 1), group('row-a', 2)]),
+    'DUPLICATE_IDENTITY_GROUP',
+    'same identity-content with differing multiplicity rejected',
+  )
+
+  // A multiplicityBound may be supplied once for the whole snapshot.
+  assert.equal(
+    computeSnapshotContentDigest([{ ...group('row-a', 1), multiplicityBound: undefined }], 16).hex,
+    computeSnapshotContentDigest([group('row-a', 1)]).hex,
+    'snapshot-level multiplicityBound applies to groups that omit their own',
+  )
 
   // input array is not mutated by the internal sort
-  const inputs = [t3, t1, t2]
+  const inputs = [g3, g1, g2]
   computeSnapshotContentDigest(inputs)
-  assert.ok(inputs[0].equals(t3) && inputs[1].equals(t1) && inputs[2].equals(t2), 'caller array untouched')
+  assert.ok(inputs[0] === g3 && inputs[1] === g1 && inputs[2] === g2, 'caller array untouched')
 
   assertThrowsReason(() => computeSnapshotContentDigest('t'), 'UNSUPPORTED_KIND', 'non-array input')
-  assertThrowsReason(() => computeSnapshotContentDigest([Buffer.alloc(0)]), 'UNSUPPORTED_KIND', 'empty tuple buffer')
+  assertThrowsReason(() => computeSnapshotContentDigest([Buffer.from([0x01])], 16), 'UNSUPPORTED_KIND', 'raw buffer is not a group')
 }
 
 function digestShape() {
@@ -400,9 +429,12 @@ function digestShape() {
   assert.equal(result.buffer.length, 32, 'sha256 digest is 32 bytes')
   assert.equal(result.hex, result.buffer.toString('hex'), 'hex mirrors the buffer')
   assert.ok(Object.isFrozen(result), 'digest result is frozen')
-  const snapshot = computeSnapshotContentDigest([Buffer.from([0x01])])
+  const snapshot = computeSnapshotContentDigest([
+    { identityKeyClass: 'valid', identityKeyBytes: 'k', canonicalRowDigest: result.buffer, multiplicity: 1, multiplicityBound: 4 },
+  ])
   assert.equal(snapshot.buffer.length, 32)
   assert.equal(snapshot.hex, snapshot.buffer.toString('hex'))
+  assert.ok(Object.isFrozen(snapshot), 'snapshot result is frozen')
 }
 
 // Review-P2 hardening: mutation-proven killing pairs + exact-layout and golden
@@ -441,10 +473,18 @@ function reviewHardening() {
   assert.equal(multWide.length, layout.length, 'multiplicity width never varies with its value (no varint)')
   assert.equal(multWide.subarray(multWide.length - 4).toString('hex'), '01020304', 'big-endian byte order pinned')
 
-  // (P3) Snapshot-level per-tuple prefix: ['ab','c'] vs ['a','bc'] must differ.
-  const snapA = computeSnapshotContentDigest([Buffer.from('ab'), Buffer.from('c')])
-  const snapB = computeSnapshotContentDigest([Buffer.from('a'), Buffer.from('bc')])
-  assert.notEqual(snapA.hex, snapB.hex, 'per-tuple length prefixes must defeat snapshot concat collisions')
+  // (P3) Snapshot-level per-tuple length prefix: two groups that would bare-
+  // concat to the same bytes as one different group must stay distinct.
+  const dA = computeCanonicalRowDigest({ fieldOrder: ['k'], row: { k: 'a' } }).buffer
+  const dB = computeCanonicalRowDigest({ fieldOrder: ['k'], row: { k: 'b' } }).buffer
+  const snapTwo = computeSnapshotContentDigest([
+    { identityKeyClass: 'valid', identityKeyBytes: 'ka', canonicalRowDigest: dA, multiplicity: 1, multiplicityBound: 4 },
+    { identityKeyClass: 'valid', identityKeyBytes: 'kb', canonicalRowDigest: dB, multiplicity: 1, multiplicityBound: 4 },
+  ])
+  const snapOne = computeSnapshotContentDigest([
+    { identityKeyClass: 'valid', identityKeyBytes: 'kakb', canonicalRowDigest: dA, multiplicity: 1, multiplicityBound: 4 },
+  ])
+  assert.notEqual(snapTwo.hex, snapOne.hex, 'per-tuple length prefixes must defeat snapshot concat collisions')
 
   // Golden byte vectors: any drift in tags, prefixes, decimal canon, NFC, or
   // hashing changes these constants — the frozen encoding's strongest pin.
@@ -465,8 +505,12 @@ function reviewHardening() {
     '01000000026b31000000205eb48f1710425c9d8ed3b441ccd7c2897bf42345056532992debd9c865f9b6f400000003',
     'golden sort-tuple encoding',
   )
+  // The golden snapshot is the SAME digest — the group encodes to goldenTuple
+  // internally, so the corrective P2 API change preserves the frozen vector.
   assert.equal(
-    computeSnapshotContentDigest([goldenTuple]).hex,
+    computeSnapshotContentDigest([
+      { identityKeyClass: 'valid', identityKeyBytes: Buffer.from('k1', 'utf8'), canonicalRowDigest: golden.buffer, multiplicity: 3, multiplicityBound: 100 },
+    ]).hex,
     '95c50cc9a3f843f3d507fde4da8451831994030818cf9a612d1eae58af9da018',
     'golden snapshot content digest',
   )

--- a/plugins/plugin-integration-core/__tests__/material-reconciliation-row-digest.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/material-reconciliation-row-digest.test.cjs
@@ -354,14 +354,17 @@ function snapshotContentDigestContract() {
   // Corrective-review P2: the API takes structured identity GROUPS and enforces
   // ONE encoding per multiset — a repeated identity-content group is rejected,
   // so [mult=1, mult=1 same-row] can no longer masquerade as [mult=2].
+  // Corrective-review P2: the multiplicityBound is supplied ONCE at the snapshot
+  // level (the unified read bound); groups must NOT carry their own.
+  const BOUND = 16
   const digestOf = (token) => computeCanonicalRowDigest({ fieldOrder: ['k1'], row: { k1: token } }).buffer
   const group = (token, multiplicity) => ({
     identityKeyClass: 'valid',
     identityKeyBytes: Buffer.from(token, 'utf8'),
     canonicalRowDigest: digestOf(token),
     multiplicity,
-    multiplicityBound: 16,
   })
+  const snap = (groups) => computeSnapshotContentDigest(groups, BOUND)
   const g1 = group('row-a', 1)
   const g2 = group('row-b', 2)
   const g3 = group('row-c', 1)
@@ -370,57 +373,61 @@ function snapshotContentDigestContract() {
     identityKeyBytes: Buffer.alloc(0),
     canonicalRowDigest: digestOf('row-d'),
     multiplicity: 1,
-    multiplicityBound: 16,
   }
 
-  const forward = computeSnapshotContentDigest([g1, g2, g3, invalidG]).hex
-  const shuffled = computeSnapshotContentDigest([invalidG, g3, g1, g2]).hex
-  const shuffled2 = computeSnapshotContentDigest([g2, invalidG, g1, g3]).hex
+  const forward = snap([g1, g2, g3, invalidG]).hex
+  const shuffled = snap([invalidG, g3, g1, g2]).hex
+  const shuffled2 = snap([g2, invalidG, g1, g3]).hex
   assert.equal(forward, shuffled, 'snapshot digest is order-independent (normalized multiset)')
   assert.equal(forward, shuffled2, 'snapshot digest is order-independent under any permutation')
 
   // changing one multiplicity -> different
-  const bumped = computeSnapshotContentDigest([g1, group('row-b', 3), g3, invalidG]).hex
+  const bumped = snap([g1, group('row-b', 3), g3, invalidG]).hex
   assert.notEqual(forward, bumped, 'multiplicity change changes the snapshot digest')
 
-  // Canonical multiset: a REPEATED identity-content group is rejected (the exact
-  // ambiguity the reviewer flagged — two mult=1 vs one mult=2 must not both be
-  // legal); the caller must pre-aggregate.
+  // Canonical multiset: a REPEATED identity-content group is rejected (two mult=1
+  // must not masquerade as one mult=2); the caller must pre-aggregate.
   assertThrowsReason(
-    () => computeSnapshotContentDigest([g1, g2, g3, invalidG, group('row-a', 1)]),
+    () => snap([g1, g2, g3, invalidG, group('row-a', 1)]),
     'DUPLICATE_IDENTITY_GROUP',
     'repeated identity-content group rejected',
   )
-  // Same row as mult=2 is DISTINCT from mult=1 and is the ONLY legal encoding
-  // for two such rows.
-  assert.notEqual(
-    computeSnapshotContentDigest([group('row-a', 1)]).hex,
-    computeSnapshotContentDigest([group('row-a', 2)]).hex,
-    'multiplicity is value-bearing',
-  )
-  // The dedup key is the identity-content (class,key,digest) WITHOUT multiplicity:
-  // the SAME row declared with two DIFFERENT multiplicities is contradictory and
-  // must be rejected (kills a mutant that keys dedup on the full tuple).
+  // Same row as mult=2 is DISTINCT from mult=1 and is the ONLY legal encoding.
+  assert.notEqual(snap([group('row-a', 1)]).hex, snap([group('row-a', 2)]).hex, 'multiplicity is value-bearing')
+  // Dedup keys on (class,key,digest) WITHOUT multiplicity: the same row with two
+  // DIFFERENT multiplicities is contradictory (kills a full-tuple-key mutant).
   assertThrowsReason(
-    () => computeSnapshotContentDigest([group('row-a', 1), group('row-a', 2)]),
+    () => snap([group('row-a', 1), group('row-a', 2)]),
     'DUPLICATE_IDENTITY_GROUP',
     'same identity-content with differing multiplicity rejected',
   )
 
-  // A multiplicityBound may be supplied once for the whole snapshot.
-  assert.equal(
-    computeSnapshotContentDigest([{ ...group('row-a', 1), multiplicityBound: undefined }], 16).hex,
-    computeSnapshotContentDigest([group('row-a', 1)]).hex,
-    'snapshot-level multiplicityBound applies to groups that omit their own',
+  // The snapshot-level bound is the SOLE authority: a per-group bound override is
+  // rejected fail-closed, and a group multiplicity above the snapshot bound is
+  // rejected even if a (forbidden) larger group bound is attempted.
+  assertThrowsReason(
+    () => computeSnapshotContentDigest([{ ...group('row-a', 1), multiplicityBound: 10 }], 16),
+    'UNSUPPORTED_KIND',
+    'per-group multiplicityBound override forbidden',
+  )
+  assertThrowsReason(
+    () => computeSnapshotContentDigest([group('row-a', 2)], 1),
+    'MULTIPLICITY_OUT_OF_BOUNDS',
+    'group multiplicity above the snapshot bound rejected (no group-level escape)',
+  )
+  assertThrowsReason(
+    () => computeSnapshotContentDigest([group('row-a', 1)]),
+    'MULTIPLICITY_OUT_OF_BOUNDS',
+    'missing snapshot bound fails closed',
   )
 
   // input array is not mutated by the internal sort
   const inputs = [g3, g1, g2]
-  computeSnapshotContentDigest(inputs)
+  snap(inputs)
   assert.ok(inputs[0] === g3 && inputs[1] === g1 && inputs[2] === g2, 'caller array untouched')
 
-  assertThrowsReason(() => computeSnapshotContentDigest('t'), 'UNSUPPORTED_KIND', 'non-array input')
-  assertThrowsReason(() => computeSnapshotContentDigest([Buffer.from([0x01])], 16), 'UNSUPPORTED_KIND', 'raw buffer is not a group')
+  assertThrowsReason(() => computeSnapshotContentDigest('t', BOUND), 'UNSUPPORTED_KIND', 'non-array input')
+  assertThrowsReason(() => computeSnapshotContentDigest([Buffer.from([0x01])], BOUND), 'UNSUPPORTED_KIND', 'raw buffer is not a group')
 }
 
 function digestShape() {
@@ -430,8 +437,8 @@ function digestShape() {
   assert.equal(result.hex, result.buffer.toString('hex'), 'hex mirrors the buffer')
   assert.ok(Object.isFrozen(result), 'digest result is frozen')
   const snapshot = computeSnapshotContentDigest([
-    { identityKeyClass: 'valid', identityKeyBytes: 'k', canonicalRowDigest: result.buffer, multiplicity: 1, multiplicityBound: 4 },
-  ])
+    { identityKeyClass: 'valid', identityKeyBytes: 'k', canonicalRowDigest: result.buffer, multiplicity: 1 },
+  ], 4)
   assert.equal(snapshot.buffer.length, 32)
   assert.equal(snapshot.hex, snapshot.buffer.toString('hex'))
   assert.ok(Object.isFrozen(snapshot), 'snapshot result is frozen')
@@ -478,12 +485,12 @@ function reviewHardening() {
   const dA = computeCanonicalRowDigest({ fieldOrder: ['k'], row: { k: 'a' } }).buffer
   const dB = computeCanonicalRowDigest({ fieldOrder: ['k'], row: { k: 'b' } }).buffer
   const snapTwo = computeSnapshotContentDigest([
-    { identityKeyClass: 'valid', identityKeyBytes: 'ka', canonicalRowDigest: dA, multiplicity: 1, multiplicityBound: 4 },
-    { identityKeyClass: 'valid', identityKeyBytes: 'kb', canonicalRowDigest: dB, multiplicity: 1, multiplicityBound: 4 },
-  ])
+    { identityKeyClass: 'valid', identityKeyBytes: 'ka', canonicalRowDigest: dA, multiplicity: 1 },
+    { identityKeyClass: 'valid', identityKeyBytes: 'kb', canonicalRowDigest: dB, multiplicity: 1 },
+  ], 4)
   const snapOne = computeSnapshotContentDigest([
-    { identityKeyClass: 'valid', identityKeyBytes: 'kakb', canonicalRowDigest: dA, multiplicity: 1, multiplicityBound: 4 },
-  ])
+    { identityKeyClass: 'valid', identityKeyBytes: 'kakb', canonicalRowDigest: dA, multiplicity: 1 },
+  ], 4)
   assert.notEqual(snapTwo.hex, snapOne.hex, 'per-tuple length prefixes must defeat snapshot concat collisions')
 
   // Golden byte vectors: any drift in tags, prefixes, decimal canon, NFC, or
@@ -509,8 +516,8 @@ function reviewHardening() {
   // internally, so the corrective P2 API change preserves the frozen vector.
   assert.equal(
     computeSnapshotContentDigest([
-      { identityKeyClass: 'valid', identityKeyBytes: Buffer.from('k1', 'utf8'), canonicalRowDigest: golden.buffer, multiplicity: 3, multiplicityBound: 100 },
-    ]).hex,
+      { identityKeyClass: 'valid', identityKeyBytes: Buffer.from('k1', 'utf8'), canonicalRowDigest: golden.buffer, multiplicity: 3 },
+    ], 100).hex,
     '95c50cc9a3f843f3d507fde4da8451831994030818cf9a612d1eae58af9da018',
     'golden snapshot content digest',
   )

--- a/plugins/plugin-integration-core/__tests__/material-reconciliation-row-digest.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/material-reconciliation-row-digest.test.cjs
@@ -615,13 +615,23 @@ function deepReviewRound() {
 // identity_invalid domain separator.
 function round4CodecSurface() {
   const mod = require(MODULE_PATH)
-  // 1. No *_SET key and no live Set instance anywhere on the export surface.
-  for (const [scopeName, scope] of [['module', mod], ['__internals', mod.__internals]]) {
-    for (const [key, value] of Object.entries(scope)) {
-      assert.ok(!key.includes('_SET'), `${scopeName}.${key}: no exported Set-mirror names`)
-      assert.ok(!(value instanceof Set), `${scopeName}.${key}: no live Set instances exported`)
+  // 1. No *_SET key and no live Set instance ANYWHERE on the export surface — at
+  //    ANY depth (owner exact-head review of a1c5e6c87): a two-level scan stays
+  //    green for a nested re-export like `__internals.membership.{SET}`, so the
+  //    check is a recursive walker over Object.entries — objects AND functions
+  //    are traversed, with a WeakSet guarding against cycles.
+  const seen = new WeakSet()
+  const walkExportSurface = (value, path) => {
+    assert.ok(!(value instanceof Set), `${path}: live Set instance exported`)
+    if (!value || (typeof value !== 'object' && typeof value !== 'function')) return
+    if (seen.has(value)) return
+    seen.add(value)
+    for (const [key, child] of Object.entries(value)) {
+      assert.ok(!key.includes('_SET'), `${path}.${key}: no exported Set-mirror names at any depth`)
+      walkExportSurface(child, `${path}.${key}`)
     }
   }
+  walkExportSurface(mod, 'module')
   // 2. Poisoning attempt is a no-op: the Set is unreachable, and an unknown
   //    identityKeyClass still fails closed afterwards (positive control pair).
   const evil = { identityKeyClass: 'evil', identityKeyBytes: Buffer.from('k'), canonicalRowDigest: Buffer.alloc(32), multiplicity: 1, multiplicityBound: 16 }

--- a/plugins/plugin-integration-core/__tests__/material-reconciliation-templates.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/material-reconciliation-templates.test.cjs
@@ -286,9 +286,10 @@ function main() {
   assert.deepStrictEqual(clone(run.uniqueness[0]), {
     fields: ['run_identity_key'],
     scope: 'tenant',
-    partial: 'run_identity_key IS NOT NULL',
+    partial: { predicate: 'not_null', field: 'run_identity_key' },
   })
-  assert.ok(run.uniqueness[0].partial.includes('IS NOT NULL'), 'partial unique excludes NULL identity keys')
+  // Corrective-review P2: partial is a CLOSED structured predicate, not raw SQL.
+  assert.deepStrictEqual([...mod.MR_PARTIAL_PREDICATES], ['not_null'])
   const runFieldById = Object.fromEntries(run.fields.map((field) => [field.id, field]))
   assert.equal(runFieldById.state.select.vocab, 'MR_RUN_STATES')
   // Deep review: fail_class is NOT stored (reason->class binding lives in
@@ -390,6 +391,15 @@ function main() {
   const evidence = summarizeMaterialReconciliationEvidence()
   assert.equal(evidence.templateCount, 9)
   assert.deepStrictEqual(evidence.objectIds, [...MATERIAL_RECONCILIATION_OBJECT_IDS])
+  // Corrective-review P2 (plant-and-assert): the summarizer takes NO caller
+  // argument, so a caller-planted business identifier can never reach evidence.
+  assert.equal(summarizeMaterialReconciliationEvidence.length, 0, 'summarizer accepts no argument')
+  const planted = summarizeMaterialReconciliationEvidence([
+    { id: 'material.reconciliation.evil.v1', objectId: 'material_reconciliation_MAT-001-SECRET', label: 'customer-alpha', version: 'v1', family: 'data', writeDiscipline: 'create_only', retention: 'permanent', keyFields: ['k'], fields: [{ id: 'k', label: 'k', type: 'string', key: true, required: true }] },
+  ])
+  const plantedJson = JSON.stringify(planted)
+  assert.ok(!plantedJson.includes('MAT-001-SECRET') && !plantedJson.includes('customer-alpha'), 'planted business ids never reach evidence (frozen registry only)')
+  assert.deepStrictEqual(planted.objectIds, [...MATERIAL_RECONCILIATION_OBJECT_IDS])
   const evidenceJson = JSON.stringify(evidence)
   assert.ok(!evidenceJson.includes('projection'), 'evidence has no projection values or field ids')
   assert.ok(!evidenceJson.includes('digest'), 'evidence has no digest field ids or values')
@@ -521,11 +531,22 @@ function main() {
   )
   // Uniqueness referencing a missing field.
   const badUniqueness = clone(baseTemplate)
-  badUniqueness.uniqueness = [{ scope: 'tenant', fields: ['k1'], partial: 'k1 IS NOT NULL' }]
+  badUniqueness.uniqueness = [{ scope: 'tenant', fields: ['k1'], partial: { predicate: 'not_null', field: 'k1' } }]
   assertThrowsTemplateError(
     () => normalizeMaterialReconciliationTemplate(badUniqueness),
     'uniqueness on unknown field rejected',
   )
+  // Corrective-review P2: a RAW-SQL free-string partial is rejected (the
+  // '1=1; DROP TABLE' probe). Only the closed structured predicate is legal.
+  const sqlPartial = clone(byObjectId.material_reconciliation_run)
+  sqlPartial.uniqueness = [{ scope: 'tenant', fields: ['run_identity_key'], partial: 'run_identity_key IS NOT NULL; DROP TABLE x' }]
+  assertThrowsTemplateError(() => normalizeMaterialReconciliationTemplate(sqlPartial), 'free-string partial rejected')
+  const badPredicate = clone(byObjectId.material_reconciliation_run)
+  badPredicate.uniqueness = [{ scope: 'tenant', fields: ['run_identity_key'], partial: { predicate: 'raw_sql', field: 'run_identity_key' } }]
+  assertThrowsTemplateError(() => normalizeMaterialReconciliationTemplate(badPredicate), 'unknown partial predicate rejected')
+  const badPartialField = clone(byObjectId.material_reconciliation_run)
+  badPartialField.uniqueness = [{ scope: 'tenant', fields: ['run_identity_key'], partial: { predicate: 'not_null', field: 'nonexistent' } }]
+  assertThrowsTemplateError(() => normalizeMaterialReconciliationTemplate(badPartialField), 'partial predicate on unknown field rejected')
   // Reference targeting a foreign-prefix object.
   const badReference = clone(byObjectId.material_reconciliation_scenario)
   badReference.references = [
@@ -552,29 +573,24 @@ function main() {
   const requireCalls = source.match(/require\((?:'|")[^'"]+(?:'|")\)/g) || []
   assert.deepStrictEqual(requireCalls, ["require('./payload-redaction.cjs')"], 'only allowed dependency is payload-redaction')
 
-  // --- Set mirrors must equal their frozen arrays (review P2-1) ------------
-  // Object.freeze cannot protect a Set (Set.prototype.add still works), so the
-  // ONLY possible guard for the charter-closed vocabularies' membership
-  // vehicles is exact parity with the frozen arrays.
-  const setPairs = [
-    [mod.MR_FIELD_TYPES, mod.MR_FIELD_TYPE_SET, 'MR_FIELD_TYPE_SET'],
-    [mod.MR_TEMPLATE_FAMILIES, mod.MR_TEMPLATE_FAMILY_SET, 'MR_TEMPLATE_FAMILY_SET'],
-    [mod.MR_ROLES, mod.MR_ROLE_SET, 'MR_ROLE_SET'],
-    [mod.MR_RUN_STATES, mod.MR_RUN_STATE_SET, 'MR_RUN_STATE_SET'],
-    [mod.MR_RUN_TERMINAL_STATES, mod.MR_RUN_TERMINAL_STATE_SET, 'MR_RUN_TERMINAL_STATE_SET'],
-    [mod.MR_BINDING_STATUSES, mod.MR_BINDING_STATUS_SET, 'MR_BINDING_STATUS_SET'],
-    [mod.MR_DIFF_BUCKETS, mod.MR_DIFF_BUCKET_SET, 'MR_DIFF_BUCKET_SET'],
-    [mod.MR_FAILURE_CLASSES, mod.MR_FAILURE_CLASS_SET, 'MR_FAILURE_CLASS_SET'],
-    [mod.MR_FAILURE_REASON_CODES, mod.MR_FAILURE_REASON_CODE_SET, 'MR_FAILURE_REASON_CODE_SET'],
-    [mod.MR_CONSISTENCY_PROOF_MECHANISMS, mod.MR_CONSISTENCY_PROOF_MECHANISM_SET, 'MR_CONSISTENCY_PROOF_MECHANISM_SET'],
-    [mod.MR_WRITE_DISCIPLINES, mod.MR_WRITE_DISCIPLINE_SET, 'MR_WRITE_DISCIPLINE_SET'],
-    [mod.MR_BINDING_AUDIT_ACTIONS, mod.MR_BINDING_AUDIT_ACTION_SET, 'MR_BINDING_AUDIT_ACTION_SET'],
-    [mod.MR_IDENTITY_KEY_CLASSES, mod.MR_IDENTITY_KEY_CLASS_SET, 'MR_IDENTITY_KEY_CLASS_SET'],
-  ]
-  for (const [array, set, name] of setPairs) {
-    assert.ok(array && set, `${name} pair exported`)
-    assert.deepStrictEqual([...set].sort(), [...array].sort(), `${name} must mirror its frozen array exactly`)
+  // --- Membership Sets must NOT be exported (corrective-review P2) ----------
+  // Object.freeze cannot protect a Set (Set.prototype.add still works), so an
+  // exported Set is a poisoning vector — `MR_FIELD_TYPE_SET.add('x')` turned
+  // the validator permissive. The public surface exports frozen ARRAYS only;
+  // membership Sets are module-private. Assert none leak.
+  const publicSetNames = Object.keys(mod).filter((name) => /_SET$/.test(name))
+  assert.deepStrictEqual(publicSetNames, [], `no membership Set may be exported (found: ${publicSetNames.join(', ')})`)
+  // The frozen arrays ARE exported and are frozen (push throws).
+  for (const arr of [mod.MR_FIELD_TYPES, mod.MR_RUN_STATES, mod.MR_BINDING_STATUSES, mod.MR_DIFF_BUCKETS, mod.MR_CONSISTENCY_PROOF_MECHANISMS, mod.MR_WRITE_DISCIPLINES, mod.MR_RETENTION_POLICIES, mod.MR_RUN_PHASES, mod.MR_PARTIAL_PREDICATES]) {
+    assert.ok(Object.isFrozen(arr), 'public vocabulary arrays are frozen')
+    assert.throws(() => arr.push('poison'), 'frozen array rejects mutation')
   }
+  // Poisoning the exported array is impossible; the validator still rejects an
+  // out-of-vocab field type (proves the private Set was not reachable/poisoned).
+  const poisonAttempt = clone(byObjectId.material_reconciliation_run)
+  poisonAttempt.fields = [{ id: 'x', label: 'x', type: 'attacker_type', key: true, required: true }]
+  poisonAttempt.keyFields = ['x']
+  assertThrowsTemplateError(() => normalizeMaterialReconciliationTemplate(poisonAttempt), 'illegal field type still rejected (private Set unreachable)')
 
   // --- Transition maps, terminal list, and select-vocab registry are frozen
   //     freezes themselves (review P2-2) ------------------------------------
@@ -672,7 +688,7 @@ function main() {
   )
   // …and the uniqueness scope vocabulary is closed (only 'tenant').
   const badScope = clone(byObjectId.material_reconciliation_run)
-  badScope.uniqueness = [{ scope: 'global', fields: ['run_identity_key'], partial: 'run_identity_key IS NOT NULL' }]
+  badScope.uniqueness = [{ scope: 'global', fields: ['run_identity_key'], partial: { predicate: 'not_null', field: 'run_identity_key' } }]
   assertThrowsTemplateError(
     () => normalizeMaterialReconciliationTemplate(badScope),
     'uniqueness scope outside the closed set rejected',
@@ -685,8 +701,9 @@ function main() {
   assertThrowsTemplateError(() => normalizeMaterialReconciliationTemplate(badRetention), 'unknown retention rejected')
 
   // Set-mirror parity for the new vocabularies.
-  assert.deepStrictEqual([...mod.MR_RETENTION_POLICY_SET].sort(), [...mod.MR_RETENTION_POLICIES].sort())
-  assert.deepStrictEqual([...mod.MR_RUN_PHASE_SET].sort(), [...mod.MR_RUN_PHASES].sort())
+  // Membership Sets are private (corrective P2): only frozen arrays are public.
+  assert.equal(mod.MR_RETENTION_POLICY_SET, undefined, 'retention Set is not exported')
+  assert.equal(mod.MR_RUN_PHASE_SET, undefined, 'run-phase Set is not exported')
   assert.ok(Object.isFrozen(mod.MR_RETENTION_POLICIES) && Object.isFrozen(mod.MR_RUN_PHASES))
 
   console.log('material-reconciliation-templates.test.cjs OK')

--- a/plugins/plugin-integration-core/__tests__/material-reconciliation-templates.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/material-reconciliation-templates.test.cjs
@@ -547,6 +547,19 @@ function main() {
   const badPartialField = clone(byObjectId.material_reconciliation_run)
   badPartialField.uniqueness = [{ scope: 'tenant', fields: ['run_identity_key'], partial: { predicate: 'not_null', field: 'nonexistent' } }]
   assertThrowsTemplateError(() => normalizeMaterialReconciliationTemplate(badPartialField), 'partial predicate on unknown field rejected')
+  // Corrective round-2 P2: the predicate field must be in THIS uniqueness's own
+  // fields, not merely a template field — run unique on run_identity_key with an
+  // attempt_id predicate (attempt_id IS a run field) must be rejected.
+  const partialFieldNotInUnique = clone(byObjectId.material_reconciliation_run)
+  partialFieldNotInUnique.uniqueness = [{ scope: 'tenant', fields: ['run_identity_key'], partial: { predicate: 'not_null', field: 'attempt_id' } }]
+  assert.ok(
+    partialFieldNotInUnique.fields.some((f) => f.id === 'attempt_id'),
+    'fixture: attempt_id IS a template field (so only the uniqueness-membership check can reject it)',
+  )
+  assertThrowsTemplateError(
+    () => normalizeMaterialReconciliationTemplate(partialFieldNotInUnique),
+    'partial predicate field not in the uniqueness fields rejected',
+  )
   // Reference targeting a foreign-prefix object.
   const badReference = clone(byObjectId.material_reconciliation_scenario)
   badReference.references = [

--- a/plugins/plugin-integration-core/lib/material-reconciliation-row-digest.cjs
+++ b/plugins/plugin-integration-core/lib/material-reconciliation-row-digest.cjs
@@ -30,9 +30,11 @@
 //   per-source decimalTransit capability (decimal fields carried as text
 //   end-to-end) and expand exponent notation before {decimal} wrapping
 //   (String(1e-7) === '1e-7' would be DECIMAL_MALFORMED here, by design).
-// - computeSnapshotContentDigest([]) is LEGAL: a complete, consistency-proven
-//   EMPTY snapshot is a chartered positive control (§8.2-4); its digest is the
-//   deterministic sha256 of zero tuples.
+// - computeSnapshotContentDigest([], validBound) is LEGAL: a complete,
+//   consistency-proven EMPTY snapshot is a chartered positive control (§8.2-4);
+//   its digest is the deterministic sha256 of zero tuples. The snapshot-level
+//   bound is still required and validated up front — an empty snapshot cannot
+//   bypass it.
 // - The returned {buffer, hex} object is frozen but Buffer CONTENTS are
 //   inherently mutable; hex is the authoritative immutable form.
 
@@ -360,6 +362,15 @@ function encodeIdentitySortTuple(input) {
 function computeSnapshotContentDigest(groups, multiplicityBound) {
   if (!Array.isArray(groups)) {
     throw new MaterialReconciliationDigestError('UNSUPPORTED_KIND', 'computeSnapshotContentDigest requires an array of identity groups')
+  }
+  // Corrective round-3 P2: validate the snapshot-level bound BEFORE the loop, so
+  // an EMPTY snapshot cannot bypass it. computeSnapshotContentDigest([], valid)
+  // succeeds (empty snapshot is legal, §8.2-4); computeSnapshotContentDigest([])
+  // with no/invalid bound fails closed.
+  if (!Number.isSafeInteger(multiplicityBound) || multiplicityBound < 1 || multiplicityBound > MAX_MULTIPLICITY_ENCODABLE) {
+    throw new MaterialReconciliationDigestError('MULTIPLICITY_OUT_OF_BOUNDS', 'snapshot multiplicityBound must be an integer within 1..2^32-1', {
+      multiplicityBound: Number.isSafeInteger(multiplicityBound) ? multiplicityBound : null,
+    })
   }
   const seenGroupKeys = new Set()
   const tuples = []

--- a/plugins/plugin-integration-core/lib/material-reconciliation-row-digest.cjs
+++ b/plugins/plugin-integration-core/lib/material-reconciliation-row-digest.cjs
@@ -52,6 +52,9 @@ const MR_DIGEST_ERROR_REASONS = Object.freeze([
   'STRING_ILL_FORMED',
   // Deep-review P3: canonicalRowDigest must be exactly 32 bytes (sha256).
   'DIGEST_WIDTH_INVALID',
+  // Corrective-review P2: a repeated identity-content group in the snapshot
+  // digest is non-canonical (the multiset has two encodings) — rejected.
+  'DUPLICATE_IDENTITY_GROUP',
 ])
 const MR_DIGEST_ERROR_REASON_SET = new Set(MR_DIGEST_ERROR_REASONS)
 
@@ -345,17 +348,35 @@ function encodeIdentitySortTuple(input) {
   ])
 }
 
-// snapshotContentDigest (frozen, §4.6): normalized multiset digest of the
-// encoded sort tuples — byte-lexicographic sort, each tuple length-prefixed,
-// sha256. Deterministic under any input order; duplicates count (multiset).
-function computeSnapshotContentDigest(tuples) {
-  if (!Array.isArray(tuples)) {
-    throw new MaterialReconciliationDigestError('UNSUPPORTED_KIND', 'computeSnapshotContentDigest requires an array of tuple Buffers')
+// snapshotContentDigest (frozen, §4.6). Corrective-review P2: the old form took
+// pre-encoded tuple Buffers, which admitted TWO encodings of the same multiset
+// (two multiplicity=1 tuples for one identity-content class vs one
+// multiplicity=2 tuple) yielding different digests. The canonical unit is the
+// identity GROUP: for each distinct (identityKeyClass, identityKeyBytes,
+// canonicalRowDigest) there is EXACTLY ONE multiplicity. This function takes
+// structured groups, encodes each canonically, and REJECTS a repeated
+// identity-content group (DUPLICATE_IDENTITY_GROUP) — so the caller must
+// pre-aggregate multiplicity and there is only one legal encoding per multiset.
+function computeSnapshotContentDigest(groups, multiplicityBound) {
+  if (!Array.isArray(groups)) {
+    throw new MaterialReconciliationDigestError('UNSUPPORTED_KIND', 'computeSnapshotContentDigest requires an array of identity groups')
   }
-  for (const tuple of tuples) {
-    if (!Buffer.isBuffer(tuple) || tuple.length === 0) {
-      throw new MaterialReconciliationDigestError('UNSUPPORTED_KIND', 'each tuple must be a non-empty Buffer')
+  const seenGroupKeys = new Set()
+  const tuples = []
+  for (const group of groups) {
+    if (!isPlainObject(group)) {
+      throw new MaterialReconciliationDigestError('UNSUPPORTED_KIND', 'each identity group must be a plain object')
     }
+    const bound = group.multiplicityBound === undefined ? multiplicityBound : group.multiplicityBound
+    const tuple = encodeIdentitySortTuple({ ...group, multiplicityBound: bound })
+    // Group identity = the tuple WITHOUT its trailing fixed 4-byte multiplicity:
+    // (classByte || len4+key || len4+digest). A repeat is a non-canonical multiset.
+    const groupKey = tuple.subarray(0, tuple.length - 4).toString('hex')
+    if (seenGroupKeys.has(groupKey)) {
+      throw new MaterialReconciliationDigestError('DUPLICATE_IDENTITY_GROUP', 'identity group repeated — pre-aggregate multiplicity (multiset must be canonical)')
+    }
+    seenGroupKeys.add(groupKey)
+    tuples.push(tuple)
   }
   const sorted = [...tuples].sort(Buffer.compare)
   const parts = sorted.map((tuple) => lengthPrefix(tuple))

--- a/plugins/plugin-integration-core/lib/material-reconciliation-row-digest.cjs
+++ b/plugins/plugin-integration-core/lib/material-reconciliation-row-digest.cjs
@@ -367,8 +367,15 @@ function computeSnapshotContentDigest(groups, multiplicityBound) {
     if (!isPlainObject(group)) {
       throw new MaterialReconciliationDigestError('UNSUPPORTED_KIND', 'each identity group must be a plain object')
     }
-    const bound = group.multiplicityBound === undefined ? multiplicityBound : group.multiplicityBound
-    const tuple = encodeIdentitySortTuple({ ...group, multiplicityBound: bound })
+    // Corrective-review P2: the snapshot-level multiplicityBound is the SOLE
+    // read-upper-bound authority (Charter unified read bound). A group may NOT
+    // carry its own multiplicityBound — that would let one group exceed the
+    // snapshot cap (snapshot bound 1 + group bound 10 + multiplicity 2). Reject
+    // any per-group override fail-closed.
+    if (Object.prototype.hasOwnProperty.call(group, 'multiplicityBound')) {
+      throw new MaterialReconciliationDigestError('UNSUPPORTED_KIND', 'per-group multiplicityBound is forbidden: the snapshot-level bound is authoritative')
+    }
+    const tuple = encodeIdentitySortTuple({ ...group, multiplicityBound })
     // Group identity = the tuple WITHOUT its trailing fixed 4-byte multiplicity:
     // (classByte || len4+key || len4+digest). A repeat is a non-canonical multiset.
     const groupKey = tuple.subarray(0, tuple.length - 4).toString('hex')

--- a/plugins/plugin-integration-core/lib/material-reconciliation-row-digest.cjs
+++ b/plugins/plugin-integration-core/lib/material-reconciliation-row-digest.cjs
@@ -328,15 +328,18 @@ function encodeIdentitySortTuple(input) {
     multiplicityBound < 1 ||
     multiplicityBound > MAX_MULTIPLICITY_ENCODABLE
   ) {
+    // Round-4 P3: details carry sanitized values only (same discipline as the
+    // snapshot-level pre-loop guard) — a non-integer input never round-trips
+    // into the error surface verbatim.
     throw new MaterialReconciliationDigestError(
       'MULTIPLICITY_OUT_OF_BOUNDS',
       'multiplicityBound must be an integer within 1..2^32-1',
-      { multiplicityBound }
+      { multiplicityBound: Number.isSafeInteger(multiplicityBound) ? multiplicityBound : null }
     )
   }
   if (!Number.isSafeInteger(multiplicity) || multiplicity < 1 || multiplicity > multiplicityBound) {
     throw new MaterialReconciliationDigestError('MULTIPLICITY_OUT_OF_BOUNDS', 'multiplicity must be an integer within 1..multiplicityBound', {
-      multiplicity,
+      multiplicity: Number.isSafeInteger(multiplicity) ? multiplicity : null,
       multiplicityBound,
     })
   }
@@ -414,10 +417,13 @@ module.exports = {
   computeCanonicalRowDigest,
   encodeIdentitySortTuple,
   computeSnapshotContentDigest,
+  // Round-4 P2: NO live membership Sets on the export surface — a mutable Set
+  // reachable through __internals lets a consumer flip a validator from reject
+  // to accept (a poisoned identityKeyClass would even encode class byte 0x00,
+  // colliding with the identity_invalid domain separator). Same ruling as the
+  // templates round-1 fix: Sets stay module-private; tests use the public
+  // frozen arrays.
   __internals: {
-    MR_DIGEST_ERROR_REASON_SET,
-    MR_VALUE_KIND_SET,
-    MR_IDENTITY_KEY_CLASS_SET,
     MAX_LENGTH_PREFIX,
     MAX_MULTIPLICITY_ENCODABLE,
     isPlainObject,

--- a/plugins/plugin-integration-core/lib/material-reconciliation-templates.cjs
+++ b/plugins/plugin-integration-core/lib/material-reconciliation-templates.cjs
@@ -152,6 +152,13 @@ const MR_RETENTION_POLICY_SET = new Set(MR_RETENTION_POLICIES)
 const MR_RUN_PHASES = Object.freeze(['planned', 'reading_sources', 'snapshots_complete', 'compared'])
 const MR_RUN_PHASE_SET = new Set(MR_RUN_PHASES)
 
+// Corrective-review P2: a partial-unique predicate must NOT be a free SQL string
+// (a '1=1; DROP TABLE' probe passed the old free-string form). D1 freezes a
+// CLOSED predicate vocabulary; the D2 migration layer maps each to fixed SQL
+// (e.g. not_null:X -> "X IS NOT NULL"). No raw SQL ever enters the manifest.
+const MR_PARTIAL_PREDICATES = Object.freeze(['not_null'])
+const MR_PARTIAL_PREDICATE_SET = new Set(MR_PARTIAL_PREDICATES)
+
 const MR_BINDING_AUDIT_ACTIONS = Object.freeze([
   'candidate_created',
   'preflight_passed',
@@ -381,8 +388,32 @@ function normalizeMaterialReconciliationUniqueness(input, index, fieldIdSet) {
     }
     out.scope = scope
   }
-  const partial = optionalString(input.partial, `${at}.partial`)
-  if (partial !== undefined) out.partial = assertSafeSchemaString(partial, `${at}.partial`)
+  // Corrective-review P2: partial is a CLOSED structured predicate, never a raw
+  // SQL string. Shape: { predicate: <MR_PARTIAL_PREDICATES>, field: <fieldId> }.
+  if (input.partial !== undefined) {
+    if (!isPlainObject(input.partial)) {
+      throw new MaterialReconciliationTemplateError(
+        `${at}.partial must be a structured predicate { predicate, field }, not a raw string`,
+        { field: `${at}.partial` },
+      )
+    }
+    assertNoContentKeys(input.partial, `${at}.partial`)
+    const predicate = assertSafeSchemaString(input.partial.predicate, `${at}.partial.predicate`)
+    if (!MR_PARTIAL_PREDICATE_SET.has(predicate)) {
+      throw new MaterialReconciliationTemplateError(
+        `${at}.partial.predicate must be one of ${MR_PARTIAL_PREDICATES.join(', ')}`,
+        { field: `${at}.partial.predicate`, value: predicate },
+      )
+    }
+    const predicateField = assertSafeSchemaString(input.partial.field, `${at}.partial.field`)
+    if (!fieldIdSet.has(predicateField)) {
+      throw new MaterialReconciliationTemplateError(`${at}.partial.field references unknown field ${predicateField}`, {
+        field: `${at}.partial.field`,
+        missing: predicateField,
+      })
+    }
+    out.partial = { predicate, field: predicateField }
+  }
   return out
 }
 
@@ -546,12 +577,12 @@ function buildSheetStructureFromMaterialReconciliationTemplate(template) {
 
 // Values-free by construction: objectIds, counts, discipline names and vocab
 // sizes only — no field ids, no labels, no business values.
-function summarizeMaterialReconciliationEvidence(templates) {
-  const list = templates || MATERIAL_RECONCILIATION_TEMPLATES
-  // Normalize BEFORE projecting anything: objectIds must come from validated
-  // templates only, so a caller-supplied list can never place unvalidated
-  // strings on the evidence surface.
-  const normalizedList = list.map((template) => normalizeMaterialReconciliationTemplate(template))
+// Corrective-review P2: takes NO caller argument. A prefix-valid objectId is
+// not values-free (an injected `material_reconciliation_MAT-001-SECRET` would
+// pass the prefix check and be echoed). Evidence is derived ONLY from the
+// frozen registry, so nothing caller-controlled can reach the surface.
+function summarizeMaterialReconciliationEvidence() {
+  const normalizedList = MATERIAL_RECONCILIATION_TEMPLATES
   return {
     manifestId: MATERIAL_RECONCILIATION_MANIFEST_ID,
     templateCount: normalizedList.length,
@@ -627,9 +658,10 @@ const MATERIAL_RECONCILIATION_TEMPLATES = Object.freeze([
       field('completed_at', 'Completed At', 'date'),
     ],
     // §4.4 — 058-precedent partial unique: only claim-winning runs carry the
-    // identity key; losers stay NULL forever.
+    // identity key; losers stay NULL forever. Closed predicate (corrective P2):
+    // the D2 migration maps not_null:run_identity_key -> "... IS NOT NULL".
     uniqueness: [
-      { scope: 'tenant', fields: ['run_identity_key'], partial: 'run_identity_key IS NOT NULL' },
+      { scope: 'tenant', fields: ['run_identity_key'], partial: { predicate: 'not_null', field: 'run_identity_key' } },
     ],
   }),
   // 2. Immutable snapshot header for one role side.
@@ -852,38 +884,24 @@ module.exports = {
   MATERIAL_RECONCILIATION_OBJECT_ID_PREFIX,
   isMaterialReconciliationFlagValueEnabled,
   MR_FIELD_TYPES,
-  MR_FIELD_TYPE_SET,
   MR_TEMPLATE_FAMILIES,
-  MR_TEMPLATE_FAMILY_SET,
   MR_ROLES,
-  MR_ROLE_SET,
   MR_RUN_STATES,
-  MR_RUN_STATE_SET,
   MR_RUN_TERMINAL_STATES,
-  MR_RUN_TERMINAL_STATE_SET,
   MR_RUN_TRANSITIONS,
   MR_BINDING_STATUSES,
-  MR_BINDING_STATUS_SET,
   MR_BINDING_TRANSITIONS,
   MR_DIFF_BUCKETS,
-  MR_DIFF_BUCKET_SET,
   MR_FAILURE_CLASSES,
-  MR_FAILURE_CLASS_SET,
   MR_FAILURE_REASONS,
   MR_FAILURE_REASON_CODES,
-  MR_FAILURE_REASON_CODE_SET,
   MR_CONSISTENCY_PROOF_MECHANISMS,
-  MR_CONSISTENCY_PROOF_MECHANISM_SET,
   MR_WRITE_DISCIPLINES,
-  MR_WRITE_DISCIPLINE_SET,
   MR_RETENTION_POLICIES,
-  MR_RETENTION_POLICY_SET,
   MR_RUN_PHASES,
-  MR_RUN_PHASE_SET,
+  MR_PARTIAL_PREDICATES,
   MR_BINDING_AUDIT_ACTIONS,
-  MR_BINDING_AUDIT_ACTION_SET,
   MR_IDENTITY_KEY_CLASSES,
-  MR_IDENTITY_KEY_CLASS_SET,
   MR_SELECT_VOCABULARIES,
   MATERIAL_RECONCILIATION_TEMPLATES,
   MATERIAL_RECONCILIATION_OBJECT_IDS,

--- a/plugins/plugin-integration-core/lib/material-reconciliation-templates.cjs
+++ b/plugins/plugin-integration-core/lib/material-reconciliation-templates.cjs
@@ -406,10 +406,15 @@ function normalizeMaterialReconciliationUniqueness(input, index, fieldIdSet) {
       )
     }
     const predicateField = assertSafeSchemaString(input.partial.field, `${at}.partial.field`)
-    if (!fieldIdSet.has(predicateField)) {
-      throw new MaterialReconciliationTemplateError(`${at}.partial.field references unknown field ${predicateField}`, {
+    // Corrective-review P2: the predicate field must be a member of THIS
+    // uniqueness constraint's own fields (a partial index's predicate ranges
+    // over the indexed columns). A run_identity_key unique with an attempt_id
+    // predicate is incoherent — reject it.
+    if (!fields.includes(predicateField)) {
+      throw new MaterialReconciliationTemplateError(`${at}.partial.field must be one of ${at}.fields`, {
         field: `${at}.partial.field`,
-        missing: predicateField,
+        value: predicateField,
+        uniquenessFields: fields,
       })
     }
     out.partial = { predicate, field: predicateField }


### PR DESCRIPTION
Refs #4484 / D1 corrective。Owner 独立复审(merged SHA `1f06ecea9`)裁决 **0 P1/4 P2/1 P3**,随后 round-2(0 P1/2 P2/1 P3)、round-3(1 P2)两轮追加裁决——**三轮全部吸收**。Owner 代码裁决 **APPROVE(0 P1/0 P2)落在 head `8b9e7a5e8`**;其后 post-APPROVE verify pass 又发现并修复 **1 P2/1 P3(round-4,见下)**——该增量**等 owner 复核**(裁决绑 SHA,不自行沿用;现 head `29ab05efd` = 已裁决的 `8b9e7a5e8` 内容 rebase 上 #4512 合并后的 main + round-4/4b 单 commit)。D2 保持锁定。因 D1 无路由/迁移/运行时消费者,无需回滚。

## Round-1 修复(0 P1/4 P2/1 P3)

1. **导出可变 Set 可污染冻结词表**:`MR_FIELD_TYPE_SET.add('x')` 使验证器由拒转纳(`Object.freeze` 拦不住 `Set.add`)。→ templates 模块 `*_SET` 移出公开面(改模块私有);测试断言 `Object.keys(mod)` 无 `_SET`、公开数组冻结(`push` 抛)、非法字段类型仍被拒。**该轮只清了 templates;codec 面同类洞 round-4 才闭合(见下)。**
2. **snapshot 摘要两种合法编码**:旧 API 收预编码 tuple,同一多重集可表示为 [mult=1,mult=1] 或 [mult=2] 得不同摘要(且有测试把「重复 tuple→不同摘要」固定为正确)。→ 改收**结构化 identity groups**,重复 identity-content 组判 `DUPLICATE_IDENTITY_GROUP`;dedup 键为 (class,key,digest) **不含 multiplicity**,故同一行不同 multiplicity 也被拒——每个多重集唯一编码。
3. **values-free evidence 回显植入业务标识**:`summarize(templates)` 原样返回前缀合法的 objectId。→ **移除参数**,只从冻结 registry 派生;plant-and-assert 测试证明植入值永不外显。
4. **partial 谓词是自由 SQL 字符串**(`1=1; DROP TABLE` 通过)。→ 闭结构化谓词 `{ predicate: not_null, field }`,D2 迁移层映射固定 SQL;自由串/未知谓词/未知字段全拒。
5. **P3**:charter 头 `PROPOSED`→`RATIFIED`(owner 裁决 2026-07-21;ratify 仅解锁 D1、不授权 D2 runtime)。

## Round-2 修复(0 P1/2 P2/1 P3;docs MD §3d)

1. **per-group `multiplicityBound` 可越权 snapshot bound**(snapshot bound=1 + group bound=10 + multiplicity=2 曾被接受)。→ snapshot 级 bound 为**唯一权威**:任何 group 携带 `multiplicityBound` 一律 fail-closed 拒收,无 group 级逃逸。
2. **partial 谓词字段只对模板字段校验,不对 uniqueness 约束自身字段**(run 对 `run_identity_key` 唯一、谓词字段却是 `attempt_id` 也曾通过)。→ 谓词字段必须 ∈ `uniqueness.fields`;判别测试(是模板字段但不在约束内)钉住。
3. **P3**:charter §10「建议裁决」→ 最终 RATIFY;§11 exit criteria 标记满足(D1 落 `1f06ecea9`)。

Round-2 变异:两处 P2 守卫逐条 RED;诚实记录一个等价变异(spread 重排为行为等价:hasOwnProperty 守卫在 spread 之前就 fail-closed 拒收携带 bound 的 group,任何 group 级 bound 都到不了 encode)。

## Round-3 修复(1 P2;docs MD §3e)

**空快照绕过 snapshot bound**:bound 只在遍历 group 时验证,`computeSnapshotContentDigest([])` 无 bound 仍成功(与「缺 bound fail-closed」声明矛盾,且曾有测试固定该行为)。→ bound 校验**前移到循环前**:`([], validBound)` 仍合法(§8.2-4 空快照正控,digest 不变——零元组 sha256 钉住);无 bound/0/2^32 全部 `MULTIPLICITY_OUT_OF_BOUNDS` fail-closed。变异:删前置守卫→RED。

## Round-4 修复(post-APPROVE verify pass,1 P2/1 P3;docs MD §3f;commit `a1c5e6c87`)

**P2:codec `__internals` 仍导出三个活 Set**——round-1「Set 移出公开面」只修了 templates 模块;codec 的 `MR_DIGEST_ERROR_REASON_SET`/`MR_VALUE_KIND_SET`/`MR_IDENTITY_KEY_CLASS_SET` 仍经 `__internals` 可达,其中 `MR_IDENTITY_KEY_CLASS_SET` 在 `encodeIdentitySortTuple` 承重。污染探针:`add('evil')` 后未知 identityKeyClass **由拒转纳**,且 class byte 编成 `0x00`,与 `identity_invalid` 域分隔符**碰撞**。→ 三 Set 改模块私有;测试钉「全导出面无 `*_SET` 键、无活 `Set` 实例」+ 污染尝试为 no-op(拒-前/拒-后双正控)。**Round-4b(owner exact-head 复审 1 P2)**:首版检查只扫两层,嵌套再导出(`__internals.membership.{SET}`)仍绿——改为**递归 walker**(`Object.entries` 遍历对象+函数、WeakSet 防环,任意深度拒 `Set` 实例与 `*_SET` 键);owner 判别变异 + 三层深嵌套 + 无关键名下藏 Set + 直接再导出 4/4 RED,函数挂载/环终止双探针过。

**P3(round-3 复审提出,本轮吸收):error details 净化口径对齐**——循环内守卫的 `multiplicityBound`/`multiplicity` 非安全整数时进 details 改为 `null`(与前置守卫一致);测试钉 `details.<field> === null`。

台账更正:§3c「70 套件」→ **94**(70 是只数了打印 `OK` 行的套件);§3d「剥离」措辞 → fail-closed 拒收。

## 验证台账

- Round-1 corrective 电池 **6/6 红**(重导出 Set/删 dup-group 守卫/恢复 evidence 参数/开放 partial 谓词词表/dedup 键含 multiplicity/开放 partial-field 检查)——docs MD §3c;
- Round-2 电池:两 P2 守卫 RED + 一等价变异如实记录——§3d;
- Round-3:删前置 bound 守卫→RED——§3e;
- 复审独立电池 **4/4 红**(删整个前置守卫/下界 1→0/去 `isSafeInteger`/上界改 2^53,见 PR 评论 2026-07-21);
- Round-4 电池 **3/3 红**(重导出活 Set 经 `__internals`/回退 bound detail 净化/回退 multiplicity detail 净化);
- Round-4b 电池 **4/4 红**(owner 嵌套判别变异 `__internals.membership.{SET}`/三层深/无关键名藏 Set/直接再导出)+ 函数挂载捕获、环终止双探针;
- 全插件 CJS 链 **94 段 EXIT=0**(round-4 后复跑,证明无套件依赖被私有化的 Set);目标套件本地复跑绿。

过程如实记账:round-3 修复曾被变异脚本的 `git checkout` 冲掉一次(「commit 前勿 mutate」),commit 后重跑成立——见 PR 评论。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
