### PR TITLE
fix(attendance): fail closed on legacy multi-segment shifts

### DIFF
--- a/docs/development/attendance-issue-4556-w2-w3-development-verification-20260724.md
+++ b/docs/development/attendance-issue-4556-w2-w3-development-verification-20260724.md
@@ -113,9 +113,12 @@ unavailable:
 - assignments, rotation assignments, swaps, dispatch targets, schedule
   publish, and automatic matching cannot create a live reference to a
   multi-segment shift;
-- converting a referenced one-segment shift to multiple segments is rejected;
+- converting a durably referenced one-segment shift to multiple segments is
+  rejected, including when the only assignment reference is inactive or ended
+  history;
 - typed rejection occurs before any durable write;
-- the legacy envelope cannot be used as authoritative payable time.
+- a second runtime guard rejects any resolved multi-segment shift before the
+  legacy envelope can be used as authoritative payable time.
 
 No environment flag was enabled by W3.
 

--- a/packages/core-backend/tests/integration/attendance-shift-segments-writer-matrix.db.test.ts
+++ b/packages/core-backend/tests/integration/attendance-shift-segments-writer-matrix.db.test.ts
@@ -373,6 +373,116 @@ describeDb('W3 shift-segments writer matrix (real DB, route-level)', () => {
     expect(await segmentCount(shiftId)).toBe(1)
   })
 
+  it('blocks converting one segment to multiple when only ended assignment history references the shift', async () => {
+    const orgId = org('put-ended-conversion')
+    const token = await mintToken(`${orgId}-admin`)
+    const created = await createShiftViaApi(token, orgId, { name: 'Historic Day', workStartTime: '09:00', workEndTime: '18:00' })
+    const shiftId = created.body.data.id as string
+    await seedPublishedAssignment(orgId, `${orgId}-worker`, shiftId, '2020-01-06')
+
+    const res = await putJson(`/api/attendance/shifts/${shiftId}`, token, orgId, {
+      segments: [
+        { startTime: '08:00', endTime: '12:00' },
+        { startTime: '13:00', endTime: '17:00' },
+      ],
+    })
+    expect(res.status, res.raw).toBe(409)
+    expect(codeOf(res)).toBe(CONVERSION_BLOCKED_CODE)
+    expect((res.body?.error?.details ?? []).map((detail: any) => detail.field)).toContain('shift_assignments')
+    expect(await segmentCount(shiftId)).toBe(1)
+  })
+
+  it('fails closed before a historical import can calculate a forced multi-segment shift with the legacy envelope', async () => {
+    const orgId = org('runtime-ended-guard')
+    const userId = `${orgId}-worker`
+    const workDate = '2020-01-06'
+    const token = await mintToken(`${orgId}-admin`)
+    const created = await createShiftViaApi(token, orgId, {
+      name: 'Historic Split',
+      timezone: 'UTC',
+      workStartTime: '08:00',
+      workEndTime: '17:00',
+    })
+    const shiftId = created.body.data.id as string
+    await seedPublishedAssignment(orgId, userId, shiftId, workDate)
+
+    // Simulate a legacy/direct-DB invalid state that bypassed the authoring guard.
+    // The compatibility envelope spans 540 minutes; the two segments sum to 480.
+    await pool.query(
+      `UPDATE attendance_shift_segments
+          SET end_time = '12:00'
+        WHERE org_id = $1 AND shift_id = $2 AND segment_index = 0`,
+      [orgId, shiftId],
+    )
+    await injectSecondSegment(orgId, shiftId)
+    expect(await segmentCount(shiftId)).toBe(2)
+
+    const imported = await postJson('/api/attendance/import', token, orgId, {
+      userId,
+      mode: 'override',
+      rows: [{
+        workDate,
+        fields: {
+          firstInAt: `${workDate}T08:00:00Z`,
+          lastOutAt: `${workDate}T17:00:00Z`,
+        },
+      }],
+    })
+    expect(imported.status, imported.raw).toBe(422)
+    expect(codeOf(imported)).toBe(GUARD_CODE)
+
+    const records = await pool.query(
+      'SELECT work_minutes FROM attendance_records WHERE org_id = $1 AND user_id = $2 AND work_date = $3',
+      [orgId, userId, workDate],
+    )
+    expect(records.rows).toHaveLength(0)
+  })
+
+  it('fails closed before a punch can calculate a forced multi-segment shift with the legacy envelope', async () => {
+    const orgId = org('runtime-punch-guard')
+    const userId = `${orgId}-worker`
+    const workDate = '2024-10-07'
+    const token = await mintToken(userId)
+    const created = await createShiftViaApi(token, orgId, {
+      name: 'Punch Split',
+      timezone: 'UTC',
+      workStartTime: '08:00',
+      workEndTime: '17:00',
+    })
+    const shiftId = created.body.data.id as string
+    await seedPublishedAssignment(orgId, userId, shiftId, workDate)
+
+    await pool.query(
+      `UPDATE attendance_shift_segments
+          SET end_time = '12:00'
+        WHERE org_id = $1 AND shift_id = $2 AND segment_index = 0`,
+      [orgId, shiftId],
+    )
+    await injectSecondSegment(orgId, shiftId)
+    expect(await segmentCount(shiftId)).toBe(2)
+
+    const punch = await postJson('/api/attendance/punch', token, orgId, {
+      eventType: 'check_in',
+      occurredAt: `${workDate}T08:00:00Z`,
+      timezone: 'UTC',
+    })
+    expect(punch.status, punch.raw).toBe(422)
+    expect(codeOf(punch)).toBe(GUARD_CODE)
+
+    const [events, records] = await Promise.all([
+      pool.query(
+        'SELECT id FROM attendance_events WHERE org_id = $1 AND user_id = $2 AND work_date = $3',
+        [orgId, userId, workDate],
+      ),
+      pool.query(
+        'SELECT id FROM attendance_records WHERE org_id = $1 AND user_id = $2 AND work_date = $3',
+        [orgId, userId, workDate],
+      ),
+    ])
+    expect(events.rows).toHaveLength(0)
+    expect(records.rows).toHaveLength(0)
+  })
+
   it('rename + rejected segment conversion is atomic and leaves legacy rotation rules untouched', async () => {
     const orgId = org('put-rename-atomic')
     const token = await mintToken(`${orgId}-admin`)

--- a/packages/core-backend/tests/unit/attendance-live-punch-work-date.test.ts
+++ b/packages/core-backend/tests/unit/attendance-live-punch-work-date.test.ts
@@ -148,11 +148,12 @@ describe('attendance live punch work_date overnight anchoring helpers', () => {
       shift_work_start_time: '22:00',
       shift_work_end_time: '06:00',
       shift_is_overnight: true,
+      shift_segment_count: 1,
     }
     const fakeDb = {
       query: async (sql: string, params?: unknown[]) => {
         const text = String(sql)
-        if (text.includes('FROM attendance_shifts WHERE id = $1 AND org_id = $2')) {
+        if (text.includes('FROM attendance_shifts s') && text.includes('s.id = $1 AND s.org_id = $2')) {
           if (params?.[0] === 'sh-overnight' && params?.[1] === 'default') {
             return [{
               id: 'sh-overnight',
@@ -166,6 +167,7 @@ describe('attendance live punch work_date overnight anchoring helpers', () => {
               early_grace_minutes: 10,
               rounding_minutes: 5,
               working_days: [1, 2, 3, 4, 5],
+              segment_count: 1,
             }]
           }
           return []
@@ -197,6 +199,7 @@ describe('attendance live punch work_date overnight anchoring helpers', () => {
               shift_early_grace_minutes: 10,
               shift_rounding_minutes: 5,
               shift_working_days: [1, 2, 3, 4, 5],
+              shift_segment_count: 1,
             }]
           }
           return []

--- a/packages/core-backend/tests/unit/attendance-shift-segments-service.test.ts
+++ b/packages/core-backend/tests/unit/attendance-shift-segments-service.test.ts
@@ -315,11 +315,11 @@ describe('assertShiftReferenceAllowed (canonical assignability guard)', () => {
   const SHIFT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 
   function fakeTrx({ shiftRows, segmentCount }: { shiftRows: Array<Record<string, unknown>>; segmentCount: number }) {
-    const calls: string[] = []
+    const calls: Array<{ sql: string; params: unknown[] }> = []
     return {
       calls,
-      async query(sql: string) {
-        calls.push(sql)
+      async query(sql: string, params: unknown[]) {
+        calls.push({ sql, params })
         if (sql.includes('FROM attendance_shifts')) return shiftRows
         if (sql.includes('FROM attendance_shift_segments')) return [{ total: segmentCount }]
         throw new Error(`unexpected query: ${sql}`)
@@ -336,13 +336,34 @@ describe('assertShiftReferenceAllowed (canonical assignability guard)', () => {
   it('locks the shift row FOR SHARE (shared delete/reference lock protocol)', async () => {
     const trx = fakeTrx({ shiftRows: [{ id: SHIFT_ID }], segmentCount: 1 })
     await service.assertShiftReferenceAllowed(trx, { orgId: 'org-a', shiftId: SHIFT_ID, producer: 'assignment_create' })
-    expect(trx.calls[0]).toContain('FOR SHARE')
+    expect(trx.calls[0]!.sql).toContain('FOR SHARE')
+  })
+
+  it('keeps the segment-count read org-scoped', async () => {
+    const trx = fakeTrx({ shiftRows: [{ id: SHIFT_ID }], segmentCount: 1 })
+    await service.assertShiftReferenceAllowed(trx, { orgId: 'org-a', shiftId: SHIFT_ID, producer: 'assignment_create' })
+    const segmentRead = trx.calls.find((call) => call.sql.includes('FROM attendance_shift_segments'))
+    expect(segmentRead?.sql).toContain('org_id = $1')
+    expect(segmentRead?.sql).toContain('shift_id = $2')
+    expect(segmentRead?.params).toEqual(['org-a', SHIFT_ID])
   })
 
   it('fails closed with a typed 422 for a multi-segment shift while the flag is OFF', async () => {
     const trx = fakeTrx({ shiftRows: [{ id: SHIFT_ID }], segmentCount: 2 })
     await expect(service.assertShiftReferenceAllowed(trx, { orgId: 'org-a', shiftId: SHIFT_ID, producer: 'assignment_create' }))
       .rejects.toMatchObject({ status: 422, code: ERR.MULTI_SEGMENT_CALCULATION_DISABLED })
+  })
+
+  it('fails closed when a calculation caller cannot prove the persisted segment count', () => {
+    expect(() => service.assertSegmentCalculationAllowed({
+      orgId: 'org-a',
+      shiftId: SHIFT_ID,
+      segmentCount: null,
+      producer: 'attendance calculation',
+    })).toThrow(expect.objectContaining({
+      status: 422,
+      code: ERR.MULTI_SEGMENT_CALCULATION_DISABLED,
+    }))
   })
 
   it('keeps multi-segment references blocked when W3 is misconfigured with the future flag', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8187,6 +8187,7 @@ function mapShiftRow(row) {
   const workStartTime = row.work_start_time ?? DEFAULT_SHIFT.workStartTime
   const workEndTime = row.work_end_time ?? DEFAULT_SHIFT.workEndTime
   const isOvernight = resolveOvernightFlag(row.is_overnight, workStartTime, workEndTime)
+  const rawSegmentCount = row.shift_segment_count ?? row.segment_count
   return {
     id: row.id,
     orgId: row.org_id ?? DEFAULT_ORG_ID,
@@ -8207,6 +8208,7 @@ function mapShiftRow(row) {
     rounding_minutes: Number(row.rounding_minutes ?? DEFAULT_SHIFT.roundingMinutes),
     workingDays: normalizeWorkingDays(row.working_days),
     working_days: normalizeWorkingDays(row.working_days),
+    segmentCount: rawSegmentCount == null ? null : Number(rawSegmentCount),
   }
 }
 
@@ -8229,6 +8231,17 @@ function getAttendanceShiftService() {
     })
   }
   return attendanceShiftService
+}
+
+function assertWorkContextSegmentCalculationAllowed(orgId, workContext) {
+  if (!workContext || workContext.source === 'rule') return
+  const shift = workContext.rule
+  getAttendanceShiftService().assertSegmentCalculationAllowed({
+    orgId,
+    shiftId: shift?.id,
+    segmentCount: shift?.segmentCount,
+    producer: 'attendance calculation',
+  })
 }
 
 function respondAttendanceShiftServiceError(res, error) {
@@ -9283,6 +9296,7 @@ function mapShiftFromAssignmentRow(row) {
     early_grace_minutes: row.shift_early_grace_minutes,
     rounding_minutes: row.shift_rounding_minutes,
     working_days: row.shift_working_days,
+    shift_segment_count: row.shift_segment_count,
   })
 }
 
@@ -14287,7 +14301,10 @@ async function loadShiftAssignment(db, orgId, userId, workDate) {
               s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
               s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
               s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,
-              s.working_days AS shift_working_days
+              s.working_days AS shift_working_days,
+              (SELECT COUNT(*)::int
+                 FROM attendance_shift_segments seg
+                WHERE seg.org_id = a.org_id AND seg.shift_id = a.shift_id) AS shift_segment_count
        FROM attendance_shift_assignments a
        JOIN attendance_shifts s ON s.id = a.shift_id AND s.org_id = a.org_id
        WHERE a.org_id = $1
@@ -14317,7 +14334,13 @@ async function loadShiftById(db, orgId, shiftId) {
   const targetOrg = orgId || DEFAULT_ORG_ID
   try {
     const rows = await db.query(
-      'SELECT * FROM attendance_shifts WHERE id = $1 AND org_id = $2 LIMIT 1',
+      `SELECT s.*,
+              (SELECT COUNT(*)::int
+                 FROM attendance_shift_segments seg
+                WHERE seg.org_id = s.org_id AND seg.shift_id = s.id) AS segment_count
+         FROM attendance_shifts s
+        WHERE s.id = $1 AND s.org_id = $2
+        LIMIT 1`,
       [shiftId, targetOrg]
     )
     if (!rows.length) return null
@@ -14377,7 +14400,12 @@ async function loadShiftReferenceLookup(db, orgId, options = {}) {
   let rows
   if (!ids.length && !names.length) {
     rows = await db.query(
-      'SELECT * FROM attendance_shifts WHERE org_id = $1',
+      `SELECT s.*,
+              (SELECT COUNT(*)::int
+                 FROM attendance_shift_segments seg
+                WHERE seg.org_id = s.org_id AND seg.shift_id = s.id) AS segment_count
+         FROM attendance_shifts s
+        WHERE s.org_id = $1`,
       [targetOrg]
     )
   } else {
@@ -14385,16 +14413,20 @@ async function loadShiftReferenceLookup(db, orgId, options = {}) {
     const predicates = []
     if (ids.length) {
       params.push(ids)
-      predicates.push(`id = ANY($${params.length}::uuid[])`)
+      predicates.push(`s.id = ANY($${params.length}::uuid[])`)
     }
     if (names.length) {
       params.push(names)
-      predicates.push(`name = ANY($${params.length}::text[])`)
+      predicates.push(`s.name = ANY($${params.length}::text[])`)
     }
     rows = await db.query(
-      `SELECT * FROM attendance_shifts
-       WHERE org_id = $1
-         AND (${predicates.join(' OR ')})`,
+      `SELECT s.*,
+              (SELECT COUNT(*)::int
+                 FROM attendance_shift_segments seg
+                WHERE seg.org_id = s.org_id AND seg.shift_id = s.id) AS segment_count
+         FROM attendance_shifts s
+        WHERE s.org_id = $1
+          AND (${predicates.join(' OR ')})`,
       params
     )
   }
@@ -14599,6 +14631,7 @@ async function resolveWorkContext(options) {
     isWorkingDay,
     source: rotationInfo ? 'rotation' : assignmentInfo ? 'shift' : 'rule',
   }
+  assertWorkContextSegmentCalculationAllowed(orgId, context)
   // Step 5: layer calendarPolicy.overrides on top of profile/holiday. D4
   // pinned: only hit the DB when we actually have overrides to match, and
   // accept caller-provided overrides/scopeContext to avoid redundant
@@ -15140,9 +15173,12 @@ async function loadShiftAssignmentMapForUsersRange(db, orgId, userIds, fromDate,
             s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
             s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
             s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,
-            s.working_days AS shift_working_days
+            s.working_days AS shift_working_days,
+            (SELECT COUNT(*)::int
+               FROM attendance_shift_segments seg
+              WHERE seg.org_id = a.org_id AND seg.shift_id = a.shift_id) AS shift_segment_count
      FROM attendance_shift_assignments a
-     JOIN attendance_shifts s ON s.id = a.shift_id
+     JOIN attendance_shifts s ON s.id = a.shift_id AND s.org_id = a.org_id
      WHERE a.org_id = $1
        AND a.user_id = ANY($2::text[])
        AND a.is_active = true
@@ -17307,6 +17343,7 @@ function resolveWorkContextFromPrefetch(options) {
     isWorkingDay,
     source: rotationInfo ? 'rotation' : assignmentInfo ? 'shift' : 'rule',
   }
+  assertWorkContextSegmentCalculationAllowed(orgId, context)
   // Step 5: apply calendarPolicy.overrides when the prefetch carries both
   // the policy list and the user's scope context. D5 pinned: when either
   // is missing (old fixtures that build prefetched manually), behave

--- a/plugins/plugin-attendance/lib/attendance-shift-service.cjs
+++ b/plugins/plugin-attendance/lib/attendance-shift-service.cjs
@@ -26,9 +26,10 @@
  *   - While ATTENDANCE_SHIFT_SEGMENT_CALCULATION_ENABLED is OFF for an org,
  *     multi-segment authoring is preview-only: assertShiftReferenceAllowed /
  *     assertShiftSequenceReferenceAllowed make every reference-producing writer
- *     named in the erratum fail with a typed 422 and zero writes, and an existing
- *     active assignment / rotation / pending swap / pending-or-published dispatch
- *     blocks converting one segment to multiple (409, zero writes).
+ *     named in the erratum fail with a typed 422 and zero writes, and any durable
+ *     assignment / rotation / pending swap / pending-or-published dispatch reference
+ *     blocks converting one segment to multiple (409, zero writes), including ended
+ *     assignment history.
  *   - Delete shares one transaction-level lock protocol with reference writers:
  *     writers lock the shift row FOR SHARE inside their write transaction before
  *     inserting a reference; delete locks it FOR UPDATE before checking blockers,
@@ -450,8 +451,8 @@ function createAttendanceShiftService(deps) {
    * Canonical update. Three modes, exactly one per request:
    *   - segments: replace all segments, derive the envelope from them. Converting
    *     one segment to multiple is blocked (409, zero writes) while the flag is OFF
-   *     and the shift has an active assignment / rotation / pending swap /
-   *     pending-or-published dispatch reference.
+   *     and the shift has any durable assignment / rotation / pending swap /
+   *     pending-or-published dispatch reference, including ended history.
    *   - envelope: legacy start/end write on a single-segment shift; updates the
    *     envelope and segment 0 together. Rejected (422, zero writes) on a
    *     multi-segment shift — a start/end-only PUT cannot collapse segments.
@@ -490,12 +491,12 @@ function createAttendanceShiftService(deps) {
         segments = validateShiftSegments(patch.segments)
         const currentCount = currentSegmentCount === 0 ? 1 : currentSegmentCount
         if (segments.length > 1 && currentCount <= 1 && !isSegmentCalculationEnabled(orgId)) {
-          const blockers = await findActiveReferenceBlockers(trx, { orgId, shiftId, shiftName: existing.name })
+          const blockers = await findShiftDeleteBlockers(trx, { orgId, shiftId, shiftName: existing.name })
           if (blockers.length > 0) {
             throw new HttpError(
               409,
               SHIFT_SERVICE_ERROR.SEGMENT_CONVERSION_BLOCKED,
-              'Shift has active references and cannot be converted from one segment to multiple segments while segment calculation is disabled',
+              'Shift has durable references and cannot be converted from one segment to multiple segments while segment calculation is disabled',
               blockers.map((blocker) => ({ field: blocker.blocker, message: `${blocker.blocker}: ${blocker.count}` })),
             )
           }
@@ -693,33 +694,6 @@ function createAttendanceShiftService(deps) {
   }
 
   /**
-   * Active-reference blockers for the one-to-many segment conversion guard
-   * (erratum: active assignment, rotation, pending swap, pending/published
-   * dispatch). Unlike delete, ended/inactive assignment history does NOT block
-   * authoring-side conversion.
-   */
-  async function findActiveReferenceBlockers(trx, { orgId, shiftId, shiftName }) {
-    const blockers = []
-    const assignmentRows = await trx.query(
-      `SELECT COUNT(*)::int AS total
-         FROM attendance_shift_assignments
-        WHERE org_id = $1
-          AND shift_id = $2
-          AND is_active = true
-          AND (end_date IS NULL OR end_date >= CURRENT_DATE)`,
-      [orgId, shiftId],
-    )
-    const assignmentCount = Number(assignmentRows[0]?.total ?? 0)
-    if (assignmentCount > 0) blockers.push({ blocker: 'active_shift_assignments', count: assignmentCount })
-
-    const all = await findShiftDeleteBlockers(trx, { orgId, shiftId, shiftName })
-    for (const blocker of all) {
-      if (blocker.blocker !== 'shift_assignments') blockers.push(blocker)
-    }
-    return blockers
-  }
-
-  /**
    * Canonical delete. Shares the reference-writer lock protocol: the shift row is
    * locked FOR UPDATE before the blocker check, and every reference writer locks
    * the same row FOR SHARE inside its own transaction before inserting, so no
@@ -777,17 +751,30 @@ function createAttendanceShiftService(deps) {
     await assertLockedShiftReferenceAllowed(trx, { orgId, shiftId, producer })
   }
 
-  async function assertLockedShiftReferenceAllowed(trx, { orgId, shiftId, producer }) {
+  function assertSegmentCalculationAllowed({ orgId, shiftId, segmentCount, producer }) {
     if (isSegmentCalculationEnabled(orgId)) return
-    const segmentCount = await countPersistedSegments(trx, orgId, shiftId)
-    if (segmentCount > 1) {
+    const normalizedCount = Number(segmentCount)
+    if (segmentCount == null || !Number.isInteger(normalizedCount) || normalizedCount < 0) {
       throw new HttpError(
         422,
         SHIFT_SERVICE_ERROR.MULTI_SEGMENT_CALCULATION_DISABLED,
-        `Shift has ${segmentCount} segments; authoritative segment calculation is disabled for this org, so ${producer} cannot reference a multi-segment shift`,
+        `Shift segment state cannot be verified; authoritative segment calculation is disabled for this org, so ${producer} cannot continue`,
+        fieldDetail('shiftId', `Unable to verify segment state for shift ${shiftId}`),
+      )
+    }
+    if (normalizedCount > 1) {
+      throw new HttpError(
+        422,
+        SHIFT_SERVICE_ERROR.MULTI_SEGMENT_CALCULATION_DISABLED,
+        `Shift has ${normalizedCount} segments; authoritative segment calculation is disabled for this org, so ${producer} cannot use a multi-segment shift`,
         fieldDetail('shiftId', 'Multi-segment shift is authoring preview-only while segment calculation is disabled'),
       )
     }
+  }
+
+  async function assertLockedShiftReferenceAllowed(trx, { orgId, shiftId, producer }) {
+    const segmentCount = await countPersistedSegments(trx, orgId, shiftId)
+    assertSegmentCalculationAllowed({ orgId, shiftId, segmentCount, producer })
   }
 
   /**
@@ -881,7 +868,7 @@ function createAttendanceShiftService(deps) {
     listShifts,
     deleteShift,
     findShiftDeleteBlockers,
-    findActiveReferenceBlockers,
+    assertSegmentCalculationAllowed,
     assertShiftReferenceAllowed,
     assertShiftSequenceReferenceAllowed,
     loadShiftNameLookup,


### PR DESCRIPTION
## What changed

- block single-to-multi segment conversion whenever any durable shift reference exists, including ended assignment history
- add an org-scoped persisted-segment count to every attendance calculation context and fail closed before legacy-envelope calculation
- cover both import/prefetch and normal punch paths with zero-write real-DB assertions
- document the tightened W3 compatibility boundary

Addresses the P1 runtime route identified while investigating #4556; this does not close the issue.

## Verification

- `attendance-shift-segments-service.test.ts`: 26/26
- `attendance-shift-segments-writer-matrix.db.test.ts` on fresh migrated isolated DB: 26/26
- mutation: remove the runtime segment guard => punch test returns 200 and writes both event + record (expected red)
- mutation: remove org predicate from segment count => focused unit test red
- mutation: ignore ended assignment history => conversion regression red
- `node --check` for both changed CJS production files
- `git diff --check`

No flag was enabled and no deployment/runtime configuration changed.