### PR TITLE
feat(ops): schema-probing, values-free data-source exposure inventory (replaces the NO-GO ad-hoc SQL)

### DIFF
--- a/.github/workflows/data-source-exposure-inventory.yml
+++ b/.github/workflows/data-source-exposure-inventory.yml
@@ -1,0 +1,46 @@
+name: Data Source Exposure Inventory
+
+# B1c exposure-inventory contract test. Hermetic, no database — the script's
+# tests inject a fake query executor (see scripts/ops/data-source-exposure-inventory.test.mjs).
+# Follows the same shape as the `contract` job in
+# multitable-permission-lists-postdeploy-smoke.yml: checkout + setup-node only,
+# no pnpm install, `node --test` directly against the .mjs test file.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/data-source-exposure-inventory.yml'
+      - 'scripts/ops/data-source-exposure-inventory.mjs'
+      - 'scripts/ops/data-source-exposure-inventory.test.mjs'
+      # This script's static-call-site enumerator asserts these files still
+      # match its DEFAULT_ANCHORS patterns (see the "drift guard" test in the
+      # .test.mjs above). Listed here so the PR that actually drifts one of
+      # them re-runs this check, instead of a later, unrelated PR going red.
+      - 'packages/core-backend/src/routes/data-sources.ts'
+      - 'packages/core-backend/src/data-adapters/DataSourceManager.ts'
+      - 'plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/data-source-exposure-inventory.yml'
+      - 'scripts/ops/data-source-exposure-inventory.mjs'
+      - 'scripts/ops/data-source-exposure-inventory.test.mjs'
+      - 'packages/core-backend/src/routes/data-sources.ts'
+      - 'packages/core-backend/src/data-adapters/DataSourceManager.ts'
+      - 'plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs'
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: exposure-inventory contract (values-free, schema-probe-first)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run hermetic exposure-inventory tests (fake executor, no DB)
+        run: node --test scripts/ops/data-source-exposure-inventory.test.mjs

--- a/.github/workflows/data-source-exposure-inventory.yml
+++ b/.github/workflows/data-source-exposure-inventory.yml
@@ -19,6 +19,7 @@ on:
       - 'packages/core-backend/src/routes/data-sources.ts'
       - 'packages/core-backend/src/data-adapters/DataSourceManager.ts'
       - 'plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs'
+      - 'plugins/plugin-integration-core/lib/pipeline-runner.cjs'
   push:
     branches: [main]
     paths:
@@ -28,6 +29,7 @@ on:
       - 'packages/core-backend/src/routes/data-sources.ts'
       - 'packages/core-backend/src/data-adapters/DataSourceManager.ts'
       - 'plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs'
+      - 'plugins/plugin-integration-core/lib/pipeline-runner.cjs'
 
 permissions:
   contents: read

--- a/.github/workflows/gip-authority-substrate-inventory.yml
+++ b/.github/workflows/gip-authority-substrate-inventory.yml
@@ -6,9 +6,8 @@ name: GIP Authority-Substrate Inventory (β/γ probes)
 # No database: the script's tests inject a fake query executor (see
 # scripts/ops/gip-authority-substrate-inventory.test.mjs). Follows the same shape as the
 # `contract` job in multitable-permission-lists-postdeploy-smoke.yml (on main), and the same
-# pattern as data-source-exposure-inventory.yml (#4594) — that workflow is NOT in this tree; it
-# lives only on branch claude/data-source-exposure-inventory-20260724, not on main: checkout +
-# setup-node only, `node --test` directly.
+# pattern as data-source-exposure-inventory.yml (#4594): checkout + setup-node only, `node --test`
+# directly. The two inventories remain separate carriers and do not import one another.
 
 on:
   pull_request:

--- a/scripts/ops/data-source-exposure-inventory.mjs
+++ b/scripts/ops/data-source-exposure-inventory.mjs
@@ -1,0 +1,1062 @@
+#!/usr/bin/env node
+/**
+ * data-source-exposure-inventory.mjs
+ *
+ * B1c exposure inventory (READ-ONLY, values-free by construction).
+ *
+ * Replaces an earlier ad-hoc SQL inventory that was rejected NO-GO because it was written
+ * from ASSUMED schema. Its four verified errors — never repeat any of these:
+ *   1. filtered external-system status with `<> 'disabled'`; the real vocabulary (CHECK
+ *      constraint on integration_external_systems.status, see migration 057) is
+ *      'active' | 'inactive' | 'error'.
+ *   2. queried `integration_pipeline_runs`, which does not exist; the real table is
+ *      `integration_runs` (migration 057_create_integration_core_tables.sql).
+ *   3. assumed a `metrics.pageCount` JSON field; the real integration_runs columns are
+ *      `details` (jsonb) and `rows_read` / `rows_cleaned` / `rows_written` / `rows_failed`.
+ *   4. used `data_sources.deleted_at` / `is_active` unconditionally. Those columns exist in
+ *      the MODERN shape (packages/core-backend/src/db/migrations/20251206000001_create_data_sources_table.ts)
+ *      but NOT in the legacy shape (packages/core-backend/migrations/040_data_sources.sql —
+ *      now a no-op history marker on fresh installs, see migration-provider.ts
+ *      SUPERSEDED_LEGACY_SQL_MIGRATIONS, but still the shape some already-migrated databases
+ *      may carry). The two shapes even use different status vocabularies
+ *      ('active'/'inactive'/'error' vs 'connected'/'disconnected'/'error'). This script
+ *      NEVER assumes either shape — see probeSchema() / buildPlan() below.
+ *
+ * THEREFORE: this script schema-probes FIRST (information_schema.tables / .columns) and
+ * refuses to guess. If a required table or column is not verified present, the affected
+ * report item is UNAVAILABLE with a stated reason — it never emits a query against an
+ * unverified shape and never silently substitutes a column.
+ *
+ * VALUES-FREE BY CONSTRUCTION: every DB query on the allowlist below returns COUNTS only
+ * (or, for information_schema probes, table/column *names* that are our own hardcoded
+ * constants being confirmed present — never arbitrary row content). Type/status buckets in
+ * the report are always drawn from fixed, pre-initialized constant keys (SUPPORTED_DATA_SOURCE
+ * roster / the CHECK-constraint-backed status vocabularies) — a database value is only ever
+ * used to select which pre-existing bucket to increment, never written into the report as a
+ * new key or string.
+ *
+ * READ-ONLY, structurally: the query executor never receives a caller-built SQL string. Every
+ * query is looked up by a fixed `tag` in QUERY_ALLOWLIST (see runQuery()); an unrecognised tag
+ * throws. assertReadOnlyAllowlist() asserts, at module load, that every allowlisted statement
+ * starts with SELECT and contains no non-trailing semicolon (so a hand-edited entry like
+ * `SELECT 1; DROP TABLE x` cannot silently become "structurally read-only"). This is a load-time
+ * check on a hand-authored constant, not a runtime SQL-injection guard or a full parser — it says
+ * nothing about a value reaching QUERY_ALLOWLIST some other way, and it is not the reason
+ * multi-statement execution is actually prevented at runtime (the pg client's parameterized-query
+ * path used by runQuery()/createPgExecutor() does not execute stacked statements). Values passed
+ * as bind parameters are either fixed module constants (the 'data-source:sql-readonly' kind,
+ * table/column names) or a bounded, validated integer (--window-days) — never string-interpolated
+ * into SQL text.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://… node scripts/ops/data-source-exposure-inventory.mjs [--window-days N] [--json]
+ *   node scripts/ops/data-source-exposure-inventory.mjs --dry-run [--window-days N]   # no DB required
+ *
+ * Exit codes:
+ *   0  ran successfully (report produced; the verdict itself may be MIGRATION_REQUIRED —
+ *      that is information, this script is an inventory, not a gate)
+ *   1  unexpected runtime/DB error
+ *   2  required input missing (DATABASE_URL absent outside --dry-run)
+ */
+
+import { readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const REPO_ROOT = path.resolve(path.dirname(__filename), '../..')
+
+// ---------------------------------------------------------------------------
+// Constants (closed vocabularies — never invented, always re-verified against
+// the real source at authoring time; see the header comment / task report for
+// citations of the exact commit/migration each one was checked against).
+// ---------------------------------------------------------------------------
+
+// Mirrors packages/core-backend/src/data-adapters/DataSourceManager.ts
+// `SUPPORTED_DATA_SOURCE_TYPES` (pinned by commit 68bcd9a67 / #4583). Keep in sync manually —
+// this script has no automated drift guard against that file (a possible follow-up).
+const SUPPORTED_DATA_SOURCE_TYPES = Object.freeze([
+  'postgresql',
+  'postgres',
+  'http',
+  'sqlserver',
+  'mysql',
+  'plm',
+])
+
+// CHECK constraint on integration_external_systems.status (migration
+// 057_create_integration_core_tables.sql line: `CHECK (status IN ('active', 'inactive', 'error'))`).
+const EXTERNAL_SYSTEM_STATUSES = Object.freeze(['active', 'inactive', 'error'])
+
+// The plugin kind string this inventory is scoped to (verified against
+// plugins/plugin-integration-core/lib/pipeline-runner.cjs DATA_SOURCE_SQL_READONLY_KIND and
+// the `source.kind` validators in stock-preparation-table-actions.cjs / stock-preparation-templates.cjs).
+const TARGET_KIND = 'data-source:sql-readonly'
+
+const DEFAULT_WINDOW_DAYS = 30
+const MIN_WINDOW_DAYS = 1
+const MAX_WINDOW_DAYS = 365
+
+// Appended to every "table/column not found" reason. information_schema only
+// reports objects visible to the connected role in the schemas on its
+// search_path — a non-'public' search_path, or a role that was never granted
+// SELECT/USAGE on the object, is indistinguishable from a genuinely absent
+// table/column, and will UNAVAILABLE that item too.
+const SCHEMA_PROBE_CAVEAT =
+  "probed via information_schema.tables/.columns, table_schema='public', as the DATABASE_URL role — a non-public search_path or missing SELECT/USAGE privileges reports the same as a genuinely absent object"
+
+// ---------------------------------------------------------------------------
+// QUERY_ALLOWLIST — the ONLY SQL statements this script will ever execute.
+// runQuery() rejects any tag not in this object. Every statement is SELECT-only;
+// assertReadOnlyAllowlist() enforces that structurally at module load.
+// ---------------------------------------------------------------------------
+
+const QUERY_ALLOWLIST = Object.freeze({
+  'probe.table_exists': {
+    sql: `SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = $1 LIMIT 1`,
+    describe: 'schema probe: does table $1 exist',
+  },
+  'probe.columns': {
+    sql: `SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = $1`,
+    describe: 'schema probe: which columns exist on table $1',
+  },
+  'count.data_sources_all_types': {
+    sql: `SELECT type, count(*)::int AS n FROM data_sources GROUP BY type`,
+    describe: 'registered data_sources grouped by type',
+  },
+  'count.data_sources_active_types.with_deleted_at': {
+    sql: `SELECT type, count(*)::int AS n FROM data_sources WHERE is_active = true AND deleted_at IS NULL GROUP BY type`,
+    describe: 'active, non-soft-deleted data_sources grouped by type (modern schema shape)',
+  },
+  'count.data_sources_active_types.without_deleted_at': {
+    sql: `SELECT type, count(*)::int AS n FROM data_sources WHERE is_active = true GROUP BY type`,
+    describe: 'active data_sources grouped by type (is_active present, no deleted_at column)',
+  },
+  'count.external_systems_status_by_kind': {
+    sql: `SELECT status, count(*)::int AS n FROM integration_external_systems WHERE kind = $1 GROUP BY status`,
+    describe: 'integration_external_systems of a given kind, grouped by status',
+  },
+  'count.approved_read_source_configs_by_kind': {
+    sql: `SELECT count(*)::int AS n
+          FROM integration_read_source_configs c
+          JOIN integration_external_systems s ON s.id = c.system_id
+          WHERE s.kind = $1 AND c.status = 'approved'`,
+    describe: 'approved integration_read_source_configs bound to external systems of a given kind',
+  },
+  'count.pipelines_by_source_kind': {
+    sql: `SELECT count(*)::int AS n
+          FROM integration_pipelines p
+          JOIN integration_external_systems s ON s.id = p.source_system_id
+          WHERE s.kind = $1`,
+    describe: 'integration_pipelines whose source_system_id resolves to a given kind',
+  },
+  'count.runs_by_kind_window': {
+    sql: `SELECT count(*)::int AS n
+          FROM integration_runs r
+          JOIN integration_pipelines p ON p.id = r.pipeline_id
+          JOIN integration_external_systems s ON s.id = p.source_system_id
+          WHERE s.kind = $1 AND r.created_at >= NOW() - make_interval(days => $2::int)`,
+    describe: 'integration_runs within a window, for pipelines whose source resolves to a given kind',
+  },
+})
+
+function assertReadOnlyAllowlist(allowlist) {
+  for (const [tag, entry] of Object.entries(allowlist)) {
+    if (!/^\s*SELECT\b/i.test(entry.sql)) {
+      throw new Error(
+        `data-source-exposure-inventory: QUERY_ALLOWLIST entry "${tag}" is not a SELECT statement — refusing to load a non-read-only query.`,
+      )
+    }
+    // Reject a non-trailing semicolon: without this, `SELECT 1; DROP TABLE x`
+    // would pass the start-anchored check above by virtue of starting with
+    // SELECT. A single semicolon at the very end (harmless statement
+    // terminator) is still allowed.
+    const trimmed = entry.sql.trim()
+    const withoutTrailingSemicolon = trimmed.endsWith(';') ? trimmed.slice(0, -1) : trimmed
+    if (withoutTrailingSemicolon.includes(';')) {
+      throw new Error(
+        `data-source-exposure-inventory: QUERY_ALLOWLIST entry "${tag}" contains a non-trailing semicolon — refusing to load a possible multi-statement query.`,
+      )
+    }
+  }
+}
+assertReadOnlyAllowlist(QUERY_ALLOWLIST)
+
+async function runQuery(exec, tag, params = []) {
+  const entry = QUERY_ALLOWLIST[tag]
+  if (!entry) {
+    throw new Error(`data-source-exposure-inventory: query tag not on allowlist: ${tag}`)
+  }
+  return exec(entry.sql, params)
+}
+
+// ---------------------------------------------------------------------------
+// Schema probing
+// ---------------------------------------------------------------------------
+
+const TABLE_SPECS = Object.freeze({
+  data_sources: ['type', 'is_active', 'deleted_at', 'status'],
+  integration_external_systems: ['id', 'kind', 'status'],
+  integration_read_source_configs: ['system_id', 'status'],
+  integration_pipelines: ['id', 'source_system_id'],
+  integration_runs: ['id', 'pipeline_id', 'created_at'],
+})
+
+async function tableExists(exec, tableName) {
+  const { rows } = await runQuery(exec, 'probe.table_exists', [tableName])
+  return rows.length > 0
+}
+
+async function probeColumns(exec, tableName, wantedColumns) {
+  const { rows } = await runQuery(exec, 'probe.columns', [tableName])
+  const present = new Set(rows.map((r) => r.column_name))
+  const result = {}
+  for (const col of wantedColumns) result[col] = present.has(col)
+  return result
+}
+
+async function probeSchema(exec) {
+  const schema = {}
+  for (const [table, cols] of Object.entries(TABLE_SPECS)) {
+    const exists = await tableExists(exec, table)
+    const columns = exists
+      ? await probeColumns(exec, table, cols)
+      : Object.fromEntries(cols.map((c) => [c, false]))
+    schema[table] = { exists, columns }
+  }
+  return schema
+}
+
+// ---------------------------------------------------------------------------
+// Plan builder — pure function of (schema, options). Used identically by
+// --dry-run (to print the plan without executing counts) and by report mode
+// (to execute it). This is the single place that decides UNAVAILABLE vs OK.
+// ---------------------------------------------------------------------------
+
+function planDataSources(schema) {
+  const t = schema.data_sources
+  if (!t.exists) {
+    return { status: 'unavailable', reason: `table data_sources not found (${SCHEMA_PROBE_CAVEAT})` }
+  }
+  if (!t.columns.type) {
+    return { status: 'unavailable', reason: `data_sources.type column not found (${SCHEMA_PROBE_CAVEAT})` }
+  }
+  const registered = { tag: 'count.data_sources_all_types', params: [] }
+  let active
+  if (!t.columns.is_active) {
+    active = {
+      status: 'unavailable',
+      reason: `data_sources.is_active column not present (${SCHEMA_PROBE_CAVEAT}) — either a legacy pre-modern-migration install (see 040_data_sources.sql vs 20251206000001_create_data_sources_table.ts) or a privilege gap; refusing to guess an "active" predicate from the status column, whose vocabulary also differs across those two shapes`,
+    }
+  } else if (t.columns.deleted_at) {
+    active = { status: 'ok', tag: 'count.data_sources_active_types.with_deleted_at', params: [] }
+  } else {
+    active = { status: 'ok', tag: 'count.data_sources_active_types.without_deleted_at', params: [] }
+  }
+  return { status: 'ok', registered, active }
+}
+
+function planExternalSystems(schema, kind) {
+  const t = schema.integration_external_systems
+  if (!t.exists) {
+    return { status: 'unavailable', reason: `table integration_external_systems not found (${SCHEMA_PROBE_CAVEAT})` }
+  }
+  const missing = ['kind', 'status'].filter((c) => !t.columns[c])
+  if (missing.length) {
+    return {
+      status: 'unavailable',
+      reason: `integration_external_systems missing column(s): ${missing.join(', ')} (${SCHEMA_PROBE_CAVEAT})`,
+    }
+  }
+  return { status: 'ok', tag: 'count.external_systems_status_by_kind', params: [kind] }
+}
+
+function planApprovedConfigs(schema, kind) {
+  const c = schema.integration_read_source_configs
+  const s = schema.integration_external_systems
+  const missingTables = []
+  if (!c.exists) missingTables.push('integration_read_source_configs')
+  if (!s.exists) missingTables.push('integration_external_systems')
+  if (missingTables.length) {
+    return { status: 'unavailable', reason: `missing table(s): ${missingTables.join(', ')} (${SCHEMA_PROBE_CAVEAT})` }
+  }
+  const missingCols = []
+  if (!c.columns.system_id) missingCols.push('integration_read_source_configs.system_id')
+  if (!c.columns.status) missingCols.push('integration_read_source_configs.status')
+  if (!s.columns.id) missingCols.push('integration_external_systems.id')
+  if (!s.columns.kind) missingCols.push('integration_external_systems.kind')
+  if (missingCols.length) {
+    return { status: 'unavailable', reason: `missing column(s): ${missingCols.join(', ')} (${SCHEMA_PROBE_CAVEAT})` }
+  }
+  return { status: 'ok', tag: 'count.approved_read_source_configs_by_kind', params: [kind] }
+}
+
+function planPipelines(schema, kind) {
+  const p = schema.integration_pipelines
+  const s = schema.integration_external_systems
+  const missingTables = []
+  if (!p.exists) missingTables.push('integration_pipelines')
+  if (!s.exists) missingTables.push('integration_external_systems')
+  if (missingTables.length) {
+    return { status: 'unavailable', reason: `missing table(s): ${missingTables.join(', ')} (${SCHEMA_PROBE_CAVEAT})` }
+  }
+  const missingCols = []
+  if (!p.columns.source_system_id) missingCols.push('integration_pipelines.source_system_id')
+  if (!s.columns.id) missingCols.push('integration_external_systems.id')
+  if (!s.columns.kind) missingCols.push('integration_external_systems.kind')
+  if (missingCols.length) {
+    return { status: 'unavailable', reason: `missing column(s): ${missingCols.join(', ')} (${SCHEMA_PROBE_CAVEAT})` }
+  }
+  return { status: 'ok', tag: 'count.pipelines_by_source_kind', params: [kind] }
+}
+
+function planRunsWindow(schema, kind, windowDays) {
+  const r = schema.integration_runs
+  const p = schema.integration_pipelines
+  const s = schema.integration_external_systems
+  const missingTables = []
+  if (!r.exists) missingTables.push('integration_runs')
+  if (!p.exists) missingTables.push('integration_pipelines')
+  if (!s.exists) missingTables.push('integration_external_systems')
+  if (missingTables.length) {
+    return { status: 'unavailable', reason: `missing table(s): ${missingTables.join(', ')} (${SCHEMA_PROBE_CAVEAT})` }
+  }
+  const missingCols = []
+  if (!r.columns.pipeline_id) missingCols.push('integration_runs.pipeline_id')
+  if (!r.columns.created_at) missingCols.push('integration_runs.created_at')
+  if (!p.columns.id) missingCols.push('integration_pipelines.id')
+  if (!p.columns.source_system_id) missingCols.push('integration_pipelines.source_system_id')
+  if (!s.columns.id) missingCols.push('integration_external_systems.id')
+  if (!s.columns.kind) missingCols.push('integration_external_systems.kind')
+  if (missingCols.length) {
+    return { status: 'unavailable', reason: `missing column(s): ${missingCols.join(', ')} (${SCHEMA_PROBE_CAVEAT})` }
+  }
+  return { status: 'ok', tag: 'count.runs_by_kind_window', params: [kind, windowDays] }
+}
+
+function buildPlan(schema, { windowDays = DEFAULT_WINDOW_DAYS, kind = TARGET_KIND } = {}) {
+  return {
+    kind,
+    windowDays,
+    dataSources: planDataSources(schema),
+    externalSystems: planExternalSystems(schema, kind),
+    approvedConfigs: planApprovedConfigs(schema, kind),
+    pipelines: planPipelines(schema, kind),
+    runsWindow: planRunsWindow(schema, kind, windowDays),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bucketing — DB values are only ever used to pick which pre-existing key to
+// increment. The serialized report never contains a key or string that did
+// not already exist as one of these fixed constants.
+// ---------------------------------------------------------------------------
+
+function bucketDataSourceTypeCounts(rows) {
+  const buckets = Object.fromEntries(SUPPORTED_DATA_SOURCE_TYPES.map((t) => [t, 0]))
+  buckets.other = 0
+  let total = 0
+  for (const row of rows) {
+    const n = Number(row.n) || 0
+    total += n
+    if (SUPPORTED_DATA_SOURCE_TYPES.includes(row.type)) {
+      buckets[row.type] += n
+    } else {
+      buckets.other += n
+    }
+  }
+  return { buckets, total }
+}
+
+function bucketExternalSystemStatusCounts(rows) {
+  const buckets = Object.fromEntries(EXTERNAL_SYSTEM_STATUSES.map((s) => [s, 0]))
+  buckets.unexpected = 0
+  let total = 0
+  for (const row of rows) {
+    const n = Number(row.n) || 0
+    total += n
+    if (EXTERNAL_SYSTEM_STATUSES.includes(row.status)) {
+      buckets[row.status] += n
+    } else {
+      buckets.unexpected += n
+    }
+  }
+  return { buckets, total }
+}
+
+// ---------------------------------------------------------------------------
+// Plan execution — only runs queries for items the plan marked 'ok'.
+// ---------------------------------------------------------------------------
+
+async function executeDataSourcesPlan(exec, plan) {
+  if (plan.status !== 'ok') return plan
+  const registeredResult = await runQuery(exec, plan.registered.tag, plan.registered.params)
+  const registered = bucketDataSourceTypeCounts(registeredResult.rows)
+
+  let active
+  if (plan.active.status !== 'ok') {
+    active = { status: 'unavailable', reason: plan.active.reason }
+  } else {
+    const activeResult = await runQuery(exec, plan.active.tag, plan.active.params)
+    const bucketed = bucketDataSourceTypeCounts(activeResult.rows)
+    active = { status: 'ok', byType: bucketed.buckets, total: bucketed.total }
+  }
+
+  return {
+    status: 'ok',
+    registeredByType: registered.buckets,
+    registeredTotal: registered.total,
+    active,
+  }
+}
+
+async function executeExternalSystemsPlan(exec, plan) {
+  if (plan.status !== 'ok') return plan
+  const { rows } = await runQuery(exec, plan.tag, plan.params)
+  const { buckets, total } = bucketExternalSystemStatusCounts(rows)
+  return { status: 'ok', kind: plan.params[0], byStatus: buckets, total }
+}
+
+async function executeScalarCountPlan(exec, plan) {
+  if (plan.status !== 'ok') return plan
+  const { rows } = await runQuery(exec, plan.tag, plan.params)
+  const count = rows.length ? Number(rows[0].n) || 0 : 0
+  return { status: 'ok', count }
+}
+
+async function executePlan(exec, plan) {
+  const [dataSources, externalSystems, approvedConfigs, pipelines, runsWindow] = await Promise.all([
+    executeDataSourcesPlan(exec, plan.dataSources),
+    executeExternalSystemsPlan(exec, plan.externalSystems),
+    executeScalarCountPlan(exec, plan.approvedConfigs),
+    executeScalarCountPlan(exec, plan.pipelines),
+    executeScalarCountPlan(exec, plan.runsWindow),
+  ])
+  return { dataSources, externalSystems, approvedConfigs, pipelines, runsWindow }
+}
+
+// ---------------------------------------------------------------------------
+// Static in-repo caller enumeration (item 2). Needs no database. Fails closed
+// (marks the item unavailable) if an anchor file cannot be found, rather than
+// silently reporting zero call sites because of a wrong repoRoot / cwd.
+// ---------------------------------------------------------------------------
+
+// Verified against the real files at authoring time:
+//   - packages/core-backend/src/routes/data-sources.ts:864
+//       router.post('/api/data-sources/:id/select', ...)
+//   - packages/core-backend/src/data-adapters/DataSourceManager.ts:780
+//       sourceAdapter.select(...) inside DataSourceManager.select
+//   - packages/core-backend/src/data-adapters/DataSourceManager.ts:746
+//       async copyData(...) — has no live in-tree caller (verified: repo-wide
+//       grep for `.copyData(` outside this file's own definition line and
+//       outside univer-meta.ts's unrelated `copyData` object-literal variable
+//       found zero call sites)
+//   - plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs:384
+//       api.select(...)
+const DEFAULT_ANCHORS = Object.freeze([
+  {
+    id: 'select_route',
+    file: 'packages/core-backend/src/routes/data-sources.ts',
+    pattern: /router\.post\(\s*'\/api\/data-sources\/:id\/select'/,
+  },
+  {
+    id: 'manager_select_internal',
+    file: 'packages/core-backend/src/data-adapters/DataSourceManager.ts',
+    pattern: /sourceAdapter\.select\(/,
+  },
+  {
+    id: 'copy_data_definition',
+    file: 'packages/core-backend/src/data-adapters/DataSourceManager.ts',
+    pattern: /async\s+copyData\(/,
+  },
+  {
+    id: 'sql_readonly_adapter_select',
+    file: 'plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs',
+    pattern: /\bapi\.select\(/,
+  },
+])
+
+const DEFAULT_SCAN_ROOTS = Object.freeze(['packages/core-backend/src', 'plugins'])
+const SCAN_EXTENSIONS = new Set(['.ts', '.cjs', '.js'])
+const TEST_PATH_PATTERN = /(^|[/\\])(__tests__|__mocks__|fixtures)([/\\]|$)|\.(test|spec)\.[cm]?[jt]s$/
+
+const SELECT_CALL_PATTERN = /\b(?:manager|adapter|sourceAdapter|api)\.select\s*\(/
+const COPY_DATA_CALL_PATTERN = /\.copyData\s*\(/
+const SELECT_ROUTE_STRING_PATTERN = /'\/api\/data-sources\/:id\/select'/
+
+function walkFiles(rootAbs, extSet, out) {
+  let entries
+  try {
+    entries = readdirSync(rootAbs, { withFileTypes: true })
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name.startsWith('.')) continue
+    const fullAbs = path.join(rootAbs, entry.name)
+    if (entry.isDirectory()) {
+      walkFiles(fullAbs, extSet, out)
+    } else if (extSet.has(path.extname(entry.name))) {
+      out.push(fullAbs)
+    }
+  }
+}
+
+function enumerateStaticCallSites({ repoRoot = REPO_ROOT, anchors = DEFAULT_ANCHORS, scanRoots = DEFAULT_SCAN_ROOTS } = {}) {
+  const anchorsMissing = []
+  const anchorsVerified = []
+  for (const anchor of anchors) {
+    const abs = path.join(repoRoot, anchor.file)
+    let content = null
+    try {
+      content = readFileSync(abs, 'utf8')
+    } catch {
+      anchorsMissing.push(anchor.id)
+      continue
+    }
+    if (anchor.pattern.test(content)) {
+      anchorsVerified.push(anchor.id)
+    } else {
+      // File exists but the expected shape drifted — also fail closed: the
+      // enumerator's assumptions about this file no longer hold.
+      anchorsMissing.push(anchor.id)
+    }
+  }
+
+  if (anchorsMissing.length > 0) {
+    return {
+      status: 'unavailable',
+      reason: `anchor file(s)/pattern(s) not verified: ${anchorsMissing.join(', ')} — refusing to report a caller count that a wrong repoRoot or code drift could make silently zero`,
+      anchorsVerified,
+      anchorsMissing,
+    }
+  }
+
+  const files = []
+  for (const root of scanRoots) {
+    walkFiles(path.join(repoRoot, root), SCAN_EXTENSIONS, files)
+  }
+
+  const counts = {
+    managerOrAdapterSelectCallSites: { nonTest: 0, test: 0 },
+    copyDataCallSites: { nonTest: 0, test: 0 },
+    selectRouteDefinitions: { nonTest: 0, test: 0 },
+  }
+
+  for (const fileAbs of files) {
+    const relPath = path.relative(repoRoot, fileAbs)
+    const isTest = TEST_PATH_PATTERN.test(relPath)
+    let content
+    try {
+      content = readFileSync(fileAbs, 'utf8')
+    } catch {
+      continue
+    }
+    const bucket = isTest ? 'test' : 'nonTest'
+    const codeOnly = stripLineCommentLines(content)
+    counts.managerOrAdapterSelectCallSites[bucket] += countMatches(codeOnly, SELECT_CALL_PATTERN)
+    counts.copyDataCallSites[bucket] += countMatches(codeOnly, COPY_DATA_CALL_PATTERN)
+    counts.selectRouteDefinitions[bucket] += countMatches(codeOnly, SELECT_ROUTE_STRING_PATTERN)
+  }
+
+  return {
+    status: 'ok',
+    scanRoots,
+    scannedFileCount: files.length,
+    anchorsVerified,
+    counts,
+    limitation:
+      'text-line scan, not an AST parse: whole-line comments are stripped before matching, but an inline trailing comment or the interior of a /* */ block can still be mis-counted; errs toward over-, not under-, counting',
+    knownCallers: [
+      { id: 'select_route', note: 'POST /api/data-sources/:id/select' },
+      { id: 'sql_readonly_adapter', note: 'plugin data-source:sql-readonly adapter (api.select)' },
+      {
+        id: 'copy_data',
+        note: 'DataSourceManager.copyData',
+        hasLiveCaller: counts.copyDataCallSites.nonTest > 0,
+      },
+    ],
+  }
+}
+
+// Heuristic-only: drops lines that are ENTIRELY a comment (leading //, /*, *,
+// or #). This is a line-based text scan, not an AST parse — it will still
+// mis-count an inline trailing comment (`foo() // adapter.select( example`)
+// or a multi-line /* ... */ block whose interior lines don't start with `*`.
+// It deliberately errs toward over-counting (a stray comment counted as a
+// "call site") rather than under-counting (a real call site hidden inside a
+// comment causing a false negative) — see the staticCallSiteEnumeration
+// limitation note in the report.
+function stripLineCommentLines(content) {
+  return content
+    .split('\n')
+    .map((line) => (/^\s*(\/\/|\/\*|\*|#)/.test(line) ? '' : line))
+    .join('\n')
+}
+
+function countMatches(content, pattern) {
+  const re = new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`)
+  const matches = content.match(re)
+  return matches ? matches.length : 0
+}
+
+// ---------------------------------------------------------------------------
+// Access-log recipe (item 3) — text only, no execution, no DB.
+// ---------------------------------------------------------------------------
+
+function buildAccessLogRecipe({ windowDays }) {
+  return {
+    status: 'manual',
+    note: 'Operator-run recipe. This script does NOT execute it or read any access log.',
+    requiredOperatorInputs: ['ACCESS_LOG_PATH', 'RETENTION_SCOPE (which log retention window this covers)', 'OBSERVATION_WINDOW_START', 'OBSERVATION_WINDOW_END'],
+    suggestedObservationWindowDays: windowDays,
+    grepShape:
+      "grep 'POST /api/data-sources/' \"$ACCESS_LOG_PATH\"",
+    jqShape:
+      'jq -R \'select(test("POST /api/data-sources/[^ ]+/select"))\' \\\n' +
+      '  | jq -Rr \'capture("offset=(?<offset>[0-9]+)").offset? // empty\' # then cross-reference the same request for an absent orderBy param',
+    fullRecipe: [
+      '# Fill in ACCESS_LOG_PATH / RETENTION_SCOPE / OBSERVATION_WINDOW_START / OBSERVATION_WINDOW_END before running.',
+      '# Counts requests to POST /api/data-sources/:id/select where the request body or query',
+      '# carries offset>0 with no orderBy — the pattern PAGED_READ certification concerns itself with.',
+      'grep "POST /api/data-sources/" "$ACCESS_LOG_PATH" \\',
+      '  | awk -v start="$OBSERVATION_WINDOW_START" -v end="$OBSERVATION_WINDOW_END" \'$0 >= start && $0 <= end\' \\',
+      '  | grep -E \'"offset":\\s*[1-9][0-9]*\' \\',
+      '  | grep -vE \'"orderBy":\\s*"[^"]+"\' \\',
+      '  | wc -l',
+    ].join('\n'),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Residual blind spots (item 4) — always non-empty; a zero result elsewhere
+// in this report must never be read as "proven zero".
+// ---------------------------------------------------------------------------
+
+const STATIC_RESIDUAL_BLIND_SPOTS = Object.freeze([
+  {
+    id: 'adapter_telemetry_not_deployed',
+    description:
+      'The BaseAdapter chokepoint counter unorderedOffsetAttemptCount (offset>0 without orderBy) is NOT deployed/exposed anywhere in this codebase today (verified: zero repo hits) — the owner deliberately did not open that gate early. This inventory has no runtime signal for offset-without-orderBy calls that actually executed. A zero elsewhere in this report is DB/static coverage only, never proof of zero live risk.',
+  },
+  {
+    id: 'access_log_window_is_operator_supplied',
+    description:
+      'The access-log recipe in this report is not executed by this script. Its coverage is exactly whatever retention window and log scope the operator supplies when they run it by hand against a real deployment access log — nothing outside that window, and nothing on a path that does not log query/body parameters (e.g. some reverse-proxy configurations).',
+  },
+  {
+    id: 'db_inventory_scoped_to_target_kind',
+    description:
+      `The DB inventory (external systems / approved configs / pipelines / runs) is scoped to kind = '${TARGET_KIND}' only, per the B1c/PAGED_READ concern. It does not cross-check the general data_sources registry (item 1a, all types) against pagination usage — a data source of any type could in principle be reached via a caller this script's static enumeration did not anticipate.`,
+  },
+])
+
+function buildResidualBlindSpots(coverage) {
+  const dynamic = []
+  if (coverage.dataSources.status === 'unavailable') {
+    dynamic.push({ id: 'data_sources_table_gap', description: coverage.dataSources.reason })
+  } else if (coverage.dataSources.active.status === 'unavailable') {
+    dynamic.push({ id: 'data_sources_active_column_gap', description: coverage.dataSources.active.reason })
+  }
+  for (const [key, item] of [
+    ['external_systems_gap', coverage.externalSystems],
+    ['approved_configs_gap', coverage.approvedConfigs],
+    ['pipelines_gap', coverage.pipelines],
+    ['runs_window_gap', coverage.runsWindow],
+  ]) {
+    if (item.status === 'unavailable') {
+      dynamic.push({ id: key, description: item.reason })
+    }
+  }
+  return [...STATIC_RESIDUAL_BLIND_SPOTS, ...dynamic]
+}
+
+// ---------------------------------------------------------------------------
+// Verdict — a positive control: three distinct reachable outcomes.
+// ---------------------------------------------------------------------------
+
+function computeVerdict(coverage) {
+  const gapReasons = []
+  if (coverage.dataSources.status !== 'ok') gapReasons.push(`dataSources: ${coverage.dataSources.reason}`)
+  else if (coverage.dataSources.active.status !== 'ok') gapReasons.push(`dataSources.active: ${coverage.dataSources.active.reason}`)
+  if (coverage.externalSystems.status !== 'ok') gapReasons.push(`externalSystems: ${coverage.externalSystems.reason}`)
+  if (coverage.approvedConfigs.status !== 'ok') gapReasons.push(`approvedConfigs: ${coverage.approvedConfigs.reason}`)
+  if (coverage.pipelines.status !== 'ok') gapReasons.push(`pipelines: ${coverage.pipelines.reason}`)
+  if (coverage.runsWindow.status !== 'ok') gapReasons.push(`runsWindow: ${coverage.runsWindow.reason}`)
+  // staticCallSiteEnumeration is a declared coverage group (see COVERAGE_LABELS /
+  // report.coverage.staticCallSiteEnumeration) with a real fail-closed UNAVAILABLE
+  // state (anchor file missing/drifted — see enumerateStaticCallSites). A missing
+  // key counts as a gap too (fail closed on an absent signal, never fail open).
+  const staticCallSites = coverage.staticCallSiteEnumeration
+  if (!staticCallSites || staticCallSites.status !== 'ok') {
+    gapReasons.push(`staticCallSiteEnumeration: ${staticCallSites ? staticCallSites.reason : 'not supplied to computeVerdict'}`)
+  }
+
+  if (gapReasons.length > 0) {
+    return {
+      verdict: 'INCONCLUSIVE',
+      reasons: [`coverage is partial — ${gapReasons.length} item(s) UNAVAILABLE`, ...gapReasons],
+    }
+  }
+
+  const activeExternalSystems = coverage.externalSystems.byStatus.active
+  const riskSum = activeExternalSystems + coverage.approvedConfigs.count + coverage.pipelines.count + coverage.runsWindow.count
+
+  if (riskSum === 0) {
+    return {
+      verdict: 'MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE',
+      reasons: [
+        `all DB coverage items resolved (full schema coverage) and the kind='${coverage.externalSystems.kind}' risk surface is zero: 0 active external systems, 0 approved configs, 0 pipelines, 0 runs in the observation window`,
+        'this is a within-coverage finding only — see residualBlindSpots for what it does NOT prove',
+      ],
+    }
+  }
+
+  return {
+    verdict: 'MIGRATION_REQUIRED',
+    reasons: [
+      `kind='${coverage.externalSystems.kind}' exposure surface is non-zero within coverage (activeExternalSystems=${activeExternalSystems}, approvedConfigs=${coverage.approvedConfigs.count}, pipelines=${coverage.pipelines.count}, runsInWindow=${coverage.runsWindow.count}) — configuration/usage exists that a PAGED_READ semantics change would affect`,
+      'this does NOT mean a paging defect (offset>0 without orderBy) was found or ever executed — this report has no runtime signal for that at all; it means the surface exists and must be planned for. See residualBlindSpots, especially adapter_telemetry_not_deployed and access_log_window_is_operator_supplied, before treating this as anything more specific than "plan a migration".',
+    ],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Coverage labels — the brief requires every coverage item to state WHAT IT
+// COVERS and its BLIND SPOT, not just a residual-blind-spots afterthought.
+// ---------------------------------------------------------------------------
+
+const COVERAGE_LABELS = Object.freeze({
+  dbInventory: {
+    covers:
+      `config-driven plugin reads: registered/active data_sources by type; external systems, approved read-source configs, pipelines, and runs bound to kind='${TARGET_KIND}'.`,
+    blindSpot:
+      'DB rows only. A caller that reaches manager.select()/adapter.select() without ever registering a data_sources row, external system, pipeline, or run is invisible here — see staticCallSiteEnumeration for the code-path side of that gap.',
+  },
+  staticCallSiteEnumeration: {
+    covers:
+      "in-repo entry points: every static call site of manager.select() / adapter.select() / the POST /api/data-sources/:id/select route, plus DataSourceManager.copyData, found by scanning packages/core-backend/src and plugins.",
+    blindSpot:
+      'source code only, at the commit checked out when this ran. Says nothing about whether any call site ever executed, how often, or with what parameters — in particular, whether any real call used offset>0 without orderBy. It is also a line-based text scan, not an AST parse (see this item\'s own "limitation" field for the precision caveat).',
+  },
+  accessLogRecipe: {
+    covers:
+      'ad-hoc HTTP callers, within the operator-supplied observation window only: a grep/jq recipe to count POST /api/data-sources/:id/select requests carrying offset>0 with no orderBy in a real deployment access log.',
+    blindSpot:
+      'this script does not execute the recipe. Coverage is exactly the retention window and log scope the operator supplies by hand when they run it — nothing before/after that window, and nothing on a path that does not log the relevant request fields.',
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Report assembly
+// ---------------------------------------------------------------------------
+
+async function buildReport({ exec, windowDays = DEFAULT_WINDOW_DAYS, repoRoot = REPO_ROOT } = {}) {
+  const schema = await probeSchema(exec)
+  const plan = buildPlan(schema, { windowDays })
+  const coverage = await executePlan(exec, plan)
+  const staticCallSiteEnumeration = enumerateStaticCallSites({ repoRoot })
+  const accessLogRecipe = buildAccessLogRecipe({ windowDays })
+  const residualBlindSpots = buildResidualBlindSpots(coverage)
+  const { verdict, reasons } = computeVerdict({ ...coverage, staticCallSiteEnumeration })
+
+  return {
+    generatedAt: new Date().toISOString(),
+    mode: 'report',
+    observationWindow: { days: windowDays, unit: 'days', appliesTo: ['runsWindow', 'accessLogRecipe.suggestedObservationWindowDays'] },
+    targetKind: TARGET_KIND,
+    coverage: {
+      dbInventory: {
+        covers: COVERAGE_LABELS.dbInventory.covers,
+        blindSpot: COVERAGE_LABELS.dbInventory.blindSpot,
+        dataSources: coverage.dataSources,
+        externalSystemsByStatus: coverage.externalSystems,
+        approvedReadSourceConfigsBoundToKind: coverage.approvedConfigs,
+        pipelinesBySourceKind: coverage.pipelines,
+        runsByKindWithinWindow: coverage.runsWindow,
+      },
+      staticCallSiteEnumeration: {
+        covers: COVERAGE_LABELS.staticCallSiteEnumeration.covers,
+        blindSpot: COVERAGE_LABELS.staticCallSiteEnumeration.blindSpot,
+        ...staticCallSiteEnumeration,
+      },
+      accessLogRecipe: {
+        covers: COVERAGE_LABELS.accessLogRecipe.covers,
+        blindSpot: COVERAGE_LABELS.accessLogRecipe.blindSpot,
+        ...accessLogRecipe,
+      },
+    },
+    residualBlindSpots,
+    verdict,
+    verdictReasons: reasons,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dry-run / plan mode — resolves the SAME buildPlan() so the printed plan can
+// never show a query/column the schema probe would have refused. If no
+// executor is available (no live DB), falls back to a fully static listing of
+// the allowlist plus the always-DB-free parts (static enumeration, recipe,
+// blind spots) — still reviewable and testable without a DB.
+// ---------------------------------------------------------------------------
+
+async function buildDryRunReport({ exec, windowDays = DEFAULT_WINDOW_DAYS, repoRoot = REPO_ROOT } = {}) {
+  const staticCallSiteEnumeration = enumerateStaticCallSites({ repoRoot })
+  const accessLogRecipe = buildAccessLogRecipe({ windowDays })
+  const labeledCoverage = {
+    staticCallSiteEnumeration: {
+      covers: COVERAGE_LABELS.staticCallSiteEnumeration.covers,
+      blindSpot: COVERAGE_LABELS.staticCallSiteEnumeration.blindSpot,
+      ...staticCallSiteEnumeration,
+    },
+    accessLogRecipe: {
+      covers: COVERAGE_LABELS.accessLogRecipe.covers,
+      blindSpot: COVERAGE_LABELS.accessLogRecipe.blindSpot,
+      ...accessLogRecipe,
+    },
+  }
+
+  if (!exec) {
+    return {
+      generatedAt: new Date().toISOString(),
+      mode: 'dry-run-static',
+      note: 'No query executor / DATABASE_URL supplied — schema was not probed. This lists every allowlisted query and the (unresolved) conditional gating logic; see buildPlan() in the script source for exact resolution rules.',
+      observationWindow: { days: windowDays, unit: 'days' },
+      targetKind: TARGET_KIND,
+      allowlist: Object.fromEntries(Object.entries(QUERY_ALLOWLIST).map(([tag, e]) => [tag, { describe: e.describe, sql: e.sql }])),
+      coverage: labeledCoverage,
+      residualBlindSpots: STATIC_RESIDUAL_BLIND_SPOTS,
+    }
+  }
+
+  const schema = await probeSchema(exec)
+  const plan = buildPlan(schema, { windowDays })
+
+  function describePlanItem(item) {
+    if (item.status !== 'ok') return { status: 'unavailable', reason: item.reason }
+    if (item.registered) {
+      // dataSources shape: nested registered/active plans
+      const out = {
+        status: 'ok',
+        registered: { tag: item.registered.tag, sql: QUERY_ALLOWLIST[item.registered.tag].sql, params: item.registered.params },
+      }
+      out.active =
+        item.active.status === 'ok'
+          ? { status: 'ok', tag: item.active.tag, sql: QUERY_ALLOWLIST[item.active.tag].sql, params: item.active.params }
+          : { status: 'unavailable', reason: item.active.reason }
+      return out
+    }
+    return { status: 'ok', tag: item.tag, sql: QUERY_ALLOWLIST[item.tag].sql, params: item.params }
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    mode: 'dry-run',
+    note: 'Schema WAS probed (read-only information_schema queries). No aggregate/count query below was executed — this is exactly what report mode would run next.',
+    observationWindow: { days: windowDays, unit: 'days' },
+    targetKind: TARGET_KIND,
+    schema,
+    plan: {
+      covers: COVERAGE_LABELS.dbInventory.covers,
+      blindSpot: COVERAGE_LABELS.dbInventory.blindSpot,
+      dataSources: describePlanItem(plan.dataSources),
+      externalSystems: describePlanItem(plan.externalSystems),
+      approvedConfigs: describePlanItem(plan.approvedConfigs),
+      pipelines: describePlanItem(plan.pipelines),
+      runsWindow: describePlanItem(plan.runsWindow),
+    },
+    coverage: labeledCoverage,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+function renderHumanSummary(report) {
+  const lines = []
+  lines.push(`data-source-exposure-inventory — mode=${report.mode} generatedAt=${report.generatedAt}`)
+  if (report.mode === 'report') {
+    lines.push(`verdict: ${report.verdict}`)
+    for (const r of report.verdictReasons) lines.push(`  - ${r}`)
+    lines.push('')
+    lines.push('coverage:')
+    const db = report.coverage.dbInventory
+    lines.push(`  data_sources:            ${db.dataSources.status}${db.dataSources.status === 'ok' ? ` (registeredTotal=${db.dataSources.registeredTotal}, active=${db.dataSources.active.status === 'ok' ? db.dataSources.active.total : 'UNAVAILABLE'})` : ` (${db.dataSources.reason})`}`)
+    lines.push(`  external_systems(${report.targetKind}): ${db.externalSystemsByStatus.status}${db.externalSystemsByStatus.status === 'ok' ? ` (total=${db.externalSystemsByStatus.total})` : ` (${db.externalSystemsByStatus.reason})`}`)
+    lines.push(`  approved_configs:        ${db.approvedReadSourceConfigsBoundToKind.status}${db.approvedReadSourceConfigsBoundToKind.status === 'ok' ? ` (count=${db.approvedReadSourceConfigsBoundToKind.count})` : ` (${db.approvedReadSourceConfigsBoundToKind.reason})`}`)
+    lines.push(`  pipelines:               ${db.pipelinesBySourceKind.status}${db.pipelinesBySourceKind.status === 'ok' ? ` (count=${db.pipelinesBySourceKind.count})` : ` (${db.pipelinesBySourceKind.reason})`}`)
+    lines.push(`  runs (window=${report.observationWindow.days}d):     ${db.runsByKindWithinWindow.status}${db.runsByKindWithinWindow.status === 'ok' ? ` (count=${db.runsByKindWithinWindow.count})` : ` (${db.runsByKindWithinWindow.reason})`}`)
+    lines.push(`  static call sites:       ${report.coverage.staticCallSiteEnumeration.status}`)
+    lines.push('')
+    lines.push('residual blind spots (this report NEVER proves zero live risk beyond these):')
+    for (const b of report.residualBlindSpots) lines.push(`  - [${b.id}] ${b.description}`)
+  } else {
+    lines.push(report.note)
+    lines.push(`static call sites: ${report.coverage.staticCallSiteEnumeration.status}`)
+  }
+  return lines.join('\n') + '\n'
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const opts = { dryRun: false, windowDays: DEFAULT_WINDOW_DAYS, json: false, help: false }
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i]
+    switch (a) {
+      case '--dry-run':
+      case '--plan':
+        opts.dryRun = true
+        break
+      case '--window-days': {
+        const next = Number.parseInt(argv[++i], 10)
+        if (!Number.isFinite(next) || next < MIN_WINDOW_DAYS || next > MAX_WINDOW_DAYS) {
+          throw new Error(`--window-days must be an integer between ${MIN_WINDOW_DAYS} and ${MAX_WINDOW_DAYS}`)
+        }
+        opts.windowDays = next
+        break
+      }
+      case '--json':
+        opts.json = true
+        break
+      case '--help':
+      case '-h':
+        opts.help = true
+        break
+      default:
+        throw new Error(`unknown argument: ${a}`)
+    }
+  }
+  return opts
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'data-source-exposure-inventory.mjs — values-free, schema-probing exposure inventory for the',
+      "manager.select()/adapter.select() read path bound to kind='" + TARGET_KIND + "'.",
+      '',
+      'Usage:',
+      '  DATABASE_URL=postgres://… node scripts/ops/data-source-exposure-inventory.mjs [--window-days N] [--json]',
+      '  node scripts/ops/data-source-exposure-inventory.mjs --dry-run [--window-days N]',
+      '',
+      'Options:',
+      '  --dry-run, --plan     Print the query plan without executing counts. Works without DATABASE_URL',
+      '                        (falls back to a static allowlist listing) or with it (schema-probed, concrete plan).',
+      '  --window-days N       Observation window for the runs-in-window count and the access-log recipe. Default 30.',
+      '  --json                Print only the machine-readable JSON report (no human summary).',
+      '  --help                Show this help.',
+      '',
+    ].join('\n'),
+  )
+}
+
+async function createPgExecutor(databaseUrl) {
+  // Lazy import: `pg` must never be required at module load, or a hermetic
+  // `node --test` CI job with no `node_modules` (no pnpm install step) fails
+  // at import time before a single test runs.
+  const { default: pg } = await import('pg')
+  const pool = new pg.Pool({ connectionString: databaseUrl, max: 2 })
+  return {
+    exec: (sql, params) => pool.query(sql, params),
+    close: () => pool.end(),
+  }
+}
+
+async function main(argv = process.argv.slice(2), env = process.env) {
+  let opts
+  try {
+    opts = parseArgs(argv)
+  } catch (err) {
+    process.stderr.write(`[data-source-exposure-inventory] ERROR: ${err.message}\n`)
+    return 1
+  }
+  if (opts.help) {
+    printHelp()
+    return 0
+  }
+
+  const databaseUrl = (env.DATABASE_URL || '').trim()
+
+  if (opts.dryRun) {
+    let executor = null
+    try {
+      if (databaseUrl) executor = await createPgExecutor(databaseUrl)
+      const report = await buildDryRunReport({ exec: executor ? executor.exec : null, windowDays: opts.windowDays })
+      if (opts.json) {
+        process.stdout.write(JSON.stringify(report, null, 2) + '\n')
+      } else {
+        process.stdout.write(renderHumanSummary(report))
+        process.stdout.write('\n' + JSON.stringify(report, null, 2) + '\n')
+      }
+      return 0
+    } catch (err) {
+      process.stderr.write(`[data-source-exposure-inventory] ERROR: ${err instanceof Error ? err.message : String(err)}\n`)
+      return 1
+    } finally {
+      if (executor) await executor.close()
+    }
+  }
+
+  if (!databaseUrl) {
+    process.stderr.write('[data-source-exposure-inventory] ERROR: DATABASE_URL is required outside --dry-run\n')
+    return 2
+  }
+
+  let executor
+  try {
+    executor = await createPgExecutor(databaseUrl)
+    const report = await buildReport({ exec: executor.exec, windowDays: opts.windowDays })
+    if (opts.json) {
+      process.stdout.write(JSON.stringify(report, null, 2) + '\n')
+    } else {
+      process.stdout.write(renderHumanSummary(report))
+      process.stdout.write('\n' + JSON.stringify(report, null, 2) + '\n')
+    }
+    return 0
+  } catch (err) {
+    process.stderr.write(`[data-source-exposure-inventory] ERROR: ${err instanceof Error ? err.message : String(err)}\n`)
+    return 1
+  } finally {
+    if (executor) await executor.close()
+  }
+}
+
+const entryPath = process.argv[1] ? path.resolve(process.argv[1]) : null
+const isEntry = entryPath && entryPath === fileURLToPath(import.meta.url)
+if (isEntry) {
+  main().then((code) => {
+    process.exitCode = code
+  })
+}
+
+export {
+  QUERY_ALLOWLIST,
+  SUPPORTED_DATA_SOURCE_TYPES,
+  EXTERNAL_SYSTEM_STATUSES,
+  TARGET_KIND,
+  DEFAULT_WINDOW_DAYS,
+  assertReadOnlyAllowlist,
+  runQuery,
+  tableExists,
+  probeColumns,
+  probeSchema,
+  buildPlan,
+  bucketDataSourceTypeCounts,
+  bucketExternalSystemStatusCounts,
+  executePlan,
+  enumerateStaticCallSites,
+  buildAccessLogRecipe,
+  buildResidualBlindSpots,
+  STATIC_RESIDUAL_BLIND_SPOTS,
+  computeVerdict,
+  buildReport,
+  buildDryRunReport,
+  renderHumanSummary,
+  parseArgs,
+  main,
+  REPO_ROOT,
+}

--- a/scripts/ops/data-source-exposure-inventory.mjs
+++ b/scripts/ops/data-source-exposure-inventory.mjs
@@ -73,8 +73,9 @@ const REPO_ROOT = path.resolve(path.dirname(__filename), '../..')
 // ---------------------------------------------------------------------------
 
 // Mirrors packages/core-backend/src/data-adapters/DataSourceManager.ts
-// `SUPPORTED_DATA_SOURCE_TYPES` (pinned by commit 68bcd9a67 / #4583). Keep in sync manually —
-// this script has no automated drift guard against that file (a possible follow-up).
+// `SUPPORTED_DATA_SOURCE_TYPES` (pinned by commit 68bcd9a67 / #4583). The
+// contract test derives the authoritative keys from DEFAULT_ADAPTER_REGISTRY,
+// and the workflow reruns when DataSourceManager.ts changes.
 const SUPPORTED_DATA_SOURCE_TYPES = Object.freeze([
   'postgresql',
   'postgres',
@@ -98,12 +99,12 @@ const MIN_WINDOW_DAYS = 1
 const MAX_WINDOW_DAYS = 365
 
 // Appended to every "table/column not found" reason. information_schema only
-// reports objects visible to the connected role in the schemas on its
-// search_path — a non-'public' search_path, or a role that was never granted
-// SELECT/USAGE on the object, is indistinguishable from a genuinely absent
-// table/column, and will UNAVAILABLE that item too.
+// reports objects visible to the connected role. A role that was never granted
+// the required privileges is indistinguishable from a genuinely absent object
+// and will UNAVAILABLE that item too. Count queries explicitly qualify the same
+// public schema, so connection-level search_path cannot redirect them elsewhere.
 const SCHEMA_PROBE_CAVEAT =
-  "probed via information_schema.tables/.columns, table_schema='public', as the DATABASE_URL role — a non-public search_path or missing SELECT/USAGE privileges reports the same as a genuinely absent object"
+  "probed via information_schema.tables/.columns, table_schema='public', as the DATABASE_URL role — missing visibility/privileges report the same as a genuinely absent object"
 
 // ---------------------------------------------------------------------------
 // QUERY_ALLOWLIST — the ONLY SQL statements this script will ever execute.
@@ -113,7 +114,7 @@ const SCHEMA_PROBE_CAVEAT =
 
 const QUERY_ALLOWLIST = Object.freeze({
   'probe.table_exists': {
-    sql: `SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = $1 LIMIT 1`,
+    sql: `SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = $1 AND table_type = 'BASE TABLE' LIMIT 1`,
     describe: 'schema probe: does table $1 exist',
   },
   'probe.columns': {
@@ -121,40 +122,40 @@ const QUERY_ALLOWLIST = Object.freeze({
     describe: 'schema probe: which columns exist on table $1',
   },
   'count.data_sources_all_types': {
-    sql: `SELECT type, count(*)::int AS n FROM data_sources GROUP BY type`,
+    sql: `SELECT type, count(*)::bigint AS n FROM public.data_sources GROUP BY type`,
     describe: 'registered data_sources grouped by type',
   },
   'count.data_sources_active_types.with_deleted_at': {
-    sql: `SELECT type, count(*)::int AS n FROM data_sources WHERE is_active = true AND deleted_at IS NULL GROUP BY type`,
+    sql: `SELECT type, count(*)::bigint AS n FROM public.data_sources WHERE is_active = true AND deleted_at IS NULL GROUP BY type`,
     describe: 'active, non-soft-deleted data_sources grouped by type (modern schema shape)',
   },
   'count.data_sources_active_types.without_deleted_at': {
-    sql: `SELECT type, count(*)::int AS n FROM data_sources WHERE is_active = true GROUP BY type`,
+    sql: `SELECT type, count(*)::bigint AS n FROM public.data_sources WHERE is_active = true GROUP BY type`,
     describe: 'active data_sources grouped by type (is_active present, no deleted_at column)',
   },
   'count.external_systems_status_by_kind': {
-    sql: `SELECT status, count(*)::int AS n FROM integration_external_systems WHERE kind = $1 GROUP BY status`,
+    sql: `SELECT status, count(*)::bigint AS n FROM public.integration_external_systems WHERE kind = $1 GROUP BY status`,
     describe: 'integration_external_systems of a given kind, grouped by status',
   },
   'count.approved_read_source_configs_by_kind': {
-    sql: `SELECT count(*)::int AS n
-          FROM integration_read_source_configs c
-          JOIN integration_external_systems s ON s.id = c.system_id
+    sql: `SELECT count(*)::bigint AS n
+          FROM public.integration_read_source_configs c
+          JOIN public.integration_external_systems s ON s.id = c.system_id
           WHERE s.kind = $1 AND c.status = 'approved'`,
     describe: 'approved integration_read_source_configs bound to external systems of a given kind',
   },
   'count.pipelines_by_source_kind': {
-    sql: `SELECT count(*)::int AS n
-          FROM integration_pipelines p
-          JOIN integration_external_systems s ON s.id = p.source_system_id
+    sql: `SELECT count(*)::bigint AS n
+          FROM public.integration_pipelines p
+          JOIN public.integration_external_systems s ON s.id = p.source_system_id
           WHERE s.kind = $1`,
     describe: 'integration_pipelines whose source_system_id resolves to a given kind',
   },
   'count.runs_by_kind_window': {
-    sql: `SELECT count(*)::int AS n
-          FROM integration_runs r
-          JOIN integration_pipelines p ON p.id = r.pipeline_id
-          JOIN integration_external_systems s ON s.id = p.source_system_id
+    sql: `SELECT count(*)::bigint AS n
+          FROM public.integration_runs r
+          JOIN public.integration_pipelines p ON p.id = r.pipeline_id
+          JOIN public.integration_external_systems s ON s.id = p.source_system_id
           WHERE s.kind = $1 AND r.created_at >= NOW() - make_interval(days => $2::int)`,
     describe: 'integration_runs within a window, for pipelines whose source resolves to a given kind',
   },
@@ -352,17 +353,30 @@ function buildPlan(schema, { windowDays = DEFAULT_WINDOW_DAYS, kind = TARGET_KIN
 // not already exist as one of these fixed constants.
 // ---------------------------------------------------------------------------
 
+function normalizeCount(value) {
+  if (Number.isSafeInteger(value) && value >= 0) return value
+  if (typeof value === 'string' && /^(0|[1-9][0-9]*)$/.test(value)) {
+    const parsed = Number(value)
+    if (Number.isSafeInteger(parsed)) return parsed
+  }
+  throw new Error('data-source-exposure-inventory: invalid aggregate count')
+}
+
+function addCounts(left, right) {
+  return normalizeCount(left + right)
+}
+
 function bucketDataSourceTypeCounts(rows) {
   const buckets = Object.fromEntries(SUPPORTED_DATA_SOURCE_TYPES.map((t) => [t, 0]))
   buckets.other = 0
   let total = 0
   for (const row of rows) {
-    const n = Number(row.n) || 0
-    total += n
+    const n = normalizeCount(row.n)
+    total = addCounts(total, n)
     if (SUPPORTED_DATA_SOURCE_TYPES.includes(row.type)) {
-      buckets[row.type] += n
+      buckets[row.type] = addCounts(buckets[row.type], n)
     } else {
-      buckets.other += n
+      buckets.other = addCounts(buckets.other, n)
     }
   }
   return { buckets, total }
@@ -373,12 +387,12 @@ function bucketExternalSystemStatusCounts(rows) {
   buckets.unexpected = 0
   let total = 0
   for (const row of rows) {
-    const n = Number(row.n) || 0
-    total += n
+    const n = normalizeCount(row.n)
+    total = addCounts(total, n)
     if (EXTERNAL_SYSTEM_STATUSES.includes(row.status)) {
-      buckets[row.status] += n
+      buckets[row.status] = addCounts(buckets[row.status], n)
     } else {
-      buckets.unexpected += n
+      buckets.unexpected = addCounts(buckets.unexpected, n)
     }
   }
   return { buckets, total }
@@ -420,7 +434,10 @@ async function executeExternalSystemsPlan(exec, plan) {
 async function executeScalarCountPlan(exec, plan) {
   if (plan.status !== 'ok') return plan
   const { rows } = await runQuery(exec, plan.tag, plan.params)
-  const count = rows.length ? Number(rows[0].n) || 0 : 0
+  if (rows.length !== 1) {
+    throw new Error('data-source-exposure-inventory: invalid aggregate row count')
+  }
+  const count = normalizeCount(rows[0].n)
   return { status: 'ok', count }
 }
 
@@ -441,19 +458,27 @@ async function executePlan(exec, plan) {
 // silently reporting zero call sites because of a wrong repoRoot / cwd.
 // ---------------------------------------------------------------------------
 
-// Verified against the real files at authoring time:
-//   - packages/core-backend/src/routes/data-sources.ts:864
+// Verified against the real symbols at authoring time and rechecked by anchors:
+//   - plugins/plugin-integration-core/lib/pipeline-runner.cjs
+//       DATA_SOURCE_SQL_READONLY_KIND
+//   - packages/core-backend/src/routes/data-sources.ts
 //       router.post('/api/data-sources/:id/select', ...)
-//   - packages/core-backend/src/data-adapters/DataSourceManager.ts:780
+//   - packages/core-backend/src/data-adapters/DataSourceManager.ts
 //       sourceAdapter.select(...) inside DataSourceManager.select
-//   - packages/core-backend/src/data-adapters/DataSourceManager.ts:746
+//   - packages/core-backend/src/data-adapters/DataSourceManager.ts
 //       async copyData(...) — has no live in-tree caller (verified: repo-wide
 //       grep for `.copyData(` outside this file's own definition line and
 //       outside univer-meta.ts's unrelated `copyData` object-literal variable
 //       found zero call sites)
-//   - plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs:384
+//   - plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs
 //       api.select(...)
 const DEFAULT_ANCHORS = Object.freeze([
+  {
+    id: 'target_kind',
+    file: 'plugins/plugin-integration-core/lib/pipeline-runner.cjs',
+    pattern:
+      /const\s+DATA_SOURCE_SQL_READONLY_KIND\s*=\s*'data-source:sql-readonly'/,
+  },
   {
     id: 'select_route',
     file: 'packages/core-backend/src/routes/data-sources.ts',
@@ -484,18 +509,19 @@ const SELECT_CALL_PATTERN = /\b(?:manager|adapter|sourceAdapter|api)\.select\s*\
 const COPY_DATA_CALL_PATTERN = /\.copyData\s*\(/
 const SELECT_ROUTE_STRING_PATTERN = /'\/api\/data-sources\/:id\/select'/
 
-function walkFiles(rootAbs, extSet, out) {
+function walkFiles(rootAbs, extSet, out, failures) {
   let entries
   try {
     entries = readdirSync(rootAbs, { withFileTypes: true })
   } catch {
+    failures.push('directory_read_failed')
     return
   }
   for (const entry of entries) {
     if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name.startsWith('.')) continue
     const fullAbs = path.join(rootAbs, entry.name)
     if (entry.isDirectory()) {
-      walkFiles(fullAbs, extSet, out)
+      walkFiles(fullAbs, extSet, out, failures)
     } else if (extSet.has(path.extname(entry.name))) {
       out.push(fullAbs)
     }
@@ -533,8 +559,19 @@ function enumerateStaticCallSites({ repoRoot = REPO_ROOT, anchors = DEFAULT_ANCH
   }
 
   const files = []
+  const scanFailures = []
   for (const root of scanRoots) {
-    walkFiles(path.join(repoRoot, root), SCAN_EXTENSIONS, files)
+    walkFiles(path.join(repoRoot, root), SCAN_EXTENSIONS, files, scanFailures)
+  }
+  if (scanFailures.length > 0) {
+    return {
+      status: 'unavailable',
+      reason:
+        'one or more declared scan roots or directories could not be read — refusing to report a partial caller count',
+      anchorsVerified,
+      anchorsMissing,
+      scanFailureCount: scanFailures.length,
+    }
   }
 
   const counts = {
@@ -550,6 +587,7 @@ function enumerateStaticCallSites({ repoRoot = REPO_ROOT, anchors = DEFAULT_ANCH
     try {
       content = readFileSync(fileAbs, 'utf8')
     } catch {
+      scanFailures.push('file_read_failed')
       continue
     }
     const bucket = isTest ? 'test' : 'nonTest'
@@ -557,6 +595,16 @@ function enumerateStaticCallSites({ repoRoot = REPO_ROOT, anchors = DEFAULT_ANCH
     counts.managerOrAdapterSelectCallSites[bucket] += countMatches(codeOnly, SELECT_CALL_PATTERN)
     counts.copyDataCallSites[bucket] += countMatches(codeOnly, COPY_DATA_CALL_PATTERN)
     counts.selectRouteDefinitions[bucket] += countMatches(codeOnly, SELECT_ROUTE_STRING_PATTERN)
+  }
+  if (scanFailures.length > 0) {
+    return {
+      status: 'unavailable',
+      reason:
+        'one or more declared source files could not be read — refusing to report a partial caller count',
+      anchorsVerified,
+      anchorsMissing,
+      scanFailureCount: scanFailures.length,
+    }
   }
 
   return {
@@ -651,7 +699,10 @@ const STATIC_RESIDUAL_BLIND_SPOTS = Object.freeze([
   },
 ])
 
-function buildResidualBlindSpots(coverage) {
+function buildResidualBlindSpots(
+  coverage,
+  { staticCallSiteEnumeration = null } = {},
+) {
   const dynamic = []
   if (coverage.dataSources.status === 'unavailable') {
     dynamic.push({ id: 'data_sources_table_gap', description: coverage.dataSources.reason })
@@ -668,6 +719,15 @@ function buildResidualBlindSpots(coverage) {
       dynamic.push({ id: key, description: item.reason })
     }
   }
+  if (
+    staticCallSiteEnumeration &&
+    staticCallSiteEnumeration.status !== 'ok'
+  ) {
+    dynamic.push({
+      id: 'static_call_site_enumeration_gap',
+      description: staticCallSiteEnumeration.reason,
+    })
+  }
   return [...STATIC_RESIDUAL_BLIND_SPOTS, ...dynamic]
 }
 
@@ -680,6 +740,14 @@ function computeVerdict(coverage) {
   if (coverage.dataSources.status !== 'ok') gapReasons.push(`dataSources: ${coverage.dataSources.reason}`)
   else if (coverage.dataSources.active.status !== 'ok') gapReasons.push(`dataSources.active: ${coverage.dataSources.active.reason}`)
   if (coverage.externalSystems.status !== 'ok') gapReasons.push(`externalSystems: ${coverage.externalSystems.reason}`)
+  else if (
+    !Number.isSafeInteger(coverage.externalSystems.byStatus?.unexpected) ||
+    coverage.externalSystems.byStatus.unexpected !== 0
+  ) {
+    gapReasons.push(
+      'externalSystems: status vocabulary drift detected; unexpected bucket must be exactly zero',
+    )
+  }
   if (coverage.approvedConfigs.status !== 'ok') gapReasons.push(`approvedConfigs: ${coverage.approvedConfigs.reason}`)
   if (coverage.pipelines.status !== 'ok') gapReasons.push(`pipelines: ${coverage.pipelines.reason}`)
   if (coverage.runsWindow.status !== 'ok') gapReasons.push(`runsWindow: ${coverage.runsWindow.reason}`)
@@ -757,7 +825,9 @@ async function buildReport({ exec, windowDays = DEFAULT_WINDOW_DAYS, repoRoot = 
   const coverage = await executePlan(exec, plan)
   const staticCallSiteEnumeration = enumerateStaticCallSites({ repoRoot })
   const accessLogRecipe = buildAccessLogRecipe({ windowDays })
-  const residualBlindSpots = buildResidualBlindSpots(coverage)
+  const residualBlindSpots = buildResidualBlindSpots(coverage, {
+    staticCallSiteEnumeration,
+  })
   const { verdict, reasons } = computeVerdict({ ...coverage, staticCallSiteEnumeration })
 
   return {
@@ -912,8 +982,12 @@ function parseArgs(argv) {
         opts.dryRun = true
         break
       case '--window-days': {
-        const next = Number.parseInt(argv[++i], 10)
-        if (!Number.isFinite(next) || next < MIN_WINDOW_DAYS || next > MAX_WINDOW_DAYS) {
+        const raw = argv[++i]
+        const next =
+          typeof raw === 'string' && /^(0|[1-9][0-9]*)$/.test(raw)
+            ? Number(raw)
+            : Number.NaN
+        if (!Number.isSafeInteger(next) || next < MIN_WINDOW_DAYS || next > MAX_WINDOW_DAYS) {
           throw new Error(`--window-days must be an integer between ${MIN_WINDOW_DAYS} and ${MAX_WINDOW_DAYS}`)
         }
         opts.windowDays = next
@@ -966,12 +1040,31 @@ async function createPgExecutor(databaseUrl) {
   }
 }
 
-async function main(argv = process.argv.slice(2), env = process.env) {
+function writeClosedError(reason) {
+  process.stderr.write(`[data-source-exposure-inventory] ERROR: ${reason}\n`)
+}
+
+async function closeExecutor(executor) {
+  if (!executor) return true
+  try {
+    await executor.close()
+    return true
+  } catch {
+    writeClosedError('INVENTORY_CLEANUP_FAILED')
+    return false
+  }
+}
+
+async function main(
+  argv = process.argv.slice(2),
+  env = process.env,
+  { executorFactory = createPgExecutor } = {},
+) {
   let opts
   try {
     opts = parseArgs(argv)
-  } catch (err) {
-    process.stderr.write(`[data-source-exposure-inventory] ERROR: ${err.message}\n`)
+  } catch {
+    writeClosedError('INVENTORY_ARGUMENT_INVALID')
     return 1
   }
   if (opts.help) {
@@ -983,8 +1076,9 @@ async function main(argv = process.argv.slice(2), env = process.env) {
 
   if (opts.dryRun) {
     let executor = null
+    let exitCode = 0
     try {
-      if (databaseUrl) executor = await createPgExecutor(databaseUrl)
+      if (databaseUrl) executor = await executorFactory(databaseUrl)
       const report = await buildDryRunReport({ exec: executor ? executor.exec : null, windowDays: opts.windowDays })
       if (opts.json) {
         process.stdout.write(JSON.stringify(report, null, 2) + '\n')
@@ -992,23 +1086,23 @@ async function main(argv = process.argv.slice(2), env = process.env) {
         process.stdout.write(renderHumanSummary(report))
         process.stdout.write('\n' + JSON.stringify(report, null, 2) + '\n')
       }
-      return 0
-    } catch (err) {
-      process.stderr.write(`[data-source-exposure-inventory] ERROR: ${err instanceof Error ? err.message : String(err)}\n`)
-      return 1
-    } finally {
-      if (executor) await executor.close()
+    } catch {
+      writeClosedError('INVENTORY_EXECUTION_FAILED')
+      exitCode = 1
     }
+    if (!(await closeExecutor(executor))) exitCode = 1
+    return exitCode
   }
 
   if (!databaseUrl) {
-    process.stderr.write('[data-source-exposure-inventory] ERROR: DATABASE_URL is required outside --dry-run\n')
+    writeClosedError('INVENTORY_DATABASE_URL_REQUIRED')
     return 2
   }
 
-  let executor
+  let executor = null
+  let exitCode = 0
   try {
-    executor = await createPgExecutor(databaseUrl)
+    executor = await executorFactory(databaseUrl)
     const report = await buildReport({ exec: executor.exec, windowDays: opts.windowDays })
     if (opts.json) {
       process.stdout.write(JSON.stringify(report, null, 2) + '\n')
@@ -1016,13 +1110,12 @@ async function main(argv = process.argv.slice(2), env = process.env) {
       process.stdout.write(renderHumanSummary(report))
       process.stdout.write('\n' + JSON.stringify(report, null, 2) + '\n')
     }
-    return 0
-  } catch (err) {
-    process.stderr.write(`[data-source-exposure-inventory] ERROR: ${err instanceof Error ? err.message : String(err)}\n`)
-    return 1
-  } finally {
-    if (executor) await executor.close()
+  } catch {
+    writeClosedError('INVENTORY_EXECUTION_FAILED')
+    exitCode = 1
   }
+  if (!(await closeExecutor(executor))) exitCode = 1
+  return exitCode
 }
 
 const entryPath = process.argv[1] ? path.resolve(process.argv[1]) : null
@@ -1045,6 +1138,7 @@ export {
   probeColumns,
   probeSchema,
   buildPlan,
+  normalizeCount,
   bucketDataSourceTypeCounts,
   bucketExternalSystemStatusCounts,
   executePlan,

--- a/scripts/ops/data-source-exposure-inventory.test.mjs
+++ b/scripts/ops/data-source-exposure-inventory.test.mjs
@@ -1,0 +1,987 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import {
+  QUERY_ALLOWLIST,
+  SUPPORTED_DATA_SOURCE_TYPES,
+  EXTERNAL_SYSTEM_STATUSES,
+  TARGET_KIND,
+  assertReadOnlyAllowlist,
+  probeSchema,
+  buildPlan,
+  bucketDataSourceTypeCounts,
+  bucketExternalSystemStatusCounts,
+  executePlan,
+  enumerateStaticCallSites,
+  buildAccessLogRecipe,
+  buildResidualBlindSpots,
+  STATIC_RESIDUAL_BLIND_SPOTS,
+  computeVerdict,
+  buildReport,
+  buildDryRunReport,
+  parseArgs,
+  main,
+} from './data-source-exposure-inventory.mjs'
+
+// ---------------------------------------------------------------------------
+// Fake DB harness
+// ---------------------------------------------------------------------------
+
+const SQL_TO_TAG = new Map(Object.entries(QUERY_ALLOWLIST).map(([tag, e]) => [e.sql, tag]))
+
+/**
+ * Builds a fake query executor from a schema description and a set of count
+ * fixtures. Dispatch is by exact SQL-string identity against QUERY_ALLOWLIST
+ * (never by regex/substring guessing), so a query the script does not
+ * actually construct simply has no matching tag and throws "unrecognized sql".
+ *
+ * `counts[tag]` fixtures are OPTIONAL by design: if the plan never resolves
+ * that tag to 'ok' (because a schema probe said a table/column is missing),
+ * the corresponding count query must never be sent — and if it were sent,
+ * this fake would throw "no fixture configured", which is exactly the
+ * "never emits a query against an unverified shape" assertion made real.
+ */
+function createFakeExec({ schema, counts = {} }, calls = null) {
+  return async (sql, params) => {
+    const tag = SQL_TO_TAG.get(sql)
+    if (!tag) {
+      throw new Error(`fake exec: SQL string is not on QUERY_ALLOWLIST (unrecognized): ${sql}`)
+    }
+    if (calls) calls.push({ tag, sql, params })
+
+    if (tag === 'probe.table_exists') {
+      const [tableName] = params
+      const t = schema[tableName]
+      return { rows: t && t.exists ? [{ '?column?': 1 }] : [] }
+    }
+    if (tag === 'probe.columns') {
+      const [tableName] = params
+      const t = schema[tableName]
+      const cols = t && t.exists ? t.columns : []
+      return { rows: cols.map((c) => ({ column_name: c })) }
+    }
+
+    const handler = counts[tag]
+    if (!handler) {
+      throw new Error(`fake exec: no count fixture configured for tag "${tag}" — the plan should never have run this query`)
+    }
+    const rows = typeof handler === 'function' ? handler(params) : handler
+    return { rows }
+  }
+}
+
+const FULL_SCHEMA = Object.freeze({
+  data_sources: { exists: true, columns: ['type', 'is_active', 'deleted_at', 'status'] },
+  integration_external_systems: { exists: true, columns: ['id', 'kind', 'status'] },
+  integration_read_source_configs: { exists: true, columns: ['system_id', 'status'] },
+  integration_pipelines: { exists: true, columns: ['id', 'source_system_id'] },
+  integration_runs: { exists: true, columns: ['id', 'pipeline_id', 'created_at'] },
+})
+
+function cloneSchema(overrides = {}) {
+  const base = JSON.parse(JSON.stringify(FULL_SCHEMA))
+  for (const [table, patch] of Object.entries(overrides)) {
+    base[table] = { ...base[table], ...patch }
+  }
+  return base
+}
+
+const ZERO_COUNTS = Object.freeze({
+  'count.data_sources_all_types': [],
+  'count.data_sources_active_types.with_deleted_at': [],
+  'count.external_systems_status_by_kind': [],
+  'count.approved_read_source_configs_by_kind': [{ n: 0 }],
+  'count.pipelines_by_source_kind': [{ n: 0 }],
+  'count.runs_by_kind_window': [{ n: 0 }],
+})
+
+// ---------------------------------------------------------------------------
+// QUERY_ALLOWLIST semantic-invariant extraction helpers (P1).
+//
+// createFakeExec dispatches by exact SQL-string identity against a SQL_TO_TAG
+// map built from the SAME QUERY_ALLOWLIST under test. That makes every test
+// above this comment self-consistent under corruption of the allowlist's SQL
+// text: if the SQL is mutated, SQL_TO_TAG is rebuilt from the mutated text and
+// the fake exec still "recognizes" it — the mutation is invisible to those
+// tests no matter how wrong the resulting query would be against a real
+// database. These helpers instead read the allowlist's SQL TEXT directly and
+// assert semantic invariants against it: which tables it touches, which
+// literal values it compares against, and its WHERE-clause predicate — the
+// three things the prior NO-GO's errors got wrong (wrong table name, wrong
+// status literal) plus the window predicate direction.
+//
+// Whitespace/formatting differences are normalized away (collapsed to single
+// spaces) so a harmless reformat of the template-literal SQL does not go red;
+// a changed table, a changed/added literal, or a changed predicate does.
+// ---------------------------------------------------------------------------
+
+function normalizeSql(sql) {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
+// Every identifier immediately following FROM or JOIN, lowercased and
+// deduplicated. Catches a swapped table name anywhere in the statement
+// (e.g. the prior NO-GO's `integration_pipeline_runs` for `integration_runs`).
+function extractTables(sql) {
+  const re = /\b(?:FROM|JOIN)\s+([a-zA-Z_][a-zA-Z0-9_]*)/gi
+  const tables = new Set()
+  let m
+  while ((m = re.exec(sql))) tables.add(m[1].toLowerCase())
+  return [...tables].sort()
+}
+
+// Every single-quoted string literal in the statement, sorted. Catches any
+// reintroduced status-vocabulary literal (the prior NO-GO's `<> 'disabled'`
+// is a comparison against the literal 'disabled' — this flags that literal's
+// mere presence, not just that one exact operator/spelling).
+function extractQuotedLiterals(sql) {
+  const re = /'([^']*)'/g
+  const out = []
+  let m
+  while ((m = re.exec(sql))) out.push(m[1])
+  return out.sort()
+}
+
+// The WHERE-clause predicate text (up to GROUP BY or end of statement),
+// whitespace-normalized. Catches an added/removed filter (status exclusion),
+// a broadened/narrowed kind scope, or a flipped window-predicate direction
+// (`>=` silently becoming `<=`).
+function extractWhereClause(sql) {
+  const normalized = normalizeSql(sql)
+  const m = /\bWHERE\s+(.*?)(?:\s+GROUP BY\b|\s*$)/i.exec(normalized)
+  return m ? m[1].trim() : null
+}
+
+// ---------------------------------------------------------------------------
+// assertReadOnlyAllowlist — structural read-only guard
+// ---------------------------------------------------------------------------
+
+describe('assertReadOnlyAllowlist', () => {
+  test('accepts the real QUERY_ALLOWLIST (every entry is a SELECT)', () => {
+    assert.doesNotThrow(() => assertReadOnlyAllowlist(QUERY_ALLOWLIST))
+  })
+
+  test('rejects a fixture allowlist containing a non-SELECT statement', () => {
+    const bad = {
+      'evil.update': { sql: `UPDATE data_sources SET status = 'active'`, describe: 'x' },
+    }
+    assert.throws(() => assertReadOnlyAllowlist(bad), /not a SELECT statement/)
+  })
+
+  test('rejects DELETE/INSERT/DROP the same way', () => {
+    for (const sql of ['DELETE FROM data_sources', 'INSERT INTO data_sources VALUES (1)', 'DROP TABLE data_sources']) {
+      assert.throws(() => assertReadOnlyAllowlist({ x: { sql, describe: 'x' } }), /not a SELECT statement/)
+    }
+  })
+
+  // P3-B: the start-anchored `/^\s*SELECT\b/i` check alone would let a stacked
+  // multi-statement query through as long as it *starts* with SELECT.
+  test('rejects a SELECT with a non-trailing semicolon (stacked statement)', () => {
+    for (const sql of [
+      'SELECT 1; DROP TABLE data_sources',
+      'SELECT 1;DROP TABLE data_sources',
+      "SELECT 1; DELETE FROM data_sources WHERE 1=1",
+    ]) {
+      assert.throws(() => assertReadOnlyAllowlist({ x: { sql, describe: 'x' } }), /non-trailing semicolon/)
+    }
+  })
+
+  test('accepts a SELECT with a single harmless trailing semicolon (or none at all)', () => {
+    assert.doesNotThrow(() => assertReadOnlyAllowlist({ x: { sql: 'SELECT 1;', describe: 'x' } }))
+    assert.doesNotThrow(() => assertReadOnlyAllowlist({ x: { sql: 'SELECT 1;   ', describe: 'x' } }))
+    assert.doesNotThrow(() => assertReadOnlyAllowlist({ x: { sql: 'SELECT 1', describe: 'x' } }))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// P1 — QUERY_ALLOWLIST SQL semantic invariants.
+//
+// Pins the SQL, not just the plumbing around it. Every test in this block
+// reads QUERY_ALLOWLIST[tag].sql directly (never goes through createFakeExec's
+// SQL-string dispatch) so a corruption of the allowlist's actual SQL text —
+// including the prior NO-GO's errors #1 (`<> 'disabled'`) and #2
+// (`integration_pipeline_runs`) verbatim — cannot hide behind a
+// self-consistent fake executor.
+// ---------------------------------------------------------------------------
+
+describe('QUERY_ALLOWLIST SQL semantic invariants (pins the SQL text itself, not just the plan/plumbing around it)', () => {
+  const EXPECTED = {
+    'count.data_sources_all_types': {
+      tables: ['data_sources'],
+      literals: [],
+      where: null,
+    },
+    'count.data_sources_active_types.with_deleted_at': {
+      tables: ['data_sources'],
+      literals: [],
+      where: 'is_active = true and deleted_at is null',
+    },
+    'count.data_sources_active_types.without_deleted_at': {
+      tables: ['data_sources'],
+      literals: [],
+      where: 'is_active = true',
+    },
+    'count.external_systems_status_by_kind': {
+      tables: ['integration_external_systems'],
+      literals: [],
+      where: 'kind = $1',
+    },
+    'count.approved_read_source_configs_by_kind': {
+      tables: ['integration_external_systems', 'integration_read_source_configs'],
+      literals: ['approved'],
+      where: "s.kind = $1 and c.status = 'approved'",
+    },
+    'count.pipelines_by_source_kind': {
+      tables: ['integration_external_systems', 'integration_pipelines'],
+      literals: [],
+      where: 's.kind = $1',
+    },
+    'count.runs_by_kind_window': {
+      tables: ['integration_external_systems', 'integration_pipelines', 'integration_runs'],
+      literals: [],
+      where: 's.kind = $1 and r.created_at >= now() - make_interval(days => $2::int)',
+    },
+  }
+
+  for (const [tag, expected] of Object.entries(EXPECTED)) {
+    describe(tag, () => {
+      test(`queries exactly {${expected.tables.join(', ')}} — no other table (this is what catches a swapped table name, e.g. integration_pipeline_runs, anywhere in the statement)`, () => {
+        assert.deepEqual(extractTables(QUERY_ALLOWLIST[tag].sql), expected.tables)
+      })
+
+      test(`quoted-literal set is exactly ${JSON.stringify([...expected.literals].sort())} (this is what catches any reintroduced status-vocabulary literal, e.g. 'disabled')`, () => {
+        assert.deepEqual(extractQuotedLiterals(QUERY_ALLOWLIST[tag].sql), [...expected.literals].sort())
+      })
+
+      test(`WHERE predicate is exactly ${JSON.stringify(expected.where)} (kind-scoping / window-predicate pin; whitespace-normalized so a harmless reformat stays green)`, () => {
+        const where = extractWhereClause(QUERY_ALLOWLIST[tag].sql)
+        if (expected.where === null) {
+          assert.equal(where, null)
+        } else {
+          assert.equal(where.toLowerCase(), expected.where)
+        }
+      })
+    })
+  }
+
+  test('no allowlisted SQL statement anywhere contains the literal "disabled" (the exact vocabulary word the prior NO-GO invented)', () => {
+    for (const [tag, entry] of Object.entries(QUERY_ALLOWLIST)) {
+      assert.doesNotMatch(entry.sql, /disabled/i, `tag "${tag}" must not reference a "disabled" status — that value was never part of any real vocabulary`)
+    }
+  })
+
+  test('no allowlisted SQL statement anywhere references integration_pipeline_runs (the exact nonexistent table the prior NO-GO invented)', () => {
+    for (const [tag, entry] of Object.entries(QUERY_ALLOWLIST)) {
+      assert.doesNotMatch(entry.sql, /integration_pipeline_runs/i, `tag "${tag}" must not reference integration_pipeline_runs — that table does not exist`)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+  test('defaults', () => {
+    const opts = parseArgs([])
+    assert.equal(opts.dryRun, false)
+    assert.equal(opts.windowDays, 30)
+    assert.equal(opts.json, false)
+  })
+
+  test('--dry-run and --plan are aliases', () => {
+    assert.equal(parseArgs(['--dry-run']).dryRun, true)
+    assert.equal(parseArgs(['--plan']).dryRun, true)
+  })
+
+  test('--window-days accepts a valid integer', () => {
+    assert.equal(parseArgs(['--window-days', '7']).windowDays, 7)
+  })
+
+  test('--window-days rejects out-of-range and non-numeric values', () => {
+    assert.throws(() => parseArgs(['--window-days', '0']), /between/)
+    assert.throws(() => parseArgs(['--window-days', '9999']), /between/)
+    assert.throws(() => parseArgs(['--window-days', 'DROP TABLE x']), /between/)
+  })
+
+  test('unknown flag throws', () => {
+    assert.throws(() => parseArgs(['--nope']), /unknown argument/)
+  })
+
+  test('--help sets help flag', () => {
+    assert.equal(parseArgs(['--help']).help, true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// probeSchema — schema-probe-first behaviour
+// ---------------------------------------------------------------------------
+
+describe('probeSchema', () => {
+  test('reports exists=false and all columns false for a missing table, without guessing', async () => {
+    const schema = cloneSchema({ integration_runs: { exists: false, columns: [] } })
+    const exec = createFakeExec({ schema, counts: {} })
+    const probed = await probeSchema(exec)
+    assert.equal(probed.integration_runs.exists, false)
+    assert.deepEqual(probed.integration_runs.columns, { id: false, pipeline_id: false, created_at: false })
+  })
+
+  test('reports only the columns actually present', async () => {
+    const schema = cloneSchema({ data_sources: { exists: true, columns: ['type', 'status'] } })
+    const exec = createFakeExec({ schema, counts: {} })
+    const probed = await probeSchema(exec)
+    assert.deepEqual(probed.data_sources.columns, { type: true, is_active: false, deleted_at: false, status: true })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildPlan + executePlan — the core "refuse to guess" contract
+// ---------------------------------------------------------------------------
+
+describe('buildPlan / executePlan: missing table -> UNAVAILABLE, never a blind query', () => {
+  test('missing integration_runs makes runsWindow UNAVAILABLE and the count query is never sent', async () => {
+    const schema = cloneSchema({ integration_runs: { exists: false, columns: [] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed, { windowDays: 30 })
+    assert.equal(plan.runsWindow.status, 'unavailable')
+    assert.match(plan.runsWindow.reason, /integration_runs/)
+
+    // No fixture registered for count.runs_by_kind_window: if executePlan tried
+    // to run it anyway, this would throw. It must not.
+    const exec = createFakeExec({ schema, counts: { ...ZERO_COUNTS, 'count.runs_by_kind_window': undefined } })
+    const coverage = await executePlan(exec, plan)
+    assert.equal(coverage.runsWindow.status, 'unavailable')
+  })
+
+  test('missing integration_pipelines table cascades to both pipelines and runsWindow', async () => {
+    const schema = cloneSchema({ integration_pipelines: { exists: false, columns: [] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed, { windowDays: 30 })
+    assert.equal(plan.pipelines.status, 'unavailable')
+    assert.equal(plan.runsWindow.status, 'unavailable')
+  })
+
+  test('missing data_sources table makes that item UNAVAILABLE (no type-bucketing query sent)', async () => {
+    const schema = cloneSchema({ data_sources: { exists: false, columns: [] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed, { windowDays: 30 })
+    assert.equal(plan.dataSources.status, 'unavailable')
+    assert.match(plan.dataSources.reason, /data_sources not found/)
+  })
+})
+
+describe('buildPlan / executePlan: missing column -> UNAVAILABLE, never a blind query', () => {
+  test('missing integration_pipelines.source_system_id column', async () => {
+    const schema = cloneSchema({ integration_pipelines: { exists: true, columns: ['id'] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed, { windowDays: 30 })
+    assert.equal(plan.pipelines.status, 'unavailable')
+    assert.match(plan.pipelines.reason, /source_system_id/)
+    assert.equal(plan.runsWindow.status, 'unavailable')
+  })
+
+  // P3-A: pins the integration_runs.created_at column check in planRunsWindow
+  // (deleting that check previously left the suite green — this is the schema
+  // shape that check exists to catch: pipeline_id present, created_at absent).
+  test('integration_runs missing created_at (but pipeline_id present) -> runsWindow UNAVAILABLE, never a blind window query', async () => {
+    const schema = cloneSchema({ integration_runs: { exists: true, columns: ['id', 'pipeline_id'] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed, { windowDays: 30 })
+    assert.equal(plan.runsWindow.status, 'unavailable')
+    assert.match(plan.runsWindow.reason, /created_at/)
+
+    const exec = createFakeExec({ schema, counts: { ...ZERO_COUNTS, 'count.runs_by_kind_window': undefined } })
+    const coverage = await executePlan(exec, plan)
+    assert.equal(coverage.runsWindow.status, 'unavailable')
+  })
+
+  test('missing integration_external_systems.status column', async () => {
+    const schema = cloneSchema({ integration_external_systems: { exists: true, columns: ['id', 'kind'] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed, { windowDays: 30 })
+    assert.equal(plan.externalSystems.status, 'unavailable')
+    assert.match(plan.externalSystems.reason, /status/)
+  })
+
+  test('data_sources missing is_active -> active sub-item UNAVAILABLE but registered total still resolves (this is the exact #4 landmine: legacy 040_data_sources.sql shape)', async () => {
+    const schema = cloneSchema({ data_sources: { exists: true, columns: ['type', 'status'] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed, { windowDays: 30 })
+    assert.equal(plan.dataSources.status, 'ok')
+    assert.equal(plan.dataSources.active.status, 'unavailable')
+    assert.match(plan.dataSources.active.reason, /is_active/)
+  })
+
+  test('data_sources has is_active but not deleted_at -> uses the without_deleted_at variant', async () => {
+    const schema = cloneSchema({ data_sources: { exists: true, columns: ['type', 'is_active'] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed, { windowDays: 30 })
+    assert.equal(plan.dataSources.active.status, 'ok')
+    assert.equal(plan.dataSources.active.tag, 'count.data_sources_active_types.without_deleted_at')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Status vocabulary correctness — the exact bug class this script replaces
+// ---------------------------------------------------------------------------
+
+describe('bucketing uses the REAL status vocabulary (catches the `<> \'disabled\'` bug class)', () => {
+  test('external systems: inactive and error rows are NOT counted as active', () => {
+    const rows = [
+      { status: 'active', n: 3 },
+      { status: 'inactive', n: 5 },
+      { status: 'error', n: 2 },
+    ]
+    const { buckets, total } = bucketExternalSystemStatusCounts(rows)
+    assert.equal(buckets.active, 3)
+    assert.equal(buckets.inactive, 5)
+    assert.equal(buckets.error, 2)
+    assert.equal(total, 10)
+    // The specific regression this guards: a `<> 'disabled'` filter would have
+    // read inactive+error rows as "enabled" (7), not 3.
+    assert.notEqual(buckets.active, 7)
+  })
+
+  test('an unrecognised status value buckets to "unexpected", never silently dropped or miscounted as active', () => {
+    const { buckets, total } = bucketExternalSystemStatusCounts([{ status: 'pending_migration', n: 4 }])
+    assert.equal(buckets.active, 0)
+    assert.equal(buckets.unexpected, 4)
+    assert.equal(total, 4)
+  })
+
+  test('EXTERNAL_SYSTEM_STATUSES is exactly the three-value CHECK-constraint vocabulary', () => {
+    assert.deepEqual([...EXTERNAL_SYSTEM_STATUSES].sort(), ['active', 'error', 'inactive'])
+  })
+
+  test('data source types: unknown/unpinned types bucket to "other", never fabricate a new key', () => {
+    const { buckets, total } = bucketDataSourceTypeCounts([
+      { type: 'postgresql', n: 2 },
+      { type: 'some-future-adapter', n: 1 },
+    ])
+    assert.equal(buckets.postgresql, 2)
+    assert.equal(buckets.other, 1)
+    assert.equal(total, 3)
+    assert.equal(Object.prototype.hasOwnProperty.call(buckets, 'some-future-adapter'), false)
+  })
+
+  test('SUPPORTED_DATA_SOURCE_TYPES matches the pinned DataSourceManager roster', () => {
+    assert.deepEqual(
+      [...SUPPORTED_DATA_SOURCE_TYPES].sort(),
+      ['http', 'mysql', 'plm', 'postgres', 'postgresql', 'sqlserver'],
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Verdict — positive control: three distinct reachable outcomes
+// ---------------------------------------------------------------------------
+
+describe('computeVerdict', () => {
+  function coverageFrom({ externalSystemsActive = 0, approvedConfigs = 0, pipelines = 0, runsWindow = 0, gap = null } = {}) {
+    if (gap) {
+      const ok = {
+        dataSources: { status: 'ok', active: { status: 'ok' } },
+        externalSystems: { status: 'ok', byStatus: { active: 0 } },
+        approvedConfigs: { status: 'ok', count: 0 },
+        pipelines: { status: 'ok', count: 0 },
+        runsWindow: { status: 'ok', count: 0 },
+        staticCallSiteEnumeration: { status: 'ok' },
+      }
+      ok[gap.key] = { status: 'unavailable', reason: gap.reason }
+      return ok
+    }
+    return {
+      dataSources: { status: 'ok', active: { status: 'ok' } },
+      externalSystems: { status: 'ok', kind: TARGET_KIND, byStatus: { active: externalSystemsActive, inactive: 0, error: 0, unexpected: 0 } },
+      approvedConfigs: { status: 'ok', count: approvedConfigs },
+      pipelines: { status: 'ok', count: pipelines },
+      runsWindow: { status: 'ok', count: runsWindow },
+      staticCallSiteEnumeration: { status: 'ok' },
+    }
+  }
+
+  test('full coverage + all-zero risk surface -> MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE', () => {
+    const { verdict } = computeVerdict(coverageFrom({}))
+    assert.equal(verdict, 'MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE')
+  })
+
+  test('full coverage + nonzero pipelines -> MIGRATION_REQUIRED', () => {
+    const { verdict, reasons } = computeVerdict(coverageFrom({ pipelines: 2 }))
+    assert.equal(verdict, 'MIGRATION_REQUIRED')
+    assert.match(reasons.join(' '), /pipelines=2/)
+  })
+
+  test('full coverage + nonzero runsWindow only -> MIGRATION_REQUIRED', () => {
+    const { verdict } = computeVerdict(coverageFrom({ runsWindow: 1 }))
+    assert.equal(verdict, 'MIGRATION_REQUIRED')
+  })
+
+  test('partial coverage (one gap) -> INCONCLUSIVE, never a bare "0" / never MIGRATION_NOT_REQUIRED', () => {
+    const { verdict, reasons } = computeVerdict(coverageFrom({ gap: { key: 'runsWindow', reason: 'missing table(s): integration_runs' } }))
+    assert.equal(verdict, 'INCONCLUSIVE')
+    assert.notEqual(verdict, 'MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE')
+    assert.ok(reasons.length > 0)
+    assert.match(reasons.join(' '), /partial/)
+  })
+
+  test('verdict is never literally "0" or falsy for any coverage shape', () => {
+    for (const cov of [coverageFrom({}), coverageFrom({ pipelines: 5 }), coverageFrom({ gap: { key: 'pipelines', reason: 'x' } })]) {
+      const { verdict } = computeVerdict(cov)
+      assert.ok(verdict && typeof verdict === 'string' && verdict !== '0')
+    }
+  })
+
+  // P2 regression: every DB coverage group that can independently go UNAVAILABLE
+  // must independently force INCONCLUSIVE — "a test per coverage group", not one
+  // representative case standing in for all of them.
+  describe('every declared coverage group forces INCONCLUSIVE on its own when UNAVAILABLE', () => {
+    for (const key of ['dataSources', 'externalSystems', 'approvedConfigs', 'pipelines', 'runsWindow']) {
+      test(`${key} UNAVAILABLE alone -> INCONCLUSIVE (never MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE)`, () => {
+        const { verdict, reasons } = computeVerdict(coverageFrom({ gap: { key, reason: `${key} gap reason` } }))
+        assert.equal(verdict, 'INCONCLUSIVE')
+        assert.notEqual(verdict, 'MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE')
+        assert.match(reasons.join(' '), new RegExp(key))
+      })
+    }
+
+    test('dataSources.active UNAVAILABLE (nested) -> INCONCLUSIVE even though dataSources.status itself is ok', () => {
+      const cov = coverageFrom({})
+      cov.dataSources = { status: 'ok', active: { status: 'unavailable', reason: 'is_active column not present' } }
+      const { verdict, reasons } = computeVerdict(cov)
+      assert.equal(verdict, 'INCONCLUSIVE')
+      assert.match(reasons.join(' '), /dataSources\.active/)
+    })
+
+    // THE P2 FIX ITSELF: staticCallSiteEnumeration is a declared coverage group
+    // (see COVERAGE_LABELS.staticCallSiteEnumeration / report.coverage.staticCallSiteEnumeration)
+    // with a real fail-closed UNAVAILABLE state (enumerateStaticCallSites returns
+    // it when an anchor file is missing/drifted). Before the fix, computeVerdict
+    // never received this group at all, so it could emit
+    // MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE while this entire coverage axis was
+    // blind — confirmed live via buildReport({ repoRoot: <empty tmpdir> }) before
+    // this fix landed (see task report for the exact repro).
+    test('staticCallSiteEnumeration UNAVAILABLE (anchor drift) -> INCONCLUSIVE even though all DB coverage is OK and the risk surface is zero', () => {
+      const cov = coverageFrom({})
+      cov.staticCallSiteEnumeration = {
+        status: 'unavailable',
+        reason: 'anchor file(s)/pattern(s) not verified: select_route',
+      }
+      const { verdict, reasons } = computeVerdict(cov)
+      assert.equal(verdict, 'INCONCLUSIVE')
+      assert.notEqual(verdict, 'MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE')
+      assert.match(reasons.join(' '), /staticCallSiteEnumeration/)
+    })
+
+    test('staticCallSiteEnumeration key entirely absent from the coverage object -> INCONCLUSIVE (fail closed on a missing signal, never fail open)', () => {
+      const cov = coverageFrom({})
+      delete cov.staticCallSiteEnumeration
+      const { verdict } = computeVerdict(cov)
+      assert.equal(verdict, 'INCONCLUSIVE')
+    })
+  })
+
+  // accessLogRecipe is a declared coverage group too, but by construction it
+  // never resolves to ok/unavailable — it is always an operator-run manual
+  // recipe (see buildAccessLogRecipe). Pin that explicitly so "a test per
+  // coverage group" is complete by construction, not by omission: there is no
+  // accessLogRecipe UNAVAILABLE case to gate on because that state does not
+  // exist.
+  test('buildAccessLogRecipe never produces an ok/unavailable status — it is unconditionally "manual"', () => {
+    const recipe = buildAccessLogRecipe({ windowDays: 30 })
+    assert.equal(recipe.status, 'manual')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// residual blind spots — always present, non-empty
+// ---------------------------------------------------------------------------
+
+describe('residual blind spots', () => {
+  test('STATIC_RESIDUAL_BLIND_SPOTS always includes the undeployed-telemetry field', () => {
+    assert.ok(STATIC_RESIDUAL_BLIND_SPOTS.some((b) => b.id === 'adapter_telemetry_not_deployed'))
+    assert.ok(STATIC_RESIDUAL_BLIND_SPOTS.length > 0)
+  })
+
+  test('buildResidualBlindSpots is non-empty even for a fully-OK coverage', () => {
+    const coverage = {
+      dataSources: { status: 'ok', active: { status: 'ok' } },
+      externalSystems: { status: 'ok' },
+      approvedConfigs: { status: 'ok' },
+      pipelines: { status: 'ok' },
+      runsWindow: { status: 'ok' },
+    }
+    const spots = buildResidualBlindSpots(coverage)
+    assert.ok(spots.length >= STATIC_RESIDUAL_BLIND_SPOTS.length)
+  })
+
+  test('buildResidualBlindSpots grows with real coverage gaps', () => {
+    const coverage = {
+      dataSources: { status: 'unavailable', reason: 'table data_sources not found' },
+      externalSystems: { status: 'ok' },
+      approvedConfigs: { status: 'ok' },
+      pipelines: { status: 'ok' },
+      runsWindow: { status: 'ok' },
+    }
+    const spots = buildResidualBlindSpots(coverage)
+    assert.ok(spots.length > STATIC_RESIDUAL_BLIND_SPOTS.length)
+    assert.ok(spots.some((b) => b.id === 'data_sources_table_gap'))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// No SQL string ever contains a caller-controlled value
+// ---------------------------------------------------------------------------
+
+describe('no caller-controlled value ever reaches SQL text or params', () => {
+  test('every executed query in a full report run is on the allowlist and every param is an expected constant', async () => {
+    const calls = []
+    const exec = createFakeExec({ schema: FULL_SCHEMA, counts: ZERO_COUNTS }, calls)
+    await buildReport({ exec, windowDays: 17 })
+
+    assert.ok(calls.length > 0)
+    for (const call of calls) {
+      // Structural: sql text is drawn from the fixed allowlist (guaranteed by
+      // createFakeExec's lookup, which throws otherwise), so this loop is really
+      // asserting the *params*.
+      for (const p of call.params) {
+        const isKnownString = typeof p === 'string' && (p === TARGET_KIND || Object.keys(FULL_SCHEMA).includes(p))
+        const isWindowInt = typeof p === 'number' && Number.isInteger(p) && p === 17
+        assert.ok(
+          isKnownString || isWindowInt,
+          `unexpected query parameter leaked into SQL bind params: ${JSON.stringify(p)} (tag=${call.tag})`,
+        )
+      }
+    }
+  })
+
+  test('a crafted CLI window-days value cannot become a SQL string fragment (it is bound as an integer)', async () => {
+    // parseArgs already rejects non-numeric --window-days (see parseArgs suite),
+    // so the only way an integer reaches executePlan is a real integer bind param.
+    const calls = []
+    const exec = createFakeExec({ schema: FULL_SCHEMA, counts: ZERO_COUNTS }, calls)
+    await buildReport({ exec, windowDays: 30 })
+    const runsCall = calls.find((c) => c.tag === 'count.runs_by_kind_window')
+    assert.ok(runsCall)
+    assert.equal(typeof runsCall.params[1], 'number')
+    assert.doesNotMatch(runsCall.sql, /\$\{|`\s*\+|days=30/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Values-free by construction — LOAD-BEARING TEST
+// ---------------------------------------------------------------------------
+
+describe('values-free by construction (load-bearing)', () => {
+  test('sentinel strings seeded into row content never appear anywhere in the serialized report', async () => {
+    const SENTINEL_TYPE = 'SENTINEL_TYPE_9f3a1c88'
+    const SENTINEL_ACTIVE_TYPE = 'SENTINEL_ACTIVE_TYPE_ae21f0'
+    const SENTINEL_STATUS = 'SENTINEL_STATUS_7b2e44aa'
+    const SENTINEL_HOSTNAME = 'sentinel-host-should-never-appear.internal'
+    const SENTINEL_ID = 'sentinel-row-id-4471'
+
+    const counts = {
+      'count.data_sources_all_types': [
+        { type: 'postgresql', n: 2 },
+        { type: SENTINEL_TYPE, n: 1 }, // unknown type -> must bucket to "other", never leak
+      ],
+      'count.data_sources_active_types.with_deleted_at': [
+        { type: 'postgresql', n: 1 },
+        { type: SENTINEL_ACTIVE_TYPE, n: 1 }, // same bucketing path, exercised on the ACTIVE query too
+      ],
+      'count.external_systems_status_by_kind': [
+        { status: 'active', n: 1 },
+        { status: SENTINEL_STATUS, n: 1 }, // unknown status -> must bucket to "unexpected"
+      ],
+      'count.approved_read_source_configs_by_kind': [{ n: 1 }],
+      'count.pipelines_by_source_kind': [{ n: 1 }],
+      'count.runs_by_kind_window': [{ n: 1 }],
+    }
+
+    // Also plant sentinels in places the script must never even read into the
+    // report: extra/irrelevant columns and identifiers a naive implementation
+    // might be tempted to pass through.
+    const schema = cloneSchema({
+      data_sources: {
+        exists: true,
+        columns: ['type', 'is_active', 'deleted_at', 'status', SENTINEL_HOSTNAME, SENTINEL_ID],
+      },
+    })
+
+    const exec = createFakeExec({ schema, counts })
+    const report = await buildReport({ exec, windowDays: 30 })
+    const serialized = JSON.stringify(report)
+
+    for (const sentinel of [SENTINEL_TYPE, SENTINEL_ACTIVE_TYPE, SENTINEL_STATUS, SENTINEL_HOSTNAME, SENTINEL_ID]) {
+      assert.equal(
+        serialized.includes(sentinel),
+        false,
+        `values-free violation: sentinel "${sentinel}" leaked into the serialized report`,
+      )
+    }
+
+    // And confirm the sentinel rows were still counted (bucketed), not silently dropped.
+    assert.equal(report.coverage.dbInventory.dataSources.registeredByType.other, 1)
+    assert.equal(report.coverage.dbInventory.dataSources.active.byType.other, 1)
+    assert.equal(report.coverage.dbInventory.externalSystemsByStatus.byStatus.unexpected, 1)
+  })
+
+  test('the dry-run report (schema-probed branch) is also values-free', async () => {
+    const SENTINEL = 'SENTINEL_DRYRUN_c001d00d'
+    const schema = cloneSchema({
+      data_sources: { exists: true, columns: ['type', 'is_active', 'deleted_at', 'status', SENTINEL] },
+    })
+    const exec = createFakeExec({ schema, counts: {} })
+    const report = await buildDryRunReport({ exec, windowDays: 30 })
+    assert.equal(JSON.stringify(report).includes(SENTINEL), false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Dry-run gating: never print a query the probe would have refused
+// ---------------------------------------------------------------------------
+
+describe('dry-run gating', () => {
+  test('with is_active missing, the active-count SQL text is never printed (only the UNAVAILABLE reason)', async () => {
+    const schema = cloneSchema({ data_sources: { exists: true, columns: ['type', 'status'] } })
+    const exec = createFakeExec({ schema, counts: {} })
+    const report = await buildDryRunReport({ exec, windowDays: 30 })
+    const serialized = JSON.stringify(report)
+
+    assert.equal(report.plan.dataSources.active.status, 'unavailable')
+    assert.equal(serialized.includes('WHERE is_active = true AND deleted_at IS NULL'), false)
+    assert.equal(serialized.includes('WHERE is_active = true GROUP BY type'), false)
+  })
+
+  test('with integration_runs missing, the runs-window SQL is never printed', async () => {
+    const schema = cloneSchema({ integration_runs: { exists: false, columns: [] } })
+    const exec = createFakeExec({ schema, counts: {} })
+    const report = await buildDryRunReport({ exec, windowDays: 30 })
+    assert.equal(report.plan.runsWindow.status, 'unavailable')
+    assert.equal(JSON.stringify(report).includes('make_interval'), false)
+  })
+
+  test('with a full schema, the dry-run plan resolves every item to "ok" and shows the exact SQL that report mode would run', async () => {
+    const exec = createFakeExec({ schema: FULL_SCHEMA, counts: {} })
+    const report = await buildDryRunReport({ exec, windowDays: 12 })
+    assert.equal(report.mode, 'dry-run')
+    for (const key of ['dataSources', 'externalSystems', 'approvedConfigs', 'pipelines', 'runsWindow']) {
+      assert.equal(report.plan[key].status, 'ok')
+    }
+    assert.equal(report.plan.runsWindow.params[1], 12)
+  })
+
+  test('with no executor at all (no DATABASE_URL, no DB), falls back to a fully static plan and stays values-free', async () => {
+    const report = await buildDryRunReport({ exec: null, windowDays: 30 })
+    assert.equal(report.mode, 'dry-run-static')
+    assert.ok(Object.keys(report.allowlist).length > 0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Static in-repo caller enumeration
+// ---------------------------------------------------------------------------
+
+describe('enumerateStaticCallSites', () => {
+  let tmpRoot
+
+  function makeTmpRepo() {
+    const root = mkdtempSync(path.join(tmpdir(), 'ds-exposure-inventory-'))
+    mkdirSync(path.join(root, 'src', 'routes'), { recursive: true })
+    mkdirSync(path.join(root, 'src', 'adapters'), { recursive: true })
+    mkdirSync(path.join(root, 'src', '__tests__'), { recursive: true })
+    writeFileSync(
+      path.join(root, 'src', 'routes', 'data-sources.ts'),
+      `router.post('/api/data-sources/:id/select', () => {})\n`,
+    )
+    writeFileSync(
+      path.join(root, 'src', 'adapters', 'DataSourceManager.ts'),
+      `class X {\n  async select() { return sourceAdapter.select('t', {}) }\n  async copyData() {}\n}\n`,
+    )
+    writeFileSync(
+      path.join(root, 'src', 'adapters', 'sql-readonly.cjs'),
+      `async function run() { return api.select('t', {}) }\n`,
+    )
+    // A real (non-test) caller of copyData, plus a test-only caller that must
+    // not count toward "live caller".
+    writeFileSync(path.join(root, 'src', 'adapters', 'caller.ts'), `x.copyData({})\n`)
+    writeFileSync(path.join(root, 'src', '__tests__', 'caller.test.ts'), `x.copyData({})\n`)
+    return root
+  }
+
+  function anchorsFor(root) {
+    return [
+      { id: 'select_route', file: 'src/routes/data-sources.ts', pattern: /router\.post\(\s*'\/api\/data-sources\/:id\/select'/ },
+      { id: 'manager_select_internal', file: 'src/adapters/DataSourceManager.ts', pattern: /sourceAdapter\.select\(/ },
+      { id: 'copy_data_definition', file: 'src/adapters/DataSourceManager.ts', pattern: /async\s+copyData\(/ },
+      { id: 'sql_readonly_adapter_select', file: 'src/adapters/sql-readonly.cjs', pattern: /\bapi\.select\(/ },
+    ]
+  }
+
+  test('positive control: a tree containing known callers yields nonzero counts', () => {
+    tmpRoot = makeTmpRepo()
+    try {
+      const result = enumerateStaticCallSites({ repoRoot: tmpRoot, anchors: anchorsFor(tmpRoot), scanRoots: ['src'] })
+      assert.equal(result.status, 'ok')
+      assert.ok(result.counts.managerOrAdapterSelectCallSites.nonTest >= 2) // sourceAdapter.select + api.select
+      assert.equal(result.counts.copyDataCallSites.nonTest, 1)
+      assert.equal(result.counts.copyDataCallSites.test, 1)
+      assert.equal(result.counts.selectRouteDefinitions.nonTest, 1)
+      assert.equal(result.knownCallers.find((k) => k.id === 'copy_data').hasLiveCaller, true)
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true })
+    }
+  })
+
+  test('negative control: an empty tree (no callers) yields zero, not a thrown error', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'ds-exposure-inventory-empty-'))
+    try {
+      mkdirSync(path.join(root, 'src', 'routes'), { recursive: true })
+      mkdirSync(path.join(root, 'src', 'adapters'), { recursive: true })
+      writeFileSync(path.join(root, 'src', 'routes', 'data-sources.ts'), `router.post('/api/data-sources/:id/select', () => {})\n`)
+      writeFileSync(path.join(root, 'src', 'adapters', 'DataSourceManager.ts'), `sourceAdapter.select('t')\nasync copyData() {}\n`)
+      writeFileSync(path.join(root, 'src', 'adapters', 'sql-readonly.cjs'), `api.select('t')\n`)
+      const result = enumerateStaticCallSites({ repoRoot: root, anchors: anchorsFor(root), scanRoots: ['src'] })
+      assert.equal(result.status, 'ok')
+      assert.equal(result.counts.copyDataCallSites.nonTest, 0)
+      assert.equal(result.knownCallers.find((k) => k.id === 'copy_data').hasLiveCaller, false)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('fail-closed: a missing anchor file makes the whole item UNAVAILABLE rather than reporting a possibly-wrong zero', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'ds-exposure-inventory-missing-'))
+    try {
+      // No files created at all -> every anchor is missing.
+      const result = enumerateStaticCallSites({ repoRoot: root, anchors: anchorsFor(root), scanRoots: ['src'] })
+      assert.equal(result.status, 'unavailable')
+      assert.ok(result.anchorsMissing.length === 4)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('fail-closed: an anchor file present but with drifted content also fails closed', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'ds-exposure-inventory-drift-'))
+    try {
+      mkdirSync(path.join(root, 'src', 'routes'), { recursive: true })
+      writeFileSync(path.join(root, 'src', 'routes', 'data-sources.ts'), `// the route used to be here but is gone\n`)
+      const result = enumerateStaticCallSites({
+        repoRoot: root,
+        anchors: [anchorsFor(root)[0]],
+        scanRoots: ['src'],
+      })
+      assert.equal(result.status, 'unavailable')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('the real repo anchors resolve OK against this actual checkout (drift guard)', () => {
+    const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..')
+    const result = enumerateStaticCallSites({ repoRoot })
+    assert.equal(result.status, 'ok', result.reason)
+    assert.ok(result.scannedFileCount > 0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// End-to-end buildReport smoke + human summary
+// ---------------------------------------------------------------------------
+
+describe('buildReport end-to-end', () => {
+  test('full schema, all-zero counts -> MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE and a non-empty residual list', async () => {
+    const exec = createFakeExec({ schema: FULL_SCHEMA, counts: ZERO_COUNTS })
+    const report = await buildReport({ exec, windowDays: 30 })
+    assert.equal(report.verdict, 'MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE')
+    assert.ok(report.residualBlindSpots.length > 0)
+    assert.equal(report.observationWindow.days, 30)
+    assert.equal(report.targetKind, TARGET_KIND)
+  })
+
+  test('P2 regression: full-zero DB coverage but staticCallSiteEnumeration UNAVAILABLE (repoRoot with no anchor files) -> INCONCLUSIVE, never MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE', async () => {
+    const emptyRoot = mkdtempSync(path.join(tmpdir(), 'ds-exposure-inventory-p2-empty-'))
+    try {
+      const exec = createFakeExec({ schema: FULL_SCHEMA, counts: ZERO_COUNTS })
+      const report = await buildReport({ exec, windowDays: 30, repoRoot: emptyRoot })
+      assert.equal(report.coverage.staticCallSiteEnumeration.status, 'unavailable')
+      assert.equal(report.verdict, 'INCONCLUSIVE')
+      assert.notEqual(report.verdict, 'MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE')
+      assert.match(report.verdictReasons.join(' '), /staticCallSiteEnumeration/)
+    } finally {
+      rmSync(emptyRoot, { recursive: true, force: true })
+    }
+  })
+
+  test('full schema, one active external system -> MIGRATION_REQUIRED', async () => {
+    const counts = { ...ZERO_COUNTS, 'count.external_systems_status_by_kind': [{ status: 'active', n: 1 }] }
+    const exec = createFakeExec({ schema: FULL_SCHEMA, counts })
+    const report = await buildReport({ exec, windowDays: 30 })
+    assert.equal(report.verdict, 'MIGRATION_REQUIRED')
+  })
+
+  test('partial schema -> INCONCLUSIVE and coverage item carries a human-readable reason', async () => {
+    const schema = cloneSchema({ integration_read_source_configs: { exists: false, columns: [] } })
+    const exec = createFakeExec({ schema, counts: ZERO_COUNTS })
+    const report = await buildReport({ exec, windowDays: 30 })
+    assert.equal(report.verdict, 'INCONCLUSIVE')
+    assert.equal(report.coverage.dbInventory.approvedReadSourceConfigsBoundToKind.status, 'unavailable')
+    assert.match(report.coverage.dbInventory.approvedReadSourceConfigsBoundToKind.reason, /integration_read_source_configs/)
+  })
+
+  test('every coverage group states WHAT IT COVERS and its blind spot (brief item 1-3 requirement), not just the global residual list', async () => {
+    const exec = createFakeExec({ schema: FULL_SCHEMA, counts: ZERO_COUNTS })
+    const report = await buildReport({ exec, windowDays: 30 })
+    for (const group of [report.coverage.dbInventory, report.coverage.staticCallSiteEnumeration, report.coverage.accessLogRecipe]) {
+      assert.equal(typeof group.covers, 'string')
+      assert.ok(group.covers.length > 0)
+      assert.equal(typeof group.blindSpot, 'string')
+      assert.ok(group.blindSpot.length > 0)
+    }
+    // And each label is specific to its own item, not a copy-pasted duplicate.
+    const labels = [report.coverage.dbInventory.covers, report.coverage.staticCallSiteEnumeration.covers, report.coverage.accessLogRecipe.covers]
+    assert.equal(new Set(labels).size, labels.length)
+  })
+
+  test('the dry-run report ALSO carries covers/blindSpot on every coverage group (both the static and schema-probed branches)', async () => {
+    const staticReport = await buildDryRunReport({ exec: null, windowDays: 30 })
+    for (const group of [staticReport.coverage.staticCallSiteEnumeration, staticReport.coverage.accessLogRecipe]) {
+      assert.ok(group.covers && group.blindSpot)
+    }
+
+    const exec = createFakeExec({ schema: FULL_SCHEMA, counts: {} })
+    const probedReport = await buildDryRunReport({ exec, windowDays: 30 })
+    for (const group of [probedReport.plan, probedReport.coverage.staticCallSiteEnumeration, probedReport.coverage.accessLogRecipe]) {
+      assert.ok(group.covers && group.blindSpot)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CLI entrypoint (hermetic only — never sets DATABASE_URL, never imports `pg`)
+// ---------------------------------------------------------------------------
+
+describe('main() CLI (hermetic paths only)', () => {
+  test('--dry-run with no DATABASE_URL succeeds without touching a live DB or importing pg', async () => {
+    const code = await main(['--dry-run', '--json'], {})
+    assert.equal(code, 0)
+  })
+
+  test('report mode with no DATABASE_URL fails closed with exit code 2', async () => {
+    const code = await main([], {})
+    assert.equal(code, 2)
+  })
+
+  test('an invalid flag fails with exit code 1', async () => {
+    const code = await main(['--not-a-real-flag'], {})
+    assert.equal(code, 1)
+  })
+
+  test('--help exits 0', async () => {
+    const code = await main(['--help'], {})
+    assert.equal(code, 0)
+  })
+})

--- a/scripts/ops/data-source-exposure-inventory.test.mjs
+++ b/scripts/ops/data-source-exposure-inventory.test.mjs
@@ -1,6 +1,12 @@
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
@@ -14,6 +20,7 @@ import {
   buildPlan,
   bucketDataSourceTypeCounts,
   bucketExternalSystemStatusCounts,
+  normalizeCount,
   executePlan,
   enumerateStaticCallSites,
   buildAccessLogRecipe,
@@ -25,6 +32,28 @@ import {
   parseArgs,
   main,
 } from './data-source-exposure-inventory.mjs'
+
+async function captureProcessWrites(callback) {
+  const originalStdoutWrite = process.stdout.write
+  const originalStderrWrite = process.stderr.write
+  let stdout = ''
+  let stderr = ''
+  process.stdout.write = (chunk) => {
+    stdout += String(chunk)
+    return true
+  }
+  process.stderr.write = (chunk) => {
+    stderr += String(chunk)
+    return true
+  }
+  try {
+    const result = await callback()
+    return { result, stdout, stderr }
+  } finally {
+    process.stdout.write = originalStdoutWrite
+    process.stderr.write = originalStderrWrite
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Fake DB harness
@@ -126,7 +155,7 @@ function normalizeSql(sql) {
 // deduplicated. Catches a swapped table name anywhere in the statement
 // (e.g. the prior NO-GO's `integration_pipeline_runs` for `integration_runs`).
 function extractTables(sql) {
-  const re = /\b(?:FROM|JOIN)\s+([a-zA-Z_][a-zA-Z0-9_]*)/gi
+  const re = /\b(?:FROM|JOIN)\s+([a-zA-Z_][a-zA-Z0-9_.]*)/gi
   const tables = new Set()
   let m
   while ((m = re.exec(sql))) tables.add(m[1].toLowerCase())
@@ -145,13 +174,16 @@ function extractQuotedLiterals(sql) {
   return out.sort()
 }
 
-// The WHERE-clause predicate text (up to GROUP BY or end of statement),
+// The WHERE-clause predicate text (up to GROUP BY, ORDER BY, LIMIT, or end),
 // whitespace-normalized. Catches an added/removed filter (status exclusion),
 // a broadened/narrowed kind scope, or a flipped window-predicate direction
 // (`>=` silently becoming `<=`).
 function extractWhereClause(sql) {
   const normalized = normalizeSql(sql)
-  const m = /\bWHERE\s+(.*?)(?:\s+GROUP BY\b|\s*$)/i.exec(normalized)
+  const m =
+    /\bWHERE\s+(.*?)(?:\s+GROUP BY\b|\s+ORDER BY\b|\s+LIMIT\b|\s*$)/i.exec(
+      normalized,
+    )
   return m ? m[1].trim() : null
 }
 
@@ -209,42 +241,67 @@ describe('assertReadOnlyAllowlist', () => {
 
 describe('QUERY_ALLOWLIST SQL semantic invariants (pins the SQL text itself, not just the plan/plumbing around it)', () => {
   const EXPECTED = {
+    'probe.table_exists': {
+      tables: ['information_schema.tables'],
+      literals: ['BASE TABLE', 'public'],
+      where:
+        "table_schema = 'public' and table_name = $1 and table_type = 'base table'",
+    },
+    'probe.columns': {
+      tables: ['information_schema.columns'],
+      literals: ['public'],
+      where: "table_schema = 'public' and table_name = $1",
+    },
     'count.data_sources_all_types': {
-      tables: ['data_sources'],
+      tables: ['public.data_sources'],
       literals: [],
       where: null,
     },
     'count.data_sources_active_types.with_deleted_at': {
-      tables: ['data_sources'],
+      tables: ['public.data_sources'],
       literals: [],
       where: 'is_active = true and deleted_at is null',
     },
     'count.data_sources_active_types.without_deleted_at': {
-      tables: ['data_sources'],
+      tables: ['public.data_sources'],
       literals: [],
       where: 'is_active = true',
     },
     'count.external_systems_status_by_kind': {
-      tables: ['integration_external_systems'],
+      tables: ['public.integration_external_systems'],
       literals: [],
       where: 'kind = $1',
     },
     'count.approved_read_source_configs_by_kind': {
-      tables: ['integration_external_systems', 'integration_read_source_configs'],
+      tables: [
+        'public.integration_external_systems',
+        'public.integration_read_source_configs',
+      ],
       literals: ['approved'],
       where: "s.kind = $1 and c.status = 'approved'",
     },
     'count.pipelines_by_source_kind': {
-      tables: ['integration_external_systems', 'integration_pipelines'],
+      tables: [
+        'public.integration_external_systems',
+        'public.integration_pipelines',
+      ],
       literals: [],
       where: 's.kind = $1',
     },
     'count.runs_by_kind_window': {
-      tables: ['integration_external_systems', 'integration_pipelines', 'integration_runs'],
+      tables: [
+        'public.integration_external_systems',
+        'public.integration_pipelines',
+        'public.integration_runs',
+      ],
       literals: [],
       where: 's.kind = $1 and r.created_at >= now() - make_interval(days => $2::int)',
     },
   }
+
+  test('every allowlisted statement has an independent semantic oracle', () => {
+    assert.deepEqual(Object.keys(EXPECTED).sort(), Object.keys(QUERY_ALLOWLIST).sort())
+  })
 
   for (const [tag, expected] of Object.entries(EXPECTED)) {
     describe(tag, () => {
@@ -278,6 +335,14 @@ describe('QUERY_ALLOWLIST SQL semantic invariants (pins the SQL text itself, not
       assert.doesNotMatch(entry.sql, /integration_pipeline_runs/i, `tag "${tag}" must not reference integration_pipeline_runs — that table does not exist`)
     }
   })
+
+  test('every aggregate count uses bigint so large inventories fail only at the JS safe-integer boundary', () => {
+    for (const [tag, entry] of Object.entries(QUERY_ALLOWLIST)) {
+      if (!tag.startsWith('count.')) continue
+      assert.match(entry.sql, /count\(\*\)::bigint\s+AS\s+n/i, tag)
+      assert.doesNotMatch(entry.sql, /count\(\*\)::int\s+AS\s+n/i, tag)
+    }
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -305,6 +370,9 @@ describe('parseArgs', () => {
     assert.throws(() => parseArgs(['--window-days', '0']), /between/)
     assert.throws(() => parseArgs(['--window-days', '9999']), /between/)
     assert.throws(() => parseArgs(['--window-days', 'DROP TABLE x']), /between/)
+    assert.throws(() => parseArgs(['--window-days', '5abc']), /between/)
+    assert.throws(() => parseArgs(['--window-days', '5.5']), /between/)
+    assert.throws(() => parseArgs(['--window-days', '1e2']), /between/)
   })
 
   test('unknown flag throws', () => {
@@ -424,11 +492,47 @@ describe('buildPlan / executePlan: missing column -> UNAVAILABLE, never a blind 
   })
 })
 
+describe('executePlan aggregate cardinality', () => {
+  for (const [label, rows] of [
+    ['zero rows', []],
+    ['multiple rows', [{ n: 1 }, { n: 2 }]],
+  ]) {
+    test(`scalar count returning ${label} fails closed`, async () => {
+      const probed = await probeSchema(
+        createFakeExec({ schema: FULL_SCHEMA, counts: {} }),
+      )
+      const plan = buildPlan(probed, { windowDays: 30 })
+      const exec = createFakeExec({
+        schema: FULL_SCHEMA,
+        counts: {
+          ...ZERO_COUNTS,
+          'count.approved_read_source_configs_by_kind': rows,
+        },
+      })
+      await assert.rejects(
+        () => executePlan(exec, plan),
+        /invalid aggregate row count/,
+      )
+    })
+  }
+})
+
 // ---------------------------------------------------------------------------
 // Status vocabulary correctness — the exact bug class this script replaces
 // ---------------------------------------------------------------------------
 
 describe('bucketing uses the REAL status vocabulary (catches the `<> \'disabled\'` bug class)', () => {
+  test('aggregate counts accept safe bigint text and reject malformed or unsafe values', () => {
+    assert.equal(normalizeCount('2147483648'), 2147483648)
+    for (const value of ['-1', '1.5', '1e3', '007', '', Number.NaN, -1]) {
+      assert.throws(() => normalizeCount(value), /invalid aggregate count/)
+    }
+    assert.throws(
+      () => normalizeCount(String(Number.MAX_SAFE_INTEGER + 1)),
+      /invalid aggregate count/,
+    )
+  })
+
   test('external systems: inactive and error rows are NOT counted as active', () => {
     const rows = [
       { status: 'active', n: 3 },
@@ -468,9 +572,25 @@ describe('bucketing uses the REAL status vocabulary (catches the `<> \'disabled\
   })
 
   test('SUPPORTED_DATA_SOURCE_TYPES matches the pinned DataSourceManager roster', () => {
+    const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..')
+    const managerSource = readFileSync(
+      path.join(
+        repoRoot,
+        'packages/core-backend/src/data-adapters/DataSourceManager.ts',
+      ),
+      'utf8',
+    )
+    const registryBlock =
+      /export const DEFAULT_ADAPTER_REGISTRY = Object\.freeze\(\{([\s\S]*?)\}\s+as const\)/.exec(
+        managerSource,
+      )
+    assert.ok(registryBlock, 'DEFAULT_ADAPTER_REGISTRY source shape must remain parseable')
+    const registryTypes = [...registryBlock[1].matchAll(/^\s*([a-zA-Z][a-zA-Z0-9_]*)\s*:/gm)]
+      .map((match) => match[1])
+      .sort()
     assert.deepEqual(
       [...SUPPORTED_DATA_SOURCE_TYPES].sort(),
-      ['http', 'mysql', 'plm', 'postgres', 'postgresql', 'sqlserver'],
+      registryTypes,
     )
   })
 })
@@ -480,11 +600,21 @@ describe('bucketing uses the REAL status vocabulary (catches the `<> \'disabled\
 // ---------------------------------------------------------------------------
 
 describe('computeVerdict', () => {
-  function coverageFrom({ externalSystemsActive = 0, approvedConfigs = 0, pipelines = 0, runsWindow = 0, gap = null } = {}) {
+  function coverageFrom({
+    externalSystemsActive = 0,
+    externalSystemsUnexpected = 0,
+    approvedConfigs = 0,
+    pipelines = 0,
+    runsWindow = 0,
+    gap = null,
+  } = {}) {
     if (gap) {
       const ok = {
         dataSources: { status: 'ok', active: { status: 'ok' } },
-        externalSystems: { status: 'ok', byStatus: { active: 0 } },
+        externalSystems: {
+          status: 'ok',
+          byStatus: { active: 0, inactive: 0, error: 0, unexpected: 0 },
+        },
         approvedConfigs: { status: 'ok', count: 0 },
         pipelines: { status: 'ok', count: 0 },
         runsWindow: { status: 'ok', count: 0 },
@@ -495,7 +625,16 @@ describe('computeVerdict', () => {
     }
     return {
       dataSources: { status: 'ok', active: { status: 'ok' } },
-      externalSystems: { status: 'ok', kind: TARGET_KIND, byStatus: { active: externalSystemsActive, inactive: 0, error: 0, unexpected: 0 } },
+      externalSystems: {
+        status: 'ok',
+        kind: TARGET_KIND,
+        byStatus: {
+          active: externalSystemsActive,
+          inactive: 0,
+          error: 0,
+          unexpected: externalSystemsUnexpected,
+        },
+      },
       approvedConfigs: { status: 'ok', count: approvedConfigs },
       pipelines: { status: 'ok', count: pipelines },
       runsWindow: { status: 'ok', count: runsWindow },
@@ -517,6 +656,14 @@ describe('computeVerdict', () => {
   test('full coverage + nonzero runsWindow only -> MIGRATION_REQUIRED', () => {
     const { verdict } = computeVerdict(coverageFrom({ runsWindow: 1 }))
     assert.equal(verdict, 'MIGRATION_REQUIRED')
+  })
+
+  test('unknown external-system status vocabulary fails closed as INCONCLUSIVE', () => {
+    const { verdict, reasons } = computeVerdict(
+      coverageFrom({ externalSystemsUnexpected: 3 }),
+    )
+    assert.equal(verdict, 'INCONCLUSIVE')
+    assert.match(reasons.join(' '), /status vocabulary drift/)
   })
 
   test('partial coverage (one gap) -> INCONCLUSIVE, never a bare "0" / never MIGRATION_NOT_REQUIRED', () => {
@@ -864,6 +1011,22 @@ describe('enumerateStaticCallSites', () => {
     }
   })
 
+  test('fail-closed: an unreadable or missing declared scan root cannot produce a partial ok count', () => {
+    const root = makeTmpRepo()
+    try {
+      const result = enumerateStaticCallSites({
+        repoRoot: root,
+        anchors: anchorsFor(root),
+        scanRoots: ['src', 'missing-declared-root'],
+      })
+      assert.equal(result.status, 'unavailable')
+      assert.match(result.reason, /could not be read/)
+      assert.equal(result.scanFailureCount, 1)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   test('fail-closed: an anchor file present but with drifted content also fails closed', () => {
     const root = mkdtempSync(path.join(tmpdir(), 'ds-exposure-inventory-drift-'))
     try {
@@ -885,6 +1048,47 @@ describe('enumerateStaticCallSites', () => {
     const result = enumerateStaticCallSites({ repoRoot })
     assert.equal(result.status, 'ok', result.reason)
     assert.ok(result.scannedFileCount > 0)
+    assert.ok(result.anchorsVerified.includes('target_kind'))
+  })
+
+  test('workflow reruns for every authoritative anchor source on pull_request and push', () => {
+    const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..')
+    const workflow = readFileSync(
+      path.join(repoRoot, '.github/workflows/data-source-exposure-inventory.yml'),
+      'utf8',
+    )
+    const pullRequestBlock =
+      /\n  pull_request:\n([\s\S]*?)(?=\n  push:)/.exec(workflow)?.[1]
+    const pushBlock = /\n  push:\n([\s\S]*?)(?=\n\npermissions:)/.exec(
+      workflow,
+    )?.[1]
+    assert.ok(pullRequestBlock, 'pull_request event block must remain parseable')
+    assert.ok(pushBlock, 'push event block must remain parseable')
+
+    const eventPaths = (block) =>
+      new Set(
+        [...block.matchAll(/^\s+- '([^']+)'$/gm)].map(
+          (match) => match[1],
+        ),
+      )
+    const expectedPaths = [
+      'packages/core-backend/src/routes/data-sources.ts',
+      'packages/core-backend/src/data-adapters/DataSourceManager.ts',
+      'plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs',
+      'plugins/plugin-integration-core/lib/pipeline-runner.cjs',
+    ]
+    for (const [eventName, block] of [
+      ['pull_request', pullRequestBlock],
+      ['push', pushBlock],
+    ]) {
+      const paths = eventPaths(block)
+      for (const expectedPath of expectedPaths) {
+        assert.ok(
+          paths.has(expectedPath),
+          `${eventName}.paths must include ${expectedPath}`,
+        )
+      }
+    }
   })
 })
 
@@ -911,6 +1115,11 @@ describe('buildReport end-to-end', () => {
       assert.equal(report.verdict, 'INCONCLUSIVE')
       assert.notEqual(report.verdict, 'MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE')
       assert.match(report.verdictReasons.join(' '), /staticCallSiteEnumeration/)
+      assert.ok(
+        report.residualBlindSpots.some(
+          (spot) => spot.id === 'static_call_site_enumeration_gap',
+        ),
+      )
     } finally {
       rmSync(emptyRoot, { recursive: true, force: true })
     }
@@ -976,12 +1185,60 @@ describe('main() CLI (hermetic paths only)', () => {
   })
 
   test('an invalid flag fails with exit code 1', async () => {
-    const code = await main(['--not-a-real-flag'], {})
-    assert.equal(code, 1)
+    const sentinel = 'PRIVATE_FLAG_VALUE_MUST_NOT_LEAK'
+    const { result, stderr } = await captureProcessWrites(() =>
+      main([`--${sentinel}`], {}),
+    )
+    assert.equal(result, 1)
+    assert.match(stderr, /INVENTORY_ARGUMENT_INVALID/)
+    assert.doesNotMatch(stderr, new RegExp(sentinel))
   })
 
   test('--help exits 0', async () => {
     const code = await main(['--help'], {})
     assert.equal(code, 0)
+  })
+
+  test('driver-shaped failures are reduced to a closed values-free reason', async () => {
+    const sentinel = 'PRIVATE_DATABASE_HOST_AND_SCHEMA'
+    const { result, stderr } = await captureProcessWrites(() =>
+      main(
+        ['--json'],
+        { DATABASE_URL: 'postgres://private.invalid/db' },
+        {
+          executorFactory: async () => ({
+            exec: async () => {
+              throw new Error(sentinel)
+            },
+            close: async () => {},
+          }),
+        },
+      ),
+    )
+    assert.equal(result, 1)
+    assert.match(stderr, /INVENTORY_EXECUTION_FAILED/)
+    assert.doesNotMatch(stderr, new RegExp(sentinel))
+  })
+
+  test('executor cleanup failure is closed, values-free, and changes success to failure', async () => {
+    const sentinel = 'PRIVATE_POOL_CLOSE_DETAIL'
+    const exec = createFakeExec({ schema: FULL_SCHEMA, counts: ZERO_COUNTS })
+    const { result, stderr } = await captureProcessWrites(() =>
+      main(
+        ['--json'],
+        { DATABASE_URL: 'postgres://private.invalid/db' },
+        {
+          executorFactory: async () => ({
+            exec,
+            close: async () => {
+              throw new Error(sentinel)
+            },
+          }),
+        },
+      ),
+    )
+    assert.equal(result, 1)
+    assert.match(stderr, /INVENTORY_CLEANUP_FAILED/)
+    assert.doesNotMatch(stderr, new RegExp(sentinel))
   })
 })

--- a/scripts/ops/gip-authority-substrate-inventory.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.mjs
@@ -9,10 +9,8 @@
  * nothing about a carrier for this script), scripts/ops/data-source-exposure-inventory.mjs (#4594)
  * must NOT be expanded or reused as the carrier for this work, so nothing here imports from or
  * depends on that script; the schema-probe-first / values-free QUERY_ALLOWLIST pattern is
- * independently re-implemented, because that is the pattern being reused, not the file. Also note:
- * #4594's script/test/workflow files live only on branch `claude/data-source-exposure-inventory-
- * 20260724` (PR #4594) — they are NOT in this tree, NOT on main, and this file makes no claim that
- * they are.
+ * independently re-implemented, because that is the pattern being reused, not the file. #4594's
+ * inventory is a separate carrier: neither inventory imports or depends on the other.
  *
  * ---------------------------------------------------------------------------------------------
  * (β) CONNECTOR-KIND PROBE — integration_external_systems.kind


### PR DESCRIPTION
**Read-only ops tooling. No runtime consumer, no customer DB run, no migration decision.**

This PR replaces the prior ad-hoc inventory SQL with a schema-probing, values-free exposure inventory for the `data-source:sql-readonly` path. The earlier body described the old 89-test head; that transport evidence is superseded by the exact-head evidence below.

## What it does

- Probes the required `public` tables and columns before constructing any count plan.
- Runs only a fixed, module-load-validated `SELECT` allowlist.
- Qualifies every count query to `public`, so `"$user"` or another `search_path` schema cannot shadow the probed objects.
- Uses `bigint` aggregates and rejects malformed, negative, unsafe, zero-row, or multi-row scalar results.
- Treats unknown external-system status values, missing schema, unreadable scan roots/files, and anchor drift as `INCONCLUSIVE`.
- Enumerates the in-repo `/select`, adapter-select, and `copyData` surfaces with fail-closed anchors.
- Emits only fixed vocabulary, counts, and coverage metadata; raw row values and driver errors are not returned.
- Leaves access-log inspection manual and explicitly records undeployed telemetry and other residual blind spots.

## Exact-head evidence

Review head: `d833a1e283d2144cc19e4d558557d58ff39662f7`

- `node --test scripts/ops/data-source-exposure-inventory.test.mjs`: **105/105 PASS**
- `node --test scripts/ops/gip-authority-substrate-inventory.test.mjs`: **144/144 PASS**
- Prettier check and `git diff --check`: PASS
- Eleven targeted mutations: **11 RED / 0 survived**, followed by restored green
- Real PostgreSQL 15.17 regression:
  - public-only exposure: `MIGRATION_REQUIRED`, five relevant counts = 1
  - same database after creating empty same-name tables in the default `"$user"` schema: still `MIGRATION_REQUIRED`, the same five counts = 1
- Independent Kimi K3 adversarial review of the hardened delta found **0 P1 / 0 P2 / 3 P3**. All three P3s were then fixed: scalar aggregate cardinality controls, per-event workflow anchor coverage, and static-enumeration residual reporting.

The attempted second Kimi delta process did not return a final verdict and is not represented as passing evidence.

## Boundaries

- This PR does not query a customer database.
- It does not deploy telemetry, alter adapters, enforce pagination, migrate callers, arm a profile, change flags, or authorize rollout.
- A zero remains only `MIGRATION_NOT_REQUIRED_WITHIN_COVERAGE`; it is never proof of zero live traffic.
- B2 enforcement remains a later, separately gated change.
