### PR TITLE
fix(approval): validate every parallel condition path

### DIFF
--- a/apps/web/src/approvals/parallelEdit.ts
+++ b/apps/web/src/approvals/parallelEdit.ts
@@ -161,9 +161,60 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
       return `manager_at_level:${source.level}`
     case 'form_field_user':
       return `form_field_user:${source.fieldId.trim()}`
-    default:
+    case 'static_user':
+    case 'static_role':
       return null
+    default: {
+      const _exhaustive: never = source
+      return _exhaustive
+    }
   }
+}
+
+function runtimeSuccessorTargets(
+  node: ApprovalNode,
+  edgeByKey: Map<string, ApprovalGraph['edges'][number]>,
+  outgoingBySource: Map<string, ApprovalGraph['edges']>,
+): string[] {
+  if (node.type === 'condition') {
+    const config = node.config as {
+      branches?: Array<{ edgeKey?: string }>
+      defaultEdgeKey?: string
+    }
+    const declaredKeys: string[] = []
+    const seenKeys = new Set<string>()
+    const pushKey = (raw: string | undefined): void => {
+      const key = typeof raw === 'string' ? raw.trim() : ''
+      if (!key || seenKeys.has(key)) return
+      seenKeys.add(key)
+      declaredKeys.push(key)
+    }
+    for (const branch of config.branches ?? []) pushKey(branch.edgeKey)
+    const hasDefault = typeof config.defaultEdgeKey === 'string' && config.defaultEdgeKey.trim().length > 0
+    if (hasDefault) pushKey(config.defaultEdgeKey)
+
+    const targets: string[] = []
+    for (const edgeKey of declaredKeys) {
+      const edge = edgeByKey.get(edgeKey)
+      if (edge?.source === node.key) targets.push(edge.target)
+    }
+    if (!hasDefault) {
+      const firstEdge = outgoingBySource.get(node.key)?.[0]
+      if (firstEdge && !seenKeys.has(firstEdge.key)) targets.push(firstEdge.target)
+    }
+    return targets
+  }
+
+  if (node.type === 'parallel') {
+    const config = node.config as { branches?: string[] }
+    return (config.branches ?? []).flatMap((edgeKey) => {
+      const edge = edgeByKey.get(edgeKey)
+      return edge?.source === node.key ? [edge.target] : []
+    })
+  }
+
+  const firstEdge = outgoingBySource.get(node.key)?.[0]
+  return firstEdge ? [firstEdge.target] : []
 }
 
 /**
@@ -178,26 +229,26 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
  * for some org shapes and stay the runtime guard's job.
  *
  * Traversal (review #4433 owner P2, mirror-ports the backend EXACTLY): within each branch the walk
- * enumerates EVERY runtime-reachable path — a condition node fans out over ALL of its outgoing
- * edges (every rules-branch edge AND the default edge: which path fires is form-data-dependent, so
- * each is possible), every other node type follows its first outgoing edge (linear in a normalized
- * graph). The branch's fingerprint set is the UNION over all condition paths up to the join node,
+ * enumerates EVERY runtime-reachable path — a condition node follows its configured rule edges and
+ * default edge; without a default it additionally follows the runtime's first-outgoing fallback.
+ * Stray outgoing edges are ignored. Every other linear node follows its first outgoing edge. The
+ * branch's fingerprint set is the UNION over all condition paths up to the join node,
  * and a conflict is flagged when SOME path through one branch and SOME path through another carry
  * the identical dynamic source — exactly the pairings for which the runtime 409 is reachable.
  * Cycles are cut with a per-branch visited set; an unexpectedly nested parallel (unauthorable via
  * the canvas F4 guard, but a legacy graph could carry one on a non-first condition path) is
- * defensively a PASS-THROUGH fan-out over all its outgoing edges (its sub-branches are all
- * simultaneously active). Deduped within a branch first — sequential same-source nodes, or the same
+ * defensively a pass-through over its configured branch edges. Deduped within a branch first —
+ * sequential same-source nodes, or the same
  * source on two ALTERNATIVE paths of ONE branch, are not a parallel conflict.
  */
 export function parallelDynamicAssigneeConflicts(graph: ApprovalGraph): string[] {
   const errors: string[] = []
   const edgeByKey = new Map(graph.edges.map((edge) => [edge.key, edge]))
-  const outgoingTargets = new Map<string, string[]>()
+  const outgoingBySource = new Map<string, ApprovalGraph['edges']>()
   for (const edge of graph.edges) {
-    const targets = outgoingTargets.get(edge.source)
-    if (targets) targets.push(edge.target)
-    else outgoingTargets.set(edge.source, [edge.target])
+    const edges = outgoingBySource.get(edge.source)
+    if (edges) edges.push(edge)
+    else outgoingBySource.set(edge.source, [edge])
   }
   const nodeByKey = new Map(graph.nodes.map((node) => [node.key, node]))
   for (const node of graph.nodes) {
@@ -224,14 +275,8 @@ export function parallelDynamicAssigneeConflicts(graph: ApprovalGraph): string[]
             if (fingerprint) branchFingerprints.add(fingerprint)
           }
         }
-        const targets = outgoingTargets.get(currentKey) ?? []
-        if (current.type === 'condition' || current.type === 'parallel') {
-          // Condition: EVERY outgoing edge (each rules branch + the default) is a possible runtime
-          // path. Parallel (defensive — see doc above): pass-through fan-out over all sub-branches.
-          for (const target of targets) queue.push(target)
-        } else if (targets.length > 0) {
-          // Linear node — follow its first outgoing edge, as before.
-          queue.push(targets[0])
+        for (const target of runtimeSuccessorTargets(current, edgeByKey, outgoingBySource)) {
+          queue.push(target)
         }
       }
       for (const fingerprint of branchFingerprints) {

--- a/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
@@ -510,6 +510,50 @@ describe('parallelDynamicAssigneeConflicts — condition paths inside a parallel
     expect(parallelDynamicAssigneeConflicts(conditionDefaultPathGraph([{ kind: 'manager_at_level', level: 2 }]))).toEqual([])
   })
 
+  it('ignores a stray outgoing edge that is absent from the condition config', () => {
+    const base = conditionDefaultPathGraph([{ kind: 'direct_manager' }])
+    const graph: ApprovalGraph = {
+      ...base,
+      nodes: [
+        ...base.nodes.slice(0, -2),
+        { key: 'approval_stray', type: 'approval', name: '幽灵边', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        ...base.nodes.slice(-2),
+      ],
+      edges: [
+        ...base.edges.slice(0, -1),
+        { key: 'e-cond-stray', source: 'cond_1', target: 'approval_stray' },
+        { key: 'e-stray-join', source: 'approval_stray', target: 'join_1' },
+        ...base.edges.slice(-1),
+      ],
+    }
+    expect(parallelDynamicAssigneeConflicts(graph)).toEqual([])
+  })
+
+  it('without a default, includes the first-outgoing runtime fallback as well as declared rules edges', () => {
+    const base = conditionDefaultPathGraph([{ kind: 'requester' }])
+    const graph: ApprovalGraph = {
+      ...base,
+      nodes: base.nodes.map((node) => (node.key === 'cond_1'
+        ? {
+            ...node,
+            config: {
+              branches: [{ edgeKey: 'e-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }],
+            },
+          } as ApprovalGraph['nodes'][number]
+        : node)),
+      // First outgoing is now the unconfigured low edge; runtime falls back to it
+      // when no rule matches, so its requester source still conflicts with branch B.
+      edges: base.edges.map((edge) => {
+        if (edge.key === 'e-cond-high') return { ...edge, key: 'e-cond-low', target: 'approval_low' }
+        if (edge.key === 'e-cond-low') return { ...edge, key: 'e-cond-high', target: 'approval_high' }
+        return edge
+      }),
+    }
+    const errors = parallelDynamicAssigneeConflicts(graph)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('requester')
+  })
+
   it('flags a conflict hidden behind the RULES edge when the default edge happens to be declared first', () => {
     // Reorder: default edge (→ approval_low, requester) declared FIRST; the dept_head conflict sits
     // behind the RULES edge, which a first-edge-only walk would never enter. Branch B = dept_head.

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -3913,6 +3913,16 @@ export class ApprovalProductService {
       throw new ServiceError('Approval template has no version to clone', 400, 'APPROVAL_TEMPLATE_VERSION_NOT_FOUND')
     }
 
+    // Stored versions remain readable under the historical compatibility rules, but
+    // cloning creates a new draft version and must satisfy the current authoring gate.
+    const formSchema = assertFormSchema(source.version.form_schema)
+    const approvalGraph = assertApprovalGraph(source.version.approval_graph)
+    validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
+    validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
+    validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
+    validateNodeTimeoutConfigs(approvalGraph)
+    validateConditionBranchRules(approvalGraph)
+
     const newName = `${source.template.name} (副本)`
 
     for (let attempt = 0; attempt < TEMPLATE_CLONE_KEY_ATTEMPTS; attempt += 1) {
@@ -3944,8 +3954,8 @@ export class ApprovalProductService {
            RETURNING *`,
           [
             template.id,
-            JSON.stringify(source.version.form_schema),
-            JSON.stringify(source.version.approval_graph),
+            JSON.stringify(formSchema),
+            JSON.stringify(approvalGraph),
           ],
         )
         const version = versionResult.rows[0]

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1298,8 +1298,14 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
       return `manager_at_level:${source.level}`
     case 'form_field_user':
       return `form_field_user:${source.fieldId}`
-    default:
+    case 'static_user':
+    case 'static_role':
+      // Statics are owned by collectBranchAssignees' duplicate check, not this gate.
       return null
+    default: {
+      const _exhaustive: never = source
+      return _exhaustive
+    }
   }
 }
 
@@ -1320,30 +1326,28 @@ function dynamicAssigneeSourceFingerprint(source: ApprovalAssigneeSource): strin
  * merge machinery legitimately absorbs same-approver overlap.
  *
  * Traversal (review #4433 owner P2): the walk enumerates EVERY runtime-reachable path inside a
- * branch — NOT just the first-outgoing-edge chain. A condition node fans out over ALL of its
- * outgoing edges (every rules-branch edge AND the default edge: which path fires is
- * form-data-dependent, so publish must treat each as possible); every other node type follows its
- * first outgoing edge (linear in a normalized graph). The branch's fingerprint set is therefore
- * the UNION over all condition paths up to the join node, and a conflict is flagged when SOME
- * path through one branch and SOME path through another carry the identical dynamic source —
- * exactly the pairings for which the runtime 409 is reachable. Cycles are cut with a per-branch
- * visited set. A nested parallel node (normalize rejects it on the first-edge path and the canvas
- * F4 guard cannot author one, but a non-first condition path of a legacy graph could carry one)
- * is treated defensively as a PASS-THROUGH fan-out over all its outgoing edges: its sub-branches
- * are all simultaneously active, so every source reachable through it belongs to this outer
- * branch's set.
- * Fingerprints are deduped WITHIN a branch first (sequential same-source nodes — or the same
- * source on two ALTERNATIVE paths of one branch — are not a parallel conflict) and then compared
- * across branches. FE mirror: apps/web/src/approvals/parallelEdit.ts
+ * branch — NOT just the first-outgoing-edge chain. Condition successors match
+ * `resolveConditionTarget` / `collectBranchAssignees`: configured `branches[].edgeKey` +
+ * `defaultEdgeKey` when present; when default is ABSENT, configured rule edges plus the first
+ * outgoing fallback. Stray outgoing edges beyond that fallback are never walked. Linear nodes follow
+ * the first outgoing edge. The branch's fingerprint set is the UNION over all condition paths up
+ * to the join node, and a conflict is flagged when SOME path through one branch and SOME path
+ * through another carry the identical dynamic source — exactly the pairings for which the runtime
+ * 409 is reachable. Cycles are cut with a per-branch visited set. A nested parallel node
+ * (normalize rejects it on authoring paths; a legacy graph could still carry one) is treated
+ * defensively as a PASS-THROUGH fan-out over its configured `branches` edgeKeys (all
+ * simultaneously active). Fingerprints are deduped WITHIN a branch first (sequential same-source
+ * nodes — or the same source on two ALTERNATIVE paths of one branch — are not a parallel
+ * conflict) and then compared across branches. FE mirror: apps/web/src/approvals/parallelEdit.ts
  * `parallelDynamicAssigneeConflicts` — SAME traversal, keep in lockstep.
  */
 function assertNoParallelDynamicAssigneeConflicts(approvalGraph: ApprovalGraph): void {
   const edgeByKey = new Map(approvalGraph.edges.map((edge) => [edge.key, edge]))
-  const outgoingTargets = new Map<string, string[]>()
+  const outgoingBySource = new Map<string, ApprovalGraph['edges']>()
   for (const edge of approvalGraph.edges) {
-    const targets = outgoingTargets.get(edge.source)
-    if (targets) targets.push(edge.target)
-    else outgoingTargets.set(edge.source, [edge.target])
+    const existing = outgoingBySource.get(edge.source)
+    if (existing) existing.push(edge)
+    else outgoingBySource.set(edge.source, [edge])
   }
   const nodeByKey = new Map(approvalGraph.nodes.map((node) => [node.key, node]))
   for (const node of approvalGraph.nodes) {
@@ -1370,15 +1374,8 @@ function assertNoParallelDynamicAssigneeConflicts(approvalGraph: ApprovalGraph):
             if (fingerprint && !branchFingerprints.has(fingerprint)) branchFingerprints.set(fingerprint, current.key)
           }
         }
-        const targets = outgoingTargets.get(currentKey) ?? []
-        if (current.type === 'condition' || current.type === 'parallel') {
-          // Condition: EVERY outgoing edge (each rules branch + the default) is a possible runtime
-          // path. Parallel (defensive — see doc above): pass-through fan-out over all sub-branches.
-          for (const target of targets) queue.push(target)
-        } else if (targets.length > 0) {
-          // Linear node — follow its first outgoing edge, as before.
-          queue.push(targets[0])
-        }
+        const targets = runtimeSuccessorTargets(current, edgeByKey, outgoingBySource)
+        for (const target of targets) queue.push(target)
       }
       for (const [fingerprint, carrierNodeKey] of branchFingerprints) {
         const priorNodeKey = seenAcrossBranches.get(fingerprint)
@@ -1394,6 +1391,73 @@ function assertNoParallelDynamicAssigneeConflicts(approvalGraph: ApprovalGraph):
       }
     }
   }
+}
+
+/**
+ * Runtime-possible successor node keys for a walk that must match
+ * `ApprovalGraphExecutor.resolveConditionTarget` / `firstTargetForNode`:
+ *   - condition: declared branches[].edgeKey + defaultEdgeKey (when set); if default is
+ *     ABSENT, also the first outgoing fallback. Other stray edges are ignored. EdgeKeys that do not
+ *     resolve to an edge sourced by this node are skipped (authoring's collectBranchAssignees
+ *     fails hard on the same shape; this helper is also used by the publish dynamic-conflict
+ *     walk where a skip is safe).
+ *   - parallel (defensive nested): configured branches[] edgeKeys only.
+ *   - linear: first outgoing edge only.
+ */
+function runtimeSuccessorTargets(
+  node: ApprovalGraph['nodes'][number],
+  edgeByKey: Map<string, ApprovalGraph['edges'][number]>,
+  outgoingBySource: Map<string, ApprovalGraph['edges']>,
+): string[] {
+  if (node.type === 'condition') {
+    const config = node.config as {
+      branches?: Array<{ edgeKey?: string }>
+      defaultEdgeKey?: string
+    }
+    const declaredKeys: string[] = []
+    const seenKeys = new Set<string>()
+    const pushKey = (raw: string | undefined): void => {
+      if (typeof raw !== 'string') return
+      const key = raw.trim()
+      if (!key || seenKeys.has(key)) return
+      seenKeys.add(key)
+      declaredKeys.push(key)
+    }
+    for (const branch of config.branches ?? []) {
+      pushKey(branch.edgeKey)
+    }
+    const hasDefault = typeof config.defaultEdgeKey === 'string' && config.defaultEdgeKey.trim().length > 0
+    if (hasDefault) {
+      pushKey(config.defaultEdgeKey)
+    }
+
+    const targets: string[] = []
+    for (const edgeKey of declaredKeys) {
+      const edge = edgeByKey.get(edgeKey)
+      if (!edge || edge.source !== node.key) continue
+      targets.push(edge.target)
+    }
+    if (!hasDefault) {
+      const firstEdge = outgoingBySource.get(node.key)?.[0]
+      if (firstEdge && !seenKeys.has(firstEdge.key)) {
+        targets.push(firstEdge.target)
+      }
+    }
+    return targets
+  }
+
+  if (node.type === 'parallel') {
+    const config = node.config as { branches?: string[] }
+    const targets: string[] = []
+    for (const branchEdgeKey of config.branches ?? []) {
+      const edge = edgeByKey.get(branchEdgeKey)
+      if (edge && edge.source === node.key) targets.push(edge.target)
+    }
+    return targets
+  }
+
+  const firstEdge = outgoingBySource.get(node.key)?.[0]
+  return firstEdge ? [firstEdge.target] : []
 }
 
 /**
@@ -1700,12 +1764,11 @@ function normalizeApprovalGraph(
       )
     }
 
-    // Collect static assignees on EVERY runtime-possible path from each branch
-    // start up to the join (see collectBranchAssignees: conditions fan out over
-    // all rules/default edges). Also structurally proves each path reaches the
-    // join — rejects end/dead-end/cycle/nested-parallel before join. Cross-branch
-    // duplicate assigneeIds are then rejected (active-assignment unique index
-    // cannot hold two active rows for the same user at once).
+    // Stored graphs keep the historical first-edge compatibility check here.
+    // New writes and publish additionally run validateAllParallelBranchPaths via
+    // assertApprovalGraph; keeping the strict gate out of normalizeApprovalGraph
+    // prevents a newly-tightened rule from bricking ordinary reads or in-flight
+    // instances created from a previously accepted graph.
     const assigneesPerBranch: Array<Set<string>> = []
     for (const branchEdgeKey of parallelConfig.branches) {
       const edge = edgeMap.get(branchEdgeKey)!
@@ -1778,6 +1841,66 @@ function collectBranchAssignees(
   edges: ApprovalGraph['edges'],
   context: ValidationContext,
 ): Set<string> {
+  const assignees = new Set<string>()
+  const outgoing = new Map<string, ApprovalGraph['edges']>()
+  for (const edge of edges) {
+    const existing = outgoing.get(edge.source) || []
+    existing.push(edge)
+    outgoing.set(edge.source, existing)
+  }
+
+  const visited = new Set<string>()
+  let currentKey: string | null = startNodeKey
+  while (currentKey) {
+    if (currentKey === joinNodeKey) return assignees
+    if (visited.has(currentKey)) {
+      failValidation(context, `approvalGraph parallel branch contains a cycle near ${currentKey}`)
+    }
+    visited.add(currentKey)
+    const node = nodeByKey.get(currentKey)
+    if (!node) {
+      failValidation(context, `approvalGraph parallel branch references unknown node ${currentKey}`)
+    }
+    if (node.type === 'parallel') {
+      failValidation(context, `approvalGraph parallel branch cannot contain nested parallel node ${node.key}`)
+    }
+    if (node.type === 'end') {
+      failValidation(context, `approvalGraph parallel branch must reach join before end (at ${node.key})`)
+    }
+    if (node.type === 'approval') {
+      const config = node.config as {
+        assigneeIds?: string[]
+        assigneeSources?: ApprovalAssigneeSource[]
+        approvalMode?: ApprovalMode
+      }
+      if (config.approvalMode === 'threshold') {
+        throw new ServiceError(
+          `approvalGraph node ${node.key} uses approvalMode 'threshold' inside a parallel region — threshold mode is linear-only in v1`,
+          400,
+          'APPROVAL_THRESHOLD_IN_PARALLEL',
+        )
+      }
+      config.assigneeIds?.forEach((assignee) => assignees.add(assignee))
+      for (const source of config.assigneeSources ?? []) {
+        if (source.kind === 'static_user') source.userIds.forEach((assignee) => assignees.add(assignee))
+        if (source.kind === 'static_role') source.roleIds.forEach((assignee) => assignees.add(assignee))
+      }
+    }
+    currentKey = outgoing.get(currentKey)?.[0]?.target ?? null
+  }
+  failValidation(
+    context,
+    `approvalGraph parallel branch starting near ${startNodeKey} never reaches join ${joinNodeKey}`,
+  )
+}
+
+function collectAllBranchAssignees(
+  startNodeKey: string,
+  joinNodeKey: string,
+  nodeByKey: Map<string, ApprovalGraph['nodes'][number]>,
+  edges: ApprovalGraph['edges'],
+  context: ValidationContext,
+): Set<string> {
   const outgoing = new Map<string, ApprovalGraph['edges']>()
   const edgeByKey = new Map<string, ApprovalGraph['edges'][number]>()
   for (const edge of edges) {
@@ -1787,10 +1910,9 @@ function collectBranchAssignees(
     edgeByKey.set(edge.key, edge)
   }
 
-  // Per-branch tri-color state. DONE memo is the static-assignee UNION of the
-  // node-to-join subgraph (self + every runtime-possible descendant); re-entry from
-  // a convergent arm reuses it instead of rewalking.
-  const visiting = new Set<string>()
+  // Per-branch tri-color state. The explicit stack avoids JS call-stack overflow
+  // on a valid deeply-nested condition chain while preserving O(V+E) memoization.
+  const visitState = new Map<string, 'visiting' | 'done'>()
   const doneMemo = new Map<string, Set<string>>()
 
   const localApprovalAssignees = (node: ApprovalGraph['nodes'][number]): string[] => {
@@ -1878,16 +2000,20 @@ function collectBranchAssignees(
     return targets
   }
 
-  /** Returns the memoized static-assignee set for `currentKey` → join (inclusive of self). */
-  const walk = (currentKey: string): Set<string> => {
-    if (currentKey === joinNodeKey) return new Set()
+  interface WalkFrame {
+    key: string
+    targets: string[]
+    nextTargetIndex: number
+    result: Set<string>
+  }
 
-    const memoized = doneMemo.get(currentKey)
-    if (memoized) return memoized
-
-    if (visiting.has(currentKey)) {
+  const stack: WalkFrame[] = []
+  const pushNode = (currentKey: string): void => {
+    if (currentKey === joinNodeKey) return
+    if (visitState.get(currentKey) === 'visiting') {
       failValidation(context, `approvalGraph parallel branch contains a cycle near ${currentKey}`)
     }
+    if (visitState.get(currentKey) === 'done') return
 
     const node = nodeByKey.get(currentKey)
     if (!node) {
@@ -1897,48 +2023,96 @@ function collectBranchAssignees(
       failValidation(context, `approvalGraph parallel branch cannot contain nested parallel node ${node.key}`)
     }
     if (node.type === 'end') {
+      failValidation(context, `approvalGraph parallel branch must reach join before end (at ${node.key})`)
+    }
+
+    const targets = node.type === 'condition'
+      ? conditionSuccessorTargets(node)
+      : (outgoing.get(currentKey)?.[0] ? [outgoing.get(currentKey)![0].target] : [])
+    if (targets.length === 0) {
       failValidation(
         context,
-        `approvalGraph parallel branch must reach join before end (at ${node.key})`,
+        `approvalGraph parallel branch starting near ${startNodeKey} never reaches join ${joinNodeKey}`,
       )
     }
 
-    visiting.add(currentKey)
-    try {
-      const result = new Set(localApprovalAssignees(node))
-      const nextEdges = outgoing.get(currentKey) ?? []
+    visitState.set(currentKey, 'visiting')
+    stack.push({
+      key: currentKey,
+      targets,
+      nextTargetIndex: 0,
+      result: new Set(localApprovalAssignees(node)),
+    })
+  }
 
-      if (node.type === 'condition') {
-        const targets = conditionSuccessorTargets(node)
-        if (targets.length === 0) {
-          failValidation(
-            context,
-            `approvalGraph parallel branch starting near ${startNodeKey} never reaches join ${joinNodeKey}`,
-          )
-        }
-        for (const target of targets) {
-          for (const assignee of walk(target)) result.add(assignee)
-        }
-      } else {
-        // Linear node — sole runtime successor is the first outgoing edge.
-        const nextKey = nextEdges[0]?.target
-        if (!nextKey) {
-          failValidation(
-            context,
-            `approvalGraph parallel branch starting near ${startNodeKey} never reaches join ${joinNodeKey}`,
-          )
-        }
-        for (const assignee of walk(nextKey)) result.add(assignee)
+  pushNode(startNodeKey)
+  while (stack.length > 0) {
+    const frame = stack[stack.length - 1]
+    if (frame.nextTargetIndex < frame.targets.length) {
+      const target = frame.targets[frame.nextTargetIndex]
+      frame.nextTargetIndex += 1
+      if (target === joinNodeKey) continue
+      const targetState = visitState.get(target)
+      if (targetState === 'visiting') {
+        failValidation(context, `approvalGraph parallel branch contains a cycle near ${target}`)
       }
+      if (targetState === 'done') {
+        for (const assignee of doneMemo.get(target) ?? []) frame.result.add(assignee)
+        continue
+      }
+      pushNode(target)
+      continue
+    }
 
-      doneMemo.set(currentKey, result)
-      return result
-    } finally {
-      visiting.delete(currentKey)
+    stack.pop()
+    visitState.set(frame.key, 'done')
+    doneMemo.set(frame.key, frame.result)
+    const parent = stack[stack.length - 1]
+    if (parent) {
+      for (const assignee of frame.result) parent.result.add(assignee)
     }
   }
 
-  return walk(startNodeKey)
+  return doneMemo.get(startNodeKey) ?? new Set()
+}
+
+function validateAllParallelBranchPaths(
+  approvalGraph: ApprovalGraph,
+  context: ValidationContext,
+  options: { allowParallelDuplicateAssignees?: boolean } = {},
+): void {
+  const edgeMap = new Map(approvalGraph.edges.map((edge) => [edge.key, edge]))
+  const nodeByKey = new Map(approvalGraph.nodes.map((node) => [node.key, node]))
+  for (const node of approvalGraph.nodes) {
+    if (node.type !== 'parallel') continue
+    const config = node.config as { branches: string[]; joinNodeKey: string }
+    const assigneesPerBranch = config.branches.map((branchEdgeKey) => {
+      const edge = edgeMap.get(branchEdgeKey)
+      if (!edge || edge.source !== node.key) {
+        failValidation(context, `approvalGraph parallel node ${node.key} references unknown branch edge ${branchEdgeKey}`)
+      }
+      return collectAllBranchAssignees(
+        edge.target,
+        config.joinNodeKey,
+        nodeByKey,
+        approvalGraph.edges,
+        context,
+      )
+    })
+    if (options.allowParallelDuplicateAssignees) continue
+    const seen = new Set<string>()
+    for (const branchAssignees of assigneesPerBranch) {
+      for (const assignee of branchAssignees) {
+        if (seen.has(assignee)) {
+          failValidation(
+            context,
+            `approvalGraph parallel node ${node.key} has duplicate approver '${assignee}' across branches`,
+          )
+        }
+        seen.add(assignee)
+      }
+    }
+  }
 }
 
 function asApprovalGraph(value: Record<string, unknown>): ApprovalGraph {
@@ -2256,7 +2430,9 @@ function assertApprovalGraph(
   context: ValidationContext = REQUEST_VALIDATION_CONTEXT,
   options?: { allowParallelDuplicateAssignees?: boolean },
 ): ApprovalGraph {
-  return normalizeApprovalGraph(value, context, options)
+  const graph = normalizeApprovalGraph(value, context, options)
+  validateAllParallelBranchPaths(graph, context, options)
+  return graph
 }
 
 function asFormSchema(value: Record<string, unknown>): FormSchema {
@@ -2294,7 +2470,10 @@ function asRuntimeGraph(value: Record<string, unknown>): RuntimeGraph {
   }
 
   const policy = assertRuntimePolicy(value.policy, STORED_RUNTIME_CONTEXT)
-  const graph = assertApprovalGraph(
+  // Published runtime graphs may predate the all-path authoring gate. Preserve
+  // their historical first-edge validation so reads and in-flight execution do
+  // not become retroactively unavailable after a validator tightening.
+  const graph = normalizeApprovalGraph(
     {
       nodes: value.nodes,
       edges: value.edges,
@@ -3343,7 +3522,13 @@ export class ApprovalProductService {
         const nextVersion = Number.parseInt(maxVersionResult.rows[0]?.max_version || '0', 10) + 1
 
         const nextFormSchema = formSchema ?? asFormSchema(latestVersion.form_schema)
-        const nextApprovalGraph = approvalGraph ?? asApprovalGraph(latestVersion.approval_graph)
+        // A form-only edit still creates a NEW template version. Re-validate the
+        // copied historical graph under current authoring rules before writing it;
+        // ordinary reads remain on asApprovalGraph's compatibility path.
+        const nextApprovalGraph = assertApprovalGraph(
+          approvalGraph ?? asApprovalGraph(latestVersion.approval_graph),
+          REQUEST_VALIDATION_CONTEXT,
+        )
         validateApprovalAssigneeSourcesAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
         validateNodeFieldPermissionsAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
         validateApprovalConditionFormulasAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
@@ -3446,7 +3631,14 @@ export class ApprovalProductService {
       )
 
       const formSchema = asFormSchema(version.form_schema)
-      const approvalGraph = asApprovalGraph(version.approval_graph)
+      const storedApprovalGraph = asApprovalGraph(version.approval_graph)
+      // Publishing is a write choke point: historical drafts stay readable, but
+      // must satisfy the current all-runtime-path contract before activation.
+      const approvalGraph = assertApprovalGraph(
+        storedApprovalGraph,
+        REQUEST_VALIDATION_CONTEXT,
+        { allowParallelDuplicateAssignees: policy.autoApproval?.mergeAdjacentApprover === true },
+      )
       validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
       validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
       // RA-1b CURATED-VOCABULARY — THE HARD GATE. Only when the graph actually routes on requester.role do

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1700,10 +1700,12 @@ function normalizeApprovalGraph(
       )
     }
 
-    // Collect the approval-node assignees reachable from each branch start up to
-    // the join node. Reject duplicate assigneeIds across branches because the
-    // active-assignment unique index cannot hold two active rows for the same
-    // user at once. Nested parallel is explicitly rejected in v1.
+    // Collect static assignees on EVERY runtime-possible path from each branch
+    // start up to the join (see collectBranchAssignees: conditions fan out over
+    // all rules/default edges). Also structurally proves each path reaches the
+    // join — rejects end/dead-end/cycle/nested-parallel before join. Cross-branch
+    // duplicate assigneeIds are then rejected (active-assignment unique index
+    // cannot hold two active rows for the same user at once).
     const assigneesPerBranch: Array<Set<string>> = []
     for (const branchEdgeKey of parallelConfig.branches) {
       const edge = edgeMap.get(branchEdgeKey)!
@@ -1735,6 +1737,40 @@ function normalizeApprovalGraph(
   return { nodes, edges }
 }
 
+/**
+ * Structural walk of ONE parallel branch: prove every runtime-possible path from
+ * `startNodeKey` reaches `joinNodeKey`, and collect static assignees along the way
+ * (UNION over all paths — feeds the cross-branch duplicate-approver check).
+ *
+ * Runtime semantics (mirrored here so create/update/publish catch shapes that would
+ * only fail mid-request) — see `ApprovalGraphExecutor.resolveConditionTarget`:
+ *   - condition nodes: successors are the DEDUPLICATED set of
+ *     `config.branches[].edgeKey` plus `config.defaultEdgeKey` when present.
+ *     Each declared edgeKey must exist AND have `source ===` this condition node
+ *     (`targetForEdge` is a global key lookup, so a key owned by another node is
+ *     malformed and must fail authoring rather than route elsewhere). When
+ *     default is ABSENT, also include the first outgoing edge
+ *     (`firstTargetForNode` fallback). Stray outgoing edges NOT referenced by
+ *     config are NOT runtime-possible and must not be walked (they must not
+ *     false-fail a valid branch).
+ *   - linear nodes (approval/cc/start/…): follow the first outgoing edge only,
+ *     matching `firstTargetForNode`.
+ *   - reject end / unknown / nested parallel / cycle / dead-end before join with
+ *     the same failValidation messages as before (stable codes via ValidationContext).
+ *
+ * Complexity (tri-color / memoized per branch — required: no graph node-count cap):
+ *   - VISITING (gray): node is on the active DFS stack → true back-edge / cycle.
+ *   - DONE (black): node-to-join subgraph already proven; return the memoized static-
+ *     assignee set (self ∪ descendants) without rewalking.
+ *   - Convergent DAG diamonds therefore cost O(V+E) per branch, not O(paths). A pure
+ *     path-local rewalk is exponential on layered diamonds (2^N path recomputations of
+ *     the shared tail) and is rejected by the layered-DAG regression test.
+ *
+ * Mutation: reverting the condition arm to `outgoing[current][0]` only REDs the
+ * exact golden in approval-product-service.test.ts (default edge → end while the
+ * first rules edge joins). Dropping DONE memoization REDs the layered-diamond
+ * acceptance (or hangs) while leaving the golden green.
+ */
 function collectBranchAssignees(
   startNodeKey: string,
   joinNodeKey: string,
@@ -1742,22 +1778,117 @@ function collectBranchAssignees(
   edges: ApprovalGraph['edges'],
   context: ValidationContext,
 ): Set<string> {
-  const assignees = new Set<string>()
   const outgoing = new Map<string, ApprovalGraph['edges']>()
+  const edgeByKey = new Map<string, ApprovalGraph['edges'][number]>()
   for (const edge of edges) {
     const existing = outgoing.get(edge.source) || []
     existing.push(edge)
     outgoing.set(edge.source, existing)
+    edgeByKey.set(edge.key, edge)
   }
 
-  const visited = new Set<string>()
-  let currentKey: string | null = startNodeKey
-  while (currentKey) {
-    if (currentKey === joinNodeKey) return assignees
-    if (visited.has(currentKey)) {
+  // Per-branch tri-color state. DONE memo is the static-assignee UNION of the
+  // node-to-join subgraph (self + every runtime-possible descendant); re-entry from
+  // a convergent arm reuses it instead of rewalking.
+  const visiting = new Set<string>()
+  const doneMemo = new Map<string, Set<string>>()
+
+  const localApprovalAssignees = (node: ApprovalGraph['nodes'][number]): string[] => {
+    if (node.type !== 'approval') return []
+    const approvalConfig = node.config as {
+      assigneeIds?: string[]
+      assigneeSources?: ApprovalAssigneeSource[]
+      approvalMode?: ApprovalMode
+    }
+    // T2-4: threshold mode is linear-only in v1 — reject a 'threshold' approval node nested
+    // inside a parallel region (distinct ServiceError code, mirrors the nested-parallel guard).
+    if (approvalConfig.approvalMode === 'threshold') {
+      throw new ServiceError(
+        `approvalGraph node ${node.key} uses approvalMode 'threshold' inside a parallel region — threshold mode is linear-only in v1`,
+        400,
+        'APPROVAL_THRESHOLD_IN_PARALLEL',
+      )
+    }
+    const local: string[] = []
+    for (const assignee of approvalConfig.assigneeIds ?? []) {
+      local.push(assignee)
+    }
+    for (const source of approvalConfig.assigneeSources ?? []) {
+      if (source.kind === 'static_user') {
+        source.userIds.forEach((assignee) => local.push(assignee))
+      }
+      if (source.kind === 'static_role') {
+        source.roleIds.forEach((assignee) => local.push(assignee))
+      }
+    }
+    return local
+  }
+
+  /**
+   * Runtime-possible condition successors — mirrors resolveConditionTarget's edge
+   * selection (rules arms + default, else firstTarget), with authoring ownership
+   * checks so a mis-owned edgeKey cannot silently route via global key lookup.
+   */
+  const conditionSuccessorTargets = (node: ApprovalGraph['nodes'][number]): string[] => {
+    const config = node.config as {
+      branches?: Array<{ edgeKey?: string }>
+      defaultEdgeKey?: string
+    }
+    const declaredKeys: string[] = []
+    const seenKeys = new Set<string>()
+    const pushKey = (raw: string | undefined): void => {
+      if (typeof raw !== 'string') return
+      const key = raw.trim()
+      if (!key || seenKeys.has(key)) return
+      seenKeys.add(key)
+      declaredKeys.push(key)
+    }
+    for (const branch of config.branches ?? []) {
+      pushKey(branch.edgeKey)
+    }
+    const hasDefault = typeof config.defaultEdgeKey === 'string' && config.defaultEdgeKey.trim().length > 0
+    if (hasDefault) {
+      pushKey(config.defaultEdgeKey)
+    }
+
+    const targets: string[] = []
+    for (const edgeKey of declaredKeys) {
+      const edge = edgeByKey.get(edgeKey)
+      // Global targetForEdge would still return a foreign-source edge's target; reject
+      // that malformed config at authoring instead of treating it as a legal route.
+      if (!edge || edge.source !== node.key) {
+        failValidation(
+          context,
+          `approvalGraph parallel branch condition ${node.key} references invalid edge ${edgeKey}`,
+        )
+      }
+      targets.push(edge.target)
+    }
+
+    // resolveConditionTarget: default ABSENT → firstTargetForNode fallback only.
+    // Stray outgoing edges beyond the first are never selected when default is set,
+    // and when default is absent only the first outgoing is the fallback — never a
+    // non-declared non-first edge.
+    if (!hasDefault) {
+      const firstEdge = outgoing.get(node.key)?.[0]
+      if (firstEdge && !seenKeys.has(firstEdge.key)) {
+        targets.push(firstEdge.target)
+      }
+    }
+    return targets
+  }
+
+  /** Returns the memoized static-assignee set for `currentKey` → join (inclusive of self). */
+  const walk = (currentKey: string): Set<string> => {
+    if (currentKey === joinNodeKey) return new Set()
+
+    const memoized = doneMemo.get(currentKey)
+    if (memoized) return memoized
+
+    if (visiting.has(currentKey)) {
       failValidation(context, `approvalGraph parallel branch contains a cycle near ${currentKey}`)
     }
-    visited.add(currentKey)
+
     const node = nodeByKey.get(currentKey)
     if (!node) {
       failValidation(context, `approvalGraph parallel branch references unknown node ${currentKey}`)
@@ -1771,45 +1902,43 @@ function collectBranchAssignees(
         `approvalGraph parallel branch must reach join before end (at ${node.key})`,
       )
     }
-    if (node.type === 'approval') {
-      const approvalConfig = node.config as {
-        assigneeIds?: string[]
-        assigneeSources?: ApprovalAssigneeSource[]
-        approvalMode?: ApprovalMode
-      }
-      // T2-4: threshold mode is linear-only in v1 — reject a 'threshold' approval node nested
-      // inside a parallel region (distinct ServiceError code, mirrors the nested-parallel guard).
-      if (approvalConfig.approvalMode === 'threshold') {
-        throw new ServiceError(
-          `approvalGraph node ${node.key} uses approvalMode 'threshold' inside a parallel region — threshold mode is linear-only in v1`,
-          400,
-          'APPROVAL_THRESHOLD_IN_PARALLEL',
-        )
-      }
-      for (const assignee of approvalConfig.assigneeIds ?? []) {
-        assignees.add(assignee)
-      }
-      for (const source of approvalConfig.assigneeSources ?? []) {
-        if (source.kind === 'static_user') {
-          source.userIds.forEach((assignee) => assignees.add(assignee))
+
+    visiting.add(currentKey)
+    try {
+      const result = new Set(localApprovalAssignees(node))
+      const nextEdges = outgoing.get(currentKey) ?? []
+
+      if (node.type === 'condition') {
+        const targets = conditionSuccessorTargets(node)
+        if (targets.length === 0) {
+          failValidation(
+            context,
+            `approvalGraph parallel branch starting near ${startNodeKey} never reaches join ${joinNodeKey}`,
+          )
         }
-        if (source.kind === 'static_role') {
-          source.roleIds.forEach((assignee) => assignees.add(assignee))
+        for (const target of targets) {
+          for (const assignee of walk(target)) result.add(assignee)
         }
+      } else {
+        // Linear node — sole runtime successor is the first outgoing edge.
+        const nextKey = nextEdges[0]?.target
+        if (!nextKey) {
+          failValidation(
+            context,
+            `approvalGraph parallel branch starting near ${startNodeKey} never reaches join ${joinNodeKey}`,
+          )
+        }
+        for (const assignee of walk(nextKey)) result.add(assignee)
       }
+
+      doneMemo.set(currentKey, result)
+      return result
+    } finally {
+      visiting.delete(currentKey)
     }
-    // Walk the first outgoing edge — condition nodes aren't explored for every
-    // branch here (the form-data isn't available at template validation
-    // time), so duplicate detection is conservative across the statically
-    // reachable first-edge path. Condition branches inside parallel remain
-    // legal at runtime; this check only flags obvious overlaps.
-    const nextEdge = outgoing.get(currentKey)?.[0]
-    currentKey = nextEdge?.target ?? null
   }
-  failValidation(
-    context,
-    `approvalGraph parallel branch starting near ${startNodeKey} never reaches join ${joinNodeKey}`,
-  )
+
+  return walk(startNodeKey)
 }
 
 function asApprovalGraph(value: Record<string, unknown>): ApprovalGraph {

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -2613,6 +2613,37 @@ describe('ApprovalProductService', () => {
       })
     })
 
+    it('GOLDEN: clone rejects a readable historical graph before creating a new draft version', async () => {
+      const graph = goldenDefaultEndsBeforeJoinGraph()
+      const template = {
+        id: 'tpl-join-reach', key: 'join-reach', name: 'Join Reach', description: null, category: null,
+        visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+        active_version_id: null, latest_version_id: 'ver-join-reach', created_at: new Date(), updated_at: new Date(),
+      }
+      const version = {
+        id: 'ver-join-reach', template_id: 'tpl-join-reach', version: 1, status: 'draft',
+        form_schema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] }, approval_graph: graph,
+        created_at: new Date(), updated_at: new Date(),
+      }
+      pgState.pool.query.mockImplementation(async (sql: string) => {
+        const statement = normalize(sql)
+        if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1')) {
+          return { rows: [template], rowCount: 1 }
+        }
+        if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) {
+          return { rows: [version], rowCount: 1 }
+        }
+        if (statement.startsWith('SELECT * FROM approval_published_definitions')) {
+          return { rows: [], rowCount: 0 }
+        }
+        throw new Error(`Unhandled pool query: ${statement}`)
+      })
+
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(new ApprovalProductService().cloneTemplate('tpl-join-reach')).rejects.toMatchObject(goldenReject)
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
     it('compatibility GOLDEN: ordinary reads still return a historical first-edge-valid graph', async () => {
       const graph = goldenDefaultEndsBeforeJoinGraph()
       const template = {

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -2381,6 +2381,621 @@ describe('ApprovalProductService', () => {
     })
   })
 
+  describe('parallel branch all-path join reachability (normalize / author)', () => {
+    // Structural gate inside collectBranchAssignees / normalizeApprovalGraph: every
+    // runtime-possible path through a parallel branch must reach the configured join.
+    // The prior first-outgoing-edge-only walk accepted templates where a condition's
+    // FIRST rules edge joined while a non-first / default edge hit end (or dead-ended /
+    // nested-parallel / cycled); create/update/publish went green, then a request that
+    // selected the alternate edge failed before insert with
+    // "Parallel branch terminated at an end node before reaching join".
+    //
+    // Mutation proof: reverting collectBranchAssignees to first-edge-only
+    // (`outgoing.get(current)?.[0]` only, no config-declared condition fan-out) REDs the
+    // exact GOLDEN below (and the symmetric non-first-rules failure). Convergent-DAG +
+    // all-paths-join positives stay green either way; nested-parallel/cycle-on-non-first
+    // negatives also RED under first-edge-only (they sit behind the non-first arm).
+    // Complexity mutation: drop DONE memoization (path-local rewalk only) hangs the
+    // layered-diamond acceptance (2^24 shared-tail recomputations) while the single-
+    // diamond convergent control still passes.
+    // Condition-successor mutation: walking ALL graph outgoing edges (instead of
+    // config.branches[].edgeKey + defaultEdgeKey, with firstTarget only when default is
+    // absent) REDs the stray-outgoing positive and may false-green foreign-owned edgeKeys.
+
+    function mockCreateInsert(templateKey: string) {
+      pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+        const statement = normalize(sql)
+        if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+          return { rows: [], rowCount: 0 }
+        }
+        if (statement.startsWith('INSERT INTO approval_templates')) {
+          return {
+            rows: [{
+              id: 'tpl-join-reach',
+              key: String(params?.[0]),
+              name: String(params?.[1]),
+              description: null,
+              category: null,
+              visibility_scope: JSON.parse(String(params?.[4])),
+              sla_hours: null,
+              status: 'draft',
+              active_version_id: null,
+              latest_version_id: null,
+              created_at: new Date('2026-06-29T00:00:00.000Z'),
+              updated_at: new Date('2026-06-29T00:00:00.000Z'),
+            }],
+            rowCount: 1,
+          }
+        }
+        if (statement.startsWith('INSERT INTO approval_template_versions')) {
+          return {
+            rows: [{
+              id: 'ver-join-reach',
+              template_id: 'tpl-join-reach',
+              version: 1,
+              status: 'draft',
+              form_schema: JSON.parse(String(params?.[1])),
+              approval_graph: JSON.parse(String(params?.[2])),
+              created_at: new Date('2026-06-29T00:00:00.000Z'),
+              updated_at: new Date('2026-06-29T00:00:00.000Z'),
+            }],
+            rowCount: 1,
+          }
+        }
+        if (statement.startsWith('UPDATE approval_templates')) {
+          return {
+            rows: [{
+              id: 'tpl-join-reach',
+              key: templateKey,
+              name: 'Join Reach Template',
+              description: null,
+              category: null,
+              visibility_scope: { type: 'all', ids: [] },
+              sla_hours: null,
+              status: 'draft',
+              active_version_id: null,
+              latest_version_id: 'ver-join-reach',
+              created_at: new Date('2026-06-29T00:00:00.000Z'),
+              updated_at: new Date('2026-06-29T00:00:00.000Z'),
+            }],
+            rowCount: 1,
+          }
+        }
+        { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
+      })
+    }
+
+    function mockPublish(graph: unknown) {
+      const template = {
+        id: 'tpl-join-reach', key: 'join-reach', name: 'Join Reach', description: null, category: null,
+        visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+        active_version_id: null, latest_version_id: 'ver-join-reach', created_at: new Date(), updated_at: new Date(),
+      }
+      const version = {
+        id: 'ver-join-reach', template_id: 'tpl-join-reach', version: 1, status: 'draft',
+        form_schema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] }, approval_graph: graph,
+        created_at: new Date(), updated_at: new Date(),
+      }
+      pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+        const statement = normalize(sql)
+        if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') return { rows: [], rowCount: 0 }
+        if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) return { rows: [template], rowCount: 1 }
+        if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) return { rows: [version], rowCount: 1 }
+        if (statement.startsWith('UPDATE approval_published_definitions SET is_active = FALSE')) return { rows: [], rowCount: 0 }
+        if (statement.startsWith('INSERT INTO approval_published_definitions')) {
+          return { rows: [{ id: 'pub-join-reach', template_id: 'tpl-join-reach', template_version_id: 'ver-join-reach', runtime_graph: JSON.parse(String(params?.[2])), is_active: true, published_at: new Date() }], rowCount: 1 }
+        }
+        if (statement.startsWith("UPDATE approval_template_versions SET status = 'published'")) return { rows: [{ ...version, status: 'published' }], rowCount: 1 }
+        if (statement.startsWith("UPDATE approval_templates SET status = 'published'")) return { rows: [], rowCount: 1 }
+        { const epochResult = epochMockResult(statement); if (epochResult) return epochResult } throw new Error(`Unhandled query: ${statement}`)
+      })
+    }
+
+    /**
+     * GOLDEN shape: parallel branch A starts at a condition whose FIRST (rules) edge
+     * reaches join via approval_high, but whose SECOND (default) edge reaches `end`
+     * without joining. Branch B is a plain approval → join. First-edge-only walks
+     * never see the default arm and accept the template.
+     */
+    function goldenDefaultEndsBeforeJoinGraph() {
+      return {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'fork', type: 'parallel', config: { branches: ['e-fork-cond', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+          {
+            key: 'cond_1',
+            type: 'condition',
+            config: {
+              branches: [{ edgeKey: 'e-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }],
+              defaultEdgeKey: 'e-cond-low',
+            },
+          },
+          { key: 'approval_high', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-high'] } },
+          { key: 'approval_low', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-low'] } },
+          { key: 'branch_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-b'] } },
+          { key: 'join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['final-1'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'e-start-fork', source: 'start', target: 'fork' },
+          { key: 'e-fork-cond', source: 'fork', target: 'cond_1' },
+          { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+          // Rules edge FIRST (joins), default edge SECOND (hits end) — first-edge-only is false-green.
+          { key: 'e-cond-high', source: 'cond_1', target: 'approval_high' },
+          { key: 'e-cond-low', source: 'cond_1', target: 'approval_low' },
+          { key: 'e-high-join', source: 'approval_high', target: 'join' },
+          { key: 'e-low-end', source: 'approval_low', target: 'end' },
+          { key: 'e-b-join', source: 'branch_b', target: 'join' },
+          { key: 'e-join-end', source: 'join', target: 'end' },
+        ],
+      }
+    }
+
+    const goldenReject = {
+      statusCode: 400,
+      code: 'VALIDATION_ERROR',
+      message: 'approvalGraph parallel branch must reach join before end (at end)',
+    }
+
+    it('GOLDEN: first condition edge joins, default edge reaches end → createTemplate rejects before DB', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate({
+        key: 'join-reach-golden',
+        name: 'Join Reach Golden',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: goldenDefaultEndsBeforeJoinGraph(),
+      } as never)).rejects.toMatchObject(goldenReject)
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
+    it('GOLDEN: same shape → updateTemplate rejects before DB', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.updateTemplate('tpl-join-reach', {
+        approvalGraph: goldenDefaultEndsBeforeJoinGraph(),
+      } as never)).rejects.toMatchObject(goldenReject)
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
+    it('GOLDEN: same shape → publishTemplate rejects (stored-graph normalize)', async () => {
+      // Publish re-normalizes the STORED draft via asApprovalGraph → STORED_GRAPH_CONTEXT
+      // (500 APPROVAL_TEMPLATE_GRAPH_INVALID), same message as the author-time gate.
+      mockPublish(goldenDefaultEndsBeforeJoinGraph())
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(
+        new ApprovalProductService().publishTemplate('tpl-join-reach', { policy: { allowRevoke: true } } as never),
+      ).rejects.toMatchObject({
+        statusCode: 500,
+        code: 'APPROVAL_TEMPLATE_GRAPH_INVALID',
+        message: 'approvalGraph parallel branch must reach join before end (at end)',
+      })
+    })
+
+    it('symmetric: non-first RULES edge reaches end (default joins) → create rejects', async () => {
+      // Two rules edges: first joins, second ends — default also joins. First-edge-only green;
+      // all-path must still reject the non-first rules arm.
+      const graph = {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'fork', type: 'parallel', config: { branches: ['e-fork-cond', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+          {
+            key: 'cond_1',
+            type: 'condition',
+            config: {
+              branches: [
+                { edgeKey: 'e-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 10000 }], conjunction: 'and' },
+                { edgeKey: 'e-cond-mid', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' },
+              ],
+              defaultEdgeKey: 'e-cond-low',
+            },
+          },
+          { key: 'approval_high', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-high'] } },
+          { key: 'approval_mid', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-mid'] } },
+          { key: 'approval_low', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-low'] } },
+          { key: 'branch_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-b'] } },
+          { key: 'join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['final-1'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'e-start-fork', source: 'start', target: 'fork' },
+          { key: 'e-fork-cond', source: 'fork', target: 'cond_1' },
+          { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+          { key: 'e-cond-high', source: 'cond_1', target: 'approval_high' },
+          { key: 'e-cond-mid', source: 'cond_1', target: 'approval_mid' },
+          { key: 'e-cond-low', source: 'cond_1', target: 'approval_low' },
+          { key: 'e-high-join', source: 'approval_high', target: 'join' },
+          { key: 'e-mid-end', source: 'approval_mid', target: 'end' },
+          { key: 'e-low-join', source: 'approval_low', target: 'join' },
+          { key: 'e-b-join', source: 'branch_b', target: 'join' },
+          { key: 'e-join-end', source: 'join', target: 'end' },
+        ],
+      }
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(new ApprovalProductService().createTemplate({
+        key: 'join-reach-rules-end',
+        name: 'Join Reach Rules End',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: graph,
+      } as never)).rejects.toMatchObject(goldenReject)
+    })
+
+    it('positive control: every condition alternative reaches join → create accepts', async () => {
+      const graph = goldenDefaultEndsBeforeJoinGraph()
+      // Fix the default arm: low → join instead of end.
+      graph.edges = graph.edges.map((edge) => (
+        edge.key === 'e-low-end' ? { ...edge, key: 'e-low-join', target: 'join' } : edge
+      ))
+      mockCreateInsert('join-reach-ok')
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().createTemplate({
+        key: 'join-reach-ok',
+        name: 'Join Reach OK',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: graph,
+      } as never)
+      expect(result.id).toBe('tpl-join-reach')
+      expect(result.approvalGraph.nodes.some((n) => n.key === 'fork' && n.type === 'parallel')).toBe(true)
+    })
+
+    it('positive control: convergent DAG (two condition arms rejoin a shared pre-join node) is NOT a cycle', async () => {
+      // cond → high → shared → join
+      //     ↘ low  ↗
+      // A global-visited cycle detector would false-positive when the second arm re-enters `shared`.
+      const graph = {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'fork', type: 'parallel', config: { branches: ['e-fork-cond', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+          {
+            key: 'cond_1',
+            type: 'condition',
+            config: {
+              branches: [{ edgeKey: 'e-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }],
+              defaultEdgeKey: 'e-cond-low',
+            },
+          },
+          { key: 'approval_high', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-high'] } },
+          { key: 'approval_low', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-low'] } },
+          { key: 'shared', type: 'cc', config: { targetType: 'user', targetIds: ['watcher-1'] } },
+          { key: 'branch_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-b'] } },
+          { key: 'join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['final-1'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'e-start-fork', source: 'start', target: 'fork' },
+          { key: 'e-fork-cond', source: 'fork', target: 'cond_1' },
+          { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+          { key: 'e-cond-high', source: 'cond_1', target: 'approval_high' },
+          { key: 'e-cond-low', source: 'cond_1', target: 'approval_low' },
+          { key: 'e-high-shared', source: 'approval_high', target: 'shared' },
+          { key: 'e-low-shared', source: 'approval_low', target: 'shared' },
+          { key: 'e-shared-join', source: 'shared', target: 'join' },
+          { key: 'e-b-join', source: 'branch_b', target: 'join' },
+          { key: 'e-join-end', source: 'join', target: 'end' },
+        ],
+      }
+      mockCreateInsert('join-reach-dag')
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().createTemplate({
+        key: 'join-reach-dag',
+        name: 'Join Reach DAG',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: graph,
+      } as never)
+      expect(result.id).toBe('tpl-join-reach')
+    })
+
+    it('positive control: layered convergent diamond DAG accepts in O(V+E) (memoized; pure path rewalk is exponential)', async () => {
+      // Complexity proof (deterministic, no wall-clock):
+      //   N stacked diamonds inside branch A:
+      //     cond_i ──► left_i  ──► merge_i ──► cond_{i+1} (or join)
+      //           └──► right_i ──┘
+      //   Path count = 2^N. A pure path-local DFS that rewalks shared tails on every
+      //   reconvergence evaluates the final merge 2^N times. With N=24 that is >16M
+      //   full tail recomputations and hangs the suite; the tri-color DONE memo evaluates
+      //   each node once (O(V+E) ≈ 3N + const), so createTemplate completes. N=24 is large
+      //   enough that non-memoized rewalk is practically impossible in the test budget,
+      //   without relying on a flaky timing assertion.
+      // Mutation: drop doneMemo short-circuit (keep path-local visiting only) → this test
+      // hangs / times out while the single-diamond convergent control still passes.
+      const LAYERS = 24
+      const nodes: Array<Record<string, unknown>> = [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'fork', type: 'parallel', config: { branches: ['e-fork-diamonds', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+        { key: 'branch_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-b'] } },
+        { key: 'join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['final-1'] } },
+        { key: 'end', type: 'end', config: {} },
+      ]
+      const edges: Array<{ key: string; source: string; target: string }> = [
+        { key: 'e-start-fork', source: 'start', target: 'fork' },
+        { key: 'e-fork-diamonds', source: 'fork', target: 'cond_0' },
+        { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+        { key: 'e-b-join', source: 'branch_b', target: 'join' },
+        { key: 'e-join-end', source: 'join', target: 'end' },
+      ]
+      for (let i = 0; i < LAYERS; i += 1) {
+        const condKey = `cond_${i}`
+        const leftKey = `left_${i}`
+        const rightKey = `right_${i}`
+        const mergeKey = `merge_${i}`
+        const nextKey = i + 1 < LAYERS ? `cond_${i + 1}` : 'join'
+        nodes.push(
+          {
+            key: condKey,
+            type: 'condition',
+            config: {
+              branches: [{ edgeKey: `e-${condKey}-left`, rules: [{ fieldId: 'amount', operator: 'gte', value: i }], conjunction: 'and' }],
+              defaultEdgeKey: `e-${condKey}-right`,
+            },
+          },
+          // Distinct static assignees per arm so a memoized UNION still sees every arm once;
+          // first-edge-only would miss all right_* ids, and path rewalk would re-collect them 2^i times.
+          { key: leftKey, type: 'approval', config: { assigneeType: 'user', assigneeIds: [`user-L${i}`] } },
+          { key: rightKey, type: 'approval', config: { assigneeType: 'user', assigneeIds: [`user-R${i}`] } },
+          { key: mergeKey, type: 'cc', config: { targetType: 'user', targetIds: [`watcher-${i}`] } },
+        )
+        edges.push(
+          { key: `e-${condKey}-left`, source: condKey, target: leftKey },
+          { key: `e-${condKey}-right`, source: condKey, target: rightKey },
+          { key: `e-${leftKey}-merge`, source: leftKey, target: mergeKey },
+          { key: `e-${rightKey}-merge`, source: rightKey, target: mergeKey },
+          { key: `e-${mergeKey}-next`, source: mergeKey, target: nextKey },
+        )
+      }
+      mockCreateInsert('join-reach-layered')
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().createTemplate({
+        key: 'join-reach-layered',
+        name: 'Join Reach Layered',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: { nodes, edges },
+      } as never)
+      expect(result.id).toBe('tpl-join-reach')
+      // Sanity: graph size is linear in LAYERS (memoized walk bound), not exponential.
+      expect(result.approvalGraph.nodes.length).toBe(5 + LAYERS * 4)
+    })
+
+    it('positive: stray outgoing edge NOT referenced by condition config must not fail a valid branch', async () => {
+      // Discriminator vs "walk every graph outgoing edge": config rules+default both join,
+      // but a stray edge from cond_1 → end sits in the edges array (not in branches /
+      // defaultEdgeKey). Runtime never selects it (resolveConditionTarget only uses
+      // declared edgeKeys + default / firstTarget), so authoring must stay green. Walking
+      // all outgoing would false-fail with "must reach join before end".
+      const graph = {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'fork', type: 'parallel', config: { branches: ['e-fork-cond', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+          {
+            key: 'cond_1',
+            type: 'condition',
+            config: {
+              branches: [{ edgeKey: 'e-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }],
+              defaultEdgeKey: 'e-cond-low',
+            },
+          },
+          { key: 'approval_high', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-high'] } },
+          { key: 'approval_low', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-low'] } },
+          { key: 'branch_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-b'] } },
+          { key: 'join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['final-1'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'e-start-fork', source: 'start', target: 'fork' },
+          { key: 'e-fork-cond', source: 'fork', target: 'cond_1' },
+          { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+          { key: 'e-cond-high', source: 'cond_1', target: 'approval_high' },
+          { key: 'e-cond-low', source: 'cond_1', target: 'approval_low' },
+          // Stray: same source as the condition, but NOT in config — must be ignored.
+          { key: 'e-cond-stray-end', source: 'cond_1', target: 'end' },
+          { key: 'e-high-join', source: 'approval_high', target: 'join' },
+          { key: 'e-low-join', source: 'approval_low', target: 'join' },
+          { key: 'e-b-join', source: 'branch_b', target: 'join' },
+          { key: 'e-join-end', source: 'join', target: 'end' },
+        ],
+      }
+      mockCreateInsert('join-reach-stray')
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().createTemplate({
+        key: 'join-reach-stray',
+        name: 'Join Reach Stray',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: graph,
+      } as never)
+      expect(result.id).toBe('tpl-join-reach')
+    })
+
+    it('negative: condition branch/default edgeKey owned by another node is rejected', async () => {
+      // resolveConditionTarget → targetForEdge looks up by key globally, so a defaultEdgeKey
+      // whose edge is sourced from branch_b would still return a target at runtime. Authoring
+      // must reject the malformed ownership rather than treat it as a legal condition route.
+      const graph = {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'fork', type: 'parallel', config: { branches: ['e-fork-cond', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+          {
+            key: 'cond_1',
+            type: 'condition',
+            config: {
+              branches: [{ edgeKey: 'e-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }],
+              // Foreign-owned: this edge's source is branch_b, not cond_1.
+              defaultEdgeKey: 'e-b-join',
+            },
+          },
+          { key: 'approval_high', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-high'] } },
+          { key: 'branch_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-b'] } },
+          { key: 'join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['final-1'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'e-start-fork', source: 'start', target: 'fork' },
+          { key: 'e-fork-cond', source: 'fork', target: 'cond_1' },
+          { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+          { key: 'e-cond-high', source: 'cond_1', target: 'approval_high' },
+          { key: 'e-high-join', source: 'approval_high', target: 'join' },
+          { key: 'e-b-join', source: 'branch_b', target: 'join' },
+          { key: 'e-join-end', source: 'join', target: 'end' },
+        ],
+      }
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(new ApprovalProductService().createTemplate({
+        key: 'join-reach-foreign-edge',
+        name: 'Join Reach Foreign Edge',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: graph,
+      } as never)).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
+        message: 'approvalGraph parallel branch condition cond_1 references invalid edge e-b-join',
+      })
+    })
+
+    it('negative: nested parallel on a NON-first condition path is rejected', async () => {
+      const graph = {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'fork', type: 'parallel', config: { branches: ['e-fork-cond', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+          {
+            key: 'cond_1',
+            type: 'condition',
+            config: {
+              branches: [{ edgeKey: 'e-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }],
+              defaultEdgeKey: 'e-cond-nested',
+            },
+          },
+          { key: 'approval_high', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-high'] } },
+          // Nested parallel sits only on the default arm (second outgoing edge).
+          {
+            key: 'nested_fork',
+            type: 'parallel',
+            config: { branches: ['e-nested-x', 'e-nested-y'], joinMode: 'all', joinNodeKey: 'join' },
+          },
+          { key: 'nested_x', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-x'] } },
+          { key: 'nested_y', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-y'] } },
+          { key: 'branch_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-b'] } },
+          { key: 'join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['final-1'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'e-start-fork', source: 'start', target: 'fork' },
+          { key: 'e-fork-cond', source: 'fork', target: 'cond_1' },
+          { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+          { key: 'e-cond-high', source: 'cond_1', target: 'approval_high' },
+          { key: 'e-cond-nested', source: 'cond_1', target: 'nested_fork' },
+          { key: 'e-high-join', source: 'approval_high', target: 'join' },
+          { key: 'e-nested-x', source: 'nested_fork', target: 'nested_x' },
+          { key: 'e-nested-y', source: 'nested_fork', target: 'nested_y' },
+          { key: 'e-nx-join', source: 'nested_x', target: 'join' },
+          { key: 'e-ny-join', source: 'nested_y', target: 'join' },
+          { key: 'e-b-join', source: 'branch_b', target: 'join' },
+          { key: 'e-join-end', source: 'join', target: 'end' },
+        ],
+      }
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(new ApprovalProductService().createTemplate({
+        key: 'join-reach-nested',
+        name: 'Join Reach Nested',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: graph,
+      } as never)).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
+        message: 'approvalGraph parallel branch cannot contain nested parallel node nested_fork',
+      })
+    })
+
+    it('negative: cycle on a NON-first condition path is rejected', async () => {
+      const graph = {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'fork', type: 'parallel', config: { branches: ['e-fork-cond', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+          {
+            key: 'cond_1',
+            type: 'condition',
+            config: {
+              branches: [{ edgeKey: 'e-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }],
+              defaultEdgeKey: 'e-cond-cycle',
+            },
+          },
+          { key: 'approval_high', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-high'] } },
+          { key: 'cycle_a', type: 'cc', config: { targetType: 'user', targetIds: ['watcher-a'] } },
+          { key: 'cycle_b', type: 'cc', config: { targetType: 'user', targetIds: ['watcher-b'] } },
+          { key: 'branch_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-b'] } },
+          { key: 'join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['final-1'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'e-start-fork', source: 'start', target: 'fork' },
+          { key: 'e-fork-cond', source: 'fork', target: 'cond_1' },
+          { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+          { key: 'e-cond-high', source: 'cond_1', target: 'approval_high' },
+          { key: 'e-cond-cycle', source: 'cond_1', target: 'cycle_a' },
+          { key: 'e-high-join', source: 'approval_high', target: 'join' },
+          { key: 'e-a-b', source: 'cycle_a', target: 'cycle_b' },
+          { key: 'e-b-a', source: 'cycle_b', target: 'cycle_a' },
+          { key: 'e-b-join', source: 'branch_b', target: 'join' },
+          { key: 'e-join-end', source: 'join', target: 'end' },
+        ],
+      }
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(new ApprovalProductService().createTemplate({
+        key: 'join-reach-cycle',
+        name: 'Join Reach Cycle',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: graph,
+      } as never)).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
+        message: 'approvalGraph parallel branch contains a cycle near cycle_a',
+      })
+    })
+
+    it('strengthens static duplicate-assignee collection across ALL condition paths', async () => {
+      // Branch A: rules arm → user-high (unique); default arm → user-shared.
+      // Branch B: user-shared. First-edge-only only saw user-high and accepted the overlap.
+      const graph = {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'fork', type: 'parallel', config: { branches: ['e-fork-cond', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+          {
+            key: 'cond_1',
+            type: 'condition',
+            config: {
+              branches: [{ edgeKey: 'e-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }],
+              defaultEdgeKey: 'e-cond-low',
+            },
+          },
+          { key: 'approval_high', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-high'] } },
+          { key: 'approval_low', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-shared'] } },
+          { key: 'branch_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-shared'] } },
+          { key: 'join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['final-1'] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'e-start-fork', source: 'start', target: 'fork' },
+          { key: 'e-fork-cond', source: 'fork', target: 'cond_1' },
+          { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+          { key: 'e-cond-high', source: 'cond_1', target: 'approval_high' },
+          { key: 'e-cond-low', source: 'cond_1', target: 'approval_low' },
+          { key: 'e-high-join', source: 'approval_high', target: 'join' },
+          { key: 'e-low-join', source: 'approval_low', target: 'join' },
+          { key: 'e-b-join', source: 'branch_b', target: 'join' },
+          { key: 'e-join-end', source: 'join', target: 'end' },
+        ],
+      }
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(new ApprovalProductService().createTemplate({
+        key: 'join-reach-dup',
+        name: 'Join Reach Dup',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: graph,
+      } as never)).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
+        message: "approvalGraph parallel node fork has duplicate approver 'user-shared' across branches",
+      })
+    })
+  })
+
   it('rejects empty assigneeSources and invalid form field sources before hitting the database', async () => {
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
     const service = new ApprovalProductService()

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -2371,6 +2371,48 @@ describe('ApprovalProductService', () => {
       })
     })
 
+    it('ignores a stray outgoing edge that runtime condition routing can never select', async () => {
+      const graph = conditionDefaultPathGraph({ kind: 'direct_manager' })
+      graph.nodes.splice(-2, 0, {
+        key: 'approval_stray',
+        type: 'approval',
+        config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+      })
+      graph.edges.splice(-1, 0,
+        { key: 'e-cond-stray', source: 'cond_1', target: 'approval_stray' },
+        { key: 'e-stray-join', source: 'approval_stray', target: 'join' },
+      )
+      mockParallelPublish(graph)
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().publishTemplate(
+        'tpl-par',
+        { policy: { allowRevoke: true } } as never,
+      )
+      expect(result.publishedDefinitionId).toBe('pub-par')
+    })
+
+    it('without a default, scans the first-outgoing fallback for dynamic conflicts', async () => {
+      const graph = conditionDefaultPathGraph({ kind: 'requester' })
+      const condition = graph.nodes.find((node) => node.key === 'cond_1')!
+      condition.config = {
+        branches: [{ edgeKey: 'e-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }],
+      }
+      const highIndex = graph.edges.findIndex((edge) => edge.key === 'e-cond-high')
+      const lowIndex = graph.edges.findIndex((edge) => edge.key === 'e-cond-low')
+      ;[graph.edges[highIndex], graph.edges[lowIndex]] = [graph.edges[lowIndex], graph.edges[highIndex]]
+      mockParallelPublish(graph)
+
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(new ApprovalProductService().publishTemplate(
+        'tpl-par',
+        { policy: { allowRevoke: true } } as never,
+      )).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT',
+        details: { nodeKey: 'fork', source: 'requester' },
+      })
+    })
+
     it('does NOT reject the same source on two ALTERNATIVE paths of ONE branch alone (within-branch union, not a conflict)', async () => {
       // Both cond_1 paths resolve to requester but branch B is a STATIC role — alternative paths of
       // one branch never run simultaneously, so publish must stay green.
@@ -2381,9 +2423,10 @@ describe('ApprovalProductService', () => {
     })
   })
 
-  describe('parallel branch all-path join reachability (normalize / author)', () => {
-    // Structural gate inside collectBranchAssignees / normalizeApprovalGraph: every
-    // runtime-possible path through a parallel branch must reach the configured join.
+  describe('parallel branch all-path join reachability (author / publish)', () => {
+    // The strict write gate proves every runtime-possible path through a parallel
+    // branch reaches the configured join. Stored reads keep the historical
+    // first-edge compatibility path so a validator tightening cannot brick them.
     // The prior first-outgoing-edge-only walk accepted templates where a condition's
     // FIRST rules edge joined while a non-first / default edge hit end (or dead-ended /
     // nested-parallel / cycled); create/update/publish went green, then a request that
@@ -2558,18 +2601,94 @@ describe('ApprovalProductService', () => {
       expect(pgState.pool.connect).not.toHaveBeenCalled()
     })
 
-    it('GOLDEN: same shape → publishTemplate rejects (stored-graph normalize)', async () => {
-      // Publish re-normalizes the STORED draft via asApprovalGraph → STORED_GRAPH_CONTEXT
-      // (500 APPROVAL_TEMPLATE_GRAPH_INVALID), same message as the author-time gate.
+    it('GOLDEN: same readable historical shape → publishTemplate rejects at the strict write gate', async () => {
       mockPublish(goldenDefaultEndsBeforeJoinGraph())
       const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
       await expect(
         new ApprovalProductService().publishTemplate('tpl-join-reach', { policy: { allowRevoke: true } } as never),
       ).rejects.toMatchObject({
-        statusCode: 500,
-        code: 'APPROVAL_TEMPLATE_GRAPH_INVALID',
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
         message: 'approvalGraph parallel branch must reach join before end (at end)',
       })
+    })
+
+    it('compatibility GOLDEN: ordinary reads still return a historical first-edge-valid graph', async () => {
+      const graph = goldenDefaultEndsBeforeJoinGraph()
+      const template = {
+        id: 'tpl-join-reach', key: 'join-reach', name: 'Join Reach', description: null, category: null,
+        visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+        active_version_id: null, latest_version_id: 'ver-join-reach', created_at: new Date(), updated_at: new Date(),
+      }
+      const version = {
+        id: 'ver-join-reach', template_id: 'tpl-join-reach', version: 1, status: 'draft',
+        form_schema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] }, approval_graph: graph,
+        created_at: new Date(), updated_at: new Date(),
+      }
+      pgState.pool.query.mockImplementation(async (sql: string) => {
+        const statement = normalize(sql)
+        if (statement.startsWith('SELECT * FROM approval_templates WHERE')) return { rows: [template], rowCount: 1 }
+        if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) return { rows: [version], rowCount: 1 }
+        if (statement.startsWith('SELECT * FROM approval_published_definitions')) return { rows: [], rowCount: 0 }
+        throw new Error(`Unhandled query: ${statement}`)
+      })
+
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().getTemplate('tpl-join-reach')
+      expect(result?.approvalGraph).toEqual(graph)
+    })
+
+    it('form-only update revalidates the copied historical graph before creating a new version', async () => {
+      const graph = goldenDefaultEndsBeforeJoinGraph()
+      const template = {
+        id: 'tpl-join-reach', key: 'join-reach', name: 'Join Reach', description: null, category: null,
+        visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft',
+        active_version_id: null, latest_version_id: 'ver-join-reach', created_at: new Date(), updated_at: new Date(),
+      }
+      const version = {
+        id: 'ver-join-reach', template_id: 'tpl-join-reach', version: 1, status: 'draft',
+        form_schema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] }, approval_graph: graph,
+        created_at: new Date(), updated_at: new Date(),
+      }
+      pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+        const statement = normalize(sql)
+        if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') return { rows: [], rowCount: 0 }
+        if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) return { rows: [template], rowCount: 1 }
+        if (statement.startsWith('SELECT * FROM approval_template_versions WHERE template_id = $1')) return { rows: [version], rowCount: 1 }
+        if (statement.startsWith('SELECT COALESCE(MAX(version), 0)::text')) return { rows: [{ max_version: '1' }], rowCount: 1 }
+        if (statement.startsWith('INSERT INTO approval_template_versions')) {
+          return { rows: [{ ...version, id: 'ver-join-reach-2', version: 2, form_schema: JSON.parse(String(params?.[2])) }], rowCount: 1 }
+        }
+        if (statement.startsWith('UPDATE approval_templates SET latest_version_id')) {
+          return { rows: [{ ...template, latest_version_id: 'ver-join-reach-2' }], rowCount: 1 }
+        }
+        throw new Error(`Unhandled query: ${statement}`)
+      })
+
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      await expect(new ApprovalProductService().updateTemplate('tpl-join-reach', {
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+      } as never)).rejects.toMatchObject(goldenReject)
+    })
+
+    it('no-default runtime fallback follows the first outgoing edge as well as declared rule edges', async () => {
+      const graph = goldenDefaultEndsBeforeJoinGraph()
+      const condition = graph.nodes.find((node) => node.key === 'cond_1')!
+      condition.config = {
+        branches: [{ edgeKey: 'e-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' }],
+      }
+      const highIndex = graph.edges.findIndex((edge) => edge.key === 'e-cond-high')
+      const lowIndex = graph.edges.findIndex((edge) => edge.key === 'e-cond-low')
+      ;[graph.edges[highIndex], graph.edges[lowIndex]] = [graph.edges[lowIndex], graph.edges[highIndex]]
+      // First outgoing is now the undeclared low edge -> end; the declared high
+      // edge joins. Omitting the firstTarget fallback would false-accept.
+      mockCreateInsert('join-reach-no-default')
+      await expect(new (await import('../../src/services/ApprovalProductService')).ApprovalProductService().createTemplate({
+        key: 'join-reach-no-default',
+        name: 'Join Reach No Default',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: graph,
+      } as never)).rejects.toMatchObject(goldenReject)
     })
 
     it('symmetric: non-first RULES edge reaches end (default joins) → create rejects', async () => {
@@ -2753,6 +2872,47 @@ describe('ApprovalProductService', () => {
       expect(result.id).toBe('tpl-join-reach')
       // Sanity: graph size is linear in LAYERS (memoized walk bound), not exponential.
       expect(result.approvalGraph.nodes.length).toBe(5 + LAYERS * 4)
+    })
+
+    it('positive control: a deep valid condition chain does not overflow the JavaScript call stack', async () => {
+      const DEPTH = 4_000
+      const nodes: Array<Record<string, unknown>> = [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'fork', type: 'parallel', config: { branches: ['e-fork-deep', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'join' } },
+        { key: 'branch_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-b'] } },
+        { key: 'join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['final-1'] } },
+        { key: 'end', type: 'end', config: {} },
+      ]
+      const edges: Array<{ key: string; source: string; target: string }> = [
+        { key: 'e-start-fork', source: 'start', target: 'fork' },
+        { key: 'e-fork-deep', source: 'fork', target: 'cond-deep-0' },
+        { key: 'e-fork-b', source: 'fork', target: 'branch_b' },
+        { key: 'e-b-join', source: 'branch_b', target: 'join' },
+        { key: 'e-join-end', source: 'join', target: 'end' },
+      ]
+      for (let index = 0; index < DEPTH; index += 1) {
+        const key = `cond-deep-${index}`
+        const edgeKey = `e-cond-deep-${index}`
+        const target = index + 1 < DEPTH ? `cond-deep-${index + 1}` : 'join'
+        nodes.push({
+          key,
+          type: 'condition',
+          config: {
+            branches: [{ edgeKey, rules: [{ fieldId: 'amount', operator: 'gte', value: index }], conjunction: 'and' }],
+          },
+        })
+        edges.push({ key: edgeKey, source: key, target })
+      }
+
+      mockCreateInsert('join-reach-deep')
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().createTemplate({
+        key: 'join-reach-deep',
+        name: 'Join Reach Deep',
+        formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+        approvalGraph: { nodes, edges },
+      } as never)
+      expect(result.approvalGraph.nodes).toHaveLength(DEPTH + 5)
     })
 
     it('positive: stray outgoing edge NOT referenced by condition config must not fail a valid branch', async () => {


### PR DESCRIPTION
## What

- validates every runtime-declared condition branch/default path inside a parallel region before create, update, publish, or clone
- preserves historical first-edge-valid graphs on ordinary reads and in-flight runtime reads, while form-only updates, clone, and publish revalidate under current authoring rules
- mirrors the runtime route set exactly: configured rule/default edges plus first-outgoing fallback when no default; stray outgoing edges are ignored
- rejects condition edge keys owned by another source node instead of allowing the runtime global lookup to misroute
- uses an explicit-stack, memoized all-path walk so deep valid graphs do not overflow the JavaScript call stack
- keeps backend publish preflight and frontend conflict preview on the same route semantics

## Why

The prior static walk followed only the first outgoing edge. A valid-looking template could publish while a later rules/default branch terminated before the parallel join, then fail only when a request selected that branch. The first strict implementation also made normal reads retroactively reject historical templates and scanned stray outgoing edges that runtime never selects. A later review found cloneTemplate was another new-version write path that still copied compatible historical graphs without the strict authoring gate.

## Verification

- approval-product-service unit file: 128/128
- approval parallel-edit frontend spec: 31/31
- backend and web TypeScript checks: pass
- compatibility golden: historical graph remains readable but is rejected by publish, clone, and form-only version creation
- deep-chain positive: 4,000 condition nodes validate without call-stack overflow
- mutations: strict stored read, all-outgoing backend/FE traversal, missing no-default fallback, missing form-only revalidation, and missing clone revalidation each turn their named golden red
- positive controls: stray non-config edge ignored; convergent and 24-layer diamond DAGs accepted

## Boundary

- stacked on #4433 and intentionally targets its branch
- authoring/read compatibility and FE preflight only; no runtime flag or deployment change
- Draft for owner review; no merge authorization implied
