### PR TITLE
fix(data-source): B2 — OFFSET-ordering fail-fast guard + typed closed 422 + MSSQL fallback deletion (DRAFT, merges LAST)

### DIFF
--- a/packages/core-backend/src/data-adapters/BaseAdapter.ts
+++ b/packages/core-backend/src/data-adapters/BaseAdapter.ts
@@ -83,6 +83,22 @@ export interface QueryOptions {
 export const DATA_SOURCE_MAX_ROWS = 10000
 export const DATA_SOURCE_DEFAULT_LIMIT = 1000
 
+/** Closed error code for the offset-ordering read contract (mapped to HTTP 422 at route surfaces). */
+export const DATA_SOURCE_OFFSET_ORDERING_REQUIRED_CODE = 'DATA_SOURCE_OFFSET_ORDERING_REQUIRED'
+
+/**
+ * Typed, closed contract error for an offset read with no deterministic order. A CALLER/CONFIG
+ * error, not a server fault: HTTP surfaces map it to 422 with the closed code above — without the
+ * type, the /select route's catch-all reported this as `SELECT_ERROR` 500.
+ */
+export class DataSourceOffsetOrderingError extends Error {
+  readonly code = DATA_SOURCE_OFFSET_ORDERING_REQUIRED_CODE
+  constructor(message: string) {
+    super(message)
+    this.name = 'DataSourceOffsetOrderingError'
+  }
+}
+
 export interface QueryResult<T = Record<string, DbValue>> {
   data: T[]
   metadata?: {
@@ -303,6 +319,46 @@ export abstract class BaseDataAdapter extends EventEmitter {
       )
     }
     return limit
+  }
+
+  /**
+   * Ordering-boundary policy — the A5 sibling for the OTHER half of a paginated read.
+   *
+   * A5 above bounds each page and tells callers to "paginate with limit+offset instead". But an
+   * OFFSET is only meaningful against a DETERMINISTIC total order: SQL gives no row-order guarantee
+   * without ORDER BY, so `LIMIT n OFFSET k` over an unordered relation may return rows in a
+   * different order on each call. The pages then SILENTLY overlap and skip — the caller reads N
+   * rows, believes it read the table, and has both duplicates and holes with no error anywhere.
+   * That is a data-integrity failure, not a performance wart, and it is invisible at every layer
+   * above this one.
+   *
+   * So an offset read MUST carry an explicit orderBy, and we fail closed when it does not — with a
+   * TYPED, closed contract error so HTTP surfaces can map it to 422 (caller/config error) instead
+   * of a 500 server fault. We do NOT auto-order by a discovered primary key: that would silently
+   * paper over the caller's missing ordering contract and keep the defect un-diagnosed. Only the
+   * caller knows which order its cursor arithmetic assumes.
+   *
+   * Enforced at the ADAPTER layer for the same reason A5 is — it is the chokepoint every structured
+   * read passes through, INCLUDING direct internal callers that bypass the route.
+   *
+   * Scope: `offset > 0` only. A limit-only first page (no offset) has no cross-page contract to
+   * violate, so it stays legal and unchanged. (Known limit, pinned in the conformance suite: a
+   * caller that reads page 1 unordered and only orders from page 2 is still incoherent — that
+   * intent is only visible to the paginating caller and closes in the caller's contract.)
+   */
+  protected assertDeterministicOffsetOrdering(
+    offset: number | null | undefined,
+    orderBy: QueryOptions['orderBy'] | undefined
+  ): void {
+    const usesOffset = offset !== null && offset !== undefined && Number(offset) > 0
+    if (!usesOffset) return
+    if (!Array.isArray(orderBy) || orderBy.length === 0) {
+      throw new DataSourceOffsetOrderingError(
+        'OFFSET pagination requires an explicit orderBy: without a deterministic total order the ' +
+          'database may return rows in any order, so successive pages can silently duplicate and ' +
+          'skip rows. Pass orderBy (e.g. the primary key) alongside offset.'
+      )
+    }
   }
 
   protected buildWhereClause(where: WhereClause): { sql: string; params: DbValue[] } {

--- a/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
@@ -303,6 +303,8 @@ export class MSSQLAdapter extends BaseDataAdapter {
     // internal caller cannot issue an unbounded read.
     const limit = this.resolveEffectiveLimit(options.limit)
     const offset = options.offset != null ? Math.floor(Number(options.offset)) : null
+    // Ordering boundary: an OFFSET page without a deterministic ORDER BY silently duplicates/skips.
+    this.assertDeterministicOffsetOrdering(offset, options.orderBy)
     // limit-without-offset uses TOP (no ORDER BY required); offset uses OFFSET/FETCH.
     const useTop = offset == null || offset === 0
 
@@ -327,8 +329,11 @@ export class MSSQLAdapter extends BaseDataAdapter {
       : null
 
     if (offset != null && offset > 0) {
-      // OFFSET requires an ORDER BY; fall back to a stable no-op ordering.
-      sql += ` ORDER BY ${orderBy ?? '(SELECT NULL)'} OFFSET ${offset} ROWS`
+      // An offset read must carry a deterministic order (assertDeterministicOffsetOrdering above),
+      // so `orderBy` is guaranteed present here. The former `ORDER BY (SELECT NULL)` fallback
+      // satisfied SQL Server's syntactic requirement while providing NO ordering guarantee, so
+      // paged reads could silently duplicate and skip rows.
+      sql += ` ORDER BY ${orderBy} OFFSET ${offset} ROWS`
       sql += ` FETCH NEXT ${limit} ROWS ONLY`
     } else if (orderBy) {
       sql += ` ORDER BY ${orderBy}`

--- a/packages/core-backend/src/data-adapters/MySQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MySQLAdapter.ts
@@ -331,6 +331,10 @@ export class MySQLAdapter extends BaseDataAdapter {
     if (options.offset) {
       const offset = parseInt(String(options.offset), 10)
       if (!isNaN(offset) && offset >= 0) {
+        // Ordering boundary: an OFFSET page without a deterministic ORDER BY silently
+        // duplicates/skips. Validated against the PARSED offset so a non-numeric value that never
+        // reaches the SQL cannot trip the guard.
+        this.assertDeterministicOffsetOrdering(offset, options.orderBy)
         sql += ` OFFSET ${offset}`
       }
     }

--- a/packages/core-backend/src/data-adapters/PostgresAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PostgresAdapter.ts
@@ -201,6 +201,8 @@ export class PostgresAdapter extends BaseDataAdapter {
     // positive integer, so the interpolation is injection-safe.
     sql += ` LIMIT ${this.resolveEffectiveLimit(options.limit)}`
     if (options.offset) {
+      // Ordering boundary: an OFFSET page without a deterministic ORDER BY silently duplicates/skips.
+      this.assertDeterministicOffsetOrdering(options.offset, options.orderBy)
       sql += ` OFFSET ${options.offset}`
     }
 

--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -24,7 +24,7 @@ import {
   SUPPORTED_DATA_SOURCE_TYPES
 } from '../data-adapters/DataSourceManager'
 import type { DataSourceConfig, QueryOptions } from '../data-adapters/BaseAdapter'
-import { DATA_SOURCE_DEFAULT_LIMIT, DATA_SOURCE_MAX_ROWS } from '../data-adapters/BaseAdapter'
+import { DATA_SOURCE_DEFAULT_LIMIT, DATA_SOURCE_MAX_ROWS, DataSourceOffsetOrderingError } from '../data-adapters/BaseAdapter'
 
 // Zod schemas for request validation
 const ConnectionConfigSchema = z.record(z.union([z.string(), z.number(), z.boolean()]))
@@ -898,6 +898,14 @@ export function dataSourcesRouter(): Router {
         return res.status(404).json({
           ok: false,
           error: { code: 'NOT_FOUND', message: `Data source '${req.params.id}' not found` }
+        })
+      }
+      if (error instanceof DataSourceOffsetOrderingError) {
+        // Closed 422: a read-CONTRACT violation (offset pagination without a deterministic order)
+        // is a caller/config error, not a server fault — it must never surface as SELECT_ERROR 500.
+        return res.status(422).json({
+          ok: false,
+          error: { code: error.code, message: error.message }
         })
       }
       return res.status(500).json({

--- a/packages/core-backend/tests/unit/data-source-offset-ordering-conformance.test.ts
+++ b/packages/core-backend/tests/unit/data-source-offset-ordering-conformance.test.ts
@@ -15,6 +15,7 @@ import {
 import { MSSQLAdapter } from '../../src/data-adapters/MSSQLAdapter'
 import { PostgresAdapter } from '../../src/data-adapters/PostgresAdapter'
 import { dataSourcesRouter } from '../../src/routes/data-sources'
+import { usePinnedServer } from '../utils/pinned-server'
 import type { DataSourceConfig, QueryOptions } from '../../src/data-adapters/BaseAdapter'
 
 /**
@@ -148,6 +149,7 @@ describe('dialect artifacts and known limits', () => {
 
 describe('/select route — the typed contract error maps to a CLOSED 422, never a 500', () => {
   let currentUser: { id: string; role?: string } | undefined
+  const pinned = usePinnedServer()
   const app = express()
   app.use(express.json())
   app.use((req, _res, next) => { (req as { user?: unknown }).user = currentUser; next() })
@@ -163,14 +165,15 @@ describe('/select route — the typed contract error maps to a CLOSED 422, never
   beforeEach(() => {
     currentUser = admin('alice')
     vi.restoreAllMocks()
+    pinned.setApp(app)
   })
 
   it('an offset-ordering violation returns 422 with the closed code (not SELECT_ERROR 500)', async () => {
     vi.spyOn(DataSourceManager.prototype, 'select').mockRejectedValue(
       new DataSourceOffsetOrderingError('OFFSET pagination requires an explicit orderBy: …')
     )
-    await request(app).post('/api/data-sources').send(body('ord-422'))
-    const res = await request(app)
+    await request(pinned.url()).post('/api/data-sources').send(body('ord-422'))
+    const res = await request(pinned.url())
       .post('/api/data-sources/ord-422/select')
       .send({ table: 't', limit: 10, offset: 10 })
     expect(res.status).toBe(422)
@@ -179,8 +182,8 @@ describe('/select route — the typed contract error maps to a CLOSED 422, never
 
   it('a generic failure still maps to SELECT_ERROR 500 (the 422 mapping is closed, not widened)', async () => {
     vi.spyOn(DataSourceManager.prototype, 'select').mockRejectedValue(new Error('boom'))
-    await request(app).post('/api/data-sources').send(body('ord-500'))
-    const res = await request(app)
+    await request(pinned.url()).post('/api/data-sources').send(body('ord-500'))
+    const res = await request(pinned.url())
       .post('/api/data-sources/ord-500/select')
       .send({ table: 't', limit: 10 })
     expect(res.status).toBe(500)
@@ -189,8 +192,8 @@ describe('/select route — the typed contract error maps to a CLOSED 422, never
 
   it('a successful select still returns 200 (positive control)', async () => {
     vi.spyOn(DataSourceManager.prototype, 'select').mockResolvedValue({ data: [] })
-    await request(app).post('/api/data-sources').send(body('ord-200'))
-    const res = await request(app)
+    await request(pinned.url()).post('/api/data-sources').send(body('ord-200'))
+    const res = await request(pinned.url())
       .post('/api/data-sources/ord-200/select')
       .send({ table: 't', limit: 10, offset: 10, orderBy: [{ column: 'id', direction: 'asc' }] })
     expect(res.status).toBe(200)

--- a/packages/core-backend/tests/unit/data-source-offset-ordering-conformance.test.ts
+++ b/packages/core-backend/tests/unit/data-source-offset-ordering-conformance.test.ts
@@ -1,0 +1,198 @@
+import express from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/audit/audit', () => ({ auditLog: vi.fn(async () => {}) }))
+
+import {
+  DEFAULT_ADAPTER_REGISTRY,
+  DataSourceManager,
+} from '../../src/data-adapters/DataSourceManager'
+import {
+  DATA_SOURCE_OFFSET_ORDERING_REQUIRED_CODE,
+  DataSourceOffsetOrderingError,
+} from '../../src/data-adapters/BaseAdapter'
+import { MSSQLAdapter } from '../../src/data-adapters/MSSQLAdapter'
+import { PostgresAdapter } from '../../src/data-adapters/PostgresAdapter'
+import { dataSourcesRouter } from '../../src/routes/data-sources'
+import type { DataSourceConfig, QueryOptions } from '../../src/data-adapters/BaseAdapter'
+
+/**
+ * OFFSET-ORDERING BOUNDARY CONFORMANCE (B2).
+ *
+ * SQL guarantees no row order without ORDER BY, so `LIMIT n OFFSET k` over an unordered relation
+ * may return rows in a different order per call: successive pages silently overlap and skip. The
+ * adapter chokepoint therefore fails closed on `offset > 0` without `orderBy` — with a TYPED,
+ * closed contract error (`DATA_SOURCE_OFFSET_ORDERING_REQUIRED`) so the HTTP surface maps it to a
+ * closed 422 instead of the catch-all `SELECT_ERROR` 500.
+ *
+ * The roster is derived from the PRODUCTION registry (same discipline as the landed A5 suite): a
+ * newly registered SQL adapter is auto-covered, with no hand-maintained list to drift.
+ */
+
+function cfg(type: string): DataSourceConfig {
+  return {
+    id: 's', name: 's', type,
+    connection: { host: 'h', port: 1, database: 'd', baseUrl: 'http://127.0.0.1:1' } as DataSourceConfig['connection'],
+    credentials: { username: 'u', password: 'p' },
+    options: { autoConnect: false },
+  } as DataSourceConfig
+}
+
+function instantiate(type: string): { isSqlDialect(): boolean } {
+  const AdapterClass = (DEFAULT_ADAPTER_REGISTRY as Record<string, new (c: DataSourceConfig) => { isSqlDialect(): boolean }>)[type]
+  return new AdapterClass(cfg(type))
+}
+
+function capture(adapter: unknown): string[] {
+  const sql: string[] = []
+  ;(adapter as { query(s: string): Promise<unknown> }).query = async (s: string) => {
+    sql.push(s)
+    return { data: [], rowCount: 0 }
+  }
+  return sql
+}
+
+function select(adapter: unknown, options: QueryOptions): Promise<unknown> {
+  return (adapter as { select(t: string, o: QueryOptions): Promise<unknown> }).select('t', options)
+}
+
+const ORDERED: QueryOptions['orderBy'] = [{ column: 'id', direction: 'asc' }]
+
+// Derived from the registry, deduped by class (`postgres` aliases `postgresql`).
+const SQL_TYPES = Object.keys(DEFAULT_ADAPTER_REGISTRY).filter(t => instantiate(t).isSqlDialect())
+const SQL_TYPES_UNDER_TEST = [...new Map(SQL_TYPES.map(t => [instantiate(t).constructor, t])).values()]
+
+describe('roster: every registered SQL adapter is exercised (registry-derived, no hand list)', () => {
+  it('derivation is non-vacuous and covers each distinct SQL adapter class', () => {
+    const exercised = new Set(SQL_TYPES_UNDER_TEST.map(t => instantiate(t).constructor))
+    const registered = new Set(SQL_TYPES.map(t => instantiate(t).constructor))
+    expect(exercised).toEqual(registered)
+    expect(SQL_TYPES_UNDER_TEST.length).toBeGreaterThan(0)
+  })
+})
+
+describe.each(SQL_TYPES_UNDER_TEST)('%s — offset-ordering boundary', type => {
+  const make = () => instantiate(type)
+
+  it('offset WITHOUT orderBy fails closed with the TYPED closed error', async () => {
+    const adapter = make()
+    capture(adapter)
+    let caught: unknown = null
+    try {
+      await select(adapter, { limit: 10, offset: 10 })
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(DataSourceOffsetOrderingError)
+    expect((caught as DataSourceOffsetOrderingError).code).toBe(DATA_SOURCE_OFFSET_ORDERING_REQUIRED_CODE)
+    expect((caught as Error).message).toMatch(/OFFSET pagination requires an explicit orderBy/)
+  })
+
+  it('offset WITH orderBy is allowed (positive control — not a blanket ban on offset)', async () => {
+    const adapter = make()
+    const sql = capture(adapter)
+    await select(adapter, { limit: 10, offset: 10, orderBy: ORDERED })
+    expect(sql).toHaveLength(1)
+    expect(sql[0]).toMatch(/ORDER BY/i)
+  })
+
+  it('a limit-only first page stays legal (no cross-page contract to violate)', async () => {
+    const adapter = make()
+    const sql = capture(adapter)
+    await select(adapter, { limit: 10 })
+    expect(sql).toHaveLength(1)
+  })
+})
+
+describe('dialect artifacts and known limits', () => {
+  // SQL Server REQUIRES an ORDER BY for OFFSET, so the old code fabricated `ORDER BY (SELECT NULL)`
+  // — syntactically valid, semantically NO ordering guarantee: the "looks ordered, isn't" construct
+  // that made paged reads corrupt silently. It must never come back.
+  it('MSSQL never re-emits the non-deterministic `ORDER BY (SELECT NULL)` offset fallback', async () => {
+    const adapter = new MSSQLAdapter(cfg('sqlserver'))
+    const sql = capture(adapter)
+    await select(adapter, { limit: 10, offset: 10, orderBy: ORDERED })
+    expect(sql[0]).not.toMatch(/\(SELECT NULL\)/i)
+    expect(sql[0]).toMatch(/ORDER BY .*OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY/i)
+  })
+
+  // Why this is data-integrity and not style: two legal-but-different physical orders for the same
+  // unordered query leave the caller with a duplicate AND a missing row while believing the table
+  // was fully read.
+  it('demonstrates the corruption the policy prevents (one duplicate + one skipped row)', () => {
+    const table = ['a', 'b', 'c', 'd']
+    const scanA = ['a', 'b', 'c', 'd']
+    const scanB = ['c', 'a', 'd', 'b']
+    const pageSize = 2
+    const collected = [...scanA.slice(0, pageSize), ...scanB.slice(pageSize, pageSize * 2)]
+
+    expect(collected).toHaveLength(table.length) // caller believes the table was fully read…
+    expect(collected.filter((r, i) => collected.indexOf(r) !== i)).toEqual(['b']) // …'b' twice
+    expect(table.filter(r => !collected.includes(r))).toEqual(['c']) // …'c' never read
+  })
+
+  // KNOWN LIMIT, pinned deliberately: the guard triggers on `offset > 0`, so a caller that reads
+  // page 1 with no offset/order and only supplies an order from page 2 still has an incoherent
+  // sequence. The adapter cannot distinguish "standalone bounded preview" from "page 1 of a
+  // sequence" — that intent closes in the caller's ordering contract, not by over-strictness here.
+  it('KNOWN LIMIT: a limit-only first page is not covered by the adapter-level guard', async () => {
+    const adapter = new PostgresAdapter(cfg('postgresql'))
+    const sql = capture(adapter)
+    await select(adapter, { limit: 10 }) // page 1 of a sequence, unordered — accepted here
+    expect(sql[0]).not.toMatch(/ORDER BY/i)
+    await expect(select(adapter, { limit: 10, offset: 10 }))
+      .rejects.toThrow(/OFFSET pagination requires an explicit orderBy/)
+  })
+})
+
+describe('/select route — the typed contract error maps to a CLOSED 422, never a 500', () => {
+  let currentUser: { id: string; role?: string } | undefined
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => { (req as { user?: unknown }).user = currentUser; next() })
+  app.use(dataSourcesRouter())
+  const admin = (id: string) => ({ id, role: 'admin' })
+  const body = (id: string) => ({
+    id, name: id, type: 'sqlserver',
+    connection: { host: 'db', port: 1433, database: 'ERP' },
+    credentials: { username: 'u', password: 'p' },
+    options: { autoConnect: false },
+  })
+
+  beforeEach(() => {
+    currentUser = admin('alice')
+    vi.restoreAllMocks()
+  })
+
+  it('an offset-ordering violation returns 422 with the closed code (not SELECT_ERROR 500)', async () => {
+    vi.spyOn(DataSourceManager.prototype, 'select').mockRejectedValue(
+      new DataSourceOffsetOrderingError('OFFSET pagination requires an explicit orderBy: …')
+    )
+    await request(app).post('/api/data-sources').send(body('ord-422'))
+    const res = await request(app)
+      .post('/api/data-sources/ord-422/select')
+      .send({ table: 't', limit: 10, offset: 10 })
+    expect(res.status).toBe(422)
+    expect(res.body.error.code).toBe(DATA_SOURCE_OFFSET_ORDERING_REQUIRED_CODE)
+  })
+
+  it('a generic failure still maps to SELECT_ERROR 500 (the 422 mapping is closed, not widened)', async () => {
+    vi.spyOn(DataSourceManager.prototype, 'select').mockRejectedValue(new Error('boom'))
+    await request(app).post('/api/data-sources').send(body('ord-500'))
+    const res = await request(app)
+      .post('/api/data-sources/ord-500/select')
+      .send({ table: 't', limit: 10 })
+    expect(res.status).toBe(500)
+    expect(res.body.error.code).toBe('SELECT_ERROR')
+  })
+
+  it('a successful select still returns 200 (positive control)', async () => {
+    vi.spyOn(DataSourceManager.prototype, 'select').mockResolvedValue({ data: [] })
+    await request(app).post('/api/data-sources').send(body('ord-200'))
+    const res = await request(app)
+      .post('/api/data-sources/ord-200/select')
+      .send({ table: 't', limit: 10, offset: 10, orderBy: [{ column: 'id', direction: 'asc' }] })
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
**Pure B2 enforcement re-cut from current main (owner ruling). Supersedes #4580 — that branch still carried the A-half already landed via #4583 and went DIRTY. DRAFT by design: per the §4 slice order this merges LAST, after adapter-chokepoint telemetry (B1-observability, its own gate), the coverage-mapped caller inventory, and customer migration. Design + evidence ledger: PR #4590.**

## Scope — exactly the three owner-listed items

1. **OFFSET-ordering fail-fast guard** (BaseAdapter chokepoint, wired in MSSQL/Postgres/MySQL): `offset > 0` without `orderBy` ⇒ fail-closed. Unordered offset windows silently duplicate AND skip rows (demonstrated by test). Limit-only first page stays legal; the first-page residual is **pinned as a KNOWN LIMIT** (closes in the caller's ordering contract, B1a+). No auto-order-by-primary-key — that would hide the missing contract.
2. **Typed closed 422** (review merge-condition): `DataSourceOffsetOrderingError` / `DATA_SOURCE_OFFSET_ORDERING_REQUIRED`; `/select` maps it to **422** instead of the old catch-all `SELECT_ERROR` 500. Mapping is closed, not widened — generic errors still 500 (pinned).
3. **MSSQL `ORDER BY (SELECT NULL)` deletion** — the "looks ordered, isn't" construct; pinned never to return.

**NOT here (deliberate):** observability contracts/counters/handshake — B1-observability slice, separate runtime gate.

## Verification

- Conformance suite with **registry-derived roster** (auto-covers a newly registered SQL adapter): per-adapter typed fail-closed + positive control + limit-only legal; MSSQL artifact pin; corruption demonstration (one duplicate + one skipped row); KNOWN LIMIT pin; route 422 / closed-500 / 200 controls. **16/16.**
- **Mutation-verified both ways**: neuter the guard → exactly the fail-closed cases red; remove the route mapping → exactly the 422 case red.
- Full core-backend unit suite **404 files / 5632 tests green**; `tsc --noEmit` clean.

## Known reachable consequence (unchanged, why this merges LAST)

`data-source:sql-readonly`'s non-watermark offset path fails closed at page 2 instead of corrupting silently. Its ordering contract arrives with the B1a resolver (`orderingKeySpec` from the approved config version); migration precedes enforcement.