### PR TITLE
feat(ops): GIP authority-substrate inventory — β connector-kind + γ objectKey probes

### DIFF
--- a/.github/workflows/gip-authority-substrate-inventory.yml
+++ b/.github/workflows/gip-authority-substrate-inventory.yml
@@ -1,0 +1,47 @@
+name: GIP Authority-Substrate Inventory (β/γ probes)
+
+# Hermetic contract test for the two read-only, values-free inventory probes that feed decisions
+# (β) connector-kind registry and (γ) canonical object contract registry — see
+# docs/development/database-system-integration-line-design-and-verification-20260724.md §4.0.
+# No database: the script's tests inject a fake query executor (see
+# scripts/ops/gip-authority-substrate-inventory.test.mjs). Follows the same shape as the
+# `contract` job in multitable-permission-lists-postdeploy-smoke.yml / the sibling
+# data-source-exposure-inventory.yml pattern: checkout + setup-node only, `node --test` directly.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/gip-authority-substrate-inventory.yml'
+      - 'scripts/ops/gip-authority-substrate-inventory.mjs'
+      - 'scripts/ops/gip-authority-substrate-inventory.test.mjs'
+      # The schema-drift guard test reads these migrations directly off disk and asserts the
+      # kind/status/object column facts this script depends on — listed here so a PR that drifts
+      # either migration re-runs this check, instead of a later, unrelated PR going red.
+      - 'packages/core-backend/migrations/057_create_integration_core_tables.sql'
+      - 'packages/core-backend/migrations/062_create_integration_read_source_configs.sql'
+      - '.gitignore'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/gip-authority-substrate-inventory.yml'
+      - 'scripts/ops/gip-authority-substrate-inventory.mjs'
+      - 'scripts/ops/gip-authority-substrate-inventory.test.mjs'
+      - 'packages/core-backend/migrations/057_create_integration_core_tables.sql'
+      - 'packages/core-backend/migrations/062_create_integration_read_source_configs.sql'
+      - '.gitignore'
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: authority-substrate inventory contract (values-free, schema-probe-first)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run hermetic inventory tests (fake executor, no DB)
+        run: node --test scripts/ops/gip-authority-substrate-inventory.test.mjs

--- a/.github/workflows/gip-authority-substrate-inventory.yml
+++ b/.github/workflows/gip-authority-substrate-inventory.yml
@@ -5,8 +5,10 @@ name: GIP Authority-Substrate Inventory (β/γ probes)
 # docs/development/database-system-integration-line-design-and-verification-20260724.md §4.0.
 # No database: the script's tests inject a fake query executor (see
 # scripts/ops/gip-authority-substrate-inventory.test.mjs). Follows the same shape as the
-# `contract` job in multitable-permission-lists-postdeploy-smoke.yml / the sibling
-# data-source-exposure-inventory.yml pattern: checkout + setup-node only, `node --test` directly.
+# `contract` job in multitable-permission-lists-postdeploy-smoke.yml (on main), and the same
+# pattern as data-source-exposure-inventory.yml (#4594) — that workflow is NOT in this tree; it
+# lives only on branch claude/data-source-exposure-inventory-20260724, not on main: checkout +
+# setup-node only, `node --test` directly.
 
 on:
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,11 @@ artifacts/integration-k3wise-onprem-preflight/
 # masked admin signoff metadata, and per-check evidence; operator-only.
 artifacts/integration-k3wise/internal-trial/
 
+# gip-authority-substrate-inventory.mjs (β/γ probes) private artefact: raw
+# connector-kind / objectKey strings observed in a deployment. Aggregate
+# counts only belong in committed output; the raw values are operator-local.
+artifacts/gip-authority-inventory/
+
 # Multitable on-prem release bundles are generated delivery artifacts. Keep
 # source manifests/runbooks in Git, not built archives and verification output.
 output/delivery/multitable-onprem/

--- a/scripts/ops/gip-authority-substrate-inventory.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.mjs
@@ -79,13 +79,27 @@
  *     [--probe beta|gamma|both] [--private-out <path> | --no-private-out] [--json]
  *   node scripts/ops/gip-authority-substrate-inventory.mjs --dry-run   # no DB required
  *
- * Exit codes:
+ * Exit codes: exit 1 is reached by TWO DIFFERENT routes through main() — they share the exit code
+ * but not the code path, and neither leaks anything about the underlying failure (see the CLI
+ * error-reason discipline right below the "CLI" section heading, and the exit-code contract test
+ * describe block in the test file, which pins the second route directly by calling main()):
  *   0  ran successfully (a MAPPING_REQUIRED / BACKFILL_REQUIRED verdict is information, not failure)
- *   1  unexpected runtime/DB error; OR the private artefact was owed (unregistered/unmapped count
- *      > 0) but could not be written; OR it was owed but --no-private-out disabled the write
- *      (report.privateArtifact.consumableByWave2 === false) — all three fail closed rather than
- *      reporting aggregate-only success while silently dropping the raw detail a human needs to
- *      act on it, or letting a caller read "ran successfully" as "this run is a complete inventory"
+ *   1  route A — an exception escaped buildReport()/buildDryRunReport()/parseArgs() (an unexpected
+ *      runtime/DB error, OR the private artefact was owed — unregistered/unmapped count > 0 — but
+ *      the write itself failed). Caught by main()'s try/catch; stderr gets a closed
+ *      CLI_ERROR_REASON token (never the caught error's own .message), never returns to the
+ *      `if (consumableByWave2 === false)` check below at all.
+ *   1  route B — buildReport() returns NORMALLY but the private artefact was owed and
+ *      --no-private-out disabled the write (report.privateArtifact.consumableByWave2 === false,
+ *      checked explicitly in main(), ~L1107). The report is still printed to stdout in this case; only
+ *      the exit code fails closed, so a caller relying on exit status alone (not reading stdout)
+ *      still cannot mistake this for a complete inventory.
+ *   Both routes fail closed rather than reporting aggregate-only success while silently dropping
+ *   the raw detail a human needs to act on it, or letting a caller read "ran successfully" as "this
+ *   run is a complete inventory". A failure to close the Postgres pool AFTER either route already
+ *   determined its result (0/1/2) is swallowed silently by design (see safeClose()) — it never
+ *   changes the exit code and never produces separate stderr output; the pool-close outcome itself
+ *   is not signalled on any channel.
  *   2  required input missing (DATABASE_URL absent outside --dry-run)
  */
 
@@ -897,6 +911,54 @@ function renderHumanSummary(report) {
 // CLI
 // ---------------------------------------------------------------------------
 
+// stderr values-free discipline (#4603 P2(a)): the report object's CLOSED VALUE DOMAIN (see the
+// describe block of that name in the test file) was proven for stdout/--json in an earlier round,
+// but the owner's probe showed stderr was NOT covered — an unrecognized flag echoed the operator's
+// literal argv value verbatim, and a `pg` import failure echoed a foreign Error's .message, which
+// on a `Cannot find package 'pg'` MODULE_NOT_FOUND carries an absolute filesystem path. Every
+// string that can reach stderr from parseArgs()/main() below is now one of these fixed tokens —
+// authored here, never argv- or env-derived — and nothing else.
+const CLI_ERROR_REASON = Object.freeze({
+  UNKNOWN_ARGUMENT: 'UNKNOWN_ARGUMENT',
+  INVALID_PROBE_VALUE: 'INVALID_PROBE_VALUE',
+  MISSING_PRIVATE_OUT_PATH: 'MISSING_PRIVATE_OUT_PATH',
+  MUTUALLY_EXCLUSIVE_PRIVATE_OUT: 'MUTUALLY_EXCLUSIVE_PRIVATE_OUT',
+  DATABASE_URL_REQUIRED: 'DATABASE_URL_REQUIRED',
+  RUNTIME_FAILURE: 'RUNTIME_FAILURE',
+})
+// Membership set, not just "is it a CliArgError" — see closedCliErrorReason() below for why the
+// extra check matters.
+const CLI_REASON_VALUES = new Set(Object.values(CLI_ERROR_REASON))
+
+// The ONLY error type parseArgs() is allowed to throw. `.reason` is always one of the frozen
+// CLI_ERROR_REASON tokens above — never an interpolated argv value — enforced by construction at
+// every throw site below (no template literal ever appears in a `new CliArgError(...)` call).
+class CliArgError extends Error {
+  constructor(reason) {
+    super(reason)
+    this.name = 'CliArgError'
+    this.reason = reason
+  }
+}
+
+// Maps ANY error that could reach a stderr write site in main() to a CLOSED reason token. This is
+// deliberately NOT `err instanceof CliArgError ? err.message : RUNTIME_FAILURE` — that shape makes
+// closedness a convention (a future `throw new CliArgError(\`unknown argument: ${a}\`)` would
+// silently re-open the exact leak this fixes, and every test below would stay green because it
+// only checks the class, not the value). Instead this re-validates that `.reason` is actually a
+// member of the frozen CLI_ERROR_REASON set; anything else — a foreign Error's .message, a
+// CliArgError constructed with a non-token string, a TypeError, a `pg` MODULE_NOT_FOUND carrying an
+// absolute path, a Postgres connection error carrying a hostname — collapses to the single generic
+// RUNTIME_FAILURE token. Mutation-confirmed (#4603 P2(a)): reverting this to the
+// `err instanceof CliArgError ? err.message : RUNTIME_FAILURE` shape (while still constructing
+// CliArgError with fixed tokens everywhere) keeps every test in this file green — the coverage gap
+// is closed only by asserting membership, so a direct unit test on this function's own contract
+// (feeding it a CliArgError built from a non-token string) is what actually pins it; see
+// 'closedCliErrorReason' below in the test file.
+function closedCliErrorReason(err) {
+  return err instanceof CliArgError && CLI_REASON_VALUES.has(err.reason) ? err.reason : CLI_ERROR_REASON.RUNTIME_FAILURE
+}
+
 function parseArgs(argv) {
   const opts = { dryRun: false, json: false, help: false, probe: 'both', privateOutPath: undefined, noPrivateOut: false }
   for (let i = 0; i < argv.length; i += 1) {
@@ -909,14 +971,14 @@ function parseArgs(argv) {
       case '--probe': {
         const next = argv[++i]
         if (!['beta', 'gamma', 'both'].includes(next)) {
-          throw new Error(`--probe must be one of beta|gamma|both, got: ${next}`)
+          throw new CliArgError(CLI_ERROR_REASON.INVALID_PROBE_VALUE)
         }
         opts.probe = next
         break
       }
       case '--private-out':
         opts.privateOutPath = argv[++i]
-        if (!opts.privateOutPath) throw new Error('--private-out requires a path argument')
+        if (!opts.privateOutPath) throw new CliArgError(CLI_ERROR_REASON.MISSING_PRIVATE_OUT_PATH)
         break
       case '--no-private-out':
         opts.noPrivateOut = true
@@ -929,11 +991,11 @@ function parseArgs(argv) {
         opts.help = true
         break
       default:
-        throw new Error(`unknown argument: ${a}`)
+        throw new CliArgError(CLI_ERROR_REASON.UNKNOWN_ARGUMENT)
     }
   }
   if (opts.privateOutPath && opts.noPrivateOut) {
-    throw new Error('--private-out and --no-private-out are mutually exclusive')
+    throw new CliArgError(CLI_ERROR_REASON.MUTUALLY_EXCLUSIVE_PRIVATE_OUT)
   }
   return opts
 }
@@ -968,7 +1030,11 @@ function printHelp() {
 
 async function createPgExecutor(databaseUrl) {
   // Lazy import: `pg` must never be required at module load, or a hermetic `node --test` CI job
-  // with no `node_modules` fails at import time before a single test runs.
+  // with no `node_modules` fails at import time before a single test runs. This is also the exact
+  // failure the owner's #4603 P2(a) probe used: in that same hermetic environment `import('pg')`
+  // rejects with a MODULE_NOT_FOUND Error whose .message is
+  // `Cannot find package 'pg' imported from <absolute path>` — main() below must never let that
+  // .message reach stderr/stdout verbatim.
   const { default: pg } = await import('pg')
   const pool = new pg.Pool({ connectionString: databaseUrl, max: 2 })
   return {
@@ -977,12 +1043,27 @@ async function createPgExecutor(databaseUrl) {
   }
 }
 
-async function main(argv = process.argv.slice(2), env = process.env) {
+// A pool-close failure after the run already computed its own result (success OR a mapped failure)
+// must never override that result, and must never leak the underlying close error's .message — same
+// values-free discipline as everything else reaching stderr. Without this, a throw inside main()'s
+// `finally { await executor.close() }` would reject main()'s own returned promise from OUTSIDE every
+// try/catch above it, bypassing closedCliErrorReason() entirely and reaching the entry-point wrapper
+// (see isEntry below) as an unmapped rejection.
+async function safeClose(executor) {
+  if (!executor) return
+  try {
+    await executor.close()
+  } catch {
+    // intentionally silent — see comment above
+  }
+}
+
+async function main(argv = process.argv.slice(2), env = process.env, { createExecutor = createPgExecutor } = {}) {
   let opts
   try {
     opts = parseArgs(argv)
   } catch (err) {
-    process.stderr.write(`[gip-authority-substrate-inventory] ERROR: ${err.message}\n`)
+    process.stderr.write(`[gip-authority-substrate-inventory] ERROR: ${closedCliErrorReason(err)}\n`)
     return 1
   }
   if (opts.help) {
@@ -995,7 +1076,7 @@ async function main(argv = process.argv.slice(2), env = process.env) {
   if (opts.dryRun) {
     let executor = null
     try {
-      if (databaseUrl) executor = await createPgExecutor(databaseUrl)
+      if (databaseUrl) executor = await createExecutor(databaseUrl)
       const report = await buildDryRunReport({ exec: executor ? executor.exec : null, probe: opts.probe })
       if (opts.json) {
         process.stdout.write(JSON.stringify(report, null, 2) + '\n')
@@ -1005,21 +1086,21 @@ async function main(argv = process.argv.slice(2), env = process.env) {
       }
       return 0
     } catch (err) {
-      process.stderr.write(`[gip-authority-substrate-inventory] ERROR: ${err instanceof Error ? err.message : String(err)}\n`)
+      process.stderr.write(`[gip-authority-substrate-inventory] ERROR: ${closedCliErrorReason(err)}\n`)
       return 1
     } finally {
-      if (executor) await executor.close()
+      await safeClose(executor)
     }
   }
 
   if (!databaseUrl) {
-    process.stderr.write('[gip-authority-substrate-inventory] ERROR: DATABASE_URL is required outside --dry-run\n')
+    process.stderr.write(`[gip-authority-substrate-inventory] ERROR: ${CLI_ERROR_REASON.DATABASE_URL_REQUIRED}\n`)
     return 2
   }
 
   let executor
   try {
-    executor = await createPgExecutor(databaseUrl)
+    executor = await createExecutor(databaseUrl)
     const report = await buildReport({
       exec: executor.exec,
       probe: opts.probe,
@@ -1035,24 +1116,39 @@ async function main(argv = process.argv.slice(2), env = process.env) {
     // The report is still printed above even in this case — a caller reading stdout gets the full
     // explanation — but the run must not be mistakable for a complete inventory by exit code alone
     // (see the header's Exit codes list and the ruling on ~L672 in the PR that added this check).
+    // Exit-code contract test coverage (#4603 P2(b)): see the 'main() exit-code contract' describe
+    // block in the test file — this line was previously reachable by none of the 127 tests.
     if (report.privateArtifact.consumableByWave2 === false) {
       return 1
     }
     return 0
   } catch (err) {
-    process.stderr.write(`[gip-authority-substrate-inventory] ERROR: ${err instanceof Error ? err.message : String(err)}\n`)
+    process.stderr.write(`[gip-authority-substrate-inventory] ERROR: ${closedCliErrorReason(err)}\n`)
     return 1
   } finally {
-    if (executor) await executor.close()
+    await safeClose(executor)
   }
 }
 
 const entryPath = process.argv[1] ? path.resolve(process.argv[1]) : null
 const isEntry = entryPath && entryPath === fileURLToPath(import.meta.url)
 if (isEntry) {
-  main().then((code) => {
-    process.exitCode = code
-  })
+  // Last-resort net, not the normal path: every branch inside main() already resolves to a mapped
+  // exit code via its own try/catch (see closedCliErrorReason() and safeClose() above). The reject
+  // handler here exists only in case something still escapes both — without it, Node prints the
+  // raw rejection (including any absolute path in its stack) straight to real stderr, and that
+  // print happens OUTSIDE main()'s own stderr writes, so nothing inside this file can intercept or
+  // redact it. Never interpolate the rejection reason here, for the same values-free discipline as
+  // every other stderr write in this file.
+  main().then(
+    (code) => {
+      process.exitCode = code
+    },
+    () => {
+      process.stderr.write(`[gip-authority-substrate-inventory] ERROR: ${CLI_ERROR_REASON.RUNTIME_FAILURE}\n`)
+      process.exitCode = 1
+    },
+  )
 }
 
 export {
@@ -1086,6 +1182,9 @@ export {
   buildDryRunReport,
   renderHumanSummary,
   parseArgs,
+  CLI_ERROR_REASON,
+  CliArgError,
+  closedCliErrorReason,
   main,
   REPO_ROOT,
   DEFAULT_PRIVATE_OUTPUT_DIR,

--- a/scripts/ops/gip-authority-substrate-inventory.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.mjs
@@ -142,11 +142,22 @@ const SCHEMA_PROBE_CAVEAT =
 const DEFAULT_PRIVATE_OUTPUT_DIR = 'artifacts/gip-authority-inventory'
 
 // ---------------------------------------------------------------------------
-// QUERY_ALLOWLIST — the ONLY SQL statements this script will ever execute.
-// Every statement is SELECT-only; assertReadOnlyAllowlist() enforces that
-// structurally at module load (same guard shape as #4594's, independently
-// implemented per the owner's task-brief carrier ruling — see the header
-// comment above; that ruling is not recorded in the ledger).
+// QUERY_ALLOWLIST — the ONLY SQL statements this script will ever execute,
+// PROVIDED an entry is not mutated post-load. `Object.freeze()` on the outer
+// object is SHALLOW: it stops a new tag from being added/removed/replaced,
+// but a nested entry object (e.g. QUERY_ALLOWLIST['probe.columns']) would
+// remain writable on its own unless frozen too — see the explicit per-entry
+// freeze loop right below this literal, which closes that gap (#4603 P3:
+// proven by an importer reassigning `.sql` on a live entry and observing
+// runQuery()/probeColumns() hand the mutated string straight to the
+// executor). With that loop in place, EVERY entry is independently frozen,
+// so a post-load `QUERY_ALLOWLIST[tag].sql = …` throws (strict-mode ESM)
+// instead of silently succeeding. assertReadOnlyAllowlist() enforces the
+// SELECT-only shape structurally at module load (same guard shape as
+// #4594's, independently implemented per the owner's task-brief carrier
+// ruling — see the header comment above; that ruling is not recorded in the
+// ledger) — freezing is what keeps that load-time proof true for the rest of
+// the process's life, not just at the instant it ran.
 // ---------------------------------------------------------------------------
 
 const QUERY_ALLOWLIST = Object.freeze({
@@ -176,6 +187,16 @@ const QUERY_ALLOWLIST = Object.freeze({
       "rows where the object column and config->>'object' disagree — a values-free integrity check; a non-zero result means some backfill/mapping decision fed only by the object column would miss rows whose stored config JSON disagrees with it. IS DISTINCT FROM (not <>) is deliberate: a row whose config JSON carries no 'object' key at all has config->>'object' = NULL, and IS DISTINCT FROM (unlike <>) treats object <> NULL as true rather than UNKNOWN per the SQL standard's IS DISTINCT FROM semantics — a missing key in config counts as a divergence, not a silent pass. A prior session in this PR reported exercising this against a seeded row with no 'object' key on an ephemeral local Postgres instance that was discarded afterward with no transcript captured — see PR body's caveat on that claim; this fix pass did not have a live Postgres runtime available to reproduce it independently, so treat the missing-key behaviour as following from the documented SQL semantics of IS DISTINCT FROM, not as an independently-reproduced live-DB proof.",
   },
 })
+
+// #4603 P3: `Object.freeze()` above is SHALLOW — it only locks the outer object's own key set, not
+// each nested entry object. Without this loop, `QUERY_ALLOWLIST['probe.columns'].sql = '…'` would
+// silently succeed post-load, and runQuery()/probeColumns() would hand the mutated string straight
+// to the executor — the "ONLY SQL statements this script will ever execute" claim above would be
+// false in scope (not just unenforced after the instant assertReadOnlyAllowlist() ran). Freeze each
+// entry independently so the same guarantee the outer freeze gives the key set also holds per-entry.
+for (const entry of Object.values(QUERY_ALLOWLIST)) {
+  Object.freeze(entry)
+}
 
 // A row count is only ever trustworthy if it is a non-negative SAFE integer. `Number(x) || 0`
 // (the prior shape of this predicate) turns undefined/null/''/'abc'/NaN into a silent 0 — the
@@ -1140,6 +1161,19 @@ if (isEntry) {
   // print happens OUTSIDE main()'s own stderr writes, so nothing inside this file can intercept or
   // redact it. Never interpolate the rejection reason here, for the same values-free discipline as
   // every other stderr write in this file.
+  //
+  // COVERAGE DISCLOSURE (#4603 HOLD, accepted gap, kept narrow — see the 'safeClose() rejection-
+  // swallow' describe block in the test file for what IS pinned): this specific `() => { ... }`
+  // rejection callback has zero test coverage, and that is not fixable through the createExecutor
+  // seam. With safeClose() now swallowing every executor.close() rejection at both finally sites
+  // (pinned by the tests referenced above), and parseArgs()/buildReport()/buildDryRunReport()
+  // already resolving every error they can produce to a mapped exit code inside main()'s own
+  // try/catch blocks, main() resolves by construction on every path the injectable seam can drive
+  // — there is no fixture that makes main() itself reject without mutating the source to
+  // (re)introduce an escape. Reaching this callback for real would require isEntry to be true (a
+  // condition gated on real process.argv[1]/import.meta.url identity, not exercisable via the
+  // createExecutor seam at all) AND some other future change to reopen an escape safeClose() no
+  // longer allows. Left disclosed rather than silently dropped; not claimed as covered.
   main().then(
     (code) => {
       process.exitCode = code

--- a/scripts/ops/gip-authority-substrate-inventory.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.mjs
@@ -4,11 +4,15 @@
  *
  * TWO READ-ONLY, values-free inventory probes feeding two of the four §4.0 owner decisions in
  * docs/development/database-system-integration-line-design-and-verification-20260724.md
- * ("the ledger"). This is a NEW, separate carrier — the ledger's owner ruling was explicit that
- * scripts/ops/data-source-exposure-inventory.mjs (#4594) must NOT be expanded or reused as the
- * carrier for this work, so nothing here imports from or depends on that script; the
- * schema-probe-first / values-free QUERY_ALLOWLIST pattern is independently re-implemented,
- * because that is the pattern being reused, not the file.
+ * ("the ledger"). This is a NEW, separate carrier — per the owner's task-brief ruling (NOT recorded
+ * in the ledger; the ledger's §4.0/§3.0 sections define the four decisions this work feeds but say
+ * nothing about a carrier for this script), scripts/ops/data-source-exposure-inventory.mjs (#4594)
+ * must NOT be expanded or reused as the carrier for this work, so nothing here imports from or
+ * depends on that script; the schema-probe-first / values-free QUERY_ALLOWLIST pattern is
+ * independently re-implemented, because that is the pattern being reused, not the file. Also note:
+ * #4594's script/test/workflow files live only on branch `claude/data-source-exposure-inventory-
+ * 20260724` (PR #4594) — they are NOT in this tree, NOT on main, and this file makes no claim that
+ * they are.
  *
  * ---------------------------------------------------------------------------------------------
  * (β) CONNECTOR-KIND PROBE — integration_external_systems.kind
@@ -63,7 +67,7 @@
  * JSON report, never into a log line, never into a PR body.
  *
  * ---------------------------------------------------------------------------------------------
- * SCOPE (ledger owner ruling, quoted in the task brief)
+ * SCOPE (from the ledger's Gate — see the ledger's "B1a AUTHORITY-SUBSTRATE gate" wording)
  * ---------------------------------------------------------------------------------------------
  * Building and testing this tool is inside the B1a AUTHORITY-SUBSTRATE gate (bounded internal
  * work, no new request surface, no runtime consumer). CONNECTING IT TO A CUSTOMER DEPLOYMENT is a
@@ -125,7 +129,8 @@ const DEFAULT_PRIVATE_OUTPUT_DIR = 'artifacts/gip-authority-inventory'
 // QUERY_ALLOWLIST — the ONLY SQL statements this script will ever execute.
 // Every statement is SELECT-only; assertReadOnlyAllowlist() enforces that
 // structurally at module load (same guard shape as #4594's, independently
-// implemented per the ledger's carrier ruling).
+// implemented per the owner's task-brief carrier ruling — see the header
+// comment above; that ruling is not recorded in the ledger).
 // ---------------------------------------------------------------------------
 
 const QUERY_ALLOWLIST = Object.freeze({
@@ -152,7 +157,7 @@ const QUERY_ALLOWLIST = Object.freeze({
   'count.read_source_config_object_config_divergence': {
     sql: `SELECT count(*)::int AS n FROM integration_read_source_configs WHERE object IS DISTINCT FROM (config ->> 'object')`,
     describe:
-      "rows where the object column and config->>'object' disagree — a values-free integrity check; a non-zero result means some backfill/mapping decision fed only by the object column would miss rows whose stored config JSON disagrees with it. IS DISTINCT FROM (not <>) is deliberate: a row whose config JSON carries no 'object' key at all has config->>'object' = NULL, and IS DISTINCT FROM (unlike <>) treats object <> NULL as true rather than UNKNOWN — a missing key in config counts as a divergence, not a silent pass. Verified live against a seeded row with no 'object' key in migration verification (see PR body).",
+      "rows where the object column and config->>'object' disagree — a values-free integrity check; a non-zero result means some backfill/mapping decision fed only by the object column would miss rows whose stored config JSON disagrees with it. IS DISTINCT FROM (not <>) is deliberate: a row whose config JSON carries no 'object' key at all has config->>'object' = NULL, and IS DISTINCT FROM (unlike <>) treats object <> NULL as true rather than UNKNOWN per the SQL standard's IS DISTINCT FROM semantics — a missing key in config counts as a divergence, not a silent pass. A prior session in this PR reported exercising this against a seeded row with no 'object' key on an ephemeral local Postgres instance that was discarded afterward with no transcript captured — see PR body's caveat on that claim; this fix pass did not have a live Postgres runtime available to reproduce it independently, so treat the missing-key behaviour as following from the documented SQL semantics of IS DISTINCT FROM, not as an independently-reproduced live-DB proof.",
   },
 })
 
@@ -511,6 +516,32 @@ function computeObjectKeyVerdict(publicObjectKeySummary) {
       ],
     }
   }
+  // `unexpected` is where splitRowsByStatus() fail-closes any row whose status is outside the
+  // CHECK-constraint vocabulary (draft/approved/retired) — see splitRowsByStatus(). The CHECK
+  // constraint should make this bucket always empty, but a report must never assume its own gate
+  // held: if it observes distinct objectKeys sitting in an out-of-vocabulary status, that is
+  // exactly the "unregistered objectKeys coexisting with a NOT_REQUIRED verdict" shape the
+  // divergence check above exists to prevent — a human reading NOT_REQUIRED must not be told
+  // "nothing to map" while rows outside the known status vocabulary are sitting unaccounted for.
+  const unexpected = publicObjectKeySummary.byStatus.unexpected
+  if (!unexpected || unexpected.status !== 'ok') {
+    return {
+      verdict: 'INCONCLUSIVE',
+      reasons: [
+        'coverage is partial — the unexpected-status objectKey count is UNAVAILABLE',
+        unexpected ? unexpected.reason : 'byStatus.unexpected field missing from summary',
+      ],
+    }
+  }
+  if (unexpected.distinctCount > 0) {
+    return {
+      verdict: 'INCONCLUSIVE',
+      reasons: [
+        `${unexpected.distinctCount} distinct objectKey(s) referenced by read-source config row(s) in an out-of-vocabulary (unexpected) status — a verdict scoped to 'approved' cannot be trusted while rows exist outside the known draft/approved/retired status vocabulary`,
+        'this is reported regardless of registeredness — see coverage.canonicalObjectKeyInventory.byStatus.unexpected',
+      ],
+    }
+  }
   const approved = publicObjectKeySummary.byStatus.approved
   if (approved.unregisteredDistinctCount === 0) {
     return {
@@ -550,6 +581,11 @@ const RESIDUAL_NOTES = Object.freeze([
     id: 'no_customer_deployment_connection',
     description:
       'This script has only ever been run against a hermetic fake executor (tests) and, if noted in the PR, a local/CI fixture database — never a customer deployment. Connecting to one is a separate ops-gated read-only authorization this task does not carry.',
+  },
+  {
+    id: 'integration_write_target_configs_object_deliberately_out_of_scope',
+    description:
+      "A second objectKey reference class exists in the same database: integration_write_target_configs.object (migration 064, External-API WRITE self-service W1). This inventory does NOT probe it. Reason: the ledger's decision (γ) scope (§4 step 1.3, §3.0 B-3) is the READ-side qualification-input tuple's objectKey, and the task this script was built for is scoped to that tuple; the write-target config table is a separate, config-time-only surface (no dry-run/apply/runtime route per its migration header) that decision (γ)'s registry may also need to cover eventually, but that is a follow-up inventory scope decision, not an oversight in this one. A canonical object referenced ONLY by a write-target config (never by a read-source config) is invisible to this report.",
   },
 ])
 
@@ -674,7 +710,7 @@ async function buildReport({ exec, repoRoot = REPO_ROOT, probe = 'both', private
         covers:
           "distinct integration_read_source_configs.object values (the ledger's `objectKey` tuple term) referenced by configs, split by status — the raw material for decision (γ)'s missing-reference and backfill lists. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
         blindSpot:
-          "DB rows only, in the ONE connected database. A canonical object referenced by a still-in-development (never-saved) config, or by a config in a DIFFERENT database this run was not pointed at, is invisible here.",
+          "DB rows only, in the ONE connected database. A canonical object referenced by a still-in-development (never-saved) config, or by a config in a DIFFERENT database this run was not pointed at, is invisible here. Also deliberately out of scope: integration_write_target_configs.object (migration 064) — a second objectKey reference class in the same database this report never queries; see residualNotes.",
         ...publicObjectKeySummary,
       },
     },
@@ -691,11 +727,12 @@ async function buildReport({ exec, repoRoot = REPO_ROOT, probe = 'both', private
 // Dry-run / plan mode
 // ---------------------------------------------------------------------------
 
-async function buildDryRunReport({ exec, repoRoot = REPO_ROOT } = {}) {
+async function buildDryRunReport({ exec, repoRoot = REPO_ROOT, probe = 'both' } = {}) {
   if (!exec) {
     return {
       generatedAt: new Date().toISOString(),
       mode: 'dry-run-static',
+      probe,
       note: 'No query executor / DATABASE_URL supplied — schema was not probed. This lists every allowlisted query; see buildPlan() in the script source for exact resolution rules.',
       allowlist: Object.fromEntries(Object.entries(QUERY_ALLOWLIST).map(([tag, e]) => [tag, { describe: e.describe, sql: e.sql }])),
       knownRegistrySizes: {
@@ -705,11 +742,18 @@ async function buildDryRunReport({ exec, repoRoot = REPO_ROOT } = {}) {
       residualNotes: RESIDUAL_NOTES,
     }
   }
-  const schema = await probeSchema(exec)
-  const plan = buildPlan(schema)
+  // `probe` scopes the dry-run's schema probe exactly the same way buildReport() scopes report
+  // mode's schema probe — see the identically-worded comment above buildReport()'s `probeSchema`
+  // call. Without this, `--probe beta --dry-run` would still name/probe
+  // integration_read_source_configs, which is exactly the drift `--probe beta` (report mode)
+  // promises never happens, and the PR's "schema probe included" scoping claim would be false in
+  // dry-run mode specifically.
+  const schema = await probeSchema(exec, tableSpecsForProbe(probe))
+  const plan = buildPlan(schema, { probe })
   return {
     generatedAt: new Date().toISOString(),
     mode: 'dry-run',
+    probe,
     note: 'Schema WAS probed (read-only information_schema queries). No aggregate/count query below was executed — this is exactly what report mode would run next.',
     schema,
     plan,
@@ -873,7 +917,7 @@ async function main(argv = process.argv.slice(2), env = process.env) {
     let executor = null
     try {
       if (databaseUrl) executor = await createPgExecutor(databaseUrl)
-      const report = await buildDryRunReport({ exec: executor ? executor.exec : null })
+      const report = await buildDryRunReport({ exec: executor ? executor.exec : null, probe: opts.probe })
       if (opts.json) {
         process.stdout.write(JSON.stringify(report, null, 2) + '\n')
       } else {

--- a/scripts/ops/gip-authority-substrate-inventory.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.mjs
@@ -81,9 +81,11 @@
  *
  * Exit codes:
  *   0  ran successfully (a MAPPING_REQUIRED / BACKFILL_REQUIRED verdict is information, not failure)
- *   1  unexpected runtime/DB error, OR the private artefact was owed (unregistered/unmapped count
- *      > 0) but could not be written — fails closed rather than reporting aggregate-only success
- *      while silently dropping the raw detail a human needs to act on it
+ *   1  unexpected runtime/DB error; OR the private artefact was owed (unregistered/unmapped count
+ *      > 0) but could not be written; OR it was owed but --no-private-out disabled the write
+ *      (report.privateArtifact.consumableByWave2 === false) — all three fail closed rather than
+ *      reporting aggregate-only success while silently dropping the raw detail a human needs to
+ *      act on it, or letting a caller read "ran successfully" as "this run is a complete inventory"
  *   2  required input missing (DATABASE_URL absent outside --dry-run)
  */
 
@@ -160,6 +162,28 @@ const QUERY_ALLOWLIST = Object.freeze({
       "rows where the object column and config->>'object' disagree — a values-free integrity check; a non-zero result means some backfill/mapping decision fed only by the object column would miss rows whose stored config JSON disagrees with it. IS DISTINCT FROM (not <>) is deliberate: a row whose config JSON carries no 'object' key at all has config->>'object' = NULL, and IS DISTINCT FROM (unlike <>) treats object <> NULL as true rather than UNKNOWN per the SQL standard's IS DISTINCT FROM semantics — a missing key in config counts as a divergence, not a silent pass. A prior session in this PR reported exercising this against a seeded row with no 'object' key on an ephemeral local Postgres instance that was discarded afterward with no transcript captured — see PR body's caveat on that claim; this fix pass did not have a live Postgres runtime available to reproduce it independently, so treat the missing-key behaviour as following from the documented SQL semantics of IS DISTINCT FROM, not as an independently-reproduced live-DB proof.",
   },
 })
+
+// A row count is only ever trustworthy if it is a non-negative SAFE integer. `Number(x) || 0`
+// (the prior shape of this predicate) turns undefined/null/''/'abc'/NaN into a silent 0 — the
+// single most dangerous wrong answer for a precondition probe, because "0 unregistered" is
+// exactly the green light a downstream gate would consume. Fail closed instead: anything that is
+// not a genuinely-observed non-negative safe integer must make the surrounding coverage
+// UNAVAILABLE (-> INCONCLUSIVE at the verdict layer), never silently read as zero.
+//
+// `typeof value === 'number'` is correct against the real driver, not merely convenient in tests:
+// every allowlisted count query casts with `count(*)::int` (int4), and node-postgres parses int4
+// results to native JS numbers. An accidental switch to a bigint-returning cast (int8/count with
+// no cast) would come back from `pg` as a STRING — and this predicate correctly fails that closed
+// too, rather than coercing it.
+function isSafeNonNegativeInteger(value) {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+}
+
+// Fixed, values-free reason used whenever a row count fails the safe-integer check above. Never
+// interpolates the observed value, the row index, or which row — those could themselves be, or be
+// derived from, database content; the fact that this happened is the entire actionable signal.
+const INVALID_COUNT_REASON =
+  'a row count value returned by the connected database was not a non-negative safe integer — treated as INCONCLUSIVE, never defaulted to zero'
 
 function assertReadOnlyAllowlist(allowlist) {
   for (const [tag, entry] of Object.entries(allowlist)) {
@@ -297,6 +321,10 @@ function buildPlan(schema, { probe = 'both' } = {}) {
 // the counts. writePrivateArtifact() is the only place `detail` may land.
 // ---------------------------------------------------------------------------
 
+// Returns EITHER { status: 'ok', counts, detail } OR { status: 'invalid_count', reason } — never
+// a throw a caller could swallow, and never counts built from a coerced/defaulted bad value. A
+// single anomalous row count invalidates the whole bucket rather than silently zeroing just that
+// row: a partial "mostly trustworthy" count is exactly the shape a human skims past.
 function bucketByRegistry(rows, knownSet, { valueKey, countKey = 'n' }) {
   const known = new Set(knownSet)
   let registeredDistinct = 0
@@ -307,7 +335,11 @@ function bucketByRegistry(rows, knownSet, { valueKey, countKey = 'n' }) {
   const detail = []
   for (const row of rows) {
     const value = row[valueKey]
-    const n = Number(row[countKey]) || 0
+    const rawCount = row[countKey]
+    if (!isSafeNonNegativeInteger(rawCount)) {
+      return { status: 'invalid_count', reason: INVALID_COUNT_REASON }
+    }
+    const n = rawCount
     totalRows += n
     const isKnown = known.has(value)
     if (isKnown) {
@@ -320,6 +352,7 @@ function bucketByRegistry(rows, knownSet, { valueKey, countKey = 'n' }) {
     detail.push({ value, count: n, registered: isKnown })
   }
   return {
+    status: 'ok',
     counts: {
       distinctCount: rows.length,
       totalRows,
@@ -343,6 +376,9 @@ async function executeKindInventoryPlan(exec, plan) {
 
   const allRes = await runQuery(exec, plan.allStatuses.tag, plan.allStatuses.params)
   const all = bucketByRegistry(allRes.rows, KNOWN_CERTIFIED_CONNECTOR_KINDS, { valueKey: 'kind' })
+  // allStatuses is what the verdict is computed from (see computeKindVerdict) — an invalid count
+  // there invalidates the whole probe, not just this sub-field, the same way a missing table does.
+  if (all.status !== 'ok') return { status: 'unavailable', reason: all.reason }
 
   let active
   if (plan.activeOnly.status !== 'ok') {
@@ -350,7 +386,9 @@ async function executeKindInventoryPlan(exec, plan) {
   } else {
     const activeRes = await runQuery(exec, plan.activeOnly.tag, plan.activeOnly.params)
     const bucketed = bucketByRegistry(activeRes.rows, KNOWN_CERTIFIED_CONNECTOR_KINDS, { valueKey: 'kind' })
-    active = { status: 'ok', counts: bucketed.counts, detail: bucketed.detail }
+    active = bucketed.status === 'ok'
+      ? { status: 'ok', counts: bucketed.counts, detail: bucketed.detail }
+      : { status: 'unavailable', reason: bucketed.reason }
   }
 
   return {
@@ -383,6 +421,9 @@ async function executeObjectKeyInventoryPlan(exec, plan) {
   const byStatus = {}
   for (const key of ['draft', 'approved', 'retired', 'unexpected']) {
     const bucketed = bucketByRegistry(split[key], KNOWN_CANONICAL_OBJECT_KEYS, { valueKey: 'object' })
+    // An invalid count in ANY status bucket invalidates the whole probe (computeObjectKeyVerdict
+    // reads approved/unexpected together; a partial trustworthy read is not a safe read).
+    if (bucketed.status !== 'ok') return { status: 'unavailable', reason: bucketed.reason }
     byStatus[key] = { status: 'ok', counts: bucketed.counts, detail: bucketed.detail }
   }
 
@@ -391,7 +432,12 @@ async function executeObjectKeyInventoryPlan(exec, plan) {
     divergence = { status: 'unavailable', reason: plan.divergence.reason }
   } else {
     const { rows } = await runQuery(exec, plan.divergence.tag, plan.divergence.params)
-    divergence = { status: 'ok', count: rows.length ? Number(rows[0].n) || 0 : 0 }
+    // A COUNT(*) query always returns exactly one row; anything else (zero or several) is itself
+    // an anomaly, not just the value inside it — fail closed rather than defaulting to 0.
+    const rawCount = rows.length === 1 ? rows[0].n : undefined
+    divergence = isSafeNonNegativeInteger(rawCount)
+      ? { status: 'ok', count: rawCount }
+      : { status: 'unavailable', reason: INVALID_COUNT_REASON }
   }
 
   return { status: 'ok', byStatus, divergence }
@@ -634,9 +680,16 @@ function buildPrivateArtifactContent(coverage, { generatedAt }) {
   }
 }
 
+// EXCLUSIVE CREATE ONLY. `flag: 'wx'` is O_CREAT|O_EXCL|O_WRONLY: per POSIX, open() with O_EXCL
+// fails EEXIST if the path already names ANYTHING — a regular file, OR a symlink node, even a
+// DANGLING one whose target does not exist — without ever following that symlink to write through
+// it. This closes both refusals atomically (no separate "check then write" race): never overwrite
+// an existing target, never follow a symlink at the target path. `mode: 0o600` only constrains the
+// permissions of a file THIS call creates; it cannot and does not retroactively tighten a
+// pre-existing target, which is exactly why exclusivity (not just the mode) is the real guard.
 function writePrivateArtifact(filePath, content) {
   mkdirSync(path.dirname(filePath), { recursive: true })
-  writeFileSync(filePath, JSON.stringify(content, null, 2) + '\n', { mode: 0o600 })
+  writeFileSync(filePath, JSON.stringify(content, null, 2) + '\n', { mode: 0o600, flag: 'wx' })
 }
 
 function defaultPrivateOutputPath(repoRoot, generatedAt) {
@@ -669,29 +722,51 @@ async function buildReport({ exec, repoRoot = REPO_ROOT, probe = 'both', private
   const kindVerdict = coverage.kindInventory.status === 'not_run' ? null : computeKindVerdict(publicKindSummary)
   const objectKeyVerdict = coverage.objectKeyInventory.status === 'not_run' ? null : computeObjectKeyVerdict(publicObjectKeySummary)
 
-  let privateArtifact = { status: 'not_attempted' }
-  if (!noPrivateOut) {
-    const owed = shouldWritePrivateArtifact(coverage)
+  // Computed unconditionally — needed BOTH to decide whether a disabled write is fail-closed
+  // (below) and, unchanged from before, to decide whether a write failure is fail-closed.
+  const owed = shouldWritePrivateArtifact(coverage)
+
+  let privateArtifact
+  if (noPrivateOut) {
+    // A private artefact is the ONLY place raw kind/objectKey detail can go (see the header's
+    // OUTPUT DISCIPLINE section). If one is owed (unregistered/unmapped values exist) and the
+    // operator disabled the write, this run is NOT a complete inventory: the raw list a human
+    // needs to author the (β)/(γ) decisions never landed anywhere. Say so structurally —
+    // `consumableByWave2: false` — rather than reporting the same bare 'skipped_by_flag' a
+    // genuinely-nothing-owed run gets; main() also turns this into a non-zero exit code (see the
+    // header's Exit codes list) so a caller relying on exit status alone still fails closed.
+    privateArtifact = owed
+      ? { status: 'incomplete_owed_disabled', consumableByWave2: false }
+      : { status: 'skipped_by_flag', consumableByWave2: true }
+  } else {
+    // Deterministic default target: DEFAULT_PRIVATE_OUTPUT_DIR + this report's own `generatedAt`
+    // (see defaultPrivateOutputPath()) — an operator who did not pass --private-out can always
+    // reconstruct a 'written' artefact's location from those two already-public values. The real
+    // filesystem path is never echoed into privateArtifact itself: report.privateArtifact is
+    // public/committed output (stdout, --json, the human summary — see the header's OUTPUT
+    // DISCIPLINE section), and an operator-supplied --private-out path is untrusted input that
+    // could itself carry a customer directory name or hostname, so it must never round-trip back
+    // out through a channel this file promises is values-free.
     const targetPath = privateOutPath || defaultPrivateOutputPath(repoRoot, generatedAt)
     try {
       const content = buildPrivateArtifactContent(coverage, { generatedAt })
       writePrivateArtifact(targetPath, content)
-      privateArtifact = { status: 'written', path: path.relative(repoRoot, targetPath) }
+      privateArtifact = { status: 'written', consumableByWave2: true }
     } catch (err) {
       if (owed) {
-        // Fail closed: raw detail existed and needed a home; the write failed. The error itself
-        // must stay values-free — never interpolate the raw content, only the path attempted.
+        // Fail closed: raw detail existed and needed a home; the write failed. The thrown message
+        // stays values-free too — never interpolate the target path or the underlying err.message,
+        // either of which can carry filesystem/OS detail (a customer directory name, a hostname)
+        // that has no business in anything that could end up in a log or a PR body.
         throw new Error(
-          `gip-authority-substrate-inventory: unregistered kind/objectKey values exist but the private artefact could not be written (target: ${path.relative(repoRoot, targetPath)}): ${err instanceof Error ? err.message : String(err)}`,
+          'gip-authority-substrate-inventory: unregistered kind/objectKey values exist but the private artefact could not be written — refusing to report aggregate-only success while silently dropping the raw detail a human needs to act on it',
         )
       }
       // Nothing was owed (every observed value already matches the known registry, or there was
       // nothing to observe) — a write failure here is a filesystem nuisance, not a lost decision
-      // input. Report it, do not fail the run.
-      privateArtifact = { status: 'write_failed_but_nothing_owed', path: path.relative(repoRoot, targetPath), reason: err instanceof Error ? err.message : String(err) }
+      // input. Report it via a closed reason CODE only — never err.message or the target path.
+      privateArtifact = { status: 'write_failed_but_nothing_owed', consumableByWave2: true, reasonCode: 'FILESYSTEM_WRITE_ERROR' }
     }
-  } else {
-    privateArtifact = { status: 'skipped_by_flag' }
   }
 
   return {
@@ -807,7 +882,11 @@ function renderHumanSummary(report) {
     lines.push(`  verdict: ${report.verdicts.canonicalObjectKey.verdict}`)
   }
   lines.push('')
-  lines.push(`private artefact: ${report.privateArtifact.status}${report.privateArtifact.path ? ` (${report.privateArtifact.path})` : ''}`)
+  // No real filesystem path is ever printed here — see the (b) ruling above writePrivateArtifact()
+  // in the source: an operator-supplied --private-out path is untrusted input, and this line is
+  // public/committed output. An operator who used the default location can reconstruct it from
+  // DEFAULT_PRIVATE_OUTPUT_DIR + this report's own generatedAt (see defaultPrivateOutputPath()).
+  lines.push(`private artefact: ${report.privateArtifact.status}`)
   lines.push('')
   lines.push('residual notes:')
   for (const n of report.residualNotes) lines.push(`  - [${n.id}] ${n.description}`)
@@ -953,6 +1032,12 @@ async function main(argv = process.argv.slice(2), env = process.env) {
       process.stdout.write(renderHumanSummary(report))
       process.stdout.write('\n' + JSON.stringify(report, null, 2) + '\n')
     }
+    // The report is still printed above even in this case — a caller reading stdout gets the full
+    // explanation — but the run must not be mistakable for a complete inventory by exit code alone
+    // (see the header's Exit codes list and the ruling on ~L672 in the PR that added this check).
+    if (report.privateArtifact.consumableByWave2 === false) {
+      return 1
+    }
     return 0
   } catch (err) {
     process.stderr.write(`[gip-authority-substrate-inventory] ERROR: ${err instanceof Error ? err.message : String(err)}\n`)
@@ -977,6 +1062,8 @@ export {
   EXTERNAL_SYSTEM_STATUSES,
   READ_SOURCE_CONFIG_STATUSES,
   assertReadOnlyAllowlist,
+  isSafeNonNegativeInteger,
+  INVALID_COUNT_REASON,
   runQuery,
   tableExists,
   probeColumns,
@@ -993,6 +1080,7 @@ export {
   RESIDUAL_NOTES,
   shouldWritePrivateArtifact,
   buildPrivateArtifactContent,
+  writePrivateArtifact,
   defaultPrivateOutputPath,
   buildReport,
   buildDryRunReport,

--- a/scripts/ops/gip-authority-substrate-inventory.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.mjs
@@ -1,0 +1,960 @@
+#!/usr/bin/env node
+/**
+ * gip-authority-substrate-inventory.mjs
+ *
+ * TWO READ-ONLY, values-free inventory probes feeding two of the four §4.0 owner decisions in
+ * docs/development/database-system-integration-line-design-and-verification-20260724.md
+ * ("the ledger"). This is a NEW, separate carrier — the ledger's owner ruling was explicit that
+ * scripts/ops/data-source-exposure-inventory.mjs (#4594) must NOT be expanded or reused as the
+ * carrier for this work, so nothing here imports from or depends on that script; the
+ * schema-probe-first / values-free QUERY_ALLOWLIST pattern is independently re-implemented,
+ * because that is the pattern being reused, not the file.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * (β) CONNECTOR-KIND PROBE — integration_external_systems.kind
+ * ---------------------------------------------------------------------------------------------
+ * Purpose, and nothing beyond it: produce the distinct-kind-string list and per-string row counts
+ * a HUMAN uses to author the explicit alias map and migration list for decision (β)'s first-party
+ * CLOSED connector-kind registry (ledger §4.0 row β, §4 step 1.2, §3.0 B-2). `kind` is a free-form
+ * `requiredString` with no vocabulary anywhere today (external-systems.cjs L91; migration 057's
+ * column comment lists illustrative EXAMPLES only, not an enum — there is no CHECK constraint on
+ * this column, unlike `status`).
+ *
+ * FORBIDDEN, enforced structurally below, not just by convention: this probe NEVER auto-expands or
+ * auto-populates KNOWN_CERTIFIED_CONNECTOR_KINDS from what it observes. That constant is frozen at
+ * module load and is the ONLY thing this script ever compares an observed kind string against; the
+ * probe has no code path that writes to it. It stays empty until a human, acting on decision (β),
+ * edits this file in a follow-up change — never as a side effect of running the inventory.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * (γ) OBJECT-KEY PROBE — integration_read_source_configs.object
+ * ---------------------------------------------------------------------------------------------
+ * Purpose, and nothing beyond it: produce the distinct-objectKey list and per-key row counts a
+ * HUMAN uses to author the missing-reference list and backfill list for decision (γ)'s first-party
+ * canonical object contract registry (ledger §4.0 row γ, §4 step 1.3, §3.0 B-3).
+ *
+ * Terminology note, stated once because it is load-bearing and easy to get wrong: the ledger's
+ * qualification-input tuple names this field `objectKey` (§3.1, §4 step 1). No column literally
+ * named `objectKey` exists on main. The stored column is `integration_read_source_configs.object`
+ * (migration 062 L28: `object TEXT NOT NULL`; both unique indexes key on it; the store's
+ * `saveVersion` writes it from `normalized.object`, which is `read-source-config.cjs`'s validated
+ * `object` field). This probe queries THAT column and reports it as the objectKey inventory the
+ * task asked for — the mapping is asserted by a schema-drift test below, not merely commented.
+ *
+ * FORBIDDEN, enforced the same way as β: KNOWN_CANONICAL_OBJECT_KEYS is frozen, empty, and never
+ * written to by this script. Canonical contracts must come from first-party frozen definitions
+ * (decision γ ruling) — this inventory never generates, synthesises, or seeds one from what it
+ * observes in a customer's approved configs.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * OUTPUT DISCIPLINE (owner ruling, quoted in the task brief)
+ * ---------------------------------------------------------------------------------------------
+ * Public/committed output (stdout, --json, the human summary): AGGREGATE COUNTS ONLY. The public
+ * report object is built exclusively from: fixed status/verdict enum tokens, fixed label strings
+ * authored in this file, and integers. It is structurally incapable of holding an observed kind or
+ * objectKey string — see buildPublicKindSummary()/buildPublicObjectKeySummary() below, which never
+ * receive the raw per-value rows, only the two counts already reduced from them. This is proven
+ * by test (a sentinel value injected through the fake executor must not appear anywhere in
+ * JSON.stringify(publicReport)) rather than merely asserted.
+ *
+ * Raw values (the actual kind / objectKey strings, with their row counts) go ONLY into a private,
+ * gitignored local artefact file — see writePrivateArtifact() / DEFAULT_PRIVATE_OUTPUT_DIR — never
+ * into this script's stdout in non-JSON mode beyond the artefact PATH, never into the committed
+ * JSON report, never into a log line, never into a PR body.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * SCOPE (ledger owner ruling, quoted in the task brief)
+ * ---------------------------------------------------------------------------------------------
+ * Building and testing this tool is inside the B1a AUTHORITY-SUBSTRATE gate (bounded internal
+ * work, no new request surface, no runtime consumer). CONNECTING IT TO A CUSTOMER DEPLOYMENT is a
+ * separate, ops-gated read-only authorization this task does not carry — see main()'s DATABASE_URL
+ * requirement and the PR body for the explicit statement that no such run has happened.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://… node scripts/ops/gip-authority-substrate-inventory.mjs \
+ *     [--probe beta|gamma|both] [--private-out <path> | --no-private-out] [--json]
+ *   node scripts/ops/gip-authority-substrate-inventory.mjs --dry-run   # no DB required
+ *
+ * Exit codes:
+ *   0  ran successfully (a MAPPING_REQUIRED / BACKFILL_REQUIRED verdict is information, not failure)
+ *   1  unexpected runtime/DB error, OR the private artefact was owed (unregistered/unmapped count
+ *      > 0) but could not be written — fails closed rather than reporting aggregate-only success
+ *      while silently dropping the raw detail a human needs to act on it
+ *   2  required input missing (DATABASE_URL absent outside --dry-run)
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const REPO_ROOT = path.resolve(path.dirname(__filename), '../..')
+
+// ---------------------------------------------------------------------------
+// Frozen registries — see the FORBIDDEN paragraphs above. Empty until a human
+// edits this file under decision (β) / decision (γ). No function in this
+// module writes to either constant; the mutation-immunity tests below prove
+// that, rather than trusting the comment.
+// ---------------------------------------------------------------------------
+
+// Decision (β): first-party CLOSED connector-kind registry. NOT populated by this script. Do not
+// seed this from any single shipped example (e.g. a GIP *profile* `connectorKind` such as
+// `bridge:legacy-sql-readonly` in gip-bridge-bounded-read-profile.cjs) — that is a DIFFERENT field
+// (a certified read-action-profile's connector kind) from `integration_external_systems.kind`
+// (an operator-supplied external-system registration kind), and conflating them would be exactly
+// the "false certification via wrong artefact" class this ledger has been burned by before (§3.0
+// B-2's retraction). Leave empty; only the owner's decision (β) may add entries here.
+const KNOWN_CERTIFIED_CONNECTOR_KINDS = Object.freeze([])
+
+// Decision (γ): first-party canonical object contract registry, keyed by the object identifiers
+// this probe observes in `integration_read_source_configs.object`. NOT populated by this script.
+// Only the owner's decision (γ) — first-party frozen definitions — may add entries here.
+const KNOWN_CANONICAL_OBJECT_KEYS = Object.freeze([])
+
+// CHECK constraint on integration_external_systems.status (migration 057).
+const EXTERNAL_SYSTEM_STATUSES = Object.freeze(['active', 'inactive', 'error'])
+// CHECK constraint on integration_read_source_configs.status (migration 062).
+const READ_SOURCE_CONFIG_STATUSES = Object.freeze(['draft', 'approved', 'retired'])
+
+const SCHEMA_PROBE_CAVEAT =
+  "probed via information_schema.tables/.columns, table_schema='public', as the DATABASE_URL role — a non-public search_path or missing SELECT/USAGE privileges reports the same as a genuinely absent object"
+
+const DEFAULT_PRIVATE_OUTPUT_DIR = 'artifacts/gip-authority-inventory'
+
+// ---------------------------------------------------------------------------
+// QUERY_ALLOWLIST — the ONLY SQL statements this script will ever execute.
+// Every statement is SELECT-only; assertReadOnlyAllowlist() enforces that
+// structurally at module load (same guard shape as #4594's, independently
+// implemented per the ledger's carrier ruling).
+// ---------------------------------------------------------------------------
+
+const QUERY_ALLOWLIST = Object.freeze({
+  'probe.table_exists': {
+    sql: `SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = $1 LIMIT 1`,
+    describe: 'schema probe: does table $1 exist',
+  },
+  'probe.columns': {
+    sql: `SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = $1`,
+    describe: 'schema probe: which columns exist on table $1',
+  },
+  'count.external_system_kinds_all': {
+    sql: `SELECT kind, count(*)::int AS n FROM integration_external_systems GROUP BY kind`,
+    describe: 'all integration_external_systems rows (any status), grouped by kind',
+  },
+  'count.external_system_kinds_active': {
+    sql: `SELECT kind, count(*)::int AS n FROM integration_external_systems WHERE status = 'active' GROUP BY kind`,
+    describe: "active-only integration_external_systems rows, grouped by kind",
+  },
+  'count.read_source_config_objects_by_status': {
+    sql: `SELECT object, status, count(*)::int AS n FROM integration_read_source_configs GROUP BY object, status`,
+    describe: 'integration_read_source_configs rows grouped by (object, status) — covers draft/approved/retired in one pass',
+  },
+  'count.read_source_config_object_config_divergence': {
+    sql: `SELECT count(*)::int AS n FROM integration_read_source_configs WHERE object IS DISTINCT FROM (config ->> 'object')`,
+    describe:
+      "rows where the object column and config->>'object' disagree — a values-free integrity check; a non-zero result means some backfill/mapping decision fed only by the object column would miss rows whose stored config JSON disagrees with it. IS DISTINCT FROM (not <>) is deliberate: a row whose config JSON carries no 'object' key at all has config->>'object' = NULL, and IS DISTINCT FROM (unlike <>) treats object <> NULL as true rather than UNKNOWN — a missing key in config counts as a divergence, not a silent pass. Verified live against a seeded row with no 'object' key in migration verification (see PR body).",
+  },
+})
+
+function assertReadOnlyAllowlist(allowlist) {
+  for (const [tag, entry] of Object.entries(allowlist)) {
+    if (!/^\s*SELECT\b/i.test(entry.sql)) {
+      throw new Error(
+        `gip-authority-substrate-inventory: QUERY_ALLOWLIST entry "${tag}" is not a SELECT statement — refusing to load a non-read-only query.`,
+      )
+    }
+    const trimmed = entry.sql.trim()
+    const withoutTrailingSemicolon = trimmed.endsWith(';') ? trimmed.slice(0, -1) : trimmed
+    if (withoutTrailingSemicolon.includes(';')) {
+      throw new Error(
+        `gip-authority-substrate-inventory: QUERY_ALLOWLIST entry "${tag}" contains a non-trailing semicolon — refusing to load a possible multi-statement query.`,
+      )
+    }
+  }
+}
+assertReadOnlyAllowlist(QUERY_ALLOWLIST)
+
+async function runQuery(exec, tag, params = []) {
+  const entry = QUERY_ALLOWLIST[tag]
+  if (!entry) {
+    throw new Error(`gip-authority-substrate-inventory: query tag not on allowlist: ${tag}`)
+  }
+  return exec(entry.sql, params)
+}
+
+// ---------------------------------------------------------------------------
+// Schema probing
+// ---------------------------------------------------------------------------
+
+const TABLE_SPECS = Object.freeze({
+  integration_external_systems: ['id', 'kind', 'status'],
+  integration_read_source_configs: ['id', 'object', 'status', 'config'],
+})
+
+// Which TABLE_SPECS entries a given --probe value needs. "Strictly separated purposes" is enforced
+// HERE, not only at the count-query layer: under --probe beta, integration_read_source_configs is
+// never even schema-probed (no information_schema.tables/.columns call naming it) — a scoped run
+// makes literally zero round-trips that mention the other probe's table, full stop.
+function tableSpecsForProbe(probe) {
+  if (probe === 'beta') {
+    return { integration_external_systems: TABLE_SPECS.integration_external_systems }
+  }
+  if (probe === 'gamma') {
+    return { integration_read_source_configs: TABLE_SPECS.integration_read_source_configs }
+  }
+  return TABLE_SPECS
+}
+
+async function tableExists(exec, tableName) {
+  const { rows } = await runQuery(exec, 'probe.table_exists', [tableName])
+  return rows.length > 0
+}
+
+async function probeColumns(exec, tableName, wantedColumns) {
+  const { rows } = await runQuery(exec, 'probe.columns', [tableName])
+  const present = new Set(rows.map((r) => r.column_name))
+  const result = {}
+  for (const col of wantedColumns) result[col] = present.has(col)
+  return result
+}
+
+async function probeSchema(exec, tableSpecs = TABLE_SPECS) {
+  const schema = {}
+  for (const [table, cols] of Object.entries(tableSpecs)) {
+    const exists = await tableExists(exec, table)
+    const columns = exists
+      ? await probeColumns(exec, table, cols)
+      : Object.fromEntries(cols.map((c) => [c, false]))
+    schema[table] = { exists, columns }
+  }
+  return schema
+}
+
+// ---------------------------------------------------------------------------
+// Plan builder — pure function of schema. Decides OK vs UNAVAILABLE; never
+// emits a query against an unverified column.
+// ---------------------------------------------------------------------------
+
+function planKindInventory(schema) {
+  const t = schema.integration_external_systems
+  if (!t.exists) {
+    return { status: 'unavailable', reason: `table integration_external_systems not found (${SCHEMA_PROBE_CAVEAT})` }
+  }
+  if (!t.columns.kind) {
+    return { status: 'unavailable', reason: `integration_external_systems.kind column not found (${SCHEMA_PROBE_CAVEAT})` }
+  }
+  const allStatuses = { status: 'ok', tag: 'count.external_system_kinds_all', params: [] }
+  const activeOnly = t.columns.status
+    ? { status: 'ok', tag: 'count.external_system_kinds_active', params: [] }
+    : { status: 'unavailable', reason: `integration_external_systems.status column not found (${SCHEMA_PROBE_CAVEAT}) — cannot separate active-only from all-statuses` }
+  return { status: 'ok', allStatuses, activeOnly }
+}
+
+function planObjectKeyInventory(schema) {
+  const t = schema.integration_read_source_configs
+  if (!t.exists) {
+    return { status: 'unavailable', reason: `table integration_read_source_configs not found (${SCHEMA_PROBE_CAVEAT})` }
+  }
+  const missing = ['object', 'status'].filter((c) => !t.columns[c])
+  if (missing.length) {
+    return {
+      status: 'unavailable',
+      reason: `integration_read_source_configs missing column(s): ${missing.join(', ')} (${SCHEMA_PROBE_CAVEAT})`,
+    }
+  }
+  const byStatus = { status: 'ok', tag: 'count.read_source_config_objects_by_status', params: [] }
+  const divergence = t.columns.config
+    ? { status: 'ok', tag: 'count.read_source_config_object_config_divergence', params: [] }
+    : { status: 'unavailable', reason: `integration_read_source_configs.config column not found (${SCHEMA_PROBE_CAVEAT}) — cannot compute the object vs config->>'object' divergence check` }
+  return { status: 'ok', byStatus, divergence }
+}
+
+// `probe` scopes WHICH plans get built, not just which summaries get rendered — a plan of
+// { status: 'not_run' } short-circuits executeKindInventoryPlan/executeObjectKeyInventoryPlan
+// below BEFORE any query is issued. This is what makes "strictly separated purposes" true at the
+// query and private-artefact layer, not just in the printed summary: `--probe beta` must never
+// query integration_read_source_configs, and must never write a γ objectKey value anywhere,
+// private artefact included.
+function buildPlan(schema, { probe = 'both' } = {}) {
+  const runBeta = probe === 'both' || probe === 'beta'
+  const runGamma = probe === 'both' || probe === 'gamma'
+  return {
+    kindInventory: runBeta ? planKindInventory(schema) : { status: 'not_run' },
+    objectKeyInventory: runGamma ? planObjectKeyInventory(schema) : { status: 'not_run' },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bucketing — the values-free chokepoint. Every function below reduces raw
+// (value, n) rows into TWO integers (registered / unregistered) plus totals.
+// The raw rows themselves are returned SEPARATELY as `detail`, and callers
+// that assemble the PUBLIC report must never forward `detail` into it — only
+// the counts. writePrivateArtifact() is the only place `detail` may land.
+// ---------------------------------------------------------------------------
+
+function bucketByRegistry(rows, knownSet, { valueKey, countKey = 'n' }) {
+  const known = new Set(knownSet)
+  let registeredDistinct = 0
+  let unregisteredDistinct = 0
+  let registeredRows = 0
+  let unregisteredRows = 0
+  let totalRows = 0
+  const detail = []
+  for (const row of rows) {
+    const value = row[valueKey]
+    const n = Number(row[countKey]) || 0
+    totalRows += n
+    const isKnown = known.has(value)
+    if (isKnown) {
+      registeredDistinct += 1
+      registeredRows += n
+    } else {
+      unregisteredDistinct += 1
+      unregisteredRows += n
+    }
+    detail.push({ value, count: n, registered: isKnown })
+  }
+  return {
+    counts: {
+      distinctCount: rows.length,
+      totalRows,
+      knownRegistrySize: known.size,
+      registeredDistinctCount: registeredDistinct,
+      unregisteredDistinctCount: unregisteredDistinct,
+      registeredRowCount: registeredRows,
+      unregisteredRowCount: unregisteredRows,
+    },
+    detail,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plan execution
+// ---------------------------------------------------------------------------
+
+async function executeKindInventoryPlan(exec, plan) {
+  if (plan.status === 'not_run') return { status: 'not_run' }
+  if (plan.status !== 'ok') return { status: 'unavailable', reason: plan.reason }
+
+  const allRes = await runQuery(exec, plan.allStatuses.tag, plan.allStatuses.params)
+  const all = bucketByRegistry(allRes.rows, KNOWN_CERTIFIED_CONNECTOR_KINDS, { valueKey: 'kind' })
+
+  let active
+  if (plan.activeOnly.status !== 'ok') {
+    active = { status: 'unavailable', reason: plan.activeOnly.reason }
+  } else {
+    const activeRes = await runQuery(exec, plan.activeOnly.tag, plan.activeOnly.params)
+    const bucketed = bucketByRegistry(activeRes.rows, KNOWN_CERTIFIED_CONNECTOR_KINDS, { valueKey: 'kind' })
+    active = { status: 'ok', counts: bucketed.counts, detail: bucketed.detail }
+  }
+
+  return {
+    status: 'ok',
+    allStatuses: { status: 'ok', counts: all.counts, detail: all.detail },
+    activeOnly: active,
+  }
+}
+
+// Splits one (object,status,n) row set into the three closed status buckets. Any status value NOT
+// in READ_SOURCE_CONFIG_STATUSES is fail-closed into its own 'unexpected' group rather than
+// silently dropped or merged into an existing bucket — the CHECK constraint should make this
+// group always empty, but a report must never assume its own gate held.
+function splitRowsByStatus(rows) {
+  const byStatus = { draft: [], approved: [], retired: [], unexpected: [] }
+  for (const row of rows) {
+    const bucket = READ_SOURCE_CONFIG_STATUSES.includes(row.status) ? row.status : 'unexpected'
+    byStatus[bucket].push(row)
+  }
+  return byStatus
+}
+
+async function executeObjectKeyInventoryPlan(exec, plan) {
+  if (plan.status === 'not_run') return { status: 'not_run' }
+  if (plan.status !== 'ok') return { status: 'unavailable', reason: plan.reason }
+
+  const res = await runQuery(exec, plan.byStatus.tag, plan.byStatus.params)
+  const split = splitRowsByStatus(res.rows)
+
+  const byStatus = {}
+  for (const key of ['draft', 'approved', 'retired', 'unexpected']) {
+    const bucketed = bucketByRegistry(split[key], KNOWN_CANONICAL_OBJECT_KEYS, { valueKey: 'object' })
+    byStatus[key] = { status: 'ok', counts: bucketed.counts, detail: bucketed.detail }
+  }
+
+  let divergence
+  if (plan.divergence.status !== 'ok') {
+    divergence = { status: 'unavailable', reason: plan.divergence.reason }
+  } else {
+    const { rows } = await runQuery(exec, plan.divergence.tag, plan.divergence.params)
+    divergence = { status: 'ok', count: rows.length ? Number(rows[0].n) || 0 : 0 }
+  }
+
+  return { status: 'ok', byStatus, divergence }
+}
+
+async function executePlan(exec, plan) {
+  const [kindInventory, objectKeyInventory] = await Promise.all([
+    executeKindInventoryPlan(exec, plan.kindInventory),
+    executeObjectKeyInventoryPlan(exec, plan.objectKeyInventory),
+  ])
+  return { kindInventory, objectKeyInventory }
+}
+
+// ---------------------------------------------------------------------------
+// PUBLIC report assembly — receives ONLY `.counts` objects (integers + fixed
+// keys), never `.detail` (which carries the raw kind/objectKey strings). This
+// is the structural boundary the values-free test below is written against.
+// ---------------------------------------------------------------------------
+
+function buildPublicKindSummary(kindInventory) {
+  if (kindInventory.status === 'not_run') {
+    return { status: 'not_run' }
+  }
+  if (kindInventory.status !== 'ok') {
+    return { status: 'unavailable', reason: kindInventory.reason }
+  }
+  const out = { status: 'ok' }
+  out.allStatuses = kindInventory.allStatuses.status === 'ok'
+    ? { status: 'ok', ...kindInventory.allStatuses.counts }
+    : { status: 'unavailable', reason: kindInventory.allStatuses.reason }
+  out.activeOnly = kindInventory.activeOnly.status === 'ok'
+    ? { status: 'ok', ...kindInventory.activeOnly.counts }
+    : { status: 'unavailable', reason: kindInventory.activeOnly.reason }
+  return out
+}
+
+function buildPublicObjectKeySummary(objectKeyInventory) {
+  if (objectKeyInventory.status === 'not_run') {
+    return { status: 'not_run' }
+  }
+  if (objectKeyInventory.status !== 'ok') {
+    return { status: 'unavailable', reason: objectKeyInventory.reason }
+  }
+  const out = { status: 'ok', byStatus: {} }
+  for (const key of ['draft', 'approved', 'retired', 'unexpected']) {
+    out.byStatus[key] = { status: 'ok', ...objectKeyInventory.byStatus[key].counts }
+  }
+  out.objectVsConfigObjectDivergence = objectKeyInventory.divergence
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Verdicts — kept SEPARATE per probe (β and γ have strictly separated
+// purposes; a blended verdict would let one probe's signal stand in for the
+// other's). Each has three reachable outcomes; any UNAVAILABLE coverage
+// forces INCONCLUSIVE — never a silent "0" read as "nothing to map".
+// ---------------------------------------------------------------------------
+
+function computeKindVerdict(publicKindSummary) {
+  if (publicKindSummary.status !== 'ok' || publicKindSummary.allStatuses.status !== 'ok') {
+    return {
+      verdict: 'INCONCLUSIVE',
+      reasons: [
+        'coverage is partial — the all-statuses kind count is UNAVAILABLE',
+        publicKindSummary.status !== 'ok' ? publicKindSummary.reason : publicKindSummary.allStatuses.reason,
+      ],
+    }
+  }
+  const { unregisteredDistinctCount, distinctKindCount } = {
+    unregisteredDistinctCount: publicKindSummary.allStatuses.unregisteredDistinctCount,
+    distinctKindCount: publicKindSummary.allStatuses.distinctCount,
+  }
+  if (unregisteredDistinctCount === 0) {
+    return {
+      verdict: 'CONNECTOR_KIND_MAPPING_NOT_REQUIRED_WITHIN_COVERAGE',
+      reasons: [
+        `${distinctKindCount} distinct kind string(s) observed across integration_external_systems, all already in the (currently ${KNOWN_CERTIFIED_CONNECTOR_KINDS.length}-entry) known registry`,
+        'a zero known-registry size makes this trivially true today — see residualNotes',
+      ],
+    }
+  }
+  return {
+    verdict: 'CONNECTOR_KIND_MAPPING_REQUIRED',
+    reasons: [
+      `${unregisteredDistinctCount} of ${distinctKindCount} distinct kind string(s) are not in the known registry (size ${KNOWN_CERTIFIED_CONNECTOR_KINDS.length}) — an explicit alias map / migration decision (β) is needed before these can bind under GIP`,
+      'raw kind strings are in the private artefact, if one was written — see privateArtifact',
+    ],
+  }
+}
+
+function computeObjectKeyVerdict(publicObjectKeySummary) {
+  if (publicObjectKeySummary.status !== 'ok' || publicObjectKeySummary.byStatus.approved.status !== 'ok') {
+    return {
+      verdict: 'INCONCLUSIVE',
+      reasons: [
+        'coverage is partial — the approved-status objectKey count is UNAVAILABLE',
+        publicObjectKeySummary.status !== 'ok' ? publicObjectKeySummary.reason : publicObjectKeySummary.byStatus.approved.reason,
+      ],
+    }
+  }
+  const divergence = publicObjectKeySummary.objectVsConfigObjectDivergence
+  if (!divergence || divergence.status !== 'ok') {
+    return {
+      verdict: 'INCONCLUSIVE',
+      reasons: [
+        'coverage is partial — the object vs config->>\'object\' divergence check is UNAVAILABLE',
+        divergence ? divergence.reason : 'divergence field missing from summary',
+      ],
+    }
+  }
+  // A non-zero divergence means the `object` column — the field the backfill list above was
+  // built from — disagrees with the config's own stored objectKey for at least one row. A
+  // NOT_REQUIRED verdict built only from `object` would then be silently wrong for the disagreeing
+  // rows: the backfill list a human builds from this report would miss whatever objectKey the
+  // config JSON actually references. Fail closed rather than let that pass as "nothing to do".
+  if (divergence.count > 0) {
+    return {
+      verdict: 'INCONCLUSIVE',
+      reasons: [
+        `${divergence.count} row(s) have integration_read_source_configs.object disagreeing with config->>'object' — a backfill/mapping decision built from the object column alone would be unreliable for those rows until the divergence is resolved`,
+        'this is reported regardless of registeredness — see coverage.canonicalObjectKeyInventory.objectVsConfigObjectDivergence',
+      ],
+    }
+  }
+  const approved = publicObjectKeySummary.byStatus.approved
+  if (approved.unregisteredDistinctCount === 0) {
+    return {
+      verdict: 'CANONICAL_OBJECT_BACKFILL_NOT_REQUIRED_WITHIN_COVERAGE',
+      reasons: [
+        `${approved.distinctCount} distinct objectKey(s) referenced by approved read-source configs, all already in the (currently ${KNOWN_CANONICAL_OBJECT_KEYS.length}-entry) known registry`,
+        'a zero known-registry size makes this trivially true today — see residualNotes',
+      ],
+    }
+  }
+  return {
+    verdict: 'CANONICAL_OBJECT_BACKFILL_REQUIRED',
+    reasons: [
+      `${approved.unregisteredDistinctCount} of ${approved.distinctCount} distinct objectKey(s) referenced by approved configs are not in the known registry (size ${KNOWN_CANONICAL_OBJECT_KEYS.length}) — inventory + backfill of these is required BEFORE activation per decision (γ)`,
+      'raw objectKey strings are in the private artefact, if one was written — see privateArtifact',
+    ],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Residual notes — always present; a zero elsewhere must never read as proof
+// of zero live risk.
+// ---------------------------------------------------------------------------
+
+const RESIDUAL_NOTES = Object.freeze([
+  {
+    id: 'known_registries_empty_by_design',
+    description:
+      'Both KNOWN_CERTIFIED_CONNECTOR_KINDS and KNOWN_CANONICAL_OBJECT_KEYS are empty. Neither decision (β) nor decision (γ) has produced a first-party registry yet, so today every distinct value observed is reported as unregistered — that is the correct, honest state, not a defect. This inventory exists to produce the raw list a human uses to populate those registries; it never populates them itself.',
+  },
+  {
+    id: 'draft_and_retired_object_keys_excluded_from_the_headline_verdict',
+    description:
+      "computeObjectKeyVerdict() is scoped to status='approved' only, matching the task's literal scope ('approved read-source configs'). draft/retired counts are still reported under byStatus for completeness, but a draft config can be approved after this inventory runs — decision (γ)'s own 'before activation' framing means the approved-only headline can understate the eventual backfill list; re-run before activation, not once.",
+  },
+  {
+    id: 'no_customer_deployment_connection',
+    description:
+      'This script has only ever been run against a hermetic fake executor (tests) and, if noted in the PR, a local/CI fixture database — never a customer deployment. Connecting to one is a separate ops-gated read-only authorization this task does not carry.',
+  },
+])
+
+// ---------------------------------------------------------------------------
+// Private artefact — the ONLY place raw kind/objectKey strings are ever
+// written. Fails CLOSED: if there is at least one unregistered/unmapped item
+// and the artefact cannot be written, buildReport()/main() treat that as a
+// hard error rather than completing with an aggregate-only success that
+// silently drops the one thing a human needs to act on it.
+// ---------------------------------------------------------------------------
+
+function shouldWritePrivateArtifact(coverage) {
+  const kindUnregistered =
+    coverage.kindInventory.status === 'ok' &&
+    coverage.kindInventory.allStatuses.status === 'ok' &&
+    coverage.kindInventory.allStatuses.counts.unregisteredDistinctCount > 0
+  const objectUnregistered =
+    coverage.objectKeyInventory.status === 'ok' &&
+    ['draft', 'approved', 'retired', 'unexpected'].some(
+      (k) => coverage.objectKeyInventory.byStatus[k].counts.unregisteredDistinctCount > 0,
+    )
+  return kindUnregistered || objectUnregistered
+}
+
+function buildPrivateArtifactContent(coverage, { generatedAt }) {
+  return {
+    generatedAt,
+    warning:
+      'PRIVATE ARTEFACT — contains raw connector kind / objectKey strings observed in this deployment. Never commit, never paste into a PR body or issue, never log. Local operator use only, for authoring the decision (β) alias map and the decision (γ) backfill list.',
+    connectorKinds: {
+      allStatuses: coverage.kindInventory.status === 'ok' ? coverage.kindInventory.allStatuses.detail ?? [] : [],
+      activeOnly:
+        coverage.kindInventory.status === 'ok' && coverage.kindInventory.activeOnly.status === 'ok'
+          ? coverage.kindInventory.activeOnly.detail
+          : [],
+    },
+    objectKeys:
+      coverage.objectKeyInventory.status === 'ok'
+        ? {
+            draft: coverage.objectKeyInventory.byStatus.draft.detail,
+            approved: coverage.objectKeyInventory.byStatus.approved.detail,
+            retired: coverage.objectKeyInventory.byStatus.retired.detail,
+            unexpected: coverage.objectKeyInventory.byStatus.unexpected.detail,
+          }
+        : {},
+  }
+}
+
+function writePrivateArtifact(filePath, content) {
+  mkdirSync(path.dirname(filePath), { recursive: true })
+  writeFileSync(filePath, JSON.stringify(content, null, 2) + '\n', { mode: 0o600 })
+}
+
+function defaultPrivateOutputPath(repoRoot, generatedAt) {
+  const stamp = generatedAt.replace(/[:.]/g, '-')
+  return path.join(repoRoot, DEFAULT_PRIVATE_OUTPUT_DIR, `gip-authority-inventory-${stamp}.json`)
+}
+
+// ---------------------------------------------------------------------------
+// Report assembly
+// ---------------------------------------------------------------------------
+
+async function buildReport({ exec, repoRoot = REPO_ROOT, probe = 'both', privateOutPath, noPrivateOut = false } = {}) {
+  const generatedAt = new Date().toISOString()
+  // `probe` scopes the SCHEMA PROBE itself, not just the count queries: under --probe beta,
+  // integration_read_source_configs is never named in an information_schema.tables/.columns call
+  // either — see tableSpecsForProbe().
+  const schema = await probeSchema(exec, tableSpecsForProbe(probe))
+  // `probe` is threaded into buildPlan(), not applied after the fact: an un-requested probe's plan
+  // is { status: 'not_run' } BEFORE executePlan runs, so executeKindInventoryPlan /
+  // executeObjectKeyInventoryPlan short-circuit and never issue that probe's query at all — under
+  // `--probe beta`, integration_read_source_configs is never touched, and no γ objectKey value can
+  // reach coverage, the public summary, or the private artefact (see shouldWritePrivateArtifact /
+  // buildPrivateArtifactContent, both driven off this same `coverage`).
+  const plan = buildPlan(schema, { probe })
+  const coverage = await executePlan(exec, plan)
+
+  const publicKindSummary = buildPublicKindSummary(coverage.kindInventory)
+  const publicObjectKeySummary = buildPublicObjectKeySummary(coverage.objectKeyInventory)
+
+  const kindVerdict = coverage.kindInventory.status === 'not_run' ? null : computeKindVerdict(publicKindSummary)
+  const objectKeyVerdict = coverage.objectKeyInventory.status === 'not_run' ? null : computeObjectKeyVerdict(publicObjectKeySummary)
+
+  let privateArtifact = { status: 'not_attempted' }
+  if (!noPrivateOut) {
+    const owed = shouldWritePrivateArtifact(coverage)
+    const targetPath = privateOutPath || defaultPrivateOutputPath(repoRoot, generatedAt)
+    try {
+      const content = buildPrivateArtifactContent(coverage, { generatedAt })
+      writePrivateArtifact(targetPath, content)
+      privateArtifact = { status: 'written', path: path.relative(repoRoot, targetPath) }
+    } catch (err) {
+      if (owed) {
+        // Fail closed: raw detail existed and needed a home; the write failed. The error itself
+        // must stay values-free — never interpolate the raw content, only the path attempted.
+        throw new Error(
+          `gip-authority-substrate-inventory: unregistered kind/objectKey values exist but the private artefact could not be written (target: ${path.relative(repoRoot, targetPath)}): ${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+      // Nothing was owed (every observed value already matches the known registry, or there was
+      // nothing to observe) — a write failure here is a filesystem nuisance, not a lost decision
+      // input. Report it, do not fail the run.
+      privateArtifact = { status: 'write_failed_but_nothing_owed', path: path.relative(repoRoot, targetPath), reason: err instanceof Error ? err.message : String(err) }
+    }
+  } else {
+    privateArtifact = { status: 'skipped_by_flag' }
+  }
+
+  return {
+    generatedAt,
+    mode: 'report',
+    probe,
+    coverage: {
+      connectorKindInventory: {
+        covers:
+          "distinct integration_external_systems.kind strings and their row counts — the raw material for decision (β)'s explicit alias map and migration list. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+        blindSpot:
+          'DB rows only, in the ONE connected database, at the moment queried. Says nothing about kinds referenced only in code/fixtures, or about a different deployment/database this run was not pointed at.',
+        ...publicKindSummary,
+      },
+      canonicalObjectKeyInventory: {
+        covers:
+          "distinct integration_read_source_configs.object values (the ledger's `objectKey` tuple term) referenced by configs, split by status — the raw material for decision (γ)'s missing-reference and backfill lists. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+        blindSpot:
+          "DB rows only, in the ONE connected database. A canonical object referenced by a still-in-development (never-saved) config, or by a config in a DIFFERENT database this run was not pointed at, is invisible here.",
+        ...publicObjectKeySummary,
+      },
+    },
+    verdicts: {
+      connectorKind: kindVerdict,
+      canonicalObjectKey: objectKeyVerdict,
+    },
+    residualNotes: RESIDUAL_NOTES,
+    privateArtifact,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dry-run / plan mode
+// ---------------------------------------------------------------------------
+
+async function buildDryRunReport({ exec, repoRoot = REPO_ROOT } = {}) {
+  if (!exec) {
+    return {
+      generatedAt: new Date().toISOString(),
+      mode: 'dry-run-static',
+      note: 'No query executor / DATABASE_URL supplied — schema was not probed. This lists every allowlisted query; see buildPlan() in the script source for exact resolution rules.',
+      allowlist: Object.fromEntries(Object.entries(QUERY_ALLOWLIST).map(([tag, e]) => [tag, { describe: e.describe, sql: e.sql }])),
+      knownRegistrySizes: {
+        connectorKind: KNOWN_CERTIFIED_CONNECTOR_KINDS.length,
+        canonicalObjectKey: KNOWN_CANONICAL_OBJECT_KEYS.length,
+      },
+      residualNotes: RESIDUAL_NOTES,
+    }
+  }
+  const schema = await probeSchema(exec)
+  const plan = buildPlan(schema)
+  return {
+    generatedAt: new Date().toISOString(),
+    mode: 'dry-run',
+    note: 'Schema WAS probed (read-only information_schema queries). No aggregate/count query below was executed — this is exactly what report mode would run next.',
+    schema,
+    plan,
+    knownRegistrySizes: {
+      connectorKind: KNOWN_CERTIFIED_CONNECTOR_KINDS.length,
+      canonicalObjectKey: KNOWN_CANONICAL_OBJECT_KEYS.length,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+function renderHumanSummary(report) {
+  const lines = []
+  lines.push(`gip-authority-substrate-inventory — mode=${report.mode} probe=${report.probe ?? '(n/a)'} generatedAt=${report.generatedAt}`)
+  if (report.mode !== 'report') {
+    lines.push(report.note)
+    return lines.join('\n') + '\n'
+  }
+  const ck = report.coverage.connectorKindInventory
+  const ok = report.coverage.canonicalObjectKeyInventory
+  lines.push('')
+  lines.push('(β) connector-kind inventory:')
+  if (ck.status === 'ok') {
+    lines.push(`  all-statuses:  ${ck.allStatuses.status}${ck.allStatuses.status === 'ok' ? ` distinct=${ck.allStatuses.distinctCount} registered=${ck.allStatuses.registeredDistinctCount} unregistered=${ck.allStatuses.unregisteredDistinctCount}` : ` (${ck.allStatuses.reason})`}`)
+    lines.push(`  active-only:   ${ck.activeOnly.status}${ck.activeOnly.status === 'ok' ? ` distinct=${ck.activeOnly.distinctCount} registered=${ck.activeOnly.registeredDistinctCount} unregistered=${ck.activeOnly.unregisteredDistinctCount}` : ` (${ck.activeOnly.reason})`}`)
+  } else if (ck.status !== 'not_run') {
+    lines.push(`  UNAVAILABLE (${ck.reason})`)
+  } else {
+    lines.push('  not run (--probe gamma)')
+  }
+  if (report.verdicts.connectorKind) {
+    lines.push(`  verdict: ${report.verdicts.connectorKind.verdict}`)
+  }
+  lines.push('')
+  lines.push('(γ) canonical-objectKey inventory (integration_read_source_configs.object):')
+  if (ok.status === 'ok') {
+    for (const key of ['draft', 'approved', 'retired', 'unexpected']) {
+      const s = ok.byStatus[key]
+      lines.push(`  ${key.padEnd(10)}: distinct=${s.distinctCount} registered=${s.registeredDistinctCount} unregistered=${s.unregisteredDistinctCount}`)
+    }
+    lines.push(`  object vs config->>'object' divergence: ${ok.objectVsConfigObjectDivergence.status}${ok.objectVsConfigObjectDivergence.status === 'ok' ? ` count=${ok.objectVsConfigObjectDivergence.count}` : ` (${ok.objectVsConfigObjectDivergence.reason})`}`)
+  } else if (ok.status !== 'not_run') {
+    lines.push(`  UNAVAILABLE (${ok.reason})`)
+  } else {
+    lines.push('  not run (--probe beta)')
+  }
+  if (report.verdicts.canonicalObjectKey) {
+    lines.push(`  verdict: ${report.verdicts.canonicalObjectKey.verdict}`)
+  }
+  lines.push('')
+  lines.push(`private artefact: ${report.privateArtifact.status}${report.privateArtifact.path ? ` (${report.privateArtifact.path})` : ''}`)
+  lines.push('')
+  lines.push('residual notes:')
+  for (const n of report.residualNotes) lines.push(`  - [${n.id}] ${n.description}`)
+  return lines.join('\n') + '\n'
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const opts = { dryRun: false, json: false, help: false, probe: 'both', privateOutPath: undefined, noPrivateOut: false }
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i]
+    switch (a) {
+      case '--dry-run':
+      case '--plan':
+        opts.dryRun = true
+        break
+      case '--probe': {
+        const next = argv[++i]
+        if (!['beta', 'gamma', 'both'].includes(next)) {
+          throw new Error(`--probe must be one of beta|gamma|both, got: ${next}`)
+        }
+        opts.probe = next
+        break
+      }
+      case '--private-out':
+        opts.privateOutPath = argv[++i]
+        if (!opts.privateOutPath) throw new Error('--private-out requires a path argument')
+        break
+      case '--no-private-out':
+        opts.noPrivateOut = true
+        break
+      case '--json':
+        opts.json = true
+        break
+      case '--help':
+      case '-h':
+        opts.help = true
+        break
+      default:
+        throw new Error(`unknown argument: ${a}`)
+    }
+  }
+  if (opts.privateOutPath && opts.noPrivateOut) {
+    throw new Error('--private-out and --no-private-out are mutually exclusive')
+  }
+  return opts
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'gip-authority-substrate-inventory.mjs — two values-free, schema-probing inventory probes:',
+      '  (β) integration_external_systems.kind distinct-value inventory',
+      "  (γ) integration_read_source_configs.object (the ledger's objectKey) distinct-value inventory",
+      '',
+      'Usage:',
+      '  DATABASE_URL=postgres://… node scripts/ops/gip-authority-substrate-inventory.mjs \\',
+      '    [--probe beta|gamma|both] [--private-out <path> | --no-private-out] [--json]',
+      '  node scripts/ops/gip-authority-substrate-inventory.mjs --dry-run',
+      '',
+      'Options:',
+      '  --probe beta|gamma|both   Which probe(s) to run. Default both.',
+      '  --private-out <path>      Where to write the RAW-VALUE private artefact. Default:',
+      `                            ${DEFAULT_PRIVATE_OUTPUT_DIR}/gip-authority-inventory-<timestamp>.json (gitignored).`,
+      '  --no-private-out          Skip writing the private artefact entirely (aggregate-only run).',
+      '  --dry-run, --plan         Print the query plan without executing counts.',
+      '  --json                    Print only the machine-readable JSON report.',
+      '  --help                    Show this help.',
+      '',
+      'This script never connects to a customer deployment on its own — DATABASE_URL is supplied by',
+      'the operator, and running it against one is a separate ops read-only authorization.',
+      '',
+    ].join('\n'),
+  )
+}
+
+async function createPgExecutor(databaseUrl) {
+  // Lazy import: `pg` must never be required at module load, or a hermetic `node --test` CI job
+  // with no `node_modules` fails at import time before a single test runs.
+  const { default: pg } = await import('pg')
+  const pool = new pg.Pool({ connectionString: databaseUrl, max: 2 })
+  return {
+    exec: (sql, params) => pool.query(sql, params),
+    close: () => pool.end(),
+  }
+}
+
+async function main(argv = process.argv.slice(2), env = process.env) {
+  let opts
+  try {
+    opts = parseArgs(argv)
+  } catch (err) {
+    process.stderr.write(`[gip-authority-substrate-inventory] ERROR: ${err.message}\n`)
+    return 1
+  }
+  if (opts.help) {
+    printHelp()
+    return 0
+  }
+
+  const databaseUrl = (env.DATABASE_URL || '').trim()
+
+  if (opts.dryRun) {
+    let executor = null
+    try {
+      if (databaseUrl) executor = await createPgExecutor(databaseUrl)
+      const report = await buildDryRunReport({ exec: executor ? executor.exec : null })
+      if (opts.json) {
+        process.stdout.write(JSON.stringify(report, null, 2) + '\n')
+      } else {
+        process.stdout.write(renderHumanSummary(report))
+        process.stdout.write('\n' + JSON.stringify(report, null, 2) + '\n')
+      }
+      return 0
+    } catch (err) {
+      process.stderr.write(`[gip-authority-substrate-inventory] ERROR: ${err instanceof Error ? err.message : String(err)}\n`)
+      return 1
+    } finally {
+      if (executor) await executor.close()
+    }
+  }
+
+  if (!databaseUrl) {
+    process.stderr.write('[gip-authority-substrate-inventory] ERROR: DATABASE_URL is required outside --dry-run\n')
+    return 2
+  }
+
+  let executor
+  try {
+    executor = await createPgExecutor(databaseUrl)
+    const report = await buildReport({
+      exec: executor.exec,
+      probe: opts.probe,
+      privateOutPath: opts.privateOutPath ? path.resolve(process.cwd(), opts.privateOutPath) : undefined,
+      noPrivateOut: opts.noPrivateOut,
+    })
+    if (opts.json) {
+      process.stdout.write(JSON.stringify(report, null, 2) + '\n')
+    } else {
+      process.stdout.write(renderHumanSummary(report))
+      process.stdout.write('\n' + JSON.stringify(report, null, 2) + '\n')
+    }
+    return 0
+  } catch (err) {
+    process.stderr.write(`[gip-authority-substrate-inventory] ERROR: ${err instanceof Error ? err.message : String(err)}\n`)
+    return 1
+  } finally {
+    if (executor) await executor.close()
+  }
+}
+
+const entryPath = process.argv[1] ? path.resolve(process.argv[1]) : null
+const isEntry = entryPath && entryPath === fileURLToPath(import.meta.url)
+if (isEntry) {
+  main().then((code) => {
+    process.exitCode = code
+  })
+}
+
+export {
+  QUERY_ALLOWLIST,
+  KNOWN_CERTIFIED_CONNECTOR_KINDS,
+  KNOWN_CANONICAL_OBJECT_KEYS,
+  EXTERNAL_SYSTEM_STATUSES,
+  READ_SOURCE_CONFIG_STATUSES,
+  assertReadOnlyAllowlist,
+  runQuery,
+  tableExists,
+  probeColumns,
+  probeSchema,
+  tableSpecsForProbe,
+  buildPlan,
+  bucketByRegistry,
+  splitRowsByStatus,
+  executePlan,
+  buildPublicKindSummary,
+  buildPublicObjectKeySummary,
+  computeKindVerdict,
+  computeObjectKeyVerdict,
+  RESIDUAL_NOTES,
+  shouldWritePrivateArtifact,
+  buildPrivateArtifactContent,
+  defaultPrivateOutputPath,
+  buildReport,
+  buildDryRunReport,
+  renderHumanSummary,
+  parseArgs,
+  main,
+  REPO_ROOT,
+  DEFAULT_PRIVATE_OUTPUT_DIR,
+}

--- a/scripts/ops/gip-authority-substrate-inventory.test.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.test.mjs
@@ -4,6 +4,7 @@ import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, symlinkSync, statS
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
 
 import {
   QUERY_ALLOWLIST,
@@ -31,6 +32,10 @@ import {
   buildDryRunReport,
   renderHumanSummary,
   parseArgs,
+  CLI_ERROR_REASON,
+  CliArgError,
+  closedCliErrorReason,
+  main,
   REPO_ROOT,
   DEFAULT_PRIVATE_OUTPUT_DIR,
 } from './gip-authority-substrate-inventory.mjs'
@@ -1920,24 +1925,246 @@ describe('parseArgs', () => {
     assert.equal(parseArgs(['--probe', 'beta']).probe, 'beta')
     assert.equal(parseArgs(['--probe', 'gamma']).probe, 'gamma')
     assert.equal(parseArgs(['--probe', 'both']).probe, 'both')
-    assert.throws(() => parseArgs(['--probe', 'delta']), /--probe must be one of/)
+    assert.throws(() => parseArgs(['--probe', 'delta']), new RegExp(CLI_ERROR_REASON.INVALID_PROBE_VALUE))
   })
 
   test('--private-out and --no-private-out are mutually exclusive', () => {
-    assert.throws(() => parseArgs(['--private-out', '/tmp/x.json', '--no-private-out']), /mutually exclusive/)
+    assert.throws(
+      () => parseArgs(['--private-out', '/tmp/x.json', '--no-private-out']),
+      new RegExp(CLI_ERROR_REASON.MUTUALLY_EXCLUSIVE_PRIVATE_OUT),
+    )
   })
 
   test('--private-out requires a path argument', () => {
-    assert.throws(() => parseArgs(['--private-out']), /requires a path argument/)
+    assert.throws(() => parseArgs(['--private-out']), new RegExp(CLI_ERROR_REASON.MISSING_PRIVATE_OUT_PATH))
   })
 
   test('unknown flag throws', () => {
-    assert.throws(() => parseArgs(['--nope']), /unknown argument/)
+    assert.throws(() => parseArgs(['--nope']), new RegExp(CLI_ERROR_REASON.UNKNOWN_ARGUMENT))
+  })
+
+  // #4603 P2(a) — parseArgs must never echo the operator's literal argv value into the thrown
+  // error's message, only the fixed CLOSED reason token. A sentinel proves this behaviourally
+  // rather than by re-reading the source: if the old `unknown argument: ${a}` shape ever came
+  // back, this would red on the sentinel appearing in err.message.
+  test('unknown flag error message never echoes the flag itself, even a sentinel-bearing one', () => {
+    const sentinel = 'SENTINEL_NEVER_ECHOED_ARGV_7f2c9a'
+    assert.throws(
+      () => parseArgs([`--${sentinel}`]),
+      (err) => {
+        assert.equal(err.message.includes(sentinel), false, 'sentinel leaked into parseArgs error message')
+        assert.equal(err.message, CLI_ERROR_REASON.UNKNOWN_ARGUMENT)
+        return true
+      },
+    )
   })
 
   test('--help sets help flag', () => {
     assert.equal(parseArgs(['--help']).help, true)
   })
+})
+
+// ---------------------------------------------------------------------------
+// closedCliErrorReason — pinned at the UNIT level, not just via its call
+// sites in main(). #4603 P2(a) review: an `err instanceof CliArgError ?
+// err.message : RUNTIME_FAILURE` shape (no membership check) would make every
+// test below pass while still re-opening the leak on a future regression
+// where some CliArgError throw site goes back to interpolating argv. These
+// tests exercise the function directly against inputs that a body-level
+// regression could produce but that none of the call-site tests below can
+// reach (the real parseArgs()/main() never construct these today).
+// ---------------------------------------------------------------------------
+
+describe('closedCliErrorReason — the mapping itself is pinned (#4603 P2(a))', () => {
+  test('a CliArgError built from a real CLI_ERROR_REASON token passes through unchanged', () => {
+    assert.equal(closedCliErrorReason(new CliArgError(CLI_ERROR_REASON.UNKNOWN_ARGUMENT)), CLI_ERROR_REASON.UNKNOWN_ARGUMENT)
+  })
+
+  test('a CliArgError built from a string OUTSIDE the frozen token set collapses to RUNTIME_FAILURE — this is the assertion an `instanceof`-only mapping (no membership check) cannot survive', () => {
+    const sentinel = 'SENTINEL_NOT_A_TOKEN_leaked-argv-value'
+    const err = new CliArgError(`unknown argument: --${sentinel}`)
+    const mapped = closedCliErrorReason(err)
+    assert.equal(mapped, CLI_ERROR_REASON.RUNTIME_FAILURE)
+    assert.equal(mapped.includes(sentinel), false)
+  })
+
+  test('a foreign (non-CliArgError) Error is never trusted by content match alone, even when its .message happens to equal a real token string', () => {
+    const foreign = new Error(CLI_ERROR_REASON.UNKNOWN_ARGUMENT)
+    assert.equal(closedCliErrorReason(foreign), CLI_ERROR_REASON.RUNTIME_FAILURE)
+  })
+
+  test('a real absolute-path-bearing foreign Error (MODULE_NOT_FOUND shape) collapses to RUNTIME_FAILURE and never echoes the path', () => {
+    const fakePath = '/Users/some-operator/secret-checkout-dir/scripts/ops/gip-authority-substrate-inventory.mjs'
+    const foreign = new Error(`Cannot find package 'pg' imported from ${fakePath}`)
+    const mapped = closedCliErrorReason(foreign)
+    assert.equal(mapped, CLI_ERROR_REASON.RUNTIME_FAILURE)
+    assert.equal(mapped.includes(fakePath), false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// stderr values-free discipline — REAL SUBPROCESS PROOF (#4603 P2(a))
+// ---------------------------------------------------------------------------
+// The owner's probe ran the actual CLI, not an in-process call to main(): an unrecognized flag's
+// literal argv text landed on real stderr, and a `pg` load failure's absolute path landed there
+// too. In-process interception of process.stderr.write would prove closedCliErrorReason() itself
+// works, but would NOT prove the entry-point wrapper at the bottom of the source (main().then(...))
+// actually routes through it, and structurally cannot observe anything that escapes main()'s own
+// promise — an unhandled rejection prints on the real stderr file descriptor, bypassing any
+// monkeypatch of process.stderr.write entirely (see safeClose() / the isEntry reject handler in the
+// source, both added in this same pass to close exactly that gap). These tests spawn the real
+// `node <script>` process and read its real stdout/stderr/exit code — no createExecutor injection
+// possible here, by design.
+// ---------------------------------------------------------------------------
+
+const SCRIPT_PATH = path.join(REPO_ROOT, 'scripts', 'ops', 'gip-authority-substrate-inventory.mjs')
+
+function countOccurrences(haystack, needle) {
+  if (!needle) return 0
+  let count = 0
+  let idx = 0
+  while ((idx = haystack.indexOf(needle, idx)) !== -1) {
+    count += 1
+    idx += needle.length
+  }
+  return count
+}
+
+function runCliSubprocess(args, env) {
+  const result = spawnSync(process.execPath, [SCRIPT_PATH, ...args], { env, encoding: 'utf8', timeout: 10_000 })
+  return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' }
+}
+
+describe('stderr values-free discipline — real subprocess (#4603 P2(a))', () => {
+  test('sentinel-bearing unknown flag: exit 1; stderr is non-empty (positive control — an implementation that prints nothing would also pass a bare zero-count check); sentinel appears in NEITHER stdout NOR stderr', () => {
+    const sentinel = 'SENTINEL_OPERATOR_SECRET_MARKER_c83fa1'
+    // Minimal explicit env: no ambient DATABASE_URL/etc. from the test runner's own environment can
+    // leak in and change which branch of main() this exercises.
+    const env = { PATH: process.env.PATH }
+    const res = runCliSubprocess([`--${sentinel}`], env)
+    assert.equal(res.status, 1)
+    assert.ok(res.stderr.length > 0, 'positive control failed: stderr was empty')
+    assert.equal(countOccurrences(res.stderr, sentinel), 0, `sentinel leaked into stderr: ${res.stderr}`)
+    assert.equal(countOccurrences(res.stdout, sentinel), 0, `sentinel leaked into stdout: ${res.stdout}`)
+    assert.equal(res.stderr.trim(), `[gip-authority-substrate-inventory] ERROR: ${CLI_ERROR_REASON.UNKNOWN_ARGUMENT}`)
+  })
+
+  test('forced `pg` driver-load failure: exit 1; stderr non-empty (positive control); the absolute path fragment PROVEN present in the raw import error is absent from both stdout and stderr', async () => {
+    // Positive control FIRST — prove the raw failure createPgExecutor() hits in this exact hermetic
+    // environment (no node_modules: the real CI workflow for this file — see
+    // .github/workflows/gip-authority-substrate-inventory.yml — checks out and runs `node --test`
+    // directly, no install step) really does carry an absolute path in its .message. If this
+    // control does not hold, the redaction assertions below would be vacuous — a probe that leaks
+    // nothing proves nothing.
+    let rawMessage = null
+    try {
+      await import('pg')
+    } catch (e) {
+      rawMessage = e.message
+    }
+    assert.ok(
+      rawMessage,
+      'control failed: `pg` imported successfully in this test environment — the driver-load-failure scenario below did not actually occur, so its redaction assertions would be vacuous',
+    )
+    assert.ok(rawMessage.includes(__dirname), `control failed: raw import error does not carry the expected absolute path fragment — got: ${rawMessage}`)
+
+    const env = { PATH: process.env.PATH, DATABASE_URL: 'postgres://sentinel-host-should-never-appear/db' }
+    const res = runCliSubprocess([], env)
+    assert.equal(res.status, 1)
+    assert.ok(res.stderr.length > 0, 'positive control failed: stderr was empty')
+    assert.equal(countOccurrences(res.stderr, __dirname), 0, `path fragment leaked into stderr: ${res.stderr}`)
+    assert.equal(countOccurrences(res.stdout, __dirname), 0, `path fragment leaked into stdout: ${res.stdout}`)
+    assert.equal(
+      countOccurrences(res.stderr, 'sentinel-host-should-never-appear'),
+      0,
+      `DATABASE_URL host leaked into stderr: ${res.stderr}`,
+    )
+    assert.equal(res.stderr.trim(), `[gip-authority-substrate-inventory] ERROR: ${CLI_ERROR_REASON.RUNTIME_FAILURE}`)
+  })
+
+  // --help is the one success-path (exit 0) public-output surface nothing else in this file
+  // exercises via a real process: printHelp() interpolates DEFAULT_PRIVATE_OUTPUT_DIR, a
+  // repo-relative constant, not an absolute path — but that is a claim about the source, and this
+  // repo's own doctrine is that claims about output need a real capture, not a re-read of the code.
+  test('--help: exit 0, and stdout never contains an absolute-path fragment', () => {
+    const env = { PATH: process.env.PATH }
+    const res = runCliSubprocess(['--help'], env)
+    assert.equal(res.status, 0)
+    assert.ok(res.stdout.length > 0)
+    assert.equal(countOccurrences(res.stdout, __dirname), 0, `path fragment leaked into --help stdout: ${res.stdout}`)
+    assert.equal(res.stderr, '')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// main() exit-code contract (#4603 P2(b)) — `consumableByWave2 === false ⇒
+// exit 1` (~L1038 in the source) gates Wave 2 consumption of this script's
+// output and, before this pass, was reachable by NONE of this file's tests
+// (none called main()). These call the REAL main() — the same function the
+// entry-point wrapper at the bottom of the source invokes — via the
+// injectable createExecutor seam added in this pass, so no real DATABASE_URL
+// or `pg` package is needed; the fake executor is the same createFakeExec
+// harness the buildReport()-level tests above already use.
+// ---------------------------------------------------------------------------
+
+async function withCapturedStdout(fn) {
+  const original = process.stdout.write.bind(process.stdout)
+  let buf = ''
+  process.stdout.write = (chunk) => {
+    buf += typeof chunk === 'string' ? chunk : chunk.toString()
+    return true
+  }
+  try {
+    const result = await fn()
+    return { result, stdout: buf }
+  } finally {
+    process.stdout.write = original
+  }
+}
+
+function fakeExecutorFactory(schema, counts) {
+  const exec = createFakeExec({ schema, counts })
+  return async () => ({ exec, close: async () => {} })
+}
+
+describe('main() exit-code contract (#4603 P2(b))', () => {
+  test('positive control: nothing owed ⇒ exit 0 (a success case must be provable too, not just the failure case)', async () => {
+    const schema = cloneSchema()
+    const createExecutor = fakeExecutorFactory(schema, ZERO_COUNTS)
+    const { result: code } = await withCapturedStdout(() =>
+      main(['--no-private-out'], { DATABASE_URL: 'postgres://fixture/db' }, { createExecutor }),
+    )
+    assert.equal(code, 0)
+  })
+
+  test('consumableByWave2 === false (something owed, --no-private-out disables the write) ⇒ exit 1 — the L1038 contract, previously untested by any of the 127 tests', async () => {
+    const schema = cloneSchema()
+    const counts = {
+      'count.external_system_kinds_all': [{ kind: 'unregistered-kind', n: 1 }],
+      'count.external_system_kinds_active': [{ kind: 'unregistered-kind', n: 1 }],
+      'count.read_source_config_objects_by_status': [],
+      'count.read_source_config_object_config_divergence': [{ n: 0 }],
+    }
+    const createExecutor = fakeExecutorFactory(schema, counts)
+    const { result: code } = await withCapturedStdout(() =>
+      main(['--no-private-out'], { DATABASE_URL: 'postgres://fixture/db' }, { createExecutor }),
+    )
+    assert.equal(code, 1)
+  })
+
+  test('DATABASE_URL missing outside --dry-run ⇒ exit 2 (documented in the header\'s Exit codes list, previously untested; needs no DB/executor)', async () => {
+    const { result: code } = await withCapturedStdout(() => main([], {}))
+    assert.equal(code, 2)
+  })
+
+  // Mutation-confirmed (#4603 P2(b)): flipping the source's `report.privateArtifact.consumableByWave2
+  // === false` to `=== true` at the L1038 exit-code check reds BOTH tests above that depend on it —
+  // the "consumableByWave2 === false ... ⇒ exit 1" test (now gets 0) and the "nothing owed ⇒ exit 0"
+  // positive control (now gets 1, since a true nothing-owed run's consumableByWave2 is also true and
+  // the inverted check fires on it) — while every other test in this file (all 127 pre-existing ones)
+  // stays green, because none of them called main(). Reverted after confirming red; not re-run here
+  // because this file has no automated mutation-testing harness, matching the existing
+  // "Mutation-confirmed (#4603 P2)" comment style used elsewhere in this file for the same reason.
 })
 
 // ---------------------------------------------------------------------------

--- a/scripts/ops/gip-authority-substrate-inventory.test.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.test.mjs
@@ -1,0 +1,1028 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  QUERY_ALLOWLIST,
+  KNOWN_CERTIFIED_CONNECTOR_KINDS,
+  KNOWN_CANONICAL_OBJECT_KEYS,
+  EXTERNAL_SYSTEM_STATUSES,
+  READ_SOURCE_CONFIG_STATUSES,
+  assertReadOnlyAllowlist,
+  probeSchema,
+  buildPlan,
+  bucketByRegistry,
+  splitRowsByStatus,
+  executePlan,
+  buildPublicKindSummary,
+  buildPublicObjectKeySummary,
+  computeKindVerdict,
+  computeObjectKeyVerdict,
+  RESIDUAL_NOTES,
+  shouldWritePrivateArtifact,
+  buildPrivateArtifactContent,
+  buildReport,
+  buildDryRunReport,
+  parseArgs,
+  REPO_ROOT,
+  DEFAULT_PRIVATE_OUTPUT_DIR,
+} from './gip-authority-substrate-inventory.mjs'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// ---------------------------------------------------------------------------
+// Fake DB harness — dispatch by EXACT SQL-string identity against
+// QUERY_ALLOWLIST, same discipline as #4594's pattern: a query the script did
+// not actually construct has no matching tag and throws, and a fixture that
+// was never consumed (because the plan correctly marked it UNAVAILABLE)
+// proves "never emits a query against an unverified shape" for real rather
+// than by assertion.
+// ---------------------------------------------------------------------------
+
+const SQL_TO_TAG = new Map(Object.entries(QUERY_ALLOWLIST).map(([tag, e]) => [e.sql, tag]))
+
+function createFakeExec({ schema, counts = {} }, calls = null) {
+  return async (sql, params) => {
+    const tag = SQL_TO_TAG.get(sql)
+    if (!tag) {
+      throw new Error(`fake exec: SQL string is not on QUERY_ALLOWLIST (unrecognized): ${sql}`)
+    }
+    if (calls) calls.push({ tag, sql, params })
+
+    if (tag === 'probe.table_exists') {
+      const [tableName] = params
+      const t = schema[tableName]
+      return { rows: t && t.exists ? [{ '?column?': 1 }] : [] }
+    }
+    if (tag === 'probe.columns') {
+      const [tableName] = params
+      const t = schema[tableName]
+      const cols = t && t.exists ? t.columns : []
+      return { rows: cols.map((c) => ({ column_name: c })) }
+    }
+
+    const handler = counts[tag]
+    if (!handler) {
+      throw new Error(`fake exec: no count fixture configured for tag "${tag}" — the plan should never have run this query`)
+    }
+    const rows = typeof handler === 'function' ? handler(params) : handler
+    return { rows }
+  }
+}
+
+const FULL_SCHEMA = Object.freeze({
+  integration_external_systems: { exists: true, columns: ['id', 'kind', 'status'] },
+  integration_read_source_configs: { exists: true, columns: ['id', 'object', 'status', 'config'] },
+})
+
+function cloneSchema(overrides = {}) {
+  const base = JSON.parse(JSON.stringify(FULL_SCHEMA))
+  for (const [table, patch] of Object.entries(overrides)) {
+    base[table] = { ...base[table], ...patch }
+  }
+  return base
+}
+
+const ZERO_COUNTS = Object.freeze({
+  'count.external_system_kinds_all': [],
+  'count.external_system_kinds_active': [],
+  'count.read_source_config_objects_by_status': [],
+  'count.read_source_config_object_config_divergence': [{ n: 0 }],
+})
+
+// ---------------------------------------------------------------------------
+// assertReadOnlyAllowlist — structural read-only guard
+// ---------------------------------------------------------------------------
+
+describe('assertReadOnlyAllowlist', () => {
+  test('accepts the real QUERY_ALLOWLIST (every entry is a SELECT)', () => {
+    assert.doesNotThrow(() => assertReadOnlyAllowlist(QUERY_ALLOWLIST))
+  })
+
+  test('rejects a fixture allowlist containing a non-SELECT statement', () => {
+    const bad = { 'evil.update': { sql: `UPDATE integration_external_systems SET kind = 'x'`, describe: 'x' } }
+    assert.throws(() => assertReadOnlyAllowlist(bad), /not a SELECT statement/)
+  })
+
+  test('rejects DELETE/INSERT/DROP the same way', () => {
+    for (const sql of [
+      'DELETE FROM integration_external_systems',
+      'INSERT INTO integration_external_systems VALUES (1)',
+      'DROP TABLE integration_external_systems',
+    ]) {
+      assert.throws(() => assertReadOnlyAllowlist({ x: { sql, describe: 'x' } }), /not a SELECT statement/)
+    }
+  })
+
+  test('rejects a SELECT with a non-trailing semicolon (stacked statement)', () => {
+    for (const sql of [
+      'SELECT 1; DROP TABLE integration_external_systems',
+      'SELECT 1;DROP TABLE integration_external_systems',
+      'SELECT 1; DELETE FROM integration_read_source_configs WHERE 1=1',
+    ]) {
+      assert.throws(() => assertReadOnlyAllowlist({ x: { sql, describe: 'x' } }), /non-trailing semicolon/)
+    }
+  })
+
+  test('accepts a SELECT with a single harmless trailing semicolon (or none at all)', () => {
+    assert.doesNotThrow(() => assertReadOnlyAllowlist({ x: { sql: 'SELECT 1;', describe: 'x' } }))
+    assert.doesNotThrow(() => assertReadOnlyAllowlist({ x: { sql: 'SELECT 1', describe: 'x' } }))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QUERY_ALLOWLIST SQL semantic invariants — pins the SQL TEXT itself, not
+// just the fake-exec plumbing (which would stay green under a corrupted
+// table/literal because SQL_TO_TAG is rebuilt from the same corrupted text).
+// ---------------------------------------------------------------------------
+
+function normalizeSql(sql) {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+function extractTables(sql) {
+  const re = /\b(?:FROM|JOIN)\s+([a-zA-Z_][a-zA-Z0-9_]*)/gi
+  const tables = new Set()
+  let m
+  while ((m = re.exec(sql))) tables.add(m[1].toLowerCase())
+  return [...tables].sort()
+}
+function extractQuotedLiterals(sql) {
+  const re = /'([^']*)'/g
+  const out = []
+  let m
+  while ((m = re.exec(sql))) out.push(m[1])
+  return out.sort()
+}
+function extractWhereClause(sql) {
+  const normalized = normalizeSql(sql)
+  const m = /\bWHERE\s+(.*?)(?:\s+GROUP BY\b|\s*$)/i.exec(normalized)
+  return m ? m[1].trim() : null
+}
+
+describe('QUERY_ALLOWLIST SQL semantic invariants', () => {
+  const EXPECTED = {
+    'count.external_system_kinds_all': {
+      tables: ['integration_external_systems'],
+      literals: [],
+      where: null,
+    },
+    'count.external_system_kinds_active': {
+      tables: ['integration_external_systems'],
+      literals: ['active'],
+      where: "status = 'active'",
+    },
+    'count.read_source_config_objects_by_status': {
+      tables: ['integration_read_source_configs'],
+      literals: [],
+      where: null,
+    },
+    'count.read_source_config_object_config_divergence': {
+      tables: ['integration_read_source_configs'],
+      literals: ['object'],
+      where: "object is distinct from (config ->> 'object')",
+    },
+  }
+
+  for (const [tag, expected] of Object.entries(EXPECTED)) {
+    describe(tag, () => {
+      test(`queries exactly {${expected.tables.join(', ')}} — no other table`, () => {
+        assert.deepEqual(extractTables(QUERY_ALLOWLIST[tag].sql), expected.tables)
+      })
+      test(`quoted-literal set is exactly ${JSON.stringify(expected.literals)}`, () => {
+        assert.deepEqual(extractQuotedLiterals(QUERY_ALLOWLIST[tag].sql), [...expected.literals].sort())
+      })
+      test(`WHERE predicate is exactly ${JSON.stringify(expected.where)}`, () => {
+        const where = extractWhereClause(QUERY_ALLOWLIST[tag].sql)
+        if (expected.where === null) assert.equal(where, null)
+        else assert.equal(where.toLowerCase(), expected.where)
+      })
+    })
+  }
+
+  test('the EXTERNAL_SYSTEM_STATUSES active literal used in the active-only query is a real member of the status vocabulary', () => {
+    assert.ok(EXTERNAL_SYSTEM_STATUSES.includes('active'))
+    assert.match(QUERY_ALLOWLIST['count.external_system_kinds_active'].sql, /status = 'active'/)
+  })
+
+  test('no allowlisted SQL statement anywhere contains a WHERE on kind (kind must never be filtered — the inventory covers every observed kind, known or not)', () => {
+    for (const [tag, entry] of Object.entries(QUERY_ALLOWLIST)) {
+      assert.doesNotMatch(entry.sql, /WHERE\s+kind\s*=/i, `tag "${tag}" must not filter on a specific kind value`)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Schema-drift guard — reads the REAL migration files, not a comment. §5's
+// landmine: a previous inventory was NO-GO for four assumed-schema errors: a
+// citation in a header comment is not load-bearing, this is.
+// ---------------------------------------------------------------------------
+
+describe('schema-drift guard (reads real migration SQL from disk)', () => {
+  const migration057 = readFileSync(
+    path.join(REPO_ROOT, 'packages/core-backend/migrations/057_create_integration_core_tables.sql'),
+    'utf8',
+  )
+  const migration062 = readFileSync(
+    path.join(REPO_ROOT, 'packages/core-backend/migrations/062_create_integration_read_source_configs.sql'),
+    'utf8',
+  )
+
+  test('integration_external_systems.kind is TEXT NOT NULL with no CHECK constraint (free-form — the whole reason β needs a probe, not a hardcoded enum)', () => {
+    assert.match(migration057, /kind\s+TEXT NOT NULL/)
+    // Confirms kind carries no CHECK(...) immediately after its declaration, unlike status.
+    const kindLine = migration057.split('\n').find((l) => /^\s*kind\s+TEXT NOT NULL/.test(l))
+    assert.ok(kindLine, 'expected a `kind TEXT NOT NULL` column declaration in migration 057')
+    assert.doesNotMatch(kindLine, /CHECK/)
+  })
+
+  test('integration_external_systems.status CHECK vocabulary matches EXTERNAL_SYSTEM_STATUSES exactly', () => {
+    const m = /status\s+TEXT NOT NULL DEFAULT '[^']*' CHECK \(status IN \(([^)]+)\)\)/.exec(migration057)
+    assert.ok(m, 'expected a status CHECK(...) clause in migration 057')
+    const vocab = m[1].split(',').map((s) => s.trim().replace(/^'|'$/g, '')).sort()
+    assert.deepEqual(vocab, [...EXTERNAL_SYSTEM_STATUSES].sort())
+  })
+
+  test('integration_read_source_configs.object is TEXT NOT NULL — this IS the column the ledger calls objectKey', () => {
+    assert.match(migration062, /object\s+TEXT NOT NULL/)
+  })
+
+  test('integration_read_source_configs.status CHECK vocabulary matches READ_SOURCE_CONFIG_STATUSES exactly', () => {
+    const m = /status\s+TEXT NOT NULL DEFAULT '[^']*' CHECK \(status IN \(([^)]+)\)\)/.exec(migration062)
+    assert.ok(m, 'expected a status CHECK(...) clause in migration 062')
+    const vocab = m[1].split(',').map((s) => s.trim().replace(/^'|'$/g, '')).sort()
+    assert.deepEqual(vocab, [...READ_SOURCE_CONFIG_STATUSES].sort())
+  })
+
+  test('integration_read_source_configs has both a unique index and the store keys the identical-content family on `object` (confirms `object`, not some other column, is the durable key this probe should read)', () => {
+    assert.match(migration062, /uniq_integration_read_source_configs_content[\s\S]*?object/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Frozen-registry mutation immunity — proves the FORBIDDEN clauses, not just
+// asserts them in a comment.
+// ---------------------------------------------------------------------------
+
+describe('KNOWN_CERTIFIED_CONNECTOR_KINDS / KNOWN_CANONICAL_OBJECT_KEYS — never auto-populated', () => {
+  test('both registries are empty today (no first-party registry exists yet on main)', () => {
+    assert.deepEqual(KNOWN_CERTIFIED_CONNECTOR_KINDS, [])
+    assert.deepEqual(KNOWN_CANONICAL_OBJECT_KEYS, [])
+  })
+
+  test('both are frozen — a push/mutation attempt throws (strict-mode ESM), never silently succeeds', () => {
+    assert.throws(() => KNOWN_CERTIFIED_CONNECTOR_KINDS.push('sql:not-really'), TypeError)
+    assert.throws(() => KNOWN_CANONICAL_OBJECT_KEYS.push('material'), TypeError)
+    assert.throws(() => { KNOWN_CERTIFIED_CONNECTOR_KINDS[0] = 'x' }, TypeError)
+  })
+
+  test('running a full report against fixture rows carrying novel kind/object values never changes either registry (referential + content immunity)', async () => {
+    const schema = cloneSchema()
+    const before = [KNOWN_CERTIFIED_CONNECTOR_KINDS, KNOWN_CANONICAL_OBJECT_KEYS]
+    const exec = createFakeExec({
+      schema,
+      counts: {
+        'count.external_system_kinds_all': [
+          { kind: 'erp:k3-wise-webapi', n: 3 },
+          { kind: 'SENTINEL_NEVER_SEEN_KIND', n: 1 },
+        ],
+        'count.external_system_kinds_active': [{ kind: 'erp:k3-wise-webapi', n: 2 }],
+        'count.read_source_config_objects_by_status': [
+          { object: 'material', status: 'approved', n: 5 },
+          { object: 'SENTINEL_NEVER_SEEN_OBJECT', status: 'approved', n: 1 },
+        ],
+        'count.read_source_config_object_config_divergence': [{ n: 0 }],
+      },
+    })
+    await buildReport({ exec, noPrivateOut: true })
+    // Same array objects (module-level `const`, frozen) — identity AND content unchanged.
+    assert.equal(KNOWN_CERTIFIED_CONNECTOR_KINDS, before[0])
+    assert.equal(KNOWN_CANONICAL_OBJECT_KEYS, before[1])
+    assert.deepEqual(KNOWN_CERTIFIED_CONNECTOR_KINDS, [])
+    assert.deepEqual(KNOWN_CANONICAL_OBJECT_KEYS, [])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// bucketByRegistry — pure bucketing logic
+// ---------------------------------------------------------------------------
+
+describe('bucketByRegistry', () => {
+  test('empty registry: everything observed is unregistered', () => {
+    const { counts } = bucketByRegistry(
+      [{ kind: 'a', n: 3 }, { kind: 'b', n: 5 }],
+      [],
+      { valueKey: 'kind' },
+    )
+    assert.equal(counts.distinctCount, 2)
+    assert.equal(counts.totalRows, 8)
+    assert.equal(counts.knownRegistrySize, 0)
+    assert.equal(counts.registeredDistinctCount, 0)
+    assert.equal(counts.unregisteredDistinctCount, 2)
+    assert.equal(counts.registeredRowCount, 0)
+    assert.equal(counts.unregisteredRowCount, 8)
+  })
+
+  test('non-empty registry: correctly splits registered vs unregistered, both distinct and row counts', () => {
+    const { counts, detail } = bucketByRegistry(
+      [{ kind: 'a', n: 3 }, { kind: 'b', n: 5 }, { kind: 'c', n: 2 }],
+      ['a', 'c'],
+      { valueKey: 'kind' },
+    )
+    assert.equal(counts.distinctCount, 3)
+    assert.equal(counts.totalRows, 10)
+    assert.equal(counts.registeredDistinctCount, 2)
+    assert.equal(counts.unregisteredDistinctCount, 1)
+    assert.equal(counts.registeredRowCount, 5) // a(3) + c(2)
+    assert.equal(counts.unregisteredRowCount, 5) // b(5)
+    assert.deepEqual(
+      detail.sort((x, y) => x.value.localeCompare(y.value)),
+      [
+        { value: 'a', count: 3, registered: true },
+        { value: 'b', count: 5, registered: false },
+        { value: 'c', count: 2, registered: true },
+      ],
+    )
+  })
+
+  test('zero rows: distinct/total are zero, never treated as UNAVAILABLE (that is a schema-plan concern, not a bucketing concern)', () => {
+    const { counts } = bucketByRegistry([], [], { valueKey: 'kind' })
+    assert.equal(counts.distinctCount, 0)
+    assert.equal(counts.totalRows, 0)
+    assert.equal(counts.registeredDistinctCount, 0)
+    assert.equal(counts.unregisteredDistinctCount, 0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// splitRowsByStatus
+// ---------------------------------------------------------------------------
+
+describe('splitRowsByStatus', () => {
+  test('splits into draft/approved/retired', () => {
+    const rows = [
+      { object: 'a', status: 'draft', n: 1 },
+      { object: 'b', status: 'approved', n: 2 },
+      { object: 'c', status: 'retired', n: 3 },
+    ]
+    const out = splitRowsByStatus(rows)
+    assert.deepEqual(out.draft, [rows[0]])
+    assert.deepEqual(out.approved, [rows[1]])
+    assert.deepEqual(out.retired, [rows[2]])
+    assert.deepEqual(out.unexpected, [])
+  })
+
+  test('an out-of-vocabulary status is fail-closed into `unexpected`, never dropped or merged', () => {
+    const rows = [{ object: 'x', status: 'some_future_status', n: 1 }]
+    const out = splitRowsByStatus(rows)
+    assert.deepEqual(out.unexpected, rows)
+    assert.deepEqual(out.draft, [])
+    assert.deepEqual(out.approved, [])
+    assert.deepEqual(out.retired, [])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildPlan / executePlan — schema-probe-first: missing table/column ->
+// UNAVAILABLE, and the corresponding count query must never be sent.
+// ---------------------------------------------------------------------------
+
+describe('buildPlan / executePlan: missing table -> UNAVAILABLE, never a blind query', () => {
+  test('missing integration_external_systems -> kindInventory UNAVAILABLE, no count query sent', async () => {
+    const schema = cloneSchema({ integration_external_systems: { exists: false, columns: [] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed)
+    assert.equal(plan.kindInventory.status, 'unavailable')
+    assert.match(plan.kindInventory.reason, /integration_external_systems not found/)
+
+    const exec = createFakeExec({ schema, counts: { ...ZERO_COUNTS, 'count.external_system_kinds_all': undefined, 'count.external_system_kinds_active': undefined } })
+    const coverage = await executePlan(exec, plan)
+    assert.equal(coverage.kindInventory.status, 'unavailable')
+  })
+
+  test('missing integration_read_source_configs -> objectKeyInventory UNAVAILABLE, no count query sent', async () => {
+    const schema = cloneSchema({ integration_read_source_configs: { exists: false, columns: [] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed)
+    assert.equal(plan.objectKeyInventory.status, 'unavailable')
+
+    const exec = createFakeExec({
+      schema,
+      counts: { ...ZERO_COUNTS, 'count.read_source_config_objects_by_status': undefined, 'count.read_source_config_object_config_divergence': undefined },
+    })
+    const coverage = await executePlan(exec, plan)
+    assert.equal(coverage.objectKeyInventory.status, 'unavailable')
+  })
+})
+
+describe('buildPlan / executePlan: missing column -> UNAVAILABLE sub-item, never a blind query', () => {
+  test('missing integration_external_systems.kind -> whole kindInventory unavailable', async () => {
+    const schema = cloneSchema({ integration_external_systems: { exists: true, columns: ['id', 'status'] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed)
+    assert.equal(plan.kindInventory.status, 'unavailable')
+    assert.match(plan.kindInventory.reason, /kind column not found/)
+  })
+
+  test('missing integration_external_systems.status -> allStatuses still ok, activeOnly unavailable, its count query never sent', async () => {
+    const schema = cloneSchema({ integration_external_systems: { exists: true, columns: ['id', 'kind'] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed)
+    assert.equal(plan.kindInventory.status, 'ok')
+    assert.equal(plan.kindInventory.allStatuses.status, 'ok')
+    assert.equal(plan.kindInventory.activeOnly.status, 'unavailable')
+
+    const exec = createFakeExec({
+      schema,
+      counts: {
+        ...ZERO_COUNTS,
+        'count.external_system_kinds_all': [{ kind: 'x', n: 1 }],
+        'count.external_system_kinds_active': undefined,
+      },
+    })
+    const coverage = await executePlan(exec, plan)
+    assert.equal(coverage.kindInventory.allStatuses.status, 'ok')
+    assert.equal(coverage.kindInventory.activeOnly.status, 'unavailable')
+  })
+
+  test('missing integration_read_source_configs.object -> whole objectKeyInventory unavailable', async () => {
+    const schema = cloneSchema({ integration_read_source_configs: { exists: true, columns: ['id', 'status', 'config'] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed)
+    assert.equal(plan.objectKeyInventory.status, 'unavailable')
+    assert.match(plan.objectKeyInventory.reason, /object/)
+  })
+
+  test('missing integration_read_source_configs.config -> byStatus still ok, divergence unavailable, its query never sent', async () => {
+    const schema = cloneSchema({ integration_read_source_configs: { exists: true, columns: ['id', 'object', 'status'] } })
+    const probed = await probeSchema(createFakeExec({ schema, counts: {} }))
+    const plan = buildPlan(probed)
+    assert.equal(plan.objectKeyInventory.status, 'ok')
+    assert.equal(plan.objectKeyInventory.byStatus.status, 'ok')
+    assert.equal(plan.objectKeyInventory.divergence.status, 'unavailable')
+
+    const exec = createFakeExec({
+      schema,
+      counts: {
+        ...ZERO_COUNTS,
+        'count.read_source_config_objects_by_status': [],
+        'count.read_source_config_object_config_divergence': undefined,
+      },
+    })
+    const coverage = await executePlan(exec, plan)
+    assert.equal(coverage.objectKeyInventory.divergence.status, 'unavailable')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Verdicts — three reachable outcomes each, INCONCLUSIVE forced by any
+// UNAVAILABLE coverage (never a silent "0 unregistered" read as "nothing to
+// map" when the underlying count could not actually be taken).
+// ---------------------------------------------------------------------------
+
+describe('computeKindVerdict', () => {
+  test('INCONCLUSIVE when allStatuses coverage is unavailable', () => {
+    const v = computeKindVerdict({ status: 'unavailable', reason: 'table gone' })
+    assert.equal(v.verdict, 'INCONCLUSIVE')
+  })
+
+  test('CONNECTOR_KIND_MAPPING_NOT_REQUIRED_WITHIN_COVERAGE when zero rows observed', () => {
+    const summary = buildPublicKindSummary({
+      status: 'ok',
+      allStatuses: { status: 'ok', counts: bucketByRegistry([], [], { valueKey: 'kind' }).counts, detail: [] },
+      activeOnly: { status: 'ok', counts: bucketByRegistry([], [], { valueKey: 'kind' }).counts, detail: [] },
+    })
+    const v = computeKindVerdict(summary)
+    assert.equal(v.verdict, 'CONNECTOR_KIND_MAPPING_NOT_REQUIRED_WITHIN_COVERAGE')
+  })
+
+  test('CONNECTOR_KIND_MAPPING_REQUIRED when any distinct kind is unregistered (registry is empty today, so any non-empty observation trips this)', () => {
+    const bucketed = bucketByRegistry([{ kind: 'erp:k3-wise-webapi', n: 1 }], [], { valueKey: 'kind' })
+    const summary = buildPublicKindSummary({
+      status: 'ok',
+      allStatuses: { status: 'ok', counts: bucketed.counts, detail: bucketed.detail },
+      activeOnly: { status: 'ok', counts: bucketed.counts, detail: bucketed.detail },
+    })
+    const v = computeKindVerdict(summary)
+    assert.equal(v.verdict, 'CONNECTOR_KIND_MAPPING_REQUIRED')
+  })
+})
+
+describe('computeObjectKeyVerdict', () => {
+  test('INCONCLUSIVE when the approved-status bucket is unavailable', () => {
+    const v = computeObjectKeyVerdict({ status: 'unavailable', reason: 'table gone' })
+    assert.equal(v.verdict, 'INCONCLUSIVE')
+  })
+
+  test('CANONICAL_OBJECT_BACKFILL_NOT_REQUIRED_WITHIN_COVERAGE when zero approved rows observed', () => {
+    const empty = bucketByRegistry([], [], { valueKey: 'object' }).counts
+    const summary = buildPublicObjectKeySummary({
+      status: 'ok',
+      byStatus: {
+        draft: { counts: empty, detail: [] },
+        approved: { counts: empty, detail: [] },
+        retired: { counts: empty, detail: [] },
+        unexpected: { counts: empty, detail: [] },
+      },
+      divergence: { status: 'ok', count: 0 },
+    })
+    const v = computeObjectKeyVerdict(summary)
+    assert.equal(v.verdict, 'CANONICAL_OBJECT_BACKFILL_NOT_REQUIRED_WITHIN_COVERAGE')
+  })
+
+  test('CANONICAL_OBJECT_BACKFILL_REQUIRED when an approved config references an unregistered object', () => {
+    const approvedBucketed = bucketByRegistry([{ object: 'material', n: 4 }], [], { valueKey: 'object' })
+    const empty = bucketByRegistry([], [], { valueKey: 'object' }).counts
+    const summary = buildPublicObjectKeySummary({
+      status: 'ok',
+      byStatus: {
+        draft: { counts: empty, detail: [] },
+        approved: { counts: approvedBucketed.counts, detail: approvedBucketed.detail },
+        retired: { counts: empty, detail: [] },
+        unexpected: { counts: empty, detail: [] },
+      },
+      divergence: { status: 'ok', count: 0 },
+    })
+    const v = computeObjectKeyVerdict(summary)
+    assert.equal(v.verdict, 'CANONICAL_OBJECT_BACKFILL_REQUIRED')
+  })
+
+  test('draft-only references do NOT trip the (approved-scoped) verdict — pins the scope decision, not an oversight', () => {
+    const draftBucketed = bucketByRegistry([{ object: 'material', n: 1 }], [], { valueKey: 'object' })
+    const empty = bucketByRegistry([], [], { valueKey: 'object' }).counts
+    const summary = buildPublicObjectKeySummary({
+      status: 'ok',
+      byStatus: {
+        draft: { counts: draftBucketed.counts, detail: draftBucketed.detail },
+        approved: { counts: empty, detail: [] },
+        retired: { counts: empty, detail: [] },
+        unexpected: { counts: empty, detail: [] },
+      },
+      divergence: { status: 'ok', count: 0 },
+    })
+    const v = computeObjectKeyVerdict(summary)
+    assert.equal(v.verdict, 'CANONICAL_OBJECT_BACKFILL_NOT_REQUIRED_WITHIN_COVERAGE')
+  })
+
+  // Same shape as the #4594-reviewer-caught bug this ledger's §1 records: a "within coverage"
+  // verdict must never coexist with a KNOWN coverage defect. Here the defect is that `object`
+  // (what the backfill list is built from) disagrees with config->>'object' for some row(s) — a
+  // NOT_REQUIRED verdict alongside that would tell a human "nothing to do" while the very column
+  // the report is built from is known-wrong for at least one row. Deliberately constructed so the
+  // approved bucket ALONE would say NOT_REQUIRED (empty/all-registered) — divergence must be the
+  // thing that flips it, not a confound.
+  test('INCONCLUSIVE when divergence > 0, even though the approved bucket alone would say NOT_REQUIRED', () => {
+    const empty = bucketByRegistry([], [], { valueKey: 'object' }).counts
+    const summary = buildPublicObjectKeySummary({
+      status: 'ok',
+      byStatus: {
+        draft: { counts: empty, detail: [] },
+        approved: { counts: empty, detail: [] },
+        retired: { counts: empty, detail: [] },
+        unexpected: { counts: empty, detail: [] },
+      },
+      divergence: { status: 'ok', count: 3 },
+    })
+    const v = computeObjectKeyVerdict(summary)
+    assert.equal(v.verdict, 'INCONCLUSIVE')
+    assert.ok(v.reasons.some((r) => r.includes('3 row(s)')))
+  })
+
+  test('INCONCLUSIVE when divergence > 0, even though the approved bucket alone would say REQUIRED (divergence reason still surfaces, not silently dropped behind the mapping-required reason)', () => {
+    const approvedBucketed = bucketByRegistry([{ object: 'material', n: 1 }], [], { valueKey: 'object' })
+    const empty = bucketByRegistry([], [], { valueKey: 'object' }).counts
+    const summary = buildPublicObjectKeySummary({
+      status: 'ok',
+      byStatus: {
+        draft: { counts: empty, detail: [] },
+        approved: { counts: approvedBucketed.counts, detail: approvedBucketed.detail },
+        retired: { counts: empty, detail: [] },
+        unexpected: { counts: empty, detail: [] },
+      },
+      divergence: { status: 'ok', count: 1 },
+    })
+    const v = computeObjectKeyVerdict(summary)
+    assert.equal(v.verdict, 'INCONCLUSIVE')
+  })
+
+  test('INCONCLUSIVE when the divergence check itself is UNAVAILABLE, even with a clean approved bucket', () => {
+    const empty = bucketByRegistry([], [], { valueKey: 'object' }).counts
+    const summary = buildPublicObjectKeySummary({
+      status: 'ok',
+      byStatus: {
+        draft: { counts: empty, detail: [] },
+        approved: { counts: empty, detail: [] },
+        retired: { counts: empty, detail: [] },
+        unexpected: { counts: empty, detail: [] },
+      },
+      divergence: { status: 'unavailable', reason: 'config column not found' },
+    })
+    const v = computeObjectKeyVerdict(summary)
+    assert.equal(v.verdict, 'INCONCLUSIVE')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// VALUES-FREE PUBLIC OUTPUT — the load-bearing test. Injects sentinel raw
+// strings through the fake executor and proves, mechanically, that they
+// cannot reach the serialized public report — not by code review, by a
+// positive control (the sentinel DOES appear in the private artefact file,
+// so this is not "the sentinel never flows anywhere") and a negative control
+// (it does NOT appear in the report object returned to the caller / printed
+// to stdout).
+// ---------------------------------------------------------------------------
+
+describe('values-free public output (sentinel injection)', () => {
+  const SENTINEL_KIND = 'SENTINEL_KIND_MUST_NEVER_LEAK_INTO_PUBLIC_OUTPUT_0xACAB'
+  const SENTINEL_OBJECT = 'SENTINEL_OBJECT_MUST_NEVER_LEAK_INTO_PUBLIC_OUTPUT_0xFEED'
+
+  function scratchDir() {
+    return mkdtempSync(path.join(tmpdir(), 'gip-authority-inventory-test-'))
+  }
+
+  test('sentinel kind/object strings do not appear anywhere in JSON.stringify(report), even though they were the only rows observed', async () => {
+    const dir = scratchDir()
+    try {
+      const schema = cloneSchema()
+      const exec = createFakeExec({
+        schema,
+        counts: {
+          'count.external_system_kinds_all': [{ kind: SENTINEL_KIND, n: 7 }],
+          'count.external_system_kinds_active': [{ kind: SENTINEL_KIND, n: 7 }],
+          'count.read_source_config_objects_by_status': [{ object: SENTINEL_OBJECT, status: 'approved', n: 9 }],
+          'count.read_source_config_object_config_divergence': [{ n: 0 }],
+        },
+      })
+      const privateOutPath = path.join(dir, 'private.json')
+      const report = await buildReport({ exec, privateOutPath })
+
+      const serialized = JSON.stringify(report)
+      assert.doesNotMatch(serialized, new RegExp(SENTINEL_KIND))
+      assert.doesNotMatch(serialized, new RegExp(SENTINEL_OBJECT))
+
+      // Positive control: the raw values are NOT silently dropped — they exist,
+      // just in the private artefact, not in the report. Confirms the previous
+      // negative assertion means "moved to the right place", not "lost".
+      const privateContent = readFileSync(privateOutPath, 'utf8')
+      assert.match(privateContent, new RegExp(SENTINEL_KIND))
+      assert.match(privateContent, new RegExp(SENTINEL_OBJECT))
+
+      // The report's own pointer to that file must be a path only, never content.
+      assert.equal(report.privateArtifact.status, 'written')
+      assert.doesNotMatch(JSON.stringify(report.privateArtifact), new RegExp(SENTINEL_KIND))
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('recursive structural check: every value in coverage/verdicts/residualNotes is either a number, a boolean, or drawn from a small closed set of authored strings — walked mechanically, not spot-checked', async () => {
+    const dir = scratchDir()
+    try {
+      const schema = cloneSchema()
+      const exec = createFakeExec({
+        schema,
+        counts: {
+          'count.external_system_kinds_all': [{ kind: SENTINEL_KIND, n: 1 }, { kind: 'another-unseen-kind', n: 2 }],
+          'count.external_system_kinds_active': [{ kind: SENTINEL_KIND, n: 1 }],
+          'count.read_source_config_objects_by_status': [
+            { object: SENTINEL_OBJECT, status: 'approved', n: 1 },
+            { object: 'yet-another-object', status: 'draft', n: 1 },
+          ],
+          'count.read_source_config_object_config_divergence': [{ n: 2 }],
+        },
+      })
+      const privateOutPath = path.join(dir, 'private.json')
+      const report = await buildReport({ exec, privateOutPath })
+
+      // Collect every string leaf reachable from coverage/verdicts/residualNotes
+      // (deliberately EXCLUDING privateArtifact.path, which legitimately names a
+      // file path chosen by the operator/test, not a database value).
+      const leaves = []
+      function walk(node) {
+        if (node == null) return
+        if (typeof node === 'string') { leaves.push(node); return }
+        if (Array.isArray(node)) { node.forEach(walk); return }
+        if (typeof node === 'object') { for (const v of Object.values(node)) walk(v); return }
+      }
+      walk(report.coverage)
+      walk(report.verdicts)
+      walk(report.residualNotes)
+
+      for (const leaf of leaves) {
+        assert.ok(
+          !leaf.includes(SENTINEL_KIND) && !leaf.includes(SENTINEL_OBJECT),
+          `string leaf unexpectedly carries a sentinel raw value: ${JSON.stringify(leaf)}`,
+        )
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Private artefact — fail-closed write behaviour
+// ---------------------------------------------------------------------------
+
+describe('private artefact write behaviour', () => {
+  function scratchDir() {
+    return mkdtempSync(path.join(tmpdir(), 'gip-authority-inventory-test-'))
+  }
+
+  test('shouldWritePrivateArtifact is true when any bucket has an unregistered distinct value', () => {
+    const bucketed = bucketByRegistry([{ kind: 'x', n: 1 }], [], { valueKey: 'kind' })
+    const emptyObj = bucketByRegistry([], [], { valueKey: 'object' }).counts
+    const owed = shouldWritePrivateArtifact({
+      kindInventory: { status: 'ok', allStatuses: { status: 'ok', counts: bucketed.counts }, activeOnly: { status: 'ok', counts: bucketed.counts } },
+      objectKeyInventory: {
+        status: 'ok',
+        byStatus: { draft: { counts: emptyObj }, approved: { counts: emptyObj }, retired: { counts: emptyObj }, unexpected: { counts: emptyObj } },
+      },
+    })
+    assert.equal(owed, true)
+  })
+
+  test('shouldWritePrivateArtifact is false when both inventories are all-registered/empty', () => {
+    const emptyKind = bucketByRegistry([], [], { valueKey: 'kind' }).counts
+    const emptyObj = bucketByRegistry([], [], { valueKey: 'object' }).counts
+    const owed = shouldWritePrivateArtifact({
+      kindInventory: { status: 'ok', allStatuses: { status: 'ok', counts: emptyKind }, activeOnly: { status: 'ok', counts: emptyKind } },
+      objectKeyInventory: {
+        status: 'ok',
+        byStatus: { draft: { counts: emptyObj }, approved: { counts: emptyObj }, retired: { counts: emptyObj }, unexpected: { counts: emptyObj } },
+      },
+    })
+    assert.equal(owed, false)
+  })
+
+  test('FAIL CLOSED: write failure with something owed makes buildReport() reject, and the error message carries no raw value', async () => {
+    const dir = scratchDir()
+    try {
+      const schema = cloneSchema()
+      const exec = createFakeExec({
+        schema,
+        counts: {
+          'count.external_system_kinds_all': [{ kind: 'SENTINEL_SHOULD_NOT_APPEAR_IN_ERROR', n: 1 }],
+          'count.external_system_kinds_active': [],
+          'count.read_source_config_objects_by_status': [],
+          'count.read_source_config_object_config_divergence': [{ n: 0 }],
+        },
+      })
+      // A regular FILE (not a directory) as the parent of the target path makes
+      // mkdirSync throw ENOTDIR — a real, unmocked filesystem failure.
+      const blockerFile = path.join(dir, 'blocker')
+      writeFileSync(blockerFile, 'x')
+      const privateOutPath = path.join(blockerFile, 'sub', 'private.json')
+
+      await assert.rejects(
+        () => buildReport({ exec, privateOutPath }),
+        (err) => {
+          assert.match(err.message, /could not be written/)
+          assert.doesNotMatch(err.message, /SENTINEL_SHOULD_NOT_APPEAR_IN_ERROR/)
+          return true
+        },
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('write failure with NOTHING owed does not fail the run', async () => {
+    const dir = scratchDir()
+    try {
+      const schema = cloneSchema()
+      const exec = createFakeExec({ schema, counts: ZERO_COUNTS })
+      const blockerFile = path.join(dir, 'blocker')
+      writeFileSync(blockerFile, 'x')
+      const privateOutPath = path.join(blockerFile, 'sub', 'private.json')
+
+      const report = await buildReport({ exec, privateOutPath })
+      assert.equal(report.privateArtifact.status, 'write_failed_but_nothing_owed')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('--no-private-out skips the write entirely, even when something is owed', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({
+      schema,
+      counts: {
+        'count.external_system_kinds_all': [{ kind: 'x', n: 1 }],
+        'count.external_system_kinds_active': [],
+        'count.read_source_config_objects_by_status': [],
+        'count.read_source_config_object_config_divergence': [{ n: 0 }],
+      },
+    })
+    const report = await buildReport({ exec, noPrivateOut: true })
+    assert.equal(report.privateArtifact.status, 'skipped_by_flag')
+  })
+
+  test('buildPrivateArtifactContent carries the raw detail (this is the ONLY function permitted to)', () => {
+    const bucketed = bucketByRegistry([{ kind: 'erp:k3-wise-webapi', n: 1 }], [], { valueKey: 'kind' })
+    const objBucketed = bucketByRegistry([{ object: 'material', n: 1 }], [], { valueKey: 'object' })
+    const empty = bucketByRegistry([], [], { valueKey: 'object' })
+    const content = buildPrivateArtifactContent(
+      {
+        kindInventory: { status: 'ok', allStatuses: { detail: bucketed.detail }, activeOnly: { status: 'ok', detail: bucketed.detail } },
+        objectKeyInventory: {
+          status: 'ok',
+          byStatus: { draft: { detail: empty.detail }, approved: { detail: objBucketed.detail }, retired: { detail: empty.detail }, unexpected: { detail: empty.detail } },
+        },
+      },
+      { generatedAt: '2026-07-25T00:00:00.000Z' },
+    )
+    assert.deepEqual(content.connectorKinds.allStatuses, bucketed.detail)
+    assert.deepEqual(content.objectKeys.approved, objBucketed.detail)
+    assert.match(content.warning, /Never commit/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// residualNotes — always present, never empty
+// ---------------------------------------------------------------------------
+
+describe('RESIDUAL_NOTES', () => {
+  test('is non-empty and states the empty-registry caveat explicitly', () => {
+    assert.ok(RESIDUAL_NOTES.length > 0)
+    assert.ok(RESIDUAL_NOTES.some((n) => n.id === 'known_registries_empty_by_design'))
+    assert.ok(RESIDUAL_NOTES.some((n) => n.id === 'no_customer_deployment_connection'))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// --probe beta|gamma|both
+// ---------------------------------------------------------------------------
+
+describe('--probe scoping', () => {
+  // The property that actually matters: under --probe beta, NO query touching
+  // integration_read_source_configs is ever issued — not merely that its summary is suppressed.
+  // A fixture with NO count.read_source_config_* entries proves this by construction: if
+  // executeObjectKeyInventoryPlan ran anyway, createFakeExec would throw "no count fixture
+  // configured" before this test could even reach its assertions. The `calls` array is a second,
+  // independent check of the same property, and also proves the schema for
+  // integration_read_source_configs was never probed either — buildPlan() short-circuited BEFORE
+  // planObjectKeyInventory ever looked at it.
+  test('probe=beta issues zero queries against integration_read_source_configs (schema probe included) and writes no γ objectKey value into the private artefact', async () => {
+    const schema = cloneSchema()
+    const calls = []
+    const exec = createFakeExec(
+      {
+        schema,
+        counts: {
+          'count.external_system_kinds_all': [{ kind: 'erp:k3-wise-webapi', n: 1 }],
+          'count.external_system_kinds_active': [{ kind: 'erp:k3-wise-webapi', n: 1 }],
+          // Deliberately NO count.read_source_config_* fixtures — if the γ probe ran under
+          // --probe beta, the fake exec would throw before any assertion below runs.
+        },
+      },
+      calls,
+    )
+    const report = await buildReport({ exec, probe: 'beta', noPrivateOut: true })
+    assert.equal(report.coverage.connectorKindInventory.status, 'ok')
+    assert.equal(report.coverage.canonicalObjectKeyInventory.status, 'not_run')
+    assert.equal(report.verdicts.canonicalObjectKey, null)
+    assert.notEqual(report.verdicts.connectorKind, null)
+
+    // No probe.table_exists / probe.columns call for integration_read_source_configs, and no
+    // count.read_source_config_* tag at all.
+    const readSourceConfigCalls = calls.filter(
+      (c) => c.tag.startsWith('count.read_source_config') || (c.params && c.params[0] === 'integration_read_source_configs'),
+    )
+    assert.deepEqual(readSourceConfigCalls, [])
+  })
+
+  test('probe=beta with something owed: shouldWritePrivateArtifact / buildPrivateArtifactContent see objectKeyInventory as not_run, never write a γ value', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({
+      schema,
+      counts: {
+        'count.external_system_kinds_all': [{ kind: 'SENTINEL_BETA_ONLY_KIND', n: 1 }],
+        'count.external_system_kinds_active': [{ kind: 'SENTINEL_BETA_ONLY_KIND', n: 1 }],
+      },
+    })
+    const dir = mkdtempSync(path.join(tmpdir(), 'gip-authority-inventory-test-'))
+    try {
+      const privateOutPath = path.join(dir, 'private.json')
+      const report = await buildReport({ exec, probe: 'beta', privateOutPath })
+      assert.equal(report.privateArtifact.status, 'written')
+      const content = JSON.parse(readFileSync(privateOutPath, 'utf8'))
+      assert.deepEqual(content.objectKeys, {}) // γ never ran — nothing to have leaked, and nothing did
+      assert.deepEqual(content.connectorKinds.allStatuses, [{ value: 'SENTINEL_BETA_ONLY_KIND', count: 1, registered: false }])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('probe=gamma issues zero queries against integration_external_systems and writes no β kind value into the private artefact', async () => {
+    const schema = cloneSchema()
+    const calls = []
+    const exec = createFakeExec(
+      {
+        schema,
+        counts: {
+          'count.read_source_config_objects_by_status': [{ object: 'material', status: 'approved', n: 1 }],
+          'count.read_source_config_object_config_divergence': [{ n: 0 }],
+          // Deliberately NO count.external_system_kinds_* fixtures.
+        },
+      },
+      calls,
+    )
+    const report = await buildReport({ exec, probe: 'gamma', noPrivateOut: true })
+    assert.equal(report.coverage.canonicalObjectKeyInventory.status, 'ok')
+    assert.equal(report.coverage.connectorKindInventory.status, 'not_run')
+    assert.equal(report.verdicts.connectorKind, null)
+
+    const externalSystemCalls = calls.filter(
+      (c) => c.tag.startsWith('count.external_system') || (c.params && c.params[0] === 'integration_external_systems'),
+    )
+    assert.deepEqual(externalSystemCalls, [])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// dry-run
+// ---------------------------------------------------------------------------
+
+describe('buildDryRunReport', () => {
+  test('no executor: static allowlist listing, no DB required', async () => {
+    const report = await buildDryRunReport({ exec: null })
+    assert.equal(report.mode, 'dry-run-static')
+    assert.ok(Object.keys(report.allowlist).length === Object.keys(QUERY_ALLOWLIST).length)
+    assert.equal(report.knownRegistrySizes.connectorKind, 0)
+    assert.equal(report.knownRegistrySizes.canonicalObjectKey, 0)
+  })
+
+  test('with executor: schema IS probed, plan resolved, no count query executed', async () => {
+    const schema = cloneSchema()
+    const calls = []
+    const exec = createFakeExec({ schema, counts: {} }, calls)
+    const report = await buildDryRunReport({ exec })
+    assert.equal(report.mode, 'dry-run')
+    assert.equal(report.plan.kindInventory.status, 'ok')
+    // Only schema-probe tags were called — no count.* tag.
+    assert.ok(calls.every((c) => c.tag.startsWith('probe.')))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+  test('defaults', () => {
+    const opts = parseArgs([])
+    assert.equal(opts.dryRun, false)
+    assert.equal(opts.probe, 'both')
+    assert.equal(opts.json, false)
+    assert.equal(opts.noPrivateOut, false)
+    assert.equal(opts.privateOutPath, undefined)
+  })
+
+  test('--probe accepts beta/gamma/both, rejects anything else', () => {
+    assert.equal(parseArgs(['--probe', 'beta']).probe, 'beta')
+    assert.equal(parseArgs(['--probe', 'gamma']).probe, 'gamma')
+    assert.equal(parseArgs(['--probe', 'both']).probe, 'both')
+    assert.throws(() => parseArgs(['--probe', 'delta']), /--probe must be one of/)
+  })
+
+  test('--private-out and --no-private-out are mutually exclusive', () => {
+    assert.throws(() => parseArgs(['--private-out', '/tmp/x.json', '--no-private-out']), /mutually exclusive/)
+  })
+
+  test('--private-out requires a path argument', () => {
+    assert.throws(() => parseArgs(['--private-out']), /requires a path argument/)
+  })
+
+  test('unknown flag throws', () => {
+    assert.throws(() => parseArgs(['--nope']), /unknown argument/)
+  })
+
+  test('--help sets help flag', () => {
+    assert.equal(parseArgs(['--help']).help, true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DEFAULT_PRIVATE_OUTPUT_DIR must be the gitignored directory — pins the
+// constant against the .gitignore entry shipped in the same PR (read the real
+// .gitignore, not just the constant's own string).
+// ---------------------------------------------------------------------------
+
+describe('DEFAULT_PRIVATE_OUTPUT_DIR is actually gitignored', () => {
+  test('.gitignore contains an entry covering this directory', () => {
+    const gitignore = readFileSync(path.join(REPO_ROOT, '.gitignore'), 'utf8')
+    const covered = gitignore
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('#'))
+      .some((pattern) => {
+        const normalized = pattern.replace(/\/$/, '')
+        return DEFAULT_PRIVATE_OUTPUT_DIR === normalized || DEFAULT_PRIVATE_OUTPUT_DIR.startsWith(normalized + '/')
+      })
+    assert.ok(covered, `.gitignore has no entry covering ${DEFAULT_PRIVATE_OUTPUT_DIR} — a real run's raw-value artefact could be committed`)
+  })
+})

--- a/scripts/ops/gip-authority-substrate-inventory.test.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.test.mjs
@@ -2158,9 +2158,15 @@ describe('stderr values-free discipline — real subprocess (#4603 P2(a))', () =
     // dependency of packages/core-backend/package.json; a contributor who ran `pnpm install` at
     // the repo root (an ordinary, unremarkable step) and then ran this test file directly would
     // resolve `pg` successfully via workspace hoisting, and the whole point of this test — proving
-    // the redaction actually engaged — would silently stop being exercised while still reading
-    // green (a false-negative-shaped risk this repo's doctrine treats as a defect, not a nuisance:
-    // see feedback_positive_control_not_failclosed.md). The CI workflow itself never installs
+    // the redaction actually engaged — would stop being exercised. CORRECTION (review, 2026-07-25):
+    // an earlier draft of this comment called that "silently ... while still reading green", i.e. a
+    // FALSE-GREEN. That is wrong, and this same block refutes it three sentences below: replaying
+    // the old shape against a stub `pg` reds LOUDLY with `control failed: 'pg' imported
+    // successfully...`. The real defect class is a FALSE-RED — an environment-dependent spurious
+    // failure that a contributor cannot act on, because it is not their change that broke it. The
+    // control was already fail-closed in the sense doctrine cares about
+    // (feedback_positive_control_not_failclosed.md); what it was not, was environment-independent.
+    // The fix below is worth keeping for exactly that reason. The CI workflow itself never installs
     // (checkout + setup-node + `node --test`, no install step — see
     // .github/workflows/gip-authority-substrate-inventory.yml), so CI never actually saw this gap;
     // this only bites a contributor running the suite locally after `pnpm install`.

--- a/scripts/ops/gip-authority-substrate-inventory.test.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.test.mjs
@@ -246,8 +246,20 @@ describe('schema-drift guard (reads real migration SQL from disk)', () => {
     assert.deepEqual(vocab, [...EXTERNAL_SYSTEM_STATUSES].sort())
   })
 
-  test('integration_read_source_configs.object is TEXT NOT NULL — this IS the column the ledger calls objectKey', () => {
-    assert.match(migration062, /object\s+TEXT NOT NULL/)
+  // Line-anchored, same shape as the `kind` guard above (M8-proof): a loose
+  // `/object\s+TEXT NOT NULL/` match over the WHOLE FILE is satisfied by a
+  // rename to `canonical_object` — that identifier still CONTAINS the
+  // substring "object" immediately followed by "        TEXT NOT NULL", so a
+  // non-anchored regex cannot tell "the object column" from "a column whose
+  // name happens to end in object". Anchoring the match to line-start (after
+  // only whitespace) closes that hole: "canonical_object" does not begin a
+  // line with the literal token "object".
+  test('integration_read_source_configs.object is TEXT NOT NULL — this IS the column the ledger calls objectKey (line-anchored: a rename to e.g. `canonical_object` must NOT satisfy this via the trailing "object" substring)', () => {
+    const objectLine = migration062.split('\n').find((l) => /^\s*object\s+TEXT NOT NULL/.test(l))
+    assert.ok(
+      objectLine,
+      'expected an `object TEXT NOT NULL` column declaration in migration 062, anchored at line start — a substring match (e.g. against `canonical_object`) does not count',
+    )
   })
 
   test('integration_read_source_configs.status CHECK vocabulary matches READ_SOURCE_CONFIG_STATUSES exactly', () => {
@@ -257,8 +269,29 @@ describe('schema-drift guard (reads real migration SQL from disk)', () => {
     assert.deepEqual(vocab, [...READ_SOURCE_CONFIG_STATUSES].sort())
   })
 
-  test('integration_read_source_configs has both a unique index and the store keys the identical-content family on `object` (confirms `object`, not some other column, is the durable key this probe should read)', () => {
-    assert.match(migration062, /uniq_integration_read_source_configs_content[\s\S]*?object/)
+  // Word-boundary anchored (not just line-anchored, because this column sits
+  // mid-line in a comma-separated index column list — `system_id, object,
+  // mode` — so a naive substring match against `canonical_object` would pass
+  // exactly the same way the old declaration test did). `\bobject\b` fails to
+  // match inside `canonical_object`: the character immediately before the
+  // trailing "object" is `_`, a word character, so there is no `\b` boundary
+  // there — the regex engine cannot find a standalone "object" token. The
+  // clause is extracted by literal marker + terminating `;`, not a
+  // paren-counting regex, because the column list also contains
+  // `COALESCE(workspace_id, '')`, whose internal comma/paren would otherwise
+  // truncate a naive `\(([^)]*)\)` capture at the wrong `)`.
+  test('integration_read_source_configs has both a unique index and the store keys the identical-content family on the standalone `object` column (word-boundary anchored: a rename to e.g. `canonical_object` must NOT satisfy this)', () => {
+    const marker = 'uniq_integration_read_source_configs_content'
+    const start = migration062.indexOf(marker)
+    assert.ok(start !== -1, `expected to find "${marker}" in migration 062`)
+    const end = migration062.indexOf(';', start)
+    assert.ok(end !== -1, `expected a terminating ";" after "${marker}"`)
+    const clause = migration062.slice(start, end + 1)
+    assert.match(
+      clause,
+      /\bobject\b/,
+      `expected a standalone "object" column reference in the ${marker} index clause, got: ${JSON.stringify(clause)}`,
+    )
   })
 })
 
@@ -623,7 +656,166 @@ describe('computeObjectKeyVerdict', () => {
     const v = computeObjectKeyVerdict(summary)
     assert.equal(v.verdict, 'INCONCLUSIVE')
   })
+
+  // splitRowsByStatus() fail-closes any row whose status is outside draft/approved/retired into
+  // `unexpected` rather than dropping or merging it (see splitRowsByStatus tests above). Without
+  // this check, a NOT_REQUIRED verdict could coexist with unregistered objectKeys sitting in an
+  // unexpected status — exactly the "verdict alongside a known coverage defect" shape the
+  // divergence check exists to prevent, just for a different coverage gap. Deliberately
+  // constructed so the approved bucket ALONE and the divergence check ALONE would both say
+  // "nothing wrong" (empty approved bucket, divergence count 0) — the unexpected bucket must be
+  // the only thing flipping it, not a confound.
+  test('INCONCLUSIVE when the unexpected-status bucket has any distinct objectKey, even though the approved bucket alone would say NOT_REQUIRED and divergence alone would say clean', () => {
+    const empty = bucketByRegistry([], [], { valueKey: 'object' }).counts
+    const unexpectedBucketed = bucketByRegistry([{ object: 'material', n: 2 }], [], { valueKey: 'object' })
+    const summary = buildPublicObjectKeySummary({
+      status: 'ok',
+      byStatus: {
+        draft: { counts: empty, detail: [] },
+        approved: { counts: empty, detail: [] },
+        retired: { counts: empty, detail: [] },
+        unexpected: { counts: unexpectedBucketed.counts, detail: unexpectedBucketed.detail },
+      },
+      divergence: { status: 'ok', count: 0 },
+    })
+    const v = computeObjectKeyVerdict(summary)
+    assert.equal(v.verdict, 'INCONCLUSIVE')
+    assert.ok(v.reasons.some((r) => r.includes('out-of-vocabulary')))
+  })
+
+  test('INCONCLUSIVE when the unexpected-status bucket has a distinct objectKey, even though the approved bucket alone would say REQUIRED (unexpected reason still surfaces, not silently dropped behind the mapping-required reason)', () => {
+    const approvedBucketed = bucketByRegistry([{ object: 'material', n: 1 }], [], { valueKey: 'object' })
+    const unexpectedBucketed = bucketByRegistry([{ object: 'other-thing', n: 1 }], [], { valueKey: 'object' })
+    const empty = bucketByRegistry([], [], { valueKey: 'object' }).counts
+    const summary = buildPublicObjectKeySummary({
+      status: 'ok',
+      byStatus: {
+        draft: { counts: empty, detail: [] },
+        approved: { counts: approvedBucketed.counts, detail: approvedBucketed.detail },
+        retired: { counts: empty, detail: [] },
+        unexpected: { counts: unexpectedBucketed.counts, detail: unexpectedBucketed.detail },
+      },
+      divergence: { status: 'ok', count: 0 },
+    })
+    const v = computeObjectKeyVerdict(summary)
+    assert.equal(v.verdict, 'INCONCLUSIVE')
+  })
 })
+
+// ---------------------------------------------------------------------------
+// EXACT KEY-SET assertion — a raw observed value can escape a plain
+// sentinel-substring scan two different ways: (a) as a STRING VALUE (the
+// sentinel-injection test below catches this), or (b) as an OBJECT KEY. A
+// walk that does `for (const v of Object.values(node)) walk(v)` never once
+// inspects `Object.keys(node)` — so a bug that keyed a bucket BY the
+// observed kind/objectKey string (instead of by one of the fixed enum
+// tokens this module actually uses: draft/approved/retired/unexpected,
+// allStatuses/activeOnly, etc.) would sail through a values-walk undetected,
+// because the walk never visits the key that carries the leak, only values
+// nested under it. This asserts the key-set property DIRECTLY: at every
+// level of coverage/verdicts/residualNotes, the object's key set is EXACTLY
+// the fixed, closed set the source is structurally capable of producing —
+// never a superset, so an unexpected key (a leaked raw value used as a key)
+// fails loudly instead of silently passing a values-only scan.
+// ---------------------------------------------------------------------------
+
+const COUNTS_KEYS = [
+  'status',
+  'distinctCount',
+  'totalRows',
+  'knownRegistrySize',
+  'registeredDistinctCount',
+  'unregisteredDistinctCount',
+  'registeredRowCount',
+  'unregisteredRowCount',
+]
+
+function assertKeysExactly(obj, allowedKeys, ctx) {
+  assert.ok(
+    obj && typeof obj === 'object' && !Array.isArray(obj),
+    `${ctx}: expected a plain object, got ${JSON.stringify(obj)}`,
+  )
+  const actual = Object.keys(obj).sort()
+  const expected = [...allowedKeys].sort()
+  assert.deepEqual(
+    actual,
+    expected,
+    `${ctx}: key set mismatch — got ${JSON.stringify(actual)}, expected exactly ${JSON.stringify(expected)}`,
+  )
+}
+
+function assertBucketKeysExactly(bucket, ctx) {
+  if (bucket.status === 'ok') {
+    assertKeysExactly(bucket, COUNTS_KEYS, ctx)
+  } else {
+    assertKeysExactly(bucket, ['status', 'reason'], ctx)
+  }
+}
+
+// Walks the ACTUAL public report structure (not a hand-authored stand-in)
+// and asserts, at every level, the exact key set. Covers every status
+// branch (ok / unavailable / not_run) each field can take.
+function assertPublicReportKeySetsExactly(report) {
+  assertKeysExactly(report.coverage, ['connectorKindInventory', 'canonicalObjectKeyInventory'], 'report.coverage')
+
+  const ck = report.coverage.connectorKindInventory
+  if (ck.status === 'not_run') {
+    assertKeysExactly(ck, ['covers', 'blindSpot', 'status'], 'coverage.connectorKindInventory (not_run)')
+  } else if (ck.status !== 'ok') {
+    assertKeysExactly(ck, ['covers', 'blindSpot', 'status', 'reason'], 'coverage.connectorKindInventory (unavailable)')
+  } else {
+    assertKeysExactly(
+      ck,
+      ['covers', 'blindSpot', 'status', 'allStatuses', 'activeOnly'],
+      'coverage.connectorKindInventory (ok)',
+    )
+    assertBucketKeysExactly(ck.allStatuses, 'coverage.connectorKindInventory.allStatuses')
+    assertBucketKeysExactly(ck.activeOnly, 'coverage.connectorKindInventory.activeOnly')
+  }
+
+  const okInv = report.coverage.canonicalObjectKeyInventory
+  if (okInv.status === 'not_run') {
+    assertKeysExactly(okInv, ['covers', 'blindSpot', 'status'], 'coverage.canonicalObjectKeyInventory (not_run)')
+  } else if (okInv.status !== 'ok') {
+    assertKeysExactly(
+      okInv,
+      ['covers', 'blindSpot', 'status', 'reason'],
+      'coverage.canonicalObjectKeyInventory (unavailable)',
+    )
+  } else {
+    assertKeysExactly(
+      okInv,
+      ['covers', 'blindSpot', 'status', 'byStatus', 'objectVsConfigObjectDivergence'],
+      'coverage.canonicalObjectKeyInventory (ok)',
+    )
+    assertKeysExactly(
+      okInv.byStatus,
+      ['draft', 'approved', 'retired', 'unexpected'],
+      'coverage.canonicalObjectKeyInventory.byStatus',
+    )
+    for (const key of ['draft', 'approved', 'retired', 'unexpected']) {
+      assertBucketKeysExactly(okInv.byStatus[key], `coverage.canonicalObjectKeyInventory.byStatus.${key}`)
+    }
+    const div = okInv.objectVsConfigObjectDivergence
+    if (div.status === 'ok') assertKeysExactly(div, ['status', 'count'], 'objectVsConfigObjectDivergence (ok)')
+    else assertKeysExactly(div, ['status', 'reason'], 'objectVsConfigObjectDivergence (unavailable)')
+  }
+
+  assertKeysExactly(report.verdicts, ['connectorKind', 'canonicalObjectKey'], 'report.verdicts')
+  for (const vk of ['connectorKind', 'canonicalObjectKey']) {
+    const v = report.verdicts[vk]
+    if (v !== null) {
+      assertKeysExactly(v, ['verdict', 'reasons'], `report.verdicts.${vk}`)
+      assert.ok(Array.isArray(v.reasons), `report.verdicts.${vk}.reasons must be an array`)
+      for (const r of v.reasons) assert.equal(typeof r, 'string', `report.verdicts.${vk}.reasons[] must be strings`)
+    }
+  }
+
+  assert.ok(Array.isArray(report.residualNotes), 'report.residualNotes must be an array')
+  for (const note of report.residualNotes) {
+    assertKeysExactly(note, ['id', 'description'], 'report.residualNotes[]')
+  }
+}
 
 // ---------------------------------------------------------------------------
 // VALUES-FREE PUBLIC OUTPUT — the load-bearing test. Injects sentinel raw
@@ -678,7 +870,7 @@ describe('values-free public output (sentinel injection)', () => {
     }
   })
 
-  test('recursive structural check: every value in coverage/verdicts/residualNotes is either a number, a boolean, or drawn from a small closed set of authored strings — walked mechanically, not spot-checked', async () => {
+  test('EXACT key-set check: coverage/verdicts/residualNotes carry exactly the fixed, authored key set at every level — not merely "no sentinel substring in a value" (a raw value used AS A KEY would pass a values-only scan; this catches that class directly)', async () => {
     const dir = scratchDir()
     try {
       const schema = cloneSchema()
@@ -697,29 +889,30 @@ describe('values-free public output (sentinel injection)', () => {
       const privateOutPath = path.join(dir, 'private.json')
       const report = await buildReport({ exec, privateOutPath })
 
-      // Collect every string leaf reachable from coverage/verdicts/residualNotes
-      // (deliberately EXCLUDING privateArtifact.path, which legitimately names a
-      // file path chosen by the operator/test, not a database value).
-      const leaves = []
-      function walk(node) {
-        if (node == null) return
-        if (typeof node === 'string') { leaves.push(node); return }
-        if (Array.isArray(node)) { node.forEach(walk); return }
-        if (typeof node === 'object') { for (const v of Object.values(node)) walk(v); return }
-      }
-      walk(report.coverage)
-      walk(report.verdicts)
-      walk(report.residualNotes)
-
-      for (const leaf of leaves) {
-        assert.ok(
-          !leaf.includes(SENTINEL_KIND) && !leaf.includes(SENTINEL_OBJECT),
-          `string leaf unexpectedly carries a sentinel raw value: ${JSON.stringify(leaf)}`,
-        )
-      }
+      // The exact-key-set walk subsumes the old sentinel-substring scan for
+      // any leak reachable as a plain string VALUE too — deepEqual on a
+      // key set diverges the instant an unexpected property name (including
+      // one equal to a sentinel) appears anywhere in this shape.
+      assertPublicReportKeySetsExactly(report)
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
+  })
+
+  test('EXACT key-set check holds across the unavailable and not_run branches too (missing column / --probe scoping), not just the all-ok happy path', async () => {
+    // unavailable: integration_external_systems.status column absent -> activeOnly UNAVAILABLE,
+    // and canonicalObjectKeyInventory entirely not_run via --probe beta.
+    const schema = cloneSchema({ integration_external_systems: { exists: true, columns: ['id', 'kind'] } })
+    const exec = createFakeExec({
+      schema,
+      counts: {
+        'count.external_system_kinds_all': [{ kind: 'erp:k3-wise-webapi', n: 1 }],
+      },
+    })
+    const report = await buildReport({ exec, probe: 'beta', noPrivateOut: true })
+    assert.equal(report.coverage.connectorKindInventory.activeOnly.status, 'unavailable')
+    assert.equal(report.coverage.canonicalObjectKeyInventory.status, 'not_run')
+    assertPublicReportKeySetsExactly(report)
   })
 })
 
@@ -851,6 +1044,24 @@ describe('RESIDUAL_NOTES', () => {
     assert.ok(RESIDUAL_NOTES.some((n) => n.id === 'known_registries_empty_by_design'))
     assert.ok(RESIDUAL_NOTES.some((n) => n.id === 'no_customer_deployment_connection'))
   })
+
+  // γ's ledger scope is the READ-side qualification-input tuple's objectKey
+  // (integration_read_source_configs.object, migration 062). A second objectKey reference class —
+  // integration_write_target_configs.object (migration 064) — exists in the same database and this
+  // script never queries it. That must be a stated, findable residual note, not a silent gap.
+  test('states the integration_write_target_configs.object (migration 064) out-of-scope caveat, naming both the table and the migration', () => {
+    const note = RESIDUAL_NOTES.find((n) => n.id === 'integration_write_target_configs_object_deliberately_out_of_scope')
+    assert.ok(note, 'expected a RESIDUAL_NOTES entry documenting integration_write_target_configs.object as out of scope')
+    assert.match(note.description, /integration_write_target_configs/)
+    assert.match(note.description, /migration 064/)
+  })
+
+  test('the γ coverage blindSpot string also names integration_write_target_configs.object as out of scope (not just buried in residualNotes)', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({ schema, counts: ZERO_COUNTS })
+    const report = await buildReport({ exec, noPrivateOut: true })
+    assert.match(report.coverage.canonicalObjectKeyInventory.blindSpot, /integration_write_target_configs/)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -962,9 +1173,49 @@ describe('buildDryRunReport', () => {
     const exec = createFakeExec({ schema, counts: {} }, calls)
     const report = await buildDryRunReport({ exec })
     assert.equal(report.mode, 'dry-run')
+    assert.equal(report.probe, 'both')
     assert.equal(report.plan.kindInventory.status, 'ok')
     // Only schema-probe tags were called — no count.* tag.
     assert.ok(calls.every((c) => c.tag.startsWith('probe.')))
+  })
+
+  // `--probe` must scope `--dry-run` the same way it scopes report mode — otherwise a PR claiming
+  // "under --probe beta, no query naming integration_read_source_configs is ever issued — schema
+  // probe included" is false specifically in dry-run mode, where buildDryRunReport() used to always
+  // probe the FULL TABLE_SPECS regardless of the requested probe.
+  test('probe=beta scopes the DRY-RUN schema probe too: zero information_schema calls name integration_read_source_configs, and the objectKeyInventory plan is not_run', async () => {
+    const schema = cloneSchema()
+    const calls = []
+    const exec = createFakeExec({ schema, counts: {} }, calls)
+    const report = await buildDryRunReport({ exec, probe: 'beta' })
+    assert.equal(report.probe, 'beta')
+    assert.equal(report.plan.kindInventory.status, 'ok')
+    assert.equal(report.plan.objectKeyInventory.status, 'not_run')
+    const readSourceConfigCalls = calls.filter((c) => c.params && c.params[0] === 'integration_read_source_configs')
+    assert.deepEqual(readSourceConfigCalls, [])
+  })
+
+  test('probe=gamma scopes the DRY-RUN schema probe too: zero information_schema calls name integration_external_systems, and the kindInventory plan is not_run', async () => {
+    const schema = cloneSchema()
+    const calls = []
+    const exec = createFakeExec({ schema, counts: {} }, calls)
+    const report = await buildDryRunReport({ exec, probe: 'gamma' })
+    assert.equal(report.probe, 'gamma')
+    assert.equal(report.plan.objectKeyInventory.status, 'ok')
+    assert.equal(report.plan.kindInventory.status, 'not_run')
+    const externalSystemCalls = calls.filter((c) => c.params && c.params[0] === 'integration_external_systems')
+    assert.deepEqual(externalSystemCalls, [])
+  })
+
+  test('no executor + probe supplied: the static (no-DB) report still records the requested probe, even though nothing was probed', async () => {
+    const report = await buildDryRunReport({ exec: null, probe: 'beta' })
+    assert.equal(report.mode, 'dry-run-static')
+    assert.equal(report.probe, 'beta')
+  })
+
+  test('probe defaults to \'both\' when not supplied', async () => {
+    const report = await buildDryRunReport({ exec: null })
+    assert.equal(report.probe, 'both')
   })
 })
 

--- a/scripts/ops/gip-authority-substrate-inventory.test.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.test.mjs
@@ -1,6 +1,6 @@
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, symlinkSync, statSync, readlinkSync, rmSync, readdirSync } from 'node:fs'
+import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, symlinkSync, statSync, readlinkSync, rmSync, readdirSync, realpathSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -15,6 +15,8 @@ import {
   assertReadOnlyAllowlist,
   isSafeNonNegativeInteger,
   INVALID_COUNT_REASON,
+  runQuery,
+  probeColumns,
   probeSchema,
   buildPlan,
   bucketByRegistry,
@@ -140,6 +142,95 @@ describe('assertReadOnlyAllowlist', () => {
   test('accepts a SELECT with a single harmless trailing semicolon (or none at all)', () => {
     assert.doesNotThrow(() => assertReadOnlyAllowlist({ x: { sql: 'SELECT 1;', describe: 'x' } }))
     assert.doesNotThrow(() => assertReadOnlyAllowlist({ x: { sql: 'SELECT 1', describe: 'x' } }))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// QUERY_ALLOWLIST entries — deep freeze (#4603 P3). `Object.freeze(QUERY_ALLOWLIST)` at the
+// literal's own definition site only locks the OUTER object's key set — it does not freeze each
+// nested `{ sql, describe }` entry object. Proven live before the fix: an importer could run
+// `QUERY_ALLOWLIST['probe.columns'].sql = 'DELETE FROM integration_external_systems; -- pwned'`
+// and BOTH runQuery() and probeColumns() would hand that exact mutated string to the executor —
+// assertReadOnlyAllowlist() never re-runs after module load, so it would never catch this. This
+// describe block holds every entry to the SAME standard KNOWN_CERTIFIED_CONNECTOR_KINDS /
+// KNOWN_CANONICAL_OBJECT_KEYS / RESIDUAL_NOTES are already held to elsewhere in this file (a
+// mutation attempt throws, not just "is frozen" as a comment).
+// ---------------------------------------------------------------------------
+
+// Best-effort restore for a module-level singleton mutation attempt. When the fix is in place the
+// original assignment above already threw (nothing changed, so this is a silent no-op attempt
+// that itself throws — swallowed here on purpose). When the fix is ABSENT the assignment above
+// succeeded and corrupted shared state; this restores it so a discrimination run's failure surface
+// stays limited to the tests in this describe block instead of cascading into every test below it
+// in the file (which all reference the same QUERY_ALLOWLIST singleton via the fake-exec harness).
+function attemptRestore(entry, key, original) {
+  try {
+    entry[key] = original
+  } catch {
+    // frozen (fix present) — nothing was mutated, nothing to restore
+  }
+}
+
+describe('QUERY_ALLOWLIST entries are deep-frozen, not just the outer object (#4603 P3)', () => {
+  test('every entry object is independently frozen (structural, not per-tag)', () => {
+    for (const [tag, entry] of Object.entries(QUERY_ALLOWLIST)) {
+      assert.ok(Object.isFrozen(entry), `QUERY_ALLOWLIST["${tag}"] entry is not frozen`)
+    }
+  })
+
+  test('the exact mutation the owner\'s probe used throws (strict-mode ESM), and the entry is unchanged afterward', () => {
+    const original = QUERY_ALLOWLIST['probe.columns'].sql
+    try {
+      assert.throws(() => {
+        QUERY_ALLOWLIST['probe.columns'].sql = 'DELETE FROM integration_external_systems; -- pwned'
+      }, TypeError)
+      // Read back: the throw must have happened BEFORE the write took effect, not merely been
+      // thrown after a silent mutation already landed.
+      assert.equal(QUERY_ALLOWLIST['probe.columns'].sql, original)
+      assert.doesNotMatch(QUERY_ALLOWLIST['probe.columns'].sql, /DELETE|pwned/)
+    } finally {
+      attemptRestore(QUERY_ALLOWLIST['probe.columns'], 'sql', original)
+    }
+  })
+
+  test('describe is frozen too (not just sql — the whole entry object, no per-field carve-out)', () => {
+    const original = QUERY_ALLOWLIST['probe.table_exists'].describe
+    try {
+      assert.throws(() => {
+        QUERY_ALLOWLIST['probe.table_exists'].describe = 'SENTINEL_SHOULD_NEVER_STICK'
+      }, TypeError)
+      assert.equal(QUERY_ALLOWLIST['probe.table_exists'].describe, original)
+    } finally {
+      attemptRestore(QUERY_ALLOWLIST['probe.table_exists'], 'describe', original)
+    }
+  })
+
+  test('positive control: after a (failed) mutation attempt, runQuery()/probeColumns() still hand the CORRECT, original SQL to the executor', async () => {
+    const original = QUERY_ALLOWLIST['probe.columns'].sql
+    try {
+      let attemptFailed = false
+      try {
+        QUERY_ALLOWLIST['probe.columns'].sql = 'DELETE FROM integration_external_systems; -- pwned'
+      } catch {
+        attemptFailed = true
+      }
+      assert.ok(attemptFailed, 'setup invariant broken: the mutation attempt above must throw for this positive control to be meaningful')
+
+      const received = []
+      const exec = async (sql, params) => {
+        received.push(sql)
+        return { rows: [{ column_name: 'kind' }] }
+      }
+      await runQuery(exec, 'probe.columns', ['integration_external_systems'])
+      await probeColumns(exec, 'integration_external_systems', ['kind'])
+      assert.equal(received.length, 2)
+      for (const sql of received) {
+        assert.equal(sql, original)
+        assert.doesNotMatch(sql, /DELETE|pwned/)
+      }
+    } finally {
+      attemptRestore(QUERY_ALLOWLIST['probe.columns'], 'sql', original)
+    }
   })
 })
 
@@ -2050,36 +2141,86 @@ describe('stderr values-free discipline — real subprocess (#4603 P2(a))', () =
   })
 
   test('forced `pg` driver-load failure: exit 1; stderr non-empty (positive control); the absolute path fragment PROVEN present in the raw import error is absent from both stdout and stderr', async () => {
-    // Positive control FIRST — prove the raw failure createPgExecutor() hits in this exact hermetic
-    // environment (no node_modules: the real CI workflow for this file — see
-    // .github/workflows/gip-authority-substrate-inventory.yml — checks out and runs `node --test`
-    // directly, no install step) really does carry an absolute path in its .message. If this
-    // control does not hold, the redaction assertions below would be vacuous — a probe that leaks
-    // nothing proves nothing.
-    let rawMessage = null
+    // #4603 P3(b): this control does NOT rely on `pg` being genuinely absent from the ambient
+    // dev/CI environment. The previous shape did — `await import('pg')` here (resolved from THIS
+    // test file's own location) and `runCliSubprocess([], env)` (resolved from SCRIPT_PATH,
+    // scripts/ops/ — the same directory) happened to coincide, but only because `pg` is a real
+    // dependency of packages/core-backend/package.json; a contributor who ran `pnpm install` at
+    // the repo root (an ordinary, unremarkable step) and then ran this test file directly would
+    // resolve `pg` successfully via workspace hoisting, and the whole point of this test — proving
+    // the redaction actually engaged — would silently stop being exercised while still reading
+    // green (a false-negative-shaped risk this repo's doctrine treats as a defect, not a nuisance:
+    // see feedback_positive_control_not_failclosed.md). The CI workflow itself never installs
+    // (checkout + setup-node + `node --test`, no install step — see
+    // .github/workflows/gip-authority-substrate-inventory.yml), so CI never actually saw this gap;
+    // this only bites a contributor running the suite locally after `pnpm install`.
+    //
+    // Fix: measure the raw `import('pg')` failure and the CLI's redaction of it in an ISOLATED
+    // directory with no `node_modules` anywhere in its ancestor chain up to the filesystem root —
+    // a fresh `mkdtemp` under `os.tmpdir()`, never a location inside this repo/workspace. Node's
+    // ESM bare-specifier resolution walks up from the IMPORTING FILE's own directory (NOT
+    // `process.cwd()`, and NOT `NODE_PATH` — that's CJS-only) looking for `node_modules`, so a
+    // copy of the script placed there resolves `pg` deterministically the same way regardless of
+    // whether the repo's own workspace has `pg` installed. This makes the control robust to a
+    // resolvable `pg` rather than merely documenting the fragility.
+    // realpathSync is REQUIRED here, not cosmetic: os.tmpdir() resolves under /var/folders on
+    // macOS, which is itself a symlink to /private/var/folders. The script's own isEntry check
+    // (`path.resolve(argv[1]) === fileURLToPath(import.meta.url)`) compares an UN-resolved argv[1]
+    // against Node's REALPATH-resolved import.meta.url — on an unresolved symlinked path those
+    // never match, isEntry is false, and main() never runs at all (silent exit 0, no output),
+    // which would make every assertion below either vacuous or wrong for the wrong reason. Calling
+    // realpathSync() up front makes the path we pass to spawnSync the SAME string Node's loader
+    // will report back, so isEntry evaluates true exactly as it does for the real script at
+    // SCRIPT_PATH (which is already realpath-stable, being inside this checkout). This is a
+    // test-construction fix, not a claim that the source's isEntry check itself is safe against
+    // symlinked invocation in general — see this PR's disclosure of that as a separate, narrower,
+    // non-blocking observation (does not affect this repo's CI, which runs on ubuntu-latest where
+    // /tmp is a real directory, not a symlink).
+    const isolatedDir = realpathSync(mkdtempSync(path.join(tmpdir(), 'gip-authority-inventory-pgcontrol-')))
     try {
-      await import('pg')
-    } catch (e) {
-      rawMessage = e.message
-    }
-    assert.ok(
-      rawMessage,
-      'control failed: `pg` imported successfully in this test environment — the driver-load-failure scenario below did not actually occur, so its redaction assertions would be vacuous',
-    )
-    assert.ok(rawMessage.includes(__dirname), `control failed: raw import error does not carry the expected absolute path fragment — got: ${rawMessage}`)
+      const isolatedScriptPath = path.join(isolatedDir, 'gip-authority-substrate-inventory.mjs')
+      // The script's only non-builtin import anywhere in its source is the lazy `import('pg')`
+      // inside createPgExecutor() (see the source's "Lazy import" comment) — no relative imports
+      // to sibling repo files — so a standalone byte-for-byte copy is a faithful, self-contained
+      // subject; confirmed by this same copy running correctly below (help text, exit codes).
+      writeFileSync(isolatedScriptPath, readFileSync(SCRIPT_PATH, 'utf8'))
 
-    const env = { PATH: process.env.PATH, DATABASE_URL: 'postgres://sentinel-host-should-never-appear/db' }
-    const res = runCliSubprocess([], env)
-    assert.equal(res.status, 1)
-    assert.ok(res.stderr.length > 0, 'positive control failed: stderr was empty')
-    assert.equal(countOccurrences(res.stderr, __dirname), 0, `path fragment leaked into stderr: ${res.stderr}`)
-    assert.equal(countOccurrences(res.stdout, __dirname), 0, `path fragment leaked into stdout: ${res.stdout}`)
-    assert.equal(
-      countOccurrences(res.stderr, 'sentinel-host-should-never-appear'),
-      0,
-      `DATABASE_URL host leaked into stderr: ${res.stderr}`,
-    )
-    assert.equal(res.stderr.trim(), `[gip-authority-substrate-inventory] ERROR: ${CLI_ERROR_REASON.RUNTIME_FAILURE}`)
+      // Positive control FIRST — prove the raw failure createPgExecutor() would hit really does
+      // carry an absolute path, measured from the SAME isolated location the CLI copy below runs
+      // from (not this test file's own location, which is a different, incidental directory).
+      const rawProbePath = path.join(isolatedDir, 'raw-pg-import-probe.mjs')
+      writeFileSync(
+        rawProbePath,
+        "import('pg').then(() => { process.stdout.write('IMPORTED_OK') }, (e) => { process.stdout.write('FAILED:' + e.message) })\n",
+      )
+      const probeRes = spawnSync(process.execPath, [rawProbePath], { env: { PATH: process.env.PATH }, encoding: 'utf8', timeout: 10_000 })
+      const rawOut = probeRes.stdout ?? ''
+      assert.ok(
+        rawOut.startsWith('FAILED:'),
+        `control failed: \`pg\` imported successfully from the isolated directory — the driver-load-failure scenario below did not actually occur, so its redaction assertions would be vacuous. Raw probe stdout: ${rawOut}`,
+      )
+      assert.ok(
+        rawOut.includes(isolatedDir),
+        `control failed: raw import error does not carry the expected isolated-directory path fragment — got: ${rawOut}`,
+      )
+
+      const env = { PATH: process.env.PATH, DATABASE_URL: 'postgres://sentinel-host-should-never-appear/db' }
+      const res = spawnSync(process.execPath, [isolatedScriptPath], { env, encoding: 'utf8', timeout: 10_000 })
+      const stdout = res.stdout ?? ''
+      const stderr = res.stderr ?? ''
+      assert.equal(res.status, 1)
+      assert.ok(stderr.length > 0, 'positive control failed: stderr was empty')
+      assert.equal(countOccurrences(stderr, isolatedDir), 0, `path fragment leaked into stderr: ${stderr}`)
+      assert.equal(countOccurrences(stdout, isolatedDir), 0, `path fragment leaked into stdout: ${stdout}`)
+      assert.equal(
+        countOccurrences(stderr, 'sentinel-host-should-never-appear'),
+        0,
+        `DATABASE_URL host leaked into stderr: ${stderr}`,
+      )
+      assert.equal(stderr.trim(), `[gip-authority-substrate-inventory] ERROR: ${CLI_ERROR_REASON.RUNTIME_FAILURE}`)
+    } finally {
+      rmSync(isolatedDir, { recursive: true, force: true })
+    }
   })
 
   // --help is the one success-path (exit 0) public-output surface nothing else in this file
@@ -2165,6 +2306,129 @@ describe('main() exit-code contract (#4603 P2(b))', () => {
   // stays green, because none of them called main(). Reverted after confirming red; not re-run here
   // because this file has no automated mutation-testing harness, matching the existing
   // "Mutation-confirmed (#4603 P2)" comment style used elsewhere in this file for the same reason.
+})
+
+// ---------------------------------------------------------------------------
+// safeClose() — pin the rejection-swallow through the SAME injectable createExecutor seam the
+// exit-code contract tests above use (#4603 HOLD, accepted-gap item). Before this block, both of
+// main()'s `finally { await safeClose(executor) }` sites (the --dry-run branch and the real-report
+// branch) had zero coverage: an isolated mutation to bare `await executor.close()` at either site
+// left all 138 pre-existing tests green. That gap is genuine, not cosmetic — via this exact seam,
+// HEAD gives `{closeCalled:true, resolvedExitCode:0, mainRejectedWith:null}` for a rejecting
+// close(), while a bare-`await executor.close()` version lets that rejection escape main()'s own
+// try/catch from OUTSIDE (a `finally` block's own throw/reject supersedes whatever the try block
+// was about to return), reaching the caller as an unhandled rejection instead of the exit code the
+// run had already determined.
+//
+// The primary assertion in both tests below is that main() RESOLVES (does not reject) with the
+// exit code its own branch already computed — not merely that stderr stays clean. A rejecting
+// `close()` escaping main() would print on the REAL stderr file descriptor outside of any
+// process.stderr.write monkeypatch (see the "REAL SUBPROCESS PROOF" comment above the real-CLI
+// describe block for the same point made about the isEntry reject handler) — an in-process stderr
+// capture structurally cannot observe that failure mode, so resolution is the load-bearing check
+// and the stderr assertion is secondary defense-in-depth for the swallow itself.
+// ---------------------------------------------------------------------------
+
+async function withCapturedStdoutAndStderr(fn) {
+  const originalOut = process.stdout.write.bind(process.stdout)
+  const originalErr = process.stderr.write.bind(process.stderr)
+  let outBuf = ''
+  let errBuf = ''
+  process.stdout.write = (chunk) => {
+    outBuf += typeof chunk === 'string' ? chunk : chunk.toString()
+    return true
+  }
+  process.stderr.write = (chunk) => {
+    errBuf += typeof chunk === 'string' ? chunk : chunk.toString()
+    return true
+  }
+  try {
+    const result = await fn()
+    return { result, stdout: outBuf, stderr: errBuf }
+  } finally {
+    process.stdout.write = originalOut
+    process.stderr.write = originalErr
+  }
+}
+
+// Builds a createExecutor whose `close()` always rejects with a marker that must never leak
+// anywhere (a stand-in for safeClose()'s own worked example: `CLOSE_FAIL_MARKER…
+// host=customer-db.internal`, an underlying DB-close error carrying a hostname). Tracks whether
+// close() was actually invoked, so a version of main() that simply never calls close() cannot pass
+// these tests vacuously.
+function rejectingCloseExecutorFactory(exec) {
+  const state = { closeCalled: false }
+  const createExecutor = async () => ({
+    exec,
+    close: () => {
+      state.closeCalled = true
+      return Promise.reject(new Error('CLOSE_FAIL_MARKER — a real close error would carry operational detail like host=customer-db.internal here'))
+    },
+  })
+  return { createExecutor, state }
+}
+
+describe('safeClose() rejection-swallow — pinned through the createExecutor seam (#4603 HOLD)', () => {
+  test('--dry-run branch (L1112-ish finally): a rejecting executor.close() does not reject main(), and the exit code / stdout report are unaffected', async () => {
+    const exec = async () => ({ rows: [] })
+    const { createExecutor, state } = rejectingCloseExecutorFactory(exec)
+
+    let mainRejectedWith = null
+    let resolvedExitCode = null
+    const { stdout, stderr } = await withCapturedStdoutAndStderr(async () => {
+      try {
+        resolvedExitCode = await main(['--dry-run'], { DATABASE_URL: 'postgres://fixture/db' }, { createExecutor })
+      } catch (e) {
+        mainRejectedWith = e
+      }
+    })
+
+    assert.equal(mainRejectedWith, null, `main() rejected instead of resolving: ${mainRejectedWith && mainRejectedWith.stack}`)
+    assert.equal(resolvedExitCode, 0, '--dry-run with no schema issues should still resolve exit 0 despite the close() failure')
+    assert.ok(state.closeCalled, 'setup invariant broken: executor.close() was never called — this test would pass vacuously otherwise')
+    assert.ok(stdout.length > 0, 'the dry-run report should still have been printed to stdout')
+    assert.equal(countOccurrences(stderr, 'CLOSE_FAIL_MARKER'), 0, `close() rejection marker leaked onto stderr: ${stderr}`)
+    assert.equal(countOccurrences(stderr, 'customer-db.internal'), 0, `close() rejection detail leaked onto stderr: ${stderr}`)
+  })
+
+  test('real-report branch (L1149-ish finally): a rejecting executor.close() does not reject main(), and the exit code / stdout report are unaffected', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({ schema, counts: ZERO_COUNTS })
+    const { createExecutor, state } = rejectingCloseExecutorFactory(exec)
+
+    let mainRejectedWith = null
+    let resolvedExitCode = null
+    const { stdout, stderr } = await withCapturedStdoutAndStderr(async () => {
+      try {
+        resolvedExitCode = await main(['--no-private-out'], { DATABASE_URL: 'postgres://fixture/db' }, { createExecutor })
+      } catch (e) {
+        mainRejectedWith = e
+      }
+    })
+
+    assert.equal(mainRejectedWith, null, `main() rejected instead of resolving: ${mainRejectedWith && mainRejectedWith.stack}`)
+    assert.equal(resolvedExitCode, 0, 'nothing owed + --no-private-out should still resolve exit 0 despite the close() failure')
+    assert.ok(state.closeCalled, 'setup invariant broken: executor.close() was never called — this test would pass vacuously otherwise')
+    assert.ok(stdout.length > 0, 'the report should still have been printed to stdout')
+    assert.equal(countOccurrences(stderr, 'CLOSE_FAIL_MARKER'), 0, `close() rejection marker leaked onto stderr: ${stderr}`)
+    assert.equal(countOccurrences(stderr, 'customer-db.internal'), 0, `close() rejection detail leaked onto stderr: ${stderr}`)
+  })
+
+  // Discrimination (run manually, not automated — this file has no mutation-testing harness; same
+  // documentation style as the other "Mutation-confirmed" comments in this file), confirmed
+  // 2026-07-25: replacing `await safeClose(executor)` with a bare `await executor.close()` at ONLY
+  // the --dry-run site (~L1113) reds exactly the first test above (main() rejects:
+  // mainRejectedWith !== null) — 143/144, nothing else. Reverting that and doing the same at ONLY
+  // the real-report site (~L1150) reds the second test above AND the pre-existing 'forced `pg`
+  // driver-load failure' real-subprocess test (142/144) — NOT test pollution: at that site
+  // `executor` is declared `let executor` (no initial value) rather than `let executor = null`
+  // (the --dry-run site's declaration), so when createExecutor() itself throws before ever
+  // assigning `executor` — exactly what the real `pg`-absent subprocess test forces — a bare
+  // `executor.close()` throws on undefined, escapes main()'s finally as a second rejection, and
+  // the entry-point's last-resort reject handler (isEntry block, bottom of source) prints ITS OWN
+  // "ERROR: RUNTIME_FAILURE" line on top of the one main()'s own catch already wrote — the exact
+  // "printed that marker twice" failure mode the reviewer's probe described. Independent
+  // confirmation from a pre-existing test, not a designed assertion of this new describe block.
 })
 
 // ---------------------------------------------------------------------------

--- a/scripts/ops/gip-authority-substrate-inventory.test.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.test.mjs
@@ -1,6 +1,6 @@
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync } from 'node:fs'
+import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, symlinkSync, statSync, readlinkSync, rmSync, readdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -12,6 +12,8 @@ import {
   EXTERNAL_SYSTEM_STATUSES,
   READ_SOURCE_CONFIG_STATUSES,
   assertReadOnlyAllowlist,
+  isSafeNonNegativeInteger,
+  INVALID_COUNT_REASON,
   probeSchema,
   buildPlan,
   bucketByRegistry,
@@ -24,8 +26,10 @@ import {
   RESIDUAL_NOTES,
   shouldWritePrivateArtifact,
   buildPrivateArtifactContent,
+  writePrivateArtifact,
   buildReport,
   buildDryRunReport,
+  renderHumanSummary,
   parseArgs,
   REPO_ROOT,
   DEFAULT_PRIVATE_OUTPUT_DIR,
@@ -387,6 +391,144 @@ describe('bucketByRegistry', () => {
     assert.equal(counts.totalRows, 0)
     assert.equal(counts.registeredDistinctCount, 0)
     assert.equal(counts.unregisteredDistinctCount, 0)
+  })
+
+  test("returns { status: 'ok', counts, detail } on success — status is always present, never absent from a good result", () => {
+    const result = bucketByRegistry([{ kind: 'a', n: 1 }], [], { valueKey: 'kind' })
+    assert.equal(result.status, 'ok')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isSafeNonNegativeInteger — #4603 owner-review P1(1): `Number(value) || 0` used to turn a
+// missing, malformed, or non-finite count into a silent ZERO — the single most dangerous wrong
+// answer for a precondition probe ("0 unregistered" is exactly the green light Wave 2 would
+// consume). Every listed adversarial input must be rejected; a genuine 0 is the positive control
+// proving the predicate does not just reject everything.
+// ---------------------------------------------------------------------------
+
+describe('isSafeNonNegativeInteger — strict accept: non-negative safe integers only', () => {
+  const REJECT = [
+    ['undefined', undefined],
+    ['null', null],
+    ["''", ''],
+    ["'abc'", 'abc'],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['-Infinity', -Infinity],
+    ['-1', -1],
+    ['1.5', 1.5],
+    ['2**53 (one past MAX_SAFE_INTEGER — not representable exactly, must not be trusted)', 2 ** 53],
+    ["'3' (a numeric STRING — real int4 rows come back as a JS number already; do not coerce)", '3'],
+    ['true', true],
+    ['[]', []],
+    ['{}', {}],
+  ]
+  for (const [label, value] of REJECT) {
+    test(`rejects ${label}`, () => {
+      assert.equal(isSafeNonNegativeInteger(value), false)
+    })
+  }
+
+  test('POSITIVE CONTROL: accepts a genuine 0 — proves the predicate is not merely "reject everything"', () => {
+    assert.equal(isSafeNonNegativeInteger(0), true)
+  })
+
+  test('accepts ordinary positive safe integers', () => {
+    assert.equal(isSafeNonNegativeInteger(1), true)
+    assert.equal(isSafeNonNegativeInteger(42), true)
+    assert.equal(isSafeNonNegativeInteger(Number.MAX_SAFE_INTEGER), true)
+  })
+})
+
+describe('bucketByRegistry — fails CLOSED (never defaults to 0) on an anomalous row count', () => {
+  const BAD_COUNTS = [undefined, null, '', 'abc', NaN, Infinity, -1, 1.5, 2 ** 53]
+  for (const bad of BAD_COUNTS) {
+    test(`row count ${JSON.stringify(bad)} -> { status: 'invalid_count' }, never a silently-zeroed row`, () => {
+      const result = bucketByRegistry([{ kind: 'a', n: bad }], [], { valueKey: 'kind' })
+      assert.equal(result.status, 'invalid_count')
+      assert.equal(result.reason, INVALID_COUNT_REASON)
+      assert.equal(result.counts, undefined, 'an invalid result must not also carry a usable counts object')
+    })
+  }
+
+  test('a genuine 0 count is still expressible — the positive control at the bucketing layer, not just the predicate layer', () => {
+    const result = bucketByRegistry([{ kind: 'a', n: 0 }], [], { valueKey: 'kind' })
+    assert.equal(result.status, 'ok')
+    assert.equal(result.counts.totalRows, 0)
+    assert.equal(result.counts.unregisteredDistinctCount, 1)
+  })
+
+  test('one bad row among otherwise-good rows invalidates the WHOLE bucket (no partial "mostly trustworthy" counts)', () => {
+    const result = bucketByRegistry(
+      [{ kind: 'a', n: 3 }, { kind: 'b', n: undefined }, { kind: 'c', n: 2 }],
+      [],
+      { valueKey: 'kind' },
+    )
+    assert.equal(result.status, 'invalid_count')
+  })
+})
+
+describe('executeKindInventoryPlan / executeObjectKeyInventoryPlan: an invalid row count is UNAVAILABLE -> INCONCLUSIVE, never a silent 0', () => {
+  test('β allStatuses count anomalous -> whole kindInventory unavailable, verdict INCONCLUSIVE (through buildReport end to end)', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({
+      schema,
+      counts: {
+        ...ZERO_COUNTS,
+        'count.external_system_kinds_all': [{ kind: 'x', n: undefined }],
+        'count.external_system_kinds_active': [{ kind: 'x', n: 1 }],
+      },
+    })
+    const report = await buildReport({ exec, noPrivateOut: true })
+    assert.equal(report.coverage.connectorKindInventory.status, 'unavailable')
+    assert.equal(report.coverage.connectorKindInventory.reason, INVALID_COUNT_REASON)
+    assert.equal(report.verdicts.connectorKind.verdict, 'INCONCLUSIVE')
+  })
+
+  test('γ approved-status count anomalous -> whole canonicalObjectKeyInventory unavailable, verdict INCONCLUSIVE (through buildReport end to end)', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({
+      schema,
+      counts: {
+        ...ZERO_COUNTS,
+        'count.read_source_config_objects_by_status': [{ object: 'material', status: 'approved', n: NaN }],
+      },
+    })
+    const report = await buildReport({ exec, noPrivateOut: true })
+    assert.equal(report.coverage.canonicalObjectKeyInventory.status, 'unavailable')
+    assert.equal(report.coverage.canonicalObjectKeyInventory.reason, INVALID_COUNT_REASON)
+    assert.equal(report.verdicts.canonicalObjectKey.verdict, 'INCONCLUSIVE')
+  })
+
+  test("γ divergence count anomalous -> divergence sub-field unavailable, verdict INCONCLUSIVE (byStatus itself stays 'ok')", async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({
+      schema,
+      counts: {
+        ...ZERO_COUNTS,
+        'count.read_source_config_object_config_divergence': [{ n: '0' }], // numeric STRING, not a number
+      },
+    })
+    const report = await buildReport({ exec, noPrivateOut: true })
+    assert.equal(report.coverage.canonicalObjectKeyInventory.status, 'ok')
+    assert.equal(report.coverage.canonicalObjectKeyInventory.objectVsConfigObjectDivergence.status, 'unavailable')
+    assert.equal(report.coverage.canonicalObjectKeyInventory.objectVsConfigObjectDivergence.reason, INVALID_COUNT_REASON)
+    assert.equal(report.verdicts.canonicalObjectKey.verdict, 'INCONCLUSIVE')
+  })
+
+  test('γ divergence query returning zero rows (never happens for a real COUNT(*), but must not default to 0 if it did) -> unavailable, INCONCLUSIVE', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({
+      schema,
+      counts: {
+        ...ZERO_COUNTS,
+        'count.read_source_config_object_config_divergence': [],
+      },
+    })
+    const report = await buildReport({ exec, noPrivateOut: true })
+    assert.equal(report.coverage.canonicalObjectKeyInventory.objectVsConfigObjectDivergence.status, 'unavailable')
+    assert.equal(report.verdicts.canonicalObjectKey.verdict, 'INCONCLUSIVE')
   })
 })
 
@@ -917,6 +1059,301 @@ describe('values-free public output (sentinel injection)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// CLOSED VALUE DOMAIN — #4603 owner-review P2(a). The exact-key-set walk above
+// (assertPublicReportKeySetsExactly) proves every KEY in the report is from the closed set the
+// source can produce, but says nothing about VALUES: `covers`/`blindSpot` are hardcoded object-
+// literal strings inside buildReport() — not derived from any row, not covered by the
+// sentinel-substring scan (which only checks strings that flow THROUGH the row-count pipeline).
+// Replace one with an arbitrary raw string and every existing test, including the key-set walk,
+// stays green, because nothing ever checks what that field actually SAYS. Verified directly
+// against 18f503bf0 — see the PR body / commit message for the two pasted mutation-probe runs.
+//
+// The check: collect every STRING leaf of a full report, normalize embedded digit runs to a
+// single '#' (every dynamic component this module ever interpolates into a sentence is a
+// bucketByRegistry-validated non-negative safe integer — never raw DB content; see
+// isSafeNonNegativeInteger), and assert the resulting SET equals a hand-frozen expected array,
+// one per fixture scenario. Set EQUALITY (not membership) means a substitution, a removal, or any
+// new unauthored prose all fail the same way: a mismatch. Every NUMBER leaf is independently
+// asserted to be a safe non-negative integer, and every BOOLEAN leaf is enumerated by position.
+//
+// The expected arrays below were captured by running buildReport() once against the FIXED source
+// (see the PR body for the capture command) and are pasted here as FROZEN literals — not
+// re-derived at test time — so a later source mutation (accidental or adversarial) diverges from
+// this independent frozen copy instead of being validated against itself.
+// ---------------------------------------------------------------------------
+
+function normalizeDigits(s) {
+  return s.replace(/\d+/g, '#')
+}
+
+function collectLeavesByType(node, out) {
+  if (node === null || node === undefined) return
+  if (Array.isArray(node)) {
+    for (const v of node) collectLeavesByType(v, out)
+    return
+  }
+  if (typeof node === 'object') {
+    for (const k of Object.keys(node)) collectLeavesByType(node[k], out)
+    return
+  }
+  if (typeof node === 'string') out.strings.push(node)
+  else if (typeof node === 'number') out.numbers.push(node)
+  else if (typeof node === 'boolean') out.booleans.push(node)
+  else throw new Error(`unexpected leaf type ${typeof node}: ${JSON.stringify(node)}`)
+}
+
+// Every number leaf anywhere in the report must be a non-negative safe integer — the same
+// discipline isSafeNonNegativeInteger() enforces at the row-count boundary, re-asserted here at
+// the OUTPUT boundary so a bug anywhere in between (not just at ingestion) is still caught.
+function assertClosedValueDomain(report, expectedNormalizedStrings) {
+  const out = { strings: [], numbers: [], booleans: [] }
+  collectLeavesByType(report, out)
+  for (const n of out.numbers) {
+    assert.ok(
+      Number.isSafeInteger(n) && n >= 0,
+      `number leaf ${n} is not a non-negative safe integer — every number in public output must come from a validated count`,
+    )
+  }
+  const normalized = [...new Set(out.strings.map(normalizeDigits))].sort()
+  assert.deepEqual(normalized, [...expectedNormalizedStrings].sort())
+}
+
+const EXPECTED_NOTHING_OWED = [
+  '# distinct kind string(s) observed across integration_external_systems, all already in the (currently #-entry) known registry',
+  '# distinct objectKey(s) referenced by approved read-source configs, all already in the (currently #-entry) known registry',
+  '#-#-#T#:#:#.#Z',
+  "A second objectKey reference class exists in the same database: integration_write_target_configs.object (migration #, External-API WRITE self-service W#). This inventory does NOT probe it. Reason: the ledger's decision (γ) scope (§# step #.#, §#.# B-#) is the READ-side qualification-input tuple's objectKey, and the task this script was built for is scoped to that tuple; the write-target config table is a separate, config-time-only surface (no dry-run/apply/runtime route per its migration header) that decision (γ)'s registry may also need to cover eventually, but that is a follow-up inventory scope decision, not an oversight in this one. A canonical object referenced ONLY by a write-target config (never by a read-source config) is invisible to this report.",
+  "Both KNOWN_CERTIFIED_CONNECTOR_KINDS and KNOWN_CANONICAL_OBJECT_KEYS are empty. Neither decision (β) nor decision (γ) has produced a first-party registry yet, so today every distinct value observed is reported as unregistered — that is the correct, honest state, not a defect. This inventory exists to produce the raw list a human uses to populate those registries; it never populates them itself.",
+  'CANONICAL_OBJECT_BACKFILL_NOT_REQUIRED_WITHIN_COVERAGE',
+  'CONNECTOR_KIND_MAPPING_NOT_REQUIRED_WITHIN_COVERAGE',
+  'DB rows only, in the ONE connected database, at the moment queried. Says nothing about kinds referenced only in code/fixtures, or about a different deployment/database this run was not pointed at.',
+  'DB rows only, in the ONE connected database. A canonical object referenced by a still-in-development (never-saved) config, or by a config in a DIFFERENT database this run was not pointed at, is invisible here. Also deliberately out of scope: integration_write_target_configs.object (migration #) — a second objectKey reference class in the same database this report never queries; see residualNotes.',
+  'This script has only ever been run against a hermetic fake executor (tests) and, if noted in the PR, a local/CI fixture database — never a customer deployment. Connecting to one is a separate ops-gated read-only authorization this task does not carry.',
+  'a zero known-registry size makes this trivially true today — see residualNotes',
+  'both',
+  "computeObjectKeyVerdict() is scoped to status='approved' only, matching the task's literal scope ('approved read-source configs'). draft/retired counts are still reported under byStatus for completeness, but a draft config can be approved after this inventory runs — decision (γ)'s own 'before activation' framing means the approved-only headline can understate the eventual backfill list; re-run before activation, not once.",
+  "distinct integration_external_systems.kind strings and their row counts — the raw material for decision (β)'s explicit alias map and migration list. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  "distinct integration_read_source_configs.object values (the ledger's `objectKey` tuple term) referenced by configs, split by status — the raw material for decision (γ)'s missing-reference and backfill lists. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  'draft_and_retired_object_keys_excluded_from_the_headline_verdict',
+  'integration_write_target_configs_object_deliberately_out_of_scope',
+  'known_registries_empty_by_design',
+  'no_customer_deployment_connection',
+  'ok',
+  'report',
+  'skipped_by_flag',
+]
+
+const EXPECTED_SOMETHING_OWED = [
+  '# of # distinct kind string(s) are not in the known registry (size #) — an explicit alias map / migration decision (β) is needed before these can bind under GIP',
+  '# of # distinct objectKey(s) referenced by approved configs are not in the known registry (size #) — inventory + backfill of these is required BEFORE activation per decision (γ)',
+  '#-#-#T#:#:#.#Z',
+  "A second objectKey reference class exists in the same database: integration_write_target_configs.object (migration #, External-API WRITE self-service W#). This inventory does NOT probe it. Reason: the ledger's decision (γ) scope (§# step #.#, §#.# B-#) is the READ-side qualification-input tuple's objectKey, and the task this script was built for is scoped to that tuple; the write-target config table is a separate, config-time-only surface (no dry-run/apply/runtime route per its migration header) that decision (γ)'s registry may also need to cover eventually, but that is a follow-up inventory scope decision, not an oversight in this one. A canonical object referenced ONLY by a write-target config (never by a read-source config) is invisible to this report.",
+  "Both KNOWN_CERTIFIED_CONNECTOR_KINDS and KNOWN_CANONICAL_OBJECT_KEYS are empty. Neither decision (β) nor decision (γ) has produced a first-party registry yet, so today every distinct value observed is reported as unregistered — that is the correct, honest state, not a defect. This inventory exists to produce the raw list a human uses to populate those registries; it never populates them itself.",
+  'CANONICAL_OBJECT_BACKFILL_REQUIRED',
+  'CONNECTOR_KIND_MAPPING_REQUIRED',
+  'DB rows only, in the ONE connected database, at the moment queried. Says nothing about kinds referenced only in code/fixtures, or about a different deployment/database this run was not pointed at.',
+  'DB rows only, in the ONE connected database. A canonical object referenced by a still-in-development (never-saved) config, or by a config in a DIFFERENT database this run was not pointed at, is invisible here. Also deliberately out of scope: integration_write_target_configs.object (migration #) — a second objectKey reference class in the same database this report never queries; see residualNotes.',
+  'This script has only ever been run against a hermetic fake executor (tests) and, if noted in the PR, a local/CI fixture database — never a customer deployment. Connecting to one is a separate ops-gated read-only authorization this task does not carry.',
+  'both',
+  "computeObjectKeyVerdict() is scoped to status='approved' only, matching the task's literal scope ('approved read-source configs'). draft/retired counts are still reported under byStatus for completeness, but a draft config can be approved after this inventory runs — decision (γ)'s own 'before activation' framing means the approved-only headline can understate the eventual backfill list; re-run before activation, not once.",
+  "distinct integration_external_systems.kind strings and their row counts — the raw material for decision (β)'s explicit alias map and migration list. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  "distinct integration_read_source_configs.object values (the ledger's `objectKey` tuple term) referenced by configs, split by status — the raw material for decision (γ)'s missing-reference and backfill lists. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  'draft_and_retired_object_keys_excluded_from_the_headline_verdict',
+  'incomplete_owed_disabled',
+  'integration_write_target_configs_object_deliberately_out_of_scope',
+  'known_registries_empty_by_design',
+  'no_customer_deployment_connection',
+  'ok',
+  'raw kind strings are in the private artefact, if one was written — see privateArtifact',
+  'raw objectKey strings are in the private artefact, if one was written — see privateArtifact',
+  'report',
+]
+
+const EXPECTED_UNAVAILABLE_AND_NOT_RUN = [
+  '# of # distinct kind string(s) are not in the known registry (size #) — an explicit alias map / migration decision (β) is needed before these can bind under GIP',
+  '#-#-#T#:#:#.#Z',
+  "A second objectKey reference class exists in the same database: integration_write_target_configs.object (migration #, External-API WRITE self-service W#). This inventory does NOT probe it. Reason: the ledger's decision (γ) scope (§# step #.#, §#.# B-#) is the READ-side qualification-input tuple's objectKey, and the task this script was built for is scoped to that tuple; the write-target config table is a separate, config-time-only surface (no dry-run/apply/runtime route per its migration header) that decision (γ)'s registry may also need to cover eventually, but that is a follow-up inventory scope decision, not an oversight in this one. A canonical object referenced ONLY by a write-target config (never by a read-source config) is invisible to this report.",
+  "Both KNOWN_CERTIFIED_CONNECTOR_KINDS and KNOWN_CANONICAL_OBJECT_KEYS are empty. Neither decision (β) nor decision (γ) has produced a first-party registry yet, so today every distinct value observed is reported as unregistered — that is the correct, honest state, not a defect. This inventory exists to produce the raw list a human uses to populate those registries; it never populates them itself.",
+  'CONNECTOR_KIND_MAPPING_REQUIRED',
+  'DB rows only, in the ONE connected database, at the moment queried. Says nothing about kinds referenced only in code/fixtures, or about a different deployment/database this run was not pointed at.',
+  'DB rows only, in the ONE connected database. A canonical object referenced by a still-in-development (never-saved) config, or by a config in a DIFFERENT database this run was not pointed at, is invisible here. Also deliberately out of scope: integration_write_target_configs.object (migration #) — a second objectKey reference class in the same database this report never queries; see residualNotes.',
+  'This script has only ever been run against a hermetic fake executor (tests) and, if noted in the PR, a local/CI fixture database — never a customer deployment. Connecting to one is a separate ops-gated read-only authorization this task does not carry.',
+  'beta',
+  "computeObjectKeyVerdict() is scoped to status='approved' only, matching the task's literal scope ('approved read-source configs'). draft/retired counts are still reported under byStatus for completeness, but a draft config can be approved after this inventory runs — decision (γ)'s own 'before activation' framing means the approved-only headline can understate the eventual backfill list; re-run before activation, not once.",
+  "distinct integration_external_systems.kind strings and their row counts — the raw material for decision (β)'s explicit alias map and migration list. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  "distinct integration_read_source_configs.object values (the ledger's `objectKey` tuple term) referenced by configs, split by status — the raw material for decision (γ)'s missing-reference and backfill lists. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  'draft_and_retired_object_keys_excluded_from_the_headline_verdict',
+  'incomplete_owed_disabled',
+  "integration_external_systems.status column not found (probed via information_schema.tables/.columns, table_schema='public', as the DATABASE_URL role — a non-public search_path or missing SELECT/USAGE privileges reports the same as a genuinely absent object) — cannot separate active-only from all-statuses",
+  'integration_write_target_configs_object_deliberately_out_of_scope',
+  'known_registries_empty_by_design',
+  'no_customer_deployment_connection',
+  'not_run',
+  'ok',
+  'raw kind strings are in the private artefact, if one was written — see privateArtifact',
+  'report',
+  'unavailable',
+]
+
+const EXPECTED_DIVERGENCE_POSITIVE = [
+  '# distinct kind string(s) observed across integration_external_systems, all already in the (currently #-entry) known registry',
+  "# row(s) have integration_read_source_configs.object disagreeing with config->>'object' — a backfill/mapping decision built from the object column alone would be unreliable for those rows until the divergence is resolved",
+  '#-#-#T#:#:#.#Z',
+  "A second objectKey reference class exists in the same database: integration_write_target_configs.object (migration #, External-API WRITE self-service W#). This inventory does NOT probe it. Reason: the ledger's decision (γ) scope (§# step #.#, §#.# B-#) is the READ-side qualification-input tuple's objectKey, and the task this script was built for is scoped to that tuple; the write-target config table is a separate, config-time-only surface (no dry-run/apply/runtime route per its migration header) that decision (γ)'s registry may also need to cover eventually, but that is a follow-up inventory scope decision, not an oversight in this one. A canonical object referenced ONLY by a write-target config (never by a read-source config) is invisible to this report.",
+  "Both KNOWN_CERTIFIED_CONNECTOR_KINDS and KNOWN_CANONICAL_OBJECT_KEYS are empty. Neither decision (β) nor decision (γ) has produced a first-party registry yet, so today every distinct value observed is reported as unregistered — that is the correct, honest state, not a defect. This inventory exists to produce the raw list a human uses to populate those registries; it never populates them itself.",
+  'CONNECTOR_KIND_MAPPING_NOT_REQUIRED_WITHIN_COVERAGE',
+  'DB rows only, in the ONE connected database, at the moment queried. Says nothing about kinds referenced only in code/fixtures, or about a different deployment/database this run was not pointed at.',
+  'DB rows only, in the ONE connected database. A canonical object referenced by a still-in-development (never-saved) config, or by a config in a DIFFERENT database this run was not pointed at, is invisible here. Also deliberately out of scope: integration_write_target_configs.object (migration #) — a second objectKey reference class in the same database this report never queries; see residualNotes.',
+  'INCONCLUSIVE',
+  'This script has only ever been run against a hermetic fake executor (tests) and, if noted in the PR, a local/CI fixture database — never a customer deployment. Connecting to one is a separate ops-gated read-only authorization this task does not carry.',
+  'a zero known-registry size makes this trivially true today — see residualNotes',
+  'both',
+  "computeObjectKeyVerdict() is scoped to status='approved' only, matching the task's literal scope ('approved read-source configs'). draft/retired counts are still reported under byStatus for completeness, but a draft config can be approved after this inventory runs — decision (γ)'s own 'before activation' framing means the approved-only headline can understate the eventual backfill list; re-run before activation, not once.",
+  "distinct integration_external_systems.kind strings and their row counts — the raw material for decision (β)'s explicit alias map and migration list. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  "distinct integration_read_source_configs.object values (the ledger's `objectKey` tuple term) referenced by configs, split by status — the raw material for decision (γ)'s missing-reference and backfill lists. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  'draft_and_retired_object_keys_excluded_from_the_headline_verdict',
+  'integration_write_target_configs_object_deliberately_out_of_scope',
+  'known_registries_empty_by_design',
+  'no_customer_deployment_connection',
+  'ok',
+  'report',
+  'skipped_by_flag',
+  'this is reported regardless of registeredness — see coverage.canonicalObjectKeyInventory.objectVsConfigObjectDivergence',
+]
+
+const EXPECTED_UNEXPECTED_STATUS = [
+  '# distinct kind string(s) observed across integration_external_systems, all already in the (currently #-entry) known registry',
+  "# distinct objectKey(s) referenced by read-source config row(s) in an out-of-vocabulary (unexpected) status — a verdict scoped to 'approved' cannot be trusted while rows exist outside the known draft/approved/retired status vocabulary",
+  '#-#-#T#:#:#.#Z',
+  "A second objectKey reference class exists in the same database: integration_write_target_configs.object (migration #, External-API WRITE self-service W#). This inventory does NOT probe it. Reason: the ledger's decision (γ) scope (§# step #.#, §#.# B-#) is the READ-side qualification-input tuple's objectKey, and the task this script was built for is scoped to that tuple; the write-target config table is a separate, config-time-only surface (no dry-run/apply/runtime route per its migration header) that decision (γ)'s registry may also need to cover eventually, but that is a follow-up inventory scope decision, not an oversight in this one. A canonical object referenced ONLY by a write-target config (never by a read-source config) is invisible to this report.",
+  "Both KNOWN_CERTIFIED_CONNECTOR_KINDS and KNOWN_CANONICAL_OBJECT_KEYS are empty. Neither decision (β) nor decision (γ) has produced a first-party registry yet, so today every distinct value observed is reported as unregistered — that is the correct, honest state, not a defect. This inventory exists to produce the raw list a human uses to populate those registries; it never populates them itself.",
+  'CONNECTOR_KIND_MAPPING_NOT_REQUIRED_WITHIN_COVERAGE',
+  'DB rows only, in the ONE connected database, at the moment queried. Says nothing about kinds referenced only in code/fixtures, or about a different deployment/database this run was not pointed at.',
+  'DB rows only, in the ONE connected database. A canonical object referenced by a still-in-development (never-saved) config, or by a config in a DIFFERENT database this run was not pointed at, is invisible here. Also deliberately out of scope: integration_write_target_configs.object (migration #) — a second objectKey reference class in the same database this report never queries; see residualNotes.',
+  'INCONCLUSIVE',
+  'This script has only ever been run against a hermetic fake executor (tests) and, if noted in the PR, a local/CI fixture database — never a customer deployment. Connecting to one is a separate ops-gated read-only authorization this task does not carry.',
+  'a zero known-registry size makes this trivially true today — see residualNotes',
+  'both',
+  "computeObjectKeyVerdict() is scoped to status='approved' only, matching the task's literal scope ('approved read-source configs'). draft/retired counts are still reported under byStatus for completeness, but a draft config can be approved after this inventory runs — decision (γ)'s own 'before activation' framing means the approved-only headline can understate the eventual backfill list; re-run before activation, not once.",
+  "distinct integration_external_systems.kind strings and their row counts — the raw material for decision (β)'s explicit alias map and migration list. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  "distinct integration_read_source_configs.object values (the ledger's `objectKey` tuple term) referenced by configs, split by status — the raw material for decision (γ)'s missing-reference and backfill lists. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  'draft_and_retired_object_keys_excluded_from_the_headline_verdict',
+  'incomplete_owed_disabled',
+  'integration_write_target_configs_object_deliberately_out_of_scope',
+  'known_registries_empty_by_design',
+  'no_customer_deployment_connection',
+  'ok',
+  'report',
+  'this is reported regardless of registeredness — see coverage.canonicalObjectKeyInventory.byStatus.unexpected',
+]
+
+const EXPECTED_MISSING_TABLES = [
+  '#-#-#T#:#:#.#Z',
+  "A second objectKey reference class exists in the same database: integration_write_target_configs.object (migration #, External-API WRITE self-service W#). This inventory does NOT probe it. Reason: the ledger's decision (γ) scope (§# step #.#, §#.# B-#) is the READ-side qualification-input tuple's objectKey, and the task this script was built for is scoped to that tuple; the write-target config table is a separate, config-time-only surface (no dry-run/apply/runtime route per its migration header) that decision (γ)'s registry may also need to cover eventually, but that is a follow-up inventory scope decision, not an oversight in this one. A canonical object referenced ONLY by a write-target config (never by a read-source config) is invisible to this report.",
+  "Both KNOWN_CERTIFIED_CONNECTOR_KINDS and KNOWN_CANONICAL_OBJECT_KEYS are empty. Neither decision (β) nor decision (γ) has produced a first-party registry yet, so today every distinct value observed is reported as unregistered — that is the correct, honest state, not a defect. This inventory exists to produce the raw list a human uses to populate those registries; it never populates them itself.",
+  'DB rows only, in the ONE connected database, at the moment queried. Says nothing about kinds referenced only in code/fixtures, or about a different deployment/database this run was not pointed at.',
+  'DB rows only, in the ONE connected database. A canonical object referenced by a still-in-development (never-saved) config, or by a config in a DIFFERENT database this run was not pointed at, is invisible here. Also deliberately out of scope: integration_write_target_configs.object (migration #) — a second objectKey reference class in the same database this report never queries; see residualNotes.',
+  'INCONCLUSIVE',
+  'This script has only ever been run against a hermetic fake executor (tests) and, if noted in the PR, a local/CI fixture database — never a customer deployment. Connecting to one is a separate ops-gated read-only authorization this task does not carry.',
+  'both',
+  "computeObjectKeyVerdict() is scoped to status='approved' only, matching the task's literal scope ('approved read-source configs'). draft/retired counts are still reported under byStatus for completeness, but a draft config can be approved after this inventory runs — decision (γ)'s own 'before activation' framing means the approved-only headline can understate the eventual backfill list; re-run before activation, not once.",
+  'coverage is partial — the all-statuses kind count is UNAVAILABLE',
+  'coverage is partial — the approved-status objectKey count is UNAVAILABLE',
+  "distinct integration_external_systems.kind strings and their row counts — the raw material for decision (β)'s explicit alias map and migration list. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  "distinct integration_read_source_configs.object values (the ledger's `objectKey` tuple term) referenced by configs, split by status — the raw material for decision (γ)'s missing-reference and backfill lists. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  'draft_and_retired_object_keys_excluded_from_the_headline_verdict',
+  'integration_write_target_configs_object_deliberately_out_of_scope',
+  'known_registries_empty_by_design',
+  'no_customer_deployment_connection',
+  'report',
+  'skipped_by_flag',
+  "table integration_external_systems not found (probed via information_schema.tables/.columns, table_schema='public', as the DATABASE_URL role — a non-public search_path or missing SELECT/USAGE privileges reports the same as a genuinely absent object)",
+  "table integration_read_source_configs not found (probed via information_schema.tables/.columns, table_schema='public', as the DATABASE_URL role — a non-public search_path or missing SELECT/USAGE privileges reports the same as a genuinely absent object)",
+  'unavailable',
+]
+
+describe('CLOSED VALUE DOMAIN — every public leaf is a safe non-negative integer or a string from a hand-frozen closed set (#4603 P2(a))', () => {
+  test('report top-level key set is EXACTLY {generatedAt, mode, probe, coverage, verdicts, residualNotes, privateArtifact} — was previously unconstrained', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({ schema, counts: ZERO_COUNTS })
+    const report = await buildReport({ exec, noPrivateOut: true })
+    assert.deepEqual(
+      Object.keys(report).sort(),
+      ['coverage', 'generatedAt', 'mode', 'privateArtifact', 'probe', 'residualNotes', 'verdicts'],
+    )
+  })
+
+  test('report.residualNotes is referentially IDENTICAL to the exported RESIDUAL_NOTES — the strongest possible pin on that section, stronger than any content re-derivation', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({ schema, counts: ZERO_COUNTS })
+    const report = await buildReport({ exec, noPrivateOut: true })
+    assert.equal(report.residualNotes, RESIDUAL_NOTES)
+  })
+
+  test('scenario: nothing owed (zero rows both probes) — closed value domain holds', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({ schema, counts: ZERO_COUNTS })
+    const report = await buildReport({ exec, noPrivateOut: true })
+    assertClosedValueDomain(report, EXPECTED_NOTHING_OWED)
+  })
+
+  test('scenario: something owed (REQUIRED verdicts both probes, numeric interpolation exercised) — closed value domain holds', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({
+      schema,
+      counts: {
+        'count.external_system_kinds_all': [{ kind: 'SENTINEL_KIND', n: 1 }, { kind: 'another-unseen-kind', n: 2 }],
+        'count.external_system_kinds_active': [{ kind: 'SENTINEL_KIND', n: 1 }],
+        'count.read_source_config_objects_by_status': [
+          { object: 'SENTINEL_OBJECT', status: 'approved', n: 1 },
+          { object: 'yet-another-object', status: 'draft', n: 1 },
+        ],
+        'count.read_source_config_object_config_divergence': [{ n: 0 }],
+      },
+    })
+    const report = await buildReport({ exec, noPrivateOut: true })
+    assertClosedValueDomain(report, EXPECTED_SOMETHING_OWED)
+  })
+
+  test('scenario: unavailable column + --probe beta (not_run branch) — closed value domain holds', async () => {
+    const schema = cloneSchema({ integration_external_systems: { exists: true, columns: ['id', 'kind'] } })
+    const exec = createFakeExec({
+      schema,
+      counts: { 'count.external_system_kinds_all': [{ kind: 'erp:k3-wise-webapi', n: 1 }] },
+    })
+    const report = await buildReport({ exec, probe: 'beta', noPrivateOut: true })
+    assertClosedValueDomain(report, EXPECTED_UNAVAILABLE_AND_NOT_RUN)
+  })
+
+  test('scenario: objectVsConfigObjectDivergence > 0 (INCONCLUSIVE, exercises the R11/R12 reason templates) — closed value domain holds', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({ schema, counts: { ...ZERO_COUNTS, 'count.read_source_config_object_config_divergence': [{ n: 3 }] } })
+    const report = await buildReport({ exec, noPrivateOut: true })
+    assertClosedValueDomain(report, EXPECTED_DIVERGENCE_POSITIVE)
+  })
+
+  test('scenario: an out-of-vocabulary (unexpected) status bucket is populated (INCONCLUSIVE, exercises the R14/R15 reason templates) — closed value domain holds', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({
+      schema,
+      counts: { ...ZERO_COUNTS, 'count.read_source_config_objects_by_status': [{ object: 'material', status: 'some_future_status', n: 2 }] },
+    })
+    const report = await buildReport({ exec, noPrivateOut: true })
+    assertClosedValueDomain(report, EXPECTED_UNEXPECTED_STATUS)
+  })
+
+  test('scenario: both tables missing (top-level UNAVAILABLE for both probes) — closed value domain holds', async () => {
+    const schema = cloneSchema({
+      integration_external_systems: { exists: false, columns: [] },
+      integration_read_source_configs: { exists: false, columns: [] },
+    })
+    const exec = createFakeExec({ schema, counts: {} })
+    const report = await buildReport({ exec, noPrivateOut: true })
+    assertClosedValueDomain(report, EXPECTED_MISSING_TABLES)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Private artefact — fail-closed write behaviour
 // ---------------------------------------------------------------------------
 
@@ -975,6 +1412,11 @@ describe('private artefact write behaviour', () => {
         (err) => {
           assert.match(err.message, /could not be written/)
           assert.doesNotMatch(err.message, /SENTINEL_SHOULD_NOT_APPEAR_IN_ERROR/)
+          // (b) ruling: no err.message, no path.relative(...) of a real target, no stack — the
+          // thrown message must be a fixed, closed-enum-shaped sentence, not filesystem detail.
+          assert.doesNotMatch(err.message, /blocker/)
+          assert.doesNotMatch(err.message, /ENOTDIR|ENOENT|EACCES/)
+          assert.doesNotMatch(err.message, new RegExp(dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
           return true
         },
       )
@@ -994,12 +1436,25 @@ describe('private artefact write behaviour', () => {
 
       const report = await buildReport({ exec, privateOutPath })
       assert.equal(report.privateArtifact.status, 'write_failed_but_nothing_owed')
+      // (b) ruling: closed enum only — a reason CODE, never the raw fs err.message and never the
+      // attempted target path (both could carry filesystem/OS detail this report must not surface).
+      assert.equal(report.privateArtifact.reasonCode, 'FILESYSTEM_WRITE_ERROR')
+      assert.deepEqual(Object.keys(report.privateArtifact).sort(), ['consumableByWave2', 'reasonCode', 'status'])
+      assert.equal(report.privateArtifact.consumableByWave2, true)
+      const serialized = JSON.stringify(report.privateArtifact)
+      assert.doesNotMatch(serialized, /blocker/)
+      assert.doesNotMatch(serialized, new RegExp(dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
   })
 
-  test('--no-private-out skips the write entirely, even when something is owed', async () => {
+  // Pins the NEW fail-closed behaviour for #4603 owner-review P1(2): --no-private-out used to
+  // report bare 'skipped_by_flag' even when a private artefact was genuinely owed (unregistered
+  // kind/objectKey values existed) — a silent SUCCESS that a downstream Wave 2 gate could consume
+  // as "nothing to map". This test formerly pinned that fail-open behaviour; it now pins the
+  // fail-closed replacement — updated, not deleted, per the ruling.
+  test('--no-private-out with something OWED: explicit INCOMPLETE status, not a bare skip — not consumable by Wave 2', async () => {
     const schema = cloneSchema()
     const exec = createFakeExec({
       schema,
@@ -1011,7 +1466,50 @@ describe('private artefact write behaviour', () => {
       },
     })
     const report = await buildReport({ exec, noPrivateOut: true })
+    assert.equal(report.privateArtifact.status, 'incomplete_owed_disabled')
+    assert.equal(report.privateArtifact.consumableByWave2, false)
+    assert.deepEqual(Object.keys(report.privateArtifact).sort(), ['consumableByWave2', 'status'])
+  })
+
+  // The complementary branch: nothing owed + --no-private-out is a genuinely fine, complete run —
+  // must NOT be downgraded to 'incomplete_owed_disabled' just because the flag was passed.
+  test('--no-private-out with NOTHING owed: plain skipped_by_flag, consumable', async () => {
+    const schema = cloneSchema()
+    const exec = createFakeExec({ schema, counts: ZERO_COUNTS })
+    const report = await buildReport({ exec, noPrivateOut: true })
     assert.equal(report.privateArtifact.status, 'skipped_by_flag')
+    assert.equal(report.privateArtifact.consumableByWave2, true)
+  })
+
+  test("a 'written' privateArtifact carries no real filesystem path — closed status/flag only", async () => {
+    const dir = scratchDir()
+    try {
+      const schema = cloneSchema()
+      const exec = createFakeExec({ schema, counts: ZERO_COUNTS })
+      const privateOutPath = path.join(dir, 'private.json')
+      const report = await buildReport({ exec, privateOutPath })
+      assert.equal(report.privateArtifact.status, 'written')
+      assert.equal(report.privateArtifact.consumableByWave2, true)
+      assert.deepEqual(Object.keys(report.privateArtifact).sort(), ['consumableByWave2', 'status'])
+      assert.doesNotMatch(JSON.stringify(report.privateArtifact), /private\.json/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("renderHumanSummary's private-artefact line carries only the closed status token, never a real path (P2(b): stdout is public/committed output)", async () => {
+    const dir = scratchDir()
+    try {
+      const schema = cloneSchema()
+      const exec = createFakeExec({ schema, counts: ZERO_COUNTS })
+      const privateOutPath = path.join(dir, 'a-directory-name-that-must-not-leak.json')
+      const report = await buildReport({ exec, privateOutPath })
+      const summary = renderHumanSummary(report)
+      assert.match(summary, /private artefact: written/)
+      assert.doesNotMatch(summary, /a-directory-name-that-must-not-leak/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   test('buildPrivateArtifactContent carries the raw detail (this is the ONLY function permitted to)', () => {
@@ -1031,6 +1529,77 @@ describe('private artefact write behaviour', () => {
     assert.deepEqual(content.connectorKinds.allStatuses, bucketed.detail)
     assert.deepEqual(content.objectKeys.approved, objBucketed.detail)
     assert.match(content.warning, /Never commit/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// writePrivateArtifact — #4603 owner-review P2(c): EXCLUSIVE CREATE ONLY. The default `writeFileSync`
+// flag ('w') follows a symlink at the target path and truncates/overwrites an existing regular
+// file; `mode: 0o600` only constrains permissions on a file THIS call creates, it does not tighten
+// an already-existing target. All three refusals below are proven directly at the writePrivateArtifact
+// unit, plus the clean-create positive control that proves the guard does not just reject everything.
+// ---------------------------------------------------------------------------
+
+describe('writePrivateArtifact — exclusive create; refuses a symlink and refuses an existing target', () => {
+  function scratchDir() {
+    return mkdtempSync(path.join(tmpdir(), 'gip-authority-inventory-wpa-test-'))
+  }
+
+  test('POSITIVE CONTROL: clean create succeeds — new file, correct content, mode 0o600', () => {
+    const dir = scratchDir()
+    try {
+      const target = path.join(dir, 'sub', 'private.json')
+      writePrivateArtifact(target, { hello: 'world' })
+      const written = JSON.parse(readFileSync(target, 'utf8'))
+      assert.deepEqual(written, { hello: 'world' })
+      const mode = statSync(target).mode & 0o777
+      assert.equal(mode, 0o600)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('REFUSAL 1: an existing regular file at the target is refused — throws, and its content is untouched (no overwrite)', () => {
+    const dir = scratchDir()
+    try {
+      const target = path.join(dir, 'private.json')
+      writeFileSync(target, 'PRE-EXISTING CONTENT — must survive')
+      assert.throws(() => writePrivateArtifact(target, { should: 'never land' }))
+      assert.equal(readFileSync(target, 'utf8'), 'PRE-EXISTING CONTENT — must survive')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('REFUSAL 2: a DANGLING symlink at the target (points at a nonexistent path) is refused — throws, symlink left unchanged, target never created', () => {
+    const dir = scratchDir()
+    try {
+      const target = path.join(dir, 'private.json')
+      const nonexistentDest = path.join(dir, 'this-path-does-not-exist.json')
+      symlinkSync(nonexistentDest, target)
+      assert.throws(() => writePrivateArtifact(target, { should: 'never land' }))
+      // The symlink node itself must be untouched — writeFileSync's default 'w' flag would have
+      // CREATED nonexistentDest and written through the dangling link; O_EXCL must refuse before that.
+      assert.equal(readlinkSync(target), nonexistentDest)
+      assert.throws(() => statSync(nonexistentDest)) // still does not exist — nothing was created through the link
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('REFUSAL 3: a symlink at the target pointing at a REAL file is refused — throws, and the pointed-to file is unmodified (proves the write never followed the link)', () => {
+    const dir = scratchDir()
+    try {
+      const target = path.join(dir, 'private.json')
+      const realFile = path.join(dir, 'some-other-real-file.json')
+      writeFileSync(realFile, 'REAL FILE CONTENT — must survive, must never be overwritten via the symlink')
+      symlinkSync(realFile, target)
+      assert.throws(() => writePrivateArtifact(target, { should: 'never land' }))
+      assert.equal(readFileSync(realFile, 'utf8'), 'REAL FILE CONTENT — must survive, must never be overwritten via the symlink')
+      assert.equal(readlinkSync(target), realFile)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/scripts/ops/gip-authority-substrate-inventory.test.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.test.mjs
@@ -1344,7 +1344,24 @@ describe('CLOSED VALUE DOMAIN — every public leaf is a safe non-negative integ
     )
   })
 
-  test('report.residualNotes is referentially IDENTICAL to the exported RESIDUAL_NOTES — the strongest possible pin on that section, stronger than any content re-derivation', async () => {
+  // report.residualNotes === RESIDUAL_NOTES pins OBJECT IDENTITY only — that buildReport() passes
+  // the frozen array through unchanged (no copy/re-derivation). It does NOT pin note CONTENT: a
+  // wording change to a note keeps the same object reference, so this assertion alone stays green.
+  // Content is pinned separately by the 8 CLOSED VALUE DOMAIN scenario tests below, via
+  // assertClosedValueDomain's hand-frozen EXPECTED_* string lists, which hardcode every
+  // residual-note description and red on any change to a note's non-numeric text.
+  // Mutation-confirmed (#4603 P2): inverting the meaning of the "no_customer_deployment_connection"
+  // note (still non-numeric text) left this identity assertion green while all 8 scenario tests
+  // below went red — proving the pin described above.
+  // Residual gap, not closed by any test in this file: assertClosedValueDomain digit-normalizes
+  // every string (s.replace(/\d+/g, '#')) before comparing, so a DIGITS-ONLY edit to a residual
+  // note — e.g. "migration 064" to "migration 164", or "§4 step 1.3, §3.0 B-3" to "§9 step 9.9,
+  // §9.0 B-9" (a wrong ledger citation) — normalizes identically and is invisible to all 8 scenario
+  // tests AND this identity test. The separate 'RESIDUAL_NOTES' describe block below catches the
+  // migration-064 digits specifically (a literal, non-normalized regex match), but nothing in this
+  // file checks the §4 step 1.3 / §3.0 B-3 ledger-section digits — mutation-confirmed: that edit
+  // alone (section digits only, migration number untouched) leaves all 127 tests in this file green.
+  test('report.residualNotes is referentially IDENTICAL to the exported RESIDUAL_NOTES — pins object identity, not note content (see comment above)', async () => {
     const schema = cloneSchema()
     const exec = createFakeExec({ schema, counts: ZERO_COUNTS })
     const report = await buildReport({ exec, noPrivateOut: true })

--- a/scripts/ops/gip-authority-substrate-inventory.test.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.test.mjs
@@ -232,6 +232,16 @@ describe('QUERY_ALLOWLIST entries are deep-frozen, not just the outer object (#4
       attemptRestore(QUERY_ALLOWLIST['probe.columns'], 'sql', original)
     }
   })
+
+  // Discrimination (run manually, not automated — this file has no mutation-testing harness),
+  // confirmed 2026-07-25 at HEAD (144-test suite): with the per-entry freeze loop in the source,
+  // 144/144 green. Deleting ONLY that loop (leaving `Object.freeze(QUERY_ALLOWLIST)` on the outer
+  // object intact) reds exactly the 4 tests in this describe block — 140/144 — and nothing else.
+  // The mutation tests above restore mutated state in a `finally` (see attemptRestore()) precisely
+  // so that a real gap here reds only its own tests instead of corrupting the module-level
+  // QUERY_ALLOWLIST singleton every other test in this file reads through the same fake-exec
+  // harness (SQL_TO_TAG, createFakeExec) — an earlier draft without the restore cascaded to ~40
+  // unrelated failures when the freeze was absent.
 })
 
 // ---------------------------------------------------------------------------
@@ -2163,6 +2173,21 @@ describe('stderr values-free discipline — real subprocess (#4603 P2(a))', () =
     // copy of the script placed there resolves `pg` deterministically the same way regardless of
     // whether the repo's own workspace has `pg` installed. This makes the control robust to a
     // resolvable `pg` rather than merely documenting the fragility.
+    //
+    // Verified against the actual failure condition, not merely asserted, on 2026-07-25: with a
+    // minimal stub package (`{"name":"pg","version":"0.0.0","main":"index.js"}` +
+    // `module.exports = { Pool: class Pool {} }`) placed at the REPO ROOT's `node_modules/pg`
+    // (the faithful stand-in for `pnpm install` hoisting `pg` from
+    // packages/core-backend/package.json into the workspace root) — (1) `import('pg')` resolved
+    // successfully from the repo root, confirming the stub genuinely reproduces the post-install
+    // condition; (2) the full suite stayed 144/144 green with the stub present — this test's
+    // isolated-directory construction is unaffected because `tmpdir()`'s ancestry never includes
+    // the repo; (3) replaying the OLD (pre-fix) control shape — `await import('pg')` from this
+    // test file's own location — against the same stub DID red with exactly the vacuous-control
+    // message this comment warns about (`control failed: 'pg' imported successfully...`),
+    // confirming the fragility being fixed was real, not hypothetical. Stub removed after
+    // verification; `node_modules/` is gitignored (`.gitignore` line 2) so it was never a
+    // candidate for being committed regardless.
     // realpathSync is REQUIRED here, not cosmetic: os.tmpdir() resolves under /var/folders on
     // macOS, which is itself a symlink to /private/var/folders. The script's own isEntry check
     // (`path.resolve(argv[1]) === fileURLToPath(import.meta.url)`) compares an UN-resolved argv[1]

--- a/scripts/ops/gip-authority-substrate-inventory.test.mjs
+++ b/scripts/ops/gip-authority-substrate-inventory.test.mjs
@@ -1272,6 +1272,67 @@ const EXPECTED_MISSING_TABLES = [
   'unavailable',
 ]
 
+// Exercises the ACTUAL write path (not noPrivateOut: true like the six scenarios above) — the
+// exact branch P2(b) was about. Differs from EXPECTED_NOTHING_OWED only by 'skipped_by_flag' ->
+// 'written'; captured the same way (run once against the fixed source, pasted as a frozen
+// literal), so a real filesystem path or err.message re-appearing in privateArtifact would show up
+// here as an unauthored string, not just fail the narrower doesNotMatch(/private\.json/) checks
+// elsewhere.
+const EXPECTED_WRITTEN = [
+  '# distinct kind string(s) observed across integration_external_systems, all already in the (currently #-entry) known registry',
+  '# distinct objectKey(s) referenced by approved read-source configs, all already in the (currently #-entry) known registry',
+  '#-#-#T#:#:#.#Z',
+  "A second objectKey reference class exists in the same database: integration_write_target_configs.object (migration #, External-API WRITE self-service W#). This inventory does NOT probe it. Reason: the ledger's decision (γ) scope (§# step #.#, §#.# B-#) is the READ-side qualification-input tuple's objectKey, and the task this script was built for is scoped to that tuple; the write-target config table is a separate, config-time-only surface (no dry-run/apply/runtime route per its migration header) that decision (γ)'s registry may also need to cover eventually, but that is a follow-up inventory scope decision, not an oversight in this one. A canonical object referenced ONLY by a write-target config (never by a read-source config) is invisible to this report.",
+  "Both KNOWN_CERTIFIED_CONNECTOR_KINDS and KNOWN_CANONICAL_OBJECT_KEYS are empty. Neither decision (β) nor decision (γ) has produced a first-party registry yet, so today every distinct value observed is reported as unregistered — that is the correct, honest state, not a defect. This inventory exists to produce the raw list a human uses to populate those registries; it never populates them itself.",
+  'CANONICAL_OBJECT_BACKFILL_NOT_REQUIRED_WITHIN_COVERAGE',
+  'CONNECTOR_KIND_MAPPING_NOT_REQUIRED_WITHIN_COVERAGE',
+  'DB rows only, in the ONE connected database, at the moment queried. Says nothing about kinds referenced only in code/fixtures, or about a different deployment/database this run was not pointed at.',
+  'DB rows only, in the ONE connected database. A canonical object referenced by a still-in-development (never-saved) config, or by a config in a DIFFERENT database this run was not pointed at, is invisible here. Also deliberately out of scope: integration_write_target_configs.object (migration #) — a second objectKey reference class in the same database this report never queries; see residualNotes.',
+  'This script has only ever been run against a hermetic fake executor (tests) and, if noted in the PR, a local/CI fixture database — never a customer deployment. Connecting to one is a separate ops-gated read-only authorization this task does not carry.',
+  'a zero known-registry size makes this trivially true today — see residualNotes',
+  'both',
+  "computeObjectKeyVerdict() is scoped to status='approved' only, matching the task's literal scope ('approved read-source configs'). draft/retired counts are still reported under byStatus for completeness, but a draft config can be approved after this inventory runs — decision (γ)'s own 'before activation' framing means the approved-only headline can understate the eventual backfill list; re-run before activation, not once.",
+  "distinct integration_external_systems.kind strings and their row counts — the raw material for decision (β)'s explicit alias map and migration list. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  "distinct integration_read_source_configs.object values (the ledger's `objectKey` tuple term) referenced by configs, split by status — the raw material for decision (γ)'s missing-reference and backfill lists. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  'draft_and_retired_object_keys_excluded_from_the_headline_verdict',
+  'integration_write_target_configs_object_deliberately_out_of_scope',
+  'known_registries_empty_by_design',
+  'no_customer_deployment_connection',
+  'ok',
+  'report',
+  'written',
+]
+
+// Exercises the write-FAILED-but-nothing-owed branch: the real filesystem error occurs (ENOTDIR,
+// via the blocker-file trick used elsewhere in this file), and 'FILESYSTEM_WRITE_ERROR' is the
+// only new leaf versus EXPECTED_WRITTEN (replacing 'written') — the raw err.message/path must NOT
+// appear here either.
+const EXPECTED_WRITE_FAILED_NOTHING_OWED = [
+  '# distinct kind string(s) observed across integration_external_systems, all already in the (currently #-entry) known registry',
+  '# distinct objectKey(s) referenced by approved read-source configs, all already in the (currently #-entry) known registry',
+  '#-#-#T#:#:#.#Z',
+  "A second objectKey reference class exists in the same database: integration_write_target_configs.object (migration #, External-API WRITE self-service W#). This inventory does NOT probe it. Reason: the ledger's decision (γ) scope (§# step #.#, §#.# B-#) is the READ-side qualification-input tuple's objectKey, and the task this script was built for is scoped to that tuple; the write-target config table is a separate, config-time-only surface (no dry-run/apply/runtime route per its migration header) that decision (γ)'s registry may also need to cover eventually, but that is a follow-up inventory scope decision, not an oversight in this one. A canonical object referenced ONLY by a write-target config (never by a read-source config) is invisible to this report.",
+  "Both KNOWN_CERTIFIED_CONNECTOR_KINDS and KNOWN_CANONICAL_OBJECT_KEYS are empty. Neither decision (β) nor decision (γ) has produced a first-party registry yet, so today every distinct value observed is reported as unregistered — that is the correct, honest state, not a defect. This inventory exists to produce the raw list a human uses to populate those registries; it never populates them itself.",
+  'CANONICAL_OBJECT_BACKFILL_NOT_REQUIRED_WITHIN_COVERAGE',
+  'CONNECTOR_KIND_MAPPING_NOT_REQUIRED_WITHIN_COVERAGE',
+  'DB rows only, in the ONE connected database, at the moment queried. Says nothing about kinds referenced only in code/fixtures, or about a different deployment/database this run was not pointed at.',
+  'DB rows only, in the ONE connected database. A canonical object referenced by a still-in-development (never-saved) config, or by a config in a DIFFERENT database this run was not pointed at, is invisible here. Also deliberately out of scope: integration_write_target_configs.object (migration #) — a second objectKey reference class in the same database this report never queries; see residualNotes.',
+  'FILESYSTEM_WRITE_ERROR',
+  'This script has only ever been run against a hermetic fake executor (tests) and, if noted in the PR, a local/CI fixture database — never a customer deployment. Connecting to one is a separate ops-gated read-only authorization this task does not carry.',
+  'a zero known-registry size makes this trivially true today — see residualNotes',
+  'both',
+  "computeObjectKeyVerdict() is scoped to status='approved' only, matching the task's literal scope ('approved read-source configs'). draft/retired counts are still reported under byStatus for completeness, but a draft config can be approved after this inventory runs — decision (γ)'s own 'before activation' framing means the approved-only headline can understate the eventual backfill list; re-run before activation, not once.",
+  "distinct integration_external_systems.kind strings and their row counts — the raw material for decision (β)'s explicit alias map and migration list. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  "distinct integration_read_source_configs.object values (the ledger's `objectKey` tuple term) referenced by configs, split by status — the raw material for decision (γ)'s missing-reference and backfill lists. The count queries are UNSCOPED: every tenant and workspace visible in the connected database, not one tenant.",
+  'draft_and_retired_object_keys_excluded_from_the_headline_verdict',
+  'integration_write_target_configs_object_deliberately_out_of_scope',
+  'known_registries_empty_by_design',
+  'no_customer_deployment_connection',
+  'ok',
+  'report',
+  'write_failed_but_nothing_owed',
+]
+
 describe('CLOSED VALUE DOMAIN — every public leaf is a safe non-negative integer or a string from a hand-frozen closed set (#4603 P2(a))', () => {
   test('report top-level key set is EXACTLY {generatedAt, mode, probe, coverage, verdicts, residualNotes, privateArtifact} — was previously unconstrained', async () => {
     const schema = cloneSchema()
@@ -1350,6 +1411,42 @@ describe('CLOSED VALUE DOMAIN — every public leaf is a safe non-negative integ
     const exec = createFakeExec({ schema, counts: {} })
     const report = await buildReport({ exec, noPrivateOut: true })
     assertClosedValueDomain(report, EXPECTED_MISSING_TABLES)
+  })
+
+  // The two scenarios above (and all six before them) always pass noPrivateOut: true — they never
+  // exercise the ACTUAL write path, which is exactly what P2(b) (report exposed caller paths and
+  // raw error messages) was about. These two close that gap: a real 'written' artefact and a real
+  // filesystem write failure, both through the closed-value-domain walk, not just the narrower
+  // doesNotMatch(/private\.json/)-style checks in the "private artefact write behaviour" describe
+  // block below.
+  test("scenario: privateArtifact actually WRITTEN (real temp-dir write, nothing owed) — closed value domain holds; no real path leaks in", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'gip-authority-inventory-cvd-written-'))
+    try {
+      const schema = cloneSchema()
+      const exec = createFakeExec({ schema, counts: ZERO_COUNTS })
+      const privateOutPath = path.join(dir, 'private.json')
+      const report = await buildReport({ exec, privateOutPath })
+      assert.equal(report.privateArtifact.status, 'written')
+      assertClosedValueDomain(report, EXPECTED_WRITTEN)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("scenario: privateArtifact write FAILED but nothing owed (real ENOTDIR) — closed value domain holds; no real path or err.message leaks in", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'gip-authority-inventory-cvd-writefail-'))
+    try {
+      const schema = cloneSchema()
+      const exec = createFakeExec({ schema, counts: ZERO_COUNTS })
+      const blockerFile = path.join(dir, 'blocker')
+      writeFileSync(blockerFile, 'x')
+      const privateOutPath = path.join(blockerFile, 'sub', 'private.json')
+      const report = await buildReport({ exec, privateOutPath })
+      assert.equal(report.privateArtifact.status, 'write_failed_but_nothing_owed')
+      assertClosedValueDomain(report, EXPECTED_WRITE_FAILED_NOTHING_OWED)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

Two read-only, values-free, schema-probing inventory probes feeding two of the four **§4.0**
owner decisions in
[`docs/development/database-system-integration-line-design-and-verification-20260724.md`](../blob/main/docs/development/database-system-integration-line-design-and-verification-20260724.md)
(the ledger; RATIFIED, merged as `402f04982`, §4 ratified `a7c562d34`):

- **(β)** distinct `integration_external_systems.kind` strings and their row counts — the raw
  material a human uses to author the explicit alias map and migration list for decision (β)'s
  first-party CLOSED connector-kind registry.
- **(γ)** distinct `integration_read_source_configs.object` values — the column the ledger's
  qualification-input tuple calls `objectKey` (no literal `objectKey` column exists on main; this
  mapping is asserted by a **line/word-boundary-anchored** schema-drift test — see "Fix pass"
  below for why the anchoring matters — not just commented) — referenced by read-source configs,
  split by status. Raw material for decision (γ)'s missing-reference and backfill lists.

This is a **new carrier**, per the **owner's task-brief ruling** — **not recorded in the ledger**;
the ledger's §4.0/§3.0 sections define the four owner decisions this work feeds but say nothing
about a carrier for this script. It reuses the schema-probe-first, values-free `QUERY_ALLOWLIST`
*pattern* of `scripts/ops/data-source-exposure-inventory.mjs` (#4594) but does **not** import
from, expand, or push to that file/branch/PR — #4594 is untouched by this change. **Note:**
`scripts/ops/data-source-exposure-inventory.mjs`, its test file, and its workflow yml live only on
branch `claude/data-source-exposure-inventory-20260724` (PR #4594) — they are **not in this tree
and not on main**; this PR's comments now say so explicitly rather than implying otherwise.

## What this does NOT do (gate boundary, stated per the task brief)

- Never auto-expands or auto-populates a first-party registry from what it observes, in either
  direction. `KNOWN_CERTIFIED_CONNECTOR_KINDS` and `KNOWN_CANONICAL_OBJECT_KEYS` are frozen,
  **empty**, module-local constants — this script has no code path that writes to them. Only a
  human, acting on the owner's decision (β)/(γ), may add entries in a follow-up change. Proven by
  test (frozen-array mutation throws; a full report run against fixture rows carrying novel values
  leaves both registries referentially and content-identical).
- No runtime consumer, no scheduler, no route, no arming/activation — pure offline DB read (two
  `information_schema` probes, four `SELECT ... GROUP BY` counts, all read-only-asserted at module
  load) plus a local JSON write.
- **Does not probe `integration_write_target_configs.object`** (migration 064) — a second
  objectKey reference class in the same database, deliberately out of scope for this inventory
  (decision (γ)'s scope per the ledger is the READ-side qualification-input tuple). Stated in both
  `RESIDUAL_NOTES` and the γ coverage `blindSpot` string, with the reason, and pinned by test.
- **Never connected to a customer deployment.** Tested hermetically (fake executor, `node --test`,
  no DB). A prior session in this PR reported testing against one **ephemeral local Postgres 15**
  that was stood up and discarded — see the downgraded claim under "Live-Postgres verification"
  below. Connecting this tool to a customer deployment is a separate, ops-gated read-only
  authorization this task does not carry, and this PR does not claim it.

## Output discipline (owner ruling, enforced structurally, not just documented)

- **Public/committed output (stdout, `--json`, the human summary): aggregate counts only.** The
  public report object is assembled exclusively from `.counts` integers, fixed status/verdict
  enum tokens, and label strings authored in the script — it is structurally incapable of holding
  an observed kind/objectKey string. Proven **two ways**: (1) a sentinel-injection test asserting a
  raw value injected through the fake executor is **absent** from `JSON.stringify(report)`
  (negative control) while **present** in the private artefact file (positive control); (2) an
  **exact key-set** test that walks `coverage`/`verdicts`/`residualNotes` and asserts the key set
  at every level is exactly the fixed, authored set — added in the fix pass below because (1) alone
  only catches a leak that lands as a string *value*, not one used *as an object key* (see "Fix
  pass").
- **Raw values go only into a private, gitignored local artefact** —
  `artifacts/gip-authority-inventory/…json` (new `.gitignore` entry, same PR), written with `0600`
  permissions, path only ever printed, never its content.
- **Fails closed**: if an unregistered/unmapped value exists but the private artefact cannot be
  written, `buildReport()` rejects (exit 1) rather than completing with an aggregate-only success
  that silently drops the one thing a human needs to act on it. If nothing was owed, a write
  failure is reported but does not fail the run.

## `--probe beta|gamma|both`

"Strictly separated purposes" (task brief) is enforced at the query layer, not just the printed
summary: under `--probe beta`, **no query naming `integration_read_source_configs` is ever
issued — schema probe included, in BOTH report mode and `--dry-run`** (`tableSpecsForProbe()`
scopes which tables even get an `information_schema` round-trip; `--dry-run` now threads `probe`
through the same way — see "Fix pass"), and no γ value can reach `coverage`, the public summary,
or the private artefact. Symmetric for `--probe gamma`. Verified hermetically: a fixture with zero
`count.read_source_config_*`/`count.external_system_*` entries for the unrequested probe — if that
probe ran anyway, the fake executor throws before any assertion — plus an equivalent zero-calls
check for `--dry-run` under each `--probe` value.

## Divergence check

One additional values-free integrity query: `integration_read_source_configs` rows where `object`
disagrees with `config->>'object'` (count only). If non-zero, the γ verdict is forced to
`INCONCLUSIVE` rather than letting a `CANONICAL_OBJECT_BACKFILL_NOT_REQUIRED_WITHIN_COVERAGE`
verdict coexist with a known disagreement between the column the backfill list is built from and
the config's own stored value. `IS DISTINCT FROM` (not `<>`) is deliberate: a row whose `config`
JSON has no `'object'` key at all is also counted — this follows from the documented SQL-standard
semantics of `IS DISTINCT FROM` treating `NULL` as distinct rather than `UNKNOWN`. A prior session
reported exercising this against a seeded row with a missing key on the (now-discarded) ephemeral
Postgres instance; see "Live-Postgres verification" below for why that specific claim is now
scoped rather than asserted as fact.

**Also fixed in this pass:** the `unexpected` status bucket (rows whose `status` is outside the
draft/approved/retired CHECK vocabulary — fail-closed by `splitRowsByStatus()`, not dropped) now
also forces `INCONCLUSIVE` when non-empty, for the same reason the divergence check does: a
`NOT_REQUIRED` verdict must not coexist with a known coverage gap. See "Fix pass".

## Fix pass (2026-07-25) — adversarial-review findings, each proved red-then-green

An adversarial review returned HOLD on the original version of this PR. All six findings were
fixed and each fix is proved with a **before/after mutation pair**: the production code (or a
migration file, for schema-drift) was temporarily mutated, `node --test` was re-run to show the
relevant new/existing test(s) going **RED**, then the mutation was reverted and the suite
confirmed **GREEN** again. No mutation was left in the committed diff.

1. **[P2] γ schema-drift guard didn't pin the `object` column name.** The old test used
   `assert.match(migration062, /object\s+TEXT NOT NULL/)` — a loose, non-anchored regex. Renaming
   the column to `canonical_object` still satisfies it, because `canonical_object` *contains* the
   substring `object` immediately followed by whitespace + `TEXT NOT NULL`. Fixed the same way
   057's `kind` guard already worked: a **line-anchored** `find()` over `migration062.split('\n')`
   requiring the literal token to start the line (after only whitespace). Also anchored the
   *index*-column assertion (`uniq_integration_read_source_configs_content`), which had the
   identical bug for a full-rename (declaration + index columns), using a **word-boundary**
   (`\bobject\b`) match against the extracted index clause — a boundary that `canonical_object`
   cannot satisfy because the character before the trailing `object` is `_` (a word character, so
   no `\b`).
   - Declaration-only rename (`object` → `canonical_object` on line 28 only): **RED** (1 failing
     test) → reverted → **GREEN**.
   - Full rename (declaration + both index column lists): **RED** (2 failing tests) → reverted →
     **GREEN**.
   - Regression check: 057's `kind` → `connector_kind` rename still **RED**s (β guard unweakened).

2. **[P2] The "recursive structural check" didn't check the property its name claimed.** Its only
   assertion was a sentinel-substring walk over `Object.values()` — it never inspected
   `Object.keys()`, so a bug that used a raw observed value **as an object key** (instead of one of
   the fixed enum tokens) would pass undetected; it also only checked for two *named* sentinels,
   not membership in any actual closed set, so an *unnamed* leaked value would pass too. Replaced
   with an **exact key-set assertion** (`assertPublicReportKeySetsExactly`) that walks the real
   report and asserts, at every level of `coverage`/`verdicts`/`residualNotes`, that the key set is
   exactly the fixed set the source can produce.
   - Mutation proof (production code, not a hand-built stand-in): temporarily changed
     `buildPublicObjectKeySummary()` to additionally key a bucket entry by the first observed raw
     `objectKey` string per status. Result: **RED**, and the assertion diff shows *two* unexpected
     keys — the injected sentinel (`SENTINEL_OBJECT_...`) **and** a second, non-sentinel value
     (`yet-another-object`) that the *old* sentinel-substring test (which only knows about two
     named sentinels) would **not** have caught. Reverted → **GREEN**.

3. **[P2] `unexpected`-status objectKeys never forced `INCONCLUSIVE`.** `computeObjectKeyVerdict`
   read only `byStatus.approved` and `divergence`; a `NOT_REQUIRED` verdict could coexist with
   unregistered objectKeys sitting in an out-of-vocabulary status. Added an `unexpected`-bucket
   check (same "known coverage defect forces INCONCLUSIVE" shape as the divergence check),
   constructed with the approved bucket empty and divergence clean so **only** the unexpected
   bucket flips the verdict (no confound).
   - Two new tests added; with the fix reverted (hunk removed, tests kept): **RED** (2 failing,
     `fail 2`, no other test disturbed) → fix restored → **GREEN**.

4. **[P3] `--probe` didn't scope `--dry-run`.** `buildDryRunReport()` always probed the full
   `TABLE_SPECS` regardless of `--probe`, so the "schema probe included" scoping claim above was
   false in `--dry-run` mode specifically. Threaded `probe` through (`tableSpecsForProbe(probe)` +
   `buildPlan(schema, { probe })`), added `probe` to the dry-run report object (so
   `renderHumanSummary`'s `probe=…` line isn't `(n/a)`), and wired `opts.probe` from `main()`.
   - Two new tests (zero `integration_read_source_configs`/`integration_external_systems` calls
     under `--dry-run --probe beta`/`gamma`); with the fix reverted: **RED** (2 failing) → fix
     restored → **GREEN**.

5. **[P3] γ coverage map omitted `integration_write_target_configs.object` (migration 064).** A
   second objectKey reference class in the same database. Added it to `RESIDUAL_NOTES` (new id
   `integration_write_target_configs_object_deliberately_out_of_scope`) and to the γ coverage
   `blindSpot` string, stating the table, the migration, and the reason (decision (γ)'s ledger
   scope is the READ-side tuple; the write-target table is a separate config-time-only surface).
   Pinned by test (both the note text and the `blindSpot` string are asserted to name the table).

6. **[P2] Committed prose attributed the #4594 non-reuse ruling to the ledger.** Grepped the
   RATIFIED ledger for `4594`, `data-source-exposure-inventory`, `non-reuse`, `must NOT be
   expanded`, `reused as the carrier` — **zero matches**:
   ```
   grep -n "4594\|data-source-exposure-inventory\|non-reuse\|must NOT be expanded\|reused as the carrier" \
     docs/development/database-system-integration-line-design-and-verification-20260724.md
   ```
   returns nothing. The ledger's §4.0/§3.0 define the four owner decisions (α/β/γ/δ) this work
   feeds; it says nothing about a carrier ruling for *this* script. That ruling came from the task
   brief given to the session that wrote this PR, not from the ledger — exactly the defect class
   (an artefact quoted as if it were in the contract) the ledger itself documents. Fixed the header
   comment, the `QUERY_ALLOWLIST` comment, and this PR body to say "the owner's task-brief ruling
   (not recorded in the ledger)". Also confirmed and stated explicitly: `scripts/ops/
   data-source-exposure-inventory.mjs`/`.test.mjs` and `.github/workflows/
   data-source-exposure-inventory.yml` live only on branch
   `claude/data-source-exposure-inventory-20260724` — `git merge-base --is-ancestor` against
   `origin/main` returns false; they are not on main.

## Live-Postgres verification — downgraded wording (P3)

The earlier version of this PR's Test plan stated as fact that a real, ephemeral local Postgres 15
instance was stood up, migrated, seeded, and hand-verified against `psql`, then discarded with **no
transcript captured**. This fix pass does not have a reproducible artefact for that claim and could
not independently re-verify it: this worktree has no `node_modules` (`pg` is not resolvable), so
`createPgExecutor()` cannot run here even though a local Postgres 15 binary is available. Per the
review instruction, the wording is downgraded rather than re-asserted:

- The **hermetic** test suite (fake executor, no DB) is the load-bearing, reproducible proof for
  everything in this PR, including all six fix-pass items above — every claim in "Fix pass" is
  backed by a pasted `node --test` command and its real output.
- The **live-Postgres** claims in the original Test plan section below are retained **as a
  historical record of what a prior session in this PR reported doing**, not as something this fix
  pass re-verified. Treat them as unreproduced. The `IS DISTINCT FROM` / missing-config-key
  semantics they were checking follow from the documented SQL standard behaviour independent of
  that specific run (see the updated `QUERY_ALLOWLIST` comment).

## Test plan

**Hermetic (CI-wired, no DB):**
```
node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
```
```
ℹ tests 78
ℹ suites 21
ℹ pass 78
ℹ fail 0
```
78 tests (up from 69 pre-fix-pass): `assertReadOnlyAllowlist` structural read-only guard (rejects
non-SELECT, rejects a stacked/semicolon statement); `QUERY_ALLOWLIST` SQL-text semantic-invariant
pins (exact table set / quoted-literal set / WHERE predicate per tag); a **line/word-boundary
-anchored** schema-drift guard reading migrations `057_create_integration_core_tables.sql` /
`062_create_integration_read_source_configs.sql` directly off disk (§5's landmine: a previous
inventory was NO-GO for four assumed-schema errors — a citation in a header comment is not
load-bearing, this is, and after the fix pass it is anchored strongly enough to catch a
column-rename that merely shares a substring with the real name); frozen-registry
mutation-immunity; `bucketByRegistry`/`splitRowsByStatus` unit tests; `buildPlan`/`executePlan`
schema-probe-first tests; three-outcome verdict tests for both probes including the divergence-
and (new) unexpected-status-forces-INCONCLUSIVE cases; sentinel-injection **and** exact-key-set
values-free tests; fail-closed private-artefact tests against a real filesystem failure; `--probe`
zero-query tests for **both** report mode and `--dry-run`; `parseArgs`; the `.gitignore` coverage
test; and the new migration-064 out-of-scope pin.

**Wired in CI**: `.github/workflows/gip-authority-substrate-inventory.yml`, same shape as
#4594's (that workflow itself is branch-only, not on main — see Fix pass item 6) — checkout +
setup-node, `node --test`, path-filtered on the script/test/migrations/`.gitignore`.

**Verified against a real database** (reported by a prior session in this PR; not independently
reproduced in the fix pass — see "Live-Postgres verification" above): `initdb` + a local Postgres
15 (Homebrew), migrations 057 and 062 applied verbatim, five `integration_external_systems` rows
and five `integration_read_source_configs` rows seeded by hand (including one config with no
`object` key inside its `config` JSON). Ran the real CLI and hand-verified every count against the
seeded data and against direct `psql` queries (β all-statuses 4/5, β active-only 2/3, γ draft 1/1,
γ approved 3/3, divergence 2); dropped/renamed a table → `UNAVAILABLE` + `INCONCLUSIVE`, never a
silent zero; `--probe beta`/`--probe gamma` each verified live with the other table renamed away;
private-artefact fail-closed path verified live via a real `ENOTDIR` write failure. That local
database and its seeded rows have been discarded; no real customer data was ever touched.

## What I could NOT do, and why

- **Could not run this against a customer deployment** — that is a separate ops read-only
  authorization the task explicitly withheld. This PR does not request or assume it.
- **Could not independently reproduce the live-Postgres verification in the fix pass** — no `pg`
  package resolvable in this worktree (no `node_modules`). Downgraded the wording rather than
  re-assert it as independently verified fact (see "Live-Postgres verification" above).
- **Did not add the β/γ registries themselves** — those are the owner's decisions (β)/(γ) to make,
  not this tool's to infer; adding entries is explicitly the FORBIDDEN direction the task guarded
  against.
- **Did not probe `integration_write_target_configs.object`** (migration 064) — deliberately out
  of scope; stated with reason in `RESIDUAL_NOTES` and the γ `blindSpot` string (Fix pass item 5).


## Scope note (owner-recorded) — this PR is the inventory TOOL, not Lane A's inventory RESULT

This PR's CI job (`.github/workflows/gip-authority-substrate-inventory.yml`) runs `node --test`
against a **fake, in-memory executor with no real database connection** — there has never been a
live-Postgres run wired into this PR's CI, and (per the "Live-Postgres verification" section above)
even the one-off manual local-Postgres session a prior session in this PR reported is unreproduced
and explicitly downgraded to "reported, not independently verified." **This PR delivers the
inventory tool only.** The concrete (β) connector-kind alias map and (γ) objectKey backfill list —
the actual Lane A inventory RESULT — do not exist yet and cannot come from this PR: they require a
privately-authorized real run against a live deployment, which is a separate ops-gated read-only
authorization this task does not carry. Nothing in this PR should be read as if that inventory had
already been performed.

## Third pass (2026-07-25) — #4603 owner review of `18f503bf0`: P1/P2 findings closed

Owner review returned **HOLD** on `18f503bf0` with two P1s and three P2s. All five are fixed below;
each fix is proved with a pasted `node --test` command and its real output, and the two findings
the owner asked to be re-probed adversarially (P1(1)'s fail-open count coercion, P2(a)'s
unscanned-value gap) are each proved **RED before the fix, GREEN after**, by temporarily
re-introducing the exact defect in the committed source, re-running the suite, then reverting.

**Baseline before this pass** (`18f503bf0`, unmodified):
```
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
ℹ tests 78
ℹ pass 78
ℹ fail 0
```

### [P1] (1) `Number(value) || 0` fail-open in the count conversion — FIXED

Added `isSafeNonNegativeInteger(value)` (`typeof value === 'number' && Number.isSafeInteger(value)
&& value >= 0`) and made `bucketByRegistry()` return `{ status: 'invalid_count', reason }` instead
of silently zeroing a bad row; `executeKindInventoryPlan`/`executeObjectKeyInventoryPlan` turn that
into the probe's whole `status: 'unavailable'`, which the existing verdict layer already turns into
`INCONCLUSIVE` — never a silent "0 unregistered". The same fix applies to the divergence count
(now also requiring the query to return **exactly one row**, since a real `COUNT(*)` always does).

New tests cover all nine listed adversarial inputs (`undefined, null, '', 'abc', NaN, Infinity,
-1, 1.5, 2**53`) plus the positive control (`0`), at both the predicate layer and the
`bucketByRegistry`/`buildReport` end-to-end layer.

**Mutation probe — revert the fix, prove the new tests catch it:**
```
$ # bucketByRegistry's countKey conversion reverted to: const n = Number(row[countKey]) || 0
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
ℹ tests 124
ℹ pass 112
ℹ fail 12
```
12 of the new strict-integer tests go RED (all nine adversarial-input cases at the bucketing
layer, plus the three end-to-end `buildReport` INCONCLUSIVE-propagation tests). Reverted back:
```
$ # fix restored
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
ℹ tests 124
ℹ pass 124
ℹ fail 0
```

### [P1] (2) `--no-private-out` let a genuinely-owed private artefact exit SUCCESS — FIXED

`buildReport()` now computes `owed` unconditionally. When `noPrivateOut` is true and something is
owed, `privateArtifact` becomes `{ status: 'incomplete_owed_disabled', consumableByWave2: false }`
instead of the old bare `{ status: 'skipped_by_flag' }`. `main()` checks
`report.privateArtifact.consumableByWave2 === false` and returns exit code **1** (report is still
printed to stdout first) — both halves of the ruling ("either exit non-zero, or return an explicit
INCOMPLETE status") are satisfied, not just one. The test that pinned the old fail-open behaviour
(`'--no-private-out skips the write entirely, even when something is owed'`) is **updated, not
deleted**, to pin the new fail-closed shape; a sibling test pins the genuinely-nothing-owed branch
still getting a plain, consumable `skipped_by_flag`.

### [P2] (a) Values-free proof only checked keys/partial types, not values — FIXED

Reproduced the owner's exact finding against `18f503bf0` first, to confirm it before fixing:

```
$ # coverage.canonicalObjectKeyInventory.covers literal replaced with a customer-shaped string:
$ #   "acme-corp-warehouse-42-legacy-erp-object-code"
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
ℹ tests 78
ℹ pass 78
ℹ fail 0
$ # replaced again with the test's own seeded sentinel: "SENTINEL_NEVER_SEEN_OBJECT"
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
ℹ tests 78
ℹ pass 78
ℹ fail 0
```
Confirmed: 78/78 GREEN both times, exactly as the owner reported — that field was not scanned.

**Fix:** a CLOSED VALUE DOMAIN check. Every STRING leaf of a full `buildReport()` output is
digit-normalized (`s.replace(/\d+/g, '#')` — every dynamic component this module ever interpolates
is a validated non-negative safe integer, never raw DB content) and the resulting **set** is
asserted equal (not "member of an allowlist" — exact set equality, so a removal or an unauthored
addition also fails, not just a substitution) to a hand-frozen expected array, one per fixture
scenario (nothing-owed, something-owed/REQUIRED verdicts, unavailable+not_run/`--probe beta`,
divergence>0, unexpected-status-populated, both-tables-missing). Every NUMBER leaf is independently
asserted to be a non-negative safe integer. The expected arrays were captured once by running
`buildReport()` against the fixed source and pasted into the test file as frozen literals — not
re-derived at test time — so a later source mutation diverges from the frozen copy instead of
being validated against itself. Also added: an exact top-level `report` key-set assertion
(`generatedAt, mode, probe, coverage, verdicts, residualNotes, privateArtifact` — previously
unconstrained) and a referential-identity check (`report.residualNotes === RESIDUAL_NOTES`).

**Re-ran both probes against the FIXED suite:**
```
$ # covers replaced with "acme-corp-warehouse-42-legacy-erp-object-code" again
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
ℹ tests 124
ℹ pass 118
ℹ fail 6
✖ scenario: nothing owed (zero rows both probes) — closed value domain holds
✖ scenario: something owed (REQUIRED verdicts both probes, numeric interpolation exercised) — closed value domain holds
✖ scenario: unavailable column + --probe beta (not_run branch) — closed value domain holds
✖ scenario: objectVsConfigObjectDivergence > 0 (INCONCLUSIVE, exercises the R11/R12 reason templates) — closed value domain holds
✖ scenario: an out-of-vocabulary (unexpected) status bucket is populated (INCONCLUSIVE, exercises the R14/R15 reason templates) — closed value domain holds
✖ scenario: both tables missing (top-level UNAVAILABLE for both probes) — closed value domain holds

$ # covers replaced with the sentinel "SENTINEL_NEVER_SEEN_OBJECT" instead
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
ℹ tests 124
ℹ pass 118
ℹ fail 6
(same six scenario tests RED)

$ # reverted to the real covers string
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
ℹ tests 124
ℹ pass 124
ℹ fail 0
```
Both the non-sentinel and the sentinel injection now RED all six closed-value-domain scenario
tests — the exact gap the owner found is closed.

### [P2] (b) Report exposed caller paths and raw error messages — FIXED

`report.privateArtifact` no longer carries a real filesystem path or a raw `err.message` in any
branch: `written` is now `{ status, consumableByWave2 }` only; `write_failed_but_nothing_owed` is
`{ status, consumableByWave2, reasonCode: 'FILESYSTEM_WRITE_ERROR' }` (closed enum, not the fs
error text); the fail-closed thrown `Error` (owed + write failed) is now a fixed, values-free
sentence with no interpolated path or `err.message`. `renderHumanSummary()`'s "private artefact:"
line dropped the same path interpolation. An operator who used the default target can still
reconstruct it from `DEFAULT_PRIVATE_OUTPUT_DIR` + the report's own `generatedAt` — no information
is lost, only removed from a channel this file promises is values-free.

### [P2] (c) Private write followed symlinks and could overwrite an existing file — FIXED

`writePrivateArtifact()` now opens with `flag: 'wx'` (`O_CREAT|O_EXCL|O_WRONLY`). Per POSIX, this
fails `EEXIST` if the target path already names **anything** — a regular file, or a symlink node,
even a **dangling** one whose target does not exist — without ever following that symlink to write
through it, atomically (no separate check-then-write race). New tests cover all three refusals
(existing regular file with content proven untouched; dangling symlink with the link itself proven
unchanged and its target proven never created; symlink to a real file with that file's content
proven untouched) plus the clean-create positive control (content + `0600` mode).

### Net test count

```
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
ℹ tests 125
ℹ suites 26
ℹ pass 125
ℹ fail 0
```
125/125 (78 baseline + 47 net new/changed: strict-integer + fail-closed-count propagation +
`--no-private-out` incomplete-status + closed-value-domain + `writePrivateArtifact` refusal tests
+ a `renderHumanSummary` no-path-leak test).

**Known coverage gap, stated rather than hidden:** `main()`'s report-mode CLI path (the code that
turns `consumableByWave2 === false` into exit code 1) is not exercised by an automated test in this
suite — `main()` is not imported by the test file (true before this pass too), because its
report-mode path hard-wires a real `pg.Pool` via `createPgExecutor()` with no injection point, and
this worktree has no `node_modules` (`pg` unresolvable) to spawn it as a subprocess against either.
The exit-code branch is verified by code inspection only, not by an executed test.

## Rebase

Rebased onto `origin/main` (`d75d3b828`) with no conflicts; branch is 3 ahead / 0 behind. Pushed
with `--force-with-lease` (branch history was rewritten by the rebase). **Not merged.**

## Fourth pass (2026-07-25) — erratum + one coverage gap closed + one scope disclosure

Self-review after the third pass surfaced three items; all three closed/disclosed below rather
than left silent.

**Erratum — wrong count in the third-pass commit message.** The commit message for
`fix(ops): GIP authority inventory — close #4603 HOLD P1/P2 findings` says "125/125 tests pass (12
net new since 18f503bf0's 78…)". **12 is wrong** — that number is the *fail* count from the
P1(1) mutation probe (`bucketByRegistry` reverted to `Number(x) || 0`), not the net-new test count.
The correct figure, stated correctly in this PR body's "Net test count" section above, is **47**
(78 → 125, before the fourth-pass additions below took it to 127). Per this repo's standing
no-amend policy, this is stated here as a retraction rather than rewriting the commit.

**Closed-value-domain coverage gap.** All six scenarios in the third pass passed
`noPrivateOut: true`, so `'written'` and `'FILESYSTEM_WRITE_ERROR'` never appeared in any frozen
expected array — the general value-domain mechanism had never once run against a report whose
`privateArtifact` took the **actual write path**, which is exactly the branch P2(b) (report
exposed caller paths/raw error messages) was about. The narrower `assertPublicReportKeySetsExactly`
+ `doesNotMatch(/private\.json/)` checks already covered this branch, but not the general
value-domain mechanism. Added two more scenarios — a real write to a temp dir (`status: 'written'`)
and a real `ENOTDIR` write failure with nothing owed (`status: 'write_failed_but_nothing_owed'`) —
captured the same way as the existing six.

Mutation probe (re-reproduces the exact P2(b) shape, this time against the new scenario
specifically):
```
$ # 'written' branch: privateArtifact = { status: 'written', consumableByWave2: true,
$ #   path: path.relative(repoRoot, targetPath) }   <- re-added the path
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
ℹ tests 127
ℹ pass 125
ℹ fail 2
✖ scenario: privateArtifact actually WRITTEN (real temp-dir write, nothing owed) — closed value domain holds; no real path leaks in
✖ a 'written' privateArtifact carries no real filesystem path — closed status/flag only
$ # path removed again
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
ℹ tests 127
ℹ pass 127
ℹ fail 0
```
Both the new closed-value-domain scenario and the pre-existing key-set test catch the
regression independently — two layers, not one.

**Disclosure — `main()`'s generic stderr handlers still interpolate raw `err.message`.** The
P2(b) ruling was scoped to the report object (`~L679`, `report.privateArtifact`), which this pass
fully closed (no path, no err.message, anywhere in `privateArtifact` or the thrown fail-closed
Error). Out of scope for this pass, left as-is and disclosed rather than silently left: `main()`'s
three top-level `catch` blocks (`parseArgs` failure, `--dry-run` failure, and the report-mode
failure/DB-connection-failure path) still do
`` process.stderr.write(`... ERROR: ${err.message}\n`) ``. The most likely real-world value there
is a `pg` connection failure, which can carry a hostname. This is operator-facing stderr on a
direct terminal invocation, not the structured report object this file promises is values-free —
but it is the same class of leak vector the (b) ruling named, just at a different call site, and a
future pass should decide whether to close it the same way (closed reason code only) or accept it
as an intentionally-different channel (a human operator debugging their own DB connection, not
public/committed output).

Final test count after this pass:
```
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
ℹ tests 127
ℹ pass 127
ℹ fail 0
```

Pushed (fast-forward from the third pass, no rebase needed — `origin/main` had not moved):
`dc8778741`.

## Fifth pass (2026-07-25) — #4603 P2: overclaimed test comment (claim defect, not code defect)

**Finding:** the test titled `report.residualNotes is referentially IDENTICAL to the exported
RESIDUAL_NOTES` called that identity check *"the strongest possible pin on that section, stronger
than any content re-derivation."* Backwards: `report.residualNotes === RESIDUAL_NOTES` pins
**object identity** (that `buildReport()` passes the frozen array through unchanged, never a copy),
not note **content** — a wording change to a note keeps the same array reference, so that
assertion alone would stay green through it. No safety property was actually lost: content pinning
is done by the 8 CLOSED VALUE DOMAIN scenario tests, whose hand-frozen `EXPECTED_*` string lists
hardcode every residual-note description.

**Mutation-confirmed:**
```
$ # 'no_customer_deployment_connection' description inverted to claim the OPPOSITE — that this
$ #   script HAS been run directly against a customer deployment
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
  ✔ report.residualNotes is referentially IDENTICAL to the exported RESIDUAL_NOTES — the strongest
    possible pin on that section, stronger than any content re-derivation
  ✖ scenario: nothing owed (zero rows both probes) — closed value domain holds
  ✖ scenario: something owed (REQUIRED verdicts both probes, numeric interpolation exercised) — closed value domain holds
  ✖ scenario: unavailable column + --probe beta (not_run branch) — closed value domain holds
  ✖ scenario: objectVsConfigObjectDivergence > 0 (INCONCLUSIVE, exercises the R11/R12 reason templates) — closed value domain holds
  ✖ scenario: an out-of-vocabulary (unexpected) status bucket is populated (INCONCLUSIVE, exercises the R14/R15 reason templates) — closed value domain holds
  ✖ scenario: both tables missing (top-level UNAVAILABLE for both probes) — closed value domain holds
  ✖ scenario: privateArtifact actually WRITTEN (real temp-dir write, nothing owed) — closed value domain holds; no real path leaks in
  ✖ scenario: privateArtifact write FAILED but nothing owed (real ENOTDIR) — closed value domain holds; no real path or err.message leaks in
ℹ tests 127
ℹ pass 119
ℹ fail 8
```
The identity assertion stayed green; the 8 content-pinning scenarios went red — exactly backwards
from the claim. Reverted before commit (`git diff` clean against `dc8778741`).

**Fix:** reworded the test title and added a comment block stating plainly what the identity check
pins (object identity, not content) and where content pinning actually lives (the 8 scenario
tests). Also disclosed a **residual gap found while re-verifying**, not closed by any test in this
file: `assertClosedValueDomain` digit-normalizes every string (`s.replace(/\d+/g, '#')`) before
comparing, so a **digits-only** edit to a residual note — e.g. the ledger citation `§4 step 1.3,
§3.0 B-3` changed to `§9 step 9.9, §9.0 B-9` (a wrong citation, migration number left untouched) —
normalizes identically and is invisible to all 8 scenario tests **and** the identity test.
Mutation-confirmed narrower: that section-digits-only edit alone leaves all 127 tests in this file
green. (The separate `migration 064` digits in the same note *are* caught elsewhere, by a literal
non-normalized `assert.match` in the `RESIDUAL_NOTES` describe block — only the ledger
section-reference digits have no covering assertion anywhere in this file.) No code changed; this
is a test-comment-only fix, and the disclosed gap is left open rather than fixed in this pass.

Grepped this PR body for the same superlative (`strongest`, `stronger`, `pin on`) — no other echo
found; body text on this topic (the "Net test count" section, "a referential-identity check
(`report.residualNotes === RESIDUAL_NOTES`)") was already a plain factual statement, not a
superlative claim, so it is unchanged.

Test count after this pass (comment-only change, no assertion added/removed):
```
$ node --test scripts/ops/gip-authority-substrate-inventory.test.mjs
ℹ tests 127
ℹ pass 127
ℹ fail 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)



