### PR TITLE
ci(attendance): publish a stable web guard check

### DIFF
--- a/.github/workflows/attendance-web-guard.yml
+++ b/.github/workflows/attendance-web-guard.yml
@@ -1,4 +1,8 @@
 # Attendance web guard (targeted gate).
+# Pull requests intentionally have no top-level `paths` filter: this job must always create a
+# stable status so it can become a required check later. The changed-file classifier below keeps
+# unrelated PRs cheap and dependency-free while preserving the targeted Vitest gate for attendance
+# changes. Main pushes retain the existing path filter.
 #
 # Why this exists: the main PR gate (plugin-tests.yml) runs core-backend tests and only
 # `pnpm --filter @metasheet/web build` for the web app — it does NOT run apps/web vitest
@@ -113,56 +117,6 @@ name: Attendance Web Guard
 
 on:
   pull_request:
-    paths:
-      - 'apps/web/src/views/AttendanceView.vue'
-      - 'apps/web/src/views/attendance/**'
-      - 'apps/web/tests/attendance-admin-regressions.spec.ts'
-      - 'apps/web/tests/attendance-shift-segments.spec.ts'
-      - 'apps/web/tests/attendance-admin-anchor-nav.spec.ts'
-      - 'apps/web/tests/useAttendanceAdminRail.spec.ts'
-      - 'apps/web/tests/useAttendanceAdminRailNavigation.spec.ts'
-      - 'apps/web/tests/AttendanceRequestCenterSection.result-edit.spec.ts'
-      - 'apps/web/tests/attendance-selfservice-dashboard.spec.ts'
-      - 'apps/web/tests/attendance-caliber-transparency.spec.ts'
-      - 'apps/web/tests/attendance-punch-outcome.spec.ts'
-      - 'apps/web/tests/attendance-import-override-guard.spec.ts'
-      - 'apps/web/tests/attendance-halfday-leave-helper.spec.ts'
-      - 'apps/web/tests/attendance-schedule-bulk-apply.spec.ts'
-      - 'apps/web/tests/attendance-import-file-guard.spec.ts'
-      - 'apps/web/tests/attendance-import-preview-regression.spec.ts'
-      - 'apps/web/tests/useAttendanceAdminImportWorkflow.spec.ts'
-      - 'apps/web/tests/attendance-import-template-columns.spec.ts'
-      - 'apps/web/tests/attendance-import-header-recognition.spec.ts'
-      - 'apps/web/tests/attendance-import-xlsx-convert.spec.ts'
-      - 'apps/web/tests/useAttendanceAdminImportBatches.spec.ts'
-      - 'apps/web/src/utils/dingtalkContainer.ts'
-      - 'apps/web/tests/dingtalk-container.spec.ts'
-      - 'apps/web/tests/attendance-bulk-balance-adjust.spec.ts'
-      - 'apps/web/src/views/LoginView.vue'
-      - 'apps/web/tests/LoginView.spec.ts'
-      - 'apps/web/tests/attendance-token-ratchet.spec.ts'
-      - 'apps/web/src/views/attendance/AttendanceApprovalFlowStepsEditor.vue'
-      - 'apps/web/src/views/attendance/attendanceApprovalSteps.ts'
-      - 'apps/web/src/views/attendance/useAttendanceApprovalDirectoryReadiness.ts'
-      - 'apps/web/tests/attendance-approval-steps.spec.ts'
-      - 'apps/web/tests/AttendanceApprovalFlowStepsEditor.spec.ts'
-      - 'apps/web/src/views/attendance/reportXlsxExport.ts'
-      - 'apps/web/tests/attendance-report-xlsx-export.spec.ts'
-      - 'apps/web/tests/attendance-reports-analytics.spec.ts'
-      - 'apps/web/tests/attendance-overview-priority.spec.ts'
-      - 'apps/web/tests/AttendanceAdminTaskHome.spec.ts'
-      - 'apps/web/tests/attendance-experience-entrypoints.spec.ts'
-      - 'apps/web/tests/attendance-setup-readiness.spec.ts'
-      - 'apps/web/tests/AttendanceSetupReadiness.spec.ts'
-      - 'apps/web/tests/useAttendanceSetupReadiness.spec.ts'
-      - 'apps/web/tests/attendance-setup-templates.spec.ts'
-      - 'apps/web/tests/attendance-decision-trace.spec.ts'
-      - 'apps/web/tests/AttendanceDecisionTrace.spec.ts'
-      - 'apps/web/tests/attendance-decision-trace-wiring.spec.ts'
-      - 'apps/web/tests/attendance-context-help.spec.ts'
-      - 'apps/web/tests/AttendanceContextHelp.spec.ts'
-      - 'apps/web/tests/attendance-context-help-wiring.spec.ts'
-      - '.github/workflows/attendance-web-guard.yml'
   push:
     branches: [main]
     paths:
@@ -214,6 +168,7 @@ on:
       - 'apps/web/tests/attendance-context-help.spec.ts'
       - 'apps/web/tests/AttendanceContextHelp.spec.ts'
       - 'apps/web/tests/attendance-context-help-wiring.spec.ts'
+      - 'apps/web/tests/attendance-web-guard-workflow.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
 
 jobs:
@@ -222,29 +177,123 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect relevant attendance changes
+        id: changes
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$BASE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            changed_files="$(git diff-tree --root --no-commit-id --name-only -r "$HEAD_SHA")"
+          else
+            changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          fi
+
+          relevant=false
+          while IFS= read -r path; do
+            case "$path" in
+              apps/web/src/views/AttendanceView.vue|\
+              apps/web/src/views/attendance/*|\
+              apps/web/tests/attendance-admin-regressions.spec.ts|\
+              apps/web/tests/attendance-shift-segments.spec.ts|\
+              apps/web/tests/attendance-admin-anchor-nav.spec.ts|\
+              apps/web/tests/useAttendanceAdminRail.spec.ts|\
+              apps/web/tests/useAttendanceAdminRailNavigation.spec.ts|\
+              apps/web/tests/AttendanceRequestCenterSection.result-edit.spec.ts|\
+              apps/web/tests/attendance-selfservice-dashboard.spec.ts|\
+              apps/web/tests/attendance-caliber-transparency.spec.ts|\
+              apps/web/tests/attendance-punch-outcome.spec.ts|\
+              apps/web/tests/attendance-import-override-guard.spec.ts|\
+              apps/web/tests/attendance-halfday-leave-helper.spec.ts|\
+              apps/web/tests/attendance-schedule-bulk-apply.spec.ts|\
+              apps/web/tests/attendance-import-file-guard.spec.ts|\
+              apps/web/tests/attendance-import-preview-regression.spec.ts|\
+              apps/web/tests/useAttendanceAdminImportWorkflow.spec.ts|\
+              apps/web/tests/attendance-import-template-columns.spec.ts|\
+              apps/web/tests/attendance-import-header-recognition.spec.ts|\
+              apps/web/tests/attendance-import-xlsx-convert.spec.ts|\
+              apps/web/tests/useAttendanceAdminImportBatches.spec.ts|\
+              apps/web/src/utils/dingtalkContainer.ts|\
+              apps/web/tests/dingtalk-container.spec.ts|\
+              apps/web/tests/attendance-bulk-balance-adjust.spec.ts|\
+              apps/web/src/views/LoginView.vue|\
+              apps/web/tests/LoginView.spec.ts|\
+              apps/web/tests/attendance-token-ratchet.spec.ts|\
+              apps/web/src/views/attendance/AttendanceApprovalFlowStepsEditor.vue|\
+              apps/web/src/views/attendance/attendanceApprovalSteps.ts|\
+              apps/web/src/views/attendance/useAttendanceApprovalDirectoryReadiness.ts|\
+              apps/web/tests/attendance-approval-steps.spec.ts|\
+              apps/web/tests/AttendanceApprovalFlowStepsEditor.spec.ts|\
+              apps/web/src/views/attendance/reportXlsxExport.ts|\
+              apps/web/tests/attendance-report-xlsx-export.spec.ts|\
+              apps/web/tests/attendance-reports-analytics.spec.ts|\
+              apps/web/tests/attendance-overview-priority.spec.ts|\
+              apps/web/tests/AttendanceAdminTaskHome.spec.ts|\
+              apps/web/tests/attendance-experience-entrypoints.spec.ts|\
+              apps/web/tests/attendance-setup-readiness.spec.ts|\
+              apps/web/tests/AttendanceSetupReadiness.spec.ts|\
+              apps/web/tests/useAttendanceSetupReadiness.spec.ts|\
+              apps/web/tests/attendance-setup-templates.spec.ts|\
+              apps/web/tests/attendance-decision-trace.spec.ts|\
+              apps/web/tests/AttendanceDecisionTrace.spec.ts|\
+              apps/web/tests/attendance-decision-trace-wiring.spec.ts|\
+              apps/web/tests/attendance-context-help.spec.ts|\
+              apps/web/tests/AttendanceContextHelp.spec.ts|\
+              apps/web/tests/attendance-context-help-wiring.spec.ts|\
+              apps/web/tests/attendance-web-guard-workflow.spec.ts|\
+              .github/workflows/attendance-web-guard.yml)
+                relevant=true
+                break
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+          if [[ "$relevant" == true ]]; then
+            echo "Attendance Web Guard: relevant changes detected for $EVENT_NAME."
+          else
+            echo "Attendance Web Guard: no relevant changes detected for $EVENT_NAME."
+          fi
+
+      - name: Report success for unrelated changes
+        if: steps.changes.outputs.relevant == 'false'
+        run: |
+          echo 'Attendance Web Guard passed: no guarded attendance web files changed.'
 
       - name: Setup Node.js 20.x
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
 
       - name: Setup pnpm
+        if: steps.changes.outputs.relevant == 'true'
         uses: pnpm/action-setup@v4
         with:
           version: 10.16.1
           run_install: false
 
       - name: Use empty npmrc for pnpm
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           echo "" > /tmp/empty-npmrc
           echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
 
       - name: Get pnpm store directory
+        if: steps.changes.outputs.relevant == 'true'
         id: pnpm-cache
         shell: bash
         run: echo "STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: Setup pnpm cache
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
@@ -253,7 +302,9 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
+        if: steps.changes.outputs.relevant == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Run attendance web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-shift-segments attendance-admin-anchor-nav useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust attendance-overview-priority AttendanceAdminTaskHome attendance-experience-entrypoints attendance-setup-readiness AttendanceSetupReadiness.spec useAttendanceSetupReadiness attendance-setup-templates attendance-decision-trace.spec AttendanceDecisionTrace.spec attendance-decision-trace-wiring attendance-context-help.spec AttendanceContextHelp.spec attendance-context-help-wiring --reporter=dot
+        if: steps.changes.outputs.relevant == 'true'
+        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-shift-segments attendance-admin-anchor-nav useAttendanceAdminRail useAttendanceAdminRailNavigation AttendanceRequestCenterSection.result-edit attendance-selfservice-dashboard attendance-caliber-transparency attendance-punch-outcome attendance-import-override-guard attendance-halfday-leave-helper attendance-schedule-bulk-apply attendance-import-file-guard attendance-import-preview-regression useAttendanceAdminImportWorkflow attendance-import-template-columns attendance-import-header-recognition attendance-import-xlsx-convert useAttendanceAdminImportBatches dingtalk-container LoginView attendance-token-ratchet attendance-approval-steps AttendanceApprovalFlowStepsEditor attendance-report-xlsx-export attendance-reports-analytics attendance-bulk-balance-adjust attendance-overview-priority AttendanceAdminTaskHome attendance-experience-entrypoints attendance-setup-readiness AttendanceSetupReadiness.spec useAttendanceSetupReadiness attendance-setup-templates attendance-decision-trace.spec AttendanceDecisionTrace.spec attendance-decision-trace-wiring attendance-context-help.spec AttendanceContextHelp.spec attendance-context-help-wiring attendance-web-guard-workflow.spec --reporter=dot

--- a/apps/web/tests/AttendanceSetupReadiness.spec.ts
+++ b/apps/web/tests/AttendanceSetupReadiness.spec.ts
@@ -11,7 +11,7 @@
 //   - §3.2 / charter L232: unknown renders fail-closed (「未知，去核查」), never as complete.
 //   - §3⑦: the manual activation checklist always lists ④ + ⑥'s three signals and never claims
 //     anything is already enabled.
-// Wired into .github/workflows/attendance-web-guard.yml (run-list + both path filters).
+// Wired into .github/workflows/attendance-web-guard.yml (run-list + relevant-change classifier).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, ref, type App } from 'vue'
 import { createMemoryHistory, createRouter, type Router } from 'vue-router'

--- a/apps/web/tests/attendance-setup-readiness.spec.ts
+++ b/apps/web/tests/attendance-setup-readiness.spec.ts
@@ -1,6 +1,6 @@
 // W4-0 (Wave 4 onboarding design-lock 2026-07-21, RATIFIED §3/§7/§9): full seven-step discriminator
 // matrix for `apps/web/src/views/attendance/attendanceSetupReadiness.ts` — zero DOM, zero fetch.
-// Wired into .github/workflows/attendance-web-guard.yml (run-list + both path filters).
+// Wired into .github/workflows/attendance-web-guard.yml (run-list + relevant-change classifier).
 //
 // Coverage goal ("判别矩阵全值域×七步"): every value the seven-value status domain can reach at
 // each step, given today's implementation — this is not literally 7×7=49 combinations (most are

--- a/apps/web/tests/attendance-setup-templates.spec.ts
+++ b/apps/web/tests/attendance-setup-templates.spec.ts
@@ -32,7 +32,7 @@
 //   5. AttendanceExperienceView navigation seams (memory router + child stubs): the OD-W4-7②
 //      切区确认 legs — refusing the confirm keeps the tab/route, confirming proceeds, and no
 //      prompt fires without a pending prefill.
-// Wired into .github/workflows/attendance-web-guard.yml (run-list + both path filters).
+// Wired into .github/workflows/attendance-web-guard.yml (run-list + relevant-change classifier).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, ref, type App } from 'vue'
 import { createMemoryHistory, createRouter, type Router } from 'vue-router'

--- a/apps/web/tests/attendance-web-guard-workflow.spec.ts
+++ b/apps/web/tests/attendance-web-guard-workflow.spec.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const workflowPath = resolve(process.cwd(), '../../.github/workflows/attendance-web-guard.yml')
+const workflow = readFileSync(workflowPath, 'utf8')
+
+describe('attendance web guard workflow contract', () => {
+  it('creates one stable check for every pull request', () => {
+    const pullRequestStart = workflow.indexOf('\n  pull_request:')
+    const pushStart = workflow.indexOf('\n  push:', pullRequestStart)
+    expect(pullRequestStart).toBeGreaterThan(-1)
+    expect(pushStart).toBeGreaterThan(pullRequestStart)
+    expect(workflow.slice(pullRequestStart, pushStart)).toBe('\n  pull_request:')
+    expect(workflow).toContain('name: Report success for unrelated changes')
+    expect(workflow).toContain("if: steps.changes.outputs.relevant == 'false'")
+  })
+
+  it('keeps this contract spec in the classifier and targeted run list', () => {
+    expect(workflow.match(/apps\/web\/tests\/attendance-web-guard-workflow\.spec\.ts/g)).toHaveLength(2)
+    expect(workflow).toContain(' attendance-web-guard-workflow.spec --reporter=dot')
+    expect(workflow).toContain("if: steps.changes.outputs.relevant == 'true'")
+  })
+})

--- a/apps/web/tests/useAttendanceSetupReadiness.spec.ts
+++ b/apps/web/tests/useAttendanceSetupReadiness.spec.ts
@@ -3,7 +3,7 @@
 // forbidden, 503 DB_NOT_READY → db_not_ready, 200 valid → ok, everything else → fail-closed load
 // error), enum-strict body validation (invalid enum = malformed, never silently defaulted), and
 // the §6.1 readiness-derived task-home badge (①②③⑤ gating only; advisory ④⑥ never trigger).
-// Wired into .github/workflows/attendance-web-guard.yml (run-list + both path filters).
+// Wired into .github/workflows/attendance-web-guard.yml (run-list + relevant-change classifier).
 import { describe, expect, it, vi } from 'vitest'
 import {
   ATTENDANCE_SETUP_ADMIN_USERS_ROUTE_PATH,


### PR DESCRIPTION
## What changed

- run the Attendance Web Guard workflow for every pull request so its status name is stable and eligible for branch protection
- classify changed files inside the job; unrelated PRs report success without installing Node/pnpm dependencies
- retain the existing main-push path filter and targeted attendance Vitest run list
- add a self-guarding workflow contract spec so reintroducing a PR path filter turns CI red

## Verification

- workflow contract spec: 2/2
- Ruby YAML parse: pass
- mutation: re-add a pull-request `paths` block => contract spec red
- `git diff --check`

## Operator follow-up

This PR only makes the check stable. Marking `attendance-web-guard` as a required branch-protection check remains an explicit repository-owner action after this workflow lands; this PR does not modify branch protection.