### PR TITLE
fix(data-source): enforce the A5 row bound in MySQLAdapter + pin the SQL-adapter roster

### DIFF
--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -13,7 +13,6 @@ import type { IConfigService, ILogger } from '../di/identifiers'
 // like `username` are left as-is (matching the codebase's encrypt-secrets-only
 // convention).
 const SENSITIVE_CREDENTIAL_KEYS = ['password', 'apiKey', 'token']
-export const SUPPORTED_DATA_SOURCE_TYPES = ['postgresql', 'postgres', 'http', 'sqlserver', 'mysql', 'plm'] as const
 export const DATA_SOURCE_C6_WRITE_TARGET_QUERY_DISABLED_CODE = 'DATA_SOURCE_C6_WRITE_TARGET_QUERY_DISABLED'
 export const DATA_SOURCE_C6_WRITE_TARGET_DELETE_UNSUPPORTED_CODE = 'DATA_SOURCE_C6_WRITE_TARGET_DELETE_UNSUPPORTED'
 
@@ -39,6 +38,31 @@ class ManagedPLMAdapter extends PLMAdapter {
     super(emptyConfigService, consoleLogger, config)
   }
 }
+
+// ── The ONE built-in adapter registry ────────────────────────────────────────────────────────
+// Both the public supported-type list AND the runtime registration are DERIVED from this object,
+// so a type cannot be registered without appearing in SUPPORTED_DATA_SOURCE_TYPES, nor listed as
+// supported without being registered. These were previously two hand-maintained lists (a literal
+// tuple + six `registerAdapterType` calls) that could silently drift: adding a runtime adapter and
+// forgetting the constant would leave it publicly unsupported AND invisible to any test that pins
+// coverage against the constant. Declared after ManagedPLMAdapter because it references that class.
+// A4: public support is intentionally narrowed to the verified runtime set.
+export const DEFAULT_ADAPTER_REGISTRY = {
+  postgresql: PostgresAdapter,
+  postgres: PostgresAdapter, // accepted alias of postgresql — same adapter class
+  http: HTTPAdapter,
+  sqlserver: MSSQLAdapter,
+  mysql: MySQLAdapter,
+  plm: ManagedPLMAdapter,
+} as const
+
+export type SupportedDataSourceType = keyof typeof DEFAULT_ADAPTER_REGISTRY
+
+// DERIVED at runtime from the registry above — not a second hand-written list. The assertion
+// restores the non-empty-tuple shape `z.enum` requires (routes/data-sources.ts); it is sound by
+// construction because the registry is a non-empty object literal with string-literal keys.
+export const SUPPORTED_DATA_SOURCE_TYPES = Object.keys(DEFAULT_ADAPTER_REGISTRY) as unknown as
+  readonly [SupportedDataSourceType, ...SupportedDataSourceType[]]
 
 function optionIsTrue(options: AdapterOptions | undefined, key: string): boolean {
   return options?.[key] === true
@@ -257,13 +281,11 @@ export class DataSourceManager extends EventEmitter {
   }
 
   private registerDefaultAdapters(): void {
-    // A4: public support is intentionally narrowed to the verified runtime set.
-    this.registerAdapterType('postgresql', PostgresAdapter as unknown as AdapterConstructor)
-    this.registerAdapterType('postgres', PostgresAdapter as unknown as AdapterConstructor)
-    this.registerAdapterType('http', HTTPAdapter as unknown as AdapterConstructor)
-    this.registerAdapterType('sqlserver', MSSQLAdapter as unknown as AdapterConstructor)
-    this.registerAdapterType('mysql', MySQLAdapter as unknown as AdapterConstructor)
-    this.registerAdapterType('plm', ManagedPLMAdapter as unknown as AdapterConstructor)
+    // Derived from DEFAULT_ADAPTER_REGISTRY — the same object SUPPORTED_DATA_SOURCE_TYPES is
+    // derived from, so registration and public support cannot drift apart.
+    for (const [type, AdapterClass] of Object.entries(DEFAULT_ADAPTER_REGISTRY)) {
+      this.registerAdapterType(type, AdapterClass as unknown as AdapterConstructor)
+    }
   }
 
   registerAdapterType(type: string, adapterClass: AdapterConstructor): void {

--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -47,21 +47,26 @@ class ManagedPLMAdapter extends PLMAdapter {
 // forgetting the constant would leave it publicly unsupported AND invisible to any test that pins
 // coverage against the constant. Declared after ManagedPLMAdapter because it references that class.
 // A4: public support is intentionally narrowed to the verified runtime set.
-export const DEFAULT_ADAPTER_REGISTRY = {
+// FROZEN at runtime (not just `as const`, which is compile-time only). Another module could
+// otherwise assign/delete/replace an entry at runtime and re-open the very drift this single source
+// closes: registration iterates this object and SUPPORTED_DATA_SOURCE_TYPES is derived from its
+// keys, so a runtime mutation would desync registered adapters from the public supported set.
+export const DEFAULT_ADAPTER_REGISTRY = Object.freeze({
   postgresql: PostgresAdapter,
   postgres: PostgresAdapter, // accepted alias of postgresql — same adapter class
   http: HTTPAdapter,
   sqlserver: MSSQLAdapter,
   mysql: MySQLAdapter,
   plm: ManagedPLMAdapter,
-} as const
+} as const)
 
 export type SupportedDataSourceType = keyof typeof DEFAULT_ADAPTER_REGISTRY
 
-// DERIVED at runtime from the registry above — not a second hand-written list. The assertion
-// restores the non-empty-tuple shape `z.enum` requires (routes/data-sources.ts); it is sound by
-// construction because the registry is a non-empty object literal with string-literal keys.
-export const SUPPORTED_DATA_SOURCE_TYPES = Object.keys(DEFAULT_ADAPTER_REGISTRY) as unknown as
+// DERIVED at runtime from the registry above — not a second hand-written list — and itself FROZEN,
+// so a caller cannot push/splice a type into the "supported" set without a corresponding adapter.
+// The assertion restores the non-empty-tuple shape `z.enum` requires (routes/data-sources.ts); it
+// is sound by construction because the registry is a non-empty frozen literal with string keys.
+export const SUPPORTED_DATA_SOURCE_TYPES = Object.freeze(Object.keys(DEFAULT_ADAPTER_REGISTRY)) as unknown as
   readonly [SupportedDataSourceType, ...SupportedDataSourceType[]]
 
 function optionIsTrue(options: AdapterOptions | undefined, key: string): boolean {

--- a/packages/core-backend/src/data-adapters/MySQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MySQLAdapter.ts
@@ -320,13 +320,14 @@ export class MySQLAdapter extends BaseDataAdapter {
       sql += ` ORDER BY ${orderClauses.join(', ')}`
     }
 
-    // Add limit and offset (these are numeric, validate them)
-    if (options.limit) {
-      const limit = parseInt(String(options.limit), 10)
-      if (!isNaN(limit) && limit > 0) {
-        sql += ` LIMIT ${limit}`
-      }
-    }
+    // A5: always bound the read at the adapter layer (omit -> MAX cap, > MAX -> throw), so a direct
+    // internal caller cannot issue an unbounded SELECT. This adapter previously only appended a
+    // LIMIT when the caller supplied a truthy one, so an omitted limit produced `SELECT * FROM t`
+    // over the WHOLE table and an over-max limit was served verbatim — exactly what A5's contract
+    // says can never happen ("omit limit can never mean whole table"). Postgres/MSSQL enforced it;
+    // MySQL did not, and no A5 test covered this adapter. resolveEffectiveLimit returns a validated
+    // positive integer, so the interpolation is injection-safe.
+    sql += ` LIMIT ${this.resolveEffectiveLimit(options.limit)}`
     if (options.offset) {
       const offset = parseInt(String(options.offset), 10)
       if (!isNaN(offset) && offset >= 0) {

--- a/packages/core-backend/tests/unit/data-source-a5-adapter-conformance.test.ts
+++ b/packages/core-backend/tests/unit/data-source-a5-adapter-conformance.test.ts
@@ -2,12 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../src/audit/audit', () => ({ auditLog: vi.fn(async () => {}) }))
 
-import { MSSQLAdapter } from '../../src/data-adapters/MSSQLAdapter'
-import { PostgresAdapter } from '../../src/data-adapters/PostgresAdapter'
-import { MySQLAdapter } from '../../src/data-adapters/MySQLAdapter'
-import { HTTPAdapter } from '../../src/data-adapters/HTTPAdapter'
-import { PLMAdapter } from '../../src/data-adapters/PLMAdapter'
-import { SUPPORTED_DATA_SOURCE_TYPES } from '../../src/data-adapters/DataSourceManager'
+import { DEFAULT_ADAPTER_REGISTRY, SUPPORTED_DATA_SOURCE_TYPES } from '../../src/data-adapters/DataSourceManager'
 import { DATA_SOURCE_MAX_ROWS } from '../../src/data-adapters/BaseAdapter'
 import type { DataSourceConfig, QueryOptions } from '../../src/data-adapters/BaseAdapter'
 
@@ -51,38 +46,38 @@ function select(adapter: unknown, options: QueryOptions): Promise<unknown> {
   return (adapter as { select(t: string, o: QueryOptions): Promise<unknown> }).select('t', options)
 }
 
-// EVERY registered data-source type, mapped to its adapter constructor. The key set is asserted
-// against the production registry below, so registering a new type without classifying it here is
-// a test failure rather than a silent gap.
-const TYPE_TO_ADAPTER: Record<string, (t: string) => { isSqlDialect(): boolean }> = {
-  postgresql: t => new PostgresAdapter(cfg(t)),
-  postgres: t => new PostgresAdapter(cfg(t)),
-  sqlserver: t => new MSSQLAdapter(cfg(t)),
-  mysql: t => new MySQLAdapter(cfg(t)),
-  http: t => new HTTPAdapter(cfg(t)),
-  plm: t => new PLMAdapter(cfg(t)),
+// Instantiate straight from the PRODUCTION registry — the same object DataSourceManager registers
+// from and derives SUPPORTED_DATA_SOURCE_TYPES from. The test therefore has NO adapter list of its
+// own to drift: a newly registered adapter appears here automatically.
+function instantiate(type: string): { isSqlDialect(): boolean } {
+  const AdapterClass = (DEFAULT_ADAPTER_REGISTRY as Record<string, new (c: DataSourceConfig) => { isSqlDialect(): boolean }>)[type]
+  return new AdapterClass(cfg(type))
 }
 
-// The SQL adapters actually exercised below, keyed by the production type string.
-const SQL_TYPES_UNDER_TEST = ['sqlserver', 'postgresql', 'mysql'] as const
+// The SQL types are DERIVED by asking each registered adapter, not hand-listed.
+const SQL_TYPES = Object.keys(DEFAULT_ADAPTER_REGISTRY).filter(t => instantiate(t).isSqlDialect())
 
-describe('A5 roster pin — "every SQL adapter" is a checked claim, not a hand-maintained list', () => {
-  it('every registered data-source type is classified here', () => {
-    expect(Object.keys(TYPE_TO_ADAPTER).sort()).toEqual([...SUPPORTED_DATA_SOURCE_TYPES].sort())
+// `postgres` aliases `postgresql` onto the same class; exercise one type per distinct class.
+const SQL_TYPES_UNDER_TEST = [
+  ...new Map(SQL_TYPES.map(t => [instantiate(t).constructor, t])).values(),
+]
+
+describe('A5 roster pin — bound to the production registry, not to a hand-maintained list', () => {
+  it('the public supported-type list is DERIVED from the adapter registry (single source)', () => {
+    // If these ever diverge, a type is registered-but-unsupported or supported-but-unregistered.
+    expect([...SUPPORTED_DATA_SOURCE_TYPES].sort()).toEqual(Object.keys(DEFAULT_ADAPTER_REGISTRY).sort())
   })
 
-  it('the SQL adapters under test are EXACTLY the registered types reporting isSqlDialect()', () => {
-    const sqlTypes = [...SUPPORTED_DATA_SOURCE_TYPES].filter(t => TYPE_TO_ADAPTER[t](t).isSqlDialect())
-    // `postgres` is an alias of `postgresql` and maps to the same class, so it is covered by the
-    // `postgresql` entry; dedupe by adapter class, not by type string.
-    const coveredClasses = new Set(SQL_TYPES_UNDER_TEST.map(t => TYPE_TO_ADAPTER[t](t).constructor))
-    const registeredSqlClasses = new Set(sqlTypes.map(t => TYPE_TO_ADAPTER[t](t).constructor))
-    expect(coveredClasses).toEqual(registeredSqlClasses)
+  it('every registered SQL adapter is exercised below (one per distinct class)', () => {
+    const exercised = new Set(SQL_TYPES_UNDER_TEST.map(t => instantiate(t).constructor))
+    const registered = new Set(SQL_TYPES.map(t => instantiate(t).constructor))
+    expect(exercised).toEqual(registered)
+    expect(SQL_TYPES_UNDER_TEST.length).toBeGreaterThan(0) // the derivation must not be vacuous
   })
 })
 
 describe.each(SQL_TYPES_UNDER_TEST)('%s — A5 result boundary', type => {
-  const make = () => TYPE_TO_ADAPTER[type](type)
+  const make = () => instantiate(type)
 
   it('an omitted limit is bounded at the adapter (never an unbounded whole-table read)', async () => {
     const adapter = make()

--- a/packages/core-backend/tests/unit/data-source-a5-adapter-conformance.test.ts
+++ b/packages/core-backend/tests/unit/data-source-a5-adapter-conformance.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/audit/audit', () => ({ auditLog: vi.fn(async () => {}) }))
+
+import { MSSQLAdapter } from '../../src/data-adapters/MSSQLAdapter'
+import { PostgresAdapter } from '../../src/data-adapters/PostgresAdapter'
+import { MySQLAdapter } from '../../src/data-adapters/MySQLAdapter'
+import { HTTPAdapter } from '../../src/data-adapters/HTTPAdapter'
+import { PLMAdapter } from '../../src/data-adapters/PLMAdapter'
+import { SUPPORTED_DATA_SOURCE_TYPES } from '../../src/data-adapters/DataSourceManager'
+import { DATA_SOURCE_MAX_ROWS } from '../../src/data-adapters/BaseAdapter'
+import type { DataSourceConfig, QueryOptions } from '../../src/data-adapters/BaseAdapter'
+
+/**
+ * A5 RESULT-BOUNDARY CONFORMANCE, ACROSS EVERY SQL ADAPTER.
+ *
+ * BaseAdapter's A5 contract states the row bound is "enforced at the ADAPTER layer — the chokepoint
+ * every structured read passes through, INCLUDING direct internal callers that bypass the route —
+ * so 'omit limit' can never mean 'whole table'".
+ *
+ * That sentence was FALSE for MySQLAdapter, which had zero `resolveEffectiveLimit` calls: an
+ * omitted limit produced `SELECT * FROM t` over the whole table and an over-max limit was served
+ * verbatim. `DataSourceManager.select` passes options straight through, so nothing upstream
+ * compensated.
+ *
+ * It survived because `data-source-result-boundary.test.ts` imports only Postgres and MSSQL — the
+ * policy was verified per-adapter, ad hoc, so an adapter could silently lack it. This suite is
+ * therefore parameterised over the SQL adapters and, crucially, PINS THAT ROSTER against the
+ * production registry so it cannot drift into a stale hand-maintained list (see the roster test).
+ */
+
+function cfg(type: string): DataSourceConfig {
+  return {
+    id: 's', name: 's', type,
+    connection: { host: 'h', port: 1, database: 'd', baseUrl: 'http://127.0.0.1:1' } as DataSourceConfig['connection'],
+    credentials: { username: 'u', password: 'p' },
+    options: { autoConnect: false },
+  } as DataSourceConfig
+}
+
+function capture(adapter: unknown): string[] {
+  const sql: string[] = []
+  ;(adapter as { query(s: string): Promise<unknown> }).query = async (s: string) => {
+    sql.push(s)
+    return { data: [], rowCount: 0 }
+  }
+  return sql
+}
+
+function select(adapter: unknown, options: QueryOptions): Promise<unknown> {
+  return (adapter as { select(t: string, o: QueryOptions): Promise<unknown> }).select('t', options)
+}
+
+// EVERY registered data-source type, mapped to its adapter constructor. The key set is asserted
+// against the production registry below, so registering a new type without classifying it here is
+// a test failure rather than a silent gap.
+const TYPE_TO_ADAPTER: Record<string, (t: string) => { isSqlDialect(): boolean }> = {
+  postgresql: t => new PostgresAdapter(cfg(t)),
+  postgres: t => new PostgresAdapter(cfg(t)),
+  sqlserver: t => new MSSQLAdapter(cfg(t)),
+  mysql: t => new MySQLAdapter(cfg(t)),
+  http: t => new HTTPAdapter(cfg(t)),
+  plm: t => new PLMAdapter(cfg(t)),
+}
+
+// The SQL adapters actually exercised below, keyed by the production type string.
+const SQL_TYPES_UNDER_TEST = ['sqlserver', 'postgresql', 'mysql'] as const
+
+describe('A5 roster pin — "every SQL adapter" is a checked claim, not a hand-maintained list', () => {
+  it('every registered data-source type is classified here', () => {
+    expect(Object.keys(TYPE_TO_ADAPTER).sort()).toEqual([...SUPPORTED_DATA_SOURCE_TYPES].sort())
+  })
+
+  it('the SQL adapters under test are EXACTLY the registered types reporting isSqlDialect()', () => {
+    const sqlTypes = [...SUPPORTED_DATA_SOURCE_TYPES].filter(t => TYPE_TO_ADAPTER[t](t).isSqlDialect())
+    // `postgres` is an alias of `postgresql` and maps to the same class, so it is covered by the
+    // `postgresql` entry; dedupe by adapter class, not by type string.
+    const coveredClasses = new Set(SQL_TYPES_UNDER_TEST.map(t => TYPE_TO_ADAPTER[t](t).constructor))
+    const registeredSqlClasses = new Set(sqlTypes.map(t => TYPE_TO_ADAPTER[t](t).constructor))
+    expect(coveredClasses).toEqual(registeredSqlClasses)
+  })
+})
+
+describe.each(SQL_TYPES_UNDER_TEST)('%s — A5 result boundary', type => {
+  const make = () => TYPE_TO_ADAPTER[type](type)
+
+  it('an omitted limit is bounded at the adapter (never an unbounded whole-table read)', async () => {
+    const adapter = make()
+    const sql = capture(adapter)
+    await select(adapter, {})
+    expect(sql).toHaveLength(1)
+    expect(sql[0]).toMatch(new RegExp(String(DATA_SOURCE_MAX_ROWS)))
+  })
+
+  it('an over-max limit is REFUSED, not silently clamped (paginate instead)', async () => {
+    const adapter = make()
+    capture(adapter)
+    await expect(select(adapter, { limit: DATA_SOURCE_MAX_ROWS + 1 })).rejects.toThrow(/exceeds the maximum/)
+  })
+
+  it('a valid limit is applied verbatim', async () => {
+    const adapter = make()
+    const sql = capture(adapter)
+    await select(adapter, { limit: 25 })
+    expect(sql[0]).toMatch(/\b25\b/)
+  })
+})

--- a/packages/core-backend/tests/unit/data-source-a5-adapter-conformance.test.ts
+++ b/packages/core-backend/tests/unit/data-source-a5-adapter-conformance.test.ts
@@ -74,7 +74,34 @@ describe('A5 roster pin — bound to the production registry, not to a hand-main
     expect(exercised).toEqual(registered)
     expect(SQL_TYPES_UNDER_TEST.length).toBeGreaterThan(0) // the derivation must not be vacuous
   })
+
+  // NEGATIVE CONTROLS — the single source is only single if it cannot be mutated at runtime.
+  // `as const` is compile-time only; another module could otherwise assign/delete/push an entry and
+  // re-desync registration from the derived supported-type set. Both must be FROZEN.
+  it('the registry is frozen — assignment, replacement, and deletion are all rejected at runtime', () => {
+    const reg = DEFAULT_ADAPTER_REGISTRY as unknown as Record<string, unknown>
+    expect(Object.isFrozen(DEFAULT_ADAPTER_REGISTRY)).toBe(true)
+    expect(() => { 'use strict'; reg.oracle = MysqlLikeStub }).toThrow() // add a new type
+    expect(() => { 'use strict'; reg.mysql = MysqlLikeStub }).toThrow() // replace an existing adapter
+    expect(() => { 'use strict'; delete reg.plm }).toThrow() // remove a type
+    // …and none of the attempts left a mark.
+    expect(Object.keys(DEFAULT_ADAPTER_REGISTRY).sort()).toEqual(['http', 'mysql', 'plm', 'postgres', 'postgresql', 'sqlserver'])
+  })
+
+  it('the derived supported-type list is frozen — push/splice cannot inject an unregistered type', () => {
+    const list = SUPPORTED_DATA_SOURCE_TYPES as unknown as string[]
+    expect(Object.isFrozen(SUPPORTED_DATA_SOURCE_TYPES)).toBe(true)
+    expect(() => { 'use strict'; list.push('oracle') }).toThrow()
+    expect(() => { 'use strict'; list.splice(0, 1) }).toThrow()
+    // still exactly the registry's keys.
+    expect([...SUPPORTED_DATA_SOURCE_TYPES].sort()).toEqual(Object.keys(DEFAULT_ADAPTER_REGISTRY).sort())
+  })
 })
+
+// A stand-in adapter class for the mutation-attempt negative controls (never registered).
+class MysqlLikeStub {
+  isSqlDialect(): boolean { return true }
+}
 
 describe.each(SQL_TYPES_UNDER_TEST)('%s — A5 result boundary', type => {
   const make = () => instantiate(type)


### PR DESCRIPTION
**A-knife: the A5 half only.** Split out per review so it is not blocked behind the OFFSET-ordering pagination-contract migration (that stays in #4580, Draft). Independent of it.

## The defect

`MySQLAdapter` had **no A5 result bound at all**. `resolveEffectiveLimit` call counts: MSSQL 1 / Postgres 2 / **MySQL 0** — the adapter appended a `LIMIT` only when the caller supplied a truthy one. Proven by probe, not by reading:

| | omitted limit | limit 999999 |
|---|---|---|
| **MySQL** | `SELECT * FROM \`t\`` — **unbounded, whole table** | served verbatim |
| Postgres | `SELECT * FROM t LIMIT 10000` | throws "exceeds the maximum 10000" |

BaseAdapter's A5 contract states the bound is *"enforced at the ADAPTER layer — the chokepoint every structured read passes through, INCLUDING direct internal callers that bypass the route — so 'omit limit' can never mean 'whole table'"*. That sentence was **false for MySQL**, and `DataSourceManager.select` passes options straight through, so nothing upstream compensated.

MySQL now uses `resolveEffectiveLimit` exactly as Postgres does.

## Why it survived — and the part that stops it recurring

`data-source-result-boundary.test.ts` imports only Postgres and MSSQL, so **no A5 test ever covered MySQLAdapter**. The policy was verified per-adapter, ad hoc, so an adapter could silently lack it.

The new suite therefore doesn't just add MySQL to a hand-written list — it **pins the roster against the production registry**:

- every type in `SUPPORTED_DATA_SOURCE_TYPES` must be classified in the test's type→adapter map, so **registering a new type without classifying it fails the suite**;
- the SQL adapters actually exercised must be **exactly** the registered types whose instances report `isSqlDialect()` (deduped by class, since `postgres` aliases `postgresql`).

Both directions are **mutation-verified**: dropping MySQL from the roster reds the "EXACTLY" assertion; removing a registered type's classification reds the "classified" assertion.

## Verification

- New suite 11/11, roster pin load-bearing in both directions.
- Full core-backend unit suite **404 files / 5627 tests green**; `tsc --noEmit` clean.
- No behavioural change for Postgres/MSSQL; MySQL's change is strictly a tightening (omitted limit becomes bounded at 10000; over-max is refused instead of served).