### PR TITLE
B1a-1: config v2 — orderingKeySpec + actionProfileVersion (additive)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/gip-profile-certification-contracts.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/gip-profile-certification-contracts.test.cjs
@@ -19,12 +19,14 @@ const {
   GIP_CONSISTENCY_REQUIREMENT_STATUSES,
   GIP_PROFILE_ERROR_REASONS,
   GipProfileContractError,
+  isValidProfileId,
   normalizeCertifiedReadActionProfile,
   normalizeCertifiedApplyProfile,
   deriveRecoveryStrategy,
   validateConsistencyEvidence,
   validateCompletenessEvidence,
   assertRoleTypeAllowed,
+  __internals,
 } = require(path.join(__dirname, '..', 'lib', 'gip-profile-certification-contracts.cjs'))
 
 function rejectsWith(fn, reason) {
@@ -333,6 +335,46 @@ function coarseDetails() {
     'offending values must never appear in thrown errors')
 }
 
+// ── 10. Public isValidProfileId is the SAME source of truth as the internal PROFILE_ID_PATTERN ──
+// Review B1a-1 P2: isValidProfileId (public) must never become a second copy of the profileId
+// regex. This table proves it agrees with __internals.PROFILE_ID_PATTERN (plus the shared 128-char
+// bound) across valid/invalid ids — including the two edge cases that would silently pass a hand-
+// rolled-regex or dropped-bound divergence: an over-length id that is otherwise pattern-valid, and
+// an id rejected purely by shape (not length).
+function publicHelperAgreesWithInternalPattern() {
+  const overLength = `fixture.${'a'.repeat(120)}.v1` // pattern-valid, 131 chars > 128 bound
+  const table = [
+    'fixture.paged_read.v1',
+    'fixture.paged_read.v12',
+    'fixture.multi.part.name.v3',
+    'FIXTURE.paged_read.v1', // uppercase — invalid
+    'fixture_paged_read_v1', // no dot — invalid
+    'fixture.paged_read', // no version token — invalid
+    'fixture.paged_read.v1.', // trailing dot — invalid
+    '.fixture.paged_read.v1', // leading dot — invalid
+    'fixture.paged_read.v0', // v0 — invalid (v[1-9][0-9]* excludes leading zero)
+    '', // empty — invalid
+    overLength,
+  ]
+  for (const id of table) {
+    const expected = typeof id === 'string' && id.length <= 128 && __internals.PROFILE_ID_PATTERN.test(id)
+    assert.equal(
+      isValidProfileId(id),
+      expected,
+      `isValidProfileId must agree with __internals.PROFILE_ID_PATTERN (+128 bound) for ${JSON.stringify(id)}`,
+    )
+  }
+  // Guard the table itself: each dimension must actually be exercised, or a broken helper could
+  // still pass this function vacuously (e.g. an all-accept or all-reject helper against a table
+  // that never varies).
+  assert.ok(table.some((id) => isValidProfileId(id)), 'table must include at least one accepted id')
+  assert.ok(table.some((id) => !__internals.PROFILE_ID_PATTERN.test(id)), 'table must include a pattern-invalid id')
+  assert.ok(
+    overLength.length > 128 && __internals.PROFILE_ID_PATTERN.test(overLength) && !isValidProfileId(overLength),
+    'table must include an id that is pattern-valid but rejected ONLY by the 128-char bound',
+  )
+}
+
 function main() {
   frozenVocabularies()
   everyFailCallSiteUsesADeclaredReason()
@@ -344,6 +386,7 @@ function main() {
   evidenceShapes()
   roleTypeGate()
   coarseDetails()
+  publicHelperAgreesWithInternalPattern()
   console.log('gip-profile-certification-contracts.test.cjs OK')
 }
 

--- a/plugins/plugin-integration-core/__tests__/gip-profile-certification-contracts.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/gip-profile-certification-contracts.test.cjs
@@ -373,6 +373,21 @@ function publicHelperAgreesWithInternalPattern() {
     overLength.length > 128 && __internals.PROFILE_ID_PATTERN.test(overLength) && !isValidProfileId(overLength),
     'table must include an id that is pattern-valid but rejected ONLY by the 128-char bound',
   )
+  // Trim-semantics asymmetry (pinned, not just asserted in prose above the function definition):
+  // isValidProfileId is deliberately UNTRIMMED — a padded id must be rejected here even though its
+  // trimmed form would match PROFILE_ID_PATTERN.
+  const padded = ' fixture.paged_read.v1 '
+  assert.equal(isValidProfileId(padded), false, 'isValidProfileId is untrimmed: a padded id must be rejected')
+  // Contrast with the PRE-EXISTING, UNCHANGED-by-this-PR behaviour of normalizeCertifiedReadActionProfile:
+  // it trims via nonBlankString BEFORE testing length/pattern, so the SAME padded string is accepted
+  // there. This is not a new decision introduced by isValidProfileId — it documents an asymmetry that
+  // already existed between this module's two profileId entry points, so isValidProfileId is not
+  // expected to (and must not silently start to) match normalizeCertifiedReadActionProfile's trimming.
+  assert.equal(
+    normalizeCertifiedReadActionProfile(fixtureProfile({ profileId: padded })).profileId,
+    'fixture.paged_read.v1',
+    'normalizeCertifiedReadActionProfile trims via nonBlankString before testing — it accepts what isValidProfileId (untrimmed) rejects',
+  )
 }
 
 function main() {

--- a/plugins/plugin-integration-core/__tests__/read-source-config-store.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-source-config-store.test.cjs
@@ -430,11 +430,33 @@ async function testConfigV2OrderingKeySpecAndActionProfileVersion() {
   assert.notEqual(variant.version, saved.version, 'an orderingKeySpec-only change must mint a NEW version, not collapse onto the existing one')
   assert.equal(db.tables[CONFIG_TABLE].length, 2, 'two distinct orderingKeySpec bodies must be two distinct rows')
 
+  // (iii) — added in the fix pass for PR #4601: a body differing ONLY in actionProfileVersion (orderingKeySpec
+  // held IDENTICAL to `withBoth`) must ALSO mint a different content_key/version. Without this, contentKeyFor
+  // could drop actionProfileVersion from its hash entirely and (i)+(ii) above would not notice — (i) only
+  // proves actionProfileVersion SURVIVES persistence, and (ii) only pins orderingKeySpec's participation.
+  // Adversarial mutation probe (reviewer, re-verified in the fix pass): editing contentKeyFor to
+  // `const { version, actionProfileVersion, ...content } = normalizedConfig` left BOTH suites green before
+  // this case existed.
+  const actionProfileVariant = await store.saveVersion({
+    ...SCOPE,
+    config: validConfig({
+      orderingKeySpec: [{ fieldId: DISTINCTIVE.fieldTarget, direction: 'ASC' }], // identical to withBoth
+      actionProfileVersion: 'erp.material_single_record.v2', // ONLY this differs from withBoth
+    }),
+    actor: 'consultant_1',
+  })
+  assert.equal(actionProfileVariant.reused, false, 'a body differing only in actionProfileVersion must NOT be treated as a reuse')
+  assert.notEqual(actionProfileVariant.contentKey, saved.contentKey, 'actionProfileVersion must participate in the content key')
+  assert.notEqual(actionProfileVariant.version, saved.version, 'an actionProfileVersion-only change must mint a NEW version, not collapse onto the existing one')
+  assert.equal(db.tables[CONFIG_TABLE].length, 3, 'three distinct bodies (base, orderingKeySpec variant, actionProfileVersion variant) must be three distinct rows')
+
   // Sanity control: the SAME body saved again is still correctly reused — this predicate is about
-  // orderingKeySpec PARTICIPATING in the content key, not about breaking idempotency generally.
+  // orderingKeySpec/actionProfileVersion PARTICIPATING in the content key, not about breaking idempotency
+  // generally.
   const repeat = await store.saveVersion({ ...SCOPE, config: withBoth, actor: 'consultant_2' })
   assert.equal(repeat.reused, true)
   assert.equal(repeat.id, saved.id)
+  assert.equal(db.tables[CONFIG_TABLE].length, 3, 'the repeat save of the original body is a no-op on the config table')
 }
 
 async function testContentKeyHelperIsStable() {

--- a/plugins/plugin-integration-core/__tests__/read-source-config-store.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-source-config-store.test.cjs
@@ -386,6 +386,57 @@ async function testAuditTrailIsValuesFree() {
   assert.deepEqual({ ...statusChange.detail }, { from: 'draft', to: 'approved' })
 }
 
+// B1a §4 step 1.1 acceptance predicate — MANDATED by the ledger (two enforcement points: the allowlist
+// decides acceptance, normalizeReadSourceConfig decides persistence, and contentKeyFor hashes the
+// normalize OUTPUT — so both must be exercised through the real save → re-read path, not the S1 validator
+// alone, or an allowlist-only change would satisfy a save/accept test while silently discarding the fields).
+async function testConfigV2OrderingKeySpecAndActionProfileVersion() {
+  const { db, store } = newStore()
+
+  // (i) save a body carrying BOTH new fields, re-read the STORED ROW, assert both survive into `config`.
+  const withBoth = validConfig({
+    orderingKeySpec: [{ fieldId: DISTINCTIVE.fieldTarget, direction: 'ASC' }],
+    actionProfileVersion: 'erp.material_single_record.v1',
+  })
+  const saved = await store.saveVersion({ ...SCOPE, config: withBoth, actor: 'consultant_1' })
+  assert.equal(saved.reused, false)
+  const reread = await store.get({ ...SCOPE, id: saved.id })
+  // rowToPublicReadSourceConfig runs the config through sanitizeIntegrationPayload, which returns a
+  // null-prototype clone (same idiom as testAuditTrailIsValuesFree's `{ ...statusChange.detail }` above) —
+  // round-trip through JSON so the comparison is about VALUE survival, not prototype identity.
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(reread.config.orderingKeySpec)), [{ fieldId: DISTINCTIVE.fieldTarget, direction: 'ASC' }],
+    'orderingKeySpec must survive save → re-read',
+  )
+  assert.equal(reread.config.actionProfileVersion, 'erp.material_single_record.v1', 'actionProfileVersion must survive save → re-read')
+  // Also assert directly against the raw stored row (bypasses rowToPublicReadSourceConfig's sanitize pass).
+  const row = db.tables[CONFIG_TABLE].find((r) => r.id === saved.id)
+  assert.deepEqual(row.config.orderingKeySpec, [{ fieldId: DISTINCTIVE.fieldTarget, direction: 'ASC' }])
+  assert.equal(row.config.actionProfileVersion, 'erp.material_single_record.v1')
+
+  // (ii) two bodies in the SAME family differing ONLY in orderingKeySpec must mint DIFFERENT content_keys
+  // and DIFFERENT versions — otherwise they collapse and the idempotent-save path returns the OLDER
+  // version, i.e. configContentKey silently stops pinning ordering behaviour.
+  const variant = await store.saveVersion({
+    ...SCOPE,
+    config: validConfig({
+      orderingKeySpec: [{ fieldId: DISTINCTIVE.fieldTarget, direction: 'DESC' }],
+      actionProfileVersion: 'erp.material_single_record.v1',
+    }),
+    actor: 'consultant_1',
+  })
+  assert.equal(variant.reused, false, 'a body differing only in orderingKeySpec must NOT be treated as a reuse of the earlier version')
+  assert.notEqual(variant.contentKey, saved.contentKey, 'orderingKeySpec must participate in the content key')
+  assert.notEqual(variant.version, saved.version, 'an orderingKeySpec-only change must mint a NEW version, not collapse onto the existing one')
+  assert.equal(db.tables[CONFIG_TABLE].length, 2, 'two distinct orderingKeySpec bodies must be two distinct rows')
+
+  // Sanity control: the SAME body saved again is still correctly reused — this predicate is about
+  // orderingKeySpec PARTICIPATING in the content key, not about breaking idempotency generally.
+  const repeat = await store.saveVersion({ ...SCOPE, config: withBoth, actor: 'consultant_2' })
+  assert.equal(repeat.reused, true)
+  assert.equal(repeat.id, saved.id)
+}
+
 async function testContentKeyHelperIsStable() {
   const key1 = __internals.contentKeyFor({ b: 2, a: [1, { d: 4, c: 3 }] })
   const key2 = __internals.contentKeyFor({ a: [1, { c: 3, d: 4 }], b: 2 })
@@ -409,6 +460,7 @@ async function main() {
   await testUniqueViolationRouting()
   await testScopingAndNotFound()
   await testAuditTrailIsValuesFree()
+  await testConfigV2OrderingKeySpecAndActionProfileVersion()
   await testContentKeyHelperIsStable()
   console.log('read-source-config-store.test.cjs OK')
 }

--- a/plugins/plugin-integration-core/__tests__/read-source-config.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-source-config.test.cjs
@@ -172,6 +172,138 @@ assert.ok(codes(validateReadSourceConfig({ ...baseValid('list_page'), resolverRu
 assert.deepEqual(validateReadSourceConfig({ valid: false }).errors[0].code, 'READ_SOURCE_UNEXPECTED_FIELD')
 assert.equal(validateReadSourceConfig(null).errors[0].code, 'READ_SOURCE_CONFIG_NOT_OBJECT')
 
+// --- 8. B1a §4 step 1.1 — config v2: orderingKeySpec + actionProfileVersion (additive, closed schema) ---
+// Ledger: docs/development/database-system-integration-line-design-and-verification-20260724.md §4 step
+// 1.1, §3.1⟲R6. Both fields are OPTIONAL — omitting them must not change behaviour (every mode's
+// baseValid() above omits both and passes unaffected; 8c below asserts it explicitly).
+//
+// THE FLIP: no test on main names either key before this PR (verified by tree-wide grep at `402f04982`) —
+// the "existing test that asserts today's rejection" the ledger points at does not exist as a named case;
+// the generic `nefariousKey` case at line 127 is the only prior guard and stays in place (8b below shows the
+// widening is exactly two keys, not "anything goes"). This block IS the flip: before the lib change below,
+// every assertion in 8a-8f that expects `valid === true` instead red with `READ_SOURCE_UNEXPECTED_FIELD` /
+// `READ_SOURCE_ORDERING_KEY_SPEC_INVALID` / `READ_SOURCE_ACTION_PROFILE_VERSION_INVALID` absent from the
+// error-code vocabulary (those codes don't exist yet either) — captured verbatim in the PR description as
+// the red run.
+
+// 8a. Well-shaped orderingKeySpec + actionProfileVersion together must be ACCEPTED and survive normalization.
+{
+  const withBoth = validateReadSourceConfig({
+    ...baseValid('single_record'),
+    fieldMap: [{ source: 'FQty', target: 'qty_col' }],
+    orderingKeySpec: [{ fieldId: 'qty_col', direction: 'ASC' }],
+    actionProfileVersion: 'erp.material_single_record.v1',
+  })
+  assert.equal(withBoth.valid, true, `well-shaped orderingKeySpec + actionProfileVersion must be ACCEPTED: ${JSON.stringify(withBoth.errors)}`)
+  assert.deepEqual(withBoth.normalized.orderingKeySpec, [{ fieldId: 'qty_col', direction: 'ASC' }])
+  assert.equal(withBoth.normalized.actionProfileVersion, 'erp.material_single_record.v1')
+  assert.ok(Object.isFrozen(withBoth.normalized.orderingKeySpec), 'orderingKeySpec array must be frozen')
+  assert.ok(Object.isFrozen(withBoth.normalized.orderingKeySpec[0]), 'orderingKeySpec entries must be frozen')
+}
+
+// 8b. Narrow widening — an UNLISTED key alongside these two still rejects (the allowlist grew by exactly
+// two keys, not "anything goes").
+assert.ok(codes(validateReadSourceConfig({ ...baseValid('list_page'), orderingSomethingElse: 'x' })).includes('READ_SOURCE_UNEXPECTED_FIELD'))
+
+// 8c. Omitting both fields is unaffected — the normalized output carries neither key when absent.
+{
+  const omitted = validateReadSourceConfig(baseValid('list_page'))
+  assert.equal(omitted.valid, true)
+  assert.ok(!('orderingKeySpec' in omitted.normalized), 'orderingKeySpec must be absent when omitted from input')
+  assert.ok(!('actionProfileVersion' in omitted.normalized), 'actionProfileVersion must be absent when omitted from input')
+}
+
+// 8d. orderingKeySpec closed schema (⟲R6).
+const orderingBase = (fieldMap, spec) => ({ ...baseValid('single_record'), fieldMap, orderingKeySpec: spec })
+// non-empty array required.
+assert.ok(codes(validateReadSourceConfig(orderingBase([{ source: 'FQty', target: 'qty' }], []))).includes('READ_SOURCE_ORDERING_KEY_SPEC_INVALID'))
+assert.ok(codes(validateReadSourceConfig(orderingBase([{ source: 'FQty', target: 'qty' }], 'qty'))).includes('READ_SOURCE_ORDERING_KEY_SPEC_INVALID'))
+// duplicate fieldIds rejected.
+assert.ok(codes(validateReadSourceConfig(orderingBase(
+  [{ source: 'FQty', target: 'qty' }],
+  [{ fieldId: 'qty', direction: 'ASC' }, { fieldId: 'qty', direction: 'DESC' }],
+))).includes('READ_SOURCE_ORDERING_KEY_SPEC_INVALID'), 'duplicate fieldIds must be rejected')
+// canonical fieldIds only — never raw SQL, expressions, or aliases.
+for (const badFieldId of ['qty; DROP TABLE x', 'qty AS q', 'qty + 1', 'a.b.c()', 'qty OR 1=1', '', 'has space']) {
+  assert.ok(
+    codes(validateReadSourceConfig(orderingBase(
+      [{ source: 'FQty', target: 'qty' }],
+      [{ fieldId: badFieldId, direction: 'ASC' }],
+    ))).includes('READ_SOURCE_ORDERING_KEY_SPEC_INVALID'),
+    `orderingKeySpec must reject raw-SQL/expression-shaped fieldId: ${JSON.stringify(badFieldId)}`,
+  )
+}
+// direction must be ASC/DESC, UPPERCASE-strict.
+for (const badDirection of ['asc', 'desc', 'Ascending', 'ASCENDING', '', 'up']) {
+  assert.ok(
+    codes(validateReadSourceConfig(orderingBase(
+      [{ source: 'FQty', target: 'qty' }],
+      [{ fieldId: 'qty', direction: badDirection }],
+    ))).includes('READ_SOURCE_ORDERING_KEY_SPEC_INVALID'),
+    `orderingKeySpec.direction must reject non-uppercase/unknown: ${JSON.stringify(badDirection)}`,
+  )
+}
+for (const okDirection of ['ASC', 'DESC']) {
+  assert.equal(validateReadSourceConfig(orderingBase(
+    [{ source: 'FQty', target: 'qty' }],
+    [{ fieldId: 'qty', direction: okDirection }],
+  )).valid, true, `orderingKeySpec.direction must accept ${okDirection}`)
+}
+// every fieldId must resolve through the SAME config version's fieldMap targets — unresolvable ⇒ rejection.
+assert.ok(codes(validateReadSourceConfig(orderingBase(
+  [{ source: 'FQty', target: 'qty' }],
+  [{ fieldId: 'not_a_target', direction: 'ASC' }],
+))).includes('READ_SOURCE_ORDERING_KEY_SPEC_INVALID'), 'a fieldId with no matching fieldMap target must be rejected')
+// orderingKeySpec present with NO fieldMap at all ⇒ every fieldId is unresolvable ⇒ rejection. Deliberate:
+// no "skip the resolution check when fieldMap is absent" escape hatch.
+{
+  const cfg = baseValid('list_page') // list_page's baseValid carries no fieldMap
+  assert.equal(cfg.fieldMap, undefined)
+  const res = validateReadSourceConfig({ ...cfg, orderingKeySpec: [{ fieldId: 'anything', direction: 'ASC' }] })
+  assert.ok(
+    codes(res).includes('READ_SOURCE_ORDERING_KEY_SPEC_INVALID'),
+    'orderingKeySpec without a fieldMap to resolve against must be rejected, not silently skipped',
+  )
+}
+// NULLability is deliberately NOT a schema check — there is no such key on an entry. An attempted extra key
+// (e.g. a "nullable" flag) is rejected as an unrecognised entry shape, the same way fieldMap's {source,
+// target}-only shape rejects a third key — not as a NULL-specific rule.
+assert.ok(codes(validateReadSourceConfig(orderingBase(
+  [{ source: 'FQty', target: 'qty' }],
+  [{ fieldId: 'qty', direction: 'ASC', nullable: false }],
+))).includes('READ_SOURCE_ORDERING_KEY_SPEC_INVALID'), 'an entry carrying any key beyond fieldId/direction must be rejected')
+
+// 8e. Direction-case decision is RATIFIED and PINNED both ways (owner ruling: keep the two vocabularies
+// separate, never unified by a read-time normalizer). resolverSortDirection stays lowercase-only;
+// orderingKeySpec.direction stays uppercase-only — each direction of the split is asserted so a future
+// one-sided normalizer would red here.
+assert.equal(
+  validateReadSourceConfig(resolver({ resolverRule: 'first_when_sorted', multiplicityRuleField: 'FDate', resolverSortDirection: 'ASC' })).valid,
+  false, 'resolverSortDirection must stay LOWERCASE-only — uppercase ASC must still be rejected',
+)
+assert.equal(
+  validateReadSourceConfig(resolver({ resolverRule: 'first_when_sorted', multiplicityRuleField: 'FDate', resolverSortDirection: 'asc' })).valid,
+  true, 'resolverSortDirection lowercase must keep working',
+)
+assert.equal(
+  validateReadSourceConfig(orderingBase([{ source: 'FQty', target: 'qty' }], [{ fieldId: 'qty', direction: 'asc' }])).valid,
+  false, 'orderingKeySpec.direction must stay UPPERCASE-only — lowercase asc must be rejected',
+)
+assert.equal(
+  validateReadSourceConfig(orderingBase([{ source: 'FQty', target: 'qty' }], [{ fieldId: 'qty', direction: 'ASC' }])).valid,
+  true, 'orderingKeySpec.direction uppercase must keep working',
+)
+
+// 8f. actionProfileVersion validates against the SAME PROFILE_ID_PATTERN vocabulary as GIP certification
+// (imported from gip-profile-certification-contracts.cjs, never duplicated, so the two cannot drift).
+for (const bad of ['NotLowercase.action.v1', 'no_dot_at_all', 'missing.version.token', 'trailing.dot.v1.', 'a.b.v0', '.leading.v1', `${'a'.repeat(130)}.b.v1`]) {
+  assert.ok(
+    codes(validateReadSourceConfig({ ...baseValid('list_page'), actionProfileVersion: bad })).includes('READ_SOURCE_ACTION_PROFILE_VERSION_INVALID'),
+    `actionProfileVersion must reject ${JSON.stringify(bad)}`,
+  )
+}
+assert.equal(validateReadSourceConfig({ ...baseValid('list_page'), actionProfileVersion: 'erp.material_list.v3' }).valid, true)
+
 // --- 7. Values-free errors (leak-bait): a secret-shaped value + a hostile endpoint must NOT appear in errors ---
 const leaky = {
   ...baseValid('list_page'),

--- a/plugins/plugin-integration-core/__tests__/read-source-config.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-source-config.test.cjs
@@ -186,7 +186,8 @@ assert.equal(validateReadSourceConfig(null).errors[0].code, 'READ_SOURCE_CONFIG_
 // `READ_SOURCE_UNEXPECTED_FIELD` / `READ_SOURCE_ORDERING_KEY_SPEC_INVALID` /
 // `READ_SOURCE_ACTION_PROFILE_VERSION_INVALID` absent from the error-code vocabulary (those codes don't
 // exist yet either) — captured verbatim in the PR description as the pre-change red run. The PRE-EXISTING
-// generic `nefariousKey` case at line 127 is a separate, already-passing negative control and is
+// generic standalone `nefariousKey` unexpected-field assertion above (before this block) is a separate,
+// already-passing negative control and is
 // RETAINED unchanged (8b below shows the widening this PR adds is exactly two keys, not "anything goes").
 
 // 8a. Well-shaped orderingKeySpec + actionProfileVersion together must be ACCEPTED and survive normalization.

--- a/plugins/plugin-integration-core/__tests__/read-source-config.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-source-config.test.cjs
@@ -177,14 +177,17 @@ assert.equal(validateReadSourceConfig(null).errors[0].code, 'READ_SOURCE_CONFIG_
 // 1.1, §3.1⟲R6. Both fields are OPTIONAL — omitting them must not change behaviour (every mode's
 // baseValid() above omits both and passes unaffected; 8c below asserts it explicitly).
 //
-// THE FLIP: no test on main names either key before this PR (verified by tree-wide grep at `402f04982`) —
-// the "existing test that asserts today's rejection" the ledger points at does not exist as a named case;
-// the generic `nefariousKey` case at line 127 is the only prior guard and stays in place (8b below shows the
-// widening is exactly two keys, not "anything goes"). This block IS the flip: before the lib change below,
-// every assertion in 8a-8f that expects `valid === true` instead red with `READ_SOURCE_UNEXPECTED_FIELD` /
-// `READ_SOURCE_ORDERING_KEY_SPEC_INVALID` / `READ_SOURCE_ACTION_PROFILE_VERSION_INVALID` absent from the
-// error-code vocabulary (those codes don't exist yet either) — captured verbatim in the PR description as
-// the red run.
+// Owner ruling on this block's description: no NAMED test on `main` asserted rejection of either key
+// before this PR (verified by tree-wide grep at `402f04982` — `orderingKeySpec` appears nowhere in
+// code or tests; `actionProfileVersion` appears only in three unrelated GIP certification/qualification
+// test files, none of which exercise this validator or module). So there was no existing named case to
+// "flip". This block is a NEWLY ADDED, NAMED pre-change RED / post-change GREEN characterisation test:
+// before the lib change below, every assertion in 8a-8f that expects `valid === true` instead red with
+// `READ_SOURCE_UNEXPECTED_FIELD` / `READ_SOURCE_ORDERING_KEY_SPEC_INVALID` /
+// `READ_SOURCE_ACTION_PROFILE_VERSION_INVALID` absent from the error-code vocabulary (those codes don't
+// exist yet either) — captured verbatim in the PR description as the pre-change red run. The PRE-EXISTING
+// generic `nefariousKey` case at line 127 is a separate, already-passing negative control and is
+// RETAINED unchanged (8b below shows the widening this PR adds is exactly two keys, not "anything goes").
 
 // 8a. Well-shaped orderingKeySpec + actionProfileVersion together must be ACCEPTED and survive normalization.
 {

--- a/plugins/plugin-integration-core/__tests__/read-source-config.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-source-config.test.cjs
@@ -223,14 +223,24 @@ assert.ok(codes(validateReadSourceConfig(orderingBase(
   [{ source: 'FQty', target: 'qty' }],
   [{ fieldId: 'qty', direction: 'ASC' }, { fieldId: 'qty', direction: 'DESC' }],
 ))).includes('READ_SOURCE_ORDERING_KEY_SPEC_INVALID'), 'duplicate fieldIds must be rejected')
-// canonical fieldIds only — never raw SQL, expressions, or aliases.
+// canonical fieldIds only — never raw SQL, expressions, or aliases. Reason EXCLUSIVITY, not mere
+// inclusion of the coarse READ_SOURCE_ORDERING_KEY_SPEC_INVALID code: every orderingKeySpec violation
+// (invalid shape, unresolved fieldId, invalid direction, ...) shares that SAME code, so a code-only
+// assertion stays green even if the `isBoundedIdentifier` guard below is deleted — a different rule in
+// this same block (the fieldMapTargets resolution check) also fires on these inputs (none of them equals
+// the lone fieldMap target 'qty') and pushes the SAME code under reason `field_id_unresolved` instead.
+// Asserting the reason SET is exactly ['field_id_invalid'] is what actually pins this guard as load-bearing.
 for (const badFieldId of ['qty; DROP TABLE x', 'qty AS q', 'qty + 1', 'a.b.c()', 'qty OR 1=1', '', 'has space']) {
-  assert.ok(
-    codes(validateReadSourceConfig(orderingBase(
-      [{ source: 'FQty', target: 'qty' }],
-      [{ fieldId: badFieldId, direction: 'ASC' }],
-    ))).includes('READ_SOURCE_ORDERING_KEY_SPEC_INVALID'),
-    `orderingKeySpec must reject raw-SQL/expression-shaped fieldId: ${JSON.stringify(badFieldId)}`,
+  const res = validateReadSourceConfig(orderingBase(
+    [{ source: 'FQty', target: 'qty' }],
+    [{ fieldId: badFieldId, direction: 'ASC' }],
+  ))
+  const orderingReasons = res.errors.filter((e) => e.field === 'orderingKeySpec').map((e) => e.reason)
+  assert.deepEqual(
+    orderingReasons,
+    ['field_id_invalid'],
+    `orderingKeySpec must reject raw-SQL/expression-shaped fieldId with EXACTLY reason field_id_invalid ` +
+    `(not some other rule catching it instead): ${JSON.stringify(badFieldId)} => ${JSON.stringify(res.errors)}`,
   )
 }
 // direction must be ASC/DESC, UPPERCASE-strict.

--- a/plugins/plugin-integration-core/lib/gip-profile-certification-contracts.cjs
+++ b/plugins/plugin-integration-core/lib/gip-profile-certification-contracts.cjs
@@ -182,6 +182,21 @@ function normalizeClosedSet(value, vocabulary, field, reason) {
 // (future, individually-gated) bridge.bounded_read.v1. The pattern is frozen here so
 // lineage fields agree on ONE spelling; certifying any concrete id stays gated.
 const PROFILE_ID_PATTERN = /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+\.v[1-9][0-9]*$/
+// Public contract (review B1a-1 P2): another module's SAVE-TIME validator needs to check the
+// profileId/applyProfileId shape without reaching into this module's `__internals` test/private
+// surface. This is that public entry point. It is a THIN wrapper over the SAME PROFILE_ID_PATTERN
+// object used by normalizeCertifiedReadActionProfile/normalizeCertifiedApplyProfile below and
+// exposed via __internals — never a second copy of the regex, so the two cannot drift. Carries the
+// same <=128-char bound as those call sites, but is DELIBERATELY untrimmed — normalizeCertified*
+// above trims (via nonBlankString) BEFORE testing length/pattern, so e.g. ' erp.a.v1 ' passes there;
+// this helper tests the raw value, so the same padded string fails here. That is not an oversight:
+// it matches how the one production consumer of this helper (read-source-config.cjs) already
+// validates its untrimmed field today, trimming only afterward at normalization/storage time — so
+// wiring this helper in is a behaviour-preserving refactor, not a widening of what that save path
+// accepts. A caller that wants the trimmed/nonBlankString semantics should trim before calling.
+function isValidProfileId(value) {
+  return typeof value === 'string' && value.length <= 128 && PROFILE_ID_PATTERN.test(value)
+}
 
 // GIP-D0 §3 "complete contract" components are all expressible: the four schema
 // dimensions + combination rules + maxScale + orderingKeyRequirement + the declared
@@ -553,6 +568,7 @@ module.exports = {
   GIP_CONSISTENCY_REQUIREMENT_STATUSES,
   GIP_PROFILE_ERROR_REASONS,
   GipProfileContractError,
+  isValidProfileId,
   normalizeCertifiedReadActionProfile,
   normalizeCertifiedApplyProfile,
   deriveRecoveryStrategy,

--- a/plugins/plugin-integration-core/lib/read-source-config.cjs
+++ b/plugins/plugin-integration-core/lib/read-source-config.cjs
@@ -14,9 +14,13 @@
 // This mirrors the fail-closed / enum-strict / coarse-reason idiom of normalizeReadSmokeContract.
 
 const { scrubSecretStringValue } = require('./payload-redaction.cjs')
-// PROFILE_ID_PATTERN is IMPORTED, never duplicated, so actionProfileVersion here and the GIP certification
-// module's profileId vocabulary cannot drift apart (ledger §4 step 1.1).
-const { __internals: { PROFILE_ID_PATTERN } } = require('./gip-profile-certification-contracts.cjs')
+// isValidProfileId is IMPORTED from the certification module's PUBLIC surface — never __internals,
+// never a second copy of the regex — so actionProfileVersion here and the GIP certification module's
+// profileId vocabulary cannot drift apart (ledger §4 step 1.1; review B1a-1 P2: a live save path must
+// not depend on another module's private/test surface). isValidProfileId carries the same <=128-char
+// bound this field needs and is untrimmed, matching this module's own untrimmed validate-then-trim
+// shape (see normalizeReadSourceConfig below) — see its definition for the exact semantics.
+const { isValidProfileId } = require('./gip-profile-certification-contracts.cjs')
 
 // The four proven read modes (standard names from #3416); nothing else is accepted.
 const READ_SOURCE_MODES = Object.freeze(['single_record', 'list_page', 'detail_with_lines', 'resolver_lookup'])
@@ -278,16 +282,11 @@ function validateReadSourceConfig(config) {
   }
 
   // actionProfileVersion — B1a §4 step 1.1. OPTIONAL; omitted ⇒ no behaviour change. Validated against the
-  // SAME PROFILE_ID_PATTERN vocabulary as GIP certification (imported above, never duplicated) so the two
-  // cannot drift; this field must not move systemContentKey (GIP-D0 §6) — it is a config-plane value only.
-  if (config.actionProfileVersion !== undefined) {
-    if (
-      typeof config.actionProfileVersion !== 'string' ||
-      config.actionProfileVersion.length > 128 ||
-      !PROFILE_ID_PATTERN.test(config.actionProfileVersion)
-    ) {
-      push('READ_SOURCE_ACTION_PROFILE_VERSION_INVALID', 'actionProfileVersion', 'not_allowlisted')
-    }
+  // SAME profileId vocabulary as GIP certification via its PUBLIC isValidProfileId (imported above, never
+  // duplicated, never reaching into __internals) so the two cannot drift; this field must not move
+  // systemContentKey (GIP-D0 §6) — it is a config-plane value only.
+  if (config.actionProfileVersion !== undefined && !isValidProfileId(config.actionProfileVersion)) {
+    push('READ_SOURCE_ACTION_PROFILE_VERSION_INVALID', 'actionProfileVersion', 'not_allowlisted')
   }
 
   // R0 resolver_lookup contract (rule-gated multiplicity; #1709 / resolver design-lock). The resolver keys

--- a/plugins/plugin-integration-core/lib/read-source-config.cjs
+++ b/plugins/plugin-integration-core/lib/read-source-config.cjs
@@ -14,6 +14,9 @@
 // This mirrors the fail-closed / enum-strict / coarse-reason idiom of normalizeReadSmokeContract.
 
 const { scrubSecretStringValue } = require('./payload-redaction.cjs')
+// PROFILE_ID_PATTERN is IMPORTED, never duplicated, so actionProfileVersion here and the GIP certification
+// module's profileId vocabulary cannot drift apart (ledger §4 step 1.1).
+const { __internals: { PROFILE_ID_PATTERN } } = require('./gip-profile-certification-contracts.cjs')
 
 // The four proven read modes (standard names from #3416); nothing else is accepted.
 const READ_SOURCE_MODES = Object.freeze(['single_record', 'list_page', 'detail_with_lines', 'resolver_lookup'])
@@ -25,6 +28,13 @@ const READ_SOURCE_KEY_ENCODINGS = Object.freeze(['structured_json_field', 'filte
 // old/pre-R0 resolver config that never declared it is fail-closed invalid (never silently reinterpreted).
 const RESOLVER_RULES = Object.freeze(['exactly_one', 'first_when_sorted', 'field_equals'])
 const RESOLVER_SORT_DIRECTIONS = Object.freeze(['asc', 'desc'])
+
+// B1a §4 step 1.1 (⟲R6) — orderingKeySpec.direction. Deliberately UPPERCASE and deliberately NOT unified
+// with RESOLVER_SORT_DIRECTIONS above (owner-ratified decision, ledger §4 step 1.1): a read-time normalizer
+// that reconciled the two vocabularies would let two textually different approved bodies — different
+// configContentKey, different qualification digest — behave identically, silently un-pinning behaviour the
+// content key exists to pin. Keep both vocabularies exactly as they are.
+const ORDERING_KEY_DIRECTIONS = Object.freeze(['ASC', 'DESC'])
 
 // Per-mode REQUIRED fields — hardcoded for the four modes (NOT a generic schema engine; per the design-lock,
 // "the four read modes" means "knows each mode's shape"). resolver_lookup: multiplicityRuleField is no longer
@@ -55,6 +65,11 @@ const ALLOWED_CONFIG_KEYS = Object.freeze(new Set([
   'multiplicityRuleField', 'fieldMap',
   // R0: resolver_lookup contract keys (rule-gated below; rejected on non-resolver modes).
   'resolverRule', 'resolverSortDirection', 'resolverDiscriminatorValue',
+  // B1a §4 step 1.1 — config v2 (additive; OPTIONAL on every mode; omitted ⇒ no behaviour change). Adding a
+  // key HERE alone is NOT sufficient — normalizeReadSourceConfig below is the second, independent
+  // enforcement point (persistence + content-key participation); both must carry the key or the field is
+  // accepted and then silently dropped before storage.
+  'orderingKeySpec', 'actionProfileVersion',
 ]))
 
 function isNonEmptyString(value) {
@@ -210,6 +225,71 @@ function validateReadSourceConfig(config) {
     }
   }
 
+  // orderingKeySpec — B1a §4 step 1.1 (⟲R6 closed schema). OPTIONAL; omitted ⇒ no behaviour change. The
+  // certificate holds only the capability-level orderingKeyRequirement (never customer columns, §3.1); this
+  // is the CONCRETE customer field list + directions, and belongs at the config layer.
+  if (config.orderingKeySpec !== undefined) {
+    if (!Array.isArray(config.orderingKeySpec) || config.orderingKeySpec.length === 0) {
+      push('READ_SOURCE_ORDERING_KEY_SPEC_INVALID', 'orderingKeySpec', 'must_be_non_empty_array')
+    } else {
+      // The ONLY place a target identifier is declared is fieldMap — every orderingKeySpec fieldId must
+      // resolve through THIS SAME config version's fieldMap targets. No fieldMap ⇒ nothing resolves ⇒ every
+      // fieldId is unresolvable (deliberate: no "skip when fieldMap is absent" escape hatch). This Set
+      // dedupes a fieldMap that itself carries a duplicate target — harmless in practice only because the
+      // fieldMap block above independently fail-closes that same body (duplicate_target, above), so a
+      // resolution against a duplicate-target fieldMap is never observable through the public valid:true path.
+      const fieldMapTargets = new Set(
+        Array.isArray(config.fieldMap)
+          ? config.fieldMap
+            .filter((entry) => entry && typeof entry.target === 'string')
+            .map((entry) => entry.target.trim())
+          : [],
+      )
+      const seenFieldIds = new Set()
+      for (const entry of config.orderingKeySpec) {
+        if (!entry || typeof entry !== 'object' || Array.isArray(entry) || !Object.keys(entry).every((k) => k === 'fieldId' || k === 'direction')) {
+          // Also the gate that keeps orderingKeySpec schema-only: NULLability (or any other per-entry flag,
+          // e.g. a hypothetical "nullable") is deliberately NOT a schema key here — it stays fail-closed at
+          // the qualification probe, where it is observable against the live source (§3.1⟲R6).
+          push('READ_SOURCE_ORDERING_KEY_SPEC_INVALID', 'orderingKeySpec', 'invalid_entry_shape')
+          continue
+        }
+        // Canonical fieldIds only — never raw SQL, expressions, or aliases. Same bounded-identifier shape as
+        // fieldMap's `target` (the thing a fieldId must resolve to).
+        if (!isBoundedIdentifier(entry.fieldId)) {
+          push('READ_SOURCE_ORDERING_KEY_SPEC_INVALID', 'orderingKeySpec', 'field_id_invalid')
+        } else {
+          const fieldId = entry.fieldId.trim()
+          if (seenFieldIds.has(fieldId)) {
+            push('READ_SOURCE_ORDERING_KEY_SPEC_INVALID', 'orderingKeySpec', 'duplicate_field_id')
+          }
+          seenFieldIds.add(fieldId)
+          if (!fieldMapTargets.has(fieldId)) {
+            push('READ_SOURCE_ORDERING_KEY_SPEC_INVALID', 'orderingKeySpec', 'field_id_unresolved')
+          }
+        }
+        // direction ∈ {ASC, DESC} ONLY, UPPERCASE-strict (deliberately NOT resolverSortDirection's lowercase
+        // vocabulary — see ORDERING_KEY_DIRECTIONS above).
+        if (!ORDERING_KEY_DIRECTIONS.includes(entry.direction)) {
+          push('READ_SOURCE_ORDERING_KEY_SPEC_INVALID', 'orderingKeySpec', 'direction_invalid')
+        }
+      }
+    }
+  }
+
+  // actionProfileVersion — B1a §4 step 1.1. OPTIONAL; omitted ⇒ no behaviour change. Validated against the
+  // SAME PROFILE_ID_PATTERN vocabulary as GIP certification (imported above, never duplicated) so the two
+  // cannot drift; this field must not move systemContentKey (GIP-D0 §6) — it is a config-plane value only.
+  if (config.actionProfileVersion !== undefined) {
+    if (
+      typeof config.actionProfileVersion !== 'string' ||
+      config.actionProfileVersion.length > 128 ||
+      !PROFILE_ID_PATTERN.test(config.actionProfileVersion)
+    ) {
+      push('READ_SOURCE_ACTION_PROFILE_VERSION_INVALID', 'actionProfileVersion', 'not_allowlisted')
+    }
+  }
+
   // R0 resolver_lookup contract (rule-gated multiplicity; #1709 / resolver design-lock). The resolver keys
   // are rejected on any other mode; for resolver_lookup, resolverRule selects which rule-specific fields are
   // required vs forbidden. Values-free: reasons are coarse enums, no config value is echoed.
@@ -292,6 +372,16 @@ function normalizeReadSourceConfig(config) {
   if (config.resolverRule !== undefined) out.resolverRule = config.resolverRule
   if (config.resolverSortDirection !== undefined) out.resolverSortDirection = config.resolverSortDirection
   if (config.resolverDiscriminatorValue !== undefined) out.resolverDiscriminatorValue = config.resolverDiscriminatorValue.trim()
+  // B1a §4 step 1.1 — THE SECOND enforcement point. ALLOWED_CONFIG_KEYS above decides acceptance only; this
+  // key-by-key projection decides PERSISTENCE, and the store hashes exactly this output (`contentKeyFor`).
+  // A key merely allowlisted and not copied here is accepted, then silently discarded before storage — add
+  // both in lockstep with the allowlist, never here alone.
+  if (config.orderingKeySpec !== undefined) {
+    out.orderingKeySpec = Object.freeze(
+      config.orderingKeySpec.map((entry) => Object.freeze({ fieldId: entry.fieldId.trim(), direction: entry.direction })),
+    )
+  }
+  if (config.actionProfileVersion !== undefined) out.actionProfileVersion = config.actionProfileVersion.trim()
   const trimList = (field) => {
     if (Array.isArray(config[field])) out[field] = Object.freeze(config[field].map((p) => p.trim()))
   }
@@ -310,6 +400,7 @@ module.exports = {
   READ_SOURCE_KEY_ENCODINGS,
   RESOLVER_RULES,
   RESOLVER_SORT_DIRECTIONS,
+  ORDERING_KEY_DIRECTIONS,
   isSafeRelativeReadPath,
   validateReadSourceConfig,
   normalizeReadSourceConfig,


### PR DESCRIPTION
## Summary

B1a §4 step 1.1 ONLY (RATIFIED ledger, `docs/development/database-system-integration-line-design-and-verification-20260724.md`, @ `a7c562d34`). B1a AUTHORITY-SUBSTRATE gate, first permitted bullet only:

> additive `orderingKeySpec` / `actionProfileVersion` acceptance in the approved-config validator — closed rejection on shape, and no behaviour change for any config that omits them.

Nothing else from B1a is touched: no identity read, no registries, no executor, no `probe()` removal, no route, no runtime consumer.

- Adds both fields to `ALLOWED_CONFIG_KEYS` (acceptance) **and** `normalizeReadSourceConfig` (persistence + content-key participation) — both enforcement points, per the ledger's own warning that an allowlist-only change accepts and then silently discards the fields before storage.
- `orderingKeySpec` — ⟲R6 closed schema: canonical `fieldId`s only (never raw SQL/expressions/aliases), non-empty, no duplicate `fieldId`s, `direction ∈ {ASC, DESC}` UPPERCASE-strict, every `fieldId` must resolve through the SAME config version's `fieldMap` targets (unresolvable ⇒ closed rejection; no fieldMap ⇒ nothing resolves, no escape hatch). NULLability deliberately not a schema check.
- `actionProfileVersion` — validated against the profileId vocabulary via `isValidProfileId`, a **public export** of `gip-profile-certification-contracts.cjs` (never `__internals`, never a duplicated regex — see the Fix pass 2 section below), so the two vocabularies cannot drift.
- Direction-case decision (already ratified) is implemented, not "fixed": `orderingKeySpec.direction` stays UPPERCASE-only, `resolverSortDirection` stays lowercase-only — pinned both ways by test.
- Both fields optional; omitting them is unaffected (proven by test).

## Fix pass (this revision) — adversarial reviewer returned HOLD on the prior revision, both findings confirmed

An adversarial reviewer ran mutation probes against the prior revision and found two vacuous assertions. I re-ran both probes myself before fixing, and again after, per the finding's own instruction. Commands and full output below; both are also reproducible from this PR's current commit by reverting the two `lib/` edits shown.

### [P2] `actionProfileVersion` did not participate in the content key (mutation-provably)

**Probe A, re-run against the prior revision (BEFORE this fix pass), confirmed as claimed:**

```
$ cd plugins/plugin-integration-core
$ # edited lib/read-source-config-store.cjs contentKeyFor:
$ #   const { version, ...content } = normalizedConfig
$ # →  const { version, actionProfileVersion, ...content } = normalizedConfig
$ node __tests__/read-source-config.test.cjs
read-source-config.test.cjs OK
$ node __tests__/read-source-config-store.test.cjs
read-source-config-store.test.cjs OK
```

Both suites stayed GREEN with `actionProfileVersion` excluded from the content-key hash. Root cause: the existing acceptance predicate (i) only proves `actionProfileVersion` **survives persistence**; (ii) only varies `orderingKeySpec`. No case varied `actionProfileVersion` alone, so its content-key participation was asserted in the commit message but never pinned by a test.

**Fix:** added a third case to `testConfigV2OrderingKeySpecAndActionProfileVersion` in `read-source-config-store.test.cjs` — a save identical to the base body except for `actionProfileVersion` (same `orderingKeySpec`), asserting `reused === false`, `contentKey !== saved.contentKey`, `version !== saved.version`, and the config table growing to exactly 3 distinct rows.

**Probe A re-run AFTER the fix — now REDs:**

```
$ node __tests__/read-source-config-store.test.cjs
AssertionError [ERR_ASSERTION]: a body differing only in actionProfileVersion must NOT be treated as a reuse
true !== false
    at testConfigV2OrderingKeySpecAndActionProfileVersion (.../read-source-config-store.test.cjs:448:10)
```

Mutation reverted; suite confirmed GREEN again with the real `contentKeyFor`.

### [P2] The ⟲R6 "canonical fieldIds only" rule was vacuously asserted (code-only, not reason-exclusive)

**Probe B, re-run against the prior revision, confirmed as claimed:**

```
$ # deleted the `if (!isBoundedIdentifier(entry.fieldId)) { push(...) } else { ... }` guard in
$ # lib/read-source-config.cjs, leaving only the (now-unconditional) duplicate/resolve checks
$ node __tests__/read-source-config.test.cjs
read-source-config.test.cjs OK
```

Root cause, confirmed by printing the actual `reason` (not just `code`) for all 7 raw-SQL/expression/alias inputs, clean vs mutated:

| input | clean `reason` | guard-deleted `reason` |
|---|---|---|
| `qty; DROP TABLE x` / `qty AS q` / `qty + 1` / `a.b.c()` / `qty OR 1=1` / `''` / `has space` | `field_id_invalid` (×7) | `field_id_unresolved` (×7) |

Every `orderingKeySpec` violation — invalid shape, unresolved fieldId, invalid direction, duplicate — pushes the **same** `code`: `READ_SOURCE_ORDERING_KEY_SPEC_INVALID`. The test only asserted `codes(...).includes('READ_SOURCE_ORDERING_KEY_SPEC_INVALID')`, so when the `isBoundedIdentifier` guard is deleted, every one of the 7 inputs still fails — just via the unrelated `fieldMapTargets.has(fieldId)` resolution check (none of them equals the lone fieldMap target `'qty'`) — under a *different* `reason`, and the code-only assertion cannot tell the difference. Two doors covering for each other behind one shared code.

**Fix:** the loop now asserts the `reason` **set** is exactly `['field_id_invalid']` (filtered to `field === 'orderingKeySpec'`), not mere code inclusion.

**Probe B re-run AFTER the fix — now REDs:**

```
$ node __tests__/read-source-config.test.cjs
AssertionError [ERR_ASSERTION]: orderingKeySpec must reject raw-SQL/expression-shaped fieldId with EXACTLY
reason field_id_invalid (not some other rule catching it instead): "qty; DROP TABLE x" =>
[{"code":"READ_SOURCE_ORDERING_KEY_SPEC_INVALID","field":"orderingKeySpec","reason":"field_id_unresolved"}]
+ actual - expected
  [
+   'field_id_unresolved'
-   'field_id_invalid'
  ]
```

Mutation reverted; suite confirmed GREEN again with the real guard in place.

### Retraction

The prior revision of this PR body claimed: *"the two probes are independently load-bearing, not covering for each other."* **That claim was false** — the reviewer's Probe A is exactly the case that sentence missed (a third, undiscriminated participation gap on `actionProfileVersion`). Retracted; replaced by the two probe write-ups above plus the new case (iii), which is what actually closes it now.

### [P3] Grep conclusion overstated — restated precisely, re-run against `402f04982`

```
$ git grep -n 'orderingKeySpec' 402f04982
(0 hits outside docs/development/database-system-integration-line-design-and-verification-20260724.md)

$ git grep -c 'actionProfileVersion' 402f04982 -- '*test*'
plugins/plugin-integration-core/__tests__/gip-binding-qualification-spike.test.cjs:6
plugins/plugin-integration-core/__tests__/gip-bridge-bounded-read-profile.test.cjs:10
plugins/plugin-integration-core/__tests__/gip-profile-certification-contracts.test.cjs:1

$ git grep -l 'validateReadSourceConfig\|read-source-config' 402f04982 -- \
    'plugins/plugin-integration-core/__tests__/gip-binding-qualification-spike.test.cjs' \
    'plugins/plugin-integration-core/__tests__/gip-bridge-bounded-read-profile.test.cjs' \
    'plugins/plugin-integration-core/__tests__/gip-profile-certification-contracts.test.cjs'
(no output — none of the three reference this validator or module at all)
```

Corrected statement: `orderingKeySpec` appears **nowhere** in code or tests on `main` at `402f04982` (only in the ledger doc). `actionProfileVersion` appears **only** in the three GIP certification/qualification test files above — none of which exercise `validateReadSourceConfig`/`read-source-config.cjs`. The prior wording ("no test on main names either key") was imprecise about `actionProfileVersion`; this is the accurate version.

### [P3] "re-read the stored row" reworded

The acceptance-predicate re-read in `testConfigV2OrderingKeySpecAndActionProfileVersion` goes through `store.get()` against the **in-memory mock db** built by `createMockDb()` in the test file — it is not a Postgres round-trip. No code change; the claim in this body (and the test's own comments) is stated in those terms now, not as a DB-integration proof.

### Ledger defect (found and preserved, not quietly absorbed)

§4 step 1.1 of the RATIFIED ledger says: *"the existing test that asserts today's rejection **flips in the same PR**."* **There is no such test on `main`.** `gip-approved-binding-resolver.cjs` and its suite — the file the ledger's own qualification-input-tuple language points at — do not exist on `main`; they exist only in the **CLOSED** PR #4596. I did not invent one and did not pretend to flip one. The correct substitute, and what this PR actually does, is: write the new tests first (8a-8f in `read-source-config.test.cjs`, the acceptance predicate in `read-source-config-store.test.cjs`), confirm RED against the pre-change validator, then implement, then confirm GREEN.

Restated in the owner-ruled shape (review #4601 P3, applied to the `8a-8f` block's own in-code comment too): the correct description is a **newly added, named pre-change RED / post-change GREEN characterisation test**, with the **pre-existing generic unknown-key negative control** (the standalone `nefariousKey` assertion in `read-source-config.test.cjs`, immediately before block 8) **retained**, unchanged, alongside it. Not a "flip" of a prior test — there was no prior named test to flip.

**Whether RED-before-implement is provable from git history:** it is not. Point-in-time capture, against the pre-fix-pass head `4a82d2c99` (this exact command no longer reproduces after the rebases below, which rewrite SHAs on every rebase — the branch carried a **single commit** (`3a1ddccf4`) on top of `402f04982` containing both the test and lib changes together at that point):

```
$ git log --format='%H %ci %s' 402f04982..origin/claude/gip-b1a-1-config-v2-20260725
3a1ddccf4b9371d6659246799273525520e532f2 2026-07-24 23:34:12 -0700 feat(integration-core): B1a-1 config v2 ...
```

No intermediate commit shows a red run before the implementation landed, so the ordering claimed in the original commit message cannot be confirmed from history alone. What I *can* confirm is that the claimed red is **reproducible now**: restoring `lib/read-source-config.cjs` to its `402f04982` (pre-PR) content while keeping this branch's test files reproduces output character-for-character identical to the "Red (before)" block below (both suites), including the store-level rejection. That does not prove the predecessor ran it in that order — it proves the claim is at least true of the code, independent of trust in the commit message.

```
$ git show 402f04982:plugins/plugin-integration-core/lib/read-source-config.cjs \
    > /tmp/read-source-config.premain.cjs
$ cp /tmp/read-source-config.premain.cjs lib/read-source-config.cjs   # branch's test files kept as-is
$ node __tests__/read-source-config.test.cjs
AssertionError [ERR_ASSERTION]: well-shaped orderingKeySpec + actionProfileVersion must be ACCEPTED:
[{"code":"READ_SOURCE_UNEXPECTED_FIELD","field":"orderingKeySpec","reason":"not_allowlisted"},
 {"code":"READ_SOURCE_UNEXPECTED_FIELD","field":"actionProfileVersion","reason":"not_allowlisted"}]
false !== true
$ node __tests__/read-source-config-store.test.cjs
ReadSourceConfigValidationError: read-source config is invalid
    at Object.saveVersion (.../read-source-config-store.cjs:214:13)
$ cp /tmp/read-source-config.branch.cjs lib/read-source-config.cjs   # restored
```

(Fix pass 2 below — and the earlier fix pass right above this Ledger-defect section — each added a further commit on top of that original one; by the time fix pass 2 started, the branch already carried 2 commits, not 1. Every rebase-onto-`main` this PR goes through since then REWRITES the original commit's SHA — `3a1ddccf4` → `a011d843b` → `a2f8da579` as of this revision (`git log --format='%H %ci %s' <current-merge-base-with-main>..HEAD` reproduces the current chain and its true commit count). The commit's CONTENT is unchanged by any rebase, so the single-commit-history argument above is accurate as a point-in-time statement about the branch BEFORE any fix pass landed — not a claim about its current commit count, which this parenthetical does not restate.)

## Fix pass 2 (owner review #4601 returned HOLD on head `4a82d2c99` — P2 public contract + P3 wording)

### [P2] `read-source-config.cjs` imported `PROFILE_ID_PATTERN` from the certification module's `__internals` — promoted to a public export

**Before (held revision):** `lib/read-source-config.cjs` did:
```js
const { __internals: { PROFILE_ID_PATTERN } } = require('./gip-profile-certification-contracts.cjs')
```
— a live save path reaching into another module's private/test surface, exactly what the finding ruled out.

**Fix:** added `isValidProfileId(value)` as a **public** export of `gip-profile-certification-contracts.cjs` — a thin wrapper (`typeof value === 'string' && value.length <= 128 && PROFILE_ID_PATTERN.test(value)`) over the SAME `PROFILE_ID_PATTERN` object the module's own `normalizeCertifiedReadActionProfile` / `normalizeCertifiedApplyProfile` use (still also exposed via `__internals`, untouched, for existing consumers). `read-source-config.cjs` now imports only the public helper:
```js
const { isValidProfileId } = require('./gip-profile-certification-contracts.cjs')
...
if (config.actionProfileVersion !== undefined && !isValidProfileId(config.actionProfileVersion)) {
  push('READ_SOURCE_ACTION_PROFILE_VERSION_INVALID', 'actionProfileVersion', 'not_allowlisted')
}
```

`__internals` is unmodified. Grep against the held revision confirms `read-source-config.cjs` was the only production `require(...)` that destructured `__internals.PROFILE_ID_PATTERN`, and no test file referenced it either — so nothing else needed touching:
```
$ git grep -n 'PROFILE_ID_PATTERN' -- '*.cjs' | grep -v node_modules   # against the held revision, before this fix pass
plugins/plugin-integration-core/__tests__/read-source-config.test.cjs:307:// 8f. actionProfileVersion validates against the SAME PROFILE_ID_PATTERN vocabulary as GIP certification
plugins/plugin-integration-core/lib/gip-bridge-bounded-read-profile.cjs:29:// The profileId literal `bridge.bounded_read.v2` decomposes (per PROFILE_ID_PATTERN,
plugins/plugin-integration-core/lib/gip-profile-certification-contracts.cjs:184:const PROFILE_ID_PATTERN = /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+\.v[1-9][0-9]*$/
plugins/plugin-integration-core/lib/gip-profile-certification-contracts.cjs:257:  if (!profileId || profileId.length > 128 || !PROFILE_ID_PATTERN.test(profileId)) {
plugins/plugin-integration-core/lib/gip-profile-certification-contracts.cjs:436:  if (!applyProfileId || applyProfileId.length > 128 || !PROFILE_ID_PATTERN.test(applyProfileId)) {
plugins/plugin-integration-core/lib/gip-profile-certification-contracts.cjs:566:    PROFILE_ID_PATTERN,
plugins/plugin-integration-core/lib/read-source-config.cjs:17:// PROFILE_ID_PATTERN is IMPORTED, never duplicated, so actionProfileVersion here and the GIP certification
plugins/plugin-integration-core/lib/read-source-config.cjs:19:const { __internals: { PROFILE_ID_PATTERN } } = require('./gip-profile-certification-contracts.cjs')
plugins/plugin-integration-core/lib/read-source-config.cjs:281:  // SAME PROFILE_ID_PATTERN vocabulary as GIP certification (imported above, never duplicated) so the two
plugins/plugin-integration-core/lib/read-source-config.cjs:287:      !PROFILE_ID_PATTERN.test(config.actionProfileVersion)
```
(`gip-bridge-bounded-read-profile.cjs`'s hit is a comment, not a `require`.)

**Same-source-of-truth proof (not a second copy of the regex), mutation-provable:** a test table (`publicHelperAgreesWithInternalPattern`, added to `gip-profile-certification-contracts.test.cjs`, wired into `main()`) asserts `isValidProfileId(id) === (id.length <= 128 && __internals.PROFILE_ID_PATTERN.test(id))` across 11 `fixture.*`-namespaced valid/invalid ids, including one that is pattern-valid but rejected only by the 128-char bound.

Probe A — drop the length bound (models "a future change forgets the bound"):
```
$ cp lib/gip-profile-certification-contracts.cjs /tmp/gip-profile-certification-contracts.cjs.orig
$ sed -i.bak "s/return typeof value === 'string' && value.length <= 128 && PROFILE_ID_PATTERN.test(value)/return typeof value === 'string' \&\& PROFILE_ID_PATTERN.test(value)/" lib/gip-profile-certification-contracts.cjs
$ node __tests__/gip-profile-certification-contracts.test.cjs
AssertionError [ERR_ASSERTION]: isValidProfileId must agree with __internals.PROFILE_ID_PATTERN (+128 bound) for "fixture.aaaa...a.v1"
true !== false
    at publicHelperAgreesWithInternalPattern (.../gip-profile-certification-contracts.test.cjs:361:12)
$ cp /tmp/gip-profile-certification-contracts.cjs.orig lib/gip-profile-certification-contracts.cjs   # reverted
$ node __tests__/gip-profile-certification-contracts.test.cjs
gip-profile-certification-contracts.test.cjs OK
$ diff /tmp/gip-profile-certification-contracts.cjs.orig lib/gip-profile-certification-contracts.cjs   # (no output — byte-identical)
```

Probe B — hand-rolled case-insensitive duplicate regex instead of referencing `PROFILE_ID_PATTERN` (models "a second copy that quietly diverges"):
```
$ sed -i.bak "s/return typeof value === 'string' && value.length <= 128 && PROFILE_ID_PATTERN.test(value)/return typeof value === 'string' \&\& value.length <= 128 \&\& \/^[a-zA-Z][a-zA-Z0-9_]*(\\\\.[a-zA-Z][a-zA-Z0-9_]*)+\\\\.v[1-9][0-9]*\$\/.test(value)/" lib/gip-profile-certification-contracts.cjs
$ node __tests__/gip-profile-certification-contracts.test.cjs
AssertionError [ERR_ASSERTION]: isValidProfileId must agree with __internals.PROFILE_ID_PATTERN (+128 bound) for "FIXTURE.paged_read.v1"
true !== false
    at publicHelperAgreesWithInternalPattern (.../gip-profile-certification-contracts.test.cjs:361:12)
$ cp /tmp/gip-profile-certification-contracts.cjs.orig lib/gip-profile-certification-contracts.cjs   # reverted
$ node __tests__/gip-profile-certification-contracts.test.cjs
gip-profile-certification-contracts.test.cjs OK
```

Both probes RED against the exact divergence class they target and GREEN on the real helper (byte-identical to the pre-mutation file) — the table is load-bearing, not vacuous.

**Advisor follow-up — a third gap in the same block:** the new `isValidProfileId` doc-comment asserted, in prose, that the helper is deliberately untrimmed and therefore diverges from `normalizeCertifiedReadActionProfile`'s pre-existing trim-then-test behaviour (`' erp.a.v1 '` accepted there, rejected here) — but nothing pinned that claim (this line's own "注释断言≠不变量" discipline). Added two asserts to `publicHelperAgreesWithInternalPattern`: a padded id must be rejected by `isValidProfileId`, and the SAME padded id must be accepted by `normalizeCertifiedReadActionProfile` (documenting the pre-existing, unchanged-by-this-PR asymmetry, not a new decision).

Probe C — make `isValidProfileId` trim before testing (models "someone unifies the two entry points' semantics"):
```
$ sed -i.bak "s/return typeof value === 'string' && value.length <= 128 && PROFILE_ID_PATTERN.test(value)/return typeof value === 'string' \&\& value.trim().length <= 128 \&\& PROFILE_ID_PATTERN.test(value.trim())/" lib/gip-profile-certification-contracts.cjs
$ node __tests__/gip-profile-certification-contracts.test.cjs
AssertionError [ERR_ASSERTION]: isValidProfileId is untrimmed: a padded id must be rejected
true !== false
    at publicHelperAgreesWithInternalPattern (.../gip-profile-certification-contracts.test.cjs:380:10)
$ cp /tmp/gip-profile-certification-contracts.cjs.orig2 lib/gip-profile-certification-contracts.cjs   # reverted
$ node __tests__/gip-profile-certification-contracts.test.cjs
gip-profile-certification-contracts.test.cjs OK
$ diff /tmp/gip-profile-certification-contracts.cjs.orig2 lib/gip-profile-certification-contracts.cjs   # (no output — byte-identical)
```

All three probes RED against the divergence class they each target and GREEN + byte-identical on revert.

### [P3] Test-comment wording — "flip" claim reworded

See the "Restated in the owner-ruled shape" sentence added to the Ledger-defect section above. The corresponding in-code comment at the top of block 8 in `read-source-config.test.cjs` (was: "THE FLIP: ... This block IS the flip") is reworded to the same ruled shape: a newly added, named pre-change RED / post-change GREEN characterisation test, with the pre-existing generic standalone `nefariousKey` unexpected-field assertion (named by content, not a pinned line number, per advisor follow-up) retained, unchanged, alongside it. The reworded comment also folds in this PR body's own earlier P3 correction on the `actionProfileVersion` grep claim (`actionProfileVersion` does appear in three unrelated GIP test files on `main` — none of which exercise this validator — rather than "no test on main names either key").

## Full plugin test suite (after this fix pass, including the Probe-C follow-up)

Fresh worktree, no `node_modules` at any level this chain touches (root, `plugins/plugin-integration-core`, `packages/core-backend`) — all three symlinked from the canonical checkout before running, per this line's evidence discipline:
```
$ cd plugins/plugin-integration-core && pnpm test
...
gip-canonical-json.test.cjs OK
gip-profile-certification-contracts.test.cjs OK
gip-profile-compliance-harness.test.cjs OK
gip-binding-qualification-spike.test.cjs OK
gip-bridge-bounded-read-profile.test.cjs OK
$ echo $?
0
```
Exit code 0; 127 `OK`/`passed` result lines across the suite; no regressions. Re-run again after each of the two subsequent rebases onto `origin/main` (below), same result both times.

## Mandated acceptance predicate (now three cases, all proven)

(i) Save a body carrying both fields, re-read the stored row (mock DB), assert both survive into `config`.
(ii) Two bodies in the same family differing **only** in `orderingKeySpec` mint **different** `content_key`s and **different** versions (`reused === false`).
(iii) *(added this fix pass)* Two bodies in the same family differing **only** in `actionProfileVersion` (identical `orderingKeySpec`) also mint **different** `content_key`s and **different** versions (`reused === false`), and the config table holds exactly 3 distinct rows across (i)/(ii)/(iii).

## Full plugin test suite (prior revision — held head `4a82d2c99`, before fix pass 2)

The worktree this fix pass ran in had no `node_modules` (fresh checkout); `pnpm test` initially failed
on `Cannot find module '@metasheet/mssql-readonly-utils'` (a workspace-linked package), unrelated to this
PR's diff. Installed at the repo root first:

```
$ pnpm install --frozen-lockfile   # repo root — resolves the workspace-linked packages
...
Done in 3.1s using pnpm v10.33.0
$ cd plugins/plugin-integration-core
$ pnpm test
... (all suites) ...
read-source-config.test.cjs OK
read-source-probe-contract.test.cjs OK
read-source-probe-runtime.test.cjs OK
read-source-config-store.test.cjs OK
...
gip-bridge-bounded-read-profile.test.cjs OK
$ echo $?
0
```
Exit code 0; no regressions.

## Test plan

- [x] `node __tests__/read-source-config.test.cjs` — OK
- [x] `node __tests__/read-source-config-store.test.cjs` — OK
- [x] Full plugin suite: `pnpm test` (in `plugins/plugin-integration-core`) — all suites green, exit 0
- [x] Probe A (actionProfileVersion content-key participation) — reproduced GREEN-when-broken on the prior revision, RED-when-broken after the fix, both pasted above
- [x] Probe B (⟲R6 fieldId-shape guard) — reproduced GREEN-when-broken on the prior revision, RED-when-broken after the fix, both pasted above
- [x] Independent reproduction of the ledger's claimed RED-before-implement state (pasted above) — history itself cannot confirm ordering (single squashed commit)
- [x] Fix pass 2 (owner review #4601): `node __tests__/gip-profile-certification-contracts.test.cjs` — OK, including the new `isValidProfileId`/`__internals.PROFILE_ID_PATTERN` agreement table
- [x] Fix pass 2 Probe A (dropped length bound), Probe B (hand-rolled duplicate regex), Probe C (advisor follow-up: trim-before-test) — all three reproduced RED against their mutation, GREEN and byte-identical to the clean file after revert, all pasted above
- [x] Full plugin suite re-run after the Probe-C follow-up commit and after each of two subsequent rebases onto `origin/main` (branch moved twice while this fix pass was in flight) — green, exit 0, each time
- [x] Rebased onto current `origin/main` (twice — branch moved during this fix pass), pushed (not merged)

## Scope discipline

- No route changes (`http-routes.cjs` untouched — confirmed the two new error codes pass through unshaped, the same way `READ_SOURCE_FIELD_MAP_INVALID` does today; only `READ_SOURCE_UNEXPECTED_FIELD` needs coarsening because its `field` is a raw caller-supplied key, not a fixed name).
- No `MODE_REQUIRED_FIELDS` change — both fields optional on every mode.
- No identity read, registry, executor, or `probe()` change.
- No feature flags touched, nothing deployed, no merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

