### PR TITLE
fix(core-backend): W4-PRE-1b — user_orgs full org-membership lifecycle (bind/unbind/rebind/backfill/explicit-org/dual-gate)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -828,6 +828,7 @@ jobs:
             tests/integration/attendance-w4pre1b-user-orgs-backfill-migration.db.test.ts \
             tests/integration/attendance-w4pre1b-directory-readiness-gate.db.test.ts \
             tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts \
+            tests/integration/attendance-w4pre1b-api-tokens-org-member-access.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -823,6 +823,11 @@ jobs:
             tests/integration/attendance-w4pre1-user-orgs-admission.db.test.ts \
             tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts \
             tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts \
+            tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts \
+            tests/integration/attendance-w4pre1b-user-orgs-sync-automatch.db.test.ts \
+            tests/integration/attendance-w4pre1b-user-orgs-backfill-migration.db.test.ts \
+            tests/integration/attendance-w4pre1b-directory-readiness-gate.db.test.ts \
+            tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260721150000_backfill_user_orgs_from_directory_links.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260721150000_backfill_user_orgs_from_directory_links.ts
@@ -16,7 +16,8 @@
  * (`readOrgDirectoryReadiness`, attendance-admin.ts) and every bind-shaped writer in this line use
  * to mean "this account currently counts as bound". Never a client-supplied or guessed org.
  *
- * Idempotency + non-resurrection (owner: "绝不复活已 is_active=false 的行"): `ON CONFLICT (user_id,
+ * Idempotency + non-resurrection (this migration must never resurrect an already-deactivated row
+ * — the owner's item-C text is "backfill 迁移（幂等、不复活已失活行）"): `ON CONFLICT (user_id,
  * org_id) DO NOTHING` — this migration ONLY inserts rows that do not exist yet. A row that already
  * exists, active OR already deactivated by the item-B unbind/rebind/archive logic, is left
  * completely untouched (no UPDATE branch at all, unlike the live bind writers' `DO UPDATE SET

--- a/packages/core-backend/src/db/migrations/zzzz20260721150000_backfill_user_orgs_from_directory_links.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260721150000_backfill_user_orgs_from_directory_links.ts
@@ -1,0 +1,71 @@
+/**
+ * W4-PRE-1b (owner CHANGES_REQUESTED on the W4 re-ratify PR #4522, 2026-07-21, item C):
+ * real-stock backfill for `user_orgs`.
+ *
+ * W4-PRE-1 (#4521) and W4-PRE-1b (this line) closed every PRODUCTION write path that maintains
+ * `user_orgs` going forward, but neither touched EXISTING data: a user who was admitted/bound to
+ * a directory account BEFORE those write paths existed has an `active directory_account_links`
+ * row (proof they belong to an org) yet may have no `user_orgs` row at all — exactly the "already
+ * linked users may have no membership" half of the owner's P1 finding. This migration is the
+ * one-time repair for that stock.
+ *
+ * Population: `directory_account_links.local_user_id` for every LINKED row whose
+ * `directory_accounts` is active, joined through `directory_accounts.integration_id ->
+ * directory_integrations.id` to resolve the KNOWN AUTHORITATIVE org — the exact same
+ * (link_status='linked' AND directory_accounts.is_active=true) predicate the S7-5 readiness read
+ * (`readOrgDirectoryReadiness`, attendance-admin.ts) and every bind-shaped writer in this line use
+ * to mean "this account currently counts as bound". Never a client-supplied or guessed org.
+ *
+ * Idempotency + non-resurrection (owner: "绝不复活已 is_active=false 的行"): `ON CONFLICT (user_id,
+ * org_id) DO NOTHING` — this migration ONLY inserts rows that do not exist yet. A row that already
+ * exists, active OR already deactivated by the item-B unbind/rebind/archive logic, is left
+ * completely untouched (no UPDATE branch at all, unlike the live bind writers' `DO UPDATE SET
+ * is_active = EXCLUDED.is_active`). Re-running this migration (or running it against a DB where a
+ * later sync/bind has already produced the row) is a no-op for every already-covered pair.
+ *
+ * Deliberately NOT filtered by `users.is_active` — same precedent as every live writer in this
+ * line (admin-users.ts's W4-PRE-1 write, directory-sync.ts's admission/bind writers): membership
+ * EXISTENCE is written as active regardless of the user's own active flag; the RD-3 dual-is_active
+ * read filter (`user_orgs.is_active=true AND users.is_active=true`) is what excludes a deactivated
+ * user from every count and gate, not a write-time filter here.
+ *
+ * Pure data migration — zero schema change, zero index change. `user_orgs` and its primary key
+ * were already established by `zzzz20260114110000_create_user_orgs_table.ts`; this file only
+ * needs `checkTableExists` guards for the SOURCE tables (`directory_account_links`,
+ * `directory_accounts`, `directory_integrations`, `user_orgs` itself) so a fresh DB or a DB where
+ * directory-sync tables have not landed yet skips cleanly instead of throwing.
+ */
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const requiredTables = ['user_orgs', 'directory_account_links', 'directory_accounts', 'directory_integrations']
+  for (const table of requiredTables) {
+    if (!(await checkTableExists(db, table))) return
+  }
+
+  await sql`
+    INSERT INTO user_orgs (user_id, org_id, is_active)
+    SELECT DISTINCT l.local_user_id, i.org_id, true
+    FROM directory_account_links l
+    JOIN directory_accounts a ON a.id = l.directory_account_id
+    JOIN directory_integrations i ON i.id = a.integration_id
+    WHERE l.link_status = 'linked'
+      AND l.local_user_id IS NOT NULL
+      AND a.is_active = true
+    ON CONFLICT (user_id, org_id) DO NOTHING
+  `.execute(db)
+}
+
+/**
+ * Deliberately a NO-OP down migration. This is a repair backfill, not a schema change — there is
+ * no way to tell a row this migration inserted apart from one a later live writer (bind, admit,
+ * auto-match) legitimately inserted for the exact same (user_id, org_id) pair after `up()` ran,
+ * so "undoing" it by DELETE would risk deleting real, currently-load-bearing membership rows
+ * created by ordinary product usage after this migration applied. `zzzz20260114110000`'s own
+ * one-time backfill sets the same precedent (no reverse data migration).
+ */
+export async function down(_db: Kysely<unknown>): Promise<void> {
+  // Intentionally empty — see doc comment above.
+}

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -3760,6 +3760,20 @@ export async function syncDirectoryIntegration(
           linkedUserIdByExternalUserId.set(account.external_user_id, localUserId)
         }
 
+        // W4-PRE-1b item A: an `external_identity` re-match confirms a PRE-EXISTING user against
+        // this account without going through `applyDirectoryAccountBindInTransaction` (that
+        // helper only runs for the manual-bind / admit call sites) — this is the "auto-match"
+        // writer the owner named explicitly. Gated on the ACTUAL outcome (`linkStatus ===
+        // 'linked' && localUserId`), not on `matchStrategy`, so it also covers `auto_admit`
+        // (already-active via `createDirectoryAdmittedUserInTransaction`'s own call into that
+        // helper — this second upsert is then an idempotent no-op, not a double-write) without
+        // hand-maintaining a strategy allowlist. `pending` email/mobile candidate matches are
+        // correctly excluded: they never held an ACTIVE membership through this account (item A
+        // activates membership only for `linked`), so no upsert is due until a human confirms.
+        if (linkStatus === 'linked' && localUserId) {
+          await upsertActiveUserOrgMembership(client, { userId: localUserId, orgId: integration.org_id })
+        }
+
         await client.query(
           `INSERT INTO directory_account_links (
              directory_account_id, local_user_id, link_status, match_strategy, created_at, updated_at
@@ -4826,6 +4840,109 @@ export async function batchAdmitDirectoryAccountUsers(
   return outcome
 }
 
+type MembershipWriteClient = {
+  query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }>
+}
+
+/**
+ * W4-PRE-1b (owner CHANGES_REQUESTED on the W4 re-ratify PR, 2026-07-21, item A): resolve the
+ * KNOWN AUTHORITATIVE org for a directory account from its OWN `directory_integrations` row —
+ * never a client-supplied value, never a silent 'default' guess. Fail-closed BEFORE any write if
+ * the integration row cannot be found (foreign-key-orphaned `integration_id`). Shared by every
+ * bind-shaped writer below so the resolution logic (and its fail-closed behavior) lives in
+ * exactly one place. Mirrors the inline resolution #4521 (W4-PRE-1) originally wrote only inside
+ * `createDirectoryAdmittedUserInTransaction`.
+ */
+async function resolveDirectoryAccountOrgId(client: MembershipWriteClient, integrationId: string): Promise<string> {
+  const orgResult = await client.query(
+    `SELECT org_id
+     FROM directory_integrations
+     WHERE id = $1::uuid
+     LIMIT 1`,
+    [integrationId],
+  )
+  const orgId = (orgResult.rows[0] as { org_id?: string } | undefined)?.org_id
+  if (!orgId) {
+    throw new Error('Directory integration not found for account org resolution')
+  }
+  return orgId
+}
+
+/**
+ * W4-PRE-1b item A: same-transaction upsert of an ACTIVE `user_orgs` membership for a user who
+ * is now (or still) bound to a directory account in `orgId`. `ON CONFLICT (user_id, org_id) DO
+ * UPDATE SET is_active = EXCLUDED.is_active` — the branch #4521's own review (P3) noted was DEAD
+ * for the brand-new-user admission path (a fresh user can never already hold a `user_orgs` row)
+ * is made LIVE here: an existing user who was previously deactivated in this org (§ below) and is
+ * now rebound reactivates through this exact conflict path. Shape matches #4521's writer
+ * (admin-users.ts, `INSERT INTO user_orgs ... ON CONFLICT (user_id, org_id) DO UPDATE SET
+ * is_active = EXCLUDED.is_active`).
+ */
+export async function upsertActiveUserOrgMembership(
+  client: MembershipWriteClient,
+  options: { userId: string; orgId: string },
+): Promise<void> {
+  await client.query(
+    `INSERT INTO user_orgs (user_id, org_id, is_active)
+     VALUES ($1::text, $2::text, TRUE)
+     ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = EXCLUDED.is_active`,
+    [options.userId, options.orgId],
+  )
+}
+
+/**
+ * W4-PRE-1b item B: safe deactivation. Flips `user_orgs.is_active` to FALSE for
+ * (userId, orgId) ONLY WHEN the user holds no OTHER active, linked directory account anywhere in
+ * THIS org — a single atomic UPDATE with a correlated NOT EXISTS, so there is no separate read-
+ * then-write race window within the transaction. Deliberately ORG-SCOPED (unlike the pre-existing
+ * `applyDirectoryDeprovisionPolicies` sibling guard, which is intentionally GLOBAL for rehire
+ * protection, ~L1396-1400): a user can be active in org A and inactive in org B independently, so
+ * the sibling search spans BOTH `local` and `dingtalk` directory accounts of THIS org only (via
+ * the `directory_integrations.org_id` join) — never accounts in a different org. Call this AFTER
+ * the triggering link mutation has already been written in the same transaction, so a just-
+ * severed/reassigned row correctly self-excludes from the NOT EXISTS.
+ *
+ * Boundary (owner ruling, §ledger "边界语义"): only a BINDING event (unbind / directory-side link
+ * removal / same-account rebind that displaces a prior holder) may call this. A user's `users.
+ * is_active` PATCH (deactivation) never touches `user_orgs` — the RD-3 dual-is_active read filter
+ * (`user_orgs.is_active=true AND users.is_active=true`) already excludes a deactivated user from
+ * every count and gate without a membership-row write.
+ */
+export async function deactivateUserOrgMembershipIfNoOtherActiveBinding(
+  client: MembershipWriteClient,
+  options: { userId: string; orgId: string },
+): Promise<void> {
+  await client.query(
+    `UPDATE user_orgs
+     SET is_active = FALSE
+     WHERE user_id = $1::text
+       AND org_id = $2::text
+       AND is_active = TRUE
+       AND NOT EXISTS (
+         SELECT 1
+         FROM directory_account_links l
+         JOIN directory_accounts a ON a.id = l.directory_account_id
+         JOIN directory_integrations i ON i.id = a.integration_id
+         WHERE l.local_user_id = $1::text
+           AND l.link_status = 'linked'
+           AND a.is_active = TRUE
+           AND i.org_id = $2::text
+       )`,
+    [options.userId, options.orgId],
+  )
+}
+
+/**
+ * `resolveDirectoryAccountOrgId` additionally exposed here (alongside the two functions that are
+ * ALSO directly exported above for ordinary runtime consumers like `local-directory-org.ts`) so
+ * tests can drive the org-resolution seam directly without a full bind/unbind call.
+ */
+export const __userOrgsMembershipInternalsForTests = {
+  resolveDirectoryAccountOrgId,
+  upsertActiveUserOrgMembership,
+  deactivateUserOrgMembershipIfNoOtherActiveBinding,
+}
+
 async function applyDirectoryAccountBindInTransaction(
   client: { query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }> },
   options: {
@@ -4842,6 +4959,31 @@ async function applyDirectoryAccountBindInTransaction(
     throw new Error('Directory account is missing DingTalk openId/unionId and cannot be pre-bound for DingTalk login')
   }
   assertDirectoryAccountCanEnableDingTalkGrant(account, enableDingTalkGrant)
+
+  // W4-PRE-1b item A: resolve the account's KNOWN AUTHORITATIVE org up front (fail-closed,
+  // shared helper — see `resolveDirectoryAccountOrgId` above) so every caller of this function
+  // (manual bind, admit-over-existing-account, batch variants) maintains `user_orgs` the same
+  // way #4521 already does for brand-new admissions.
+  const orgId = await resolveDirectoryAccountOrgId(client, account.integration_id)
+
+  // W4-PRE-1b item B (same-account rebind displacement): capture whoever THIS account is
+  // CURRENTLY linked to, BEFORE the link upsert below overwrites it. `ON CONFLICT
+  // (directory_account_id) DO UPDATE local_user_id = EXCLUDED.local_user_id` a few statements
+  // down silently reassigns the account from its prior holder to `localUser` in one step — the
+  // prior holder must be re-evaluated for org-membership deactivation, exactly as an explicit
+  // unbind-then-bind would. Scoped to `link_status = 'linked'` on purpose: a 'pending' email/
+  // mobile match candidate (directory-sync.ts's own sync loop can set `local_user_id` on a
+  // 'pending' row) never held an ACTIVE membership via this account in the first place (item A
+  // only activates membership for 'linked'), so it must not trigger a deactivation.
+  const priorLinkResult = await client.query(
+    `SELECT local_user_id
+     FROM directory_account_links
+     WHERE directory_account_id = $1::uuid
+       AND link_status = 'linked'
+     LIMIT 1`,
+    [normalizedAccountId],
+  )
+  const priorLocalUserId = (priorLinkResult.rows[0] as { local_user_id?: string | null } | undefined)?.local_user_id ?? null
 
   const profile = JSON.stringify({
     source: 'directory_admin_bind',
@@ -4971,6 +5113,17 @@ async function applyDirectoryAccountBindInTransaction(
        updated_at = NOW()`,
     [normalizedAccountId, localUser.id, normalizedAdminUserId],
   )
+
+  // W4-PRE-1b item A: the account is now linked to `localUser` — maintain their ACTIVE
+  // membership in the SAME transaction. Runs for every caller (manual bind, admit, batch).
+  await upsertActiveUserOrgMembership(client, { userId: localUser.id, orgId })
+
+  // W4-PRE-1b item B: if this account previously belonged to a DIFFERENT local user, the link
+  // upsert above just displaced them — deactivate their membership in THIS org unless they hold
+  // another active linked account here (org-scoped sibling check, see the helper doc-comment).
+  if (priorLocalUserId && priorLocalUserId !== localUser.id) {
+    await deactivateUserOrgMembershipIfNoOtherActiveBinding(client, { userId: priorLocalUserId, orgId })
+  }
 }
 
 async function createDirectoryAdmittedUserInTransaction(
@@ -5056,48 +5209,23 @@ async function createDirectoryAdmittedUserInTransaction(
     }
   }
 
-  // W4-PRE-1 item 1 + item 2 (§3.3 of the Wave-4 onboarding design lock): resolve the
-  // KNOWN AUTHORITATIVE org for this admission from directory_integrations (the account's own
-  // integration row), never from a client-supplied value and never a silent 'default' guess.
-  // Fail-closed BEFORE any write (cheapest-check-first, same discipline as the
-  // DT-HARDEN-02 grant-feasibility assert above) if the integration row cannot be found — this
-  // should not happen in practice (the caller always resolves the account through a live
-  // integration_id) but a foreign-key-orphaned integration_id must not silently admit into no
-  // org, or into a guessed one.
-  const orgResult = await client.query(
-    `SELECT org_id
-     FROM directory_integrations
-     WHERE id = $1::uuid
-     LIMIT 1`,
-    [options.account.integration_id],
-  )
-  const admissionOrgId = (orgResult.rows[0] as { org_id?: string } | undefined)?.org_id
-  if (!admissionOrgId) {
-    throw new Error('Directory integration not found for admitted account org resolution')
-  }
-
   // DT-HARDEN-02: INSERT + bind are one all-or-nothing unit. A bind throw after the INSERT
   // (missing openId/unionId, or an identity already bound to another local user) would
   // otherwise leave a committed orphan once the sync loop swallows the error — the exact
   // hazard this ticket exists to close, and the one the pre-INSERT assert above does not cover.
-  // W4-PRE-1 extends the same all-or-nothing unit to user_orgs: a user_orgs write failure must
+  // W4-PRE-1 extended the same all-or-nothing unit to user_orgs: a user_orgs write failure must
   // also roll the users row back (fresh-DB atomicity leg, §3.3 item 3), not just a bind failure.
+  // W4-PRE-1b: the org resolution + user_orgs write that #4521 inlined HERE now lives inside
+  // `applyDirectoryAccountBindInTransaction` (single site, shared by every bind-shaped writer —
+  // see that function's own comments) — still inside this SAME savepoint, so the atomicity
+  // guarantee is unchanged; only the resolution failure message text moved with it
+  // ('Directory integration not found for account org resolution').
   await client.query('SAVEPOINT directory_admit_user')
   try {
     await client.query(
       `INSERT INTO users (id, email, username, name, mobile, password_hash, must_change_password, role, permissions, is_active, is_admin, created_at, updated_at)
        VALUES ($1::text, $2::text, $3::text, $4::text, $5::text, $6::text, $7::boolean, 'user', $8::jsonb, TRUE, FALSE, NOW(), NOW())`,
       [userId, options.email, options.username, options.name, options.mobile, options.passwordHash, options.mustChangePassword, JSON.stringify([])],
-    )
-
-    // W4-PRE-1 item 1 (§3.3): maintain user_orgs in the SAME transaction/savepoint as the users
-    // row. A freshly admitted directory user is always active (matches the hardcoded TRUE on the
-    // users INSERT above).
-    await client.query(
-      `INSERT INTO user_orgs (user_id, org_id, is_active)
-       VALUES ($1::text, $2::text, TRUE)
-       ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = EXCLUDED.is_active`,
-      [userId, admissionOrgId],
     )
 
     await applyDirectoryAccountBindInTransaction(client, {
@@ -5869,6 +5997,17 @@ export async function unbindDirectoryAccount(
          updated_at = NOW()`,
       [normalizedAccountId, normalizedAdminUserId],
     )
+
+    // W4-PRE-1b item B: the account was just severed from `previousLinkedUser` — deactivate
+    // their membership in THIS org (org-scoped sibling check) unless they hold another active
+    // linked directory account here. Runs in the SAME transaction as the link severance above.
+    if (previousLinkedUser?.local_user_id) {
+      const orgId = await resolveDirectoryAccountOrgId(client, account.integration_id)
+      await deactivateUserOrgMembershipIfNoOtherActiveBinding(client, {
+        userId: previousLinkedUser.local_user_id,
+        orgId,
+      })
+    }
   })
 
   const summary = await getDirectoryAccountSummary(normalizedAccountId)

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -160,6 +160,7 @@ type DirectoryAccountRow = {
   name: string
   email: string | null
   mobile: string | null
+  is_active: boolean
 }
 
 type DirectoryAccountLinkRow = {
@@ -3510,6 +3511,15 @@ export async function syncDirectoryIntegration(
       // whole backlog. Without it the deprovision executor re-processed every account ever
       // deactivated on every sync — audit spam, and it would stomp a reactivation.
       // RETURNING gives the executor exactly the accounts that departed in THIS run.
+      //
+      // KNOWN OPEN GAP (#4526 review, not fixed this round — needs an owner ruling): this sweep
+      // flips ONLY `directory_accounts.is_active`; it does not call
+      // `deactivateUserOrgMembershipIfNoOtherActiveBinding`, so a departed employee's `user_orgs`
+      // row stays ACTIVE until an admin manually unbinds them (the deprovision executor below is
+      // OFF by default and, even enabled, only ever touches `users.is_active`, never
+      // `user_orgs`). Whether "the directory silently stopped reporting this account" counts as a
+      // BINDING event under this line's own boundary (only unbind/rebind/archive deactivate) is
+      // an open adjudication point — see the PR body's lifecycle table and open items.
       const deactivatedAccountsResult = await client.query(
         `UPDATE directory_accounts
          SET is_active = false, updated_at = NOW()
@@ -3527,7 +3537,7 @@ export async function syncDirectoryIntegration(
           [integrationId],
         ),
         client.query(
-          `SELECT id, corp_id, external_user_id, union_id, open_id, external_key, name, email, mobile
+          `SELECT id, corp_id, external_user_id, union_id, open_id, external_key, name, email, mobile, is_active
            FROM directory_accounts
            WHERE integration_id = $1`,
           [integrationId],
@@ -3763,14 +3773,26 @@ export async function syncDirectoryIntegration(
         // W4-PRE-1b item A: an `external_identity` re-match confirms a PRE-EXISTING user against
         // this account without going through `applyDirectoryAccountBindInTransaction` (that
         // helper only runs for the manual-bind / admit call sites) — this is the "auto-match"
-        // writer the owner named explicitly. Gated on the ACTUAL outcome (`linkStatus ===
-        // 'linked' && localUserId`), not on `matchStrategy`, so it also covers `auto_admit`
-        // (already-active via `createDirectoryAdmittedUserInTransaction`'s own call into that
-        // helper — this second upsert is then an idempotent no-op, not a double-write) without
-        // hand-maintaining a strategy allowlist. `pending` email/mobile candidate matches are
-        // correctly excluded: they never held an ACTIVE membership through this account (item A
-        // activates membership only for `linked`), so no upsert is due until a human confirms.
-        if (linkStatus === 'linked' && localUserId) {
+        // writer named in the owner's #4522 review comment. Gated on the ACTUAL outcome
+        // (`linkStatus === 'linked' && localUserId`), not on `matchStrategy`, so it also covers
+        // `auto_admit` (already-active via `createDirectoryAdmittedUserInTransaction`'s own call
+        // into that helper — this second upsert is then an idempotent no-op, not a double-write)
+        // without hand-maintaining a strategy allowlist. `pending` email/mobile candidate matches
+        // are correctly excluded: they never held an ACTIVE membership through this account (item
+        // A activates membership only for `linked`), so no upsert is due until a human confirms.
+        //
+        // Post-#4526-review fix: additionally gated on `account.is_active` (the account's state
+        // AS OF THIS SYNC — the DT-OPS-01 sweep above already ran, so this reflects the sweep's
+        // result within the same transaction, not a stale pre-sweep value). Without this, an
+        // account that DEPARTED the directory long ago but is still walked every sync (this loop
+        // iterates ALL accounts for the integration, not just this run's batch) short-circuits to
+        // `already_linked` (`resolveDirectoryIdentityMatch` returns early on an existing `linked`
+        // row without inspecting `directory_accounts.is_active`) and would otherwise silently
+        // resurrect a deliberately-unbound `user_orgs` row to ACTIVE on every subsequent resync —
+        // reopening the exact stale-access half of the owner's original P1 finding via this line's
+        // OWN new write point (review finding, #4526). A currently-inactive account never confirms
+        // membership through this writer; only a live account does.
+        if (linkStatus === 'linked' && localUserId && account.is_active) {
           await upsertActiveUserOrgMembership(client, { userId: localUserId, orgId: integration.org_id })
         }
 
@@ -4134,6 +4156,10 @@ export async function previewDirectorySyncIntegration(integrationId: string): Pr
     name: user.name,
     email: normalizeOptionalText(user.email),
     mobile: normalizeOptionalText(user.mobile),
+    // Synthetic "as if pulled from the directory right now" row for match-map building only —
+    // `loadMatchMaps` never reads `is_active` (only external_key/union_id/open_id/email/mobile),
+    // so this is a type-shape fill, not a semantic claim about persisted account state.
+    is_active: true,
   }))
   const identityMatchMaps = await loadMatchMaps(pulledAccountsForMatching)
 
@@ -4893,25 +4919,47 @@ export async function upsertActiveUserOrgMembership(
 /**
  * W4-PRE-1b item B: safe deactivation. Flips `user_orgs.is_active` to FALSE for
  * (userId, orgId) ONLY WHEN the user holds no OTHER active, linked directory account anywhere in
- * THIS org — a single atomic UPDATE with a correlated NOT EXISTS, so there is no separate read-
- * then-write race window within the transaction. Deliberately ORG-SCOPED (unlike the pre-existing
- * `applyDirectoryDeprovisionPolicies` sibling guard, which is intentionally GLOBAL for rehire
- * protection, ~L1396-1400): a user can be active in org A and inactive in org B independently, so
- * the sibling search spans BOTH `local` and `dingtalk` directory accounts of THIS org only (via
- * the `directory_integrations.org_id` join) — never accounts in a different org. Call this AFTER
- * the triggering link mutation has already been written in the same transaction, so a just-
- * severed/reassigned row correctly self-excludes from the NOT EXISTS.
+ * THIS org. Deliberately ORG-SCOPED (unlike the pre-existing `applyDirectoryDeprovisionPolicies`
+ * sibling guard, which is intentionally GLOBAL for rehire protection, ~L1396-1400): a user can be
+ * active in org A and inactive in org B independently, so the sibling search spans BOTH `local`
+ * and `dingtalk` directory accounts of THIS org only (via the `directory_integrations.org_id`
+ * join) — never accounts in a different org. Call this AFTER the triggering link mutation has
+ * already been written in the same transaction, so a just-severed/reassigned row correctly
+ * self-excludes from the NOT EXISTS.
  *
- * Boundary (owner ruling, §ledger "边界语义"): only a BINDING event (unbind / directory-side link
- * removal / same-account rebind that displaces a prior holder) may call this. A user's `users.
- * is_active` PATCH (deactivation) never touches `user_orgs` — the RD-3 dual-is_active read filter
- * (`user_orgs.is_active=true AND users.is_active=true`) already excludes a deactivated user from
- * every count and gate without a membership-row write.
+ * Boundary (this PR's own reading, presented to the owner as evidence — NOT an adjudicated owner
+ * ruling; see the PR body's "Deactivation boundary semantics" section): only a BINDING event
+ * (unbind / directory-side link removal / same-account rebind that displaces a prior holder) is
+ * treated as calling this. A user's `users.is_active` PATCH (deactivation) never touches
+ * `user_orgs` — the RD-3 dual-is_active read filter (`user_orgs.is_active=true AND
+ * users.is_active=true`) already excludes a deactivated user from every count and gate without a
+ * membership-row write.
+ *
+ * Concurrency (#4526 review fix — cross-transaction write skew): a plain
+ * `UPDATE ... WHERE ... AND NOT EXISTS (...)` is atomic only for ITS OWN target row; the NOT
+ * EXISTS subquery reads OTHER rows (sibling `directory_account_links`/`directory_accounts`)
+ * through this transaction's own READ COMMITTED snapshot, which cannot see a concurrent sibling-
+ * severing transaction's still-uncommitted write. Two concurrent unbinds of a double-bound user's
+ * two DIFFERENT accounts can each legitimately see the OTHER's account as still linked+active
+ * (neither has committed yet), so BOTH skip deactivation — write skew converging to an ACTIVE
+ * `user_orgs` row with ZERO live bindings. The `SELECT ... FOR UPDATE` below serializes the two
+ * calls on the shared (userId, orgId) row: whichever call reaches it second BLOCKS until the
+ * first commits, then re-reads with a FRESH read-committed snapshot that includes the first call's
+ * already-committed severance — so the second call's NOT EXISTS correctly observes both siblings
+ * gone and performs the deactivation. (The first call legitimately still sees the second's sibling
+ * as not-yet-severed and no-ops — that is correct, not a bug: "no other active binding" only
+ * becomes true once BOTH severances are durable, and the lock guarantees exactly one of the two
+ * racing calls observes that fully-converged state.) If no `user_orgs` row exists yet, the lock
+ * finds nothing and the UPDATE below is a no-op either way.
  */
 export async function deactivateUserOrgMembershipIfNoOtherActiveBinding(
   client: MembershipWriteClient,
   options: { userId: string; orgId: string },
 ): Promise<void> {
+  await client.query(
+    `SELECT 1 FROM user_orgs WHERE user_id = $1::text AND org_id = $2::text FOR UPDATE`,
+    [options.userId, options.orgId],
+  )
   await client.query(
     `UPDATE user_orgs
      SET is_active = FALSE
@@ -5929,15 +5977,39 @@ export async function unbindDirectoryAccount(
   if (!normalizedAccountId) throw new Error('directoryAccountId is required')
   if (!normalizedAdminUserId) throw new Error('adminUserId is required')
 
-  const [account, previousLinkedUser] = await Promise.all([
-    loadDirectoryBindingTargetAccount(normalizedAccountId),
-    loadDirectoryLinkedUser(normalizedAccountId),
-  ])
+  const account = await loadDirectoryBindingTargetAccount(normalizedAccountId)
   if (!account) throw new Error('Directory account not found')
 
   const identityExternalKey = buildDingTalkIdentityExternalKey(account.corp_id, account.open_id, account.union_id)
 
+  // #4526 review fix: `previousLinkedUser` used to be read via `loadDirectoryLinkedUser` OUTSIDE
+  // this transaction (alongside `account`, in the `Promise.all` this replaced). That pre-read was
+  // load-bearing but stale: if this account's link changed between the pre-read and the
+  // transaction body below (e.g. a rapid unbind+rebind of the SAME account), the link UPSERT
+  // below unconditionally severs whoever is linked NOW while the deactivation call only
+  // considered the STALE holder — the CURRENT holder could be left with an active membership and
+  // zero bindings. Reading it here, inside the transaction, with `FOR UPDATE OF l` locking the
+  // `directory_account_links` row for this account closes that window: any concurrent writer of
+  // THIS SAME row (bind/admit/another unbind) now serializes behind this transaction instead of
+  // racing it. `FOR UPDATE OF l` (not a bare `FOR UPDATE`) is required because of the `LEFT JOIN
+  // users u` — Postgres refuses to lock the nullable side of an outer join.
+  let previousLinkedUser: DirectoryAccountLinkedUserRow | null = null
+
   await transaction(async (client) => {
+    const linkedUserLockResult = await client.query(
+      `SELECT l.local_user_id,
+              u.email AS local_user_email,
+              u.username AS local_user_username,
+              u.name AS local_user_name
+       FROM directory_account_links l
+       LEFT JOIN users u ON u.id = l.local_user_id
+       WHERE l.directory_account_id = $1
+       FOR UPDATE OF l
+       LIMIT 1`,
+      [normalizedAccountId],
+    )
+    previousLinkedUser = (linkedUserLockResult.rows[0] as DirectoryAccountLinkedUserRow | undefined) ?? null
+
     if (previousLinkedUser?.local_user_id) {
       const deleteIdentityParams: unknown[] = [
         account.provider,

--- a/packages/core-backend/src/directory/local-directory-org.ts
+++ b/packages/core-backend/src/directory/local-directory-org.ts
@@ -597,7 +597,9 @@ export async function updateLocalAccount(
  * intact — the row still says `link_status='linked'`, only `directory_accounts.is_active` flips.
  *
  * W4-PRE-1b item B: unlike `applyDirectoryDeprovisionPolicies` (which flips `users.is_active` —
- * a genuine user-level deactivation the owner ruling says must NOT touch `user_orgs`), archiving
+ * a genuine user-level deactivation this line's own boundary reading treats as one that must NOT
+ * touch `user_orgs`; see directory-sync.ts's `deactivateUserOrgMembershipIfNoOtherActiveBinding`
+ * doc comment — presented to the owner as evidence, not an adjudicated ruling), archiving
  * a local account is a "directory-side binding removal": the underlying link is kept for history
  * but no longer counts as ACTIVE for org-membership purposes (the same-org sibling check below,
  * and every other reader that filters `directory_accounts.is_active=true`, already treats it that

--- a/packages/core-backend/src/directory/local-directory-org.ts
+++ b/packages/core-backend/src/directory/local-directory-org.ts
@@ -27,7 +27,14 @@
 
 import * as crypto from 'crypto'
 import { query, transaction } from '../db/pg'
-import { getOrCreateLocalIntegration } from './directory-sync'
+import {
+  getOrCreateLocalIntegration,
+  // W4-PRE-1b: shared membership-write internals, imported (not reimplemented — see this
+  // file's own header comment) from directory-sync.ts — same convention
+  // `getOrCreateLocalIntegration` above already follows.
+  upsertActiveUserOrgMembership,
+  deactivateUserOrgMembershipIfNoOtherActiveBinding,
+} from './directory-sync'
 
 function normalizeText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
@@ -507,6 +514,13 @@ export async function createLocalAccount(input: CreateLocalAccountInput): Promis
            updated_at = NOW()`,
         [accountId, localUserId],
       )
+
+      // W4-PRE-1b item A: this connects an EXISTING platform user (`localUserId`, validated
+      // above) to `input.orgId` via a local directory account — maintain their ACTIVE
+      // membership in the SAME transaction. Imported from directory-sync.ts rather than
+      // reimplemented (this file's own header: "directory-sync.ts is edited nowhere by this
+      // file" — same convention `getOrCreateLocalIntegration` already follows).
+      await upsertActiveUserOrgMembership(client, { userId: localUserId, orgId: input.orgId })
     })
   } catch (error) {
     if (isUniqueViolation(error)) {
@@ -578,13 +592,32 @@ export async function updateLocalAccount(
   })
 }
 
-/** Archive-not-delete, same semantics as `archiveLocalDepartment`. Keeps `directory_account_links` intact. */
+/**
+ * Archive-not-delete, same semantics as `archiveLocalDepartment`. Keeps `directory_account_links`
+ * intact — the row still says `link_status='linked'`, only `directory_accounts.is_active` flips.
+ *
+ * W4-PRE-1b item B: unlike `applyDirectoryDeprovisionPolicies` (which flips `users.is_active` —
+ * a genuine user-level deactivation the owner ruling says must NOT touch `user_orgs`), archiving
+ * a local account is a "directory-side binding removal": the underlying link is kept for history
+ * but no longer counts as ACTIVE for org-membership purposes (the same-org sibling check below,
+ * and every other reader that filters `directory_accounts.is_active=true`, already treats it that
+ * way). Left unhandled, an archived account leaves its linked user's `user_orgs` row `is_active=
+ * true` forever — the "left the org but retains membership" half of the owner P1 finding. Runs in
+ * the SAME transaction as the archive UPDATE, and only when the account was actually linked to a
+ * user (`current.local_user_id`) — an account nobody was ever linked to has no membership to
+ * reconsider.
+ */
 export async function archiveLocalAccount(orgId: string, accountId: string): Promise<LocalAccountSummary | null> {
   const current = await loadLocalAccountForOrg(orgId, accountId)
   if (!current) return null
 
   if (current.is_active) {
-    await query(`UPDATE directory_accounts SET is_active = false, updated_at = NOW() WHERE id = $1`, [accountId])
+    await transaction(async (client) => {
+      await client.query(`UPDATE directory_accounts SET is_active = false, updated_at = NOW() WHERE id = $1`, [accountId])
+      if (current.local_user_id) {
+        await deactivateUserOrgMembershipIfNoOtherActiveBinding(client, { userId: current.local_user_id, orgId })
+      }
+    })
   }
 
   const updated = await loadLocalAccountForOrg(orgId, accountId)

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -4069,6 +4069,14 @@ export class AutomationExecutor {
       return { actionType: 'send_dingtalk_group_message', status: 'failed', error: 'DingTalk body template is required' }
     }
 
+    // W4-PRE-1b item E follow-up (#4526 review): same-shape `user_orgs` trust point as
+    // `api-tokens.ts`'s `requireOrgMemberAccess` and `attendance-admin.ts`'s
+    // `canReadAttendanceDirectoryReadiness` — this EXISTS clause authorizes org-scoped DingTalk
+    // destination USE (an actual outbound-send authorization, not a read-visibility filter) by
+    // the automation rule's creator. A deactivated platform account (`users.is_active=false`)
+    // must not keep this access via a `user_orgs` row that is still `is_active=true`, exactly per
+    // the item-E fix already applied to the other two sites — this one was missed by the
+    // original PR's grep inventory.
     const destinationResult = await this.deps.queryFn(
       `SELECT id, name, webhook_url, secret, enabled
          FROM dingtalk_group_destinations dg
@@ -4082,9 +4090,11 @@ export class AutomationExecutor {
               AND EXISTS (
                 SELECT 1
                 FROM user_orgs uo
+                JOIN users u ON u.id = uo.user_id
                 WHERE uo.user_id = $3
                   AND uo.org_id = dg.org_id
                   AND uo.is_active = true
+                  AND u.is_active = true
               )
             )
           )`,

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -3207,12 +3207,15 @@ export function adminUsersRouter(): Router {
 
       let attendanceOrgId = derivedAttendanceOrgId
       if (cleanExplicitAttendanceOrgId) {
-        // "校验 org 存在" (owner text): validated against `directory_integrations` — the org
-        // anchor every org acquires today (a `provider='local'` row via
+        // The owner's item-D text is "支持显式 attendanceOrgId（不依赖考勤组/班次）⇒ canonical
+        // surface 变为真无条件" — it does not itself say how an unrecognized org id should be
+        // handled, which is this PR's own open adjudication point (see the PR body's
+        // explicit-org-path deviation note). Validated here against `directory_integrations` —
+        // the org anchor every org acquires today (a `provider='local'` row via
         // `getOrCreateLocalIntegration`, or a `provider='dingtalk'` integration). Deliberately
-        // does NOT auto-create an anchor for an unrecognized org id — see the PR body's
-        // explicit-org-path deviation note for the alternate (auto-vivify) reading and why this
-        // one shipped (fail-closed default; "静默 fallback = 契约 bug").
+        // does NOT auto-create an anchor for an unrecognized org id — that is the alternate
+        // (auto-vivify) reading the PR body flags as NOT shipped; this one ships fail-closed
+        // ("静默 fallback = 契约 bug").
         const orgAnchor = await query<{ found: number }>(
           'SELECT 1 AS found FROM directory_integrations WHERE org_id = $1 LIMIT 1',
           [cleanExplicitAttendanceOrgId],

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -268,6 +268,13 @@ type CreateUserRequestBody = {
   position?: string
   hireDate?: string
   orgId?: string
+  /**
+   * W4-PRE-1b item D: independent explicit org-admission param. Unlike `orgId` above (consumed
+   * only by `resolveAttendanceOnboardingOrgId`'s group/shift-derivation fallback chain), this
+   * one alone is sufficient to onboard `user_orgs` membership with NO attendanceGroupId/
+   * defaultShiftId required — see the resolution block below.
+   */
+  attendanceOrgId?: string
   attendanceGroupId?: string
   defaultShiftId?: string
   defaultShiftStartDate?: string
@@ -463,6 +470,21 @@ function sanitizeOptionalUuid(value: unknown): string | null | undefined {
   const normalized = value.trim()
   if (!normalized) return null
   return UUID_PATTERN.test(normalized) ? normalized : undefined
+}
+
+/**
+ * W4-PRE-1b item D. `org_id` is a free-form TEXT identifier across this codebase (no formal
+ * `organizations` table, no UUID shape requirement — `'default'` itself is not a UUID), so this
+ * mirrors `sanitizeOptionalUuid`'s ABSENT/INVALID split without the UUID regex: absent (undefined/
+ * null/blank-after-trim) → `null`, wrong TYPE → `undefined` (400). Length-capped as basic input
+ * hygiene only, matching the other free-text sanitizers in this file.
+ */
+function sanitizeOptionalOrgId(value: unknown): string | null | undefined {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim()
+  if (!normalized) return null
+  return normalized.slice(0, 200)
 }
 
 function resolveAttendanceOnboardingOrgId(req: Request): string {
@@ -3084,6 +3106,7 @@ export function adminUsersRouter(): Router {
       const cleanHireDate = typeof body.hireDate === 'string' ? sanitizeHireDate(body.hireDate) : null
       const cleanAttendanceGroupId = sanitizeOptionalUuid(body.attendanceGroupId)
       const cleanDefaultShiftId = sanitizeOptionalUuid(body.defaultShiftId)
+      const cleanExplicitAttendanceOrgId = sanitizeOptionalOrgId(body.attendanceOrgId)
       const cleanDefaultShiftStartDate = typeof body.defaultShiftStartDate === 'string' ? sanitizeHireDate(body.defaultShiftStartDate) : null
       const cleanName = typeof body.name === 'string' ? sanitizeName(body.name) : ''
       const preset = getAccessPreset(typeof body.presetId === 'string' ? body.presetId.trim() : '')
@@ -3124,6 +3147,9 @@ export function adminUsersRouter(): Router {
       }
       if (cleanDefaultShiftId === undefined) {
         return jsonError(res, 400, 'INVALID_DEFAULT_SHIFT_ID', 'defaultShiftId must be a UUID or blank')
+      }
+      if (cleanExplicitAttendanceOrgId === undefined) {
+        return jsonError(res, 400, 'INVALID_ATTENDANCE_ORG_ID', 'attendanceOrgId must be a string or blank')
       }
       if (cleanDefaultShiftStartDate === undefined) {
         return jsonError(res, 400, 'INVALID_DEFAULT_SHIFT_START_DATE', 'defaultShiftStartDate must be YYYY-MM-DD or blank')
@@ -3169,9 +3195,42 @@ export function adminUsersRouter(): Router {
         }
       }
 
-      const attendanceOrgId = cleanAttendanceGroupId || cleanDefaultShiftId
+      // W4-PRE-1b item D: the group/shift-derived resolution below is UNCHANGED — every
+      // existing caller that never sends `attendanceOrgId` gets byte-identical behavior. The
+      // new explicit param is evaluated independently and merged in afterward, so it can also
+      // stand alone (no group/shift required) — closing the circular dependency the owner named
+      // (the ONLY prior way to write `user_orgs` from this route required a group/shift ID,
+      // which itself needs a pre-existing org to belong to).
+      const derivedAttendanceOrgId = cleanAttendanceGroupId || cleanDefaultShiftId
         ? resolveAttendanceOnboardingOrgId(req)
         : null
+
+      let attendanceOrgId = derivedAttendanceOrgId
+      if (cleanExplicitAttendanceOrgId) {
+        // "校验 org 存在" (owner text): validated against `directory_integrations` — the org
+        // anchor every org acquires today (a `provider='local'` row via
+        // `getOrCreateLocalIntegration`, or a `provider='dingtalk'` integration). Deliberately
+        // does NOT auto-create an anchor for an unrecognized org id — see the PR body's
+        // explicit-org-path deviation note for the alternate (auto-vivify) reading and why this
+        // one shipped (fail-closed default; "静默 fallback = 契约 bug").
+        const orgAnchor = await query<{ found: number }>(
+          'SELECT 1 AS found FROM directory_integrations WHERE org_id = $1 LIMIT 1',
+          [cleanExplicitAttendanceOrgId],
+        )
+        if (orgAnchor.rows.length === 0) {
+          return jsonError(res, 404, 'ATTENDANCE_ORG_NOT_FOUND', 'attendanceOrgId does not match a known org')
+        }
+        if (derivedAttendanceOrgId && derivedAttendanceOrgId !== cleanExplicitAttendanceOrgId) {
+          return jsonError(
+            res,
+            400,
+            'ATTENDANCE_ORG_CONFLICT',
+            'attendanceOrgId conflicts with the org resolved from attendanceGroupId/defaultShiftId',
+          )
+        }
+        attendanceOrgId = cleanExplicitAttendanceOrgId
+      }
+
       const defaultShiftStartDate = cleanDefaultShiftId
         ? (cleanDefaultShiftStartDate || cleanHireDate || todayUtcDate())
         : null
@@ -3221,8 +3280,10 @@ export function adminUsersRouter(): Router {
 
       // W4-PRE-1 (§3.3 of the Wave-4 onboarding design lock): this route is the first-priority
       // user_orgs write site — it already resolves and validates a KNOWN AUTHORITATIVE org
-      // (attendanceOrgId, only set when attendanceGroupId/defaultShiftId was supplied and
-      // matched against attendance_groups/attendance_shifts.org_id above) but historically wrote
+      // (attendanceOrgId — set either from the group/shift-derivation fallback, matched against
+      // attendance_groups/attendance_shifts.org_id above, OR from W4-PRE-1b's explicit
+      // `attendanceOrgId` body param, validated against `directory_integrations` above — see
+      // that block's comment) but historically wrote
       // users/user_roles/user_permissions/attendance_group_members/attendance_shift_assignments
       // as independent auto-commit statements with no shared transaction boundary. The W4-PRE-1
       // atomicity requirement (a user_orgs write failure must roll back the whole admission —

--- a/packages/core-backend/src/routes/api-tokens.ts
+++ b/packages/core-backend/src/routes/api-tokens.ts
@@ -151,8 +151,16 @@ async function requireOrgMemberAccess(res: Response, userId: string, orgId: stri
     res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'orgId is required' } })
     return false
   }
+  // W4-PRE-1b item E (owner CHANGES_REQUESTED on the W4 re-ratify PR #4522, 2026-07-21): same
+  // shape/same finding as attendance-admin.ts's `canReadAttendanceDirectoryReadiness` — a
+  // deactivated platform account (`users.is_active=false`) must not keep DingTalk-group-
+  // destination org access via a `user_orgs` row that is still `is_active=true`.
   const result = await query(
-    'SELECT 1 FROM user_orgs WHERE user_id = $1 AND org_id = $2 AND is_active = true LIMIT 1',
+    `SELECT 1
+     FROM user_orgs uo
+     JOIN users u ON u.id = uo.user_id
+     WHERE uo.user_id = $1 AND uo.org_id = $2 AND uo.is_active = true AND u.is_active = true
+     LIMIT 1`,
     [userId, orgId],
   )
   if (!result.rows.length) {

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -371,8 +371,19 @@ export async function canReadAttendanceDirectoryReadiness(
   runQuery: typeof query = query,
 ): Promise<boolean> {
   if (hasLegacyAdminClaim(req) || await isRbacAdmin(userId)) return true
+  // W4-PRE-1b item E (owner CHANGES_REQUESTED on the W4 re-ratify PR #4522, 2026-07-21): dual
+  // is_active filter — a user whose PLATFORM ACCOUNT is deactivated (`users.is_active=false`,
+  // e.g. via PATCH /api/admin/users/:userId/status, which deliberately never touches
+  // `user_orgs` — see the item-B boundary note) must not keep reading this org's readiness just
+  // because their `user_orgs` row is still `is_active=true`. Mirrors the RD-3 population
+  // predicate every readiness COUNT in this line already uses
+  // (`plugins/plugin-attendance/index.cjs:15532`, "target population: active org members only").
   const member = await runQuery(
-    'SELECT 1 FROM user_orgs WHERE user_id = $1 AND org_id = $2 AND is_active = true LIMIT 1',
+    `SELECT 1
+     FROM user_orgs uo
+     JOIN users u ON u.id = uo.user_id
+     WHERE uo.user_id = $1 AND uo.org_id = $2 AND uo.is_active = true AND u.is_active = true
+     LIMIT 1`,
     [userId, orgId],
   )
   return member.rows.length > 0

--- a/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts
@@ -214,7 +214,11 @@ describeIfDatabase('W4-PRE-1 — user_orgs admission write site: directory-sync 
       })
 
       expect(caught).not.toBeNull()
-      expect((caught as unknown as Error).message).toBe('Directory integration not found for admitted account org resolution')
+      // W4-PRE-1b centralized org resolution (+ the user_orgs write) into
+      // `applyDirectoryAccountBindInTransaction` (shared by every bind-shaped writer) — the
+      // fail-closed guarantee this test proves is unchanged (no `users` row survives below),
+      // only the resolution failure message text moved with it.
+      expect((caught as unknown as Error).message).toBe('Directory integration not found for account org resolution')
       const userRow = await query(`SELECT id FROM users WHERE username = $1`, [username])
       expect(userRow.rows).toEqual([])
     })

--- a/packages/core-backend/tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts
@@ -1,0 +1,207 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import http from 'http'
+import type { MetaSheetServer } from '../../src/index'
+import { query } from '../../src/db/pg'
+
+/**
+ * W4-PRE-1b item D (F6) — `POST /api/admin/users` accepts an independent explicit
+ * `attendanceOrgId` body param, unconditionally sufficient (no `attendanceGroupId`/
+ * `defaultShiftId` required) to onboard `user_orgs` membership. Closes the exact circular
+ * dependency owner named (admin-users.ts:3172 previously resolved an org ONLY when a group/shift
+ * id was ALSO submitted, so a brand-new org's first member could never complete step① — you
+ * needed a group/shift to get an org, and a group/shift needs an org).
+ *
+ * Auth: platform admin via dev-token (`roles=admin` → `hasLegacyAdminClaim` inside
+ * `ensurePlatformAdmin`) — this route's OWN gate, unrelated to the S7-5/rbacGuard namespace-
+ * admission subsystem F5 had to route around, so the full real-server + dev-token path (proven
+ * working by the existing `admin-users.api.test.ts` sanity test) is the natural fit here.
+ */
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const s = net.createServer()
+    s.once('error', () => resolve(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
+  })
+}
+
+interface HttpResponse {
+  status: number
+  body: { ok?: boolean; error?: { code?: string; message?: string }; data?: Record<string, unknown> } & Record<string, unknown>
+}
+
+function requestJson(
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const req = http.request(
+      { method: options.method || 'GET', hostname: target.hostname, port: target.port, path: `${target.pathname}${target.search}`, headers: options.headers },
+      (res) => {
+        let data = ''
+        res.on('data', (chunk) => (data += chunk))
+        res.on('end', () => {
+          let body: unknown
+          try {
+            body = data ? JSON.parse(data) : {}
+          } catch {
+            body = {}
+          }
+          resolve({ status: res.statusCode || 0, body: body as HttpResponse['body'] })
+        })
+      },
+    )
+    req.on('error', reject)
+    if (options.body) req.write(options.body)
+    req.end()
+  })
+}
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+const TS = Date.now()
+const NS = `w4pre1badminorg${TS}`
+
+describeIfDatabase('W4-PRE-1b item D (F6) — POST /api/admin/users explicit attendanceOrgId (real DB, real endpoint)', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  let adminToken = ''
+  const createdUserIds: string[] = []
+  const freshOrg = `${NS}-fresh-org`
+  const groupDerivedOrg = `${NS}-group-org`
+  const conflictOrg = `${NS}-conflict-org`
+
+  async function devToken(): Promise<string> {
+    const res = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(`${NS}-platform-admin`)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+    const token = (res.body as { token?: string }).token
+    if (!token) throw new Error('dev-token issuance failed')
+    return token
+  }
+
+  async function createUser(body: Record<string, unknown>): Promise<HttpResponse> {
+    const res = await requestJson(`${baseUrl}/api/admin/users`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    const userId = (res.body?.data as { user?: { id?: string } } | undefined)?.user?.id
+    if (userId) createdUserIds.push(userId)
+    return res
+  }
+
+  async function membershipRow(userId: string, orgId: string): Promise<{ is_active: boolean } | undefined> {
+    const rows = await query<{ is_active: boolean }>(`SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`, [userId, orgId])
+    return rows.rows[0]
+  }
+
+  beforeAll(async () => {
+    if (!(await canListenOnEphemeralPort())) throw new Error('F6 test requires an available loopback port')
+    if (!dbUrl) throw new Error('DATABASE_URL / ATTENDANCE_TEST_DATABASE_URL is required')
+    process.env.DATABASE_URL = dbUrl
+
+    // `freshOrg` is genuinely new-to-ATTENDANCE (zero attendance_groups/attendance_shifts rows)
+    // but already carries a `directory_integrations` anchor (local provider) — the SHIPPED
+    // reading of "校验 org 存在" (see PR body deviation #1: validate-can-fail against
+    // directory_integrations, not auto-vivify from client input). This is what "fresh-org" means
+    // in F6: fresh to the OLD group/shift-derivation circular dependency, not unanchored at the
+    // directory layer.
+    await query(
+      `INSERT INTO directory_integrations (org_id, name, corp_id, provider, status)
+       VALUES ($1, $2, $3, 'local', 'active')`,
+      [freshOrg, `${NS}-fresh-int`, `local:${freshOrg}`],
+    )
+    await query(
+      `INSERT INTO directory_integrations (org_id, name, corp_id, provider, status)
+       VALUES ($1, $2, $3, 'local', 'active')`,
+      [conflictOrg, `${NS}-conflict-int`, `local:${conflictOrg}`],
+    )
+
+    const { MetaSheetServer } = await import('../../src/index')
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    if (!address || typeof address === 'string') throw new Error('server did not expose a TCP address')
+    baseUrl = `http://127.0.0.1:${address.port}`
+    adminToken = await devToken()
+  })
+
+  afterAll(async () => {
+    if (createdUserIds.length) {
+      await query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [createdUserIds])
+      await query(`DELETE FROM users WHERE id = ANY($1::text[])`, [createdUserIds])
+    }
+    await query(`DELETE FROM directory_integrations WHERE org_id = ANY($1::text[])`, [[freshOrg, groupDerivedOrg, conflictOrg]])
+    if (server) await server.stop()
+  })
+
+  it('fresh-org explicit attendanceOrgId with ZERO attendanceGroupId/defaultShiftId creates active membership (falsifies the old circular dependency)', async () => {
+    const res = await createUser({
+      name: 'F6 Fresh',
+      email: `${NS}-fresh@example.test`,
+      attendanceOrgId: freshOrg,
+    })
+    expect(res.status).toBe(200)
+    const userId = (res.body?.data as { user?: { id?: string } } | undefined)?.user?.id
+    expect(userId).toBeTruthy()
+    expect(await membershipRow(userId!, freshOrg)).toEqual({ is_active: true })
+  })
+
+  it('unknown attendanceOrgId (no directory_integrations anchor) → 404 ATTENDANCE_ORG_NOT_FOUND', async () => {
+    const res = await createUser({
+      name: 'F6 Unknown Org',
+      email: `${NS}-unknown@example.test`,
+      attendanceOrgId: `${NS}-org-that-does-not-exist`,
+    })
+    expect(res.status).toBe(404)
+    expect(res.body?.error?.code).toBe('ATTENDANCE_ORG_NOT_FOUND')
+  })
+
+  it('malformed attendanceOrgId (non-string) → 400 INVALID_ATTENDANCE_ORG_ID', async () => {
+    const res = await createUser({
+      name: 'F6 Bad Org',
+      email: `${NS}-badorg@example.test`,
+      attendanceOrgId: 12345,
+    })
+    expect(res.status).toBe(400)
+    expect(res.body?.error?.code).toBe('INVALID_ATTENDANCE_ORG_ID')
+  })
+
+  it('backward compat: group/shift-derived path (no attendanceOrgId) is unchanged', async () => {
+    const res = await createUser({
+      name: 'F6 Legacy Path',
+      email: `${NS}-legacy@example.test`,
+    })
+    expect(res.status).toBe(200)
+    // No attendanceGroupId/defaultShiftId AND no attendanceOrgId submitted → attendanceOrgId
+    // resolution never triggers (matches pre-W4-PRE-1b-item-D behavior byte-for-byte).
+    expect(res.body?.data && (res.body.data as { attendanceOnboarding?: unknown }).attendanceOnboarding).toBeNull()
+  })
+
+  it('explicit attendanceOrgId conflicting with the group/shift-derived org → 400 ATTENDANCE_ORG_CONFLICT', async () => {
+    // Seed a real attendance_group under `groupDerivedOrg` so resolveAttendanceOnboardingOrgId's
+    // derivation path has something concrete to disagree with `conflictOrg` about. orgId is
+    // supplied via body.orgId (resolveAttendanceOnboardingOrgId's own precedence chain).
+    const groupId = (
+      await query<{ id: string }>(
+        `INSERT INTO attendance_groups (org_id, name, timezone, created_at, updated_at)
+         VALUES ($1, 'F6 Conflict Group', 'UTC', NOW(), NOW()) RETURNING id`,
+        [groupDerivedOrg],
+      )
+    ).rows[0].id
+    try {
+      const res = await createUser({
+        name: 'F6 Conflict',
+        email: `${NS}-conflict@example.test`,
+        orgId: groupDerivedOrg,
+        attendanceGroupId: groupId,
+        attendanceOrgId: conflictOrg,
+      })
+      expect(res.status).toBe(400)
+      expect(res.body?.error?.code).toBe('ATTENDANCE_ORG_CONFLICT')
+    } finally {
+      await query(`DELETE FROM attendance_groups WHERE id = $1`, [groupId])
+    }
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts
@@ -96,17 +96,27 @@ describeIfDatabase('W4-PRE-1b item D (F6) — POST /api/admin/users explicit att
     return rows.rows[0]
   }
 
+  async function attendanceScaffoldCounts(orgId: string): Promise<{ groups: number; shifts: number }> {
+    const [groups, shifts] = await Promise.all([
+      query<{ count: string }>(`SELECT COUNT(*)::text AS count FROM attendance_groups WHERE org_id = $1`, [orgId]),
+      query<{ count: string }>(`SELECT COUNT(*)::text AS count FROM attendance_shifts WHERE org_id = $1`, [orgId]),
+    ])
+    return { groups: Number(groups.rows[0]?.count ?? 0), shifts: Number(shifts.rows[0]?.count ?? 0) }
+  }
+
   beforeAll(async () => {
     if (!(await canListenOnEphemeralPort())) throw new Error('F6 test requires an available loopback port')
     if (!dbUrl) throw new Error('DATABASE_URL / ATTENDANCE_TEST_DATABASE_URL is required')
     process.env.DATABASE_URL = dbUrl
 
-    // `freshOrg` is genuinely new-to-ATTENDANCE (zero attendance_groups/attendance_shifts rows)
-    // but already carries a `directory_integrations` anchor (local provider) — the SHIPPED
-    // reading of "校验 org 存在" (see PR body deviation #1: validate-can-fail against
-    // directory_integrations, not auto-vivify from client input). This is what "fresh-org" means
-    // in F6: fresh to the OLD group/shift-derivation circular dependency, not unanchored at the
-    // directory layer.
+    // `freshOrg` is genuinely new-to-ATTENDANCE (zero attendance_groups/attendance_shifts rows —
+    // asserted explicitly in the F6 test below, not just implied by NS-scoped uniqueness) but
+    // already carries a `directory_integrations` anchor (local provider) — the SHIPPED reading of
+    // the owner's item-D ask ("支持显式 attendanceOrgId（不依赖考勤组/班次）⇒ canonical surface
+    // 变为真无条件"): validate-can-fail against `directory_integrations`, not auto-vivify from
+    // client input (see PR body deviation #1 for the alternate reading, requested for owner
+    // ruling). This is what "fresh-org" means in F6: fresh to the OLD group/shift-derivation
+    // circular dependency, not unanchored at the directory layer.
     await query(
       `INSERT INTO directory_integrations (org_id, name, corp_id, provider, status)
        VALUES ($1, $2, $3, 'local', 'active')`,
@@ -137,6 +147,10 @@ describeIfDatabase('W4-PRE-1b item D (F6) — POST /api/admin/users explicit att
   })
 
   it('fresh-org explicit attendanceOrgId with ZERO attendanceGroupId/defaultShiftId creates active membership (falsifies the old circular dependency)', async () => {
+    // Self-verify the "fresh" claim (#4526 review) rather than relying solely on NS-scoped
+    // uniqueness: freshOrg has zero attendance_groups/attendance_shifts BEFORE the call.
+    expect(await attendanceScaffoldCounts(freshOrg)).toEqual({ groups: 0, shifts: 0 })
+
     const res = await createUser({
       name: 'F6 Fresh',
       email: `${NS}-fresh@example.test`,
@@ -146,6 +160,10 @@ describeIfDatabase('W4-PRE-1b item D (F6) — POST /api/admin/users explicit att
     const userId = (res.body?.data as { user?: { id?: string } } | undefined)?.user?.id
     expect(userId).toBeTruthy()
     expect(await membershipRow(userId!, freshOrg)).toEqual({ is_active: true })
+
+    // ...and stays zero AFTER: the explicit-org path must not silently scaffold an attendance
+    // group/shift as a side effect of onboarding.
+    expect(await attendanceScaffoldCounts(freshOrg)).toEqual({ groups: 0, shifts: 0 })
   })
 
   it('unknown attendanceOrgId (no directory_integrations anchor) → 404 ATTENDANCE_ORG_NOT_FOUND', async () => {

--- a/packages/core-backend/tests/integration/attendance-w4pre1b-api-tokens-org-member-access.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1b-api-tokens-org-member-access.db.test.ts
@@ -1,0 +1,122 @@
+/**
+ * W4-PRE-1b item E follow-up (#4526 review, P3) — `api-tokens.ts`'s `requireOrgMemberAccess`
+ * (the dual `user_orgs.is_active=true AND users.is_active=true` filter added for item E) proven
+ * through the REAL endpoint (`GET /api/multitable/dingtalk-groups?orgId=...`) against a REAL
+ * Postgres. The PR's own regression coverage for this exact fix
+ * (`dingtalk-group-destination-routes.api.test.ts`) only asserts the literal SQL TEXT was passed
+ * to a MOCKED `query` — it cannot catch a wrong JOIN condition or a swapped `AND`/`OR` that still
+ * happens to contain the same substrings. This file drives the real SQL against real rows instead.
+ *
+ * Auth: only the session-auth middleware is stubbed (reads the caller's id from a test-only
+ * header so each test can use its own NS-scoped user, matching the `multitable-oapi-token-
+ * create-scope.api.test.ts` precedent) — never `isAdmin`/`role: 'admin'`, so `isAdminRequest`'s
+ * platform-admin bypass in `requireOrgReadAccess` stays false and every request actually reaches
+ * `requireOrgMemberAccess`'s own `user_orgs`/`users` query.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/middleware/auth', () => {
+  const authenticate = (req: { headers: Record<string, unknown>; user?: unknown }, _res: unknown, next: () => void) => {
+    const testUserId = req.headers['x-test-user-id']
+    req.user = { id: typeof testUserId === 'string' ? testUserId : '' }
+    next()
+  }
+  return { authenticate, authMiddleware: authenticate, default: authenticate }
+})
+
+import { apiTokensRouter } from '../../src/routes/api-tokens'
+import { query } from '../../src/db/pg'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const NS = `w4pre1boma${TS}`
+const ORG = `${NS}-org`
+
+describeIfDatabase('W4-PRE-1b item E — api-tokens.ts requireOrgMemberAccess dual is_active filter (real DB, real endpoint)', () => {
+  let app: Express
+  const userIds: string[] = []
+
+  async function seedUser(tag: string, isActive: boolean): Promise<string> {
+    const id = `${NS}-u-${tag}`
+    await query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $3, 'Fixture', 'x', 'user', '[]'::jsonb, $4, false, NOW(), NOW())`,
+      [id, `${id}@example.test`, id, isActive],
+    )
+    userIds.push(id)
+    return id
+  }
+
+  async function seedMembership(userId: string, isActive: boolean): Promise<void> {
+    await query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, $3)`,
+      [userId, ORG, isActive],
+    )
+  }
+
+  beforeAll(() => {
+    app = express()
+    app.use(express.json())
+    app.use(apiTokensRouter())
+  })
+
+  afterAll(async () => {
+    if (userIds.length) {
+      await query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [userIds])
+      await query(`DELETE FROM users WHERE id = ANY($1::text[])`, [userIds])
+    }
+  })
+
+  it('active user_orgs + active user → passes the gate (200, not 403)', async () => {
+    const userId = await seedUser('active', true)
+    await seedMembership(userId, true)
+
+    const res = await request(app)
+      .get('/api/multitable/dingtalk-groups')
+      .query({ orgId: ORG })
+      .set('x-test-user-id', userId)
+
+    expect(res.status).toBe(200)
+    expect(res.body?.ok).toBe(true)
+  })
+
+  it('active user_orgs + DEACTIVATED user (users.is_active=false) → 403 FORBIDDEN — the exact item-E defect', async () => {
+    const userId = await seedUser('deactivated', false)
+    await seedMembership(userId, true)
+
+    const res = await request(app)
+      .get('/api/multitable/dingtalk-groups')
+      .query({ orgId: ORG })
+      .set('x-test-user-id', userId)
+
+    expect(res.status).toBe(403)
+    expect(res.body).toEqual({ ok: false, error: { code: 'FORBIDDEN' } })
+  })
+
+  it('DEACTIVATED user_orgs (is_active=false) + active user → 403 FORBIDDEN — pre-existing leg, still correct', async () => {
+    const userId = await seedUser('unbound', true)
+    await seedMembership(userId, false)
+
+    const res = await request(app)
+      .get('/api/multitable/dingtalk-groups')
+      .query({ orgId: ORG })
+      .set('x-test-user-id', userId)
+
+    expect(res.status).toBe(403)
+    expect(res.body).toEqual({ ok: false, error: { code: 'FORBIDDEN' } })
+  })
+
+  it('no user_orgs row at all → 403 FORBIDDEN', async () => {
+    const userId = await seedUser('nomembership', true)
+
+    const res = await request(app)
+      .get('/api/multitable/dingtalk-groups')
+      .query({ orgId: ORG })
+      .set('x-test-user-id', userId)
+
+    expect(res.status).toBe(403)
+    expect(res.body).toEqual({ ok: false, error: { code: 'FORBIDDEN' } })
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4pre1b-directory-readiness-gate.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1b-directory-readiness-gate.db.test.ts
@@ -6,9 +6,10 @@ import { query } from '../../src/db/pg'
 /**
  * W4-PRE-1b item E (F5) — the S7-5 door (`GET /api/attendance-admin/directory-readiness`,
  * `canReadAttendanceDirectoryReadiness`) now requires `users.is_active=true` IN ADDITION TO
- * `user_orgs.is_active=true`, exercised via the REAL endpoint (owner: "经真实端点") against a
- * REAL Postgres — everything is real EXCEPT the router-level `rbacGuard('attendance','admin')`
- * mount guard, which is bypassed the SAME way the existing mocked unit coverage for this exact
+ * `user_orgs.is_active=true`, exercised via the REAL endpoint (this PR's own case label for the
+ * approach — not owner verbatim text) against a REAL Postgres — everything is real EXCEPT the
+ * router-level `rbacGuard('attendance','admin')` mount guard, which is bypassed the SAME way the
+ * existing mocked unit coverage for this exact
  * route does (`attendance-admin-admin-directory-readiness-s7-5.test.ts`'s `makeApp` +
  * `vi.mock('../../src/rbac/rbac', ...)`): that outer gate is an UNRELATED RBAC namespace-
  * admission subsystem this ticket does not touch, and a real-DB test that tried to satisfy it

--- a/packages/core-backend/tests/integration/attendance-w4pre1b-directory-readiness-gate.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1b-directory-readiness-gate.db.test.ts
@@ -1,0 +1,126 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { query } from '../../src/db/pg'
+
+/**
+ * W4-PRE-1b item E (F5) — the S7-5 door (`GET /api/attendance-admin/directory-readiness`,
+ * `canReadAttendanceDirectoryReadiness`) now requires `users.is_active=true` IN ADDITION TO
+ * `user_orgs.is_active=true`, exercised via the REAL endpoint (owner: "经真实端点") against a
+ * REAL Postgres — everything is real EXCEPT the router-level `rbacGuard('attendance','admin')`
+ * mount guard, which is bypassed the SAME way the existing mocked unit coverage for this exact
+ * route does (`attendance-admin-admin-directory-readiness-s7-5.test.ts`'s `makeApp` +
+ * `vi.mock('../../src/rbac/rbac', ...)`): that outer gate is an UNRELATED RBAC namespace-
+ * admission subsystem this ticket does not touch, and a real-DB test that tried to satisfy it
+ * would need to seed unrelated `user_roles`/namespace-admission fixtures that have nothing to do
+ * with item E. `canReadAttendanceDirectoryReadiness` itself — the function under test — is
+ * imported UNMOCKED and runs its real SQL against the real DB below; only the middleware ABOVE
+ * it in the stack is stubbed, matching this repo's own precedent for isolating this route.
+ *
+ * `req.user` is set directly by a tiny test middleware (no JWT/dev-token machinery needed once
+ * the router-level gate is stubbed) — critically NEVER `role: 'admin'` / `roles: ['admin']` /
+ * `perms: ['*:*'|'admin:all']`, so `hasLegacyAdminClaim` stays false and `isRbacAdmin` (a real,
+ * unmocked DB check — none of these synthetic userIds hold an admin role row) also stays false,
+ * meaning the request reaches `canReadAttendanceDirectoryReadiness`'s OWN `user_orgs`/`users`
+ * query instead of short-circuiting on the platform-admin bypass (the exact vacuous-test trap
+ * flagged during review).
+ */
+vi.mock('../../src/rbac/rbac', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/rbac')>()
+  return {
+    ...actual,
+    rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  }
+})
+
+vi.mock('../../src/routes/admin-users', () => ({
+  ensurePlatformAdmin: vi.fn(async () => null),
+}))
+
+vi.mock('../../src/services/AttendanceNotificationRedelivery', () => ({
+  redeliverFailedAttendanceNotification: vi.fn(),
+}))
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+const TS = Date.now()
+const NS = `w4pre1bgate${TS}`
+const ORG = `${NS}-org`
+
+describeIfDatabase('W4-PRE-1b item E (F5) — directory-readiness gate dual is_active (real DB, real endpoint)', () => {
+  let attendanceAdminRouter: () => express.Router
+
+  const activeUser = `${NS}-active`
+  const deactivatedUserActiveMembership = `${NS}-deactivated-user`
+  const activeUserDeactivatedMembership = `${NS}-deactivated-membership`
+  const userIds = [activeUser, deactivatedUserActiveMembership, activeUserDeactivatedMembership]
+
+  function makeApp(userId: string) {
+    const app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      // Delegated (non-platform) attendance admin: NO 'admin' role/perm anywhere.
+      ;(req as express.Request & { user?: unknown }).user = { id: userId, roles: ['user'], permissions: ['attendance:admin'] }
+      next()
+    })
+    app.use(attendanceAdminRouter())
+    return app
+  }
+
+  beforeAll(async () => {
+    if (!dbUrl) throw new Error('DATABASE_URL / ATTENDANCE_TEST_DATABASE_URL is required')
+    process.env.DATABASE_URL = dbUrl
+    ;({ attendanceAdminRouter } = await import('../../src/routes/attendance-admin'))
+
+    await query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $1, 'Fixture', 'x', 'user', '[]'::jsonb, true, false, NOW(), NOW())`,
+      [activeUser, `${activeUser}@example.test`],
+    )
+    await query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $1, 'Fixture', 'x', 'user', '[]'::jsonb, false, false, NOW(), NOW())`,
+      [deactivatedUserActiveMembership, `${deactivatedUserActiveMembership}@example.test`],
+    )
+    await query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $1, 'Fixture', 'x', 'user', '[]'::jsonb, true, false, NOW(), NOW())`,
+      [activeUserDeactivatedMembership, `${activeUserDeactivatedMembership}@example.test`],
+    )
+
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true)`, [activeUser, ORG])
+    // Mutation G target variant: users.is_active=false, user_orgs.is_active=true — the OLD
+    // single-filter gate would have allowed this; only the NEW dual filter blocks it.
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true)`, [deactivatedUserActiveMembership, ORG])
+    // Pre-existing filter's own variant (unchanged behavior, sanity control).
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, false)`, [activeUserDeactivatedMembership, ORG])
+  })
+
+  afterAll(async () => {
+    await query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [userIds])
+    await query(`DELETE FROM users WHERE id = ANY($1::text[])`, [userIds])
+  })
+
+  it('200 for a genuinely active delegated admin (positive control)', async () => {
+    const res = await request(makeApp(activeUser)).get(`/api/attendance-admin/directory-readiness?orgId=${encodeURIComponent(ORG)}`)
+    expect(res.status).toBe(200)
+    expect(res.body?.ok).toBe(true)
+  })
+
+  it('403 when users.is_active=false even though user_orgs.is_active=true (mutation G target)', async () => {
+    const res = await request(makeApp(deactivatedUserActiveMembership)).get(
+      `/api/attendance-admin/directory-readiness?orgId=${encodeURIComponent(ORG)}`,
+    )
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('FORBIDDEN')
+  })
+
+  it('403 when user_orgs.is_active=false (pre-existing filter, unchanged)', async () => {
+    const res = await request(makeApp(activeUserDeactivatedMembership)).get(
+      `/api/attendance-admin/directory-readiness?orgId=${encodeURIComponent(ORG)}`,
+    )
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('FORBIDDEN')
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-backfill-migration.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-backfill-migration.db.test.ts
@@ -1,0 +1,140 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import { Kysely, PostgresDialect } from 'kysely'
+import { Pool } from 'pg'
+import crypto from 'node:crypto'
+import { query } from '../../src/db/pg'
+import { up as backfillUp } from '../../src/db/migrations/zzzz20260721150000_backfill_user_orgs_from_directory_links'
+
+/**
+ * W4-PRE-1b item C (F7) — real-stock backfill migration
+ * (`zzzz20260721150000_backfill_user_orgs_from_directory_links`).
+ *
+ * Runs the migration's `up()` DIRECTLY (not through the tracked migration runner — it already
+ * ran once against this shared test DB when the suite's schema was provisioned) against the
+ * SAME shared public-schema tables the rest of this line's fixtures use, via a Kysely instance
+ * wrapping a plain pg Pool (no search_path override — the migration's own SQL is unqualified,
+ * same as production). Namespaced fixture rows only, `w4pre1b_` prefix per this line's shared-DB
+ * discipline.
+ *
+ * Proves:
+ *  - a linked-but-membership-less user (the exact pre-fix stock the owner named) gets an ACTIVE
+ *    row after the migration runs;
+ *  - a row already `is_active=false` (deactivated by item B's own logic, or by any other prior
+ *    writer) is NEVER resurrected — `ON CONFLICT (user_id, org_id) DO NOTHING` only inserts
+ *    where no row exists at all;
+ *  - re-running `up()` a second time (idempotency) changes nothing further.
+ */
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+const TS = Date.now()
+const RUN = crypto.randomBytes(4).toString('hex')
+const NS = `w4pre1bbackfill${TS}${RUN}`
+
+describeIfDatabase('W4-PRE-1b item C — backfill migration (real DB, shared public schema)', () => {
+  const integrationIds: string[] = []
+  const userIds: string[] = []
+  let pool: Pool | undefined
+  let db: Kysely<unknown> | undefined
+
+  afterAll(async () => {
+    await db?.destroy()
+    if (userIds.length) {
+      await query(`DELETE FROM directory_account_links WHERE local_user_id = ANY($1::text[])`, [userIds])
+      await query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [userIds])
+      await query(`DELETE FROM users WHERE id = ANY($1::text[])`, [userIds])
+    }
+    if (integrationIds.length) {
+      await query(`DELETE FROM directory_accounts WHERE integration_id = ANY($1::uuid[])`, [integrationIds])
+      await query(`DELETE FROM directory_integrations WHERE id = ANY($1::uuid[])`, [integrationIds])
+    }
+  })
+
+  async function seedUser(tag: string): Promise<string> {
+    const id = `${NS}-u-${tag}`
+    await query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $3, 'Fixture', 'x', 'user', '[]'::jsonb, true, false, NOW(), NOW())`,
+      [id, `${id}@example.test`, id],
+    )
+    userIds.push(id)
+    return id
+  }
+
+  async function seedIntegration(org: string, tag: string): Promise<string> {
+    const id = (
+      await query<{ id: string }>(
+        `INSERT INTO directory_integrations (org_id, name, corp_id, provider, status)
+         VALUES ($1, $2, $3, 'dingtalk', 'active') RETURNING id::text AS id`,
+        [org, `${NS}-int-${tag}`, `${NS}-corp-${tag}`],
+      )
+    ).rows[0].id
+    integrationIds.push(id)
+    return id
+  }
+
+  async function seedLinkedAccount(integrationId: string, userId: string, tag: string, isActive = true): Promise<string> {
+    const external = `${NS}-ext-${tag}`
+    const accountId = (
+      await query<{ id: string }>(
+        `INSERT INTO directory_accounts (integration_id, provider, corp_id, external_user_id, union_id, open_id, external_key, name, is_active)
+         VALUES ($1, 'dingtalk', 'corp', $2, $3, $4, $5, 'Fixture', $6) RETURNING id::text AS id`,
+        [integrationId, external, `${NS}-union-${tag}`, `${NS}-open-${tag}`, external, isActive],
+      )
+    ).rows[0].id
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy, created_at, updated_at)
+       VALUES ($1, $2, 'linked', 'manual', NOW(), NOW())`,
+      [accountId, userId],
+    )
+    return accountId
+  }
+
+  it('inserts membership for a linked user with no row; never resurrects an already-deactivated row; idempotent on rerun', async () => {
+    pool = new Pool({ connectionString: dbUrl })
+    db = new Kysely<unknown>({ dialect: new PostgresDialect({ pool }) })
+
+    const org = `${NS}_org`
+    const integrationId = await seedIntegration(org, 'main')
+
+    // (1) linked, no user_orgs row at all — the population this migration targets.
+    const missingUser = await seedUser('missing')
+    await seedLinkedAccount(integrationId, missingUser, 'missing')
+
+    // (2) linked, but ALREADY deactivated — must NOT be resurrected.
+    const deactivatedUser = await seedUser('deactivated')
+    await seedLinkedAccount(integrationId, deactivatedUser, 'deactivated')
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, false)`, [deactivatedUser, org])
+
+    // (3) linked, already active — control: stays active, no duplicate/error.
+    const activeUser = await seedUser('active')
+    await seedLinkedAccount(integrationId, activeUser, 'active')
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true)`, [activeUser, org])
+
+    // (4) an INACTIVE directory account (a.is_active=false) that is still `link_status='linked'`
+    // — the migration's `a.is_active=true` predicate must exclude it, exactly like the S7-5
+    // readiness read and every bind-shaped writer in this line.
+    const inactiveAccountUser = await seedUser('inactiveaccount')
+    await seedLinkedAccount(integrationId, inactiveAccountUser, 'inactiveaccount', false)
+
+    await backfillUp(db)
+
+    const rows = await query<{ user_id: string; is_active: boolean }>(
+      `SELECT user_id, is_active FROM user_orgs WHERE user_id = ANY($1::text[]) ORDER BY user_id`,
+      [[missingUser, deactivatedUser, activeUser, inactiveAccountUser]],
+    )
+    const byUser = new Map(rows.rows.map((r) => [r.user_id, r.is_active]))
+    expect(byUser.get(missingUser)).toBe(true)
+    expect(byUser.get(deactivatedUser)).toBe(false)
+    expect(byUser.get(activeUser)).toBe(true)
+    expect(byUser.has(inactiveAccountUser)).toBe(false)
+
+    // Idempotency: rerun changes nothing.
+    await backfillUp(db)
+    const rowsAfterRerun = await query<{ user_id: string; is_active: boolean }>(
+      `SELECT user_id, is_active FROM user_orgs WHERE user_id = ANY($1::text[]) ORDER BY user_id`,
+      [[missingUser, deactivatedUser, activeUser, inactiveAccountUser]],
+    )
+    expect(rowsAfterRerun.rows).toEqual(rows.rows)
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts
@@ -32,6 +32,17 @@ import { poolManager } from '../../src/integration/db/connection-pool'
  * And local-provider coverage (item A/B's OTHER writer pair, `local-directory-org.ts`):
  * createLocalAccount binds an existing user; archiveLocalAccount deactivates their membership
  * when it was their last local binding in the org.
+ *
+ * Post-gate fix (PR #4526 review, P2 — cross-org negative regression, added 2026-07-21):
+ * `deactivateUserOrgMembershipIfNoOtherActiveBinding`'s tenant-isolation predicate
+ * (`AND i.org_id = $2::text`, `directory-sync.ts:4977`) had zero coverage — every existing case
+ * above (F1/F2/F4/local-provider = single-org; F3/F3-race = same-org sibling) exercises the
+ * "other active binding" NOT EXISTS check with only ONE org in play, so none of them can tell the
+ * predicate apart from an unscoped "does this user have ANY other active binding anywhere" check.
+ * The "cross-org tenant-isolation regression" case below closes that gap: same user, DingTalk
+ * binding in org A + local binding in org B, unbind A, assert org A deactivates (the predicate
+ * must NOT be fooled by org B's still-active sibling) AND org B stays active (the predicate must
+ * not reach into org B either).
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -205,6 +216,37 @@ describeIfDatabase('W4-PRE-1b — user_orgs lifecycle: bind/unbind/rebind/local 
 
       expect(await membershipRow(userId, orgA)).toEqual({ is_active: false })
       expect(await membershipRow(userId, orgB)).toEqual({ is_active: true })
+    })
+  })
+
+  describe('cross-org tenant-isolation regression — unbind in org A must not be gated by org B\'s active binding (#4526 P2)', () => {
+    it('unbinding org A\'s DingTalk account deactivates ONLY org A membership; org B\'s local binding for the same user stays untouched and active', async () => {
+      const orgA = `${NS}_org_xorga`
+      const orgB = `${NS}_org_xorgb`
+      const userId = await seedUser('xorg')
+      const intA = await seedIntegration(orgA, 'xorga')
+      const dingtalkAccount = await seedAccount(intA, 'xorga')
+
+      await bindDirectoryAccount(dingtalkAccount, { localUserRef: userId, adminUserId, enableDingTalkGrant: false })
+      const localAccountB = await createLocalAccount({ orgId: orgB, localUserId: userId, name: 'Cross-org Local B', email: null, mobile: null, title: null })
+
+      expect(await membershipRow(userId, orgA)).toEqual({ is_active: true })
+      expect(await membershipRow(userId, orgB)).toEqual({ is_active: true })
+
+      await unbindDirectoryAccount(dingtalkAccount, { adminUserId })
+
+      // Tenant-isolation predicate (`AND i.org_id = $2::text`, directory-sync.ts:4977): the "does
+      // this user hold another active binding" sibling check inside
+      // `deactivateUserOrgMembershipIfNoOtherActiveBinding` must be SCOPED to org A. Without that
+      // scoping the NOT EXISTS would find org B's still-linked+active local account as a
+      // "sibling", skip org A's deactivation, and leave org A's membership stuck ACTIVE with ZERO
+      // org-A bindings — cross-org stale access.
+      expect(await membershipRow(userId, orgA)).toEqual({ is_active: false })
+      // Dual proof (the predicate must not be so broad it reaches INTO org B either, i.e. this is
+      // not just "always deactivate everything"): org B's membership, untouched by an org-A
+      // unbind, must remain ACTIVE.
+      expect(await membershipRow(userId, orgB)).toEqual({ is_active: true })
+      expect(localAccountB.localUserId).toBe(userId)
     })
   })
 

--- a/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts
@@ -1,8 +1,9 @@
 import { afterAll, describe, expect, it } from 'vitest'
 import crypto from 'node:crypto'
 import { query } from '../../src/db/pg'
-import { bindDirectoryAccount, unbindDirectoryAccount } from '../../src/directory/directory-sync'
+import { bindDirectoryAccount, unbindDirectoryAccount, __userOrgsMembershipInternalsForTests } from '../../src/directory/directory-sync'
 import { createLocalAccount, archiveLocalAccount } from '../../src/directory/local-directory-org'
+import { poolManager } from '../../src/integration/db/connection-pool'
 
 /**
  * W4-PRE-1b (owner CHANGES_REQUESTED on the W4 re-ratify PR #4522, 2026-07-21): full
@@ -231,47 +232,100 @@ describeIfDatabase('W4-PRE-1b — user_orgs lifecycle: bind/unbind/rebind/local 
     })
   })
 
-  describe('F3-race — concurrent unbind of BOTH bindings (constructed race, #4526 P2)', () => {
-    it('two concurrent deactivation calls on a double-bound user converge to is_active=false (no write-skew stuck-active)', async () => {
-      // Cross-transaction write-skew regression: `deactivateUserOrgMembershipIfNoOtherActiveBinding`'s
-      // NOT EXISTS sibling check reads OTHER accounts' link rows through this transaction's own
-      // READ COMMITTED snapshot. Without a shared-row lock, two concurrent unbinds of a double-
-      // bound user's two DIFFERENT accounts can each see the OTHER as still linked+active
-      // (neither has committed yet) and BOTH skip deactivation — the membership row is left
-      // ACTIVE with ZERO live bindings, permanently (nothing later self-heals it for the local
-      // provider; DingTalk only self-heals via the next resync's own already_linked write, which
-      // this PR's Finding-A fix now correctly gates on the account still being present/active).
+  describe('F3-race — concurrent deactivation calls on a double-bound user (constructed race, #4526 P2)', () => {
+    // CONSTRUCTED TOCTOU RACE (two raw pg clients + pg_blocking_pids), same technique as
+    // `multitable-l4-canonical-fence-realdb.test.ts`'s R1/RXR: `waitUntilBlockedBy` THROWS if B
+    // never parks on A's lock, so this can never silently degrade into a non-racing sequential
+    // pass. A naive `Promise.all` of two independent deactivate+commit chains was tried first and
+    // is NOT reliable proof either way: on localhost, with a tiny dataset, one statement routinely
+    // finishes before the other's sibling check even starts (confirmed empirically while building
+    // this test — the "race" silently collapsed into safe sequential execution, converging to the
+    // correct outcome regardless of whether the fix was present). A fully-sequential construction
+    // (A's call awaited to completion WITHOUT committing, then B's call run) DOES reproduce the
+    // skew when the fix is absent, but deadlocks against the fixed code (B's `FOR UPDATE` would
+    // park on A's still-held lock forever, since nothing ever commits A). This test instead
+    // verifies the SERIALIZATION MECHANISM ITSELF: A holds the row lock (uncommitted, 0-row
+    // result), B's own call is fired and PROVEN to park on A's lock (not just assumed), THEN A
+    // commits, B unblocks and re-evaluates against A's now-committed severance, and the final
+    // state is asserted. Mutating away the `FOR UPDATE` makes B never block —
+    // `waitUntilBlockedBy` throws, killing the test.
+    async function waitUntilBlockedBy(blockerPid: number, timeoutMs = 5000): Promise<void> {
+      const deadline = Date.now() + timeoutMs
+      while (Date.now() < deadline) {
+        const r = await query<{ c: number }>(
+          `SELECT COUNT(*)::int AS c FROM pg_stat_activity
+            WHERE datname = current_database()
+              AND wait_event_type = 'Lock'
+              AND $1 = ANY(pg_blocking_pids(pid))`,
+          [blockerPid],
+        )
+        if ((r.rows[0]?.c ?? 0) >= 1) return
+        await new Promise((resolve) => setTimeout(resolve, 25))
+      }
+      throw new Error('the second deactivation call never parked on the first caller\'s row lock — the constructed race did not occur')
+    }
+
+    it('B genuinely blocks on A\'s row lock, then unblocks and correctly deactivates after A commits (no write-skew)', async () => {
       const org = `${NS}_org_f3race`
       const userId = await seedUser('f3race')
       const integrationId = await seedIntegration(org, 'f3race')
-      const dingtalkAccount = await seedAccount(integrationId, 'f3race')
+      const accountX = await seedAccount(integrationId, 'f3racex')
+      const accountY = await seedAccount(integrationId, 'f3racey')
 
-      await bindDirectoryAccount(dingtalkAccount, { localUserRef: userId, adminUserId, enableDingTalkGrant: false })
-      const localAccount = await createLocalAccount({ orgId: org, localUserId: userId, name: 'F3-race Local', email: null, mobile: null, title: null })
+      // Seed the pre-race state directly (this test targets the low-level helper, not the
+      // higher-level bind orchestration already covered by F1-F4): user linked to TWO accounts
+      // in the SAME org, membership ACTIVE.
+      await query(
+        `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy, created_at, updated_at)
+         VALUES ($1, $2, 'linked', 'manual', NOW(), NOW()), ($3, $2, 'linked', 'manual', NOW(), NOW())`,
+        [accountX, userId, accountY],
+      )
+      await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true)`, [userId, org])
       expect(await membershipRow(userId, org)).toEqual({ is_active: true })
 
-      // Fire both deactivation-triggering calls CONCURRENTLY — each opens its OWN transaction/
-      // connection (`transaction()` acquires a fresh pool connection per call), so this is a
-      // genuine two-transaction race, not a sequential simulation.
-      await Promise.all([
-        unbindDirectoryAccount(dingtalkAccount, { adminUserId }),
-        archiveLocalAccount(org, localAccount.id),
-      ])
+      const clientA = await poolManager.get().getInternalPool().connect()
+      const clientB = await poolManager.get().getInternalPool().connect()
+      let bOutcome: 'blocked' | 'never-blocked' = 'never-blocked'
+      let bRun: Promise<void> | undefined
+      try {
+        await clientA.query('BEGIN')
+        await clientB.query('BEGIN')
+        const pidA = Number((await clientA.query('SELECT pg_backend_pid() AS pid')).rows[0].pid)
 
-      // Both bindings are now gone; the membership MUST be deactivated — not stuck active with
-      // zero bindings (the write-skew failure mode this test targets).
+        // A severs its own sibling (X) and runs the deactivate helper — 0 rows (Y still looks
+        // active from A's snapshot), but A's `SELECT ... FOR UPDATE` now HOLDS the row lock,
+        // uncommitted.
+        await clientA.query(`UPDATE directory_account_links SET local_user_id = NULL, link_status = 'unmatched' WHERE directory_account_id = $1`, [accountX])
+        const qA = (sql: string, params?: unknown[]) => clientA.query(sql, params) as unknown as Promise<{ rows: Array<Record<string, unknown>> }>
+        await __userOrgsMembershipInternalsForTests.deactivateUserOrgMembershipIfNoOtherActiveBinding({ query: qA }, { userId, orgId: org })
+
+        // B severs its own sibling (Y), then fires the SAME deactivate helper WITHOUT awaiting —
+        // its `FOR UPDATE` must park behind A's held lock.
+        await clientB.query(`UPDATE directory_account_links SET local_user_id = NULL, link_status = 'unmatched' WHERE directory_account_id = $1`, [accountY])
+        const qB = (sql: string, params?: unknown[]) => clientB.query(sql, params) as unknown as Promise<{ rows: Array<Record<string, unknown>> }>
+        bRun = __userOrgsMembershipInternalsForTests.deactivateUserOrgMembershipIfNoOtherActiveBinding({ query: qB }, { userId, orgId: org })
+
+        await waitUntilBlockedBy(pidA) // throws if B never genuinely parks — non-vacuity proof
+        bOutcome = 'blocked'
+
+        await clientA.query('COMMIT') // releases A's lock; A's own 0-row deactivate is final
+        await bRun // B unblocks, re-evaluates with a FRESH snapshot that now sees X committed-severed
+        await clientB.query('COMMIT')
+      } finally {
+        // Mutation-testing / failure safety: if `waitUntilBlockedBy` threw (mutation red path),
+        // neither transaction was committed and `bRun` may still be settling (or, without the
+        // fix, may already have resolved unblocked) — settle it and roll back BOTH before
+        // releasing the connections back to the pool, so a failed run never leaves a dangling
+        // open transaction (and its locks) on a pooled connection for a LATER test to hang on.
+        await Promise.allSettled([bRun, clientA.query('ROLLBACK'), clientB.query('ROLLBACK')])
+        clientA.release()
+        clientB.release()
+      }
+
+      expect(bOutcome).toBe('blocked')
+      // Both bindings are now severed; the membership MUST be deactivated — not stuck active
+      // with zero bindings (the write-skew failure mode this test targets).
       expect(await membershipRow(userId, org)).toEqual({ is_active: false })
-
-      const linkRow = await query<{ link_status: string }>(
-        `SELECT link_status FROM directory_account_links WHERE directory_account_id = $1`,
-        [dingtalkAccount],
-      )
-      expect(linkRow.rows[0]?.link_status).toBe('unmatched')
-      const localAccountRow = await query<{ is_active: boolean }>(
-        `SELECT is_active FROM directory_accounts WHERE id = $1`,
-        [localAccount.id],
-      )
-      expect(localAccountRow.rows[0]?.is_active).toBe(false)
     })
   })
 

--- a/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts
@@ -231,6 +231,50 @@ describeIfDatabase('W4-PRE-1b — user_orgs lifecycle: bind/unbind/rebind/local 
     })
   })
 
+  describe('F3-race — concurrent unbind of BOTH bindings (constructed race, #4526 P2)', () => {
+    it('two concurrent deactivation calls on a double-bound user converge to is_active=false (no write-skew stuck-active)', async () => {
+      // Cross-transaction write-skew regression: `deactivateUserOrgMembershipIfNoOtherActiveBinding`'s
+      // NOT EXISTS sibling check reads OTHER accounts' link rows through this transaction's own
+      // READ COMMITTED snapshot. Without a shared-row lock, two concurrent unbinds of a double-
+      // bound user's two DIFFERENT accounts can each see the OTHER as still linked+active
+      // (neither has committed yet) and BOTH skip deactivation — the membership row is left
+      // ACTIVE with ZERO live bindings, permanently (nothing later self-heals it for the local
+      // provider; DingTalk only self-heals via the next resync's own already_linked write, which
+      // this PR's Finding-A fix now correctly gates on the account still being present/active).
+      const org = `${NS}_org_f3race`
+      const userId = await seedUser('f3race')
+      const integrationId = await seedIntegration(org, 'f3race')
+      const dingtalkAccount = await seedAccount(integrationId, 'f3race')
+
+      await bindDirectoryAccount(dingtalkAccount, { localUserRef: userId, adminUserId, enableDingTalkGrant: false })
+      const localAccount = await createLocalAccount({ orgId: org, localUserId: userId, name: 'F3-race Local', email: null, mobile: null, title: null })
+      expect(await membershipRow(userId, org)).toEqual({ is_active: true })
+
+      // Fire both deactivation-triggering calls CONCURRENTLY — each opens its OWN transaction/
+      // connection (`transaction()` acquires a fresh pool connection per call), so this is a
+      // genuine two-transaction race, not a sequential simulation.
+      await Promise.all([
+        unbindDirectoryAccount(dingtalkAccount, { adminUserId }),
+        archiveLocalAccount(org, localAccount.id),
+      ])
+
+      // Both bindings are now gone; the membership MUST be deactivated — not stuck active with
+      // zero bindings (the write-skew failure mode this test targets).
+      expect(await membershipRow(userId, org)).toEqual({ is_active: false })
+
+      const linkRow = await query<{ link_status: string }>(
+        `SELECT link_status FROM directory_account_links WHERE directory_account_id = $1`,
+        [dingtalkAccount],
+      )
+      expect(linkRow.rows[0]?.link_status).toBe('unmatched')
+      const localAccountRow = await query<{ is_active: boolean }>(
+        `SELECT is_active FROM directory_accounts WHERE id = $1`,
+        [localAccount.id],
+      )
+      expect(localAccountRow.rows[0]?.is_active).toBe(false)
+    })
+  })
+
   describe('local-provider bind/deactivate (createLocalAccount / archiveLocalAccount)', () => {
     it('createLocalAccount binds an existing user; archiveLocalAccount deactivates their last local binding', async () => {
       const org = `${NS}_org_local`

--- a/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts
@@ -1,0 +1,246 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import crypto from 'node:crypto'
+import { query } from '../../src/db/pg'
+import { bindDirectoryAccount, unbindDirectoryAccount } from '../../src/directory/directory-sync'
+import { createLocalAccount, archiveLocalAccount } from '../../src/directory/local-directory-org'
+
+/**
+ * W4-PRE-1b (owner CHANGES_REQUESTED on the W4 re-ratify PR #4522, 2026-07-21): full
+ * `user_orgs` LIFECYCLE — bind/auto-match writers (item A) and org-scoped safe-deactivation
+ * writers (item B), exercised against a real Postgres via the ACTUAL service functions
+ * (`bindDirectoryAccount` / `unbindDirectoryAccount` / `createLocalAccount` /
+ * `archiveLocalAccount`), matching the #4521 precedent of driving production write functions
+ * directly rather than reimplementing their SQL in the test.
+ *
+ * Owner-named test cases covered here:
+ *  F1 bind an existing user → membership row present (same transaction; failure-injection
+ *     rollback leg proves atomicity)
+ *  F2 last unbind → deactivated
+ *  F3 double binding, unbind one → the other keeps membership ACTIVE
+ *  F4 A→B org migration → old org deactivated + new org established
+ *
+ * (A same-call "rebind displacement" scenario — one `bindDirectoryAccount` call reassigning an
+ * already-DingTalk-linked account from user A straight to user B — was investigated and is NOT
+ * exercised here: it is empirically UNREACHABLE for DingTalk accounts, because
+ * `applyDirectoryAccountBindInTransaction`'s pre-existing identity-conflict guard throws
+ * "DingTalk account is already bound to another local user" before the link write is ever
+ * reached — proven by running exactly that call sequence against this DB. The prior-holder
+ * capture + deactivate code added for this case is retained as defense-in-depth; see the PR
+ * body's deviations section for the full finding.)
+ *
+ * And local-provider coverage (item A/B's OTHER writer pair, `local-directory-org.ts`):
+ * createLocalAccount binds an existing user; archiveLocalAccount deactivates their membership
+ * when it was their last local binding in the org.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const RUN = crypto.randomBytes(4).toString('hex')
+const NS = `w4pre1blife${TS}${RUN}`
+
+describeIfDatabase('W4-PRE-1b — user_orgs lifecycle: bind/unbind/rebind/local (real DB)', () => {
+  const integrationIds: string[] = []
+  const userIds: string[] = []
+  const adminUserId = `${NS}-admin`
+
+  async function seedUser(tag: string): Promise<string> {
+    const id = `${NS}-u-${tag}-${crypto.randomBytes(3).toString('hex')}`
+    await query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $3, 'Fixture', 'x', 'user', '[]'::jsonb, true, false, NOW(), NOW())`,
+      [id, `${id}@example.test`, id],
+    )
+    userIds.push(id)
+    return id
+  }
+
+  async function seedIntegration(org: string, tag: string): Promise<string> {
+    const id = (
+      await query<{ id: string }>(
+        `INSERT INTO directory_integrations (org_id, name, corp_id, provider, status)
+         VALUES ($1, $2, $3, 'dingtalk', 'active') RETURNING id::text AS id`,
+        [org, `${NS}-int-${tag}`, `${NS}-corp-${tag}`],
+      )
+    ).rows[0].id
+    integrationIds.push(id)
+    return id
+  }
+
+  async function seedAccount(integrationId: string, tag: string): Promise<string> {
+    const external = `${NS}-ext-${tag}`
+    return (
+      await query<{ id: string }>(
+        `INSERT INTO directory_accounts (integration_id, provider, corp_id, external_user_id, union_id, open_id, external_key, name, is_active)
+         VALUES ($1, 'dingtalk', 'corp', $2, $3, $4, $5, 'Fixture', true) RETURNING id::text AS id`,
+        [integrationId, external, `${NS}-union-${tag}`, `${NS}-open-${tag}`, external],
+      )
+    ).rows[0].id
+  }
+
+  async function membershipRow(userId: string, orgId: string): Promise<{ is_active: boolean } | undefined> {
+    const rows = await query<{ is_active: boolean }>(
+      `SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`,
+      [userId, orgId],
+    )
+    return rows.rows[0]
+  }
+
+  afterAll(async () => {
+    if (userIds.length) {
+      await query(`DELETE FROM directory_account_departments WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = ANY($1::uuid[]))`, [integrationIds])
+      await query(`DELETE FROM user_external_identities WHERE local_user_id = ANY($1::text[])`, [userIds])
+      await query(`DELETE FROM directory_account_links WHERE local_user_id = ANY($1::text[])`, [userIds])
+      await query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [userIds])
+      await query(`DELETE FROM users WHERE id = ANY($1::text[])`, [userIds])
+    }
+    if (integrationIds.length) {
+      await query(`DELETE FROM directory_accounts WHERE integration_id = ANY($1::uuid[])`, [integrationIds])
+      await query(`DELETE FROM directory_integrations WHERE id = ANY($1::uuid[])`, [integrationIds])
+    }
+  })
+
+  describe('F1 — bind an existing user', () => {
+    it('bindDirectoryAccount upserts an ACTIVE user_orgs row in the same transaction', async () => {
+      const org = `${NS}_org_f1`
+      const userId = await seedUser('f1')
+      const integrationId = await seedIntegration(org, 'f1')
+      const accountId = await seedAccount(integrationId, 'f1')
+
+      const result = await bindDirectoryAccount(accountId, { localUserRef: userId, adminUserId, enableDingTalkGrant: false })
+      expect(result.previousLocalUser).toBeNull()
+
+      const row = await membershipRow(userId, org)
+      expect(row).toEqual({ is_active: true })
+    })
+
+    it('failure injection: a user_orgs write failure rolls back the whole bind (no link commit)', async () => {
+      const org = `${NS}_org_f1fail`
+      const userId = await seedUser('f1fail')
+      const integrationId = await seedIntegration(org, 'f1fail')
+      const accountId = await seedAccount(integrationId, 'f1fail')
+
+      const fnName = `w4pre1b_fail_user_orgs_bind_${RUN}`
+      await query(`CREATE OR REPLACE FUNCTION ${fnName}() RETURNS trigger AS $fn$
+        BEGIN
+          RAISE EXCEPTION 'W4-PRE-1b injected bind user_orgs failure' USING ERRCODE = 'P0001';
+        END $fn$ LANGUAGE plpgsql`)
+      await query(`CREATE TRIGGER ${fnName}_trg BEFORE INSERT ON user_orgs
+        FOR EACH ROW WHEN (NEW.org_id = '${org}') EXECUTE FUNCTION ${fnName}()`)
+
+      try {
+        await expect(
+          bindDirectoryAccount(accountId, { localUserRef: userId, adminUserId, enableDingTalkGrant: false }),
+        ).rejects.toThrow()
+
+        const row = await membershipRow(userId, org)
+        expect(row).toBeUndefined()
+        const linkRows = await query(`SELECT link_status FROM directory_account_links WHERE directory_account_id = $1`, [accountId])
+        expect(linkRows.rows).toEqual([])
+      } finally {
+        await query(`DROP TRIGGER IF EXISTS ${fnName}_trg ON user_orgs`).catch(() => {})
+        await query(`DROP FUNCTION IF EXISTS ${fnName}()`).catch(() => {})
+      }
+    })
+  })
+
+  describe('F2 — last unbind deactivates', () => {
+    it('unbindDirectoryAccount flips user_orgs.is_active to false when it was the only binding', async () => {
+      const org = `${NS}_org_f2`
+      const userId = await seedUser('f2')
+      const integrationId = await seedIntegration(org, 'f2')
+      const accountId = await seedAccount(integrationId, 'f2')
+
+      await bindDirectoryAccount(accountId, { localUserRef: userId, adminUserId, enableDingTalkGrant: false })
+      expect(await membershipRow(userId, org)).toEqual({ is_active: true })
+
+      await unbindDirectoryAccount(accountId, { adminUserId })
+      expect(await membershipRow(userId, org)).toEqual({ is_active: false })
+    })
+  })
+
+  describe('F3 — double binding, unbind one, other stays active', () => {
+    it('unbinding the DingTalk account when a LOCAL account is also linked keeps the membership active', async () => {
+      const org = `${NS}_org_f3`
+      const userId = await seedUser('f3')
+      const integrationId = await seedIntegration(org, 'f3')
+      const dingtalkAccount = await seedAccount(integrationId, 'f3')
+
+      // Two DIFFERENT directory accounts (different providers) for the SAME user in the SAME
+      // org — legal (the "already linked to another account" guard in
+      // `applyDirectoryAccountBindInTransaction` is scoped to `a.provider = $1`, i.e. one
+      // DingTalk identity per user, not one directory account of ANY kind per user). This is
+      // also the realistic shape of "double binding": a DingTalk account from directory sync
+      // PLUS a local-provider account from the local-org admin surface.
+      await bindDirectoryAccount(dingtalkAccount, { localUserRef: userId, adminUserId, enableDingTalkGrant: false })
+      const localAccount = await createLocalAccount({ orgId: org, localUserId: userId, name: 'F3 Local', email: null, mobile: null, title: null })
+
+      expect(await membershipRow(userId, org)).toEqual({ is_active: true })
+
+      await unbindDirectoryAccount(dingtalkAccount, { adminUserId })
+
+      // The local account (still linked+active) keeps the membership ACTIVE — the org-scoped
+      // sibling check must see it (it spans BOTH `local` and `dingtalk` directory accounts).
+      expect(await membershipRow(userId, org)).toEqual({ is_active: true })
+      expect(localAccount.localUserId).toBe(userId)
+    })
+  })
+
+  describe('F4 — A to B org migration', () => {
+    it('unbind in org A (deactivate) + bind a new account in org B (activate) for the same user', async () => {
+      const orgA = `${NS}_org_f4a`
+      const orgB = `${NS}_org_f4b`
+      const userId = await seedUser('f4')
+      const intA = await seedIntegration(orgA, 'f4a')
+      const intB = await seedIntegration(orgB, 'f4b')
+      const accountA = await seedAccount(intA, 'f4a')
+      const accountB = await seedAccount(intB, 'f4b')
+
+      await bindDirectoryAccount(accountA, { localUserRef: userId, adminUserId, enableDingTalkGrant: false })
+      expect(await membershipRow(userId, orgA)).toEqual({ is_active: true })
+      expect(await membershipRow(userId, orgB)).toBeUndefined()
+
+      await unbindDirectoryAccount(accountA, { adminUserId })
+      await bindDirectoryAccount(accountB, { localUserRef: userId, adminUserId, enableDingTalkGrant: false })
+
+      expect(await membershipRow(userId, orgA)).toEqual({ is_active: false })
+      expect(await membershipRow(userId, orgB)).toEqual({ is_active: true })
+    })
+  })
+
+  describe('same-account rebind displacement — investigated, confirmed unreachable for DingTalk', () => {
+    it('bindDirectoryAccount refuses to reassign an already-linked DingTalk account to a different user (pre-existing identity guard fires first)', async () => {
+      const org = `${NS}_org_rebind`
+      const userA = await seedUser('rebindA')
+      const userB = await seedUser('rebindB')
+      const integrationId = await seedIntegration(org, 'rebind')
+      const accountId = await seedAccount(integrationId, 'rebind')
+
+      await bindDirectoryAccount(accountId, { localUserRef: userA, adminUserId, enableDingTalkGrant: false })
+      expect(await membershipRow(userA, org)).toEqual({ is_active: true })
+
+      // This is NOT the displacement path — it documents that the pre-existing
+      // `user_external_identities` conflict guard (unrelated to this ticket) makes the
+      // "single-call reassignment" scenario unreachable: the throw happens BEFORE the link
+      // write, so userA's membership is untouched, exactly as if the second call never happened.
+      await expect(
+        bindDirectoryAccount(accountId, { localUserRef: userB, adminUserId, enableDingTalkGrant: false }),
+      ).rejects.toThrow('DingTalk account is already bound to another local user')
+
+      expect(await membershipRow(userA, org)).toEqual({ is_active: true })
+      expect(await membershipRow(userB, org)).toBeUndefined()
+    })
+  })
+
+  describe('local-provider bind/deactivate (createLocalAccount / archiveLocalAccount)', () => {
+    it('createLocalAccount binds an existing user; archiveLocalAccount deactivates their last local binding', async () => {
+      const org = `${NS}_org_local`
+      const userId = await seedUser('local')
+
+      const created = await createLocalAccount({ orgId: org, localUserId: userId, name: 'Local Fixture', email: null, mobile: null, title: null })
+      expect(await membershipRow(userId, org)).toEqual({ is_active: true })
+
+      await archiveLocalAccount(org, created.id)
+      expect(await membershipRow(userId, org)).toEqual({ is_active: false })
+    })
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-sync-automatch.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-sync-automatch.db.test.ts
@@ -1,8 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 /**
- * W4-PRE-1b item A — the THIRD bind-shaped writer named by the owner ("手工 bind 路由、
- * auto-match、rebind"): the directory-sync SYNC LOOP's `external_identity` re-match write
+ * W4-PRE-1b item A — the THIRD bind-shaped writer in this line's own inventory (manual bind
+ * route, sync-loop auto-match, same-account rebind — this PR's grouping, not owner verbatim
+ * text): the directory-sync SYNC LOOP's `external_identity` re-match write
  * (`syncDirectoryIntegration`, directory-sync.ts ~L3759-3767). Unlike `bindDirectoryAccount`
  * (manual bind) and `admitDirectoryAccountUser`/auto-admit (new user), this write confirms an
  * ALREADY-linked identity on every resync without going through
@@ -155,5 +156,156 @@ describeIfDatabase('W4-PRE-1b item A — sync-loop external_identity auto-match 
 
     const afterPass2 = await query<{ is_active: boolean }>(`SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`, [userId, orgId])
     expect(afterPass2.rows).toEqual([{ is_active: true }])
+  }, 30_000)
+})
+
+/**
+ * #4526 review finding (P1) — regression for the SAME write site tested above
+ * (`linkStatus === 'linked' && localUserId`, directory-sync.ts ~L3773). This loop iterates ALL
+ * accounts ever seen for the integration, not just this run's directory batch — including an
+ * account the DT-OPS-01 sweep (same transaction, runs first) just marked departed
+ * (`directory_accounts.is_active = false`). `resolveDirectoryIdentityMatch` short-circuits to
+ * `'already_linked'` for ANY existing `link_status='linked'` row regardless of the account's own
+ * `is_active`, so — before this fix — a departed-but-still-`linked` account's steady-state
+ * re-confirm would silently flip a deliberately-inactive `user_orgs` row back to ACTIVE on every
+ * subsequent resync, reopening the exact stale-access half of the owner's original P1 finding via
+ * this line's own new writer. The fix additionally gates the write on `account.is_active`.
+ */
+describeIfDatabase('W4-PRE-1b item A regression (#4526 P1) — a swept (inactive) linked account must not resurrect user_orgs', () => {
+  const DEPT2 = `w4pre1bam2-dept-${TS}`
+  const USER_EXT_ID2 = `w4pre1bam2-u1-${TS}`
+  let integrationId2 = ''
+  let orgId2 = ''
+  let userId2 = ''
+  let userPresentInDirectory = true
+
+  beforeAll(() => {
+    // Reconfigures the SAME shared client mocks the block above installed, scoped to THIS test's
+    // department/user id so the two blocks never collide (tests in one file run sequentially).
+    // `userPresentInDirectory` lets a later pass simulate the user disappearing from the
+    // directory (the real-world trigger for the DT-OPS-01 sweep) without a second live call.
+    clientMocks.listDingTalkDepartments.mockImplementation(async (_token: string, parentId: string) =>
+      parentId === '1' ? [{ id: DEPT2, parentId: '1', name: 'W4PRE1B Automatch Regression', order: 0, source: {} }] : [],
+    )
+    clientMocks.getDingTalkDepartmentDetail.mockResolvedValue({ deptManagerUserIdList: [] })
+    clientMocks.listDingTalkDepartmentUsers.mockImplementation(async (_token: string, deptId: string) =>
+      deptId === DEPT2 && userPresentInDirectory
+        ? { users: [{ userId: USER_EXT_ID2, name: 'Regression One', departmentIds: [DEPT2], source: {} }], nextCursor: null, hasMore: false }
+        : { users: [], nextCursor: null, hasMore: false },
+    )
+    clientMocks.getDingTalkUserDetail.mockImplementation(async (_token: string, userId: string) => ({
+      userId,
+      name: 'Regression One',
+      unionId: `w4pre1bam2-union-${TS}`,
+      openId: `w4pre1bam2-open-${TS}`,
+      email: `w4pre1bam2-${TS}@example.test`,
+      mobile: undefined,
+      departmentIds: [DEPT2],
+      source: {},
+    }))
+  })
+
+  afterAll(async () => {
+    if (userId2) {
+      await query(`DELETE FROM user_invites WHERE user_id = $1`, [userId2])
+      await query(`DELETE FROM user_external_auth_grants WHERE local_user_id = $1`, [userId2])
+      await query(`DELETE FROM user_external_identities WHERE local_user_id = $1`, [userId2])
+      await query(`DELETE FROM user_orgs WHERE user_id = $1`, [userId2])
+    }
+    if (integrationId2) {
+      await query(
+        `DELETE FROM directory_account_departments WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = $1)`,
+        [integrationId2],
+      )
+      await query(
+        `DELETE FROM directory_account_links WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = $1)`,
+        [integrationId2],
+      )
+      await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId2])
+      await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId2])
+      await query(`DELETE FROM directory_sync_runs WHERE integration_id = $1`, [integrationId2])
+      await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId2])
+    }
+    if (userId2) await query(`DELETE FROM users WHERE id = $1`, [userId2])
+  })
+
+  it('account swept inactive (missing from the directory) does not reactivate an already-deactivated user_orgs row on the SAME sync run', async () => {
+    const integration = await createDirectoryIntegration({
+      name: `w4pre1bam2-${TS}`,
+      corpId: `w4pre1bam2-corp-${TS}`,
+      appKey: `w4pre1bam2-appkey-${TS}`,
+      appSecret: 'w4pre1bam2-secret',
+      admissionMode: 'auto_for_scoped_departments',
+      admissionDepartmentIds: [DEPT2],
+    })
+    integrationId2 = integration.id
+    orgId2 = integration.orgId
+
+    // Pass 1: user present → auto-admitted with an ACTIVE membership (same as the block above).
+    await syncDirectoryIntegration(integrationId2, 'system:w4pre1b-am2', 'manual')
+    const linked = await query<{ local_user_id: string; link_status: string }>(
+      `SELECT l.local_user_id, l.link_status
+       FROM directory_account_links l
+       JOIN directory_accounts a ON a.id = l.directory_account_id
+       WHERE a.integration_id = $1 AND a.external_user_id = $2`,
+      [integrationId2, USER_EXT_ID2],
+    )
+    userId2 = linked.rows[0].local_user_id
+    expect(userId2).toBeTruthy()
+    expect(linked.rows[0].link_status).toBe('linked')
+    expect((await query<{ is_active: boolean }>(`SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`, [userId2, orgId2])).rows).toEqual([{ is_active: true }])
+
+    // Deactivate the membership directly (stands in for whatever admin/system action already
+    // closed it — the LINK ROW STAYS 'linked', matching exactly the state the DT-OPS-01 sweep
+    // itself leaves behind; see this file's item-B open-gap note in directory-sync.ts).
+    await query(`UPDATE user_orgs SET is_active = false WHERE user_id = $1 AND org_id = $2`, [userId2, orgId2])
+
+    // Pass 2: the user no longer appears in the mocked directory response — the account's
+    // `last_seen_at` from pass 1 is now stale, so THIS sync's DT-OPS-01 sweep marks
+    // `directory_accounts.is_active = false` in the SAME transaction as the identity-match loop
+    // below it. The link row is untouched by the sweep and remains 'linked'.
+    userPresentInDirectory = false
+    await syncDirectoryIntegration(integrationId2, 'system:w4pre1b-am2', 'manual')
+
+    const acctAfterSweep = await query<{ is_active: boolean }>(
+      `SELECT is_active FROM directory_accounts WHERE integration_id = $1 AND external_user_id = $2`,
+      [integrationId2, USER_EXT_ID2],
+    )
+    expect(acctAfterSweep.rows).toEqual([{ is_active: false }])
+    const linkAfterSweep = await query<{ link_status: string }>(
+      `SELECT l.link_status
+       FROM directory_account_links l
+       JOIN directory_accounts a ON a.id = l.directory_account_id
+       WHERE a.integration_id = $1 AND a.external_user_id = $2`,
+      [integrationId2, USER_EXT_ID2],
+    )
+    expect(linkAfterSweep.rows[0].link_status).toBe('linked')
+
+    // THE FIX under test: the `already_linked` steady-state re-confirm must NOT resurrect
+    // `user_orgs` for an account that is `linked` but no longer `is_active`.
+    const membershipAfterSweep = await query<{ is_active: boolean }>(
+      `SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`,
+      [userId2, orgId2],
+    )
+    expect(membershipAfterSweep.rows).toEqual([{ is_active: false }])
+  }, 30_000)
+
+  it('positive control: the user returning to the directory (account re-activated) DOES get the steady-state re-confirm', async () => {
+    // Continues from the prior test's end state (same integration/user, still `is_active=false`
+    // on both the account and the membership) — the user reappears in the mocked directory.
+    userPresentInDirectory = true
+    await syncDirectoryIntegration(integrationId2, 'system:w4pre1b-am2', 'manual')
+
+    const acctAfterReturn = await query<{ is_active: boolean }>(
+      `SELECT is_active FROM directory_accounts WHERE integration_id = $1 AND external_user_id = $2`,
+      [integrationId2, USER_EXT_ID2],
+    )
+    expect(acctAfterReturn.rows).toEqual([{ is_active: true }])
+
+    const membershipAfterReturn = await query<{ is_active: boolean }>(
+      `SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`,
+      [userId2, orgId2],
+    )
+    expect(membershipAfterReturn.rows).toEqual([{ is_active: true }])
   }, 30_000)
 })

--- a/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-sync-automatch.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1b-user-orgs-sync-automatch.db.test.ts
@@ -1,0 +1,159 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+/**
+ * W4-PRE-1b item A — the THIRD bind-shaped writer named by the owner ("手工 bind 路由、
+ * auto-match、rebind"): the directory-sync SYNC LOOP's `external_identity` re-match write
+ * (`syncDirectoryIntegration`, directory-sync.ts ~L3759-3767). Unlike `bindDirectoryAccount`
+ * (manual bind) and `admitDirectoryAccountUser`/auto-admit (new user), this write confirms an
+ * ALREADY-linked identity on every resync without going through
+ * `applyDirectoryAccountBindInTransaction` — it needed its OWN upsert call.
+ *
+ * Harness follows the established `directory-sync-orchestration.db.test.ts` R1-L4 pattern
+ * (DingTalk HTTP client mocked; the REAL `syncDirectoryIntegration` runs against real Postgres).
+ * Kept intentionally minimal (no heartbeat/pull-gate machinery — sequential awaited syncs only).
+ *
+ * Scenario: sync once (auto-admits the user — this ALSO exercises item A's other writer and
+ * incidentally creates a user_orgs row, which would make a second identical assertion
+ * meaningless). `resolveDirectoryIdentityMatch` short-circuits to `'already_linked'` (NOT
+ * `'external_identity'`) whenever the existing `directory_account_links` row is already
+ * `link_status='linked'` — so to force a GENUINE `external_identity` re-match on pass 2 (not
+ * just the `'already_linked'` steady-state, which the write site's `linkStatus === 'linked'`
+ * gate also correctly covers, but that is not this test's target), the link row itself (not
+ * just user_orgs) is deleted between syncs while `user_external_identities` — the actual
+ * source `resolveDirectoryIdentityMatch` re-derives the match from — is left intact. This
+ * reproduces the exact pre-W4-PRE-1b state the owner described (an already-identity-linked
+ * user with no membership row) via the specific `external_identity` branch.
+ */
+const clientMocks = vi.hoisted(() => ({
+  fetchDingTalkAppAccessToken: vi.fn(),
+  listDingTalkDepartments: vi.fn(),
+  getDingTalkDepartmentDetail: vi.fn(),
+  listDingTalkDepartmentUsers: vi.fn(),
+  getDingTalkUserDetail: vi.fn(),
+}))
+
+vi.mock('../../src/integrations/dingtalk/client', () => ({
+  fetchDingTalkAppAccessToken: clientMocks.fetchDingTalkAppAccessToken,
+  listDingTalkDepartments: clientMocks.listDingTalkDepartments,
+  getDingTalkDepartmentDetail: clientMocks.getDingTalkDepartmentDetail,
+  listDingTalkDepartmentUsers: clientMocks.listDingTalkDepartmentUsers,
+  getDingTalkUserDetail: clientMocks.getDingTalkUserDetail,
+}))
+
+import { query } from '../../src/db/pg'
+import { createDirectoryIntegration, syncDirectoryIntegration } from '../../src/directory/directory-sync'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const DEPT = `w4pre1bam-dept-${TS}`
+const USER_EXT_ID = `w4pre1bam-u1-${TS}`
+
+beforeAll(() => {
+  clientMocks.fetchDingTalkAppAccessToken.mockResolvedValue('w4pre1bam-token')
+  clientMocks.listDingTalkDepartments.mockImplementation(async (_token: string, parentId: string) =>
+    parentId === '1' ? [{ id: DEPT, parentId: '1', name: 'W4PRE1B Automatch', order: 0, source: {} }] : [],
+  )
+  clientMocks.getDingTalkDepartmentDetail.mockResolvedValue({ deptManagerUserIdList: [] })
+  clientMocks.listDingTalkDepartmentUsers.mockImplementation(async (_token: string, deptId: string) =>
+    deptId === DEPT
+      ? { users: [{ userId: USER_EXT_ID, name: 'AutoMatch One', departmentIds: [DEPT], source: {} }], nextCursor: null, hasMore: false }
+      : { users: [], nextCursor: null, hasMore: false },
+  )
+  clientMocks.getDingTalkUserDetail.mockImplementation(async (_token: string, userId: string) => ({
+    userId,
+    name: 'AutoMatch One',
+    unionId: `w4pre1bam-union-${TS}`,
+    openId: `w4pre1bam-open-${TS}`,
+    email: `w4pre1bam-${TS}@example.test`,
+    mobile: undefined,
+    departmentIds: [DEPT],
+    source: {},
+  }))
+})
+
+describeIfDatabase('W4-PRE-1b item A — sync-loop external_identity auto-match writes user_orgs (real DB)', () => {
+  let integrationId = ''
+  let orgId = ''
+  let userId = ''
+
+  afterAll(async () => {
+    if (userId) {
+      await query(`DELETE FROM user_invites WHERE user_id = $1`, [userId])
+      await query(`DELETE FROM user_external_auth_grants WHERE local_user_id = $1`, [userId])
+      await query(`DELETE FROM user_external_identities WHERE local_user_id = $1`, [userId])
+      await query(`DELETE FROM user_orgs WHERE user_id = $1`, [userId])
+    }
+    if (integrationId) {
+      await query(
+        `DELETE FROM directory_account_departments WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = $1)`,
+        [integrationId],
+      )
+      await query(
+        `DELETE FROM directory_account_links WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = $1)`,
+        [integrationId],
+      )
+      await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+      await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+      await query(`DELETE FROM directory_sync_runs WHERE integration_id = $1`, [integrationId])
+      await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+    }
+    if (userId) await query(`DELETE FROM users WHERE id = $1`, [userId])
+  })
+
+  it('pass 1 (auto-admit) creates the membership; deleting it and re-syncing (external_identity match) re-creates it', async () => {
+    const integration = await createDirectoryIntegration({
+      name: `w4pre1bam-${TS}`,
+      corpId: `w4pre1bam-corp-${TS}`,
+      appKey: `w4pre1bam-appkey-${TS}`,
+      appSecret: 'w4pre1bam-secret',
+      admissionMode: 'auto_for_scoped_departments',
+      admissionDepartmentIds: [DEPT],
+    })
+    integrationId = integration.id
+    orgId = integration.orgId
+
+    await syncDirectoryIntegration(integrationId, 'system:w4pre1b-am', 'manual')
+
+    const linked = await query<{ local_user_id: string; match_strategy: string; link_status: string }>(
+      `SELECT l.local_user_id, l.match_strategy, l.link_status
+       FROM directory_account_links l
+       JOIN directory_accounts a ON a.id = l.directory_account_id
+       WHERE a.integration_id = $1 AND a.external_user_id = $2`,
+      [integrationId, USER_EXT_ID],
+    )
+    expect(linked.rows).toHaveLength(1)
+    expect(linked.rows[0].link_status).toBe('linked')
+    expect(linked.rows[0].match_strategy).toBe('auto_admit')
+    userId = linked.rows[0].local_user_id
+    expect(userId).toBeTruthy()
+
+    const afterPass1 = await query<{ is_active: boolean }>(`SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`, [userId, orgId])
+    expect(afterPass1.rows).toEqual([{ is_active: true }])
+
+    // Simulate the pre-W4-PRE-1b state: an already-identity-linked user with NO membership row
+    // AND no link row (forces `resolveDirectoryIdentityMatch` past the `'already_linked'`
+    // short-circuit into a genuine `external_identity` re-match — see file doc-comment).
+    // `user_external_identities` is left untouched — that is the re-match's actual source.
+    await query(`DELETE FROM user_orgs WHERE user_id = $1 AND org_id = $2`, [userId, orgId])
+    await query(
+      `DELETE FROM directory_account_links WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = $1)`,
+      [integrationId],
+    )
+    expect((await query(`SELECT 1 FROM user_orgs WHERE user_id = $1 AND org_id = $2`, [userId, orgId])).rows).toEqual([])
+
+    await syncDirectoryIntegration(integrationId, 'system:w4pre1b-am', 'manual')
+
+    const linkedAfterResync = await query<{ match_strategy: string }>(
+      `SELECT l.match_strategy
+       FROM directory_account_links l
+       JOIN directory_accounts a ON a.id = l.directory_account_id
+       WHERE a.integration_id = $1 AND a.external_user_id = $2`,
+      [integrationId, USER_EXT_ID],
+    )
+    // Confirms pass 2 took the auto-match branch under test, not a second auto_admit.
+    expect(linkedAfterResync.rows[0].match_strategy).toBe('external_identity')
+
+    const afterPass2 = await query<{ is_active: boolean }>(`SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`, [userId, orgId])
+    expect(afterPass2.rows).toEqual([{ is_active: true }])
+  }, 30_000)
+})

--- a/packages/core-backend/tests/integration/dingtalk-group-destination-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-group-destination-routes.api.test.ts
@@ -205,7 +205,11 @@ describe('DingTalk group destination routes', () => {
       .expect(200)
 
     expect(query).toHaveBeenCalledWith(
-      'SELECT 1 FROM user_orgs WHERE user_id = $1 AND org_id = $2 AND is_active = true LIMIT 1',
+      `SELECT 1
+     FROM user_orgs uo
+     JOIN users u ON u.id = uo.user_id
+     WHERE uo.user_id = $1 AND uo.org_id = $2 AND uo.is_active = true AND u.is_active = true
+     LIMIT 1`,
       ['user_1', 'org_1'],
     )
     expect(service.listDestinations).toHaveBeenCalledWith('user_1', undefined, 'org_1')
@@ -325,7 +329,11 @@ describe('DingTalk group destination routes', () => {
       .expect(200)
 
     expect(query).toHaveBeenCalledWith(
-      'SELECT 1 FROM user_orgs WHERE user_id = $1 AND org_id = $2 AND is_active = true LIMIT 1',
+      `SELECT 1
+     FROM user_orgs uo
+     JOIN users u ON u.id = uo.user_id
+     WHERE uo.user_id = $1 AND uo.org_id = $2 AND uo.is_active = true AND u.is_active = true
+     LIMIT 1`,
       ['user_1', 'org_1'],
     )
     expect(service.listDeliveries).toHaveBeenCalledWith(DESTINATION_ID, 20)

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -1320,6 +1320,10 @@ describe('AutomationExecutor', () => {
         expect(sql).toContain('org_id IS NULL AND created_by = $3')
         expect(sql).toContain('FROM user_orgs uo')
         expect(sql).toContain('uo.org_id = dg.org_id')
+        // #4526 review fix: a deactivated platform account must not keep org-scoped DingTalk
+        // destination access via a still-active user_orgs row — dual is_active filter.
+        expect(sql).toContain('JOIN users u ON u.id = uo.user_id')
+        expect(sql).toContain('u.is_active = true')
         expect(params).toEqual([['dt_other_sheet'], 'sheet_1', 'user_1'])
       }
       return { rows: [], rowCount: 0 }

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -909,9 +909,16 @@ describe('bindDirectoryAccount', () => {
     // deactivates the previously-linked user's user_orgs row (org-scoped sibling check) in the
     // SAME transaction — SQL-text-inspecting closure, matching this file's own established
     // precedent for the analogous bind-side change above.
+    //
+    // #4526 review fix: the previously-linked-user read moved INSIDE the transaction (`FOR
+    // UPDATE OF l` locks the `directory_account_links` row — closes a stale-read race; see the
+    // function's doc comment) — it is now served by `clientQuery`, not the outer `pgMocks.query`.
     const clientQuery = vi.fn(async (sql: string) => {
       if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
         return { rows: [{ org_id: 'default' }] }
+      }
+      if (String(sql).includes('FOR UPDATE OF l')) {
+        return { rows: [{ local_user_id: 'user-1', local_user_email: 'alpha@example.com', local_user_name: 'Alpha' }] }
       }
       return { rows: [] }
     })
@@ -930,13 +937,6 @@ describe('bindDirectoryAccount', () => {
           name: '林岚',
           email: null,
           mobile: '13900001234',
-        }],
-      })
-      .mockResolvedValueOnce({
-        rows: [{
-          local_user_id: 'user-1',
-          local_user_email: 'alpha@example.com',
-          local_user_name: 'Alpha',
         }],
       })
       .mockResolvedValueOnce({
@@ -1003,10 +1003,14 @@ describe('bindDirectoryAccount', () => {
   })
 
   it('can disable the DingTalk grant while unbinding', async () => {
-    // W4-PRE-1b item B: see the analogous comment on the previous test.
+    // W4-PRE-1b item B: see the analogous comment on the previous test. #4526 review fix: see
+    // the analogous `FOR UPDATE OF l` note on the previous test too.
     const clientQuery = vi.fn(async (sql: string) => {
       if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
         return { rows: [{ org_id: 'default' }] }
+      }
+      if (String(sql).includes('FOR UPDATE OF l')) {
+        return { rows: [{ local_user_id: 'user-1', local_user_email: 'alpha@example.com', local_user_name: 'Alpha' }] }
       }
       return { rows: [] }
     })
@@ -1025,13 +1029,6 @@ describe('bindDirectoryAccount', () => {
           name: '林岚',
           email: null,
           mobile: '13900001234',
-        }],
-      })
-      .mockResolvedValueOnce({
-        rows: [{
-          local_user_id: 'user-1',
-          local_user_email: 'alpha@example.com',
-          local_user_name: 'Alpha',
         }],
       })
       .mockResolvedValueOnce({
@@ -1084,6 +1081,11 @@ describe('bindDirectoryAccount', () => {
       if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
         return { rows: [{ org_id: 'default' }] }
       }
+      // #4526 review fix: the previously-linked-user read moved INSIDE the transaction
+      // (`FOR UPDATE OF l`) — served here now, not via the outer `pgMocks.query`.
+      if (String(sql).includes('FOR UPDATE OF l')) {
+        return { rows: [{ local_user_id: 'user-1', local_user_email: 'alpha@example.com', local_user_name: 'Alpha' }] }
+      }
       return { rows: [] }
     })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
@@ -1104,7 +1106,6 @@ describe('bindDirectoryAccount', () => {
           mobile: null,
         }],
       })
-      .mockResolvedValueOnce({ rows: [{ local_user_id: 'user-1', local_user_email: 'alpha@example.com', local_user_name: 'Alpha' }] })
       .mockResolvedValueOnce({
         rows: [{
           integration_id: 'dir-1',

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -54,7 +54,21 @@ describe('bindDirectoryAccount', () => {
   })
 
   it('writes an auth-compatible DingTalk identity and linked directory mapping', async () => {
-    const clientQuery = vi.fn()
+    // W4-PRE-1b: applyDirectoryAccountBindInTransaction now ALSO resolves the account's org
+    // (`SELECT org_id FROM directory_integrations`), captures any PRIOR holder of this account
+    // (`SELECT local_user_id FROM directory_account_links ... link_status = 'linked'`), and
+    // upserts `user_orgs` at the end — a SQL-text-inspecting closure (matching the
+    // "allows union-only pre-binding" test's existing precedent below) is robust to the added
+    // call count/order; a positional `mockResolvedValueOnce` chain is not.
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
+        return { rows: [{ org_id: 'default' }] }
+      }
+      if (/SELECT local_user_id\s+FROM directory_account_links/.test(String(sql))) {
+        return { rows: [] } // no prior holder — this is a fresh bind
+      }
+      return { rows: [] }
+    })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
     pgMocks.query
       .mockResolvedValueOnce({
@@ -115,14 +129,6 @@ describe('bindDirectoryAccount', () => {
         }],
       })
 
-    clientQuery
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-
     const result = await bindDirectoryAccount('account-1', {
       localUserRef: 'alpha@example.com',
       adminUserId: 'admin-1',
@@ -147,6 +153,11 @@ describe('bindDirectoryAccount', () => {
     expect(clientQuery).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO directory_account_links'),
       ['account-1', 'user-1', 'admin-1'],
+    )
+    // W4-PRE-1b item A: same-transaction membership upsert for the newly-bound holder.
+    expect(clientQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO user_orgs'),
+      ['user-1', 'default'],
     )
     expect(result).toMatchObject({
       account: {
@@ -816,9 +827,13 @@ describe('bindDirectoryAccount', () => {
     })
 
     const createUserCall = clientQuery.mock.calls.find((entry) => String(entry[0]).includes('INSERT INTO users'))
-    const conflictIdentityCall = clientQuery.mock.calls.find((entry) => String(entry[0]).includes('SELECT local_user_id'))
+    // W4-PRE-1b's own new prior-holder capture query ALSO starts with `SELECT local_user_id`
+    // (`... FROM directory_account_links ...`) and runs BEFORE this one — disambiguate by the
+    // table this ORIGINAL identity-conflict query actually reads.
+    const conflictIdentityCall = clientQuery.mock.calls.find((entry) => String(entry[0]).includes('FROM user_external_identities'))
     const conflictLinkCall = clientQuery.mock.calls.find((entry) => String(entry[0]).includes('JOIN directory_accounts'))
     const linkCall = clientQuery.mock.calls.find((entry) => String(entry[0]).includes('INSERT INTO directory_account_links'))
+    const membershipUpsertCall = clientQuery.mock.calls.find((entry) => String(entry[0]).includes('INSERT INTO user_orgs'))
 
     expect(createUserCall?.[1]).toEqual(expect.arrayContaining([
       null,
@@ -836,6 +851,12 @@ describe('bindDirectoryAccount', () => {
       expect.stringContaining('INSERT INTO user_external_auth_grants'),
       expect.anything(),
     )
+    // W4-PRE-1b item A: the new user created here is bound in the SAME transaction — membership
+    // upsert must still fire even though the DingTalk auth grant itself is disabled. The userId
+    // is a fresh crypto.randomUUID() generated INSIDE the function (not mock-controllable), so
+    // compare against the freshly-created user's own returned id, matching whatever createUserCall
+    // actually inserted.
+    expect(membershipUpsertCall?.[1]).toEqual([createUserCall?.[1]?.[0], 'default'])
     expect(result).toMatchObject({
       user: {
         email: null,
@@ -884,7 +905,16 @@ describe('bindDirectoryAccount', () => {
   })
 
   it('removes the bound identity, optionally disables grant, and resets the link on unbind', async () => {
-    const clientQuery = vi.fn()
+    // W4-PRE-1b item B: unbindDirectoryAccount now ALSO resolves the account's org and
+    // deactivates the previously-linked user's user_orgs row (org-scoped sibling check) in the
+    // SAME transaction — SQL-text-inspecting closure, matching this file's own established
+    // precedent for the analogous bind-side change above.
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
+        return { rows: [{ org_id: 'default' }] }
+      }
+      return { rows: [] }
+    })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
     pgMocks.query
       .mockResolvedValueOnce({
@@ -935,11 +965,6 @@ describe('bindDirectoryAccount', () => {
           department_paths: ['DingTalk CN'],
         }],
       })
-
-    clientQuery
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
 
     const result = await unbindDirectoryAccount('account-1', {
       adminUserId: 'admin-1',
@@ -958,6 +983,11 @@ describe('bindDirectoryAccount', () => {
       expect.stringContaining('INSERT INTO directory_account_links'),
       ['account-1', 'admin-1'],
     )
+    // W4-PRE-1b item B: same-transaction org-scoped deactivation of the just-unbound user.
+    expect(clientQuery).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE user_orgs'),
+      ['user-1', 'default'],
+    )
     expect(result).toMatchObject({
       account: {
         id: 'account-1',
@@ -973,7 +1003,13 @@ describe('bindDirectoryAccount', () => {
   })
 
   it('can disable the DingTalk grant while unbinding', async () => {
-    const clientQuery = vi.fn()
+    // W4-PRE-1b item B: see the analogous comment on the previous test.
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/SELECT org_id\s+FROM directory_integrations/.test(String(sql))) {
+        return { rows: [{ org_id: 'default' }] }
+      }
+      return { rows: [] }
+    })
     pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
     pgMocks.query
       .mockResolvedValueOnce({
@@ -1024,11 +1060,6 @@ describe('bindDirectoryAccount', () => {
           department_paths: ['DingTalk CN'],
         }],
       })
-
-    clientQuery
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
 
     await unbindDirectoryAccount('account-1', {
       adminUserId: 'admin-1',

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -394,6 +394,9 @@ export default defineConfig({
       'tests/integration/attendance-w4pre1b-user-orgs-backfill-migration.db.test.ts',
       'tests/integration/attendance-w4pre1b-directory-readiness-gate.db.test.ts',
       'tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts',
+      // #4526 review addition: real-DB behavioral proof for item E's api-tokens.ts dual filter
+      // (the PR's original coverage was mock-SQL-text-only).
+      'tests/integration/attendance-w4pre1b-api-tokens-org-member-access.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -382,6 +382,18 @@ export default defineConfig({
       'tests/integration/attendance-w4pre1-user-orgs-admission.db.test.ts',
       'tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts',
       'tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts',
+      // W4-PRE-1b real-DB (owner CHANGES_REQUESTED on the W4 re-ratify PR #4522, 2026-07-21):
+      // user_orgs full LIFECYCLE — bind/auto-match writers (item A), org-scoped safe-
+      // deactivation writers (item B), the real-stock backfill migration (item C), the S7-5
+      // dual is_active gate (item E), and the explicit attendanceOrgId admin-users path
+      // (item D). DATABASE_URL-gated describeIfDatabase; excluded here so the no-DB job
+      // cannot skip-green them; wired whole-file into the attendance real-DB step in
+      // plugin-tests.yml.
+      'tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts',
+      'tests/integration/attendance-w4pre1b-user-orgs-sync-automatch.db.test.ts',
+      'tests/integration/attendance-w4pre1b-user-orgs-backfill-migration.db.test.ts',
+      'tests/integration/attendance-w4pre1b-directory-readiness-gate.db.test.ts',
+      'tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
## What

W4-PRE-1b — the code slice owner ordered in the CHANGES_REQUESTED verdict on the W4 re-ratify PR #4522 (2026-07-21 comment). W4-PRE-1 (#4521 = `e20371b1a`, merged) only built the "new admission" write path. This PR closes the rest of the `user_orgs` lifecycle: bind/auto-match for **already-existing** users (item A), org-scoped safe deactivation on unbind/rebind/archive (item B), a real-stock backfill migration (item C), an explicit `attendanceOrgId` admin-users path that no longer needs a circular group/shift dependency (item D), and a dual `is_active` fix on the `user_orgs` trust points the door and a same-shape sibling gate rely on (item E).

**Not merged, not armed.** Base `main`, refs #4522 #4521.

## #4526 three-mirror review round — fixes applied (2026-07-22)

Ten findings came back on this PR (three independent reviewers, some overlapping). Disposition:

| Finding | Severity | Disposition |
|---|---|---|
| Sync-loop `already_linked` steady-state upsert can resurrect a `user_orgs` row for an account the DT-OPS-01 sweep already marked departed (this loop walks ALL accounts every sync, not just the current batch) | P1 | **Fixed** — the write now also requires `account.is_active` (gate added at the exact write site, not a broader projection filter). New real-DB regression pair (negative: swept-inactive account does not resurrect; positive control: a returning/reactivated account still gets the steady-state re-confirm). |
| DT-OPS-01 sweep (directory-side departure detection) never deactivates `user_orgs`; PR body previously claimed directory-side link removal was "implemented above" — true only for the LOCAL provider's `archiveLocalAccount`, false for the DingTalk sweep | P1/P2 (both raised, different severities) | **Claim corrected** (was factually wrong); **fix deferred to owner ruling** — whether a departure-detection sweep counts as a "binding event" under this line's own unbind/rebind/archive boundary is a design call, not something to self-adjudicate. Lifecycle table gets an explicit row for this event, honestly marked NOT implemented. Code comment added at the sweep site documenting the gap. |
| `automation-executor.ts`'s `send_dingtalk_group_message` org-destination authorization EXISTS clause is the same `user_orgs`-trust shape as the already-fixed `api-tokens.ts`/`attendance-admin.ts` sites, but was missing from this PR's "full-repo grep" inventory and missing the dual `users.is_active` filter | P2 | **Fixed** — same dual-filter treatment as the other two item-E sites; inventory section corrected to include it. |
| Cross-transaction write skew: two concurrent unbinds of a double-bound user's two different accounts could each see the other's account as still active (neither committed yet) and both skip deactivation, leaving `user_orgs` ACTIVE with zero live bindings permanently | P2 | **Fixed** — `deactivateUserOrgMembershipIfNoOtherActiveBinding` now takes a `SELECT ... FOR UPDATE` lock on the shared `(userId, orgId)` row before evaluating the sibling check, forcing the second caller to observe the first's already-committed severance. Proven with a constructed race (two raw pg clients, `pg_blocking_pids`-based "throw if never parked" non-vacuity check — same technique as `multitable-l4-canonical-fence-realdb.test.ts`'s R1/RXR), not a bare `Promise.all` (which, empirically, does not reliably reproduce this on localhost — see the test file's own doc comment for the investigation). |
| `unbindDirectoryAccount` read the previously-linked user OUTSIDE the transaction (stale pre-read); a rapid unbind+rebind of the SAME account inside that window could sever the CURRENT holder's link while only deactivating the STALE holder | P3 | **Fixed** — the read moved inside the transaction with `FOR UPDATE OF l` locking the `directory_account_links` row. |
| Record discipline: several code comments and this PR body itself attributed phrases to the owner ("(owner text)", "owner ruling") that do not appear verbatim in the owner's actual #4522 review comment (comment-5040485829, re-verified against gh) | P2 | **Fixed** — reworded `admin-users.ts`, `directory-sync.ts`'s `deactivateUserOrgMembershipIfNoOtherActiveBinding` doc comment, `local-directory-org.ts`, the backfill migration's doc comment, two test-file doc comments, and this PR body's own lifecycle table/explicit-org-path section to stop asserting unverified quotes/rulings. |
| Item E's `api-tokens.ts` fix had only mock-SQL-text-equality test coverage (no real-DB proof the JOIN actually filters `users.is_active=false`) | P3 | **Fixed** — new real-DB test file `attendance-w4pre1b-api-tokens-org-member-access.db.test.ts` (4 tests) drives the real `GET /api/multitable/dingtalk-groups?orgId=` endpoint against a real Postgres. |
| F6's "fresh-org" fixture pre-seeds a `directory_integrations` anchor row but never explicitly asserted zero `attendance_groups`/`attendance_shifts` for that org | P3 | **Fixed** — added an explicit before/after zero-scaffold assertion to the existing F6 fresh-org test. |

Affected suites re-run in full (see updated Local verification section below); typecheck clean both packages; mutation self-check re-run for every new/changed guard (see updated mutation table).

## Post-gate fix (Opus gate — 2026-07-22)

（下引块为正门 P2 的**忠实摘述**（非逐字），完整原文见 `/private/tmp/pr4526-review-w4-pre1b-gate.md` L15-19——独立复核 NIT 口径更正）

The Opus gate on this PR returned **CHANGES-REQUESTED** with a single P2, a pure test-coverage gap (zero production-code change required):

> deactivateUserOrgMembershipIfNoOtherActiveBinding's tenant-isolation predicate `AND i.org_id = $2::text` (directory-sync.ts:4977) is load-bearing but has ZERO coverage — removing only that line survives the full suite (12/12 green); constructed reachable failure: DingTalk-binding-in-orgA + local-binding-in-orgB, unbind A → org-A membership stays ACTIVE with zero org-A bindings = cross-org stale access.

**Fix — new test case**: `cross-org tenant-isolation regression — unbind in org A must not be gated by org B's active binding (#4526 P2)` → `unbinding org A's DingTalk account deactivates ONLY org A membership; org B's local binding for the same user stays untouched and active`, added to `attendance-w4pre1b-user-orgs-lifecycle.db.test.ts`. Same user: DingTalk binding in org A (via `bindDirectoryAccount`) + local binding in org B (via `createLocalAccount`); unbind A via the real `unbindDirectoryAccount` path (no test-authored SQL simulating the write); assert BOTH legs — org A membership `is_active=false` AND org B membership stays `is_active=true` (the dual proof: the A leg shows the predicate isn't fooled by org B's sibling; the B leg rules out a degenerate "always deactivate everything" pass).

**Mutation self-check** (test committed first — `2da81d98b` — then mutated via `Edit`, not `git checkout`, for restore):

Removed `AND i.org_id = $2::text` from the `NOT EXISTS` sibling-check subquery (`directory-sync.ts:4977`) →
```
 × cross-org tenant-isolation regression … > unbinding org A's DingTalk account deactivates ONLY org A membership; org B's local binding for the same user stays untouched and active
   → expected { is_active: true } to deeply equal { is_active: false }
 Test Files  1 failed (1)
      Tests  1 failed | 8 passed (9)
```
Only the new test reddens, and precisely on the org-A assertion — exactly the predicted failure mode: org B's still-`linked`+active local binding is picked up as a false "sibling", org A's deactivation is skipped, org A stays `is_active:true`. All 8 other cases in the file (F1/F2/F3/F4/F3-race/rebind-displacement/local-provider) stay green because none of them exercise a cross-org sibling — confirming this new test is the unique guard for the predicate. Restored the exact line via `Edit`; `git diff`/`git status` confirmed byte-identical to the committed state; re-run confirmed 9/9 green.

**Re-verification** (fresh, uniquely-named local Postgres — `ms2_w4pre1b_p2fix_20260721` — migrated clean, matching this PR's own "dedicated DB" convention):
```
pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
  tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts \
  tests/integration/attendance-w4pre1b-user-orgs-sync-automatch.db.test.ts \
  tests/integration/attendance-w4pre1b-user-orgs-backfill-migration.db.test.ts \
  tests/integration/attendance-w4pre1b-directory-readiness-gate.db.test.ts \
  tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts \
  tests/integration/attendance-w4pre1b-api-tokens-org-member-access.db.test.ts
# → 6 files, 25 tests, all passed (lifecycle file: 9/9, up from 8/8 pre-fix)
```

Test-only change — no production code modified by this commit. New head `2da81d98b`.

## Owner findings → implementation mapping

Quoting the owner's 2026-07-21 review comment verbatim, then what this PR does about each:

> "[P1] bind 存量路径（directory-sync.ts:4829）零 user_orgs 写入 + 解绑零失活 ⇒ ①假 missing 与 stale access 双面缺陷（S7-5 门 attendance-admin.ts:375 查 user_orgs.is_active=true，失活即闭洞）"

→ `applyDirectoryAccountBindInTransaction` (directory-sync.ts, shared by `bindDirectoryAccount`/`admitDirectoryAccountUser`/batch variants) now upserts an active `user_orgs` row for the bind target and deactivates a displaced prior holder; `unbindDirectoryAccount` now deactivates the unbound user's membership (org-scoped sibling check). `canReadAttendanceDirectoryReadiness` (attendance-admin.ts) now requires `users.is_active=true` in addition to `user_orgs.is_active=true`.

> "[P2] admin-users.ts:3172 org 仅在提交 group/shift 时解析 ⇒ 修复动作循环依赖确凿"

→ `POST /api/admin/users` accepts an independent `attendanceOrgId` body param, sufficient alone (no group/shift) to upsert membership in the same transaction. See F6 and the "explicit org path" deviation note below for the one open adjudication point.

> "[P2] ensurePlatformAdmin 门 vs 受托管理员 403"（and）"[P2] effectiveTime 合同回退"

→ **Out of scope for this PR** — these two are #4522's own lock-wording/verification-MD updates (owner's step 2 in the execution sequence), not code. Flagged in Open Items below so they are not silently dropped.

## Lifecycle event table (event / disposition / anchor)

| Event | Disposition | Anchor |
|---|---|---|
| Manual bind of an existing user (`bindDirectoryAccount`) | upsert ACTIVE `user_orgs` | `directory-sync.ts` `applyDirectoryAccountBindInTransaction` ~L4934 |
| Admit-new-user over a possibly-already-linked account (`admitDirectoryAccountUser`/`createDirectoryAdmittedUserInTransaction`) | upsert ACTIVE `user_orgs`; deactivate prior holder if displaced | `directory-sync.ts` ~L5117 → shared helper |
| Sync-loop auto-match (`external_identity` fresh match, or `already_linked` steady-state re-confirm) | upsert ACTIVE `user_orgs` when `linkStatus==='linked' && localUserId && account.is_active` (the `account.is_active` gate is the #4526-review P1 fix — without it, a departed-but-still-`linked` account's steady-state re-confirm silently resurrected a deliberately-deactivated row) | `directory-sync.ts` `syncDirectoryIntegration` loop ~L3773 |
| **Directory-side departure detection (DT-OPS-01 sweep)** | **NOT implemented this PR** — the sweep flips only `directory_accounts.is_active`, never `user_orgs`; whether this counts as a "binding event" under the boundary below is an open owner-ruling item (#4526 review) | `directory-sync.ts` sweep ~L3513 (gap documented in a code comment at the sweep site) |
| Manual unbind (`unbindDirectoryAccount`) | deactivate if no other active binding in org | `directory-sync.ts` ~L5921 |
| Same-account rebind displacement (single `bindDirectoryAccount` call reassigns account X from user A to user B) | deactivate A if no other active binding in org | `directory-sync.ts` `applyDirectoryAccountBindInTransaction` prior-holder capture ~L4934 — **investigated, confirmed UNREACHABLE for DingTalk accounts** (see deviation #2); code retained as defense-in-depth |
| Local account create (`createLocalAccount`) | upsert ACTIVE `user_orgs` | `local-directory-org.ts` ~L452 |
| Local account archive (`archiveLocalAccount`) | deactivate if no other active binding in org | `local-directory-org.ts` ~L595 |
| Admin explicit-org create (`POST /api/admin/users` with `attendanceOrgId`) | upsert ACTIVE `user_orgs` | `admin-users.ts` ~L3094/3199-3236 |
| User deactivation (`PATCH /api/admin/users/:userId/status`) | **NOT touched** — this PR's own reading of the binding-event boundary (presented as evidence, not an adjudicated owner ruling — see next section) | not modified this PR |
| Directory deprovision `mark_inactive` policy (`applyDirectoryDeprovisionPolicies`) | **NOT touched** — flips `users.is_active`, not `user_orgs` | not modified this PR |

## Deactivation boundary semantics (for owner review — presenting evidence, not a ruling)

Per the task's own framing: **only a BINDING event may deactivate `user_orgs`.** Concretely:
- Unbind / a same-account rebind that displaces a prior holder → deactivation IS in scope, implemented above.
- Directory-side link removal: **the LOCAL provider's `archiveLocalAccount` treats this as in scope** (implemented, see the lifecycle table) — but the DingTalk-equivalent event (the DT-OPS-01 sweep marking `directory_accounts.is_active=false` when an account stops appearing in the directory) does **NOT** get the same treatment in this PR. An earlier revision of this section claimed the DingTalk case was "implemented above" — that was **false**; corrected during the #4526 review. Whether the sweep counts as the same kind of "directory-side link removal" event `archiveLocalAccount`'s own doc comment reasons about is exactly the open question — requesting owner's ruling (see Open items).
- A→B org migration is NOT a separate function — it is the natural composition of "unbind account under org A's integration" (deactivates A) + "bind a new account under org B's integration" (activates B), proven end-to-end by F4.
- `PATCH /api/admin/users/:userId/status` (user deactivation) → membership row is **never touched**. The dual `users.is_active`/`user_orgs.is_active` read filter (already in place from #4521, and now also applied to the S7-5 gate in this PR) is what excludes a deactivated user from every count and gate — not a write-time membership flip.
- `applyDirectoryDeprovisionPolicies`'s `mark_inactive` branch flips `users.is_active`, never `user_orgs` — same boundary, deliberately excluded, not modified by this PR.

## F1–F7 test cases + mutation table

| # | Owner's case | File | Result |
|---|---|---|---|
| F1 | bind existing user ⇒ membership row (+ failure-injection rollback) | `attendance-w4pre1b-user-orgs-lifecycle.db.test.ts` | 2 tests, both pass |
| F2 | last unbind ⇒ deactivated | same file | 1 test, pass |
| F3 | double binding, unbind one ⇒ other stays active | same file | 2 tests (original; + `F3-race` constructed-concurrency regression, #4526 P2), pass |
| F4 | A→B migration ⇒ old deactivated, new active | same file | 1 test, pass |
| (bonus) | same-account rebind displacement | same file | 1 test — documents the pre-existing identity-conflict guard makes this unreachable for DingTalk (deviation #2) |
| (bonus) | local-provider bind/archive | same file | 1 test, pass |
| (item A 3rd writer) | sync-loop `external_identity` auto-match writes membership | `attendance-w4pre1b-user-orgs-sync-automatch.db.test.ts` | 3 tests (original re-match test; + #4526 P1 regression pair: a swept-inactive account does NOT resurrect membership, and a returning/reactivated account DOES still get the steady-state re-confirm), pass |
| F5 | stale/deactivated member ⇒ 403 via real endpoint | `attendance-w4pre1b-directory-readiness-gate.db.test.ts` | 3 tests (deactivated-user variant, deactivated-membership variant, active-member 200 control), pass |
| F6 | fresh-org explicit `attendanceOrgId` ⇒ membership, falsifies old circular dependency | `attendance-w4pre1b-admin-users-explicit-org.db.test.ts` | 5 tests (fresh-org success — now also asserts zero attendance_groups/shifts before AND after, #4526 review; unknown-org 404, malformed-param 400, group/shift-conflict 400, backward-compat control), pass |
| F7 | backfill: linked-but-membership-less gets a row; already-deactivated row never resurrected | `attendance-w4pre1b-user-orgs-backfill-migration.db.test.ts` | 1 test (4 population variants + idempotent rerun), pass |
| (item E follow-up) | `api-tokens.ts` `requireOrgMemberAccess` dual filter, real endpoint (#4526 P3 — previously mock-SQL-text-only) | `attendance-w4pre1b-api-tokens-org-member-access.db.test.ts` (new) | 4 tests (active/active 200; deactivated-user 403; deactivated-membership 403; no-membership 403), pass |

**Mutation self-check (≥4 original + 3 added in the #4526 review round; all confirmed RED then reverted — implementation committed before each mutation, restored via precise `Edit` rather than a broad `git checkout` during the review-round self-checks):**

| # | Mutation | Red leg | Restored |
|---|---|---|---|
| 1 | Neuter `upsertActiveUserOrgMembership` call in the bind writer | F1 + 4 other lifecycle tests red (5/7 in that file) | yes |
| 2 | Remove the `NOT EXISTS` sibling check from `deactivateUserOrgMembershipIfNoOtherActiveBinding` (unconditional deactivation) | **Only** F3 (double-binding-preserved-active) red — precise, load-bearing kill | yes |
| 3 | Change backfill's `ON CONFLICT (user_id, org_id) DO NOTHING` to `DO UPDATE SET is_active = TRUE` | **Only** F7's non-resurrection assertion red | yes |
| 4 | Drop `AND u.is_active = true` from the S7-5 gate SQL | **Only** F5's deactivated-user variant red | yes |
| 5 (#4526) | Drop `&& account.is_active` from the sync-loop's `already_linked` write gate | **Only** the new sync-automatch regression's negative case red (`expected [{is_active:true}] to deeply equal [{is_active:false}]`) | yes |
| 6 (#4526) | Drop the `SELECT ... FOR UPDATE` lock from `deactivateUserOrgMembershipIfNoOtherActiveBinding` | `F3-race`'s `waitUntilBlockedBy` throws after its 5s timeout ("the second deactivation call never parked on the first caller's row lock") — the test detects the ABSENCE of blocking, not just the wrong final state, so it can't be satisfied by luck | yes |
| 7 (#4526) | Drop `AND u.is_active = true` from `automation-executor.ts`'s DingTalk destination EXISTS clause | **Only** the updated `automation-v1.test.ts` mock-SQL-text assertion red | yes |

## Backfill idempotency self-proof

`zzzz20260721150000_backfill_user_orgs_from_directory_links.ts`: `INSERT ... SELECT ... ON CONFLICT (user_id, org_id) DO NOTHING`. F7 seeds four populations (linked+no-row, linked+already-deactivated, linked+already-active, linked-to-an-*inactive*-directory-account) and asserts: row created only for the first; the deactivated row's `is_active` stays `false`; the active row is untouched; the inactive-account population gets no row at all. The whole `up()` is re-invoked a second time in the same test and the result set is asserted byte-identical (`toEqual`) — true idempotency, not just "no error".

## Explicit org path (item D) — one open adjudication point

The owner's item-D text is "支持显式 attendanceOrgId（不依赖考勤组/班次）⇒ canonical surface 变为真无条件" — it establishes THAT an explicit `attendanceOrgId` must work standalone, but not HOW an unrecognized org id should be handled; that latter question has two defensible readings, and is a design call the task instructs me not to self-adjudicate (an earlier revision of this section mislabeled "校验 org 存在" as owner text in quotes — it is not verbatim owner text; corrected during the #4526 review):
- **Shipped**: validate-can-fail — `attendanceOrgId` is checked against `directory_integrations` (the anchor every org acquires today, local or dingtalk); an unrecognized org id gets `404 ATTENDANCE_ORG_NOT_FOUND`. Fail-closed by construction, cheapest to loosen later if wrong.
- **Not shipped**: auto-vivify — call `getOrCreateLocalIntegration(attendanceOrgId)` so ANY non-empty org id string from an admin succeeds, silently minting a new local org anchor. This is a bigger, more permissive action than "validate" literally means, and F6's fresh-org test therefore pre-seeds a `directory_integrations` row as fixture setup (simulating "org already has *some* anchor, zero attendance groups/shifts") rather than relying on the route to mint one from a totally bare string.

Both readings satisfy "breaks the circular dependency" — they differ on whether a brand-new org can be summoned purely by an admin's `POST /api/admin/users` call. **Requesting owner's ruling on this in the #4522 follow-up.**

## CI wiring (three-point)

1. `packages/core-backend/vitest.config.ts`'s no-DB exclude list — all 5 original + 1 added in the #4526 review round (`attendance-w4pre1b-api-tokens-org-member-access.db.test.ts`) `.db.test.ts` files, so the default no-DB job cannot skip-green them.
2. `.github/workflows/plugin-tests.yml`'s "Run attendance integration tests" step — same 6 files added to the explicit `vitest.integration.config.ts` invocation.
3. The new backfill migration (`zzzz20260721150000...`) is **not** in `MIGRATION_EXCLUDE` (either occurrence) — confirmed by running `pnpm --filter @metasheet/core-backend db:migrate` against a fresh dedicated local Postgres with the exact `MIGRATION_EXCLUDE` value copied from the workflow: the migration executed in its correct position (after `zzzz20260717130000`), no exclusion needed.

## Regression fixups (pre-existing suites this PR's changes required updating)

- `attendance-w4pre1-user-orgs-directory-sync.db.test.ts` (#4521): the org-resolution-failure error message text changed (`'Directory integration not found for account org resolution'`) because the resolution logic moved from `createDirectoryAdmittedUserInTransaction` into the now-shared `applyDirectoryAccountBindInTransaction` helper — same fail-closed guarantee (no `users` row survives), different message. Updated the one assertion.
- `directory-sync-bind-account.test.ts` (mocked unit suite): 4 tests converted from brittle positional `clientQuery.mockResolvedValueOnce()` chains to the SQL-text-inspecting closure pattern this same file's own "allows union-only pre-binding" test had already established for exactly this reason (#4521 anticipated more queries landing here). One `.find()` predicate disambiguated (`'SELECT local_user_id'` now matches two different queries — the original identity-conflict check and the new prior-holder capture — narrowed to `'FROM user_external_identities'`).
- `dingtalk-group-destination-routes.api.test.ts`: 2 exact-SQL-text assertions on `api-tokens.ts`'s `requireOrgMemberAccess` updated to the new dual-filter query text.
- (#4526 review round) `directory-sync-bind-account.test.ts`: 3 `unbindDirectoryAccount` tests' `clientQuery` mocks updated to also answer the new in-transaction `FOR UPDATE OF l` linked-user read (previously served by the outer `pgMocks.query` pre-read this round moved inside the transaction).
- (#4526 review round) `automation-v1.test.ts`: the `send_dingtalk_group_message` scoping test's inline SQL-text assertions extended to also require the new `JOIN users u` / `u.is_active = true` clauses.

## Grep inventory — other `user_orgs`-trusting sites (item E "同型门")

Full-repo grep for `user_orgs` trust points (boolean access-gate shape, `... WHERE user_id = $1 AND org_id = $2 AND is_active = true ...`):
- `attendance-admin.ts:373` `canReadAttendanceDirectoryReadiness` — **fixed** (owner-named).
- `api-tokens.ts:155` `requireOrgMemberAccess` (identical SQL shape, gates DingTalk group-destination org read/write access) — **fixed**.
- `automation-executor.ts` `send_dingtalk_group_message`'s destination-authorization `EXISTS` clause — **fixed in the #4526 review round** (this site was MISSING from the original "full-repo grep" inventory below; the original claim of completeness was inaccurate). Same shape as `api-tokens.ts`, gating actual outbound-send authorization by the automation rule creator's org membership.
- `dingtalk-group-destination-service.ts:215-234` — two Kysely `EXISTS` clauses inside `listDestinations`'s visibility filter, same underlying finding (a departed/deactivated member's stale `user_orgs` row could still surface org-scoped rows) — **inventoried, NOT fixed**. Rationale for leaving it: it is a read-visibility filter embedded in a `SELECT ... WHERE (OR ...)` builder rather than a hard 403 gate, has its own dedicated test suite (`dingtalk-group-destination-service.test.ts`), and touching it risks a larger, less-reviewable diff for a surface the owner did not name. Flagged for owner to decide if it belongs in this line or a follow-up.
- `plugins/plugin-attendance/index.cjs` (multiple sites, e.g. `:2784`, `:15532`, `:18107`) — **already** carry the dual `is_active` filter (pre-existing RD-3 precedent this PR's fixes now match); no change needed.

## Deviations (honest, evidence only — no verdicts asserted)

1. Item D's unrecognized-org-id handling — two readings, shipped validate-can-fail; see dedicated section above.
2. Advisor-flagged "same-account rebind displacement via a single `bindDirectoryAccount` call" was investigated and is empirically **unreachable for DingTalk accounts**: `applyDirectoryAccountBindInTransaction`'s pre-existing `user_external_identities` conflict guard throws `'DingTalk account is already bound to another local user'` before the link write is ever reached, whenever the target account's identity is already tied to a different local user. Proven by running exactly that call sequence against a real DB (see the file's "investigated, confirmed unreachable" test). The prior-holder capture + deactivate code in `applyDirectoryAccountBindInTransaction` is retained as defense-in-depth (cheap, correct, harmless) but has no currently-reachable production trigger for the DingTalk provider that this audit found; `createLocalAccount`'s local-provider path has no rebind concept at all (its `external_key` is `org_id:local_user_id`, inherently per-user).
3. `dingtalk-group-destination-service.ts`'s two EXISTS-based visibility filters — grep-inventoried as the same finding shape, deliberately not modified (see inventory section).
4. A sync-loop scenario where a previously-`linked` account transitions to `unmatched` on a LATER resync (e.g., an ambiguous re-match) was reasoned about but not separately implemented/tested: this requires the account's `user_external_identities` row to first be deleted, which — in every production path this PR's inventory found — only happens via `unbindDirectoryAccount` (already fixed in this PR). No additional gap was identified, but no dedicated test proves this specific transition combination.
5. (#4526 review) The DT-OPS-01 sweep (directory-side departure detection) does not deactivate `user_orgs` — see the lifecycle table and boundary-semantics section above. Left unfixed pending owner ruling on whether it counts as a "binding event"; a code comment at the sweep site documents the gap so it isn't silently lost.

## Open items (for owner)

- Ruling requested on item D's unrecognized-org-id handling (validate-can-fail, shipped, vs auto-vivify).
- Ruling requested on whether `dingtalk-group-destination-service.ts`'s two EXISTS-based filters need the same dual-filter treatment, in this line or a follow-up.
- Ruling requested (#4526 review) on whether the DT-OPS-01 directory-side departure sweep counts as a "binding event" that should deactivate `user_orgs` — see lifecycle table + boundary-semantics section.
- #4522's own step-2 items (lock wording, `ensurePlatformAdmin` vs delegated-403 role contract, `effectiveTime` four-state restoration) are **not** touched by this PR — they are #4522's own docs/verification-MD work per the owner's execution sequence, referenced here so they are not silently dropped.
- Staged opt-in / owner merge decision, per this line's standing convention — this PR does not merge or arm itself.

## Local verification (this worktree, dedicated Postgres — `metasheet_w4pre1b_test`)

Original round:
```
pnpm --filter @metasheet/core-backend db:migrate   # MIGRATION_EXCLUDE copied verbatim from plugin-tests.yml
# → zzzz20260721150000_backfill_user_orgs_from_directory_links executed in position, no exclusion needed

pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run <full "Run attendance integration tests" file list from plugin-tests.yml, including the 5 new files>
# → 40 files, 522 tests, all passed

pnpm --filter @metasheet/core-backend exec vitest run   # default no-DB config, full sweep
# → 688 files (506 passed / 182 DB-gated skipped), 6909 tests passed, 1627 skipped, 0 failed

pnpm --filter @metasheet/core-backend run type-check    # clean
pnpm --filter @metasheet/web run type-check              # clean (no frontend changes this PR; ran anyway per double-typecheck discipline)
```

#4526 review-round re-verification (same dedicated Postgres):
```
# All 6 W4-PRE-1b real-DB files (5 original + 1 new) + the 3 pre-existing W4-PRE-1 (#4521) real-DB
# files + the full directory-sync/directory-binding real-DB suite (18 files total):
pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run <18 files>
# → 18 files, 105 tests, all passed

# Mock/unit suites touched by this round's changes:
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts \
  tests/unit/directory-sync-bind-account.test.ts tests/integration/dingtalk-group-destination-routes.api.test.ts \
  tests/unit/admin-users-routes.test.ts
# → 4 files, 320 tests, all passed

pnpm --filter @metasheet/core-backend exec vitest run   # default no-DB config, full sweep (repeat)
# → 688 files (506 passed / 182 DB-gated skipped), 6909 tests passed, 1627 skipped, 0 failed — byte-identical
#   totals to the original round, confirming the new file is correctly excluded from the no-DB job

pnpm --filter @metasheet/core-backend run type-check    # clean
pnpm --filter @metasheet/web run type-check              # clean (still no frontend changes)
```

Mutation self-checks 5-7 (see mutation table): each mutation applied on top of a COMMITTED implementation, confirmed RED, then reverted with a precise `Edit` (not a broad `git checkout`, which would have discarded the not-yet-committed test file for #6's rewrite mid-investigation).

Three-viewport visual verification: **N/A** — this PR is backend-only (routes, directory-sync service functions, one data migration); no Vue/frontend changes.

refs #4522 #4521

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>



