### PR TITLE
feat(stock-prep-ops): RC-A sidecar v2 — 4XX sub-classification for a single dispositive auth run (#4437)

### DIFF
--- a/docs/development/stock-preparation-rca-abort-provenance-sidecar-v2-20260721.md
+++ b/docs/development/stock-preparation-rca-abort-provenance-sidecar-v2-20260721.md
@@ -21,7 +21,7 @@ closed set (values-free — the server's own error codes, not business data):
 |---|---|---|---|
 | 401 | `UNAUTHORIZED` | global JWT gate | token still missing / invalid / expired (token problem persists) |
 | 403 | `PASSWORD_CHANGE_REQUIRED` | global JWT gate | the token's account is flagged for forced password change (account state) |
-| 401 | `UNAUTHENTICATED` | plugin requireAccess | no user resolved at the plugin layer (structurally odd token) |
+| ~~401~~ | ~~`UNAUTHENTICATED`~~ | plugin requireAccess | unreachable behind the global JWT gate — NOT a recognized branch (folds to `OTHER`) |
 | 403 | `FORBIDDEN` | plugin requireAccess | valid token, no forced-change, but lacks `integration:read` (permission) |
 | 404 | — | — | not reachable for auth failures (route mounted); a 404 would mean route/base-URL/deploy |
 | 2XX | — | — | healthy — the fast-track condition |
@@ -36,10 +36,12 @@ Two closed-vocabulary, values-free fields added to
 
 - `authReadStatusClass = HTTP_2XX | HTTP_401 | HTTP_403 | HTTP_404 | HTTP_409 | HTTP_4XX_OTHER |
   HTTP_5XX | OTHER | UNAVAILABLE` — from the numeric HTTP status (a closed protocol enum).
-- `authReadReasonClass = NONE | UNAUTHORIZED | PASSWORD_CHANGE_REQUIRED | UNAUTHENTICATED |
-  FORBIDDEN | OTHER | UNAVAILABLE` — the server's own `body.error.code` matched against the
-  four-code allowlist; anything else (or absent) folds to `OTHER`, so no free-text can reach the
-  output. `NONE` on 2xx; `UNAVAILABLE` when a transport/abort rejection produced no HTTP response.
+- `authReadReasonClass = NONE | UNAUTHORIZED | PASSWORD_CHANGE_REQUIRED | FORBIDDEN | INCONSISTENT
+  | OTHER | UNAVAILABLE` — bound to the exact `(status, code)` pair (see §4b): the three real pairs
+  pass through, a recognized code with the wrong status is `INCONSISTENT`, anything else folds to
+  `OTHER` (no free-text). `NONE` on 2xx; `UNAVAILABLE` on non-integer status / no HTTP response.
+- `authReadContractClass = VALID | RESPONSE_CONTRACT_INVALID | UNAVAILABLE` — the 2xx success
+  contract (see §4b P1): `VALID` only for `{ok:true,data:{adapters:[],routes:[]}}`.
 
 Everything else about the client is unchanged (exact-SHA helper binding, fixed `timeoutMs=15000`,
 one internal read-only GET, DIAGNOSTIC_COMPLETE contract, token scrub).
@@ -55,6 +57,28 @@ one internal read-only GET, DIAGNOSTIC_COMPLETE contract, token scrub).
 - CI: covered by the existing `stock-preparation-prep-line-extended-smoke.yml` contract job
   (Node 20 path filter already lists this client + its test).
 
+## 4b. Corrective-review absorption (2026-07-21)
+
+Owner review found **1 P1 / 2 P2** the green tests missed; both closed:
+
+- **P1: a 200 login/HTML page could read as a healthy API and unlock the RC-A fast-track.**
+  A 200 with an HTML body parses to `body=null` but still reported `HTTP_2XX`/`NONE`. New field
+  `authReadContractClass = VALID | RESPONSE_CONTRACT_INVALID | UNAVAILABLE`: a 2xx is `VALID` only
+  when `body.ok === true` AND `body.data.adapters`/`body.data.routes` are arrays; otherwise
+  `RESPONSE_CONTRACT_INVALID`. The fast-track condition (§5) now requires `VALID`, so a 200-HTML or
+  `200 {ok:false}` can never authorize a window. Tests: 200-HTML, 200 `{ok:false}`, and
+  arrays-missing all → `RESPONSE_CONTRACT_INVALID`; a real `{ok:true,data:{adapters,routes}}` →
+  `VALID`.
+- **P2: `authReadReasonClass` was keyed on the code alone**, so a `404 + FORBIDDEN` read as
+  `FORBIDDEN`. Now bound to the exact `(status, code)` pair — only `401+UNAUTHORIZED`,
+  `403+PASSWORD_CHANGE_REQUIRED`, `403+FORBIDDEN` are recognized; a recognized code with the wrong
+  status is `INCONSISTENT`; a non-integer status is `UNAVAILABLE`.
+- **P2: the plugin `401 UNAUTHENTICATED` is unreachable behind the global JWT gate** — removed as a
+  named branch (folds to `OTHER`); §2 table annotated accordingly.
+
+Suite 45 → 46; corrective mutation battery 6/6 RED (contract always-VALID, drop ok-check, drop
+array-checks, reason-by-code-alone, non-integer-not-UNAVAILABLE, INCONSISTENT-off).
+
 ## 5. Operating the single dispositive run (owner-directed; operator action)
 
 Publish a sidecar **v2** (this client + the byte-exact RC-A helpers, same packaging as the v1
@@ -69,7 +93,7 @@ node scripts/ops/stock-preparation-rca-abort-provenance.mjs \
 
 Routing from that single run (owner-court):
 
-- `authReadStatusClass=HTTP_2XX` + hygiene PASS ⇒ the conditional RC-A flag-ON window is authorized.
+- `authReadStatusClass=HTTP_2XX` **and `authReadContractClass=VALID`** + hygiene PASS ⇒ the conditional RC-A flag-ON window is authorized. A 200 whose `authReadContractClass=RESPONSE_CONTRACT_INVALID` (login/HTML page) must NOT fast-track.
 - `HTTP_401` / `UNAUTHORIZED` ⇒ token still invalid (re-issue).
 - `HTTP_403` / `PASSWORD_CHANGE_REQUIRED` ⇒ clear the account's forced-password-change, re-run.
 - `HTTP_403` / `FORBIDDEN` ⇒ grant `integration:read` to the token's principal, re-run.

--- a/docs/development/stock-preparation-rca-abort-provenance-sidecar-v2-20260721.md
+++ b/docs/development/stock-preparation-rca-abort-provenance-sidecar-v2-20260721.md
@@ -1,0 +1,80 @@
+# RC-A Abort-Provenance Sidecar v2 — 4XX Sub-Classification (2026-07-21)
+
+Issue: #4437. Purpose: **accelerate** the RC-A auth diagnostic so ONE flag-OFF run with a
+known-good token is dispositive — no "try v1, then maybe cut v2" two-step. Test-only client
+change; no service change, no RC-A package republish, no flag/PM2 interaction.
+
+## 1. Why
+
+The sidecar v1 run returned `authReadResult=HTTP_4XX` (service reachable and answering; client,
+runtime, transport, service-liveness all cleared — the abort mystery was a v1 wrapper artifact).
+A 4XX on `GET /api/integration/status` can be several distinct things, and v1 could not tell them
+apart, forcing a second round-trip. The owner's plan (known-good token → 2XX or 4XX; if 4XX, cut
+v2) can be collapsed to a single run by shipping the discriminator now.
+
+## 2. The closed 4XX surface (mapped from code, not guessed)
+
+`GET /api/integration/status` is gated by two stacked auth layers; the exact non-2xx codes are a
+closed set (values-free — the server's own error codes, not business data):
+
+| HTTP | Server `error.code` | Layer | Meaning for a known-good-token run |
+|---|---|---|---|
+| 401 | `UNAUTHORIZED` | global JWT gate | token still missing / invalid / expired (token problem persists) |
+| 403 | `PASSWORD_CHANGE_REQUIRED` | global JWT gate | the token's account is flagged for forced password change (account state) |
+| 401 | `UNAUTHENTICATED` | plugin requireAccess | no user resolved at the plugin layer (structurally odd token) |
+| 403 | `FORBIDDEN` | plugin requireAccess | valid token, no forced-change, but lacks `integration:read` (permission) |
+| 404 | — | — | not reachable for auth failures (route mounted); a 404 would mean route/base-URL/deploy |
+| 2XX | — | — | healthy — the fast-track condition |
+
+(Sources: `packages/core-backend/src/auth/jwt-middleware.ts` UNAUTHORIZED/PASSWORD_CHANGE_REQUIRED;
+`plugins/plugin-integration-core/lib/http-routes.cjs` requireAccess UNAUTHENTICATED/FORBIDDEN.)
+
+## 3. Change
+
+Two closed-vocabulary, values-free fields added to
+`scripts/ops/stock-preparation-rca-abort-provenance.mjs`:
+
+- `authReadStatusClass = HTTP_2XX | HTTP_401 | HTTP_403 | HTTP_404 | HTTP_409 | HTTP_4XX_OTHER |
+  HTTP_5XX | OTHER | UNAVAILABLE` — from the numeric HTTP status (a closed protocol enum).
+- `authReadReasonClass = NONE | UNAUTHORIZED | PASSWORD_CHANGE_REQUIRED | UNAUTHENTICATED |
+  FORBIDDEN | OTHER | UNAVAILABLE` — the server's own `body.error.code` matched against the
+  four-code allowlist; anything else (or absent) folds to `OTHER`, so no free-text can reach the
+  output. `NONE` on 2xx; `UNAVAILABLE` when a transport/abort rejection produced no HTTP response.
+
+Everything else about the client is unchanged (exact-SHA helper binding, fixed `timeoutMs=15000`,
+one internal read-only GET, DIAGNOSTIC_COMPLETE contract, token scrub).
+
+## 4. Verification
+
+- `node --test` suite 42 → **45/45** (v1 unchanged; new: status-class boundaries, reason-class
+  allowlist incl. an `MAT-001-SECRET`-shaped code folding to `OTHER`, and an end-to-end run for
+  each of 401/403-pwchange/403-forbidden/2xx plus the transport-abort UNAVAILABLE arm).
+- CLI end-to-end: dead port → `authReadStatusClass=UNAVAILABLE` / `authReadReasonClass=UNAVAILABLE`.
+- Mutation battery **6/6 RED** (merge 401/403 classes, open the reason allowlist, drop the 2xx→NONE
+  rule, ignore the body, mislabel 401→403, swap the two field wirings); clean rerun 45/45.
+- CI: covered by the existing `stock-preparation-prep-line-extended-smoke.yml` contract job
+  (Node 20 path filter already lists this client + its test).
+
+## 5. Operating the single dispositive run (owner-directed; operator action)
+
+Publish a sidecar **v2** (this client + the byte-exact RC-A helpers, same packaging as the v1
+no-Git sidecar), then run ONCE, flag OFF, with a **known-good token** (short-lived, `integration:read`
+or `role:admin`, **not** flagged for forced password change):
+
+```
+node scripts/ops/stock-preparation-rca-abort-provenance.mjs \
+  --helper <sidecar>/scripts/ops/stock-preparation-prep-line-extended-smoke.mjs \
+  --base-url <internal-base-url> [--tenant-id <tenant>]
+```
+
+Routing from that single run (owner-court):
+
+- `authReadStatusClass=HTTP_2XX` + hygiene PASS ⇒ the conditional RC-A flag-ON window is authorized.
+- `HTTP_401` / `UNAUTHORIZED` ⇒ token still invalid (re-issue).
+- `HTTP_403` / `PASSWORD_CHANGE_REQUIRED` ⇒ clear the account's forced-password-change, re-run.
+- `HTTP_403` / `FORBIDDEN` ⇒ grant `integration:read` to the token's principal, re-run.
+- `HTTP_404` ⇒ route not mounted / wrong base URL ⇒ deployment-side, not token.
+
+Same discipline as v1: flag stays OFF, one internal GET, no full smoke, no approved config, no
+PM2/redeploy/package edit, no retries. Sidecar publish + entity-machine run remain owner/operator
+actions; this PR only ships the tested client.

--- a/docs/development/stock-preparation-rca-abort-provenance-sidecar-v2-20260721.md
+++ b/docs/development/stock-preparation-rca-abort-provenance-sidecar-v2-20260721.md
@@ -24,7 +24,7 @@ closed set (values-free — the server's own error codes, not business data):
 | ~~401~~ | ~~`UNAUTHENTICATED`~~ | plugin requireAccess | unreachable behind the global JWT gate — NOT a recognized branch (folds to `OTHER`) |
 | 403 | `FORBIDDEN` | plugin requireAccess | valid token, no forced-change, but lacks `integration:read` (permission) |
 | 404 | — | — | not reachable for auth failures (route mounted); a 404 would mean route/base-URL/deploy |
-| 2XX | — | — | healthy — the fast-track condition |
+| 2XX | — | — | healthy **only if `authReadContractClass=VALID`** (§4b P1); a bare 2XX is NOT the fast-track condition — a 200 login/HTML page is `RESPONSE_CONTRACT_INVALID` |
 
 (Sources: `packages/core-backend/src/auth/jwt-middleware.ts` UNAUTHORIZED/PASSWORD_CHANGE_REQUIRED;
 `plugins/plugin-integration-core/lib/http-routes.cjs` requireAccess UNAUTHENTICATED/FORBIDDEN.)

--- a/scripts/ops/stock-preparation-rca-abort-provenance.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.mjs
@@ -87,7 +87,8 @@ export const RESULT_VOCABULARY = Object.freeze({
   networkTarget: Object.freeze(['INTERNAL_API_ONLY', 'OTHER', 'UNAVAILABLE']),
   authReadResult: Object.freeze(['HTTP_2XX', 'HTTP_4XX', 'HTTP_5XX', 'TYPE_ERROR', 'ABORT_ERROR', 'OTHER', 'UNAVAILABLE']),
   authReadStatusClass: Object.freeze(['HTTP_2XX', 'HTTP_401', 'HTTP_403', 'HTTP_404', 'HTTP_409', 'HTTP_4XX_OTHER', 'HTTP_5XX', 'OTHER', 'UNAVAILABLE']),
-  authReadReasonClass: Object.freeze(['NONE', 'UNAUTHORIZED', 'PASSWORD_CHANGE_REQUIRED', 'UNAUTHENTICATED', 'FORBIDDEN', 'OTHER', 'UNAVAILABLE']),
+  authReadReasonClass: Object.freeze(['NONE', 'UNAUTHORIZED', 'PASSWORD_CHANGE_REQUIRED', 'FORBIDDEN', 'INCONSISTENT', 'OTHER', 'UNAVAILABLE']),
+  authReadContractClass: Object.freeze(['VALID', 'RESPONSE_CONTRACT_INVALID', 'UNAVAILABLE']),
   elapsedClass: Object.freeze(['LT_1S', '1_TO_14S', '15_TO_20S', 'GT_20S', 'UNAVAILABLE']),
   typeErrorBoundary: Object.freeze(['INVALID_URL', 'REQUEST_HEADERS', 'CONNECT', 'DNS', 'TLS', 'FETCH_API', 'RESPONSE_READ', 'OTHER', 'NONE', 'UNAVAILABLE']),
   abortErrorNameClass: Object.freeze(['ABORT_ERROR', 'TIMEOUT_ERROR', 'OTHER', 'NONE']),
@@ -309,24 +310,48 @@ export function classifyAuthReadStatusClass(status) {
   return 'OTHER'
 }
 
-// The server's OWN closed error-code vocabulary for GET /api/integration/status
-// auth failures (mapped from the codebase, not business values): the global JWT
-// gate emits UNAUTHORIZED (missing/invalid/expired token) and
-// PASSWORD_CHANGE_REQUIRED (must_change_password); the plugin requireAccess gate
-// emits UNAUTHENTICATED (no user) and FORBIDDEN (lacks integration:read). Any
-// other/absent code folds to OTHER, so no free-text ever reaches the surface.
-export const AUTH_READ_REASON_ALLOWLIST = Object.freeze([
-  'UNAUTHORIZED',
-  'PASSWORD_CHANGE_REQUIRED',
-  'UNAUTHENTICATED',
-  'FORBIDDEN',
-])
-const AUTH_READ_REASON_SET = new Set(AUTH_READ_REASON_ALLOWLIST)
+// The reason class is bound to the EXACT (status, code) pair, not the code alone
+// (review P2): a 404+FORBIDDEN or 401+PASSWORD_CHANGE_REQUIRED is a contradiction,
+// not a FORBIDDEN / PASSWORD_CHANGE_REQUIRED. Only these three pairs occur for
+// GET /api/integration/status auth failures on a real deployment (behind the
+// global JWT gate, the plugin's 401 UNAUTHENTICATED is unreachable — deliberately
+// NOT a recognized branch). A recognized code with the wrong status is
+// INCONSISTENT; any other/absent code is OTHER — no free-text ever surfaces.
+const AUTH_READ_REASON_PAIRS = Object.freeze({
+  '401|UNAUTHORIZED': 'UNAUTHORIZED',
+  '403|PASSWORD_CHANGE_REQUIRED': 'PASSWORD_CHANGE_REQUIRED',
+  '403|FORBIDDEN': 'FORBIDDEN',
+})
+export const AUTH_READ_REASON_CODES = Object.freeze(['UNAUTHORIZED', 'PASSWORD_CHANGE_REQUIRED', 'FORBIDDEN'])
+const AUTH_READ_REASON_CODE_SET = new Set(AUTH_READ_REASON_CODES)
 
 export function classifyAuthReadReasonClass(status, body) {
-  if (Number.isInteger(status) && status >= 200 && status <= 299) return 'NONE'
+  if (!Number.isInteger(status)) return 'UNAVAILABLE'
+  if (status >= 200 && status <= 299) return 'NONE'
   const code = body && body.error && typeof body.error.code === 'string' ? body.error.code : ''
-  return AUTH_READ_REASON_SET.has(code) ? code : 'OTHER'
+  const exact = AUTH_READ_REASON_PAIRS[`${status}|${code}`]
+  if (exact) return exact
+  // A recognized auth code paired with the wrong status is a contradiction.
+  if (AUTH_READ_REASON_CODE_SET.has(code)) return 'INCONSISTENT'
+  return 'OTHER'
+}
+
+// Success-response contract (review P1): a bare 200 is NOT proof of a healthy API.
+// A login/HTML page returns 200 and parses to body=null yet would otherwise read
+// as HTTP_2XX/NONE and unlock the RC-A fast-track. A genuine status success is
+// { ok:true, data:{ adapters:[...], routes:[...] } } — validate it or fail closed
+// to RESPONSE_CONTRACT_INVALID (never fast-track). Non-2xx has no success contract.
+export function classifyAuthReadContractClass(status, body) {
+  if (!Number.isInteger(status) || status < 200 || status > 299) return 'UNAVAILABLE'
+  const valid =
+    body &&
+    typeof body === 'object' &&
+    body.ok === true &&
+    body.data &&
+    typeof body.data === 'object' &&
+    Array.isArray(body.data.adapters) &&
+    Array.isArray(body.data.routes)
+  return valid ? 'VALID' : 'RESPONSE_CONTRACT_INVALID'
 }
 
 // Error codes are collected from a small closed set of locations: the error itself, its cause,
@@ -507,6 +532,7 @@ export function baselineFields() {
     authReadResult: 'UNAVAILABLE',
     authReadStatusClass: 'UNAVAILABLE',
     authReadReasonClass: 'UNAVAILABLE',
+    authReadContractClass: 'UNAVAILABLE',
     elapsedClass: 'UNAVAILABLE',
     typeErrorBoundary: 'UNAVAILABLE',
     abortErrorNameClass: 'NONE',
@@ -581,6 +607,7 @@ export async function runDiagnostic({
       fields.authReadResult = classifyHttpStatusClass(status)
       fields.authReadStatusClass = classifyAuthReadStatusClass(status)
       fields.authReadReasonClass = classifyAuthReadReasonClass(status, body)
+      fields.authReadContractClass = classifyAuthReadContractClass(status, body)
       fields.typeErrorBoundary = 'NONE'
       fields.abortErrorNameClass = 'NONE'
     } else {
@@ -591,6 +618,7 @@ export async function runDiagnostic({
       // A transport/abort rejection produced no HTTP response to classify.
       fields.authReadStatusClass = 'UNAVAILABLE'
       fields.authReadReasonClass = 'UNAVAILABLE'
+      fields.authReadContractClass = 'UNAVAILABLE'
     }
     fields.abortProvenance = deriveAbortProvenance({
       authReadResult: fields.authReadResult,

--- a/scripts/ops/stock-preparation-rca-abort-provenance.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.mjs
@@ -86,6 +86,8 @@ export const RESULT_VOCABULARY = Object.freeze({
   networkRequestCount: Object.freeze(['0', '1', 'OTHER']),
   networkTarget: Object.freeze(['INTERNAL_API_ONLY', 'OTHER', 'UNAVAILABLE']),
   authReadResult: Object.freeze(['HTTP_2XX', 'HTTP_4XX', 'HTTP_5XX', 'TYPE_ERROR', 'ABORT_ERROR', 'OTHER', 'UNAVAILABLE']),
+  authReadStatusClass: Object.freeze(['HTTP_2XX', 'HTTP_401', 'HTTP_403', 'HTTP_404', 'HTTP_409', 'HTTP_4XX_OTHER', 'HTTP_5XX', 'OTHER', 'UNAVAILABLE']),
+  authReadReasonClass: Object.freeze(['NONE', 'UNAUTHORIZED', 'PASSWORD_CHANGE_REQUIRED', 'UNAUTHENTICATED', 'FORBIDDEN', 'OTHER', 'UNAVAILABLE']),
   elapsedClass: Object.freeze(['LT_1S', '1_TO_14S', '15_TO_20S', 'GT_20S', 'UNAVAILABLE']),
   typeErrorBoundary: Object.freeze(['INVALID_URL', 'REQUEST_HEADERS', 'CONNECT', 'DNS', 'TLS', 'FETCH_API', 'RESPONSE_READ', 'OTHER', 'NONE', 'UNAVAILABLE']),
   abortErrorNameClass: Object.freeze(['ABORT_ERROR', 'TIMEOUT_ERROR', 'OTHER', 'NONE']),
@@ -291,6 +293,42 @@ export function classifyHttpStatusClass(status) {
   return 'OTHER'
 }
 
+// v2 acceleration: a finer HTTP status class so ONE run with a known-good token
+// is dispositive. 401 vs 403 splits token-invalid from account/permission
+// failures without a second sidecar. Values-free: HTTP status is a closed
+// protocol enum, not business data.
+export function classifyAuthReadStatusClass(status) {
+  if (!Number.isInteger(status)) return 'UNAVAILABLE'
+  if (status >= 200 && status <= 299) return 'HTTP_2XX'
+  if (status === 401) return 'HTTP_401'
+  if (status === 403) return 'HTTP_403'
+  if (status === 404) return 'HTTP_404'
+  if (status === 409) return 'HTTP_409'
+  if (status >= 400 && status <= 499) return 'HTTP_4XX_OTHER'
+  if (status >= 500 && status <= 599) return 'HTTP_5XX'
+  return 'OTHER'
+}
+
+// The server's OWN closed error-code vocabulary for GET /api/integration/status
+// auth failures (mapped from the codebase, not business values): the global JWT
+// gate emits UNAUTHORIZED (missing/invalid/expired token) and
+// PASSWORD_CHANGE_REQUIRED (must_change_password); the plugin requireAccess gate
+// emits UNAUTHENTICATED (no user) and FORBIDDEN (lacks integration:read). Any
+// other/absent code folds to OTHER, so no free-text ever reaches the surface.
+export const AUTH_READ_REASON_ALLOWLIST = Object.freeze([
+  'UNAUTHORIZED',
+  'PASSWORD_CHANGE_REQUIRED',
+  'UNAUTHENTICATED',
+  'FORBIDDEN',
+])
+const AUTH_READ_REASON_SET = new Set(AUTH_READ_REASON_ALLOWLIST)
+
+export function classifyAuthReadReasonClass(status, body) {
+  if (Number.isInteger(status) && status >= 200 && status <= 299) return 'NONE'
+  const code = body && body.error && typeof body.error.code === 'string' ? body.error.code : ''
+  return AUTH_READ_REASON_SET.has(code) ? code : 'OTHER'
+}
+
 // Error codes are collected from a small closed set of locations: the error itself, its cause,
 // the cause's AggregateError members (Node >=20 wraps connection failures this way), and one
 // nested cause level. Values are never printed — they only feed the closed classification below.
@@ -467,6 +505,8 @@ export function baselineFields() {
     networkRequestCount: '0',
     networkTarget: 'UNAVAILABLE',
     authReadResult: 'UNAVAILABLE',
+    authReadStatusClass: 'UNAVAILABLE',
+    authReadReasonClass: 'UNAVAILABLE',
     elapsedClass: 'UNAVAILABLE',
     typeErrorBoundary: 'UNAVAILABLE',
     abortErrorNameClass: 'NONE',
@@ -536,7 +576,11 @@ export async function runDiagnostic({
     fields.networkRequestCount = state.requestCount === 0 ? '0' : state.requestCount === 1 ? '1' : 'OTHER'
     fields.networkTarget = state.requestCount === 0 ? 'UNAVAILABLE' : state.networkTarget
     if (outcome.resolved) {
-      fields.authReadResult = classifyHttpStatusClass(outcome.response ? outcome.response.status : undefined)
+      const status = outcome.response ? outcome.response.status : undefined
+      const body = outcome.response ? outcome.response.body : undefined
+      fields.authReadResult = classifyHttpStatusClass(status)
+      fields.authReadStatusClass = classifyAuthReadStatusClass(status)
+      fields.authReadReasonClass = classifyAuthReadReasonClass(status, body)
       fields.typeErrorBoundary = 'NONE'
       fields.abortErrorNameClass = 'NONE'
     } else {
@@ -544,6 +588,9 @@ export async function runDiagnostic({
       fields.authReadResult = rejection.authReadResult
       fields.typeErrorBoundary = rejection.typeErrorBoundary
       fields.abortErrorNameClass = rejection.abortErrorNameClass
+      // A transport/abort rejection produced no HTTP response to classify.
+      fields.authReadStatusClass = 'UNAVAILABLE'
+      fields.authReadReasonClass = 'UNAVAILABLE'
     }
     fields.abortProvenance = deriveAbortProvenance({
       authReadResult: fields.authReadResult,

--- a/scripts/ops/stock-preparation-rca-abort-provenance.test.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.test.mjs
@@ -27,6 +27,9 @@ import {
   buildProvenanceFetchImpl,
   classifyElapsedNs,
   classifyHttpStatusClass,
+  classifyAuthReadStatusClass,
+  classifyAuthReadReasonClass,
+  AUTH_READ_REASON_ALLOWLIST,
   classifyNodeMajor,
   classifyRejection,
   classifyTypeErrorBoundary,
@@ -698,6 +701,82 @@ test('runDiagnostic classifies 4xx/5xx and TypeError CONNECT outcomes', async ()
   assert.equal(refused.authReadResult, 'TYPE_ERROR')
   assert.equal(refused.typeErrorBoundary, 'CONNECT')
   assert.equal(refused.abortProvenance, 'NONE')
+})
+
+// ── v2 acceleration: 4XX sub-classification (one dispositive run) ─────────────────────────────────
+
+test('classifyAuthReadStatusClass splits 401/403/404/409 from other 4xx', () => {
+  assert.equal(classifyAuthReadStatusClass(200), 'HTTP_2XX')
+  assert.equal(classifyAuthReadStatusClass(204), 'HTTP_2XX')
+  assert.equal(classifyAuthReadStatusClass(401), 'HTTP_401')
+  assert.equal(classifyAuthReadStatusClass(403), 'HTTP_403')
+  assert.equal(classifyAuthReadStatusClass(404), 'HTTP_404')
+  assert.equal(classifyAuthReadStatusClass(409), 'HTTP_409')
+  assert.equal(classifyAuthReadStatusClass(400), 'HTTP_4XX_OTHER')
+  assert.equal(classifyAuthReadStatusClass(429), 'HTTP_4XX_OTHER')
+  assert.equal(classifyAuthReadStatusClass(500), 'HTTP_5XX')
+  assert.equal(classifyAuthReadStatusClass(302), 'OTHER')
+  assert.equal(classifyAuthReadStatusClass(undefined), 'UNAVAILABLE')
+})
+
+test('classifyAuthReadReasonClass maps ONLY the server closed error codes; anything else -> OTHER', () => {
+  // 2xx has no reason.
+  assert.equal(classifyAuthReadReasonClass(200, { ok: true }), 'NONE')
+  // the four codebase-mapped codes pass through verbatim.
+  assert.deepEqual([...AUTH_READ_REASON_ALLOWLIST], ['UNAUTHORIZED', 'PASSWORD_CHANGE_REQUIRED', 'UNAUTHENTICATED', 'FORBIDDEN'])
+  assert.equal(classifyAuthReadReasonClass(401, { ok: false, error: { code: 'UNAUTHORIZED' } }), 'UNAUTHORIZED')
+  assert.equal(classifyAuthReadReasonClass(403, { ok: false, error: { code: 'PASSWORD_CHANGE_REQUIRED' } }), 'PASSWORD_CHANGE_REQUIRED')
+  assert.equal(classifyAuthReadReasonClass(401, { ok: false, error: { code: 'UNAUTHENTICATED' } }), 'UNAUTHENTICATED')
+  assert.equal(classifyAuthReadReasonClass(403, { ok: false, error: { code: 'FORBIDDEN' } }), 'FORBIDDEN')
+  // values-free by construction: an unknown or business-shaped code folds to OTHER.
+  assert.equal(classifyAuthReadReasonClass(403, { ok: false, error: { code: 'MAT-001-SECRET' } }), 'OTHER')
+  assert.equal(classifyAuthReadReasonClass(404, { ok: false, error: {} }), 'OTHER')
+  assert.equal(classifyAuthReadReasonClass(404, null), 'OTHER')
+  assert.equal(classifyAuthReadReasonClass(400, { error: { code: 42 } }), 'OTHER')
+})
+
+test('runDiagnostic v2: one run is dispositive — the four 4XX sub-classes come through end to end', async () => {
+  const run = (status, code) =>
+    runDiagnostic({
+      args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+      verifyImpl: VERIFY_PASS,
+      importImpl: REAL_HELPER_IMPORT,
+      fetchDelegate: async () => jsonResponse(status, JSON.stringify({ ok: false, error: { code } })),
+      timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+    })
+  const tokenBad = await run(401, 'UNAUTHORIZED')
+  assert.equal(tokenBad.authReadStatusClass, 'HTTP_401')
+  assert.equal(tokenBad.authReadReasonClass, 'UNAUTHORIZED')
+  const pwChange = await run(403, 'PASSWORD_CHANGE_REQUIRED')
+  assert.equal(pwChange.authReadStatusClass, 'HTTP_403')
+  assert.equal(pwChange.authReadReasonClass, 'PASSWORD_CHANGE_REQUIRED')
+  const forbidden = await run(403, 'FORBIDDEN')
+  assert.equal(forbidden.authReadStatusClass, 'HTTP_403')
+  assert.equal(forbidden.authReadReasonClass, 'FORBIDDEN')
+
+  // success arm: 2xx -> NONE, and the run reports DIAGNOSTIC_COMPLETE (fast-track eligible).
+  const ok = await runDiagnostic({
+    args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    verifyImpl: VERIFY_PASS,
+    importImpl: REAL_HELPER_IMPORT,
+    fetchDelegate: async () => jsonResponse(200, JSON.stringify({ ok: true, data: {} })),
+    timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+  })
+  assert.equal(ok.authReadResult, 'HTTP_2XX')
+  assert.equal(ok.authReadStatusClass, 'HTTP_2XX')
+  assert.equal(ok.authReadReasonClass, 'NONE')
+  assert.equal(ok.executionState, 'DIAGNOSTIC_COMPLETE')
+
+  // transport rejection: no HTTP response to sub-classify.
+  const aborted = await runDiagnostic({
+    args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    verifyImpl: VERIFY_PASS,
+    importImpl: REAL_HELPER_IMPORT,
+    fetchDelegate: async () => { throw makeDomError('AbortError') },
+    timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+  })
+  assert.equal(aborted.authReadStatusClass, 'UNAVAILABLE')
+  assert.equal(aborted.authReadReasonClass, 'UNAVAILABLE')
 })
 
 // ── Pathname shape ───────────────────────────────────────────────────────────────────────────────

--- a/scripts/ops/stock-preparation-rca-abort-provenance.test.mjs
+++ b/scripts/ops/stock-preparation-rca-abort-provenance.test.mjs
@@ -29,7 +29,8 @@ import {
   classifyHttpStatusClass,
   classifyAuthReadStatusClass,
   classifyAuthReadReasonClass,
-  AUTH_READ_REASON_ALLOWLIST,
+  classifyAuthReadContractClass,
+  AUTH_READ_REASON_CODES,
   classifyNodeMajor,
   classifyRejection,
   classifyTypeErrorBoundary,
@@ -719,20 +720,46 @@ test('classifyAuthReadStatusClass splits 401/403/404/409 from other 4xx', () => 
   assert.equal(classifyAuthReadStatusClass(undefined), 'UNAVAILABLE')
 })
 
-test('classifyAuthReadReasonClass maps ONLY the server closed error codes; anything else -> OTHER', () => {
-  // 2xx has no reason.
+test('classifyAuthReadReasonClass binds reason to the EXACT (status, code) pair (review P2)', () => {
+  // 2xx has no reason; non-integer status -> UNAVAILABLE.
   assert.equal(classifyAuthReadReasonClass(200, { ok: true }), 'NONE')
-  // the four codebase-mapped codes pass through verbatim.
-  assert.deepEqual([...AUTH_READ_REASON_ALLOWLIST], ['UNAUTHORIZED', 'PASSWORD_CHANGE_REQUIRED', 'UNAUTHENTICATED', 'FORBIDDEN'])
+  assert.equal(classifyAuthReadReasonClass(undefined, { error: { code: 'FORBIDDEN' } }), 'UNAVAILABLE')
+  assert.equal(classifyAuthReadReasonClass(NaN, { error: { code: 'FORBIDDEN' } }), 'UNAVAILABLE')
+  // The three real pairs pass through.
+  assert.deepEqual([...AUTH_READ_REASON_CODES], ['UNAUTHORIZED', 'PASSWORD_CHANGE_REQUIRED', 'FORBIDDEN'])
   assert.equal(classifyAuthReadReasonClass(401, { ok: false, error: { code: 'UNAUTHORIZED' } }), 'UNAUTHORIZED')
   assert.equal(classifyAuthReadReasonClass(403, { ok: false, error: { code: 'PASSWORD_CHANGE_REQUIRED' } }), 'PASSWORD_CHANGE_REQUIRED')
-  assert.equal(classifyAuthReadReasonClass(401, { ok: false, error: { code: 'UNAUTHENTICATED' } }), 'UNAUTHENTICATED')
   assert.equal(classifyAuthReadReasonClass(403, { ok: false, error: { code: 'FORBIDDEN' } }), 'FORBIDDEN')
-  // values-free by construction: an unknown or business-shaped code folds to OTHER.
+  // The reviewer's contradictions: recognized code + wrong status -> INCONSISTENT, never the code.
+  assert.equal(classifyAuthReadReasonClass(404, { ok: false, error: { code: 'FORBIDDEN' } }), 'INCONSISTENT')
+  assert.equal(classifyAuthReadReasonClass(401, { ok: false, error: { code: 'PASSWORD_CHANGE_REQUIRED' } }), 'INCONSISTENT')
+  assert.equal(classifyAuthReadReasonClass(403, { ok: false, error: { code: 'UNAUTHORIZED' } }), 'INCONSISTENT')
+  // The plugin 401 UNAUTHENTICATED is unreachable behind the global gate — not a
+  // recognized branch; it folds to OTHER, not a named reason.
+  assert.equal(classifyAuthReadReasonClass(401, { ok: false, error: { code: 'UNAUTHENTICATED' } }), 'OTHER')
+  // Unknown / business-shaped / absent codes fold to OTHER — no free-text surfaces.
   assert.equal(classifyAuthReadReasonClass(403, { ok: false, error: { code: 'MAT-001-SECRET' } }), 'OTHER')
   assert.equal(classifyAuthReadReasonClass(404, { ok: false, error: {} }), 'OTHER')
   assert.equal(classifyAuthReadReasonClass(404, null), 'OTHER')
   assert.equal(classifyAuthReadReasonClass(400, { error: { code: 42 } }), 'OTHER')
+})
+
+test('classifyAuthReadContractClass: a bare 200 is NOT healthy unless the success contract holds (review P1)', () => {
+  const ok = { ok: true, data: { adapters: [], routes: [] } }
+  assert.equal(classifyAuthReadContractClass(200, ok), 'VALID')
+  assert.equal(classifyAuthReadContractClass(204, ok), 'VALID')
+  // 200 login/HTML page -> parses to null -> INVALID (the P1 repro).
+  assert.equal(classifyAuthReadContractClass(200, null), 'RESPONSE_CONTRACT_INVALID')
+  // 200 { ok:false } -> INVALID.
+  assert.equal(classifyAuthReadContractClass(200, { ok: false, error: { code: 'X' } }), 'RESPONSE_CONTRACT_INVALID')
+  // 200 with ok:true but missing/mis-typed data arrays -> INVALID.
+  assert.equal(classifyAuthReadContractClass(200, { ok: true }), 'RESPONSE_CONTRACT_INVALID')
+  assert.equal(classifyAuthReadContractClass(200, { ok: true, data: { adapters: [] } }), 'RESPONSE_CONTRACT_INVALID')
+  assert.equal(classifyAuthReadContractClass(200, { ok: true, data: { adapters: 'x', routes: [] } }), 'RESPONSE_CONTRACT_INVALID')
+  assert.equal(classifyAuthReadContractClass(200, { ok: 'true', data: { adapters: [], routes: [] } }), 'RESPONSE_CONTRACT_INVALID')
+  // Non-2xx has no success contract to judge.
+  assert.equal(classifyAuthReadContractClass(403, { ok: false }), 'UNAVAILABLE')
+  assert.equal(classifyAuthReadContractClass(undefined, ok), 'UNAVAILABLE')
 })
 
 test('runDiagnostic v2: one run is dispositive — the four 4XX sub-classes come through end to end', async () => {
@@ -754,18 +781,41 @@ test('runDiagnostic v2: one run is dispositive — the four 4XX sub-classes come
   assert.equal(forbidden.authReadStatusClass, 'HTTP_403')
   assert.equal(forbidden.authReadReasonClass, 'FORBIDDEN')
 
-  // success arm: 2xx -> NONE, and the run reports DIAGNOSTIC_COMPLETE (fast-track eligible).
+  // GENUINE success arm: 200 with the real status contract -> VALID (fast-track eligible).
   const ok = await runDiagnostic({
     args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
     verifyImpl: VERIFY_PASS,
     importImpl: REAL_HELPER_IMPORT,
-    fetchDelegate: async () => jsonResponse(200, JSON.stringify({ ok: true, data: {} })),
+    fetchDelegate: async () => jsonResponse(200, JSON.stringify({ ok: true, data: { adapters: [], routes: [] } })),
     timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
   })
   assert.equal(ok.authReadResult, 'HTTP_2XX')
   assert.equal(ok.authReadStatusClass, 'HTTP_2XX')
   assert.equal(ok.authReadReasonClass, 'NONE')
+  assert.equal(ok.authReadContractClass, 'VALID')
   assert.equal(ok.executionState, 'DIAGNOSTIC_COMPLETE')
+
+  // P1 repro: a 200 login/HTML page (body parses to null) must NOT read as a
+  // healthy API — the contract field flags it and the fast-track cannot fire.
+  const htmlPage = await runDiagnostic({
+    args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    verifyImpl: VERIFY_PASS,
+    importImpl: REAL_HELPER_IMPORT,
+    fetchDelegate: async () => ({ status: 200, text: async () => '<html><body>login</body></html>' }),
+    timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+  })
+  assert.equal(htmlPage.authReadStatusClass, 'HTTP_2XX')
+  assert.equal(htmlPage.authReadContractClass, 'RESPONSE_CONTRACT_INVALID', 'a 200 HTML page is not a healthy API')
+
+  // 200 { ok:false } must also fail the success contract.
+  const okFalse = await runDiagnostic({
+    args: { helperPath: 'x/stock-preparation-prep-line-extended-smoke.mjs', baseUrl: BASE_URL, tenantId: '' },
+    verifyImpl: VERIFY_PASS,
+    importImpl: REAL_HELPER_IMPORT,
+    fetchDelegate: async () => jsonResponse(200, JSON.stringify({ ok: false })),
+    timerProbeOverrides: { sleepTargetMs: 40, minSleepMs: 20, maxSleepMs: 4000, abortTimerMs: 2000 },
+  })
+  assert.equal(okFalse.authReadContractClass, 'RESPONSE_CONTRACT_INVALID')
 
   // transport rejection: no HTTP response to sub-classify.
   const aborted = await runDiagnostic({
@@ -777,6 +827,7 @@ test('runDiagnostic v2: one run is dispositive — the four 4XX sub-classes come
   })
   assert.equal(aborted.authReadStatusClass, 'UNAVAILABLE')
   assert.equal(aborted.authReadReasonClass, 'UNAVAILABLE')
+  assert.equal(aborted.authReadContractClass, 'UNAVAILABLE')
 })
 
 // ── Pathname shape ───────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Refs #4437 — **加速**:把 RC-A auth 诊断从「先跑 v1、失败再造 v2」两次操作员往返,压缩成**带已知良好 token 的一跑定生死**。纯客户端测试改动;不动服务、不重发 RC-A 包、不碰 flag/PM2。

> **状态**:owner corrective review(1 P1/2 P2)已全部吸收;复审代码裁决 **APPROVE(0 P1/0 P2,head `9f1e59a37`)**。本 body 为修复后口径;初版口径(裸 2XX fast-track、UNAUTHENTICATED 命名分支、45/45)已废,见 §勘误。

## 背景

v1 那跑回 `authReadResult=HTTP_4XX`——服务可达且在答,客户端/运行时/传输/服务存活全洗清(abort 疑云是 v1 wrapper 产物)。但 `/api/integration/status` 的 4XX 有多种成因,v1 分不清,逼出第二往返。现在直接把判别器发出去,一跑分清。

## 闭 4XX/2XX 判别面(从代码映射,非猜测;corrective 后口径)

reason 绑定**精确 `(status, code)` 对**,不再按 code 单独匹配:

| HTTP | 服务 `error.code` | 层 | 已知良好 token 那跑的含义 |
|---|---|---|---|
| 401 | `UNAUTHORIZED` | 全局 JWT 门 | token 仍缺失/无效/过期 |
| 403 | `PASSWORD_CHANGE_REQUIRED` | 全局 JWT 门 | 账号被标强制改密(账号态) |
| ~~401~~ | ~~`UNAUTHENTICATED`~~ | 插件 requireAccess | **全局 JWT 门后不可达——非命名分支,折 `OTHER`**(corrective P2) |
| 403 | `FORBIDDEN` | 插件 requireAccess | token 有效、无强制改密,但缺 `integration:read`(权限) |
| 404 | — | — | auth 失败不会到 404;若 404 ⇒ 路由/base-URL/部署面 |
| 2XX | — | — | **仅当 `authReadContractClass=VALID` 才算健康/fast-track**;200 登录页/HTML ⇒ `RESPONSE_CONTRACT_INVALID`,禁止放行(corrective P1) |

识别码配错状态(如 `404+FORBIDDEN`、`401+PASSWORD_CHANGE_REQUIRED`)⇒ `INCONSISTENT`,不产出矛盾诊断;非整数 status ⇒ `UNAVAILABLE`。

## 改动

三个 values-free 闭词表字段:
- `authReadStatusClass=HTTP_2XX|HTTP_401|HTTP_403|HTTP_404|HTTP_409|HTTP_4XX_OTHER|HTTP_5XX|OTHER|UNAVAILABLE`(HTTP 状态是闭协议枚举);
- `authReadReasonClass=NONE|UNAUTHORIZED|PASSWORD_CHANGE_REQUIRED|FORBIDDEN|INCONSISTENT|OTHER|UNAVAILABLE`——只认三个精确对 `401+UNAUTHORIZED`/`403+PASSWORD_CHANGE_REQUIRED`/`403+FORBIDDEN`;识别码配错状态→`INCONSISTENT`;其余/缺省 code→`OTHER`(无自由文本外显);2xx→`NONE`;非整数 status→`UNAVAILABLE`;
- `authReadContractClass=VALID|RESPONSE_CONTRACT_INVALID|UNAVAILABLE`——2xx 仅当 `body.ok===true` 且 `data.adapters`/`data.routes` 均为数组才 `VALID`,否则 `RESPONSE_CONTRACT_INVALID`(200 HTML→`body=null`、`200 {ok:false}`、缺数组全都拦);非 2xx/传输中止→`UNAVAILABLE`。

exact-SHA helper 绑定、固定 `timeoutMs=15000`、恰一内部只读 GET、DIAGNOSTIC_COMPLETE 合同、token scrub 全部不变。渲染面为闭词表通用发射(`RESULT_FIELD_ORDER`+`composeResultBlock` 拒收词表外值),新字段自动进结果块。

## 验证

**46/46**(v1 不变 + 状态类边界 + 三精确对端到端 + `INCONSISTENT` 错配对 + `UNAUTHENTICATED` 折 `OTHER` 钉住 + 200-HTML/`200 {ok:false}`/缺数组→`RESPONSE_CONTRACT_INVALID` + 真 `{ok:true,data:{adapters,routes}}`→`VALID` + 传输中止 UNAVAILABLE);CLI 端到端(死端口→UNAVAILABLE)。

变异证据(全 RED 才收):
- 初版电池 **6/6 红**(合并 401/403、开放 reason 匹配、删 2xx→NONE、忽略 body、401 误标 403、两字段接线互换);
- corrective 电池 **6/6 红**(contract 恒 VALID、删 `ok===true`、删数组校验、reason 退化 code-only、非整数不 UNAVAILABLE、INCONSISTENT 关断)——docs MD §4b;
- 复审独立电池 **6/6 红**(异构实现,见 PR 评论 2026-07-21)。

CI 由现有 prep-line contract job(Node 20 path 已含本客户端+测试)覆盖。

## 勘误(相对初版 body)

初版曾写「2XX⇒fast-track」「UNAUTHENTICATED 为有效分支」「reason 四码白名单」「45/45」。**均已废**:fast-track 须 `HTTP_2XX` **且** `authReadContractClass=VALID`;`UNAUTHENTICATED` 不可达、折 `OTHER`;reason 按精确 `(status,code)` 对;套件 46/46。docs MD §2 判别面表同步修正(复审 P3;注:该修正 commit message 误写「§3」,表实际在 §2)。

## 操作(owner 裁决 + 操作侧动作)

发布 sidecar **v2**(本客户端 + 字节精确 RC-A helper,同 v1 no-Git 打包),用**已知良好 token**(短时、`integration:read` 或 `role:admin`、**无强制改密**)flag-OFF 单跑一次。分流(owner-court):
- `HTTP_2XX` **且 `authReadContractClass=VALID`** + 卫生 PASS ⇒ 授权 RC-A 窗口;`RESPONSE_CONTRACT_INVALID`(登录页/HTML)**禁止 fast-track**;
- `HTTP_401`/`UNAUTHORIZED` ⇒ token 仍无效;`HTTP_403`/`PASSWORD_CHANGE_REQUIRED` ⇒ 清强制改密再跑;`HTTP_403`/`FORBIDDEN` ⇒ 授 `integration:read` 再跑;`HTTP_404` ⇒ 部署面。以上五路见 docs MD §5;任何未列组合(如 `INCONSISTENT`/`OTHER`)**不自动分流,回 owner 裁决**(PR 侧操作注记,循 #4437 惯例;§5 本身只列五路)。

sidecar v2 从本 PR **合并 SHA** 制作并独立校验后更新 #4437 执行指针;实体机单跑仍归 owner/操作侧。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
