### PR TITLE
feat(attendance): add shift segment editor

### DIFF
--- a/.github/workflows/attendance-web-guard.yml
+++ b/.github/workflows/attendance-web-guard.yml
@@ -95,6 +95,7 @@ on:
       - 'apps/web/src/views/AttendanceView.vue'
       - 'apps/web/src/views/attendance/**'
       - 'apps/web/tests/attendance-admin-regressions.spec.ts'
+      - 'apps/web/tests/attendance-shift-segments.spec.ts'
       - 'apps/web/tests/attendance-admin-anchor-nav.spec.ts'
       - 'apps/web/tests/useAttendanceAdminRail.spec.ts'
       - 'apps/web/tests/useAttendanceAdminRailNavigation.spec.ts'
@@ -140,6 +141,7 @@ on:
       - 'apps/web/src/views/AttendanceView.vue'
       - 'apps/web/src/views/attendance/**'
       - 'apps/web/tests/attendance-admin-regressions.spec.ts'
+      - 'apps/web/tests/attendance-shift-segments.spec.ts'
       - 'apps/web/tests/attendance-admin-anchor-nav.spec.ts'
       - 'apps/web/tests/useAttendanceAdminRail.spec.ts'
       - 'apps/web/tests/useAttendanceAdminRailNavigation.spec.ts'
@@ -220,4 +222,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run attendance web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust attendance-overview-priority AttendanceAdminTaskHome attendance-experience-entrypoints attendance-setup-readiness AttendanceSetupReadiness.spec useAttendanceSetupReadiness attendance-setup-templates --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-shift-segments attendance-admin-anchor-nav useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust attendance-overview-priority AttendanceAdminTaskHome attendance-experience-entrypoints attendance-setup-readiness AttendanceSetupReadiness.spec useAttendanceSetupReadiness attendance-setup-templates --reporter=dot

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -8760,24 +8760,11 @@
                   </select>
                   <small class="attendance__field-hint">{{ tr('Current', '当前') }}: {{ shiftTimezoneLabel }}</small>
                 </label>
-                <label class="attendance__field" for="attendance-shift-start">
-                  <span>{{ tr('Work start', '上班开始') }}</span>
-                  <input
-                    id="attendance-shift-start"
-                    name="shiftWorkStartTime"
-                    v-model="shiftForm.workStartTime"
-                    type="time"
-                  />
-                </label>
-                <label class="attendance__field" for="attendance-shift-end">
-                  <span>{{ tr('Work end', '下班结束') }}</span>
-                  <input
-                    id="attendance-shift-end"
-                    name="shiftWorkEndTime"
-                    v-model="shiftForm.workEndTime"
-                    type="time"
-                  />
-                </label>
+                <AttendanceShiftSegmentsEditor
+                  v-model:segments="shiftForm.segments"
+                  :analysis="shiftSegmentAnalysis"
+                  :preview-only="shiftSegmentPreviewOnly"
+                />
                 <label class="attendance__field" for="attendance-shift-late-grace">
                   <span>{{ tr('Late grace (min)', '迟到宽限（分钟）') }}</span>
                   <input
@@ -8834,8 +8821,8 @@
                     <tr>
                       <th>{{ tr('Name', '名称') }}</th>
                       <th>{{ tr('Timezone', '时区') }}</th>
-                      <th>{{ tr('Start', '开始') }}</th>
-                      <th>{{ tr('End', '结束') }}</th>
+                      <th>{{ tr('Segments', '时段') }}</th>
+                      <th>{{ tr('Planned', '计划时长') }}</th>
                       <th>{{ tr('Working days', '工作日') }}</th>
                       <th>{{ tr('Actions', '操作') }}</th>
                     </tr>
@@ -8844,8 +8831,17 @@
                     <tr v-for="shift in shifts" :key="shift.id">
                       <td>{{ shift.name }}</td>
                       <td>{{ displayTimezone(shift.timezone) }}</td>
-                      <td>{{ shift.workStartTime }}</td>
-                      <td>{{ shift.workEndTime }}</td>
+                      <td>
+                        <span data-attendance-shift-list-segments>{{ shiftSegmentsLabel(shift) }}</span>
+                        <span
+                          v-if="shiftIsPreviewOnly(shift)"
+                          class="attendance__shift-preview-badge"
+                          data-attendance-shift-list-preview-only
+                        >
+                          {{ tr('Preview only', '仅供预览') }}
+                        </span>
+                      </td>
+                      <td class="attendance__tabular-number">{{ shiftPlannedMinutes(shift) }} {{ tr('min', '分钟') }}</td>
                       <td>{{ shift.workingDays.join(',') }}</td>
                       <td class="attendance__table-actions">
                         <button class="attendance__btn" @click="editShift(shift)">{{ tr('Edit', '编辑') }}</button>
@@ -9756,8 +9752,20 @@ import { ArrowLeft } from '@element-plus/icons-vue'
 import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import AttendanceAdminRail from './attendance/AttendanceAdminRail.vue'
 import AttendanceAdminTaskHome from './attendance/AttendanceAdminTaskHome.vue'
+import AttendanceShiftSegmentsEditor from './attendance/AttendanceShiftSegmentsEditor.vue'
 import AttendanceSetupReadiness from './attendance/AttendanceSetupReadiness.vue'
 import AttendanceSetupTemplatePrefillDialog from './attendance/AttendanceSetupTemplatePrefillDialog.vue'
+import {
+  analyzeAttendanceShiftSegments,
+  calculateAttendanceShiftPlannedMinutes,
+  cloneAttendanceShiftSegmentDrafts,
+  formatAttendanceShiftSegments,
+  isAttendanceShiftPreviewOnly,
+  normalizeAttendanceShiftSegments,
+  type AttendanceShiftSegment,
+  type AttendanceShiftSegmentCapabilities,
+  type AttendanceShiftSegmentDraft,
+} from './attendance/attendanceShiftSegments'
 import { attendanceSetupPrefillPending } from './attendance/attendanceSetupPrefillLeaveGuard'
 import {
   buildAttendanceSetupTemplatePrefillPlan,
@@ -11120,6 +11128,10 @@ interface AttendanceShift {
   earlyGraceMinutes: number
   roundingMinutes: number
   workingDays: number[]
+  segments?: AttendanceShiftSegment[]
+  calculationMode?: 'envelope' | 'segments'
+  plannedMinutes?: number
+  capabilities?: AttendanceShiftSegmentCapabilities
 }
 
 interface AttendanceAssignment {
@@ -14526,6 +14538,7 @@ const setupTemplateDialog = ref<null | {
   orgTimezone: string | null
   snapshot: AttendanceSetupPrefillSnapshot
 }>(null)
+const setupTemplateShiftSegmentsSnapshot = ref<AttendanceShiftSegmentDraft[] | null>(null)
 
 // Applied-but-unsaved prefill tracker (per target form). Cleared by: undo (both), a successful
 // group save, and each form's reset (reset discards the prefilled content, so the leave warning
@@ -14588,6 +14601,7 @@ function openSetupTemplate(templateId: AttendanceSetupTemplateId): void {
   const orgTimezone = resolveAttendanceSetupOrgTimezone(
     attendanceGroups.value.map((group) => group.timezone),
   )
+  setupTemplateShiftSegmentsSnapshot.value = cloneAttendanceShiftSegmentDrafts(shiftForm.segments)
   setupTemplateDialog.value = {
     stage: 'confirm',
     templateId,
@@ -14620,6 +14634,12 @@ function applySetupTemplate(): void {
     shiftForm.timezone = plan.shift.timezone
     shiftForm.workStartTime = plan.shift.workStartTime
     shiftForm.workEndTime = plan.shift.workEndTime
+    replaceShiftSegments([{
+      startTime: plan.shift.workStartTime,
+      startDayOffset: 0,
+      endTime: plan.shift.workEndTime,
+      endDayOffset: plan.shift.workEndTime <= plan.shift.workStartTime ? 1 : 0,
+    }])
     shiftForm.lateGraceMinutes = plan.shift.lateGraceMinutes
     shiftForm.earlyGraceMinutes = plan.shift.earlyGraceMinutes
     shiftForm.roundingMinutes = plan.shift.roundingMinutes
@@ -14636,6 +14656,7 @@ function applySetupTemplate(): void {
 function cancelSetupTemplateConfirm(): void {
   // Confirm-stage cancel: nothing was applied, nothing to restore.
   setupTemplateDialog.value = null
+  setupTemplateShiftSegmentsSnapshot.value = null
 }
 
 function closeSetupTemplateDialogKeepPrefill(): void {
@@ -14643,6 +14664,7 @@ function closeSetupTemplateDialogKeepPrefill(): void {
   // pending-unsaved tracker (leave warnings stay armed); only the dialog and its undo snapshot
   // are released — exactly what the dialog's undo-scope copy promises.
   setupTemplateDialog.value = null
+  setupTemplateShiftSegmentsSnapshot.value = null
 }
 
 function undoSetupTemplate(): void {
@@ -14661,12 +14683,21 @@ function undoSetupTemplate(): void {
   shiftForm.timezone = snapshot.shift.timezone
   shiftForm.workStartTime = snapshot.shift.workStartTime
   shiftForm.workEndTime = snapshot.shift.workEndTime
+  replaceShiftSegments(
+    setupTemplateShiftSegmentsSnapshot.value ?? [{
+      startTime: snapshot.shift.workStartTime,
+      startDayOffset: 0,
+      endTime: snapshot.shift.workEndTime,
+      endDayOffset: snapshot.shift.workEndTime <= snapshot.shift.workStartTime ? 1 : 0,
+    }],
+  )
   shiftForm.lateGraceMinutes = snapshot.shift.lateGraceMinutes
   shiftForm.earlyGraceMinutes = snapshot.shift.earlyGraceMinutes
   shiftForm.roundingMinutes = snapshot.shift.roundingMinutes
   shiftForm.workingDays = snapshot.shift.workingDays
   setupTemplatePrefillPending.value = { group: false, shift: false, templateId: null }
   setupTemplateDialog.value = null
+  setupTemplateShiftSegmentsSnapshot.value = null
 }
 
 function navigateSetupTemplate(sectionId: string): void {
@@ -15582,11 +15613,24 @@ const shiftForm = reactive({
   timezone: defaultTimezone,
   workStartTime: '09:00',
   workEndTime: '18:00',
+  segments: [
+    {
+      startTime: '09:00',
+      startDayOffset: 0,
+      endTime: '18:00',
+      endDayOffset: 0,
+    },
+  ] as AttendanceShiftSegmentDraft[],
   lateGraceMinutes: 10,
   earlyGraceMinutes: 10,
   roundingMinutes: 5,
   workingDays: '1,2,3,4,5',
 })
+
+watch(
+  () => shiftForm.segments.map(segment => `${segment.startTime}/${segment.endTime}/${segment.endDayOffset}`).join('|'),
+  () => syncShiftEnvelopeFields(),
+)
 
 const assignmentForm = reactive({
   userId: '',
@@ -25918,6 +25962,45 @@ async function deleteRotationAssignment(id: string) {
   }
 }
 
+function replaceShiftSegments(segments: AttendanceShiftSegmentDraft[]): void {
+  shiftForm.segments.splice(0, shiftForm.segments.length, ...cloneAttendanceShiftSegmentDrafts(segments))
+  syncShiftEnvelopeFields()
+}
+
+function syncShiftEnvelopeFields(): void {
+  const first = shiftForm.segments[0]
+  const last = shiftForm.segments[shiftForm.segments.length - 1]
+  if (!first || !last) return
+  shiftForm.workStartTime = first.startTime
+  shiftForm.workEndTime = last.endTime
+}
+
+const shiftSegmentAnalysis = computed(() => analyzeAttendanceShiftSegments(shiftForm.segments, tr))
+
+const shiftSegmentValidationErrors = computed(() => shiftSegmentAnalysis.value.errors)
+const editingShift = computed(() => (
+  shiftEditingId.value
+    ? shifts.value.find(shift => shift.id === shiftEditingId.value) ?? null
+    : null
+))
+const shiftSegmentPreviewOnly = computed(() => {
+  if (shiftForm.segments.length <= 1) return false
+  const capability = editingShift.value?.capabilities?.segmentCalculation
+  return capability?.authoritativeResults !== true || capability?.multiSegmentAuthoring !== 'enabled'
+})
+
+function shiftSegmentsLabel(shift: AttendanceShift): string {
+  return formatAttendanceShiftSegments(shift, tr)
+}
+
+function shiftPlannedMinutes(shift: AttendanceShift): number {
+  return calculateAttendanceShiftPlannedMinutes(shift)
+}
+
+function shiftIsPreviewOnly(shift: AttendanceShift): boolean {
+  return isAttendanceShiftPreviewOnly(shift)
+}
+
 function resetShiftForm() {
   // W4-2: a reset discards any template-prefilled shift content (save success also lands here) —
   // stop the unsaved-prefill leave warning for this form.
@@ -25927,6 +26010,12 @@ function resetShiftForm() {
   shiftForm.timezone = defaultTimezone
   shiftForm.workStartTime = '09:00'
   shiftForm.workEndTime = '18:00'
+  replaceShiftSegments([{
+    startTime: '09:00',
+    startDayOffset: 0,
+    endTime: '18:00',
+    endDayOffset: 0,
+  }])
   shiftForm.lateGraceMinutes = 10
   shiftForm.earlyGraceMinutes = 10
   shiftForm.roundingMinutes = 5
@@ -25939,6 +26028,7 @@ function editShift(shift: AttendanceShift) {
   shiftForm.timezone = shift.timezone
   shiftForm.workStartTime = shift.workStartTime
   shiftForm.workEndTime = shift.workEndTime
+  replaceShiftSegments(normalizeAttendanceShiftSegments(shift))
   shiftForm.lateGraceMinutes = shift.lateGraceMinutes
   shiftForm.earlyGraceMinutes = shift.earlyGraceMinutes
   shiftForm.roundingMinutes = shift.roundingMinutes
@@ -25977,14 +26067,23 @@ async function loadShifts() {
 }
 
 async function saveShift() {
+  if (shiftSegmentValidationErrors.value.length > 0) {
+    setStatus(shiftSegmentValidationErrors.value[0]!, 'error')
+    return
+  }
   shiftSaving.value = true
   const isEditing = Boolean(shiftEditingId.value)
   try {
     const payload = {
       name: shiftForm.name,
       timezone: shiftForm.timezone,
-      workStartTime: shiftForm.workStartTime,
-      workEndTime: shiftForm.workEndTime,
+      segments: shiftForm.segments.map((segment, segmentIndex) => ({
+        segmentIndex,
+        startTime: segment.startTime,
+        startDayOffset: 0,
+        endTime: segment.endTime,
+        endDayOffset: segment.endDayOffset,
+      })),
       lateGraceMinutes: Number(shiftForm.lateGraceMinutes) || 0,
       earlyGraceMinutes: Number(shiftForm.earlyGraceMinutes) || 0,
       roundingMinutes: Number(shiftForm.roundingMinutes) || 0,
@@ -26018,7 +26117,10 @@ async function saveShift() {
 }
 
 async function deleteShift(id: string) {
-  if (!window.confirm(tr('Delete this shift? Assignments will be removed.', '确认删除该班次吗？关联分配也会被移除。'))) return
+  if (!window.confirm(tr(
+    'Delete this shift? Deletion is blocked while assignments, rotation rules, pending swaps, or pending/published dispatches still reference it.',
+    '确认删除该班次吗？只要仍有分配、轮班规则、待处理换班，或待处理/已发布调度引用它，系统就会阻止删除。',
+  ))) return
   try {
     const response = await apiFetch(`/api/attendance/shifts/${id}`, { method: 'DELETE' })
     if (response.status === 403) {
@@ -28722,6 +28824,21 @@ defineExpose({
 
 .attendance__field--full {
   flex: 1;
+}
+
+.attendance__shift-preview-badge {
+  display: inline-block;
+  margin-left: var(--ms-space-2);
+  padding: 2px var(--ms-space-2);
+  border: 1px solid var(--ms-color-warning);
+  border-radius: var(--ms-radius-sm);
+  color: var(--ms-text-1);
+  background: var(--ms-bg-page);
+  white-space: nowrap;
+}
+
+.attendance__tabular-number {
+  font-variant-numeric: tabular-nums;
 }
 
 .attendance__field--compact {

--- a/apps/web/src/views/attendance/AttendanceShiftSegmentsEditor.vue
+++ b/apps/web/src/views/attendance/AttendanceShiftSegmentsEditor.vue
@@ -1,0 +1,324 @@
+<template>
+  <div class="shift-segments" data-attendance-shift-segments>
+    <div class="shift-segments__header">
+      <span>{{ tr('Paid work segments', '计薪工作时段') }}</span>
+      <button
+        class="shift-segments__icon-button"
+        type="button"
+        :disabled="!canAddSegment"
+        :title="addSegmentTitle"
+        :aria-label="tr('Add segment', '添加时段')"
+        data-attendance-shift-segment-add
+        @click="addSegment"
+      >
+        <Plus />
+      </button>
+    </div>
+
+    <div
+      v-for="(segment, segmentIndex) in segments"
+      :key="`shift-segment-${segmentIndex}`"
+      class="shift-segments__row"
+      data-attendance-shift-segment-row
+    >
+      <strong>{{ tr(`Segment ${segmentIndex + 1}`, `时段 ${segmentIndex + 1}`) }}</strong>
+      <label class="shift-segments__field">
+        <span>{{ tr('Start', '开始') }}</span>
+        <input
+          v-model="segment.startTime"
+          type="time"
+          step="60"
+          :data-attendance-shift-segment-start="segmentIndex"
+        />
+      </label>
+      <label class="shift-segments__field">
+        <span>{{ tr('End', '结束') }}</span>
+        <input
+          v-model="segment.endTime"
+          type="time"
+          step="60"
+          :data-attendance-shift-segment-end="segmentIndex"
+        />
+      </label>
+      <label class="shift-segments__field">
+        <span>{{ tr('End day', '结束日期') }}</span>
+        <select
+          v-model.number="segment.endDayOffset"
+          :data-attendance-shift-segment-end-day="segmentIndex"
+        >
+          <option :value="0">{{ tr('Same day', '当日') }}</option>
+          <option :value="1">{{ tr('Next day', '次日') }}</option>
+        </select>
+      </label>
+      <div class="shift-segments__actions">
+        <button
+          class="shift-segments__icon-button"
+          type="button"
+          :disabled="segmentIndex === 0"
+          :title="tr('Move segment up', '上移时段')"
+          :aria-label="tr(`Move segment ${segmentIndex + 1} up`, `上移时段 ${segmentIndex + 1}`)"
+          :data-attendance-shift-segment-up="segmentIndex"
+          @click="moveSegment(segmentIndex, -1)"
+        >
+          <Top />
+        </button>
+        <button
+          class="shift-segments__icon-button"
+          type="button"
+          :disabled="segmentIndex === segments.length - 1"
+          :title="tr('Move segment down', '下移时段')"
+          :aria-label="tr(`Move segment ${segmentIndex + 1} down`, `下移时段 ${segmentIndex + 1}`)"
+          :data-attendance-shift-segment-down="segmentIndex"
+          @click="moveSegment(segmentIndex, 1)"
+        >
+          <Bottom />
+        </button>
+        <button
+          class="shift-segments__icon-button shift-segments__icon-button--danger"
+          type="button"
+          :disabled="segments.length === 1"
+          :title="tr('Remove segment', '删除时段')"
+          :aria-label="tr(`Remove segment ${segmentIndex + 1}`, `删除时段 ${segmentIndex + 1}`)"
+          :data-attendance-shift-segment-remove="segmentIndex"
+          @click="removeSegment(segmentIndex)"
+        >
+          <Delete />
+        </button>
+      </div>
+    </div>
+
+    <ul
+      v-if="analysis.errors.length"
+      class="shift-segments__errors"
+      role="alert"
+      data-attendance-shift-segment-errors
+    >
+      <li v-for="error in analysis.errors" :key="error">{{ error }}</li>
+    </ul>
+
+    <div
+      class="shift-segments__preview"
+      data-attendance-shift-segment-preview
+      :data-planned-minutes="analysis.plannedMinutes"
+      :data-gap-minutes="analysis.unpaidGapMinutes"
+    >
+      <span>
+        <strong>{{ analysis.plannedMinutes }}</strong>
+        {{ tr('paid min', '计薪分钟') }}
+      </span>
+      <span>
+        <strong>{{ analysis.unpaidGapMinutes }}</strong>
+        {{ tr('unpaid gap min', '非计薪间隔分钟') }}
+      </span>
+      <span>{{ analysis.midnightCrossings ? tr('Crosses midnight', '跨午夜') : tr('Same-day', '当日') }}</span>
+      <span>{{ analysis.flexEligible ? tr('Flex eligible', '可配置弹性') : tr('Flex unavailable', '不可配置弹性') }}</span>
+      <span>{{ tr('Envelope', '兼容时间窗') }}: {{ analysis.compatibilityEnvelope }}</span>
+    </div>
+
+    <p
+      v-if="previewOnly"
+      class="shift-segments__warning"
+      role="status"
+      data-attendance-shift-segment-preview-only
+    >
+      {{
+        tr(
+          'Preview only: you may save and edit this shift, but it cannot be assigned, rotated, swapped, dispatched, published, or auto-matched until authoritative segment calculation is enabled.',
+          '仅供预览：可以保存和编辑，但在权威分段核算启用前，不能用于分配、轮班、换班、调度、发布或自动匹配。',
+        )
+      }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Bottom, Delete, Plus, Top } from '@element-plus/icons-vue'
+import { computed } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import type {
+  AttendanceShiftSegmentAnalysis,
+  AttendanceShiftSegmentDraft,
+} from './attendanceShiftSegments'
+
+defineProps<{
+  analysis: AttendanceShiftSegmentAnalysis
+  previewOnly: boolean
+}>()
+
+const segments = defineModel<AttendanceShiftSegmentDraft[]>('segments', { required: true })
+const { isZh } = useLocale()
+const tr = (en: string, zh: string): string => (isZh.value ? zh : en)
+const canAddSegment = computed(() => (
+  segments.value.length < 3
+  && segments.value[segments.value.length - 1]?.endDayOffset !== 1
+))
+const addSegmentTitle = computed(() => (
+  segments.value[segments.value.length - 1]?.endDayOffset === 1
+    ? tr('A cross-midnight segment must be last.', '跨午夜时段必须是最后一段。')
+    : tr('Add segment', '添加时段')
+))
+
+function addSegment(): void {
+  if (!canAddSegment.value) return
+  const previous = segments.value[segments.value.length - 1]
+  const startTime = previous?.endTime ?? '09:00'
+  const [hour = 9, minute = 0] = startTime.split(':').map(Number)
+  const nextTotalMinutes = hour * 60 + minute + 60
+  const nextHour = Math.floor((nextTotalMinutes % 1440) / 60)
+  const nextMinute = nextTotalMinutes % 60
+  segments.value.push({
+    startTime,
+    startDayOffset: 0,
+    endTime: `${String(nextHour).padStart(2, '0')}:${String(nextMinute).padStart(2, '0')}`,
+    endDayOffset: nextTotalMinutes >= 1440 ? 1 : 0,
+  })
+}
+
+function moveSegment(index: number, direction: -1 | 1): void {
+  const target = index + direction
+  if (target < 0 || target >= segments.value.length) return
+  const [segment] = segments.value.splice(index, 1)
+  if (segment) segments.value.splice(target, 0, segment)
+}
+
+function removeSegment(index: number): void {
+  if (segments.value.length <= 1) return
+  segments.value.splice(index, 1)
+}
+</script>
+
+<style scoped>
+.shift-segments {
+  display: grid;
+  grid-column: 1 / -1;
+  gap: var(--ms-space-3);
+  min-width: 0;
+  padding: var(--ms-space-3);
+  border: 1px solid var(--ms-border-light);
+  border-radius: var(--ms-radius-md);
+  background: var(--ms-bg-card);
+  font-size: 12px;
+}
+
+.shift-segments__header,
+.shift-segments__actions,
+.shift-segments__preview {
+  display: flex;
+  align-items: center;
+  gap: var(--ms-space-2);
+}
+
+.shift-segments__header {
+  justify-content: space-between;
+  color: var(--ms-text-1);
+  font-weight: var(--ms-font-weight-title);
+}
+
+.shift-segments__row {
+  display: grid;
+  grid-template-columns: minmax(72px, max-content) repeat(3, minmax(140px, 1fr)) max-content;
+  align-items: end;
+  gap: var(--ms-space-3);
+  padding-top: var(--ms-space-3);
+  border-top: 1px solid var(--ms-border-light);
+}
+
+.shift-segments__row > strong {
+  align-self: center;
+  color: var(--ms-text-1);
+}
+
+.shift-segments__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  color: var(--ms-text-2);
+}
+
+.shift-segments__field input,
+.shift-segments__field select {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  padding: 6px 10px;
+  border: 1px solid var(--ms-border);
+  border-radius: var(--ms-radius-sm);
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
+}
+
+.shift-segments__actions {
+  min-height: 36px;
+}
+
+.shift-segments__icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 1px solid var(--ms-border);
+  border-radius: var(--ms-radius-sm);
+  background: var(--ms-bg-card);
+  color: var(--ms-text-1);
+  cursor: pointer;
+}
+
+.shift-segments__icon-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.shift-segments__icon-button--danger {
+  border-color: var(--ms-color-danger);
+  color: var(--ms-color-danger);
+}
+
+.shift-segments__icon-button svg {
+  width: 16px;
+  height: 16px;
+}
+
+.shift-segments__errors {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--ms-color-danger);
+}
+
+.shift-segments__preview {
+  flex-wrap: wrap;
+  color: var(--ms-text-2);
+  font-variant-numeric: tabular-nums;
+}
+
+.shift-segments__preview span {
+  padding-right: var(--ms-space-3);
+  border-right: 1px solid var(--ms-border-light);
+}
+
+.shift-segments__preview span:last-child {
+  padding-right: 0;
+  border-right: 0;
+}
+
+.shift-segments__warning {
+  margin: 0;
+  padding: var(--ms-space-3);
+  border-left: 3px solid var(--ms-color-warning);
+  color: var(--ms-text-1);
+  background: var(--ms-bg-page);
+}
+
+@media (max-width: 768px) {
+  .shift-segments__row {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .shift-segments__actions {
+    justify-content: flex-end;
+  }
+}
+</style>

--- a/apps/web/src/views/attendance/attendanceShiftSegments.ts
+++ b/apps/web/src/views/attendance/attendanceShiftSegments.ts
@@ -1,0 +1,166 @@
+export interface AttendanceShiftSegment {
+  id?: string | null
+  segmentIndex: number
+  startTime: string
+  startDayOffset: 0
+  endTime: string
+  endDayOffset: 0 | 1
+}
+
+export interface AttendanceShiftSegmentDraft {
+  startTime: string
+  startDayOffset: 0
+  endTime: string
+  endDayOffset: 0 | 1
+}
+
+export interface AttendanceShiftSegmentCapabilities {
+  segmentCalculation?: {
+    enabled?: boolean
+    authoritativeResults?: boolean
+    multiSegmentAuthoring?: 'preview_only' | 'enabled'
+  }
+}
+
+export interface AttendanceShiftSegmentSource {
+  workStartTime: string
+  workEndTime: string
+  segments?: AttendanceShiftSegment[]
+  plannedMinutes?: number
+  capabilities?: AttendanceShiftSegmentCapabilities
+}
+
+export interface AttendanceShiftSegmentAnalysis {
+  errors: string[]
+  plannedMinutes: number
+  unpaidGapMinutes: number
+  midnightCrossings: number
+  flexEligible: boolean
+  compatibilityEnvelope: string
+}
+
+type AttendanceShiftSegmentTranslate = (en: string, zh: string) => string
+
+export function cloneAttendanceShiftSegmentDrafts(
+  segments: AttendanceShiftSegmentDraft[],
+): AttendanceShiftSegmentDraft[] {
+  return segments.map(segment => ({
+    startTime: segment.startTime,
+    startDayOffset: 0,
+    endTime: segment.endTime,
+    endDayOffset: segment.endDayOffset === 1 ? 1 : 0,
+  }))
+}
+
+export function normalizeAttendanceShiftSegments(
+  shift: AttendanceShiftSegmentSource,
+): AttendanceShiftSegmentDraft[] {
+  if (Array.isArray(shift.segments) && shift.segments.length > 0) {
+    return shift.segments
+      .slice()
+      .sort((left, right) => Number(left.segmentIndex) - Number(right.segmentIndex))
+      .map(segment => ({
+        startTime: segment.startTime,
+        startDayOffset: 0,
+        endTime: segment.endTime,
+        endDayOffset: segment.endDayOffset === 1 ? 1 : 0,
+      }))
+  }
+  return [{
+    startTime: shift.workStartTime,
+    startDayOffset: 0,
+    endTime: shift.workEndTime,
+    endDayOffset: shift.workEndTime <= shift.workStartTime ? 1 : 0,
+  }]
+}
+
+export function parseAttendanceShiftClockMinutes(value: string): number | null {
+  const match = /^(?:([01]\d|2[0-3])):([0-5]\d)$/.exec(value)
+  if (!match) return null
+  return Number(match[1]) * 60 + Number(match[2])
+}
+
+export function analyzeAttendanceShiftSegments(
+  segments: AttendanceShiftSegmentDraft[],
+  tr: AttendanceShiftSegmentTranslate,
+): AttendanceShiftSegmentAnalysis {
+  const errors: string[] = []
+  if (segments.length < 1 || segments.length > 3) {
+    errors.push(tr('A shift must contain 1 to 3 segments.', '一个班次必须包含 1 至 3 个时段。'))
+  }
+
+  let plannedMinutes = 0
+  let unpaidGapMinutes = 0
+  let midnightCrossings = 0
+  let previousEnd: number | null = null
+
+  segments.forEach((segment, index) => {
+    const start = parseAttendanceShiftClockMinutes(segment.startTime)
+    const end = parseAttendanceShiftClockMinutes(segment.endTime)
+    const row = index + 1
+    if (start === null || end === null) {
+      errors.push(tr(`Segment ${row} must use HH:MM times.`, `时段 ${row} 必须使用 HH:MM 时间。`))
+      return
+    }
+    const absoluteEnd = end + segment.endDayOffset * 1440
+    if (absoluteEnd <= start) {
+      errors.push(tr(`Segment ${row} must end after it starts.`, `时段 ${row} 的结束时间必须晚于开始时间。`))
+      return
+    }
+    if (previousEnd !== null && start < previousEnd) {
+      errors.push(tr(`Segment ${row} overlaps or is out of order.`, `时段 ${row} 与前一时段重叠或顺序错误。`))
+    } else if (previousEnd !== null) {
+      unpaidGapMinutes += start - previousEnd
+    }
+    plannedMinutes += absoluteEnd - start
+    previousEnd = absoluteEnd
+    if (segment.endDayOffset === 1) midnightCrossings += 1
+  })
+
+  if (midnightCrossings > 1) {
+    errors.push(tr('At most one segment may cross midnight.', '最多只能有一个时段跨午夜。'))
+  }
+  if (plannedMinutes > 1440) {
+    errors.push(tr('Total planned time cannot exceed 24 hours.', '计划总时长不能超过 24 小时。'))
+  }
+
+  const first = segments[0]
+  const last = segments[segments.length - 1]
+  return {
+    errors: Array.from(new Set(errors)),
+    plannedMinutes,
+    unpaidGapMinutes,
+    midnightCrossings,
+    flexEligible: segments.length === 1,
+    compatibilityEnvelope: first && last
+      ? `${first.startTime} - ${last.endTime}${midnightCrossings > 0 ? tr(' (next day)', '（次日）') : ''}`
+      : '--',
+  }
+}
+
+export function formatAttendanceShiftSegments(
+  shift: AttendanceShiftSegmentSource,
+  tr: AttendanceShiftSegmentTranslate,
+): string {
+  return normalizeAttendanceShiftSegments(shift)
+    .map(segment => `${segment.startTime}-${segment.endTime}${segment.endDayOffset === 1 ? tr(' next day', ' 次日') : ''}`)
+    .join(' / ')
+}
+
+export function calculateAttendanceShiftPlannedMinutes(shift: AttendanceShiftSegmentSource): number {
+  if (typeof shift.plannedMinutes === 'number' && Number.isFinite(shift.plannedMinutes)) {
+    return shift.plannedMinutes
+  }
+  return normalizeAttendanceShiftSegments(shift).reduce((total, segment) => {
+    const start = parseAttendanceShiftClockMinutes(segment.startTime)
+    const end = parseAttendanceShiftClockMinutes(segment.endTime)
+    if (start === null || end === null) return total
+    return total + Math.max(0, end + segment.endDayOffset * 1440 - start)
+  }, 0)
+}
+
+export function isAttendanceShiftPreviewOnly(shift: AttendanceShiftSegmentSource): boolean {
+  if (normalizeAttendanceShiftSegments(shift).length <= 1) return false
+  const capability = shift.capabilities?.segmentCalculation
+  return capability?.authoritativeResults !== true || capability?.multiSegmentAuthoring !== 'enabled'
+}

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -844,6 +844,225 @@ describe('Attendance admin regressions', () => {
     container = null
   })
 
+  type ShiftWrite = {
+    url: string
+    method: string
+    body: Record<string, unknown>
+  }
+
+  function attendanceShiftFixture(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      id: 'shift-day',
+      name: 'Day shift',
+      timezone: 'Asia/Shanghai',
+      workStartTime: '09:00',
+      workEndTime: '18:00',
+      isOvernight: false,
+      lateGraceMinutes: 10,
+      earlyGraceMinutes: 10,
+      roundingMinutes: 5,
+      workingDays: [1, 2, 3, 4, 5],
+      ...overrides,
+    }
+  }
+
+  function installShiftSegmentApi(shifts: Array<Record<string, unknown>>): ShiftWrite[] {
+    const writes: ShiftWrite[] = []
+    const fallback = vi.mocked(apiFetch).getMockImplementation()
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      const method = String(init?.method || 'GET').toUpperCase()
+      if (/^\/api\/attendance\/shifts(?:\?.*)?$/.test(url) && method === 'GET') {
+        return jsonResponse(200, { ok: true, data: { items: shifts, total: shifts.length } })
+      }
+      if (url === '/api/attendance/shifts' && method === 'POST') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        writes.push({ url, method, body })
+        return jsonResponse(201, { ok: true, data: { shift: { id: 'shift-created', ...body } } })
+      }
+      if (/^\/api\/attendance\/shifts\/[^/]+$/.test(url) && method === 'PUT') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        writes.push({ url, method, body })
+        return jsonResponse(200, { ok: true, data: { shift: { id: url.split('/').pop(), ...body } } })
+      }
+      if (/^\/api\/attendance\/shifts\/[^/]+$/.test(url) && method === 'DELETE') {
+        writes.push({ url, method, body: {} })
+        return jsonResponse(200, { ok: true, data: { deleted: true } })
+      }
+      return fallback ? fallback(input, init) : emptyAttendanceResponse()
+    })
+    return writes
+  }
+
+  async function mountShiftAdmin(): Promise<HTMLElement> {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    const shiftsNav = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-shifts"]')
+    expect(shiftsNav).toBeTruthy()
+    shiftsNav!.click()
+    await flushUi(4)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-shifts')
+    expect(section).toBeTruthy()
+    return section!
+  }
+
+  it('normalizes legacy shifts, preserves ordered segments on edit, and exposes preview-only limits', async () => {
+    const splitShift = attendanceShiftFixture({
+      id: 'shift-split',
+      name: 'Split shift',
+      workStartTime: '08:00',
+      workEndTime: '17:00',
+      segments: [
+        { id: 'segment-b', segmentIndex: 1, startTime: '13:00', startDayOffset: 0, endTime: '17:00', endDayOffset: 0 },
+        { id: 'segment-a', segmentIndex: 0, startTime: '08:00', startDayOffset: 0, endTime: '12:00', endDayOffset: 0 },
+      ],
+      plannedMinutes: 480,
+      capabilities: {
+        segmentCalculation: {
+          enabled: false,
+          authoritativeResults: false,
+          multiSegmentAuthoring: 'preview_only',
+        },
+      },
+    })
+    const writes = installShiftSegmentApi([
+      attendanceShiftFixture(),
+      splitShift,
+    ])
+    const section = await mountShiftAdmin()
+
+    const rows = Array.from(section.querySelectorAll<HTMLTableRowElement>('tbody tr'))
+    expect(rows).toHaveLength(2)
+    expect(rows[0]!.querySelector('[data-attendance-shift-list-segments]')?.textContent).toContain('09:00-18:00')
+    expect(rows[1]!.querySelector('[data-attendance-shift-list-segments]')?.textContent).toContain('08:00-12:00 / 13:00-17:00')
+    expect(rows[1]!.querySelector('[data-attendance-shift-list-preview-only]')?.textContent).toContain('Preview only')
+
+    const editButton = Array.from(rows[1]!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.trim() === 'Edit')
+    expect(editButton).toBeTruthy()
+    editButton!.click()
+    await flushUi(3)
+
+    expect(section.querySelectorAll('[data-attendance-shift-segment-row]')).toHaveLength(2)
+    expect(section.querySelector<HTMLInputElement>('[data-attendance-shift-segment-start="0"]')?.value).toBe('08:00')
+    expect(section.querySelector<HTMLInputElement>('[data-attendance-shift-segment-start="1"]')?.value).toBe('13:00')
+    const preview = section.querySelector<HTMLElement>('[data-attendance-shift-segment-preview]')
+    expect(preview?.dataset.plannedMinutes).toBe('480')
+    expect(preview?.dataset.gapMinutes).toBe('60')
+    const warning = section.querySelector<HTMLElement>('[data-attendance-shift-segment-preview-only]')
+    expect(warning?.textContent).toContain('assigned, rotated, swapped, dispatched, published, or auto-matched')
+
+    section.querySelector<HTMLButtonElement>('.attendance__admin-actions .attendance__btn--primary')!.click()
+    await flushUi(6)
+    expect(writes).toHaveLength(1)
+    expect(writes[0]).toMatchObject({
+      url: '/api/attendance/shifts/shift-split',
+      method: 'PUT',
+      body: {
+        name: 'Split shift',
+        timezone: 'Asia/Shanghai',
+        segments: [
+          { segmentIndex: 0, startTime: '08:00', startDayOffset: 0, endTime: '12:00', endDayOffset: 0 },
+          { segmentIndex: 1, startTime: '13:00', startDayOffset: 0, endTime: '17:00', endDayOffset: 0 },
+        ],
+      },
+    })
+    expect(writes[0]!.body).not.toHaveProperty('workStartTime')
+    expect(writes[0]!.body).not.toHaveProperty('workEndTime')
+    expect(writes[0]!.body).not.toHaveProperty('isOvernight')
+  })
+
+  it('adds, reorders, and removes shift segments while calculating paid time without gaps', async () => {
+    installShiftSegmentApi([])
+    const section = await mountShiftAdmin()
+    setInput(section, '[data-attendance-shift-segment-start="0"]', '08:00')
+    setInput(section, '[data-attendance-shift-segment-end="0"]', '12:00')
+    section.querySelector<HTMLButtonElement>('[data-attendance-shift-segment-add]')!.click()
+    await flushUi(2)
+    setInput(section, '[data-attendance-shift-segment-start="1"]', '13:00')
+    setInput(section, '[data-attendance-shift-segment-end="1"]', '17:00')
+    await flushUi(2)
+
+    const preview = section.querySelector<HTMLElement>('[data-attendance-shift-segment-preview]')
+    expect(preview?.dataset.plannedMinutes).toBe('480')
+    expect(preview?.dataset.gapMinutes).toBe('60')
+    expect(section.querySelector('[data-attendance-shift-segment-preview-only]')).toBeTruthy()
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-shift-segment-up="1"]')!.click()
+    await flushUi(2)
+    expect(section.querySelector<HTMLInputElement>('[data-attendance-shift-segment-start="0"]')?.value).toBe('13:00')
+    expect(section.querySelector<HTMLInputElement>('[data-attendance-shift-segment-start="1"]')?.value).toBe('08:00')
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-shift-segment-remove="1"]')!.click()
+    await flushUi(2)
+    expect(section.querySelectorAll('[data-attendance-shift-segment-row]')).toHaveLength(1)
+    expect(section.querySelector<HTMLButtonElement>('[data-attendance-shift-segment-remove="0"]')?.disabled).toBe(true)
+  })
+
+  it('blocks overlapping segments before any write and emits the exact create payload after correction', async () => {
+    const writes = installShiftSegmentApi([])
+    const section = await mountShiftAdmin()
+    setInput(section, '#attendance-shift-name', 'Split shift')
+    const timezone = section.querySelector<HTMLSelectElement>('#attendance-shift-timezone')
+    expect(timezone).toBeTruthy()
+    timezone!.value = 'Asia/Shanghai'
+    timezone!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(section, '[data-attendance-shift-segment-start="0"]', '09:00')
+    setInput(section, '[data-attendance-shift-segment-end="0"]', '12:00')
+    section.querySelector<HTMLButtonElement>('[data-attendance-shift-segment-add]')!.click()
+    await flushUi(2)
+    setInput(section, '[data-attendance-shift-segment-start="1"]', '11:00')
+    setInput(section, '[data-attendance-shift-segment-end="1"]', '17:00')
+    await flushUi(2)
+
+    expect(section.querySelector('[data-attendance-shift-segment-errors]')?.textContent).toContain('overlaps or is out of order')
+    section.querySelector<HTMLButtonElement>('.attendance__admin-actions .attendance__btn--primary')!.click()
+    await flushUi(3)
+    expect(writes).toEqual([])
+
+    setInput(section, '[data-attendance-shift-segment-start="1"]', '13:00')
+    await flushUi(2)
+    expect(section.querySelector('[data-attendance-shift-segment-errors]')).toBeNull()
+    section.querySelector<HTMLButtonElement>('.attendance__admin-actions .attendance__btn--primary')!.click()
+    await flushUi(6)
+
+    expect(writes).toHaveLength(1)
+    expect(writes[0]).toEqual({
+      url: '/api/attendance/shifts',
+      method: 'POST',
+      body: {
+        name: 'Split shift',
+        timezone: 'Asia/Shanghai',
+        segments: [
+          { segmentIndex: 0, startTime: '09:00', startDayOffset: 0, endTime: '12:00', endDayOffset: 0 },
+          { segmentIndex: 1, startTime: '13:00', startDayOffset: 0, endTime: '17:00', endDayOffset: 0 },
+        ],
+        lateGraceMinutes: 10,
+        earlyGraceMinutes: 10,
+        roundingMinutes: 5,
+        workingDays: [1, 2, 3, 4, 5],
+      },
+    })
+  })
+
+  it('states the reference-blocking shift deletion contract before calling the API', async () => {
+    const writes = installShiftSegmentApi([attendanceShiftFixture()])
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const section = await mountShiftAdmin()
+    const deleteButton = Array.from(section.querySelectorAll<HTMLButtonElement>('tbody tr button'))
+      .find(button => button.textContent?.trim() === 'Delete')
+    expect(deleteButton).toBeTruthy()
+    deleteButton!.click()
+    await flushUi(2)
+
+    expect(confirm).toHaveBeenCalledWith(expect.stringContaining(
+      'blocked while assignments, rotation rules, pending swaps, or pending/published dispatches',
+    ))
+    expect(writes).toEqual([])
+    confirm.mockRestore()
+  })
+
   it('does not preload admin-only attendance data on the employee overview surface', async () => {
     app = createApp(AttendanceView, { mode: 'overview' })
     app.mount(container!)

--- a/apps/web/tests/attendance-setup-templates.spec.ts
+++ b/apps/web/tests/attendance-setup-templates.spec.ts
@@ -645,6 +645,33 @@ describe('AttendanceView wiring — §5.2 template prefill contract (mounted)', 
     timezone: 'Asia/Shanghai',
     workStartTime: '10:30',
     workEndTime: '19:30',
+    segments: [
+      {
+        id: 's1-segment-1',
+        segmentIndex: 0,
+        startTime: '10:30',
+        startDayOffset: 0,
+        endTime: '14:00',
+        endDayOffset: 0,
+      },
+      {
+        id: 's1-segment-2',
+        segmentIndex: 1,
+        startTime: '15:00',
+        startDayOffset: 0,
+        endTime: '19:30',
+        endDayOffset: 0,
+      },
+    ],
+    calculationMode: 'segments',
+    plannedMinutes: 480,
+    capabilities: {
+      segmentCalculation: {
+        enabled: false,
+        authoritativeResults: false,
+        multiSegmentAuthoring: 'preview_only',
+      },
+    },
     lateGraceMinutes: 25,
     earlyGraceMinutes: 20,
     roundingMinutes: 15,
@@ -737,13 +764,22 @@ describe('AttendanceView wiring — §5.2 template prefill contract (mounted)', 
   /** EVERY field applySetupTemplate writes (plus both save-button labels = the editing posture),
    *  so a before/after deepEqual can never pass on a partial restore. */
   function readFormState() {
+    const shiftSegments = Array.from(
+      container!.querySelectorAll<HTMLElement>('[data-attendance-shift-segment-row]'),
+    ).map((row) => ({
+      startTime: row.querySelector<HTMLInputElement>('[data-attendance-shift-segment-start]')!.value,
+      startDayOffset: 0,
+      endTime: row.querySelector<HTMLInputElement>('[data-attendance-shift-segment-end]')!.value,
+      endDayOffset: Number(
+        row.querySelector<HTMLSelectElement>('[data-attendance-shift-segment-end-day]')!.value,
+      ),
+    }))
     return {
       groupName: groupNameInput().value,
       groupTimezone: container!.querySelector<HTMLSelectElement>('#attendance-group-timezone')!.value,
       groupType: container!.querySelector<HTMLSelectElement>('#attendance-group-type')!.value,
       shiftName: shiftNameInput().value,
-      shiftStart: container!.querySelector<HTMLInputElement>('#attendance-shift-start')!.value,
-      shiftEnd: container!.querySelector<HTMLInputElement>('#attendance-shift-end')!.value,
+      shiftSegments,
       shiftTimezone: container!.querySelector<HTMLSelectElement>('#attendance-shift-timezone')!.value,
       shiftLateGrace: container!.querySelector<HTMLInputElement>('#attendance-shift-late-grace')!.value,
       shiftEarlyGrace: container!.querySelector<HTMLInputElement>('#attendance-shift-early-grace')!.value,
@@ -922,8 +958,12 @@ describe('AttendanceView wiring — §5.2 template prefill contract (mounted)', 
       groupTimezone: 'Asia/Shanghai',
       groupType: 'fixed_shift',
       shiftName: 'Office shift 09:00-18:00',
-      shiftStart: '09:00',
-      shiftEnd: '18:00',
+      shiftSegments: [{
+        startTime: '09:00',
+        startDayOffset: 0,
+        endTime: '18:00',
+        endDayOffset: 0,
+      }],
       shiftTimezone: 'Asia/Shanghai',
       shiftLateGrace: '10',
       shiftEarlyGrace: '10',
@@ -983,14 +1023,28 @@ describe('AttendanceView wiring — §5.2 template prefill contract (mounted)', 
     expect(writes.map((c) => ({ url: c.url, method: c.method }))).toEqual([
       { url: '/api/attendance/shifts/s1', method: 'PUT' },
     ])
-    // Full body shape — the ORIGINAL shift record byte for byte (grace/rounding/workingDays are
-    // all non-default, so any missed field in undoSetupTemplate turns this red; no orgId key —
-    // the harness org is blank and JSON.stringify drops the undefined normalizedOrgId()).
+    // Full canonical body shape — the ORIGINAL two-segment shift plus its non-default
+    // grace/rounding/workingDays. Any missed field in undoSetupTemplate turns this red; no orgId
+    // key because the harness org is blank and JSON.stringify drops normalizedOrgId().
     expect(JSON.parse(writes[0].body || 'null')).toEqual({
       name: 'Night audit shift',
       timezone: 'Asia/Shanghai',
-      workStartTime: '10:30',
-      workEndTime: '19:30',
+      segments: [
+        {
+          segmentIndex: 0,
+          startTime: '10:30',
+          startDayOffset: 0,
+          endTime: '14:00',
+          endDayOffset: 0,
+        },
+        {
+          segmentIndex: 1,
+          startTime: '15:00',
+          startDayOffset: 0,
+          endTime: '19:30',
+          endDayOffset: 0,
+        },
+      ],
       lateGraceMinutes: 25,
       earlyGraceMinutes: 20,
       roundingMinutes: 15,

--- a/apps/web/tests/attendance-shift-segments.spec.ts
+++ b/apps/web/tests/attendance-shift-segments.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import {
+  analyzeAttendanceShiftSegments,
+  calculateAttendanceShiftPlannedMinutes,
+  isAttendanceShiftPreviewOnly,
+  normalizeAttendanceShiftSegments,
+  parseAttendanceShiftClockMinutes,
+  type AttendanceShiftSegmentDraft,
+} from '../src/views/attendance/attendanceShiftSegments'
+
+const tr = (en: string): string => en
+
+function segment(
+  startTime: string,
+  endTime: string,
+  endDayOffset: 0 | 1 = 0,
+): AttendanceShiftSegmentDraft {
+  return {
+    startTime,
+    startDayOffset: 0,
+    endTime,
+    endDayOffset,
+  }
+}
+
+describe('attendance shift segment analysis', () => {
+  it('accepts only strict minute-resolution wall-clock values', () => {
+    expect(parseAttendanceShiftClockMinutes('00:00')).toBe(0)
+    expect(parseAttendanceShiftClockMinutes('23:59')).toBe(1439)
+    expect(parseAttendanceShiftClockMinutes('9:00')).toBeNull()
+    expect(parseAttendanceShiftClockMinutes('09:00:00')).toBeNull()
+    expect(parseAttendanceShiftClockMinutes('24:00')).toBeNull()
+    expect(parseAttendanceShiftClockMinutes('12:60')).toBeNull()
+  })
+
+  it('sums paid segments without counting the gap and blocks multi-segment flex', () => {
+    const result = analyzeAttendanceShiftSegments([
+      segment('08:00', '12:00'),
+      segment('13:00', '17:00'),
+    ], tr)
+
+    expect(result).toEqual({
+      errors: [],
+      plannedMinutes: 480,
+      unpaidGapMinutes: 60,
+      midnightCrossings: 0,
+      flexEligible: false,
+      compatibilityEnvelope: '08:00 - 17:00',
+    })
+  })
+
+  it('keeps one final cross-midnight segment on the originating shift day', () => {
+    const result = analyzeAttendanceShiftSegments([
+      segment('20:00', '22:00'),
+      segment('23:00', '02:00', 1),
+    ], tr)
+
+    expect(result.errors).toEqual([])
+    expect(result.plannedMinutes).toBe(300)
+    expect(result.unpaidGapMinutes).toBe(60)
+    expect(result.midnightCrossings).toBe(1)
+    expect(result.compatibilityEnvelope).toBe('20:00 - 02:00 (next day)')
+  })
+
+  it('rejects missing, excess, non-positive, overlapping, and non-terminal midnight segments', () => {
+    expect(analyzeAttendanceShiftSegments([], tr).errors).toContain(
+      'A shift must contain 1 to 3 segments.',
+    )
+    expect(analyzeAttendanceShiftSegments([
+      segment('08:00', '09:00'),
+      segment('10:00', '11:00'),
+      segment('12:00', '13:00'),
+      segment('14:00', '15:00'),
+    ], tr).errors).toContain('A shift must contain 1 to 3 segments.')
+    expect(analyzeAttendanceShiftSegments([
+      segment('09:00', '09:00'),
+    ], tr).errors).toContain('Segment 1 must end after it starts.')
+    expect(analyzeAttendanceShiftSegments([
+      segment('08:00', '12:00'),
+      segment('11:00', '17:00'),
+    ], tr).errors).toContain('Segment 2 overlaps or is out of order.')
+    expect(analyzeAttendanceShiftSegments([
+      segment('22:00', '02:00', 1),
+      segment('03:00', '04:00', 1),
+    ], tr).errors).toEqual(expect.arrayContaining([
+      'Segment 2 overlaps or is out of order.',
+      'At most one segment may cross midnight.',
+    ]))
+  })
+
+  it('rejects aggregate planned time above the 24-hour ceiling', () => {
+    const result = analyzeAttendanceShiftSegments([
+      segment('00:00', '23:59'),
+      segment('00:00', '23:59'),
+      segment('00:00', '23:59'),
+    ], tr)
+
+    expect(result.plannedMinutes).toBe(4317)
+    expect(result.errors).toContain('Total planned time cannot exceed 24 hours.')
+  })
+
+  it('normalizes persisted order and synthesizes a legacy overnight segment', () => {
+    expect(normalizeAttendanceShiftSegments({
+      workStartTime: '08:00',
+      workEndTime: '17:00',
+      segments: [
+        { segmentIndex: 1, startTime: '13:00', startDayOffset: 0, endTime: '17:00', endDayOffset: 0 },
+        { segmentIndex: 0, startTime: '08:00', startDayOffset: 0, endTime: '12:00', endDayOffset: 0 },
+      ],
+    })).toEqual([
+      segment('08:00', '12:00'),
+      segment('13:00', '17:00'),
+    ])
+    expect(normalizeAttendanceShiftSegments({
+      workStartTime: '22:00',
+      workEndTime: '06:00',
+    })).toEqual([segment('22:00', '06:00', 1)])
+  })
+
+  it('uses an authoritative finite planned total and otherwise falls back to segment sums', () => {
+    const shift = {
+      workStartTime: '08:00',
+      workEndTime: '17:00',
+      segments: [
+        { segmentIndex: 0, ...segment('08:00', '12:00') },
+        { segmentIndex: 1, ...segment('13:00', '17:00') },
+      ],
+    }
+
+    expect(calculateAttendanceShiftPlannedMinutes({ ...shift, plannedMinutes: 475 })).toBe(475)
+    expect(calculateAttendanceShiftPlannedMinutes({ ...shift, plannedMinutes: Number.NaN })).toBe(480)
+  })
+
+  it('fails closed to preview-only unless multi-segment calculation is authoritative', () => {
+    const shift = {
+      workStartTime: '08:00',
+      workEndTime: '17:00',
+      segments: [
+        { segmentIndex: 0, ...segment('08:00', '12:00') },
+        { segmentIndex: 1, ...segment('13:00', '17:00') },
+      ],
+    }
+
+    expect(isAttendanceShiftPreviewOnly(shift)).toBe(true)
+    expect(isAttendanceShiftPreviewOnly({
+      ...shift,
+      capabilities: {
+        segmentCalculation: {
+          authoritativeResults: true,
+          multiSegmentAuthoring: 'enabled' as const,
+        },
+      },
+    })).toBe(false)
+    expect(isAttendanceShiftPreviewOnly({
+      workStartTime: '09:00',
+      workEndTime: '18:00',
+    })).toBe(false)
+  })
+})


### PR DESCRIPTION
## What changed

- replace the single start/end shift form with an ordered 1-3 paid-segment editor
- preserve legacy shifts as a normalized one-segment draft and submit the exact W3 segments payload
- show paid minutes, unpaid gaps, midnight posture, flex eligibility, compatibility envelope, and preview-only capability posture
- keep multi-segment shifts visibly preview-only until authoritative calculation is enabled
- preserve and restore canonical segment drafts across quick-start template apply/undo
- extract the editor and pure segment analysis from the large AttendanceView component
- make shift deletion copy match the backend reference-protection contract
- wire the pure segment boundary spec into the required attendance web guard

This is the frontend half of W3 after backend PR #4569. It continues issue #4556 without enabling W4 authoritative calculation.

## Verification

- pnpm --filter @metasheet/web type-check
- attendance admin regressions + setup template regressions: 179/179
- pure segment analysis: 8/8 (strict HH:MM, paid-gap arithmetic, midnight, 1-3 segments, overlap/order, 24h ceiling, normalization, capability fail-closed)
- scoped ESLint: 0 errors (existing one-component-per-file warnings in the regression suite remain)
- mutation proofs: legacy payload key reintroduction, overlap-validation bypass, envelope-as-paid-time, and dropping the template segment snapshot each turn the targeted test red
- responsive browser inspection at 1440px, 768px, and 390px; no editor overflow or overlap

## Boundaries

- no W4 authoritative attendance calculation
- no feature-flag or deployment changes
- no backend or migration changes in this PR