### PR TITLE
test(attendance): prove W1 timeline integrity guard

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -321,6 +321,15 @@ jobs:
         run: |
           node --test scripts/ops/attendance-calculation-group-membership-w1-contract.test.mjs
 
+      # #4561 W1 P2: the service-level read/transition matrix bypasses the DB
+      # EXCLUDE constraint on purpose and proves the runtime integrity guard is
+      # independently load-bearing. Keep whole-file execution explicit.
+      - name: Run attendance calculation-group W1 timeline-integrity unit
+        run: |
+          pnpm --filter @metasheet/core-backend exec vitest run \
+            tests/unit/attendance-calculation-group-membership-timeline-integrity.test.ts \
+            --reporter=dot
+
       # #4556 W2: shared work-date resolver unit matrix (overlap precedence, attribution tail,
       # free_time/unscheduled/explicit-import hard stop, overtimeAttributionV1 freeze/legacy,
       # six-adapter parity). Explicit whole-file gate so it cannot drift out of the default suite.

--- a/packages/core-backend/tests/unit/attendance-calculation-group-membership-timeline-integrity.test.ts
+++ b/packages/core-backend/tests/unit/attendance-calculation-group-membership-timeline-integrity.test.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from 'node:crypto'
+import type { QueryResult, QueryResultRow } from 'pg'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// #4561 W1 P2 hardening: proves assertTimelineIntegrity is independently
+// load-bearing on the READ path, even when the DB EXCLUDE constraint
+// (attendance_calc_group_memberships_no_overlap) cannot protect it, such as rows
+// written while the constraint was absent, or served from a replica/cache.
+// The failure cases must turn RED if assertTimelineIntegrity becomes an immediate
+// return (mutation-verified 2026-07-24).
+
+const { clientQueryMock, executedStatements } = vi.hoisted(() => ({
+  clientQueryMock: vi.fn(),
+  executedStatements: [] as string[],
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: vi.fn(),
+  transaction: vi.fn(
+    async (callback: (client: { query: typeof clientQueryMock }) => unknown) =>
+      callback({ query: clientQueryMock }),
+  ),
+}))
+
+import {
+  AttendanceCalculationGroupMembershipError,
+  listAttendanceCalculationGroupMemberships,
+  transitionAttendanceCalculationGroupMembership,
+} from '../../src/services/AttendanceCalculationGroupMembership'
+
+type Executor = (
+  statement: string,
+  params?: unknown[],
+) => Promise<QueryResult<QueryResultRow>>
+
+const ORG_ID = 'org-corrupt-timeline'
+const USER_ID = 'user-corrupt-timeline'
+const ACTOR_ID = 'actor-corrupt-timeline'
+const GROUP_A = randomUUID()
+const GROUP_B = randomUUID()
+const GROUP_C = randomUUID()
+
+function membershipRow(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: randomUUID(),
+    org_id: ORG_ID,
+    user_id: USER_ID,
+    group_id: GROUP_A,
+    effective_from: '2026-01-01',
+    effective_to: null,
+    assigned_by: ACTOR_ID,
+    assigned_reason: 'seed',
+    assigned_correlation_id: `seed-${randomUUID()}`,
+    closed_by: null,
+    closed_reason: null,
+    closed_correlation_id: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+// Two rows whose effective intervals overlap ([01-01..06-30] vs [03-01..null]).
+// The EXCLUDE constraint would refuse this pair on INSERT, so reaching the read
+// path with these rows means the constraint was bypassed or absent, exactly the
+// gap assertTimelineIntegrity must close.
+const overlappingTimeline = [
+  membershipRow({ group_id: GROUP_A, effective_from: '2026-01-01', effective_to: '2026-06-30' }),
+  membershipRow({ group_id: GROUP_B, effective_from: '2026-03-01', effective_to: null }),
+]
+
+function executorReturning(rows: Record<string, unknown>[]): Executor {
+  return (async () => ({ rows })) as unknown as Executor
+}
+
+describe('W1 timeline integrity guard without DB EXCLUDE protection (service level)', () => {
+  beforeEach(() => {
+    executedStatements.length = 0
+    clientQueryMock.mockReset()
+    clientQueryMock.mockImplementation(async (statement: string) => {
+      executedStatements.push(statement)
+      if (statement.includes('pg_advisory_xact_lock')) return { rows: [] }
+      if (statement.includes('attendance_calculation_group_membership_operations')) {
+        return { rows: [] }
+      }
+      if (statement.includes('FROM attendance_groups')) {
+        return { rows: [{ id: GROUP_C }] }
+      }
+      if (statement.includes('FROM attendance_calculation_group_memberships')) {
+        return { rows: overlappingTimeline }
+      }
+      if (statement.includes('FROM users u')) return { rows: [{ '?column?': 1 }] }
+      if (statement.trimStart().startsWith('UPDATE')) return { rows: [], rowCount: 1 }
+      if (statement.includes('RETURNING *')) {
+        return {
+          rows: [
+            membershipRow({
+              group_id: GROUP_C,
+              effective_from: '2026-05-01',
+              effective_to: null,
+            }),
+          ],
+        }
+      }
+      return { rows: [] }
+    })
+  })
+
+  it('rejects the list read path with the typed corrupt error on overlapping rows', async () => {
+    const failure = await listAttendanceCalculationGroupMemberships(
+      ORG_ID,
+      USER_ID,
+      executorReturning(overlappingTimeline),
+    ).catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AttendanceCalculationGroupMembershipError)
+    expect(failure).toMatchObject({
+      code: 'ATTENDANCE_CALCULATION_GROUP_TIMELINE_CORRUPT',
+      status: 409,
+    })
+  })
+
+  it('rejects the list read path on an inverted interval (effective_to < effective_from)', async () => {
+    const inverted = [
+      membershipRow({ effective_from: '2026-02-01', effective_to: '2026-01-15' }),
+    ]
+    const failure = await listAttendanceCalculationGroupMemberships(
+      ORG_ID,
+      USER_ID,
+      executorReturning(inverted),
+    ).catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AttendanceCalculationGroupMembershipError)
+    expect(failure).toMatchObject({
+      code: 'ATTENDANCE_CALCULATION_GROUP_TIMELINE_CORRUPT',
+      status: 409,
+    })
+  })
+
+  it('still serves a contiguous timeline (positive control for the stub path)', async () => {
+    const contiguous = [
+      membershipRow({ effective_from: '2026-01-01', effective_to: '2026-01-31' }),
+      membershipRow({ group_id: GROUP_B, effective_from: '2026-02-01', effective_to: null }),
+    ]
+    const result = await listAttendanceCalculationGroupMemberships(
+      ORG_ID,
+      USER_ID,
+      executorReturning(contiguous),
+    )
+    expect(result).toHaveLength(2)
+  })
+
+  it('fails the transition closed with the typed corrupt error and writes nothing', async () => {
+    const failure = await transitionAttendanceCalculationGroupMembership({
+      orgId: ORG_ID,
+      userId: USER_ID,
+      targetGroupId: GROUP_C,
+      // Lands strictly inside the first overlapping interval, so a neutered guard
+      // would proceed to close row 1 and INSERT a new membership + operation row.
+      effectiveOn: '2026-05-01',
+      actorId: ACTOR_ID,
+      reason: 'Must refuse to write on top of a corrupt timeline',
+      correlationId: `corrupt-timeline-${randomUUID()}`,
+    }).catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AttendanceCalculationGroupMembershipError)
+    expect(failure).toMatchObject({
+      code: 'ATTENDANCE_CALCULATION_GROUP_TIMELINE_CORRUPT',
+      status: 409,
+    })
+
+    // No attendance-result write of any kind: no membership close-out UPDATE, no
+    // membership INSERT, no idempotency/operation INSERT.
+    const writes = executedStatements.filter((statement) =>
+      /^\s*(INSERT|UPDATE|DELETE)/i.test(statement),
+    )
+    expect(writes).toEqual([])
+  })
+})

--- a/scripts/ops/attendance-calculation-group-membership-w1-contract.test.mjs
+++ b/scripts/ops/attendance-calculation-group-membership-w1-contract.test.mjs
@@ -16,6 +16,10 @@ const dbTestPath = path.join(
   rootDir,
   'packages/core-backend/tests/integration/attendance-calculation-group-membership-w1.db.test.ts',
 )
+const timelineIntegrityUnitTestPath = path.join(
+  rootDir,
+  'packages/core-backend/tests/unit/attendance-calculation-group-membership-timeline-integrity.test.ts',
+)
 
 function read(filePath) {
   assert.ok(fs.existsSync(filePath), `missing contract file: ${filePath}`)
@@ -76,6 +80,16 @@ test('real-DB W1 suite has both skip-green exclusion and explicit CI execution p
   assert.match(source, /toUpperCase\(\)/)
   assert.match(source, /listAttendanceCalculationGroupMemberships\(orgA, uuidUserId\)/)
   assert.match(source, /uses one lock order for a direct semantic update racing a service transition/)
+})
+
+test('runtime timeline-integrity guard has explicit required CI execution', () => {
+  const fileName =
+    'attendance-calculation-group-membership-timeline-integrity.test.ts'
+  assert.match(read(workflowPath), new RegExp(fileName.replaceAll('.', '\\.')))
+  const source = read(timelineIntegrityUnitTestPath)
+  assert.match(source, /ATTENDANCE_CALCULATION_GROUP_TIMELINE_CORRUPT/)
+  assert.match(source, /transitionAttendanceCalculationGroupMembership/)
+  assert.match(source, /expect\(writes\)\.toEqual\(\[\]\)/)
 })
 
 test('OpenAPI exposes list and transition only, with no delete or replace-all path', () => {


### PR DESCRIPTION
## What

- add a service-level fake-DB matrix that feeds overlapping and inverted calculation-group membership timelines directly into the read path
- assert the typed 409 corruption error for list and transition paths
- prove a corrupt transition emits no membership or operation write
- execute the test file explicitly in the required plugin test matrix
- extend the W1 source contract so removing that CI execution turns the contract red

## Why

The database EXCLUDE constraint prevents new overlaps, but it cannot replace a runtime fail-closed check for historical, replica, or otherwise corrupted rows. This test proves `assertTimelineIntegrity` remains independently load-bearing. It is a test/CI-only follow-up for #4561; no runtime behavior changes.

## Verification

- `node --test scripts/ops/attendance-calculation-group-membership-w1-contract.test.mjs` (6/6)
- focused unit + sibling route suites (11/11)
- immediate-return mutation in `assertTimelineIntegrity`: 3 failure cases red; positive control remains green
- CI-wiring mutation replacing the explicit file path: W1 contract red
- production service restored byte-for-byte after mutation
- `git diff --check`

Full package type-check was attempted locally but the shared dependency tree lacks `@aws-sdk/client-s3`; fresh GitHub checks remain authoritative for type-checking.