### PR TITLE
feat(approval): add ordinary-user FWB mapping editor shell

### DIFF
--- a/apps/web/src/approvals/components/ApprovalFwbMappingEditor.vue
+++ b/apps/web/src/approvals/components/ApprovalFwbMappingEditor.vue
@@ -1,0 +1,420 @@
+<script lang="ts">
+/** Confirmation lifecycle the PARENT owns (server-confirmed state machine). */
+export type FwbMappingConfirmationState = 'unconfirmed' | 'confirming' | 'confirmed'
+</script>
+
+<script setup lang="ts">
+// FWB create-mode mapping editor — a bounded, reusable UI shell over the FWB-1 authoring
+// contract in `../fwbMappingConfig` (#4515/#4516). Production mounting and the server
+// confirmation round-trip are later slices; this component deliberately:
+//   - re-validates the WHOLE draft via validateFwbMappingConfig on every render (fail-closed
+//     allowlist — the editor is UX, not the security boundary);
+//   - NEVER generates, stores, or accepts a confirmationHash — the parent/server owns the
+//     hash; this shell only knows the three confirmation STATES and asks for confirmation
+//     (`request-confirmation`) when the draft validates;
+//   - emits `invalidate-confirmation` on EVERY mapping mutation, so an edit after `confirmed`
+//     immediately tears down the parent's confirmed state;
+//   - keeps exact-number mappings unavailable: number targets are never offered for NEW
+//     mappings, and a LOADED number mapping stays visible with a blocked reason instead of
+//     being silently dropped (same treatment for unsupported types and option-less selects);
+//   - keeps stale/unknown loaded field ids losslessly: the id survives only as the option
+//     VALUE (round-trip), while the user-facing label is a generic localized
+//     "Unavailable field" marker — never a blank select, never the raw id as the only label.
+import { computed } from 'vue'
+import { Delete, Plus } from '@element-plus/icons-vue'
+import {
+  toExecutorMappings,
+  validateFwbMappingConfig,
+  type FwbConfigIssue,
+  type FwbMappingDraft,
+  type TargetFieldInfo,
+  type TemplateFieldInfo,
+} from '../fwbMappingConfig'
+
+type FwbConfirmationMapping = ReturnType<typeof toExecutorMappings>[number]
+
+const props = withDefaults(defineProps<{
+  templateFields: readonly TemplateFieldInfo[]
+  targetFields: readonly TargetFieldInfo[]
+  modelValue: readonly FwbMappingDraft[]
+  disabled?: boolean
+  loading?: boolean
+  /** Bilingual chrome: zh labels when true, en otherwise. */
+  isZh?: boolean
+  confirmationState?: FwbMappingConfirmationState
+}>(), {
+  disabled: false,
+  loading: false,
+  isZh: true,
+  confirmationState: 'unconfirmed',
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: FwbMappingDraft[]): void
+  /** Fired ONLY when the whole draft validates; payload is the executor-shaped mappings. */
+  (e: 'request-confirmation', value: FwbConfirmationMapping[]): void
+  /** Fired on every mapping mutation so the parent drops any confirmed state/hash. */
+  (e: 'invalidate-confirmation'): void
+}>()
+
+const LABELS = {
+  formField: { zh: '表单字段', en: 'Form field' },
+  targetField: { zh: '目标字段', en: 'Target field' },
+  addMapping: { zh: '添加映射', en: 'Add mapping' },
+  removeMapping: { zh: '移除映射', en: 'Remove mapping' },
+  confirm: { zh: '请求确认', en: 'Request confirmation' },
+  unconfirmed: { zh: '未确认', en: 'Unconfirmed' },
+  confirming: { zh: '确认中…', en: 'Confirming…' },
+  confirmed: { zh: '已确认', en: 'Confirmed' },
+  unavailableField: { zh: '不可用字段', en: 'Unavailable field' },
+  emptyConfig: { zh: '至少需要一条映射', en: 'Add at least one mapping' },
+  selectFormField: { zh: '请选择表单字段', en: 'Select a form field' },
+  selectTargetField: { zh: '请选择目标字段', en: 'Select a target field' },
+  unknownFormField: { zh: '表单字段已失效', en: 'Form field is no longer available' },
+  unknownTargetField: { zh: '目标字段已失效', en: 'Target field is no longer available' },
+  unsupportedType: { zh: '目标字段类型不支持', en: 'Unsupported target field type' },
+  numberUnavailable: { zh: '数值字段暂不支持精确映射', en: 'Exact number mapping is not available yet' },
+  selectNoOptions: { zh: '目标选项字段缺少可选值', en: 'Target select field has no options' },
+  duplicateTarget: { zh: '目标字段重复', en: 'Duplicate target field' },
+} as const
+
+type LabelKey = keyof typeof LABELS
+
+function t(key: LabelKey): string {
+  return props.isZh ? LABELS[key].zh : LABELS[key].en
+}
+
+const controlsDisabled = computed(() => props.disabled || props.loading)
+
+// Whole-draft validation — the single source of truth for what blocks confirmation.
+const issues = computed<FwbConfigIssue[]>(() =>
+  validateFwbMappingConfig(props.modelValue, props.templateFields, props.targetFields),
+)
+
+const globalReasons = computed<string[]>(() =>
+  issues.value.filter((issue) => issue.code === 'empty_config').map(() => t('emptyConfig')),
+)
+
+function issueLabel(code: FwbConfigIssue['code']): string {
+  switch (code) {
+    case 'unknown_form_field': return t('unknownFormField')
+    case 'unknown_target_field': return t('unknownTargetField')
+    case 'unsupported_target_type': return t('unsupportedType')
+    case 'exact_number_mapping_unavailable': return t('numberUnavailable')
+    case 'select_options_missing': return t('selectNoOptions')
+    case 'duplicate_target': return t('duplicateTarget')
+    case 'empty_config': return t('emptyConfig')
+  }
+}
+
+/** Compact per-row block reasons; empty (not-yet-picked) selects get a friendlier prompt. */
+function rowReasons(index: number): string[] {
+  const row = props.modelValue[index]
+  const reasons: string[] = []
+  if (row) {
+    if (!row.formFieldId) reasons.push(t('selectFormField'))
+    if (!row.targetFieldId) reasons.push(t('selectTargetField'))
+  }
+  for (const issue of issues.value) {
+    if (!('index' in issue) || issue.index !== index) continue
+    if (issue.code === 'unknown_form_field' && row && !row.formFieldId) continue
+    if (issue.code === 'unknown_target_field' && row && !row.targetFieldId) continue
+    reasons.push(issueLabel(issue.code))
+  }
+  return reasons
+}
+
+interface SelectOption {
+  value: string
+  label: string
+  disabled: boolean
+}
+
+function formOptions(row: FwbMappingDraft): SelectOption[] {
+  const options: SelectOption[] = props.templateFields.map((f) => ({ value: f.id, label: f.label, disabled: false }))
+  if (row.formFieldId && !props.templateFields.some((f) => f.id === row.formFieldId)) {
+    // Stale loaded id: lossless value, generic marker label (never the raw id alone).
+    options.push({ value: row.formFieldId, label: t('unavailableField'), disabled: true })
+  }
+  return options
+}
+
+type NormalizedTargetType = 'text' | 'number' | 'date' | 'select' | null
+
+function normalizeTargetType(type: string): NormalizedTargetType {
+  if (type === 'string' || type === 'text') return 'text'
+  if (type === 'number' || type === 'date' || type === 'select') return type
+  return null
+}
+
+function targetOptions(row: FwbMappingDraft, rowIndex: number): SelectOption[] {
+  const options: SelectOption[] = []
+  for (const field of props.targetFields) {
+    const normalized = normalizeTargetType(field.type)
+    const isCurrentValue = row.targetFieldId === field.id
+    const isHeldByAnotherRow = props.modelValue.some(
+      (mapping, index) => index !== rowIndex && mapping.targetFieldId === field.id,
+    )
+    if (normalized === 'text' || normalized === 'date') {
+      options.push({ value: field.id, label: field.label, disabled: isHeldByAnotherRow })
+    } else if (normalized === 'select') {
+      const hasOptions = !!field.selectOptions && field.selectOptions.length > 0
+      options.push(hasOptions
+        ? { value: field.id, label: field.label, disabled: isHeldByAnotherRow }
+        : { value: field.id, label: `${field.label}（${t('selectNoOptions')}）`, disabled: true })
+    } else if (isCurrentValue) {
+      // number / unsupported: never offered for NEW mappings — only kept visible (disabled,
+      // with a blocked reason) when a LOADED mapping already points at it.
+      const reason = normalized === 'number' ? t('numberUnavailable') : t('unsupportedType')
+      options.push({ value: field.id, label: `${field.label}（${reason}）`, disabled: true })
+    }
+  }
+  if (row.targetFieldId && !props.targetFields.some((f) => f.id === row.targetFieldId)) {
+    options.push({ value: row.targetFieldId, label: t('unavailableField'), disabled: true })
+  }
+  return options
+}
+
+const stateLabel = computed(() => t(props.confirmationState))
+
+const confirmDisabled = computed(() =>
+  controlsDisabled.value || props.confirmationState !== 'unconfirmed' || issues.value.length > 0,
+)
+
+function emitDraft(next: FwbMappingDraft[]): void {
+  emit('update:modelValue', next)
+  // Any mutation — including one made while `confirmed` — invalidates confirmation immediately.
+  emit('invalidate-confirmation')
+}
+
+function addRow(): void {
+  if (controlsDisabled.value) return
+  emitDraft([...props.modelValue, { formFieldId: '', targetFieldId: '' }])
+}
+
+function removeRow(index: number): void {
+  if (controlsDisabled.value) return
+  emitDraft(props.modelValue.filter((_, i) => i !== index))
+}
+
+function setFormField(index: number, value: unknown): void {
+  if (controlsDisabled.value) return
+  const id = typeof value === 'string' ? value : ''
+  emitDraft(props.modelValue.map((m, i) => (i === index ? { ...m, formFieldId: id } : m)))
+}
+
+function setTargetField(index: number, value: unknown): void {
+  if (controlsDisabled.value) return
+  const id = typeof value === 'string' ? value : ''
+  emitDraft(props.modelValue.map((m, i) => (i === index ? { ...m, targetFieldId: id } : m)))
+}
+
+function requestConfirmation(): void {
+  if (controlsDisabled.value || props.confirmationState !== 'unconfirmed') return
+  // Fail-closed: ask for confirmation ONLY when the whole draft validates. The parent/server
+  // owns the confirmationHash — this component never sees one.
+  if (issues.value.length > 0) return
+  emit('request-confirmation', toExecutorMappings(props.modelValue, props.targetFields))
+}
+</script>
+
+<template>
+  <div class="fwb-mapping-editor" data-testid="approval-fwb-mapping-editor">
+    <div v-if="modelValue.length > 0" class="fwb-mapping-editor__head">
+      <span class="fwb-mapping-editor__col-label">{{ t('formField') }}</span>
+      <span class="fwb-mapping-editor__col-label">{{ t('targetField') }}</span>
+      <span class="fwb-mapping-editor__col-spacer" />
+    </div>
+
+    <div
+      v-for="(row, index) in modelValue"
+      :key="index"
+      class="fwb-mapping-editor__row"
+      data-testid="fwb-mapping-row"
+      :data-row-index="index"
+    >
+      <el-select
+        class="fwb-mapping-editor__select fwb-mapping-editor__select--form"
+        size="small"
+        :model-value="row.formFieldId || undefined"
+        :placeholder="t('formField')"
+        :disabled="controlsDisabled"
+        data-testid="fwb-form-field-select"
+        @update:model-value="setFormField(index, $event)"
+      >
+        <el-option
+          v-for="option in formOptions(row)"
+          :key="option.value"
+          :label="option.label"
+          :value="option.value"
+          :disabled="option.disabled"
+        />
+      </el-select>
+
+      <el-select
+        class="fwb-mapping-editor__select fwb-mapping-editor__select--target"
+        size="small"
+        :model-value="row.targetFieldId || undefined"
+        :placeholder="t('targetField')"
+        :disabled="controlsDisabled"
+        data-testid="fwb-target-field-select"
+        @update:model-value="setTargetField(index, $event)"
+      >
+        <el-option
+          v-for="option in targetOptions(row, index)"
+          :key="option.value"
+          :label="option.label"
+          :value="option.value"
+          :disabled="option.disabled"
+        />
+      </el-select>
+
+      <el-button
+        class="fwb-mapping-editor__icon-btn"
+        size="small"
+        text
+        type="danger"
+        :disabled="controlsDisabled"
+        :aria-label="t('removeMapping')"
+        :title="t('removeMapping')"
+        data-testid="fwb-remove-mapping"
+        @click="removeRow(index)"
+      >
+        <el-icon><Delete /></el-icon>
+      </el-button>
+
+      <p
+        v-if="rowReasons(index).length > 0"
+        class="fwb-mapping-editor__row-issues"
+        data-testid="fwb-row-issues"
+      >{{ rowReasons(index).join('；') }}</p>
+    </div>
+
+    <div class="fwb-mapping-editor__footer">
+      <el-button
+        size="small"
+        :disabled="controlsDisabled"
+        :aria-label="t('addMapping')"
+        :title="t('addMapping')"
+        data-testid="fwb-add-mapping"
+        @click="addRow"
+      >
+        <el-icon><Plus /></el-icon>
+        <span>{{ t('addMapping') }}</span>
+      </el-button>
+
+      <span
+        class="fwb-mapping-editor__state"
+        :class="`fwb-mapping-editor__state--${confirmationState}`"
+        :data-state="confirmationState"
+        data-testid="fwb-confirmation-state"
+      >{{ stateLabel }}</span>
+
+      <el-button
+        size="small"
+        type="primary"
+        :disabled="confirmDisabled"
+        data-testid="fwb-request-confirmation"
+        @click="requestConfirmation"
+      >{{ t('confirm') }}</el-button>
+    </div>
+
+    <p
+      v-if="globalReasons.length > 0"
+      class="fwb-mapping-editor__global-issues"
+      data-testid="fwb-global-issues"
+    >{{ globalReasons.join('；') }}</p>
+  </div>
+</template>
+
+<style scoped>
+.fwb-mapping-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.fwb-mapping-editor__head,
+.fwb-mapping-editor__row {
+  display: grid;
+  /* Stable dimensions: both field columns share width and shrink without wrapping. */
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 32px;
+  gap: 8px;
+  align-items: center;
+}
+
+.fwb-mapping-editor__row {
+  min-height: 32px;
+}
+
+.fwb-mapping-editor__col-label {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fwb-mapping-editor__select {
+  width: 100%;
+  min-width: 0;
+}
+
+.fwb-mapping-editor__icon-btn {
+  justify-self: end;
+}
+
+.fwb-mapping-editor__row-issues {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--el-color-danger);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fwb-mapping-editor__footer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.fwb-mapping-editor__state {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  white-space: nowrap;
+}
+
+.fwb-mapping-editor__state--confirmed {
+  color: var(--el-color-success);
+}
+
+.fwb-mapping-editor__state--confirming {
+  color: var(--el-color-warning);
+}
+
+.fwb-mapping-editor__global-issues {
+  margin: 0;
+  font-size: 12px;
+  color: var(--el-color-danger);
+}
+
+/* Responsive: stack the two field columns on narrow widths, keep the remove button beside
+   the target field; the header row is redundant once stacked. */
+@media (max-width: 640px) {
+  .fwb-mapping-editor__head {
+    display: none;
+  }
+
+  .fwb-mapping-editor__row {
+    grid-template-columns: minmax(0, 1fr) 32px;
+  }
+
+  .fwb-mapping-editor__select--form {
+    grid-column: 1 / -1;
+  }
+}
+</style>

--- a/apps/web/src/approvals/fwbMappingConfig.ts
+++ b/apps/web/src/approvals/fwbMappingConfig.ts
@@ -78,10 +78,24 @@ export function toExecutorMappings(
   targetFields: readonly TargetFieldInfo[],
 ): Array<{ formFieldId: string; targetFieldId: string; targetType: FwbTargetType; selectOptions?: readonly string[] }> {
   const tgt = new Map(targetFields.map((f) => [f.id, f]))
+  const seenTargets = new Set<string>()
   return draft.map((m) => {
     const t = tgt.get(m.targetFieldId)
     const targetType = t ? toFwbTargetType(t.type) : null
-    if (!t || !targetType || targetType === 'number') throw new RangeError('toExecutorMappings called on an unvalidated draft')
+    const invalidSelect = targetType === 'select' && (!t?.selectOptions || t.selectOptions.length === 0)
+    const duplicateTarget = seenTargets.has(m.targetFieldId)
+    if (
+      !m.formFieldId
+      || !m.targetFieldId
+      || !t
+      || !targetType
+      || targetType === 'number'
+      || invalidSelect
+      || duplicateTarget
+    ) {
+      throw new RangeError('toExecutorMappings called on an unvalidated draft')
+    }
+    seenTargets.add(m.targetFieldId)
     return {
       formFieldId: m.formFieldId,
       targetFieldId: m.targetFieldId,

--- a/apps/web/tests/approval-fwb-mapping-config.test.ts
+++ b/apps/web/tests/approval-fwb-mapping-config.test.ts
@@ -48,5 +48,10 @@ describe('FWB mapping config model', () => {
     expect(() => toExecutorMappings([{ formFieldId: 'f1', targetFieldId: 'ghost' }], TGT)).toThrow(/unvalidated/)
     expect(() => toExecutorMappings([{ formFieldId: 'f1', targetFieldId: 't_formula' }], TGT)).toThrow(/unvalidated/)
     expect(() => toExecutorMappings([{ formFieldId: 'f1', targetFieldId: 't_num' }], TGT)).toThrow(/unvalidated/)
+    expect(() => toExecutorMappings([{ formFieldId: 'f1', targetFieldId: 't_sel_empty' }], TGT)).toThrow(/unvalidated/)
+    expect(() => toExecutorMappings([
+      { formFieldId: 'f1', targetFieldId: 't_text' },
+      { formFieldId: 'f2', targetFieldId: 't_text' },
+    ], TGT)).toThrow(/unvalidated/)
   })
 })

--- a/apps/web/tests/approval-fwb-mapping-editor.spec.ts
+++ b/apps/web/tests/approval-fwb-mapping-editor.spec.ts
@@ -1,0 +1,430 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+import ApprovalFwbMappingEditor from '../src/approvals/components/ApprovalFwbMappingEditor.vue'
+import type { FwbMappingDraft, TargetFieldInfo, TemplateFieldInfo } from '../src/approvals/fwbMappingConfig'
+
+// FWB create-mode mapping editor — mounted contract tests over the #4515/#4516 model.
+// Element Plus is stubbed with NATIVE form controls (the established pattern in this repo,
+// e.g. approvalUserPicker.spec.ts): the stubs prove the component wires the el-select /
+// el-option / el-button CONTRACT correctly — value binding, disabled options, click/change
+// emission — without dragging in popper/keyboard machinery jsdom cannot layout.
+
+// Native <select> stand-in. The value is synced AFTER options mount (onMounted/onUpdated)
+// because a programmatic value set before the <option> children exist would not stick —
+// this also matches real browser behavior of selecting a DISABLED option programmatically
+// (a loaded blocked mapping stays displayed).
+const ElSelect = defineComponent({
+  name: 'ElSelect',
+  props: {
+    modelValue: { type: String, default: undefined },
+    disabled: Boolean,
+    placeholder: String,
+    size: String,
+  },
+  emits: ['update:modelValue'],
+  methods: {
+    syncValue() {
+      const el = this.$el as HTMLSelectElement | null
+      if (el) el.value = this.modelValue ?? ''
+    },
+  },
+  mounted() {
+    this.syncValue()
+  },
+  updated() {
+    this.syncValue()
+  },
+  render() {
+    return h('select', {
+      disabled: this.disabled,
+      'data-placeholder': this.placeholder,
+      onChange: (e: Event) => this.$emit('update:modelValue', (e.target as HTMLSelectElement).value),
+    }, this.$slots.default?.())
+  },
+})
+
+const ElOption = defineComponent({
+  name: 'ElOption',
+  props: { label: String, value: String, disabled: Boolean },
+  render() {
+    return h('option', { value: this.value, disabled: this.disabled }, this.label)
+  },
+})
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { disabled: Boolean, type: String, size: String, text: Boolean },
+  emits: ['click'],
+  render() {
+    return h('button', {
+      disabled: this.disabled,
+      onClick: (e: MouseEvent) => this.$emit('click', e),
+    }, this.$slots.default?.())
+  },
+})
+
+const ElIcon = defineComponent({
+  name: 'ElIcon',
+  render() {
+    return h('span', { class: 'el-icon-stub' }, this.$slots.default?.())
+  },
+})
+
+const TPL: TemplateFieldInfo[] = [
+  { id: 'f_title', label: '申请标题' },
+  { id: 'f_date', label: '出差日期' },
+  { id: 'f_level', label: '报销等级' },
+]
+
+const TGT: TargetFieldInfo[] = [
+  { id: 't_text', label: '标题', type: 'string' },
+  { id: 't_date', label: '日期', type: 'date' },
+  { id: 't_sel', label: '等级', type: 'select', selectOptions: ['低', '高'] },
+  { id: 't_sel_empty', label: '空选项', type: 'select', selectOptions: [] },
+  { id: 't_num', label: '金额', type: 'number' },
+  { id: 't_formula', label: '公式', type: 'formula' },
+]
+
+const VALID_DRAFT: FwbMappingDraft[] = [
+  { formFieldId: 'f_title', targetFieldId: 't_text' },
+  { formFieldId: 'f_date', targetFieldId: 't_date' },
+  { formFieldId: 'f_level', targetFieldId: 't_sel' },
+]
+
+interface EditorEvents {
+  'update:modelValue': FwbMappingDraft[][]
+  'request-confirmation': unknown[][]
+  'invalidate-confirmation': null[]
+}
+
+describe('ApprovalFwbMappingEditor', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    container?.remove()
+    app = null
+    container = null
+  })
+
+  async function mountEditor(props: Record<string, unknown> = {}): Promise<EditorEvents> {
+    const events: EditorEvents = {
+      'update:modelValue': [],
+      'request-confirmation': [],
+      'invalidate-confirmation': [],
+    }
+    const Host = defineComponent({
+      setup() {
+        const model = ref<FwbMappingDraft[]>([
+          ...((props.modelValue as readonly FwbMappingDraft[] | undefined) ?? []),
+        ])
+        return () =>
+          h(ApprovalFwbMappingEditor, {
+            templateFields: TPL,
+            targetFields: TGT,
+            ...props,
+            modelValue: model.value,
+            'onUpdate:modelValue': (value: FwbMappingDraft[]) => {
+              model.value = value
+              events['update:modelValue'].push(value)
+            },
+            'onRequest-confirmation': (value: unknown[]) => events['request-confirmation'].push(value),
+            'onInvalidate-confirmation': () => events['invalidate-confirmation'].push(null),
+          })
+      },
+    })
+    app = createApp(Host)
+    app.component('ElSelect', ElSelect)
+    app.component('ElOption', ElOption)
+    app.component('ElButton', ElButton)
+    app.component('ElIcon', ElIcon)
+    app.mount(container!)
+    await nextTick()
+    return events
+  }
+
+  function rows(): HTMLElement[] {
+    return Array.from(container!.querySelectorAll('[data-testid="fwb-mapping-row"]'))
+  }
+
+  function formSelect(row: HTMLElement): HTMLSelectElement {
+    return row.querySelector('[data-testid="fwb-form-field-select"]') as HTMLSelectElement
+  }
+
+  function targetSelect(row: HTMLElement): HTMLSelectElement {
+    return row.querySelector('[data-testid="fwb-target-field-select"]') as HTMLSelectElement
+  }
+
+  function targetOptions(row: HTMLElement): HTMLOptionElement[] {
+    return Array.from(targetSelect(row).querySelectorAll('option'))
+  }
+
+  function change(select: HTMLSelectElement, value: string): void {
+    select.value = value
+    select.dispatchEvent(new Event('change'))
+  }
+
+  function confirmButton(): HTMLButtonElement {
+    return container!.querySelector('[data-testid="fwb-request-confirmation"]') as HTMLButtonElement
+  }
+
+  it('add appends an empty mapping row; remove drops the row (both invalidate confirmation)', async () => {
+    const events = await mountEditor({ modelValue: [] })
+    expect(rows()).toHaveLength(0)
+
+    ;(container!.querySelector('[data-testid="fwb-add-mapping"]') as HTMLButtonElement).click()
+    await nextTick()
+    expect(events['update:modelValue'].at(-1)).toEqual([{ formFieldId: '', targetFieldId: '' }])
+    expect(events['invalidate-confirmation']).toHaveLength(1)
+
+    ;(container!.querySelector('[data-testid="fwb-add-mapping"]') as HTMLButtonElement).click()
+    await nextTick()
+    expect(events['update:modelValue'].at(-1)).toEqual([
+      { formFieldId: '', targetFieldId: '' },
+      { formFieldId: '', targetFieldId: '' },
+    ])
+
+    // remove the second row of a two-row draft
+    app!.unmount()
+    const events2 = await mountEditor({
+      modelValue: [
+        { formFieldId: 'f_title', targetFieldId: 't_text' },
+        { formFieldId: 'f_date', targetFieldId: 't_date' },
+      ],
+    })
+    const removeButtons = container!.querySelectorAll('[data-testid="fwb-remove-mapping"]')
+    ;(removeButtons[1] as HTMLButtonElement).click()
+    await nextTick()
+    expect(events2['update:modelValue'].at(-1)).toEqual([{ formFieldId: 'f_title', targetFieldId: 't_text' }])
+    expect(events2['invalidate-confirmation']).toHaveLength(1)
+    expect(events).not.toBe(events2)
+  })
+
+  it('stale loaded ids stay losslessly selected: id only as option VALUE, generic localized marker as label', async () => {
+    await mountEditor({ modelValue: [{ formFieldId: 'ghost_f', targetFieldId: 'ghost_t' }] })
+    const row = rows()[0]
+
+    // both selects keep the stale id as their value (lossless round-trip, no blank select)
+    expect(formSelect(row).value).toBe('ghost_f')
+    expect(targetSelect(row).value).toBe('ghost_t')
+
+    const staleFormOption = formSelect(row).querySelector('option[value="ghost_f"]') as HTMLOptionElement
+    const staleTargetOption = targetSelect(row).querySelector('option[value="ghost_t"]') as HTMLOptionElement
+    expect(staleFormOption).not.toBeNull()
+    expect(staleTargetOption).not.toBeNull()
+    // user-facing label is the generic marker — never the raw id alone
+    expect(staleFormOption.textContent?.trim()).toBe('不可用字段')
+    expect(staleTargetOption.textContent?.trim()).toBe('不可用字段')
+    expect(Array.from(row.querySelectorAll('option')).some((o) => o.textContent?.trim() === 'ghost_f')).toBe(false)
+    expect(Array.from(row.querySelectorAll('option')).some((o) => o.textContent?.trim() === 'ghost_t')).toBe(false)
+
+    // stale fields are marked non-authoritative: the row carries block reasons and confirmation stays blocked
+    expect(row.querySelector('[data-testid="fwb-row-issues"]')?.textContent).toContain('已失效')
+    expect(confirmButton().disabled).toBe(true)
+  })
+
+  it('a LOADED exact-number mapping stays visible with a clear blocked reason (never silently dropped)', async () => {
+    const events = await mountEditor({ modelValue: [{ formFieldId: 'f_title', targetFieldId: 't_num' }] })
+    expect(rows()).toHaveLength(1)
+    const row = rows()[0]
+    expect(targetSelect(row).value).toBe('t_num')
+    const numberOption = targetSelect(row).querySelector('option[value="t_num"]') as HTMLOptionElement
+    expect(numberOption).not.toBeNull()
+    expect(numberOption.disabled).toBe(true)
+    const reason = row.querySelector('[data-testid="fwb-row-issues"]')?.textContent ?? ''
+    expect(reason).toContain('数值字段暂不支持')
+    confirmButton().click()
+    await nextTick()
+    expect(events['request-confirmation']).toHaveLength(0)
+  })
+
+  it('TRIPWIRE — number/unsupported targets are never offered for NEW mappings (fails if number becomes authorable)', async () => {
+    await mountEditor({ modelValue: [{ formFieldId: 'f_title', targetFieldId: '' }] })
+    const options = targetOptions(rows()[0])
+    // number target: entirely absent from the new-mapping option set
+    expect(options.some((o) => o.value === 't_num')).toBe(false)
+    // unsupported type: also absent
+    expect(options.some((o) => o.value === 't_formula')).toBe(false)
+    // every OFFERED (enabled) option is a text/date/select-with-options target — if number
+    // ever becomes authorable, an enabled t_num option appears here and this fails
+    for (const option of options) {
+      if (option.disabled) continue
+      expect(['t_text', 't_date', 't_sel']).toContain(option.value)
+    }
+  })
+
+  it('a select target without options stays visible but blocked — for loaded AND new mappings', async () => {
+    // loaded: row visible, blocked reason, confirmation blocked
+    const events = await mountEditor({ modelValue: [{ formFieldId: 'f_title', targetFieldId: 't_sel_empty' }] })
+    const row = rows()[0]
+    expect(targetSelect(row).value).toBe('t_sel_empty')
+    expect(row.querySelector('[data-testid="fwb-row-issues"]')?.textContent).toContain('缺少可选值')
+    confirmButton().click()
+    await nextTick()
+    expect(events['request-confirmation']).toHaveLength(0)
+
+    // new mapping: the option-less select target is offered only as a DISABLED, reason-marked option
+    app!.unmount()
+    await mountEditor({ modelValue: [{ formFieldId: 'f_title', targetFieldId: '' }] })
+    const emptySelect = targetOptions(rows()[0]).find((o) => o.value === 't_sel_empty')!
+    expect(emptySelect.disabled).toBe(true)
+    expect(emptySelect.textContent).toContain('缺少可选值')
+  })
+
+  it('duplicate targets block confirmation with a per-row reason', async () => {
+    const events = await mountEditor({
+      modelValue: [
+        { formFieldId: 'f_title', targetFieldId: 't_text' },
+        { formFieldId: 'f_date', targetFieldId: 't_text' },
+      ],
+    })
+    expect(rows()[1].querySelector('[data-testid="fwb-row-issues"]')?.textContent).toContain('目标字段重复')
+    expect(confirmButton().disabled).toBe(true)
+    confirmButton().click()
+    await nextTick()
+    expect(events['request-confirmation']).toHaveLength(0)
+    expect(targetSelect(rows()[0]).querySelector('option[value="t_text"]')?.disabled).toBe(true)
+    expect(targetSelect(rows()[1]).querySelector('option[value="t_text"]')?.disabled).toBe(true)
+  })
+
+  it('a target selected by another row is unavailable before it can create a duplicate', async () => {
+    await mountEditor({
+      modelValue: [
+        { formFieldId: 'f_title', targetFieldId: 't_text' },
+        { formFieldId: 'f_date', targetFieldId: '' },
+      ],
+    })
+    const firstTarget = targetSelect(rows()[0]).querySelector('option[value="t_text"]') as HTMLOptionElement
+    const secondTarget = targetSelect(rows()[1]).querySelector('option[value="t_text"]') as HTMLOptionElement
+    expect(firstTarget.disabled).toBe(false)
+    expect(secondTarget.disabled).toBe(true)
+  })
+
+  it('empty config blocks confirmation with a global reason', async () => {
+    const events = await mountEditor({ modelValue: [] })
+    expect(container!.querySelector('[data-testid="fwb-global-issues"]')?.textContent).toContain('至少需要一条映射')
+    expect(confirmButton().disabled).toBe(true)
+    confirmButton().click()
+    await nextTick()
+    expect(events['request-confirmation']).toHaveLength(0)
+  })
+
+  it('request-confirmation fires ONLY for a fully valid text/date/select draft, carrying executor-shaped mappings', async () => {
+    const events = await mountEditor({ modelValue: VALID_DRAFT })
+    expect(confirmButton().disabled).toBe(false)
+    confirmButton().click()
+    await nextTick()
+    expect(events['request-confirmation']).toHaveLength(1)
+    expect(events['request-confirmation'][0]).toEqual([
+      { formFieldId: 'f_title', targetFieldId: 't_text', targetType: 'text' },
+      { formFieldId: 'f_date', targetFieldId: 't_date', targetType: 'date' },
+      { formFieldId: 'f_level', targetFieldId: 't_sel', targetType: 'select', selectOptions: ['低', '高'] },
+    ])
+  })
+
+  it('an edit while CONFIRMED immediately emits invalidate-confirmation (and every mutation does)', async () => {
+    const events = await mountEditor({ modelValue: VALID_DRAFT, confirmationState: 'confirmed' })
+    expect(container!.querySelector('[data-testid="fwb-confirmation-state"]')?.textContent).toContain('已确认')
+
+    change(formSelect(rows()[0]), 'f_date')
+    await nextTick()
+    expect(events['update:modelValue'].at(-1)![0]).toMatchObject({ formFieldId: 'f_date', targetFieldId: 't_text' })
+    expect(events['invalidate-confirmation'].length).toBeGreaterThanOrEqual(1)
+    const invalidationsAfterEdit = events['invalidate-confirmation'].length
+
+    change(targetSelect(rows()[1]), 't_text')
+    await nextTick()
+    expect(events['update:modelValue'].at(-1)![1]).toMatchObject({ formFieldId: 'f_date', targetFieldId: 't_text' })
+    expect(events['invalidate-confirmation'].length).toBe(invalidationsAfterEdit + 1)
+  })
+
+  it('does not expose a client-owned confirmation hash prop', () => {
+    const componentProps = (ApprovalFwbMappingEditor as unknown as {
+      props?: Record<string, unknown>
+    }).props ?? {}
+    expect(Object.keys(componentProps)).not.toContain('confirmationHash')
+  })
+
+  it('disabled and loading disable every control and block all interaction', async () => {
+    for (const gate of [{ disabled: true }, { loading: true }]) {
+      const events = await mountEditor({ modelValue: VALID_DRAFT, ...gate })
+      for (const select of container!.querySelectorAll('select')) {
+        expect((select as HTMLSelectElement).disabled).toBe(true)
+      }
+      for (const button of container!.querySelectorAll('button')) {
+        expect((button as HTMLButtonElement).disabled).toBe(true)
+      }
+      confirmButton().click()
+      ;(container!.querySelector('[data-testid="fwb-add-mapping"]') as HTMLButtonElement).click()
+      change(formSelect(rows()[0]), 'f_date')
+      change(targetSelect(rows()[0]), 't_date')
+      await nextTick()
+      expect(events['update:modelValue']).toHaveLength(0)
+      expect(events['request-confirmation']).toHaveLength(0)
+      expect(events['invalidate-confirmation']).toHaveLength(0)
+      app!.unmount()
+    }
+  })
+
+  it('confirming state blocks re-requesting confirmation; state label tracks the prop', async () => {
+    const events = await mountEditor({ modelValue: VALID_DRAFT, confirmationState: 'confirming' })
+    expect(container!.querySelector('[data-testid="fwb-confirmation-state"]')?.textContent).toContain('确认中')
+    expect(confirmButton().disabled).toBe(true)
+    confirmButton().click()
+    await nextTick()
+    expect(events['request-confirmation']).toHaveLength(0)
+  })
+
+  it('confirmed state blocks a duplicate confirmation request until a mapping mutation invalidates it', async () => {
+    const events = await mountEditor({ modelValue: VALID_DRAFT, confirmationState: 'confirmed' })
+    expect(confirmButton().disabled).toBe(true)
+    confirmButton().click()
+    await nextTick()
+    expect(events['request-confirmation']).toHaveLength(0)
+  })
+
+  it('en locale renders the generic unavailable marker and reasons in English', async () => {
+    await mountEditor({ modelValue: [{ formFieldId: 'ghost_f', targetFieldId: 't_num' }], isZh: false })
+    const row = rows()[0]
+    expect(formSelect(row).querySelector('option[value="ghost_f"]')?.textContent?.trim()).toBe('Unavailable field')
+    expect(row.querySelector('[data-testid="fwb-row-issues"]')?.textContent).toContain('Exact number mapping is not available yet')
+    expect(container!.querySelector('[data-testid="fwb-confirmation-state"]')?.textContent).toContain('Unconfirmed')
+  })
+
+  it('longest bilingual labels remain inside the bounded row structure', async () => {
+    const LONG_ZH = '非常非常非常长的一个审批表单字段名称用于验证布局不会溢出'
+    const LONG_EN = 'An-extremely-long-approval-form-field-label-that-must-never-break-the-row-layout'
+    await mountEditor({
+      templateFields: [{ id: 'f_long', label: LONG_ZH }],
+      targetFields: [{ id: 't_long', label: LONG_EN, type: 'string' }],
+      modelValue: [{ formFieldId: 'f_long', targetFieldId: 't_long' }],
+    })
+    const row = rows()[0]
+    // row is a fixed 3-column grid; both selects live inside it with the remove button
+    expect(row.classList.contains('fwb-mapping-editor__row')).toBe(true)
+    expect(row.querySelectorAll('select')).toHaveLength(2)
+    expect(row.querySelector('[data-testid="fwb-remove-mapping"]')).not.toBeNull()
+    // long labels render as option text (truncation is CSS, content stays lossless)
+    expect(formSelect(row).querySelector('option[value="f_long"]')?.textContent).toBe(LONG_ZH)
+    expect(targetSelect(row).querySelector('option[value="t_long"]')?.textContent).toBe(LONG_EN)
+
+    expect(container!.querySelector('textarea')).toBeNull()
+    expect(container!.querySelector('input')).toBeNull()
+  })
+
+  it('add/remove controls carry aria-label + title (icon-only remove button stays accessible)', async () => {
+    await mountEditor({ modelValue: [{ formFieldId: 'f_title', targetFieldId: 't_text' }] })
+    const add = container!.querySelector('[data-testid="fwb-add-mapping"]') as HTMLButtonElement
+    const remove = container!.querySelector('[data-testid="fwb-remove-mapping"]') as HTMLButtonElement
+    expect(add.getAttribute('aria-label')).toBe('添加映射')
+    expect(add.getAttribute('title')).toBe('添加映射')
+    expect(remove.getAttribute('aria-label')).toBe('移除映射')
+    expect(remove.getAttribute('title')).toBe('移除映射')
+  })
+})


### PR DESCRIPTION
## What
- add a reusable controlled mapping editor for approval-form-to-multitable create-mode mappings
- preserve stale loaded mappings visibly while blocking confirmation
- keep exact-number and unsupported targets unavailable until their end-to-end contracts land
- keep confirmation hash/server state parent-owned; this component only requests or invalidates confirmation
- disable targets already held by another mapping row and fail closed in the executor-shape converter

## Boundary
This is the reusable editor shell only. Production mounting in `MetaAutomationRuleEditor.vue` and the server confirmation round trip remain a later stacked slice. No runtime flag is enabled.

## Verification
- `approval-fwb-mapping-editor.spec.ts`: 17/17
- `approval-fwb-mapping-config.test.ts`: 3/3
- `vue-tsc --noEmit -p tsconfig.json`
- discriminating mutations: removing confirmed-state replay protection and option-less-select rejection makes their named tests fail; restored head is green
- independent adversarial review findings (confirmation replay, option-less select, cross-row duplicate options, disabled/loading mutations) are fixed
