### PR TITLE
docs(attendance): align advanced scheduling OpenAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "verify:multitable-feishu-rc:api-smoke": "node scripts/ops/multitable-feishu-rc-api-smoke.mjs",
     "verify:multitable-feishu-rc:api-smoke:test": "node --test scripts/ops/multitable-feishu-rc-api-smoke.test.mjs",
     "verify:multitable-openapi:parity": "pnpm exec tsx packages/openapi/tools/build.ts && node --test scripts/ops/multitable-openapi-parity.test.mjs",
+    "verify:attendance-openapi:parity": "pnpm exec tsx packages/openapi/tools/build.ts && node --test scripts/ops/attendance-openapi-parity-4556-contract.test.mjs",
     "verify:multitable-yjs:contract": "node --test scripts/ops/multitable-yjs-contract-parity.test.mjs",
     "ops:multitable-dangling-link-sweep": "node scripts/ops/multitable-dangling-link-sweep.mjs",
     "verify:multitable-release:phase3": "node scripts/ops/multitable-phase3-release-gate.mjs --gate release:phase3",

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1068,6 +1068,24 @@ components:
         description:
           type: string
           nullable: true
+        attendanceType:
+          type: string
+          enum:
+            - fixed_shift
+            - scheduled_shift
+            - free_time
+        attendance_type:
+          type: string
+          enum:
+            - fixed_shift
+            - scheduled_shift
+            - free_time
+          deprecated: true
+        memberCount:
+          type: integer
+        member_count:
+          type: integer
+          deprecated: true
         createdAt:
           type: string
           format: date-time
@@ -1845,6 +1863,15 @@ components:
           type: string
         shift_id:
           type: string
+          deprecated: true
+        slotIndex:
+          type: integer
+          minimum: 0
+          maximum: 2
+        slot_index:
+          type: integer
+          minimum: 0
+          maximum: 2
           deprecated: true
         startDate:
           type: string
@@ -7678,6 +7705,8 @@ paths:
                   type: string
                 workEndTime:
                   type: string
+                isOvernight:
+                  type: boolean
                 lateGraceMinutes:
                   type: integer
                 earlyGraceMinutes:
@@ -7816,6 +7845,10 @@ paths:
                   type: string
                 shiftId:
                   type: string
+                slotIndex:
+                  type: integer
+                  minimum: 0
+                  maximum: 2
                 startDate:
                   type: string
                   format: date
@@ -7833,6 +7866,11 @@ paths:
                 shift_id:
                   type: string
                   description: Legacy snake_case alias for shiftId.
+                slot_index:
+                  type: integer
+                  minimum: 0
+                  maximum: 2
+                  description: Legacy snake_case alias for slotIndex.
                 start_date:
                   type: string
                   format: date
@@ -7912,6 +7950,10 @@ paths:
                   type: string
                 shiftId:
                   type: string
+                slotIndex:
+                  type: integer
+                  minimum: 0
+                  maximum: 2
                 startDate:
                   type: string
                   format: date
@@ -7927,6 +7969,11 @@ paths:
                   type: string
                 shift_id:
                   type: string
+                slot_index:
+                  type: integer
+                  minimum: 0
+                  maximum: 2
+                  description: Legacy snake_case alias for slotIndex.
                 start_date:
                   type: string
                   format: date
@@ -8443,6 +8490,12 @@ paths:
                   type: string
                 description:
                   type: string
+                attendanceType:
+                  type: string
+                  enum:
+                    - fixed_shift
+                    - scheduled_shift
+                    - free_time
                 orgId:
                   type: string
               required:
@@ -8525,6 +8578,15 @@ paths:
                   type: string
                 description:
                   type: string
+                attendanceType:
+                  type: string
+                  enum:
+                    - fixed_shift
+                    - scheduled_shift
+                    - free_time
+                  description: >-
+                    Accepted for parity with create; runtime rejects type
+                    changes after creation (ATTENDANCE_GROUP_TYPE_LOCKED).
                 orgId:
                   type: string
       responses:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -1520,6 +1520,30 @@
             "type": "string",
             "nullable": true
           },
+          "attendanceType": {
+            "type": "string",
+            "enum": [
+              "fixed_shift",
+              "scheduled_shift",
+              "free_time"
+            ]
+          },
+          "attendance_type": {
+            "type": "string",
+            "enum": [
+              "fixed_shift",
+              "scheduled_shift",
+              "free_time"
+            ],
+            "deprecated": true
+          },
+          "memberCount": {
+            "type": "integer"
+          },
+          "member_count": {
+            "type": "integer",
+            "deprecated": true
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",
@@ -2577,6 +2601,17 @@
           },
           "shift_id": {
             "type": "string",
+            "deprecated": true
+          },
+          "slotIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 2
+          },
+          "slot_index": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 2,
             "deprecated": true
           },
           "startDate": {
@@ -11098,6 +11133,9 @@
                   "workEndTime": {
                     "type": "string"
                   },
+                  "isOvernight": {
+                    "type": "boolean"
+                  },
                   "lateGraceMinutes": {
                     "type": "integer"
                   },
@@ -11325,6 +11363,11 @@
                   "shiftId": {
                     "type": "string"
                   },
+                  "slotIndex": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 2
+                  },
                   "startDate": {
                     "type": "string",
                     "format": "date"
@@ -11347,6 +11390,12 @@
                   "shift_id": {
                     "type": "string",
                     "description": "Legacy snake_case alias for shiftId."
+                  },
+                  "slot_index": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 2,
+                    "description": "Legacy snake_case alias for slotIndex."
                   },
                   "start_date": {
                     "type": "string",
@@ -11466,6 +11515,11 @@
                   "shiftId": {
                     "type": "string"
                   },
+                  "slotIndex": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 2
+                  },
                   "startDate": {
                     "type": "string",
                     "format": "date"
@@ -11486,6 +11540,12 @@
                   },
                   "shift_id": {
                     "type": "string"
+                  },
+                  "slot_index": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 2,
+                    "description": "Legacy snake_case alias for slotIndex."
                   },
                   "start_date": {
                     "type": "string",
@@ -12327,6 +12387,14 @@
                   "description": {
                     "type": "string"
                   },
+                  "attendanceType": {
+                    "type": "string",
+                    "enum": [
+                      "fixed_shift",
+                      "scheduled_shift",
+                      "free_time"
+                    ]
+                  },
                   "orgId": {
                     "type": "string"
                   }
@@ -12460,6 +12528,15 @@
                   },
                   "description": {
                     "type": "string"
+                  },
+                  "attendanceType": {
+                    "type": "string",
+                    "enum": [
+                      "fixed_shift",
+                      "scheduled_shift",
+                      "free_time"
+                    ],
+                    "description": "Accepted for parity with create; runtime rejects type changes after creation (ATTENDANCE_GROUP_TYPE_LOCKED)."
                   },
                   "orgId": {
                     "type": "string"

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1068,6 +1068,24 @@ components:
         description:
           type: string
           nullable: true
+        attendanceType:
+          type: string
+          enum:
+            - fixed_shift
+            - scheduled_shift
+            - free_time
+        attendance_type:
+          type: string
+          enum:
+            - fixed_shift
+            - scheduled_shift
+            - free_time
+          deprecated: true
+        memberCount:
+          type: integer
+        member_count:
+          type: integer
+          deprecated: true
         createdAt:
           type: string
           format: date-time
@@ -1845,6 +1863,15 @@ components:
           type: string
         shift_id:
           type: string
+          deprecated: true
+        slotIndex:
+          type: integer
+          minimum: 0
+          maximum: 2
+        slot_index:
+          type: integer
+          minimum: 0
+          maximum: 2
           deprecated: true
         startDate:
           type: string
@@ -7678,6 +7705,8 @@ paths:
                   type: string
                 workEndTime:
                   type: string
+                isOvernight:
+                  type: boolean
                 lateGraceMinutes:
                   type: integer
                 earlyGraceMinutes:
@@ -7816,6 +7845,10 @@ paths:
                   type: string
                 shiftId:
                   type: string
+                slotIndex:
+                  type: integer
+                  minimum: 0
+                  maximum: 2
                 startDate:
                   type: string
                   format: date
@@ -7833,6 +7866,11 @@ paths:
                 shift_id:
                   type: string
                   description: Legacy snake_case alias for shiftId.
+                slot_index:
+                  type: integer
+                  minimum: 0
+                  maximum: 2
+                  description: Legacy snake_case alias for slotIndex.
                 start_date:
                   type: string
                   format: date
@@ -7912,6 +7950,10 @@ paths:
                   type: string
                 shiftId:
                   type: string
+                slotIndex:
+                  type: integer
+                  minimum: 0
+                  maximum: 2
                 startDate:
                   type: string
                   format: date
@@ -7927,6 +7969,11 @@ paths:
                   type: string
                 shift_id:
                   type: string
+                slot_index:
+                  type: integer
+                  minimum: 0
+                  maximum: 2
+                  description: Legacy snake_case alias for slotIndex.
                 start_date:
                   type: string
                   format: date
@@ -8443,6 +8490,12 @@ paths:
                   type: string
                 description:
                   type: string
+                attendanceType:
+                  type: string
+                  enum:
+                    - fixed_shift
+                    - scheduled_shift
+                    - free_time
                 orgId:
                   type: string
               required:
@@ -8525,6 +8578,15 @@ paths:
                   type: string
                 description:
                   type: string
+                attendanceType:
+                  type: string
+                  enum:
+                    - fixed_shift
+                    - scheduled_shift
+                    - free_time
+                  description: >-
+                    Accepted for parity with create; runtime rejects type
+                    changes after creation (ATTENDANCE_GROUP_TYPE_LOCKED).
                 orgId:
                   type: string
       responses:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -973,6 +973,18 @@ components:
         description:
           type: string
           nullable: true
+        attendanceType:
+          type: string
+          enum: [fixed_shift, scheduled_shift, free_time]
+        attendance_type:
+          type: string
+          enum: [fixed_shift, scheduled_shift, free_time]
+          deprecated: true
+        memberCount:
+          type: integer
+        member_count:
+          type: integer
+          deprecated: true
         createdAt:
           type: string
           format: date-time
@@ -1680,6 +1692,15 @@ components:
           type: string
         shift_id:
           type: string
+          deprecated: true
+        slotIndex:
+          type: integer
+          minimum: 0
+          maximum: 2
+        slot_index:
+          type: integer
+          minimum: 0
+          maximum: 2
           deprecated: true
         startDate:
           type: string

--- a/packages/openapi/src/paths/attendance.yml
+++ b/packages/openapi/src/paths/attendance.yml
@@ -1330,6 +1330,7 @@ paths:
                 timezone: { type: string }
                 workStartTime: { type: string }
                 workEndTime: { type: string }
+                isOvernight: { type: boolean }
                 lateGraceMinutes: { type: integer }
                 earlyGraceMinutes: { type: integer }
                 roundingMinutes: { type: integer }
@@ -1432,6 +1433,10 @@ paths:
               properties:
                 userId: { type: string }
                 shiftId: { type: string }
+                slotIndex:
+                  type: integer
+                  minimum: 0
+                  maximum: 2
                 startDate: { type: string, format: date }
                 endDate: { type: string, format: date, nullable: true }
                 isActive: { type: boolean }
@@ -1442,6 +1447,11 @@ paths:
                 shift_id:
                   type: string
                   description: Legacy snake_case alias for shiftId.
+                slot_index:
+                  type: integer
+                  minimum: 0
+                  maximum: 2
+                  description: Legacy snake_case alias for slotIndex.
                 start_date:
                   type: string
                   format: date
@@ -1508,12 +1518,21 @@ paths:
               properties:
                 userId: { type: string }
                 shiftId: { type: string }
+                slotIndex:
+                  type: integer
+                  minimum: 0
+                  maximum: 2
                 startDate: { type: string, format: date }
                 endDate: { type: string, format: date, nullable: true }
                 isActive: { type: boolean }
                 orgId: { type: string }
                 user_id: { type: string }
                 shift_id: { type: string }
+                slot_index:
+                  type: integer
+                  minimum: 0
+                  maximum: 2
+                  description: Legacy snake_case alias for slotIndex.
                 start_date: { type: string, format: date }
                 end_date: { type: string, format: date, nullable: true }
                 is_active: { type: boolean }
@@ -1883,6 +1902,9 @@ paths:
                 timezone: { type: string }
                 ruleSetId: { type: string }
                 description: { type: string }
+                attendanceType:
+                  type: string
+                  enum: [fixed_shift, scheduled_shift, free_time]
                 orgId: { type: string }
               required: [name, timezone]
       responses:
@@ -1942,6 +1964,10 @@ paths:
                 timezone: { type: string }
                 ruleSetId: { type: string }
                 description: { type: string }
+                attendanceType:
+                  type: string
+                  enum: [fixed_shift, scheduled_shift, free_time]
+                  description: Accepted for parity with create; runtime rejects type changes after creation (ATTENDANCE_GROUP_TYPE_LOCKED).
                 orgId: { type: string }
       responses:
         '200':

--- a/scripts/ops/attendance-openapi-parity-4556-contract.test.mjs
+++ b/scripts/ops/attendance-openapi-parity-4556-contract.test.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * OpenAPI parity contract for attendance low-risk slice (#4556).
+ *
+ * Parses source YAML structurally (not string grep) and fails if required fields
+ * or enums disappear or drift from the runtime-aligned contract:
+ * - AttendanceGroup: attendanceType enum + memberCount integer
+ * - Group POST/PUT request: optional attendanceType with the same enum
+ * - Shift PUT request: isOvernight boolean
+ * - AttendanceShiftAssignment + assignment POST/PUT: slotIndex (0..2) and
+ *   legacy slot_index where runtime accepts/returns it (response legacy deprecated)
+ */
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+const require = createRequire(import.meta.url)
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const basePath = path.join(rootDir, 'packages/openapi/src/base.yml')
+const attendancePath = path.join(rootDir, 'packages/openapi/src/paths/attendance.yml')
+
+const ATTENDANCE_GROUP_TYPES = ['fixed_shift', 'scheduled_shift', 'free_time']
+
+function resolveYamlModule() {
+  const candidates = [
+    'js-yaml',
+    path.join(rootDir, 'node_modules/js-yaml'),
+    path.join(rootDir, 'packages/openapi/node_modules/js-yaml'),
+    // Partial installs may leave the package under pnpm's .ignored tree.
+    path.join(rootDir, 'packages/openapi/node_modules/.ignored/js-yaml'),
+  ]
+  const errors = []
+  for (const candidate of candidates) {
+    try {
+      return require(candidate)
+    } catch (error) {
+      errors.push(`${candidate}: ${error?.message || error}`)
+    }
+  }
+  throw new Error(`Unable to resolve js-yaml for YAML structural parse.\n${errors.join('\n')}`)
+}
+
+const yaml = resolveYamlModule()
+
+function loadYaml(filePath) {
+  assert.ok(fs.existsSync(filePath), `missing YAML file: ${filePath}`)
+  return yaml.load(fs.readFileSync(filePath, 'utf8'))
+}
+
+function requireSchema(doc, name) {
+  const schema = doc?.components?.schemas?.[name]
+  assert.ok(schema && typeof schema === 'object', `missing components.schemas.${name}`)
+  return schema
+}
+
+function requireProperty(schema, name, context) {
+  const prop = schema?.properties?.[name]
+  assert.ok(prop && typeof prop === 'object', `${context} missing property: ${name}`)
+  return prop
+}
+
+function assertEnumExact(prop, expected, context) {
+  assert.equal(prop.type, 'string', `${context} must be type string`)
+  assert.ok(Array.isArray(prop.enum), `${context} must declare enum`)
+  assert.deepEqual(prop.enum, expected, `${context} enum drifted`)
+}
+
+function assertSlotIndex(prop, context) {
+  assert.equal(prop.type, 'integer', `${context} must be type integer`)
+  assert.equal(prop.minimum, 0, `${context} must have minimum: 0`)
+  assert.equal(prop.maximum, 2, `${context} must have maximum: 2`)
+}
+
+function requestBodySchema(pathsDoc, apiPath, method) {
+  const op = pathsDoc?.paths?.[apiPath]?.[method]
+  assert.ok(op && typeof op === 'object', `missing path ${method.toUpperCase()} ${apiPath}`)
+  const schema = op?.requestBody?.content?.['application/json']?.schema
+  assert.ok(schema && typeof schema === 'object', `${method.toUpperCase()} ${apiPath} missing JSON request schema`)
+  return schema
+}
+
+test('AttendanceGroup response schema includes attendanceType enum and memberCount', () => {
+  const base = loadYaml(basePath)
+  const group = requireSchema(base, 'AttendanceGroup')
+
+  const attendanceType = requireProperty(group, 'attendanceType', 'AttendanceGroup')
+  assertEnumExact(attendanceType, ATTENDANCE_GROUP_TYPES, 'AttendanceGroup.attendanceType')
+
+  const memberCount = requireProperty(group, 'memberCount', 'AttendanceGroup')
+  assert.equal(memberCount.type, 'integer', 'AttendanceGroup.memberCount must be integer')
+
+  const legacyAttendanceType = requireProperty(group, 'attendance_type', 'AttendanceGroup')
+  assertEnumExact(legacyAttendanceType, ATTENDANCE_GROUP_TYPES, 'AttendanceGroup.attendance_type')
+  assert.equal(legacyAttendanceType.deprecated, true, 'AttendanceGroup.attendance_type must be deprecated')
+
+  const legacyMemberCount = requireProperty(group, 'member_count', 'AttendanceGroup')
+  assert.equal(legacyMemberCount.type, 'integer', 'AttendanceGroup.member_count must be integer')
+  assert.equal(legacyMemberCount.deprecated, true, 'AttendanceGroup.member_count must be deprecated')
+})
+
+test('group POST/PUT request schemas include optional attendanceType enum (not invented required)', () => {
+  const attendance = loadYaml(attendancePath)
+
+  for (const [apiPath, method] of [
+    ['/api/attendance/groups', 'post'],
+    ['/api/attendance/groups/{id}', 'put'],
+  ]) {
+    const schema = requestBodySchema(attendance, apiPath, method)
+    const attendanceType = requireProperty(schema, 'attendanceType', `${method.toUpperCase()} ${apiPath}`)
+    assertEnumExact(attendanceType, ATTENDANCE_GROUP_TYPES, `${method.toUpperCase()} ${apiPath} attendanceType`)
+
+    const required = Array.isArray(schema.required) ? schema.required : []
+    assert.ok(
+      !required.includes('attendanceType'),
+      `${method.toUpperCase()} ${apiPath} must not invent required attendanceType`,
+    )
+  }
+
+  // Preserve existing create required fields; do not invent new ones.
+  const createSchema = requestBodySchema(attendance, '/api/attendance/groups', 'post')
+  assert.deepEqual(
+    createSchema.required,
+    ['name', 'timezone'],
+    'POST /api/attendance/groups required list drifted',
+  )
+})
+
+test('shift PUT request schema includes isOvernight', () => {
+  const attendance = loadYaml(attendancePath)
+  const schema = requestBodySchema(attendance, '/api/attendance/shifts/{id}', 'put')
+  const isOvernight = requireProperty(schema, 'isOvernight', 'PUT /api/attendance/shifts/{id}')
+  assert.equal(isOvernight.type, 'boolean', 'PUT shift isOvernight must be boolean')
+})
+
+test('AttendanceShiftAssignment schema includes slotIndex min 0 and deprecated slot_index', () => {
+  const base = loadYaml(basePath)
+  const assignment = requireSchema(base, 'AttendanceShiftAssignment')
+
+  const slotIndex = requireProperty(assignment, 'slotIndex', 'AttendanceShiftAssignment')
+  assertSlotIndex(slotIndex, 'AttendanceShiftAssignment.slotIndex')
+
+  const legacy = requireProperty(assignment, 'slot_index', 'AttendanceShiftAssignment')
+  assertSlotIndex(legacy, 'AttendanceShiftAssignment.slot_index')
+  assert.equal(legacy.deprecated, true, 'AttendanceShiftAssignment.slot_index must be deprecated')
+})
+
+test('assignment POST/PUT request schemas include slotIndex min 0 and legacy slot_index', () => {
+  const attendance = loadYaml(attendancePath)
+
+  for (const [apiPath, method] of [
+    ['/api/attendance/assignments', 'post'],
+    ['/api/attendance/assignments/{id}', 'put'],
+  ]) {
+    const schema = requestBodySchema(attendance, apiPath, method)
+    const slotIndex = requireProperty(schema, 'slotIndex', `${method.toUpperCase()} ${apiPath}`)
+    assertSlotIndex(slotIndex, `${method.toUpperCase()} ${apiPath} slotIndex`)
+
+    const legacy = requireProperty(schema, 'slot_index', `${method.toUpperCase()} ${apiPath}`)
+    assertSlotIndex(legacy, `${method.toUpperCase()} ${apiPath} slot_index`)
+  }
+
+  // Create still requires the original identity fields only.
+  const createSchema = requestBodySchema(attendance, '/api/attendance/assignments', 'post')
+  assert.deepEqual(
+    createSchema.required,
+    ['userId', 'shiftId', 'startDate'],
+    'POST /api/attendance/assignments required list drifted',
+  )
+  assert.ok(
+    !(createSchema.required || []).includes('slotIndex'),
+    'POST assignment must not invent required slotIndex',
+  )
+})

--- a/scripts/ops/attendance-run-gate-contract-case.sh
+++ b/scripts/ops/attendance-run-gate-contract-case.sh
@@ -148,6 +148,10 @@ if [[ "$CASE_ID" == "openapi" ]]; then
     packages/openapi/dist/openapi.json \
     packages/openapi/src/paths/attendance.yml >"${openapi_dir}/validate.log"
 
+  info "running openapi attendance #4556 parity contract"
+  node --test ./scripts/ops/attendance-openapi-parity-4556-contract.test.mjs \
+    >"${openapi_dir}/parity-4556.log"
+
   invalid_openapi="${openapi_dir}/openapi.invalid.json"
   jq 'del(.paths["/api/attendance/import/commit-async"])' \
     packages/openapi/dist/openapi.json >"${invalid_openapi}"

--- a/scripts/ops/attendance-strict-import-advanced-contract.test.mjs
+++ b/scripts/ops/attendance-strict-import-advanced-contract.test.mjs
@@ -80,3 +80,15 @@ test('required strict contract case executes this verifier contract', () => {
 
   assert.match(strictCase, /node --test \.\/scripts\/ops\/attendance-strict-import-advanced-contract\.test\.mjs/)
 })
+
+test('required openapi contract case executes attendance runtime-parity contract', () => {
+  const openapiCase = gateContractRunner.slice(
+    gateContractRunner.indexOf('if [[ "$CASE_ID" == "openapi" ]]'),
+    gateContractRunner.indexOf('if [[ "$CASE_ID" == "dashboard" ]]'),
+  )
+
+  assert.match(
+    openapiCase,
+    /node --test \.\/scripts\/ops\/attendance-openapi-parity-4556-contract\.test\.mjs/,
+  )
+})


### PR DESCRIPTION
## What changed

- Align the attendance OpenAPI source and generated artifacts with runtime fields already shipped for group type/member count, overnight shift updates, and assignment slots.
- Add a structural YAML parity contract covering response, POST, and PUT shapes without inventing new required fields.
- Wire the parity contract into the required attendance OpenAPI matrix and add an independent wiring assertion in the strict contract suite.

This is the bounded contract-parity slice for issue #4556. It changes no attendance runtime, calculation, migration, authorization, or UI behavior, and does not close the umbrella issue.

## Verification

- `bash scripts/ops/attendance-run-gate-contract-case.sh openapi /tmp/codex-attendance-4556-openapi-gate`
- `node --test scripts/ops/attendance-strict-import-advanced-contract.test.mjs`
- `git diff --check`
- Mutation evidence: removing the group enum value, assignment max=2, shift PUT isOvernight, or required-gate invocation makes the corresponding test fail.

## Review provenance

Grok produced the initial bounded edit and tests. Codex independently compared every field to current runtime code, corrected Node compatibility and schema-bound issues, added generated/source parity, strengthened CI wiring, and reran the gates above.