### PR TITLE
fix(core-backend): W4-PRE-1c — controlled-departure user_orgs deactivation + destination dual is_active (owner 裁决②③, #4522 rev3 review)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -829,6 +829,10 @@ jobs:
             tests/integration/attendance-w4pre1b-directory-readiness-gate.db.test.ts \
             tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts \
             tests/integration/attendance-w4pre1b-api-tokens-org-member-access.db.test.ts \
+            tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts \
+            tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts \
+            tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts \
+            tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -1320,6 +1320,21 @@ export type DirectoryDeprovisionOutcome = {
     localUserId: string
     policy: DirectoryDeprovisionPolicy
   }>
+  /**
+   * W4-PRE-1c item B (owner 裁决②, #4522 rev3 review, 2026-07-22): `manual_review` never
+   * writes anything — `manualReviewCount` alone cannot answer WHO is pending. This is the
+   * same (directoryAccountId, localUserId) shape as `affected`, plus `orgId` (every entry
+   * from one call shares the same org, but the run-stats consumer — `GET
+   * /integrations/:integrationId/runs`, see `admin-directory.ts` — should not have to
+   * cross-reference the integration to learn it). Populated regardless of `enabled`
+   * (preview and real runs both resolve policy the same way; only the WRITE is gated).
+   * Values-free: ids only, no name/email/mobile.
+   */
+  manualReviewPending: Array<{
+    directoryAccountId: string
+    localUserId: string
+    orgId: string
+  }>
 }
 
 type DeprovisionCandidateRow = {
@@ -1387,6 +1402,7 @@ export async function applyDirectoryDeprovisionPolicies(
     usersDeactivatedCount: 0,
     abortedReason: null,
     affected: [],
+    manualReviewPending: [],
   }
 
   if (options.deactivatedAccountIds.length === 0) return outcome
@@ -1449,9 +1465,24 @@ export async function applyDirectoryDeprovisionPolicies(
     return outcome
   }
 
+  // W4-PRE-1c (owner 裁决②, #4522 rev3 review, 2026-07-22): resolved LAZILY and at most
+  // ONCE per call — every candidate here was selected for the SAME `options.integrationId`,
+  // hence the SAME org. Only queried the first time it is actually needed (a manual_review
+  // candidate to report, or a non-manual_review write to perform), so a run with neither
+  // never pays for it.
+  let resolvedOrgId: string | null = null
+  const resolveOrgIdOnce = async (): Promise<string> => {
+    if (resolvedOrgId === null) resolvedOrgId = await resolveDirectoryAccountOrgId(client, options.integrationId)
+    return resolvedOrgId
+  }
+
   for (const [localUserId, { directoryAccountId, policy }] of byUser) {
     if (policy === 'manual_review') {
       outcome.manualReviewCount += 1
+      // Owner 裁决②, 逐字: "manual_review 则保持 active 并暴露待人工确认状态" — never a
+      // write, membership stays exactly as it was; only the pending-confirmation state is
+      // exposed (org/membership-scoped) on the existing run-stats surface.
+      outcome.manualReviewPending.push({ directoryAccountId, localUserId, orgId: await resolveOrgIdOnce() })
       continue
     }
 
@@ -1466,6 +1497,22 @@ export async function applyDirectoryDeprovisionPolicies(
          DO UPDATE SET enabled = FALSE, updated_at = NOW()`,
         [DEFAULT_PROVIDER, localUserId, 'system:directory-deprovision'],
       )
+      // W4-PRE-1c (owner 裁决②, 逐字: "推荐在 deprovision circuit-breaker 通过、开关启用且
+      // 策略实际执行时,同事务失活对应 user_orgs"): the circuit breaker already passed (we are
+      // past the abort-and-return above), the switch is on (`options.enabled`), and this
+      // policy just executed a REAL write for this person — a grant revoked here, and for
+      // `mark_inactive` the local account too, below. THIS moment — not the DT-OPS-01 sweep
+      // flipping `directory_accounts.is_active` alone — is "策略实际执行", and is what may
+      // deactivate `user_orgs`, same transaction. Reuses #4526's own org-scoped "no other
+      // active binding" rule verbatim (`deactivateUserOrgMembershipIfNoOtherActiveBinding`);
+      // see the PR body's combination-semantics section for how that org-scoped check
+      // composes with (is currently dominated by) this function's OWN global sibling guard
+      // above. `manual_review` is excluded by the `continue` above: a single missed sync,
+      // or a policy that never executes, must never itself revoke membership.
+      await deactivateUserOrgMembershipIfNoOtherActiveBinding(client, {
+        userId: localUserId,
+        orgId: await resolveOrgIdOnce(),
+      })
     }
 
     if (policy === 'mark_inactive') {
@@ -3512,14 +3559,17 @@ export async function syncDirectoryIntegration(
       // deactivated on every sync — audit spam, and it would stomp a reactivation.
       // RETURNING gives the executor exactly the accounts that departed in THIS run.
       //
-      // KNOWN OPEN GAP (#4526 review, not fixed this round — needs an owner ruling): this sweep
-      // flips ONLY `directory_accounts.is_active`; it does not call
-      // `deactivateUserOrgMembershipIfNoOtherActiveBinding`, so a departed employee's `user_orgs`
-      // row stays ACTIVE until an admin manually unbinds them (the deprovision executor below is
-      // OFF by default and, even enabled, only ever touches `users.is_active`, never
-      // `user_orgs`). Whether "the directory silently stopped reporting this account" counts as a
-      // BINDING event under this line's own boundary (only unbind/rebind/archive deactivate) is
-      // an open adjudication point — see the PR body's lifecycle table and open items.
+      // W4-PRE-1c (owner 裁决②, #4522 rev3 review, 2026-07-22 — resolves the #4526-review open
+      // gap this comment used to describe): this sweep ALONE still flips only
+      // `directory_accounts.is_active` — it never itself deactivates `user_orgs`. A single
+      // missed sync (one account absent from one fetch) must never, by itself, revoke
+      // membership — owner 逐字: "不要因『单次同步缺失』直接撤销 membership". The deprovision
+      // executor below (`applyDirectoryDeprovisionPolicies`, OFF by default) is the ONLY path
+      // that may deactivate `user_orgs` for a swept account, and only once ALL of its own gates
+      // clear: circuit breaker passed, `DIRECTORY_DEPROVISION_ENABLED=true`, AND the resolved
+      // policy actually executes a write (`disable_grant_only` / `mark_inactive`; `manual_review`
+      // never writes — see that function's own `manual_review` branch, which instead exposes a
+      // pending-confirmation state on `manualReviewPending`).
       const deactivatedAccountsResult = await client.query(
         `UPDATE directory_accounts
          SET is_active = false, updated_at = NOW()
@@ -3892,6 +3942,13 @@ export async function syncDirectoryIntegration(
         // the stats JSONB.
         deprovisionAffected: deprovisionOutcome.affected.slice(0, 100),
         deprovisionAffectedTruncated: deprovisionOutcome.affected.length > 100,
+        // W4-PRE-1c item B (owner 裁决②): manual_review candidates never appear in
+        // `deprovisionAffected` above (nothing was written for them) — this is the minimal
+        // read-only exposure of WHO is pending manual confirmation, org/membership-scoped,
+        // on this same existing queryable surface (`GET /integrations/:integrationId/runs`).
+        // No new table, no new endpoint, no new UI. Values-free: ids only.
+        deprovisionManualReviewPending: deprovisionOutcome.manualReviewPending.slice(0, 100),
+        deprovisionManualReviewPendingTruncated: deprovisionOutcome.manualReviewPending.length > 100,
         linkedCount,
         pendingCount,
         unmatchedCount,

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -1313,6 +1313,20 @@ export type DirectoryDeprovisionOutcome = {
   manualReviewCount: number
   grantsDisabledCount: number
   usersDeactivatedCount: number
+  /**
+   * W4-PRE-1c (owner 裁决②, #4522 rev3 review, 2026-07-22, review-finding observability gap):
+   * how many PEOPLE this run attempted a `user_orgs` deactivation for — every non-`manual_review`
+   * candidate, i.e. the same set (and same count, by construction) as `grantsDisabledCount`,
+   * since both writes are gated by the exact same `if (options.enabled)` block for the exact
+   * same candidates. Named separately so the `user_orgs` consequence is visible on its own in
+   * run stats/logs rather than requiring the reader to know it is implied by
+   * `grantsDisabledCount`. Like that field, this counts an ATTEMPT (preview mode included) —
+   * it does NOT mean the row actually flipped: `deactivateUserOrgMembershipIfNoOtherActiveBinding`
+   * no-ops (without erroring) when the org-scoped sibling check finds another active binding, or
+   * when no `user_orgs` row exists yet. Whether it actually flipped is not tracked (the shared
+   * helper's `UPDATE` has no `RETURNING`); this is attempt-visibility, not flip-visibility.
+   */
+  membershipDeactivationAttemptedCount: number
   /** Set when the circuit breaker refused to act; `applied` is forced false. */
   abortedReason: DirectoryDeprovisionAbortReason | null
   affected: Array<{
@@ -1400,6 +1414,7 @@ export async function applyDirectoryDeprovisionPolicies(
     manualReviewCount: 0,
     grantsDisabledCount: 0,
     usersDeactivatedCount: 0,
+    membershipDeactivationAttemptedCount: 0,
     abortedReason: null,
     affected: [],
     manualReviewPending: [],
@@ -1479,9 +1494,10 @@ export async function applyDirectoryDeprovisionPolicies(
   for (const [localUserId, { directoryAccountId, policy }] of byUser) {
     if (policy === 'manual_review') {
       outcome.manualReviewCount += 1
-      // Owner 裁决②, 逐字: "manual_review 则保持 active 并暴露待人工确认状态" — never a
-      // write, membership stays exactly as it was; only the pending-confirmation state is
-      // exposed (org/membership-scoped) on the existing run-stats surface.
+      // Owner 裁决② (#4522 rev3 review — issuecomment-5042388830: "manual_review 保持 active
+      // 并暴露待人工确认状态") — never a write, membership stays exactly as it was; only the
+      // pending-confirmation state is exposed (org/membership-scoped) on the existing
+      // run-stats surface.
       outcome.manualReviewPending.push({ directoryAccountId, localUserId, orgId: await resolveOrgIdOnce() })
       continue
     }
@@ -1489,6 +1505,11 @@ export async function applyDirectoryDeprovisionPolicies(
     outcome.affected.push({ directoryAccountId, localUserId, policy })
 
     outcome.grantsDisabledCount += 1
+    // Same gate, same candidate set as `grantsDisabledCount` above — see this field's own
+    // doc-comment on `DirectoryDeprovisionOutcome`. Counted here (before the `enabled` check,
+    // like `grantsDisabledCount`) so preview runs also report how many `user_orgs`
+    // deactivation attempts WOULD happen if the switch were flipped on.
+    outcome.membershipDeactivationAttemptedCount += 1
     if (options.enabled) {
       await client.query(
         `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
@@ -1497,18 +1518,31 @@ export async function applyDirectoryDeprovisionPolicies(
          DO UPDATE SET enabled = FALSE, updated_at = NOW()`,
         [DEFAULT_PROVIDER, localUserId, 'system:directory-deprovision'],
       )
-      // W4-PRE-1c (owner 裁决②, 逐字: "推荐在 deprovision circuit-breaker 通过、开关启用且
-      // 策略实际执行时,同事务失活对应 user_orgs"): the circuit breaker already passed (we are
+      // W4-PRE-1c (owner 裁决②, #4522 rev3 review — the only GitHub-persisted record is the
+      // owner's own acknowledgment comment, issuecomment-5042388830: "不因单次同步缺失撤销
+      // membership；deprovision circuit-breaker 通过 + 开关启用 + 策略实际执行时同事务失活对应
+      // user_orgs；manual_review 保持 active 并暴露待人工确认状态。" No #4522 review or review-
+      // thread comment carries a longer/earlier original — this IS the citable text, not a
+      // paraphrase of something else on record): the circuit breaker already passed (we are
       // past the abort-and-return above), the switch is on (`options.enabled`), and this
       // policy just executed a REAL write for this person — a grant revoked here, and for
       // `mark_inactive` the local account too, below. THIS moment — not the DT-OPS-01 sweep
       // flipping `directory_accounts.is_active` alone — is "策略实际执行", and is what may
       // deactivate `user_orgs`, same transaction. Reuses #4526's own org-scoped "no other
-      // active binding" rule verbatim (`deactivateUserOrgMembershipIfNoOtherActiveBinding`);
-      // see the PR body's combination-semantics section for how that org-scoped check
-      // composes with (is currently dominated by) this function's OWN global sibling guard
-      // above. `manual_review` is excluded by the `continue` above: a single missed sync,
-      // or a policy that never executes, must never itself revoke membership.
+      // active binding" rule verbatim (`deactivateUserOrgMembershipIfNoOtherActiveBinding`) —
+      // and that helper's OWN re-read (`SELECT ... FOR UPDATE` then a fresh READ COMMITTED
+      // `NOT EXISTS`) is NOT redundant with this function's global candidate-selection sibling
+      // guard above, despite both checking "no other active binding": guard (1) above is read
+      // ONCE, early, before this loop and before any write in this run; this helper re-checks
+      // AT WRITE TIME under a row lock. A concurrent transaction that commits a brand-new
+      // linked+active directory account for this SAME person in this SAME org, in the window
+      // between guard (1)'s read and this call, is invisible to guard (1)'s stale snapshot but
+      // IS caught by this helper's fresh re-read — the same write-skew shape #4526 itself fixed
+      // with `FOR UPDATE` for concurrent unbinds. So this check is independently load-bearing on
+      // this call path, not merely inherited defense-in-depth; see the PR body's combination-
+      // semantics section (owner review flagged) for the full reasoning. `manual_review` is
+      // excluded by the `continue` above: a single missed sync, or a policy that never executes,
+      // must never itself revoke membership.
       await deactivateUserOrgMembershipIfNoOtherActiveBinding(client, {
         userId: localUserId,
         orgId: await resolveOrgIdOnce(),
@@ -1529,7 +1563,8 @@ export async function applyDirectoryDeprovisionPolicies(
   if (!options.enabled && outcome.candidateCount > 0) {
     logger.info(
       `Directory deprovision preview for ${options.integrationId}: ${outcome.candidateCount} person(s) — `
-      + `${outcome.grantsDisabledCount} grant(s) and ${outcome.usersDeactivatedCount} local user(s) would be disabled. `
+      + `${outcome.grantsDisabledCount} grant(s) and ${outcome.usersDeactivatedCount} local user(s) would be disabled, `
+      + `and ${outcome.membershipDeactivationAttemptedCount} org membership(s) (user_orgs) would be deactivation-attempted. `
       + `Affected: ${outcome.affected.map((a) => a.localUserId).join(', ') || '(none)'}. `
       + 'Set DIRECTORY_DEPROVISION_ENABLED=true to apply.',
     )
@@ -3563,7 +3598,8 @@ export async function syncDirectoryIntegration(
       // gap this comment used to describe): this sweep ALONE still flips only
       // `directory_accounts.is_active` — it never itself deactivates `user_orgs`. A single
       // missed sync (one account absent from one fetch) must never, by itself, revoke
-      // membership — owner 逐字: "不要因『单次同步缺失』直接撤销 membership". The deprovision
+      // membership — owner 裁决② per issuecomment-5042388830: "不因单次同步缺失撤销
+      // membership". The deprovision
       // executor below (`applyDirectoryDeprovisionPolicies`, OFF by default) is the ONLY path
       // that may deactivate `user_orgs` for a swept account, and only once ALL of its own gates
       // clear: circuit breaker passed, `DIRECTORY_DEPROVISION_ENABLED=true`, AND the resolved
@@ -3935,6 +3971,11 @@ export async function syncDirectoryIntegration(
         deprovisionManualReviewCount: deprovisionOutcome.manualReviewCount,
         deprovisionGrantsDisabledCount: deprovisionOutcome.grantsDisabledCount,
         deprovisionUsersDeactivatedCount: deprovisionOutcome.usersDeactivatedCount,
+        // W4-PRE-1c (owner 裁决②, review-finding observability gap): the new user_orgs
+        // consequence, surfaced on its own so an operator does not have to infer it from
+        // `deprovisionGrantsDisabledCount`. See `membershipDeactivationAttemptedCount`'s own
+        // doc-comment for what "attempted" does and does not mean.
+        deprovisionMembershipDeactivationAttemptedCount: deprovisionOutcome.membershipDeactivationAttemptedCount,
         deprovisionAbortedReason: deprovisionOutcome.abortedReason,
         // Identities, not just a number: an operator deciding whether to flip
         // DIRECTORY_DEPROVISION_ENABLED needs to see WHO would lose access, and there is no
@@ -3947,6 +3988,20 @@ export async function syncDirectoryIntegration(
         // read-only exposure of WHO is pending manual confirmation, org/membership-scoped,
         // on this same existing queryable surface (`GET /integrations/:integrationId/runs`).
         // No new table, no new endpoint, no new UI. Values-free: ids only.
+        //
+        // Scope, read carefully (review finding — this is a per-run snapshot, not a queue):
+        // this array is written ONCE, into THIS run's `directory_sync_runs.stats` row, and
+        // reflects only the accounts THIS run's own sweep transitioned to inactive AND
+        // resolved to `manual_review` (see `deactivatedAccountIds`'s own "this run's
+        // transitions, not the lifetime backlog" contract above). A person who is still
+        // pending confirmation after this run does NOT reappear here on the NEXT run (their
+        // `directory_accounts.is_active` is already `false`, so they no longer satisfy the
+        // sweep's `AND is_active = true` transition filter). There is no aggregate "who is
+        // currently still pending" view and no confirm/resolve marker anywhere in this repo
+        // — an operator must enumerate PAST runs' `stats` blobs to find unresolved
+        // manual_review candidates. Acceptable as a minimal read-only exposure per the
+        // owner's "暴露待人工确认状态" bar, but flagged: this is a one-shot audit trail entry,
+        // not a live pending-queue.
         deprovisionManualReviewPending: deprovisionOutcome.manualReviewPending.slice(0, 100),
         deprovisionManualReviewPendingTruncated: deprovisionOutcome.manualReviewPending.length > 100,
         linkedCount,
@@ -4040,6 +4095,12 @@ export async function syncDirectoryIntegration(
             policy: affected.policy,
             grantDisabled: true,
             userDeactivated: affected.policy === 'mark_inactive',
+            // W4-PRE-1c (owner 裁决②, review-finding observability gap): every entry in
+            // `deprovisionOutcome.affected` (this loop's source) attempted the user_orgs
+            // deactivation unconditionally when `applied` is true — same gate as
+            // `grantDisabled` above, see `membershipDeactivationAttemptedCount`'s doc-comment.
+            // Attempted, not necessarily flipped (org-scoped sibling check may have no-op'd it).
+            membershipDeactivationAttempted: true,
             triggeredBy,
           },
         })

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
@@ -209,12 +209,17 @@ export class DingTalkGroupDestinationService {
       builder = builder.where((eb) =>
         eb.or([
           eb('sheet_id', '=', normalizedSheetId),
-          // W4-PRE-1c item C (owner 裁决③, #4522 rev3 review, 2026-07-22, 逐字: "现在就统一为
-          // user_orgs.is_active && users.is_active,不留同型后续债"): same finding shape as
+          // W4-PRE-1c item C (owner 裁决③, #4522 rev3 review, 2026-07-22 — the only
+          // GitHub-persisted text is issuecomment-5042388830's acknowledgment: "两处 EXISTS
+          // 统一为 user_orgs.is_active && users.is_active"): same finding shape as
           // `attendance-admin.ts`'s `canReadAttendanceDirectoryReadiness` and `api-tokens.ts`'s
           // `requireOrgMemberAccess` (both already fixed in #4526) — a deactivated PLATFORM
           // account (`users.is_active=false`) must not keep surfacing org-scoped destinations
-          // through a `user_orgs` row that is still `is_active=true`.
+          // through a `user_orgs` row that is still `is_active=true`. This is the byte-identical
+          // twin of the `else` branch's EXISTS below; real-behavioral coverage for THIS branch
+          // specifically lives in `attendance-w4pre1c-departure-permission-negative.db.test.ts`
+          // case ⑤ leg 3 (the original PR shipped only leg 2, which never calls `listDestinations`
+          // with a `sheetId` argument and so never reached this branch — review finding).
           eb.exists(
             eb.selectFrom('user_orgs')
               .innerJoin('users', 'users.id', 'user_orgs.user_id')
@@ -234,8 +239,9 @@ export class DingTalkGroupDestinationService {
     } else {
       builder = builder.where((eb) =>
         eb.or([
-          // W4-PRE-1c item C (owner 裁决③, #4522 rev3 review, 2026-07-22, 逐字: "现在就统一为
-          // user_orgs.is_active && users.is_active,不留同型后续债"): same finding shape as
+          // W4-PRE-1c item C (owner 裁决③, #4522 rev3 review, 2026-07-22 — the only
+          // GitHub-persisted text is issuecomment-5042388830's acknowledgment: "两处 EXISTS
+          // 统一为 user_orgs.is_active && users.is_active"): same finding shape as
           // `attendance-admin.ts`'s `canReadAttendanceDirectoryReadiness` and `api-tokens.ts`'s
           // `requireOrgMemberAccess` (both already fixed in #4526) — a deactivated PLATFORM
           // account (`users.is_active=false`) must not keep surfacing org-scoped destinations

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
@@ -209,12 +209,20 @@ export class DingTalkGroupDestinationService {
       builder = builder.where((eb) =>
         eb.or([
           eb('sheet_id', '=', normalizedSheetId),
+          // W4-PRE-1c item C (owner 裁决③, #4522 rev3 review, 2026-07-22, 逐字: "现在就统一为
+          // user_orgs.is_active && users.is_active,不留同型后续债"): same finding shape as
+          // `attendance-admin.ts`'s `canReadAttendanceDirectoryReadiness` and `api-tokens.ts`'s
+          // `requireOrgMemberAccess` (both already fixed in #4526) — a deactivated PLATFORM
+          // account (`users.is_active=false`) must not keep surfacing org-scoped destinations
+          // through a `user_orgs` row that is still `is_active=true`.
           eb.exists(
             eb.selectFrom('user_orgs')
-              .select('user_id')
+              .innerJoin('users', 'users.id', 'user_orgs.user_id')
+              .select('user_orgs.user_id')
               .whereRef('user_orgs.org_id', '=', 'dingtalk_group_destinations.org_id')
               .where('user_orgs.user_id', '=', userId)
-              .where('user_orgs.is_active', '=', true),
+              .where('user_orgs.is_active', '=', true)
+              .where('users.is_active', '=', true),
           ),
           eb.and([
             eb('sheet_id', 'is', null),
@@ -226,12 +234,20 @@ export class DingTalkGroupDestinationService {
     } else {
       builder = builder.where((eb) =>
         eb.or([
+          // W4-PRE-1c item C (owner 裁决③, #4522 rev3 review, 2026-07-22, 逐字: "现在就统一为
+          // user_orgs.is_active && users.is_active,不留同型后续债"): same finding shape as
+          // `attendance-admin.ts`'s `canReadAttendanceDirectoryReadiness` and `api-tokens.ts`'s
+          // `requireOrgMemberAccess` (both already fixed in #4526) — a deactivated PLATFORM
+          // account (`users.is_active=false`) must not keep surfacing org-scoped destinations
+          // through a `user_orgs` row that is still `is_active=true`.
           eb.exists(
             eb.selectFrom('user_orgs')
-              .select('user_id')
+              .innerJoin('users', 'users.id', 'user_orgs.user_id')
+              .select('user_orgs.user_id')
               .whereRef('user_orgs.org_id', '=', 'dingtalk_group_destinations.org_id')
               .where('user_orgs.user_id', '=', userId)
-              .where('user_orgs.is_active', '=', true),
+              .where('user_orgs.is_active', '=', true)
+              .where('users.is_active', '=', true),
           ),
           eb.and([
             eb('sheet_id', 'is', null),

--- a/packages/core-backend/tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts
@@ -1,0 +1,183 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory-sync'
+
+/**
+ * W4-PRE-1c items A/B, owner cases ② ("双组织") and ③ ("活跃 sibling") — proved against real
+ * Postgres via a DIRECT call to `applyDirectoryDeprovisionPolicies` (same harness style as the
+ * pre-existing `directory-deprovision-selection.db.test.ts`; case ①'s own file drives the full
+ * `syncDirectoryIntegration` orchestration, which owner named specifically for that case only).
+ *
+ * Case ② construction note (see PR body's combination-semantics section for the full reasoning):
+ * `applyDirectoryDeprovisionPolicies`'s OWN candidate-selection sibling guard is GLOBAL (any
+ * OTHER active *directory-linked* account, in ANY org, disqualifies a person from being a
+ * candidate at all — pre-existing #4526 "rehire protection" behaviour, unchanged by this PR).
+ * So a person who ALSO holds an active directory-linked account in org B would never become a
+ * candidate for org A's sweep in the first place — nothing would execute, and the test would
+ * prove nothing. Org B's membership here is therefore NOT directory-linked (no
+ * `directory_account_links` row) — seeded directly as a `user_orgs` row, exactly the shape a
+ * `POST /api/admin/users` explicit-`attendanceOrgId` admission (#4526 item D) would leave
+ * behind. This is the only construction that lets org A's policy actually execute while org B
+ * stays provably untouched.
+ *
+ * Case ③ framing (owner asked for this explicitly; see PR body): whenever the GLOBAL guard
+ * above admits a candidate, the ORG-SCOPED "no other active binding" check INSIDE
+ * `deactivateUserOrgMembershipIfNoOtherActiveBinding` (#4526) is provably always satisfied too
+ * — global no-sibling-anywhere is a strictly stronger condition than org-scoped no-sibling-
+ * here. So this call path can only reach case ③ via the GLOBAL pre-filter (candidateCount: 0,
+ * the new user_orgs write is never reached at all), not via the org-scoped helper's own check
+ * blocking anything. Presented as evidence for owner review, not an adjudicated claim about the
+ * helper being load-bearing on this specific call path.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const uid = (name: string) => `w4pre1cos-${name}-${TS}`
+
+describeIfDatabase('W4-PRE-1c cases ②③ — org-scoped user_orgs deactivation on policy execution (real DB)', () => {
+  let integrationA = ''
+  let integrationB = ''
+  let orgA = ''
+  let orgB = ''
+
+  const client = {
+    query: (sql: string, params?: unknown[]) =>
+      query(sql, params).then((r) => ({ rows: r.rows as Array<Record<string, unknown>> })),
+  }
+
+  const baseOptions = {
+    integrationDefaultPolicy: 'mark_inactive',
+    syncedAccountCount: 100,
+    enabled: true,
+  }
+
+  async function seedAccount(opts: {
+    integrationId: string
+    userId: string
+    accountActive: boolean
+    override?: string | null
+  }): Promise<string> {
+    await query(
+      `INSERT INTO users (id, password_hash, is_active) VALUES ($1, 'x', true) ON CONFLICT (id) DO NOTHING`,
+      [opts.userId],
+    )
+    const external = `${opts.userId}-acct-${Math.random().toString(36).slice(2, 10)}`
+    const account = await query<{ id: string }>(
+      `INSERT INTO directory_accounts
+         (integration_id, external_user_id, external_key, name, is_active, deprovision_policy_override)
+       VALUES ($1, $2, $3, 'Fixture', $4, $5)
+       RETURNING id::text AS id`,
+      [opts.integrationId, external, `dingtalk:${external}`, opts.accountActive, opts.override ?? null],
+    )
+    const accountId = account.rows[0].id
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status)
+       VALUES ($1::uuid, $2, 'linked')`,
+      [accountId, opts.userId],
+    )
+    return accountId
+  }
+
+  const membershipIsActive = async (userId: string, orgId: string): Promise<boolean | null> => {
+    const result = await query<{ is_active: boolean }>(`SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`, [userId, orgId])
+    return result.rows[0]?.is_active ?? null
+  }
+
+  beforeAll(async () => {
+    integrationA = (await query<{ id: string; org_id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id, org_id) VALUES ($1, $2, $3) RETURNING id::text AS id, org_id`,
+      [`w4pre1cos-a-${TS}`, `w4pre1cos-corp-a-${TS}`, `w4pre1cos-org-a-${TS}`],
+    )).rows[0].id
+    orgA = `w4pre1cos-org-a-${TS}`
+    integrationB = (await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id, org_id) VALUES ($1, $2, $3) RETURNING id::text AS id`,
+      [`w4pre1cos-b-${TS}`, `w4pre1cos-corp-b-${TS}`, `w4pre1cos-org-b-${TS}`],
+    )).rows[0].id
+    orgB = `w4pre1cos-org-b-${TS}`
+  })
+
+  afterEach(async () => {
+    await query(`DELETE FROM user_external_auth_grants WHERE local_user_id LIKE $1`, [`w4pre1cos-%-${TS}`])
+    await query(`DELETE FROM user_orgs WHERE user_id LIKE $1`, [`w4pre1cos-%-${TS}`])
+    await query(`DELETE FROM directory_accounts WHERE integration_id = ANY($1::uuid[])`, [[integrationA, integrationB]]) // links cascade
+    await query(`DELETE FROM users WHERE id LIKE $1`, [`w4pre1cos-%-${TS}`])
+  })
+
+  afterAll(async () => {
+    await query(`DELETE FROM directory_integrations WHERE id = ANY($1::uuid[])`, [[integrationA, integrationB]])
+  })
+
+  it('case ② dual-org: org A policy execution deactivates ONLY org A membership; org B (non-directory-linked) membership is untouched', async () => {
+    const user = uid('dualorg')
+    const departedA = await seedAccount({ integrationId: integrationA, userId: user, accountActive: false })
+
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)`, [user, orgA])
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)`, [user, orgB])
+
+    const outcome = await applyDirectoryDeprovisionPolicies(client, {
+      ...baseOptions,
+      integrationId: integrationA,
+      deactivatedAccountIds: [departedA],
+    })
+
+    expect(outcome.candidateCount).toBe(1)
+    expect(outcome.usersDeactivatedCount).toBe(1)
+    await expect(membershipIsActive(user, orgA)).resolves.toBe(false)
+    await expect(membershipIsActive(user, orgB)).resolves.toBe(true)
+  })
+
+  it('case ③ active sibling (same org): a person with another linked+active account is not even a candidate, so the pre-seeded active user_orgs row stays untouched', async () => {
+    const user = uid('sibling')
+    const departed = await seedAccount({ integrationId: integrationA, userId: user, accountActive: false })
+    await seedAccount({ integrationId: integrationA, userId: user, accountActive: true }) // active sibling, SAME org/integration
+
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)`, [user, orgA])
+
+    const outcome = await applyDirectoryDeprovisionPolicies(client, {
+      ...baseOptions,
+      integrationId: integrationA,
+      deactivatedAccountIds: [departed],
+    })
+
+    // The GLOBAL sibling guard excludes this person from candidacy entirely (pre-existing
+    // #4526 behaviour) — the new user_orgs write is never reached. See file doc-comment.
+    expect(outcome.candidateCount).toBe(0)
+    expect(outcome.affected).toEqual([])
+    await expect(membershipIsActive(user, orgA)).resolves.toBe(true)
+  })
+
+  it('positive control: a genuinely single-binding departure in org A DOES deactivate org A membership (sanity check for the two tests above)', async () => {
+    const user = uid('control')
+    const departed = await seedAccount({ integrationId: integrationA, userId: user, accountActive: false })
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)`, [user, orgA])
+
+    const outcome = await applyDirectoryDeprovisionPolicies(client, {
+      ...baseOptions,
+      integrationId: integrationA,
+      deactivatedAccountIds: [departed],
+    })
+
+    expect(outcome.candidateCount).toBe(1)
+    await expect(membershipIsActive(user, orgA)).resolves.toBe(false)
+  })
+
+  it('disable_grant_only ALSO attempts the user_orgs deactivation (owner 裁决②: "策略实际执行" excludes only manual_review)', async () => {
+    const user = uid('grantonly')
+    const departed = await seedAccount({ integrationId: integrationA, userId: user, accountActive: false })
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)`, [user, orgA])
+
+    const outcome = await applyDirectoryDeprovisionPolicies(client, {
+      ...baseOptions,
+      integrationId: integrationA,
+      integrationDefaultPolicy: 'disable_grant_only',
+      deactivatedAccountIds: [departed],
+    })
+
+    expect(outcome.usersDeactivatedCount).toBe(0) // users.is_active untouched, as before
+    expect(outcome.grantsDisabledCount).toBe(1)
+    const user_active = await query<{ is_active: boolean }>(`SELECT is_active FROM users WHERE id = $1`, [user])
+    expect(user_active.rows[0].is_active).toBe(true)
+    // …but org membership IS deactivated — a genuinely new consequence flagged for owner review.
+    await expect(membershipIsActive(user, orgA)).resolves.toBe(false)
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts
@@ -1,0 +1,198 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { query } from '../../src/db/pg'
+import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory-sync'
+import { db } from '../../src/db/db'
+import { DingTalkGroupDestinationService } from '../../src/multitable/dingtalk-group-destination-service'
+
+/**
+ * W4-PRE-1c owner case ⑤ ("权限负例") — after a genuine policy-executed departure (real
+ * `applyDirectoryDeprovisionPolicies` call, mark_inactive, real DB), the S7-5 readiness door
+ * 403s AND the DingTalk group destination visibility disappears; a positive control (a
+ * genuinely active member) proves the gate is not vacuously always-403/never-visible.
+ *
+ * Two SEPARATE fixture shapes are used deliberately (see the destination sub-suite's own
+ * doc-comment): the readiness-gate leg uses the REAL policy-executed deactivation (proving
+ * THIS PR's new mechanism feeds the pre-existing #4526 gate); the destination leg additionally
+ * needs a `users.is_active=false` + `user_orgs.is_active=true` fixture — the ONE shape that can
+ * distinguish "the two-clause EXISTS is correct" from "user_orgs alone already excluded the
+ * row" (mutation ④, owner E) — a fixture where ONLY user_orgs is deactivated would pass even
+ * with the `users.is_active` join deleted.
+ */
+vi.mock('../../src/rbac/rbac', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/rbac')>()
+  return {
+    ...actual,
+    rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  }
+})
+
+vi.mock('../../src/routes/admin-users', () => ({
+  ensurePlatformAdmin: vi.fn(async () => null),
+}))
+
+vi.mock('../../src/services/AttendanceNotificationRedelivery', () => ({
+  redeliverFailedAttendanceNotification: vi.fn(),
+}))
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+const TS = Date.now()
+const NS = `w4pre1cneg${TS}`
+
+describeIfDatabase('W4-PRE-1c case ⑤ leg 1 — readiness gate 403 after a policy-executed departure, real endpoint (real DB)', () => {
+  let attendanceAdminRouter: () => express.Router
+
+  const integrationName = `${NS}-integration`
+  const departedUser = `${NS}-departed`
+  const activeUser = `${NS}-active`
+  let integrationId = ''
+  let orgId = ''
+
+  const depClient = {
+    query: (sql: string, params?: unknown[]) =>
+      query(sql, params).then((r) => ({ rows: r.rows as Array<Record<string, unknown>> })),
+  }
+
+  function makeApp(userId: string) {
+    const app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as express.Request & { user?: unknown }).user = { id: userId, roles: ['user'], permissions: ['attendance:admin'] }
+      next()
+    })
+    app.use(attendanceAdminRouter())
+    return app
+  }
+
+  beforeAll(async () => {
+    if (!dbUrl) throw new Error('DATABASE_URL / ATTENDANCE_TEST_DATABASE_URL is required')
+    process.env.DATABASE_URL = dbUrl
+    ;({ attendanceAdminRouter } = await import('../../src/routes/attendance-admin'))
+
+    const row = (await query<{ id: string; org_id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id, org_id, default_deprovision_policy)
+       VALUES ($1, $2, $3, 'mark_inactive') RETURNING id::text AS id, org_id`,
+      [integrationName, `${integrationName}-corp`, `${NS}-org`],
+    )).rows[0]
+    integrationId = row.id
+    orgId = row.org_id
+
+    for (const userId of [departedUser, activeUser]) {
+      await query(
+        `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+         VALUES ($1, $2, $1, 'Fixture', 'x', 'user', '[]'::jsonb, true, false, NOW(), NOW())`,
+        [userId, `${userId}@example.test`],
+      )
+      await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true)`, [userId, orgId])
+    }
+
+    // The departed user's directory binding actually departs, and the policy actually
+    // executes — this is what deactivates user_orgs, not a raw SQL flip.
+    const external = `${departedUser}-acct`
+    const account = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, is_active)
+       VALUES ($1, $2, $3, 'Fixture', false) RETURNING id::text AS id`,
+      [integrationId, external, `dingtalk:${external}`],
+    )
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status) VALUES ($1::uuid, $2, 'linked')`,
+      [account.rows[0].id, departedUser],
+    )
+    const outcome = await applyDirectoryDeprovisionPolicies(depClient, {
+      integrationId,
+      deactivatedAccountIds: [account.rows[0].id],
+      syncedAccountCount: 50,
+      integrationDefaultPolicy: 'mark_inactive',
+      enabled: true,
+    })
+    expect(outcome.usersDeactivatedCount).toBe(1)
+  })
+
+  afterAll(async () => {
+    await query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [[departedUser, activeUser]])
+    await query(`DELETE FROM user_external_auth_grants WHERE local_user_id = $1`, [departedUser])
+    await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId]) // links cascade
+    await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+    await query(`DELETE FROM users WHERE id = ANY($1::text[])`, [[departedUser, activeUser]])
+  })
+
+  it('200 for a genuinely active org member (positive control)', async () => {
+    const res = await request(makeApp(activeUser)).get(`/api/attendance-admin/directory-readiness?orgId=${encodeURIComponent(orgId)}`)
+    expect(res.status).toBe(200)
+    expect(res.body?.ok).toBe(true)
+  })
+
+  it('403 for the departed member after the deprovision policy actually executed (this PR\'s own mechanism feeding the pre-existing #4526 gate)', async () => {
+    const readback = await query<{ is_active: boolean }>(`SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`, [departedUser, orgId])
+    expect(readback.rows[0].is_active).toBe(false) // sanity: the fixture setup actually deactivated it
+
+    const res = await request(makeApp(departedUser)).get(`/api/attendance-admin/directory-readiness?orgId=${encodeURIComponent(orgId)}`)
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('FORBIDDEN')
+  })
+})
+
+describeIfDatabase('W4-PRE-1c case ⑤ leg 2 — destination visibility disappears with the dual is_active filter (real DB, real Kysely)', () => {
+  const activeUser = `${NS}-dest-active`
+  const deactivatedUserActiveMembership = `${NS}-dest-deactivated-user`
+  const userIds = [activeUser, deactivatedUserActiveMembership]
+  const orgId = `${NS}-dest-org`
+  const service = new DingTalkGroupDestinationService(db, vi.fn())
+  let destinationId = ''
+
+  beforeAll(async () => {
+    process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'w4pre1c-test-key'
+    process.env.ENCRYPTION_SALT = process.env.ENCRYPTION_SALT || 'w4pre1c-test-salt'
+
+    await query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $1, 'Fixture', 'x', 'user', '[]'::jsonb, true, false, NOW(), NOW())`,
+      [activeUser, `${activeUser}@example.test`],
+    )
+    // Mutation ④ target fixture: users.is_active=false, user_orgs.is_active=true — the OLD
+    // single-filter EXISTS would still surface this row; only the NEW dual filter excludes it.
+    await query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $1, 'Fixture', 'x', 'user', '[]'::jsonb, false, false, NOW(), NOW())`,
+      [deactivatedUserActiveMembership, `${deactivatedUserActiveMembership}@example.test`],
+    )
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true)`, [activeUser, orgId])
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true)`, [deactivatedUserActiveMembership, orgId])
+
+    const destination = await service.createDestination('w4pre1c-creator', {
+      name: `${NS} org destination`,
+      webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=w4pre1c-token',
+      orgId,
+    })
+    destinationId = destination.id
+  })
+
+  afterAll(async () => {
+    if (destinationId) await query(`DELETE FROM dingtalk_group_destinations WHERE id = $1`, [destinationId])
+    await query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [userIds])
+    await query(`DELETE FROM users WHERE id = ANY($1::text[])`, [userIds])
+  })
+
+  it('visible to a genuinely active org member (positive control)', async () => {
+    const list = await service.listDestinations(activeUser)
+    expect(list.map((d) => d.id)).toContain(destinationId)
+  })
+
+  it('NOT visible when users.is_active=false even though user_orgs.is_active=true (mutation ④ target — the load-bearing case)', async () => {
+    const list = await service.listDestinations(deactivatedUserActiveMembership)
+    expect(list.map((d) => d.id)).not.toContain(destinationId)
+  })
+
+  it('NOT visible when user_orgs.is_active=false (pre-existing filter, unchanged by this PR — deactivated departure end state)', async () => {
+    await query(`UPDATE user_orgs SET is_active = false WHERE user_id = $1 AND org_id = $2`, [activeUser, orgId])
+    try {
+      const list = await service.listDestinations(activeUser)
+      expect(list.map((d) => d.id)).not.toContain(destinationId)
+    } finally {
+      await query(`UPDATE user_orgs SET is_active = true WHERE user_id = $1 AND org_id = $2`, [activeUser, orgId])
+    }
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts
@@ -19,6 +19,12 @@ import { DingTalkGroupDestinationService } from '../../src/multitable/dingtalk-g
  * distinguish "the two-clause EXISTS is correct" from "user_orgs alone already excluded the
  * row" (mutation ④, owner E) — a fixture where ONLY user_orgs is deactivated would pass even
  * with the `users.is_active` join deleted.
+ *
+ * Leg 3 (review finding, added after the original PR): `listDestinations` has TWO EXISTS
+ * clauses with the byte-identical dual `is_active` filter — one in the `else` branch (no
+ * sheetId/orgId, covered by leg 2 above) and a twin in the `normalizedSheetId` branch (a
+ * sheetId argument IS passed). Leg 2 never passes a sheetId, so it never reached the twin;
+ * leg 3 repeats the same three assertions WITH a sheetId argument to close that gap.
  */
 vi.mock('../../src/rbac/rbac', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/rbac/rbac')>()
@@ -190,6 +196,83 @@ describeIfDatabase('W4-PRE-1c case ⑤ leg 2 — destination visibility disappea
     await query(`UPDATE user_orgs SET is_active = false WHERE user_id = $1 AND org_id = $2`, [activeUser, orgId])
     try {
       const list = await service.listDestinations(activeUser)
+      expect(list.map((d) => d.id)).not.toContain(destinationId)
+    } finally {
+      await query(`UPDATE user_orgs SET is_active = true WHERE user_id = $1 AND org_id = $2`, [activeUser, orgId])
+    }
+  })
+})
+
+describeIfDatabase('W4-PRE-1c case ⑤ leg 3 — destination dual is_active filter on the normalizedSheetId branch twin (real DB, real Kysely)', () => {
+  // Review finding: leg 2 above only ever calls `listDestinations(user)` with NO sheetId
+  // argument, so it exercises the `else` branch's EXISTS clause only. This branch's twin
+  // (`normalizedSheetId` truthy) has the byte-identical dual `user_orgs.is_active AND
+  // users.is_active` EXISTS clause but had ZERO real-behavioral coverage — the ONLY test
+  // that ever passed a sheetId argument was the fully-mocked unit suite, whose `.where()`
+  // chain never invokes its callback (the EXISTS shape is never evaluated there).
+  //
+  // To reach this branch, `listDestinations` must be called WITH a sheetId, and the
+  // destination under test must be reachable via the EXISTS clause (org-scoped, org_id set)
+  // rather than via the direct `sheet_id = normalizedSheetId` match — the fixture's sheetId
+  // argument deliberately does NOT match the destination's (null) sheet_id column, so only
+  // the `sheet_id IS NULL` branch of `eb('sheet_id', '=', ...)` is false and the EXISTS
+  // clause is what actually decides visibility.
+  const activeUser = `${NS}-dest3-active`
+  const deactivatedUserActiveMembership = `${NS}-dest3-deactivated-user`
+  const userIds = [activeUser, deactivatedUserActiveMembership]
+  const orgId = `${NS}-dest3-org`
+  const unrelatedSheetId = `${NS}-dest3-unrelated-sheet`
+  const service = new DingTalkGroupDestinationService(db, vi.fn())
+  let destinationId = ''
+
+  beforeAll(async () => {
+    process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'w4pre1c-test-key'
+    process.env.ENCRYPTION_SALT = process.env.ENCRYPTION_SALT || 'w4pre1c-test-salt'
+
+    await query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $1, 'Fixture', 'x', 'user', '[]'::jsonb, true, false, NOW(), NOW())`,
+      [activeUser, `${activeUser}@example.test`],
+    )
+    // Same fixture shape as leg 2's mutation-④ target: users.is_active=false, user_orgs.is_active=true.
+    await query(
+      `INSERT INTO users (id, email, username, name, password_hash, role, permissions, is_active, is_admin, created_at, updated_at)
+       VALUES ($1, $2, $1, 'Fixture', 'x', 'user', '[]'::jsonb, false, false, NOW(), NOW())`,
+      [deactivatedUserActiveMembership, `${deactivatedUserActiveMembership}@example.test`],
+    )
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true)`, [activeUser, orgId])
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, true)`, [deactivatedUserActiveMembership, orgId])
+
+    // org-scoped (sheet_id stays NULL) — reachable ONLY via the EXISTS clause when a sheetId
+    // is passed to listDestinations, never via the direct sheet_id match.
+    const destination = await service.createDestination('w4pre1c-creator', {
+      name: `${NS} org destination (sheetId-branch twin)`,
+      webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=w4pre1c-token-3',
+      orgId,
+    })
+    destinationId = destination.id
+  })
+
+  afterAll(async () => {
+    if (destinationId) await query(`DELETE FROM dingtalk_group_destinations WHERE id = $1`, [destinationId])
+    await query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [userIds])
+    await query(`DELETE FROM users WHERE id = ANY($1::text[])`, [userIds])
+  })
+
+  it('visible to a genuinely active org member when a sheetId is ALSO passed (positive control, normalizedSheetId branch)', async () => {
+    const list = await service.listDestinations(activeUser, unrelatedSheetId)
+    expect(list.map((d) => d.id)).toContain(destinationId)
+  })
+
+  it('NOT visible when users.is_active=false even though user_orgs.is_active=true, with a sheetId passed (the load-bearing twin of mutation ④)', async () => {
+    const list = await service.listDestinations(deactivatedUserActiveMembership, unrelatedSheetId)
+    expect(list.map((d) => d.id)).not.toContain(destinationId)
+  })
+
+  it('NOT visible when user_orgs.is_active=false, with a sheetId passed (pre-existing filter, unchanged by this PR)', async () => {
+    await query(`UPDATE user_orgs SET is_active = false WHERE user_id = $1 AND org_id = $2`, [activeUser, orgId])
+    try {
+      const list = await service.listDestinations(activeUser, unrelatedSheetId)
       expect(list.map((d) => d.id)).not.toContain(destinationId)
     } finally {
       await query(`UPDATE user_orgs SET is_active = true WHERE user_id = $1 AND org_id = $2`, [activeUser, orgId])

--- a/packages/core-backend/tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts
@@ -1,10 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 /**
- * W4-PRE-1c item A (owner 裁决②, #4522 rev3 review, 2026-07-22, 逐字):
- * "不要因『单次同步缺失』直接撤销 membership。推荐在 deprovision circuit-breaker 通过、开关
- * 启用且策略实际执行时,同事务失活对应 user_orgs;manual_review 则保持 active 并暴露待人工
- * 确认状态。"
+ * W4-PRE-1c item A (owner 裁决②, #4522 rev3 review, 2026-07-22 — the only GitHub-persisted
+ * text is issuecomment-5042388830's acknowledgment):
+ * "不因单次同步缺失撤销 membership；deprovision circuit-breaker 通过 + 开关启用 + 策略实际
+ * 执行时同事务失活对应 user_orgs；manual_review 保持 active 并暴露待人工确认状态。"
  *
  * Owner's case ① ("真实同步 sweep"): drives the REAL `syncDirectoryIntegration` orchestration
  * over a genuine departure (an account absent from the mocked DingTalk pull), not a hand-

--- a/packages/core-backend/tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts
@@ -1,0 +1,247 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+/**
+ * W4-PRE-1c item A (owner 裁决②, #4522 rev3 review, 2026-07-22, 逐字):
+ * "不要因『单次同步缺失』直接撤销 membership。推荐在 deprovision circuit-breaker 通过、开关
+ * 启用且策略实际执行时,同事务失活对应 user_orgs;manual_review 则保持 active 并暴露待人工
+ * 确认状态。"
+ *
+ * Owner's case ① ("真实同步 sweep"): drives the REAL `syncDirectoryIntegration` orchestration
+ * over a genuine departure (an account absent from the mocked DingTalk pull), not a hand-
+ * invoked `applyDirectoryDeprovisionPolicies` call — proving the DT-OPS-01 sweep and the
+ * deprovision executor compose correctly end-to-end in the production call path, both inside
+ * the SAME transaction.
+ *
+ * Fixture pattern follows `directory-sync-orchestration.db.test.ts`'s own "departure fixture"
+ * (§3, `seedDepartureFixture`): pre-seed a `directory_accounts` row with an old `last_seen_at`
+ * so ONE sync (the account absent from the mock pull) both transitions the sweep AND feeds the
+ * deprovision executor — no second pass needed. That file proves the executor's existing
+ * `users.is_active` / grant effects; THIS file proves the NEW `user_orgs` effect (owner 裁决②)
+ * on top of an initial ACTIVE `user_orgs` row that file never seeds.
+ */
+const clientMocks = vi.hoisted(() => ({
+  fetchDingTalkAppAccessToken: vi.fn(),
+  listDingTalkDepartments: vi.fn(),
+  getDingTalkDepartmentDetail: vi.fn(),
+  listDingTalkDepartmentUsers: vi.fn(),
+  getDingTalkUserDetail: vi.fn(),
+}))
+
+vi.mock('../../src/integrations/dingtalk/client', () => ({
+  fetchDingTalkAppAccessToken: clientMocks.fetchDingTalkAppAccessToken,
+  listDingTalkDepartments: clientMocks.listDingTalkDepartments,
+  getDingTalkDepartmentDetail: clientMocks.getDingTalkDepartmentDetail,
+  listDingTalkDepartmentUsers: clientMocks.listDingTalkDepartmentUsers,
+  getDingTalkUserDetail: clientMocks.getDingTalkUserDetail,
+}))
+
+import { query } from '../../src/db/pg'
+import { createDirectoryIntegration, listDirectorySyncRuns, syncDirectoryIntegration } from '../../src/directory/directory-sync'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+type Fixture = {
+  integrationId: string
+  orgId: string
+  localUserId: string
+  accountId: string
+  deptId: string
+  survivorExt: string
+}
+
+/** The departed account and its `user_orgs` row are pre-seeded; the survivor keeps
+ * `syncedAccountCount > 0` so the empty-fetch circuit breaker never fires. */
+async function seedDepartureFixture(tag: string): Promise<Fixture> {
+  const integration = await createDirectoryIntegration({
+    name: `w4pre1cdep-${tag}-${TS}`,
+    corpId: `w4pre1cdep-corp-${tag}-${TS}`,
+    appKey: `w4pre1cdep-appkey-${tag}-${TS}`,
+    appSecret: 'w4pre1cdep-secret',
+    admissionMode: 'manual_only',
+    defaultDeprovisionPolicy: 'mark_inactive',
+  })
+
+  const localUserId = `w4pre1cdep-user-${tag}-${TS}`
+  await query(`INSERT INTO users (id, email, password_hash, is_active) VALUES ($1, $2, 'x', TRUE)`, [
+    localUserId,
+    `${localUserId}@example.test`,
+  ])
+  await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)`, [localUserId, integration.orgId])
+
+  const account = await query<{ id: string }>(
+    `INSERT INTO directory_accounts (
+       integration_id, corp_id, external_user_id, union_id, external_key, name, is_active, last_seen_at, created_at, updated_at
+     ) VALUES ($1, $2, $3, $4, $4, 'Departed', true, NOW(), NOW(), NOW())
+     RETURNING id`,
+    [integration.id, `w4pre1cdep-corp-${tag}-${TS}`, `w4pre1cdep-ext-${tag}-${TS}`, `w4pre1cdep-un-${tag}-${TS}`],
+  )
+  await query(
+    `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy, created_at, updated_at)
+     VALUES ($1, $2, 'linked', 'manual', NOW(), NOW())`,
+    [account.rows[0].id, localUserId],
+  )
+
+  return {
+    integrationId: integration.id,
+    orgId: integration.orgId,
+    localUserId,
+    accountId: account.rows[0].id,
+    deptId: `w4pre1cdep-dept-${tag}-${TS}`,
+    survivorExt: `w4pre1cdep-surv-${tag}-${TS}`,
+  }
+}
+
+function armMockDirectory(fixture: Fixture): void {
+  clientMocks.fetchDingTalkAppAccessToken.mockResolvedValue('w4pre1cdep-token')
+  clientMocks.listDingTalkDepartments.mockImplementation(async (_token: string, parentId: string) =>
+    parentId === '1' ? [{ id: fixture.deptId, parentId: '1', name: 'W4PRE1C Departure', order: 0, source: {} }] : [],
+  )
+  clientMocks.getDingTalkDepartmentDetail.mockResolvedValue({ deptManagerUserIdList: [] })
+  clientMocks.listDingTalkDepartmentUsers.mockImplementation(async (_token: string, deptId: string) =>
+    // The departed account is deliberately NOT in the pull; the survivor keeps
+    // syncedAccountCount > 0 so the empty-fetch circuit breaker stays quiet.
+    deptId === fixture.deptId
+      ? { users: [{ userId: fixture.survivorExt, name: 'Survivor', departmentIds: [fixture.deptId], source: {} }], nextCursor: null, hasMore: false }
+      : { users: [], nextCursor: null, hasMore: false },
+  )
+  clientMocks.getDingTalkUserDetail.mockImplementation(async (_token: string, userId: string) => ({
+    userId,
+    name: 'Survivor',
+    unionId: `${fixture.survivorExt}-un`,
+    openId: `${fixture.survivorExt}-op`,
+    email: `${fixture.survivorExt}@example.test`,
+    mobile: undefined,
+    departmentIds: [fixture.deptId],
+    source: {},
+  }))
+}
+
+async function cleanupFixture(fixture: Fixture): Promise<void> {
+  await query(`DELETE FROM directory_sync_alerts WHERE integration_id = $1`, [fixture.integrationId])
+  await query(`DELETE FROM directory_sync_runs WHERE integration_id = $1`, [fixture.integrationId])
+  await query(
+    `DELETE FROM directory_account_links WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = $1)`,
+    [fixture.integrationId],
+  )
+  await query(
+    `DELETE FROM directory_account_departments WHERE directory_account_id IN (SELECT id FROM directory_accounts WHERE integration_id = $1)`,
+    [fixture.integrationId],
+  )
+  await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [fixture.integrationId])
+  await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [fixture.integrationId])
+  await query(`DELETE FROM directory_integrations WHERE id = $1`, [fixture.integrationId])
+  await query(`DELETE FROM user_external_auth_grants WHERE local_user_id = $1`, [fixture.localUserId])
+  await query(`DELETE FROM user_orgs WHERE user_id = $1`, [fixture.localUserId])
+  await query(`DELETE FROM users WHERE id = $1`, [fixture.localUserId])
+}
+
+const membershipIsActive = async (userId: string, orgId: string): Promise<boolean | null> => {
+  const result = await query<{ is_active: boolean }>(`SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`, [userId, orgId])
+  return result.rows[0]?.is_active ?? null
+}
+
+describeIfDatabase('W4-PRE-1c case ① — real sync sweep composed with the deprovision executor (real DB)', () => {
+  describe('DIRECTORY_DEPROVISION_ENABLED unset (shipped default) — the switch being off means ZERO user_orgs deactivation', () => {
+    let fixture: Fixture
+
+    afterAll(async () => {
+      if (fixture) await cleanupFixture(fixture)
+    })
+
+    it('a genuine departure (sweep transitions + circuit breaker passes) writes NOTHING to user_orgs while the switch is off', async () => {
+      fixture = await seedDepartureFixture('off')
+      armMockDirectory(fixture)
+      expect(process.env.DIRECTORY_DEPROVISION_ENABLED).toBeUndefined()
+
+      await expect(membershipIsActive(fixture.localUserId, fixture.orgId)).resolves.toBe(true)
+
+      const result = await syncDirectoryIntegration(fixture.integrationId, 'system:w4pre1c-dep-off', 'manual')
+      const stats = result.run.stats as Record<string, unknown>
+
+      // The sweep DID transition the account (real, unconditional) and the executor DID
+      // evaluate it (candidateCount / would-be counts) — only the WRITE is gated off.
+      const account = await query<{ is_active: boolean }>(`SELECT is_active FROM directory_accounts WHERE id = $1`, [fixture.accountId])
+      expect(account.rows[0].is_active).toBe(false)
+      expect(stats.deprovisionApplied).toBe(false)
+      expect(stats.deprovisionCandidateCount).toBe(1)
+      expect(stats.deprovisionUsersDeactivatedCount).toBe(1) // preview: "would have"
+
+      // THE LOAD-BEARING ASSERTION for mutations ①/② (owner E): switch off ⇒ membership
+      // stays ACTIVE, no matter where in the pipeline the sweep sits.
+      await expect(membershipIsActive(fixture.localUserId, fixture.orgId)).resolves.toBe(true)
+
+      // …and users.is_active also stayed untouched (pre-existing default-off guarantee).
+      const user = await query<{ is_active: boolean }>(`SELECT is_active FROM users WHERE id = $1`, [fixture.localUserId])
+      expect(user.rows[0].is_active).toBe(true)
+    }, 30_000)
+  })
+
+  describe('DIRECTORY_DEPROVISION_ENABLED=true + circuit breaker passes + mark_inactive actually executes — SAME-transaction user_orgs deactivation', () => {
+    let fixture: Fixture
+
+    afterAll(async () => {
+      if (fixture) await cleanupFixture(fixture)
+      delete process.env.DIRECTORY_DEPROVISION_ENABLED
+    })
+
+    it('the departure is swept, the policy executes, and user_orgs is deactivated in the SAME run/transaction', async () => {
+      fixture = await seedDepartureFixture('on')
+      armMockDirectory(fixture)
+
+      await expect(membershipIsActive(fixture.localUserId, fixture.orgId)).resolves.toBe(true)
+
+      process.env.DIRECTORY_DEPROVISION_ENABLED = 'true'
+      const result = await syncDirectoryIntegration(fixture.integrationId, 'system:w4pre1c-dep-on', 'manual')
+      const stats = result.run.stats as Record<string, unknown>
+
+      const account = await query<{ is_active: boolean }>(`SELECT is_active FROM directory_accounts WHERE id = $1`, [fixture.accountId])
+      expect(account.rows[0].is_active).toBe(false)
+      expect(stats.deprovisionApplied).toBe(true)
+      expect(stats.deprovisionCandidateCount).toBe(1)
+      expect(stats.deprovisionUsersDeactivatedCount).toBe(1)
+      expect(stats.deprovisionAbortedReason).toBeNull()
+
+      // THE LOAD-BEARING ASSERTION: circuit breaker passed + switch on + policy actually
+      // executed (mark_inactive, not manual_review) ⇒ same-transaction user_orgs deactivation.
+      await expect(membershipIsActive(fixture.localUserId, fixture.orgId)).resolves.toBe(false)
+
+      const user = await query<{ is_active: boolean }>(`SELECT is_active FROM users WHERE id = $1`, [fixture.localUserId])
+      expect(user.rows[0].is_active).toBe(false)
+    }, 30_000)
+  })
+})
+
+/** Sanity check that the new stats field the deprovision executor now writes is reachable
+ * through the SAME existing admin surface `deprovisionAffected` already used
+ * (`listDirectorySyncRuns` → `GET /integrations/:integrationId/runs`, see `admin-directory.ts`) —
+ * proving the end of the wiring, not just the in-memory function return. Case ④'s own file
+ * proves the manualReviewPending CONTENT semantics against a lighter direct-call harness; this
+ * confirms the full production wiring persists it into `directory_sync_runs.stats` too.
+ */
+describeIfDatabase('W4-PRE-1c — manualReviewPending persists through the run-stats surface (real sync, real DB)', () => {
+  let fixture: Fixture
+
+  afterAll(async () => {
+    if (fixture) await cleanupFixture(fixture)
+    delete process.env.DIRECTORY_DEPROVISION_ENABLED
+  })
+
+  it('a manual_review departure appears in directory_sync_runs.stats.deprovisionManualReviewPending, and membership stays active', async () => {
+    fixture = await seedDepartureFixture('review')
+    await query(`UPDATE directory_integrations SET default_deprovision_policy = 'manual_review' WHERE id = $1`, [fixture.integrationId])
+    armMockDirectory(fixture)
+
+    process.env.DIRECTORY_DEPROVISION_ENABLED = 'true'
+    await syncDirectoryIntegration(fixture.integrationId, 'system:w4pre1c-dep-review', 'manual')
+
+    const runs = await listDirectorySyncRuns(fixture.integrationId, { limit: 1, offset: 0 })
+    const stats = runs.items[0]?.stats as Record<string, unknown>
+    expect(stats.deprovisionManualReviewPending).toEqual([
+      { directoryAccountId: fixture.accountId, localUserId: fixture.localUserId, orgId: fixture.orgId },
+    ])
+    expect(stats.deprovisionAffected).toEqual([])
+
+    await expect(membershipIsActive(fixture.localUserId, fixture.orgId)).resolves.toBe(true)
+  }, 30_000)
+})

--- a/packages/core-backend/tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory-sync'
+
+/**
+ * W4-PRE-1c item B, owner case ④ ("人工复核") — owner 裁决②, 逐字: "manual_review 则保持
+ * active 并暴露待人工确认状态".
+ *
+ * Run with `enabled: true` (not the default-off preview) — deliberately, so a mutation that
+ * moves the `user_orgs` deactivation call INSIDE the `manual_review` branch (mutation ③, owner
+ * E) actually fires and this test catches it. Running disabled would make such a mutation
+ * unreachable regardless of correctness (the write is gated on `enabled` either way) and the
+ * test would pass for the wrong reason.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const uid = (name: string) => `w4pre1cmr-${name}-${TS}`
+
+describeIfDatabase('W4-PRE-1c case ④ — manual_review keeps membership ACTIVE and exposes a pending-confirmation state (real DB)', () => {
+  let integrationId = ''
+  let orgId = ''
+
+  const client = {
+    query: (sql: string, params?: unknown[]) =>
+      query(sql, params).then((r) => ({ rows: r.rows as Array<Record<string, unknown>> })),
+  }
+
+  const membershipIsActive = async (userId: string, org: string): Promise<boolean | null> => {
+    const result = await query<{ is_active: boolean }>(`SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`, [userId, org])
+    return result.rows[0]?.is_active ?? null
+  }
+
+  beforeAll(async () => {
+    const row = (await query<{ id: string; org_id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id, org_id, default_deprovision_policy)
+       VALUES ($1, $2, $3, 'manual_review') RETURNING id::text AS id, org_id`,
+      [`w4pre1cmr-${TS}`, `w4pre1cmr-corp-${TS}`, `w4pre1cmr-org-${TS}`],
+    )).rows[0]
+    integrationId = row.id
+    orgId = row.org_id
+  })
+
+  afterEach(async () => {
+    await query(`DELETE FROM user_external_auth_grants WHERE local_user_id LIKE $1`, [`w4pre1cmr-%-${TS}`])
+    await query(`DELETE FROM user_orgs WHERE user_id LIKE $1`, [`w4pre1cmr-%-${TS}`])
+    await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId]) // links cascade
+    await query(`DELETE FROM users WHERE id LIKE $1`, [`w4pre1cmr-%-${TS}`])
+  })
+
+  afterAll(async () => {
+    await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+  })
+
+  it('manual_review: membership stays ACTIVE, no grant/user write, and the pending state is exposed org/membership-scoped', async () => {
+    const user = uid('pending')
+    await query(`INSERT INTO users (id, password_hash, is_active) VALUES ($1, 'x', true)`, [user])
+    const external = `${user}-acct`
+    const account = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, is_active)
+       VALUES ($1, $2, $3, 'Fixture', false) RETURNING id::text AS id`,
+      [integrationId, external, `dingtalk:${external}`],
+    )
+    const accountId = account.rows[0].id
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status) VALUES ($1::uuid, $2, 'linked')`,
+      [accountId, user],
+    )
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)`, [user, orgId])
+
+    const outcome = await applyDirectoryDeprovisionPolicies(client, {
+      integrationId,
+      deactivatedAccountIds: [accountId],
+      syncedAccountCount: 50,
+      integrationDefaultPolicy: 'manual_review',
+      enabled: true, // deliberately enabled — see file doc-comment for why this matters
+    })
+
+    expect(outcome.candidateCount).toBe(1)
+    expect(outcome.manualReviewCount).toBe(1)
+    expect(outcome.affected).toEqual([])
+    expect(outcome.usersDeactivatedCount).toBe(0)
+    expect(outcome.grantsDisabledCount).toBe(0)
+
+    // THE LOAD-BEARING ASSERTION for mutation ③ (owner E): manual_review must never deactivate
+    // user_orgs, even when the switch is on and the circuit breaker passed.
+    await expect(membershipIsActive(user, orgId)).resolves.toBe(true)
+
+    const grant = await query(`SELECT 1 FROM user_external_auth_grants WHERE local_user_id = $1`, [user])
+    expect(grant.rows).toEqual([])
+    const platformUser = await query<{ is_active: boolean }>(`SELECT is_active FROM users WHERE id = $1`, [user])
+    expect(platformUser.rows[0].is_active).toBe(true)
+
+    // The "待人工确认" exposure (owner裁决②): org/membership-scoped, values-free (ids only).
+    expect(outcome.manualReviewPending).toEqual([{ directoryAccountId: accountId, localUserId: user, orgId }])
+  })
+
+  it('a per-account override to manual_review inside an otherwise mark_inactive integration ALSO stays active and pending (least-destructive-wins composition)', async () => {
+    const user = uid('override')
+    await query(`UPDATE directory_integrations SET default_deprovision_policy = 'mark_inactive' WHERE id = $1`, [integrationId])
+    await query(`INSERT INTO users (id, password_hash, is_active) VALUES ($1, 'x', true)`, [user])
+    const external = `${user}-acct`
+    const account = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, is_active, deprovision_policy_override)
+       VALUES ($1, $2, $3, 'Fixture', false, 'manual_review') RETURNING id::text AS id`,
+      [integrationId, external, `dingtalk:${external}`],
+    )
+    const accountId = account.rows[0].id
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status) VALUES ($1::uuid, $2, 'linked')`,
+      [accountId, user],
+    )
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)`, [user, orgId])
+
+    const outcome = await applyDirectoryDeprovisionPolicies(client, {
+      integrationId,
+      deactivatedAccountIds: [accountId],
+      syncedAccountCount: 50,
+      integrationDefaultPolicy: 'mark_inactive',
+      enabled: true,
+    })
+
+    expect(outcome.manualReviewCount).toBe(1)
+    await expect(membershipIsActive(user, orgId)).resolves.toBe(true)
+    expect(outcome.manualReviewPending).toEqual([{ directoryAccountId: accountId, localUserId: user, orgId }])
+
+    await query(`UPDATE directory_integrations SET default_deprovision_policy = 'manual_review' WHERE id = $1`, [integrationId])
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts
@@ -3,14 +3,21 @@ import { query } from '../../src/db/pg'
 import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory-sync'
 
 /**
- * W4-PRE-1c item B, owner case ④ ("人工复核") — owner 裁决②, 逐字: "manual_review 则保持
+ * W4-PRE-1c item B, owner case ④ ("人工复核") — owner 裁决② (#4522 rev3 review; the only
+ * GitHub-persisted text is issuecomment-5042388830's acknowledgment): "manual_review 保持
  * active 并暴露待人工确认状态".
  *
- * Run with `enabled: true` (not the default-off preview) — deliberately, so a mutation that
- * moves the `user_orgs` deactivation call INSIDE the `manual_review` branch (mutation ③, owner
- * E) actually fires and this test catches it. Running disabled would make such a mutation
- * unreachable regardless of correctness (the write is gated on `enabled` either way) and the
- * test would pass for the wrong reason.
+ * The first two tests run with `enabled: true` (not the default-off preview) — deliberately, so
+ * a mutation that moves the `user_orgs` deactivation call INSIDE the `manual_review` branch
+ * (mutation ③, owner E) actually fires and those tests catch it. Running disabled would make
+ * such a mutation unreachable regardless of correctness (the write is gated on `enabled` either
+ * way) and the test would pass for the wrong reason.
+ *
+ * The third test below is the complement: `manualReviewPending` (item B's body claim — "Populated
+ * … regardless of `enabled`") must ALSO hold with `enabled: false`, which is the shipped default
+ * (`DIRECTORY_DEPROVISION_ENABLED` unset). Without this leg, wrapping the `manualReviewPending.push`
+ * in the `if (options.enabled)` gate would leave the whole exposure silently empty under the
+ * default-off posture while every other test in this file (all `enabled: true`) stayed green.
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -125,5 +132,39 @@ describeIfDatabase('W4-PRE-1c case ④ — manual_review keeps membership ACTIVE
     expect(outcome.manualReviewPending).toEqual([{ directoryAccountId: accountId, localUserId: user, orgId }])
 
     await query(`UPDATE directory_integrations SET default_deprovision_policy = 'manual_review' WHERE id = $1`, [integrationId])
+  })
+
+  it('manual_review pending exposure holds with enabled:false too (shipped default — DIRECTORY_DEPROVISION_ENABLED unset)', async () => {
+    const user = uid('pending-disabled')
+    await query(`INSERT INTO users (id, password_hash, is_active) VALUES ($1, 'x', true)`, [user])
+    const external = `${user}-acct`
+    const account = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, is_active)
+       VALUES ($1, $2, $3, 'Fixture', false) RETURNING id::text AS id`,
+      [integrationId, external, `dingtalk:${external}`],
+    )
+    const accountId = account.rows[0].id
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status) VALUES ($1::uuid, $2, 'linked')`,
+      [accountId, user],
+    )
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)`, [user, orgId])
+
+    const outcome = await applyDirectoryDeprovisionPolicies(client, {
+      integrationId,
+      deactivatedAccountIds: [accountId],
+      syncedAccountCount: 50,
+      integrationDefaultPolicy: 'manual_review',
+      enabled: false, // shipped default — item B claims exposure holds here too
+    })
+
+    expect(outcome.applied).toBe(false)
+    expect(outcome.manualReviewCount).toBe(1)
+    // THE LOAD-BEARING ASSERTION for this test: manualReviewPending must be populated even
+    // when the switch is off — a regression that wraps the push in `if (options.enabled)`
+    // would zero this out silently while every OTHER test in this file (all enabled:true)
+    // stays green.
+    expect(outcome.manualReviewPending).toEqual([{ directoryAccountId: accountId, localUserId: user, orgId }])
+    await expect(membershipIsActive(user, orgId)).resolves.toBe(true)
   })
 })

--- a/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
+++ b/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
@@ -24,6 +24,16 @@ import {
  * policy dispatch; the write-shape of each policy; the circuit breaker; the env gate; and the
  * fail-safe direction of policy resolution.
  */
+// W4-PRE-1c (owner 裁决②, #4522 rev3 review, 2026-07-22): `applyDirectoryDeprovisionPolicies`
+// now ALSO resolves the run's org (`SELECT org_id FROM directory_integrations ...`, lazily, at
+// most once) and — for a policy that actually executed a write — attempts a same-transaction
+// `user_orgs` deactivation via `deactivateUserOrgMembershipIfNoOtherActiveBinding` (a row lock
+// SELECT, then a conditional UPDATE). This stub answers all three shapes the same "does not
+// evaluate the predicate" way the pre-existing shapes do — the org-scoped sibling predicate
+// itself is proved against real Postgres in the real-DB suites (this file's own scope note),
+// same discipline extended to the new queries.
+const STUB_ORG_ID = 'org-1'
+
 function stubClient(candidates: Array<{ directory_account_id: string; local_user_id: string; deprovision_policy_override: string | null }>) {
   const queries: string[] = []
   return {
@@ -38,6 +48,15 @@ function stubClient(candidates: Array<{ directory_account_id: string; local_user
       if (/INSERT INTO user_external_auth_grants/i.test(sql) || /UPDATE users SET is_active = FALSE/i.test(sql)) {
         return { rows: [] }
       }
+      if (/SELECT org_id\s+FROM directory_integrations/i.test(sql)) {
+        return { rows: [{ org_id: STUB_ORG_ID }] }
+      }
+      if (/FROM user_orgs WHERE user_id = \$1::text AND org_id = \$2::text\s+FOR UPDATE/i.test(sql)) {
+        return { rows: [] }
+      }
+      if (/UPDATE user_orgs\s+SET is_active = FALSE/i.test(sql)) {
+        return { rows: [] }
+      }
       // Anything else is drift: a new query appeared that no test has reasoned about.
       throw new Error(`Unhandled SQL in deprovision stub:\n${sql}`)
     },
@@ -46,6 +65,7 @@ function stubClient(candidates: Array<{ directory_account_id: string; local_user
 
 const wrote = (queries: string[], pattern: RegExp) => queries.some((sql) => pattern.test(sql))
 const DEACTIVATES_USER = /UPDATE users SET is_active = FALSE/i
+const DEACTIVATES_USER_ORG = /UPDATE user_orgs\s+SET is_active = FALSE/i
 const DISABLES_GRANT = /INSERT INTO user_external_auth_grants/i
 
 const CANDIDATE = { directory_account_id: 'acct-1', local_user_id: 'user-1', deprovision_policy_override: null }
@@ -65,6 +85,10 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
     // The load-bearing safety property: merging this cannot deactivate anyone.
     expect(wrote(client.queries, DEACTIVATES_USER)).toBe(false)
     expect(wrote(client.queries, DISABLES_GRANT)).toBe(false)
+    // W4-PRE-1c (owner 裁决②): disabled must ALSO never attempt the user_orgs deactivation —
+    // this is the unit-level half of mutation ①/② (moving the write before the enabled gate,
+    // or dropping the gate); the real-DB half lives in the W4-PRE-1c real-DB suite.
+    expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(false)
 
     // …but the operator gets the preview.
     expect(outcome).toMatchObject({
@@ -76,17 +100,22 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
     })
   })
 
-  it('enabled + mark_inactive: disables the grant AND deactivates the local user', async () => {
+  it('enabled + mark_inactive: disables the grant, deactivates the local user, AND attempts the user_orgs deactivation', async () => {
     const client = stubClient([CANDIDATE])
     const outcome = await applyDirectoryDeprovisionPolicies(client, { ...baseOptions, enabled: true })
 
     expect(wrote(client.queries, DISABLES_GRANT)).toBe(true)
     expect(wrote(client.queries, DEACTIVATES_USER)).toBe(true)
+    // W4-PRE-1c (owner 裁决②): mark_inactive is a policy that "actually executes" — the
+    // user_orgs deactivation attempt must fire in the same run. Whether it actually FLIPS the
+    // row depends on the org-scoped sibling check (real-DB suites); this stub cannot evaluate
+    // that predicate, only that the write was attempted.
+    expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(true)
     expect(outcome.applied).toBe(true)
     expect(outcome.affected).toEqual([{ directoryAccountId: 'acct-1', localUserId: 'user-1', policy: 'mark_inactive' }])
   })
 
-  it('enabled + disable_grant_only: revokes DingTalk login but leaves the local user active', async () => {
+  it('enabled + disable_grant_only: revokes DingTalk login, leaves the local user active, but STILL attempts the user_orgs deactivation', async () => {
     const client = stubClient([CANDIDATE])
     const outcome = await applyDirectoryDeprovisionPolicies(client, {
       ...baseOptions,
@@ -96,10 +125,17 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
 
     expect(wrote(client.queries, DISABLES_GRANT)).toBe(true)
     expect(wrote(client.queries, DEACTIVATES_USER)).toBe(false)
+    // W4-PRE-1c (owner 裁决②, 逐字 "策略实际执行"): disable_grant_only is NOT manual_review —
+    // it revokes real access (the grant) — so per the owner's own carve-out (only
+    // manual_review is excluded), this branch ALSO attempts the user_orgs deactivation, even
+    // though it leaves `users.is_active` untouched. Flagged for owner confirmation in the PR
+    // body's combination-semantics section: this is a genuinely NEW consequence of
+    // disable_grant_only that did not exist before this PR.
+    expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(true)
     expect(outcome).toMatchObject({ grantsDisabledCount: 1, usersDeactivatedCount: 0 })
   })
 
-  it('enabled + manual_review: touches nothing, but the offboarding is counted', async () => {
+  it('enabled + manual_review: touches nothing (including user_orgs), but the offboarding is counted and exposed as pending', async () => {
     const client = stubClient([CANDIDATE])
     const outcome = await applyDirectoryDeprovisionPolicies(client, {
       ...baseOptions,
@@ -109,7 +145,13 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
 
     expect(wrote(client.queries, DISABLES_GRANT)).toBe(false)
     expect(wrote(client.queries, DEACTIVATES_USER)).toBe(false)
+    // W4-PRE-1c (owner 裁决②, 逐字: "manual_review 则保持 active 并暴露待人工确认状态"): the
+    // unique carve-out — no write attempted at all, including user_orgs.
+    expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(false)
     expect(outcome).toMatchObject({ candidateCount: 1, manualReviewCount: 1, affected: [] })
+    expect(outcome.manualReviewPending).toEqual([
+      { directoryAccountId: 'acct-1', localUserId: 'user-1', orgId: STUB_ORG_ID },
+    ])
   })
 
   it('honours a per-account override inside a batch', async () => {

--- a/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
+++ b/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
@@ -96,6 +96,9 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
       candidateCount: 1,
       usersDeactivatedCount: 1,
       grantsDisabledCount: 1,
+      // Preview mode reports what WOULD be attempted too — same construction as
+      // grantsDisabledCount (review-finding observability fix).
+      membershipDeactivationAttemptedCount: 1,
       abortedReason: null,
     })
   })
@@ -113,6 +116,7 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
     expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(true)
     expect(outcome.applied).toBe(true)
     expect(outcome.affected).toEqual([{ directoryAccountId: 'acct-1', localUserId: 'user-1', policy: 'mark_inactive' }])
+    expect(outcome.membershipDeactivationAttemptedCount).toBe(1)
   })
 
   it('enabled + disable_grant_only: revokes DingTalk login, leaves the local user active, but STILL attempts the user_orgs deactivation', async () => {
@@ -125,14 +129,15 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
 
     expect(wrote(client.queries, DISABLES_GRANT)).toBe(true)
     expect(wrote(client.queries, DEACTIVATES_USER)).toBe(false)
-    // W4-PRE-1c (owner 裁决②, 逐字 "策略实际执行"): disable_grant_only is NOT manual_review —
+    // W4-PRE-1c (owner 裁决②, #4522 rev3 review, phrase "策略实际执行" per issuecomment-5042388830):
+    // disable_grant_only is NOT manual_review —
     // it revokes real access (the grant) — so per the owner's own carve-out (only
     // manual_review is excluded), this branch ALSO attempts the user_orgs deactivation, even
     // though it leaves `users.is_active` untouched. Flagged for owner confirmation in the PR
     // body's combination-semantics section: this is a genuinely NEW consequence of
     // disable_grant_only that did not exist before this PR.
     expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(true)
-    expect(outcome).toMatchObject({ grantsDisabledCount: 1, usersDeactivatedCount: 0 })
+    expect(outcome).toMatchObject({ grantsDisabledCount: 1, usersDeactivatedCount: 0, membershipDeactivationAttemptedCount: 1 })
   })
 
   it('enabled + manual_review: touches nothing (including user_orgs), but the offboarding is counted and exposed as pending', async () => {
@@ -145,10 +150,11 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
 
     expect(wrote(client.queries, DISABLES_GRANT)).toBe(false)
     expect(wrote(client.queries, DEACTIVATES_USER)).toBe(false)
-    // W4-PRE-1c (owner 裁决②, 逐字: "manual_review 则保持 active 并暴露待人工确认状态"): the
+    // W4-PRE-1c (owner 裁决②, #4522 rev3 review — issuecomment-5042388830: "manual_review 保持
+    // active 并暴露待人工确认状态"): the
     // unique carve-out — no write attempted at all, including user_orgs.
     expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(false)
-    expect(outcome).toMatchObject({ candidateCount: 1, manualReviewCount: 1, affected: [] })
+    expect(outcome).toMatchObject({ candidateCount: 1, manualReviewCount: 1, affected: [], membershipDeactivationAttemptedCount: 0 })
     expect(outcome.manualReviewPending).toEqual([
       { directoryAccountId: 'acct-1', localUserId: 'user-1', orgId: STUB_ORG_ID },
     ])
@@ -213,6 +219,13 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
     expect(outcome.applied).toBe(false)
     expect(wrote(client.queries, DEACTIVATES_USER)).toBe(false)
     expect(wrote(client.queries, DISABLES_GRANT)).toBe(false)
+    // Review finding: the circuit-breaker's negative — "not passed ⇒ user_orgs is NEVER
+    // touched" — had no test anywhere in the repo. Without this, a future edit that moved the
+    // W4-PRE-1c deactivation call ahead of the abort-and-return (e.g. into the candidate
+    // dedup loop) would abort correctly for grants/users but still flip user_orgs, and every
+    // existing test (including the two in this describe block) would stay green.
+    expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(false)
+    expect(outcome.membershipDeactivationAttemptedCount).toBe(0)
   })
 
   it('an oversized batch aborts before any write', async () => {
@@ -230,6 +243,9 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
     expect(outcome.abortedReason).toBe('batch_exceeds_max')
     expect(outcome.applied).toBe(false)
     expect(wrote(client.queries, DEACTIVATES_USER)).toBe(false)
+    // Same breaker-negative coverage as the empty-fetch abort test above.
+    expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(false)
+    expect(outcome.membershipDeactivationAttemptedCount).toBe(0)
   })
 })
 

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -397,6 +397,17 @@ export default defineConfig({
       // #4526 review addition: real-DB behavioral proof for item E's api-tokens.ts dual filter
       // (the PR's original coverage was mock-SQL-text-only).
       'tests/integration/attendance-w4pre1b-api-tokens-org-member-access.db.test.ts',
+      // W4-PRE-1c real-DB (owner CHANGES_REQUESTED on the W4 re-ratify PR #4522, rev3 review,
+      // 2026-07-22): controlled-departure user_orgs deactivation (owner 裁决②) — real sync
+      // sweep composed with the deprovision executor (case ①), org-scoped composition with the
+      // global sibling guard (cases ②/③), manual_review pending exposure (case ④), and the
+      // readiness-gate + DingTalk destination permission negatives (case ⑤). DATABASE_URL-gated
+      // describeIfDatabase; excluded here so the no-DB job cannot skip-green them; wired
+      // whole-file into the attendance real-DB step in plugin-tests.yml.
+      'tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts',
+      'tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts',
+      'tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts',
+      'tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
## What

W4-PRE-1c — the code slice owner ordered in the CHANGES_REQUESTED verdict on the rev3 re-review of the W4 re-ratify PR #4522 (2026-07-22 comment). Closes owner's remaining [P1] ("钉钉离职主路径") and folds in [P2] ("destination 双活") from that same comment.

**Not merged, not armed.** Base `main` (`3727cd92e` = #4526 merged), refs #4522 #4526.

## 裁决②③ → 实现映射（处置；引用勘误见下方 REV1 FIXUP）

> [P1] 钉钉离职主路径 — owner 唯一 GitHub-持久化记录（issuecomment-5042388830，owner 本人确认 comment，非另一条"原文"的转述）: 「不因单次同步缺失撤销 membership；deprovision circuit-breaker 通过 + 开关启用 + 策略实际执行时同事务失活对应 user_orgs；manual_review 保持 active 并暴露待人工确认状态。」

→ `applyDirectoryDeprovisionPolicies` (`directory-sync.ts`): inside the existing per-candidate loop, for a policy that is **not** `manual_review` (i.e. `disable_grant_only` or `mark_inactive` — the two branches that already write something when `options.enabled`), the SAME `if (options.enabled)` block that writes the grant-disable row now ALSO calls `deactivateUserOrgMembershipIfNoOtherActiveBinding` (the #4526 helper, reused verbatim — same org-scoped "no other active binding" rule) for `{userId: localUserId, orgId}`. This code only runs once the circuit breaker has already passed (the function returns early on `abortedReason`) — so all three conditions (breaker passed / switch on / policy actually executed) gate the write together. `manual_review` hits a `continue` before this point and is never reached. The DT-OPS-01 sweep itself (`directory_accounts.is_active` flip) is untouched — it still only marks the account, never `user_orgs`; the comment at that call site (previously "KNOWN OPEN GAP … needs owner ruling") is rewritten to state the resolved boundary.

> [P2] destination 双活 — owner 唯一 GitHub-持久化记录（issuecomment-5042388830）: 「`dingtalk-group-destination-service.ts:213` 两处 EXISTS 统一为 `user_orgs.is_active && users.is_active`。」

→ `dingtalk-group-destination-service.ts`'s `listDestinations` — the ONE EXISTS clause owner named (`:213`, the "no explicit sheetId/orgId" implicit-org-visibility branch, plus its `normalizedSheetId`-branch twin at the same shape) now `.innerJoin('users', 'users.id', 'user_orgs.user_id')` and adds `.where('users.is_active', '=', true)`, matching the #4526 shape already shipped on `attendance-admin.ts`'s `canReadAttendanceDirectoryReadiness` and `api-tokens.ts`'s `requireOrgMemberAccess`. The THIRD branch (explicit `?orgId=` query param) is untouched — deliberately: that path is already gated at the ROUTE layer (`api-tokens.ts`'s `requireOrgReadAccess` → `requireOrgMemberAccess`, the already-dual-filtered check) before `listDestinations` is even called, so adding a second filter inside the service for that branch would be redundant, not a gap.

## 离职场景语义表（scenario / behavior / anchor）

| Scenario | Behavior | Anchor |
|---|---|---|
| Account absent from ONE DingTalk fetch (DT-OPS-01 sweep transitions `directory_accounts.is_active→false`) | `user_orgs` untouched by the sweep alone — a single missed sync never revokes membership | `directory-sync.ts` sweep ~L3550 (comment rewritten) |
| Deprovision executor runs, circuit breaker ABORTS (`empty_directory_fetch` / `batch_exceeds_max`) | `user_orgs` untouched — function returns before the loop | `applyDirectoryDeprovisionPolicies` abort branch |
| Circuit breaker passes, `DIRECTORY_DEPROVISION_ENABLED` unset/false (shipped default) | `user_orgs` untouched — preview only (`usersDeactivatedCount` reports "would have") | same function, `if (options.enabled)` gate |
| Breaker passes + switch on + resolved policy = `mark_inactive` | Same-transaction `user_orgs` deactivation (org-scoped, "no other active binding") + `users.is_active=false` + grant revoked | new `deactivateUserOrgMembershipIfNoOtherActiveBinding` call, gated `if (options.enabled)` |
| Breaker passes + switch on + resolved policy = `disable_grant_only` | Same-transaction `user_orgs` deactivation + grant revoked; `users.is_active` stays true | same call site — **genuinely new consequence of this PR**, flagged below |
| Breaker passes + switch on + resolved policy = `manual_review` | `user_orgs` stays ACTIVE (unconditionally — the branch `continue`s before reaching the write); pending-confirmation state exposed (`manualReviewPending`) | manual_review branch, before the non-manual-review code |
| Person has another linked+active directory account ANYWHERE (any org/provider) | Excluded from candidacy entirely (pre-existing #4526 GLOBAL sibling guard) — new `user_orgs` write is never reached | candidate SELECT's `NOT EXISTS`, unchanged by this PR |
| `PATCH /api/admin/users/:userId/status` (manual user deactivation) | `user_orgs` **not** touched — unchanged, pre-existing #4526 boundary | not modified this PR |

## 组合语义节 — 策略执行 × 其他有效绑定（留 owner 复核；REV1 修正见下）

Two DIFFERENT "no sibling" checks are now stacked on this call path:

1. `applyDirectoryDeprovisionPolicies`'s OWN candidate-selection sibling guard (pre-existing, #4526-era) is **GLOBAL**: any OTHER linked+active directory account for the same `local_user_id`, in ANY org, ANY provider, disqualifies the person from being a "candidate" at all — no grant/user/user_orgs write of any kind happens for them in this run. It is read **ONCE, early**, before the per-candidate loop and before any write in this run.
2. `deactivateUserOrgMembershipIfNoOtherActiveBinding` (#4526, reused here) is **ORG-SCOPED**: it only checks siblings within the SAME org as the deactivation target, and it re-checks **AT WRITE TIME**, under `SELECT ... FOR UPDATE`.

**REV1 correction (three-mirror review finding — this claim was WRONG in the original PR and has been removed from the code comment too):** the original text here asserted "whenever this call path reaches the deactivation call, check (2) is provably always satisfied already" and called check (2) "currently non-load-bearing" on this call path. That reasoning silently assumed guard (1)'s read and the helper's write happen atomically/simultaneously — they do not. Guard (1) reads a snapshot early; the helper re-reads under a row lock later, after at least one intervening `await` (the grant-disable INSERT). A concurrent transaction that commits a brand-new linked+active directory account for the SAME person in the SAME org, in that window, is invisible to guard (1)'s stale snapshot but IS caught by the helper's fresh re-read — the same cross-transaction write-skew shape #4526 itself fixed with `FOR UPDATE` for concurrent unbinds. **The org-scoped helper is therefore independently load-bearing on this call path, not merely inherited defense-in-depth.** This PR's own case ③ test still demonstrates a scenario where guard (1) alone is sufficient (no directory-linked sibling → excluded from candidacy before the helper is ever reached, `candidateCount: 0`) — that observation stands — but it does not establish that the helper is redundant in general, only that this ONE test's fixture happens not to need it. No concurrency-race test was added this round (would require two overlapping DB transactions coordinated via a manual lock-wait probe); flagging that as a real gap, not claiming it is closed.

Separately: `disable_grant_only` executing a `user_orgs` deactivation (not just `mark_inactive`) is a genuinely NEW consequence introduced by this PR — the owner's phrase "策略实际执行" (excluding only `manual_review` explicitly) is what this PR is scoping "actually executes" to. Flagging this reading for owner confirmation; it is a straightforward literal reading of the ruling, not an area with ambiguity noticed during implementation, but it changes real behavior for `disable_grant_only` integrations that did not exist before — see the blast-radius enumeration below (REV1 addition).

## Item B — manual_review pending exposure

No dedicated manual-review queue/table exists in this repo (checked: no `directory_review_queue` / `deprovision_queue` / equivalent). The minimal read-only exposure lives on the EXISTING queryable surface `GET /integrations/:integrationId/runs` (`admin-directory.ts`, platform-admin gated via `ensurePlatformAdmin`), which already returns the whole `directory_sync_runs.stats` JSONB blob (including the pre-existing `deprovisionAffected` array with raw ids). Added `deprovisionManualReviewPending: Array<{directoryAccountId, localUserId, orgId}>` (capped at 100 + a `…Truncated` flag, mirroring `deprovisionAffected`'s own pattern) — populated whenever a `manual_review` candidate is evaluated, **regardless of `enabled`** (consistent with the pre-existing `manualReviewCount`, which was already `enabled`-independent). Values-free: ids only, no name/email/mobile. Zero new table, zero new endpoint, zero new UI. **New real-DB test (REV1): `attendance-w4pre1c-manual-review-pending.db.test.ts`'s third case now proves this holds with `enabled: false` too (the shipped default) — the original PR shipped zero coverage for that leg.**

**REV1 disclosure (three-mirror review finding — this scope was previously implicit, not stated):** this array is a **per-run snapshot, not a queue**. It is written ONCE, into THIS run's `directory_sync_runs.stats` row, for the accounts THIS run's own sweep transitioned to inactive AND resolved to `manual_review`. A person still pending confirmation does NOT reappear on the next run — their `directory_accounts.is_active` is already `false`, so they no longer satisfy the sweep's own "this-run transition" filter. There is **no aggregate "who is currently still pending" view and no confirm/resolve marker anywhere in this repo**; an operator must enumerate past runs' `stats` blobs to find unresolved candidates. Acceptable as a minimal read-only exposure against the owner's "暴露待人工确认状态" bar, but flagged explicitly here so the limitation is visible before the owner adjudicates it, not discovered later.

## C — destination dual-filter

Done as described above. `dingtalk-group-destination-service.ts`'s own test suites (`tests/unit/dingtalk-group-destination-service.test.ts`, `tests/integration/dingtalk-group-destination-routes.api.test.ts`) are both FULLY MOCKED (the mock `.where()` chain never invokes its callback argument, so the EXISTS-subquery shape was never actually exercised by either file) — re-ran both, unaffected (37/37 green, unchanged), confirming this PR did not need to touch their assertions. New real-behavioral coverage for the dual filter lives in this PR's own real-DB suite (case ⑤ leg 2, below) — the first genuinely behavioral (real Kysely, real Postgres) test this service has ever had.

**REV1 correction (three-mirror review finding, P2):** the ORIGINAL version of this PR shipped leg 2 as the ONLY real-behavioral coverage, and leg 2 exclusively calls `listDestinations(user)` — **no `sheetId` argument, ever**. `listDestinations` has TWO structurally-identical EXISTS clauses with the dual filter: the `else` branch (no sheetId/orgId — the one leg 2 covers) and a byte-identical twin in the `normalizedSheetId` branch (reached only when a `sheetId` argument IS passed). The twin had **zero real-behavioral coverage** — dropping `.where('users.is_active', '=', true)` from JUST that branch left the whole suite green. Fixed: added case ⑤ **leg 3** (3 new real-DB tests, same fixture/assertion shape as leg 2 but calling `listDestinations(user, sheetId)`), and confirmed via mutation self-check that dropping the twin's filter now reddens leg 3's users-inactive test ONLY (leg 2 and everything else stays green — precise, isolated kill, same discipline as the original mutation ④).

## D — five test groups (owner-named cases, real DB, `w4pre1c` fixture prefix)

| # | Owner's case | File | Result |
|---|---|---|---|
| ① | 真实同步 sweep: switch off ⇒ zero user_orgs deactivation; switch on + breaker pass + policy executes ⇒ same-transaction deactivation | `attendance-w4pre1c-departure-sweep-deprovision.db.test.ts` — drives the REAL `syncDirectoryIntegration` orchestration (mocked DingTalk client only), not a direct function call | 3 tests (off leg, on leg, + a manual_review-through-real-sync test proving `manualReviewPending` persists into `directory_sync_runs.stats` end-to-end) |
| ② | 双组织: org A policy execution deactivates ONLY org A; org B membership untouched | `attendance-w4pre1c-departure-org-scoped.db.test.ts` | 1 test (+ positive control). Construction note: org B's membership is seeded as a raw `user_orgs` row with NO `directory_account_links` backing it (the shape a `POST /api/admin/users` explicit-org admission leaves) — a directory-LINKED org B account would disqualify the person from candidacy entirely via guard (1) above, and the test would prove nothing |
| ③ | 活跃 sibling: same-org other active binding ⇒ not deactivated | same file | 1 test — passes via the GLOBAL guard (1), not the org-scoped helper; see combination-semantics section |
| ④ | 人工复核: manual_review ⇒ active stays + pending state queryable | `attendance-w4pre1c-manual-review-pending.db.test.ts` — run with `enabled: true` deliberately (disabled would make mutation ③ unreachable and the test would pass for the wrong reason) | **3 tests** (default-policy manual_review; per-account override inside an otherwise mark_inactive integration; **REV1**: pending exposure holds with `enabled: false` too) |
| ⑤ | 权限负例: policy-executed deactivation ⇒ readiness gate 403 + destination invisible; positive control ⇒ 200/visible | `attendance-w4pre1c-departure-permission-negative.db.test.ts` — leg 1 real endpoint (`GET /api/attendance-admin/directory-readiness`) after a REAL `applyDirectoryDeprovisionPolicies` call (not a raw SQL flip); leg 2 + **REV1 leg 3** real `DingTalkGroupDestinationService` against real Kysely/Postgres | **8 tests** (200 control / 403 departed / destination-visible control / destination-invisible-users.is_active=false / destination-invisible-user_orgs.is_active=false / **REV1 leg 3 ×3**: same three destination assertions repeated with a `sheetId` argument, closing the `normalizedSheetId`-branch coverage gap — see item C) |

Plus 2 supplementary tests: `disable_grant_only` also attempts the user_orgs deactivation (org-scoped file), and the corresponding unit-level assertions in `directory-deprovision-policy.test.ts` (stub client updated to answer the 3 new SQL shapes; extended 4 existing tests + no new test count needed there — see CI wiring). **REV1** adds 2 more unit assertions (`membershipDeactivationAttemptedCount=0` on both circuit-breaker abort tests, closing the "breaker not passed ⇒ user_orgs never touched" negative that had zero coverage anywhere) and a `membershipDeactivationAttemptedCount` assertion on 4 existing unit tests (new observability field — see item F below).

**Local run** (dedicated Postgres `ms2_w4pre1c_20260721232937`, migrated with the exact `MIGRATION_EXCLUDE` copied from `plugin-tests.yml`):
```
pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
  tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts \
  tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts \
  tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts \
  tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts \
  tests/integration/directory-deprovision-selection.db.test.ts \
  tests/integration/directory-sync-orchestration.db.test.ts \
  tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts \
  tests/integration/attendance-w4pre1b-user-orgs-sync-automatch.db.test.ts \
  tests/integration/attendance-w4pre1b-user-orgs-backfill-migration.db.test.ts \
  tests/integration/attendance-w4pre1b-directory-readiness-gate.db.test.ts \
  tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts \
  tests/integration/attendance-w4pre1b-api-tokens-org-member-access.db.test.ts
# → 12 files, 61 tests, all passed  [ORIGINAL, pre-REV1]

pnpm --filter @metasheet/core-backend exec vitest run \
  tests/unit/directory-deprovision-policy.test.ts \
  tests/unit/dingtalk-group-destination-service.test.ts \
  tests/integration/dingtalk-group-destination-routes.api.test.ts
# → 3 files, 55 tests, all passed  [ORIGINAL, pre-REV1]

pnpm --filter @metasheet/core-backend exec vitest run   # default no-DB config, full sweep, NO DATABASE_URL set (matches CI's "Run core-backend tests" step, which runs BEFORE "Start Postgres")
# → 688 files (506 passed / 182 DB-gated skipped), 6909 tests passed, 1627 skipped, 0 failed
#   (byte-identical totals to #4526's own baseline — confirms the 4 new files are correctly
#   excluded from this job and nothing else regressed)

pnpm --filter @metasheet/core-backend run type-check    # clean
pnpm --filter @metasheet/web run type-check              # clean (no frontend changes this PR; ran anyway per double-typecheck discipline)
```

**REV1 re-run** (three-mirror review fixes, head `2870e391e`, same dedicated Postgres):
```
pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
  tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts \
  tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts \
  tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts \
  tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts \
  tests/integration/directory-deprovision-selection.db.test.ts \
  tests/integration/directory-sync-orchestration.db.test.ts \
  tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts \
  tests/integration/attendance-w4pre1b-user-orgs-sync-automatch.db.test.ts \
  tests/integration/attendance-w4pre1b-user-orgs-backfill-migration.db.test.ts \
  tests/integration/attendance-w4pre1b-directory-readiness-gate.db.test.ts \
  tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts \
  tests/integration/attendance-w4pre1b-api-tokens-org-member-access.db.test.ts
# → 12 files, 65 tests, all passed  (+4 vs original: leg 3 ×3 + manual_review enabled:false ×1)

pnpm --filter @metasheet/core-backend exec vitest run \
  tests/unit/directory-deprovision-policy.test.ts \
  tests/unit/dingtalk-group-destination-service.test.ts \
  tests/integration/dingtalk-group-destination-routes.api.test.ts
# → 3 files, 55 tests, all passed  (test COUNT unchanged — REV1 added assertions to 6 existing
#   unit tests, not new `it()` blocks, per the "extend, don't inflate the count" pattern already
#   used in this file)

pnpm --filter @metasheet/core-backend exec vitest run   # default no-DB config, full sweep
# → 688 files (506 passed / 182 DB-gated skipped), 6909 tests passed, 1627 skipped, 0 failed
#   (byte-identical to the pre-REV1 baseline — the new field/tests are all DB-gated or unit-file
#   assertion additions, no new file, no count drift)

pnpm --filter @metasheet/core-backend run type-check    # clean
pnpm --filter @metasheet/web run type-check              # clean
```

## E — mutation self-check (≥4, owner-specified)

Implementation committed first (`88ca82a59`); each mutation applied via `Edit`, confirmed RED, then reverted via a precise `Edit` (never `git checkout`) — `git diff` confirmed byte-identical to the committed state after each restore.

**REV1 correction (three-mirror review finding, P3):** the ORIGINAL red-leg column below was scoped by running each mutation against ONLY the file(s) that seemed relevant, not the full combined suite this PR's own "Local run" section runs — so entries like "ONLY case ①'s disabled-switch leg reddened" undercounted (the sibling unit-level `DEFAULT-OFF` test, which asserts the same property, also reddens and was not mentioned). REV1 re-ran all 4 original mutations against the SAME combined command as the "Local run" section (12 real-DB files + 3 unit/mocked files) and reports the actual full red set below; a `[REV1: full-suite red set]` line replaces the original narrower claim where it undercounted. Where the original claim already matched the full-suite result (mutation 4), it is confirmed unchanged.

| # | Mutation | Red leg | Restored |
|---|---|---|---|
| 1 | Moved the `deactivateUserOrgMembershipIfNoOtherActiveBinding` call to fire unconditionally at the TOP of the per-candidate loop (before the `manual_review` policy-dispatch check, before the `enabled` gate) — simulating "sweep transition alone deactivates" | Case ① disabled-switch leg (`expected false to be true`) AND the manual_review-through-real-sync test (both reddened — the mutation is unconditional so it also broke manual_review). **[REV1: full-suite red set = 7 tests]** — the above 2, PLUS all 3 tests in `attendance-w4pre1c-manual-review-pending.db.test.ts` (both original + the REV1 enabled:false addition) and 2 unit tests (`DEFAULT-OFF`, `enabled + manual_review`) — the mutation is unconditional, so every manual_review-touching test anywhere in the suite reddens, not just the ones in the same file as case ① | yes |
| 2 | Pulled the SAME call out of the `if (options.enabled)` block specifically (grant-disable write stays correctly gated) | ONLY case ①'s disabled-switch leg reddened — a more surgical kill, isolating just the new code's own gate. **[REV1: full-suite red set = 2 tests]** — case ①'s disabled leg AND the unit `DEFAULT-OFF` test (same property, sibling file) — original claim's "ONLY" undercounted by exactly the unit-level twin, confirming this line's own review finding | yes |
| 3 | Added the deactivation call (still `enabled`-gated) inside the `manual_review` branch | Case ④'s BOTH (original) tests reddened (real DB) + the unit-level `directory-deprovision-policy.test.ts` manual_review assertion reddened too. **[REV1: full-suite red set = 4 tests]** — the above 3, PLUS the manual_review-through-real-sync test in `attendance-w4pre1c-departure-sweep-deprovision.db.test.ts` (same policy path, different file — again undercounted by the original per-file framing). The REV1 `enabled:false` addition correctly stays GREEN under this mutation (the injected call is still `enabled`-gated) — confirms that test's own scope | yes |
| 4 | Dropped `.where('users.is_active', '=', true)` from the `listDestinations` no-orgId/no-sheetId (`else` branch) EXISTS clause | ONLY case ⑤ leg 2's `users.is_active=false` test reddened (`expected [...] to not include ...` — the row that should have been excluded stayed visible); the OTHER tests in that file, INCLUDING the REV1 leg 3 (`normalizedSheetId` branch, unaffected — separate code path), stayed green — precise, load-bearing kill. **[REV1: full-suite re-run confirms — original "ONLY" claim was accurate here, unlike 1/2/3]** | yes |
| 5 (REV1) | Dropped `.where('users.is_active', '=', true)` from the `listDestinations` **`normalizedSheetId`-branch twin** EXISTS clause (item C's coverage gap) | ONLY case ⑤ leg 3's users-inactive test reddened; leg 2 (the `else` branch, separate code path) and everything else stayed green | yes |
| 6 (REV1) | Removed the circuit-breaker's `return outcome` early-exit (simulating a future edit that lets deprovision writes proceed past an ABORTED breaker) | Both circuit-breaker abort tests reddened (on the pre-existing `DEACTIVATES_USER`/`DISABLES_GRANT` assertions, before even reaching the new `DEACTIVATES_USER_ORG` one) — proves the abort boundary as a whole is load-bearing | yes |
| 7 (REV1) | Isolated repeat of #6: inserted an unconditional `deactivateUserOrgMembershipIfNoOtherActiveBinding` call BEFORE the circuit-breaker check specifically (grants/users writes untouched) | ONLY the new `DEACTIVATES_USER_ORG=false` / `membershipDeactivationAttemptedCount=0` assertions on both abort tests reddened — precise, isolated kill of the exact negative this review round added (owner review finding: this negative had ZERO coverage anywhere before REV1) | yes |
| 8 (REV1) | Gated the `manualReviewPending.push` on `options.enabled` (simulating item B's "regardless of enabled" claim silently breaking) | ONLY the REV1 `enabled:false` manual-review test reddened; both original (enabled:true) case ④ tests stayed green — precise, isolated kill | yes |
| 9 (REV1) | Dropped the new `outcome.membershipDeactivationAttemptedCount += 1` increment | 3 unit tests reddened (`DEFAULT-OFF`, `enabled + mark_inactive`, `enabled + disable_grant_only` — all now assert this field) | yes |

## CI wiring (two-point)

1. `packages/core-backend/vitest.config.ts`'s no-DB exclude list — all 4 new `attendance-w4pre1c-*.db.test.ts` files added.
2. `.github/workflows/plugin-tests.yml`'s "Run attendance integration tests" step — same 4 files added to the explicit `vitest.integration.config.ts` invocation.

No new migration this PR (no schema change — the destination-service change is a query-shape edit on an existing table join; the deprovision change reuses #4526's existing `deactivateUserOrgMembershipIfNoOtherActiveBinding` and `resolveDirectoryAccountOrgId` helpers verbatim).

## Regression fixups (pre-existing suite this PR's change required updating)

- `tests/unit/directory-deprovision-policy.test.ts`: the stub client's `query()` threw "Unhandled SQL" on any query shape it didn't recognize (by design, per the file's own scope note) — extended to answer the 3 new shapes (`SELECT org_id FROM directory_integrations…`, the `user_orgs … FOR UPDATE` lock, and the `UPDATE user_orgs SET is_active = FALSE…`). Extended 2 existing tests (mark_inactive / disable_grant_only) with a `DEACTIVATES_USER_ORG` assertion, rewrote the DEFAULT-OFF and manual_review tests' assertions to cover the new field/behavior. All 18 tests (13 pre-existing behavior + 5 newly-asserted properties on pre-existing tests) pass.
- `tests/integration/directory-deprovision-selection.db.test.ts`: untouched — re-ran for regression (10/10 green). No `user_orgs` rows exist in any of its fixtures, so the new deactivation call is a documented no-op there (`deactivateUserOrgMembershipIfNoOtherActiveBinding`'s own doc comment: "If no `user_orgs` row exists yet… a no-op either way").
- `tests/integration/directory-sync-orchestration.db.test.ts`: untouched — re-ran for regression (12/12 green, including its own pre-existing deprovision-executor-wiring tests).
- `tests/unit/dingtalk-group-destination-service.test.ts` + `tests/integration/dingtalk-group-destination-routes.api.test.ts`: untouched — re-ran for regression (37/37 green; both fully mocked, as noted in the item-C section above).

## F — observability (REV1 addition, owner review finding)

The new `user_orgs` deactivation was invisible on every observability surface in the original PR: not in `DirectoryDeprovisionOutcome`, not in run stats, not in the post-commit audit trail, not in the default-off preview log — an operator deciding whether to flip `DIRECTORY_DEPROVISION_ENABLED` had no way to see this NEW consequence coming, despite this exact "operator needs to see WHO would lose access" principle already being stated in this function's own `deprovisionAffected` comment. Fixed, values-free (counts/flags only, no ids beyond what `affected`/`manualReviewPending` already carry):

- `DirectoryDeprovisionOutcome.membershipDeactivationAttemptedCount: number` — new field, same construction/gate as `grantsDisabledCount` (counts an ATTEMPT, preview-mode included; does NOT mean the row actually flipped — the shared helper's `UPDATE` has no `RETURNING`, so flip-visibility is a separate, NOT-YET-DONE follow-up).
- Threaded into run stats as `deprovisionMembershipDeactivationAttemptedCount` (`directory_sync_runs.stats`).
- Threaded into the default-off preview log line (now also reports "N org membership(s) (user_orgs) would be deactivation-attempted").
- Threaded into the post-commit audit `meta` as `membershipDeactivationAttempted: true` per affected record (same boolean pattern as the pre-existing `grantDisabled`/`userDeactivated`).

Pinned by unit-test assertions (mutation 9 above) rather than left as an "asserted invariant" — the field's own value is checked, not just its presence.

## Deviations (honest, evidence only — no verdicts asserted)

1. `disable_grant_only` now also deactivates `user_orgs` (not just `mark_inactive`) — see combination-semantics section AND the blast-radius enumeration below (REV1); flagged for owner confirmation, not self-adjudicated.
2. Case ③'s test passes via the pre-existing GLOBAL candidate-selection sibling guard; the org-scoped helper check is ALSO exercised on this call path (**REV1 correction**: the original claim that it was "currently non-load-bearing" was wrong — see the combination-semantics section's REV1 correction for why it is independently load-bearing under concurrency, even though case ③'s specific fixture happens not to need it).
3. The explicit-`?orgId=` branch of `listDestinations` was NOT touched (already route-gated by the dual-filtered `requireOrgReadAccess`) — owner named `:213`'s EXISTS clauses specifically; this branch has no EXISTS clause at all.

## REV1 — `disable_grant_only` blast radius by read-point (owner review finding, P2)

Deviation 1 above was previously described only as "changes real behavior for `disable_grant_only` integrations" — too generic for the owner to adjudicate without independently auditing every `user_orgs` read site. Enumerated here instead. All 5 `user_orgs` read points in the repo already apply a dual `is_active` filter (`uo.is_active AND u.is_active`) — the #4526 shape:

- `automation-executor.ts:~4092` — automation org-destination visibility
- `dingtalk-group-destination-service.ts:~219,~244` — this PR's own item C
- `api-tokens.ts:~160` — `requireOrgMemberAccess`
- `attendance-admin.ts:~383` — `canReadAttendanceDirectoryReadiness` (S7-5 gate)
- `AttendanceNotificationDeliveryWorker.ts:~1335` — email recipient resolution

For `mark_inactive` departures, `users.is_active=false` ALONE already excludes the row at all 5 sites (pre-#4526 shape) — this PR's `user_orgs` write there is redundant defense-in-depth, not a behavior change. For `disable_grant_only`, `users.is_active` stays `true` — so the NET NEW effect of this PR (a `user_orgs` deactivation with `users.is_active` untouched) lands ENTIRELY on `disable_grant_only` integrations, at these 2 read points specifically that were previously unaffected:

- **(a) Email notification delivery** (`AttendanceNotificationDeliveryWorker.ts` `send()`) — the recipient-lookup query now returns zero rows for a `disable_grant_only` departed user, which the worker treats as **`ok: false, retryable: false`** → a **permanent, non-retryable dead-letter** (`email_recipient_unresolved`). Before this PR, a pending email delivery to such a user was retryable/deliverable; after, it dead-letters immediately. Fail-closed direction is correct (do not email an ex-employee), but it is a state-machine consequence (pending → permanently failed, not just "would fail if retried"), not merely "an email won't send."
- **(b) Automation DingTalk group-destination sends** (`automation-executor.ts`) — for an org-scoped destination whose visibility depends on the RULE CREATOR's (not the recipient's) org membership, a `disable_grant_only`-departed rule creator now loses destination resolution, so THAT rule's automated sends fail for everyone the rule targets, not just the departed person.

(c) the S7-5 readiness-gate 403 and (d) destination invisibility to the departed user themself were already called out in the scenario table and are lower-surprise (self-scoped, not third-party-impacting). Flagged here so (a) and (b) are visible before the owner adjudicates deviation 1, not discovered after `disable_grant_only` integrations start seeing dead-lettered mail.

## Open items (for owner)

- Confirm/adjudicate the `disable_grant_only` → also-deactivates-`user_orgs` reading, INCLUDING the (a)/(b) blast-radius items above (deviation 1).
- The combination-semantics section's REV1 correction: the org-scoped sibling check is independently load-bearing under concurrent binds (not "dominated" as originally claimed) — no code change requested here (the check was already retained), just confirming the corrected reasoning is accepted. A constructed-concurrency test for this specific race was NOT added this round (flagged as a real gap).
- Staged opt-in / owner merge decision, per this line's standing convention — this PR does not merge or arm itself.

Three-viewport visual verification: **N/A** — backend-only (one service file, one directory-sync module, test files); no Vue/frontend changes.

---

## REV1 — three-mirror review round (this update)

Nine findings from a three-mirror review of the original PR (head `88ca82a59`) were addressed on head `2870e391e`. Summary (full per-finding disposition available on request):

| # | Sev | Finding | Disposition |
|---|---|---|---|
| 1 | P2 | Combination-semantics claim ("check (2) provably dominated by check (1)") ignored a real TOCTOU window under concurrent binds | Fixed — code comment + PR body corrected; check was ALREADY retained in code (no behavior change), only the false premise removed |
| 2 | P3 | `manualReviewPending`'s "one-shot per-run, no aggregate/resolve state" property was implicit, not disclosed | Fixed — explicit disclosure added to doc-comment + PR body |
| 3 | P3 | "逐字" (verbatim) citations of the owner's #4522 ruling did not match any GitHub-persisted text | Fixed — every citation (code comments + PR body) now cites the actual persisted acknowledgment comment (issuecomment-5042388830) instead of unverifiable "verbatim" wording |
| 4 | P2 | `listDestinations`'s `normalizedSheetId`-branch EXISTS twin had ZERO real-behavioral test coverage | Fixed — case ⑤ leg 3 (3 new real-DB tests) + isolated mutation kill |
| 5 | P3 | `manualReviewPending`'s "regardless of enabled" claim had no `enabled:false` test | Fixed — new real-DB test + mutation self-check |
| 6 | P3 | Original mutation table's red-leg claims were scoped per-file, not per the PR's own combined test command, undercounting 1/2/3's true red sets | Fixed — all 4 original mutations re-run against the full combined suite, table corrected with actual counts |
| 7 | P2 | Circuit-breaker's negative ("not passed ⇒ `user_orgs` never touched") had zero test coverage anywhere | Fixed — new assertions on both abort tests + isolated mutation kill |
| 8 | P3 | New `user_orgs` deactivation was invisible on every observability surface (outcome/stats/audit/preview log) | Fixed — `membershipDeactivationAttemptedCount` field, threaded through all 4 surfaces, pinned by tests |
| 9 | P2 | `disable_grant_only` blast radius was described generically, not enumerated by read-point | Fixed — 2 specific consequences ((a) email dead-letter, (b) automation destination failure) enumerated in a new section |

refs #4522 #4526

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

