### PR TITLE
fix(core-backend): W4-PRE-1d — split deprovision candidacy into org-membership vs global sets (owner P1/P2, #4530 review)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -839,6 +839,7 @@ jobs:
             tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts \
             tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts \
             tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts \
+            tests/integration/attendance-w4pre1d-departure-candidate-split.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -1308,22 +1308,47 @@ export function resolveDirectoryDeprovisionPolicy(
 
 export type DirectoryDeprovisionOutcome = {
   applied: boolean
-  /** Number of PEOPLE, not accounts — a user reached through two departed accounts counts once. */
+  /**
+   * W4-PRE-1d (owner P2 item 1, #4530 review, issuecomment-5043752399, 2026-07-22): the
+   * ORG-MEMBERSHIP candidate set — number of PEOPLE (not accounts; a user reached through two
+   * departed accounts counts once) who, in THIS run's org, hold no OTHER active linked
+   * directory account in that SAME org. This is now the circuit breaker's own input (owner P2
+   * item 3) — see `evaluateDirectoryDeprovisionCircuitBreaker`'s call site below. Before
+   * W4-PRE-1d this field was computed from a GLOBAL "no active binding ANYWHERE" guard, which
+   * silently dropped a person who departed org A but is still employed in org B out of
+   * candidacy entirely — see the file-level W4-PRE-1d note on `applyDirectoryDeprovisionPolicies`
+   * for the full owner-confirmed defect. That global guard still exists — see
+   * `globalCandidateCount` below — but it no longer gates membership candidacy, only the
+   * grant/platform-user actions.
+   */
   candidateCount: number
   manualReviewCount: number
+  /**
+   * W4-PRE-1d (owner P2 item 2): the GLOBAL candidate set, restricted to non-`manual_review`
+   * org-membership candidates (`candidateCount` above) who ALSO hold no other active linked
+   * directory account ANYWHERE (any org) — the pre-existing "任意位置无活跃绑定" guard,
+   * relocated here from candidate selection. This is the set eligible for
+   * `grantsDisabledCount` / `usersDeactivatedCount` this run; by construction it equals
+   * `grantsDisabledCount` (both increment on the exact same condition, before the `enabled`
+   * gate, mirroring that field's own attempt-not-flip semantics) — named separately so the
+   * SET is visible on its own in run stats/logs per the two-candidate-set observability
+   * requirement, not only inferable from the grant-specific field.
+   */
+  globalCandidateCount: number
   grantsDisabledCount: number
   usersDeactivatedCount: number
   /**
    * W4-PRE-1c (owner 裁决②, #4522 rev3 review, 2026-07-22, review-finding observability gap):
    * how many PEOPLE this run attempted a `user_orgs` deactivation for — every non-`manual_review`
-   * candidate, i.e. the same set (and same count, by construction) as `grantsDisabledCount`,
-   * since both writes are gated by the exact same `if (options.enabled)` block for the exact
-   * same candidates. Named separately so the `user_orgs` consequence is visible on its own in
-   * run stats/logs rather than requiring the reader to know it is implied by
-   * `grantsDisabledCount`. Like that field, this counts an ATTEMPT (preview mode included) —
-   * it does NOT mean the row actually flipped: `deactivateUserOrgMembershipIfNoOtherActiveBinding`
-   * no-ops (without erroring) when the org-scoped sibling check finds another active binding, or
-   * when no `user_orgs` row exists yet. Whether it actually flipped is not tracked (the shared
+   * org-membership candidate (W4-PRE-1d: no longer the same set as `grantsDisabledCount` — see
+   * that field's own doc-comment on the W4-PRE-1d split), since the write is gated by the exact
+   * same `if (options.enabled)` block for the exact same candidates. Named separately so the
+   * `user_orgs` consequence is visible on its own in run stats/logs rather than requiring the
+   * reader to know it is implied by `grantsDisabledCount`. Like that field, this counts an
+   * ATTEMPT (preview mode included) — it does NOT mean the row actually flipped:
+   * `deactivateUserOrgMembershipIfNoOtherActiveBinding` no-ops (without erroring) when the
+   * org-scoped sibling check finds another active binding, or when no `user_orgs` row exists
+   * yet. Whether it actually flipped is not tracked (the shared
    * helper's `UPDATE` has no `RETURNING`); this is attempt-visibility, not flip-visibility.
    */
   membershipDeactivationAttemptedCount: number
@@ -1333,6 +1358,14 @@ export type DirectoryDeprovisionOutcome = {
     directoryAccountId: string
     localUserId: string
     policy: DirectoryDeprovisionPolicy
+    /**
+     * W4-PRE-1d (owner P2 item 2): whether this person was in `globalCandidateCount` — no
+     * other active linked directory account ANYWHERE (any org) at the time the global check
+     * ran. `false` means org-membership deactivation was (maybe) attempted but grant-disable
+     * and platform-user deactivation were NOT — they stayed exactly as they were. Values-free:
+     * a boolean, not the sibling's identity.
+     */
+    globallyClear: boolean
   }>
   /**
    * W4-PRE-1c item B (owner 裁决②, #4522 rev3 review, 2026-07-22): `manual_review` never
@@ -1395,6 +1428,29 @@ export function evaluateDirectoryDeprovisionCircuitBreaker(options: {
   return null
 }
 
+/**
+ * W4-PRE-1d — candidate-set split (owner P1/P2, #4530 review, issuecomment-5043752399,
+ * 2026-07-22).
+ *
+ * Owner's confirmed P1, verbatim: "全局 sibling guard（directory-sync.ts:1425）把「A 离职但仍
+ * 在 B 任职」的用户整体排除出候选集 ⇒ A/B membership 都保持 active"。Before this PR, the ONE
+ * candidate-selection query used a GLOBAL "no active linked directory account anywhere" guard
+ * for everything: whether a person was a candidate AT ALL, whether their `user_orgs` row for
+ * THIS org got deactivated, and whether their grant/platform account did too. A person who left
+ * org A's directory but is still genuinely employed via org B's directory was globally
+ * disqualified from candidacy — org A's own membership stayed active forever, with no other
+ * mechanism to ever clear it.
+ *
+ * The fix splits candidacy into the two sets the owner named:
+ *   1. ORG-MEMBERSHIP candidates (`candidateCount` / `byUser` below) — org-scoped: excluded
+ *      only by another ACTIVE linked account in THIS SAME org. Governs `user_orgs` deactivation
+ *      AND is now the circuit breaker's input (owner P2 item 3).
+ *   2. GLOBAL candidates (`globalCandidateCount` / `globallyClearUserIds` below) — the
+ *      pre-existing "anywhere" guard, relocated here. Governs ONLY the DingTalk grant-disable
+ *      and (for `mark_inactive`) `users.is_active` writes.
+ * A person can now be set-1-yes/set-2-no: org A membership deactivates, grant and platform
+ * account survive because org B still vouches for them.
+ */
 export async function applyDirectoryDeprovisionPolicies(
   client: { query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }> },
   options: {
@@ -1412,6 +1468,7 @@ export async function applyDirectoryDeprovisionPolicies(
     applied: options.enabled,
     candidateCount: 0,
     manualReviewCount: 0,
+    globalCandidateCount: 0,
     grantsDisabledCount: 0,
     usersDeactivatedCount: 0,
     membershipDeactivationAttemptedCount: 0,
@@ -1422,14 +1479,23 @@ export async function applyDirectoryDeprovisionPolicies(
 
   if (options.deactivatedAccountIds.length === 0) return outcome
 
-  // Accounts this run just deactivated, whose linked local user has NO other active linked
-  // directory account ANYWHERE.
+  // W4-PRE-1d (owner P2, #4530 review, issuecomment-5043752399, 2026-07-22): resolved EAGERLY
+  // now — the org-membership candidate SELECT below is itself org-scoped and needs it as a
+  // WHERE parameter. (Pre-W4-PRE-1d this was resolved lazily; that is no longer possible.)
+  const orgId = await resolveDirectoryAccountOrgId(client, options.integrationId)
+
+  // W4-PRE-1d item 1 (owner P2, #4530 review — the owner's own confirmed-fact quote: "全局
+  // sibling guard（directory-sync.ts:1425）把「A 离职但仍在 B 任职」的用户整体排除出候选集 ⇒
+  // A/B membership 都保持 active"):
   //
-  // The sibling guard is deliberately NOT scoped by integration_id, and that is the whole
-  // point: `directory_account_links` is unique on directory_account_id only — local_user_id
-  // carries a plain index — so N accounts map to 1 user. A rehire (the old account departs,
-  // the new one links via the stable unionId) or a second integration would otherwise
-  // deactivate a person who is actively employed, with no way to undo it.
+  // ORG-MEMBERSHIP candidates — accounts this run just deactivated, whose linked local user
+  // has no OTHER active linked directory account in THIS SAME org (`i.org_id = $2`). Mirrors
+  // `deactivateUserOrgMembershipIfNoOtherActiveBinding`'s own org-scoped predicate exactly
+  // (same three clauses: linked, active, same org) so candidate SELECTION and the WRITE agree
+  // on who still "works here". A user who departed org A but is still actively employed in a
+  // DIFFERENT org B is now correctly a candidate for org A (the P1 defect this fixes) — the
+  // separate GLOBAL guard below decides only whether the grant/platform-user actions may also
+  // fire, never whether org A's own membership may be deactivated.
   const candidates = await client.query(
     `SELECT a.id::text AS directory_account_id,
             l.local_user_id,
@@ -1444,11 +1510,13 @@ export async function applyDirectoryDeprovisionPolicies(
           SELECT 1
             FROM directory_account_links sibling_link
             JOIN directory_accounts sibling ON sibling.id = sibling_link.directory_account_id
+            JOIN directory_integrations sibling_integration ON sibling_integration.id = sibling.integration_id
            WHERE sibling_link.local_user_id = l.local_user_id
              AND sibling_link.link_status = 'linked'
              AND sibling.is_active = true
+             AND sibling_integration.org_id = $2::text
         )`,
-    [options.deactivatedAccountIds],
+    [options.deactivatedAccountIds, orgId],
   )
 
   // One decision per PERSON, not per account: a user reached through two departed accounts
@@ -1462,6 +1530,10 @@ export async function applyDirectoryDeprovisionPolicies(
     }
   }
 
+  // W4-PRE-1d item 3 (owner P2 — "breaker 改用组织成员候选数（防大批跨组织失活绕上限）"): the
+  // breaker's input is the ORG-MEMBERSHIP candidate count computed above, not a
+  // globally-filtered count — a batch of cross-org membership deactivations can no longer
+  // slip under the cap just because each person also holds an active binding elsewhere.
   outcome.candidateCount = byUser.size
 
   const abortReason = evaluateDirectoryDeprovisionCircuitBreaker({
@@ -1480,15 +1552,34 @@ export async function applyDirectoryDeprovisionPolicies(
     return outcome
   }
 
-  // W4-PRE-1c (owner 裁决②, #4522 rev3 review, 2026-07-22): resolved LAZILY and at most
-  // ONCE per call — every candidate here was selected for the SAME `options.integrationId`,
-  // hence the SAME org. Only queried the first time it is actually needed (a manual_review
-  // candidate to report, or a non-manual_review write to perform), so a run with neither
-  // never pays for it.
-  let resolvedOrgId: string | null = null
-  const resolveOrgIdOnce = async (): Promise<string> => {
-    if (resolvedOrgId === null) resolvedOrgId = await resolveDirectoryAccountOrgId(client, options.integrationId)
-    return resolvedOrgId
+  // W4-PRE-1d item 2 (owner P2 — "全局账号/授权候选：保留现有『任意位置无活跃绑定』守卫，才允许
+  // 关闭 DingTalk grant 或 users.is_active"): the pre-existing GLOBAL "no active binding
+  // ANYWHERE" guard, relocated from candidate SELECTION (where it wrongly excluded org-A-only
+  // candidacy) to here, where it gates only the grant-disable / platform-user-deactivation
+  // actions. Computed once for every non-`manual_review` org-membership candidate — manual_review
+  // never writes anything regardless, so it is excluded from this batch check entirely.
+  const nonManualReviewUserIds = Array.from(byUser.entries())
+    .filter(([, c]) => c.policy !== 'manual_review')
+    .map(([localUserId]) => localUserId)
+
+  const globallyClearUserIds = new Set<string>()
+  if (nonManualReviewUserIds.length > 0) {
+    const globalClear = await client.query(
+      `SELECT candidate_user AS local_user_id
+         FROM UNNEST($1::text[]) AS candidate_user
+        WHERE NOT EXISTS (
+          SELECT 1
+            FROM directory_account_links sibling_link
+            JOIN directory_accounts sibling ON sibling.id = sibling_link.directory_account_id
+           WHERE sibling_link.local_user_id = candidate_user
+             AND sibling_link.link_status = 'linked'
+             AND sibling.is_active = true
+        )`,
+      [nonManualReviewUserIds],
+    )
+    for (const row of globalClear.rows as Array<{ local_user_id: string }>) {
+      globallyClearUserIds.add(row.local_user_id)
+    }
   }
 
   for (const [localUserId, { directoryAccountId, policy }] of byUser) {
@@ -1498,26 +1589,20 @@ export async function applyDirectoryDeprovisionPolicies(
       // 并暴露待人工确认状态") — never a write, membership stays exactly as it was; only the
       // pending-confirmation state is exposed (org/membership-scoped) on the existing
       // run-stats surface.
-      outcome.manualReviewPending.push({ directoryAccountId, localUserId, orgId: await resolveOrgIdOnce() })
+      outcome.manualReviewPending.push({ directoryAccountId, localUserId, orgId })
       continue
     }
 
-    outcome.affected.push({ directoryAccountId, localUserId, policy })
+    const globallyClear = globallyClearUserIds.has(localUserId)
+    outcome.affected.push({ directoryAccountId, localUserId, policy, globallyClear })
 
-    outcome.grantsDisabledCount += 1
-    // Same gate, same candidate set as `grantsDisabledCount` above — see this field's own
-    // doc-comment on `DirectoryDeprovisionOutcome`. Counted here (before the `enabled` check,
-    // like `grantsDisabledCount`) so preview runs also report how many `user_orgs`
-    // deactivation attempts WOULD happen if the switch were flipped on.
+    // W4-PRE-1d: org-membership deactivation is attempted for EVERY org-membership candidate
+    // reaching this point, unconditional on `globallyClear` — the global guard governs only the
+    // grant/platform-user actions below, never this one (owner P2 item 1 vs item 2 split).
+    // Same gate as before (breaker passed + `options.enabled`), see this field's own doc-comment
+    // on `DirectoryDeprovisionOutcome` for the attempt-not-flip distinction.
     outcome.membershipDeactivationAttemptedCount += 1
     if (options.enabled) {
-      await client.query(
-        `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
-         VALUES ($1, $2, FALSE, $3, NOW(), NOW())
-         ON CONFLICT (provider, local_user_id)
-         DO UPDATE SET enabled = FALSE, updated_at = NOW()`,
-        [DEFAULT_PROVIDER, localUserId, 'system:directory-deprovision'],
-      )
       // W4-PRE-1c (owner 裁决②, #4522 rev3 review — the only GitHub-persisted record is the
       // owner's own acknowledgment comment, issuecomment-5042388830: "不因单次同步缺失撤销
       // membership；deprovision circuit-breaker 通过 + 开关启用 + 策略实际执行时同事务失活对应
@@ -1525,44 +1610,58 @@ export async function applyDirectoryDeprovisionPolicies(
       // thread comment carries a longer/earlier original — this IS the citable text, not a
       // paraphrase of something else on record): the circuit breaker already passed (we are
       // past the abort-and-return above), the switch is on (`options.enabled`), and this
-      // policy just executed a REAL write for this person — a grant revoked here, and for
-      // `mark_inactive` the local account too, below. THIS moment — not the DT-OPS-01 sweep
-      // flipping `directory_accounts.is_active` alone — is "策略实际执行", and is what may
-      // deactivate `user_orgs`, same transaction. Reuses #4526's own org-scoped "no other
-      // active binding" rule verbatim (`deactivateUserOrgMembershipIfNoOtherActiveBinding`) —
-      // and that helper's OWN re-read (`SELECT ... FOR UPDATE` then a fresh READ COMMITTED
-      // `NOT EXISTS`) is NOT redundant with this function's global candidate-selection sibling
-      // guard above, despite both checking "no other active binding": guard (1) above is read
-      // ONCE, early, before this loop and before any write in this run; this helper re-checks
-      // AT WRITE TIME under a row lock. A concurrent transaction that commits a brand-new
+      // policy just executed for this person — THIS moment — not the DT-OPS-01 sweep flipping
+      // `directory_accounts.is_active` alone — is "策略实际执行", and is what deactivates
+      // `user_orgs`, same transaction. Reuses #4526's own org-scoped "no other active binding"
+      // rule verbatim (`deactivateUserOrgMembershipIfNoOtherActiveBinding`) — and that helper's
+      // OWN re-read (`SELECT ... FOR UPDATE` then a fresh READ COMMITTED `NOT EXISTS`) is NOT
+      // redundant with this function's own org-scoped candidate-selection guard above, despite
+      // both checking "no other active binding in this org": the guard above is read ONCE,
+      // early, before this loop and before any write in this run; this helper re-checks AT
+      // WRITE TIME under a row lock. A concurrent transaction that commits a brand-new
       // linked+active directory account for this SAME person in this SAME org, in the window
-      // between guard (1)'s read and this call, is invisible to guard (1)'s stale snapshot but
+      // between the guard's read and this call, is invisible to the guard's stale snapshot but
       // IS caught by this helper's fresh re-read — the same write-skew shape #4526 itself fixed
       // with `FOR UPDATE` for concurrent unbinds. So this check is independently load-bearing on
-      // this call path, not merely inherited defense-in-depth; see the PR body's combination-
-      // semantics section (owner review flagged) for the full reasoning. `manual_review` is
-      // excluded by the `continue` above: a single missed sync, or a policy that never executes,
-      // must never itself revoke membership.
-      await deactivateUserOrgMembershipIfNoOtherActiveBinding(client, {
-        userId: localUserId,
-        orgId: await resolveOrgIdOnce(),
-      })
+      // this call path, not merely inherited defense-in-depth. `manual_review` is excluded by
+      // the `continue` above: a single missed sync, or a policy that never executes, must never
+      // itself revoke membership.
+      await deactivateUserOrgMembershipIfNoOtherActiveBinding(client, { userId: localUserId, orgId })
     }
 
-    if (policy === 'mark_inactive') {
-      outcome.usersDeactivatedCount += 1
+    // W4-PRE-1d item 2: grant-disable and (for mark_inactive) platform-user deactivation are
+    // gated by the GLOBAL "no active binding ANYWHERE" guard — a person still actively employed
+    // through a DIFFERENT org's directory keeps DingTalk login and their platform account, even
+    // though THIS org's membership was just deactivated above.
+    if (globallyClear) {
+      outcome.globalCandidateCount += 1
+      outcome.grantsDisabledCount += 1
       if (options.enabled) {
         await client.query(
-          `UPDATE users SET is_active = FALSE, updated_at = NOW() WHERE id = $1::text`,
-          [localUserId],
+          `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
+           VALUES ($1, $2, FALSE, $3, NOW(), NOW())
+           ON CONFLICT (provider, local_user_id)
+           DO UPDATE SET enabled = FALSE, updated_at = NOW()`,
+          [DEFAULT_PROVIDER, localUserId, 'system:directory-deprovision'],
         )
+      }
+
+      if (policy === 'mark_inactive') {
+        outcome.usersDeactivatedCount += 1
+        if (options.enabled) {
+          await client.query(
+            `UPDATE users SET is_active = FALSE, updated_at = NOW() WHERE id = $1::text`,
+            [localUserId],
+          )
+        }
       }
     }
   }
 
   if (!options.enabled && outcome.candidateCount > 0) {
     logger.info(
-      `Directory deprovision preview for ${options.integrationId}: ${outcome.candidateCount} person(s) — `
+      `Directory deprovision preview for ${options.integrationId}: ${outcome.candidateCount} org-membership `
+      + `candidate(s) (${outcome.globalCandidateCount} also globally clear) — `
       + `${outcome.grantsDisabledCount} grant(s) and ${outcome.usersDeactivatedCount} local user(s) would be disabled, `
       + `and ${outcome.membershipDeactivationAttemptedCount} org membership(s) (user_orgs) would be deactivation-attempted. `
       + `Affected: ${outcome.affected.map((a) => a.localUserId).join(', ') || '(none)'}. `
@@ -3967,8 +4066,14 @@ export async function syncDirectoryIntegration(
         managerCoverage: managerBindingCoverage.coverage,
         durationMs: Date.now() - runStartedAtMs,
         deprovisionApplied: deprovisionOutcome.applied,
+        // W4-PRE-1d (owner P2 item 1/3): org-membership candidates — the circuit breaker's own
+        // input. See `DirectoryDeprovisionOutcome.candidateCount`'s doc-comment.
         deprovisionCandidateCount: deprovisionOutcome.candidateCount,
         deprovisionManualReviewCount: deprovisionOutcome.manualReviewCount,
+        // W4-PRE-1d (owner P2 item 2, two-candidate-set observability): the GLOBAL candidate
+        // count — non-manual_review org-membership candidates who ALSO have no other active
+        // binding anywhere, i.e. eligible for the grant/platform-user actions below.
+        deprovisionGlobalCandidateCount: deprovisionOutcome.globalCandidateCount,
         deprovisionGrantsDisabledCount: deprovisionOutcome.grantsDisabledCount,
         deprovisionUsersDeactivatedCount: deprovisionOutcome.usersDeactivatedCount,
         // W4-PRE-1c (owner 裁决②, review-finding observability gap): the new user_orgs
@@ -4093,13 +4198,20 @@ export async function syncDirectoryIntegration(
             directoryAccountId: affected.directoryAccountId,
             localUserId: affected.localUserId,
             policy: affected.policy,
-            grantDisabled: true,
-            userDeactivated: affected.policy === 'mark_inactive',
-            // W4-PRE-1c (owner 裁决②, review-finding observability gap): every entry in
-            // `deprovisionOutcome.affected` (this loop's source) attempted the user_orgs
-            // deactivation unconditionally when `applied` is true — same gate as
-            // `grantDisabled` above, see `membershipDeactivationAttemptedCount`'s doc-comment.
-            // Attempted, not necessarily flipped (org-scoped sibling check may have no-op'd it).
+            // W4-PRE-1d (owner P2 item 2): NO LONGER unconditionally true — grant-disable and
+            // platform-user deactivation only actually ran when this person was also globally
+            // clear (no other active binding anywhere). A false here truthfully records that
+            // this org's membership was (maybe) deactivated but the grant/platform account
+            // were left untouched because the person is still active elsewhere.
+            grantDisabled: affected.globallyClear,
+            userDeactivated: affected.policy === 'mark_inactive' && affected.globallyClear,
+            globallyClear: affected.globallyClear,
+            // W4-PRE-1d: every entry in `deprovisionOutcome.affected` (this loop's source)
+            // attempted the org-membership (user_orgs) deactivation unconditionally when
+            // `applied` is true — this is now a SEPARATE gate from `grantDisabled` above (owner
+            // P2 item 1 vs item 2 split), see `membershipDeactivationAttemptedCount`'s
+            // doc-comment. Attempted, not necessarily flipped (the org-scoped sibling check at
+            // write time may have no-op'd it).
             membershipDeactivationAttempted: true,
             triggeredBy,
           },

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -1552,12 +1552,32 @@ export async function applyDirectoryDeprovisionPolicies(
     return outcome
   }
 
-  // W4-PRE-1d item 2 (owner P2 — "全局账号/授权候选：保留现有『任意位置无活跃绑定』守卫，才允许
-  // 关闭 DingTalk grant 或 users.is_active"): the pre-existing GLOBAL "no active binding
-  // ANYWHERE" guard, relocated from candidate SELECTION (where it wrongly excluded org-A-only
-  // candidacy) to here, where it gates only the grant-disable / platform-user-deactivation
-  // actions. Computed once for every non-`manual_review` org-membership candidate — manual_review
-  // never writes anything regardless, so it is excluded from this batch check entirely.
+  // W4-PRE-1d item 2 (owner P2, #4530 review, issuecomment-5043752399, verbatim — "全局账号/
+  // 授权候选：保留『任意位置无活跃绑定』守卫，才允许关闭 DingTalk grant 或 users.is_active"): the
+  // pre-existing GLOBAL "no active binding ANYWHERE" guard, relocated from candidate SELECTION
+  // (where it wrongly excluded org-A-only candidacy) to here, where it gates only the
+  // grant-disable / platform-user-deactivation actions. Computed once for every non-
+  // `manual_review` org-membership candidate — manual_review never writes anything regardless,
+  // so it is excluded from this batch check entirely.
+  //
+  // Known gap (review finding, deferred — not overlooked): this is a batch-level, no-lock
+  // check-then-act read. It is taken ONCE, before the write loop below, over READ COMMITTED
+  // snapshots for every candidate in the batch. A concurrent transaction that changes this
+  // person's binding elsewhere (another org's departure completing, or a rehire committing a
+  // new linked+active account) between this read and the write loop's `INSERT`/`UPDATE` below
+  // is invisible to this snapshot — unlike `deactivateUserOrgMembershipIfNoOtherActiveBinding`'s
+  // own write-time `SELECT ... FOR UPDATE` re-read for the org-membership write, there is no
+  // equivalent write-time re-check here for the grant/platform-user writes. Concretely: (a) two
+  // concurrent last-org departures for the same person can each see the other's org as still
+  // active and both skip the grant/user-deactivate writes, leaving an enabled DingTalk grant
+  // with zero live bindings and no automatic reconciliation; (b) a same-window rehire can have
+  // its grant/user-deactivate writes applied against a now-stale "globally clear" snapshot. Both
+  // shapes are inherited from the pre-existing (pre-W4-PRE-1d) global guard, which read from an
+  // even earlier point (the old unscoped candidate SELECT) — this relocation does not widen
+  // either window. Closing it needs a lock-strategy or reconciliation-sweep design decision
+  // (e.g. a `users`-row `FOR UPDATE` re-check at write time, mirroring the org-membership
+  // helper) that is outside the owner's verbatim 4-item P2 spec this PR implements — left for
+  // the owner to scope as a follow-up, not silently dropped.
   const nonManualReviewUserIds = Array.from(byUser.entries())
     .filter(([, c]) => c.policy !== 'manual_review')
     .map(([localUserId]) => localUserId)
@@ -1633,6 +1653,15 @@ export async function applyDirectoryDeprovisionPolicies(
     // gated by the GLOBAL "no active binding ANYWHERE" guard — a person still actively employed
     // through a DIFFERENT org's directory keeps DingTalk login and their platform account, even
     // though THIS org's membership was just deactivated above.
+    //
+    // Known gap (review finding, deferred — see this function's `globallyClearUserIds` batch
+    // read above for the forward-direction case; this is the reverse): `globallyClear` here is
+    // the STALE batch snapshot, not re-checked at this write. If a concurrent transaction
+    // commits a brand-new linked+active directory account for this SAME person (rehire, or a
+    // new org's onboarding) in the window between that snapshot and this write, these two writes
+    // still fire against the stale `true`, closing the grant and (mark_inactive) deactivating an
+    // otherwise-currently-employed user. Same inherited-not-widened window as the guard's own
+    // doc-comment above; same deferred lock/reconciliation design decision.
     if (globallyClear) {
       outcome.globalCandidateCount += 1
       outcome.grantsDisabledCount += 1
@@ -5149,12 +5178,18 @@ export async function upsertActiveUserOrgMembership(
 /**
  * W4-PRE-1b item B: safe deactivation. Flips `user_orgs.is_active` to FALSE for
  * (userId, orgId) ONLY WHEN the user holds no OTHER active, linked directory account anywhere in
- * THIS org. Deliberately ORG-SCOPED (unlike the pre-existing `applyDirectoryDeprovisionPolicies`
- * sibling guard, which is intentionally GLOBAL for rehire protection, ~L1396-1400): a user can be
- * active in org A and inactive in org B independently, so the sibling search spans BOTH `local`
- * and `dingtalk` directory accounts of THIS org only (via the `directory_integrations.org_id`
- * join) — never accounts in a different org. Call this AFTER the triggering link mutation has
- * already been written in the same transaction, so a just-severed/reassigned row correctly
+ * THIS org. Deliberately ORG-SCOPED — and, as of W4-PRE-1d (owner P2 item 1, #4530 review,
+ * issuecomment-5043752399), so is `applyDirectoryDeprovisionPolicies`'s own org-membership
+ * candidate-selection guard now (~L1491-1516, joins `directory_integrations.org_id`): the two
+ * predicates are deliberately mirrored (same three clauses: linked, active, same org) so
+ * candidate SELECTION and this WRITE agree on who still "works here". Only
+ * `applyDirectoryDeprovisionPolicies`'s SEPARATE global "no active binding ANYWHERE" guard
+ * (~L1587, gating the DingTalk grant / `users.is_active` writes, not this one) stays GLOBAL, for
+ * rehire protection: a user can be active in org A and inactive in org B independently, so the
+ * sibling search HERE spans BOTH `local` and `dingtalk` directory accounts of THIS org only (via
+ * the `directory_integrations.org_id` join) — never accounts in a different org. Call this AFTER
+ * the triggering link mutation has already been written in the same transaction, so a
+ * just-severed/reassigned row correctly
  * self-excludes from the NOT EXISTS.
  *
  * Boundary (this PR's own reading, presented to the owner as evidence — NOT an adjudicated owner

--- a/packages/core-backend/tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts
@@ -8,26 +8,33 @@ import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory
  * pre-existing `directory-deprovision-selection.db.test.ts`; case ①'s own file drives the full
  * `syncDirectoryIntegration` orchestration, which owner named specifically for that case only).
  *
- * Case ② construction note (see PR body's combination-semantics section for the full reasoning):
- * `applyDirectoryDeprovisionPolicies`'s OWN candidate-selection sibling guard is GLOBAL (any
- * OTHER active *directory-linked* account, in ANY org, disqualifies a person from being a
- * candidate at all — pre-existing #4526 "rehire protection" behaviour, unchanged by this PR).
- * So a person who ALSO holds an active directory-linked account in org B would never become a
- * candidate for org A's sweep in the first place — nothing would execute, and the test would
- * prove nothing. Org B's membership here is therefore NOT directory-linked (no
- * `directory_account_links` row) — seeded directly as a `user_orgs` row, exactly the shape a
- * `POST /api/admin/users` explicit-`attendanceOrgId` admission (#4526 item D) would leave
- * behind. This is the only construction that lets org A's policy actually execute while org B
- * stays provably untouched.
+ * DOC-COMMENT CORRECTED post-hoc by W4-PRE-1d (owner P1/P2, #4530 review, issuecomment-
+ * 5043752399) — the file's assertions and fixtures are UNCHANGED and still pass (both cases'
+ * outcomes happen to coincide under the new org-scoped guard, for the reasons below); only the
+ * stale "GLOBAL guard" framing below has been corrected so it does not misdescribe the current
+ * candidate-selection predicate as GLOBAL when it is now ORG-SCOPED.
  *
- * Case ③ framing (owner asked for this explicitly; see PR body): whenever the GLOBAL guard
- * above admits a candidate, the ORG-SCOPED "no other active binding" check INSIDE
- * `deactivateUserOrgMembershipIfNoOtherActiveBinding` (#4526) is provably always satisfied too
- * — global no-sibling-anywhere is a strictly stronger condition than org-scoped no-sibling-
- * here. So this call path can only reach case ③ via the GLOBAL pre-filter (candidateCount: 0,
- * the new user_orgs write is never reached at all), not via the org-scoped helper's own check
- * blocking anything. Presented as evidence for owner review, not an adjudicated claim about the
- * helper being load-bearing on this specific call path.
+ * Case ② construction note (see PR body's combination-semantics section for the full reasoning):
+ * `applyDirectoryDeprovisionPolicies`'s OWN candidate-selection sibling guard was GLOBAL when
+ * this file was written (any OTHER active *directory-linked* account, in ANY org, disqualified a
+ * person from being a candidate at all — pre-existing #4526 "rehire protection" behaviour). As of
+ * W4-PRE-1d it is ORG-SCOPED (same org as the departing account only) — case ②'s org-B sibling
+ * being a BARE `user_orgs` row (no `directory_account_links` row at all) means it was, and still
+ * is, invisible to this guard EITHER way, so this case's outcome is unaffected by the split; it
+ * was never actually exercising the GLOBAL-vs-org-scoped distinction (that gap is exactly what
+ * the owner's P1 finding named, and what `attendance-w4pre1d-departure-candidate-split.db.test.ts`
+ * now covers with a REAL org-B binding instead of this bare stand-in). Org B's membership here is
+ * seeded directly as a `user_orgs` row, exactly the shape a `POST /api/admin/users` explicit-
+ * `attendanceOrgId` admission (#4526 item D) would leave behind.
+ *
+ * Case ③ framing (owner asked for this explicitly; see PR body): the sibling here is in THIS
+ * SAME org (same integration), so both the pre-W4-PRE-1d GLOBAL guard and the current ORG-SCOPED
+ * guard exclude this person from candidacy for the same underlying reason (an active, linked
+ * sibling in org A itself) — this case does not distinguish the two guards either. Whenever
+ * either guard admits a candidate, the org-scoped "no other active binding" check INSIDE
+ * `deactivateUserOrgMembershipIfNoOtherActiveBinding` (#4526) is provably always satisfied too,
+ * so this call path can only reach case ③ via the candidate-selection pre-filter (candidateCount:
+ * 0, the new user_orgs write is never reached at all).
  */
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -139,8 +146,10 @@ describeIfDatabase('W4-PRE-1c cases ②③ — org-scoped user_orgs deactivation
       deactivatedAccountIds: [departed],
     })
 
-    // The GLOBAL sibling guard excludes this person from candidacy entirely (pre-existing
-    // #4526 behaviour) — the new user_orgs write is never reached. See file doc-comment.
+    // The (as of W4-PRE-1d, ORG-SCOPED) sibling guard excludes this person from candidacy
+    // entirely — the sibling is active+linked in this SAME org, so both the pre-existing GLOBAL
+    // guard and the current org-scoped one agree here; the new user_orgs write is never reached.
+    // See file doc-comment.
     expect(outcome.candidateCount).toBe(0)
     expect(outcome.affected).toEqual([])
     await expect(membershipIsActive(user, orgA)).resolves.toBe(true)

--- a/packages/core-backend/tests/integration/attendance-w4pre1d-departure-candidate-split.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-w4pre1d-departure-candidate-split.db.test.ts
@@ -1,0 +1,366 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { applyDirectoryDeprovisionPolicies } from '../../src/directory/directory-sync'
+
+/**
+ * W4-PRE-1d — candidate-set split (owner P1/P2, #4530 review, issuecomment-5043752399,
+ * 2026-07-22), replacing the false-negative "双组织测试" from W4-PRE-1c
+ * (`attendance-w4pre1c-departure-org-scoped.db.test.ts` case②, whose org-B leg was a BARE
+ * `user_orgs` row with NO real directory binding — a shape that never reaches the code path the
+ * P1 actually lives in).
+ *
+ * Owner's confirmed P1, verbatim: "全局 sibling guard（directory-sync.ts:1425）把「A 离职但仍
+ * 在 B 任职」的用户整体排除出候选集 ⇒ A/B membership 都保持 active；我方「双组织测试」用裸 B
+ * user_orgs 行（无真实 binding）替身构造，恰好避开了点名场景——正门 0/0/0 在此为假阴性（fixture
+ * 形状与场景名失配，已固化为教训）。"
+ *
+ * FIXTURE SHAPE CHECKLIST for the named scenario below (every test that exercises it re-creates
+ * this shape from scratch; nothing is a bare `user_orgs` row standing in for a binding):
+ *   - TWO real `directory_integrations` rows (org A / org B), each with its OWN distinct,
+ *     explicit `org_id` (never the shared `default` sentinel — two integrations created without
+ *     an explicit org_id would collapse onto the SAME default org and silently defeat the whole
+ *     point of this fixture).
+ *   - TWO real `directory_accounts` rows for the SAME local user, one per integration.
+ *   - TWO real `directory_account_links` rows (`link_status = 'linked'`), one per account —
+ *     this is the exact join `applyDirectoryDeprovisionPolicies`'s candidate/global queries
+ *     read; a row in `user_orgs` alone (no link) is invisible to both queries.
+ *   - TWO real `user_orgs` rows (org A / org B), both `is_active = true` before the run.
+ * "Departs org A" = org A's `directory_accounts.is_active` flips to `false` (the real sweep
+ * transition) while org B's account stays `is_active = true` and linked throughout.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const uid = (name: string) => `w4pre1d-${name}-${TS}`
+
+describeIfDatabase('W4-PRE-1d — org-membership vs global candidate-set split (real DB)', () => {
+  let integrationA = ''
+  let integrationB = ''
+  let orgA = ''
+  let orgB = ''
+
+  const client = {
+    query: (sql: string, params?: unknown[]) =>
+      query(sql, params).then((r) => ({ rows: r.rows as Array<Record<string, unknown>> })),
+  }
+
+  const membershipIsActive = async (userId: string, orgId: string): Promise<boolean | null> => {
+    const result = await query<{ is_active: boolean }>(
+      `SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`,
+      [userId, orgId],
+    )
+    return result.rows[0]?.is_active ?? null
+  }
+
+  const isUserActive = async (userId: string): Promise<boolean | null> =>
+    (await query<{ is_active: boolean }>(`SELECT is_active FROM users WHERE id = $1`, [userId])).rows[0]?.is_active ?? null
+
+  const grantEnabled = async (userId: string): Promise<boolean | undefined> =>
+    (await query<{ enabled: boolean }>(
+      `SELECT enabled FROM user_external_auth_grants WHERE provider = 'dingtalk' AND local_user_id = $1`,
+      [userId],
+    )).rows[0]?.enabled
+
+  /** Creates a user (if not already present) plus one linked directory account in `integrationId`,
+   * plus an ACTIVE `user_orgs` row in `orgId`. Returns the directory_accounts.id. */
+  async function seedRealBinding(opts: {
+    userId: string
+    integrationId: string
+    orgId: string
+    accountActive: boolean
+  }): Promise<string> {
+    await query(
+      `INSERT INTO users (id, password_hash, is_active) VALUES ($1, 'x', true) ON CONFLICT (id) DO NOTHING`,
+      [opts.userId],
+    )
+    await query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)
+       ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = TRUE`,
+      [opts.userId, opts.orgId],
+    )
+    const external = `${opts.userId}-${opts.integrationId}-acct`
+    const account = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, is_active)
+       VALUES ($1, $2, $3, 'Fixture', $4) RETURNING id::text AS id`,
+      [opts.integrationId, external, `dingtalk:${external}`, opts.accountActive],
+    )
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status)
+       VALUES ($1::uuid, $2, 'linked')`,
+      [account.rows[0].id, opts.userId],
+    )
+    return account.rows[0].id
+  }
+
+  async function seedEnabledGrant(userId: string): Promise<void> {
+    await query(
+      `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
+       VALUES ('dingtalk', $1, TRUE, 'system:test-fixture', NOW(), NOW())`,
+      [userId],
+    )
+  }
+
+  beforeAll(async () => {
+    integrationA = (await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id, org_id) VALUES ($1, $2, $3) RETURNING id::text AS id`,
+      [`w4pre1d-a-${TS}`, `w4pre1d-corp-a-${TS}`, `w4pre1d-org-a-${TS}`],
+    )).rows[0].id
+    orgA = `w4pre1d-org-a-${TS}`
+    integrationB = (await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id, org_id) VALUES ($1, $2, $3) RETURNING id::text AS id`,
+      [`w4pre1d-b-${TS}`, `w4pre1d-corp-b-${TS}`, `w4pre1d-org-b-${TS}`],
+    )).rows[0].id
+    orgB = `w4pre1d-org-b-${TS}`
+  })
+
+  afterEach(async () => {
+    await query(`DELETE FROM user_external_auth_grants WHERE local_user_id LIKE $1`, [`w4pre1d-%-${TS}`])
+    await query(`DELETE FROM user_orgs WHERE user_id LIKE $1`, [`w4pre1d-%-${TS}`])
+    await query(`DELETE FROM directory_accounts WHERE integration_id = ANY($1::uuid[])`, [[integrationA, integrationB]]) // links cascade
+    await query(`DELETE FROM users WHERE id LIKE $1`, [`w4pre1d-%-${TS}`])
+  })
+
+  afterAll(async () => {
+    await query(`DELETE FROM directory_integrations WHERE id = ANY($1::uuid[])`, [[integrationA, integrationB]])
+  })
+
+  describe('① owner-named scenario, field-for-field: A departs while B is a REAL, still-active binding', () => {
+    it('mark_inactive leg: A membership deactivated, B membership stays active, platform user stays active, grant survives', async () => {
+      const user = uid('named-mi')
+      await seedRealBinding({ userId: user, integrationId: integrationB, orgId: orgB, accountActive: true })
+      const departedA = await seedRealBinding({ userId: user, integrationId: integrationA, orgId: orgA, accountActive: false })
+      await seedEnabledGrant(user)
+
+      const outcome = await applyDirectoryDeprovisionPolicies(client, {
+        integrationId: integrationA,
+        deactivatedAccountIds: [departedA],
+        syncedAccountCount: 50,
+        integrationDefaultPolicy: 'mark_inactive',
+        enabled: true,
+      })
+
+      // Org-membership candidate set (item 1): A alone has no OTHER active binding in org A —
+      // real, so this person IS a candidate.
+      expect(outcome.candidateCount).toBe(1)
+      // Global candidate set (item 2): B's REAL active binding means this person is NOT
+      // globally clear — the P1 defect's exact axis.
+      expect(outcome.globalCandidateCount).toBe(0)
+      expect(outcome.affected).toEqual([
+        { directoryAccountId: departedA, localUserId: user, policy: 'mark_inactive', globallyClear: false },
+      ])
+
+      // THE LOAD-BEARING ASSERTIONS (owner's named scenario, exact fields):
+      await expect(membershipIsActive(user, orgA)).resolves.toBe(false) // A membership deactivated
+      await expect(membershipIsActive(user, orgB)).resolves.toBe(true) // B membership untouched
+      await expect(isUserActive(user)).resolves.toBe(true) // platform user stays active
+      await expect(grantEnabled(user)).resolves.toBe(true) // grant survives (was TRUE, still TRUE)
+    })
+
+    it('disable_grant_only leg: A membership deactivated, B membership stays active, platform user stays active, grant survives', async () => {
+      const user = uid('named-dgo')
+      await seedRealBinding({ userId: user, integrationId: integrationB, orgId: orgB, accountActive: true })
+      const departedA = await seedRealBinding({ userId: user, integrationId: integrationA, orgId: orgA, accountActive: false })
+      await seedEnabledGrant(user)
+
+      const outcome = await applyDirectoryDeprovisionPolicies(client, {
+        integrationId: integrationA,
+        deactivatedAccountIds: [departedA],
+        syncedAccountCount: 50,
+        integrationDefaultPolicy: 'disable_grant_only',
+        enabled: true,
+      })
+
+      expect(outcome.candidateCount).toBe(1)
+      expect(outcome.globalCandidateCount).toBe(0)
+      expect(outcome.grantsDisabledCount).toBe(0)
+      expect(outcome.usersDeactivatedCount).toBe(0)
+
+      await expect(membershipIsActive(user, orgA)).resolves.toBe(false)
+      await expect(membershipIsActive(user, orgB)).resolves.toBe(true)
+      await expect(isUserActive(user)).resolves.toBe(true)
+      await expect(grantEnabled(user)).resolves.toBe(true)
+    })
+  })
+
+  describe('② last-org departure: once B ALSO departs, the global guard clears and grant/platform-user actions fire', () => {
+    it('mark_inactive: second run (B departs too) deactivates the platform user and closes the grant', async () => {
+      const user = uid('lastdep-mi')
+      const bindingB = await seedRealBinding({ userId: user, integrationId: integrationB, orgId: orgB, accountActive: true })
+      const departedA = await seedRealBinding({ userId: user, integrationId: integrationA, orgId: orgA, accountActive: false })
+      await seedEnabledGrant(user)
+
+      // Run 1: A departs while B is still active — same as case① above.
+      const first = await applyDirectoryDeprovisionPolicies(client, {
+        integrationId: integrationA,
+        deactivatedAccountIds: [departedA],
+        syncedAccountCount: 50,
+        integrationDefaultPolicy: 'mark_inactive',
+        enabled: true,
+      })
+      expect(first.globalCandidateCount).toBe(0)
+      await expect(isUserActive(user)).resolves.toBe(true)
+      await expect(grantEnabled(user)).resolves.toBe(true)
+
+      // Now B ALSO departs — the real sweep transition, then the executor runs for org B.
+      await query(`UPDATE directory_accounts SET is_active = false WHERE id = $1`, [bindingB])
+      const second = await applyDirectoryDeprovisionPolicies(client, {
+        integrationId: integrationB,
+        deactivatedAccountIds: [bindingB],
+        syncedAccountCount: 50,
+        integrationDefaultPolicy: 'mark_inactive',
+        enabled: true,
+      })
+
+      // Org-membership candidate for org B (no other active binding in org B); NOW globally
+      // clear too (org A's account is already inactive from run 1).
+      expect(second.candidateCount).toBe(1)
+      expect(second.globalCandidateCount).toBe(1)
+
+      await expect(membershipIsActive(user, orgA)).resolves.toBe(false)
+      await expect(membershipIsActive(user, orgB)).resolves.toBe(false)
+      await expect(isUserActive(user)).resolves.toBe(false) // NOW deactivated
+      await expect(grantEnabled(user)).resolves.toBe(false) // NOW closed
+    })
+
+    it('disable_grant_only: second run (B departs too) closes the grant but the platform user is NEVER touched', async () => {
+      const user = uid('lastdep-dgo')
+      const bindingB = await seedRealBinding({ userId: user, integrationId: integrationB, orgId: orgB, accountActive: true })
+      const departedA = await seedRealBinding({ userId: user, integrationId: integrationA, orgId: orgA, accountActive: false })
+      await seedEnabledGrant(user)
+
+      await applyDirectoryDeprovisionPolicies(client, {
+        integrationId: integrationA,
+        deactivatedAccountIds: [departedA],
+        syncedAccountCount: 50,
+        integrationDefaultPolicy: 'disable_grant_only',
+        enabled: true,
+      })
+      await expect(grantEnabled(user)).resolves.toBe(true)
+      await expect(isUserActive(user)).resolves.toBe(true)
+
+      await query(`UPDATE directory_accounts SET is_active = false WHERE id = $1`, [bindingB])
+      const second = await applyDirectoryDeprovisionPolicies(client, {
+        integrationId: integrationB,
+        deactivatedAccountIds: [bindingB],
+        syncedAccountCount: 50,
+        integrationDefaultPolicy: 'disable_grant_only',
+        enabled: true,
+      })
+
+      expect(second.globalCandidateCount).toBe(1)
+      expect(second.usersDeactivatedCount).toBe(0) // disable_grant_only never sets this
+
+      await expect(membershipIsActive(user, orgA)).resolves.toBe(false)
+      await expect(membershipIsActive(user, orgB)).resolves.toBe(false)
+      await expect(grantEnabled(user)).resolves.toBe(false) // NOW closed — globally clear
+      await expect(isUserActive(user)).resolves.toBe(true) // …but the platform user survives, always
+    })
+  })
+
+  describe('③ breaker uses the org-membership candidate count, not the global-filtered count', () => {
+    it('trips batch_exceeds_max on candidateCount even though EVERY candidate is globally protected (globalCandidateCount would be 0)', async () => {
+      // Three DIFFERENT users, each with a real departed account in org A and a real ACTIVE
+      // account in their OWN separate org (so none of them is globally clear) — a batch that
+      // the OLD global-guard-at-selection code would have reported as 0 candidates (silently
+      // admitting all three), but which the org-membership count correctly sees as 3.
+      const users = [uid('breaker1'), uid('breaker2'), uid('breaker3')]
+      const departedIds: string[] = []
+      const otherOrgIntegrationIds: string[] = []
+      try {
+        for (const [i, user] of users.entries()) {
+          const otherOrgIntegration = (await query<{ id: string }>(
+            `INSERT INTO directory_integrations (name, corp_id, org_id) VALUES ($1, $2, $3) RETURNING id::text AS id`,
+            [`w4pre1d-breaker-other-${i}-${TS}`, `w4pre1d-breaker-other-corp-${i}-${TS}`, `w4pre1d-breaker-other-org-${i}-${TS}`],
+          )).rows[0].id
+          otherOrgIntegrationIds.push(otherOrgIntegration)
+          await seedRealBinding({
+            userId: user,
+            integrationId: otherOrgIntegration,
+            orgId: `w4pre1d-breaker-other-org-${i}-${TS}`,
+            accountActive: true,
+          })
+          const departed = await seedRealBinding({ userId: user, integrationId: integrationA, orgId: orgA, accountActive: false })
+          departedIds.push(departed)
+        }
+
+        const outcome = await applyDirectoryDeprovisionPolicies(client, {
+          integrationId: integrationA,
+          deactivatedAccountIds: departedIds,
+          syncedAccountCount: 50,
+          integrationDefaultPolicy: 'mark_inactive',
+          maxBatch: 2, // 3 org-membership candidates > 2 ⇒ must abort
+          enabled: true,
+        })
+
+        expect(outcome.candidateCount).toBe(3)
+        expect(outcome.abortedReason).toBe('batch_exceeds_max')
+        expect(outcome.applied).toBe(false)
+        expect(outcome.globalCandidateCount).toBe(0)
+
+        // Nothing was touched — the abort happened before any write, for all three.
+        for (const user of users) {
+          await expect(membershipIsActive(user, orgA)).resolves.toBe(true)
+          await expect(isUserActive(user)).resolves.toBe(true)
+        }
+      } finally {
+        // Cascades to that integration's own directory_accounts/links (FK ON DELETE CASCADE);
+        // the shared afterEach only reaches integrationA/integrationB.
+        await query(`DELETE FROM directory_integrations WHERE id = ANY($1::uuid[])`, [otherOrgIntegrationIds])
+      }
+    })
+  })
+
+  describe('④ manual_review regression under the split: unaffected by globallyClear either way', () => {
+    it('manual_review: both memberships stay active, no write at all, pending exposure unaffected by cross-org binding', async () => {
+      const user = uid('mr')
+      await seedRealBinding({ userId: user, integrationId: integrationB, orgId: orgB, accountActive: true })
+      const departedA = await seedRealBinding({ userId: user, integrationId: integrationA, orgId: orgA, accountActive: false })
+
+      const outcome = await applyDirectoryDeprovisionPolicies(client, {
+        integrationId: integrationA,
+        deactivatedAccountIds: [departedA],
+        syncedAccountCount: 50,
+        integrationDefaultPolicy: 'manual_review',
+        enabled: true,
+      })
+
+      expect(outcome.candidateCount).toBe(1)
+      expect(outcome.manualReviewCount).toBe(1)
+      expect(outcome.affected).toEqual([])
+      expect(outcome.manualReviewPending).toEqual([{ directoryAccountId: departedA, localUserId: user, orgId: orgA }])
+
+      await expect(membershipIsActive(user, orgA)).resolves.toBe(true)
+      await expect(membershipIsActive(user, orgB)).resolves.toBe(true)
+      await expect(isUserActive(user)).resolves.toBe(true)
+    })
+  })
+
+  describe('⑤ switch OFF: zero deactivation even for the owner-named scenario, preview numbers still split correctly', () => {
+    it('enabled:false leaves both real memberships, the platform user, and the grant untouched — preview reports the split', async () => {
+      const user = uid('off')
+      await seedRealBinding({ userId: user, integrationId: integrationB, orgId: orgB, accountActive: true })
+      const departedA = await seedRealBinding({ userId: user, integrationId: integrationA, orgId: orgA, accountActive: false })
+      await seedEnabledGrant(user)
+
+      const outcome = await applyDirectoryDeprovisionPolicies(client, {
+        integrationId: integrationA,
+        deactivatedAccountIds: [departedA],
+        syncedAccountCount: 50,
+        integrationDefaultPolicy: 'mark_inactive',
+        enabled: false,
+      })
+
+      expect(outcome.applied).toBe(false)
+      expect(outcome.candidateCount).toBe(1) // org-membership candidate, preview-counted
+      expect(outcome.globalCandidateCount).toBe(0) // not globally clear — B is real+active
+      expect(outcome.membershipDeactivationAttemptedCount).toBe(1) // "would have" attempted
+      expect(outcome.usersDeactivatedCount).toBe(0) // "would have" — gated on globallyClear, which is false here
+      expect(outcome.grantsDisabledCount).toBe(0)
+
+      await expect(membershipIsActive(user, orgA)).resolves.toBe(true)
+      await expect(membershipIsActive(user, orgB)).resolves.toBe(true)
+      await expect(isUserActive(user)).resolves.toBe(true)
+      await expect(grantEnabled(user)).resolves.toBe(true)
+    })
+  })
+})

--- a/packages/core-backend/tests/integration/directory-sync-orchestration.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-sync-orchestration.db.test.ts
@@ -549,11 +549,13 @@ describeIfDatabase('syncDirectoryIntegration orchestration harness (real DB)', (
       }
     }
 
-    const cleanupTargets: Array<{ integrationId: string; localUserId: string }> = []
+    const cleanupTargets: Array<{ integrationId: string; localUserId: string; siblingIntegrationId?: string }> = []
 
     afterAll(async () => {
       for (const target of cleanupTargets) {
         await cleanupIntegration(target.integrationId)
+        if (target.siblingIntegrationId) await cleanupIntegration(target.siblingIntegrationId)
+        await query(`DELETE FROM user_orgs WHERE user_id = $1`, [target.localUserId])
         await query(`DELETE FROM user_external_auth_grants WHERE local_user_id = $1`, [target.localUserId])
         await query(`DELETE FROM users WHERE id = $1`, [target.localUserId])
       }
@@ -590,12 +592,39 @@ describeIfDatabase('syncDirectoryIntegration orchestration harness (real DB)', (
 
       expect(stats.deprovisionApplied).toBe(true)
       expect(stats.deprovisionCandidateCount).toBe(1)
+      // W4-PRE-1d (owner P2 item 2, review-findings P1/P2): this fixture is a single-org
+      // departure with no sibling binding anywhere, so the org-membership candidate is ALSO
+      // globally clear — both counts read 1 for this scenario. The dual-org test below
+      // ("with a real, still-active binding in ANOTHER org...") is the one that actually
+      // exercises `globalCandidateCount` diverging from `candidateCount`.
+      expect(stats.deprovisionGlobalCandidateCount).toBe(1)
       expect(stats.deprovisionGrantsDisabledCount).toBe(1)
       expect(stats.deprovisionUsersDeactivatedCount).toBe(1)
       expect(stats.deprovisionAbortedReason).toBeNull()
       expect(stats.deprovisionAffected).toEqual([
-        { directoryAccountId: fixture.accountId, localUserId: fixture.localUserId, policy: 'mark_inactive' },
+        { directoryAccountId: fixture.accountId, localUserId: fixture.localUserId, policy: 'mark_inactive', globallyClear: true },
       ])
+
+      // Sweep-layer audit trail (owner P2 item 2, review finding: `meta.grantDisabled` /
+      // `meta.userDeactivated` were previously hardcoded `true` / `policy === 'mark_inactive'`
+      // and NO test — at the real `syncDirectoryIntegration` sweep layer, as opposed to a
+      // direct `applyDirectoryDeprovisionPolicies` call — asserted on them; a revert to the
+      // hardcoded form would have stayed green here). This is the globally-clear=true branch;
+      // the dual-org test below covers the false branch.
+      const audit = await query<{ action_details: Record<string, unknown> }>(
+        `SELECT action_details FROM audit_logs
+          WHERE resource_type = 'directory-account-link' AND resource_id = $1
+          ORDER BY id DESC LIMIT 1`,
+        [fixture.accountId],
+      )
+      expect(audit.rows).toHaveLength(1)
+      expect(audit.rows[0].action_details).toMatchObject({
+        policy: 'mark_inactive',
+        grantDisabled: true,
+        userDeactivated: true,
+        globallyClear: true,
+        membershipDeactivationAttempted: true,
+      })
     })
 
     it('with the flag unset (shipped default), the same departure writes NOTHING — counts are preview-only', async () => {
@@ -620,7 +649,181 @@ describeIfDatabase('syncDirectoryIntegration orchestration harness (real DB)', (
       // But the run REPORTS what it would have done (the operator preview).
       expect(stats.deprovisionApplied).toBe(false)
       expect(stats.deprovisionCandidateCount).toBe(1)
+      expect(stats.deprovisionGlobalCandidateCount).toBe(1)
       expect(stats.deprovisionUsersDeactivatedCount).toBe(1)
+    })
+
+    // -----------------------------------------------------------------------
+    // Dual-org fixture (owner P1/P2, #4530 review — issuecomment-5043752399):
+    // the named scenario is a real, still-active binding in a DIFFERENT org, not a
+    // bare `user_orgs` stand-in. This is the one test in this file where
+    // `globalCandidateCount` actually diverges from `candidateCount` (0 vs 1),
+    // exercising the sweep-layer observability (run-stats + audit meta) that the
+    // two single-org fixtures above cannot: their globally-clear=true scenario
+    // cannot distinguish a correct `globallyClear`-gated write from an
+    // unconditional one.
+    // -----------------------------------------------------------------------
+    async function seedDualOrgDepartureFixture(tag: string): Promise<{
+      integrationId: string
+      siblingIntegrationId: string
+      siblingOrgId: string
+      localUserId: string
+      accountId: string
+      deptId: string
+      survivorExt: string
+    }> {
+      const integration = await createDirectoryIntegration({
+        name: `dso-dep-${tag}-${TS}`,
+        corpId: `dso-dep-corp-${tag}-${TS}`,
+        appKey: `dso-dep-appkey-${tag}-${TS}`,
+        appSecret: 'dso-secret',
+        admissionMode: 'manual_only',
+        defaultDeprovisionPolicy: 'mark_inactive',
+      })
+
+      // A second, real integration with its OWN distinct, explicit org_id (never the shared
+      // 'default' sentinel the fixture above uses — two integrations without an explicit
+      // org_id would collapse onto the same org and silently defeat this fixture).
+      const siblingOrgId = `dso-dep-orgB-${tag}-${TS}`
+      const siblingIntegration = await query<{ id: string }>(
+        `INSERT INTO directory_integrations (name, corp_id, org_id) VALUES ($1, $2, $3) RETURNING id::text AS id`,
+        [`dso-dep-sib-${tag}-${TS}`, `dso-dep-sib-corp-${tag}-${TS}`, siblingOrgId],
+      )
+
+      const localUserId = `dso-dep-dual-user-${tag}-${TS}`
+      await query(`INSERT INTO users (id, email, password_hash, is_active) VALUES ($1, $2, 'x', TRUE)`, [
+        localUserId,
+        `${localUserId}@example.test`,
+      ])
+      await query(
+        `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, 'default', TRUE)
+         ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = TRUE`,
+        [localUserId],
+      )
+
+      // THIS org's account: pre-linked, absent from the pull below — the sweep transitions it
+      // to inactive and hands its id to the executor within the same run (same shape as the
+      // single-org fixture above).
+      const account = await query<{ id: string }>(
+        `INSERT INTO directory_accounts (
+           integration_id, corp_id, external_user_id, union_id, external_key, name, is_active, last_seen_at, created_at, updated_at
+         ) VALUES ($1, $2, $3, $4, $4, 'Departed', true, NOW(), NOW(), NOW())
+         RETURNING id`,
+        [integration.id, `dso-dep-corp-${tag}-${TS}`, `dso-dep-dual-ext-${tag}-${TS}`, `dso-dep-dual-un-${tag}-${TS}`],
+      )
+      await query(
+        `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy, created_at, updated_at)
+         VALUES ($1, $2, 'linked', 'manual', NOW(), NOW())`,
+        [account.rows[0].id, localUserId],
+      )
+
+      // The REAL sibling binding in the OTHER org — active and linked throughout. Owner P1,
+      // verbatim: "全局 sibling guard...把「A 离职但仍在 B 任职」的用户整体排除出候选集"; owner
+      // P2 item 4 requires this be a real integration + real binding, never a bare `user_orgs`
+      // row standing in for one.
+      const siblingAccount = await query<{ id: string }>(
+        `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, is_active)
+         VALUES ($1, $2, $3, 'Sibling', TRUE) RETURNING id`,
+        [siblingIntegration.rows[0].id, `dso-dep-dual-sib-ext-${tag}-${TS}`, `dingtalk:dso-dep-dual-sib-${tag}-${TS}`],
+      )
+      await query(
+        `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status)
+         VALUES ($1, $2, 'linked')`,
+        [siblingAccount.rows[0].id, localUserId],
+      )
+      await query(
+        `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, TRUE)
+         ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = TRUE`,
+        [localUserId, siblingOrgId],
+      )
+
+      // Pre-existing enabled grant — must survive UNTOUCHED (globallyClear is false here).
+      await query(
+        `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
+         VALUES ('dingtalk', $1, TRUE, 'system:test-fixture', NOW(), NOW())`,
+        [localUserId],
+      )
+
+      return {
+        integrationId: integration.id,
+        siblingIntegrationId: siblingIntegration.rows[0].id,
+        siblingOrgId,
+        localUserId,
+        accountId: account.rows[0].id,
+        deptId: `dso-dep-dual-dept-${tag}-${TS}`,
+        survivorExt: `dso-dep-dual-surv-${tag}-${TS}`,
+      }
+    }
+
+    it('with a real, still-active binding in ANOTHER org, mark_inactive deactivates only THIS org membership: grant + platform user survive, and the sweep-layer observability tells the truth (owner P2 items 1/2/4)', async () => {
+      const fixture = await seedDualOrgDepartureFixture('dual')
+      cleanupTargets.push(fixture)
+      activeDirectory = departureDirectory(fixture)
+
+      process.env.DIRECTORY_DEPROVISION_ENABLED = 'true'
+      let stats: Record<string, unknown>
+      try {
+        const result = await syncDirectoryIntegration(fixture.integrationId, 'system:dso-dep-dual')
+        stats = result.run.stats as Record<string, unknown>
+      } finally {
+        delete process.env.DIRECTORY_DEPROVISION_ENABLED
+      }
+
+      // THIS org's membership WAS deactivated — item 1 is org-scoped and unconditional on
+      // global clearance.
+      const membershipA = await query<{ is_active: boolean }>(
+        `SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = 'default'`,
+        [fixture.localUserId],
+      )
+      expect(membershipA.rows[0].is_active).toBe(false)
+
+      // The SIBLING org's membership is untouched — a different run, a different org.
+      const membershipB = await query<{ is_active: boolean }>(
+        `SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`,
+        [fixture.localUserId, fixture.siblingOrgId],
+      )
+      expect(membershipB.rows[0].is_active).toBe(true)
+
+      // NOT globally clear: the platform user and the DingTalk grant both survive.
+      const user = await query<{ is_active: boolean }>(`SELECT is_active FROM users WHERE id = $1`, [fixture.localUserId])
+      expect(user.rows[0].is_active).toBe(true)
+
+      const grant = await query<{ enabled: boolean }>(
+        `SELECT enabled FROM user_external_auth_grants WHERE provider = 'dingtalk' AND local_user_id = $1`,
+        [fixture.localUserId],
+      )
+      expect(grant.rows).toHaveLength(1)
+      expect(grant.rows[0].enabled).toBe(true)
+
+      expect(stats.deprovisionApplied).toBe(true)
+      expect(stats.deprovisionCandidateCount).toBe(1)
+      expect(stats.deprovisionGlobalCandidateCount).toBe(0)
+      expect(stats.deprovisionGrantsDisabledCount).toBe(0)
+      expect(stats.deprovisionUsersDeactivatedCount).toBe(0)
+      expect(stats.deprovisionMembershipDeactivationAttemptedCount).toBe(1)
+      expect(stats.deprovisionAbortedReason).toBeNull()
+      expect(stats.deprovisionAffected).toEqual([
+        { directoryAccountId: fixture.accountId, localUserId: fixture.localUserId, policy: 'mark_inactive', globallyClear: false },
+      ])
+
+      // Sweep-layer audit trail must tell the truth per-person (owner P2 item 2, review
+      // finding: this is the globally-clear=FALSE branch of the same hardcoded-value regression
+      // the test above closes for the TRUE branch — a revert to `grantDisabled: true` /
+      // `userDeactivated: policy === 'mark_inactive'` unconditionally would go red here).
+      const audit = await query<{ action_details: Record<string, unknown> }>(
+        `SELECT action_details FROM audit_logs
+          WHERE resource_type = 'directory-account-link' AND resource_id = $1
+          ORDER BY id DESC LIMIT 1`,
+        [fixture.accountId],
+      )
+      expect(audit.rows).toHaveLength(1)
+      expect(audit.rows[0].action_details).toMatchObject({
+        policy: 'mark_inactive',
+        grantDisabled: false,
+        userDeactivated: false,
+        globallyClear: false,
+        membershipDeactivationAttempted: true,
+      })
     })
   })
 

--- a/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
+++ b/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
@@ -25,20 +25,33 @@ import {
  * fail-safe direction of policy resolution.
  */
 // W4-PRE-1c (owner 裁决②, #4522 rev3 review, 2026-07-22): `applyDirectoryDeprovisionPolicies`
-// now ALSO resolves the run's org (`SELECT org_id FROM directory_integrations ...`, lazily, at
-// most once) and — for a policy that actually executed a write — attempts a same-transaction
-// `user_orgs` deactivation via `deactivateUserOrgMembershipIfNoOtherActiveBinding` (a row lock
-// SELECT, then a conditional UPDATE). This stub answers all three shapes the same "does not
-// evaluate the predicate" way the pre-existing shapes do — the org-scoped sibling predicate
-// itself is proved against real Postgres in the real-DB suites (this file's own scope note),
-// same discipline extended to the new queries.
+// now ALSO resolves the run's org (`SELECT org_id FROM directory_integrations ...`) and — for a
+// policy that actually executed a write — attempts a same-transaction `user_orgs` deactivation
+// via `deactivateUserOrgMembershipIfNoOtherActiveBinding` (a row lock SELECT, then a conditional
+// UPDATE). This stub answers all three shapes the same "does not evaluate the predicate" way the
+// pre-existing shapes do — the org-scoped sibling predicate itself is proved against real
+// Postgres in the real-DB suites (this file's own scope note), same discipline extended to the
+// new queries.
+//
+// W4-PRE-1d (owner P2, #4530 review, issuecomment-5043752399, 2026-07-22): the candidate
+// SELECT is now itself org-scoped (org resolved EAGERLY, no longer lazily — the org id is a
+// WHERE parameter) and a SECOND query decides the GLOBAL candidate set (no other active binding
+// ANYWHERE) that gates grant/platform-user actions. This stub answers the global-clear query
+// with "every requested user IS globally clear" by default — same "does not evaluate the
+// predicate" discipline — unless a test opts a user OUT via `notGloballyClear`, which is how
+// the new item-2 dispatch tests below exercise the "org-membership candidate but NOT globally
+// clear" branch without a real database.
 const STUB_ORG_ID = 'org-1'
 
-function stubClient(candidates: Array<{ directory_account_id: string; local_user_id: string; deprovision_policy_override: string | null }>) {
+function stubClient(
+  candidates: Array<{ directory_account_id: string; local_user_id: string; deprovision_policy_override: string | null }>,
+  options: { notGloballyClear?: string[] } = {},
+) {
+  const notGloballyClear = new Set(options.notGloballyClear ?? [])
   const queries: string[] = []
   return {
     queries,
-    query: async (sql: string) => {
+    query: async (sql: string, params?: unknown[]) => {
       queries.push(sql)
       if (/FROM directory_accounts a/i.test(sql) && /JOIN directory_account_links/i.test(sql)) {
         // The stub answers the selection query with whatever the test asked for. It does NOT
@@ -56,6 +69,10 @@ function stubClient(candidates: Array<{ directory_account_id: string; local_user
       }
       if (/UPDATE user_orgs\s+SET is_active = FALSE/i.test(sql)) {
         return { rows: [] }
+      }
+      if (/FROM UNNEST\(\$1::text\[\]\) AS candidate_user/i.test(sql)) {
+        const requested = (params?.[0] as string[] | undefined) ?? []
+        return { rows: requested.filter((id) => !notGloballyClear.has(id)).map((id) => ({ local_user_id: id })) }
       }
       // Anything else is drift: a new query appeared that no test has reasoned about.
       throw new Error(`Unhandled SQL in deprovision stub:\n${sql}`)
@@ -94,6 +111,7 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
     expect(outcome).toMatchObject({
       applied: false,
       candidateCount: 1,
+      globalCandidateCount: 1,
       usersDeactivatedCount: 1,
       grantsDisabledCount: 1,
       // Preview mode reports what WOULD be attempted too — same construction as
@@ -115,8 +133,34 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
     // that predicate, only that the write was attempted.
     expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(true)
     expect(outcome.applied).toBe(true)
-    expect(outcome.affected).toEqual([{ directoryAccountId: 'acct-1', localUserId: 'user-1', policy: 'mark_inactive' }])
+    expect(outcome.affected).toEqual([
+      { directoryAccountId: 'acct-1', localUserId: 'user-1', policy: 'mark_inactive', globallyClear: true },
+    ])
     expect(outcome.membershipDeactivationAttemptedCount).toBe(1)
+    expect(outcome.globalCandidateCount).toBe(1)
+  })
+
+  // W4-PRE-1d item 1 vs item 2 (owner P2, #4530 review): the P1 defect this PR fixes — a person
+  // whose org-membership candidacy is real (org A has no other active binding) but who is NOT
+  // globally clear (still actively employed via a DIFFERENT org's directory) must have org A's
+  // `user_orgs` deactivated while their grant and platform account survive untouched.
+  it('enabled + mark_inactive + NOT globally clear: attempts the user_orgs deactivation but leaves the grant and platform user alone', async () => {
+    const client = stubClient([CANDIDATE], { notGloballyClear: ['user-1'] })
+    const outcome = await applyDirectoryDeprovisionPolicies(client, { ...baseOptions, enabled: true })
+
+    expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(true)
+    expect(wrote(client.queries, DISABLES_GRANT)).toBe(false)
+    expect(wrote(client.queries, DEACTIVATES_USER)).toBe(false)
+    expect(outcome).toMatchObject({
+      candidateCount: 1,
+      globalCandidateCount: 0,
+      grantsDisabledCount: 0,
+      usersDeactivatedCount: 0,
+      membershipDeactivationAttemptedCount: 1,
+    })
+    expect(outcome.affected).toEqual([
+      { directoryAccountId: 'acct-1', localUserId: 'user-1', policy: 'mark_inactive', globallyClear: false },
+    ])
   })
 
   it('enabled + disable_grant_only: revokes DingTalk login, leaves the local user active, but STILL attempts the user_orgs deactivation', async () => {
@@ -137,7 +181,28 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
     // body's combination-semantics section: this is a genuinely NEW consequence of
     // disable_grant_only that did not exist before this PR.
     expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(true)
-    expect(outcome).toMatchObject({ grantsDisabledCount: 1, usersDeactivatedCount: 0, membershipDeactivationAttemptedCount: 1 })
+    expect(outcome).toMatchObject({
+      grantsDisabledCount: 1,
+      globalCandidateCount: 1,
+      usersDeactivatedCount: 0,
+      membershipDeactivationAttemptedCount: 1,
+    })
+  })
+
+  it('enabled + disable_grant_only + NOT globally clear: attempts the user_orgs deactivation but the grant survives (owner P2 item 2: grant closure stays global-guarded)', async () => {
+    const client = stubClient([CANDIDATE], { notGloballyClear: ['user-1'] })
+    const outcome = await applyDirectoryDeprovisionPolicies(client, {
+      ...baseOptions,
+      integrationDefaultPolicy: 'disable_grant_only',
+      enabled: true,
+    })
+
+    expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(true)
+    expect(wrote(client.queries, DISABLES_GRANT)).toBe(false)
+    expect(outcome).toMatchObject({ grantsDisabledCount: 0, globalCandidateCount: 0, membershipDeactivationAttemptedCount: 1 })
+    expect(outcome.affected).toEqual([
+      { directoryAccountId: 'acct-1', localUserId: 'user-1', policy: 'disable_grant_only', globallyClear: false },
+    ])
   })
 
   it('enabled + manual_review: touches nothing (including user_orgs), but the offboarding is counted and exposed as pending', async () => {
@@ -246,6 +311,35 @@ describe('DT-OPS-01 deprovision executor (policy dispatch, given candidates)', (
     // Same breaker-negative coverage as the empty-fetch abort test above.
     expect(wrote(client.queries, DEACTIVATES_USER_ORG)).toBe(false)
     expect(outcome.membershipDeactivationAttemptedCount).toBe(0)
+  })
+
+  // W4-PRE-1d item 3 (owner P2, #4530 review — "breaker 改用组织成员候选数（防大批跨组织失活绕
+  // 上限）"): the breaker must trip on the ORG-MEMBERSHIP candidate count even when NEITHER
+  // candidate is globally clear (globalCandidateCount would be 0) — proving the breaker's input
+  // is `candidateCount`, not a globally-filtered count that could stay under the cap while a
+  // large cross-org membership batch slips through. The global-clear query is never even
+  // reached: the abort-and-return happens before it runs.
+  it('the breaker trips on org-membership candidateCount even when globalCandidateCount would be zero (owner P2 item 3)', async () => {
+    const client = stubClient(
+      [
+        { directory_account_id: 'acct-1', local_user_id: 'user-1', deprovision_policy_override: null },
+        { directory_account_id: 'acct-2', local_user_id: 'user-2', deprovision_policy_override: null },
+      ],
+      { notGloballyClear: ['user-1', 'user-2'] },
+    )
+    const outcome = await applyDirectoryDeprovisionPolicies(client, {
+      ...baseOptions,
+      deactivatedAccountIds: ['acct-1', 'acct-2'],
+      maxBatch: 1,
+      enabled: true,
+    })
+
+    expect(outcome.candidateCount).toBe(2)
+    expect(outcome.abortedReason).toBe('batch_exceeds_max')
+    expect(outcome.applied).toBe(false)
+    expect(outcome.globalCandidateCount).toBe(0)
+    // The global-clear query never ran — the abort happened before it was reached.
+    expect(client.queries.some((sql) => /FROM UNNEST\(\$1::text\[\]\) AS candidate_user/i.test(sql))).toBe(false)
   })
 })
 


### PR DESCRIPTION
## What

W4-PRE-1d — the fix ticket owner opened on the #4530 (W4-PRE-1c) re-review verdict (2026-07-22, 1P1/1P2, comment [issuecomment-5043752399](https://github.com/zensgit/metasheet2/issues/4530#issuecomment-5043752399)). #4530 itself stayed **MERGED** (`1a209a5cc`) — its `DIRECTORY_DEPROVISION_ENABLED` switch is default-OFF, so nothing to roll back — but the owner's re-review confirmed a real defect in its candidate selection and opened this follow-up.

**Not merged, not armed.** Base `main` (`1a209a5cc` = #4530 merged), refs #4530 #4522. `DIRECTORY_DEPROVISION_ENABLED` stays default-OFF; never armed on any non-test surface in this branch.

**2026-07-22 update**: a three-mirror review of this PR returned 8 findings (1 P1, 3 P2, 4 P3) — see "Review-fix round" below for the full disposition table (1 required-check test regression fixed, 1 sweep-layer coverage gap closed with mutation proof, 3 doc/quote-fidelity corrections, 2 concurrency findings documented and deferred to an owner-scoped follow-up, one already-covered duplicate).

Owner's confirmed [P1], verbatim: 「全局 sibling guard（directory-sync.ts:1425）把「A 离职但仍在 B 任职」的用户整体排除出候选集 ⇒ A/B membership 都保持 active；我方「双组织测试」用裸 B user_orgs 行（无真实 binding）替身构造，恰好避开了点名场景——**正门 0/0/0 在此为假阴性**（fixture 形状与场景名失配，已固化为教训）。」

## 拆分规格 → 实现映射

Owner's [P2] spec (verbatim, four items — quoted exactly from the only GitHub-persisted record,
[issuecomment-5043752399](https://github.com/zensgit/metasheet2/issues/4530#issuecomment-5043752399);
a prior revision of this table paraphrased items 2–4 while labeling them "verbatim" — corrected
per review finding):

> 1. **组织成员资格候选**：按 (userId, orgId) 计算——A 无同组织活跃绑定即可失活 A 的 user_orgs；
> 2. **全局账号/授权候选**：保留「任意位置无活跃绑定」守卫，才允许关闭 DingTalk grant 或 users.is_active；
> 3. **breaker 改用组织成员候选数**（防大批跨组织失活绕上限）；
> 4. 真库测试改为 **A、B 两真实 integration + 两真实 directory binding**，点名场景逐字段构造（离职 A ⇒ A 失活、B 保留、平台用户 active）。

| Item | Owner spec | Implementation |
|---|---|---|
| 1 | Org-membership candidates, (userId, orgId)-scoped | `directory-sync.ts` candidate `SELECT` inside `applyDirectoryDeprovisionPolicies`: the `NOT EXISTS` sibling guard now joins `directory_integrations sibling_integration` and filters `sibling_integration.org_id = $2::text` (this run's own org, resolved eagerly up front) instead of being unscoped. Mirrors `deactivateUserOrgMembershipIfNoOtherActiveBinding`'s (#4526) own org-scoped predicate exactly. |
| 2 | Global guard kept, but only gates grant/`users.is_active` | The old unscoped `NOT EXISTS` is relocated to a **second** query (`SELECT ... FROM UNNEST($1::text[]) ... WHERE NOT EXISTS (...)`) run once per batch, restricted to non-`manual_review` org-membership candidates. Its result (`globallyClearUserIds`) gates the `INSERT INTO user_external_auth_grants` and (for `mark_inactive`) `UPDATE users SET is_active = FALSE` writes — the org-membership `user_orgs` write is now **unconditional** on this check. |
| 3 | Breaker uses org-membership count | `evaluateDirectoryDeprovisionCircuitBreaker({ candidateCount: outcome.candidateCount, ... })` — `outcome.candidateCount` is now `byUser.size` from the ORG-scoped candidate query (item 1), computed and checked **before** the global-clear query even runs. Threshold semantics (`DIRECTORY_DEPROVISION_MAX_BATCH`, absolute count, no ratio mode) are unchanged — only what gets counted changed. |
| 4 | Real A/B integrations + real bindings | New file `attendance-w4pre1d-departure-candidate-split.db.test.ts` — see fixture checklist below. |

Observability (owner: "按两候选集分列计数"):
- `DirectoryDeprovisionOutcome.candidateCount` — re-documented as the org-membership set (breaker input).
- `DirectoryDeprovisionOutcome.globalCandidateCount` (**new field**) — the global set (non-`manual_review` org-membership candidates who are also globally clear); by construction equals `grantsDisabledCount`, named separately so the SET is visible on its own.
- `affected[]` entries gained `globallyClear: boolean` (values-free).
- Run-stats gained `deprovisionGlobalCandidateCount`.
- Audit `meta.grantDisabled` / `meta.userDeactivated` now read the real per-person `globallyClear` flag instead of being hardcoded `true` / `policy === 'mark_inactive'` — this was silently wrong the instant a not-globally-clear candidate existed; a `meta.globallyClear` field was also added.
- Preview log line now reports both counts: `"N org-membership candidate(s) (M also globally clear)"`.

## candidateSets

| Set | Predicate | Governs | Field |
|---|---|---|---|
| Org-membership | No OTHER active linked directory account in the **same org** as the departed account | `user_orgs` deactivation (all non-`manual_review`); circuit breaker input | `candidateCount` |
| Global | No OTHER active linked directory account **anywhere** (any org) — restricted to non-`manual_review` org-membership candidates | DingTalk grant close; `users.is_active` (mark_inactive only) | `globalCandidateCount` |

## policyMatrix

| Policy | org membership (this org's `user_orgs`) | platform user (`users.is_active`) | DingTalk grant |
|---|---|---|---|
| `manual_review` | stays active; exposed via `manualReviewPending` (org/membership-scoped, values-free) | untouched | untouched |
| `disable_grant_only` | deactivated (org-membership candidate + breaker + switch + policy-executed, #4526/#4530 three-gate unchanged) | **never** touched, regardless of global clearance | closed **only if globally clear** |
| `mark_inactive` | deactivated (same three-gate) | deactivated **only if globally clear** | closed **only if globally clear** |

## ①案 fixture 形状清单（owner-named scenario, `attendance-w4pre1d-departure-candidate-split.db.test.ts`）

Every test that exercises the named scenario builds this shape from scratch (no bare `user_orgs` stand-in anywhere in this file):

| Table | Rows | Notes |
|---|---|---|
| `directory_integrations` | 2 (`integrationA`, `integrationB`) | Each with its **own explicit, distinct** `org_id` — never the shared `'default'` migration sentinel (two integrations created without an explicit `org_id` collapse onto the same default org and silently defeat the fixture). |
| `directory_accounts` | 2 per user (one per integration) | A's account `is_active = false` (departed); B's account `is_active = true` throughout the A-departure legs. |
| `directory_account_links` | 2 per user (one per account), `link_status = 'linked'` | The exact join both the candidate and global-clear queries read — a `user_orgs` row alone is invisible to either. |
| `user_orgs` | 2 per user (org A / org B), both `is_active = true` before the run | |

## ①-⑤ suite summary (`attendance-w4pre1d-departure-candidate-split.db.test.ts`, `w4pre1d-` namespaced fixtures)

1. Owner-named scenario field-for-field, `mark_inactive` and `disable_grant_only` legs: A departs while B is a REAL still-active binding ⇒ A membership deactivated, B membership stays active, `users.is_active` stays `true`, a pre-seeded enabled grant survives.
2. Last-org departure: B also departs (second real run against integration B) ⇒ `mark_inactive` now deactivates the platform user and closes the grant; `disable_grant_only` closes the grant but the platform user is **never** touched.
3. Breaker: three different users, each with a real departed account in org A and a real ACTIVE account in their own separate org (so `globalCandidateCount` would be 0 for all three) — `maxBatch: 2` still trips `batch_exceeds_max` on `candidateCount: 3`; nothing was written for any of the three.
4. `manual_review` regression under the split (dual-org fixture): both memberships stay active, zero writes, pending exposure unaffected by the cross-org binding.
5. Switch OFF: zero deactivation for the owner-named scenario; preview numbers (`candidateCount`, `globalCandidateCount`, `membershipDeactivationAttemptedCount`, `usersDeactivatedCount`, `grantsDisabledCount`) still correctly split.

Unit suite (`tests/unit/directory-deprovision-policy.test.ts`) extended: the stub now answers the new global-clear query (`FROM UNNEST($1::text[]) AS candidate_user ...`) — default "every requested user is globally clear", opt a user out via `notGloballyClear` — and gained dispatch coverage for the org-membership-candidate-but-NOT-globally-clear branch (both `mark_inactive` and `disable_grant_only`) plus a breaker test proving it keys off `candidateCount`, not `globalCandidateCount`.

**All pre-existing W4-PRE-1/1b/1c real-DB and unit suites pass with their assertions and fixtures UNCHANGED.** Their fixtures happen to share `directory_integrations.org_id`'s `'default'` sentinel (both integrations created without an explicit `org_id`) or explicit-but-same org ids for any two-integration scenario, so the org-scoped guard behaves identically to the old global one for every one of those cases — confirmed empirically, not assumed (see test-run evidence below). One file, `attendance-w4pre1c-departure-org-scoped.db.test.ts`, got a **doc-comment-only** correction in the review-fix round below (its own header and case-③ inline comment still described the candidate-selection guard as GLOBAL after this PR made it org-scoped); no assertion or fixture changed, and the file's own test run is included in the re-run evidence.

## mutation self-check (5/5, restored)

Discipline followed: implementation + tests committed FIRST (`929be17f2`, `c23fe8803`), each mutation applied via `Edit`, target test run and confirmed red, then restored via `git checkout -- packages/core-backend/src/directory/directory-sync.ts` (safe because everything was already committed).

| # | Mutation | Target red leg | Result |
|---|---|---|---|
| 1 | Org candidate query reverted to the global sibling guard (dropped `sibling_integration.org_id = $2` and its param) — reproduces the owner's P1 | All 7 tests in the new w4pre1d file | RED — `candidateCount` collapses to 0 for the named scenario; `membershipIsActive(user, orgA)` stays `true` instead of flipping to `false` |
| 2 | Breaker fed a literal `0` instead of `outcome.candidateCount` — simulates "breaker reverted to global-filtered count" | w4pre1d case ③ (`abortedReason` expected `'batch_exceeds_max'`) + unit breaker test | RED — `abortedReason` comes back `null`, breaker never trips |
| 3 | `mark_inactive`'s `users.is_active` UPDATE moved outside the `globallyClear` gate | w4pre1d case ① `mark_inactive` leg, case ② `mark_inactive` leg, case ⑤ preview | RED (3 tests) — `isUserActive(user)` flips to `false` even though B is still real+active |
| 4 | Grant-disable `INSERT` moved outside the `globallyClear` gate (unconditional again) | w4pre1d case ① both legs, case ② both legs, case ⑤ preview | RED (5 tests) — `grantEnabled(user)` flips to `false` even though B is still real+active |
| 5 | `deactivateUserOrgMembershipIfNoOtherActiveBinding` call routed through the raw pool `query` (separate, auto-commit connection) instead of the transaction-scoped `client` | Unit suite (5 tests reaching the `enabled: true` + non-`manual_review` path) | RED — the stub's `client.queries` never records the `UPDATE user_orgs` write (proving the call left the injected/transactional client); under real conditions it even throws (`database "chouhua" does not exist`) because it tries a genuine separate pool connection instead of the mocked one |

After each restore, the full w4pre1d file + unit suite were re-run to confirm green before proceeding to the next mutation; a final full sweep (see below) confirms the clean restored state.

## Review-fix-round mutation self-check (1/1, restored)

Discipline followed: review-fix commit (`c8cbd18d2`) landed first, mutation applied via `Edit`,
target test run and confirmed RED, then restored via a precise `Edit` back to the committed text
(not `git checkout -- .`) — `git diff --stat` confirmed byte-identical to the commit afterward.

| # | Mutation | Target red leg | Result |
|---|---|---|---|
| 1 | `meta.grantDisabled: affected.globallyClear` reverted to hardcoded `true`, and `meta.userDeactivated: affected.policy === 'mark_inactive' && affected.globallyClear` reverted to drop the `&& affected.globallyClear` conjunct — reproduces the exact "hardcoded value survives green" regression review finding #4 named | New dual-org sweep test's audit-meta assertion (`directory-sync-orchestration.db.test.ts`, "with a real, still-active binding in ANOTHER org…") | RED — `action_details` came back `{ grantDisabled: true, userDeactivated: true, ... }` against an expected `{ grantDisabled: false, userDeactivated: false, ... }`; 1 failed \| 12 passed |

Re-ran the same file after restore: 13/13 passed.

## Test runs (local, real DB `ms2_w4pre1d_test_20260722`, migrated to head — refreshed for the review-fix round, 2026-07-22)

```
# New w4pre1d file alone
pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
  tests/integration/attendance-w4pre1d-departure-candidate-split.db.test.ts
  → 1 file, 7/7 passed

# Orchestration file alone — the file review finding #3 (P1) named as the CI-wired real-DB
# regression this PR's head was missing from local scope; now includes the new dual-org test
# and the strengthened TRUE-branch assertions
pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
  tests/integration/directory-sync-orchestration.db.test.ts
  → 1 file, 13/13 passed (was 12; +1 new dual-org test)

# Orchestration file + directory-deprovision-selection.db.test.ts together (both live in CI's
# "Run approval real-DB integration" step, both exercise applyDirectoryDeprovisionPolicies)
pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
  tests/integration/directory-sync-orchestration.db.test.ts \
  tests/integration/directory-deprovision-selection.db.test.ts
  → 2 files, 23/23 passed

# Full attendance-integration-gate line (CI-matching set, this PR's addition included) — re-run
# because attendance-w4pre1c-departure-org-scoped.db.test.ts's doc-comment changed in this round
pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
  tests/integration/directory-deprovision-selection.db.test.ts \
  tests/integration/attendance-w4pre1-user-orgs-admission.db.test.ts \
  tests/integration/attendance-w4pre1-user-orgs-directory-sync.db.test.ts \
  tests/integration/attendance-w4pre1-user-orgs-policy.db.test.ts \
  tests/integration/attendance-w4pre1b-user-orgs-lifecycle.db.test.ts \
  tests/integration/attendance-w4pre1b-user-orgs-sync-automatch.db.test.ts \
  tests/integration/attendance-w4pre1b-user-orgs-backfill-migration.db.test.ts \
  tests/integration/attendance-w4pre1b-directory-readiness-gate.db.test.ts \
  tests/integration/attendance-w4pre1b-admin-users-explicit-org.db.test.ts \
  tests/integration/attendance-w4pre1b-api-tokens-org-member-access.db.test.ts \
  tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts \
  tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts \
  tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts \
  tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts \
  tests/integration/attendance-w4pre1d-departure-candidate-split.db.test.ts
  → 15 files, 75/75 passed

# Unit suite (targeted, then full)
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/directory-deprovision-policy.test.ts
  → 1 file, 21/21 passed (18 pre-existing + 3 new)
pnpm --filter @metasheet/core-backend exec vitest run tests/unit
  → 423 files, 5811/5811 passed

# Typecheck (both packages)
pnpm --filter @metasheet/core-backend run type-check   → clean
pnpm --filter @metasheet/web run type-check (vue-tsc -b) → clean (no frontend changes in this slice; confirmed baseline unaffected)
```

## CI wiring

Added `tests/integration/attendance-w4pre1d-departure-candidate-split.db.test.ts` to the existing attendance-integration `vitest` invocation list in `.github/workflows/plugin-tests.yml` (same job/step as the W4-PRE-1/1b/1c files, right after `attendance-w4pre1c-departure-permission-negative.db.test.ts`). No `attendance-web-guard.yml` change — this slice touches only `packages/core-backend`, no frontend spec. The workflow's existing `push.paths: packages/core-backend/**` filter and unrestricted `pull_request` trigger already cover this path; no filter change needed.

## Review-fix round (three-mirror findings, 2026-07-22)

8 raw findings (1 P1, 3 P2, 4 P3) came back from a three-mirror review of this PR; two pairs
point at the same underlying defect (#2/#8 at the same doc-comment location, #6/#7 the same
concurrency shape) so they are grouped below. Disposition:

| # | Sev | Finding | Disposition |
|---|---|---|---|
| 1 | P3 | `directory-sync.ts:1555` code comment, and this PR body's "verbatim, four items" spec table, quoted the owner's P2 items 2 to 4 as paraphrases while labeling them verbatim (extra "现有" in item 2; item 3 expanded from the terse original; item 4's "点名场景逐字段构造" clause dropped and replaced with "不得再用裸 B membership") | **Fixed.** Code comment corrected to drop "现有" and cite issuecomment-5043752399 explicitly. PR body's spec table above now quotes all four items exactly as they appear in that comment, with a correction note. |
| 2 | P3 | `directory-sync.ts:5153` doc-comment on `deactivateUserOrgMembershipIfNoOtherActiveBinding` still described `applyDirectoryDeprovisionPolicies`'s sibling guard as "intentionally GLOBAL for rehire protection, ~L1396-1400" — false as of this PR (candidate selection is now org-scoped; only the separate grant/user guard stays global) and the line anchor was stale | **Fixed.** Doc-comment rewritten: candidate-selection guard is now org-scoped and mirrors this function's own predicate; only the separate global grant/`users.is_active` guard (now ~L1587) stays global. `~L` anchors corrected. (Same defect re-flagged as #8 below.) |
| 3 | P1 | `directory-sync-orchestration.db.test.ts:596` — pre-existing sweep-level test's strict `toEqual` on `stats.deprovisionAffected` didn't expect the new `globallyClear` field; **actually FAILING on this PR's head** (this file is CI-wired in the "Run approval real-DB integration" step, not the 15-file attendance list this PR's body ran locally — a real gap in local re-run scope) | **Fixed.** Added `globallyClear: true` to the expected object (this fixture is globally clear). Reproduced RED locally first (`1 failed | 11 passed`), confirmed GREEN after. |
| 4 | P2 | Sweep-layer (`syncDirectoryIntegration`, not a direct `applyDirectoryDeprovisionPolicies` call) had zero test coverage of `deprovisionGlobalCandidateCount` and the audit `meta.grantDisabled`/`meta.userDeactivated`/`meta.globallyClear` fields — a revert to the old hardcoded `grantDisabled: true` / `userDeactivated: policy === 'mark_inactive'` would stay green | **Fixed.** New test in `directory-sync-orchestration.db.test.ts`: a dual-org fixture (real second `directory_integrations` row with its own `org_id`, real second linked+active `directory_accounts`/`directory_account_links`/`user_orgs` row — not a bare `user_orgs` stand-in) driven through the REAL `syncDirectoryIntegration` sweep, asserting `deprovisionGlobalCandidateCount: 0`, grant/user survive, and `audit_logs.action_details` reads `grantDisabled: false / userDeactivated: false / globallyClear: false`. Also added the matching TRUE-branch assertions (`globalCandidateCount: 1`, `grantDisabled: true`, `userDeactivated: true`) to the pre-existing globally-clear=`true` sweep test. Mutation-proved below. |
| 5 | P3 | `attendance-w4pre1c-departure-org-scoped.db.test.ts` (untouched by the original PR) — file header and case-③ inline comment still asserted the candidate-selection sibling guard "is GLOBAL … unchanged by this PR", now false | **Fixed (doc-comment only).** Header and case-③ comment corrected: case ② is unaffected either way (its org-B sibling was never directory-linked, so it was always invisible to both the old global and new org-scoped guard) and case ③ is unaffected either way (its sibling is in the SAME org, so old and new guards agree) — no assertion or fixture changed; file re-run confirmed still green (4/4). This PR body's "pass UNMODIFIED" claim, which finding #8 below points out this same doc-comment fix would otherwise falsify, is corrected above to "assertions/fixtures unchanged, doc-comment corrected". |
| 6 | P2 | `directory-sync.ts:1567` — the GLOBAL "no active binding anywhere" guard is a batch-level, no-lock check-then-act read with no write-time re-check (unlike the org-membership write's own `FOR UPDATE` re-read) — a concurrent last-org departure race can leave an enabled grant with zero live bindings, with no reconciliation path (a stuck absorbing state) | **Deferred, not fixed — documented in code + here.** The finding itself concedes this race shape is inherited from the pre-existing (pre-W4-PRE-1d) global guard, not introduced or widened by this PR ("该竞态形状继承自 pre-1d…本 PR 严格不更差"). `DIRECTORY_DEPROVISION_ENABLED` stays default-OFF and is never armed anywhere in this branch. Closing it requires a lock-strategy or reconciliation-sweep design decision (e.g. a `users`-row `FOR UPDATE` re-check at write time, mirroring the org-membership helper) outside the owner's verbatim 4-item P2 spec this PR implements — and per this line's own standing discipline, any fix would itself need a constructed-concurrency real-DB test to prove, not a same-round addition. Inline comments added at both the read site (~L1567) and the two gated writes (~L1656) crediting the finding and naming the direction; owner should scope the follow-up. |
| 7 | P3 | Reverse-direction of #6: a same-window rehire committing a new active binding can still get its grant/user-deactivate writes applied against a stale "globally clear" snapshot | **Deferred alongside #6** — same root cause, same disposition, same inline comment block (at the two gated writes, ~L1656). |
| 8 | P3 | Same location as #2 (`directory-sync.ts:5152`), re-flagged with the additional observation that the untouched `attendance-w4pre1c-departure-org-scoped.db.test.ts` carries the same stale-GLOBAL framing, and that fixing #2 without also fixing this PR's "pass UNMODIFIED" claim would reproduce the finding's own point | **Fixed** — covered by #2's code fix and #5's test-file/PR-body fix above; no separate action needed. |


## 偏离 (deviations from the literal task instructions)

- The task suggested removing the candidate-selection guard outright and relying solely on the downstream `deactivateUserOrgMembershipIfNoOtherActiveBinding` helper's own org-scoped re-check. Implemented instead as an **org-scoped** selection guard (mirroring the helper's predicate) so `candidateCount` (the breaker's own input, owner item 3) counts exactly "memberships genuinely at risk" rather than "every user swept, including same-org actives whose membership will never flip". This is also why every pre-existing F-series test passed **unmodified** — under a "remove entirely" design, the `directory-deprovision-selection.db.test.ts` rehire/twocorps tests and the PRE-1c case③ same-org-sibling test would all have needed their `candidateCount` assertions changed from `0` to `1`, which is real test churn a pure "read the letter of item 1" implementation would have caused for scenarios the owner did NOT flag as broken.

## 遗留

- #4522 (the umbrella W4 re-ratify PR) stays un-RATIFIED per the owner's own note in the #4530 review comment; rev4 (effectiveTime two/four-state conflict + stale body) was explicitly deferred to land after W4-PRE-1d, not part of this PR.
- `DIRECTORY_DEPROVISION_ENABLED` staged opt-in (any environment) is an owner/staged-rollout decision, out of scope here as with every prior slice in this line.
- **New from the review-fix round**: the GLOBAL "no active binding anywhere" guard (`directory-sync.ts:1567`, gates DingTalk grant close + `mark_inactive`'s `users.is_active`) is a batch-snapshot check-then-act with no write-time re-check in either direction (a concurrent last-org departure can under-deactivate; a concurrent rehire can over-deactivate) — inherited from the pre-existing pre-W4-PRE-1d guard, not new or widened here, and unreachable while `DIRECTORY_DEPROVISION_ENABLED` stays default-OFF. Closing it is a lock-strategy/reconciliation-sweep design decision outside this PR's owner-spec scope; needs its own follow-up ticket, scoped by the owner, with a constructed-concurrency real-DB test as part of that ticket's own proof — not added here.
- This PR does not merge or arm anything; it is offered for review only.

