### PR TITLE
fix(directory): T2 lock-correctness — canonical UUID lock key + explicit READ COMMITTED for freeze-lock txns

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -728,6 +728,7 @@ jobs:
             tests/integration/directory-tenant-change-immutable.db.test.ts \
             tests/integration/directory-sync-orchestration.db.test.ts \
             tests/integration/directory-org-transfer-source-freeze.db.test.ts \
+            tests/integration/directory-source-freeze-lock-correctness.db.test.ts \
             tests/integration/directory-account-external-key-collision-mechanism.db.test.ts \
             tests/integration/directory-sync-schedule-timezone.db.test.ts \
             tests/integration/directory-local-provider-bootstrap.db.test.ts \

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -3493,7 +3493,7 @@ async function claimDirectorySyncRun(
 }
 
 export async function syncDirectoryIntegration(
-  integrationId: string,
+  rawIntegrationId: string,
   triggeredBy: string,
   triggerSource: 'manual' | 'scheduler' = 'manual',
   /**
@@ -3508,8 +3508,18 @@ export async function syncDirectoryIntegration(
   autoAdmissionOnboardingPackets: DirectoryAutoAdmissionOnboardingPacket[]
 }> {
   const governedUserIds = new Set<string>()
-  const integration = await getIntegrationRow(integrationId)
+  const integration = await getIntegrationRow(rawIntegrationId)
   if (!integration) throw new Error('Directory integration not found')
+  // T2 lock-correctness P1: the manual-sync route passes req.params.integrationId VERBATIM
+  // (admin-directory.ts). `directory_integrations.id` is a uuid column, so a case-variant
+  // (e.g. uppercase) id still resolves THIS row via uuid casting — but the shared source
+  // freeze advisory lock hashes the RAW TEXT key (`hashtext(sourceSyncFreezeLockKey(id))`),
+  // so an uppercase caller would hash a DIFFERENT lock key than the transfer side's
+  // DB-canonical `source.id` and silently lose sync↔freeze mutual exclusion (a freeze
+  // committing after the entry check could race this sync's local apply). Canonicalize to
+  // the DB-read-back id here, and use it for EVERYTHING downstream: entry freeze check,
+  // stale-run reclaim, run-lease claim, apply-txn lock, under-lock recheck, and every write.
+  const integrationId = integration.id
 
   const config = parseIntegrationConfig(integration)
   // T2 (§12.2): cheap freeze gate BEFORE the lease claim — a freeze already active at entry
@@ -3596,7 +3606,18 @@ export async function syncDirectoryIntegration(
     const autoAdmissionOnboardingPackets: DirectoryAutoAdmissionOnboardingPacket[] = []
 
     await transaction(async (client) => {
-      // T2 P1: shared source freeze lock is the FIRST operation of the local-apply transaction.
+      // T2 lock-correctness P2 (PB4-3 idiom — see local-directory-org.ts's reparent guard): the
+      // pool wrapper issues a bare BEGIN, so on a deployment where default_transaction_isolation
+      // is 'repeatable read' this transaction's snapshot would be taken by the
+      // pg_advisory_xact_lock SELECT itself — BEFORE the lock is granted — and the post-lock
+      // freeze recheck below would read a pre-freeze snapshot, missing a freeze that committed
+      // while we waited on the lock. Pin READ COMMITTED as the FIRST statement (SET TRANSACTION
+      // must precede the transaction's first query) so the recheck takes a fresh per-statement
+      // snapshot. Under the production RC default this is a no-op; its mechanism is proven in
+      // directory-source-freeze-lock-correctness.db.test.ts (RR-default pool harness).
+      await client.query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED')
+      // T2 P1: shared source freeze lock is the first REAL operation of the local-apply
+      // transaction (nothing but the isolation pin above may precede it).
       // Transfer create / freeze=true refreeze take the same key before writing freeze state.
       // Re-check under the lock before ANY directory upsert, absence sweep, membership rewrite,
       // identity/link write, local-user admission, group projection, deprovision, integration

--- a/packages/core-backend/src/directory/org-transfer-service.ts
+++ b/packages/core-backend/src/directory/org-transfer-service.ts
@@ -271,6 +271,12 @@ export async function createOrgTransfer(input: CreateOrgTransferInput): Promise<
     // pass its apply-time recheck and commit directory writes after this freeze becomes active.
     // Default freeze_source_sync=true on the row makes create itself a freeze activation.
     return await transaction(async (client) => {
+      // T2 lock-correctness P2 (PB4-3 idiom): the pool wrapper issues a bare BEGIN, so under a
+      // repeatable-read default_transaction_isolation this transaction's snapshot would be
+      // frozen by the lock-acquisition SELECT itself, before the lock is granted. Freeze
+      // writers pin READ COMMITTED as the first statement — same as the sync local-apply
+      // side — so post-lock reads observe state committed while waiting on the shared key.
+      await client.query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED')
       await acquireSourceSyncFreezeLock(client, source.id)
       const inserted = await client.query(
         `INSERT INTO provider_org_transfers
@@ -498,6 +504,11 @@ export async function setOrgTransferSourceSyncFreeze(
   freezeSourceSync: boolean
 ): Promise<OrgTransferSummary> {
   return transaction(async (client) => {
+    // T2 lock-correctness P2 (see createOrgTransfer): pin BEFORE the source probe — the probe
+    // is this transaction's first snapshot-taking query, and SET TRANSACTION ISOLATION LEVEL
+    // must precede it. Under a repeatable-read default the post-lock lockTransfer/UPDATE
+    // would otherwise run against a pre-lock snapshot.
+    await client.query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED')
     // Derive immutable source id first (no row lock yet) so the shared freeze lock is keyed
     // correctly before we serialize on the transfer row.
     const sourceProbe = await client.query(

--- a/packages/core-backend/tests/integration/directory-source-freeze-lock-correctness.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-source-freeze-lock-correctness.db.test.ts
@@ -1,0 +1,398 @@
+import { randomUUID } from 'crypto'
+import { Client } from 'pg'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+// T2 lock-correctness (owner order step 3) — canonical UUID lock key + explicit READ COMMITTED.
+//
+// [P1] The manual sync route passes RAW `req.params.integrationId` (admin-directory.ts) into
+// `syncDirectoryIntegration`. `directory_integrations.id` is a uuid COLUMN, so an uppercase
+// id still resolves the same row via uuid casting — but the shared source freeze advisory
+// lock hashes the RAW TEXT key (`hashtext('directory:source-sync-freeze:' || id)`), so an
+// uppercase caller hashed a DIFFERENT lock key than the transfer side's DB-canonical
+// `source.id` ⇒ sync and transfer lost mutual exclusion ⇒ a freeze committing after the
+// entry check could race sync's local apply. Fix: canonicalize to the DB-read-back
+// `integration.id` immediately after `getIntegrationRow` and use it for everything downstream.
+//
+// [P2] All generic pool transactions run a bare BEGIN (connection-pool.ts `transaction()`).
+// On a deployment where `default_transaction_isolation = 'repeatable read'`, the transaction
+// snapshot is taken by the `pg_advisory_xact_lock` SELECT itself — BEFORE the lock is granted
+// — so the post-lock freeze recheck reads a pre-freeze snapshot and misses a freeze that
+// committed while the sync waited on the lock. Fix (PB4-3 idiom, local-directory-org.ts):
+// `SET TRANSACTION ISOLATION LEVEL READ COMMITTED` as the first statement of the sync
+// local-apply transaction and of both transfer-side freeze-taking transactions.
+//
+// HARNESS: this file runs the ENTIRE service pool with the RR default (the P2 deployment
+// posture) by amending DATABASE_URL with `options=-c default_transaction_isolation=
+// repeatable\ read` inside vi.hoisted — which executes BEFORE the static imports below, i.e.
+// before the PoolManager (constructed at first import of the db module) reads DATABASE_URL.
+// vitest.integration.config.ts runs files in isolated forks with fileParallelism:false, so
+// the RR default cannot leak into any other suite. A sentinel test asserts the posture is
+// actually active (a silently-RC harness would make the pin tests vacuous).
+//
+// Mutation proofs (each independently reds this suite; exact signatures in PR body):
+//   (i) revert the P1 canonicalization (pass the raw route id to the freeze-lock/apply path)
+//       → the uppercase-caller test's waitUntilBlockedOnHolder times out (the sync never
+//       parks on the canonical key) and the absence sweep commits against a frozen source;
+//   (ii) drop the `SET TRANSACTION ISOLATION LEVEL READ COMMITTED` line from the sync
+//       local-apply transaction → the RR-barrier test's post-lock recheck misses the freeze
+//       committed while waiting: sync completes and sweeps the seeded account.
+//
+// DATABASE_URL-gated (describeIfDatabase): excluded from the no-DB vitest job so it cannot
+// skip-green, and wired as a WHOLE FILE into the directory real-DB step in plugin-tests.yml
+// (both points asserted by t2-source-freeze-ci-wiring.test.mjs).
+vi.hoisted(() => {
+  const base = process.env.DATABASE_URL
+  if (base) {
+    const sep = base.includes('?') ? '&' : '?'
+    // libpq `options`: spaces separate arguments unless backslash-escaped, hence the
+    // escaped space inside `repeatable\ read`.
+    process.env.DATABASE_URL = `${base}${sep}options=${encodeURIComponent(
+      '-c default_transaction_isolation=repeatable\\ read',
+    )}`
+  }
+})
+
+const clientMocks = vi.hoisted(() => ({
+  fetchDingTalkAppAccessToken: vi.fn(),
+  listDingTalkDepartments: vi.fn(),
+  getDingTalkDepartmentDetail: vi.fn(),
+  listDingTalkDepartmentUsers: vi.fn(),
+  getDingTalkUserDetail: vi.fn(),
+}))
+
+vi.mock('../../src/integrations/dingtalk/client', () => ({
+  fetchDingTalkAppAccessToken: clientMocks.fetchDingTalkAppAccessToken,
+  listDingTalkDepartments: clientMocks.listDingTalkDepartments,
+  getDingTalkDepartmentDetail: clientMocks.getDingTalkDepartmentDetail,
+  listDingTalkDepartmentUsers: clientMocks.listDingTalkDepartmentUsers,
+  getDingTalkUserDetail: clientMocks.getDingTalkUserDetail,
+}))
+
+import { query, transaction } from '../../src/db/pg'
+import {
+  createDirectoryIntegration,
+  DirectorySyncFrozenByTransferError,
+  syncDirectoryIntegration,
+} from '../../src/directory/directory-sync'
+import { createOrgTransfer } from '../../src/directory/org-transfer-service'
+import { sourceSyncFreezeLockKey } from '../../src/directory/source-sync-freeze-lock'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+/** Dedicated raw connection for barrier lock-holders — never from the service pool. */
+async function withHolder(fn: (holder: Client, holderPid: number) => Promise<void>): Promise<void> {
+  const holder = new Client({ connectionString: process.env.DATABASE_URL })
+  await holder.connect()
+  try {
+    const pidRow = await holder.query<{ pid: number }>('SELECT pg_backend_pid() AS pid')
+    await fn(holder, pidRow.rows[0].pid)
+  } finally {
+    try {
+      await holder.query('ROLLBACK')
+    } catch {
+      /* already closed / idle */
+    }
+    await holder.end()
+  }
+}
+
+/**
+ * Deterministic barrier: poll until at least one backend is blocked by the holder's pid
+ * (pg_blocking_pids). Proves the waiter is parked on the holder's lock — not a fixed sleep.
+ */
+async function waitUntilBlockedOnHolder(holderPid: number, timeoutMs = 8000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const r = await query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM pg_stat_activity
+        WHERE state = 'active'
+          AND wait_event_type = 'Lock'
+          AND $1 = ANY(pg_blocking_pids(pid))`,
+      [holderPid],
+    )
+    if ((r.rows[0]?.n ?? 0) >= 1) return
+    await new Promise((res) => setTimeout(res, 20))
+  }
+  throw new Error(
+    `timed out waiting for a backend blocked by holder pid ${holderPid} (source freeze lock never engaged)`,
+  )
+}
+
+/**
+ * SAME-KEY proof: while blocked, the waiter's ungranted advisory lock must carry the exact
+ * (classid, objid, objsubid) tuple of an advisory lock the holder has granted. This is the
+ * direct pg_locks witness that both sides contend on ONE advisory key.
+ */
+async function countWaitersOnHolderAdvisoryKey(holderPid: number): Promise<number> {
+  const r = await query<{ n: number }>(
+    `SELECT count(*)::int AS n
+       FROM pg_locks waiter
+       JOIN pg_locks held
+         ON held.locktype = 'advisory'
+        AND held.granted
+        AND held.pid = $1
+        AND waiter.locktype = 'advisory'
+        AND NOT waiter.granted
+        AND waiter.classid = held.classid
+        AND waiter.objid = held.objid
+        AND waiter.objsubid = held.objsubid`,
+    [holderPid],
+  )
+  return r.rows[0]?.n ?? 0
+}
+
+function settled<T>(p: Promise<T>): Promise<T | unknown> {
+  return p.then(
+    (v) => v,
+    (e) => e,
+  )
+}
+
+describeIfDatabase('T2 lock-correctness — canonical UUID lock key + READ COMMITTED pin (RR-default pool harness)', () => {
+  const cleanupTransferIds: string[] = []
+  const cleanupIntegrationIds: string[] = []
+
+  beforeAll(() => {
+    clientMocks.fetchDingTalkAppAccessToken.mockResolvedValue('t2-lkc-token')
+    // EMPTY tenant: every sync that is allowed to apply absence-sweeps everything — the
+    // destructive write whose (non-)occurrence is this suite's observable.
+    clientMocks.listDingTalkDepartments.mockResolvedValue([])
+    clientMocks.getDingTalkDepartmentDetail.mockResolvedValue({ deptManagerUserIdList: [] })
+    clientMocks.listDingTalkDepartmentUsers.mockResolvedValue({ users: [], nextCursor: null, hasMore: false })
+    clientMocks.getDingTalkUserDetail.mockRejectedValue(new Error('empty tenant — no user details expected'))
+  })
+
+  afterAll(async () => {
+    for (const id of cleanupTransferIds.splice(0)) await query(`DELETE FROM provider_org_transfers WHERE id = $1`, [id])
+    // integration delete cascades its departments/accounts/runs
+    for (const id of cleanupIntegrationIds.splice(0)) await query(`DELETE FROM directory_integrations WHERE id = $1`, [id])
+  })
+
+  async function seedIntegrationWithLiveAccount(tag: string): Promise<{ integrationId: string; accountId: string }> {
+    const integration = await createDirectoryIntegration({
+      name: `t2-lkc-${tag}-${TS}`,
+      corpId: `t2-lkc-corp-${tag}-${TS}`,
+      appKey: `t2-lkc-appkey-${tag}-${TS}`,
+      appSecret: 't2-lkc-secret',
+      admissionMode: 'manual_only',
+    })
+    cleanupIntegrationIds.push(integration.id)
+    // A previously-synced account: present in the DB, ABSENT from the (empty) mocked tenant —
+    // precisely what an allowed sync's absence sweep would mark inactive.
+    const account = await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, is_active, raw)
+       VALUES ($1, 'dingtalk', $2, $3, $4, true, '{}'::jsonb) RETURNING id`,
+      [integration.id, `t2-lkc-${tag}-user-${TS}`, `dingtalk:t2-lkc-${tag}-user-${TS}`, `T2 LKC ${tag}`],
+    )
+    return { integrationId: integration.id, accountId: account.rows[0].id }
+  }
+
+  async function createTransferRow(sourceId: string, targetId: string, freeze: boolean): Promise<string> {
+    const row = await query<{ id: string }>(
+      `INSERT INTO provider_org_transfers (org_id, provider, source_integration_id, target_integration_id, status, freeze_source_sync)
+       SELECT org_id, provider, $1, $2, 'draft', $3 FROM directory_integrations WHERE id = $1
+       RETURNING id`,
+      [sourceId, targetId, freeze],
+    )
+    const id = row.rows[0].id
+    cleanupTransferIds.push(id)
+    return id
+  }
+
+  async function accountActive(accountId: string): Promise<boolean> {
+    const row = await query<{ is_active: boolean }>(`SELECT is_active FROM directory_accounts WHERE id = $1`, [accountId])
+    return row.rows[0].is_active
+  }
+
+  async function completedRunCount(integrationId: string): Promise<number> {
+    const row = await query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM directory_sync_runs WHERE integration_id = $1 AND status = 'completed'`,
+      [integrationId],
+    )
+    return Number(row.rows[0].n)
+  }
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('sentinel: the service pool REALLY runs repeatable-read default — a bare-BEGIN generic transaction is RR', async () => {
+    // Positive control for the whole harness: if the options plumbing ever silently broke,
+    // the pin tests below would be vacuously green under an RC default. This reds instead.
+    const def = await query<{ iso: string }>(`SELECT current_setting('default_transaction_isolation') AS iso`)
+    expect(def.rows[0].iso).toBe('repeatable read')
+    const inTxn = await transaction(async (client) => {
+      const r = (await client.query(`SELECT current_setting('transaction_isolation') AS iso`)) as {
+        rows: Array<{ iso: string }>
+      }
+      return r.rows[0].iso
+    })
+    expect(inTxn).toBe('repeatable read')
+  })
+
+  it('unit guard (P1 key contract): fix-path canonicalization maps an uppercase route id onto the SAME lock key as the DB-canonical id', async () => {
+    // Deterministic case-variant id: force hex letters into the first group, keep the rest random.
+    const canonical = `facade00-${randomUUID().slice(9)}`.toLowerCase()
+    const upper = canonical.toUpperCase()
+    expect(upper).not.toBe(canonical)
+    await query(
+      `INSERT INTO directory_integrations (id, name, corp_id, config) VALUES ($1::uuid, $2, $3, '{}'::jsonb)`,
+      [canonical, `t2-lkc-keyguard-${TS}`, `t2-lkc-keyguard-corp-${TS}`],
+    )
+    cleanupIntegrationIds.push(canonical)
+
+    // The very read-back shape getIntegrationRow uses (WHERE id = $1 on the uuid column):
+    // an uppercase text param resolves the row and reads back the canonical lowercase id.
+    const readBack = await query<{ id: string }>(
+      `SELECT id FROM directory_integrations WHERE id = $1 AND provider = $2`,
+      [upper, 'dingtalk'],
+    )
+    expect(readBack.rows[0]?.id).toBe(canonical)
+
+    // key(raw uppercase) after fix-path canonicalization === key(canonical lowercase).
+    expect(sourceSyncFreezeLockKey(readBack.rows[0].id)).toBe(sourceSyncFreezeLockKey(canonical))
+    // Why canonicalization is load-bearing: the raw uppercase key is a DIFFERENT string…
+    expect(sourceSyncFreezeLockKey(upper)).not.toBe(sourceSyncFreezeLockKey(canonical))
+    // …and hashes a DIFFERENT advisory-lock key at the PostgreSQL level (the P1 mechanism).
+    const hashes = await query<{ same: boolean }>(`SELECT hashtext($1) = hashtext($2) AS same`, [
+      sourceSyncFreezeLockKey(upper),
+      sourceSyncFreezeLockKey(canonical),
+    ])
+    expect(hashes.rows[0].same).toBe(false)
+  })
+
+  it('P1 RACE: an UPPERCASE manual-sync id parks on the canonical transfer freeze key (same pg_locks tuple) and rolls back after the freeze commits', async () => {
+    const source = await seedIntegrationWithLiveAccount('p1-up-src')
+    const target = await seedIntegrationWithLiveAccount('p1-up-dst')
+    const upper = source.integrationId.toUpperCase()
+    // Loud precondition (gen_random_uuid contains hex letters with overwhelming probability;
+    // fail loudly rather than pass vacuously in the astronomically unlikely all-digit case).
+    expect(upper).not.toBe(source.integrationId)
+
+    let transferId = ''
+    await withHolder(async (holder, holderPid) => {
+      // SQL STAND-IN for createOrgTransfer mid-flight, exactly as production now runs it:
+      // pinned READ COMMITTED + canonical-key advisory lock + freeze-active INSERT, held open.
+      await holder.query('BEGIN')
+      await holder.query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED')
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        sourceSyncFreezeLockKey(source.integrationId),
+      ])
+      const ins = await holder.query<{ id: string }>(
+        `INSERT INTO provider_org_transfers
+           (org_id, provider, source_integration_id, target_integration_id, status, freeze_source_sync)
+         SELECT org_id, provider, $1, $2, 'draft', true
+           FROM directory_integrations WHERE id = $1
+         RETURNING id`,
+        [source.integrationId, target.integrationId],
+      )
+      transferId = ins.rows[0].id
+      cleanupTransferIds.push(transferId)
+
+      // REAL sync through the fixed path, with the route-shaped RAW uppercase id. Entry check
+      // sees no committed freeze; mutual exclusion is entirely on the apply-txn lock key.
+      const syncOutcome = settled(syncDirectoryIntegration(upper, `t2-lkc-admin-${TS}`))
+
+      // Pre-fix RED signature (and mutation (i)'s): the uppercase caller hashes its own key,
+      // never parks on the holder, and this barrier TIMES OUT while the sweep commits.
+      await waitUntilBlockedOnHolder(holderPid)
+      // SAME-KEY witness: the parked waiter's ungranted advisory tuple equals the holder's.
+      expect(await countWaitersOnHolderAdvisoryKey(holderPid)).toBeGreaterThanOrEqual(1)
+
+      await holder.query('COMMIT')
+
+      const outcome = await syncOutcome
+      expect(outcome).toBeInstanceOf(DirectorySyncFrozenByTransferError)
+      expect((outcome as DirectorySyncFrozenByTransferError).transferId).toBe(transferId)
+    })
+
+    // The freeze linearized first ⇒ no local directory mutation may commit.
+    expect(await accountActive(source.accountId)).toBe(true)
+    expect(await completedRunCount(source.integrationId)).toBe(0)
+  })
+
+  it('P2 RACE (RR-default barrier): a freeze committed WHILE the apply waits on the lock is seen by the post-lock recheck', async () => {
+    const source = await seedIntegrationWithLiveAccount('p2-rr-src')
+    const target = await seedIntegrationWithLiveAccount('p2-rr-dst')
+    // Active but UNFROZEN transfer: the entry check passes; only the under-lock recheck can
+    // catch the refreeze that commits while the apply is parked on the advisory lock.
+    const transferId = await createTransferRow(source.integrationId, target.integrationId, false)
+
+    await withHolder(async (holder, holderPid) => {
+      // Refreeze-writer stand-in mid-flight: canonical key held, freeze=true NOT yet committed.
+      await holder.query('BEGIN')
+      await holder.query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED')
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        sourceSyncFreezeLockKey(source.integrationId),
+      ])
+      await holder.query(
+        `UPDATE provider_org_transfers SET freeze_source_sync = true, updated_at = now() WHERE id = $1`,
+        [transferId],
+      )
+
+      // Constructed interleaving on an RR-default pool: (1) sync apply txn opens and issues its
+      // first statements — without the RC pin, the advisory-lock SELECT itself would fix the
+      // transaction snapshot NOW, pre-freeze; (2) it parks on the held lock; (3) holder commits
+      // the freeze; (4) sync acquires the lock and re-checks.
+      const syncOutcome = settled(syncDirectoryIntegration(source.integrationId, `t2-lkc-admin-${TS}`))
+      await waitUntilBlockedOnHolder(holderPid)
+
+      await holder.query('COMMIT')
+
+      // With the pin, the recheck's fresh per-statement snapshot sees the freeze. Without it
+      // (mutation (ii)) the recheck reads the pre-freeze RR snapshot: the sync COMPLETES and
+      // sweeps the seeded account — that is the mutation's red signature.
+      const outcome = await syncOutcome
+      expect(outcome).toBeInstanceOf(DirectorySyncFrozenByTransferError)
+      expect((outcome as DirectorySyncFrozenByTransferError).transferId).toBe(transferId)
+    })
+
+    expect(await accountActive(source.accountId)).toBe(true)
+    expect(await completedRunCount(source.integrationId)).toBe(0)
+    const flag = await query<{ freeze_source_sync: boolean }>(
+      `SELECT freeze_source_sync FROM provider_org_transfers WHERE id = $1`,
+      [transferId],
+    )
+    expect(flag.rows[0].freeze_source_sync).toBe(true)
+  })
+
+  it('P2 posture: the REAL createOrgTransfer (pinned RC) still parks on the shared key and activates the freeze under an RR-default pool', async () => {
+    const source = await seedIntegrationWithLiveAccount('p2-create-src')
+    const target = await seedIntegrationWithLiveAccount('p2-create-dst')
+
+    await withHolder(async (holder, holderPid) => {
+      // Sync-apply stand-in holding the canonical key (no freeze yet).
+      await holder.query('BEGIN')
+      await holder.query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED')
+      await holder.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        sourceSyncFreezeLockKey(source.integrationId),
+      ])
+
+      const createOutcome = settled(
+        createOrgTransfer({
+          provider: 'dingtalk',
+          sourceIntegrationId: source.integrationId,
+          targetIntegrationId: target.integrationId,
+          createdBy: `t2-lkc-admin-${TS}`,
+        }),
+      )
+      await waitUntilBlockedOnHolder(holderPid)
+
+      await holder.query('COMMIT')
+
+      const created = await createOutcome
+      expect(created).not.toBeInstanceOf(Error)
+      const summary = created as Awaited<ReturnType<typeof createOrgTransfer>>
+      cleanupTransferIds.push(summary.id)
+      expect(summary.freezeSourceSync).toBe(true)
+      expect(summary.sourceIntegrationId).toBe(source.integrationId)
+    })
+
+    // And the activated freeze governs a subsequent canonical-id sync.
+    await expect(syncDirectoryIntegration(source.integrationId, `t2-lkc-admin-${TS}`)).rejects.toBeInstanceOf(
+      DirectorySyncFrozenByTransferError,
+    )
+    expect(await accountActive(source.accountId)).toBe(true)
+  })
+})

--- a/packages/core-backend/tests/unit/source-sync-freeze-lock-key.test.ts
+++ b/packages/core-backend/tests/unit/source-sync-freeze-lock-key.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { sourceSyncFreezeLockKey } from '../../src/directory/source-sync-freeze-lock'
+
+// T2 lock-correctness P1 — no-DB guard for the key contract. The advisory lock hashes the
+// RAW TEXT key, so the key function is case-SENSITIVE even though `directory_integrations.id`
+// is a uuid column that matches case-insensitively. That asymmetry is exactly why
+// `syncDirectoryIntegration` MUST canonicalize the route-supplied id to the DB-read-back
+// `integration.id` before any lock acquisition (the DB-side proof — read-back equality and
+// hashtext divergence on a real row — lives in
+// tests/integration/directory-source-freeze-lock-correctness.db.test.ts).
+describe('sourceSyncFreezeLockKey — case-sensitivity makes canonicalization load-bearing', () => {
+  it('is a pure prefix + verbatim id (no normalization inside the key fn)', () => {
+    expect(sourceSyncFreezeLockKey('abc-def')).toBe('directory:source-sync-freeze:abc-def')
+  })
+
+  it('case-variant ids of the SAME uuid row produce DIFFERENT keys', () => {
+    const lower = 'facade00-1234-4abc-8def-0123456789ab'
+    const upper = lower.toUpperCase()
+    expect(sourceSyncFreezeLockKey(upper)).not.toBe(sourceSyncFreezeLockKey(lower))
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -195,6 +195,16 @@ export default defineConfig({
       // job cannot skip-green it, and wired as a WHOLE FILE into the approval real-DB step in
       // plugin-tests.yml (both points asserted by t2-source-freeze-ci-wiring.test.mjs).
       'tests/integration/directory-org-transfer-source-freeze.db.test.ts',
+      // T2 lock-correctness: canonical UUID lock key (uppercase route id must contend on the
+      // transfer side's DB-canonical advisory key — proven via pg_locks same-tuple witness)
+      // + explicit READ COMMITTED pin for the freeze-lock transactions, proven against a
+      // repeatable-read-DEFAULT service pool (the file amends DATABASE_URL with
+      // `options=-c default_transaction_isolation=repeatable\ read` before the pool is built).
+      // Drives the REAL syncDirectoryIntegration / createOrgTransfer with a mocked DingTalk
+      // client against real Postgres. DATABASE_URL-gated; excluded here so the no-DB job
+      // cannot skip-green it, and wired as a WHOLE FILE into the directory real-DB step in
+      // plugin-tests.yml (both points asserted by t2-source-freeze-ci-wiring.test.mjs).
+      'tests/integration/directory-source-freeze-lock-correctness.db.test.ts',
       // T2-Gate evidence (§3.4): the (provider, external_key) collision MECHANISM — unique-index
       // pin, bare-unionId derivation pin, and the end-to-end wholesale second-corp sync failure
       // signature the staging two-corp runbook greps for. Real sync + mocked DingTalk client.

--- a/scripts/ops/t2-source-freeze-ci-wiring.test.mjs
+++ b/scripts/ops/t2-source-freeze-ci-wiring.test.mjs
@@ -13,14 +13,23 @@ import { dirname, join } from 'node:path'
 // disables the §12.2 freeze proof while CI stays green. Runs in the gating no-DB test job.
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, '..', '..')
-const FILE = 'tests/integration/directory-org-transfer-source-freeze.db.test.ts'
+// Same two-point contract for every T2 freeze-linearization suite:
+// - the original §12.2 source-freeze suite;
+// - the lock-correctness suite (canonical UUID lock key + READ COMMITTED pin, proven on an
+//   RR-default pool), added by the T2 lock-correctness ticket.
+const FILES = [
+  'tests/integration/directory-org-transfer-source-freeze.db.test.ts',
+  'tests/integration/directory-source-freeze-lock-correctness.db.test.ts',
+]
 
-test('vitest.config.ts excludes the T2 source-freeze suite from the no-DB job', () => {
-  const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
-  assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE} (DATABASE_URL-gated whole file)`)
-})
+for (const FILE of FILES) {
+  test(`vitest.config.ts excludes ${FILE} from the no-DB job`, () => {
+    const cfg = readFileSync(join(repoRoot, 'packages/core-backend/vitest.config.ts'), 'utf8')
+    assert.ok(cfg.includes(`'${FILE}'`), `vitest.config.ts must exclude ${FILE} (DATABASE_URL-gated whole file)`)
+  })
 
-test('plugin-tests.yml runs the T2 source-freeze suite as a whole file in a real-DB step', () => {
-  const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
-  assert.match(wf, new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${FILE} in a real-DB step`)
-})
+  test(`plugin-tests.yml runs ${FILE} as a whole file in a real-DB step`, () => {
+    const wf = readFileSync(join(repoRoot, '.github/workflows/plugin-tests.yml'), 'utf8')
+    assert.match(wf, new RegExp(`\\n\\s*${FILE.replace(/[.]/g, '\\.')} \\\\`), `plugin-tests.yml must run ${FILE} in a real-DB step`)
+  })
+}


### PR DESCRIPTION
T2 lock-correctness (owner order step 3). Both owner findings CONFIRMED and fixed; real-DB constructed-concurrency proofs + two mutation reds below. **UNARMED** — no auto-merge; orchestrator serializes arming.

## P1 — canonical UUID lock key

The manual sync route passes RAW `req.params.integrationId` (`admin-directory.ts:529` async branch, `:566` sync branch) into `syncDirectoryIntegration`. `directory_integrations.id` is a **uuid** column (`zzzz20260324150000_create_directory_sync_tables.ts:15`), so an uppercase id resolves the same row via uuid casting — but `acquireSourceSyncFreezeLock` hashes the RAW TEXT key (`hashtext('directory:source-sync-freeze:' || id)`, `source-sync-freeze-lock.ts:41-43`). An uppercase caller therefore hashed a **different advisory key** than the transfer side's DB-canonical `source.id` (`org-transfer-service.ts` create / refreeze) ⇒ sync↔freeze mutual exclusion silently lost ⇒ a freeze committing after the entry check could race sync's local apply (live probe: `hashtext` lower vs upper = `2116517213` vs `1496837228`).

**Fix** (`directory-sync.ts`): immediately after `getIntegrationRow` succeeds, canonicalize — parameter renamed to `rawIntegrationId`, and `const integrationId = integration.id` (DB read-back) feeds EVERYTHING downstream: entry freeze check, stale-run reclaim, run-lease claim, apply-txn lock, under-lock recheck, every write.

**Caller sweep** (all `acquireSourceSyncFreezeLock` / `sourceSyncFreezeLockKey` call sites on this branch):
- `org-transfer-service.ts:281` (`createOrgTransfer`) — uses `source.id` read back from `SELECT ... WHERE id = ANY($1::uuid[])`; a case-variant input additionally fails the strict `r.id === input.sourceIntegrationId` match and 404s. Already canonical — **verified, unchanged**.
- `org-transfer-service.ts:523` (`setOrgTransferSourceSyncFreeze`) — keyed by `source_integration_id` probed from the transfer row (DB-read). Already canonical — **verified, unchanged**.
- `directory-sync.ts` apply txn — was the raw param; now canonical (the fix).
- Scheduler trigger `directory-sync-scheduler.ts:136` passes `row.id` from its own DB reads — canonical — and now additionally flows through the entry canonicalization.

## P2 — explicit READ COMMITTED for freeze-lock transactions

`connection-pool.ts` `transaction()` issues a bare `BEGIN` (line 158). On a deployment with `default_transaction_isolation = 'repeatable read'`, the transaction snapshot is fixed by the `pg_advisory_xact_lock` SELECT itself — **before the lock is granted** — so the post-lock freeze recheck reads a pre-freeze snapshot and misses a freeze committed while waiting.

**Fix** (PB4-3 idiom, matching `local-directory-org.ts:259`): `SET TRANSACTION ISOLATION LEVEL READ COMMITTED` as the first statement after BEGIN in:
1. the sync local-apply transaction (`directory-sync.ts`),
2. `createOrgTransfer`'s freeze-taking transaction (`org-transfer-service.ts`),
3. `setOrgTransferSourceSyncFreeze`'s freeze-taking transaction (pinned BEFORE the source probe — the probe is that txn's first snapshot-taking query).

**Scope statement (deliberate):** `connection-pool.ts`'s generic bare `BEGIN` is **NOT** changed — pinning every transaction in the codebase to RC is a blast radius far beyond this ticket. The isolation pin is scoped to the three freeze-lock transactions only.

## Tests — real DB, two-connection, constructed interleavings

`tests/integration/directory-source-freeze-lock-correctness.db.test.ts` runs the **entire service pool under `default_transaction_isolation='repeatable read'`** (DATABASE_URL amended with `options=-c default_transaction_isolation=repeatable\ read` in `vi.hoisted`, before the PoolManager reads it; isolated fork per file so nothing leaks). A sentinel asserts the posture (`SHOW` + bare-BEGIN generic txn reports `repeatable read`) so the pin proof cannot go vacuous. Real `syncDirectoryIntegration` / `createOrgTransfer`, mocked DingTalk client, EMPTY tenant ⇒ any allowed apply performs the destructive absence sweep (the observable).

- **(a) P1 RACE**: holder (create-shaped stand-in) holds the **canonical**-key lock + uncommitted freeze INSERT; real sync is called with the **UPPERCASE** id. Fixed code parks — proven by `pg_blocking_pids` barrier **and** a `pg_locks` witness that the waiter's ungranted advisory tuple equals the holder's granted `(classid, objid, objsubid)` (same-key proof) — then, after the freeze commits, rolls back with `DirectorySyncFrozenByTransferError`; seeded account stays live, zero completed runs.
- **(b) P2 RACE (RR-default barrier)**: active UNFROZEN transfer (entry check passes); holder holds the lock + uncommitted `freeze=true`; sync (canonical id) parks; holder commits; post-lock recheck must see the freeze. Exact interleaving: apply txn opens → would-be snapshot at the lock SELECT → parks → freeze commits → lock acquired → recheck.
- **P2 posture**: real `createOrgTransfer` (pinned) parks on the shared key and activates the freeze under the RR-default pool.
- **Unit guards (item 5)**: DB suite — seeded row `facade00-…`, read-back via the `getIntegrationRow` SELECT shape with the uppercase id returns the canonical lowercase id; `key(readBack) === key(canonical)`, `key(upper) !== key(canonical)`, and `SELECT hashtext(k1)=hashtext(k2)` is false. No-DB guard `tests/unit/source-sync-freeze-lock-key.test.ts` pins the key fn's case-sensitivity (runs in the gating no-DB job).

## Mutation proofs — both red, exact signatures

**(i) revert canonicalization** (`const integrationId = rawIntegrationId`):
```
× P1 RACE: an UPPERCASE manual-sync id parks on the canonical transfer freeze key (same pg_locks tuple) and rolls back after the freeze commits  8067ms
  → timed out waiting for a backend blocked by holder pid 15826 (source freeze lock never engaged)
Test Files  1 failed (1) / Tests  1 failed | 5 passed (6)
```
(the uppercase caller hashes its own key and never parks — pre-fix behavior reproduced)

**(ii) drop `SET TRANSACTION ISOLATION LEVEL READ COMMITTED` from the sync local-apply txn**:
```
× P2 RACE (RR-default barrier): a freeze committed WHILE the apply waits on the lock is seen by the post-lock recheck
  → AssertionError: expected { integration: { …(17) }, …(2) } to be an instance of DirectorySyncFrozenByTransferError
× P1 RACE: … → same AssertionError (recheck misses the freeze after parking, too)
Test Files  1 failed (1) / Tests  2 failed | 4 passed (6)
```
(the sync COMPLETES against a frozen source — the recheck read the pre-freeze RR snapshot; test (a) reds as well, consistent with the same mechanism)

Both mutations reverted; committed tree is the fixed code (working tree diff vs HEAD empty before push).

## Green evidence (local, real DB `metasheet_test`, PG 15.17)

- New suite: 6/6 passed (764ms); regression: existing `directory-org-transfer-source-freeze.db.test.ts` 16/16 passed; combined re-run at rebased HEAD: 22/22.
- `tests/unit/source-sync-freeze-lock-key.test.ts` + `tests/unit/admin-directory-routes.test.ts`: 103/103.
- `tsc --noEmit` clean; extended `t2-source-freeze-ci-wiring.test.mjs` 4/4 (two-point wiring for BOTH freeze suites: vitest.config.ts exclude + plugin-tests.yml whole-file real-DB step).

## CI wiring

New DB suite added to `vitest.config.ts` exclude (no-DB job cannot skip-green it) and to the plugin-tests.yml directory real-DB step as a whole file, directly under the original T2 freeze suite; the wiring contract test now loops over both files.

Rebased onto `ee39a13eb` (#4545, vitest.config.ts exclude for w4pre1d — clean auto-merge, adjacent exclude entries) and fully re-verified at the rebased HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
