### PR TITLE
feat(attendance): W4-0 setup-readiness aggregate + endpoint (design-lock #4522 §3/§4/§9)

### DIFF
--- a/.github/workflows/attendance-web-guard.yml
+++ b/.github/workflows/attendance-web-guard.yml
@@ -65,7 +65,11 @@
 # attendance-experience-entrypoints.spec.ts (newly wired here — Wave 3 added real behavior to
 # this previously-ungated file: the admin/import "Management home" clear-section round trip
 # through the router and the overview anomaly-section deep link; the file's pre-existing
-# tab/section routing coverage rides along).
+# tab/section routing coverage rides along), and attendance-setup-readiness.spec.ts (W4-0 —
+# vNext Wave 4 onboarding design-lock 2026-07-21: pure discriminator matrix for the seven-step
+# setup-readiness aggregate, `attendanceSetupReadiness.ts` — full status-value domain × step
+# coverage, previewReady's ①②③⑤-only formula, and ⑥'s three-signals-never-merged contract; see
+# docs/development/attendance-vnext-wave4-onboarding-design-lock-20260721.md §3/§7/§9).
 # The full
 # `@metasheet/web` vitest suite still has historical/flaky failures, so wiring the whole
 # suite as a required gate now would be red on arrival. Keep expanding the `vitest run`
@@ -112,6 +116,7 @@ on:
       - 'apps/web/tests/attendance-overview-priority.spec.ts'
       - 'apps/web/tests/AttendanceAdminTaskHome.spec.ts'
       - 'apps/web/tests/attendance-experience-entrypoints.spec.ts'
+      - 'apps/web/tests/attendance-setup-readiness.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
   push:
     branches: [main]
@@ -153,6 +158,7 @@ on:
       - 'apps/web/tests/attendance-overview-priority.spec.ts'
       - 'apps/web/tests/AttendanceAdminTaskHome.spec.ts'
       - 'apps/web/tests/attendance-experience-entrypoints.spec.ts'
+      - 'apps/web/tests/attendance-setup-readiness.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
 
 jobs:
@@ -195,4 +201,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run attendance web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust attendance-overview-priority AttendanceAdminTaskHome attendance-experience-entrypoints --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust attendance-overview-priority AttendanceAdminTaskHome attendance-experience-entrypoints attendance-setup-readiness --reporter=dot

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -840,6 +840,7 @@ jobs:
             tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts \
             tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts \
             tests/integration/attendance-w4pre1d-departure-candidate-split.db.test.ts \
+            tests/integration/attendance-setup-readiness-w4-0.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/apps/web/src/views/attendance/attendanceSetupReadiness.ts
+++ b/apps/web/src/views/attendance/attendanceSetupReadiness.ts
@@ -78,9 +78,10 @@ export interface AttendanceSetupReadinessNotify {
 }
 
 /** Mirrors `packages/core-backend/src/routes/attendance-admin.ts` AttendanceSetupReadinessResponse
- *  — the §4.2-locked key set PLUS `viewerIsPlatformAdmin`, a disclosed addition NOT in the §4.2
- *  locked list (§3① role-gated remediation contract, W4-1 强制) still pending explicit owner
- *  sign-off — see that file's response-interface doc comment for the full tension writeup. */
+ *  — the §4.2-locked 13-key set, exactly (P2, #4541 review: a prior revision also carried
+ *  `viewerIsPlatformAdmin` as a 14th key; removed — this pure discriminator module never consumed
+ *  it, so it was speculative surface, not something this slice was authorized to add unilaterally.
+ *  See the backend file's response-interface doc comment for the full removal writeup). */
 export interface AttendanceSetupReadinessResponse {
   directoryLinked: boolean
   orgActiveMemberCount: number
@@ -95,7 +96,6 @@ export interface AttendanceSetupReadinessResponse {
   notify: AttendanceSetupReadinessNotify
   previewReady: boolean
   perStep: Readonly<Record<AttendanceSetupStepId, AttendanceSetupReadinessPerStepEntry>>
-  viewerIsPlatformAdmin: boolean
 }
 
 /** §3.2 "判别值域（纯模块判别矩阵的行）...且每信号携带 scope: 'org' | 'deployment'（全局信号显式标

--- a/apps/web/src/views/attendance/attendanceSetupReadiness.ts
+++ b/apps/web/src/views/attendance/attendanceSetupReadiness.ts
@@ -54,6 +54,15 @@ export interface AttendanceSetupReadinessEffectiveTime {
   effectiveAt?: string
 }
 
+/** §4.2-locked wire shape for each `perStep` entry — the design lock's own JSON block writes
+ *  `perStep.effectiveTime: {source, posture, effectiveAt?}`, i.e. each entry nests under an
+ *  `effectiveTime` key rather than being the effective-time record itself (mirrors
+ *  `packages/core-backend/src/services/AttendanceSetupReadinessAggregate.ts`
+ *  `AttendanceSetupReadinessPerStepEntry`). */
+export interface AttendanceSetupReadinessPerStepEntry {
+  effectiveTime: AttendanceSetupReadinessEffectiveTime
+}
+
 export type AttendancePunchPolicyPosture = 'default' | 'customized' | 'unknown'
 export type AttendanceSetupReadinessDeliveryRuntime = 'ready' | 'not_ready' | 'unknown'
 
@@ -69,8 +78,9 @@ export interface AttendanceSetupReadinessNotify {
 }
 
 /** Mirrors `packages/core-backend/src/routes/attendance-admin.ts` AttendanceSetupReadinessResponse
- *  (§4.2-locked key set + the one pre-authorized addition, `viewerIsPlatformAdmin` — see that
- *  file's doc comment for the "§4.2 键集" note). */
+ *  — the §4.2-locked key set PLUS `viewerIsPlatformAdmin`, a disclosed addition NOT in the §4.2
+ *  locked list (§3① role-gated remediation contract, W4-1 强制) still pending explicit owner
+ *  sign-off — see that file's response-interface doc comment for the full tension writeup. */
 export interface AttendanceSetupReadinessResponse {
   directoryLinked: boolean
   orgActiveMemberCount: number
@@ -84,8 +94,29 @@ export interface AttendanceSetupReadinessResponse {
   punchPolicyPosture: AttendancePunchPolicyPosture
   notify: AttendanceSetupReadinessNotify
   previewReady: boolean
-  perStep: Readonly<Record<AttendanceSetupStepId, AttendanceSetupReadinessEffectiveTime>>
+  perStep: Readonly<Record<AttendanceSetupStepId, AttendanceSetupReadinessPerStepEntry>>
   viewerIsPlatformAdmin: boolean
+}
+
+/** §3.2 "判别值域（纯模块判别矩阵的行）...且每信号携带 scope: 'org' | 'deployment'（全局信号显式标
+ *  deployment，追加门禁 2）" — a scope tag per STEP (not per raw backend field), since that is the
+ *  granularity `AttendanceSetupReadinessStepResult` rows expose. Mirrors the backend's
+ *  `ATTENDANCE_SETUP_READINESS_DEPLOYMENT_SCOPED_FIELDS` registry
+ *  (`packages/core-backend/src/routes/attendance-admin.ts`): step④ (`punchPolicyPosture`) and
+ *  step⑥ (`recipientScopeConfig` IS the step's `status` — see the module header's ⑥ shape note) are
+ *  deployment-scoped; every other step's completion signal is an org-scoped COUNT. Note the
+ *  nuance for ⑥: `notifySignals.orgRecipientBinding` (carried alongside, unreduced) is itself
+ *  org-scoped even though the step's overall `scope` tag is `deployment` — this constant tags the
+ *  STEP, not each individual signal riding on it; a future per-signal breakdown is W4-1's call, not
+ *  this slice's. */
+export const ATTENDANCE_SETUP_STEP_SCOPE: Readonly<Record<AttendanceSetupStepId, 'org' | 'deployment'>> = {
+  'attendance-admin-user-access': 'org',
+  'attendance-admin-groups': 'org',
+  'attendance-admin-shifts': 'org',
+  'attendance-admin-settings': 'deployment',
+  'attendance-admin-approval-flows': 'org',
+  'attendance-admin-notification-deliveries': 'deployment',
+  preview: 'org',
 }
 
 /** Discriminated input the wizard shell can build directly from an HTTP response. */
@@ -115,6 +146,9 @@ export interface AttendanceSetupReadinessStepResult {
   status: AttendanceSetupReadinessStatus
   /** display-only reason key — never a raw value (values-free, §4.2) */
   reason: AttendanceSetupReadinessReasonKey
+  /** §3.2 "每信号携带 scope: 'org' | 'deployment'" — see `ATTENDANCE_SETUP_STEP_SCOPE` doc comment
+   *  for what this tags at step granularity. */
+  scope: 'org' | 'deployment'
   effectiveTime?: AttendanceSetupReadinessEffectiveTime
   /** step⑥ ONLY: the two non-blended advisory notify signals, carried unreduced (see module
    *  header). Absent on every other step. */
@@ -128,7 +162,7 @@ function stepMeta(
   data: AttendanceSetupReadinessResponse,
   stepId: AttendanceSetupStepId,
 ): AttendanceSetupReadinessEffectiveTime | undefined {
-  return data.perStep[stepId]
+  return data.perStep[stepId]?.effectiveTime
 }
 
 /** §3③ errata, owner-literal: org-level EXISTENCE test, not per-group rotation coverage. Exported
@@ -169,10 +203,20 @@ export function deriveAttendanceSetupReadinessSteps(
   input: AttendanceSetupReadinessInput,
 ): AttendanceSetupReadinessStepResult[] {
   if (input.kind === 'forbidden') {
-    return ATTENDANCE_SETUP_STEP_IDS.map((stepId) => ({ stepId, status: 'forbidden', reason: 'forbidden' }))
+    return ATTENDANCE_SETUP_STEP_IDS.map((stepId) => ({
+      stepId,
+      status: 'forbidden',
+      reason: 'forbidden',
+      scope: ATTENDANCE_SETUP_STEP_SCOPE[stepId],
+    }))
   }
   if (input.kind === 'db_not_ready') {
-    return ATTENDANCE_SETUP_STEP_IDS.map((stepId) => ({ stepId, status: 'db_not_ready', reason: 'db_not_ready' }))
+    return ATTENDANCE_SETUP_STEP_IDS.map((stepId) => ({
+      stepId,
+      status: 'db_not_ready',
+      reason: 'db_not_ready',
+      scope: ATTENDANCE_SETUP_STEP_SCOPE[stepId],
+    }))
   }
 
   const { data } = input
@@ -183,6 +227,7 @@ export function deriveAttendanceSetupReadinessSteps(
     stepId: 'attendance-admin-user-access',
     status: data.orgActiveMemberCount > 0 ? 'ready' : 'missing',
     reason: data.orgActiveMemberCount > 0 ? 'ready' : 'org_active_member_count_zero',
+    scope: ATTENDANCE_SETUP_STEP_SCOPE['attendance-admin-user-access'],
     effectiveTime: stepMeta(data, 'attendance-admin-user-access'),
   }
 
@@ -192,6 +237,7 @@ export function deriveAttendanceSetupReadinessSteps(
     stepId: 'attendance-admin-groups',
     status: step2Ready ? 'ready' : 'missing',
     reason: step2Ready ? 'ready' : 'group_or_membership_missing',
+    scope: ATTENDANCE_SETUP_STEP_SCOPE['attendance-admin-groups'],
     effectiveTime: stepMeta(data, 'attendance-admin-groups'),
   }
 
@@ -209,6 +255,7 @@ export function deriveAttendanceSetupReadinessSteps(
       : data.shiftCount === 0
         ? 'shift_count_zero'
         : 'scheduled_shift_group_without_rotation_rules',
+    scope: ATTENDANCE_SETUP_STEP_SCOPE['attendance-admin-shifts'],
     effectiveTime: stepMeta(data, 'attendance-admin-shifts'),
   }
 
@@ -232,6 +279,7 @@ export function deriveAttendanceSetupReadinessSteps(
         : data.punchPolicyPosture === 'customized'
           ? 'punch_policy_customized'
           : 'punch_policy_unknown',
+    scope: ATTENDANCE_SETUP_STEP_SCOPE['attendance-admin-settings'],
     effectiveTime: stepMeta(data, 'attendance-admin-settings'),
   }
 
@@ -241,6 +289,7 @@ export function deriveAttendanceSetupReadinessSteps(
     stepId: 'attendance-admin-approval-flows',
     status: step5Ready ? 'ready' : 'missing',
     reason: step5Ready ? 'ready' : 'approval_flow_count_zero',
+    scope: ATTENDANCE_SETUP_STEP_SCOPE['attendance-admin-approval-flows'],
     effectiveTime: stepMeta(data, 'attendance-admin-approval-flows'),
   }
 
@@ -250,6 +299,7 @@ export function deriveAttendanceSetupReadinessSteps(
     stepId: 'attendance-admin-notification-deliveries',
     status: 'unsupported',
     reason: 'recipient_scope_unsupported',
+    scope: ATTENDANCE_SETUP_STEP_SCOPE['attendance-admin-notification-deliveries'],
     effectiveTime: stepMeta(data, 'attendance-admin-notification-deliveries'),
     notifySignals: {
       deliveryRuntime: data.notify.deliveryRuntime,
@@ -266,6 +316,7 @@ export function deriveAttendanceSetupReadinessSteps(
     stepId: 'preview',
     status: previewReady ? 'ready' : 'missing',
     reason: previewReady ? 'preview_ready' : 'preview_blocked_by_prior_step',
+    scope: ATTENDANCE_SETUP_STEP_SCOPE.preview,
     effectiveTime: stepMeta(data, 'preview'),
   }
 

--- a/apps/web/src/views/attendance/attendanceSetupReadiness.ts
+++ b/apps/web/src/views/attendance/attendanceSetupReadiness.ts
@@ -1,0 +1,273 @@
+// W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED): pure discriminator for the seven-step
+// setup-readiness aggregate (`GET /api/attendance-admin/setup-readiness`). This module ONLY turns
+// the aggregate response (or a whole-endpoint 403/503) into the seven-step judgement matrix — zero
+// DOM, zero fetch, zero Vue reactivity. The wizard shell (`AttendanceSetupReadiness.vue`) and its
+// fetch/section-registration wiring belong to W4-1, not this slice (§7 "父层 AttendanceView：
+// readiness 加载/聚合调用..."; §2 W4-0 scope = "纯逻辑模块 attendanceSetupReadiness.ts（判别矩阵
+// 完整，分支不埋 template）").
+//
+// Design lock: docs/development/attendance-vnext-wave4-onboarding-design-lock-20260721.md §3/§4/§7.
+// Backend mirror (types + SQL): packages/core-backend/src/services/AttendanceSetupReadinessAggregate.ts
+// and packages/core-backend/src/routes/attendance-admin.ts (AttendanceSetupReadinessResponse).
+//
+// §3⑥ shape note (P2-2, "三个互不等价的信号...不得合并"): this module deliberately does NOT
+// collapse step⑥'s three notify signals into one blended status. `recipientScopeConfig` is always
+// `'unsupported'` and IS the step's `status` (it's literally the capability the step name
+// "配置...接收范围" names, and it's the one signal with a remediation-relevant value); the other
+// two signals (`deliveryRuntime`, `orgRecipientBinding`) are carried alongside, unreduced, for a
+// future W4-1 three-line render — never folded into `status`.
+
+/** The seven judgement values (§3/§7) — exhaustive, never an eighth. */
+export const ATTENDANCE_SETUP_READINESS_STATUS_VALUES = [
+  'ready',
+  'missing',
+  'forbidden',
+  'unknown',
+  'manual_review_required',
+  'unsupported',
+  'db_not_ready',
+] as const
+export type AttendanceSetupReadinessStatus = (typeof ATTENDANCE_SETUP_READINESS_STATUS_VALUES)[number]
+
+/** The seven canonical step ids, in wizard order (§3). Doubles as the canonical admin-section id
+ *  for steps ①-⑥; `preview` (⑦) has no section — it lives inside the wizard, read-only. */
+export const ATTENDANCE_SETUP_STEP_IDS = [
+  'attendance-admin-user-access',
+  'attendance-admin-groups',
+  'attendance-admin-shifts',
+  'attendance-admin-settings',
+  'attendance-admin-approval-flows',
+  'attendance-admin-notification-deliveries',
+  'preview',
+] as const
+export type AttendanceSetupStepId = (typeof ATTENDANCE_SETUP_STEP_IDS)[number]
+
+export type AttendanceSetupReadinessEffectiveTimePosture =
+  | 'immediate'
+  | 'scheduled'
+  | 'manual_activation'
+  | 'undeterminable'
+
+export interface AttendanceSetupReadinessEffectiveTime {
+  source: string
+  posture: AttendanceSetupReadinessEffectiveTimePosture
+  effectiveAt?: string
+}
+
+export type AttendancePunchPolicyPosture = 'default' | 'customized' | 'unknown'
+export type AttendanceSetupReadinessDeliveryRuntime = 'ready' | 'not_ready' | 'unknown'
+
+export interface AttendanceSetupReadinessOrgRecipientBinding {
+  boundRecipientCount: number
+  hasAnyBoundRecipient: boolean
+}
+
+export interface AttendanceSetupReadinessNotify {
+  deliveryRuntime: AttendanceSetupReadinessDeliveryRuntime
+  orgRecipientBinding: AttendanceSetupReadinessOrgRecipientBinding
+  recipientScopeConfig: 'unsupported'
+}
+
+/** Mirrors `packages/core-backend/src/routes/attendance-admin.ts` AttendanceSetupReadinessResponse
+ *  (§4.2-locked key set + the one pre-authorized addition, `viewerIsPlatformAdmin` — see that
+ *  file's doc comment for the "§4.2 键集" note). */
+export interface AttendanceSetupReadinessResponse {
+  directoryLinked: boolean
+  orgActiveMemberCount: number
+  groupCount: number
+  groupsWithMembers: number
+  shiftCount: number
+  scheduledShiftGroupCount: number
+  activeRotationRuleCount: number
+  hasRotationRules: boolean
+  approvalFlowCount: number
+  punchPolicyPosture: AttendancePunchPolicyPosture
+  notify: AttendanceSetupReadinessNotify
+  previewReady: boolean
+  perStep: Readonly<Record<AttendanceSetupStepId, AttendanceSetupReadinessEffectiveTime>>
+  viewerIsPlatformAdmin: boolean
+}
+
+/** Discriminated input the wizard shell can build directly from an HTTP response. */
+export type AttendanceSetupReadinessInput =
+  | { kind: 'forbidden' }
+  | { kind: 'db_not_ready' }
+  | { kind: 'ok'; data: AttendanceSetupReadinessResponse }
+
+export type AttendanceSetupReadinessReasonKey =
+  | 'org_active_member_count_zero'
+  | 'group_or_membership_missing'
+  | 'shift_count_zero'
+  | 'scheduled_shift_group_without_rotation_rules'
+  | 'punch_policy_default'
+  | 'punch_policy_customized'
+  | 'punch_policy_unknown'
+  | 'approval_flow_count_zero'
+  | 'recipient_scope_unsupported'
+  | 'preview_ready'
+  | 'preview_blocked_by_prior_step'
+  | 'ready'
+  | 'forbidden'
+  | 'db_not_ready'
+
+export interface AttendanceSetupReadinessStepResult {
+  stepId: AttendanceSetupStepId
+  status: AttendanceSetupReadinessStatus
+  /** display-only reason key — never a raw value (values-free, §4.2) */
+  reason: AttendanceSetupReadinessReasonKey
+  effectiveTime?: AttendanceSetupReadinessEffectiveTime
+  /** step⑥ ONLY: the two non-blended advisory notify signals, carried unreduced (see module
+   *  header). Absent on every other step. */
+  notifySignals?: {
+    deliveryRuntime: AttendanceSetupReadinessDeliveryRuntime
+    orgRecipientBinding: AttendanceSetupReadinessOrgRecipientBinding
+  }
+}
+
+function stepMeta(
+  data: AttendanceSetupReadinessResponse,
+  stepId: AttendanceSetupStepId,
+): AttendanceSetupReadinessEffectiveTime | undefined {
+  return data.perStep[stepId]
+}
+
+/** §3③ errata, owner-literal: org-level EXISTENCE test, not per-group rotation coverage. Exported
+ *  so the wizard shell (W4-1) can reuse the exact same formula for optimistic/preview math. */
+export function deriveAttendanceSetupReadinessStep3Ready(
+  shiftCount: number,
+  scheduledShiftGroupCount: number,
+  activeRotationRuleCount: number,
+): boolean {
+  return shiftCount > 0 && (scheduledShiftGroupCount === 0 || activeRotationRuleCount > 0)
+}
+
+/**
+ * §3.2 / §9 W4-0-G4: previewReady = ①②③⑤ ALL ready. ④ and ⑥ are advisory and MUST NOT
+ * participate. This is an INDEPENDENT re-derivation from the raw counts (not a read of
+ * `data.previewReady`) — defense in depth so a backend regression in the previewReady field itself
+ * cannot silently agree with a broken FE render; the contract test suite separately asserts the two
+ * stay consistent.
+ */
+export function deriveAttendanceSetupReadinessPreviewReady(data: AttendanceSetupReadinessResponse): boolean {
+  const step1Ready = data.orgActiveMemberCount > 0
+  const step2Ready = data.groupCount > 0 && data.groupsWithMembers > 0
+  const step3Ready = deriveAttendanceSetupReadinessStep3Ready(
+    data.shiftCount,
+    data.scheduledShiftGroupCount,
+    data.activeRotationRuleCount,
+  )
+  const step5Ready = data.approvalFlowCount > 0
+  return step1Ready && step2Ready && step3Ready && step5Ready
+}
+
+/**
+ * Derive the full seven-step judgement matrix from a setup-readiness response (or a whole-endpoint
+ * 403/503 fold). Every row's `status` is one of the seven locked values (§3 判别值域) — never an
+ * eighth, never a guess.
+ */
+export function deriveAttendanceSetupReadinessSteps(
+  input: AttendanceSetupReadinessInput,
+): AttendanceSetupReadinessStepResult[] {
+  if (input.kind === 'forbidden') {
+    return ATTENDANCE_SETUP_STEP_IDS.map((stepId) => ({ stepId, status: 'forbidden', reason: 'forbidden' }))
+  }
+  if (input.kind === 'db_not_ready') {
+    return ATTENDANCE_SETUP_STEP_IDS.map((stepId) => ({ stepId, status: 'db_not_ready', reason: 'db_not_ready' }))
+  }
+
+  const { data } = input
+
+  // ① orgActiveMemberCount>0 is sufficient (round-3 P2-1/P2-3: "同步或创建" OR semantics —
+  // directoryLinked is auxiliary/display-only, never gating).
+  const step1: AttendanceSetupReadinessStepResult = {
+    stepId: 'attendance-admin-user-access',
+    status: data.orgActiveMemberCount > 0 ? 'ready' : 'missing',
+    reason: data.orgActiveMemberCount > 0 ? 'ready' : 'org_active_member_count_zero',
+    effectiveTime: stepMeta(data, 'attendance-admin-user-access'),
+  }
+
+  // ② groupCount>0 AND groupsWithMembers>0 (OD-W4-6).
+  const step2Ready = data.groupCount > 0 && data.groupsWithMembers > 0
+  const step2: AttendanceSetupReadinessStepResult = {
+    stepId: 'attendance-admin-groups',
+    status: step2Ready ? 'ready' : 'missing',
+    reason: step2Ready ? 'ready' : 'group_or_membership_missing',
+    effectiveTime: stepMeta(data, 'attendance-admin-groups'),
+  }
+
+  // ③ errata step3Ready formula (org-level existence test, §3③).
+  const step3Ready = deriveAttendanceSetupReadinessStep3Ready(
+    data.shiftCount,
+    data.scheduledShiftGroupCount,
+    data.activeRotationRuleCount,
+  )
+  const step3: AttendanceSetupReadinessStepResult = {
+    stepId: 'attendance-admin-shifts',
+    status: step3Ready ? 'ready' : 'missing',
+    reason: step3Ready
+      ? 'ready'
+      : data.shiftCount === 0
+        ? 'shift_count_zero'
+        : 'scheduled_shift_group_without_rotation_rules',
+    effectiveTime: stepMeta(data, 'attendance-admin-shifts'),
+  }
+
+  // ④ errata mapping (recomputed here, NOT trusted from a pre-mapped backend field — the backend
+  // returns the raw 3-value `punchPolicyPosture` enum; this module owns the ready/manual_review/
+  // unknown mapping): customized -> ready; default -> manual_review_required (NEVER ready — the
+  // errata that overturned the frozen predecessor's default->ready mapping); unknown -> unknown
+  // fail-closed.
+  const step4Status: AttendanceSetupReadinessStatus =
+    data.punchPolicyPosture === 'customized'
+      ? 'ready'
+      : data.punchPolicyPosture === 'default'
+        ? 'manual_review_required'
+        : 'unknown'
+  const step4: AttendanceSetupReadinessStepResult = {
+    stepId: 'attendance-admin-settings',
+    status: step4Status,
+    reason:
+      data.punchPolicyPosture === 'default'
+        ? 'punch_policy_default'
+        : data.punchPolicyPosture === 'customized'
+          ? 'punch_policy_customized'
+          : 'punch_policy_unknown',
+    effectiveTime: stepMeta(data, 'attendance-admin-settings'),
+  }
+
+  // ⑤ approvalFlowCount>0 (active flows).
+  const step5Ready = data.approvalFlowCount > 0
+  const step5: AttendanceSetupReadinessStepResult = {
+    stepId: 'attendance-admin-approval-flows',
+    status: step5Ready ? 'ready' : 'missing',
+    reason: step5Ready ? 'ready' : 'approval_flow_count_zero',
+    effectiveTime: stepMeta(data, 'attendance-admin-approval-flows'),
+  }
+
+  // ⑥ §4.5(iii): recipientScopeConfig is always 'unsupported' and IS this step's status — the
+  // other two signals ride unreduced on `notifySignals` (module header; §3⑥ "不得合并").
+  const step6: AttendanceSetupReadinessStepResult = {
+    stepId: 'attendance-admin-notification-deliveries',
+    status: 'unsupported',
+    reason: 'recipient_scope_unsupported',
+    effectiveTime: stepMeta(data, 'attendance-admin-notification-deliveries'),
+    notifySignals: {
+      deliveryRuntime: data.notify.deliveryRuntime,
+      orgRecipientBinding: data.notify.orgRecipientBinding,
+    },
+  }
+
+  // ⑦ previewReady = ①②③⑤ ALL ready (§3.2). ④/⑥ never participate — independently re-derived
+  // (see deriveAttendanceSetupReadinessPreviewReady doc), so this cannot silently misattribute an
+  // ④/⑥ unknown/manual_review_required the way the frozen predecessor's "anyUnknown across all six
+  // priors" formula did (trilens P3 on that predecessor).
+  const previewReady = deriveAttendanceSetupReadinessPreviewReady(data)
+  const step7: AttendanceSetupReadinessStepResult = {
+    stepId: 'preview',
+    status: previewReady ? 'ready' : 'missing',
+    reason: previewReady ? 'preview_ready' : 'preview_blocked_by_prior_step',
+    effectiveTime: stepMeta(data, 'preview'),
+  }
+
+  return [step1, step2, step3, step4, step5, step6, step7]
+}

--- a/apps/web/tests/attendance-setup-readiness.spec.ts
+++ b/apps/web/tests/attendance-setup-readiness.spec.ts
@@ -1,0 +1,405 @@
+// W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED §3/§7/§9): full seven-step discriminator
+// matrix for `apps/web/src/views/attendance/attendanceSetupReadiness.ts` — zero DOM, zero fetch.
+// Wired into .github/workflows/attendance-web-guard.yml (run-list + both path filters).
+//
+// Coverage goal ("判别矩阵全值域×七步"): every value the seven-value status domain can reach at
+// each step, given today's implementation — this is not literally 7×7=49 combinations (most are
+// structurally impossible per step, e.g. step① can never be 'unsupported'), it is every REACHABLE
+// (step, status) pair:
+//   forbidden/db_not_ready — whole-endpoint folds, all seven steps
+//   ①②③⑤⑦ — ready / missing
+//   ④ — ready / manual_review_required / unknown
+//   ⑥ — unsupported (constant; the other two notify signals ride unreduced on notifySignals)
+// That covers all seven domain values across the matrix.
+import { describe, expect, it } from 'vitest'
+import {
+  ATTENDANCE_SETUP_READINESS_STATUS_VALUES,
+  ATTENDANCE_SETUP_STEP_IDS,
+  deriveAttendanceSetupReadinessPreviewReady,
+  deriveAttendanceSetupReadinessSteps,
+  deriveAttendanceSetupReadinessStep3Ready,
+  type AttendanceSetupReadinessResponse,
+} from '../src/views/attendance/attendanceSetupReadiness'
+
+const EFFECTIVE_TIME = {
+  source: 'test',
+  posture: 'immediate' as const,
+}
+
+const PER_STEP = Object.fromEntries(ATTENDANCE_SETUP_STEP_IDS.map((id) => [id, EFFECTIVE_TIME])) as Record<
+  (typeof ATTENDANCE_SETUP_STEP_IDS)[number],
+  typeof EFFECTIVE_TIME
+>
+
+function baseResponse(overrides: Partial<AttendanceSetupReadinessResponse> = {}): AttendanceSetupReadinessResponse {
+  return {
+    directoryLinked: false,
+    orgActiveMemberCount: 1,
+    groupCount: 1,
+    groupsWithMembers: 1,
+    shiftCount: 1,
+    scheduledShiftGroupCount: 0,
+    activeRotationRuleCount: 0,
+    hasRotationRules: false,
+    approvalFlowCount: 1,
+    punchPolicyPosture: 'customized',
+    notify: {
+      deliveryRuntime: 'not_ready',
+      orgRecipientBinding: { boundRecipientCount: 0, hasAnyBoundRecipient: false },
+      recipientScopeConfig: 'unsupported',
+    },
+    previewReady: true,
+    perStep: PER_STEP,
+    viewerIsPlatformAdmin: false,
+    ...overrides,
+  }
+}
+
+function stepById(rows: ReturnType<typeof deriveAttendanceSetupReadinessSteps>, stepId: string) {
+  const row = rows.find((r) => r.stepId === stepId)
+  if (!row) throw new Error(`missing step ${stepId}`)
+  return row
+}
+
+describe('value domain exhaustiveness', () => {
+  it('is exactly the seven locked values', () => {
+    expect(ATTENDANCE_SETUP_READINESS_STATUS_VALUES).toEqual([
+      'ready',
+      'missing',
+      'forbidden',
+      'unknown',
+      'manual_review_required',
+      'unsupported',
+      'db_not_ready',
+    ])
+  })
+})
+
+describe('whole-endpoint folds', () => {
+  it('forbidden folds all seven steps to forbidden', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({ kind: 'forbidden' })
+    expect(rows).toHaveLength(7)
+    expect(rows.map((r) => r.stepId)).toEqual([...ATTENDANCE_SETUP_STEP_IDS])
+    for (const row of rows) {
+      expect(row.status).toBe('forbidden')
+      expect(row.reason).toBe('forbidden')
+      expect(row.effectiveTime).toBeUndefined()
+    }
+  })
+
+  it('db_not_ready folds all seven steps to db_not_ready', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({ kind: 'db_not_ready' })
+    expect(rows).toHaveLength(7)
+    for (const row of rows) {
+      expect(row.status).toBe('db_not_ready')
+      expect(row.reason).toBe('db_not_ready')
+    }
+  })
+})
+
+describe('step① attendance-admin-user-access — orgActiveMemberCount (OR semantics)', () => {
+  it('ready when orgActiveMemberCount>0, regardless of directoryLinked', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ orgActiveMemberCount: 5, directoryLinked: false }),
+    })
+    expect(stepById(rows, 'attendance-admin-user-access').status).toBe('ready')
+  })
+
+  it('ready via a directory-linked org too (directoryLinked is auxiliary, never the gate)', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ orgActiveMemberCount: 5, directoryLinked: true }),
+    })
+    expect(stepById(rows, 'attendance-admin-user-access').status).toBe('ready')
+  })
+
+  it('missing when orgActiveMemberCount=0 even though directoryLinked=true (negative: not an AND gate)', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ orgActiveMemberCount: 0, directoryLinked: true }),
+    })
+    const row = stepById(rows, 'attendance-admin-user-access')
+    expect(row.status).toBe('missing')
+    expect(row.reason).toBe('org_active_member_count_zero')
+  })
+})
+
+describe('step② attendance-admin-groups — groupCount AND groupsWithMembers', () => {
+  it('ready when both > 0', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ groupCount: 3, groupsWithMembers: 1 }),
+    })
+    expect(stepById(rows, 'attendance-admin-groups').status).toBe('ready')
+  })
+
+  it('missing when groups exist but none have members', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ groupCount: 3, groupsWithMembers: 0 }),
+    })
+    const row = stepById(rows, 'attendance-admin-groups')
+    expect(row.status).toBe('missing')
+    expect(row.reason).toBe('group_or_membership_missing')
+  })
+
+  it('missing when there are no groups at all', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ groupCount: 0, groupsWithMembers: 0 }),
+    })
+    expect(stepById(rows, 'attendance-admin-groups').status).toBe('missing')
+  })
+})
+
+describe('step③ attendance-admin-shifts — §3③ errata formula', () => {
+  it('missing when shiftCount=0', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ shiftCount: 0, scheduledShiftGroupCount: 0, activeRotationRuleCount: 0 }),
+    })
+    const row = stepById(rows, 'attendance-admin-shifts')
+    expect(row.status).toBe('missing')
+    expect(row.reason).toBe('shift_count_zero')
+  })
+
+  it('ready when shiftCount>0 and no scheduled-shift group exists (org-level existence test)', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ shiftCount: 2, scheduledShiftGroupCount: 0, activeRotationRuleCount: 0 }),
+    })
+    expect(stepById(rows, 'attendance-admin-shifts').status).toBe('ready')
+  })
+
+  it('missing when a scheduled-shift group exists but no active rotation rule does', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ shiftCount: 2, scheduledShiftGroupCount: 1, activeRotationRuleCount: 0 }),
+    })
+    const row = stepById(rows, 'attendance-admin-shifts')
+    expect(row.status).toBe('missing')
+    expect(row.reason).toBe('scheduled_shift_group_without_rotation_rules')
+  })
+
+  it('ready when a scheduled-shift group exists AND an active rotation rule does', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ shiftCount: 2, scheduledShiftGroupCount: 1, activeRotationRuleCount: 1 }),
+    })
+    expect(stepById(rows, 'attendance-admin-shifts').status).toBe('ready')
+  })
+
+  it('deriveAttendanceSetupReadinessStep3Ready matches the step③ status exactly (single source of truth)', () => {
+    for (const [shiftCount, scheduledShiftGroupCount, activeRotationRuleCount] of [
+      [0, 0, 0],
+      [2, 0, 0],
+      [2, 1, 0],
+      [2, 1, 1],
+    ] as const) {
+      const formula = deriveAttendanceSetupReadinessStep3Ready(shiftCount, scheduledShiftGroupCount, activeRotationRuleCount)
+      const rows = deriveAttendanceSetupReadinessSteps({
+        kind: 'ok',
+        data: baseResponse({ shiftCount, scheduledShiftGroupCount, activeRotationRuleCount }),
+      })
+      expect(stepById(rows, 'attendance-admin-shifts').status).toBe(formula ? 'ready' : 'missing')
+    }
+  })
+})
+
+describe('step④ attendance-admin-settings — punchPolicyPosture mapping (errata, NEVER default→ready)', () => {
+  it('customized -> ready', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ punchPolicyPosture: 'customized' }),
+    })
+    const row = stepById(rows, 'attendance-admin-settings')
+    expect(row.status).toBe('ready')
+    expect(row.reason).toBe('punch_policy_customized')
+  })
+
+  it('default -> manual_review_required (errata; the frozen predecessor mapped this to ready — must not regress)', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ punchPolicyPosture: 'default' }),
+    })
+    const row = stepById(rows, 'attendance-admin-settings')
+    expect(row.status).toBe('manual_review_required')
+    expect(row.reason).toBe('punch_policy_default')
+  })
+
+  it('unknown -> unknown (fail-closed)', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ punchPolicyPosture: 'unknown' }),
+    })
+    const row = stepById(rows, 'attendance-admin-settings')
+    expect(row.status).toBe('unknown')
+    expect(row.reason).toBe('punch_policy_unknown')
+  })
+})
+
+describe('step⑤ attendance-admin-approval-flows — approvalFlowCount', () => {
+  it('ready when approvalFlowCount>0', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({ kind: 'ok', data: baseResponse({ approvalFlowCount: 2 }) })
+    expect(stepById(rows, 'attendance-admin-approval-flows').status).toBe('ready')
+  })
+  it('missing when approvalFlowCount=0', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({ kind: 'ok', data: baseResponse({ approvalFlowCount: 0 }) })
+    const row = stepById(rows, 'attendance-admin-approval-flows')
+    expect(row.status).toBe('missing')
+    expect(row.reason).toBe('approval_flow_count_zero')
+  })
+})
+
+describe('step⑥ attendance-admin-notification-deliveries — three signals, never merged (§3⑥ P2-2)', () => {
+  it('status is always unsupported (recipientScopeConfig, the step-naming capability) regardless of the other two signals', () => {
+    for (const deliveryRuntime of ['ready', 'not_ready', 'unknown'] as const) {
+      for (const hasAnyBoundRecipient of [true, false]) {
+        const rows = deriveAttendanceSetupReadinessSteps({
+          kind: 'ok',
+          data: baseResponse({
+            notify: {
+              deliveryRuntime,
+              orgRecipientBinding: { boundRecipientCount: hasAnyBoundRecipient ? 3 : 0, hasAnyBoundRecipient },
+              recipientScopeConfig: 'unsupported',
+            },
+          }),
+        })
+        const row = stepById(rows, 'attendance-admin-notification-deliveries')
+        expect(row.status).toBe('unsupported')
+        expect(row.reason).toBe('recipient_scope_unsupported')
+      }
+    }
+  })
+
+  it('carries the other two signals unreduced on notifySignals — never folded into status', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({
+        notify: {
+          deliveryRuntime: 'unknown',
+          orgRecipientBinding: { boundRecipientCount: 4, hasAnyBoundRecipient: true },
+          recipientScopeConfig: 'unsupported',
+        },
+      }),
+    })
+    const row = stepById(rows, 'attendance-admin-notification-deliveries')
+    expect(row.notifySignals).toEqual({
+      deliveryRuntime: 'unknown',
+      orgRecipientBinding: { boundRecipientCount: 4, hasAnyBoundRecipient: true },
+    })
+  })
+
+  it('no other step carries notifySignals', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({ kind: 'ok', data: baseResponse() })
+    for (const row of rows) {
+      if (row.stepId !== 'attendance-admin-notification-deliveries') {
+        expect(row.notifySignals).toBeUndefined()
+      }
+    }
+  })
+})
+
+describe('step⑦ preview — previewReady = ①②③⑤ only; ④/⑥ never gate (§3.2 / §9 W4-0-G4)', () => {
+  const readyBase = baseResponse()
+
+  it('ready when ①②③⑤ all ready, regardless of ④=default/unknown', () => {
+    for (const punchPolicyPosture of ['default', 'customized', 'unknown'] as const) {
+      const rows = deriveAttendanceSetupReadinessSteps({
+        kind: 'ok',
+        data: baseResponse({ punchPolicyPosture }),
+      })
+      const row = stepById(rows, 'preview')
+      expect(row.status).toBe('ready')
+      expect(row.reason).toBe('preview_ready')
+    }
+  })
+
+  it('ready regardless of every ⑥ notify combination', () => {
+    for (const deliveryRuntime of ['ready', 'not_ready', 'unknown'] as const) {
+      const rows = deriveAttendanceSetupReadinessSteps({
+        kind: 'ok',
+        data: baseResponse({
+          notify: {
+            deliveryRuntime,
+            orgRecipientBinding: { boundRecipientCount: 0, hasAnyBoundRecipient: false },
+            recipientScopeConfig: 'unsupported',
+          },
+        }),
+      })
+      expect(stepById(rows, 'preview').status).toBe('ready')
+    }
+  })
+
+  it.each([
+    ['orgActiveMemberCount', 0],
+    ['groupCount', 0],
+    ['groupsWithMembers', 0],
+    ['shiftCount', 0],
+    ['approvalFlowCount', 0],
+  ] as const)('missing when %s drops to %d, even with ④=customized and ⑥ fully bound', (field, value) => {
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({
+        [field]: value,
+        punchPolicyPosture: 'customized',
+        notify: {
+          deliveryRuntime: 'unknown',
+          orgRecipientBinding: { boundRecipientCount: 9, hasAnyBoundRecipient: true },
+          recipientScopeConfig: 'unsupported',
+        },
+      } as Partial<AttendanceSetupReadinessResponse>),
+    })
+    const row = stepById(rows, 'preview')
+    expect(row.status).toBe('missing')
+    expect(row.reason).toBe('preview_blocked_by_prior_step')
+  })
+
+  it('deriveAttendanceSetupReadinessPreviewReady matches the step⑦ status exactly', () => {
+    expect(deriveAttendanceSetupReadinessPreviewReady(readyBase)).toBe(true)
+    const rows = deriveAttendanceSetupReadinessSteps({ kind: 'ok', data: readyBase })
+    expect(stepById(rows, 'preview').status).toBe('ready')
+  })
+})
+
+describe('effectiveTime pass-through', () => {
+  it('carries each step perStep entry through unchanged', () => {
+    const custom = { source: 'user_orgs.is_active', posture: 'immediate' as const }
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ perStep: { ...PER_STEP, 'attendance-admin-user-access': custom } }),
+    })
+    expect(stepById(rows, 'attendance-admin-user-access').effectiveTime).toEqual(custom)
+  })
+
+  it('an "undeterminable"/effectiveAt-bearing entry round-trips exactly', () => {
+    const scheduled = { source: 'holiday_sync_window', posture: 'scheduled' as const, effectiveAt: '2026-08-01T00:00:00.000Z' }
+    const rows = deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ perStep: { ...PER_STEP, 'attendance-admin-groups': scheduled } }),
+    })
+    expect(stepById(rows, 'attendance-admin-groups').effectiveTime).toEqual(scheduled)
+  })
+})
+
+describe('full-matrix status-value coverage (every domain value reachable in the current implementation)', () => {
+  it('touches all seven values across the folds + a representative "ok" response', () => {
+    const touched = new Set<string>()
+    for (const row of deriveAttendanceSetupReadinessSteps({ kind: 'forbidden' })) touched.add(row.status)
+    for (const row of deriveAttendanceSetupReadinessSteps({ kind: 'db_not_ready' })) touched.add(row.status)
+    for (const row of deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ orgActiveMemberCount: 0, punchPolicyPosture: 'unknown' }),
+    })) {
+      touched.add(row.status)
+    }
+    for (const row of deriveAttendanceSetupReadinessSteps({
+      kind: 'ok',
+      data: baseResponse({ punchPolicyPosture: 'default' }),
+    })) {
+      touched.add(row.status)
+    }
+    expect([...touched].sort()).toEqual([...ATTENDANCE_SETUP_READINESS_STATUS_VALUES].sort())
+  })
+})

--- a/apps/web/tests/attendance-setup-readiness.spec.ts
+++ b/apps/web/tests/attendance-setup-readiness.spec.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from 'vitest'
 import {
   ATTENDANCE_SETUP_READINESS_STATUS_VALUES,
   ATTENDANCE_SETUP_STEP_IDS,
+  ATTENDANCE_SETUP_STEP_SCOPE,
   deriveAttendanceSetupReadinessPreviewReady,
   deriveAttendanceSetupReadinessSteps,
   deriveAttendanceSetupReadinessStep3Ready,
@@ -26,10 +27,11 @@ const EFFECTIVE_TIME = {
   posture: 'immediate' as const,
 }
 
-const PER_STEP = Object.fromEntries(ATTENDANCE_SETUP_STEP_IDS.map((id) => [id, EFFECTIVE_TIME])) as Record<
-  (typeof ATTENDANCE_SETUP_STEP_IDS)[number],
-  typeof EFFECTIVE_TIME
->
+// §4.2-locked nested shape: perStep.effectiveTime: {source, posture, effectiveAt?} — each entry
+// wraps under an `effectiveTime` key (not the effective-time record itself).
+const PER_STEP = Object.fromEntries(
+  ATTENDANCE_SETUP_STEP_IDS.map((id) => [id, { effectiveTime: EFFECTIVE_TIME }]),
+) as Record<(typeof ATTENDANCE_SETUP_STEP_IDS)[number], { effectiveTime: typeof EFFECTIVE_TIME }>
 
 function baseResponse(overrides: Partial<AttendanceSetupReadinessResponse> = {}): AttendanceSetupReadinessResponse {
   return {
@@ -368,7 +370,7 @@ describe('effectiveTime pass-through', () => {
     const custom = { source: 'user_orgs.is_active', posture: 'immediate' as const }
     const rows = deriveAttendanceSetupReadinessSteps({
       kind: 'ok',
-      data: baseResponse({ perStep: { ...PER_STEP, 'attendance-admin-user-access': custom } }),
+      data: baseResponse({ perStep: { ...PER_STEP, 'attendance-admin-user-access': { effectiveTime: custom } } }),
     })
     expect(stepById(rows, 'attendance-admin-user-access').effectiveTime).toEqual(custom)
   })
@@ -377,9 +379,38 @@ describe('effectiveTime pass-through', () => {
     const scheduled = { source: 'holiday_sync_window', posture: 'scheduled' as const, effectiveAt: '2026-08-01T00:00:00.000Z' }
     const rows = deriveAttendanceSetupReadinessSteps({
       kind: 'ok',
-      data: baseResponse({ perStep: { ...PER_STEP, 'attendance-admin-groups': scheduled } }),
+      data: baseResponse({ perStep: { ...PER_STEP, 'attendance-admin-groups': { effectiveTime: scheduled } } }),
     })
     expect(stepById(rows, 'attendance-admin-groups').effectiveTime).toEqual(scheduled)
+  })
+})
+
+describe('scope tag (§3.2 "每信号携带 scope: org | deployment") on every matrix row', () => {
+  it('org-scoped for ①②③⑤⑦, deployment-scoped for ④⑥, on an "ok" response', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({ kind: 'ok', data: baseResponse() })
+    expect(stepById(rows, 'attendance-admin-user-access').scope).toBe('org')
+    expect(stepById(rows, 'attendance-admin-groups').scope).toBe('org')
+    expect(stepById(rows, 'attendance-admin-shifts').scope).toBe('org')
+    expect(stepById(rows, 'attendance-admin-settings').scope).toBe('deployment')
+    expect(stepById(rows, 'attendance-admin-approval-flows').scope).toBe('org')
+    expect(stepById(rows, 'attendance-admin-notification-deliveries').scope).toBe('deployment')
+    expect(stepById(rows, 'preview').scope).toBe('org')
+  })
+
+  it('every row scope matches the exported ATTENDANCE_SETUP_STEP_SCOPE registry exactly', () => {
+    const rows = deriveAttendanceSetupReadinessSteps({ kind: 'ok', data: baseResponse() })
+    for (const row of rows) {
+      expect(row.scope).toBe(ATTENDANCE_SETUP_STEP_SCOPE[row.stepId])
+    }
+  })
+
+  it('scope is present even on the whole-endpoint forbidden/db_not_ready folds (a scope tag is a property of the STEP, not of the current judgement)', () => {
+    for (const input of [{ kind: 'forbidden' as const }, { kind: 'db_not_ready' as const }]) {
+      const rows = deriveAttendanceSetupReadinessSteps(input)
+      for (const row of rows) {
+        expect(row.scope).toBe(ATTENDANCE_SETUP_STEP_SCOPE[row.stepId])
+      }
+    }
   })
 })
 

--- a/apps/web/tests/attendance-setup-readiness.spec.ts
+++ b/apps/web/tests/attendance-setup-readiness.spec.ts
@@ -52,7 +52,6 @@ function baseResponse(overrides: Partial<AttendanceSetupReadinessResponse> = {})
     },
     previewReady: true,
     perStep: PER_STEP,
-    viewerIsPlatformAdmin: false,
     ...overrides,
   }
 }

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -9,7 +9,7 @@ import { redeliverFailedAttendanceNotification } from '../services/AttendanceNot
 import { ensurePlatformAdmin } from './admin-users'
 import { isDatabaseSchemaError } from '../utils/database-errors'
 import {
-  ATTENDANCE_SETUP_READINESS_STEP_EFFECTIVE_TIME,
+  ATTENDANCE_SETUP_READINESS_PER_STEP,
   ATTENDANCE_SETUP_READINESS_RECIPIENT_SCOPE_CONFIG,
   computeAttendanceSetupReadinessDeliveryRuntime,
   computeAttendanceSetupReadinessPreviewReady,
@@ -19,7 +19,7 @@ import {
   runAttendanceSetupReadinessReadOnly,
   type AttendanceSetupReadinessOrgCounts,
   type AttendanceSetupReadinessNotify,
-  type AttendanceSetupReadinessEffectiveTime,
+  type AttendanceSetupReadinessPerStepEntry,
   type AttendanceSetupStepId,
   type AttendancePunchPolicyPosture,
 } from '../services/AttendanceSetupReadinessAggregate'
@@ -416,10 +416,19 @@ export async function canReadAttendanceDirectoryReadiness(
 // pre-existing `readOrgDirectoryReadiness` (S7-5) into the §4.2-locked response shape.
 // ---------------------------------------------------------------------------------------------
 
-/** Mirrors the §4.2-locked response key set EXACTLY — see the PR body's "§4.2 键集" note for the
- *  one pre-authorized addition (`viewerIsPlatformAdmin`, §3① role-gated remediation data) and why
- *  `scope` is NOT a wire field (kept as code-level documentation only, per the design lock's own
- *  §4.2 illustration, which marks scope via comments rather than a runtime key). */
+/** Mirrors the §4.2-locked response key set PLUS one disclosed, not-yet-owner-ratified addition —
+ *  see the PR body's "§4.2 键集偏离说明" for the full disclosure. `directoryLinked` ... `perStep`
+ *  are the §4.2-locked 13 keys verbatim (`perStep` nested as `perStep[stepId].effectiveTime`, per
+ *  the lock's own `perStep.effectiveTime: {...}` JSON-block notation). `viewerIsPlatformAdmin` is
+ *  NOT in that locked list — it exists to satisfy the §3① role-gated remediation contract
+ *  ("W4-1 强制"), which needs viewer-role data the locked shape has no other field for. This is a
+ *  genuine tension between two ratified provisions (exact-key-set lock vs. role-gated display
+ *  contract), not a settled call this implementation is authorized to make either direction of —
+ *  keeping the field (rather than silently dropping a value a ratified clause depends on) is the
+ *  reversible choice pending explicit owner sign-off at the next gate; do not read the contract
+ *  test's key-set assertion below as itself constituting that sign-off. `scope` is NOT a wire field
+ *  (kept as code-level documentation only, per the design lock's own §4.2 illustration, which marks
+ *  scope via comments rather than a runtime key). */
 export interface AttendanceSetupReadinessResponse {
   directoryLinked: boolean
   orgActiveMemberCount: number
@@ -433,7 +442,7 @@ export interface AttendanceSetupReadinessResponse {
   punchPolicyPosture: AttendancePunchPolicyPosture
   notify: AttendanceSetupReadinessNotify
   previewReady: boolean
-  perStep: Readonly<Record<AttendanceSetupStepId, AttendanceSetupReadinessEffectiveTime>>
+  perStep: Readonly<Record<AttendanceSetupStepId, AttendanceSetupReadinessPerStepEntry>>
   viewerIsPlatformAdmin: boolean
 }
 
@@ -476,7 +485,7 @@ async function buildAttendanceSetupReadiness(
       punchPolicyPosture,
       notify,
       previewReady: computeAttendanceSetupReadinessPreviewReady(counts),
-      perStep: ATTENDANCE_SETUP_READINESS_STEP_EFFECTIVE_TIME,
+      perStep: ATTENDANCE_SETUP_READINESS_PER_STEP,
       viewerIsPlatformAdmin,
     } satisfies AttendanceSetupReadinessResponse
   })

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -7,6 +7,22 @@ import { MAX_MANAGER_CHAIN_LEVELS } from '../services/ApprovalDirectoryOrg'
 import { jsonError, jsonOk, parsePagination } from '../util/response'
 import { redeliverFailedAttendanceNotification } from '../services/AttendanceNotificationRedelivery'
 import { ensurePlatformAdmin } from './admin-users'
+import { isDatabaseSchemaError } from '../utils/database-errors'
+import {
+  ATTENDANCE_SETUP_READINESS_STEP_EFFECTIVE_TIME,
+  ATTENDANCE_SETUP_READINESS_RECIPIENT_SCOPE_CONFIG,
+  computeAttendanceSetupReadinessDeliveryRuntime,
+  computeAttendanceSetupReadinessPreviewReady,
+  readAttendanceSetupReadinessOrgCounts,
+  readAttendanceSetupReadinessOrgRecipientBinding,
+  readAttendancePunchPolicyPosture,
+  runAttendanceSetupReadinessReadOnly,
+  type AttendanceSetupReadinessOrgCounts,
+  type AttendanceSetupReadinessNotify,
+  type AttendanceSetupReadinessEffectiveTime,
+  type AttendanceSetupStepId,
+  type AttendancePunchPolicyPosture,
+} from '../services/AttendanceSetupReadinessAggregate'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -389,6 +405,83 @@ export async function canReadAttendanceDirectoryReadiness(
   return member.rows.length > 0
 }
 
+// ---------------------------------------------------------------------------------------------
+// W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED §3/§4/§9): seven-step setup-readiness
+// aggregate. §4.1 OD-W4-1=(a): same org-membership door as S7-5 (`canReadAttendanceDirectoryReadiness`,
+// reused verbatim), and authorization ALWAYS completes before this function is ever invoked — a
+// foreign-org 403 issues zero aggregation SQL, zero transactions (§9 W4-0-G1 case 2). Every
+// aggregation read happens inside ONE `SET TRANSACTION READ ONLY` transaction (R1 / §9 W4-0-G2);
+// the query/posture/notify computations themselves live in
+// `services/AttendanceSetupReadinessAggregate.ts` — this function only assembles them plus the
+// pre-existing `readOrgDirectoryReadiness` (S7-5) into the §4.2-locked response shape.
+// ---------------------------------------------------------------------------------------------
+
+/** Mirrors the §4.2-locked response key set EXACTLY — see the PR body's "§4.2 键集" note for the
+ *  one pre-authorized addition (`viewerIsPlatformAdmin`, §3① role-gated remediation data) and why
+ *  `scope` is NOT a wire field (kept as code-level documentation only, per the design lock's own
+ *  §4.2 illustration, which marks scope via comments rather than a runtime key). */
+export interface AttendanceSetupReadinessResponse {
+  directoryLinked: boolean
+  orgActiveMemberCount: number
+  groupCount: number
+  groupsWithMembers: number
+  shiftCount: number
+  scheduledShiftGroupCount: number
+  activeRotationRuleCount: number
+  hasRotationRules: boolean
+  approvalFlowCount: number
+  punchPolicyPosture: AttendancePunchPolicyPosture
+  notify: AttendanceSetupReadinessNotify
+  previewReady: boolean
+  perStep: Readonly<Record<AttendanceSetupStepId, AttendanceSetupReadinessEffectiveTime>>
+  viewerIsPlatformAdmin: boolean
+}
+
+/** §4.2/§4.5 deployment-scoped signal registry (code-level documentation of the design lock's own
+ *  §4.2 `// scope=...` comments, NOT a response field — see §4.2 键集 note above). Every response
+ *  key NOT listed here is org-scoped. Kept exported so a contract test can assert this list against
+ *  the design lock text rather than re-deriving it from prose each time. */
+export const ATTENDANCE_SETUP_READINESS_DEPLOYMENT_SCOPED_FIELDS = [
+  'punchPolicyPosture',
+  'notify.deliveryRuntime',
+  'notify.recipientScopeConfig',
+] as const
+
+async function buildAttendanceSetupReadiness(
+  orgId: string,
+  viewerIsPlatformAdmin: boolean,
+): Promise<AttendanceSetupReadinessResponse> {
+  return runAttendanceSetupReadinessReadOnly(async (readOnlyQuery) => {
+    const [directory, counts, punchPolicyPosture, orgRecipientBinding] = await Promise.all([
+      readOrgDirectoryReadiness(orgId, readOnlyQuery),
+      readAttendanceSetupReadinessOrgCounts(orgId, readOnlyQuery),
+      readAttendancePunchPolicyPosture(readOnlyQuery),
+      readAttendanceSetupReadinessOrgRecipientBinding(orgId, readOnlyQuery),
+    ])
+    const notify: AttendanceSetupReadinessNotify = {
+      deliveryRuntime: computeAttendanceSetupReadinessDeliveryRuntime(),
+      orgRecipientBinding,
+      recipientScopeConfig: ATTENDANCE_SETUP_READINESS_RECIPIENT_SCOPE_CONFIG,
+    }
+    return {
+      directoryLinked: directory.hasLinkedDirectoryAccounts,
+      orgActiveMemberCount: counts.orgActiveMemberCount,
+      groupCount: counts.groupCount,
+      groupsWithMembers: counts.groupsWithMembers,
+      shiftCount: counts.shiftCount,
+      scheduledShiftGroupCount: counts.scheduledShiftGroupCount,
+      activeRotationRuleCount: counts.activeRotationRuleCount,
+      hasRotationRules: counts.activeRotationRuleCount > 0,
+      approvalFlowCount: counts.approvalFlowCount,
+      punchPolicyPosture,
+      notify,
+      previewReady: computeAttendanceSetupReadinessPreviewReady(counts),
+      perStep: ATTENDANCE_SETUP_READINESS_STEP_EFFECTIVE_TIME,
+      viewerIsPlatformAdmin,
+    } satisfies AttendanceSetupReadinessResponse
+  })
+}
+
 export function attendanceAdminRouter(): Router {
   const r = Router()
 
@@ -419,6 +512,44 @@ export function attendanceAdminRouter(): Router {
     } catch (_error) {
       // Values-free seam: never leak raw DB / driver messages to the client.
       return jsonError(res, 500, 'DIRECTORY_READINESS_FAILED', 'Failed to load directory readiness')
+    }
+  })
+
+  // W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED §4.1 OD-W4-1=(a)): seven-step
+  // setup-readiness aggregate. Same org-membership door as S7-5 above
+  // (`canReadAttendanceDirectoryReadiness`, reused verbatim) — authorization completes BEFORE
+  // `buildAttendanceSetupReadiness` is ever called, so a foreign-org 403 issues zero aggregation
+  // SQL and opens zero transactions (§9 W4-0-G1 case 2). Response is values-free by construction
+  // (§4.2): counts, booleans, and closed enums only — never IDs, names, credentials, or raw
+  // configuration values.
+  r.get('/api/attendance-admin/setup-readiness', async (req: Request, res: Response) => {
+    try {
+      const orgId = String(req.query.orgId || '').trim()
+      if (!orgId) {
+        return jsonError(res, 400, 'ORG_ID_REQUIRED', 'orgId is required')
+      }
+      const userId = getAttendanceAdminRequestUserId(req)
+      if (!userId) {
+        return jsonError(res, 401, 'UNAUTHENTICATED', 'Authentication required')
+      }
+      const allowed = await canReadAttendanceDirectoryReadiness(req, userId, orgId)
+      if (!allowed) {
+        return jsonError(res, 403, 'FORBIDDEN', 'Org membership required for setup readiness')
+      }
+      // §3① role-gated remediation contract (owner P2, W4-1-enforced display branch — see the
+      // response interface doc comment): the SAME predicate `canReadAttendanceDirectoryReadiness`
+      // already evaluated internally as its platform-admin bypass (`hasLegacyAdminClaim` /
+      // `isRbacAdmin`), recomputed here (cheap — no new query) so the response can carry a single
+      // values-free boolean instead of the route re-deriving admin-ness a second, different way.
+      const viewerIsPlatformAdmin = hasLegacyAdminClaim(req) || (await isRbacAdmin(userId))
+      const readiness = await buildAttendanceSetupReadiness(orgId, viewerIsPlatformAdmin)
+      return jsonOk(res, readiness)
+    } catch (error) {
+      if (isDatabaseSchemaError(error)) {
+        return jsonError(res, 503, 'DB_NOT_READY', 'Attendance tables not ready')
+      }
+      // Values-free seam: never leak raw DB / driver messages to the client.
+      return jsonError(res, 500, 'SETUP_READINESS_FAILED', 'Failed to load setup readiness')
     }
   })
 

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -416,19 +416,17 @@ export async function canReadAttendanceDirectoryReadiness(
 // pre-existing `readOrgDirectoryReadiness` (S7-5) into the §4.2-locked response shape.
 // ---------------------------------------------------------------------------------------------
 
-/** Mirrors the §4.2-locked response key set PLUS one disclosed, not-yet-owner-ratified addition —
- *  see the PR body's "§4.2 键集偏离说明" for the full disclosure. `directoryLinked` ... `perStep`
- *  are the §4.2-locked 13 keys verbatim (`perStep` nested as `perStep[stepId].effectiveTime`, per
- *  the lock's own `perStep.effectiveTime: {...}` JSON-block notation). `viewerIsPlatformAdmin` is
- *  NOT in that locked list — it exists to satisfy the §3① role-gated remediation contract
- *  ("W4-1 强制"), which needs viewer-role data the locked shape has no other field for. This is a
- *  genuine tension between two ratified provisions (exact-key-set lock vs. role-gated display
- *  contract), not a settled call this implementation is authorized to make either direction of —
- *  keeping the field (rather than silently dropping a value a ratified clause depends on) is the
- *  reversible choice pending explicit owner sign-off at the next gate; do not read the contract
- *  test's key-set assertion below as itself constituting that sign-off. `scope` is NOT a wire field
- *  (kept as code-level documentation only, per the design lock's own §4.2 illustration, which marks
- *  scope via comments rather than a runtime key). */
+/** Mirrors the §4.2-locked response key set EXACTLY — `directoryLinked` ... `perStep` are the
+ *  §4.2-locked 13 keys verbatim (`perStep` nested as `perStep[stepId].effectiveTime`, per the
+ *  lock's own `perStep.effectiveTime: {...}` JSON-block notation). A prior revision of this file
+ *  also carried `viewerIsPlatformAdmin` as a disclosed, not-yet-owner-ratified 14th key (P2, #4541
+ *  review) — removed: the pure discriminator module
+ *  (`apps/web/src/views/attendance/attendanceSetupReadiness.ts`) has zero consumption of it, so it
+ *  was speculative surface for the §3① role-gated remediation contract, not something this slice
+ *  was authorized to add unilaterally. W4-1, if it needs viewer-role data for that contract, gets
+ *  it via its own owner request to extend this shape — not by resurrecting this field. `scope` is
+ *  NOT a wire field (kept as code-level documentation only, per the design lock's own §4.2
+ *  illustration, which marks scope via comments rather than a runtime key). */
 export interface AttendanceSetupReadinessResponse {
   directoryLinked: boolean
   orgActiveMemberCount: number
@@ -443,7 +441,6 @@ export interface AttendanceSetupReadinessResponse {
   notify: AttendanceSetupReadinessNotify
   previewReady: boolean
   perStep: Readonly<Record<AttendanceSetupStepId, AttendanceSetupReadinessPerStepEntry>>
-  viewerIsPlatformAdmin: boolean
 }
 
 /** §4.2/§4.5 deployment-scoped signal registry (code-level documentation of the design lock's own
@@ -456,10 +453,7 @@ export const ATTENDANCE_SETUP_READINESS_DEPLOYMENT_SCOPED_FIELDS = [
   'notify.recipientScopeConfig',
 ] as const
 
-async function buildAttendanceSetupReadiness(
-  orgId: string,
-  viewerIsPlatformAdmin: boolean,
-): Promise<AttendanceSetupReadinessResponse> {
+async function buildAttendanceSetupReadiness(orgId: string): Promise<AttendanceSetupReadinessResponse> {
   return runAttendanceSetupReadinessReadOnly(async (readOnlyQuery) => {
     const [directory, counts, punchPolicyPosture, orgRecipientBinding] = await Promise.all([
       readOrgDirectoryReadiness(orgId, readOnlyQuery),
@@ -486,7 +480,6 @@ async function buildAttendanceSetupReadiness(
       notify,
       previewReady: computeAttendanceSetupReadinessPreviewReady(counts),
       perStep: ATTENDANCE_SETUP_READINESS_PER_STEP,
-      viewerIsPlatformAdmin,
     } satisfies AttendanceSetupReadinessResponse
   })
 }
@@ -545,13 +538,7 @@ export function attendanceAdminRouter(): Router {
       if (!allowed) {
         return jsonError(res, 403, 'FORBIDDEN', 'Org membership required for setup readiness')
       }
-      // §3① role-gated remediation contract (owner P2, W4-1-enforced display branch — see the
-      // response interface doc comment): the SAME predicate `canReadAttendanceDirectoryReadiness`
-      // already evaluated internally as its platform-admin bypass (`hasLegacyAdminClaim` /
-      // `isRbacAdmin`), recomputed here (cheap — no new query) so the response can carry a single
-      // values-free boolean instead of the route re-deriving admin-ness a second, different way.
-      const viewerIsPlatformAdmin = hasLegacyAdminClaim(req) || (await isRbacAdmin(userId))
-      const readiness = await buildAttendanceSetupReadiness(orgId, viewerIsPlatformAdmin)
+      const readiness = await buildAttendanceSetupReadiness(orgId)
       return jsonOk(res, readiness)
     } catch (error) {
       if (isDatabaseSchemaError(error)) {

--- a/packages/core-backend/src/services/AttendanceSetupReadinessAggregate.ts
+++ b/packages/core-backend/src/services/AttendanceSetupReadinessAggregate.ts
@@ -278,11 +278,16 @@ export type AttendancePunchPolicyPosture = 'default' | 'customized' | 'unknown'
  *  direction), so this is an independently pinned literal copy of ONLY the closed set — never the
  *  other 20 settings keys, so an unrelated write (e.g. a holiday-sync machine write to
  *  `holidaySync.lastRun`) can never mislabel this posture (§3.1 "整包比对必然误判").
- *  KNOWN DRIFT RISK (flagged, not silently accepted — trilens P3 on the frozen predecessor): if the
- *  plugin's DEFAULT_SETTINGS closed-set defaults ever change, this mirror will not auto-follow; the
- *  §9 W4-0-G5 reconciliation test only checks that the KEY NAMES in the closed set are exhaustively
- *  classified against the live key set, not that this mirror's VALUES still match the plugin's. */
-const ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT = {
+ *  Drift risk between this mirror and the plugin's live literal is closed by §9 W4-0-G5's test
+ *  suite two ways: a KEY-NAME reconciliation (every DEFAULT_SETTINGS top-level key is exhaustively
+ *  classified IN/OUT of the closed set) AND, separately, a VALUE-level reconciliation (P3-2, #4541
+ *  review) that parses the plugin's live source text for these four keys' literal values and
+ *  deep-diffs them against this exact object — see
+ *  `tests/unit/attendance-admin-setup-readiness-w4-0.test.ts`. Exported (not module-private) so
+ *  that value-reconciliation test diffs against the SAME object this module actually compares
+ *  against at runtime, rather than a second, independently-typed copy in the test file that could
+ *  itself drift unnoticed. */
+export const ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT = {
   punchPolicy: {
     unscheduled: { mode: 'allow' },
     merge: { internalWinsOnIn: false, externalWinsOnOut: false },
@@ -347,6 +352,10 @@ function deepEqualJsonValue(a: unknown, b: unknown): boolean {
   return a === b
 }
 
+/** SAVEPOINT name for the ④ probe (P3-1, #4541 review) — see `readAttendancePunchPolicyPosture`'s
+ *  doc comment for why this exists. */
+const ATTENDANCE_PUNCH_POLICY_POSTURE_PROBE_SAVEPOINT = 'attendance_punch_policy_posture_probe'
+
 /**
  * §3④ / OD-W4-4=(c). Reads the ONE deployment-wide `system_configs` row and classifies the §3.1
  * closed-set subset against normalized defaults. Any write to `attendance.settings` is ALWAYS
@@ -357,37 +366,69 @@ function deepEqualJsonValue(a: unknown, b: unknown): boolean {
  * `JSON.parse(String(raw))` on that shape throws `"[object Object]" is not valid JSON`; today's
  * canonical migration creates `value text`, but a legacy-migrated deployment could still carry the
  * older jsonb column, so both shapes are handled here.
+ *
+ * P3-1 (#4541 review) — SAVEPOINT-scoped probe: this function shares ONE Postgres
+ * transaction/connection with the other three §4.1 aggregation reads (`buildAttendanceSetupReadiness`'s
+ * `Promise.all` queues all four on the SAME client). A bare try/catch around the probe was not
+ * enough: once Postgres sees ANY error on a statement inside a transaction, the WHOLE transaction is
+ * marked aborted (SQLSTATE 25P02, "current transaction is aborted") and every subsequent statement
+ * on that connection fails too — so an optional/missing `system_configs` table (42P01) here would
+ * cascade into the sibling `orgRecipientBinding` read failing next, turning ONE probe's fail-closed
+ * `unknown` into a whole-endpoint 503/500 instead of the intended "④=unknown, everything else
+ * normal, 200". A SAVEPOINT scopes the blast radius to just this probe: on any failure (a DB error
+ * OR a synchronous parse error) we `ROLLBACK TO SAVEPOINT`, which restores the shared transaction to
+ * a healthy state before returning — see the real-DB negative test (drops/renames `system_configs`
+ * out from under a live request) in `attendance-setup-readiness-w4-0.db.test.ts`.
  */
 export async function readAttendancePunchPolicyPosture(
   runQuery: AttendanceSetupReadinessQueryFn,
 ): Promise<AttendancePunchPolicyPosture> {
   try {
+    await runQuery(`SAVEPOINT ${ATTENDANCE_PUNCH_POLICY_POSTURE_PROBE_SAVEPOINT}`)
+  } catch {
+    // Could not even open a savepoint (e.g. the shared transaction was already aborted upstream of
+    // this probe) — nothing left here to protect; fail closed.
+    return 'unknown'
+  }
+  try {
     const result = await runQuery<{ value: unknown }>('SELECT value FROM system_configs WHERE key = $1', [
       ATTENDANCE_SETTINGS_KEY,
     ])
     const raw = result.rows[0]?.value
+    let posture: AttendancePunchPolicyPosture
     if (raw === undefined || raw === null) {
       // No row at all: the platform default is in force (never explicitly saved).
-      return 'default'
+      posture = 'default'
+    } else {
+      const parsed: unknown = typeof raw === 'object' ? raw : JSON.parse(String(raw))
+      if (!parsed || typeof parsed !== 'object' || !('punchPolicy' in (parsed as Record<string, unknown>))) {
+        // A row exists but carries no punchPolicy subtree (pre-S0 shape / corrupted write) — cannot
+        // honestly claim default or customized.
+        posture = 'unknown'
+      } else {
+        const p = parsed as Record<string, unknown>
+        const closedSet = {
+          punchPolicy: p.punchPolicy,
+          ipAllowlist: 'ipAllowlist' in p ? p.ipAllowlist : ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT.ipAllowlist,
+          geoFence: 'geoFence' in p ? p.geoFence : ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT.geoFence,
+          minPunchIntervalMinutes:
+            'minPunchIntervalMinutes' in p
+              ? p.minPunchIntervalMinutes
+              : ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT.minPunchIntervalMinutes,
+        }
+        posture = deepEqualJsonValue(closedSet, ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT) ? 'default' : 'customized'
+      }
     }
-    const parsed: unknown = typeof raw === 'object' ? raw : JSON.parse(String(raw))
-    if (!parsed || typeof parsed !== 'object' || !('punchPolicy' in (parsed as Record<string, unknown>))) {
-      // A row exists but carries no punchPolicy subtree (pre-S0 shape / corrupted write) — cannot
-      // honestly claim default or customized.
-      return 'unknown'
-    }
-    const p = parsed as Record<string, unknown>
-    const closedSet = {
-      punchPolicy: p.punchPolicy,
-      ipAllowlist: 'ipAllowlist' in p ? p.ipAllowlist : ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT.ipAllowlist,
-      geoFence: 'geoFence' in p ? p.geoFence : ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT.geoFence,
-      minPunchIntervalMinutes:
-        'minPunchIntervalMinutes' in p
-          ? p.minPunchIntervalMinutes
-          : ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT.minPunchIntervalMinutes,
-    }
-    return deepEqualJsonValue(closedSet, ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT) ? 'default' : 'customized'
+    await runQuery(`RELEASE SAVEPOINT ${ATTENDANCE_PUNCH_POLICY_POSTURE_PROBE_SAVEPOINT}`)
+    return posture
   } catch {
+    try {
+      await runQuery(`ROLLBACK TO SAVEPOINT ${ATTENDANCE_PUNCH_POLICY_POSTURE_PROBE_SAVEPOINT}`)
+    } catch {
+      // Rollback-to-savepoint itself failed — nothing more this function can do; still fail closed
+      // (the shared transaction may end up aborted regardless in this doubly-failed case, but that
+      // was already the pre-fix behaviour for every failure, not a regression).
+    }
     return 'unknown'
   }
 }

--- a/packages/core-backend/src/services/AttendanceSetupReadinessAggregate.ts
+++ b/packages/core-backend/src/services/AttendanceSetupReadinessAggregate.ts
@@ -92,6 +92,26 @@ export const ATTENDANCE_SETUP_READINESS_STEP_EFFECTIVE_TIME: Readonly<
   preview: { source: 'none', posture: 'manual_activation' },
 }
 
+/** §4.2-locked wire shape for the response's `perStep` key: the design lock's own JSON block
+ *  writes `perStep.effectiveTime: { source, posture, effectiveAt? }` — i.e. each per-step ENTRY
+ *  is an object carrying an `effectiveTime` key, not the effective-time record itself. (Trilens
+ *  review on the frozen predecessor: a flat `perStep[stepId] = {source,posture,effectiveAt?}`
+ *  shape reads as a claims-vs-lock-text deviation.) This wraps
+ *  `ATTENDANCE_SETUP_READINESS_STEP_EFFECTIVE_TIME` — the single source of truth for VALUES — into
+ *  the locked wire shape once, at module load, so every request reuses the same frozen object. */
+export interface AttendanceSetupReadinessPerStepEntry {
+  effectiveTime: AttendanceSetupReadinessEffectiveTime
+}
+
+export const ATTENDANCE_SETUP_READINESS_PER_STEP: Readonly<
+  Record<AttendanceSetupStepId, AttendanceSetupReadinessPerStepEntry>
+> = Object.fromEntries(
+  ATTENDANCE_SETUP_STEP_IDS.map((stepId) => [
+    stepId,
+    { effectiveTime: ATTENDANCE_SETUP_READINESS_STEP_EFFECTIVE_TIME[stepId] },
+  ]),
+) as Readonly<Record<AttendanceSetupStepId, AttendanceSetupReadinessPerStepEntry>>
+
 // ---------------------------------------------------------------------------------------------
 // §4.1 / R1: the read-only seam. Exported so a real-DB test can drive it DIRECTLY with synthetic
 // SQL (the behavioural proof §9 W4-0-G2 requires) without going through any business query.
@@ -404,31 +424,43 @@ export function computeAttendanceSetupReadinessDeliveryRuntime(): AttendanceSetu
 
 /**
  * §4.5(ii): org-scoped bound-recipient coverage. Mirrors the EXACT join
- * `AttendanceNotificationDeliveryWorker.resolveRecipient` uses to find a usable DingTalk
- * recipient (directory_account_links ⋈ directory_accounts ⋈ directory_integrations), minus the
- * per-recipient `local_user_id = $1` filter (this is an org-wide aggregate, not a single lookup).
- * Returns ONLY a count/boolean — never a userId, external_user_id, or integration id (values-free,
- * §4.2). No `unknown` state exists for this signal (its type is count/boolean only, unlike
- * deliveryRuntime); a query failure here is not swallowed — it propagates to the route's
- * DB_NOT_READY/500 handling so the response is never a fabricated zero.
+ * `AttendanceNotificationDeliveryWorker.resolveRecipient` uses to find a usable recipient
+ * (directory_account_links ⋈ directory_accounts ⋈ directory_integrations), minus the per-recipient
+ * `local_user_id = $1` filter (this is an org-wide aggregate, not a single lookup).
+ * **Provider coverage (§4.5(ii) real-source note "企微同型")**: the WeCom channel's own
+ * `resolveRecipient` (`AttendanceNotificationDeliveryWorker.ts` WeCom section) uses the EXACT same
+ * three-table join shape as DingTalk's, just with `provider='wecom'` on both legs — a
+ * dingtalk-only filter here would under-report coverage (false `hasAnyBoundRecipient=false`) for a
+ * purely-WeCom-deployed org. `a.provider = i.provider` (rather than pinning both sides to one
+ * literal) plus the `IN (...)` list below covers both wired channels without a cross-provider
+ * account/integration mismatch. `l.local_user_id IS NOT NULL` and `COUNT(DISTINCT ...)` mirror the
+ * worker's own resolution precondition (`resolveRecipient` selects `WHERE l.local_user_id = $1`, so
+ * a NULL-local_user_id link can never be resolved for anyone and must not inflate this count; two+
+ * active links for the same local user is one recipient, not two — the worker itself flags that
+ * shape as a data-integrity anomaly, not extra coverage). Returns ONLY a count/boolean — never a
+ * userId, external_user_id, or integration id (values-free, §4.2). No `unknown` state exists for
+ * this signal (its type is count/boolean only, unlike deliveryRuntime); a query failure here is not
+ * swallowed — it propagates to the route's DB_NOT_READY/500 handling so the response is never a
+ * fabricated zero.
  */
 export async function readAttendanceSetupReadinessOrgRecipientBinding(
   orgId: string,
   runQuery: AttendanceSetupReadinessQueryFn,
 ): Promise<AttendanceSetupReadinessOrgRecipientBinding> {
   const result = await runQuery<{ bound_recipient_count: number }>(
-    `SELECT COUNT(*)::int AS bound_recipient_count
+    `SELECT COUNT(DISTINCT l.local_user_id)::int AS bound_recipient_count
        FROM directory_account_links l
        JOIN directory_accounts a
          ON a.id = l.directory_account_id
-        AND a.provider = 'dingtalk'
+        AND a.provider IN ('dingtalk', 'wecom')
         AND a.is_active = true
        JOIN directory_integrations i
          ON i.id = a.integration_id
-        AND i.provider = 'dingtalk'
+        AND i.provider = a.provider
         AND i.status = 'active'
         AND i.org_id = $1
-      WHERE l.link_status = 'linked'`,
+      WHERE l.link_status = 'linked'
+        AND l.local_user_id IS NOT NULL`,
     [orgId],
   )
   const count = Number(result.rows[0]?.bound_recipient_count ?? 0)

--- a/packages/core-backend/src/services/AttendanceSetupReadinessAggregate.ts
+++ b/packages/core-backend/src/services/AttendanceSetupReadinessAggregate.ts
@@ -1,0 +1,443 @@
+/**
+ * W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED §3/§4/§9 — see
+ * docs/development/attendance-vnext-wave4-onboarding-design-lock-20260721.md): the seven-step
+ * setup-readiness aggregate's computational core — every org-scoped COUNT, the ④ punch-policy
+ * closed-set posture check, the ⑥ notify readiness port, the §3② step③/⑦ pure formulas, and the
+ * ONLY authorized read-only proof (§4.2 / §9 W4-0-G2). This module has zero Express/route
+ * dependencies (no `Request`/`Response`) so every function is directly unit-testable with a mock
+ * query function — the route wiring (authorization-before-aggregation, `directoryLinked` reuse of
+ * S7-5's `readOrgDirectoryReadiness`, HTTP status mapping) lives in
+ * `packages/core-backend/src/routes/attendance-admin.ts`, which imports from here.
+ *
+ * §0 red line R1 (readiness is READ-ONLY): `runAttendanceSetupReadinessReadOnly` is the ONLY
+ * sanctioned way any of this module's queries may reach Postgres in production. It is a REAL
+ * `SET TRANSACTION READ ONLY` transaction — never a prefix/regex check on SQL text. A prior,
+ * frozen attempt at this line used `sql.trim().toUpperCase().startsWith('SELECT'||'WITH')`; it was
+ * killed in review (three independent findings, all confirmed) because Postgres freely permits:
+ *   (a) a data-modifying CTE — `WITH d AS (DELETE FROM t RETURNING 1) SELECT * FROM d` starts with
+ *       `WITH` and passes a prefix check, but is a write;
+ *   (b) `SELECT ... INTO new_table` — starts with `SELECT`, creates a table;
+ *   (c) a multi-statement batch sent as a single un-parameterized string (`SELECT 1; DELETE ...`) —
+ *       the simple-query protocol executes every statement in the batch.
+ * All three slip straight past any first-token/regex test. `SET TRANSACTION READ ONLY` is a real
+ * Postgres transaction property enforced by the server at EXECUTION time against the actual
+ * command type of every statement that follows — bare, CTE-nested, or later in a batch — so it
+ * closes all three holes at once, structurally, with no text inspection at all. See §9 W4-0-G2 for
+ * the three required-reject test cases and the "no first-word/regex readiness check anywhere in
+ * this module" negative meta-assertion (grep guard, not just a test).
+ */
+import type { QueryResult, QueryResultRow } from 'pg'
+import { query, transaction } from '../db/pg'
+import { getSharedAttendanceScheduler } from './AttendanceScheduler'
+
+// ---------------------------------------------------------------------------------------------
+// Value domain (§3 / §7): the SEVEN judgement values a step (or the whole per-step matrix, on a
+// whole-endpoint fold) may take. Exhaustive — a discriminator branch must never invent an eighth.
+// ---------------------------------------------------------------------------------------------
+
+export const ATTENDANCE_SETUP_READINESS_STATUS_VALUES = [
+  'ready',
+  'missing',
+  'forbidden',
+  'unknown',
+  'manual_review_required',
+  'unsupported',
+  'db_not_ready',
+] as const
+export type AttendanceSetupReadinessStatus = (typeof ATTENDANCE_SETUP_READINESS_STATUS_VALUES)[number]
+
+/** The seven canonical step ids (§3), stable wizard order. Doubles as the canonical admin-section
+ *  deep-link id for steps ①-⑥ (§6.2); `preview` has no section — ⑦ lives inside the wizard. */
+export const ATTENDANCE_SETUP_STEP_IDS = [
+  'attendance-admin-user-access',
+  'attendance-admin-groups',
+  'attendance-admin-shifts',
+  'attendance-admin-settings',
+  'attendance-admin-approval-flows',
+  'attendance-admin-notification-deliveries',
+  'preview',
+] as const
+export type AttendanceSetupStepId = (typeof ATTENDANCE_SETUP_STEP_IDS)[number]
+
+// ---------------------------------------------------------------------------------------------
+// §3.2 "计划生效时间" — four-state posture, registered once per step, never guessed (追加门禁4).
+// Fully static (no step in this slice has an app-observable *scheduled* trigger), so this is a
+// plain constant, computed with zero DB access, safe to reuse verbatim in every response.
+// ---------------------------------------------------------------------------------------------
+
+export type AttendanceSetupReadinessEffectiveTimePosture =
+  | 'immediate'
+  | 'scheduled'
+  | 'manual_activation'
+  | 'undeterminable'
+
+export interface AttendanceSetupReadinessEffectiveTime {
+  source: string
+  posture: AttendanceSetupReadinessEffectiveTimePosture
+  effectiveAt?: string
+}
+
+export const ATTENDANCE_SETUP_READINESS_STEP_EFFECTIVE_TIME: Readonly<
+  Record<AttendanceSetupStepId, AttendanceSetupReadinessEffectiveTime>
+> = {
+  'attendance-admin-user-access': { source: 'user_orgs.is_active', posture: 'immediate' },
+  'attendance-admin-groups': { source: 'attendance_group_members', posture: 'immediate' },
+  'attendance-admin-shifts': { source: 'attendance_shifts+attendance_rotation_rules', posture: 'immediate' },
+  'attendance-admin-settings': { source: 'system_configs.attendance_settings', posture: 'immediate' },
+  'attendance-admin-approval-flows': { source: 'attendance_approval_flows.is_active', posture: 'immediate' },
+  // Channel/worker enablement is operator env/redeploy-controlled — no app-observable schedule.
+  'attendance-admin-notification-deliveries': { source: 'none', posture: 'undeterminable' },
+  // §3⑦: preview-ready never means "already enabled" — activation is always a human action against
+  // the canonical checklist, never an app-triggered event.
+  preview: { source: 'none', posture: 'manual_activation' },
+}
+
+// ---------------------------------------------------------------------------------------------
+// §4.1 / R1: the read-only seam. Exported so a real-DB test can drive it DIRECTLY with synthetic
+// SQL (the behavioural proof §9 W4-0-G2 requires) without going through any business query.
+// ---------------------------------------------------------------------------------------------
+
+/** Matches `typeof query`'s call shape so it is a drop-in replacement everywhere `query` is used
+ *  as a parameter default (e.g. S7-5's `readOrgDirectoryReadiness`). */
+export type AttendanceSetupReadinessQueryFn = typeof query
+
+export async function runAttendanceSetupReadinessReadOnly<T>(
+  handler: (readOnlyQuery: AttendanceSetupReadinessQueryFn) => Promise<T>,
+  runTransaction: typeof transaction = transaction,
+): Promise<T> {
+  return runTransaction(async (client) => {
+    // MUST be the first statement in the transaction (Postgres applies READ ONLY to every
+    // statement issued afterward in THIS transaction, regardless of shape or batching — see the
+    // module header for exactly which write-shapes this closes that a text check could not).
+    await client.query('SET TRANSACTION READ ONLY')
+    const readOnlyQuery = (<T2 extends QueryResultRow = QueryResultRow>(
+      sql: string,
+      params?: unknown[],
+    ): Promise<QueryResult<T2>> => client.query(sql, params) as Promise<QueryResult<T2>>) as AttendanceSetupReadinessQueryFn
+    return handler(readOnlyQuery)
+  })
+}
+
+// ---------------------------------------------------------------------------------------------
+// §3①②③⑤ / §4.2 / OD-W4-1 追加门禁2: every org-scoped count in a single CTE, `org_id = $1` on
+// every leg, one positional parameter for the whole query (S7-5 precedent; §9 audits this SQL
+// text literally — 7 occurrences of `org_id = $1`, exactly one `$` parameter).
+// ---------------------------------------------------------------------------------------------
+
+export interface AttendanceSetupReadinessOrgCounts {
+  orgActiveMemberCount: number
+  groupCount: number
+  groupsWithMembers: number
+  shiftCount: number
+  scheduledShiftGroupCount: number
+  activeRotationRuleCount: number
+  approvalFlowCount: number
+}
+
+export async function readAttendanceSetupReadinessOrgCounts(
+  orgId: string,
+  runQuery: AttendanceSetupReadinessQueryFn,
+): Promise<AttendanceSetupReadinessOrgCounts> {
+  const result = await runQuery<{
+    org_active_member_count: number
+    group_count: number
+    groups_with_members: number
+    shift_count: number
+    scheduled_shift_group_count: number
+    active_rotation_rule_count: number
+    approval_flow_count: number
+  }>(
+    `WITH member_scope AS (
+       -- §3① P2-1: RD-3 "active org members only" — BOTH user_orgs.is_active AND users.is_active
+       -- (mirrors canReadAttendanceDirectoryReadiness's own org-membership door verbatim).
+       SELECT COUNT(*)::int AS org_active_member_count
+         FROM user_orgs uo
+         JOIN users u ON u.id = uo.user_id AND u.is_active = true
+        WHERE uo.org_id = $1 AND uo.is_active = true
+     ),
+     group_member_counts AS (
+       SELECT group_id, COUNT(*)::int AS member_count
+         FROM attendance_group_members
+        WHERE org_id = $1
+        GROUP BY group_id
+     ),
+     group_scope AS (
+       -- §3② / OD-W4-6: groupCount vs groupsWithMembers, deliberately split.
+       SELECT COUNT(*)::int AS group_count,
+              COUNT(*) FILTER (WHERE COALESCE(gmc.member_count, 0) > 0)::int AS groups_with_members
+         FROM attendance_groups g
+         LEFT JOIN group_member_counts gmc ON gmc.group_id = g.id
+        WHERE g.org_id = $1
+     ),
+     shift_scope AS (
+       SELECT COUNT(*)::int AS shift_count
+         FROM attendance_shifts
+        WHERE org_id = $1
+     ),
+     scheduled_shift_group_scope AS (
+       -- §3③ errata: the missing "排班制组是否存在" signal, owner's literal definition.
+       SELECT COUNT(*)::int AS scheduled_shift_group_count
+         FROM attendance_groups
+        WHERE org_id = $1 AND attendance_type = 'scheduled_shift'
+     ),
+     rotation_scope AS (
+       SELECT COUNT(*)::int AS active_rotation_rule_count
+         FROM attendance_rotation_rules
+        WHERE org_id = $1 AND is_active = true
+     ),
+     approval_scope AS (
+       SELECT COUNT(*)::int AS approval_flow_count
+         FROM attendance_approval_flows
+        WHERE org_id = $1 AND is_active = true
+     )
+     SELECT member_scope.org_active_member_count,
+            group_scope.group_count,
+            group_scope.groups_with_members,
+            shift_scope.shift_count,
+            scheduled_shift_group_scope.scheduled_shift_group_count,
+            rotation_scope.active_rotation_rule_count,
+            approval_scope.approval_flow_count
+       FROM member_scope, group_scope, shift_scope, scheduled_shift_group_scope, rotation_scope, approval_scope`,
+    [orgId],
+  )
+  const row = result.rows[0]
+  return {
+    orgActiveMemberCount: Number(row?.org_active_member_count ?? 0),
+    groupCount: Number(row?.group_count ?? 0),
+    groupsWithMembers: Number(row?.groups_with_members ?? 0),
+    shiftCount: Number(row?.shift_count ?? 0),
+    scheduledShiftGroupCount: Number(row?.scheduled_shift_group_count ?? 0),
+    activeRotationRuleCount: Number(row?.active_rotation_rule_count ?? 0),
+    approvalFlowCount: Number(row?.approval_flow_count ?? 0),
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// §3③ step3Ready / §3⑦ previewReady — pure formulas, zero I/O, owner-literal (errata + re-ratify).
+// ---------------------------------------------------------------------------------------------
+
+/** §3③ errata, owner-literal: org-level EXISTENCE test, not per-group rotation coverage (today's
+ *  schema has no group<->rotation-rule association — see the design lock's §3③ cell). */
+export function computeAttendanceSetupReadinessStep3Ready(
+  shiftCount: number,
+  scheduledShiftGroupCount: number,
+  activeRotationRuleCount: number,
+): boolean {
+  return shiftCount > 0 && (scheduledShiftGroupCount === 0 || activeRotationRuleCount > 0)
+}
+
+/** §3.2 / §9 W4-0-G4: previewReady = ①②③⑤ ALL ready. ④ and ⑥ are advisory and MUST NOT
+ *  participate — this is asserted directly by a contract test that flips every ④/⑥ combination
+ *  and shows previewReady unaffected. */
+export function computeAttendanceSetupReadinessPreviewReady(counts: AttendanceSetupReadinessOrgCounts): boolean {
+  const step1Ready = counts.orgActiveMemberCount > 0
+  const step2Ready = counts.groupCount > 0 && counts.groupsWithMembers > 0
+  const step3Ready = computeAttendanceSetupReadinessStep3Ready(
+    counts.shiftCount,
+    counts.scheduledShiftGroupCount,
+    counts.activeRotationRuleCount,
+  )
+  const step5Ready = counts.approvalFlowCount > 0
+  return step1Ready && step2Ready && step3Ready && step5Ready
+}
+
+// ---------------------------------------------------------------------------------------------
+// §3④ / §3.1 / OD-W4-4=(c) — punch-policy posture: back-end internal semantic check against the
+// §3.1 CLOSED SET (punchPolicy, ipAllowlist, geoFence, minPunchIntervalMinutes — 4 of 24 top-level
+// DEFAULT_SETTINGS keys), never the whole settings blob. The front end only ever sees this 3-value
+// enum — raw settings values never leave this function.
+// ---------------------------------------------------------------------------------------------
+
+const ATTENDANCE_SETTINGS_KEY = 'attendance.settings'
+
+export type AttendancePunchPolicyPosture = 'default' | 'customized' | 'unknown'
+
+/** Literal mirror of `DEFAULT_SETTINGS`'s §3.1 closed-set subset
+ *  (plugins/plugin-attendance/index.cjs, `DEFAULT_SETTINGS` ~L295-512). core-backend has no
+ *  sanctioned import of plugin internals (plugin -> core-backend is the only wired dependency
+ *  direction), so this is an independently pinned literal copy of ONLY the closed set — never the
+ *  other 20 settings keys, so an unrelated write (e.g. a holiday-sync machine write to
+ *  `holidaySync.lastRun`) can never mislabel this posture (§3.1 "整包比对必然误判").
+ *  KNOWN DRIFT RISK (flagged, not silently accepted — trilens P3 on the frozen predecessor): if the
+ *  plugin's DEFAULT_SETTINGS closed-set defaults ever change, this mirror will not auto-follow; the
+ *  §9 W4-0-G5 reconciliation test only checks that the KEY NAMES in the closed set are exhaustively
+ *  classified against the live key set, not that this mirror's VALUES still match the plugin's. */
+const ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT = {
+  punchPolicy: {
+    unscheduled: { mode: 'allow' },
+    merge: { internalWinsOnIn: false, externalWinsOnOut: false },
+    outdoor: { requireApproval: false, requireNote: false, requirePhoto: false, approvalFlowId: '' },
+  },
+  ipAllowlist: [] as unknown[],
+  geoFence: null as Record<string, unknown> | null,
+  minPunchIntervalMinutes: 1,
+}
+
+/** §3.1 closed-set membership registry, IN + OUT = all 24 DEFAULT_SETTINGS top-level keys. §9
+ *  W4-0-G5's contract test parses the LIVE plugin source text (not a second hardcoded mirror of
+ *  this list) and asserts IN ∪ OUT equals the live key set — a new settings key nobody classified
+ *  reds that test instead of silently being swept into (or excluded from) the ④ comparison. */
+export const ATTENDANCE_PUNCH_POLICY_CLOSED_SET_KEYS_IN = [
+  'punchPolicy',
+  'ipAllowlist',
+  'geoFence',
+  'minPunchIntervalMinutes',
+] as const
+
+export const ATTENDANCE_PUNCH_POLICY_CLOSED_SET_KEYS_OUT = [
+  'autoAbsence',
+  'holidayPolicy',
+  'calendarPolicy',
+  'holidaySync',
+  'shiftEditPolicy',
+  'shiftCompliance',
+  'multiShiftDay',
+  'formula',
+  'comprehensiveHours',
+  'compTimeFromOvertime',
+  'annualLeavePolicy',
+  'overtimeSegmentation',
+  'overtimeBankPolicy',
+  'leaveBalanceDeductionPolicy',
+  'attendanceBonusPolicy',
+  'attendanceReportDigestPolicy',
+  'makeupPunchPolicy',
+  'attendanceResultEditPolicy',
+  'autoShiftMatching',
+  'reportSync',
+] as const
+
+function deepEqualJsonValue(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (a === null || b === null || a === undefined || b === undefined) return a === b
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false
+    return a.every((v, i) => deepEqualJsonValue(v, b[i]))
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    const aKeys = Object.keys(a as Record<string, unknown>)
+    const bKeys = Object.keys(b as Record<string, unknown>)
+    if (aKeys.length !== bKeys.length) return false
+    return aKeys.every(
+      (k) =>
+        Object.prototype.hasOwnProperty.call(b, k) &&
+        deepEqualJsonValue((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]),
+    )
+  }
+  return a === b
+}
+
+/**
+ * §3④ / OD-W4-4=(c). Reads the ONE deployment-wide `system_configs` row and classifies the §3.1
+ * closed-set subset against normalized defaults. Any write to `attendance.settings` is ALWAYS
+ * `normalizeSettings(...)`'s output (plugin `saveSettings`, the sole write path) — so a stored row
+ * is already normalized and this function compares it directly, with no re-normalization pass.
+ * Legacy-schema note (found via a real Postgres probe against a pre-`z20251231` "038" JSONB
+ * `system_configs.value` column): the pg driver auto-parses a `jsonb` column into a JS object, so
+ * `JSON.parse(String(raw))` on that shape throws `"[object Object]" is not valid JSON`; today's
+ * canonical migration creates `value text`, but a legacy-migrated deployment could still carry the
+ * older jsonb column, so both shapes are handled here.
+ */
+export async function readAttendancePunchPolicyPosture(
+  runQuery: AttendanceSetupReadinessQueryFn,
+): Promise<AttendancePunchPolicyPosture> {
+  try {
+    const result = await runQuery<{ value: unknown }>('SELECT value FROM system_configs WHERE key = $1', [
+      ATTENDANCE_SETTINGS_KEY,
+    ])
+    const raw = result.rows[0]?.value
+    if (raw === undefined || raw === null) {
+      // No row at all: the platform default is in force (never explicitly saved).
+      return 'default'
+    }
+    const parsed: unknown = typeof raw === 'object' ? raw : JSON.parse(String(raw))
+    if (!parsed || typeof parsed !== 'object' || !('punchPolicy' in (parsed as Record<string, unknown>))) {
+      // A row exists but carries no punchPolicy subtree (pre-S0 shape / corrupted write) — cannot
+      // honestly claim default or customized.
+      return 'unknown'
+    }
+    const p = parsed as Record<string, unknown>
+    const closedSet = {
+      punchPolicy: p.punchPolicy,
+      ipAllowlist: 'ipAllowlist' in p ? p.ipAllowlist : ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT.ipAllowlist,
+      geoFence: 'geoFence' in p ? p.geoFence : ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT.geoFence,
+      minPunchIntervalMinutes:
+        'minPunchIntervalMinutes' in p
+          ? p.minPunchIntervalMinutes
+          : ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT.minPunchIntervalMinutes,
+    }
+    return deepEqualJsonValue(closedSet, ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT) ? 'default' : 'customized'
+  } catch {
+    return 'unknown'
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// §4.5 — ⑥ the three independent notify signals (P2-2, MUST NOT be merged into one value).
+// ---------------------------------------------------------------------------------------------
+
+export type AttendanceSetupReadinessDeliveryRuntime = 'ready' | 'not_ready' | 'unknown'
+
+export interface AttendanceSetupReadinessOrgRecipientBinding {
+  boundRecipientCount: number
+  hasAnyBoundRecipient: boolean
+}
+
+export interface AttendanceSetupReadinessNotify {
+  deliveryRuntime: AttendanceSetupReadinessDeliveryRuntime
+  orgRecipientBinding: AttendanceSetupReadinessOrgRecipientBinding
+  recipientScopeConfig: 'unsupported'
+}
+
+/**
+ * §4.5(i): "调度器真的起来了" — the ONLY today-observable half of "scheduler up AND delivery job
+ * registered" (the job-registration half has no public accessor; §4.5(i) explicitly forbids
+ * inventing one for this slice). Deliberately reads `getSharedAttendanceScheduler()` ONLY — NEVER
+ * `ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED` (§9 W4-0-G4's exact point: that env var being
+ * `true` while the scheduler itself is down must still read `not_ready`, not `ready`).
+ * scheduler null => 'not_ready' (actionable: an operator can start it); scheduler non-null =>
+ * 'unknown', fail-closed — never 'ready' today (§4.5(i) "绝不报 ready").
+ */
+export function computeAttendanceSetupReadinessDeliveryRuntime(): AttendanceSetupReadinessDeliveryRuntime {
+  return getSharedAttendanceScheduler() === null ? 'not_ready' : 'unknown'
+}
+
+/**
+ * §4.5(ii): org-scoped bound-recipient coverage. Mirrors the EXACT join
+ * `AttendanceNotificationDeliveryWorker.resolveRecipient` uses to find a usable DingTalk
+ * recipient (directory_account_links ⋈ directory_accounts ⋈ directory_integrations), minus the
+ * per-recipient `local_user_id = $1` filter (this is an org-wide aggregate, not a single lookup).
+ * Returns ONLY a count/boolean — never a userId, external_user_id, or integration id (values-free,
+ * §4.2). No `unknown` state exists for this signal (its type is count/boolean only, unlike
+ * deliveryRuntime); a query failure here is not swallowed — it propagates to the route's
+ * DB_NOT_READY/500 handling so the response is never a fabricated zero.
+ */
+export async function readAttendanceSetupReadinessOrgRecipientBinding(
+  orgId: string,
+  runQuery: AttendanceSetupReadinessQueryFn,
+): Promise<AttendanceSetupReadinessOrgRecipientBinding> {
+  const result = await runQuery<{ bound_recipient_count: number }>(
+    `SELECT COUNT(*)::int AS bound_recipient_count
+       FROM directory_account_links l
+       JOIN directory_accounts a
+         ON a.id = l.directory_account_id
+        AND a.provider = 'dingtalk'
+        AND a.is_active = true
+       JOIN directory_integrations i
+         ON i.id = a.integration_id
+        AND i.provider = 'dingtalk'
+        AND i.status = 'active'
+        AND i.org_id = $1
+      WHERE l.link_status = 'linked'`,
+    [orgId],
+  )
+  const count = Number(result.rows[0]?.bound_recipient_count ?? 0)
+  return { boundRecipientCount: count, hasAnyBoundRecipient: count > 0 }
+}
+
+/** §4.5(iii): today there is no per-org/per-recipient scope-configuration capability at all
+ *  (deployment-wide single default channel — see `AttendanceNotificationDeliveryWorker.ts`'s own
+ *  "Per-org / per-recipient routing is the design-lock §3 follow-up" comment). Always
+ *  `'unsupported'` — never rendered as "not configured yet" (that would name a remediation action
+ *  that does not exist). */
+export const ATTENDANCE_SETUP_READINESS_RECIPIENT_SCOPE_CONFIG = 'unsupported' as const

--- a/packages/core-backend/tests/integration/attendance-setup-readiness-w4-0.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-setup-readiness-w4-0.db.test.ts
@@ -38,9 +38,10 @@
  * `attendance_rotation_rules(org_id, name, is_active?)`; `attendance_approval_flows(id, org_id,
  * name, request_type, steps, is_active)`; `directory_integrations(org_id, provider, name, status,
  * corp_id)`; `directory_accounts(integration_id, provider, external_user_id, external_key, name,
- * is_active)`; `directory_account_links(directory_account_id, link_status, match_strategy)`
- * (local_user_id left NULL — the readiness queries never filter on it, see §4.5(ii));
- * `system_configs(key, value)` for the ONE deployment-wide `attendance.settings` row.
+ * is_active)`; `directory_account_links(directory_account_id, link_status, match_strategy,
+ * local_user_id)` (local_user_id set to a real seeded `users.id` — the readiness query REQUIRES
+ * `local_user_id IS NOT NULL`, mirroring `resolveRecipient`'s own `WHERE l.local_user_id = $1`, see
+ * §4.5(ii)); `system_configs(key, value)` for the ONE deployment-wide `attendance.settings` row.
  */
 import express from 'express'
 import request from 'supertest'
@@ -104,6 +105,19 @@ function makeApp(user: Record<string, unknown> | null) {
   return app
 }
 
+// Fail-closed sentinel (trilens review: a sentinel placed INSIDE `describeIfDatabase` is
+// structurally unable to ever fire when DATABASE_URL is unset — that whole block is
+// `describe.skip`-ed, and a skipped test cannot itself go red). Kept at MODULE scope, a sibling of
+// `describeIfDatabase(...)` below, not nested inside it, so it runs unconditionally: if this whole
+// real-DB lane were ever invoked without DATABASE_URL set (e.g. a workflow-file misconfiguration),
+// THIS is the one assertion that still executes and goes red, rather than the entire G1-G5 file
+// silently reporting zero failures. `plugin-tests.yml`'s attendance step also shell-guards
+// `DATABASE_URL` before ever reaching vitest, and `vitest.config.ts` excludes this file from the
+// no-DB unit lane — this sentinel is defense-in-depth on top of those, not a substitute for them.
+it('sentinel: DATABASE_URL is set (real-DB lane must not silently skip)', () => {
+  expect(dbUrl).toBeTruthy()
+})
+
 describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', () => {
   const pool = new Pool({ connectionString: dbUrl })
   const pinned = usePinnedServer()
@@ -118,8 +132,18 @@ describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', (
       [userId, isActive],
     )
   }
-  async function seedMembership(orgId: string, userId: string, isActive = true): Promise<void> {
-    await seedUser(userId, true)
+  // `userIsActive` is a SEPARATE knob from `isActive` (which is `user_orgs.is_active`) — the ①
+  // count is a DOUBLE filter (`user_orgs.is_active=true` AND `users.is_active=true`, RD-3), and
+  // until this fix every caller passed `seedUser(userId, true)` unconditionally, leaving the
+  // `users.is_active=false` leg of that double filter with zero real-DB behavioural coverage
+  // (P2 — only a source-text regex asserted the SQL mentions `u.is_active = true` at all).
+  async function seedMembership(
+    orgId: string,
+    userId: string,
+    isActive = true,
+    userIsActive = true,
+  ): Promise<void> {
+    await seedUser(userId, userIsActive)
     await pool.query(
       `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, $3)
        ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = EXCLUDED.is_active`,
@@ -181,11 +205,21 @@ describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', (
     )
     return r.rows[0].id
   }
-  async function linkAccount(accountId: string, linkStatus: 'linked' | 'pending' = 'linked'): Promise<void> {
+  // `localUserId` is REQUIRED (not optional) — a NULL `local_user_id` link can never be resolved by
+  // `AttendanceNotificationDeliveryWorker.resolveRecipient` (`WHERE l.local_user_id = $1`), so
+  // `readAttendanceSetupReadinessOrgRecipientBinding` correctly excludes it too (P2 fix — the prior
+  // fixture left this NULL and the query never filtered on it, silently counting an unresolvable
+  // link as a "bound recipient"). Callers pass an id already seeded via `seedMembership`/`seedUser`
+  // so the `users.id` FK is satisfied.
+  async function linkAccount(
+    accountId: string,
+    linkStatus: 'linked' | 'pending' = 'linked',
+    localUserId: string,
+  ): Promise<void> {
     await pool.query(
-      `INSERT INTO directory_account_links (directory_account_id, link_status, match_strategy)
-       VALUES ($1, $2, 'manual')`,
-      [accountId, linkStatus],
+      `INSERT INTO directory_account_links (directory_account_id, link_status, match_strategy, local_user_id)
+       VALUES ($1, $2, 'manual', $3)`,
+      [accountId, linkStatus, localUserId],
     )
   }
 
@@ -244,10 +278,6 @@ describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', (
   beforeEach(() => {
     getSharedAttendanceSchedulerMock.mockReset()
     getSharedAttendanceSchedulerMock.mockReturnValue(null)
-  })
-
-  it('sentinel: DATABASE_URL is set (real-DB lane must not silently skip)', () => {
-    expect(dbUrl).toBeTruthy()
   })
 
   describe('§9 W4-0-G1: org-membership door (two-org forgery + platform-admin bypass)', () => {
@@ -392,21 +422,35 @@ describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', (
     const ADMIN_DT = `${PFX}_g3_admin_dt`
 
     beforeAll(async () => {
-      // Positive control 1: PURE LOCAL org — active member, ZERO directory_account_links rows.
+      // Positive control 1: PURE LOCAL org — active member, ZERO directory_account_links rows, AND
+      // (P2 fix — a bare orgActiveMemberCount>0 check cannot distinguish "① is judged ready" from
+      // "① is judged ready by an implementation that ALSO requires directoryLinked", since the
+      // fixture below never populated ②③⑤ to make previewReady observable) a full ①②③⑤ fixture so
+      // previewReady is independently, behaviourally provable — a mutant that ANDs step① with
+      // `directoryLinked` (which is false here) would flip previewReady to false and this test
+      // would catch it; a bare orgActiveMemberCount assertion alone would not.
       await seedMembership(ORG_LOCAL, ADMIN_LOCAL, true)
+      const localGroup = await seedGroup(ORG_LOCAL, `${PFX} g3 local group`)
+      await seedGroupMember(ORG_LOCAL, localGroup, ADMIN_LOCAL)
+      await seedShift(ORG_LOCAL, `${PFX} g3 local shift`)
+      await seedApprovalFlow(ORG_LOCAL, `${PFX} g3 local flow`, 'leave', true)
 
       // Positive control 2: DingTalk-LINKED org — active member AND a linked dingtalk account.
       await seedMembership(ORG_DINGTALK, ADMIN_DT, true)
       const integration = await seedDingtalkIntegration(ORG_DINGTALK, `${PFX} g3 dt integration`, `${PFX}-g3-corp`)
       const account = await seedDingtalkAccount(integration, `${PFX}-g3-ext`, `${PFX}-g3-key`, `${PFX} g3 account`)
-      await linkAccount(account, 'linked')
+      await linkAccount(account, 'linked', ADMIN_DT)
     }, 30000)
 
     afterAll(async () => {
+      await pool.query(`DELETE FROM attendance_approval_flows WHERE org_id = $1`, [ORG_LOCAL])
+      await pool.query(`DELETE FROM attendance_shifts WHERE org_id = $1`, [ORG_LOCAL])
+      await pool.query(`DELETE FROM attendance_group_members WHERE org_id = $1`, [ORG_LOCAL])
+      await pool.query(`DELETE FROM attendance_groups WHERE org_id = $1`, [ORG_LOCAL])
       await pool.query(`DELETE FROM user_orgs WHERE org_id IN ($1, $2)`, [ORG_LOCAL, ORG_DINGTALK])
     })
 
-    it('pure local org: orgActiveMemberCount>0, directoryLinked=false, step① still ready (via previewReady prerequisites)', async () => {
+    it('pure local org: orgActiveMemberCount>0, directoryLinked=false, AND previewReady=true (directoryLinked never gates ① or ⑦)', async () => {
       const app = makeApp({ id: ADMIN_LOCAL })
       pinned.setApp(app)
       const res = await request(pinned.url()).get(
@@ -415,6 +459,11 @@ describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', (
       expect(res.status).toBe(200)
       expect(res.body.data.orgActiveMemberCount).toBe(1)
       expect(res.body.data.directoryLinked).toBe(false)
+      // Mutation target (P2): an implementation that computed ① (or previewReady) as
+      // `orgActiveMemberCount>0 && directoryLinked` would flip this to false — directoryLinked is
+      // false here by construction, so this is the actual, behavioural "OR semantics" proof the
+      // frozen `orgActiveMemberCount` assertion above could not provide on its own.
+      expect(res.body.data.previewReady).toBe(true)
     })
 
     it('DingTalk-linked org: orgActiveMemberCount>0 AND directoryLinked=true, both correctly reported', async () => {
@@ -444,7 +493,7 @@ describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', (
       // A bound DingTalk recipient, so orgRecipientBinding can be exercised non-trivially.
       const integration = await seedDingtalkIntegration(ORG_NOTIFY, `${PFX} g4 dt integration`, `${PFX}-g4-corp`)
       const account = await seedDingtalkAccount(integration, `${PFX}-g4-ext`, `${PFX}-g4-key`, `${PFX} g4 account`)
-      await linkAccount(account, 'linked')
+      await linkAccount(account, 'linked', ADMIN_NOTIFY)
     }, 30000)
 
     afterAll(async () => {
@@ -598,9 +647,17 @@ describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', (
       const memberA = `${PFX}_audit_member_a`
       const memberB = `${PFX}_audit_member_b`
       const memberInactive = `${PFX}_audit_member_inactive`
+      const memberPlatformDeactivated = `${PFX}_audit_member_platform_deactivated`
       await seedMembership(ORG_AUDIT, memberA, true)
       await seedMembership(ORG_AUDIT, memberB, true)
-      await seedMembership(ORG_AUDIT, memberInactive, false) // proves the is_active filter
+      await seedMembership(ORG_AUDIT, memberInactive, false) // proves the user_orgs.is_active filter
+      // P2 fix: user_orgs.is_active=true but users.is_active=false — e.g. a platform-level
+      // deactivation (PATCH /api/admin/users/:id/status) that deliberately never touches user_orgs.
+      // Before this fixture, the RD-3 double-filter's users.is_active leg had zero real-DB
+      // behavioural coverage (only a source-text regex in the unit test asserted the SQL mentions
+      // it). Mutation target: dropping `AND u.is_active = true` from member_scope would count this
+      // member too, inflating orgActiveMemberCount to 3.
+      await seedMembership(ORG_AUDIT, memberPlatformDeactivated, true, false)
 
       const groupWithMembers = await seedGroup(ORG_AUDIT, `${PFX} audit group with members`)
       await seedGroup(ORG_AUDIT, `${PFX} audit group without members`) // groupCount !== groupsWithMembers
@@ -666,7 +723,7 @@ describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', (
       expect(sql).not.toMatch(/\$2/)
       // Exact counts — this org's rows only, the sibling org's rows never leak in.
       expect(counts).toEqual({
-        orgActiveMemberCount: 2, // memberInactive excluded
+        orgActiveMemberCount: 2, // memberInactive (user_orgs.is_active=false) AND memberPlatformDeactivated (users.is_active=false) both excluded
         groupCount: 3, // 2 fixed_shift + 1 scheduled_shift
         groupsWithMembers: 1,
         shiftCount: 3,

--- a/packages/core-backend/tests/integration/attendance-setup-readiness-w4-0.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-setup-readiness-w4-0.db.test.ts
@@ -86,6 +86,7 @@ const { query: mockedQuery, transaction: mockedTransaction } = await import('../
 const {
   runAttendanceSetupReadinessReadOnly,
   readAttendanceSetupReadinessOrgCounts,
+  ATTENDANCE_SETUP_READINESS_PER_STEP,
 } = await import('../../src/services/AttendanceSetupReadinessAggregate')
 const queryMock = mockedQuery as unknown as ReturnType<typeof vi.fn>
 const transactionMock = mockedTransaction as unknown as ReturnType<typeof vi.fn>
@@ -319,7 +320,6 @@ describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', (
       pinned.setApp(app)
       const res = await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_A)}`)
       expect(res.status).toBe(200)
-      expect(res.body.data.viewerIsPlatformAdmin).toBe(false)
       expect(res.body.data.orgActiveMemberCount).toBe(1)
     })
 
@@ -343,7 +343,6 @@ describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', (
       pinned.setApp(app)
       const res = await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_B)}`)
       expect(res.status).toBe(200)
-      expect(res.body.data.viewerIsPlatformAdmin).toBe(true)
       // The platform-admin shortcut (hasLegacyAdminClaim/isRbacAdmin) returns true BEFORE ever
       // querying user_orgs — this 200 proves the bypass exists, NOT that the org-membership door
       // works (that is case 2's job, and the real-DB two-org matrix's job as a whole).
@@ -633,6 +632,79 @@ describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', (
         minPunchIntervalMinutes: 1,
       })
       expect(await readPosture()).toBe('customized')
+    })
+
+    // P3-1 (#4541 review): before this fix, ④'s catch-all swallowed a real 42P01 (system_configs
+    // missing) but left the SHARED read-only transaction aborted (Postgres SQLSTATE 25P02) — the
+    // sibling ⑥ orgRecipientBinding read, queued on the SAME client via the §4.1 `Promise.all`, then
+    // failed too, turning ONE optional table's absence into a whole-endpoint 503/500 instead of the
+    // intended "④=unknown, everything else normal, 200". This is the regression proof: real
+    // Postgres, a real missing-table error, asserting the endpoint still returns 200 with every
+    // OTHER signal intact.
+    describe('P3-1: ④ probe failure does not abort the shared read-only transaction', () => {
+      const ORG_P31 = `${PFX}_p31_org`
+      const ADMIN_P31 = `${PFX}_p31_admin`
+      // Rename-out rather than DROP+recreate: identical effect on any query issued against the bare
+      // `system_configs` name (a real Postgres 42P01, not a simulation) with zero DDL-fidelity risk
+      // (no re-derivation of columns/indexes/triggers/constraints) and an atomic, instant restore.
+      // `system_configs` is also read by `ConfigService` outside this test file, so an actual
+      // DROP+CREATE against the shared test Postgres (`vitest.integration.config.ts` pins
+      // `fileParallelism: false`, but that only protects against OTHER test FILES racing — a crash
+      // mid-test would still leave a dropped table for every later suite in this run) is
+      // deliberately avoided; a RENAME is instant and the `finally` below always reverses it.
+      const BACKUP_TABLE_NAME = `system_configs_w40_p31_backup_${RUN}`
+
+      beforeAll(async () => {
+        await seedMembership(ORG_P31, ADMIN_P31, true)
+        const g = await seedGroup(ORG_P31, `${PFX} p31 group`)
+        await seedGroupMember(ORG_P31, g, ADMIN_P31)
+        await seedShift(ORG_P31, `${PFX} p31 shift`)
+        await seedApprovalFlow(ORG_P31, `${PFX} p31 flow`, 'leave', true)
+      })
+      afterAll(async () => {
+        await pool.query(`DELETE FROM attendance_approval_flows WHERE org_id = $1`, [ORG_P31])
+        await pool.query(`DELETE FROM attendance_shifts WHERE org_id = $1`, [ORG_P31])
+        await pool.query(`DELETE FROM attendance_group_members WHERE org_id = $1`, [ORG_P31])
+        await pool.query(`DELETE FROM attendance_groups WHERE org_id = $1`, [ORG_P31])
+        await pool.query(`DELETE FROM user_orgs WHERE org_id = $1`, [ORG_P31])
+      })
+
+      it('system_configs missing (real 42P01) ⇒ punchPolicyPosture=unknown, every OTHER signal normal, endpoint 200 (not 503/500)', async () => {
+        await pool.query(`ALTER TABLE system_configs RENAME TO ${BACKUP_TABLE_NAME}`)
+        try {
+          const app = makeApp({ id: ADMIN_P31 })
+          pinned.setApp(app)
+          const res = await request(pinned.url()).get(
+            `/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_P31)}`,
+          )
+          expect(res.status).toBe(200)
+          // Full-body exact shape (not piecemeal existence checks): every OTHER signal is exactly
+          // what the seeded fixture implies, proving the ④ failure was contained to ④ alone — the
+          // sibling ⑥ orgRecipientBinding read (queued on the SAME shared transaction right after
+          // ④'s SAVEPOINT) is unaffected, which is precisely the regression this test guards.
+          expect(res.body.data).toEqual({
+            directoryLinked: false,
+            orgActiveMemberCount: 1,
+            groupCount: 1,
+            groupsWithMembers: 1,
+            shiftCount: 1,
+            scheduledShiftGroupCount: 0,
+            activeRotationRuleCount: 0,
+            hasRotationRules: false,
+            approvalFlowCount: 1,
+            punchPolicyPosture: 'unknown',
+            notify: {
+              deliveryRuntime: 'not_ready',
+              orgRecipientBinding: { boundRecipientCount: 0, hasAnyBoundRecipient: false },
+              recipientScopeConfig: 'unsupported',
+            },
+            previewReady: true, // ①②③⑤ all ready — ④'s unknown correctly does not gate (§3.2)
+            perStep: ATTENDANCE_SETUP_READINESS_PER_STEP,
+          })
+        } finally {
+          await pool.query(`ALTER TABLE ${BACKUP_TABLE_NAME} RENAME TO system_configs`)
+        }
+      })
     })
   })
 

--- a/packages/core-backend/tests/integration/attendance-setup-readiness-w4-0.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-setup-readiness-w4-0.db.test.ts
@@ -1,0 +1,679 @@
+/**
+ * W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED §3/§4/§9): real-Postgres coverage of
+ * `GET /api/attendance-admin/setup-readiness` and its computational core
+ * (`services/AttendanceSetupReadinessAggregate.ts`). The mock-level unit test
+ * (`tests/unit/attendance-admin-setup-readiness-w4-0.test.ts`) already covers query-shape/branch
+ * coverage exhaustively; THIS file proves the things only real Postgres can prove:
+ *   G1 — the org-membership door (two-org forgery + platform-admin single-column-labeled bypass);
+ *   G2 — `SET TRANSACTION READ ONLY` actually REJECTS a write, a writable CTE, and a multi-statement
+ *        batch (a mock cannot prove Postgres's own enforcement — this is the ONLY authorized proof,
+ *        §4.2/§9 W4-0-G2);
+ *   G3 — ①'s two positive controls (pure local org / DingTalk-linked org), both `ready`, proving
+ *        `directoryLinked` is display-only and never gates;
+ *   G4 — ⑥'s three independent notify signals against real directory tables + a real (mocked-
+ *        singleton) scheduler state, and previewReady's independence from every combination;
+ *   G5 — ④'s closed-set posture against a REAL `system_configs` row: positive control (punchPolicy
+ *        change ⇒ customized) and negative control (an UNRELATED key changing ⇒ still default).
+ *
+ * Scope boundary (deliberate — read before "fixing" the auth setup, mirrors the S7-5 precedent):
+ * the router's COARSE permission gate (`rbacGuard('attendance','admin')`) and the platform-admin
+ * shortcut (`isRbacAdmin`) are pre-existing shared middleware exercised elsewhere; this file mocks
+ * BOTH (bypass / per-userId-string) and keeps `../../src/db/pg`'s `query` AND `transaction` REAL
+ * (each wrapped in `vi.fn(actual.fn)` so every call still hits Postgres, while `.mock.calls` gives
+ * spy visibility for the "zero aggregation before 403" and SQL-text-audit proofs). The scheduler
+ * SINGLETON (`getSharedAttendanceScheduler`) is mocked too — deliberately NOT started for real,
+ * because the real `AttendanceScheduler.start()` registers hour-scale interval timers and an
+ * optional Redis leader lock that would outlive this file's test run; G4 is about the readiness
+ * PORT's decision logic (null vs non-null), which a controllable mock proves without that risk.
+ *
+ * Shared-DB fixture discipline: every fixture id is prefixed `w40_<run>_` — never a bare
+ * `Date.now()` alone — because `plugin-tests.yml`'s attendance step runs many `.db.test.ts` files
+ * against ONE shared Postgres; `vitest.integration.config.ts` also pins `fileParallelism: false`
+ * so files never race, but the prefix stands as defense-in-depth.
+ *
+ * Fixture shape reference (per-table, so a future maintainer does not have to re-derive it from
+ * migrations): `users(id, password_hash, is_active)` — minimal row satisfying the ① dual is_active
+ * join; `user_orgs(user_id, org_id, is_active)`; `attendance_groups(org_id, name, attendance_type?)`;
+ * `attendance_group_members(org_id, group_id, user_id)`; `attendance_shifts(org_id, name)`;
+ * `attendance_rotation_rules(org_id, name, is_active?)`; `attendance_approval_flows(id, org_id,
+ * name, request_type, steps, is_active)`; `directory_integrations(org_id, provider, name, status,
+ * corp_id)`; `directory_accounts(integration_id, provider, external_user_id, external_key, name,
+ * is_active)`; `directory_account_links(directory_account_id, link_status, match_strategy)`
+ * (local_user_id left NULL — the readiness queries never filter on it, see §4.5(ii));
+ * `system_configs(key, value)` for the ONE deployment-wide `attendance.settings` row.
+ */
+import express from 'express'
+import request from 'supertest'
+import { randomUUID } from 'crypto'
+import { Pool } from 'pg'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePinnedServer } from '../utils/pinned-server'
+
+const getSharedAttendanceSchedulerMock = vi.fn()
+vi.mock('../../src/services/AttendanceScheduler', () => ({
+  getSharedAttendanceScheduler: () => getSharedAttendanceSchedulerMock(),
+}))
+
+vi.mock('../../src/rbac/rbac', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/rbac')>()
+  return {
+    ...actual,
+    rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  }
+})
+vi.mock('../../src/rbac/service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/service')>()
+  return { ...actual, isAdmin: vi.fn(async (userId: string) => userId.endsWith('_platform_admin')) }
+})
+
+// Real Postgres, spy-WRAPPED (not replaced): `vi.fn(actual.fn)` still calls through to the real
+// `poolManager` implementation, so every assertion below is against real Postgres — the wrapper
+// only gives `.mock.calls` visibility for the "zero aggregation before 403" proof (§9 W4-0-G1) and
+// the org-anchor SQL-text audit (§4.2). `vi.mock` + `importOriginal` is required (not
+// `vi.spyOn(pgModule, 'query')`) because Vitest's ESM interop makes named exports non-configurable
+// for direct property-level spying.
+vi.mock('../../src/db/pg', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/db/pg')>()
+  return { ...actual, query: vi.fn(actual.query), transaction: vi.fn(actual.transaction) }
+})
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+const { attendanceAdminRouter } = await import('../../src/routes/attendance-admin')
+const { query: mockedQuery, transaction: mockedTransaction } = await import('../../src/db/pg')
+const {
+  runAttendanceSetupReadinessReadOnly,
+  readAttendanceSetupReadinessOrgCounts,
+} = await import('../../src/services/AttendanceSetupReadinessAggregate')
+const queryMock = mockedQuery as unknown as ReturnType<typeof vi.fn>
+const transactionMock = mockedTransaction as unknown as ReturnType<typeof vi.fn>
+
+const RUN = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
+const PFX = `w40_${RUN}`
+const SETTINGS_KEY = 'attendance.settings'
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    ;(req as express.Request & { user?: unknown }).user = user ?? undefined
+    next()
+  })
+  app.use(attendanceAdminRouter())
+  return app
+}
+
+describeIfDatabase('W4-0 GET /api/attendance-admin/setup-readiness (real DB)', () => {
+  const pool = new Pool({ connectionString: dbUrl })
+  const pinned = usePinnedServer()
+
+  const integrationIds: string[] = []
+  let originalSettingsRow: { value: string } | null | undefined
+
+  async function seedUser(userId: string, isActive = true): Promise<void> {
+    await pool.query(
+      `INSERT INTO users (id, password_hash, is_active) VALUES ($1, 'x', $2)
+       ON CONFLICT (id) DO UPDATE SET is_active = EXCLUDED.is_active`,
+      [userId, isActive],
+    )
+  }
+  async function seedMembership(orgId: string, userId: string, isActive = true): Promise<void> {
+    await seedUser(userId, true)
+    await pool.query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, $3)
+       ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = EXCLUDED.is_active`,
+      [userId, orgId, isActive],
+    )
+  }
+  async function seedGroup(orgId: string, name: string, attendanceType = 'fixed_shift'): Promise<string> {
+    const r = await pool.query<{ id: string }>(
+      `INSERT INTO attendance_groups (org_id, name, attendance_type) VALUES ($1, $2, $3) RETURNING id`,
+      [orgId, name, attendanceType],
+    )
+    return r.rows[0].id
+  }
+  async function seedGroupMember(orgId: string, groupId: string, userId: string): Promise<void> {
+    await seedUser(userId, true)
+    await pool.query(`INSERT INTO attendance_group_members (org_id, group_id, user_id) VALUES ($1, $2, $3)`, [
+      orgId,
+      groupId,
+      userId,
+    ])
+  }
+  async function seedShift(orgId: string, name: string): Promise<string> {
+    const r = await pool.query<{ id: string }>(`INSERT INTO attendance_shifts (org_id, name) VALUES ($1, $2) RETURNING id`, [
+      orgId,
+      name,
+    ])
+    return r.rows[0].id
+  }
+  async function seedRotationRule(orgId: string, name: string, isActive = true): Promise<string> {
+    const r = await pool.query<{ id: string }>(
+      `INSERT INTO attendance_rotation_rules (org_id, name, is_active) VALUES ($1, $2, $3) RETURNING id`,
+      [orgId, name, isActive],
+    )
+    return r.rows[0].id
+  }
+  async function seedApprovalFlow(orgId: string, name: string, requestType: string, isActive: boolean): Promise<string> {
+    const id = randomUUID()
+    await pool.query(
+      `INSERT INTO attendance_approval_flows (id, org_id, name, request_type, steps, is_active)
+       VALUES ($1, $2, $3, $4, '[]'::jsonb, $5)`,
+      [id, orgId, name, requestType, isActive],
+    )
+    return id
+  }
+  async function seedDingtalkIntegration(orgId: string, name: string, corpId: string, status = 'active'): Promise<string> {
+    const r = await pool.query<{ id: string }>(
+      `INSERT INTO directory_integrations (org_id, provider, name, status, corp_id)
+       VALUES ($1, 'dingtalk', $2, $3, $4) RETURNING id`,
+      [orgId, name, status, corpId],
+    )
+    integrationIds.push(r.rows[0].id)
+    return r.rows[0].id
+  }
+  async function seedDingtalkAccount(integrationId: string, externalUserId: string, externalKey: string, name: string): Promise<string> {
+    const r = await pool.query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, is_active)
+       VALUES ($1, 'dingtalk', $2, $3, $4, true) RETURNING id`,
+      [integrationId, externalUserId, externalKey, name],
+    )
+    return r.rows[0].id
+  }
+  async function linkAccount(accountId: string, linkStatus: 'linked' | 'pending' = 'linked'): Promise<void> {
+    await pool.query(
+      `INSERT INTO directory_account_links (directory_account_id, link_status, match_strategy)
+       VALUES ($1, $2, 'manual')`,
+      [accountId, linkStatus],
+    )
+  }
+
+  async function snapshotSettings(): Promise<void> {
+    const r = await pool.query<{ value: string }>(`SELECT value FROM system_configs WHERE key = $1`, [SETTINGS_KEY])
+    originalSettingsRow = r.rows[0] ? { value: r.rows[0].value } : null
+  }
+  async function restoreSettings(): Promise<void> {
+    if (originalSettingsRow === undefined) return
+    if (originalSettingsRow === null) {
+      await pool.query(`DELETE FROM system_configs WHERE key = $1`, [SETTINGS_KEY])
+    } else {
+      await pool.query(
+        `INSERT INTO system_configs (key, value) VALUES ($1, $2)
+         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+        [SETTINGS_KEY, originalSettingsRow.value],
+      )
+    }
+  }
+  async function writeSettingsRow(value: Record<string, unknown>): Promise<void> {
+    await pool.query(
+      `INSERT INTO system_configs (key, value) VALUES ($1, $2)
+       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+      [SETTINGS_KEY, JSON.stringify(value)],
+    )
+  }
+  async function deleteSettingsRow(): Promise<void> {
+    await pool.query(`DELETE FROM system_configs WHERE key = $1`, [SETTINGS_KEY])
+  }
+
+  const NORMALIZED_DEFAULT_PUNCH_POLICY = {
+    unscheduled: { mode: 'allow' },
+    merge: { internalWinsOnIn: false, externalWinsOnOut: false },
+    outdoor: { requireApproval: false, requireNote: false, requirePhoto: false, approvalFlowId: '' },
+  }
+
+  beforeAll(async () => {
+    await snapshotSettings()
+  }, 30000)
+
+  afterAll(async () => {
+    await restoreSettings()
+    for (const id of integrationIds) {
+      await pool.query(`DELETE FROM directory_integrations WHERE id = $1`, [id]) // cascades accounts/links
+    }
+    await pool.query(`DELETE FROM attendance_approval_flows WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_rotation_rules WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_shifts WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_group_members WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_groups WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM user_orgs WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM users WHERE id LIKE $1`, [`${PFX}%`])
+    await pool.end()
+  })
+
+  beforeEach(() => {
+    getSharedAttendanceSchedulerMock.mockReset()
+    getSharedAttendanceSchedulerMock.mockReturnValue(null)
+  })
+
+  it('sentinel: DATABASE_URL is set (real-DB lane must not silently skip)', () => {
+    expect(dbUrl).toBeTruthy()
+  })
+
+  describe('§9 W4-0-G1: org-membership door (two-org forgery + platform-admin bypass)', () => {
+    const ORG_A = `${PFX}_g1_org_a`
+    const ORG_B = `${PFX}_g1_org_b`
+    const ADMIN_ID = `${PFX}_g1_admin`
+
+    beforeAll(async () => {
+      // "该受托管理员" — writ per the lock's exact test identity: attendance:admin only (rbacGuard
+      // is bypassed here, mirroring only the coarse gate — see file header), active member of A,
+      // NOT a member of B, and — critically — NOT a platform admin (the mocked `isAdmin` only
+      // returns true for ids ending `_platform_admin`, so this id is fail-closed false).
+      await seedMembership(ORG_A, ADMIN_ID, true)
+      // A minimal but non-empty org A so the 200 path exercises real aggregation, not just auth.
+      const g = await seedGroup(ORG_A, `${PFX} g1 group`)
+      await seedGroupMember(ORG_A, g, ADMIN_ID)
+      await seedShift(ORG_A, `${PFX} g1 shift`)
+      await seedApprovalFlow(ORG_A, `${PFX} g1 flow`, 'leave', true)
+      // Org B exists (someone else's org) — the admin above is deliberately NOT a member.
+      const ownerB = `${PFX}_g1_org_b_owner`
+      await seedMembership(ORG_B, ownerB, true)
+    }, 30000)
+
+    afterAll(async () => {
+      await pool.query(`DELETE FROM attendance_approval_flows WHERE org_id = $1`, [ORG_A])
+      await pool.query(`DELETE FROM attendance_shifts WHERE org_id = $1`, [ORG_A])
+      await pool.query(`DELETE FROM attendance_group_members WHERE org_id = $1`, [ORG_A])
+      await pool.query(`DELETE FROM attendance_groups WHERE org_id = $1`, [ORG_A])
+      await pool.query(`DELETE FROM user_orgs WHERE org_id IN ($1, $2)`, [ORG_A, ORG_B])
+    })
+
+    beforeEach(() => {
+      queryMock.mockClear()
+      transactionMock.mockClear()
+    })
+
+    it('case 1: delegated admin, orgId=A (own org) ⇒ 200', async () => {
+      const app = makeApp({ id: ADMIN_ID })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_A)}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.viewerIsPlatformAdmin).toBe(false)
+      expect(res.body.data.orgActiveMemberCount).toBe(1)
+    })
+
+    it('case 2: delegated admin forges orgId=B ⇒ 403 BEFORE any aggregation SQL (transaction never opened)', async () => {
+      const app = makeApp({ id: ADMIN_ID })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_B)}`)
+      expect(res.status).toBe(403)
+      expect(res.body?.error?.code).toBe('FORBIDDEN')
+      // Mutation target: reordering aggregation before authz would make this fail.
+      expect(transactionMock).not.toHaveBeenCalled()
+      // Exactly the one user_orgs membership-door query — no aggregation query at all.
+      expect(queryMock).toHaveBeenCalledTimes(1)
+      const [sql] = queryMock.mock.calls[0] as [string]
+      expect(sql).toMatch(/user_orgs/)
+    })
+
+    it('case 3 (single-column-labeled bypass — does NOT substitute for case 2): platform admin, orgId=B ⇒ 200, zero user_orgs query', async () => {
+      const platformAdminId = `${PFX}_g1_platform_admin`
+      const app = makeApp({ id: platformAdminId })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_B)}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.viewerIsPlatformAdmin).toBe(true)
+      // The platform-admin shortcut (hasLegacyAdminClaim/isRbacAdmin) returns true BEFORE ever
+      // querying user_orgs — this 200 proves the bypass exists, NOT that the org-membership door
+      // works (that is case 2's job, and the real-DB two-org matrix's job as a whole).
+      expect(queryMock).not.toHaveBeenCalled()
+      expect(transactionMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('§9 W4-0-G2: read-only transaction — the ONLY authorized proof (real Postgres rejection)', () => {
+    const ORG_RO = `${PFX}_g2_org`
+
+    beforeAll(async () => {
+      await seedShift(ORG_RO, `${PFX} g2 shift`)
+    })
+    afterAll(async () => {
+      await pool.query(`DELETE FROM attendance_shifts WHERE org_id = $1`, [ORG_RO])
+    })
+
+    it('positive control: a legal SELECT succeeds inside the seam', async () => {
+      const result = await runAttendanceSetupReadinessReadOnly(async (q) => {
+        const r = await q<{ n: number }>('SELECT COUNT(*)::int AS n FROM attendance_shifts WHERE org_id = $1', [ORG_RO])
+        return r.rows[0]?.n
+      })
+      expect(result).toBe(1)
+    })
+
+    it('rejects a bare UPDATE (first-word check would have PASSED this if it looked like SELECT — it does not even look like one, proving the guard is not text-based)', async () => {
+      await expect(
+        runAttendanceSetupReadinessReadOnly(async (q) => {
+          await q(`UPDATE attendance_shifts SET name = name WHERE org_id = $1`, [ORG_RO])
+        }),
+      ).rejects.toThrow(/read-only transaction/i)
+    })
+
+    it('rejects a writable CTE — proves the guard is NOT a first-word/regex check (a WITH-prefix text check would PASS this)', async () => {
+      await expect(
+        runAttendanceSetupReadinessReadOnly(async (q) => {
+          await q(
+            `WITH d AS (DELETE FROM attendance_shifts WHERE org_id = $1 AND false RETURNING 1)
+             SELECT COUNT(*)::int AS n FROM d`,
+            [ORG_RO],
+          )
+        }),
+      ).rejects.toThrow(/read-only transaction/i)
+    })
+
+    it('rejects a multi-statement batch (SELECT 1; DELETE ...) — a SELECT-prefix text check would PASS this', async () => {
+      await expect(
+        runAttendanceSetupReadinessReadOnly(async (q) => {
+          // No params ⇒ node-pg's simple-query protocol, which executes every ;-separated
+          // statement in the batch — the exact shape the design lock names as un-catchable by a
+          // prefix/regex check.
+          await q(`SELECT 1; DELETE FROM attendance_shifts WHERE org_id = 'nonexistent-org-guard'`)
+        }),
+      ).rejects.toThrow(/read-only transaction/i)
+    })
+
+    it('a rejected write leaves no trace — the shift count is unchanged after all three reject attempts', async () => {
+      const result = await runAttendanceSetupReadinessReadOnly(async (q) => {
+        const r = await q<{ n: number }>('SELECT COUNT(*)::int AS n FROM attendance_shifts WHERE org_id = $1', [ORG_RO])
+        return r.rows[0]?.n
+      })
+      expect(result).toBe(1)
+    })
+
+    it('the production org-counts CTE itself runs cleanly through the seam (positive control, not just synthetic SQL)', async () => {
+      const counts = await runAttendanceSetupReadinessReadOnly((q) => readAttendanceSetupReadinessOrgCounts(ORG_RO, q))
+      expect(counts.shiftCount).toBe(1)
+    })
+  })
+
+  describe('§9 W4-0-G3: ① two positive controls (P2-3, directoryLinked never gates)', () => {
+    const ORG_LOCAL = `${PFX}_g3_local`
+    const ORG_DINGTALK = `${PFX}_g3_dingtalk`
+    const ADMIN_LOCAL = `${PFX}_g3_admin_local`
+    const ADMIN_DT = `${PFX}_g3_admin_dt`
+
+    beforeAll(async () => {
+      // Positive control 1: PURE LOCAL org — active member, ZERO directory_account_links rows.
+      await seedMembership(ORG_LOCAL, ADMIN_LOCAL, true)
+
+      // Positive control 2: DingTalk-LINKED org — active member AND a linked dingtalk account.
+      await seedMembership(ORG_DINGTALK, ADMIN_DT, true)
+      const integration = await seedDingtalkIntegration(ORG_DINGTALK, `${PFX} g3 dt integration`, `${PFX}-g3-corp`)
+      const account = await seedDingtalkAccount(integration, `${PFX}-g3-ext`, `${PFX}-g3-key`, `${PFX} g3 account`)
+      await linkAccount(account, 'linked')
+    }, 30000)
+
+    afterAll(async () => {
+      await pool.query(`DELETE FROM user_orgs WHERE org_id IN ($1, $2)`, [ORG_LOCAL, ORG_DINGTALK])
+    })
+
+    it('pure local org: orgActiveMemberCount>0, directoryLinked=false, step① still ready (via previewReady prerequisites)', async () => {
+      const app = makeApp({ id: ADMIN_LOCAL })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_LOCAL)}`,
+      )
+      expect(res.status).toBe(200)
+      expect(res.body.data.orgActiveMemberCount).toBe(1)
+      expect(res.body.data.directoryLinked).toBe(false)
+    })
+
+    it('DingTalk-linked org: orgActiveMemberCount>0 AND directoryLinked=true, both correctly reported', async () => {
+      const app = makeApp({ id: ADMIN_DT })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_DINGTALK)}`,
+      )
+      expect(res.status).toBe(200)
+      expect(res.body.data.orgActiveMemberCount).toBe(1)
+      expect(res.body.data.directoryLinked).toBe(true)
+    })
+  })
+
+  describe('§9 W4-0-G4: ⑥ three independent notify signals + previewReady independence (real DB)', () => {
+    const ORG_NOTIFY = `${PFX}_g4_org`
+    const ADMIN_NOTIFY = `${PFX}_g4_admin`
+
+    beforeAll(async () => {
+      await seedMembership(ORG_NOTIFY, ADMIN_NOTIFY, true)
+      // Fully "previewReady-able" org, so the notify combinations below can prove previewReady is
+      // UNAFFECTED by them (not just vacuously false already).
+      const g = await seedGroup(ORG_NOTIFY, `${PFX} g4 group`)
+      await seedGroupMember(ORG_NOTIFY, g, ADMIN_NOTIFY)
+      await seedShift(ORG_NOTIFY, `${PFX} g4 shift`)
+      await seedApprovalFlow(ORG_NOTIFY, `${PFX} g4 flow`, 'leave', true)
+      // A bound DingTalk recipient, so orgRecipientBinding can be exercised non-trivially.
+      const integration = await seedDingtalkIntegration(ORG_NOTIFY, `${PFX} g4 dt integration`, `${PFX}-g4-corp`)
+      const account = await seedDingtalkAccount(integration, `${PFX}-g4-ext`, `${PFX}-g4-key`, `${PFX} g4 account`)
+      await linkAccount(account, 'linked')
+    }, 30000)
+
+    afterAll(async () => {
+      await pool.query(`DELETE FROM attendance_approval_flows WHERE org_id = $1`, [ORG_NOTIFY])
+      await pool.query(`DELETE FROM attendance_shifts WHERE org_id = $1`, [ORG_NOTIFY])
+      await pool.query(`DELETE FROM attendance_group_members WHERE org_id = $1`, [ORG_NOTIFY])
+      await pool.query(`DELETE FROM attendance_groups WHERE org_id = $1`, [ORG_NOTIFY])
+      await pool.query(`DELETE FROM user_orgs WHERE org_id = $1`, [ORG_NOTIFY])
+    })
+
+    it('scheduler NOT started (null) ⇒ deliveryRuntime=not_ready, EVEN WITH the worker-enabled env var set true', async () => {
+      const original = process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED
+      process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED = 'true'
+      getSharedAttendanceSchedulerMock.mockReturnValue(null)
+      try {
+        const app = makeApp({ id: ADMIN_NOTIFY })
+        pinned.setApp(app)
+        const res = await request(pinned.url()).get(
+          `/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_NOTIFY)}`,
+        )
+        expect(res.status).toBe(200)
+        // Mutation target: reading the env var instead of the scheduler singleton would flip this.
+        expect(res.body.data.notify.deliveryRuntime).toBe('not_ready')
+        expect(res.body.data.previewReady).toBe(true)
+      } finally {
+        if (original === undefined) delete process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED
+        else process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED = original
+      }
+    })
+
+    it('scheduler STARTED (non-null) ⇒ deliveryRuntime=unknown (never ready), previewReady still unaffected', async () => {
+      getSharedAttendanceSchedulerMock.mockReturnValue({ started: true })
+      const app = makeApp({ id: ADMIN_NOTIFY })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_NOTIFY)}`,
+      )
+      expect(res.status).toBe(200)
+      expect(res.body.data.notify.deliveryRuntime).toBe('unknown')
+      expect(res.body.data.previewReady).toBe(true)
+    })
+
+    it('orgRecipientBinding reflects the real seeded DingTalk link (boundRecipientCount>=1)', async () => {
+      const app = makeApp({ id: ADMIN_NOTIFY })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_NOTIFY)}`,
+      )
+      expect(res.body.data.notify.orgRecipientBinding.boundRecipientCount).toBeGreaterThanOrEqual(1)
+      expect(res.body.data.notify.orgRecipientBinding.hasAnyBoundRecipient).toBe(true)
+    })
+
+    it('recipientScopeConfig is always unsupported, and previewReady is unaffected by ANY of the above', async () => {
+      const app = makeApp({ id: ADMIN_NOTIFY })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_NOTIFY)}`,
+      )
+      expect(res.body.data.notify.recipientScopeConfig).toBe('unsupported')
+      expect(res.body.data.previewReady).toBe(true)
+    })
+  })
+
+  describe('§9 W4-0-G5: ④ closed-set posture against a REAL system_configs row', () => {
+    const ORG_G5 = `${PFX}_g5_org`
+    const ADMIN_G5 = `${PFX}_g5_admin`
+
+    beforeAll(async () => {
+      await seedMembership(ORG_G5, ADMIN_G5, true)
+    })
+    afterAll(async () => {
+      await pool.query(`DELETE FROM user_orgs WHERE org_id = $1`, [ORG_G5])
+    })
+
+    async function readPosture(): Promise<string> {
+      const app = makeApp({ id: ADMIN_G5 })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance-admin/setup-readiness?orgId=${encodeURIComponent(ORG_G5)}`)
+      expect(res.status).toBe(200)
+      return res.body.data.punchPolicyPosture
+    }
+
+    it('no system_configs row at all ⇒ default', async () => {
+      await deleteSettingsRow()
+      expect(await readPosture()).toBe('default')
+    })
+
+    it('row equals normalized defaults exactly ⇒ default', async () => {
+      await writeSettingsRow({
+        punchPolicy: NORMALIZED_DEFAULT_PUNCH_POLICY,
+        ipAllowlist: [],
+        geoFence: null,
+        minPunchIntervalMinutes: 1,
+      })
+      expect(await readPosture()).toBe('default')
+    })
+
+    it('negative control: ONLY holidaySync.lastRun differs (simulated machine write) ⇒ STILL default', async () => {
+      await writeSettingsRow({
+        punchPolicy: NORMALIZED_DEFAULT_PUNCH_POLICY,
+        ipAllowlist: [],
+        geoFence: null,
+        minPunchIntervalMinutes: 1,
+        holidaySync: { lastRun: new Date().toISOString() },
+      })
+      // Mutation target: an implementation that compares the WHOLE settings blob (not just the
+      // §3.1 closed set) would misreport this as customized.
+      expect(await readPosture()).toBe('default')
+    })
+
+    it('negative control: ONLY annualLeavePolicy differs ⇒ STILL default', async () => {
+      await writeSettingsRow({
+        punchPolicy: NORMALIZED_DEFAULT_PUNCH_POLICY,
+        ipAllowlist: [],
+        geoFence: null,
+        minPunchIntervalMinutes: 1,
+        annualLeavePolicy: { enabled: true, accrualDays: 5 },
+      })
+      expect(await readPosture()).toBe('default')
+    })
+
+    it('positive control: punchPolicy.unscheduled.mode differs ⇒ customized', async () => {
+      await writeSettingsRow({
+        punchPolicy: { ...NORMALIZED_DEFAULT_PUNCH_POLICY, unscheduled: { mode: 'block' } },
+        ipAllowlist: [],
+        geoFence: null,
+        minPunchIntervalMinutes: 1,
+      })
+      expect(await readPosture()).toBe('customized')
+    })
+
+    it('positive control: ipAllowlist differs ⇒ customized', async () => {
+      await writeSettingsRow({
+        punchPolicy: NORMALIZED_DEFAULT_PUNCH_POLICY,
+        ipAllowlist: ['10.0.0.0/8'],
+        geoFence: null,
+        minPunchIntervalMinutes: 1,
+      })
+      expect(await readPosture()).toBe('customized')
+    })
+  })
+
+  describe('org-anchor SQL audit against REAL Postgres, with exact seeded counts (§4.2 追加门禁2)', () => {
+    const ORG_AUDIT = `${PFX}_audit_org`
+    const afterAllExtraOrgIds: string[] = []
+
+    beforeAll(async () => {
+      // "Rich" fixture — non-zero, DISTINCT values on every leg so a leg that silently counted
+      // across all orgs (dropping its own org_id filter) would visibly diverge from a leg that
+      // didn't, rather than every count coincidentally matching by chance.
+      const memberA = `${PFX}_audit_member_a`
+      const memberB = `${PFX}_audit_member_b`
+      const memberInactive = `${PFX}_audit_member_inactive`
+      await seedMembership(ORG_AUDIT, memberA, true)
+      await seedMembership(ORG_AUDIT, memberB, true)
+      await seedMembership(ORG_AUDIT, memberInactive, false) // proves the is_active filter
+
+      const groupWithMembers = await seedGroup(ORG_AUDIT, `${PFX} audit group with members`)
+      await seedGroup(ORG_AUDIT, `${PFX} audit group without members`) // groupCount !== groupsWithMembers
+      await seedGroupMember(ORG_AUDIT, groupWithMembers, memberA)
+      await seedGroupMember(ORG_AUDIT, groupWithMembers, memberB)
+
+      await seedShift(ORG_AUDIT, `${PFX} audit shift AM`)
+      await seedShift(ORG_AUDIT, `${PFX} audit shift PM`)
+      await seedShift(ORG_AUDIT, `${PFX} audit shift NIGHT`)
+
+      await seedGroup(ORG_AUDIT, `${PFX} audit scheduled group`, 'scheduled_shift')
+      await seedRotationRule(ORG_AUDIT, `${PFX} audit rotation active`, true)
+      await seedRotationRule(ORG_AUDIT, `${PFX} audit rotation inactive`, false) // proves is_active filter
+
+      await seedApprovalFlow(ORG_AUDIT, `${PFX} audit flow active`, 'leave', true)
+      await seedApprovalFlow(ORG_AUDIT, `${PFX} audit flow inactive`, 'overtime', false) // proves is_active filter
+
+      // A sibling org with DIFFERENT counts on every dimension — if any leg's org_id filter were
+      // dropped, its count would leak this org's rows in and diverge from the assertion below.
+      const otherOrg = `${PFX}_audit_other_org`
+      const otherOwner = `${PFX}_audit_other_owner`
+      await seedMembership(otherOrg, otherOwner, true)
+      const otherGroup = await seedGroup(otherOrg, `${PFX} audit other group`)
+      await seedGroupMember(otherOrg, otherGroup, otherOwner)
+      await seedShift(otherOrg, `${PFX} audit other shift`)
+      await seedShift(otherOrg, `${PFX} audit other shift 2`)
+      await seedRotationRule(otherOrg, `${PFX} audit other rotation`, true)
+      await seedApprovalFlow(otherOrg, `${PFX} audit other flow`, 'leave', true)
+      afterAllExtraOrgIds.push(otherOrg)
+    }, 30000)
+
+    afterAll(async () => {
+      for (const orgId of afterAllExtraOrgIds) {
+        await pool.query(`DELETE FROM attendance_approval_flows WHERE org_id = $1`, [orgId])
+        await pool.query(`DELETE FROM attendance_rotation_rules WHERE org_id = $1`, [orgId])
+        await pool.query(`DELETE FROM attendance_shifts WHERE org_id = $1`, [orgId])
+        await pool.query(`DELETE FROM attendance_group_members WHERE org_id = $1`, [orgId])
+        await pool.query(`DELETE FROM attendance_groups WHERE org_id = $1`, [orgId])
+        await pool.query(`DELETE FROM user_orgs WHERE org_id = $1`, [orgId])
+      }
+      await pool.query(`DELETE FROM attendance_approval_flows WHERE org_id = $1`, [ORG_AUDIT])
+      await pool.query(`DELETE FROM attendance_rotation_rules WHERE org_id = $1`, [ORG_AUDIT])
+      await pool.query(`DELETE FROM attendance_shifts WHERE org_id = $1`, [ORG_AUDIT])
+      await pool.query(`DELETE FROM attendance_group_members WHERE org_id = $1`, [ORG_AUDIT])
+      await pool.query(`DELETE FROM attendance_groups WHERE org_id = $1`, [ORG_AUDIT])
+      await pool.query(`DELETE FROM user_orgs WHERE org_id = $1`, [ORG_AUDIT])
+    })
+
+    it('org_id = $1 appears exactly 7 times, one positional param, against REAL Postgres — with exact counts proving no cross-org leak', async () => {
+      const spy = vi.fn<Parameters<typeof mockedQuery>, ReturnType<typeof mockedQuery>>()
+      const counts = await runAttendanceSetupReadinessReadOnly(async (q) => {
+        const wrapped: typeof q = ((sql: string, params?: unknown[]) => {
+          spy(sql, params as never)
+          return q(sql, params)
+        }) as typeof q
+        return readAttendanceSetupReadinessOrgCounts(ORG_AUDIT, wrapped)
+      })
+      expect(spy).toHaveBeenCalledTimes(1)
+      const [sql, params] = spy.mock.calls[0]
+      const orgIdMatches = (sql as string).match(/org_id\s*=\s*\$1/g) ?? []
+      expect(orgIdMatches).toHaveLength(7)
+      expect(params).toEqual([ORG_AUDIT])
+      expect(sql).not.toMatch(/\$2/)
+      // Exact counts — this org's rows only, the sibling org's rows never leak in.
+      expect(counts).toEqual({
+        orgActiveMemberCount: 2, // memberInactive excluded
+        groupCount: 3, // 2 fixed_shift + 1 scheduled_shift
+        groupsWithMembers: 1,
+        shiftCount: 3,
+        scheduledShiftGroupCount: 1,
+        activeRotationRuleCount: 1, // the inactive rotation rule excluded
+        approvalFlowCount: 1, // the inactive flow excluded
+      })
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-admin-setup-readiness-w4-0.test.ts
+++ b/packages/core-backend/tests/unit/attendance-admin-setup-readiness-w4-0.test.ts
@@ -396,6 +396,19 @@ describe('§9 W4-0-G5: closed-set reconciliation against the LIVE plugin source 
   })
 })
 
+// §4.5 names three contract-test requirements: (1) zero env-value/credential leakage — covered by
+// the route test's `JSON.stringify(data)).not.toMatch(/ATTENDANCE_[A-Z_]/)` assertion below; (2)
+// "缺 port 时聚合端点仍 200 且 notify={deliveryRuntime:'unknown',…}" (missing port ⇒ still 200,
+// fail-closed to unknown); (3) "不得由 deliveries 表推断" — covered by the SQL-shape assertions
+// below (the query never touches `attendance_notification_deliveries`) and the real-DB G4 describe.
+// Requirement (2) is explicitly N/A-BY-CONSTRUCTION for this slice, not silently skipped: this
+// module has exactly one production import path for the scheduler port
+// (`import { getSharedAttendanceScheduler } from './AttendanceScheduler'` at the top of
+// `AttendanceSetupReadinessAggregate.ts`) with no conditional/optional wiring — there is no runtime
+// state in which that import resolves but the function is "missing", so a test simulating a missing
+// port would have nothing to exercise beyond re-asserting the null-check branch already covered by
+// "deliveryRuntime = not_ready when the scheduler is not started (null)" below. If a future slice
+// ever makes the port pluggable/optional, this comment is the marker to add the real test then.
 describe('§4.5 notify readiness (⑥ three independent signals, §9 W4-0-G4)', () => {
   beforeEach(() => {
     queryMock.mockReset()
@@ -426,16 +439,23 @@ describe('§4.5 notify readiness (⑥ three independent signals, §9 W4-0-G4)', 
     }
   })
 
-  it('orgRecipientBinding: org-scoped EXISTS-style join, boundRecipientCount/hasAnyBoundRecipient only', async () => {
+  it('orgRecipientBinding: org-scoped join covering BOTH wired channels (dingtalk+wecom, §4.5(ii) "企微同型"), boundRecipientCount/hasAnyBoundRecipient only', async () => {
     queryMock.mockResolvedValueOnce({ rows: [{ bound_recipient_count: 2 }] })
     const result = await readAttendanceSetupReadinessOrgRecipientBinding('org-a', queryMock as never)
     expect(result).toEqual({ boundRecipientCount: 2, hasAnyBoundRecipient: true })
     const [sql, params] = queryMock.mock.calls[0] as [string, unknown[]]
     expect(sql).toMatch(/i\.org_id\s*=\s*\$1/)
-    expect(sql).toMatch(/provider\s*=\s*'dingtalk'/)
+    // Mutation target: pinning either leg back to a single literal 'dingtalk' (dropping wecom
+    // coverage, or letting a.provider/i.provider mismatch) reds this.
+    expect(sql).toMatch(/provider\s+IN\s*\(\s*'dingtalk'\s*,\s*'wecom'\s*\)/)
+    expect(sql).toMatch(/i\.provider\s*=\s*a\.provider/)
     expect(sql).toMatch(/link_status\s*=\s*'linked'/)
+    // Mutation target: dropping either guard lets a NULL-local_user_id link or a duplicate binding
+    // for the same local user inflate the count.
+    expect(sql).toMatch(/local_user_id\s+IS\s+NOT\s+NULL/)
+    expect(sql).toMatch(/COUNT\(\s*DISTINCT\s+l\.local_user_id\s*\)/)
     expect(params).toEqual(['org-a'])
-    expect(sql).not.toMatch(/external_user_id|local_user_id\s*,|name|email/i)
+    expect(sql).not.toMatch(/external_user_id|name|email/i)
   })
 
   it('orgRecipientBinding: zero rows ⇒ hasAnyBoundRecipient=false', async () => {
@@ -491,7 +511,15 @@ describe('§9 W4-0-G2 negative meta-assertion: no first-word/regex read-only che
   it('the route file contains no prefix/regex "is this SQL a SELECT" guard either (code only)', () => {
     const routePath = path.resolve(__dirname, '../../src/routes/attendance-admin.ts')
     const code = stripCommentsAndStrings(readFileSync(routePath, 'utf8'))
-    expect(code).not.toMatch(/\.startsWith\(\s*``\s*\)/) // any startsWith(<stripped-literal>) call
+    // As strong as the aggregate-module leg above (not just the stripped-template-literal-arg
+    // shape): a re-introduced `sql.trim().toUpperCase().startsWith('SELECT')`-style guard using a
+    // quoted string literal (not a template literal) or any `.startsWith(` call at all — plus the
+    // three named helper functions the frozen predecessor used — must all red this test. The route
+    // file is production "implementation" exactly as much as the aggregate module (§9 W4-0-G2's ban
+    // covers "the implementation", not one file within it) and today's stripped code has zero
+    // legitimate `.startsWith(`/`toUpperCase()` occurrences, so there is no false-positive risk.
+    expect(code).not.toMatch(/\.startsWith\(/)
+    expect(code).not.toMatch(/toUpperCase\(\)/)
     expect(code).not.toMatch(/isSelectOnly|assertSelectOnly|isReadOnlySql/i)
   })
 })
@@ -530,7 +558,7 @@ describe('GET /api/attendance-admin/setup-readiness (route)', () => {
     expect(transactionMock).not.toHaveBeenCalled()
   })
 
-  it('200 for an org member, with the exact §4.2-locked key set and values-free payload', async () => {
+  it('200 for an org member, with the §4.2-locked key set PLUS the disclosed viewerIsPlatformAdmin addition, and a values-free payload', async () => {
     queryMock.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] }) // user_orgs membership: member
     mockTransactionQueries([
       { rows: [{ ready: true }] }, // directoryLinked
@@ -546,6 +574,7 @@ describe('GET /api/attendance-admin/setup-readiness (route)', () => {
     const data = res.body.data
     expect(Object.keys(data).sort()).toEqual(
       [
+        // §4.2-locked 13 keys, verbatim:
         'directoryLinked',
         'orgActiveMemberCount',
         'groupCount',
@@ -559,6 +588,8 @@ describe('GET /api/attendance-admin/setup-readiness (route)', () => {
         'notify',
         'previewReady',
         'perStep',
+        // Disclosed, not-yet-owner-ratified 14th key (§3① role-gated remediation contract — see
+        // the response interface's doc comment; do NOT read this assertion as the sign-off).
         'viewerIsPlatformAdmin',
       ].sort(),
     )
@@ -569,9 +600,19 @@ describe('GET /api/attendance-admin/setup-readiness (route)', () => {
     expect(data.viewerIsPlatformAdmin).toBe(false)
     expect(data.previewReady).toBe(true) // OK_COUNTS_ROW satisfies ①②③⑤
     expect(Object.keys(data.perStep).sort()).toEqual([...ATTENDANCE_SETUP_STEP_IDS].sort())
+    // §4.2 `perStep.effectiveTime: {source, posture, effectiveAt?}` — each perStep ENTRY nests
+    // under an `effectiveTime` key (not a flat {source,posture} record); mutation target: flattening
+    // this back out reds every assertion in this loop.
+    for (const stepId of ATTENDANCE_SETUP_STEP_IDS) {
+      const entry = data.perStep[stepId]
+      expect(Object.keys(entry)).toEqual(['effectiveTime'])
+      expect(entry.effectiveTime).toHaveProperty('source')
+      expect(entry.effectiveTime).toHaveProperty('posture')
+    }
     // Values-free: no raw env-var NAMES (uppercase-with-underscore, e.g. the notify env flags) or
-    // credentials anywhere. (perStep[*].source table-name identifiers like "attendance_groups" are
-    // the sanctioned §4.2 contract, not an env leak — hence the uppercase-only pattern here.)
+    // credentials anywhere. (perStep[*].effectiveTime.source table-name identifiers like
+    // "attendance_groups" are the sanctioned §4.2 contract, not an env leak — hence the
+    // uppercase-only pattern here.)
     expect(JSON.stringify(data)).not.toMatch(/ATTENDANCE_[A-Z_]/)
     expect(JSON.stringify(data)).not.toMatch(/password|secret|token/i)
   })

--- a/packages/core-backend/tests/unit/attendance-admin-setup-readiness-w4-0.test.ts
+++ b/packages/core-backend/tests/unit/attendance-admin-setup-readiness-w4-0.test.ts
@@ -78,6 +78,7 @@ const {
   ATTENDANCE_SETUP_STEP_IDS,
   ATTENDANCE_PUNCH_POLICY_CLOSED_SET_KEYS_IN,
   ATTENDANCE_PUNCH_POLICY_CLOSED_SET_KEYS_OUT,
+  ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT,
   computeAttendanceSetupReadinessDeliveryRuntime,
   computeAttendanceSetupReadinessPreviewReady,
   computeAttendanceSetupReadinessStep3Ready,
@@ -100,13 +101,33 @@ function makeApp(user: Record<string, unknown> | null) {
   return app
 }
 
-/** Wires `transactionMock` so the code under test's `SET TRANSACTION READ ONLY` + N subsequent
- *  `client.query(...)` calls resolve, in order, to `resolvedValues`. */
-function mockTransactionQueries(resolvedValues: Array<{ rows: unknown[] }>) {
+/** Wires `transactionMock` so `SET TRANSACTION READ ONLY`, the SAVEPOINT/RELEASE SAVEPOINT pair
+ *  bracketing the ④ probe (P3-1, #4541 review), and the four business reads all resolve correctly
+ *  — content-DISPATCHED on SQL text rather than positional FIFO. This is deliberate, not
+ *  incidental: P3-1's SAVEPOINT wrapping means `readAttendancePunchPolicyPosture` now issues THREE
+ *  round-trips (SAVEPOINT / SELECT / RELEASE SAVEPOINT) that interleave with the sibling ⑥
+ *  `orgRecipientBinding` read inside the SAME `Promise.all` (all four aggregation reads share one
+ *  client) — a fixed positional sequence would silently feed the wrong canned row to the wrong
+ *  query the moment that interleaving shifts (fragile even today, and a future change to any of the
+ *  four functions' internal await count would shift it further). Dispatching on each query's own
+ *  distinguishing SQL fragment is immune to call-order entirely. */
+function mockTransactionQueries(resolvedValues: {
+  directoryLinked?: { rows: unknown[] }
+  orgCounts?: { rows: unknown[] }
+  punchPolicy?: { rows: unknown[] }
+  orgRecipientBinding?: { rows: unknown[] }
+}) {
   transactionMock.mockImplementationOnce(async (handler: (client: { query: (...a: unknown[]) => Promise<unknown> }) => Promise<unknown>) => {
-    const clientQuery = vi.fn()
-    clientQuery.mockResolvedValueOnce({ rows: [] }) // SET TRANSACTION READ ONLY
-    for (const v of resolvedValues) clientQuery.mockResolvedValueOnce(v)
+    const clientQuery = vi.fn(async (sql: string) => {
+      if (/^SET TRANSACTION READ ONLY/i.test(sql)) return { rows: [] }
+      // SAVEPOINT / RELEASE SAVEPOINT / ROLLBACK TO SAVEPOINT (P3-1) — no business row, always a
+      // no-op ack.
+      if (/SAVEPOINT/i.test(sql)) return { rows: [] }
+      if (/FROM system_configs/.test(sql)) return resolvedValues.punchPolicy ?? { rows: [] }
+      if (/bound_recipient_count/.test(sql)) return resolvedValues.orgRecipientBinding ?? { rows: [{ bound_recipient_count: 0 }] }
+      if (/AS ready/.test(sql)) return resolvedValues.directoryLinked ?? { rows: [{ ready: false }] }
+      return resolvedValues.orgCounts ?? { rows: [OK_COUNTS_ROW] } // org-counts CTE (member_scope ...)
+    })
     return handler({ query: clientQuery })
   })
 }
@@ -247,13 +268,22 @@ describe('computeAttendanceSetupReadinessPreviewReady (§3.2 / §9 W4-0-G4)', ()
 describe('readAttendancePunchPolicyPosture (§3④ / §3.1 closed set)', () => {
   beforeEach(() => queryMock.mockReset())
 
+  // P3-1 (#4541 review): the probe now brackets its SELECT with SAVEPOINT/RELEASE SAVEPOINT — queue
+  // the bracketing acks around the given SELECT resolution so every test below still only has to
+  // state the SELECT's own result.
+  function mockPostureProbe(selectResolvedValue: { rows: unknown[] }) {
+    queryMock.mockResolvedValueOnce({ rows: [] }) // SAVEPOINT
+    queryMock.mockResolvedValueOnce(selectResolvedValue) // SELECT value FROM system_configs
+    queryMock.mockResolvedValueOnce({ rows: [] }) // RELEASE SAVEPOINT
+  }
+
   it('no system_configs row ⇒ default', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [] })
+    mockPostureProbe({ rows: [] })
     expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('default')
   })
 
   it('row equals normalized defaults exactly ⇒ default', async () => {
-    queryMock.mockResolvedValueOnce({
+    mockPostureProbe({
       rows: [
         {
           value: JSON.stringify({
@@ -275,7 +305,7 @@ describe('readAttendancePunchPolicyPosture (§3④ / §3.1 closed set)', () => {
   })
 
   it('G5 negative control: only annualLeavePolicy differs ⇒ still default', async () => {
-    queryMock.mockResolvedValueOnce({
+    mockPostureProbe({
       rows: [
         {
           value: JSON.stringify({
@@ -296,7 +326,7 @@ describe('readAttendancePunchPolicyPosture (§3④ / §3.1 closed set)', () => {
   })
 
   it('G5 positive control: unscheduled.mode differs ⇒ customized', async () => {
-    queryMock.mockResolvedValueOnce({
+    mockPostureProbe({
       rows: [
         {
           value: JSON.stringify({
@@ -316,17 +346,22 @@ describe('readAttendancePunchPolicyPosture (§3④ / §3.1 closed set)', () => {
   })
 
   it('row exists but has no punchPolicy key ⇒ unknown (pre-S0 / corrupted shape)', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [{ value: JSON.stringify({ foo: 'bar' }) }] })
+    mockPostureProbe({ rows: [{ value: JSON.stringify({ foo: 'bar' }) }] })
     expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('unknown')
   })
 
-  it('malformed JSON ⇒ unknown (fail-closed, not a throw)', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [{ value: '{not json' }] })
+  it('malformed JSON ⇒ unknown (fail-closed, not a throw), and the savepoint is rolled back (P3-1)', async () => {
+    mockPostureProbe({ rows: [{ value: '{not json' }] })
     expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('unknown')
+    // The SELECT itself succeeded (it's the synchronous JSON.parse afterward that throws) — the
+    // catch block still issues ROLLBACK TO SAVEPOINT unconditionally, never RELEASE, for any error
+    // caught in this scope.
+    expect(queryMock).toHaveBeenCalledTimes(3)
+    expect((queryMock.mock.calls[2] as [string])[0]).toMatch(/^ROLLBACK TO SAVEPOINT/)
   })
 
   it('legacy 038-JSONB shape (driver returns an already-parsed object) ⇒ handled, not thrown', async () => {
-    queryMock.mockResolvedValueOnce({
+    mockPostureProbe({
       rows: [
         {
           value: {
@@ -345,34 +380,68 @@ describe('readAttendancePunchPolicyPosture (§3④ / §3.1 closed set)', () => {
     expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('default')
   })
 
-  it('query throws ⇒ unknown', async () => {
-    queryMock.mockRejectedValueOnce(new Error('SECRET_DETAIL boom'))
+  it('a successful probe SAVEPOINTs then RELEASEs — never leaves an open savepoint (P3-1)', async () => {
+    mockPostureProbe({ rows: [] })
+    await readAttendancePunchPolicyPosture(queryMock as never)
+    expect(queryMock).toHaveBeenCalledTimes(3)
+    expect((queryMock.mock.calls[0] as [string])[0]).toMatch(/^SAVEPOINT /)
+    expect((queryMock.mock.calls[2] as [string])[0]).toMatch(/^RELEASE SAVEPOINT /)
+    // Same savepoint name on both ends of the bracket.
+    const savepointName = (queryMock.mock.calls[0] as [string])[0].replace(/^SAVEPOINT /, '')
+    expect((queryMock.mock.calls[2] as [string])[0]).toBe(`RELEASE SAVEPOINT ${savepointName}`)
+  })
+
+  it('query throws ⇒ unknown, and the shared transaction is recovered via ROLLBACK TO SAVEPOINT, not left aborted (P3-1)', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] }) // SAVEPOINT
+    queryMock.mockRejectedValueOnce(new Error('SECRET_DETAIL boom')) // SELECT throws
+    queryMock.mockResolvedValueOnce({ rows: [] }) // ROLLBACK TO SAVEPOINT
     expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('unknown')
+    // Mutation target (P3-1): removing the ROLLBACK TO SAVEPOINT call would leave the shared
+    // transaction aborted for every subsequent read sharing this connection (the sibling ⑥
+    // orgRecipientBinding read, in production) — assert it was actually issued, using the SAME
+    // savepoint name SAVEPOINT itself opened.
+    expect(queryMock).toHaveBeenCalledTimes(3)
+    const savepointName = (queryMock.mock.calls[0] as [string])[0].replace(/^SAVEPOINT /, '')
+    expect((queryMock.mock.calls[2] as [string])[0]).toBe(`ROLLBACK TO SAVEPOINT ${savepointName}`)
+  })
+
+  it('cannot even open a SAVEPOINT (shared transaction already aborted upstream) ⇒ unknown, no further query attempted', async () => {
+    queryMock.mockRejectedValueOnce(new Error('current transaction is aborted'))
+    expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('unknown')
+    // Fail-closed immediately — no SELECT, no ROLLBACK TO SAVEPOINT attempt against a connection
+    // that cannot even take a savepoint.
+    expect(queryMock).toHaveBeenCalledTimes(1)
   })
 })
 
-describe('§9 W4-0-G5: closed-set reconciliation against the LIVE plugin source text', () => {
-  it('IN ∪ OUT equals every DEFAULT_SETTINGS top-level key in plugins/plugin-attendance/index.cjs', () => {
-    const pluginPath = path.resolve(__dirname, '../../../../plugins/plugin-attendance/index.cjs')
-    const source = readFileSync(pluginPath, 'utf8')
-    const startIdx = source.indexOf('const DEFAULT_SETTINGS = {')
-    expect(startIdx).toBeGreaterThan(-1)
-    const blockStart = source.indexOf('{', startIdx)
-    // Find the matching top-level closing brace by scanning brace depth.
-    let depth = 0
-    let endIdx = -1
-    for (let i = blockStart; i < source.length; i++) {
-      if (source[i] === '{') depth++
-      else if (source[i] === '}') {
-        depth--
-        if (depth === 0) {
-          endIdx = i
-          break
-        }
+/** Locates the literal body text of `const DEFAULT_SETTINGS = { ... }` in the live plugin source —
+ *  shared by both the key-NAME (existing) and key-VALUE (P3-2, #4541 review) reconciliation tests
+ *  below, via brace-depth counting (handles arbitrarily nested objects/arrays inside the block). */
+function readDefaultSettingsBlock(): string {
+  const pluginPath = path.resolve(__dirname, '../../../../plugins/plugin-attendance/index.cjs')
+  const source = readFileSync(pluginPath, 'utf8')
+  const startIdx = source.indexOf('const DEFAULT_SETTINGS = {')
+  if (startIdx < 0) throw new Error('DEFAULT_SETTINGS not found in plugin source')
+  const blockStart = source.indexOf('{', startIdx)
+  let depth = 0
+  let endIdx = -1
+  for (let i = blockStart; i < source.length; i++) {
+    if (source[i] === '{') depth++
+    else if (source[i] === '}') {
+      depth--
+      if (depth === 0) {
+        endIdx = i
+        break
       }
     }
-    expect(endIdx).toBeGreaterThan(blockStart)
-    const block = source.slice(blockStart + 1, endIdx)
+  }
+  if (endIdx <= blockStart) throw new Error('could not find the matching closing brace for DEFAULT_SETTINGS')
+  return source.slice(blockStart + 1, endIdx)
+}
+
+describe('§9 W4-0-G5: closed-set reconciliation against the LIVE plugin source text', () => {
+  it('IN ∪ OUT equals every DEFAULT_SETTINGS top-level key in plugins/plugin-attendance/index.cjs', () => {
+    const block = readDefaultSettingsBlock()
     const liveKeys = new Set<string>()
     // Top-level keys are 2-space-indented `key:` lines (object or scalar values alike).
     for (const line of block.split('\n')) {
@@ -393,6 +462,62 @@ describe('§9 W4-0-G5: closed-set reconciliation against the LIVE plugin source 
     expect([...ATTENDANCE_PUNCH_POLICY_CLOSED_SET_KEYS_IN].sort()).toEqual(
       ['geoFence', 'ipAllowlist', 'minPunchIntervalMinutes', 'punchPolicy'].sort(),
     )
+  })
+
+  // P3-2 (#4541 review): the key-NAME reconciliation above only proves every DEFAULT_SETTINGS key is
+  // classified IN/OUT of the closed set — it says nothing about whether `ATTENDANCE_PUNCH_POLICY_
+  // CLOSED_SET_DEFAULT` (the independently-pinned VALUE mirror `readAttendancePunchPolicyPosture`
+  // actually compares against) still matches the plugin's own literal VALUES for those four IN keys.
+  // This test closes that gap: it parses the LIVE plugin source text for each IN key's own literal
+  // value and deep-diffs it against the mirror, so a value-only drift on EITHER side (the plugin's
+  // default changes, or the mirror is edited without following) reds here even though the key-NAME
+  // test above stays green.
+  it('the closed-set default MIRROR matches the LIVE plugin literal values, key-by-key (P3-2)', () => {
+    const block = readDefaultSettingsBlock()
+
+    // Extract the literal source text for one top-level `key: <value>,` entry inside `block`, using
+    // the SAME brace/bracket-depth-counting technique as `readDefaultSettingsBlock` above
+    // (generalized to stop at a depth-0 comma, or the block's end) — never a hand-rolled
+    // per-shape regex, so a nested object/array inside the value is handled uniformly.
+    function extractValueSource(key: string): string {
+      const marker = new RegExp(`\\n  ${key}:\\s*`)
+      const m = marker.exec(block)
+      if (!m) throw new Error(`key not found in DEFAULT_SETTINGS: ${key}`)
+      const start = m.index + m[0].length
+      let d = 0
+      let end = block.length
+      for (let i = start; i < block.length; i++) {
+        const ch = block[i]
+        if (ch === '{' || ch === '[') d++
+        else if (ch === '}' || ch === ']') d--
+        else if (ch === ',' && d === 0) {
+          end = i
+          break
+        }
+      }
+      return block.slice(start, end).trim()
+    }
+
+    // Evaluated as a JS literal (not JSON.parse) because the source uses single-quoted strings
+    // (e.g. `mode: 'allow'`) — this reads a literal out of THIS repo's own static source file (not
+    // untrusted input), the standard idiom for "parse a value straight out of source text" that a
+    // JSON-only parser cannot handle.
+    function evalLiteral(src: string): unknown {
+      // eslint-disable-next-line no-new-func
+      return new Function(`"use strict"; return (${src});`)()
+    }
+
+    const liveClosedSetDefault = {
+      punchPolicy: evalLiteral(extractValueSource('punchPolicy')),
+      ipAllowlist: evalLiteral(extractValueSource('ipAllowlist')),
+      geoFence: evalLiteral(extractValueSource('geoFence')),
+      minPunchIntervalMinutes: evalLiteral(extractValueSource('minPunchIntervalMinutes')),
+    }
+
+    // Mutation target (P3-2): a change to EITHER side (the plugin's own DEFAULT_SETTINGS literal, or
+    // ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT) without updating the other reds this — e.g.
+    // minPunchIntervalMinutes silently drifting from 1 to some other value on only one side.
+    expect(liveClosedSetDefault).toEqual(ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT)
   })
 })
 
@@ -558,23 +683,25 @@ describe('GET /api/attendance-admin/setup-readiness (route)', () => {
     expect(transactionMock).not.toHaveBeenCalled()
   })
 
-  it('200 for an org member, with the §4.2-locked key set PLUS the disclosed viewerIsPlatformAdmin addition, and a values-free payload', async () => {
+  it('200 for an org member, with the §4.2-locked 13-key set EXACTLY, and a values-free payload', async () => {
     queryMock.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] }) // user_orgs membership: member
-    mockTransactionQueries([
-      { rows: [{ ready: true }] }, // directoryLinked
-      { rows: [OK_COUNTS_ROW] }, // org counts CTE
-      { rows: [] }, // punch policy (no row => default)
-      { rows: [{ bound_recipient_count: 0 }] }, // orgRecipientBinding
-    ])
+    mockTransactionQueries({
+      directoryLinked: { rows: [{ ready: true }] },
+      orgCounts: { rows: [OK_COUNTS_ROW] },
+      punchPolicy: { rows: [] }, // no row => default
+      orgRecipientBinding: { rows: [{ bound_recipient_count: 0 }] },
+    })
     const app = makeApp({ id: 'delegated-admin' })
     pinned.setApp(app)
     const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-a')
     expect(res.status).toBe(200)
     expect(res.body.ok).toBe(true)
     const data = res.body.data
+    // §4.2-locked 13 keys, verbatim — EXACT, not a subset/superset. Mutation target (P2, #4541
+    // review): a prior revision carried a 14th `viewerIsPlatformAdmin` key the pure discriminator
+    // module never consumed; re-adding ANY 14th key here (that one or another) reds this.
     expect(Object.keys(data).sort()).toEqual(
       [
-        // §4.2-locked 13 keys, verbatim:
         'directoryLinked',
         'orgActiveMemberCount',
         'groupCount',
@@ -588,16 +715,12 @@ describe('GET /api/attendance-admin/setup-readiness (route)', () => {
         'notify',
         'previewReady',
         'perStep',
-        // Disclosed, not-yet-owner-ratified 14th key (§3① role-gated remediation contract — see
-        // the response interface's doc comment; do NOT read this assertion as the sign-off).
-        'viewerIsPlatformAdmin',
       ].sort(),
     )
     expect(Object.keys(data.notify).sort()).toEqual(['deliveryRuntime', 'orgRecipientBinding', 'recipientScopeConfig'].sort())
     expect(Object.keys(data.notify.orgRecipientBinding).sort()).toEqual(['boundRecipientCount', 'hasAnyBoundRecipient'].sort())
     expect(data.notify.recipientScopeConfig).toBe('unsupported')
     expect(data.punchPolicyPosture).toBe('default')
-    expect(data.viewerIsPlatformAdmin).toBe(false)
     expect(data.previewReady).toBe(true) // OK_COUNTS_ROW satisfies ①②③⑤
     expect(Object.keys(data.perStep).sort()).toEqual([...ATTENDANCE_SETUP_STEP_IDS].sort())
     // §4.2 `perStep.effectiveTime: {source, posture, effectiveAt?}` — each perStep ENTRY nests
@@ -617,38 +740,22 @@ describe('GET /api/attendance-admin/setup-readiness (route)', () => {
     expect(JSON.stringify(data)).not.toMatch(/password|secret|token/i)
   })
 
-  it('viewerIsPlatformAdmin=true for the platform-admin bypass (single-column-labeled — NOT a substitute for the membership case)', async () => {
+  it('platform-admin bypass (single-column-labeled — NOT a substitute for the membership case): orgId=org-b (foreign) ⇒ 200, zero user_orgs query', async () => {
     // No user_orgs query at all: the platform-admin shortcut in canReadAttendanceDirectoryReadiness
     // returns true before ever touching user_orgs (attendance-admin.ts, hasLegacyAdminClaim/isRbacAdmin).
-    mockTransactionQueries([
-      { rows: [{ ready: false }] },
-      { rows: [OK_COUNTS_ROW] },
-      { rows: [] },
-      { rows: [{ bound_recipient_count: 0 }] },
-    ])
+    mockTransactionQueries({
+      directoryLinked: { rows: [{ ready: false }] },
+      orgCounts: { rows: [OK_COUNTS_ROW] },
+      punchPolicy: { rows: [] },
+      orgRecipientBinding: { rows: [{ bound_recipient_count: 0 }] },
+    })
     const app = makeApp({ id: 'platform-admin' })
     pinned.setApp(app)
     const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-b')
     expect(res.status).toBe(200)
-    expect(res.body.data.viewerIsPlatformAdmin).toBe(true)
     // This 200 for a foreign org is the DESIGNED bypass, not proof of the org-membership door — the
     // membership-door proof is case 2 above (403) and the real-DB two-org matrix (G1).
     expect(queryMock).not.toHaveBeenCalled()
-  })
-
-  it('viewerIsPlatformAdmin=false for a delegated org member', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] })
-    mockTransactionQueries([
-      { rows: [{ ready: false }] },
-      { rows: [OK_COUNTS_ROW] },
-      { rows: [] },
-      { rows: [{ bound_recipient_count: 0 }] },
-    ])
-    const app = makeApp({ id: 'delegated-admin' })
-    pinned.setApp(app)
-    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-a')
-    expect(res.status).toBe(200)
-    expect(res.body.data.viewerIsPlatformAdmin).toBe(false)
   })
 
   it('503 DB_NOT_READY when the schema is not ready', async () => {
@@ -682,12 +789,12 @@ describe('GET /api/attendance-admin/setup-readiness (route)', () => {
     getSharedAttendanceSchedulerMock.mockReturnValue(null)
     try {
       queryMock.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] })
-      mockTransactionQueries([
-        { rows: [{ ready: false }] },
-        { rows: [OK_COUNTS_ROW] },
-        { rows: [] },
-        { rows: [{ bound_recipient_count: 0 }] },
-      ])
+      mockTransactionQueries({
+        directoryLinked: { rows: [{ ready: false }] },
+        orgCounts: { rows: [OK_COUNTS_ROW] },
+        punchPolicy: { rows: [] },
+        orgRecipientBinding: { rows: [{ bound_recipient_count: 0 }] },
+      })
       const app = makeApp({ id: 'delegated-admin' })
       pinned.setApp(app)
       const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-a')

--- a/packages/core-backend/tests/unit/attendance-admin-setup-readiness-w4-0.test.ts
+++ b/packages/core-backend/tests/unit/attendance-admin-setup-readiness-w4-0.test.ts
@@ -1,0 +1,666 @@
+/**
+ * W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED §3/§4/§9): mock-level contract coverage
+ * for `GET /api/attendance-admin/setup-readiness` and its computational core in
+ * `services/AttendanceSetupReadinessAggregate.ts`.
+ *
+ * Real-Postgres behavioural proof (§9 W4-0-G1..G5, especially the read-only transaction actually
+ * REJECTING writes — a mock cannot prove that) lives in
+ * `tests/integration/attendance-setup-readiness-w4-0.db.test.ts`. This file's job is everything a
+ * mock CAN prove: response shape, key-set/values-free discipline, status-code matrix, the SQL
+ * text's org-anchor count, the ④ closed-set posture branches, the ⑥ deliveryRuntime/env
+ * independence, the previewReady formula, and the negative meta-assertion that no first-word/regex
+ * "read-only" check exists anywhere in the implementation (§9 W4-0-G2's explicit ban).
+ *
+ * Mutation evidence (load-bearing; PR body cross-references these by name):
+ *  - move the `buildAttendanceSetupReadiness` call before `canReadAttendanceDirectoryReadiness` ⇒
+ *    "403 issues ZERO aggregation" red.
+ *  - drop `org_id = $1` from any org-counts CTE leg ⇒ the SQL-audit test's exact-count assertion red.
+ *  - change ④'s default→ready mapping ⇒ the punch-policy-posture branch tests red.
+ *  - fold ⑥'s three notify signals into one, or make previewReady read `punchPolicyPosture`/`notify`
+ *    ⇒ the G4-echo / previewReady-independence tests red.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import express from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePinnedServer } from '../utils/pinned-server'
+
+const queryMock = vi.fn()
+const transactionMock = vi.fn()
+const getSharedAttendanceSchedulerMock = vi.fn()
+
+vi.mock('../../src/db/pg', () => ({
+  query: (...args: unknown[]) => queryMock(...args),
+  transaction: (...args: unknown[]) => transactionMock(...args),
+  pool: { query: (...args: unknown[]) => queryMock(...args) },
+}))
+
+vi.mock('../../src/services/AttendanceScheduler', () => ({
+  getSharedAttendanceScheduler: () => getSharedAttendanceSchedulerMock(),
+}))
+
+vi.mock('../../src/rbac/rbac', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/rbac')>()
+  return {
+    ...actual,
+    rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  }
+})
+
+vi.mock('../../src/rbac/service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/service')>()
+  return {
+    ...actual,
+    isAdmin: vi.fn(async (userId: string) => userId === 'platform-admin'),
+    listUserPermissions: vi.fn(async () => []),
+  }
+})
+
+vi.mock('../../src/routes/admin-users', () => ({
+  ensurePlatformAdmin: vi.fn(async () => null),
+}))
+
+vi.mock('../../src/services/AttendanceNotificationRedelivery', () => ({
+  redeliverFailedAttendanceNotification: vi.fn(),
+}))
+
+vi.mock('../../src/services/ApprovalDirectoryOrg', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/services/ApprovalDirectoryOrg')>()
+  return { ...actual, MAX_MANAGER_CHAIN_LEVELS: 10 }
+})
+
+const { attendanceAdminRouter, ATTENDANCE_SETUP_READINESS_DEPLOYMENT_SCOPED_FIELDS } = await import(
+  '../../src/routes/attendance-admin'
+)
+const {
+  ATTENDANCE_SETUP_READINESS_STATUS_VALUES,
+  ATTENDANCE_SETUP_STEP_IDS,
+  ATTENDANCE_PUNCH_POLICY_CLOSED_SET_KEYS_IN,
+  ATTENDANCE_PUNCH_POLICY_CLOSED_SET_KEYS_OUT,
+  computeAttendanceSetupReadinessDeliveryRuntime,
+  computeAttendanceSetupReadinessPreviewReady,
+  computeAttendanceSetupReadinessStep3Ready,
+  readAttendanceSetupReadinessOrgCounts,
+  readAttendancePunchPolicyPosture,
+  readAttendanceSetupReadinessOrgRecipientBinding,
+  runAttendanceSetupReadinessReadOnly,
+} = await import('../../src/services/AttendanceSetupReadinessAggregate')
+
+const pinned = usePinnedServer()
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    ;(req as express.Request & { user?: unknown }).user = user ?? undefined
+    next()
+  })
+  app.use(attendanceAdminRouter())
+  return app
+}
+
+/** Wires `transactionMock` so the code under test's `SET TRANSACTION READ ONLY` + N subsequent
+ *  `client.query(...)` calls resolve, in order, to `resolvedValues`. */
+function mockTransactionQueries(resolvedValues: Array<{ rows: unknown[] }>) {
+  transactionMock.mockImplementationOnce(async (handler: (client: { query: (...a: unknown[]) => Promise<unknown> }) => Promise<unknown>) => {
+    const clientQuery = vi.fn()
+    clientQuery.mockResolvedValueOnce({ rows: [] }) // SET TRANSACTION READ ONLY
+    for (const v of resolvedValues) clientQuery.mockResolvedValueOnce(v)
+    return handler({ query: clientQuery })
+  })
+}
+
+const OK_COUNTS_ROW = {
+  org_active_member_count: 3,
+  group_count: 2,
+  groups_with_members: 1,
+  shift_count: 2,
+  scheduled_shift_group_count: 0,
+  active_rotation_rule_count: 0,
+  approval_flow_count: 1,
+}
+
+describe('value domain (§3/§7 exhaustiveness)', () => {
+  it('is exactly the seven locked values, in the locked order', () => {
+    expect(ATTENDANCE_SETUP_READINESS_STATUS_VALUES).toEqual([
+      'ready',
+      'missing',
+      'forbidden',
+      'unknown',
+      'manual_review_required',
+      'unsupported',
+      'db_not_ready',
+    ])
+  })
+
+  it('exposes exactly the seven canonical step ids, in wizard order', () => {
+    expect(ATTENDANCE_SETUP_STEP_IDS).toEqual([
+      'attendance-admin-user-access',
+      'attendance-admin-groups',
+      'attendance-admin-shifts',
+      'attendance-admin-settings',
+      'attendance-admin-approval-flows',
+      'attendance-admin-notification-deliveries',
+      'preview',
+    ])
+  })
+})
+
+describe('readAttendanceSetupReadinessOrgCounts (org-anchor SQL audit, §4.2 追加门禁2)', () => {
+  beforeEach(() => queryMock.mockReset())
+
+  it('issues a single query with org_id = $1 exactly 7 times and one positional param', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [OK_COUNTS_ROW] })
+    const result = await readAttendanceSetupReadinessOrgCounts('org-a', queryMock as never)
+    expect(queryMock).toHaveBeenCalledTimes(1)
+    const [sql, params] = queryMock.mock.calls[0] as [string, unknown[]]
+    const orgIdMatches = sql.match(/org_id\s*=\s*\$1/g) ?? []
+    // Mutation target ②: dropping any leg's org_id filter drops this count below 7.
+    expect(orgIdMatches).toHaveLength(7)
+    expect(params).toEqual(['org-a'])
+    expect(sql).not.toMatch(/\$2/)
+    expect(result).toEqual({
+      orgActiveMemberCount: 3,
+      groupCount: 2,
+      groupsWithMembers: 1,
+      shiftCount: 2,
+      scheduledShiftGroupCount: 0,
+      activeRotationRuleCount: 0,
+      approvalFlowCount: 1,
+    })
+  })
+
+  it('scopes ① to BOTH user_orgs.is_active AND users.is_active (RD-3 double filter)', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [OK_COUNTS_ROW] })
+    await readAttendanceSetupReadinessOrgCounts('org-a', queryMock as never)
+    const [sql] = queryMock.mock.calls[0] as [string]
+    expect(sql).toMatch(/uo\.is_active\s*=\s*true/)
+    expect(sql).toMatch(/u\.is_active\s*=\s*true/)
+  })
+
+  it('scopes ③ activeRotationRuleCount to is_active = true (not all rotation rules)', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [OK_COUNTS_ROW] })
+    await readAttendanceSetupReadinessOrgCounts('org-a', queryMock as never)
+    const [sql] = queryMock.mock.calls[0] as [string]
+    expect(sql).toMatch(/attendance_rotation_rules[\s\S]*?is_active\s*=\s*true/)
+  })
+
+  it('returns no PII/identifying columns — counts only', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [OK_COUNTS_ROW] })
+    await readAttendanceSetupReadinessOrgCounts('org-a', queryMock as never)
+    const [sql] = queryMock.mock.calls[0] as [string]
+    expect(sql).not.toMatch(/name|email|mobile|phone|user_id\s*[,)]/i)
+  })
+})
+
+describe('computeAttendanceSetupReadinessStep3Ready (§3③ errata formula)', () => {
+  it('false when shiftCount=0 regardless of other signals', () => {
+    expect(computeAttendanceSetupReadinessStep3Ready(0, 0, 0)).toBe(false)
+    expect(computeAttendanceSetupReadinessStep3Ready(0, 1, 5)).toBe(false)
+  })
+  it('true when shiftCount>0 and no scheduled-shift group exists', () => {
+    expect(computeAttendanceSetupReadinessStep3Ready(2, 0, 0)).toBe(true)
+  })
+  it('false when a scheduled-shift group exists but no active rotation rule does', () => {
+    expect(computeAttendanceSetupReadinessStep3Ready(2, 1, 0)).toBe(false)
+  })
+  it('true when a scheduled-shift group exists AND an active rotation rule does', () => {
+    expect(computeAttendanceSetupReadinessStep3Ready(2, 1, 1)).toBe(true)
+  })
+})
+
+describe('computeAttendanceSetupReadinessPreviewReady (§3.2 / §9 W4-0-G4)', () => {
+  const base = {
+    orgActiveMemberCount: 1,
+    groupCount: 1,
+    groupsWithMembers: 1,
+    shiftCount: 1,
+    scheduledShiftGroupCount: 0,
+    activeRotationRuleCount: 0,
+    approvalFlowCount: 1,
+  }
+
+  it('true when ①②③⑤ all ready', () => {
+    expect(computeAttendanceSetupReadinessPreviewReady(base)).toBe(true)
+  })
+
+  it.each([
+    ['orgActiveMemberCount', 0],
+    ['groupCount', 0],
+    ['groupsWithMembers', 0],
+    ['shiftCount', 0],
+    ['approvalFlowCount', 0],
+  ] as const)('false when %s drops to %d', (field, value) => {
+    expect(computeAttendanceSetupReadinessPreviewReady({ ...base, [field]: value })).toBe(false)
+  })
+
+  // §9 W4-0-G4: the function signature itself cannot see punchPolicyPosture or notify — the
+  // strongest possible "④/⑥ never gate previewReady" proof (a compile-time, not just runtime, one).
+  it('the input type structurally excludes punchPolicyPosture and notify (④/⑥ cannot gate)', () => {
+    const keys = Object.keys(base)
+    expect(keys).not.toContain('punchPolicyPosture')
+    expect(keys).not.toContain('notify')
+  })
+})
+
+describe('readAttendancePunchPolicyPosture (§3④ / §3.1 closed set)', () => {
+  beforeEach(() => queryMock.mockReset())
+
+  it('no system_configs row ⇒ default', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] })
+    expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('default')
+  })
+
+  it('row equals normalized defaults exactly ⇒ default', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          value: JSON.stringify({
+            punchPolicy: {
+              unscheduled: { mode: 'allow' },
+              merge: { internalWinsOnIn: false, externalWinsOnOut: false },
+              outdoor: { requireApproval: false, requireNote: false, requirePhoto: false, approvalFlowId: '' },
+            },
+            ipAllowlist: [],
+            geoFence: null,
+            minPunchIntervalMinutes: 1,
+            // Negative control (G5): an unrelated key changing must NOT flip the posture.
+            holidaySync: { lastRun: '2026-07-21T00:00:00.000Z' },
+          }),
+        },
+      ],
+    })
+    expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('default')
+  })
+
+  it('G5 negative control: only annualLeavePolicy differs ⇒ still default', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          value: JSON.stringify({
+            punchPolicy: {
+              unscheduled: { mode: 'allow' },
+              merge: { internalWinsOnIn: false, externalWinsOnOut: false },
+              outdoor: { requireApproval: false, requireNote: false, requirePhoto: false, approvalFlowId: '' },
+            },
+            ipAllowlist: [],
+            geoFence: null,
+            minPunchIntervalMinutes: 1,
+            annualLeavePolicy: { enabled: true },
+          }),
+        },
+      ],
+    })
+    expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('default')
+  })
+
+  it('G5 positive control: unscheduled.mode differs ⇒ customized', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          value: JSON.stringify({
+            punchPolicy: {
+              unscheduled: { mode: 'block' },
+              merge: { internalWinsOnIn: false, externalWinsOnOut: false },
+              outdoor: { requireApproval: false, requireNote: false, requirePhoto: false, approvalFlowId: '' },
+            },
+            ipAllowlist: [],
+            geoFence: null,
+            minPunchIntervalMinutes: 1,
+          }),
+        },
+      ],
+    })
+    expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('customized')
+  })
+
+  it('row exists but has no punchPolicy key ⇒ unknown (pre-S0 / corrupted shape)', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ value: JSON.stringify({ foo: 'bar' }) }] })
+    expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('unknown')
+  })
+
+  it('malformed JSON ⇒ unknown (fail-closed, not a throw)', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ value: '{not json' }] })
+    expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('unknown')
+  })
+
+  it('legacy 038-JSONB shape (driver returns an already-parsed object) ⇒ handled, not thrown', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          value: {
+            punchPolicy: {
+              unscheduled: { mode: 'allow' },
+              merge: { internalWinsOnIn: false, externalWinsOnOut: false },
+              outdoor: { requireApproval: false, requireNote: false, requirePhoto: false, approvalFlowId: '' },
+            },
+            ipAllowlist: [],
+            geoFence: null,
+            minPunchIntervalMinutes: 1,
+          },
+        },
+      ],
+    })
+    expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('default')
+  })
+
+  it('query throws ⇒ unknown', async () => {
+    queryMock.mockRejectedValueOnce(new Error('SECRET_DETAIL boom'))
+    expect(await readAttendancePunchPolicyPosture(queryMock as never)).toBe('unknown')
+  })
+})
+
+describe('§9 W4-0-G5: closed-set reconciliation against the LIVE plugin source text', () => {
+  it('IN ∪ OUT equals every DEFAULT_SETTINGS top-level key in plugins/plugin-attendance/index.cjs', () => {
+    const pluginPath = path.resolve(__dirname, '../../../../plugins/plugin-attendance/index.cjs')
+    const source = readFileSync(pluginPath, 'utf8')
+    const startIdx = source.indexOf('const DEFAULT_SETTINGS = {')
+    expect(startIdx).toBeGreaterThan(-1)
+    const blockStart = source.indexOf('{', startIdx)
+    // Find the matching top-level closing brace by scanning brace depth.
+    let depth = 0
+    let endIdx = -1
+    for (let i = blockStart; i < source.length; i++) {
+      if (source[i] === '{') depth++
+      else if (source[i] === '}') {
+        depth--
+        if (depth === 0) {
+          endIdx = i
+          break
+        }
+      }
+    }
+    expect(endIdx).toBeGreaterThan(blockStart)
+    const block = source.slice(blockStart + 1, endIdx)
+    const liveKeys = new Set<string>()
+    // Top-level keys are 2-space-indented `key:` lines (object or scalar values alike).
+    for (const line of block.split('\n')) {
+      const m = /^  ([a-zA-Z][a-zA-Z0-9]*):/.exec(line)
+      if (m) liveKeys.add(m[1])
+    }
+    expect(liveKeys.size).toBeGreaterThan(0)
+    const classified = new Set([...ATTENDANCE_PUNCH_POLICY_CLOSED_SET_KEYS_IN, ...ATTENDANCE_PUNCH_POLICY_CLOSED_SET_KEYS_OUT])
+    // Mutation target ③: adding a new DEFAULT_SETTINGS key without classifying it here reds this.
+    expect([...liveKeys].sort()).toEqual([...classified].sort())
+    // No key double-classified.
+    expect(ATTENDANCE_PUNCH_POLICY_CLOSED_SET_KEYS_IN.length + ATTENDANCE_PUNCH_POLICY_CLOSED_SET_KEYS_OUT.length).toBe(
+      classified.size,
+    )
+  })
+
+  it('the closed-set IN list is exactly the §3.1 four keys', () => {
+    expect([...ATTENDANCE_PUNCH_POLICY_CLOSED_SET_KEYS_IN].sort()).toEqual(
+      ['geoFence', 'ipAllowlist', 'minPunchIntervalMinutes', 'punchPolicy'].sort(),
+    )
+  })
+})
+
+describe('§4.5 notify readiness (⑥ three independent signals, §9 W4-0-G4)', () => {
+  beforeEach(() => {
+    queryMock.mockReset()
+    getSharedAttendanceSchedulerMock.mockReset()
+  })
+
+  it('deliveryRuntime = not_ready when the scheduler is not started (null)', () => {
+    getSharedAttendanceSchedulerMock.mockReturnValue(null)
+    expect(computeAttendanceSetupReadinessDeliveryRuntime()).toBe('not_ready')
+  })
+
+  it('deliveryRuntime = unknown (never ready) when the scheduler IS started', () => {
+    getSharedAttendanceSchedulerMock.mockReturnValue({ started: true })
+    expect(computeAttendanceSetupReadinessDeliveryRuntime()).toBe('unknown')
+  })
+
+  it('deliveryRuntime does not read ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED at all', () => {
+    const original = process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED
+    process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED = 'true'
+    getSharedAttendanceSchedulerMock.mockReturnValue(null)
+    try {
+      // Mutation target ④: reading the env var here (worker-enabled-but-scheduler-down ⇒ 'ready')
+      // would flip this to something other than 'not_ready'.
+      expect(computeAttendanceSetupReadinessDeliveryRuntime()).toBe('not_ready')
+    } finally {
+      if (original === undefined) delete process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED
+      else process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED = original
+    }
+  })
+
+  it('orgRecipientBinding: org-scoped EXISTS-style join, boundRecipientCount/hasAnyBoundRecipient only', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ bound_recipient_count: 2 }] })
+    const result = await readAttendanceSetupReadinessOrgRecipientBinding('org-a', queryMock as never)
+    expect(result).toEqual({ boundRecipientCount: 2, hasAnyBoundRecipient: true })
+    const [sql, params] = queryMock.mock.calls[0] as [string, unknown[]]
+    expect(sql).toMatch(/i\.org_id\s*=\s*\$1/)
+    expect(sql).toMatch(/provider\s*=\s*'dingtalk'/)
+    expect(sql).toMatch(/link_status\s*=\s*'linked'/)
+    expect(params).toEqual(['org-a'])
+    expect(sql).not.toMatch(/external_user_id|local_user_id\s*,|name|email/i)
+  })
+
+  it('orgRecipientBinding: zero rows ⇒ hasAnyBoundRecipient=false', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ bound_recipient_count: 0 }] })
+    const result = await readAttendanceSetupReadinessOrgRecipientBinding('org-a', queryMock as never)
+    expect(result).toEqual({ boundRecipientCount: 0, hasAnyBoundRecipient: false })
+  })
+})
+
+describe('runAttendanceSetupReadinessReadOnly (structural wiring — real rejection proof is the .db.test.ts)', () => {
+  it('issues SET TRANSACTION READ ONLY as the FIRST statement inside the transaction', async () => {
+    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    const runTransaction = vi.fn(async (handler: (c: { query: typeof clientQuery }) => Promise<unknown>) =>
+      handler({ query: clientQuery }),
+    )
+    await runAttendanceSetupReadinessReadOnly(async () => 'done', runTransaction as never)
+    expect(clientQuery.mock.calls[0]?.[0]).toBe('SET TRANSACTION READ ONLY')
+  })
+
+  it('propagates the transaction result', async () => {
+    const runTransaction = vi.fn(async (handler: (c: { query: () => Promise<{ rows: unknown[] }> }) => Promise<unknown>) =>
+      handler({ query: async () => ({ rows: [] }) }),
+    )
+    const result = await runAttendanceSetupReadinessReadOnly(async () => ({ ok: true }), runTransaction as never)
+    expect(result).toEqual({ ok: true })
+  })
+})
+
+/** Strips block comments, line comments, and string literals so a source-scan regex only ever
+ *  inspects live CODE — never this very test file's own docblocks (which quote the banned pattern
+ *  BY NAME, in prose, precisely to explain why it is banned) or an unrelated string constant. */
+function stripCommentsAndStrings(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1')
+    .replace(/`(?:[^`\\]|\\.)*`/g, '``')
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+}
+
+describe('§9 W4-0-G2 negative meta-assertion: no first-word/regex read-only check anywhere', () => {
+  it('the aggregate module contains no prefix/regex "is this SQL a SELECT" guard (code only, comments/strings stripped)', () => {
+    const modulePath = path.resolve(__dirname, '../../src/services/AttendanceSetupReadinessAggregate.ts')
+    const code = stripCommentsAndStrings(readFileSync(modulePath, 'utf8'))
+    // Mutation target: re-introducing a `.startsWith('SELECT'` / `.toUpperCase().startsWith(` /
+    // `/^SELECT/`-shaped guard anywhere in this file's CODE must red this test — the design lock
+    // names this pattern as the exact thing killed in review (a frozen predecessor's
+    // `assertSelectOnlyReadinessSql`), and forbids re-introducing it.
+    expect(code).not.toMatch(/\.startsWith\(/)
+    expect(code).not.toMatch(/toUpperCase\(\)/)
+  })
+
+  it('the route file contains no prefix/regex "is this SQL a SELECT" guard either (code only)', () => {
+    const routePath = path.resolve(__dirname, '../../src/routes/attendance-admin.ts')
+    const code = stripCommentsAndStrings(readFileSync(routePath, 'utf8'))
+    expect(code).not.toMatch(/\.startsWith\(\s*``\s*\)/) // any startsWith(<stripped-literal>) call
+    expect(code).not.toMatch(/isSelectOnly|assertSelectOnly|isReadOnlySql/i)
+  })
+})
+
+describe('GET /api/attendance-admin/setup-readiness (route)', () => {
+  beforeEach(() => {
+    queryMock.mockReset()
+    transactionMock.mockReset()
+    getSharedAttendanceSchedulerMock.mockReset()
+    getSharedAttendanceSchedulerMock.mockReturnValue(null)
+  })
+
+  it('400 when orgId is missing', async () => {
+    const app = makeApp({ id: 'delegated-admin' })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness')
+    expect(res.status).toBe(400)
+    expect(res.body?.error?.code).toBe('ORG_ID_REQUIRED')
+  })
+
+  it('401 when unauthenticated', async () => {
+    const app = makeApp(null)
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-a')
+    expect(res.status).toBe(401)
+  })
+
+  it('403 for a foreign-org delegated admin — and issues ZERO aggregation (transaction never opened)', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] }) // user_orgs membership check: not a member
+    const app = makeApp({ id: 'foreign-admin' })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-b')
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('FORBIDDEN')
+    // Mutation target ①: moving the aggregation call before the authz check makes this fail.
+    expect(transactionMock).not.toHaveBeenCalled()
+  })
+
+  it('200 for an org member, with the exact §4.2-locked key set and values-free payload', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] }) // user_orgs membership: member
+    mockTransactionQueries([
+      { rows: [{ ready: true }] }, // directoryLinked
+      { rows: [OK_COUNTS_ROW] }, // org counts CTE
+      { rows: [] }, // punch policy (no row => default)
+      { rows: [{ bound_recipient_count: 0 }] }, // orgRecipientBinding
+    ])
+    const app = makeApp({ id: 'delegated-admin' })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-a')
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    const data = res.body.data
+    expect(Object.keys(data).sort()).toEqual(
+      [
+        'directoryLinked',
+        'orgActiveMemberCount',
+        'groupCount',
+        'groupsWithMembers',
+        'shiftCount',
+        'scheduledShiftGroupCount',
+        'activeRotationRuleCount',
+        'hasRotationRules',
+        'approvalFlowCount',
+        'punchPolicyPosture',
+        'notify',
+        'previewReady',
+        'perStep',
+        'viewerIsPlatformAdmin',
+      ].sort(),
+    )
+    expect(Object.keys(data.notify).sort()).toEqual(['deliveryRuntime', 'orgRecipientBinding', 'recipientScopeConfig'].sort())
+    expect(Object.keys(data.notify.orgRecipientBinding).sort()).toEqual(['boundRecipientCount', 'hasAnyBoundRecipient'].sort())
+    expect(data.notify.recipientScopeConfig).toBe('unsupported')
+    expect(data.punchPolicyPosture).toBe('default')
+    expect(data.viewerIsPlatformAdmin).toBe(false)
+    expect(data.previewReady).toBe(true) // OK_COUNTS_ROW satisfies ①②③⑤
+    expect(Object.keys(data.perStep).sort()).toEqual([...ATTENDANCE_SETUP_STEP_IDS].sort())
+    // Values-free: no raw env-var NAMES (uppercase-with-underscore, e.g. the notify env flags) or
+    // credentials anywhere. (perStep[*].source table-name identifiers like "attendance_groups" are
+    // the sanctioned §4.2 contract, not an env leak — hence the uppercase-only pattern here.)
+    expect(JSON.stringify(data)).not.toMatch(/ATTENDANCE_[A-Z_]/)
+    expect(JSON.stringify(data)).not.toMatch(/password|secret|token/i)
+  })
+
+  it('viewerIsPlatformAdmin=true for the platform-admin bypass (single-column-labeled — NOT a substitute for the membership case)', async () => {
+    // No user_orgs query at all: the platform-admin shortcut in canReadAttendanceDirectoryReadiness
+    // returns true before ever touching user_orgs (attendance-admin.ts, hasLegacyAdminClaim/isRbacAdmin).
+    mockTransactionQueries([
+      { rows: [{ ready: false }] },
+      { rows: [OK_COUNTS_ROW] },
+      { rows: [] },
+      { rows: [{ bound_recipient_count: 0 }] },
+    ])
+    const app = makeApp({ id: 'platform-admin' })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-b')
+    expect(res.status).toBe(200)
+    expect(res.body.data.viewerIsPlatformAdmin).toBe(true)
+    // This 200 for a foreign org is the DESIGNED bypass, not proof of the org-membership door — the
+    // membership-door proof is case 2 above (403) and the real-DB two-org matrix (G1).
+    expect(queryMock).not.toHaveBeenCalled()
+  })
+
+  it('viewerIsPlatformAdmin=false for a delegated org member', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] })
+    mockTransactionQueries([
+      { rows: [{ ready: false }] },
+      { rows: [OK_COUNTS_ROW] },
+      { rows: [] },
+      { rows: [{ bound_recipient_count: 0 }] },
+    ])
+    const app = makeApp({ id: 'delegated-admin' })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-a')
+    expect(res.status).toBe(200)
+    expect(res.body.data.viewerIsPlatformAdmin).toBe(false)
+  })
+
+  it('503 DB_NOT_READY when the schema is not ready', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] })
+    transactionMock.mockImplementationOnce(async () => {
+      const err = new Error('relation "attendance_groups" does not exist') as Error & { code?: string }
+      err.code = '42P01'
+      throw err
+    })
+    const app = makeApp({ id: 'delegated-admin' })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-a')
+    expect(res.status).toBe(503)
+    expect(res.body?.error?.code).toBe('DB_NOT_READY')
+  })
+
+  it('500 returns a generic message — never raw DB/driver text (values-free)', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] })
+    transactionMock.mockRejectedValueOnce(new Error('SECRET_DETAIL leak boom'))
+    const app = makeApp({ id: 'delegated-admin' })
+    pinned.setApp(app)
+    const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-a')
+    expect(res.status).toBe(500)
+    expect(res.body?.error?.code).toBe('SETUP_READINESS_FAILED')
+    expect(JSON.stringify(res.body)).not.toContain('SECRET_DETAIL')
+  })
+
+  it('§9 W4-0-G4 echo: deliveryRuntime=not_ready with worker-env=true but scheduler down (route-level)', async () => {
+    const original = process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED
+    process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED = 'true'
+    getSharedAttendanceSchedulerMock.mockReturnValue(null)
+    try {
+      queryMock.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] })
+      mockTransactionQueries([
+        { rows: [{ ready: false }] },
+        { rows: [OK_COUNTS_ROW] },
+        { rows: [] },
+        { rows: [{ bound_recipient_count: 0 }] },
+      ])
+      const app = makeApp({ id: 'delegated-admin' })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get('/api/attendance-admin/setup-readiness?orgId=org-a')
+      expect(res.body.data.notify.deliveryRuntime).toBe('not_ready')
+      expect(res.body.data.previewReady).toBe(true) // unaffected by notify (§3.2)
+    } finally {
+      if (original === undefined) delete process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED
+      else process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED = original
+    }
+  })
+
+  it('§4.2 deployment-scoped field registry matches the design lock text exactly', () => {
+    expect([...ATTENDANCE_SETUP_READINESS_DEPLOYMENT_SCOPED_FIELDS].sort()).toEqual(
+      ['punchPolicyPosture', 'notify.deliveryRuntime', 'notify.recipientScopeConfig'].sort(),
+    )
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -408,6 +408,15 @@ export default defineConfig({
       'tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts',
       'tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts',
       'tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts',
+      // W4-0 real-DB (§9 of attendance-vnext-wave4-onboarding-design-lock-20260721.md): the
+      // setup-readiness aggregate's G1 (two-org forgery + platform-admin bypass), G2 (SET
+      // TRANSACTION READ ONLY actually rejecting a bare write / writable CTE / multi-statement
+      // batch against real Postgres — a mock cannot prove this), G3 (① two positive controls), G4
+      // (⑥ three notify signals + previewReady independence), and G5 (④ closed-set posture
+      // against a real system_configs row) matrices. DATABASE_URL-gated describeIfDatabase;
+      // excluded here so the no-DB job cannot skip-green it; wired whole-file into the attendance
+      // real-DB step in plugin-tests.yml.
+      'tests/integration/attendance-setup-readiness-w4-0.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
## 摘要

实现 Wave 4 §9 三切片之第一片 **W4-0 readiness 底座**：`GET /api/attendance-admin/setup-readiness`
聚合端点 + 七步纯判别模块 + §4.5 通知三信号 port，逐字对照
`docs/development/attendance-vnext-wave4-onboarding-design-lock-20260721.md`（RATIFIED via #4522）
§3/§4/§9。refs #4522（W4 re-ratify）；本锁授权 W4-0 开工。

**冻结材料库**（`claude/w4-0-setup-readiness-20260721`，head `b2789cce7`，PR #4514 CLOSED 未合并）
只作只读参考，未 merge/rebase/cherry-pick；逐项 re-port 见下方 reportLedger。

## 锁 → 实现映射表

| 锁条款 | 实现 | 文件:符号 |
|---|---|---|
| §4.1 端点 + org 门 | `GET /api/attendance-admin/setup-readiness`，复用 `canReadAttendanceDirectoryReadiness`（S7-5 逐字） | `attendance-admin.ts` router 内新 `r.get(...)` |
| §4.2 响应键集 | 精确匹配锁 JSON 块顶层键（`perStep` 按锁字面嵌套为 `perStep[stepId].effectiveTime`，修复轮吸收）——13 键恒等，**无第 14 键**（`viewerIsPlatformAdmin` 曾作为披露中新增键存在，二轮 Opus 正门判 P2 后已移除，见下方「二轮 Opus 正门审阅吸收」小节） | `attendance-admin.ts` `AttendanceSetupReadinessResponse` |
| §4.2 只读证明 | `SET TRANSACTION READ ONLY` 真事务，禁首词/正则 | `AttendanceSetupReadinessAggregate.ts` `runAttendanceSetupReadinessReadOnly` |
| §3① 完成真值 | `orgActiveMemberCount>0`（双 `user_orgs.is_active`+`users.is_active`），`directoryLinked` 仅 posture | `readAttendanceSetupReadinessOrgCounts` CTE `member_scope` |
| §3② | `groupCount>0 && groupsWithMembers>0` | 同 CTE `group_scope` |
| §3③ errata | `scheduledShiftGroupCount`+`activeRotationRuleCount`（`is_active=true`）+ `step3Ready` 公式 | `computeAttendanceSetupReadinessStep3Ready` |
| §3④ / §3.1 闭集 | 4 键闭集（`punchPolicy`/`ipAllowlist`/`geoFence`/`minPunchIntervalMinutes`）vs normalized defaults；`default→manual_review_required`（**绝不 ready**）、`customized→ready`、`unknown→unknown` | 后端 `readAttendancePunchPolicyPosture`（返回原始 3 值枚举）+ FE `deriveAttendanceSetupReadinessSteps` 步④（映射） |
| §3⑤ | `approvalFlowCount>0`（`is_active`过滤） | CTE `approval_scope` |
| §3⑥ / §4.5 三信号 | `deliveryRuntime`（仅 `getSharedAttendanceScheduler()`，绝不读 worker env）、`orgRecipientBinding{boundRecipientCount,hasAnyBoundRecipient}`、`recipientScopeConfig`恒 `'unsupported'`；FE 不合并，`notifySignals` 携带另两信号 | `computeAttendanceSetupReadinessDeliveryRuntime`/`readAttendanceSetupReadinessOrgRecipientBinding`；FE 步⑥ |
| §3⑦ / §3.2 previewReady | `= ①②③⑤` 全 ready，④⑥ advisory 不参与；后端+FE 双重独立推导 | `computeAttendanceSetupReadinessPreviewReady` / `deriveAttendanceSetupReadinessPreviewReady` |
| §3.2 生效时间四态 | 七步全登记，静态常量（本切片无 `scheduled` 案例） | `ATTENDANCE_SETUP_READINESS_STEP_EFFECTIVE_TIME` |
| §4.3 错误档 | 400/401/403/503/500 全型，S7-5 同款 | route handler |
| §7 值域 | 七值穷尽 + 值域常量导出 | 后端+FE 各自 `ATTENDANCE_SETUP_READINESS_STATUS_VALUES` |
| §9 G1-G5 | 见下表 | — |

## §4.2 键集偏离说明（诚实披露，非静默决定；二轮更新——键集已收口）

冻结材料在 trilens 审计中被判 P2：响应多出锁定形状外的顶层键 `deploymentScopedSignals`，且 `perStep`
条目携带锁枚举外的 `step`/`scope` 字段。本实现**吸收该 finding**：`scope` 标记按锁 §4.2 现文（注释/
文档层面），不作为响应字段；`perStep` 精简为 `Record<stepId, {effectiveTime}>`，不携带 `step`/`scope`。

**（二轮更新）** 修复轮曾新增 `viewerIsPlatformAdmin` 作为「披露中、待 owner 门审签字」的第 14 键，
供 §3① 角色化合同预留。二轮 Opus 正门审阅判定该键为 P2：纯判别模块（`attendanceSetupReadiness.ts`）
对它零消费（正门实证），本质是为 W4-1 角色化显示做的前瞻投机，未经 owner 请示扩形——与冻结库存
`deploymentScopedSignals` 同类。**已移除**：响应回到锁 §4.2 的 13 键恒等（后端 + FE 类型镜像同步），
键集锁定测试（unit + 真库）同步改为断言 13 键、不再是「13+1」。W4-1 若确需 viewer 角色信号，由其自行
向 owner 请示扩形，本 PR 不再在代码里留 TODO 式投机。

## 三镜（trilens）review 吸收（修复轮，本次追加提交）

对本 PR head 的独立三镜代码审跑出 17 条 findings（P2×5、P3×12，含跨镜重复计次）。逐条处置：

**代码修复（8 类，覆盖 12 条 findings）**：
- **§4.2 perStep 嵌套**（P2）：锁原文 `perStep.effectiveTime: {source,posture,effectiveAt?}` 按字面
  应为嵌套形，PR body 原自述与代码（扁平 `perStep[stepId]={source,posture,...}`）不一致——已改为
  `perStep[stepId] = {effectiveTime: {...}}`，前后端镜像同步（`AttendanceSetupReadinessAggregate.ts`
  新增 `AttendanceSetupReadinessPerStepEntry`/`ATTENDANCE_SETUP_READINESS_PER_STEP`；FE 同名类型 +
  `stepMeta()` 改读 `.effectiveTime`），单测/FE spec 断言同步更新为嵌套形状。
- **§3.2 scope 标记落地 FE**（P2）：锁「每信号携带 `scope: 'org'|'deployment'`」此前只有后端 wire 级
  注记常量、FE 判别矩阵行无该字段。新增 FE 导出 `ATTENDANCE_SETUP_STEP_SCOPE` 登记表（④⑥=deployment，
  余下=org）并给 `AttendanceSetupReadinessStepResult` 加 `scope` 字段（含 forbidden/db_not_ready 折叠
  态），FE spec 新增 3 条断言。
- **§9 W4-0-G3 正控 1 补全**（P2）：纯本地组织用例此前只 seed 了 membership，无法观测 previewReady，
  真库对 `previewReady && directoryLinked` 式误接的变异体不会翻红。已补 group/member/shift/flow 全
  ①②③⑤ 夹具并断言 `previewReady===true`（`directoryLinked` 仍 `false`）。
- **RD-3 双 is_active 审计真库覆盖**（P2）：`users.is_active=false` 腿此前只有单测源码文本正则覆盖，
  真库审计 0 覆盖（`seedMembership` 硬编码 `seedUser(userId, true)`）。`seedMembership` 新增
  `userIsActive` 参数，真库审计夹具新增一名 `user_orgs.is_active=true` 但 `users.is_active=false` 的
  成员并保持计数断言（仍 2，两类失活成员均排除）。
- **§4.5(ii) 收件人绑定信号 provider 泛化**（P3）：`orgRecipientBinding` 此前把两个 join 腿都钉死
  `provider='dingtalk'`；锁真源本身点名「企微同型」（`AttendanceNotificationDeliveryWorker.ts` WeCom
  channel 用完全相同的三表 join 形状）。改为 `a.provider IN ('dingtalk','wecom')` +
  `i.provider = a.provider`，纯企微部署的组织不再误报零绑定。
- **§4.5(ii) NULL/重复 local_user_id 过计**（P3）：同一函数此前未过滤 `local_user_id IS NULL`（不可
  被 `resolveRecipient` 解析的绑定）也未去重（同一本地用户的多条绑定，worker 自身判为数据完整性异常
  态）。加 `AND l.local_user_id IS NOT NULL` + `COUNT(DISTINCT l.local_user_id)`；真库/单测夹具同步补
  上真实 `local_user_id`（此前留 NULL）。
- **§9 W4-0-G2 route 文件腿加固**（P3×2 重复计次）：路由文件的负向元断言此前只匹配反引号剥离形
  `.startsWith(``)`，重引入单引号/`toUpperCase()` 形态的首词守卫可绕过；已与聚合模块腿同等严格（全
  面禁 `.startsWith(`/`toUpperCase()`），验证 head 路由文件剥离后确无合法命中（无误报）。
- **真库 sentinel 移出 gate**（P3×2 重复计次）：sentinel 此前位于 `describeIfDatabase` 内部，
  `DATABASE_URL` 缺失时随整块 skip、结构性不可能翻红（装饰性守卫）。移到模块顶层、`describeIfDatabase`
  之外，成为该 lane 真正的 fail-closed 防线。
- **§4.2 键集契约测试名**（P3）：单测名原称「the exact §4.2-locked key set」但实际锁定的是 §4.2 +
  一个未在锁列出的键——已改名并加注释区分「§4.2 锁定 13 键」与「披露中、待签字的第 14 键」。

**文档化 / N/A-by-construction 登记（1 条）**：
- **§4.5「缺 port 仍 200+unknown」契约测试腿**（P3）：`getSharedAttendanceScheduler` 是本模块唯一、
  非条件导入路径，今天没有可模拟「port 缺失」的运行期状态——单测文件新增显式 N/A-by-construction 注
  释登记该结论，而非静默略过锁点名的第二项契约测试。

**披露但暂不作代码改动 / deferred-to-gate（4 条，含跨镜重复计次）**：
- **`viewerIsPlatformAdmin` 超出 §4.2 精确键集**（P2 + P3×2，共 3 条重复计次）：锁 §4.2「响应键集合
  恒等锁定」与 §3①「角色化合同（W4-1 强制，需要 viewer 角色数据）」两条已 ratify 条款之间存在真实张
  力——删掉该字段等同单方面替 owner 裁决（本线纪律不许），保留亦未获 owner 就键集本身的明确签字。
  处置：**保留字段**（不悄悄丢弃一个已 ratify 条款依赖的数据），响应接口文档注释与本 PR body 均已改
  措辞为「披露中、待下一次门审明确签字」，不再自称「预授权」；契约测试名同步改为不再断言「exact」。
- **④ 闭集默认值镜像的值域漂移风险**（P3×2，跨镜重复计次）：`ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT`
  是插件 `DEFAULT_SETTINGS` 闭集默认值的独立字面拷贝，G5 对账测试只锁键名不锁值——若插件侧默认值漂移，
  该镜像会误判 default→customized 或反之。**已在代码注释内披露（KNOWN DRIFT RISK）**；advisory 信号，
  不影响 `previewReady`；未在本轮改动（从 live 源文本解析嵌套对象字面值的对账测试比键名对账复杂得多，
  与本轮 P3 严重度不成比例），登记为下一次门审待办。
- **④ posture 查询 catch-all 掩盖共享只读事务内的 DB 级错误**（P3）：`readAttendancePunchPolicyPosture`
  的 `catch { return 'unknown' }` 会把（罕见场景：`system_configs` 缺失但其余考勤表健在时的）42P01
  吞成 `'unknown'`，而共享 `READ ONLY` 事务已因此中止，后续 `orgRecipientBinding` 查询会以 25P02
  失败，`isDatabaseSchemaError` 不识别该错误码，端点误报泛化 500 而非更准确的 503
  `DB_NOT_READY`。**常规「考勤表全缺」场景仍正确 503**（counts 腿先于 posture 腿抛出可识别的 42P01）；
  值域仍 values-free，仅错误档精度受影响。修复需要重构 `Promise.all` 四腿共享同一只读事务的错误传播
  顺序，与 P3 严重度不成比例的结构性改动——登记为下一次门审待办，未在本轮改动。

## §9 W4-0-G1..G5 checklist（证据）

| 门 | 状态 | 证据 |
|---|---|---|
| G1 用例1（受托管理员 orgId=A ⇒ 200） | ✅ | `attendance-setup-readiness-w4-0.db.test.ts` "case 1" |
| G1 用例2（受托管理员伪造 orgId=B ⇒ 403，聚合 SQL 前拦截） | ✅ | 同文件 "case 2"：`expect(transactionMock).not.toHaveBeenCalled()` + `queryMock` 仅 1 次（`user_orgs` 门） |
| G1 用例3（平台 admin 单列标注旁路，不替代用例2） | ✅ | 同文件 "case 3"：测试名与注释显式声明「不证明 org 门存在」 |
| G2 用例1（裸 UPDATE 被拒） | ✅ | 同文件 G2 describe："rejects a bare UPDATE" — 真 Postgres `read-only transaction` 错误 |
| G2 用例2（writable CTE 被拒） | ✅ | "rejects a writable CTE" |
| G2 用例3（多语句 `SELECT;DELETE` 被拒） | ✅ | "rejects a multi-statement batch" |
| G2 负向元断言（禁首词/正则只读校验） | ✅ | 单测 `attendance-admin-setup-readiness-w4-0.test.ts` "negative meta-assertion" describe：对服务模块与路由文件源码剥离注释/字符串后 grep `.startsWith(`/`toUpperCase()` 均无命中 |
| G3 两正控（纯本地 org / 钉钉已联通 org） | ✅ | 同 db.test.ts "G3" describe，两用例分别断言 `directoryLinked=false/true`，① 均 `orgActiveMemberCount>0` |
| G4 三信号不塌缩 | ✅ | "G4" describe：`notify` 恒三字段；`ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED=true`+调度器未启动⇒`not_ready`；调度器已启动⇒`unknown`；`recipientScopeConfig`恒`unsupported`；`previewReady`在所有组合下均 `true` |
| G5 常量对账 | ✅ | 单测 "G5" describe：解析**活文件** `plugins/plugin-attendance/index.cjs` 的 `DEFAULT_SETTINGS` 顶层键文本，断言 IN∪OUT 恒等（非硬编码镜像自证） |
| G5 正控（`unscheduled.mode`/`ipAllowlist`变化⇒customized） | ✅ | db.test.ts "G5" describe + 单测同名 |
| G5 负控（`holidaySync.lastRun`/`annualLeavePolicy`独立变化⇒仍 default） | ✅ | 同上，两条独立负控用例 |
| G5 default 判别 = `manual_review_required`（非 ready） | ✅ | FE spec 步④："default -> manual_review_required (errata...)" |
| 三视口门 | N/A（W4-0 无 UI，owner 追加门禁5，本切片仅纯模块+端点） | — |

## reportLedger（材料库逐项处置）

| 项 | 处置 | 说明 |
|---|---|---|
| 授权先于聚合 SQL 结构（route 先 `canReadAttendanceDirectoryReadiness` 再聚合） | re-ported-verified | 骨架沿用，真库+单测两级验证「零聚合 SQL/事务」 |
| CTE org_id 审计骨架 | re-ported-verified | 6 腿扩为 7 腿（新增 `scheduled_shift_group_scope`），负控/真库计数扩充 |
| 两组织矩阵（G1 身份重写） | re-ported-verified | 身份改写为「仅 attendance:admin + A org active member + 非 B 成员 + 无平台 admin 声明」，新增用例3单列标注 |
| CI 双点接线骨架（plugin-tests.yml 显式文件 + vitest.config.ts exclude） | re-ported-verified | 沿用命名/位置惯例，插入点相邻 w4pre1d 条目之后 |
| FE 纯模块 + spec 骨架（判别函数结构、鉴别输入 union） | rebuilt | 值域从 5 值扩为 7 值；previewReady 从「① 6 步」改为「①②③⑤」；④映射 default→ready 推翻为 manual_review_required；⑥从 4 平铺字段改 3 独立信号且不合并 |
| seam（只读证明） | rebuilt | `assertSelectOnlyReadinessSql` 前缀方案（已被判死）**未 re-port**；改为真 `SET TRANSACTION READ ONLY` 事务 |
| ④ 判别映射 | rebuilt | 见上 |
| ⑥ 形状（§4.5 三信号） | rebuilt | 删除 `workerEnabled`/`defaultChannelAvailable`/`availableChannelCount`/`orgRecipientBindingReady` 四平铺字段；新三信号 `deliveryRuntime`/`orgRecipientBinding`/`recipientScopeConfig` |
| ③ 信号（新增） | new | `scheduledShiftGroupCount`/`activeRotationRuleCount`（`is_active` 过滤）/`step3Ready` |
| ⑦ 逻辑 | rebuilt | 从「全六步含④⑥」改为「仅①②③⑤」；消除冻结版 trilens NIT（步⑦ unknown 折叠 reason 恒定错标④来源——新设计下 previewReady 结构性排除④⑥，该类 bug 不可能重现） |
| §4.2 响应键集 | rebuilt | 移除冻结版新增的 `deploymentScopedSignals` 顶层键与 `perStep.step`/`perStep.scope`（trilens P2 已判定为未经请示的形状偏离）；`viewerIsPlatformAdmin` 作为唯一披露中新增键，见上方专节；`perStep` 修复轮改为按锁字面嵌套 `{effectiveTime}` |
| ④ system_configs 读取兼容性 | new | trilens 镜头 C 的 038-JSONB P3 finding 吸收：`typeof raw==='object'?raw:JSON.parse(raw)` |
| 真库 sentinel 反模式 | re-ported（修复轮加固） | 冻结版内 `describeIfDatabase` 内的自我禁用 sentinel（镜头 B P3：结构性不可能触发）本 PR 首版原样重现了同一结构性缺陷（逐字节相同）；修复轮已移出 `describeIfDatabase`（模块顶层），成为真正 fail-closed 的第四道防线（叠加既有 CI 显式文件列表 + `vitest.config.ts` exclude 两点接线） |
| G1 用例3（平台 admin 单列标注） | new | 冻结版无此单列标注对照，本实现新增并显式注释「不替代用例2」 |

## 测试实跑（本地，全部对 origin/main 头 7a64424d1 之上的本分支跑）

- 后端 unit（`vitest run`）：`attendance-admin-setup-readiness-w4-0.test.ts` **46/46 通过**；连同既有
  `attendance-admin-directory-readiness-s7-5.test.ts` **11/11 通过**（无回归）。
- 后端真库集成（`vitest --config vitest.integration.config.ts run`，`DATABASE_URL` 指向本地
  `postgres@127.0.0.1:5432/metasheet_test`，先跑 `pnpm --filter @metasheet/core-backend db:migrate`
  同 CI `MIGRATION_EXCLUDE` 清单对齐现势）：`attendance-setup-readiness-w4-0.db.test.ts`
  **23/23 通过**；夹具残留核验（直接 psql 查询 `user_orgs`/`users`/`attendance_groups`/
  `directory_integrations` 按 `w40_%` 前缀，均 0 行；`system_configs.attendance.settings`
  正确 snapshot/restore 回原值，非新增残留）。
- 后端 attendance 域回归（同一真库，`plugin-tests.yml`「Run attendance integration tests」步的
  attendance 子集，31 个既有文件 + 本 PR 新文件）：**32 文件 / 460 测试全通过**，含 S7-1..S7-4、
  W4-PRE-1/1b/1c/1d 全链、通知重投递。
- 前端 spec（`vitest run`）：`attendance-setup-readiness.spec.ts` **33/33 通过**。
- 前端 attendance-web-guard 完整 run-list（含新 spec）：**30 文件 / 601 测试全通过**。
- 双 typecheck：`pnpm --filter @metasheet/core-backend run type-check`（`tsc --noEmit`）0 错误；
  `pnpm --filter @metasheet/web run type-check`（`vue-tsc -b`）0 错误。

## 修复轮测试实跑（本地，`postgres@127.0.0.1:5432/metasheet_test`，头 `c32f62dec`）

- 后端 unit：`attendance-admin-setup-readiness-w4-0.test.ts` **46/46 通过**；
  `attendance-admin-directory-readiness-s7-5.test.ts`（共享 `canReadAttendanceDirectoryReadiness`）
  **11/11 通过**（无回归）。
- 后端真库集成：`attendance-setup-readiness-w4-0.db.test.ts` **23/23 通过**；
  `attendance-notification-deliveries.test.ts`（§4.5(ii) provider 泛化改动的相邻真源表）
  **10/10 通过**。
- 前端 spec：`attendance-setup-readiness.spec.ts` **36/36 通过**（33 既有 + 3 条新 scope 断言）；
  `attendance-web-guard.yml` 完整 run-list（30 文件，含新 spec）：**604/604 通过**。
- 双 typecheck：均 0 错误（同上命令）。
- 更广的 attendance 域真库回归（`plugin-tests.yml`「Run attendance integration tests」步的
  attendance 子集 32 文件，排除本轮未触碰的 multitable/files/stock-prep 条目）：**30/32 文件通过**；
  `attendance-plugin.test.ts`/`attendance-schedule-dispatch.test.ts` 2 文件共 18 个用例失败
  （`SHIFT_COMPLIANCE_CAP_EXCEEDED capMinutes:1`），经 `git stash` A/B 双跑核实：**在未应用本轮任何
  改动的 head 上原样复现相同失败**（`attendance-plugin.test.ts` 内部跨用例 `system_configs` 状态未
  完全隔离，向后污染本地共享测试库），与本轮 diff 无关，非本轮引入的回归。

## 修复轮 mutation 自检（2 刀，先 commit `c32f62dec` 后 mutate；①用补丁精确插入/移除，②用
`git checkout -- <file>` 对单文件精确还原——mutate 前无其它未提交改动，安全）

| # | 靶 | 变异 | 翻红证据 | 已还原 |
|---|---|---|---|---|
| ① | §9 W4-0-G2 route 文件负向元断言 | 在 `attendance-admin.ts` 内重新插入 `sql.trim().toUpperCase().startsWith('SELECT')` 形态的首词守卫 | 单测「the route file contains no prefix/regex...」精确翻红（`expect(code).not.toMatch(/\.startsWith\(/)` 失败） | ✅ |
| ② | §4.5(ii) provider 泛化 + NULL/DISTINCT | `AttendanceSetupReadinessAggregate.ts` 的 `readAttendanceSetupReadinessOrgRecipientBinding` SQL 还原为冻结前的 `provider='dingtalk'`/`COUNT(*)`/无 `local_user_id IS NOT NULL` 形态 | 单测「orgRecipientBinding: org-scoped join covering BOTH wired channels...」精确翻红（SQL 文本断言不再匹配 `provider IN ('dingtalk','wecom')`） | ✅ |

## 首版 mutation 自检（4 刀，均先 commit 后 mutate，`git checkout -- <file>` 精确还原，还原后 typecheck 复核干净）

| # | 靶 | 变异 | 翻红证据 | 已还原 |
|---|---|---|---|---|
| ① | 授权顺序 | 聚合调用挪到 `canReadAttendanceDirectoryReadiness` 之前 | 单测「403 ... issues ZERO aggregation」+ 真库「case 2」均从「0 次调用」翻为「1 次调用」精确翻红 | ✅ |
| ② | 只读事务 | `runAttendanceSetupReadinessReadOnly` 内移除 `SET TRANSACTION READ ONLY` | 真库 G2 三条拒绝用例（裸 UPDATE / writable CTE / 多语句）全部从「拒绝」变「静默成功」翻红（`rejects.toThrow` 断言失败，`promise resolved undefined`） | ✅ |
| ③ | ④ default 映射 | FE 判别改为 `unknown→unknown` 外恒 `ready`（含 default） | FE spec「default -> manual_review_required」+「全值域覆盖」两条断言翻红 | ✅ |
| ④ | ⑥ 三信号塌缩 | `deliveryRuntime` 改依赖 `orgRecipientBinding.hasAnyBoundRecipient`（折叠两信号） | 真库 G4 两条用例（调度器未启动/已启动）均翻红（`ready` vs 期望 `not_ready`/`unknown`） | ✅ |

## 二轮 Opus 正门审阅吸收（本次追加提交，head `ede4d4fc7`）

对本 PR 一轮修复后的 head（`c32f62dec`）跑独立 Opus 对抗正门审：G1-G5 全 pass、11/11 mutation killed，
verdict = REQUEST_CHANGES（0P1 / 1P2 / 2P3）。三项均在本轮处理，**未留待第三轮**：

| # | 级别 | Finding | 处置 |
|---|---|---|---|
| P2 | 键集恒等 | `viewerIsPlatformAdmin` 第 14 顶层键破坏锁 §4.2 键集恒等——纯判别模块零消费，属未经请示的前瞻投机 | **移除**该键（后端响应 + FE 类型镜像 + 两处键集锁定测试改回 13 键）；见上方「§4.2 键集偏离说明」二轮更新 |
| P3-1 | 事务健壮性 | ④ 探测 `readAttendancePunchPolicyPosture` 的 catch-all 吞掉 42P01 后共享只读事务已 abort，后续 `orgRecipientBinding` 查询报 25P02，端点误报 500/503（而非「④=unknown，其余正常，200」） | ④ 探测包 **SAVEPOINT**：失败时 `ROLLBACK TO SAVEPOINT` 保事务存活，posture fail-closed 到 `unknown`；成功时 `RELEASE SAVEPOINT`。新增真库负例：`ALTER TABLE system_configs RENAME`（非 DROP+CREATE——`system_configs` 也被 `ConfigService` 读取，rename 是原子瞬时操作，`finally` 恒复原，零 DDL 保真度风险）模拟真实 42P01，断言端点仍 200、④=`unknown`、其余全部信号 `toEqual` 精确匹配（含 `perStep`/`notify`/`previewReady`） |
| P3-2 | 对账精度 | G5 常量对账（`ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT` vs 插件 `DEFAULT_SETTINGS`）只锁键名，不锁值——插件侧默认值漂移时无测试覆盖 | 新增值级对账测试：用与既有键名对账**同法**（brace-depth 扫描）解析插件源文本四个闭集键各自的字面值文本，`new Function(...)` 求值后与导出的 `ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT` 逐值 `toEqual`；任一侧漂移即翻红 |

**测试实跑（本地，`postgres@127.0.0.1:5432`，头 `ede4d4fc7`）**：
- 后端 unit：`attendance-admin-setup-readiness-w4-0.test.ts` **48/48 通过**（含 P3-1 新增 4 条
  SAVEPOINT/ROLLBACK 行为断言 + P3-2 新增 1 条值级对账断言，较一轮的 46 条净增 2 条为整理去重后的净值）。
- 后端真库集成：`attendance-setup-readiness-w4-0.db.test.ts` **24/24 通过**（较一轮 23 条 +1 条 P3-1
  真库负例）；相邻真库文件（`attendance-w4pre1-user-orgs-policy.db.test.ts`、
  `attendance-notification-redelivery-route.db.test.ts`，均 import 自 `attendance-admin.ts`）
  **11/11 通过**（无回归）。
- 前端 spec：`attendance-setup-readiness.spec.ts` **36/36 通过**。
- 双 typecheck：`packages/core-backend`（`tsc --noEmit`）与 `apps/web`（`vue-tsc -b`）均 0 错误。
- 表恢复核验：P3-1 负例的 `finally` 块在测试**失败态**（mutation 自检期间）与**通过态**下均正确将
  `system_configs` rename 回原名（`\dt system_configs` 核实），未在共享真库上留下残留改名。

**二轮 mutation 自检（3 刀，均先 `git commit` 后 mutate，`git checkout -- <file>` 精确还原）**：

| # | 靶 | 变异 | 翻红证据 | 已还原 |
|---|---|---|---|---|
| ① | P2 键集恒等（unit） | 响应对象重新插入 `viewerIsPlatformAdmin: false` | 单测「13-key set EXACTLY」精确翻红（`Object.keys` diff 多出该键） | ✅ |
| ①b | P2 键集恒等（db 侧，独立复核） | 同一变异，改跑**整个** `attendance-setup-readiness-w4-0.db.test.ts`（24 用例） | 23/24 通过，仅 P3-1 负例的全量 `toEqual` 精确翻红（diff 多出 `viewerIsPlatformAdmin: false`）——db 侧**没有专门的键集锁断言**，13 键恒等目前由 P3-1 负例的全量 body `toEqual` 顺带把关；如后续把该断言弱化为 `toMatchObject` 会静默丢失这一 db 侧判别力，留意 | ✅ |
| ② | P3-1 SAVEPOINT | `readAttendancePunchPolicyPosture` 还原为裸 `try/catch`（移除 SAVEPOINT/RELEASE/ROLLBACK） | 单测 5/6 条 SAVEPOINT 相关断言翻红 + 真库新负例从 200 翻为 **500**（`expected 500 to be 200`） | ✅ |
| ③ | P3-2 值级对账 | `ATTENDANCE_PUNCH_POLICY_CLOSED_SET_DEFAULT.minPunchIntervalMinutes` 由 `1` 改为 `5`（不同步插件源） | 新值级对账测试精确翻红（`minPunchIntervalMinutes: 5` vs 插件源解析出的 `1`） | ✅ |

三项处置均**在本轮代码层面解决**，不再是「披露但未决」——下方「剩余项」章节已相应更新（原「修复轮新增
待办」1-3 项标记为已解决）。①b 每次变异后表恢复均已核实（`\dt system_configs`），失败态/通过态均正确
`finally` 复原。

## CI 接线

- `plugin-tests.yml`「Run attendance integration tests」步：`tests/integration/attendance-setup-readiness-w4-0.db.test.ts` 显式列出（紧随 `attendance-w4pre1d-departure-candidate-split.db.test.ts` 之后）。
- `packages/core-backend/vitest.config.ts`：同文件加入 `exclude` 列表，附与既有条目同款注释（防 no-DB 任务
  skip-shaped-green）。`vitest.integration.config.ts` 无需改动——其 include glob
  `tests/integration/**/*.{test,spec}.?(c|m)[jt]s?(x)` 已覆盖新文件名（已核实）。
- `attendance-web-guard.yml`：`attendance-setup-readiness.spec.ts` 加入 run-list 命令行 + **两处**
  `paths:` 过滤块（`pull_request` 与 `push` 均已核对，非仅一处）。

## §11.1 六项记录

1. **基线 SHA**：`origin/main` `7a64424d1`（W4 re-ratify PR #4522 合入 head，本分支起点，2026-07-22）。
2. **查重**：`git fetch origin main` + `git log --oneline -20` 核对 W4 re-ratify commit 在列；
   `gh pr list --search "w4-0 OR setup-readiness"` 确认唯一相关历史 PR #4514 **CLOSED 未合并**；
   全仓 `git grep setup-readiness|setupReadiness|SetupReadiness` 在 `origin/main` 上 0 命中（本 PR 前）；
   `git worktree list` 未见任何在飞的 W4-0 worktree。
3. **修改文件**：见本 PR diff（9 文件，2 新增源码 + 1 新增单测 + 1 新增真库测试 + 3 CI/config 接线 +
   1 前端模块 + 1 前端 spec）。未来切片碰撞车道：`AttendanceView.vue`（W4-1/W4-2 会碰，本片未触碰）。
4. **IN/OUT**：本片 = W4-0（§2 IN 范围「七步 readiness 聚合读端点 + 纯逻辑模块」）；W4-1（向导壳/导航）
   与 W4-2（模板预填+⑦预览 UI）显式 OUT，未开工，未触碰 `AttendanceView.vue`。
5. **权威数据源/唯一写路径/权限真源**：readiness 真源 = `setup-readiness` 聚合（各计数 SQL 单点，见映射
   表）；本切片零写路径（端点全程只读事务，无 mutation 语句）；权限真源 = router 级 `rbacGuard` +
   `canReadAttendanceDirectoryReadiness`（S7-5 复用）。
6. **完成门与 mutation 目标**：见上方 G1-G5 checklist 与 mutation 自检表；Opus 对抗审尚未跑（本 PR 提交
   后由 owner/审阅流程安排，任务书未要求本轮自跑对抗审）。

## 偏离

修复轮：见上方「三镜（trilens）review 吸收」小节——8 类代码修复 + 1 处文档化登记 + 4 条披露-但-未改动
（deferred-to-gate，两项为跨镜重复计次后的 2 个独立技术点：`viewerIsPlatformAdmin` 键集张力、④ 闭集
默认值漂移风险、④ posture 查询 catch-all 错误码精度）。首版原计划的 4 项材料复用/重建划分与实际
reportLedger 一致，未发现需要新增的偏离项。

## 剩余项（如实）

- Opus/独立对抗审尚未运行——按本仓惯例由后续审阅流程执行，非本 PR 范围内自证。
- 章程/锁均要求 W4-0/W4-1/W4-2 严格串行；本 PR 只完成 W4-0，**不推进 W4-1/W4-2**。
- 三视口视觉证据 N/A（W4-0 无 UI，owner 追加门禁5 显式排除）。
- 冻结分支 `claude/w4-0-setup-readiness-20260721` 与其 PR #4514 保持不变（只读参照，未合并/未关闭/未新开
  PR，处置属 owner 决定）。
- 顺手发现（非本 PR 范围，仅如实记录）：`attendance-w4pre1d-departure-candidate-split.db.test.ts`
  （#4534 引入）在 `plugin-tests.yml` 有显式接线，但似缺失 `packages/core-backend/vitest.config.ts` 的
  对应 `exclude` 条目——本 PR 未touch该文件，留 owner/后续 PR 核实是否为遗留缺口。
- ~~**修复轮新增待办（owner 门审决定）**~~ **已在二轮全部解决**（见上方「二轮 Opus 正门审阅吸收」）：
  1. ~~`viewerIsPlatformAdmin` 是否正式纳入 §4.2 键集~~ → **已移除**，键集回到锁定 13 键恒等，不再
     是待裁决项；W4-1 若需角色信号，走独立 owner 请示，不在本 PR 遗留投机代码。
  2. ~~④ 闭集默认值镜像值域对账仅锁键名不锁值~~ → **已补值级对账测试**（同法解析插件源文本 + 逐值
     `toEqual`），`KNOWN DRIFT RISK` 注释相应更新为「已由 P3-2 测试闭合」。
  3. ~~`readAttendancePunchPolicyPosture` 的 `catch-all` 在共享只读事务下把 503 误报为泛化 500~~ →
     **已加 SAVEPOINT/ROLLBACK TO SAVEPOINT**，罕见场景现在正确 fail-closed 为「④=unknown，端点
     200」而非误报，真库负例已覆盖。
- 顺手发现（非本 PR 范围，修复轮观测）：本地共享真库 `metasheet_test` 的 `attendance-plugin.test.ts`
  存在跨用例 `system_configs`（`shiftCompliance`）状态未完全隔离的问题，会向后污染同进程内运行的
  `attendance-schedule-dispatch.test.ts`；已用 `git stash` 双跑确认与本 PR diff 无关（pre-existing），
  留 owner/后续 PR 视情核实是否也在 CI 共享库场景重现。

## 本 PR 状态

**不合并、不 arm、不开 W4-1**。等待 owner/审阅流程处置。

---
refs #4522（W4 re-ratify，本锁授权来源）


