### PR TITLE
feat(approval): update linked records from approved form values

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -684,6 +684,7 @@ jobs:
             tests/integration/multitable-automation-outbound-intent-realdb.test.ts \
             tests/integration/multitable-fwb-write-action-realdb.test.ts \
             tests/integration/multitable-fwb-activation-realdb.test.ts \
+            tests/integration/multitable-fwb-update-activation-realdb.test.ts \
             tests/integration/approval-attachment-gc-realdb.test.ts \
             tests/integration/approval-attachment-bind-reconcile-realdb.test.ts \
             tests/integration/approval-attachment-scan-purge-upgrade-migration.db.test.ts \

--- a/packages/core-backend/src/multitable/approval-fwb-activation.ts
+++ b/packages/core-backend/src/multitable/approval-fwb-activation.ts
@@ -20,19 +20,107 @@
  * Gate binding (`buildProductionFwbGateChecks`) implements the §11 Q6 four-gate set with the checks the
  * lock names: G1 admin OR existing `canManageSheetAccess` on the target sheet, G2 source template
  * readable (both existing creator legs), G3 target sheet writable, G4 recorded confirmation — with the
- * per-sheet resolution going through `resolveSheetCapabilitiesForUser` as Q6 gate (4) explicitly demands
- * ("权限复核须显式调用目标 sheet 的 resolveSheetCapabilitiesForUser……不能只读一个全局 capability").
+ * per-sheet resolution going through the transaction-local counterpart of
+ * `resolveSheetCapabilitiesForUser` as Q6 gate (4) explicitly demands (never a cached/global read).
  */
 import { createHash } from 'node:crypto'
 
-import { canonicalizeConfig } from './automation-action-idempotency'
+import { canonicalizeConfig, deriveActionKey } from './automation-action-idempotency'
 import type { FwbFieldMapping } from './approval-form-value-mapping'
-import type { FwbGateChecks } from './approval-fwb-permission-gates'
+import type { FwbGateChecks, FwbWriteMode } from './approval-fwb-permission-gates'
+import { enumerateRuleActions } from './automation-rule-fingerprint'
 import { deriveFieldPermissions, isFieldWriteForbidden, type FieldLike } from './permission-derivation'
 import { loadFieldPermissionScopeMap } from './permission-service'
-import { resolveSheetCapabilitiesForUser } from './sheet-capabilities'
+import { resolveSheetCapabilitiesForUserOnQuery } from '../services/approval-record-link-txn-auth'
 
 export const FWB_ACTION_TYPE = 'write_approval_form_values'
+
+const V1_TARGET_TYPES = new Set(['text', 'number', 'date', 'select'])
+const NON_BLANK = /[!-~]/
+
+/** Parsed FWB write mode. Absent/`create` stay byte-compatible with FWB-1 configs. */
+export type FwbModeParseResult =
+  | { ok: true; mode: FwbWriteMode }
+  | { ok: false; issue: 'unknown_mode' }
+
+/**
+ * Parse `mode` from a raw action config. Absent / undefined / `'create'` → create; `'update'` → update;
+ * any other value is rejected (unknown modes must never silently fall through to create).
+ */
+export function parseFwbWriteMode(raw: unknown): FwbModeParseResult {
+  if (raw === undefined) return { ok: true, mode: 'create' }
+  if (raw === 'create') return { ok: true, mode: 'create' }
+  if (raw === 'update') return { ok: true, mode: 'update' }
+  return { ok: false, issue: 'unknown_mode' }
+}
+
+export type FwbUpdateConfigIssue =
+  | 'record_link_field_missing'
+  | 'record_link_field_blank'
+
+/**
+ * FWB-2 update config contract: one non-blank `recordLinkFieldId`. Does not look up the template
+ * schema (that needs query access — save/execute do it). Returns the trimmed id or the first issue.
+ */
+export function normalizeFwbUpdateRecordLinkFieldId(raw: unknown):
+  | { ok: true; recordLinkFieldId: string }
+  | { ok: false; issue: FwbUpdateConfigIssue } {
+  if (raw === undefined || raw === null) return { ok: false, issue: 'record_link_field_missing' }
+  if (typeof raw !== 'string') return { ok: false, issue: 'record_link_field_blank' }
+  const recordLinkFieldId = raw.trim()
+  if (!NON_BLANK.test(recordLinkFieldId)) return { ok: false, issue: 'record_link_field_blank' }
+  return { ok: true, recordLinkFieldId }
+}
+
+/**
+ * Extract the exact single `{ recordId: string }` shape from a form_snapshot value (D3: 0 or multi →
+ * reject). Values-free: returns null for any malformed shape (no existence oracle / no free-text id).
+ */
+export function extractExactLinkedRecordId(value: unknown): string | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const keys = Object.keys(value as Record<string, unknown>)
+  if (keys.length !== 1 || keys[0] !== 'recordId') return null
+  const recordId = (value as { recordId?: unknown }).recordId
+  if (typeof recordId !== 'string') return null
+  const trimmed = recordId.trim()
+  return NON_BLANK.test(trimmed) ? trimmed : null
+}
+
+/** Top-level record-link field props used to derive the FWB-2 write target (never client-supplied). */
+export interface FwbRecordLinkTarget {
+  fieldId: string
+  baseId: string
+  sheetId: string
+}
+
+/**
+ * Locate a top-level `record-link` field in a form schema and return its pinned baseId/sheetId props.
+ * Nested (detail) fields are ignored — v1 record-link is top-level only.
+ */
+export function resolveRecordLinkTargetFromSchema(
+  formSchema: unknown,
+  recordLinkFieldId: string,
+): FwbRecordLinkTarget | null {
+  if (!recordLinkFieldId || !NON_BLANK.test(recordLinkFieldId)) return null
+  const schema = formSchema && typeof formSchema === 'object' && !Array.isArray(formSchema)
+    ? formSchema as { fields?: unknown }
+    : null
+  const fields = Array.isArray(schema?.fields) ? schema.fields : []
+  for (const field of fields) {
+    if (!field || typeof field !== 'object' || Array.isArray(field)) continue
+    const f = field as { id?: unknown; type?: unknown; props?: unknown }
+    if (f.id !== recordLinkFieldId) continue
+    if (f.type !== 'record-link') return null
+    const props = f.props && typeof f.props === 'object' && !Array.isArray(f.props)
+      ? f.props as Record<string, unknown>
+      : null
+    const baseId = typeof props?.baseId === 'string' ? props.baseId.trim() : ''
+    const sheetId = typeof props?.sheetId === 'string' ? props.sheetId.trim() : ''
+    if (!NON_BLANK.test(baseId) || !NON_BLANK.test(sheetId)) return null
+    return { fieldId: recordLinkFieldId, baseId, sheetId }
+  }
+  return null
+}
 
 /**
  * Runtime flag, default OFF. Execution additionally requires the durable-delivery flag (D9/D10: claim +
@@ -43,9 +131,6 @@ export function isFwbWritebackEnabled(env: NodeJS.ProcessEnv = process.env): boo
   return String(env.APPROVAL_FWB_WRITEBACK_ENABLED ?? '').trim().toLowerCase() === 'true'
 }
 
-const V1_TARGET_TYPES = new Set(['text', 'number', 'date', 'select'])
-const NON_BLANK = /[!-~]/
-
 export type FwbConfigStructuralIssue =
   | 'empty_config'
   | 'invalid_mapping_entry'
@@ -53,6 +138,9 @@ export type FwbConfigStructuralIssue =
   | 'select_options_missing'
   | 'duplicate_target'
   | 'confirmation_hash_missing'
+  | 'unknown_mode'
+  | 'record_link_field_missing'
+  | 'record_link_field_blank'
 
 /**
  * Structural (schema-free) validation of a `write_approval_form_values` action config. Mirrors the FE
@@ -100,26 +188,44 @@ export interface FwbConfirmationSubject {
   templateId: string
   /** exact published form schema whose field meanings were explicitly confirmed. */
   sourceTemplateVersionId: string
-  /** FWB-1 target = the rule's OWN sheet (lock D2) — bound into the hash so a sheet move invalidates. */
+  /**
+   * Write target sheet. FWB-1 = the rule's OWN sheet (lock D2). FWB-2 = derived from the pinned
+   * record-link field's props (never client-supplied). Bound into the hash so a rehome/repin invalidates.
+   */
   targetSheetId: string
   /** base containing targetSheetId at confirmation time; a sheet rehome invalidates confirmation. */
   targetBaseId: string
   mappings: readonly FwbFieldMapping[]
+  /**
+   * FWB-2 only. When mode is `'update'`, both `mode` and `recordLinkFieldId` are part of the
+   * confirmation subject. Create-mode subjects OMIT these keys so existing create-mode hashes stay
+   * byte-identical.
+   */
+  mode?: FwbWriteMode
+  recordLinkFieldId?: string
 }
 
 /**
  * §11 Q6 gate-3 confirmation hash: sha256 over the canonicalized (deep key-sorted; array order kept —
  * it is meaning) subject. Deterministic across process restarts and property order.
+ *
+ * Create-mode subjects intentionally omit `mode`/`recordLinkFieldId` so pre-FWB-2 hashes remain
+ * byte-compatible. Update-mode subjects bind mode + recordLinkFieldId + derived target base/sheet.
  */
 export function deriveFwbConfirmationHash(subject: FwbConfirmationSubject): string {
+  const body: Record<string, unknown> = {
+    templateId: subject.templateId,
+    sourceTemplateVersionId: subject.sourceTemplateVersionId,
+    targetBaseId: subject.targetBaseId,
+    targetSheetId: subject.targetSheetId,
+    mappings: subject.mappings,
+  }
+  if (subject.mode === 'update') {
+    body.mode = 'update'
+    body.recordLinkFieldId = subject.recordLinkFieldId ?? ''
+  }
   return createHash('sha256')
-    .update(canonicalizeConfig({
-      templateId: subject.templateId,
-      sourceTemplateVersionId: subject.sourceTemplateVersionId,
-      targetBaseId: subject.targetBaseId,
-      targetSheetId: subject.targetSheetId,
-      mappings: subject.mappings,
-    }))
+    .update(canonicalizeConfig(body))
     .digest('hex')
 }
 
@@ -129,22 +235,55 @@ interface PersistedActionShape {
   config?: unknown
 }
 
-/** Collect every FWB action config on a persisted/incoming rule shape (top-level + actions array). */
+export interface PersistedFwbAction {
+  config: Record<string, unknown>
+  structuralPath: string
+  actionKey: string
+}
+
+/**
+ * Enumerate the effective runtime action set with the executor's exact identity rules. When `actions[]`
+ * is non-empty it wins; the legacy `action_type`/`action_config` pair is only the fallback. This mirrors
+ * `toExecutorRule` and prevents stale legacy columns from participating in save/execute authorization.
+ */
+export function collectPersistedFwbActions(
+  actionType: string | null | undefined,
+  actionConfig: unknown,
+  actions: readonly PersistedActionShape[] | null | undefined,
+): PersistedFwbAction[] {
+  const effectiveActions: Array<{ type: string; config?: unknown }> = []
+  if (Array.isArray(actions) && actions.length > 0) {
+    for (const action of actions) {
+      if (action && typeof action.type === 'string') {
+        effectiveActions.push({ type: action.type, config: action.config })
+      }
+    }
+  } else if (typeof actionType === 'string') {
+    effectiveActions.push({ type: actionType, config: actionConfig })
+  }
+
+  const out: PersistedFwbAction[] = []
+  for (const { action, structuralPath } of enumerateRuleActions(effectiveActions)) {
+    if (action.type !== FWB_ACTION_TYPE || !action.config || typeof action.config !== 'object' || Array.isArray(action.config)) {
+      continue
+    }
+    const config = action.config as Record<string, unknown>
+    out.push({
+      config,
+      structuralPath,
+      actionKey: deriveActionKey({ structuralPath, actionType: FWB_ACTION_TYPE, canonicalConfig: config }),
+    })
+  }
+  return out
+}
+
+/** Collect every effective FWB action config (including branch actions the executor can enumerate). */
 export function collectFwbActionConfigs(
   actionType: string | null | undefined,
   actionConfig: unknown,
   actions: readonly PersistedActionShape[] | null | undefined,
 ): Array<Record<string, unknown>> {
-  const out: Array<Record<string, unknown>> = []
-  if (actionType === FWB_ACTION_TYPE && actionConfig && typeof actionConfig === 'object' && !Array.isArray(actionConfig)) {
-    out.push(actionConfig as Record<string, unknown>)
-  }
-  for (const action of actions ?? []) {
-    if (action && action.type === FWB_ACTION_TYPE && action.config && typeof action.config === 'object' && !Array.isArray(action.config)) {
-      out.push(action.config as Record<string, unknown>)
-    }
-  }
-  return out
+  return collectPersistedFwbActions(actionType, actionConfig, actions).map(({ config }) => config)
 }
 
 type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>
@@ -172,24 +311,33 @@ function parseFieldProperty(value: unknown): Record<string, unknown> {
   return {}
 }
 
-/** Canonical layer-2/layer-3 create-field gate for every FWB target field. */
+/**
+ * Canonical layer-2/layer-3 field-write gate for every FWB target field.
+ * - create (default): sheet canCreateRecord + create-field permissions (allowCreateOnly).
+ * - update: sheet canEditRecord + update-field permissions (must NOT require create).
+ */
 export async function canUserWriteFwbTargetFields(
   queryFn: QueryFn,
   userId: string,
   sheetId: string,
   targetFieldIds: readonly string[],
+  mode: FwbWriteMode = 'create',
 ): Promise<boolean> {
   if (!userId || targetFieldIds.length === 0) return false
   const uniqueIds = [...new Set(targetFieldIds)]
   const [resolved, fieldScopeMap, fieldResult] = await Promise.all([
-    resolveSheetCapabilitiesForUser(queryFn, sheetId, userId),
+    resolveSheetCapabilitiesForUserOnQuery(queryFn, sheetId, userId),
     loadFieldPermissionScopeMap(queryFn, sheetId, userId),
     queryFn(
       'SELECT id, type, property FROM meta_fields WHERE sheet_id = $1 AND id = ANY($2::text[])',
       [sheetId, uniqueIds],
     ),
   ])
-  if (!resolved.capabilities.canCreateRecord) return false
+  if (mode === 'update') {
+    if (!resolved.capabilities.canEditRecord) return false
+  } else if (!resolved.capabilities.canCreateRecord) {
+    return false
+  }
   const fields: FieldLike[] = (fieldResult.rows as Array<{ id?: unknown; type?: unknown; property?: unknown }>)
     .filter((row): row is { id: string; type: string; property?: unknown } => (
       typeof row.id === 'string' && typeof row.type === 'string'
@@ -197,7 +345,7 @@ export async function canUserWriteFwbTargetFields(
     .map((row) => ({ id: row.id, type: row.type, property: parseFieldProperty(row.property) }))
   if (fields.length !== uniqueIds.length) return false
   const permissions = deriveFieldPermissions(fields, resolved.capabilities, {
-    allowCreateOnly: true,
+    allowCreateOnly: mode !== 'update',
     fieldScopeMap,
   })
   return uniqueIds.every((fieldId) => !isFieldWriteForbidden(permissions[fieldId]))
@@ -206,99 +354,142 @@ export async function canUserWriteFwbTargetFields(
 /**
  * The REAL §11 Q6 gate set bound at AutomationService construction. Every check is fail-closed at the
  * caller (`recheckFwbPermissionGates` counts a thrown check as failed), so none of these needs its own
- * try/catch. Per-sheet checks go through `resolveSheetCapabilitiesForUser` (Q6 gate 4 — never a global
- * capability read).
+ * try/catch. Per-sheet checks go through `resolveSheetCapabilitiesForUserOnQuery` (Q6 gate 4 — the
+ * caller supplies the current write transaction, never a global/cached capability read).
  */
 export function buildProductionFwbGateChecks(deps: ProductionFwbGateDeps): FwbGateChecks {
+  type ResolvedGateAction = {
+    mode: FwbWriteMode
+    targetSheetId: string
+    mappings: FwbFieldMapping[]
+    confirmationValid: boolean
+  }
+
+  const resolveGateAction = async (ruleId: string, actionKey: string): Promise<ResolvedGateAction | null> => {
+    if (!ruleId || !actionKey) return null
+    const res = await deps.queryFn(
+      `SELECT r.sheet_id, s.base_id, r.trigger_config, r.action_type, r.action_config, r.actions
+         FROM automation_rules r
+         JOIN meta_sheets s ON s.id = r.sheet_id
+        WHERE r.id = $1 AND r.enabled = TRUE`,
+      [ruleId],
+    )
+    const row = res.rows[0] as {
+      sheet_id?: unknown
+      base_id?: unknown
+      trigger_config?: unknown
+      action_type?: unknown
+      action_config?: unknown
+      actions?: unknown
+    } | undefined
+    if (!row || typeof row.sheet_id !== 'string' || typeof row.base_id !== 'string') return null
+
+    const matches = collectPersistedFwbActions(
+      typeof row.action_type === 'string' ? row.action_type : null,
+      parseJsonObject(row.action_config),
+      parseJsonArray(row.actions) as PersistedActionShape[] | null,
+    ).filter((candidate) => candidate.actionKey === actionKey)
+    if (matches.length !== 1) return null
+
+    const config = matches[0].config
+    const modeParsed = parseFwbWriteMode(config.mode)
+    const normalized = normalizeFwbMappings(config.mappings)
+    if (!modeParsed.ok || !normalized.ok) return null
+
+    const triggerConfig = parseJsonObject(row.trigger_config)
+    const templateId = typeof triggerConfig?.templateId === 'string' ? triggerConfig.templateId : ''
+    if (!templateId) return null
+    const templateResult = await deps.queryFn(
+      `SELECT t.active_version_id, v.form_schema
+         FROM approval_templates t
+         JOIN approval_template_versions v ON v.id = t.active_version_id
+        WHERE t.id = $1`,
+      [templateId],
+    )
+    const templateRow = templateResult.rows[0] as {
+      active_version_id?: unknown
+      form_schema?: unknown
+    } | undefined
+    const activeVersionId = templateRow?.active_version_id
+    if (typeof activeVersionId !== 'string' || !activeVersionId) return null
+    const formSchema = parseJsonObject(templateRow?.form_schema)
+      ?? (() => {
+        if (typeof templateRow?.form_schema === 'string') {
+          try {
+            const parsed = JSON.parse(templateRow.form_schema) as unknown
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as Record<string, unknown>
+          } catch { /* fail closed */ }
+        }
+        return null
+      })()
+
+    let targetBaseId = row.base_id
+    let targetSheetId = row.sheet_id
+    let recordLinkFieldId: string | undefined
+    if (modeParsed.mode === 'update') {
+      const linkField = normalizeFwbUpdateRecordLinkFieldId(config.recordLinkFieldId)
+      if (!linkField.ok) return null
+      const derived = resolveRecordLinkTargetFromSchema(formSchema, linkField.recordLinkFieldId)
+      if (!derived) return null
+      const membership = await deps.queryFn('SELECT base_id FROM meta_sheets WHERE id = $1', [derived.sheetId])
+      const liveBase = (membership.rows[0] as { base_id?: unknown } | undefined)?.base_id
+      if (typeof liveBase !== 'string' || liveBase !== derived.baseId) return null
+      targetBaseId = derived.baseId
+      targetSheetId = derived.sheetId
+      recordLinkFieldId = linkField.recordLinkFieldId
+    }
+
+    const confirmedVersionId = typeof config.sourceTemplateVersionId === 'string'
+      ? config.sourceTemplateVersionId
+      : ''
+    const stored = typeof config.confirmationHash === 'string' ? config.confirmationHash : ''
+    const expected = deriveFwbConfirmationHash({
+      templateId,
+      sourceTemplateVersionId: confirmedVersionId,
+      targetBaseId,
+      targetSheetId,
+      mappings: normalized.mappings,
+      ...(modeParsed.mode === 'update'
+        ? { mode: 'update' as const, recordLinkFieldId }
+        : {}),
+    })
+
+    return {
+      mode: modeParsed.mode,
+      targetSheetId,
+      mappings: normalized.mappings,
+      confirmationValid: confirmedVersionId === activeVersionId && stored === expected,
+    }
+  }
+
   return {
     isAdmin: (userId) => deps.isAdminFn(userId),
     canManageSheetAccess: async (userId, sheetId) => {
-      const resolved = await resolveSheetCapabilitiesForUser(deps.queryFn, sheetId, userId)
+      const resolved = await resolveSheetCapabilitiesForUserOnQuery(deps.queryFn, sheetId, userId)
       return resolved.capabilities.canManageSheetAccess
     },
     canReadTemplate: (userId, templateId) => deps.canReadTemplateFn(userId, templateId),
-    canWriteSheet: async (userId, sheetId) => {
-      // FWB-1 writes = record CREATE on the target sheet (lock §4 mode:'create').
-      const resolved = await resolveSheetCapabilitiesForUser(deps.queryFn, sheetId, userId)
-      return resolved.capabilities.canCreateRecord
+    canWriteSheet: async (userId, sheetId, mode = 'create') => {
+      // FWB-1 = record CREATE (canCreateRecord). FWB-2 = record UPDATE (canEditRecord — not create).
+      const resolved = await resolveSheetCapabilitiesForUserOnQuery(deps.queryFn, sheetId, userId)
+      return mode === 'update'
+        ? resolved.capabilities.canEditRecord
+        : resolved.capabilities.canCreateRecord
     },
-    canWriteTargetFields: async (userId, ruleId, sheetId) => {
-      const res = await deps.queryFn(
-        'SELECT action_type, action_config, actions FROM automation_rules WHERE id = $1 AND sheet_id = $2',
-        [ruleId, sheetId],
+    canWriteTargetFields: async (userId, ruleId, actionKey, sheetId, mode = 'create') => {
+      const action = await resolveGateAction(ruleId, actionKey)
+      if (!action || action.mode !== mode || action.targetSheetId !== sheetId) return false
+      return canUserWriteFwbTargetFields(
+        deps.queryFn,
+        userId,
+        sheetId,
+        action.mappings.map((mapping) => mapping.targetFieldId),
+        mode,
       )
-      const row = res.rows[0] as {
-        action_type?: unknown
-        action_config?: unknown
-        actions?: unknown
-      } | undefined
-      if (!row) return false
-      const configs = collectFwbActionConfigs(
-        typeof row.action_type === 'string' ? row.action_type : null,
-        parseJsonObject(row.action_config),
-        parseJsonArray(row.actions) as PersistedActionShape[] | null,
-      )
-      const targetFieldIds: string[] = []
-      for (const config of configs) {
-        const normalized = normalizeFwbMappings(config.mappings)
-        if (!normalized.ok) return false
-        targetFieldIds.push(...normalized.mappings.map((mapping) => mapping.targetFieldId))
-      }
-      return canUserWriteFwbTargetFields(deps.queryFn, userId, sheetId, targetFieldIds)
     },
-    hasRecordedConfirmation: async (ruleId) => {
-      // G4 re-derivation against the CURRENT persisted rule: every FWB action's stored confirmationHash
-      // must equal the hash of its CURRENT normalized config + the rule's CURRENT sheet/template. A rule
-      // with no FWB action, a broken config, or ANY stale hash → false (fail-closed).
-      const res = await deps.queryFn(
-        `SELECT r.sheet_id, s.base_id, r.trigger_config, r.action_type, r.action_config, r.actions
-           FROM automation_rules r
-           JOIN meta_sheets s ON s.id = r.sheet_id
-          WHERE r.id = $1`,
-        [ruleId],
-      )
-      const row = res.rows[0] as {
-        sheet_id?: unknown
-        base_id?: unknown
-        trigger_config?: unknown
-        action_type?: unknown
-        action_config?: unknown
-        actions?: unknown
-      } | undefined
-      if (!row || typeof row.sheet_id !== 'string' || typeof row.base_id !== 'string') return false
-      const triggerConfig = parseJsonObject(row.trigger_config)
-      const templateId = typeof triggerConfig?.templateId === 'string' ? triggerConfig.templateId : ''
-      if (!templateId) return false
-      const templateResult = await deps.queryFn(
-        'SELECT active_version_id FROM approval_templates WHERE id = $1',
-        [templateId],
-      )
-      const activeVersionId = (templateResult.rows[0] as { active_version_id?: unknown } | undefined)?.active_version_id
-      if (typeof activeVersionId !== 'string' || !activeVersionId) return false
-      const configs = collectFwbActionConfigs(
-        typeof row.action_type === 'string' ? row.action_type : null,
-        parseJsonObject(row.action_config),
-        parseJsonArray(row.actions) as PersistedActionShape[] | null,
-      )
-      if (configs.length === 0) return false
-      for (const config of configs) {
-        const normalized = normalizeFwbMappings(config.mappings)
-        if (!normalized.ok) return false
-        const confirmedVersionId = typeof config.sourceTemplateVersionId === 'string'
-          ? config.sourceTemplateVersionId
-          : ''
-        if (confirmedVersionId !== activeVersionId) return false
-        const stored = typeof config.confirmationHash === 'string' ? config.confirmationHash : ''
-        const expected = deriveFwbConfirmationHash({
-          templateId,
-          sourceTemplateVersionId: confirmedVersionId,
-          targetBaseId: row.base_id,
-          targetSheetId: row.sheet_id,
-          mappings: normalized.mappings,
-        })
-        if (stored !== expected) return false
-      }
-      return true
+    hasRecordedConfirmation: async (ruleId, actionKey) => {
+      const action = await resolveGateAction(ruleId, actionKey)
+      return action?.confirmationValid === true
     },
   }
 }

--- a/packages/core-backend/src/multitable/approval-fwb-permission-gates.ts
+++ b/packages/core-backend/src/multitable/approval-fwb-permission-gates.ts
@@ -15,22 +15,39 @@
  * module is testable and the real ACL wiring is one seam. All-or-nothing; check failures (thrown errors)
  * are NOT treated as passes (fail-closed on error).
  */
+/** FWB write mode for sheet/field authority. Omitted/`create` = FWB-1; `update` = FWB-2. */
+export type FwbWriteMode = 'create' | 'update'
+
 export interface FwbGateChecks {
   isAdmin(userId: string): Promise<boolean>
   canManageSheetAccess(userId: string, sheetId: string): Promise<boolean>
   canReadTemplate(userId: string, templateId: string): Promise<boolean>
-  canWriteSheet(userId: string, sheetId: string): Promise<boolean>
-  canWriteTargetFields(userId: string, ruleId: string, sheetId: string): Promise<boolean>
+  /**
+   * G3 target writable. Create mode requires canCreateRecord; update mode requires canEditRecord
+   * (must NOT require create permission for update — FWB-2).
+   */
+  canWriteSheet(userId: string, sheetId: string, mode?: FwbWriteMode): Promise<boolean>
+  canWriteTargetFields(
+    userId: string,
+    ruleId: string,
+    actionKey: string,
+    sheetId: string,
+    mode?: FwbWriteMode,
+  ): Promise<boolean>
   /** G4: the saved rule carries a recorded explicit confirmation (identifiers only). */
-  hasRecordedConfirmation(ruleId: string): Promise<boolean>
+  hasRecordedConfirmation(ruleId: string, actionKey: string): Promise<boolean>
 }
 
 export interface FwbGateSubject {
   /** the rule's configurer (creator/last enabler) — the authority the gates bind to. */
   configurerUserId: string
   ruleId: string
+  /** Exact persisted action identity; prevents sibling FWB actions from contaminating this gate. */
+  actionKey: string
   sourceTemplateId: string
   targetSheetId: string
+  /** FWB-1 create (default when omitted) vs FWB-2 update. */
+  mode?: FwbWriteMode
 }
 
 export type FwbGateId =
@@ -52,13 +69,14 @@ export async function recheckFwbPermissionGates(checks: FwbGateChecks, s: FwbGat
       return false // fail-closed: an errored check is a failed check
     }
   }
+  const mode = s.mode === 'update' ? 'update' : 'create'
   const [admin, manage, readSrc, writeTgt, writeFields, confirmed] = await Promise.all([
     safe(checks.isAdmin(s.configurerUserId)),
     safe(checks.canManageSheetAccess(s.configurerUserId, s.targetSheetId)),
     safe(checks.canReadTemplate(s.configurerUserId, s.sourceTemplateId)),
-    safe(checks.canWriteSheet(s.configurerUserId, s.targetSheetId)),
-    safe(checks.canWriteTargetFields(s.configurerUserId, s.ruleId, s.targetSheetId)),
-    safe(checks.hasRecordedConfirmation(s.ruleId)),
+    safe(checks.canWriteSheet(s.configurerUserId, s.targetSheetId, mode)),
+    safe(checks.canWriteTargetFields(s.configurerUserId, s.ruleId, s.actionKey, s.targetSheetId, mode)),
+    safe(checks.hasRecordedConfirmation(s.ruleId, s.actionKey)),
   ])
   if (!admin && !manage) failed.push('configurer_authority')
   if (!readSrc) failed.push('source_readable')

--- a/packages/core-backend/src/multitable/approval-fwb-record-link.ts
+++ b/packages/core-backend/src/multitable/approval-fwb-record-link.ts
@@ -10,7 +10,8 @@
  *
  * `executeUpdateBoundRecord` composes exactly like FWB-1's executor (gates → mapping → claim → seam) but
  * UPDATES the bound record + bumps its revision instead of creating one; same-transaction with the ledger
- * claim and the outbox row. Checks and writes are injected seams; no production caller yet.
+ * claim and the outbox row. Checks and writes are injected seams; AutomationExecutor supplies the
+ * production transaction-bound implementation for mode:'update'.
  */
 import type { Queryable } from './automation-durable-dispatcher'
 import type { TransactionalQueryable } from './pg-transaction-guard'

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -54,9 +54,14 @@ export const ALL_ACTION_TYPES: AutomationActionType[] = [
 /**
  * Config shape for write_approval_form_values (FWB activation).
  *
- * Deliberately NO target sheet/base fields: FWB-1's target is the rule's own sheet (FWB0 lock D2; §11 Q3
- * rejected same-base explicit sheet targets — "显式表目标无表单锚点，会重开 W7 Q2 字面目标之争").
- * Form VALUES never appear here either — the executor reads the immutable `form_snapshot` server-side by
+ * FWB-1 (`mode` absent or `'create'`): target is the rule's own sheet (FWB0 lock D2; §11 Q3 rejected
+ * same-base explicit sheet targets). Deliberately NO client-supplied target sheet/base fields.
+ *
+ * FWB-2 (`mode: 'update'`): target base/sheet are derived server-side from the pinned active template
+ * version's top-level `record-link` field props (D3); `recordLinkFieldId` selects which form field
+ * anchors the existing record. Client-supplied target base/sheet ids are never trusted.
+ *
+ * Form VALUES never appear here — the executor reads the immutable `form_snapshot` server-side by
  * instanceId (lock D4: 表单值永不进事件载荷/动作配置).
  */
 export interface WriteApprovalFormValuesConfig {
@@ -72,10 +77,23 @@ export interface WriteApprovalFormValuesConfig {
   sourceTemplateVersionId: string
   /**
    * §11 Q6 gate-3 explicit confirmation, BOUND to the actual config: the server-derived sha256 of the
-   * canonicalized {templateId, sourceTemplateVersionId, targetSheetId, mappings}. Save rejects a mismatch; execute re-derives from
-   * the persisted row, so any config/target/template change invalidates the confirmation.
+   * canonicalized subject (create: {templateId, sourceTemplateVersionId, targetBaseId, targetSheetId,
+   * mappings}; update additionally binds mode + recordLinkFieldId + derived target). Save rejects a
+   * mismatch; execute re-derives from the persisted row, so any config/target/template change
+   * invalidates the confirmation.
    */
   confirmationHash: string
+  /**
+   * Write mode. Absent or `'create'` = FWB-1 create on the rule sheet (byte-compatible with pre-FWB-2
+   * configs). `'update'` = FWB-2 update of the form-anchored existing record. Any other value is
+   * save-rejected.
+   */
+  mode?: 'create' | 'update'
+  /**
+   * FWB-2 only: id of the top-level `record-link` form field whose value addresses the bound record.
+   * Required (non-blank) when mode is `'update'`; ignored for create.
+   */
+  recordLinkFieldId?: string
 }
 
 /** Config shape for update_record */

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -3364,7 +3364,7 @@ export class AutomationExecutor {
           const updatedRow = updateRes.rows[0] as { version?: unknown; data?: unknown } | undefined
           // Fail closed if the locked row vanished between FOR UPDATE and UPDATE (should be impossible
           // under FOR UPDATE, but never report success with a missing mutation).
-          if (!updatedRow) throw new Error('fwb_rejected:record_missing')
+          if (!updatedRow) throw new Error('fwb_rejected:linked_record_unavailable')
           const nextVersion = Number(updatedRow.version)
           await recordRecordRevision(t.query as AutomationDeps['queryFn'], {
             sheetId,
@@ -3420,8 +3420,10 @@ export class AutomationExecutor {
     if (result.reason === 'mapping') {
       return { actionType, status: 'failed', error: 'fwb_rejected:mapping' }
     }
-    // record_missing | record_locked | record_not_writable — values-free stable codes.
-    return { actionType, status: 'failed', error: `fwb_rejected:${result.reason}` }
+    // Do not expose whether the filler-selected id is missing, locked, or merely
+    // unwritable through the persisted execution log. The internal reason still
+    // selects the fail-closed control path; the observable code is deliberately uniform.
+    return { actionType, status: 'failed', error: 'fwb_rejected:linked_record_unavailable' }
   }
 
   private async executeSendWebhook(

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -26,9 +26,31 @@ import { withAutomationEventId } from './automation-event-dedup'
 import { enqueueRecordEventIfDurable, emitRecordEventIfLegacy } from './automation-producer-emit'
 import { isDurableDeliveryEnabled } from './automation-durable-delivery'
 import { produceAutomationEvent } from './automation-durable-activation'
-import { isFwbWritebackEnabled, normalizeFwbMappings } from './approval-fwb-activation'
+import {
+  extractExactLinkedRecordId,
+  isFwbWritebackEnabled,
+  normalizeFwbMappings,
+  normalizeFwbUpdateRecordLinkFieldId,
+  parseFwbWriteMode,
+  resolveRecordLinkTargetFromSchema,
+} from './approval-fwb-activation'
 import { executeWriteApprovalFormValues, type FwbRecordWriteSeam } from './approval-fwb-write-action'
+import {
+  executeUpdateBoundRecord,
+  type FwbUpdateSeam,
+  type RecordLinkChecks,
+} from './approval-fwb-record-link'
 import type { FwbGateChecks } from './approval-fwb-permission-gates'
+import {
+  ensureRecordWriteAllowed,
+  loadRecordPermissionScopeMap,
+  loadSheetPermissionScopeMap,
+} from './permission-service'
+import {
+  lockRecordLinkMultiTargetAuthorityPhasedOnQuery,
+  resolveSheetCapabilitiesForUserOnQuery,
+} from '../services/approval-record-link-txn-auth'
+import { acquireRecordLinkRowAuthLockOnQuery } from '../services/approval-record-link-row-auth-lock'
 import { redactString } from './automation-log-redact'
 import { computeActionFingerprint } from './automation-suspension-service'
 import type { ConditionBranchResumeCursor } from './automation-resume-cursor'
@@ -901,6 +923,11 @@ export interface AutomationDeps {
   /** FWB activation (§11 Q6): the four-gate set re-checked at execute time. OMITTED ⇒ DEFAULT-DENY —
    *  a wiring that forgets to bind gates can never silently allow (fail-closed, kills default-allow). */
   fwbGateChecks?: FwbGateChecks
+  /**
+   * Production FWB gate factory. The executor passes the CURRENT transaction query so every
+   * authorization read shares the write transaction; a fixed `fwbGateChecks` remains a test seam.
+   */
+  fwbGateChecksFactory?: (queryFn: AutomationDeps['queryFn']) => FwbGateChecks
 }
 
 /** FWB fail-closed default: every gate denies. Production binds real checks at AutomationService
@@ -2832,14 +2859,75 @@ export class AutomationExecutor {
     }
   }
 
+  /** Bind the production gate set to the current write transaction; fixed checks are tests only. */
+  private fwbGateChecksFor(queryFn: AutomationDeps['queryFn']): FwbGateChecks {
+    return this.deps.fwbGateChecksFactory?.(queryFn)
+      ?? this.deps.fwbGateChecks
+      ?? DEFAULT_DENY_FWB_GATES
+  }
+
   /**
-   * FWB activation — `write_approval_form_values` (FWB0 lock, RATIFIED). Writes the approved instance's
-   * immutable `form_snapshot` (D4 — values NEVER ride the event payload or action config) into the rule's
-   * OWN sheet as a NEW record (D2), atomically with the FWB idempotency claim, the create revision and the
-   * chained durable outbox row (D9: ONE transaction). Preconditions fail closed with zero writes:
-   * flag OFF → skipped; durable chain OFF → failed (no half-durable path, D10); no rule-execution identity
-   * (ad-hoc dispatch) → failed (D11); no transaction seam → failed (the withTransaction autocommit
-   * fallback would silently break the four-way atomicity). Gates default to DENY when unbound.
+   * Freeze every authority source consumed by the FWB execute-time gate before any record lock/write.
+   * Existing grant rows are protected by FOR SHARE through the shared record-link lock order. The
+   * field-permission table lock also closes the absent-row -> concurrent read-only INSERT phantom.
+   * Membership is re-read after locking so a sheet rehome cannot preserve a stale base claim.
+   */
+  private async lockFwbExecutionAuthority(
+    queryFn: AutomationDeps['queryFn'],
+    input: {
+      userId: string
+      ruleId: string
+      templateId: string
+      templateVersionId: string
+      targets: ReadonlyArray<{ baseId: string; sheetId: string }>
+    },
+  ): Promise<void> {
+    await lockRecordLinkMultiTargetAuthorityPhasedOnQuery(queryFn, {
+      userId: input.userId,
+      targets: input.targets,
+    })
+    await queryFn('LOCK TABLE field_permissions IN SHARE MODE')
+    const rule = await queryFn(
+      'SELECT id FROM automation_rules WHERE id = $1 AND enabled = TRUE FOR SHARE',
+      [input.ruleId],
+    )
+    const template = await queryFn(
+      'SELECT id FROM approval_templates WHERE id = $1 FOR SHARE',
+      [input.templateId],
+    )
+    const version = await queryFn(
+      'SELECT id FROM approval_template_versions WHERE id = $1 AND template_id = $2 FOR SHARE',
+      [input.templateVersionId, input.templateId],
+    )
+    if (rule.rows.length !== 1 || template.rows.length !== 1 || version.rows.length !== 1) {
+      throw new Error('fwb_rejected:authority_changed')
+    }
+    for (const target of input.targets) {
+      const membership = await queryFn(
+        'SELECT base_id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL',
+        [target.sheetId],
+      )
+      const liveBaseId = (membership.rows[0] as { base_id?: unknown } | undefined)?.base_id
+      if (typeof liveBaseId !== 'string' || liveBaseId !== target.baseId) {
+        throw new Error('fwb_rejected:target_schema')
+      }
+    }
+  }
+
+  /**
+   * FWB activation — `write_approval_form_values` (FWB0 lock, RATIFIED).
+   *
+   * - mode absent/`create` (FWB-1): writes the approved instance's immutable `form_snapshot` (D4)
+   *   into the rule's OWN sheet as a NEW record (D2).
+   * - mode `'update'` (FWB-2): updates the existing record addressed by the form's record-link
+   *   field (D3); target base/sheet are derived from the pinned template-version schema, never from
+   *   client-supplied ids. Cross-base writes go through `evaluateCrossBaseWriteGate` with the rule
+   *   creator (not the event actor).
+   *
+   * Both modes commit claim + record write + revision + durable outbox in ONE transaction (D9).
+   * Preconditions fail closed with zero writes: flag OFF → skipped; durable chain OFF → failed
+   * (no half-durable path, D10); no rule-execution identity → failed (D11); no transaction seam →
+   * failed. Gates default to DENY when unbound.
    */
   private async executeWriteApprovalFormValuesAction(
     config: Record<string, unknown>,
@@ -2872,149 +2960,14 @@ export class AutomationExecutor {
           error: 'write_approval_form_values requires the transaction seam — the autocommit fallback cannot honour claim+record+revision+outbox atomicity (FWB0 D9)',
         }
       }
-      const trig = (context.triggerEvent && typeof context.triggerEvent === 'object' ? context.triggerEvent : {}) as Record<string, unknown>
-      const approval = (trig.approval && typeof trig.approval === 'object' ? trig.approval : {}) as Record<string, unknown>
-      const instanceId = typeof approval.instanceId === 'string' ? approval.instanceId.trim() : ''
-      const templateId = typeof approval.templateId === 'string' ? approval.templateId.trim() : ''
-      const templateVersionId = typeof approval.templateVersionId === 'string'
-        ? approval.templateVersionId.trim()
-        : ''
-      const baseEventId = typeof trig.eventId === 'string' && trig.eventId.trim()
-        ? trig.eventId.trim()
-        : (typeof trig._eventId === 'string' ? trig._eventId.trim() : '')
-      if (!instanceId || !templateId || !templateVersionId || !baseEventId) {
-        return { actionType, status: 'failed', error: 'write_approval_form_values requires an approval completion event carrying instanceId + templateId + templateVersionId + a stable eventId' }
+      const modeParsed = parseFwbWriteMode(config.mode)
+      if (!modeParsed.ok) {
+        return { actionType, status: 'failed', error: 'fwb_rejected:mapping_config:unknown_mode' }
       }
-      // D1 hard gate: writeback fires on APPROVED completions only — regardless of the rule's outcome filter.
-      const transition = (trig.transition && typeof trig.transition === 'object' ? trig.transition : {}) as Record<string, unknown>
-      const outcome = typeof transition.toStatus === 'string' && transition.toStatus
-        ? transition.toStatus
-        : (typeof trig.eventType === 'string' && trig.eventType.startsWith('approval.') ? trig.eventType.slice('approval.'.length) : '')
-      if (outcome !== 'approved') {
-        return { actionType, status: 'skipped', output: { reason: 'fwb_outcome_not_approved' } }
+      if (modeParsed.mode === 'update') {
+        return await this.executeWriteApprovalFormValuesUpdateAction(config, context, identity)
       }
-      const normalized = normalizeFwbMappings((config as { mappings?: unknown }).mappings)
-      if (!normalized.ok) {
-        return { actionType, status: 'failed', error: `fwb_rejected:mapping_config:${(normalized as { issue: string }).issue}` }
-      }
-      const confirmedVersionId = typeof config.sourceTemplateVersionId === 'string'
-        ? config.sourceTemplateVersionId.trim()
-        : ''
-      if (!confirmedVersionId || confirmedVersionId !== templateVersionId) {
-        return { actionType, status: 'failed', error: 'fwb_rejected:source_template_version' }
-      }
-      const gates = this.deps.fwbGateChecks ?? DEFAULT_DENY_FWB_GATES
-      // Per-action identity: the SAME §2.1 derivation Class-A uses — structuralPath keeps two
-      // byte-identical FWB actions in one rule distinct (config-hash identity would collapse them).
-      const actionKey = deriveActionKey({ structuralPath: identity.structuralPath, actionType, canonicalConfig: config })
-      const fwbEventId = `${baseEventId}::fwb::${context.ruleId}::${actionKey}`
-      const automationDepth = (typeof trig._automationDepth === 'number' ? trig._automationDepth : 0) + 1
-
-      const result = await this.withTransaction(context.sheetId, async (query) => {
-        const targetFieldResult = await query(
-          `SELECT id, type, property
-             FROM meta_fields
-            WHERE sheet_id = $1 AND id = ANY($2::text[])
-            FOR SHARE`,
-          [context.sheetId, normalized.mappings.map((mapping) => mapping.targetFieldId)],
-        )
-        const targetFields = new Map(
-          (targetFieldResult.rows as Array<{ id?: unknown; type?: unknown; property?: unknown }>)
-            .filter((row): row is { id: string; type: string; property?: unknown } => (
-              typeof row.id === 'string' && typeof row.type === 'string'
-            ))
-            .map((row) => [row.id, { type: row.type, property: normalizeJson(row.property) }] as const),
-        )
-        if (targetFields.size !== normalized.mappings.length) throw new Error('fwb_rejected:mapping_target_changed')
-        const runtimeMappings = normalized.mappings.map((mapping) => {
-          const field = targetFields.get(mapping.targetFieldId)
-          if (!field || field.type !== mapping.targetType) throw new Error('fwb_rejected:mapping_target_changed')
-          if (mapping.targetType !== 'number') return mapping
-          // Number fields persist their decimal-place cap as `property.decimals` (the canonical
-          // field codec contract). Do not infer a second `precision` spelling here: doing so silently
-          // removes the execute-time cap from every normally authored number field.
-          const precision = field.property.decimals
-          return {
-            ...mapping,
-            ...(typeof precision === 'number' && Number.isSafeInteger(precision) && precision >= 0
-              ? { numberPrecision: precision }
-              : {}),
-          }
-        })
-        // D4: the immutable form snapshot is the ONLY value source, read server-side inside the txn.
-        const snapRes = await query(
-          `SELECT form_snapshot FROM approval_instances
-            WHERE id = $1 AND template_id = $2 AND template_version_id = $3 AND status = 'approved'`,
-          [instanceId, templateId, templateVersionId],
-        )
-        const snapRow = snapRes.rows[0] as { form_snapshot?: unknown } | undefined
-        if (!snapRow) throw new Error('fwb_rejected:instance_not_found')
-        const rawSnap = snapRow.form_snapshot
-        const formValues = (rawSnap && typeof rawSnap === 'object' && !Array.isArray(rawSnap)
-          ? rawSnap
-          : (() => { try { return JSON.parse(String(rawSnap ?? '{}')) as Record<string, unknown> } catch { return {} } })()) as Record<string, unknown>
-        const trx = { query, isTransaction: true } as unknown as TransactionalQueryable
-        const seam: FwbRecordWriteSeam = {
-          createRecordWithRevision: async (t, targetSheetId, values) => {
-            const recordId = `rec_${randomUUID()}`
-            // xbase-write-exempt: FWB-1 writes ONLY the rule's OWN sheet (FWB0 D2 — the config schema has
-            // no targetBase/targetSheet fields, §11 Q3 rejected them), so this create can never retarget
-            // to a config-declared base; the §11 Q6 gate set (incl. canWriteSheet on THIS sheet) ran above.
-            // revision-emitted: recordRecordRevision(action:'create') immediately below, SAME transaction.
-            await t.query(
-              'INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1, $2, $3::jsonb, 1)',
-              [recordId, targetSheetId, JSON.stringify(values)],
-            )
-            // Same revision contract as executeCreateRecord (OD-2 source names the write entry point;
-            // the write identity is the rule CREATOR — §2.2: system completions carry no human actor).
-            await recordRecordRevision(t.query as AutomationDeps['queryFn'], {
-              sheetId: targetSheetId,
-              recordId,
-              version: 1,
-              action: 'create',
-              source: 'automation',
-              actorId: context.ruleCreatedBy ?? null,
-              changedFieldIds: Object.keys(values),
-              patch: values,
-              snapshot: values,
-            })
-            return recordId
-          },
-          enqueueOutbox: async (t, event) => {
-            await produceAutomationEvent(
-              { query: t.query, isTransaction: true } as unknown as TransactionalQueryable,
-              { eventType: event.eventType, eventId: event.eventId, payload: event.payload, automationDepth: event.automationDepth },
-            )
-          },
-        }
-        return executeWriteApprovalFormValues(trx, {
-          claimId: `fwb_${randomUUID()}`,
-          instanceId,
-          ruleId: context.ruleId,
-          actionKey,
-          gateSubject: {
-            configurerUserId: context.ruleCreatedBy,
-            ruleId: context.ruleId,
-            sourceTemplateId: templateId,
-            targetSheetId: context.sheetId,
-          },
-          mappings: runtimeMappings,
-          formValues,
-          eventId: fwbEventId,
-          automationDepth,
-        }, gates, seam)
-      })
-
-      if (result.status === 'applied') {
-        return { actionType, status: 'success', output: { recordId: result.recordId, sheetId: context.sheetId } }
-      }
-      if (result.status === 'already_applied') {
-        return { actionType, status: 'success', alreadyApplied: true, output: { alreadyApplied: true } }
-      }
-      if (result.reason === 'permission_gates') {
-        return { actionType, status: 'failed', error: `fwb_rejected:permission_gates:${(result.failedGates ?? []).join(',')}` }
-      }
-      return { actionType, status: 'failed', error: 'fwb_rejected:mapping' }
+      return await this.executeWriteApprovalFormValuesCreateAction(config, context, identity)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       if (message.startsWith('fwb_rejected:') || message.startsWith('write_approval_form_values requires')) {
@@ -3023,6 +2976,452 @@ export class AutomationExecutor {
       logger.warn('write_approval_form_values execution failed')
       return { actionType, status: 'failed', error: 'fwb_execution_failed' }
     }
+  }
+
+  /** Shared completion-event identity extraction for FWB create/update. */
+  private parseFwbCompletionContext(context: ExecutionContext): {
+    ok: true
+    instanceId: string
+    templateId: string
+    templateVersionId: string
+    baseEventId: string
+    automationDepth: number
+  } | { ok: false; error: string; skipped?: true; skipReason?: string } {
+    const trig = (context.triggerEvent && typeof context.triggerEvent === 'object' ? context.triggerEvent : {}) as Record<string, unknown>
+    const approval = (trig.approval && typeof trig.approval === 'object' ? trig.approval : {}) as Record<string, unknown>
+    const instanceId = typeof approval.instanceId === 'string' ? approval.instanceId.trim() : ''
+    const templateId = typeof approval.templateId === 'string' ? approval.templateId.trim() : ''
+    const templateVersionId = typeof approval.templateVersionId === 'string'
+      ? approval.templateVersionId.trim()
+      : ''
+    const baseEventId = typeof trig.eventId === 'string' && trig.eventId.trim()
+      ? trig.eventId.trim()
+      : (typeof trig._eventId === 'string' ? trig._eventId.trim() : '')
+    if (!instanceId || !templateId || !templateVersionId || !baseEventId) {
+      return {
+        ok: false,
+        error: 'write_approval_form_values requires an approval completion event carrying instanceId + templateId + templateVersionId + a stable eventId',
+      }
+    }
+    // D1 hard gate: writeback fires on APPROVED completions only — regardless of the rule's outcome filter.
+    const transition = (trig.transition && typeof trig.transition === 'object' ? trig.transition : {}) as Record<string, unknown>
+    const outcome = typeof transition.toStatus === 'string' && transition.toStatus
+      ? transition.toStatus
+      : (typeof trig.eventType === 'string' && trig.eventType.startsWith('approval.') ? trig.eventType.slice('approval.'.length) : '')
+    if (outcome !== 'approved') {
+      return { ok: false, error: '', skipped: true, skipReason: 'fwb_outcome_not_approved' }
+    }
+    const automationDepth = (typeof trig._automationDepth === 'number' ? trig._automationDepth : 0) + 1
+    return { ok: true, instanceId, templateId, templateVersionId, baseEventId, automationDepth }
+  }
+
+  /** FWB-1 create path — rule's own sheet (D2). Byte-compatible with pre-FWB-2 wiring. */
+  private async executeWriteApprovalFormValuesCreateAction(
+    config: Record<string, unknown>,
+    context: ExecutionContext,
+    identity: ClassAActionIdentity,
+  ): Promise<AutomationStepResult> {
+    const actionType = 'write_approval_form_values'
+    const parsed = this.parseFwbCompletionContext(context)
+    if (parsed.ok === false) {
+      if (parsed.skipped) return { actionType, status: 'skipped', output: { reason: parsed.skipReason } }
+      return { actionType, status: 'failed', error: parsed.error }
+    }
+    const { instanceId, templateId, templateVersionId, baseEventId, automationDepth } = parsed
+    const normalized = normalizeFwbMappings((config as { mappings?: unknown }).mappings)
+    if (!normalized.ok) {
+      return { actionType, status: 'failed', error: `fwb_rejected:mapping_config:${(normalized as { issue: string }).issue}` }
+    }
+    const confirmedVersionId = typeof config.sourceTemplateVersionId === 'string'
+      ? config.sourceTemplateVersionId.trim()
+      : ''
+    if (!confirmedVersionId || confirmedVersionId !== templateVersionId) {
+      return { actionType, status: 'failed', error: 'fwb_rejected:source_template_version' }
+    }
+    const actionKey = deriveActionKey({ structuralPath: identity.structuralPath, actionType, canonicalConfig: config })
+    const fwbEventId = `${baseEventId}::fwb::${context.ruleId}::${actionKey}`
+
+    const result = await this.withTransaction(context.sheetId, async (query) => {
+      if (this.deps.fwbGateChecksFactory) {
+        const ruleMembership = await query(
+          'SELECT base_id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL',
+          [context.sheetId],
+        )
+        const ruleBaseId = (ruleMembership.rows[0] as { base_id?: unknown } | undefined)?.base_id
+        if (typeof ruleBaseId !== 'string' || !ruleBaseId) throw new Error('fwb_rejected:target_schema')
+        await this.lockFwbExecutionAuthority(query, {
+          userId: context.ruleCreatedBy,
+          ruleId: context.ruleId,
+          templateId,
+          templateVersionId,
+          targets: [{ baseId: ruleBaseId, sheetId: context.sheetId }],
+        })
+      }
+      const gates = this.fwbGateChecksFor(query)
+      const targetFieldResult = await query(
+        `SELECT id, type, property
+           FROM meta_fields
+          WHERE sheet_id = $1 AND id = ANY($2::text[])
+          FOR SHARE`,
+        [context.sheetId, normalized.mappings.map((mapping) => mapping.targetFieldId)],
+      )
+      const targetFields = new Map(
+        (targetFieldResult.rows as Array<{ id?: unknown; type?: unknown; property?: unknown }>)
+          .filter((row): row is { id: string; type: string; property?: unknown } => (
+            typeof row.id === 'string' && typeof row.type === 'string'
+          ))
+          .map((row) => [row.id, { type: row.type, property: normalizeJson(row.property) }] as const),
+      )
+      if (targetFields.size !== normalized.mappings.length) throw new Error('fwb_rejected:mapping_target_changed')
+      const runtimeMappings = normalized.mappings.map((mapping) => {
+        const field = targetFields.get(mapping.targetFieldId)
+        if (!field || field.type !== mapping.targetType) throw new Error('fwb_rejected:mapping_target_changed')
+        if (mapping.targetType !== 'number') return mapping
+        const precision = field.property.decimals
+        return {
+          ...mapping,
+          ...(typeof precision === 'number' && Number.isSafeInteger(precision) && precision >= 0
+            ? { numberPrecision: precision }
+            : {}),
+        }
+      })
+      // D4: the immutable form snapshot is the ONLY value source, read server-side inside the txn.
+      const snapRes = await query(
+        `SELECT form_snapshot FROM approval_instances
+          WHERE id = $1 AND template_id = $2 AND template_version_id = $3 AND status = 'approved'
+          FOR SHARE`,
+        [instanceId, templateId, templateVersionId],
+      )
+      const snapRow = snapRes.rows[0] as { form_snapshot?: unknown } | undefined
+      if (!snapRow) throw new Error('fwb_rejected:instance_not_found')
+      const rawSnap = snapRow.form_snapshot
+      const formValues = (rawSnap && typeof rawSnap === 'object' && !Array.isArray(rawSnap)
+        ? rawSnap
+        : (() => { try { return JSON.parse(String(rawSnap ?? '{}')) as Record<string, unknown> } catch { return {} } })()) as Record<string, unknown>
+      const trx = { query, isTransaction: true } as unknown as TransactionalQueryable
+      const seam: FwbRecordWriteSeam = {
+        createRecordWithRevision: async (t, targetSheetId, values) => {
+          const recordId = `rec_${randomUUID()}`
+          // xbase-write-exempt: FWB-1 writes ONLY the rule's OWN sheet (FWB0 D2).
+          // revision-emitted: recordRecordRevision(action:'create') immediately below, SAME transaction.
+          await t.query(
+            'INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1, $2, $3::jsonb, 1)',
+            [recordId, targetSheetId, JSON.stringify(values)],
+          )
+          await recordRecordRevision(t.query as AutomationDeps['queryFn'], {
+            sheetId: targetSheetId,
+            recordId,
+            version: 1,
+            action: 'create',
+            source: 'automation',
+            actorId: context.ruleCreatedBy ?? null,
+            changedFieldIds: Object.keys(values),
+            patch: values,
+            snapshot: values,
+          })
+          return recordId
+        },
+        enqueueOutbox: async (t, event) => {
+          await produceAutomationEvent(
+            { query: t.query, isTransaction: true } as unknown as TransactionalQueryable,
+            { eventType: event.eventType, eventId: event.eventId, payload: event.payload, automationDepth: event.automationDepth },
+          )
+        },
+      }
+      return executeWriteApprovalFormValues(trx, {
+        claimId: `fwb_${randomUUID()}`,
+        instanceId,
+        ruleId: context.ruleId,
+        actionKey,
+        gateSubject: {
+          configurerUserId: context.ruleCreatedBy,
+          ruleId: context.ruleId,
+          actionKey,
+          sourceTemplateId: templateId,
+          targetSheetId: context.sheetId,
+          mode: 'create',
+        },
+        mappings: runtimeMappings,
+        formValues,
+        eventId: fwbEventId,
+        automationDepth,
+      }, gates, seam)
+    })
+
+    if (result.status === 'applied') {
+      return { actionType, status: 'success', output: { recordId: result.recordId, sheetId: context.sheetId } }
+    }
+    if (result.status === 'already_applied') {
+      return { actionType, status: 'success', alreadyApplied: true, output: { alreadyApplied: true } }
+    }
+    if (result.reason === 'permission_gates') {
+      return { actionType, status: 'failed', error: `fwb_rejected:permission_gates:${(result.failedGates ?? []).join(',')}` }
+    }
+    return { actionType, status: 'failed', error: 'fwb_rejected:mapping' }
+  }
+
+  /**
+   * FWB-2 update path — form-anchored existing record (D3). Target base/sheet from the pinned
+   * template-version record-link field props; exact one `{recordId}` from form_snapshot; cross-base
+   * via evaluateCrossBaseWriteGate(ruleCreatedBy); reuses executeUpdateBoundRecord for the D9 four-way
+   * atomic claim + UPDATE + revision + outbox.
+   */
+  private async executeWriteApprovalFormValuesUpdateAction(
+    config: Record<string, unknown>,
+    context: ExecutionContext,
+    identity: ClassAActionIdentity,
+  ): Promise<AutomationStepResult> {
+    const actionType = 'write_approval_form_values'
+    const parsed = this.parseFwbCompletionContext(context)
+    if (parsed.ok === false) {
+      if (parsed.skipped) return { actionType, status: 'skipped', output: { reason: parsed.skipReason } }
+      return { actionType, status: 'failed', error: parsed.error }
+    }
+    const { instanceId, templateId, templateVersionId, baseEventId, automationDepth } = parsed
+    const linkField = normalizeFwbUpdateRecordLinkFieldId(config.recordLinkFieldId)
+    if (linkField.ok === false) {
+      return { actionType, status: 'failed', error: `fwb_rejected:mapping_config:${linkField.issue}` }
+    }
+    const normalized = normalizeFwbMappings((config as { mappings?: unknown }).mappings)
+    if (!normalized.ok) {
+      return { actionType, status: 'failed', error: `fwb_rejected:mapping_config:${(normalized as { issue: string }).issue}` }
+    }
+    const confirmedVersionId = typeof config.sourceTemplateVersionId === 'string'
+      ? config.sourceTemplateVersionId.trim()
+      : ''
+    if (!confirmedVersionId || confirmedVersionId !== templateVersionId) {
+      return { actionType, status: 'failed', error: 'fwb_rejected:source_template_version' }
+    }
+    const actionKey = deriveActionKey({ structuralPath: identity.structuralPath, actionType, canonicalConfig: config })
+    const fwbEventId = `${baseEventId}::fwb::${context.ruleId}::${actionKey}`
+    const ruleCreatorId = typeof context.ruleCreatedBy === 'string' ? context.ruleCreatedBy : ''
+
+    // Transaction keyed on the RULE sheet (same as create) — the write may retarget, but the
+    // transaction seam is stable; FOR UPDATE on the bound row serializes the target mutation.
+    const result = await this.withTransaction(context.sheetId, async (query) => {
+      // D4: immutable form_snapshot + pinned template-version schema are the ONLY sources of truth.
+      const snapRes = await query(
+        `SELECT i.form_snapshot, v.form_schema
+           FROM approval_instances i
+           JOIN approval_template_versions v ON v.id = i.template_version_id
+          WHERE i.id = $1 AND i.template_id = $2 AND i.template_version_id = $3 AND i.status = 'approved'
+          FOR SHARE OF i, v`,
+        [instanceId, templateId, templateVersionId],
+      )
+      const snapRow = snapRes.rows[0] as { form_snapshot?: unknown; form_schema?: unknown } | undefined
+      if (!snapRow) throw new Error('fwb_rejected:instance_not_found')
+
+      const rawSchema = snapRow.form_schema && typeof snapRow.form_schema === 'object' && !Array.isArray(snapRow.form_schema)
+        ? snapRow.form_schema
+        : (() => {
+          try { return JSON.parse(String(snapRow.form_schema ?? 'null')) as unknown } catch { return null }
+        })()
+      const derived = resolveRecordLinkTargetFromSchema(rawSchema, linkField.recordLinkFieldId)
+      if (!derived) throw new Error('fwb_rejected:record_link_field')
+
+      if (this.deps.fwbGateChecksFactory) {
+        const ruleMembership = await query(
+          'SELECT base_id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL',
+          [context.sheetId],
+        )
+        const ruleBaseId = (ruleMembership.rows[0] as { base_id?: unknown } | undefined)?.base_id
+        if (typeof ruleBaseId !== 'string' || !ruleBaseId) throw new Error('fwb_rejected:target_schema')
+        await this.lockFwbExecutionAuthority(query, {
+          userId: ruleCreatorId,
+          ruleId: context.ruleId,
+          templateId,
+          templateVersionId,
+          targets: [
+            { baseId: ruleBaseId, sheetId: context.sheetId },
+            { baseId: derived.baseId, sheetId: derived.sheetId },
+          ],
+        })
+      }
+      const gates = this.fwbGateChecksFor(query)
+
+      const rawSnap = snapRow.form_snapshot
+      const formValues = (rawSnap && typeof rawSnap === 'object' && !Array.isArray(rawSnap)
+        ? rawSnap
+        : (() => { try { return JSON.parse(String(rawSnap ?? '{}')) as Record<string, unknown> } catch { return {} } })()) as Record<string, unknown>
+
+      // D3: exactly one { recordId: string }; 0 / multi / free-text / extra keys → reject (no oracle).
+      const boundRecordId = extractExactLinkedRecordId(formValues[linkField.recordLinkFieldId])
+      if (!boundRecordId) throw new Error('fwb_rejected:linked_record')
+
+      // Cross-base gate with rule CREATOR (not event actor — §2.2). claim == derived target base.
+      // Same-base remains the fast path inside evaluateCrossBaseWriteGate.
+      const crossGate = await this.evaluateCrossBaseWriteGate(
+        query as AutomationDeps['queryFn'],
+        ruleCreatorId || null,
+        context.sheetId,
+        derived.sheetId,
+        derived.baseId,
+      )
+      if (crossGate.crossBase && crossGate.ok === false) {
+        // Values-free stable reason (do not leak the full gate error string's internal identifiers beyond code).
+        throw new Error('fwb_rejected:cross_base')
+      }
+
+      // Fire-time type recheck on the DERIVED target sheet (field retype/delete since save → reject).
+      const targetFieldResult = await query(
+        `SELECT id, type, property
+           FROM meta_fields
+          WHERE sheet_id = $1 AND id = ANY($2::text[])
+          FOR SHARE`,
+        [derived.sheetId, normalized.mappings.map((mapping) => mapping.targetFieldId)],
+      )
+      const targetFields = new Map(
+        (targetFieldResult.rows as Array<{ id?: unknown; type?: unknown; property?: unknown }>)
+          .filter((row): row is { id: string; type: string; property?: unknown } => (
+            typeof row.id === 'string' && typeof row.type === 'string'
+          ))
+          .map((row) => [row.id, { type: row.type, property: normalizeJson(row.property) }] as const),
+      )
+      if (targetFields.size !== normalized.mappings.length) throw new Error('fwb_rejected:mapping_target_changed')
+      const runtimeMappings = normalized.mappings.map((mapping) => {
+        const field = targetFields.get(mapping.targetFieldId)
+        if (!field || field.type !== mapping.targetType) throw new Error('fwb_rejected:mapping_target_changed')
+        if (mapping.targetType !== 'number') return mapping
+        const precision = field.property.decimals
+        return {
+          ...mapping,
+          ...(typeof precision === 'number' && Number.isSafeInteger(precision) && precision >= 0
+            ? { numberPrecision: precision }
+            : {}),
+        }
+      })
+
+      const trx = { query, isTransaction: true } as unknown as TransactionalQueryable
+      const queryFn = query as AutomationDeps['queryFn']
+
+      // Production bound-record checks: FOR UPDATE + lock + sheet/own-write/record-scope authority.
+      // Missing / unreadable / not-writable share fail-closed codes (no existence oracle on responses).
+      const linkChecks: RecordLinkChecks = {
+        fillerCanReadRecord: async () => false, // not used at execute time
+        recordExists: async (t, sheetId, recordId) => {
+          await acquireRecordLinkRowAuthLockOnQuery(t.query, sheetId, recordId)
+          const r = await t.query(
+            'SELECT id FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE',
+            [sheetId, recordId],
+          )
+          return r.rows.length > 0
+        },
+        recordIsLocked: async (t, sheetId, recordId) => {
+          const r = await t.query(
+            'SELECT locked, locked_by, created_by FROM meta_records WHERE sheet_id = $1 AND id = $2',
+            [sheetId, recordId],
+          )
+          const row = r.rows[0] as { locked?: unknown; locked_by?: unknown; created_by?: unknown } | undefined
+          if (!row) return false // missing → handled by recordExists first
+          try {
+            ensureRecordNotLocked(ruleCreatorId || null, row, () => new Error('locked'))
+            return false
+          } catch {
+            return true
+          }
+        },
+        configurerCanWriteRecord: async (t, configurerUserId, sheetId, recordId) => {
+          if (!configurerUserId) return false
+          const resolved = await resolveSheetCapabilitiesForUserOnQuery(queryFn, sheetId, configurerUserId)
+          const sheetScope = (await loadSheetPermissionScopeMap(queryFn, [sheetId], configurerUserId)).get(sheetId)
+          const rowRes = await t.query(
+            'SELECT created_by FROM meta_records WHERE sheet_id = $1 AND id = $2',
+            [sheetId, recordId],
+          )
+          const createdBy = (rowRes.rows[0] as { created_by?: unknown } | undefined)?.created_by
+          const access = {
+            userId: configurerUserId,
+            permissions: resolved.permissions,
+            isAdminRole: resolved.isAdminRole,
+          }
+          const scopeMap = await loadRecordPermissionScopeMap(queryFn, sheetId, [recordId], configurerUserId)
+          return ensureRecordWriteAllowed(
+            resolved.capabilities,
+            sheetScope,
+            access,
+            typeof createdBy === 'string' ? createdBy : null,
+            'edit',
+            scopeMap,
+            recordId,
+          )
+        },
+      }
+
+      const seam: FwbUpdateSeam = {
+        updateRecordWithRevision: async (t, sheetId, recordId, values) => {
+          // xbase-write-gated: evaluateCrossBaseWriteGate accepted the server-pinned target above.
+          // lock-guarded: recordExists holds FOR UPDATE and calls ensureRecordNotLocked in this transaction.
+          // revision-emitted: recordRecordRevision runs below in this transaction before commit.
+          const updateRes = await t.query(
+            `UPDATE meta_records
+             SET data = COALESCE(data, '{}'::jsonb) || $1::jsonb,
+                 version = version + 1,
+                 updated_at = NOW()
+             WHERE id = $2 AND sheet_id = $3
+             RETURNING version, data`,
+            [JSON.stringify(values), recordId, sheetId],
+          )
+          const updatedRow = updateRes.rows[0] as { version?: unknown; data?: unknown } | undefined
+          // Fail closed if the locked row vanished between FOR UPDATE and UPDATE (should be impossible
+          // under FOR UPDATE, but never report success with a missing mutation).
+          if (!updatedRow) throw new Error('fwb_rejected:record_missing')
+          const nextVersion = Number(updatedRow.version)
+          await recordRecordRevision(t.query as AutomationDeps['queryFn'], {
+            sheetId,
+            recordId,
+            version: Number.isFinite(nextVersion) ? nextVersion : 0,
+            action: 'update',
+            source: 'automation',
+            // §2.2: write identity = rule creator, never the event actor (may be null on auto-approve).
+            actorId: ruleCreatorId || null,
+            changedFieldIds: Object.keys(values),
+            patch: values,
+            snapshot: normalizeJson(updatedRow.data),
+          })
+        },
+        enqueueOutbox: async (t, event) => {
+          await produceAutomationEvent(
+            { query: t.query, isTransaction: true } as unknown as TransactionalQueryable,
+            { eventType: event.eventType, eventId: event.eventId, payload: event.payload, automationDepth: event.automationDepth },
+          )
+        },
+      }
+
+      return executeUpdateBoundRecord(trx, {
+        claimId: `fwb_${randomUUID()}`,
+        instanceId,
+        ruleId: context.ruleId,
+        actionKey,
+        gateSubject: {
+          configurerUserId: ruleCreatorId,
+          ruleId: context.ruleId,
+          actionKey,
+          sourceTemplateId: templateId,
+          targetSheetId: derived.sheetId,
+          mode: 'update',
+        },
+        boundRecordId,
+        mappings: runtimeMappings,
+        formValues,
+        eventId: fwbEventId,
+        automationDepth,
+      }, gates, linkChecks, seam)
+    })
+
+    if (result.status === 'applied') {
+      return { actionType, status: 'success', output: { mode: 'update', alreadyApplied: false } }
+    }
+    if (result.status === 'already_applied') {
+      return { actionType, status: 'success', alreadyApplied: true, output: { mode: 'update', alreadyApplied: true } }
+    }
+    if (result.reason === 'permission_gates') {
+      return { actionType, status: 'failed', error: `fwb_rejected:permission_gates:${(result.failedGates ?? []).join(',')}` }
+    }
+    if (result.reason === 'mapping') {
+      return { actionType, status: 'failed', error: 'fwb_rejected:mapping' }
+    }
+    // record_missing | record_locked | record_not_writable — values-free stable codes.
+    return { actionType, status: 'failed', error: `fwb_rejected:${result.reason}` }
   }
 
   private async executeSendWebhook(

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -42,6 +42,9 @@ import {
   collectFwbActionConfigs,
   deriveFwbConfirmationHash,
   normalizeFwbMappings,
+  normalizeFwbUpdateRecordLinkFieldId,
+  parseFwbWriteMode,
+  resolveRecordLinkTargetFromSchema,
 } from './approval-fwb-activation'
 import { isAdmin as rbacIsAdmin } from '../rbac/service'
 import { resolveSheetCapabilitiesForUser } from './sheet-capabilities'
@@ -86,6 +89,10 @@ import {
 import type { ApprovalCompletionEventV1 } from '../services/ApprovalCompletionEvent'
 import type { ApprovalTaskCreatedEventV1 } from '../services/ApprovalTaskCreatedEvent'
 import { applyTemplateVisibilityFilter, type ApprovalTemplateVisibilityActor } from '../services/ApprovalProductService'
+import {
+  isAdminOnQuery,
+  loadApprovalTemplateVisibilityActorOnQuery,
+} from '../services/approval-record-link-txn-auth'
 import { metrics } from '../metrics/metrics'
 import {
   normalizeDingTalkAutomationActionInputs,
@@ -897,14 +904,25 @@ export class AutomationService {
       }),
       fetchFn,
       notificationService,
-      // FWB activation (§11 Q6): the REAL four-gate set, re-checked at execute time inside the write
-      // transaction. Test seams inject their own; production always binds these.
-      fwbGateChecks: buildProductionFwbGateChecks({
-        queryFn,
-        isAdminFn: (userId) => rbacIsAdmin(userId),
-        canReadTemplateFn: async (userId, templateId) =>
-          (await this.approvalCompletedCreatorAuthorized(userId)) &&
-          (await this.approvalTemplateVisibleToCreator(templateId, userId)),
+      // FWB activation (§11 Q6): construct the REAL four-gate set from the CURRENT write
+      // transaction. Pool/cached permission reads here would reopen a revoke-after-check race.
+      fwbGateChecksFactory: (transactionQuery) => buildProductionFwbGateChecks({
+        queryFn: transactionQuery,
+        isAdminFn: (userId) => isAdminOnQuery(transactionQuery, userId),
+        canReadTemplateFn: async (userId, templateId) => {
+          const actor = await loadApprovalTemplateVisibilityActorOnQuery(transactionQuery, userId)
+          if (!actor || !hasPermissionCode(actor.permissions, 'approvals:read')) return false
+          const conditions = ['id = $1']
+          const params: unknown[] = [templateId]
+          applyTemplateVisibilityFilter(conditions, params, 2, actor)
+          const visible = await transactionQuery(
+            `SELECT id FROM approval_templates
+              WHERE ${conditions.join(' AND ')}
+              LIMIT 1 FOR SHARE`,
+            params,
+          )
+          return visible.rows.length > 0
+        },
       }),
     }
     this.executor = new AutomationExecutor(deps)
@@ -1938,13 +1956,17 @@ export class AutomationService {
    *     the executor additionally hard-gates on the approved outcome, so a broader filter can never
    *     write back a rejection);
    *   - mapping structure via `normalizeFwbMappings` (empty/duplicate/unsupported/select-without-options);
-   *   - target-schema truth: every targetFieldId exists on the RULE's sheet, its meta_fields.type equals
-   *     the declared targetType, and select options are ⊆ the field's configured option values (D6
-   *     closed vocabulary — `select_option_not_on_field`);
+   *   - mode contract: absent/`create` (FWB-1) or `update` (FWB-2); unknown modes rejected;
+   *   - FWB-2: one non-blank `recordLinkFieldId`; target base/sheet DERIVED from the pinned active
+   *     template version's top-level record-link field props (never client-supplied target ids);
+   *   - target-schema truth: every targetFieldId exists on the resolved target sheet, its
+   *     meta_fields.type equals the declared targetType, and select options are ⊆ the field's
+   *     configured option values (D6 closed vocabulary — `select_option_not_on_field`);
    *   - source truth: every formFieldId exists in the currently active template version, and the
    *     action explicitly binds that version; a new publish therefore requires confirmation again;
-   *   - Q6 gate 3: the submitted confirmationHash equals the server-derived hash over
-   *     {templateId, sourceTemplateVersionId, targetBaseId, targetSheetId, normalized mappings} — any drift invalidates the confirmation;
+   *   - Q6 gate 3: the submitted confirmationHash equals the server-derived hash over the
+   *     mode-appropriate subject (create hashes omit mode/recordLinkFieldId for byte-compat;
+   *     update binds mode + recordLinkFieldId + derived target) — any drift invalidates;
    *   - Q6 gate 1 at save: the actual creator/modifier/enabler is a platform admin OR holds
    *     canManageSheetAccess on the target sheet; source/target data authority remains bound to the
    *     persisted rule creator and is re-checked at execute time.
@@ -2003,13 +2025,29 @@ export class AutomationService {
           : null)
         .filter((id): id is string => typeof id === 'string' && /[!-~]/.test(id)),
     )
-    const targetSheetResult = await this.queryFn('SELECT base_id FROM meta_sheets WHERE id = $1', [sheetId])
-    const targetBaseId = (targetSheetResult.rows[0] as { base_id?: unknown } | undefined)?.base_id
-    if (typeof targetBaseId !== 'string' || !targetBaseId) {
+    const ruleSheetResult = await this.queryFn('SELECT base_id FROM meta_sheets WHERE id = $1', [sheetId])
+    const ruleBaseId = (ruleSheetResult.rows[0] as { base_id?: unknown } | undefined)?.base_id
+    if (typeof ruleBaseId !== 'string' || !ruleBaseId) {
       return `${FWB_ACTION_TYPE} target sheet is unavailable`
     }
-    const allTargetFieldIds: string[] = []
+
+    // Per-config resolved targets (create → rule sheet; update → derived record-link sheet).
+    // Authority checks below run against every distinct target.
+    type ResolvedTarget = {
+      targetSheetId: string
+      targetBaseId: string
+      mode: 'create' | 'update'
+      targetFieldIds: string[]
+    }
+    const resolvedTargets: ResolvedTarget[] = []
+
     for (const config of configs) {
+      const modeParsed = parseFwbWriteMode(config.mode)
+      if (!modeParsed.ok) {
+        return `${FWB_ACTION_TYPE} mapping config invalid: unknown_mode`
+      }
+      const mode = modeParsed.mode
+
       const normalized = normalizeFwbMappings(config.mappings)
       if (!normalized.ok) {
         return `${FWB_ACTION_TYPE} mapping config invalid: ${(normalized as { issue: string }).issue}`
@@ -2025,12 +2063,38 @@ export class AutomationService {
       if (confirmedVersionId !== activeVersionId) {
         return `${FWB_ACTION_TYPE} sourceTemplateVersionId must match the active template version`
       }
-      // target-schema truth on the rule's OWN sheet (FWB-1 target, lock D2)
+
+      let targetSheetId = sheetId
+      let targetBaseId = ruleBaseId
+      let recordLinkFieldId: string | undefined
+      if (mode === 'update') {
+        const linkField = normalizeFwbUpdateRecordLinkFieldId(config.recordLinkFieldId)
+        if (linkField.ok === false) {
+          return `${FWB_ACTION_TYPE} mapping config invalid: ${linkField.issue}`
+        }
+        const derived = resolveRecordLinkTargetFromSchema(rawSchema, linkField.recordLinkFieldId)
+        if (!derived) {
+          return `${FWB_ACTION_TYPE} mapping invalid: unknown_record_link_field`
+        }
+        // Membership: pinned sheet must still live in the pinned base (no client-supplied override).
+        const membership = await this.queryFn(
+          'SELECT base_id FROM meta_sheets WHERE id = $1',
+          [derived.sheetId],
+        )
+        const liveBase = (membership.rows[0] as { base_id?: unknown } | undefined)?.base_id
+        if (typeof liveBase !== 'string' || liveBase !== derived.baseId) {
+          return `${FWB_ACTION_TYPE} target sheet is unavailable`
+        }
+        targetSheetId = derived.sheetId
+        targetBaseId = derived.baseId
+        recordLinkFieldId = linkField.recordLinkFieldId
+      }
+
+      // target-schema truth on the resolved target sheet (FWB-1 = rule sheet; FWB-2 = record-link pin)
       const targetIds = normalized.mappings.map((m) => m.targetFieldId)
-      allTargetFieldIds.push(...targetIds)
       const fieldRes = await this.queryFn(
         'SELECT id, type, property FROM meta_fields WHERE sheet_id = $1 AND id = ANY($2::text[])',
-        [sheetId, targetIds],
+        [targetSheetId, targetIds],
       )
       const byId = new Map<string, { type: string; property: unknown }>()
       for (const row of fieldRes.rows as Array<{ id: string; type: string; property: unknown }>) {
@@ -2057,46 +2121,60 @@ export class AutomationService {
           }
         }
       }
-      // Q6 gate 3: recorded confirmation = hash over the canonicalized subject
+
+      // Q6 gate 3: recorded confirmation = hash over the canonicalized subject (create omits mode keys)
       const stored = typeof config.confirmationHash === 'string' ? config.confirmationHash : ''
       const expected = deriveFwbConfirmationHash({
         templateId,
         sourceTemplateVersionId: confirmedVersionId,
         targetBaseId,
-        targetSheetId: sheetId,
+        targetSheetId,
         mappings: normalized.mappings,
+        ...(mode === 'update'
+          ? { mode: 'update' as const, recordLinkFieldId }
+          : {}),
       })
       if (stored !== expected) {
         return `${FWB_ACTION_TYPE} actionConfig.confirmationHash must match the server-derived confirmation hash (FWB0 §11 Q6 gate 3)`
       }
+
+      resolvedTargets.push({ targetSheetId, targetBaseId, mode, targetFieldIds: targetIds })
     }
+
     // Q6 gate 1 at save binds the authorization to the actor performing this create/modify/enable,
-    // while the data-plane identity remains the persisted rule creator.
+    // while the data-plane identity remains the persisted rule creator. Checked per resolved target.
     if (!authoringActorId) return `${FWB_ACTION_TYPE} rules require an authenticated authoring actor`
     const authoringAdmin = await rbacIsAdmin(authoringActorId).catch(() => false)
     if (!authoringAdmin) {
-      const resolved = await resolveSheetCapabilitiesForUser(this.queryFn, sheetId, authoringActorId).catch(() => null)
-      if (!resolved || !resolved.capabilities.canManageSheetAccess) {
-        return `${FWB_ACTION_TYPE} rules require the creator, modifier, or enabler to be a platform admin or hold canManageSheetAccess on the target sheet (FWB0 §11 Q6 gate 1)`
+      for (const target of resolvedTargets) {
+        const resolved = await resolveSheetCapabilitiesForUser(this.queryFn, target.targetSheetId, authoringActorId).catch(() => null)
+        if (!resolved || !resolved.capabilities.canManageSheetAccess) {
+          return `${FWB_ACTION_TYPE} rules require the creator, modifier, or enabler to be a platform admin or hold canManageSheetAccess on the target sheet (FWB0 §11 Q6 gate 1)`
+        }
       }
     }
 
-    // Q6 gate 2 and the canonical field-write spine: the persisted creator must still be able to
-    // create a record and write every mapped target field. Hidden, computed, schema-readonly, and
-    // per-subject read-only fields all fail closed through the same helpers used by REST/Yjs writes.
+    // Q6 gate 2 + field-write spine: creator authority is mode-aware (create vs edit) and per target.
     if (!createdBy) return `${FWB_ACTION_TYPE} rules require an authenticated creator`
-    const creatorResolved = await resolveSheetCapabilitiesForUser(this.queryFn, sheetId, createdBy).catch(() => null)
-    if (!creatorResolved?.capabilities.canCreateRecord) {
-      return `${FWB_ACTION_TYPE} rules require the creator to hold target-sheet create-record authority (FWB0 §11 Q6 gate 2)`
-    }
-    const targetFieldsWritable = await canUserWriteFwbTargetFields(
-      this.queryFn,
-      createdBy,
-      sheetId,
-      allTargetFieldIds,
-    ).catch(() => false)
-    if (!targetFieldsWritable) {
-      return `${FWB_ACTION_TYPE} mappings contain one or more target fields that are not writable by the rule creator`
+    for (const target of resolvedTargets) {
+      const creatorResolved = await resolveSheetCapabilitiesForUser(this.queryFn, target.targetSheetId, createdBy).catch(() => null)
+      if (target.mode === 'update') {
+        if (!creatorResolved?.capabilities.canEditRecord) {
+          return `${FWB_ACTION_TYPE} rules require the creator to hold target-sheet edit-record authority (FWB0 §11 Q6 gate 2)`
+        }
+      } else if (!creatorResolved?.capabilities.canCreateRecord) {
+        return `${FWB_ACTION_TYPE} rules require the creator to hold target-sheet create-record authority (FWB0 §11 Q6 gate 2)`
+      }
+      const targetFieldsWritable = await canUserWriteFwbTargetFields(
+        this.queryFn,
+        createdBy,
+        target.targetSheetId,
+        target.targetFieldIds,
+        target.mode,
+      ).catch(() => false)
+      if (!targetFieldsWritable) {
+        return `${FWB_ACTION_TYPE} mappings contain one or more target fields that are not writable by the rule creator`
+      }
     }
     return null
   }

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -1654,7 +1654,10 @@ export function ensureRecordWriteAllowed(
   const rowActions = deriveRecordRowActions(capabilities, scope, access, createdBy)
   const baseAllowed = action === 'edit' ? rowActions.canEdit : rowActions.canDelete
   if (baseAllowed) return true
-  if (recordScopeMap && recordId) {
+  // Record grants are additive only when THIS record has an explicit grant. Passing an empty map (or
+  // a map for other records) must not turn a write-own denial back into sheet-wide edit authority via
+  // deriveRecordPermissions' no-scope fallback.
+  if (recordScopeMap && recordId && recordScopeMap.has(recordId)) {
     const recordPerms = deriveRecordPermissions(recordId, capabilities, recordScopeMap)
     return action === 'edit' ? recordPerms.canEdit : recordPerms.canDelete
   }

--- a/packages/core-backend/src/services/approval-record-link-txn-auth.ts
+++ b/packages/core-backend/src/services/approval-record-link-txn-auth.ts
@@ -688,10 +688,7 @@ export async function resolveSheetCapabilitiesForUserOnQuery(
   precomputed?: { isAdminRole: boolean; permissions: string[] },
 ): Promise<{
   isAdminRole: boolean
-  capabilities: Pick<
-    MultitableCapabilities,
-    'canRead' | 'canEditRecord' | 'canCreateRecord' | 'canManageSheetAccess'
-  >
+  capabilities: MultitableCapabilities
   permissions: string[]
 }> {
   const normalizedUserId = userId.trim()
@@ -736,12 +733,7 @@ export async function resolveSheetCapabilitiesForUserOnQuery(
 
   return {
     isAdminRole,
-    capabilities: {
-      canRead: capabilities.canRead === true,
-      canEditRecord: capabilities.canEditRecord === true,
-      canCreateRecord: capabilities.canCreateRecord === true,
-      canManageSheetAccess: capabilities.canManageSheetAccess === true,
-    },
+    capabilities,
     permissions,
   }
 }

--- a/packages/core-backend/tests/integration/multitable-fwb-update-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-fwb-update-activation-realdb.test.ts
@@ -8,7 +8,7 @@
  *   - same-base update happy path through AutomationExecutor → executeUpdateBoundRecord;
  *   - exact linked-record extraction (malformed → fwb_rejected:linked_record, zero writes);
  *   - cross-base deny (rule creator lacks target base write) / allow;
- *   - locked / deleted / write-revoked fail-closed;
+ *   - locked / deleted / write-revoked fail closed behind one non-oracular error code;
  *   - duplicate net-once under a new eventId;
  *   - rollback atomicity (injected post-handler abort erases claim + update + revision + outbox);
  *   - discriminating mutation target (updates bound record A, never sibling record B).
@@ -741,7 +741,7 @@ describeIfDatabase('FWB-2 production write_approval_form_values mode:update (rea
     }
   })
 
-  test('locked / deleted fail-closed with stable reasons and zero mutation', async () => {
+  test('locked / deleted fail closed behind one non-oracular reason with zero mutation', async () => {
     setFlags(true, true)
     try {
       // Locked: ensureRecordNotLocked lets locker/owner through. Construct a row whose created_by
@@ -766,7 +766,7 @@ describeIfDatabase('FWB-2 production write_approval_form_values mode:update (rea
           triggerPayload(lockedId, `evt_fwb2_lock_${TS}`),
         )
         expect(run.steps[0]?.status).toBe('failed')
-        expect(String(run.steps[0]?.error ?? '')).toBe('fwb_rejected:record_locked')
+        expect(String(run.steps[0]?.error ?? '')).toBe('fwb_rejected:linked_record_unavailable')
         expect(await recordData(lockedRec)).toEqual(before)
         expect(await claimCount(lockedId, ruleId)).toBe(0)
       } finally {
@@ -792,7 +792,7 @@ describeIfDatabase('FWB-2 production write_approval_form_values mode:update (rea
         triggerPayload(delId, `evt_fwb2_del_${TS}`),
       )
       expect(run2.steps[0]?.status).toBe('failed')
-      expect(String(run2.steps[0]?.error ?? '')).toBe('fwb_rejected:record_missing')
+      expect(String(run2.steps[0]?.error ?? '')).toBe('fwb_rejected:linked_record_unavailable')
       expect(await claimCount(delId, ruleId2)).toBe(0)
     } finally {
       setFlags(false, false)
@@ -839,7 +839,7 @@ describeIfDatabase('FWB-2 production write_approval_form_values mode:update (rea
 
       const run = await runPromise
       expect(run.steps[0]?.status).toBe('failed')
-      expect(String(run.steps[0]?.error ?? '')).toBe('fwb_rejected:record_locked')
+      expect(String(run.steps[0]?.error ?? '')).toBe('fwb_rejected:linked_record_unavailable')
       expect(await recordData(raceRecord)).toMatchObject({ [F_TITLE]: 'race-before', [F_AMOUNT]: 0 })
       expect(await claimCount(instanceId, ruleId)).toBe(0)
     } finally {
@@ -1094,7 +1094,7 @@ describeIfDatabase('FWB-2 production write_approval_form_values mode:update (rea
         triggerPayload(foreignInstance, `evt_fwb2_foreign_${TS}`),
       )
       expect(foreignRun.steps[0]?.status).toBe('failed')
-      expect(String(foreignRun.steps[0]?.error ?? '')).toBe('fwb_rejected:record_not_writable')
+      expect(String(foreignRun.steps[0]?.error ?? '')).toBe('fwb_rejected:linked_record_unavailable')
       expect(await recordData(foreignRecord)).toMatchObject({ [F_TITLE]: 'scope-before', [F_AMOUNT]: 0 })
       expect(await claimCount(foreignInstance, ruleId)).toBe(0)
     } finally {

--- a/packages/core-backend/tests/integration/multitable-fwb-update-activation-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-fwb-update-activation-realdb.test.ts
@@ -1,0 +1,1382 @@
+/**
+ * FWB-2 production `write_approval_form_values` mode:'update' wiring (real DB).
+ *
+ * Proves the production dispatch surface (not pure seams alone):
+ *   - save gate: mode contract, recordLinkFieldId, schema-derived target (never client ids),
+ *     confirmation-hash binding (update mode + recordLinkFieldId + derived target; create hashes
+ *     stay byte-compatible), edit authority (not create) on the derived target;
+ *   - same-base update happy path through AutomationExecutor → executeUpdateBoundRecord;
+ *   - exact linked-record extraction (malformed → fwb_rejected:linked_record, zero writes);
+ *   - cross-base deny (rule creator lacks target base write) / allow;
+ *   - locked / deleted / write-revoked fail-closed;
+ *   - duplicate net-once under a new eventId;
+ *   - rollback atomicity (injected post-handler abort erases claim + update + revision + outbox);
+ *   - discriminating mutation target (updates bound record A, never sibling record B).
+ *
+ * Two-point wired (plugin-tests.yml multitable real-DB step + vitest.config.ts exclude).
+ */
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { db } from '../../src/db/db'
+import { eventBus as integrationEventBus } from '../../src/integration/events/event-bus'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+import {
+  AutomationExecutor,
+  type AutomationDeps,
+  type AutomationRule as ExecutorRule,
+} from '../../src/multitable/automation-executor'
+import {
+  buildProductionFwbGateChecks,
+  collectPersistedFwbActions,
+  deriveFwbConfirmationHash,
+} from '../../src/multitable/approval-fwb-activation'
+import { recheckFwbPermissionGates, type FwbGateChecks } from '../../src/multitable/approval-fwb-permission-gates'
+import { resolveSheetCapabilitiesForUser } from '../../src/multitable/sheet-capabilities'
+import { isAdmin as rbacIsAdmin, invalidateUserPerms } from '../../src/rbac/service'
+import { isAdminOnQuery } from '../../src/services/approval-record-link-txn-auth'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = randomUUID().replace(/-/g, '')
+const RULE_BASE = `base_fwb2r_${TS}`
+const RULE_SHEET = `sheet_fwb2r_${TS}`
+const TARGET_BASE = `base_fwb2t_${TS}`
+const TARGET_SHEET = `sheet_fwb2t_${TS}`
+const SECONDARY_SHEET = `sheet_fwb2s_${TS}`
+const CROSS_BASE = `base_fwb2x_${TS}`
+const CROSS_SHEET = `sheet_fwb2x_${TS}`
+const F_TITLE = `fld_fwb2_title_${TS}`
+const F_AMOUNT = `fld_fwb2_amount_${TS}`
+const F_SECONDARY_TITLE = `fld_fwb2s_title_${TS}`
+const F_CROSS_TITLE = `fld_fwb2x_title_${TS}`
+const CREATOR = `u_fwb2_creator_${TS}`
+const REQUESTER = `u_fwb2_req_${TS}`
+const APPROVER = `u_fwb2_appr_${TS}`
+const REC_A = `rec_fwb2_a_${TS}`
+const REC_B = `rec_fwb2_b_${TS}`
+const REC_CROSS = `rec_fwb2_x_${TS}`
+
+const q = (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)
+const queryFn = ((sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params)) as never
+
+let svc: AutomationService
+let approvals: ApprovalProductService
+let templateId = ''
+let templateVersionId = ''
+const ruleIds: string[] = []
+
+const MAPPINGS = [
+  { formFieldId: 'summary', targetFieldId: F_TITLE, targetType: 'text' as const },
+  { formFieldId: 'amount', targetFieldId: F_AMOUNT, targetType: 'number' as const },
+]
+
+function setFlags(fwb: boolean, durable: boolean) {
+  if (fwb) process.env.APPROVAL_FWB_WRITEBACK_ENABLED = 'true'
+  else delete process.env.APPROVAL_FWB_WRITEBACK_ENABLED
+  if (durable) process.env.AUTOMATION_DURABLE_DELIVERY_ENABLED = 'true'
+  else delete process.env.AUTOMATION_DURABLE_DELIVERY_ENABLED
+}
+
+function updateConfirmation(
+  mappings: unknown = MAPPINGS,
+  sourceVersionId = templateVersionId,
+  targetBaseId = TARGET_BASE,
+  targetSheetId = TARGET_SHEET,
+  recordLinkFieldId = 'linked',
+) {
+  return deriveFwbConfirmationHash({
+    templateId,
+    sourceTemplateVersionId: sourceVersionId,
+    targetBaseId,
+    targetSheetId,
+    mappings: mappings as never,
+    mode: 'update',
+    recordLinkFieldId,
+  })
+}
+
+function updateConfig(
+  over: {
+    mappings?: unknown
+    sourceVersionId?: string
+    targetBaseId?: string
+    targetSheetId?: string
+    recordLinkFieldId?: string
+    confirmationHash?: string
+    mode?: unknown
+  } = {},
+) {
+  const mappings = over.mappings ?? MAPPINGS
+  const sourceVersionId = over.sourceVersionId ?? templateVersionId
+  const recordLinkFieldId = over.recordLinkFieldId ?? 'linked'
+  const targetBaseId = over.targetBaseId ?? TARGET_BASE
+  const targetSheetId = over.targetSheetId ?? TARGET_SHEET
+  return {
+    mode: over.mode === undefined ? 'update' : over.mode,
+    recordLinkFieldId,
+    mappings,
+    sourceTemplateVersionId: sourceVersionId,
+    confirmationHash: over.confirmationHash ?? updateConfirmation(
+      mappings,
+      sourceVersionId,
+      targetBaseId,
+      targetSheetId,
+      recordLinkFieldId,
+    ),
+  }
+}
+
+function approvalTemplateRequest(linkBaseId: string, linkSheetId: string) {
+  return {
+    key: `fwb2-${TS}`,
+    name: 'FWB-2 Update Template',
+    formSchema: {
+      fields: [
+        { id: 'summary', type: 'text', label: 'Summary', required: true },
+        { id: 'amount', type: 'number', label: 'Amount', required: true },
+        {
+          id: 'linked',
+          type: 'record-link',
+          label: 'Bound record',
+          required: true,
+          props: { baseId: linkBaseId, sheetId: linkSheetId },
+        },
+        {
+          id: 'linked_secondary',
+          type: 'record-link',
+          label: 'Secondary bound record',
+          required: false,
+          props: { baseId: TARGET_BASE, sheetId: SECONDARY_SHEET },
+        },
+      ],
+    },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: 'Start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          name: 'Approver',
+          config: { mode: 'any', assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }] },
+        },
+        { key: 'end', type: 'end', name: 'End', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+  }
+}
+
+async function startInstance(formData: Record<string, unknown>): Promise<string> {
+  const dto = await approvals.createApproval(
+    { templateId, formData },
+    { userId: REQUESTER, userName: REQUESTER },
+  )
+  return (dto as { id: string }).id
+}
+
+async function approveInstance(instanceId: string): Promise<void> {
+  await approvals.dispatchAction(
+    instanceId,
+    { action: 'approve', comment: 'ok' } as never,
+    { userId: APPROVER, userName: APPROVER },
+  )
+}
+
+function completionEvent(instanceId: string, eventId: string) {
+  return {
+    version: 1,
+    source: 'approval-product',
+    eventType: 'approval.approved',
+    eventId,
+    occurredAt: new Date().toISOString(),
+    approval: { instanceId, templateId, templateVersionId, status: 'approved' },
+    transition: {
+      action: 'approve',
+      fromStatus: 'pending',
+      toStatus: 'approved',
+      fromVersion: 1,
+      toVersion: 2,
+      nodeKey: 'approval_1',
+    },
+    requester: { id: REQUESTER, name: REQUESTER },
+    actor: null,
+  } as never
+}
+
+function executorRule(ruleId: string, actionConfig: Record<string, unknown>): ExecutorRule {
+  return {
+    id: ruleId,
+    name: 'fwb2 update rule',
+    sheetId: RULE_SHEET,
+    trigger: { type: 'approval.completed', config: { templateId } } as never,
+    actions: [{ type: 'write_approval_form_values', config: actionConfig }] as never,
+    enabled: true,
+    createdBy: CREATOR,
+    createdAt: new Date().toISOString(),
+  }
+}
+
+function triggerPayload(instanceId: string, eventId: string): Record<string, unknown> {
+  return {
+    sheetId: RULE_SHEET,
+    recordId: '',
+    data: {},
+    actorId: null,
+    _automationDepth: 0,
+    eventId,
+    eventType: 'approval.approved',
+    approval: { instanceId, templateId, templateVersionId },
+    transition: { action: 'approve', fromStatus: 'pending', toStatus: 'approved' },
+    requester: { id: REQUESTER, name: REQUESTER },
+  }
+}
+
+const allowAllGates: FwbGateChecks = {
+  isAdmin: async () => true,
+  canManageSheetAccess: async () => true,
+  canReadTemplate: async () => true,
+  canWriteSheet: async () => true,
+  canWriteTargetFields: async () => true,
+  hasRecordedConfirmation: async () => true,
+}
+
+const productionGateFactory: NonNullable<AutomationDeps['fwbGateChecksFactory']> = (transactionQuery) =>
+  buildProductionFwbGateChecks({
+    queryFn: transactionQuery,
+    isAdminFn: (userId) => isAdminOnQuery(transactionQuery, userId),
+    // Source-template visibility is independently covered by the approval.completed trigger suite;
+    // this file keeps that leg true while exercising transaction-bound target/field/action authority.
+    canReadTemplateFn: async () => true,
+  })
+
+const realTransaction: NonNullable<AutomationDeps['transaction']> = async (handler) =>
+  poolManager.get().transaction(async ({ query }) => handler({
+    query: async (sqlText: string, params?: unknown[]) => {
+      const result = await query(sqlText, params)
+      return {
+        rows: Array.isArray((result as { rows?: unknown[] }).rows) ? (result as { rows: unknown[] }).rows : [],
+        rowCount: typeof (result as { rowCount?: number }).rowCount === 'number'
+          ? (result as { rowCount: number }).rowCount
+          : undefined,
+      }
+    },
+  }))
+
+function buildExecutor(overrides: Partial<AutomationDeps> = {}) {
+  const deps: AutomationDeps = {
+    eventBus: { emit: () => {}, subscribe: () => () => {} } as never,
+    queryFn: (sqlText: string, params?: unknown[]) => poolManager.get().query(sqlText, params) as never,
+    transaction: overrides.transaction ?? realTransaction,
+    fwbGateChecks: overrides.fwbGateChecks ?? allowAllGates,
+    ...overrides,
+  }
+  return new AutomationExecutor(deps)
+}
+
+async function claimCount(instanceId: string, ruleId: string): Promise<number> {
+  const r = await q(
+    'SELECT COUNT(*)::int AS c FROM meta_fwb_action_applied WHERE instance_id = $1 AND rule_id = $2',
+    [instanceId, ruleId],
+  )
+  return Number((r.rows[0] as { c: number }).c)
+}
+
+async function outboxCountLike(prefix: string): Promise<number> {
+  const r = await q('SELECT COUNT(*)::int AS c FROM meta_automation_outbox WHERE event_id LIKE $1', [`${prefix}%`])
+  return Number((r.rows[0] as { c: number }).c)
+}
+
+async function revisionCount(recordId: string, action = 'update'): Promise<number> {
+  const r = await q(
+    'SELECT COUNT(*)::int AS c FROM meta_record_revisions WHERE record_id = $1 AND action = $2 AND source = $3',
+    [recordId, action, 'automation'],
+  )
+  return Number((r.rows[0] as { c: number }).c)
+}
+
+async function recordData(recordId: string): Promise<Record<string, unknown> | null> {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1', [recordId])
+  const row = r.rows[0] as { data?: unknown } | undefined
+  if (!row) return null
+  return (typeof row.data === 'string' ? JSON.parse(row.data) : row.data) as Record<string, unknown>
+}
+
+async function waitForRecordLockWaiter(holderPid: number): Promise<void> {
+  for (let attempt = 0; attempt < 80; attempt++) {
+    const result = await q(
+      `SELECT COUNT(*)::int AS c
+         FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND wait_event_type = 'Lock'
+          AND query ILIKE '%SELECT id FROM meta_records%FOR UPDATE%'
+          AND $1 = ANY(pg_blocking_pids(pid))`,
+      [holderPid],
+    )
+    if (Number((result.rows[0] as { c?: unknown } | undefined)?.c ?? 0) > 0) return
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error('FWB-2 executor never blocked on its SELECT ... FOR UPDATE behind the test holder')
+}
+
+async function waitForAuthorityLockWaiter(holderPid: number): Promise<void> {
+  for (let attempt = 0; attempt < 80; attempt++) {
+    const result = await q(
+      `SELECT COUNT(*)::int AS c
+         FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND wait_event_type = 'Lock'
+          AND query ILIKE '%SELECT permission_code FROM user_permissions%FOR SHARE%'
+          AND $1 = ANY(pg_blocking_pids(pid))`,
+      [holderPid],
+    )
+    if (Number((result.rows[0] as { c?: unknown } | undefined)?.c ?? 0) > 0) return
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error('FWB-2 executor never blocked on the transaction-bound authority lock')
+}
+
+async function waitForFieldPermissionTableLockWaiter(holderPid: number): Promise<void> {
+  for (let attempt = 0; attempt < 80; attempt++) {
+    const result = await q(
+      `SELECT COUNT(*)::int AS c
+         FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND wait_event_type = 'Lock'
+          AND query ILIKE '%LOCK TABLE field_permissions IN SHARE MODE%'
+          AND $1 = ANY(pg_blocking_pids(pid))`,
+      [holderPid],
+    )
+    if (Number((result.rows[0] as { c?: unknown } | undefined)?.c ?? 0) > 0) return
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error('FWB-2 executor never blocked behind the field-permission phantom writer')
+}
+
+describeIfDatabase('FWB-2 production write_approval_form_values mode:update (real DB)', () => {
+  beforeAll(async () => {
+    setFlags(false, false)
+    // REQUESTER owns target bases so record-link submit base-read passes (owner path) without a
+    // multitable:base:read seed that full migrations may not provide.
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [RULE_BASE, 'FWB2 Rule Base', REQUESTER])
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [TARGET_BASE, 'FWB2 Target Base', REQUESTER])
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [CROSS_BASE, 'FWB2 Cross Base', REQUESTER])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [RULE_SHEET, RULE_BASE, 'FWB2 Rule Sheet'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [TARGET_SHEET, TARGET_BASE, 'FWB2 Target Sheet'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SECONDARY_SHEET, TARGET_BASE, 'FWB2 Secondary Sheet'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [CROSS_SHEET, CROSS_BASE, 'FWB2 Cross Sheet'])
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_TITLE, TARGET_SHEET, 'Title', 'text', '{}', 1],
+    )
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_AMOUNT, TARGET_SHEET, 'Amount', 'number', '{}', 2],
+    )
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_SECONDARY_TITLE, SECONDARY_SHEET, 'Secondary Title', 'text', '{}', 1],
+    )
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_CROSS_TITLE, CROSS_SHEET, 'Title', 'text', '{}', 1],
+    )
+    // Discriminating targets: A is bound by the form; B must never be mutated.
+    await q(
+      `INSERT INTO meta_records (id, sheet_id, data, version, created_by)
+       VALUES ($1,$2,$3::jsonb,1,$4), ($5,$2,$6::jsonb,1,$4)`,
+      [
+        REC_A, TARGET_SHEET, JSON.stringify({ [F_TITLE]: 'before-A', [F_AMOUNT]: 1 }), CREATOR,
+        REC_B, JSON.stringify({ [F_TITLE]: 'before-B', [F_AMOUNT]: 99 }),
+      ],
+    )
+    await q(
+      `INSERT INTO meta_records (id, sheet_id, data, version, created_by)
+       VALUES ($1,$2,$3::jsonb,1,$4)`,
+      [REC_CROSS, CROSS_SHEET, JSON.stringify({ [F_CROSS_TITLE]: 'cross-before' }), CREATOR],
+    )
+
+    await q(
+      `INSERT INTO permissions (code, name, description)
+       VALUES ('approvals:read', 'Approvals Read', 'FWB2'),
+              ('approvals:write', 'Approvals Write', 'FWB2'),
+              ('approvals:act', 'Approvals Act', 'FWB2'),
+              ('multitable:write', 'Multitable Write', 'FWB2'),
+              ('multitable:read', 'Multitable Read', 'FWB2'),
+              ('multitable:share', 'Multitable Share', 'FWB2'),
+              ('multitable:base:read', 'Multitable Base Read', 'FWB2')
+       ON CONFLICT (code) DO NOTHING`,
+    )
+    for (const uid of [CREATOR, REQUESTER, APPROVER]) {
+      await q(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+         VALUES ($1, $2, $1, 'x', 'user', '[]'::jsonb, TRUE, $3)
+         ON CONFLICT (id) DO UPDATE SET is_active = TRUE, is_admin = EXCLUDED.is_admin`,
+        [uid, `${uid}@fwb2.test`, false],
+      )
+    }
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:read') ON CONFLICT DO NOTHING`, [CREATOR])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'multitable:write') ON CONFLICT DO NOTHING`, [CREATOR])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'multitable:read') ON CONFLICT DO NOTHING`, [CREATOR])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'multitable:share') ON CONFLICT DO NOTHING`, [CREATOR])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'multitable:base:read') ON CONFLICT DO NOTHING`, [CREATOR])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:write') ON CONFLICT DO NOTHING`, [REQUESTER])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:read') ON CONFLICT DO NOTHING`, [REQUESTER])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'multitable:read') ON CONFLICT DO NOTHING`, [REQUESTER])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approvals:act') ON CONFLICT DO NOTHING`, [APPROVER])
+    // Sheet-scoped read for the filler on every record-link target (belt-and-suspenders with multitable:read).
+    for (const sheet of [TARGET_SHEET, CROSS_SHEET]) {
+      try {
+        await q(
+          `INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code)
+           VALUES ($1, 'user', $2, 'spreadsheet:read')`,
+          [sheet, REQUESTER],
+        )
+      } catch {
+        await q(
+          `INSERT INTO spreadsheet_permissions (sheet_id, user_id, subject_type, subject_id, perm_code)
+           VALUES ($1, $2, 'user', $2, 'spreadsheet:read')`,
+          [sheet, REQUESTER],
+        )
+      }
+    }
+    invalidateUserPerms(CREATOR)
+    invalidateUserPerms(REQUESTER)
+
+    approvals = new ApprovalProductService()
+    // Same-base-of-truth for the default template: record-link pins TARGET_SHEET (may differ from rule sheet).
+    // TARGET_BASE may equal RULE_BASE for same-base legs — here they differ so cross-base is testable,
+    // but same-base path is exercised by evaluating gate when bases match. For same-base update we
+    // keep TARGET on its base and place the rule sheet on the same base for the happy path.
+    // Re-home rule sheet onto TARGET_BASE so same-base update is the primary happy path.
+    await q('UPDATE meta_sheets SET base_id = $1 WHERE id = $2', [TARGET_BASE, RULE_SHEET])
+
+    const template = await approvals.createTemplate(
+      approvalTemplateRequest(TARGET_BASE, TARGET_SHEET) as never,
+    )
+    templateId = (template as { id: string }).id
+    await approvals.publishTemplate(templateId, {
+      policy: { allowRevoke: true },
+      actorUserId: CREATOR,
+    } as never)
+    const activeVersion = await q('SELECT active_version_id FROM approval_templates WHERE id = $1', [templateId])
+    templateVersionId = String((activeVersion.rows[0] as { active_version_id: string }).active_version_id)
+
+    svc = new AutomationService(integrationEventBus, db as never, queryFn)
+  })
+
+  afterAll(async () => {
+    setFlags(false, false)
+    try { svc?.shutdown() } catch { /* noop */ }
+    for (const ruleId of ruleIds) {
+      await q('DELETE FROM automation_rules WHERE id = $1', [ruleId]).catch(() => {})
+      await q('DELETE FROM multitable_automation_executions WHERE rule_id = $1', [ruleId]).catch(() => {})
+      await q('DELETE FROM meta_fwb_action_applied WHERE rule_id = $1', [ruleId]).catch(() => {})
+    }
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = ANY($1::text[])', [[TARGET_SHEET, SECONDARY_SHEET, CROSS_SHEET, RULE_SHEET]]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[TARGET_SHEET, SECONDARY_SHEET, CROSS_SHEET, RULE_SHEET]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[TARGET_SHEET, SECONDARY_SHEET, CROSS_SHEET, RULE_SHEET]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[TARGET_SHEET, SECONDARY_SHEET, CROSS_SHEET, RULE_SHEET]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[RULE_BASE, TARGET_BASE, CROSS_BASE]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('save gate: unknown mode / missing recordLinkFieldId / client target ids ignored / hash binding', async () => {
+    const base = {
+      name: 'fwb2 update rule',
+      triggerType: 'approval.completed',
+      triggerConfig: { templateId, outcomes: ['approved'] },
+      actionType: 'write_approval_form_values',
+      createdBy: CREATOR,
+    }
+    await expect(svc.createRule(RULE_SHEET, {
+      ...base,
+      actionConfig: updateConfig({ mode: 'patch' }),
+    } as never)).rejects.toThrow(/unknown_mode/)
+
+    await expect(svc.createRule(RULE_SHEET, {
+      ...base,
+      actionConfig: {
+        mode: 'update',
+        mappings: MAPPINGS,
+        sourceTemplateVersionId: templateVersionId,
+        confirmationHash: 'deadbeef',
+      },
+    } as never)).rejects.toThrow(/record_link_field/)
+
+    // Client-supplied target base/sheet must NOT be trusted: hash is derived from schema pin only.
+    // A wrong hash that assumes client override is rejected.
+    await expect(svc.createRule(RULE_SHEET, {
+      ...base,
+      actionConfig: updateConfig({
+        confirmationHash: deriveFwbConfirmationHash({
+          templateId,
+          sourceTemplateVersionId: templateVersionId,
+          targetBaseId: 'client-smuggled-base',
+          targetSheetId: 'client-smuggled-sheet',
+          mappings: MAPPINGS,
+          mode: 'update',
+          recordLinkFieldId: 'linked',
+        }),
+      }),
+    } as never)).rejects.toThrow(/confirmationHash must match/)
+
+    // Create-mode hash (no mode keys) must not satisfy an update config.
+    await expect(svc.createRule(RULE_SHEET, {
+      ...base,
+      actionConfig: updateConfig({
+        confirmationHash: deriveFwbConfirmationHash({
+          templateId,
+          sourceTemplateVersionId: templateVersionId,
+          targetBaseId: TARGET_BASE,
+          targetSheetId: TARGET_SHEET,
+          mappings: MAPPINGS,
+        }),
+      }),
+    } as never)).rejects.toThrow(/confirmationHash must match/)
+
+    const rule = await svc.createRule(RULE_SHEET, {
+      ...base,
+      actionConfig: updateConfig(),
+    } as never)
+    ruleIds.push((rule as { id: string }).id)
+    expect((rule as { id: string }).id).toBeTruthy()
+  })
+
+  test('same-base update: maps form values onto bound record A; sibling B untouched; revision + claim + outbox', async () => {
+    setFlags(true, true)
+    try {
+      const instanceId = await startInstance({
+        summary: 'updated-A',
+        amount: 42,
+        linked: { recordId: REC_A },
+      })
+      await approveInstance(instanceId)
+      const config = updateConfig() as Record<string, unknown>
+      const saved = await svc.createRule(RULE_SHEET, {
+        name: 'fwb2 production-gate happy path',
+        triggerType: 'approval.completed',
+        triggerConfig: { templateId, outcomes: ['approved'] },
+        actionType: 'write_approval_form_values',
+        actionConfig: config,
+        createdBy: CREATOR,
+      } as never)
+      const ruleId = (saved as { id: string }).id
+      ruleIds.push(ruleId)
+      expect(await rbacIsAdmin(CREATOR)).toBe(false)
+      const executor = buildExecutor({
+        fwbGateChecks: undefined,
+        fwbGateChecksFactory: productionGateFactory,
+      })
+      const evt = `evt_fwb2_same_${TS}`
+      const run = await executor.execute(
+        executorRule(ruleId, config),
+        triggerPayload(instanceId, evt),
+      )
+      expect(run.steps[0]?.status).toBe('success')
+      expect(await recordData(REC_A)).toMatchObject({ [F_TITLE]: 'updated-A', [F_AMOUNT]: 42 })
+      expect(await recordData(REC_B)).toMatchObject({ [F_TITLE]: 'before-B', [F_AMOUNT]: 99 })
+      expect(await claimCount(instanceId, ruleId)).toBe(1)
+      expect(await revisionCount(REC_A)).toBe(1)
+      expect(await outboxCountLike(`${evt}::fwb::`)).toBe(1)
+    } finally {
+      setFlags(false, false)
+    }
+  })
+
+  test('action-scoped gates: a stale sibling update on another sheet cannot block the current action', async () => {
+    const secondaryMappings = [
+      { formFieldId: 'summary', targetFieldId: F_SECONDARY_TITLE, targetType: 'text' as const },
+    ]
+    const primaryConfig = updateConfig() as Record<string, unknown>
+    const secondaryConfig = {
+      mode: 'update',
+      recordLinkFieldId: 'linked_secondary',
+      mappings: secondaryMappings,
+      sourceTemplateVersionId: templateVersionId,
+      confirmationHash: deriveFwbConfirmationHash({
+        templateId,
+        sourceTemplateVersionId: templateVersionId,
+        targetBaseId: TARGET_BASE,
+        targetSheetId: SECONDARY_SHEET,
+        mappings: secondaryMappings,
+        mode: 'update',
+        recordLinkFieldId: 'linked_secondary',
+      }),
+    }
+    const saved = await svc.createRule(RULE_SHEET, {
+      name: 'fwb2 action-scoped gates',
+      triggerType: 'approval.completed',
+      triggerConfig: { templateId, outcomes: ['approved'] },
+      actionType: 'write_approval_form_values',
+      actionConfig: primaryConfig,
+      actions: [
+        { type: 'write_approval_form_values', config: primaryConfig },
+        { type: 'write_approval_form_values', config: secondaryConfig },
+      ],
+      createdBy: CREATOR,
+    } as never)
+    const ruleId = (saved as { id: string }).id
+    ruleIds.push(ruleId)
+    const identities = collectPersistedFwbActions(
+      'write_approval_form_values',
+      primaryConfig,
+      [
+        { type: 'write_approval_form_values', config: primaryConfig },
+        { type: 'write_approval_form_values', config: secondaryConfig },
+      ],
+    )
+    expect(identities).toHaveLength(2)
+
+    const brokenSecondary = { ...secondaryConfig, confirmationHash: 'stale-sibling-confirmation' }
+    await q(
+      'UPDATE automation_rules SET actions = $1::jsonb WHERE id = $2',
+      [JSON.stringify([
+        { type: 'write_approval_form_values', config: primaryConfig },
+        { type: 'write_approval_form_values', config: brokenSecondary },
+      ]), ruleId],
+    )
+    const productionGates = buildProductionFwbGateChecks({
+      queryFn,
+      isAdminFn: (userId) => rbacIsAdmin(userId),
+      canReadTemplateFn: async () => true,
+    })
+    const primary = await recheckFwbPermissionGates(productionGates, {
+      configurerUserId: CREATOR,
+      ruleId,
+      actionKey: identities[0].actionKey,
+      sourceTemplateId: templateId,
+      targetSheetId: TARGET_SHEET,
+      mode: 'update',
+    })
+    expect(primary).toEqual({ ok: true })
+
+    const secondary = await recheckFwbPermissionGates(productionGates, {
+      configurerUserId: CREATOR,
+      ruleId,
+      actionKey: identities[1].actionKey,
+      sourceTemplateId: templateId,
+      targetSheetId: SECONDARY_SHEET,
+      mode: 'update',
+    })
+    expect(secondary).toEqual({ ok: false, failed: ['target_fields_writable', 'confirmation_recorded'] })
+
+    const secondaryRecord = `rec_fwb2_secondary_${TS}`
+    setFlags(true, true)
+    try {
+      await q(
+        `INSERT INTO meta_records (id, sheet_id, data, version, created_by)
+         VALUES ($1,$2,$3::jsonb,1,$4)`,
+        [secondaryRecord, SECONDARY_SHEET, JSON.stringify({ [F_SECONDARY_TITLE]: 'secondary-before' }), CREATOR],
+      )
+      await q(
+        `UPDATE meta_records SET data = $1::jsonb, version = 1 WHERE id = $2`,
+        [JSON.stringify({ [F_TITLE]: 'primary-before', [F_AMOUNT]: 0 }), REC_A],
+      )
+      const instanceId = await startInstance({
+        summary: 'primary-applied',
+        amount: 73,
+        linked: { recordId: REC_A },
+        linked_secondary: { recordId: secondaryRecord },
+      })
+      await approveInstance(instanceId)
+      const eventId = `evt_fwb2_actions_${TS}`
+      const run = await buildExecutor({ fwbGateChecksFactory: productionGateFactory }).execute(
+        {
+          ...executorRule(ruleId, primaryConfig),
+          actions: [
+            { type: 'write_approval_form_values', config: primaryConfig },
+            { type: 'write_approval_form_values', config: brokenSecondary },
+          ] as never,
+        },
+        triggerPayload(instanceId, eventId),
+      )
+      expect(run.steps.map((step) => step.status)).toEqual(['success', 'failed'])
+      expect(String(run.steps[1]?.error ?? '')).toContain('confirmation_recorded')
+      expect(await recordData(REC_A)).toMatchObject({ [F_TITLE]: 'primary-applied', [F_AMOUNT]: 73 })
+      expect(await recordData(secondaryRecord)).toMatchObject({ [F_SECONDARY_TITLE]: 'secondary-before' })
+      expect(await claimCount(instanceId, ruleId)).toBe(1)
+      expect(await outboxCountLike(`${eventId}::fwb::`)).toBe(1)
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [secondaryRecord]).catch(() => {})
+      setFlags(false, false)
+    }
+  })
+
+  test('exact linked-record extraction: malformed value → fwb_rejected:linked_record, zero writes', async () => {
+    setFlags(true, true)
+    try {
+      // Bypass form validation by writing a malicious snapshot shape directly (executor contract).
+      const instanceId = await startInstance({
+        summary: 'bad-link',
+        amount: 1,
+        linked: { recordId: REC_A },
+      })
+      await approveInstance(instanceId)
+      await q(
+        `UPDATE approval_instances SET form_snapshot = $1::jsonb WHERE id = $2`,
+        [JSON.stringify({ summary: 'bad-link', amount: 1, linked: { recordId: REC_A, sheetId: 'smuggle' } }), instanceId],
+      )
+      const beforeA = await recordData(REC_A)
+      const ruleId = `rule_fwb2_link_${TS}`
+      const run = await buildExecutor({}).execute(
+        executorRule(ruleId, updateConfig() as Record<string, unknown>),
+        triggerPayload(instanceId, `evt_fwb2_link_${TS}`),
+      )
+      expect(run.steps[0]?.status).toBe('failed')
+      expect(String(run.steps[0]?.error ?? '')).toBe('fwb_rejected:linked_record')
+      expect(await recordData(REC_A)).toEqual(beforeA)
+      expect(await claimCount(instanceId, ruleId)).toBe(0)
+    } finally {
+      setFlags(false, false)
+    }
+  })
+
+  test('locked / deleted fail-closed with stable reasons and zero mutation', async () => {
+    setFlags(true, true)
+    try {
+      // Locked: ensureRecordNotLocked lets locker/owner through. Construct a row whose created_by
+      // is NOT the rule creator and locked_by is a third party so the configurer is hard-denied.
+      const lockedRec = `rec_fwb2_locked_${TS}`
+      await q(
+        `INSERT INTO meta_records (id, sheet_id, data, version, created_by, locked, locked_by)
+         VALUES ($1,$2,$3::jsonb,1,$4,TRUE,$5)`,
+        [lockedRec, TARGET_SHEET, JSON.stringify({ [F_TITLE]: 'locked-before', [F_AMOUNT]: 0 }), 'other_owner', 'other_locker'],
+      )
+      try {
+        const lockedId = await startInstance({
+          summary: 'locked',
+          amount: 2,
+          linked: { recordId: lockedRec },
+        })
+        await approveInstance(lockedId)
+        const ruleId = `rule_fwb2_lock_${TS}`
+        const before = await recordData(lockedRec)
+        const run = await buildExecutor({}).execute(
+          executorRule(ruleId, updateConfig() as Record<string, unknown>),
+          triggerPayload(lockedId, `evt_fwb2_lock_${TS}`),
+        )
+        expect(run.steps[0]?.status).toBe('failed')
+        expect(String(run.steps[0]?.error ?? '')).toBe('fwb_rejected:record_locked')
+        expect(await recordData(lockedRec)).toEqual(before)
+        expect(await claimCount(lockedId, ruleId)).toBe(0)
+      } finally {
+        await q('DELETE FROM meta_records WHERE id = $1', [lockedRec]).catch(() => {})
+      }
+
+      // Deleted
+      const ghostRec = `rec_fwb2_gone_${TS}`
+      await q(
+        `INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)`,
+        [ghostRec, TARGET_SHEET, JSON.stringify({ [F_TITLE]: 'ghost' }), CREATOR],
+      )
+      const delId = await startInstance({
+        summary: 'deleted',
+        amount: 3,
+        linked: { recordId: ghostRec },
+      })
+      await approveInstance(delId)
+      await q('DELETE FROM meta_records WHERE id = $1', [ghostRec])
+      const ruleId2 = `rule_fwb2_del_${TS}`
+      const run2 = await buildExecutor({}).execute(
+        executorRule(ruleId2, updateConfig() as Record<string, unknown>),
+        triggerPayload(delId, `evt_fwb2_del_${TS}`),
+      )
+      expect(run2.steps[0]?.status).toBe('failed')
+      expect(String(run2.steps[0]?.error ?? '')).toBe('fwb_rejected:record_missing')
+      expect(await claimCount(delId, ruleId2)).toBe(0)
+    } finally {
+      setFlags(false, false)
+    }
+  })
+
+  test('TOCTOU: a lock applied while FWB waits on the record row is observed before any write', async () => {
+    setFlags(true, true)
+    const raceRecord = `rec_fwb2_race_${TS}`
+    const holder = await poolManager.get().getInternalPool().connect()
+    let runPromise: ReturnType<AutomationExecutor['execute']> | undefined
+    let holderOpen = false
+    try {
+      await q(
+        `INSERT INTO meta_records (id, sheet_id, data, version, created_by, locked)
+         VALUES ($1,$2,$3::jsonb,1,$4,FALSE)`,
+        [raceRecord, TARGET_SHEET, JSON.stringify({ [F_TITLE]: 'race-before', [F_AMOUNT]: 0 }), 'other_owner'],
+      )
+      const instanceId = await startInstance({
+        summary: 'must-not-write',
+        amount: 88,
+        linked: { recordId: raceRecord },
+      })
+      await approveInstance(instanceId)
+      const ruleId = `rule_fwb2_race_${TS}`
+
+      await holder.query('BEGIN')
+      holderOpen = true
+      const pidResult = await holder.query('SELECT pg_backend_pid() AS pid')
+      const holderPid = Number((pidResult.rows[0] as { pid: number }).pid)
+      await holder.query('SELECT id FROM meta_records WHERE id = $1 FOR UPDATE', [raceRecord])
+
+      runPromise = buildExecutor({}).execute(
+        executorRule(ruleId, updateConfig() as Record<string, unknown>),
+        triggerPayload(instanceId, `evt_fwb2_race_${TS}`),
+      )
+      await waitForRecordLockWaiter(holderPid)
+      await holder.query(
+        'UPDATE meta_records SET locked = TRUE, locked_by = $1 WHERE id = $2',
+        ['other_locker', raceRecord],
+      )
+      await holder.query('COMMIT')
+      holderOpen = false
+
+      const run = await runPromise
+      expect(run.steps[0]?.status).toBe('failed')
+      expect(String(run.steps[0]?.error ?? '')).toBe('fwb_rejected:record_locked')
+      expect(await recordData(raceRecord)).toMatchObject({ [F_TITLE]: 'race-before', [F_AMOUNT]: 0 })
+      expect(await claimCount(instanceId, ruleId)).toBe(0)
+    } finally {
+      if (holderOpen) await holder.query('ROLLBACK').catch(() => {})
+      holder.release()
+      if (runPromise) await runPromise.catch(() => {})
+      await q('DELETE FROM meta_records WHERE id = $1', [raceRecord]).catch(() => {})
+      setFlags(false, false)
+    }
+  })
+
+  test('TOCTOU: revoke wins before the authority lock; executor blocks, re-reads denial, and writes nothing', async () => {
+    setFlags(true, true)
+    const revoker = await poolManager.get().getInternalPool().connect()
+    let revokerOpen = false
+    let runPromise: ReturnType<AutomationExecutor['execute']> | undefined
+    try {
+      const config = updateConfig() as Record<string, unknown>
+      const saved = await svc.createRule(RULE_SHEET, {
+        name: 'fwb2 authority-revoke race',
+        triggerType: 'approval.completed',
+        triggerConfig: { templateId, outcomes: ['approved'] },
+        actionType: 'write_approval_form_values',
+        actionConfig: config,
+        createdBy: CREATOR,
+      } as never)
+      const ruleId = (saved as { id: string }).id
+      ruleIds.push(ruleId)
+      const instanceId = await startInstance({
+        summary: 'must-not-write-after-revoke',
+        amount: 91,
+        linked: { recordId: REC_A },
+      })
+      await approveInstance(instanceId)
+      const before = await recordData(REC_A)
+
+      await revoker.query('BEGIN')
+      revokerOpen = true
+      const pidResult = await revoker.query('SELECT pg_backend_pid() AS pid')
+      const revokerPid = Number((pidResult.rows[0] as { pid: number }).pid)
+      const deleted = await revoker.query(
+        `DELETE FROM user_permissions
+          WHERE user_id = $1 AND permission_code = 'multitable:write'
+          RETURNING permission_code`,
+        [CREATOR],
+      )
+      expect(deleted.rowCount).toBe(1)
+
+      runPromise = buildExecutor({ fwbGateChecksFactory: productionGateFactory }).execute(
+        executorRule(ruleId, config),
+        triggerPayload(instanceId, `evt_fwb2_revoke_${TS}`),
+      )
+      await waitForAuthorityLockWaiter(revokerPid)
+      await revoker.query('COMMIT')
+      revokerOpen = false
+      invalidateUserPerms(CREATOR)
+
+      const run = await runPromise
+      expect(run.steps[0]?.status).toBe('failed')
+      expect(String(run.steps[0]?.error ?? '')).toMatch(/fwb_rejected:permission_gates/)
+      expect(await recordData(REC_A)).toEqual(before)
+      expect(await claimCount(instanceId, ruleId)).toBe(0)
+    } finally {
+      if (revokerOpen) await revoker.query('ROLLBACK').catch(() => {})
+      revoker.release()
+      if (runPromise) await runPromise.catch(() => {})
+      await q(
+        `INSERT INTO user_permissions (user_id, permission_code)
+         VALUES ($1, 'multitable:write') ON CONFLICT DO NOTHING`,
+        [CREATOR],
+      ).catch(() => {})
+      invalidateUserPerms(CREATOR)
+      setFlags(false, false)
+    }
+  })
+
+  test('write-revoked (field read-only after save) → permission_gates, zero writes', async () => {
+    setFlags(true, true)
+    try {
+      // Save the rule while fields are still writable, THEN revoke field write before execute.
+      const saved = await svc.createRule(RULE_SHEET, {
+        name: 'fwb2 revoked field',
+        triggerType: 'approval.completed',
+        triggerConfig: { templateId, outcomes: ['approved'] },
+        actionType: 'write_approval_form_values',
+        actionConfig: updateConfig(),
+        createdBy: CREATOR,
+      } as never)
+      const ruleId = (saved as { id: string }).id
+      ruleIds.push(ruleId)
+
+      const instanceId = await startInstance({
+        summary: 'revoked-field',
+        amount: 5,
+        linked: { recordId: REC_A },
+      })
+      await approveInstance(instanceId)
+      const before = await recordData(REC_A)
+      await q(
+        `INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only)
+         VALUES ($1,$2,'user',$3,true,true)`,
+        [TARGET_SHEET, F_AMOUNT, CREATOR],
+      )
+      try {
+        // Production §11 Q6 gates (field writability is real).
+        const executor = buildExecutor({ fwbGateChecksFactory: productionGateFactory })
+        const run = await executor.execute(
+          executorRule(ruleId, updateConfig() as Record<string, unknown>),
+          triggerPayload(instanceId, `evt_fwb2_field_${TS}`),
+        )
+        expect(run.steps[0]?.status).toBe('failed')
+        expect(String(run.steps[0]?.error ?? '')).toMatch(/fwb_rejected:permission_gates/)
+        expect(await recordData(REC_A)).toEqual(before)
+        expect(await claimCount(instanceId, ruleId)).toBe(0)
+      } finally {
+        await q(
+          `DELETE FROM field_permissions
+            WHERE sheet_id = $1 AND field_id = $2 AND subject_type = 'user' AND subject_id = $3`,
+          [TARGET_SHEET, F_AMOUNT, CREATOR],
+        )
+      }
+    } finally {
+      setFlags(false, false)
+    }
+  })
+
+  test('TOCTOU: concurrent field read-only INSERT wins; table lock blocks then rejects the write', async () => {
+    setFlags(true, true)
+    const revoker = await poolManager.get().getInternalPool().connect()
+    let revokerOpen = false
+    let runPromise: ReturnType<AutomationExecutor['execute']> | undefined
+    try {
+      const config = updateConfig() as Record<string, unknown>
+      const saved = await svc.createRule(RULE_SHEET, {
+        name: 'fwb2 field-permission phantom race',
+        triggerType: 'approval.completed',
+        triggerConfig: { templateId, outcomes: ['approved'] },
+        actionType: 'write_approval_form_values',
+        actionConfig: config,
+        createdBy: CREATOR,
+      } as never)
+      const ruleId = (saved as { id: string }).id
+      ruleIds.push(ruleId)
+      const instanceId = await startInstance({
+        summary: 'must-not-write-after-field-revoke',
+        amount: 92,
+        linked: { recordId: REC_A },
+      })
+      await approveInstance(instanceId)
+      const before = await recordData(REC_A)
+
+      await revoker.query('BEGIN')
+      revokerOpen = true
+      const pidResult = await revoker.query('SELECT pg_backend_pid() AS pid')
+      const revokerPid = Number((pidResult.rows[0] as { pid: number }).pid)
+      await revoker.query(
+        `INSERT INTO field_permissions
+           (sheet_id, field_id, subject_type, subject_id, visible, read_only)
+         VALUES ($1,$2,'user',$3,TRUE,TRUE)`,
+        [TARGET_SHEET, F_AMOUNT, CREATOR],
+      )
+
+      runPromise = buildExecutor({ fwbGateChecksFactory: productionGateFactory }).execute(
+        executorRule(ruleId, config),
+        triggerPayload(instanceId, `evt_fwb2_field_race_${TS}`),
+      )
+      await waitForFieldPermissionTableLockWaiter(revokerPid)
+      await revoker.query('COMMIT')
+      revokerOpen = false
+
+      const run = await runPromise
+      expect(run.steps[0]?.status).toBe('failed')
+      expect(String(run.steps[0]?.error ?? '')).toMatch(/fwb_rejected:permission_gates/)
+      expect(await recordData(REC_A)).toEqual(before)
+      expect(await claimCount(instanceId, ruleId)).toBe(0)
+    } finally {
+      if (revokerOpen) await revoker.query('ROLLBACK').catch(() => {})
+      revoker.release()
+      if (runPromise) await runPromise.catch(() => {})
+      await q(
+        `DELETE FROM field_permissions
+          WHERE sheet_id = $1 AND field_id = $2
+            AND subject_type = 'user' AND subject_id = $3`,
+        [TARGET_SHEET, F_AMOUNT, CREATOR],
+      ).catch(() => {})
+      setFlags(false, false)
+    }
+  })
+
+  test('record scope: sheet write-own updates creator-owned record but rejects a foreign record', async () => {
+    setFlags(true, true)
+    const ownRecord = `rec_fwb2_own_${TS}`
+    const foreignRecord = `rec_fwb2_foreign_${TS}`
+    try {
+      await q(
+        `INSERT INTO meta_records (id, sheet_id, data, version, created_by)
+         VALUES ($1,$3,$4::jsonb,1,$5), ($2,$3,$4::jsonb,1,$6)`,
+        [ownRecord, foreignRecord, TARGET_SHEET, JSON.stringify({ [F_TITLE]: 'scope-before', [F_AMOUNT]: 0 }), CREATOR, 'other_owner'],
+      )
+      await q(
+        `DELETE FROM user_permissions
+          WHERE user_id = $1 AND permission_code = 'multitable:write'`,
+        [CREATOR],
+      )
+      for (const permCode of ['spreadsheet:read', 'spreadsheet:write-own']) {
+        try {
+          await q(
+            `INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code)
+             VALUES ($1, 'user', $2, $3)`,
+            [TARGET_SHEET, CREATOR, permCode],
+          )
+        } catch {
+          await q(
+            `INSERT INTO spreadsheet_permissions (sheet_id, user_id, subject_type, subject_id, perm_code)
+             VALUES ($1, $2, 'user', $2, $3)`,
+            [TARGET_SHEET, CREATOR, permCode],
+          )
+        }
+      }
+      invalidateUserPerms(CREATOR)
+      const resolved = await resolveSheetCapabilitiesForUser(queryFn, TARGET_SHEET, CREATOR)
+      expect(resolved.permissions).not.toContain('multitable:write')
+      expect(resolved.isAdminRole).toBe(false)
+      expect(resolved.sheetScope).toMatchObject({ canRead: true, canWrite: false, canWriteOwn: true })
+
+      const config = updateConfig() as Record<string, unknown>
+      const saved = await svc.createRule(RULE_SHEET, {
+        name: 'fwb2 record-scope rule',
+        triggerType: 'approval.completed',
+        triggerConfig: { templateId, outcomes: ['approved'] },
+        actionType: 'write_approval_form_values',
+        actionConfig: config,
+        createdBy: CREATOR,
+      } as never)
+      const ruleId = (saved as { id: string }).id
+      ruleIds.push(ruleId)
+      const executor = buildExecutor({ fwbGateChecksFactory: productionGateFactory })
+
+      const ownInstance = await startInstance({ summary: 'own-updated', amount: 1, linked: { recordId: ownRecord } })
+      await approveInstance(ownInstance)
+      const ownRun = await executor.execute(
+        executorRule(ruleId, config),
+        triggerPayload(ownInstance, `evt_fwb2_own_${TS}`),
+      )
+      expect(ownRun.steps[0]?.status).toBe('success')
+      expect(await recordData(ownRecord)).toMatchObject({ [F_TITLE]: 'own-updated', [F_AMOUNT]: 1 })
+
+      const foreignInstance = await startInstance({ summary: 'must-not-update', amount: 2, linked: { recordId: foreignRecord } })
+      await approveInstance(foreignInstance)
+      const foreignRun = await executor.execute(
+        executorRule(ruleId, config),
+        triggerPayload(foreignInstance, `evt_fwb2_foreign_${TS}`),
+      )
+      expect(foreignRun.steps[0]?.status).toBe('failed')
+      expect(String(foreignRun.steps[0]?.error ?? '')).toBe('fwb_rejected:record_not_writable')
+      expect(await recordData(foreignRecord)).toMatchObject({ [F_TITLE]: 'scope-before', [F_AMOUNT]: 0 })
+      expect(await claimCount(foreignInstance, ruleId)).toBe(0)
+    } finally {
+      await q(
+        `DELETE FROM spreadsheet_permissions
+          WHERE sheet_id = $1 AND subject_type = 'user' AND subject_id = $2
+            AND perm_code = ANY($3::text[])`,
+        [TARGET_SHEET, CREATOR, ['spreadsheet:read', 'spreadsheet:write-own']],
+      ).catch(() => {})
+      await q(
+        `INSERT INTO user_permissions (user_id, permission_code)
+         VALUES ($1, 'multitable:write') ON CONFLICT DO NOTHING`,
+        [CREATOR],
+      ).catch(() => {})
+      invalidateUserPerms(CREATOR)
+      await q('DELETE FROM meta_records WHERE id = ANY($1::text[])', [[ownRecord, foreignRecord]]).catch(() => {})
+      setFlags(false, false)
+    }
+  })
+
+  test('duplicate net-once under new eventId; second instance is the positive control', async () => {
+    setFlags(true, true)
+    try {
+      // Reset REC_A for a clean apply.
+      await q(
+        `UPDATE meta_records SET data = $1::jsonb, version = 1, locked = FALSE WHERE id = $2`,
+        [JSON.stringify({ [F_TITLE]: 'net-once', [F_AMOUNT]: 0 }), REC_A],
+      )
+      const instanceId = await startInstance({
+        summary: 'net-once-1',
+        amount: 10,
+        linked: { recordId: REC_A },
+      })
+      await approveInstance(instanceId)
+      const ruleId = `rule_fwb2_net_${TS}`
+      const executor = buildExecutor({})
+      const cfg = updateConfig() as Record<string, unknown>
+      const run1 = await executor.execute(executorRule(ruleId, cfg), triggerPayload(instanceId, `evt_fwb2_net1_${TS}`))
+      expect(run1.steps[0]?.status).toBe('success')
+      expect(await claimCount(instanceId, ruleId)).toBe(1)
+      const versionAfter = Number(
+        ((await q('SELECT version FROM meta_records WHERE id = $1', [REC_A])).rows[0] as { version: number }).version,
+      )
+
+      const run2 = await executor.execute(executorRule(ruleId, cfg), triggerPayload(instanceId, `evt_fwb2_net2_${TS}`))
+      expect(run2.steps[0]?.status).toBe('success')
+      expect(run2.steps[0]?.alreadyApplied).toBe(true)
+      expect(await claimCount(instanceId, ruleId)).toBe(1)
+      expect(await outboxCountLike(`evt_fwb2_net2_${TS}::fwb::`)).toBe(0)
+      const versionDup = Number(
+        ((await q('SELECT version FROM meta_records WHERE id = $1', [REC_A])).rows[0] as { version: number }).version,
+      )
+      expect(versionDup).toBe(versionAfter)
+
+      // Positive control: different instance produces a second claim and mutates again.
+      const instanceB = await startInstance({
+        summary: 'net-once-2',
+        amount: 11,
+        linked: { recordId: REC_A },
+      })
+      await approveInstance(instanceB)
+      const run3 = await executor.execute(executorRule(ruleId, cfg), triggerPayload(instanceB, `evt_fwb2_net3_${TS}`))
+      expect(run3.steps[0]?.status).toBe('success')
+      expect(await claimCount(instanceB, ruleId)).toBe(1)
+      expect(await recordData(REC_A)).toMatchObject({ [F_TITLE]: 'net-once-2', [F_AMOUNT]: 11 })
+    } finally {
+      setFlags(false, false)
+    }
+  })
+
+  test('ATOMICITY: injected post-handler abort rolls claim + update + revision + outbox back together', async () => {
+    setFlags(true, true)
+    try {
+      await q(
+        `UPDATE meta_records SET data = $1::jsonb, version = 1 WHERE id = $2`,
+        [JSON.stringify({ [F_TITLE]: 'atomic-before', [F_AMOUNT]: 0 }), REC_A],
+      )
+      const instanceId = await startInstance({
+        summary: 'atomic',
+        amount: 7,
+        linked: { recordId: REC_A },
+      })
+      await approveInstance(instanceId)
+      const ruleId = `rule_fwb2_atomic_${TS}`
+      let inject = true
+      const injectingTransaction: NonNullable<AutomationDeps['transaction']> = async (handler) =>
+        realTransaction(async (client) => {
+          const result = await handler(client)
+          if (inject) throw new Error('injected post-handler abort host=db.internal user=secret_owner')
+          return result
+        })
+      const executor = buildExecutor({ transaction: injectingTransaction })
+      const before = await recordData(REC_A)
+      const run1 = await executor.execute(
+        executorRule(ruleId, updateConfig() as Record<string, unknown>),
+        triggerPayload(instanceId, `evt_fwb2_atomic1_${TS}`),
+      )
+      expect(run1.steps[0]?.status).toBe('failed')
+      expect(String(run1.steps[0]?.error ?? '')).toBe('fwb_execution_failed')
+      expect(String(run1.steps[0]?.error ?? '')).not.toMatch(/db\.internal|secret_owner|injected/)
+      expect(await recordData(REC_A)).toEqual(before)
+      expect(await claimCount(instanceId, ruleId)).toBe(0)
+      expect(await outboxCountLike(`evt_fwb2_atomic1_${TS}::fwb::`)).toBe(0)
+
+      inject = false
+      const run2 = await executor.execute(
+        executorRule(ruleId, updateConfig() as Record<string, unknown>),
+        triggerPayload(instanceId, `evt_fwb2_atomic2_${TS}`),
+      )
+      expect(run2.steps[0]?.status).toBe('success')
+      expect(await recordData(REC_A)).toMatchObject({ [F_TITLE]: 'atomic', [F_AMOUNT]: 7 })
+      expect(await claimCount(instanceId, ruleId)).toBe(1)
+      expect(await revisionCount(REC_A)).toBeGreaterThanOrEqual(1)
+      expect(await outboxCountLike(`evt_fwb2_atomic2_${TS}::fwb::`)).toBe(1)
+    } finally {
+      setFlags(false, false)
+    }
+  })
+
+  test('cross-base deny when rule creator lacks target base write; allow when authorized', async () => {
+    setFlags(true, true)
+    try {
+      // Publish a second template that pins CROSS_SHEET, so derivation points at another base.
+      const crossTpl = await approvals.createTemplate(
+        {
+          ...approvalTemplateRequest(CROSS_BASE, CROSS_SHEET),
+          key: `fwb2-cross-${TS}`,
+          name: 'FWB-2 Cross Template',
+          formSchema: {
+            fields: [
+              { id: 'summary', type: 'text', label: 'Summary', required: true },
+              {
+                id: 'linked',
+                type: 'record-link',
+                label: 'Bound',
+                required: true,
+                props: { baseId: CROSS_BASE, sheetId: CROSS_SHEET },
+              },
+            ],
+          },
+        } as never,
+      )
+      const crossTemplateId = (crossTpl as { id: string }).id
+      await approvals.publishTemplate(crossTemplateId, {
+        policy: { allowRevoke: true },
+        actorUserId: CREATOR,
+      } as never)
+      const crossVer = await q('SELECT active_version_id FROM approval_templates WHERE id = $1', [crossTemplateId])
+      const crossVersionId = String((crossVer.rows[0] as { active_version_id: string }).active_version_id)
+
+      const crossMappings = [
+        { formFieldId: 'summary', targetFieldId: F_CROSS_TITLE, targetType: 'text' as const },
+      ]
+      const crossCfg = {
+        mode: 'update',
+        recordLinkFieldId: 'linked',
+        mappings: crossMappings,
+        sourceTemplateVersionId: crossVersionId,
+        confirmationHash: deriveFwbConfirmationHash({
+          templateId: crossTemplateId,
+          sourceTemplateVersionId: crossVersionId,
+          targetBaseId: CROSS_BASE,
+          targetSheetId: CROSS_SHEET,
+          mappings: crossMappings,
+          mode: 'update',
+          recordLinkFieldId: 'linked',
+        }),
+      }
+      const crossRule = await svc.createRule(RULE_SHEET, {
+        name: 'fwb2 production cross-base rule',
+        triggerType: 'approval.completed',
+        triggerConfig: { templateId: crossTemplateId, outcomes: ['approved'] },
+        actionType: 'write_approval_form_values',
+        actionConfig: crossCfg,
+        createdBy: CREATOR,
+      } as never)
+      const crossRuleId = (crossRule as { id: string }).id
+      ruleIds.push(crossRuleId)
+
+      // Create + approve against the cross template.
+      const dto = await approvals.createApproval(
+        {
+          templateId: crossTemplateId,
+          formData: { summary: 'cross-write', linked: { recordId: REC_CROSS } },
+        },
+        { userId: REQUESTER, userName: REQUESTER },
+      )
+      const instanceId = (dto as { id: string }).id
+      await approveInstance(instanceId)
+
+      // Cross-base authority uses resolveBaseWritable (multitable:base:write / base ownership),
+      // NOT sheet multitable:write and NOT users.is_admin. Seed the code, then DENY by stripping it.
+      await q(
+        `INSERT INTO permissions (code, name, description)
+         VALUES ('multitable:base:write', 'Base Write', 'FWB2')
+         ON CONFLICT (code) DO NOTHING`,
+      )
+      await q(
+        `DELETE FROM user_permissions WHERE user_id = $1 AND permission_code = 'multitable:base:write'`,
+        [CREATOR],
+      )
+      try {
+        const before = await recordData(REC_CROSS)
+        const denyRun = await buildExecutor({ fwbGateChecksFactory: productionGateFactory }).execute(
+          {
+            ...executorRule(crossRuleId, crossCfg as Record<string, unknown>),
+            trigger: { type: 'approval.completed', config: { templateId: crossTemplateId } } as never,
+            createdBy: CREATOR,
+          },
+          {
+            ...triggerPayload(instanceId, `evt_fwb2_xdeny_${TS}`),
+            approval: { instanceId, templateId: crossTemplateId, templateVersionId: crossVersionId },
+          },
+        )
+        expect(denyRun.steps[0]?.status).toBe('failed')
+        expect(String(denyRun.steps[0]?.error ?? '')).toBe('fwb_rejected:cross_base')
+        expect(await recordData(REC_CROSS)).toEqual(before)
+        expect(await claimCount(instanceId, crossRuleId)).toBe(0)
+      } finally {
+        await q(
+          `INSERT INTO user_permissions (user_id, permission_code)
+           VALUES ($1, 'multitable:base:write') ON CONFLICT DO NOTHING`,
+          [CREATOR],
+        )
+      }
+
+      // ALLOW: rule creator holds multitable:base:write on the target base path.
+      const allowDto = await approvals.createApproval(
+        {
+          templateId: crossTemplateId,
+          formData: { summary: 'cross-write-allow', linked: { recordId: REC_CROSS } },
+        },
+        { userId: REQUESTER, userName: REQUESTER },
+      )
+      const allowInstanceId = (allowDto as { id: string }).id
+      await approveInstance(allowInstanceId)
+      const allowRun = await buildExecutor({ fwbGateChecksFactory: productionGateFactory }).execute(
+        {
+          ...executorRule(crossRuleId, crossCfg as Record<string, unknown>),
+          trigger: { type: 'approval.completed', config: { templateId: crossTemplateId } } as never,
+          createdBy: CREATOR,
+        },
+        {
+          ...triggerPayload(allowInstanceId, `evt_fwb2_xallow_${TS}`),
+          approval: { instanceId: allowInstanceId, templateId: crossTemplateId, templateVersionId: crossVersionId },
+        },
+      )
+      expect(String(allowRun.steps[0]?.error ?? '')).toBe('')
+      expect(allowRun.steps[0]?.status).toBe('success')
+      expect(await recordData(REC_CROSS)).toMatchObject({ [F_CROSS_TITLE]: 'cross-write-allow' })
+      expect(await claimCount(allowInstanceId, crossRuleId)).toBe(1)
+    } finally {
+      setFlags(false, false)
+    }
+  })
+
+  test('flag OFF skips; durable OFF fails closed — zero writes', async () => {
+    await q(
+      `UPDATE meta_records SET data = $1::jsonb WHERE id = $2`,
+      [JSON.stringify({ [F_TITLE]: 'flag-before', [F_AMOUNT]: 0 }), REC_A],
+    )
+    const instanceId = await startInstance({
+      summary: 'flag-test',
+      amount: 1,
+      linked: { recordId: REC_A },
+    })
+    await approveInstance(instanceId)
+    const ruleId = `rule_fwb2_flag_${TS}`
+    const cfg = updateConfig() as Record<string, unknown>
+    const before = await recordData(REC_A)
+
+    setFlags(false, false)
+    const off = await buildExecutor({}).execute(executorRule(ruleId, cfg), triggerPayload(instanceId, `evt_fwb2_off_${TS}`))
+    expect(off.steps[0]?.status).toBe('skipped')
+    expect(await recordData(REC_A)).toEqual(before)
+
+    setFlags(true, false)
+    const half = await buildExecutor({}).execute(executorRule(ruleId, cfg), triggerPayload(instanceId, `evt_fwb2_half_${TS}`))
+    expect(half.steps[0]?.status).toBe('failed')
+    expect(String(half.steps[0]?.error ?? '')).toMatch(/AUTOMATION_DURABLE_DELIVERY_ENABLED/)
+    expect(await recordData(REC_A)).toEqual(before)
+    expect(await claimCount(instanceId, ruleId)).toBe(0)
+    setFlags(false, false)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-fwb-write-action-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-fwb-write-action-realdb.test.ts
@@ -50,7 +50,7 @@ const input = (over: Partial<FwbWriteActionInput> = {}): FwbWriteActionInput => 
   instanceId: `apr_${RUN}`,
   ruleId: `rule_${RUN}`,
   actionKey: `ak_${RUN}_1`,
-  gateSubject: { configurerUserId: 'u1', ruleId: `rule_${RUN}`, sourceTemplateId: 'tpl', targetSheetId: `sheet_${RUN}` },
+  gateSubject: { configurerUserId: 'u1', ruleId: `rule_${RUN}`, actionKey: `ak_${RUN}_1`, sourceTemplateId: 'tpl', targetSheetId: `sheet_${RUN}` },
   mappings: [{ formFieldId: 'f1', targetFieldId: 't1', targetType: 'text' }],
   formValues: { f1: 'hello' },
   eventId: `evt_${RUN}_${randomUUID().slice(0, 8)}`,

--- a/packages/core-backend/tests/unit/approval-fwb-permission-gates.test.ts
+++ b/packages/core-backend/tests/unit/approval-fwb-permission-gates.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest'
 
 import { recheckFwbPermissionGates, type FwbGateChecks } from '../../src/multitable/approval-fwb-permission-gates'
 
-const S = { configurerUserId: 'u1', ruleId: 'r1', sourceTemplateId: 'tpl1', targetSheetId: 'sh1' }
+const S = { configurerUserId: 'u1', ruleId: 'r1', actionKey: 'ak1', sourceTemplateId: 'tpl1', targetSheetId: 'sh1' }
 const allTrue = (over: Partial<Record<keyof FwbGateChecks, boolean | 'throw'>> = {}): FwbGateChecks => {
   const mk = (k: keyof FwbGateChecks) => async () => {
     const v = over[k]

--- a/packages/core-backend/tests/unit/approval-fwb-update-mode.test.ts
+++ b/packages/core-backend/tests/unit/approval-fwb-update-mode.test.ts
@@ -1,0 +1,254 @@
+/**
+ * FWB-2 pure helpers — mode contract, confirmation-hash binding, linked-record extraction,
+ * and schema-derived target resolution. Required no-DB lane.
+ */
+import { createHash } from 'node:crypto'
+import { describe, expect, test, vi } from 'vitest'
+
+import {
+  collectPersistedFwbActions,
+  deriveFwbConfirmationHash,
+  extractExactLinkedRecordId,
+  normalizeFwbUpdateRecordLinkFieldId,
+  parseFwbWriteMode,
+  resolveRecordLinkTargetFromSchema,
+} from '../../src/multitable/approval-fwb-activation'
+import { canonicalizeConfig } from '../../src/multitable/automation-action-idempotency'
+import { recheckFwbPermissionGates, type FwbGateChecks } from '../../src/multitable/approval-fwb-permission-gates'
+import {
+  executeUpdateBoundRecord,
+  type FwbUpdateSeam,
+  type RecordLinkChecks,
+} from '../../src/multitable/approval-fwb-record-link'
+import type { TransactionalQueryable } from '../../src/multitable/pg-transaction-guard'
+
+const MAPPINGS = [
+  { formFieldId: 'summary', targetFieldId: 'fld_title', targetType: 'text' as const },
+]
+
+describe('FWB-2 mode / config contract (pure)', () => {
+  test('parseFwbWriteMode: only absent/create → create; update → update; null/blank/unknown rejected', () => {
+    expect(parseFwbWriteMode(undefined)).toEqual({ ok: true, mode: 'create' })
+    expect(parseFwbWriteMode('create')).toEqual({ ok: true, mode: 'create' })
+    expect(parseFwbWriteMode('update')).toEqual({ ok: true, mode: 'update' })
+    expect(parseFwbWriteMode(null)).toEqual({ ok: false, issue: 'unknown_mode' })
+    expect(parseFwbWriteMode('')).toEqual({ ok: false, issue: 'unknown_mode' })
+    expect(parseFwbWriteMode('patch')).toEqual({ ok: false, issue: 'unknown_mode' })
+    expect(parseFwbWriteMode(1)).toEqual({ ok: false, issue: 'unknown_mode' })
+  })
+
+  test('persisted action identity mirrors executor precedence and isolates sibling configs', () => {
+    const legacy = { mappings: [{ ...MAPPINGS[0], targetFieldId: 'legacy' }] }
+    const actions = [
+      { type: 'write_approval_form_values', config: { mode: 'update', recordLinkFieldId: 'link_a', mappings: MAPPINGS } },
+      { type: 'write_approval_form_values', config: { mode: 'update', recordLinkFieldId: 'link_b', mappings: [{ ...MAPPINGS[0], targetFieldId: 'other' }] } },
+    ]
+    const collected = collectPersistedFwbActions('write_approval_form_values', legacy, actions)
+    expect(collected).toHaveLength(2)
+    expect(collected.map((entry) => entry.structuralPath)).toEqual(['0', '1'])
+    expect(collected[0].actionKey).not.toBe(collected[1].actionKey)
+    expect(collected.some((entry) => entry.config === legacy)).toBe(false)
+
+    const fallback = collectPersistedFwbActions('write_approval_form_values', legacy, null)
+    expect(fallback).toHaveLength(1)
+    expect(fallback[0].structuralPath).toBe('0')
+    expect(fallback[0].config).toBe(legacy)
+  })
+
+  test('normalizeFwbUpdateRecordLinkFieldId: requires one non-blank string', () => {
+    expect(normalizeFwbUpdateRecordLinkFieldId('linked')).toEqual({ ok: true, recordLinkFieldId: 'linked' })
+    expect(normalizeFwbUpdateRecordLinkFieldId('  linked  ')).toEqual({ ok: true, recordLinkFieldId: 'linked' })
+    expect(normalizeFwbUpdateRecordLinkFieldId(undefined)).toEqual({ ok: false, issue: 'record_link_field_missing' })
+    expect(normalizeFwbUpdateRecordLinkFieldId('   ')).toEqual({ ok: false, issue: 'record_link_field_blank' })
+    expect(normalizeFwbUpdateRecordLinkFieldId(42)).toEqual({ ok: false, issue: 'record_link_field_blank' })
+  })
+
+  test('extractExactLinkedRecordId: only exactly { recordId: nonblank string }', () => {
+    expect(extractExactLinkedRecordId({ recordId: 'rec_1' })).toBe('rec_1')
+    expect(extractExactLinkedRecordId({ recordId: '  rec_2  ' })).toBe('rec_2')
+    expect(extractExactLinkedRecordId(null)).toBeNull()
+    expect(extractExactLinkedRecordId('rec_1')).toBeNull()
+    expect(extractExactLinkedRecordId(['rec_1'])).toBeNull()
+    expect(extractExactLinkedRecordId({ recordId: '' })).toBeNull()
+    expect(extractExactLinkedRecordId({ recordId: 'a', sheetId: 'smuggle' })).toBeNull()
+    expect(extractExactLinkedRecordId({ recordIds: ['a'] })).toBeNull()
+  })
+
+  test('resolveRecordLinkTargetFromSchema: top-level record-link props only', () => {
+    const schema = {
+      fields: [
+        { id: 'linked', type: 'record-link', props: { baseId: 'base_a', sheetId: 'sheet_a' } },
+        { id: 'summary', type: 'text' },
+        {
+          id: 'detail',
+          type: 'detail',
+          columns: [
+            { id: 'nested_link', type: 'record-link', props: { baseId: 'base_b', sheetId: 'sheet_b' } },
+          ],
+        },
+      ],
+    }
+    expect(resolveRecordLinkTargetFromSchema(schema, 'linked')).toEqual({
+      fieldId: 'linked',
+      baseId: 'base_a',
+      sheetId: 'sheet_a',
+    })
+    // Nested record-link is not discoverable as a top-level target.
+    expect(resolveRecordLinkTargetFromSchema(schema, 'nested_link')).toBeNull()
+    // Wrong type / blank props / missing field.
+    expect(resolveRecordLinkTargetFromSchema(schema, 'summary')).toBeNull()
+    expect(resolveRecordLinkTargetFromSchema(
+      { fields: [{ id: 'linked', type: 'record-link', props: { baseId: '  ', sheetId: 's' } }] },
+      'linked',
+    )).toBeNull()
+    expect(resolveRecordLinkTargetFromSchema(schema, 'nope')).toBeNull()
+  })
+})
+
+describe('FWB confirmation hash — create byte-compat + update binding', () => {
+  const baseSubject = {
+    templateId: 'tpl_1',
+    sourceTemplateVersionId: 'ver_1',
+    targetBaseId: 'base_1',
+    targetSheetId: 'sheet_1',
+    mappings: MAPPINGS,
+  }
+
+  test('create-mode hash omits mode/recordLinkFieldId (byte-identical to pre-FWB-2 subject)', () => {
+    const hash = deriveFwbConfirmationHash(baseSubject)
+    const expected = createHash('sha256')
+      .update(canonicalizeConfig({
+        templateId: 'tpl_1',
+        sourceTemplateVersionId: 'ver_1',
+        targetBaseId: 'base_1',
+        targetSheetId: 'sheet_1',
+        mappings: MAPPINGS,
+      }))
+      .digest('hex')
+    expect(hash).toBe(expected)
+    // Explicit mode:'create' must NOT alter the subject (only update binds mode).
+    expect(deriveFwbConfirmationHash({ ...baseSubject, mode: 'create' as const })).toBe(expected)
+  })
+
+  test('update-mode hash binds mode + recordLinkFieldId + derived target', () => {
+    const updateHash = deriveFwbConfirmationHash({
+      ...baseSubject,
+      mode: 'update',
+      recordLinkFieldId: 'linked',
+    })
+    expect(updateHash).not.toBe(deriveFwbConfirmationHash(baseSubject))
+    // Changing recordLinkFieldId invalidates.
+    expect(deriveFwbConfirmationHash({
+      ...baseSubject,
+      mode: 'update',
+      recordLinkFieldId: 'other',
+    })).not.toBe(updateHash)
+    // Changing derived target sheet invalidates.
+    expect(deriveFwbConfirmationHash({
+      ...baseSubject,
+      mode: 'update',
+      recordLinkFieldId: 'linked',
+      targetSheetId: 'sheet_other',
+    })).not.toBe(updateHash)
+  })
+})
+
+describe('FWB-2 permission gates pass mode to sheet/field checks', () => {
+  test('update mode invokes canWriteSheet/canWriteTargetFields with mode=update', async () => {
+    const canWriteSheet = vi.fn(async () => true)
+    const canWriteTargetFields = vi.fn(async () => true)
+    const checks: FwbGateChecks = {
+      isAdmin: async () => true,
+      canManageSheetAccess: async () => false,
+      canReadTemplate: async () => true,
+      canWriteSheet,
+      canWriteTargetFields,
+      hasRecordedConfirmation: async () => true,
+    }
+    const r = await recheckFwbPermissionGates(checks, {
+      configurerUserId: 'u1',
+      ruleId: 'r1',
+      actionKey: 'ak1',
+      sourceTemplateId: 'tpl',
+      targetSheetId: 'sh_target',
+      mode: 'update',
+    })
+    expect(r).toEqual({ ok: true })
+    expect(canWriteSheet).toHaveBeenCalledWith('u1', 'sh_target', 'update')
+    expect(canWriteTargetFields).toHaveBeenCalledWith('u1', 'r1', 'ak1', 'sh_target', 'update')
+  })
+
+  test('create (default) invokes checks with mode=create', async () => {
+    const canWriteSheet = vi.fn(async () => true)
+    const canWriteTargetFields = vi.fn(async () => true)
+    const checks: FwbGateChecks = {
+      isAdmin: async () => true,
+      canManageSheetAccess: async () => false,
+      canReadTemplate: async () => true,
+      canWriteSheet,
+      canWriteTargetFields,
+      hasRecordedConfirmation: async () => true,
+    }
+    await recheckFwbPermissionGates(checks, {
+      configurerUserId: 'u1',
+      ruleId: 'r1',
+      actionKey: 'ak1',
+      sourceTemplateId: 'tpl',
+      targetSheetId: 'sh1',
+    })
+    expect(canWriteSheet).toHaveBeenCalledWith('u1', 'sh1', 'create')
+    expect(canWriteTargetFields).toHaveBeenCalledWith('u1', 'r1', 'ak1', 'sh1', 'create')
+  })
+})
+
+describe('executeUpdateBoundRecord composition (seam-level, no DB)', () => {
+  const trx = { query: async () => ({ rows: [], rowCount: 0 }), isTransaction: true } as unknown as TransactionalQueryable
+  const gatesAll = (): FwbGateChecks => ({
+    isAdmin: async () => true,
+    canManageSheetAccess: async () => true,
+    canReadTemplate: async () => true,
+    canWriteSheet: async () => true,
+    canWriteTargetFields: async () => true,
+    hasRecordedConfirmation: async () => true,
+  })
+  const linkOk = (): RecordLinkChecks => ({
+    fillerCanReadRecord: async () => true,
+    recordExists: async () => true,
+    recordIsLocked: async () => false,
+    configurerCanWriteRecord: async () => true,
+  })
+
+  test('applied path calls update + outbox; lock/missing reject before claim', async () => {
+    const update = vi.fn(async () => {})
+    const enqueue = vi.fn(async () => {})
+    const seam: FwbUpdateSeam = { updateRecordWithRevision: update, enqueueOutbox: enqueue }
+    // Without a real claim ledger this only proves the bound-record fail-closed path before claim.
+    const locked = await executeUpdateBoundRecord(
+      trx,
+      {
+        claimId: 'c1',
+        instanceId: 'i1',
+        ruleId: 'r1',
+        actionKey: 'ak1',
+        gateSubject: {
+          configurerUserId: 'u1',
+          ruleId: 'r1',
+          actionKey: 'ak1',
+          sourceTemplateId: 'tpl',
+          targetSheetId: 'sh',
+          mode: 'update',
+        },
+        boundRecordId: 'rec1',
+        mappings: MAPPINGS,
+        formValues: { summary: 'x' },
+        eventId: 'evt1',
+      },
+      gatesAll(),
+      { ...linkOk(), recordIsLocked: async () => true },
+      seam,
+    )
+    expect(locked).toEqual({ status: 'rejected', reason: 'record_locked' })
+    expect(update).not.toHaveBeenCalled()
+    expect(enqueue).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-permission-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-permission-service.test.ts
@@ -320,6 +320,20 @@ describe('permission-service: row-actions and write-allowed', () => {
     expect(
       ensureRecordWriteAllowed(editorCaps, writeOwnScope, access, 'user_2', 'edit'),
     ).toBe(false)
+    expect(
+      ensureRecordWriteAllowed(editorCaps, writeOwnScope, access, 'user_2', 'edit', new Map(), 'rec_other'),
+    ).toBe(false)
+    expect(
+      ensureRecordWriteAllowed(
+        editorCaps,
+        writeOwnScope,
+        access,
+        'user_2',
+        'edit',
+        new Map([['some_other_record', { recordId: 'some_other_record', accessLevel: 'admin' as const }]]),
+        'rec_other',
+      ),
+    ).toBe(false)
   })
 })
 

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -562,6 +562,11 @@ export default defineConfig({
       // skip-green in the no-DB lane, whole-file wired into `Run multitable real-DB integration` in
       // plugin-tests.yml. Two-point wiring.
       'tests/integration/multitable-fwb-activation-realdb.test.ts',
+      // FWB-2 production write_approval_form_values mode:update (same-base/cross-base/lock/delete/
+      // net-once/atomicity): real Postgres only — excluded HERE so it cannot skip-green in the no-DB
+      // lane, whole-file wired into `Run multitable real-DB integration` in plugin-tests.yml.
+      // Two-point wiring.
+      'tests/integration/multitable-fwb-update-activation-realdb.test.ts',
       // approval attachment GC worker (TTL sweep + purge-intent drain) — real-DB. Two-point wiring.
       'tests/integration/approval-attachment-gc-realdb.test.ts',
       // attachment bind (form-freeze) + bucket reconciler — real-DB. Two-point wiring.


### PR DESCRIPTION
## What

- Add FWB-2 `mode: update`: derive the destination base/sheet from the pinned template-version record-link field and accept only an exact `{ recordId }` form snapshot value.
- Re-check the exact persisted action identity, template/version, cross-base authority, sheet/field/row permissions, record lock, and target types inside the write transaction.
- Commit claim + record update + revision + durable outbox atomically; replay returns already-applied with no second mutation or event.
- Fix the shared own-write fallback so an empty or unrelated record-scope map cannot widen edit authority.
- Collapse missing, locked, and unwritable linked-record outcomes to one persisted error code so execution logs cannot serve as a record-existence oracle.

## Stack and gates

- Stacked on #4524 (`codex/approval-record-link-layer2-20260721`); do not merge before that base.
- `APPROVAL_FWB_WRITEBACK_ENABLED` and durable-delivery activation remain default OFF.
- Draft for owner review; no production enablement in this PR.

## Verification

- Fresh PostgreSQL 15: FWB-2 real-DB suite 15/15.
- Fresh PostgreSQL 15 composed FWB-1 helper + production + FWB-2: 33/33.
- Related unit suites: 68/68.
- Full backend no-DB Vitest config: 8747/8747, 0 failed.
- CI-equivalent backend `tsc --noEmit`: clean.
- Structural guards: cross-base, record-lock, revision disposition, raw-data projection 23/23.
- Discriminating mutations: unknown mode, exact action-key isolation, record `FOR UPDATE`, empty scope-map fallback, transaction-local grant revoke, absent-field-permission phantom, and non-oracular linked-record errors.
- Constructed two-connection races prove the executor blocks on authority locks, then refuses after the revoke/deny commits.

## Review note

ReClaude Opus reviewed the production chain at the prior head. It verified the same-transaction claim/update/revision/outbox contract and found one actionable log-oracle issue, fixed in the current head with a real-DB mutation proof. Its two remaining P2-labelled concerns are conditional residuals rather than established production exploits: production binds the transaction-scoped gate factory, and `approval_instances.form_snapshot` has one INSERT writer and no UPDATE writer in the application. They remain explicit re-review targets.
