### PR TITLE
HELD — D3 ledger hardening + D4 writer wiring (awaiting owner fork decision)

### DIFF
--- a/docs/development/dingtalk-lifecycle-postmerge-findings-20260724.md
+++ b/docs/development/dingtalk-lifecycle-postmerge-findings-20260724.md
@@ -26,6 +26,58 @@ to restore from — with no error anywhere to indicate that.
 
 ---
 
+## 0.1 Empirical run (real Postgres, `main`'s own code)
+
+Static reads are not behaviour, so the findings below were re-established by **executing merged
+`main`**: worktree detached at `8aad0ef8f`, all migrations applied to a throwaway DB
+(`d4_probe_20260724`), then `applyDirectoryDeprovisionPolicies` / `previewDeprovisionForUser` /
+`restoreDeprovisionEvent` called directly. Probe scripts are session-scratch, not committed.
+
+### A — deprovision with `enabled: true` (what the canary GO turns on)
+
+| | before | after |
+|---|---|---|
+| `users.is_active` | true | **false** |
+| `user_orgs.is_active` | true | **false** |
+| grant `enabled` | true | **false** |
+| `users.access_generation` | 0 | **0** |
+| ledger events / effects | 0 / 0 | **0 / 0** |
+
+Writer returned `applied:true, grantsDisabledCount:1, usersDeactivatedCount:1`. So the person
+**was** fully deprovisioned, and **nothing was recorded**. That is the whole finding, measured
+rather than inferred.
+
+### B — D7 preview vs a grant that is genuinely ON
+
+Grant row in DB: `enabled = true`. Preview plan effects:
+`["clear_user_orgs","set_user_inactive"]` — **no `disable_dingtalk_grant`**. The preview cannot
+represent the grant, because it reads `user_external_identities.grant_enabled`, and
+`information_schema` confirms that column does not exist on the migrated database.
+
+### C — restore, with controls
+
+Same event shape each time; only the effect's *leg* and the drift condition change.
+
+| Case | Expected | Actual |
+|---|---|---|
+| **Control 1** — user leg, no drift | success, user reactivated | **SUCCESS**, `is_active` → true |
+| **Control 2** — user leg, real drift (user already active) | `DRIFT_CONFLICT` | **`DRIFT_CONFLICT`** ✓ |
+| **Subject** — grant leg, real drift (grant still enabled) | `DRIFT_CONFLICT` | **`25P02`**, nothing restored |
+
+The controls matter: they prove the restore machinery and the drift guard both work on a leg that
+reads a real column. The grant leg fails in two separate ways:
+
+1. **Drift is not detected.** `currentMatchesAfter` for the grant effect reads the phantom column;
+   the query errors, `.catch` turns it into "no grant", and "no grant" is read as *matching*
+   `after_active=false`. The gate is satisfied **by the read failing**, so it can never fire — the
+   subject case sailed past it despite the grant genuinely still being on.
+2. **The restore then aborts unconditionally.** `.catch(() => {})` swallows the JS rejection but
+   cannot un-abort a Postgres transaction: every later statement in that transaction fails with
+   `25P02`, so the whole restore rolls back and the admin gets an opaque error. Any event carrying
+   a `disable_dingtalk_grant` effect is **unrestorable**.
+
+---
+
 ## 1. The writer is not wired (P1)
 
 | Fact | Evidence |
@@ -95,13 +147,18 @@ authoritative table is `user_external_auth_grants (provider, local_user_id, enab
 
 Three merged paths write or read the non-existent column behind a swallow, so each fails silently:
 
-| Path | Landed behaviour | Impact |
-|---|---|---|
-| `user-activate.ts:141` (T3, #4574) | `UPDATE user_external_identities SET grant_enabled = TRUE` inside `.catch(() => {})` | Activation reports success; the person is **never granted DingTalk login** |
-| `deprovision-evidence-api.ts` preview (D7, #4575) | reads `COALESCE(grant_enabled, FALSE)` inside `.catch` | preview can **never** show a grant effect |
-| `deprovision-evidence-api.ts` restore (D7, #4575) | `UPDATE … SET grant_enabled = TRUE` inside `.catch` | restore reports success; the grant **stays revoked** |
+| Path | Landed behaviour | Impact | Measured |
+|---|---|---|---|
+| `user-activate.ts:141` (T3, #4574) | `UPDATE user_external_identities SET grant_enabled = TRUE` inside `.catch(() => {})` | Activation reports success; the person is **never granted DingTalk login** | column absent in `information_schema` |
+| `deprovision-evidence-api.ts` preview (D7, #4575) | reads `COALESCE(grant_enabled, FALSE)` inside `.catch` | preview can **never** show a grant effect | §0.1 B |
+| `deprovision-evidence-api.ts` restore (D7, #4575) | `UPDATE … SET grant_enabled = TRUE` inside `.catch` | drift gate can never fire, and the restore aborts (`25P02`) | §0.1 C |
 
 The T3 activation defect is live in merged code today and is independent of the deprovision flag.
+
+Note the `.catch(() => {})` idiom is worse than "silently no-ops" here: inside a transaction, a
+failed statement poisons the connection, so swallowing the rejection converts a precise error
+(`42703 column does not exist`) into a confusing one (`25P02 transaction is aborted`) raised by
+whatever innocent statement runs next.
 
 ---
 

--- a/docs/development/dingtalk-lifecycle-postmerge-findings-20260724.md
+++ b/docs/development/dingtalk-lifecycle-postmerge-findings-20260724.md
@@ -138,7 +138,48 @@ not a reviewer's.
 
 ---
 
-## 3. Grant writes target a column that does not exist (P1) — fork-independent
+## 3. Writes target columns that do not exist (P1) — fork-independent, **now fixed**
+
+Fixed on `claude/dingtalk-t3-grant-table-fix-20260724` (`6c1a093ef`), with a real-DB suite:
+4/4 green with the fix, **4/4 red with `src` reverted to `main`**. Added to the plugin-tests
+run-list (that list is explicit — a new `.db.test.ts` is not auto-collected) and its collection
+proven by running it next to `directory-deprovision-selection.db.test.ts` (10/10 still green).
+Typecheck clean. The slice touches no deprovision writer and no `effect_type`, so it is
+independent of the schema fork in §2.
+
+Two phantom columns, four statements, every one behind a `.catch`:
+
+| Phantom write | Where |
+|---|---|
+| `user_external_identities.grant_enabled` | T3 activate (#4574); D7 preview and D7 restore (#4575) |
+| `user_orgs.updated_at` | T3 activate (#4574); D7 restore (#4575) |
+
+`user_orgs` is `(user_id, org_id, is_active, created_at)`, PK `(user_id, org_id)`. The grant lives
+in `user_external_auth_grants`, which is what `dingtalk-oauth.ts` reads at login.
+
+The `.catch` is what makes this severe rather than cosmetic. Inside a transaction a failed
+statement poisons the connection, so swallowing the rejection does not contain the failure — it
+relocates it, as `25P02`, onto whatever innocent statement runs next. Measured consequences on
+`main`:
+
+- **T3 activate with an `orgId` could not succeed at all** — the membership INSERT aborted the
+  transaction and it died at COMMIT. The "schema variance" fallback written underneath it is
+  structurally unreachable: a poisoned transaction rejects the fallback too.
+- With `enableDingTalkGrant: true`, activation **reported success and granted nothing**.
+- The D7 preview could **never** show a grant effect (§0.1 B).
+- Restoring any event carrying a membership **or** grant effect aborted — i.e. **every real
+  deprovision event**, since every candidate carries a membership effect (§0.1 C).
+- The grant drift gate was satisfied **by its own query failing**: the error became "no grant",
+  which reads as "matches `after_active=false`", so `DRIFT_CONFLICT` could never fire on that leg
+  (§0.1 C subject vs control 2).
+
+Why unit tests did not catch any of it: a stub client answers whatever SQL it is handed, so a
+statement naming a column that does not exist looks identical to one that does. Only real
+Postgres can tell them apart — which is the argument for §2 fork (A) restated in miniature.
+
+### Original detail
+
+
 
 `user_external_identities.grant_enabled` appears in **no migration**. Control: three migrations
 reference that table, and `grep -rn "grant_enabled" src/db/migrations/` returns zero rows. The

--- a/docs/development/dingtalk-lifecycle-postmerge-findings-20260724.md
+++ b/docs/development/dingtalk-lifecycle-postmerge-findings-20260724.md
@@ -1,0 +1,177 @@
+# DingTalk lifecycle line — post-merge findings (T1–T3 · D1–D7)
+
+- Date: 2026-07-24
+- Status: **findings — owner decision required on one fork**
+- Reviewed at: `origin/main @ 8aad0ef8f` (after #4559 / #4574 / #4575 / #4577)
+- Against: `dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md` Rev 4.2 (implementation design lock)
+- Companion lock: `dingtalk-directory-admission-activation-lifecycle-design-20260723.md` Rev 4.2
+
+This document records what a read of the merged lane found. It states evidence and the decision
+the owner has to make; it does not claim any of it was ratified.
+
+---
+
+## 0. Summary
+
+`dingtalk-lifecycle-line-closeout-20260724.md` presents **D1–D6 (backend)** as landed. The
+planner, the ledger helpers and the migration did land. What did not land is the thing that makes
+them mean anything: **the deprovision writer was never connected to any of it.** On `main`,
+`deprovision-ledger.ts` has no importer.
+
+Consequence if the canary sequence is followed as written and `DIRECTORY_DEPROVISION_ENABLED` is
+set to `true`: deprovisions execute the pre-existing path at `directory-sync.ts:4147`, which
+writes **no event, no effect row, and no `access_generation` bump**, and takes **no per-user
+mutex**. The D7 evidence panel would show an empty ledger, and the restore API would have nothing
+to restore from — with no error anywhere to indicate that.
+
+---
+
+## 1. The writer is not wired (P1)
+
+| Fact | Evidence |
+|------|----------|
+| The D4 writer + D5 supersede helpers are dead code | `git grep "from './deprovision-ledger'" origin/main` → no match. Control: the file exists (`git ls-tree origin/main -- packages/core-backend/src/directory/`) and sibling modules' imports do match, so the empty result is absence, not a bad path. |
+| The real writer is untouched by the lane | `applyDirectoryDeprovisionPolicies` (`directory-sync.ts:1462`) — no `access_generation`, no ledger, no `users … FOR UPDATE` |
+| `deprovision-restore.ts` exports only a pure evaluator | `evaluateDeprovisionRestoreEligibility`; the restore WRITE lives in `deprovision-evidence-api.ts` |
+
+Note on framing: **#4574's own PR body is accurate** — it says "D2–D4: … ledger/generation
+**helpers** + immutability migration". It never claimed the writer was swapped. The overstatement
+is in the closeout MD, which lists D1–D6 as done. So this reads as a documentation defect plus an
+unfinished step, not a false claim in the PR.
+
+Beyond the wiring, the landed helper would not have been safe to wire as written:
+
+- `writeDeprovisionLedger` opened its **own** `transaction()`, so evidence would commit
+  independently of the access-graph write it claims to witness (lock §5.3 requires one
+  transaction).
+- Every ledger `INSERT` was wrapped in `.catch(() => {})` ("table may not exist in unit mocks") —
+  a failed evidence write would have been invisible while the deprovision still committed.
+- It set `users.is_active = FALSE` unconditionally, and never applied `clear_user_orgs` or
+  `disable_dingtalk_grant` — so the recorded effects and the applied effects were different sets
+  ("Apply≈Plan", §11).
+
+---
+
+## 2. Ledger schema deviates from the ratified §5.2 (P1) — **the fork**
+
+`zzzz20260724170000` created the tables but not the enforcement §5.2/§5.2.1 marks mandatory.
+
+| § 5.2 requires | Landed in `zzzz20260724170000` |
+|---|---|
+| prerequisite `UNIQUE` keys on `directory_accounts (id, integration_id)`, `directory_integrations (id, org_id)`, `directory_sync_runs (id, integration_id)` | none |
+| composite FKs `(directory_account_id, integration_id)`, `(integration_id, org_id)`, `(run_id, integration_id)` | none |
+| `local_user_id … REFERENCES users(id)` | no FK |
+| `link_witness_account_id` / `link_witness_local_user_id` NOT NULL + self-consistency CHECKs | columns absent |
+| `policy`, `globally_clear`, `restore_mode`, `resolved_at/by`, `resolve_note` | columns absent |
+| `CHECK (event_origin IN ('sync','admin_manual'))` and sync ⇒ `run_id NOT NULL` | absent |
+| `CHECK (status IN (…))` on events and effects | absent |
+| effects `event_id NOT NULL REFERENCES events ON DELETE CASCADE` | nullable, no FK |
+| `CHECK` effect_type ∈ (`membership_changed`,`grant_changed`,`user_changed`) + org_id-by-type | absent; planner emits `clear_user_orgs` / `disable_dingtalk_grant` / `set_user_inactive` |
+| `UNIQUE (event_id, effect_type)` | absent |
+| **BEFORE INSERT** triggers proving the link existed at apply time, account ∈ integration, integration ∈ org, sync run of same integration | absent (only a partial immutability trigger on UPDATE) |
+| child table named `directory_deprovision_event_effects` | named `directory_deprovision_effects` |
+
+**Owner decision.** Two coherent resolutions, and they lead to different work:
+
+- **(A) Build to the lock** — corrective migration to the §5.2 shape, adopt the locked
+  `effect_type` enum, then wire. Stronger (the DB refuses a malformed evidence chain), and it is
+  what the ratified document says. Cost: an effect_type rename rippling through the D7 API/UI and
+  ~27 real-DB call sites needing a `directory_sync_runs` fixture.
+- **(B) Amend the lock** to match what shipped, and wire to the landed schema. Cheaper; gives up
+  the DB-level guarantees the lock calls mandatory, leaving them to application code.
+
+Recommendation: **(A)**, sliced — the lock's whole argument in §5.1 is that application-level
+evidence is insufficient. But this is a ratified document, so the amendment is the owner's call,
+not a reviewer's.
+
+---
+
+## 3. Grant writes target a column that does not exist (P1) — fork-independent
+
+`user_external_identities.grant_enabled` appears in **no migration**. Control: three migrations
+reference that table, and `grep -rn "grant_enabled" src/db/migrations/` returns zero rows. The
+authoritative table is `user_external_auth_grants (provider, local_user_id, enabled)` — the one
+`dingtalk-oauth.ts` reads at login.
+
+Three merged paths write or read the non-existent column behind a swallow, so each fails silently:
+
+| Path | Landed behaviour | Impact |
+|---|---|---|
+| `user-activate.ts:141` (T3, #4574) | `UPDATE user_external_identities SET grant_enabled = TRUE` inside `.catch(() => {})` | Activation reports success; the person is **never granted DingTalk login** |
+| `deprovision-evidence-api.ts` preview (D7, #4575) | reads `COALESCE(grant_enabled, FALSE)` inside `.catch` | preview can **never** show a grant effect |
+| `deprovision-evidence-api.ts` restore (D7, #4575) | `UPDATE … SET grant_enabled = TRUE` inside `.catch` | restore reports success; the grant **stays revoked** |
+
+The T3 activation defect is live in merged code today and is independent of the deprovision flag.
+
+---
+
+## 4. Restore decides eligibility outside its own transaction (P2)
+
+`restoreDeprovisionEvent` read the event, the user's `access_generation` and the directory-source
+state with plain `query()`, evaluated eligibility, and only then opened the transaction that takes
+`users … FOR UPDATE`. §5.4 makes restore conditional on the generation being **unchanged**;
+deciding that before the lock is a check-then-act. A concurrent access-graph write landing in the
+window lets a restore proceed on a verdict that was true only in the past, replaying a stale
+`before` over the newer writer's decision.
+
+---
+
+## 5. Process observations (not code)
+
+- **#4574 and #4575 carry no independent adversarial review.** Their only PR comments are bot
+  notices (Gemini sunset; Codex usage-limit). #4574 is the largest slice of the lane (T2 aliases,
+  T3 activate, D2–D6 core). The standing pre-push norm for core/cross-package changes is an
+  independent Opus pass; that review is **owed** for the whole T1–D7 stack, and I cannot
+  self-satisfy it in this session.
+- **No T1 GO record found.** Both locks state "design lock ≠ T1 GO … 另令开工". I found no GO in
+  #4559/#4574/#4575/#4577 bodies or comments. It may have been given in session and simply not
+  recorded on the PRs — worth the owner confirming rather than assuming either way.
+- What I checked, and what I did not: I read the deprovision writer, the ledger/planner/restore
+  modules, the evidence API and the two migrations. I did **not** audit the T2 alias
+  backfill/cutover gate or the T1 invite/activation guards beyond their grant interaction — those
+  surfaces are still unreviewed.
+
+---
+
+## 6. Work in flight on `claude/dingtalk-d4-d5-writer-ledger-wiring-20260724`
+
+Built against fork (A), **not pushed, not merged**, held for the decision above:
+
+- `zzzz20260724190000_harden_directory_deprovision_ledger.ts` — corrective migration to §5.2.
+  Fails closed if either ledger table is non-empty rather than discarding evidence to make room
+  for the new NOT NULL provenance columns.
+- `deprovision-planner.ts` — locked effect-type enum; `policy` input plus the org-scoped vs
+  globally-clear split, so the plan is the same decision the writer takes.
+- `deprovision-ledger.ts` — runs on the caller's transaction; no swallowed errors; refuses an
+  empty effect set.
+- `directory-sync.ts` — per-user `users … FOR UPDATE` in sorted id order (§7.2), globally-clear
+  re-read **under the lock** (§7.4 — this closes the write-skew gap the file's own comments
+  recorded as deferred), plan → apply → `recordDeprovisionEvent` in the sync transaction,
+  zero-effect ⇒ zero write.
+- `deprovision-evidence-api.ts` — eligibility moved inside the locked transaction; grant reads and
+  writes repointed at `user_external_auth_grants`; `restore_mode`/`resolved_*` recorded.
+- `user-activate.ts` — T3 grant repointed at `user_external_auth_grants`, swallow removed.
+
+Not built: **D5** (mutex on the full §7.3 writer inventory — bind/unbind, admit/activate,
+admin-users is_active/grant, `user_orgs` upsert, `directory_accounts.is_active` transitions with
+the D0 protocol) and its dual-connection race tests.
+
+### Risk the owner should own explicitly
+
+`assertAppliedMatchesPlan` throws when the applied effect set diverges from the plan, which rolls
+back **the entire directory sync run**, not just the deprovision step. Under the mutex this can
+only fire when another writer mutated the access graph without taking the same lock — i.e. the D5
+gap. The alternative is committing an evidence chain known to disagree with what happened. This
+argues D5 must precede any deprovision canary; it is a deliberate hammer, and it should be an
+owner-accepted one rather than a surprise.
+
+### Verification status — honest
+
+| Item | State |
+|---|---|
+| Corrective migration up/down against real PG | **not run** |
+| §11 real-DB matrix (raw-INSERT rejections, zero-effect no-write, Apply≈Plan, generation) | **not written** |
+| Existing 5 real-DB deprovision suites (27 call sites) updated for `runId`/`triggeredBy` + run fixture | **not done** |
+| Unit suites | stub updated for the new query shapes; **not run** |
+| Typecheck / CI | **not run** |
+| Independent adversarial review | **owed** — for this branch and for merged #4574/#4575 |

--- a/docs/development/dingtalk-lifecycle-postmerge-findings-20260724.md
+++ b/docs/development/dingtalk-lifecycle-postmerge-findings-20260724.md
@@ -153,7 +153,15 @@ Three merged paths write or read the non-existent column behind a swallow, so ea
 | `deprovision-evidence-api.ts` preview (D7, #4575) | reads `COALESCE(grant_enabled, FALSE)` inside `.catch` | preview can **never** show a grant effect | §0.1 B |
 | `deprovision-evidence-api.ts` restore (D7, #4575) | `UPDATE … SET grant_enabled = TRUE` inside `.catch` | drift gate can never fire, and the restore aborts (`25P02`) | §0.1 C |
 
-The T3 activation defect is live in merged code today and is independent of the deprovision flag.
+**Trigger condition for the T3 defect (precise).** `POST /api/admin/users/:id/activate` accepts
+`enableDingTalkGrant` from the request body with no flag of its own, but `activatePendingUser`
+only accepts a user already in `activation_status='pending_activation'`
+(`user-activate.ts:112`), and pending users are created **only** by the directory admission paths
+gated on `isDirectoryPendingActivationEnabled()` (three call sites in `directory-sync.ts`,
+default OFF). So the defect is **latent today** and **arms at canary step 2**
+(`DIRECTORY_PENDING_ACTIVATION_ENABLED=true`) — the first write-bearing step of the canary
+sequence, reached before deprovision is ever touched. It is not blocked by, and does not wait
+for, the deprovision flag.
 
 Note the `.catch(() => {})` idiom is worse than "silently no-ops" here: inside a transaction, a
 failed statement poisons the connection, so swallowing the rejection converts a precise error

--- a/packages/core-backend/src/auth/user-activate.ts
+++ b/packages/core-backend/src/auth/user-activate.ts
@@ -139,14 +139,18 @@ export async function activatePendingUser(input: ActivateUserInput): Promise<Act
     }
 
     if (input.enableDingTalkGrant === true) {
+      // `user_external_auth_grants` is where the DingTalk grant lives — it is the table
+      // `dingtalk-oauth.ts` reads to decide whether a login is allowed. The first cut wrote
+      // `user_external_identities.grant_enabled`, a column that exists in no migration, behind a
+      // `.catch` that made the failure invisible: activation reported success while the person
+      // was never actually granted DingTalk login. Same upsert shape the OAuth bind path uses.
       await client.query(
-        `UPDATE user_external_identities
-            SET grant_enabled = TRUE, updated_at = NOW()
-          WHERE local_user_id = $1 AND provider = 'dingtalk'`,
-        [userId],
-      ).catch(() => {
-        /* grant column may be named differently — non-fatal for unit/mock */
-      })
+        `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
+         VALUES ('dingtalk', $1, TRUE, $2, NOW(), NOW())
+         ON CONFLICT (provider, local_user_id)
+         DO UPDATE SET enabled = TRUE, granted_by = EXCLUDED.granted_by, updated_at = NOW()`,
+        [userId, `activate:${input.adminUserId ?? 'system'}`],
+      )
     }
   })
 

--- a/packages/core-backend/src/db/migrations/zzzz20260724190000_harden_directory_deprovision_ledger.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260724190000_harden_directory_deprovision_ledger.ts
@@ -1,0 +1,390 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+/**
+ * D3 completion — bring the deprovision ledger up to the ratified §5.2 shape
+ * (`dingtalk-deprovision-reactivation-and-evidence-chain-design-20260723.md`, Rev 4.2).
+ *
+ * `zzzz20260724170000` landed the tables but not the enforcement the lock marks **mandatory**:
+ * no composite FKs (and none of the three prerequisite UNIQUE keys they need), no witness
+ * columns, no policy / globally_clear provenance, no CHECKs, no BEFORE INSERT live-link
+ * validation, and `effects.event_id` nullable with no FK — so an effect row could be orphaned or
+ * attached to another person's event. The lock's §5.2.1 table is the authority: the DB, not the
+ * application, rejects a malformed evidence chain.
+ *
+ * Safe to run destructively-typed (`ALTER COLUMN ... TYPE uuid`) because the forward writer was
+ * never wired to these tables (`deprovision-ledger.ts` had no importer on `main`) and
+ * `DIRECTORY_DEPROVISION_ENABLED` has never been on: both tables are empty everywhere. The
+ * migration still guards each step so a re-run (or a partially-applied environment) is a no-op.
+ *
+ * Deliberate deviation, recorded for owner ratification: the lock names the child table
+ * `directory_deprovision_event_effects`; `zzzz20260724170000` created it as
+ * `directory_deprovision_effects` and D7's API/UI already read that name. Renaming buys no
+ * semantics, so the landed name is kept and the deviation is documented rather than silently
+ * normalised.
+ */
+
+const EFFECT_TYPES = ['membership_changed', 'grant_changed', 'user_changed'] as const
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const hasEvents = await checkTableExists(db, 'directory_deprovision_events')
+  const hasEffects = await checkTableExists(db, 'directory_deprovision_effects')
+  if (!hasEvents || !hasEffects) return
+
+  // ---------------------------------------------------------------------------------------
+  // 0. Prerequisite UNIQUE keys (§5.2 "迁移必须先有，否则复合 FK 无法建").
+  // ---------------------------------------------------------------------------------------
+  await sql`
+    ALTER TABLE directory_accounts
+    ADD CONSTRAINT directory_accounts_id_integration_key UNIQUE (id, integration_id)
+  `.execute(db).catch(swallowDuplicateObject)
+  await sql`
+    ALTER TABLE directory_integrations
+    ADD CONSTRAINT directory_integrations_id_org_key UNIQUE (id, org_id)
+  `.execute(db).catch(swallowDuplicateObject)
+  await sql`
+    ALTER TABLE directory_sync_runs
+    ADD CONSTRAINT directory_sync_runs_id_integration_key UNIQUE (id, integration_id)
+  `.execute(db).catch(swallowDuplicateObject)
+
+  // ---------------------------------------------------------------------------------------
+  // 1. Column types + the provenance columns §5.2 requires.
+  //    `integration_id` / `directory_account_id` / `run_id` land as `text`; the composite FKs
+  //    below reference `uuid` columns, so they must be converted first.
+  // ---------------------------------------------------------------------------------------
+  // Fail closed rather than deleting: the new NOT NULL provenance columns cannot be backfilled
+  // for a pre-existing row without knowing its policy / globally_clear / witness, and this ledger
+  // IS the evidence chain — a migration must never silently discard it. Empty everywhere by
+  // construction (the writer had no importer; the flag has never been on), so a non-empty table
+  // means something unmodelled happened and an operator has to look.
+  await assertLedgerEmpty(db)
+
+  await sql`
+    ALTER TABLE directory_deprovision_events
+      ALTER COLUMN integration_id TYPE uuid USING integration_id::uuid,
+      ALTER COLUMN directory_account_id TYPE uuid USING directory_account_id::uuid,
+      ALTER COLUMN run_id TYPE uuid USING run_id::uuid
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE directory_deprovision_events
+      ADD COLUMN IF NOT EXISTS link_witness_account_id uuid,
+      ADD COLUMN IF NOT EXISTS link_witness_local_user_id text,
+      ADD COLUMN IF NOT EXISTS policy text,
+      ADD COLUMN IF NOT EXISTS globally_clear boolean,
+      ADD COLUMN IF NOT EXISTS resolved_at timestamptz,
+      ADD COLUMN IF NOT EXISTS resolved_by text,
+      ADD COLUMN IF NOT EXISTS resolve_note text,
+      ADD COLUMN IF NOT EXISTS restore_mode text
+  `.execute(db)
+
+  // Tables are empty (see file header), so NOT NULL needs no backfill.
+  await sql`
+    ALTER TABLE directory_deprovision_events
+      ALTER COLUMN link_witness_account_id SET NOT NULL,
+      ALTER COLUMN link_witness_local_user_id SET NOT NULL,
+      ALTER COLUMN policy SET NOT NULL,
+      ALTER COLUMN globally_clear SET NOT NULL,
+      ALTER COLUMN triggered_by SET NOT NULL
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+      ALTER COLUMN event_id SET NOT NULL
+  `.execute(db)
+
+  // ---------------------------------------------------------------------------------------
+  // 2. CHECK constraints (§5.2).
+  // ---------------------------------------------------------------------------------------
+  await addCheck(db, 'directory_deprovision_events', 'ddev_event_origin_check', `
+    event_origin IN ('sync','admin_manual')
+  `)
+  await addCheck(db, 'directory_deprovision_events', 'ddev_run_id_by_origin_check', `
+    (event_origin = 'sync' AND run_id IS NOT NULL)
+    OR (event_origin = 'admin_manual' AND run_id IS NULL)
+  `)
+  await addCheck(db, 'directory_deprovision_events', 'ddev_policy_check', `
+    policy IN ('manual_review','disable_grant_only','mark_inactive')
+  `)
+  await addCheck(db, 'directory_deprovision_events', 'ddev_status_check', `
+    status IN ('applied','fully_resolved','superseded')
+  `)
+  // "CHECK 只防自相矛盾，trigger 才验 live link" — these two only pin the witness to the event's
+  // own subject; the BEFORE INSERT trigger below is what proves the link existed at the time.
+  await addCheck(db, 'directory_deprovision_events', 'ddev_witness_account_check', `
+    link_witness_account_id = directory_account_id
+  `)
+  await addCheck(db, 'directory_deprovision_events', 'ddev_witness_user_check', `
+    link_witness_local_user_id = local_user_id
+  `)
+  await addCheck(db, 'directory_deprovision_events', 'ddev_restore_mode_check', `
+    restore_mode IS NULL OR restore_mode IN ('rehire','admin_force')
+  `)
+
+  await addCheck(db, 'directory_deprovision_effects', 'ddef_effect_type_check', `
+    effect_type IN ('membership_changed','grant_changed','user_changed')
+  `)
+  await addCheck(db, 'directory_deprovision_effects', 'ddef_status_check', `
+    status IN ('applied','reversed','superseded')
+  `)
+  await addCheck(db, 'directory_deprovision_effects', 'ddef_org_id_by_type_check', `
+    (effect_type = 'membership_changed' AND org_id IS NOT NULL)
+    OR (effect_type IN ('grant_changed','user_changed') AND org_id IS NULL)
+  `)
+
+  await sql`
+    ALTER TABLE directory_deprovision_effects
+    ADD CONSTRAINT ddef_event_effect_type_key UNIQUE (event_id, effect_type)
+  `.execute(db).catch(swallowDuplicateObject)
+
+  // ---------------------------------------------------------------------------------------
+  // 3. Foreign keys — including the composite ones that pin a run to its own integration and an
+  //    account to its own integration. §5.2 explicitly forbids an FK to the *current*
+  //    `directory_account_links` row (unbind NULLs `local_user_id`, which would make historical
+  //    events permanently block a legitimate unbind/rebind).
+  // ---------------------------------------------------------------------------------------
+  await addForeignKey(db, 'directory_deprovision_events', 'ddev_user_fk', `
+    FOREIGN KEY (local_user_id) REFERENCES users (id)
+  `)
+  await addForeignKey(db, 'directory_deprovision_events', 'ddev_account_integration_fk', `
+    FOREIGN KEY (directory_account_id, integration_id)
+    REFERENCES directory_accounts (id, integration_id)
+  `)
+  await addForeignKey(db, 'directory_deprovision_events', 'ddev_integration_org_fk', `
+    FOREIGN KEY (integration_id, org_id)
+    REFERENCES directory_integrations (id, org_id)
+  `)
+  await addForeignKey(db, 'directory_deprovision_events', 'ddev_run_integration_fk', `
+    FOREIGN KEY (run_id, integration_id)
+    REFERENCES directory_sync_runs (id, integration_id)
+  `)
+  await addForeignKey(db, 'directory_deprovision_effects', 'ddef_event_fk', `
+    FOREIGN KEY (event_id) REFERENCES directory_deprovision_events (id) ON DELETE CASCADE
+  `)
+
+  // ---------------------------------------------------------------------------------------
+  // 4. Mandatory BEFORE INSERT validation (§5.2.1). The CHECKs above cannot see other tables;
+  //    this is what refuses an event whose account/user were not actually linked at the time.
+  // ---------------------------------------------------------------------------------------
+  await sql`
+    CREATE OR REPLACE FUNCTION directory_deprovision_validate_event()
+    RETURNS trigger AS $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM directory_account_links l
+         WHERE l.directory_account_id = NEW.directory_account_id
+           AND l.local_user_id = NEW.local_user_id
+           AND l.link_status = 'linked'
+      ) THEN
+        RAISE EXCEPTION 'directory_deprovision_events requires a linked account/user at apply time (account=%, user=%)',
+          NEW.directory_account_id, NEW.local_user_id;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM directory_accounts a
+         WHERE a.id = NEW.directory_account_id
+           AND a.integration_id = NEW.integration_id
+      ) THEN
+        RAISE EXCEPTION 'directory_deprovision_events account % does not belong to integration %',
+          NEW.directory_account_id, NEW.integration_id;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM directory_integrations i
+         WHERE i.id = NEW.integration_id
+           AND i.org_id = NEW.org_id
+      ) THEN
+        RAISE EXCEPTION 'directory_deprovision_events integration % does not belong to org %',
+          NEW.integration_id, NEW.org_id;
+      END IF;
+
+      IF NEW.event_origin = 'sync' AND NOT EXISTS (
+        SELECT 1 FROM directory_sync_runs r
+         WHERE r.id = NEW.run_id
+           AND r.integration_id = NEW.integration_id
+      ) THEN
+        RAISE EXCEPTION 'directory_deprovision_events sync event requires a run of the same integration (run=%, integration=%)',
+          NEW.run_id, NEW.integration_id;
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+  `.execute(db)
+
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_events_validate ON directory_deprovision_events`.execute(db)
+  await sql`
+    CREATE TRIGGER trg_deprovision_events_validate
+    BEFORE INSERT ON directory_deprovision_events
+    FOR EACH ROW EXECUTE FUNCTION directory_deprovision_validate_event()
+  `.execute(db)
+
+  await sql`
+    CREATE OR REPLACE FUNCTION directory_deprovision_validate_effect()
+    RETURNS trigger AS $$
+    DECLARE
+      parent_org text;
+    BEGIN
+      SELECT org_id INTO parent_org
+        FROM directory_deprovision_events
+       WHERE id = NEW.event_id;
+
+      IF parent_org IS NULL THEN
+        RAISE EXCEPTION 'directory_deprovision_effects has no parent event %', NEW.event_id;
+      END IF;
+
+      IF NEW.effect_type = 'membership_changed' AND NEW.org_id IS DISTINCT FROM parent_org THEN
+        RAISE EXCEPTION 'membership_changed effect org % must equal parent event org %',
+          NEW.org_id, parent_org;
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+  `.execute(db)
+
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_effects_validate ON directory_deprovision_effects`.execute(db)
+  await sql`
+    CREATE TRIGGER trg_deprovision_effects_validate
+    BEFORE INSERT ON directory_deprovision_effects
+    FOR EACH ROW EXECUTE FUNCTION directory_deprovision_validate_effect()
+  `.execute(db)
+
+  // ---------------------------------------------------------------------------------------
+  // 5. Immutability — `zzzz20260724170000`'s trigger covered a subset of the identity columns.
+  //    §5.2.1 requires the provenance columns added above to be frozen too; only the resolve
+  //    columns (events) and status/reversed_* (effects) may ever change after INSERT.
+  // ---------------------------------------------------------------------------------------
+  await sql`
+    CREATE OR REPLACE FUNCTION directory_deprovision_reject_identity_update()
+    RETURNS trigger AS $$
+    BEGIN
+      IF TG_TABLE_NAME = 'directory_deprovision_events' THEN
+        IF NEW.org_id IS DISTINCT FROM OLD.org_id
+           OR NEW.integration_id IS DISTINCT FROM OLD.integration_id
+           OR NEW.directory_account_id IS DISTINCT FROM OLD.directory_account_id
+           OR NEW.local_user_id IS DISTINCT FROM OLD.local_user_id
+           OR NEW.link_witness_account_id IS DISTINCT FROM OLD.link_witness_account_id
+           OR NEW.link_witness_local_user_id IS DISTINCT FROM OLD.link_witness_local_user_id
+           OR NEW.policy IS DISTINCT FROM OLD.policy
+           OR NEW.globally_clear IS DISTINCT FROM OLD.globally_clear
+           OR NEW.access_generation_at_apply IS DISTINCT FROM OLD.access_generation_at_apply
+           OR NEW.event_origin IS DISTINCT FROM OLD.event_origin
+           OR NEW.run_id IS DISTINCT FROM OLD.run_id
+           OR NEW.triggered_by IS DISTINCT FROM OLD.triggered_by THEN
+          RAISE EXCEPTION 'directory_deprovision_events identity fields are immutable';
+        END IF;
+      ELSIF TG_TABLE_NAME = 'directory_deprovision_effects' THEN
+        IF NEW.effect_type IS DISTINCT FROM OLD.effect_type
+           OR NEW.org_id IS DISTINCT FROM OLD.org_id
+           OR NEW.before_active IS DISTINCT FROM OLD.before_active
+           OR NEW.after_active IS DISTINCT FROM OLD.after_active
+           OR NEW.access_generation_at_apply IS DISTINCT FROM OLD.access_generation_at_apply
+           OR NEW.local_user_id IS DISTINCT FROM OLD.local_user_id
+           OR NEW.event_id IS DISTINCT FROM OLD.event_id THEN
+          RAISE EXCEPTION 'directory_deprovision_effects identity fields are immutable';
+        END IF;
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_effects_validate ON directory_deprovision_effects`.execute(db)
+    .catch(() => undefined)
+  await sql`DROP TRIGGER IF EXISTS trg_deprovision_events_validate ON directory_deprovision_events`.execute(db)
+    .catch(() => undefined)
+  await sql`DROP FUNCTION IF EXISTS directory_deprovision_validate_effect()`.execute(db).catch(() => undefined)
+  await sql`DROP FUNCTION IF EXISTS directory_deprovision_validate_event()`.execute(db).catch(() => undefined)
+
+  for (const [table, constraint] of [
+    ['directory_deprovision_effects', 'ddef_event_fk'],
+    ['directory_deprovision_effects', 'ddef_event_effect_type_key'],
+    ['directory_deprovision_effects', 'ddef_org_id_by_type_check'],
+    ['directory_deprovision_effects', 'ddef_status_check'],
+    ['directory_deprovision_effects', 'ddef_effect_type_check'],
+    ['directory_deprovision_events', 'ddev_run_integration_fk'],
+    ['directory_deprovision_events', 'ddev_integration_org_fk'],
+    ['directory_deprovision_events', 'ddev_account_integration_fk'],
+    ['directory_deprovision_events', 'ddev_user_fk'],
+    ['directory_deprovision_events', 'ddev_restore_mode_check'],
+    ['directory_deprovision_events', 'ddev_witness_user_check'],
+    ['directory_deprovision_events', 'ddev_witness_account_check'],
+    ['directory_deprovision_events', 'ddev_status_check'],
+    ['directory_deprovision_events', 'ddev_policy_check'],
+    ['directory_deprovision_events', 'ddev_run_id_by_origin_check'],
+    ['directory_deprovision_events', 'ddev_event_origin_check'],
+  ] as const) {
+    await sql`ALTER TABLE ${sql.raw(table)} DROP CONSTRAINT IF EXISTS ${sql.raw(constraint)}`
+      .execute(db)
+      .catch(() => undefined)
+  }
+
+  await sql`
+    ALTER TABLE directory_deprovision_events
+      DROP COLUMN IF EXISTS restore_mode,
+      DROP COLUMN IF EXISTS resolve_note,
+      DROP COLUMN IF EXISTS resolved_by,
+      DROP COLUMN IF EXISTS resolved_at,
+      DROP COLUMN IF EXISTS globally_clear,
+      DROP COLUMN IF EXISTS policy,
+      DROP COLUMN IF EXISTS link_witness_local_user_id,
+      DROP COLUMN IF EXISTS link_witness_account_id
+  `.execute(db).catch(() => undefined)
+
+  for (const [table, constraint] of [
+    ['directory_sync_runs', 'directory_sync_runs_id_integration_key'],
+    ['directory_integrations', 'directory_integrations_id_org_key'],
+    ['directory_accounts', 'directory_accounts_id_integration_key'],
+  ] as const) {
+    await sql`ALTER TABLE ${sql.raw(table)} DROP CONSTRAINT IF EXISTS ${sql.raw(constraint)}`
+      .execute(db)
+      .catch(() => undefined)
+  }
+}
+
+/** Exported so the real-DB suite asserts against the same list the migration writes. */
+export const __deprovisionLedgerEffectTypes = EFFECT_TYPES
+
+async function assertLedgerEmpty(db: Kysely<unknown>): Promise<void> {
+  for (const table of ['directory_deprovision_events', 'directory_deprovision_effects']) {
+    const result = await sql<{ n: number }>`
+      SELECT count(*)::int AS n FROM ${sql.raw(table)}
+    `.execute(db)
+    const rows = Number(result.rows[0]?.n ?? 0)
+    if (rows > 0) {
+      throw new Error(
+        `${table} already holds ${rows} row(s); zzzz20260724190000 hardens the ledger to the `
+        + 'Rev 4.2 §5.2 shape and cannot backfill link_witness_* / policy / globally_clear for '
+        + 'pre-existing evidence. Export the rows and decide their provenance before migrating.',
+      )
+    }
+  }
+}
+
+async function addCheck(db: Kysely<unknown>, table: string, name: string, body: string): Promise<void> {
+  await sql`
+    ALTER TABLE ${sql.raw(table)}
+    ADD CONSTRAINT ${sql.raw(name)} CHECK (${sql.raw(body.trim())})
+  `.execute(db).catch(swallowDuplicateObject)
+}
+
+async function addForeignKey(db: Kysely<unknown>, table: string, name: string, body: string): Promise<void> {
+  await sql`
+    ALTER TABLE ${sql.raw(table)}
+    ADD CONSTRAINT ${sql.raw(name)} ${sql.raw(body.trim())}
+  `.execute(db).catch(swallowDuplicateObject)
+}
+
+/**
+ * Re-running the migration must be a no-op, but a genuine failure (missing prerequisite index,
+ * a row that violates the constraint) must still surface — only "already exists" is swallowed.
+ */
+function swallowDuplicateObject(error: unknown): void {
+  const code = (error as { code?: string } | null)?.code
+  if (code === '42710' || code === '42P07') return
+  throw error
+}

--- a/packages/core-backend/src/directory/deprovision-evidence-api.ts
+++ b/packages/core-backend/src/directory/deprovision-evidence-api.ts
@@ -46,22 +46,33 @@ export async function previewDeprovisionForUser(localUserId: string) {
   const orgs = await query<{ org_id: string }>(
     `SELECT org_id FROM user_orgs WHERE user_id = $1 AND COALESCE(is_active, TRUE) = TRUE`,
     [localUserId],
-  ).catch(() => ({ rows: [] as Array<{ org_id: string }> }))
+  )
 
+  // The DingTalk grant lives in `user_external_auth_grants` — the table `dingtalk-oauth.ts`
+  // itself reads at login. An earlier cut read `user_external_identities.grant_enabled`, a
+  // column no migration has ever created, behind a `.catch` that turned the resulting error into
+  // "no grant": the preview could therefore never show a grant effect, whatever the truth was.
+  // No `.catch` here either — a preview that cannot read the access graph must say so rather
+  // than quietly under-report what deprovision would take away.
   const grant = await query<{ enabled: boolean }>(
-    `SELECT COALESCE(grant_enabled, FALSE) AS enabled
-       FROM user_external_identities
+    `SELECT enabled
+       FROM user_external_auth_grants
       WHERE local_user_id = $1 AND provider = 'dingtalk'
       LIMIT 1`,
     [localUserId],
-  ).catch(() => ({ rows: [] as Array<{ enabled: boolean }> }))
+  )
 
   const plan = planDirectoryDeprovision({
     localUserId,
+    // Preview answers "what would deprovision do to this person if it fired", so it asks the
+    // most permissive policy and the globally-clear branch; the writer re-decides both under the
+    // per-user lock against that person's actual integration policy.
+    policy: 'mark_inactive',
     activationStatus: u.activation_status,
-    isActive: u.is_active,
-    activeOrgIds: orgs.rows.map((r) => r.org_id),
+    membershipOrgId: orgs.rows[0]?.org_id ?? null,
+    membershipActive: orgs.rows.length > 0,
     dingtalkGrantEnabled: grant.rows[0]?.enabled === true,
+    userActive: u.is_active,
     globallyClear: true,
   })
 
@@ -73,6 +84,11 @@ export async function previewDeprovisionForUser(localUserId: string) {
       isActive: u.is_active,
       accessGeneration: Number(u.access_generation ?? 0),
     },
+    // A person can hold memberships in several orgs while a deprovision event is anchored to ONE
+    // (`UNIQUE (event_id, effect_type)`, and the writer is scoped to the integration's org). The
+    // plan below therefore models the first; the full set is reported so the admin is not shown a
+    // single membership effect and left to assume it is the only one.
+    activeOrgIds: orgs.rows.map((r) => r.org_id),
     plan,
   }
 }
@@ -140,23 +156,34 @@ async function loadEventBundle(eventId: string) {
     ;(err as Error & { code?: string }).code = 'EVENT_NOT_FOUND'
     throw err
   }
-  const effects = await listDeprovisionEffects(eventId)
-  return { event: ev.rows[0], effects }
+  return { event: ev.rows[0] }
 }
 
-async function isDirectorySourceActive(directoryAccountId: string): Promise<boolean> {
-  const r = await query<{ account_active: boolean; integration_status: string }>(
+type ReadClient = { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> }
+
+/**
+ * "Is the person still gone according to the directory?" — the question that separates a rehire
+ * restore from an admin force. Takes the caller's client so the restore transaction reads it
+ * under the same lock as everything else it decides on; no `.catch` swallow, because a read
+ * failure here would otherwise present as "source inactive" and silently push an eligible rehire
+ * onto the force path.
+ */
+async function isDirectorySourceActive(
+  directoryAccountId: string,
+  client: ReadClient = { query: (sql, params) => query(sql, params) },
+): Promise<boolean> {
+  const r = await client.query(
     `SELECT COALESCE(da.is_active, FALSE) AS account_active,
             COALESCE(di.status, '') AS integration_status
        FROM directory_accounts da
        JOIN directory_integrations di ON di.id = da.integration_id
-      WHERE da.id::text = $1 OR da.id = $1::uuid
+      WHERE da.id = $1::uuid
       LIMIT 1`,
     [directoryAccountId],
-  ).catch(() => ({ rows: [] as Array<{ account_active: boolean; integration_status: string }> }))
-  const row = r.rows[0]
+  )
+  const row = r.rows[0] as { account_active?: boolean; integration_status?: string } | undefined
   if (!row) return false
-  return row.account_active === true && String(row.integration_status).toLowerCase() === 'active'
+  return row.account_active === true && String(row.integration_status ?? '').toLowerCase() === 'active'
 }
 
 /**
@@ -182,102 +209,121 @@ export async function restoreDeprovisionEvent(options: {
     }
   }
 
-  const { event, effects } = await loadEventBundle(options.eventId)
-  const applied = effects.filter((e: any) => e.status === 'applied') as Array<{
-    id: string
-    status: string
-    after_active: boolean
-    access_generation_at_apply: number
-    effect_type: string
-    org_id: string | null
-  }>
+  const { event } = await loadEventBundle(options.eventId)
 
-  const user = await query<{ is_active: boolean; access_generation: number }>(
-    `SELECT COALESCE(is_active, TRUE) AS is_active,
-            COALESCE(access_generation, 0) AS access_generation
-       FROM users WHERE id = $1`,
-    [event.local_user_id],
-  )
-  if (!user.rows[0]) {
-    const err = new Error('User not found')
-    ;(err as Error & { code?: string }).code = 'USER_NOT_FOUND'
-    throw err
-  }
-
-  const sourceActive = await isDirectorySourceActive(event.directory_account_id)
-
-  const effectViews: RestoreEffectView[] = applied.map((e) => ({
-    id: e.id,
-    status: e.status,
-    afterActive: e.after_active,
-    accessGenerationAtApply: Number(e.access_generation_at_apply),
-    effectType: e.effect_type,
-  }))
-
-  const currentMatchesAfter: Record<string, boolean> = {}
-  for (const e of applied) {
-    if (e.effect_type === 'set_user_inactive') {
-      // after_active false means user should still be inactive for restore eligibility
-      currentMatchesAfter[e.id] = user.rows[0].is_active === false
-    } else if (e.effect_type === 'clear_user_orgs') {
-      const org = await query<{ n: number }>(
-        `SELECT count(*)::int AS n FROM user_orgs
-          WHERE user_id = $1 AND org_id = $2 AND COALESCE(is_active, TRUE) = TRUE`,
-        [event.local_user_id, e.org_id],
-      ).catch(() => ({ rows: [{ n: 0 }] }))
-      // after false → no active membership
-      currentMatchesAfter[e.id] = (org.rows[0]?.n ?? 0) === 0
-    } else if (e.effect_type === 'disable_dingtalk_grant') {
-      const g = await query<{ enabled: boolean }>(
-        `SELECT COALESCE(grant_enabled, FALSE) AS enabled
-           FROM user_external_identities
-          WHERE local_user_id = $1 AND provider = 'dingtalk' LIMIT 1`,
-        [event.local_user_id],
-      ).catch(() => ({ rows: [{ enabled: false }] }))
-      currentMatchesAfter[e.id] = g.rows[0]?.enabled !== true
-    } else {
-      currentMatchesAfter[e.id] = true
+  // §5.4: eligibility turns on `access_generation` being UNCHANGED since the event was applied.
+  // Deciding that outside the transaction and then writing inside it is a check-then-act: a
+  // concurrent access-graph write (admin deactivate, a newer deprovision) could bump the
+  // generation in between, and the restore would proceed on an eligibility verdict that was true
+  // only in the past — replaying a stale `before` over whatever the newer writer decided. The
+  // whole decision therefore happens under the same `users` row lock that guards the write.
+  const restored = await transaction(async (client) => {
+    const lockedUserResult = await client.query(
+      `SELECT COALESCE(is_active, TRUE) AS is_active,
+              COALESCE(access_generation, 0) AS access_generation
+         FROM users WHERE id = $1 FOR UPDATE`,
+      [event.local_user_id],
+    )
+    const lockedUser = lockedUserResult.rows[0] as
+      | { is_active: boolean; access_generation: number }
+      | undefined
+    if (!lockedUser) {
+      const err = new Error('User not found')
+      ;(err as Error & { code?: string }).code = 'USER_NOT_FOUND'
+      throw err
     }
-  }
 
-  const eligibility = evaluateDeprovisionRestoreEligibility({
-    mode: options.mode,
-    directorySourceActive: sourceActive,
-    currentUserAccessGeneration: Number(user.rows[0].access_generation),
-    eventAccessGeneration: Number(event.access_generation_at_apply),
-    effects: effectViews,
-    currentMatchesAfter,
-  })
+    const effects = await client.query(
+      `SELECT id, status, after_active, access_generation_at_apply, effect_type, org_id
+         FROM directory_deprovision_effects
+        WHERE event_id = $1
+        ORDER BY created_at ASC`,
+      [options.eventId],
+    )
+    const applied = (effects.rows as Array<{
+      id: string
+      status: string
+      after_active: boolean
+      access_generation_at_apply: number
+      effect_type: string
+      org_id: string | null
+    }>).filter((e) => e.status === 'applied')
 
-  if (eligibility.ok === false) {
-    const err = new Error(eligibility.message)
-    ;(err as Error & { code?: string }).code =
-      eligibility.code === 'DRIFT' ? 'DRIFT_CONFLICT' : eligibility.code
-    throw err
-  }
+    const sourceActive = await isDirectorySourceActive(event.directory_account_id, client)
 
-  await transaction(async (client) => {
-    await client.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [event.local_user_id])
+    const effectViews: RestoreEffectView[] = applied.map((e) => ({
+      id: e.id,
+      status: e.status,
+      afterActive: e.after_active,
+      accessGenerationAtApply: Number(e.access_generation_at_apply),
+      effectType: e.effect_type,
+    }))
+
+    const currentMatchesAfter: Record<string, boolean> = {}
+    for (const e of applied) {
+      if (e.effect_type === 'user_changed') {
+        // after_active false means user should still be inactive for restore eligibility
+        currentMatchesAfter[e.id] = lockedUser.is_active === false
+      } else if (e.effect_type === 'membership_changed') {
+        const org = await client.query(
+          `SELECT count(*)::int AS n FROM user_orgs
+            WHERE user_id = $1 AND org_id = $2 AND COALESCE(is_active, TRUE) = TRUE`,
+          [event.local_user_id, e.org_id],
+        )
+        // after false → no active membership
+        currentMatchesAfter[e.id] = Number((org.rows[0] as { n?: number } | undefined)?.n ?? 0) === 0
+      } else if (e.effect_type === 'grant_changed') {
+        const g = await client.query(
+          `SELECT enabled
+             FROM user_external_auth_grants
+            WHERE local_user_id = $1 AND provider = 'dingtalk' LIMIT 1`,
+          [event.local_user_id],
+        )
+        currentMatchesAfter[e.id] = (g.rows[0] as { enabled?: boolean } | undefined)?.enabled !== true
+      } else {
+        currentMatchesAfter[e.id] = true
+      }
+    }
+
+    const eligibility = evaluateDeprovisionRestoreEligibility({
+      mode: options.mode,
+      directorySourceActive: sourceActive,
+      currentUserAccessGeneration: Number(lockedUser.access_generation),
+      eventAccessGeneration: Number(event.access_generation_at_apply),
+      effects: effectViews,
+      currentMatchesAfter,
+    })
+
+    if (eligibility.ok === false) {
+      const err = new Error(eligibility.message)
+      ;(err as Error & { code?: string }).code =
+        eligibility.code === 'DRIFT' ? 'DRIFT_CONFLICT' : eligibility.code
+      throw err
+    }
 
     for (const e of applied) {
-      if (e.effect_type === 'set_user_inactive') {
+      // No `.catch` on any of these: a restore that silently fails to give access back is worse
+      // than one that fails loudly — the admin would be told the person was restored while the
+      // grant or membership stayed revoked.
+      if (e.effect_type === 'user_changed') {
         await client.query(
           `UPDATE users SET is_active = TRUE, updated_at = NOW() WHERE id = $1`,
           [event.local_user_id],
         )
-      } else if (e.effect_type === 'clear_user_orgs' && e.org_id) {
+      } else if (e.effect_type === 'membership_changed' && e.org_id) {
         await client.query(
           `UPDATE user_orgs SET is_active = TRUE, updated_at = NOW()
             WHERE user_id = $1 AND org_id = $2`,
           [event.local_user_id, e.org_id],
-        ).catch(() => {})
-      } else if (e.effect_type === 'disable_dingtalk_grant') {
+        )
+      } else if (e.effect_type === 'grant_changed') {
         await client.query(
-          `UPDATE user_external_identities
-              SET grant_enabled = TRUE, updated_at = NOW()
-            WHERE local_user_id = $1 AND provider = 'dingtalk'`,
-          [event.local_user_id],
-        ).catch(() => {})
+          `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
+           VALUES ('dingtalk', $1, TRUE, $2, NOW(), NOW())
+           ON CONFLICT (provider, local_user_id)
+           DO UPDATE SET enabled = TRUE, updated_at = NOW()`,
+          [event.local_user_id, `admin:${options.adminUserId}`],
+        )
       }
       await client.query(
         `UPDATE directory_deprovision_effects
@@ -297,16 +343,23 @@ export async function restoreDeprovisionEvent(options: {
 
     await client.query(
       `UPDATE directory_deprovision_events
-          SET status = 'fully_resolved', updated_at = NOW()
+          SET status = 'fully_resolved',
+              restore_mode = $2,
+              resolved_at = NOW(),
+              resolved_by = $3,
+              resolve_note = $4,
+              updated_at = NOW()
         WHERE id = $1`,
-      [options.eventId],
+      [options.eventId, options.mode, options.adminUserId, options.note ?? null],
     )
+
+    return applied.length
   })
 
   return {
     eventId: options.eventId,
     mode: options.mode,
-    restoredEffectCount: applied.length,
+    restoredEffectCount: restored,
     localUserId: event.local_user_id,
     note: options.note ?? null,
     adminUserId: options.adminUserId,

--- a/packages/core-backend/src/directory/deprovision-ledger.ts
+++ b/packages/core-backend/src/directory/deprovision-ledger.ts
@@ -1,213 +1,227 @@
 /**
- * D3/D4 — deprovision effect ledger helpers (design lock Rev 4.2 companion §5).
+ * D3/D4 — deprovision effect ledger (design lock Rev 4.2 companion §5.2–§5.4).
  *
- * Immutability of identity fields is enforced by DB triggers in migration;
- * application helpers only INSERT events/effects and supersede open rows.
+ * Every function here runs on the CALLER's transaction client. That is the whole point: §5.3
+ * requires the access-graph write and its evidence row to commit or roll back together, so the
+ * ledger must never open a transaction of its own (a nested `transaction()` would commit the
+ * evidence independently of the write it claims to witness, and would take the per-user mutex on
+ * a second connection while the caller still holds its own).
+ *
+ * Nothing here swallows a database error. An evidence chain whose INSERT can silently fail is
+ * not an evidence chain — if the ledger cannot be written, the deprovision it describes must not
+ * commit either. Identity/link/org/run validity is additionally enforced by the DB triggers from
+ * `zzzz20260724190000` (§5.2.1 "trigger 才验 live link"); these helpers are the forward path, not
+ * the guard.
  */
 
-import { query, transaction } from '../db/pg'
-import type { PlannedEffect } from './deprovision-planner'
-import { planDirectoryDeprovision } from './deprovision-planner'
+import type { DeprovisionPolicy, PlannedEffect } from './deprovision-planner'
 
-export type ApplyDeprovisionInput = {
+/** The narrow shape both the sync transaction client and `pg`'s client satisfy. */
+export type LedgerClient = {
+  query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }> }
+
+export type UserAccessState = {
   localUserId: string
-  orgId: string
-  integrationId: string
-  directoryAccountId: string
-  runId: string | null
-  triggeredBy: string
-  enabled: boolean
-  /** When false, planner runs but writer is no-op (preview mode). */
-  write: boolean
-  loadUserState: () => Promise<{
-    activationStatus: string | null
-    isActive: boolean
-    activeOrgIds: string[]
-    dingtalkGrantEnabled: boolean
-    accessGeneration: number
-  }>
-  globallyClear?: boolean
-}
-
-export type ApplyDeprovisionResult = {
-  applied: boolean
-  effectCount: number
-  accessGeneration: number | null
-  skipReason: string | null
-  eventId: string | null
+  activationStatus: string | null
+  isActive: boolean
+  accessGeneration: number
 }
 
 /**
- * Apply deprovision: zero-effect → no generation++ / no ledger rows.
- * Non-zero → generation++ AND event+effects in one transaction.
+ * §5.3 step 0 / §5.4 — the ONE mutex. `SELECT ... FOR UPDATE` on the `users` row, never an
+ * advisory lock (the lock explicitly forbids a second, parallel locking protocol). Callers that
+ * lock several people in one transaction MUST sort the ids first (§7.2 批量) or two runs touching
+ * the same pair in opposite order deadlock.
+ *
+ * Returns null when the user disappeared — the caller then has nothing to deprovision.
  */
-export async function applyDirectoryDeprovisionPlan(
-  input: ApplyDeprovisionInput,
-): Promise<ApplyDeprovisionResult> {
-  if (!input.enabled) {
-    return {
-      applied: false,
-      effectCount: 0,
-      accessGeneration: null,
-      skipReason: 'deprovision_disabled',
-      eventId: null,
-    }
+export async function lockUserForAccessGraphWrite(
+  client: LedgerClient,
+  localUserId: string,
+): Promise<UserAccessState | null> {
+  const result = await client.query(
+    `SELECT id::text AS id,
+            activation_status,
+            COALESCE(is_active, TRUE) AS is_active,
+            COALESCE(access_generation, 0)::bigint AS access_generation
+       FROM users
+      WHERE id = $1::text
+      FOR UPDATE`,
+    [localUserId],
+  )
+  const row = result.rows[0]
+  if (!row) return null
+  return {
+    localUserId: String(row.id),
+    activationStatus: row.activation_status === null || row.activation_status === undefined
+      ? null
+      : String(row.activation_status),
+    isActive: row.is_active === true,
+    accessGeneration: Number(row.access_generation ?? 0),
   }
-
-  const state = await input.loadUserState()
-  const plan = planDirectoryDeprovision({
-    localUserId: input.localUserId,
-    activationStatus: state.activationStatus,
-    isActive: state.isActive,
-    activeOrgIds: state.activeOrgIds,
-    dingtalkGrantEnabled: state.dingtalkGrantEnabled,
-    globallyClear: input.globallyClear !== false,
-  })
-
-  if (plan.effects.length === 0) {
-    return {
-      applied: false,
-      effectCount: 0,
-      accessGeneration: state.accessGeneration,
-      skipReason: plan.skipReason ?? 'zero_effect',
-      eventId: null,
-    }
-  }
-
-  if (!input.write) {
-    return {
-      applied: false,
-      effectCount: plan.effects.length,
-      accessGeneration: state.accessGeneration,
-      skipReason: 'preview_only',
-      eventId: null,
-    }
-  }
-
-  return writeDeprovisionLedger({
-    localUserId: input.localUserId,
-    orgId: input.orgId,
-    integrationId: input.integrationId,
-    directoryAccountId: input.directoryAccountId,
-    runId: input.runId,
-    triggeredBy: input.triggeredBy,
-    effects: plan.effects,
-    previousGeneration: state.accessGeneration,
-  })
 }
 
-async function writeDeprovisionLedger(options: {
+export type RecordDeprovisionEventInput = {
   localUserId: string
   orgId: string
   integrationId: string
   directoryAccountId: string
-  runId: string | null
+  /** NOT NULL for `event_origin='sync'` — the DB CHECK and trigger both enforce it. */
+  runId: string
   triggeredBy: string
+  policy: DeprovisionPolicy
+  globallyClear: boolean
+  /** The effects that were ACTUALLY applied, not merely planned. */
   effects: PlannedEffect[]
-  previousGeneration: number
-}): Promise<ApplyDeprovisionResult> {
-  let eventId: string | null = null
-  let nextGen = options.previousGeneration
+}
 
-  await transaction(async (client) => {
-    // Per-user mutex
-    await client.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [options.localUserId])
+export type RecordDeprovisionEventResult = {
+  eventId: string
+  accessGeneration: number
+  effectCount: number
+}
 
-    const gen = await client.query(
-      `UPDATE users
-          SET access_generation = COALESCE(access_generation, 0) + 1,
-              is_active = FALSE,
-              updated_at = NOW()
-        WHERE id = $1
-        RETURNING access_generation`,
-      [options.localUserId],
+/**
+ * §5.3 step 4: generation++ → `G'`, then the event, then its effects, all stamped `G'`.
+ *
+ * The caller is responsible for step 3 (zero effects ⇒ zero write): this function refuses an
+ * empty effect set rather than quietly writing an event with no effects, because a generation
+ * bump with nothing behind it would invalidate every outstanding restore for that person.
+ */
+export async function recordDeprovisionEvent(
+  client: LedgerClient,
+  input: RecordDeprovisionEventInput,
+): Promise<RecordDeprovisionEventResult> {
+  if (input.effects.length === 0) {
+    throw new Error(
+      `recordDeprovisionEvent called with zero effects for user ${input.localUserId}: `
+      + '§5.3 requires the caller to return without writing when the effect set is empty',
     )
-    nextGen = Number(gen.rows[0]?.access_generation ?? options.previousGeneration + 1)
+  }
 
-    // Supersede open effects for this user
+  const bumped = await client.query(
+    `UPDATE users
+        SET access_generation = COALESCE(access_generation, 0) + 1,
+            updated_at = NOW()
+      WHERE id = $1::text
+      RETURNING access_generation`,
+    [input.localUserId],
+  )
+  const generation = Number(bumped.rows[0]?.access_generation)
+  if (!Number.isFinite(generation)) {
+    throw new Error(`Failed to bump access_generation for user ${input.localUserId}`)
+  }
+
+  const event = await client.query(
+    `INSERT INTO directory_deprovision_events (
+       org_id, integration_id, directory_account_id, local_user_id,
+       link_witness_account_id, link_witness_local_user_id,
+       run_id, triggered_by, event_origin, policy, globally_clear,
+       access_generation_at_apply, status
+     ) VALUES ($1, $2::uuid, $3::uuid, $4,
+               $3::uuid, $4,
+               $5::uuid, $6, 'sync', $7, $8,
+               $9, 'applied')
+     RETURNING id::text AS id`,
+    [
+      input.orgId,
+      input.integrationId,
+      input.directoryAccountId,
+      input.localUserId,
+      input.runId,
+      input.triggeredBy,
+      input.policy,
+      input.globallyClear,
+      generation,
+    ],
+  )
+  const eventId = event.rows[0]?.id
+  if (typeof eventId !== 'string' || eventId.length === 0) {
+    throw new Error(`Deprovision event INSERT returned no id for user ${input.localUserId}`)
+  }
+
+  for (const effect of input.effects) {
     await client.query(
-      `UPDATE directory_deprovision_effects
-          SET status = 'superseded', updated_at = NOW()
-        WHERE local_user_id = $1 AND status = 'applied'`,
-      [options.localUserId],
-    ).catch(() => {
-      /* table may not exist in unit mocks */
-    })
-
-    const ev = await client.query(
-      `INSERT INTO directory_deprovision_events (
-         org_id, integration_id, directory_account_id, local_user_id,
-         run_id, triggered_by, event_origin, access_generation_at_apply, status
-       ) VALUES ($1,$2,$3,$4,$5,$6,'sync',$7,'open')
-       RETURNING id`,
+      `INSERT INTO directory_deprovision_effects (
+         event_id, local_user_id, org_id, effect_type,
+         before_active, after_active, access_generation_at_apply, status
+       ) VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, 'applied')`,
       [
-        options.orgId,
-        options.integrationId,
-        options.directoryAccountId,
-        options.localUserId,
-        options.runId,
-        options.triggeredBy,
-        nextGen,
+        eventId,
+        input.localUserId,
+        effect.orgId,
+        effect.type,
+        effect.beforeActive,
+        effect.afterActive,
+        generation,
       ],
-    ).catch(() => ({ rows: [] as Array<{ id: string }> }))
+    )
+  }
 
-    eventId = (ev.rows[0] as { id?: string } | undefined)?.id ?? null
+  return { eventId, accessGeneration: generation, effectCount: input.effects.length }
+}
 
-    for (const effect of options.effects) {
-      await client.query(
-        `INSERT INTO directory_deprovision_effects (
-           event_id, local_user_id, org_id, effect_type,
-           before_active, after_active, access_generation_at_apply, status
-         ) VALUES ($1,$2,$3,$4,$5,$6,$7,'applied')`,
-        [
-          eventId,
-          options.localUserId,
-          effect.orgId ?? options.orgId,
-          effect.type,
-          effect.beforeActive,
-          effect.afterActive,
-          nextGen,
-        ],
-      ).catch(() => {
-        /* unit/mock */
-      })
-    }
-  })
+/**
+ * §5.4 — "其他访问图写者 必须同时 generation++ AND supersede open effects（不可只做一腿）".
+ *
+ * Any writer that changes this person's access graph outside the deprovision path (admin
+ * activate/deactivate, grant toggle, bind/unbind, membership upsert) invalidates every open
+ * effect as a restore target: replaying a stale `before` would overwrite whatever the newer
+ * writer just decided. Doing only the supersede leg would leave `access_generation` equal and let
+ * a restore proceed; doing only the bump would leave `applied` rows that no longer describe
+ * anything. Hence one function, both legs, on the caller's transaction.
+ *
+ * Caller must already hold the mutex via `lockUserForAccessGraphWrite`.
+ */
+export async function supersedeOpenDeprovisionEffects(
+  client: LedgerClient,
+  localUserId: string,
+): Promise<{ supersededEffectCount: number; accessGeneration: number }> {
+  const superseded = await client.query(
+    `UPDATE directory_deprovision_effects
+        SET status = 'superseded', updated_at = NOW()
+      WHERE local_user_id = $1
+        AND status = 'applied'
+      RETURNING id`,
+    [localUserId],
+  )
+
+  await client.query(
+    `UPDATE directory_deprovision_events e
+        SET status = 'superseded', updated_at = NOW()
+      WHERE e.local_user_id = $1
+        AND e.status = 'applied'
+        AND NOT EXISTS (
+          SELECT 1 FROM directory_deprovision_effects fx
+           WHERE fx.event_id = e.id AND fx.status = 'applied'
+        )`,
+    [localUserId],
+  )
+
+  const bumped = await client.query(
+    `UPDATE users
+        SET access_generation = COALESCE(access_generation, 0) + 1,
+            updated_at = NOW()
+      WHERE id = $1::text
+      RETURNING access_generation`,
+    [localUserId],
+  )
 
   return {
-    applied: true,
-    effectCount: options.effects.length,
-    accessGeneration: nextGen,
-    skipReason: null,
-    eventId,
+    supersededEffectCount: superseded.rows.length,
+    accessGeneration: Number(bumped.rows[0]?.access_generation ?? 0),
   }
 }
 
-/** D5 helper — supersede open effects + bump generation (other writers). */
-export async function supersedeOpenDeprovisionEffects(userId: string): Promise<void> {
-  await transaction(async (client) => {
-    await client.query(`SELECT id FROM users WHERE id = $1 FOR UPDATE`, [userId])
-    await client.query(
-      `UPDATE users
-          SET access_generation = COALESCE(access_generation, 0) + 1,
-              updated_at = NOW()
-        WHERE id = $1`,
-      [userId],
-    )
-    await client.query(
-      `UPDATE directory_deprovision_effects
-          SET status = 'superseded', updated_at = NOW()
-        WHERE local_user_id = $1 AND status = 'applied'`,
-      [userId],
-    ).catch(() => {})
-  })
-}
-
-export async function countOpenDeprovisionEffects(userId: string): Promise<number> {
-  const r = await query<{ n: number }>(
-    `SELECT count(*)::int AS n FROM directory_deprovision_effects
+export async function countOpenDeprovisionEffects(
+  client: LedgerClient,
+  localUserId: string,
+): Promise<number> {
+  const result = await client.query(
+    `SELECT count(*)::int AS n
+       FROM directory_deprovision_effects
       WHERE local_user_id = $1 AND status = 'applied'`,
-    [userId],
-  ).catch(() => ({ rows: [{ n: 0 }] }))
-  return r.rows[0]?.n ?? 0
+    [localUserId],
+  )
+  return Number(result.rows[0]?.n ?? 0)
 }

--- a/packages/core-backend/src/directory/deprovision-planner.ts
+++ b/packages/core-backend/src/directory/deprovision-planner.ts
@@ -3,29 +3,46 @@
  *
  * Pure read model: compute intended effects without writing ledger or access graph.
  * Pending_activation users produce zero offboarding effects (no fake deprovision).
+ *
+ * D4 amendment: the plan must be the SAME decision the writer takes, or "Apply≈Plan" (§11) is
+ * unverifiable and the preview lies. Two gates the first cut did not model:
+ *   - `policy` — `manual_review` never writes anything, and only `mark_inactive` may touch
+ *     `users.is_active` (`disable_grant_only` stops at the grant).
+ *   - the org-scoped / globally-clear split (W4-PRE-1d): org membership is deactivated for every
+ *     org-membership candidate, but the grant and the platform user are gated on the person
+ *     having no active binding ANYWHERE.
+ * Effect names are the §5.2 enum (the DB CHECK constraint is the authority), and there is at most
+ * one effect per type per event — `UNIQUE (event_id, effect_type)`.
  */
 
 export type DeprovisionEffectType =
-  | 'clear_user_orgs'
-  | 'disable_dingtalk_grant'
-  | 'set_user_inactive'
+  | 'membership_changed'
+  | 'grant_changed'
+  | 'user_changed'
+
+export type DeprovisionPolicy = 'manual_review' | 'disable_grant_only' | 'mark_inactive'
 
 export type PlannedEffect = {
   type: DeprovisionEffectType
-  orgId?: string | null
+  /** §5.2 CHECK: NOT NULL for membership_changed, NULL for the other two. */
+  orgId: string | null
   beforeActive: boolean
   afterActive: boolean
 }
 
 export type DirectoryDeprovisionPlanInput = {
   localUserId: string
+  policy: DeprovisionPolicy
   activationStatus: string | null | undefined
-  isActive: boolean
-  /** Current active user_org memberships for this user. */
-  activeOrgIds: string[]
-  /** Whether DingTalk grant is currently enabled. */
+  /** Org whose membership this run would deactivate (the integration's org). */
+  membershipOrgId: string | null
+  /** Whether that membership is currently active — a no-op flip is not an effect. */
+  membershipActive: boolean
+  /** Whether the DingTalk grant is currently enabled (`user_external_auth_grants`). */
   dingtalkGrantEnabled: boolean
-  /** Policy: when true, plan will clear all orgs + grant + is_active. */
+  /** Whether the platform user is currently active. */
+  userActive: boolean
+  /** No active linked directory account ANYWHERE — gates grant + platform-user effects only. */
   globallyClear: boolean
 }
 
@@ -49,31 +66,45 @@ export function planDirectoryDeprovision(
     }
   }
 
+  // Owner 裁决② (#4522 rev3): manual_review keeps membership active and exposes a pending state
+  // — it is never a write, so it can never produce a ledger effect either.
+  if (input.policy === 'manual_review') {
+    return {
+      localUserId: input.localUserId,
+      skipReason: 'manual_review_no_write',
+      effects: [],
+    }
+  }
+
   const effects: PlannedEffect[] = []
 
-  if (input.globallyClear) {
-    for (const orgId of input.activeOrgIds) {
-      effects.push({
-        type: 'clear_user_orgs',
-        orgId,
-        beforeActive: true,
-        afterActive: false,
-      })
-    }
-    if (input.dingtalkGrantEnabled) {
-      effects.push({
-        type: 'disable_dingtalk_grant',
-        beforeActive: true,
-        afterActive: false,
-      })
-    }
-    if (input.isActive) {
-      effects.push({
-        type: 'set_user_inactive',
-        beforeActive: true,
-        afterActive: false,
-      })
-    }
+  // W4-PRE-1d item 1: org-scoped, NOT gated on globallyClear.
+  if (input.membershipOrgId && input.membershipActive) {
+    effects.push({
+      type: 'membership_changed',
+      orgId: input.membershipOrgId,
+      beforeActive: true,
+      afterActive: false,
+    })
+  }
+
+  // W4-PRE-1d item 2: grant + platform user require "no active binding anywhere".
+  if (input.globallyClear && input.dingtalkGrantEnabled) {
+    effects.push({
+      type: 'grant_changed',
+      orgId: null,
+      beforeActive: true,
+      afterActive: false,
+    })
+  }
+
+  if (input.globallyClear && input.policy === 'mark_inactive' && input.userActive) {
+    effects.push({
+      type: 'user_changed',
+      orgId: null,
+      beforeActive: true,
+      afterActive: false,
+    })
   }
 
   // Drop no-ops (before==after) — prospective truth.

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -7,6 +7,8 @@ import { validatePassword } from '../auth/password-policy'
 import { Logger } from '../core/logger'
 import { query, transaction } from '../db/pg'
 import { sweepStaleDepartmentBindings } from './department-binding-reconciliation'
+import { lockUserForAccessGraphWrite, recordDeprovisionEvent } from './deprovision-ledger'
+import { planDirectoryDeprovision, type PlannedEffect } from './deprovision-planner'
 import {
   fetchDingTalkAppAccessToken,
   getDingTalkDepartmentDetail,
@@ -1356,10 +1358,20 @@ export type DirectoryDeprovisionOutcome = {
    * ATTEMPT (preview mode included) — it does NOT mean the row actually flipped:
    * `deactivateUserOrgMembershipIfNoOtherActiveBinding` no-ops (without erroring) when the
    * org-scoped sibling check finds another active binding, or when no `user_orgs` row exists
-   * yet. Whether it actually flipped is not tracked (the shared
-   * helper's `UPDATE` has no `RETURNING`); this is attempt-visibility, not flip-visibility.
+   * yet. This is attempt-visibility, not flip-visibility — for what actually flipped, D4's
+   * effect ledger (`ledgerEffectCount` below, and the `directory_deprovision_effects` rows
+   * themselves) is the authoritative record.
    */
   membershipDeactivationAttemptedCount: number
+  /**
+   * D4 (deprovision design lock Rev 4.2 §5.3): how many deprovision EVENTS this run wrote, and
+   * how many effect rows they carry. Zero in preview mode by construction, and zero for a
+   * candidate whose effect set came out empty ("零 effect 零写") — an enabled run with
+   * candidates but no ledger rows means every candidate was already in the state the policy
+   * wanted, which is a materially different fact from "the writer did not run".
+   */
+  ledgerEventCount: number
+  ledgerEffectCount: number
   /** Set when the circuit breaker refused to act; `applied` is forced false. */
   abortedReason: DirectoryDeprovisionAbortReason | null
   affected: Array<{
@@ -1396,6 +1408,84 @@ type DeprovisionCandidateRow = {
   directory_account_id: string
   local_user_id: string
   deprovision_policy_override: string | null
+}
+
+/**
+ * D4 — would `deactivateUserOrgMembershipIfNoOtherActiveBinding` actually flip this membership?
+ *
+ * Deliberately re-states that helper's predicate rather than approximating it with "is there an
+ * active `user_orgs` row": the plan has to be the same decision as the write, and the write
+ * declines when another active binding in this org still vouches for the person. Called with the
+ * person's `users` row already locked, so its answer is the answer at write time.
+ */
+async function isUserOrgMembershipDeactivatable(
+  client: MembershipWriteClient,
+  options: { userId: string; orgId: string },
+): Promise<boolean> {
+  const result = await client.query(
+    `SELECT 1
+       FROM user_orgs
+      WHERE user_id = $1::text
+        AND org_id = $2::text
+        AND is_active = TRUE
+        AND NOT EXISTS (
+          SELECT 1
+          FROM directory_account_links l
+          JOIN directory_accounts a ON a.id = l.directory_account_id
+          JOIN directory_integrations i ON i.id = a.integration_id
+          WHERE l.local_user_id = $1::text
+            AND l.link_status = 'linked'
+            AND a.is_active = TRUE
+            AND i.org_id = $2::text
+        )`,
+    [options.userId, options.orgId],
+  )
+  return result.rows.length > 0
+}
+
+/**
+ * D4 — current DingTalk grant state from `user_external_auth_grants`, the table the OAuth login
+ * path itself reads. A missing row means "no grant", the same way `dingtalk-oauth.ts` reads it.
+ */
+async function isDingTalkGrantEnabled(
+  client: MembershipWriteClient,
+  localUserId: string,
+): Promise<boolean> {
+  const result = await client.query(
+    `SELECT enabled
+       FROM user_external_auth_grants
+      WHERE provider = $1 AND local_user_id = $2
+      LIMIT 1`,
+    [DEFAULT_PROVIDER, localUserId],
+  )
+  return result.rows[0]?.enabled === true
+}
+
+/**
+ * D4 — "Apply≈Plan" (§11) as a runtime invariant, not a hope.
+ *
+ * The ledger is the evidence a later restore reasons from; an event that claims an effect which
+ * never landed (or omits one that did) turns every downstream restore decision into a guess. So
+ * a divergence throws, the sync transaction rolls back, and nothing is witnessed — rather than
+ * committing a record known to be wrong. Under the mutex this can only fire when another writer
+ * mutated the access graph without taking the same lock, which is exactly the D5 gap this slice
+ * does not close.
+ */
+function assertAppliedMatchesPlan(
+  localUserId: string,
+  planned: PlannedEffect[],
+  applied: PlannedEffect[],
+): void {
+  const key = (effect: PlannedEffect): string => `${effect.type}:${effect.orgId ?? ''}`
+  const plannedKeys = planned.map(key).sort()
+  const appliedKeys = applied.map(key).sort()
+  if (plannedKeys.join('|') === appliedKeys.join('|')) return
+  throw new Error(
+    `Directory deprovision effect divergence for user ${localUserId}: planned [${plannedKeys.join(', ')}] `
+    + `but applied [${appliedKeys.join(', ')}]. Another writer changed this person's access graph `
+    + 'without taking the users-row mutex (design lock Rev 4.2 §7.3, D5). Refusing to write a '
+    + 'deprovision event that disagrees with what actually happened.',
+  )
 }
 
 /**
@@ -1470,6 +1560,15 @@ export async function applyDirectoryDeprovisionPolicies(
     integrationDefaultPolicy: string
     enabled: boolean
     maxBatch?: number
+    /**
+     * D4: the sync run this deprovision belongs to. `directory_deprovision_events` requires it
+     * for `event_origin='sync'` (CHECK + trigger, §5.2), so an event can always be traced back
+     * to the run that produced it. Required even in preview mode — preview writes no events, but
+     * a caller that cannot name its run has no business enabling the writer either.
+     */
+    runId: string
+    /** Audit provenance for the event row (`triggered_by`). */
+    triggeredBy: string
   },
 ): Promise<DirectoryDeprovisionOutcome> {
   const outcome: DirectoryDeprovisionOutcome = {
@@ -1480,6 +1579,8 @@ export async function applyDirectoryDeprovisionPolicies(
     grantsDisabledCount: 0,
     usersDeactivatedCount: 0,
     membershipDeactivationAttemptedCount: 0,
+    ledgerEventCount: 0,
+    ledgerEffectCount: 0,
     abortedReason: null,
     affected: [],
     manualReviewPending: [],
@@ -1586,31 +1687,42 @@ export async function applyDirectoryDeprovisionPolicies(
   // (e.g. a `users`-row `FOR UPDATE` re-check at write time, mirroring the org-membership
   // helper) that is outside the owner's verbatim 4-item P2 spec this PR implements — left for
   // the owner to scope as a follow-up, not silently dropped.
-  const nonManualReviewUserIds = Array.from(byUser.entries())
-    .filter(([, c]) => c.policy !== 'manual_review')
-    .map(([localUserId]) => localUserId)
-
-  const globallyClearUserIds = new Set<string>()
-  if (nonManualReviewUserIds.length > 0) {
+  //
+  // D4 UPDATE (deprovision design lock Rev 4.2 §7.4) — the gap described immediately above is no
+  // longer deferred. §7.4 is the ratified fix and it is implemented below: the guard is re-read
+  // PER PERSON, inside that person's `users` row lock ("在同一 users FOR UPDATE 事务内重读
+  // sibling/global（含最新 directory_accounts.is_active）后再写 grant/user"), so the value the
+  // grant/platform-user writes are gated on is the value at write time rather than a batch
+  // snapshot taken before any write in this run. The batch pre-read this replaces is gone
+  // entirely; both write-skew shapes it documented (concurrent last-org departures, same-window
+  // rehire) are closed for THIS writer. They remain reachable from writers that do not yet take
+  // the mutex — that is D5 (全写者挂 mutex), a canary precondition, not part of this slice.
+  //
+  // Preview (`options.enabled === false`) takes no lock: it writes nothing, so there is nothing
+  // to serialise. It re-reads through the same helper so its reported counters come from the
+  // same predicate the enabled path decides on.
+  const evaluateGloballyClear = async (candidateUserId: string): Promise<boolean> => {
     const globalClear = await client.query(
-      `SELECT candidate_user AS local_user_id
-         FROM UNNEST($1::text[]) AS candidate_user
-        WHERE NOT EXISTS (
-          SELECT 1
-            FROM directory_account_links sibling_link
-            JOIN directory_accounts sibling ON sibling.id = sibling_link.directory_account_id
-           WHERE sibling_link.local_user_id = candidate_user
-             AND sibling_link.link_status = 'linked'
-             AND sibling.is_active = true
-        )`,
-      [nonManualReviewUserIds],
+      `SELECT NOT EXISTS (
+                SELECT 1
+                  FROM directory_account_links sibling_link
+                  JOIN directory_accounts sibling ON sibling.id = sibling_link.directory_account_id
+                 WHERE sibling_link.local_user_id = $1::text
+                   AND sibling_link.link_status = 'linked'
+                   AND sibling.is_active = true
+              ) AS globally_clear`,
+      [candidateUserId],
     )
-    for (const row of globalClear.rows as Array<{ local_user_id: string }>) {
-      globallyClearUserIds.add(row.local_user_id)
-    }
+    return globalClear.rows[0]?.globally_clear === true
   }
 
-  for (const [localUserId, { directoryAccountId, policy }] of byUser) {
+  // §7.2 批量: lock in a deterministic id order, so two runs touching the same two people in
+  // opposite order cannot deadlock against each other.
+  const orderedCandidates = Array.from(byUser.entries()).sort(([left], [right]) => (
+    left < right ? -1 : left > right ? 1 : 0
+  ))
+
+  for (const [localUserId, { directoryAccountId, policy }] of orderedCandidates) {
     if (policy === 'manual_review') {
       outcome.manualReviewCount += 1
       // Owner 裁决② (#4522 rev3 review — issuecomment-5042388830: "manual_review 保持 active
@@ -1621,7 +1733,25 @@ export async function applyDirectoryDeprovisionPolicies(
       continue
     }
 
-    const globallyClear = globallyClearUserIds.has(localUserId)
+    // §5.3 step 0 — the mutex comes FIRST, before anything this person's decision is read from.
+    // Only the enabled path locks: preview writes nothing, and taking row locks during a
+    // read-only preview would serialise real work behind a dry run for no benefit.
+    const lockedState = options.enabled
+      ? await lockUserForAccessGraphWrite(client, localUserId)
+      : null
+    if (options.enabled && !lockedState) {
+      // The user row disappeared between candidate selection and the lock. Nothing to
+      // deprovision, and nothing to witness — skip rather than write an event about a person
+      // who no longer exists (the event FK to `users` would reject it anyway).
+      logger.warn(
+        `Directory deprovision skipped ${localUserId} for ${options.integrationId}: `
+        + 'user row vanished between candidate selection and lock acquisition',
+      )
+      continue
+    }
+
+    // §7.4 — read under the lock, decide under the lock.
+    const globallyClear = await evaluateGloballyClear(localUserId)
     outcome.affected.push({ directoryAccountId, localUserId, policy, globallyClear })
 
     // W4-PRE-1d: org-membership deactivation is attempted for EVERY org-membership candidate
@@ -1630,6 +1760,36 @@ export async function applyDirectoryDeprovisionPolicies(
     // Same gate as before (breaker passed + `options.enabled`), see this field's own doc-comment
     // on `DirectoryDeprovisionOutcome` for the attempt-not-flip distinction.
     outcome.membershipDeactivationAttemptedCount += 1
+
+    // §5.3 steps 1-2 — with the lock held, read every layer's CURRENT active boolean and compute
+    // the effect set this person's writes are about to produce. `planDirectoryDeprovision` is the
+    // same function the admin preview calls, given the same gates (policy, org-scoped membership,
+    // globally-clear), so "Apply≈Plan" (§11) is a property of one shared decision rather than two
+    // implementations that have to be kept in agreement by hand.
+    const plannedEffects: PlannedEffect[] = []
+    let grantWasEnabled = false
+    if (options.enabled && lockedState) {
+      const membershipActive = await isUserOrgMembershipDeactivatable(client, {
+        userId: localUserId,
+        orgId,
+      })
+      grantWasEnabled = await isDingTalkGrantEnabled(client, localUserId)
+      const plan = planDirectoryDeprovision({
+        localUserId,
+        policy,
+        activationStatus: lockedState.activationStatus,
+        membershipOrgId: orgId,
+        membershipActive,
+        dingtalkGrantEnabled: grantWasEnabled,
+        userActive: lockedState.isActive,
+        globallyClear,
+      })
+      plannedEffects.push(...plan.effects)
+    }
+
+    /** What the writes below ACTUALLY changed — compared against the plan before anything is witnessed. */
+    const appliedEffects: PlannedEffect[] = []
+
     if (options.enabled) {
       // W4-PRE-1c (owner 裁决②, #4522 rev3 review — the only GitHub-persisted record is the
       // owner's own acknowledgment comment, issuecomment-5042388830: "不因单次同步缺失撤销
@@ -1654,7 +1814,18 @@ export async function applyDirectoryDeprovisionPolicies(
       // this call path, not merely inherited defense-in-depth. `manual_review` is excluded by
       // the `continue` above: a single missed sync, or a policy that never executes, must never
       // itself revoke membership.
-      await deactivateUserOrgMembershipIfNoOtherActiveBinding(client, { userId: localUserId, orgId })
+      const membershipFlipped = await deactivateUserOrgMembershipIfNoOtherActiveBinding(
+        client,
+        { userId: localUserId, orgId },
+      )
+      if (membershipFlipped > 0) {
+        appliedEffects.push({
+          type: 'membership_changed',
+          orgId,
+          beforeActive: true,
+          afterActive: false,
+        })
+      }
     }
 
     // W4-PRE-1d item 2: grant-disable and (for mark_inactive) platform-user deactivation are
@@ -1662,18 +1833,18 @@ export async function applyDirectoryDeprovisionPolicies(
     // through a DIFFERENT org's directory keeps DingTalk login and their platform account, even
     // though THIS org's membership was just deactivated above.
     //
-    // Known gap (review finding, deferred — see this function's `globallyClearUserIds` batch
-    // read above for the forward-direction case; this is the reverse): `globallyClear` here is
-    // the STALE batch snapshot, not re-checked at this write. If a concurrent transaction
-    // commits a brand-new linked+active directory account for this SAME person (rehire, or a
-    // new org's onboarding) in the window between that snapshot and this write, these two writes
-    // still fire against the stale `true`, closing the grant and (mark_inactive) deactivating an
-    // otherwise-currently-employed user. Same inherited-not-widened window as the guard's own
-    // doc-comment above; same deferred lock/reconciliation design decision.
+    // D4 (§7.4): `globallyClear` is no longer the stale batch snapshot the deferred-gap note
+    // above described — it was re-read a few lines up, under this person's `users` row lock, so
+    // these two writes are gated on the value at write time.
     if (globallyClear) {
       outcome.globalCandidateCount += 1
       outcome.grantsDisabledCount += 1
       if (options.enabled) {
+        // The INSERT stays unconditional so the row shape after a deprovision is exactly what it
+        // has always been. Whether an ACCESS CHANGE happened is a different question, and it is
+        // answered by the pre-read taken under this person's lock: writing a fresh
+        // `enabled=FALSE` row for someone who never had a grant took nothing away from them, and
+        // must not appear in the ledger as if it had.
         await client.query(
           `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
            VALUES ($1, $2, FALSE, $3, NOW(), NOW())
@@ -1681,17 +1852,63 @@ export async function applyDirectoryDeprovisionPolicies(
            DO UPDATE SET enabled = FALSE, updated_at = NOW()`,
           [DEFAULT_PROVIDER, localUserId, 'system:directory-deprovision'],
         )
+        if (grantWasEnabled) {
+          appliedEffects.push({
+            type: 'grant_changed',
+            orgId: null,
+            beforeActive: true,
+            afterActive: false,
+          })
+        }
       }
 
       if (policy === 'mark_inactive') {
         outcome.usersDeactivatedCount += 1
         if (options.enabled) {
-          await client.query(
-            `UPDATE users SET is_active = FALSE, updated_at = NOW() WHERE id = $1::text`,
+          const userWrite = await client.query(
+            `UPDATE users SET is_active = FALSE, updated_at = NOW()
+              WHERE id = $1::text AND is_active = TRUE
+              RETURNING id`,
             [localUserId],
           )
+          if (userWrite.rows.length > 0) {
+            appliedEffects.push({
+              type: 'user_changed',
+              orgId: null,
+              beforeActive: true,
+              afterActive: false,
+            })
+          }
         }
       }
+    }
+
+    if (options.enabled) {
+      // §5.3 steps 3-4. Zero effects means zero evidence: no generation bump, no event, no effect
+      // rows — a bump with nothing behind it would invalidate every outstanding restore for this
+      // person for free.
+      if (appliedEffects.length === 0) continue
+
+      // "Apply≈Plan" is enforced, not assumed. Under the mutex the plan and the applied set can
+      // only diverge if some OTHER writer changed this person's access graph without taking the
+      // same lock — precisely the D5 gap. Committing a ledger that disagrees with what actually
+      // happened would poison every later restore decision, so a divergence aborts the run
+      // (rolling back this transaction) instead of writing evidence known to be wrong.
+      assertAppliedMatchesPlan(localUserId, plannedEffects, appliedEffects)
+
+      const recorded = await recordDeprovisionEvent(client, {
+        localUserId,
+        orgId,
+        integrationId: options.integrationId,
+        directoryAccountId,
+        runId: options.runId,
+        triggeredBy: options.triggeredBy,
+        policy,
+        globallyClear,
+        effects: appliedEffects,
+      })
+      outcome.ledgerEventCount += 1
+      outcome.ledgerEffectCount += recorded.effectCount
     }
   }
 
@@ -4152,6 +4369,10 @@ export async function syncDirectoryIntegration(
         syncedAccountCount: users.size,
         integrationDefaultPolicy: integration.default_deprovision_policy,
         enabled: isDirectoryDeprovisionEnabled(),
+        // D4: the event ledger is anchored to this run — `event_origin='sync'` requires a run of
+        // the SAME integration (CHECK + BEFORE INSERT trigger, §5.2).
+        runId,
+        triggeredBy,
       })
 
       // R5: per-run manager-binding snapshot. The live GET /manager-coverage endpoint
@@ -5319,12 +5540,17 @@ export async function upsertActiveUserOrgMembership(
 export async function deactivateUserOrgMembershipIfNoOtherActiveBinding(
   client: MembershipWriteClient,
   options: { userId: string; orgId: string },
-): Promise<void> {
+): Promise<number> {
   await client.query(
     `SELECT 1 FROM user_orgs WHERE user_id = $1::text AND org_id = $2::text FOR UPDATE`,
     [options.userId, options.orgId],
   )
-  await client.query(
+  // D4: `RETURNING` so the caller learns whether the row ACTUALLY flipped. The deprovision
+  // ledger records applied effects, and "the UPDATE ran" is not the same fact as "a membership
+  // was deactivated" — the predicate below deliberately declines to flip when another active
+  // binding still vouches for this person in this org. Existing callers ignore the return value;
+  // only the effect ledger needs it.
+  const flipped = await client.query(
     `UPDATE user_orgs
      SET is_active = FALSE
      WHERE user_id = $1::text
@@ -5339,9 +5565,11 @@ export async function deactivateUserOrgMembershipIfNoOtherActiveBinding(
            AND l.link_status = 'linked'
            AND a.is_active = TRUE
            AND i.org_id = $2::text
-       )`,
+       )
+     RETURNING user_id`,
     [options.userId, options.orgId],
   )
+  return flipped.rows.length
 }
 
 /**

--- a/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
+++ b/packages/core-backend/tests/unit/directory-deprovision-policy.test.ts
@@ -41,14 +41,39 @@ import {
 // predicate" discipline — unless a test opts a user OUT via `notGloballyClear`, which is how
 // the new item-2 dispatch tests below exercise the "org-membership candidate but NOT globally
 // clear" branch without a real database.
+//
+// D4 (deprovision design lock Rev 4.2, §5.3/§7.2/§7.4): the executor now takes a per-user
+// `users ... FOR UPDATE` mutex, re-reads globally-clear PER PERSON inside that lock (the batch
+// `UNNEST` pre-read is gone), reads each layer's current active boolean to build the effect set,
+// and — only when that set is non-empty — bumps `access_generation` and writes the event/effect
+// ledger rows. The stub therefore has to model a COHERENT world rather than answering each query
+// in isolation: `applyDirectoryDeprovisionPolicies` cross-checks the plan against what the writes
+// actually returned and throws on divergence, so a stub whose "would this membership flip?" probe
+// disagrees with what its `UPDATE ... RETURNING` hands back would fail every test for a reason
+// that has nothing to do with the code under test. One flag drives both halves of each pair.
 const STUB_ORG_ID = 'org-1'
 
 function stubClient(
   candidates: Array<{ directory_account_id: string; local_user_id: string; deprovision_policy_override: string | null }>,
-  options: { notGloballyClear?: string[] } = {},
+  options: {
+    notGloballyClear?: string[]
+    /** Drives BOTH the plan probe and the `UPDATE user_orgs ... RETURNING` result. */
+    membershipDeactivatable?: boolean
+    grantEnabled?: boolean
+    userActive?: boolean
+    activationStatus?: string | null
+    /** Escape hatch for the divergence test: make the write disagree with the plan. */
+    membershipWriteFlips?: boolean
+  } = {},
 ) {
   const notGloballyClear = new Set(options.notGloballyClear ?? [])
+  const membershipDeactivatable = options.membershipDeactivatable ?? true
+  const membershipWriteFlips = options.membershipWriteFlips ?? membershipDeactivatable
+  const grantEnabled = options.grantEnabled ?? true
+  const userActive = options.userActive ?? true
+  const activationStatus = options.activationStatus === undefined ? 'activated' : options.activationStatus
   const queries: string[] = []
+  let eventSeq = 0
   return {
     queries,
     query: async (sql: string, params?: unknown[]) => {
@@ -58,21 +83,52 @@ function stubClient(
         // evaluate the predicate — see the scope note.
         return { rows: candidates }
       }
-      if (/INSERT INTO user_external_auth_grants/i.test(sql) || /UPDATE users SET is_active = FALSE/i.test(sql)) {
+      if (/INSERT INTO user_external_auth_grants/i.test(sql)) {
         return { rows: [] }
+      }
+      if (/UPDATE users SET is_active = FALSE/i.test(sql)) {
+        return { rows: userActive ? [{ id: String(params?.[0] ?? '') }] : [] }
       }
       if (/SELECT org_id\s+FROM directory_integrations/i.test(sql)) {
         return { rows: [{ org_id: STUB_ORG_ID }] }
+      }
+      // §7.2 mutex + the state the plan is computed from.
+      if (/FROM users\s+WHERE id = \$1::text\s+FOR UPDATE/i.test(sql)) {
+        return {
+          rows: [{
+            id: String(params?.[0] ?? ''),
+            activation_status: activationStatus,
+            is_active: userActive,
+            access_generation: 0,
+          }],
+        }
+      }
+      // §7.4 per-person globally-clear re-read, taken under the lock.
+      if (/AS globally_clear/i.test(sql)) {
+        return { rows: [{ globally_clear: !notGloballyClear.has(String(params?.[0] ?? '')) }] }
+      }
+      // "Would the org-scoped membership write actually flip?" — the plan's probe.
+      if (/SELECT 1\s+FROM user_orgs/i.test(sql) && /NOT EXISTS/i.test(sql)) {
+        return { rows: membershipDeactivatable ? [{ '?column?': 1 }] : [] }
+      }
+      if (/SELECT enabled\s+FROM user_external_auth_grants/i.test(sql)) {
+        return { rows: grantEnabled ? [{ enabled: true }] : [] }
       }
       if (/FROM user_orgs WHERE user_id = \$1::text AND org_id = \$2::text\s+FOR UPDATE/i.test(sql)) {
         return { rows: [] }
       }
       if (/UPDATE user_orgs\s+SET is_active = FALSE/i.test(sql)) {
-        return { rows: [] }
+        return { rows: membershipWriteFlips ? [{ user_id: String(params?.[0] ?? '') }] : [] }
       }
-      if (/FROM UNNEST\(\$1::text\[\]\) AS candidate_user/i.test(sql)) {
-        const requested = (params?.[0] as string[] | undefined) ?? []
-        return { rows: requested.filter((id) => !notGloballyClear.has(id)).map((id) => ({ local_user_id: id })) }
+      if (/UPDATE users\s+SET access_generation/i.test(sql)) {
+        return { rows: [{ access_generation: 1 }] }
+      }
+      if (/INSERT INTO directory_deprovision_events/i.test(sql)) {
+        eventSeq += 1
+        return { rows: [{ id: `evt-${eventSeq}` }] }
+      }
+      if (/INSERT INTO directory_deprovision_effects/i.test(sql)) {
+        return { rows: [] }
       }
       // Anything else is drift: a new query appeared that no test has reasoned about.
       throw new Error(`Unhandled SQL in deprovision stub:\n${sql}`)


### PR DESCRIPTION
## ⛔ HELD — do not merge, do not duplicate

Open **only** so the lifecycle line has one visible claim on `directory-sync.ts`. Two agents are working this line; this file can have exactly one owner at a time.

## The finding this exists for

On merged `main`, running the deprovision writer with `enabled: true` — what the canary GO turns on — **fully offboards a person and writes zero evidence**. Measured on real Postgres, `main@8aad0ef8f`:

| | before | after |
|---|---|---|
| `users.is_active` | true | **false** |
| `user_orgs.is_active` | true | **false** |
| grant `enabled` | true | **false** |
| `users.access_generation` | 0 | **0** |
| ledger events / effects | 0/0 | **0/0** |

`deprovision-ledger.ts` has **no importer** on `main`. The only `INSERT INTO directory_deprovision_events` in the repo is inside that unimported file, so no code path can create an event — the D7 panel has nothing to show and restore has nothing to restore from, silently.

Note `#4574`'s PR body is accurate (it says "helpers"). The overstatement is in `dingtalk-lifecycle-line-closeout-20260724.md`, which lists D1–D6 as done.

## Owner decision this is blocked on

The landed ledger schema deviates from ratified §5.2 in ~10 places (no prerequisite UNIQUE keys, no composite FKs, no witness/policy/globally_clear columns, no CHECKs, no BEFORE INSERT link validation, `event_id` nullable, no `UNIQUE (event_id, effect_type)`).

- **(A) build to the lock** — corrective migration + locked `effect_type` enum, then wire. Ripples into D7 API/UI and ~27 real-DB call sites needing a run fixture.
- **(B) amend the lock** to match what shipped.

Recommendation: **(A)**. §5.1's argument is that application-level evidence is insufficient, and #4578 just demonstrated the cost of relying on it — a drift gate satisfied by its own query failing. DB constraints are immune to a swallowed error; application checks are not.

## What is written here (fork A)

- corrective migration to §5.2 (fails closed if the ledger is non-empty rather than discarding evidence)
- planner: locked effect-type enum + `policy` input + org-scoped/globally-clear split, so plan == the writer's decision
- ledger: runs on the caller's transaction (not its own), no swallowed errors, refuses an empty effect set
- writer: per-user `users … FOR UPDATE` in sorted id order (§7.2), globally-clear re-read **under the lock** (§7.4 — closes the write-skew gap the file's own comments recorded as deferred), plan → apply → record in the sync transaction, zero-effect ⇒ zero write
- restore: eligibility moved inside the locked transaction (it was a check-then-act on `access_generation`)

## Honest verification status

| | |
|---|---|
| migration up/down against real PG | **not run** |
| §11 real-DB matrix | **not written** |
| 27 existing call sites updated | **not done** |
| unit stub updated for new query shapes | done, **not run** |
| independent adversarial review | **owed** — also for merged #4574/#4575, which landed with only bot comments |

## Risk for the owner to accept explicitly

`assertAppliedMatchesPlan` throws on plan/applied divergence, which rolls back **the whole sync run**, not just the deprovision step. Under the mutex it can only fire when another writer mutated the access graph without taking the same lock — the D5 gap. The alternative is committing evidence known to disagree with reality. This is why **D5 must precede any deprovision canary**.

Findings + reproduction method: `docs/development/dingtalk-lifecycle-postmerge-findings-20260724.md` (in this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)