### PR TITLE
feat(attendance): add effective calculation group membership

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -317,6 +317,10 @@ jobs:
           name: install-log-${{ matrix.node-version }}
           path: install.log
 
+      - name: Run attendance calculation-group W1 contract
+        run: |
+          node --test scripts/ops/attendance-calculation-group-membership-w1-contract.test.mjs
+
       - name: Run linting
         if: matrix.node-version == '20.x'
         run: |
@@ -879,6 +883,7 @@ jobs:
             tests/integration/attendance-w4pre1d-departure-candidate-split.db.test.ts \
             tests/integration/attendance-setup-readiness-w4-0.db.test.ts \
             tests/integration/attendance-decision-trace-w5-0.db.test.ts \
+            tests/integration/attendance-calculation-group-membership-w1.db.test.ts \
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "openapi:validate": "pnpm --filter @metasheet/openapi validate",
     "openapi:generate:sdk": "pnpm --filter @metasheet/openapi generate:sdk",
     "openapi:guard": "pnpm --filter @metasheet/openapi generate:sdk && pnpm --filter @metasheet/openapi guard:codegen",
+    "verify:attendance-calculation-group-membership:w1": "node --test scripts/ops/attendance-calculation-group-membership-w1-contract.test.mjs",
     "verify:multitable-yjs:contract": "node --test scripts/ops/multitable-yjs-contract-parity.test.mjs",
     "ops:multitable-dangling-link-sweep": "node scripts/ops/multitable-dangling-link-sweep.mjs",
     "verify:multitable-release:phase3": "node scripts/ops/multitable-phase3-release-gate.mjs --gate release:phase3",

--- a/packages/core-backend/src/db/migrations/zzzz20260723140000_create_attendance_calculation_group_memberships.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260723140000_create_attendance_calculation_group_memberships.ts
@@ -1,0 +1,198 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+const GROUP_ORG_UNIQUE = 'attendance_groups_id_org_unique'
+const MEMBERSHIP_USER_ORG_TRIGGER = 'attendance_calculation_group_memberships_user_org_guard'
+const MEMBERSHIP_USER_ORG_FUNCTION = 'guard_attendance_calculation_group_membership_user_org'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+  await sql`CREATE EXTENSION IF NOT EXISTS btree_gist`.execute(db)
+
+  await sql.raw(`
+    DO $$ BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conname = '${GROUP_ORG_UNIQUE}'
+           AND conrelid = 'attendance_groups'::regclass
+      ) THEN
+        ALTER TABLE attendance_groups
+          ADD CONSTRAINT attendance_groups_id_org_unique UNIQUE (id, org_id);
+      END IF;
+    END $$;
+  `).execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS attendance_calculation_group_memberships (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      org_id text NOT NULL,
+      user_id text NOT NULL,
+      group_id uuid NOT NULL,
+      effective_from date NOT NULL,
+      effective_to date,
+      assigned_by text NOT NULL,
+      assigned_reason text NOT NULL,
+      assigned_correlation_id text NOT NULL,
+      closed_by text,
+      closed_reason text,
+      closed_correlation_id text,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT attendance_calc_group_membership_id_org_unique
+        UNIQUE (id, org_id),
+      CONSTRAINT attendance_calc_group_membership_dates_valid
+        CHECK (effective_to IS NULL OR effective_to >= effective_from),
+      CONSTRAINT attendance_calc_group_membership_assignment_audit_valid
+        CHECK (
+          btrim(assigned_by) <> ''
+          AND btrim(assigned_reason) <> ''
+          AND btrim(assigned_correlation_id) <> ''
+        ),
+      CONSTRAINT attendance_calc_group_membership_close_audit_valid
+        CHECK (
+          (closed_by IS NULL AND closed_reason IS NULL AND closed_correlation_id IS NULL)
+          OR (
+            closed_by IS NOT NULL
+            AND closed_reason IS NOT NULL
+            AND closed_correlation_id IS NOT NULL
+            AND btrim(closed_by) <> ''
+            AND btrim(closed_reason) <> ''
+            AND btrim(closed_correlation_id) <> ''
+          )
+        ),
+      CONSTRAINT attendance_calc_group_membership_group_org_fk
+        FOREIGN KEY (group_id, org_id)
+        REFERENCES attendance_groups(id, org_id)
+        ON DELETE RESTRICT
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_attendance_calc_group_memberships_timeline
+      ON attendance_calculation_group_memberships(org_id, user_id, effective_from)
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_attendance_calc_group_memberships_group
+      ON attendance_calculation_group_memberships(org_id, group_id)
+  `.execute(db)
+
+  await sql`
+    DO $$ BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conname = 'attendance_calc_group_memberships_no_overlap'
+           AND conrelid = 'attendance_calculation_group_memberships'::regclass
+      ) THEN
+        ALTER TABLE attendance_calculation_group_memberships
+          ADD CONSTRAINT attendance_calc_group_memberships_no_overlap
+          EXCLUDE USING gist (
+            org_id WITH =,
+            user_id WITH =,
+            daterange(
+              effective_from,
+              COALESCE(effective_to, 'infinity'::date),
+              '[]'
+            ) WITH &&
+          );
+      END IF;
+    END $$;
+  `.execute(db)
+
+  // The trigger validates direct SQL writes without tying historical rows to the
+  // lifecycle of user_orgs through a foreign key.
+  await sql.raw(`
+    CREATE OR REPLACE FUNCTION ${MEMBERSHIP_USER_ORG_FUNCTION}()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      PERFORM 1
+        FROM users u
+        JOIN user_orgs uo
+          ON uo.user_id = u.id
+         AND uo.org_id = NEW.org_id
+       WHERE u.id = NEW.user_id
+         AND u.is_active = true
+         AND uo.is_active = true
+       FOR UPDATE OF u, uo;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'active user and org membership required'
+          USING ERRCODE = '23503',
+                CONSTRAINT = 'attendance_calc_group_membership_user_org_required';
+      END IF;
+      RETURN NEW;
+    END;
+    $$;
+  `).execute(db)
+  await sql.raw(`
+    DROP TRIGGER IF EXISTS ${MEMBERSHIP_USER_ORG_TRIGGER}
+      ON attendance_calculation_group_memberships;
+    CREATE TRIGGER ${MEMBERSHIP_USER_ORG_TRIGGER}
+      BEFORE INSERT OR UPDATE OF org_id, user_id, group_id, effective_from, effective_to
+      ON attendance_calculation_group_memberships
+      FOR EACH ROW
+      EXECUTE FUNCTION ${MEMBERSHIP_USER_ORG_FUNCTION}();
+  `).execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS attendance_calculation_group_membership_operations (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      org_id text NOT NULL,
+      correlation_id text NOT NULL,
+      user_id text NOT NULL,
+      target_group_id uuid NOT NULL,
+      effective_on date NOT NULL,
+      actor_id text NOT NULL,
+      reason text NOT NULL,
+      result_membership_id uuid NOT NULL,
+      result_snapshot jsonb NOT NULL,
+      outcome text NOT NULL
+        CHECK (outcome IN ('transitioned', 'unchanged')),
+      created_at timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT attendance_calc_group_membership_operation_audit_valid
+        CHECK (
+          btrim(correlation_id) <> ''
+          AND btrim(actor_id) <> ''
+          AND btrim(reason) <> ''
+        ),
+      CONSTRAINT attendance_calc_group_membership_operation_snapshot_valid
+        CHECK (jsonb_typeof(result_snapshot) = 'object'),
+      CONSTRAINT attendance_calc_group_membership_operation_group_org_fk
+        FOREIGN KEY (target_group_id, org_id)
+        REFERENCES attendance_groups(id, org_id)
+        ON DELETE RESTRICT,
+      CONSTRAINT attendance_calc_group_membership_operation_result_org_fk
+        FOREIGN KEY (result_membership_id, org_id)
+        REFERENCES attendance_calculation_group_memberships(id, org_id)
+        ON DELETE RESTRICT,
+      CONSTRAINT attendance_calc_group_membership_operations_correlation_unique
+        UNIQUE (org_id, correlation_id)
+    )
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_attendance_calc_group_membership_operations_user
+      ON attendance_calculation_group_membership_operations(org_id, user_id, created_at)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .dropTable('attendance_calculation_group_membership_operations')
+    .ifExists()
+    .execute()
+  await sql.raw(`
+    DROP TRIGGER IF EXISTS ${MEMBERSHIP_USER_ORG_TRIGGER}
+      ON attendance_calculation_group_memberships
+  `).execute(db)
+  await db.schema
+    .dropTable('attendance_calculation_group_memberships')
+    .ifExists()
+    .execute()
+  await sql.raw(`DROP FUNCTION IF EXISTS ${MEMBERSHIP_USER_ORG_FUNCTION}()`).execute(db)
+  await sql`
+    ALTER TABLE attendance_groups
+      DROP CONSTRAINT IF EXISTS attendance_groups_id_org_unique
+  `.execute(db)
+}

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -39,8 +39,17 @@ import {
   type AttendanceDecisionTraceResponse,
   type AttendanceDecisionTraceSettingsGates,
 } from '../services/AttendanceDecisionTrace'
+import {
+  AttendanceCalculationGroupMembershipError,
+  listAttendanceCalculationGroupMemberships,
+  transitionAttendanceCalculationGroupMembership,
+} from '../services/AttendanceCalculationGroupMembership'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function readStrictString(value: unknown): string | null {
+  return typeof value === 'string' ? value.trim() : null
+}
 
 type AttendanceRoleTemplateId = 'employee' | 'approver' | 'importer' | 'admin'
 
@@ -530,6 +539,119 @@ export function attendanceAdminRouter(): Router {
     } catch (_error) {
       // Values-free seam: never leak raw DB / driver messages to the client.
       return jsonError(res, 500, 'DIRECTORY_READINESS_FAILED', 'Failed to load directory readiness')
+    }
+  })
+
+  r.get('/api/attendance-admin/calculation-group-memberships', async (req: Request, res: Response) => {
+    try {
+      const orgId = readStrictString(req.query.orgId)
+      const targetUserId = readStrictString(req.query.userId)
+      if (!orgId) {
+        return jsonError(res, 400, 'ORG_ID_REQUIRED', 'orgId is required')
+      }
+      if (!targetUserId) {
+        return jsonError(res, 400, 'USER_ID_REQUIRED', 'userId is required')
+      }
+      const actorId = getAttendanceAdminRequestUserId(req)
+      if (!actorId) {
+        return jsonError(res, 401, 'UNAUTHENTICATED', 'Authentication required')
+      }
+      const allowed = await canReadAttendanceDirectoryReadiness(req, actorId, orgId)
+      if (!allowed) {
+        return jsonError(res, 403, 'FORBIDDEN', 'Org membership required for calculation-group membership')
+      }
+      const items = await listAttendanceCalculationGroupMemberships(orgId, targetUserId)
+      return jsonOk(res, { items })
+    } catch (error) {
+      if (error instanceof AttendanceCalculationGroupMembershipError) {
+        return jsonError(res, error.status, error.code, error.message)
+      }
+      if (isDatabaseSchemaError(error)) {
+        return jsonError(res, 503, 'DB_NOT_READY', 'Attendance calculation-group membership tables not ready')
+      }
+      return jsonError(
+        res,
+        500,
+        'CALCULATION_GROUP_MEMBERSHIP_LIST_FAILED',
+        'Failed to load calculation-group membership timeline',
+      )
+    }
+  })
+
+  r.post('/api/attendance-admin/calculation-group-memberships/transition', async (req: Request, res: Response) => {
+    try {
+      const body =
+        req.body && typeof req.body === 'object'
+          ? (req.body as Record<string, unknown>)
+          : {}
+      const orgId = readStrictString(body.orgId)
+      const targetUserId = readStrictString(body.userId)
+      const targetGroupId = readStrictString(body.targetGroupId)
+      const effectiveOn = readStrictString(body.effectiveOn)
+      const reason = readStrictString(body.reason)
+      const suppliedCorrelationId =
+        body.correlationId === undefined
+          ? undefined
+          : readStrictString(body.correlationId)
+      if (!orgId) {
+        return jsonError(res, 400, 'ORG_ID_REQUIRED', 'orgId is required')
+      }
+      if (!targetUserId) {
+        return jsonError(res, 400, 'USER_ID_REQUIRED', 'userId is required')
+      }
+      if (!targetGroupId) {
+        return jsonError(res, 400, 'TARGET_GROUP_ID_REQUIRED', 'targetGroupId is required')
+      }
+      if (!UUID_RE.test(targetGroupId)) {
+        return jsonError(res, 400, 'TARGET_GROUP_ID_INVALID', 'targetGroupId must be a UUID')
+      }
+      if (!effectiveOn) {
+        return jsonError(res, 400, 'EFFECTIVE_ON_REQUIRED', 'effectiveOn is required')
+      }
+      if (!reason) {
+        return jsonError(res, 400, 'REASON_REQUIRED', 'reason is required')
+      }
+      if (body.correlationId !== undefined && !suppliedCorrelationId) {
+        return jsonError(
+          res,
+          400,
+          'CORRELATION_ID_INVALID',
+          'correlationId must be a non-empty string when provided',
+        )
+      }
+      const actorId = getAttendanceAdminRequestUserId(req)
+      if (!actorId) {
+        return jsonError(res, 401, 'UNAUTHENTICATED', 'Authentication required')
+      }
+      const allowed = await canReadAttendanceDirectoryReadiness(req, actorId, orgId)
+      if (!allowed) {
+        return jsonError(res, 403, 'FORBIDDEN', 'Org membership required for calculation-group transition')
+      }
+
+      const result = await transitionAttendanceCalculationGroupMembership({
+        orgId,
+        userId: targetUserId,
+        targetGroupId,
+        effectiveOn,
+        actorId,
+        reason,
+        correlationId: suppliedCorrelationId || req.correlationId,
+      })
+      res.setHeader('X-Correlation-Id', result.correlationId)
+      return jsonOk(res, result)
+    } catch (error) {
+      if (error instanceof AttendanceCalculationGroupMembershipError) {
+        return jsonError(res, error.status, error.code, error.message)
+      }
+      if (isDatabaseSchemaError(error)) {
+        return jsonError(res, 503, 'DB_NOT_READY', 'Attendance calculation-group membership tables not ready')
+      }
+      return jsonError(
+        res,
+        500,
+        'CALCULATION_GROUP_MEMBERSHIP_TRANSITION_FAILED',
+        'Failed to transition calculation-group membership',
+      )
     }
   })
 

--- a/packages/core-backend/src/services/AttendanceCalculationGroupMembership.ts
+++ b/packages/core-backend/src/services/AttendanceCalculationGroupMembership.ts
@@ -1,0 +1,550 @@
+import { randomUUID } from 'node:crypto'
+import type { QueryResult, QueryResultRow } from 'pg'
+import { query, transaction } from '../db/pg'
+
+export const ATTENDANCE_CALCULATION_GROUP_MEMBERSHIP_OVERLAP =
+  'ATTENDANCE_CALCULATION_GROUP_MEMBERSHIP_OVERLAP'
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const MAX_CORRELATION_ID_LENGTH = 128
+const MAX_REASON_LENGTH = 1000
+
+type QueryExecutor = (
+  statement: string,
+  params?: unknown[],
+) => Promise<QueryResult<QueryResultRow>>
+
+type MembershipRow = {
+  id: string
+  org_id: string
+  user_id: string
+  group_id: string
+  effective_from: string
+  effective_to: string | null
+  assigned_by: string
+  assigned_reason: string
+  assigned_correlation_id: string
+  closed_by: string | null
+  closed_reason: string | null
+  closed_correlation_id: string | null
+  created_at: string | Date
+  updated_at: string | Date
+}
+
+type OperationRow = {
+  org_id: string
+  correlation_id: string
+  user_id: string
+  target_group_id: string
+  effective_on: string
+  actor_id: string
+  reason: string
+  result_membership_id: string
+  result_snapshot: unknown
+  outcome: AttendanceCalculationGroupMembershipTransitionOutcome
+}
+
+export type AttendanceCalculationGroupMembershipTransitionOutcome =
+  | 'transitioned'
+  | 'unchanged'
+
+export interface AttendanceCalculationGroupMembership {
+  id: string
+  orgId: string
+  userId: string
+  groupId: string
+  effectiveFrom: string
+  effectiveTo: string | null
+  assignedBy: string
+  assignedReason: string
+  assignedCorrelationId: string
+  closedBy: string | null
+  closedReason: string | null
+  closedCorrelationId: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface TransitionAttendanceCalculationGroupMembershipInput {
+  orgId: string
+  userId: string
+  targetGroupId: string
+  effectiveOn: string
+  actorId: string
+  reason: string
+  correlationId?: string
+}
+
+export interface TransitionAttendanceCalculationGroupMembershipResult {
+  correlationId: string
+  outcome: AttendanceCalculationGroupMembershipTransitionOutcome
+  membership: AttendanceCalculationGroupMembership
+}
+
+export class AttendanceCalculationGroupMembershipError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'AttendanceCalculationGroupMembershipError'
+  }
+}
+
+function asDateString(value: unknown): string {
+  if (value instanceof Date) {
+    const year = String(value.getFullYear()).padStart(4, '0')
+    const month = String(value.getMonth() + 1).padStart(2, '0')
+    const day = String(value.getDate()).padStart(2, '0')
+    return `${year}-${month}-${day}`
+  }
+  return String(value)
+}
+
+function asIsoString(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : String(value)
+}
+
+function mapMembership(row: MembershipRow): AttendanceCalculationGroupMembership {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    userId: row.user_id,
+    groupId: row.group_id,
+    effectiveFrom: asDateString(row.effective_from),
+    effectiveTo: row.effective_to == null ? null : asDateString(row.effective_to),
+    assignedBy: row.assigned_by,
+    assignedReason: row.assigned_reason,
+    assignedCorrelationId: row.assigned_correlation_id,
+    closedBy: row.closed_by,
+    closedReason: row.closed_reason,
+    closedCorrelationId: row.closed_correlation_id,
+    createdAt: asIsoString(row.created_at),
+    updatedAt: asIsoString(row.updated_at),
+  }
+}
+
+function requireText(
+  value: string,
+  code: string,
+  field: string,
+  maxLength?: number,
+): string {
+  const normalized = value.trim()
+  if (!normalized) {
+    throw new AttendanceCalculationGroupMembershipError(code, 400, `${field} is required`)
+  }
+  if (maxLength && normalized.length > maxLength) {
+    throw new AttendanceCalculationGroupMembershipError(
+      code,
+      400,
+      `${field} must be at most ${maxLength} characters`,
+    )
+  }
+  return normalized
+}
+
+function normalizeUuid(value: string, code: string, field: string): string {
+  const normalized = requireText(value, code, field)
+  if (!UUID_RE.test(normalized)) {
+    throw new AttendanceCalculationGroupMembershipError(
+      code,
+      400,
+      `${field} must be a UUID`,
+    )
+  }
+  return normalized.toLowerCase()
+}
+
+export function normalizeAttendanceMembershipDate(value: string): string {
+  const normalized = value.trim()
+  if (!DATE_RE.test(normalized)) {
+    throw new AttendanceCalculationGroupMembershipError(
+      'EFFECTIVE_ON_INVALID',
+      400,
+      'effectiveOn must be a calendar date in YYYY-MM-DD format',
+    )
+  }
+  const [year, month, day] = normalized.split('-').map(Number)
+  const date = new Date(Date.UTC(year, month - 1, day))
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    throw new AttendanceCalculationGroupMembershipError(
+      'EFFECTIVE_ON_INVALID',
+      400,
+      'effectiveOn must be a valid calendar date',
+    )
+  }
+  return normalized
+}
+
+function previousCalendarDate(value: string): string {
+  const date = new Date(`${value}T00:00:00.000Z`)
+  date.setUTCDate(date.getUTCDate() - 1)
+  return date.toISOString().slice(0, 10)
+}
+
+function isOverlapError(error: unknown): boolean {
+  const candidate = error as { code?: string; constraint?: string }
+  return (
+    candidate?.code === '23P01' &&
+    candidate?.constraint === 'attendance_calc_group_memberships_no_overlap'
+  )
+}
+
+function assertTimelineIntegrity(rows: MembershipRow[]): void {
+  for (let index = 0; index < rows.length; index += 1) {
+    const current = rows[index]
+    const from = asDateString(current.effective_from)
+    const to = current.effective_to == null ? null : asDateString(current.effective_to)
+    if (to && to < from) {
+      throw new AttendanceCalculationGroupMembershipError(
+        'ATTENDANCE_CALCULATION_GROUP_TIMELINE_CORRUPT',
+        409,
+        'Calculation-group membership timeline contains an invalid interval',
+      )
+    }
+    const next = rows[index + 1]
+    if (next && (to == null || to >= asDateString(next.effective_from))) {
+      throw new AttendanceCalculationGroupMembershipError(
+        'ATTENDANCE_CALCULATION_GROUP_TIMELINE_CORRUPT',
+        409,
+        'Calculation-group membership timeline contains overlapping intervals',
+      )
+    }
+  }
+}
+
+function operationMatches(
+  operation: OperationRow,
+  input: Required<TransitionAttendanceCalculationGroupMembershipInput>,
+): boolean {
+  return (
+    operation.org_id === input.orgId &&
+    operation.user_id === input.userId &&
+    operation.target_group_id === input.targetGroupId &&
+    asDateString(operation.effective_on) === input.effectiveOn &&
+    operation.actor_id === input.actorId &&
+    operation.reason === input.reason &&
+    operation.correlation_id === input.correlationId
+  )
+}
+
+function readOperationSnapshot(value: unknown): AttendanceCalculationGroupMembership {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new AttendanceCalculationGroupMembershipError(
+      'ATTENDANCE_CALCULATION_GROUP_TIMELINE_CORRUPT',
+      409,
+      'Idempotency record contains an invalid membership snapshot',
+    )
+  }
+  const snapshot = value as Partial<AttendanceCalculationGroupMembership>
+  const requiredText = [
+    snapshot.id,
+    snapshot.orgId,
+    snapshot.userId,
+    snapshot.groupId,
+    snapshot.effectiveFrom,
+    snapshot.assignedBy,
+    snapshot.assignedReason,
+    snapshot.assignedCorrelationId,
+    snapshot.createdAt,
+    snapshot.updatedAt,
+  ]
+  if (requiredText.some((entry) => typeof entry !== 'string' || !entry)) {
+    throw new AttendanceCalculationGroupMembershipError(
+      'ATTENDANCE_CALCULATION_GROUP_TIMELINE_CORRUPT',
+      409,
+      'Idempotency record contains an incomplete membership snapshot',
+    )
+  }
+  return snapshot as AttendanceCalculationGroupMembership
+}
+
+async function readMembershipById(
+  runQuery: QueryExecutor,
+  orgId: string,
+  membershipId: string,
+): Promise<MembershipRow | null> {
+  const result = await runQuery(
+    `SELECT *
+       FROM attendance_calculation_group_memberships
+      WHERE org_id = $1 AND id = $2`,
+    [orgId, membershipId],
+  )
+  return (result.rows[0] as MembershipRow | undefined) ?? null
+}
+
+export async function listAttendanceCalculationGroupMemberships(
+  orgIdInput: string,
+  userIdInput: string,
+  runQuery: QueryExecutor = query,
+): Promise<AttendanceCalculationGroupMembership[]> {
+  const orgId = requireText(orgIdInput, 'ORG_ID_REQUIRED', 'orgId')
+  const userId = requireText(userIdInput, 'USER_ID_REQUIRED', 'userId')
+  const result = await runQuery(
+    `SELECT *
+       FROM attendance_calculation_group_memberships
+      WHERE org_id = $1 AND user_id = $2
+      ORDER BY effective_from ASC, id ASC`,
+    [orgId, userId],
+  )
+  const rows = result.rows as MembershipRow[]
+  assertTimelineIntegrity(rows)
+  return rows.map(mapMembership)
+}
+
+export async function transitionAttendanceCalculationGroupMembership(
+  rawInput: TransitionAttendanceCalculationGroupMembershipInput,
+): Promise<TransitionAttendanceCalculationGroupMembershipResult> {
+  const input: Required<TransitionAttendanceCalculationGroupMembershipInput> = {
+    orgId: requireText(rawInput.orgId, 'ORG_ID_REQUIRED', 'orgId'),
+    userId: requireText(rawInput.userId, 'USER_ID_REQUIRED', 'userId'),
+    targetGroupId: normalizeUuid(
+      rawInput.targetGroupId,
+      'TARGET_GROUP_ID_INVALID',
+      'targetGroupId',
+    ),
+    effectiveOn: normalizeAttendanceMembershipDate(rawInput.effectiveOn),
+    actorId: requireText(rawInput.actorId, 'ACTOR_ID_REQUIRED', 'actorId'),
+    reason: requireText(
+      rawInput.reason,
+      'REASON_REQUIRED',
+      'reason',
+      MAX_REASON_LENGTH,
+    ),
+    correlationId: requireText(
+      rawInput.correlationId || randomUUID(),
+      'CORRELATION_ID_INVALID',
+      'correlationId',
+      MAX_CORRELATION_ID_LENGTH,
+    ),
+  }
+
+  try {
+    return await transaction(async (client) => {
+      const runQuery = client.query as QueryExecutor
+
+      await runQuery(
+        `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+        [`attendance-calc-operation\u001f${input.orgId}\u001f${input.correlationId}`],
+      )
+
+      const operationResult = await runQuery(
+        `SELECT org_id, correlation_id, user_id, target_group_id, effective_on,
+                actor_id, reason, result_membership_id, result_snapshot, outcome
+           FROM attendance_calculation_group_membership_operations
+          WHERE org_id = $1 AND correlation_id = $2
+          FOR UPDATE`,
+        [input.orgId, input.correlationId],
+      )
+      const existingOperation = operationResult.rows[0] as OperationRow | undefined
+      if (existingOperation) {
+        if (!operationMatches(existingOperation, input)) {
+          throw new AttendanceCalculationGroupMembershipError(
+            'CORRELATION_ID_REUSED',
+            409,
+            'correlationId was already used with a different transition payload',
+          )
+        }
+        const membership = await readMembershipById(
+          runQuery,
+          input.orgId,
+          existingOperation.result_membership_id,
+        )
+        if (!membership) {
+          throw new AttendanceCalculationGroupMembershipError(
+            'ATTENDANCE_CALCULATION_GROUP_TIMELINE_CORRUPT',
+            409,
+            'Idempotency record points to a missing membership',
+          )
+        }
+        return {
+          correlationId: input.correlationId,
+          outcome: existingOperation.outcome,
+          membership: readOperationSnapshot(existingOperation.result_snapshot),
+        }
+      }
+
+      await runQuery(
+        `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+        [`attendance-calc-timeline\u001f${input.orgId}\u001f${input.userId}`],
+      )
+
+      const targetGroup = await runQuery(
+        `SELECT id
+           FROM attendance_groups
+          WHERE id = $1 AND org_id = $2`,
+        [input.targetGroupId, input.orgId],
+      )
+      if (targetGroup.rows.length === 0) {
+        throw new AttendanceCalculationGroupMembershipError(
+          'TARGET_GROUP_NOT_FOUND',
+          404,
+          'No calculation group exists in the requested organization',
+        )
+      }
+
+      const timelineResult = await runQuery(
+        `SELECT *
+           FROM attendance_calculation_group_memberships
+          WHERE org_id = $1 AND user_id = $2
+          ORDER BY effective_from ASC, id ASC
+          FOR UPDATE`,
+        [input.orgId, input.userId],
+      )
+      const timeline = timelineResult.rows as MembershipRow[]
+      assertTimelineIntegrity(timeline)
+
+      // Lock order is timeline -> lifecycle rows. A direct semantic UPDATE already
+      // owns its membership tuple before the DB trigger locks users/user_orgs, so
+      // taking these locks in the opposite order would create a mixed-writer deadlock.
+      const activeUser = await runQuery(
+        `SELECT 1
+           FROM users u
+           JOIN user_orgs uo
+             ON uo.user_id = u.id
+            AND uo.org_id = $2
+          WHERE u.id = $1
+            AND u.is_active = true
+            AND uo.is_active = true
+          LIMIT 1
+          FOR UPDATE OF u, uo`,
+        [input.userId, input.orgId],
+      )
+      if (activeUser.rows.length === 0) {
+        throw new AttendanceCalculationGroupMembershipError(
+          'ACTIVE_ORG_USER_REQUIRED',
+          422,
+          'Target user must be active in the requested organization',
+        )
+      }
+
+      const current = timeline.find((row) => {
+        const from = asDateString(row.effective_from)
+        const to = row.effective_to == null ? null : asDateString(row.effective_to)
+        return from <= input.effectiveOn && (to == null || to >= input.effectiveOn)
+      })
+
+      if (current?.group_id === input.targetGroupId) {
+        const membership = mapMembership(current)
+        await runQuery(
+          `INSERT INTO attendance_calculation_group_membership_operations (
+             org_id, correlation_id, user_id, target_group_id, effective_on,
+             actor_id, reason, result_membership_id, result_snapshot, outcome
+           ) VALUES ($1, $2, $3, $4, $5::date, $6, $7, $8, $9::jsonb, 'unchanged')`,
+          [
+            input.orgId,
+            input.correlationId,
+            input.userId,
+            input.targetGroupId,
+            input.effectiveOn,
+            input.actorId,
+            input.reason,
+            current.id,
+            JSON.stringify(membership),
+          ],
+        )
+        return {
+          correlationId: input.correlationId,
+          outcome: 'unchanged',
+          membership,
+        }
+      }
+
+      if (current && asDateString(current.effective_from) === input.effectiveOn) {
+        throw new AttendanceCalculationGroupMembershipError(
+          'ATTENDANCE_CALCULATION_GROUP_TRANSITION_IMPOSSIBLE',
+          409,
+          'A different membership already begins on effectiveOn; it cannot be replaced without deleting history',
+        )
+      }
+
+      const next = timeline.find(
+        (row) => asDateString(row.effective_from) > input.effectiveOn,
+      )
+      const targetEffectiveTo = next
+        ? previousCalendarDate(asDateString(next.effective_from))
+        : null
+
+      if (current) {
+        await runQuery(
+          `UPDATE attendance_calculation_group_memberships
+              SET effective_to = ($3::date - 1),
+                  closed_by = $4,
+                  closed_reason = $5,
+                  closed_correlation_id = $6,
+                  updated_at = now()
+            WHERE id = $1 AND org_id = $2`,
+          [
+            current.id,
+            input.orgId,
+            input.effectiveOn,
+            input.actorId,
+            input.reason,
+            input.correlationId,
+          ],
+        )
+      }
+
+      const inserted = await runQuery(
+        `INSERT INTO attendance_calculation_group_memberships (
+           org_id, user_id, group_id, effective_from, effective_to,
+           assigned_by, assigned_reason, assigned_correlation_id
+         ) VALUES ($1, $2, $3, $4::date, $5::date, $6, $7, $8)
+         RETURNING *`,
+        [
+          input.orgId,
+          input.userId,
+          input.targetGroupId,
+          input.effectiveOn,
+          targetEffectiveTo,
+          input.actorId,
+          input.reason,
+          input.correlationId,
+        ],
+      )
+      const membership = inserted.rows[0] as MembershipRow
+      const membershipSnapshot = mapMembership(membership)
+
+      await runQuery(
+        `INSERT INTO attendance_calculation_group_membership_operations (
+           org_id, correlation_id, user_id, target_group_id, effective_on,
+           actor_id, reason, result_membership_id, result_snapshot, outcome
+         ) VALUES ($1, $2, $3, $4, $5::date, $6, $7, $8, $9::jsonb, 'transitioned')`,
+        [
+          input.orgId,
+          input.correlationId,
+          input.userId,
+          input.targetGroupId,
+          input.effectiveOn,
+          input.actorId,
+          input.reason,
+          membership.id,
+          JSON.stringify(membershipSnapshot),
+        ],
+      )
+
+      return {
+        correlationId: input.correlationId,
+        outcome: 'transitioned',
+        membership: membershipSnapshot,
+      }
+    })
+  } catch (error) {
+    if (error instanceof AttendanceCalculationGroupMembershipError) throw error
+    if (isOverlapError(error)) {
+      throw new AttendanceCalculationGroupMembershipError(
+        ATTENDANCE_CALCULATION_GROUP_MEMBERSHIP_OVERLAP,
+        409,
+        'Calculation-group membership overlaps an existing effective interval',
+      )
+    }
+    throw error
+  }
+}

--- a/packages/core-backend/tests/integration/attendance-calculation-group-membership-w1.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-calculation-group-membership-w1.db.test.ts
@@ -1,0 +1,696 @@
+import { randomUUID } from 'node:crypto'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Kysely, PostgresDialect } from 'kysely'
+import { Pool } from 'pg'
+import {
+  AttendanceCalculationGroupMembershipError,
+  listAttendanceCalculationGroupMemberships,
+  transitionAttendanceCalculationGroupMembership,
+} from '../../src/services/AttendanceCalculationGroupMembership'
+import {
+  down as membershipMigrationDown,
+  up as membershipMigrationUp,
+} from '../../src/db/migrations/zzzz20260723140000_create_attendance_calculation_group_memberships'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+describeIfDatabase('W1 effective calculation-group membership (real DB)', () => {
+  const pool = new Pool({ connectionString: dbUrl })
+  const suffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+  const orgA = `calc-w1-a-${suffix}`
+  const orgB = `calc-w1-b-${suffix}`
+  const actorId = `calc-w1-actor-${suffix}`
+  const userId = `calc-w1-user-${suffix}`
+  const futureUserId = `calc-w1-future-${suffix}`
+  const raceUserId = `calc-w1-race-${suffix}`
+  const lifecycleUserId = `calc-w1-lifecycle-${suffix}`
+  const mixedWriterUserId = `calc-w1-mixed-writer-${suffix}`
+  const uuidUserId = `calc-w1-uuid-${suffix}`
+  const inactiveUserId = `calc-w1-inactive-${suffix}`
+  const groupA = randomUUID()
+  const groupB = randomUUID()
+  const groupC = randomUUID()
+  const foreignGroup = randomUUID()
+  const userIds = [
+    actorId,
+    userId,
+    futureUserId,
+    raceUserId,
+    lifecycleUserId,
+    mixedWriterUserId,
+    uuidUserId,
+    inactiveUserId,
+  ]
+  const groupIds = [groupA, groupB, groupC, foreignGroup]
+
+  beforeAll(async () => {
+    if (!dbUrl) throw new Error('DATABASE_URL / ATTENDANCE_TEST_DATABASE_URL is required')
+
+    for (const [id, active] of [
+      [actorId, true],
+      [userId, true],
+      [futureUserId, true],
+      [raceUserId, true],
+      [lifecycleUserId, true],
+      [mixedWriterUserId, true],
+      [uuidUserId, true],
+      [inactiveUserId, false],
+    ] as const) {
+      await pool.query(
+        `INSERT INTO users (
+           id, email, username, name, password_hash, role, permissions,
+           is_active, is_admin, created_at, updated_at
+         ) VALUES ($1, $2, $1, 'Fixture', 'x', 'user', '[]'::jsonb, $3, false, now(), now())`,
+        [id, `${id}@example.test`, active],
+      )
+    }
+    for (const id of [
+      actorId,
+      userId,
+      futureUserId,
+      raceUserId,
+      lifecycleUserId,
+      mixedWriterUserId,
+      uuidUserId,
+    ]) {
+      await pool.query(
+        `INSERT INTO user_orgs (user_id, org_id, is_active)
+         VALUES ($1, $2, true)`,
+        [id, orgA],
+      )
+    }
+    await pool.query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active)
+       VALUES ($1, $2, true)`,
+      [futureUserId, orgB],
+    )
+    await pool.query(
+      `INSERT INTO user_orgs (user_id, org_id, is_active)
+       VALUES ($1, $2, false)`,
+      [inactiveUserId, orgA],
+    )
+
+    for (const [id, orgId, name] of [
+      [groupA, orgA, 'Group A'],
+      [groupB, orgA, 'Group B'],
+      [groupC, orgA, 'Group C'],
+      [foreignGroup, orgB, 'Foreign Group'],
+    ]) {
+      await pool.query(
+        `INSERT INTO attendance_groups (
+           id, org_id, name, code, timezone, created_at, updated_at
+         ) VALUES ($1, $2, $3, $4, 'UTC', now(), now())`,
+        [id, orgId, `${name} ${suffix}`, `${name.replaceAll(' ', '-').toLowerCase()}-${suffix}`],
+      )
+    }
+  })
+
+  it('replays the migration down/up path and a second up without schema drift', async () => {
+    const migrationPool = new Pool({ connectionString: dbUrl, max: 2 })
+    const db = new Kysely<unknown>({
+      dialect: new PostgresDialect({ pool: migrationPool }),
+    })
+    try {
+      await membershipMigrationDown(db)
+      const removed = await pool.query<{ membership: string | null; operation: string | null }>(
+        `SELECT to_regclass('attendance_calculation_group_memberships')::text AS membership,
+                to_regclass('attendance_calculation_group_membership_operations')::text AS operation`,
+      )
+      expect(removed.rows[0]).toEqual({ membership: null, operation: null })
+
+      await membershipMigrationUp(db)
+      await membershipMigrationUp(db)
+      const restored = await pool.query<{ membership: string | null; operation: string | null }>(
+        `SELECT to_regclass('attendance_calculation_group_memberships')::text AS membership,
+                to_regclass('attendance_calculation_group_membership_operations')::text AS operation`,
+      )
+      expect(restored.rows[0]).toEqual({
+        membership: 'attendance_calculation_group_memberships',
+        operation: 'attendance_calculation_group_membership_operations',
+      })
+    } finally {
+      await db.destroy()
+    }
+  })
+
+  afterAll(async () => {
+    await pool.query(
+      `DELETE FROM attendance_calculation_group_membership_operations
+        WHERE org_id = ANY($1::text[])`,
+      [[orgA, orgB]],
+    ).catch(() => undefined)
+    await pool.query(
+      `DELETE FROM attendance_calculation_group_memberships
+        WHERE org_id = ANY($1::text[])`,
+      [[orgA, orgB]],
+    ).catch(() => undefined)
+    await pool.query(
+      `DELETE FROM attendance_group_members
+        WHERE org_id = ANY($1::text[]) OR user_id = ANY($2::text[])`,
+      [[orgA, orgB], userIds],
+    ).catch(() => undefined)
+    await pool.query(
+      `DELETE FROM attendance_groups WHERE id = ANY($1::uuid[])`,
+      [groupIds],
+    ).catch(() => undefined)
+    await pool.query(
+      `DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`,
+      [userIds],
+    ).catch(() => undefined)
+    await pool.query(
+      `DELETE FROM users WHERE id = ANY($1::text[])`,
+      [userIds],
+    ).catch(() => undefined)
+    await pool.end()
+  })
+
+  it('installs inclusive non-overlap, same-org group, and active user-org database guards', async () => {
+    const constraints = await pool.query<{ conname: string }>(
+      `SELECT conname
+         FROM pg_constraint
+        WHERE conrelid = 'attendance_calculation_group_memberships'::regclass`,
+    )
+    expect(constraints.rows.map((row) => row.conname)).toEqual(
+      expect.arrayContaining([
+        'attendance_calc_group_membership_dates_valid',
+        'attendance_calc_group_membership_group_org_fk',
+        'attendance_calc_group_memberships_no_overlap',
+      ]),
+    )
+
+    await expect(
+      pool.query(
+        `INSERT INTO attendance_calculation_group_memberships (
+           org_id, user_id, group_id, effective_from, effective_to,
+           assigned_by, assigned_reason, assigned_correlation_id
+         ) VALUES ($1, $2, $3, '2026-01-01', NULL, $4, 'wrong org', 'wrong-org')`,
+        [orgA, userId, foreignGroup, actorId],
+      ),
+    ).rejects.toMatchObject({
+      code: '23503',
+      constraint: 'attendance_calc_group_membership_group_org_fk',
+    })
+
+    await expect(
+      pool.query(
+        `INSERT INTO attendance_calculation_group_memberships (
+           org_id, user_id, group_id, effective_from, effective_to,
+           assigned_by, assigned_reason, assigned_correlation_id
+         ) VALUES ($1, $2, $3, '2026-01-01', NULL, $4, 'inactive user', 'inactive-user')`,
+        [orgA, inactiveUserId, groupA, actorId],
+      ),
+    ).rejects.toMatchObject({
+      code: '23503',
+      constraint: 'attendance_calc_group_membership_user_org_required',
+    })
+
+    await pool.query(
+      `INSERT INTO attendance_calculation_group_memberships (
+         org_id, user_id, group_id, effective_from, effective_to,
+         assigned_by, assigned_reason, assigned_correlation_id
+       ) VALUES
+         ($1, $3, $4, '2030-01-01', '2030-01-31', $6, 'org A interval', 'org-a-allowed'),
+         ($2, $3, $5, '2030-01-01', '2030-01-31', $6, 'org B interval', 'org-b-allowed')`,
+      [orgA, orgB, futureUserId, groupA, foreignGroup, actorId],
+    )
+    const crossOrg = await pool.query<{ count: string }>(
+      `SELECT count(*)::text AS count
+         FROM attendance_calculation_group_memberships
+        WHERE user_id = $1 AND effective_from = '2030-01-01'`,
+      [futureUserId],
+    )
+    expect(crossOrg.rows[0]?.count).toBe('2')
+    const orgAOnly = await listAttendanceCalculationGroupMemberships(orgA, futureUserId)
+    expect(orgAOnly).toHaveLength(1)
+    expect(orgAOnly[0]).toMatchObject({
+      orgId: orgA,
+      userId: futureUserId,
+      groupId: groupA,
+    })
+    await pool.query(
+      `DELETE FROM attendance_calculation_group_memberships
+        WHERE user_id = $1 AND effective_from = '2030-01-01'`,
+      [futureUserId],
+    )
+  })
+
+  it('closes the prior inclusive interval at D-1, starts the next at D, and records audit context', async () => {
+    const legacyBefore = await pool.query<{ count: string }>(
+      `SELECT count(*)::text AS count
+         FROM attendance_group_members
+        WHERE org_id = $1 AND user_id = $2`,
+      [orgA, userId],
+    )
+    const orgMembershipBefore = await pool.query(
+      `SELECT user_id, org_id, is_active
+         FROM user_orgs
+        WHERE user_id = $1 AND org_id = $2`,
+      [userId, orgA],
+    )
+
+    const first = await transitionAttendanceCalculationGroupMembership({
+      orgId: orgA,
+      userId,
+      targetGroupId: groupA,
+      effectiveOn: '2026-01-01',
+      actorId,
+      reason: 'Initial calculation policy',
+      correlationId: `initial-${suffix}`,
+    })
+    const second = await transitionAttendanceCalculationGroupMembership({
+      orgId: orgA,
+      userId,
+      targetGroupId: groupB,
+      effectiveOn: '2026-02-01',
+      actorId,
+      reason: 'Move to February policy',
+      correlationId: `february-${suffix}`,
+    })
+
+    expect(first.membership.effectiveTo).toBeNull()
+    expect(second.membership).toMatchObject({
+      groupId: groupB,
+      effectiveFrom: '2026-02-01',
+      effectiveTo: null,
+      assignedBy: actorId,
+      assignedReason: 'Move to February policy',
+      assignedCorrelationId: `february-${suffix}`,
+    })
+
+    const timeline = await pool.query(
+      `SELECT group_id, effective_from::text, effective_to::text,
+              closed_by, closed_reason, closed_correlation_id
+         FROM attendance_calculation_group_memberships
+        WHERE org_id = $1 AND user_id = $2
+        ORDER BY effective_from`,
+      [orgA, userId],
+    )
+    expect(timeline.rows).toEqual([
+      expect.objectContaining({
+        group_id: groupA,
+        effective_from: '2026-01-01',
+        effective_to: '2026-01-31',
+        closed_by: actorId,
+        closed_reason: 'Move to February policy',
+        closed_correlation_id: `february-${suffix}`,
+      }),
+      expect.objectContaining({
+        group_id: groupB,
+        effective_from: '2026-02-01',
+        effective_to: null,
+      }),
+    ])
+
+    const legacyAfter = await pool.query<{ count: string }>(
+      `SELECT count(*)::text AS count
+         FROM attendance_group_members
+        WHERE org_id = $1 AND user_id = $2`,
+      [orgA, userId],
+    )
+    const orgMembershipAfter = await pool.query(
+      `SELECT user_id, org_id, is_active
+         FROM user_orgs
+        WHERE user_id = $1 AND org_id = $2`,
+      [userId, orgA],
+    )
+    expect(legacyAfter.rows).toEqual(legacyBefore.rows)
+    expect(orgMembershipAfter.rows).toEqual(orgMembershipBefore.rows)
+  })
+
+  it('replays an identical correlation and rejects mismatched reuse without another write', async () => {
+    const correlationId = `february-${suffix}`
+    await transitionAttendanceCalculationGroupMembership({
+      orgId: orgA,
+      userId,
+      targetGroupId: groupC,
+      effectiveOn: '2026-03-01',
+      actorId,
+      reason: 'Move to March policy',
+      correlationId: `march-${suffix}`,
+    })
+    const replay = await transitionAttendanceCalculationGroupMembership({
+      orgId: orgA,
+      userId,
+      targetGroupId: groupB,
+      effectiveOn: '2026-02-01',
+      actorId,
+      reason: 'Move to February policy',
+      correlationId,
+    })
+    expect(replay.outcome).toBe('transitioned')
+    expect(replay.membership).toMatchObject({
+      groupId: groupB,
+      effectiveFrom: '2026-02-01',
+      effectiveTo: null,
+    })
+
+    await expect(
+      transitionAttendanceCalculationGroupMembership({
+        orgId: orgA,
+        userId,
+        targetGroupId: groupB,
+        effectiveOn: '2026-02-02',
+        actorId,
+        reason: 'Move to February policy',
+        correlationId,
+      }),
+    ).rejects.toMatchObject({
+      code: 'CORRELATION_ID_REUSED',
+      status: 409,
+    } satisfies Partial<AttendanceCalculationGroupMembershipError>)
+
+    const operations = await pool.query<{ count: string }>(
+      `SELECT count(*)::text AS count
+         FROM attendance_calculation_group_membership_operations
+        WHERE org_id = $1 AND correlation_id = $2`,
+      [orgA, correlationId],
+    )
+    expect(operations.rows[0]?.count).toBe('1')
+  })
+
+  it('canonicalizes UUID casing for exact replay and same-group no-op detection', async () => {
+    const uppercaseGroup = groupA.toUpperCase()
+    const first = await transitionAttendanceCalculationGroupMembership({
+      orgId: orgA,
+      userId: uuidUserId,
+      targetGroupId: uppercaseGroup,
+      effectiveOn: '2026-06-01',
+      actorId,
+      reason: 'Canonical UUID transition',
+      correlationId: `uuid-first-${suffix}`,
+    })
+    const replay = await transitionAttendanceCalculationGroupMembership({
+      orgId: orgA,
+      userId: uuidUserId,
+      targetGroupId: uppercaseGroup,
+      effectiveOn: '2026-06-01',
+      actorId,
+      reason: 'Canonical UUID transition',
+      correlationId: `uuid-first-${suffix}`,
+    })
+    const unchanged = await transitionAttendanceCalculationGroupMembership({
+      orgId: orgA,
+      userId: uuidUserId,
+      targetGroupId: uppercaseGroup,
+      effectiveOn: '2026-06-10',
+      actorId,
+      reason: 'Already in this calculation group',
+      correlationId: `uuid-unchanged-${suffix}`,
+    })
+
+    expect(first.membership.groupId).toBe(groupA)
+    expect(replay).toEqual(first)
+    expect(unchanged.outcome).toBe('unchanged')
+    expect(unchanged.membership.id).toBe(first.membership.id)
+    const timeline = await listAttendanceCalculationGroupMemberships(orgA, uuidUserId)
+    expect(timeline).toHaveLength(1)
+    expect(timeline[0]).toMatchObject({
+      orgId: orgA,
+      userId: uuidUserId,
+      groupId: groupA,
+      effectiveFrom: '2026-06-01',
+      effectiveTo: null,
+    })
+  })
+
+  it('preserves an existing future interval by ending the inserted target at futureStart-1', async () => {
+    await pool.query(
+      `INSERT INTO attendance_calculation_group_memberships (
+         org_id, user_id, group_id, effective_from, effective_to,
+         assigned_by, assigned_reason, assigned_correlation_id
+       ) VALUES
+         ($1, $2, $3, '2026-01-01', '2026-01-31', $5, 'past', 'future-past'),
+         ($1, $2, $4, '2026-03-01', NULL, $5, 'future', 'future-existing')`,
+      [orgA, futureUserId, groupA, groupC, actorId],
+    )
+
+    const inserted = await transitionAttendanceCalculationGroupMembership({
+      orgId: orgA,
+      userId: futureUserId,
+      targetGroupId: groupB,
+      effectiveOn: '2026-02-01',
+      actorId,
+      reason: 'Fill the planned February interval',
+      correlationId: `future-fill-${suffix}`,
+    })
+
+    expect(inserted.membership).toMatchObject({
+      effectiveFrom: '2026-02-01',
+      effectiveTo: '2026-02-28',
+    })
+    const future = await pool.query(
+      `SELECT group_id, effective_from::text, effective_to::text
+         FROM attendance_calculation_group_memberships
+        WHERE org_id = $1 AND user_id = $2
+        ORDER BY effective_from`,
+      [orgA, futureUserId],
+    )
+    expect(future.rows).toEqual([
+      { group_id: groupA, effective_from: '2026-01-01', effective_to: '2026-01-31' },
+      { group_id: groupB, effective_from: '2026-02-01', effective_to: '2026-02-28' },
+      { group_id: groupC, effective_from: '2026-03-01', effective_to: null },
+    ])
+  })
+
+  it('lets the database reject one of two concurrent direct overlapping writes', async () => {
+    const statements = [
+      pool.query(
+        `INSERT INTO attendance_calculation_group_memberships (
+           org_id, user_id, group_id, effective_from, effective_to,
+           assigned_by, assigned_reason, assigned_correlation_id
+         ) VALUES ($1, $2, $3, '2027-01-01', '2027-01-31', $4, 'race one', $5)`,
+        [orgA, raceUserId, groupA, actorId, `race-one-${suffix}`],
+      ),
+      pool.query(
+        `INSERT INTO attendance_calculation_group_memberships (
+           org_id, user_id, group_id, effective_from, effective_to,
+           assigned_by, assigned_reason, assigned_correlation_id
+         ) VALUES ($1, $2, $3, '2027-01-31', NULL, $4, 'race two', $5)`,
+        [orgA, raceUserId, groupB, actorId, `race-two-${suffix}`],
+      ),
+    ]
+    const results = await Promise.allSettled(statements)
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1)
+    const rejected = results.find((result) => result.status === 'rejected')
+    expect(rejected).toMatchObject({
+      reason: {
+        code: '23P01',
+        constraint: 'attendance_calc_group_memberships_no_overlap',
+      },
+    })
+  })
+
+  it('serializes a service transition against deactivation and guards direct timeline rewrites', async () => {
+    const lifecycleClient = await pool.connect()
+    try {
+      await lifecycleClient.query('BEGIN')
+      await lifecycleClient.query(
+        `SELECT 1
+           FROM user_orgs
+          WHERE user_id = $1 AND org_id = $2
+          FOR UPDATE`,
+        [lifecycleUserId, orgA],
+      )
+
+      const transition = transitionAttendanceCalculationGroupMembership({
+        orgId: orgA,
+        userId: lifecycleUserId,
+        targetGroupId: groupA,
+        effectiveOn: '2026-07-01',
+        actorId,
+        reason: 'Must not race deactivation',
+        correlationId: `lifecycle-race-${suffix}`,
+      })
+      let observedLockWait = false
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        const blocked = await pool.query<{ count: string }>(
+          `SELECT count(*)::text AS count
+             FROM pg_stat_activity
+            WHERE datname = current_database()
+              AND pid <> pg_backend_pid()
+              AND wait_event_type = 'Lock'
+              AND (
+                query LIKE '%FROM users u%'
+                OR query LIKE '%attendance_calculation_group_memberships%'
+              )`,
+        )
+        if (blocked.rows[0]?.count !== '0') {
+          observedLockWait = true
+          break
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+      expect(observedLockWait).toBe(true)
+
+      await lifecycleClient.query(
+        `UPDATE user_orgs
+            SET is_active = false
+          WHERE user_id = $1 AND org_id = $2`,
+        [lifecycleUserId, orgA],
+      )
+      await lifecycleClient.query('COMMIT')
+
+      await expect(transition).rejects.toMatchObject({
+        code: 'ACTIVE_ORG_USER_REQUIRED',
+        status: 422,
+      } satisfies Partial<AttendanceCalculationGroupMembershipError>)
+      const noWrite = await pool.query<{ count: string }>(
+        `SELECT count(*)::text AS count
+           FROM attendance_calculation_group_memberships
+          WHERE org_id = $1 AND user_id = $2`,
+        [orgA, lifecycleUserId],
+      )
+      expect(noWrite.rows[0]?.count).toBe('0')
+    } finally {
+      await lifecycleClient.query('ROLLBACK').catch(() => undefined)
+      lifecycleClient.release()
+    }
+
+    await pool.query(
+      `UPDATE user_orgs
+          SET is_active = true
+        WHERE user_id = $1 AND org_id = $2`,
+      [lifecycleUserId, orgA],
+    )
+    const created = await transitionAttendanceCalculationGroupMembership({
+      orgId: orgA,
+      userId: lifecycleUserId,
+      targetGroupId: groupA,
+      effectiveOn: '2026-07-01',
+      actorId,
+      reason: 'Create before later lifecycle change',
+      correlationId: `lifecycle-created-${suffix}`,
+    })
+    await pool.query(
+      `UPDATE user_orgs
+          SET is_active = false
+        WHERE user_id = $1 AND org_id = $2`,
+      [lifecycleUserId, orgA],
+    )
+    await expect(
+      pool.query(
+        `UPDATE attendance_calculation_group_memberships
+            SET group_id = $1
+          WHERE id = $2`,
+        [groupB, created.membership.id],
+      ),
+    ).rejects.toMatchObject({
+      code: '23503',
+      constraint: 'attendance_calc_group_membership_user_org_required',
+    })
+  })
+
+  it('uses one lock order for a direct semantic update racing a service transition', async () => {
+    const initial = await transitionAttendanceCalculationGroupMembership({
+      orgId: orgA,
+      userId: mixedWriterUserId,
+      targetGroupId: groupA,
+      effectiveOn: '2028-01-01',
+      actorId,
+      reason: 'Seed mixed-writer timeline',
+      correlationId: `mixed-seed-${suffix}`,
+    })
+    const directClient = await pool.connect()
+    try {
+      await directClient.query('BEGIN')
+      await directClient.query(
+        `SELECT 1
+           FROM attendance_calculation_group_memberships
+          WHERE id = $1
+          FOR UPDATE`,
+        [initial.membership.id],
+      )
+
+      const serviceTransition = transitionAttendanceCalculationGroupMembership({
+        orgId: orgA,
+        userId: mixedWriterUserId,
+        targetGroupId: groupB,
+        effectiveOn: '2028-02-01',
+        actorId,
+        reason: 'Service waits behind direct timeline writer',
+        correlationId: `mixed-service-${suffix}`,
+      }).then(
+        (value) => ({ status: 'fulfilled' as const, value }),
+        (reason: unknown) => ({ status: 'rejected' as const, reason }),
+      )
+
+      let observedTimelineWait = false
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        const blocked = await pool.query<{ count: string }>(
+          `SELECT count(*)::text AS count
+             FROM pg_stat_activity
+            WHERE datname = current_database()
+              AND pid <> pg_backend_pid()
+              AND wait_event_type = 'Lock'
+              AND query LIKE '%attendance_calculation_group_memberships%'`,
+        )
+        if (blocked.rows[0]?.count !== '0') {
+          observedTimelineWait = true
+          break
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+      expect(observedTimelineWait).toBe(true)
+
+      await expect(
+        directClient.query(
+          `UPDATE attendance_calculation_group_memberships
+              SET effective_to = '2028-01-31',
+                  closed_by = $2,
+                  closed_reason = 'Direct writer closes the first interval',
+                  closed_correlation_id = $3
+            WHERE id = $1`,
+          [initial.membership.id, actorId, `mixed-direct-${suffix}`],
+        ),
+      ).resolves.toMatchObject({ rowCount: 1 })
+      await directClient.query('COMMIT')
+
+      await expect(serviceTransition).resolves.toMatchObject({
+        status: 'fulfilled',
+        value: {
+          outcome: 'transitioned',
+          membership: {
+            groupId: groupB,
+            effectiveFrom: '2028-02-01',
+          },
+        },
+      })
+    } finally {
+      await directClient.query('ROLLBACK').catch(() => undefined)
+      directClient.release()
+    }
+  })
+
+  it('fails closed for an inactive target and a group from another org', async () => {
+    await expect(
+      transitionAttendanceCalculationGroupMembership({
+        orgId: orgA,
+        userId: inactiveUserId,
+        targetGroupId: groupA,
+        effectiveOn: '2026-04-01',
+        actorId,
+        reason: 'Should not apply',
+        correlationId: `inactive-${suffix}`,
+      }),
+    ).rejects.toMatchObject({
+      code: 'ACTIVE_ORG_USER_REQUIRED',
+      status: 422,
+    } satisfies Partial<AttendanceCalculationGroupMembershipError>)
+
+    await expect(
+      transitionAttendanceCalculationGroupMembership({
+        orgId: orgA,
+        userId,
+        targetGroupId: foreignGroup,
+        effectiveOn: '2026-04-01',
+        actorId,
+        reason: 'Should not cross organizations',
+        correlationId: `foreign-${suffix}`,
+      }),
+    ).rejects.toMatchObject({
+      code: 'TARGET_GROUP_NOT_FOUND',
+      status: 404,
+    } satisfies Partial<AttendanceCalculationGroupMembershipError>)
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-calculation-group-membership-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-calculation-group-membership-routes.test.ts
@@ -1,0 +1,219 @@
+import express from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  queryMock,
+  listMock,
+  transitionMock,
+  isRbacAdminMock,
+} = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  listMock: vi.fn(),
+  transitionMock: vi.fn(),
+  isRbacAdminMock: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: queryMock,
+}))
+
+vi.mock('../../src/rbac/rbac', () => ({
+  rbacGuard: () => (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => next(),
+}))
+
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: isRbacAdminMock,
+  listUserPermissions: vi.fn(async () => []),
+}))
+
+vi.mock('../../src/routes/admin-users', () => ({
+  ensurePlatformAdmin: vi.fn(),
+}))
+
+vi.mock('../../src/services/AttendanceNotificationRedelivery', () => ({
+  redeliverFailedAttendanceNotification: vi.fn(),
+}))
+
+vi.mock('../../src/services/AttendanceCalculationGroupMembership', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../src/services/AttendanceCalculationGroupMembership')>()
+  return {
+    ...actual,
+    listAttendanceCalculationGroupMemberships: listMock,
+    transitionAttendanceCalculationGroupMembership: transitionMock,
+  }
+})
+
+import {
+  AttendanceCalculationGroupMembershipError,
+} from '../../src/services/AttendanceCalculationGroupMembership'
+import { attendanceAdminRouter } from '../../src/routes/attendance-admin'
+
+function makeApp(userId = 'delegated-admin') {
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.user = {
+      id: userId,
+      roles: ['user'],
+      permissions: ['attendance:admin'],
+    }
+    req.correlationId = 'request-correlation'
+    next()
+  })
+  app.use(attendanceAdminRouter())
+  return app
+}
+
+describe('attendance calculation-group membership admin routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isRbacAdminMock.mockResolvedValue(false)
+    queryMock.mockResolvedValue({ rows: [{ allowed: 1 }] })
+    listMock.mockResolvedValue([])
+    transitionMock.mockResolvedValue({
+      correlationId: 'request-correlation',
+      outcome: 'transitioned',
+      membership: { id: 'membership-1' },
+    })
+  })
+
+  it('authorizes the org before reading a target timeline', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] })
+
+    const response = await request(makeApp()).get(
+      '/api/attendance-admin/calculation-group-memberships?orgId=foreign-org&userId=target-user',
+    )
+
+    expect(response.status).toBe(403)
+    expect(response.body?.error?.code).toBe('FORBIDDEN')
+    expect(listMock).not.toHaveBeenCalled()
+    expect(
+      queryMock.mock.calls.some(([statement]) =>
+        String(statement).includes('attendance_calculation_group_memberships'),
+      ),
+    ).toBe(false)
+  })
+
+  it('lists an authorized user timeline after the active org-membership gate', async () => {
+    listMock.mockResolvedValueOnce([{ id: 'membership-1' }])
+
+    const response = await request(makeApp()).get(
+      '/api/attendance-admin/calculation-group-memberships?orgId=org-a&userId=target-user',
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual({
+      ok: true,
+      data: { items: [{ id: 'membership-1' }] },
+    })
+    expect(listMock).toHaveBeenCalledWith('org-a', 'target-user')
+  })
+
+  it('takes actor identity and fallback correlation from the authenticated request', async () => {
+    const response = await request(makeApp('real-actor'))
+      .post('/api/attendance-admin/calculation-group-memberships/transition')
+      .send({
+        orgId: 'org-a',
+        userId: 'target-user',
+        targetGroupId: '11111111-1111-4111-8111-111111111111',
+        effectiveOn: '2026-08-01',
+        reason: 'Move to the night-shift policy',
+        actorId: 'spoofed-actor',
+      })
+
+    expect(response.status).toBe(200)
+    expect(response.headers['x-correlation-id']).toBe('request-correlation')
+    expect(transitionMock).toHaveBeenCalledWith({
+      orgId: 'org-a',
+      userId: 'target-user',
+      targetGroupId: '11111111-1111-4111-8111-111111111111',
+      effectiveOn: '2026-08-01',
+      actorId: 'real-actor',
+      reason: 'Move to the night-shift policy',
+      correlationId: 'request-correlation',
+    })
+  })
+
+  it('rejects a foreign-org transition before invoking the write service', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] })
+
+    const response = await request(makeApp())
+      .post('/api/attendance-admin/calculation-group-memberships/transition')
+      .send({
+        orgId: 'foreign-org',
+        userId: 'target-user',
+        targetGroupId: '11111111-1111-4111-8111-111111111111',
+        effectiveOn: '2026-08-01',
+        reason: 'Move group',
+        correlationId: 'transition-1',
+      })
+
+    expect(response.status).toBe(403)
+    expect(response.body?.error?.code).toBe('FORBIDDEN')
+    expect(transitionMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-string request fields instead of coercing arrays into valid values', async () => {
+    const response = await request(makeApp())
+      .post('/api/attendance-admin/calculation-group-memberships/transition')
+      .send({
+        orgId: 'org-a',
+        userId: 'target-user',
+        targetGroupId: '11111111-1111-4111-8111-111111111111',
+        effectiveOn: ['2026-08-01'],
+        reason: 'Move group',
+      })
+
+    expect(response.status).toBe(400)
+    expect(response.body?.error?.code).toBe('EFFECTIVE_ON_REQUIRED')
+    expect(transitionMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a blank supplied correlation id instead of silently replacing it', async () => {
+    const response = await request(makeApp())
+      .post('/api/attendance-admin/calculation-group-memberships/transition')
+      .send({
+        orgId: 'org-a',
+        userId: 'target-user',
+        targetGroupId: '11111111-1111-4111-8111-111111111111',
+        effectiveOn: '2026-08-01',
+        reason: 'Move group',
+        correlationId: '   ',
+      })
+
+    expect(response.status).toBe(400)
+    expect(response.body?.error?.code).toBe('CORRELATION_ID_INVALID')
+    expect(transitionMock).not.toHaveBeenCalled()
+  })
+
+  it('preserves typed service errors without exposing database details', async () => {
+    transitionMock.mockRejectedValueOnce(
+      new AttendanceCalculationGroupMembershipError(
+        'CORRELATION_ID_REUSED',
+        409,
+        'correlationId was already used with a different transition payload',
+      ),
+    )
+
+    const response = await request(makeApp())
+      .post('/api/attendance-admin/calculation-group-memberships/transition')
+      .send({
+        orgId: 'org-a',
+        userId: 'target-user',
+        targetGroupId: '11111111-1111-4111-8111-111111111111',
+        effectiveOn: '2026-08-01',
+        reason: 'Move group',
+        correlationId: 'transition-1',
+      })
+
+    expect(response.status).toBe(409)
+    expect(response.body?.error?.code).toBe('CORRELATION_ID_REUSED')
+    expect(response.body?.error?.message).not.toMatch(/SELECT|constraint|postgres/i)
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-calculation-group-membership-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-calculation-group-membership-routes.test.ts
@@ -53,6 +53,7 @@ import {
   AttendanceCalculationGroupMembershipError,
 } from '../../src/services/AttendanceCalculationGroupMembership'
 import { attendanceAdminRouter } from '../../src/routes/attendance-admin'
+import { usePinnedServer } from '../utils/pinned-server'
 
 function makeApp(userId = 'delegated-admin') {
   const app = express()
@@ -70,6 +71,8 @@ function makeApp(userId = 'delegated-admin') {
   return app
 }
 
+const pinned = usePinnedServer()
+
 describe('attendance calculation-group membership admin routes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -81,12 +84,13 @@ describe('attendance calculation-group membership admin routes', () => {
       outcome: 'transitioned',
       membership: { id: 'membership-1' },
     })
+    pinned.setApp(makeApp())
   })
 
   it('authorizes the org before reading a target timeline', async () => {
     queryMock.mockResolvedValueOnce({ rows: [] })
 
-    const response = await request(makeApp()).get(
+    const response = await request(pinned.url()).get(
       '/api/attendance-admin/calculation-group-memberships?orgId=foreign-org&userId=target-user',
     )
 
@@ -103,7 +107,7 @@ describe('attendance calculation-group membership admin routes', () => {
   it('lists an authorized user timeline after the active org-membership gate', async () => {
     listMock.mockResolvedValueOnce([{ id: 'membership-1' }])
 
-    const response = await request(makeApp()).get(
+    const response = await request(pinned.url()).get(
       '/api/attendance-admin/calculation-group-memberships?orgId=org-a&userId=target-user',
     )
 
@@ -116,7 +120,8 @@ describe('attendance calculation-group membership admin routes', () => {
   })
 
   it('takes actor identity and fallback correlation from the authenticated request', async () => {
-    const response = await request(makeApp('real-actor'))
+    pinned.setApp(makeApp('real-actor'))
+    const response = await request(pinned.url())
       .post('/api/attendance-admin/calculation-group-memberships/transition')
       .send({
         orgId: 'org-a',
@@ -143,7 +148,7 @@ describe('attendance calculation-group membership admin routes', () => {
   it('rejects a foreign-org transition before invoking the write service', async () => {
     queryMock.mockResolvedValueOnce({ rows: [] })
 
-    const response = await request(makeApp())
+    const response = await request(pinned.url())
       .post('/api/attendance-admin/calculation-group-memberships/transition')
       .send({
         orgId: 'foreign-org',
@@ -160,7 +165,7 @@ describe('attendance calculation-group membership admin routes', () => {
   })
 
   it('rejects non-string request fields instead of coercing arrays into valid values', async () => {
-    const response = await request(makeApp())
+    const response = await request(pinned.url())
       .post('/api/attendance-admin/calculation-group-memberships/transition')
       .send({
         orgId: 'org-a',
@@ -176,7 +181,7 @@ describe('attendance calculation-group membership admin routes', () => {
   })
 
   it('rejects a blank supplied correlation id instead of silently replacing it', async () => {
-    const response = await request(makeApp())
+    const response = await request(pinned.url())
       .post('/api/attendance-admin/calculation-group-memberships/transition')
       .send({
         orgId: 'org-a',
@@ -201,7 +206,7 @@ describe('attendance calculation-group membership admin routes', () => {
       ),
     )
 
-    const response = await request(makeApp())
+    const response = await request(pinned.url())
       .post('/api/attendance-admin/calculation-group-memberships/transition')
       .send({
         orgId: 'org-a',

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -450,6 +450,9 @@ export default defineConfig({
       // no-DB job cannot skip-green it; wired whole-file into the attendance real-DB step in
       // plugin-tests.yml.
       'tests/integration/attendance-decision-trace-w5-0.db.test.ts',
+      // #4561 W1: database exclusion/concurrency and effective-date transition proof.
+      // Kept out of the no-DB run and explicitly wired into plugin-tests.yml.
+      'tests/integration/attendance-calculation-group-membership-w1.db.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',

--- a/packages/openapi/dist-sdk/index.d.ts
+++ b/packages/openapi/dist-sdk/index.d.ts
@@ -3222,6 +3222,145 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/attendance-admin/calculation-group-memberships": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List a user's effective calculation-group membership timeline */
+        get: {
+            parameters: {
+                query: {
+                    orgId: string;
+                    userId: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Ordered, non-overlapping membership timeline */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            ok: boolean;
+                            data: {
+                                items: components["schemas"]["AttendanceCalculationGroupMembership"][];
+                            };
+                        };
+                    };
+                };
+                400: components["responses"]["ValidationError"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                /** @description Calculation-group timeline read failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                503: components["responses"]["ServiceUnavailable"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/attendance-admin/calculation-group-memberships/transition": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Transition a user to a calculation group on an inclusive effective date */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        orgId: string;
+                        userId: string;
+                        /** Format: uuid */
+                        targetGroupId: string;
+                        /** Format: date */
+                        effectiveOn: string;
+                        reason: string;
+                        correlationId?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Transition applied or replayed idempotently */
+                200: {
+                    headers: {
+                        "X-Correlation-Id"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            ok: boolean;
+                            data: {
+                                correlationId: string;
+                                /** @enum {string} */
+                                outcome: "transitioned" | "unchanged";
+                                membership: components["schemas"]["AttendanceCalculationGroupMembership"];
+                            };
+                        };
+                    };
+                };
+                400: components["responses"]["ValidationError"];
+                401: components["responses"]["Unauthorized"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                409: components["responses"]["Conflict"];
+                /** @description Target user is not active in the requested organization */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                /** @description Calculation-group transition failed */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                503: components["responses"]["ServiceUnavailable"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/attendance/groups": {
         parameters: {
             query?: never;
@@ -14906,6 +15045,28 @@ export interface components {
             userId?: string;
             /** Format: date-time */
             createdAt?: string | null;
+        };
+        AttendanceCalculationGroupMembership: {
+            /** Format: uuid */
+            id: string;
+            orgId: string;
+            userId: string;
+            /** Format: uuid */
+            groupId: string;
+            /** Format: date */
+            effectiveFrom: string;
+            /** Format: date */
+            effectiveTo: string | null;
+            assignedBy: string;
+            assignedReason: string;
+            assignedCorrelationId: string;
+            closedBy: string | null;
+            closedReason: string | null;
+            closedCorrelationId: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
         };
         AttendancePayrollTemplate: {
             id?: string;

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1109,6 +1109,62 @@ components:
           type: string
           format: date-time
           nullable: true
+    AttendanceCalculationGroupMembership:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        orgId:
+          type: string
+        userId:
+          type: string
+        groupId:
+          type: string
+          format: uuid
+        effectiveFrom:
+          type: string
+          format: date
+        effectiveTo:
+          type: string
+          format: date
+          nullable: true
+        assignedBy:
+          type: string
+        assignedReason:
+          type: string
+        assignedCorrelationId:
+          type: string
+        closedBy:
+          type: string
+          nullable: true
+        closedReason:
+          type: string
+          nullable: true
+        closedCorrelationId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - orgId
+        - userId
+        - groupId
+        - effectiveFrom
+        - effectiveTo
+        - assignedBy
+        - assignedReason
+        - assignedCorrelationId
+        - closedBy
+        - closedReason
+        - closedCorrelationId
+        - createdAt
+        - updatedAt
     AttendancePayrollTemplate:
       type: object
       properties:
@@ -8708,6 +8764,153 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/attendance-admin/calculation-group-memberships:
+    get:
+      summary: List a user's effective calculation-group membership timeline
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: orgId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: userId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Ordered, non-overlapping membership timeline
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: >-
+                            #/components/schemas/AttendanceCalculationGroupMembership
+                    required:
+                      - items
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          description: Calculation-group timeline read failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /api/attendance-admin/calculation-group-memberships/transition:
+    post:
+      summary: Transition a user to a calculation group on an inclusive effective date
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                orgId:
+                  type: string
+                userId:
+                  type: string
+                targetGroupId:
+                  type: string
+                  format: uuid
+                effectiveOn:
+                  type: string
+                  format: date
+                reason:
+                  type: string
+                  minLength: 1
+                  maxLength: 1000
+                correlationId:
+                  type: string
+                  minLength: 1
+                  maxLength: 128
+              required:
+                - orgId
+                - userId
+                - targetGroupId
+                - effectiveOn
+                - reason
+      responses:
+        '200':
+          description: Transition applied or replayed idempotently
+          headers:
+            X-Correlation-Id:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      correlationId:
+                        type: string
+                      outcome:
+                        type: string
+                        enum:
+                          - transitioned
+                          - unchanged
+                      membership:
+                        $ref: >-
+                          #/components/schemas/AttendanceCalculationGroupMembership
+                    required:
+                      - correlationId
+                      - outcome
+                      - membership
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          description: Target user is not active in the requested organization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Calculation-group transition failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /api/attendance/groups:
     x-plugin: plugin-attendance
     get:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -1578,6 +1578,79 @@
           }
         }
       },
+      "AttendanceCalculationGroupMembership": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "orgId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "groupId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "effectiveFrom": {
+            "type": "string",
+            "format": "date"
+          },
+          "effectiveTo": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "assignedBy": {
+            "type": "string"
+          },
+          "assignedReason": {
+            "type": "string"
+          },
+          "assignedCorrelationId": {
+            "type": "string"
+          },
+          "closedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "closedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "closedCorrelationId": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "orgId",
+          "userId",
+          "groupId",
+          "effectiveFrom",
+          "effectiveTo",
+          "assignedBy",
+          "assignedReason",
+          "assignedCorrelationId",
+          "closedBy",
+          "closedReason",
+          "closedCorrelationId",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
       "AttendancePayrollTemplate": {
         "type": "object",
         "properties": {
@@ -12632,6 +12705,233 @@
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/attendance-admin/calculation-group-memberships": {
+      "get": {
+        "summary": "List a user's effective calculation-group membership timeline",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "orgId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ordered, non-overlapping membership timeline",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/AttendanceCalculationGroupMembership"
+                          }
+                        }
+                      },
+                      "required": [
+                        "items"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "description": "Calculation-group timeline read failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/api/attendance-admin/calculation-group-memberships/transition": {
+      "post": {
+        "summary": "Transition a user to a calculation group on an inclusive effective date",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "orgId": {
+                    "type": "string"
+                  },
+                  "userId": {
+                    "type": "string"
+                  },
+                  "targetGroupId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "effectiveOn": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "reason": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  "correlationId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  }
+                },
+                "required": [
+                  "orgId",
+                  "userId",
+                  "targetGroupId",
+                  "effectiveOn",
+                  "reason"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Transition applied or replayed idempotently",
+            "headers": {
+              "X-Correlation-Id": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "correlationId": {
+                          "type": "string"
+                        },
+                        "outcome": {
+                          "type": "string",
+                          "enum": [
+                            "transitioned",
+                            "unchanged"
+                          ]
+                        },
+                        "membership": {
+                          "$ref": "#/components/schemas/AttendanceCalculationGroupMembership"
+                        }
+                      },
+                      "required": [
+                        "correlationId",
+                        "outcome",
+                        "membership"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "422": {
+            "description": "Target user is not active in the requested organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Calculation-group transition failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
           }
         }
       }

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1109,6 +1109,62 @@ components:
           type: string
           format: date-time
           nullable: true
+    AttendanceCalculationGroupMembership:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        orgId:
+          type: string
+        userId:
+          type: string
+        groupId:
+          type: string
+          format: uuid
+        effectiveFrom:
+          type: string
+          format: date
+        effectiveTo:
+          type: string
+          format: date
+          nullable: true
+        assignedBy:
+          type: string
+        assignedReason:
+          type: string
+        assignedCorrelationId:
+          type: string
+        closedBy:
+          type: string
+          nullable: true
+        closedReason:
+          type: string
+          nullable: true
+        closedCorrelationId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - orgId
+        - userId
+        - groupId
+        - effectiveFrom
+        - effectiveTo
+        - assignedBy
+        - assignedReason
+        - assignedCorrelationId
+        - closedBy
+        - closedReason
+        - closedCorrelationId
+        - createdAt
+        - updatedAt
     AttendancePayrollTemplate:
       type: object
       properties:
@@ -8708,6 +8764,153 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/attendance-admin/calculation-group-memberships:
+    get:
+      summary: List a user's effective calculation-group membership timeline
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: orgId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: userId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Ordered, non-overlapping membership timeline
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: >-
+                            #/components/schemas/AttendanceCalculationGroupMembership
+                    required:
+                      - items
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          description: Calculation-group timeline read failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /api/attendance-admin/calculation-group-memberships/transition:
+    post:
+      summary: Transition a user to a calculation group on an inclusive effective date
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                orgId:
+                  type: string
+                userId:
+                  type: string
+                targetGroupId:
+                  type: string
+                  format: uuid
+                effectiveOn:
+                  type: string
+                  format: date
+                reason:
+                  type: string
+                  minLength: 1
+                  maxLength: 1000
+                correlationId:
+                  type: string
+                  minLength: 1
+                  maxLength: 128
+              required:
+                - orgId
+                - userId
+                - targetGroupId
+                - effectiveOn
+                - reason
+      responses:
+        '200':
+          description: Transition applied or replayed idempotently
+          headers:
+            X-Correlation-Id:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      correlationId:
+                        type: string
+                      outcome:
+                        type: string
+                        enum:
+                          - transitioned
+                          - unchanged
+                      membership:
+                        $ref: >-
+                          #/components/schemas/AttendanceCalculationGroupMembership
+                    required:
+                      - correlationId
+                      - outcome
+                      - membership
+                required:
+                  - ok
+                  - data
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          description: Target user is not active in the requested organization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Calculation-group transition failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /api/attendance/groups:
     x-plugin: plugin-attendance
     get:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1008,6 +1008,62 @@ components:
           type: string
           format: date-time
           nullable: true
+    AttendanceCalculationGroupMembership:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        orgId:
+          type: string
+        userId:
+          type: string
+        groupId:
+          type: string
+          format: uuid
+        effectiveFrom:
+          type: string
+          format: date
+        effectiveTo:
+          type: string
+          format: date
+          nullable: true
+        assignedBy:
+          type: string
+        assignedReason:
+          type: string
+        assignedCorrelationId:
+          type: string
+        closedBy:
+          type: string
+          nullable: true
+        closedReason:
+          type: string
+          nullable: true
+        closedCorrelationId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - orgId
+        - userId
+        - groupId
+        - effectiveFrom
+        - effectiveTo
+        - assignedBy
+        - assignedReason
+        - assignedCorrelationId
+        - closedBy
+        - closedReason
+        - closedCorrelationId
+        - createdAt
+        - updatedAt
     AttendancePayrollTemplate:
       type: object
       properties:

--- a/packages/openapi/src/paths/attendance.yml
+++ b/packages/openapi/src/paths/attendance.yml
@@ -1861,6 +1861,103 @@ paths:
                       to: { type: string, format: date }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+  /api/attendance-admin/calculation-group-memberships:
+    get:
+      summary: List a user's effective calculation-group membership timeline
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: query
+          name: orgId
+          required: true
+          schema: { type: string }
+        - in: query
+          name: userId
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Ordered, non-overlapping membership timeline
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/AttendanceCalculationGroupMembership'
+                    required: [items]
+                required: [ok, data]
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '500':
+          description: Calculation-group timeline read failed
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '503': { $ref: '#/components/responses/ServiceUnavailable' }
+  /api/attendance-admin/calculation-group-memberships/transition:
+    post:
+      summary: Transition a user to a calculation group on an inclusive effective date
+      security: [ { bearerAuth: [] } ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                orgId: { type: string }
+                userId: { type: string }
+                targetGroupId: { type: string, format: uuid }
+                effectiveOn: { type: string, format: date }
+                reason: { type: string, minLength: 1, maxLength: 1000 }
+                correlationId: { type: string, minLength: 1, maxLength: 128 }
+              required: [orgId, userId, targetGroupId, effectiveOn, reason]
+      responses:
+        '200':
+          description: Transition applied or replayed idempotently
+          headers:
+            X-Correlation-Id:
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      correlationId: { type: string }
+                      outcome:
+                        type: string
+                        enum: [transitioned, unchanged]
+                      membership:
+                        $ref: '#/components/schemas/AttendanceCalculationGroupMembership'
+                    required: [correlationId, outcome, membership]
+                required: [ok, data]
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
+        '422':
+          description: Target user is not active in the requested organization
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '500':
+          description: Calculation-group transition failed
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '503': { $ref: '#/components/responses/ServiceUnavailable' }
   /api/attendance/groups:
     x-plugin: plugin-attendance
     get:

--- a/scripts/ops/attendance-calculation-group-membership-w1-contract.test.mjs
+++ b/scripts/ops/attendance-calculation-group-membership-w1-contract.test.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const migrationPath = path.join(rootDir, 'packages/core-backend/src/db/migrations/zzzz20260723140000_create_attendance_calculation_group_memberships.ts')
+const servicePath = path.join(rootDir, 'packages/core-backend/src/services/AttendanceCalculationGroupMembership.ts')
+const routePath = path.join(rootDir, 'packages/core-backend/src/routes/attendance-admin.ts')
+const configPath = path.join(rootDir, 'packages/core-backend/vitest.config.ts')
+const workflowPath = path.join(rootDir, '.github/workflows/plugin-tests.yml')
+const openapiPath = path.join(rootDir, 'packages/openapi/src/paths/attendance.yml')
+const dbTestPath = path.join(
+  rootDir,
+  'packages/core-backend/tests/integration/attendance-calculation-group-membership-w1.db.test.ts',
+)
+
+function read(filePath) {
+  assert.ok(fs.existsSync(filePath), `missing contract file: ${filePath}`)
+  return fs.readFileSync(filePath, 'utf8')
+}
+
+test('W1 migration creates an inclusive database overlap invariant without legacy dual writes', () => {
+  const source = read(migrationPath)
+  assert.match(source, /CREATE TABLE IF NOT EXISTS attendance_calculation_group_memberships/)
+  assert.match(source, /EXCLUDE USING gist/)
+  assert.match(source, /daterange\([\s\S]*'\[\]'/)
+  assert.match(source, /attendance_calc_group_membership_group_org_fk/)
+  assert.match(source, /attendance_calc_group_membership_user_org_required/)
+  assert.doesNotMatch(source, /\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM|ALTER\s+TABLE)\s+attendance_group_members\b/i)
+  assert.doesNotMatch(source, /\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM|ALTER\s+TABLE)\s+attendance_schedule_group_members\b/i)
+  assert.doesNotMatch(source, /\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM|ALTER\s+TABLE)\s+user_orgs\b/i)
+})
+
+test('W1 service has only timeline/operation writes and no calculation-chain or org-membership cutover', () => {
+  const source = read(servicePath)
+  assert.match(source, /attendance-calc-operation/)
+  assert.match(source, /attendance-calc-timeline/)
+  assert.match(source, /effective_to = \(\$3::date - 1\)/)
+  assert.match(source, /attendance_calculation_group_membership_operations/)
+  assert.doesNotMatch(source, /\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+user_orgs\b/i)
+  assert.doesNotMatch(source, /attendance_group_members\b/)
+  assert.doesNotMatch(source, /attendance_schedule_group_members\b/)
+  assert.doesNotMatch(source, /attendance_records\b/)
+  const timelineLock = source.indexOf('const timelineResult = await runQuery(')
+  const lifecycleLock = source.indexOf('const activeUser = await runQuery(')
+  assert.ok(timelineLock >= 0, 'missing membership timeline lock')
+  assert.ok(lifecycleLock > timelineLock, 'lifecycle rows must be locked after membership timeline rows')
+})
+
+test('both admin endpoints authorize org membership before timeline service access', () => {
+  const source = read(routePath)
+  for (const [startNeedle, serviceNeedle] of [
+    ["r.get('/api/attendance-admin/calculation-group-memberships'", 'listAttendanceCalculationGroupMemberships(orgId, targetUserId)'],
+    ["r.post('/api/attendance-admin/calculation-group-memberships/transition'", 'transitionAttendanceCalculationGroupMembership({'],
+  ]) {
+    const start = source.indexOf(startNeedle)
+    const service = source.indexOf(serviceNeedle, start)
+    const authorization = source.indexOf('canReadAttendanceDirectoryReadiness(req, actorId, orgId)', start)
+    assert.ok(start >= 0, `missing route: ${startNeedle}`)
+    assert.ok(authorization > start, `missing authorization in ${startNeedle}`)
+    assert.ok(service > authorization, `timeline service precedes authorization in ${startNeedle}`)
+  }
+})
+
+test('real-DB W1 suite has both skip-green exclusion and explicit CI execution points', () => {
+  const fileName = 'attendance-calculation-group-membership-w1.db.test.ts'
+  assert.match(read(configPath), new RegExp(fileName.replaceAll('.', '\\.')))
+  assert.match(read(workflowPath), new RegExp(fileName.replaceAll('.', '\\.')))
+  const source = read(dbTestPath)
+  assert.match(source, /membershipMigrationDown\(db\)/)
+  assert.match(source, /membershipMigrationUp\(db\)/)
+  assert.match(source, /pg_stat_activity/)
+  assert.match(source, /toUpperCase\(\)/)
+  assert.match(source, /listAttendanceCalculationGroupMemberships\(orgA, uuidUserId\)/)
+  assert.match(source, /uses one lock order for a direct semantic update racing a service transition/)
+})
+
+test('OpenAPI exposes list and transition only, with no delete or replace-all path', () => {
+  const source = read(openapiPath)
+  const listPath = source.indexOf('/api/attendance-admin/calculation-group-memberships:')
+  const transitionPath = source.indexOf('/api/attendance-admin/calculation-group-memberships/transition:')
+  const nextAttendancePath = source.indexOf('/api/attendance/groups:', transitionPath)
+  assert.ok(listPath >= 0 && transitionPath > listPath && nextAttendancePath > transitionPath)
+  const surface = source.slice(listPath, nextAttendancePath)
+  assert.match(surface, /\n    get:/)
+  assert.match(surface, /\n    post:/)
+  assert.doesNotMatch(surface, /\n    (?:put|patch|delete):/)
+  assert.match(surface, /required: \[orgId, userId, targetGroupId, effectiveOn, reason\]/)
+})

--- a/scripts/ops/attendance-openapi-parity-4556-contract.test.mjs
+++ b/scripts/ops/attendance-openapi-parity-4556-contract.test.mjs
@@ -174,3 +174,89 @@ test('assignment POST/PUT request schemas include slotIndex min 0 and legacy slo
     'POST assignment must not invent required slotIndex',
   )
 })
+
+test('W1 calculation-group membership schema exposes effective dates and durable audit context', () => {
+  const base = loadYaml(basePath)
+  const membership = requireSchema(base, 'AttendanceCalculationGroupMembership')
+  const required = membership.required || []
+  assert.deepEqual(
+    required,
+    [
+      'id',
+      'orgId',
+      'userId',
+      'groupId',
+      'effectiveFrom',
+      'effectiveTo',
+      'assignedBy',
+      'assignedReason',
+      'assignedCorrelationId',
+      'closedBy',
+      'closedReason',
+      'closedCorrelationId',
+      'createdAt',
+      'updatedAt',
+    ],
+    'AttendanceCalculationGroupMembership required fields drifted',
+  )
+  assert.equal(
+    requireProperty(membership, 'effectiveFrom', 'AttendanceCalculationGroupMembership').format,
+    'date',
+  )
+  assert.equal(
+    requireProperty(membership, 'effectiveTo', 'AttendanceCalculationGroupMembership').nullable,
+    true,
+  )
+})
+
+test('W1 admin API exposes only timeline GET and atomic transition POST', () => {
+  const attendance = loadYaml(attendancePath)
+  const list = attendance.paths?.['/api/attendance-admin/calculation-group-memberships']
+  const transition =
+    attendance.paths?.['/api/attendance-admin/calculation-group-memberships/transition']
+  assert.deepEqual(Object.keys(list || {}), ['get'], 'W1 timeline path method surface drifted')
+  assert.deepEqual(
+    Object.keys(transition || {}),
+    ['post'],
+    'W1 transition path method surface drifted',
+  )
+
+  const listParameters = list.get.parameters || []
+  assert.deepEqual(
+    listParameters.map((parameter) => [parameter.name, parameter.required]),
+    [
+      ['orgId', true],
+      ['userId', true],
+    ],
+  )
+
+  const transitionSchema = requestBodySchema(
+    attendance,
+    '/api/attendance-admin/calculation-group-memberships/transition',
+    'post',
+  )
+  assert.deepEqual(
+    transitionSchema.required,
+    ['orgId', 'userId', 'targetGroupId', 'effectiveOn', 'reason'],
+  )
+  assert.equal(transitionSchema.properties.targetGroupId.format, 'uuid')
+  assert.equal(transitionSchema.properties.effectiveOn.format, 'date')
+  assert.equal(transitionSchema.properties.reason.minLength, 1)
+  assert.equal(transitionSchema.properties.correlationId.maxLength, 128)
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(transitionSchema.properties, 'actorId'),
+    false,
+    'actor identity must come from authentication, not the request body',
+  )
+
+  assert.deepEqual(
+    Object.keys(list.get.responses).sort(),
+    ['200', '400', '401', '403', '500', '503'],
+    'timeline responses must cover every reachable route status',
+  )
+  assert.deepEqual(
+    Object.keys(transition.post.responses).sort(),
+    ['200', '400', '401', '403', '404', '409', '422', '500', '503'],
+    'transition responses must cover every reachable route status',
+  )
+})


### PR DESCRIPTION
## Summary

Implements the **W1-only** runtime slice authorized by the ratified advanced attendance capability lock in #4561:

- adds effective-dated calculation-group membership and immutable operation-ledger tables;
- enforces inclusive, non-overlapping `org + user + date` intervals and same-org group references in PostgreSQL;
- adds an org-scoped timeline read and one atomic transition command under the delegated `attendance:admin` surface;
- preserves actor, reason, correlation, close audit, and exact idempotent response snapshots;
- generates the OpenAPI/SDK contract and wires both no-DB and real-DB CI gates.

## Safety boundaries

This PR deliberately does **not**:

- write or reuse `attendance_group_members` or `attendance_schedule_group_members`;
- mutate `user_orgs`;
- cut over any attendance calculation/read path;
- add backfill, feature-flag enablement, deployment, historical recalculation, or a universal group save endpoint.

Authorization completes before timeline service access. The authenticated actor is authoritative; request-body actor spoofing is ignored. Request fields are strict strings, UUIDs are canonicalized, and database details are not exposed.

## Adversarial review fixes

Independent review initially returned CHANGES_REQUESTED and found:

1. active user/org TOCTOU across transition and deactivation;
2. uppercase UUID replay/no-op fragmentation;
3. missing reachable `422/500/503` OpenAPI responses;
4. insufficient migration/concurrency CI proof;
5. a second-round mixed-writer deadlock caused by opposite lifecycle/timeline lock order.

All were reproduced and fixed. The final lock order is timeline rows → lifecycle rows, shared by the service and semantic-update trigger path. The mixed direct-UPDATE/service-transition probe now completes both writes without `40P01`. Final independent verdict: **APPROVE, 0 P1 / 0 P2**.

## Verification

Exact head `b32095c52` after rebase onto current `main`:

- backend type-check: PASS;
- adjacent attendance admin unit suites: 3 files / 66 tests PASS;
- W1 route unit suite: 7/7 PASS;
- W1 source/CI contract: 5/5 PASS;
- attendance OpenAPI parity: 7/7 PASS;
- W1 real-DB suite: 10/10 PASS;
- full fresh database migration: PASS;
- migration down → up → second up replay: PASS;
- second migration run: pending=0 / PASS;
- OpenAPI build + SDK generation: PASS;
- `git diff --check`: PASS;
- dedicated DB residue: 0; temporary databases removed.

Mutation/negative proof:

- remove both lifecycle row locks → deactivation race test RED;
- remove UUID lower-case canonicalization → exact replay test RED;
- change inclusive `[]` range to `[)` → boundary/concurrency tests RED;
- remove OpenAPI `422` → parity test RED;
- reintroduce pre-timeline lifecycle lock → mixed-writer test reproduces `40P01` and RED.

Issue #4556 remains open; this is only W1 of the ratified sequence. This draft is intentionally unarmed for owner review.
