### PR TITLE
fix(directory): point grant/membership writes at the tables that exist (T1–D7 follow-up)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -784,6 +784,7 @@ jobs:
             tests/integration/directory-sync-preview-apply-parity.db.test.ts \
             tests/integration/directory-sync-alert-coverage.db.test.ts \
             tests/integration/directory-deprovision-selection.db.test.ts \
+            tests/integration/directory-deprovision-grant-table.db.test.ts \
             tests/integration/directory-sync-run-lease.db.test.ts \
             tests/integration/directory-tenant-change-immutable.db.test.ts \
             tests/integration/directory-sync-orchestration.db.test.ts \

--- a/packages/core-backend/src/auth/user-activate.ts
+++ b/packages/core-backend/src/auth/user-activate.ts
@@ -119,34 +119,40 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
 
     // Active membership for current org when provided.
     if (input.orgId) {
+      // `user_orgs` is (user_id, org_id, is_active, created_at) with PK (user_id, org_id) — there
+      // is no `updated_at`. Writing one raised `42703` and aborted this transaction, which is why
+      // the "schema variance" fallback underneath could never help: once a statement fails inside
+      // a transaction, Postgres rejects every later statement with `25P02`, the fallback
+      // included. The net effect was that activating a pending user WITH an org — the ordinary
+      // case — could not succeed at all; it died at COMMIT. Writing the real shape is the fix,
+      // and the fallback goes with it: a second guess at the schema is not a substitute for
+      // matching it.
       await client.query(
-        `INSERT INTO user_orgs (user_id, org_id, is_active, created_at, updated_at)
-         VALUES ($1, $2, TRUE, NOW(), NOW())
+        `INSERT INTO user_orgs (user_id, org_id, is_active, created_at)
+         VALUES ($1, $2, TRUE, NOW())
          ON CONFLICT (user_id, org_id) DO UPDATE
-           SET is_active = TRUE, updated_at = NOW()`,
+           SET is_active = TRUE`,
         [userId, input.orgId],
-      ).catch(async () => {
-        // Schema variance: try minimal shape
-        await client.query(
-          `INSERT INTO user_orgs (user_id, org_id, is_active)
-           VALUES ($1, $2, TRUE)
-           ON CONFLICT DO NOTHING`,
-          [userId, input.orgId],
-        ).catch(() => {
-          /* membership optional if table shape differs */
-        })
-      })
+      )
     }
 
     if (input.enableDingTalkGrant === true) {
+      // The DingTalk grant lives in `user_external_auth_grants` — the table `dingtalk-oauth.ts`
+      // reads to decide whether a login is allowed. This wrote `user_external_identities
+      // .grant_enabled`, a column no migration creates, inside a `.catch`: activation reported
+      // success while the person was never actually granted DingTalk login. Same upsert shape the
+      // OAuth bind path uses.
+      //
+      // The swallow is gone with it. Inside a transaction a failed statement poisons the
+      // connection, so catching the rejection does not make the failure harmless — it only moves
+      // the error to whichever innocent statement runs next, as `25P02`.
       await client.query(
-        `UPDATE user_external_identities
-            SET grant_enabled = TRUE, updated_at = NOW()
-          WHERE local_user_id = $1 AND provider = 'dingtalk'`,
-        [userId],
-      ).catch(() => {
-        /* grant column may be named differently — non-fatal for unit/mock */
-      })
+        `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
+         VALUES ('dingtalk', $1, TRUE, $2, NOW(), NOW())
+         ON CONFLICT (provider, local_user_id)
+         DO UPDATE SET enabled = TRUE, granted_by = EXCLUDED.granted_by, updated_at = NOW()`,
+        [userId, `activate:${input.adminUserId ?? 'system'}`],
+      )
     }
   })
 

--- a/packages/core-backend/src/directory/deprovision-evidence-api.ts
+++ b/packages/core-backend/src/directory/deprovision-evidence-api.ts
@@ -48,13 +48,18 @@ export async function previewDeprovisionForUser(localUserId: string) {
     [localUserId],
   ).catch(() => ({ rows: [] as Array<{ org_id: string }> }))
 
+  // `user_external_auth_grants` is the table the OAuth login path reads. This used to read
+  // `user_external_identities.grant_enabled` — a column no migration creates — behind a `.catch`
+  // that turned the resulting error into "no grant", so the preview could never show a grant
+  // effect no matter what the truth was. No `.catch` either: a preview that cannot read the
+  // access graph must say so rather than quietly under-report what deprovision would take away.
   const grant = await query<{ enabled: boolean }>(
-    `SELECT COALESCE(grant_enabled, FALSE) AS enabled
-       FROM user_external_identities
+    `SELECT enabled
+       FROM user_external_auth_grants
       WHERE local_user_id = $1 AND provider = 'dingtalk'
       LIMIT 1`,
     [localUserId],
-  ).catch(() => ({ rows: [] as Array<{ enabled: boolean }> }))
+  )
 
   const plan = planDirectoryDeprovision({
     localUserId,
@@ -228,12 +233,16 @@ export async function restoreDeprovisionEvent(options: {
       // after false → no active membership
       currentMatchesAfter[e.id] = (org.rows[0]?.n ?? 0) === 0
     } else if (e.effect_type === 'disable_dingtalk_grant') {
+      // This is a DRIFT GATE, so it must fail closed. Reading the phantom column and catching the
+      // error yielded "no grant", which reads as "current state matches after_active=false" — the
+      // gate was satisfied *by the read failing*, so it could never fire, and a grant that was
+      // genuinely still enabled sailed straight through as if there were no drift.
       const g = await query<{ enabled: boolean }>(
-        `SELECT COALESCE(grant_enabled, FALSE) AS enabled
-           FROM user_external_identities
+        `SELECT enabled
+           FROM user_external_auth_grants
           WHERE local_user_id = $1 AND provider = 'dingtalk' LIMIT 1`,
         [event.local_user_id],
-      ).catch(() => ({ rows: [{ enabled: false }] }))
+      )
       currentMatchesAfter[e.id] = g.rows[0]?.enabled !== true
     } else {
       currentMatchesAfter[e.id] = true
@@ -266,18 +275,31 @@ export async function restoreDeprovisionEvent(options: {
           [event.local_user_id],
         )
       } else if (e.effect_type === 'clear_user_orgs' && e.org_id) {
+        // `user_orgs` is (user_id, org_id, is_active, created_at) — there is no `updated_at`.
+        // Setting one raised `42703`, which the `.catch` hid; the aborted transaction then failed
+        // the very next statement with `25P02`, so restoring ANY event carrying a membership
+        // effect — which is every real deprovision event — rolled back entirely. The sibling
+        // writer in `directory-sync.ts` gets this right; only this path invented the column.
+        // Same reasoning as the grant leg: a restore that cannot give membership back must fail
+        // loudly, not report a success the admin will act on.
         await client.query(
-          `UPDATE user_orgs SET is_active = TRUE, updated_at = NOW()
+          `UPDATE user_orgs SET is_active = TRUE
             WHERE user_id = $1 AND org_id = $2`,
           [event.local_user_id, e.org_id],
-        ).catch(() => {})
+        )
       } else if (e.effect_type === 'disable_dingtalk_grant') {
+        // Upsert, not UPDATE: deprovision may have created the disabled row itself, and a restore
+        // that silently matched zero rows would report success while the person stayed locked
+        // out. The `.catch` is gone for the same reason it was wrong on the read — it could not
+        // make the failure harmless, only turn it into `25P02` on the next statement, which is
+        // what made every event carrying a grant effect unrestorable.
         await client.query(
-          `UPDATE user_external_identities
-              SET grant_enabled = TRUE, updated_at = NOW()
-            WHERE local_user_id = $1 AND provider = 'dingtalk'`,
-          [event.local_user_id],
-        ).catch(() => {})
+          `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
+           VALUES ('dingtalk', $1, TRUE, $2, NOW(), NOW())
+           ON CONFLICT (provider, local_user_id)
+           DO UPDATE SET enabled = TRUE, updated_at = NOW()`,
+          [event.local_user_id, `restore:${options.adminUserId}`],
+        )
       }
       await client.query(
         `UPDATE directory_deprovision_effects

--- a/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
+++ b/packages/core-backend/tests/integration/directory-deprovision-grant-table.db.test.ts
@@ -1,0 +1,203 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { activatePendingUser } from '../../src/auth/user-activate'
+import { restoreDeprovisionEvent } from '../../src/directory/deprovision-evidence-api'
+
+/**
+ * The DingTalk grant lives in `user_external_auth_grants`; `user_orgs` is
+ * (user_id, org_id, is_active, created_at). Three merged paths wrote neither shape —
+ * `user_external_identities.grant_enabled` (a column no migration creates) and a
+ * `user_orgs.updated_at` that does not exist — each behind `.catch(() => {})`.
+ *
+ * Every one of those failures was invisible in unit tests, because a stub client answers any SQL
+ * you hand it. They are only observable against real Postgres, and only because of what a
+ * swallowed error does INSIDE a transaction: the failed statement poisons the connection, so the
+ * next innocent statement dies with `25P02` and the whole restore rolls back. The admin is shown
+ * an opaque error, or — worse, on the read path — a drift gate that was satisfied by its own
+ * query failing, and therefore could never fire.
+ *
+ * These tests assert the observable end state (is the person actually granted / actually a member
+ * again), never the SQL text, so they keep their meaning if the statements are rewritten.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const ORG = 'org-grant-fix-test'
+const USER = 'u-grant-fix-test'
+
+async function cleanup() {
+  await query(`DELETE FROM directory_deprovision_effects WHERE local_user_id = $1`, [USER])
+  await query(
+    `DELETE FROM directory_deprovision_events WHERE local_user_id = $1`, [USER])
+  await query(
+    `DELETE FROM directory_account_links WHERE local_user_id = $1`, [USER])
+  await query(`DELETE FROM directory_sync_runs WHERE integration_id IN
+                 (SELECT id FROM directory_integrations WHERE org_id = $1)`, [ORG])
+  await query(`DELETE FROM directory_accounts WHERE integration_id IN
+                 (SELECT id FROM directory_integrations WHERE org_id = $1)`, [ORG])
+  await query(`DELETE FROM directory_integrations WHERE org_id = $1`, [ORG])
+  await query(`DELETE FROM user_external_auth_grants WHERE local_user_id = $1`, [USER])
+  await query(`DELETE FROM user_orgs WHERE user_id = $1`, [USER])
+  await query(`DELETE FROM users WHERE id = $1`, [USER])
+}
+
+async function seedDirectory(opts: { sourceActive: boolean }) {
+  const integ = await query<{ id: string }>(
+    `INSERT INTO directory_integrations (name, corp_id, org_id, status, default_deprovision_policy)
+     VALUES ('grant-fix-test', $1, $2, 'active', 'mark_inactive')
+     RETURNING id::text AS id`,
+    [`corp-${ORG}`, ORG],
+  )
+  const integrationId = integ.rows[0].id
+  const acct = await query<{ id: string }>(
+    `INSERT INTO directory_accounts (integration_id, provider, external_user_id, external_key, name, is_active)
+     VALUES ($1::uuid, 'dingtalk', 'ext-grant-fix', 'dingtalk:grant-fix:ext', 'Grant Fix', $2)
+     RETURNING id::text AS id`,
+    [integrationId, opts.sourceActive],
+  )
+  const accountId = acct.rows[0].id
+  await query(
+    `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status)
+     VALUES ($1::uuid, $2, 'linked')`,
+    [accountId, USER],
+  )
+  const run = await query<{ id: string }>(
+    `INSERT INTO directory_sync_runs (integration_id, status, triggered_by)
+     VALUES ($1::uuid, 'success', 'test') RETURNING id::text AS id`,
+    [integrationId],
+  )
+  return { integrationId, accountId, runId: run.rows[0].id }
+}
+
+async function seedEvent(
+  seeded: { integrationId: string; accountId: string; runId: string },
+  effects: Array<{ type: string; orgId: string | null }>,
+  generation: number,
+) {
+  const ev = await query<{ id: string }>(
+    `INSERT INTO directory_deprovision_events
+       (org_id, integration_id, directory_account_id, local_user_id, run_id, triggered_by,
+        event_origin, access_generation_at_apply, status)
+     VALUES ($1, $2, $3, $4, $5, 'test', 'sync', $6, 'open')
+     RETURNING id::text AS id`,
+    [ORG, seeded.integrationId, seeded.accountId, USER, seeded.runId, generation],
+  )
+  for (const effect of effects) {
+    await query(
+      `INSERT INTO directory_deprovision_effects
+         (event_id, local_user_id, org_id, effect_type, before_active, after_active,
+          access_generation_at_apply, status)
+       VALUES ($1::uuid, $2, $3, $4, TRUE, FALSE, $5, 'applied')`,
+      [ev.rows[0].id, USER, effect.orgId, effect.type, generation],
+    )
+  }
+  return ev.rows[0].id
+}
+
+const grantEnabled = async (): Promise<boolean | undefined> => (
+  await query<{ enabled: boolean }>(
+    `SELECT enabled FROM user_external_auth_grants WHERE local_user_id = $1 AND provider = 'dingtalk'`,
+    [USER],
+  )
+).rows[0]?.enabled
+
+describeIfDatabase('DingTalk grant/membership writes target the real tables (real DB)', () => {
+  beforeEach(cleanup)
+  afterAll(cleanup)
+
+  it('T3 activate with enableDingTalkGrant actually grants DingTalk login', async () => {
+    await query(
+      `INSERT INTO users (id, email, name, password_hash, is_active, activation_status, local_password_set)
+       VALUES ($1, 'grant-fix@example.com', 'Grant Fix', 'x', FALSE, 'pending_activation', FALSE)`,
+      [USER],
+    )
+
+    // Positive control: nothing has granted anything yet.
+    expect(await grantEnabled()).toBeUndefined()
+
+    await activatePendingUser({
+      userId: USER,
+      mode: 'admin_no_password',
+      adminUserId: 'admin-test',
+      orgId: ORG,
+      enableDingTalkGrant: true,
+      claimAliases: false,
+    })
+
+    // The observable claim: the person can now be admitted by the OAuth path, which reads
+    // `user_external_auth_grants`. Before the fix this was `undefined` — activation reported
+    // success and granted nothing.
+    expect(await grantEnabled()).toBe(true)
+  })
+
+  it('restoring a membership effect actually re-activates the membership', async () => {
+    await query(
+      `INSERT INTO users (id, email, name, password_hash, is_active, activation_status, access_generation)
+       VALUES ($1, 'grant-fix@example.com', 'Grant Fix', 'x', TRUE, 'activated', 3)`,
+      [USER],
+    )
+    await query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, FALSE)`, [USER, ORG])
+    const seeded = await seedDirectory({ sourceActive: true })
+    const eventId = await seedEvent(seeded, [{ type: 'clear_user_orgs', orgId: ORG }], 3)
+
+    const result = await restoreDeprovisionEvent({
+      eventId, mode: 'rehire', adminUserId: 'admin-test',
+    })
+    expect(result.restoredEffectCount).toBe(1)
+
+    // Before the fix this whole call aborted with 25P02 (`user_orgs.updated_at` does not exist),
+    // so the membership stayed FALSE — for EVERY real deprovision event, since every candidate
+    // carries a membership effect.
+    const membership = await query<{ is_active: boolean }>(
+      `SELECT is_active FROM user_orgs WHERE user_id = $1 AND org_id = $2`, [USER, ORG])
+    expect(membership.rows[0]?.is_active).toBe(true)
+
+    const effects = await query<{ status: string }>(
+      `SELECT status FROM directory_deprovision_effects WHERE local_user_id = $1`, [USER])
+    expect(effects.rows.map((r) => r.status)).toEqual(['reversed'])
+  })
+
+  it('restoring a grant effect actually re-enables the grant', async () => {
+    await query(
+      `INSERT INTO users (id, email, name, password_hash, is_active, activation_status, access_generation)
+       VALUES ($1, 'grant-fix@example.com', 'Grant Fix', 'x', TRUE, 'activated', 3)`,
+      [USER],
+    )
+    // Deprovision left a disabled grant row behind, which is what the writer's upsert produces.
+    await query(
+      `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by)
+       VALUES ('dingtalk', $1, FALSE, 'system:directory-deprovision')`, [USER])
+    const seeded = await seedDirectory({ sourceActive: true })
+    const eventId = await seedEvent(seeded, [{ type: 'disable_dingtalk_grant', orgId: null }], 3)
+
+    await restoreDeprovisionEvent({ eventId, mode: 'rehire', adminUserId: 'admin-test' })
+
+    expect(await grantEnabled()).toBe(true)
+  })
+
+  it('a grant that is still enabled is real drift, and the gate refuses the restore', async () => {
+    await query(
+      `INSERT INTO users (id, email, name, password_hash, is_active, activation_status, access_generation)
+       VALUES ($1, 'grant-fix@example.com', 'Grant Fix', 'x', TRUE, 'activated', 3)`,
+      [USER],
+    )
+    // The event says the grant was revoked (after_active=false); reality says it is ON. That is
+    // exactly the drift DRIFT_CONFLICT exists for. The pre-fix read could not see it: its query
+    // errored, the `.catch` reported "no grant", and "no grant" matched after_active=false — the
+    // gate was satisfied BY ITS OWN FAILURE and let the restore through.
+    await query(
+      `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by)
+       VALUES ('dingtalk', $1, TRUE, 'someone-re-granted-it')`, [USER])
+    const seeded = await seedDirectory({ sourceActive: true })
+    const eventId = await seedEvent(seeded, [{ type: 'disable_dingtalk_grant', orgId: null }], 3)
+
+    await expect(
+      restoreDeprovisionEvent({ eventId, mode: 'rehire', adminUserId: 'admin-test' }),
+    ).rejects.toMatchObject({ code: 'DRIFT_CONFLICT' })
+
+    // And the refusal must be inert: the grant is left exactly as the other writer set it.
+    expect(await grantEnabled()).toBe(true)
+    const effects = await query<{ status: string }>(
+      `SELECT status FROM directory_deprovision_effects WHERE local_user_id = $1`, [USER])
+    expect(effects.rows.map((r) => r.status)).toEqual(['applied'])
+  })
+})


### PR DESCRIPTION
## What

Four merged statements write columns that **no migration creates**, each behind a `.catch`, so every failure was invisible.

| Phantom column | Written by |
|---|---|
| `user_external_identities.grant_enabled` | T3 activate (#4574); D7 preview + D7 restore (#4575) |
| `user_orgs.updated_at` | T3 activate (#4574); D7 restore (#4575) |

`user_orgs` is `(user_id, org_id, is_active, created_at)`, PK `(user_id, org_id)`. The DingTalk grant lives in `user_external_auth_grants` — the table `dingtalk-oauth.ts` reads at login.

## Why it is severe, not cosmetic

Inside a transaction a failed statement poisons the connection. Catching the rejection does not contain the failure — it relocates it, as `25P02`, onto the next innocent statement. Measured on `main`:

- **T3 activate with an `orgId` or `enableDingTalkGrant` cannot succeed at all** — the membership INSERT aborts the transaction and it dies at COMMIT. Only the degenerate call (no org, no grant) survives.
- The "schema variance" fallback under that INSERT is **structurally unreachable**: a poisoned transaction rejects the fallback too.
- D7 preview can **never** show a grant effect, whatever the truth is.
- Restoring any event carrying a membership **or** grant effect aborts — that is **every real deprovision event**, since every candidate carries a membership effect.
- The grant drift gate was satisfied **by its own query failing**: the error became "no grant", which reads as "matches `after_active=false`", so `DRIFT_CONFLICT` could never fire on that leg.

## Verification

- New real-DB suite `directory-deprovision-grant-table.db.test.ts` — **4/4 green** with the fix, **4/4 red** with `src` reverted to `main` (mutation control: the tests are load-bearing, and all four defects are real on `main`).
- Includes a discriminating pair: the `user`-leg drift gate correctly refuses (control), the `grant`-leg gate must too (subject).
- Added to the **plugin-tests explicit run-list** — that list is hand-written, so a new `.db.test.ts` is not auto-collected. Collection proven by running it alongside `directory-deprovision-selection.db.test.ts` (neighbour 10/10 still green).
- `tsc --noEmit` clean; four related unit suites 32/32.
- Assertions are on observable end state (is the person actually granted / actually a member again), never on SQL text.

Why unit tests missed all of it: a stub client answers whatever SQL it is handed, so a statement naming a nonexistent column looks identical to one that does not.

## Scope

Touches no deprovision writer and no `effect_type` — **independent of the ledger-schema decision still open on the lifecycle line**. Enables no flag.

Draft, not for merge without owner review. Related findings: `docs/development/dingtalk-lifecycle-postmerge-findings-20260724.md` on `claude/dingtalk-d4-d5-writer-ledger-wiring-20260724`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)