### PR TITLE
fix(approval): preserve FWB mapping contracts

### DIFF
--- a/apps/web/src/approvals/fwbMappingConfig.ts
+++ b/apps/web/src/approvals/fwbMappingConfig.ts
@@ -38,6 +38,11 @@ export type FwbConfigIssue =
 
 const V1_TYPES: readonly string[] = ['text', 'number', 'date', 'select']
 
+function toFwbTargetType(type: string): FwbTargetType | null {
+  if (type === 'string' || type === 'text') return 'text'
+  return V1_TYPES.includes(type) ? type as FwbTargetType : null
+}
+
 /** Validate the whole draft; [] = saveable. Editor disables save while non-empty. */
 export function validateFwbMappingConfig(
   draft: readonly FwbMappingDraft[],
@@ -56,8 +61,9 @@ export function validateFwbMappingConfig(
       issues.push({ code: 'unknown_target_field', index })
       return
     }
-    if (!V1_TYPES.includes(t.type)) issues.push({ code: 'unsupported_target_type', index })
-    if (t.type === 'select' && (!t.selectOptions || t.selectOptions.length === 0)) issues.push({ code: 'select_options_missing', index })
+    const targetType = toFwbTargetType(t.type)
+    if (!targetType) issues.push({ code: 'unsupported_target_type', index })
+    if (targetType === 'select' && (!t.selectOptions || t.selectOptions.length === 0)) issues.push({ code: 'select_options_missing', index })
     if (seenTargets.has(m.targetFieldId)) issues.push({ code: 'duplicate_target', index })
     seenTargets.add(m.targetFieldId)
   })
@@ -72,12 +78,13 @@ export function toExecutorMappings(
   const tgt = new Map(targetFields.map((f) => [f.id, f]))
   return draft.map((m) => {
     const t = tgt.get(m.targetFieldId)
-    if (!t || !V1_TYPES.includes(t.type)) throw new RangeError('toExecutorMappings called on an unvalidated draft')
+    const targetType = t ? toFwbTargetType(t.type) : null
+    if (!t || !targetType) throw new RangeError('toExecutorMappings called on an unvalidated draft')
     return {
       formFieldId: m.formFieldId,
       targetFieldId: m.targetFieldId,
-      targetType: t.type as FwbTargetType,
-      ...(t.type === 'select' ? { selectOptions: t.selectOptions } : {}),
+      targetType,
+      ...(targetType === 'select' ? { selectOptions: t.selectOptions } : {}),
     }
   })
 }

--- a/apps/web/tests/approval-fwb-mapping-config.test.ts
+++ b/apps/web/tests/approval-fwb-mapping-config.test.ts
@@ -5,7 +5,7 @@ import { toExecutorMappings, validateFwbMappingConfig } from '../src/approvals/f
 
 const TPL = [{ id: 'f1', label: '金额' }, { id: 'f2', label: '等级' }]
 const TGT = [
-  { id: 't_text', label: 'T', type: 'text' },
+  { id: 't_text', label: 'T', type: 'string' },
   { id: 't_num', label: 'N', type: 'number' },
   { id: 't_sel', label: 'S', type: 'select', selectOptions: ['低', '高'] },
   { id: 't_sel_empty', label: 'SE', type: 'select', selectOptions: [] },
@@ -15,11 +15,13 @@ const TGT = [
 describe('FWB mapping config model', () => {
   test('valid draft → no issues; executor mappings carry types + select options', () => {
     const draft = [
+      { formFieldId: 'f1', targetFieldId: 't_text' },
       { formFieldId: 'f1', targetFieldId: 't_num' },
       { formFieldId: 'f2', targetFieldId: 't_sel' },
     ]
     expect(validateFwbMappingConfig(draft, TPL, TGT)).toEqual([])
     expect(toExecutorMappings(draft, TGT)).toEqual([
+      { formFieldId: 'f1', targetFieldId: 't_text', targetType: 'text' },
       { formFieldId: 'f1', targetFieldId: 't_num', targetType: 'number' },
       { formFieldId: 'f2', targetFieldId: 't_sel', targetType: 'select', selectOptions: ['低', '高'] },
     ])

--- a/packages/core-backend/src/multitable/approval-form-value-mapping.ts
+++ b/packages/core-backend/src/multitable/approval-form-value-mapping.ts
@@ -7,10 +7,19 @@
  *   - an unmapped/unknown target field type → the WHOLE action is rejected (never a silent partial write);
  *   - a value that cannot be coerced to the target type → per-mapping error, action rejected (a form value
  *     is business data — writing a mangled coercion would fabricate audit-adjacent data);
- *   - select values must be in the target field's option set (closed vocabulary — no invention);
- *   - date accepts ISO `YYYY-MM-DD` or epoch-ms number, normalized to ISO; number accepts only decimal
- *     values that remain lossless in JS and fit the execute-time target precision; text is stringified
- *     from string/number/boolean ONLY (objects rejected).
+ *   - select values must be in the target field's CURRENT option set (closed vocabulary — no invention;
+ *     the execute-time seam re-derives options from the live field metadata, never from the saved mapping);
+ *   - date accepts ONLY explicit calendar-date strings `YYYY-MM-DD` that are real Gregorian dates — no
+ *     epoch-ms input, no timezone conversion (lock D8: 日历日字面写入，禁止任何隐式时区转换);
+ *   - number preserves EXACT decimal semantics as a CANONICAL DECIMAL STRING (lock D7: decimal 定点字符串
+ *     规范化流转). STRING lexemes are exact at arbitrary scale and never pass through JS Number; JSON
+ *     NUMERIC inputs are accepted only inside a conservative lossless envelope (finite, safe-integer when
+ *     integral, plain-decimal `String()` form, ≤15 significant digits) because JSON.parse has already
+ *     rounded them before we see them — exponent notation, NaN/Infinity, malformed numbers and any
+ *     precision-changing coercion reject. Canonical form strips leading/trailing zeros and collapses
+ *     signed zero (`-0` → `0`); scale beyond the execute-time target precision REJECTS the whole step
+ *     (§11 Q5 — never rounds);
+ *   - text is stringified from string/number/boolean ONLY (objects rejected).
  *
  * Pure and synchronous — permission rechecks, the same-transaction claim+record+revision+outbox composition,
  * and the config UI are the later FWB-1 slices. No callers yet.
@@ -30,7 +39,7 @@ export interface FwbFieldMapping {
 }
 
 export type FwbMappingResult =
-  | { ok: true; values: Record<string, string | number> }
+  | { ok: true; values: Record<string, string> }
   | { ok: false; errors: Array<{ formFieldId: string; targetFieldId: string; code: FwbMappingErrorCode }> }
 
 export type FwbMappingErrorCode =
@@ -45,42 +54,61 @@ export type FwbMappingErrorCode =
   | 'select_options_missing'
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
-const DECIMAL = /^-?(?:0|[1-9]\d*)(?:\.(\d+))?$/
+// Plain decimal grammar ONLY: optional '-', integer digits, optional fraction. No exponent, no '+',
+// no hex/binary, no NaN/Infinity, no bare '.', no '.5'/'5.' — anything else is malformed, never coerced.
+const DECIMAL = /^-?\d+(?:\.\d+)?$/
 
-function normalizedDecimal(raw: string): { value: number; scale: number; significantDigits: number } | null {
-  const trimmed = raw.trim()
-  const match = DECIMAL.exec(trimmed)
-  if (!match) return null
-  const unsigned = trimmed.startsWith('-') ? trimmed.slice(1) : trimmed
-  const [integerPart, fractionPart = ''] = unsigned.split('.')
-  const fraction = fractionPart.replace(/0+$/, '')
-  const significant = `${integerPart}${fraction}`.replace(/^0+/, '') || '0'
-  const value = Number(trimmed)
-  if (!Number.isFinite(value)) return null
-  return { value, scale: fraction.length, significantDigits: significant.length }
+/**
+ * Canonicalize a plain-decimal lexeme WITHOUT routing through JS Number (lock D7): strip integer-part
+ * leading zeros (keeping a single `0`), strip fraction trailing zeros (dropping the dot when emptied),
+ * and collapse signed zero (`-0`, `-0.00` → `0`). Returns the canonical decimal string and its scale
+ * (fraction digits after trailing-zero stripping — trailing zeros carry no information, so `12.340`
+ * under precision 2 passes as `12.34`, exactly as Q5 intends; excess REAL scale rejects, never rounds).
+ */
+function canonicalizeDecimal(lexeme: string): { canonical: string; scale: number } {
+  const negative = lexeme.startsWith('-')
+  const unsigned = negative ? lexeme.slice(1) : lexeme
+  const [integerRaw, fractionRaw = ''] = unsigned.split('.')
+  const integer = integerRaw.replace(/^0+(?=\d)/, '')
+  const fraction = fractionRaw.replace(/0+$/, '')
+  const digits = fraction.length > 0 ? `${integer}.${fraction}` : integer
+  const isZero = integer === '0' && fraction.length === 0
+  return { canonical: isZero ? '0' : `${negative ? '-' : ''}${digits}`, scale: fraction.length }
 }
 
 function coerceNumber(
   mapping: FwbFieldMapping,
   raw: unknown,
-): { ok: true; value: number } | { ok: false; code: FwbMappingErrorCode } {
-  const parsed = typeof raw === 'number'
-    ? normalizedDecimal(String(raw))
-    : (typeof raw === 'string' ? normalizedDecimal(raw) : null)
-  if (!parsed) return { ok: false, code: 'not_a_number' }
-  if (Number.isInteger(parsed.value)) {
-    if (!Number.isSafeInteger(parsed.value)) return { ok: false, code: 'number_not_lossless' }
-  } else if (parsed.significantDigits > 15) {
-    // JSON/JS has already lost the source lexeme by this point. Reject values whose represented
-    // precision exceeds the reliably round-trippable decimal envelope instead of writing an approximation.
-    return { ok: false, code: 'number_not_lossless' }
+): { ok: true; value: string } | { ok: false; code: FwbMappingErrorCode } {
+  let lexeme: string
+  if (typeof raw === 'string') {
+    lexeme = raw.trim()
+    if (!DECIMAL.test(lexeme)) return { ok: false, code: 'not_a_number' }
+  } else if (typeof raw === 'number') {
+    // JSON snapshots carry numbers as JS numbers — JSON.parse has ALREADY rounded the source literal to
+    // this double before we see it, so provenance is lossless only inside a conservative envelope:
+    // finite, safe-integer when integral (an unsafe integer means fabricated digits), a plain-decimal
+    // `String(raw)` form (exponent outputs like 1e-7/1e21 have no canonical fixed-point form here), and
+    // ≤15 significant digits (beyond the reliably round-trippable decimal envelope the represented value
+    // may already differ from the source lexeme — e.g. 9007199254740990.5 parses to the SAFE integer
+    // 9007199254740990, its fraction silently destroyed). Anything outside rejects; strings above are
+    // the exact arbitrary-precision path.
+    if (!Number.isFinite(raw)) return { ok: false, code: 'not_a_number' }
+    if (Number.isInteger(raw) && !Number.isSafeInteger(raw)) return { ok: false, code: 'number_not_lossless' }
+    lexeme = String(raw)
+    if (!DECIMAL.test(lexeme)) return { ok: false, code: 'number_not_lossless' }
+    const significantDigits = canonicalizeDecimal(lexeme).canonical.replace(/[-.]/g, '').replace(/^0+/, '').length || 1
+    if (significantDigits > 15) return { ok: false, code: 'number_not_lossless' }
+  } else {
+    return { ok: false, code: 'not_a_number' }
   }
+  const { canonical, scale } = canonicalizeDecimal(lexeme)
   const precision = mapping.numberPrecision
   if (
     precision !== undefined
-    && (!Number.isSafeInteger(precision) || precision < 0 || parsed.scale > precision)
+    && (!Number.isSafeInteger(precision) || precision < 0 || scale > precision)
   ) return { ok: false, code: 'number_precision_exceeded' }
-  return { ok: true, value: parsed.value }
+  return { ok: true, value: canonical }
 }
 
 function isValidIsoCalendarDate(value: string): boolean {
@@ -92,7 +120,7 @@ function isValidIsoCalendarDate(value: string): boolean {
   return day <= daysInMonth[month - 1]
 }
 
-function coerce(mapping: FwbFieldMapping, raw: unknown): { ok: true; v: string | number } | { ok: false; code: FwbMappingErrorCode } {
+function coerce(mapping: FwbFieldMapping, raw: unknown): { ok: true; v: string } | { ok: false; code: FwbMappingErrorCode } {
   switch (mapping.targetType) {
     case 'text': {
       if (typeof raw === 'string') return { ok: true, v: raw }
@@ -106,13 +134,11 @@ function coerce(mapping: FwbFieldMapping, raw: unknown): { ok: true; v: string |
       return { ok: true, v: number.value }
     }
     case 'date': {
+      // Lock D8: explicit calendar-date strings ONLY — no epoch-ms input, no Date construction,
+      // no timezone conversion. Numbers (and everything else) reject.
       if (typeof raw === 'string') {
         const value = raw.trim()
         if (isValidIsoCalendarDate(value)) return { ok: true, v: value }
-      }
-      if (typeof raw === 'number' && Number.isFinite(raw)) {
-        const d = new Date(raw)
-        if (Number.isFinite(d.getTime())) return { ok: true, v: d.toISOString().slice(0, 10) }
       }
       return { ok: false, code: 'not_a_date' }
     }
@@ -136,7 +162,7 @@ export function mapApprovalFormValues(
   formValues: Readonly<Record<string, unknown>>,
 ): FwbMappingResult {
   const errors: Array<{ formFieldId: string; targetFieldId: string; code: FwbMappingErrorCode }> = []
-  const values: Record<string, string | number> = {}
+  const values: Record<string, string> = {}
   for (const m of mappings) {
     const supported: readonly string[] = ['text', 'number', 'date', 'select']
     if (!supported.includes(m.targetType)) {
@@ -148,7 +174,7 @@ export function mapApprovalFormValues(
       errors.push({ formFieldId: m.formFieldId, targetFieldId: m.targetFieldId, code: 'missing_required_value' })
       continue
     }
-    const r = coerce(m, raw) as { ok: boolean; v?: string | number; code?: FwbMappingErrorCode }
+    const r = coerce(m, raw) as { ok: boolean; v?: string; code?: FwbMappingErrorCode }
     if (r.ok && r.v !== undefined) {
       values[m.targetFieldId] = r.v
     } else {

--- a/packages/core-backend/src/multitable/approval-fwb-activation.ts
+++ b/packages/core-backend/src/multitable/approval-fwb-activation.ts
@@ -46,6 +46,20 @@ export function isFwbWritebackEnabled(env: NodeJS.ProcessEnv = process.env): boo
 const V1_TARGET_TYPES = new Set(['text', 'number', 'date', 'select'])
 const NON_BLANK = /[!-~]/
 
+/**
+ * FWB uses the lock's conceptual `text` mapping type while multitable persists ordinary text fields
+ * as `string`. Keep the alias explicit at both save and execute time; never broaden it to longText or
+ * another writable-looking field type without a separate product decision.
+ */
+export function isFwbTargetFieldTypeCompatible(
+  storedFieldType: string,
+  targetType: FwbFieldMapping['targetType'],
+): boolean {
+  return targetType === 'text'
+    ? storedFieldType === 'string' || storedFieldType === 'text'
+    : storedFieldType === targetType
+}
+
 export type FwbConfigStructuralIssue =
   | 'empty_config'
   | 'invalid_mapping_entry'

--- a/packages/core-backend/src/multitable/approval-fwb-write-action.ts
+++ b/packages/core-backend/src/multitable/approval-fwb-write-action.ts
@@ -13,14 +13,134 @@
  *      downstream fan-out commits or rolls back WITH the claim and the record).
  *
  * Any throw from the seam propagates and aborts the caller's transaction — claim, record, revision and
- * outbox rows all vanish together (proven in the real-DB spec). NO production caller yet; the dispatchAction
- * wiring lands with the FWB activation slice behind its own gate.
+ * outbox rows all vanish together (proven in the real-DB spec). The production caller is
+ * `executeWriteApprovalFormValuesAction` (automation-executor.ts), which runs the recheck seam and this
+ * executor inside ONE transaction behind the FWB + durable-delivery flags.
+ *
+ * Also exports `resolveFwbRuntimeMappings` — the execute-time target-field recheck (current select
+ * option set + canonical number precision, fail-closed on missing/retyped fields) that MUST run before
+ * `mapApprovalFormValues`; the production caller is `executeWriteApprovalFormValuesAction`
+ * (automation-executor.ts), which invokes it inside the same transaction as this executor.
  */
 import type { Queryable } from './automation-durable-dispatcher'
 import type { TransactionalQueryable } from './pg-transaction-guard'
 import { claimActionApplied } from './automation-action-idempotency'
 import { mapApprovalFormValues, type FwbFieldMapping } from './approval-form-value-mapping'
 import { recheckFwbPermissionGates, type FwbGateChecks, type FwbGateId, type FwbGateSubject } from './approval-fwb-permission-gates'
+import { extractSelectOptions, sanitizeFieldProperty } from './field-codecs'
+import { isFwbTargetFieldTypeCompatible } from './approval-fwb-activation'
+
+type SqlQueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+
+export type FwbRuntimeMappingsResult =
+  | { ok: true; mappings: FwbFieldMapping[] }
+  | { ok: false; code: 'mapping_target_changed' }
+
+function parseFieldProperty(value: unknown): Record<string, unknown> | null {
+  if (value === null || value === undefined) return {}
+  if (value && typeof value === 'object' && !Array.isArray(value)) return value as Record<string, unknown>
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as Record<string, unknown>
+    } catch { return null }
+  }
+  return null
+}
+
+function hasCanonicalNumberPrecisionLexeme(value: unknown): boolean {
+  if (typeof value === 'number') return Number.isFinite(value)
+  if (typeof value !== 'string') return false
+  const normalized = value.trim()
+  return normalized.length > 0 && /^-?\d+(?:\.\d+)?$/.test(normalized)
+}
+
+/**
+ * Execute-time target-field recheck (FWB0 §5 「字段类型 fire 时复验」 + D6): re-derive the runtime
+ * mappings from the CURRENT `meta_fields` rows INSIDE the caller's transaction (`FOR SHARE`), never
+ * trusting the saved mapping's stale metadata:
+ *   - any target field missing, or its type changed since save → fail closed;
+ *   - `select` mappings get the intersection of the explicitly confirmed and currently existing option
+ *     values. Removed values and newly-added-but-unconfirmed values both reject (D6 closed vocabulary);
+ *     absent/unparseable/empty current options fail closed (no open-vocabulary write);
+ *   - `number` mappings get `numberPrecision` from the canonical `property.decimals` (the field codec
+ *     contract — no second spelling): the saved mapping's precision is DISCARDED first, then the current
+ *     cap is attached only when valid — a tightened cap applies (§11 Q5), a removed cap stays removed,
+ *     and a stale saved value never survives.
+ * The failure carries NO values — callers map it to the values-free `fwb_rejected:mapping_target_changed`.
+ */
+export async function resolveFwbRuntimeMappings(
+  query: SqlQueryFn,
+  targetSheetId: string,
+  mappings: readonly FwbFieldMapping[],
+): Promise<FwbRuntimeMappingsResult> {
+  const fail: FwbRuntimeMappingsResult = { ok: false, code: 'mapping_target_changed' }
+  const result = await query(
+    `SELECT id, type, property
+       FROM meta_fields
+      WHERE sheet_id = $1 AND id = ANY($2::text[])
+      FOR SHARE`,
+    [targetSheetId, mappings.map((mapping) => mapping.targetFieldId)],
+  )
+  const targetFields = new Map(
+    (result.rows as Array<{ id?: unknown; type?: unknown; property?: unknown }>)
+      .filter((row): row is { id: string; type: string; property?: unknown } => (
+        typeof row.id === 'string' && typeof row.type === 'string'
+      ))
+      .map((row) => [row.id, { type: row.type, property: parseFieldProperty(row.property) }] as const),
+  )
+  if (targetFields.size !== mappings.length) return fail
+  const runtimeMappings: FwbFieldMapping[] = []
+  for (const mapping of mappings) {
+    const field = targetFields.get(mapping.targetFieldId)
+    if (!field || !isFwbTargetFieldTypeCompatible(field.type, mapping.targetType)) return fail
+    if (mapping.targetType === 'select') {
+      // The effective vocabulary is the INTERSECTION of the values explicitly confirmed in the
+      // persisted mapping and the values that still exist now. Replacing the confirmed list with the
+      // whole current field vocabulary would let a newly-added option bypass the confirmation hash.
+      const current = field.property
+        ? extractSelectOptions(field.property)?.map((option) => option.value)
+        : undefined
+      const confirmed = mapping.selectOptions ?? []
+      if (!current || current.length === 0 || confirmed.length === 0) return fail
+      const currentSet = new Set(current)
+      const allowed = confirmed.filter((value) => currentSet.has(value))
+      if (allowed.length === 0) return fail
+      runtimeMappings.push({ ...mapping, selectOptions: allowed })
+      continue
+    }
+    if (mapping.targetType === 'number') {
+      // Current field metadata REPLACES the saved mapping's: a saved numberPrecision must not survive
+      // when the field's own cap was removed (stale tightening) or changed (stale value) since save.
+      if (!field.property) return fail
+      const { numberPrecision: _savedPrecision, ...withoutSavedPrecision } = mapping
+      const hasPrecision = Object.prototype.hasOwnProperty.call(field.property, 'decimals')
+      const rawPrecision = field.property.decimals
+      // The shared field sanitizer intentionally accepts broad UI inputs via Number(...). At execute
+      // time that coercion would turn true/blank/arrays/hex into an invented precision. A present value
+      // therefore needs a plain-decimal lexeme before we reuse the established rounding/range policy.
+      if (hasPrecision && !hasCanonicalNumberPrecisionLexeme(rawPrecision)) return fail
+      const sanitized = sanitizeFieldProperty('number', field.property)
+      const precision = sanitized.decimals
+      // Absence means the field deliberately has no scale cap. Presence with a value the canonical
+      // field-property sanitizer rejects must fail closed instead of silently becoming uncapped.
+      if (hasPrecision && (
+        typeof precision !== 'number'
+        || !Number.isSafeInteger(precision)
+        || precision < 0
+      )) return fail
+      runtimeMappings.push({
+        ...withoutSavedPrecision,
+        ...(hasPrecision && typeof precision === 'number'
+          ? { numberPrecision: precision }
+          : {}),
+      })
+      continue
+    }
+    runtimeMappings.push(mapping)
+  }
+  return { ok: true, mappings: runtimeMappings }
+}
 
 export interface FwbWriteActionInput {
   /** idempotency identity (ledger): */
@@ -41,7 +161,7 @@ export interface FwbWriteActionInput {
 
 export interface FwbRecordWriteSeam {
   /** Create the record + its revision on the SAME trx; returns the new record id (identifier only). */
-  createRecordWithRevision(trx: Queryable, targetSheetId: string, values: Record<string, string | number>): Promise<string>
+  createRecordWithRevision(trx: Queryable, targetSheetId: string, values: Record<string, string>): Promise<string>
   /** Durable outbox enqueue on the SAME trx (final wiring passes produceAutomationEvent; flag-gated there). */
   enqueueOutbox(trx: Queryable, event: { eventType: string; eventId: string; payload: unknown; automationDepth: number }): Promise<void>
 }

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -27,7 +27,7 @@ import { enqueueRecordEventIfDurable, emitRecordEventIfLegacy } from './automati
 import { isDurableDeliveryEnabled } from './automation-durable-delivery'
 import { produceAutomationEvent } from './automation-durable-activation'
 import { isFwbWritebackEnabled, normalizeFwbMappings } from './approval-fwb-activation'
-import { executeWriteApprovalFormValues, type FwbRecordWriteSeam } from './approval-fwb-write-action'
+import { executeWriteApprovalFormValues, resolveFwbRuntimeMappings, type FwbRecordWriteSeam } from './approval-fwb-write-action'
 import type { FwbGateChecks } from './approval-fwb-permission-gates'
 import { redactString } from './automation-log-redact'
 import { computeActionFingerprint } from './automation-suspension-service'
@@ -2911,36 +2911,13 @@ export class AutomationExecutor {
       const automationDepth = (typeof trig._automationDepth === 'number' ? trig._automationDepth : 0) + 1
 
       const result = await this.withTransaction(context.sheetId, async (query) => {
-        const targetFieldResult = await query(
-          `SELECT id, type, property
-             FROM meta_fields
-            WHERE sheet_id = $1 AND id = ANY($2::text[])
-            FOR SHARE`,
-          [context.sheetId, normalized.mappings.map((mapping) => mapping.targetFieldId)],
-        )
-        const targetFields = new Map(
-          (targetFieldResult.rows as Array<{ id?: unknown; type?: unknown; property?: unknown }>)
-            .filter((row): row is { id: string; type: string; property?: unknown } => (
-              typeof row.id === 'string' && typeof row.type === 'string'
-            ))
-            .map((row) => [row.id, { type: row.type, property: normalizeJson(row.property) }] as const),
-        )
-        if (targetFields.size !== normalized.mappings.length) throw new Error('fwb_rejected:mapping_target_changed')
-        const runtimeMappings = normalized.mappings.map((mapping) => {
-          const field = targetFields.get(mapping.targetFieldId)
-          if (!field || field.type !== mapping.targetType) throw new Error('fwb_rejected:mapping_target_changed')
-          if (mapping.targetType !== 'number') return mapping
-          // Number fields persist their decimal-place cap as `property.decimals` (the canonical
-          // field codec contract). Do not infer a second `precision` spelling here: doing so silently
-          // removes the execute-time cap from every normally authored number field.
-          const precision = field.property.decimals
-          return {
-            ...mapping,
-            ...(typeof precision === 'number' && Number.isSafeInteger(precision) && precision >= 0
-              ? { numberPrecision: precision }
-              : {}),
-          }
-        })
+        // Execute-time target-field recheck (FWB0 §5 + D6/D7): current select option set and canonical
+        // number precision are re-derived from meta_fields INSIDE this transaction — fail closed on a
+        // missing/retyped field or absent select options; the saved mapping's stale metadata is never
+        // trusted for membership or scale.
+        const runtime = await resolveFwbRuntimeMappings(query, context.sheetId, normalized.mappings)
+        if (!runtime.ok) throw new Error('fwb_rejected:mapping_target_changed')
+        const runtimeMappings = runtime.mappings
         // D4: the immutable form snapshot is the ONLY value source, read server-side inside the txn.
         const snapRes = await query(
           `SELECT form_snapshot FROM approval_instances

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -41,6 +41,7 @@ import {
   canUserWriteFwbTargetFields,
   collectFwbActionConfigs,
   deriveFwbConfirmationHash,
+  isFwbTargetFieldTypeCompatible,
   normalizeFwbMappings,
 } from './approval-fwb-activation'
 import { isAdmin as rbacIsAdmin } from '../rbac/service'
@@ -2039,7 +2040,9 @@ export class AutomationService {
       for (const m of normalized.mappings) {
         const field = byId.get(m.targetFieldId)
         if (!field) return `${FWB_ACTION_TYPE} mapping invalid: unknown_target_field`
-        if (field.type !== m.targetType) return `${FWB_ACTION_TYPE} mapping invalid: target_type_mismatch`
+        if (!isFwbTargetFieldTypeCompatible(field.type, m.targetType)) {
+          return `${FWB_ACTION_TYPE} mapping invalid: target_type_mismatch`
+        }
         if (m.targetType === 'select') {
           const property = typeof field.property === 'string'
             ? (() => { try { return JSON.parse(field.property as string) as Record<string, unknown> } catch { return {} } })()

--- a/packages/core-backend/tests/integration/multitable-fwb-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-fwb-activation-realdb.test.ts
@@ -179,7 +179,7 @@ describeIfDatabase('FWB activation — production write_approval_form_values wir
     setFlags(false, false)
     await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'FWB Act Base'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'FWB Act Sheet'])
-    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_TITLE, SHEET_ID, 'Title', 'text', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_TITLE, SHEET_ID, 'Title', 'string', '{}', 1])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_AMOUNT, SHEET_ID, 'Amount', 'number', '{}', 2])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [
       F_STATUS, SHEET_ID, 'Status', 'select', JSON.stringify({ options: [{ value: 'A' }, { value: 'B' }] }), 3,
@@ -437,7 +437,7 @@ describeIfDatabase('FWB activation — production write_approval_form_values wir
     state = await stateFor(instanceId, ruleId)
     expect(state.records.length).toBe(1)
     expect(state.claims).toBe(1)
-    expect(state.records[0].data).toMatchObject({ [F_TITLE]: 'FWB run', [F_AMOUNT]: 42 })
+    expect(state.records[0].data).toMatchObject({ [F_TITLE]: 'FWB run', [F_AMOUNT]: '42' }) // D7: canonical decimal STRING
     expect(await revisionCountFor(state.records[0].id)).toBe(1)
     expect(await outboxCountLike(`${evtOn}::fwb::`)).toBe(1)
     expect(legacyChainedEmits).toBe(0) // REPLACE, not keep-both
@@ -565,6 +565,121 @@ describeIfDatabase('FWB activation — production write_approval_form_values wir
     } finally {
       setFlags(false, false)
       await q('UPDATE meta_fields SET property = $1::jsonb WHERE id = $2', ['{}', F_AMOUNT])
+    }
+  })
+
+  test('execute-time number precision rejects coercible malformed metadata before claim or record write', async () => {
+    const ruleId = ruleIds[0]
+    const instanceId = await startInstance({ summary: 'invalid precision metadata', amount: 12.3 })
+    await approveInstance(instanceId)
+    const beforeExecutions = await waitForExecutionCount(ruleId, 0)
+    const beforeRecords = Number(((await q(
+      'SELECT COUNT(*)::int AS c FROM meta_records WHERE sheet_id = $1',
+      [SHEET_ID],
+    )).rows[0] as { c: number }).c)
+    await q('UPDATE meta_fields SET property = $1::jsonb WHERE id = $2', [JSON.stringify({ decimals: true }), F_AMOUNT])
+    try {
+      setFlags(true, true)
+      await svc.handleApprovalCompletionTrigger(completionEvent(instanceId, `evt_fwbact_${TS}_precision_invalid_metadata`))
+      await waitForExecutionCount(ruleId, beforeExecutions + 1)
+      const exec = await lastExecution(ruleId)
+      expect(exec?.steps?.[0]?.status).toBe('failed')
+      expect(String(exec?.steps?.[0]?.error ?? '')).toBe('fwb_rejected:mapping_target_changed')
+      expect((await stateFor(instanceId, ruleId)).claims).toBe(0)
+      const afterRecords = Number(((await q(
+        'SELECT COUNT(*)::int AS c FROM meta_records WHERE sheet_id = $1',
+        [SHEET_ID],
+      )).rows[0] as { c: number }).c)
+      expect(afterRecords).toBe(beforeRecords)
+    } finally {
+      setFlags(false, false)
+      await q('UPDATE meta_fields SET property = $1::jsonb WHERE id = $2', ['{}', F_AMOUNT])
+    }
+  })
+
+  test('execute-time select recheck uses confirmed-current intersection; additions require re-confirmation (D6/Q6)', async () => {
+    // A dedicated rule whose select mapping's SAVED selectOptions include 'B' (valid at save time).
+    const selectMappings = [{ formFieldId: 'summary', targetFieldId: F_STATUS, targetType: 'select' as const, selectOptions: ['A', 'B'] }]
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'fwb select staleness',
+      triggerType: 'approval.completed',
+      triggerConfig: { templateId, outcomes: ['approved'] },
+      actionType: 'write_approval_form_values',
+      actionConfig: fwbConfig(selectMappings),
+      createdBy: CREATOR,
+    } as never)
+    const ruleId = (rule as { id: string }).id
+    ruleIds.push(ruleId)
+    // Per-rule write observability: the main MAPPINGS rule fires on the SAME completions, so sheet-wide
+    // record counts and unqualified outbox prefixes are NOT discriminating — every "zero writes" and
+    // "exactly one record" assertion below is scoped to THIS rule via the ledger (instance-scoped claim
+    // precedes the record write in the same txn) and the rule-qualified outbox event id.
+    const ruleOutbox = async (eventPrefix: string) => {
+      const r = await q('SELECT payload FROM meta_automation_outbox WHERE event_id LIKE $1', [`${eventPrefix}::fwb::${ruleId}::%`])
+      return r.rows as Array<{ payload: { recordId?: string } }>
+    }
+    const before = await waitForExecutionCount(ruleId, 0)
+    setFlags(true, true)
+    try {
+      // 1) option REMOVED from the field after save: the stale saved mapping still lists 'B', but the
+      //    execute-time recheck re-derives options from meta_fields → 'B' is rejected, zero writes.
+      await q('UPDATE meta_fields SET property = $1::jsonb WHERE id = $2', [JSON.stringify({ options: [{ value: 'A' }] }), F_STATUS])
+      const removedInstance = await startInstance({ summary: 'B', amount: 1 })
+      await approveInstance(removedInstance)
+      await svc.handleApprovalCompletionTrigger(completionEvent(removedInstance, `evt_fwbact_${TS}_sel_removed`))
+      await waitForExecutionCount(ruleId, before + 1)
+      let exec = await lastExecution(ruleId)
+      expect(exec?.steps?.[0]?.status).toBe('failed')
+      expect(String(exec?.steps?.[0]?.error ?? '')).toBe('fwb_rejected:mapping')
+      expect((await stateFor(removedInstance, ruleId)).claims).toBe(0)
+      expect(await ruleOutbox(`evt_fwbact_${TS}_sel_removed`)).toEqual([])
+
+      // 2) an option ADDED after save is not in the confirmation subject and must reject. Replacing
+      //    the saved options with the complete current set would silently widen a confirmed mapping.
+      await q('UPDATE meta_fields SET property = $1::jsonb WHERE id = $2', [JSON.stringify({ options: [{ value: 'A' }, { value: 'C' }] }), F_STATUS])
+      const addedInstance = await startInstance({ summary: 'C', amount: 2 })
+      await approveInstance(addedInstance)
+      await svc.handleApprovalCompletionTrigger(completionEvent(addedInstance, `evt_fwbact_${TS}_sel_added`))
+      await waitForExecutionCount(ruleId, before + 2)
+      exec = await lastExecution(ruleId)
+      expect(exec?.steps?.[0]?.status).toBe('failed')
+      expect(String(exec?.steps?.[0]?.error ?? '')).toBe('fwb_rejected:mapping')
+      expect((await stateFor(addedInstance, ruleId)).claims).toBe(0)
+      expect(await ruleOutbox(`evt_fwbact_${TS}_sel_added`)).toEqual([])
+
+      // Positive control: update the persisted mapping to include C with a fresh server-derived
+      // confirmation hash. The same value is now authorized and writes exactly once.
+      const reconfirmedMappings = [{ formFieldId: 'summary', targetFieldId: F_STATUS, targetType: 'select' as const, selectOptions: ['A', 'C'] }]
+      await svc.updateRule(ruleId, SHEET_ID, {
+        actionConfig: fwbConfig(reconfirmedMappings),
+      }, CREATOR)
+      const reconfirmedInstance = await startInstance({ summary: 'C', amount: 2 })
+      await approveInstance(reconfirmedInstance)
+      await svc.handleApprovalCompletionTrigger(completionEvent(reconfirmedInstance, `evt_fwbact_${TS}_sel_reconfirmed`))
+      await waitForExecutionCount(ruleId, before + 3)
+      exec = await lastExecution(ruleId)
+      expect(exec?.steps?.[0]?.status).toBe('success')
+      expect((await stateFor(reconfirmedInstance, ruleId)).claims).toBe(1)
+      const reconfirmedOutbox = await ruleOutbox(`evt_fwbact_${TS}_sel_reconfirmed`)
+      expect(reconfirmedOutbox.length).toBe(1)
+      const recordId = reconfirmedOutbox[0].payload.recordId
+      const record = await q('SELECT data FROM meta_records WHERE id = $1', [recordId])
+      expect((record.rows[0] as { data: Record<string, unknown> }).data).toEqual({ [F_STATUS]: 'C' })
+
+      // 3) options ABSENT from the field metadata → fail closed BEFORE the claim (no open vocabulary).
+      await q('UPDATE meta_fields SET property = $1::jsonb WHERE id = $2', ['{}', F_STATUS])
+      const absentInstance = await startInstance({ summary: 'A', amount: 3 })
+      await approveInstance(absentInstance)
+      await svc.handleApprovalCompletionTrigger(completionEvent(absentInstance, `evt_fwbact_${TS}_sel_absent`))
+      await waitForExecutionCount(ruleId, before + 4)
+      exec = await lastExecution(ruleId)
+      expect(exec?.steps?.[0]?.status).toBe('failed')
+      expect(String(exec?.steps?.[0]?.error ?? '')).toBe('fwb_rejected:mapping_target_changed')
+      expect((await stateFor(absentInstance, ruleId)).claims).toBe(0)
+      expect(await ruleOutbox(`evt_fwbact_${TS}_sel_absent`)).toEqual([])
+    } finally {
+      setFlags(false, false)
+      await q('UPDATE meta_fields SET property = $1::jsonb WHERE id = $2', [JSON.stringify({ options: [{ value: 'A' }, { value: 'B' }] }), F_STATUS])
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-p2-fwb-eight-scenario-matrix.test.ts
+++ b/packages/core-backend/tests/integration/multitable-p2-fwb-eight-scenario-matrix.test.ts
@@ -377,7 +377,7 @@ describeIfDatabase('八场景全链验收矩阵 (P2 × ledger × FWB, real DB)',
       expect(await sheetRecordCount()).toBe(1)
       expect(await claimsFor(instanceA)).toBe(1)
       const rec = await q('SELECT data FROM meta_records WHERE sheet_id = $1', [SHEET_ID])
-      expect((rec.rows[0] as { data: Record<string, unknown> }).data).toMatchObject({ [F_TITLE]: 'S6 net-once', [F_AMOUNT]: 42 })
+      expect((rec.rows[0] as { data: Record<string, unknown> }).data).toMatchObject({ [F_TITLE]: 'S6 net-once', [F_AMOUNT]: '42' }) // D7: canonical decimal STRING
       expect(await sheetRevisionCount()).toBe(1)
       expect(await outboxCountLike(`${evtA}::fwb::`)).toBe(1)
 

--- a/packages/core-backend/tests/unit/approval-form-value-mapping.test.ts
+++ b/packages/core-backend/tests/unit/approval-form-value-mapping.test.ts
@@ -1,4 +1,23 @@
-/** FWB-1 slice ① — pure mapping goldens (runs in the required no-DB lane). Fail-closed all-or-nothing. */
+/**
+ * FWB-1 slice ① — pure mapping goldens (runs in the required no-DB lane). Fail-closed all-or-nothing.
+ *
+ * MUTATION NOTES (discriminating assertions — each pins a mutant that a weaker test would pass):
+ *   - number output is a STRING ('42', not 42): kills the mutant that returns JS Numbers (D7 float-loss).
+ *   - '1e3'/'1E-2' reject: kills a mutant regex that admits exponent notation.
+ *   - '.5'/'5.'/'+5'/''/'  ' reject: kills grammar mutants admitting partial lexemes.
+ *   - '007.50' → '7.5', '-0.00' → '0': kills mutants that skip leading-zero or signed-zero canonicalization
+ *     (two DISTINCT mutants — one test each).
+ *   - '12.340' under precision 2 → '12.34' passes while '12.345' rejects: kills mutants measuring scale
+ *     before trailing-zero stripping, and mutants that round instead of rejecting (Q5).
+ *   - '9007199254740993' (string) passes EXACTLY while 9007199254740993 (number) rejects: kills the mutant
+ *     that rejects long decimal STRING lexemes (exact arbitrary precision — they never pass through
+ *     Number) AND the mutant that trusts unsafe JS integers.
+ *   - 9007199254740991.1 (number) rejects: JSON.parse rounds it to the SAFE integer 9007199254740991 —
+ *     the safe-integer check alone cannot see the destroyed fraction; kills the mutant that drops the
+ *     ≤15-significant-digit envelope on numeric inputs (fabricated digits would be written).
+ *   - date rejects epoch-ms numbers (not_a_date): kills the mutant that keeps the deleted epoch branch
+ *     (D8: no epoch input, no timezone conversion).
+ */
 import { describe, expect, test } from 'vitest'
 
 import { mapApprovalFormValues, type FwbFieldMapping } from '../../src/multitable/approval-form-value-mapping'
@@ -10,19 +29,26 @@ const M = (over: Partial<FwbFieldMapping>): FwbFieldMapping => ({
   ...over,
 })
 
+const rejectCode = (m: FwbFieldMapping, v: unknown): string => {
+  const r = mapApprovalFormValues([m], { f1: v })
+  expect(r.ok).toBe(false)
+  if (!r.ok) return r.errors[0].code
+  throw new Error('unreachable')
+}
+
 describe('FWB-1 form-value mapping (pure, fail-closed)', () => {
-  test('happy path: text/number/date/select all map; number strings + epoch dates normalize', () => {
+  test('happy path: text/number/date/select all map; numbers normalize to CANONICAL DECIMAL STRINGS', () => {
     const r = mapApprovalFormValues(
       [
         M({ formFieldId: 'a', targetFieldId: 'ta', targetType: 'text' }),
         M({ formFieldId: 'b', targetFieldId: 'tb', targetType: 'number' }),
         M({ formFieldId: 'c', targetFieldId: 'tc', targetType: 'date' }),
-        M({ formFieldId: 'd', targetFieldId: 'td', targetType: 'date' }),
+        M({ formFieldId: 'd', targetFieldId: 'td', targetType: 'number' }),
         M({ formFieldId: 'e', targetFieldId: 'te', targetType: 'select', selectOptions: ['低', '中', '高'] }),
       ],
-      { a: 42, b: ' 3.5 ', c: '2026-07-15', d: Date.UTC(2026, 6, 15), e: '高' },
+      { a: 42, b: ' 3.5 ', c: '2026-07-15', d: 1000, e: '高' },
     )
-    expect(r).toEqual({ ok: true, values: { ta: '42', tb: 3.5, tc: '2026-07-15', td: '2026-07-15', te: '高' } })
+    expect(r).toEqual({ ok: true, values: { ta: '42', tb: '3.5', tc: '2026-07-15', td: '1000', te: '高' } })
   })
 
   test('ALL-OR-NOTHING: one bad mapping rejects the whole action with per-mapping codes', () => {
@@ -46,17 +72,13 @@ describe('FWB-1 form-value mapping (pure, fail-closed)', () => {
       [M({ targetType: 'date' }), '15/07/2026', 'not_a_date'],
     ]
     for (const [m, v, code] of cases) {
-      const r = mapApprovalFormValues([m], { f1: v })
-      expect(r.ok).toBe(false)
-      if (!r.ok) expect(r.errors[0].code).toBe(code)
+      expect(rejectCode(m, v)).toBe(code)
     }
   })
 
   test('rejects calendar-invalid ISO dates instead of persisting invented dates', () => {
     for (const value of ['2026-02-29', '2026-02-31', '2026-04-31', '2026-13-01', '2026-00-10']) {
-      const r = mapApprovalFormValues([M({ targetType: 'date' })], { f1: value })
-      expect(r.ok).toBe(false)
-      if (!r.ok) expect(r.errors[0].code).toBe('not_a_date')
+      expect(rejectCode(M({ targetType: 'date' }), value)).toBe('not_a_date')
     }
 
     expect(mapApprovalFormValues([M({ targetType: 'date' })], { f1: '2024-02-29' })).toEqual({
@@ -65,24 +87,103 @@ describe('FWB-1 form-value mapping (pure, fail-closed)', () => {
     })
   })
 
+  test('date accepts ONLY explicit calendar-date strings — epoch-ms numbers and datetimes reject (lock D8)', () => {
+    // epoch-ms number input: the deleted coercion path — a number must NEVER become a date.
+    expect(rejectCode(M({ targetType: 'date' }), Date.UTC(2026, 6, 15))).toBe('not_a_date')
+    expect(rejectCode(M({ targetType: 'date' }), 0)).toBe('not_a_date')
+    // datetime / timezoned strings are not calendar-date literals.
+    expect(rejectCode(M({ targetType: 'date' }), '2026-07-15T00:00:00Z')).toBe('not_a_date')
+    expect(rejectCode(M({ targetType: 'date' }), '2026-07-15+08:00')).toBe('not_a_date')
+  })
+
   test('missing/blank form values are errors (never silently skipped)', () => {
     for (const v of [undefined, null, '   ']) {
-      const r = mapApprovalFormValues([M({})], { f1: v })
-      expect(r.ok).toBe(false)
-      if (!r.ok) expect(r.errors[0].code).toBe('missing_required_value')
+      expect(rejectCode(M({}), v)).toBe('missing_required_value')
     }
   })
 
-  test('numbers fail closed on unsafe integer precision and target decimal scale', () => {
-    const unsafe = mapApprovalFormValues([M({ targetType: 'number' })], { f1: 9007199254740993 })
-    expect(unsafe.ok).toBe(false)
-    if (!unsafe.ok) expect(unsafe.errors[0].code).toBe('number_not_lossless')
+  test('number canonicalization: leading zeros, trailing zeros, signed zero (lock D7)', () => {
+    const cases: Array<[string, string]> = [
+      ['007.50', '7.5'],
+      ['000', '0'],
+      ['-0', '0'],
+      ['-0.00', '0'],
+      ['0.0', '0'],
+      ['3.500', '3.5'],
+      ['10.000', '10'],
+      ['-001.2500', '-1.25'],
+      ['0.5', '0.5'],
+      ['-42', '-42'],
+    ]
+    for (const [input, canonical] of cases) {
+      expect(mapApprovalFormValues([M({ targetType: 'number' })], { f1: input }))
+        .toEqual({ ok: true, values: { t1: canonical } })
+    }
+  })
 
-    const tooPrecise = mapApprovalFormValues([M({ targetType: 'number', numberPrecision: 2 })], { f1: '12.345' })
-    expect(tooPrecise.ok).toBe(false)
-    if (!tooPrecise.ok) expect(tooPrecise.errors[0].code).toBe('number_precision_exceeded')
+  test('number STRING lexemes are EXACT at any scale — arbitrary precision, never through Number', () => {
+    // 17 significant digits exceed the numeric-input envelope; as a STRING lexeme it is exact decimal
+    // data and must round-trip byte-for-byte (the envelope bounds only JSON.parse-rounded numerics).
+    expect(mapApprovalFormValues([M({ targetType: 'number' })], { f1: '9007199254740993' }))
+      .toEqual({ ok: true, values: { t1: '9007199254740993' } })
+    expect(mapApprovalFormValues([M({ targetType: 'number' })], { f1: '0.123456789012345678901234567890' }))
+      .toEqual({ ok: true, values: { t1: '0.12345678901234567890123456789' } })
+  })
 
+  test('number rejects JSON numeric inputs whose provenance cannot be lossless (>15 significant digits)', () => {
+    // REGRESSION (exact counterexample): the literal 9007199254740991.1 rounds to the SAFE integer
+    // 9007199254740991 at JSON parse — the .1 fraction is destroyed before this function runs and the
+    // safe-integer check alone PASSES it. The significant-digit envelope is what rejects it; writing it
+    // would fabricate digits. (Same shape: 9007199254740990.5 → 9007199254740990.)
+    expect(rejectCode(M({ targetType: 'number' }), 9007199254740991.1)).toBe('number_not_lossless')
+    expect(rejectCode(M({ targetType: 'number' }), 9007199254740990.5)).toBe('number_not_lossless')
+    expect(rejectCode(M({ targetType: 'number' }), 1234567890123456.7)).toBe('number_not_lossless')
+    // boundary: exactly 15 significant digits stays inside the reliably round-trippable envelope.
+    expect(mapApprovalFormValues([M({ targetType: 'number' })], { f1: 123456789012345 }))
+      .toEqual({ ok: true, values: { t1: '123456789012345' } })
+    expect(mapApprovalFormValues([M({ targetType: 'number' })], { f1: 0.123456789012345 }))
+      .toEqual({ ok: true, values: { t1: '0.123456789012345' } })
+  })
+
+  test('number rejects exponent notation, NaN/Infinity and malformed lexemes (never coerced)', () => {
+    const notANumber: unknown[] = [
+      '1e3', '1E-2', '1e+3', // exponent notation
+      'NaN', 'Infinity', '-Infinity', 'inf',
+      '.5', '5.', '+5', '--5', '0x10', '0b101', '1_000', '1,000', '1.2.3', 'abc', '-',
+      true, {}, [], Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY,
+    ]
+    for (const v of notANumber) {
+      expect(rejectCode(M({ targetType: 'number' }), v)).toBe('not_a_number')
+    }
+  })
+
+  test('number rejects unsafe JS-number inputs (already lossy / non-canonical), not_a_number vs not_lossless', () => {
+    // unsafe integer: JSON parse already destroyed the source lexeme — writing it would fabricate digits.
+    expect(rejectCode(M({ targetType: 'number' }), 9007199254740993)).toBe('number_not_lossless')
+    // exponent-form String() output: no canonical fixed-point form here.
+    expect(rejectCode(M({ targetType: 'number' }), 1e21)).toBe('number_not_lossless')
+    expect(rejectCode(M({ targetType: 'number' }), 1e-7)).toBe('number_not_lossless')
+    // safe finite JS numbers DO map (the JSON-snapshot happy path), canonicalized.
+    expect(mapApprovalFormValues([M({ targetType: 'number' })], { f1: 12.340 }))
+      .toEqual({ ok: true, values: { t1: '12.34' } })
+  })
+
+  test('numbers fail closed on target decimal scale — excess REAL scale rejects, never rounds (§11 Q5)', () => {
+    expect(rejectCode(M({ targetType: 'number', numberPrecision: 2 }), '12.345')).toBe('number_precision_exceeded')
+    expect(rejectCode(M({ targetType: 'number', numberPrecision: 0 }), '0.5')).toBe('number_precision_exceeded')
+    // trailing zeros carry no information: scale is measured AFTER canonicalization.
     expect(mapApprovalFormValues([M({ targetType: 'number', numberPrecision: 2 })], { f1: '12.340' }))
-      .toEqual({ ok: true, values: { t1: 12.34 } })
+      .toEqual({ ok: true, values: { t1: '12.34' } })
+    expect(mapApprovalFormValues([M({ targetType: 'number', numberPrecision: 0 })], { f1: '5.000' }))
+      .toEqual({ ok: true, values: { t1: '5' } })
+  })
+
+  test('errors stay values-free: rejection payloads carry identifiers and codes only', () => {
+    const r = mapApprovalFormValues([M({ targetType: 'number' })], { f1: 'secret-amount-1e9' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(JSON.stringify(r.errors)).not.toContain('secret-amount')
+      expect(r.errors[0]).toEqual({ formFieldId: 'f1', targetFieldId: 't1', code: 'not_a_number' })
+    }
   })
 })

--- a/packages/core-backend/tests/unit/approval-fwb-runtime-mappings.test.ts
+++ b/packages/core-backend/tests/unit/approval-fwb-runtime-mappings.test.ts
@@ -1,0 +1,174 @@
+/**
+ * FWB-1 — `resolveFwbRuntimeMappings` execute-time target-field recheck (no-DB lane, stubbed query).
+ *
+ * Contract (FWB0 §5 「字段类型 fire 时复验」 + D6/D7): the saved mapping's metadata is NEVER trusted at
+ * execute time — select option membership and number precision are re-derived from the CURRENT
+ * meta_fields rows inside the transaction, and every staleness shape fails CLOSED before
+ * `mapApprovalFormValues` runs.
+ *
+ * MUTATION NOTES (discriminating assertions):
+ *   - stale saved selectOptions containing the REMOVED option must NOT admit it: kills the mutant that
+ *     keeps consulting the saved mapping's option set (the exact bug this seam exists to close).
+ *   - an option ADDED after save remains unauthorized until the mapping is re-confirmed; the real-DB
+ *     suite carries the re-save positive control so this does not degenerate into "reject everything".
+ *   - property.options absent / unparseable-string / empty → fail closed: kills mutants that treat a
+ *     missing option set as an open vocabulary (D6).
+ *   - field row missing / type changed → fail closed: kills mutants that skip the count or type check.
+ *   - numberPrecision comes from property.decimals only: kills the mutant that invents a second
+ *     `precision` spelling (which would silently drop the execute-time cap, §11 Q5).
+ *   - failure shape carries NO field values/options — identifiers-free, values-free.
+ */
+import { describe, expect, test } from 'vitest'
+
+import { resolveFwbRuntimeMappings } from '../../src/multitable/approval-fwb-write-action'
+import type { FwbFieldMapping } from '../../src/multitable/approval-form-value-mapping'
+
+type Row = { id: string; type: string; property?: unknown }
+
+const stubQuery = (rows: Row[]) => {
+  const calls: Array<{ sql: string; params?: unknown[] }> = []
+  const query = async (sql: string, params?: unknown[]) => {
+    calls.push({ sql, params })
+    expect(sql).toContain('FOR SHARE') // the recheck must hold the rows for the whole transaction
+    return { rows: rows as unknown[] }
+  }
+  return { query, calls }
+}
+
+const M = (over: Partial<FwbFieldMapping>): FwbFieldMapping => ({
+  formFieldId: 'f1',
+  targetFieldId: 't1',
+  targetType: 'select',
+  ...over,
+})
+
+describe('resolveFwbRuntimeMappings — execute-time target-field recheck (fail closed)', () => {
+  test('select mappings use confirmed-current intersection; added and removed options cannot bypass confirmation', async () => {
+    const { query } = stubQuery([
+      { id: 't1', type: 'select', property: JSON.stringify({ options: [{ value: '中' }, { value: '新' }] }) },
+    ])
+    const r = await resolveFwbRuntimeMappings(query, 'sheet1', [
+      M({ selectOptions: ['低', '中', '高'] }), // saved set is stale — the field dropped '低'
+    ])
+    expect(r).toEqual({
+      ok: true,
+      // '新' exists now but was never confirmed; '低'/'高' were confirmed but no longer exist.
+      mappings: [{ formFieldId: 'f1', targetFieldId: 't1', targetType: 'select', selectOptions: ['中'] }],
+    })
+  })
+
+  test('fails closed when select field options are absent, unparseable, or empty (D6: no open vocabulary)', async () => {
+    for (const property of [
+      '{}', // options absent
+      '{broken json', // unparseable
+      JSON.stringify({ options: [] }), // empty
+      JSON.stringify({ options: [{ name: 'no value key' }, 42, null] }), // no usable option values
+    ]) {
+      const { query } = stubQuery([{ id: 't1', type: 'select', property }])
+      const r = await resolveFwbRuntimeMappings(query, 'sheet1', [M({ selectOptions: ['a'] })])
+      expect(r.ok).toBe(false)
+      if (!r.ok) {
+        expect(r.code).toBe('mapping_target_changed')
+        expect(JSON.stringify(r)).not.toContain('no value key') // values-free failure
+      }
+    }
+  })
+
+  test('fails closed when a target field row is missing or its type changed since save', async () => {
+    // missing row
+    const missing = stubQuery([])
+    expect(await resolveFwbRuntimeMappings(missing.query, 'sheet1', [M({ selectOptions: ['a'] })]))
+      .toEqual({ ok: false, code: 'mapping_target_changed' })
+    // type changed select → text
+    const retyped = stubQuery([{ id: 't1', type: 'text', property: '{}' }])
+    expect(await resolveFwbRuntimeMappings(retyped.query, 'sheet1', [M({ selectOptions: ['a'] })]))
+      .toEqual({ ok: false, code: 'mapping_target_changed' })
+  })
+
+  test('number mappings attach numberPrecision from canonical property.decimals, including numeric strings', async () => {
+    const { query } = stubQuery([
+      { id: 't1', type: 'number', property: { decimals: '2', precision: 99 } },
+      { id: 't2', type: 'number', property: '{}' },
+    ])
+    const r = await resolveFwbRuntimeMappings(query, 'sheet1', [
+      M({ targetFieldId: 't1', targetType: 'number' }),
+      M({ targetFieldId: 't2', targetType: 'number' }),
+    ])
+    expect(r).toEqual({
+      ok: true,
+      mappings: [
+        { formFieldId: 'f1', targetFieldId: 't1', targetType: 'number', numberPrecision: 2 },
+        { formFieldId: 'f1', targetFieldId: 't2', targetType: 'number' },
+      ],
+    })
+  })
+
+  test('number precision: current field metadata REPLACES saved numberPrecision — tightening applies, removal removes', async () => {
+    // tightening: saved cap 5, field tightened to 1 after save → current 1 caps the execution (§11 Q5).
+    const tightened = stubQuery([{ id: 't1', type: 'number', property: { decimals: 1 } }])
+    expect(await resolveFwbRuntimeMappings(tightened.query, 'sheet1', [
+      M({ targetFieldId: 't1', targetType: 'number', numberPrecision: 5 }),
+    ])).toEqual({
+      ok: true,
+      mappings: [{ formFieldId: 'f1', targetFieldId: 't1', targetType: 'number', numberPrecision: 1 }],
+    })
+    // removal: saved cap 5, field cap REMOVED after save → the stale saved cap must NOT survive
+    // (kills the mutant that spreads `...mapping` and keeps saved numberPrecision).
+    const removed = stubQuery([{ id: 't1', type: 'number', property: '{}' }])
+    expect(await resolveFwbRuntimeMappings(removed.query, 'sheet1', [
+      M({ targetFieldId: 't1', targetType: 'number', numberPrecision: 5 }),
+    ])).toEqual({
+      ok: true,
+      mappings: [{ formFieldId: 'f1', targetFieldId: 't1', targetType: 'number' }],
+    })
+  })
+
+  test('number precision fails closed when present metadata cannot be canonicalized', async () => {
+    for (const property of [
+      { decimals: 'not-a-number' },
+      { decimals: true },
+      { decimals: null },
+      { decimals: '' },
+      { decimals: [] },
+      { decimals: [2] },
+      { decimals: '0x2' },
+      { decimals: '1e2' },
+      { decimals: -1 },
+      { decimals: 7 },
+      '{broken json',
+    ]) {
+      const invalid = stubQuery([{ id: 't1', type: 'number', property }])
+      expect(await resolveFwbRuntimeMappings(invalid.query, 'sheet1', [
+        M({ targetFieldId: 't1', targetType: 'number', numberPrecision: 5 }),
+      ])).toEqual({ ok: false, code: 'mapping_target_changed' })
+    }
+
+    // The platform canonicalizer rounds a fractional field-property value at write time; preserve
+    // that established metadata contract instead of inventing a second precision parser here.
+    const fractional = stubQuery([{ id: 't1', type: 'number', property: { decimals: 1.6 } }])
+    expect(await resolveFwbRuntimeMappings(fractional.query, 'sheet1', [
+      M({ targetFieldId: 't1', targetType: 'number' }),
+    ])).toEqual({
+      ok: true,
+      mappings: [{ formFieldId: 'f1', targetFieldId: 't1', targetType: 'number', numberPrecision: 2 }],
+    })
+  })
+
+  test('text/date mappings pass through unchanged once existence + type are verified', async () => {
+    const { query } = stubQuery([
+      { id: 't1', type: 'string', property: '{}' },
+      { id: 't2', type: 'date', property: '{}' },
+    ])
+    const r = await resolveFwbRuntimeMappings(query, 'sheet1', [
+      M({ targetFieldId: 't1', targetType: 'text' }),
+      M({ targetFieldId: 't2', targetType: 'date' }),
+    ])
+    expect(r).toEqual({
+      ok: true,
+      mappings: [
+        { formFieldId: 'f1', targetFieldId: 't1', targetType: 'text' },
+        { formFieldId: 'f1', targetFieldId: 't2', targetType: 'date' },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
## Scope\n\nStacked on #4510. This slice closes the FWB mapping contract without changing runtime flags.\n\n- preserves exact decimal strings and rejects already-lossy numeric provenance\n- validates strict calendar dates\n- re-reads target-field metadata in the write transaction\n- intersects saved and current select options\n- distinguishes conceptual FWB text from canonical multitable string fields\n\n## Verification\n\n- backend mapping/runtime unit: 20 passed\n- frontend mapping contract: 3 passed\n- backend tsc and frontend vue-tsc: passed\n- fresh PostgreSQL activation + S1-S8 matrix: 25 passed\n- independent adversarial re-review: APPROVE, no blockers\n\n## Boundary\n\nDraft and stacked. Merge #4510 first, then retarget/rebase this PR. FWB and durable-delivery flags remain OFF.