### PR TITLE
feat(attendance): W4-0 readiness 安全底座 — setup-readiness 聚合端点 + 七步判别纯模块（锁 #4509 切片 1/3）

### DIFF
--- a/.github/workflows/attendance-web-guard.yml
+++ b/.github/workflows/attendance-web-guard.yml
@@ -112,6 +112,7 @@ on:
       - 'apps/web/tests/attendance-overview-priority.spec.ts'
       - 'apps/web/tests/AttendanceAdminTaskHome.spec.ts'
       - 'apps/web/tests/attendance-experience-entrypoints.spec.ts'
+      - 'apps/web/tests/attendance-setup-readiness.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
   push:
     branches: [main]
@@ -153,6 +154,7 @@ on:
       - 'apps/web/tests/attendance-overview-priority.spec.ts'
       - 'apps/web/tests/AttendanceAdminTaskHome.spec.ts'
       - 'apps/web/tests/attendance-experience-entrypoints.spec.ts'
+      - 'apps/web/tests/attendance-setup-readiness.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
 
 jobs:
@@ -195,4 +197,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run attendance web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust attendance-overview-priority AttendanceAdminTaskHome attendance-experience-entrypoints --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust attendance-overview-priority AttendanceAdminTaskHome attendance-experience-entrypoints attendance-setup-readiness --reporter=dot

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -820,6 +820,7 @@ jobs:
             tests/integration/attendance-approval-direct-manager-s7-2.db.test.ts \
             tests/integration/attendance-approval-dept-head-s7-3.db.test.ts \
             tests/integration/attendance-approval-manager-at-level-s7-4.db.test.ts \
+            tests/integration/attendance-setup-readiness-w4-0.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/apps/web/src/views/attendance/attendanceSetupReadiness.ts
+++ b/apps/web/src/views/attendance/attendanceSetupReadiness.ts
@@ -1,0 +1,202 @@
+// W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED): pure discriminator for the seven-step
+// setup-readiness aggregate (`GET /api/attendance-admin/setup-readiness`). This module ONLY turns
+// the aggregate response (or a whole-endpoint 403/503) into the seven-step judgement matrix — zero
+// DOM, zero fetch, zero Vue reactivity. The wizard shell (`AttendanceSetupReadiness.vue`) and its
+// fetch/section-registration wiring belong to W4-1, not this slice (§7 "父层 AttendanceView：
+// readiness 加载/聚合调用..."; §2 W4-0 scope = "纯逻辑模块 attendanceSetupReadiness.ts（判别矩阵
+// 完整，分支不埋 template）").
+//
+// Design lock: docs/development/attendance-vnext-wave4-onboarding-design-lock-20260721.md §3/§4/§7.
+//
+// KNOWN SCOPE GAP (flagged for owner ruling, not decided here — see PR body): §3③ conditions
+// rotation-rule readiness on "排班制组存在" (a scheduled_shift-type group exists), but §4.2's
+// response key set is explicitly locked and carries no group-type signal. This module therefore
+// treats step③ readiness as `shiftCount > 0` alone (informational-only `rotationRuleCount` /
+// `hasRotationRules`, never gating) until the owner picks: (a) add a `hasScheduledShiftGroups`
+// signal to the locked response shape, or (b) defer the AND-with-rotation-rules gating to W4-1
+// where group-type breakdown is already loaded by the wizard shell.
+
+export type AttendanceSetupReadinessStatus = 'ready' | 'missing' | 'forbidden' | 'unknown' | 'db_not_ready'
+
+export type AttendanceSetupReadinessEffectiveTimePosture =
+  | 'immediate'
+  | 'scheduled'
+  | 'manual_activation'
+  | 'undeterminable'
+
+export interface AttendanceSetupReadinessEffectiveTime {
+  source: string
+  posture: AttendanceSetupReadinessEffectiveTimePosture
+  effectiveAt?: string
+}
+
+export interface AttendanceSetupReadinessStepMeta {
+  step: string
+  scope: 'org' | 'deployment'
+  effectiveTime: AttendanceSetupReadinessEffectiveTime
+}
+
+/** Mirrors `packages/core-backend/src/routes/attendance-admin.ts` AttendanceSetupReadinessResponse. */
+export interface AttendanceSetupReadinessResponse {
+  directoryLinked: boolean
+  orgActiveMemberCount: number
+  groupCount: number
+  groupsWithMembers: number
+  shiftCount: number
+  rotationRuleCount: number
+  hasRotationRules: boolean
+  approvalFlowCount: number
+  punchPolicyPosture: 'default' | 'customized' | 'unknown'
+  notify: {
+    workerEnabled: boolean | 'unknown'
+    defaultChannelAvailable: boolean | 'unknown'
+    availableChannelCount: number | 'unknown'
+    orgRecipientBindingReady: boolean | 'unknown'
+  }
+  perStep: AttendanceSetupReadinessStepMeta[]
+  deploymentScopedSignals: readonly string[]
+}
+
+/** The seven canonical step ids, in wizard order (§3). Stable across W4-0/W4-1/W4-2. */
+export const ATTENDANCE_SETUP_STEP_IDS = [
+  'attendance-admin-user-access',
+  'attendance-admin-groups',
+  'attendance-admin-shifts',
+  'attendance-admin-settings',
+  'attendance-admin-approval-flows',
+  'attendance-admin-notification-deliveries',
+  'preview',
+] as const
+
+export type AttendanceSetupStepId = (typeof ATTENDANCE_SETUP_STEP_IDS)[number]
+
+export interface AttendanceSetupReadinessStepResult {
+  stepId: AttendanceSetupStepId
+  status: AttendanceSetupReadinessStatus
+  /** display-only reason key — never a raw value (values-free, §4.2) */
+  reason:
+    | 'org_active_member_count_zero'
+    | 'group_or_membership_missing'
+    | 'shift_count_zero'
+    | 'punch_policy_default'
+    | 'punch_policy_customized'
+    | 'punch_policy_unknown'
+    | 'approval_flow_count_zero'
+    | 'notify_not_ready'
+    | 'notify_signal_unknown'
+    | 'preview_blocked_by_prior_step'
+    | 'preview_ready'
+    | 'ready'
+    | 'forbidden'
+    | 'db_not_ready'
+  effectiveTime?: AttendanceSetupReadinessEffectiveTime
+}
+
+/** Discriminated input the wizard shell can build directly from an HTTP response. */
+export type AttendanceSetupReadinessInput =
+  | { kind: 'forbidden' }
+  | { kind: 'db_not_ready' }
+  | { kind: 'ok'; data: AttendanceSetupReadinessResponse }
+
+function stepMeta(
+  data: AttendanceSetupReadinessResponse,
+  stepId: AttendanceSetupStepId,
+): AttendanceSetupReadinessEffectiveTime | undefined {
+  return data.perStep.find((s) => s.step === stepId)?.effectiveTime
+}
+
+function notifyReady(notify: AttendanceSetupReadinessResponse['notify']): 'ready' | 'missing' | 'unknown' {
+  const values = [notify.workerEnabled, notify.defaultChannelAvailable, notify.orgRecipientBindingReady]
+  if (values.some((v) => v === 'unknown')) return 'unknown'
+  return notify.workerEnabled === true && notify.defaultChannelAvailable === true && notify.orgRecipientBindingReady === true
+    ? 'ready'
+    : 'missing'
+}
+
+/**
+ * Derive the full seven-step judgement matrix from a setup-readiness response (or a whole-endpoint
+ * 403/503). Every row is one of the five locked values: ready / missing / forbidden / unknown /
+ * db_not_ready (§3 判别值域) — never a sixth value, never a guess.
+ */
+export function deriveAttendanceSetupReadinessSteps(
+  input: AttendanceSetupReadinessInput,
+): AttendanceSetupReadinessStepResult[] {
+  if (input.kind === 'forbidden') {
+    return ATTENDANCE_SETUP_STEP_IDS.map((stepId) => ({ stepId, status: 'forbidden', reason: 'forbidden' }))
+  }
+  if (input.kind === 'db_not_ready') {
+    return ATTENDANCE_SETUP_STEP_IDS.map((stepId) => ({ stepId, status: 'db_not_ready', reason: 'db_not_ready' }))
+  }
+
+  const { data } = input
+
+  // ① orgActiveMemberCount>0 is sufficient (round-3 P2-1: "同步或创建" — directoryLinked is
+  // auxiliary/display-only, never gating).
+  const step1: AttendanceSetupReadinessStepResult = {
+    stepId: 'attendance-admin-user-access',
+    status: data.orgActiveMemberCount > 0 ? 'ready' : 'missing',
+    reason: data.orgActiveMemberCount > 0 ? 'ready' : 'org_active_member_count_zero',
+    effectiveTime: stepMeta(data, 'attendance-admin-user-access'),
+  }
+
+  // ② groupCount>0 AND groupsWithMembers>0.
+  const step2: AttendanceSetupReadinessStepResult = {
+    stepId: 'attendance-admin-groups',
+    status: data.groupCount > 0 && data.groupsWithMembers > 0 ? 'ready' : 'missing',
+    reason: data.groupCount > 0 && data.groupsWithMembers > 0 ? 'ready' : 'group_or_membership_missing',
+    effectiveTime: stepMeta(data, 'attendance-admin-groups'),
+  }
+
+  // ③ shiftCount>0. rotationRuleCount/hasRotationRules are carried informationally only — see the
+  // KNOWN SCOPE GAP note at the top of this file; NOT gating in W4-0.
+  const step3: AttendanceSetupReadinessStepResult = {
+    stepId: 'attendance-admin-shifts',
+    status: data.shiftCount > 0 ? 'ready' : 'missing',
+    reason: data.shiftCount > 0 ? 'ready' : 'shift_count_zero',
+    effectiveTime: stepMeta(data, 'attendance-admin-shifts'),
+  }
+
+  // ④ default and customized are BOTH ready (round-3 (b)); only unknown fails closed.
+  const step4: AttendanceSetupReadinessStepResult = {
+    stepId: 'attendance-admin-settings',
+    status: data.punchPolicyPosture === 'unknown' ? 'unknown' : 'ready',
+    reason:
+      data.punchPolicyPosture === 'default'
+        ? 'punch_policy_default'
+        : data.punchPolicyPosture === 'customized'
+          ? 'punch_policy_customized'
+          : 'punch_policy_unknown',
+    effectiveTime: stepMeta(data, 'attendance-admin-settings'),
+  }
+
+  // ⑤ approvalFlowCount>0 (active flows).
+  const step5: AttendanceSetupReadinessStepResult = {
+    stepId: 'attendance-admin-approval-flows',
+    status: data.approvalFlowCount > 0 ? 'ready' : 'missing',
+    reason: data.approvalFlowCount > 0 ? 'ready' : 'approval_flow_count_zero',
+    effectiveTime: stepMeta(data, 'attendance-admin-approval-flows'),
+  }
+
+  // ⑥ notify port: any unknown signal ⇒ unknown (fail-closed, never displayed as complete).
+  const notify = notifyReady(data.notify)
+  const step6: AttendanceSetupReadinessStepResult = {
+    stepId: 'attendance-admin-notification-deliveries',
+    status: notify === 'unknown' ? 'unknown' : notify === 'ready' ? 'ready' : 'missing',
+    reason: notify === 'unknown' ? 'notify_signal_unknown' : notify === 'ready' ? 'ready' : 'notify_not_ready',
+    effectiveTime: stepMeta(data, 'attendance-admin-notification-deliveries'),
+  }
+
+  // ⑦ previewReady = all six prior steps ready. Any prior 'unknown' propagates as 'unknown'
+  // (fail-closed — §3 "unknown 绝不显示为已完成" applies transitively to the preview gate too).
+  const priorSteps = [step1, step2, step3, step4, step5, step6]
+  const anyUnknown = priorSteps.some((s) => s.status === 'unknown')
+  const allReady = priorSteps.every((s) => s.status === 'ready')
+  const step7: AttendanceSetupReadinessStepResult = {
+    stepId: 'preview',
+    status: anyUnknown ? 'unknown' : allReady ? 'ready' : 'missing',
+    reason: anyUnknown ? 'notify_signal_unknown' : allReady ? 'preview_ready' : 'preview_blocked_by_prior_step',
+    effectiveTime: stepMeta(data, 'preview'),
+  }
+
+  return [step1, step2, step3, step4, step5, step6, step7]
+}

--- a/apps/web/tests/attendance-setup-readiness.spec.ts
+++ b/apps/web/tests/attendance-setup-readiness.spec.ts
@@ -1,0 +1,296 @@
+// W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED) — pure-module spec for
+// attendanceSetupReadiness.ts. Zero DOM/zero fetch/zero Vue: this file only proves the seven-step
+// discriminator matrix (§3/§4/§7). The wizard shell (AttendanceSetupReadiness.vue) that consumes this
+// module is W4-1 scope, not tested here.
+//
+// Design lock: docs/development/attendance-vnext-wave4-onboarding-design-lock-20260721.md §3/§4/§7.
+import { describe, expect, it } from 'vitest'
+import {
+  ATTENDANCE_SETUP_STEP_IDS,
+  deriveAttendanceSetupReadinessSteps,
+  type AttendanceSetupReadinessInput,
+  type AttendanceSetupReadinessResponse,
+  type AttendanceSetupReadinessStatus,
+  type AttendanceSetupStepId,
+} from '../src/views/attendance/attendanceSetupReadiness'
+
+const STATUS_DOMAIN: AttendanceSetupReadinessStatus[] = ['ready', 'missing', 'forbidden', 'unknown', 'db_not_ready']
+
+/** A fully-"everything ready" response — individual fields are overridden per test. */
+function readyResponse(overrides: Partial<AttendanceSetupReadinessResponse> = {}): AttendanceSetupReadinessResponse {
+  return {
+    directoryLinked: true,
+    orgActiveMemberCount: 3,
+    groupCount: 2,
+    groupsWithMembers: 2,
+    shiftCount: 2,
+    rotationRuleCount: 0,
+    hasRotationRules: false,
+    approvalFlowCount: 1,
+    punchPolicyPosture: 'default',
+    notify: {
+      workerEnabled: true,
+      defaultChannelAvailable: true,
+      availableChannelCount: 1,
+      orgRecipientBindingReady: true,
+    },
+    perStep: [
+      { step: 'attendance-admin-user-access', scope: 'org', effectiveTime: { source: 'user_orgs.is_active', posture: 'immediate' } },
+      { step: 'attendance-admin-groups', scope: 'org', effectiveTime: { source: 'attendance_group_members', posture: 'immediate' } },
+      { step: 'attendance-admin-shifts', scope: 'org', effectiveTime: { source: 'attendance_shifts+attendance_rotation_rules', posture: 'immediate' } },
+      { step: 'attendance-admin-settings', scope: 'deployment', effectiveTime: { source: 'system_configs.attendance_settings', posture: 'immediate' } },
+      { step: 'attendance-admin-approval-flows', scope: 'org', effectiveTime: { source: 'attendance_approval_flows.is_active', posture: 'immediate' } },
+      { step: 'attendance-admin-notification-deliveries', scope: 'deployment', effectiveTime: { source: 'none', posture: 'undeterminable' } },
+      { step: 'preview', scope: 'org', effectiveTime: { source: 'none', posture: 'manual_activation' } },
+    ],
+    deploymentScopedSignals: ['punchPolicyPosture', 'notify.workerEnabled', 'notify.defaultChannelAvailable', 'notify.availableChannelCount'],
+    ...overrides,
+  }
+}
+
+function ok(overrides: Partial<AttendanceSetupReadinessResponse> = {}): AttendanceSetupReadinessInput {
+  return { kind: 'ok', data: readyResponse(overrides) }
+}
+
+function stepResult(steps: ReturnType<typeof deriveAttendanceSetupReadinessSteps>, stepId: AttendanceSetupStepId) {
+  const found = steps.find((s) => s.stepId === stepId)
+  if (!found) throw new Error(`step ${stepId} missing from derived matrix`)
+  return found
+}
+
+describe('ATTENDANCE_SETUP_STEP_IDS', () => {
+  it('is the seven canonical step ids, in wizard order', () => {
+    expect(ATTENDANCE_SETUP_STEP_IDS).toEqual([
+      'attendance-admin-user-access',
+      'attendance-admin-groups',
+      'attendance-admin-shifts',
+      'attendance-admin-settings',
+      'attendance-admin-approval-flows',
+      'attendance-admin-notification-deliveries',
+      'preview',
+    ])
+  })
+})
+
+describe('deriveAttendanceSetupReadinessSteps — whole-endpoint 403/503 folding', () => {
+  it('forbidden: all seven steps fold to forbidden (§4.3 per-surface 403, not the global adminForbidden flag)', () => {
+    const steps = deriveAttendanceSetupReadinessSteps({ kind: 'forbidden' })
+    expect(steps).toHaveLength(7)
+    expect(steps.map((s) => s.stepId)).toEqual([...ATTENDANCE_SETUP_STEP_IDS])
+    for (const s of steps) {
+      expect(s.status).toBe('forbidden')
+      expect(s.reason).toBe('forbidden')
+    }
+  })
+
+  it('db_not_ready: all seven steps fold to db_not_ready (503 DB_NOT_READY)', () => {
+    const steps = deriveAttendanceSetupReadinessSteps({ kind: 'db_not_ready' })
+    expect(steps).toHaveLength(7)
+    for (const s of steps) {
+      expect(s.status).toBe('db_not_ready')
+      expect(s.reason).toBe('db_not_ready')
+    }
+  })
+
+  it('every derived status is a member of the five-value locked domain — never a sixth value', () => {
+    const inputs: AttendanceSetupReadinessInput[] = [
+      { kind: 'forbidden' },
+      { kind: 'db_not_ready' },
+      ok(),
+      ok({ orgActiveMemberCount: 0 }),
+      ok({ punchPolicyPosture: 'unknown' }),
+    ]
+    for (const input of inputs) {
+      for (const s of deriveAttendanceSetupReadinessSteps(input)) {
+        expect(STATUS_DOMAIN).toContain(s.status)
+      }
+    }
+  })
+})
+
+describe('① attendance-admin-user-access — orgActiveMemberCount only (round-3 P2-1: OR not AND)', () => {
+  it('ready when orgActiveMemberCount > 0, regardless of directoryLinked', () => {
+    const steps = deriveAttendanceSetupReadinessSteps(ok({ orgActiveMemberCount: 5, directoryLinked: false }))
+    const s = stepResult(steps, 'attendance-admin-user-access')
+    expect(s.status).toBe('ready')
+    expect(s.reason).toBe('ready')
+  })
+
+  it('missing when orgActiveMemberCount === 0, even when directoryLinked is true (directoryLinked is auxiliary-only, never gating)', () => {
+    const steps = deriveAttendanceSetupReadinessSteps(ok({ orgActiveMemberCount: 0, directoryLinked: true }))
+    const s = stepResult(steps, 'attendance-admin-user-access')
+    expect(s.status).toBe('missing')
+    expect(s.reason).toBe('org_active_member_count_zero')
+  })
+
+  it('carries the registered effectiveTime for this step', () => {
+    const steps = deriveAttendanceSetupReadinessSteps(ok())
+    const s = stepResult(steps, 'attendance-admin-user-access')
+    expect(s.effectiveTime).toEqual({ source: 'user_orgs.is_active', posture: 'immediate' })
+  })
+})
+
+describe('② attendance-admin-groups — groupCount>0 AND groupsWithMembers>0 (OD-W4-6)', () => {
+  it('ready when both counts are positive', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok({ groupCount: 3, groupsWithMembers: 1 })), 'attendance-admin-groups')
+    expect(s.status).toBe('ready')
+    expect(s.reason).toBe('ready')
+  })
+
+  it('missing when groups exist but none has members', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok({ groupCount: 2, groupsWithMembers: 0 })), 'attendance-admin-groups')
+    expect(s.status).toBe('missing')
+    expect(s.reason).toBe('group_or_membership_missing')
+  })
+
+  it('missing when there are zero groups at all', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok({ groupCount: 0, groupsWithMembers: 0 })), 'attendance-admin-groups')
+    expect(s.status).toBe('missing')
+    expect(s.reason).toBe('group_or_membership_missing')
+  })
+})
+
+describe('③ attendance-admin-shifts — shiftCount>0; rotation-rule fields are informational only (KNOWN SCOPE GAP, see module header)', () => {
+  it('ready when shiftCount > 0, even with hasRotationRules=false', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok({ shiftCount: 1, hasRotationRules: false, rotationRuleCount: 0 })), 'attendance-admin-shifts')
+    expect(s.status).toBe('ready')
+    expect(s.reason).toBe('ready')
+  })
+
+  it('missing when shiftCount === 0, even with hasRotationRules=true (rotation fields never gate step③ in W4-0)', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok({ shiftCount: 0, hasRotationRules: true, rotationRuleCount: 4 })), 'attendance-admin-shifts')
+    expect(s.status).toBe('missing')
+    expect(s.reason).toBe('shift_count_zero')
+  })
+})
+
+describe('④ attendance-admin-settings — punchPolicyPosture (OD-W4-4=(c), round-3 (b) default→ready)', () => {
+  it('default posture is ready with reason punch_policy_default (displayed as 「使用平台默认策略」 by the W4-1 tr() layer — this pure module locks the reason KEY, not the Chinese literal)', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok({ punchPolicyPosture: 'default' })), 'attendance-admin-settings')
+    expect(s.status).toBe('ready')
+    expect(s.reason).toBe('punch_policy_default')
+  })
+
+  it('customized posture is ready with reason punch_policy_customized (displayed as 「已自定义」 by W4-1)', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok({ punchPolicyPosture: 'customized' })), 'attendance-admin-settings')
+    expect(s.status).toBe('ready')
+    expect(s.reason).toBe('punch_policy_customized')
+  })
+
+  it('unknown posture fails closed to unknown — never displayed as complete (§3 未知态红线)', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok({ punchPolicyPosture: 'unknown' })), 'attendance-admin-settings')
+    expect(s.status).toBe('unknown')
+    expect(s.reason).toBe('punch_policy_unknown')
+  })
+})
+
+describe('⑤ attendance-admin-approval-flows — approvalFlowCount>0', () => {
+  it('ready when approvalFlowCount > 0', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok({ approvalFlowCount: 2 })), 'attendance-admin-approval-flows')
+    expect(s.status).toBe('ready')
+    expect(s.reason).toBe('ready')
+  })
+
+  it('missing when approvalFlowCount === 0', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok({ approvalFlowCount: 0 })), 'attendance-admin-approval-flows')
+    expect(s.status).toBe('missing')
+    expect(s.reason).toBe('approval_flow_count_zero')
+  })
+})
+
+describe('⑥ attendance-admin-notification-deliveries — §4.5 port fail-closed to unknown on ANY unknown signal', () => {
+  it('ready when all three gating signals are true', () => {
+    const s = stepResult(
+      deriveAttendanceSetupReadinessSteps(ok({ notify: { workerEnabled: true, defaultChannelAvailable: true, availableChannelCount: 1, orgRecipientBindingReady: true } })),
+      'attendance-admin-notification-deliveries',
+    )
+    expect(s.status).toBe('ready')
+    expect(s.reason).toBe('ready')
+  })
+
+  it('missing when every signal resolved but at least one is false (not unknown)', () => {
+    const s = stepResult(
+      deriveAttendanceSetupReadinessSteps(ok({ notify: { workerEnabled: false, defaultChannelAvailable: false, availableChannelCount: 0, orgRecipientBindingReady: false } })),
+      'attendance-admin-notification-deliveries',
+    )
+    expect(s.status).toBe('missing')
+    expect(s.reason).toBe('notify_not_ready')
+  })
+
+  it('unknown when workerEnabled is unknown (port missing), even though the other two look ready', () => {
+    const s = stepResult(
+      deriveAttendanceSetupReadinessSteps(ok({ notify: { workerEnabled: 'unknown', defaultChannelAvailable: true, availableChannelCount: 1, orgRecipientBindingReady: true } })),
+      'attendance-admin-notification-deliveries',
+    )
+    expect(s.status).toBe('unknown')
+    expect(s.reason).toBe('notify_signal_unknown')
+  })
+
+  it('unknown when only orgRecipientBindingReady is unknown (the narrowed DB-probe-failure case, §4.5)', () => {
+    const s = stepResult(
+      deriveAttendanceSetupReadinessSteps(ok({ notify: { workerEnabled: true, defaultChannelAvailable: true, availableChannelCount: 1, orgRecipientBindingReady: 'unknown' } })),
+      'attendance-admin-notification-deliveries',
+    )
+    expect(s.status).toBe('unknown')
+  })
+})
+
+describe('⑦ preview — previewReady iff all six prior steps ready; any prior unknown propagates as unknown', () => {
+  it('ready ("preview-ready") when all six prior steps are ready', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok()), 'preview')
+    expect(s.status).toBe('ready')
+    expect(s.reason).toBe('preview_ready')
+  })
+
+  it('missing ("blocked by prior step") when at least one prior step is missing but none is unknown', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok({ shiftCount: 0 })), 'preview')
+    expect(s.status).toBe('missing')
+    expect(s.reason).toBe('preview_blocked_by_prior_step')
+  })
+
+  it('unknown when a prior step is unknown (transitive fail-closed — §3 未知态红线 applies through the preview gate too)', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok({ punchPolicyPosture: 'unknown' })), 'preview')
+    expect(s.status).toBe('unknown')
+  })
+
+  it('never claims ready when both a missing AND an unknown prior step are present (unknown wins over missing)', () => {
+    const s = stepResult(
+      deriveAttendanceSetupReadinessSteps(ok({ shiftCount: 0, punchPolicyPosture: 'unknown' })),
+      'preview',
+    )
+    expect(s.status).toBe('unknown')
+  })
+
+  it('carries the manual_activation effectiveTime posture — preview never implies an app-triggered enable event', () => {
+    const s = stepResult(deriveAttendanceSetupReadinessSteps(ok()), 'preview')
+    expect(s.effectiveTime).toEqual({ source: 'none', posture: 'manual_activation' })
+  })
+})
+
+describe('full seven-row matrix on a maximally-mixed input (every status value represented at least once elsewhere in this file)', () => {
+  it('produces exactly seven rows, each with a stepId from the locked step-id list and a status from the locked domain', () => {
+    const steps = deriveAttendanceSetupReadinessSteps(
+      ok({
+        orgActiveMemberCount: 4,
+        groupCount: 1,
+        groupsWithMembers: 0, // ② missing
+        shiftCount: 2, // ③ ready
+        punchPolicyPosture: 'customized', // ④ ready
+        approvalFlowCount: 0, // ⑤ missing
+        notify: { workerEnabled: true, defaultChannelAvailable: true, availableChannelCount: 1, orgRecipientBindingReady: 'unknown' }, // ⑥ unknown
+      }),
+    )
+    expect(steps).toHaveLength(7)
+    expect(steps.map((s) => s.stepId)).toEqual([...ATTENDANCE_SETUP_STEP_IDS])
+    expect(steps.map((s) => s.status)).toEqual([
+      'ready', // ①
+      'missing', // ②
+      'ready', // ③
+      'ready', // ④
+      'missing', // ⑤
+      'unknown', // ⑥
+      'unknown', // ⑦ transitive from ⑥
+    ])
+    for (const s of steps) expect(STATUS_DOMAIN).toContain(s.status)
+  })
+})

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -7,6 +7,11 @@ import { MAX_MANAGER_CHAIN_LEVELS } from '../services/ApprovalDirectoryOrg'
 import { jsonError, jsonOk, parsePagination } from '../util/response'
 import { redeliverFailedAttendanceNotification } from '../services/AttendanceNotificationRedelivery'
 import { ensurePlatformAdmin } from './admin-users'
+import { isDatabaseSchemaError } from '../utils/database-errors'
+import {
+  createAttendanceDeliveryChannelsFromEnv,
+  DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME,
+} from '../services/AttendanceNotificationDeliveryWorker'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -378,6 +383,375 @@ export async function canReadAttendanceDirectoryReadiness(
   return member.rows.length > 0
 }
 
+// ---------------------------------------------------------------------------------------------
+// W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED): seven-step setup-readiness aggregate.
+// §0 red line R1: readiness is READ-ONLY. Every aggregation query below MUST be issued through
+// `createReadOnlyReadinessSeam` — a runtime guard (not a comment) that rejects any non-SELECT/WITH
+// statement before it reaches the database. Authorization (`canReadAttendanceDirectoryReadiness`,
+// reused verbatim from S7-5 above) is checked by the route BEFORE `buildAttendanceSetupReadiness`
+// is ever invoked, so a foreign-org 403 issues zero aggregation SQL (OD-W4-1 追加门禁1).
+// ---------------------------------------------------------------------------------------------
+
+export type AttendanceSetupReadinessQueryFn = typeof query
+
+/**
+ * §9 追加门禁3: the setup-readiness query seam only accepts SELECT/WITH statements. Throws
+ * synchronously — before any I/O — for anything else, so a mutation that slips a write statement
+ * into a call site fails loudly instead of silently running against the database.
+ */
+export function assertSelectOnlyReadinessSql(sql: string): void {
+  const normalized = sql.trim().toUpperCase()
+  if (!(normalized.startsWith('SELECT') || normalized.startsWith('WITH'))) {
+    throw new Error('attendance setup-readiness query seam rejected a non-SELECT/WITH statement')
+  }
+}
+
+export function createReadOnlyReadinessSeam(
+  runQuery: AttendanceSetupReadinessQueryFn = query,
+): AttendanceSetupReadinessQueryFn {
+  // `async` (not a plain arrow returning runQuery's promise) so the guard's synchronous throw
+  // becomes a REJECTED PROMISE — matching `typeof query`'s always-async contract and letting every
+  // caller keep using `await`/`.catch` uniformly instead of needing a try/catch just for the guard.
+  return async (sql, params) => {
+    assertSelectOnlyReadinessSql(sql)
+    return runQuery(sql, params)
+  }
+}
+
+export interface AttendanceSetupReadinessOrgCounts {
+  orgActiveMemberCount: number
+  groupCount: number
+  groupsWithMembers: number
+  shiftCount: number
+  rotationRuleCount: number
+  approvalFlowCount: number
+}
+
+/**
+ * §4.2 single CTE covering every org-scoped count (①②③⑤ + group-membership, OD-W4-6). ④ (settings)
+ * and ⑥ (notify runtime port) are deliberately NOT here — ④ is a deployment-level system_configs
+ * read, ⑥ is a non-DB runtime port; both live in their own functions below.
+ */
+export async function readAttendanceSetupReadinessOrgCounts(
+  orgId: string,
+  runQuery: AttendanceSetupReadinessQueryFn,
+): Promise<AttendanceSetupReadinessOrgCounts> {
+  const result = await runQuery<{
+    org_active_member_count: number
+    group_count: number
+    groups_with_members: number
+    shift_count: number
+    rotation_rule_count: number
+    approval_flow_count: number
+  }>(
+    `WITH member_scope AS (
+       SELECT COUNT(*)::int AS org_active_member_count
+         FROM user_orgs
+        WHERE org_id = $1 AND is_active = true
+     ),
+     group_member_counts AS (
+       SELECT group_id, COUNT(*)::int AS member_count
+         FROM attendance_group_members
+        WHERE org_id = $1
+        GROUP BY group_id
+     ),
+     group_scope AS (
+       SELECT COUNT(*)::int AS group_count,
+              COUNT(*) FILTER (WHERE COALESCE(gmc.member_count, 0) > 0)::int AS groups_with_members
+         FROM attendance_groups g
+         LEFT JOIN group_member_counts gmc ON gmc.group_id = g.id
+        WHERE g.org_id = $1
+     ),
+     shift_scope AS (
+       SELECT COUNT(*)::int AS shift_count
+         FROM attendance_shifts
+        WHERE org_id = $1
+     ),
+     rotation_scope AS (
+       SELECT COUNT(*)::int AS rotation_rule_count
+         FROM attendance_rotation_rules
+        WHERE org_id = $1
+     ),
+     approval_scope AS (
+       SELECT COUNT(*)::int AS approval_flow_count
+         FROM attendance_approval_flows
+        WHERE org_id = $1 AND is_active = true
+     )
+     SELECT member_scope.org_active_member_count,
+            group_scope.group_count,
+            group_scope.groups_with_members,
+            shift_scope.shift_count,
+            rotation_scope.rotation_rule_count,
+            approval_scope.approval_flow_count
+       FROM member_scope, group_scope, shift_scope, rotation_scope, approval_scope`,
+    [orgId],
+  )
+  const row = result.rows[0]
+  return {
+    orgActiveMemberCount: Number(row?.org_active_member_count ?? 0),
+    groupCount: Number(row?.group_count ?? 0),
+    groupsWithMembers: Number(row?.groups_with_members ?? 0),
+    shiftCount: Number(row?.shift_count ?? 0),
+    rotationRuleCount: Number(row?.rotation_rule_count ?? 0),
+    approvalFlowCount: Number(row?.approval_flow_count ?? 0),
+  }
+}
+
+const ATTENDANCE_SETTINGS_KEY = 'attendance.settings'
+
+export type AttendancePunchPolicyPosture = 'default' | 'customized' | 'unknown'
+
+// Mirrors plugins/plugin-attendance/index.cjs DEFAULT_SETTINGS.punchPolicy (~L291-345; SETTINGS_KEY
+// 'attendance.settings' is a single DEPLOYMENT-WIDE key — round-1 P2-2). Core-backend has no
+// sanctioned import of plugin internals (plugin -> core-backend is the only wired dependency
+// direction, e.g. the attendanceScheduler/approvalAssigneeResolver ports), so this is a literal,
+// independently pinned mirror of the punchPolicy subtree only — deliberately NOT the whole settings
+// blob, so an unrelated customization elsewhere (e.g. holiday sync years) can never mislabel step ④.
+const ATTENDANCE_DEFAULT_PUNCH_POLICY_MIRROR = {
+  unscheduledMode: 'allow',
+  mergeInternalWinsOnIn: false,
+  mergeExternalWinsOnOut: false,
+  outdoorRequireApproval: false,
+  outdoorRequireNote: false,
+  outdoorRequirePhoto: false,
+  outdoorApprovalFlowId: '',
+} as const
+
+function isDefaultAttendancePunchPolicy(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  const unscheduled = (v.unscheduled ?? {}) as Record<string, unknown>
+  const merge = (v.merge ?? {}) as Record<string, unknown>
+  const outdoor = (v.outdoor ?? {}) as Record<string, unknown>
+  const d = ATTENDANCE_DEFAULT_PUNCH_POLICY_MIRROR
+  return (
+    unscheduled.mode === d.unscheduledMode &&
+    merge.internalWinsOnIn === d.mergeInternalWinsOnIn &&
+    merge.externalWinsOnOut === d.mergeExternalWinsOnOut &&
+    outdoor.requireApproval === d.outdoorRequireApproval &&
+    outdoor.requireNote === d.outdoorRequireNote &&
+    outdoor.requirePhoto === d.outdoorRequirePhoto &&
+    (outdoor.approvalFlowId ?? '') === d.outdoorApprovalFlowId
+  )
+}
+
+/**
+ * §3④ / OD-W4-4=(c): back-end internal semantic check against normalized defaults. The FRONT END
+ * never sees `attendance.settings` values — only this values-free posture enum (round-3 P3).
+ * `default` and `customized` are both `ready` at the discriminator layer (round-3 (b): the platform
+ * default is a legitimate, usable policy); only `unknown` fails closed.
+ */
+export async function readAttendancePunchPolicyPosture(
+  runQuery: AttendanceSetupReadinessQueryFn,
+): Promise<AttendancePunchPolicyPosture> {
+  try {
+    const result = await runQuery<{ value: string }>(
+      'SELECT value FROM system_configs WHERE key = $1',
+      [ATTENDANCE_SETTINGS_KEY],
+    )
+    const raw = result.rows[0]?.value
+    if (raw === undefined || raw === null) {
+      // No row at all: the platform default is in force (never explicitly saved).
+      return 'default'
+    }
+    const parsed = JSON.parse(String(raw)) as Record<string, unknown>
+    if (!parsed || typeof parsed !== 'object' || !('punchPolicy' in parsed)) {
+      // A row exists but carries no punchPolicy subtree (pre-S0 shape / corrupted write) — cannot
+      // honestly claim default or customized.
+      return 'unknown'
+    }
+    return isDefaultAttendancePunchPolicy(parsed.punchPolicy) ? 'default' : 'customized'
+  } catch {
+    return 'unknown'
+  }
+}
+
+export interface AttendanceSetupReadinessNotifyPort {
+  workerEnabled: boolean | 'unknown'
+  defaultChannelAvailable: boolean | 'unknown'
+  availableChannelCount: number | 'unknown'
+  orgRecipientBindingReady: boolean | 'unknown'
+}
+
+const ATTENDANCE_NOTIFY_PORT_UNKNOWN: AttendanceSetupReadinessNotifyPort = {
+  workerEnabled: 'unknown',
+  defaultChannelAvailable: 'unknown',
+  availableChannelCount: 'unknown',
+  orgRecipientBindingReady: 'unknown',
+}
+
+/**
+ * §4.5 read-only runtime readiness port (P2-3). Never returns env names, channel names, or
+ * credentials — only booleans/counts. `orgRecipientBindingReady` mirrors the EXACT join
+ * `AttendanceNotificationDeliveryWorker.resolveRecipient` uses to find a bound DingTalk recipient
+ * (org-scoped, values-free EXISTS). If the port itself throws, the WHOLE block fails closed to
+ * `unknown` rather than a partial/misleading signal; if only the org-scoped DB probe fails, that
+ * one field alone goes `unknown` while the pure env-derived fields still resolve.
+ */
+export async function readAttendanceNotifyReadinessPort(
+  orgId: string,
+  runQuery: AttendanceSetupReadinessQueryFn,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<AttendanceSetupReadinessNotifyPort> {
+  try {
+    const workerEnabled = env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED === 'true'
+    const channels = createAttendanceDeliveryChannelsFromEnv(env)
+    const defaultChannelAvailable = channels.some((c) => c.name === DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME)
+    const availableChannelCount = channels.length
+
+    let orgRecipientBindingReady: boolean | 'unknown' = 'unknown'
+    try {
+      const result = await runQuery<{ ready: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1
+             FROM directory_account_links l
+             JOIN directory_accounts a
+               ON a.id = l.directory_account_id
+              AND a.provider = 'dingtalk'
+              AND a.is_active = true
+             JOIN directory_integrations i
+               ON i.id = a.integration_id
+              AND i.provider = 'dingtalk'
+              AND i.status = 'active'
+              AND i.org_id = $1
+            WHERE l.link_status = 'linked'
+            LIMIT 1
+         ) AS ready`,
+        [orgId],
+      )
+      orgRecipientBindingReady = Boolean(result.rows[0]?.ready)
+    } catch {
+      orgRecipientBindingReady = 'unknown'
+    }
+
+    return { workerEnabled, defaultChannelAvailable, availableChannelCount, orgRecipientBindingReady }
+  } catch {
+    return { ...ATTENDANCE_NOTIFY_PORT_UNKNOWN }
+  }
+}
+
+export type AttendanceSetupReadinessEffectiveTimePosture =
+  | 'immediate'
+  | 'scheduled'
+  | 'manual_activation'
+  | 'undeterminable'
+
+export interface AttendanceSetupReadinessEffectiveTime {
+  source: string
+  posture: AttendanceSetupReadinessEffectiveTimePosture
+  effectiveAt?: string
+}
+
+export interface AttendanceSetupReadinessStepMeta {
+  /** Canonical admin-section deep-link id (§6.2) that "去配置/修复" resolves to; 'preview' for ⑦
+   *  (no section — the preview lives inside the wizard itself, read-only). */
+  step: string
+  scope: 'org' | 'deployment'
+  effectiveTime: AttendanceSetupReadinessEffectiveTime
+}
+
+// §3 "计划生效时间" (追加门禁4): each step's authoritative source registered here, once, for the
+// whole W4-0/W4-1/W4-2 lifetime. A step with no app-observable trigger is 'undeterminable' or
+// 'manual_activation' — NEVER guessed as 'immediate' ("不得省略、不得猜测").
+export const ATTENDANCE_SETUP_READINESS_STEP_META: readonly AttendanceSetupReadinessStepMeta[] = [
+  {
+    step: 'attendance-admin-user-access',
+    scope: 'org',
+    effectiveTime: { source: 'user_orgs.is_active', posture: 'immediate' },
+  },
+  {
+    step: 'attendance-admin-groups',
+    scope: 'org',
+    effectiveTime: { source: 'attendance_group_members', posture: 'immediate' },
+  },
+  {
+    step: 'attendance-admin-shifts',
+    scope: 'org',
+    effectiveTime: { source: 'attendance_shifts+attendance_rotation_rules', posture: 'immediate' },
+  },
+  {
+    step: 'attendance-admin-settings',
+    scope: 'deployment',
+    effectiveTime: { source: 'system_configs.attendance_settings', posture: 'immediate' },
+  },
+  {
+    step: 'attendance-admin-approval-flows',
+    scope: 'org',
+    effectiveTime: { source: 'attendance_approval_flows.is_active', posture: 'immediate' },
+  },
+  {
+    step: 'attendance-admin-notification-deliveries',
+    scope: 'deployment',
+    // Channel/worker enablement is operator env/redeploy-controlled — no app-observable schedule.
+    effectiveTime: { source: 'none', posture: 'undeterminable' },
+  },
+  {
+    step: 'preview',
+    scope: 'org',
+    // §3⑦: preview-ready never means "already enabled" — activation is a human action against the
+    // canonical checklist, never an app-triggered event.
+    effectiveTime: { source: 'none', posture: 'manual_activation' },
+  },
+] as const
+
+// §4.2 / 追加门禁2: the deployment-scoped ("global") signals, explicitly enumerated so a contract
+// test can lock this list rather than re-deriving it from prose. Every signal NOT listed here is
+// org-scoped (org_id-anchored).
+export const ATTENDANCE_SETUP_READINESS_DEPLOYMENT_SCOPED_SIGNALS = [
+  'punchPolicyPosture',
+  'notify.workerEnabled',
+  'notify.defaultChannelAvailable',
+  'notify.availableChannelCount',
+] as const
+
+export interface AttendanceSetupReadinessResponse {
+  directoryLinked: boolean
+  orgActiveMemberCount: number
+  groupCount: number
+  groupsWithMembers: number
+  shiftCount: number
+  rotationRuleCount: number
+  hasRotationRules: boolean
+  approvalFlowCount: number
+  punchPolicyPosture: AttendancePunchPolicyPosture
+  notify: AttendanceSetupReadinessNotifyPort
+  perStep: readonly AttendanceSetupReadinessStepMeta[]
+  deploymentScopedSignals: readonly string[]
+}
+
+/**
+ * Owns EVERY aggregation read for the setup-readiness endpoint. The route calls this ONLY after
+ * `canReadAttendanceDirectoryReadiness` has already returned true — so a 403 response path never
+ * reaches this function, and therefore never issues a single aggregation query (OD-W4-1 追加门禁1).
+ */
+export async function buildAttendanceSetupReadiness(
+  orgId: string,
+  runQuery: AttendanceSetupReadinessQueryFn = query,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<AttendanceSetupReadinessResponse> {
+  const seam = createReadOnlyReadinessSeam(runQuery)
+  const [directory, counts, punchPolicyPosture, notify] = await Promise.all([
+    readOrgDirectoryReadiness(orgId, seam),
+    readAttendanceSetupReadinessOrgCounts(orgId, seam),
+    readAttendancePunchPolicyPosture(seam),
+    readAttendanceNotifyReadinessPort(orgId, seam, env),
+  ])
+  return {
+    directoryLinked: directory.hasLinkedDirectoryAccounts,
+    orgActiveMemberCount: counts.orgActiveMemberCount,
+    groupCount: counts.groupCount,
+    groupsWithMembers: counts.groupsWithMembers,
+    shiftCount: counts.shiftCount,
+    rotationRuleCount: counts.rotationRuleCount,
+    hasRotationRules: counts.rotationRuleCount > 0,
+    approvalFlowCount: counts.approvalFlowCount,
+    punchPolicyPosture,
+    notify,
+    perStep: ATTENDANCE_SETUP_READINESS_STEP_META,
+    deploymentScopedSignals: ATTENDANCE_SETUP_READINESS_DEPLOYMENT_SCOPED_SIGNALS,
+  }
+}
+
 export function attendanceAdminRouter(): Router {
   const r = Router()
 
@@ -408,6 +782,36 @@ export function attendanceAdminRouter(): Router {
     } catch (_error) {
       // Values-free seam: never leak raw DB / driver messages to the client.
       return jsonError(res, 500, 'DIRECTORY_READINESS_FAILED', 'Failed to load directory readiness')
+    }
+  })
+
+  // W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED §4.1 OD-W4-1=(a)): seven-step
+  // setup-readiness aggregate. Same org-membership door as S7-5 above (canReadAttendanceDirectoryReadiness,
+  // reused verbatim) — authorization completes BEFORE buildAttendanceSetupReadiness is ever called, so a
+  // foreign-org 403 issues zero aggregation SQL. Response is values-free by construction (§4.2): counts,
+  // enums, and time postures only — never IDs, names, credentials, or raw configuration values.
+  r.get('/api/attendance-admin/setup-readiness', async (req: Request, res: Response) => {
+    try {
+      const orgId = String(req.query.orgId || '').trim()
+      if (!orgId) {
+        return jsonError(res, 400, 'ORG_ID_REQUIRED', 'orgId is required')
+      }
+      const userId = getAttendanceAdminRequestUserId(req)
+      if (!userId) {
+        return jsonError(res, 401, 'UNAUTHENTICATED', 'Authentication required')
+      }
+      const allowed = await canReadAttendanceDirectoryReadiness(req, userId, orgId)
+      if (!allowed) {
+        return jsonError(res, 403, 'FORBIDDEN', 'Org membership required for setup readiness')
+      }
+      const readiness = await buildAttendanceSetupReadiness(orgId)
+      return jsonOk(res, readiness)
+    } catch (error) {
+      if (isDatabaseSchemaError(error)) {
+        return jsonError(res, 503, 'DB_NOT_READY', 'Attendance tables not ready')
+      }
+      // Values-free seam: never leak raw DB / driver messages to the client.
+      return jsonError(res, 500, 'SETUP_READINESS_FAILED', 'Failed to load setup readiness')
     }
   })
 

--- a/packages/core-backend/tests/integration/attendance-setup-readiness-w4-0.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-setup-readiness-w4-0.db.test.ts
@@ -1,0 +1,453 @@
+/**
+ * W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED §9): real-Postgres coverage of
+ * `GET /api/attendance-admin/setup-readiness` — the aggregate the mock-level unit test
+ * (`tests/unit/attendance-admin-setup-readiness-w4-0.test.ts`) already covers exhaustively at the
+ * query-shape level. THIS file's job is the thing a mock cannot prove: that the SQL, run against a
+ * real schema, produces the right org-anchored counts, and that a cross-org forgery is refused
+ * BEFORE any aggregation SQL reaches Postgres (OD-W4-1 追加门禁1).
+ *
+ * Scope boundary (deliberate — read before "fixing" the auth setup):
+ *   The router's COARSE permission gate (`rbacGuard('attendance','admin')`) and the platform-admin
+ *   shortcut (`isRbacAdmin`) are PRE-EXISTING shared middleware, exercised elsewhere. This slice adds
+ *   exactly one new authorization surface: the ORG-MEMBERSHIP door (`canReadAttendanceDirectoryReadiness`
+ *   / `user_orgs`, reused verbatim from S7-5). So — mirroring the mock unit test's own boundary — this
+ *   file mocks `rbacGuard` (bypass) and `isAdmin` (constant false) and keeps `../../src/db/pg`'s `query`
+ *   REAL (wrapped in `vi.fn(actual.query)` so every call still hits Postgres, and `.mock.calls` gives us
+ *   the exact SQL text and count for the "zero aggregation SQL before 403" proof). A `req.user = { id }`
+ *   with no admin claims is therefore a faithful "org A's delegated attendance admin" — real DB
+ *   membership in `user_orgs` is what separates a 200 from a 403, exactly as in production.
+ *
+ * Proves:
+ *   A. Two-org forgery matrix (OD-W4-1 追加门禁1): an admin who is an active member of org A, but NOT
+ *      of org B, requesting `orgId=orgB` gets 403 FORBIDDEN — and the query spy shows EXACTLY ONE query
+ *      fired (the `user_orgs` membership door), never any of the aggregation tables.
+ *   B. Positive control (the same admin, own org): every org-scoped signal is asserted to its exact
+ *      seeded value — orgActiveMemberCount (is_active filter proven with a seeded inactive row),
+ *      groupCount vs groupsWithMembers (OD-W4-6 split), shiftCount, rotationRuleCount/hasRotationRules,
+ *      approvalFlowCount (is_active filter), directoryLinked, notify.orgRecipientBindingReady.
+ *   C. Empty org: a member with zero seeded resources sees every org-scoped signal at 0/false.
+ *   D. Org-anchor SQL audit against the REAL query text: the org-counts CTE contains `org_id = $1`
+ *      exactly six times, a single positional param, and no PII/identifying columns (mirrors the unit
+ *      test's assertion, now against Postgres's own EXPLAIN-able SQL rather than a mock).
+ *   E. ④ punch-policy posture (OD-W4-4=(c)) against the REAL deployment-wide `system_configs` row —
+ *      snapshotted and restored around a tight critical section so this file never permanently mutates
+ *      the shared global key other attendance integration files also touch.
+ *   F. §4.5 notify port: env-derived fields resolve from real env vars; the org-recipient-binding
+ *      EXISTS query is asserted to be org-anchored.
+ *
+ * Deliberately deferred to the existing mock unit test (already covers it — see PR body): the
+ * "missing table → 503 DB_NOT_READY" leg. Constructing a genuinely broken schema against the shared
+ * CI Postgres would require an isolated schema/DB for one leg that's already exhaustively proven at
+ * the mock level (`isDatabaseSchemaError` is a pure function of the driver error shape, not of
+ * anything DB-specific), so the added real-DB complexity would not buy new confidence.
+ *
+ * Shared-DB fixture discipline: every fixture (org id, user id, corp id, resource name) is prefixed
+ * `w40_<run>_` (a per-file-invocation-unique run suffix) — never a bare `Date.now()` — because
+ * `plugin-tests.yml`'s attendance step runs many `.db.test.ts` files against ONE shared Postgres.
+ * `vitest.integration.config.ts` also pins `fileParallelism: false` / `maxConcurrency: 1`, so files
+ * never race each other; the prefix discipline still stands as defense-in-depth and for local re-runs.
+ */
+import express from 'express'
+import request from 'supertest'
+import { randomUUID } from 'crypto'
+import { Pool } from 'pg'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { usePinnedServer } from '../utils/pinned-server'
+
+// Bypass the coarse, pre-existing RBAC gate — out of scope for this slice (see header). Keep the
+// factory shape identical to the mock unit test so both files assert the exact same boundary.
+vi.mock('../../src/rbac/rbac', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/rbac')>()
+  return {
+    ...actual,
+    rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  }
+})
+vi.mock('../../src/rbac/service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/service')>()
+  return {
+    ...actual,
+    isAdmin: vi.fn(async () => false),
+  }
+})
+
+// Real Postgres, spy-WRAPPED (not replaced): `vi.fn(actual.query)` still calls through to the real
+// `poolManager` query implementation, so every assertion below is against real Postgres — the wrapper
+// only gives `.mock.calls` visibility for the "zero aggregation SQL before 403" proof (§9 追加门禁1)
+// and the org-anchor SQL-text audit (§4.2). This is the SAME technique the mock unit test would need
+// if it wanted real-DB coverage — `vi.mock` with `importOriginal` is required here (not a bare
+// `vi.spyOn(pgModule, 'query')`) because Vitest's ESM interop makes named exports non-configurable for
+// direct property-level spying; replacing the whole module via the mock registry is what lets every
+// importer (this file AND attendance-admin.ts) resolve to the same wrapped function.
+vi.mock('../../src/db/pg', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/db/pg')>()
+  return { ...actual, query: vi.fn(actual.query) }
+})
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+const { attendanceAdminRouter } = await import('../../src/routes/attendance-admin')
+const { query: mockedQuery } = await import('../../src/db/pg')
+const queryMock = mockedQuery as unknown as ReturnType<typeof vi.fn>
+
+const RUN = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
+const PFX = `w40_${RUN}`
+const SETTINGS_KEY = 'attendance.settings'
+
+const ORG_A = `${PFX}_org_a`
+const ORG_B = `${PFX}_org_b`
+const ORG_EMPTY = `${PFX}_org_empty`
+
+const ADMIN_ID = `${PFX}_admin`
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    ;(req as express.Request & { user?: unknown }).user = user ?? undefined
+    next()
+  })
+  app.use(attendanceAdminRouter())
+  return app
+}
+
+describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', () => {
+  const pool = new Pool({ connectionString: dbUrl })
+  const pinned = usePinnedServer()
+
+  const integrationIds: string[] = []
+  let originalSettingsRow: { value: string } | null | undefined
+  let originalEnv: Record<string, string | undefined> = {}
+
+  const NOTIFY_ENV_KEYS = [
+    'ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED',
+    'ATTENDANCE_NOTIFICATION_DINGTALK_WORK_NOTIFICATION_ENABLED',
+    'ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED',
+  ]
+
+  async function seedGroup(orgId: string, name: string): Promise<string> {
+    const r = await pool.query<{ id: string }>(
+      `INSERT INTO attendance_groups (org_id, name) VALUES ($1, $2) RETURNING id`,
+      [orgId, name],
+    )
+    return r.rows[0].id
+  }
+  async function seedGroupMember(orgId: string, groupId: string, userId: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO attendance_group_members (org_id, group_id, user_id) VALUES ($1, $2, $3)`,
+      [orgId, groupId, userId],
+    )
+  }
+  async function seedShift(orgId: string, name: string): Promise<string> {
+    const r = await pool.query<{ id: string }>(
+      `INSERT INTO attendance_shifts (org_id, name) VALUES ($1, $2) RETURNING id`,
+      [orgId, name],
+    )
+    return r.rows[0].id
+  }
+  async function seedRotationRule(orgId: string, name: string): Promise<string> {
+    const r = await pool.query<{ id: string }>(
+      `INSERT INTO attendance_rotation_rules (org_id, name) VALUES ($1, $2) RETURNING id`,
+      [orgId, name],
+    )
+    return r.rows[0].id
+  }
+  async function seedApprovalFlow(orgId: string, name: string, requestType: string, isActive: boolean): Promise<string> {
+    const id = randomUUID()
+    await pool.query(
+      `INSERT INTO attendance_approval_flows (id, org_id, name, request_type, steps, is_active)
+       VALUES ($1, $2, $3, $4, '[]'::jsonb, $5)`,
+      [id, orgId, name, requestType, isActive],
+    )
+    return id
+  }
+  async function seedDingtalkIntegration(orgId: string, name: string, corpId: string, status = 'active'): Promise<string> {
+    const r = await pool.query<{ id: string }>(
+      `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id)
+       VALUES ($1, 'dingtalk', $2, $3, $4) RETURNING id`,
+      [orgId, name, status, corpId],
+    )
+    integrationIds.push(r.rows[0].id)
+    return r.rows[0].id
+  }
+  async function seedDingtalkAccount(integrationId: string, externalUserId: string, externalKey: string, name: string): Promise<string> {
+    const r = await pool.query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, is_active)
+       VALUES ($1, 'dingtalk', $2, $3, $4, true) RETURNING id`,
+      [integrationId, externalUserId, externalKey, name],
+    )
+    return r.rows[0].id
+  }
+  async function linkAccount(accountId: string, linkStatus: 'linked' | 'pending' = 'linked'): Promise<void> {
+    // local_user_id intentionally NULL — the readiness queries (S7-5 reuse + §4.5 port) never filter
+    // on it, and leaving it unset avoids needing a real `users` row for a directory_account_links FK.
+    await pool.query(
+      `INSERT INTO directory_account_links (directory_account_id, link_status, match_strategy)
+       VALUES ($1, $2, 'manual')`,
+      [accountId, linkStatus],
+    )
+  }
+  async function seedMembership(orgId: string, userId: string, isActive = true): Promise<void> {
+    await pool.query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, $3)
+       ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = EXCLUDED.is_active`,
+      [userId, orgId, isActive],
+    )
+  }
+
+  async function snapshotSettings(): Promise<void> {
+    const r = await pool.query<{ value: string }>(`SELECT value FROM system_configs WHERE key = $1`, [SETTINGS_KEY])
+    originalSettingsRow = r.rows[0] ? { value: r.rows[0].value } : null
+  }
+  async function restoreSettings(): Promise<void> {
+    if (originalSettingsRow === undefined) return
+    if (originalSettingsRow === null) {
+      await pool.query(`DELETE FROM system_configs WHERE key = $1`, [SETTINGS_KEY])
+    } else {
+      await pool.query(
+        `INSERT INTO system_configs (key, value) VALUES ($1, $2)
+         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+        [SETTINGS_KEY, originalSettingsRow.value],
+      )
+    }
+  }
+  async function deleteSettingsRow(): Promise<void> {
+    await pool.query(`DELETE FROM system_configs WHERE key = $1`, [SETTINGS_KEY])
+  }
+  async function writeSettingsPunchPolicy(punchPolicy: Record<string, unknown>): Promise<void> {
+    await pool.query(
+      `INSERT INTO system_configs (key, value) VALUES ($1, $2)
+       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+      [SETTINGS_KEY, JSON.stringify({ punchPolicy })],
+    )
+  }
+
+  beforeAll(async () => {
+    await snapshotSettings()
+    for (const key of NOTIFY_ENV_KEYS) originalEnv[key] = process.env[key]
+
+    // --- org A: the rich positive-control fixture ---
+    await seedMembership(ORG_A, ADMIN_ID, true)
+    await seedMembership(ORG_A, `${PFX}_member_2`, true)
+    await seedMembership(ORG_A, `${PFX}_member_3`, true)
+    await seedMembership(ORG_A, `${PFX}_member_inactive`, false) // proves the is_active filter
+
+    const groupWithMembers = await seedGroup(ORG_A, `${PFX} group with members`)
+    await seedGroup(ORG_A, `${PFX} group without members`) // proves groupCount !== groupsWithMembers
+    await seedGroupMember(ORG_A, groupWithMembers, `${PFX}_member_2`)
+    await seedGroupMember(ORG_A, groupWithMembers, `${PFX}_member_3`)
+
+    await seedShift(ORG_A, `${PFX} shift AM`)
+    await seedShift(ORG_A, `${PFX} shift PM`)
+
+    await seedRotationRule(ORG_A, `${PFX} rotation`)
+
+    await seedApprovalFlow(ORG_A, `${PFX} leave flow active`, 'leave', true)
+    await seedApprovalFlow(ORG_A, `${PFX} leave flow inactive`, 'overtime', false) // proves is_active filter
+
+    const orgAIntegration = await seedDingtalkIntegration(ORG_A, `${PFX} DT org A`, `${PFX}-corp-a`)
+    const orgAAccount = await seedDingtalkAccount(orgAIntegration, `${PFX}-ext-a`, `${PFX}-key-a`, `${PFX} account A`)
+    await linkAccount(orgAAccount, 'linked')
+
+    // --- org B: forgery TARGET — the admin is deliberately NOT a member ---
+    await seedMembership(ORG_B, `${PFX}_org_b_owner`, true) // someone else's org, never our admin
+    const orgBGroup = await seedGroup(ORG_B, `${PFX} org B group`)
+    await seedGroupMember(ORG_B, orgBGroup, `${PFX}_org_b_owner`)
+    await seedShift(ORG_B, `${PFX} org B shift`)
+
+    // --- org empty: membership only, zero of everything else ---
+    await seedMembership(ORG_EMPTY, ADMIN_ID, true)
+  }, 30000)
+
+  afterAll(async () => {
+    await restoreSettings()
+    for (const key of NOTIFY_ENV_KEYS) {
+      if (originalEnv[key] === undefined) delete process.env[key]
+      else process.env[key] = originalEnv[key]
+    }
+    for (const id of integrationIds) {
+      await pool.query(`DELETE FROM directory_integrations WHERE id = $1`, [id]) // cascades accounts/links
+    }
+    await pool.query(`DELETE FROM attendance_approval_flows WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_rotation_rules WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_shifts WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_group_members WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_groups WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM user_orgs WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.end()
+  })
+
+  it('sentinel: DATABASE_URL is set (real-DB lane must not silently skip)', () => {
+    expect(dbUrl).toBeTruthy()
+  })
+
+  it('A. cross-org forgery: org-A admin requesting orgId=B gets 403 and issues EXACTLY ONE query (the user_orgs door) — zero aggregation SQL', async () => {
+    queryMock.mockClear()
+    const app = makeApp({ id: ADMIN_ID })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_B)}`)
+
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('FORBIDDEN')
+
+    const calls = queryMock.mock.calls as [string, unknown[]?][]
+    expect(calls).toHaveLength(1)
+    expect(calls[0][0]).toMatch(/user_orgs/i)
+    expect(calls[0][1]).toEqual([ADMIN_ID, ORG_B])
+
+    // Belt-and-suspenders: none of the aggregation tables ever appear in ANY captured SQL.
+    const aggregationTables = [
+      'attendance_groups', 'attendance_group_members', 'attendance_shifts',
+      'attendance_rotation_rules', 'attendance_approval_flows', 'system_configs',
+      'directory_account_links', 'directory_accounts', 'directory_integrations',
+    ]
+    for (const [sql] of calls) {
+      for (const table of aggregationTables) {
+        expect(sql).not.toMatch(new RegExp(table, 'i'))
+      }
+    }
+  })
+
+  it('B. positive control: org-A admin gets 200 with every org-scoped signal at its exact seeded value', async () => {
+    queryMock.mockClear()
+    const app = makeApp({ id: ADMIN_ID })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_A)}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    const data = res.body.data
+
+    expect(data.orgActiveMemberCount).toBe(3) // ADMIN_ID + member_2 + member_3 (inactive row excluded)
+    expect(data.groupCount).toBe(2)
+    expect(data.groupsWithMembers).toBe(1)
+    expect(data.shiftCount).toBe(2)
+    expect(data.rotationRuleCount).toBe(1)
+    expect(data.hasRotationRules).toBe(true)
+    expect(data.approvalFlowCount).toBe(1) // one active, one inactive seeded
+    expect(data.directoryLinked).toBe(true)
+    expect(data.notify.orgRecipientBindingReady).toBe(true)
+
+    // Exact response key-set lock (§4.2), proven against a REAL response, not just the mock unit test.
+    expect(Object.keys(data).sort()).toEqual(
+      [
+        'approvalFlowCount', 'deploymentScopedSignals', 'directoryLinked', 'groupCount',
+        'groupsWithMembers', 'hasRotationRules', 'notify', 'orgActiveMemberCount', 'perStep',
+        'punchPolicyPosture', 'rotationRuleCount', 'shiftCount',
+      ].sort(),
+    )
+
+    // Values-free: no PII/identifying text anywhere in the real response payload.
+    const flat = JSON.stringify(data)
+    expect(flat).not.toMatch(/email|phone|mobile|password|secret|token/i)
+    expect(flat).not.toContain(ADMIN_ID)
+    expect(flat).not.toContain(`${PFX}-ext-a`)
+  })
+
+  it('C. empty org: a bare member sees every org-scoped signal at 0/false', async () => {
+    const app = makeApp({ id: ADMIN_ID })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_EMPTY)}`)
+
+    expect(res.status).toBe(200)
+    const data = res.body.data
+    expect(data.orgActiveMemberCount).toBe(1) // only ADMIN_ID itself
+    expect(data.groupCount).toBe(0)
+    expect(data.groupsWithMembers).toBe(0)
+    expect(data.shiftCount).toBe(0)
+    expect(data.rotationRuleCount).toBe(0)
+    expect(data.hasRotationRules).toBe(false)
+    expect(data.approvalFlowCount).toBe(0)
+    expect(data.directoryLinked).toBe(false)
+    expect(data.notify.orgRecipientBindingReady).toBe(false)
+  })
+
+  it('D. org-anchor SQL audit: the real org-counts CTE anchors org_id = $1 exactly six times, single param, no PII columns', async () => {
+    queryMock.mockClear()
+    const app = makeApp({ id: ADMIN_ID })
+    pinned.setApp(app)
+    await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_A)}`)
+
+    const calls = queryMock.mock.calls as [string, unknown[]?][]
+    const ctecall = calls.find(([sql]) => /WITH member_scope/i.test(sql))
+    expect(ctecall).toBeTruthy()
+    const [sql, params] = ctecall as [string, unknown[]]
+    expect(params).toEqual([ORG_A])
+    const orgAnchorMatches = sql.match(/org_id\s*=\s*\$1/g) ?? []
+    expect(orgAnchorMatches.length).toBe(6)
+    expect(sql).not.toMatch(/\$2\b/)
+    expect(sql).not.toMatch(/email|phone|mobile|external_user_id|display_name|full_name/i)
+  })
+
+  it('E. ④ punch-policy posture against the real deployment-wide system_configs row (snapshot + restore)', async () => {
+    try {
+      // No row at all → 'default' (round-3 (b): the platform default is a legitimate ready state).
+      await deleteSettingsRow()
+      let app = makeApp({ id: ADMIN_ID })
+      pinned.setApp(app)
+      let res = await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_A)}`)
+      expect(res.body.data.punchPolicyPosture).toBe('default')
+
+      // A row exists but matches the normalized defaults exactly → still 'default'.
+      await writeSettingsPunchPolicy({
+        unscheduled: { mode: 'allow' },
+        merge: { internalWinsOnIn: false, externalWinsOnOut: false },
+        outdoor: { requireApproval: false, requireNote: false, requirePhoto: false, approvalFlowId: '' },
+      })
+      app = makeApp({ id: ADMIN_ID })
+      pinned.setApp(app)
+      res = await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_A)}`)
+      expect(res.body.data.punchPolicyPosture).toBe('default')
+
+      // A row diverges from the defaults → 'customized' (round-3 (b): also 'ready' at the discriminator
+      // layer, but a DISTINCT posture value — the FE never sees the settings VALUES, only this enum).
+      await writeSettingsPunchPolicy({
+        unscheduled: { mode: 'block' },
+        merge: { internalWinsOnIn: false, externalWinsOnOut: false },
+        outdoor: { requireApproval: false, requireNote: false, requirePhoto: false, approvalFlowId: '' },
+      })
+      app = makeApp({ id: ADMIN_ID })
+      pinned.setApp(app)
+      res = await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_A)}`)
+      expect(res.body.data.punchPolicyPosture).toBe('customized')
+
+      // Values-free: the customized punch-policy VALUE ('block') never appears in the response.
+      expect(JSON.stringify(res.body.data)).not.toContain('block')
+    } finally {
+      await restoreSettings()
+    }
+  })
+
+  it('F. §4.5 notify port: env-derived fields resolve live, org-recipient-binding query is org-anchored', async () => {
+    queryMock.mockClear()
+    process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED = 'true'
+    process.env.ATTENDANCE_NOTIFICATION_DINGTALK_WORK_NOTIFICATION_ENABLED = 'true'
+    delete process.env.ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED
+    try {
+      const app = makeApp({ id: ADMIN_ID })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_A)}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.notify).toEqual({
+        workerEnabled: true,
+        defaultChannelAvailable: true,
+        availableChannelCount: 1,
+        orgRecipientBindingReady: true,
+      })
+
+      const calls = queryMock.mock.calls as [string, unknown[]?][]
+      const notifyCall = calls.find(([sql]) => /directory_account_links/i.test(sql) && /provider = 'dingtalk'/i.test(sql))
+      expect(notifyCall).toBeTruthy()
+      const [sql, params] = notifyCall as [string, unknown[]]
+      expect(params).toEqual([ORG_A])
+      expect(sql).toMatch(/org_id\s*=\s*\$1/)
+      expect(sql).not.toMatch(/env|channel_name|credential|secret|token/i)
+    } finally {
+      for (const key of NOTIFY_ENV_KEYS) {
+        if (originalEnv[key] === undefined) delete process.env[key]
+        else process.env[key] = originalEnv[key]
+      }
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-admin-setup-readiness-w4-0.test.ts
+++ b/packages/core-backend/tests/unit/attendance-admin-setup-readiness-w4-0.test.ts
@@ -1,0 +1,516 @@
+/**
+ * W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED): unit coverage for the
+ * `GET /api/attendance-admin/setup-readiness` seven-step aggregate.
+ *
+ * Proves:
+ *  - §9 追加门禁3: the query seam (`assertSelectOnlyReadinessSql` / `createReadOnlyReadinessSeam`)
+ *    accepts SELECT/WITH and rejects everything else BEFORE any I/O.
+ *  - §4.2 org-scoped counts: single CTE, every branch anchored by `org_id = $1` (six occurrences,
+ *    never a second param), values-free (no identifying columns).
+ *  - §3④ / OD-W4-4=(c): `punchPolicyPosture` is a back-end-only semantic comparison against the
+ *    normalized punchPolicy defaults — default / customized / unknown, never leaking settings values.
+ *  - §4.5 notify readiness port: env-derived fields resolve independently of the org-scoped DB
+ *    probe; a DB failure narrows to `orgRecipientBindingReady: 'unknown'` alone, while a port-level
+ *    failure collapses the WHOLE notify block to `unknown`.
+ *  - OD-W4-1 追加门禁1: authorization (`canReadAttendanceDirectoryReadiness`, reused from S7-5) runs
+ *    BEFORE `buildAttendanceSetupReadiness` — a foreign-org 403 issues ZERO aggregation queries.
+ *  - Route status-code matrix (400/401/403/503/500/200) + exact response key-set lock +
+ *    deployment-scoped signal registry + per-step effectiveTime registration.
+ *
+ * Mutation evidence (load-bearing; see PR body for the executed record):
+ *  - drop the seam's SELECT/WITH guard → the seam-rejects-UPDATE test reds.
+ *  - drop any `org_id = $1` filter in the CTE → the org-anchor count assertion reds.
+ *  - call buildAttendanceSetupReadiness before the authz check → the "403 issues zero aggregation
+ *    SQL" assertion reds.
+ */
+import express from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePinnedServer } from '../utils/pinned-server'
+
+const queryMock = vi.fn()
+
+vi.mock('../../src/db/pg', () => ({
+  query: (...args: unknown[]) => queryMock(...args),
+  pool: { query: (...args: unknown[]) => queryMock(...args) },
+}))
+
+vi.mock('../../src/rbac/rbac', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/rbac')>()
+  return {
+    ...actual,
+    rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  }
+})
+
+vi.mock('../../src/rbac/service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/service')>()
+  return {
+    ...actual,
+    isAdmin: vi.fn(async (userId: string) => userId === 'platform-admin'),
+    listUserPermissions: vi.fn(async () => []),
+  }
+})
+
+vi.mock('../../src/routes/admin-users', () => ({
+  ensurePlatformAdmin: vi.fn(async () => null),
+}))
+
+vi.mock('../../src/services/AttendanceNotificationRedelivery', () => ({
+  redeliverFailedAttendanceNotification: vi.fn(),
+}))
+
+vi.mock('../../src/services/ApprovalDirectoryOrg', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/services/ApprovalDirectoryOrg')>()
+  return {
+    ...actual,
+    MAX_MANAGER_CHAIN_LEVELS: 10,
+  }
+})
+
+vi.mock('../../src/services/AttendanceNotificationDeliveryWorker', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/services/AttendanceNotificationDeliveryWorker')>()
+  return {
+    ...actual,
+    createAttendanceDeliveryChannelsFromEnv: vi.fn(actual.createAttendanceDeliveryChannelsFromEnv),
+  }
+})
+
+const {
+  attendanceAdminRouter,
+  assertSelectOnlyReadinessSql,
+  createReadOnlyReadinessSeam,
+  readAttendanceSetupReadinessOrgCounts,
+  readAttendancePunchPolicyPosture,
+  readAttendanceNotifyReadinessPort,
+  buildAttendanceSetupReadiness,
+  ATTENDANCE_SETUP_READINESS_STEP_META,
+  ATTENDANCE_SETUP_READINESS_DEPLOYMENT_SCOPED_SIGNALS,
+} = await import('../../src/routes/attendance-admin')
+const { createAttendanceDeliveryChannelsFromEnv } = await import(
+  '../../src/services/AttendanceNotificationDeliveryWorker'
+)
+const pinned = usePinnedServer()
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    ;(req as express.Request & { user?: unknown }).user = user ?? undefined
+    next()
+  })
+  app.use(attendanceAdminRouter())
+  return app
+}
+
+describe('assertSelectOnlyReadinessSql / createReadOnlyReadinessSeam (§9 追加门禁3)', () => {
+  it('accepts SELECT and WITH statements', () => {
+    expect(() => assertSelectOnlyReadinessSql('SELECT 1')).not.toThrow()
+    expect(() => assertSelectOnlyReadinessSql('  select COUNT(*) FROM t')).not.toThrow()
+    expect(() => assertSelectOnlyReadinessSql('WITH x AS (SELECT 1) SELECT * FROM x')).not.toThrow()
+  })
+
+  it('rejects UPDATE/INSERT/DELETE — mutation target for R1', () => {
+    expect(() => assertSelectOnlyReadinessSql('UPDATE t SET x = 1')).toThrow(/SELECT\/WITH/)
+    expect(() => assertSelectOnlyReadinessSql('INSERT INTO t VALUES (1)')).toThrow(/SELECT\/WITH/)
+    expect(() => assertSelectOnlyReadinessSql('DELETE FROM t')).toThrow(/SELECT\/WITH/)
+  })
+
+  it('seam calls through to the underlying runner for SELECT and never for a write statement', async () => {
+    const inner = vi.fn(async () => ({ rows: [] }))
+    const seam = createReadOnlyReadinessSeam(inner as never)
+    await seam('SELECT 1', [])
+    expect(inner).toHaveBeenCalledTimes(1)
+
+    await expect(seam('UPDATE t SET x = 1', [])).rejects.toThrow(/SELECT\/WITH/)
+    // Mutation evidence: the guard rejects BEFORE any I/O — inner must still be called exactly once.
+    expect(inner).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('readAttendanceSetupReadinessOrgCounts (single CTE, org-anchored, values-free)', () => {
+  beforeEach(() => {
+    queryMock.mockReset()
+  })
+
+  it('issues exactly one query, org_id = $1 six times, never a second param, no identifying columns', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          org_active_member_count: 3,
+          group_count: 2,
+          groups_with_members: 1,
+          shift_count: 4,
+          rotation_rule_count: 0,
+          approval_flow_count: 1,
+        },
+      ],
+    })
+    const result = await readAttendanceSetupReadinessOrgCounts('org-a', queryMock as never)
+    expect(result).toEqual({
+      orgActiveMemberCount: 3,
+      groupCount: 2,
+      groupsWithMembers: 1,
+      shiftCount: 4,
+      rotationRuleCount: 0,
+      approvalFlowCount: 1,
+    })
+    expect(queryMock).toHaveBeenCalledTimes(1)
+    const [sql, params] = queryMock.mock.calls[0] as [string, unknown[]]
+    expect(params).toEqual(['org-a'])
+    const orgAnchorMatches = sql.match(/org_id\s*=\s*\$1/g) ?? []
+    expect(orgAnchorMatches.length).toBe(6)
+    expect(sql).not.toMatch(/\$2\b/)
+    expect(sql).toMatch(/WITH /i)
+    expect(sql).not.toMatch(/email|phone|mobile|external_user_id|display_name|full_name/i)
+  })
+
+  it('defaults every count to 0 on an empty row', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{}] })
+    const result = await readAttendanceSetupReadinessOrgCounts('org-empty', queryMock as never)
+    expect(result).toEqual({
+      orgActiveMemberCount: 0,
+      groupCount: 0,
+      groupsWithMembers: 0,
+      shiftCount: 0,
+      rotationRuleCount: 0,
+      approvalFlowCount: 0,
+    })
+  })
+})
+
+describe('readAttendancePunchPolicyPosture (§3④ / OD-W4-4=(c), values-free)', () => {
+  beforeEach(() => {
+    queryMock.mockReset()
+  })
+
+  it('returns default when no settings row exists', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] })
+    await expect(readAttendancePunchPolicyPosture(queryMock as never)).resolves.toBe('default')
+  })
+
+  it('returns default when the persisted punchPolicy subtree matches the normalized defaults', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          value: JSON.stringify({
+            punchPolicy: {
+              unscheduled: { mode: 'allow' },
+              merge: { internalWinsOnIn: false, externalWinsOnOut: false },
+              outdoor: { requireApproval: false, requireNote: false, requirePhoto: false, approvalFlowId: '' },
+            },
+          }),
+        },
+      ],
+    })
+    await expect(readAttendancePunchPolicyPosture(queryMock as never)).resolves.toBe('default')
+  })
+
+  it('returns customized when the punchPolicy subtree diverges from defaults', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          value: JSON.stringify({
+            punchPolicy: {
+              unscheduled: { mode: 'block' },
+              merge: { internalWinsOnIn: false, externalWinsOnOut: false },
+              outdoor: { requireApproval: false, requireNote: false, requirePhoto: false, approvalFlowId: '' },
+            },
+          }),
+        },
+      ],
+    })
+    await expect(readAttendancePunchPolicyPosture(queryMock as never)).resolves.toBe('customized')
+  })
+
+  it('returns unknown when the row exists but has no punchPolicy subtree at all', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ value: JSON.stringify({ holidayPolicy: {} }) }] })
+    await expect(readAttendancePunchPolicyPosture(queryMock as never)).resolves.toBe('unknown')
+  })
+
+  it('returns unknown on a malformed/unparsable row rather than throwing', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ value: 'not-json' }] })
+    await expect(readAttendancePunchPolicyPosture(queryMock as never)).resolves.toBe('unknown')
+  })
+
+  it('returns unknown on a DB error (fail-closed)', async () => {
+    queryMock.mockRejectedValueOnce(new Error('relation "system_configs" does not exist'))
+    await expect(readAttendancePunchPolicyPosture(queryMock as never)).resolves.toBe('unknown')
+  })
+
+  it('the query never selects columns other than value, and is not org-scoped (deployment-wide key)', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] })
+    await readAttendancePunchPolicyPosture(queryMock as never)
+    const [sql, params] = queryMock.mock.calls[0] as [string, unknown[]]
+    expect(sql).toMatch(/SELECT value FROM system_configs WHERE key = \$1/)
+    expect(params).toEqual(['attendance.settings'])
+  })
+})
+
+describe('readAttendanceNotifyReadinessPort (§4.5, values-free, port-missing fails whole block closed)', () => {
+  beforeEach(() => {
+    queryMock.mockReset()
+    vi.mocked(createAttendanceDeliveryChannelsFromEnv).mockClear()
+  })
+
+  it('worker enabled + dingtalk channel registered + org has a bound recipient', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ ready: true }] })
+    const env = { ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED: 'true', ATTENDANCE_NOTIFICATION_DINGTALK_WORK_NOTIFICATION_ENABLED: 'true' } as NodeJS.ProcessEnv
+    const result = await readAttendanceNotifyReadinessPort('org-a', queryMock as never, env)
+    expect(result).toEqual({
+      workerEnabled: true,
+      defaultChannelAvailable: true,
+      availableChannelCount: 1,
+      orgRecipientBindingReady: true,
+    })
+    const [sql, params] = queryMock.mock.calls[0] as [string, unknown[]]
+    expect(params).toEqual(['org-a'])
+    expect(sql).toMatch(/org_id\s*=\s*\$1/)
+    expect(sql).not.toMatch(/env|channel_name|credential|secret|token/i)
+  })
+
+  it('worker disabled and no channels registered', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ ready: false }] })
+    const result = await readAttendanceNotifyReadinessPort('org-a', queryMock as never, {} as NodeJS.ProcessEnv)
+    expect(result).toEqual({
+      workerEnabled: false,
+      defaultChannelAvailable: false,
+      availableChannelCount: 0,
+      orgRecipientBindingReady: false,
+    })
+  })
+
+  it('narrows ONLY orgRecipientBindingReady to unknown when the org-scoped DB probe fails', async () => {
+    queryMock.mockRejectedValueOnce(new Error('connection lost'))
+    const env = { ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED: 'true', ATTENDANCE_NOTIFICATION_DINGTALK_WORK_NOTIFICATION_ENABLED: 'true' } as NodeJS.ProcessEnv
+    const result = await readAttendanceNotifyReadinessPort('org-a', queryMock as never, env)
+    expect(result.workerEnabled).toBe(true)
+    expect(result.defaultChannelAvailable).toBe(true)
+    expect(result.availableChannelCount).toBe(1)
+    expect(result.orgRecipientBindingReady).toBe('unknown')
+  })
+
+  it('collapses the WHOLE block to unknown when the port itself throws (port missing)', async () => {
+    vi.mocked(createAttendanceDeliveryChannelsFromEnv).mockImplementationOnce(() => {
+      throw new Error('port unavailable')
+    })
+    const result = await readAttendanceNotifyReadinessPort('org-a', queryMock as never, {} as NodeJS.ProcessEnv)
+    expect(result).toEqual({
+      workerEnabled: 'unknown',
+      defaultChannelAvailable: 'unknown',
+      availableChannelCount: 'unknown',
+      orgRecipientBindingReady: 'unknown',
+    })
+    // The org-scoped probe must never have been attempted once the port itself is unavailable.
+    expect(queryMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('ATTENDANCE_SETUP_READINESS_STEP_META / deploymentScopedSignals (locked registries)', () => {
+  it('registers exactly seven steps with a source + posture for each — never omitted, never guessed immediate for unsourced steps', () => {
+    expect(ATTENDANCE_SETUP_READINESS_STEP_META).toHaveLength(7)
+    const steps = ATTENDANCE_SETUP_READINESS_STEP_META.map((s) => s.step)
+    expect(steps).toEqual([
+      'attendance-admin-user-access',
+      'attendance-admin-groups',
+      'attendance-admin-shifts',
+      'attendance-admin-settings',
+      'attendance-admin-approval-flows',
+      'attendance-admin-notification-deliveries',
+      'preview',
+    ])
+    for (const meta of ATTENDANCE_SETUP_READINESS_STEP_META) {
+      expect(meta.effectiveTime.source).toBeTruthy()
+      expect(['immediate', 'scheduled', 'manual_activation', 'undeterminable']).toContain(
+        meta.effectiveTime.posture,
+      )
+      expect(meta.effectiveTime.effectiveAt).toBeUndefined()
+    }
+    // The two steps with no app-observable trigger must never be mislabeled 'immediate'.
+    const notify = ATTENDANCE_SETUP_READINESS_STEP_META.find((s) => s.step === 'attendance-admin-notification-deliveries')
+    expect(notify?.effectiveTime.posture).toBe('undeterminable')
+    const preview = ATTENDANCE_SETUP_READINESS_STEP_META.find((s) => s.step === 'preview')
+    expect(preview?.effectiveTime.posture).toBe('manual_activation')
+  })
+
+  it('marks only the deployment-wide signals — every other signal is org-scoped by omission', () => {
+    expect(ATTENDANCE_SETUP_READINESS_DEPLOYMENT_SCOPED_SIGNALS).toEqual([
+      'punchPolicyPosture',
+      'notify.workerEnabled',
+      'notify.defaultChannelAvailable',
+      'notify.availableChannelCount',
+    ])
+  })
+
+  it('settings and notification-deliveries steps are the only deployment-scoped perStep entries', () => {
+    const deploymentSteps = ATTENDANCE_SETUP_READINESS_STEP_META.filter((s) => s.scope === 'deployment').map(
+      (s) => s.step,
+    )
+    expect(deploymentSteps).toEqual(['attendance-admin-settings', 'attendance-admin-notification-deliveries'])
+  })
+})
+
+describe('buildAttendanceSetupReadiness (orchestration)', () => {
+  beforeEach(() => {
+    queryMock.mockReset()
+  })
+
+  it('assembles the full values-free response from all four reads', async () => {
+    queryMock
+      // directoryLinked (S7-5 reused query)
+      .mockResolvedValueOnce({ rows: [{ ready: true }] })
+      // org counts CTE
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            org_active_member_count: 5,
+            group_count: 2,
+            groups_with_members: 2,
+            shift_count: 3,
+            rotation_rule_count: 1,
+            approval_flow_count: 1,
+          },
+        ],
+      })
+      // punch policy posture
+      .mockResolvedValueOnce({ rows: [] })
+      // notify org-recipient-binding
+      .mockResolvedValueOnce({ rows: [{ ready: false }] })
+
+    const result = await buildAttendanceSetupReadiness('org-a', queryMock as never, {} as NodeJS.ProcessEnv)
+    expect(result).toEqual({
+      directoryLinked: true,
+      orgActiveMemberCount: 5,
+      groupCount: 2,
+      groupsWithMembers: 2,
+      shiftCount: 3,
+      rotationRuleCount: 1,
+      hasRotationRules: true,
+      approvalFlowCount: 1,
+      punchPolicyPosture: 'default',
+      notify: {
+        workerEnabled: false,
+        defaultChannelAvailable: false,
+        availableChannelCount: 0,
+        orgRecipientBindingReady: false,
+      },
+      perStep: ATTENDANCE_SETUP_READINESS_STEP_META,
+      deploymentScopedSignals: ATTENDANCE_SETUP_READINESS_DEPLOYMENT_SCOPED_SIGNALS,
+    })
+  })
+})
+
+describe('GET /api/attendance-admin/setup-readiness (route)', () => {
+  beforeEach(() => {
+    queryMock.mockReset()
+  })
+
+  it('400 when orgId is missing', async () => {
+    const app = makeApp({ id: 'delegated-admin' })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness')
+    expect(res.status).toBe(400)
+    expect(res.body?.error?.code).toBe('ORG_ID_REQUIRED')
+  })
+
+  it('401 when unauthenticated', async () => {
+    const app = makeApp(null)
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-a')
+    expect(res.status).toBe(401)
+  })
+
+  it('403 when the caller is not a member of the org — and issues ZERO aggregation SQL (OD-W4-1 追加门禁1)', async () => {
+    // Only the membership-check query may fire (0 rows = not a member).
+    queryMock.mockResolvedValueOnce({ rows: [] })
+    const app = makeApp({ id: 'foreign-admin' })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-b')
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('FORBIDDEN')
+    // Mutation evidence: reordering authz after aggregation would push this above 1.
+    expect(queryMock).toHaveBeenCalledTimes(1)
+    const [sql] = queryMock.mock.calls[0] as [string]
+    expect(sql).toMatch(/user_orgs/)
+  })
+
+  it('200 with values-free payload + exact response key-set lock for an org member', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] }) // membership
+      .mockResolvedValueOnce({ rows: [{ ready: false }] }) // directoryLinked
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            org_active_member_count: 0,
+            group_count: 0,
+            groups_with_members: 0,
+            shift_count: 0,
+            rotation_rule_count: 0,
+            approval_flow_count: 0,
+          },
+        ],
+      }) // org counts
+      .mockResolvedValueOnce({ rows: [] }) // punch policy posture
+      .mockResolvedValueOnce({ rows: [{ ready: false }] }) // notify binding
+
+    const app = makeApp({ id: 'delegated-admin' })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-a')
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(Object.keys(res.body.data).sort()).toEqual(
+      [
+        'approvalFlowCount',
+        'deploymentScopedSignals',
+        'directoryLinked',
+        'groupCount',
+        'groupsWithMembers',
+        'hasRotationRules',
+        'notify',
+        'orgActiveMemberCount',
+        'perStep',
+        'punchPolicyPosture',
+        'rotationRuleCount',
+        'shiftCount',
+      ].sort(),
+    )
+    expect(Object.keys(res.body.data.notify).sort()).toEqual(
+      ['availableChannelCount', 'defaultChannelAvailable', 'orgRecipientBindingReady', 'workerEnabled'].sort(),
+    )
+    expect(res.body.data.punchPolicyPosture).toBe('default')
+    // Values-free: no raw config, no ids, no names anywhere in the payload.
+    const flat = JSON.stringify(res.body.data)
+    expect(flat).not.toMatch(/email|phone|mobile|password|secret|token/i)
+  })
+
+  it('503 DB_NOT_READY when an aggregation read hits a missing-relation error', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] }) // membership
+      .mockResolvedValueOnce({ rows: [{ ready: false }] }) // directoryLinked
+      .mockRejectedValueOnce(
+        Object.assign(new Error('relation "attendance_groups" does not exist'), { code: '42P01' }),
+      ) // org counts CTE
+      .mockResolvedValueOnce({ rows: [] }) // punch policy posture
+      .mockResolvedValueOnce({ rows: [{ ready: false }] }) // notify binding
+    const app = makeApp({ id: 'delegated-admin' })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-a')
+    expect(res.status).toBe(503)
+    expect(res.body?.error?.code).toBe('DB_NOT_READY')
+  })
+
+  it('500 returns a generic message — never raw DB/driver text (values-free)', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] }) // membership
+      .mockResolvedValueOnce({ rows: [{ ready: false }] }) // directoryLinked
+      .mockRejectedValueOnce(new Error('SECRET_DETAIL leaking column names')) // org counts CTE
+      .mockResolvedValueOnce({ rows: [] }) // punch policy posture
+      .mockResolvedValueOnce({ rows: [{ ready: false }] }) // notify binding
+    const app = makeApp({ id: 'delegated-admin' })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-a')
+    expect(res.status).toBe(500)
+    expect(res.body?.error?.code).toBe('SETUP_READINESS_FAILED')
+    expect(JSON.stringify(res.body)).not.toContain('SECRET_DETAIL')
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -373,6 +373,12 @@ export default defineConfig({
       // authz + flag-off. DATABASE_URL-gated describeIfDatabase; excluded here so the no-DB job cannot
       // skip-green it; wired whole-file into the attendance real-DB step in plugin-tests.yml.
       'tests/integration/attendance-approval-manager-at-level-s7-4.db.test.ts',
+      // W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED §9): real-Postgres two-org forgery
+      // matrix + org-anchor SQL audit for the setup-readiness aggregate. DATABASE_URL-gated
+      // (describeIfDatabase); excluded here so the no-DB job cannot skip-green it, and wired as a
+      // WHOLE FILE into the `Run attendance integration tests` step in plugin-tests.yml (same shape
+      // as the S7-1..S7-4 entries immediately above).
+      'tests/integration/attendance-setup-readiness-w4-0.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
## What

W4-0 readiness 安全底座 — 考勤 vNext Wave 4 首次启用向导的七步聚合读端点 + 前端纯判别模块。切片 1/3
（W4-1 向导壳、W4-2 模板预填保留给后续独立 PR，严格串行——见锁 §9）。

refs #4509（Wave 4 onboarding design-lock, RATIFIED, owner 终裁 2026-07-21）

## 背景 / 续作说明

前一会话（考勤开通-260717）在实现子代理死于会话登录过期前，已产出未提交的 WIP（endpoint + 纯判别模块 +
契约单测，零跑测）。本 PR 在既有 worktree（分支 `claude/w4-0-setup-readiness-20260721`，基
`origin/main` `d0c1669b2`）上批判性验收该 WIP（先跑通全部既有单测 + typecheck，见下方证据），然后补齐
锁 §9 完成门要求的全部剩余项：真库集成测试、CI 双点接线、FE 纯模块 spec、mutation 自检、PR。

## 锁条文 → 实现映射表

| 锁条文 | 要求 | 实现 |
|---|---|---|
| §0 R1（只读 readiness） | 聚合端点无任何写路径 | `buildAttendanceSetupReadiness` 全程走 `createReadOnlyReadinessSeam`（`assertSelectOnlyReadinessSql` 拒绝非 SELECT/WITH，见 mutation①）；R4 自证见下 |
| §0 R4（禁自动开 S7/通知 worker/外发/生产 flag，settings 整体禁写） | 向导对 `PUT /api/attendance/settings` 整体禁写 | 本片零新增写路由/写 SQL（grep 断言见下）；§5.4 受禁 flag 清单零出现于本片新增文件 |
| §3①（同步或创建，OR 非 AND） | `orgActiveMemberCount>0` 完成，`directoryLinked` 仅辅助 | `attendanceSetupReadiness.ts` step1；FE spec「① … OR not AND」块 |
| §3②（OD-W4-6） | `groupCount>0 && groupsWithMembers>0` | step2；FE spec「②」块；真库测试 B/D 逐值断言 |
| §3③（排班制组闭合，KNOWN SCOPE GAP） | `shiftCount>0`；`rotationRuleCount`/`hasRotationRules` 闭合原料存在但**不参与门控**（见下方 KNOWN SCOPE GAP） | step3 informational-only；模块头注释 + FE spec「③」块显式锁定现状 |
| §3④（OD-W4-4=(c)，round-3 (b)） | 后端内部语义检查，`default/customized` 均 ready，`unknown` fail-closed | `readAttendancePunchPolicyPosture`（后端语义比对，FE 只收枚举）；真库测试 E（snapshot+restore 对真实 `system_configs` 行三态验证）；FE spec「④」块（reason key，非中文字面量——见下方说明） |
| §3⑤ | `approvalFlowCount>0`（含 active 判定） | step5；真库测试 B 断言 is_active 过滤（active/inactive 各一行） |
| §3⑥（§4.5 只读 port） | `workerEnabled/defaultChannelAvailable/availableChannelCount/orgRecipientBindingReady`，缺失⇒unknown，禁由 delivery 存在性推断 | `readAttendanceNotifyReadinessPort`；真库测试 F（env 实值 + org-anchored EXISTS 查询审计） |
| §3⑦（preview-ready，非「已启用」） | 前六步全绿⇒previewReady；unknown 透传 | step7；FE spec「⑦」块含「missing+unknown 并存时 unknown 优先」边界 |
| §3 判别值域 | 5 值：ready/missing/forbidden/unknown/db_not_ready | FE spec「every derived status is a member of the five-value locked domain」穷举断言 |
| §4.1（OD-W4-1=(a)） | core-backend + `user_orgs` 门，S7-5 同款；不选 plugin 路由 | `attendanceAdminRouter()` 内 `GET /api/attendance-admin/setup-readiness`，`canReadAttendanceDirectoryReadiness` 逐字复用 S7-5（`attendance-admin.ts:372-384`） |
| §4.2（单 CTE，values-free，响应键集合锁定） | ①②③⑤+group-membership 单 CTE；④⑥在 CTE 外 | `readAttendanceSetupReadinessOrgCounts` 单 WITH 查询；单测+真库测试 D 逐 SQL 审计 `org_id=$1` ×6、无 PII 列；响应键集合锁定于单测「200 …exact response key-set lock」+ 真库测试 B |
| §4.3（per-surface 403） | 端点级 403=整面 forbidden，不复用 `adminForbidden` 全局 flag | 路由 403 分支；FE `deriveAttendanceSetupReadinessSteps({kind:'forbidden'})` 全七步折叠 |
| §4.5（P2-3 通知 port） | 见上 §3⑥ | 同上 |
| §9 W4-0 完成门 | 见下方 checklist | 见下方 |
| §9 追加门禁1（两组织真库矩阵） | A org 管理员伪造 orgId=B ⇒ 在任何聚合 SQL 执行前 403 | 真库测试 A：`vi.fn(actual.query)` 真库 spy，403 时精确断言仅 1 次 `user_orgs` 查询、零聚合表出现；mutation② 验证 |
| §9 追加门禁2（scope 标记） | 全局信号显式 `scope=deployment` | `ATTENDANCE_SETUP_READINESS_DEPLOYMENT_SCOPED_SIGNALS` + `perStep[].scope`；单测锁定清单 |
| §9 追加门禁3（SELECT-only seam） | 写语句 mutation ⇒ 契约测试精确翻红 | `assertSelectOnlyReadinessSql`；mutation① |
| §9 追加门禁4（生效时间来源逐行登记） | 每步 `effectiveTime:{source,posture,effectiveAt?}`，不得省略/猜测 | `ATTENDANCE_SETUP_READINESS_STEP_META`（7 步全登记）；单测「never guessed immediate for unsourced steps」 |
| §9 追加门禁5（W4-0 无 UI，三视口门 N/A） | 见下 | 见下 |

## §9 W4-0 完成门 checklist（逐条带证据锚点）

- [x] 纯模块 + `setup-readiness` 端点 + §4.5 通知 readiness port + 契约/判别矩阵测试
  → `packages/core-backend/src/routes/attendance-admin.ts`、`apps/web/src/views/attendance/attendanceSetupReadiness.ts`、
  `packages/core-backend/tests/unit/attendance-admin-setup-readiness-w4-0.test.ts`（26 用例）、
  `apps/web/tests/attendance-setup-readiness.spec.ts`（27 用例）
- [x] R1 只读断言 → mutation①（seam 放行 UPDATE ⇒ 2 单测精确翻红）
- [x] §4.3 per-surface 403 → 单测「200…」「403…」两档独立；FE spec forbidden 折叠块
- [x] 两组织真库矩阵（追加门禁1） → `attendance-setup-readiness-w4-0.db.test.ts` 测试 A；mutation②
- [x] 计数 SQL 逐项含 `org_id=$1` 审计（全局信号显式 `scope=deployment`） → 单测「issues exactly one query, org_id = $1 six times」+ 真库测试 D；mutation③
- [x] query seam 只接受 SELECT（追加门禁3） → `assertSelectOnlyReadinessSql` 单测；mutation①
- [x] 生效时间来源逐行登记 → `ATTENDANCE_SETUP_READINESS_STEP_META` 单测
- [x] W4-0 无 UI：三视口门标 N/A（owner 追加门禁5） → 本片零 `.vue` 文件、零截图证据；`AttendanceSetupReadiness.vue` 留给 W4-1，本 PR 不做假验收

## Mutation 记录（3 刀，均已还原，见下方逐刀日志）

| # | 靶 | 变异 | 红腿 | 还原 |
|---|---|---|---|---|
| ① | `assertSelectOnlyReadinessSql` | 函数体替换为 `return`（放行一切 SQL，包括 UPDATE/INSERT/DELETE） | 单测 2 条精确翻红：`rejects UPDATE/INSERT/DELETE — mutation target for R1`、`seam calls through to the underlying runner for SELECT and never for a write statement` | `git checkout -- packages/core-backend/src/routes/attendance-admin.ts`，复跑 26/26 绿 |
| ② | 路由 `GET /setup-readiness` 处理器 | `buildAttendanceSetupReadiness(orgId)` 挪到 `canReadAttendanceDirectoryReadiness` 授权检查**之前** | 单测「403 … issues ZERO aggregation SQL」翻红（200 而非 403 时序错乱触发级联，另 2 条 503/500 单测因 queryMock 序列错位连带翻红）；**真库测试 A（跨组织伪造矩阵）精确翻红**：`expect(res.status).toBe(403)` 实际收到 200 | 同上，复跑单测 26/26 绿 + 真库 7/7 绿 |
| ③ | `readAttendanceSetupReadinessOrgCounts` CTE | `shift_scope` 子查询去掉 `WHERE org_id = $1` | 单测「issues exactly one query, org_id = $1 six times」精确翻红（计数变 5）；**真库测试更严重**：B/C/D 三条同时翻红——因为真实跨组织泄漏，org A 的 shiftCount 把 org B 的 shift 也数进去了（真库比 mock 更早抓到这类真实跨组织泄漏） | 同上，复跑单测 26/26 绿 + 真库 7/7 绿 |

每刀均：先 commit 干净基线 → mutate → 跑对应测试确认精确翻红 → `git checkout -- <file>` 精确还原（非
`git checkout -- .`）→ 复跑确认复绿。三刀之间及之后额外做了一次全量攻坚回归（见下方本地实跑证据）。

## R4 自证（grep 断言级，values-free）

```
$ git diff d0c1669b2..HEAD -- packages/core-backend/src/routes/attendance-admin.ts \
    | grep -E '^\+' | grep -iE 'r\.(put|post|delete|patch)|UPDATE |INSERT INTO|DELETE FROM'
(no output — zero new write routes / write SQL statements)

$ grep -rn 'attendance/settings' packages/core-backend/src/routes/attendance-admin.ts \
    apps/web/src/views/attendance/attendanceSetupReadiness.ts
(no output)

$ for f in ATTENDANCE_APPROVAL_DYNAMIC_ASSIGNEE_SOURCES_ENABLED ATTENDANCE_SCHEDULER_ENABLED \
    ATTENDANCE_AUTO_SHIFT ATTENDANCE_REPORT_; do grep -rn "$f" <本片新增文件>; done
(no output for any — §5.4 受禁清单零出现于本片)
```

唯一读取的 env（`ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED`）是 §4.5 明确批准的只读 port 字段
（`env.X === 'true'` 纯读，从不写），非 §5.4 受禁清单成员。

## 三视口门 — 明记 N/A（owner 追加门禁5）

W4-0 不含任何 `.vue` 文件、不含任何前端可见 UI 元素——纯后端聚合端点 + 前端纯 TS 判别模块。三视口视觉
证据（1440/1024/390）从 W4-1（`AttendanceSetupReadiness.vue` 落地）起才有意义；本 PR 不产出、不声称截图
证据，避免形式化假验收。

## KNOWN SCOPE GAP（§3③，供 owner 裁决，非本 PR 单方面决定）

`attendanceSetupReadiness.ts` 模块头注释原文：锁 §3③ 把「排班制组存在时」的完成条件定义为
`shiftCount>0 且 hasRotationRules`（针对排班制组），但 §4.2 的响应键集合是显式锁定的，其中不含任何
「组类型」信号（无法区分 fixed_shift / scheduled_shift 组）。本模块因此把 step③ 就低判定为
`shiftCount>0` 单独门控，`rotationRuleCount`/`hasRotationRules` 仅作为**展示用信息**、不参与门控，直到
owner 在以下两个选项间裁决：
(a) 往 §4.2 锁定的响应键集合里加一个 `hasScheduledShiftGroups` 信号（本 PR 未做——键集合是锁定条款，
    不可单方面扩），或
(b) 把「AND rotation-rule」门控推迟到 W4-1（向导壳已经会按组类型加载明细，届时天然可用）。

真库测试与 FE spec 均已显式锁定「现状 = 不门控」这一事实（而非藏在实现里悄悄决定）。

## §11.1 六项

1. 基线 SHA：`d0c1669b2`（origin/main，锁 PR #4509 merged 后）。worktree 曾落后 origin/main 2 commit
   （`d9834673b`/`6ea0ccfab`，均为 multitable docs / stock-prep-ops，与本片零文件重叠，未 rebase）。
2. 查重：`git log origin/main` + 全仓 grep `setup-readiness/attendanceSetupReadiness/AttendanceSetupReadiness`
   ——无冲突在飞分支，本分支独占该 slug。
3. 修改文件：见下方文件清单；未来切片（W4-1/W4-2）碰撞车道 = `AttendanceView.vue`（锁 §11.1-3 已预警，
   与本片零重叠）。
4. IN/OUT：锁 §2；本片仅覆盖 IN 中的「七步 readiness 聚合读端点」+「纯逻辑模块」两项，向导壳/模板预填
   留给 W4-1/W4-2。
5. 权威数据源/唯一写路径/权限真源：readiness 真源 = `setup-readiness` 聚合单 CTE + 独立 port；本片零写
   路径；权限真源 = router 级 `rbacGuard('attendance','admin')` + `user_orgs` 门（S7-5 逐字复用）。
6. 完成门与 mutation 目标：见上方 checklist + mutation 记录表。

## 本地实跑证据（命令 + 实数，非 --reporter 掩盖）

**环境**：本机 PG 127.0.0.1:5432（postgres 用户），测试库 `metasheet_w40b_<run>`（唯一命名，非共享/非
production），照 `plugin-tests.yml` 的 `MIGRATION_EXCLUDE` 清单跑 `pnpm run db:migrate`。

- core-backend typecheck：`pnpm --filter @metasheet/core-backend type-check` → 0 errors
- apps/web typecheck：`pnpm --filter @metasheet/web type-check`（`vue-tsc -b`） → 0 errors
- 新+既有 unit 契约测试：
  `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-admin-setup-readiness-w4-0.test.ts tests/unit/attendance-admin-directory-readiness-s7-5.test.ts`
  → **2 files, 37 tests passed**
- 新真库集成测试（单独）：
  `vitest --config vitest.integration.config.ts run tests/integration/attendance-setup-readiness-w4-0.db.test.ts`
  → **7/7 passed**
- CI 同构：`plugin-tests.yml`「Run attendance integration tests」步骤**完整 33 文件列表**（含本片新文件、
  单次全新数据库 `createdb`+`db:migrate`（同 `MIGRATION_EXCLUDE`）、单次运行、命令逐字复制自
  `.github/workflows/plugin-tests.yml` 该步骤——与 CI 完全同构，非子集）：
  → **33 files, 497/497 tests passed, 0 failed**（证明未弄坏邻居，含 attendance/multitable/files/stock-prep
  各系混跑同库场景）
- FE 纯模块 spec（单独）：`pnpm --filter @metasheet/web exec vitest run attendance-setup-readiness` → **27/27 passed**
- `attendance-web-guard.yml` 全运行列表（含本片新增 spec，31 个 pattern）：
  → **30 files, 595/595 tests passed**
- 双点/三点 CI 接线核验（`git diff` 实证，非文本断言）：
  - `plugin-tests.yml`「Run attendance integration tests」步骤显式文件列表新增一行
  - `packages/core-backend/vitest.config.ts` exclude 数组新增一条（同形制注释，紧邻 S7-4 条目）
  - `vitest.integration.config.ts` include glob `tests/integration/**/*.{test,spec}.?(c|m)[jt]s?(x)` 已自动覆盖
    新文件名（用子串过滤而非显式路径复跑验证，非文本断言）
  - `attendance-web-guard.yml` run-list（L198）+ `pull_request.paths` + `push.paths` 三处新增

## 值纪律

响应/错误面全程 values-free：仅计数/枚举/布尔/posture；`readAttendancePunchPolicyPosture` 后端语义比对，
FE 永不见 `attendance.settings` 原始值；§4.5 port 只回布尔/计数，从不回 env 名/渠道名/凭据；500/503 错误
文案不透传原始 driver 报文（单测「never leak raw DB / driver text」+ 真库测试同型覆盖）。

## 未做 / 明确 deferred

- 「缺表/坏 schema → 503 DB_NOT_READY」腿仅留在 mock 单测（已存在、已覆盖 `isDatabaseSchemaError` 的
  纯函数行为），未在真库层面额外构造坏 schema——该函数是纯粹的驱动错误形状判别，构造隔离坏库不会带来
  新增置信度，反而给共享 CI Postgres 增加脆弱面。
- `AttendanceSetupReadiness.vue`、section 注册、任务首页 action、模板预填、preview 全部留给 W4-1/W4-2
  （锁 §9 严格串行，本 PR 不越界）。
- 小瑕疵（display-only，不影响 status 判定，留 W4-1 tr() 层顺手修）：`attendanceSetupReadiness.ts` 的
  step⑦，当 `anyUnknown` 为真时，`reason` 硬编码为 `'notify_signal_unknown'`，即便 unknown 实际来自
  step④（punch policy）而非 step⑥（notify）。`status` 判定本身正确（transitively unknown），只有展示用
  `reason` 的归因不精确；FE spec 的「unknown propagates」用例只断言 `status`、刻意不断言这条路径下的
  `reason`，避免把这个已知瑕疵伪装成已验证行为。

不合并、不 arm auto-merge、不开下一切片——留给 owner/主会话裁决。
