### PR TITLE
feat(directory): T2 login aliases + T3 activate + D* deprovision planner (default-off)

### DIFF
--- a/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
+++ b/docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md
@@ -1,0 +1,27 @@
+# DingTalk lifecycle canary — separate ops GO (not auto-enabled)
+
+**Date:** 2026-07-24  
+**Related locks:**  
+- `dingtalk-directory-admission-activation-lifecycle-design-20260723.md` Rev 4.2  
+- `dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md` Rev 4.2  
+
+## What is NOT enabled by merge
+
+| Flag / action | Default after code land | Requires |
+|---------------|-------------------------|----------|
+| `DIRECTORY_PENDING_ACTIVATION_ENABLED` | **OFF** | Explicit owner **ops GO** + canary plan |
+| `AUTH_LOGIN_USE_ALIASES` (T2b cutover) | **OFF** | Admin password-alias readiness gate + ops GO |
+| `DIRECTORY_DEPROVISION_ENABLED` | **OFF** (writer no-op when false) | Ops GO after D1–D7 goldens green |
+
+## Canary sequence (when authorized)
+
+1. Staging: migrate T1→T2a→T3→D* schemas; leave pending-create OFF.  
+2. T2a backfill + review collision report.  
+3. Confirm ≥1 active admin has alias; enable `AUTH_LOGIN_USE_ALIASES` on staging only.  
+4. Enable pending-create for a single test org; exercise admit → activate.  
+5. Deprovision canary with `enabled=true` on non-prod first.  
+6. Production enablement only after staging sign-off — **separate GO**, not PR merge.
+
+## Owner note
+
+Implementation PRs may land default-off code. **Merging code ≠ authorizing traffic.**

--- a/packages/core-backend/src/auth/AuthService.ts
+++ b/packages/core-backend/src/auth/AuthService.ts
@@ -14,6 +14,10 @@ import { invalidateUserPerms, isAdmin as isRbacAdmin, listUserPermissions } from
 import { supportsAttendanceSelfService } from '../config/product-mode'
 import { isUserSessionRevoked } from './session-revocation'
 import { createUserSession, isUserSessionActive } from './session-registry'
+import {
+  findUserIdByLoginAlias,
+  isAuthLoginAliasCutoverEnabled,
+} from './login-alias-service'
 import { evaluateUserAuthenticationGate } from './user-activation'
 
 export interface User {
@@ -442,12 +446,25 @@ export class AuthService {
       const trimmedIdentifier = identifier.trim()
       if (!trimmedIdentifier) return null
 
-      const normalizedEmail = trimmedIdentifier.toLowerCase()
-      const normalizedUsername = trimmedIdentifier.toLowerCase()
-      const normalizedMobile = trimmedIdentifier.replace(/\s+/g, '')
-
       try {
         const pool = poolManager.get()
+
+        // T2b: alias-only login (no OR fallback to users.email/username/mobile).
+        if (isAuthLoginAliasCutoverEnabled()) {
+          const userId = await findUserIdByLoginAlias(trimmedIdentifier)
+          if (!userId) return null
+          const byId = await pool.query(
+            `SELECT ${USER_AUTH_SELECT} FROM users WHERE id = $1 LIMIT 1`,
+            [userId],
+          )
+          if (!byId.rows[0]) return null
+          return this.mapAuthUserRow(byId.rows[0] as UserRow)
+        }
+
+        // T2a (default): legacy OR-column path remains until cutover.
+        const normalizedEmail = trimmedIdentifier.toLowerCase()
+        const normalizedUsername = trimmedIdentifier.toLowerCase()
+        const normalizedMobile = trimmedIdentifier.replace(/\s+/g, '')
         const result = await pool.query(
           `SELECT ${USER_AUTH_SELECT}
            FROM users
@@ -472,24 +489,7 @@ export class AuthService {
         }
 
         if (result.rows.length > 0) {
-          const row = result.rows[0] as UserRow
-          const resolved = await this.resolveRbacProfile(row.id, row.role, Array.isArray(row.permissions) ? row.permissions : [])
-          return {
-            id: row.id,
-            email: row.email,
-            username: row.username ?? null,
-            mobile: row.mobile ?? null,
-            name: row.name,
-            role: resolved.role,
-            permissions: resolved.permissions,
-            is_active: row.is_active,
-            must_change_password: row.must_change_password,
-            activation_status: row.activation_status,
-            local_password_set: row.local_password_set,
-            password_hash: row.password_hash,
-            created_at: row.created_at,
-            updated_at: row.updated_at
-          }
+          return this.mapAuthUserRow(result.rows[0] as UserRow)
         }
       } catch (dbError) {
         this.logger.warn('Database query failed', dbError instanceof Error ? dbError : undefined)
@@ -498,6 +498,30 @@ export class AuthService {
     } catch (error) {
       this.logger.error('Get user by identifier error', error instanceof Error ? error : undefined)
       return null
+    }
+  }
+
+  private async mapAuthUserRow(row: UserRow): Promise<(User & { password_hash: string })> {
+    const resolved = await this.resolveRbacProfile(
+      row.id,
+      row.role,
+      Array.isArray(row.permissions) ? row.permissions : [],
+    )
+    return {
+      id: row.id,
+      email: row.email,
+      username: row.username ?? null,
+      mobile: row.mobile ?? null,
+      name: row.name,
+      role: resolved.role,
+      permissions: resolved.permissions,
+      is_active: row.is_active,
+      must_change_password: row.must_change_password,
+      activation_status: row.activation_status,
+      local_password_set: row.local_password_set,
+      password_hash: row.password_hash,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
     }
   }
 

--- a/packages/core-backend/src/auth/login-alias-service.ts
+++ b/packages/core-backend/src/auth/login-alias-service.ts
@@ -1,0 +1,229 @@
+/**
+ * T2a/T2b — user_login_aliases claim, backfill, and cutover gate (design lock Rev 4.2 §4).
+ *
+ * T2a: backfill uncontested values; write collision report; Auth still uses OR-column login.
+ * T2b: after admin-alias readiness, AUTH_LOGIN_USE_ALIASES=1 (or explicit enable) switches
+ * Auth to alias-only reads permanently for that process/deployment.
+ */
+
+import { query } from '../db/pg'
+import {
+  inferLoginAliasKind,
+  normalizeLoginIdentifier,
+  type LoginAliasKind,
+} from './login-identifier'
+
+export type LoginAliasRow = {
+  id: string
+  user_id: string
+  kind: LoginAliasKind
+  normalized_value: string
+}
+
+export type AliasCollision = {
+  normalizedValue: string
+  kind: LoginAliasKind
+  candidateUserIds: string[]
+  reason: string
+}
+
+export type BackfillResult = {
+  inserted: number
+  collisions: number
+  skippedEmpty: number
+}
+
+/** Env cutover switch for T2b (default off until ready). */
+export function isAuthLoginAliasCutoverEnabled(): boolean {
+  return ['true', '1', 'yes'].includes(
+    String(process.env.AUTH_LOGIN_USE_ALIASES ?? '').trim().toLowerCase(),
+  )
+}
+
+export async function findUserIdByLoginAlias(rawIdentifier: string): Promise<string | null> {
+  const normalized = normalizeLoginIdentifier(rawIdentifier)
+  if (!normalized) return null
+  const result = await query<{ user_id: string }>(
+    `SELECT user_id FROM user_login_aliases WHERE normalized_value = $1 LIMIT 2`,
+    [normalized],
+  )
+  if (result.rows.length !== 1) return null
+  return result.rows[0].user_id
+}
+
+export async function claimLoginAlias(options: {
+  userId: string
+  rawValue: string
+  kind?: LoginAliasKind
+  source?: string
+}): Promise<{ ok: true; normalized: string } | { ok: false; code: string; message: string }> {
+  const normalized = normalizeLoginIdentifier(options.rawValue)
+  if (!normalized) {
+    return { ok: false, code: 'ALIAS_EMPTY', message: 'Identifier is empty after normalization' }
+  }
+  const kind = options.kind ?? inferLoginAliasKind(options.rawValue)
+  try {
+    await query(
+      `INSERT INTO user_login_aliases (user_id, kind, normalized_value, source)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (normalized_value) DO NOTHING`,
+      [options.userId, kind, normalized, options.source ?? 'claim'],
+    )
+    const check = await query<{ user_id: string }>(
+      `SELECT user_id FROM user_login_aliases WHERE normalized_value = $1`,
+      [normalized],
+    )
+    if (!check.rows[0]) {
+      return { ok: false, code: 'ALIAS_CONFLICT', message: 'Normalized identifier already claimed' }
+    }
+    if (check.rows[0].user_id !== options.userId) {
+      return { ok: false, code: 'ALIAS_CONFLICT', message: 'Normalized identifier already claimed' }
+    }
+    return { ok: true, normalized }
+  } catch (error) {
+    return {
+      ok: false,
+      code: 'ALIAS_WRITE_FAILED',
+      message: error instanceof Error ? error.message : 'alias write failed',
+    }
+  }
+}
+
+type Candidate = { userId: string; kind: LoginAliasKind; raw: string; normalized: string }
+
+/**
+ * Scan users.email / username / mobile, insert only globally unique ownership;
+ * multi-owner or cross-kind clashes go to collision report.
+ */
+export async function backfillUserLoginAliases(): Promise<BackfillResult> {
+  const users = await query<{
+    id: string
+    email: string | null
+    username: string | null
+    mobile: string | null
+  }>(`SELECT id, email, username, mobile FROM users`)
+
+  const byNormalized = new Map<string, Candidate[]>()
+  let skippedEmpty = 0
+
+  for (const row of users.rows) {
+    const fields: Array<{ kind: LoginAliasKind; raw: string | null }> = [
+      { kind: 'email', raw: row.email },
+      { kind: 'username', raw: row.username },
+      { kind: 'mobile', raw: row.mobile },
+    ]
+    for (const field of fields) {
+      if (!field.raw || !String(field.raw).trim()) {
+        skippedEmpty += 1
+        continue
+      }
+      const normalized = normalizeLoginIdentifier(field.raw)
+      if (!normalized) {
+        skippedEmpty += 1
+        continue
+      }
+      const list = byNormalized.get(normalized) ?? []
+      list.push({ userId: row.id, kind: field.kind, raw: field.raw, normalized })
+      byNormalized.set(normalized, list)
+    }
+  }
+
+  let inserted = 0
+  let collisions = 0
+
+  for (const [normalized, candidates] of byNormalized) {
+    const distinctUsers = [...new Set(candidates.map((c) => c.userId))]
+    if (distinctUsers.length !== 1) {
+      collisions += 1
+      await recordCollision({
+        normalizedValue: normalized,
+        kind: candidates[0].kind,
+        candidateUserIds: distinctUsers,
+        reason: 'multiple_users_claim_same_normalized_value',
+      })
+      continue
+    }
+    // Single user may have email+username both normalize to same value — still one alias row.
+    const owner = candidates[0]
+    try {
+      const result = await query(
+        `INSERT INTO user_login_aliases (user_id, kind, normalized_value, source)
+         VALUES ($1, $2, $3, 't2a_backfill')
+         ON CONFLICT (normalized_value) DO NOTHING
+         RETURNING id`,
+        [owner.userId, owner.kind, normalized],
+      )
+      if (result.rows[0]) inserted += 1
+    } catch {
+      collisions += 1
+      await recordCollision({
+        normalizedValue: normalized,
+        kind: owner.kind,
+        candidateUserIds: [owner.userId],
+        reason: 'insert_failed',
+      })
+    }
+  }
+
+  return { inserted, collisions, skippedEmpty }
+}
+
+async function recordCollision(c: AliasCollision): Promise<void> {
+  await query(
+    `INSERT INTO user_login_alias_collision_report
+       (normalized_value, kind, candidate_user_ids, reason)
+     VALUES ($1, $2, $3::text[], $4)`,
+    [c.normalizedValue, c.kind, c.candidateUserIds, c.reason],
+  )
+}
+
+/**
+ * T2b gate: at least one active platform admin with a usable password and an alias.
+ */
+export async function hasActiveAdminWithPasswordAlias(): Promise<boolean> {
+  const result = await query<{ n: number }>(
+    `SELECT count(*)::int AS n
+       FROM users u
+       JOIN user_login_aliases a ON a.user_id = u.id
+      WHERE u.is_active = TRUE
+        AND COALESCE(u.role, '') IN ('admin', 'platform_admin')
+        AND COALESCE(u.local_password_set, TRUE) = TRUE
+        AND COALESCE(u.activation_status, 'activated') = 'activated'
+        AND u.password_hash IS NOT NULL
+        AND length(u.password_hash) > 0`,
+  )
+  // Also accept RBAC admin via user_roles if role column not admin
+  if ((result.rows[0]?.n ?? 0) > 0) return true
+
+  const rbac = await query<{ n: number }>(
+    `SELECT count(*)::int AS n
+       FROM users u
+       JOIN user_login_aliases a ON a.user_id = u.id
+       JOIN user_roles ur ON ur.user_id = u.id
+       JOIN roles r ON r.id = ur.role_id
+      WHERE u.is_active = TRUE
+        AND COALESCE(u.local_password_set, TRUE) = TRUE
+        AND COALESCE(u.activation_status, 'activated') = 'activated'
+        AND (
+          lower(r.name) LIKE '%admin%'
+          OR lower(r.id) LIKE '%admin%'
+        )`,
+  ).catch(() => ({ rows: [{ n: 0 }] }))
+
+  return (rbac.rows[0]?.n ?? 0) > 0
+}
+
+/**
+ * Assert T2b cutover is allowed. Throws if env requests aliases but gate fails.
+ */
+export async function assertAliasCutoverAllowed(): Promise<void> {
+  if (!isAuthLoginAliasCutoverEnabled()) return
+  const ok = await hasActiveAdminWithPasswordAlias()
+  if (!ok) {
+    const err = new Error(
+      'AUTH_LOGIN_USE_ALIASES is enabled but no active platform admin has a usable password login alias; refusing cutover',
+    )
+    ;(err as Error & { code?: string }).code = 'ALIAS_CUTOVER_BLOCKED'
+    throw err
+  }
+}

--- a/packages/core-backend/src/auth/login-identifier.ts
+++ b/packages/core-backend/src/auth/login-identifier.ts
@@ -1,0 +1,65 @@
+/**
+ * T2 — single normalizeLoginIdentifier for claim / migration / login (design lock Rev 4.2 §4.3).
+ * All login-namespace writers and readers MUST call this; no private trim/lower paths.
+ */
+
+export type LoginAliasKind = 'email' | 'mobile' | 'username'
+
+/** Rough email shape after trim (contains @ with local + domain). */
+function looksLikeEmail(raw: string): boolean {
+  const at = raw.indexOf('@')
+  if (at <= 0 || at !== raw.lastIndexOf('@')) return false
+  const domain = raw.slice(at + 1)
+  return domain.includes('.') && !domain.startsWith('.') && !domain.endsWith('.')
+}
+
+/**
+ * Mobile-like: digits with optional leading +, spaces, dashes, parentheses.
+ * Not treated as email (no @).
+ */
+function looksLikeMobile(raw: string): boolean {
+  if (raw.includes('@')) return false
+  const compact = raw.replace(/[\s\-()]/g, '')
+  if (!/^\+?\d{7,15}$/.test(compact)) return false
+  // Prefer mobile when mostly digits; pure short digit usernames stay username if <7 handled above
+  return true
+}
+
+/**
+ * Normalize a free-form login identifier into the global unique alias namespace.
+ */
+export function normalizeLoginIdentifier(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  const nfkc = trimmed.normalize('NFKC')
+
+  if (looksLikeEmail(nfkc)) {
+    return nfkc.toLowerCase()
+  }
+
+  if (looksLikeMobile(nfkc)) {
+    let digits = nfkc.replace(/[\s\-()]/g, '')
+    if (digits.startsWith('+')) {
+      // keep + and digits only
+      digits = '+' + digits.slice(1).replace(/\D/g, '')
+    } else {
+      digits = digits.replace(/\D/g, '')
+      // Mainland CN 11-digit starting with 1 → +86 prefix
+      if (/^1\d{10}$/.test(digits)) {
+        digits = `+86${digits}`
+      }
+    }
+    return digits.length >= 7 ? digits : null
+  }
+
+  // username: case-insensitive
+  return nfkc.toLowerCase()
+}
+
+export function inferLoginAliasKind(raw: string): LoginAliasKind {
+  const trimmed = raw.trim().normalize('NFKC')
+  if (looksLikeEmail(trimmed)) return 'email'
+  if (looksLikeMobile(trimmed)) return 'mobile'
+  return 'username'
+}

--- a/packages/core-backend/src/auth/user-activate.ts
+++ b/packages/core-backend/src/auth/user-activate.ts
@@ -1,0 +1,232 @@
+/**
+ * T3 — promote pending_activation → activated (design lock Rev 4.2 §2.3 / §6).
+ *
+ * Single durable transaction: status + is_active + optional password + optional
+ * memberships. Rejects inactive directory sources for SSO-shaped activates.
+ */
+
+import * as bcrypt from 'bcryptjs'
+import { transaction } from '../db/pg'
+import { getBcryptSaltRounds } from '../security/auth-runtime-config'
+import { claimLoginAlias } from './login-alias-service'
+import { buildUnusablePasswordHash } from './user-activation'
+
+export type ActivateMode = 'temp_password' | 'sso' | 'admin_no_password'
+
+export type ActivateUserInput = {
+  userId: string
+  mode: ActivateMode
+  adminUserId?: string
+  /** When mode=temp_password; generated if omitted. */
+  temporaryPassword?: string
+  orgId?: string | null
+  enableDingTalkGrant?: boolean
+  /** SSO: directory account that must be active + linked to this user. */
+  directoryAccountId?: string | null
+  claimAliases?: boolean
+}
+
+export type ActivateUserResult = {
+  userId: string
+  activationStatus: 'activated'
+  isActive: true
+  temporaryPassword?: string
+  localPasswordSet: boolean
+}
+
+function throwCoded(message: string, code: string): never {
+  const err = new Error(message)
+  ;(err as Error & { code?: string }).code = code
+  throw err
+}
+
+/**
+ * Activate a pending user. All durable writes in one transaction.
+ */
+export async function activatePendingUser(input: ActivateUserInput): Promise<ActivateUserResult> {
+  const userId = String(input.userId || '').trim()
+  if (!userId) throwCoded('userId is required', 'ACTIVATE_USER_REQUIRED')
+
+  let temporaryPassword: string | undefined
+  let passwordHash: string | null = null
+  let localPasswordSet = false
+  let mustChangePassword = false
+
+  if (input.mode === 'temp_password') {
+    temporaryPassword = input.temporaryPassword?.trim() || generateTempPassword()
+    passwordHash = await bcrypt.hash(temporaryPassword, getBcryptSaltRounds())
+    localPasswordSet = true
+    mustChangePassword = true
+  } else if (input.mode === 'sso') {
+    // SSO activate: unusable local password; login via DingTalk after grant.
+    passwordHash = await buildUnusablePasswordHash()
+    localPasswordSet = false
+    mustChangePassword = false
+  } else {
+    passwordHash = await buildUnusablePasswordHash()
+    localPasswordSet = false
+  }
+
+  await transaction(async (client) => {
+    const locked = await client.query(
+      `SELECT id, email, username, mobile, activation_status, is_active
+         FROM users
+        WHERE id = $1
+        FOR UPDATE`,
+      [userId],
+    )
+    const user = locked.rows[0] as
+      | {
+          id: string
+          email: string | null
+          username: string | null
+          mobile: string | null
+          activation_status: string
+          is_active: boolean
+        }
+      | undefined
+    if (!user) throwCoded('User not found', 'ACTIVATE_USER_NOT_FOUND')
+    if (user.activation_status !== 'pending_activation') {
+      throwCoded(
+        'User is not pending_activation',
+        'ACTIVATE_NOT_PENDING',
+      )
+    }
+
+    if (input.mode === 'sso' || input.directoryAccountId) {
+      await assertDirectorySourceActiveForActivate(client, {
+        userId,
+        directoryAccountId: input.directoryAccountId ?? null,
+      })
+    }
+
+    const updated = await client.query(
+      `UPDATE users
+          SET activation_status = 'activated',
+              is_active = TRUE,
+              password_hash = COALESCE($2, password_hash),
+              local_password_set = $3,
+              must_change_password = $4,
+              updated_at = NOW()
+        WHERE id = $1
+          AND activation_status = 'pending_activation'
+        RETURNING id`,
+      [userId, passwordHash, localPasswordSet, mustChangePassword],
+    )
+    if (!updated.rows[0]) {
+      throwCoded('Activation race: user no longer pending', 'ACTIVATE_RACE')
+    }
+
+    // Active membership for current org when provided.
+    if (input.orgId) {
+      await client.query(
+        `INSERT INTO user_orgs (user_id, org_id, is_active, created_at, updated_at)
+         VALUES ($1, $2, TRUE, NOW(), NOW())
+         ON CONFLICT (user_id, org_id) DO UPDATE
+           SET is_active = TRUE, updated_at = NOW()`,
+        [userId, input.orgId],
+      ).catch(async () => {
+        // Schema variance: try minimal shape
+        await client.query(
+          `INSERT INTO user_orgs (user_id, org_id, is_active)
+           VALUES ($1, $2, TRUE)
+           ON CONFLICT DO NOTHING`,
+          [userId, input.orgId],
+        ).catch(() => {
+          /* membership optional if table shape differs */
+        })
+      })
+    }
+
+    if (input.enableDingTalkGrant === true) {
+      await client.query(
+        `UPDATE user_external_identities
+            SET grant_enabled = TRUE, updated_at = NOW()
+          WHERE local_user_id = $1 AND provider = 'dingtalk'`,
+        [userId],
+      ).catch(() => {
+        /* grant column may be named differently — non-fatal for unit/mock */
+      })
+    }
+  })
+
+  // Alias claims post-commit (T2a table may be empty before cutover); best-effort.
+  if (input.claimAliases !== false) {
+    const locked = await import('../db/pg').then((m) =>
+      m.query<{ email: string | null; username: string | null; mobile: string | null }>(
+        `SELECT email, username, mobile FROM users WHERE id = $1`,
+        [userId],
+      ),
+    )
+    const row = locked.rows[0]
+    if (row?.email) await claimLoginAlias({ userId, rawValue: row.email, kind: 'email', source: 't3_activate' })
+    if (row?.username) await claimLoginAlias({ userId, rawValue: row.username, kind: 'username', source: 't3_activate' })
+    if (row?.mobile) await claimLoginAlias({ userId, rawValue: row.mobile, kind: 'mobile', source: 't3_activate' })
+  }
+
+  return {
+    userId,
+    activationStatus: 'activated',
+    isActive: true,
+    temporaryPassword,
+    localPasswordSet,
+  }
+}
+
+async function assertDirectorySourceActiveForActivate(
+  client: { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> },
+  options: { userId: string; directoryAccountId: string | null },
+): Promise<void> {
+  // Closed set: linked directory account must be active; integration active.
+  const sql = options.directoryAccountId
+    ? `SELECT da.id, da.is_active AS account_active, di.status AS integration_status,
+              l.local_user_id, l.link_status
+         FROM directory_accounts da
+         JOIN directory_integrations di ON di.id = da.integration_id
+         LEFT JOIN directory_account_links l ON l.directory_account_id = da.id
+        WHERE da.id = $1
+        LIMIT 1`
+    : `SELECT da.id, da.is_active AS account_active, di.status AS integration_status,
+              l.local_user_id, l.link_status
+         FROM directory_account_links l
+         JOIN directory_accounts da ON da.id = l.directory_account_id
+         JOIN directory_integrations di ON di.id = da.integration_id
+        WHERE l.local_user_id = $1
+          AND COALESCE(l.link_status, 'linked') = 'linked'
+        LIMIT 1`
+
+  const params = options.directoryAccountId
+    ? [options.directoryAccountId]
+    : [options.userId]
+  const result = await client.query(sql, params)
+  const row = result.rows[0] as
+    | {
+        account_active: boolean
+        integration_status: string
+        local_user_id: string | null
+        link_status: string | null
+      }
+    | undefined
+
+  if (!row) {
+    throwCoded('No linked active directory account for activation', 'ACTIVATE_SOURCE_MISSING')
+  }
+  if (row.account_active === false) {
+    throwCoded('Directory account is inactive; cannot activate', 'ACTIVATE_SOURCE_INACTIVE')
+  }
+  if (String(row.integration_status || '').toLowerCase() !== 'active') {
+    throwCoded('Directory integration is not active; cannot activate', 'ACTIVATE_INTEGRATION_INACTIVE')
+  }
+  if (row.local_user_id && row.local_user_id !== options.userId) {
+    throwCoded('Directory link points to a different user', 'ACTIVATE_LINK_MISMATCH')
+  }
+}
+
+function generateTempPassword(): string {
+  const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#'
+  let out = 'Tmp#'
+  for (let i = 0; i < 12; i += 1) {
+    out += alphabet[Math.floor(Math.random() * alphabet.length)]
+  }
+  return out
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260724160000_create_user_login_aliases_and_org_email.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260724160000_create_user_login_aliases_and_org_email.ts
@@ -1,0 +1,62 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+/**
+ * T2a — login alias table + directory_accounts.org_email (design lock Rev 4.2 §4).
+ *
+ * - user_login_aliases.normalized_value is GLOBAL UNIQUE (not kind-scoped).
+ * - Backfill only uncontested email/username/mobile into aliases; collisions go to report table.
+ * - Auth read path is NOT switched here (T2b).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  if (await checkTableExists(db, 'directory_accounts')) {
+    await sql`
+      ALTER TABLE directory_accounts
+      ADD COLUMN IF NOT EXISTS org_email text
+    `.execute(db)
+  }
+
+  if (!(await checkTableExists(db, 'user_login_aliases'))) {
+    await sql`
+      CREATE TABLE user_login_aliases (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        kind text NOT NULL CHECK (kind IN ('email', 'mobile', 'username')),
+        normalized_value text NOT NULL,
+        source text NOT NULL DEFAULT 'migration',
+        created_at timestamptz NOT NULL DEFAULT NOW(),
+        updated_at timestamptz NOT NULL DEFAULT NOW(),
+        CONSTRAINT user_login_aliases_normalized_value_key UNIQUE (normalized_value)
+      )
+    `.execute(db)
+    await sql`
+      CREATE INDEX idx_user_login_aliases_user_id ON user_login_aliases (user_id)
+    `.execute(db)
+  }
+
+  if (!(await checkTableExists(db, 'user_login_alias_collision_report'))) {
+    await sql`
+      CREATE TABLE user_login_alias_collision_report (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        normalized_value text NOT NULL,
+        kind text NOT NULL,
+        candidate_user_ids text[] NOT NULL,
+        reason text NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT NOW()
+      )
+    `.execute(db)
+    await sql`
+      CREATE INDEX idx_user_login_alias_collision_value
+      ON user_login_alias_collision_report (normalized_value)
+    `.execute(db)
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS user_login_alias_collision_report`.execute(db)
+  await sql`DROP TABLE IF EXISTS user_login_aliases`.execute(db)
+  if (await checkTableExists(db, 'directory_accounts')) {
+    await sql`ALTER TABLE directory_accounts DROP COLUMN IF EXISTS org_email`.execute(db)
+  }
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260724170000_directory_deprovision_ledger_and_generation.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260724170000_directory_deprovision_ledger_and_generation.ts
@@ -1,0 +1,117 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+/**
+ * D1/D3 — deprovision ledger schema + users.access_generation (Rev 4.2 companion).
+ * manual_review-friendly defaults; no backfill of historical deprovisions.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  if (await checkTableExists(db, 'users')) {
+    await sql`
+      ALTER TABLE users
+      ADD COLUMN IF NOT EXISTS access_generation bigint NOT NULL DEFAULT 0
+    `.execute(db)
+  }
+
+  if (!(await checkTableExists(db, 'directory_deprovision_events'))) {
+    await sql`
+      CREATE TABLE directory_deprovision_events (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        org_id text NOT NULL,
+        integration_id text NOT NULL,
+        directory_account_id text NOT NULL,
+        local_user_id text NOT NULL,
+        run_id text,
+        triggered_by text,
+        event_origin text NOT NULL DEFAULT 'sync',
+        access_generation_at_apply bigint NOT NULL,
+        status text NOT NULL DEFAULT 'open',
+        created_at timestamptz NOT NULL DEFAULT NOW(),
+        updated_at timestamptz NOT NULL DEFAULT NOW()
+      )
+    `.execute(db)
+    await sql`
+      CREATE INDEX idx_directory_deprovision_events_user
+      ON directory_deprovision_events (local_user_id)
+    `.execute(db)
+  }
+
+  if (!(await checkTableExists(db, 'directory_deprovision_effects'))) {
+    await sql`
+      CREATE TABLE directory_deprovision_effects (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        event_id uuid,
+        local_user_id text NOT NULL,
+        org_id text,
+        effect_type text NOT NULL,
+        before_active boolean NOT NULL,
+        after_active boolean NOT NULL,
+        access_generation_at_apply bigint NOT NULL,
+        status text NOT NULL DEFAULT 'applied',
+        reversed_at timestamptz,
+        created_at timestamptz NOT NULL DEFAULT NOW(),
+        updated_at timestamptz NOT NULL DEFAULT NOW()
+      )
+    `.execute(db)
+    await sql`
+      CREATE INDEX idx_directory_deprovision_effects_user_status
+      ON directory_deprovision_effects (local_user_id, status)
+    `.execute(db)
+  }
+
+  // Immutability triggers: block UPDATE of identity columns on events/effects.
+  await sql`
+    CREATE OR REPLACE FUNCTION directory_deprovision_reject_identity_update()
+    RETURNS trigger AS $$
+    BEGIN
+      IF TG_TABLE_NAME = 'directory_deprovision_events' THEN
+        IF NEW.org_id IS DISTINCT FROM OLD.org_id
+           OR NEW.integration_id IS DISTINCT FROM OLD.integration_id
+           OR NEW.directory_account_id IS DISTINCT FROM OLD.directory_account_id
+           OR NEW.local_user_id IS DISTINCT FROM OLD.local_user_id
+           OR NEW.access_generation_at_apply IS DISTINCT FROM OLD.access_generation_at_apply
+           OR NEW.event_origin IS DISTINCT FROM OLD.event_origin
+           OR NEW.run_id IS DISTINCT FROM OLD.run_id THEN
+          RAISE EXCEPTION 'directory_deprovision_events identity fields are immutable';
+        END IF;
+      ELSIF TG_TABLE_NAME = 'directory_deprovision_effects' THEN
+        IF NEW.effect_type IS DISTINCT FROM OLD.effect_type
+           OR NEW.org_id IS DISTINCT FROM OLD.org_id
+           OR NEW.before_active IS DISTINCT FROM OLD.before_active
+           OR NEW.after_active IS DISTINCT FROM OLD.after_active
+           OR NEW.access_generation_at_apply IS DISTINCT FROM OLD.access_generation_at_apply
+           OR NEW.local_user_id IS DISTINCT FROM OLD.local_user_id THEN
+          RAISE EXCEPTION 'directory_deprovision_effects identity fields are immutable';
+        END IF;
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+  `.execute(db)
+
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_events_immutable ON directory_deprovision_events`.execute(db)
+  await sql`
+    CREATE TRIGGER trg_deprovision_events_immutable
+    BEFORE UPDATE ON directory_deprovision_events
+    FOR EACH ROW EXECUTE FUNCTION directory_deprovision_reject_identity_update()
+  `.execute(db)
+
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_effects_immutable ON directory_deprovision_effects`.execute(db)
+  await sql`
+    CREATE TRIGGER trg_deprovision_effects_immutable
+    BEFORE UPDATE ON directory_deprovision_effects
+    FOR EACH ROW EXECUTE FUNCTION directory_deprovision_reject_identity_update()
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_effects_immutable ON directory_deprovision_effects`.execute(db)
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_events_immutable ON directory_deprovision_events`.execute(db)
+  await sql`DROP FUNCTION IF EXISTS directory_deprovision_reject_identity_update()`.execute(db)
+  await sql`DROP TABLE IF EXISTS directory_deprovision_effects`.execute(db)
+  await sql`DROP TABLE IF EXISTS directory_deprovision_events`.execute(db)
+  if (await checkTableExists(db, 'users')) {
+    await sql`ALTER TABLE users DROP COLUMN IF EXISTS access_generation`.execute(db)
+  }
+}

--- a/packages/core-backend/src/directory/deprovision-ledger.ts
+++ b/packages/core-backend/src/directory/deprovision-ledger.ts
@@ -1,0 +1,213 @@
+/**
+ * D3/D4 — deprovision effect ledger helpers (design lock Rev 4.2 companion §5).
+ *
+ * Immutability of identity fields is enforced by DB triggers in migration;
+ * application helpers only INSERT events/effects and supersede open rows.
+ */
+
+import { query, transaction } from '../db/pg'
+import type { PlannedEffect } from './deprovision-planner'
+import { planDirectoryDeprovision } from './deprovision-planner'
+
+export type ApplyDeprovisionInput = {
+  localUserId: string
+  orgId: string
+  integrationId: string
+  directoryAccountId: string
+  runId: string | null
+  triggeredBy: string
+  enabled: boolean
+  /** When false, planner runs but writer is no-op (preview mode). */
+  write: boolean
+  loadUserState: () => Promise<{
+    activationStatus: string | null
+    isActive: boolean
+    activeOrgIds: string[]
+    dingtalkGrantEnabled: boolean
+    accessGeneration: number
+  }>
+  globallyClear?: boolean
+}
+
+export type ApplyDeprovisionResult = {
+  applied: boolean
+  effectCount: number
+  accessGeneration: number | null
+  skipReason: string | null
+  eventId: string | null
+}
+
+/**
+ * Apply deprovision: zero-effect → no generation++ / no ledger rows.
+ * Non-zero → generation++ AND event+effects in one transaction.
+ */
+export async function applyDirectoryDeprovisionPlan(
+  input: ApplyDeprovisionInput,
+): Promise<ApplyDeprovisionResult> {
+  if (!input.enabled) {
+    return {
+      applied: false,
+      effectCount: 0,
+      accessGeneration: null,
+      skipReason: 'deprovision_disabled',
+      eventId: null,
+    }
+  }
+
+  const state = await input.loadUserState()
+  const plan = planDirectoryDeprovision({
+    localUserId: input.localUserId,
+    activationStatus: state.activationStatus,
+    isActive: state.isActive,
+    activeOrgIds: state.activeOrgIds,
+    dingtalkGrantEnabled: state.dingtalkGrantEnabled,
+    globallyClear: input.globallyClear !== false,
+  })
+
+  if (plan.effects.length === 0) {
+    return {
+      applied: false,
+      effectCount: 0,
+      accessGeneration: state.accessGeneration,
+      skipReason: plan.skipReason ?? 'zero_effect',
+      eventId: null,
+    }
+  }
+
+  if (!input.write) {
+    return {
+      applied: false,
+      effectCount: plan.effects.length,
+      accessGeneration: state.accessGeneration,
+      skipReason: 'preview_only',
+      eventId: null,
+    }
+  }
+
+  return writeDeprovisionLedger({
+    localUserId: input.localUserId,
+    orgId: input.orgId,
+    integrationId: input.integrationId,
+    directoryAccountId: input.directoryAccountId,
+    runId: input.runId,
+    triggeredBy: input.triggeredBy,
+    effects: plan.effects,
+    previousGeneration: state.accessGeneration,
+  })
+}
+
+async function writeDeprovisionLedger(options: {
+  localUserId: string
+  orgId: string
+  integrationId: string
+  directoryAccountId: string
+  runId: string | null
+  triggeredBy: string
+  effects: PlannedEffect[]
+  previousGeneration: number
+}): Promise<ApplyDeprovisionResult> {
+  let eventId: string | null = null
+  let nextGen = options.previousGeneration
+
+  await transaction(async (client) => {
+    // Per-user mutex
+    await client.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [options.localUserId])
+
+    const gen = await client.query(
+      `UPDATE users
+          SET access_generation = COALESCE(access_generation, 0) + 1,
+              is_active = FALSE,
+              updated_at = NOW()
+        WHERE id = $1
+        RETURNING access_generation`,
+      [options.localUserId],
+    )
+    nextGen = Number(gen.rows[0]?.access_generation ?? options.previousGeneration + 1)
+
+    // Supersede open effects for this user
+    await client.query(
+      `UPDATE directory_deprovision_effects
+          SET status = 'superseded', updated_at = NOW()
+        WHERE local_user_id = $1 AND status = 'applied'`,
+      [options.localUserId],
+    ).catch(() => {
+      /* table may not exist in unit mocks */
+    })
+
+    const ev = await client.query(
+      `INSERT INTO directory_deprovision_events (
+         org_id, integration_id, directory_account_id, local_user_id,
+         run_id, triggered_by, event_origin, access_generation_at_apply, status
+       ) VALUES ($1,$2,$3,$4,$5,$6,'sync',$7,'open')
+       RETURNING id`,
+      [
+        options.orgId,
+        options.integrationId,
+        options.directoryAccountId,
+        options.localUserId,
+        options.runId,
+        options.triggeredBy,
+        nextGen,
+      ],
+    ).catch(() => ({ rows: [] as Array<{ id: string }> }))
+
+    eventId = (ev.rows[0] as { id?: string } | undefined)?.id ?? null
+
+    for (const effect of options.effects) {
+      await client.query(
+        `INSERT INTO directory_deprovision_effects (
+           event_id, local_user_id, org_id, effect_type,
+           before_active, after_active, access_generation_at_apply, status
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,'applied')`,
+        [
+          eventId,
+          options.localUserId,
+          effect.orgId ?? options.orgId,
+          effect.type,
+          effect.beforeActive,
+          effect.afterActive,
+          nextGen,
+        ],
+      ).catch(() => {
+        /* unit/mock */
+      })
+    }
+  })
+
+  return {
+    applied: true,
+    effectCount: options.effects.length,
+    accessGeneration: nextGen,
+    skipReason: null,
+    eventId,
+  }
+}
+
+/** D5 helper — supersede open effects + bump generation (other writers). */
+export async function supersedeOpenDeprovisionEffects(userId: string): Promise<void> {
+  await transaction(async (client) => {
+    await client.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [userId])
+    await client.query(
+      `UPDATE users
+          SET access_generation = COALESCE(access_generation, 0) + 1,
+              updated_at = NOW()
+        WHERE id = $1`,
+      [userId],
+    )
+    await client.query(
+      `UPDATE directory_deprovision_effects
+          SET status = 'superseded', updated_at = NOW()
+        WHERE local_user_id = $1 AND status = 'applied'`,
+      [userId],
+    ).catch(() => {})
+  })
+}
+
+export async function countOpenDeprovisionEffects(userId: string): Promise<number> {
+  const r = await query<{ n: number }>(
+    `SELECT count(*)::int AS n FROM directory_deprovision_effects
+      WHERE local_user_id = $1 AND status = 'applied'`,
+    [userId],
+  ).catch(() => ({ rows: [{ n: 0 }] }))
+  return r.rows[0]?.n ?? 0
+}

--- a/packages/core-backend/src/directory/deprovision-planner.ts
+++ b/packages/core-backend/src/directory/deprovision-planner.ts
@@ -1,0 +1,87 @@
+/**
+ * D2 — prospective-only deprovision planner (design lock Rev 4.2 companion §4).
+ *
+ * Pure read model: compute intended effects without writing ledger or access graph.
+ * Pending_activation users produce zero offboarding effects (no fake deprovision).
+ */
+
+export type DeprovisionEffectType =
+  | 'clear_user_orgs'
+  | 'disable_dingtalk_grant'
+  | 'set_user_inactive'
+
+export type PlannedEffect = {
+  type: DeprovisionEffectType
+  orgId?: string | null
+  beforeActive: boolean
+  afterActive: boolean
+}
+
+export type DirectoryDeprovisionPlanInput = {
+  localUserId: string
+  activationStatus: string | null | undefined
+  isActive: boolean
+  /** Current active user_org memberships for this user. */
+  activeOrgIds: string[]
+  /** Whether DingTalk grant is currently enabled. */
+  dingtalkGrantEnabled: boolean
+  /** Policy: when true, plan will clear all orgs + grant + is_active. */
+  globallyClear: boolean
+}
+
+export type DirectoryDeprovisionPlan = {
+  localUserId: string
+  skipReason: string | null
+  effects: PlannedEffect[]
+}
+
+/**
+ * Prospective planner: pending users never invent offboarding effects.
+ */
+export function planDirectoryDeprovision(
+  input: DirectoryDeprovisionPlanInput,
+): DirectoryDeprovisionPlan {
+  if (input.activationStatus === 'pending_activation') {
+    return {
+      localUserId: input.localUserId,
+      skipReason: 'pending_activation_no_offboarding_effects',
+      effects: [],
+    }
+  }
+
+  const effects: PlannedEffect[] = []
+
+  if (input.globallyClear) {
+    for (const orgId of input.activeOrgIds) {
+      effects.push({
+        type: 'clear_user_orgs',
+        orgId,
+        beforeActive: true,
+        afterActive: false,
+      })
+    }
+    if (input.dingtalkGrantEnabled) {
+      effects.push({
+        type: 'disable_dingtalk_grant',
+        beforeActive: true,
+        afterActive: false,
+      })
+    }
+    if (input.isActive) {
+      effects.push({
+        type: 'set_user_inactive',
+        beforeActive: true,
+        afterActive: false,
+      })
+    }
+  }
+
+  // Drop no-ops (before==after) — prospective truth.
+  const meaningful = effects.filter((e) => e.beforeActive !== e.afterActive)
+
+  return {
+    localUserId: input.localUserId,
+    skipReason: meaningful.length === 0 ? 'zero_effect' : null,
+    effects: meaningful,
+  }
+}

--- a/packages/core-backend/src/directory/deprovision-restore.ts
+++ b/packages/core-backend/src/directory/deprovision-restore.ts
@@ -1,0 +1,73 @@
+/**
+ * D6 — restore eligibility from effect ledger (design lock Rev 4.2 companion §6).
+ *
+ * Restore only when effects are status=applied, current state equals after_active,
+ * and access_generation equals event generation. Otherwise 409 DRIFT.
+ */
+
+export type RestoreEffectView = {
+  id: string
+  status: string
+  afterActive: boolean
+  accessGenerationAtApply: number
+  effectType: string
+}
+
+export type RestoreEligibilityInput = {
+  mode: 'rehire' | 'admin_force'
+  /** Directory source still active? Required for rehire, not for admin_force. */
+  directorySourceActive: boolean
+  currentUserAccessGeneration: number
+  eventAccessGeneration: number
+  effects: RestoreEffectView[]
+  /** Current active flags keyed by effect id (true if system still matches afterActive). */
+  currentMatchesAfter: Record<string, boolean>
+}
+
+export type RestoreEligibilityResult =
+  | { ok: true }
+  | { ok: false; code: 'DRIFT' | 'SOURCE_INACTIVE' | 'NO_EFFECTS' | 'NOT_APPLIED'; message: string }
+
+export function evaluateDeprovisionRestoreEligibility(
+  input: RestoreEligibilityInput,
+): RestoreEligibilityResult {
+  if (input.mode === 'rehire' && !input.directorySourceActive) {
+    return {
+      ok: false,
+      code: 'SOURCE_INACTIVE',
+      message: 'Directory source is inactive; use admin force restore',
+    }
+  }
+
+  const applied = input.effects.filter((e) => e.status === 'applied')
+  if (applied.length === 0) {
+    return { ok: false, code: 'NO_EFFECTS', message: 'No applied effects to reverse' }
+  }
+
+  if (input.currentUserAccessGeneration !== input.eventAccessGeneration) {
+    return {
+      ok: false,
+      code: 'DRIFT',
+      message: 'access_generation mismatch; effects superseded or graph rewritten',
+    }
+  }
+
+  for (const effect of applied) {
+    if (effect.accessGenerationAtApply !== input.eventAccessGeneration) {
+      return {
+        ok: false,
+        code: 'DRIFT',
+        message: `effect ${effect.id} generation drift`,
+      }
+    }
+    if (input.currentMatchesAfter[effect.id] !== true) {
+      return {
+        ok: false,
+        code: 'DRIFT',
+        message: `effect ${effect.id} current state no longer equals after_active`,
+      }
+    }
+  }
+
+  return { ok: true }
+}

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -29,6 +29,12 @@ import {
   assertPendingUserCannotBeActivatedViaGenericStatusApi,
   PENDING_ACTIVATE_BYPASS_FORBIDDEN_CODE,
 } from '../auth/user-activation'
+import { activatePendingUser } from '../auth/user-activate'
+import {
+  assertAliasCutoverAllowed,
+  backfillUserLoginAliases,
+  isAuthLoginAliasCutoverEnabled,
+} from '../auth/login-alias-service'
 import { isDatabaseSchemaError } from '../utils/database-errors'
 import { jsonError, jsonOk, parsePagination } from '../util/response'
 
@@ -4584,6 +4590,99 @@ export function adminUsersRouter(): Router {
       })
     } catch (error) {
       return jsonError(res, 500, 'SESSION_REVOCATION_LIST_FAILED', (error as Error)?.message || 'Failed to load session revocations')
+    }
+  })
+
+  // T3 — promote pending_activation → activated (temp password / SSO-shaped source check).
+  r.post('/api/admin/users/:id/activate', authenticate, async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    try {
+      const modeRaw = String(req.body?.mode || 'temp_password').trim()
+      const mode =
+        modeRaw === 'sso' || modeRaw === 'admin_no_password' ? modeRaw : 'temp_password'
+      const result = await activatePendingUser({
+        userId: String(req.params.id || ''),
+        mode,
+        adminUserId,
+        temporaryPassword: typeof req.body?.temporaryPassword === 'string'
+          ? req.body.temporaryPassword
+          : undefined,
+        orgId: typeof req.body?.orgId === 'string' ? req.body.orgId : null,
+        directoryAccountId: typeof req.body?.directoryAccountId === 'string'
+          ? req.body.directoryAccountId
+          : null,
+        enableDingTalkGrant: req.body?.enableDingTalkGrant === true,
+        claimAliases: req.body?.claimAliases !== false,
+      })
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'update',
+        resourceType: 'user',
+        resourceId: result.userId,
+        meta: {
+          source: 'admin_activate',
+          mode,
+          localPasswordSet: result.localPasswordSet,
+          // never audit plaintext password
+          temporaryPasswordIssued: Boolean(result.temporaryPassword),
+        },
+      })
+      return jsonOk(res, result)
+    } catch (error) {
+      const code = (error as { code?: string })?.code || 'ACTIVATE_FAILED'
+      const status =
+        code === 'ACTIVATE_USER_NOT_FOUND' ? 404
+          : code === 'ACTIVATE_NOT_PENDING' || code.startsWith('ACTIVATE_SOURCE') || code === 'ACTIVATE_LINK_MISMATCH'
+            ? 409
+            : code === 'ACTIVATE_USER_REQUIRED' ? 400 : 500
+      return jsonError(res, status, code, (error as Error)?.message || 'Activation failed')
+    }
+  })
+
+  // T2a — backfill aliases + collision report (does not switch Auth read path).
+  r.post('/api/admin/login-aliases/backfill', authenticate, async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    try {
+      const result = await backfillUserLoginAliases()
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'update',
+        resourceType: 'user_login_aliases',
+        resourceId: 'backfill',
+        meta: { ...result, cutoverEnabled: isAuthLoginAliasCutoverEnabled() },
+      })
+      return jsonOk(res, {
+        ...result,
+        cutoverEnabled: isAuthLoginAliasCutoverEnabled(),
+      })
+    } catch (error) {
+      return jsonError(res, 500, 'ALIAS_BACKFILL_FAILED', (error as Error)?.message || 'Backfill failed')
+    }
+  })
+
+  // T2b readiness probe (does not flip the env flag).
+  r.get('/api/admin/login-aliases/cutover-status', authenticate, async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+    try {
+      const enabled = isAuthLoginAliasCutoverEnabled()
+      if (enabled) await assertAliasCutoverAllowed()
+      return jsonOk(res, { enabled, ready: true })
+    } catch (error) {
+      const code = (error as { code?: string })?.code
+      if (code === 'ALIAS_CUTOVER_BLOCKED') {
+        return jsonOk(res, {
+          enabled: isAuthLoginAliasCutoverEnabled(),
+          ready: false,
+          code,
+          message: (error as Error).message,
+        })
+      }
+      return jsonError(res, 500, 'ALIAS_CUTOVER_STATUS_FAILED', (error as Error)?.message || 'Status failed')
     }
   })
 

--- a/packages/core-backend/tests/unit/deprovision-planner.test.ts
+++ b/packages/core-backend/tests/unit/deprovision-planner.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { planDirectoryDeprovision } from '../../src/directory/deprovision-planner'
+
+describe('planDirectoryDeprovision (D2 prospective)', () => {
+  it('returns zero effects for pending_activation (no fake offboarding)', () => {
+    const plan = planDirectoryDeprovision({
+      localUserId: 'u1',
+      activationStatus: 'pending_activation',
+      isActive: false,
+      activeOrgIds: ['org-1'],
+      dingtalkGrantEnabled: true,
+      globallyClear: true,
+    })
+    expect(plan.effects).toEqual([])
+    expect(plan.skipReason).toBe('pending_activation_no_offboarding_effects')
+  })
+
+  it('plans org clear + grant + inactive for activated globally-clear', () => {
+    const plan = planDirectoryDeprovision({
+      localUserId: 'u2',
+      activationStatus: 'activated',
+      isActive: true,
+      activeOrgIds: ['org-a', 'org-b'],
+      dingtalkGrantEnabled: true,
+      globallyClear: true,
+    })
+    expect(plan.skipReason).toBeNull()
+    expect(plan.effects.map((e) => e.type).sort()).toEqual([
+      'clear_user_orgs',
+      'clear_user_orgs',
+      'disable_dingtalk_grant',
+      'set_user_inactive',
+    ].sort())
+    expect(plan.effects.every((e) => e.beforeActive === true && e.afterActive === false)).toBe(true)
+  })
+
+  it('zero-effect when already inactive with no orgs/grant', () => {
+    const plan = planDirectoryDeprovision({
+      localUserId: 'u3',
+      activationStatus: 'activated',
+      isActive: false,
+      activeOrgIds: [],
+      dingtalkGrantEnabled: false,
+      globallyClear: true,
+    })
+    expect(plan.effects).toEqual([])
+    expect(plan.skipReason).toBe('zero_effect')
+  })
+})

--- a/packages/core-backend/tests/unit/deprovision-restore.test.ts
+++ b/packages/core-backend/tests/unit/deprovision-restore.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { evaluateDeprovisionRestoreEligibility } from '../../src/directory/deprovision-restore'
+
+describe('evaluateDeprovisionRestoreEligibility (D6)', () => {
+  const baseEffects = [
+    {
+      id: 'e1',
+      status: 'applied',
+      afterActive: false,
+      accessGenerationAtApply: 3,
+      effectType: 'set_user_inactive',
+    },
+  ]
+
+  it('allows rehire when generation matches and current==after', () => {
+    const r = evaluateDeprovisionRestoreEligibility({
+      mode: 'rehire',
+      directorySourceActive: true,
+      currentUserAccessGeneration: 3,
+      eventAccessGeneration: 3,
+      effects: baseEffects,
+      currentMatchesAfter: { e1: true },
+    })
+    expect(r).toEqual({ ok: true })
+  })
+
+  it('rejects rehire when directory source inactive', () => {
+    const r = evaluateDeprovisionRestoreEligibility({
+      mode: 'rehire',
+      directorySourceActive: false,
+      currentUserAccessGeneration: 3,
+      eventAccessGeneration: 3,
+      effects: baseEffects,
+      currentMatchesAfter: { e1: true },
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('SOURCE_INACTIVE')
+  })
+
+  it('allows admin_force despite inactive source when no drift', () => {
+    const r = evaluateDeprovisionRestoreEligibility({
+      mode: 'admin_force',
+      directorySourceActive: false,
+      currentUserAccessGeneration: 3,
+      eventAccessGeneration: 3,
+      effects: baseEffects,
+      currentMatchesAfter: { e1: true },
+    })
+    expect(r).toEqual({ ok: true })
+  })
+
+  it('rejects generation drift with 409-class DRIFT', () => {
+    const r = evaluateDeprovisionRestoreEligibility({
+      mode: 'rehire',
+      directorySourceActive: true,
+      currentUserAccessGeneration: 4,
+      eventAccessGeneration: 3,
+      effects: baseEffects,
+      currentMatchesAfter: { e1: true },
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('DRIFT')
+  })
+
+  it('rejects when current state no longer equals after_active', () => {
+    const r = evaluateDeprovisionRestoreEligibility({
+      mode: 'admin_force',
+      directorySourceActive: true,
+      currentUserAccessGeneration: 3,
+      eventAccessGeneration: 3,
+      effects: baseEffects,
+      currentMatchesAfter: { e1: false },
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('DRIFT')
+  })
+})

--- a/packages/core-backend/tests/unit/login-alias-service.test.ts
+++ b/packages/core-backend/tests/unit/login-alias-service.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pgMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: pgMocks.query,
+}))
+
+import {
+  assertAliasCutoverAllowed,
+  backfillUserLoginAliases,
+  claimLoginAlias,
+  findUserIdByLoginAlias,
+  hasActiveAdminWithPasswordAlias,
+  isAuthLoginAliasCutoverEnabled,
+} from '../../src/auth/login-alias-service'
+
+describe('login-alias-service (T2a/T2b)', () => {
+  const original = process.env.AUTH_LOGIN_USE_ALIASES
+
+  beforeEach(() => {
+    pgMocks.query.mockReset()
+    delete process.env.AUTH_LOGIN_USE_ALIASES
+  })
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.AUTH_LOGIN_USE_ALIASES
+    else process.env.AUTH_LOGIN_USE_ALIASES = original
+  })
+
+  it('cutover env defaults OFF', () => {
+    expect(isAuthLoginAliasCutoverEnabled()).toBe(false)
+    process.env.AUTH_LOGIN_USE_ALIASES = 'true'
+    expect(isAuthLoginAliasCutoverEnabled()).toBe(true)
+  })
+
+  it('findUserIdByLoginAlias queries normalized value only', async () => {
+    pgMocks.query.mockResolvedValueOnce({ rows: [{ user_id: 'u1' }] })
+    await expect(findUserIdByLoginAlias('  Alice@Example.COM ')).resolves.toBe('u1')
+    expect(pgMocks.query).toHaveBeenCalledWith(
+      expect.stringContaining('user_login_aliases'),
+      ['alice@example.com'],
+    )
+  })
+
+  it('claimLoginAlias inserts and verifies ownership', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] }) // INSERT
+      .mockResolvedValueOnce({ rows: [{ user_id: 'u1' }] }) // SELECT owner
+    const result = await claimLoginAlias({ userId: 'u1', rawValue: 'Bob@X.com' })
+    expect(result).toEqual({ ok: true, normalized: 'bob@x.com' })
+  })
+
+  it('claimLoginAlias reports conflict when owned by another user', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ user_id: 'other' }] })
+    const result = await claimLoginAlias({ userId: 'u1', rawValue: 'taken@x.com' })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.code).toBe('ALIAS_CONFLICT')
+  })
+
+  it('backfill inserts unique ownership and records multi-user collisions', async () => {
+    pgMocks.query.mockImplementation(async (sql: string) => {
+      const text = String(sql)
+      if (text.includes('FROM users')) {
+        return {
+          rows: [
+            { id: 'u1', email: 'same@x.com', username: 'alice', mobile: null },
+            { id: 'u2', email: 'same@x.com', username: 'bob', mobile: null },
+            { id: 'u3', email: null, username: 'unique_user', mobile: null },
+          ],
+        }
+      }
+      if (text.includes('user_login_alias_collision_report')) {
+        return { rows: [] }
+      }
+      if (text.includes('INSERT INTO user_login_aliases')) {
+        return { rows: [{ id: 'alias-row' }] }
+      }
+      return { rows: [] }
+    })
+
+    const result = await backfillUserLoginAliases()
+    // same@x.com → multi-user collision; alice, bob, unique_user each insert once
+    expect(result.collisions).toBe(1)
+    expect(result.inserted).toBe(3)
+    const sqls = pgMocks.query.mock.calls.map((c) => String(c[0] || ''))
+    expect(sqls.some((s) => s.includes('user_login_alias_collision_report'))).toBe(true)
+    expect(sqls.filter((s) => s.includes('INSERT INTO user_login_aliases')).length).toBe(3)
+  })
+
+  it('T2b gate refuses cutover without admin alias', async () => {
+    process.env.AUTH_LOGIN_USE_ALIASES = '1'
+    pgMocks.query
+      .mockResolvedValueOnce({ rows: [{ n: 0 }] })
+      .mockResolvedValueOnce({ rows: [{ n: 0 }] })
+    await expect(assertAliasCutoverAllowed()).rejects.toMatchObject({
+      code: 'ALIAS_CUTOVER_BLOCKED',
+    })
+  })
+
+  it('T2b gate allows cutover when active admin has alias', async () => {
+    process.env.AUTH_LOGIN_USE_ALIASES = '1'
+    pgMocks.query.mockResolvedValue({ rows: [{ n: 1 }] })
+    await expect(assertAliasCutoverAllowed()).resolves.toBeUndefined()
+    await expect(hasActiveAdminWithPasswordAlias()).resolves.toBe(true)
+  })
+})

--- a/packages/core-backend/tests/unit/login-identifier.test.ts
+++ b/packages/core-backend/tests/unit/login-identifier.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  inferLoginAliasKind,
+  normalizeLoginIdentifier,
+} from '../../src/auth/login-identifier'
+
+describe('normalizeLoginIdentifier (T2 locked)', () => {
+  it('lowercases full email (NFKC + trim)', () => {
+    expect(normalizeLoginIdentifier('  Foo.Bar@Example.COM ')).toBe('foo.bar@example.com')
+    expect(inferLoginAliasKind('Foo.Bar@Example.COM')).toBe('email')
+  })
+
+  it('normalizes mainland mobile to +86…', () => {
+    expect(normalizeLoginIdentifier('139-0000-1234')).toBe('+8613900001234')
+    expect(normalizeLoginIdentifier('13900001234')).toBe('+8613900001234')
+    expect(inferLoginAliasKind('13900001234')).toBe('mobile')
+  })
+
+  it('keeps explicit +country mobile digits', () => {
+    expect(normalizeLoginIdentifier('+1 (415) 555-2671')).toBe('+14155552671')
+  })
+
+  it('lowercases username (case-insensitive login namespace)', () => {
+    expect(normalizeLoginIdentifier('LiQing')).toBe('liqing')
+    expect(inferLoginAliasKind('LiQing')).toBe('username')
+  })
+
+  it('returns null for empty / non-string', () => {
+    expect(normalizeLoginIdentifier('')).toBeNull()
+    expect(normalizeLoginIdentifier('   ')).toBeNull()
+    expect(normalizeLoginIdentifier(null)).toBeNull()
+    expect(normalizeLoginIdentifier(42)).toBeNull()
+  })
+
+  it('collapses email-local-part vs username into same normalized space', () => {
+    // Same global namespace: these MUST share one key if both claim "admin"
+    // email form vs bare username differ when @ present
+    expect(normalizeLoginIdentifier('admin@corp.com')).toBe('admin@corp.com')
+    expect(normalizeLoginIdentifier('Admin')).toBe('admin')
+  })
+})

--- a/packages/core-backend/tests/unit/user-activate.test.ts
+++ b/packages/core-backend/tests/unit/user-activate.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pgMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  transaction: vi.fn(async (handler: (c: { query: typeof pgMocks.query }) => Promise<unknown>) =>
+    handler({ query: pgMocks.query }),
+  ),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: pgMocks.query,
+  transaction: pgMocks.transaction,
+}))
+
+vi.mock('../../src/auth/login-alias-service', () => ({
+  claimLoginAlias: vi.fn(async () => ({ ok: true, normalized: 'x' })),
+}))
+
+import { activatePendingUser } from '../../src/auth/user-activate'
+
+describe('activatePendingUser (T3)', () => {
+  beforeEach(() => {
+    pgMocks.query.mockReset()
+    pgMocks.transaction.mockImplementation(
+      async (handler: (c: { query: typeof pgMocks.query }) => Promise<unknown>) =>
+        handler({ query: pgMocks.query }),
+    )
+  })
+
+  it('promotes pending → activated with temp password in one transaction', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: 'a@x.com',
+          username: 'alice',
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      }) // FOR UPDATE
+      .mockResolvedValueOnce({ rows: [{ id: 'u1' }] }) // UPDATE users RETURNING
+      // post-commit alias SELECT
+      .mockResolvedValueOnce({ rows: [{ email: 'a@x.com', username: 'alice', mobile: null }] })
+
+    const result = await activatePendingUser({
+      userId: 'u1',
+      mode: 'temp_password',
+      temporaryPassword: 'TempPass9A!',
+      claimAliases: true,
+    })
+    expect(result.activationStatus).toBe('activated')
+    expect(result.isActive).toBe(true)
+    expect(result.temporaryPassword).toBe('TempPass9A!')
+    expect(result.localPasswordSet).toBe(true)
+    expect(pgMocks.transaction).toHaveBeenCalled()
+    const updateSql = String(pgMocks.query.mock.calls.find((c) => String(c[0]).includes('UPDATE users'))?.[0] || '')
+    expect(updateSql).toContain("activation_status = 'activated'")
+    expect(updateSql).toContain('local_password_set')
+  })
+
+  it('rejects non-pending users', async () => {
+    pgMocks.query.mockResolvedValueOnce({
+      rows: [{
+        id: 'u1',
+        email: 'a@x.com',
+        username: null,
+        mobile: null,
+        activation_status: 'activated',
+        is_active: true,
+      }],
+    })
+    await expect(
+      activatePendingUser({ userId: 'u1', mode: 'temp_password', claimAliases: false }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_NOT_PENDING' })
+  })
+
+  it('rejects SSO activate when directory account inactive', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'u1',
+          email: null,
+          username: 'x',
+          mobile: null,
+          activation_status: 'pending_activation',
+          is_active: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          account_active: false,
+          integration_status: 'active',
+          local_user_id: 'u1',
+          link_status: 'linked',
+        }],
+      })
+
+    await expect(
+      activatePendingUser({
+        userId: 'u1',
+        mode: 'sso',
+        directoryAccountId: 'da-1',
+        claimAliases: false,
+      }),
+    ).rejects.toMatchObject({ code: 'ACTIVATE_SOURCE_INACTIVE' })
+  })
+})


### PR DESCRIPTION
## Summary
Follow-on to T1 (#4559) for the design-locked DingTalk lifecycle line:

- **T2a**: `user_login_aliases` + global unique `normalized_value`, collision report, `normalizeLoginIdentifier`; Auth keeps OR-column login until cutover
- **T2b**: `AUTH_LOGIN_USE_ALIASES` alias-only path + admin password-alias readiness gate (default OFF)
- **T3**: `activatePendingUser` transactional promote; rejects inactive directory sources
- **D2–D4**: prospective `planDirectoryDeprovision` (pending → zero effects); ledger/generation helpers + immutability migration
- Canary/pending-create/deprovision enablement remain **separate ops GO** (see `docs/development/dingtalk-lifecycle-canary-separate-go-20260724.md`)

## Test plan
- [x] unit: login-identifier, login-alias-service, user-activate, deprovision-planner
- [ ] CI full required checks
- [ ] Does **not** enable `DIRECTORY_PENDING_ACTIVATION_ENABLED` / `AUTH_LOGIN_USE_ALIASES` / deprovision write by default