### PR TITLE
fix(attendance): anchor overnight punches to shift work date

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -121,6 +121,12 @@ function utcDateKeyOffset(days: number): string {
   return date.toISOString().slice(0, 10)
 }
 
+function addDaysToDateKeyForTest(dateKey: string, days: number): string {
+  const date = new Date(`${dateKey}T00:00:00.000Z`)
+  date.setUTCDate(date.getUTCDate() + days)
+  return date.toISOString().slice(0, 10)
+}
+
 function dateOnlyForTest(value: unknown): string {
   if (value instanceof Date) return value.toISOString().slice(0, 10)
   return String(value ?? '').slice(0, 10)
@@ -8353,6 +8359,358 @@ attendanceIntegrationDescribe(
       expect(recordRows[0]?.status).toBe('normal')
     } finally {
       await pool.end().catch(() => undefined)
+    }
+  })
+
+  it('anchors live overnight check-in/out punches to one normal work_date D record (staging 22:00-06:00)', async () => {
+    if (!baseUrl) return
+
+    // Staging reproduction: Asia/Shanghai 22:00–06:00 on day D; check-in D 22:05 and
+    // check-out D+1 05:55 must both store work_date=D and yield one 470-minute normal row
+    // (calendar-date anchoring previously split them into two partial rows).
+    const runSuffix = Date.now().toString(36)
+    const userId = `attendance-live-overnight-${runSuffix}`
+    const workDate = utcDateKeyOffset(-3)
+    const nextDate = addDaysToDateKeyForTest(workDate, 1)
+    const firstInAt = new Date(`${workDate}T22:05:00+08:00`).toISOString()
+    const lastOutAt = new Date(`${nextDate}T05:55:00+08:00`).toISOString()
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }
+    let shiftId: string | undefined
+    const pool = new Pool({ connectionString: attendanceIntegrationDbUrl })
+
+    try {
+      const shiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name: `Live overnight ${runSuffix}`,
+          timezone: 'Asia/Shanghai',
+          start_time: '22:00',
+          end_time: '06:00',
+          is_overnight: true,
+          late_grace_minutes: 10,
+          early_grace_minutes: 10,
+          rounding_minutes: 5,
+          working_days: [0, 1, 2, 3, 4, 5, 6],
+        }),
+      })
+      expect(shiftRes.status).toBe(201)
+      shiftId = (shiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(shiftId).toBeTruthy()
+      if (!shiftId) return
+
+      const assignmentRes = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ userId, shiftId, startDate: workDate, isActive: true }),
+      })
+      expect(assignmentRes.status).toBe(201)
+
+      const punchInRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          eventType: 'check_in',
+          occurredAt: firstInAt,
+          timezone: 'Asia/Shanghai',
+          source: 'integration-live-overnight',
+          location: { lat: 0, lng: 0 },
+        }),
+      })
+      expect(punchInRes.status).toBe(200)
+
+      const punchOutRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          eventType: 'check_out',
+          occurredAt: lastOutAt,
+          timezone: 'Asia/Shanghai',
+          source: 'integration-live-overnight',
+          location: { lat: 0, lng: 0 },
+        }),
+      })
+      expect(punchOutRes.status).toBe(200)
+
+      const events = await pool.query(
+        `SELECT work_date::text, event_type
+           FROM attendance_events
+          WHERE user_id = $1 AND org_id = $2
+          ORDER BY occurred_at`,
+        [userId, 'default']
+      )
+      expect(events.rows).toEqual([
+        { work_date: workDate, event_type: 'check_in' },
+        { work_date: workDate, event_type: 'check_out' },
+      ])
+
+      const records = await pool.query(
+        `SELECT work_date::text, first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes, status
+           FROM attendance_records
+          WHERE user_id = $1 AND org_id = $2
+          ORDER BY work_date`,
+        [userId, 'default']
+      )
+      expect(records.rows).toHaveLength(1)
+      expect(records.rows[0]?.work_date).toBe(workDate)
+      expect(records.rows[0]?.first_in_at?.toISOString()).toBe(firstInAt)
+      expect(records.rows[0]?.last_out_at?.toISOString()).toBe(lastOutAt)
+      expect(Number(records.rows[0]?.work_minutes)).toBe(470)
+      expect(Number(records.rows[0]?.late_minutes)).toBe(0)
+      expect(Number(records.rows[0]?.early_leave_minutes)).toBe(0)
+      expect(records.rows[0]?.status).toBe('normal')
+    } finally {
+      await pool.query('DELETE FROM attendance_requests WHERE user_id = $1', [userId]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_events WHERE user_id = $1', [userId]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_records WHERE user_id = $1', [userId]).catch(() => undefined)
+      if (shiftId) {
+        await pool.query('DELETE FROM attendance_shift_assignments WHERE user_id = $1 AND shift_id = $2', [userId, shiftId]).catch(() => undefined)
+        await pool.query('DELETE FROM attendance_shifts WHERE id = $1', [shiftId]).catch(() => undefined)
+      }
+      await pool.end()
+    }
+  })
+
+  it('keeps non-overnight live punches on the calendar work_date (no overnight re-anchor regression)', async () => {
+    if (!baseUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const userId = `attendance-live-dayshift-${runSuffix}`
+    const workDate = utcDateKeyOffset(-3)
+    const firstInAt = new Date(`${workDate}T09:05:00+08:00`).toISOString()
+    const lastOutAt = new Date(`${workDate}T17:55:00+08:00`).toISOString()
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }
+    let shiftId: string | undefined
+    const pool = new Pool({ connectionString: attendanceIntegrationDbUrl })
+
+    try {
+      const shiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name: `Live day shift ${runSuffix}`,
+          timezone: 'Asia/Shanghai',
+          start_time: '09:00',
+          end_time: '18:00',
+          is_overnight: false,
+          late_grace_minutes: 10,
+          early_grace_minutes: 10,
+          rounding_minutes: 5,
+          working_days: [0, 1, 2, 3, 4, 5, 6],
+        }),
+      })
+      expect(shiftRes.status).toBe(201)
+      shiftId = (shiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(shiftId).toBeTruthy()
+      if (!shiftId) return
+
+      const assignmentRes = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ userId, shiftId, startDate: workDate, isActive: true }),
+      })
+      expect(assignmentRes.status).toBe(201)
+
+      for (const [eventType, occurredAt] of [
+        ['check_in', firstInAt],
+        ['check_out', lastOutAt],
+      ] as const) {
+        const punchRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            eventType,
+            occurredAt,
+            timezone: 'Asia/Shanghai',
+            source: 'integration-live-dayshift',
+            location: { lat: 0, lng: 0 },
+          }),
+        })
+        expect(punchRes.status).toBe(200)
+      }
+
+      const events = await pool.query(
+        `SELECT work_date::text, event_type
+           FROM attendance_events
+          WHERE user_id = $1 AND org_id = $2
+          ORDER BY occurred_at`,
+        [userId, 'default']
+      )
+      expect(events.rows).toEqual([
+        { work_date: workDate, event_type: 'check_in' },
+        { work_date: workDate, event_type: 'check_out' },
+      ])
+
+      const records = await pool.query(
+        `SELECT work_date::text, first_in_at, last_out_at, work_minutes, status
+           FROM attendance_records
+          WHERE user_id = $1 AND org_id = $2
+          ORDER BY work_date`,
+        [userId, 'default']
+      )
+      expect(records.rows).toHaveLength(1)
+      expect(records.rows[0]?.work_date).toBe(workDate)
+      expect(records.rows[0]?.first_in_at?.toISOString()).toBe(firstInAt)
+      expect(records.rows[0]?.last_out_at?.toISOString()).toBe(lastOutAt)
+      expect(Number(records.rows[0]?.work_minutes)).toBe(530)
+      expect(records.rows[0]?.status).toBe('normal')
+    } finally {
+      await pool.query('DELETE FROM attendance_events WHERE user_id = $1', [userId]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_records WHERE user_id = $1', [userId]).catch(() => undefined)
+      if (shiftId) {
+        await pool.query('DELETE FROM attendance_shift_assignments WHERE user_id = $1 AND shift_id = $2', [userId, shiftId]).catch(() => undefined)
+        await pool.query('DELETE FROM attendance_shifts WHERE id = $1', [shiftId]).catch(() => undefined)
+      }
+      await pool.end()
+    }
+  })
+
+  it('prefers current-day matching shift when overnight previous window overlaps post-midnight', async () => {
+    if (!baseUrl) return
+
+    // D overnight 22:00–06:00 + D+1 morning 06:00–14:00: a punch at the exact
+    // shared boundary matches both windows. Current day must win.
+    const runSuffix = Date.now().toString(36)
+    const userId = `attendance-live-overlap-${runSuffix}`
+    const overnightDate = utcDateKeyOffset(-3)
+    const morningDate = addDaysToDateKeyForTest(overnightDate, 1)
+    const overlapPunchAt = new Date(`${morningDate}T06:00:00+08:00`).toISOString()
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }
+    let overnightShiftId: string | undefined
+    let morningShiftId: string | undefined
+    const pool = new Pool({ connectionString: attendanceIntegrationDbUrl })
+
+    try {
+      const overnightShiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name: `Overlap overnight ${runSuffix}`,
+          timezone: 'Asia/Shanghai',
+          start_time: '22:00',
+          end_time: '06:00',
+          is_overnight: true,
+          late_grace_minutes: 10,
+          early_grace_minutes: 10,
+          rounding_minutes: 5,
+          working_days: [0, 1, 2, 3, 4, 5, 6],
+        }),
+      })
+      expect(overnightShiftRes.status).toBe(201)
+      overnightShiftId = (overnightShiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(overnightShiftId).toBeTruthy()
+      if (!overnightShiftId) return
+
+      const morningShiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name: `Overlap morning ${runSuffix}`,
+          timezone: 'Asia/Shanghai',
+          start_time: '06:00',
+          end_time: '14:00',
+          is_overnight: false,
+          late_grace_minutes: 10,
+          early_grace_minutes: 10,
+          rounding_minutes: 5,
+          working_days: [0, 1, 2, 3, 4, 5, 6],
+        }),
+      })
+      expect(morningShiftRes.status).toBe(201)
+      morningShiftId = (morningShiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(morningShiftId).toBeTruthy()
+      if (!morningShiftId) return
+
+      const overnightAssign = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          userId,
+          shiftId: overnightShiftId,
+          startDate: overnightDate,
+          endDate: overnightDate,
+          isActive: true,
+        }),
+      })
+      expect(overnightAssign.status).toBe(201)
+
+      const morningAssign = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          userId,
+          shiftId: morningShiftId,
+          startDate: morningDate,
+          endDate: morningDate,
+          isActive: true,
+        }),
+      })
+      expect(morningAssign.status).toBe(201)
+
+      const punchRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          eventType: 'check_in',
+          occurredAt: overlapPunchAt,
+          timezone: 'Asia/Shanghai',
+          source: 'integration-live-overlap',
+          location: { lat: 0, lng: 0 },
+        }),
+      })
+      expect(punchRes.status).toBe(200)
+
+      const events = await pool.query(
+        `SELECT work_date::text, event_type
+           FROM attendance_events
+          WHERE user_id = $1 AND org_id = $2
+          ORDER BY occurred_at`,
+        [userId, 'default']
+      )
+      expect(events.rows).toEqual([
+        { work_date: morningDate, event_type: 'check_in' },
+      ])
+    } finally {
+      await pool.query('DELETE FROM attendance_events WHERE user_id = $1', [userId]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_records WHERE user_id = $1', [userId]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_shift_assignments WHERE user_id = $1', [userId]).catch(() => undefined)
+      if (overnightShiftId) {
+        await pool.query('DELETE FROM attendance_shifts WHERE id = $1', [overnightShiftId]).catch(() => undefined)
+      }
+      if (morningShiftId) {
+        await pool.query('DELETE FROM attendance_shifts WHERE id = $1', [morningShiftId]).catch(() => undefined)
+      }
+      await pool.end()
     }
   })
 

--- a/packages/core-backend/tests/unit/attendance-live-punch-work-date.test.ts
+++ b/packages/core-backend/tests/unit/attendance-live-punch-work-date.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest'
+
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceLivePunchWorkDateForTests as {
+  getPunchShiftWindow: (
+    context: { rule?: Record<string, unknown> } | null,
+    workDate: string,
+    fallbackTimezone: string
+  ) => { startAt: Date; endAt: Date; timezone: string; isOvernight: boolean } | null
+  isPunchWithinShiftWindow: (
+    occurredAt: Date,
+    context: { rule?: Record<string, unknown> } | null,
+    workDate: string,
+    fallbackTimezone: string
+  ) => boolean
+  resolvePunchWorkDateByShiftWindow: (options: Record<string, unknown>) => Promise<{
+    workDate: string
+    context: { rule?: Record<string, unknown> } | null
+    timezone: string
+  }>
+}
+
+function overnightRule(overrides: Record<string, unknown> = {}) {
+  return {
+    workStartTime: '22:00',
+    workEndTime: '06:00',
+    isOvernight: true,
+    timezone: 'Asia/Shanghai',
+    lateGraceMinutes: 10,
+    earlyGraceMinutes: 10,
+    workingDays: [0, 1, 2, 3, 4, 5, 6],
+    ...overrides,
+  }
+}
+
+function dayRule(overrides: Record<string, unknown> = {}) {
+  return {
+    workStartTime: '09:00',
+    workEndTime: '18:00',
+    isOvernight: false,
+    timezone: 'Asia/Shanghai',
+    lateGraceMinutes: 10,
+    earlyGraceMinutes: 10,
+    workingDays: [0, 1, 2, 3, 4, 5, 6],
+    ...overrides,
+  }
+}
+
+function morningRule(overrides: Record<string, unknown> = {}) {
+  return {
+    workStartTime: '06:00',
+    workEndTime: '14:00',
+    isOvernight: false,
+    timezone: 'Asia/Shanghai',
+    lateGraceMinutes: 10,
+    earlyGraceMinutes: 10,
+    workingDays: [0, 1, 2, 3, 4, 5, 6],
+    ...overrides,
+  }
+}
+
+describe('attendance live punch work_date overnight anchoring helpers', () => {
+  it('builds overnight windows that cross local midnight in Asia/Shanghai', () => {
+    const window = helpers.getPunchShiftWindow({ rule: overnightRule() }, '2026-07-15', 'Asia/Shanghai')
+    expect(window).not.toBeNull()
+    expect(window?.isOvernight).toBe(true)
+    expect(window?.startAt.toISOString()).toBe('2026-07-15T14:00:00.000Z') // 22:00 CST
+    expect(window?.endAt.toISOString()).toBe('2026-07-15T22:00:00.000Z') // 06:00 CST next day
+  })
+
+  it('matches staging overnight check-in/out instants inside the D window', () => {
+    const context = { rule: overnightRule() }
+    const checkIn = new Date('2026-07-15T14:05:00.000Z') // D 22:05 CST
+    const checkOut = new Date('2026-07-15T21:55:00.000Z') // D+1 05:55 CST
+    expect(helpers.isPunchWithinShiftWindow(checkIn, context, '2026-07-15', 'Asia/Shanghai')).toBe(true)
+    expect(helpers.isPunchWithinShiftWindow(checkOut, context, '2026-07-15', 'Asia/Shanghai')).toBe(true)
+    // Calendar date alone would put check-out on D+1; D+1 overnight starts at 22:00 and must NOT match 05:55.
+    expect(helpers.isPunchWithinShiftWindow(checkOut, context, '2026-07-16', 'Asia/Shanghai')).toBe(false)
+  })
+
+  it('does not reinterpret late/early scoring grace as a work-date association window', () => {
+    const context = { rule: overnightRule({ lateGraceMinutes: 30, earlyGraceMinutes: 30 }) }
+    expect(
+      helpers.isPunchWithinShiftWindow(new Date('2026-07-15T22:05:00.000Z'), context, '2026-07-15', 'Asia/Shanghai')
+    ).toBe(false)
+  })
+
+  it('does not treat an ordinary day shift as an overnight candidate', () => {
+    const currentContext = { rule: dayRule() }
+    const previousContext = { rule: dayRule() }
+    const noon = new Date('2026-07-14T04:00:00.000Z') // 12:00 CST
+    expect(helpers.isPunchWithinShiftWindow(noon, currentContext, '2026-07-14', 'Asia/Shanghai')).toBe(true)
+    expect(helpers.isPunchWithinShiftWindow(noon, previousContext, '2026-07-13', 'Asia/Shanghai')).toBe(false)
+    const previousWindow = helpers.getPunchShiftWindow(previousContext, '2026-07-13', 'Asia/Shanghai')
+    expect(previousWindow?.isOvernight).toBe(false)
+  })
+
+  it('has an exact boundary where previous overnight and current morning windows overlap', () => {
+    const previous = { rule: overnightRule() }
+    const current = { rule: morningRule() }
+    const overlap = new Date('2026-07-15T22:00:00.000Z') // D+1 06:00 CST
+    expect(helpers.isPunchWithinShiftWindow(overlap, previous, '2026-07-15', 'Asia/Shanghai')).toBe(true)
+    expect(helpers.isPunchWithinShiftWindow(overlap, current, '2026-07-16', 'Asia/Shanghai')).toBe(true)
+  })
+
+  it('resolvePunchWorkDateByShiftWindow re-anchors only when current misses and previous overnight matches', async () => {
+    const currentContext = { rule: overnightRule() } // D+1 same overnight profile (starts 22:00) — 05:55 misses
+    const previousContext = { rule: overnightRule() }
+    const fakeDb = {
+      query: async (sql: string, params?: unknown[]) => {
+        // resolveWorkContext path: holidays / rotation / assignments / settings
+        if (String(sql).includes('attendance_shift_assignments')) {
+          const workDate = String(params?.[2] ?? '')
+          if (workDate === '2026-07-15') {
+            return [{
+              id: 'asg-prev',
+              org_id: 'default',
+              user_id: 'u1',
+              shift_id: 'sh-overnight',
+              slot_index: 0,
+              start_date: '2026-07-15',
+              end_date: null,
+              is_active: true,
+              publish_status: 'published',
+              shift_name: 'Night',
+              shift_timezone: 'Asia/Shanghai',
+              shift_work_start_time: '22:00',
+              shift_work_end_time: '06:00',
+              shift_is_overnight: true,
+              shift_late_grace_minutes: 10,
+              shift_early_grace_minutes: 10,
+              shift_rounding_minutes: 5,
+              shift_working_days: [1, 2, 3, 4, 5],
+            }]
+          }
+          return []
+        }
+        if (String(sql).includes('attendance_holidays')) return []
+        if (String(sql).includes('attendance_rotation')) return []
+        if (String(sql).includes('system_configs') || String(sql).includes('attendance.settings')) return []
+        return []
+      },
+    }
+
+    const checkOut = new Date('2026-07-15T21:55:00.000Z') // calendar D+1 05:55 CST
+    const resolved = await helpers.resolvePunchWorkDateByShiftWindow({
+      db: fakeDb,
+      orgId: 'default',
+      userId: 'u1',
+      occurredAt: checkOut,
+      workDate: '2026-07-16',
+      context: currentContext,
+      defaultRule: dayRule({ timezone: 'Asia/Shanghai' }),
+      timezone: 'Asia/Shanghai',
+    })
+    expect(resolved.workDate).toBe('2026-07-15')
+    expect(resolved.context).toBeTruthy()
+    expect(resolved.timezone).toBe('Asia/Shanghai')
+
+    // Current already matches → no previous-day steal.
+    const sameDayCheckIn = new Date('2026-07-15T14:05:00.000Z')
+    const stays = await helpers.resolvePunchWorkDateByShiftWindow({
+      db: fakeDb,
+      orgId: 'default',
+      userId: 'u1',
+      occurredAt: sameDayCheckIn,
+      workDate: '2026-07-15',
+      context: previousContext,
+      defaultRule: dayRule({ timezone: 'Asia/Shanghai' }),
+      timezone: 'Asia/Shanghai',
+    })
+    expect(stays.workDate).toBe('2026-07-15')
+    expect(stays.context).toBe(previousContext)
+  })
+
+  it('negative control: without overnight previous assignment, post-midnight punch keeps calendar date', async () => {
+    const currentContext = { rule: dayRule({ workStartTime: '09:00', workEndTime: '18:00' }) }
+    const fakeDb = {
+      query: async (sql: string) => {
+        if (String(sql).includes('attendance_shift_assignments')) return []
+        if (String(sql).includes('attendance_holidays')) return []
+        if (String(sql).includes('attendance_rotation')) return []
+        return []
+      },
+    }
+    const earlyMorning = new Date('2026-07-15T21:55:00.000Z') // 05:55 CST on calendar 2026-07-16
+    const resolved = await helpers.resolvePunchWorkDateByShiftWindow({
+      db: fakeDb,
+      orgId: 'default',
+      userId: 'u1',
+      occurredAt: earlyMorning,
+      workDate: '2026-07-16',
+      context: currentContext,
+      defaultRule: dayRule({ timezone: 'Asia/Shanghai' }),
+      timezone: 'Asia/Shanghai',
+    })
+    expect(resolved.workDate).toBe('2026-07-16')
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -14393,6 +14393,78 @@ async function resolveWorkContext(options) {
   return context
 }
 
+function getPunchShiftWindow(context, workDate, fallbackTimezone) {
+  const rule = context?.rule
+  const workStartTime = normalizeTimeString(rule?.workStartTime ?? rule?.work_start_time)
+  const workEndTime = normalizeTimeString(rule?.workEndTime ?? rule?.work_end_time)
+  if (!workStartTime || !workEndTime) return null
+  const timezone = typeof rule?.timezone === 'string' && rule.timezone.trim()
+    ? rule.timezone.trim()
+    : fallbackTimezone
+  const isOvernight = resolveOvernightFlag(rule?.isOvernight ?? rule?.is_overnight, workStartTime, workEndTime)
+  const endDate = isOvernight ? addDaysToDateKey(workDate, 1) : workDate
+  const startAt = buildZonedDate(workDate, workStartTime, timezone)
+  const endAt = buildZonedDate(endDate, workEndTime, timezone)
+  if (!startAt || !endAt || endAt.getTime() <= startAt.getTime()) return null
+  return { startAt, endAt, timezone, isOvernight }
+}
+
+function isPunchWithinShiftWindow(occurredAt, context, workDate, fallbackTimezone) {
+  const window = getPunchShiftWindow(context, workDate, fallbackTimezone)
+  if (!window || !(occurredAt instanceof Date) || Number.isNaN(occurredAt.getTime())) return false
+  const occurredAtMs = occurredAt.getTime()
+  return occurredAtMs >= window.startAt.getTime() && occurredAtMs <= window.endAt.getTime()
+}
+
+async function resolvePunchWorkDateByShiftWindow(options) {
+  const {
+    db,
+    orgId,
+    userId,
+    occurredAt,
+    workDate,
+    context,
+    defaultRule,
+    timezone,
+  } = options
+
+  // A punch shortly after local midnight may still belong to the previous day's
+  // overnight shift. Evaluate both date candidates against their actual shift
+  // windows instead of letting the calendar date alone decide the attendance row.
+  if (!userId || !workDate || !(occurredAt instanceof Date) || Number.isNaN(occurredAt.getTime())) {
+    return { workDate, context, timezone }
+  }
+
+  // Prefer the calendar day's own matching shift when windows overlap (or when
+  // the punch is simply a normal same-day punch). Skip the previous-day lookup.
+  if (isPunchWithinShiftWindow(occurredAt, context, workDate, timezone)) {
+    return { workDate, context, timezone }
+  }
+
+  const previousWorkDate = addDaysToDateKey(workDate, -1)
+  if (!previousWorkDate) return { workDate, context, timezone }
+
+  const previousContext = await resolveWorkContext({
+    db,
+    orgId,
+    userId,
+    workDate: previousWorkDate,
+    defaultRule,
+  })
+  const previousWindow = getPunchShiftWindow(previousContext, previousWorkDate, timezone)
+  // Only a genuine overnight previous shift may claim a post-midnight punch.
+  if (!previousWindow?.isOvernight) return { workDate, context, timezone }
+  if (!isPunchWithinShiftWindow(occurredAt, previousContext, previousWorkDate, timezone)) {
+    return { workDate, context, timezone }
+  }
+
+  return {
+    workDate: previousWorkDate,
+    context: previousContext,
+    timezone: previousWindow.timezone ?? timezone,
+  }
+}
+
 async function loadHolidayMapByDates(db, orgId, workDates) {
   const targetOrg = orgId || DEFAULT_ORG_ID
   if (!Array.isArray(workDates) || workDates.length === 0) return new Map()
@@ -21333,6 +21405,11 @@ module.exports = {
   // exported nested one bag down, so the top-level optional call silently no-op'd
   // and the 60s settings cache leaked across tests in the shared attendance suite.
   resetAttendanceSettingsCacheForTests,
+  __attendanceLivePunchWorkDateForTests: {
+    getPunchShiftWindow,
+    isPunchWithinShiftWindow,
+    resolvePunchWorkDateByShiftWindow,
+  },
   __attendanceLeaveCancellationForTests: {
     reverseLeaveBalanceDeduction,
   },
@@ -25411,6 +25488,20 @@ module.exports = {
               })
             }
           }
+
+          const punchWorkDate = await resolvePunchWorkDateByShiftWindow({
+            db,
+            orgId,
+            userId,
+            occurredAt,
+            workDate,
+            context,
+            defaultRule: baseRule,
+            timezone,
+          })
+          workDate = punchWorkDate.workDate
+          context = punchWorkDate.context
+          timezone = punchWorkDate.timezone
 
           // Punch-policy S1 (#2203): block a punch on a day with no schedule when the org opted into
           // unscheduled.mode='block'. workDate is the FINAL (tz-recalculated) date. Default 'allow' and


### PR DESCRIPTION
## What changed

- Resolve live punch `work_date` against both the calendar day's shift window and the previous day's genuine overnight shift window.
- Keep the calendar day's matching shift authoritative when the two windows share a boundary.
- Reuse the resolved previous-day context for event/record calculation so checkout, status, and work minutes stay on one business-day row.
- Keep late/early grace semantics unchanged; they are not reused as work-date association padding.

This is a focused contribution to umbrella issue #4556. It changes no API shape, migration, import path, historical recomputation, or runtime flag.

## Reproduction covered

Asia/Shanghai shift `22:00-06:00`:

- check-in D `22:05`
- check-out D+1 `05:55`
- expected: both events use `work_date=D`, one `normal` record, `work_minutes=470`

Negative coverage includes ordinary day shifts and an exact overlap boundary where the current day's shift must win.

## Verification

- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend type-check`
- unit helper spec: `7/7`
- focused real-DB overnight/ordinary/overlap integration: `4/4`
- fresh migrated real DB, full `attendance-plugin.test.ts`: `161/161`
- mutation: disabling previous overnight ownership makes checkout return to D+1 and the live endpoint test fail; restoring the implementation returns green
- synthetic test residue: events/records/assignments/shifts `0/0/0/0`

## Review notes

A delegated Grok implementation pass was independently reviewed and tightened before this PR. The initial symmetric grace-window proposal was rejected because it changed the meaning of late/early grace fields; the final implementation uses only the actual inclusive shift interval.
