### PR TITLE
feat(core-backend): W4-PRE-1 — user_orgs production maintenance write path (org-membership lifecycle)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -820,6 +820,9 @@ jobs:
             tests/integration/attendance-approval-direct-manager-s7-2.db.test.ts \
             tests/integration/attendance-approval-dept-head-s7-3.db.test.ts \
             tests/integration/attendance-approval-manager-at-level-s7-4.db.test.ts \
+            tests/integration/attendance-w4pre1-user-orgs-admission.db.test.ts \
+            tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts \
+            tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/packages/core-backend/src/auth/AuthService.ts
+++ b/packages/core-backend/src/auth/AuthService.ts
@@ -296,6 +296,19 @@ export class AuthService {
   /**
    * 用户注册
    */
+  // W4-PRE-1 policy (§3.3 item 2 of the Wave-4 onboarding design lock, docs/development/
+  // attendance-w4-pre1-user-orgs-lifecycle-20260721.md): this signature carries no org
+  // parameter and this deployment-level self-service registration path has no source of an
+  // authoritative org anywhere in its call chain — it is the design lock's own example of an
+  // "org 不可知的路径(如部署级注册)". Per the explicit ticket instruction, an org-unknowable
+  // path MUST record its policy and MUST NOT silently guess an org (e.g. defaulting to
+  // 'default' — that string is the one-time zzzz20260114110000 backfill's semantics, not a
+  // live admission default). Deliberately: this method does NOT write user_orgs. A user
+  // created here has no org membership until an org-aware admission path (POST
+  // /api/admin/users with attendanceOrgId, or directory sync admission) later adds one, or an
+  // operator backfills it explicitly. Verified by
+  // attendance-w4pre1-user-orgs-org-unknowable-policy.db.test.ts (zero user_orgs rows for a
+  // user created via this path).
   async register(email: string, password: string, name: string): Promise<User | null> {
     try {
       // 检查邮箱是否已存在

--- a/packages/core-backend/src/auth/AuthService.ts
+++ b/packages/core-backend/src/auth/AuthService.ts
@@ -297,7 +297,7 @@ export class AuthService {
    * 用户注册
    */
   // W4-PRE-1 policy (§3.3 item 2 of the Wave-4 onboarding design lock, docs/development/
-  // attendance-w4-pre1-user-orgs-lifecycle-20260721.md): this signature carries no org
+  // attendance-vnext-wave4-onboarding-design-lock-20260721.md): this signature carries no org
   // parameter and this deployment-level self-service registration path has no source of an
   // authoritative org anywhere in its call chain — it is the design lock's own example of an
   // "org 不可知的路径(如部署级注册)". Per the explicit ticket instruction, an org-unknowable
@@ -307,7 +307,7 @@ export class AuthService {
   // created here has no org membership until an org-aware admission path (POST
   // /api/admin/users with attendanceOrgId, or directory sync admission) later adds one, or an
   // operator backfills it explicitly. Verified by
-  // attendance-w4pre1-user-orgs-org-unknowable-policy.db.test.ts (zero user_orgs rows for a
+  // tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts (zero user_orgs rows for a
   // user created via this path).
   async register(email: string, password: string, name: string): Promise<User | null> {
     try {

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -613,8 +613,8 @@ function assertLocalUserLoginAllowed(localUser: LocalUserRow): void {
 }
 
 // W4-PRE-1 policy (§3.3 item 2 of the Wave-4 onboarding design lock, docs/development/
-// attendance-w4-pre1-user-orgs-lifecycle-20260721.md): DingTalk OAuth JIT admission has no
-// per-org context anywhere in this module — `readDingTalkOauthConfig()` reads a single
+// attendance-vnext-wave4-onboarding-design-lock-20260721.md): DingTalk OAuth JIT admission has
+// no per-org context anywhere in this module — `readDingTalkOauthConfig()` reads a single
 // deployment-wide `DINGTALK_CORP_ID` env var, not an org-scoped value, and there is no
 // existing corp_id→org resolution primitive elsewhere in this codebase this call could reuse
 // (the directory-sync admission path resolves org from a `directory_integrations` ROW, which
@@ -622,8 +622,8 @@ function assertLocalUserLoginAllowed(localUser: LocalUserRow): void {
 // design surface, not a wiring fix, and risks a WRONG org being silently attached (worse than
 // none). Per the explicit ticket instruction, org-unknowable paths record policy and do NOT
 // guess. Deliberately: this function does NOT write user_orgs. Verified by
-// attendance-w4pre1-user-orgs-org-unknowable-policy.db.test.ts (zero user_orgs rows for a user
-// created via this path).
+// tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts (zero user_orgs rows for a
+// user created via this path).
 async function createProvisionedUser(dtUser: DingTalkUserInfo): Promise<LocalUserRow> {
   const userId = crypto.randomUUID()
   // unionId first (review #3771 P2-1): the container surface has no openId, and

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -612,6 +612,18 @@ function assertLocalUserLoginAllowed(localUser: LocalUserRow): void {
   }
 }
 
+// W4-PRE-1 policy (§3.3 item 2 of the Wave-4 onboarding design lock, docs/development/
+// attendance-w4-pre1-user-orgs-lifecycle-20260721.md): DingTalk OAuth JIT admission has no
+// per-org context anywhere in this module — `readDingTalkOauthConfig()` reads a single
+// deployment-wide `DINGTALK_CORP_ID` env var, not an org-scoped value, and there is no
+// existing corp_id→org resolution primitive elsewhere in this codebase this call could reuse
+// (the directory-sync admission path resolves org from a `directory_integrations` ROW, which
+// this login flow never touches). Inventing a new corp_id→org inference here would be new
+// design surface, not a wiring fix, and risks a WRONG org being silently attached (worse than
+// none). Per the explicit ticket instruction, org-unknowable paths record policy and do NOT
+// guess. Deliberately: this function does NOT write user_orgs. Verified by
+// attendance-w4pre1-user-orgs-org-unknowable-policy.db.test.ts (zero user_orgs rows for a user
+// created via this path).
 async function createProvisionedUser(dtUser: DingTalkUserInfo): Promise<LocalUserRow> {
   const userId = crypto.randomUUID()
   // unionId first (review #3771 P2-1): the container surface has no openId, and
@@ -1114,4 +1126,14 @@ export async function bindDingTalkIdentityToUser(input: {
       )
     }
   })
+}
+
+/**
+ * W4-PRE-1 (§3.3 item 2): test-only seam so the "org-unknowable path does not silently write
+ * user_orgs" policy (see the comment on createProvisionedUser above) can be verified against a
+ * real admission, not just read as a comment. Mirrors the __directorySyncInternalsForTests
+ * pattern in directory-sync.ts — not a new production surface.
+ */
+export const __dingtalkOAuthInternalsForTests = {
+  createProvisionedUser,
 }

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -5056,16 +5056,48 @@ async function createDirectoryAdmittedUserInTransaction(
     }
   }
 
+  // W4-PRE-1 item 1 + item 2 (§3.3 of the Wave-4 onboarding design lock): resolve the
+  // KNOWN AUTHORITATIVE org for this admission from directory_integrations (the account's own
+  // integration row), never from a client-supplied value and never a silent 'default' guess.
+  // Fail-closed BEFORE any write (cheapest-check-first, same discipline as the
+  // DT-HARDEN-02 grant-feasibility assert above) if the integration row cannot be found — this
+  // should not happen in practice (the caller always resolves the account through a live
+  // integration_id) but a foreign-key-orphaned integration_id must not silently admit into no
+  // org, or into a guessed one.
+  const orgResult = await client.query(
+    `SELECT org_id
+     FROM directory_integrations
+     WHERE id = $1::uuid
+     LIMIT 1`,
+    [options.account.integration_id],
+  )
+  const admissionOrgId = (orgResult.rows[0] as { org_id?: string } | undefined)?.org_id
+  if (!admissionOrgId) {
+    throw new Error('Directory integration not found for admitted account org resolution')
+  }
+
   // DT-HARDEN-02: INSERT + bind are one all-or-nothing unit. A bind throw after the INSERT
   // (missing openId/unionId, or an identity already bound to another local user) would
   // otherwise leave a committed orphan once the sync loop swallows the error — the exact
   // hazard this ticket exists to close, and the one the pre-INSERT assert above does not cover.
+  // W4-PRE-1 extends the same all-or-nothing unit to user_orgs: a user_orgs write failure must
+  // also roll the users row back (fresh-DB atomicity leg, §3.3 item 3), not just a bind failure.
   await client.query('SAVEPOINT directory_admit_user')
   try {
     await client.query(
       `INSERT INTO users (id, email, username, name, mobile, password_hash, must_change_password, role, permissions, is_active, is_admin, created_at, updated_at)
        VALUES ($1::text, $2::text, $3::text, $4::text, $5::text, $6::text, $7::boolean, 'user', $8::jsonb, TRUE, FALSE, NOW(), NOW())`,
       [userId, options.email, options.username, options.name, options.mobile, options.passwordHash, options.mustChangePassword, JSON.stringify([])],
+    )
+
+    // W4-PRE-1 item 1 (§3.3): maintain user_orgs in the SAME transaction/savepoint as the users
+    // row. A freshly admitted directory user is always active (matches the hardcoded TRUE on the
+    // users INSERT above).
+    await client.query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active)
+       VALUES ($1::text, $2::text, TRUE)
+       ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = EXCLUDED.is_active`,
+      [userId, admissionOrgId],
     )
 
     await applyDirectoryAccountBindInTransaction(client, {

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -12,7 +12,7 @@ import { getUserSession, listUserSessions, revokeUserSession } from '../auth/ses
 import { revokeUserSessions } from '../auth/session-revocation'
 import { auditLog } from '../audit/audit'
 import { authenticate } from '../middleware/auth'
-import { query } from '../db/pg'
+import { query, transaction } from '../db/pg'
 import { invalidateUserPerms, isAdmin as isRbacAdmin, listUserPermissions } from '../rbac/service'
 import {
   deriveDelegatedAdminNamespace,
@@ -3211,52 +3211,6 @@ export function adminUsersRouter(): Router {
         userId,
       })
 
-      await query(
-        `INSERT INTO users (
-           id, email, username, name, mobile, employee_no, department, position, hire_date,
-           password_hash, must_change_password, role, permissions, is_active, is_admin, created_at, updated_at
-         )
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::date, $10, $11, $12, $13::jsonb, $14, $15, NOW(), NOW())`,
-        [
-          userId,
-          cleanEmail || null,
-          cleanUsername,
-          cleanName,
-          cleanMobile,
-          cleanEmployeeNo,
-          cleanDepartment,
-          cleanPosition,
-          cleanHireDate,
-          passwordHash,
-          mustChangePassword,
-          effectiveRole,
-          JSON.stringify(directPermissions),
-          isActive,
-          effectiveRole === 'admin',
-        ],
-      )
-
-      if (roleId) {
-        await query(
-          `INSERT INTO user_roles (user_id, role_id)
-           VALUES ($1, $2)
-           ON CONFLICT DO NOTHING`,
-          [userId, roleId],
-        )
-        invalidateUserPerms(userId)
-      }
-
-      if (directPermissions.length > 0) {
-        const values = directPermissions.map((_, index) => `($1, $${index + 2})`).join(', ')
-        await query(
-          `INSERT INTO user_permissions (user_id, permission_code)
-           VALUES ${values}
-           ON CONFLICT DO NOTHING`,
-          [userId, ...directPermissions],
-        )
-        invalidateUserPerms(userId)
-      }
-
       const attendanceOnboarding: AttendanceOnboardingResponse | null = attendanceOrgId
         ? {
             orgId: attendanceOrgId,
@@ -3264,36 +3218,112 @@ export function adminUsersRouter(): Router {
             defaultShift: null,
           }
         : null
-      if (attendanceOnboarding && cleanAttendanceGroupId) {
-        const memberResult = await query<{ memberId: string }>(
-          `INSERT INTO attendance_group_members (org_id, group_id, user_id, created_at, updated_at)
-           VALUES ($1, $2, $3, NOW(), NOW())
-           ON CONFLICT (org_id, group_id, user_id) DO NOTHING
-           RETURNING id AS "memberId"`,
-          [attendanceOrgId, cleanAttendanceGroupId, userId],
+
+      // W4-PRE-1 (§3.3 of the Wave-4 onboarding design lock): this route is the first-priority
+      // user_orgs write site — it already resolves and validates a KNOWN AUTHORITATIVE org
+      // (attendanceOrgId, only set when attendanceGroupId/defaultShiftId was supplied and
+      // matched against attendance_groups/attendance_shifts.org_id above) but historically wrote
+      // users/user_roles/user_permissions/attendance_group_members/attendance_shift_assignments
+      // as independent auto-commit statements with no shared transaction boundary. The W4-PRE-1
+      // atomicity requirement (a user_orgs write failure must roll back the whole admission —
+      // never a `users` row with no membership row) cannot be met without a transaction, and none
+      // existed to reuse, so this establishes the single boundary for the whole write sequence
+      // (not a second/competing one — every write below moved from `query()` to `client.query()`
+      // inside this one call).
+      await transaction(async (client) => {
+        await client.query(
+          `INSERT INTO users (
+             id, email, username, name, mobile, employee_no, department, position, hire_date,
+             password_hash, must_change_password, role, permissions, is_active, is_admin, created_at, updated_at
+           )
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::date, $10, $11, $12, $13::jsonb, $14, $15, NOW(), NOW())`,
+          [
+            userId,
+            cleanEmail || null,
+            cleanUsername,
+            cleanName,
+            cleanMobile,
+            cleanEmployeeNo,
+            cleanDepartment,
+            cleanPosition,
+            cleanHireDate,
+            passwordHash,
+            mustChangePassword,
+            effectiveRole,
+            JSON.stringify(directPermissions),
+            isActive,
+            effectiveRole === 'admin',
+          ],
         )
-        attendanceOnboarding.group = {
-          id: cleanAttendanceGroupId,
-          name: attendanceGroupName,
-          memberCreated: memberResult.rows.length > 0,
+
+        if (roleId) {
+          await client.query(
+            `INSERT INTO user_roles (user_id, role_id)
+             VALUES ($1, $2)
+             ON CONFLICT DO NOTHING`,
+            [userId, roleId],
+          )
         }
-      }
-      if (attendanceOnboarding && cleanDefaultShiftId && defaultShiftStartDate) {
-        const assignmentId = crypto.randomUUID()
-        const assignmentResult = await query<{ assignmentId: string }>(
-          `INSERT INTO attendance_shift_assignments
-             (id, org_id, user_id, shift_id, start_date, is_active, created_at, updated_at)
-           VALUES ($1, $2, $3, $4, $5::date, true, NOW(), NOW())
-           RETURNING id AS "assignmentId"`,
-          [assignmentId, attendanceOrgId, userId, cleanDefaultShiftId, defaultShiftStartDate],
-        )
-        attendanceOnboarding.defaultShift = {
-          id: cleanDefaultShiftId,
-          name: defaultShiftName,
-          startDate: defaultShiftStartDate,
-          assignmentId: assignmentResult.rows[0]?.assignmentId ?? assignmentId,
+
+        if (directPermissions.length > 0) {
+          const values = directPermissions.map((_, index) => `($1, $${index + 2})`).join(', ')
+          await client.query(
+            `INSERT INTO user_permissions (user_id, permission_code)
+             VALUES ${values}
+             ON CONFLICT DO NOTHING`,
+            [userId, ...directPermissions],
+          )
         }
-      }
+
+        if (attendanceOrgId) {
+          // W4-PRE-1 item 1 (first-priority site, §3.3): maintain user_orgs in the SAME
+          // transaction as the users row whenever the org is known-authoritative. `isActive`
+          // mirrors the created user's own active flag — an admin-created-but-deactivated user
+          // must not count as an active org member (RD-3 dual is_active precedent,
+          // plugins/plugin-attendance/index.cjs:15532-15541).
+          await client.query(
+            `INSERT INTO user_orgs (user_id, org_id, is_active)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = EXCLUDED.is_active`,
+            [userId, attendanceOrgId, isActive],
+          )
+        }
+
+        if (attendanceOnboarding && cleanAttendanceGroupId) {
+          const memberResult = await client.query(
+            `INSERT INTO attendance_group_members (org_id, group_id, user_id, created_at, updated_at)
+             VALUES ($1, $2, $3, NOW(), NOW())
+             ON CONFLICT (org_id, group_id, user_id) DO NOTHING
+             RETURNING id AS "memberId"`,
+            [attendanceOrgId, cleanAttendanceGroupId, userId],
+          )
+          attendanceOnboarding.group = {
+            id: cleanAttendanceGroupId,
+            name: attendanceGroupName,
+            memberCreated: (memberResult.rows as Array<{ memberId: string }>).length > 0,
+          }
+        }
+        if (attendanceOnboarding && cleanDefaultShiftId && defaultShiftStartDate) {
+          const assignmentId = crypto.randomUUID()
+          const assignmentResult = await client.query(
+            `INSERT INTO attendance_shift_assignments
+               (id, org_id, user_id, shift_id, start_date, is_active, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5::date, true, NOW(), NOW())
+             RETURNING id AS "assignmentId"`,
+            [assignmentId, attendanceOrgId, userId, cleanDefaultShiftId, defaultShiftStartDate],
+          )
+          attendanceOnboarding.defaultShift = {
+            id: cleanDefaultShiftId,
+            name: defaultShiftName,
+            startDate: defaultShiftStartDate,
+            assignmentId: (assignmentResult.rows as Array<{ assignmentId: string }>)[0]?.assignmentId ?? assignmentId,
+          }
+        }
+      })
+
+      // Cache invalidation is a post-commit side effect, not part of the atomic write set.
+      if (roleId) invalidateUserPerms(userId)
+      if (directPermissions.length > 0) invalidateUserPerms(userId)
 
       await auditLog({
         actorId: adminUserId,

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -3277,15 +3277,25 @@ export function adminUsersRouter(): Router {
 
         if (attendanceOrgId) {
           // W4-PRE-1 item 1 (first-priority site, §3.3): maintain user_orgs in the SAME
-          // transaction as the users row whenever the org is known-authoritative. `isActive`
-          // mirrors the created user's own active flag — an admin-created-but-deactivated user
-          // must not count as an active org member (RD-3 dual is_active precedent,
-          // plugins/plugin-attendance/index.cjs:15532-15541).
+          // transaction as the users row whenever the org is known-authoritative.
+          //
+          // user_orgs.is_active is hardcoded TRUE (mirrors directory-sync.ts's own admission
+          // write, ~L5097) — it deliberately does NOT mirror the created user's `isActive` flag.
+          // The RD-3 dual-is_active count (§3.3 item 4: user_orgs.is_active=true AND
+          // users.is_active=true) already excludes an admin-created-inactive user via
+          // users.is_active=false, so mirroring `isActive` here would add nothing to that count
+          // — but it WOULD create an unrecoverable stuck-false membership row: no production
+          // write path ever updates user_orgs.is_active after admission (PATCH
+          // /api/admin/users/:userId/status only touches users.is_active), so an
+          // admin-created-inactive user later reactivated via that endpoint would stay
+          // permanently excluded from the ① count with no repair surface. Hardcoding TRUE avoids
+          // the absorbing state entirely: membership existence is TRUE the moment it is known,
+          // and users.is_active alone gates the active-member-count filter.
           await client.query(
             `INSERT INTO user_orgs (user_id, org_id, is_active)
-             VALUES ($1, $2, $3)
+             VALUES ($1, $2, TRUE)
              ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = EXCLUDED.is_active`,
-            [userId, attendanceOrgId, isActive],
+            [userId, attendanceOrgId],
           )
         }
 

--- a/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-admission.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-admission.db.test.ts
@@ -23,6 +23,12 @@ import { query } from '../../src/db/pg'
  *     in the same org.
  * …plus the org-unknowable negative control for THIS route (no attendanceGroupId/
  * defaultShiftId supplied): zero user_orgs rows, never a silent 'default' guess (§3.3 item 2).
+ * …plus item 4's is_active semantics: user_orgs.is_active is hardcoded TRUE at admission
+ * (never mirrors the created user's own isActive) — an admin-created-inactive user is excluded
+ * from the RD-3 dual-is_active count via users.is_active alone, and reactivating that user later
+ * (PATCH /api/admin/users/:userId/status, the only production writer of users.is_active) needs
+ * no separate user_orgs repair, because user_orgs.is_active was never set to false in the first
+ * place.
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -242,6 +248,48 @@ describeIfDatabase('W4-PRE-1 — user_orgs admission write site: POST /api/admin
 
       const rows = await query(`SELECT org_id FROM user_orgs WHERE user_id = $1`, [userId])
       expect(rows.rows).toEqual([])
+    })
+  })
+
+  describe('user_orgs.is_active is hardcoded TRUE (never mirrors the created user\'s isActive)', () => {
+    it('isActive:false at creation still writes user_orgs.is_active=true, exclusion comes ONLY from users.is_active, and reactivation via PATCH status needs no membership repair', async () => {
+      const org = orgId('inactive')
+      const group = await seedGroup(org, 'inactive')
+
+      const { status, json } = await createUserViaRoute({
+        name: 'W4PRE1 Inactive',
+        email: emailFor('inactive'),
+        orgId: org,
+        attendanceGroupId: group.id,
+        isActive: false,
+      })
+
+      expect(status).toBe(200)
+      const userId = json.data.user.id as string
+
+      // The membership row exists and is_active=TRUE even though the user itself is inactive —
+      // this is the fix under test: is_active must NOT mirror the created user's isActive flag.
+      const row = await userOrgRow(userId, org)
+      expect(row).toEqual({ user_id: userId, org_id: org, is_active: true })
+
+      // Excluded from the RD-3 dual-is_active active-member count purely via users.is_active,
+      // never via user_orgs.is_active.
+      expect(await activeMemberCount(org)).toBe(0)
+
+      // Reactivate through the ONLY production write path that ever flips users.is_active
+      // (PATCH /api/admin/users/:userId/status — it never touches user_orgs).
+      const patchRes = await fetch(`${baseUrl}/api/admin/users/${userId}/status`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ isActive: true }),
+      })
+      expect(patchRes.status).toBe(200)
+
+      // No stuck-false membership to repair: user_orgs.is_active was TRUE all along, so the
+      // count now includes this member purely because users.is_active flipped.
+      expect(await activeMemberCount(org)).toBe(1)
+      const rowAfterReactivate = await userOrgRow(userId, org)
+      expect(rowAfterReactivate).toEqual({ user_id: userId, org_id: org, is_active: true })
     })
   })
 

--- a/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-admission.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-admission.db.test.ts
@@ -1,0 +1,289 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import crypto from 'node:crypto'
+import http from 'node:http'
+import express from 'express'
+import { authRouter } from '../../src/routes/auth'
+import { adminUsersRouter } from '../../src/routes/admin-users'
+import { query } from '../../src/db/pg'
+
+/**
+ * W4-PRE-1 (§3.3 of docs/development/attendance-vnext-wave4-onboarding-design-lock-20260721.md,
+ * the pre-ticket owner errata #4513 blocked Wave 4 on): before this PR, `user_orgs` had exactly
+ * ONE production writer — the one-time zzzz20260114110000 backfill migration. `POST
+ * /api/admin/users` is the FIRST-PRIORITY write site named in the ticket: it already resolves
+ * and validates a known-authoritative org (attendanceOrgId, checked against
+ * attendance_groups.org_id / attendance_shifts.org_id above the write) whenever attendance
+ * onboarding fields are supplied, but historically never persisted that org into `user_orgs`.
+ *
+ * This file proves, against a real Postgres, the three required suites (§3.3 item 3):
+ *   - fresh-DB: a brand-new admission writes the user_orgs row, and a user_orgs write failure
+ *     rolls back the WHOLE admission (no orphan `users` row with no membership).
+ *   - two-org: two admissions in different orgs never cross-count.
+ *   - upgrade: a pre-existing zzzz20260114110000-style backfill row survives a later admission
+ *     in the same org.
+ * …plus the org-unknowable negative control for THIS route (no attendanceGroupId/
+ * defaultShiftId supplied): zero user_orgs rows, never a silent 'default' guess (§3.3 item 2).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const RUN = crypto.randomBytes(4).toString('hex')
+const NS = `w4pre1admit${TS}${RUN}`
+
+function orgId(tag: string): string {
+  return `${NS}_org_${tag}`
+}
+function emailFor(tag: string): string {
+  return `${NS}.${tag}@example.com`
+}
+
+describeIfDatabase('W4-PRE-1 — user_orgs admission write site: POST /api/admin/users (real DB)', () => {
+  // Deliberately NOT MetaSheetServer: its stop() closes the shared pg pool (src/index.ts, "Close
+  // database pool" shutdown task), which would poison every OTHER .db.test.ts file that shares
+  // this vitest.integration.config.ts invocation (fileParallelism:false runs them serially in one
+  // process — plugin-tests.yml's "Run attendance integration tests" step runs dozens of files in
+  // one command). A bare Express app mounting only the routers under test, closed via
+  // httpServer.close() (HTTP listener only), keeps this file's real-route/real-DB coverage
+  // without that blast radius.
+  let httpServer: http.Server
+  let baseUrl = ''
+  let adminToken = ''
+
+  const createdUserIds: string[] = []
+  const createdGroupIds: string[] = []
+
+  async function seedGroup(org: string, tag: string): Promise<{ id: string; name: string }> {
+    const id = crypto.randomUUID()
+    const name = `${NS}-group-${tag}`
+    await query(
+      `INSERT INTO attendance_groups (id, org_id, name, attendance_type) VALUES ($1, $2, $3, 'fixed_shift')`,
+      [id, org, name],
+    )
+    createdGroupIds.push(id)
+    return { id, name }
+  }
+
+  async function createUserViaRoute(body: Record<string, unknown>): Promise<{ status: number; json: any }> {
+    const res = await fetch(`${baseUrl}/api/admin/users`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken}` },
+      body: JSON.stringify(body),
+    })
+    const json = await res.json().catch(() => null)
+    if (json?.data?.user?.id) createdUserIds.push(json.data.user.id)
+    return { status: res.status, json }
+  }
+
+  async function userOrgRow(userId: string, org: string): Promise<{ user_id: string; org_id: string; is_active: boolean } | null> {
+    const result = await query<{ user_id: string; org_id: string; is_active: boolean }>(
+      `SELECT user_id, org_id, is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`,
+      [userId, org],
+    )
+    return result.rows[0] ?? null
+  }
+
+  async function activeMemberCount(org: string): Promise<number> {
+    // Mirrors plugins/plugin-attendance/index.cjs:15532-15541 RD-3 target-population semantics
+    // (§3.3 item 4): active org members = user_orgs.is_active=true AND users.is_active=true.
+    const result = await query<{ n: number }>(
+      `SELECT count(*)::int AS n
+         FROM user_orgs uo
+         JOIN users u ON u.id = uo.user_id
+        WHERE uo.org_id = $1 AND uo.is_active = true AND u.is_active = true`,
+      [org],
+    )
+    return result.rows[0]?.n ?? 0
+  }
+
+  beforeAll(async () => {
+    const app = express()
+    app.use(express.json())
+    app.use('/api/auth', authRouter)
+    app.use(adminUsersRouter())
+    httpServer = http.createServer(app)
+    const port = await new Promise<number>((resolve, reject) => {
+      httpServer.once('error', reject)
+      httpServer.listen(0, '127.0.0.1', () => {
+        const address = httpServer.address()
+        if (address && typeof address === 'object') resolve(address.port)
+        else reject(new Error('failed to bind ephemeral port for W4-PRE-1 admission test server'))
+      })
+    })
+    baseUrl = `http://127.0.0.1:${port}`
+
+    const tokenRes = await fetch(
+      `${baseUrl}/api/auth/dev-token?userId=${NS}-admin&roles=admin&perms=${encodeURIComponent('*:*')}`,
+    )
+    const tokenJson = await tokenRes.json()
+    adminToken = tokenJson.token as string
+  })
+
+  afterAll(async () => {
+    if (httpServer) {
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()))
+    }
+    if (createdUserIds.length) {
+      await query(`DELETE FROM attendance_shift_assignments WHERE user_id = ANY($1::text[])`, [createdUserIds])
+      await query(`DELETE FROM attendance_group_members WHERE user_id = ANY($1::text[])`, [createdUserIds])
+      await query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [createdUserIds])
+      await query(`DELETE FROM users WHERE id = ANY($1::text[])`, [createdUserIds])
+    }
+    if (createdGroupIds.length) {
+      await query(`DELETE FROM attendance_groups WHERE id = ANY($1::uuid[])`, [createdGroupIds])
+    }
+  })
+
+  describe('fresh-DB', () => {
+    it('a first-priority admission (attendanceOrgId known) writes user_orgs in the same transaction', async () => {
+      const org = orgId('fresh')
+      const group = await seedGroup(org, 'fresh')
+
+      const { status, json } = await createUserViaRoute({
+        name: 'W4PRE1 Fresh',
+        email: emailFor('fresh'),
+        orgId: org,
+        attendanceGroupId: group.id,
+      })
+
+      expect(status).toBe(200)
+      expect(json.ok).toBe(true)
+      const userId = json.data.user.id as string
+      expect(json.data.attendanceOnboarding).toEqual({
+        orgId: org,
+        group: { id: group.id, name: group.name, memberCreated: true },
+        defaultShift: null,
+      })
+
+      const row = await userOrgRow(userId, org)
+      expect(row).toEqual({ user_id: userId, org_id: org, is_active: true })
+    })
+
+    it('atomicity: a user_orgs write failure rolls back the whole admission (no orphan users row)', async () => {
+      const org = orgId('atomicfail')
+      const group = await seedGroup(org, 'atomicfail')
+      const fnName = `w4pre1_fail_user_orgs_admin_${RUN}`
+      const testEmail = emailFor('atomicfail')
+
+      await query(`CREATE OR REPLACE FUNCTION ${fnName}() RETURNS trigger AS $fn$
+        BEGIN
+          RAISE EXCEPTION 'W4-PRE-1 injected admin-users user_orgs failure' USING ERRCODE = 'P0001';
+        END $fn$ LANGUAGE plpgsql`)
+      await query(`CREATE TRIGGER ${fnName}_trg BEFORE INSERT ON user_orgs
+        FOR EACH ROW WHEN (NEW.org_id = '${org}') EXECUTE FUNCTION ${fnName}()`)
+
+      try {
+        const { status, json } = await createUserViaRoute({
+          name: 'W4PRE1 Atomic',
+          email: testEmail,
+          orgId: org,
+          attendanceGroupId: group.id,
+        })
+
+        expect(status).toBe(500)
+        expect(json.ok).toBe(false)
+
+        const usersRow = await query(`SELECT id FROM users WHERE email = $1`, [testEmail])
+        expect(usersRow.rows).toEqual([])
+        const orgRows = await query(`SELECT user_id FROM user_orgs WHERE org_id = $1`, [org])
+        expect(orgRows.rows).toEqual([])
+        // The group-member insert is part of the SAME transaction — it must have rolled back too.
+        const memberRows = await query(`SELECT id FROM attendance_group_members WHERE group_id = $1`, [group.id])
+        expect(memberRows.rows).toEqual([])
+      } finally {
+        await query(`DROP TRIGGER IF EXISTS ${fnName}_trg ON user_orgs`).catch(() => {})
+        await query(`DROP FUNCTION IF EXISTS ${fnName}()`).catch(() => {})
+      }
+    })
+  })
+
+  describe('two-org', () => {
+    it('admissions in org A and org B do not cross-count (org_id-anchored)', async () => {
+      const orgA = orgId('twoA')
+      const orgB = orgId('twoB')
+      const groupA = await seedGroup(orgA, 'twoA')
+      const groupB = await seedGroup(orgB, 'twoB')
+
+      const { json: jsonA } = await createUserViaRoute({
+        name: 'W4PRE1 TwoA',
+        email: emailFor('twoA'),
+        orgId: orgA,
+        attendanceGroupId: groupA.id,
+      })
+      const { json: jsonB } = await createUserViaRoute({
+        name: 'W4PRE1 TwoB',
+        email: emailFor('twoB'),
+        orgId: orgB,
+        attendanceGroupId: groupB.id,
+      })
+      const userA = jsonA.data.user.id as string
+      const userB = jsonB.data.user.id as string
+
+      expect(await activeMemberCount(orgA)).toBe(1)
+      expect(await activeMemberCount(orgB)).toBe(1)
+
+      const rowsA = await query<{ user_id: string }>(`SELECT user_id FROM user_orgs WHERE org_id = $1`, [orgA])
+      expect(rowsA.rows.map((r) => r.user_id)).toEqual([userA])
+      const rowsB = await query<{ user_id: string }>(`SELECT user_id FROM user_orgs WHERE org_id = $1`, [orgB])
+      expect(rowsB.rows.map((r) => r.user_id)).toEqual([userB])
+    })
+  })
+
+  describe('org-unknowable (this route without attendance onboarding fields)', () => {
+    it('creating a user with no attendanceGroupId/defaultShiftId writes zero user_orgs rows (no silent default)', async () => {
+      const testEmail = emailFor('noorg')
+      const { status, json } = await createUserViaRoute({
+        name: 'W4PRE1 NoOrg',
+        email: testEmail,
+      })
+
+      expect(status).toBe(200)
+      const userId = json.data.user.id as string
+      expect(json.data.attendanceOnboarding).toBeNull()
+
+      const rows = await query(`SELECT org_id FROM user_orgs WHERE user_id = $1`, [userId])
+      expect(rows.rows).toEqual([])
+    })
+  })
+
+  describe('upgrade', () => {
+    it('a pre-existing zzzz20260114110000-style backfill row survives a new admission in the same org', async () => {
+      // 'default' is the literal org_id the real backfill migration writes for every pre-existing
+      // active user (zzzz20260114110000_create_user_orgs_table.ts). Simulating it here (rather
+      // than a synthetic org) is deliberate: it proves the new write path is additive against
+      // the actual upgrade shape, not just against a fresh custom org.
+      const org = 'default'
+      const legacyUserId = `${NS}-legacy-user`
+      const legacyEmail = emailFor('legacy')
+      const legacyUsername = `${NS}legacyuser`
+      createdUserIds.push(legacyUserId)
+
+      await query(
+        `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+         VALUES ($1, $2, $3, 'W4PRE1 Legacy', 'x', 'user', '[]'::jsonb, true, false, NOW(), NOW())`,
+        [legacyUserId, legacyEmail, legacyUsername],
+      )
+      // Simulates the backfill migration's own INSERT shape exactly (user_id, org_id, is_active).
+      await query(
+        `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true)`,
+        [legacyUserId, org],
+      )
+
+      const group = await seedGroup(org, 'upgrade')
+      const { status, json } = await createUserViaRoute({
+        name: 'W4PRE1 Upgrade',
+        email: emailFor('upgrade'),
+        orgId: org,
+        attendanceGroupId: group.id,
+      })
+
+      expect(status).toBe(200)
+      const newUserId = json.data.user.id as string
+
+      const newRow = await userOrgRow(newUserId, org)
+      expect(newRow).toEqual({ user_id: newUserId, org_id: org, is_active: true })
+
+      const legacyRow = await userOrgRow(legacyUserId, org)
+      expect(legacyRow).toEqual({ user_id: legacyUserId, org_id: org, is_active: true })
+    })
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts
@@ -16,6 +16,11 @@ import { __directorySyncInternalsForTests } from '../../src/directory/directory-
  * This file drives the shared internals directly (matching the existing
  * directory-sync-admission-orphan-guard.db.test.ts precedent) rather than the full sync loop,
  * so each scenario is isolated and fast.
+ *
+ * Suites: fresh-DB (write + atomicity) / fail-closed org resolution / upgrade (a pre-existing
+ * zzzz20260114110000-style backfill row survives a later admission in the same org — this is
+ * the second production user_orgs writer, so it gets its own upgrade leg, not just the
+ * admin-users.ts route's) / two-org.
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const { createDirectoryAdmittedUserInTransaction } = __directorySyncInternalsForTests
@@ -212,6 +217,45 @@ describeIfDatabase('W4-PRE-1 — user_orgs admission write site: directory-sync 
       expect((caught as unknown as Error).message).toBe('Directory integration not found for admitted account org resolution')
       const userRow = await query(`SELECT id FROM users WHERE username = $1`, [username])
       expect(userRow.rows).toEqual([])
+    })
+  })
+
+  describe('upgrade', () => {
+    it('a pre-existing zzzz20260114110000-style backfill row survives a new directory-sync admission in the same org', async () => {
+      const org = `${NS}_org_upgrade`
+      const integrationId = await seedIntegration(org, 'upgrade')
+      const account = await seedAccount(integrationId, 'upgrade')
+      const username = `${NS}upgrade`
+      pendingUsernames.push(username)
+
+      const legacyUserId = crypto.randomUUID()
+      const legacyUsername = `${NS}dslegacy`
+      pendingUsernames.push(legacyUsername)
+      await query(
+        `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+         VALUES ($1, $2, $3, 'W4PRE1 DS Legacy', 'x', 'user', '[]'::jsonb, true, false, NOW(), NOW())`,
+        [legacyUserId, `${NS}-ds-legacy@example.com`, legacyUsername],
+      )
+      // Simulates the backfill migration's own INSERT shape exactly (user_id, org_id, is_active).
+      await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true)`, [legacyUserId, org])
+
+      let userId = ''
+      await transaction(async (client) => {
+        const created = await createDirectoryAdmittedUserInTransaction(client, admitOptions(account, username))
+        userId = created.userId
+      })
+
+      const newRow = await query<{ user_id: string; org_id: string; is_active: boolean }>(
+        `SELECT user_id, org_id, is_active FROM user_orgs WHERE user_id = $1`,
+        [userId],
+      )
+      expect(newRow.rows).toEqual([{ user_id: userId, org_id: org, is_active: true }])
+
+      const legacyRow = await query<{ user_id: string; org_id: string; is_active: boolean }>(
+        `SELECT user_id, org_id, is_active FROM user_orgs WHERE user_id = $1`,
+        [legacyUserId],
+      )
+      expect(legacyRow.rows).toEqual([{ user_id: legacyUserId, org_id: org, is_active: true }])
     })
   })
 

--- a/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts
@@ -1,0 +1,245 @@
+import { afterAll, afterEach, describe, expect, it } from 'vitest'
+import crypto from 'node:crypto'
+import { query, transaction } from '../../src/db/pg'
+import { __directorySyncInternalsForTests } from '../../src/directory/directory-sync'
+
+/**
+ * W4-PRE-1 (§3.3): the directory-sync admission write site
+ * (`createDirectoryAdmittedUserInTransaction`, packages/core-backend/src/directory/
+ * directory-sync.ts:4976) is the ticket's second write site. It admits users through TWO
+ * callers — the auto-admission sync loop (syncDirectoryIntegration) and the manual
+ * admitDirectoryAccountUser API — both of which already run inside an outer `transaction()` and
+ * wrap this call in its own SAVEPOINT (DT-HARDEN-02). The org here is resolved from the
+ * account's own `directory_integrations.org_id` row — never a client-supplied value, never a
+ * silent 'default' guess (fail-closed if the integration row is missing).
+ *
+ * This file drives the shared internals directly (matching the existing
+ * directory-sync-admission-orphan-guard.db.test.ts precedent) rather than the full sync loop,
+ * so each scenario is isolated and fast.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const { createDirectoryAdmittedUserInTransaction } = __directorySyncInternalsForTests
+
+const TS = Date.now()
+const RUN = crypto.randomBytes(4).toString('hex')
+const NS = `w4pre1dsync${TS}${RUN}`
+
+type FixtureAccount = {
+  id: string
+  integration_id: string
+  provider: string
+  corp_id: string | null
+  external_user_id: string
+  union_id: string | null
+  open_id: string | null
+  external_key: string
+  name: string
+  email: string | null
+  mobile: string | null
+}
+
+describeIfDatabase('W4-PRE-1 — user_orgs admission write site: directory-sync admission (real DB)', () => {
+  const integrationIds: string[] = []
+  let pendingUsernames: string[] = []
+
+  async function seedIntegration(org: string, tag: string): Promise<string> {
+    const id = (
+      await query<{ id: string }>(
+        `INSERT INTO directory_integrations (org_id, name, corp_id) VALUES ($1, $2, $3) RETURNING id::text AS id`,
+        [org, `${NS}-int-${tag}`, `${NS}-corp-${tag}`],
+      )
+    ).rows[0].id
+    integrationIds.push(id)
+    return id
+  }
+
+  async function seedAccount(integrationId: string, tag: string): Promise<FixtureAccount> {
+    const external = `${NS}-ext-${tag}`
+    const unionId = `${NS}-union-${tag}`
+    const openId = `${NS}-open-${tag}`
+    const id = (
+      await query<{ id: string }>(
+        `INSERT INTO directory_accounts (integration_id, provider, corp_id, external_user_id, union_id, open_id, external_key, name, is_active)
+         VALUES ($1, 'dingtalk', 'corp', $2, $3, $4, $5, 'Fixture', true) RETURNING id::text AS id`,
+        [integrationId, external, unionId, openId, external],
+      )
+    ).rows[0].id
+    return {
+      id,
+      integration_id: integrationId,
+      provider: 'dingtalk',
+      corp_id: 'corp',
+      external_user_id: external,
+      union_id: unionId,
+      open_id: openId,
+      external_key: external,
+      name: 'Fixture',
+      email: null,
+      mobile: null,
+    }
+  }
+
+  function admitOptions(account: FixtureAccount, username: string) {
+    return {
+      account,
+      adminUserId: 'system:w4pre1-test',
+      name: 'Fixture',
+      email: null,
+      username,
+      mobile: null,
+      passwordHash: 'hashed',
+      mustChangePassword: true,
+      enableDingTalkGrant: false,
+    }
+  }
+
+  afterEach(async () => {
+    if (pendingUsernames.length) {
+      await query(
+        `DELETE FROM user_external_identities WHERE local_user_id IN (SELECT id FROM users WHERE username = ANY($1::text[]))`,
+        [pendingUsernames],
+      )
+      await query(
+        `DELETE FROM directory_account_links WHERE local_user_id IN (SELECT id FROM users WHERE username = ANY($1::text[]))`,
+        [pendingUsernames],
+      )
+      await query(`DELETE FROM user_orgs WHERE user_id IN (SELECT id FROM users WHERE username = ANY($1::text[]))`, [
+        pendingUsernames,
+      ])
+      await query(`DELETE FROM users WHERE username = ANY($1::text[])`, [pendingUsernames])
+      pendingUsernames = []
+    }
+  })
+
+  afterAll(async () => {
+    if (integrationIds.length) {
+      await query(`DELETE FROM directory_accounts WHERE integration_id = ANY($1::uuid[])`, [integrationIds])
+      await query(`DELETE FROM directory_integrations WHERE id = ANY($1::uuid[])`, [integrationIds])
+    }
+  })
+
+  describe('fresh-DB', () => {
+    it('admission resolves org from directory_integrations and writes user_orgs in the same savepoint', async () => {
+      const org = `${NS}_org_fresh`
+      const integrationId = await seedIntegration(org, 'fresh')
+      const account = await seedAccount(integrationId, 'fresh')
+      const username = `${NS}fresh`
+      pendingUsernames.push(username)
+
+      let userId = ''
+      await transaction(async (client) => {
+        const created = await createDirectoryAdmittedUserInTransaction(client, admitOptions(account, username))
+        userId = created.userId
+      })
+
+      const row = await query<{ user_id: string; org_id: string; is_active: boolean }>(
+        `SELECT user_id, org_id, is_active FROM user_orgs WHERE user_id = $1`,
+        [userId],
+      )
+      expect(row.rows).toEqual([{ user_id: userId, org_id: org, is_active: true }])
+    })
+
+    it('atomicity: a user_orgs write failure rolls back the savepoint (no orphan users row), tx stays usable', async () => {
+      const org = `${NS}_org_atomicfail`
+      const integrationId = await seedIntegration(org, 'atomicfail')
+      const badAccount = await seedAccount(integrationId, 'atomicfailbad')
+      const badUsername = `${NS}atomicfailbad`
+      pendingUsernames.push(badUsername)
+
+      const fnName = `w4pre1_fail_user_orgs_ds_${RUN}`
+      await query(`CREATE OR REPLACE FUNCTION ${fnName}() RETURNS trigger AS $fn$
+        BEGIN
+          RAISE EXCEPTION 'W4-PRE-1 injected directory-sync user_orgs failure' USING ERRCODE = 'P0001';
+        END $fn$ LANGUAGE plpgsql`)
+      await query(`CREATE TRIGGER ${fnName}_trg BEFORE INSERT ON user_orgs
+        FOR EACH ROW WHEN (NEW.org_id = '${org}') EXECUTE FUNCTION ${fnName}()`)
+
+      try {
+        let threw = false
+        await transaction(async (client) => {
+          try {
+            await createDirectoryAdmittedUserInTransaction(client, admitOptions(badAccount, badUsername))
+          } catch {
+            threw = true // mirrors the sync loop's own swallow-and-continue behavior
+          }
+          // Prove the SAVEPOINT recovered the outer transaction (DT-HARDEN-02 invariant, extended
+          // to the user_orgs write): a plain statement must still succeed on the same client.
+          const stillUsable = await client.query('SELECT 1 AS ok')
+          expect((stillUsable.rows[0] as { ok: number }).ok).toBe(1)
+        }) // ← COMMIT: with the SAVEPOINT, the rolled-back INSERT is not here to commit
+
+        expect(threw).toBe(true)
+        const usersRow = await query(`SELECT id FROM users WHERE username = $1`, [badUsername])
+        expect(usersRow.rows).toEqual([])
+        const orgRows = await query(`SELECT user_id FROM user_orgs WHERE org_id = $1`, [org])
+        expect(orgRows.rows).toEqual([])
+      } finally {
+        await query(`DROP TRIGGER IF EXISTS ${fnName}_trg ON user_orgs`).catch(() => {})
+        await query(`DROP FUNCTION IF EXISTS ${fnName}()`).catch(() => {})
+      }
+    })
+  })
+
+  describe('fail-closed org resolution', () => {
+    it('an integration_id with no directory_integrations row throws before any write (never guesses an org)', async () => {
+      const ghostIntegrationId = crypto.randomUUID() // deliberately never inserted
+      const account: FixtureAccount = {
+        id: crypto.randomUUID(),
+        integration_id: ghostIntegrationId,
+        provider: 'dingtalk',
+        corp_id: 'corp',
+        external_user_id: `${NS}-ghost`,
+        union_id: `${NS}-ghost-union`,
+        open_id: `${NS}-ghost-open`,
+        external_key: `${NS}-ghost`,
+        name: 'Ghost',
+        email: null,
+        mobile: null,
+      }
+      const username = `${NS}ghost`
+      pendingUsernames.push(username)
+
+      let caught: Error | null = null
+      await transaction(async (client) => {
+        try {
+          await createDirectoryAdmittedUserInTransaction(client, admitOptions(account, username))
+        } catch (error) {
+          caught = error as Error
+        }
+      })
+
+      expect(caught).not.toBeNull()
+      expect((caught as unknown as Error).message).toBe('Directory integration not found for admitted account org resolution')
+      const userRow = await query(`SELECT id FROM users WHERE username = $1`, [username])
+      expect(userRow.rows).toEqual([])
+    })
+  })
+
+  describe('two-org', () => {
+    it('admissions via two different directory_integrations do not cross-count', async () => {
+      const orgA = `${NS}_org_dsA`
+      const orgB = `${NS}_org_dsB`
+      const intA = await seedIntegration(orgA, 'dsA')
+      const intB = await seedIntegration(orgB, 'dsB')
+      const accountA = await seedAccount(intA, 'dsA')
+      const accountB = await seedAccount(intB, 'dsB')
+      const userAName = `${NS}dsa`
+      const userBName = `${NS}dsb`
+      pendingUsernames.push(userAName, userBName)
+
+      let userIdA = ''
+      let userIdB = ''
+      await transaction(async (client) => {
+        userIdA = (await createDirectoryAdmittedUserInTransaction(client, admitOptions(accountA, userAName))).userId
+      })
+      await transaction(async (client) => {
+        userIdB = (await createDirectoryAdmittedUserInTransaction(client, admitOptions(accountB, userBName))).userId
+      })
+
+      const rowsA = await query<{ user_id: string }>(`SELECT user_id FROM user_orgs WHERE org_id = $1`, [orgA])
+      expect(rowsA.rows.map((r) => r.user_id)).toEqual([userIdA])
+      const rowsB = await query<{ user_id: string }>(`SELECT user_id FROM user_orgs WHERE org_id = $1`, [orgB])
+      expect(rowsB.rows.map((r) => r.user_id)).toEqual([userIdB])
+    })
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import crypto from 'node:crypto'
+import { query } from '../../src/db/pg'
+import { authService } from '../../src/auth/AuthService'
+import { __dingtalkOAuthInternalsForTests } from '../../src/auth/dingtalk-oauth'
+import { readOrgDirectoryReadiness } from '../../src/routes/attendance-admin'
+
+/**
+ * W4-PRE-1 (§3.3 item 2 + item 5's dependent, W4-0-G3): two things this file proves against a
+ * real Postgres.
+ *
+ * 1. Org-unknowable admission paths (AuthService.register — deployment-level self-service
+ *    registration; DingTalk OAuth JIT admission — no per-org context anywhere in that module)
+ *    write ZERO user_orgs rows. This is the negative half of the ticket's "never silently guess
+ *    an org" instruction — the dual-syntax grep in the PR body proves these are the only OTHER
+ *    production create-user call sites; this test proves their behavior matches the policy
+ *    comments left at each site.
+ *
+ * 2. W4-0-G3's two positive controls (design lock §9), pre-run here per the lock's own
+ *    instruction ("两正控在 SQL/服务层验证计数语义即可" — the setup-readiness HTTP endpoint is
+ *    W4-0 scope, explicitly OUT of this ticket, and is NOT built by this PR):
+ *      - a pure local org (>=1 active user_orgs member, zero directory_account_links) must
+ *        compute orgActiveMemberCount>0 while directoryLinked stays false — i.e. the two signals
+ *        are independent, never combined as `directoryLinked && count>0`.
+ *      - a DingTalk-linked org must report BOTH orgActiveMemberCount>0 and directoryLinked=true
+ *        correctly at the same time.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const RUN = crypto.randomBytes(4).toString('hex')
+const NS = `w4pre1policy${TS}${RUN}`
+
+describeIfDatabase('W4-PRE-1 — org-unknowable admission paths + W4-0-G3 positive-control pre-run (real DB)', () => {
+  const createdUserIds: string[] = []
+  const createdIntegrationIds: string[] = []
+
+  afterAll(async () => {
+    if (createdUserIds.length) {
+      await query(`DELETE FROM directory_account_links WHERE local_user_id = ANY($1::text[])`, [createdUserIds])
+      await query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [createdUserIds])
+      await query(`DELETE FROM user_external_identities WHERE local_user_id = ANY($1::text[])`, [createdUserIds])
+      await query(`DELETE FROM users WHERE id = ANY($1::text[])`, [createdUserIds])
+    }
+    if (createdIntegrationIds.length) {
+      await query(`DELETE FROM directory_accounts WHERE integration_id = ANY($1::uuid[])`, [createdIntegrationIds])
+      await query(`DELETE FROM directory_integrations WHERE id = ANY($1::uuid[])`, [createdIntegrationIds])
+    }
+  })
+
+  describe('org-unknowable policy (never silently guess an org)', () => {
+    it('AuthService.register (deployment-level registration) writes zero user_orgs rows', async () => {
+      const emailAddr = `${NS}-register@example.com`
+      const user = await authService.register(emailAddr, 'W4pre1-Passw0rd!', 'W4PRE1 Register')
+      expect(user).toBeTruthy()
+      createdUserIds.push(user!.id)
+
+      const rows = await query(`SELECT org_id FROM user_orgs WHERE user_id = $1`, [user!.id])
+      expect(rows.rows).toEqual([])
+    })
+
+    it('DingTalk OAuth JIT admission (createProvisionedUser) writes zero user_orgs rows', async () => {
+      const { createProvisionedUser } = __dingtalkOAuthInternalsForTests
+      const localUser = await createProvisionedUser({
+        unionId: `${NS}-union`,
+        nick: 'W4PRE1 DingTalk',
+        email: `${NS}-dingtalk@example.com`,
+      })
+      createdUserIds.push(localUser.id)
+
+      const rows = await query(`SELECT org_id FROM user_orgs WHERE user_id = $1`, [localUser.id])
+      expect(rows.rows).toEqual([])
+    })
+  })
+
+  describe('W4-0-G3 two positive controls (pre-run at SQL/service layer)', () => {
+    async function activeMemberCount(org: string): Promise<number> {
+      // Mirrors plugins/plugin-attendance/index.cjs:15532-15541 RD-3 target-population semantics
+      // (§3.3 item 4): active org members = user_orgs.is_active=true AND users.is_active=true,
+      // org-anchored. This is the counting query semantics being validated by G3 — the
+      // setup-readiness aggregation endpoint that will eventually expose it is W4-0 scope.
+      const result = await query<{ n: number }>(
+        `SELECT count(*)::int AS n
+           FROM user_orgs uo
+           JOIN users u ON u.id = uo.user_id
+          WHERE uo.org_id = $1 AND uo.is_active = true AND u.is_active = true`,
+        [org],
+      )
+      return result.rows[0]?.n ?? 0
+    }
+
+    async function seedActiveUser(org: string, tag: string): Promise<string> {
+      const id = `${NS}-g3-${tag}`
+      await query(
+        `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+         VALUES ($1, $2, $3, 'G3 Fixture', 'x', 'user', '[]'::jsonb, true, false, NOW(), NOW())`,
+        [id, `${NS}-g3-${tag}@example.com`, `${NS}g3${tag}`],
+      )
+      await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true)`, [id, org])
+      createdUserIds.push(id)
+      return id
+    }
+
+    it('pure local org: >=1 active member, zero directory_account_links => orgActiveMemberCount>0 && directoryLinked=false', async () => {
+      const org = `${NS}_g3_local`
+      await seedActiveUser(org, 'local')
+
+      const count = await activeMemberCount(org)
+      expect(count).toBe(1)
+
+      // Negative control per lock text: an implementation gated on `directoryLinked && count>0`
+      // would wrongly treat this org as not-ready. Assert the two signals independently.
+      const readiness = await readOrgDirectoryReadiness(org)
+      expect(readiness.hasLinkedDirectoryAccounts).toBe(false)
+    })
+
+    it('DingTalk-linked org: directoryLinked=true and count>0, both correctly reported at once', async () => {
+      const org = `${NS}_g3_linked`
+      const userId = await seedActiveUser(org, 'linked')
+
+      const integrationId = (
+        await query<{ id: string }>(
+          `INSERT INTO directory_integrations (org_id, name, corp_id, provider, status)
+           VALUES ($1, $2, $3, 'dingtalk', 'active') RETURNING id::text AS id`,
+          [org, `${NS}-g3-int`, `${NS}-g3-corp`],
+        )
+      ).rows[0].id
+      createdIntegrationIds.push(integrationId)
+
+      const accountId = (
+        await query<{ id: string }>(
+          `INSERT INTO directory_accounts (integration_id, provider, corp_id, external_user_id, union_id, open_id, external_key, name, is_active)
+           VALUES ($1, 'dingtalk', $2, $3, $4, $5, $6, 'G3 Linked', true) RETURNING id::text AS id`,
+          [integrationId, `${NS}-g3-corp`, `${NS}-g3-ext`, `${NS}-g3-union`, `${NS}-g3-open`, `${NS}-g3-ext`],
+        )
+      ).rows[0].id
+
+      await query(
+        `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+         VALUES ($1, $2, 'linked', 'manual_admin')`,
+        [accountId, userId],
+      )
+
+      const count = await activeMemberCount(org)
+      expect(count).toBe(1)
+
+      const readiness = await readOrgDirectoryReadiness(org)
+      expect(readiness.hasLinkedDirectoryAccounts).toBe(true)
+    })
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts
@@ -16,9 +16,10 @@ import { readOrgDirectoryReadiness } from '../../src/routes/attendance-admin'
  *    production create-user call sites; this test proves their behavior matches the policy
  *    comments left at each site.
  *
- * 2. W4-0-G3's two positive controls (design lock §9), pre-run here per the lock's own
- *    instruction ("两正控在 SQL/服务层验证计数语义即可" — the setup-readiness HTTP endpoint is
- *    W4-0 scope, explicitly OUT of this ticket, and is NOT built by this PR):
+ * 2. W4-0-G3's two positive controls (design lock §9's exact words: "两正控在 W4-PRE-1 完成门先
+ *    跑一遍，W4-0 完成门复跑" — run once at the W4-PRE-1 completion gate, re-run at the W4-0
+ *    completion gate). Pre-run here at the SQL/service layer because the setup-readiness HTTP
+ *    endpoint itself is W4-0 scope, explicitly OUT of this ticket, and is NOT built by this PR:
  *      - a pure local org (>=1 active user_orgs member, zero directory_account_links) must
  *        compute orgActiveMemberCount>0 while directoryLinked stays false — i.e. the two signals
  *        are independent, never combined as `directoryLinked && count>0`.

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -55,6 +55,12 @@ vi.mock('../../src/middleware/auth', () => ({
 
 vi.mock('../../src/db/pg', () => ({
   query: pgMocks.query,
+  // W4-PRE-1: POST /api/admin/users now wraps its write sequence in transaction() (the
+  // user_orgs atomicity requirement, §3.3). The handler's client.query is backed by the SAME
+  // pgMocks.query mock so every existing test's call-order/count scripting (mockResolvedValueOnce
+  // chains) is unaffected — transaction() is transparent here, not a second mock surface.
+  transaction: vi.fn(async (handler: (client: { query: typeof pgMocks.query }) => Promise<unknown>) =>
+    handler({ query: pgMocks.query })),
 }))
 
 vi.mock('../../src/rbac/service', () => ({

--- a/packages/core-backend/tests/unit/directory-sync-admission-orphan-guard.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-admission-orphan-guard.test.ts
@@ -22,6 +22,14 @@ function fakeClient() {
     queries,
     query: async (sql: string) => {
       queries.push(sql)
+      // W4-PRE-1: createDirectoryAdmittedUserInTransaction now resolves the admission org via
+      // `SELECT org_id FROM directory_integrations WHERE id = $1` (§3.3) before writing
+      // user_orgs. This fixture's account.integration_id must resolve to SOME org for the
+      // grant-feasibility scenarios below to reach the INSERT INTO users assertions they exist
+      // to prove — everything else keeps the previous always-empty-rows behavior.
+      if (/SELECT org_id\s+FROM directory_integrations/.test(sql)) {
+        return { rows: [{ org_id: 'orgA' }] as Array<Record<string, unknown>> }
+      }
       return { rows: [] as Array<Record<string, unknown>> }
     },
   }

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -231,7 +231,16 @@ describe('bindDirectoryAccount', () => {
   })
 
   it('allows union-only pre-binding when DingTalk grant is disabled', async () => {
-    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    // W4-PRE-1: createDirectoryAdmittedUserInTransaction now resolves the admission org via
+    // `SELECT org_id FROM directory_integrations WHERE id = $1` (§3.3) before writing user_orgs.
+    // Tests that never reach admission (bind/unbind) never hit this branch, so this is a
+    // superset of the previous always-empty-rows default, not a behavior change for them.
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
+        return { rows: [{ org_id: 'default' }] }
+      }
+      return { rows: [] }
+    })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
     pgMocks.query
       .mockResolvedValueOnce({
@@ -434,7 +443,16 @@ describe('bindDirectoryAccount', () => {
   })
 
   it('prefers an exact local user id over cross-field identifier ambiguity', async () => {
-    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    // W4-PRE-1: createDirectoryAdmittedUserInTransaction now resolves the admission org via
+    // `SELECT org_id FROM directory_integrations WHERE id = $1` (§3.3) before writing user_orgs.
+    // Tests that never reach admission (bind/unbind) never hit this branch, so this is a
+    // superset of the previous always-empty-rows default, not a behavior change for them.
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
+        return { rows: [{ org_id: 'default' }] }
+      }
+      return { rows: [] }
+    })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
     pgMocks.query
       .mockResolvedValueOnce({
@@ -522,7 +540,16 @@ describe('bindDirectoryAccount', () => {
   })
 
   it('creates a local user and binds it to a directory account in one server-side admission flow', async () => {
-    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    // W4-PRE-1: createDirectoryAdmittedUserInTransaction now resolves the admission org via
+    // `SELECT org_id FROM directory_integrations WHERE id = $1` (§3.3) before writing user_orgs.
+    // Tests that never reach admission (bind/unbind) never hit this branch, so this is a
+    // superset of the previous always-empty-rows default, not a behavior change for them.
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
+        return { rows: [{ org_id: 'default' }] }
+      }
+      return { rows: [] }
+    })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
     pgMocks.query
       .mockResolvedValueOnce({
@@ -624,7 +651,16 @@ describe('bindDirectoryAccount', () => {
   })
 
   it('admits a no-email local user with username/mobile and skips invite issuance', async () => {
-    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    // W4-PRE-1: createDirectoryAdmittedUserInTransaction now resolves the admission org via
+    // `SELECT org_id FROM directory_integrations WHERE id = $1` (§3.3) before writing user_orgs.
+    // Tests that never reach admission (bind/unbind) never hit this branch, so this is a
+    // superset of the previous always-empty-rows default, not a behavior change for them.
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
+        return { rows: [{ org_id: 'default' }] }
+      }
+      return { rows: [] }
+    })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
     pgMocks.query
       .mockResolvedValueOnce({
@@ -709,7 +745,16 @@ describe('bindDirectoryAccount', () => {
   })
 
   it('admits a no-email union-only DingTalk account when grant is disabled', async () => {
-    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    // W4-PRE-1: createDirectoryAdmittedUserInTransaction now resolves the admission org via
+    // `SELECT org_id FROM directory_integrations WHERE id = $1` (§3.3) before writing user_orgs.
+    // Tests that never reach admission (bind/unbind) never hit this branch, so this is a
+    // superset of the previous always-empty-rows default, not a behavior change for them.
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
+        return { rows: [{ org_id: 'default' }] }
+      }
+      return { rows: [] }
+    })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
     pgMocks.query
       .mockResolvedValueOnce({
@@ -1000,7 +1045,16 @@ describe('bindDirectoryAccount', () => {
   // the first bad item, so the caller never learned which items had already COMMITTED —
   // and the route, auditing only after the whole batch returned, dropped their audit trail.
   it('isolates a failing item so already-committed items are still returned (batch unbind)', async () => {
-    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    // W4-PRE-1: createDirectoryAdmittedUserInTransaction now resolves the admission org via
+    // `SELECT org_id FROM directory_integrations WHERE id = $1` (§3.3) before writing user_orgs.
+    // Tests that never reach admission (bind/unbind) never hit this branch, so this is a
+    // superset of the previous always-empty-rows default, not a behavior change for them.
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
+        return { rows: [{ org_id: 'default' }] }
+      }
+      return { rows: [] }
+    })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
     pgMocks.query
       // account-1 loads, unbinds, and reloads its summary
@@ -1065,7 +1119,16 @@ describe('bindDirectoryAccount', () => {
   })
 
   it('batch-admits no-email directory accounts with generated usernames and grant disabled by default', async () => {
-    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    // W4-PRE-1: createDirectoryAdmittedUserInTransaction now resolves the admission org via
+    // `SELECT org_id FROM directory_integrations WHERE id = $1` (§3.3) before writing user_orgs.
+    // Tests that never reach admission (bind/unbind) never hit this branch, so this is a
+    // superset of the previous always-empty-rows default, not a behavior change for them.
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
+        return { rows: [{ org_id: 'default' }] }
+      }
+      return { rows: [] }
+    })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
     pgMocks.query
       // batch service preloads account-1 to derive name/username
@@ -1250,7 +1313,16 @@ describe('bindDirectoryAccount', () => {
   // loop would abort the whole batch on the first bad item, so a valid bind earlier in
   // the batch would never be reported (or even attempted, once the batch is reordered).
   it('isolates a failing item so already-committed items are still returned (batch bind)', async () => {
-    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    // W4-PRE-1: createDirectoryAdmittedUserInTransaction now resolves the admission org via
+    // `SELECT org_id FROM directory_integrations WHERE id = $1` (§3.3) before writing user_orgs.
+    // Tests that never reach admission (bind/unbind) never hit this branch, so this is a
+    // superset of the previous always-empty-rows default, not a behavior change for them.
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
+        return { rows: [{ org_id: 'default' }] }
+      }
+      return { rows: [] }
+    })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
     pgMocks.query
       // account-1: loads with no previous link, resolves the local user, binds, and reloads its summary

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -373,6 +373,15 @@ export default defineConfig({
       // authz + flag-off. DATABASE_URL-gated describeIfDatabase; excluded here so the no-DB job cannot
       // skip-green it; wired whole-file into the attendance real-DB step in plugin-tests.yml.
       'tests/integration/attendance-approval-manager-at-level-s7-4.db.test.ts',
+      // W4-PRE-1 real-DB (§3.3 of attendance-vnext-wave4-onboarding-design-lock-20260721.md):
+      // user_orgs admission write-site suites (fresh-DB/atomicity/two-org/upgrade across
+      // POST /api/admin/users + directory-sync admission, plus the org-unknowable policy
+      // negative controls). DATABASE_URL-gated describeIfDatabase; excluded here so the no-DB
+      // job cannot skip-green them; wired whole-file into the attendance real-DB step in
+      // plugin-tests.yml.
+      'tests/integration/attendance-w4pre1-user-orgs-admission.db.test.ts',
+      'tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts',
+      'tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
## W4-PRE-1 — `user_orgs` production maintenance write path (org-membership lifecycle)

Pre-ticket for Wave 4 restart sequence. Authoritative spec = **main** at `57d89bc1d`
`docs/development/attendance-vnext-wave4-onboarding-design-lock-20260721.md` §3.3 (the
"W4-PRE-1 票面", introduced by owner errata `#4513`, which currently marks the lock
`RATIFICATION SUSPENDED / W4-0 FROZEN`). This PR implements that ticket's five items and does
**not** touch, re-open, or ratify anything else in the lock — Wave 4 slices (W4-0..W4-2) remain
FROZEN, and the frozen materiel branch `claude/w4-0-setup-readiness-20260721` was not touched.

Base: `origin/main` `57d89bc1d189d7fe18f3b3a848a4e0b4cce07ce6`. Branch:
`claude/w4-pre1-user-orgs-lifecycle-20260721`.

Backend-only change (`packages/core-backend`). **Three-viewport visual evidence: N/A** — no UI
surface in this PR.

### Post-review fixes (three-mirror pre-door review, fix commit `a3d05837f`)

A three-mirror pre-door review of this PR raised 2 P2 + 8 P3 findings (some duplicate across
files). All addressed on top of the original `84475f1ab` head, head is now `a3d05837f`:

- **P2 (behavior)**: `admin-users.ts`'s `user_orgs` write hardcodes `is_active=TRUE` at
  admission now (mirrors `directory-sync.ts`'s own writer), instead of copying the created
  user's own `isActive` flag. Mirroring `isActive` added nothing to the RD-3 dual-is_active
  count (`users.is_active=false` already excludes an admin-created-inactive user) but created an
  **unrecoverable stuck-false membership row**: no production write path ever updates
  `user_orgs.is_active` after admission, so reactivating that user later via `PATCH
  /api/admin/users/:userId/status` (which only touches `users.is_active`) left them permanently
  excluded from the design-lock §3① count — an absorbing state with no repair surface. New test
  (`attendance-w4pre1-user-orgs-admission.db.test.ts`) proves `isActive:false` at creation still
  writes `user_orgs.is_active=true`, exclusion comes only from `users.is_active`, and
  reactivation needs no separate membership repair. See updated item-4 row and mutation #4 below.
- **P2 (record fidelity)**: the policy test's docblock quoted a sentence ("两正控在 SQL/服务层
  验证计数语义即可") attributed to the design lock that does not appear anywhere in the lock, on
  `origin/main`, or in `#4513`. Reworded to quote the lock's actual §9 sentence ("两正控在
  W4-PRE-1 完成门先跑一遍，W4-0 完成门复跑" — a pre-run mandate only) and separate it from this
  PR's own still-defensible SQL/service-layer scoping choice (see corrected Test suites section
  below).
- **P3 (dead anchors)**: the item-2 policy comments in `AuthService.ts:~312` and
  `dingtalk-oauth.ts:~627` cited a nonexistent doc filename
  (`attendance-w4-pre1-user-orgs-lifecycle-20260721.md` — corrected to the real
  `attendance-vnext-wave4-onboarding-design-lock-20260721.md`) and a nonexistent test filename
  (`attendance-w4pre1-user-orgs-org-unknowable-policy.db.test.ts` — corrected to the real
  `attendance-w4pre1-user-orgs-policy.db.test.ts`). Fixed at all four sites.
- **P3 (coverage gap)**: `directory-sync.ts`'s write site (the ticket's *second* production
  writer) had no `upgrade` leg — only `admin-users.ts`'s did. Added one:
  `attendance-w4pre1-user-orgs-directory-sync.db.test.ts` now proves a pre-existing backfill row
  survives a new directory-sync admission in the same org, same shape as the existing
  `admin-users.ts` upgrade test.
- **P3 (advisory, not applied)**: the reviewer flagged that item 1's "含未来新增" inventory
  clause has no standing CI guard — a fifth future `INSERT INTO users` site could skip
  `user_orgs` silently. Left as-is: the reviewer's own writeup calls this "a process obligation
  enforced at re-ratify rather than a mechanical one" (hence P3, not P2), and this repo's own
  standing convention (`feedback_source_text_assertions_are_not_behaviour`) is that a
  regex/inventory-count guard over `INSERT INTO users` call sites is trivially defeated by
  reformatting the SQL and would give a false sense of enforcement; the real mechanical check
  this ticket already relies on is the dual-syntax grep re-run in this PR body, repeated at each
  future admission-path PR and at the lock's own re-ratify step, not a standing test.

### Ticket → implementation map (§3.3 "W4-PRE-1 票面", five items, verbatim order)

| # | Ticket text | Implementation |
|---|---|---|
| 1 | Inventory every admission write site; maintain `user_orgs` in the **same transaction** on paths with a known-authoritative org (admin-created-with-`attendanceOrgId` is first priority) | `POST /api/admin/users` (admin-users.ts) and `createDirectoryAdmittedUserInTransaction` (directory-sync.ts) — see write-site table below |
| 2 | Org-unknowable paths record policy explicitly; never silently guess an org | Code comments on `AuthService.register` and `dingtalk-oauth.ts createProvisionedUser`, doc paragraph below, test assertions (zero `user_orgs` rows) in `attendance-w4pre1-user-orgs-policy.db.test.ts` |
| 3 | Test trio: fresh-DB / upgrade / two-org | Three `.db.test.ts` files, real Postgres — see Test suites section |
| 4 | Counting correctness = `user_orgs.is_active=true AND users.is_active=true` (RD-3 precedent); **补双 is_active 不闭合①** | `activeMemberCount()` helper in the test files implements this exactly. **Post-review fix**: both writers hardcode `user_orgs.is_active=TRUE` at admission rather than mirroring the created user's own `isActive` — an admin-created-inactive user is excluded from the count via `users.is_active=false` alone, never via `user_orgs.is_active`, so reactivating that user later needs no membership-row repair (no stuck-false absorbing state). This PR does **not** claim §3① closed — see Remaining items |
| 5 (done-gate) | Name + behaviorally verify the real create/sync canonical surface | See Canonical surface section |

### Org-unknowable policy (item 2, doc paragraph)

`AuthService.register(email, password, name)` (deployment-level self-service registration) and
DingTalk OAuth JIT admission (`dingtalk-oauth.ts createProvisionedUser`) have **no org parameter
and no org context anywhere in their call chains** — `register()`'s signature carries none, and
`readDingTalkOauthConfig()` reads a single deployment-wide `DINGTALK_CORP_ID` env var, not an
org-scoped value. There is no existing corp_id→org resolution primitive elsewhere in this
codebase these paths could reuse (directory-sync resolves org from a `directory_integrations`
**row**, which these two paths never touch). Inventing a new corp_id→org inference here would be
new design surface, not a wiring fix, and risks attaching a **wrong** org silently — worse than
none. Per the ticket's explicit instruction, both paths are left writing **zero** `user_orgs`
rows, with the policy recorded in a code comment at each site
(`AuthService.ts:~312`, `dingtalk-oauth.ts:~627`) and verified behaviorally (not just
documented) in `attendance-w4pre1-user-orgs-policy.db.test.ts`. `'default'` is **not** used as a
silent fallback anywhere in this PR's new code — it appears only where the ticket's own §3.3
text and the real `zzzz20260114110000` backfill migration already use it (the *upgrade* test's
simulated legacy row, matching the migration's actual literal), which is explicitly the
one-time-backfill semantics the ticket says NOT to treat as a live-admission default.

### Write-site inventory (site / disposition / anchor)

| Site | Disposition | Anchor |
|---|---|---|
| `POST /api/admin/users` (admin-created user w/ `attendanceOrgId`) | same-txn-write | `packages/core-backend/src/routes/admin-users.ts:3072` (route), `:3233` (new `transaction()` boundary), `:3295` (new `user_orgs` INSERT, `is_active` hardcoded `TRUE` post-review) |
| `createDirectoryAdmittedUserInTransaction` (directory-sync auto-admission + manual `admitDirectoryAccountUser`) | same-txn-write | `packages/core-backend/src/directory/directory-sync.ts:4976` (function), `:5068` (org resolution SELECT), `:5097` (new `user_orgs` INSERT, inside existing DT-HARDEN-02 SAVEPOINT) |
| `AuthService.register` (deployment-level self-service registration) | explicit-policy-recorded | `packages/core-backend/src/auth/AuthService.ts:~312` |
| DingTalk OAuth JIT admission (`createProvisionedUser`) | explicit-policy-recorded | `packages/core-backend/src/auth/dingtalk-oauth.ts:~627` |

**Dual-syntax writer grep (raw `INSERT/UPDATE/DELETE ... user_orgs` + kysely
`insertInto('user_orgs')`), re-run against `a3d05837f` (post-review fix head):**

```
$ grep -rn "INSERT INTO user_orgs" packages/core-backend/src plugins apps
packages/core-backend/src/directory/directory-sync.ts:5097
packages/core-backend/src/db/migrations/zzzz20260114110000_create_user_orgs_table.ts:35   (one-time backfill, untouched)
packages/core-backend/src/routes/admin-users.ts:3295

$ grep -rn "UPDATE user_orgs\|DELETE FROM user_orgs" packages/core-backend/src plugins apps
(no matches)

$ grep -rn "insertInto('user_orgs')" packages/core-backend/src plugins apps
(no matches)
```

Confirms exactly **two** new production writers (plus the pre-existing one-time migration
backfill, not touched/rewritten). No `UPDATE`/`DELETE` writer exists anywhere.

### Canonical surface (done-gate item 5)

**`POST /api/admin/users`** — `packages/core-backend/src/routes/admin-users.ts:3072`.
`behaviorVerified: true` — driven through the **real HTTP route** (not a direct function call)
in `attendance-w4pre1-user-orgs-admission.db.test.ts`: a request with `attendanceGroupId`
produces a `users` row **and** a `user_orgs` row in the same committed transaction, verified by
querying Postgres directly after the request completes. This is the surface the ticket names as
"the first-priority site" and the one a future admin-facing "add member" UI would call — it is
the only legitimate source, per item 5, for the eventual §3① repair-action deep link when the
lock is re-ratified. `createDirectoryAdmittedUserInTransaction`
(`directory-sync.ts:4976`) is the second, automated (sync-triggered) admission surface and is
also behaviorally verified, but is not itself an interactive "go fix this" action — it is listed
in the write-site table above and in
`attendance-w4pre1-user-orgs-directory-sync.db.test.ts`, not claimed as *the* canonical repair
surface.

### Test suites (real Postgres, `.db.test.ts`, two-point CI wiring per S7-1 precedent)

Wired at both points: excluded from the no-DB default run
(`packages/core-backend/vitest.config.ts` exclude list) and run whole-file, with
`DATABASE_URL`/`ATTENDANCE_TEST_DATABASE_URL` set, in `.github/workflows/plugin-tests.yml`'s
existing "Run attendance integration tests" step (the S7-1..S7-4 gate file) — no second gate
file created.

- `attendance-w4pre1-user-orgs-admission.db.test.ts` — `POST /api/admin/users` via a bare
  Express app (deliberately **not** `MetaSheetServer`: its `stop()` closes the shared pg pool,
  which would poison every other `.db.test.ts` file sharing this CI step's single vitest
  invocation — verified this stays green when run alongside the full attendance gate list, see
  below). fresh-DB write + atomicity (Postgres trigger injects a `user_orgs` failure scoped to
  the test's own org → whole admission rolls back, 500, zero orphan `users`/`user_orgs`/
  `attendance_group_members` rows) + two-org non-crossing + org-unknowable negative control (no
  attendance fields ⇒ zero rows) + upgrade (simulated `zzzz20260114110000`-shape backfill row
  survives a later admission in the same `'default'` org) + **post-review**: `isActive:false` at
  creation still writes `user_orgs.is_active=true`, is excluded from the count only via
  `users.is_active`, and needs no membership repair after reactivation via `PATCH
  /api/admin/users/:userId/status`.
- `attendance-w4pre1-user-orgs-directory-sync.db.test.ts` — drives
  `createDirectoryAdmittedUserInTransaction` directly (mirrors the existing
  `directory-sync-admission-orphan-guard.db.test.ts` precedent). fresh-DB write + atomicity
  (same trigger-injection pattern, SAVEPOINT rollback, tx stays usable) + fail-closed org
  resolution (an `integration_id` with no matching `directory_integrations` row throws **before
  any write** — proves it never falls back to a guessed org) + two-org non-crossing + **post-review:
  upgrade** (a pre-existing backfill row survives a new directory-sync admission in the same org —
  this write site had no upgrade leg before).
- `attendance-w4pre1-user-orgs-policy.db.test.ts` — org-unknowable policy proof (zero rows from
  `AuthService.register` and DingTalk JIT admission) + **W4-0-G3 two positive controls
  pre-run** (design lock §9's exact words: "两正控在 W4-PRE-1 完成门先跑一遍，W4-0 完成门复跑" —
  run once at the W4-PRE-1 completion gate, re-run at the W4-0 completion gate). **`setup-readiness`
  HTTP endpoint does not exist and is not built by this PR** — W4-0 scope, explicitly OUT; both
  controls are pre-run here at the SQL/service layer instead (this PR's own scoping choice, not
  a lock quote): pure local org (≥1 active `user_orgs` member, zero `directory_account_links`) ⇒
  `orgActiveMemberCount>0` AND `directoryLinked=false` (via the existing
  `readOrgDirectoryReadiness`, reused not reimplemented); DingTalk-linked org ⇒ both
  `orgActiveMemberCount>0` and `directoryLinked=true` reported correctly at once.

#### Real numbers, original round (local Postgres 14, dedicated DB `metasheet_test_w4pre1`,
`MIGRATION_EXCLUDE` = the exact CI value)

```
$ pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
    tests/integration/attendance-w4pre1-user-orgs-admission.db.test.ts \
    tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts \
    tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts
 Test Files  3 passed (3)
      Tests  13 passed (13)
```

```
$ pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
    <the full 34-file "Run attendance integration tests" list + the 3 new files, exact CI command>
 Test Files  35 passed (35)
      Tests  503 passed (503)
```

#### Real numbers, post-review fix round (head `a3d05837f`, local Postgres 14, own dedicated DB
`metasheet_test_w4pre1fix20260721` — deliberately a different name from the original round's DB
to avoid any shared-fixture collision — `MIGRATION_EXCLUDE` = the exact CI value)

```
$ pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
    tests/integration/attendance-w4pre1-user-orgs-admission.db.test.ts \
    tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts \
    tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts
 Test Files  3 passed (3)
      Tests  15 passed (15)
```
(15 = 13 original + 2 new: the `isActive:false` admission test + the directory-sync `upgrade`
test.)

```
$ pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
    <the full 34-file "Run attendance integration tests" list + the 3 new files, exact CI command>
 Test Files  35 passed (35)
      Tests  505 passed (505)
```
(Confirms the new files coexist cleanly with the S7-1..S7-4 suite and the other 27 files in the
same CI step — no pool-lifecycle interference from the new bare-Express harness, and no cross-run
DB-name assumptions.)

```
$ pnpm --filter @metasheet/core-backend exec tsc --noEmit          # core-backend typecheck
(clean, both rounds)
```

```
$ pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-users-routes.test.ts \
    tests/unit/directory-sync-admission-orphan-guard.test.ts \
    tests/unit/directory-sync-auto-admission.test.ts \
    tests/unit/directory-sync-bind-account.test.ts \
    tests/unit/dingtalk-oauth-login-gates.test.ts --reporter=dot
 Test Files  5 passed (5)
      Tests  109 passed (109)
```
(Re-ran affected-surface unit suite after the fix commit — unaffected by the post-review changes,
still green. Original round's full no-DB unit suite: 423 files / 5808 tests passed, unchanged by
this fix since no unit test file was touched in the fix commit.)

### Why two pre-existing unit test files needed updates (not new gaps — pre-existing mocks that predate this PR's new query shapes)

- `admin-users-routes.test.ts`: `POST /api/admin/users` now wraps its write sequence in
  `transaction()` (`db/pg.ts`) — required for the fresh-DB atomicity leg (§3.3 item 3: a
  `user_orgs` write failure must roll back the **whole** admission, and no transaction boundary
  existed to reuse before this PR, so this establishes the one boundary, not a second one). The
  file's `vi.mock('../../src/db/pg', ...)` didn't export `transaction` at all, so any test that
  reached the write path threw `transaction is not a function`. Fix: added a transparent
  `transaction: vi.fn(async (handler) => handler({ query: pgMocks.query }))` — `client.query`
  and `query` are now the SAME mock function, so every existing `mockResolvedValueOnce`
  call-order script is untouched.
- `directory-sync-admission-orphan-guard.test.ts` + `directory-sync-bind-account.test.ts`:
  `createDirectoryAdmittedUserInTransaction` now runs
  `SELECT org_id FROM directory_integrations WHERE id = $1` before writing. Both files' fake/mock
  clients always returned `{ rows: [] }` for every query — before this PR that was harmless (no
  query relied on a non-empty result at that point); now it made the fixtures' admissions fail
  closed too, above the tests' actual load-bearing assertions. Fix: special-case that one SELECT
  to return a plausible `org_id` row; every other SQL keeps the previous always-empty-rows
  default, so tests that never reach admission (bind/unbind) are unaffected — a strict superset,
  not a behavior change for them.

### Mutation self-checks (≥3, committed-then-mutated-then-reverted; never `git checkout -- <file>`)

| # | Target | Mutation | Red leg | Restored |
|---|---|---|---|---|
| 1 | `admin-users.ts` `user_orgs` write | `if (false && attendanceOrgId) {` (neuter the write) | `attendance-w4pre1-user-orgs-admission.db.test.ts`: fresh-DB write test red (no row), atomicity test red (200 instead of 500 — trigger never fires because nothing is written), two-org red (both counts 0), upgrade red (new row missing) — 4/5 tests red, `org-unknowable` negative control correctly stayed green | yes — `git diff` against the commit was empty after revert, re-ran green (5/5) |
| 2 | two-org test's own `orgB` binding | `const orgB = orgA` (collapse the second org into a constant equal to the first) | `two-org` test red: `expect(await activeMemberCount(orgA)).toBe(1)` got `2` (both users landed in the same org once the test stopped distinguishing them) — proves the assertion is discriminating, not vacuously true regardless of actual cross-org behavior | yes — reverted the one line, re-ran green |
| 3 | `admin-users.ts` `user_orgs` write | inserted a spurious `DELETE FROM user_orgs WHERE org_id = $1` immediately before the real `INSERT` (simulates a naive "reset" implementation bug) | `upgrade` test red: `legacyRow` assertion got `null` instead of the pre-existing backfill row — proves "backfill row untouched" is a load-bearing assertion, not a no-op check | yes — removed the injected line, `git diff` empty, re-ran green |
| 4 (post-review, head `a3d05837f`) | `admin-users.ts` `user_orgs` write — the fixed hardcoded-`TRUE` line | reverted the fix back to `VALUES ($1, $2, $3)` / `[userId, attendanceOrgId, isActive]` (the pre-review mirroring behavior) | new `isActive:false` admission test red: `expect(row).toEqual({..., is_active: true})` got `is_active: false` — proves the new test actually discriminates the fixed behavior from the old bug, not a vacuous assertion | yes — restored from a pre-mutation file copy (not `git checkout --`), `git diff` against the commit was empty, re-ran green (6/6 in that file) |
| 5 (post-review, head `a3d05837f`) | `directory-sync.ts` `user_orgs` write | wrapped the `INSERT INTO user_orgs` `client.query(...)` call in `if (false) { … }` (neuter the write) | `attendance-w4pre1-user-orgs-directory-sync.db.test.ts`: fresh-DB write test red (no row), **upgrade test red** (new row missing — this is the new leg added by this fix), two-org red (both counts 0) — 4/5 tests red, `fail-closed org resolution` negative control correctly stayed green | yes — restored from a pre-mutation file copy, `git diff` against the commit was empty, re-ran green (5/5 in that file) |

### CI wiring

- `packages/core-backend/vitest.config.ts`: three new files added to the no-DB `exclude` list
  (S7-1-style comment block).
- `.github/workflows/plugin-tests.yml`: three new files added to the "Run attendance integration
  tests" step's `vitest run` file list (same step as S7-1..S7-4, `attendance-plugin.test.ts`,
  etc.) — the only `.db.test.ts` step this domain uses; no second workflow file exists for it.

### Deviations from the ticket

None. All five §3.3 items implemented as specified; no scope was added beyond what item 3
(atomicity) forced (the `transaction()` wrap in `admin-users.ts`, called out explicitly above
rather than left as a silent side effect).

### Remaining / honest gaps

- **§3① is NOT declared closed by this PR** — per the ticket's own instruction ("只补双
  is_active 不闭合①"), this PR's job was making the write path exist and be correct, not
  pronouncing the design lock's completion criterion satisfied. That judgment belongs to the
  owner's re-ratify step (§10 of the lock).
- Re-ratifying the design lock (SUSPENDED → RATIFIED), refreshing the lock branch against the
  latest main, and opening W4-0 are all explicitly **out of scope** per the lock's own restart
  sequence (§10) and are not done by this PR.
- The frozen branch `claude/w4-0-setup-readiness-20260721` was not touched, rebased onto, or
  built upon.
- No new migration was needed or added (`user_orgs` already exists); if one had been needed this
  PR would have stopped and reported it instead.

Refs #4513 (owner errata that created this ticket) and
`docs/development/attendance-vnext-wave4-onboarding-design-lock-20260721.md` §3.3. Does **not**
close or ratify that document — the lock stays `RATIFICATION SUSPENDED / W4-0 FROZEN` until the
owner's own re-ratify step.

This PR is **not armed for auto-merge and does not merge itself** — staged opt-in / re-ratify
decision belongs to the owner per repo convention.

