### PR TITLE
feat(attendance): W5-0 — six decision-trace endpoints (dual-host) + settlement read face + lot overtime_source projection

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -847,6 +847,7 @@ jobs:
             tests/integration/attendance-w4pre1c-departure-permission-negative.db.test.ts \
             tests/integration/attendance-w4pre1d-departure-candidate-split.db.test.ts \
             tests/integration/attendance-setup-readiness-w4-0.db.test.ts \
+            tests/integration/attendance-decision-trace-w5-0.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -23,6 +23,22 @@ import {
   type AttendanceSetupStepId,
   type AttendancePunchPolicyPosture,
 } from '../services/AttendanceSetupReadinessAggregate'
+import {
+  ATTENDANCE_DECISION_TRACE_NOT_FOUND,
+  buildApproverSourceTrace,
+  buildCompTimeBalanceTrace,
+  buildLateEarlyTrace,
+  buildMissingPunchTrace,
+  buildOvertimeSegmentationTrace,
+  buildTodayStatusTrace,
+  isAttendanceDecisionTraceCategory,
+  readAttendanceDecisionTraceSettingsGates,
+  runAttendanceDecisionTraceReadOnly,
+  type AttendanceDecisionTraceCategory,
+  type AttendanceDecisionTraceQueryFn,
+  type AttendanceDecisionTraceResponse,
+  type AttendanceDecisionTraceSettingsGates,
+} from '../services/AttendanceDecisionTrace'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -1104,6 +1120,231 @@ export function attendanceAdminRouter(): Router {
       }
     } catch (error) {
       return jsonError(res, 500, 'DELIVERY_REDELIVER_FAILED', (error as Error)?.message || 'Failed to redeliver notification')
+    }
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // W5-0 (Wave 5 explainability design-lock 2026-07-22, RATIFIED §3/§4/§9 — see
+  // docs/development/attendance-vnext-wave5-explainability-data-contract-lock-20260722.md): six
+  // read-only decision-trace endpoints, DUAL-HOSTED per §4.1 (owner terminal-review P2-1):
+  //   - admin:  GET /api/attendance-admin/decision-trace  — inside the router-level
+  //             `rbacGuard('attendance','admin')` (`:492` above) + delegated-admin org-membership
+  //             door (`canReadAttendanceDirectoryReadiness`, reused verbatim, S7-5/W4-0 precedent).
+  //   - self:   GET /api/attendance/decision-trace         — deliberately registered under a path
+  //             that does NOT start with `/api/attendance-admin`, so `r.use('/api/attendance-admin',
+  //             rbacGuard('attendance','admin'))` above never applies to it (Express `router.use`
+  //             is a path-PREFIX match). Guarded instead by `rbacGuard('attendance','read')` — the
+  //             existing self-service permission (`ATTENDANCE_SELF_SERVICE_PERMISSIONS`,
+  //             `auth/AuthService.ts:57`). `user` is ALWAYS the token subject
+  //             (`getAttendanceAdminRequestUserId`, same helper as the admin host) — a `userId`
+  //             query parameter is REJECTED outright (400), never silently ignored (§4.1 "绝不接受
+  //             userId 参数" — silent-ignore would itself be a contract bug, same posture as hard
+  //             rule 3's silent-fallback ban).
+  //
+  // Evidence-chain construction lives entirely in `services/AttendanceDecisionTrace.ts` — this
+  // block is authorization + org resolution + thin dispatch only (§4.1: "every trace SQL" only
+  // fires AFTER authorization/org-resolution passes — `runAttendanceDecisionTraceReadOnly` is
+  // invoked strictly after every 400/401/403 branch below returns, so a rejected request opens
+  // ZERO trace SQL / ZERO transactions, W4-0-G1 case 2 precedent, §9 W5-0-G7).
+  // -----------------------------------------------------------------------------------------------
+
+  const ATTENDANCE_DECISION_TRACE_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+  interface AttendanceDecisionTraceParsedQuery {
+    category: AttendanceDecisionTraceCategory
+    workDate?: string
+    requestId?: string
+    instanceId?: string
+  }
+
+  // NOTE: `strict`/`strictNullChecks` is OFF in this package's tsconfig (`packages/core-backend/
+  // tsconfig.json`), under which TS does NOT narrow a `{ok:true;value}|{ok:false;code;message}`
+  // discriminated union on a plain `if (!parsed.ok)` check (verified empirically — the boolean-
+  // literal discriminant only narrows under `strictNullChecks`). A single shape with optional
+  // fields sidesteps that entirely rather than fighting the compiler config.
+  interface AttendanceDecisionTraceParseResult {
+    ok: boolean
+    value?: AttendanceDecisionTraceParsedQuery
+    code?: string
+    message?: string
+  }
+
+  /** §3.1 hard rule 3 (enum-strict) / §9 W5-0-G4: an unrecognized or missing `category` is a 400,
+   *  NEVER a silent fallback to some default category. Each category's REQUIRED companion
+   *  parameter (workDate for ①②③, requestId for ④, instanceId for ⑥) is validated here too — a
+   *  missing/malformed one is also a 400, not a query that silently returns an empty/undeterminable
+   *  trace for the wrong reason. */
+  function parseAttendanceDecisionTraceQuery(req: Request): AttendanceDecisionTraceParseResult {
+    const categoryRaw = typeof req.query.category === 'string' ? req.query.category.trim() : ''
+    if (!categoryRaw) {
+      return { ok: false, code: 'CATEGORY_REQUIRED', message: 'category is required' }
+    }
+    if (!isAttendanceDecisionTraceCategory(categoryRaw)) {
+      return { ok: false, code: 'CATEGORY_INVALID', message: 'category is not a recognized decision-trace category' }
+    }
+    if (categoryRaw === 'today_status' || categoryRaw === 'late_early' || categoryRaw === 'missing_punch') {
+      const workDate = typeof req.query.workDate === 'string' ? req.query.workDate.trim() : ''
+      if (!ATTENDANCE_DECISION_TRACE_DATE_RE.test(workDate)) {
+        return { ok: false, code: 'WORK_DATE_REQUIRED', message: 'workDate (YYYY-MM-DD) is required for this category' }
+      }
+      return { ok: true, value: { category: categoryRaw, workDate } }
+    }
+    if (categoryRaw === 'overtime_segmentation') {
+      const requestId = typeof req.query.requestId === 'string' ? req.query.requestId.trim() : ''
+      if (!UUID_RE.test(requestId)) {
+        return { ok: false, code: 'REQUEST_ID_REQUIRED', message: 'requestId (uuid) is required for this category' }
+      }
+      return { ok: true, value: { category: categoryRaw, requestId } }
+    }
+    if (categoryRaw === 'approver_source') {
+      const instanceId = typeof req.query.instanceId === 'string' ? req.query.instanceId.trim() : ''
+      if (!instanceId) {
+        return { ok: false, code: 'INSTANCE_ID_REQUIRED', message: 'instanceId is required for this category' }
+      }
+      return { ok: true, value: { category: categoryRaw, instanceId } }
+    }
+    // comp_time_balance needs no extra target id (org+user scoped, mirrors L5a).
+    return { ok: true, value: { category: categoryRaw } }
+  }
+
+  async function dispatchAttendanceDecisionTrace(
+    orgId: string,
+    userId: string,
+    parsed: AttendanceDecisionTraceParsedQuery,
+    readOnlyQuery: AttendanceDecisionTraceQueryFn,
+    gates: AttendanceDecisionTraceSettingsGates,
+  ): Promise<AttendanceDecisionTraceResponse | typeof ATTENDANCE_DECISION_TRACE_NOT_FOUND> {
+    switch (parsed.category) {
+      case 'today_status':
+        return buildTodayStatusTrace(orgId, userId, parsed.workDate as string, readOnlyQuery)
+      case 'late_early':
+        return buildLateEarlyTrace(orgId, userId, parsed.workDate as string, readOnlyQuery)
+      case 'missing_punch':
+        return buildMissingPunchTrace(orgId, userId, parsed.workDate as string, readOnlyQuery)
+      case 'overtime_segmentation':
+        return buildOvertimeSegmentationTrace(
+          orgId,
+          userId,
+          parsed.requestId as string,
+          readOnlyQuery,
+          gates.overtimeSegmentation,
+        )
+      case 'comp_time_balance':
+        return buildCompTimeBalanceTrace(orgId, userId, readOnlyQuery, gates)
+      case 'approver_source':
+        return buildApproverSourceTrace(
+          orgId,
+          userId,
+          parsed.instanceId as string,
+          readOnlyQuery,
+          gates.dynamicAssigneeSourcesEnabled,
+        )
+      /* istanbul ignore next -- `isAttendanceDecisionTraceCategory` already narrowed the closed set */
+      default:
+        return ATTENDANCE_DECISION_TRACE_NOT_FOUND
+    }
+  }
+
+  r.get('/api/attendance-admin/decision-trace', async (req: Request, res: Response) => {
+    try {
+      const orgId = String(req.query.orgId || '').trim()
+      if (!orgId) {
+        return jsonError(res, 400, 'ORG_ID_REQUIRED', 'orgId is required')
+      }
+      const requestUserId = getAttendanceAdminRequestUserId(req)
+      if (!requestUserId) {
+        return jsonError(res, 401, 'UNAUTHENTICATED', 'Authentication required')
+      }
+      const allowed = await canReadAttendanceDirectoryReadiness(req, requestUserId, orgId)
+      if (!allowed) {
+        return jsonError(res, 403, 'FORBIDDEN', 'Org membership required for decision trace')
+      }
+      const targetUserId = String(req.query.userId || '').trim()
+      if (!targetUserId) {
+        return jsonError(res, 400, 'USER_ID_REQUIRED', 'userId is required')
+      }
+      const parsed = parseAttendanceDecisionTraceQuery(req)
+      if (!parsed.ok || !parsed.value) {
+        return jsonError(res, 400, parsed.code || 'CATEGORY_INVALID', parsed.message || 'Invalid decision-trace query')
+      }
+
+      const result = await runAttendanceDecisionTraceReadOnly(async (readOnlyQuery) => {
+        const gates = await readAttendanceDecisionTraceSettingsGates(readOnlyQuery)
+        return dispatchAttendanceDecisionTrace(orgId, targetUserId, parsed.value, readOnlyQuery, gates)
+      })
+      if (result === ATTENDANCE_DECISION_TRACE_NOT_FOUND) {
+        return jsonError(res, 404, 'DECISION_TRACE_TARGET_NOT_FOUND', 'No such decision-trace target')
+      }
+      return jsonOk(res, result)
+    } catch (error) {
+      if (isDatabaseSchemaError(error)) {
+        return jsonError(res, 503, 'DB_NOT_READY', 'Attendance tables missing')
+      }
+      // Values-free seam: never leak raw DB / driver messages to the client.
+      return jsonError(res, 500, 'DECISION_TRACE_FAILED', 'Failed to load decision trace')
+    }
+  })
+
+  r.get('/api/attendance/decision-trace', rbacGuard('attendance', 'read'), async (req: Request, res: Response) => {
+    try {
+      // §4.1 "绝不接受 userId 参数": presence alone is rejected — never silently ignored (that would
+      // be the exact silent-fallback shape hard rule 3 forbids for other closed-set inputs).
+      if (Object.prototype.hasOwnProperty.call(req.query, 'userId')) {
+        return jsonError(res, 400, 'USER_ID_NOT_ACCEPTED', 'userId is not accepted on the self decision-trace host')
+      }
+      const subject = getAttendanceAdminRequestUserId(req)
+      if (!subject) {
+        return jsonError(res, 401, 'UNAUTHENTICATED', 'Authentication required')
+      }
+
+      // §4.1 self multi-org four-leg (owner two-round-terminal-review P2-d) — same dual is_active
+      // predicate as `canReadAttendanceDirectoryReadiness` (`:397-404`), never the plugin's
+      // client-trusted `getOrgId(req)` fallback.
+      const memberships = await query<{ org_id: string }>(
+        `SELECT uo.org_id
+           FROM user_orgs uo
+           JOIN users u ON u.id = uo.user_id
+          WHERE uo.user_id = $1 AND uo.is_active = true AND u.is_active = true
+          ORDER BY uo.org_id ASC`,
+        [subject],
+      )
+      const activeOrgIds = memberships.rows.map((row) => row.org_id)
+      const requestedOrgId = String(req.query.orgId || '').trim()
+      let orgId: string
+      if (activeOrgIds.length === 0) {
+        return jsonError(res, 403, 'FORBIDDEN', 'No active org membership')
+      } else if (!requestedOrgId && activeOrgIds.length === 1) {
+        orgId = activeOrgIds[0]
+      } else if (!requestedOrgId) {
+        return jsonError(res, 400, 'ORG_ID_REQUIRED', 'orgId is required (multiple active org memberships)')
+      } else if (activeOrgIds.includes(requestedOrgId)) {
+        orgId = requestedOrgId
+      } else {
+        return jsonError(res, 403, 'FORBIDDEN', 'orgId does not match an active org membership')
+      }
+
+      const parsed = parseAttendanceDecisionTraceQuery(req)
+      if (!parsed.ok || !parsed.value) {
+        return jsonError(res, 400, parsed.code || 'CATEGORY_INVALID', parsed.message || 'Invalid decision-trace query')
+      }
+
+      // §4.1 subject-constrained horizontal authorization (owner three-round-terminal-review P2-1):
+      // `subject` (never a client value) is threaded into EVERY builder as the ownership column
+      // value alongside `orgId` — this is the query-internal predicate the two-user/same-org G7
+      // matrix mutates against, not a pre-gate.
+      const result = await runAttendanceDecisionTraceReadOnly(async (readOnlyQuery) => {
+        const gates = await readAttendanceDecisionTraceSettingsGates(readOnlyQuery)
+        return dispatchAttendanceDecisionTrace(orgId, subject, parsed.value, readOnlyQuery, gates)
+      })
+      if (result === ATTENDANCE_DECISION_TRACE_NOT_FOUND) {
+        return jsonError(res, 404, 'DECISION_TRACE_TARGET_NOT_FOUND', 'No such decision-trace target')
+      }
+      return jsonOk(res, result)
+    } catch (error) {
+      if (isDatabaseSchemaError(error)) {
+        return jsonError(res, 503, 'DB_NOT_READY', 'Attendance tables missing')
+      }
+      return jsonError(res, 500, 'DECISION_TRACE_FAILED', 'Failed to load decision trace')
     }
   })
 

--- a/packages/core-backend/src/services/AttendanceDecisionTrace.ts
+++ b/packages/core-backend/src/services/AttendanceDecisionTrace.ts
@@ -1,0 +1,1255 @@
+/**
+ * W5-0 (Wave 5 explainability design-lock 2026-07-22, RATIFIED — see
+ * docs/development/attendance-vnext-wave5-explainability-data-contract-lock-20260722.md, §3/§4/§9):
+ * the six read-only decision-trace evidence-chain builders + the payroll-cycle-settlement "seventh
+ * read face" (OD-W5-6=(a)). Zero Express/Request/Response dependency (mirrors
+ * `AttendanceSetupReadinessAggregate.ts`) so every builder is directly unit-testable with a mock
+ * query function; route wiring (authorization-before-query, host/subject resolution, HTTP status
+ * mapping) lives in `routes/attendance-admin.ts`.
+ *
+ * §0 red line R1 (explainability is READ-ONLY): every builder here runs its queries through
+ * `runAttendanceDecisionTraceReadOnly`, a verbatim re-export of the ALREADY-proven
+ * `runAttendanceSetupReadinessReadOnly` seam (`AttendanceSetupReadinessAggregate.ts:124-139`) — a
+ * REAL `SET TRANSACTION READ ONLY` transaction, never a first-word/regex text check (§9 W4-0-G2's
+ * three-case Postgres proof already covers this exact function; W5-0-G3 reuses it, not
+ * re-derives it).
+ *
+ * §0 red line R2 (basis must point at real storage): every environment below reads STORED rows —
+ * this module NEVER calls `computeMetrics`/rebuilds overtime segmentation/re-resolves the current
+ * rule and presents the result as "what was decided". A `current_live_no_history` environment is
+ * always the CURRENT policy, read fresh and labeled as such (never substituted for a missing
+ * `snapshot_frozen` environment — §3.1 hard rule 6, "快照排他").
+ *
+ * Scope note (disclosed, W5-0 PR body "deviations"): the ①/③ "current effective rule" environment
+ * resolves shift-assignment → org default rule → global default rule (mirrors two of the three
+ * `resolveWorkContext` priority tiers, `index.cjs:14347-14394`) but does NOT walk
+ * `attendance_rotation_rules` (the first, highest-priority tier) — `source.ref` only ever claims
+ * `'shift_assignment' | 'org_default_rule' | 'global_default_rule'`, never `'rotation'`, so the
+ * label is always honest about what was actually read even though rotation-assigned orgs get a
+ * less specific (but never wrong) `current_live_no_history` citation.
+ */
+import type { QueryResultRow } from 'pg'
+import {
+  runAttendanceSetupReadinessReadOnly,
+  type AttendanceSetupReadinessQueryFn,
+} from './AttendanceSetupReadinessAggregate'
+
+// -------------------------------------------------------------------------------------------------
+// §4.2 read-only seam — verbatim reuse, not reimplementation (W5-0-G3).
+// -------------------------------------------------------------------------------------------------
+export const runAttendanceDecisionTraceReadOnly = runAttendanceSetupReadinessReadOnly
+export type AttendanceDecisionTraceQueryFn = AttendanceSetupReadinessQueryFn
+
+// -------------------------------------------------------------------------------------------------
+// §3.1 category closed set (six classes, charter §7-Wave5 L366 verbatim order).
+// -------------------------------------------------------------------------------------------------
+export const ATTENDANCE_DECISION_TRACE_CATEGORIES = [
+  'today_status',
+  'late_early',
+  'missing_punch',
+  'overtime_segmentation',
+  'comp_time_balance',
+  'approver_source',
+] as const
+export type AttendanceDecisionTraceCategory = (typeof ATTENDANCE_DECISION_TRACE_CATEGORIES)[number]
+
+export function isAttendanceDecisionTraceCategory(value: unknown): value is AttendanceDecisionTraceCategory {
+  return (
+    typeof value === 'string' &&
+    (ATTENDANCE_DECISION_TRACE_CATEGORIES as readonly string[]).includes(value)
+  )
+}
+
+// -------------------------------------------------------------------------------------------------
+// §3.1 shared closed sets.
+// -------------------------------------------------------------------------------------------------
+export type AttendanceDecisionTraceVersionPosture =
+  | 'snapshot_frozen'
+  | 'current_live_no_history'
+  | 'not_in_effect'
+  | 'undeterminable'
+
+export type AttendanceDecisionTraceConfidence = 'grounded' | 'partial' | 'undeterminable'
+
+/** §5.1 / owner two-round-terminal-review P2-b — `'deleted'` deliberately excluded: `users` carries
+ *  no delete tombstone (`zzzz20260119100000_create_users_table.ts:18`, only `is_active`), so
+ *  "deleted" has no authoritative ground truth to distinguish from "never existed". */
+export type AttendanceIdentityPosture = 'resolved' | 'inactive' | 'unknown'
+
+export interface AttendanceDecisionTraceActor {
+  displayLabel: string
+  identityPosture: AttendanceIdentityPosture
+}
+
+export interface AttendanceDecisionTraceAuditRef {
+  kind: string
+  at: string
+  actor?: AttendanceDecisionTraceActor
+}
+
+export interface AttendanceDecisionTraceVersion {
+  posture: AttendanceDecisionTraceVersionPosture
+  asOf?: string
+  snapshotVersion?: string
+}
+
+export type AttendanceDecisionTraceSourceKind =
+  | 'record'
+  | 'snapshot'
+  | 'rule_live'
+  | 'ledger'
+  | 'audit'
+  | 'policy_gate'
+
+export interface AttendanceDecisionTraceSource {
+  kind: AttendanceDecisionTraceSourceKind
+  ref: string
+}
+
+export interface AttendanceDecisionTraceBasisEnv {
+  source: AttendanceDecisionTraceSource
+  version: AttendanceDecisionTraceVersion
+  auditRef?: AttendanceDecisionTraceAuditRef
+}
+
+/** `attendance_records_status_check` closed set (`zzzz20260114120000...ts:211`, 8 values —
+ *  `'off'` added by the scheduling migration over the original 7). Single source of truth for the
+ *  ①/② `reasonCode` code source (§3.1 hard rule 5①②). */
+export const ATTENDANCE_RECORD_STATUS_VALUES = [
+  'normal',
+  'late',
+  'early_leave',
+  'late_early',
+  'partial',
+  'absent',
+  'adjusted',
+  'off',
+] as const
+export type AttendanceRecordStatus = (typeof ATTENDANCE_RECORD_STATUS_VALUES)[number]
+
+// -------------------------------------------------------------------------------------------------
+// Row shapes read directly off storage (documented per-table so a future maintainer does not have
+// to re-derive them from migrations/index.cjs — same discipline as the W4-0 module).
+// -------------------------------------------------------------------------------------------------
+interface AttendanceRecordRow extends QueryResultRow {
+  id: string
+  status: string
+  is_workday: boolean
+  work_minutes: number
+  late_minutes: number
+  early_leave_minutes: number
+  meta: Record<string, unknown> | null
+  source_batch_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+interface UserIdentityRow extends QueryResultRow {
+  id: string
+  name: string | null
+  email: string | null
+  is_active: boolean
+}
+
+/** Resolve a stored actor user id into the §5.1 wire-safe `{displayLabel, identityPosture}` shape.
+ *  NEVER falls back to the raw id (owner terminal-review P2-3) — absent/inactive rows get a neutral
+ *  Chinese label, matching the existing never-fabricate precedent
+ *  (`apps/web/src/approvals/routePreviewSummary.ts:11`). */
+export async function resolveAttendanceDecisionTraceActor(
+  userId: string | null | undefined,
+  runQuery: AttendanceDecisionTraceQueryFn,
+): Promise<AttendanceDecisionTraceActor | null> {
+  const id = typeof userId === 'string' ? userId.trim() : ''
+  if (!id) return null
+  const result = await runQuery<UserIdentityRow>(
+    `SELECT id, name, email, is_active FROM users WHERE id = $1`,
+    [id],
+  )
+  const row = result.rows[0]
+  if (!row) {
+    return { displayLabel: '未知用户', identityPosture: 'unknown' }
+  }
+  if (row.is_active === false) {
+    return { displayLabel: '已停用用户', identityPosture: 'inactive' }
+  }
+  const label = (row.name && row.name.trim()) || (row.email && row.email.trim()) || '已注册用户'
+  return { displayLabel: label, identityPosture: 'resolved' }
+}
+
+/** §3.1 hard rule — confidence is PURELY derived from the basis chain, never an independent
+ *  assertion. `grounded` requires every environment to be `snapshot_frozen` (or absent); any
+ *  `current_live_no_history`/`not_in_effect` degrades to `partial`; any `undeterminable` degrades
+ *  the whole trace to `undeterminable` (§3.1 hard rule 1). */
+export function deriveAttendanceDecisionTraceConfidence(
+  basis: AttendanceDecisionTraceBasisEnv[],
+): AttendanceDecisionTraceConfidence {
+  if (basis.length === 0) return 'undeterminable'
+  let sawNonFrozen = false
+  for (const env of basis) {
+    if (env.version.posture === 'undeterminable') return 'undeterminable'
+    if (env.version.posture !== 'snapshot_frozen') sawNonFrozen = true
+  }
+  return sawNonFrozen ? 'partial' : 'grounded'
+}
+
+// -------------------------------------------------------------------------------------------------
+// §4.1 current-rule resolution (shift assignment → org default rule → global default rule). Only
+// ever produces `current_live_no_history` environments — NEVER presented as a historical decision
+// basis (§3.1 hard rule 6).
+// -------------------------------------------------------------------------------------------------
+interface CurrentRuleGraceParams {
+  refKind: 'shift_assignment' | 'org_default_rule' | 'global_default_rule'
+  lateGraceMinutes: number
+  earlyGraceMinutes: number
+  severeLateThresholdMinutes: number | null
+  absenceLateThresholdMinutes: number | null
+}
+
+async function resolveCurrentRuleGraceParams(
+  orgId: string,
+  userId: string,
+  runQuery: AttendanceDecisionTraceQueryFn,
+): Promise<CurrentRuleGraceParams | null> {
+  const shiftAssignment = await runQuery<{
+    late_grace_minutes: number
+    early_grace_minutes: number
+  }>(
+    `SELECT s.late_grace_minutes, s.early_grace_minutes
+       FROM attendance_shift_assignments a
+       JOIN attendance_shifts s ON s.id = a.shift_id
+      WHERE a.org_id = $1 AND a.user_id = $2 AND a.is_active = true
+        AND a.start_date <= CURRENT_DATE
+        AND (a.end_date IS NULL OR a.end_date >= CURRENT_DATE)
+      ORDER BY a.start_date DESC
+      LIMIT 1`,
+    [orgId, userId],
+  )
+  if (shiftAssignment.rows[0]) {
+    const row = shiftAssignment.rows[0]
+    return {
+      refKind: 'shift_assignment',
+      lateGraceMinutes: Number(row.late_grace_minutes) || 0,
+      earlyGraceMinutes: Number(row.early_grace_minutes) || 0,
+      severeLateThresholdMinutes: null,
+      absenceLateThresholdMinutes: null,
+    }
+  }
+  const orgDefault = await runQuery<{
+    late_grace_minutes: number
+    early_grace_minutes: number
+    severe_late_threshold_minutes: number | null
+    absence_late_threshold_minutes: number | null
+  }>(
+    `SELECT late_grace_minutes, early_grace_minutes, severe_late_threshold_minutes, absence_late_threshold_minutes
+       FROM attendance_rules WHERE org_id = $1 AND is_default = true LIMIT 1`,
+    [orgId],
+  )
+  if (orgDefault.rows[0]) {
+    const row = orgDefault.rows[0]
+    return {
+      refKind: 'org_default_rule',
+      lateGraceMinutes: Number(row.late_grace_minutes) || 0,
+      earlyGraceMinutes: Number(row.early_grace_minutes) || 0,
+      severeLateThresholdMinutes:
+        row.severe_late_threshold_minutes == null ? null : Number(row.severe_late_threshold_minutes),
+      absenceLateThresholdMinutes:
+        row.absence_late_threshold_minutes == null ? null : Number(row.absence_late_threshold_minutes),
+    }
+  }
+  const globalDefault = await runQuery<{
+    late_grace_minutes: number
+    early_grace_minutes: number
+    severe_late_threshold_minutes: number | null
+    absence_late_threshold_minutes: number | null
+  }>(
+    `SELECT late_grace_minutes, early_grace_minutes, severe_late_threshold_minutes, absence_late_threshold_minutes
+       FROM attendance_rules WHERE org_id = 'default' AND is_default = true LIMIT 1`,
+    [],
+  )
+  if (globalDefault.rows[0]) {
+    const row = globalDefault.rows[0]
+    return {
+      refKind: 'global_default_rule',
+      lateGraceMinutes: Number(row.late_grace_minutes) || 0,
+      earlyGraceMinutes: Number(row.early_grace_minutes) || 0,
+      severeLateThresholdMinutes:
+        row.severe_late_threshold_minutes == null ? null : Number(row.severe_late_threshold_minutes),
+      absenceLateThresholdMinutes:
+        row.absence_late_threshold_minutes == null ? null : Number(row.absence_late_threshold_minutes),
+    }
+  }
+  return null
+}
+
+function currentRuleBasisEnv(rule: CurrentRuleGraceParams | null): AttendanceDecisionTraceBasisEnv {
+  if (!rule) {
+    return { source: { kind: 'rule_live', ref: 'none' }, version: { posture: 'undeterminable' } }
+  }
+  return { source: { kind: 'rule_live', ref: rule.refKind }, version: { posture: 'current_live_no_history' } }
+}
+
+async function readAttendanceRecordRow(
+  orgId: string,
+  userId: string,
+  workDate: string,
+  runQuery: AttendanceDecisionTraceQueryFn,
+): Promise<AttendanceRecordRow | null> {
+  const result = await runQuery<AttendanceRecordRow>(
+    `SELECT id, status, is_workday, work_minutes, late_minutes, early_leave_minutes, meta, source_batch_id,
+            created_at, updated_at
+       FROM attendance_records
+      WHERE org_id = $1 AND user_id = $2 AND work_date = $3
+      LIMIT 1`,
+    [orgId, userId, workDate],
+  )
+  return result.rows[0] ?? null
+}
+
+/** §3.3①E3 correction environment — `attendance_record_result_edits` (AE-1, no FK on `record_id`,
+ *  keyed to the record's SUBJECT column `user_id` here — §4.1 distinguishes it from `actor_user_id`,
+ *  the operator column). Returns the MOST RECENT correction row, if any. */
+async function readMostRecentResultEdit(
+  orgId: string,
+  userId: string,
+  workDate: string,
+  runQuery: AttendanceDecisionTraceQueryFn,
+): Promise<{ created_at: string; actor_user_id: string } | null> {
+  const result = await runQuery<{ created_at: string; actor_user_id: string }>(
+    `SELECT created_at, actor_user_id
+       FROM attendance_record_result_edits
+      WHERE org_id = $1 AND user_id = $2 AND work_date = $3
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [orgId, userId, workDate],
+  )
+  return result.rows[0] ?? null
+}
+
+// -------------------------------------------------------------------------------------------------
+// ① today_status
+// -------------------------------------------------------------------------------------------------
+export interface AttendanceTodayStatusTraceResponse {
+  category: 'today_status'
+  reasonCode?: AttendanceRecordStatus
+  conclusion: {
+    workDate: string
+    status: AttendanceRecordStatus | null
+    isWorkday: boolean | null
+    workMinutes: number | null
+    lateMinutes: number | null
+    earlyLeaveMinutes: number | null
+  }
+  basis: AttendanceDecisionTraceBasisEnv[]
+  confidence: AttendanceDecisionTraceConfidence
+}
+
+export async function buildTodayStatusTrace(
+  orgId: string,
+  userId: string,
+  workDate: string,
+  runQuery: AttendanceDecisionTraceQueryFn,
+): Promise<AttendanceTodayStatusTraceResponse> {
+  const record = await readAttendanceRecordRow(orgId, userId, workDate, runQuery)
+  // §3.3① fail-closed: "record 行不存在 ⇒ 整类 undeterminable" — every environment undeterminable,
+  // and `reasonCode` (whose only closed set is the `status` column) has no value to report — the
+  // key is OMITTED (not fabricated as null/placeholder), mirroring the ⑤ unknown-branch discipline
+  // (§3.3⑤ "键整体缺席，非 null").
+  if (!record) {
+    const basis: AttendanceDecisionTraceBasisEnv[] = [
+      { source: { kind: 'record', ref: 'attendance_records' }, version: { posture: 'undeterminable' } },
+    ]
+    return {
+      category: 'today_status',
+      conclusion: {
+        workDate,
+        status: null,
+        isWorkday: null,
+        workMinutes: null,
+        lateMinutes: null,
+        earlyLeaveMinutes: null,
+      },
+      basis,
+      confidence: 'undeterminable',
+    }
+  }
+
+  const status = record.status as AttendanceRecordStatus
+  const rule = await resolveCurrentRuleGraceParams(orgId, userId, runQuery)
+  const correction = await readMostRecentResultEdit(orgId, userId, workDate, runQuery)
+
+  const basis: AttendanceDecisionTraceBasisEnv[] = [
+    {
+      source: { kind: 'record', ref: 'attendance_records' },
+      version: { posture: 'snapshot_frozen', asOf: record.updated_at },
+      auditRef: {
+        kind: 'record_write',
+        at: record.updated_at,
+      },
+    },
+    // §3.3① E2: this environment ALSO carries the "为什么应出勤" decision chain (owner freeze ③) —
+    // its RESULT is the E1 record's `is_workday` column (already surfaced above); the environment
+    // here is only the current rule-resolution identity, always `current_live_no_history`.
+    currentRuleBasisEnv(rule),
+  ]
+  if (correction) {
+    basis.push({
+      source: { kind: 'audit', ref: 'attendance_record_result_edits' },
+      version: { posture: 'snapshot_frozen', asOf: correction.created_at },
+      auditRef: {
+        kind: 'result_edit',
+        at: correction.created_at,
+        actor: (await resolveAttendanceDecisionTraceActor(correction.actor_user_id, runQuery)) ?? undefined,
+      },
+    })
+  }
+  if (status === 'absent') {
+    // §1-3 / §3.3① E4: materialized absence rows carry zero generation-source marker — always
+    // undeterminable, never a fabricated "who ran the job" claim.
+    basis.push({ source: { kind: 'policy_gate', ref: 'auto_absence_generation' }, version: { posture: 'undeterminable' } })
+  }
+
+  return {
+    category: 'today_status',
+    reasonCode: status,
+    conclusion: {
+      workDate,
+      status,
+      isWorkday: record.is_workday,
+      workMinutes: record.work_minutes,
+      lateMinutes: record.late_minutes,
+      earlyLeaveMinutes: record.early_leave_minutes,
+    },
+    basis,
+    confidence: deriveAttendanceDecisionTraceConfidence(basis),
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+// ② late_early
+// -------------------------------------------------------------------------------------------------
+export interface AttendanceLateEarlyTraceResponse {
+  category: 'late_early'
+  reasonCode?: AttendanceRecordStatus
+  conclusion: {
+    lateMinutes: number | null
+    earlyLeaveMinutes: number | null
+    severeLateCount: number | null
+    severeLateMinutes: number | null
+    absenceLateCount: number | null
+    status: AttendanceRecordStatus | null
+  }
+  basis: AttendanceDecisionTraceBasisEnv[]
+  confidence: AttendanceDecisionTraceConfidence
+}
+
+export async function buildLateEarlyTrace(
+  orgId: string,
+  userId: string,
+  workDate: string,
+  runQuery: AttendanceDecisionTraceQueryFn,
+): Promise<AttendanceLateEarlyTraceResponse> {
+  const record = await readAttendanceRecordRow(orgId, userId, workDate, runQuery)
+  if (!record) {
+    const basis: AttendanceDecisionTraceBasisEnv[] = [
+      { source: { kind: 'record', ref: 'attendance_records' }, version: { posture: 'undeterminable' } },
+    ]
+    return {
+      category: 'late_early',
+      conclusion: {
+        lateMinutes: null,
+        earlyLeaveMinutes: null,
+        severeLateCount: null,
+        severeLateMinutes: null,
+        absenceLateCount: null,
+        status: null,
+      },
+      basis,
+      confidence: 'undeterminable',
+    }
+  }
+
+  const status = record.status as AttendanceRecordStatus
+  const meta = (record.meta ?? {}) as Record<string, unknown>
+  // §1-2 / §3.2 last row: tier counts are a HALF-snapshot — the RESULT is frozen in `meta` at
+  // upsert time, but the threshold VALUE itself is not. Legacy rows predating #3055 never carry
+  // these keys (`index.cjs:18824-18825` comment, verbatim) — that leg is `undeterminable`, never a
+  // fabricated "no severe lateness" 0.
+  const hasTierKeys =
+    Object.prototype.hasOwnProperty.call(meta, 'severe_late_count') &&
+    Object.prototype.hasOwnProperty.call(meta, 'severe_late_minutes') &&
+    Object.prototype.hasOwnProperty.call(meta, 'absence_late_count')
+  const rule = await resolveCurrentRuleGraceParams(orgId, userId, runQuery)
+  const correction = await readMostRecentResultEdit(orgId, userId, workDate, runQuery)
+  const remediation = await runQuery<{ id: string; metadata: Record<string, unknown> | null; created_at: string }>(
+    `SELECT id, metadata, created_at
+       FROM attendance_requests
+      WHERE org_id = $1 AND user_id = $2 AND work_date = $3
+        AND request_type IN ('missed_check_in', 'missed_check_out', 'time_correction')
+        AND status = 'approved'
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [orgId, userId, workDate],
+  )
+
+  const basis: AttendanceDecisionTraceBasisEnv[] = [
+    {
+      source: { kind: 'record', ref: 'attendance_records' },
+      version: { posture: 'snapshot_frozen', asOf: record.updated_at },
+    },
+    {
+      source: { kind: 'record', ref: 'attendance_records.meta.tier' },
+      version: hasTierKeys ? { posture: 'snapshot_frozen', asOf: record.updated_at } : { posture: 'undeterminable' },
+    },
+    currentRuleBasisEnv(rule),
+  ]
+  if (correction) {
+    basis.push({
+      source: { kind: 'audit', ref: 'attendance_record_result_edits' },
+      version: { posture: 'snapshot_frozen', asOf: correction.created_at },
+      auditRef: {
+        kind: 'result_edit',
+        at: correction.created_at,
+        actor: (await resolveAttendanceDecisionTraceActor(correction.actor_user_id, runQuery)) ?? undefined,
+      },
+    })
+  }
+  const remediationRow = remediation.rows[0]
+  const makeupSnapshot = remediationRow?.metadata
+    ? (remediationRow.metadata as Record<string, unknown>).makeupPunchPolicySnapshot
+    : null
+  if (remediationRow && makeupSnapshot && typeof makeupSnapshot === 'object') {
+    const snap = makeupSnapshot as Record<string, unknown>
+    const requestEvaluatedAt = typeof snap.requestEvaluatedAt === 'string' ? snap.requestEvaluatedAt : remediationRow.created_at
+    basis.push({
+      source: { kind: 'snapshot', ref: 'attendance_requests.metadata.makeupPunchPolicySnapshot' },
+      version: {
+        posture: 'snapshot_frozen',
+        asOf: requestEvaluatedAt,
+        snapshotVersion: typeof snap.version === 'number' ? String(snap.version) : undefined,
+      },
+    })
+  }
+
+  return {
+    category: 'late_early',
+    reasonCode: status,
+    conclusion: {
+      lateMinutes: record.late_minutes,
+      earlyLeaveMinutes: record.early_leave_minutes,
+      severeLateCount: hasTierKeys ? Number(meta.severe_late_count) || 0 : null,
+      severeLateMinutes: hasTierKeys ? Number(meta.severe_late_minutes) || 0 : null,
+      absenceLateCount: hasTierKeys ? Number(meta.absence_late_count) || 0 : null,
+      status,
+    },
+    basis,
+    confidence: deriveAttendanceDecisionTraceConfidence(basis),
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+// ③ missing_punch
+// -------------------------------------------------------------------------------------------------
+export type AttendanceMissingSide = 'check_in' | 'check_out' | 'both'
+export type AttendanceSuggestedRequestType = 'leave' | 'missed_check_in' | 'missed_check_out' | 'time_correction'
+
+/** Mirrors `classifyOwedPunchRecord` (`index.cjs:25932-25956`) EXACTLY — same decision table, same
+ *  closed set of reason strings. Not imported (core-backend has no sanctioned static import of the
+ *  plugin CJS runtime), reproduced here as the authoritative TS copy for the trace read path; drift
+ *  risk is closed by the contract test parsing the plugin source text (mirrors the W4-0 punch-policy
+ *  closed-set reconciliation precedent). NEVER invents a new reason string beyond this table (§3.1
+ *  hard rule 4). */
+export function classifyAttendanceOwedPunch(row: {
+  status: string | null
+  is_workday: boolean | null
+  first_in_at: unknown
+  last_out_at: unknown
+}): { owedPunch: boolean; missingSide: AttendanceMissingSide | null; owedPunchReason: string } {
+  const status = String(row?.status ?? '')
+  if (row?.is_workday === false) {
+    return { owedPunch: false, missingSide: null, owedPunchReason: 'non_workday' }
+  }
+  if (status === 'absent') {
+    return { owedPunch: true, missingSide: 'both', owedPunchReason: 'absent_workday' }
+  }
+  if (status !== 'partial') {
+    return { owedPunch: false, missingSide: null, owedPunchReason: status ? `status_${status}` : 'status_unknown' }
+  }
+  const missingIn = !row.first_in_at
+  const missingOut = !row.last_out_at
+  if (missingIn && missingOut) {
+    return { owedPunch: true, missingSide: 'both', owedPunchReason: 'partial_missing_both' }
+  }
+  if (missingIn) {
+    return { owedPunch: true, missingSide: 'check_in', owedPunchReason: 'partial_missing_check_in' }
+  }
+  if (missingOut) {
+    return { owedPunch: true, missingSide: 'check_out', owedPunchReason: 'partial_missing_check_out' }
+  }
+  return { owedPunch: false, missingSide: null, owedPunchReason: 'partial_complete' }
+}
+
+/** Mirrors `suggestRequestType` (`index.cjs:26427-26436`) exactly. */
+export function suggestAttendanceRequestType(row: {
+  status: string | null
+  first_in_at: unknown
+  last_out_at: unknown
+}): AttendanceSuggestedRequestType | null {
+  const status = row?.status ? String(row.status) : ''
+  if (status === 'absent') return 'leave'
+  if (status === 'partial') {
+    if (!row.first_in_at) return 'missed_check_in'
+    if (!row.last_out_at) return 'missed_check_out'
+    return 'time_correction'
+  }
+  if (status === 'late' || status === 'early_leave' || status === 'late_early') return 'time_correction'
+  return null
+}
+
+export interface AttendanceMissingPunchTraceResponse {
+  category: 'missing_punch'
+  reasonCode?: string
+  conclusion: {
+    missingSide: AttendanceMissingSide | null
+    isWorkday: boolean | null
+    suggestedRequestType: AttendanceSuggestedRequestType | null
+  }
+  basis: AttendanceDecisionTraceBasisEnv[]
+  confidence: AttendanceDecisionTraceConfidence
+}
+
+export async function buildMissingPunchTrace(
+  orgId: string,
+  userId: string,
+  workDate: string,
+  runQuery: AttendanceDecisionTraceQueryFn,
+): Promise<AttendanceMissingPunchTraceResponse> {
+  const recordResult = await runQuery<
+    AttendanceRecordRow & { first_in_at: string | null; last_out_at: string | null }
+  >(
+    `SELECT id, status, is_workday, work_minutes, late_minutes, early_leave_minutes, meta, source_batch_id,
+            created_at, updated_at, first_in_at, last_out_at
+       FROM attendance_records
+      WHERE org_id = $1 AND user_id = $2 AND work_date = $3
+      LIMIT 1`,
+    [orgId, userId, workDate],
+  )
+  const record = recordResult.rows[0] ?? null
+  const rule = await resolveCurrentRuleGraceParams(orgId, userId, runQuery)
+  // §3.3③ fail-closed: no record AND the current rule cannot resolve ⇒整类 undeterminable.
+  if (!record) {
+    const basis: AttendanceDecisionTraceBasisEnv[] = [
+      { source: { kind: 'record', ref: 'attendance_records' }, version: { posture: 'undeterminable' } },
+    ]
+    if (rule) basis.push(currentRuleBasisEnv(rule))
+    return {
+      category: 'missing_punch',
+      conclusion: { missingSide: null, isWorkday: null, suggestedRequestType: null },
+      basis,
+      confidence: 'undeterminable',
+    }
+  }
+
+  const classification = classifyAttendanceOwedPunch(record)
+  const suggested = suggestAttendanceRequestType(record)
+  const remediation = await runQuery<{ id: string; created_at: string; metadata: Record<string, unknown> | null }>(
+    `SELECT id, created_at, metadata
+       FROM attendance_requests
+      WHERE org_id = $1 AND user_id = $2 AND work_date = $3
+        AND request_type IN ('missed_check_in', 'missed_check_out', 'time_correction')
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [orgId, userId, workDate],
+  )
+
+  const basis: AttendanceDecisionTraceBasisEnv[] = [
+    { source: { kind: 'record', ref: 'attendance_records' }, version: { posture: 'snapshot_frozen', asOf: record.updated_at } },
+    currentRuleBasisEnv(rule),
+  ]
+  if (record.status === 'absent') {
+    basis.push({ source: { kind: 'policy_gate', ref: 'auto_absence_generation' }, version: { posture: 'undeterminable' } })
+  }
+  const remediationRow = remediation.rows[0]
+  if (remediationRow) {
+    const snap = (remediationRow.metadata ?? {}) as Record<string, unknown>
+    const makeupSnapshot = snap.makeupPunchPolicySnapshot
+    if (makeupSnapshot && typeof makeupSnapshot === 'object') {
+      const s = makeupSnapshot as Record<string, unknown>
+      basis.push({
+        source: { kind: 'snapshot', ref: 'attendance_requests.metadata.makeupPunchPolicySnapshot' },
+        version: {
+          posture: 'snapshot_frozen',
+          asOf: typeof s.requestEvaluatedAt === 'string' ? s.requestEvaluatedAt : remediationRow.created_at,
+          snapshotVersion: typeof s.version === 'number' ? String(s.version) : undefined,
+        },
+      })
+    } else {
+      basis.push({
+        source: { kind: 'audit', ref: 'attendance_requests' },
+        version: { posture: 'snapshot_frozen', asOf: remediationRow.created_at },
+      })
+    }
+  }
+
+  return {
+    category: 'missing_punch',
+    reasonCode: classification.owedPunchReason,
+    conclusion: {
+      missingSide: classification.missingSide,
+      isWorkday: record.is_workday,
+      suggestedRequestType: suggested,
+    },
+    basis,
+    confidence: deriveAttendanceDecisionTraceConfidence(basis),
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+// ④ overtime_segmentation (keyed by a single overtime `attendance_requests` row — the segmentation
+// snapshot and rule/flow/approval environments are all per-instance facts, §3.2's `resolvedAt`
+// anchor is a single request's terminal-review timestamp, not an aggregate).
+// -------------------------------------------------------------------------------------------------
+const OVERTIME_SEGMENTATION_ENGINE = 'attendance_overtime_segmentation_v1'
+const OVERTIME_SEGMENTATION_VERSION = 1
+
+export type AttendanceOvertimeDayType = 'workday' | 'restday' | 'holiday'
+export type AttendanceOvertimeCoverageNote = 'full' | 'partial_legacy'
+
+export interface AttendanceOvertimeSegmentationTraceResponse {
+  category: 'overtime_segmentation'
+  coverageNote: AttendanceOvertimeCoverageNote
+  conclusion: {
+    workdayMinutes: number
+    restdayMinutes: number
+    holidayMinutes: number
+    totalMinutes: number
+    segmentationVersion: number | null
+    segments: Array<{ dayType: AttendanceOvertimeDayType; minutes: number; reasonCode: string; holidayName: string | null }>
+  }
+  basis: AttendanceDecisionTraceBasisEnv[]
+  confidence: AttendanceDecisionTraceConfidence
+}
+
+/** 404-shape sentinel — reference-style targets (④ requestId, ⑥ instanceId) return this exact
+ *  literal so a real-not-found and an other-user's-row-under-subject-constraint 404 are
+ *  byte-identical (§4.1 存在性 oracle defense). */
+export const ATTENDANCE_DECISION_TRACE_NOT_FOUND = Symbol('attendance-decision-trace-not-found')
+
+export async function buildOvertimeSegmentationTrace(
+  orgId: string,
+  userId: string,
+  requestId: string,
+  runQuery: AttendanceDecisionTraceQueryFn,
+  overtimeSegmentationEnabled: boolean,
+): Promise<AttendanceOvertimeSegmentationTraceResponse | typeof ATTENDANCE_DECISION_TRACE_NOT_FOUND> {
+  const result = await runQuery<{
+    id: string
+    metadata: Record<string, unknown> | null
+    resolved_at: string | null
+    updated_at: string
+  }>(
+    `SELECT id, metadata, resolved_at, updated_at
+       FROM attendance_requests
+      WHERE org_id = $1 AND user_id = $2 AND id = $3
+        AND request_type = 'overtime'
+      LIMIT 1`,
+    [orgId, userId, requestId],
+  )
+  const row = result.rows[0]
+  if (!row) return ATTENDANCE_DECISION_TRACE_NOT_FOUND
+
+  const metadata = (row.metadata ?? {}) as Record<string, unknown>
+  const snapshot = metadata.overtimeSegmentation as Record<string, unknown> | undefined
+  const snapshotValid =
+    snapshot &&
+    typeof snapshot === 'object' &&
+    snapshot.version === OVERTIME_SEGMENTATION_VERSION &&
+    snapshot.engine === OVERTIME_SEGMENTATION_ENGINE
+  const resolvedAt = row.resolved_at ?? row.updated_at
+
+  const basis: AttendanceDecisionTraceBasisEnv[] = []
+  const segments: AttendanceOvertimeSegmentationTraceResponse['conclusion']['segments'] = []
+  let workdayMinutes = 0
+  let restdayMinutes = 0
+  let holidayMinutes = 0
+  let totalMinutes = 0
+
+  if (snapshotValid) {
+    const segs = (snapshot!.segments ?? {}) as Record<string, unknown>
+    workdayMinutes = Number(segs.workdayMinutes) || 0
+    restdayMinutes = Number(segs.restdayMinutes) || 0
+    holidayMinutes = Number(segs.holidayMinutes) || 0
+    totalMinutes = Number(snapshot!.totalMinutes) || 0
+    const calendar = (snapshot!.calendar ?? {}) as Record<string, unknown>
+    const dayType = (snapshot!.dayType as AttendanceOvertimeDayType) ?? 'restday'
+    const minutesForType = dayType === 'workday' ? workdayMinutes : dayType === 'holiday' ? holidayMinutes : restdayMinutes
+    segments.push({
+      dayType,
+      minutes: minutesForType,
+      reasonCode: typeof calendar.effectiveSource === 'string' ? calendar.effectiveSource : 'unknown',
+      holidayName: typeof calendar.holidayName === 'string' ? calendar.holidayName : null,
+    })
+    basis.push({
+      source: { kind: 'snapshot', ref: 'attendance_requests.metadata.overtimeSegmentation' },
+      version: { posture: 'snapshot_frozen', asOf: resolvedAt, snapshotVersion: String(OVERTIME_SEGMENTATION_VERSION) },
+    })
+  } else {
+    basis.push({ source: { kind: 'snapshot', ref: 'attendance_requests.metadata.overtimeSegmentation' }, version: { posture: 'undeterminable' } })
+    totalMinutes = Number(metadata.minutes) || 0
+  }
+
+  const overtimeRule = metadata.overtimeRule
+  if (overtimeRule && typeof overtimeRule === 'object') {
+    basis.push({
+      source: { kind: 'snapshot', ref: 'attendance_requests.metadata.overtimeRule' },
+      version: { posture: 'snapshot_frozen', asOf: resolvedAt },
+    })
+  }
+  const liveRule = await runQuery<{ id: string }>(
+    `SELECT id FROM attendance_overtime_rules WHERE org_id = $1 AND is_active = true LIMIT 1`,
+    [orgId],
+  )
+  basis.push({
+    source: { kind: 'rule_live', ref: 'attendance_overtime_rules' },
+    version: { posture: liveRule.rows[0] ? 'current_live_no_history' : 'undeterminable' },
+  })
+
+  const approvalFlow = metadata.approvalFlow
+  basis.push({
+    source: { kind: 'audit', ref: 'attendance_requests.metadata.approvalFlow' },
+    version: approvalFlow ? { posture: 'snapshot_frozen', asOf: resolvedAt } : { posture: 'undeterminable' },
+  })
+  // §3.3④E4 engine-gate: a snapshot present on THIS request always wins (§3.1 hard rule 6, "快照排
+  // 他") — the engine gate is only informative for requests that never got a snapshot (legacy /
+  // engine-off-at-submit-time), where it explains WHY `coverageNote='partial_legacy'`.
+  if (!snapshotValid) {
+    basis.push({
+      source: { kind: 'policy_gate', ref: 'overtimeSegmentation' },
+      version: { posture: overtimeSegmentationEnabled ? 'undeterminable' : 'not_in_effect' },
+    })
+  }
+
+  return {
+    category: 'overtime_segmentation',
+    coverageNote: snapshotValid ? 'full' : 'partial_legacy',
+    conclusion: {
+      workdayMinutes,
+      restdayMinutes,
+      holidayMinutes,
+      totalMinutes,
+      segmentationVersion: snapshotValid ? OVERTIME_SEGMENTATION_VERSION : null,
+      segments,
+    },
+    basis,
+    confidence: deriveAttendanceDecisionTraceConfidence(basis),
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+// ⑤ comp_time_balance — `sourceResolution` known/unknown discriminated union (§3.1 hard rule 5⑤).
+// -------------------------------------------------------------------------------------------------
+
+/** Frozen enum by literal write-site value (§3.1 hard rule 5⑤ / §11.1) —
+ *  `'annual_accrual'` (`index.cjs:17922`), `'annual_manual_adjust'` (`:18162`),
+ *  `'overtime_conversion'` (`:29788`/`:29863`). `attendance_leave_balances.source_type` is free TEXT
+ *  (no CHECK, `zzzz20260603120000:34`) — NEVER pass a raw value through; anything outside this map
+ *  is the `'unknown_source'` branch with the `reasonCode` key entirely absent. */
+const ATTENDANCE_COMP_TIME_LOT_SOURCE_TYPE_TO_REASON_CODE: Record<string, string> = {
+  annual_accrual: 'annual_accrual',
+  annual_manual_adjust: 'annual_manual_adjust',
+  overtime_conversion: 'overtime_conversion',
+}
+
+export type AttendanceCompTimeLot =
+  | { sourceResolution: 'mapped'; reasonCode: string; grantedAt: string; expiresAt: string | null; overtimeSource?: string }
+  | { sourceResolution: 'unknown_source'; grantedAt: string; expiresAt: string | null; overtimeSource?: string }
+
+export interface AttendanceCompTimeBalanceTraceResponse {
+  category: 'comp_time_balance'
+  conclusion: {
+    summary: { grantedMinutes: number; remainingMinutes: number; exhaustedMinutes: number; expiredMinutes: number }
+    lots: AttendanceCompTimeLot[]
+    events: Array<{ eventType: string; deltaMinutes: number; occurredAt: string }>
+  }
+  basis: AttendanceDecisionTraceBasisEnv[]
+  confidence: AttendanceDecisionTraceConfidence
+}
+
+const COMP_TIME_LEAVE_TYPE_CODE = 'comp_time'
+
+export async function buildCompTimeBalanceTrace(
+  orgId: string,
+  userId: string,
+  runQuery: AttendanceDecisionTraceQueryFn,
+  settingsEnabled: { compTimeFromOvertime: boolean; overtimeBankPolicy: boolean },
+): Promise<AttendanceCompTimeBalanceTraceResponse> {
+  const summaryResult = await runQuery<{ granted: string; exhausted: string; expired: string }>(
+    `SELECT
+       COALESCE(SUM(CASE WHEN e.event_type = 'grant' THEN e.delta_minutes ELSE 0 END), 0) AS granted,
+       COALESCE(SUM(CASE WHEN e.event_type = 'deduct' THEN -e.delta_minutes ELSE 0 END), 0) AS exhausted,
+       COALESCE(SUM(CASE WHEN e.event_type = 'expire' THEN -e.delta_minutes ELSE 0 END), 0) AS expired
+     FROM attendance_leave_balance_events e
+     JOIN attendance_leave_balances b ON b.id = e.balance_id AND b.org_id = e.org_id AND b.user_id = e.user_id
+     WHERE e.org_id = $1 AND e.user_id = $2 AND b.leave_type_code = $3`,
+    [orgId, userId, COMP_TIME_LEAVE_TYPE_CODE],
+  )
+  const remainingResult = await runQuery<{ remaining: string }>(
+    `SELECT COALESCE(SUM(remaining_minutes), 0) AS remaining
+       FROM attendance_leave_balances
+      WHERE org_id = $1 AND user_id = $2 AND leave_type_code = $3 AND status = 'active'`,
+    [orgId, userId, COMP_TIME_LEAVE_TYPE_CODE],
+  )
+  const lotsResult = await runQuery<{
+    id: string
+    source_type: string
+    granted_at: string
+    expires_at: string | null
+    overtime_source: string | null
+  }>(
+    `SELECT id, source_type, granted_at, expires_at, overtime_source
+       FROM attendance_leave_balances
+      WHERE org_id = $1 AND user_id = $2 AND leave_type_code = $3 AND status = 'active'
+      ORDER BY expires_at ASC NULLS LAST, granted_at ASC, id ASC`,
+    [orgId, userId, COMP_TIME_LEAVE_TYPE_CODE],
+  )
+  const eventsResult = await runQuery<{ event_type: string; delta_minutes: number; occurred_at: string }>(
+    `SELECT e.event_type, e.delta_minutes, e.occurred_at
+       FROM attendance_leave_balance_events e
+       JOIN attendance_leave_balances b ON b.id = e.balance_id AND b.org_id = e.org_id AND b.user_id = e.user_id
+      WHERE e.org_id = $1 AND e.user_id = $2 AND b.leave_type_code = $3
+      ORDER BY e.occurred_at DESC, e.id DESC
+      LIMIT 50`,
+    [orgId, userId, COMP_TIME_LEAVE_TYPE_CODE],
+  )
+
+  const lots: AttendanceCompTimeLot[] = lotsResult.rows.map((row) => {
+    const overtimeSource = row.overtime_source ?? undefined
+    const mapped = ATTENDANCE_COMP_TIME_LOT_SOURCE_TYPE_TO_REASON_CODE[row.source_type]
+    if (mapped) {
+      return {
+        sourceResolution: 'mapped',
+        reasonCode: mapped,
+        grantedAt: row.granted_at,
+        expiresAt: row.expires_at,
+        ...(overtimeSource ? { overtimeSource } : {}),
+      }
+    }
+    return {
+      sourceResolution: 'unknown_source',
+      grantedAt: row.granted_at,
+      expiresAt: row.expires_at,
+      ...(overtimeSource ? { overtimeSource } : {}),
+    }
+  })
+
+  const basis: AttendanceDecisionTraceBasisEnv[] = [
+    {
+      source: { kind: 'ledger', ref: 'attendance_leave_balances' },
+      version: lots.length > 0 ? { posture: 'snapshot_frozen', asOf: lots[0].grantedAt } : { posture: 'undeterminable' },
+    },
+    {
+      source: { kind: 'ledger', ref: 'attendance_leave_balance_events' },
+      version:
+        eventsResult.rows.length > 0
+          ? { posture: 'snapshot_frozen', asOf: eventsResult.rows[0].occurred_at }
+          : { posture: 'undeterminable' },
+    },
+    {
+      source: { kind: 'policy_gate', ref: 'compTimeFromOvertime' },
+      version: { posture: settingsEnabled.compTimeFromOvertime ? 'current_live_no_history' : 'not_in_effect' },
+    },
+  ]
+
+  return {
+    category: 'comp_time_balance',
+    conclusion: {
+      summary: {
+        grantedMinutes: Number(summaryResult.rows[0]?.granted ?? 0),
+        remainingMinutes: Number(remainingResult.rows[0]?.remaining ?? 0),
+        exhaustedMinutes: Number(summaryResult.rows[0]?.exhausted ?? 0),
+        expiredMinutes: Number(summaryResult.rows[0]?.expired ?? 0),
+      },
+      lots,
+      events: eventsResult.rows.map((row) => ({
+        eventType: row.event_type,
+        deltaMinutes: row.delta_minutes,
+        occurredAt: row.occurred_at,
+      })),
+    },
+    basis,
+    confidence: deriveAttendanceDecisionTraceConfidence(basis),
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+// "Seventh read face" (OD-W5-6=(a)) — `attendance_payroll_cycle_settlements` has NO existing read
+// API (only INSERT + LIMIT-1 existence probes, per the design lock's §1-4 grounding). This is a
+// standalone read used both directly (admin/self list) and as ⑤'s E4 settlement environment.
+// -------------------------------------------------------------------------------------------------
+export interface AttendancePayrollCycleSettlementRow {
+  cycleId: string
+  periodStartDate: string
+  periodEndDate: string
+  closedAt: string
+  source: string
+  convertibleMinutes: number
+  mustPayMinutes: number
+}
+
+export async function readAttendancePayrollCycleSettlements(
+  orgId: string,
+  userId: string,
+  runQuery: AttendanceDecisionTraceQueryFn,
+): Promise<AttendancePayrollCycleSettlementRow[]> {
+  const result = await runQuery<{
+    cycle_id: string
+    period_start_date: string
+    period_end_date: string
+    closed_at: string
+    source: string
+    convertible_minutes: number
+    must_pay_minutes: number
+  }>(
+    `SELECT cycle_id, period_start_date, period_end_date, closed_at, source, convertible_minutes, must_pay_minutes
+       FROM attendance_payroll_cycle_settlements
+      WHERE org_id = $1 AND user_id = $2
+      ORDER BY closed_at DESC, cycle_id ASC`,
+    [orgId, userId],
+  )
+  return result.rows.map((row) => ({
+    cycleId: row.cycle_id,
+    periodStartDate: row.period_start_date,
+    periodEndDate: row.period_end_date,
+    closedAt: row.closed_at,
+    source: row.source,
+    convertibleMinutes: row.convertible_minutes,
+    mustPayMinutes: row.must_pay_minutes,
+  }))
+}
+
+/** Fold the settlement read face into ⑤'s E4 basis environment (§3.3⑤E4) — has its OWN
+ *  `not_in_effect` vs `undeterminable` split, gated by `overtimeBankPolicy.enabled`. */
+export function attendancePayrollCycleSettlementBasisEnv(
+  settlements: AttendancePayrollCycleSettlementRow[],
+  overtimeBankPolicyEnabled: boolean,
+): AttendanceDecisionTraceBasisEnv {
+  if (settlements.length > 0) {
+    return {
+      source: { kind: 'snapshot', ref: 'attendance_payroll_cycle_settlements' },
+      version: { posture: 'snapshot_frozen', asOf: settlements[0].closedAt },
+    }
+  }
+  return {
+    source: { kind: 'snapshot', ref: 'attendance_payroll_cycle_settlements' },
+    version: { posture: overtimeBankPolicyEnabled ? 'undeterminable' : 'not_in_effect' },
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+// ⑥ approver_source
+// -------------------------------------------------------------------------------------------------
+export const ATTENDANCE_APPROVER_SOURCE_KINDS = [
+  'direct_manager',
+  'dept_head',
+  'manager_at_level',
+  'static',
+  'legacy_fallback',
+  'unknown',
+] as const
+export type AttendanceApproverSourceKind = (typeof ATTENDANCE_APPROVER_SOURCE_KINDS)[number]
+
+export interface AttendanceApproverSourceStep {
+  stepIndex: number
+  assigneeResolved: boolean
+  sourceKind: AttendanceApproverSourceKind
+  reasonCode: AttendanceApproverSourceKind
+  level?: number
+  actor?: AttendanceDecisionTraceActor
+}
+
+export interface AttendanceApproverSourceTraceResponse {
+  category: 'approver_source'
+  conclusion: { steps: AttendanceApproverSourceStep[] }
+  basis: AttendanceDecisionTraceBasisEnv[]
+  confidence: AttendanceDecisionTraceConfidence
+}
+
+function classifyApproverAssignmentMetadata(metadata: Record<string, unknown>): {
+  sourceKind: AttendanceApproverSourceKind
+  level?: number
+} {
+  const resolvedFrom = metadata.resolvedFrom
+  if (resolvedFrom && typeof resolvedFrom === 'object') {
+    const kind = (resolvedFrom as Record<string, unknown>).kind
+    if (kind === 'direct_manager' || kind === 'dept_head' || kind === 'manager_at_level') {
+      const level = (resolvedFrom as Record<string, unknown>).level
+      return { sourceKind: kind, ...(typeof level === 'number' ? { level } : {}) }
+    }
+  }
+  if (typeof metadata.queue === 'string') return { sourceKind: 'legacy_fallback' }
+  if (typeof metadata.stepName !== 'undefined') return { sourceKind: 'static' }
+  return { sourceKind: 'unknown' }
+}
+
+export async function buildApproverSourceTrace(
+  orgId: string,
+  userId: string,
+  instanceId: string,
+  runQuery: AttendanceDecisionTraceQueryFn,
+  dynamicAssigneeSourcesEnabled: boolean,
+): Promise<AttendanceApproverSourceTraceResponse | typeof ATTENDANCE_DECISION_TRACE_NOT_FOUND> {
+  // §4.1 reverse-link ownership: attendance_requests.user_id = subject AND approval_instance_id =
+  // target — NEVER a requester_snapshot JSONB comparison (the snapshot is a display artifact, not
+  // an authorization source of truth).
+  const requestLink = await runQuery<{ id: string }>(
+    `SELECT id FROM attendance_requests WHERE org_id = $1 AND user_id = $2 AND approval_instance_id = $3 LIMIT 1`,
+    [orgId, userId, instanceId],
+  )
+  if (!requestLink.rows[0]) return ATTENDANCE_DECISION_TRACE_NOT_FOUND
+
+  const instanceResult = await runQuery<{
+    id: string
+    created_at: string
+    requester_snapshot: Record<string, unknown> | null
+    metadata: Record<string, unknown> | null
+  }>(
+    `SELECT id, created_at, requester_snapshot, metadata FROM approval_instances WHERE id = $1 LIMIT 1`,
+    [instanceId],
+  )
+  const instance = instanceResult.rows[0]
+  if (!instance) return ATTENDANCE_DECISION_TRACE_NOT_FOUND
+
+  const assignmentsResult = await runQuery<{
+    assignment_type: string
+    assignee_id: string
+    source_step: number
+    metadata: Record<string, unknown> | null
+    updated_at: string
+  }>(
+    `SELECT assignment_type, assignee_id, source_step, metadata, updated_at
+       FROM approval_assignments
+      WHERE instance_id = $1
+      ORDER BY source_step ASC, created_at ASC`,
+    [instanceId],
+  )
+
+  const bySourceStep = new Map<number, (typeof assignmentsResult.rows)[number][]>()
+  for (const row of assignmentsResult.rows) {
+    const list = bySourceStep.get(row.source_step) ?? []
+    list.push(row)
+    bySourceStep.set(row.source_step, list)
+  }
+
+  const steps: AttendanceApproverSourceStep[] = []
+  for (const [stepIndex, rows] of Array.from(bySourceStep.entries()).sort((a, b) => a[0] - b[0])) {
+    const first = rows[0]
+    const meta = (first.metadata ?? {}) as Record<string, unknown>
+    const { sourceKind, level } = classifyApproverAssignmentMetadata(meta)
+    let actor: AttendanceDecisionTraceActor | undefined
+    if (first.assignment_type === 'user') {
+      actor = (await resolveAttendanceDecisionTraceActor(first.assignee_id, runQuery)) ?? undefined
+    }
+    steps.push({
+      stepIndex,
+      assigneeResolved: true,
+      sourceKind,
+      reasonCode: sourceKind,
+      ...(typeof level === 'number' ? { level } : {}),
+      ...(actor ? { actor } : {}),
+    })
+  }
+
+  const basis: AttendanceDecisionTraceBasisEnv[] = [
+    {
+      source: { kind: 'record', ref: 'approval_assignments' },
+      version: steps.length > 0 ? { posture: 'snapshot_frozen', asOf: assignmentsResult.rows[0].updated_at } : { posture: 'undeterminable' },
+    },
+  ]
+  const recordsResult = await runQuery<{ occurred_at: string }>(
+    `SELECT occurred_at FROM approval_records WHERE instance_id = $1 ORDER BY occurred_at DESC LIMIT 1`,
+    [instanceId],
+  )
+  basis.push({
+    source: { kind: 'audit', ref: 'approval_records' },
+    version: recordsResult.rows[0]
+      ? { posture: 'snapshot_frozen', asOf: recordsResult.rows[0].occurred_at }
+      : { posture: 'undeterminable' },
+  })
+  basis.push({
+    source: { kind: 'snapshot', ref: 'approval_instances.requester_snapshot' },
+    version: { posture: 'snapshot_frozen', asOf: instance.created_at },
+  })
+  const approvalFlow = (instance.metadata ?? {}) as Record<string, unknown>
+  basis.push({
+    source: { kind: 'snapshot', ref: 'approval_instances.metadata.approvalFlow' },
+    version: approvalFlow.approvalFlow ? { posture: 'snapshot_frozen', asOf: instance.created_at } : { posture: 'undeterminable' },
+  })
+  // §3.3⑥E5 door: whether the DYNAMIC-kind resolver is enabled TODAY — informational only (the
+  // steps above already reflect the frozen historical resolution, §0.1⑥/OD-W5-2=(a): this module
+  // never re-explains WHY a resolution failed or would fail now, only discloses today's gate state
+  // honestly alongside the frozen facts).
+  const hasDynamicStep = steps.some((s) => s.sourceKind === 'direct_manager' || s.sourceKind === 'dept_head' || s.sourceKind === 'manager_at_level')
+  if (hasDynamicStep) {
+    basis.push({
+      source: { kind: 'policy_gate', ref: 'ATTENDANCE_APPROVAL_DYNAMIC_ASSIGNEE_SOURCES_ENABLED' },
+      version: { posture: dynamicAssigneeSourcesEnabled ? 'current_live_no_history' : 'not_in_effect' },
+    })
+  }
+
+  return {
+    category: 'approver_source',
+    conclusion: { steps },
+    basis,
+    confidence: deriveAttendanceDecisionTraceConfidence(basis),
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+// §5.2②/§9 W5-0-G5: engine-enablement gates read off the ONE deployment-wide `system_configs` row
+// (`attendance.settings`, single key — `index.cjs` `SETTINGS_KEY` `:291`, no org_id column). Only
+// the two booleans this module needs — never the whole settings blob (same discipline as W4-0's
+// punch-policy closed-set reader). Absent row / absent sub-key ⇒ the documented DEFAULT_SETTINGS
+// default (`false` for both — `index.cjs:377-380` compTimeFromOvertime, `:412-417`
+// overtimeBankPolicy), never a fabricated `true`.
+// -------------------------------------------------------------------------------------------------
+const ATTENDANCE_SETTINGS_KEY = 'attendance.settings'
+
+export interface AttendanceDecisionTraceSettingsGates {
+  compTimeFromOvertime: boolean
+  overtimeBankPolicy: boolean
+  overtimeSegmentation: boolean
+  autoAbsence: boolean
+  dynamicAssigneeSourcesEnabled: boolean
+}
+
+export async function readAttendanceDecisionTraceSettingsGates(
+  runQuery: AttendanceDecisionTraceQueryFn,
+): Promise<AttendanceDecisionTraceSettingsGates> {
+  const result = await runQuery<{ value: unknown }>('SELECT value FROM system_configs WHERE key = $1', [
+    ATTENDANCE_SETTINGS_KEY,
+  ])
+  const raw = result.rows[0]?.value
+  const value = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {}
+  const boolAt = (key: string, subkey: string): boolean => {
+    const section = value[key]
+    if (!section || typeof section !== 'object') return false
+    return (section as Record<string, unknown>)[subkey] === true
+  }
+  return {
+    compTimeFromOvertime: boolAt('compTimeFromOvertime', 'enabled'),
+    overtimeBankPolicy: boolAt('overtimeBankPolicy', 'enabled'),
+    overtimeSegmentation: boolAt('overtimeSegmentation', 'enabled'),
+    autoAbsence: boolAt('autoAbsence', 'enabled'),
+    dynamicAssigneeSourcesEnabled: process.env.ATTENDANCE_APPROVAL_DYNAMIC_ASSIGNEE_SOURCES_ENABLED === 'true',
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Discriminated response union (contract-test-friendly).
+// -------------------------------------------------------------------------------------------------
+export type AttendanceDecisionTraceResponse =
+  | AttendanceTodayStatusTraceResponse
+  | AttendanceLateEarlyTraceResponse
+  | AttendanceMissingPunchTraceResponse
+  | AttendanceOvertimeSegmentationTraceResponse
+  | AttendanceCompTimeBalanceTraceResponse
+  | AttendanceApproverSourceTraceResponse

--- a/packages/core-backend/src/services/AttendanceDecisionTrace.ts
+++ b/packages/core-backend/src/services/AttendanceDecisionTrace.ts
@@ -1228,7 +1228,22 @@ export async function readAttendanceDecisionTraceSettingsGates(
     ATTENDANCE_SETTINGS_KEY,
   ])
   const raw = result.rows[0]?.value
-  const value = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {}
+  // §11.1 legacy-schema note (same dual shape `readAttendancePunchPolicyPosture` handles,
+  // `AttendanceSetupReadinessAggregate.ts:364-368`): today's canonical migration creates
+  // `system_configs.value text` (`z20251231_create_system_configs.ts:14`, confirmed against the
+  // real dev DB — the pg driver returns a STRING here, never an auto-parsed object), but a
+  // legacy-migrated deployment could still carry an older `jsonb` column where the driver DOES
+  // auto-parse. Handle both shapes; a malformed/corrupt row fails closed to `{}` (every gate reads
+  // `false`), never throws.
+  let value: Record<string, unknown> = {}
+  if (raw !== undefined && raw !== null) {
+    try {
+      const parsed: unknown = typeof raw === 'object' ? raw : JSON.parse(String(raw))
+      if (parsed && typeof parsed === 'object') value = parsed as Record<string, unknown>
+    } catch {
+      value = {}
+    }
+  }
   const boolAt = (key: string, subkey: string): boolean => {
     const section = value[key]
     if (!section || typeof section !== 'object') return false

--- a/packages/core-backend/src/services/AttendanceDecisionTrace.ts
+++ b/packages/core-backend/src/services/AttendanceDecisionTrace.ts
@@ -172,7 +172,11 @@ export async function resolveAttendanceDecisionTraceActor(
   if (row.is_active === false) {
     return { displayLabel: '已停用用户', identityPosture: 'inactive' }
   }
-  const label = (row.name && row.name.trim()) || (row.email && row.email.trim()) || '已注册用户'
+  // §5.1 masking table, "裸内部 user id" row: email is NOT an allowlisted field for trace actor
+  // display (only displayName or a neutral label) — falling back to email would leak PII outside
+  // the §3.1 allowlist (owner review finding, W5-0 fix-round). A resolved user with no `name` gets
+  // the neutral label, same as the unresolved/inactive branches.
+  const label = (row.name && row.name.trim()) || '已注册用户'
   return { displayLabel: label, identityPosture: 'resolved' }
 }
 
@@ -554,10 +558,14 @@ export type AttendanceSuggestedRequestType = 'leave' | 'missed_check_in' | 'miss
 
 /** Mirrors `classifyOwedPunchRecord` (`index.cjs:25932-25956`) EXACTLY — same decision table, same
  *  closed set of reason strings. Not imported (core-backend has no sanctioned static import of the
- *  plugin CJS runtime), reproduced here as the authoritative TS copy for the trace read path; drift
- *  risk is closed by the contract test parsing the plugin source text (mirrors the W4-0 punch-policy
- *  closed-set reconciliation precedent). NEVER invents a new reason string beyond this table (§3.1
- *  hard rule 4). */
+ *  plugin CJS runtime), reproduced here as the authoritative TS copy for the trace read path.
+ *  KNOWN LIMITATION (disclosed, not a completion-door claim): `classifyOwedPunchRecord` and
+ *  `suggestRequestType` are closures scoped inside their route handlers in `index.cjs`, not
+ *  top-level exports (unlike `resolveOvertimeDayTypeFromEffectiveCalendarItem`, which IS exported
+ *  via `__attendanceOvertimeSegmentationForTests` and could support a real cross-runtime equivalence
+ *  test) — this copy's drift protection today is manual code-review re-sync on any future edit to
+ *  the plugin decision table, NOT an automated contract test. NEVER invents a new reason string
+ *  beyond this table (§3.1 hard rule 4). */
 export function classifyAttendanceOwedPunch(row: {
   status: string | null
   is_workday: boolean | null
@@ -689,6 +697,26 @@ export async function buildMissingPunchTrace(
       })
     }
   }
+  // §3.3③E4 "终审 adjustment 审计事件" — the generic write-time audit event every non-outdoor-punch/
+  // shift-swap/schedule-dispatch request type gets on resolution (`index.cjs:30077-30097`,
+  // `event_type='adjustment', source='request'`). Distinct from the `attendance_requests` row above
+  // (which only proves the REQUEST exists) — this proves an ADJUSTMENT was actually recorded against
+  // the day.
+  const adjustmentEvent = await runQuery<{ occurred_at: string }>(
+    `SELECT occurred_at
+       FROM attendance_events
+      WHERE org_id = $1 AND user_id = $2 AND work_date = $3
+        AND event_type = 'adjustment' AND source = 'request'
+      ORDER BY occurred_at DESC
+      LIMIT 1`,
+    [orgId, userId, workDate],
+  )
+  if (adjustmentEvent.rows[0]) {
+    basis.push({
+      source: { kind: 'audit', ref: 'attendance_events' },
+      version: { posture: 'snapshot_frozen', asOf: adjustmentEvent.rows[0].occurred_at },
+    })
+  }
 
   return {
     category: 'missing_punch',
@@ -713,6 +741,9 @@ const OVERTIME_SEGMENTATION_VERSION = 1
 
 export type AttendanceOvertimeDayType = 'workday' | 'restday' | 'holiday'
 export type AttendanceOvertimeCoverageNote = 'full' | 'partial_legacy'
+/** Mirrors `OVERTIME_DAY_TYPES` (`index.cjs`, same three-value closed set the plugin's own
+ *  segmentation snapshot builder validates against). */
+const OVERTIME_DAY_TYPES: ReadonlySet<string> = new Set(['workday', 'restday', 'holiday'])
 
 export interface AttendanceOvertimeSegmentationTraceResponse {
   category: 'overtime_segmentation'
@@ -723,7 +754,12 @@ export interface AttendanceOvertimeSegmentationTraceResponse {
     holidayMinutes: number
     totalMinutes: number
     segmentationVersion: number | null
-    segments: Array<{ dayType: AttendanceOvertimeDayType; minutes: number; reasonCode: string; holidayName: string | null }>
+    // `reasonCode` is OMITTED (not a placeholder literal) when the stored `effectiveSource` for
+    // that date is not a recognized non-empty string — same discipline as ⑤'s
+    // `sourceResolution:'unknown_source'` branch (§3.1 hard rule 5⑤ precedent; G4 "未知 code
+    // fail-closed", never a fabricated code outside the closed set actually written by
+    // `resolveOvertimeDayTypeFromEffectiveCalendarItem`, `index.cjs:10612-10635`).
+    segments: Array<{ dayType: AttendanceOvertimeDayType; minutes: number; reasonCode?: string; holidayName: string | null }>
   }
   basis: AttendanceDecisionTraceBasisEnv[]
   confidence: AttendanceDecisionTraceConfidence
@@ -759,12 +795,23 @@ export async function buildOvertimeSegmentationTrace(
 
   const metadata = (row.metadata ?? {}) as Record<string, unknown>
   const snapshot = metadata.overtimeSegmentation as Record<string, unknown> | undefined
+  // §3.2 "分段生效时点=终审时刻": a snapshot is only the FINAL, terminal-review-anchored decision
+  // once `resolved_at` is set (the write path overwrites the submit-time snapshot exactly when the
+  // request is resolved, `index.cjs:29706-29717`) — treating a still-pending request's submit-time
+  // snapshot as `coverageNote:'full'` would present a not-yet-finalized value with false confidence
+  // (R4). `snapshot.dayType` is also validated here (never `?? 'restday'` — a malformed/legacy
+  // `dayType` outside the closed set falls through to the `partial_legacy` branch instead of a
+  // fabricated default, §3.1 hard rule 3).
   const snapshotValid =
-    snapshot &&
+    !!snapshot &&
     typeof snapshot === 'object' &&
     snapshot.version === OVERTIME_SEGMENTATION_VERSION &&
-    snapshot.engine === OVERTIME_SEGMENTATION_ENGINE
-  const resolvedAt = row.resolved_at ?? row.updated_at
+    snapshot.engine === OVERTIME_SEGMENTATION_ENGINE &&
+    OVERTIME_DAY_TYPES.has(snapshot.dayType as string) &&
+    row.resolved_at != null
+  // Never fabricated from `updated_at` (§3.2 "不得伪造时点") — `undefined` when the request has not
+  // been through terminal review; envs below fail closed to `undeterminable` rather than borrow it.
+  const resolvedAt = row.resolved_at ?? undefined
 
   const basis: AttendanceDecisionTraceBasisEnv[] = []
   const segments: AttendanceOvertimeSegmentationTraceResponse['conclusion']['segments'] = []
@@ -779,15 +826,38 @@ export async function buildOvertimeSegmentationTrace(
     restdayMinutes = Number(segs.restdayMinutes) || 0
     holidayMinutes = Number(segs.holidayMinutes) || 0
     totalMinutes = Number(snapshot!.totalMinutes) || 0
-    const calendar = (snapshot!.calendar ?? {}) as Record<string, unknown>
-    const dayType = (snapshot!.dayType as AttendanceOvertimeDayType) ?? 'restday'
-    const minutesForType = dayType === 'workday' ? workdayMinutes : dayType === 'holiday' ? holidayMinutes : restdayMinutes
-    segments.push({
-      dayType,
-      minutes: minutesForType,
-      reasonCode: typeof calendar.effectiveSource === 'string' ? calendar.effectiveSource : 'unknown',
-      holidayName: typeof calendar.holidayName === 'string' ? calendar.holidayName : null,
-    })
+    // §9 W5-0-G7 two-user ⑤ fidelity note carried over to ④: `crossesMidnight` snapshots
+    // (`buildCrossMidnightOvertimeSegmentationSnapshot`, `index.cjs:10669-10715`) carry a `perDate`
+    // array — one entry PER SPANNED DATE, each with its own `dayType`/`minutes`/`calendar`. Walking
+    // it (instead of collapsing to the primary date only) keeps Σsegments[].minutes === totalMinutes
+    // and preserves each date's own `reasonCode`/`holidayName` (R2 — no discarded storage rows).
+    const perDate = Array.isArray(snapshot!.perDate) ? (snapshot!.perDate as Array<Record<string, unknown>>) : null
+    const segmentSources: Array<{ dayType: unknown; minutes: unknown; calendar: unknown }> =
+      perDate && perDate.length > 0
+        ? perDate.map((entry) => ({ dayType: entry.dayType, minutes: entry.minutes, calendar: entry.calendar }))
+        : [
+            {
+              dayType: snapshot!.dayType,
+              minutes:
+                snapshot!.dayType === 'workday'
+                  ? workdayMinutes
+                  : snapshot!.dayType === 'holiday'
+                    ? holidayMinutes
+                    : restdayMinutes,
+              calendar: snapshot!.calendar,
+            },
+          ]
+    for (const entry of segmentSources) {
+      const dayType = OVERTIME_DAY_TYPES.has(entry.dayType as string) ? (entry.dayType as AttendanceOvertimeDayType) : 'restday'
+      const calendar = (entry.calendar ?? {}) as Record<string, unknown>
+      const effectiveSource = typeof calendar.effectiveSource === 'string' && calendar.effectiveSource ? calendar.effectiveSource : undefined
+      segments.push({
+        dayType,
+        minutes: Number(entry.minutes) || 0,
+        ...(effectiveSource ? { reasonCode: effectiveSource } : {}),
+        holidayName: typeof calendar.holidayName === 'string' ? calendar.holidayName : null,
+      })
+    }
     basis.push({
       source: { kind: 'snapshot', ref: 'attendance_requests.metadata.overtimeSegmentation' },
       version: { posture: 'snapshot_frozen', asOf: resolvedAt, snapshotVersion: String(OVERTIME_SEGMENTATION_VERSION) },
@@ -798,7 +868,7 @@ export async function buildOvertimeSegmentationTrace(
   }
 
   const overtimeRule = metadata.overtimeRule
-  if (overtimeRule && typeof overtimeRule === 'object') {
+  if (overtimeRule && typeof overtimeRule === 'object' && resolvedAt) {
     basis.push({
       source: { kind: 'snapshot', ref: 'attendance_requests.metadata.overtimeRule' },
       version: { posture: 'snapshot_frozen', asOf: resolvedAt },
@@ -816,7 +886,7 @@ export async function buildOvertimeSegmentationTrace(
   const approvalFlow = metadata.approvalFlow
   basis.push({
     source: { kind: 'audit', ref: 'attendance_requests.metadata.approvalFlow' },
-    version: approvalFlow ? { posture: 'snapshot_frozen', asOf: resolvedAt } : { posture: 'undeterminable' },
+    version: approvalFlow && resolvedAt ? { posture: 'snapshot_frozen', asOf: resolvedAt } : { posture: 'undeterminable' },
   })
   // §3.3④E4 engine-gate: a snapshot present on THIS request always wins (§3.1 hard rule 6, "快照排
   // 他") — the engine gate is only informative for requests that never got a snapshot (legacy /
@@ -882,6 +952,12 @@ export async function buildCompTimeBalanceTrace(
   runQuery: AttendanceDecisionTraceQueryFn,
   settingsEnabled: { compTimeFromOvertime: boolean; overtimeBankPolicy: boolean },
 ): Promise<AttendanceCompTimeBalanceTraceResponse> {
+  // §3.3⑤E4 / OD-W5-6=(a) "seventh read face": the payroll-cycle-settlement snapshot is folded in
+  // as ITS OWN basis environment here — not exposed as a `conclusion` field (the §3.1 ⑤ conclusion
+  // shape is frozen as "L5a shape + comp_time projection", no settlements key), so a snapshot that
+  // already exists on this ledger is never presented as "unknown" (owner verbatim: "已有权威快照不
+  // 应人为降成 unknown"). This is a READ of `attendance_payroll_cycle_settlements` — no write.
+  const settlements = await readAttendancePayrollCycleSettlements(orgId, userId, runQuery)
   const summaryResult = await runQuery<{ granted: string; exhausted: string; expired: string }>(
     `SELECT
        COALESCE(SUM(CASE WHEN e.event_type = 'grant' THEN e.delta_minutes ELSE 0 END), 0) AS granted,
@@ -941,22 +1017,34 @@ export async function buildCompTimeBalanceTrace(
     }
   })
 
+  // §3.1 hard rule 2 ("not_in_effect 与 undeterminable 是两个判别值") applied to the ledger legs:
+  // an EMPTY ledger while `compTimeFromOvertime` is OFF is the dormant-org policy fact the rule's
+  // own worked example names ("dormant org 的零调休余额...是『调休计提策略未启用』"); an EMPTY
+  // ledger while the engine is ON is a real gap (OD-W5-4: rejected/never-pooled leaves no row to
+  // cite) and stays `undeterminable`. A non-empty ledger is always `snapshot_frozen` regardless of
+  // the current gate (a lot granted while the policy was on stays a real fact after the policy is
+  // later turned off — §3.1 hard rule 6, snapshot exclusivity).
+  const dormantLedgerPosture: AttendanceDecisionTraceVersionPosture = settingsEnabled.compTimeFromOvertime
+    ? 'undeterminable'
+    : 'not_in_effect'
+
   const basis: AttendanceDecisionTraceBasisEnv[] = [
     {
       source: { kind: 'ledger', ref: 'attendance_leave_balances' },
-      version: lots.length > 0 ? { posture: 'snapshot_frozen', asOf: lots[0].grantedAt } : { posture: 'undeterminable' },
+      version: lots.length > 0 ? { posture: 'snapshot_frozen', asOf: lots[0].grantedAt } : { posture: dormantLedgerPosture },
     },
     {
       source: { kind: 'ledger', ref: 'attendance_leave_balance_events' },
       version:
         eventsResult.rows.length > 0
           ? { posture: 'snapshot_frozen', asOf: eventsResult.rows[0].occurred_at }
-          : { posture: 'undeterminable' },
+          : { posture: dormantLedgerPosture },
     },
     {
       source: { kind: 'policy_gate', ref: 'compTimeFromOvertime' },
       version: { posture: settingsEnabled.compTimeFromOvertime ? 'current_live_no_history' : 'not_in_effect' },
     },
+    attendancePayrollCycleSettlementBasisEnv(settlements, settingsEnabled.overtimeBankPolicy),
   ]
 
   return {
@@ -1125,9 +1213,12 @@ export async function buildApproverSourceTrace(
     metadata: Record<string, unknown> | null
     updated_at: string
   }>(
+    // §3.3⑥E1 "当前有效指派的决策标记" — `is_active = true` only (the active-unique-index partial
+    // predicate, `approval-schema-bootstrap.ts:196`); a superseded/deactivated assignment row must
+    // never surface as a live step (owner review finding, W5-0 fix-round).
     `SELECT assignment_type, assignee_id, source_step, metadata, updated_at
        FROM approval_assignments
-      WHERE instance_id = $1
+      WHERE instance_id = $1 AND is_active = true
       ORDER BY source_step ASC, created_at ASC`,
     [instanceId],
   )

--- a/packages/core-backend/tests/integration/attendance-decision-trace-w5-0.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-decision-trace-w5-0.db.test.ts
@@ -45,6 +45,7 @@
 import express from 'express'
 import request from 'supertest'
 import { randomUUID } from 'crypto'
+import { readFileSync } from 'node:fs'
 import { Pool } from 'pg'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { usePinnedServer } from '../utils/pinned-server'
@@ -214,6 +215,19 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
     )
     return r.rows[0].id
   }
+  async function seedSettlement(orgId: string, userId: string, closedAt: string): Promise<void> {
+    const cycle = await pool.query<{ id: string }>(
+      `INSERT INTO attendance_payroll_cycles (org_id, start_date, end_date, status)
+       VALUES ($1, '2026-06-01', '2026-06-30', 'closed') RETURNING id`,
+      [orgId],
+    )
+    await pool.query(
+      `INSERT INTO attendance_payroll_cycle_settlements
+         (org_id, cycle_id, period_start_date, period_end_date, closed_at, user_id, source, convertible_minutes, must_pay_minutes)
+       VALUES ($1,$2,'2026-06-01','2026-06-30',$3,$4,'workday',60,0)`,
+      [orgId, cycle.rows[0].id, closedAt, userId],
+    )
+  }
   async function writeSettingsRow(value: Record<string, unknown>): Promise<void> {
     await pool.query(
       `INSERT INTO system_configs (key, value) VALUES ($1, $2)
@@ -300,16 +314,17 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
       expect(res.body.data.conclusion.status).toBe('normal')
     })
 
-    it('self host: no active org membership ⇒ 403', async () => {
+    it('self host: no active org membership ⇒ 403 BEFORE any trace SQL (zero transactions)', async () => {
       const lonelyUser = `${PFX}_g7_lonely`
       await seedUser(lonelyUser, true)
       const app = makeApp({ id: lonelyUser })
       pinned.setApp(app)
       const res = await request(pinned.url()).get(`/api/attendance/decision-trace?category=today_status&workDate=${WORK_DATE}`)
       expect(res.status).toBe(403)
+      expect(transactionMock).not.toHaveBeenCalled()
     })
 
-    it('self host: userId query parameter (spoofed) ⇒ 400, REGARDLESS of value — never silently ignored', async () => {
+    it('self host: userId query parameter (spoofed) ⇒ 400, REGARDLESS of value — never silently ignored, rejected BEFORE any SQL at all', async () => {
       const app = makeApp({ id: USER_A })
       pinned.setApp(app)
       const res = await request(pinned.url()).get(
@@ -317,6 +332,10 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
       )
       expect(res.status).toBe(400)
       expect(res.body?.error?.code).toBe('USER_ID_NOT_ACCEPTED')
+      // This is the earliest-possible reject (before even the org-membership lookup) — zero SQL of
+      // any kind, not just zero trace SQL.
+      expect(queryMock).not.toHaveBeenCalled()
+      expect(transactionMock).not.toHaveBeenCalled()
     })
 
     it('self host: single active org membership ⇒ auto-selected, 200, subject-locked to own data', async () => {
@@ -327,13 +346,14 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
       expect(res.body.data.conclusion.status).toBe('normal')
     })
 
-    it('self host: orgId not matching an active membership ⇒ 403', async () => {
+    it('self host: orgId not matching an active membership ⇒ 403 BEFORE any trace SQL (zero transactions)', async () => {
       const app = makeApp({ id: USER_A })
       pinned.setApp(app)
       const res = await request(pinned.url()).get(
         `/api/attendance/decision-trace?orgId=${ORG_B}&category=today_status&workDate=${WORK_DATE}`,
       )
       expect(res.status).toBe(403)
+      expect(transactionMock).not.toHaveBeenCalled()
     })
 
     describe('self multi-org four-leg (owner two-round-terminal-review P2-d)', () => {
@@ -355,25 +375,28 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
         await seedRecord(ORG_M1, MULTI_USER_REVERSED, WORK_DATE, { status: 'late', lateMinutes: 10 })
       }, 30000)
 
-      it('leg 1 — 0 active orgs ⇒ 403', async () => {
+      it('leg 1 — 0 active orgs ⇒ 403 BEFORE any trace SQL (zero transactions)', async () => {
         const app = makeApp({ id: ZERO_ORG_USER })
         pinned.setApp(app)
         const res = await request(pinned.url()).get(`/api/attendance/decision-trace?category=today_status&workDate=${WORK_DATE}`)
         expect(res.status).toBe(403)
+        expect(transactionMock).not.toHaveBeenCalled()
       })
 
-      it('leg 2 — >1 active orgs, no orgId ⇒ 400 ORG_ID_REQUIRED, stable regardless of membership insertion order', async () => {
+      it('leg 2 — >1 active orgs, no orgId ⇒ 400 ORG_ID_REQUIRED, stable regardless of membership insertion order, zero trace SQL', async () => {
         const appA = makeApp({ id: MULTI_USER })
         pinned.setApp(appA)
         const resA = await request(pinned.url()).get(`/api/attendance/decision-trace?category=today_status&workDate=${WORK_DATE}`)
         expect(resA.status).toBe(400)
         expect(resA.body?.error?.code).toBe('ORG_ID_REQUIRED')
+        expect(transactionMock).not.toHaveBeenCalled()
 
         const appB = makeApp({ id: MULTI_USER_REVERSED })
         pinned.setApp(appB)
         const resB = await request(pinned.url()).get(`/api/attendance/decision-trace?category=today_status&workDate=${WORK_DATE}`)
         expect(resB.status).toBe(400)
         expect(resB.body?.error?.code).toBe('ORG_ID_REQUIRED')
+        expect(transactionMock).not.toHaveBeenCalled()
       })
 
       it('leg 3 — >1 active orgs, orgId matches a membership ⇒ 200', async () => {
@@ -386,13 +409,14 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
         expect(res.body.data.conclusion.status).toBe('late')
       })
 
-      it('leg 4 — >1 active orgs, orgId does NOT match any membership ⇒ 403', async () => {
+      it('leg 4 — >1 active orgs, orgId does NOT match any membership ⇒ 403 BEFORE any trace SQL (zero transactions)', async () => {
         const app = makeApp({ id: MULTI_USER })
         pinned.setApp(app)
         const res = await request(pinned.url()).get(
           `/api/attendance/decision-trace?orgId=${ORG_M3}&category=today_status&workDate=${WORK_DATE}`,
         )
         expect(res.status).toBe(403)
+        expect(transactionMock).not.toHaveBeenCalled()
       })
     })
 
@@ -400,13 +424,19 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
       const ORG_TU = `${PFX}_g7_org_tu`
       const USER_SUBJECT = `${PFX}_g7_tu_subject`
       const USER_OTHER = `${PFX}_g7_tu_other`
-      const OTHER_WORK_DATE = '2026-07-11'
+      // §9 W5-0-G7 negative matrix requires ①②'s "late" fixture and ③'s "partial" fixture to be
+      // DISTINCT, real, independently-queryable rows — using the SAME (org,user,work_date) for both
+      // `seedRecord` calls hits the table's `(user_id, work_date, org_id)` unique index and the
+      // second UPSERT silently overwrites the first (P1 fixture regression, W5-0 fix-round: the
+      // "late" row never existed at query time under the shared-date fixture).
+      const OTHER_WORK_DATE_LATE = '2026-07-11'
+      const OTHER_WORK_DATE_PARTIAL = '2026-07-16'
 
       beforeAll(async () => {
         await seedMembership(ORG_TU, USER_SUBJECT, true)
         await seedMembership(ORG_TU, USER_OTHER, true)
-        await seedRecord(ORG_TU, USER_OTHER, OTHER_WORK_DATE, { status: 'late', lateMinutes: 5 })
-        await seedRecord(ORG_TU, USER_OTHER, `${OTHER_WORK_DATE}`, { status: 'partial' })
+        await seedRecord(ORG_TU, USER_OTHER, OTHER_WORK_DATE_LATE, { status: 'late', lateMinutes: 5 })
+        await seedRecord(ORG_TU, USER_OTHER, OTHER_WORK_DATE_PARTIAL, { status: 'partial' })
       }, 30000)
 
       function selfApp(userId: string) {
@@ -415,42 +445,67 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
         return app
       }
 
-      it('① today_status — subject queries a workDate that only OTHER has a record for ⇒ 200 + undeterminable, zero cross-user data', async () => {
+      it('① today_status — subject queries a workDate that only OTHER has a (late) record for ⇒ 200 + undeterminable, zero cross-user data', async () => {
         selfApp(USER_SUBJECT)
         const res = await request(pinned.url()).get(
-          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=today_status&workDate=${OTHER_WORK_DATE}`,
+          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=today_status&workDate=${OTHER_WORK_DATE_LATE}`,
         )
         expect(res.status).toBe(200)
         expect(res.body.data.confidence).toBe('undeterminable')
         expect(res.body.data.conclusion.status).toBeNull()
+        expect(Object.prototype.hasOwnProperty.call(res.body.data, 'reasonCode')).toBe(false)
         // OTHER's actual status value ('late') must never appear AS A VALUE — checked precisely
         // (not a bare substring match, which would false-positive on the `lateMinutes` KEY name
-        // that legitimately appears, null-valued, in every ①/② conclusion shape).
+        // that legitimately appears, null-valued, in every ①/② conclusion shape). This fixture's
+        // `USER_OTHER` row at this workDate IS genuinely `status='late'` (verified by the G1/G2
+        // sanity check below) — a subject-predicate regression would leak it here.
         expect(res.body.data.conclusion.status).not.toBe('late')
         expect(JSON.stringify(res.body)).not.toContain('"status":"late"')
       })
 
-      it('② late_early — same-org other-user workDate ⇒ 200 + undeterminable, zero cross-user data', async () => {
+      it('sanity check: OTHER really does have a late/lateMinutes=5 record at OTHER_WORK_DATE_LATE (fixture is not vacuous)', async () => {
+        const app = makeApp({ id: USER_OTHER })
+        pinned.setApp(app)
+        const res = await request(pinned.url()).get(
+          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=late_early&workDate=${OTHER_WORK_DATE_LATE}`,
+        )
+        expect(res.status).toBe(200)
+        expect(res.body.data.conclusion.status).toBe('late')
+        expect(res.body.data.conclusion.lateMinutes).toBe(5)
+      })
+
+      it('② late_early — same-org other-user workDate ⇒ 200 + undeterminable, zero cross-user data (precise: lateMinutes=5 never appears)', async () => {
         selfApp(USER_SUBJECT)
         const res = await request(pinned.url()).get(
-          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=late_early&workDate=${OTHER_WORK_DATE}`,
+          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=late_early&workDate=${OTHER_WORK_DATE_LATE}`,
         )
         expect(res.status).toBe(200)
         expect(res.body.data.confidence).toBe('undeterminable')
         expect(res.body.data.conclusion.lateMinutes).toBeNull()
+        expect(res.body.data.conclusion.status).not.toBe('late')
+        expect(Object.prototype.hasOwnProperty.call(res.body.data, 'reasonCode')).toBe(false)
+        expect(JSON.stringify(res.body)).not.toContain('"lateMinutes":5')
+        expect(JSON.stringify(res.body)).not.toContain('"status":"late"')
       })
 
-      it('③ missing_punch — same-org other-user workDate ⇒ 200 + undeterminable', async () => {
+      it('③ missing_punch — same-org other-user workDate (OTHER has a partial record here) ⇒ 200 + undeterminable, zero cross-user data', async () => {
         selfApp(USER_SUBJECT)
         const res = await request(pinned.url()).get(
-          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=missing_punch&workDate=${OTHER_WORK_DATE}`,
+          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=missing_punch&workDate=${OTHER_WORK_DATE_PARTIAL}`,
         )
         expect(res.status).toBe(200)
         expect(res.body.data.confidence).toBe('undeterminable')
+        expect(res.body.data.conclusion.missingSide).toBeNull()
+        expect(Object.prototype.hasOwnProperty.call(res.body.data, 'reasonCode')).toBe(false)
+        // OTHER's partial row would classify as owedPunchReason='partial_missing_both'/missingSide='both'
+        // (`classifyAttendanceOwedPunch`) if the subject predicate leaked it — zero-occurrence, precise.
+        expect(JSON.stringify(res.body)).not.toContain('partial_missing_both')
+        expect(JSON.stringify(res.body)).not.toContain('"missingSide":"both"')
+        expect(JSON.stringify(res.body)).not.toContain('"status":"partial"')
       })
 
       it('④ overtime_segmentation — OTHER-owned requestId ⇒ 404, byte-identical shape to a truly-nonexistent id', async () => {
-        const otherRequestId = await seedOvertimeRequest(ORG_TU, USER_OTHER, OTHER_WORK_DATE, { minutes: 60 })
+        const otherRequestId = await seedOvertimeRequest(ORG_TU, USER_OTHER, OTHER_WORK_DATE_LATE, { minutes: 60 })
         selfApp(USER_SUBJECT)
         const resOther = await request(pinned.url()).get(
           `/api/attendance/decision-trace?orgId=${ORG_TU}&category=overtime_segmentation&requestId=${otherRequestId}`,
@@ -517,7 +572,7 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
       expect(Object.keys(res.body.data).sort()).toEqual(['basis', 'category', 'conclusion', 'confidence', 'reasonCode'])
     })
 
-    it('auditRef.actor never leaks a raw user id — the actor who wrote the correction is identity-posture-resolved, not echoed as an id', async () => {
+    it('auditRef.actor never leaks a raw user id — the actor who wrote the correction is identity-posture-resolved, not echoed as an id; EXACT key set', async () => {
       const app = makeApp({ id: USER_G2 })
       pinned.setApp(app)
       const res = await request(pinned.url()).get(
@@ -526,25 +581,81 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
       expect(res.status).toBe(200)
       const body = JSON.stringify(res.body)
       expect(body).not.toContain(OTHER_ORG_USER)
+      // §5.1 masking table — none of the explicitly-named禁字段 ever appear in the wire body.
+      expect(body).not.toContain('managerChainIds')
+      expect(body).not.toContain('ip_address')
+      expect(body).not.toContain('user_agent')
       const auditEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'attendance_record_result_edits')
       expect(auditEnv.auditRef.actor.identityPosture).toBe('unknown') // OTHER_ORG_USER was never seeded into `users`
       expect(auditEnv.auditRef.actor.displayLabel).toBe('未知用户')
+      // §3.1 "exact key set由此可锁" (owner two-round-terminal-review P2-b) — {displayLabel,
+      // identityPosture} and NOTHING else (no raw id key alongside it).
+      expect(Object.keys(auditEnv.auditRef.actor).sort()).toEqual(['displayLabel', 'identityPosture'])
+      expect(Object.keys(auditEnv.auditRef).sort()).toEqual(['actor', 'at', 'kind'])
     })
 
-    it('invalid category ⇒ 400 CATEGORY_INVALID (enum-strict, no silent fallback)', async () => {
+    it('auditRef.actor identityPosture="inactive" leg (users.is_active=false) — real-DB negative distinct from "unknown"', async () => {
+      const inactiveActor = `${PFX}_g2_inactive_actor`
+      await seedUser(inactiveActor, false)
+      const inactiveWorkDate = '2026-07-17'
+      await seedRecord(ORG_G2, USER_G2, inactiveWorkDate, { status: 'normal' })
+      await pool.query(
+        `INSERT INTO attendance_record_result_edits
+           (org_id, record_id, user_id, work_date, before_status, after_status, before_snapshot, after_snapshot, reason, actor_user_id, idempotency_key)
+         VALUES ($1, gen_random_uuid(), $2, $3, 'late', 'normal', '{}'::jsonb, '{}'::jsonb, 'appeal', $4, $5)`,
+        [ORG_G2, USER_G2, inactiveWorkDate, inactiveActor, `${PFX}:g2:inactive:${randomUUID()}`],
+      )
+      const app = makeApp({ id: USER_G2 })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?orgId=${ORG_G2}&category=today_status&workDate=${inactiveWorkDate}`,
+      )
+      expect(res.status).toBe(200)
+      const body = JSON.stringify(res.body)
+      expect(body).not.toContain(inactiveActor)
+      const auditEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'attendance_record_result_edits')
+      expect(auditEnv.auditRef.actor).toEqual({ displayLabel: '已停用用户', identityPosture: 'inactive' })
+    })
+
+    it('invalid category ⇒ 400 CATEGORY_INVALID (enum-strict, no silent fallback), zero trace SQL', async () => {
       const app = makeApp({ id: USER_G2 })
       pinned.setApp(app)
       const res = await request(pinned.url()).get(`/api/attendance/decision-trace?orgId=${ORG_G2}&category=not_a_real_category`)
       expect(res.status).toBe(400)
       expect(res.body?.error?.code).toBe('CATEGORY_INVALID')
+      expect(transactionMock).not.toHaveBeenCalled()
     })
 
-    it('missing category ⇒ 400 CATEGORY_REQUIRED', async () => {
+    it('missing category ⇒ 400 CATEGORY_REQUIRED, zero trace SQL', async () => {
       const app = makeApp({ id: USER_G2 })
       pinned.setApp(app)
       const res = await request(pinned.url()).get(`/api/attendance/decision-trace?orgId=${ORG_G2}`)
       expect(res.status).toBe(400)
       expect(res.body?.error?.code).toBe('CATEGORY_REQUIRED')
+      expect(transactionMock).not.toHaveBeenCalled()
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // G2 completion-gate negative meta-assertion (§9 W5-0-G2 "禁记录 response body" — spec files must
+  // never write a trace response body to console/log or freeze it into a snapshot file).
+  // -----------------------------------------------------------------------------------------------
+  describe('§9 W5-0-G2: negative meta-assertion — no response-body logging/snapshotting in the W5-0 spec files', () => {
+    it('neither this file nor the mock-level unit spec calls console.* on a response body or uses the snapshot matcher', () => {
+      // The snapshot-matcher name is assembled from parts so this assertion's own source text does
+      // not self-match when it reads its own file back in (spelling the literal name out here would
+      // trip the very check it defines).
+      const snapshotMatcherName = ['to', 'Match', 'Snap' + 'shot'].join('') + '('
+      const consoleBodyLogPattern = /console\.(log|debug|info)\(\s*(res(Other|Ghost)?\.body|JSON\.stringify\(res)/
+      const dbSpecSource = readFileSync(new URL(import.meta.url), 'utf8')
+      const unitSpecSource = readFileSync(
+        new URL('../unit/attendance-decision-trace-w5-0.test.ts', import.meta.url),
+        'utf8',
+      )
+      for (const [label, source] of [['db spec', dbSpecSource], ['unit spec', unitSpecSource]] as const) {
+        expect(source, `${label} must not console.log/console.debug/console.info a response body`).not.toMatch(consoleBodyLogPattern)
+        expect(source.includes(snapshotMatcherName), `${label} must not use the snapshot matcher on a full response body`).toBe(false)
+      }
     })
   })
 
@@ -593,6 +704,185 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
       expect(Object.keys(lot).sort()).toEqual(['expiresAt', 'grantedAt', 'sourceResolution'])
       expect(lot.sourceResolution).toBe('unknown_source')
       expect(JSON.stringify(res.body)).not.toContain('some_unmapped_future_source_kind')
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // §9 W5-0-G1 break-the-chain real-DB negatives (④ no-snapshot-org / ⑤ NULL overtime_source / ⑥
+  // zero-assignment failed history) — deepEqual on the FULL basis/conclusion shape, not existence.
+  // -----------------------------------------------------------------------------------------------
+  describe('§9 W5-0-G1: break-the-chain real-DB negatives', () => {
+    it('④ no-snapshot org (OD-W5-9 legacy edge, distinct from G4\'s unmapped-source-type case): a MAPPED lot with a NULL overtime_source column ⇒ the `overtimeSource` key is OMITTED entirely, deepEqual on the whole lot item', async () => {
+      const orgId = `${PFX}_g1_e5_org`
+      const userId = `${PFX}_g1_e5_user`
+      await seedMembership(orgId, userId, true)
+      await seedLot(orgId, userId, 'annual_accrual', 'g1-null-overtime-source', null)
+      const app = makeApp({ id: userId })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance/decision-trace?orgId=${orgId}&category=comp_time_balance`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.conclusion.lots).toHaveLength(1)
+      // deepEqual the WHOLE item — no `overtimeSource` key at all (never a fabricated null/placeholder).
+      expect(res.body.data.conclusion.lots[0]).toEqual({
+        sourceResolution: 'mapped',
+        reasonCode: 'annual_accrual',
+        grantedAt: expect.any(String),
+        expiresAt: null,
+      })
+      expect(Object.prototype.hasOwnProperty.call(res.body.data.conclusion.lots[0], 'overtimeSource')).toBe(false)
+    })
+
+    it('a lot WITH a non-null overtime_source DOES carry the key, for contrast (positive control)', async () => {
+      const orgId = `${PFX}_g1_e5b_org`
+      const userId = `${PFX}_g1_e5b_user`
+      await seedMembership(orgId, userId, true)
+      await seedLot(orgId, userId, 'overtime_conversion', 'g1-with-overtime-source', 'workday')
+      const app = makeApp({ id: userId })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance/decision-trace?orgId=${orgId}&category=comp_time_balance`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.conclusion.lots[0]).toEqual({
+        sourceResolution: 'mapped',
+        reasonCode: 'overtime_conversion',
+        grantedAt: expect.any(String),
+        expiresAt: null,
+        overtimeSource: 'workday',
+      })
+    })
+
+    it('⑥ zero-assignment "failed history" instance (resolver never persisted an assignee for any step) ⇒ E1 basis env undeterminable, deepEqual FULL response (steps=[], confidence=undeterminable)', async () => {
+      const orgId = `${PFX}_g1_e6_org`
+      const requesterId = `${PFX}_g1_e6_requester`
+      await seedMembership(orgId, requesterId, true)
+      const instanceId = `${PFX}_g1_e6_inst_${randomUUID()}`
+      await pool.query(
+        `INSERT INTO approval_instances (id, status, version, requester_snapshot, metadata)
+         VALUES ($1, 'pending', 0, '{}'::jsonb, '{}'::jsonb)`,
+        [instanceId],
+      )
+      // Deliberately ZERO rows in approval_assignments — the OD-W5-2=(a) "resolution failed for
+      // every step, reason discarded, nothing persisted" scenario (§1-6① / §3.3⑥ 断环 clause).
+      await pool.query(
+        `INSERT INTO attendance_requests (org_id, user_id, work_date, request_type, status, approval_instance_id)
+         VALUES ($1,$2,CURRENT_DATE,'time_correction','pending',$3)`,
+        [orgId, requesterId, instanceId],
+      )
+      const app = makeApp({ id: requesterId })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?orgId=${orgId}&category=approver_source&instanceId=${instanceId}`,
+      )
+      expect(res.status).toBe(200)
+      expect(res.body.data.conclusion.steps).toEqual([])
+      expect(res.body.data.confidence).toBe('undeterminable')
+      const assignmentEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'approval_assignments')
+      expect(assignmentEnv.version).toEqual({ posture: 'undeterminable' })
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // §3.3⑤E4 / OD-W5-6=(a) — payroll-cycle-settlement snapshot folded into ⑤'s trace, real Postgres.
+  // -----------------------------------------------------------------------------------------------
+  describe('§3.3⑤E4: payroll-cycle-settlement basis env (previously dead code, now wired)', () => {
+    it('a real settlement row ⇒ E4 env is snapshot_frozen @ closed_at (the read actually reaches attendance_payroll_cycle_settlements)', async () => {
+      const orgId = `${PFX}_e4_present_org`
+      const userId = `${PFX}_e4_present_user`
+      await seedMembership(orgId, userId, true)
+      await seedSettlement(orgId, userId, '2026-07-01T00:00:00Z')
+      const app = makeApp({ id: userId })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance/decision-trace?orgId=${orgId}&category=comp_time_balance`)
+      expect(res.status).toBe(200)
+      const settlementEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'attendance_payroll_cycle_settlements')
+      expect(settlementEnv).toEqual({
+        source: { kind: 'snapshot', ref: 'attendance_payroll_cycle_settlements' },
+        version: { posture: 'snapshot_frozen', asOf: '2026-07-01T00:00:00.000Z' },
+      })
+    })
+
+    it('no settlement row + overtimeBankPolicy OFF ⇒ E4 is not_in_effect (policy fact, never fabricated as unknown)', async () => {
+      const orgId = `${PFX}_e4_off_org`
+      const userId = `${PFX}_e4_off_user`
+      await seedMembership(orgId, userId, true)
+      await restoreAttendanceSettingsRow(pool, settingsRowSnapshot) // ensure default OFF
+      const app = makeApp({ id: userId })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance/decision-trace?orgId=${orgId}&category=comp_time_balance`)
+      expect(res.status).toBe(200)
+      const settlementEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'attendance_payroll_cycle_settlements')
+      expect(settlementEnv.version.posture).toBe('not_in_effect')
+    })
+
+    it('no settlement row + overtimeBankPolicy ON ⇒ E4 is undeterminable (should have settled but did not)', async () => {
+      const orgId = `${PFX}_e4_on_org`
+      const userId = `${PFX}_e4_on_user`
+      await seedMembership(orgId, userId, true)
+      await writeSettingsRow({ overtimeBankPolicy: { enabled: true } })
+      const app = makeApp({ id: userId })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance/decision-trace?orgId=${orgId}&category=comp_time_balance`)
+      expect(res.status).toBe(200)
+      const settlementEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'attendance_payroll_cycle_settlements')
+      expect(settlementEnv.version.posture).toBe('undeterminable')
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // §3.1 hard rule 2 dormant-org real-DB proof — empty ledger + engine OFF ⇒ confidence "partial",
+  // never "undeterminable" (the exact owner worked example).
+  // -----------------------------------------------------------------------------------------------
+  describe('§3.1 hard rule 2: dormant org ⑤ confidence real-DB proof', () => {
+    it('compTimeFromOvertime OFF + zero lots/events ⇒ confidence is "partial" (a policy fact, not a data gap)', async () => {
+      const orgId = `${PFX}_dormant_org`
+      const userId = `${PFX}_dormant_user`
+      await seedMembership(orgId, userId, true)
+      await restoreAttendanceSettingsRow(pool, settingsRowSnapshot) // ensure default OFF
+      const app = makeApp({ id: userId })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance/decision-trace?orgId=${orgId}&category=comp_time_balance`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.confidence).toBe('partial')
+      const ledgerEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'attendance_leave_balances')
+      expect(ledgerEnv.version.posture).toBe('not_in_effect')
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // §3.3⑥E1 real-DB negative: a deactivated (`is_active=false`) assignment must never surface as a
+  // live step.
+  // -----------------------------------------------------------------------------------------------
+  describe('§3.3⑥E1: is_active=true predicate on approval_assignments (real Postgres)', () => {
+    it('a deactivated assignment row is excluded ⇒ steps=[], E1 env undeterminable', async () => {
+      const orgId = `${PFX}_e6_inactive_org`
+      const requesterId = `${PFX}_e6_inactive_requester`
+      const assigneeId = `${PFX}_e6_inactive_assignee`
+      await seedMembership(orgId, requesterId, true)
+      const instanceId = `${PFX}_e6_inactive_inst_${randomUUID()}`
+      await pool.query(
+        `INSERT INTO approval_instances (id, status, version, requester_snapshot, metadata)
+         VALUES ($1, 'pending', 0, '{}'::jsonb, '{}'::jsonb)`,
+        [instanceId],
+      )
+      await pool.query(
+        `INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, source_step, metadata, is_active)
+         VALUES ($1, 'user', $2, 0, $3::jsonb, false)`,
+        [instanceId, assigneeId, JSON.stringify({ resolvedFrom: { kind: 'direct_manager' } })],
+      )
+      await pool.query(
+        `INSERT INTO attendance_requests (org_id, user_id, work_date, request_type, status, approval_instance_id)
+         VALUES ($1,$2,CURRENT_DATE,'time_correction','pending',$3)`,
+        [orgId, requesterId, instanceId],
+      )
+      const app = makeApp({ id: requesterId })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?orgId=${orgId}&category=approver_source&instanceId=${instanceId}`,
+      )
+      expect(res.status).toBe(200)
+      expect(res.body.data.conclusion.steps).toEqual([])
+      expect(JSON.stringify(res.body)).not.toContain(assigneeId)
+      const assignmentEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'approval_assignments')
+      expect(assignmentEnv.version.posture).toBe('undeterminable')
     })
   })
 

--- a/packages/core-backend/tests/integration/attendance-decision-trace-w5-0.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-decision-trace-w5-0.db.test.ts
@@ -1,0 +1,697 @@
+/**
+ * W5-0 (Wave 5 explainability design-lock 2026-07-22, RATIFIED §3/§4/§9): real-Postgres coverage of
+ * `GET /api/attendance-admin/decision-trace` (admin host) and `GET /api/attendance/decision-trace`
+ * (self host). The mock-level unit test
+ * (`tests/unit/attendance-decision-trace-w5-0.test.ts`) already covers response-shape/discriminated-
+ * union/branch coverage exhaustively; THIS file proves the things only real Postgres + real
+ * authorization wiring can prove:
+ *   G1/G7 — dual-host authorization matrix: admin/self × own-org/foreign-org × spoofed
+ *           userId/orgId, self multi-org four-leg (0/1/>1-no-orgId/>1-with-orgId), platform-admin
+ *           override, and the two-user/same-org SUBJECT-CONSTRAINED negative matrix (one leg per
+ *           category) with a subject-predicate-removal mutation.
+ *   G2      — response key-set + no-raw-id + org-scoping negative controls against a REAL cross-org
+ *             fixture (a mock can assert "the SQL text mentions org_id=$1" but only real Postgres
+ *             proves the actual result set never crosses the boundary).
+ *   G3      — the READ ONLY seam is REUSED (not re-derived) — `runAttendanceSetupReadinessReadOnly`
+ *             already has the three-case Postgres write-rejection proof
+ *             (`attendance-setup-readiness-w4-0.db.test.ts` §9 W4-0-G2); this file adds ONE
+ *             confirming assertion that `runAttendanceDecisionTraceReadOnly` is that exact function.
+ *   G4      — ⑤ unknown-source-type real fixture: a raw string is INSERTed DIRECTLY into
+ *             `attendance_leave_balances.source_type` (NEVER via `deductLeaveBalance`, which writes
+ *             the EVENTS table's `source_type` column, not the lot's — that fixture shape would let
+ *             the lot-side assertion pass vacuously, per the design lock's own G4 warning).
+ *   G5      — `not_in_effect` (engine OFF) vs `undeterminable` (engine ON, no snapshot) are two
+ *             DIFFERENT postures against the real `system_configs` row.
+ *   G6      — a request that was overtime-segmented BEFORE this test flips the live
+ *             `attendance_overtime_rules` row stays BYTE-STABLE afterward (snapshot exclusivity).
+ *
+ * Shared-DB fixture discipline: every fixture id is prefixed `w50_<run>_` (W4-0 precedent,
+ * `plugin-tests.yml` runs many `.db.test.ts` files against ONE shared Postgres;
+ * `vitest.integration.config.ts` pins `fileParallelism: false`).
+ *
+ * Fixture shape reference (per-table): `attendance_records(org_id, user_id, work_date, status,
+ * is_workday, work_minutes, late_minutes, early_leave_minutes, meta)`; `attendance_requests(org_id,
+ * user_id, work_date, request_type, status, approval_instance_id, metadata, resolved_at)`;
+ * `attendance_leave_balances(org_id, user_id, leave_type_code, amount_minutes, remaining_minutes,
+ * source_type, source_key, status, granted_at, expires_at, overtime_source)`;
+ * `attendance_leave_balance_events(org_id, user_id, balance_id, event_type, delta_minutes,
+ * source_type, source_id)`; `approval_instances(id, status, version, requester_snapshot, metadata,
+ * created_at)`; `approval_assignments(instance_id, assignment_type, assignee_id, source_step,
+ * metadata, is_active)`; `approval_records(instance_id, action, actor_id, to_status, occurred_at)`;
+ * `attendance_overtime_rules(org_id, name, is_active)`; `attendance_payroll_cycles(org_id,
+ * start_date, end_date, status)`; `attendance_payroll_cycle_settlements(org_id, cycle_id, user_id,
+ * source, closed_at, period_start_date, period_end_date)`.
+ */
+import express from 'express'
+import request from 'supertest'
+import { randomUUID } from 'crypto'
+import { Pool } from 'pg'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePinnedServer } from '../utils/pinned-server'
+import {
+  snapshotAttendanceSettingsRow,
+  restoreAttendanceSettingsRow,
+  type AttendanceSettingsRowSnapshot,
+} from '../utils/attendance-settings-row'
+
+vi.mock('../../src/rbac/rbac', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/rbac')>()
+  return {
+    ...actual,
+    rbacGuard: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  }
+})
+vi.mock('../../src/rbac/service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/rbac/service')>()
+  return { ...actual, isAdmin: vi.fn(async (userId: string) => userId.endsWith('_platform_admin')) }
+})
+
+// Real Postgres, spy-WRAPPED (not replaced) — same technique as the W4-0 precedent: `.mock.calls`
+// gives visibility for the "zero trace SQL before rejection" proof (G1/G7) while every call still
+// hits real Postgres.
+vi.mock('../../src/db/pg', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/db/pg')>()
+  return { ...actual, query: vi.fn(actual.query), transaction: vi.fn(actual.transaction) }
+})
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+const { attendanceAdminRouter } = await import('../../src/routes/attendance-admin')
+const { query: mockedQuery, transaction: mockedTransaction } = await import('../../src/db/pg')
+const { runAttendanceDecisionTraceReadOnly } = await import('../../src/services/AttendanceDecisionTrace')
+const { runAttendanceSetupReadinessReadOnly } = await import('../../src/services/AttendanceSetupReadinessAggregate')
+const queryMock = mockedQuery as unknown as ReturnType<typeof vi.fn>
+const transactionMock = mockedTransaction as unknown as ReturnType<typeof vi.fn>
+
+const RUN = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
+const PFX = `w50_${RUN}`
+const SETTINGS_KEY = 'attendance.settings'
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    ;(req as express.Request & { user?: unknown }).user = user ?? undefined
+    next()
+  })
+  app.use(attendanceAdminRouter())
+  return app
+}
+
+it('sentinel: DATABASE_URL is set (real-DB lane must not silently skip)', () => {
+  expect(dbUrl).toBeTruthy()
+})
+
+describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () => {
+  const pool = new Pool({ connectionString: dbUrl })
+  const pinned = usePinnedServer()
+  let settingsRowSnapshot: AttendanceSettingsRowSnapshot | undefined
+
+  async function seedUser(userId: string, isActive = true): Promise<void> {
+    await pool.query(
+      `INSERT INTO users (id, password_hash, is_active) VALUES ($1, 'x', $2)
+       ON CONFLICT (id) DO UPDATE SET is_active = EXCLUDED.is_active`,
+      [userId, isActive],
+    )
+  }
+  async function seedMembership(orgId: string, userId: string, isActive = true, userIsActive = true): Promise<void> {
+    await seedUser(userId, userIsActive)
+    await pool.query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, $3)
+       ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = EXCLUDED.is_active`,
+      [userId, orgId, isActive],
+    )
+  }
+  async function seedRecord(
+    orgId: string,
+    userId: string,
+    workDate: string,
+    fields: Partial<{
+      status: string
+      isWorkday: boolean
+      workMinutes: number
+      lateMinutes: number
+      earlyLeaveMinutes: number
+      meta: Record<string, unknown>
+      firstInAt: string | null
+      lastOutAt: string | null
+    }> = {},
+  ): Promise<string> {
+    const r = await pool.query<{ id: string }>(
+      `INSERT INTO attendance_records
+         (org_id, user_id, work_date, status, is_workday, work_minutes, late_minutes, early_leave_minutes, meta, first_in_at, last_out_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,$10,$11)
+       ON CONFLICT (user_id, work_date, org_id) DO UPDATE SET
+         status = EXCLUDED.status, is_workday = EXCLUDED.is_workday, work_minutes = EXCLUDED.work_minutes,
+         late_minutes = EXCLUDED.late_minutes, early_leave_minutes = EXCLUDED.early_leave_minutes,
+         meta = EXCLUDED.meta, first_in_at = EXCLUDED.first_in_at, last_out_at = EXCLUDED.last_out_at
+       RETURNING id`,
+      [
+        orgId, userId, workDate,
+        fields.status ?? 'normal', fields.isWorkday ?? true, fields.workMinutes ?? 480,
+        fields.lateMinutes ?? 0, fields.earlyLeaveMinutes ?? 0, JSON.stringify(fields.meta ?? {}),
+        fields.firstInAt ?? null, fields.lastOutAt ?? null,
+      ],
+    )
+    return r.rows[0].id
+  }
+  async function seedOvertimeRequest(
+    orgId: string,
+    userId: string,
+    workDate: string,
+    metadata: Record<string, unknown>,
+    resolvedAt: string | null = null,
+  ): Promise<string> {
+    const r = await pool.query<{ id: string }>(
+      `INSERT INTO attendance_requests (org_id, user_id, work_date, request_type, status, metadata, resolved_at)
+       VALUES ($1,$2,$3,'overtime','approved',$4::jsonb,$5) RETURNING id`,
+      [orgId, userId, workDate, JSON.stringify(metadata), resolvedAt],
+    )
+    return r.rows[0].id
+  }
+  async function seedApprovalInstanceWithAssignment(
+    orgId: string,
+    requesterUserId: string,
+    assigneeUserId: string,
+    resolvedFromKind: string,
+  ): Promise<string> {
+    const instanceId = `${PFX}_inst_${randomUUID()}`
+    await pool.query(
+      `INSERT INTO approval_instances (id, status, version, requester_snapshot, metadata)
+       VALUES ($1, 'pending', 0, '{}'::jsonb, '{"approvalFlow":{"steps":[]}}'::jsonb)`,
+      [instanceId],
+    )
+    await pool.query(
+      `INSERT INTO approval_assignments (instance_id, assignment_type, assignee_id, source_step, metadata, is_active)
+       VALUES ($1, 'user', $2, 0, $3::jsonb, true)`,
+      [instanceId, assigneeUserId, JSON.stringify({ resolvedFrom: { kind: resolvedFromKind } })],
+    )
+    await pool.query(
+      `INSERT INTO approval_records (instance_id, action, actor_id, to_status, occurred_at)
+       VALUES ($1, 'approve', $2, 'pending', now())`,
+      [instanceId, assigneeUserId],
+    )
+    // The reverse-link that authorizes ⑥: a request row owned by requesterUserId pointing at this instance.
+    await pool.query(
+      `INSERT INTO attendance_requests (org_id, user_id, work_date, request_type, status, approval_instance_id)
+       VALUES ($1,$2,CURRENT_DATE,'time_correction','pending',$3)`,
+      [orgId, requesterUserId, instanceId],
+    )
+    return instanceId
+  }
+  async function seedLot(
+    orgId: string,
+    userId: string,
+    sourceType: string,
+    tag: string,
+    overtimeSource: string | null = null,
+  ): Promise<string> {
+    const r = await pool.query<{ id: string }>(
+      `INSERT INTO attendance_leave_balances (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key, status, granted_at, overtime_source)
+       VALUES ($1,$2,'comp_time',480,480,$3,$4,'active','2026-07-01',$5) RETURNING id`,
+      [orgId, userId, sourceType, `${PFX}:${tag}:${randomUUID()}`, overtimeSource],
+    )
+    return r.rows[0].id
+  }
+  async function writeSettingsRow(value: Record<string, unknown>): Promise<void> {
+    await pool.query(
+      `INSERT INTO system_configs (key, value) VALUES ($1, $2)
+       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+      [SETTINGS_KEY, JSON.stringify(value)],
+    )
+  }
+
+  beforeAll(async () => {
+    settingsRowSnapshot = await snapshotAttendanceSettingsRow(pool)
+  }, 30000)
+
+  afterAll(async () => {
+    await restoreAttendanceSettingsRow(pool, settingsRowSnapshot)
+    await pool.query(`DELETE FROM attendance_leave_balance_events WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_leave_balances WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_payroll_cycle_settlements WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_payroll_cycles WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_record_result_edits WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_requests WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_records WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM attendance_overtime_rules WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM approval_assignments WHERE instance_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM approval_records WHERE instance_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM approval_instances WHERE id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM user_orgs WHERE org_id LIKE $1`, [`${PFX}%`])
+    await pool.query(`DELETE FROM users WHERE id LIKE $1`, [`${PFX}%`])
+    await pool.end()
+  })
+
+  afterEach(async () => {
+    await restoreAttendanceSettingsRow(pool, settingsRowSnapshot)
+    queryMock.mockClear()
+    transactionMock.mockClear()
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // G1/G7 dual-host authorization matrix
+  // -----------------------------------------------------------------------------------------------
+  describe('§9 W5-0-G7: dual-host authorization matrix', () => {
+    const ORG_A = `${PFX}_g7_org_a`
+    const ORG_B = `${PFX}_g7_org_b`
+    const ADMIN_A = `${PFX}_g7_admin_a`
+    const USER_A = `${PFX}_g7_user_a`
+    const WORK_DATE = '2026-07-10'
+
+    beforeAll(async () => {
+      await seedMembership(ORG_A, ADMIN_A, true)
+      await seedMembership(ORG_A, USER_A, true)
+      const ownerB = `${PFX}_g7_org_b_owner`
+      await seedMembership(ORG_B, ownerB, true)
+      await seedRecord(ORG_A, USER_A, WORK_DATE, { status: 'normal' })
+    }, 30000)
+
+    it('admin host: delegated admin, own org ⇒ 200', async () => {
+      const app = makeApp({ id: ADMIN_A })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance-admin/decision-trace?orgId=${ORG_A}&userId=${USER_A}&category=today_status&workDate=${WORK_DATE}`,
+      )
+      expect(res.status).toBe(200)
+      expect(res.body.data.category).toBe('today_status')
+    })
+
+    it('admin host: delegated admin forges a foreign org ⇒ 403 BEFORE any trace SQL (zero transactions)', async () => {
+      const app = makeApp({ id: ADMIN_A })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance-admin/decision-trace?orgId=${ORG_B}&userId=${USER_A}&category=today_status&workDate=${WORK_DATE}`,
+      )
+      expect(res.status).toBe(403)
+      expect(res.body?.error?.code).toBe('FORBIDDEN')
+      expect(transactionMock).not.toHaveBeenCalled()
+    })
+
+    it('admin host: platform admin override ⇒ 200 even for a non-member org, response still org-scoped', async () => {
+      const platformAdminId = `${PFX}_g7_platform_admin`
+      const app = makeApp({ id: platformAdminId })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance-admin/decision-trace?orgId=${ORG_A}&userId=${USER_A}&category=today_status&workDate=${WORK_DATE}`,
+      )
+      expect(res.status).toBe(200)
+      expect(res.body.data.conclusion.status).toBe('normal')
+    })
+
+    it('self host: no active org membership ⇒ 403', async () => {
+      const lonelyUser = `${PFX}_g7_lonely`
+      await seedUser(lonelyUser, true)
+      const app = makeApp({ id: lonelyUser })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance/decision-trace?category=today_status&workDate=${WORK_DATE}`)
+      expect(res.status).toBe(403)
+    })
+
+    it('self host: userId query parameter (spoofed) ⇒ 400, REGARDLESS of value — never silently ignored', async () => {
+      const app = makeApp({ id: USER_A })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?userId=${ADMIN_A}&category=today_status&workDate=${WORK_DATE}`,
+      )
+      expect(res.status).toBe(400)
+      expect(res.body?.error?.code).toBe('USER_ID_NOT_ACCEPTED')
+    })
+
+    it('self host: single active org membership ⇒ auto-selected, 200, subject-locked to own data', async () => {
+      const app = makeApp({ id: USER_A })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance/decision-trace?category=today_status&workDate=${WORK_DATE}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.conclusion.status).toBe('normal')
+    })
+
+    it('self host: orgId not matching an active membership ⇒ 403', async () => {
+      const app = makeApp({ id: USER_A })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?orgId=${ORG_B}&category=today_status&workDate=${WORK_DATE}`,
+      )
+      expect(res.status).toBe(403)
+    })
+
+    describe('self multi-org four-leg (owner two-round-terminal-review P2-d)', () => {
+      const ORG_M1 = `${PFX}_g7_org_m1`
+      const ORG_M2 = `${PFX}_g7_org_m2`
+      const ORG_M3 = `${PFX}_g7_org_m3`
+      const MULTI_USER = `${PFX}_g7_multi`
+      const MULTI_USER_REVERSED = `${PFX}_g7_multi_rev`
+      const ZERO_ORG_USER = `${PFX}_g7_zero`
+
+      beforeAll(async () => {
+        await seedMembership(ORG_M1, MULTI_USER, true)
+        await seedMembership(ORG_M2, MULTI_USER, true)
+        // Reversed insertion order — proves ORG_ID_REQUIRED does not depend on row order (§4.1 leg 3).
+        await seedMembership(ORG_M2, MULTI_USER_REVERSED, true)
+        await seedMembership(ORG_M1, MULTI_USER_REVERSED, true)
+        await seedUser(ZERO_ORG_USER, true)
+        await seedRecord(ORG_M1, MULTI_USER, WORK_DATE, { status: 'late', lateMinutes: 10 })
+        await seedRecord(ORG_M1, MULTI_USER_REVERSED, WORK_DATE, { status: 'late', lateMinutes: 10 })
+      }, 30000)
+
+      it('leg 1 — 0 active orgs ⇒ 403', async () => {
+        const app = makeApp({ id: ZERO_ORG_USER })
+        pinned.setApp(app)
+        const res = await request(pinned.url()).get(`/api/attendance/decision-trace?category=today_status&workDate=${WORK_DATE}`)
+        expect(res.status).toBe(403)
+      })
+
+      it('leg 2 — >1 active orgs, no orgId ⇒ 400 ORG_ID_REQUIRED, stable regardless of membership insertion order', async () => {
+        const appA = makeApp({ id: MULTI_USER })
+        pinned.setApp(appA)
+        const resA = await request(pinned.url()).get(`/api/attendance/decision-trace?category=today_status&workDate=${WORK_DATE}`)
+        expect(resA.status).toBe(400)
+        expect(resA.body?.error?.code).toBe('ORG_ID_REQUIRED')
+
+        const appB = makeApp({ id: MULTI_USER_REVERSED })
+        pinned.setApp(appB)
+        const resB = await request(pinned.url()).get(`/api/attendance/decision-trace?category=today_status&workDate=${WORK_DATE}`)
+        expect(resB.status).toBe(400)
+        expect(resB.body?.error?.code).toBe('ORG_ID_REQUIRED')
+      })
+
+      it('leg 3 — >1 active orgs, orgId matches a membership ⇒ 200', async () => {
+        const app = makeApp({ id: MULTI_USER })
+        pinned.setApp(app)
+        const res = await request(pinned.url()).get(
+          `/api/attendance/decision-trace?orgId=${ORG_M1}&category=today_status&workDate=${WORK_DATE}`,
+        )
+        expect(res.status).toBe(200)
+        expect(res.body.data.conclusion.status).toBe('late')
+      })
+
+      it('leg 4 — >1 active orgs, orgId does NOT match any membership ⇒ 403', async () => {
+        const app = makeApp({ id: MULTI_USER })
+        pinned.setApp(app)
+        const res = await request(pinned.url()).get(
+          `/api/attendance/decision-trace?orgId=${ORG_M3}&category=today_status&workDate=${WORK_DATE}`,
+        )
+        expect(res.status).toBe(403)
+      })
+    })
+
+    describe('two-user/same-org subject-constrained negative matrix (one leg per category)', () => {
+      const ORG_TU = `${PFX}_g7_org_tu`
+      const USER_SUBJECT = `${PFX}_g7_tu_subject`
+      const USER_OTHER = `${PFX}_g7_tu_other`
+      const OTHER_WORK_DATE = '2026-07-11'
+
+      beforeAll(async () => {
+        await seedMembership(ORG_TU, USER_SUBJECT, true)
+        await seedMembership(ORG_TU, USER_OTHER, true)
+        await seedRecord(ORG_TU, USER_OTHER, OTHER_WORK_DATE, { status: 'late', lateMinutes: 5 })
+        await seedRecord(ORG_TU, USER_OTHER, `${OTHER_WORK_DATE}`, { status: 'partial' })
+      }, 30000)
+
+      function selfApp(userId: string) {
+        const app = makeApp({ id: userId })
+        pinned.setApp(app)
+        return app
+      }
+
+      it('① today_status — subject queries a workDate that only OTHER has a record for ⇒ 200 + undeterminable, zero cross-user data', async () => {
+        selfApp(USER_SUBJECT)
+        const res = await request(pinned.url()).get(
+          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=today_status&workDate=${OTHER_WORK_DATE}`,
+        )
+        expect(res.status).toBe(200)
+        expect(res.body.data.confidence).toBe('undeterminable')
+        expect(res.body.data.conclusion.status).toBeNull()
+        // OTHER's actual status value ('late') must never appear AS A VALUE — checked precisely
+        // (not a bare substring match, which would false-positive on the `lateMinutes` KEY name
+        // that legitimately appears, null-valued, in every ①/② conclusion shape).
+        expect(res.body.data.conclusion.status).not.toBe('late')
+        expect(JSON.stringify(res.body)).not.toContain('"status":"late"')
+      })
+
+      it('② late_early — same-org other-user workDate ⇒ 200 + undeterminable, zero cross-user data', async () => {
+        selfApp(USER_SUBJECT)
+        const res = await request(pinned.url()).get(
+          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=late_early&workDate=${OTHER_WORK_DATE}`,
+        )
+        expect(res.status).toBe(200)
+        expect(res.body.data.confidence).toBe('undeterminable')
+        expect(res.body.data.conclusion.lateMinutes).toBeNull()
+      })
+
+      it('③ missing_punch — same-org other-user workDate ⇒ 200 + undeterminable', async () => {
+        selfApp(USER_SUBJECT)
+        const res = await request(pinned.url()).get(
+          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=missing_punch&workDate=${OTHER_WORK_DATE}`,
+        )
+        expect(res.status).toBe(200)
+        expect(res.body.data.confidence).toBe('undeterminable')
+      })
+
+      it('④ overtime_segmentation — OTHER-owned requestId ⇒ 404, byte-identical shape to a truly-nonexistent id', async () => {
+        const otherRequestId = await seedOvertimeRequest(ORG_TU, USER_OTHER, OTHER_WORK_DATE, { minutes: 60 })
+        selfApp(USER_SUBJECT)
+        const resOther = await request(pinned.url()).get(
+          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=overtime_segmentation&requestId=${otherRequestId}`,
+        )
+        const resGhost = await request(pinned.url()).get(
+          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=overtime_segmentation&requestId=${randomUUID()}`,
+        )
+        expect(resOther.status).toBe(404)
+        expect(resGhost.status).toBe(404)
+        expect(resOther.body).toEqual(resGhost.body)
+      })
+
+      it('⑤ comp_time_balance — OTHER-owned lot never appears in subject-locked response (no lot-id targeting exists, so no 404 leg applies)', async () => {
+        await seedLot(ORG_TU, USER_OTHER, 'annual_accrual', 'tu-other-lot')
+        selfApp(USER_SUBJECT)
+        const res = await request(pinned.url()).get(`/api/attendance/decision-trace?orgId=${ORG_TU}&category=comp_time_balance`)
+        expect(res.status).toBe(200)
+        expect(res.body.data.conclusion.lots).toEqual([])
+      })
+
+      it('⑥ approver_source — OTHER-owned instanceId ⇒ 404, byte-identical shape to a truly-nonexistent id', async () => {
+        const otherInstanceId = await seedApprovalInstanceWithAssignment(ORG_TU, USER_OTHER, USER_OTHER, 'direct_manager')
+        selfApp(USER_SUBJECT)
+        const resOther = await request(pinned.url()).get(
+          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=approver_source&instanceId=${otherInstanceId}`,
+        )
+        const resGhost = await request(pinned.url()).get(
+          `/api/attendance/decision-trace?orgId=${ORG_TU}&category=approver_source&instanceId=${randomUUID()}`,
+        )
+        expect(resOther.status).toBe(404)
+        expect(resGhost.status).toBe(404)
+        expect(resOther.body).toEqual(resGhost.body)
+      })
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // G2: response allowlist + org-scoping negative controls
+  // -----------------------------------------------------------------------------------------------
+  describe('§9 W5-0-G2: allowlist + org-scoping negative controls', () => {
+    const ORG_G2 = `${PFX}_g2_org`
+    const USER_G2 = `${PFX}_g2_user`
+    const OTHER_ORG_USER = `${PFX}_g2_other_org_user`
+    const WORK_DATE = '2026-07-12'
+
+    beforeAll(async () => {
+      await seedMembership(ORG_G2, USER_G2, true)
+      await seedRecord(ORG_G2, USER_G2, WORK_DATE, { status: 'normal', meta: { manual_result_edit: { correctedAgainst: {} } } })
+      await pool.query(
+        `INSERT INTO attendance_record_result_edits
+           (org_id, record_id, user_id, work_date, before_status, after_status, before_snapshot, after_snapshot, reason, actor_user_id, idempotency_key)
+         VALUES ($1, gen_random_uuid(), $2, $3, 'late', 'normal', '{}'::jsonb, '{}'::jsonb, 'appeal', $4, $5)`,
+        [ORG_G2, USER_G2, WORK_DATE, OTHER_ORG_USER, `${PFX}:g2:${randomUUID()}`],
+      )
+    }, 30000)
+
+    it('response key set is EXACT (today_status) — no extraneous keys leak through', async () => {
+      const app = makeApp({ id: USER_G2 })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?orgId=${ORG_G2}&category=today_status&workDate=${WORK_DATE}`,
+      )
+      expect(res.status).toBe(200)
+      expect(Object.keys(res.body.data).sort()).toEqual(['basis', 'category', 'conclusion', 'confidence', 'reasonCode'])
+    })
+
+    it('auditRef.actor never leaks a raw user id — the actor who wrote the correction is identity-posture-resolved, not echoed as an id', async () => {
+      const app = makeApp({ id: USER_G2 })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?orgId=${ORG_G2}&category=today_status&workDate=${WORK_DATE}`,
+      )
+      expect(res.status).toBe(200)
+      const body = JSON.stringify(res.body)
+      expect(body).not.toContain(OTHER_ORG_USER)
+      const auditEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'attendance_record_result_edits')
+      expect(auditEnv.auditRef.actor.identityPosture).toBe('unknown') // OTHER_ORG_USER was never seeded into `users`
+      expect(auditEnv.auditRef.actor.displayLabel).toBe('未知用户')
+    })
+
+    it('invalid category ⇒ 400 CATEGORY_INVALID (enum-strict, no silent fallback)', async () => {
+      const app = makeApp({ id: USER_G2 })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance/decision-trace?orgId=${ORG_G2}&category=not_a_real_category`)
+      expect(res.status).toBe(400)
+      expect(res.body?.error?.code).toBe('CATEGORY_INVALID')
+    })
+
+    it('missing category ⇒ 400 CATEGORY_REQUIRED', async () => {
+      const app = makeApp({ id: USER_G2 })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance/decision-trace?orgId=${ORG_G2}`)
+      expect(res.status).toBe(400)
+      expect(res.body?.error?.code).toBe('CATEGORY_REQUIRED')
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // G3: read-only seam reuse (the exhaustive 3-case Postgres proof lives in the W4-0 file)
+  // -----------------------------------------------------------------------------------------------
+  describe('§9 W5-0-G3: READ ONLY seam is REUSED, not re-derived', () => {
+    it('runAttendanceDecisionTraceReadOnly IS runAttendanceSetupReadinessReadOnly (verbatim reuse)', () => {
+      expect(runAttendanceDecisionTraceReadOnly).toBe(runAttendanceSetupReadinessReadOnly)
+    })
+    it('confirming instance: a write inside the seam is rejected by real Postgres', async () => {
+      const orgId = `${PFX}_g3_org`
+      await seedMembership(orgId, `${PFX}_g3_owner`, true)
+      await expect(
+        runAttendanceDecisionTraceReadOnly(async (q) => {
+          await q(`UPDATE user_orgs SET is_active = is_active WHERE org_id = $1`, [orgId])
+        }),
+      ).rejects.toThrow(/read-only transaction/i)
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // G4: enum-strict + ⑤ discriminated union with a REAL raw-fixture negative
+  // -----------------------------------------------------------------------------------------------
+  describe('§9 W5-0-G4: ⑤ lot sourceResolution — raw fixture negative (direct lot INSERT, not via deductLeaveBalance)', () => {
+    const ORG_G4 = `${PFX}_g4_org`
+    const USER_G4 = `${PFX}_g4_user`
+
+    beforeAll(async () => {
+      await seedMembership(ORG_G4, USER_G4, true)
+      // G4 fixture discipline (design lock §9 W5-0-G4 explicit warning): INSERT directly into
+      // attendance_leave_balances.source_type — attendance_leave_balances.source_type has NO CHECK
+      // constraint (zzzz20260603120000:34), so an arbitrary future-migration-shaped string is legal
+      // here. `deductLeaveBalance` would instead write the EVENTS table's source_type column, which
+      // this assertion does NOT read — that fixture shape would make the lot-side assertion pass
+      // vacuously (nothing to classify), the exact trap the design lock names.
+      await seedLot(ORG_G4, USER_G4, 'some_unmapped_future_source_kind', 'g4-raw')
+    }, 30000)
+
+    it('unmapped source_type ⇒ lot item is EXACTLY the unknown_source branch; the raw string is never echoed anywhere in the response', async () => {
+      const app = makeApp({ id: USER_G4 })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(`/api/attendance/decision-trace?orgId=${ORG_G4}&category=comp_time_balance`)
+      expect(res.status).toBe(200)
+      const lot = res.body.data.conclusion.lots[0]
+      expect(Object.keys(lot).sort()).toEqual(['expiresAt', 'grantedAt', 'sourceResolution'])
+      expect(lot.sourceResolution).toBe('unknown_source')
+      expect(JSON.stringify(res.body)).not.toContain('some_unmapped_future_source_kind')
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // G5: not_in_effect vs undeterminable — two DIFFERENT postures against real system_configs
+  // -----------------------------------------------------------------------------------------------
+  describe('§9 W5-0-G5: not_in_effect ≠ undeterminable', () => {
+    const ORG_G5 = `${PFX}_g5_org`
+    const USER_G5 = `${PFX}_g5_user`
+    const WORK_DATE = '2026-07-13'
+
+    beforeAll(async () => {
+      await seedMembership(ORG_G5, USER_G5, true)
+      await seedOvertimeRequest(ORG_G5, USER_G5, WORK_DATE, { minutes: 90 }) // no valid snapshot ⇒ legacy
+    }, 30000)
+
+    it('positive control: engine OFF (dormant org, default settings) ⇒ engine-gate env is not_in_effect', async () => {
+      await restoreAttendanceSettingsRow(pool, settingsRowSnapshot) // ensure default OFF
+      const app = makeApp({ id: USER_G5 })
+      pinned.setApp(app)
+      const orgOwnerRequestId = (
+        await pool.query<{ id: string }>(
+          `SELECT id FROM attendance_requests WHERE org_id = $1 AND user_id = $2 AND request_type='overtime' LIMIT 1`,
+          [ORG_G5, USER_G5],
+        )
+      ).rows[0].id
+      const res = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?orgId=${ORG_G5}&category=overtime_segmentation&requestId=${orgOwnerRequestId}`,
+      )
+      expect(res.status).toBe(200)
+      const gateEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'overtimeSegmentation')
+      expect(gateEnv.version.posture).toBe('not_in_effect')
+    })
+
+    it('negative control: engine ON but no snapshot on THIS request ⇒ engine-gate env is undeterminable (a real gap, not a policy fact)', async () => {
+      await writeSettingsRow({ overtimeSegmentation: { enabled: true } })
+      const app = makeApp({ id: USER_G5 })
+      pinned.setApp(app)
+      const orgOwnerRequestId = (
+        await pool.query<{ id: string }>(
+          `SELECT id FROM attendance_requests WHERE org_id = $1 AND user_id = $2 AND request_type='overtime' LIMIT 1`,
+          [ORG_G5, USER_G5],
+        )
+      ).rows[0].id
+      const res = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?orgId=${ORG_G5}&category=overtime_segmentation&requestId=${orgOwnerRequestId}`,
+      )
+      expect(res.status).toBe(200)
+      const gateEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'overtimeSegmentation')
+      expect(gateEnv.version.posture).toBe('undeterminable')
+    })
+  })
+
+  // -----------------------------------------------------------------------------------------------
+  // G6: snapshot exclusivity — a request that WAS segmented stays byte-stable after the live rule
+  // table changes (positive control lives here; the recompute-from-current MUTATION is a separate,
+  // manually-applied source-code cut recorded in the PR body per the harness's mutation discipline).
+  // -----------------------------------------------------------------------------------------------
+  describe('§9 W5-0-G6: snapshot exclusivity — policy change does not alter an already-decided request', () => {
+    const ORG_G6 = `${PFX}_g6_org`
+    const USER_G6 = `${PFX}_g6_user`
+    const WORK_DATE = '2026-07-14'
+
+    it('byte-stable trace before/after the live attendance_overtime_rules row changes', async () => {
+      await seedMembership(ORG_G6, USER_G6, true)
+      const requestId = await seedOvertimeRequest(
+        ORG_G6, USER_G6, WORK_DATE,
+        {
+          minutes: 120,
+          overtimeSegmentation: {
+            version: 1, engine: 'attendance_overtime_segmentation_v1', workDate: WORK_DATE, dayType: 'workday',
+            calendar: { effectiveSource: 'calendar_default', holidayName: null },
+            segments: { workdayMinutes: 120, restdayMinutes: 0, holidayMinutes: 0 }, totalMinutes: 120,
+          },
+        },
+        '2026-07-15T10:00:00Z',
+      )
+      const app = makeApp({ id: USER_G6 })
+      pinned.setApp(app)
+
+      const before = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?orgId=${ORG_G6}&category=overtime_segmentation&requestId=${requestId}`,
+      )
+      expect(before.status).toBe(200)
+
+      // Live policy churn AFTER the decision: insert a brand-new active overtime rule for this org.
+      await pool.query(
+        `INSERT INTO attendance_overtime_rules (org_id, name, min_minutes, is_active) VALUES ($1, $2, 999, true)`,
+        [ORG_G6, `${PFX} g6 new rule`],
+      )
+
+      const after = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?orgId=${ORG_G6}&category=overtime_segmentation&requestId=${requestId}`,
+      )
+      expect(after.status).toBe(200)
+      // The frozen segmentation conclusion/coverageNote must be byte-identical; only the (informational,
+      // separately-labeled) rule_live environment's presence may legitimately change.
+      expect(after.body.data.conclusion).toEqual(before.body.data.conclusion)
+      expect(after.body.data.coverageNote).toEqual(before.body.data.coverageNote)
+    })
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-decision-trace-w5-0.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-decision-trace-w5-0.db.test.ts
@@ -714,7 +714,59 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
   // zero-assignment failed history) — deepEqual on the FULL basis/conclusion shape, not existence.
   // -----------------------------------------------------------------------------------------------
   describe('§9 W5-0-G1: break-the-chain real-DB negatives', () => {
-    it('④ no-snapshot org (OD-W5-9 legacy edge, distinct from G4\'s unmapped-source-type case): a MAPPED lot with a NULL overtime_source column ⇒ the `overtimeSource` key is OMITTED entirely, deepEqual on the whole lot item', async () => {
+    it('② legacy record without tier meta keys ⇒ tier basis env is EXACTLY {source:{kind:record,ref:attendance_records.meta.tier}, version:{posture:undeterminable}} (deepEqual, real DB)', async () => {
+      const orgId = `${PFX}_g1_e2_org`
+      const userId = `${PFX}_g1_e2_user`
+      const workDate = '2026-07-18'
+      await seedMembership(orgId, userId, true)
+      // seedRecord never sets meta.severe_late_count/etc — this IS the "legacy row" shape.
+      await seedRecord(orgId, userId, workDate, { status: 'late', lateMinutes: 12 })
+      const app = makeApp({ id: userId })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?orgId=${orgId}&category=late_early&workDate=${workDate}`,
+      )
+      expect(res.status).toBe(200)
+      expect(res.body.data.conclusion.severeLateCount).toBeNull()
+      expect(res.body.data.conclusion.severeLateMinutes).toBeNull()
+      expect(res.body.data.conclusion.absenceLateCount).toBeNull()
+      const tierEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'attendance_records.meta.tier')
+      expect(tierEnv).toEqual({ source: { kind: 'record', ref: 'attendance_records.meta.tier' }, version: { posture: 'undeterminable' } })
+    })
+
+    it('③ auto-generated absent row ⇒ generation-source basis env is EXACTLY {source:{kind:policy_gate,ref:auto_absence_generation}, version:{posture:undeterminable}} (deepEqual, real DB — no job/run marker exists to cite)', async () => {
+      const orgId = `${PFX}_g1_e3_org`
+      const userId = `${PFX}_g1_e3_user`
+      const workDate = '2026-07-19'
+      await seedMembership(orgId, userId, true)
+      await seedRecord(orgId, userId, workDate, { status: 'absent' })
+      const app = makeApp({ id: userId })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?orgId=${orgId}&category=missing_punch&workDate=${workDate}`,
+      )
+      expect(res.status).toBe(200)
+      const genEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'auto_absence_generation')
+      expect(genEnv).toEqual({ source: { kind: 'policy_gate', ref: 'auto_absence_generation' }, version: { posture: 'undeterminable' } })
+    })
+
+    it('④ request with no valid segmentation snapshot (legacy / never segmented) ⇒ snapshot basis env is EXACTLY {source:{kind:snapshot,ref:...overtimeSegmentation}, version:{posture:undeterminable}} (deepEqual, real DB)', async () => {
+      const orgId = `${PFX}_g1_e4_org`
+      const userId = `${PFX}_g1_e4_user`
+      const workDate = '2026-07-20'
+      await seedMembership(orgId, userId, true)
+      const requestId = await seedOvertimeRequest(orgId, userId, workDate, { minutes: 45 }) // no overtimeSegmentation key at all
+      const app = makeApp({ id: userId })
+      pinned.setApp(app)
+      const res = await request(pinned.url()).get(
+        `/api/attendance/decision-trace?orgId=${orgId}&category=overtime_segmentation&requestId=${requestId}`,
+      )
+      expect(res.status).toBe(200)
+      const snapEnv = res.body.data.basis.find((b: { source: { ref: string } }) => b.source.ref === 'attendance_requests.metadata.overtimeSegmentation')
+      expect(snapEnv).toEqual({ source: { kind: 'snapshot', ref: 'attendance_requests.metadata.overtimeSegmentation' }, version: { posture: 'undeterminable' } })
+    })
+
+    it('⑤ (OD-W5-9 legacy edge, distinct from G4\'s unmapped-source-type case): a MAPPED lot with a NULL overtime_source column ⇒ the `overtimeSource` key is OMITTED entirely, deepEqual on the whole lot item', async () => {
       const orgId = `${PFX}_g1_e5_org`
       const userId = `${PFX}_g1_e5_user`
       await seedMembership(orgId, userId, true)

--- a/packages/core-backend/tests/integration/attendance-decision-trace-w5-0.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-decision-trace-w5-0.db.test.ts
@@ -518,12 +518,14 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
         expect(resOther.body).toEqual(resGhost.body)
       })
 
-      it('⑤ comp_time_balance — OTHER-owned lot never appears in subject-locked response (no lot-id targeting exists, so no 404 leg applies)', async () => {
+      it('⑤ comp_time_balance — OTHER-owned lot/events never appear in subject-locked response (no lot-id targeting exists, so no 404 leg applies)', async () => {
         await seedLot(ORG_TU, USER_OTHER, 'annual_accrual', 'tu-other-lot')
         selfApp(USER_SUBJECT)
         const res = await request(pinned.url()).get(`/api/attendance/decision-trace?orgId=${ORG_TU}&category=comp_time_balance`)
         expect(res.status).toBe(200)
+        // §9 W5-0-G7 "200 + 空 lot/event 投影" — both projections, not just lots.
         expect(res.body.data.conclusion.lots).toEqual([])
+        expect(res.body.data.conclusion.events).toEqual([])
       })
 
       it('⑥ approver_source — OTHER-owned instanceId ⇒ 404, byte-identical shape to a truly-nonexistent id', async () => {
@@ -982,6 +984,11 @@ describeIfDatabase('W5-0 GET decision-trace (admin + self hosts, real DB)', () =
       // separately-labeled) rule_live environment's presence may legitimately change.
       expect(after.body.data.conclusion).toEqual(before.body.data.conclusion)
       expect(after.body.data.coverageNote).toEqual(before.body.data.coverageNote)
+      // Every OTHER basis environment (snapshot/audit/policy_gate) must also be byte-stable — only
+      // `rule_live` is licensed to change (§3.1 hard rule 6 "快照排他").
+      const beforeNonRuleLive = before.body.data.basis.filter((b: { source: { kind: string } }) => b.source.kind !== 'rule_live')
+      const afterNonRuleLive = after.body.data.basis.filter((b: { source: { kind: string } }) => b.source.kind !== 'rule_live')
+      expect(afterNonRuleLive).toEqual(beforeNonRuleLive)
     })
   })
 })

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5610,6 +5610,59 @@ attendanceIntegrationDescribe(
     }
   })
 
+  // W5-0 (Wave 5 explainability design-lock 2026-07-22, RATIFIED §2/§7, OD-W5-9=(a)): the L5a
+  // activeLots SELECT now projects `overtime_source` — purely additive (only the new key is
+  // asserted here; every OTHER key's presence/values are already covered by the L5a tests above,
+  // which stay green unmodified — proving this is a pure compatibility extension, not a behaviour
+  // change). A non-null value round-trips on BOTH hosts (admin + /me); a legacy NULL-source lot
+  // (pre-v1-1b, or any lot never tagged) stays honestly absent/null — never fabricated.
+  it('④/年假 L5a + /me — overtime_source projection (OD-W5-9): non-null value round-trips on both hosts; legacy NULL lot stays null', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const pool = new Pool({ connectionString: dbUrl })
+    const runSuffix = Date.now().toString(36)
+    const adminId = `al-w50-admin-${runSuffix}`
+    const meId = `al-w50-me-${runSuffix}`
+    const adminTokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${adminId}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
+    const adminToken = (adminTokenRes.body as { token?: string } | undefined)?.token
+    const meTokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${meId}&roles=employee&perms=attendance:read`)
+    const meToken = (meTokenRes.body as { token?: string } | undefined)?.token
+    if (!adminToken || !meToken) { await pool.end().catch(() => undefined); return }
+    try {
+      const taggedLot = (await pool.query<{ id: string }>(
+        `INSERT INTO attendance_leave_balances (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key, status, granted_at, overtime_source)
+         VALUES ('default',$1,'comp_time',480,480,'overtime_conversion',$2,'active','2026-01-01','workday') RETURNING id`,
+        [meId, `w50:${runSuffix}:tagged`],
+      )).rows[0].id
+      const legacyLot = (await pool.query<{ id: string }>(
+        `INSERT INTO attendance_leave_balances (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key, status, granted_at)
+         VALUES ('default',$1,'comp_time',240,240,'overtime_conversion',$2,'active','2026-01-01') RETURNING id`,
+        [meId, `w50:${runSuffix}:legacy`],
+      )).rows[0].id
+
+      const adminRes = await requestJson(
+        `${baseUrl}/api/attendance/leave-balances?userId=${encodeURIComponent(meId)}&leaveTypeCode=comp_time`,
+        { headers: { Authorization: `Bearer ${adminToken}` } },
+      )
+      expect(adminRes.status, JSON.stringify(adminRes.body)).toBe(200)
+      const adminLots = (adminRes.body as { data?: { activeLots?: Array<{ id: string; overtime_source: string | null }> } })?.data?.activeLots ?? []
+      expect(adminLots.find((l) => l.id === taggedLot)?.overtime_source).toBe('workday')
+      expect(adminLots.find((l) => l.id === legacyLot)?.overtime_source ?? null).toBeNull()
+
+      const meRes = await requestJson(
+        `${baseUrl}/api/attendance/leave-balances/me?leaveTypeCode=comp_time`,
+        { headers: { Authorization: `Bearer ${meToken}` } },
+      )
+      expect(meRes.status, JSON.stringify(meRes.body)).toBe(200)
+      const meLots = (meRes.body as { data?: { activeLots?: Array<{ id: string; overtime_source: string | null }> } })?.data?.activeLots ?? []
+      expect(meLots.find((l) => l.id === taggedLot)?.overtime_source).toBe('workday')
+    } finally {
+      await pool.query(`DELETE FROM attendance_leave_balances WHERE user_id = $1`, [meId]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('attendance rules /me — returns a token-subject rule summary, rejects overrides, and does not leak admin settings', async () => {
     if (!baseUrl) return
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL

--- a/packages/core-backend/tests/unit/attendance-decision-trace-w5-0.test.ts
+++ b/packages/core-backend/tests/unit/attendance-decision-trace-w5-0.test.ts
@@ -132,6 +132,14 @@ describe('W5-0 identity resolution (§5.1 auditRef.actor, owner P2-b)', () => {
     expect(await resolveAttendanceDecisionTraceActor(null, q)).toBeNull()
     expect(await resolveAttendanceDecisionTraceActor('', q)).toBeNull()
   })
+  it('resolved user with NO name ⇒ neutral label, NEVER falls back to email (§5.1 allowlist has no email row)', async () => {
+    const q = makeMockQuery([{ match: /FROM users WHERE id/, rows: [{ id: 'u3', name: null, email: 'carol@example.com', is_active: true }] }])
+    const actor = await resolveAttendanceDecisionTraceActor('u3', q)
+    expect(actor).toEqual({ displayLabel: '已注册用户', identityPosture: 'resolved' })
+    expect(JSON.stringify(actor)).not.toContain('carol@example.com')
+    expect(JSON.stringify(actor)).not.toContain('@')
+  })
+
   it('identityPosture closed set is exactly resolved|inactive|unknown (deleted deliberately excluded, owner P2-b)', async () => {
     const q1 = makeMockQuery([{ match: /FROM users WHERE id/, rows: [{ id: 'u', name: null, email: null, is_active: true }] }])
     const resolved = await resolveAttendanceDecisionTraceActor('u', q1)
@@ -237,6 +245,19 @@ describe('② late_early — tier legacy fail-closed (not a fabricated zero)', (
     expect(trace.reasonCode).toBe('normal')
     expect(Array.isArray(trace.reasonCode)).toBe(false)
   })
+
+  it('EXACT response key set (G4 — a `requester`/extra-key leak would fail this, not just toMatchObject)', async () => {
+    const q = makeMockQuery([
+      { match: /FROM attendance_records/, rows: [{ id: 'r1', status: 'normal', is_workday: true, work_minutes: 480, late_minutes: 0, early_leave_minutes: 0, meta: {}, source_batch_id: null, created_at: 'x', updated_at: 'y' }] },
+      { match: /attendance_requests/, rows: [] },
+      ...NO_RULE_HANDLERS,
+    ])
+    const trace = await buildLateEarlyTrace('org1', 'user1', '2026-07-01', q)
+    expect(Object.keys(trace).sort()).toEqual(['basis', 'category', 'conclusion', 'confidence', 'reasonCode'])
+    expect(Object.keys(trace.conclusion).sort()).toEqual(
+      ['absenceLateCount', 'earlyLeaveMinutes', 'lateMinutes', 'severeLateCount', 'severeLateMinutes', 'status'],
+    )
+  })
 })
 
 describe('③ missing_punch — reuses classifyAttendanceOwedPunch / suggestAttendanceRequestType closed sets', () => {
@@ -283,6 +304,40 @@ describe('③ missing_punch — reuses classifyAttendanceOwedPunch / suggestAtte
     const genEnv = trace.basis.find((b) => b.source.ref === 'auto_absence_generation')
     expect(genEnv?.version.posture).toBe('undeterminable')
     expect(trace.reasonCode).toBe('absent_workday')
+  })
+
+  it('EXACT response key set (G4 — a `requester`/extra-key leak would fail this, not just toMatchObject)', async () => {
+    const q = makeMockQuery([
+      { match: /FROM attendance_records/, rows: [{ id: 'r1', status: 'partial', is_workday: true, work_minutes: 0, late_minutes: 0, early_leave_minutes: 0, meta: {}, source_batch_id: null, created_at: 'x', updated_at: 'y', first_in_at: null, last_out_at: '2026-07-01T18:00:00Z' }] },
+      { match: /FROM attendance_requests/, rows: [] },
+      ...NO_RULE_HANDLERS,
+    ])
+    const trace = await buildMissingPunchTrace('org1', 'user1', '2026-07-01', q)
+    expect(Object.keys(trace).sort()).toEqual(['basis', 'category', 'conclusion', 'confidence', 'reasonCode'])
+    expect(Object.keys(trace.conclusion).sort()).toEqual(['isWorkday', 'missingSide', 'suggestedRequestType'])
+  })
+
+  it('③E4 adjustment audit event (index.cjs:30077-30097, event_type=adjustment/source=request) is cited when present', async () => {
+    const q = makeMockQuery([
+      { match: /FROM attendance_records/, rows: [{ id: 'r1', status: 'partial', is_workday: true, work_minutes: 0, late_minutes: 0, early_leave_minutes: 0, meta: {}, source_batch_id: null, created_at: 'x', updated_at: 'y', first_in_at: null, last_out_at: '2026-07-01T18:00:00Z' }] },
+      { match: /FROM attendance_requests/, rows: [] },
+      { match: /FROM attendance_events/, rows: [{ occurred_at: '2026-07-02T00:00:00Z' }] },
+      ...NO_RULE_HANDLERS,
+    ])
+    const trace = await buildMissingPunchTrace('org1', 'user1', '2026-07-01', q)
+    const adjustmentEnv = trace.basis.find((b) => b.source.ref === 'attendance_events')
+    expect(adjustmentEnv?.version).toEqual({ posture: 'snapshot_frozen', asOf: '2026-07-02T00:00:00Z' })
+  })
+
+  it('③E4 adjustment audit event ABSENT ⇒ no attendance_events env pushed (no fabricated env)', async () => {
+    const q = makeMockQuery([
+      { match: /FROM attendance_records/, rows: [{ id: 'r1', status: 'partial', is_workday: true, work_minutes: 0, late_minutes: 0, early_leave_minutes: 0, meta: {}, source_batch_id: null, created_at: 'x', updated_at: 'y', first_in_at: null, last_out_at: '2026-07-01T18:00:00Z' }] },
+      { match: /FROM attendance_requests/, rows: [] },
+      { match: /FROM attendance_events/, rows: [] },
+      ...NO_RULE_HANDLERS,
+    ])
+    const trace = await buildMissingPunchTrace('org1', 'user1', '2026-07-01', q)
+    expect(trace.basis.find((b) => b.source.ref === 'attendance_events')).toBeUndefined()
   })
 })
 
@@ -350,6 +405,115 @@ describe('④ overtime_segmentation', () => {
     if (trace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
     expect(Object.keys(trace).sort()).toEqual(['basis', 'category', 'conclusion', 'confidence', 'coverageNote'])
   })
+
+  it('otherwise-valid snapshot but resolved_at IS NULL (still pending) ⇒ treated as NOT valid — never fabricates asOf from updated_at (§3.2 "不得伪造时点")', async () => {
+    const q = makeMockQuery([
+      {
+        match: /FROM attendance_requests/,
+        rows: [{
+          id: 'req1',
+          metadata: {
+            minutes: 120,
+            overtimeSegmentation: {
+              version: 1, engine: 'attendance_overtime_segmentation_v1', workDate: '2026-07-01', dayType: 'workday',
+              calendar: { effectiveSource: 'calendar_default', holidayName: null },
+              segments: { workdayMinutes: 120, restdayMinutes: 0, holidayMinutes: 0 }, totalMinutes: 120,
+            },
+          },
+          resolved_at: null, updated_at: '2026-07-01T20:00:00Z',
+        }],
+      },
+      { match: /FROM attendance_overtime_rules/, rows: [] },
+    ])
+    const trace = await buildOvertimeSegmentationTrace('org1', 'user1', 'req1', q, false)
+    if (trace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
+    expect(trace.coverageNote).toBe('partial_legacy')
+    const snapEnv = trace.basis.find((b) => b.source.ref === 'attendance_requests.metadata.overtimeSegmentation')
+    expect(snapEnv?.version.posture).toBe('undeterminable')
+    expect(snapEnv?.version.asOf).toBeUndefined() // never falls back to updated_at
+  })
+
+  it('snapshot with a malformed dayType outside the closed set ⇒ treated as NOT valid, never silently defaults to "restday" (§3.1 hard rule 3)', async () => {
+    const q = makeMockQuery([
+      {
+        match: /FROM attendance_requests/,
+        rows: [{
+          id: 'req1',
+          metadata: {
+            overtimeSegmentation: {
+              version: 1, engine: 'attendance_overtime_segmentation_v1', workDate: '2026-07-01', dayType: 'bogus_day_type',
+              calendar: { effectiveSource: 'calendar_default', holidayName: null },
+              segments: { workdayMinutes: 0, restdayMinutes: 120, holidayMinutes: 0 }, totalMinutes: 120,
+            },
+          },
+          resolved_at: '2026-07-02T10:00:00Z', updated_at: 'y',
+        }],
+      },
+      { match: /FROM attendance_overtime_rules/, rows: [] },
+    ])
+    const trace = await buildOvertimeSegmentationTrace('org1', 'user1', 'req1', q, false)
+    if (trace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
+    expect(trace.coverageNote).toBe('partial_legacy')
+    expect(trace.conclusion.segments).toHaveLength(0)
+  })
+
+  it('segment reasonCode is OMITTED (not a fabricated "unknown" literal) when effectiveSource is not a recognized string (§3.1 hard rule 5⑤ precedent applied to ④)', async () => {
+    const q = makeMockQuery([
+      {
+        match: /FROM attendance_requests/,
+        rows: [{
+          id: 'req1',
+          metadata: {
+            overtimeSegmentation: {
+              version: 1, engine: 'attendance_overtime_segmentation_v1', workDate: '2026-07-01', dayType: 'workday',
+              calendar: { effectiveSource: null, holidayName: null },
+              segments: { workdayMinutes: 60, restdayMinutes: 0, holidayMinutes: 0 }, totalMinutes: 60,
+            },
+          },
+          resolved_at: '2026-07-02T10:00:00Z', updated_at: 'y',
+        }],
+      },
+      { match: /FROM attendance_overtime_rules/, rows: [] },
+    ])
+    const trace = await buildOvertimeSegmentationTrace('org1', 'user1', 'req1', q, false)
+    if (trace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
+    expect(trace.conclusion.segments).toHaveLength(1)
+    expect(Object.prototype.hasOwnProperty.call(trace.conclusion.segments[0], 'reasonCode')).toBe(false)
+    expect(JSON.stringify(trace)).not.toContain('unknown')
+  })
+
+  it('crossesMidnight snapshot ⇒ segments[] walks EVERY perDate entry (Σsegments.minutes === totalMinutes, no discarded date)', async () => {
+    const q = makeMockQuery([
+      {
+        match: /FROM attendance_requests/,
+        rows: [{
+          id: 'req1',
+          metadata: {
+            overtimeSegmentation: {
+              version: 1, engine: 'attendance_overtime_segmentation_v1', workDate: '2026-07-01',
+              crossesMidnight: true,
+              dayType: 'workday', // primary/back-compat fields — must NOT be the only segment
+              calendar: { effectiveSource: 'calendar_default', holidayName: null },
+              perDate: [
+                { date: '2026-07-01', dayType: 'workday', minutes: 40, calendar: { effectiveSource: 'calendar_default', holidayName: null } },
+                { date: '2026-07-02', dayType: 'restday', minutes: 20, calendar: { effectiveSource: 'weekend_default', holidayName: null } },
+              ],
+              segments: { workdayMinutes: 40, restdayMinutes: 20, holidayMinutes: 0 }, totalMinutes: 60,
+            },
+          },
+          resolved_at: '2026-07-03T10:00:00Z', updated_at: 'y',
+        }],
+      },
+      { match: /FROM attendance_overtime_rules/, rows: [] },
+    ])
+    const trace = await buildOvertimeSegmentationTrace('org1', 'user1', 'req1', q, false)
+    if (trace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
+    expect(trace.conclusion.segments).toHaveLength(2)
+    expect(trace.conclusion.segments[0]).toEqual({ dayType: 'workday', minutes: 40, reasonCode: 'calendar_default', holidayName: null })
+    expect(trace.conclusion.segments[1]).toEqual({ dayType: 'restday', minutes: 20, reasonCode: 'weekend_default', holidayName: null })
+    const sum = trace.conclusion.segments.reduce((acc, s) => acc + s.minutes, 0)
+    expect(sum).toBe(trace.conclusion.totalMinutes)
+  })
 })
 
 describe('⑤ comp_time_balance — sourceResolution known/unknown discriminated union (hard rule 5⑤)', () => {
@@ -401,9 +565,100 @@ describe('⑤ comp_time_balance — sourceResolution known/unknown discriminated
     const gateEnv = trace.basis.find((b) => b.source.ref === 'compTimeFromOvertime')
     expect(gateEnv?.version.posture).toBe('not_in_effect')
   })
+
+  describe('§3.1 hard rule 2 — dormant org (engine OFF, empty ledger) is `not_in_effect`, NEVER `undeterminable` (owner worked example)', () => {
+    it('compTimeFromOvertime OFF + empty lots/events ⇒ E1/E2 ledger envs are not_in_effect, top-level confidence is "partial" (never "undeterminable" for a policy fact)', async () => {
+      const q = makeMockQuery([
+        { match: /SUM\(CASE WHEN e\.event_type = 'grant'/, rows: [{ granted: '0', exhausted: '0', expired: '0' }] },
+        { match: /SUM\(remaining_minutes\)/, rows: [{ remaining: '0' }] },
+        { match: /FROM attendance_leave_balances/, rows: [] },
+        { match: /FROM attendance_leave_balance_events/, rows: [] },
+      ])
+      const trace = await buildCompTimeBalanceTrace('org1', 'user1', q, { compTimeFromOvertime: false, overtimeBankPolicy: false })
+      const ledgerEnv = trace.basis.find((b) => b.source.ref === 'attendance_leave_balances')
+      const eventsEnv = trace.basis.find((b) => b.source.ref === 'attendance_leave_balance_events')
+      expect(ledgerEnv?.version.posture).toBe('not_in_effect')
+      expect(eventsEnv?.version.posture).toBe('not_in_effect')
+      expect(trace.confidence).toBe('partial')
+    })
+
+    it('compTimeFromOvertime ON + empty lots/events (pool empty / never accrued) ⇒ E1/E2 stay undeterminable (OD-W5-4: a real gap, not a policy fact)', async () => {
+      const q = makeMockQuery([
+        { match: /SUM\(CASE WHEN e\.event_type = 'grant'/, rows: [{ granted: '0', exhausted: '0', expired: '0' }] },
+        { match: /SUM\(remaining_minutes\)/, rows: [{ remaining: '0' }] },
+        { match: /FROM attendance_leave_balances/, rows: [] },
+        { match: /FROM attendance_leave_balance_events/, rows: [] },
+      ])
+      const trace = await buildCompTimeBalanceTrace('org1', 'user1', q, { compTimeFromOvertime: true, overtimeBankPolicy: false })
+      const ledgerEnv = trace.basis.find((b) => b.source.ref === 'attendance_leave_balances')
+      const eventsEnv = trace.basis.find((b) => b.source.ref === 'attendance_leave_balance_events')
+      expect(ledgerEnv?.version.posture).toBe('undeterminable')
+      expect(eventsEnv?.version.posture).toBe('undeterminable')
+      expect(trace.confidence).toBe('undeterminable')
+    })
+
+    it('a non-empty ledger stays snapshot_frozen regardless of the CURRENT gate value (§3.1 hard rule 6 — a real lot does not un-happen when the policy is later turned off)', async () => {
+      const q = makeMockQuery([
+        { match: /SUM\(CASE WHEN e\.event_type = 'grant'/, rows: [{ granted: '480', exhausted: '0', expired: '0' }] },
+        { match: /SUM\(remaining_minutes\)/, rows: [{ remaining: '480' }] },
+        { match: /FROM attendance_leave_balances/, rows: [{ id: 'lot1', source_type: 'annual_manual_adjust', granted_at: '2026-07-01T00:00:00Z', expires_at: null, overtime_source: null }] },
+        { match: /FROM attendance_leave_balance_events/, rows: [] },
+      ])
+      const trace = await buildCompTimeBalanceTrace('org1', 'user1', q, { compTimeFromOvertime: false, overtimeBankPolicy: false })
+      const ledgerEnv = trace.basis.find((b) => b.source.ref === 'attendance_leave_balances')
+      expect(ledgerEnv?.version.posture).toBe('snapshot_frozen')
+    })
+  })
+
+  describe('§3.3⑤E4 — payroll-cycle-settlement snapshot folded into THIS builder (OD-W5-6=(a), no longer dead code)', () => {
+    it('settlement rows present ⇒ E4 basis env is snapshot_frozen (the settlements query is actually issued from buildCompTimeBalanceTrace)', async () => {
+      const q = makeMockQuery([
+        { match: /SUM\(CASE WHEN e\.event_type = 'grant'/, rows: [{ granted: '0', exhausted: '0', expired: '0' }] },
+        { match: /SUM\(remaining_minutes\)/, rows: [{ remaining: '0' }] },
+        { match: /FROM attendance_leave_balances/, rows: [] },
+        { match: /FROM attendance_leave_balance_events/, rows: [] },
+        {
+          match: /FROM attendance_payroll_cycle_settlements/,
+          rows: [{ cycle_id: 'c1', period_start_date: '2026-06-01', period_end_date: '2026-06-30', closed_at: '2026-07-01T00:00:00Z', source: 'workday', convertible_minutes: 60, must_pay_minutes: 0 }],
+        },
+      ])
+      const trace = await buildCompTimeBalanceTrace('org1', 'user1', q, { compTimeFromOvertime: false, overtimeBankPolicy: true })
+      const settlementEnv = trace.basis.find((b) => b.source.ref === 'attendance_payroll_cycle_settlements')
+      expect(settlementEnv).toEqual({
+        source: { kind: 'snapshot', ref: 'attendance_payroll_cycle_settlements' },
+        version: { posture: 'snapshot_frozen', asOf: '2026-07-01T00:00:00Z' },
+      })
+    })
+
+    it('no settlement rows + overtimeBankPolicy OFF ⇒ E4 is not_in_effect (policy fact)', async () => {
+      const q = makeMockQuery([
+        { match: /SUM\(CASE WHEN e\.event_type = 'grant'/, rows: [{ granted: '0', exhausted: '0', expired: '0' }] },
+        { match: /SUM\(remaining_minutes\)/, rows: [{ remaining: '0' }] },
+        { match: /FROM attendance_leave_balances/, rows: [] },
+        { match: /FROM attendance_leave_balance_events/, rows: [] },
+        { match: /FROM attendance_payroll_cycle_settlements/, rows: [] },
+      ])
+      const trace = await buildCompTimeBalanceTrace('org1', 'user1', q, { compTimeFromOvertime: false, overtimeBankPolicy: false })
+      const settlementEnv = trace.basis.find((b) => b.source.ref === 'attendance_payroll_cycle_settlements')
+      expect(settlementEnv?.version.posture).toBe('not_in_effect')
+    })
+
+    it('no settlement rows + overtimeBankPolicy ON ⇒ E4 is undeterminable (should have settled but did not)', async () => {
+      const q = makeMockQuery([
+        { match: /SUM\(CASE WHEN e\.event_type = 'grant'/, rows: [{ granted: '0', exhausted: '0', expired: '0' }] },
+        { match: /SUM\(remaining_minutes\)/, rows: [{ remaining: '0' }] },
+        { match: /FROM attendance_leave_balances/, rows: [] },
+        { match: /FROM attendance_leave_balance_events/, rows: [] },
+        { match: /FROM attendance_payroll_cycle_settlements/, rows: [] },
+      ])
+      const trace = await buildCompTimeBalanceTrace('org1', 'user1', q, { compTimeFromOvertime: false, overtimeBankPolicy: true })
+      const settlementEnv = trace.basis.find((b) => b.source.ref === 'attendance_payroll_cycle_settlements')
+      expect(settlementEnv?.version.posture).toBe('undeterminable')
+    })
+  })
 })
 
-describe('settlement seventh read face (OD-W5-6)', () => {
+describe('settlement seventh read face (OD-W5-6) — pure helper unit coverage', () => {
   it('rows present ⇒ snapshot_frozen anchored at closed_at (most recent)', () => {
     const env = attendancePayrollCycleSettlementBasisEnv(
       [{ cycleId: 'c1', periodStartDate: '2026-06-01', periodEndDate: '2026-06-30', closedAt: '2026-07-01T00:00:00Z', source: 'workday', convertibleMinutes: 60, mustPayMinutes: 0 }],
@@ -445,8 +700,38 @@ describe('⑥ approver_source', () => {
     const trace = await buildApproverSourceTrace('org1', 'user1', 'inst1', q, false)
     if (trace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
     expect(Object.prototype.hasOwnProperty.call(trace, 'reasonCode')).toBe(false)
+    // EXACT key set (G4 — toMatchObject alone would pass even if a `requester`/raw `assigneeId` key
+    // were added; deepEqual on the sorted key list is what actually turns red on that mutation).
+    expect(Object.keys(trace.conclusion.steps[0]).sort()).toEqual(['actor', 'assigneeResolved', 'reasonCode', 'sourceKind', 'stepIndex'])
     expect(trace.conclusion.steps[0]).toMatchObject({ stepIndex: 0, assigneeResolved: true, sourceKind: 'direct_manager', reasonCode: 'direct_manager' })
     expect(trace.conclusion.steps[0].actor).toEqual({ displayLabel: 'Manager One', identityPosture: 'resolved' })
+    expect(Object.keys(trace).sort()).toEqual(['basis', 'category', 'conclusion', 'confidence'])
+  })
+
+  it('a step with NO level and NO resolved actor (role-type assignment) has the MINIMAL key set — no `level`/`actor` key at all (not null-valued)', async () => {
+    const q = makeMockQuery([
+      { match: /FROM attendance_requests WHERE org_id/, rows: [{ id: 'req1' }] },
+      { match: /FROM approval_instances/, rows: [{ id: 'inst1', created_at: 'x', requester_snapshot: {}, metadata: {} }] },
+      { match: /FROM approval_assignments/, rows: [{ assignment_type: 'role', assignee_id: 'admin', source_step: 0, metadata: { source: 'attendance', queue: 'attendance-approval' }, updated_at: 'y' }] },
+      { match: /FROM approval_records/, rows: [] },
+    ])
+    const trace = await buildApproverSourceTrace('org1', 'user1', 'inst1', q, false)
+    if (trace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
+    expect(Object.keys(trace.conclusion.steps[0]).sort()).toEqual(['assigneeResolved', 'reasonCode', 'sourceKind', 'stepIndex'])
+  })
+
+  it('is_active = true predicate on approval_assignments (§3.3⑥E1 "当前有效指派" — a deactivated/superseded assignment must never surface as a step)', async () => {
+    const calls: string[] = []
+    const q = (async (sql: string) => {
+      calls.push(sql)
+      if (/FROM attendance_requests WHERE org_id/.test(sql)) return { rows: [{ id: 'req1' }], rowCount: 1 } as never
+      if (/FROM approval_instances/.test(sql)) return { rows: [{ id: 'inst1', created_at: 'x', requester_snapshot: {}, metadata: {} }], rowCount: 1 } as never
+      return { rows: [], rowCount: 0 } as never
+    }) as AttendanceDecisionTraceQueryFn
+    await buildApproverSourceTrace('org1', 'user1', 'inst1', q, false)
+    const assignmentsSql = calls.find((sql) => /FROM approval_assignments/.test(sql))
+    expect(assignmentsSql).toBeDefined()
+    expect(assignmentsSql).toMatch(/is_active\s*=\s*true/)
   })
 
   it('manager_at_level assignment ⇒ step carries level', async () => {

--- a/packages/core-backend/tests/unit/attendance-decision-trace-w5-0.test.ts
+++ b/packages/core-backend/tests/unit/attendance-decision-trace-w5-0.test.ts
@@ -1,0 +1,501 @@
+/**
+ * W5-0 (Wave 5 explainability design-lock 2026-07-22, RATIFIED §3/§4/§9): mock-level contract
+ * coverage for the six evidence-chain builders in `services/AttendanceDecisionTrace.ts`.
+ *
+ * Real-Postgres behavioural proof (§9 W5-0-G1..G7 — the READ ONLY seam actually rejecting writes,
+ * the two-user/same-org subject-constrained negative matrix, the ⑤ raw-`source_type` fixture, the
+ * G6 snapshot-exclusivity mutation) lives in
+ * `tests/integration/attendance-decision-trace-w5-0.db.test.ts`. This file's job is everything a
+ * mock CAN prove: exact response key-set per category, the `reasonCode` discriminated-union
+ * carrier rule (hard rule 5 — ①②③ scalar / ④⑤⑥ absent at response level), the ⑤ lot
+ * `sourceResolution` known/unknown branches with EXACT per-branch key sets, enum-strict category
+ * validation, the confidence-derivation pure formula, and the identity-posture resolver's three
+ * branches.
+ *
+ * Mutation evidence (load-bearing; PR body cross-references these by name):
+ *  - move `reasonCode` from ① response-level to a `[reasonCode]` array ⇒ scalar-vs-array test red.
+ *  - add a `reasonCode` key to the ④/⑤/⑥ response level ⇒ "no top-level reasonCode" tests red.
+ *  - make the ⑤ unknown-source branch carry the raw `source_type` string ⇒ no-raw-value test red.
+ *  - make the ⑤ unknown-source branch carry a placeholder `reasonCode` ⇒ key-set test red.
+ *  - collapse `identityPosture` 'unknown'/'inactive' into one branch ⇒ identity tests red.
+ */
+import { describe, expect, it } from 'vitest'
+import type { QueryResult, QueryResultRow } from 'pg'
+import {
+  ATTENDANCE_APPROVER_SOURCE_KINDS,
+  ATTENDANCE_DECISION_TRACE_CATEGORIES,
+  ATTENDANCE_DECISION_TRACE_NOT_FOUND,
+  ATTENDANCE_RECORD_STATUS_VALUES,
+  attendancePayrollCycleSettlementBasisEnv,
+  buildApproverSourceTrace,
+  buildCompTimeBalanceTrace,
+  buildLateEarlyTrace,
+  buildMissingPunchTrace,
+  buildOvertimeSegmentationTrace,
+  buildTodayStatusTrace,
+  classifyAttendanceOwedPunch,
+  deriveAttendanceDecisionTraceConfidence,
+  isAttendanceDecisionTraceCategory,
+  resolveAttendanceDecisionTraceActor,
+  suggestAttendanceRequestType,
+  type AttendanceDecisionTraceBasisEnv,
+  type AttendanceDecisionTraceQueryFn,
+} from '../../src/services/AttendanceDecisionTrace'
+
+// ---------------------------------------------------------------------------------------------
+// Mock query function: dispatches on a SQL-text substring so builders that issue several queries
+// stay testable without depending on call ORDER (resilient to future query re-sequencing).
+// ---------------------------------------------------------------------------------------------
+type Handler = { match: RegExp; rows: QueryResultRow[] }
+
+function makeMockQuery(handlers: Handler[], fallback: QueryResultRow[] = []): AttendanceDecisionTraceQueryFn {
+  return (async <T extends QueryResultRow = QueryResultRow>(sql: string) => {
+    for (const h of handlers) {
+      if (h.match.test(sql)) {
+        return { rows: h.rows, rowCount: h.rows.length } as unknown as QueryResult<T>
+      }
+    }
+    return { rows: fallback, rowCount: fallback.length } as unknown as QueryResult<T>
+  }) as AttendanceDecisionTraceQueryFn
+}
+
+const NO_RULE_HANDLERS: Handler[] = [
+  { match: /attendance_shift_assignments/, rows: [] },
+  { match: /FROM attendance_rules WHERE org_id = \$1/, rows: [] },
+  { match: /FROM attendance_rules WHERE org_id = 'default'/, rows: [] },
+  { match: /attendance_record_result_edits/, rows: [] },
+  { match: /FROM users WHERE id/, rows: [] },
+]
+
+describe('W5-0 category closed set', () => {
+  it('has exactly the six charter-ordered categories', () => {
+    expect(ATTENDANCE_DECISION_TRACE_CATEGORIES).toEqual([
+      'today_status',
+      'late_early',
+      'missing_punch',
+      'overtime_segmentation',
+      'comp_time_balance',
+      'approver_source',
+    ])
+  })
+
+  it('isAttendanceDecisionTraceCategory rejects unknown strings and non-strings (enum-strict)', () => {
+    expect(isAttendanceDecisionTraceCategory('today_status')).toBe(true)
+    expect(isAttendanceDecisionTraceCategory('bogus_category')).toBe(false)
+    expect(isAttendanceDecisionTraceCategory('')).toBe(false)
+    expect(isAttendanceDecisionTraceCategory(undefined)).toBe(false)
+    expect(isAttendanceDecisionTraceCategory(123)).toBe(false)
+  })
+})
+
+describe('W5-0 confidence derivation (pure formula, §3.1)', () => {
+  const frozen: AttendanceDecisionTraceBasisEnv = { source: { kind: 'record', ref: 'x' }, version: { posture: 'snapshot_frozen', asOf: '2026-01-01T00:00:00Z' } }
+  const live: AttendanceDecisionTraceBasisEnv = { source: { kind: 'rule_live', ref: 'x' }, version: { posture: 'current_live_no_history' } }
+  const notInEffect: AttendanceDecisionTraceBasisEnv = { source: { kind: 'policy_gate', ref: 'x' }, version: { posture: 'not_in_effect' } }
+  const undeterminable: AttendanceDecisionTraceBasisEnv = { source: { kind: 'record', ref: 'x' }, version: { posture: 'undeterminable' } }
+
+  it('all snapshot_frozen ⇒ grounded', () => {
+    expect(deriveAttendanceDecisionTraceConfidence([frozen, frozen])).toBe('grounded')
+  })
+  it('any current_live_no_history/not_in_effect (no undeterminable) ⇒ partial', () => {
+    expect(deriveAttendanceDecisionTraceConfidence([frozen, live])).toBe('partial')
+    expect(deriveAttendanceDecisionTraceConfidence([frozen, notInEffect])).toBe('partial')
+  })
+  it('any undeterminable ⇒ undeterminable, even alongside grounded environments', () => {
+    expect(deriveAttendanceDecisionTraceConfidence([frozen, undeterminable])).toBe('undeterminable')
+  })
+  it('empty basis ⇒ undeterminable (fail-closed, never grounded-by-vacuous-truth)', () => {
+    expect(deriveAttendanceDecisionTraceConfidence([])).toBe('undeterminable')
+  })
+})
+
+describe('W5-0 identity resolution (§5.1 auditRef.actor, owner P2-b)', () => {
+  it('resolved: active user with a name ⇒ {displayLabel:name, identityPosture:"resolved"}', async () => {
+    const q = makeMockQuery([{ match: /FROM users WHERE id/, rows: [{ id: 'u1', name: 'Alice', email: 'a@x.com', is_active: true }] }])
+    const actor = await resolveAttendanceDecisionTraceActor('u1', q)
+    expect(actor).toEqual({ displayLabel: 'Alice', identityPosture: 'resolved' })
+  })
+  it('inactive: users.is_active=false ⇒ neutral label, NEVER the raw id', async () => {
+    const q = makeMockQuery([{ match: /FROM users WHERE id/, rows: [{ id: 'u2', name: 'Bob', email: 'b@x.com', is_active: false }] }])
+    const actor = await resolveAttendanceDecisionTraceActor('u2', q)
+    expect(actor).toEqual({ displayLabel: '已停用用户', identityPosture: 'inactive' })
+    expect(JSON.stringify(actor)).not.toContain('u2')
+  })
+  it('unknown: no users row ⇒ neutral label, NEVER the raw id', async () => {
+    const q = makeMockQuery([{ match: /FROM users WHERE id/, rows: [] }])
+    const actor = await resolveAttendanceDecisionTraceActor('ghost-id', q)
+    expect(actor).toEqual({ displayLabel: '未知用户', identityPosture: 'unknown' })
+    expect(JSON.stringify(actor)).not.toContain('ghost-id')
+  })
+  it('null/blank userId ⇒ null (no actor key at all upstream)', async () => {
+    const q = makeMockQuery([])
+    expect(await resolveAttendanceDecisionTraceActor(null, q)).toBeNull()
+    expect(await resolveAttendanceDecisionTraceActor('', q)).toBeNull()
+  })
+  it('identityPosture closed set is exactly resolved|inactive|unknown (deleted deliberately excluded, owner P2-b)', async () => {
+    const q1 = makeMockQuery([{ match: /FROM users WHERE id/, rows: [{ id: 'u', name: null, email: null, is_active: true }] }])
+    const resolved = await resolveAttendanceDecisionTraceActor('u', q1)
+    const closedSet = ['resolved', 'inactive', 'unknown']
+    expect(closedSet).toContain(resolved?.identityPosture)
+  })
+})
+
+describe('① today_status', () => {
+  it('record absent ⇒ 200-shaped undeterminable trace, reasonCode KEY ABSENT (not null/placeholder)', async () => {
+    const q = makeMockQuery([{ match: /FROM attendance_records/, rows: [] }, ...NO_RULE_HANDLERS])
+    const trace = await buildTodayStatusTrace('org1', 'user1', '2026-07-01', q)
+    expect(trace.confidence).toBe('undeterminable')
+    expect(trace.conclusion.status).toBeNull()
+    expect(Object.prototype.hasOwnProperty.call(trace, 'reasonCode')).toBe(false)
+    expect(trace.basis.every((b) => b.version.posture === 'undeterminable')).toBe(true)
+  })
+
+  it('record present ⇒ EXACT response key set + reasonCode is the status column value (scalar, hard rule 5①)', async () => {
+    const q = makeMockQuery([
+      {
+        match: /FROM attendance_records/,
+        rows: [
+          {
+            id: 'r1', status: 'late', is_workday: true, work_minutes: 400, late_minutes: 15, early_leave_minutes: 0,
+            meta: {}, source_batch_id: null, created_at: '2026-07-01T09:00:00Z', updated_at: '2026-07-01T09:20:00Z',
+          },
+        ],
+      },
+      ...NO_RULE_HANDLERS,
+    ])
+    const trace = await buildTodayStatusTrace('org1', 'user1', '2026-07-01', q)
+    expect(trace.category).toBe('today_status')
+    expect(trace.reasonCode).toBe('late')
+    expect(typeof trace.reasonCode).toBe('string') // scalar, never an array
+    expect(Object.keys(trace).sort()).toEqual(['basis', 'category', 'conclusion', 'confidence', 'reasonCode'])
+    expect(Object.keys(trace.conclusion).sort()).toEqual(
+      ['earlyLeaveMinutes', 'isWorkday', 'lateMinutes', 'status', 'workDate', 'workMinutes'],
+    )
+    expect(ATTENDANCE_RECORD_STATUS_VALUES).toContain(trace.reasonCode)
+  })
+
+  it('current-rule environment is ALWAYS current_live_no_history, never snapshot_frozen (R4/§3.1 hard rule 6)', async () => {
+    const q = makeMockQuery([
+      {
+        match: /FROM attendance_records/,
+        rows: [{ id: 'r1', status: 'normal', is_workday: true, work_minutes: 480, late_minutes: 0, early_leave_minutes: 0, meta: {}, source_batch_id: null, created_at: 'x', updated_at: '2026-07-01T09:00:00Z' }],
+      },
+      { match: /attendance_shift_assignments/, rows: [] },
+      { match: /FROM attendance_rules WHERE org_id = \$1/, rows: [{ late_grace_minutes: 10, early_grace_minutes: 10, severe_late_threshold_minutes: 30, absence_late_threshold_minutes: 60 }] },
+      { match: /attendance_record_result_edits/, rows: [] },
+    ])
+    const trace = await buildTodayStatusTrace('org1', 'user1', '2026-07-01', q)
+    const ruleEnv = trace.basis.find((b) => b.source.kind === 'rule_live')
+    expect(ruleEnv?.version.posture).toBe('current_live_no_history')
+    expect(ruleEnv?.version.asOf).toBeUndefined() // current_live_no_history never carries asOf
+  })
+})
+
+describe('② late_early — tier legacy fail-closed (not a fabricated zero)', () => {
+  it('legacy record without tier meta keys ⇒ tier environment undeterminable, conclusion tier fields null', async () => {
+    const q = makeMockQuery([
+      {
+        match: /FROM attendance_records/,
+        rows: [{ id: 'r1', status: 'late', is_workday: true, work_minutes: 400, late_minutes: 20, early_leave_minutes: 0, meta: {}, source_batch_id: null, created_at: 'x', updated_at: '2026-07-01T09:00:00Z' }],
+      },
+      { match: /attendance_requests/, rows: [] },
+      ...NO_RULE_HANDLERS,
+    ])
+    const trace = await buildLateEarlyTrace('org1', 'user1', '2026-07-01', q)
+    expect(trace.conclusion.severeLateCount).toBeNull()
+    const tierEnv = trace.basis.find((b) => b.source.ref === 'attendance_records.meta.tier')
+    expect(tierEnv?.version.posture).toBe('undeterminable')
+  })
+
+  it('record with tier meta keys present ⇒ tier fields surfaced from meta, tier env snapshot_frozen', async () => {
+    const q = makeMockQuery([
+      {
+        match: /FROM attendance_records/,
+        rows: [{
+          id: 'r1', status: 'late', is_workday: true, work_minutes: 400, late_minutes: 45, early_leave_minutes: 0,
+          meta: { severe_late_count: 1, severe_late_minutes: 45, absence_late_count: 0 },
+          source_batch_id: null, created_at: 'x', updated_at: '2026-07-01T09:00:00Z',
+        }],
+      },
+      { match: /attendance_requests/, rows: [] },
+      ...NO_RULE_HANDLERS,
+    ])
+    const trace = await buildLateEarlyTrace('org1', 'user1', '2026-07-01', q)
+    expect(trace.conclusion.severeLateCount).toBe(1)
+    expect(trace.conclusion.severeLateMinutes).toBe(45)
+    const tierEnv = trace.basis.find((b) => b.source.ref === 'attendance_records.meta.tier')
+    expect(tierEnv?.version.posture).toBe('snapshot_frozen')
+  })
+
+  it('reasonCode is present at response level (scalar, hard rule 5②) and NEVER an array', async () => {
+    const q = makeMockQuery([
+      { match: /FROM attendance_records/, rows: [{ id: 'r1', status: 'normal', is_workday: true, work_minutes: 480, late_minutes: 0, early_leave_minutes: 0, meta: {}, source_batch_id: null, created_at: 'x', updated_at: 'y' }] },
+      { match: /attendance_requests/, rows: [] },
+      ...NO_RULE_HANDLERS,
+    ])
+    const trace = await buildLateEarlyTrace('org1', 'user1', '2026-07-01', q)
+    expect(trace.reasonCode).toBe('normal')
+    expect(Array.isArray(trace.reasonCode)).toBe(false)
+  })
+})
+
+describe('③ missing_punch — reuses classifyAttendanceOwedPunch / suggestAttendanceRequestType closed sets', () => {
+  it('classifyAttendanceOwedPunch mirrors index.cjs:25932-25956 decision table exactly', () => {
+    expect(classifyAttendanceOwedPunch({ status: 'absent', is_workday: true, first_in_at: null, last_out_at: null })).toEqual({
+      owedPunch: true, missingSide: 'both', owedPunchReason: 'absent_workday',
+    })
+    expect(classifyAttendanceOwedPunch({ status: 'partial', is_workday: true, first_in_at: null, last_out_at: '2026-01-01T18:00:00Z' })).toEqual({
+      owedPunch: true, missingSide: 'check_in', owedPunchReason: 'partial_missing_check_in',
+    })
+    expect(classifyAttendanceOwedPunch({ status: 'partial', is_workday: true, first_in_at: '2026-01-01T09:00:00Z', last_out_at: null })).toEqual({
+      owedPunch: true, missingSide: 'check_out', owedPunchReason: 'partial_missing_check_out',
+    })
+    expect(classifyAttendanceOwedPunch({ status: 'normal', is_workday: true, first_in_at: 'x', last_out_at: 'y' })).toEqual({
+      owedPunch: false, missingSide: null, owedPunchReason: 'status_normal',
+    })
+    expect(classifyAttendanceOwedPunch({ status: 'late', is_workday: false, first_in_at: 'x', last_out_at: 'y' })).toEqual({
+      owedPunch: false, missingSide: null, owedPunchReason: 'non_workday',
+    })
+  })
+
+  it('suggestAttendanceRequestType mirrors index.cjs:26427-26436 exactly', () => {
+    expect(suggestAttendanceRequestType({ status: 'absent', first_in_at: null, last_out_at: null })).toBe('leave')
+    expect(suggestAttendanceRequestType({ status: 'partial', first_in_at: null, last_out_at: 'y' })).toBe('missed_check_in')
+    expect(suggestAttendanceRequestType({ status: 'partial', first_in_at: 'x', last_out_at: null })).toBe('missed_check_out')
+    expect(suggestAttendanceRequestType({ status: 'late', first_in_at: 'x', last_out_at: 'y' })).toBe('time_correction')
+    expect(suggestAttendanceRequestType({ status: 'normal', first_in_at: 'x', last_out_at: 'y' })).toBeNull()
+  })
+
+  it('no record row ⇒ undeterminable, reasonCode key absent', async () => {
+    const q = makeMockQuery([{ match: /FROM attendance_records/, rows: [] }, ...NO_RULE_HANDLERS])
+    const trace = await buildMissingPunchTrace('org1', 'user1', '2026-07-01', q)
+    expect(trace.confidence).toBe('undeterminable')
+    expect(Object.prototype.hasOwnProperty.call(trace, 'reasonCode')).toBe(false)
+  })
+
+  it('absent row ⇒ generation-source environment always undeterminable (no run marker exists, §1-3)', async () => {
+    const q = makeMockQuery([
+      { match: /FROM attendance_records/, rows: [{ id: 'r1', status: 'absent', is_workday: true, work_minutes: 0, late_minutes: 0, early_leave_minutes: 0, meta: {}, source_batch_id: null, created_at: 'x', updated_at: 'y', first_in_at: null, last_out_at: null }] },
+      { match: /FROM attendance_requests/, rows: [] },
+      ...NO_RULE_HANDLERS,
+    ])
+    const trace = await buildMissingPunchTrace('org1', 'user1', '2026-07-01', q)
+    const genEnv = trace.basis.find((b) => b.source.ref === 'auto_absence_generation')
+    expect(genEnv?.version.posture).toBe('undeterminable')
+    expect(trace.reasonCode).toBe('absent_workday')
+  })
+})
+
+describe('④ overtime_segmentation', () => {
+  it('unknown requestId (or belongs to another org/user) ⇒ NOT_FOUND sentinel', async () => {
+    const q = makeMockQuery([{ match: /FROM attendance_requests/, rows: [] }])
+    const result = await buildOvertimeSegmentationTrace('org1', 'user1', 'req-ghost', q, false)
+    expect(result).toBe(ATTENDANCE_DECISION_TRACE_NOT_FOUND)
+  })
+
+  it('valid snapshot ⇒ response-level has NO reasonCode key; segment carries its own reasonCode; coverageNote="full"', async () => {
+    const q = makeMockQuery([
+      {
+        match: /FROM attendance_requests/,
+        rows: [{
+          id: 'req1',
+          metadata: {
+            minutes: 120,
+            overtimeSegmentation: {
+              version: 1, engine: 'attendance_overtime_segmentation_v1', workDate: '2026-07-01', dayType: 'workday',
+              calendar: { effectiveSource: 'calendar_default', holidayName: null },
+              segments: { workdayMinutes: 120, restdayMinutes: 0, holidayMinutes: 0 }, totalMinutes: 120,
+            },
+            overtimeRule: { minMinutes: 30 },
+            approvalFlow: { steps: [] },
+          },
+          resolved_at: '2026-07-02T10:00:00Z', updated_at: '2026-07-01T20:00:00Z',
+        }],
+      },
+      { match: /FROM attendance_overtime_rules/, rows: [{ id: 'rule1' }] },
+    ])
+    const trace = await buildOvertimeSegmentationTrace('org1', 'user1', 'req1', q, false)
+    if (trace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
+    expect(Object.prototype.hasOwnProperty.call(trace, 'reasonCode')).toBe(false)
+    expect(trace.coverageNote).toBe('full')
+    expect(trace.conclusion.segments).toHaveLength(1)
+    expect(trace.conclusion.segments[0].reasonCode).toBe('calendar_default')
+    expect(trace.conclusion.segmentationVersion).toBe(1)
+    // asOf anchors resolvedAt (terminal review time), NEVER created_at (§5.2①).
+    const snapEnv = trace.basis.find((b) => b.source.ref === 'attendance_requests.metadata.overtimeSegmentation')
+    expect(snapEnv?.version.asOf).toBe('2026-07-02T10:00:00Z')
+  })
+
+  it('legacy request (no valid snapshot) ⇒ coverageNote="partial_legacy", snapshot env undeterminable, engine-gate env present', async () => {
+    const q = makeMockQuery([
+      { match: /FROM attendance_requests/, rows: [{ id: 'req1', metadata: { minutes: 90 }, resolved_at: null, updated_at: '2026-06-01T10:00:00Z' }] },
+      { match: /FROM attendance_overtime_rules/, rows: [] },
+    ])
+    const trace = await buildOvertimeSegmentationTrace('org1', 'user1', 'req1', q, false)
+    if (trace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
+    expect(trace.coverageNote).toBe('partial_legacy')
+    expect(trace.conclusion.segmentationVersion).toBeNull()
+    const snapEnv = trace.basis.find((b) => b.source.ref === 'attendance_requests.metadata.overtimeSegmentation')
+    expect(snapEnv?.version.posture).toBe('undeterminable')
+    const gateEnv = trace.basis.find((b) => b.source.ref === 'overtimeSegmentation')
+    expect(gateEnv?.version.posture).toBe('not_in_effect') // engine disabled param
+  })
+
+  it('response-level key set has no reasonCode, has coverageNote (hard rule 5④)', async () => {
+    const q = makeMockQuery([
+      { match: /FROM attendance_requests/, rows: [{ id: 'req1', metadata: { minutes: 90 }, resolved_at: null, updated_at: 'y' }] },
+      { match: /FROM attendance_overtime_rules/, rows: [] },
+    ])
+    const trace = await buildOvertimeSegmentationTrace('org1', 'user1', 'req1', q, false)
+    if (trace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
+    expect(Object.keys(trace).sort()).toEqual(['basis', 'category', 'conclusion', 'confidence', 'coverageNote'])
+  })
+})
+
+describe('⑤ comp_time_balance — sourceResolution known/unknown discriminated union (hard rule 5⑤)', () => {
+  it('mapped source_type ⇒ {sourceResolution:"mapped", reasonCode, grantedAt, expiresAt} EXACT key set', async () => {
+    const q = makeMockQuery([
+      { match: /SUM\(CASE WHEN e\.event_type = 'grant'/, rows: [{ granted: '480', exhausted: '0', expired: '0' }] },
+      { match: /SUM\(remaining_minutes\)/, rows: [{ remaining: '480' }] },
+      { match: /FROM attendance_leave_balances/, rows: [{ id: 'lot1', source_type: 'overtime_conversion', granted_at: '2026-07-01T00:00:00Z', expires_at: null, overtime_source: 'workday' }] },
+      { match: /FROM attendance_leave_balance_events/, rows: [] },
+    ])
+    const trace = await buildCompTimeBalanceTrace('org1', 'user1', q, { compTimeFromOvertime: true, overtimeBankPolicy: true })
+    const lot = trace.conclusion.lots[0]
+    expect(lot).toEqual({ sourceResolution: 'mapped', reasonCode: 'overtime_conversion', grantedAt: '2026-07-01T00:00:00Z', expiresAt: null, overtimeSource: 'workday' })
+  })
+
+  it('unmapped/unknown source_type ⇒ {sourceResolution:"unknown_source", grantedAt, expiresAt} — reasonCode key ABSENT, raw value NEVER echoed', async () => {
+    const q = makeMockQuery([
+      { match: /SUM\(CASE WHEN e\.event_type = 'grant'/, rows: [{ granted: '480', exhausted: '0', expired: '0' }] },
+      { match: /SUM\(remaining_minutes\)/, rows: [{ remaining: '480' }] },
+      { match: /FROM attendance_leave_balances/, rows: [{ id: 'lot1', source_type: 'some_future_migration_source', granted_at: '2026-07-01T00:00:00Z', expires_at: null, overtime_source: null }] },
+      { match: /FROM attendance_leave_balance_events/, rows: [] },
+    ])
+    const trace = await buildCompTimeBalanceTrace('org1', 'user1', q, { compTimeFromOvertime: true, overtimeBankPolicy: true })
+    const lot = trace.conclusion.lots[0]
+    expect(lot).toEqual({ sourceResolution: 'unknown_source', grantedAt: '2026-07-01T00:00:00Z', expiresAt: null })
+    expect(Object.prototype.hasOwnProperty.call(lot, 'reasonCode')).toBe(false)
+    expect(JSON.stringify(lot)).not.toContain('some_future_migration_source')
+  })
+
+  it('response level has NO reasonCode key (hard rule 5⑤)', async () => {
+    const q = makeMockQuery([
+      { match: /SUM\(CASE WHEN e\.event_type = 'grant'/, rows: [{ granted: '0', exhausted: '0', expired: '0' }] },
+      { match: /SUM\(remaining_minutes\)/, rows: [{ remaining: '0' }] },
+      { match: /FROM attendance_leave_balances/, rows: [] },
+      { match: /FROM attendance_leave_balance_events/, rows: [] },
+    ])
+    const trace = await buildCompTimeBalanceTrace('org1', 'user1', q, { compTimeFromOvertime: false, overtimeBankPolicy: false })
+    expect(Object.prototype.hasOwnProperty.call(trace, 'reasonCode')).toBe(false)
+  })
+
+  it('engine disabled ⇒ policy-gate environment is not_in_effect (not undeterminable, §5.2②)', async () => {
+    const q = makeMockQuery([
+      { match: /SUM\(CASE WHEN e\.event_type = 'grant'/, rows: [{ granted: '0', exhausted: '0', expired: '0' }] },
+      { match: /SUM\(remaining_minutes\)/, rows: [{ remaining: '0' }] },
+      { match: /FROM attendance_leave_balances/, rows: [] },
+      { match: /FROM attendance_leave_balance_events/, rows: [] },
+    ])
+    const trace = await buildCompTimeBalanceTrace('org1', 'user1', q, { compTimeFromOvertime: false, overtimeBankPolicy: false })
+    const gateEnv = trace.basis.find((b) => b.source.ref === 'compTimeFromOvertime')
+    expect(gateEnv?.version.posture).toBe('not_in_effect')
+  })
+})
+
+describe('settlement seventh read face (OD-W5-6)', () => {
+  it('rows present ⇒ snapshot_frozen anchored at closed_at (most recent)', () => {
+    const env = attendancePayrollCycleSettlementBasisEnv(
+      [{ cycleId: 'c1', periodStartDate: '2026-06-01', periodEndDate: '2026-06-30', closedAt: '2026-07-01T00:00:00Z', source: 'workday', convertibleMinutes: 60, mustPayMinutes: 0 }],
+      true,
+    )
+    expect(env).toEqual({ source: { kind: 'snapshot', ref: 'attendance_payroll_cycle_settlements' }, version: { posture: 'snapshot_frozen', asOf: '2026-07-01T00:00:00Z' } })
+  })
+  it('no rows + bank policy disabled ⇒ not_in_effect (policy fact, not a data gap)', () => {
+    const env = attendancePayrollCycleSettlementBasisEnv([], false)
+    expect(env.version.posture).toBe('not_in_effect')
+  })
+  it('no rows + bank policy enabled ⇒ undeterminable (should have settled but did not)', () => {
+    const env = attendancePayrollCycleSettlementBasisEnv([], true)
+    expect(env.version.posture).toBe('undeterminable')
+  })
+})
+
+describe('⑥ approver_source', () => {
+  it('instanceId not linked to this (org,user) via attendance_requests reverse-link ⇒ NOT_FOUND', async () => {
+    const q = makeMockQuery([{ match: /FROM attendance_requests WHERE org_id/, rows: [] }])
+    const result = await buildApproverSourceTrace('org1', 'user1', 'inst-ghost', q, false)
+    expect(result).toBe(ATTENDANCE_DECISION_TRACE_NOT_FOUND)
+  })
+
+  it('sourceKind closed set covers three dynamic kinds + static + legacy_fallback + unknown', () => {
+    expect(ATTENDANCE_APPROVER_SOURCE_KINDS).toEqual([
+      'direct_manager', 'dept_head', 'manager_at_level', 'static', 'legacy_fallback', 'unknown',
+    ])
+  })
+
+  it('resolvedFrom.kind=direct_manager assignment ⇒ step.sourceKind/reasonCode = "direct_manager"; response has NO top-level reasonCode', async () => {
+    const q = makeMockQuery([
+      { match: /FROM attendance_requests WHERE org_id/, rows: [{ id: 'req1' }] },
+      { match: /FROM approval_instances/, rows: [{ id: 'inst1', created_at: '2026-07-01T00:00:00Z', requester_snapshot: {}, metadata: { approvalFlow: { steps: [] } } }] },
+      { match: /FROM approval_assignments/, rows: [{ assignment_type: 'user', assignee_id: 'mgr1', source_step: 0, metadata: { resolvedFrom: { kind: 'direct_manager' } }, updated_at: '2026-07-01T00:05:00Z' }] },
+      { match: /FROM approval_records/, rows: [{ occurred_at: '2026-07-01T00:10:00Z' }] },
+      { match: /FROM users WHERE id/, rows: [{ id: 'mgr1', name: 'Manager One', email: null, is_active: true }] },
+    ])
+    const trace = await buildApproverSourceTrace('org1', 'user1', 'inst1', q, false)
+    if (trace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
+    expect(Object.prototype.hasOwnProperty.call(trace, 'reasonCode')).toBe(false)
+    expect(trace.conclusion.steps[0]).toMatchObject({ stepIndex: 0, assigneeResolved: true, sourceKind: 'direct_manager', reasonCode: 'direct_manager' })
+    expect(trace.conclusion.steps[0].actor).toEqual({ displayLabel: 'Manager One', identityPosture: 'resolved' })
+  })
+
+  it('manager_at_level assignment ⇒ step carries level', async () => {
+    const q = makeMockQuery([
+      { match: /FROM attendance_requests WHERE org_id/, rows: [{ id: 'req1' }] },
+      { match: /FROM approval_instances/, rows: [{ id: 'inst1', created_at: 'x', requester_snapshot: {}, metadata: {} }] },
+      { match: /FROM approval_assignments/, rows: [{ assignment_type: 'user', assignee_id: 'mgr2', source_step: 0, metadata: { resolvedFrom: { kind: 'manager_at_level', level: 2 } }, updated_at: 'y' }] },
+      { match: /FROM approval_records/, rows: [] },
+      { match: /FROM users WHERE id/, rows: [{ id: 'mgr2', name: null, email: null, is_active: true }] },
+    ])
+    const trace = await buildApproverSourceTrace('org1', 'user1', 'inst1', q, false)
+    if (trace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
+    expect(trace.conclusion.steps[0].level).toBe(2)
+    expect(trace.conclusion.steps[0].sourceKind).toBe('manager_at_level')
+  })
+
+  it('legacy admin-queue fallback metadata ⇒ sourceKind="legacy_fallback"; static step metadata ⇒ "static"', async () => {
+    const legacyQ = makeMockQuery([
+      { match: /FROM attendance_requests WHERE org_id/, rows: [{ id: 'req1' }] },
+      { match: /FROM approval_instances/, rows: [{ id: 'inst1', created_at: 'x', requester_snapshot: {}, metadata: {} }] },
+      { match: /FROM approval_assignments/, rows: [{ assignment_type: 'role', assignee_id: 'admin', source_step: 0, metadata: { source: 'attendance', queue: 'attendance-approval' }, updated_at: 'y' }] },
+      { match: /FROM approval_records/, rows: [] },
+    ])
+    const legacyTrace = await buildApproverSourceTrace('org1', 'user1', 'inst1', legacyQ, false)
+    if (legacyTrace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
+    expect(legacyTrace.conclusion.steps[0].sourceKind).toBe('legacy_fallback')
+
+    const staticQ = makeMockQuery([
+      { match: /FROM attendance_requests WHERE org_id/, rows: [{ id: 'req1' }] },
+      { match: /FROM approval_instances/, rows: [{ id: 'inst1', created_at: 'x', requester_snapshot: {}, metadata: {} }] },
+      { match: /FROM approval_assignments/, rows: [{ assignment_type: 'user', assignee_id: 'u9', source_step: 0, metadata: { source: 'attendance', stepName: '经理审批' }, updated_at: 'y' }] },
+      { match: /FROM approval_records/, rows: [] },
+      { match: /FROM users WHERE id/, rows: [{ id: 'u9', name: 'Static Approver', email: null, is_active: true }] },
+    ])
+    const staticTrace = await buildApproverSourceTrace('org1', 'user1', 'inst1', staticQ, false)
+    if (staticTrace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
+    expect(staticTrace.conclusion.steps[0].sourceKind).toBe('static')
+  })
+
+  it('default/JSON.stringify-style dumps NEVER appear — unrecognized metadata shape ⇒ "unknown"', async () => {
+    const q = makeMockQuery([
+      { match: /FROM attendance_requests WHERE org_id/, rows: [{ id: 'req1' }] },
+      { match: /FROM approval_instances/, rows: [{ id: 'inst1', created_at: 'x', requester_snapshot: {}, metadata: {} }] },
+      { match: /FROM approval_assignments/, rows: [{ assignment_type: 'role', assignee_id: 'weird', source_step: 0, metadata: { somethingElse: true }, updated_at: 'y' }] },
+      { match: /FROM approval_records/, rows: [] },
+    ])
+    const trace = await buildApproverSourceTrace('org1', 'user1', 'inst1', q, false)
+    if (trace === ATTENDANCE_DECISION_TRACE_NOT_FOUND) throw new Error('unexpected not-found')
+    expect(trace.conclusion.steps[0].sourceKind).toBe('unknown')
+    expect(JSON.stringify(trace)).not.toContain('somethingElse')
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-decision-trace-w5-0.test.ts
+++ b/packages/core-backend/tests/unit/attendance-decision-trace-w5-0.test.ts
@@ -784,3 +784,119 @@ describe('⑥ approver_source', () => {
     expect(JSON.stringify(trace)).not.toContain('somethingElse')
   })
 })
+
+describe('SQL values-free (S7-5 same-type — every builder\'s SQL text is parameterized, never string-concatenated)', () => {
+  // §9 W5-0-G2 "SQL 无标识列断言（S7-5 同型）": capture EVERY SQL string issued by EVERY builder and
+  // assert none of the caller-supplied identifiers ever appear literally in the query TEXT (only as
+  // bind-parameter array entries) — the same technique as
+  // `attendance-admin-directory-readiness-s7-5.test.ts:82-189`. A future edit that string-interpolates
+  // any of these values into a query would turn this red.
+  const ORG = 'ORGVALUE_f3a1'
+  const USER = 'USERVALUE_9c2b'
+  const WORK_DATE = '2026-07-01'
+  const REQUEST_ID = 'REQVALUE_77dd'
+  const INSTANCE_ID = 'INSTVALUE_88ee'
+
+  // Unlike `makeMockQuery`, this ALSO records every SQL string issued (in call order) so a
+  // "record found, keep walking the basis chain" fixture can exercise every downstream query a
+  // builder issues — a bare empty-rows stub would short-circuit most builders after their first
+  // (not-found) query and leave the deeper queries unchecked.
+  function makeCapturingQuery(handlers: Handler[] = []): { calls: string[]; query: AttendanceDecisionTraceQueryFn } {
+    const calls: string[] = []
+    const query = (async (sql: string) => {
+      calls.push(sql)
+      for (const h of handlers) {
+        if (h.match.test(sql)) return { rows: h.rows, rowCount: h.rows.length } as never
+      }
+      return { rows: [], rowCount: 0 } as never
+    }) as AttendanceDecisionTraceQueryFn
+    return { calls, query }
+  }
+
+  function assertValuesFree(calls: string[]) {
+    expect(calls.length).toBeGreaterThan(0)
+    for (const sql of calls) {
+      expect(sql, `SQL text must not embed the org id literally: ${sql}`).not.toContain(ORG)
+      expect(sql, `SQL text must not embed the user id literally: ${sql}`).not.toContain(USER)
+      expect(sql, `SQL text must not embed the work date literally: ${sql}`).not.toContain(WORK_DATE)
+      expect(sql, `SQL text must not embed the request id literally: ${sql}`).not.toContain(REQUEST_ID)
+      expect(sql, `SQL text must not embed the instance id literally: ${sql}`).not.toContain(INSTANCE_ID)
+      // Every query in this module is org-scoped and parameterized — a bare `$1` placeholder must
+      // be present (mirrors S7-5's `sql).toMatch(/\$1/)` positive control).
+      expect(sql, `SQL text must be parameterized: ${sql}`).toMatch(/\$1/)
+    }
+  }
+
+  const RECORD_ROW = {
+    id: 'r1', status: 'late', is_workday: true, work_minutes: 400, late_minutes: 15, early_leave_minutes: 0,
+    meta: { severe_late_count: 0, severe_late_minutes: 0, absence_late_count: 0 }, source_batch_id: 'batch1',
+    created_at: '2026-07-01T09:00:00Z', updated_at: '2026-07-01T09:20:00Z', first_in_at: '2026-07-01T09:00:00Z', last_out_at: '2026-07-01T18:00:00Z',
+  }
+  const RECORD_FOUND_HANDLERS: Handler[] = [
+    { match: /FROM attendance_records/, rows: [RECORD_ROW] },
+    { match: /attendance_shift_assignments/, rows: [] },
+    { match: /FROM attendance_rules WHERE org_id = \$1/, rows: [{ late_grace_minutes: 10, early_grace_minutes: 10, severe_late_threshold_minutes: 30, absence_late_threshold_minutes: 60 }] },
+    { match: /attendance_record_result_edits/, rows: [{ created_at: '2026-07-01T09:30:00Z', actor_user_id: 'actor1' }] },
+    { match: /FROM users WHERE id/, rows: [{ id: 'actor1', name: 'Actor One', email: null, is_active: true }] },
+    { match: /FROM attendance_requests/, rows: [{ id: 'req1', created_at: '2026-07-01T09:00:00Z', metadata: { makeupPunchPolicySnapshot: { version: 1, requestEvaluatedAt: '2026-07-01T09:00:00Z' } } }] },
+    { match: /FROM attendance_events/, rows: [{ occurred_at: '2026-07-01T10:00:00Z' }] },
+  ]
+
+  it('buildTodayStatusTrace — all queries parameterized (record-found path, incl. correction env)', async () => {
+    const { calls, query } = makeCapturingQuery(RECORD_FOUND_HANDLERS)
+    await buildTodayStatusTrace(ORG, USER, WORK_DATE, query)
+    assertValuesFree(calls)
+    expect(calls.length).toBeGreaterThan(1)
+  })
+  it('buildLateEarlyTrace — all queries parameterized (record-found path, incl. remediation env)', async () => {
+    const { calls, query } = makeCapturingQuery(RECORD_FOUND_HANDLERS)
+    await buildLateEarlyTrace(ORG, USER, WORK_DATE, query)
+    assertValuesFree(calls)
+    expect(calls.length).toBeGreaterThan(1)
+  })
+  it('buildMissingPunchTrace — all queries parameterized (record-found path, incl. ③E4 adjustment event)', async () => {
+    const { calls, query } = makeCapturingQuery(RECORD_FOUND_HANDLERS)
+    await buildMissingPunchTrace(ORG, USER, WORK_DATE, query)
+    assertValuesFree(calls)
+    expect(calls.length).toBeGreaterThan(1)
+    expect(calls.some((sql) => /FROM attendance_events/.test(sql))).toBe(true)
+  })
+  it('buildOvertimeSegmentationTrace — all queries parameterized (snapshot-found path)', async () => {
+    const { calls, query } = makeCapturingQuery([
+      {
+        match: /FROM attendance_requests/,
+        rows: [{
+          id: 'req1',
+          metadata: {
+            overtimeSegmentation: { version: 1, engine: 'attendance_overtime_segmentation_v1', dayType: 'workday', calendar: { effectiveSource: 'calendar_default' }, segments: { workdayMinutes: 60, restdayMinutes: 0, holidayMinutes: 0 }, totalMinutes: 60 },
+            overtimeRule: { minMinutes: 30 },
+            approvalFlow: { steps: [] },
+          },
+          resolved_at: '2026-07-02T10:00:00Z', updated_at: 'y',
+        }],
+      },
+      { match: /FROM attendance_overtime_rules/, rows: [{ id: 'rule1' }] },
+    ])
+    await buildOvertimeSegmentationTrace(ORG, USER, REQUEST_ID, query, false)
+    assertValuesFree(calls)
+    expect(calls.length).toBeGreaterThan(1)
+  })
+  it('buildCompTimeBalanceTrace — all queries parameterized (incl. the newly-wired settlement read)', async () => {
+    const { calls, query } = makeCapturingQuery()
+    await buildCompTimeBalanceTrace(ORG, USER, query, { compTimeFromOvertime: false, overtimeBankPolicy: false })
+    assertValuesFree(calls)
+    expect(calls.some((sql) => /attendance_payroll_cycle_settlements/.test(sql))).toBe(true)
+  })
+  it('buildApproverSourceTrace — all queries parameterized (assignment-found path)', async () => {
+    const { calls, query } = makeCapturingQuery([
+      { match: /FROM attendance_requests WHERE org_id/, rows: [{ id: 'req1' }] },
+      { match: /FROM approval_instances/, rows: [{ id: 'inst1', created_at: 'x', requester_snapshot: {}, metadata: { approvalFlow: { steps: [] } } }] },
+      { match: /FROM approval_assignments/, rows: [{ assignment_type: 'user', assignee_id: 'mgr1', source_step: 0, metadata: { resolvedFrom: { kind: 'direct_manager' } }, updated_at: 'y' }] },
+      { match: /FROM approval_records/, rows: [{ occurred_at: 'z' }] },
+      { match: /FROM users WHERE id/, rows: [{ id: 'mgr1', name: 'Manager One', email: null, is_active: true }] },
+    ])
+    await buildApproverSourceTrace(ORG, USER, INSTANCE_ID, query, false)
+    assertValuesFree(calls)
+    expect(calls.length).toBeGreaterThan(1)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -432,6 +432,13 @@ export default defineConfig({
       // excluded here so the no-DB job cannot skip-green it; wired whole-file into the attendance
       // real-DB step in plugin-tests.yml.
       'tests/integration/attendance-setup-readiness-w4-0.db.test.ts',
+      // W5-0 (Wave 5 explainability design-lock 2026-07-22, RATIFIED §9): dual-host decision-trace
+      // authorization matrix (G1/G7), allowlist/org-scoping negative controls (G2), the ⑤ raw
+      // source_type fixture (G4), not_in_effect vs undeterminable (G5), and snapshot-exclusivity
+      // (G6) against real Postgres. DATABASE_URL-gated describeIfDatabase; excluded here so the
+      // no-DB job cannot skip-green it; wired whole-file into the attendance real-DB step in
+      // plugin-tests.yml.
+      'tests/integration/attendance-decision-trace-w5-0.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -42736,8 +42736,13 @@ module.exports = {
          WHERE org_id = $1 AND user_id = $2 AND leave_type_code = $3 AND status = 'active'`,
         [orgId, userId, leaveTypeCode]
       )
+      // W5-0 (OD-W5-9=(a), design-lock 2026-07-22 §2/§7): project `overtime_source` — the column has
+      // been on `attendance_leave_balances` since v1-1b (`zzzz20260624160000`), but this SELECT never
+      // read it, so per-source bank provenance was invisible even to admin. Purely additive: legacy
+      // NULLs pass through unchanged (no per-source lot is fabricated a value); every existing key
+      // above is untouched (compat regression: `attendance-plugin.test.ts` ④/年假 L5a cases).
       const activeLots = await db.query(
-        `SELECT id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, status, granted_at, expires_at
+        `SELECT id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, status, granted_at, expires_at, overtime_source
          FROM attendance_leave_balances
          WHERE org_id = $1 AND user_id = $2 AND leave_type_code = $3 AND status = 'active'
          ORDER BY expires_at ASC NULLS LAST, granted_at ASC, id ASC`,


### PR DESCRIPTION
## W5-0 — 六类只读 decision-trace 端点（双宿主）+ 结算第七只读面 + lot `overtime_source` 投影

refs #4546 #4554

依据：`docs/development/attendance-vnext-wave5-explainability-data-contract-lock-20260722.md`
（**RATIFIED**，owner 终裁 comment 2026-07-23T07:30Z 对 merged SHA `15a256fe2`，§10-④ 同步已合
`1bcfc86b8`）§3/§4/§9 W5-0。

### 开工前置校验（硬门）

1. `docs/development/...wave5-explainability-data-contract-lock-20260722.md` header 确认
   `Status: RATIFIED`，凭据 = PR #4546 comment `RATIFY — Wave 5 数据合同设计锁` @2026-07-23T07:30Z，
   对象 = merged exact SHA `15a256fe2`；§10-④ 同步（章程 §15 行）= PR #4554，已合
   `1bcfc86b8`——均已在 origin/main 上核验。
2. **锚点重验**：见下方"锚点校正表"——本 PR 分支基（rebase 后）= `48a425044`
   （原始开工时 = `1bcfc86b8`，两者之间 origin/main 仅新增一个 dingtalk docs-only PR #4555，
   零 attendance runtime/路由/迁移触碰，`git diff --stat 1bcfc86b8..48a425044` 实证）。锁引用的
   全部 §1/§3.2/§3.3/§4.1 file:line 锚点对 `48a425044` 逐条重验，**零漂移**（index.cjs 与
   attendance-admin.ts 在两点之间均未被其它 PR 触碰）。
3. **查重扫描**：开工前 `git grep -in "decision-trace|DecisionTrace"` 全仓零既存实现命中（仅锁文档
   本身与章程组件表行）；`gh pr list` 无同题在飞分支/PR。

### 锁 → 实现映射

| 锁条款 | 实现 |
|---|---|
| §3.1 通用 trace 形制 + 硬规则 1-6 | `packages/core-backend/src/services/AttendanceDecisionTrace.ts`：`AttendanceDecisionTraceBasisEnv`/`Version`/`Source`/`AuditRef`/`Actor` 类型 + `deriveAttendanceDecisionTraceConfidence`（纯派生，§3.1 末段）|
| §3.1 硬规则 5（reasonCode discriminated union，逐类承载位置） | ①②③ 响应级单标量 `reasonCode`（必在场，除"record 不存在⇒整类 undeterminable"时键缺席，见下"偏离"）；④ 响应级零 `reasonCode`、段级各携（**修复轮**：未识别 `effectiveSource` 时段级 `reasonCode` 键缺席，不再造 `'unknown'` 占位码）；⑤ 响应级零 `reasonCode`、lot item `sourceResolution` 判别 union；⑥ 响应级零 `reasonCode`、step 级携 `sourceKind`+`reasonCode` |
| §3.1 硬规则 5⑤（lot reasonCode 独立冻结枚举 + `source_type`→reasonCode 映射） | `ATTENDANCE_COMP_TIME_LOT_SOURCE_TYPE_TO_REASON_CODE`（`annual_accrual`\|`annual_manual_adjust`\|`overtime_conversion`，按锁 §11.1 三写入点字面值穷尽）+ `sourceResolution:'mapped'\|'unknown_source'` 判别子，`'unknown_source'` 分支键整体缺席 |
| §3.1 硬规则 6（快照排他） | ④/⑤/⑥ 的 `current_live_no_history` 环与 `snapshot_frozen` 环并列且显式区分，从不替位；G6 mutation 证明（**修复轮**：新增 ③④⑤⑥ 逐类独立 subject 谓词 mutation + G6 重算模拟 mutation，见下）|
| §3.1 硬规则 2（`not_in_effect`≠`undeterminable`，dormant org） | **修复轮修复**：⑤ E1/E2 台账环此前在 `compTimeFromOvertime` 关闭且台账为空时判为 `undeterminable`（与硬规则 2 的 dormant-org 措辞例逐字冲突）；现按引擎开关值分流：关闭 ⇒ `not_in_effect`（策略事实），开启但确实为空 ⇒ 仍 `undeterminable`（OD-W5-4，真实缺口）|
| §3.2 asOf 锚点表（逐类） | ④ `resolvedAt`（**修复轮修复**：不再 `?? row.updated_at`——`resolved_at` 为 null 时该请求视为未终审，快照环/规则冻结环/审批流环各自 fail-closed 为 `undeterminable`，不伪造时点）；⑤ lot `granted_at`；结算 `closed_at`；⑥ `approval_instances.created_at`；①/② 更正环 `attendance_record_result_edits.created_at` |
| §3.3 六类结论/依据链/断环 | 六个 `buildXxxTrace` 函数逐类实现（同文件）；③ 新增 E4"终审 adjustment 审计事件"环（`attendance_events`，`event_type='adjustment'`，**修复轮新增**，此前锁点名但未落地）|
| §3.3④ 快照有效性 | **修复轮修复**：`dayType` 需在 `'workday'\|'restday'\|'holiday'` 闭集内才判定快照有效（此前 `?? 'restday'` 会把畸形快照静默编造为 restday）；`crossesMidnight` 快照现在遍历 `perDate[]` 逐日构造多段（此前只取主日期单段，Σsegments < totalMinutes） |
| §4.1 双宿主 + self subject-constrained | `packages/core-backend/src/routes/attendance-admin.ts`：admin = `GET /api/attendance-admin/decision-trace`（router 级 `rbacGuard('attendance','admin')` + `canReadAttendanceDirectoryReadiness` 复用）；self = `GET /api/attendance/decision-trace`（**同文件，挂在 admin prefix/guard 之外**，`rbacGuard('attendance','read')` 单路由级 + token subject + active `user_orgs` 四腿解析）；每条目标读取权威查询内 `org_id=selectedOrg AND <归属列>=subject` |
| §4.1 六类归属谓词 | ①②③/更正环 `attendance_records.user_id`/`attendance_record_result_edits.user_id`；④ `attendance_requests.user_id`；⑤ `attendance_leave_balances.user_id`；⑥ `attendance_requests.user_id AND approval_instance_id`（反链，**非** `requester_snapshot` JSONB 比对）——**修复轮**：③④⑤⑥ 各自独立 mutation 验红（见下 mutation 表，此前仅 ①② 共用的 `readAttendanceRecordRow` 验过）|
| §4.1 平台 admin override | `canReadAttendanceDirectoryReadiness` 既有 `hasLegacyAdminClaim \|\| isRbacAdmin` 直通，原样复用 |
| §4.2 READ ONLY | `runAttendanceDecisionTraceReadOnly` = `runAttendanceSetupReadinessReadOnly` **逐字重用**（`export const ... = ...`），零重新实现 |
| §4.4 错误档 | 400（`ORG_ID_REQUIRED`/`USER_ID_REQUIRED`/`USER_ID_NOT_ACCEPTED`/`CATEGORY_REQUIRED`/`CATEGORY_INVALID`/`WORK_DATE_REQUIRED`/`REQUEST_ID_REQUIRED`/`INSTANCE_ID_REQUIRED`）/401/403/404（`DECISION_TRACE_TARGET_NOT_FOUND`，引用式目标恒等形状）/503/500 values-free |
| §5.1 遮罩清单 + org 边界 | 裸 id 零出现（`resolveAttendanceDecisionTraceActor` 恒返回 `{displayLabel, identityPosture}`，绝不回退 id；**修复轮修复**：resolved-但-无-name 分支此前会回退到 `email`——email 不在 §5.1 允许行内，现改为中性标签"已注册用户"）；`managerChainIds`/`ip_address`/`user_agent`/`holidayRefId` 等禁字段本实现从不读取/透出 |
| §3.3⑥E1 | **修复轮修复**：`approval_assignments` 查询新增 `is_active = true` 谓词（此前失活/被取代的指派行会被当作当前有效步骤返回）|
| §5.2①（分段锚 resolvedAt，非 created_at） | `buildOvertimeSegmentationTrace` 显式取 `resolved_at`，且不再回退 `updated_at`（见上）|
| §5.2②（`not_in_effect`≠`undeterminable`） | `readAttendanceDecisionTraceSettingsGates` 读 `system_configs.attendance.settings`（**双 schema 形状兼容**：`text`/`jsonb` 两种列类型，实跑本地 DB 时发现现势列是 `text`，已按 `readAttendancePunchPolicyPosture` 同款兼容处理）；④/⑤/⑥ 各自的 policy-gate 环按此判别 |
| §7 边界（不重复建设） | ⑤ 不新造第二套余额读面，仍复用 L5a 读投影（补 `overtime_source`）；trace 只补 provenance 环 |
| §2 结算第七只读面（OD-W5-6） | `readAttendancePayrollCycleSettlements` + `attendancePayrollCycleSettlementBasisEnv`——**修复轮修复**：两者此前只是定义、从未被任何调用路径触达（死代码，`grep` 唯一命中是各自的孤立单测），责任是「折入 ⑤E4」但代码里没有那次调用。现已在 `buildCompTimeBalanceTrace` 内实际调用并 push 为⑤的第四条 basis env，真正 wire 到两个端点。|
| §2 lot `overtime_source` 投影（OD-W5-9） | `plugins/plugin-attendance/index.cjs` `readAnnualLeaveBalanceForUser` 的 `activeLots` SELECT 加一列（纯增量，admin + self `/me` 两既有端点同时生效）|

### G1-G7 完成门 checklist

| 门 | 状态 | 证据 |
|---|---|---|
| G1（依据链断环真库负例，④/②/③/⑤/⑥ 各≥1 条 deepEqual 整链） | ✅（**修复轮补齐**——此前 checklist 把 G1 与"org-membership 门"混记为已完成，实际锁 §9 G1 文本是"断环矩阵"，与 G7 的授权矩阵是两件事，且真库文件通篇只用 `.find()` 存在性取环、从无 deepEqual 整链。本次新增 `§9 W5-0-G1: break-the-chain real-DB negatives` 专门描述块，五腿逐条 deepEqual 整个 basis env（非仅 posture 字段）：②legacy 记录无 tier meta keys ⇒ tier env；③auto-absence 生成的 absent 行 ⇒ generation-source env；④无有效分段快照的请求 ⇒ snapshot env；⑤MAPPED lot 但 `overtime_source` 为 NULL ⇒ `overtimeSource` 键整体缺席（deepEqual 整个 lot item）；⑥零 assignment 行的"失败历史"实例 ⇒ E1 env，deepEqual 完整响应）|
| G2（allowlist/无裸 id/org 边界/禁记录 response body/SQL 无标识列） | ✅ | 同文件 §9 W5-0-G2 描述块：响应键集合恒等、`auditRef.actor` 身份**双档**负例（**修复轮新增** `inactive` 档，此前只有 `unknown` 档进真库）+ `auditRef`/`auditRef.actor` exact key set、跨 org 数据零出现、§5.1 禁字段（`managerChainIds`/`ip_address`/`user_agent`）零出现断言；新增专门的"负向元断言"描述块——两份 spec 文件源码文本扫描，断言不含 response-body console 记录或 snapshot matcher 调用（此前该完成门义务只在 PR body 散文声称，代码里无对应断言）；**修复轮新增** `SQL values-free (S7-5 same-type)` 描述块——单测层面对全部六个 builder 逐一捕获其发出的每条 SQL 文本，断言调用方传入的 org/user/workDate/requestId/instanceId 值绝不以字符串拼接方式出现在查询文本里（仅作为 `$1` 式绑定参数），此前锁点名的这条腿在两文件里都不存在 |
| G3（READ ONLY 复用非再造） | ✅ | `runAttendanceDecisionTraceReadOnly === runAttendanceSetupReadinessReadOnly` 恒等断言 + 一条确认性真写拒绝测试（完整三案例证明已在 W4-0 文件，本门不重复造轮子）|
| G4（enum-strict + ⑤ 未知原值真库负例 + discriminated union + exact key set） | ✅（**修复轮加固**：②③⑤⑥ 响应级/step 级此前只用 `toMatchObject`（部分匹配，容忍多余键），已改为 `Object.keys(...).sort()` 恒等断言——手工验证：给 ⑥ step 加一个 `assigneeId` 裸 id 键，新断言精确红，旧 `toMatchObject` 断言仍绿）| 真库直接 INSERT `attendance_leave_balances.source_type='some_unmapped_future_source_kind'`（**不经** `deductLeaveBalance`）；契约单测覆盖①②③④⑤⑥全部 discriminated 分支 |
| G5（`not_in_effect` ≠ `undeterminable`） | ✅ | 引擎 OFF（默认）正控 = `not_in_effect`；引擎 ON 但请求无快照负控 = `undeterminable`（真库两分支）；**修复轮新增** ⑤ dormant-org 真库同款正控（compTimeFromOvertime OFF + 空台账 ⇒ confidence=`partial` 非 `undeterminable`）+ 结算 E4 三腿（有快照/无快照+bank OFF/无快照+bank ON）|
| G6（快照排他 + 禁反推） | ✅（**修复轮加固**：byte-stable 断言范围此前只覆盖 `conclusion`/`coverageNote`，现扩展到除 `rule_live` 外的**整个 basis 数组**；并新增"改按现行规则重算"的手工 mutation 验证——见下 mutation 表，此前 PR body 承诺记录但缺失）| 正控：终审后插入新 `attendance_overtime_rules` 行，trace `conclusion`/`coverageNote`/其余 basis env byte-stable |
| G7（双宿主授权矩阵：身份/org 腿 + self 四腿 + two-user/same-org 六腿 + mutation） | ✅（**修复轮补齐**：① P1 fixture 退化修复——两条 `seedRecord` 撞同一 `(org,user,work_date)` 唯一键，第二条 UPSERT 静默覆写了"late"为"partial"，导致①的零泄漏断言实为空转；已拆成两个不同 workDate + 新增一条"fixture 非空转"哨兵测试；② 补齐②③腿的精确零出现断言（此前仅①有）；③ 8 条身份/org 门拒绝腿此前仅 1 条断言 `transactionMock`/`queryMock` 零调用，现已补齐全部 8 条；④ ③④⑤⑥ 各自独立 subject-谓词-移除 mutation 手工验证（此前仅 ①②共用的 `readAttendanceRecordRow` 验过），见下 mutation 表）| admin own/foreign org、platform admin override、self 零 org/单 org 自动选择/orgId 越权、self 多组织四腿（含插入序无关性）、six-category 两用户同 org 负例（①②③=200+undeterminable、④⑥=404 与 ghost id 形状恒等、⑤=空 lot **及 event** 列表）|

### 锚点校正表

无漂移——本 PR 开工时锚点基线 = W5 锁自身声明的三轮终审现势（`e32f2d533`），锁 PR #4546/#4554
合入后新增的 origin/main 提交（`15a256fe2`→`1bcfc86b8`→`48a425044`，含本 PR rebase 目标）
全部为 **docs-only**（`git diff --stat e32f2d533..48a425044` 只命中两份 `.md` 文件），
`packages/core-backend/src/routes/attendance-admin.ts`、
`plugins/plugin-attendance/index.cjs`、迁移文件、`AttendanceSetupReadinessAggregate.ts`
零触碰——锁 §1/§3.2/§3.3/§4.1 引用的全部 file:line 锚点（`attendance-admin.ts:333/:383-407/:389/
:457/:492/:498-518/:502`、`index.cjs:41/:291/:10637/:10737/:11081/:14347/:17530-17573/
:25932-25956/:26427-26436/:42722-42846`、各 migration 文件行号）逐条对当时 HEAD 重开验证，
**全部命中不变**（详见开工前研究记录；本 PR 未在 body 中逐条列出全部数十个锚点，因零漂移无需
校正——仅记录"零校正"这一事实本身）。

### Mutation 自检（原 6 刀 + 修复轮追加 6 刀，均在独立提交之后现场 mutate → 真库/契约测试验红 →
`git checkout --` 精确还原，过程零遗留）

| # | 目标 | 手法 | 结果 |
|---|---|---|---|
| ① 聚合提到授权门前 | admin 路由：把 `runAttendanceDecisionTraceReadOnly(...)` 移到 `canReadAttendanceDirectoryReadiness` 检查之前 | `admin host: delegated admin forges a foreign org ⇒ 403 BEFORE any trace SQL` 精确红（`transactionMock` 被调用 1 次，断言 `.not.toHaveBeenCalled()` 失败）|
| ② 去 ①②共用 subject 谓词 | `readAttendanceRecordRow`（①②共用）SQL 去掉 `AND user_id = $2` | 两用户同 org 负例矩阵 3 条断言精确红（①/②/G2 响应键集合测试均转 500/内容错误）|
| ③ unknown 分支携占位码 | ⑤ `unknown_source` 分支加 `reasonCode: 'unknown'` | 契约单测 + 真库测试均精确红（`toEqual`/键集合断言，diff 精确显示多出的 `reasonCode` 键）|
| ④ 裸 source_type 透传 | ⑤ 恒返回 `sourceResolution:'mapped', reasonCode: row.source_type`（去掉映射表判别） | 契约单测 diff 直接显示原值 `some_future_migration_source` 泄漏到 `reasonCode`；真库 G4 测试键集合断言精确红 |
| ⑤ READ ONLY 剥除 | `runAttendanceDecisionTraceReadOnly` 改为裸 `transaction()`（无 `SET TRANSACTION READ ONLY`） | G3 两条测试精确红（恒等引用断言 + 真写拒绝断言"promise resolved undefined instead of rejecting"）|
| ⑥ 404 形状分化（存在性 oracle） | self 路由 404 分支加"存在性探测"——命中则 403、未命中才 404 | ④/⑥ 两条"byte-identical 404"测试精确红（跨用户目标返回 403/500，与真不存在目标的 404 不再等同）|
| ⑦ 去 ③ 独立 subject 谓词（修复轮） | `buildMissingPunchTrace` 的独立 `attendance_records` 查询去掉 `user_id=$2`（改 `($2=$2)` 保持 SQL 合法以证明真泄漏而非语法错） | ③ two-user 腿精确红——响应体真实泄漏 OTHER 的 `missingSide:'both'`（`expected 'both' to be null`）|
| ⑧ 去 ④ 独立 subject 谓词（修复轮） | `buildOvertimeSegmentationTrace` 的 `attendance_requests` 查询同款去谓词 | ④ two-user 404 腿精确红（`expected 200 to be 404`——OTHER 的请求变为可读）|
| ⑨ 去 ⑤ 独立 subject 谓词（修复轮） | `buildCompTimeBalanceTrace` 的 lots 查询同款去谓词 | ⑤ two-user 腿精确红——OTHER 的 lot 出现在响应 `lots` 数组中 |
| ⑩ 去 ⑥ 独立 subject 谓词（修复轮） | `buildApproverSourceTrace` 的反链查询同款去谓词 | ⑥ two-user 404 腿精确红（`expected 200 to be 404`）|
| ⑪ G6 改按现行规则重算（修复轮） | ④ 已终审快照分支内混入 `liveRule.rows.length`（模拟"重算掺入现行规则表状态"） | G6 byte-stable 测试精确红（`totalMinutes: 120→121`，diff 精确定位）|
| ⑫ G4 ⑥ step 裸 id 泄漏（修复轮） | ⑥ step 对象加一个裸 `assigneeId` 键 | 单测两条新 exact-key-set 断言精确红（旧 `toMatchObject` 断言仍绿——证明本轮加固前该泄漏不可判红）|

（mutation 手法与代码定位均记录于本 PR 开发过程；十二刀均已在合入前用
`git checkout -- <file>` 精确还原并复跑全绿确认——**mutation 全程发生在对应功能提交之后**，
不存在"未提交实现被误删"的风险。）

### §11.1 六项记录（本 PR 增量）

1. **基线 SHA**：分支基（rebase 后）= `48a425044`；实现锚点重验对象见上"锚点校正表"。
2. **查重**：全仓 `grep -in "decision-trace|DecisionTrace"` 开工前后核验，唯一命中变为本 PR
   自身新增的实现文件 + 锁文档；无同题在飞分支/PR。
3. **修改文件**：见本 PR diff（`attendance-admin.ts` + 新 `AttendanceDecisionTrace.ts` +
   `index.cjs` 一行 SELECT 扩列 + 三个测试文件 + `vitest.config.ts`/`plugin-tests.yml` 两点接线）。
   车道声明：本 PR **不触碰** `AttendanceView.vue`（W5-1 专属热文件）、`attendance-web-guard.yml`
   （W5-0 无 UI，三视口门 N/A，见下）。
4. **IN/OUT**：按锁 §2；本 PR 仅 W5-0 范围（六类 trace + 结算读面 + lot 投影），**不含**
   `AttendanceDecisionTrace.vue`/纯模块/上下文帮助（W5-1/W5-2）、任何 operator flag/S7/W5-5/W5-10
   runtime 翻转。
5. **权威数据源/权限真源**：见"锁→实现映射"表。
6. **完成门与 mutation**：见上两表。

### 三视口

**N/A**——W5-0 无 UI（锁 §9 W5-0 段"W5-0 无 UI：三视口门 N/A（W4-0 先例）"逐字）。

### 本地实跑（PG `127.0.0.1:5432`）

```
packages/core-backend$ tsc --noEmit -p tsconfig.json                    # 0 errors
packages/core-backend$ vitest run tests/unit/attendance-decision-trace-w5-0.test.ts
  ✓ 61 passed（修复轮前 38 → 修复轮 +23，含新增 SQL values-free 六 builder 全覆盖描述块）
packages/core-backend$ vitest --config vitest.integration.config.ts run \
  tests/integration/attendance-decision-trace-w5-0.db.test.ts
  ✓ 42 passed（修复轮前 28 → 修复轮 +14，含 §9 W5-0-G1 五腿全部补齐——②legacy 无 tier keys/
    ③absent 无来源/④无快照/⑤overtime_source NULL/⑥失败历史，逐条 deepEqual 整个 basis env）
# 修复轮：受影响面回归（既有 attendance integration gate 全量，33 文件同进程跑，验证零 fixture 撞车）
packages/core-backend$ vitest --config vitest.integration.config.ts run \
  tests/integration/attendance-plugin.test.ts \
  tests/integration/attendance-approval-action-authorization.db.test.ts \
  tests/integration/attendance-approval-flow-dynamic-kind-s7-1.db.test.ts \
  ... (.github/workflows/plugin-tests.yml 同一段落全部 33 个 attendance-* 文件) ...
  ✓ 501 passed（33 files）
$ pnpm type-check   # 根目录，同 CI
  packages/core-backend type-check: Done（0 errors）
```

CI 两点接线：`packages/core-backend/vitest.config.ts` exclude 新增
`tests/integration/attendance-decision-trace-w5-0.db.test.ts`（no-DB job 不可 skip-green）+
`.github/workflows/plugin-tests.yml` attendance 真库步骤 run-list 同步新增（W4-0 同型两点接线，
F1 skip-shaped-green 教训）——本轮修复未改动这两处接线（新增测试全部落在已接线的同一文件内）。

### 偏离（disclosed，供 owner 复核；标 ✅ 为本修复轮已吸收，标 ⏳ 为仍待 owner 裁决）

1. **①/②/③ record 不存在（§3.3① fail-closed）时，`reasonCode` 键缺席而非在场** ⏳（沿用原判断，
   未改动）：锁 §3.1 硬规则 5 对①②③写"响应级单个 `reasonCode`（必在场，标量）"，但未显式覆盖
   "record 行整体不存在"这一 fail-closed 特例。本实现选择：record 不存在 ⇒ 整类 `undeterminable`
   ⇒ `reasonCode` 键缺席（与④⑤⑥ unknown 分支"键缺席非 null/占位码"同一纪律），因为 `status`
   8 值闭集没有可诚实映射"无记录"的值。已在 `tests/unit/attendance-decision-trace-w5-0.test.ts`
   用显式测试锁定此行为，供 owner 认可或改判——**按 §10-② "改动任一类的码承载键位=合同修订"，
   该键位行为在 owner 裁决前不属锁内**，本轮不自行拍板。
2. **①/③ 当前规则环省略 `attendance_rotation_rules`（rotation）优先级层** ⏳（沿用原判断，未改
   动）：`resolveWorkContext` 的三层优先级为 rotation > shift assignment > default rule；本实现
   只走后两层，`source.ref` 诚实标注实际读取来源（`'shift_assignment'\|'org_default_rule'\|
   'global_default_rule'`，**从不**声称 `'rotation'`），故不会误报依据来源，但排班使用 rotation
   的组织会得到较不精确（仍诚实）的 `current_live_no_history` 标注。范围内如需补全，属独立小票
   （三层皆 `current_live_no_history`，非快照缺口，不影响 R4/G5/G6）——**本轮评估**：补全需新增
   `attendance_rotation_rules` 查询与优先级判别逻辑，是新查询面而非缺陷修复，维持独立小票边界，
   不在本轮吸收。
3. **④ 加班分段 trace 键定为单个 `attendance_requests`（`request_type='overtime'`）而非聚合周期
   汇总** ⏳（沿用原判断，未改动）：锁 §3.3④ 结论字段名（`workdayMinutes`/`restdayMinutes`/...）
   与 `loadAttendanceSummary`（周期聚合函数）同名，存在"是否应为聚合视图"的读法歧义；本实现按
   "单笔决策可追溯"（章程 L364 逐字"先只读决策轨迹"+ 依据链 E1-E4 均为单实例快照/审批环，语义
   上只能对应单一请求）取 `requestId` 作为目标键。供 owner 复核是否与设计意图一致。
4. **⑥ `assigneeResolved` 恒为 `true`** ⏳（沿用原判断，未改动）：steps 数组只枚举"已有
   `approval_assignments` 行"的步骤（未触达的后续步骤不在数组中，而非以 `assigneeResolved:false`
   表示）——因为"尚未触达"与"解析失败"是两个不同语义，锁 OD-W5-2=(a) 明确"v1 不解释失败历史"，
   本实现选择省略未触达步骤而非发明一个占位判别值。
5. **①/② E2 规则环的白名单参数投影未落地** ⏳（新披露，本轮三镜审查发现）：§3.1 硬规则/§3.3①②
   逐字要求 E2 环携带"该来源的白名单参数投影"（§5.1 明确把班次起止/宽限分钟/tier 阈值列为
   allowed 字段），`resolveCurrentRuleGraceParams` 已解析出 `lateGraceMinutes`/`earlyGraceMinutes`/
   `severeLateThresholdMinutes`/`absenceLateThresholdMinutes` 四个字段，但 `currentRuleBasisEnv`
   只用了 `refKind` 构造 `source.ref`，四个参数值从未进入响应。**未落地原因**：§3.1 的 basis
   envelope 通用形制显式冻结为 `{source:{kind,ref}, version, auditRef?}` 三键（`source.ref` 定义
   为"白名单来源标识……绝不含用户值"），§3.3①②的 `conclusion` 字段清单里也没有列出规则参数——
   把四个数值参数塞进 `source.ref`（字符串标识位）或扩展 `conclusion`/`basis` 键位都是**新开
   wire 键位**，按 G4"逐类 exact key set 由契约测试键集合恒等锁定"与硬规则 5"改动任一类的码
   承载键位=合同修订"的同一纪律，键位落点（走 conclusion 新增字段？basis env 新增字段？）需
   owner 定，本轮不自行发明形状，留待 owner 裁决后独立小票补齐。
6. **§2 IN "只读历史读面"（E3 更正环）内容深度不足，仅一条最近行的 `{created_at, actor}` 标记**
   ⏳（新披露，本轮三镜审查发现）：`readMostRecentResultEdit` 只 `SELECT created_at, actor_user_id
   LIMIT 1`，不读 `reason`/`before_status`/`after_status`，也不支持多条历史（只取最近一条）。
   §3.3① 明确"①E1 不透出编辑内容，详情走 E3"，暗示 E3 应携带内容细节，但 §3.1 的
   `auditRef?: {kind, at, actor?}` 通用形制同样没有为 `reason`/`before`/`after` 预留键位——与上一
   条同款"新开 wire 键位需 owner 定形状"边界，本轮不自行扩展。①E1 auditRef 合同内容
   （`source_batch_id` 导入批次存在性 + `manual_result_edit` 标记布尔）同理未落地（现恒为
   `{kind:'record_write', at}`），同一原因、同一处置。

### 本轮修复未采纳/维持原判的三镜 finding（reasoned reject，非沉默）

- **rbacGuard 被 mock 成直通，G7 授权矩阵的权限档区分（`attendance:admin` vs `attendance:read`）
  无测试证明**：真库测试文件按 W4-0 先例把 `rbacGuard` mock 为 `next()` 直通（同 S7-5/setup-
  readiness 两个先例同款盲区）。代码读实证 self 路由确有 `rbacGuard('attendance','read')`
  （挂在 admin prefix/guard 之外）、admin 路由的 router 级 `rbacGuard('attendance','admin')`
  因 Express 前缀边界不覆盖 self 路由——两点均可静态读源码验证。补齐需要真实签发不同 RBAC 权限
  的 JWT/session 走真实中间件，是测试基础设施改动而非本文件的缺陷，且 W4-0 同型盲区从未单独
  立票修复过，维持现状不在本轮处理。
- **④/⑥ 404 形状恒等用解析后 JSON `toEqual` 而非 `res.text` 字节级比对**：deepEqual-on-parsed-
  body 能抓住值差异；byte 级比对只多防"键序/空白差异承载 oracle"这一更窄的边缘场景，超出
  header/status 外的信息载体主要仍是 body 值本身。判定为可接受现状，不作改动。

（"SQL 无标识列断言（S7-5 同型）腿缺失"一项已在本轮吸收——见上 G2 checklist 行，不在本节。）

---

**不合并、不 arm。** 请求 owner 复核。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
