### PR TITLE
feat(approval): add semantic Canvas node reorder

### DIFF
--- a/apps/web/src/approvals/graphTopologyEdit.ts
+++ b/apps/web/src/approvals/graphTopologyEdit.ts
@@ -55,6 +55,122 @@ function inEdges(graph: ApprovalGraph, nodeKey: string): ApprovalEdge[] {
   return graph.edges.filter((e) => e.target === nodeKey)
 }
 
+function gatewayOwnedEdgeKeys(graph: ApprovalGraph): Set<string> {
+  const keys = new Set<string>()
+  for (const node of graph.nodes) {
+    if (node.type === 'condition') {
+      const config = node.config as ConditionNodeConfig
+      for (const branch of config.branches ?? []) keys.add(branch.edgeKey)
+      if (typeof config.defaultEdgeKey === 'string') keys.add(config.defaultEdgeKey)
+    }
+    if (node.type === 'parallel') {
+      const config = node.config as ParallelNodeConfig
+      for (const edgeKey of config.branches ?? []) keys.add(edgeKey)
+    }
+  }
+  return keys
+}
+
+/**
+ * Stable anchor for one maximal linear region. Walking upstream stops at either a gateway-owned
+ * branch edge or the first node that is not single-in/single-out. Edges sharing this anchor belong
+ * to the same path segment without crossing a condition/parallel fork or rejoin boundary.
+ */
+function linearRegionAnchorEdgeKey(graph: ApprovalGraph, edgeKey: string): string | undefined {
+  const edgesByKey = new Map(graph.edges.map((edge) => [edge.key, edge]))
+  const nodesByKey = new Map(graph.nodes.map((node) => [node.key, node]))
+  const gatewayEdges = gatewayOwnedEdgeKeys(graph)
+  let current = edgesByKey.get(edgeKey)
+  const visited = new Set<string>()
+  while (current && !visited.has(current.key)) {
+    visited.add(current.key)
+    const source = nodesByKey.get(current.source)
+    if (!source) return undefined
+    const ins = inEdges(graph, source.key)
+    const outs = outEdges(graph, source.key)
+    if (ins.length !== 1 || outs.length !== 1) return current.key
+    const predecessor = ins[0]
+    if (gatewayEdges.has(predecessor.key)) return predecessor.key
+    current = predecessor
+  }
+  return undefined
+}
+
+export interface LinearNodeMoveTarget {
+  edgeKey: string
+  source: string
+  target: string
+}
+
+/** Legal semantic drop slots for an approval/cc node, restricted to its current linear region. */
+export function linearNodeMoveTargets(graph: ApprovalGraph, nodeKey: string): LinearNodeMoveTarget[] {
+  const node = graph.nodes.find((candidate) => candidate.key === nodeKey)
+  if (!node || (node.type !== 'approval' && node.type !== 'cc')) return []
+  const ins = inEdges(graph, nodeKey)
+  const outs = outEdges(graph, nodeKey)
+  if (ins.length !== 1 || outs.length !== 1) return []
+  const anchor = linearRegionAnchorEdgeKey(graph, ins[0].key)
+  if (!anchor) return []
+  const gatewayEdges = gatewayOwnedEdgeKeys(graph)
+  return graph.edges
+    .filter((edge) => edge.key !== ins[0].key && edge.key !== outs[0].key)
+    .filter((edge) => !gatewayEdges.has(edge.key))
+    .filter((edge) => linearRegionAnchorEdgeKey(graph, edge.key) === anchor)
+    .map((edge) => ({ edgeKey: edge.key, source: edge.source, target: edge.target }))
+}
+
+/**
+ * Move one single-in/single-out approval/cc node onto a legal edge in the same linear region.
+ * Rewires exactly three existing edges and preserves every node/edge key:
+ * `pred→node→succ` + `before→after` becomes `pred→succ` + `before→node→after`.
+ */
+export function moveLinearNode(graph: ApprovalGraph, nodeKey: string, targetEdgeKey: string): ApprovalGraph {
+  const node = graph.nodes.find((candidate) => candidate.key === nodeKey)
+  if (!node) throw new Error(`moveLinearNode: node ${nodeKey} not found`)
+  if (node.type !== 'approval' && node.type !== 'cc') {
+    throw new Error(`moveLinearNode: ${nodeKey} is ${node.type}, only approval/cc movable`)
+  }
+  const ins = inEdges(graph, nodeKey)
+  const outs = outEdges(graph, nodeKey)
+  if (ins.length !== 1 || outs.length !== 1) {
+    throw new Error(`moveLinearNode: ${nodeKey} must be single-in/single-out (in=${ins.length} out=${outs.length})`)
+  }
+  const target = graph.edges.find((edge) => edge.key === targetEdgeKey)
+  if (!target) throw new Error(`moveLinearNode: target edge ${targetEdgeKey} not found`)
+  if (!linearNodeMoveTargets(graph, nodeKey).some((candidate) => candidate.edgeKey === targetEdgeKey)) {
+    throw new Error(`moveLinearNode: target edge ${targetEdgeKey} is outside ${nodeKey}'s linear region`)
+  }
+
+  return {
+    nodes: graph.nodes.map(clone),
+    edges: graph.edges.map((edge) => {
+      if (edge.key === ins[0].key) return { ...clone(edge), target: outs[0].target }
+      if (edge.key === outs[0].key) return { ...clone(edge), target: target.target }
+      if (edge.key === target.key) return { ...clone(edge), target: nodeKey }
+      return clone(edge)
+    }),
+  }
+}
+
+/** Target edge for a one-step keyboard move, or undefined at a region boundary. */
+export function adjacentLinearNodeMoveTarget(
+  graph: ApprovalGraph,
+  nodeKey: string,
+  direction: 'up' | 'down',
+): string | undefined {
+  const ins = inEdges(graph, nodeKey)
+  const outs = outEdges(graph, nodeKey)
+  if (ins.length !== 1 || outs.length !== 1) return undefined
+  const adjacentKey = direction === 'up' ? ins[0].source : outs[0].target
+  const adjacent = graph.nodes.find((node) => node.key === adjacentKey)
+  if (!adjacent || (adjacent.type !== 'approval' && adjacent.type !== 'cc')) return undefined
+  const target = direction === 'up' ? inEdges(graph, adjacentKey)[0] : outEdges(graph, adjacentKey)[0]
+  if (!target) return undefined
+  return linearNodeMoveTargets(graph, nodeKey).some((candidate) => candidate.edgeKey === target.key)
+    ? target.key
+    : undefined
+}
+
 /**
  * Node keys strictly INSIDE any parallel region — every node on a branch path between a parallel
  * gateway and its `joinNodeKey` (join and gateway excluded). Mirrors the backend

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -535,18 +535,33 @@
                     data-testid="approval-canvas-edge"
                   />
                 </svg>
+                <button
+                  v-for="line in canvasMoveTargetLines"
+                  :key="`move-target-${line.key}`"
+                  type="button"
+                  class="template-authoring__canvas-move-target"
+                  :style="{ left: `${line.dropX}px`, top: `${line.dropY}px` }"
+                  :aria-label="canvasMoveTargetLabel(line.key)"
+                  :data-testid="`approval-canvas-move-target-${line.key}`"
+                  @click.stop="applyCanvasNodeMove(line.key)"
+                  @dragover.prevent
+                  @drop="onCanvasNodeDrop($event, line.key)"
+                >
+                  <el-icon><Rank /></el-icon>
+                  <span>移到这里</span>
+                </button>
                 <div
                   v-for="pos in canvasLayout.nodes"
                   :key="pos.key"
                   class="template-authoring__canvas-node"
-                  :class="{ 'is-selected': selectedCanvasNode === pos.key }"
+                  :class="{ 'is-selected': selectedCanvasNode === pos.key, 'is-moving': movingCanvasNode === pos.key }"
                   :style="{ position: 'absolute', left: pos.x + 'px', top: pos.y + 'px', width: CANVAS_NODE_W + 'px' }"
                   :data-canvas-node="pos.key"
                   data-testid="approval-canvas-node"
-                  :draggable="!readOnly"
+                  :draggable="!readOnly && canMoveCanvasNode(pos.key)"
                   @click="selectCanvasNode(pos.key)"
-                  @dragstart="onCanvasNodeDragStart(pos.key)"
-                  @dragend="onCanvasNodeDragEnd($event)"
+                  @dragstart="onCanvasNodeDragStart($event, pos.key)"
+                  @dragend="cancelCanvasNodeMove"
                 >
                   <div
                     class="template-authoring__canvas-node-selector"
@@ -558,6 +573,7 @@
                     @click.stop="selectCanvasNode(pos.key)"
                     @keydown.enter.stop.prevent="selectCanvasNode(pos.key)"
                     @keydown.space.stop.prevent="selectCanvasNode(pos.key)"
+                    @keydown="onCanvasNodeKeydown($event, pos.key)"
                   >
                     <strong>{{ graphNodeLabel(pos.key) }}</strong>
                     <span class="template-authoring__node-type" :data-node-type="canvasNodeByKey(pos.key)?.type">
@@ -565,6 +581,35 @@
                     </span>
                   </div>
                   <div v-if="!readOnly" class="template-authoring__canvas-node-actions">
+                    <template v-if="canMoveCanvasNode(pos.key)">
+                      <el-button
+                        :icon="Top"
+                        size="small"
+                        title="上移节点"
+                        :aria-label="`上移${graphNodeLabel(pos.key)}`"
+                        :disabled="!canvasStepMoveTarget(pos.key, 'up')"
+                        :data-testid="`approval-canvas-move-up-${pos.key}`"
+                        @click.stop="moveCanvasNodeStep(pos.key, 'up')"
+                      />
+                      <el-button
+                        :icon="Bottom"
+                        size="small"
+                        title="下移节点"
+                        :aria-label="`下移${graphNodeLabel(pos.key)}`"
+                        :disabled="!canvasStepMoveTarget(pos.key, 'down')"
+                        :data-testid="`approval-canvas-move-down-${pos.key}`"
+                        @click.stop="moveCanvasNodeStep(pos.key, 'down')"
+                      />
+                      <el-button
+                        :icon="Rank"
+                        size="small"
+                        title="移动节点"
+                        :aria-label="`选择${graphNodeLabel(pos.key)}的移动位置`"
+                        :type="movingCanvasNode === pos.key ? 'primary' : undefined"
+                        :data-testid="`approval-canvas-move-${pos.key}`"
+                        @click.stop="beginCanvasNodeMove(pos.key)"
+                      />
+                    </template>
                     <el-button v-if="canvasNodeByKey(pos.key)?.type === 'condition'" size="small" :data-testid="`approval-canvas-add-condition-${pos.key}`" @click.stop="onAddConditionBranch(pos.key)">+条件分支</el-button>
                     <el-button v-if="canvasNodeByKey(pos.key)?.type === 'parallel'" size="small" :data-testid="`approval-canvas-add-parallel-${pos.key}`" @click.stop="onAddParallelBranch(pos.key)">+并行分支</el-button>
                     <template v-if="canInsertAfter(canvasNodeByKey(pos.key)!)">
@@ -1244,7 +1289,7 @@ import { computed, nextTick, onMounted, onUnmounted, provide, ref, watch } from 
 import PageShell from '../../components/layout/PageShell.vue'
 import PageHeader from '../../components/layout/PageHeader.vue'
 import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
-import { FullScreen, Plus, ZoomIn, ZoomOut } from '@element-plus/icons-vue'
+import { Bottom, FullScreen, Plus, Rank, Top, ZoomIn, ZoomOut } from '@element-plus/icons-vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { summarizeConditionBranch, summarizeConditionNode } from '../../approvals/conditionSummary'
@@ -1310,10 +1355,13 @@ import {
 import {
   addConditionBranch,
   addParallelBranch,
+  adjacentLinearNodeMoveTarget,
   appendApprovalNode,
   collectParallelRegionNodeKeys,
   insertConditionGateway,
   insertParallelGateway,
+  linearNodeMoveTargets,
+  moveLinearNode,
   removeLinearNode,
 } from '../../approvals/graphTopologyEdit'
 import {
@@ -1324,7 +1372,6 @@ import {
   type GraphLayout,
 } from '../../approvals/graphLayout'
 import {
-  clientToCanvasPoint,
   computeMinimapFrame,
   fitCanvasZoom,
   stepCanvasZoom,
@@ -1854,16 +1901,14 @@ function canRemoveNode(node: ApprovalNode): boolean {
     && topologyEdgeCount(node.key, 'source') === 1
 }
 
-// ── D-1/D-5/D-6 visual canvas (bespoke SVG/HTML — the render is DATA, so it's unit-testable; only the
-// raw mouse-drag GESTURE is manual/E2E QA). Auto-layout via computeLayout, overridable by a position
-// SIDECAR (`nodePositions`) that NEVER reaches the saved graph. Reuses the same topology handlers as
-// the list. Canvas V2 Slice A: selecting a node opens the right-side inspector (same draft handlers). ──
+// ── D-1/D-5/D-6 visual canvas. Layout and semantic move targets are pure data; drag/drop and
+// Alt+Arrow both invoke the same topology edit, so visual position never diverges from the saved graph.
+// Reuses the same topology handlers as the list and the same draft-backed right-side inspector. ──
 const canvasViewMode = ref<'list' | 'canvas'>('list')
 const selectedCanvasNode = ref<string | null>(null)
 const canvasInspectorRef = ref<HTMLElement | null>(null)
 const canvasViewportRef = ref<HTMLElement | null>(null)
-const nodePositions = ref<Record<string, { x: number; y: number }>>({})
-const draggingCanvasNode = ref<string | null>(null)
+const movingCanvasNode = ref<string | null>(null)
 const canvasZoom = ref(1)
 const canvasViewportState = ref({ width: 0, height: 0, scrollLeft: 0, scrollTop: 0 })
 const CANVAS_NODE_W = GRAPH_LAYOUT_NODE_WIDTH
@@ -1871,16 +1916,7 @@ const CANVAS_NODE_H = GRAPH_LAYOUT_NODE_HEIGHT
 const CANVAS_MINIMAP_W = 220
 const CANVAS_MINIMAP_H = 120
 const canvasEffectiveGraph = computed<ApprovalGraph>(() => buildApprovalGraph(draft.value))
-const canvasLayout = computed<GraphLayout>(() => {
-  const layout = computeLayout(canvasEffectiveGraph.value)
-  return {
-    ...layout,
-    nodes: layout.nodes.map((n) => {
-      const override = nodePositions.value[n.key]
-      return override ? { ...n, x: override.x, y: override.y } : n
-    }),
-  }
-})
+const canvasLayout = computed<GraphLayout>(() => computeLayout(canvasEffectiveGraph.value))
 const canvasValidity = computed<string[]>(() => (draft.value.preservedGraph ? graphValidityIssues(canvasEffectiveGraph.value) : []))
 const canvasZoomLabel = computed(() => `${Math.round(canvasZoom.value * 100)}%`)
 const canvasStageStyle = computed(() => ({
@@ -1953,8 +1989,9 @@ const selectedCanvasInspectorNode = computed<ApprovalNode | null>(() => {
 })
 watch(canvasEffectiveGraph, (graph) => {
   const key = selectedCanvasNode.value
-  if (!key) return
-  if (!graph.nodes.some((node) => node.key === key)) clearCanvasSelection()
+  if (key && !graph.nodes.some((node) => node.key === key)) clearCanvasSelection()
+  const movingKey = movingCanvasNode.value
+  if (movingKey && linearNodeMoveTargets(graph, movingKey).length === 0) cancelCanvasNodeMove()
 })
 watch([canvasViewMode, canvasLayout], async ([mode]) => {
   if (mode !== 'canvas') return
@@ -2010,28 +2047,68 @@ const canvasEdgeLines = computed(() => {
     const x2 = (t?.x ?? 0) + CANVAS_NODE_W / 2
     const y2 = t?.y ?? 0
     const midY = y1 + (y2 - y1) / 2
-    return { key: edge.key, path: `M ${x1} ${y1} L ${x1} ${midY} L ${x2} ${midY} L ${x2} ${y2}` }
+    return {
+      key: edge.key,
+      path: `M ${x1} ${y1} L ${x1} ${midY} L ${x2} ${midY} L ${x2} ${y2}`,
+      dropX: (x1 + x2) / 2,
+      dropY: midY,
+    }
   })
 })
-function onCanvasNodeDragStart(key: string): void {
-  if (!readOnly.value) draggingCanvasNode.value = key
+const canvasMoveTargets = computed(() => movingCanvasNode.value
+  ? new Set(linearNodeMoveTargets(canvasEffectiveGraph.value, movingCanvasNode.value).map((target) => target.edgeKey))
+  : new Set<string>())
+const canvasMoveTargetLines = computed(() => canvasEdgeLines.value.filter((line) => canvasMoveTargets.value.has(line.key)))
+function canvasStepMoveTarget(nodeKey: string, direction: 'up' | 'down'): string | undefined {
+  return adjacentLinearNodeMoveTarget(canvasEffectiveGraph.value, nodeKey, direction)
 }
-function onCanvasNodeDragEnd(event: DragEvent): void {
-  // The drag GESTURE is manual/E2E QA; this position-update (sidecar only, never saved) is exercised.
-  if (readOnly.value || !draggingCanvasNode.value) return
-  const surface = (event.currentTarget as HTMLElement | null)?.closest('[data-testid="approval-graph-canvas"]')
-  const rect = surface?.getBoundingClientRect()
-  if (rect) {
-    const point = clientToCanvasPoint(event.clientX, event.clientY, rect, canvasZoom.value)
-    nodePositions.value = {
-      ...nodePositions.value,
-      [draggingCanvasNode.value]: {
-        x: Math.max(0, Math.round(point.x - CANVAS_NODE_W / 2)),
-        y: Math.max(0, Math.round(point.y - CANVAS_NODE_H / 2)),
-      },
-    }
+function canMoveCanvasNode(nodeKey: string): boolean {
+  return linearNodeMoveTargets(canvasEffectiveGraph.value, nodeKey).length > 0
+}
+function canvasMoveTargetLabel(edgeKey: string): string {
+  const edge = canvasEffectiveGraph.value.edges.find((candidate) => candidate.key === edgeKey)
+  const movingLabel = movingCanvasNode.value ? graphNodeLabel(movingCanvasNode.value) : '节点'
+  return edge ? `将${movingLabel}移动到${graphNodeLabel(edge.source)}之后` : `移动${movingLabel}`
+}
+function beginCanvasNodeMove(nodeKey: string): void {
+  if (readOnly.value || !canMoveCanvasNode(nodeKey)) return
+  movingCanvasNode.value = movingCanvasNode.value === nodeKey ? null : nodeKey
+}
+function cancelCanvasNodeMove(): void {
+  movingCanvasNode.value = null
+}
+function applyCanvasNodeMove(targetEdgeKey: string): void {
+  const nodeKey = movingCanvasNode.value
+  if (!nodeKey || !canvasMoveTargets.value.has(targetEdgeKey)) return
+  runTopologyOp((graph) => moveLinearNode(graph, nodeKey, targetEdgeKey))
+  selectedCanvasNode.value = nodeKey
+  cancelCanvasNodeMove()
+}
+function moveCanvasNodeStep(nodeKey: string, direction: 'up' | 'down'): void {
+  const target = canvasStepMoveTarget(nodeKey, direction)
+  if (!target) return
+  movingCanvasNode.value = nodeKey
+  applyCanvasNodeMove(target)
+}
+function onCanvasNodeKeydown(event: KeyboardEvent, nodeKey: string): void {
+  if (!event.altKey || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) return
+  event.preventDefault()
+  event.stopPropagation()
+  moveCanvasNodeStep(nodeKey, event.key === 'ArrowUp' ? 'up' : 'down')
+}
+function onCanvasNodeDragStart(event: DragEvent, nodeKey: string): void {
+  if (readOnly.value || !canMoveCanvasNode(nodeKey)) {
+    event.preventDefault()
+    return
   }
-  draggingCanvasNode.value = null
+  movingCanvasNode.value = nodeKey
+  event.dataTransfer?.setData('text/plain', nodeKey)
+  if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move'
+}
+function onCanvasNodeDrop(event: DragEvent, edgeKey: string): void {
+  event.preventDefault()
+  event.stopPropagation()
+  applyCanvasNodeMove(edgeKey)
 }
 function setApprovalSourceIds(nodeKey: string, ids: string[]): void {
   const kind = approvalSourceKind(nodeKey)
@@ -2329,8 +2406,8 @@ function moveStep(index: number, delta: -1 | 1) {
 }
 
 async function loadTemplateForEdit() {
-  nodePositions.value = {}
   selectedCanvasNode.value = null
+  movingCanvasNode.value = null
   canvasZoom.value = 1
   if (!isEditMode.value) {
     draft.value = createEmptyTemplateDraft()
@@ -3150,13 +3227,20 @@ pre {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  cursor: grab;
+  cursor: default;
   font-size: 12px;
   min-height: 96px;
+}
+.template-authoring__canvas-node[draggable='true'] {
+  cursor: grab;
 }
 .template-authoring__canvas-node.is-selected {
   border-color: var(--el-color-primary);
   box-shadow: 0 0 0 2px var(--el-color-primary-light-5);
+}
+.template-authoring__canvas-node.is-moving {
+  border-style: dashed;
+  border-color: var(--el-color-primary);
 }
 .template-authoring__canvas-node-selector {
   display: flex;
@@ -3175,6 +3259,29 @@ pre {
   flex-wrap: wrap;
   gap: 4px;
   margin-top: 4px;
+}
+.template-authoring__canvas-move-target {
+  position: absolute;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 28px;
+  padding: 4px 8px;
+  border: 1px dashed var(--el-color-primary);
+  border-radius: 6px;
+  color: var(--el-color-primary);
+  background: var(--el-bg-color);
+  box-shadow: var(--el-box-shadow-lighter);
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+  font-size: 12px;
+}
+.template-authoring__canvas-move-target:hover,
+.template-authoring__canvas-move-target:focus-visible {
+  border-style: solid;
+  background: var(--el-color-primary-light-9);
+  outline: none;
 }
 .template-authoring__canvas-minimap {
   position: absolute;

--- a/apps/web/tests/approval-graph-topology-edit.test.ts
+++ b/apps/web/tests/approval-graph-topology-edit.test.ts
@@ -3,6 +3,7 @@ import type { ApprovalGraph, ApprovalNode, ApprovalTemplateDetailDTO, ApprovalAs
 import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../src/types/approval'
 import { parallelDynamicAssigneeConflicts } from '../src/approvals/parallelEdit'
 import { placeholderRoleNodeKeys } from '../src/approvals/approvalNodeEdit'
+import { graphValidityIssues } from '../src/approvals/graphLayout'
 import {
   appendApprovalNode,
   collectParallelRegionNodeKeys,
@@ -13,6 +14,9 @@ import {
   removeParallelBranch,
   addConditionBranch,
   removeConditionBranch,
+  adjacentLinearNodeMoveTarget,
+  linearNodeMoveTargets,
+  moveLinearNode,
 } from '../src/approvals/graphTopologyEdit'
 import {
   applyTopologyToComplexDraft,
@@ -83,6 +87,43 @@ const CONDITION: ApprovalGraph = {
     { key: 'e-high', source: 'cond_1', target: 'app_high' },
     { key: 'e-low', source: 'cond_1', target: 'end' },
     { key: 'e-high-end', source: 'app_high', target: 'end' },
+  ],
+}
+
+const LINEAR_LONG: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    { key: 'app_a', type: 'approval', name: 'A', config: { approvalMode: 'all', assigneeSources: [{ kind: 'dept_head' }] } },
+    { key: 'cc_b', type: 'cc', name: 'B', config: { targetType: 'user', targetIds: ['user-1'] } },
+    { key: 'app_c', type: 'approval', name: 'C', config: { approvalMode: 'single', assigneeSources: [{ kind: 'requester' }] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'e-start-a', source: 'start', target: 'app_a' },
+    { key: 'e-a-b', source: 'app_a', target: 'cc_b' },
+    { key: 'e-b-c', source: 'cc_b', target: 'app_c' },
+    { key: 'e-c-end', source: 'app_c', target: 'end' },
+  ],
+}
+
+const PARALLEL_LONG: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    { key: 'parallel', type: 'parallel', name: '并行', config: { branches: ['e-fork-a', 'e-fork-b'], joinMode: 'all', joinNodeKey: 'end' } },
+    { key: 'a1', type: 'approval', name: 'A1', config: { assigneeSources: [{ kind: 'dept_head' }] } },
+    { key: 'a2', type: 'cc', name: 'A2', config: { targetType: 'user', targetIds: ['user-2'] } },
+    { key: 'a3', type: 'approval', name: 'A3', config: { assigneeSources: [{ kind: 'requester' }] } },
+    { key: 'b1', type: 'approval', name: 'B1', config: { assigneeSources: [{ kind: 'static_role', roleIds: ['finance'] }] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'e-start-p', source: 'start', target: 'parallel' },
+    { key: 'e-fork-a', source: 'parallel', target: 'a1' },
+    { key: 'e-a1-a2', source: 'a1', target: 'a2' },
+    { key: 'e-a2-a3', source: 'a2', target: 'a3' },
+    { key: 'e-a3-end', source: 'a3', target: 'end' },
+    { key: 'e-fork-b', source: 'parallel', target: 'b1' },
+    { key: 'e-b1-end', source: 'b1', target: 'end' },
   ],
 }
 
@@ -226,6 +267,51 @@ describe('removeLinearNode', () => {
   it('refuses to remove start/end/condition/parallel', () => {
     expect(() => removeLinearNode(CONDITION, 'cond_1')).toThrow(/only approval\/cc/)
     expect(() => removeLinearNode(LINEAR, 'start')).toThrow(/only approval\/cc/)
+  })
+})
+
+describe('semantic linear-node reorder', () => {
+  it('moves an approval/cc node onto a plain edge while preserving every identity and input byte-for-byte', () => {
+    const before = snap(LINEAR_LONG)
+    const out = moveLinearNode(LINEAR_LONG, 'cc_b', 'e-start-a')
+    expect(LINEAR_LONG).toEqual(before)
+    expect(out.nodes).toEqual(LINEAR_LONG.nodes)
+    expect(out.edges.map((edge) => edge.key)).toEqual(LINEAR_LONG.edges.map((edge) => edge.key))
+    expect(edgeBetween(out, 'start', 'cc_b')).toMatchObject({ key: 'e-start-a' })
+    expect(edgeBetween(out, 'cc_b', 'app_a')).toMatchObject({ key: 'e-b-c' })
+    expect(edgeBetween(out, 'app_a', 'app_c')).toMatchObject({ key: 'e-a-b' })
+    expect(edgeBetween(out, 'app_c', 'end')).toEqual(edgeBetween(LINEAR_LONG, 'app_c', 'end'))
+    expect(graphValidityIssues(out)).toEqual([])
+  })
+
+  it('supports reordering inside one branch without crossing its fork or rejoin boundary', () => {
+    expect(linearNodeMoveTargets(PARALLEL_LONG, 'a3').map((target) => target.edgeKey))
+      .toEqual(['e-a1-a2'])
+    const out = moveLinearNode(PARALLEL_LONG, 'a3', 'e-a1-a2')
+    expect(edgeBetween(out, 'parallel', 'a1')).toMatchObject({ key: 'e-fork-a' })
+    expect(edgeBetween(out, 'a1', 'a3')).toMatchObject({ key: 'e-a1-a2' })
+    expect(edgeBetween(out, 'a3', 'a2')).toMatchObject({ key: 'e-a3-end' })
+    expect(edgeBetween(out, 'a2', 'end')).toMatchObject({ key: 'e-a2-a3' })
+    expect(node(out, 'b1')).toEqual(node(PARALLEL_LONG, 'b1'))
+    expect(graphValidityIssues(out)).toEqual([])
+  })
+
+  it('refuses cross-region, condition-branch, parallel-fork, and current-position targets', () => {
+    expect(linearNodeMoveTargets(PARALLEL_LONG, 'a2').map((target) => target.edgeKey))
+      .toEqual(['e-a3-end'])
+    expect(() => moveLinearNode(PARALLEL_LONG, 'a2', 'e-b1-end')).toThrow(/outside/)
+    expect(() => moveLinearNode(PARALLEL_LONG, 'a2', 'e-fork-a')).toThrow(/outside/)
+    expect(() => moveLinearNode(PARALLEL_LONG, 'a2', 'e-a1-a2')).toThrow(/outside/)
+    expect(() => moveLinearNode(CONDITION, 'app_high', 'e-high')).toThrow(/outside/)
+  })
+
+  it('never offers structural nodes and returns only legal one-step keyboard targets', () => {
+    expect(linearNodeMoveTargets(PARALLEL_LONG, 'parallel')).toEqual([])
+    expect(() => moveLinearNode(PARALLEL_LONG, 'parallel', 'e-a1-a2')).toThrow(/only approval\/cc movable/)
+    expect(adjacentLinearNodeMoveTarget(LINEAR_LONG, 'cc_b', 'up')).toBe('e-start-a')
+    expect(adjacentLinearNodeMoveTarget(LINEAR_LONG, 'cc_b', 'down')).toBe('e-c-end')
+    expect(adjacentLinearNodeMoveTarget(PARALLEL_LONG, 'a2', 'up')).toBeUndefined()
+    expect(adjacentLinearNodeMoveTarget(PARALLEL_LONG, 'a2', 'down')).toBe('e-a3-end')
   })
 })
 

--- a/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
+++ b/apps/web/tests/approval-template-authoring-canvas-inspector.spec.ts
@@ -350,6 +350,24 @@ function buildMixedGraph() {
   }
 }
 
+function buildLinearReorderGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      { key: 'app_a', type: 'approval', name: '审批 A', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'cc_b', type: 'cc', name: '抄送 B', config: { targetType: 'user', targetIds: ['u_finance'] } },
+      { key: 'app_c', type: 'approval', name: '审批 C', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-a', source: 'start', target: 'app_a' },
+      { key: 'e-a-b', source: 'app_a', target: 'cc_b' },
+      { key: 'e-b-c', source: 'cc_b', target: 'app_c' },
+      { key: 'e-c-end', source: 'app_c', target: 'end' },
+    ],
+  }
+}
+
 let container: HTMLDivElement | null = null
 let app: VueApp<Element> | null = null
 
@@ -469,9 +487,9 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
     expect(node.getAttribute('aria-pressed')).toBe('true')
   })
 
-  it('renders stable navigation controls and keeps free-drag coordinates correct under zoom', async () => {
+  it('renders navigation controls and persists semantic drag/drop plus Alt+Arrow reorder', async () => {
     routeParams = { id: 'tpl_canvas_navigation' }
-    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: buildMixedGraph() as any }))
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: buildLinearReorderGraph() as any }))
     await mountView()
     await flushUi()
 
@@ -490,34 +508,36 @@ describe('Canvas V2 Slice A — canvas inspector', () => {
 
     const surface = container!.querySelector('[data-testid="approval-graph-canvas"]') as HTMLElement
     expect(surface.style.transform).toBe('scale(1.25)')
-    surface.getBoundingClientRect = () => ({
-      left: 100,
-      top: 50,
-      width: 1000,
-      height: 750,
-      right: 1100,
-      bottom: 800,
-      x: 100,
-      y: 50,
-      toJSON: () => ({}),
-    })
 
-    const node = container!.querySelector('[data-canvas-node="approval_high"]') as HTMLElement
-    node.dispatchEvent(new Event('dragstart', { bubbles: true }))
-    const dragEnd = new Event('dragend', { bubbles: true })
-    Object.defineProperties(dragEnd, {
-      clientX: { value: 344 },
-      clientY: { value: 210 },
+    const node = container!.querySelector('[data-canvas-node="cc_b"]') as HTMLElement
+    const dragStart = new Event('dragstart', { bubbles: true, cancelable: true })
+    Object.defineProperty(dragStart, 'dataTransfer', {
+      value: { setData: vi.fn(), effectAllowed: '' },
     })
-    node.dispatchEvent(dragEnd)
+    node.dispatchEvent(dragStart)
+    await flushUi()
+    const dropTarget = container!.querySelector('[data-testid="approval-canvas-move-target-e-start-a"]') as HTMLButtonElement
+    expect(dropTarget).not.toBeNull()
+    dropTarget.dispatchEvent(new Event('drop', { bubbles: true, cancelable: true }))
     await flushUi()
 
-    expect(node.style.left).toBe('100px')
-    expect(node.style.top).toBe('80px')
+    const movedNode = container!.querySelector('[data-canvas-node="cc_b"]') as HTMLElement
+    const appA = container!.querySelector('[data-canvas-node="app_a"]') as HTMLElement
+    expect(Number.parseFloat(movedNode.style.top)).toBeLessThan(Number.parseFloat(appA.style.top))
+
+    const selector = movedNode.querySelector('[data-testid="approval-canvas-node-select"]') as HTMLElement
+    selector.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', altKey: true, bubbles: true }))
+    await flushUi()
+    expect(Number.parseFloat(movedNode.style.top)).toBeGreaterThan(Number.parseFloat(appA.style.top))
 
     zoomLabel.click()
     await flushUi()
     expect(surface.style.transform).toBe('scale(1)')
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    const payload = updateTemplateSpy.mock.calls.at(-1)?.[1] as any
+    expect(payload.approvalGraph.edges).toEqual(buildLinearReorderGraph().edges)
   })
 
   it('shows business labels instead of internal topology keys in the inspector', async () => {


### PR DESCRIPTION
## What

- replace visual-only free-position dragging with topology-backed node reordering
- keep approval/cc moves inside one maximal linear branch region
- preserve every node and edge key while rewiring exactly three edges
- expose drag/drop targets, icon controls, and Alt+Arrow keyboard movement through one mutation path

## Safety boundary

- condition and parallel gateway-owned edges cannot be drop targets
- moves cannot cross a fork, branch, or rejoin boundary
- structural nodes are immovable and read-only mode exposes no mutation controls

## Verification

- required web gate: 353 files / 4207 tests
- targeted topology, Canvas, and style gate: 124/124
- production web build: pass
- mutation 1: remove same-region filter -> 2 topology tests RED
- mutation 2: break outgoing-edge rewire -> 2 topology tests RED
- final targeted suite after restore: 43/43

## Review status

- Codex adversarial self-review: no P1/P2
- ReClaude Opus was invoked read-only through the existing login but returned Execution error before a verdict; no external verdict is claimed

Stacked on #4537; keep Draft until the Canvas stack is reviewed bottom-up.