### PR TITLE
chore(test): w4pre1d departure db test — 补 vitest.config.ts exclude(双点接线缺失的第二点)

### DIFF
--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -404,6 +404,11 @@ export default defineConfig({
       // readiness-gate + DingTalk destination permission negatives (case ⑤). DATABASE_URL-gated
       // describeIfDatabase; excluded here so the no-DB job cannot skip-green them; wired
       // whole-file into the attendance real-DB step in plugin-tests.yml.
+      // W4-PRE-1d (owner candidate-set split, #4534): real-DB dual-integration departure matrix.
+      // DATABASE_URL-gated describeIfDatabase; excluded here so the no-DB job cannot skip-green it;
+      // wired whole-file into the attendance real-DB step in plugin-tests.yml (two-point wiring —
+      // this exclude line was the missing second point, caught by the W4 wave-MD pre-review).
+      'tests/integration/attendance-w4pre1d-departure-candidate-split.db.test.ts',
       'tests/integration/attendance-w4pre1c-departure-sweep-deprovision.db.test.ts',
       'tests/integration/attendance-w4pre1c-departure-org-scoped.db.test.ts',
       'tests/integration/attendance-w4pre1c-manual-review-pending.db.test.ts',


### PR DESCRIPTION
W4 波次验证 MD 预审(#4544 c-5052904294)确证:`attendance-w4pre1d-departure-candidate-split.db.test.ts` 在 plugin-tests.yml:842 有接线但 vitest.config.ts 缺 exclude——no-DB 默认 job 会收集并 skip-green 其 describeIfDatabase 块。本 PR 补上第二点,与 attendance 步其余 .db.test.ts 形制一致。一行清单变更+注释,零行为改动。

refs #4534 #4544

🤖 Generated with [Claude Code](https://claude.com/claude-code)